### PR TITLE
fix(frontend): move sidebar toggle beside filters

### DIFF
--- a/cmd/agentsview/pricing_schedule_test.go
+++ b/cmd/agentsview/pricing_schedule_test.go
@@ -16,6 +16,10 @@ import (
 	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
+// Resync may spend up to five seconds draining SQLite connections before a
+// swap, particularly on Windows where open handles prevent the rename.
+const pricingResyncTestTimeout = 10 * time.Second
+
 type pricingCatalogTransport struct {
 	requests chan *http.Request
 }
@@ -122,7 +126,7 @@ func TestStartPeriodicPricingRefreshWaitsForResyncSwap(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 
 	requests := make(chan *http.Request, 1)
 	originalTransport := http.DefaultTransport
@@ -146,7 +150,7 @@ func TestStartPeriodicPricingRefreshWaitsForResyncSwap(t *testing.T) {
 			default:
 				return false
 			}
-		}, time.Second, time.Millisecond)
+		}, pricingResyncTestTimeout, time.Millisecond)
 	})
 
 	assert.Never(t, func() bool {
@@ -162,12 +166,12 @@ func TestStartPeriodicPricingRefreshWaitsForResyncSwap(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 	require.NoError(t, swapErr)
 	require.Eventually(t, func() bool {
 		price, err := database.GetModelPricing("scheduled-model")
 		return err == nil && price != nil
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 }
 
 func TestSeedPricingWaitsForResyncSwap(t *testing.T) {
@@ -208,7 +212,7 @@ func TestSeedPricingWaitsForResyncSwap(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 
 	seedDone := make(chan struct{})
 	go func() {
@@ -233,7 +237,7 @@ func TestSeedPricingWaitsForResyncSwap(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 	require.NoError(t, swapErr)
 	require.Eventually(t, func() bool {
 		select {
@@ -242,7 +246,7 @@ func TestSeedPricingWaitsForResyncSwap(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 	price, err = database.GetModelPricing("gpt-5.5")
 	require.NoError(t, err)
 	require.NotNil(t, price)

--- a/docs/superpowers/plans/2026-07-30-sidebar-toggle-placement.md
+++ b/docs/superpowers/plans/2026-07-30-sidebar-toggle-placement.md
@@ -15,8 +15,10 @@ the relocated filter; keep the current mobile hamburger and drawer behavior.
 **Architecture:** Add one shared state-aware sidebar toggle built from kit-ui's
 `IconButton`, then render it at the two session-list boundaries that own the
 filter. The global header keeps the hamburger only on mobile. Session detail
-receives the same closed-state toggle/filter pair in its breadcrumb so closing
-the sidebar never strands the user without a way to reopen it.
+receives the same closed-state toggle/filter pair in its breadcrumb. Focus moves
+to the newly visible counterpart after a keyboard-initiated toggle, and each
+control exposes the sidebar relationship through `aria-expanded` and
+`aria-controls`, so closing the sidebar never strands the user.
 
 **Tech Stack:** Svelte 5, TypeScript, kit-ui, Lucide icons, Paraglide JS, Vitest
 through Vite+
@@ -39,14 +41,16 @@ ______________________________________________________________________
 - Modify: `frontend/src/lib/components/sidebar/SessionList.test.ts`
 - Modify: `frontend/src/lib/components/analytics/AnalyticsPage.test.ts`
 - Modify: `frontend/src/lib/components/layout/SessionBreadcrumb.test.ts`
+- Create: `frontend/src/lib/components/layout/SidebarToggleButton.test.ts`
 
 **Interfaces:**
 
 - Consumes: current `ui.sidebarOpen`, `ui.isMobileViewport`, and rendered filter
   controls.
 
-- Produces: regression coverage for desktop header removal, mobile preservation,
-  open-state filter/collapse order, and closed-state expand/filter order.
+- Produces: regression coverage for desktop header removal, both mobile
+  hamburger branches, open-state filter/collapse order, closed-state
+  expand/filter order, and keyboard focus handoff in both directions.
 
 - [ ] **Step 1: Install the pinned frontend dependencies**
 
@@ -63,18 +67,20 @@ dependency set.
 
 Add tests that query the localized `aria-label` values, compare sibling order
 around `.filter-btn`, click the toggle, and assert the observable
-`ui.sidebarOpen` state change. The mobile AppHeader test must click the retained
-hamburger and observe the existing drawer behavior. Mobile SessionList,
-Analytics, and Breadcrumb tests must prove the relocated controls are absent.
-Each desktop relocated control must retain the existing localized
-`Toggle sidebar (b)` title so the keyboard shortcut remains discoverable.
+`ui.sidebarOpen` state change. Focused-button tests must assert that focus moves
+to the newly visible counterpart after both collapse and reopen. Mobile
+AppHeader tests must cover closing the drawer on the sessions route and
+navigating from another route to open it. Mobile SessionList, Analytics, and
+Breadcrumb tests must prove the relocated controls are absent. Each desktop
+relocated control must retain the existing localized `Toggle sidebar (b)` title
+so the keyboard shortcut remains discoverable.
 
 - [ ] **Step 3: Run the focused tests and verify RED**
 
 Run:
 
 ```bash
-cd frontend && PATH="$(pwd)/node_modules/.bin:$PATH" vp test src/lib/components/layout/AppHeader.test.ts src/lib/components/sidebar/SessionList.test.ts src/lib/components/analytics/AnalyticsPage.test.ts src/lib/components/layout/SessionBreadcrumb.test.ts
+cd frontend && PATH="$(pwd)/node_modules/.bin:$PATH" vp test src/lib/components/layout/AppHeader.test.ts src/lib/components/layout/SidebarToggleButton.test.ts src/lib/components/sidebar/SessionList.test.ts src/lib/components/analytics/AnalyticsPage.test.ts src/lib/components/layout/SessionBreadcrumb.test.ts
 ```
 
 Expected: assertion failures because the desktop hamburger is still global and
@@ -86,7 +92,9 @@ the filter-adjacent controls do not exist.
 
 - Create: `frontend/src/lib/components/layout/SidebarToggleButton.svelte`
 - Modify: `frontend/src/lib/icons.ts`
+- Modify: `frontend/src/lib/icons.test.ts`
 - Modify: `frontend/src/lib/components/layout/AppHeader.svelte`
+- Modify: `frontend/src/lib/components/layout/ThreeColumnLayout.svelte`
 - Modify: `frontend/src/lib/components/sidebar/SessionList.svelte`
 - Modify: `frontend/src/lib/components/analytics/AnalyticsPage.svelte`
 - Modify: `frontend/src/lib/components/layout/SessionBreadcrumb.svelte`
@@ -114,7 +122,11 @@ accurate translation in each catalog.
 Create `SidebarToggleButton.svelte` with kit-ui `IconButton`. It calls
 `ui.toggleSidebar()`, labels itself from the current state, retains
 `m.nav_toggle_sidebar_shortcut()` as its title, and uses `PanelLeftCloseIcon`
-while open and `PanelLeftOpenIcon` while closed.
+while open and `PanelLeftOpenIcon` while closed. Export both icons through the
+app icon facade and add them to its allowlist. Identify whether each toggle is
+in the sidebar or content region, expose `aria-expanded` and `aria-controls`,
+and move keyboard focus to the opposite region's toggle after the state change.
+Give the layout sidebar the stable ID referenced by the controls.
 
 - [ ] **Step 3: Relocate the desktop control**
 
@@ -163,13 +175,19 @@ cd frontend && PATH="$(pwd)/node_modules/.bin:$PATH" vp test src/lib/components/
 
 Expected: all selected tests pass with no failures.
 
-- [ ] **Step 3: Review the diff and commit**
+- [ ] **Step 3: Check the responsive layout visually**
+
+At the minimum desktop width, verify the open and collapsed control groups in
+English and a locale with longer labels. Confirm that the sidebar header and
+analytics toolbar do not overlap, clip, or wrap unexpectedly.
+
+- [ ] **Step 4: Review the diff and commit**
 
 Stage only the plan, component, catalog, and test changes, then create a focused
 conventional commit explaining why the toggle belongs with the panel controls
 and why mobile remains unchanged.
 
-- [ ] **Step 4: Push and open the pull request**
+- [ ] **Step 5: Push and open the pull request**
 
 The user already authorized the commit-push-PR workflow. Push the current
 feature branch to `origin`, run the private-data scrub on the proposed

--- a/docs/superpowers/plans/2026-07-30-sidebar-toggle-placement.md
+++ b/docs/superpowers/plans/2026-07-30-sidebar-toggle-placement.md
@@ -1,0 +1,177 @@
+# Sidebar Toggle Placement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans
+> to implement this plan directly in the current agent, task-by-task. Never use
+> subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the desktop sidebar toggle next to the session filter while
+preserving the existing mobile hamburger behavior.
+
+**Approved spec/design:** This plan is based directly on the user's approved
+requirements: with the desktop sidebar open, render the collapse control to the
+right of the filter; with it closed, render the expand control to the left of
+the relocated filter; keep the current mobile hamburger and drawer behavior.
+
+**Architecture:** Add one shared state-aware sidebar toggle built from kit-ui's
+`IconButton`, then render it at the two session-list boundaries that own the
+filter. The global header keeps the hamburger only on mobile. Session detail
+receives the same closed-state toggle/filter pair in its breadcrumb so closing
+the sidebar never strands the user without a way to reopen it.
+
+**Tech Stack:** Svelte 5, TypeScript, kit-ui, Lucide icons, Paraglide JS, Vitest
+through Vite+
+
+## Global Constraints
+
+- Do not change the existing mobile hamburger route and drawer behavior, and do
+  not render the relocated controls on mobile.
+- Use shared controls rather than adding one-off button chrome.
+- Keep every locale catalog's message keys identical.
+- Tests must assert rendered order and click behavior, not source text.
+
+______________________________________________________________________
+
+### Task 1: Protect the responsive placement contract
+
+**Files:**
+
+- Modify: `frontend/src/lib/components/layout/AppHeader.test.ts`
+- Modify: `frontend/src/lib/components/sidebar/SessionList.test.ts`
+- Modify: `frontend/src/lib/components/analytics/AnalyticsPage.test.ts`
+- Modify: `frontend/src/lib/components/layout/SessionBreadcrumb.test.ts`
+
+**Interfaces:**
+
+- Consumes: current `ui.sidebarOpen`, `ui.isMobileViewport`, and rendered filter
+  controls.
+
+- Produces: regression coverage for desktop header removal, mobile preservation,
+  open-state filter/collapse order, and closed-state expand/filter order.
+
+- [ ] **Step 1: Install the pinned frontend dependencies**
+
+Run:
+
+```bash
+cd frontend && vp install -- --allow-git=root
+```
+
+Expected: dependencies install successfully without changing the pinned
+dependency set.
+
+- [ ] **Step 2: Write failing rendered-behavior tests**
+
+Add tests that query the localized `aria-label` values, compare sibling order
+around `.filter-btn`, click the toggle, and assert the observable
+`ui.sidebarOpen` state change. The mobile AppHeader test must click the retained
+hamburger and observe the existing drawer behavior. Mobile SessionList,
+Analytics, and Breadcrumb tests must prove the relocated controls are absent.
+Each desktop relocated control must retain the existing localized
+`Toggle sidebar (b)` title so the keyboard shortcut remains discoverable.
+
+- [ ] **Step 3: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+cd frontend && PATH="$(pwd)/node_modules/.bin:$PATH" vp test src/lib/components/layout/AppHeader.test.ts src/lib/components/sidebar/SessionList.test.ts src/lib/components/analytics/AnalyticsPage.test.ts src/lib/components/layout/SessionBreadcrumb.test.ts
+```
+
+Expected: assertion failures because the desktop hamburger is still global and
+the filter-adjacent controls do not exist.
+
+### Task 2: Add the shared sidebar toggle and place it around the filter
+
+**Files:**
+
+- Create: `frontend/src/lib/components/layout/SidebarToggleButton.svelte`
+- Modify: `frontend/src/lib/icons.ts`
+- Modify: `frontend/src/lib/components/layout/AppHeader.svelte`
+- Modify: `frontend/src/lib/components/sidebar/SessionList.svelte`
+- Modify: `frontend/src/lib/components/analytics/AnalyticsPage.svelte`
+- Modify: `frontend/src/lib/components/layout/SessionBreadcrumb.svelte`
+- Modify: `frontend/messages/en.json`
+- Modify: `frontend/messages/zh-CN.json`
+- Modify: `frontend/messages/zh-TW.json`
+- Modify: `frontend/messages/ko.json`
+- Modify: `frontend/messages/fr.json`
+
+**Interfaces:**
+
+- Consumes: `ui.sidebarOpen`, `ui.toggleSidebar()`, `m.nav_open_sidebar()`, and
+  `m.nav_close_sidebar()`.
+
+- Produces: `SidebarToggleButton`, a shared icon-only button that renders the
+  correct panel-open/panel-close icon and accessible state-specific label.
+
+- [ ] **Step 1: Add localized open-sidebar copy**
+
+Add `nav_open_sidebar` to every locale next to `nav_close_sidebar`, with an
+accurate translation in each catalog.
+
+- [ ] **Step 2: Implement the shared control**
+
+Create `SidebarToggleButton.svelte` with kit-ui `IconButton`. It calls
+`ui.toggleSidebar()`, labels itself from the current state, retains
+`m.nav_toggle_sidebar_shortcut()` as its title, and uses `PanelLeftCloseIcon`
+while open and `PanelLeftOpenIcon` while closed.
+
+- [ ] **Step 3: Relocate the desktop control**
+
+Render the AppHeader hamburger only when `ui.isMobileViewport`. On desktop only,
+place `SidebarToggleButton` immediately after `SessionFilterControl` in
+`SessionList`. On desktop with the sidebar collapsed, place
+`SidebarToggleButton` immediately before `SessionFilterControl` in the Analytics
+toolbar and SessionBreadcrumb. Give the breadcrumb pair a positioned flex
+wrapper, and configure its filter with `showDisplay={false}`,
+`showStarred={false}`, and `align="left"` so its dropdown has a valid anchor and
+exposes only working filters.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the same focused test command from Task 1. Expected: all selected tests
+pass.
+
+### Task 3: Verify the frontend, commit, push, and open the pull request
+
+**Files:**
+
+- Verify all files listed above.
+
+**Interfaces:**
+
+- Consumes: the completed responsive placement implementation.
+
+- Produces: compiled locale output, repository-required frontend validation, one
+  focused commit, a pushed feature branch, and an open pull request.
+
+- [ ] **Step 1: Compile localization and run frontend checks**
+
+```bash
+cd frontend && npm run i18n:compile && PATH="$(pwd)/node_modules/.bin:$PATH" vp check && PATH="$(pwd)/node_modules/.bin:$PATH" vp test && PATH="$(pwd)/node_modules/.bin:$PATH" vp run check:kit-ui
+```
+
+Expected: locale compilation, formatting, linting, type checking, the full
+frontend suite (including locale key parity), and the kit-ui contract check all
+exit successfully.
+
+- [ ] **Step 2: Re-run the focused regression tests**
+
+```bash
+cd frontend && PATH="$(pwd)/node_modules/.bin:$PATH" vp test src/lib/components/layout/AppHeader.test.ts src/lib/components/sidebar/SessionList.test.ts src/lib/components/analytics/AnalyticsPage.test.ts src/lib/components/layout/SessionBreadcrumb.test.ts
+```
+
+Expected: all selected tests pass with no failures.
+
+- [ ] **Step 3: Review the diff and commit**
+
+Stage only the plan, component, catalog, and test changes, then create a focused
+conventional commit explaining why the toggle belongs with the panel controls
+and why mobile remains unchanged.
+
+- [ ] **Step 4: Push and open the pull request**
+
+The user already authorized the commit-push-PR workflow. Push the current
+feature branch to `origin`, run the private-data scrub on the proposed
+title/body, then create a pull request whose description summarizes the behavior
+and rationale without a test-plan section or checklist.

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -8,6 +8,7 @@
   "app_undo_undo": "Undo",
   "nav_toggle_sidebar": "Toggle sidebar",
   "nav_toggle_sidebar_shortcut": "Toggle sidebar (b)",
+  "nav_open_sidebar": "Open sidebar",
   "nav_close_sidebar": "Close sidebar",
   "nav_resize_sidebar": "Resize sidebar",
   "nav_home": "Home",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -8,6 +8,7 @@
   "app_undo_undo": "Annuler",
   "nav_toggle_sidebar": "Afficher/masquer la barre latérale",
   "nav_toggle_sidebar_shortcut": "Afficher/masquer la barre latérale (b)",
+  "nav_open_sidebar": "Ouvrir la barre latérale",
   "nav_close_sidebar": "Fermer la barre latérale",
   "nav_resize_sidebar": "Redimensionner la barre latérale",
   "nav_home": "Accueil",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -8,6 +8,7 @@
   "app_undo_undo": "실행 취소",
   "nav_toggle_sidebar": "사이드바 전환",
   "nav_toggle_sidebar_shortcut": "사이드바 전환 (b)",
+  "nav_open_sidebar": "사이드바 열기",
   "nav_close_sidebar": "사이드바 닫기",
   "nav_resize_sidebar": "사이드바 크기 조정",
   "nav_home": "홈",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -8,6 +8,7 @@
   "app_undo_undo": "撤销",
   "nav_toggle_sidebar": "切换侧边栏",
   "nav_toggle_sidebar_shortcut": "切换侧边栏 (b)",
+  "nav_open_sidebar": "打开侧边栏",
   "nav_close_sidebar": "关闭侧边栏",
   "nav_resize_sidebar": "调整侧边栏大小",
   "nav_home": "首页",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -8,6 +8,7 @@
   "app_undo_undo": "復原",
   "nav_toggle_sidebar": "切換側邊欄",
   "nav_toggle_sidebar_shortcut": "切換側邊欄 (b)",
+  "nav_open_sidebar": "開啟側邊欄",
   "nav_close_sidebar": "關閉側邊欄",
   "nav_resize_sidebar": "調整側邊欄大小",
   "nav_home": "首頁",

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -510,7 +510,10 @@
 <div class="analytics-page">
   <div class="analytics-toolbar">
     {#if !ui.isMobileViewport && !ui.sidebarOpen}
-      <div class="toolbar-filter-anchor">
+      <div
+        class="toolbar-filter-anchor"
+        data-sidebar-focus-region="content"
+      >
         <SidebarToggleButton placement="content" />
         <SessionFilterControl
           showDisplay={false}

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -511,7 +511,7 @@
   <div class="analytics-toolbar">
     {#if !ui.isMobileViewport && !ui.sidebarOpen}
       <div class="toolbar-filter-anchor">
-        <SidebarToggleButton />
+        <SidebarToggleButton placement="content" />
         <SessionFilterControl
           showDisplay={false}
           showStarred={false}

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -22,6 +22,7 @@
   import TopSessions from "./TopSessions.svelte";
   import ActiveFilters from "./ActiveFilters.svelte";
   import SessionFilterControl from "../filters/SessionFilterControl.svelte";
+  import SidebarToggleButton from "../layout/SidebarToggleButton.svelte";
   import FilterDropdown from "../usage/FilterDropdown.svelte";
   import { analytics } from "../../stores/analytics.svelte.js";
   import { analyticsPageDates } from "../../stores/analyticsPageDates.js";
@@ -508,8 +509,9 @@
 
 <div class="analytics-page">
   <div class="analytics-toolbar">
-    {#if !ui.sidebarOpen}
+    {#if !ui.isMobileViewport && !ui.sidebarOpen}
       <div class="toolbar-filter-anchor">
+        <SidebarToggleButton />
         <SessionFilterControl
           showDisplay={false}
           showStarred={false}

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -12,6 +12,7 @@ import { analyticsPageDates } from "../../stores/analyticsPageDates.js";
 import { insights } from "../../stores/insights.svelte.js";
 import { router } from "../../stores/router.svelte.js";
 import { sessions } from "../../stores/sessions.svelte.js";
+import { ui } from "../../stores/ui.svelte.js";
 import { yokedDates } from "../../stores/yokedDates.svelte.js";
 import sourceRaw from "./AnalyticsPage.svelte?raw";
 // @ts-ignore
@@ -71,6 +72,70 @@ afterEach(() => {
   sessions.filters.dateTo = "";
   yokedDates.setEnabled(false);
   analyticsPageDates.clear();
+  ui.sidebarOpen = true;
+  ui.isMobileViewport = false;
+});
+
+describe("AnalyticsPage sidebar controls", () => {
+  it("places the desktop expand control to the left of the relocated filter", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(analytics, "fetchAll").mockResolvedValue();
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    ui.sidebarOpen = false;
+    ui.isMobileViewport = false;
+
+    component = mount(AnalyticsPage, { target: document.body });
+    await flushEffects();
+
+    const anchor = document.querySelector<HTMLElement>(
+      ".toolbar-filter-anchor",
+    );
+    const expandButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open sidebar"]',
+    );
+    const filterButton = anchor?.querySelector<HTMLButtonElement>(
+      ".filter-btn",
+    );
+
+    expect(anchor).not.toBeNull();
+    expect(expandButton).not.toBeNull();
+    expect(filterButton).not.toBeNull();
+    expect(expandButton?.nextElementSibling).toBe(filterButton);
+    expect(expandButton?.title).toBe("Toggle sidebar (b)");
+
+    expandButton!.click();
+    await flushEffects();
+
+    expect(ui.sidebarOpen).toBe(true);
+  });
+
+  it("leaves collapsed mobile sidebar controls in the title bar", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(analytics, "fetchAll").mockResolvedValue();
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    ui.sidebarOpen = false;
+    ui.isMobileViewport = true;
+
+    component = mount(AnalyticsPage, { target: document.body });
+    await flushEffects();
+
+    expect(document.querySelector(".toolbar-filter-anchor")).toBeNull();
+    expect(
+      document.querySelector('button[aria-label="Open sidebar"]'),
+    ).toBeNull();
+  });
 });
 
 describe("AnalyticsPage refresh behavior", () => {

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -326,6 +326,7 @@
         aria-label={m.nav_toggle_sidebar()}
         aria-expanded={ui.sidebarOpen}
         aria-controls="session-sidebar"
+        data-sidebar-focus-target="mobile"
       >
         <MenuIcon size="16" strokeWidth="2" aria-hidden="true" />
       </button>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -324,6 +324,8 @@
         }}
         title={m.nav_toggle_sidebar_shortcut()}
         aria-label={m.nav_toggle_sidebar()}
+        aria-expanded={ui.sidebarOpen}
+        aria-controls="session-sidebar"
       >
         <MenuIcon size="16" strokeWidth="2" aria-hidden="true" />
       </button>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -311,21 +311,23 @@
   ariaLabel={m.nav_primary()}
 >
   {#snippet left()}
-    <button
-      class="hamburger"
-      onclick={() => {
-        if (ui.isMobileViewport && router.route !== "sessions") {
-          router.navigate("sessions");
-          ui.sidebarOpen = true;
-        } else {
-          ui.toggleSidebar();
-        }
-      }}
-      title={m.nav_toggle_sidebar_shortcut()}
-      aria-label={m.nav_toggle_sidebar()}
-    >
-      <MenuIcon size="16" strokeWidth="2" aria-hidden="true" />
-    </button>
+    {#if ui.isMobileViewport}
+      <button
+        class="hamburger"
+        onclick={() => {
+          if (router.route !== "sessions") {
+            router.navigate("sessions");
+            ui.sidebarOpen = true;
+          } else {
+            ui.toggleSidebar();
+          }
+        }}
+        title={m.nav_toggle_sidebar_shortcut()}
+        aria-label={m.nav_toggle_sidebar()}
+      >
+        <MenuIcon size="16" strokeWidth="2" aria-hidden="true" />
+      </button>
+    {/if}
     <button
       class="header-home"
       onclick={() => router.navigate("sessions")}

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -199,6 +199,31 @@ describe("AppHeader export actions", () => {
     expect(ui.sidebarOpen).toBe(false);
   });
 
+  it("opens the sessions drawer from another mobile route", async () => {
+    ui.isMobileViewport = true;
+    ui.sidebarOpen = false;
+    router.route = "usage";
+
+    component = mount(AppHeader, { target: document.body });
+    await tick();
+
+    const sidebarButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Toggle sidebar"]',
+    );
+
+    expect(sidebarButton).not.toBeNull();
+    expect(sidebarButton?.getAttribute("aria-controls")).toBe(
+      "session-sidebar",
+    );
+    expect(sidebarButton?.getAttribute("aria-expanded")).toBe("false");
+
+    sidebarButton!.click();
+    await tick();
+
+    expect(router.route).toBe("sessions");
+    expect(ui.sidebarOpen).toBe(true);
+  });
+
   it("renders every route as a primary-nav tab", async () => {
     component = mount(AppHeader, { target: document.body });
     await tick();

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -28,6 +28,7 @@ vi.mock("../../utils/clipboard.js", () => ({
 import { sessions } from "../../stores/sessions.svelte.js";
 import { sync } from "../../stores/sync.svelte.js";
 import { ui } from "../../stores/ui.svelte.js";
+import { router } from "../../stores/router.svelte.js";
 import { setLocale } from "../../i18n/index.js";
 import type { Session } from "../../api/types.js";
 
@@ -62,7 +63,9 @@ describe("AppHeader export actions", () => {
     sessions.sessions = [testSession()];
     sync.serverVersion = null;
     ui.isMobileViewport = false;
+    ui.sidebarOpen = true;
     ui.followLatest = false;
+    router.route = "sessions";
     setLocale("en");
   });
 
@@ -72,6 +75,9 @@ describe("AppHeader export actions", () => {
       component = undefined;
     }
     document.body.innerHTML = "";
+    ui.isMobileViewport = false;
+    ui.sidebarOpen = true;
+    router.route = "sessions";
   });
 
   it("copies markdown export link from export menu", async () => {
@@ -158,7 +164,7 @@ describe("AppHeader export actions", () => {
     expect(followButton!.classList.contains("active")).toBe(false);
   });
 
-  it("labels compact title-bar actions with hover hints", async () => {
+  it("keeps the sidebar toggle out of the desktop title bar", async () => {
     component = mount(AppHeader, { target: document.body });
     await tick();
 
@@ -169,10 +175,28 @@ describe("AppHeader export actions", () => {
       'button[aria-label="Keyboard shortcuts"]',
     );
 
-    expect(sidebarButton).not.toBeNull();
-    expect(sidebarButton?.title).toBe("Toggle sidebar (b)");
+    expect(sidebarButton).toBeNull();
     expect(shortcutsButton).not.toBeNull();
     expect(shortcutsButton?.title).toBe("Keyboard shortcuts (?)");
+  });
+
+  it("keeps the mobile hamburger and its drawer behavior", async () => {
+    ui.isMobileViewport = true;
+    ui.sidebarOpen = true;
+
+    component = mount(AppHeader, { target: document.body });
+    await tick();
+
+    const sidebarButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Toggle sidebar"]',
+    );
+    expect(sidebarButton).not.toBeNull();
+    expect(sidebarButton?.title).toBe("Toggle sidebar (b)");
+
+    sidebarButton!.click();
+    await tick();
+
+    expect(ui.sidebarOpen).toBe(false);
   });
 
   it("renders every route as a primary-nav tab", async () => {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -745,7 +745,7 @@
 <div class="session-breadcrumb">
   {#if !ui.isMobileViewport && !ui.sidebarOpen}
     <div class="sidebar-controls">
-      <SidebarToggleButton />
+      <SidebarToggleButton placement="content" />
       <SessionFilterControl
         showDisplay={false}
         showStarred={false}

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -39,6 +39,8 @@
   import { normalizeMessagePreview } from "../../utils/messages.js";
   import { getGradeStyle, getGradeLabel } from "../../utils/grade.js";
   import SignalPanel from "../content/SignalPanel.svelte";
+  import SessionFilterControl from "../filters/SessionFilterControl.svelte";
+  import SidebarToggleButton from "./SidebarToggleButton.svelte";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { router } from "../../stores/router.svelte.js";
   import { insights } from "../../stores/insights.svelte.js";
@@ -741,6 +743,16 @@
 
 
 <div class="session-breadcrumb">
+  {#if !ui.isMobileViewport && !ui.sidebarOpen}
+    <div class="sidebar-controls">
+      <SidebarToggleButton />
+      <SessionFilterControl
+        showDisplay={false}
+        showStarred={false}
+        align="left"
+      />
+    </div>
+  {/if}
   <button
     class="breadcrumb-link"
     onclick={onBack}
@@ -1122,6 +1134,12 @@
     flex-shrink: 0;
     font-size: 11px;
     color: var(--text-muted);
+  }
+
+  .sidebar-controls {
+    position: relative;
+    display: flex;
+    align-items: center;
   }
 
   .breadcrumb-link {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -744,7 +744,10 @@
 
 <div class="session-breadcrumb">
   {#if !ui.isMobileViewport && !ui.sidebarOpen}
-    <div class="sidebar-controls">
+    <div
+      class="sidebar-controls"
+      data-sidebar-focus-region="content"
+    >
       <SidebarToggleButton placement="content" />
       <SessionFilterControl
         showDisplay={false}

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -10,6 +10,7 @@ import { messages } from "../../stores/messages.svelte.js";
 import { sessions } from "../../stores/sessions.svelte.js";
 import { setLocale } from "../../i18n/index.js";
 import { router } from "../../stores/router.svelte.js";
+import { ui } from "../../stores/ui.svelte.js";
 import { testMoney } from "../../test/money.js";
 import type { Money } from "../../money.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
@@ -196,14 +197,74 @@ beforeEach(() => {
   sessions.activeSessionId = null;
   sessions.activeSessionUsageVersion = 0;
   sessions.childSessions = new Map();
+  ui.sidebarOpen = true;
+  ui.isMobileViewport = false;
 });
 
 afterEach(() => {
   setLocale("en");
   document.body.innerHTML = "";
+  ui.sidebarOpen = true;
+  ui.isMobileViewport = false;
 });
 
 describe("SessionBreadcrumb", () => {
+  it("places the desktop expand control to the left of the relocated filter", async () => {
+    ui.sidebarOpen = false;
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude"),
+        onBack: () => {},
+      },
+    });
+    await tick();
+
+    const controls = document.querySelector<HTMLElement>(
+      ".sidebar-controls",
+    );
+    const expandButton = controls?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open sidebar"]',
+    );
+    const filterButton = controls?.querySelector<HTMLButtonElement>(
+      ".filter-btn",
+    );
+
+    expect(controls).not.toBeNull();
+    expect(expandButton).not.toBeNull();
+    expect(filterButton).not.toBeNull();
+    expect(expandButton?.nextElementSibling).toBe(filterButton);
+    expect(expandButton?.title).toBe("Toggle sidebar (b)");
+
+    expandButton!.click();
+    await tick();
+
+    expect(ui.sidebarOpen).toBe(true);
+    await unmount(component);
+  });
+
+  it("does not duplicate collapsed sidebar controls below the mobile title bar", async () => {
+    ui.sidebarOpen = false;
+    ui.isMobileViewport = true;
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude"),
+        onBack: () => {},
+      },
+    });
+    await tick();
+
+    expect(document.querySelector(".sidebar-controls")).toBeNull();
+    expect(
+      document.querySelector('button[aria-label="Open sidebar"]'),
+    ).toBeNull();
+
+    await unmount(component);
+  });
+
   it("renders session reading controls in Simplified Chinese", async () => {
     setLocale("zh-CN");
     openersService.getApiV1Openers.mockResolvedValue({

--- a/frontend/src/lib/components/layout/SidebarToggleButton.svelte
+++ b/frontend/src/lib/components/layout/SidebarToggleButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { IconButton } from "@kenn-io/kit-ui";
+  import { tick } from "svelte";
   import { m } from "../../i18n/index.js";
   import {
     PanelLeftCloseIcon,
@@ -7,18 +8,42 @@
   } from "../../icons.js";
   import { ui } from "../../stores/ui.svelte.js";
 
+  interface Props {
+    placement: "sidebar" | "content";
+  }
+
+  let { placement }: Props = $props();
+
   const label = $derived(
     ui.sidebarOpen
       ? m.nav_close_sidebar()
       : m.nav_open_sidebar(),
   );
+
+  async function toggleSidebar(event: MouseEvent) {
+    const shouldMoveFocus = document.activeElement === event.currentTarget;
+    ui.toggleSidebar();
+
+    if (!shouldMoveFocus) return;
+
+    await tick();
+    const nextPlacement = placement === "sidebar" ? "content" : "sidebar";
+    document
+      .querySelector<HTMLButtonElement>(
+        `.sidebar-panel-control--${nextPlacement}`,
+      )
+      ?.focus();
+  }
 </script>
 
 <IconButton
+  class={`sidebar-panel-control sidebar-panel-control--${placement}`}
   size="sm"
-  onclick={() => ui.toggleSidebar()}
+  onclick={toggleSidebar}
   title={m.nav_toggle_sidebar_shortcut()}
   ariaLabel={label}
+  ariaExpanded={ui.sidebarOpen}
+  ariaControls="session-sidebar"
 >
   {#if ui.sidebarOpen}
     <PanelLeftCloseIcon size="14" strokeWidth="2" aria-hidden="true" />

--- a/frontend/src/lib/components/layout/SidebarToggleButton.svelte
+++ b/frontend/src/lib/components/layout/SidebarToggleButton.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { IconButton } from "@kenn-io/kit-ui";
+  import { m } from "../../i18n/index.js";
+  import {
+    PanelLeftCloseIcon,
+    PanelLeftOpenIcon,
+  } from "../../icons.js";
+  import { ui } from "../../stores/ui.svelte.js";
+
+  const label = $derived(
+    ui.sidebarOpen
+      ? m.nav_close_sidebar()
+      : m.nav_open_sidebar(),
+  );
+</script>
+
+<IconButton
+  size="sm"
+  onclick={() => ui.toggleSidebar()}
+  title={m.nav_toggle_sidebar_shortcut()}
+  ariaLabel={label}
+>
+  {#if ui.sidebarOpen}
+    <PanelLeftCloseIcon size="14" strokeWidth="2" aria-hidden="true" />
+  {:else}
+    <PanelLeftOpenIcon size="14" strokeWidth="2" aria-hidden="true" />
+  {/if}
+</IconButton>

--- a/frontend/src/lib/components/layout/SidebarToggleButton.svelte
+++ b/frontend/src/lib/components/layout/SidebarToggleButton.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { IconButton } from "@kenn-io/kit-ui";
-  import { tick } from "svelte";
   import { m } from "../../i18n/index.js";
   import {
     PanelLeftCloseIcon,
     PanelLeftOpenIcon,
   } from "../../icons.js";
   import { ui } from "../../stores/ui.svelte.js";
+  import { toggleSidebarWithFocus } from "../../utils/sidebar-toggle.js";
 
   interface Props {
     placement: "sidebar" | "content";
@@ -19,27 +19,12 @@
       ? m.nav_close_sidebar()
       : m.nav_open_sidebar(),
   );
-
-  async function toggleSidebar(event: MouseEvent) {
-    const shouldMoveFocus = document.activeElement === event.currentTarget;
-    ui.toggleSidebar();
-
-    if (!shouldMoveFocus) return;
-
-    await tick();
-    const nextPlacement = placement === "sidebar" ? "content" : "sidebar";
-    document
-      .querySelector<HTMLButtonElement>(
-        `.sidebar-panel-control--${nextPlacement}`,
-      )
-      ?.focus();
-  }
 </script>
 
 <IconButton
   class={`sidebar-panel-control sidebar-panel-control--${placement}`}
   size="sm"
-  onclick={toggleSidebar}
+  onclick={() => void toggleSidebarWithFocus()}
   title={m.nav_toggle_sidebar_shortcut()}
   ariaLabel={label}
   ariaExpanded={ui.sidebarOpen}

--- a/frontend/src/lib/components/layout/SidebarToggleButton.test.ts
+++ b/frontend/src/lib/components/layout/SidebarToggleButton.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount, tick, unmount } from "svelte";
+import SidebarToggleButton from "./SidebarToggleButton.svelte";
+import { setLocale } from "../../i18n/index.js";
+import { ui } from "../../stores/ui.svelte.js";
+
+describe("SidebarToggleButton keyboard focus", () => {
+  beforeEach(() => {
+    setLocale("en");
+    ui.sidebarOpen = true;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    ui.sidebarOpen = true;
+  });
+
+  it("moves focus to the visible counterpart after collapse and reopen", async () => {
+    const sidebarToggle = mount(SidebarToggleButton, {
+      target: document.body,
+      props: { placement: "sidebar" },
+    });
+    const contentToggle = mount(SidebarToggleButton, {
+      target: document.body,
+      props: { placement: "content" },
+    });
+
+    const sidebarButton = document.querySelector<HTMLButtonElement>(
+      ".sidebar-panel-control--sidebar",
+    );
+    const contentButton = document.querySelector<HTMLButtonElement>(
+      ".sidebar-panel-control--content",
+    );
+
+    expect(sidebarButton).not.toBeNull();
+    expect(contentButton).not.toBeNull();
+    expect(sidebarButton?.getAttribute("aria-controls")).toBe(
+      "session-sidebar",
+    );
+    expect(sidebarButton?.getAttribute("aria-expanded")).toBe("true");
+
+    sidebarButton!.focus();
+    sidebarButton!.click();
+    await tick();
+
+    expect(ui.sidebarOpen).toBe(false);
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(contentButton);
+    });
+    expect(contentButton?.getAttribute("aria-expanded")).toBe("false");
+
+    contentButton!.click();
+    await tick();
+
+    expect(ui.sidebarOpen).toBe(true);
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(sidebarButton);
+    });
+
+    await unmount(contentToggle);
+    await unmount(sidebarToggle);
+  });
+});

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
@@ -299,6 +299,7 @@
   {/if}
 
   <aside
+    id="session-sidebar"
     class="sidebar"
     class:open={ui.sidebarOpen}
     style:width={isDesktop ? `${sidebarWidth}px` : undefined}

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -2,9 +2,11 @@
   import { onDestroy, onMount } from "svelte";
   import { m } from "../../i18n/index.js";
   import { sessions } from "../../stores/sessions.svelte.js";
+  import { ui } from "../../stores/ui.svelte.js";
   import { starred } from "../../stores/starred.svelte.js";
   import SessionItem from "./SessionItem.svelte";
   import SessionFilterControl from "../filters/SessionFilterControl.svelte";
+  import SidebarToggleButton from "../layout/SidebarToggleButton.svelte";
   import {
     ChevronDownIcon,
     ChevronRightIcon,
@@ -494,6 +496,9 @@
       onClearExtra={() => sessions.setTerminationFilter("")}
       extraSections={statusFilterSection}
     />
+    {#if !ui.isMobileViewport}
+      <SidebarToggleButton />
+    {/if}
     {#snippet statusFilterSection()}
       <div class="filter-section">
         <div class="filter-section-label">{m.sidebar_status()}</div>

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -497,7 +497,7 @@
       extraSections={statusFilterSection}
     />
     {#if !ui.isMobileViewport}
-      <SidebarToggleButton />
+      <SidebarToggleButton placement="sidebar" />
     {/if}
     {#snippet statusFilterSection()}
       <div class="filter-section">

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -16,6 +16,7 @@ import { readProgress } from "../../stores/read-progress.svelte.js";
 import { sessions } from "../../stores/sessions.svelte.js";
 import type { Session } from "../../api/types.js";
 import { starred } from "../../stores/starred.svelte.js";
+import { ui } from "../../stores/ui.svelte.js";
 import { m, setLocale } from "../../i18n/index.js";
 import {
   ITEM_HEIGHT,
@@ -91,6 +92,8 @@ describe("SessionList filter dropdown", () => {
     readProgress.reset();
     starred.filterOnly = false;
     starred.ids = new Set();
+    ui.sidebarOpen = true;
+    ui.isMobileViewport = false;
     setLocale("en");
     localStorage.clear();
   });
@@ -109,6 +112,8 @@ describe("SessionList filter dropdown", () => {
     clientHeightSpy?.mockRestore();
     rafSpy?.mockRestore();
     readProgress.reset();
+    ui.sidebarOpen = true;
+    ui.isMobileViewport = false;
     vi.restoreAllMocks();
   });
 
@@ -146,6 +151,39 @@ describe("SessionList filter dropdown", () => {
     expect(filterButton).not.toBeNull();
     expect(filterButton?.title).toBe("Filter sessions");
     expect(filterButton?.getAttribute("aria-label")).toBe("Filters");
+  });
+
+  it("places the desktop collapse control to the right of the filter", async () => {
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    const filterButton = document.querySelector<HTMLButtonElement>(
+      ".filter-btn",
+    );
+    const collapseButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Close sidebar"]',
+    );
+
+    expect(filterButton).not.toBeNull();
+    expect(collapseButton).not.toBeNull();
+    expect(filterButton?.nextElementSibling).toBe(collapseButton);
+    expect(collapseButton?.title).toBe("Toggle sidebar (b)");
+
+    collapseButton!.click();
+    await tick();
+
+    expect(ui.sidebarOpen).toBe(false);
+  });
+
+  it("does not duplicate the hamburger inside the mobile drawer", async () => {
+    ui.isMobileViewport = true;
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    expect(
+      document.querySelector('button[aria-label="Close sidebar"]'),
+    ).toBeNull();
   });
 
   it("renders translated sidebar filter controls and row actions", async () => {

--- a/frontend/src/lib/icons.test.ts
+++ b/frontend/src/lib/icons.test.ts
@@ -50,6 +50,8 @@ const approvedIconNames = [
   "MoonIcon",
   "MoreHorizontalIcon",
   "MousePointer2Icon",
+  "PanelLeftCloseIcon",
+  "PanelLeftOpenIcon",
   "PencilIcon",
   "PinIcon",
   "PlusIcon",

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -44,6 +44,8 @@ export { default as MonitorIcon } from "@lucide/svelte/icons/monitor";
 export { default as MoonIcon } from "@lucide/svelte/icons/moon";
 export { default as MoreHorizontalIcon } from "@lucide/svelte/icons/ellipsis";
 export { default as MousePointer2Icon } from "@lucide/svelte/icons/mouse-pointer-2";
+export { default as PanelLeftCloseIcon } from "@lucide/svelte/icons/panel-left-close";
+export { default as PanelLeftOpenIcon } from "@lucide/svelte/icons/panel-left-open";
 export { default as PencilIcon } from "@lucide/svelte/icons/pencil";
 export { default as PinIcon } from "@lucide/svelte/icons/pin";
 export { default as PlusIcon } from "@lucide/svelte/icons/plus";

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
+import { mount, tick, unmount } from "svelte";
 import { ui } from "../stores/ui.svelte.js";
 import { sessions } from "../stores/sessions.svelte.js";
 import { starred } from "../stores/starred.svelte.js";
@@ -6,6 +7,7 @@ import { router } from "../stores/router.svelte.js";
 import { messages } from "../stores/messages.svelte.js";
 import { SessionsService } from "../api/generated/index";
 import { copyToClipboard } from "../utils/clipboard.js";
+import SidebarToggleButton from "../components/layout/SidebarToggleButton.svelte";
 import { registerShortcuts } from "./keyboard.js";
 
 vi.mock("../utils/clipboard.js", () => ({
@@ -324,6 +326,41 @@ describe("registerShortcuts", () => {
 
       fireKey("b");
       expect(ui.sidebarOpen).toBe(true);
+    });
+
+    it("moves focus out of the sidebar when the shortcut collapses it", async () => {
+      router.navigate("sessions");
+      ui.isMobileViewport = false;
+      ui.sidebarOpen = true;
+
+      const sidebar = document.createElement("aside");
+      sidebar.id = "session-sidebar";
+      const focusedControl = document.createElement("button");
+      focusedControl.textContent = "Focused sidebar control";
+      sidebar.appendChild(focusedControl);
+      document.body.appendChild(sidebar);
+      const contentToggle = mount(SidebarToggleButton, {
+        target: document.body,
+        props: { placement: "content" },
+      });
+
+      try {
+        focusedControl.focus();
+        fireKey("b");
+        await tick();
+
+        const openButton = document.querySelector<HTMLButtonElement>(
+          'button[aria-label="Open sidebar"]',
+        );
+        expect(ui.sidebarOpen).toBe(false);
+        expect(openButton).not.toBeNull();
+        await vi.waitFor(() => {
+          expect(document.activeElement).toBe(openButton);
+        });
+      } finally {
+        await unmount(contentToggle);
+        sidebar.remove();
+      }
     });
 
     it("should navigate to sessions on non-session routes when mobile", () => {

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -7,6 +7,7 @@ import { router } from "../stores/router.svelte.js";
 import { messages } from "../stores/messages.svelte.js";
 import { SessionsService } from "../api/generated/index";
 import { copyToClipboard } from "../utils/clipboard.js";
+import AppHeader from "../components/layout/AppHeader.svelte";
 import SidebarToggleButton from "../components/layout/SidebarToggleButton.svelte";
 import { registerShortcuts } from "./keyboard.js";
 
@@ -360,6 +361,39 @@ describe("registerShortcuts", () => {
       } finally {
         await unmount(contentToggle);
         sidebar.remove();
+      }
+    });
+
+    it("moves mobile focus from the closing drawer to the hamburger", async () => {
+      router.navigate("sessions");
+      ui.isMobileViewport = true;
+      ui.sidebarOpen = true;
+
+      const sidebar = document.createElement("aside");
+      sidebar.id = "session-sidebar";
+      const focusedControl = document.createElement("button");
+      focusedControl.textContent = "Focused mobile drawer control";
+      sidebar.appendChild(focusedControl);
+      document.body.appendChild(sidebar);
+      const header = mount(AppHeader, { target: document.body });
+
+      try {
+        focusedControl.focus();
+        fireKey("b");
+        await tick();
+
+        const hamburger = document.querySelector<HTMLButtonElement>(
+          'button[aria-label="Toggle sidebar"]',
+        );
+        expect(ui.sidebarOpen).toBe(false);
+        expect(hamburger).not.toBeNull();
+        await vi.waitFor(() => {
+          expect(document.activeElement).toBe(hamburger);
+        });
+      } finally {
+        await unmount(header);
+        sidebar.remove();
+        ui.isMobileViewport = false;
       }
     });
 

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -10,6 +10,7 @@ import { SessionsService, type ResumeRequest, type ResumeResponse } from "../api
 import { configureGeneratedClient } from "../api/runtime.js";
 import { supportsResume, buildResumeCommand, formatResumeResponseCommand } from "./resume.js";
 import { copyToClipboard } from "./clipboard.js";
+import { toggleSidebarWithFocus } from "./sidebar-toggle.js";
 
 function isInputFocused(): boolean {
   const el = document.activeElement;
@@ -227,12 +228,12 @@ export function registerShortcuts(opts: ShortcutOptions): () => void {
       },
       b: () => {
         if (router.route === "sessions") {
-          ui.toggleSidebar();
+          void toggleSidebarWithFocus();
         } else if (ui.isMobileViewport) {
           router.navigate("sessions");
           ui.sidebarOpen = true;
         } else {
-          ui.toggleSidebar();
+          void toggleSidebarWithFocus();
         }
       },
     };

--- a/frontend/src/lib/utils/sidebar-toggle.ts
+++ b/frontend/src/lib/utils/sidebar-toggle.ts
@@ -37,9 +37,11 @@ export async function toggleSidebarWithFocus(): Promise<void> {
   if (!shouldMoveFocus) return;
 
   await tick();
+  const focusTarget =
+    ui.isMobileViewport && nextPlacement === "content"
+      ? '[data-sidebar-focus-target="mobile"]'
+      : `.sidebar-panel-control--${nextPlacement}`;
   document
-    .querySelector<HTMLButtonElement>(
-      `.sidebar-panel-control--${nextPlacement}`,
-    )
+    .querySelector<HTMLButtonElement>(focusTarget)
     ?.focus();
 }

--- a/frontend/src/lib/utils/sidebar-toggle.ts
+++ b/frontend/src/lib/utils/sidebar-toggle.ts
@@ -1,0 +1,45 @@
+import { tick } from "svelte";
+import { ui } from "../stores/ui.svelte.js";
+
+type SidebarControlPlacement = "sidebar" | "content";
+
+function focusedPlacement(
+  element: Element | null,
+): SidebarControlPlacement | null {
+  if (!element) return null;
+
+  const sidebar = document.getElementById("session-sidebar");
+  if (
+    sidebar?.contains(element) ||
+    element.closest(".sidebar-panel-control--sidebar")
+  ) {
+    return "sidebar";
+  }
+  if (
+    element.closest('[data-sidebar-focus-region="content"]') ||
+    element.closest(".sidebar-panel-control--content")
+  ) {
+    return "content";
+  }
+  return null;
+}
+
+export async function toggleSidebarWithFocus(): Promise<void> {
+  const placementBeingHidden: SidebarControlPlacement = ui.sidebarOpen
+    ? "sidebar"
+    : "content";
+  const shouldMoveFocus =
+    focusedPlacement(document.activeElement) === placementBeingHidden;
+  const nextPlacement = ui.sidebarOpen ? "content" : "sidebar";
+
+  ui.toggleSidebar();
+
+  if (!shouldMoveFocus) return;
+
+  await tick();
+  document
+    .querySelector<HTMLButtonElement>(
+      `.sidebar-panel-control--${nextPlacement}`,
+    )
+    ?.focus();
+}


### PR DESCRIPTION
Moves the desktop sidebar control out of the global header and into the session filter controls it affects. With the sidebar open, the filter is followed by the collapse action; when closed, the expand action precedes the relocated filter on both the analytics landing page and session detail breadcrumb.

The mobile hamburger and drawer behavior remain unchanged. A shared icon button provides state-specific accessible labels, with the new open-sidebar copy kept in sync across every locale.

<sup>generated by a clanker</sup>