### PR TITLE
ci(e2e): cache Playwright browser downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,8 +354,32 @@ jobs:
         env:
           CGO_ENABLED: "1"
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+        working-directory: frontend
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium webkit
+        working-directory: frontend
+
+      # Cache hit: browser binaries are already present, but the runner
+      # image itself isn't guaranteed to have the OS packages Playwright
+      # needs (e.g. after a fresh self-hosted runner or an ubuntu-latest
+      # image bump), so make sure those are still installed.
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium webkit
         working-directory: frontend
 
       - name: Run E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,12 +361,18 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
         working-directory: frontend
 
+      - name: Resolve Playwright runner platform
+        id: playwright-platform
+        run: |
+          . /etc/os-release
+          echo "linux-distribution=${ID:-unknown}-${VERSION_ID:-unknown}" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          key: playwright-browsers-${{ runner.os }}-${{ runner.arch }}-${{ runner.environment }}-${{ steps.playwright-platform.outputs.linux-distribution }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

Caches Playwright browser downloads for end-to-end CI. Cache keys include the
Playwright version and the runner's architecture, hosted environment, and Linux
distribution, so incompatible runner families cannot share browser archives.

Cache misses keep the full Chromium and WebKit install. Cache hits reuse the
browsers and install only the required system packages.
