### PR TITLE
fix(sync): preserve retries across repeated stale paths

### DIFF
--- a/internal/sync/live_activity.go
+++ b/internal/sync/live_activity.go
@@ -55,11 +55,12 @@ type LiveActivityPollStats struct {
 }
 
 type liveActivityHotEntry struct {
-	target       int
-	source       LiveActivitySource
-	lastActivity time.Time
-	pending      bool
-	refreshRetry *liveActivityRetryEntry
+	target           int
+	source           LiveActivitySource
+	lastActivity     time.Time
+	pending          bool
+	refreshRetry     *liveActivityRetryEntry
+	retryPendingStat bool
 }
 
 type liveActivityRetryEntry struct {
@@ -278,6 +279,7 @@ func (p *LiveActivityPoller) PollOnce(
 		if _, ok := attempted[fullID]; ok {
 			continue
 		}
+		attempted[fullID] = struct{}{}
 		stats.SessionLookups++
 		source, found, err := p.lookup(ctx, fullID)
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -308,6 +310,7 @@ func (p *LiveActivityPoller) PollOnce(
 		if _, ok := attempted[fullID]; ok {
 			continue
 		}
+		attempted[fullID] = struct{}{}
 		stats.SessionLookups++
 		source, found, err := p.lookup(ctx, fullID)
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -365,6 +368,10 @@ func (p *LiveActivityPoller) PollOnce(
 			pollErrors = append(pollErrors,
 				fmt.Errorf("stat live activity source %q: %w", entry.source.Path, err))
 			continue
+		}
+		if entry.retryPendingStat {
+			entry.refreshRetry = nil
+			entry.retryPendingStat = false
 		}
 		inode, device := getFileIdentity(entry.source.Path, info)
 		if entry.source.HasStoredStat &&
@@ -495,6 +502,7 @@ func (p *LiveActivityPoller) addHotRefreshRetry(
 		retry.target = target
 		retry.lastHint = lastHint
 	}
+	entry.retryPendingStat = false
 }
 
 func (p *LiveActivityPoller) setHot(
@@ -504,6 +512,7 @@ func (p *LiveActivityPoller) setHot(
 	lastActivity time.Time,
 ) {
 	source.Path = filepath.Clean(source.Path)
+	var refreshRetry *liveActivityRetryEntry
 	if entry := p.hot[fullID]; entry != nil {
 		if entry.lastActivity.After(lastActivity) {
 			lastActivity = entry.lastActivity
@@ -512,15 +521,20 @@ func (p *LiveActivityPoller) setHot(
 			retry.lastHint.After(lastActivity) {
 			lastActivity = retry.lastHint
 		}
+		refreshRetry = entry.refreshRetry
 	}
-	if retry := p.retries[fullID]; retry != nil &&
-		retry.lastHint.After(lastActivity) {
-		lastActivity = retry.lastHint
+	if retry := p.retries[fullID]; retry != nil {
+		if retry.lastHint.After(lastActivity) {
+			lastActivity = retry.lastHint
+		}
+		refreshRetry = retry
 	}
 	p.hot[fullID] = &liveActivityHotEntry{
-		target:       target,
-		source:       source,
-		lastActivity: lastActivity,
+		target:           target,
+		source:           source,
+		lastActivity:     lastActivity,
+		refreshRetry:     refreshRetry,
+		retryPendingStat: refreshRetry != nil,
 	}
 	delete(p.retries, fullID)
 }

--- a/internal/sync/live_activity.go
+++ b/internal/sync/live_activity.go
@@ -355,12 +355,13 @@ func (p *LiveActivityPoller) PollOnce(
 		}
 		if errors.Is(err, os.ErrNotExist) {
 			delete(p.hot, fullID)
+			if entry.refreshRetry != nil {
+				p.retries[fullID] = entry.refreshRetry
+			}
 			if hint, ok := hinted[fullID]; ok {
 				p.addRetry(
 					fullID, hint.target, now, hint.lastHint,
 				)
-			} else if entry.refreshRetry != nil {
-				p.retries[fullID] = entry.refreshRetry
 			}
 			continue
 		}

--- a/internal/sync/live_activity_test.go
+++ b/internal/sync/live_activity_test.go
@@ -585,6 +585,64 @@ func TestLiveActivityRetriesRepeatedMissingIndexedPaths(t *testing.T) {
 	assert.Equal(t, []string{canonical}, synced)
 }
 
+func TestLiveActivityOlderReplayPreservesRetryAcrossRepeatedMissingPaths(
+	t *testing.T,
+) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	dir := t.TempDir()
+	history := filepath.Join(dir, "history.jsonl")
+	firstMissing := filepath.Join(dir, "first-missing.jsonl")
+	secondMissing := filepath.Join(dir, "second-missing.jsonl")
+	canonical := filepath.Join(dir, "canonical.jsonl")
+	require.NoError(t, os.WriteFile(
+		history, []byte(hintRecord("move", now)), 0o644,
+	))
+	require.NoError(t, os.WriteFile(canonical, []byte("active\n"), 0o644))
+	provider := newLiveActivityTestProvider(history)
+	lookupPaths := []string{firstMissing, secondMissing, canonical}
+	lookups := 0
+	var synced []string
+	poller := NewLiveActivityPoller([]LiveActivityTarget{{
+		Provider: provider,
+		Hints:    provider,
+		Sources:  []parser.ActivityHintSource{{Path: history}},
+	}}, func(_ context.Context, id string) (LiveActivitySource, bool, error) {
+		assert.Equal(t, "codex:move", id)
+		require.Less(t, lookups, len(lookupPaths))
+		path := lookupPaths[lookups]
+		lookups++
+		return LiveActivitySource{Path: path}, true, nil
+	}, func(_ context.Context, paths []string) error {
+		synced = append(synced, paths...)
+		return nil
+	}, nil)
+
+	_, err := poller.PollOnce(t.Context(), now)
+	require.NoError(t, err)
+	require.Contains(t, poller.retries, "codex:move")
+
+	replacement := history + ".older"
+	require.NoError(t, os.WriteFile(
+		replacement,
+		[]byte(hintRecord("move", now.Add(-time.Hour))),
+		0o644,
+	))
+	require.NoError(t, os.Rename(replacement, history))
+	_, err = poller.PollOnce(t.Context(), now.Add(time.Minute))
+	require.NoError(t, err)
+	require.Contains(t, poller.retries, "codex:move")
+	assert.Equal(t, now, poller.retries["codex:move"].firstSeen)
+	assert.Equal(t, now, poller.retries["codex:move"].lastHint)
+
+	_, err = poller.PollOnce(t.Context(), now.Add(time.Minute+time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, 3, lookups)
+	require.Contains(t, poller.hot, "codex:move")
+	assert.Equal(t, canonical, poller.hot["codex:move"].source.Path)
+	assert.NotContains(t, poller.retries, "codex:move")
+	assert.Equal(t, []string{canonical}, synced)
+}
+
 func TestLiveActivityPreservesRefreshRetryAcrossHotExpiration(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0).UTC()
 	dir := t.TempDir()

--- a/internal/sync/live_activity_test.go
+++ b/internal/sync/live_activity_test.go
@@ -537,6 +537,54 @@ func TestLiveActivityRetriesHintWhoseIndexedPathIsMissing(t *testing.T) {
 	assert.Equal(t, []string{canonical}, synced)
 }
 
+func TestLiveActivityRetriesRepeatedMissingIndexedPaths(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	dir := t.TempDir()
+	history := filepath.Join(dir, "history.jsonl")
+	firstMissing := filepath.Join(dir, "first-missing.jsonl")
+	secondMissing := filepath.Join(dir, "second-missing.jsonl")
+	canonical := filepath.Join(dir, "canonical.jsonl")
+	require.NoError(t, os.WriteFile(
+		history, []byte(hintRecord("move", now)), 0o644,
+	))
+	require.NoError(t, os.WriteFile(canonical, []byte("active\n"), 0o644))
+	provider := newLiveActivityTestProvider(history)
+	lookupPaths := []string{firstMissing, secondMissing, canonical}
+	lookups := 0
+	var synced []string
+	poller := NewLiveActivityPoller([]LiveActivityTarget{{
+		Provider: provider,
+		Hints:    provider,
+		Sources:  []parser.ActivityHintSource{{Path: history}},
+	}}, func(_ context.Context, id string) (LiveActivitySource, bool, error) {
+		assert.Equal(t, "codex:move", id)
+		require.Less(t, lookups, len(lookupPaths))
+		path := lookupPaths[lookups]
+		lookups++
+		return LiveActivitySource{Path: path}, true, nil
+	}, func(_ context.Context, paths []string) error {
+		synced = append(synced, paths...)
+		return nil
+	}, nil)
+
+	_, err := poller.PollOnce(t.Context(), now)
+	require.NoError(t, err)
+	require.Contains(t, poller.retries, "codex:move")
+
+	_, err = poller.PollOnce(t.Context(), now.Add(time.Second))
+	require.NoError(t, err)
+	require.Contains(t, poller.retries, "codex:move",
+		"a second stale indexed path must not consume the retry")
+
+	_, err = poller.PollOnce(t.Context(), now.Add(2*time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, 3, lookups)
+	require.Contains(t, poller.hot, "codex:move")
+	assert.Equal(t, canonical, poller.hot["codex:move"].source.Path)
+	assert.NotContains(t, poller.retries, "codex:move")
+	assert.Equal(t, []string{canonical}, synced)
+}
+
 func TestLiveActivityPreservesRefreshRetryAcrossHotExpiration(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0).UTC()
 	dir := t.TempDir()


### PR DESCRIPTION
Live activity hints can resolve through several stale indexed paths while a rollout is moving. #1308 kept the initial missing-path lookup retryable, but a later retry that resolved to another missing path consumed that state and could leave the session stale until another prompt arrived.

This follow-up retains the bounded retry until the candidate path is successfully statted and records retry and refresh lookups in the poll-wide attempted set. Cursor resets can replay older hints, so carried retry state is restored before merging the replay and only genuinely newer activity can restart the retry window.

Each session still incurs at most one lookup per poll, while the existing retry TTL and global state bounds remain unchanged.