### PR TITLE
fix(daemon): scope degraded-coverage polling to one provider per pass

### DIFF
--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -108,6 +108,7 @@ func newArchivePushUnwatchedPoller(
 	ticker := time.NewTicker(unwatchedPollInterval)
 	return newUnwatchedPollCoordinatorWithTicks(
 		ctx, engine, ticker.C, ticker.Stop, func(work func()) { work() }, nil,
+		time.Now, time.After,
 	)
 }
 
@@ -147,18 +148,29 @@ func archivePushWatchWatcherOptions(
 			// the affected roots authoritatively (including tombstoning
 			// missed deletions) and the loop re-pushes the refreshed
 			// archive on its floor.
+			scopes := make([]pollingScope, 0, len(roots))
+			for _, r := range roots {
+				scopes = append(scopes, pollingScope{Root: r})
+			}
 			if err := poller.AddObligation(pollingObligation{
-				Key: "watcher-fallback", Roots: roots,
+				Key: "watcher-fallback", Scopes: scopes,
 			}); err != nil {
 				return err
 			}
 			return loop.NotifyCoverageDegraded(roots)
 		},
 		OnPollingRequired: func(obligation syncpkg.PollingObligation) error {
+			scopes := make([]pollingScope, 0, len(obligation.Scopes))
+			for _, s := range obligation.Scopes {
+				scopes = append(scopes, pollingScope{
+					Agent: parser.AgentType(s.Agent),
+					Root:  s.Root,
+				})
+			}
 			return poller.AddObligation(pollingObligation{
-				Key:   obligation.Key,
-				Roots: obligation.Roots,
-				Probe: obligation.Probe,
+				Key:    obligation.Key,
+				Scopes: scopes,
+				Probe:  obligation.Probe,
 			})
 		},
 		OnPollingReleased: poller.RemoveObligation,

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -905,7 +905,7 @@ func TestLocalPGPushWatchGivesDeferredScopesAPollingOwner(t *testing.T) {
 				ctx, engine, ticks, func() {}, func(work func()) { work() },
 				func(roots []string) {
 					owned <- append([]string(nil), roots...)
-				},
+				}, time.Now, time.After,
 			)
 		},
 	}
