### PR TITLE
fix(sync): suppress OpenCode SHM-only daemon watch pushes

### DIFF
--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
+	"strings"
 	stdsync "sync"
 	"time"
 
@@ -179,7 +181,7 @@ func archivePushWatchWatcherOptions(
 
 func archivePushWatchBatchCallback(
 	appCfg config.Config,
-	engine *syncpkg.Engine,
+	engine watchSyncer,
 	loop *pushLoop,
 ) syncpkg.WatchCallback {
 	return func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
@@ -189,7 +191,9 @@ func archivePushWatchBatchCallback(
 		if err := syncWatchBatch(callbackCtx, engine, batch, scope); err != nil {
 			return err
 		}
-		return notifyPushForWatchBatch(callbackCtx, loop, batch)
+		return notifyPushForWatchBatchWithConfig(
+			callbackCtx, loop, appCfg, batch,
+		)
 	}
 }
 
@@ -247,6 +251,95 @@ func notifyPushForWatchBatch(
 	case err := <-ack:
 		return err
 	}
+}
+
+func notifyPushForWatchBatchWithConfig(
+	ctx context.Context,
+	loop *pushLoop,
+	cfg config.Config,
+	batch syncpkg.WatchBatch,
+) error {
+	if watchBatchIsAffirmativelyNonData(ctx, cfg, batch) {
+		return nil
+	}
+	return notifyPushForWatchBatch(ctx, loop, batch)
+}
+
+type watchPathRelevanceProvider struct {
+	provider parser.Provider
+	root     string
+}
+
+func watchBatchIsAffirmativelyNonData(
+	ctx context.Context,
+	cfg config.Config,
+	batch syncpkg.WatchBatch,
+) bool {
+	if ctx.Err() != nil || len(batch.Paths) == 0 || batch.FullSync ||
+		batch.LostEvents || len(batch.ReconcileRoots) > 0 ||
+		len(batch.Renames) > 0 {
+		return false
+	}
+
+	providers := configuredWatchPathRelevanceProviders(cfg)
+	if len(providers) == 0 {
+		return false
+	}
+	for _, path := range batch.Paths {
+		matched := false
+		for _, candidate := range providers {
+			if !watchPathUnderRoot(candidate.root, path) {
+				continue
+			}
+			matched = true
+			relevance, err := parser.ResolveChangedPathRelevance(
+				ctx, candidate.provider, parser.ChangedPathRequest{
+					Path: path, WatchRoot: candidate.root,
+				},
+			)
+			if err != nil || relevance != parser.ChangedPathNonData {
+				return false
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+func configuredWatchPathRelevanceProviders(
+	cfg config.Config,
+) []watchPathRelevanceProvider {
+	var providers []watchPathRelevanceProvider
+	for _, factory := range parser.ProviderFactories() {
+		if factory.Capabilities().Source.ChangedPathRelevance !=
+			parser.CapabilitySupported {
+			continue
+		}
+		roots := cfg.ResolveDirs(factory.Definition().Type)
+		for _, root := range roots {
+			root = filepath.Clean(root)
+			if root == "." || root == "" {
+				continue
+			}
+			providers = append(providers, watchPathRelevanceProvider{
+				provider: factory.NewProvider(parser.ProviderConfig{
+					Roots: []string{root},
+				}),
+				root: root,
+			})
+		}
+	}
+	return providers
+}
+
+func watchPathUnderRoot(root, path string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil || rel == "." || rel == ".." || filepath.IsAbs(rel) {
+		return false
+	}
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func watchBatchNeedsPushAck(batch syncpkg.WatchBatch) bool {
@@ -471,7 +564,9 @@ func (b daemonArchiveWriteBackend) DuckDBPushWatch(
 	stopWatcher, openDispatch, unwatchedDirs := startArchivePushWatcher(
 		b.watchHooks, b.appCfg, nil,
 		func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
-			return notifyPushForWatchBatch(callbackCtx, loop, batch)
+			return notifyPushForWatchBatchWithConfig(
+				callbackCtx, loop, b.appCfg, batch,
+			)
 		},
 		syncpkg.WatcherOptions{OnCoverageDegraded: loop.NotifyCoverageDegraded},
 	)
@@ -601,7 +696,9 @@ func (b daemonArchiveWriteBackend) PGPushWatch(
 	stopWatcher, openDispatch, unwatchedDirs := startArchivePushWatcher(
 		b.watchHooks, b.appCfg, nil,
 		func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
-			return notifyPushForWatchBatch(callbackCtx, loop, batch)
+			return notifyPushForWatchBatchWithConfig(
+				callbackCtx, loop, b.appCfg, batch,
+			)
 		},
 		syncpkg.WatcherOptions{OnCoverageDegraded: loop.NotifyCoverageDegraded},
 	)

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -319,10 +319,10 @@ func configuredWatchPathRelevanceProviders(
 		}
 		roots := cfg.ResolveDirs(factory.Definition().Type)
 		for _, root := range roots {
-			root = filepath.Clean(root)
-			if root == "." || root == "" {
+			if root == "" {
 				continue
 			}
+			root = filepath.Clean(root)
 			providers = append(providers, watchPathRelevanceProvider{
 				provider: factory.NewProvider(parser.ProviderConfig{
 					Roots: []string{root},

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -264,8 +264,9 @@ func notifyPushForWatchBatchWithConfig(
 }
 
 type watchPathRelevanceProvider struct {
-	provider parser.Provider
-	root     string
+	provider           parser.Provider
+	root               string
+	relevanceSupported bool
 }
 
 func watchBatchIsAffirmativelyNonData(
@@ -294,6 +295,9 @@ func watchBatchIsAffirmativelyNonData(
 				continue
 			}
 			matched = true
+			if !candidate.relevanceSupported {
+				return false
+			}
 			relevance, err := parser.ResolveChangedPathRelevance(
 				ctx, candidate.provider, parser.ChangedPathRequest{
 					Path: path, WatchRoot: candidate.root,
@@ -315,21 +319,24 @@ func configuredWatchPathRelevanceProviders(
 ) []watchPathRelevanceProvider {
 	var providers []watchPathRelevanceProvider
 	for _, factory := range parser.ProviderFactories() {
-		if factory.Capabilities().Source.ChangedPathRelevance !=
-			parser.CapabilitySupported {
-			continue
-		}
+		relevanceSupported := factory.Capabilities().Source.ChangedPathRelevance ==
+			parser.CapabilitySupported
 		roots := cfg.ResolveDirs(factory.Definition().Type)
 		for _, root := range roots {
 			if root == "" {
 				continue
 			}
 			root = absRootPath(root)
-			providers = append(providers, watchPathRelevanceProvider{
-				provider: factory.NewProvider(parser.ProviderConfig{
+			var provider parser.Provider
+			if relevanceSupported {
+				provider = factory.NewProvider(parser.ProviderConfig{
 					Roots: []string{root},
-				}),
-				root: root,
+				})
+			}
+			providers = append(providers, watchPathRelevanceProvider{
+				provider:           provider,
+				root:               root,
+				relevanceSupported: relevanceSupported,
 			})
 		}
 	}

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 	stdsync "sync"
 	"time"
 
@@ -286,9 +284,13 @@ func watchBatchIsAffirmativelyNonData(
 		return false
 	}
 	for _, path := range batch.Paths {
+		if path == "" {
+			return false
+		}
+		path = absRootPath(path)
 		matched := false
 		for _, candidate := range providers {
-			if !watchPathUnderRoot(candidate.root, path) {
+			if !pathWithinRoot(path, candidate.root) {
 				continue
 			}
 			matched = true
@@ -322,7 +324,7 @@ func configuredWatchPathRelevanceProviders(
 			if root == "" {
 				continue
 			}
-			root = filepath.Clean(root)
+			root = absRootPath(root)
 			providers = append(providers, watchPathRelevanceProvider{
 				provider: factory.NewProvider(parser.ProviderConfig{
 					Roots: []string{root},
@@ -333,15 +335,6 @@ func configuredWatchPathRelevanceProviders(
 	}
 	return providers
 }
-
-func watchPathUnderRoot(root, path string) bool {
-	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
-	if err != nil || rel == "." || rel == ".." || filepath.IsAbs(rel) {
-		return false
-	}
-	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
 func watchBatchNeedsPushAck(batch syncpkg.WatchBatch) bool {
 	if batch.FullSync || len(batch.ReconcileRoots) > 0 {
 		return true

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -832,6 +832,26 @@ func TestDaemonPGPushWatchSuppressesRepeatedOpenCodeSHMOnlyBatches(t *testing.T)
 	t.Log("reason_change_attempts=0 path=opencode.db-shm")
 }
 
+func TestDaemonPGPushWatchRelevancePreservesExplicitCurrentDirectoryRoot(t *testing.T) {
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {"."},
+		},
+	}
+	loop, _, _ := newTestLoop(func(context.Context, pushReason) error {
+		t.Fatal("explicit current-directory roots must suppress SHM-only batches")
+		return nil
+	})
+	require.NoError(t, notifyPushForWatchBatchWithConfig(
+		t.Context(), loop, cfg, syncpkg.WatchBatch{
+			Paths: []string{filepath.Join(".", "opencode.db-shm")},
+		},
+	))
+	assert.False(t, loop.pending,
+		"an explicit current-directory root must retain relevance coverage")
+	t.Log("reason_change_attempts=0 root=. path=opencode.db-shm")
+}
+
 func TestDaemonPushWatchOwnersSuppressOpenCodeSHMOnlyBatches(t *testing.T) {
 	root := t.TempDir()
 	cfg := config.Config{

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -759,6 +760,16 @@ func indexOfEvent(events []string, want string) int {
 	return -1
 }
 
+func countEvents(events []string, want string) int {
+	total := 0
+	for _, event := range events {
+		if event == want {
+			total++
+		}
+	}
+	return total
+}
+
 func receiveArchiveTest[T any](t *testing.T, ch <-chan T) T {
 	t.Helper()
 	select {
@@ -785,6 +796,346 @@ func TestPushWatchCollectingCallbackAcknowledgesOnlyReconciliationBatches(t *tes
 	err := notifyPushForWatchBatch(ctx, loop, syncpkg.WatchBatch{FullSync: true})
 	require.ErrorIs(t, err, context.Canceled,
 		"authoritative batches wait with the watcher worker context")
+}
+
+func TestDaemonPGPushWatchSuppressesRepeatedOpenCodeSHMOnlyBatches(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {root},
+		},
+	}
+	pushes := make(chan pushReason, 3)
+	loop, _, _ := newTestLoop(func(_ context.Context, reason pushReason) error {
+		pushes <- reason
+		return nil
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go loop.Run(ctx)
+	batch := syncpkg.WatchBatch{
+		Paths: []string{filepath.Join(root, "opencode.db-shm")},
+	}
+	for range 3 {
+		require.NoError(t,
+			notifyPushForWatchBatchWithConfig(ctx, loop, cfg, batch),
+		)
+		select {
+		case reason := <-pushes:
+			require.Failf(t, "SHM-only batches must not schedule a push",
+				"received %q", reason)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	assert.False(t, loop.pending,
+		"repeated opencode.db-shm batches must not mark the push loop dirty")
+	t.Log("reason_change_attempts=0 path=opencode.db-shm")
+}
+
+func TestDaemonPushWatchOwnersSuppressOpenCodeSHMOnlyBatches(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {root},
+		},
+	}
+	owners := []pushWatchOwnerCase{
+		{
+			name: "daemon DuckDB",
+			run: func(ctx context.Context, hooks *archivePushWatchHooks) error {
+				backend := daemonArchiveWriteBackend{
+					appCfg: cfg, watchHooks: hooks,
+				}
+				return backend.DuckDBPushWatch(
+					ctx, config.DuckDBConfig{}, DuckDBPushConfig{}, nil, nil,
+					time.Hour, time.Hour,
+				)
+			},
+		},
+		{
+			name: "daemon PostgreSQL",
+			run: func(ctx context.Context, hooks *archivePushWatchHooks) error {
+				backend := daemonArchiveWriteBackend{
+					appCfg: cfg, watchHooks: hooks,
+				}
+				return backend.PGPushWatch(
+					ctx, pgTargetSelection{}, PGPushConfig{}, nil, nil,
+					time.Hour, time.Hour,
+				)
+			},
+		},
+	}
+	for _, owner := range owners {
+		t.Run(owner.name, func(t *testing.T) {
+			h := newPushWatchOwnerHarness()
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			done := make(chan error, 1)
+			go func() { done <- owner.run(ctx, h.hooks()) }()
+
+			startup := receiveArchiveTest(t, h.attempts)
+			require.Equal(t, 1, startup.index)
+			receiveArchiveTest(t, h.opened)
+			callback := h.watcherCallback()
+			require.NotNil(t, callback)
+
+			batch := syncpkg.WatchBatch{
+				Paths: []string{filepath.Join(root, "opencode.db-shm")},
+			}
+			for range 3 {
+				require.NoError(t, callback(ctx, batch))
+			}
+			pending, waiters := h.pending()
+			assert.False(t, pending,
+				"repeated opencode.db-shm batches must not mark the push loop dirty")
+			assert.Zero(t, waiters,
+				"suppressed batches must not register an acknowledgement waiter")
+			events, _, _, _ := h.snapshot()
+			t.Logf("owner=%s path=opencode.db-shm push_pending=%t waiters=%d pushes=%d",
+				owner.name, pending, waiters, countEvents(events, "push"))
+
+			cancel()
+			require.NoError(t, receiveArchiveTest(t, done))
+		})
+	}
+}
+
+func TestDaemonPGPushWatchSuppressesNonDataOpenCodeWALBatches(t *testing.T) {
+	size := func(value int) *int { return &value }
+	tests := []struct {
+		name   string
+		size   *int
+		remove bool
+	}{
+		{name: "missing"},
+		{name: "empty", size: size(0)},
+		{name: "partial", size: size(3)},
+		{name: "header-only", size: size(32)},
+		{name: "removed", size: size(64), remove: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			walPath := filepath.Join(root, "opencode.db-wal")
+			if tc.size != nil {
+				require.NoError(t, os.WriteFile(walPath, make([]byte, *tc.size), 0o600))
+			}
+			if tc.remove {
+				require.NoError(t, os.Remove(walPath))
+			}
+
+			cfg := config.Config{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentOpenCode: {root},
+				},
+			}
+			loop, _, _ := newTestLoop(func(context.Context, pushReason) error {
+				t.Fatal("non-data WAL batches must not schedule a push")
+				return nil
+			})
+			require.NoError(t, notifyPushForWatchBatchWithConfig(
+				t.Context(), loop, cfg, syncpkg.WatchBatch{Paths: []string{walPath}},
+			))
+			assert.False(t, loop.pending,
+				"non-data WAL batches must not mark the push loop dirty")
+			t.Logf("reason_change_attempts=0 wal=%s", tc.name)
+		})
+	}
+}
+
+func TestDaemonPGPushWatchRetainsDataBearingMixedBatches(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {root},
+		},
+	}
+	walPath := filepath.Join(root, "opencode.db-wal")
+	require.NoError(t, os.WriteFile(walPath, make([]byte, 33), 0o600))
+
+	tests := []struct {
+		name  string
+		paths []string
+	}{
+		{
+			name: "main database",
+			paths: []string{filepath.Join(root, "opencode.db-shm"),
+				filepath.Join(root, "opencode.db")},
+		},
+		{
+			name:  "framed WAL",
+			paths: []string{filepath.Join(root, "opencode.db-shm"), walPath},
+		},
+		{
+			name: "unknown sidecar",
+			paths: []string{filepath.Join(root, "opencode.db-shm"),
+				filepath.Join(root, "opencode.db-backup")},
+		},
+		{
+			name:  "wrong root",
+			paths: []string{filepath.Join(t.TempDir(), "opencode.db-shm")},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			loop, _, _ := newTestLoop(func(context.Context, pushReason) error {
+				return nil
+			})
+			require.NoError(t, notifyPushForWatchBatchWithConfig(
+				t.Context(), loop, cfg, syncpkg.WatchBatch{Paths: tc.paths},
+			))
+			assert.True(t, loop.pending,
+				"data-bearing or unclassified paths must retain notification")
+			t.Logf("notification_retained=%s paths=%d", tc.name, len(tc.paths))
+		})
+	}
+}
+
+func TestDaemonPGPushWatchRetainsAmbiguousOverlappingRootBatch(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {root},
+			parser.AgentKilo:     {root},
+		},
+	}
+	loop, _, _ := newTestLoop(func(context.Context, pushReason) error {
+		return nil
+	})
+	require.NoError(t, notifyPushForWatchBatchWithConfig(
+		t.Context(), loop, cfg, syncpkg.WatchBatch{
+			Paths: []string{filepath.Join(root, "opencode.db-shm")},
+		},
+	))
+	assert.True(t, loop.pending,
+		"ambiguous provider ownership must retain the notification")
+	t.Log("notification_retained=ambiguous overlap paths=1")
+}
+
+func TestDaemonPGPushWatchRelevanceDoesNotEnumerateSessions(t *testing.T) {
+	measure := func(sessionFiles int) float64 {
+		root := t.TempDir()
+		sessionRoot := filepath.Join(root, "storage", "session", "global")
+		require.NoError(t, os.MkdirAll(sessionRoot, 0o700))
+		for i := range sessionFiles {
+			require.NoError(t, os.WriteFile(
+				filepath.Join(sessionRoot, fmt.Sprintf("session-%d.json", i)),
+				[]byte("{}"), 0o600,
+			))
+		}
+		cfg := config.Config{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentOpenCode: {root},
+			},
+		}
+		var err error
+		allocations := testing.AllocsPerRun(20, func() {
+			loop, _, _ := newTestLoop(func(context.Context, pushReason) error {
+				t.Fatal("bounded SHM classification must suppress the push")
+				return nil
+			})
+			err = notifyPushForWatchBatchWithConfig(
+				t.Context(), loop, cfg, syncpkg.WatchBatch{
+					Paths: []string{filepath.Join(root, "opencode.db-shm")},
+				},
+			)
+			assert.False(t, loop.pending)
+		})
+		require.NoError(t, err)
+		t.Logf("session_files=%d allocations=%.0f", sessionFiles, allocations)
+		return allocations
+	}
+
+	small := measure(1)
+	large := measure(64)
+	assert.LessOrEqual(t, large, small+1,
+		"classification allocations must stay independent of session count")
+}
+
+func TestPushWatchRelevancePreservesAuthoritativeBatches(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {root},
+		},
+	}
+	tests := []struct {
+		name        string
+		batch       syncpkg.WatchBatch
+		waitForPush bool
+	}{
+		{name: "FullSync", batch: syncpkg.WatchBatch{
+			FullSync: true,
+			Paths:    []string{filepath.Join(root, "opencode.db-shm")},
+		}, waitForPush: true},
+		{name: "LostEvents", batch: syncpkg.WatchBatch{
+			LostEvents: true,
+			Paths:      []string{filepath.Join(root, "opencode.db-shm")},
+		}},
+		{name: "ReconcileRoots", batch: syncpkg.WatchBatch{
+			ReconcileRoots: []string{root},
+			Paths:          []string{filepath.Join(root, "opencode.db-shm")},
+		}, waitForPush: true},
+		{name: "rename", batch: syncpkg.WatchBatch{
+			Paths: []string{filepath.Join(root, "opencode.db-shm")},
+			Renames: []syncpkg.WatchRename{{
+				Path: filepath.Join(root, "opencode.db-shm"),
+				Root: root, ItemType: syncpkg.ItemIsFile,
+			}},
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pushed := make(chan pushReason, 1)
+			loop, fire, _ := newTestLoop(func(_ context.Context, reason pushReason) error {
+				pushed <- reason
+				return nil
+			})
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			go loop.Run(ctx)
+			if tc.waitForPush {
+				done := make(chan error, 1)
+				go func() {
+					done <- notifyPushForWatchBatchWithConfig(ctx, loop, cfg, tc.batch)
+				}()
+				fire <- time.Now()
+				require.NoError(t, <-done)
+				assert.Equal(t, reasonChange, <-pushed)
+			} else {
+				require.NoError(t,
+					notifyPushForWatchBatchWithConfig(t.Context(), loop, cfg, tc.batch),
+				)
+			}
+			if tc.waitForPush {
+				assert.False(t, loop.pending)
+			} else {
+				assert.True(t, loop.pending)
+			}
+			t.Logf("authoritative=%s notification_retained=true", tc.name)
+		})
+	}
+}
+
+func TestArchivePushWatchCallbackPassesUnfilteredBatchToSync(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {root},
+		},
+	}
+	path := filepath.Join(root, "opencode.db-shm")
+	recorder := &watchSyncRecorder{}
+	loop, _, _ := newTestLoop(func(context.Context, pushReason) error {
+		require.Fail(t, "the local SHM batch should be suppressed after sync")
+		return nil
+	})
+	callback := archivePushWatchBatchCallback(cfg, recorder, loop)
+	require.NoError(t, callback(t.Context(), syncpkg.WatchBatch{Paths: []string{path}}))
+	assert.Equal(t, [][]string{{path}}, recorder.pathCalls)
+	assert.Equal(t, []string{"paths"}, recorder.callOrder)
+	assert.False(t, loop.pending)
+	t.Log("engine_sync=completed push_pending=false")
 }
 
 func TestResolveArchiveWriteBackendCopiesNoSyncRuntime(t *testing.T) {

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -854,6 +854,27 @@ func TestDaemonPGPushWatchRelevancePreservesExplicitCurrentDirectoryRoot(t *test
 	t.Log("reason_change_attempts=0 root=. absolute_event=opencode.db-shm")
 }
 
+func TestDaemonPGPushWatchRetainsOpenCodeSHMWhenOverlappingUnsupportedProvider(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode:       {root},
+			parser.AgentAntigravityCLI: {root},
+		},
+	}
+	loop, _, _ := newTestLoop(func(context.Context, pushReason) error {
+		return nil
+	})
+	require.NoError(t, notifyPushForWatchBatchWithConfig(
+		t.Context(), loop, cfg, syncpkg.WatchBatch{
+			Paths: []string{filepath.Join(root, "opencode.db-shm")},
+		},
+	))
+	assert.True(t, loop.pending,
+		"an unsupported overlapping provider must retain the notification")
+	t.Log("notification_retained=unsupported_overlap path=opencode.db-shm")
+}
+
 func TestDaemonPushWatchOwnersSuppressOpenCodeSHMOnlyBatches(t *testing.T) {
 	root := t.TempDir()
 	cfg := config.Config{

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -833,6 +833,8 @@ func TestDaemonPGPushWatchSuppressesRepeatedOpenCodeSHMOnlyBatches(t *testing.T)
 }
 
 func TestDaemonPGPushWatchRelevancePreservesExplicitCurrentDirectoryRoot(t *testing.T) {
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
 	cfg := config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentOpenCode: {"."},
@@ -844,12 +846,12 @@ func TestDaemonPGPushWatchRelevancePreservesExplicitCurrentDirectoryRoot(t *test
 	})
 	require.NoError(t, notifyPushForWatchBatchWithConfig(
 		t.Context(), loop, cfg, syncpkg.WatchBatch{
-			Paths: []string{filepath.Join(".", "opencode.db-shm")},
+			Paths: []string{filepath.Join(workingDir, "opencode.db-shm")},
 		},
 	))
 	assert.False(t, loop.pending,
 		"an explicit current-directory root must retain relevance coverage")
-	t.Log("reason_change_attempts=0 root=. path=opencode.db-shm")
+	t.Log("reason_change_attempts=0 root=. absolute_event=opencode.db-shm")
 }
 
 func TestDaemonPushWatchOwnersSuppressOpenCodeSHMOnlyBatches(t *testing.T) {

--- a/internal/parser/capabilities.go
+++ b/internal/parser/capabilities.go
@@ -54,6 +54,7 @@ type SourceCapabilities struct {
 	WatchRoots           CapabilitySupport
 	ActivityHints        CapabilitySupport
 	ClassifyChangedPath  CapabilitySupport
+	ChangedPathRelevance CapabilitySupport
 	StoredSourceHints    CapabilitySupport
 	FindSource           CapabilitySupport
 	CompositeFingerprint CapabilitySupport

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -98,6 +98,13 @@ func (p *openCodeFormatProvider) SourcesForChangedPath(
 	return p.sources.SourcesForChangedPath(ctx, req)
 }
 
+func (p *openCodeFormatProvider) ChangedPathRelevance(
+	ctx context.Context,
+	req ChangedPathRequest,
+) (ChangedPathRelevance, error) {
+	return p.sources.ChangedPathRelevance(ctx, req)
+}
+
 func (p *openCodeFormatProvider) SourceForReconciliation(
 	ctx context.Context, path, project string,
 ) (SourceRef, bool, error) {
@@ -854,24 +861,9 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 	if !ok {
 		return nil, false, nil
 	}
-	isSQLiteChange := true
-	switch rel {
-	case s.spec.dbName + "-shm":
-		// SHM is only SQLite's WAL index. WAL frames (or the checkpointed main
-		// database) carry the source changes, so SHM events are redundant.
+	relevance, isSQLiteChange := s.sqliteChangeRelevance(root, path, rel)
+	if isSQLiteChange && relevance == ChangedPathNonData {
 		return nil, true, nil
-	case s.spec.dbName + "-wal":
-		// A read-only connection can create an empty WAL while inspecting a
-		// quiet database. Ignore it, as well as WAL removal after a checkpoint;
-		// the corresponding main-database write is watched separately.
-		if !sqliteWALHasFrames(path) {
-			return nil, true, nil
-		}
-	case s.spec.dbName:
-		// The main database and WALs with transaction frames both fan out to
-		// the logical sessions stored in this shared SQLite container.
-	default:
-		isSQLiteChange = false
 	}
 
 	if isSQLiteChange {
@@ -966,6 +958,73 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 		return []SourceRef{source}, true, nil
 	}
 	return nil, false, nil
+}
+
+func (s openCodeFormatSourceSet) ChangedPathRelevance(
+	ctx context.Context,
+	req ChangedPathRequest,
+) (ChangedPathRelevance, error) {
+	if err := ctx.Err(); err != nil {
+		return ChangedPathUnclassified, err
+	}
+	if req.WatchRoot != "" {
+		root := filepath.Clean(req.WatchRoot)
+		if !s.hasConfiguredRoot(root) {
+			return ChangedPathUnclassified, nil
+		}
+		return s.changedPathRelevanceInRoot(root, req.Path), nil
+	}
+	for _, root := range s.roots {
+		if relevance := s.changedPathRelevanceInRoot(root, req.Path); relevance != ChangedPathUnclassified {
+			return relevance, nil
+		}
+	}
+	return ChangedPathUnclassified, nil
+}
+
+func (s openCodeFormatSourceSet) changedPathRelevanceInRoot(
+	root, path string,
+) ChangedPathRelevance {
+	rel, ok := relUnder(root, path)
+	if !ok {
+		return ChangedPathUnclassified
+	}
+	relevance, _ := s.sqliteChangeRelevance(root, path, rel)
+	return relevance
+}
+
+func (s openCodeFormatSourceSet) sqliteChangeRelevance(
+	root, path, rel string,
+) (ChangedPathRelevance, bool) {
+	switch rel {
+	case s.spec.dbName + "-shm":
+		// SHM is only SQLite's WAL index. WAL frames or the checkpointed main
+		// database carry the source changes, so SHM events are redundant.
+		return ChangedPathNonData, true
+	case s.spec.dbName + "-wal":
+		// A read-only connection can create an empty WAL while inspecting a
+		// quiet database. Ignore it, as well as WAL removal after a checkpoint;
+		// the corresponding main-database write is watched separately.
+		if !sqliteWALHasFrames(path) {
+			return ChangedPathNonData, true
+		}
+		return ChangedPathDataBearing, true
+	case s.spec.dbName:
+		// A missing main database is still a data-bearing change. It can mean
+		// the container moved or was removed, so the watch push must remain.
+		return ChangedPathDataBearing, true
+	default:
+		return ChangedPathUnclassified, false
+	}
+}
+
+func (s openCodeFormatSourceSet) hasConfiguredRoot(root string) bool {
+	for _, configured := range s.roots {
+		if samePath(root, configured) {
+			return true
+		}
+	}
+	return false
 }
 
 func sqliteWALHasFrames(path string) bool {
@@ -1108,6 +1167,7 @@ func openCodeFormatProviderCapabilities() Capabilities {
 			StreamingDiscovery:    CapabilitySupported,
 			WatchSources:          CapabilitySupported,
 			ClassifyChangedPath:   CapabilitySupported,
+			ChangedPathRelevance:  CapabilitySupported,
 			FindSource:            CapabilitySupported,
 			CompositeFingerprint:  CapabilitySupported,
 			IncrementalAppend:     CapabilityNotApplicable,

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -622,6 +622,80 @@ func TestOpenCodeProviderIgnoresNonDataSQLiteSidecars(t *testing.T) {
 	}
 }
 
+func TestOpenCodeFormatWatchPathRelevance(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent AgentType
+		db    string
+	}{
+		{name: "OpenCode", agent: AgentOpenCode, db: "opencode.db"},
+		{name: "Kilo", agent: AgentKilo, db: "kilo.db"},
+		{name: "MiMoCode", agent: AgentMiMoCode, db: "mimocode.db"},
+		{name: "Icodemate", agent: AgentIcodemate, db: "icodemate.db"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			provider, ok := NewProvider(tc.agent, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+
+			check := func(path string) ChangedPathRelevance {
+				relevance, err := ResolveChangedPathRelevance(
+					t.Context(), provider, ChangedPathRequest{
+						Path: path, WatchRoot: root,
+					},
+				)
+				require.NoError(t, err)
+				return relevance
+			}
+
+			assert.Equal(t, ChangedPathNonData,
+				check(filepath.Join(root, tc.db+"-shm")))
+			assert.Equal(t, ChangedPathNonData,
+				check(filepath.Join(root, tc.db+"-wal")),
+				"missing WAL is non-data")
+			walPath := filepath.Join(root, tc.db+"-wal")
+			require.NoError(t, os.WriteFile(walPath, make([]byte, 32), 0o600))
+			assert.Equal(t, ChangedPathNonData, check(walPath),
+				"32-byte WAL header has no transaction frame")
+			require.NoError(t, os.WriteFile(walPath, make([]byte, 33), 0o600))
+			assert.Equal(t, ChangedPathDataBearing, check(walPath),
+				"WAL data begins after the 32-byte header")
+			assert.Equal(t, ChangedPathDataBearing,
+				check(filepath.Join(root, tc.db)),
+				"the main database remains push-worthy even when absent")
+			assert.Equal(t, ChangedPathUnclassified,
+				check(filepath.Join(root, tc.db+"-backup")))
+			assert.Equal(t, ChangedPathUnclassified,
+				check(filepath.Join(t.TempDir(), tc.db+"-shm")),
+				"the same basename outside the configured root is unclaimed")
+		})
+	}
+}
+
+func TestOpenCodeFormatWatchPathRelevanceFailsOpen(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory-permission stat failures are not portable to this runner")
+	}
+	root := t.TempDir()
+	walDir := filepath.Join(root, "locked")
+	require.NoError(t, os.Mkdir(walDir, 0o700))
+	walPath := filepath.Join(walDir, "opencode.db-wal")
+	require.NoError(t, os.WriteFile(walPath, make([]byte, 64), 0o600))
+	require.NoError(t, os.Chmod(walDir, 0o000))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(walDir, 0o700)) })
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{walDir}})
+	require.True(t, ok)
+	relevance, err := ResolveChangedPathRelevance(
+		t.Context(), provider, ChangedPathRequest{Path: walPath, WatchRoot: walDir},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, ChangedPathDataBearing, relevance,
+		"unexpected WAL stat failures must retain the push")
+}
+
 func TestSQLiteWALHasFramesFailsOpenOnStatError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("directory-permission stat failures are not portable to Windows")

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	ProviderFeatureFingerprint   = "fingerprint"
-	ProviderFeatureParse         = "parse"
-	ProviderFeatureWatchRoots    = "watch roots"
-	ProviderFeatureActivityHints = "activity hints"
+	ProviderFeatureFingerprint          = "fingerprint"
+	ProviderFeatureParse                = "parse"
+	ProviderFeatureWatchRoots           = "watch roots"
+	ProviderFeatureActivityHints        = "activity hints"
+	ProviderFeatureChangedPathRelevance = "changed path relevance"
 )
 
 // ErrUnsupportedProviderFeature identifies optional provider behavior that is
@@ -386,6 +387,42 @@ func ResolveActivityHintProvider(
 		}
 	}
 	return hints, true, nil
+}
+
+// ChangedPathRelevance distinguishes paths that are known to carry no source
+// data from paths that should keep the watch-triggered push active.
+type ChangedPathRelevance uint8
+
+const (
+	ChangedPathUnclassified ChangedPathRelevance = iota
+	ChangedPathNonData
+	ChangedPathDataBearing
+)
+
+// ChangedPathRelevanceProvider owns the bounded, engine-free path decision
+// needed by watch-trigger adapters.
+type ChangedPathRelevanceProvider interface {
+	ChangedPathRelevance(context.Context, ChangedPathRequest) (ChangedPathRelevance, error)
+}
+
+// ResolveChangedPathRelevance returns the optional path-relevance contract
+// only when the provider explicitly advertises it.
+func ResolveChangedPathRelevance(
+	ctx context.Context,
+	provider Provider,
+	req ChangedPathRequest,
+) (ChangedPathRelevance, error) {
+	if provider.Capabilities().Source.ChangedPathRelevance != CapabilitySupported {
+		return ChangedPathUnclassified, nil
+	}
+	relevance, ok := provider.(ChangedPathRelevanceProvider)
+	if !ok {
+		return ChangedPathUnclassified, UnsupportedProviderFeatureError{
+			Provider: provider.Definition().Type,
+			Feature:  ProviderFeatureChangedPathRelevance,
+		}
+	}
+	return relevance.ChangedPathRelevance(ctx, req)
 }
 
 // ChangedPathRequest is passed back to providers for authoritative changed-path

--- a/internal/parser/provider_capabilities_test.go
+++ b/internal/parser/provider_capabilities_test.go
@@ -42,6 +42,27 @@ func TestProviderCapabilitiesActivityHintsMatchConsumers(t *testing.T) {
 	}
 }
 
+func TestProviderCapabilitiesChangedPathRelevanceMatchConsumers(t *testing.T) {
+	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).ChangedPathRelevance,
+		"new providers must opt in explicitly")
+
+	for _, factory := range ProviderFactories() {
+		agent := factory.Definition().Type
+		got := factory.Capabilities().Source.ChangedPathRelevance
+		if agent == AgentOpenCode || agent == AgentKilo ||
+			agent == AgentMiMoCode || agent == AgentIcodemate {
+			assert.Equal(t, CapabilitySupported, got)
+			provider := factory.NewProvider(ProviderConfig{
+				Roots: []string{t.TempDir()},
+			})
+			assert.Implements(t, (*ChangedPathRelevanceProvider)(nil), provider)
+			continue
+		}
+		assert.Equalf(t, CapabilityUnsupported, got,
+			"%s must not classify watch path relevance", agent)
+	}
+}
+
 func TestWatchSourceProvidersDiscoverEachDirectly(t *testing.T) {
 	for _, factory := range ProviderFactories() {
 		t.Run(string(factory.Definition().Type), func(t *testing.T) {


### PR DESCRIPTION
Daemon-delegated watch pushes currently treat every filesystem batch as dirty, so OpenCode's WAL shared-memory index can retrigger a zero-session push after the daemon reads a quiet database. The repeated `opencode.db-shm` sequence came from @ngocphamm's report.

This adds a provider-owned changed-path relevance check at the push trigger boundary. OpenCode-family SHM-only events become no-ops while checkpointed database writes and WALs containing frames continue to trigger synchronization. The existing provider classification from #956 remains the source of the SHM and WAL rules, and authoritative recovery batches continue to push.

All four watch notification owners route through the same gate: daemon PostgreSQL, daemon DuckDB, local PostgreSQL, and local DuckDB. Filesystem event delivery, local archive synchronization, coverage-degradation notification, startup and interval pushes, storage, and mirror schemas remain unchanged.

Closes #1317
