### PR TITLE
fix(devin): treat session timestamps as epoch seconds

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -820,7 +820,9 @@ Grok section and remove the explicit registry exception in the coverage test.
 ## Devin CLI (`devin`)
 
 - **Format:** `cli/sessions.db` for session metadata plus transcript JSON
-  artifacts.
+  artifacts. The `sessions.created_at`, `sessions.last_activity_at`, and
+  `message_nodes.created_at` columns are Unix epoch seconds (not
+  milliseconds). Verified against a live Devin CLI database 2026-07-31.
 - **Evidence:** `no-public-source`.
 - **Upstream:** Cognition's first-party
   [Devin documentation](https://docs.devin.ai/) and public repositories were

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -822,7 +822,12 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Format:** `cli/sessions.db` for session metadata plus transcript JSON
   artifacts. The `sessions.created_at`, `sessions.last_activity_at`, and
   `message_nodes.created_at` columns are Unix epoch seconds (not
-  milliseconds). Verified against a live Devin CLI database 2026-07-31.
+  milliseconds). Verified against a live Devin CLI database 2026-07-31, and
+  reverified independently against CLI 3000.3.22 the same day. Because the unit
+  is observed rather than documented, the parser rejects values outside the
+  nanosecond-representable epoch-second range instead of converting them, so a
+  future unit change surfaces as missing timestamps rather than as a silently
+  overflowed far-future mtime that would wedge resync.
 - **Evidence:** `no-public-source`.
 - **Upstream:** Cognition's first-party
   [Devin documentation](https://docs.devin.ai/) and public repositories were

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -821,10 +821,10 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** `cli/sessions.db` for session metadata plus transcript JSON
   artifacts. The `sessions.created_at`, `sessions.last_activity_at`, and
-  `message_nodes.created_at` columns are Unix epoch seconds (not
-  milliseconds). Verified against a live Devin CLI database 2026-07-31, and
-  reverified independently against CLI 3000.3.22 the same day. Because the unit
-  is observed rather than documented, the parser rejects values outside the
+  `message_nodes.created_at` columns are Unix epoch seconds (not milliseconds).
+  Verified against a live Devin CLI database 2026-07-31, and reverified
+  independently against CLI 3000.3.22 the same day. Because the unit is observed
+  rather than documented, the parser rejects values outside the
   nanosecond-representable epoch-second range instead of converting them, so a
   future unit change surfaces as missing timestamps rather than as a silently
   overflowed far-future mtime that would wedge resync.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -350,7 +350,18 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // project identity snapshots that older mapping behavior could persist with
 // the mapped target label before incremental ingestion is allowed to reuse
 // them.)
-const dataVersion = 77
+//
+// (78: Devin timestamp reparse. The Devin parser read sessions.created_at,
+// sessions.last_activity_at, and message_nodes.created_at as epoch
+// milliseconds when Devin writes epoch seconds, so every existing Devin row
+// carries 1970-era started_at/ended_at and message timestamps that were
+// discarded as invalid. Existing rows need re-parsing to backfill real
+// timestamps. A fingerprint change alone cannot cover this: for a message-node
+// fallback session whose sessions row has no usable created_at or
+// last_activity_at, the Devin fingerprint hashes only raw epoch integers and
+// zero-time metadata, so it is byte-identical before and after the fix and
+// incremental sync would skip the correction.)
+const dataVersion = 78
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1008,9 +1008,10 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionVibeCachedTokensAndProjectIdentityReparse(t *testing.T) {
-	assert.Equal(t, 77, CurrentDataVersion(),
-		"version 77 reparses Vibe usage and project identity snapshots")
+func TestCurrentDataVersionDevinEpochSecondsReparse(t *testing.T) {
+	assert.Equal(t, 78, CurrentDataVersion(),
+		"version 78 reparses Devin sessions whose timestamps were read as "+
+			"milliseconds and stored as 1970 dates")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -86,27 +86,27 @@ func ForEachDevinSessionMeta(
 
 	for rows.Next() {
 		var meta DevinSessionMeta
-		var createdAtMS int64
-		var lastActivityMS sql.NullInt64
-		var updatedAtMS int64
+		var createdAt int64
+		var lastActivity sql.NullInt64
+		var updatedAt int64
 		if err := rows.Scan(
 			&meta.RawSessionID,
 			&meta.Title,
 			&meta.CWD,
 			&meta.Model,
-			&createdAtMS,
-			&lastActivityMS,
-			&updatedAtMS,
+			&createdAt,
+			&lastActivity,
+			&updatedAt,
 		); err != nil {
 			return fmt.Errorf("scanning devin session meta: %w", err)
 		}
 		meta.VirtualPath = VirtualSourcePath(dbPath, meta.RawSessionID)
-		meta.CreatedAt = devinUnixMilli(createdAtMS)
-		if lastActivityMS.Valid {
-			meta.LastActivity = devinUnixMilli(lastActivityMS.Int64)
+		meta.CreatedAt = devinUnixSec(createdAt)
+		if lastActivity.Valid {
+			meta.LastActivity = devinUnixSec(lastActivity.Int64)
 		}
-		meta.UpdatedAt = devinUnixMilli(updatedAtMS)
-		meta.FileMtime = updatedAtMS * 1_000_000
+		meta.UpdatedAt = devinUnixSec(updatedAt)
+		meta.FileMtime = updatedAt * 1_000_000_000
 		observeStreamingDiscoveryBuffer(ctx, 1)
 		if err := yield(meta); err != nil {
 			return err
@@ -137,9 +137,9 @@ func getDevinSessionMeta(
 	defer db.Close()
 
 	var meta DevinSessionMeta
-	var createdAtMS int64
-	var lastActivityMS sql.NullInt64
-	var updatedAtMS int64
+	var createdAt int64
+	var lastActivity sql.NullInt64
+	var updatedAt int64
 	err = db.QueryRow(`
 		SELECT id,
 		       COALESCE(title, ''),
@@ -156,9 +156,9 @@ func getDevinSessionMeta(
 		&meta.Title,
 		&meta.CWD,
 		&meta.Model,
-		&createdAtMS,
-		&lastActivityMS,
-		&updatedAtMS,
+		&createdAt,
+		&lastActivity,
+		&updatedAt,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -168,20 +168,20 @@ func getDevinSessionMeta(
 	}
 
 	meta.VirtualPath = VirtualSourcePath(dbPath, meta.RawSessionID)
-	meta.CreatedAt = devinUnixMilli(createdAtMS)
-	if lastActivityMS.Valid {
-		meta.LastActivity = devinUnixMilli(lastActivityMS.Int64)
+	meta.CreatedAt = devinUnixSec(createdAt)
+	if lastActivity.Valid {
+		meta.LastActivity = devinUnixSec(lastActivity.Int64)
 	}
-	meta.UpdatedAt = devinUnixMilli(updatedAtMS)
-	meta.FileMtime = updatedAtMS * 1_000_000
+	meta.UpdatedAt = devinUnixSec(updatedAt)
+	meta.FileMtime = updatedAt * 1_000_000_000
 	return &meta, nil
 }
 
-func devinUnixMilli(ms int64) time.Time {
-	if ms <= 0 {
+func devinUnixSec(sec int64) time.Time {
+	if sec <= 0 {
 		return time.Time{}
 	}
-	return time.UnixMilli(ms).UTC()
+	return time.Unix(sec, 0).UTC()
 }
 
 type devinTranscriptError struct {
@@ -406,7 +406,7 @@ type devinMessageNodeRow struct {
 	NodeID       int64
 	ParentNodeID sql.NullInt64
 	ChatMessage  string
-	CreatedAtMS  int64
+	CreatedAt    int64
 }
 
 func listDevinMessageNodes(dbPath, rawSessionID string) ([]devinMessageNodeRow, error) {
@@ -434,7 +434,7 @@ func listDevinMessageNodes(dbPath, rawSessionID string) ([]devinMessageNodeRow, 
 	var nodes []devinMessageNodeRow
 	for rows.Next() {
 		var row devinMessageNodeRow
-		if err := rows.Scan(&row.RowID, &row.NodeID, &row.ParentNodeID, &row.ChatMessage, &row.CreatedAtMS); err != nil {
+		if err := rows.Scan(&row.RowID, &row.NodeID, &row.ParentNodeID, &row.ChatMessage, &row.CreatedAt); err != nil {
 			return nil, err
 		}
 		nodes = append(nodes, row)
@@ -489,7 +489,7 @@ func parseDevinDBMessageNode(
 		Role:          role,
 		Content:       content,
 		ThinkingText:  thinking,
-		Timestamp:     devinUnixMilli(row.CreatedAtMS),
+		Timestamp:     devinUnixSec(row.CreatedAt),
 		HasThinking:   hasThinking,
 		HasToolUse:    hasToolUse || len(toolCalls) > 0,
 		IsSystem:      isSystem,

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,7 +107,7 @@ func ForEachDevinSessionMeta(
 			meta.LastActivity = devinUnixSec(lastActivity.Int64)
 		}
 		meta.UpdatedAt = devinUnixSec(updatedAt)
-		meta.FileMtime = updatedAt * 1_000_000_000
+		meta.FileMtime = devinFileMtimeNS(updatedAt)
 		observeStreamingDiscoveryBuffer(ctx, 1)
 		if err := yield(meta); err != nil {
 			return err
@@ -173,15 +174,41 @@ func getDevinSessionMeta(
 		meta.LastActivity = devinUnixSec(lastActivity.Int64)
 	}
 	meta.UpdatedAt = devinUnixSec(updatedAt)
-	meta.FileMtime = updatedAt * 1_000_000_000
+	meta.FileMtime = devinFileMtimeNS(updatedAt)
 	return &meta, nil
 }
 
+// devinMaxEpochSec is the largest epoch-second value whose nanosecond form
+// still fits in int64 (year 2262). Anything larger is not a plausible Devin
+// timestamp and signals a unit mismatch -- a 13-digit millisecond value, for
+// example. Rejecting it keeps a bad column from silently overflowing into a
+// far-future mtime, which would wedge change detection: devinApplyFileInfoTimes
+// only ever raises Mtime, so a wrapped value can never be superseded and the
+// session would stop resyncing.
+const devinMaxEpochSec = math.MaxInt64 / int64(time.Second)
+
+// devinPlausibleEpochSec reports whether sec is a usable Devin epoch-second
+// timestamp. Devin stores created_at, last_activity_at, and
+// message_nodes.created_at as Unix seconds.
+func devinPlausibleEpochSec(sec int64) bool {
+	return sec > 0 && sec <= devinMaxEpochSec
+}
+
 func devinUnixSec(sec int64) time.Time {
-	if sec <= 0 {
+	if !devinPlausibleEpochSec(sec) {
 		return time.Time{}
 	}
 	return time.Unix(sec, 0).UTC()
+}
+
+// devinFileMtimeNS converts a Devin epoch-second timestamp to the nanosecond
+// mtime the sync layer compares against. Implausible values yield 0, which
+// callers already treat as "no synthetic mtime available".
+func devinFileMtimeNS(sec int64) int64 {
+	if !devinPlausibleEpochSec(sec) {
+		return 0
+	}
+	return sec * int64(time.Second)
 }
 
 type devinTranscriptError struct {

--- a/internal/parser/devin_provider.go
+++ b/internal/parser/devin_provider.go
@@ -473,13 +473,13 @@ func devinAppendMessageNodesFingerprint(h io.Writer, dbPath, rawSessionID string
 	if err != nil {
 		return err
 	}
-	var maxCreatedAtMS int64
+	var maxCreatedAt int64
 	for _, node := range nodes {
-		if node.CreatedAtMS > maxCreatedAtMS {
-			maxCreatedAtMS = node.CreatedAtMS
+		if node.CreatedAt > maxCreatedAt {
+			maxCreatedAt = node.CreatedAt
 		}
 	}
-	if _, err := fmt.Fprintf(h, "message_nodes\x00count\x00%d\x00max_created\x00%d\x00", len(nodes), maxCreatedAtMS); err != nil {
+	if _, err := fmt.Fprintf(h, "message_nodes\x00count\x00%d\x00max_created\x00%d\x00", len(nodes), maxCreatedAt); err != nil {
 		return err
 	}
 	for _, node := range nodes {
@@ -490,7 +490,7 @@ func devinAppendMessageNodesFingerprint(h io.Writer, dbPath, rawSessionID string
 			node.NodeID,
 			node.ParentNodeID.Valid,
 			node.ParentNodeID.Int64,
-			node.CreatedAtMS,
+			node.CreatedAt,
 			len(node.ChatMessage),
 		); err != nil {
 			return err

--- a/internal/parser/devin_provider_test.go
+++ b/internal/parser/devin_provider_test.go
@@ -27,12 +27,12 @@ func TestDevinProviderCapabilities(t *testing.T) {
 func TestDevinProviderDiscoverFindParse(t *testing.T) {
 	const sessionID = "session-123"
 	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "DB title wins",
-		WorkingDirectory:   "/Users/alice/code/my-app",
-		Model:              "db-model",
-		CreatedAtMillis:    new(int64(1704103199000)),
-		LastActivityMillis: new(int64(1704103265000)),
+		ID:               sessionID,
+		Title:            "DB title wins",
+		WorkingDirectory: "/Users/alice/code/my-app",
+		Model:            "db-model",
+		CreatedAt:        new(int64(1704103199)),
+		LastActivityAt:   new(int64(1704103265)),
 	}, `{
 		"agent":{"model_name":"devin-1"},
 		"steps":[
@@ -65,7 +65,7 @@ func TestDevinProviderDiscoverFindParse(t *testing.T) {
 	assert.Equal(t, virtualPath, discovered[0].Key)
 	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
 	assert.Equal(t, virtualPath, discovered[0].FingerprintKey)
-	assert.Equal(t, int64(1704103265000000000), discovered[0].DiscoveryMTimeNS)
+	assert.Equal(t, int64(1704103265_000_000_000), discovered[0].DiscoveryMTimeNS)
 
 	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
 		Path:      filepath.Join(root, "cli", "transcripts", sessionID+".json"),
@@ -111,8 +111,8 @@ func TestDevinProviderDiscoverFindParse(t *testing.T) {
 func TestDevinProviderDBEventsFanOutAndPreserveTombstones(t *testing.T) {
 	const liveSessionID = "session-live"
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: liveSessionID, Title: "Live", WorkingDirectory: "/tmp/live", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
-		devinSessionRow{ID: "session-deleted", Title: "Deleted", WorkingDirectory: "/tmp/deleted", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103264000))},
+		devinSessionRow{ID: liveSessionID, Title: "Live", WorkingDirectory: "/tmp/live", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))},
+		devinSessionRow{ID: "session-deleted", Title: "Deleted", WorkingDirectory: "/tmp/deleted", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103264))},
 	)
 	fixture.writeTranscript(t, liveSessionID, `{"steps":[]}`)
 	root := fixture.Root
@@ -143,8 +143,8 @@ func TestDevinProviderDBEventsFanOutAndPreserveTombstones(t *testing.T) {
 func TestDevinProviderTranscriptEventsTargetLiveOrStoredSession(t *testing.T) {
 	const liveSessionID = "session-live"
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: liveSessionID, Title: "Live", WorkingDirectory: "/tmp/live", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
-		devinSessionRow{ID: "session-deleted", Title: "Deleted", WorkingDirectory: "/tmp/deleted", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103264000))},
+		devinSessionRow{ID: liveSessionID, Title: "Live", WorkingDirectory: "/tmp/live", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))},
+		devinSessionRow{ID: "session-deleted", Title: "Deleted", WorkingDirectory: "/tmp/deleted", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103264))},
 	)
 	fixture.writeTranscript(t, liveSessionID, `{"steps":[]}`)
 	root := fixture.Root
@@ -178,7 +178,7 @@ func TestDevinProviderTranscriptEventsTargetLiveOrStoredSession(t *testing.T) {
 
 func TestDevinProviderRejectsUnrelatedChangedPaths(t *testing.T) {
 	const sessionID = "session-123"
-	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 
 	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
@@ -215,12 +215,12 @@ func TestDevinProviderRejectsUnrelatedChangedPaths(t *testing.T) {
 func TestDevinProviderMissingTranscriptUsesMessageNodeFallback(t *testing.T) {
 	const sessionID = "session-db-only"
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/db-only-project", Model: "db-only-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))},
+		devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/db-only-project", Model: "db-only-model", CreatedAt: new(int64(1704103200)), LastActivityAt: new(int64(1704103209))},
 	)
 	root := fixture.Root
 	fixture.insertMessageNodes(t,
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"fallback user"}`, CreatedAtMillis: 1704103201000},
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"fallback assistant"}`, CreatedAtMillis: 1704103205000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"fallback user"}`, CreatedAt: 1704103201},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"fallback assistant"}`, CreatedAt: 1704103205},
 	)
 
 	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}, Machine: "devbox"})