@@ -1023,6 +1023,7 @@ func TestLocalDuckDBPushWatchGivesDeferredScopesAPollingOwner(t *testing.T) {
 				func(roots []string) {
 					owned <- append([]string(nil), roots...)
 				},
+				time.Now, time.After,
 			)
 		},
 	}

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -795,7 +795,7 @@ func (s watchRecoveryScope) coversProviderRoot(root string) bool {
 // probeWatchRecoveryScope computes the probed reconciliation scope backing
 // reconcileRootPaths; see that function for the deferral semantics.
 func probeWatchRecoveryScope(cfg config.Config) watchRecoveryScope {
-	roots, unwatchedDirs, symlinkGatedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, symlinkGatedDirs, _ := collectWatchRoots(cfg)
 	deferred := make(map[string]struct{})
 	// A recursive symlink root never joins the watch roots, so its exact
 	// availability probe is the symlink target itself: os.Stat follows the
@@ -1818,7 +1818,7 @@ func startFileWatcher(
 	queueRetry func(sync.WatchBatch),
 ) {
 	t := time.Now()
-	roots, unwatchedDirs, symlinkGatedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, symlinkGatedDirs, persistentDirAgents := collectWatchRoots(cfg)
 	watcher, err := sync.NewWatcherWithCallback(
 		watcherBatchDelay,
 		watcherSyncMinInterval,
@@ -1831,7 +1831,7 @@ func startFileWatcher(
 			unwatchedDirs = appendUniqueStrings(unwatchedDirs, root.syncDirs()...)
 		}
 		if coverageErr := registerWatcherUnavailableObligations(
-			options, roots, unwatchedDirs, symlinkGatedDirs,
+			options, roots, unwatchedDirs, symlinkGatedDirs, persistentDirAgents,
 		); coverageErr != nil {
 			err = errors.Join(err, coverageErr)
 		}
@@ -1878,7 +1878,7 @@ func startFileWatcher(
 		}
 	}
 	if options.OnPollingRequired != nil {
-		obligations := watchPollingObligations(roots, results, unwatchedDirs, symlinkGatedDirs)
+		obligations := watchPollingObligations(roots, results, unwatchedDirs, persistentDirAgents)
 		obligations = append(obligations, symlinkPollingObligations(symlinkGatedDirs)...)
 		for _, obligation := range obligations {
 			if err := options.OnPollingRequired(obligation); err != nil {
@@ -1911,11 +1911,18 @@ func startFileWatcher(
 		watcher.QueueRetryBatch
 }
 
+// watchPollingObligations builds the polling obligations for the watch plan.
+// persistentDirAgents maps each clean persistent-polling dir to the providers
+// that requested persistent polling for it (from collectWatchRoots); persistent
+// obligations carry scopes only for those requesters. Other agents that merely
+// share the configured dir are covered by their own watch results, and pulling
+// them into another provider's persistent poll would reconcile them
+// authoritatively — tombstoning sessions under a lifecycle-owned missing root.
 func watchPollingObligations(
 	roots []watchRoot,
 	results []sync.RecursiveWatchResult,
 	unwatchedDirs []string,
-	symlinkGatedDirs map[string][]watchScope,
+	persistentDirAgents map[string][]parser.AgentType,
 ) []sync.PollingObligation {
 	type draft struct {
 		probe  string
@@ -1944,32 +1951,6 @@ func watchPollingObligations(
 		}
 	}
 
-	// syncDirToAgents maps clean syncDir → all agents configured for that dir.
-	// Include both regular roots and symlink-gated dirs so that a provider
-	// whose only physical root is a symlink (excluded from the watch plan) still
-	// has its agent recorded for persistent obligation scopes.
-	syncDirToAgents := make(map[string][]parser.AgentType)
-	for _, root := range roots {
-		for _, scope := range root.scopes {
-			if scope.syncDir != "" {
-				cleanDir := filepath.Clean(scope.syncDir)
-				if !slices.Contains(syncDirToAgents[cleanDir], scope.agent) {
-					syncDirToAgents[cleanDir] = append(syncDirToAgents[cleanDir], scope.agent)
-				}
-			}
-		}
-	}
-	for _, scopes := range symlinkGatedDirs {
-		for _, scope := range scopes {
-			if scope.syncDir != "" {
-				cleanDir := filepath.Clean(scope.syncDir)
-				if !slices.Contains(syncDirToAgents[cleanDir], scope.agent) {
-					syncDirToAgents[cleanDir] = append(syncDirToAgents[cleanDir], scope.agent)
-				}
-			}
-		}
-	}
-
 	for i, root := range roots {
 		var result sync.RecursiveWatchResult
 		if i < len(results) {
@@ -1981,7 +1962,7 @@ func watchPollingObligations(
 		}
 		for _, dir := range root.persistentPollingDirs {
 			cleanDir := filepath.Clean(dir)
-			agents := syncDirToAgents[cleanDir]
+			agents := persistentDirAgents[cleanDir]
 			if len(agents) == 0 {
 				addScope(pollingObligationKey("persistent", cleanDir), dir,
 					pollingScope{Root: dir})
@@ -2012,7 +1993,7 @@ func watchPollingObligations(
 	for _, dir := range unwatchedDirs {
 		cleanDir := filepath.Clean(dir)
 		if _, ok := represented[cleanDir]; !ok {
-			agents := syncDirToAgents[cleanDir]
+			agents := persistentDirAgents[cleanDir]
 			if len(agents) == 0 {
 				addScope(pollingObligationKey("persistent", cleanDir), cleanDir,
 					pollingScope{Root: dir})
@@ -2073,8 +2054,9 @@ func registerWatcherUnavailableObligations(
 	roots []watchRoot,
 	unwatchedDirs []string,
 	symlinkGatedDirs map[string][]watchScope,
+	persistentDirAgents map[string][]parser.AgentType,
 ) error {
-	obligations := watchPollingObligations(roots, nil, unwatchedDirs, symlinkGatedDirs)
+	obligations := watchPollingObligations(roots, nil, unwatchedDirs, persistentDirAgents)
 	obligations = append(obligations, symlinkPollingObligations(symlinkGatedDirs)...)
 	if options.OnPollingRequired != nil {
 		for _, obligation := range obligations {
@@ -2503,14 +2485,27 @@ func (r watchRoot) pollingScopesForDirs(dirs []string) []pollingScope {
 // each recursive provider root skipped because it is a symlink to the
 // configured dirs whose reconciliation scope its target availability gates;
 // those roots never join the watcher plan or the returned roots.
+// persistentDirAgents maps each clean persistent-polling dir to the providers
+// that requested persistent polling for it, so obligation scopes can stay
+// limited to the owning providers rather than every agent sharing the dir.
 func collectWatchRoots(cfg config.Config) (
 	roots []watchRoot,
 	unwatchedDirs []string,
 	symlinkGatedDirs map[string][]watchScope,
+	persistentDirAgents map[string][]parser.AgentType,
 ) {
 	rootIndexes := make(map[string]int)
 	persistentPollingDirs := make(map[string]struct{})
 	symlinkGatedDirs = make(map[string][]watchScope)
+	persistentDirAgents = make(map[string][]parser.AgentType)
+	addPersistent := func(agent parser.AgentType, dir string) {
+		persistentPollingDirs[dir] = struct{}{}
+		unwatchedDirs = appendUniqueString(unwatchedDirs, dir)
+		cleanDir := filepath.Clean(dir)
+		if !slices.Contains(persistentDirAgents[cleanDir], agent) {
+			persistentDirAgents[cleanDir] = append(persistentDirAgents[cleanDir], agent)
+		}
+	}
 	addRoot := func(agent parser.AgentType, dir, path string, recursive, exists bool) {
 		path = filepath.Clean(path)
 		scope := watchScope{agent: agent, syncDir: dir}
@@ -2538,8 +2533,7 @@ func collectWatchRoots(cfg config.Config) (
 			_, hasProvider := parser.ProviderFactoryByType(def.Type)
 			if providerWatched, polling := collectProviderWatchRoots(def, d, addAgentRoot); providerWatched {
 				if polling.persistent {
-					persistentPollingDirs[d] = struct{}{}
-					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
+					addPersistent(def.Type, d)
 				}
 				for _, symRoot := range polling.symlinkRoots {
 					scope := watchScope{agent: def.Type, syncDir: d}
@@ -2561,15 +2555,13 @@ func collectWatchRoots(cfg config.Config) (
 			}
 			if !def.FileBased {
 				if hasProvider {
-					persistentPollingDirs[d] = struct{}{}
-					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
+					addPersistent(def.Type, d)
 				}
 				continue
 			}
 			fallbackUnwatched := collectLegacyWatchRoots(def, d, addAgentRoot)
 			for _, pollingDir := range fallbackUnwatched {
-				persistentPollingDirs[pollingDir] = struct{}{}
-				unwatchedDirs = appendUniqueString(unwatchedDirs, pollingDir)
+				addPersistent(def.Type, pollingDir)
 			}
 		}
 	}
@@ -2583,7 +2575,7 @@ func collectWatchRoots(cfg config.Config) (
 			}
 		}
 	}
-	return roots, unwatchedDirs, symlinkGatedDirs
+	return roots, unwatchedDirs, symlinkGatedDirs, persistentDirAgents
 }
 
 type providerPollingReasons struct {
@@ -2917,7 +2909,7 @@ type scheduledReconcileTarget struct {
 // present scope would read the missing one as an authoritative empty discovery
 // and tombstone every session beneath it.
 func scheduledReconcileTargets(cfg config.Config) []scheduledReconcileTarget {
-	roots, _, _ := collectWatchRoots(cfg)
+	roots, _, _, _ := collectWatchRoots(cfg)
 	deferred := make(map[parser.AgentType]map[string]struct{})
 	for _, root := range roots {
 		if root.exists {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -898,31 +898,6 @@ func syncObligationToPoller(o sync.PollingObligation) pollingObligation {
 	return pollingObligation{Key: o.Key, Scopes: scopes, Probe: o.Probe}
 }
 
-// rootPathsToPollingScopes resolves which (agent, syncDir) pairs are configured
-// at the given physical root paths, for building coverage-degraded obligations.
-func rootPathsToPollingScopes(roots []watchRoot, paths []string) []pollingScope {
-	var scopes []pollingScope
-	for _, path := range paths {
-		cleanPath := filepath.Clean(path)
-		for _, root := range roots {
-			if filepath.Clean(root.path) == cleanPath {
-				for _, scope := range root.scopes {
-					ps := pollingScope{Agent: scope.agent, Root: scope.syncDir}
-					if !slices.Contains(scopes, ps) {
-						scopes = append(scopes, ps)
-					}
-				}
-			}
-		}
-	}
-	if len(scopes) == 0 {
-		for _, path := range paths {
-			scopes = append(scopes, pollingScope{Root: path})
-		}
-	}
-	return scopes
-}
-
 // absRootPath mirrors the engine's cleanRootPath so daemon-side scope-overlap
 // checks compare the same path form the engine's root expansion uses.
 func absRootPath(path string) string {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -323,17 +323,17 @@ func runServe(cfg config.Config, opts serveOptions) {
 				})
 			},
 			sync.WatcherOptions{
-				OnCoverageDegraded: func(roots []string) error {
+				OnCoverageDegraded: func(degradedRoots []string) error {
+					scopes := make([]pollingScope, 0, len(degradedRoots))
+					for _, r := range degradedRoots {
+						scopes = append(scopes, pollingScope{Root: r})
+					}
 					return unwatchedPoller.AddObligation(pollingObligation{
-						Key: "watcher-fallback", Roots: roots,
+						Key: "watcher-fallback", Scopes: scopes,
 					})
 				},
 				OnPollingRequired: func(obligation sync.PollingObligation) error {
-					return unwatchedPoller.AddObligation(pollingObligation{
-						Key:   obligation.Key,
-						Roots: obligation.Roots,
-						Probe: obligation.Probe,
-					})
+					return unwatchedPoller.AddObligation(syncObligationToPoller(obligation))
 				},
 				OnPollingReleased: unwatchedPoller.RemoveObligation,
 			},
@@ -801,12 +801,12 @@ func probeWatchRecoveryScope(cfg config.Config) watchRecoveryScope {
 	// availability probe is the symlink target itself: os.Stat follows the
 	// link and fails while the target is gone, deferring the configured
 	// scope before an overlapping present path could expand into it.
-	for symRoot, dirs := range symlinkGatedDirs {
+	for symRoot, scopes := range symlinkGatedDirs {
 		if _, err := os.Stat(symRoot); err == nil {
 			continue
 		}
-		for _, dir := range dirs {
-			deferred[filepath.Clean(dir)] = struct{}{}
+		for _, scope := range scopes {
+			deferred[filepath.Clean(scope.syncDir)] = struct{}{}
 		}
 	}
 	for _, r := range roots {
@@ -878,6 +878,49 @@ func overlapsDeferredScope(path string, deferred map[string]struct{}) bool {
 		}
 	}
 	return false
+}
+
+// pollingObligationKey returns a reason-namespaced key so different reasons
+// over one physical root produce independent obligations. The reason argument
+// is required so a missing reason is a compile error rather than a silent
+// key collision.
+func pollingObligationKey(reason, path string) string {
+	return reason + ":" + path
+}
+
+// syncObligationToPoller converts a sync.PollingObligation to the local
+// pollingObligation type used by the coordinator.
+func syncObligationToPoller(o sync.PollingObligation) pollingObligation {
+	scopes := make([]pollingScope, 0, len(o.Scopes))
+	for _, s := range o.Scopes {
+		scopes = append(scopes, pollingScope{Agent: parser.AgentType(s.Agent), Root: s.Root})
+	}
+	return pollingObligation{Key: o.Key, Scopes: scopes, Probe: o.Probe}
+}
+
+// rootPathsToPollingScopes resolves which (agent, syncDir) pairs are configured
+// at the given physical root paths, for building coverage-degraded obligations.
+func rootPathsToPollingScopes(roots []watchRoot, paths []string) []pollingScope {
+	var scopes []pollingScope
+	for _, path := range paths {
+		cleanPath := filepath.Clean(path)
+		for _, root := range roots {
+			if filepath.Clean(root.path) == cleanPath {
+				for _, scope := range root.scopes {
+					ps := pollingScope{Agent: scope.agent, Root: scope.syncDir}
+					if !slices.Contains(scopes, ps) {
+						scopes = append(scopes, ps)
+					}
+				}
+			}
+		}
+	}
+	if len(scopes) == 0 {
+		for _, path := range paths {
+			scopes = append(scopes, pollingScope{Root: path})
+		}
+	}
+	return scopes
 }
 
 // absRootPath mirrors the engine's cleanRootPath so daemon-side scope-overlap
@@ -1860,7 +1903,7 @@ func startFileWatcher(
 		}
 	}
 	if options.OnPollingRequired != nil {
-		obligations := watchPollingObligations(roots, results, unwatchedDirs)
+		obligations := watchPollingObligations(roots, results, unwatchedDirs, symlinkGatedDirs)
 		obligations = append(obligations, symlinkPollingObligations(symlinkGatedDirs)...)
 		for _, obligation := range obligations {
 			if err := options.OnPollingRequired(obligation); err != nil {
@@ -1897,64 +1940,133 @@ func watchPollingObligations(
 	roots []watchRoot,
 	results []sync.RecursiveWatchResult,
 	unwatchedDirs []string,
+	symlinkGatedDirs map[string][]watchScope,
 ) []sync.PollingObligation {
-	byKey := make(map[string][]string)
-	probes := make(map[string]string)
+	type draft struct {
+		probe  string
+		scopes []pollingScope
+	}
+	byKey := make(map[string]*draft)
 	represented := make(map[string]struct{})
-	// The probe is the physical path whose availability gates the
-	// obligation's reconciliation roots: the watch root's own path for
-	// root-keyed groups, the dir itself for persistent dirs.
-	add := func(key, probe string, roots ...string) {
+
+	addScope := func(key, probe string, scopes ...pollingScope) {
 		if key == "" {
 			return
 		}
-		probes[key] = filepath.Clean(probe)
-		for _, root := range roots {
-			if root == "" {
+		probe = filepath.Clean(probe)
+		if _, ok := byKey[key]; !ok {
+			byKey[key] = &draft{probe: probe}
+		}
+		for _, scope := range scopes {
+			if scope.Root == "" {
 				continue
 			}
-			root = filepath.Clean(root)
-			byKey[key] = appendUniqueString(byKey[key], root)
-			represented[root] = struct{}{}
+			scope.Root = filepath.Clean(scope.Root)
+			if !slices.Contains(byKey[key].scopes, scope) {
+				byKey[key].scopes = append(byKey[key].scopes, scope)
+			}
+			represented[scope.Root] = struct{}{}
 		}
 	}
+
+	// syncDirToAgents maps clean syncDir → all agents configured for that dir.
+	// Include both regular roots and symlink-gated dirs so that a provider
+	// whose only physical root is a symlink (excluded from the watch plan) still
+	// has its agent recorded for persistent obligation scopes.
+	syncDirToAgents := make(map[string][]parser.AgentType)
+	for _, root := range roots {
+		for _, scope := range root.scopes {
+			if scope.syncDir != "" {
+				cleanDir := filepath.Clean(scope.syncDir)
+				if !slices.Contains(syncDirToAgents[cleanDir], scope.agent) {
+					syncDirToAgents[cleanDir] = append(syncDirToAgents[cleanDir], scope.agent)
+				}
+			}
+		}
+	}
+	for _, scopes := range symlinkGatedDirs {
+		for _, scope := range scopes {
+			if scope.syncDir != "" {
+				cleanDir := filepath.Clean(scope.syncDir)
+				if !slices.Contains(syncDirToAgents[cleanDir], scope.agent) {
+					syncDirToAgents[cleanDir] = append(syncDirToAgents[cleanDir], scope.agent)
+				}
+			}
+		}
+	}
+
 	for i, root := range roots {
 		var result sync.RecursiveWatchResult
 		if i < len(results) {
 			result = results[i]
 		}
 		if !result.MissingRootLifecycleOwned {
-			add(root.path, root.path, root.pendingPollingDirs...)
+			// Pending dirs: keyed on the physical root path; derive agent from scopes.
+			addScope(root.path, root.path, root.pollingScopesForDirs(root.pendingPollingDirs)...)
 		}
 		for _, dir := range root.persistentPollingDirs {
-			add("persistent:"+filepath.Clean(dir), dir, dir)
+			cleanDir := filepath.Clean(dir)
+			agents := syncDirToAgents[cleanDir]
+			if len(agents) == 0 {
+				addScope(pollingObligationKey("persistent", cleanDir), dir,
+					pollingScope{Root: dir})
+			} else {
+				for _, agent := range agents {
+					addScope(pollingObligationKey("persistent", cleanDir), dir,
+						pollingScope{Agent: agent, Root: dir})
+				}
+			}
 		}
 		if i >= len(results) {
-			// No registration result exists for this root: the watcher was
-			// never constructed, so nothing covers the physical root. Gate
-			// its sync scopes on the root itself, or a root that disappears
-			// after the obligations are installed leaves its configured dir
-			// pollable and the fallback poll reconciles it as an
-			// authoritative empty discovery.
-			add(root.path, root.path, root.syncDirs()...)
+			// No watcher constructed: gate sync scopes on the physical root path,
+			// one obligation per agent so releases are independent.
+			for _, scope := range root.scopes {
+				key := pollingObligationKey("nowatcher:"+string(scope.agent), root.path)
+				addScope(key, root.path, pollingScope{Agent: scope.agent, Root: scope.syncDir})
+			}
 			continue
 		}
 		if result.Unwatched > 0 || result.BudgetExhausted ||
 			result.ResourceExhausted || result.Err != nil {
-			add(root.path, root.path, root.syncDirs()...)
+			for _, scope := range root.scopes {
+				key := pollingObligationKey("degraded:"+string(scope.agent), root.path)
+				addScope(key, root.path, pollingScope{Agent: scope.agent, Root: scope.syncDir})
+			}
 		}
 	}
 	for _, dir := range unwatchedDirs {
-		dir = filepath.Clean(dir)
-		if _, ok := represented[dir]; !ok {
-			add("persistent:"+dir, dir, dir)
+		cleanDir := filepath.Clean(dir)
+		if _, ok := represented[cleanDir]; !ok {
+			agents := syncDirToAgents[cleanDir]
+			if len(agents) == 0 {
+				addScope(pollingObligationKey("persistent", cleanDir), cleanDir,
+					pollingScope{Root: dir})
+			} else {
+				for _, agent := range agents {
+					addScope(pollingObligationKey("persistent", cleanDir), cleanDir,
+						pollingScope{Agent: agent, Root: dir})
+				}
+			}
 		}
 	}
+
 	obligations := make([]sync.PollingObligation, 0, len(byKey))
-	for key, roots := range byKey {
-		slices.Sort(roots)
+	for key, d := range byKey {
+		if len(d.scopes) == 0 {
+			continue
+		}
+		ps := make([]sync.PollingScope, 0, len(d.scopes))
+		for _, scope := range d.scopes {
+			ps = append(ps, sync.PollingScope{Agent: string(scope.Agent), Root: scope.Root})
+		}
+		slices.SortFunc(ps, func(a, b sync.PollingScope) int {
+			if a.Agent != b.Agent {
+				return strings.Compare(a.Agent, b.Agent)
+			}
+			return strings.Compare(a.Root, b.Root)
+		})
 		obligations = append(obligations, sync.PollingObligation{
-			Key: key, Roots: roots, Probe: probes[key],
+			Key: key, Scopes: ps, Probe: d.probe,
 		})
 	}
 	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {
@@ -1985,13 +2097,11 @@ func registerWatcherUnavailableObligations(
 	options sync.WatcherOptions,
 	roots []watchRoot,
 	unwatchedDirs []string,
-	symlinkGatedDirs map[string][]string,
+	symlinkGatedDirs map[string][]watchScope,
 ) error {
+	obligations := watchPollingObligations(roots, nil, unwatchedDirs, symlinkGatedDirs)
+	obligations = append(obligations, symlinkPollingObligations(symlinkGatedDirs)...)
 	if options.OnPollingRequired != nil {
-		obligations := watchPollingObligations(roots, nil, unwatchedDirs)
-		obligations = append(
-			obligations, symlinkPollingObligations(symlinkGatedDirs)...,
-		)
 		for _, obligation := range obligations {
 			if err := options.OnPollingRequired(obligation); err != nil {
 				log.Printf(
@@ -2003,7 +2113,35 @@ func registerWatcherUnavailableObligations(
 	if options.OnCoverageDegraded == nil {
 		return nil
 	}
-	return options.OnCoverageDegraded(unwatchedDirs)
+	// Exclude dirs already covered by probe-gated obligations so the empty-agent
+	// coverage-degraded fallback does not bypass per-agent probe gates. Only
+	// apply this exclusion when OnPollingRequired is set: the probe-gated
+	// obligations are only installed when OnPollingRequired is non-nil, so when
+	// it is nil the exclusion would silently drop every dir (all obligations have
+	// probes) and coverage-degraded would never fire — breaking archive-watch
+	// call sites that set only OnCoverageDegraded.
+	fallbackDirs := unwatchedDirs
+	if options.OnPollingRequired != nil {
+		probeGated := make(map[string]struct{})
+		for _, ob := range obligations {
+			if ob.Probe != "" {
+				for _, scope := range ob.Scopes {
+					probeGated[scope.Root] = struct{}{}
+				}
+			}
+		}
+		filtered := make([]string, 0, len(unwatchedDirs))
+		for _, dir := range unwatchedDirs {
+			if _, ok := probeGated[filepath.Clean(dir)]; !ok {
+				filtered = append(filtered, dir)
+			}
+		}
+		fallbackDirs = filtered
+	}
+	if len(fallbackDirs) == 0 {
+		return nil
+	}
+	return options.OnCoverageDegraded(fallbackDirs)
 }
 
 // symlinkPollingObligations gates persistent polling of dirs whose recursive
@@ -2015,19 +2153,30 @@ func registerWatcherUnavailableObligations(
 // referencing it has a missing probe, so this composes with the dir's own
 // persistent obligation.
 func symlinkPollingObligations(
-	symlinkGatedDirs map[string][]string,
+	symlinkGatedDirs map[string][]watchScope,
 ) []sync.PollingObligation {
 	obligations := make([]sync.PollingObligation, 0, len(symlinkGatedDirs))
-	for symRoot, dirs := range symlinkGatedDirs {
-		roots := make([]string, 0, len(dirs))
-		for _, dir := range dirs {
-			roots = appendUniqueString(roots, filepath.Clean(dir))
+	for symRoot, gatedScopes := range symlinkGatedDirs {
+		scopes := make([]sync.PollingScope, 0, len(gatedScopes))
+		for _, scope := range gatedScopes {
+			ps := sync.PollingScope{
+				Agent: string(scope.agent),
+				Root:  filepath.Clean(scope.syncDir),
+			}
+			if !slices.Contains(scopes, ps) {
+				scopes = append(scopes, ps)
+			}
 		}
-		slices.Sort(roots)
+		slices.SortFunc(scopes, func(a, b sync.PollingScope) int {
+			if a.Agent != b.Agent {
+				return strings.Compare(a.Agent, b.Agent)
+			}
+			return strings.Compare(a.Root, b.Root)
+		})
 		obligations = append(obligations, sync.PollingObligation{
-			Key:   "symlink:" + filepath.Clean(symRoot),
-			Roots: roots,
-			Probe: filepath.Clean(symRoot),
+			Key:    "symlink:" + filepath.Clean(symRoot),
+			Scopes: scopes,
+			Probe:  filepath.Clean(symRoot),
 		})
 	}
 	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {
@@ -2339,6 +2488,42 @@ func (r watchRoot) syncDirs() []string {
 	return dirs
 }
 
+// pollingScopesForDirs resolves pollingScope values for the given configured
+// dirs by matching against the root's scopes. Each dir emits one scope per
+// matching agent; dirs not matched by any scope use an empty agent.
+func (r watchRoot) pollingScopesForDirs(dirs []string) []pollingScope {
+	agentsByDir := make(map[string][]parser.AgentType, len(r.scopes))
+	for _, scope := range r.scopes {
+		if scope.syncDir != "" {
+			cleanDir := filepath.Clean(scope.syncDir)
+			if !slices.Contains(agentsByDir[cleanDir], scope.agent) {
+				agentsByDir[cleanDir] = append(agentsByDir[cleanDir], scope.agent)
+			}
+		}
+	}
+	var scopes []pollingScope
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		agents := agentsByDir[filepath.Clean(dir)]
+		if len(agents) == 0 {
+			ps := pollingScope{Root: dir}
+			if !slices.Contains(scopes, ps) {
+				scopes = append(scopes, ps)
+			}
+		} else {
+			for _, agent := range agents {
+				ps := pollingScope{Agent: agent, Root: dir}
+				if !slices.Contains(scopes, ps) {
+					scopes = append(scopes, ps)
+				}
+			}
+		}
+	}
+	return scopes
+}
+
 // collectWatchRoots resolves the configured watch plan. symlinkGatedDirs maps
 // each recursive provider root skipped because it is a symlink to the
 // configured dirs whose reconciliation scope its target availability gates;
@@ -2346,11 +2531,11 @@ func (r watchRoot) syncDirs() []string {
 func collectWatchRoots(cfg config.Config) (
 	roots []watchRoot,
 	unwatchedDirs []string,
-	symlinkGatedDirs map[string][]string,
+	symlinkGatedDirs map[string][]watchScope,
 ) {
 	rootIndexes := make(map[string]int)
 	persistentPollingDirs := make(map[string]struct{})
-	symlinkGatedDirs = make(map[string][]string)
+	symlinkGatedDirs = make(map[string][]watchScope)
 	addRoot := func(agent parser.AgentType, dir, path string, recursive, exists bool) {
 		path = filepath.Clean(path)
 		scope := watchScope{agent: agent, syncDir: dir}
@@ -2382,9 +2567,10 @@ func collectWatchRoots(cfg config.Config) (
 					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
 				}
 				for _, symRoot := range polling.symlinkRoots {
-					symlinkGatedDirs[symRoot] = appendUniqueString(
-						symlinkGatedDirs[symRoot], d,
-					)
+					scope := watchScope{agent: def.Type, syncDir: d}
+					if !slices.Contains(symlinkGatedDirs[symRoot], scope) {
+						symlinkGatedDirs[symRoot] = append(symlinkGatedDirs[symRoot], scope)
+					}
 				}
 				for _, missing := range polling.missingRoots {
 					idx, ok := rootIndexes[filepath.Clean(missing)]

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -526,30 +526,27 @@ func TestNewDaemonIdleTrackerEnvOverridesConfig(t *testing.T) {
 type fakeUnwatchedPollSyncer struct {
 	calls     int
 	callRoots [][]string
-	callFull  []bool
 }
 
-func (f *fakeUnwatchedPollSyncer) ReconcileWatchRoots(
-	_ context.Context, roots []string, full bool,
+func (f *fakeUnwatchedPollSyncer) ReconcileProviderRoots(
+	_ context.Context, _ parser.AgentType, roots []string,
 ) error {
 	f.calls++
 	f.callRoots = append(f.callRoots, append([]string(nil), roots...))
-	f.callFull = append(f.callFull, full)
 	return nil
 }
 
-func TestPollUnwatchedRootsOnceUsesScopedAuthoritativeReconciliation(t *testing.T) {
+func TestPollUnwatchedScopesOnceUsesScopedAuthoritativeReconciliation(t *testing.T) {
 	fake := &fakeUnwatchedPollSyncer{}
 	roots := []string{"/tmp/claude", "/tmp/codex"}
+	groups := map[parser.AgentType][]string{"": roots}
 
-	pollUnwatchedRootsOnce(t.Context(), fake, roots)
-	pollUnwatchedRootsOnce(t.Context(), fake, roots)
+	require.NoError(t, pollUnwatchedScopesOnce(t.Context(), fake, groups))
+	require.NoError(t, pollUnwatchedScopesOnce(t.Context(), fake, groups))
 
 	require.Equal(t, 2, fake.calls)
 	assert.Equal(t, roots, fake.callRoots[0])
-	assert.False(t, fake.callFull[0])
 	assert.Equal(t, roots, fake.callRoots[1])
-	assert.False(t, fake.callFull[1])
 }
 
 func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
@@ -1308,6 +1305,7 @@ func TestStartFileWatcherSuppressesPendingPollingWhenLifecycleIsOwned(t *testing
 			MissingRootLifecycleOwned: true,
 		}},
 		got,
+		nil,
 	), "owned missing roots must not schedule authoritative polling")
 }
 
@@ -1520,9 +1518,9 @@ func TestWatchPollingObligationsMissingRootLifecycleCardinality(t *testing.T) {
 				unwatched = append(unwatched, syncDir)
 			}
 
-			assert.Empty(t, watchPollingObligations(roots, owned, nil),
+			assert.Empty(t, watchPollingObligations(roots, owned, nil, nil),
 				"native lifecycle work must remain independent of configured archive cardinality")
-			assert.Len(t, watchPollingObligations(roots, portable, unwatched), rootCount,
+			assert.Len(t, watchPollingObligations(roots, portable, unwatched, nil), rootCount,
 				"portable backends retain one obligation per uncovered missing root")
 		})
 	}
@@ -1551,7 +1549,7 @@ func TestOpenCodeFormatMissingRootsUseNativeLifecycleWithoutPolling(t *testing.T
 			}
 			unwatched = accountRegisteredWatchRoots(unwatched, roots, results)
 
-			assert.Empty(t, watchPollingObligations(roots, results, unwatched),
+			assert.Empty(t, watchPollingObligations(roots, results, unwatched, nil),
 				"absent OpenCode-format providers must not add archive-scale polling")
 		})
 	}
@@ -1577,11 +1575,20 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 		roots,
 		[]agentsync.RecursiveWatchResult{{Watched: 1}, {Watched: 1}},
 		[]string{shared},
+		nil,
 	)
 
 	assert.Equal(t, []agentsync.PollingObligation{
-		{Key: pendingPath, Roots: []string{shared}, Probe: pendingPath},
-		{Key: "persistent:" + shared, Roots: []string{shared}, Probe: shared},
+		{
+			Key:    pendingPath,
+			Scopes: []agentsync.PollingScope{{Agent: "devin", Root: shared}},
+			Probe:  pendingPath,
+		},
+		{
+			Key:    "persistent:" + shared,
+			Scopes: []agentsync.PollingScope{{Agent: "devin", Root: shared}},
+			Probe:  shared,
+		},
 	}, got)
 }
 
@@ -1597,10 +1604,13 @@ func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing
 		roots,
 		[]agentsync.RecursiveWatchResult{{Unwatched: 1, Err: errors.New("watch failed")}},
 		[]string{syncDir},
+		nil,
 	)
 
 	assert.Equal(t, []agentsync.PollingObligation{{
-		Key: watchPath, Roots: []string{syncDir}, Probe: watchPath,
+		Key:    "degraded:claude:" + watchPath,
+		Scopes: []agentsync.PollingScope{{Agent: "claude", Root: syncDir}},
+		Probe:  watchPath,
 	}}, got)
 }
 
@@ -1616,22 +1626,26 @@ func TestSymlinkPollingObligationsGateDirsOnTargetAvailability(t *testing.T) {
 	symRoot := filepath.Join(parent, "sessions")
 	requireSymlinkOrSkip(t, target, symRoot)
 
-	obligations := symlinkPollingObligations(map[string][]string{
-		symRoot: {parent},
+	obligations := symlinkPollingObligations(map[string][]watchScope{
+		symRoot: {{syncDir: parent}},
 	})
 	require.Equal(t, []agentsync.PollingObligation{{
-		Key: "symlink:" + symRoot, Roots: []string{parent}, Probe: symRoot,
+		Key: "symlink:" + symRoot, Scopes: []agentsync.PollingScope{{Root: parent}}, Probe: symRoot,
 	}}, obligations)
 
 	combined := []pollingObligation{
-		{Key: "persistent:" + parent, Roots: []string{parent}, Probe: parent},
-		{Key: obligations[0].Key, Roots: obligations[0].Roots, Probe: obligations[0].Probe},
+		{Key: "persistent:" + parent, Scopes: []pollingScope{{Root: parent}}, Probe: parent},
+		{
+			Key:    obligations[0].Key,
+			Scopes: []pollingScope{{Root: parent}},
+			Probe:  obligations[0].Probe,
+		},
 	}
-	assert.Equal(t, []string{parent}, availableUnwatchedPollRoots(combined),
+	assert.Equal(t, []string{parent}, availableUnwatchedPollRootsFlat(combined),
 		"a working symlink target keeps the dir pollable")
 
 	require.NoError(t, os.RemoveAll(target))
-	assert.Empty(t, availableUnwatchedPollRoots(combined),
+	assert.Empty(t, availableUnwatchedPollRootsFlat(combined),
 		"a broken symlink target must defer the dir even though the dir itself exists")
 }
 
@@ -1653,21 +1667,26 @@ func TestWatcherUnavailableFallbackDefersBrokenSymlinkScope(t *testing.T) {
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, time.Now,
+		func(d time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
 		OnCoverageDegraded: func(roots []string) error {
+			scopes := make([]pollingScope, 0, len(roots))
+			for _, r := range roots {
+				scopes = append(scopes, pollingScope{Root: r})
+			}
 			return coordinator.AddObligation(pollingObligation{
-				Key: "watcher-fallback", Roots: roots,
+				Key: "watcher-fallback", Scopes: scopes,
 			})
 		},
 		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
-			return coordinator.AddObligation(pollingObligation{
-				Key:   obligation.Key,
-				Roots: obligation.Roots,
-				Probe: obligation.Probe,
-			})
+			return coordinator.AddObligation(syncObligationToPoller(obligation))
 		},
 	}
 
@@ -1675,7 +1694,7 @@ func TestWatcherUnavailableFallbackDefersBrokenSymlinkScope(t *testing.T) {
 		options,
 		nil,
 		[]string{parent, other},
-		map[string][]string{symRoot: {parent}},
+		map[string][]watchScope{symRoot: {{syncDir: parent}}},
 	))
 
 	bothDirs := []string{parent, other}
@@ -1710,24 +1729,41 @@ func TestWatcherUnavailableFallbackDefersMissingNestedRootScope(t *testing.T) {
 	nestedRoot := filepath.Join(parent, "tmp")
 	other := requireExistingPollRoot(t, t.TempDir(), "other")
 
-	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 4)}
+	// passDone fires once per complete poll pass regardless of how many
+	// per-agent ReconcileProviderRoots calls the pass makes. Waiting on
+	// syncer.wake races when two agent groups fire: the empty-agent group
+	// runs first, syncer.wake fires, and the test resumes before Gemini
+	// records parent — intermittently failing the assertion.
+	passDone := make(chan struct{}, 4)
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) {
+			run()
+			select {
+			case passDone <- struct{}{}:
+			default:
+			}
+		}, nil, time.Now,
+		func(d time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
 		OnCoverageDegraded: func(roots []string) error {
+			scopes := make([]pollingScope, 0, len(roots))
+			for _, r := range roots {
+				scopes = append(scopes, pollingScope{Root: r})
+			}
 			return coordinator.AddObligation(pollingObligation{
-				Key: "watcher-fallback", Roots: roots,
+				Key: "watcher-fallback", Scopes: scopes,
 			})
 		},
 		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
-			return coordinator.AddObligation(pollingObligation{
-				Key:   obligation.Key,
-				Roots: obligation.Roots,
-				Probe: obligation.Probe,
-			})
+			return coordinator.AddObligation(syncObligationToPoller(obligation))
 		},
 	}
 	roots := []watchRoot{{
@@ -1742,17 +1778,27 @@ func TestWatcherUnavailableFallbackDefersMissingNestedRootScope(t *testing.T) {
 	))
 
 	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
+	requirePollWithin(t, passDone, time.Second)
 	assert.Equal(t, [][]string{{other}}, syncer.snapshot(),
 		"a missing nested watch root must defer the configured dir from the fallback poll")
 
 	require.NoError(t, os.MkdirAll(nestedRoot, 0o755))
-	bothDirs := []string{parent, other}
-	slices.Sort(bothDirs)
+	snap1 := syncer.snapshot()
 	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{{other}, bothDirs}, syncer.snapshot(),
+	requirePollWithin(t, passDone, time.Second)
+	// Per-agent polling: parent (gemini) and other ("") arrive as separate calls.
+	// Collect everything new since poll 1.
+	snap2 := syncer.snapshot()
+	polled2 := make(map[string]bool)
+	for _, call := range snap2[len(snap1):] {
+		for _, d := range call {
+			polled2[d] = true
+		}
+	}
+	assert.True(t, polled2[parent],
 		"the deferred dir must rejoin the poll once the nested root is restored")
+	assert.True(t, polled2[other],
+		"other must continue to be polled")
 }
 
 // TestWatcherUnavailableFallbackDefersNestedRootLostAfterRegistration guards
@@ -1770,23 +1816,39 @@ func TestWatcherUnavailableFallbackDefersNestedRootLostAfterRegistration(t *test
 	other := requireExistingPollRoot(t, t.TempDir(), "other")
 
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+	// passDone fires once per poll pass (after run() returns), regardless of how
+	// many per-agent ReconcileProviderRoots calls the pass makes. This avoids a
+	// timing hazard where syncer.wake (fired per-call) leaves a leftover signal
+	// that causes requirePollWithin to return early for the next pass.
+	passDone := make(chan struct{}, 3)
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) {
+			run()
+			select {
+			case passDone <- struct{}{}:
+			default:
+			}
+		}, nil, time.Now,
+		func(d time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
 		OnCoverageDegraded: func(roots []string) error {
+			scopes := make([]pollingScope, 0, len(roots))
+			for _, r := range roots {
+				scopes = append(scopes, pollingScope{Root: r})
+			}
 			return coordinator.AddObligation(pollingObligation{
-				Key: "watcher-fallback", Roots: roots,
+				Key: "watcher-fallback", Scopes: scopes,
 			})
 		},
 		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
-			return coordinator.AddObligation(pollingObligation{
-				Key:   obligation.Key,
-				Roots: obligation.Roots,
-				Probe: obligation.Probe,
-			})
+			return coordinator.AddObligation(syncObligationToPoller(obligation))
 		},
 	}
 	roots := []watchRoot{{
@@ -1800,24 +1862,98 @@ func TestWatcherUnavailableFallbackDefersNestedRootLostAfterRegistration(t *test
 		options, roots, []string{parent, other}, nil,
 	))
 
-	bothDirs := []string{parent, other}
-	slices.Sort(bothDirs)
+	// Per-agent polling: parent (gemini) and other ("") arrive as separate calls.
+	// Collect unique dirs across all calls within a pass to check coverage.
+	collectPolled := func(calls [][]string) map[string]bool {
+		m := make(map[string]bool)
+		for _, c := range calls {
+			for _, d := range c {
+				m[d] = true
+			}
+		}
+		return m
+	}
+
 	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{bothDirs}, syncer.snapshot(),
+	requirePollWithin(t, passDone, time.Second)
+	snap1 := syncer.snapshot()
+	polled1 := collectPolled(snap1)
+	assert.True(t, polled1[parent] && polled1[other],
 		"a present nested watch root keeps the configured dir pollable")
 
 	require.NoError(t, os.RemoveAll(nestedRoot))
 	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{bothDirs, {other}}, syncer.snapshot(),
-		"a nested root lost after registration must defer the configured dir")
+	requirePollWithin(t, passDone, time.Second)
+	snap2 := syncer.snapshot()
+	delta2 := snap2[len(snap1):]
+	polled2 := collectPolled(delta2)
+	for _, call := range delta2 {
+		assert.NotContains(t, call, parent,
+			"a nested root lost after registration must defer the configured dir")
+	}
+	// De-vacuumize: if a regression causes zero second-pass calls the loop above
+	// passes vacuously. Assert other is present to catch over-suppression.
+	assert.True(t, polled2[other],
+		"the unaffected other dir must still be polled when the nested root is missing")
 
 	require.NoError(t, os.MkdirAll(nestedRoot, 0o755))
 	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{bothDirs, {other}, bothDirs}, syncer.snapshot(),
+	requirePollWithin(t, passDone, time.Second)
+	snap3 := syncer.snapshot()
+	polled3 := collectPolled(snap3[len(snap2):])
+	assert.True(t, polled3[parent] && polled3[other],
 		"the deferred dir must rejoin the poll once the nested root is restored")
+}
+
+// TestRegisterWatcherUnavailableCoversDegradedWithoutPollingRequired
+// when OnCoverageDegraded is set but OnPollingRequired is nil (as archive-watch
+// callers do), registerWatcherUnavailableObligations must still call
+// OnCoverageDegraded with all unwatched dirs.
+//
+// Pre-fix, the probeGated exclusion is applied unconditionally. Because
+// every obligation returned by watchPollingObligations has a probe (the
+// physical watch root path), probeGated ends up containing every scope root,
+// and fallbackDirs is always empty → OnCoverageDegraded is silently never
+// called and archive coverage is silently dropped.
+//
+// The fix: skip the probeGated exclusion when OnPollingRequired is nil, because
+// without a named obligation owner the probe-gated obligations are NOT
+// installed; the coverage-degraded fallback must cover all dirs.
+func TestRegisterWatcherUnavailableCoversDegradedWithoutPollingRequired(t *testing.T) {
+	parent := t.TempDir()
+	// nestedRoot does not exist; it becomes the probe for parent's obligation.
+	nestedRoot := filepath.Join(parent, "tmp")
+	other := requireExistingPollRoot(t, t.TempDir(), "other")
+
+	var degradedRoots []string
+	options := agentsync.WatcherOptions{
+		// OnPollingRequired is intentionally nil — archive-watch callers omit it.
+		OnCoverageDegraded: func(roots []string) error {
+			degradedRoots = append(degradedRoots, roots...)
+			return nil
+		},
+	}
+	roots := []watchRoot{{
+		path:               nestedRoot,
+		recursive:          true,
+		scopes:             []watchScope{{agent: parser.AgentGemini, syncDir: parent}},
+		pendingPollingDirs: []string{parent},
+	}}
+
+	require.NoError(t, registerWatcherUnavailableObligations(
+		options, roots, []string{parent, other}, nil,
+	))
+
+	// Pre-fix, probeGated excludes parent (its scope has a probe=nestedRoot
+	// obligation) and other (its scope has a probe=other persistent obligation),
+	// so fallbackDirs is empty and OnCoverageDegraded is never called.
+	// Post-fix, the probeGated exclusion is skipped when OnPollingRequired
+	// is nil, and OnCoverageDegraded receives all dirs.
+	assert.Contains(t, degradedRoots, parent,
+		"OnCoverageDegraded must cover parent even though it has a probe obligation, "+
+			"when OnPollingRequired is nil")
+	assert.Contains(t, degradedRoots, other,
+		"OnCoverageDegraded must also cover other")
 }
 
 // TestWatcherUnavailableObligationsGateBeforeFallback snapshots the pollable
@@ -1840,22 +1976,22 @@ func TestWatcherUnavailableObligationsGateBeforeFallback(t *testing.T) {
 		make(chan time.Time), func() {}, func(run func()) { run() },
 		func([]string) {
 			stepAvailable = append(stepAvailable,
-				availableUnwatchedPollRoots(coordinator.currentPollObligations()))
-		},
+				availableUnwatchedPollRootsFlat(coordinator.currentPollObligations()))
+		}, time.Now, time.After,
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
 		OnCoverageDegraded: func(roots []string) error {
+			scopes := make([]pollingScope, 0, len(roots))
+			for _, r := range roots {
+				scopes = append(scopes, pollingScope{Root: r})
+			}
 			return coordinator.AddObligation(pollingObligation{
-				Key: "watcher-fallback", Roots: roots,
+				Key: "watcher-fallback", Scopes: scopes,
 			})
 		},
 		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
-			return coordinator.AddObligation(pollingObligation{
-				Key:   obligation.Key,
-				Roots: obligation.Roots,
-				Probe: obligation.Probe,
-			})
+			return coordinator.AddObligation(syncObligationToPoller(obligation))
 		},
 	}
 	roots := []watchRoot{{

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -561,7 +561,7 @@ func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	assert.ElementsMatch(t, []string{sessionsDir, archivedDir}, unwatchedDirs,
 		"missing roots retain polling until native activation completes")
@@ -610,7 +610,7 @@ func TestCollectWatchRootsPollsRecursiveSymlinkProviderRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Len(t, roots, 2)
 	assert.Equal(t, root, roots[0].path)
@@ -1086,7 +1086,7 @@ func TestCollectWatchRootsHermesSessionsWatchesStateDBParent(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs, "unwatched dirs before watcher setup")
 	require.Len(t, roots, 2)
@@ -1109,7 +1109,7 @@ func TestCollectWatchRootsWatchesHermesProfilesContainerRecursively(t *testing.T
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs)
 	require.Len(t, roots, 1)
@@ -1127,7 +1127,7 @@ func TestCollectWatchRootsUsesCoworkProviderRecursiveRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs, "cowork root should be watched directly")
 	got, ok := findCollectedWatchRoot(roots, root)
@@ -1148,7 +1148,7 @@ func TestCollectWatchRootsUsesGeminiProviderMetadataRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs, "all gemini provider roots exist")
 	metadataRoot, ok := findCollectedWatchRoot(roots, root)
@@ -1172,7 +1172,7 @@ func TestCollectWatchRootsUsesAntigravityCLIHistoryRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs, "all antigravity cli provider roots exist")
 	historyRoot, ok := findCollectedWatchRoot(roots, root)
@@ -1199,7 +1199,7 @@ func TestCollectWatchRootsIncludesDevinProviderRootsForNonFileAgent(t *testing.T
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs)
 	cliRoot, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cli"))
@@ -1221,7 +1221,7 @@ func TestCollectWatchRootsTracksExactAgentsForSharedRoot(t *testing.T) {
 		parser.AgentCodex:  {root},
 	}}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs)
 	shared, ok := findCollectedWatchRoot(roots, root)
@@ -1247,7 +1247,7 @@ func TestCollectWatchRootsPreservesMissingProviderRoots(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _, _ := collectWatchRoots(cfg)
 
 	require.Len(t, roots, 2)
 	cliRoot, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cli"))
@@ -1538,7 +1538,7 @@ func TestOpenCodeFormatMissingRootsUseNativeLifecycleWithoutPolling(t *testing.T
 				parser.AgentMiMoCode: dirs,
 			}}
 
-			roots, unwatched, _ := collectWatchRoots(cfg)
+			roots, unwatched, _, persistentDirAgents := collectWatchRoots(cfg)
 			require.Len(t, roots, rootCount)
 			results := make([]agentsync.RecursiveWatchResult, rootCount)
 			for i := range results {
@@ -1549,7 +1549,7 @@ func TestOpenCodeFormatMissingRootsUseNativeLifecycleWithoutPolling(t *testing.T
 			}
 			unwatched = accountRegisteredWatchRoots(unwatched, roots, results)
 
-			assert.Empty(t, watchPollingObligations(roots, results, unwatched, nil),
+			assert.Empty(t, watchPollingObligations(roots, results, unwatched, persistentDirAgents),
 				"absent OpenCode-format providers must not add archive-scale polling")
 		})
 	}
@@ -1575,7 +1575,7 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 		roots,
 		[]agentsync.RecursiveWatchResult{{Watched: 1}, {Watched: 1}},
 		[]string{shared},
-		nil,
+		map[string][]parser.AgentType{shared: {parser.AgentDevin}},
 	)
 
 	assert.Equal(t, []agentsync.PollingObligation{
@@ -1695,6 +1695,7 @@ func TestWatcherUnavailableFallbackDefersBrokenSymlinkScope(t *testing.T) {
 		nil,
 		[]string{parent, other},
 		map[string][]watchScope{symRoot: {{syncDir: parent}}},
+		nil,
 	))
 
 	bothDirs := []string{parent, other}
@@ -1774,7 +1775,7 @@ func TestWatcherUnavailableFallbackDefersMissingNestedRootScope(t *testing.T) {
 	}}
 
 	require.NoError(t, registerWatcherUnavailableObligations(
-		options, roots, []string{parent, other}, nil,
+		options, roots, []string{parent, other}, nil, nil,
 	))
 
 	coordinator.requestPoll()
@@ -1859,7 +1860,7 @@ func TestWatcherUnavailableFallbackDefersNestedRootLostAfterRegistration(t *test
 	}}
 
 	require.NoError(t, registerWatcherUnavailableObligations(
-		options, roots, []string{parent, other}, nil,
+		options, roots, []string{parent, other}, nil, nil,
 	))
 
 	// Per-agent polling: parent (gemini) and other ("") arrive as separate calls.
@@ -1941,7 +1942,7 @@ func TestRegisterWatcherUnavailableCoversDegradedWithoutPollingRequired(t *testi
 	}}
 
 	require.NoError(t, registerWatcherUnavailableObligations(
-		options, roots, []string{parent, other}, nil,
+		options, roots, []string{parent, other}, nil, nil,
 	))
 
 	// Pre-fix, probeGated excludes parent (its scope has a probe=nestedRoot
@@ -2002,7 +2003,7 @@ func TestWatcherUnavailableObligationsGateBeforeFallback(t *testing.T) {
 	}}
 
 	require.NoError(t, registerWatcherUnavailableObligations(
-		options, roots, []string{parent, other}, nil,
+		options, roots, []string{parent, other}, nil, nil,
 	))
 
 	require.NotEmpty(t, stepAvailable)

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -536,6 +536,12 @@ func (f *fakeUnwatchedPollSyncer) ReconcileProviderRoots(
 	return nil
 }
 
+func (f *fakeUnwatchedPollSyncer) ReconcileProviderRootsGrouped(
+	ctx context.Context, groups []agentsync.ProviderRootsGroup,
+) error {
+	return reconcileGroupsSequentially(ctx, groups, f.ReconcileProviderRoots)
+}
+
 func TestPollUnwatchedScopesOnceUsesScopedAuthoritativeReconciliation(t *testing.T) {
 	fake := &fakeUnwatchedPollSyncer{}
 	roots := []string{"/tmp/claude", "/tmp/codex"}

--- a/cmd/agentsview/poll_coordinator_scope_test.go
+++ b/cmd/agentsview/poll_coordinator_scope_test.go
@@ -1,9 +1,6 @@
 package main
 
 // Tests for scoping degraded-coverage polling to one provider per pass.
-// These tests reference ReconcileProviderRoots and pollingScope which are added by
-// this PR. They will not compile against the base code; that compilation error is
-// the captured red state.
 
 import (
 	"context"
@@ -131,10 +128,8 @@ func TestUnwatchedPollDoesNotDragUnrelatedProvidersThroughOneProvidersGap(t *tes
 		rootB := requireExistingPollRoot(t, parent, "root-b")
 
 		syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
-		var logged []string
 		var logMu sync.Mutex
 		origOutput := log.Writer()
-		_ = origOutput
 		var logBuf strings.Builder
 		log.SetOutput(&lockedWriter{mu: &logMu, w: &logBuf})
 		t.Cleanup(func() { log.SetOutput(origOutput) })
@@ -164,7 +159,6 @@ func TestUnwatchedPollDoesNotDragUnrelatedProvidersThroughOneProvidersGap(t *tes
 		logMu.Lock()
 		output := logBuf.String()
 		logMu.Unlock()
-		_ = logged
 		assert.Contains(t, output, "polling 2 unwatched root(s)",
 			"log must report total root count, not per-group count")
 	})
@@ -395,8 +389,8 @@ func TestUnwatchedPollDefersOnlyTheProviderWhoseProbeIsMissing(t *testing.T) {
 		"provider A must never be called while its probe is missing")
 }
 
-// TestUnwatchedPollStopDuringCooldown is added as a subtest of shutdown.
-// Stop() must return immediately during the cooldown wait.
+// TestUnwatchedPollStopDuringCooldown asserts that Stop() returns immediately
+// during the cooldown wait rather than waiting out the cooldown.
 func TestUnwatchedPollStopDuringCooldown(t *testing.T) {
 	ticks := make(chan time.Time, 1)
 	passRelease := make(chan struct{})

--- a/cmd/agentsview/poll_coordinator_scope_test.go
+++ b/cmd/agentsview/poll_coordinator_scope_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/parser"
+	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
 // recordingProviderPollSyncer records ReconcileProviderRoots calls.
@@ -51,6 +53,12 @@ func (s *recordingProviderPollSyncer) ReconcileProviderRoots(
 	return err
 }
 
+func (s *recordingProviderPollSyncer) ReconcileProviderRootsGrouped(
+	ctx context.Context, groups []agentsync.ProviderRootsGroup,
+) error {
+	return reconcileGroupsSequentially(ctx, groups, s.ReconcileProviderRoots)
+}
+
 func (s *recordingProviderPollSyncer) snapshot() []providerPollCall {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -62,6 +70,79 @@ func (s *recordingProviderPollSyncer) snapshot() []providerPollCall {
 		}
 	}
 	return out
+}
+
+// groupedCountingPollSyncer records each grouped reconcile call verbatim.
+type groupedCountingPollSyncer struct {
+	mu    sync.Mutex
+	calls [][]agentsync.ProviderRootsGroup
+	wake  chan struct{}
+}
+
+func (s *groupedCountingPollSyncer) ReconcileProviderRootsGrouped(
+	_ context.Context, groups []agentsync.ProviderRootsGroup,
+) error {
+	copied := make([]agentsync.ProviderRootsGroup, len(groups))
+	for i, group := range groups {
+		copied[i] = agentsync.ProviderRootsGroup{
+			Agent: group.Agent,
+			Roots: append([]string(nil), group.Roots...),
+		}
+	}
+	s.mu.Lock()
+	s.calls = append(s.calls, copied)
+	s.mu.Unlock()
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (s *groupedCountingPollSyncer) snapshot() [][]agentsync.ProviderRootsGroup {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][]agentsync.ProviderRootsGroup(nil), s.calls...)
+}
+
+// TestUnwatchedPollIssuesOneGroupedReconcilePerPass is the cardinality
+// regression for the shared epilogue: a poll pass must hand every provider
+// group to the engine in a single grouped call, so the engine's archive-sized
+// per-pass work (skip-cache persistence, global subagent linking) stays
+// constant as the number of providers holding obligations grows.
+func TestUnwatchedPollIssuesOneGroupedReconcilePerPass(t *testing.T) {
+	for _, providerCount := range []int{2, 8} {
+		t.Run(fmt.Sprintf("providers=%d", providerCount), func(t *testing.T) {
+			parent := t.TempDir()
+			syncer := &groupedCountingPollSyncer{wake: make(chan struct{}, 1)}
+			coordinator := newUnwatchedPollCoordinatorWithTicks(
+				t.Context(), syncer, make(chan time.Time), func() {},
+				func(run func()) { run() }, nil,
+				time.Now, time.After,
+			)
+			t.Cleanup(coordinator.Stop)
+
+			for i := range providerCount {
+				root := requireExistingPollRoot(t, parent, fmt.Sprintf("root-%d", i))
+				agent := parser.AgentType(fmt.Sprintf("agent-%d", i))
+				require.NoError(t, coordinator.AddObligation(pollingObligation{
+					Key:    fmt.Sprintf("degraded:%s:%s", agent, root),
+					Scopes: []pollingScope{{Agent: agent, Root: root}},
+					Probe:  root,
+				}))
+			}
+
+			coordinator.requestPoll()
+			requirePollWithin(t, syncer.wake, time.Second)
+
+			calls := syncer.snapshot()
+			require.Len(t, calls, 1,
+				"a pass must issue exactly one grouped reconcile call, "+
+					"independent of provider count")
+			assert.Len(t, calls[0], providerCount,
+				"the single grouped call must cover every provider's group")
+		})
+	}
 }
 
 // TestUnwatchedPollDoesNotDragUnrelatedProvidersThroughOneProvidersGap is the
@@ -279,6 +360,12 @@ func (s *manualProviderPollSyncer) ReconcileProviderRoots(
 	ctx context.Context, agent parser.AgentType, roots []string,
 ) error {
 	return s.fn(ctx, agent, roots)
+}
+
+func (s *manualProviderPollSyncer) ReconcileProviderRootsGrouped(
+	ctx context.Context, groups []agentsync.ProviderRootsGroup,
+) error {
+	return reconcileGroupsSequentially(ctx, groups, s.ReconcileProviderRoots)
 }
 
 // TestUnwatchedPollAttemptsEveryProviderAfterOneFails asserts that when the

--- a/cmd/agentsview/poll_coordinator_scope_test.go
+++ b/cmd/agentsview/poll_coordinator_scope_test.go
@@ -1,0 +1,519 @@
+package main
+
+// Tests for scoping degraded-coverage polling to one provider per pass.
+// These tests reference ReconcileProviderRoots and pollingScope which are added by
+// this PR. They will not compile against the base code; that compilation error is
+// the captured red state.
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// recordingProviderPollSyncer records ReconcileProviderRoots calls.
+type recordingProviderPollSyncer struct {
+	mu    sync.Mutex
+	calls []providerPollCall
+	wake  chan struct{}
+	errs  map[parser.AgentType]error
+}
+
+type providerPollCall struct {
+	Agent parser.AgentType
+	Roots []string
+}
+
+func (s *recordingProviderPollSyncer) ReconcileProviderRoots(
+	_ context.Context, agent parser.AgentType, roots []string,
+) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, providerPollCall{
+		Agent: agent,
+		Roots: append([]string(nil), roots...),
+	})
+	var err error
+	if s.errs != nil {
+		err = s.errs[agent]
+	}
+	s.mu.Unlock()
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+	return err
+}
+
+func (s *recordingProviderPollSyncer) snapshot() []providerPollCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]providerPollCall, len(s.calls))
+	for i, c := range s.calls {
+		out[i] = providerPollCall{
+			Agent: c.Agent,
+			Roots: append([]string(nil), c.Roots...),
+		}
+	}
+	return out
+}
+
+func (s *recordingProviderPollSyncer) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+// blockingProviderPollSyncer blocks until released, per-agent.
+type blockingProviderPollSyncer struct {
+	mu      sync.Mutex
+	started chan providerPollCall
+	release chan struct{}
+	calls   []providerPollCall
+	errs    map[parser.AgentType]error
+}
+
+func (s *blockingProviderPollSyncer) ReconcileProviderRoots(
+	_ context.Context, agent parser.AgentType, roots []string,
+) error {
+	call := providerPollCall{Agent: agent, Roots: append([]string(nil), roots...)}
+	s.mu.Lock()
+	s.calls = append(s.calls, call)
+	var err error
+	if s.errs != nil {
+		err = s.errs[agent]
+	}
+	s.mu.Unlock()
+	s.started <- call
+	if err != nil {
+		return err
+	}
+	<-s.release
+	return nil
+}
+
+func (s *blockingProviderPollSyncer) snapshot() []providerPollCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]providerPollCall, len(s.calls))
+	for i, c := range s.calls {
+		out[i] = providerPollCall{Agent: c.Agent, Roots: append([]string(nil), c.Roots...)}
+	}
+	return out
+}
+
+// TestUnwatchedPollDoesNotDragUnrelatedProvidersThroughOneProvidersGap is the
+// reproduction test: one provider's degraded coverage must not cause an
+// authoritative pass for any other provider.
+func TestUnwatchedPollDoesNotDragUnrelatedProvidersThroughOneProvidersGap(t *testing.T) {
+	t.Run("main", func(t *testing.T) {
+		parent := t.TempDir()
+		rootA := requireExistingPollRoot(t, parent, "root-a")
+		rootB := requireExistingPollRoot(t, parent, "root-b")
+
+		syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			t.Context(), syncer, make(chan time.Time), func() {},
+			func(run func()) { run() }, nil,
+			time.Now, time.After,
+		)
+		t.Cleanup(coordinator.Stop)
+
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key: "degraded:agentA:" + rootA,
+			Scopes: []pollingScope{
+				{Agent: parser.AgentClaude, Root: rootA},
+			},
+			Probe: rootA,
+		}))
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key: "degraded:agentB:" + rootB,
+			Scopes: []pollingScope{
+				{Agent: parser.AgentOpenHands, Root: rootB},
+			},
+			Probe: rootB,
+		}))
+
+		coordinator.requestPoll()
+		requirePollWithin(t, syncer.wake, time.Second)
+		requirePollWithin(t, syncer.wake, time.Second)
+
+		calls := syncer.snapshot()
+		require.Len(t, calls, 2,
+			"each provider must get exactly one ReconcileProviderRoots call")
+		var agentACalls, agentBCalls []providerPollCall
+		for _, c := range calls {
+			if c.Agent == parser.AgentClaude {
+				agentACalls = append(agentACalls, c)
+			} else if c.Agent == parser.AgentOpenHands {
+				agentBCalls = append(agentBCalls, c)
+			}
+		}
+		require.Len(t, agentACalls, 1, "provider A must have exactly one call")
+		assert.Equal(t, []string{rootA}, agentACalls[0].Roots,
+			"provider A's call must contain only A's root")
+		require.Len(t, agentBCalls, 1, "provider B must have exactly one call")
+		assert.Equal(t, []string{rootB}, agentBCalls[0].Roots,
+			"provider B must not see provider A's root")
+	})
+
+	// log_reports_total_roots: the log line must report the TOTAL root count
+	// across all groups, not a per-group count.
+	t.Run("log_reports_total_roots", func(t *testing.T) {
+		parent := t.TempDir()
+		rootA := requireExistingPollRoot(t, parent, "root-a")
+		rootB := requireExistingPollRoot(t, parent, "root-b")
+
+		syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
+		var logged []string
+		var logMu sync.Mutex
+		origOutput := log.Writer()
+		_ = origOutput
+		var logBuf strings.Builder
+		log.SetOutput(&lockedWriter{mu: &logMu, w: &logBuf})
+		t.Cleanup(func() { log.SetOutput(origOutput) })
+
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			t.Context(), syncer, make(chan time.Time), func() {},
+			func(run func()) { run() }, nil,
+			time.Now, time.After,
+		)
+		t.Cleanup(coordinator.Stop)
+
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key:    "degraded:agentA:" + rootA,
+			Scopes: []pollingScope{{Agent: parser.AgentClaude, Root: rootA}},
+			Probe:  rootA,
+		}))
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key:    "degraded:agentB:" + rootB,
+			Scopes: []pollingScope{{Agent: parser.AgentOpenHands, Root: rootB}},
+			Probe:  rootB,
+		}))
+
+		coordinator.requestPoll()
+		requirePollWithin(t, syncer.wake, time.Second)
+		requirePollWithin(t, syncer.wake, time.Second)
+
+		logMu.Lock()
+		output := logBuf.String()
+		logMu.Unlock()
+		_ = logged
+		assert.Contains(t, output, "polling 2 unwatched root(s)",
+			"log must report total root count, not per-group count")
+	})
+}
+
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  *strings.Builder
+}
+
+func (lw *lockedWriter) Write(p []byte) (n int, err error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	return lw.w.Write(p)
+}
+
+// TestUnwatchedPollWaitsAfterAPassLongerThanTheInterval asserts that if the
+// previous pass took longer than the interval, the worker waits until
+// lastCompletion + interval before starting the next pass.
+func TestUnwatchedPollWaitsAfterAPassLongerThanTheInterval(t *testing.T) {
+	ticks := make(chan time.Time, 2)
+	passRelease := make(chan struct{})
+	passStarted := make(chan struct{}, 1)
+	t0 := time.Unix(1000, 0)
+	now := t0
+
+	var nowMu sync.Mutex
+	getNow := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+
+	afterCh := make(chan (<-chan time.Time), 4)
+	var afterArgs []time.Duration
+	var afterMu sync.Mutex
+	getAfter := func(d time.Duration) <-chan time.Time {
+		afterMu.Lock()
+		afterArgs = append(afterArgs, d)
+		afterMu.Unlock()
+		ch := make(chan time.Time, 1)
+		afterCh <- ch
+		return ch
+	}
+
+	firstCall := make(chan struct{}, 1)
+	callCount := 0
+	var callMu sync.Mutex
+	syncer := &manualProviderPollSyncer{
+		fn: func(_ context.Context, _ parser.AgentType, _ []string) error {
+			callMu.Lock()
+			callCount++
+			n := callCount
+			callMu.Unlock()
+			if n == 1 {
+				select {
+				case firstCall <- struct{}{}:
+				default:
+				}
+				<-passRelease
+			}
+			select {
+			case passStarted <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	}
+
+	root := requireExistingPollRoot(t, t.TempDir(), "root")
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {},
+		func(run func()) { run() }, nil,
+		getNow, getAfter,
+	)
+	t.Cleanup(coordinator.Stop)
+
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "test-root",
+		Scopes: []pollingScope{{Root: root}},
+	}))
+
+	// First tick starts the pass.
+	ticks <- t0
+	requirePollWithin(t, firstCall, time.Second)
+
+	// Second tick arrives while the pass is running; gets buffered.
+	ticks <- t0.Add(unwatchedPollInterval)
+
+	// Advance "now" to simulate the pass taking longer than the interval.
+	nowMu.Lock()
+	now = t0.Add(unwatchedPollInterval + 500*time.Millisecond)
+	nowMu.Unlock()
+
+	// Release the first pass.
+	close(passRelease)
+
+	// The worker should call after() with a positive remaining duration.
+	select {
+	case <-afterCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected after() to be called for cooldown wait")
+	}
+
+	afterMu.Lock()
+	args := append([]time.Duration(nil), afterArgs...)
+	afterMu.Unlock()
+	require.Len(t, args, 1)
+	assert.Greater(t, args[0], time.Duration(0),
+		"the cooldown must wait a positive duration when the pass ran over the interval")
+}
+
+type manualProviderPollSyncer struct {
+	fn func(context.Context, parser.AgentType, []string) error
+}
+
+func (s *manualProviderPollSyncer) ReconcileProviderRoots(
+	ctx context.Context, agent parser.AgentType, roots []string,
+) error {
+	return s.fn(ctx, agent, roots)
+}
+
+// TestUnwatchedPollAttemptsEveryProviderAfterOneFails asserts that when the
+// first provider group errors, subsequent groups are still attempted once.
+func TestUnwatchedPollAttemptsEveryProviderAfterOneFails(t *testing.T) {
+	parent := t.TempDir()
+	rootA := requireExistingPollRoot(t, parent, "root-a")
+	rootB := requireExistingPollRoot(t, parent, "root-b")
+	rootC := requireExistingPollRoot(t, parent, "root-c")
+
+	wantErr := errors.New("agent-a failed")
+	syncer := &recordingProviderPollSyncer{
+		wake: make(chan struct{}, 8),
+		errs: map[parser.AgentType]error{
+			parser.AgentClaude: wantErr,
+		},
+	}
+
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+		time.Now, time.After,
+	)
+	t.Cleanup(coordinator.Stop)
+
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "agent-a-root",
+		Scopes: []pollingScope{{Agent: parser.AgentClaude, Root: rootA}},
+	}))
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "agent-b-root",
+		Scopes: []pollingScope{{Agent: parser.AgentOpenHands, Root: rootB}},
+	}))
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "agent-c-root",
+		Scopes: []pollingScope{{Agent: parser.AgentDevin, Root: rootC}},
+	}))
+
+	coordinator.requestPoll()
+	// Wait for all three groups to be attempted.
+	requirePollWithin(t, syncer.wake, time.Second)
+	requirePollWithin(t, syncer.wake, time.Second)
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	calls := syncer.snapshot()
+	assert.Len(t, calls, 3,
+		"all three providers must be attempted even when agent-a fails")
+
+	agents := make(map[parser.AgentType]bool)
+	for _, c := range calls {
+		agents[c.Agent] = true
+	}
+	assert.True(t, agents[parser.AgentClaude], "agent-a must be attempted")
+	assert.True(t, agents[parser.AgentOpenHands], "agent-b must be attempted even after agent-a's error")
+	assert.True(t, agents[parser.AgentDevin], "agent-c must be attempted even after agent-a's error")
+}
+
+// TestUnwatchedPollDefersOnlyTheProviderWhoseProbeIsMissing asserts that a
+// missing probe defers only its own provider; the healthy provider still polls.
+func TestUnwatchedPollDefersOnlyTheProviderWhoseProbeIsMissing(t *testing.T) {
+	parent := t.TempDir()
+	sharedRoot := requireExistingPollRoot(t, parent, "shared")
+	probeA := filepath.Join(sharedRoot, "probe-a")
+	require.NoError(t, os.Mkdir(probeA, 0o755))
+	// probeB is intentionally absent — A's probe is missing.
+
+	syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+		time.Now, time.After,
+	)
+	t.Cleanup(coordinator.Stop)
+
+	// Provider A: probe is missing → must be deferred.
+	missingProbeA := filepath.Join(sharedRoot, "missing-probe-a")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "agent-a-root",
+		Scopes: []pollingScope{{Agent: parser.AgentClaude, Root: sharedRoot}},
+		Probe:  missingProbeA,
+	}))
+	// Provider B: probe is present → must be polled.
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "agent-b-root",
+		Scopes: []pollingScope{{Agent: parser.AgentOpenHands, Root: sharedRoot}},
+		Probe:  probeA, // present
+	}))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	calls := syncer.snapshot()
+	require.Len(t, calls, 1,
+		"only the healthy provider must be called; the one with missing probe must be deferred")
+	assert.Equal(t, parser.AgentOpenHands, calls[0].Agent,
+		"the call must be for the healthy provider")
+	assert.Equal(t, []string{sharedRoot}, calls[0].Roots)
+
+	// Assert A was never called.
+	assert.Never(t, func() bool {
+		for _, c := range syncer.snapshot() {
+			if c.Agent == parser.AgentClaude {
+				return true
+			}
+		}
+		return false
+	}, 100*time.Millisecond, 10*time.Millisecond,
+		"provider A must never be called while its probe is missing")
+}
+
+// TestUnwatchedPollStopDuringCooldown is added as a subtest of shutdown.
+// Stop() must return immediately during the cooldown wait.
+func TestUnwatchedPollStopDuringCooldown(t *testing.T) {
+	ticks := make(chan time.Time, 1)
+	passRelease := make(chan struct{})
+	passStarted := make(chan struct{}, 1)
+
+	t0 := time.Unix(2000, 0)
+	getNow := func() time.Time { return t0.Add(10 * time.Millisecond) }
+
+	// after() blocks until Stop cancels the context.
+	afterBlocking := make(chan (<-chan time.Time), 1)
+	getAfter := func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time) // never fires
+		afterBlocking <- ch
+		return ch
+	}
+
+	syncer := &manualProviderPollSyncer{
+		fn: func(_ context.Context, _ parser.AgentType, _ []string) error {
+			select {
+			case passStarted <- struct{}{}:
+			default:
+			}
+			<-passRelease
+			return nil
+		},
+	}
+
+	root := requireExistingPollRoot(t, t.TempDir(), "root")
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {},
+		func(run func()) { run() }, nil,
+		getNow, getAfter,
+	)
+	t.Cleanup(func() {
+		select {
+		case <-passRelease:
+		default:
+			close(passRelease)
+		}
+		coordinator.Stop()
+	})
+
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "root",
+		Scopes: []pollingScope{{Root: root}},
+	}))
+
+	// First tick: start a pass.
+	ticks <- t0
+	requirePollWithin(t, passStarted, time.Second)
+
+	// Second tick: buffer a wake. This will trigger the cooldown when the
+	// first pass finishes.
+	ticks <- t0.Add(time.Millisecond)
+
+	// Release the first pass. The worker now enters the cooldown wait (after()).
+	close(passRelease)
+
+	// Wait for after() to be called.
+	select {
+	case <-afterBlocking:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cooldown after() was not called")
+	}
+
+	// Stop must return without waiting out the cooldown.
+	stopDone := make(chan struct{})
+	go func() {
+		coordinator.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return while in cooldown wait")
+	}
+}

