### PR TITLE
fix(duckdb): give local push-watch deferred scopes a polling owner

### DIFF
--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -74,7 +74,11 @@ type archivePushWatchHooks struct {
 	pgStartupSync func(
 		context.Context, *syncpkg.Engine, bool,
 	) (bool, error)
+	duckDBStartupSync func(
+		context.Context, *syncpkg.Engine, bool,
+	) (bool, error)
 	newPGPusher        func(*syncpkg.Engine) *pgPusher
+	newDuckDBPusher    func(*syncpkg.Engine) *duckDBPusher
 	newUnwatchedPoller func(context.Context, unwatchedPollSyncer) unwatchedRootPoller
 }
 
@@ -87,8 +91,8 @@ type unwatchedRootPoller interface {
 	Stop()
 }
 
-// newArchivePushUnwatchedPoller builds the pg watch polling owner for
-// deferred scopes. The watcher's full recovery and rename promotion defer
+// newArchivePushUnwatchedPoller builds the archive push-watch polling owner
+// for deferred scopes. The watcher's full recovery and rename promotion defer
 // unavailable scopes to their polling probes, and the interval push runs a
 // plain SyncAll that never tombstones missed deletions, so without this owner
 // a deletion lost while a root was unavailable would stay active in the
@@ -132,6 +136,49 @@ func newArchivePushLoop(
 	}
 	loop, ticker := newPushLoopWithLabel(label, debounce, interval, push)
 	return loop, ticker.Stop