@@ -243,7 +243,7 @@ func TestDevinProviderMissingTranscriptUsesMessageNodeFallback(t *testing.T) {
 func TestDevinProviderMissingTranscriptWithoutDBMessagesReturnsProviderError(t *testing.T) {
 	const sessionID = "session-db-only-empty"
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/db-only-project", Model: "db-only-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))},
+		devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/db-only-project", Model: "db-only-model", CreatedAt: new(int64(1704103200)), LastActivityAt: new(int64(1704103209))},
 	)
 	root := fixture.Root
 
@@ -264,7 +264,7 @@ func TestDevinProviderMissingTranscriptWithoutDBMessagesReturnsProviderError(t *
 
 func TestDevinProviderCompositeFingerprintStableAndRedacted(t *testing.T) {
 	const sessionID = "session-fingerprint"
-	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Stable title", WorkingDirectory: "/Users/alice/.config/devin/project", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000)), MetadataJSON: `{"token_hint":"redacted"}`}, `{"token":"secret-token-123","steps":[{"step_id":"step-1","source":"user","message":"hello"}]}`)
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Stable title", WorkingDirectory: "/Users/alice/.config/devin/project", Model: "db-model", CreatedAt: new(int64(1704103200)), LastActivityAt: new(int64(1704103209)), MetadataJSON: `{"token_hint":"redacted"}`}, `{"token":"secret-token-123","steps":[{"step_id":"step-1","source":"user","message":"hello"}]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 	virtualPath := VirtualSourcePath(dbPath, sessionID)
 
@@ -291,7 +291,7 @@ func TestDevinProviderCompositeFingerprintStableAndRedacted(t *testing.T) {
 
 func TestDevinProviderFingerprintChangesWhenTranscriptChangesWithoutDBMetadataChange(t *testing.T) {
 	const sessionID = "session-transcript-change"
-	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Transcript change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[{"step_id":"step-1","source":"user","message":"alpha"}]}`)
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Transcript change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103200)), LastActivityAt: new(int64(1704103209))}, `{"steps":[{"step_id":"step-1","source":"user","message":"alpha"}]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 
 	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
@@ -319,7 +319,7 @@ func TestDevinProviderFingerprintChangesWhenTranscriptChangesWithoutDBMetadataCh
 
 func TestDevinProviderFingerprintChangesWhenLastActivityChanges(t *testing.T) {
 	const sessionID = "session-last-activity"
-	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "DB change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[]}`)
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "DB change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103200)), LastActivityAt: new(int64(1704103209))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 
 	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
@@ -332,7 +332,7 @@ func TestDevinProviderFingerprintChangesWhenLastActivityChanges(t *testing.T) {
 	before, err := provider.Fingerprint(context.Background(), source)
 	require.NoError(t, err)
 
-	execDevinTestSQL(t, dbPath, `UPDATE sessions SET last_activity_at = 1704103215000 WHERE id = 'session-last-activity'`)
+	execDevinTestSQL(t, dbPath, `UPDATE sessions SET last_activity_at = 1704103215 WHERE id = 'session-last-activity'`)
 
 	after, err := provider.Fingerprint(context.Background(), source)
 	require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestDevinProviderFingerprintChangesWhenLastActivityChanges(t *testing.T) {
 
 func TestDevinProviderFingerprintChangesWhenWorkingDirectoryChanges(t *testing.T) {
 	const sessionID = "session-cwd-change"
-	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "CWD change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[]}`)
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "CWD change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103200)), LastActivityAt: new(int64(1704103209))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 
 	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
@@ -368,7 +368,7 @@ func TestDevinProviderFingerprintChangesWhenWorkingDirectoryChanges(t *testing.T
 
 func TestDevinProviderFingerprintWithoutTranscriptUsesDBFreshnessOnly(t *testing.T) {
 	const sessionID = "session-missing-transcript"
-	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[]}`)
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103200)), LastActivityAt: new(int64(1704103209))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 	virtualPath := VirtualSourcePath(dbPath, sessionID)
 	require.NoError(t, os.Remove(transcriptPath))
@@ -393,10 +393,10 @@ func TestDevinProviderFingerprintWithoutTranscriptUsesDBFreshnessOnly(t *testing
 func TestDevinProviderFingerprintWithoutTranscriptChangesWhenMessageNodesChange(t *testing.T) {
 	const sessionID = "session-message-node-change"
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: sessionID, Title: "DB messages", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))},
+		devinSessionRow{ID: sessionID, Title: "DB messages", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103200)), LastActivityAt: new(int64(1704103209))},
 	)
 	fixture.insertMessageNodes(t,
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"alpha"}`, CreatedAtMillis: 1704103201000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"alpha"}`, CreatedAt: 1704103201},
 	)
 
 	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{fixture.Root}})
@@ -421,8 +421,8 @@ func TestDevinProviderFingerprintWithoutTranscriptChangesWhenMessageNodesChange(
 func TestDevinProviderRejectsInvalidStoredVirtualPaths(t *testing.T) {
 	const sessionID = "session-123"
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
-		devinSessionRow{ID: "session-999", Title: "Other", WorkingDirectory: "/tmp/other", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+		devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))},
+		devinSessionRow{ID: "session-999", Title: "Other", WorkingDirectory: "/tmp/other", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))},
 	)
 	fixture.writeTranscript(t, sessionID, `{"steps":[]}`)
 	root := fixture.Root
@@ -459,7 +459,7 @@ func TestDevinProviderRejectsInvalidStoredVirtualPaths(t *testing.T) {
 
 func TestDevinProviderDedupesDuplicateRoots(t *testing.T) {
 	const sessionID = "session-123"
-	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 
 	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root, root, filepath.Join(root, ".")}})
@@ -472,7 +472,7 @@ func TestDevinProviderDedupesDuplicateRoots(t *testing.T) {
 
 func TestDevinProviderDeletedRowFingerprintsTombstoneAndSkips(t *testing.T) {
 	const sessionID = "session-123"
-	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 	virtualPath := VirtualSourcePath(dbPath, sessionID)
 
@@ -508,7 +508,7 @@ func TestDevinProviderDeletedRowFingerprintsTombstoneAndSkips(t *testing.T) {
 
 func TestDevinProviderHiddenRowFingerprintsTombstoneAndSkips(t *testing.T) {
 	const sessionID = "session-hidden"
-	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000)), Hidden: false}, `{"steps":[]}`)
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265)), Hidden: false}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 	virtualPath := VirtualSourcePath(dbPath, sessionID)
 
@@ -544,7 +544,7 @@ func TestDevinProviderHiddenRowFingerprintsTombstoneAndSkips(t *testing.T) {
 
 func TestDevinProviderCorruptTranscriptReturnsProviderError(t *testing.T) {
 	const sessionID = "session-corrupt"
-	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Corrupt transcript", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Corrupt transcript", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 	require.NoError(t, os.WriteFile(transcriptPath, []byte(`{"secret":"token-123","steps":[`), 0o644))
 
@@ -571,7 +571,7 @@ func TestDevinProviderIgnoresCredentialPathsAndRedactsSecretBearingErrors(t *tes
 		secretSentinel = "oauth-token-SYNTHETIC-SECRET-SENTINEL"
 	)
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: sessionID, Title: "Privacy", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+		devinSessionRow{ID: sessionID, Title: "Privacy", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))},
 	)
 	transcriptPath := fixture.writeTranscript(t, sessionID, `{"api_key":"oauth-token-SYNTHETIC-SECRET-SENTINEL","steps":[`)
 
@@ -626,7 +626,7 @@ func TestDevinProviderIgnoresCredentialPathsAndRedactsSecretBearingErrors(t *tes
 
 func TestDevinProviderMissingDBSkipsAndPreservesSessions(t *testing.T) {
 	const sessionID = "session-123"
-	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
 	virtualPath := VirtualSourcePath(dbPath, sessionID)
 

--- a/internal/parser/devin_test.go
+++ b/internal/parser/devin_test.go
@@ -31,10 +31,10 @@ func TestDevinDBPath(t *testing.T) {
 
 func TestListDevinSessionMeta(t *testing.T) {
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: "session-hidden", Title: "Hidden", WorkingDirectory: "/cwd/hidden", Model: "model-hidden", CreatedAtMillis: new(int64(1_700_000_010_000)), LastActivityMillis: new(int64(1_700_000_090_000)), Hidden: true},
-		devinSessionRow{ID: "session-fallback", Title: "Fallback title", WorkingDirectory: "/cwd/fallback", Model: "model-fallback", CreatedAtMillis: new(int64(1_700_000_020_000))},
-		devinSessionRow{ID: "session-active", Title: "Active title", WorkingDirectory: "/cwd/active", Model: "model-active", CreatedAtMillis: new(int64(1_700_000_030_000)), LastActivityMillis: new(int64(1_700_000_080_000))},
-		devinSessionRow{ID: "session-newest", Title: "Newest title", WorkingDirectory: "/cwd/newest", Model: "model-newest", CreatedAtMillis: new(int64(1_700_000_040_000)), LastActivityMillis: new(int64(1_700_000_095_000))},
+		devinSessionRow{ID: "session-hidden", Title: "Hidden", WorkingDirectory: "/cwd/hidden", Model: "model-hidden", CreatedAt: new(int64(1_700_000_010)), LastActivityAt: new(int64(1_700_000_090)), Hidden: true},
+		devinSessionRow{ID: "session-fallback", Title: "Fallback title", WorkingDirectory: "/cwd/fallback", Model: "model-fallback", CreatedAt: new(int64(1_700_000_020))},
+		devinSessionRow{ID: "session-active", Title: "Active title", WorkingDirectory: "/cwd/active", Model: "model-active", CreatedAt: new(int64(1_700_000_030)), LastActivityAt: new(int64(1_700_000_080))},
+		devinSessionRow{ID: "session-newest", Title: "Newest title", WorkingDirectory: "/cwd/newest", Model: "model-newest", CreatedAt: new(int64(1_700_000_040)), LastActivityAt: new(int64(1_700_000_095))},
 	)
 
 	metas, err := ListDevinSessionMeta(fixture.DBPath)
@@ -47,10 +47,10 @@ func TestListDevinSessionMeta(t *testing.T) {
 	assert.Equal(t, "Newest title", metas[0].Title)
 	assert.Equal(t, "/cwd/newest", metas[0].CWD)
 	assert.Equal(t, "model-newest", metas[0].Model)
-	assert.Equal(t, time.UnixMilli(1_700_000_095_000).UTC(), metas[0].UpdatedAt)
+	assert.Equal(t, time.Unix(1_700_000_095, 0).UTC(), metas[0].UpdatedAt)
 	assert.Equal(t, int64(1_700_000_095_000_000_000), metas[0].FileMtime)
 
-	assert.Equal(t, time.UnixMilli(1_700_000_020_000).UTC(), metas[2].UpdatedAt)
+	assert.Equal(t, time.Unix(1_700_000_020, 0).UTC(), metas[2].UpdatedAt)
 	assert.Equal(t, int64(1_700_000_020_000_000_000), metas[2].FileMtime)
 
 	for _, meta := range metas {
@@ -100,7 +100,7 @@ func TestListDevinSessionMetaMalformedSchema(t *testing.T) {
 
 func TestOpenDevinDBUsesReadOnlyMode(t *testing.T) {
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: "session-readonly", Title: "Read only", WorkingDirectory: "/tmp/readonly", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+		devinSessionRow{ID: "session-readonly", Title: "Read only", WorkingDirectory: "/tmp/readonly", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))},
 	)
 
 	db, err := openDevinDB(fixture.DBPath)
@@ -151,14 +151,14 @@ func TestOpenDevinDBWithSpecialCharPath(t *testing.T) {
 func TestParseDevinSession(t *testing.T) {
 	const sessionID = "session-123"
 	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "DB title wins",
-		WorkingDirectory:   "/Users/alice/code/my-app",
-		Model:              "db-model",
-		CreatedAtMillis:    new(int64(1704103199000)),
-		LastActivityMillis: new(int64(1704103265000)),
-		WorkspaceJSON:      `{"root_path":"/Users/alice/code/my-app"}`,
-		MetadataJSON:       `{"source":"synthetic"}`,
+		ID:               sessionID,
+		Title:            "DB title wins",
+		WorkingDirectory: "/Users/alice/code/my-app",
+		Model:            "db-model",
+		CreatedAt:        new(int64(1704103199)),
+		LastActivityAt:   new(int64(1704103265)),
+		WorkspaceJSON:    `{"root_path":"/Users/alice/code/my-app"}`,
+		MetadataJSON:     `{"source":"synthetic"}`,
 	}, `{
 		"title":"Transcript title loses",
 		"cwd":"/Users/alice/code/transcript-cwd",
@@ -192,8 +192,8 @@ func TestParseDevinSession(t *testing.T) {
 	assert.Equal(t, "/Users/alice/code/my-app", sess.Cwd)
 	assert.Equal(t, "Fix the login bug", sess.FirstMessage)
 	assert.Equal(t, 1, sess.UserMessageCount)
-	assertTimestamp(t, sess.StartedAt, time.UnixMilli(1_704_103_199_000).UTC())
-	assertTimestamp(t, sess.EndedAt, time.UnixMilli(1_704_103_265_000).UTC())
+	assertTimestamp(t, sess.StartedAt, time.Unix(1_704_103_199, 0).UTC())
+	assertTimestamp(t, sess.EndedAt, time.Unix(1_704_103_265, 0).UTC())
 	assert.True(t, sess.HasTotalOutputTokens)
 	assert.Equal(t, 222, sess.TotalOutputTokens)
 	assert.True(t, sess.HasPeakContextTokens)
@@ -248,12 +248,12 @@ func TestParseDevinSession(t *testing.T) {
 func TestParseDevinSessionStepMetricsPopulateTokenUsage(t *testing.T) {
 	const sessionID = "session-step-metrics"
 	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "Step metrics",
-		WorkingDirectory:   "/tmp/devin-pricing",
-		Model:              "adaptive",
-		CreatedAtMillis:    new(int64(1704103199000)),
-		LastActivityMillis: new(int64(1704103265000)),
+		ID:               sessionID,
+		Title:            "Step metrics",
+		WorkingDirectory: "/tmp/devin-pricing",
+		Model:            "adaptive",
+		CreatedAt:        new(int64(1704103199)),
+		LastActivityAt:   new(int64(1704103265)),
 	}, `{
 		"agent":{"model_name":"Adaptive"},
 		"final_metrics":{
@@ -301,12 +301,12 @@ func TestParseDevinSessionStepMetricsPopulateTokenUsage(t *testing.T) {
 func TestParseDevinSessionFinalMetricsTotalKeys(t *testing.T) {
 	const sessionID = "session-final-total-metrics"
 	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "Final metrics",
-		WorkingDirectory:   "/tmp/devin-final-metrics",
-		Model:              "glm-5-2",
-		CreatedAtMillis:    new(int64(1704103199000)),
-		LastActivityMillis: new(int64(1704103265000)),
+		ID:               sessionID,
+		Title:            "Final metrics",
+		WorkingDirectory: "/tmp/devin-final-metrics",
+		Model:            "glm-5-2",
+		CreatedAt:        new(int64(1704103199)),
+		LastActivityAt:   new(int64(1704103265)),
 	}, `{
 		"agent":{"model_name":"Adaptive"},
 		"final_metrics":{
@@ -335,12 +335,12 @@ func TestParseDevinSessionTranscriptFallbacks(t *testing.T) {
 	worktree := filepath.Join(t.TempDir(), "fallback-app")
 	require.NoError(t, os.MkdirAll(filepath.Join(worktree, ".git"), 0o755))
 	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Model:              "db-model",
-		CreatedAtMillis:    new(int64(0)),
-		WorkspaceJSON:      fmt.Sprintf(`[{"root_path":%q}]`, worktree),
-		MetadataJSON:       `{"mode":"fallback"}`,
-		LastActivityMillis: nil,
+		ID:             sessionID,
+		Model:          "db-model",
+		CreatedAt:      new(int64(0)),
+		WorkspaceJSON:  fmt.Sprintf(`[{"root_path":%q}]`, worktree),
+		MetadataJSON:   `{"mode":"fallback"}`,
+		LastActivityAt: nil,
 	}, fmt.Sprintf(`{
 		"agent":{"model_name":""},
 		"workspace_dirs":[{"root_path":%q}],
@@ -403,12 +403,12 @@ func TestParseDevinSessionEmptyTranscriptUsesDBMetadata(t *testing.T) {
 	worktree := filepath.Join(t.TempDir(), "db-only-project")
 	require.NoError(t, os.MkdirAll(filepath.Join(worktree, ".git"), 0o755))
 	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "DB only session",
-		WorkingDirectory:   worktree,
-		Model:              "db-only-model",
-		CreatedAtMillis:    new(int64(1704103200000)),
-		LastActivityMillis: new(int64(1704103209000)),
+		ID:               sessionID,
+		Title:            "DB only session",
+		WorkingDirectory: worktree,
+		Model:            "db-only-model",
+		CreatedAt:        new(int64(1704103200)),
+		LastActivityAt:   new(int64(1704103209)),
 	}, `{
 		"agent":{"model_name":"transcript-model"},
 		"steps":[]
@@ -423,24 +423,24 @@ func TestParseDevinSessionEmptyTranscriptUsesDBMetadata(t *testing.T) {
 	assert.Equal(t, "db_only_project", sess.Project)
 	assert.Equal(t, 0, sess.MessageCount)
 	assert.Equal(t, 0, sess.UserMessageCount)
-	assertTimestamp(t, sess.StartedAt, time.UnixMilli(1_704_103_200_000).UTC())
-	assertTimestamp(t, sess.EndedAt, time.UnixMilli(1_704_103_209_000).UTC())
+	assertTimestamp(t, sess.StartedAt, time.Unix(1_704_103_200, 0).UTC())
+	assertTimestamp(t, sess.EndedAt, time.Unix(1_704_103_209, 0).UTC())
 }
 
 func TestParseDevinSessionMissingTranscriptFallsBackToMessageNodes(t *testing.T) {
 	const sessionID = "session-db-only"
 	fixture := newDevinTestFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "DB only session",
-		WorkingDirectory:   "/tmp/db-only-project",
-		Model:              "db-only-model",
-		CreatedAtMillis:    new(int64(1704103200000)),
-		LastActivityMillis: new(int64(1704103209000)),
+		ID:               sessionID,
+		Title:            "DB only session",
+		WorkingDirectory: "/tmp/db-only-project",
+		Model:            "db-only-model",
+		CreatedAt:        new(int64(1704103200)),
+		LastActivityAt:   new(int64(1704103209)),
 	})
 	fixture.insertMessageNodes(t,
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"Recover from SQLite fallback"}`, CreatedAtMillis: 1704103201000},
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"I'll use the database transcript fallback.","thinking":"checking message_nodes","tool_calls":[{"id":"call-1","function":{"name":"read_file","arguments":"{\"file_path\":\"main.go\"}"}}]}`, CreatedAtMillis: 1704103205000},
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 3, ChatMessage: `{"role":"tool","content":"package main\n","tool_call_id":"call-1"}`, CreatedAtMillis: 1704103207000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"Recover from SQLite fallback"}`, CreatedAt: 1704103201},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"I'll use the database transcript fallback.","thinking":"checking message_nodes","tool_calls":[{"id":"call-1","function":{"name":"read_file","arguments":"{\"file_path\":\"main.go\"}"}}]}`, CreatedAt: 1704103205},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 3, ChatMessage: `{"role":"tool","content":"package main\n","tool_call_id":"call-1"}`, CreatedAt: 1704103207},
 	)
 
 	sess, msgs, err := parseDevinSession(fixture.DBPath, sessionID, "local")
@@ -469,12 +469,12 @@ func TestParseDevinSessionMissingTranscriptFallsBackToMessageNodes(t *testing.T)
 func TestParseDevinSessionTranscriptStillWinsOverMessageNodes(t *testing.T) {
 	const sessionID = "session-transcript-wins"
 	fixture := newDevinTestFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "Transcript wins",
-		WorkingDirectory:   "/tmp/transcript-wins",
-		Model:              "db-model",
-		CreatedAtMillis:    new(int64(1704103200000)),
-		LastActivityMillis: new(int64(1704103209000)),
+		ID:               sessionID,
+		Title:            "Transcript wins",
+		WorkingDirectory: "/tmp/transcript-wins",
+		Model:            "db-model",
+		CreatedAt:        new(int64(1704103200)),
+		LastActivityAt:   new(int64(1704103209)),
 	})
 	fixture.writeTranscript(t, sessionID, `{
 		"agent":{"model_name":"transcript-model"},
@@ -484,8 +484,8 @@ func TestParseDevinSessionTranscriptStillWinsOverMessageNodes(t *testing.T) {
 		]
 	}`)
 	fixture.insertMessageNodes(t,
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"Use fallback instead"}`, CreatedAtMillis: 1704103201000},
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"Fallback answer"}`, CreatedAtMillis: 1704103205000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"Use fallback instead"}`, CreatedAt: 1704103201},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"Fallback answer"}`, CreatedAt: 1704103205},
 	)
 
 	sess, msgs, err := parseDevinSession(fixture.DBPath, sessionID, "local")
@@ -500,12 +500,12 @@ func TestParseDevinSessionTranscriptStillWinsOverMessageNodes(t *testing.T) {
 func TestParseDevinSessionMissingTranscriptWithoutDBMessagesReturnsRedactedError(t *testing.T) {
 	const sessionID = "session-db-only-empty"
 	fixture := newDevinTestFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "DB only session",
-		WorkingDirectory:   "/tmp/db-only-project",
-		Model:              "db-only-model",
-		CreatedAtMillis:    new(int64(1704103200000)),
-		LastActivityMillis: new(int64(1704103209000)),
+		ID:               sessionID,
+		Title:            "DB only session",
+		WorkingDirectory: "/tmp/db-only-project",
+		Model:            "db-only-model",
+		CreatedAt:        new(int64(1704103200)),
+		LastActivityAt:   new(int64(1704103209)),
 	})
 
 	sess, msgs, err := parseDevinSession(fixture.DBPath, sessionID, "local")
@@ -524,15 +524,15 @@ func TestParseDevinSessionFallbackErrorsStayRedacted(t *testing.T) {
 		secretSentinel = "oauth-token-SYNTHETIC-SECRET-SENTINEL"
 	)
 	fixture := newDevinTestFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "DB only session",
-		WorkingDirectory:   "/tmp/db-only-project",
-		Model:              "db-only-model",
-		CreatedAtMillis:    new(int64(1704103200000)),
-		LastActivityMillis: new(int64(1704103209000)),
+		ID:               sessionID,
+		Title:            "DB only session",
+		WorkingDirectory: "/tmp/db-only-project",
+		Model:            "db-only-model",
+		CreatedAt:        new(int64(1704103200)),
+		LastActivityAt:   new(int64(1704103209)),
 	})
 	fixture.insertMessageNodes(t,
-		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"content":"` + secretSentinel, CreatedAtMillis: 1704103201000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"content":"` + secretSentinel, CreatedAt: 1704103201},
 	)
 
 	sess, msgs, err := parseDevinSession(fixture.DBPath, sessionID, "local")
@@ -549,12 +549,12 @@ func TestParseDevinSessionFallbackErrorsStayRedacted(t *testing.T) {
 func TestParseDevinSessionCorruptTranscriptReturnsRedactedError(t *testing.T) {
 	const sessionID = "secret-session"
 	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{
-		ID:                 sessionID,
-		Title:              "Corrupt transcript",
-		WorkingDirectory:   "/tmp/app",
-		Model:              "db-model",
-		CreatedAtMillis:    new(int64(1704103199000)),
-		LastActivityMillis: new(int64(1704103265000)),
+		ID:               sessionID,
+		Title:            "Corrupt transcript",
+		WorkingDirectory: "/tmp/app",
+		Model:            "db-model",
+		CreatedAt:        new(int64(1704103199)),
+		LastActivityAt:   new(int64(1704103265)),
 	}, `{"steps":[]}`)
 	require.NoError(t, os.WriteFile(transcriptPath, []byte(`{"apiKey":"secret-value","steps":[`), 0o644))
 
@@ -595,7 +595,7 @@ func TestParseDevinSessionRedactsCredentialPathsAndTokenLikeValues(t *testing.T)
 		secretSentinel = "oauth-token-SYNTHETIC-SECRET-SENTINEL"
 	)
 	fixture := newDevinTestFixture(t,
-		devinSessionRow{ID: sessionID, Title: "Privacy", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+		devinSessionRow{ID: sessionID, Title: "Privacy", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAt: new(int64(1704103199)), LastActivityAt: new(int64(1704103265))},
 	)
 	transcriptPath := fixture.writeTranscript(t, sessionID, `{"access_token":"oauth-token-SYNTHETIC-SECRET-SENTINEL","steps":[`)
 

--- a/internal/parser/devin_test.go
+++ b/internal/parser/devin_test.go
@@ -73,6 +73,69 @@ func TestListDevinSessionMetaAllowsMissingTimestamps(t *testing.T) {
 	assert.Zero(t, metas[0].FileMtime)
 }
 
+// Devin stores epoch seconds. A row carrying some other unit (milliseconds, in
+// practice) must not be converted anyway: FileMtime is seconds*1e9, which
+// overflows int64 above year 2262 and wraps to a far-future nanosecond value.
+// devinApplyFileInfoTimes only ever raises Mtime, so a wrapped value can never
+// be superseded by a real file mtime and the session stops resyncing.
+func TestListDevinSessionMetaRejectsImplausibleTimestamps(t *testing.T) {
+	tests := []struct {
+		name           string
+		lastActivityAt int64
+		wantUpdatedAt  time.Time
+		wantFileMtime  int64
+	}{
+		{
+			name:           "epoch seconds are accepted",
+			lastActivityAt: 1_700_000_095,
+			wantUpdatedAt:  time.Unix(1_700_000_095, 0).UTC(),
+			wantFileMtime:  1_700_000_095_000_000_000,
+		},
+		{
+			name:           "largest nanosecond-representable second is accepted",
+			lastActivityAt: 9_223_372_036,
+			wantUpdatedAt:  time.Unix(9_223_372_036, 0).UTC(),
+			wantFileMtime:  9_223_372_036_000_000_000,
+		},
+		{
+			name:           "one second past the nanosecond range is rejected",
+			lastActivityAt: 9_223_372_037,
+		},
+		{
+			name:           "millisecond value is rejected instead of overflowing",
+			lastActivityAt: 1_700_000_095_000,
+		},
+		{
+			name:           "negative value is rejected",
+			lastActivityAt: -1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newDevinTestFixture(t,
+				devinSessionRow{
+					ID:               "session-units",
+					Title:            "Units",
+					WorkingDirectory: "/cwd/units",
+					Model:            "model-units",
+					CreatedAt:        new(tc.lastActivityAt),
+					LastActivityAt:   new(tc.lastActivityAt),
+				},
+			)
+
+			metas, err := ListDevinSessionMeta(fixture.DBPath)
+			require.NoError(t, err)
+			require.Len(t, metas, 1)
+
+			assert.Equal(t, tc.wantUpdatedAt, metas[0].UpdatedAt)
+			assert.Equal(t, tc.wantUpdatedAt, metas[0].CreatedAt)
+			assert.Equal(t, tc.wantUpdatedAt, metas[0].LastActivity)
+			assert.Equal(t, tc.wantFileMtime, metas[0].FileMtime)
+		})
+	}
+}
+
 func TestListDevinSessionMetaMissingDB(t *testing.T) {
 	metas, err := ListDevinSessionMeta(filepath.Join(t.TempDir(), "cli", devinDBFilename))
 	require.NoError(t, err)

--- a/internal/parser/test_helpers_test.go
+++ b/internal/parser/test_helpers_test.go
@@ -44,15 +44,15 @@ CREATE TABLE message_nodes (
 `
 
 type devinSessionRow struct {
-	ID                 string
-	Title              string
-	WorkingDirectory   string
-	Model              string
-	CreatedAtMillis    *int64
-	LastActivityMillis *int64
-	WorkspaceJSON      string
-	MetadataJSON       string
-	Hidden             bool
+	ID               string
+	Title            string
+	WorkingDirectory string
+	Model            string
+	CreatedAt        *int64
+	LastActivityAt   *int64
+	WorkspaceJSON    string
+	MetadataJSON     string
+	Hidden           bool
 }
 
 type devinTestFixture struct {
@@ -63,12 +63,12 @@ type devinTestFixture struct {
 }
 
 type devinSyntheticMessageNodeRow struct {
-	SessionID       string
-	NodeID          int64
-	ParentNodeID    *int64
-	ChatMessage     string
-	CreatedAtMillis int64
-	MetadataJSON    string
+	SessionID    string
+	NodeID       int64
+	ParentNodeID *int64
+	ChatMessage  string
+	CreatedAt    int64
+	MetadataJSON string
 }
 
 func newDevinTestFixture(t *testing.T, rows ...devinSessionRow) *devinTestFixture {
@@ -127,8 +127,8 @@ func insertDevinSessionRow(t *testing.T, dbPath string, row devinSessionRow) {
 		row.Title,
 		row.WorkingDirectory,
 		row.Model,
-		devinNullableMillis(row.CreatedAtMillis),
-		devinNullableMillis(row.LastActivityMillis),
+		devinNullableTimestamp(row.CreatedAt),
+		devinNullableTimestamp(row.LastActivityAt),
 		devinNullableString(row.WorkspaceJSON),
 		devinNullableString(row.MetadataJSON),
 		row.Hidden,
@@ -136,11 +136,11 @@ func insertDevinSessionRow(t *testing.T, dbPath string, row devinSessionRow) {
 	require.NoError(t, err)
 }
 
-func devinNullableMillis(ms *int64) any {
-	if ms == nil {
+func devinNullableTimestamp(sec *int64) any {
+	if sec == nil {
 		return nil
 	}
-	return *ms
+	return *sec
 }
 
 func devinNullableString(value string) any {
@@ -204,7 +204,7 @@ func insertDevinMessageNodeRow(t *testing.T, dbPath string, row devinSyntheticMe
 		row.NodeID,
 		devinNullableInt64(row.ParentNodeID),
 		row.ChatMessage,
-		row.CreatedAtMillis,
+		row.CreatedAt,
 		devinNullableString(row.MetadataJSON),
 	)
 	require.NoError(t, err)

--- a/internal/sync/devin_timestamp_resync_test.go
+++ b/internal/sync/devin_timestamp_resync_test.go
@@ -1,0 +1,245 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// writeDevinMessageNodeOnlyFixture builds a Devin root whose session has no
+// transcript artifact and no session-level timestamps. Both the session and its
+// message timestamps then come solely from message_nodes.created_at, which is
+// the shape whose fingerprint the epoch-seconds fix cannot disturb.
+func writeDevinMessageNodeOnlyFixture(
+	t *testing.T,
+	root string,
+	sessionID string,
+	nodeCreatedAtSec int64,
+) string {
+	t.Helper()
+	cliDir := filepath.Join(root, "cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	dbPath := filepath.Join(cliDir, "sessions.db")
+
+	database, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, database.Close()) }()
+
+	_, err = database.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			title TEXT,
+			working_directory TEXT,
+			model TEXT,
+			created_at INTEGER,
+			last_activity_at INTEGER,
+			hidden INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE message_nodes (
+			row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			node_id INTEGER NOT NULL,
+			parent_node_id INTEGER,
+			chat_message TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			metadata TEXT
+		);
+	`)
+	require.NoError(t, err)
+
+	// created_at and last_activity_at stay NULL: this session's only timestamp
+	// source is message_nodes.created_at.
+	_, err = database.Exec(
+		`INSERT INTO sessions (id, title, working_directory, model, hidden)
+		 VALUES (?, ?, ?, ?, 0)`,
+		sessionID, "Devin node-only fixture", "/src/agentsview", "devin-1",
+	)
+	require.NoError(t, err)
+
+	for i, node := range []struct {
+		nodeID  int64
+		payload string
+	}{
+		{0, `{"role":"user","content":"Fix the parser"}`},
+		{1, `{"role":"assistant","content":"Fixed it"}`},
+	} {
+		var parent any
+		if i > 0 {
+			parent = int64(i - 1)
+		}
+		_, err = database.Exec(
+			`INSERT INTO message_nodes
+				(session_id, node_id, parent_node_id, chat_message, created_at)
+			 VALUES (?, ?, ?, ?, ?)`,
+			sessionID, node.nodeID, parent, node.payload, nodeCreatedAtSec,
+		)
+		require.NoError(t, err)
+	}
+	return dbPath
+}
+
+// devinSourceFingerprint returns the provider fingerprint for the single Devin
+// source under root, so a test can prove the fingerprint did or did not move.
+func devinSourceFingerprint(t *testing.T, root string) parser.SourceFingerprint {
+	t.Helper()
+	var factory parser.ProviderFactory
+	for _, candidate := range parser.ProviderFactories() {
+		if candidate.Definition().Type == parser.AgentDevin {
+			factory = candidate
+			break
+		}
+	}
+	require.NotNil(t, factory, "devin provider factory must be registered")
+
+	provider := factory.NewProvider(parser.ProviderConfig{
+		Roots: []string{root}, Machine: "local",
+	})
+	refs, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), refs[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, fingerprint.Hash)
+	return fingerprint
+}
+
+// staleStartedAt is what the pre-fix parser stored for a message-node session
+// whose nodes carry created_at 1700000000: read as milliseconds that is
+// 1970-01-20, which the parser kept only because it came from a message rather
+// than the discarded session metadata.
+const staleStartedAt = "1970-01-20T16:13:20Z"
+
+// staleUserVersion picks the archive user_version to stamp: one below the
+// current data version to demand a resync, or the current version to model an
+// archive that a bump never reached.
+func staleUserVersion(demandResync bool) int {
+	if demandResync {
+		return db.CurrentDataVersion() - 1
+	}
+	return db.CurrentDataVersion()
+}
+
+// writeStaleDevinTimestamps rewrites every stored session timestamp to the
+// pre-fix value and stamps the archive's data version, standing in for an
+// archive an older binary produced.
+func writeStaleDevinTimestamps(t *testing.T, archivePath string, userVersion int) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", archivePath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	_, err = conn.Exec(
+		`UPDATE sessions SET started_at = ?, ended_at = ?`,
+		staleStartedAt, staleStartedAt,
+	)
+	require.NoError(t, err)
+	_, err = conn.Exec(fmt.Sprintf("PRAGMA user_version = %d", userVersion))
+	require.NoError(t, err)
+}
+
+func requireOnlyStoredSession(t *testing.T, database *db.DB) db.Session {
+	t.Helper()
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Sessions, 1)
+	return page.Sessions[0]
+}
+
+// TestDevinMessageNodeSessionResyncsDespiteUnchangedFingerprint protects the
+// upgrade path for the epoch-seconds fix. A Devin session that falls back to
+// message_nodes and has no usable sessions-row timestamps hashes to the same
+// fingerprint before and after that fix, so nothing source-side signals that
+// its stored 1970-era timestamps are wrong. Correction has to come from the
+// stale-data-version resync, which rebuilds the archive and reparses every
+// source unconditionally. If resync ever starts consulting fingerprints to skip
+// unchanged sources, this session would keep its wrong timestamps forever and
+// this test fails.
+func TestDevinMessageNodeSessionResyncsDespiteUnchangedFingerprint(t *testing.T) {
+	const (
+		sessionID = "node-only-session"
+		// 2023-11-14T22:13:20Z as epoch seconds. Read as milliseconds this is
+		// 1970-01-20, which the parser discards as invalid.
+		nodeCreatedAtSec = 1_700_000_000
+		wantStartedAt    = "2023-11-14T22:13:20Z"
+	)
+
+	root := t.TempDir()
+	writeDevinMessageNodeOnlyFixture(t, root, sessionID, nodeCreatedAtSec)
+	archivePath := filepath.Join(t.TempDir(), "archive.db")
+
+	database, err := db.Open(archivePath)
+	require.NoError(t, err)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentDevin: {root}},
+		Machine:   "local",
+	})
+	require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
+
+	stored := requireOnlyStoredSession(t, database)
+	require.NotNil(t, stored.StartedAt)
+	assert.Equal(t, wantStartedAt, *stored.StartedAt,
+		"message_nodes.created_at is epoch seconds and must date the session")
+
+	fingerprintBefore := devinSourceFingerprint(t, root)
+
+	// Simulate the archive an older binary left behind: the same source, but
+	// stored timestamps the millisecond misreading produced.
+	engine.Close()
+	require.NoError(t, database.Close())
+	writeStaleDevinTimestamps(t, archivePath, staleUserVersion(false))
+
+	// An incremental sync cannot repair this. The source bytes never changed,
+	// so its fingerprint is what it always was, and the fix lives entirely in
+	// how the parser interprets integers the fingerprint hashes raw.
+	currentVersioned, err := db.Open(archivePath)
+	require.NoError(t, err)
+	require.False(t, currentVersioned.NeedsResync())
+	incremental := NewEngine(currentVersioned, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentDevin: {root}},
+		Machine:   "local",
+	})
+	incremental.SyncAll(context.Background(), nil)
+	skipped := requireOnlyStoredSession(t, currentVersioned)
+	require.NotNil(t, skipped.StartedAt)
+	assert.Equal(t, staleStartedAt, *skipped.StartedAt,
+		"incremental sync must be unable to notice the correction, which is why "+
+			"this fix needs a data-version bump rather than a fingerprint change")
+	assert.Equal(t, fingerprintBefore.Hash, devinSourceFingerprint(t, root).Hash,
+		"the source is unchanged, so nothing source-side can signal the reparse")
+	incremental.Close()
+	require.NoError(t, currentVersioned.Close())
+
+	// The data-version bump is the only thing that reaches this session.
+	writeStaleDevinTimestamps(t, archivePath, staleUserVersion(true))
+	reopened, err := db.Open(archivePath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reopened.Close()) }()
+	require.True(t, reopened.NeedsResync(),
+		"an archive below the current data version must ask for a resync")
+
+	upgraded := NewEngine(reopened, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentDevin: {root}},
+		Machine:   "local",
+	})
+	defer upgraded.Close()
+
+	resyncStats := upgraded.ResyncAll(context.Background(), nil)
+	require.False(t, resyncStats.Aborted)
+
+	corrected := requireOnlyStoredSession(t, reopened)
+	require.NotNil(t, corrected.StartedAt)
+	assert.Equal(t, wantStartedAt, *corrected.StartedAt,
+		"resync must reparse the session and replace the 1970-era timestamp")
+	assert.False(t, reopened.NeedsResync(),
+		"a completed resync must clear the stale-data flag")
+}

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -796,8 +796,8 @@ func TestProcessFileProviderDevinSkipsStoredFreshSource(t *testing.T) {
 		root,
 		"session-001",
 		"Initial reply",
-		1700000000000,
-		1700000005000,
+		1700000000,
+		1700000005,
 	)
 	virtualPath := parser.VirtualSourcePath(dbPath, "session-001")
 	database := dbtest.OpenTestDB(t)
@@ -856,8 +856,8 @@ func TestProcessFileProviderDevinReparsesTranscriptOnlyChange(t *testing.T) {
 		root,
 		"session-002",
 		"Initial reply",
-		1700000000000,
-		1700000005000,
+		1700000000,
+		1700000005,
 	)
 	virtualPath := parser.VirtualSourcePath(dbPath, "session-002")
 	database := dbtest.OpenTestDB(t)
@@ -924,8 +924,8 @@ func TestProcessFileProviderDevinSameSizeSameMtimeTranscriptRewriteReparses(t *t
 				root,
 				"session-same-mtime",
 				"Initial reply",
-				1700000000000,
-				1700000005000,
+				1700000000,
+				1700000005,
 			)
 			virtualPath := parser.VirtualSourcePath(dbPath, "session-same-mtime")
 			database := dbtest.OpenTestDB(t)
@@ -1005,8 +1005,8 @@ func TestProcessFileProviderDevinRepeatedHashRewriteIgnoresStaleHashedCache(t *t
 		root,
 		"session-repeated-hash",
 		"Initial reply",
-		1700000000000,
-		1700000005000,
+		1700000000,
+		1700000005,
 	)
 	virtualPath := parser.VirtualSourcePath(dbPath, "session-repeated-hash")
 	file := parser.DiscoveredFile{
@@ -1070,8 +1070,8 @@ func TestSyncAllProviderDevinMissingDBPreservesArchive(t *testing.T) {
 		root,
 		"session-003",
 		"Archived reply",
-		1700000000000,
-		1700000005000,
+		1700000000,
+		1700000005,
 	)
 	database := dbtest.OpenTestDB(t)
 	engine := NewEngine(database, EngineConfig{
@@ -1168,8 +1168,8 @@ func writeProcessProviderDevinFixture(
 	root string,
 	sessionID string,
 	assistantReply string,
-	createdAtMS int64,
-	lastActivityAtMS int64,
+	createdAtSec int64,
+	lastActivityAtSec int64,
 ) (string, string) {
 	t.Helper()
 	cliDir := filepath.Join(root, "cli")
@@ -1198,8 +1198,8 @@ func writeProcessProviderDevinFixture(
 		"Devin fixture",
 		"/Users/devbox/src/agentsview",
 		"devin-1",
-		createdAtMS,
-		lastActivityAtMS,
+		createdAtSec,
+		lastActivityAtSec,
 	)
 	require.NoError(t, err)
 	require.NoError(t, database.Close())

--- a/internal/sync/stored_source_hints_test.go
+++ b/internal/sync/stored_source_hints_test.go
@@ -205,7 +205,7 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 			setup: func(t *testing.T) (string, string, string) {
 				root := t.TempDir()
 				path, _ := writeProcessProviderDevinFixture(
-					t, root, "deleted", "reply", 1710000000000, 1710000005000,
+					t, root, "deleted", "reply", 1710000000, 1710000005,
 				)
 				conn, err := sql.Open("sqlite3", path)
 				require.NoError(t, err)


### PR DESCRIPTION
The Devin CLI stores created_at and last_activity_at as Unix epoch seconds, but the parser treated them as milliseconds. This produced dates in 1970 that were discarded as invalid, leaving started_at and ended_at NULL for every Devin session.

Replace devinUnixMilli (time.UnixMilli) with devinUnixSec (time.Unix) and correct the FileMtime multiplier from 1e6 to 1e9. The same fix applies to message_nodes.created_at, which is also epoch seconds.

Rename variables and test helpers from the misleading MS/Millis suffixes to match the Devin DB column names. Update all test data from 13-digit millisecond values to 10-digit second values.

Add timestamp-unit evidence to the Devin provenance entry.

I tested this and confirmed it fixes #1199 