--- a/cmd/agentsview/poll_coordinator_scope_test.go
+++ b/cmd/agentsview/poll_coordinator_scope_test.go
@@ -67,50 +67,6 @@ func (s *recordingProviderPollSyncer) snapshot() []providerPollCall {
 	return out
 }
 
-func (s *recordingProviderPollSyncer) callCount() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return len(s.calls)
-}
-
-// blockingProviderPollSyncer blocks until released, per-agent.
-type blockingProviderPollSyncer struct {
-	mu      sync.Mutex
-	started chan providerPollCall
-	release chan struct{}
-	calls   []providerPollCall
-	errs    map[parser.AgentType]error
-}
-
-func (s *blockingProviderPollSyncer) ReconcileProviderRoots(
-	_ context.Context, agent parser.AgentType, roots []string,
-) error {
-	call := providerPollCall{Agent: agent, Roots: append([]string(nil), roots...)}
-	s.mu.Lock()
-	s.calls = append(s.calls, call)
-	var err error
-	if s.errs != nil {
-		err = s.errs[agent]
-	}
-	s.mu.Unlock()
-	s.started <- call
-	if err != nil {
-		return err
-	}
-	<-s.release
-	return nil
-}
-
-func (s *blockingProviderPollSyncer) snapshot() []providerPollCall {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	out := make([]providerPollCall, len(s.calls))
-	for i, c := range s.calls {
-		out[i] = providerPollCall{Agent: c.Agent, Roots: append([]string(nil), c.Roots...)}
-	}
-	return out
-}
-
 // TestUnwatchedPollDoesNotDragUnrelatedProvidersThroughOneProvidersGap is the
 // reproduction test: one provider's degraded coverage must not cause an
 // authoritative pass for any other provider.
@@ -152,9 +108,10 @@ func TestUnwatchedPollDoesNotDragUnrelatedProvidersThroughOneProvidersGap(t *tes
 			"each provider must get exactly one ReconcileProviderRoots call")
 		var agentACalls, agentBCalls []providerPollCall
 		for _, c := range calls {
-			if c.Agent == parser.AgentClaude {
+			switch c.Agent {
+			case parser.AgentClaude:
 				agentACalls = append(agentACalls, c)
-			} else if c.Agent == parser.AgentOpenHands {
+			case parser.AgentOpenHands:
 				agentBCalls = append(agentBCalls, c)
 			}
 		}

--- a/cmd/agentsview/polling_scope_identity_test.go
+++ b/cmd/agentsview/polling_scope_identity_test.go
@@ -1,0 +1,501 @@
+package main
+
+// Regression tests for provider identity in polling obligations.
+// Tests are written test-first; they are expected to fail against the
+// un-fixed head before the production-code changes are applied.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+	agentsync "go.kenn.io/agentsview/internal/sync"
+)
+
+// TestPollingScopesForDirsEmitsAllAgents covers the pending-dir branch: when two
+// providers share the same configured syncDir, pollingScopesForDirs must emit
+// one scope per agent, not collapse them to a single scope for whichever agent
+// happens to appear last in the map iteration.
+func TestPollingScopesForDirsEmitsAllAgents(t *testing.T) {
+	parent := t.TempDir()
+	sharedDir := filepath.Join(parent, "shared-sync")
+
+	root := watchRoot{
+		path: filepath.Join(parent, "physical-root"),
+		scopes: []watchScope{
+			{agent: parser.AgentClaude, syncDir: sharedDir},
+			{agent: parser.AgentGemini, syncDir: sharedDir},
+		},
+	}
+
+	scopes := root.pollingScopesForDirs([]string{sharedDir})
+
+	agentSet := make(map[parser.AgentType]bool)
+	for _, s := range scopes {
+		agentSet[s.Agent] = true
+	}
+	assert.True(t, agentSet[parser.AgentClaude],
+		"Claude scope must appear when two providers share a syncDir")
+	assert.True(t, agentSet[parser.AgentGemini],
+		"Gemini scope must appear when two providers share a syncDir")
+	assert.Len(t, scopes, 2,
+		"one scope per agent, not collapsed to a single scope")
+}
+
+// TestWatchPollingObligationsPersistentDirBothAgents covers the persistent-dir branch:
+// when two agents share a persistent polling dir, the obligation for that dir
+// must carry both agents' scopes, not just the last writer in syncDirToAgents.
+// Uses a non-nil results slice so the "no watcher" path is not taken; only the
+// persistent-dir loop runs.
+func TestWatchPollingObligationsPersistentDirBothAgents(t *testing.T) {
+	parent := t.TempDir()
+	sharedDir := filepath.Join(parent, "shared-sync")
+
+	roots := []watchRoot{{
+		path: filepath.Join(parent, "physical-root"),
+		scopes: []watchScope{
+			{agent: parser.AgentClaude, syncDir: sharedDir},
+			{agent: parser.AgentGemini, syncDir: sharedDir},
+		},
+		persistentPollingDirs: []string{sharedDir},
+	}}
+	// Non-nil results: root is watched and the lifecycle is owned, so the
+	// "no watcher" (i >= len(results)) branch does NOT execute.
+	results := []agentsync.RecursiveWatchResult{{Watched: 1, MissingRootLifecycleOwned: false}}
+
+	got := watchPollingObligations(roots, results, nil, nil)
+
+	agentSet := make(map[parser.AgentType]bool)
+	for _, ob := range got {
+		for _, scope := range ob.Scopes {
+			if scope.Root == filepath.Clean(sharedDir) {
+				agentSet[parser.AgentType(scope.Agent)] = true
+			}
+		}
+	}
+	assert.True(t, agentSet[parser.AgentClaude],
+		"persistent obligation for shared dir must carry Claude's scope")
+	assert.True(t, agentSet[parser.AgentGemini],
+		"persistent obligation for shared dir must carry Gemini's scope")
+}
+
+// TestWatchPollingObligationsUnwatchedFallbackBothAgents covers the unwatched-fallback branch:
+// when two agents share a dir in the unwatched-dirs fallback, both agents'
+// scopes must appear in the resulting obligation. Uses non-nil results so the
+// "no watcher" path is not taken.
+func TestWatchPollingObligationsUnwatchedFallbackBothAgents(t *testing.T) {
+	parent := t.TempDir()
+	sharedDir := filepath.Join(parent, "shared-sync")
+
+	roots := []watchRoot{{
+		path: filepath.Join(parent, "physical-root"),
+		scopes: []watchScope{
+			{agent: parser.AgentClaude, syncDir: sharedDir},
+			{agent: parser.AgentGemini, syncDir: sharedDir},
+		},
+	}}
+	// Non-nil results so the "no watcher" branch is not taken.
+	results := []agentsync.RecursiveWatchResult{{Watched: 1}}
+	unwatchedDirs := []string{sharedDir}
+
+	got := watchPollingObligations(roots, results, unwatchedDirs, nil)
+
+	agentSet := make(map[parser.AgentType]bool)
+	for _, ob := range got {
+		for _, scope := range ob.Scopes {
+			if scope.Root == filepath.Clean(sharedDir) {
+				agentSet[parser.AgentType(scope.Agent)] = true
+			}
+		}
+	}
+	assert.True(t, agentSet[parser.AgentClaude],
+		"unwatched-fallback obligation for shared dir must carry Claude's scope")
+	assert.True(t, agentSet[parser.AgentGemini],
+		"unwatched-fallback obligation for shared dir must carry Gemini's scope")
+}
+
+// TestRegisterWatcherUnavailablePreservesAgents: when the file watcher
+// cannot be constructed, registerWatcherUnavailableObligations must NOT strip
+// the agent field from each scope. Stripping makes per-agent blocking in the
+// coordinator ineffective: a missing probe for Gemini would block the empty-
+// agent group instead of Gemini's group, and healthy Claude changes would be
+// frozen.
+func TestRegisterWatcherUnavailablePreservesAgents(t *testing.T) {
+	parent := t.TempDir()
+	claudeDir := filepath.Join(parent, "claude-dir")
+	require.NoError(t, os.Mkdir(claudeDir, 0o755))
+	geminiDir := filepath.Join(parent, "gemini-dir")
+	require.NoError(t, os.Mkdir(geminiDir, 0o755))
+
+	var mu sync.Mutex
+	var registered []agentsync.PollingObligation
+
+	opts := agentsync.WatcherOptions{
+		OnPollingRequired: func(ob agentsync.PollingObligation) error {
+			mu.Lock()
+			registered = append(registered, ob)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	roots := []watchRoot{{
+		path: filepath.Join(parent, "shared-root"),
+		scopes: []watchScope{
+			{agent: parser.AgentClaude, syncDir: claudeDir},
+			{agent: parser.AgentGemini, syncDir: geminiDir},
+		},
+	}}
+
+	err := registerWatcherUnavailableObligations(opts, roots, nil, nil)
+	require.NoError(t, err)
+
+	mu.Lock()
+	obs := append([]agentsync.PollingObligation(nil), registered...)
+	mu.Unlock()
+
+	agentSet := make(map[string]bool)
+	for _, ob := range obs {
+		for _, scope := range ob.Scopes {
+			agentSet[scope.Agent] = true
+		}
+	}
+	assert.True(t, agentSet[string(parser.AgentClaude)],
+		"Claude's agent must be preserved in watcher-unavailable obligations")
+	assert.True(t, agentSet[string(parser.AgentGemini)],
+		"Gemini's agent must be preserved in watcher-unavailable obligations")
+	assert.False(t, agentSet[""],
+		"no scope must be stripped to the empty agent; per-provider blocking requires real agents")
+}
+
+// TestWatchPollingObligationsPersistentDirCarriesAgentFromSymlinkOnlyProvider
+// : when a provider's only physical root
+// is a symlink and is therefore recorded in symlinkGatedDirs rather than roots,
+// the persistent obligation for its syncDir must still carry the provider's
+// agent. Without the fix, syncDirToAgents is built from roots only (empty in
+// this case), so the persistent obligation gets Agent:"" and the coordinator
+// cannot distinguish the provider's dir from an unowned fallback dir.
+//
+// This test uses the post-fix 4-parameter watchPollingObligations signature.
+// The compile error is the red state: the function currently accepts 3 args.
+func TestWatchPollingObligationsPersistentDirCarriesAgentFromSymlinkOnlyProvider(t *testing.T) {
+	parent := t.TempDir()
+	syncDir := filepath.Join(parent, "copilot-dir")
+	require.NoError(t, os.Mkdir(syncDir, 0o755))
+	symRoot := filepath.Join(parent, "sessions-symlink") // symlink root; not in roots
+
+	// symlinkGatedDirs records that symRoot is a symlink root for
+	// parser.AgentCopilot whose syncDir is syncDir.
+	symlinkGated := map[string][]watchScope{
+		symRoot: {{agent: parser.AgentCopilot, syncDir: syncDir}},
+	}
+
+	// roots is empty: the provider's only root is a symlink (in symlinkGatedDirs),
+	// so nothing appears in the watch plan's regular root list.
+	got := watchPollingObligations(
+		nil, nil, []string{syncDir}, symlinkGated,
+	)
+
+	agentSet := make(map[string]bool)
+	for _, ob := range got {
+		for _, scope := range ob.Scopes {
+			if scope.Root == filepath.Clean(syncDir) {
+				agentSet[scope.Agent] = true
+			}
+		}
+	}
+	assert.True(t, agentSet[string(parser.AgentCopilot)],
+		"persistent obligation for syncDir must carry the provider's agent "+
+			"when its only root is a symlink recorded in symlinkGatedDirs")
+	assert.False(t, agentSet[""],
+		"no scope should carry the empty agent when provider identity is known from symlinkGatedDirs")
+}
+
+// TestWatcherStartFailureEmptyAgentBypassesNamedGate (coordinator level):
+// level): after a backend Start failure, the coordinator may receive a generic
+// "watcher-fallback" empty-agent obligation alongside the named per-provider
+// obligations. Without cross-agent blocking, the empty-agent
+// obligation bypasses the named provider's probe gate and reconciles a scope
+// whose physical nested root is missing, tombstoning its sessions.
+//
+// The test installs a named Gemini obligation with a missing probe gate
+// (simulating OnPollingRequired output for a Gemini root with a missing
+// nested physical dir) alongside a watcher-fallback empty-agent obligation for
+// both geminiDir and otherDir (simulating the OnCoverageDegraded output the
+// current code emits on backend Start failure). After the fix, geminiDir must
+// NOT be reconciled while the nested root is missing; otherDir must still run.
+func TestWatcherStartFailureEmptyAgentBypassesNamedGate(t *testing.T) {
+	parent := t.TempDir()
+	nestedRoot := filepath.Join(parent, "gemini-nested") // does not exist
+	geminiDir := requireExistingPollRoot(t, parent, "gemini-dir")
+	otherDir := requireExistingPollRoot(t, parent, "other-dir")
+
+	syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil, time.Now, time.After,
+	)
+	t.Cleanup(coordinator.Stop)
+
+	// Named Gemini obligation with a missing probe gate — the nested physical
+	// root (gemini-nested) is gone, so Gemini should be deferred.
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    pollingObligationKey("gemini", geminiDir),
+		Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: geminiDir}},
+		Probe:  nestedRoot,
+	}))
+	// Simulates what OnCoverageDegraded("watcher-fallback") installs when the
+	// current code calls it on backend Start failure even though
+	// OnPollingRequired is also set: an empty-agent obligation covering every
+	// registered root.
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "watcher-fallback",
+		Scopes: []pollingScope{
+			{Agent: parser.AgentType(""), Root: geminiDir},
+			{Agent: parser.AgentType(""), Root: otherDir},
+		},
+	}))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	calls := syncer.snapshot()
+	reconciledRoots := make(map[string]bool)
+	for _, c := range calls {
+		for _, r := range c.Roots {
+			reconciledRoots[r] = true
+		}
+	}
+	assert.False(t, reconciledRoots[geminiDir],
+		"geminiDir must not be reconciled while its nested root is missing: "+
+			"the empty-agent obligation must be blocked by cross-agent deferral")
+	assert.True(t, reconciledRoots[otherDir],
+		"otherDir must still be reconciled via the empty-agent obligation")
+}
+
+// TestSymlinkGateNamedProviderDefersOnlyThatProvider covers the coordinator level:
+// a persistent obligation and a symlink-gate obligation for a named provider
+// both carry that provider's agent. When the symlink probe is missing the
+// coordinator must defer only that provider; a second, healthy provider must
+// still be reconciled.
+func TestSymlinkGateNamedProviderDefersOnlyThatProvider(t *testing.T) {
+	parent := t.TempDir()
+	claudeDir := requireExistingPollRoot(t, parent, "claude-dir")
+	geminiDir := requireExistingPollRoot(t, parent, "gemini-dir")
+	missingProbe := filepath.Join(parent, "gemini-sessions-target") // does not exist
+
+	syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil, time.Now, time.After,
+	)
+	t.Cleanup(coordinator.Stop)
+
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "gemini-persistent",
+		Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: geminiDir}},
+	}))
+	// Symlink gate for Gemini: when probe is missing this must defer ONLY Gemini.
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "gemini-symlink-gate",
+		Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: geminiDir}},
+		Probe:  missingProbe,
+	}))
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "claude-persistent",
+		Scopes: []pollingScope{{Agent: parser.AgentClaude, Root: claudeDir}},
+	}))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	calls := syncer.snapshot()
+	agents := make(map[parser.AgentType]bool)
+	for _, c := range calls {
+		agents[c.Agent] = true
+	}
+	assert.True(t, agents[parser.AgentClaude],
+		"Claude must be reconciled; it is not affected by Gemini's broken symlink gate")
+	assert.False(t, agents[parser.AgentGemini],
+		"Gemini must NOT be reconciled while its symlink probe is missing")
+}
+
+// TestSharedSyncDirBothProvidersReconciled end to end: two providers
+// sharing the same sync dir must each receive a ReconcileProviderRoots call
+// once the dir is available, regardless of whether the path is in the pending
+// or persistent branch.
+func TestSharedSyncDirBothProvidersReconciled(t *testing.T) {
+	parent := t.TempDir()
+	sharedDir := requireExistingPollRoot(t, parent, "shared-sync")
+
+	syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil, time.Now, time.After,
+	)
+	t.Cleanup(coordinator.Stop)
+
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "shared-dir",
+		Scopes: []pollingScope{
+			{Agent: parser.AgentClaude, Root: sharedDir},
+			{Agent: parser.AgentGemini, Root: sharedDir},
+		},
+	}))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	calls := syncer.snapshot()
+	agents := make(map[parser.AgentType]bool)
+	for _, c := range calls {
+		agents[c.Agent] = true
+	}
+	assert.True(t, agents[parser.AgentClaude],
+		"Claude must receive ReconcileProviderRoots for the shared dir")
+	assert.True(t, agents[parser.AgentGemini],
+		"Gemini must receive ReconcileProviderRoots for the shared dir")
+}
+
+// TestUnwatchedPollCooldownIsExactlyOneInterval strengthens the
+// existing cooldown invariant test:
+//  1. The duration passed to after() must equal unwatchedPollInterval (not just
+//     be positive — a 1ns wait would satisfy the weaker assertion).
+//  2. No second reconcile call must start before the captured timer fires.
+//  3. Exactly one second reconcile call must happen after the timer fires.
+func TestUnwatchedPollCooldownIsExactlyOneInterval(t *testing.T) {
+	ticks := make(chan time.Time, 2)
+	passRelease := make(chan struct{})
+	passStarted := make(chan struct{}, 1)
+	t0 := time.Unix(1000, 0)
+	now := t0
+
+	var nowMu sync.Mutex
+	getNow := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+
+	// afterTimers carries the bidirectional channel so the test can fire the timer.
+	afterTimers := make(chan chan time.Time, 4)
+	var afterArgs []time.Duration
+	var afterMu sync.Mutex
+	getAfter := func(d time.Duration) <-chan time.Time {
+		afterMu.Lock()
+		afterArgs = append(afterArgs, d)
+		afterMu.Unlock()
+		ch := make(chan time.Time, 1)
+		afterTimers <- ch
+		return ch
+	}
+
+	firstCallDone := make(chan struct{})
+	var callMu sync.Mutex
+	var callCount int
+	syncer := &manualProviderPollSyncer{
+		fn: func(_ context.Context, _ parser.AgentType, _ []string) error {
+			callMu.Lock()
+			callCount++
+			n := callCount
+			callMu.Unlock()
+			select {
+			case passStarted <- struct{}{}:
+			default:
+			}
+			if n == 1 {
+				<-passRelease
+				select {
+				case firstCallDone <- struct{}{}:
+				default:
+				}
+			}
+			return nil
+		},
+	}
+
+	root := requireExistingPollRoot(t, t.TempDir(), "root")
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {},
+		func(run func()) { run() }, nil,
+		getNow, getAfter,
+	)
+	t.Cleanup(coordinator.Stop)
+
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:    "test-root",
+		Scopes: []pollingScope{{Root: root}},
+	}))
+
+	// First tick starts the pass (which blocks).
+	ticks <- t0
+	select {
+	case <-passStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first pass did not start before timeout")
+	}
+
+	// Second tick arrives while the first pass is running.
+	ticks <- t0.Add(unwatchedPollInterval)
+
+	// Advance "now" so that at completion the full interval has elapsed since
+	// the tick deadline, making the cooldown remainder = unwatchedPollInterval.
+	nowMu.Lock()
+	now = t0.Add(unwatchedPollInterval + 500*time.Millisecond)
+	nowMu.Unlock()
+
+	// Release the first pass.
+	close(passRelease)
+
+	// Wait for the first pass to finish so lastCompletion is set.
+	select {
+	case <-firstCallDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first pass did not complete before timeout")
+	}
+
+	// The worker must call after() with exactly unwatchedPollInterval.
+	var timerCh chan time.Time
+	select {
+	case timerCh = <-afterTimers:
+	case <-time.After(2 * time.Second):
+		t.Fatal("after() was not called for the cooldown wait")
+	}
+
+	afterMu.Lock()
+	args := append([]time.Duration(nil), afterArgs...)
+	afterMu.Unlock()
+	require.Len(t, args, 1)
+	assert.Equal(t, unwatchedPollInterval, args[0],
+		"cooldown must wait exactly unwatchedPollInterval, not just a positive duration")
+
+	// No second reconcile must have started before the timer fires.
+	callMu.Lock()
+	beforeFire := callCount
+	callMu.Unlock()
+	assert.Equal(t, 1, beforeFire,
+		"no second reconcile must start before the cooldown timer fires (P10)")
+
+	// Fire the cooldown timer.
+	timerCh <- time.Now()
+
+	// Exactly one second reconcile must start.
+	select {
+	case <-passStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second reconcile did not start after the cooldown timer fired")
+	}
+
+	callMu.Lock()
+	afterFire := callCount
+	callMu.Unlock()
+	assert.Equal(t, 2, afterFire,
+		"exactly one second reconcile must fire after the cooldown timer (P10)")
+}

