### PR TITLE
fix(ci): restore cross-platform main checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
         run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Test with coverage
-        run: go test -tags "fts5" -coverprofile=coverage.out ./...
+        run: go test -tags "fts5" -coverprofile=coverage.out ./... -timeout=20m
         env:
           CGO_ENABLED: "1"
 

--- a/internal/sync/activity_hint_reader.go
+++ b/internal/sync/activity_hint_reader.go
@@ -24,6 +24,9 @@ const (
 
 type activityHintCursor struct {
 	info           os.FileInfo
+	inode          int64
+	device         int64
+	hasIdentity    bool
 	offset         int64
 	boundaryDigest [sha256.Size]byte
 	boundaryLength int
@@ -71,9 +74,19 @@ func readActivityHints(
 		)
 	}
 
+	// Freeze identity now. Windows FileInfo resolves SameFile lazily from the
+	// path, so an old snapshot can otherwise resolve to its replacement.
+	inode, device := getFileIdentity(source.Path, info)
+	hasIdentity := inode != 0 || device != 0
+	sameFile := false
+	if cursor.hasIdentity && hasIdentity {
+		sameFile = cursor.inode == inode && cursor.device == device
+	} else if cursor.info != nil {
+		sameFile = os.SameFile(cursor.info, info)
+	}
 	if cursor.initialized &&
 		(cursor.info == nil ||
-			!os.SameFile(cursor.info, info) ||
+			!sameFile ||
 			info.Size() < cursor.offset) {
 		*cursor = activityHintCursor{}
 	}
@@ -138,6 +151,9 @@ func readActivityHints(
 
 	result.BytesRead = len(data)
 	cursor.info = info
+	cursor.inode = inode
+	cursor.device = device
+	cursor.hasIdentity = hasIdentity
 	cursor.offset = start + int64(len(data))
 	cursor.initialized = true
 	digest, length, err := readActivityHintBoundary(file, cursor.offset)


### PR DESCRIPTION
Main is red for two independent assumptions exposed by loaded runners. On Windows, Go can resolve a saved FileInfo identity lazily from its pathname, allowing an old activity-hint cursor snapshot to bind to an atomic replacement and skip replay. Capturing identity with the cursor keeps replacements distinguishable across platforms.

Coverage instrumentation can also push the artifact package beyond Go's default ten-minute timeout while the package is still making progress and completes within the ordinary suite's existing budget. Aligning coverage with that twenty-minute allowance prevents false aborts without weakening assertions.