### PR TITLE
ci: cache Rust deps in desktop-windows-unit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          workspaces: desktop/src-tauri
+
       - name: Prepare placeholder sidecar resource
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary

Caches Rust dependencies and build outputs for the Windows desktop unit-test
job, using `desktop/src-tauri` as the workspace. The first run seeds the cache;
later runs can avoid rebuilding unchanged dependencies.