--- a/cmd/agentsview/polling_scope_identity_test.go
+++ b/cmd/agentsview/polling_scope_identity_test.go
@@ -1,8 +1,6 @@
 package main
 
 // Regression tests for provider identity in polling obligations.
-// Tests are written test-first; they are expected to fail against the
-// un-fixed head before the production-code changes are applied.
 
 import (
 	"context"
@@ -174,16 +172,13 @@ func TestRegisterWatcherUnavailablePreservesAgents(t *testing.T) {
 		"no scope must be stripped to the empty agent; per-provider blocking requires real agents")
 }
 
-// TestWatchPollingObligationsPersistentDirCarriesAgentFromSymlinkOnlyProvider
-// : when a provider's only physical root
-// is a symlink and is therefore recorded in symlinkGatedDirs rather than roots,
-// the persistent obligation for its syncDir must still carry the provider's
-// agent. Without the fix, syncDirToAgents is built from roots only (empty in
-// this case), so the persistent obligation gets Agent:"" and the coordinator
-// cannot distinguish the provider's dir from an unowned fallback dir.
-//
-// This test uses the post-fix 4-parameter watchPollingObligations signature.
-// The compile error is the red state: the function currently accepts 3 args.
+// TestWatchPollingObligationsPersistentDirCarriesAgentFromSymlinkOnlyProvider:
+// when a provider's only physical root is a symlink and is therefore recorded
+// in symlinkGatedDirs rather than roots, the persistent obligation for its
+// syncDir must still carry the provider's agent. If syncDirToAgents were built
+// from roots only (empty in this case), the persistent obligation would get
+// Agent:"" and the coordinator could not distinguish the provider's dir from
+// an unowned fallback dir.
 func TestWatchPollingObligationsPersistentDirCarriesAgentFromSymlinkOnlyProvider(t *testing.T) {
 	parent := t.TempDir()
 	syncDir := filepath.Join(parent, "copilot-dir")
@@ -481,7 +476,7 @@ func TestUnwatchedPollCooldownIsExactlyOneInterval(t *testing.T) {
 	beforeFire := callCount
 	callMu.Unlock()
 	assert.Equal(t, 1, beforeFire,
-		"no second reconcile must start before the cooldown timer fires (P10)")
+		"no second reconcile must start before the cooldown timer fires")
 
 	// Fire the cooldown timer.
 	timerCh <- time.Now()
@@ -497,5 +492,5 @@ func TestUnwatchedPollCooldownIsExactlyOneInterval(t *testing.T) {
 	afterFire := callCount
 	callMu.Unlock()
 	assert.Equal(t, 2, afterFire,
-		"exactly one second reconcile must fire after the cooldown timer (P10)")
+		"exactly one second reconcile must fire after the cooldown timer")
 }

--- a/cmd/agentsview/polling_scope_identity_test.go
+++ b/cmd/agentsview/polling_scope_identity_test.go
@@ -47,8 +47,8 @@ func TestPollingScopesForDirsEmitsAllAgents(t *testing.T) {
 }
 
 // TestWatchPollingObligationsPersistentDirBothAgents covers the persistent-dir branch:
-// when two agents share a persistent polling dir, the obligation for that dir
-// must carry both agents' scopes, not just the last writer in syncDirToAgents.
+// when two agents both request persistent polling for a shared dir, the
+// obligation for that dir must carry both requesters' scopes.
 // Uses a non-nil results slice so the "no watcher" path is not taken; only the
 // persistent-dir loop runs.
 func TestWatchPollingObligationsPersistentDirBothAgents(t *testing.T) {
@@ -67,7 +67,9 @@ func TestWatchPollingObligationsPersistentDirBothAgents(t *testing.T) {
 	// "no watcher" (i >= len(results)) branch does NOT execute.
 	results := []agentsync.RecursiveWatchResult{{Watched: 1, MissingRootLifecycleOwned: false}}
 
-	got := watchPollingObligations(roots, results, nil, nil)
+	got := watchPollingObligations(roots, results, nil, map[string][]parser.AgentType{
+		sharedDir: {parser.AgentClaude, parser.AgentGemini},
+	})
 
 	agentSet := make(map[parser.AgentType]bool)
 	for _, ob := range got {
@@ -83,10 +85,44 @@ func TestWatchPollingObligationsPersistentDirBothAgents(t *testing.T) {
 		"persistent obligation for shared dir must carry Gemini's scope")
 }
 
+// TestWatchPollingObligationsPersistentDirScopedToRequestingProvider is the
+// ownership regression: when only one of two agents sharing a configured dir
+// requested persistent polling, the persistent obligation must carry only the
+// requester's scope. Granting the other agent a scope would reconcile it
+// authoritatively on every pass and tombstone its sessions under a
+// lifecycle-owned missing root.
+func TestWatchPollingObligationsPersistentDirScopedToRequestingProvider(t *testing.T) {
+	parent := t.TempDir()
+	sharedDir := filepath.Join(parent, "shared-sync")
+
+	roots := []watchRoot{{
+		path: filepath.Join(parent, "physical-root"),
+		scopes: []watchScope{
+			{agent: parser.AgentClaude, syncDir: sharedDir},
+			{agent: parser.AgentGemini, syncDir: sharedDir},
+		},
+		persistentPollingDirs: []string{sharedDir},
+	}}
+	results := []agentsync.RecursiveWatchResult{{Watched: 1}}
+
+	// Only Claude requested persistent polling for the shared dir.
+	got := watchPollingObligations(roots, results, nil, map[string][]parser.AgentType{
+		sharedDir: {parser.AgentClaude},
+	})
+
+	require.Len(t, got, 1)
+	assert.Equal(t, []agentsync.PollingScope{
+		{Agent: string(parser.AgentClaude), Root: filepath.Clean(sharedDir)},
+	}, got[0].Scopes,
+		"persistent obligation must carry only the requesting provider's scope; "+
+			"Gemini shares the dir but did not request persistent polling")
+}
+
 // TestWatchPollingObligationsUnwatchedFallbackBothAgents covers the unwatched-fallback branch:
-// when two agents share a dir in the unwatched-dirs fallback, both agents'
-// scopes must appear in the resulting obligation. Uses non-nil results so the
-// "no watcher" path is not taken.
+// when two agents both request persistent polling for a dir that reaches the
+// unwatched-dirs fallback, both requesters' scopes must appear in the
+// resulting obligation. Uses non-nil results so the "no watcher" path is not
+// taken.
 func TestWatchPollingObligationsUnwatchedFallbackBothAgents(t *testing.T) {
 	parent := t.TempDir()
 	sharedDir := filepath.Join(parent, "shared-sync")
@@ -102,7 +138,9 @@ func TestWatchPollingObligationsUnwatchedFallbackBothAgents(t *testing.T) {
 	results := []agentsync.RecursiveWatchResult{{Watched: 1}}
 	unwatchedDirs := []string{sharedDir}
 
-	got := watchPollingObligations(roots, results, unwatchedDirs, nil)
+	got := watchPollingObligations(roots, results, unwatchedDirs, map[string][]parser.AgentType{
+		sharedDir: {parser.AgentClaude, parser.AgentGemini},
+	})
 
 	agentSet := make(map[parser.AgentType]bool)
 	for _, ob := range got {
@@ -151,7 +189,7 @@ func TestRegisterWatcherUnavailablePreservesAgents(t *testing.T) {
 		},
 	}}
 
-	err := registerWatcherUnavailableObligations(opts, roots, nil, nil)
+	err := registerWatcherUnavailableObligations(opts, roots, nil, nil, nil)
 	require.NoError(t, err)
 
 	mu.Lock()
@@ -173,28 +211,25 @@ func TestRegisterWatcherUnavailablePreservesAgents(t *testing.T) {
 }
 
 // TestWatchPollingObligationsPersistentDirCarriesAgentFromSymlinkOnlyProvider:
-// when a provider's only physical root is a symlink and is therefore recorded
-// in symlinkGatedDirs rather than roots, the persistent obligation for its
-// syncDir must still carry the provider's agent. If syncDirToAgents were built
-// from roots only (empty in this case), the persistent obligation would get
-// Agent:"" and the coordinator could not distinguish the provider's dir from
-// an unowned fallback dir.
+// when a provider's only physical root is a symlink and is therefore excluded
+// from roots, the persistent obligation for its syncDir must still carry the
+// provider's agent. collectWatchRoots records the symlink provider as a
+// persistent-polling requester, so the provenance map identifies the agent
+// even though no watch root mentions the dir; without it the persistent
+// obligation would get Agent:"" and the coordinator could not distinguish the
+// provider's dir from an unowned fallback dir.
 func TestWatchPollingObligationsPersistentDirCarriesAgentFromSymlinkOnlyProvider(t *testing.T) {
 	parent := t.TempDir()
 	syncDir := filepath.Join(parent, "copilot-dir")
 	require.NoError(t, os.Mkdir(syncDir, 0o755))
-	symRoot := filepath.Join(parent, "sessions-symlink") // symlink root; not in roots
 
-	// symlinkGatedDirs records that symRoot is a symlink root for
-	// parser.AgentCopilot whose syncDir is syncDir.
-	symlinkGated := map[string][]watchScope{
-		symRoot: {{agent: parser.AgentCopilot, syncDir: syncDir}},
-	}
-
-	// roots is empty: the provider's only root is a symlink (in symlinkGatedDirs),
-	// so nothing appears in the watch plan's regular root list.
+	// roots is empty: the provider's only root is a symlink, so nothing appears
+	// in the watch plan's regular root list. The provenance map records the
+	// symlink provider's persistent-polling request for its syncDir.
 	got := watchPollingObligations(
-		nil, nil, []string{syncDir}, symlinkGated,
+		nil, nil, []string{syncDir}, map[string][]parser.AgentType{
+			syncDir: {parser.AgentCopilot},
+		},
 	)
 
 	agentSet := make(map[string]bool)
@@ -207,9 +242,9 @@ func TestWatchPollingObligationsPersistentDirCarriesAgentFromSymlinkOnlyProvider
 	}
 	assert.True(t, agentSet[string(parser.AgentCopilot)],
 		"persistent obligation for syncDir must carry the provider's agent "+
-			"when its only root is a symlink recorded in symlinkGatedDirs")
+			"when its only root is a symlink excluded from the watch plan")
 	assert.False(t, agentSet[""],
-		"no scope should carry the empty agent when provider identity is known from symlinkGatedDirs")
+		"no scope should carry the empty agent when provider identity is known from provenance")
 }
 
 // TestWatcherStartFailureEmptyAgentBypassesNamedGate (coordinator level):

--- a/cmd/agentsview/symlink_polling_scope_test.go
+++ b/cmd/agentsview/symlink_polling_scope_test.go
@@ -1,0 +1,38 @@
+package main
+
+// TestSymlinkPollingObligationsCarryProviderAgent: symlinkPollingObligations
+// must preserve the agent from the watchScope when building PollingScope values.
+// This test uses the post-fix type map[string][]watchScope; before the fix the
+// parameter type is map[string][]string and the test fails to compile.
+//
+// The compile error is the pre-fix state:
+//   cannot use map[string][]watchScope as map[string][]string
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestSymlinkPollingObligationsCarryProviderAgent(t *testing.T) {
+	parent := t.TempDir()
+	symRoot := filepath.Join(parent, "sessions-symlink")
+	dir := filepath.Join(parent, "provider-dir")
+
+	gatedDirs := map[string][]watchScope{
+		symRoot: {{agent: parser.AgentClaude, syncDir: dir}},
+	}
+	obligations := symlinkPollingObligations(gatedDirs)
+
+	require.Len(t, obligations, 1)
+	require.Len(t, obligations[0].Scopes, 1)
+	assert.Equal(t, string(parser.AgentClaude), obligations[0].Scopes[0].Agent,
+		"symlink gate obligation must carry the provider's agent")
+	assert.Equal(t, filepath.Clean(dir), obligations[0].Scopes[0].Root,
+		"symlink gate obligation scope must use the configured dir as Root")
+	assert.Equal(t, filepath.Clean(symRoot), obligations[0].Probe,
+		"symlink gate obligation probe must be the symlink root path")
+}

--- a/cmd/agentsview/symlink_polling_scope_test.go
+++ b/cmd/agentsview/symlink_polling_scope_test.go
@@ -1,13 +1,5 @@
 package main
 
-// TestSymlinkPollingObligationsCarryProviderAgent: symlinkPollingObligations
-// must preserve the agent from the watchScope when building PollingScope values.
-// This test uses the post-fix type map[string][]watchScope; before the fix the
-// parameter type is map[string][]string and the test fails to compile.
-//
-// The compile error is the pre-fix state:
-//   cannot use map[string][]watchScope as map[string][]string
-
 import (
 	"path/filepath"
 	"testing"
@@ -17,6 +9,9 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 )
 
