### PR TITLE
fix(duckdb): preserve source machine attribution

### DIFF
--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -154,20 +154,10 @@ func readLocalMirrorStatus(
 	)
 }
 
-// readMachineStatus reads the target's push metadata and machine-scoped row
-// counts. It tolerates a mirror with no sync_metadata rows yet, or missing
-// tables entirely (a fresh, foreign, or pre-v3 file): both degrade to zero
-// values instead of erroring, since status must not crash on an old mirror.
-//
-// The row counts are filtered by the TARGET's own recorded LastPushMachine
-// when it is set, not by the caller's configured machine name: a remote
-// Quack client's configured machine name is normally its own hostname,
-// which almost never matches the hostname of whatever machine actually
-// pushed the mirror it is reading, so filtering by the configured name
-// there would report zero rows even though the display line above already
-// shows a real LastPushMachine and non-zero mirror content. The configured
-// machine name is used only as the fallback for a mirror with no recorded
-// push yet (LastPushMachine == ""), where it is the best available guess.
+// readMachineStatus reads the target's push metadata and total mirror row
+// counts. Sessions retain their per-source machine attribution, so status
+// cannot use LastPushMachine as a row filter. Missing metadata or tables
+// degrade to zero values so status remains usable for fresh and old mirrors.
 func readMachineStatus(
 	ctx context.Context,
 	duck *sql.DB,
@@ -186,14 +176,8 @@ func readMachineStatus(
 	status.DataVersion = meta.DataVersion
 	status.Scope = meta.Scope
 
-	countMachine := meta.LastPushMachine
-	if countMachine == "" {
-		countMachine = machine
-	}
-
 	if err := queryDuckDBRowContext(ctx, duck, connectionKind, quack,
-		`SELECT COUNT(*) FROM sessions WHERE machine = ?`,
-		countMachine,
+		`SELECT COUNT(*) FROM sessions`,
 	).Scan(&status.DuckDBSessions); err != nil {
 		if isMissingDuckDBTable(err) {
 			return status, nil
@@ -204,9 +188,8 @@ func readMachineStatus(
 		`SELECT COUNT(*)
 		 FROM messages
 		 WHERE session_id IN (
-			SELECT id FROM sessions WHERE machine = ?
+			SELECT id FROM sessions
 		 )`,
-		countMachine,
 	).Scan(&status.DuckDBMessages); err != nil {
 		if isMissingDuckDBTable(err) {
 			return status, nil

--- a/internal/duckdb/probe.go
+++ b/internal/duckdb/probe.go
@@ -278,15 +278,10 @@ func (p MirrorProbe) NeedsRebuild(scope string, sourceDataVersion int) bool {
 // rebuilds: identity-less mirrors only come from earlier builds of this
 // unreleased branch, so they simply rebuild once and record the id.
 //
-// The machine-change check exists because mirror rows are machine-stamped
-// (see the sessions.machine column and duckSessionFingerprintFields): an
-// incremental push only rewrites sessions whose LOCAL content changed
-// within the current mirror window, so a session that has not changed
-// since the mirror's last push stays permanently labeled with the OLD
-// machine name even after the push metadata's LastPushMachine flips to the
-// new one — silently stranding it under a machine filter (see
-// readMachineStatus) that will never again select it. A full rebuild
-// re-pushes every session under the new machine name instead.
+// The machine-change check remains necessary for legacy sessions whose local
+// machine is empty or "local": mirroring substitutes the current push machine
+// for those values, so a full rebuild must restamp every such row when that
+// configured name changes. Explicit per-source machine labels remain unchanged.
 //
 // localDeletionRevision is the caller's local.SessionDeletionPublicationRevision
 // read, and localDatabaseID the caller's local.GetDatabaseID read; both are

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -641,8 +641,8 @@ func (s *Sync) replaceCuration(
 			if err := s.execMutation(ctx, tx, `
 				DELETE FROM `+table+`
 				WHERE session_id IN (
-					SELECT id FROM sessions WHERE machine = ?
-				)`, s.machine); err != nil {
+					SELECT id FROM sessions
+				)`); err != nil {
 				return fmt.Errorf("clearing duckdb %s: %w", table, err)
 			}
 		}
@@ -899,7 +899,9 @@ func (s *Sync) upsertSession(
 			secrets_rules_version = excluded.secrets_rules_version,
 			agentsview_push_fingerprint = excluded.agentsview_push_fingerprint`
 
-	args := sessionInsertArgs(sess, s.machine, fingerprint)
+	args := sessionInsertArgs(
+		sess, mirroredSessionMachine(sess, s.machine), fingerprint,
+	)
 	if err := s.execMutation(ctx, exec, query, args...); err != nil {
 		return fmt.Errorf("writing duckdb session %s: %w", sess.ID, err)
 	}
@@ -942,6 +944,13 @@ func sessionInsertArgs(sess db.Session, machine, fingerprint string) []any {
 		sess.SecretLeakCount, sess.SecretsRulesVersion,
 		nilEmpty(fingerprint),
 	}
+}
+
+func mirroredSessionMachine(sess db.Session, pushMachine string) string {
+	if sess.Machine == "" || sess.Machine == "local" {
+		return pushMachine
+	}
+	return sess.Machine
 }
 
 func insertMessages(

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -600,7 +600,7 @@ func (snap curationSnapshot) fingerprint() (string, error) {
 // All work is bounded by curation size, not mirror size: mirror membership
 // is validated for exactly the snapshot's session IDs (one batched lookup,
 // see mirrorResidentSessionIDs), pin notes are preserved, and the delete
-// side stays the machine-scoped clear of both tables, so removed
+// side clears both tables for sessions in this source archive, so removed
 // stars/pins disappear without enumerating them.
 func (s *Sync) replaceCuration(
 	ctx context.Context, snap curationSnapshot,

--- a/internal/duckdb/rebuild.go
+++ b/internal/duckdb/rebuild.go
@@ -81,7 +81,7 @@ func ensureMirrorWorkDir(path string) (string, error) {
 // rebuildMirror builds a fresh DuckDB mirror file from scratch in a
 // temporary file inside the mirror's work directory, then atomically swaps
 // it over path. It is
-// the only way a schema v6 mirror is created or repaired: unlike Sync.Push,
+// the only way a schema v7 mirror is created or repaired: unlike Sync.Push,
 // it never touches an existing mirror file in place, so a rebuild that
 // fails at any point leaves the previous mirror (if any) fully intact.
 func rebuildMirror(

--- a/internal/duckdb/schema.go
+++ b/internal/duckdb/schema.go
@@ -11,10 +11,10 @@ import (
 )
 
 // SchemaVersion is the version of the DuckDB mirror schema created by
-// createSchema. Mirror schema v6 is create-only: there are no in-place
+// createSchema. Mirror schema v7 is create-only: there are no in-place
 // migrations between versions. A version mismatch means the mirror file
 // must be rebuilt with 'agentsview duckdb push --full'.
-const SchemaVersion = 6
+const SchemaVersion = 7
 
 const schemaVersionMetadataKey = "agentsview_schema_version"
 

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -597,7 +597,7 @@ func (s *Sync) readMirrorFingerprintBatch(
 }
 
 // mirrorResidentSessionIDs reports which of ids currently exist in the
-// mirror under this Sync's machine name. IDs are deduplicated and queried
+// mirror for this source archive. IDs are deduplicated and queried
 // in batches of 500, so cost tracks the caller's ID list (a candidate
 // window, a tombstone delta, the curation set), never total mirror size.
 func (s *Sync) mirrorResidentSessionIDs(
@@ -627,14 +627,13 @@ func (s *Sync) readMirrorResidentBatch(
 	ctx context.Context, batch []string, out map[string]bool,
 ) error {
 	placeholders := make([]string, len(batch))
-	args := make([]any, 0, len(batch)+1)
-	args = append(args, s.machine)
+	args := make([]any, 0, len(batch))
 	for i, id := range batch {
 		placeholders[i] = "?"
 		args = append(args, id)
 	}
 	rows, err := s.duck.QueryContext(ctx,
-		`SELECT id FROM sessions WHERE machine = ? AND id IN (`+
+		`SELECT id FROM sessions WHERE id IN (`+
 			strings.Join(placeholders, ",")+`)`, args...,
 	)
 	if err != nil {
@@ -938,7 +937,9 @@ func (s *Sync) sessionFingerprints(
 			SecretFindings []db.SecretFinding
 			Pins           []db.PinnedMessage
 		}{
-			SessionFields:  duckSessionFingerprintFields(sess, s.machine),
+			SessionFields: duckSessionFingerprintFields(
+				sess, mirroredSessionMachine(sess, s.machine),
+			),
 			Messages:       msgs,
 			Usage:          usage[sess.ID],
 			ToolCalls:      toolCalls,

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -44,6 +44,43 @@ func TestPushIncrementalReplacesOnlyChangedSessions(t *testing.T) {
 	assertMirrorMessageCount(t, path, "sess-2", 3)
 }
 
+func TestMirroredSessionMachine(t *testing.T) {
+	tests := []struct {
+		name           string
+		sessionMachine string
+		want           string
+	}{
+		{
+			name:           "explicit source machine",
+			sessionMachine: "source-machine",
+			want:           "source-machine",
+		},
+		{
+			name:           "empty source machine",
+			sessionMachine: "",
+			want:           "push-machine",
+		},
+		{
+			name:           "local sentinel",
+			sessionMachine: "local",
+			want:           "push-machine",
+		},
+		{
+			name:           "explicit whitespace is preserved",
+			sessionMachine: " source-machine ",
+			want:           " source-machine ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, mirroredSessionMachine(
+				db.Session{Machine: tt.sessionMachine}, "push-machine",
+			))
+		})
+	}
+}
+
 func TestPushPreservesFilesystemSourceMachineAndCuration(t *testing.T) {
 	ctx := context.Background()
 	local, path := newPushFixture(t, 3)
@@ -60,16 +97,11 @@ func TestPushPreservesFilesystemSourceMachineAndCuration(t *testing.T) {
 		)
 		return err
 	}))
-	starred, err := local.StarSession("sess-2")
-	require.NoError(t, err)
-	require.True(t, starred)
-
-	_, err = Push(ctx, path, local, "push-machine", SyncOptions{}, false, nil)
+	_, err := Push(ctx, path, local, "push-machine", SyncOptions{}, false, nil)
 	require.NoError(t, err)
 
 	conn, err := Open(path)
 	require.NoError(t, err)
-	defer conn.Close()
 	var machine string
 	require.NoError(t, conn.QueryRow(
 		`SELECT machine FROM sessions WHERE id = ?`, "sess-2",
@@ -79,9 +111,79 @@ func TestPushPreservesFilesystemSourceMachineAndCuration(t *testing.T) {
 		`SELECT machine FROM sessions WHERE id = ?`, "sess-3",
 	).Scan(&machine))
 	assert.Equal(t, " source-machine ", machine)
+	require.NoError(t, conn.Close())
+
+	starred, err := local.StarSession("sess-2")
+	require.NoError(t, err)
+	require.True(t, starred)
+	msgs, err := local.GetAllMessages(ctx, "sess-2")
+	require.NoError(t, err)
+	require.NotEmpty(t, msgs)
+	pinID, err := local.PinMessage("sess-2", msgs[0].ID, nil)
+	require.NoError(t, err)
+	require.NotZero(t, pinID)
+
+	res, err := Push(
+		ctx, path, local, "push-machine", SyncOptions{}, false, nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, res.Diagnostics.CurationRefreshed)
+
+	conn, err = Open(path)
+	require.NoError(t, err)
 	assertDuckDBCountWhere(
 		t, conn, "starred_sessions", "session_id = ?", "sess-2", 1,
 	)
+	assertDuckDBCountWhere(
+		t, conn, "pinned_messages", "session_id = ?", "sess-2", 1,
+	)
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, local.UnstarSession("sess-2"))
+	require.NoError(t, local.UnpinMessage("sess-2", msgs[0].ID))
+	res, err = Push(
+		ctx, path, local, "push-machine", SyncOptions{}, false, nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, res.Diagnostics.CurationRefreshed)
+
+	conn, err = Open(path)
+	require.NoError(t, err)
+	defer conn.Close()
+	assertDuckDBCountWhere(
+		t, conn, "starred_sessions", "session_id = ?", "sess-2", 0,
+	)
+	assertDuckDBCountWhere(
+		t, conn, "pinned_messages", "session_id = ?", "sess-2", 0,
+	)
+}
+
+func TestPushRepushesLegacySessionWhenResolvedMachineChanges(t *testing.T) {
+	ctx := context.Background()
+	local, path := newPushFixture(t, 1)
+	_, err := Push(ctx, path, local, "machine-a", SyncOptions{}, false, nil)
+	require.NoError(t, err)
+
+	// Bypass the normal machine-change rebuild and widen the candidate window
+	// so only the resolved machine changes in the per-session fingerprint.
+	setMirrorMetadataValue(t, path, lastPushMachineMetadataKey, "machine-b")
+	setMirrorMetadataValue(
+		t, path, lastPushCutoffMetadataKey, "2020-01-01T00:00:00.000Z",
+	)
+
+	res, err := Push(ctx, path, local, "machine-b", SyncOptions{}, false, nil)
+	require.NoError(t, err)
+	assert.False(t, res.Diagnostics.Full)
+	assert.Equal(t, 1, res.Diagnostics.PushedSessions.Total)
+
+	conn, err := Open(path)
+	require.NoError(t, err)
+	defer conn.Close()
+	var machine string
+	require.NoError(t, conn.QueryRow(
+		`SELECT machine FROM sessions WHERE id = ?`, "sess-1",
+	).Scan(&machine))
+	assert.Equal(t, "machine-b", machine)
 }
 
 // TestPushBoundaryEqualSessionIsNotLost regression-tests the inclusive

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -44,6 +44,46 @@ func TestPushIncrementalReplacesOnlyChangedSessions(t *testing.T) {
 	assertMirrorMessageCount(t, path, "sess-2", 3)
 }
 
+func TestPushPreservesFilesystemSourceMachineAndCuration(t *testing.T) {
+	ctx := context.Background()
+	local, path := newPushFixture(t, 3)
+	require.NoError(t, local.Update(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(
+			`UPDATE sessions SET machine = ? WHERE id = ?`,
+			"source-machine", "sess-2",
+		); err != nil {
+			return err
+		}
+		_, err := tx.Exec(
+			`UPDATE sessions SET machine = ? WHERE id = ?`,
+			" source-machine ", "sess-3",
+		)
+		return err
+	}))
+	starred, err := local.StarSession("sess-2")
+	require.NoError(t, err)
+	require.True(t, starred)
+
+	_, err = Push(ctx, path, local, "push-machine", SyncOptions{}, false, nil)
+	require.NoError(t, err)
+
+	conn, err := Open(path)
+	require.NoError(t, err)
+	defer conn.Close()
+	var machine string
+	require.NoError(t, conn.QueryRow(
+		`SELECT machine FROM sessions WHERE id = ?`, "sess-2",
+	).Scan(&machine))
+	assert.Equal(t, "source-machine", machine)
+	require.NoError(t, conn.QueryRow(
+		`SELECT machine FROM sessions WHERE id = ?`, "sess-3",
+	).Scan(&machine))
+	assert.Equal(t, " source-machine ", machine)
+	assertDuckDBCountWhere(
+		t, conn, "starred_sessions", "session_id = ?", "sess-2", 1,
+	)
+}
+
 // TestPushBoundaryEqualSessionIsNotLost regression-tests the inclusive
 // mirror window: an update whose sync_marker equals the stored cutoff must
 // still be selected and pushed when its fingerprint differs, not skipped
@@ -233,6 +273,47 @@ func TestPushRebuildTriggers(t *testing.T) {
 			assertMirrorMessageCount(t, path, "sess-1", 2)
 		})
 	}
+}
+
+func TestPushRebuildsV6MirrorToRestoreSourceMachine(t *testing.T) {
+	ctx := context.Background()
+	local, path := newPushFixture(t, 1)
+	require.NoError(t, local.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			`UPDATE sessions SET machine = ? WHERE id = ?`,
+			"source-machine", "sess-1",
+		)
+		return err
+	}))
+	_, err := Push(ctx, path, local, "push-machine", SyncOptions{}, false, nil)
+	require.NoError(t, err)
+
+	// Recreate the relevant state of a v6 mirror: rows were attributed to
+	// the publisher, and this session predates the next incremental window.
+	conn, err := Open(path)
+	require.NoError(t, err)
+	_, err = conn.Exec(
+		`UPDATE sessions SET machine = ? WHERE id = ?`,
+		"push-machine", "sess-1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	setMirrorMetadataValue(t, path, schemaVersionMetadataKey, "6")
+	setSessionSignalsTo(t, local, "sess-1", "2020-01-01T00:00:00.000Z")
+
+	res, err := Push(ctx, path, local, "push-machine", SyncOptions{}, false, nil)
+	require.NoError(t, err)
+	assert.True(t, res.Diagnostics.Full)
+	assert.Contains(t, res.Diagnostics.RebuildReason, "schema version 6")
+
+	conn, err = Open(path)
+	require.NoError(t, err)
+	defer conn.Close()
+	var machine string
+	require.NoError(t, conn.QueryRow(
+		`SELECT machine FROM sessions WHERE id = ?`, "sess-1",
+	).Scan(&machine))
+	assert.Equal(t, "source-machine", machine)
 }
 
 // TestPushRefusesToReplaceUnrecognizedExistingFile is the fail-closed
@@ -725,16 +806,10 @@ func TestPushRebuildsWhenMirrorBuiltFromDifferentArchive(t *testing.T) {
 		"a matching source database id must allow the incremental path")
 }
 
-// TestPushRebuildsWhenMachineNameChanges is the FIX1 regression: mirror rows
-// are machine-stamped, and an incremental push only re-pushes sessions whose
-// LOCAL content changed within the current window. A session that has not
-// changed locally since the mirror's last push would otherwise stay
-// permanently labeled with the OLD machine name even after the client's
-// configured machine name (and so the mirror's LastPushMachine metadata)
-// changes, stranding it under a machine filter that will never select it
-// again (see readMachineStatus). The mirror's recorded LastPushMachine
-// differing from the currently configured machine name must force a
-// rebuild instead, so every session is re-pushed and relabeled.
+// TestPushRebuildsWhenMachineNameChanges guards legacy sessions whose source
+// machine is empty or "local". Those rows use the configured push machine, so
+// changing that name must rebuild the mirror and restamp every fallback row.
+// Sessions with explicit source-machine labels keep those labels unchanged.
 func TestPushRebuildsWhenMachineNameChanges(t *testing.T) {
 	ctx := context.Background()
 	local, path := newPushFixture(t, 1)
@@ -1696,8 +1771,8 @@ func TestReadStatusFromConfigReportsTargetPushMetadataAndCounts(t *testing.T) {
 	assert.Equal(t, SchemaVersion, status.SchemaVersion)
 	assert.Equal(t, db.CurrentDataVersion(), status.DataVersion)
 	assert.Empty(t, status.Scope, "unfiltered push canonicalizes to empty scope")
-	assert.Equal(t, 2, status.DuckDBSessions)
-	assert.Equal(t, 3, status.DuckDBMessages)
+	assert.Equal(t, 3, status.DuckDBSessions)
+	assert.Equal(t, 4, status.DuckDBMessages)
 
 	lastPushAt, err := time.Parse(time.RFC3339, status.LastPushAt)
 	require.NoError(t, err)
@@ -1767,17 +1842,10 @@ func TestReadStatusFromConfigDoesNotCreateMissingMirror(t *testing.T) {
 		"status must never create the mirror file")
 }
 
-// TestReadStatusFromConfigCountsByTargetMachineNotConfiguredMachine is the
-// FIX2 regression: readMachineStatus previously filtered its row counts by
-// the CLIENT's configured machine name, while the LastPushMachine it
-// displays comes from the target's own metadata. A remote Quack client is
-// normally configured under its own hostname, which almost never matches
-// whatever machine actually pushed the mirror it is reading, so filtering
-// counts by the configured name reports zero rows even though the mirror
-// plainly has data and the display line already shows a real
-// LastPushMachine. Counts must be keyed off the target's recorded
-// LastPushMachine when it is set.
-func TestReadStatusFromConfigCountsByTargetMachineNotConfiguredMachine(t *testing.T) {
+// Mirror status reports every resident source machine. LastPushMachine identifies
+// the process that published the mirror; it is not the source attribution shared
+// by every mirrored session.
+func TestReadStatusFromConfigCountsAllSourceMachines(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)
 	seedDuckDBSyncFixture(t, local)
@@ -1786,6 +1854,11 @@ func TestReadStatusFromConfigCountsByTargetMachineNotConfiguredMachine(t *testin
 	_, err := Push(ctx, target, local, "actual-pusher", SyncOptions{}, true, nil)
 	require.NoError(t, err)
 
+	conn, err := Open(target)
+	require.NoError(t, err)
+	insertOtherMachineDuckSession(t, conn)
+	require.NoError(t, conn.Close())
+
 	status, err := ReadStatusFromConfig(ctx, config.DuckDBConfig{
 		Path:        target,
 		MachineName: "remote-client-hostname",
@@ -1793,9 +1866,8 @@ func TestReadStatusFromConfigCountsByTargetMachineNotConfiguredMachine(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, "remote-client-hostname", status.Machine)
 	assert.Equal(t, "actual-pusher", status.LastPushMachine)
-	assert.Equal(t, 2, status.DuckDBSessions,
-		"counts must key off the target's LastPushMachine, not the client's configured name")
-	assert.Equal(t, 3, status.DuckDBMessages)
+	assert.Equal(t, 3, status.DuckDBSessions)
+	assert.Equal(t, 4, status.DuckDBMessages)
 }
 
 type syncFixture struct {


### PR DESCRIPTION
DuckDB mirrors now preserve each session's source-machine label, falling back to the publishing machine only for legacy empty or `local` values. The resolved label also participates in the session fingerprint, so attribution changes re-push the row and match PostgreSQL's existing behavior.

Mirror status, residency checks, and curation replacement now operate across every session in the single source archive instead of filtering by the last publishing machine. These dropped machine filters are the most behaviorally significant part of the change: the publisher remains mirror metadata, while resident sessions may carry labels from multiple filesystem sources.

This bumps the disposable mirror schema from 6 to 7. Existing mirrors rebuild once into a fresh validated file and atomically swap on upgrade, which corrects older rows that could sit outside the incremental cutoff.

The change was extracted from #1170, where it was bundled with separate session-source work, so that PR can shed this pre-existing DuckDB/PostgreSQL parity fix and its schema-wide rebuild.