+}
+
+func archivePushWatchWatcherOptions(
+	loop *pushLoop, poller unwatchedRootPoller,
+) syncpkg.WatcherOptions {
+	return syncpkg.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			// Degraded coverage needs both owners: the poller reconciles
+			// the affected roots authoritatively (including tombstoning
+			// missed deletions) and the loop re-pushes the refreshed
+			// archive on its floor.
+			if err := poller.AddObligation(pollingObligation{
+				Key: "watcher-fallback", Roots: roots,
+			}); err != nil {
+				return err
+			}
+			return loop.NotifyCoverageDegraded(roots)
+		},
+		OnPollingRequired: func(obligation syncpkg.PollingObligation) error {
+			return poller.AddObligation(pollingObligation{
+				Key:   obligation.Key,
+				Roots: obligation.Roots,
+				Probe: obligation.Probe,
+			})
+		},
+		OnPollingReleased: poller.RemoveObligation,
+	}
+}
+
+func archivePushWatchBatchCallback(
+	appCfg config.Config,
+	engine *syncpkg.Engine,
+	loop *pushLoop,
+) syncpkg.WatchCallback {
+	return func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
+		scope := func() watchRecoveryScope {
+			return probeWatchRecoveryScope(appCfg)
+		}
+		if err := syncWatchBatch(callbackCtx, engine, batch, scope); err != nil {
+			return err
+		}
+		return notifyPushForWatchBatch(callbackCtx, loop, batch)
+	}
 }
 
 func completeDuckDBWatchPush(
@@ -687,6 +734,22 @@ func (b *localArchiveWriteBackend) duckDBPush(
 	forceFull := cfg.Full || didResync
 
 	fmt.Println("Starting DuckDB push...")
+	return b.duckDBMirrorPush(
+		ctx, duckCfg, cfg, projects, excludeProjects, forceFull,
+	)
+}
+
+func (b *localArchiveWriteBackend) duckDBMirrorPush(
+	ctx context.Context,
+	duckCfg config.DuckDBConfig,
+	cfg DuckDBPushConfig,
+	projects []string,
+	excludeProjects []string,
+	forceFull bool,
+) (duckdbsync.PushResult, error) {
+	if err := duckdbsync.ValidatePushTarget(duckCfg); err != nil {
+		return duckdbsync.PushResult{}, err
+	}
 	opts := duckdbsync.SyncOptions{
 		Projects:        projects,
 		ExcludeProjects: excludeProjects,
@@ -708,6 +771,37 @@ func (b *localArchiveWriteBackend) duckDBPush(
 	return result, nil
 }
 
+func (b *localArchiveWriteBackend) newDuckDBPusher(
+	engine *syncpkg.Engine,
+	duckCfg config.DuckDBConfig,
+	cfg DuckDBPushConfig,
+	projects, exclude []string,
+) *duckDBPusher {
+	pushCfg := cfg
+	pushCfg.Automatic = true
+	return &duckDBPusher{
+		localSync: func(c context.Context) error {
+			stats := engine.SyncAll(c, nil)
+			if err := c.Err(); err != nil {
+				return err
+			}
+			if !stats.AuthoritativeDiscoveryComplete() {
+				return errors.New("local sync discovery incomplete")
+			}
+			engine.FlushSignals()
+			return nil
+		},
+		ensurePricing: b.ensureCurrentPricing,
+		mirrorPush: func(c context.Context, forceFull bool) (
+			duckdbsync.PushResult, error,
+		) {
+			return b.duckDBMirrorPush(
+				c, duckCfg, pushCfg, projects, exclude, forceFull,
+			)
+		},
+	}
+}
+
 func (b *localArchiveWriteBackend) DuckDBPushWatch(
 	ctx context.Context,
 	duckCfg config.DuckDBConfig,
@@ -723,53 +817,70 @@ func (b *localArchiveWriteBackend) DuckDBPushWatch(
 	if debounce <= 0 {
 		debounce = defaultWatchDebounce
 	}
-	push := func(pctx context.Context, reason pushReason, full bool) error {
-		pushCfg := cfg
-		pushCfg.Full = full
-		// Watch pushes are automatic: a mirror held by a live serve
-		// process defers instead of rebuilding the whole archive on
-		// every changed batch, and archive-scale diagnostics are
-		// skipped. Push ignores the defer behavior when full is set.
-		pushCfg.Automatic = true
-		var res duckdbsync.PushResult
-		var err error
-		if b.watchHooks != nil && b.watchHooks.duckDBPush != nil {
-			res, err = b.watchHooks.duckDBPush(pctx, reason, full)
-		} else {
-			res, err = b.DuckDBPush(
-				pctx, duckCfg, pushCfg, projects, exclude,
-			)
+	for _, def := range parser.Registry {
+		if !b.appCfg.IsUserConfigured(def.Type) {
+			continue
 		}
-		if err != nil {
-			return err
-		}
-		return completeDuckDBWatchPush(res, reason)
+		warnMissingDirs(b.appCfg.ResolveDirs(def.Type), string(def.Type))
 	}
+	cleanResyncTemp(b.appCfg.DBPath)
+
+	engine := syncpkg.NewEngine(b.database, syncpkg.EngineConfig{
+		AgentDirs:               b.appCfg.AgentDirs,
+		IncludeCwdPrefixes:      b.appCfg.SyncIncludeCwdPrefixes,
+		Machine:                 b.appCfg.LocalMachineName,
+		BlockedResultCategories: b.appCfg.ResultContentBlockedCategories,
+	})
+	defer engine.Close()
+
+	var pusher *duckDBPusher
+	if b.watchHooks != nil && b.watchHooks.newDuckDBPusher != nil {
+		pusher = b.watchHooks.newDuckDBPusher(engine)
+	} else {
+		pusher = b.newDuckDBPusher(engine, duckCfg, cfg, projects, exclude)
+	}
+
 	loop, stopLoop := newArchivePushLoop(
 		b.watchHooks,
 		"duckdb watch", debounce, interval,
 		func(c context.Context, r pushReason) error {
-			return push(c, r, false)
+			return pusher.push(c, r, false)
 		},
 	)
 	defer stopLoop()
 
+	poller := newArchivePushUnwatchedPoller(ctx, b.watchHooks, engine)
+	defer poller.Stop()
+
 	stopWatcher, openDispatch, unwatchedDirs := startArchivePushWatcher(
-		b.watchHooks, b.appCfg, nil,
-		func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
-			return notifyPushForWatchBatch(callbackCtx, loop, batch)
-		},
-		syncpkg.WatcherOptions{OnCoverageDegraded: loop.NotifyCoverageDegraded},
+		b.watchHooks, b.appCfg, engine,
+		archivePushWatchBatchCallback(b.appCfg, engine, loop),
+		archivePushWatchWatcherOptions(loop, poller),
 	)
 	defer stopWatcher()
 	if len(unwatchedDirs) > 0 {
 		log.Printf(
-			"duckdb watch: %d root(s) not watched; relying on the %s floor for coverage",
-			len(unwatchedDirs), interval,
+			"duckdb watch: %d root(s) not watched; polling every %s",
+			len(unwatchedDirs), unwatchedPollInterval,
 		)
 	}
-	initialErr := push(ctx, reasonStartup, cfg.Full)
+
+	startupSync := runPGWatchStartupSync
+	if b.watchHooks != nil && b.watchHooks.duckDBStartupSync != nil {
+		startupSync = b.watchHooks.duckDBStartupSync
+	}
+	didResync, startupErr := startupSync(ctx, engine, cfg.Full)
+	if startupErr != nil && errors.Is(startupErr, context.Canceled) {
+		return nil
+	}
+	initialErr := startupErr
+	if initialErr == nil {
+		initialErr = pusher.push(ctx, reasonStartup, didResync)
+	}
 	if initialErr != nil {
+		if errors.Is(initialErr, context.Canceled) && ctx.Err() != nil {
+			return nil
+		}
 		log.Printf("duckdb watch: initial push failed: %v", initialErr)
 	}
 	completePushWatchStartup(ctx, initialErr, loop, openDispatch)
@@ -900,37 +1011,8 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 
 	stopWatcher, openDispatch, unwatchedDirs := startArchivePushWatcher(
 		b.watchHooks, b.appCfg, engine,
-		func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
-			scope := func() watchRecoveryScope {
-				return probeWatchRecoveryScope(b.appCfg)
-			}
-			if err := syncWatchBatch(callbackCtx, engine, batch, scope); err != nil {
-				return err
-			}
-			return notifyPushForWatchBatch(callbackCtx, loop, batch)
-		},
-		syncpkg.WatcherOptions{
-			OnCoverageDegraded: func(roots []string) error {
-				// Degraded coverage needs both owners: the poller reconciles
-				// the affected roots authoritatively (including tombstoning
-				// missed deletions) and the loop re-pushes the refreshed
-				// archive on its floor.
-				if err := poller.AddObligation(pollingObligation{
-					Key: "watcher-fallback", Roots: roots,
-				}); err != nil {
-					return err
-				}
-				return loop.NotifyCoverageDegraded(roots)
-			},
-			OnPollingRequired: func(obligation syncpkg.PollingObligation) error {
-				return poller.AddObligation(pollingObligation{
-					Key:   obligation.Key,
-					Roots: obligation.Roots,
-					Probe: obligation.Probe,
-				})
-			},
-			OnPollingReleased: poller.RemoveObligation,
-		},
+		archivePushWatchBatchCallback(b.appCfg, engine, loop),
+		archivePushWatchWatcherOptions(loop, poller),
 	)
 	defer stopWatcher()
 	if len(unwatchedDirs) > 0 {

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -475,6 +475,15 @@ func (h *pushWatchOwnerHarness) hooks() *archivePushWatchHooks {
 			h.mu.Unlock()
 			return false, nil
 		},
+		duckDBStartupSync: func(
+			context.Context, *syncpkg.Engine, bool,
+		) (bool, error) {
+			h.mu.Lock()
+			h.startupSyncs++
+			h.events = append(h.events, "startup-sync")
+			h.mu.Unlock()
+			return false, nil
+		},
 		newPGPusher: func(*syncpkg.Engine) *pgPusher {
 			target := &pushWatchPGTarget{harness: h}
 			return &pgPusher{
@@ -486,6 +495,26 @@ func (h *pushWatchOwnerHarness) hooks() *archivePushWatchHooks {
 					return nil
 				},
 				connect: func() (pgTarget, error) { return target, nil },
+			}
+		},
+		newDuckDBPusher: func(*syncpkg.Engine) *duckDBPusher {
+			return &duckDBPusher{
+				localSync: func(context.Context) error {
+					h.mu.Lock()
+					h.localPushSyncs++
+					h.events = append(h.events, "local-sync")
+					h.mu.Unlock()
+					return nil
+				},
+				mirrorPush: func(
+					_ context.Context, _ bool,
+				) (duckdbsync.PushResult, error) {
+					attempt, partial := h.nextAttempt("")
+					if partial {
+						return duckdbsync.PushResult{Errors: 1}, nil
+					}
+					return duckdbsync.PushResult{SessionsPushed: attempt}, nil
+				},
 			}
 		},
 	}
@@ -563,6 +592,10 @@ func (t *pushWatchPGTarget) PushWithOptions(
 }
 func (*pushWatchPGTarget) Close() error { return nil }
 
+func isLocalEnginePushWatchOwner(name string) bool {
+	return name == "local PostgreSQL" || name == "local DuckDB"
+}
+
 func TestPushWatchProductionOwnersRetainPartialStartupUntilPeriodicSuccess(
 	t *testing.T,
 ) {
@@ -576,7 +609,7 @@ func TestPushWatchProductionOwnersRetainPartialStartupUntilPeriodicSuccess(
 
 			first := receiveArchiveTest(t, h.attempts)
 			require.Equal(t, 1, first.index)
-			if owner.name != "local PostgreSQL" {
+			if !isLocalEnginePushWatchOwner(owner.name) {
 				assert.Equal(t, reasonStartup, first.reason)
 			}
 			require.Eventually(t, func() bool {
@@ -593,7 +626,7 @@ func TestPushWatchProductionOwnersRetainPartialStartupUntilPeriodicSuccess(
 			h.floor <- time.Now()
 			second := receiveArchiveTest(t, h.attempts)
 			require.Equal(t, 2, second.index)
-			if owner.name != "local PostgreSQL" {
+			if !isLocalEnginePushWatchOwner(owner.name) {
 				assert.Equal(t, reasonInterval, second.reason)
 			}
 			receiveArchiveTest(t, h.opened)
@@ -608,7 +641,7 @@ func TestPushWatchProductionOwnersRetainPartialStartupUntilPeriodicSuccess(
 			assert.Equal(t, "collect", events[0],
 				"watcher collection must precede startup work")
 			assert.Equal(t, 1, opens)
-			if owner.name == "local PostgreSQL" {
+			if isLocalEnginePushWatchOwner(owner.name) {
 				assert.Equal(t, 1, startupSyncs)
 				assert.GreaterOrEqual(t, localSyncs, 2,
 					"initial and retry pushes each run local sync")
@@ -637,7 +670,7 @@ func TestPushWatchProductionOwnersRetryPartialAuthoritativeBatch(
 
 			first := receiveArchiveTest(t, h.attempts)
 			require.Equal(t, 1, first.index)
-			if owner.name != "local PostgreSQL" {
+			if !isLocalEnginePushWatchOwner(owner.name) {
 				assert.Equal(t, reasonStartup, first.reason)
 			}
 			receiveArchiveTest(t, h.opened)
@@ -655,7 +688,7 @@ func TestPushWatchProductionOwnersRetryPartialAuthoritativeBatch(
 			h.floor <- time.Now()
 			second := receiveArchiveTest(t, h.attempts)
 			require.Equal(t, 2, second.index)
-			if owner.name != "local PostgreSQL" {
+			if !isLocalEnginePushWatchOwner(owner.name) {
 				assert.Equal(t, reasonInterval, second.reason)
 			}
 			select {
@@ -671,7 +704,7 @@ func TestPushWatchProductionOwnersRetryPartialAuthoritativeBatch(
 			h.floor <- time.Now()
 			third := receiveArchiveTest(t, h.attempts)
 			require.Equal(t, 3, third.index)
-			if owner.name != "local PostgreSQL" {
+			if !isLocalEnginePushWatchOwner(owner.name) {
 				assert.Equal(t, reasonInterval, third.reason)
 			}
 			require.NoError(t, receiveArchiveTest(t, callbackDone))
@@ -708,7 +741,7 @@ func TestPushWatchProductionOwnersFallbackUsesActiveIntervalFloor(t *testing.T) 
 
 			h.floor <- time.Now()
 			attempt := receiveArchiveTest(t, h.attempts)
-			if owner.name != "local PostgreSQL" {
+			if !isLocalEnginePushWatchOwner(owner.name) {
 				assert.Equal(t, reasonInterval, attempt.reason)
 			}
 			cancel()
@@ -930,6 +963,121 @@ func TestLocalPGPushWatchGivesDeferredScopesAPollingOwner(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(30 * time.Second):
 		t.Fatal("pg watch did not shut down")
+	}
+}
+
+func TestLocalDuckDBPushWatchGivesDeferredScopesAPollingOwner(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "sessions.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	target := t.TempDir()
+	codexRoot := filepath.Join(t.TempDir(), "sessions")
+	require.NoError(t, os.Symlink(target, codexRoot))
+
+	backend := &localArchiveWriteBackend{
+		appCfg: config.Config{
+			DataDir:          dataDir,
+			DBPath:           dbPath,
+			LocalMachineName: "local",
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentCodex: {codexRoot},
+			},
+		},
+		database: database,
+	}
+
+	ticks := make(chan time.Time, 1)
+	owned := make(chan []string, 8)
+	fire := make(chan time.Time)
+	floor := make(chan time.Time)
+	backend.watchHooks = &archivePushWatchHooks{
+		newLoop: func(
+			label string, _, _ time.Duration,
+			push func(context.Context, pushReason) error,
+		) (*pushLoop, func()) {
+			return &pushLoop{
+				debounce: time.Hour,
+				dirty:    make(chan struct{}, 1),
+				floor:    floor,
+				after:    func(time.Duration) <-chan time.Time { return fire },
+				push:     push,
+				label:    label,
+			}, func() {}
+		},
+		duckDBStartupSync: func(context.Context, *syncpkg.Engine, bool) (bool, error) {
+			return false, nil
+		},
+		newDuckDBPusher: func(*syncpkg.Engine) *duckDBPusher {
+			return &duckDBPusher{
+				localSync: func(context.Context) error { return nil },
+				mirrorPush: func(context.Context, bool) (duckdbsync.PushResult, error) {
+					return duckdbsync.PushResult{}, nil
+				},
+			}
+		},
+		newUnwatchedPoller: func(
+			ctx context.Context, engine unwatchedPollSyncer,
+		) unwatchedRootPoller {
+			return newUnwatchedPollCoordinatorWithTicks(
+				ctx, engine, ticks, func() {}, func(work func()) { work() },
+				func(roots []string) {
+					owned <- append([]string(nil), roots...)
+				},
+			)
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- backend.DuckDBPushWatch(
+			ctx, config.DuckDBConfig{}, DuckDBPushConfig{}, nil, nil,
+			time.Hour, time.Hour,
+		)
+	}()
+
+	select {
+	case roots := <-owned:
+		assert.Contains(t, roots, codexRoot,
+			"the unwatchable root's polling obligation must reach the duckdb watch poller")
+	case err := <-done:
+		t.Fatalf("duckdb watch exited before registering obligations: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("no polling obligation was registered for the unwatchable root")
+	}
+
+	uuid := "e5f6a7b8-5555-4666-8777-888899990000"
+	day := filepath.Join(codexRoot, "2026", "05", "04")
+	require.NoError(t, os.MkdirAll(day, 0o755))
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			"2026-05-04T14:00:00Z", uuid, "/home/user/code/api",
+			"codex_cli_rs",
+		).
+		AddCodexMessage("2026-05-04T14:00:01Z", "user", "hello").
+		String()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(day, "rollout-2026-05-04T14-31-58-"+uuid+".jsonl"),
+		[]byte(content), 0o644,
+	))
+
+	require.Eventually(t, func() bool {
+		select {
+		case ticks <- time.Now():
+		default:
+		}
+		session, err := database.GetSession(context.Background(), "codex:"+uuid)
+		return err == nil && session != nil
+	}, 10*time.Second, 20*time.Millisecond,
+		"the returned root must be reconciled by the poller without watcher events or floor pushes")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("duckdb watch did not shut down")
 	}
 }
 

--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -39,6 +39,40 @@ type DuckDBPushConfig struct {
 	Automatic bool
 }
 
+// duckDBPusher runs a local engine sync then pushes to the DuckDB mirror.
+// It mirrors pgPusher's watch-loop shape: interval pushes use SyncAll, which
+// never tombstones missed deletions, so deferred scopes rely on the separate
+// unwatched-root poller wired by DuckDBPushWatch.
+type duckDBPusher struct {
+	localSync     func(context.Context) error
+	ensurePricing func(context.Context) error
+	mirrorPush    func(context.Context, bool) (duckdbsync.PushResult, error)
+}
+
+func (p *duckDBPusher) push(
+	ctx context.Context, reason pushReason, full bool,
+) error {
+	if err := p.localSync(ctx); err != nil {
+		return fmt.Errorf("local sync: %w", err)
+	}
+	if p.ensurePricing != nil {
+		if err := p.ensurePricing(ctx); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			log.Printf("warning: pricing refresh failed: %v", err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	res, err := p.mirrorPush(ctx, full)
+	if err != nil {
+		return err
+	}
+	return completeDuckDBWatchPush(res, reason)
+}
+
 type DuckDBQuackServeConfig struct {
 	Bind          string
 	Path          string


### PR DESCRIPTION
Local DuckDBPushWatch mirrored pg watch's pre-fix gap: no sync engine, no unwatched-root poller, and watcher options only wired OnCoverageDegraded. Interval pushes used runLocalSyncAuthoritative → SyncAll, which never tombstones missed deletions under deferred scopes.

Align local duckdb watch with local pg watch: shared watcher options, engine-backed batch sync, startup sync, and the probe-gated poller. Add TestLocalDuckDBPushWatchGivesDeferredScopesAPollingOwner parallel to the existing pg regression at archive_write_backend_test.go:821.

Daemon-delegated duckdb/pg watch remains unchanged (no local engine).