+// TestSymlinkPollingObligationsCarryProviderAgent asserts that
+// symlinkPollingObligations preserves the agent from the watchScope when
+// building PollingScope values.
 func TestSymlinkPollingObligationsCarryProviderAgent(t *testing.T) {
 	parent := t.TempDir()
 	symRoot := filepath.Join(parent, "sessions-symlink")

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -400,8 +400,8 @@ func unwatchedPollRoots(owned map[string]struct{}) []string {
 
 // pollUnwatchedScopesOnce calls ReconcileProviderRoots once per agent group.
 // Every available group receives exactly one attempt regardless of whether an
-// earlier group errored; failures are joined and returned together (P10).
-// At most one reconcile call is in flight at a time (P11).
+// earlier group errored; failures are joined and returned together.
+// At most one reconcile call is in flight at a time.
 func pollUnwatchedScopesOnce(
 	ctx context.Context,
 	engine unwatchedPollSyncer,

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -13,12 +13,16 @@ import (
 
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/server"
+	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
 var errUnwatchedPollStopped = errors.New("unwatched poll coordinator stopped")
 
 type unwatchedPollSyncer interface {
-	ReconcileProviderRoots(context.Context, parser.AgentType, []string) error
+	// ReconcileProviderRootsGrouped runs one bounded pass per provider group
+	// while sharing a single archive-sized epilogue across the batch; the
+	// coordinator issues exactly one grouped call per poll pass.
+	ReconcileProviderRootsGrouped(context.Context, []agentsync.ProviderRootsGroup) error
 }
 
 type unwatchedPollAdd struct {
@@ -398,10 +402,11 @@ func unwatchedPollRoots(owned map[string]struct{}) []string {
 	return roots
 }
 
-// pollUnwatchedScopesOnce calls ReconcileProviderRoots once per agent group.
-// Every available group receives exactly one attempt regardless of whether an
-// earlier group errored; failures are joined and returned together.
-// At most one reconcile call is in flight at a time.
+// pollUnwatchedScopesOnce issues one grouped reconcile call covering every
+// agent group, in agent order. The engine attempts every group even when an
+// earlier one errors and shares one archive-sized epilogue (subagent linking,
+// skip-cache persistence) across the batch, so per-pass database work does not
+// multiply with the number of providers holding obligations.
 func pollUnwatchedScopesOnce(
 	ctx context.Context,
 	engine unwatchedPollSyncer,
@@ -417,12 +422,11 @@ func pollUnwatchedScopesOnce(
 	slices.SortFunc(agents, func(a, b parser.AgentType) int {
 		return strings.Compare(string(a), string(b))
 	})
-	var errs []error
+	grouped := make([]agentsync.ProviderRootsGroup, 0, len(agents))
 	for _, agent := range agents {
-		roots := groups[agent]
-		if err := engine.ReconcileProviderRoots(ctx, agent, roots); err != nil {
-			errs = append(errs, err)
-		}
+		grouped = append(grouped, agentsync.ProviderRootsGroup{
+			Agent: agent, Roots: groups[agent],
+		})
 	}
-	return errors.Join(errs...)
+	return engine.ReconcileProviderRootsGrouped(ctx, grouped)
 }

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -11,13 +11,14 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/server"
 )
 
 var errUnwatchedPollStopped = errors.New("unwatched poll coordinator stopped")
 
 type unwatchedPollSyncer interface {
-	ReconcileWatchRoots(context.Context, []string, bool) error
+	ReconcileProviderRoots(context.Context, parser.AgentType, []string) error
 }
 
 type unwatchedPollAdd struct {
@@ -26,16 +27,22 @@ type unwatchedPollAdd struct {
 	done       chan struct{}
 }
 
+// pollingScope identifies one configured provider root within a polling obligation.
+type pollingScope struct {
+	Agent parser.AgentType
+	Root  string
+}
+
 type pollingObligation struct {
-	Key   string
-	Roots []string
+	Key    string
+	Scopes []pollingScope
 	// Probe mirrors sync.PollingObligation.Probe: the physical watcher path
-	// whose availability gates this obligation's reconciliation Roots. When
-	// it is missing, the roots are deferred rather than reconciled
+	// whose availability gates this obligation's reconciliation scopes. When
+	// it is missing, the scopes are deferred rather than reconciled
 	// authoritatively — a nested physical root (Gemini's <root>/tmp) can
 	// vanish while its configured scope <root> still exists, and reconciling
 	// the scope then would tombstone every session under the missing
-	// subtree. Empty means the Roots themselves are probed.
+	// subtree. Empty means the Scopes' roots themselves are probed.
 	Probe string
 }
 
@@ -49,6 +56,8 @@ type sharedUnwatchedPollCoordinator struct {
 	doWork       func(func())
 	// onRootsOwned is a test observer invoked after installation and before ack.
 	onRootsOwned func([]string)
+	now          func() time.Time
+	after        func(time.Duration) <-chan time.Time
 	add          chan unwatchedPollAdd
 	// pollWake coalesces ticks and explicit wakes while the serialized worker runs.
 	pollWake chan struct{}
@@ -58,9 +67,12 @@ type sharedUnwatchedPollCoordinator struct {
 	// coordinator loop; each entry keeps its probe so availability is
 	// evaluated per obligation at poll time.
 	pollObligations []pollingObligation
-	stop            chan struct{}
-	done            chan struct{}
-	stopOnce        sync.Once
+	// lastCompletion is the wall-clock time the most recent pass completed.
+	// Zero means no prior pass; a zero value skips the cooldown on the first wake.
+	lastCompletion time.Time
+	stop           chan struct{}
+	done           chan struct{}
+	stopOnce       sync.Once
 }
 
 func newUnwatchedPollCoordinator(
@@ -70,7 +82,7 @@ func newUnwatchedPollCoordinator(
 ) *sharedUnwatchedPollCoordinator {
 	ticker := time.NewTicker(unwatchedPollInterval)
 	return newUnwatchedPollCoordinatorWithTicks(
-		ctx, engine, ticker.C, ticker.Stop, idleTracker.Do, nil,
+		ctx, engine, ticker.C, ticker.Stop, idleTracker.Do, nil, time.Now, time.After,
 	)
 }
 
@@ -81,6 +93,8 @@ func newUnwatchedPollCoordinatorWithTicks(
 	stopTicker func(),
 	doWork func(func()),
 	onRootsOwned func([]string),
+	now func() time.Time,
+	after func(time.Duration) <-chan time.Time,
 ) *sharedUnwatchedPollCoordinator {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	coordinator := &sharedUnwatchedPollCoordinator{
@@ -91,6 +105,8 @@ func newUnwatchedPollCoordinatorWithTicks(
 		ticks:        ticks,
 		stopTicker:   stopTicker,
 		doWork:       doWork,
+		now:          now,
+		after:        after,
 		add:          make(chan unwatchedPollAdd),
 		pollWake:     make(chan struct{}, 1),
 		pollDone:     make(chan struct{}),
@@ -120,9 +136,9 @@ func (c *sharedUnwatchedPollCoordinator) updateRoots(
 ) error {
 	request := unwatchedPollAdd{
 		obligation: pollingObligation{
-			Key:   obligation.Key,
-			Roots: append([]string(nil), obligation.Roots...),
-			Probe: obligation.Probe,
+			Key:    obligation.Key,
+			Scopes: append([]pollingScope(nil), obligation.Scopes...),
+			Probe:  obligation.Probe,
 		},
 		remove: remove,
 		done:   make(chan struct{}),
@@ -216,41 +232,70 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 			if c.workerCtx.Err() != nil {
 				return
 			}
-			roots := availableUnwatchedPollRoots(c.currentPollObligations())
-			if len(roots) == 0 {
+			// Cooldown gate: if the previous pass completed less than
+			// unwatchedPollInterval ago, wait out the remaining idle time.
+			// The gate is here (after consuming the wake) so every path into
+			// a pass crosses it. lastCompletion is zero on first construction,
+			// which means no prior pass and therefore no cooldown on startup.
+			c.pollMu.Lock()
+			last := c.lastCompletion
+			c.pollMu.Unlock()
+			if !last.IsZero() {
+				remaining := last.Add(unwatchedPollInterval).Sub(c.now())
+				if remaining > 0 {
+					select {
+					case <-c.workerCtx.Done():
+						return
+					case <-c.after(remaining):
+					}
+				}
+			}
+			groups := availableUnwatchedPollScopes(c.currentPollObligations())
+			totalRoots := countUniqueRoots(groups)
+			if totalRoots == 0 {
 				continue
 			}
-			log.Printf("polling %d unwatched root(s)", len(roots))
+			log.Printf("polling %d unwatched root(s)", totalRoots)
 			c.doWork(func() {
 				if c.workerCtx.Err() != nil {
 					return
 				}
-				pollUnwatchedRootsOnce(c.workerCtx, c.engine, roots)
+				if err := pollUnwatchedScopesOnce(c.workerCtx, c.engine, groups); err != nil {
+					log.Printf("polling unwatched roots: %v", err)
+				}
 			})
+			c.pollMu.Lock()
+			c.lastCompletion = c.now()
+			c.pollMu.Unlock()
 		}
 	}
 }
 
-// availableUnwatchedPollRoots selects the reconciliation roots whose
-// obligations are currently pollable. An obligation with a probe path is gated
-// on that physical path: while it is missing, its roots are deferred entirely
-// rather than authoritatively reconciled, because the configured scope can
-// still exist while the physical subtree holding every session is gone.
+// availableUnwatchedPollScopes selects the reconciliation scopes whose
+// obligations are currently pollable, grouped by agent. An obligation with a
+// probe path is gated on that physical path: while it is missing, its scopes
+// are deferred entirely rather than authoritatively reconciled.
 //
-// A root shared by several obligations is gated on every probe that references
-// it, not just one: Gemini's shallow <root> metadata plan and recursive
-// <root>/tmp plan both reconcile <root>, and the present shallow plan must not
-// make <root> pollable while the subtree holding every session is missing.
+// Blocking is conservative in both directions between the empty agent and named
+// agents. The empty agent means "every provider" for deferral (an unscoped
+// reconciliation pass walks all providers, including any deferred one) and
+// "unscoped" for reconciliation. Therefore:
+//   - A root blocked under the empty agent also defers every named-agent
+//     candidate for that root.
+//   - A root blocked under any named agent also defers the empty-agent
+//     candidate for that root.
 //
-// Blocking extends beyond exact root matches to every candidate overlapping a
-// blocked root in either direction (overlapsDeferredScope): ReconcileWatchRoots
-// expands each requested root to the configured dirs above and below it, so a
-// pollable ancestor or descendant of a blocked root would reconcile the
-// deferred scope as an authoritative empty discovery and tombstone its
-// sessions.
-func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
-	candidates := make(map[string]struct{})
-	blocked := make(map[string]struct{})
+// Within each agent, overlap blocking extends beyond exact root matches
+// (overlapsDeferredScope), so a pollable ancestor or descendant of a blocked
+// root is also deferred for that agent.
+func availableUnwatchedPollScopes(
+	obligations []pollingObligation,
+) map[parser.AgentType][]string {
+	// blocked[agent][cleanRoot] = true when agent's probe is missing.
+	blocked := make(map[parser.AgentType]map[string]struct{})
+	// candidates[agent][root] = true when the root exists and probe is present.
+	candidates := make(map[parser.AgentType]map[string]struct{})
+
 	for _, obligation := range obligations {
 		probeMissing := false
 		if obligation.Probe != "" {
@@ -258,33 +303,86 @@ func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
 				probeMissing = true
 			}
 		}
-		for _, root := range obligation.Roots {
-			if root == "" {
+		for _, scope := range obligation.Scopes {
+			if scope.Root == "" {
 				continue
 			}
+			agent := scope.Agent
 			if probeMissing {
-				blocked[filepath.Clean(root)] = struct{}{}
+				if blocked[agent] == nil {
+					blocked[agent] = make(map[string]struct{})
+				}
+				blocked[agent][filepath.Clean(scope.Root)] = struct{}{}
 				continue
 			}
-			if _, err := os.Stat(root); err == nil {
-				candidates[root] = struct{}{}
+			if _, err := os.Stat(scope.Root); err == nil {
+				if candidates[agent] == nil {
+					candidates[agent] = make(map[string]struct{})
+				}
+				candidates[agent][scope.Root] = struct{}{}
 			}
 		}
 	}
-	for root := range candidates {
-		if overlapsDeferredScope(filepath.Clean(root), blocked) {
-			delete(candidates, root)
+
+	// Pre-build the union of all named-agent blocked roots for the empty-agent
+	// cross-direction check below.
+	allNamedBlocked := make(map[string]struct{})
+	for namedAgent, namedBlocked := range blocked {
+		if namedAgent == "" {
+			continue
+		}
+		for root := range namedBlocked {
+			allNamedBlocked[root] = struct{}{}
 		}
 	}
-	return unwatchedPollRoots(candidates)
+	emptyAgentBlocked := blocked[parser.AgentType("")]
+
+	result := make(map[parser.AgentType][]string)
+	for agent, agentCandidates := range candidates {
+		agentBlocked := blocked[agent]
+		for root := range agentCandidates {
+			cleanRoot := filepath.Clean(root)
+			if agentBlocked != nil && overlapsDeferredScope(cleanRoot, agentBlocked) {
+				continue
+			}
+			// Cross-agent blocking: an unscoped reconciliation pass walks every
+			// provider, so a root deferred under either the empty agent or any
+			// named agent must also block the other side.
+			if agent != "" && emptyAgentBlocked != nil &&
+				overlapsDeferredScope(cleanRoot, emptyAgentBlocked) {
+				continue
+			}
+			if agent == "" && overlapsDeferredScope(cleanRoot, allNamedBlocked) {
+				continue
+			}
+			result[agent] = append(result[agent], root)
+		}
+		if len(result[agent]) > 0 {
+			slices.Sort(result[agent])
+		} else {
+			delete(result, agent)
+		}
+	}
+	return result
+}
+
+// countUniqueRoots returns the number of unique root paths across all agent groups.
+func countUniqueRoots(groups map[parser.AgentType][]string) int {
+	unique := make(map[string]struct{})
+	for _, roots := range groups {
+		for _, root := range roots {
+			unique[root] = struct{}{}
+		}
+	}
+	return len(unique)
 }
 
 func unwatchedPollObligationRoots(obligations map[string]pollingObligation) []string {
 	owned := make(map[string]struct{})
 	for _, obligation := range obligations {
-		for _, root := range obligation.Roots {
-			if root != "" {
-				owned[root] = struct{}{}
+		for _, scope := range obligation.Scopes {
+			if scope.Root != "" {
+				owned[scope.Root] = struct{}{}
 			}
 		}
 	}
@@ -300,13 +398,31 @@ func unwatchedPollRoots(owned map[string]struct{}) []string {
 	return roots
 }
 
-func pollUnwatchedRootsOnce(
-	ctx context.Context, engine unwatchedPollSyncer, roots []string,
-) {
-	if len(roots) == 0 {
-		return
+// pollUnwatchedScopesOnce calls ReconcileProviderRoots once per agent group.
+// Every available group receives exactly one attempt regardless of whether an
+// earlier group errored; failures are joined and returned together (P10).
+// At most one reconcile call is in flight at a time (P11).
+func pollUnwatchedScopesOnce(
+	ctx context.Context,
+	engine unwatchedPollSyncer,
+	groups map[parser.AgentType][]string,
+) error {
+	if len(groups) == 0 {
+		return nil
 	}
-	if err := engine.ReconcileWatchRoots(ctx, roots, false); err != nil {
-		log.Printf("polling unwatched roots: %v", err)
+	agents := make([]parser.AgentType, 0, len(groups))
+	for agent := range groups {
+		agents = append(agents, agent)
 	}
+	slices.SortFunc(agents, func(a, b parser.AgentType) int {
+		return strings.Compare(string(a), string(b))
+	})
+	var errs []error
+	for _, agent := range agents {
+		roots := groups[agent]
+		if err := engine.ReconcileProviderRoots(ctx, agent, roots); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,6 +19,24 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	agentsync "go.kenn.io/agentsview/internal/sync"
 )
+
+// reconcileGroupsSequentially adapts a per-group fake to the grouped syncer
+// interface, mirroring the engine contract pinned by
+// TestReconcileProviderRootsGrouped*: every group is attempted in order and
+// failures are joined.
+func reconcileGroupsSequentially(
+	ctx context.Context,
+	groups []agentsync.ProviderRootsGroup,
+	reconcile func(context.Context, parser.AgentType, []string) error,
+) error {
+	var errs []error
+	for _, group := range groups {
+		if err := reconcile(ctx, group.Agent, group.Roots); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
 
 type recordingUnwatchedPollSyncer struct {
 	mu           sync.Mutex
@@ -54,6 +73,12 @@ func (s *cancelBlockingUnwatchedPollSyncer) ReconcileProviderRoots(
 	return ctx.Err()
 }
 
+func (s *cancelBlockingUnwatchedPollSyncer) ReconcileProviderRootsGrouped(
+	ctx context.Context, groups []agentsync.ProviderRootsGroup,
+) error {
+	return reconcileGroupsSequentially(ctx, groups, s.ReconcileProviderRoots)
+}
+
 func (s *cancelBlockingUnwatchedPollSyncer) callCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -77,6 +102,12 @@ func (s *blockingUnwatchedPollSyncer) ReconcileProviderRoots(
 	return nil
 }
 
+func (s *blockingUnwatchedPollSyncer) ReconcileProviderRootsGrouped(
+	ctx context.Context, groups []agentsync.ProviderRootsGroup,
+) error {
+	return reconcileGroupsSequentially(ctx, groups, s.ReconcileProviderRoots)
+}
+
 func (s *blockingUnwatchedPollSyncer) snapshot() ([][]string, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -98,6 +129,12 @@ func (s *recordingUnwatchedPollSyncer) ReconcileProviderRoots(
 	default:
 	}
 	return s.reconcileErr
+}
+
+func (s *recordingUnwatchedPollSyncer) ReconcileProviderRootsGrouped(
+	ctx context.Context, groups []agentsync.ProviderRootsGroup,
+) error {
+	return reconcileGroupsSequentially(ctx, groups, s.ReconcileProviderRoots)
 }
 
 func (s *recordingUnwatchedPollSyncer) snapshot() [][]string {

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -21,7 +22,6 @@ import (
 type recordingUnwatchedPollSyncer struct {
 	mu           sync.Mutex
 	calls        [][]string
-	full         []bool
 	wake         chan struct{}
 	reconcileErr error
 }
@@ -42,8 +42,8 @@ type cancelBlockingUnwatchedPollSyncer struct {
 	calls    int
 }
 
-func (s *cancelBlockingUnwatchedPollSyncer) ReconcileWatchRoots(
-	ctx context.Context, _ []string, _ bool,
+func (s *cancelBlockingUnwatchedPollSyncer) ReconcileProviderRoots(
+	ctx context.Context, _ parser.AgentType, _ []string,
 ) error {
 	s.mu.Lock()
 	s.calls++
@@ -60,8 +60,8 @@ func (s *cancelBlockingUnwatchedPollSyncer) callCount() int {
 	return s.calls
 }
 
-func (s *blockingUnwatchedPollSyncer) ReconcileWatchRoots(
-	_ context.Context, roots []string, _ bool,
+func (s *blockingUnwatchedPollSyncer) ReconcileProviderRoots(
+	_ context.Context, _ parser.AgentType, roots []string,
 ) error {
 	owned := append([]string(nil), roots...)
 	s.mu.Lock()
@@ -87,12 +87,11 @@ func (s *blockingUnwatchedPollSyncer) snapshot() ([][]string, int) {
 	return calls, s.maxActive
 }
 
-func (s *recordingUnwatchedPollSyncer) ReconcileWatchRoots(
-	_ context.Context, roots []string, full bool,
+func (s *recordingUnwatchedPollSyncer) ReconcileProviderRoots(
+	_ context.Context, _ parser.AgentType, roots []string,
 ) error {
 	s.mu.Lock()
 	s.calls = append(s.calls, append([]string(nil), roots...))
-	s.full = append(s.full, full)
 	s.mu.Unlock()
 	select {
 	case s.wake <- struct{}{}:
@@ -115,7 +114,7 @@ func TestUnwatchedPollConcurrentAddDeduplicatesUpdatedRootSet(t *testing.T) {
 	ticks := make(chan time.Time)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 4)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now, time.After,
 	)
 	t.Cleanup(coordinator.Stop)
 	parent := t.TempDir()
@@ -123,17 +122,17 @@ func TestUnwatchedPollConcurrentAddDeduplicatesUpdatedRootSet(t *testing.T) {
 	rootB := requireExistingPollRoot(t, parent, "root-b")
 	rootC := requireExistingPollRoot(t, parent, "root-c")
 
-	additions := [][]string{
-		{rootB, rootA},
-		{rootA, rootC},
-		{rootC, rootB},
+	additions := [][]pollingScope{
+		{{Root: rootB}, {Root: rootA}},
+		{{Root: rootA}, {Root: rootC}},
+		{{Root: rootC}, {Root: rootB}},
 	}
 	var wg sync.WaitGroup
 	addErrors := make(chan error, len(additions))
-	for i, roots := range additions {
+	for i, scopes := range additions {
 		wg.Go(func() {
 			addErrors <- coordinator.AddObligation(pollingObligation{
-				Key: fmt.Sprintf("direct-%d", i), Roots: roots,
+				Key: fmt.Sprintf("direct-%d", i), Scopes: scopes,
 			})
 		})
 	}
@@ -152,25 +151,23 @@ func TestUnwatchedPollTickUsesRootsAddedAfterStart(t *testing.T) {
 	ticks := make(chan time.Time, 1)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now, time.After,
 	)
 	t.Cleanup(coordinator.Stop)
 	parent := t.TempDir()
 	initial := requireExistingPollRoot(t, parent, "initial")
 	runtime := requireExistingPollRoot(t, parent, "runtime")
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "initial", Roots: []string{initial},
+		Key: "initial", Scopes: []pollingScope{{Root: initial}},
 	}))
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "runtime", Roots: []string{runtime},
+		Key: "runtime", Scopes: []pollingScope{{Root: runtime}},
 	}))
 
 	ticks <- time.Now()
 	requirePollWithin(t, syncer.wake, time.Second)
 
 	assert.Equal(t, [][]string{{initial, runtime}}, syncer.snapshot())
-	assert.Equal(t, []bool{false}, syncer.full,
-		"unwatched polling must reconcile the owned scopes authoritatively")
 }
 
 func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
@@ -184,11 +181,16 @@ func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, time.Now,
+		func(d time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
 	)
 	t.Cleanup(coordinator.Stop)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "provider-root", Roots: []string{root},
+		Key: "provider-root", Scopes: []pollingScope{{Root: root}},
 	}))
 
 	coordinator.requestPoll()
@@ -222,11 +224,16 @@ func TestUnwatchedPollDefersScopesWhileProbePathMissing(t *testing.T) {
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, time.Now,
+		func(d time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
 	)
 	t.Cleanup(coordinator.Stop)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: physical, Roots: []string{configured}, Probe: physical,
+		Key: physical, Scopes: []pollingScope{{Root: configured}}, Probe: physical,
 	}))
 
 	coordinator.requestPoll()
@@ -261,14 +268,19 @@ func TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing(t *testing.T) {
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, time.Now,
+		func(d time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
 	)
 	t.Cleanup(coordinator.Stop)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: configured, Roots: []string{configured}, Probe: configured,
+		Key: configured, Scopes: []pollingScope{{Root: configured}}, Probe: configured,
 	}))
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: sessions, Roots: []string{configured}, Probe: sessions,
+		Key: sessions, Scopes: []pollingScope{{Root: configured}}, Probe: sessions,
 	}))
 
 	coordinator.requestPoll()
@@ -310,31 +322,31 @@ func TestAvailableUnwatchedPollRootsDefersRootsOverlappingBlockedScopes(t *testi
 		{
 			name: "blocked descendant defers available ancestor",
 			obligations: []pollingObligation{
-				{Key: "base", Roots: []string{base, unrelated}},
-				{Key: "nested", Roots: []string{nested}, Probe: missingProbe},
+				{Key: "base", Scopes: []pollingScope{{Root: base}, {Root: unrelated}}},
+				{Key: "nested", Scopes: []pollingScope{{Root: nested}}, Probe: missingProbe},
 			},
 			want: []string{unrelated},
 		},
 		{
 			name: "blocked ancestor defers available descendant",
 			obligations: []pollingObligation{
-				{Key: "nested", Roots: []string{nested, unrelated}},
-				{Key: "base", Roots: []string{base}, Probe: filepath.Join(base, "gone")},
+				{Key: "nested", Scopes: []pollingScope{{Root: nested}, {Root: unrelated}}},
+				{Key: "base", Scopes: []pollingScope{{Root: base}}, Probe: filepath.Join(base, "gone")},
 			},
 			want: []string{unrelated},
 		},
 		{
 			name: "available probes keep overlapping roots pollable",
 			obligations: []pollingObligation{
-				{Key: "base", Roots: []string{base}},
-				{Key: "nested", Roots: []string{nested}, Probe: nested},
+				{Key: "base", Scopes: []pollingScope{{Root: base}}},
+				{Key: "nested", Scopes: []pollingScope{{Root: nested}}, Probe: nested},
 			},
 			want: []string{base, nested},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, availableUnwatchedPollRoots(tc.obligations))
+			assert.Equal(t, tc.want, availableUnwatchedPollRootsFlat(tc.obligations))
 		})
 	}
 }
@@ -361,21 +373,21 @@ func TestAvailableUnwatchedPollRootsBlocksMixedRelativeAndAbsoluteScopes(t *test
 		{
 			name: "relative blocked scope defers absolute descendant",
 			obligations: []pollingObligation{
-				{Key: "blocked", Roots: []string{"scope"}, Probe: missingProbe},
-				{Key: "poll", Roots: []string{sub}},
+				{Key: "blocked", Scopes: []pollingScope{{Root: "scope"}}, Probe: missingProbe},
+				{Key: "poll", Scopes: []pollingScope{{Root: sub}}},
 			},
 		},
 		{
 			name: "absolute blocked scope defers relative descendant",
 			obligations: []pollingObligation{
-				{Key: "blocked", Roots: []string{scope}, Probe: missingProbe},
-				{Key: "poll", Roots: []string{filepath.Join("scope", "sub")}},
+				{Key: "blocked", Scopes: []pollingScope{{Root: scope}}, Probe: missingProbe},
+				{Key: "poll", Scopes: []pollingScope{{Root: filepath.Join("scope", "sub")}}},
 			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Empty(t, availableUnwatchedPollRoots(tc.obligations),
+			assert.Empty(t, availableUnwatchedPollRootsFlat(tc.obligations),
 				"a blocked scope must defer overlapping roots regardless of "+
 					"the path form each side was configured with")
 		})
@@ -390,11 +402,11 @@ func TestAvailableUnwatchedPollRootsBlocksScopesUnderFilesystemRoot(t *testing.T
 	candidate := t.TempDir()
 	fsRoot := filepath.VolumeName(candidate) + string(filepath.Separator)
 	obligations := []pollingObligation{
-		{Key: "blocked", Roots: []string{fsRoot},
+		{Key: "blocked", Scopes: []pollingScope{{Root: fsRoot}},
 			Probe: filepath.Join(candidate, "missing-probe")},
-		{Key: "poll", Roots: []string{candidate}},
+		{Key: "poll", Scopes: []pollingScope{{Root: candidate}}},
 	}
-	assert.Empty(t, availableUnwatchedPollRoots(obligations),
+	assert.Empty(t, availableUnwatchedPollRootsFlat(obligations),
 		"a blocked filesystem-root scope must defer every candidate beneath it")
 }
 
@@ -431,12 +443,15 @@ func TestUnwatchedPollPreservesSessionsUnderBlockedOverlappingScope(t *testing.T
 	t.Cleanup(engine.Close)
 
 	obligations := []pollingObligation{
-		{Key: "persistent:" + base, Roots: []string{base}, Probe: base},
-		{Key: "nested-gate", Roots: []string{nested},
+		{Key: "persistent:" + base, Scopes: []pollingScope{{Root: base}}, Probe: base},
+		{Key: "nested-gate", Scopes: []pollingScope{{Root: nested}},
 			Probe: filepath.Join(nested, "missing-subtree")},
 	}
-	roots := availableUnwatchedPollRoots(obligations)
-	pollUnwatchedRootsOnce(t.Context(), engine, roots)
+	groups := availableUnwatchedPollScopes(obligations)
+	if err := pollUnwatchedScopesOnce(t.Context(), engine, groups); err != nil {
+		t.Logf("pollUnwatchedScopesOnce: %v", err)
+	}
+	roots := availableUnwatchedPollRootsFlat(obligations)
 
 	assert.Empty(t, roots,
 		"an ancestor overlapping a blocked scope must not stay pollable")
@@ -455,7 +470,12 @@ func TestUnwatchedPollObligationUpdatesRemainResponsiveDuringReconciliation(
 		release: make(chan struct{}),
 	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now,
+		func(d time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
 	)
 	t.Cleanup(func() {
 		select {
@@ -469,7 +489,7 @@ func TestUnwatchedPollObligationUpdatesRemainResponsiveDuringReconciliation(
 	initial := requireExistingPollRoot(t, parent, "initial")
 	replacement := requireExistingPollRoot(t, parent, "replacement")
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "initial", Roots: []string{initial},
+		Key: "initial", Scopes: []pollingScope{{Root: initial}},
 	}))
 
 	coordinator.requestPoll()
@@ -479,7 +499,7 @@ func TestUnwatchedPollObligationUpdatesRemainResponsiveDuringReconciliation(
 	addResult := make(chan error, 1)
 	go func() {
 		addResult <- coordinator.AddObligation(pollingObligation{
-			Key: "replacement", Roots: []string{replacement},
+			Key: "replacement", Scopes: []pollingScope{{Root: replacement}},
 		})
 	}()
 	require.NoError(t, requireReceivePollResult(t, addResult, time.Second),
@@ -509,7 +529,7 @@ func TestUnwatchedPollStopCancelsAndJoinsActiveReconciliation(t *testing.T) {
 	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		parentCtx, syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, time.Now, time.After,
 	)
 	t.Cleanup(func() {
 		cancelParent()
@@ -517,7 +537,7 @@ func TestUnwatchedPollStopCancelsAndJoinsActiveReconciliation(t *testing.T) {
 	})
 	owned := requireExistingPollRoot(t, t.TempDir(), "owned")
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "owned", Roots: []string{owned},
+		Key: "owned", Scopes: []pollingScope{{Root: owned}},
 	}))
 	coordinator.requestPoll()
 	requirePollWithin(t, syncer.started, time.Second)
@@ -549,7 +569,7 @@ func TestUnwatchedPollParentCancellationCancelsJoinsAndRejectsUpdates(
 	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		parentCtx, syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, time.Now, time.After,
 	)
 	t.Cleanup(func() {
 		cancelParent()
@@ -557,7 +577,7 @@ func TestUnwatchedPollParentCancellationCancelsJoinsAndRejectsUpdates(
 	})
 	owned := requireExistingPollRoot(t, t.TempDir(), "owned")
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "owned", Roots: []string{owned},
+		Key: "owned", Scopes: []pollingScope{{Root: owned}},
 	}))
 	coordinator.requestPoll()
 	requirePollWithin(t, syncer.started, time.Second)
@@ -573,7 +593,7 @@ func TestUnwatchedPollParentCancellationCancelsJoinsAndRejectsUpdates(
 	lateUpdate := make(chan error, 1)
 	go func() {
 		lateUpdate <- coordinator.AddObligation(pollingObligation{
-			Key: "late", Roots: []string{"/late"},
+			Key: "late", Scopes: []pollingScope{{Root: "/late"}},
 		})
 	}()
 	assert.ErrorIs(t, requireReceivePollResult(t, lateUpdate, time.Second),
@@ -585,17 +605,17 @@ func TestUnwatchedPollRemoveRootsStopsReconciliationAfterNativeRecovery(t *testi
 	ticks := make(chan time.Time, 1)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now, time.After,
 	)
 	t.Cleanup(coordinator.Stop)
 	parent := t.TempDir()
 	recovered := requireExistingPollRoot(t, parent, "recovered")
 	stillUnwatched := requireExistingPollRoot(t, parent, "still-unwatched")
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "recovered-watch", Roots: []string{recovered},
+		Key: "recovered-watch", Scopes: []pollingScope{{Root: recovered}},
 	}))
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "still-unwatched", Roots: []string{stillUnwatched},
+		Key: "still-unwatched", Scopes: []pollingScope{{Root: stillUnwatched}},
 	}))
 	require.NoError(t, coordinator.RemoveObligation("recovered-watch"))
 
@@ -609,17 +629,17 @@ func TestUnwatchedPollRemovingOneOverlappingObligationKeepsSharedRoot(t *testing
 	ticks := make(chan time.Time)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now, time.After,
 	)
 	t.Cleanup(coordinator.Stop)
 	parent := t.TempDir()
 	shared := requireExistingPollRoot(t, parent, "shared")
 	persistentOnly := requireExistingPollRoot(t, parent, "persistent-only")
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "pending", Roots: []string{shared},
+		Key: "pending", Scopes: []pollingScope{{Root: shared}},
 	}))
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "persistent", Roots: []string{shared, persistentOnly},
+		Key: "persistent", Scopes: []pollingScope{{Root: shared}, {Root: persistentOnly}},
 	}))
 	require.NoError(t, coordinator.RemoveObligation("pending"))
 
@@ -634,7 +654,7 @@ func TestUnwatchedPollEmptyObligationNeverExpandsToFullReconciliation(t *testing
 	ticks := make(chan time.Time)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now, time.After,
 	)
 	t.Cleanup(coordinator.Stop)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{Key: "empty"}))
@@ -649,10 +669,10 @@ func TestUnwatchedPollStopIsConcurrentAndRejectsLaterRoots(t *testing.T) {
 	ticks := make(chan time.Time)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now, time.After,
 	)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "owned", Roots: []string{"/owned"},
+		Key: "owned", Scopes: []pollingScope{{Root: "/owned"}},
 	}))
 
 	var wg sync.WaitGroup
@@ -664,7 +684,7 @@ func TestUnwatchedPollStopIsConcurrentAndRejectsLaterRoots(t *testing.T) {
 	wg.Wait()
 
 	assert.ErrorIs(t, coordinator.AddObligation(pollingObligation{
-		Key: "late", Roots: []string{"/late"},
+		Key: "late", Scopes: []pollingScope{{Root: "/late"}},
 	}), errUnwatchedPollStopped)
 	coordinator.requestPoll()
 	assert.Empty(t, syncer.snapshot())
@@ -680,7 +700,7 @@ func TestUnwatchedPollAddObligationRacingStopReturnsOwnershipOrStopped(t *testin
 			context.Background(), syncer, ticks, func() {}, func(run func()) { run() },
 			func(roots []string) {
 				ownedSnapshots <- append([]string(nil), roots...)
-			},
+			}, time.Now, time.After,
 		)
 		start := make(chan struct{})
 		addResult := make(chan error, 1)
@@ -689,7 +709,7 @@ func TestUnwatchedPollAddObligationRacingStopReturnsOwnershipOrStopped(t *testin
 		go func() {
 			<-start
 			addResult <- coordinator.AddObligation(pollingObligation{
-				Key: root, Roots: []string{root},
+				Key: root, Scopes: []pollingScope{{Root: root}},
 			})
 		}()
 		go func() {
@@ -709,11 +729,133 @@ func TestUnwatchedPollAddObligationRacingStopReturnsOwnershipOrStopped(t *testin
 		}
 		assert.ErrorIs(t,
 			coordinator.AddObligation(pollingObligation{
-				Key:   fmt.Sprintf("/late-root-%d", i),
-				Roots: []string{fmt.Sprintf("/late-root-%d", i)},
+				Key:    fmt.Sprintf("/late-root-%d", i),
+				Scopes: []pollingScope{{Root: fmt.Sprintf("/late-root-%d", i)}},
 			}),
 			errUnwatchedPollStopped,
 		)
+	}
+}
+
+// availableUnwatchedPollRootsFlat is a test helper that flattens the
+// per-agent groups from availableUnwatchedPollScopes into one sorted []string.
+func availableUnwatchedPollRootsFlat(obligations []pollingObligation) []string {
+	groups := availableUnwatchedPollScopes(obligations)
+	unique := make(map[string]struct{})
+	for _, roots := range groups {
+		for _, r := range roots {
+			unique[r] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(unique))
+	for r := range unique {
+		result = append(result, r)
+	}
+	slices.Sort(result)
+	return result
+}
+
+// TestCrossAgentBlockingBothDirections verifies cross-agent deferral: the empty
+// agent means "every provider" for deferral purposes, so blocking must be
+// conservative in both directions.
+//
+//   - Direction A: a missing probe on an empty-agent obligation must also block
+//     a named-agent candidate for the same root.
+//   - Direction B: a missing probe on a named-agent obligation must also block
+//     an empty-agent candidate for the same root.
+//
+// Without the fix, availableUnwatchedPollScopes only checks blocked[scope.Agent]
+// for each candidate; cross-agent blocks (where the blocking obligation uses a
+// different agent) are invisible and the candidate is polled despite the gate.
+//
+// Ancestor and descendant cases are included in both directions so that
+// overlapsDeferredScope is load-bearing: plain string equality between the
+// blocked root and the candidate root would leave those cases unprotected.
+func TestCrossAgentBlockingBothDirections(t *testing.T) {
+	parent := t.TempDir()
+	dir := requireExistingPollRoot(t, parent, "shared-dir")
+	childDir := requireExistingPollRoot(t, dir, "child")
+	missingProbe := filepath.Join(parent, "missing-probe") // does not exist
+
+	tests := []struct {
+		name            string
+		obligations     []pollingObligation
+		wantAbsentAgent parser.AgentType
+		wantAbsentRoot  string
+	}{
+		// Exact-root cases (original coverage, kept for regression).
+		{
+			name: "empty_agent_blocked_defers_named_agent_exact",
+			obligations: []pollingObligation{
+				{Key: "k1", Probe: missingProbe, Scopes: []pollingScope{{Agent: parser.AgentType(""), Root: dir}}},
+				{Key: "k2", Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: dir}}},
+			},
+			wantAbsentAgent: parser.AgentGemini,
+			wantAbsentRoot:  dir,
+		},
+		{
+			name: "named_agent_blocked_defers_empty_agent_exact",
+			obligations: []pollingObligation{
+				{Key: "k1", Probe: missingProbe, Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: dir}}},
+				{Key: "k2", Scopes: []pollingScope{{Agent: parser.AgentType(""), Root: dir}}},
+			},
+			wantAbsentAgent: parser.AgentType(""),
+			wantAbsentRoot:  dir,
+		},
+		// Ancestor-blocked cases: the blocked scope's Root is an ancestor of the
+		// candidate's Root. Plain string equality would miss this relationship;
+		// overlapsDeferredScope must be called to detect it.
+		{
+			name: "empty_agent_ancestor_blocked_defers_named_agent_descendant",
+			obligations: []pollingObligation{
+				// empty agent blocked at parent; candidate is a child of parent
+				{Key: "k1", Probe: missingProbe, Scopes: []pollingScope{{Agent: parser.AgentType(""), Root: dir}}},
+				{Key: "k2", Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: childDir}}},
+			},
+			wantAbsentAgent: parser.AgentGemini,
+			wantAbsentRoot:  childDir,
+		},
+		{
+			name: "named_agent_ancestor_blocked_defers_empty_agent_descendant",
+			obligations: []pollingObligation{
+				// named agent blocked at parent; candidate is a child of parent
+				{Key: "k1", Probe: missingProbe, Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: dir}}},
+				{Key: "k2", Scopes: []pollingScope{{Agent: parser.AgentType(""), Root: childDir}}},
+			},
+			wantAbsentAgent: parser.AgentType(""),
+			wantAbsentRoot:  childDir,
+		},
+		// Descendant-blocked cases: the blocked scope's Root is a descendant of
+		// the candidate's Root. Plain string equality would miss this too.
+		{
+			name: "empty_agent_descendant_blocked_defers_named_agent_ancestor",
+			obligations: []pollingObligation{
+				// empty agent blocked at child; candidate is the parent of child
+				{Key: "k1", Probe: missingProbe, Scopes: []pollingScope{{Agent: parser.AgentType(""), Root: childDir}}},
+				{Key: "k2", Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: dir}}},
+			},
+			wantAbsentAgent: parser.AgentGemini,
+			wantAbsentRoot:  dir,
+		},
+		{
+			name: "named_agent_descendant_blocked_defers_empty_agent_ancestor",
+			obligations: []pollingObligation{
+				// named agent blocked at child; candidate is the parent of child
+				{Key: "k1", Probe: missingProbe, Scopes: []pollingScope{{Agent: parser.AgentGemini, Root: childDir}}},
+				{Key: "k2", Scopes: []pollingScope{{Agent: parser.AgentType(""), Root: dir}}},
+			},
+			wantAbsentAgent: parser.AgentType(""),
+			wantAbsentRoot:  dir,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := availableUnwatchedPollScopes(tc.obligations)
+			roots := result[tc.wantAbsentAgent]
+			assert.NotContains(t, roots, tc.wantAbsentRoot,
+				"cross-agent blocking must prevent root from appearing in %q group",
+				tc.wantAbsentAgent)
+		})
 	}
 }
 

--- a/cmd/agentsview/watch_obligations_scope_test.go
+++ b/cmd/agentsview/watch_obligations_scope_test.go
@@ -1,0 +1,69 @@
+package main
+
+// TestWatchPollingObligationsKeepProvidersIndependentOnOneRoot tests that two
+// agents configured at one physical root produce two independent obligations with
+// distinct keys rather than one merged obligation. This is the fault test for
+// Obligation keys must stay independent per provider on a shared root.
+//
+// Base: one obligation keyed on the bare root path, both sync dirs merged.
+// Head: two obligations, distinct keys, one agent each.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+	agentsync "go.kenn.io/agentsview/internal/sync"
+)
+
+func TestWatchPollingObligationsKeepProvidersIndependentOnOneRoot(t *testing.T) {
+	// One physical root shared by two agents.
+	parent := t.TempDir()
+	physicalRoot := filepath.Join(parent, "sessions")
+
+	syncDirA := filepath.Join(parent, "agent-a-sync")
+	syncDirB := filepath.Join(parent, "agent-b-sync")
+
+	roots := []watchRoot{
+		{
+			path: physicalRoot,
+			scopes: []watchScope{
+				{agent: parser.AgentClaude, syncDir: syncDirA},
+				{agent: parser.AgentOpenHands, syncDir: syncDirB},
+			},
+		},
+	}
+
+	// No watcher result for this root → triggers the "no watcher" branch
+	// (i >= len(results)), which currently uses root.path as the key for
+	// both agents and produces a single merged obligation.
+	got := watchPollingObligations(roots, nil, nil, nil)
+
+	// Head assertion: two obligations, one per agent, distinct keys.
+	require.Len(t, got, 2,
+		"two agents sharing one physical root must produce two independent obligations")
+
+	// Each obligation must have exactly one agent's scope.
+	agentSeen := make(map[parser.AgentType]bool)
+	for _, ob := range got {
+		require.Len(t, ob.Scopes, 1,
+			"each obligation must carry exactly one agent's scope")
+		agent := parser.AgentType(ob.Scopes[0].Agent)
+		assert.False(t, agentSeen[agent],
+			"each agent must appear in exactly one obligation")
+		agentSeen[agent] = true
+	}
+	assert.True(t, agentSeen[parser.AgentClaude],
+		"obligation for agent-a must be present")
+	assert.True(t, agentSeen[parser.AgentOpenHands],
+		"obligation for agent-b must be present")
+
+	// Keys must be distinct.
+	assert.NotEqual(t, got[0].Key, got[1].Key,
+		"distinct agents must have distinct obligation keys")
+
+	// Verify the type matches what the sync package declares.
+	_ = []agentsync.PollingObligation(got)
+}

--- a/cmd/agentsview/watch_obligations_scope_test.go
+++ b/cmd/agentsview/watch_obligations_scope_test.go
@@ -1,12 +1,8 @@
 package main
 
 // TestWatchPollingObligationsKeepProvidersIndependentOnOneRoot tests that two
