### PR TITLE
test: stabilize platform-sensitive CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           go test -tags "fts5" ./internal/duckdb -count=1
-          go test -tags "fts5" -race $(go list ./... | grep -v '/internal/duckdb$') -count=1
+          go test -tags "fts5" -race $(go list ./... | grep -v '/internal/duckdb$') -count=1 -timeout=20m
         env:
           CGO_ENABLED: "1"
 

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -1522,7 +1522,7 @@ func TestVectorServingCloseWaitsForAPIStartedRecallBuild(t *testing.T) {
 	select {
 	case closeErr := <-closeDone:
 		require.NoError(t, closeErr)
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		require.Fail(t, "vector serving did not close after the API build completed")
 	}
 }


### PR DESCRIPTION
The Linux race suite inherits Go’s ten-minute default package timeout even though the ordinary suite allows twenty minutes. On the failed main run, `internal/sync` reached that boundary without reporting a data race, turning an instrumentation-slow package into a false CI failure.

Windows hit a similar timing assumption: vector serving stayed open correctly while the API build was blocked, but the test allowed only two seconds for index finalization after release. This keeps both lifecycle assertions while giving finalization a bounded allowance appropriate for loaded Windows runners.

This is intentionally a reliability fix, not a suite-sharding change. `internal/sync` and `internal/artifact` are already near co-critical paths; the larger follow-up opportunity is to run the separate non-race DuckDB command in parallel with the race suite.