### PR TITLE
fix: improve worktree path readability

### DIFF
--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -449,6 +449,7 @@ func createDurationShowcaseFixture(
 		Project:          project,
 		Machine:          "test-machine",
 		Agent:            "claude",
+		Cwd:              "/workspace/مشروع/.worktrees/שלום-feature-with-a-long-checkout-name",
 		StartedAt:        new(t0.Format(time.RFC3339Nano)),
 		EndedAt:          new(endParent.Format(time.RFC3339Nano)),
 		MessageCount:     len(parentMessages),

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -449,7 +449,7 @@ func createDurationShowcaseFixture(
 		Project:          project,
 		Machine:          "test-machine",
 		Agent:            "claude",
-		Cwd:              "/workspace/مشروع/.worktrees/שלום-feature-with-a-long-checkout-name",
+		Cwd:              "/workspace/مشروع/.worktrees/שלום-feature-with-a-deliberately-long-checkout-name-for-tooltip-wrapping",
 		StartedAt:        new(t0.Format(time.RFC3339Nano)),
 		EndedAt:          new(endParent.Format(time.RFC3339Nano)),
 		MessageCount:     len(parentMessages),

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -449,7 +449,7 @@ func createDurationShowcaseFixture(
 		Project:          project,
 		Machine:          "test-machine",
 		Agent:            "claude",
-		Cwd:              "/workspace/مشروع/.worktrees/שלום-feature-with-a-deliberately-long-checkout-name-for-tooltip-wrapping",
+		Cwd:              "/workspace/مشروع/.worktrees/שלוםfeaturewithalongcheckoutnamefortooltipwrappingwithoutbreakopportunities",
 		StartedAt:        new(t0.Format(time.RFC3339Nano)),
 		EndedAt:          new(endParent.Format(time.RFC3339Nano)),
 		MessageCount:     len(parentMessages),

--- a/docs/superpowers/plans/2026-07-30-worktree-tooltip-width.md
+++ b/docs/superpowers/plans/2026-07-30-worktree-tooltip-width.md
@@ -1,0 +1,214 @@
+# Worktree Tooltip Width Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans
+> to implement this plan directly in the current agent, task-by-task. Never use
+> subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the session-vitals worktree tooltip use up to half of the viewport
+so ordinary paths stay on one line while oversized paths wrap.
+
+**Approved spec/design:**
+`docs/superpowers/specs/2026-07-30-worktree-tooltip-width-design.md`
+
+**Architecture:** Keep kit-ui's generic tooltip sizing unchanged. Pass a
+dedicated class to the existing worktree `Tooltip`, then use the supported class
+hook to override only that popover's maximum width while retaining kit-ui's
+fixed viewport positioning.
+
+**Tech Stack:** Svelte 5, TypeScript, `@kenn-io/kit-ui`, Playwright, Vitest
+
+## Global Constraints
+
+- The generic kit-ui tooltip must retain its 280-pixel default maximum width.
+- The worktree tooltip maximum width is `min(50vw, calc(100vw - 32px))`.
+- Paths that fit within the cap stay on one line; longer paths wrap.
+- The tooltip may extend left of the analysis sidebar but must remain inside the
+  viewport.
+- Preserve the existing LTR-isolated path text, start truncation, hover and
+  keyboard behavior, copy control, and empty state.
+
+______________________________________________________________________
+
+### Task 1: Make the worktree tooltip viewport-relative
+
+**Files:**
+
+- Modify: `cmd/testfixture/main.go`
+- Modify: `frontend/e2e/session-timing.spec.ts`
+- Modify: `frontend/src/lib/components/content/SessionVitals.svelte`
+
+**Interfaces:**
+
+- Consumes: kit-ui `Tooltip`'s supported `class?: string` prop and existing
+  fixed-position viewport clamping.
+
+- Produces: a `worktree-path-tooltip` popover class scoped to the session-vitals
+  worktree tooltip.
+
+- [ ] **Step 1: Make the fixture deterministic and write the failing browser
+  test**
+
+In `cmd/testfixture/main.go`, lengthen the showcase session's existing synthetic
+worktree path to exactly this value:
+
+```go
+Cwd: "/workspace/مشروع/.worktrees/שלום-feature-with-a-deliberately-long-checkout-name-for-tooltip-wrapping",
+```
+
+Update `SHOWCASE_WORKTREE` in `frontend/e2e/session-timing.spec.ts` to the same
+literal:
+
+```ts
+const SHOWCASE_WORKTREE =
+  "/workspace/مشروع/.worktrees/שלום-feature-with-a-deliberately-long-checkout-name-for-tooltip-wrapping";
+```
+
+Add this test after the existing mixed-direction worktree-path regression in
+`frontend/e2e/session-timing.spec.ts`:
+
+```ts
+test("uses available viewport width for the worktree tooltip", async ({
+  page,
+}) => {
+  await gotoShowcase(page);
+
+  const panel = page.locator("aside.vitals");
+  const path = page.locator(".context-value--path");
+  await path.hover();
+
+  const tooltip = page.getByRole("tooltip");
+  await expect(tooltip).toHaveText(SHOWCASE_WORKTREE);
+  const panelLeft = await panel.evaluate(
+    (element) => element.getBoundingClientRect().left,
+  );
+  const wideLayout = await tooltip.evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const lineTops = Array.from(
+      range.getClientRects(),
+      (rect) => Math.round(rect.top),
+    );
+    const rect = element.getBoundingClientRect();
+    return {
+      left: rect.left,
+      lineCount: new Set(lineTops).size,
+      viewportWidth: window.innerWidth,
+      width: rect.width,
+    };
+  });
+
+  expect(wideLayout.width).toBeLessThanOrEqual(
+    wideLayout.viewportWidth * 0.5 + 1,
+  );
+  expect(wideLayout.lineCount).toBe(1);
+  expect(wideLayout.left).toBeLessThan(panelLeft);
+
+  await page.setViewportSize({ width: 1000, height: 900 });
+  await expect(path).toBeVisible();
+  await path.hover();
+  const narrowLayout = await tooltip.evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const lineTops = Array.from(
+      range.getClientRects(),
+      (rect) => Math.round(rect.top),
+    );
+    const rect = element.getBoundingClientRect();
+    return {
+      lineCount: new Set(lineTops).size,
+      viewportWidth: window.innerWidth,
+      width: rect.width,
+    };
+  });
+
+  expect(narrowLayout.width).toBeLessThanOrEqual(
+    narrowLayout.viewportWidth * 0.5 + 1,
+  );
+  expect(narrowLayout.lineCount).toBeGreaterThan(1);
+});
+```
+
+- [ ] **Step 2: Run the browser test to verify it fails**
+
+Run:
+
+```bash
+cd frontend
+npm run e2e -- session-timing.spec.ts --project=chromium \
+  --grep "uses available viewport width for the worktree tooltip"
+```
+
+Expected: FAIL because the current 280-pixel maximum wraps the 100-character
+fixture path at the default 1600-pixel viewport, so `wideLayout.lineCount` is
+greater than 1 and the tooltip remains inside the sidebar.
+
+- [ ] **Step 3: Add the per-use width override**
+
+In `frontend/src/lib/components/content/SessionVitals.svelte`, pass the popover
+class through the existing tooltip:
+
+```svelte
+<Tooltip
+  text={session.cwd}
+  focusable
+  class="worktree-path-tooltip"
+>
+```
+
+Add the scoped global rule next to the existing `.context-tooltip` integration
+styles:
+
+```css
+.context-tooltip :global(.worktree-path-tooltip) {
+  max-width: min(50vw, calc(100vw - 32px));
+  overflow-wrap: anywhere;
+}
+```
+
+Do not modify kit-ui source or the shared `.kit-tooltip` rule.
+
+- [ ] **Step 4: Run the focused browser regression in both engines**
+
+Run:
+
+```bash
+cd frontend
+npm run e2e -- session-timing.spec.ts --project=chromium \
+  --grep "uses available viewport width for the worktree tooltip"
+npm run e2e -- session-timing.spec.ts --project=webkit \
+  --grep "uses available viewport width for the worktree tooltip"
+```
+
+Expected: PASS in Chromium and WebKit. The default viewport renders one line and
+positions the tooltip left of the sidebar; the 1000-pixel viewport wraps the
+same complete path without exceeding 500 pixels.
+
+- [ ] **Step 5: Run the affected component and integration checks**
+
+Run:
+
+```bash
+cd frontend
+npm test -- --run src/lib/components/content/SessionVitals.test.ts
+npm run e2e -- session-timing.spec.ts --project=chromium
+npm run check
+npm run check:kit-ui
+cd ..
+go fmt ./...
+go vet ./...
+```
+
+Expected: 12 component tests and all 7 Chromium session-vitals tests pass,
+Svelte reports 0 errors, kit-ui reports 0 findings, and Go formatting and vet
+complete successfully. Existing unrelated Svelte unused-selector warnings may
+remain.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add cmd/testfixture/main.go \
+  frontend/e2e/session-timing.spec.ts \
+  frontend/src/lib/components/content/SessionVitals.svelte
+git commit -m "fix: widen worktree path tooltip" \
+  -m "The shared 280-pixel default suits prose but forces filesystem paths to wrap inside the analysis sidebar. Give only the worktree tooltip a viewport-relative limit so ordinary paths stay on one line while oversized paths wrap at half the viewport."
+```

--- a/docs/superpowers/plans/2026-07-30-worktree-tooltip-width.md
+++ b/docs/superpowers/plans/2026-07-30-worktree-tooltip-width.md
@@ -13,7 +13,7 @@ so ordinary paths stay on one line while oversized paths wrap.
 **Architecture:** Keep kit-ui's generic tooltip sizing unchanged. Pass a
 dedicated class to the existing worktree `Tooltip`, then use the supported class
 hook to override only that popover's maximum width while retaining kit-ui's
-fixed viewport positioning.
+fixed viewport positioning and end-aligning its arrow with the trigger.
 
 **Tech Stack:** Svelte 5, TypeScript, `@kenn-io/kit-ui`, Playwright, Vitest
 
@@ -24,6 +24,8 @@ fixed viewport positioning.
 - Paths that fit within the cap stay on one line; longer paths wrap.
 - The tooltip may extend left of the analysis sidebar but must remain inside the
   viewport.
+- Unbroken path segments must wrap rather than overflow, and the tooltip arrow
+  must remain over the worktree trigger.
 - Preserve the existing LTR-isolated path text, start truncation, hover and
   keyboard behavior, copy control, and empty state.
 
@@ -39,8 +41,8 @@ ______________________________________________________________________
 
 **Interfaces:**
 
-- Consumes: kit-ui `Tooltip`'s supported `class?: string` prop and existing
-  fixed-position viewport clamping.
+- Consumes: kit-ui `Tooltip`'s supported `class?: string` and `align` props plus
+  existing fixed-position viewport clamping.
 
 - Produces: a `worktree-path-tooltip` popover class scoped to the session-vitals
   worktree tooltip.
@@ -52,7 +54,7 @@ In `cmd/testfixture/main.go`, lengthen the showcase session's existing synthetic
 worktree path to exactly this value:
 
 ```go
-Cwd: "/workspace/مشروع/.worktrees/שלום-feature-with-a-deliberately-long-checkout-name-for-tooltip-wrapping",
+Cwd: "/workspace/مشروع/.worktrees/שלוםfeaturewithalongcheckoutnamefortooltipwrappingwithoutbreakopportunities",
 ```
 
 Update `SHOWCASE_WORKTREE` in `frontend/e2e/session-timing.spec.ts` to the same
@@ -60,7 +62,7 @@ literal:
 
 ```ts
 const SHOWCASE_WORKTREE =
-  "/workspace/مشروع/.worktrees/שלום-feature-with-a-deliberately-long-checkout-name-for-tooltip-wrapping";
+  "/workspace/مشروع/.worktrees/שלוםfeaturewithalongcheckoutnamefortooltipwrappingwithoutbreakopportunities";
 ```
 
 Add this test after the existing mixed-direction worktree-path regression in
@@ -74,6 +76,7 @@ test("uses available viewport width for the worktree tooltip", async ({
 
   const panel = page.locator("aside.vitals");
   const path = page.locator(".context-value--path");
+  const trigger = page.locator(".context-tooltip .kit-tooltip-trigger");
   await path.hover();
 
   const tooltip = page.getByRole("tooltip");
@@ -89,19 +92,35 @@ test("uses available viewport width for the worktree tooltip", async ({
       (rect) => Math.round(rect.top),
     );
     const rect = element.getBoundingClientRect();
+    const arrowStyle = getComputedStyle(element, "::before");
+    const arrowWidth = Number.parseFloat(arrowStyle.width);
+    const arrowCenter =
+      arrowStyle.left === "auto"
+        ? rect.right - Number.parseFloat(arrowStyle.right) - arrowWidth / 2
+        : rect.left + Number.parseFloat(arrowStyle.left) + arrowWidth / 2;
     return {
+      arrowCenter,
       left: rect.left,
       lineCount: new Set(lineTops).size,
+      right: rect.right,
       viewportWidth: window.innerWidth,
       width: rect.width,
     };
   });
+  const triggerBounds = await trigger.boundingBox();
+  expect(triggerBounds).not.toBeNull();
 
   expect(wideLayout.width).toBeLessThanOrEqual(
     wideLayout.viewportWidth * 0.5 + 1,
   );
   expect(wideLayout.lineCount).toBe(1);
+  expect(wideLayout.left).toBeGreaterThanOrEqual(0);
+  expect(wideLayout.right).toBeLessThanOrEqual(wideLayout.viewportWidth);
   expect(wideLayout.left).toBeLessThan(panelLeft);
+  expect(wideLayout.arrowCenter).toBeGreaterThanOrEqual(triggerBounds!.x);
+  expect(wideLayout.arrowCenter).toBeLessThanOrEqual(
+    triggerBounds!.x + triggerBounds!.width,
+  );
 
   await page.setViewportSize({ width: 1000, height: 900 });
   await expect(path).toBeVisible();
@@ -115,7 +134,11 @@ test("uses available viewport width for the worktree tooltip", async ({
     );
     const rect = element.getBoundingClientRect();
     return {
+      clientWidth: element.clientWidth,
+      left: rect.left,
       lineCount: new Set(lineTops).size,
+      right: rect.right,
+      scrollWidth: element.scrollWidth,
       viewportWidth: window.innerWidth,
       width: rect.width,
     };
@@ -125,6 +148,11 @@ test("uses available viewport width for the worktree tooltip", async ({
     narrowLayout.viewportWidth * 0.5 + 1,
   );
   expect(narrowLayout.lineCount).toBeGreaterThan(1);
+  expect(narrowLayout.scrollWidth).toBeLessThanOrEqual(
+    narrowLayout.clientWidth + 1,
+  );
+  expect(narrowLayout.left).toBeGreaterThanOrEqual(0);
+  expect(narrowLayout.right).toBeLessThanOrEqual(narrowLayout.viewportWidth);
 });
 ```
 
@@ -138,9 +166,10 @@ npm run e2e -- session-timing.spec.ts --project=chromium \
   --grep "uses available viewport width for the worktree tooltip"
 ```
 
-Expected: FAIL because the current 280-pixel maximum wraps the 100-character
-fixture path at the default 1600-pixel viewport, so `wideLayout.lineCount` is
-greater than 1 and the tooltip remains inside the sidebar.
+Expected: FAIL because the current 280-pixel maximum wraps the fixture path at
+the default 1600-pixel viewport, so `wideLayout.lineCount` is greater than 1.
+After adding only the width override, the arrow assertion also fails until the
+tooltip is end-aligned.
 
 - [ ] **Step 3: Add the per-use width override**
 
@@ -151,6 +180,7 @@ class through the existing tooltip:
 <Tooltip
   text={session.cwd}
   focusable
+  align="end"
   class="worktree-path-tooltip"
 >
 ```
@@ -181,7 +211,9 @@ npm run e2e -- session-timing.spec.ts --project=webkit \
 
 Expected: PASS in Chromium and WebKit. The default viewport renders one line and
 positions the tooltip left of the sidebar; the 1000-pixel viewport wraps the
-same complete path without exceeding 500 pixels.
+same complete path without exceeding 500 pixels or overflowing its unbroken
+segment. Both layouts remain viewport-contained, with the arrow over the
+trigger.
 
 - [ ] **Step 5: Run the affected component and integration checks**
 

--- a/docs/superpowers/specs/2026-07-30-worktree-tooltip-width-design.md
+++ b/docs/superpowers/specs/2026-07-30-worktree-tooltip-width-design.md
@@ -1,0 +1,43 @@
+# Worktree Tooltip Width Design
+
+## Problem
+
+The shared kit-ui tooltip limits all content to 280 pixels. That is useful for
+short explanatory copy, but it forces ordinary filesystem paths to wrap inside
+the narrow session-analysis sidebar. The tooltip uses fixed positioning and can
+already move outside that sidebar, so the generic width limit wastes available
+viewport space.
+
+## Design
+
+Keep the shared tooltip default unchanged. Pass a dedicated class through the
+worktree tooltip's supported `class` prop and override only that tooltip's
+maximum width:
+
+```css
+max-width: min(50vw, calc(100vw - 32px));
+```
+
+The tooltip retains kit-ui's existing `width: max-content`. A path that fits
+within half of the viewport therefore stays on one line. A longer path wraps
+naturally once it reaches the 50 percent cap. Kit-ui's fixed-position floating
+logic continues to shift the tooltip left when the trigger is near the right
+viewport edge, allowing the bubble to extend outside the sidebar without leaving
+the viewport.
+
+The displayed path and tooltip content remain LTR-isolated technical
+identifiers. Hover, keyboard focus, copy behavior, and the compact truncated row
+remain unchanged.
+
+## Verification
+
+Extend the session-vitals browser coverage to assert that the worktree tooltip:
+
+- contains the complete path;
+- never exceeds 50 percent of the viewport width;
+- stays on one line when the fixture path fits under that limit;
+- extends left of the sidebar when additional width is needed; and
+- wraps when synthetic content exceeds the viewport-relative cap.
+
+Keep the existing mixed-direction path geometry regression and component tooltip
+interaction test.

--- a/docs/superpowers/specs/2026-07-30-worktree-tooltip-width-design.md
+++ b/docs/superpowers/specs/2026-07-30-worktree-tooltip-width-design.md
@@ -16,14 +16,17 @@ maximum width:
 
 ```css
 max-width: min(50vw, calc(100vw - 32px));
+overflow-wrap: anywhere;
 ```
 
 The tooltip retains kit-ui's existing `width: max-content`. A path that fits
 within half of the viewport therefore stays on one line. A longer path wraps
-naturally once it reaches the 50 percent cap. Kit-ui's fixed-position floating
-logic continues to shift the tooltip left when the trigger is near the right
-viewport edge, allowing the bubble to extend outside the sidebar without leaving
-the viewport.
+once it reaches the 50 percent cap, including when a single path segment has no
+natural line-breaking opportunity. The tooltip uses end alignment so kit-ui's
+fixed-position floating logic anchors its right edge and arrow to the trigger
+near the viewport's right edge. This allows the bubble to extend outside the
+sidebar without leaving the viewport or visually detaching its arrow from the
+worktree row.
 
 The displayed path and tooltip content remain LTR-isolated technical
 identifiers. Hover, keyboard focus, copy behavior, and the compact truncated row
@@ -36,8 +39,10 @@ Extend the session-vitals browser coverage to assert that the worktree tooltip:
 - contains the complete path;
 - never exceeds 50 percent of the viewport width;
 - stays on one line when the fixture path fits under that limit;
-- extends left of the sidebar when additional width is needed; and
-- wraps when synthetic content exceeds the viewport-relative cap.
+- extends left of the sidebar when additional width is needed;
+- remains inside the viewport with its arrow over the trigger; and
+- wraps an unbroken path segment without overflowing when synthetic content
+  exceeds the viewport-relative cap.
 
 Keep the existing mixed-direction path geometry regression and component tooltip
 interaction test.

--- a/frontend/e2e/session-timing.spec.ts
+++ b/frontend/e2e/session-timing.spec.ts
@@ -13,7 +13,7 @@ import { test, expect, type Page } from "@playwright/test";
 
 const SHOWCASE = "test-session-duration-showcase";
 const SHOWCASE_WORKTREE =
-  "/workspace/مشروع/.worktrees/שלום-feature-with-a-deliberately-long-checkout-name-for-tooltip-wrapping";
+  "/workspace/مشروع/.worktrees/שלוםfeaturewithalongcheckoutnamefortooltipwrappingwithoutbreakopportunities";
 
 // The conversation scrolls inside `.message-list-scroll`
 // (`SessionsPage.scroller`). The plan's sketch referenced
@@ -131,6 +131,7 @@ test.describe("Session Vital Signs", () => {
 
     const panel = page.locator("aside.vitals");
     const path = page.locator(".context-value--path");
+    const trigger = page.locator(".context-tooltip .kit-tooltip-trigger");
     await path.hover();
 
     const tooltip = page.getByRole("tooltip");
@@ -146,19 +147,35 @@ test.describe("Session Vital Signs", () => {
         (rect) => Math.round(rect.top),
       );
       const rect = element.getBoundingClientRect();
+      const arrowStyle = getComputedStyle(element, "::before");
+      const arrowWidth = Number.parseFloat(arrowStyle.width);
+      const arrowCenter =
+        arrowStyle.left === "auto"
+          ? rect.right - Number.parseFloat(arrowStyle.right) - arrowWidth / 2
+          : rect.left + Number.parseFloat(arrowStyle.left) + arrowWidth / 2;
       return {
+        arrowCenter,
         left: rect.left,
         lineCount: new Set(lineTops).size,
+        right: rect.right,
         viewportWidth: window.innerWidth,
         width: rect.width,
       };
     });
+    const triggerBounds = await trigger.boundingBox();
+    expect(triggerBounds).not.toBeNull();
 
     expect(wideLayout.width).toBeLessThanOrEqual(
       wideLayout.viewportWidth * 0.5 + 1,
     );
     expect(wideLayout.lineCount).toBe(1);
+    expect(wideLayout.left).toBeGreaterThanOrEqual(0);
+    expect(wideLayout.right).toBeLessThanOrEqual(wideLayout.viewportWidth);
     expect(wideLayout.left).toBeLessThan(panelLeft);
+    expect(wideLayout.arrowCenter).toBeGreaterThanOrEqual(triggerBounds!.x);
+    expect(wideLayout.arrowCenter).toBeLessThanOrEqual(
+      triggerBounds!.x + triggerBounds!.width,
+    );
 
     await page.setViewportSize({ width: 1000, height: 900 });
     await expect(path).toBeVisible();
@@ -172,7 +189,11 @@ test.describe("Session Vital Signs", () => {
       );
       const rect = element.getBoundingClientRect();
       return {
+        clientWidth: element.clientWidth,
+        left: rect.left,
         lineCount: new Set(lineTops).size,
+        right: rect.right,
+        scrollWidth: element.scrollWidth,
         viewportWidth: window.innerWidth,
         width: rect.width,
       };
@@ -182,6 +203,11 @@ test.describe("Session Vital Signs", () => {
       narrowLayout.viewportWidth * 0.5 + 1,
     );
     expect(narrowLayout.lineCount).toBeGreaterThan(1);
+    expect(narrowLayout.scrollWidth).toBeLessThanOrEqual(
+      narrowLayout.clientWidth + 1,
+    );
+    expect(narrowLayout.left).toBeGreaterThanOrEqual(0);
+    expect(narrowLayout.right).toBeLessThanOrEqual(narrowLayout.viewportWidth);
   });
 
   test("slowest-call link scrolls the conversation", async ({

--- a/frontend/e2e/session-timing.spec.ts
+++ b/frontend/e2e/session-timing.spec.ts
@@ -13,7 +13,7 @@ import { test, expect, type Page } from "@playwright/test";
 
 const SHOWCASE = "test-session-duration-showcase";
 const SHOWCASE_WORKTREE =
-  "/workspace/مشروع/.worktrees/שלום-feature-with-a-long-checkout-name";
+  "/workspace/مشروع/.worktrees/שלום-feature-with-a-deliberately-long-checkout-name-for-tooltip-wrapping";
 
 // The conversation scrolls inside `.message-list-scroll`
 // (`SessionsPage.scroller`). The plan's sketch referenced
@@ -122,6 +122,66 @@ test.describe("Session Vital Signs", () => {
     expect(layout.lastRight).toBeLessThanOrEqual(
       layout.containerRight,
     );
+  });
+
+  test("uses available viewport width for the worktree tooltip", async ({
+    page,
+  }) => {
+    await gotoShowcase(page);
+
+    const panel = page.locator("aside.vitals");
+    const path = page.locator(".context-value--path");
+    await path.hover();
+
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toHaveText(SHOWCASE_WORKTREE);
+    const panelLeft = await panel.evaluate(
+      (element) => element.getBoundingClientRect().left,
+    );
+    const wideLayout = await tooltip.evaluate((element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      const lineTops = Array.from(
+        range.getClientRects(),
+        (rect) => Math.round(rect.top),
+      );
+      const rect = element.getBoundingClientRect();
+      return {
+        left: rect.left,
+        lineCount: new Set(lineTops).size,
+        viewportWidth: window.innerWidth,
+        width: rect.width,
+      };
+    });
+
+    expect(wideLayout.width).toBeLessThanOrEqual(
+      wideLayout.viewportWidth * 0.5 + 1,
+    );
+    expect(wideLayout.lineCount).toBe(1);
+    expect(wideLayout.left).toBeLessThan(panelLeft);
+
+    await page.setViewportSize({ width: 1000, height: 900 });
+    await expect(path).toBeVisible();
+    await path.hover();
+    const narrowLayout = await tooltip.evaluate((element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      const lineTops = Array.from(
+        range.getClientRects(),
+        (rect) => Math.round(rect.top),
+      );
+      const rect = element.getBoundingClientRect();
+      return {
+        lineCount: new Set(lineTops).size,
+        viewportWidth: window.innerWidth,
+        width: rect.width,
+      };
+    });
+
+    expect(narrowLayout.width).toBeLessThanOrEqual(
+      narrowLayout.viewportWidth * 0.5 + 1,
+    );
+    expect(narrowLayout.lineCount).toBeGreaterThan(1);
   });
 
   test("slowest-call link scrolls the conversation", async ({

--- a/frontend/e2e/session-timing.spec.ts
+++ b/frontend/e2e/session-timing.spec.ts
@@ -12,6 +12,8 @@ import { test, expect, type Page } from "@playwright/test";
 // shape needed to cover all four section interactions.
 
 const SHOWCASE = "test-session-duration-showcase";
+const SHOWCASE_WORKTREE =
+  "/workspace/مشروع/.worktrees/שלום-feature-with-a-long-checkout-name";
 
 // The conversation scrolls inside `.message-list-scroll`
 // (`SessionsPage.scroller`). The plan's sketch referenced
@@ -60,6 +62,66 @@ test.describe("Session Vital Signs", () => {
     await expect(
       page.locator(".v-section .v-h", { hasText: "Calls" }),
     ).toBeVisible();
+  });
+
+  test("keeps an absolute mixed-direction worktree path ordered", async ({
+    page,
+  }) => {
+    await gotoShowcase(page);
+
+    const path = page.locator(".context-value--path");
+    await expect(path).toHaveText(SHOWCASE_WORKTREE);
+
+    const layout = await path.evaluate((element, expectedPath) => {
+      const walker = document.createTreeWalker(
+        element,
+        NodeFilter.SHOW_TEXT,
+      );
+      let textNode = walker.nextNode();
+      while (
+        textNode &&
+        !textNode.textContent?.includes(expectedPath)
+      ) {
+        textNode = walker.nextNode();
+      }
+      if (!textNode?.textContent) {
+        throw new Error("worktree path text node not found");
+      }
+
+      const start = textNode.textContent.indexOf(expectedPath);
+      const firstCharacter = document.createRange();
+      firstCharacter.setStart(textNode, start);
+      firstCharacter.setEnd(textNode, start + 1);
+      const lastCharacter = document.createRange();
+      lastCharacter.setStart(
+        textNode,
+        start + expectedPath.length - 1,
+      );
+      lastCharacter.setEnd(textNode, start + expectedPath.length);
+
+      const container = element.getBoundingClientRect();
+      const first = firstCharacter.getBoundingClientRect();
+      const last = lastCharacter.getBoundingClientRect();
+      return {
+        overflows: element.scrollWidth > element.clientWidth,
+        containerLeft: container.left,
+        containerRight: container.right,
+        firstRight: first.right,
+        lastLeft: last.left,
+        lastRight: last.right,
+      };
+    }, SHOWCASE_WORKTREE);
+
+    expect(layout.overflows).toBe(true);
+    expect(layout.firstRight).toBeLessThanOrEqual(
+      layout.containerLeft,
+    );
+    expect(layout.lastLeft).toBeGreaterThanOrEqual(
+      layout.containerLeft,
+    );
+    expect(layout.lastRight).toBeLessThanOrEqual(
+      layout.containerRight,
+    );
   });
 
   test("slowest-call link scrolls the conversation", async ({

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -343,7 +343,11 @@
               </div>
               {#if session.cwd}
                 <div class="context-tooltip">
-                  <Tooltip text={session.cwd} focusable>
+                  <Tooltip
+                    text={session.cwd}
+                    focusable
+                    class="worktree-path-tooltip"
+                  >
                     <div class="context-value context-value--path">
                       <bdi dir="ltr">{session.cwd}</bdi>
                     </div>
@@ -801,6 +805,11 @@
   .context-tooltip :global(.kit-tooltip-trigger) {
     display: flex;
     width: 100%;
+  }
+
+  .context-tooltip :global(.worktree-path-tooltip) {
+    max-width: min(50vw, calc(100vw - 32px));
+    overflow-wrap: anywhere;
   }
 
   /* Stat grid */

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -346,6 +346,7 @@
                   <Tooltip
                     text={session.cwd}
                     focusable
+                    align="end"
                     class="worktree-path-tooltip"
                   >
                     <div class="context-value context-value--path">

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -1,7 +1,7 @@
 <!-- ABOUTME: Session Vital Signs panel — replaces ActivityMinimap on the right column. -->
 <script lang="ts">
   import { onDestroy } from "svelte";
-  import { CopyButton } from "@kenn-io/kit-ui";
+  import { CopyButton, Tooltip } from "@kenn-io/kit-ui";
   import { sessionTiming } from "../../stores/sessionTiming.svelte.js";
   import { liveTick } from "../../stores/liveTick.svelte.js";
   import { fetchSessionTiming } from "../../api/timing.js";
@@ -341,9 +341,20 @@
               <div class="context-label">
                 {m.session_vitals_worktree()}
               </div>
-              <div class="context-value" title={session.cwd || undefined}>
-                {session.cwd || "—"}
-              </div>
+              {#if session.cwd}
+                <div class="context-tooltip">
+                  <Tooltip text={session.cwd} focusable>
+                    <div
+                      class="context-value context-value--path"
+                      dir="rtl"
+                    >
+                      {session.cwd}
+                    </div>
+                  </Tooltip>
+                </div>
+              {:else}
+                <div class="context-value">—</div>
+              {/if}
             </div>
             {#if session.cwd}
               <CopyButton
@@ -779,6 +790,19 @@
     line-height: 1.35;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .context-value--path {
+    text-align: left;
+  }
+
+  .context-tooltip {
+    min-width: 0;
+  }
+
+  .context-tooltip :global(.kit-tooltip-trigger) {
+    display: flex;
+    width: 100%;
   }
 
   /* Stat grid */

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -344,11 +344,8 @@
               {#if session.cwd}
                 <div class="context-tooltip">
                   <Tooltip text={session.cwd} focusable>
-                    <div
-                      class="context-value context-value--path"
-                      dir="rtl"
-                    >
-                      {session.cwd}
+                    <div class="context-value context-value--path">
+                      <bdi dir="ltr">{session.cwd}</bdi>
                     </div>
                   </Tooltip>
                 </div>
@@ -793,6 +790,7 @@
   }
 
   .context-value--path {
+    direction: rtl;
     text-align: left;
   }
 

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -140,11 +140,6 @@ describe("SessionVitals", () => {
     expect(
       document.querySelector('[title="agentsview"]'),
     ).not.toBeNull();
-    const worktreeValue = rows[1]?.querySelector<HTMLElement>(
-      ".context-value--path",
-    );
-    expect(worktreeValue).not.toBeNull();
-    expect(worktreeValue?.dir).toBe("rtl");
   });
 
   it("reveals the full worktree path in a tooltip", async () => {

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -8,7 +8,7 @@ import {
   vi,
 } from "vitest";
 import { mount, tick, unmount } from "svelte";
-import { cleanup, render } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import type { Session } from "../../api/types/core.js";
 import type { SessionTiming } from "../../api/types/timing.js";
 
@@ -140,11 +140,35 @@ describe("SessionVitals", () => {
     expect(
       document.querySelector('[title="agentsview"]'),
     ).not.toBeNull();
+    const worktreeValue = rows[1]?.querySelector<HTMLElement>(
+      ".context-value--path",
+    );
+    expect(worktreeValue).not.toBeNull();
+    expect(worktreeValue?.dir).toBe("rtl");
+  });
+
+  it("reveals the full worktree path in a tooltip", async () => {
+    component = mount(SessionVitals, {
+      target: document.body,
+      props: { sessionId: traceSession.id, session: traceSession },
+    });
+    await tick();
+    await tick();
+
+    const worktreeValue = document.querySelector<HTMLElement>(
+      ".context-value--path",
+    );
+    expect(worktreeValue).not.toBeNull();
+
+    const trigger = worktreeValue!.closest<HTMLElement>(
+      ".kit-tooltip-trigger",
+    );
+    expect(trigger).not.toBeNull();
+    await fireEvent.mouseEnter(trigger!);
+
     expect(
-      document.querySelector(
-        '[title="/repos/agentsview/.worktrees/trace-context"]',
-      ),
-    ).not.toBeNull();
+      (await screen.findByRole("tooltip")).textContent?.trim(),
+    ).toBe(traceSession.cwd);
   });
 
   it("keeps trace context visible when timing fails to load", async () => {


### PR DESCRIPTION
Long worktree paths often share a low-signal prefix, while the final checkout or branch segments identify the context a developer actually needs. This keeps that useful tail visible in the compact session-vitals panel and preserves the actual order of mixed-direction paths through explicit LTR isolation.

The complete value is available through the shared tooltip for hover and keyboard focus. This worktree-specific tooltip can use up to half the viewport, expand left beyond the sidebar, and wrap long unbroken segments at the cap while remaining viewport-contained with its arrow anchored to the trigger; kit-ui’s generic 280-pixel tooltip default remains unchanged. Existing copy behavior and the empty-path state are preserved.

<sup>generated by a clanker</sup>