-// agents configured at one physical root produce two independent obligations with
-// distinct keys rather than one merged obligation. This is the fault test for
-// Obligation keys must stay independent per provider on a shared root.
-//
-// Base: one obligation keyed on the bare root path, both sync dirs merged.
-// Head: two obligations, distinct keys, one agent each.
+// agents configured at one physical root produce two independent obligations
+// with distinct keys rather than one merged obligation.
 
 import (
 	"path/filepath"
@@ -15,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/parser"
-	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
 func TestWatchPollingObligationsKeepProvidersIndependentOnOneRoot(t *testing.T) {
@@ -37,11 +32,9 @@ func TestWatchPollingObligationsKeepProvidersIndependentOnOneRoot(t *testing.T) 
 	}
 
 	// No watcher result for this root → triggers the "no watcher" branch
-	// (i >= len(results)), which currently uses root.path as the key for
-	// both agents and produces a single merged obligation.
+	// (i >= len(results)).
 	got := watchPollingObligations(roots, nil, nil, nil)
 
-	// Head assertion: two obligations, one per agent, distinct keys.
 	require.Len(t, got, 2,
 		"two agents sharing one physical root must produce two independent obligations")
 
@@ -63,7 +56,4 @@ func TestWatchPollingObligationsKeepProvidersIndependentOnOneRoot(t *testing.T) 
 	// Keys must be distinct.
 	assert.NotEqual(t, got[0].Key, got[1].Key,
 		"distinct agents must have distinct obligation keys")
-
-	// Verify the type matches what the sync package declares.
-	_ = []agentsync.PollingObligation(got)
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3219,6 +3219,9 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 		linkEligible := false
 		persistEligible := false
 		for _, group := range groups {
+			if ctx.Err() != nil {
+				break
+			}
 			stats, tombstoned, err := e.reconcileScopedWatchRootsLocked(
 				deferredCtx, group.Agent, group.Roots, false, false,
 			)
@@ -3237,6 +3240,17 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 				agent = "unscoped"
 			}
 			errs = append(errs, fmt.Errorf("reconcile %s roots: %w", agent, err))
+		}
+		// A canceled batch skips the epilogue entirely: linking and skip-cache
+		// persistence are not context-aware, and shutdown must not block on
+		// archive-sized database work. In-memory skip promotions survive and
+		// persist on the next clean pass; the returned error keeps the batch
+		// from being mistaken for a completed one.
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"grouped reconciliation epilogue skipped: %w", err,
+			))
+			return
 		}
 		if linkEligible {
 			if err := e.linkSubagentSessions(ctx); err != nil {
@@ -3382,7 +3396,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 	} else if scope != nil {
 		scope.agent = agent
 	}
-	preContainerStates := e.captureSQLiteContainerStatesForAgent(agent)
+	preContainerStates := e.captureSQLiteContainerStatesForAgent(agent, roots)
 	providers, completedScopes, failedRoots,
 		failures, discoveryErr, err := e.streamReconciliationCandidates(
 		ctx, scope, spool,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -53,6 +53,17 @@ func passEpilogueDeferred(ctx context.Context) bool {
 	return deferred
 }
 
+// passEpilogueEligibility records, at the per-pass gate sites, whether a
+// pass would have run global subagent linking and skip-cache persistence.
+// Grouped callers consume it instead of inferring eligibility from the
+// pass's final error: that error also reflects later tombstoning and spool
+// cleanup failures, which never suppressed the per-pass epilogue and must
+// not suppress the shared one.
+type passEpilogueEligibility struct {
+	link    bool
+	persist bool
+}
+
 type reconciliationBaselineTracker struct {
 	sources     map[db.SessionSourcePath]struct{}
 	cacheWrites map[string]skipCacheWrite
@@ -3203,10 +3214,11 @@ type ProviderRootsGroup struct {
 // resurrecting removed entries after a restart. "sessions" emits happen after
 // the lock is released, coalesced into one event for the batch.
 //
-// Linking runs when any group committed its page writes (a clean pass or one
-// reporting only provider discovery failures), matching the per-pass rule.
-// The skip cache persists when any group completed cleanly, mirroring the
-// per-pass retErr == nil condition.
+// Epilogue eligibility is recorded at each pass's own gate sites — after
+// page writes commit, before tombstoning and spool cleanup — so a later
+// tombstoning or cleanup failure in one group cannot leave successfully
+// synced sessions unlinked or the skip cache unpersisted, matching the
+// per-pass ordering exactly.
 func (e *Engine) ReconcileProviderRootsGrouped(
 	ctx context.Context, groups []ProviderRootsGroup,
 ) error {
@@ -3222,18 +3234,14 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 			if ctx.Err() != nil {
 				break
 			}
-			stats, tombstoned, err := e.reconcileScopedWatchRootsLocked(
+			stats, tombstoned, eligibility, err := e.reconcileScopedWatchRootsLocked(
 				deferredCtx, group.Agent, group.Roots, false, false,
 			)
 			changed = changed || stats.Synced > 0 || tombstoned > 0
+			linkEligible = linkEligible || eligibility.link
+			persistEligible = persistEligible || eligibility.persist
 			if err == nil {
-				linkEligible = true
-				persistEligible = true
 				continue
-			}
-			var incomplete *incompleteReconciliationError
-			if errors.As(err, &incomplete) {
-				linkEligible = true
 			}
 			agent := string(group.Agent)
 			if agent == "" {
@@ -3272,7 +3280,7 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 func (e *Engine) reconcileScopedWatchRoots(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
 ) (SyncStats, int, error) {
-	stats, tombstoned, err := func() (SyncStats, int, error) {
+	stats, tombstoned, _, err := func() (SyncStats, int, passEpilogueEligibility, error) {
 		e.syncMu.Lock()
 		defer e.syncMu.Unlock()
 		return e.reconcileScopedWatchRootsLocked(ctx, agent, roots, full, force)
@@ -3287,10 +3295,12 @@ func (e *Engine) reconcileScopedWatchRoots(
 
 // reconcileScopedWatchRootsLocked is the scoped pass body. The caller holds
 // syncMu and is responsible for emitting "sessions" when the returned stats
-// or tombstone count report changes.
+// or tombstone count report changes. The returned eligibility reflects the
+// per-pass epilogue gates so a deferring caller can run the shared epilogue
+// exactly when the pass itself would have.
 func (e *Engine) reconcileScopedWatchRootsLocked(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
-) (SyncStats, int, error) {
+) (SyncStats, int, passEpilogueEligibility, error) {
 	var logicalRoots []string
 	var excludedRemoteRoots int
 	if agent == "" {
@@ -3303,9 +3313,9 @@ func (e *Engine) reconcileScopedWatchRootsLocked(
 			Complete: true,
 			Metrics:  ReconciliationMetrics{ExcludedRemoteRoots: excludedRemoteRoots},
 		})
-		return SyncStats{}, 0, nil
+		return SyncStats{}, 0, passEpilogueEligibility{}, nil
 	}
-	stats, metrics, tombstoned, err := e.reconcileWatchRootsStreamedLocked(
+	stats, metrics, tombstoned, eligibility, err := e.reconcileWatchRootsStreamedLocked(
 		ctx, agent, logicalRoots, full, force,
 	)
 	metrics.ExcludedRemoteRoots = excludedRemoteRoots
@@ -3320,7 +3330,7 @@ func (e *Engine) reconcileScopedWatchRootsLocked(
 		ProviderFailures: stats.providerFailures,
 		Metrics:          metrics,
 	})
-	return stats, tombstoned, err
+	return stats, tombstoned, eligibility, err
 }
 
 // ReconcileWatchRootsAfterLostEvents is the watcher-overflow entrypoint. It is
@@ -3345,9 +3355,12 @@ func (e *Engine) ReconciliationRootsForAgent(agent string) []string {
 // shared epilogue so no other pass can interleave with a pending epilogue.
 func (e *Engine) reconcileWatchRootsStreamedLocked(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
-) (stats SyncStats, metrics ReconciliationMetrics, tombstoned int, retErr error) {
+) (
+	stats SyncStats, metrics ReconciliationMetrics, tombstoned int,
+	eligibility passEpilogueEligibility, retErr error,
+) {
 	if err := ctx.Err(); err != nil {
-		return SyncStats{Aborted: true}, metrics, 0, err
+		return SyncStats{Aborted: true}, metrics, 0, eligibility, err
 	}
 	if force {
 		e.clearWatcherOverflowCaches()
@@ -3365,7 +3378,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 	ctx, closeProviderCache, err := parser.WithReconciliationCache(ctx)
 	if err != nil {
 		stats.Aborted = true
-		return stats, metrics, 0, err
+		return stats, metrics, 0, eligibility, err
 	}
 	defer func() {
 		if cleanupErr := closeProviderCache(); cleanupErr != nil {
@@ -3381,7 +3394,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 	spool, err := e.reconciliationSpoolFactory(e.db.Path())
 	if err != nil {
 		stats.Aborted = true
-		return stats, metrics, 0, err
+		return stats, metrics, 0, eligibility, err
 	}
 	cleaned := false
 	defer func() {
@@ -3409,7 +3422,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 			err = errors.Join(err, cleanupErr)
 		}
 		cleaned = true
-		return stats, metrics, 0, err
+		return stats, metrics, 0, eligibility, err
 	}
 	authoritativeProviders := make(map[parser.AgentType]struct{}, len(completedScopes))
 	for _, completed := range completedScopes {
@@ -3515,11 +3528,13 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 	// error or a failed write; provider discovery failures are layered on
 	// below and must not suppress work that only depends on committed writes.
 	// A grouped caller (passEpilogueDeferred) runs linking once after every
-	// group instead; tombstoning below then proceeds without the linking
-	// gate, which is safe because linking is idempotent and retried on the
-	// caller's next pass.
-	if retErr == nil && stats.Failed == 0 && !stats.Aborted &&
-		!passEpilogueDeferred(ctx) {
+	// group instead, consuming the eligibility recorded here; tombstoning
+	// below then proceeds without the linking gate, which is safe because
+	// linking is idempotent and retried on the caller's next pass.
+	if retErr == nil && stats.Failed == 0 && !stats.Aborted {
+		eligibility.link = true
+	}
+	if eligibility.link && !passEpilogueDeferred(ctx) {
 		// Batch-level linking was deferred to this global pass, so run it
 		// whenever the committed page writes succeeded — including partial
 		// provider failures. Sessions from healthy providers are already in
@@ -3566,6 +3581,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 		)
 	}
 	if retErr == nil {
+		eligibility.persist = true
 		if !passEpilogueDeferred(ctx) {
 			e.persistSkipCache()
 		}
@@ -3599,7 +3615,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 		retErr = errors.Join(retErr, cleanupErr)
 	}
 	cleaned = true
-	return stats, metrics, tombstoned, retErr
+	return stats, metrics, tombstoned, eligibility, retErr
 }
 
 func (e *Engine) tombstoneCompletedReconciliationScopesLocked(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -43,6 +43,15 @@ var errSessionPreserved = errors.New("session preserved")
 type reconciliationMetricsContextKey struct{}
 type reconciliationBaselineContextKey struct{}
 type deferGlobalLinkContextKey struct{}
+type deferPassEpilogueContextKey struct{}
+
+// passEpilogueDeferred reports whether a grouped caller owns the pass
+// epilogue — global subagent linking and skip-cache persistence — so a
+// scoped reconciliation must not repeat that archive-sized work itself.
+func passEpilogueDeferred(ctx context.Context) bool {
+	deferred, _ := ctx.Value(deferPassEpilogueContextKey{}).(bool)
+	return deferred
+}
 
 type reconciliationBaselineTracker struct {
 	sources     map[db.SessionSourcePath]struct{}
@@ -3174,6 +3183,61 @@ func (e *Engine) ReconcileProviderRoots(
 	return err
 }
 
+// ProviderRootsGroup pairs one provider with the roots of its bounded
+// scheduled pass. An empty Agent runs the unscoped local reconciliation path.
+type ProviderRootsGroup struct {
+	Agent parser.AgentType
+	Roots []string
+}
+
+// ReconcileProviderRootsGrouped runs ReconcileProviderRoots for every group
+// and shares one pass epilogue — global subagent linking and skip-cache
+// persistence — across the whole batch, so a multi-provider poll performs
+// that archive-sized work once instead of once per provider. Every group is
+// attempted even when an earlier one fails; per-group failures are wrapped
+// with the provider and joined.
+//
+// Linking runs when any group committed its page writes (a clean pass or one
+// reporting only provider discovery failures), matching the per-pass rule.
+// The skip cache persists when any group completed cleanly, mirroring the
+// per-pass retErr == nil condition.
+func (e *Engine) ReconcileProviderRootsGrouped(
+	ctx context.Context, groups []ProviderRootsGroup,
+) error {
+	deferredCtx := context.WithValue(ctx, deferPassEpilogueContextKey{}, true)
+	var errs []error
+	linkEligible := false
+	persistEligible := false
+	for _, group := range groups {
+		err := e.ReconcileProviderRoots(deferredCtx, group.Agent, group.Roots)
+		if err == nil {
+			linkEligible = true
+			persistEligible = true
+			continue
+		}
+		var incomplete *incompleteReconciliationError
+		if errors.As(err, &incomplete) {
+			linkEligible = true
+		}
+		agent := string(group.Agent)
+		if agent == "" {
+			agent = "unscoped"
+		}
+		errs = append(errs, fmt.Errorf("reconcile %s roots: %w", agent, err))
+	}
+	if linkEligible {
+		if err := e.linkSubagentSessions(ctx); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"link subagent sessions after grouped reconciliation: %w", err,
+			))
+		}
+	}
+	if persistEligible {
+		e.persistSkipCache()
+	}
+	return errors.Join(errs...)
+}
+
 func (e *Engine) reconcileScopedWatchRoots(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
 ) (SyncStats, int, error) {
@@ -3401,7 +3465,12 @@ func (e *Engine) reconcileWatchRootsStreamed(
 	// Page writes committed cleanly when the paging loop finished without an
 	// error or a failed write; provider discovery failures are layered on
 	// below and must not suppress work that only depends on committed writes.
-	if retErr == nil && stats.Failed == 0 && !stats.Aborted {
+	// A grouped caller (passEpilogueDeferred) runs linking once after every
+	// group instead; tombstoning below then proceeds without the linking
+	// gate, which is safe because linking is idempotent and retried on the
+	// caller's next pass.
+	if retErr == nil && stats.Failed == 0 && !stats.Aborted &&
+		!passEpilogueDeferred(ctx) {
 		// Batch-level linking was deferred to this global pass, so run it
 		// whenever the committed page writes succeeded — including partial
 		// provider failures. Sessions from healthy providers are already in
@@ -3448,7 +3517,9 @@ func (e *Engine) reconcileWatchRootsStreamed(
 		)
 	}
 	if retErr == nil {
-		e.persistSkipCache()
+		if !passEpilogueDeferred(ctx) {
+			e.persistSkipCache()
+		}
 		e.mu.Lock()
 		e.lastSync = time.Now()
 		e.lastSyncStats = stats

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3190,12 +3190,18 @@ type ProviderRootsGroup struct {
 	Roots []string
 }
 
-// ReconcileProviderRootsGrouped runs ReconcileProviderRoots for every group
-// and shares one pass epilogue — global subagent linking and skip-cache
+// ReconcileProviderRootsGrouped runs the bounded scheduled pass for every
+// group and shares one pass epilogue — global subagent linking and skip-cache
 // persistence — across the whole batch, so a multi-provider poll performs
 // that archive-sized work once instead of once per provider. Every group is
 // attempted even when an earlier one fails; per-group failures are wrapped
 // with the provider and joined.
+//
+// syncMu is held across every group and the epilogue: releasing it between a
+// group and the deferred persistSkipCache would let a concurrent pass update
+// and persist newer skip state that the epilogue's snapshot then overwrites,
+// resurrecting removed entries after a restart. "sessions" emits happen after
+// the lock is released, coalesced into one event for the batch.
 //
 // Linking runs when any group committed its page writes (a clean pass or one
 // reporting only provider discovery failures), matching the per-pass rule.
@@ -3206,39 +3212,69 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 ) error {
 	deferredCtx := context.WithValue(ctx, deferPassEpilogueContextKey{}, true)
 	var errs []error
-	linkEligible := false
-	persistEligible := false
-	for _, group := range groups {
-		err := e.ReconcileProviderRoots(deferredCtx, group.Agent, group.Roots)
-		if err == nil {
-			linkEligible = true
-			persistEligible = true
-			continue
+	changed := false
+	func() {
+		e.syncMu.Lock()
+		defer e.syncMu.Unlock()
+		linkEligible := false
+		persistEligible := false
+		for _, group := range groups {
+			stats, tombstoned, err := e.reconcileScopedWatchRootsLocked(
+				deferredCtx, group.Agent, group.Roots, false, false,
+			)
+			changed = changed || stats.Synced > 0 || tombstoned > 0
+			if err == nil {
+				linkEligible = true
+				persistEligible = true
+				continue
+			}
+			var incomplete *incompleteReconciliationError
+			if errors.As(err, &incomplete) {
+				linkEligible = true
+			}
+			agent := string(group.Agent)
+			if agent == "" {
+				agent = "unscoped"
+			}
+			errs = append(errs, fmt.Errorf("reconcile %s roots: %w", agent, err))
 		}
-		var incomplete *incompleteReconciliationError
-		if errors.As(err, &incomplete) {
-			linkEligible = true
+		if linkEligible {
+			if err := e.linkSubagentSessions(ctx); err != nil {
+				errs = append(errs, fmt.Errorf(
+					"link subagent sessions after grouped reconciliation: %w", err,
+				))
+			}
 		}
-		agent := string(group.Agent)
-		if agent == "" {
-			agent = "unscoped"
+		if persistEligible {
+			e.persistSkipCache()
 		}
-		errs = append(errs, fmt.Errorf("reconcile %s roots: %w", agent, err))
-	}
-	if linkEligible {
-		if err := e.linkSubagentSessions(ctx); err != nil {
-			errs = append(errs, fmt.Errorf(
-				"link subagent sessions after grouped reconciliation: %w", err,
-			))
-		}
-	}
-	if persistEligible {
-		e.persistSkipCache()
+	}()
+	if changed {
+		e.emit("sessions")
 	}
 	return errors.Join(errs...)
 }
 
 func (e *Engine) reconcileScopedWatchRoots(
+	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
+) (SyncStats, int, error) {
+	stats, tombstoned, err := func() (SyncStats, int, error) {
+		e.syncMu.Lock()
+		defer e.syncMu.Unlock()
+		return e.reconcileScopedWatchRootsLocked(ctx, agent, roots, full, force)
+	}()
+	// Emit outside syncMu so an Emitter implementation cannot widen the
+	// critical section or deadlock by re-entering sync code (see SyncAll).
+	if stats.Synced > 0 || tombstoned > 0 {
+		e.emit("sessions")
+	}
+	return stats, tombstoned, err
+}
+
+// reconcileScopedWatchRootsLocked is the scoped pass body. The caller holds
+// syncMu and is responsible for emitting "sessions" when the returned stats
+// or tombstone count report changes.
+func (e *Engine) reconcileScopedWatchRootsLocked(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
 ) (SyncStats, int, error) {
 	var logicalRoots []string
@@ -3255,13 +3291,10 @@ func (e *Engine) reconcileScopedWatchRoots(
 		})
 		return SyncStats{}, 0, nil
 	}
-	stats, metrics, tombstoned, err := e.reconcileWatchRootsStreamed(
+	stats, metrics, tombstoned, err := e.reconcileWatchRootsStreamedLocked(
 		ctx, agent, logicalRoots, full, force,
 	)
 	metrics.ExcludedRemoteRoots = excludedRemoteRoots
-	if stats.Synced > 0 || tombstoned > 0 {
-		e.emit("sessions")
-	}
 	complete := err == nil && ctx.Err() == nil && !stats.Aborted &&
 		stats.Failed == 0 && stats.providerFailures == 0
 	if err == nil && !complete {
@@ -3292,14 +3325,16 @@ func (e *Engine) ReconciliationRootsForAgent(agent string) []string {
 	return append([]string(nil), e.agentDirs[parser.AgentType(agent)]...)
 }
 
-func (e *Engine) reconcileWatchRootsStreamed(
+// reconcileWatchRootsStreamedLocked runs one streamed reconciliation pass.
+// The caller must hold syncMu: reconcileScopedWatchRoots takes it per pass,
+// and ReconcileProviderRootsGrouped holds it across every group plus the
+// shared epilogue so no other pass can interleave with a pending epilogue.
+func (e *Engine) reconcileWatchRootsStreamedLocked(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
 ) (stats SyncStats, metrics ReconciliationMetrics, tombstoned int, retErr error) {
 	if err := ctx.Err(); err != nil {
 		return SyncStats{Aborted: true}, metrics, 0, err
 	}
-	e.syncMu.Lock()
-	defer e.syncMu.Unlock()
 	if force {
 		e.clearWatcherOverflowCaches()
 	}
@@ -3347,7 +3382,7 @@ func (e *Engine) reconcileWatchRootsStreamed(
 	} else if scope != nil {
 		scope.agent = agent
 	}
-	preContainerStates := e.captureSQLiteContainerStates(nil)
+	preContainerStates := e.captureSQLiteContainerStatesForAgent(agent)
 	providers, completedScopes, failedRoots,
 		failures, discoveryErr, err := e.streamReconciliationCandidates(
 		ctx, scope, spool,

--- a/internal/sync/grouped_reconcile_test.go
+++ b/internal/sync/grouped_reconcile_test.go
@@ -1,0 +1,187 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+func writeGroupedClaudeFixture(t *testing.T, root, name string) {
+	t.Helper()
+	path := filepath.Join(root, "project", name+".jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2024-01-01T00:00:00Z", "grouped fixture").
+			String()),
+		0o644,
+	))
+}
+
+// seedGroupedSubagentFixture inserts a parent/child pair whose tool call
+// references the child, so the shared epilogue's subagent linking pass has
+// observable work. The rows live outside every reconciled root and under a
+// different agent, keeping them out of scoped tombstoning.
+func seedGroupedSubagentFixture(t *testing.T, database *db.DB) {
+	t.Helper()
+	fixturePath := filepath.Join(t.TempDir(), "fixture.jsonl")
+	size := int64(1)
+	mtime := int64(1)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "grouped-parent", Agent: "zencoder", Project: "project",
+		Machine: "local", FilePath: &fixturePath, FileSize: &size,
+		FileMtime: &mtime, MessageCount: 1,
+	}))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "grouped-child", Agent: "zencoder", Project: "project",
+		Machine: "local", FilePath: &fixturePath, FileSize: &size,
+		FileMtime: &mtime, MessageCount: 1,
+		RelationshipType: "continuation",
+	}))
+	require.NoError(t, database.InsertMessages([]db.Message{{
+		SessionID: "grouped-parent", Ordinal: 0, Role: "assistant",
+		Content: "spawning subagent", HasToolUse: true,
+		ToolCalls: []db.ToolCall{{
+			ToolUseID: "call-1", ToolName: "Task",
+			SubagentSessionID: "grouped-child",
+		}},
+	}}))
+}
+
+func requireGroupedChildParent(
+	t *testing.T, database *db.DB, wantLinked bool, msg string,
+) {
+	t.Helper()
+	child, err := database.GetSession(context.Background(), "grouped-child")
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	if wantLinked {
+		require.NotNil(t, child.ParentSessionID, msg)
+		assert.Equal(t, "grouped-parent", *child.ParentSessionID, msg)
+	} else {
+		if child.ParentSessionID != nil {
+			assert.NotEqual(t, "grouped-parent", *child.ParentSessionID, msg)
+		}
+	}
+}
+
+// TestReconcileProviderRootsGroupedRunsSharedEpilogueOnce is the
+// providers-times-archive regression: each per-group pass must defer the
+// archive-sized epilogue (global subagent linking and skip-cache persistence),
+// and the grouped call must run that epilogue exactly once after every group,
+// so per-poll database work does not multiply with provider-group count.
+func TestReconcileProviderRootsGroupedRunsSharedEpilogueOnce(t *testing.T) {
+	database := openTestDB(t)
+	rootA := filepath.Join(t.TempDir(), "claude-a")
+	rootB := filepath.Join(t.TempDir(), "claude-b")
+	writeGroupedClaudeFixture(t, rootA, "grouped-a")
+	writeGroupedClaudeFixture(t, rootB, "grouped-b")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {rootA, rootB},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	seedGroupedSubagentFixture(t, database)
+	// Seed a skip entry directly: persistSkipCache snapshots this map, so the
+	// skipped_files table observably distinguishes "persisted" from "deferred".
+	engine.cacheSkip(filepath.Join(rootA, "seeded-skip.jsonl"), 42)
+
+	// A single deferred pass must sync its scope but leave the epilogue to
+	// the grouped caller: no skip-cache persistence, no subagent linking.
+	deferredCtx := context.WithValue(
+		t.Context(), deferPassEpilogueContextKey{}, true,
+	)
+	require.NoError(t, engine.ReconcileProviderRoots(
+		deferredCtx, parser.AgentClaude, []string{rootA},
+	))
+	synced, err := database.GetSession(t.Context(), "grouped-a")
+	require.NoError(t, err)
+	require.NotNil(t, synced, "a deferred pass must still sync its scope")
+	skipped, err := database.LoadSkippedFiles()
+	require.NoError(t, err)
+	assert.Empty(t, skipped,
+		"a deferred pass must not persist the archive-sized skip cache")
+	requireGroupedChildParent(t, database, false,
+		"a deferred pass must not run global subagent linking")
+
+	// The grouped call reconciles every group and then runs the shared
+	// epilogue once: both scopes synced, skip cache persisted, links set.
+	require.NoError(t, engine.ReconcileProviderRootsGrouped(t.Context(),
+		[]ProviderRootsGroup{
+			{Agent: parser.AgentClaude, Roots: []string{rootA}},
+			{Agent: parser.AgentClaude, Roots: []string{rootB}},
+		},
+	))
+	syncedB, err := database.GetSession(t.Context(), "grouped-b")
+	require.NoError(t, err)
+	require.NotNil(t, syncedB, "the grouped call must sync every group's scope")
+	skipped, err = database.LoadSkippedFiles()
+	require.NoError(t, err)
+	assert.NotEmpty(t, skipped,
+		"the grouped call must persist the skip cache after the last group")
+	requireGroupedChildParent(t, database, true,
+		"the grouped call must run subagent linking in the shared epilogue")
+}
+
+// TestReconcileProviderRootsGroupedAttemptsEveryGroupAfterFailure pins the
+// attempt-all contract: a failing group must not prevent later groups from
+// reconciling, the shared epilogue still runs for the groups that committed,
+// and the failure is reported with the provider it belongs to.
+func TestReconcileProviderRootsGroupedAttemptsEveryGroupAfterFailure(t *testing.T) {
+	database := openTestDB(t)
+	rootA := filepath.Join(t.TempDir(), "claude-a")
+	rootB := filepath.Join(t.TempDir(), "claude-b")
+	writeGroupedClaudeFixture(t, rootA, "grouped-a")
+	writeGroupedClaudeFixture(t, rootB, "grouped-b")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {rootA, rootB},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	engine.cacheSkip(filepath.Join(rootA, "seeded-skip.jsonl"), 42)
+
+	// Fail the first group's pass at the spool, then restore the factory so
+	// the second group runs normally.
+	defaultFactory := engine.reconciliationSpoolFactory
+	failures := 0
+	engine.reconciliationSpoolFactory = func(path string) (reconciliationSpoolStore, error) {
+		if failures == 0 {
+			failures++
+			return nil, errors.New("spool unavailable")
+		}
+		return defaultFactory(path)
+	}
+
+	err := engine.ReconcileProviderRootsGrouped(t.Context(),
+		[]ProviderRootsGroup{
+			{Agent: parser.AgentClaude, Roots: []string{rootA}},
+			{Agent: parser.AgentClaude, Roots: []string{rootB}},
+		},
+	)
+	require.Error(t, err, "the failing group's error must be reported")
+	assert.ErrorContains(t, err, "spool unavailable")
+	assert.ErrorContains(t, err, "claude",
+		"the joined error must name the failing group's provider")
+
+	syncedB, err := database.GetSession(t.Context(), "grouped-b")
+	require.NoError(t, err)
+	require.NotNil(t, syncedB,
+		"a later group must still reconcile after an earlier group fails")
+	skipped, err := database.LoadSkippedFiles()
+	require.NoError(t, err)
+	assert.NotEmpty(t, skipped,
+		"the shared epilogue must still run for the groups that completed")
+}

--- a/internal/sync/grouped_reconcile_test.go
+++ b/internal/sync/grouped_reconcile_test.go
@@ -3,8 +3,10 @@ package sync
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -132,6 +134,79 @@ func TestReconcileProviderRootsGroupedRunsSharedEpilogueOnce(t *testing.T) {
 		"the grouped call must persist the skip cache after the last group")
 	requireGroupedChildParent(t, database, true,
 		"the grouped call must run subagent linking in the shared epilogue")
+}
+
+// TestGroupedReconcileContainerProbesDoNotScaleWithProviderGroups is the
+// cardinality regression for the pre-discovery container capture: an
+// agent-scoped pass outside the OpenCode SQLite family can never discover a
+// shared container, so it must not probe any configured container. Otherwise
+// per-poll probe work would multiply as provider groups grow, even with the
+// shared epilogue.
+func TestGroupedReconcileContainerProbesDoNotScaleWithProviderGroups(t *testing.T) {
+	countContainerProbes := func(t *testing.T) *atomic.Int32 {
+		t.Helper()
+		var probes atomic.Int32
+		orig := statSQLiteContainerState
+		statSQLiteContainerState = func(dbPath string) (parser.SQLiteContainerState, bool) {
+			probes.Add(1)
+			return orig(dbPath)
+		}
+		t.Cleanup(func() { statSQLiteContainerState = orig })
+		return &probes
+	}
+	newContainerEngine := func(t *testing.T, claudeRoots []string) *Engine {
+		t.Helper()
+		openCodeDir := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(openCodeDir, "opencode.db"), []byte("not a real db"), 0o644,
+		))
+		engine := NewEngine(openTestDB(t), EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude:   claudeRoots,
+				parser.AgentOpenCode: {openCodeDir},
+			},
+			Machine: "local",
+		})
+		t.Cleanup(engine.Close)
+		return engine
+	}
+
+	for _, groupCount := range []int{2, 8} {
+		t.Run(fmt.Sprintf("groups=%d", groupCount), func(t *testing.T) {
+			var claudeRoots []string
+			var groups []ProviderRootsGroup
+			for i := range groupCount {
+				root := filepath.Join(t.TempDir(), fmt.Sprintf("claude-%d", i))
+				writeGroupedClaudeFixture(t, root, fmt.Sprintf("session-%d", i))
+				claudeRoots = append(claudeRoots, root)
+				groups = append(groups, ProviderRootsGroup{
+					Agent: parser.AgentClaude, Roots: []string{root},
+				})
+			}
+			engine := newContainerEngine(t, claudeRoots)
+			probes := countContainerProbes(t)
+
+			require.NoError(t, engine.ReconcileProviderRootsGrouped(t.Context(), groups))
+
+			assert.Zero(t, probes.Load(),
+				"out-of-family provider groups must not probe any container, "+
+					"regardless of group count")
+		})
+	}
+
+	t.Run("unscoped group still captures containers", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), "claude-0")
+		writeGroupedClaudeFixture(t, root, "session-0")
+		engine := newContainerEngine(t, []string{root})
+		probes := countContainerProbes(t)
+
+		require.NoError(t, engine.ReconcileProviderRootsGrouped(t.Context(),
+			[]ProviderRootsGroup{{Agent: "", Roots: []string{root}}},
+		))
+
+		assert.Positive(t, probes.Load(),
+			"the unscoped pass must still capture configured containers")
+	})
 }
 
 // TestReconcileProviderRootsGroupedAttemptsEveryGroupAfterFailure pins the

--- a/internal/sync/grouped_reconcile_test.go
+++ b/internal/sync/grouped_reconcile_test.go
@@ -136,6 +136,60 @@ func TestReconcileProviderRootsGroupedRunsSharedEpilogueOnce(t *testing.T) {
 		"the grouped call must run subagent linking in the shared epilogue")
 }
 
+// TestReconcileProviderRootsGroupedSkipsEpilogueOnCancellation: linking and
+// skip-cache persistence are not context-aware, so a batch canceled after an
+// eligible group must skip the archive-sized epilogue instead of blocking
+// shutdown on it, and must report the cancellation rather than succeed.
+func TestReconcileProviderRootsGroupedSkipsEpilogueOnCancellation(t *testing.T) {
+	database := openTestDB(t)
+	rootA := filepath.Join(t.TempDir(), "claude-a")
+	rootB := filepath.Join(t.TempDir(), "claude-b")
+	writeGroupedClaudeFixture(t, rootA, "grouped-a")
+	writeGroupedClaudeFixture(t, rootB, "grouped-b")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {rootA, rootB},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	seedGroupedSubagentFixture(t, database)
+	engine.cacheSkip(filepath.Join(rootA, "seeded-skip.jsonl"), 42)
+
+	// Cancel while the second group's pass starts, after the first group has
+	// completed cleanly and made the epilogue eligible.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	defaultFactory := engine.reconciliationSpoolFactory
+	spoolCalls := 0
+	engine.reconciliationSpoolFactory = func(path string) (reconciliationSpoolStore, error) {
+		spoolCalls++
+		if spoolCalls == 2 {
+			cancel()
+		}
+		return defaultFactory(path)
+	}
+
+	err := engine.ReconcileProviderRootsGrouped(ctx,
+		[]ProviderRootsGroup{
+			{Agent: parser.AgentClaude, Roots: []string{rootA}},
+			{Agent: parser.AgentClaude, Roots: []string{rootB}},
+		},
+	)
+	require.Error(t, err, "a canceled batch must not report success")
+	assert.ErrorIs(t, err, context.Canceled)
+
+	synced, err := database.GetSession(context.Background(), "grouped-a")
+	require.NoError(t, err)
+	require.NotNil(t, synced, "the group completed before cancellation must be synced")
+	skipped, err := database.LoadSkippedFiles()
+	require.NoError(t, err)
+	assert.Empty(t, skipped,
+		"a canceled batch must not persist the archive-sized skip cache")
+	requireGroupedChildParent(t, database, false,
+		"a canceled batch must not run global subagent linking")
+}
+
 // TestGroupedReconcileContainerProbesDoNotScaleWithProviderGroups is the
 // cardinality regression for the pre-discovery container capture: an
 // agent-scoped pass outside the OpenCode SQLite family can never discover a
@@ -207,6 +261,57 @@ func TestGroupedReconcileContainerProbesDoNotScaleWithProviderGroups(t *testing.
 		assert.Positive(t, probes.Load(),
 			"the unscoped pass must still capture configured containers")
 	})
+}
+
+// TestInFamilyContainerCaptureBoundedByBatchRoots: an in-family scoped pass
+// must probe only the configured containers overlapping its reconciliation
+// roots. Probe work per pass must stay constant as unrelated configured dirs
+// for the same agent grow.
+func TestInFamilyContainerCaptureBoundedByBatchRoots(t *testing.T) {
+	probeCounts := make(map[int]int32)
+	for _, dirCount := range []int{2, 8} {
+		t.Run(fmt.Sprintf("dirs=%d", dirCount), func(t *testing.T) {
+			dirs := make([]string, 0, dirCount)
+			for i := range dirCount {
+				dir := filepath.Join(t.TempDir(), fmt.Sprintf("opencode-%d", i))
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, "opencode.db"), []byte("not a real db"), 0o644,
+				))
+				dirs = append(dirs, dir)
+			}
+			engine := NewEngine(openTestDB(t), EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentOpenCode: dirs,
+				},
+				Machine: "local",
+			})
+			t.Cleanup(engine.Close)
+
+			var probes atomic.Int32
+			orig := statSQLiteContainerState
+			statSQLiteContainerState = func(dbPath string) (parser.SQLiteContainerState, bool) {
+				probes.Add(1)
+				return orig(dbPath)
+			}
+			t.Cleanup(func() { statSQLiteContainerState = orig })
+
+			// The pass may report provider failures for the unreadable
+			// container; only the capture cardinality is under test.
+			_ = engine.ReconcileProviderRootsGrouped(t.Context(),
+				[]ProviderRootsGroup{
+					{Agent: parser.AgentOpenCode, Roots: []string{dirs[0]}},
+				},
+			)
+
+			require.Positive(t, probes.Load(),
+				"the batch root's own container must still be probed")
+			probeCounts[dirCount] = probes.Load()
+		})
+	}
+	assert.Equal(t, probeCounts[2], probeCounts[8],
+		"container probes per pass must be bounded by the batch roots, "+
+			"not by the agent's total configured dirs")
 }
 
 // TestReconcileProviderRootsGroupedAttemptsEveryGroupAfterFailure pins the

