### PR TITLE
test: stabilize background wait synchronization

### DIFF
--- a/cmd/agentsview/polling_scope_identity_test.go
+++ b/cmd/agentsview/polling_scope_identity_test.go
@@ -427,7 +427,7 @@ func TestUnwatchedPollCooldownIsExactlyOneInterval(t *testing.T) {
 		return ch
 	}
 
-	firstCallDone := make(chan struct{})
+	firstCallDone := make(chan struct{}, 1)
 	var callMu sync.Mutex
 	var callCount int
 	syncer := &manualProviderPollSyncer{

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1532,9 +1532,26 @@ func TestEnsureBackgroundServeReplacesIncompatibleDaemonAfterStartupWait(
 
 	unlockStart := holdExternalDaemonStartLock(t, dir)
 	oldHost, oldPort := testPingServer(t)
+	waitStarted := make(chan struct{})
+	oldWaitForDaemonStartup := waitForDaemonStartupForEnsure
+	waitForDaemonStartupForEnsure = func(
+		ctx context.Context,
+		dataDir string,
+		timeout time.Duration,
+		authToken ...string,
+	) bool {
+		close(waitStarted)
+		return oldWaitForDaemonStartup(
+			ctx, dataDir, timeout, authToken...,
+		)
+	}
+	t.Cleanup(func() {
+		waitForDaemonStartupForEnsure = oldWaitForDaemonStartup
+	})
+
 	errCh := make(chan error, 1)
 	go func() {
-		time.Sleep(2 * startProbeTick())
+		<-waitStarted
 		_, err := writeRuntimeRecordForTest(dir, daemonRuntimeRecord(
 			oldHost, oldPort,
 			withRuntimeVersion("1.0.0"),


### PR DESCRIPTION
Two background timing tests depended on receiver or scheduler ordering and could exercise the wrong state under differently scheduled CI runners.

The unwatched poll cooldown test now retains its one-shot completion notification so a completed reconcile pass cannot become a timeout. The daemon replacement startup-wait test now waits until ensureBackgroundServe enters the startup wait before publishing the incompatible runtime, ensuring it exercises replacement rather than a fresh launch.

Both changes are test-only; production polling and daemon lifecycle behavior are unchanged. The race/non-race job split already exists on main via #1323.