--- a/internal/sync/grouped_reconcile_test.go
+++ b/internal/sync/grouped_reconcile_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -312,6 +313,101 @@ func TestInFamilyContainerCaptureBoundedByBatchRoots(t *testing.T) {
 	assert.Equal(t, probeCounts[2], probeCounts[8],
 		"container probes per pass must be bounded by the batch roots, "+
 			"not by the agent's total configured dirs")
+}
+
+// tombstoneFailingSpool wraps the real spool and fails the stored-source
+// lookups (replacement, persistent-member, identity) that only the tombstone
+// phase performs, so page writes commit cleanly and the pass errors
+// afterwards.
+type tombstoneFailingSpool struct {
+	reconciliationSpoolStore
+}
+
+func (s *tombstoneFailingSpool) Candidate(
+	context.Context, parser.AgentType, string,
+) (reconciliationCandidate, bool, error) {
+	return reconciliationCandidate{}, false, errors.New("tombstone lookup unavailable")
+}
+
+func (s *tombstoneFailingSpool) ContainsSource(
+	context.Context, parser.AgentType, string,
+) (bool, error) {
+	return false, errors.New("tombstone lookup unavailable")
+}
+
+func (s *tombstoneFailingSpool) ContainsSourceIdentity(
+	context.Context, parser.AgentType, string, string,
+) (bool, error) {
+	return false, errors.New("tombstone lookup unavailable")
+}
+
+// TestReconcileProviderRootsGroupedRunsEpilogueDespiteTombstoneFailure:
+// epilogue eligibility is decided when page writes commit, before
+// tombstoning. A pass whose sessions synced but whose tombstone sweep fails
+// must still get subagent linking and skip-cache persistence from the shared
+// epilogue — otherwise a persistent tombstone failure would leave synced
+// subagents unlinked indefinitely.
+func TestReconcileProviderRootsGroupedRunsEpilogueDespiteTombstoneFailure(t *testing.T) {
+	database := openTestDB(t)
+	rootA := filepath.Join(t.TempDir(), "claude-a")
+	writeGroupedClaudeFixture(t, rootA, "grouped-a")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {rootA},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	seedGroupedSubagentFixture(t, database)
+	engine.cacheSkip(filepath.Join(rootA, "seeded-skip.jsonl"), 42)
+
+	// A stored session whose file vanished forces the tombstone sweep to
+	// consult the spool, which the wrapper below fails.
+	missingPath := filepath.Join(rootA, "project", "vanished.jsonl")
+	size := int64(1)
+	mtime := int64(1)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "vanished", Agent: string(parser.AgentClaude), Project: "project",
+		Machine: "local", FilePath: &missingPath, FileSize: &size,
+		FileMtime: &mtime,
+	}))
+	require.NoError(t, database.SetSessionDataVersion(
+		"vanished", db.CurrentDataVersion(),
+	))
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`INSERT INTO local_session_source_baselines
+		(session_id, machine, agent, file_path) VALUES (?,?,?,?)`,
+		"vanished", "local", string(parser.AgentClaude), missingPath)
+	require.NoError(t, err)
+
+	defaultFactory := engine.reconciliationSpoolFactory
+	engine.reconciliationSpoolFactory = func(path string) (reconciliationSpoolStore, error) {
+		spool, err := defaultFactory(path)
+		if err != nil {
+			return nil, err
+		}
+		return &tombstoneFailingSpool{reconciliationSpoolStore: spool}, nil
+	}
+
+	err = engine.ReconcileProviderRootsGrouped(t.Context(),
+		[]ProviderRootsGroup{
+			{Agent: parser.AgentClaude, Roots: []string{rootA}},
+		},
+	)
+	require.Error(t, err, "the tombstone failure must be reported")
+	assert.ErrorContains(t, err, "tombstone lookup unavailable")
+
+	synced, getErr := database.GetSession(t.Context(), "grouped-a")
+	require.NoError(t, getErr)
+	require.NotNil(t, synced, "page writes must commit before the tombstone failure")
+	skipped, loadErr := database.LoadSkippedFiles()
+	require.NoError(t, loadErr)
+	assert.NotEmpty(t, skipped,
+		"a tombstone failure after committed writes must not skip skip-cache persistence")
+	requireGroupedChildParent(t, database, true,
+		"a tombstone failure after committed writes must not skip subagent linking")
 }
 
 // TestReconcileProviderRootsGroupedAttemptsEveryGroupAfterFailure pins the

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -102,7 +102,7 @@ func (e *Engine) captureSQLiteContainerStates(
 	states := make(map[string]parser.SQLiteContainerState)
 	if len(changedPaths) == 0 {
 		for _, agent := range openCodeFamilySQLiteAgents {
-			e.captureAgentSQLiteContainerStates(agent, states)
+			e.captureAgentSQLiteContainerStates(agent, nil, states)
 		}
 		return states
 	}
@@ -126,10 +126,12 @@ func (e *Engine) captureSQLiteContainerStates(
 // what an agent-scoped pass can discover. A pass scoped to a provider outside
 // the OpenCode SQLite family streams no shared containers, so probing every
 // configured container there would repeat once per provider group in a
-// grouped poll; an in-family scope probes only that agent's containers. The
-// unscoped pass (empty agent) still captures every configured container.
+// grouped poll; an in-family scope probes only its own containers that
+// overlap the pass's reconciliation roots, keeping capture work bounded by
+// the batch rather than the agent's full configuration. The unscoped pass
+// (empty agent) still captures every configured container.
 func (e *Engine) captureSQLiteContainerStatesForAgent(
-	agent parser.AgentType,
+	agent parser.AgentType, roots []string,
 ) map[string]parser.SQLiteContainerState {
 	if agent == "" {
 		return e.captureSQLiteContainerStates(nil)
@@ -138,20 +140,45 @@ func (e *Engine) captureSQLiteContainerStatesForAgent(
 		return nil
 	}
 	states := make(map[string]parser.SQLiteContainerState)
-	e.captureAgentSQLiteContainerStates(agent, states)
+	e.captureAgentSQLiteContainerStates(agent, roots, states)
 	return states
 }
 
+// captureAgentSQLiteContainerStates captures one agent's containers. Non-nil
+// roots restrict the capture to configured dirs overlapping them; nil roots
+// capture every configured dir (full and changed-path passes).
 func (e *Engine) captureAgentSQLiteContainerStates(
-	agent parser.AgentType, states map[string]parser.SQLiteContainerState,
+	agent parser.AgentType,
+	roots []string,
+	states map[string]parser.SQLiteContainerState,
 ) {
 	for _, dir := range e.agentDirs[agent] {
 		if dir == "" || strings.HasPrefix(dir, "s3://") {
 			continue
 		}
+		if !containerDirOverlapsRoots(dir, roots) {
+			continue
+		}
 		src := resolveOpenCodeFormatSource(agent, filepath.Clean(dir))
 		addSQLiteContainerState(states, src.DBPath)
 	}
+}
+
+// containerDirOverlapsRoots mirrors logicalRootsForAgentWatchRoots's
+// bidirectional overlap so the capture covers exactly the configured dirs a
+// scoped pass can expand into: a dir is capturable when it is the same path
+// as, an ancestor of, or a descendant of any reconciliation root. Empty
+// roots match everything.
+func containerDirOverlapsRoots(dir string, roots []string) bool {
+	if len(roots) == 0 {
+		return true
+	}
+	cleanedDir := cleanRootPath(dir)
+	return slices.ContainsFunc(roots, func(root string) bool {
+		cleanedRoot := cleanRootPath(root)
+		return samePathOrDescendant(cleanedRoot, cleanedDir) ||
+			samePathOrDescendant(cleanedDir, cleanedRoot)
+	})
 }
 
 func addSQLiteContainerState(

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -5,6 +5,7 @@ package sync
 import (
 	"maps"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"go.kenn.io/agentsview/internal/db"
@@ -99,28 +100,9 @@ func (e *Engine) captureSQLiteContainerStates(
 		return nil
 	}
 	states := make(map[string]parser.SQLiteContainerState)
-	addState := func(agent parser.AgentType, dbPath string) {
-		if dbPath == "" {
-			return
-		}
-		if _, seen := states[dbPath]; seen {
-			return
-		}
-		state, ok := statSQLiteContainerState(dbPath)
-		if !ok {
-			return
-		}
-		states[dbPath] = state
-	}
 	if len(changedPaths) == 0 {
 		for _, agent := range openCodeFamilySQLiteAgents {
-			for _, dir := range e.agentDirs[agent] {
-				if dir == "" || strings.HasPrefix(dir, "s3://") {
-					continue
-				}
-				src := resolveOpenCodeFormatSource(agent, filepath.Clean(dir))
-				addState(agent, src.DBPath)
-			}
+			e.captureAgentSQLiteContainerStates(agent, states)
 		}
 		return states
 	}
@@ -131,11 +113,61 @@ func (e *Engine) captureSQLiteContainerStates(
 				if dir == "" || strings.HasPrefix(dir, "s3://") {
 					continue
 				}
-				addState(agent, openCodeContainerPathForEvent(agent, dir, path))
+				addSQLiteContainerState(
+					states, openCodeContainerPathForEvent(agent, dir, path),
+				)
 			}
 		}
 	}
 	return states
+}
+
+// captureSQLiteContainerStatesForAgent scopes the pre-discovery capture to
+// what an agent-scoped pass can discover. A pass scoped to a provider outside
+// the OpenCode SQLite family streams no shared containers, so probing every
+// configured container there would repeat once per provider group in a
+// grouped poll; an in-family scope probes only that agent's containers. The
+// unscoped pass (empty agent) still captures every configured container.
+func (e *Engine) captureSQLiteContainerStatesForAgent(
+	agent parser.AgentType,
+) map[string]parser.SQLiteContainerState {
+	if agent == "" {
+		return e.captureSQLiteContainerStates(nil)
+	}
+	if e.forceParse || !slices.Contains(openCodeFamilySQLiteAgents, agent) {
+		return nil
+	}
+	states := make(map[string]parser.SQLiteContainerState)
+	e.captureAgentSQLiteContainerStates(agent, states)
+	return states
+}
+
+func (e *Engine) captureAgentSQLiteContainerStates(
+	agent parser.AgentType, states map[string]parser.SQLiteContainerState,
+) {
+	for _, dir := range e.agentDirs[agent] {
+		if dir == "" || strings.HasPrefix(dir, "s3://") {
+			continue
+		}
+		src := resolveOpenCodeFormatSource(agent, filepath.Clean(dir))
+		addSQLiteContainerState(states, src.DBPath)
+	}
+}
+
+func addSQLiteContainerState(
+	states map[string]parser.SQLiteContainerState, dbPath string,
+) {
+	if dbPath == "" {
+		return
+	}
+	if _, seen := states[dbPath]; seen {
+		return
+	}
+	state, ok := statSQLiteContainerState(dbPath)
+	if !ok {
+		return
+	}
+	states[dbPath] = state
 }
 
 func openCodeContainerPathForEvent(

--- a/internal/sync/watch_backend.go
+++ b/internal/sync/watch_backend.go
@@ -49,6 +49,7 @@ func (w *Watcher) RegisterRoots(
 				}
 			}
 			w.SetRootAgents(root.Path, agents)
+			w.setRootScopes(root.Path, root.Scopes)
 		}
 		return backend.RegisterRoots(roots, recursiveBudget)
 	}
@@ -62,6 +63,7 @@ func (w *Watcher) RegisterRoots(
 			}
 		}
 		w.SetRootAgents(root.Path, agents)
+		w.setRootScopes(root.Path, root.Scopes)
 		if !root.Exists {
 			continue
 		}

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -48,8 +48,8 @@ const (
 // probe on the collapsed scope roots would let authoritative reconciliation
 // tombstone every session under the absent subtree.
 type darwinFallbackPollPlan struct {
-	path  string
-	roots []string
+	path   string
+	scopes []PollingScope
 }
 
 // darwinFallbackPollingObligationKey names the per-plan fallback obligation so
@@ -61,26 +61,29 @@ func darwinFallbackPollingObligationKey(path string) string {
 // appendFallbackPollPlan adds a plan's scope roots under its physical path,
 // merging into an existing entry for the same path.
 func appendFallbackPollPlan(
-	plans []darwinFallbackPollPlan, path string, scopes []WatchScope,
+	plans []darwinFallbackPollPlan, path string, watchScopes []WatchScope,
 ) []darwinFallbackPollPlan {
-	roots := appendWatchScopeRoots(nil, scopes)
-	if len(roots) == 0 {
+	newScopes := appendWatchScopeRoots(nil, watchScopes)
+	if len(newScopes) == 0 {
 		return plans
 	}
 	for i := range plans {
 		if plans[i].path == path {
-			merged := plans[i].roots
-			for _, root := range roots {
-				if !slices.Contains(merged, root) {
-					merged = append(merged, root)
+			for _, ps := range newScopes {
+				if !slices.Contains(plans[i].scopes, ps) {
+					plans[i].scopes = append(plans[i].scopes, ps)
 				}
 			}
-			slices.Sort(merged)
-			plans[i].roots = merged
+			slices.SortFunc(plans[i].scopes, func(a, b PollingScope) int {
+				if a.Agent != b.Agent {
+					return strings.Compare(a.Agent, b.Agent)
+				}
+				return strings.Compare(a.Root, b.Root)
+			})
 			return plans
 		}
 	}
-	plans = append(plans, darwinFallbackPollPlan{path: path, roots: roots})
+	plans = append(plans, darwinFallbackPollPlan{path: path, scopes: newScopes})
 	slices.SortFunc(plans, func(a, b darwinFallbackPollPlan) int {
 		return strings.Compare(a.path, b.path)
 	})
@@ -1052,13 +1055,19 @@ func (b *darwinWatchBackend) requireRootPollingLocked(
 func (b *darwinWatchBackend) installRootPollingLocked(
 	state *darwinLogicalRoot,
 ) error {
-	roots := appendWatchScopeRoots(nil, state.plan.Scopes)
+	scopes := appendWatchScopeRoots(nil, state.plan.Scopes)
 	if b.onPollingRequired != nil {
 		return b.onPollingRequired(PollingObligation{
-			Key: state.plan.Path, Roots: roots, Probe: state.plan.Path,
+			Key: state.plan.Path, Scopes: scopes, Probe: state.plan.Path,
 		})
 	}
 	if b.onCoverageDegraded != nil {
+		roots := make([]string, 0, len(scopes))
+		for _, s := range scopes {
+			if !slices.Contains(roots, s.Root) {
+				roots = append(roots, s.Root)
+			}
+		}
 		return b.onCoverageDegraded(roots)
 	}
 	return nil
@@ -1251,9 +1260,9 @@ func (b *darwinWatchBackend) requireFallbackPolling(
 	if required != nil {
 		for _, plan := range plans {
 			if err := required(PollingObligation{
-				Key:   darwinFallbackPollingObligationKey(plan.path),
-				Roots: plan.roots,
-				Probe: plan.path,
+				Key:    darwinFallbackPollingObligationKey(plan.path),
+				Scopes: plan.scopes,
+				Probe:  plan.path,
 			}); err != nil {
 				return err
 			}
@@ -1273,9 +1282,9 @@ func (b *darwinWatchBackend) requireFallbackPolling(
 		// absent.
 		var roots []string
 		for _, plan := range plans {
-			for _, root := range plan.roots {
-				if !slices.Contains(roots, root) {
-					roots = append(roots, root)
+			for _, scope := range plan.scopes {
+				if !slices.Contains(roots, scope.Root) {
+					roots = append(roots, scope.Root)
 				}
 			}
 		}
@@ -1589,14 +1598,23 @@ func (b *darwinWatchBackend) scheduleFallbackRetryLocked(now time.Time) {
 	b.fallbackRetryAt = now.Add(b.fallbackRetryDelay)
 }
 
-func appendWatchScopeRoots(roots []string, scopes []WatchScope) []string {
-	for _, scope := range scopes {
-		if scope.SyncDir != "" && !slices.Contains(roots, filepath.Clean(scope.SyncDir)) {
-			roots = append(roots, filepath.Clean(scope.SyncDir))
+func appendWatchScopeRoots(scopes []PollingScope, watchScopes []WatchScope) []PollingScope {
+	for _, scope := range watchScopes {
+		if scope.SyncDir == "" {
+			continue
+		}
+		ps := PollingScope{Agent: scope.Agent, Root: filepath.Clean(scope.SyncDir)}
+		if !slices.Contains(scopes, ps) {
+			scopes = append(scopes, ps)
 		}
 	}
-	slices.Sort(roots)
-	return roots
+	slices.SortFunc(scopes, func(a, b PollingScope) int {
+		if a.Agent != b.Agent {
+			return strings.Compare(a.Agent, b.Agent)
+		}
+		return strings.Compare(a.Root, b.Root)
+	})
+	return scopes
 }
 
 func fallbackReasonLabel(reason darwinFallbackReason) string {

--- a/internal/sync/watch_backend_fsnotify.go
+++ b/internal/sync/watch_backend_fsnotify.go
@@ -30,7 +30,7 @@ type fsnotifyBackend struct {
 	watchOwners       map[string]map[string]struct{}
 	watchBudgetCost   map[string]int
 	runtimeBudget     int
-	rootScopes        map[string][]string
+	rootScopes        map[string][]PollingScope
 	degradedRoots     map[string]struct{}
 	onPollingRequired func(PollingObligation) error
 	lifecycleMu       sync.Mutex
@@ -67,7 +67,7 @@ func newFSNotifyBackend(excludes []string) (*fsnotifyBackend, error) {
 		excludes:        normalizeExcludePatterns(excludes),
 		watchOwners:     make(map[string]map[string]struct{}),
 		watchBudgetCost: make(map[string]int),
-		rootScopes:      make(map[string][]string),
+		rootScopes:      make(map[string][]PollingScope),
 		degradedRoots:   make(map[string]struct{}),
 		stop:            make(chan struct{}),
 		done:            make(chan struct{}),
@@ -134,16 +134,24 @@ func (b *fsnotifyBackend) AddRecursive(root string, budget int) RecursiveWatchRe
 func (b *fsnotifyBackend) setWatchRootPlan(roots []WatchRoot) {
 	b.watchMu.Lock()
 	defer b.watchMu.Unlock()
-	b.rootScopes = make(map[string][]string, len(roots))
+	b.rootScopes = make(map[string][]PollingScope, len(roots))
 	for _, root := range roots {
 		path := filepath.Clean(root.Path)
 		for _, scope := range root.Scopes {
-			if scope.SyncDir != "" {
-				b.rootScopes[path] = append(b.rootScopes[path], scope.SyncDir)
+			if scope.SyncDir == "" {
+				continue
+			}
+			ps := PollingScope{Agent: scope.Agent, Root: filepath.Clean(scope.SyncDir)}
+			if !slices.Contains(b.rootScopes[path], ps) {
+				b.rootScopes[path] = append(b.rootScopes[path], ps)
 			}
 		}
-		slices.Sort(b.rootScopes[path])
-		b.rootScopes[path] = slices.Compact(b.rootScopes[path])
+		slices.SortFunc(b.rootScopes[path], func(a, b PollingScope) int {
+			if a.Agent != b.Agent {
+				return strings.Compare(a.Agent, b.Agent)
+			}
+			return strings.Compare(a.Root, b.Root)
+		})
 	}
 }
 
@@ -493,10 +501,10 @@ func (b *fsnotifyBackend) requireRuntimePolling(roots []string) {
 			continue
 		}
 		required := b.onPollingRequired
-		scopes := append([]string(nil), b.rootScopes[root]...)
+		scopes := append([]PollingScope(nil), b.rootScopes[root]...)
 		b.watchMu.Unlock()
 		if len(scopes) == 0 {
-			scopes = []string{root}
+			scopes = []PollingScope{{Root: root}}
 		}
 		if required == nil {
 			b.reportError(fmt.Errorf(
@@ -505,7 +513,7 @@ func (b *fsnotifyBackend) requireRuntimePolling(roots []string) {
 			continue
 		}
 		if err := required(PollingObligation{
-			Key: "fsnotify-runtime:" + root, Roots: scopes, Probe: root,
+			Key: "fsnotify-runtime:" + root, Scopes: scopes, Probe: root,
 		}); err != nil {
 			b.reportError(fmt.Errorf(
 				"transfer fsnotify coverage for %s to polling: %w", root, err,

--- a/internal/sync/watch_backend_fsnotify_test.go
+++ b/internal/sync/watch_backend_fsnotify_test.go
@@ -213,7 +213,7 @@ func TestFSNotifyBackendRuntimeBudgetDegradesExactScopesToPolling(t *testing.T) 
 	require.NoError(t, os.Mkdir(created, 0o755))
 	obligation := requireReceiveWithin(t, polling, time.Second)
 	assert.NotEmpty(t, obligation.Key)
-	assert.Equal(t, []string{syncDir}, obligation.Roots)
+	assert.Equal(t, []PollingScope{{Agent: "claude", Root: syncDir}}, obligation.Scopes)
 	assert.NotContains(t, backend.watcher.WatchList(), created)
 }
 
@@ -289,7 +289,7 @@ func TestFSNotifyBackendRootLossTransfersExactScopeToPolling(t *testing.T) {
 	assert.Equal(t, backendItemDirectory, event.ItemType)
 	obligation := requireReceiveWithin(t, polling, time.Second)
 	assert.Equal(t, "fsnotify-runtime:"+root, obligation.Key)
-	assert.Equal(t, []string{syncDir}, obligation.Roots)
+	assert.Equal(t, []PollingScope{{Agent: "claude", Root: syncDir}}, obligation.Scopes)
 	assert.Empty(t, backend.watcher.WatchList())
 }
 
@@ -344,7 +344,7 @@ func TestFSNotifyBackendRuntimeAddFailureDegradesExactScopesToPolling(t *testing
 	assert.Equal(t, backendItemDirectory, itemType)
 	assert.False(t, excluded)
 	obligation := requireReceiveWithin(t, polling, time.Second)
-	assert.Equal(t, []string{syncDir}, obligation.Roots)
+	assert.Equal(t, []PollingScope{{Agent: "claude", Root: syncDir}}, obligation.Scopes)
 	assert.NotContains(t, backend.watcher.WatchList(), created)
 }
 
@@ -385,12 +385,12 @@ func TestFSNotifyBackendRuntimeDegradationPreservesOverlappingRootScopes(t *test
 	assert.False(t, excluded)
 	first := requireReceiveWithin(t, polling, time.Second)
 	second := requireReceiveWithin(t, polling, time.Second)
-	obligations := map[string][]string{
-		first.Key:  first.Roots,
-		second.Key: second.Roots,
+	obligations := map[string][]PollingScope{
+		first.Key:  first.Scopes,
+		second.Key: second.Scopes,
 	}
-	assert.Equal(t, []string{parentScope}, obligations["fsnotify-runtime:"+parent])
-	assert.Equal(t, []string{nestedScope}, obligations["fsnotify-runtime:"+nested])
+	assert.Equal(t, []PollingScope{{Agent: "claude", Root: parentScope}}, obligations["fsnotify-runtime:"+parent])
+	assert.Equal(t, []PollingScope{{Agent: "cursor", Root: nestedScope}}, obligations["fsnotify-runtime:"+nested])
 }
 
 func TestFSNotifyBackendRuntimeCreateRecursivelyWatchesMovedSubtree(t *testing.T) {

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -67,18 +67,24 @@ type WatchBatch struct {
 
 type WatchCallback func(context.Context, WatchBatch) error
 
+// PollingScope identifies one configured provider root within a polling obligation.
+type PollingScope struct {
+	Agent string
+	Root  string
+}
+
 // PollingObligation identifies one independently releasable reason that a set
-// of configured roots needs authoritative polling coverage.
+// of configured scopes needs authoritative polling coverage.
 type PollingObligation struct {
-	Key   string
-	Roots []string
+	Key    string
+	Scopes []PollingScope
 	// Probe is the physical watcher path whose availability gates this
-	// obligation's reconciliation Roots. For nested provider roots (e.g.
+	// obligation's reconciliation Scopes. For nested provider roots (e.g.
 	// Gemini's <root>/tmp) the physical path differs from the configured
 	// reconciliation scope; probing the scope instead would let polling
 	// authoritatively reconcile a present <root> while the missing physical
 	// subtree holds every session, tombstoning all of them. Empty means the
-	// Roots themselves are the physical paths to probe.
+	// Scopes' roots themselves are the physical paths to probe.
 	Probe string
 }
 
@@ -611,19 +617,25 @@ func (s *watchEventSink) signal() {
 // Watcher schedules backend changes into serialized callbacks with short-burst
 // batching and a dispatch floor.
 type Watcher struct {
-	onChange            WatchCallback
-	onCoverageDegraded  func([]string) error
-	callbackCtx         context.Context
-	callbackCancel      context.CancelFunc
-	backend             watchBackend
-	eventSink           *watchEventSink
-	batchDelay          time.Duration
-	minInterval         time.Duration
-	maxEntries          int
-	dispatchEnabled     atomic.Bool
-	dispatchMu          sync.Mutex
-	rootAgentsMu        sync.RWMutex
-	rootAgents          map[string][]string
+	onChange           WatchCallback
+	onCoverageDegraded func([]string) error
+	onPollingRequired  func(PollingObligation) error
+	callbackCtx        context.Context
+	callbackCancel     context.CancelFunc
+	backend            watchBackend
+	eventSink          *watchEventSink
+	batchDelay         time.Duration
+	minInterval        time.Duration
+	maxEntries         int
+	dispatchEnabled    atomic.Bool
+	dispatchMu         sync.Mutex
+	rootAgentsMu       sync.RWMutex
+	rootAgents         map[string][]string
+	// rootScopes retains the full WatchScope set per physical root path,
+	// including scopes with empty Agent strings. The start-failure path uses
+	// this to emit PollingScope{Root: scope.SyncDir} rather than the physical
+	// path, so the coordinator's overlap check can match the configured dir.
+	rootScopes          map[string][]WatchScope
 	registeredSyncRoots []string
 	stopping            bool
 	lifecycleMu         sync.Mutex
@@ -750,6 +762,7 @@ func newWatcherWithBackendOptions(
 	w := &Watcher{
 		onChange:           onChange,
 		onCoverageDegraded: options.OnCoverageDegraded,
+		onPollingRequired:  options.OnPollingRequired,
 		callbackCtx:        callbackCtx,
 		callbackCancel:     callbackCancel,
 		backend:            backend,
@@ -758,6 +771,7 @@ func newWatcherWithBackendOptions(
 		minInterval:        minInterval,
 		maxEntries:         maxEntries,
 		rootAgents:         make(map[string][]string),
+		rootScopes:         make(map[string][]WatchScope),
 		stop:               make(chan struct{}),
 		done:               make(chan struct{}),
 	}
@@ -791,6 +805,17 @@ func (w *Watcher) agentsForRoot(root string) []string {
 	w.rootAgentsMu.RLock()
 	defer w.rootAgentsMu.RUnlock()
 	return append([]string(nil), w.rootAgents[filepath.Clean(root)]...)
+}
+
+// setRootScopes records the complete WatchScope set for a physical root,
+// including scopes with empty Agent strings. It is called from RegisterRoots
+// alongside SetRootAgents so the start-failure emission can use scope.SyncDir
+// rather than the physical path.
+func (w *Watcher) setRootScopes(root string, scopes []WatchScope) {
+	w.rootAgentsMu.Lock()
+	defer w.rootAgentsMu.Unlock()
+	stored := append([]WatchScope(nil), scopes...)
+	w.rootScopes[filepath.Clean(root)] = stored
 }
 
 // WatchRecursive walks a directory tree and adds all
@@ -832,34 +857,132 @@ func (w *Watcher) StartCollecting() error {
 
 func (w *Watcher) start(openDispatch bool) error {
 	w.lifecycleMu.Lock()
-	defer w.lifecycleMu.Unlock()
+
 	if w.lifecycle == watcherCollecting && openDispatch {
 		w.lifecycle = watcherDispatching
 		w.dispatchEnabled.Store(true)
+		w.lifecycleMu.Unlock()
 		w.eventSink.signal()
 		return nil
 	}
 	if w.lifecycle != watcherNew {
-		return w.startErr
+		err := w.startErr
+		w.lifecycleMu.Unlock()
+		return err
 	}
-	if err := w.backend.Start(); err != nil {
+
+	backendErr := w.backend.Start()
+	if backendErr != nil {
 		w.lifecycle = watcherStopped
 		w.beginStopping()
 		w.stopBackend()
 		w.finish()
-		if w.onCoverageDegraded != nil && len(w.registeredSyncRoots) > 0 {
-			err = errors.Join(err, w.onCoverageDegraded(w.registeredSyncRoots))
+
+		// Snapshot the callback obligations under the lock so the external
+		// callbacks run after lifecycleMu is released. A callback that calls
+		// w.Stop(), w.Start(), or w.OpenDispatch() must be able to re-acquire
+		// lifecycleMu without deadlocking.
+		//
+		// Lock order: lifecycleMu → rootAgentsMu.RLock is safe; rootAgentsMu
+		// is never acquired while lifecycleMu is held by other callers.
+		type startFailureEntry struct {
+			path   string
+			scopes []WatchScope
 		}
-		w.startErr = fmt.Errorf("starting %s backend: %w", w.backend.Name(), err)
-		log.Printf("watcher: %v", w.startErr)
-		return w.startErr
+		var obligations []PollingObligation
+		var fallbackRoots []string
+		if w.onPollingRequired != nil {
+			// Backend start failed while onPollingRequired is set. The
+			// caller's pre-start obligations (watchPollingObligations) only
+			// cover roots with known problems; cleanly-registered roots have
+			// none and would otherwise go dark. Emit one obligation per
+			// registered root so native-backend failure never silently drops
+			// clean roots.
+			//
+			// Use the full WatchScope set from rootScopes (not just agent
+			// names from rootAgents) so each scope's SyncDir becomes the
+			// PollingScope Root. The physical path is used only for the
+			// obligation Key and Probe; when the two differ (the common case
+			// for nested provider roots), using the physical path would leave
+			// the configured dir with no authoritative polling coverage.
+			//
+			// Preserve the invariant that a root whose scopes genuinely have
+			// no agent still gets one empty-agent scope so coverage is never
+			// silently dropped, but do NOT synthesise an extra empty-agent
+			// scope for a root that already has named scopes.
+			w.rootAgentsMu.RLock()
+			entries := make([]startFailureEntry, 0, len(w.rootScopes))
+			for path, scopes := range w.rootScopes {
+				entries = append(entries, startFailureEntry{
+					path:   path,
+					scopes: append([]WatchScope(nil), scopes...),
+				})
+			}
+			w.rootAgentsMu.RUnlock()
+			for _, e := range entries {
+				var pollScopes []PollingScope
+				for _, scope := range e.scopes {
+					root := scope.SyncDir
+					if root == "" {
+						root = e.path
+					}
+					pollScopes = append(pollScopes, PollingScope{
+						Agent: scope.Agent,
+						Root:  root,
+					})
+				}
+				if len(pollScopes) == 0 {
+					// No scopes at all: emit a synthetic empty-agent scope so
+					// this root is not silently dropped by the coordinator.
+					pollScopes = []PollingScope{{Root: e.path}}
+				}
+				obligations = append(obligations, PollingObligation{
+					Key:    "startfailure:" + e.path,
+					Scopes: pollScopes,
+					Probe:  e.path,
+				})
+			}
+		} else if w.onCoverageDegraded != nil && len(w.registeredSyncRoots) > 0 {
+			fallbackRoots = append([]string(nil), w.registeredSyncRoots...)
+		}
+
+		// Set startErr to a preliminary value before releasing lifecycleMu so
+		// any concurrent Start()/Stop() call observes failure and returns a
+		// non-nil error rather than seeing a nil startErr.
+		prelimErr := fmt.Errorf("starting %s backend: %w", w.backend.Name(), backendErr)
+		w.startErr = prelimErr
+		log.Printf("watcher: %v", prelimErr)
+		w.lifecycleMu.Unlock()
+
+		// Invoke all external callbacks after releasing lifecycleMu.
+		var callbackErr error
+		for _, ob := range obligations {
+			callbackErr = errors.Join(callbackErr, w.onPollingRequired(ob))
+		}
+		if len(fallbackRoots) > 0 {
+			callbackErr = errors.Join(callbackErr, w.onCoverageDegraded(fallbackRoots))
+		}
+
+		if callbackErr == nil {
+			return prelimErr
+		}
+		// Incorporate callback errors into the final startErr so callers that
+		// retry Start() see the complete failure reason.
+		finalErr := fmt.Errorf("starting %s backend: %w",
+			w.backend.Name(), errors.Join(backendErr, callbackErr))
+		w.lifecycleMu.Lock()
+		w.startErr = finalErr
+		w.lifecycleMu.Unlock()
+		return finalErr
 	}
+
 	w.lifecycle = watcherCollecting
 	go w.loop()
 	if openDispatch {
 		w.lifecycle = watcherDispatching
 		w.dispatchEnabled.Store(true)
 	}
+	w.lifecycleMu.Unlock()
 	return nil
 }
 

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -1449,7 +1449,11 @@ func TestDarwinWatcherFallbackRecoversNativeStreamsAndReleasesPolling(t *testing
 		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
 		WatcherOptions{
 			OnCoverageDegraded: func(roots []string) error {
-				polling <- PollingObligation{Key: "watcher-fallback", Roots: roots}
+				scopes := make([]PollingScope, len(roots))
+				for i, r := range roots {
+					scopes[i] = PollingScope{Root: r}
+				}
+				polling <- PollingObligation{Key: "watcher-fallback", Scopes: scopes}
 				return nil
 			},
 			OnPollingRequired: func(obligation PollingObligation) error {
@@ -1478,9 +1482,9 @@ func TestDarwinWatcherFallbackRecoversNativeStreamsAndReleasesPolling(t *testing
 	initialSink([]fsevents.Event{{Flags: fseventFlagKernelDropped}})
 
 	assert.Equal(t, PollingObligation{
-		Key:   darwinFallbackPollingObligationKey(root),
-		Roots: []string{root},
-		Probe: root,
+		Key:    darwinFallbackPollingObligationKey(root),
+		Scopes: []PollingScope{{Agent: "agent-a", Root: root}},
+		Probe:  root,
 	}, requireReceiveWithin(t, polling, time.Second))
 	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
 	assert.Equal(t, darwinFallbackPollingObligationKey(root),
@@ -1551,9 +1555,9 @@ func TestDarwinWatcherFallbackKeepsPollingUntilNativeRetrySucceeds(t *testing.T)
 
 	backend.requestFallback(darwinFallbackNativeDrop)
 	assert.Equal(t, PollingObligation{
-		Key:   darwinFallbackPollingObligationKey(root),
-		Roots: []string{root},
-		Probe: root,
+		Key:    darwinFallbackPollingObligationKey(root),
+		Scopes: []PollingScope{{Root: root}},
+		Probe:  root,
 	}, requireReceiveWithin(t, polling, time.Second))
 	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
 	requireReceiveWithin(t, failedRecovery, time.Second)
@@ -1687,19 +1691,19 @@ func TestDarwinWatcherFallbackTransfersMissingRootPollingBeforeRecovery(t *testi
 
 	backend.requestFallback(darwinFallbackNativeDrop)
 	assert.Equal(t, PollingObligation{
-		Key:   darwinFallbackPollingObligationKey(missing),
-		Roots: []string{missing},
-		Probe: missing,
+		Key:    darwinFallbackPollingObligationKey(missing),
+		Scopes: []PollingScope{{Root: missing}},
+		Probe:  missing,
 	}, requireReceiveWithin(t, polling, time.Second),
 		"each watch plan owns its own fallback obligation probed on its path")
 	assert.Equal(t, PollingObligation{
-		Key:   darwinFallbackPollingObligationKey(present),
-		Roots: []string{present},
-		Probe: present,
+		Key:    darwinFallbackPollingObligationKey(present),
+		Scopes: []PollingScope{{Root: present}},
+		Probe:  present,
 	}, requireReceiveWithin(t, polling, time.Second))
 	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
 	assert.Equal(t,
-		PollingObligation{Key: missing, Roots: []string{missing}, Probe: missing},
+		PollingObligation{Key: missing, Scopes: []PollingScope{{Root: missing}}, Probe: missing},
 		requireReceiveWithin(t, polling, time.Second),
 		"the skipped root must own polling before generic fallback polling is released")
 	assert.Equal(t, darwinFallbackPollingObligationKey(missing),
@@ -1754,9 +1758,9 @@ func TestDarwinWatcherStartupCreateFailureSelectsRecursiveFallbackOnce(t *testin
 	}, results)
 	assert.Equal(t, int32(1), creates.Load(), "one failed stream selects global fallback")
 	assert.Equal(t, []darwinFallbackPollPlan{
-		{path: first, roots: []string{first}},
-		{path: missing, roots: []string{missing}},
-		{path: second, roots: []string{second}},
+		{path: first, scopes: []PollingScope{{Root: first}}},
+		{path: missing, scopes: []PollingScope{{Root: missing}}},
+		{path: second, scopes: []PollingScope{{Root: second}}},
 	}, backend.fallbackPollPlans)
 	assert.Equal(t, uint32(1), backend.fallbackActivations.Load())
 }
@@ -2334,7 +2338,7 @@ func TestDarwinWatcherMissingRecursiveSymlinkStaysPolled(t *testing.T) {
 		return slices.Contains(batch.ReconcileRoots, ancestor)
 	})
 	assert.Equal(t,
-		PollingObligation{Key: root, Roots: []string{ancestor}, Probe: root},
+		PollingObligation{Key: root, Scopes: []PollingScope{{Agent: "agent-a", Root: ancestor}}, Probe: root},
 		requireReceiveWithin(t, required, time.Second))
 	require.True(t, firstRootInspection.Load())
 	backend.mu.Lock()
@@ -2427,7 +2431,7 @@ func TestDarwinWatcherPendingLossWinsOverActivationAcknowledgement(t *testing.T)
 	assert.Equal(t, darwinRootLossCollecting, state.phase)
 	assert.False(t, state.active)
 	assert.Equal(t,
-		PollingObligation{Key: root, Roots: []string{ancestor}, Probe: root},
+		PollingObligation{Key: root, Scopes: []PollingScope{{Agent: "agent-a", Root: ancestor}}, Probe: root},
 		requireReceiveWithin(t, required, time.Second))
 	requireReceiveWithin(t, closed, time.Second)
 }

--- a/internal/sync/watcher_polling_test.go
+++ b/internal/sync/watcher_polling_test.go
@@ -55,7 +55,7 @@ func TestWatcherStartFailureSuppressesFallbackWhenPollingOwnershipSet(t *testing
 	// OnCoverageDegraded must not be called; OnPollingRequired is the
 	// authoritative coverage path when it is set.
 	assert.False(t, degradedCalled,
-		"OnCoverageDegraded must not be called when OnPollingRequired is set (P1-B)")
+		"OnCoverageDegraded must not be called when OnPollingRequired is set")
 
 	// Named obligations must be emitted for all registered roots.
 	require.Len(t, emitted, 1,
@@ -226,7 +226,7 @@ func TestWatcherStartFailureNoEmptyAgentForNamedRoot(t *testing.T) {
 }
 
 // TestWatcherStartFailureMixedScopesBothDirsAreCovered verifies the P1
-// Failure 2 regression: when a registered root has both a named-agent scope
+// Mixed-scope regression: when a registered root has both a named-agent scope
 // and an empty-agent scope, the start-failure emission must carry BOTH
 // configured dirs and must NOT suppress the empty-agent scope just because a
 // named agent also exists on the same physical root. Before the fix,
@@ -279,7 +279,7 @@ func TestWatcherStartFailureMixedScopesBothDirsAreCovered(t *testing.T) {
 	assert.Equal(t, filepath.Clean("/gemini-dir"), filepath.Clean(geminiRoot),
 		"gemini scope Root must be the configured SyncDir /gemini-dir, not the physical path")
 	assert.NotEmpty(t, legacyRoot,
-		"empty-agent scope must not be dropped when a named agent coexists on the same root (P1 Failure 2)")
+		"empty-agent scope must not be dropped when a named agent coexists on the same root")
 	assert.Equal(t, filepath.Clean("/legacy-dir"), filepath.Clean(legacyRoot),
 		"empty-agent scope Root must be the configured SyncDir /legacy-dir")
 }

--- a/internal/sync/watcher_polling_test.go
+++ b/internal/sync/watcher_polling_test.go
@@ -1,0 +1,285 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWatcherStartFailureSuppressesFallbackWhenPollingOwnershipSet verifies
+// that when OnPollingRequired is set and backend Start fails, named obligations
+// are emitted for every registered root (carrying per-agent identity) and the
+// generic empty-agent OnCoverageDegraded fallback is NOT called. Calling
+// OnCoverageDegraded in addition would bypass per-agent probe gates.
+func TestWatcherStartFailureSuppressesFallbackWhenPollingOwnershipSet(t *testing.T) {
+	backend := newFakeWatchBackend()
+	backend.startErr = errors.New("backend start failed")
+
+	var degradedCalled bool
+	var emitted []PollingObligation
+
+	w, err := newWatcherWithBackendOptions(
+		0, 0,
+		func(_ context.Context, _ WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{
+			OnCoverageDegraded: func(_ []string) error {
+				degradedCalled = true
+				return nil
+			},
+			OnPollingRequired: func(o PollingObligation) error {
+				emitted = append(emitted, o)
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// Register roots so rootAgents is populated and the start-failure path
+	// has something to emit.
+	w.RegisterRoots([]WatchRoot{{
+		Path:      "/gemini",
+		Recursive: true,
+		Exists:    true,
+		Scopes:    []WatchScope{{Agent: "gemini", SyncDir: "/gemini-dir"}},
+	}}, 100)
+
+	startErr := w.Start()
+	require.Error(t, startErr, "Start must return an error when backend fails")
+
+	// OnCoverageDegraded must not be called; OnPollingRequired is the
+	// authoritative coverage path when it is set.
+	assert.False(t, degradedCalled,
+		"OnCoverageDegraded must not be called when OnPollingRequired is set (P1-B)")
+
+	// Named obligations must be emitted for all registered roots.
+	require.Len(t, emitted, 1,
+		"one obligation must be emitted per registered root on start failure")
+	ob := emitted[0]
+	assert.Equal(t, "startfailure:"+filepath.Clean("/gemini"), ob.Key,
+		"obligation key must use startfailure: prefix to avoid colliding with caller obligations")
+	assert.Equal(t, filepath.Clean("/gemini"), ob.Probe,
+		"probe must be the registered root path")
+	require.Len(t, ob.Scopes, 1,
+		"obligation must carry one scope per named agent")
+	assert.Equal(t, "gemini", ob.Scopes[0].Agent,
+		"scope must carry the provider agent identity from rootAgents")
+	assert.False(t, ob.Scopes[0].Agent == "",
+		"named-agent root must not produce an empty-agent scope")
+}
+
+// TestWatcherStartFailureEmitsNamedObligationForCleanRoot verifies the P1
+// regression: when OnPollingRequired is set and a root registered cleanly
+// (healthy result, no pending dirs), the backend's Start failure must still
+// emit a named obligation covering that root. The caller's pre-start
+// obligations (from watchPollingObligations) only cover roots with known
+// problems; a clean root has none, so start-failure coverage is the only
+// fallback.
+//
+// Crucially, the emitted scope's Root must be the configured SyncDir, not the
+// physical watch path. When the physical path and configured dir do not overlap
+// in either direction (the common case for nested provider roots), using the
+// physical path leaves the configured dir with no authoritative polling
+// coverage.
+func TestWatcherStartFailureEmitsNamedObligationForCleanRoot(t *testing.T) {
+	backend := newFakeWatchBackend()
+	backend.startErr = errors.New("backend start failed")
+
+	var emitted []PollingObligation
+	w, err := newWatcherWithBackendOptions(
+		0, 0,
+		func(_ context.Context, _ WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{
+			OnPollingRequired: func(o PollingObligation) error {
+				emitted = append(emitted, o)
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	w.RegisterRoots([]WatchRoot{{
+		Path:      "/claude",
+		Recursive: true,
+		Exists:    true,
+		Scopes:    []WatchScope{{Agent: "claude", SyncDir: "/claude-dir"}},
+	}}, 100)
+
+	startErr := w.Start()
+	require.Error(t, startErr)
+
+	require.Len(t, emitted, 1,
+		"start failure must emit one obligation for the cleanly-registered root")
+	ob := emitted[0]
+	assert.Equal(t, filepath.Clean("/claude"), ob.Probe)
+	hasClaudeAgent := slices.ContainsFunc(ob.Scopes, func(s PollingScope) bool {
+		return s.Agent == "claude"
+	})
+	assert.True(t, hasClaudeAgent,
+		"obligation must carry the provider's agent identity")
+	// The scope Root must be the configured SyncDir, not the physical watch path.
+	// Physical path /claude and configured dir /claude-dir do not overlap in
+	// either direction; using /claude instead of /claude-dir leaves the
+	// configured dir with no authoritative polling coverage.
+	claudeScope, found := func() (PollingScope, bool) {
+		for _, s := range ob.Scopes {
+			if s.Agent == "claude" {
+				return s, true
+			}
+		}
+		return PollingScope{}, false
+	}()
+	require.True(t, found, "claude agent scope must be present")
+	assert.Equal(t, filepath.Clean("/claude-dir"), filepath.Clean(claudeScope.Root),
+		"scope Root must be the configured SyncDir (/claude-dir), not the physical watch path (/claude)")
+}
+
+// TestWatcherStartFailureEmitsEmptyAgentScopeForNoAgentRoot verifies that when
+// a registered root has no named agents in rootScopes (e.g., all scopes had an
+// empty agent string), the start-failure path still emits an obligation
+// covering it with an empty-agent scope so that root is never silently dropped.
+func TestWatcherStartFailureEmitsEmptyAgentScopeForNoAgentRoot(t *testing.T) {
+	backend := newFakeWatchBackend()
+	backend.startErr = errors.New("backend start failed")
+
+	var emitted []PollingObligation
+	w, err := newWatcherWithBackendOptions(
+		0, 0,
+		func(_ context.Context, _ WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{
+			OnPollingRequired: func(o PollingObligation) error {
+				emitted = append(emitted, o)
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// Register with no scopes so rootScopes[path] = [] (no named agents).
+	w.RegisterRoots([]WatchRoot{{
+		Path:   "/no-agent-root",
+		Exists: true,
+		Scopes: nil,
+	}}, 100)
+
+	startErr := w.Start()
+	require.Error(t, startErr)
+
+	require.Len(t, emitted, 1,
+		"start failure must emit an obligation even for a root with no named agents")
+	ob := emitted[0]
+	require.Len(t, ob.Scopes, 1,
+		"absent-agent root must still emit one empty-agent scope for coverage")
+	assert.Equal(t, "", ob.Scopes[0].Agent,
+		"scope must use empty agent when rootScopes has no named agents for the root")
+}
+
+// TestWatcherStartFailureNoEmptyAgentForNamedRoot verifies that when
+// OnPollingRequired is set and a root has a named agent, the start-failure
+// emission does not produce an unscoped empty-agent obligation for that root.
+// An empty-agent scope would bypass per-agent probe gates and could let polling
+// authoritatively reconcile a scope whose nested root is missing, tombstoning
+// every session beneath it.
+func TestWatcherStartFailureNoEmptyAgentForNamedRoot(t *testing.T) {
+	backend := newFakeWatchBackend()
+	backend.startErr = errors.New("backend start failed")
+
+	var emitted []PollingObligation
+	w, err := newWatcherWithBackendOptions(
+		0, 0,
+		func(_ context.Context, _ WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{
+			OnPollingRequired: func(o PollingObligation) error {
+				emitted = append(emitted, o)
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	w.RegisterRoots([]WatchRoot{{
+		Path:      "/gemini",
+		Recursive: true,
+		Exists:    true,
+		Scopes:    []WatchScope{{Agent: "gemini", SyncDir: "/gemini-dir"}},
+	}}, 100)
+
+	startErr := w.Start()
+	require.Error(t, startErr)
+
+	require.NotEmpty(t, emitted,
+		"start failure must emit at least one obligation for the named-agent root")
+	for _, ob := range emitted {
+		for _, scope := range ob.Scopes {
+			assert.NotEmpty(t, scope.Agent,
+				"start failure must not emit empty-agent scope for a root with a named agent")
+		}
+	}
+}
+
+// TestWatcherStartFailureMixedScopesBothDirsAreCovered verifies the P1
+// Failure 2 regression: when a registered root has both a named-agent scope
+// and an empty-agent scope, the start-failure emission must carry BOTH
+// configured dirs and must NOT suppress the empty-agent scope just because a
+// named agent also exists on the same physical root. Before the fix,
+// RegisterRoots only stored named agents in rootAgents, discarding empty-agent
+// scopes entirely, so /legacy-dir was silently dropped.
+func TestWatcherStartFailureMixedScopesBothDirsAreCovered(t *testing.T) {
+	backend := newFakeWatchBackend()
+	backend.startErr = errors.New("backend start failed")
+
+	var emitted []PollingObligation
+	w, err := newWatcherWithBackendOptions(
+		0, 0,
+		func(_ context.Context, _ WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{
+			OnPollingRequired: func(o PollingObligation) error {
+				emitted = append(emitted, o)
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	w.RegisterRoots([]WatchRoot{{
+		Path:      "/watch",
+		Recursive: true,
+		Exists:    true,
+		Scopes: []WatchScope{
+			{Agent: "gemini", SyncDir: "/gemini-dir"},
+			{Agent: "", SyncDir: "/legacy-dir"},
+		},
+	}}, 100)
+
+	startErr := w.Start()
+	require.Error(t, startErr)
+
+	require.Len(t, emitted, 1, "one obligation per physical root")
+	ob := emitted[0]
+
+	// Both configured dirs must appear in the emitted scopes.
+	var geminiRoot, legacyRoot string
+	for _, s := range ob.Scopes {
+		switch s.Agent {
+		case "gemini":
+			geminiRoot = s.Root
+		case "":
+			legacyRoot = s.Root
+		}
+	}
+	assert.Equal(t, filepath.Clean("/gemini-dir"), filepath.Clean(geminiRoot),
+		"gemini scope Root must be the configured SyncDir /gemini-dir, not the physical path")
+	assert.NotEmpty(t, legacyRoot,
+		"empty-agent scope must not be dropped when a named agent coexists on the same root (P1 Failure 2)")
+	assert.Equal(t, filepath.Clean("/legacy-dir"), filepath.Clean(legacyRoot),
+		"empty-agent scope Root must be the configured SyncDir /legacy-dir")
+}

--- a/internal/sync/watcher_polling_test.go
+++ b/internal/sync/watcher_polling_test.go
@@ -73,8 +73,8 @@ func TestWatcherStartFailureSuppressesFallbackWhenPollingOwnershipSet(t *testing
 		"named-agent root must not produce an empty-agent scope")
 }
 
-// TestWatcherStartFailureEmitsNamedObligationForCleanRoot verifies the P1
-// regression: when OnPollingRequired is set and a root registered cleanly
+// TestWatcherStartFailureEmitsNamedObligationForCleanRoot verifies that
+// when OnPollingRequired is set and a root registered cleanly
 // (healthy result, no pending dirs), the backend's Start failure must still
 // emit a named obligation covering that root. The caller's pre-start
 // obligations (from watchPollingObligations) only cover roots with known
@@ -225,8 +225,8 @@ func TestWatcherStartFailureNoEmptyAgentForNamedRoot(t *testing.T) {
 	}
 }
 
-// TestWatcherStartFailureMixedScopesBothDirsAreCovered verifies the P1
-// Mixed-scope regression: when a registered root has both a named-agent scope
+// TestWatcherStartFailureMixedScopesBothDirsAreCovered verifies the
+// mixed-scope regression: when a registered root has both a named-agent scope
 // and an empty-agent scope, the start-failure emission must carry BOTH
 // configured dirs and must NOT suppress the empty-agent scope just because a
 // named agent also exists on the same physical root. Before the fix,


### PR DESCRIPTION
When one provider loses native watch coverage, the unwatched-root poller
flattened every obligation into a single root list and called the unscoped
reconcile entry point, which expands each root across every configured agent.
One provider's coverage gap therefore dragged every overlapping provider
through a full authoritative discovery every two minutes, and an authoritative
pass for the wrong provider can tombstone sessions under a lifecycle-owned
missing root. Two smaller bugs compounded it: obligations for different
reasons over one physical root collapsed into one map entry (releasing one
silently released the other), and the poll interval was measured between
ticker deadlines, so a pass that ran longer than the interval was followed
immediately by the next one.

What this changes:

- `PollingObligation` now carries `(agent, root)` scopes instead of bare
  roots. Provider identity travels through registration, the watcher
  backends, and the polling handoff instead of being reconstructed
  downstream (`internal/sync/watcher.go`, `cmd/agentsview/main.go`).
- The coordinator groups available scopes by agent and reconciles each
  provider only over its own roots. Obligation keys are namespaced by reason
  and provider (`degraded:<agent>:<path>`, `nowatcher:<agent>:<path>`,
  `persistent:<dir>`), so overlapping obligations stay independently
  releasable (`cmd/agentsview/unwatched_poll.go`).
- Persistent-polling obligations carry scopes only for the providers that
  requested persistent polling for a directory, not every agent sharing it.
  `collectWatchRoots` records that provenance and `watchPollingObligations`
  consumes it (`cmd/agentsview/main.go`).
- A poll pass issues one grouped engine call,
  `Engine.ReconcileProviderRootsGrouped`, which runs each provider's bounded
  pass but shares a single epilogue — global subagent linking and skip-cache
  persistence — across the batch. Without this, that archive-sized work ran
  once per provider per tick. The sync lock is held across the groups and the
  epilogue so a concurrent pass cannot persist newer skip state that the
  shared epilogue would then overwrite; a canceled batch stops between groups
  and skips the epilogue rather than blocking shutdown on it; epilogue
  eligibility is recorded at each pass's own gate sites (after page writes
  commit, before tombstoning), so a tombstoning or cleanup failure cannot
  leave synced sessions unlinked; and session events are emitted once per
  batch outside the lock (`internal/sync/engine.go`).
- The pre-discovery SQLite container capture is scoped to the pass: a group
  outside the OpenCode container family probes no containers, and an
  in-family group probes only the containers overlapping its roots, so probe
  work per poll is bounded by the batch instead of group count or total
  configuration (`internal/sync/opencode_container_gate.go`).
- The worker waits a full interval measured from the previous pass's
  completion, not from the previous ticker deadline.

Deferral is conservative where scopes mix: an obligation without a provider
keeps the unscoped path, so a blocked provider-less root defers every provider
on it and vice versa. Probe gates, remote roots, watcher recovery, and the
daily audit are unchanged; the audit remains the backstop for anything a
scoped poll declines to prove.

Each provider's pass still performs a full discovery over its scope; making
the pass itself incremental needs provider-declared coverage units and is
deferred to #1318, which builds on the polling-scope API introduced here. The
15-minute scheduled sync (`runScheduledSyncPass`) still reconciles providers
individually and could adopt the grouped call in a follow-up.

Refs #1208.
