### PR TITLE
test(artifact): run internal/artifact tests in parallel

### DIFF
--- a/internal/artifact/canonical_json_test.go
+++ b/internal/artifact/canonical_json_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestCanonicalJSONSortsStructAndMapKeys(t *testing.T) {
+	t.Parallel()
+
 	type inner struct {
 		Zeta  string `json:"zeta"`
 		Alpha string `json:"alpha"`
@@ -30,6 +32,8 @@ func TestCanonicalJSONSortsStructAndMapKeys(t *testing.T) {
 }
 
 func TestCanonicalJSONPreservesSliceOrder(t *testing.T) {
+	t.Parallel()
+
 	v := struct {
 		Items []string `json:"items"`
 	}{Items: []string{"z", "a", "m"}}
@@ -40,6 +44,8 @@ func TestCanonicalJSONPreservesSliceOrder(t *testing.T) {
 }
 
 func TestCanonicalJSONRecanonicalizesRawMessage(t *testing.T) {
+	t.Parallel()
+
 	type wrapper struct {
 		Value json.RawMessage `json:"value"`
 	}
@@ -51,6 +57,8 @@ func TestCanonicalJSONRecanonicalizesRawMessage(t *testing.T) {
 }
 
 func TestCanonicalJSONRejectsTrailingRawMessageContent(t *testing.T) {
+	t.Parallel()
+
 	type wrapper struct {
 		Value json.RawMessage `json:"value"`
 	}
@@ -77,6 +85,8 @@ func TestCanonicalJSONRejectsTrailingRawMessageContent(t *testing.T) {
 }
 
 func TestCanonicalJSONEmptyRawMessageEncodesAsNull(t *testing.T) {
+	t.Parallel()
+
 	type wrapper struct {
 		Value json.RawMessage `json:"value"`
 	}
@@ -87,6 +97,8 @@ func TestCanonicalJSONEmptyRawMessageEncodesAsNull(t *testing.T) {
 }
 
 func TestCanonicalJSONPreservesLargeNumberPrecision(t *testing.T) {
+	t.Parallel()
+
 	type wrapper struct {
 		Value json.RawMessage `json:"value"`
 	}
@@ -100,6 +112,8 @@ func TestCanonicalJSONPreservesLargeNumberPrecision(t *testing.T) {
 }
 
 func TestCanonicalJSONNilPointerAndInterfaceEncodeAsNull(t *testing.T) {
+	t.Parallel()
+
 	var nilPointer *int
 	data, err := canonicalJSON(nilPointer)
 	require.NoError(t, err)
@@ -112,6 +126,8 @@ func TestCanonicalJSONNilPointerAndInterfaceEncodeAsNull(t *testing.T) {
 }
 
 func TestCanonicalJSONDereferencesPopulatedPointerFields(t *testing.T) {
+	t.Parallel()
+
 	name := "Fixture"
 	v := struct {
 		Name *string `json:"name"`
@@ -123,6 +139,8 @@ func TestCanonicalJSONDereferencesPopulatedPointerFields(t *testing.T) {
 }
 
 func TestCanonicalJSONOmitsEmptyFieldsAndKeepsZeroValuesWithoutTag(t *testing.T) {
+	t.Parallel()
+
 	type v struct {
 		Kept    int    `json:"kept"`
 		Skipped string `json:"skipped,omitempty"`
@@ -135,6 +153,8 @@ func TestCanonicalJSONOmitsEmptyFieldsAndKeepsZeroValuesWithoutTag(t *testing.T)
 }
 
 func TestCanonicalJSONRejectsNonStringMapKeys(t *testing.T) {
+	t.Parallel()
+
 	v := map[int]string{1: "a"}
 
 	_, err := canonicalJSON(v)
@@ -143,6 +163,8 @@ func TestCanonicalJSONRejectsNonStringMapKeys(t *testing.T) {
 }
 
 func TestCanonicalJSONRejectsUnsupportedKind(t *testing.T) {
+	t.Parallel()
+
 	v := struct {
 		Ch chan int `json:"ch"`
 	}{Ch: make(chan int)}

--- a/internal/artifact/export_checkpoint_test.go
+++ b/internal/artifact/export_checkpoint_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestCheckpointFloorBootstrapsFromLiveAndQuarantinedNodes(t *testing.T) {
+	t.Parallel()
+
 	_, store := newTestDocbankStore(t, docbank.Config{})
 	database := testDB(t)
 	origin := contractOrigin
@@ -47,6 +49,8 @@ func TestCheckpointFloorBootstrapsFromLiveAndQuarantinedNodes(t *testing.T) {
 }
 
 func TestCheckpointFloorTraversesStoreOnlyBeforeBootstrap(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	store := &countingCheckpointFloorStore{floor: 40}
 
@@ -75,6 +79,8 @@ func (s *countingCheckpointFloorStore) checkpointFloor(context.Context, string) 
 }
 
 func TestExportCheckpointBootstrapStreamsLargeSessionMap(t *testing.T) {
+	t.Parallel()
+
 	sessions := make(map[string]string, 2000)
 	for i := range 2000 {
 		sessions[fmt.Sprintf("%s~session-%04d", contractOrigin, i)] = strings64("a")
@@ -95,6 +101,8 @@ func TestExportCheckpointBootstrapStreamsLargeSessionMap(t *testing.T) {
 }
 
 func TestExportCheckpointBootstrapSkipsNoncanonicalJSON(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		body string
@@ -132,6 +140,8 @@ func TestExportCheckpointBootstrapSkipsNoncanonicalJSON(t *testing.T) {
 }
 
 func TestExportCheckpointBootstrapSkipsMalformedCheckpointBeforeEOF(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	body := append([]byte(`{"unexpected":`), deterministicDocbankBytes(1<<20)...)
@@ -153,6 +163,8 @@ func TestExportCheckpointBootstrapSkipsMalformedCheckpointBeforeEOF(t *testing.T
 }
 
 func TestExportCheckpointBootstrapDefersOnlyValidFutureCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		body       string
@@ -291,6 +303,8 @@ func strings64(ch string) string {
 }
 
 func TestDecodeSegmentRejectsAggregateNestedLimitsWithSmallLimits(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		records   []segmentMessage
@@ -334,6 +348,8 @@ func TestDecodeSegmentRejectsAggregateNestedLimitsWithSmallLimits(t *testing.T) 
 }
 
 func TestDecodeSegmentAcceptsCanonicalTrailingNewlineAndEmptySession(t *testing.T) {
+	t.Parallel()
+
 	record := nestedSegmentData(t, segmentMessage{})
 	tests := []struct {
 		name string

--- a/internal/artifact/export_limits_test.go
+++ b/internal/artifact/export_limits_test.go
@@ -92,6 +92,8 @@ func assertFinalizedExportRejection(
 }
 
 func TestExportClassifiesBoundedLoadLimit(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -113,6 +115,8 @@ func TestExportClassifiesBoundedLoadLimit(t *testing.T) {
 }
 
 func TestExportRejectsNativeSessionIDsImporterCannotRepresent(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		sessionID string
@@ -153,6 +157,8 @@ func TestExportRejectsNativeSessionIDsImporterCannotRepresent(t *testing.T) {
 }
 
 func TestExportRejectsNestedAmplificationBeforePublication(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		message   db.Message
@@ -200,6 +206,8 @@ func TestExportRejectsNestedAmplificationBeforePublication(t *testing.T) {
 }
 
 func TestExportChunksOnAggregateNestedLimitsWithSmallLimits(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		resultEvents []db.ToolResultEvent
@@ -265,6 +273,8 @@ func TestExportChunksOnAggregateNestedLimitsWithSmallLimits(t *testing.T) {
 }
 
 func TestExportRejectsMessageThatCannotFitNestedSegmentLimits(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		message   db.Message
@@ -322,6 +332,8 @@ func TestExportRejectsMessageThatCannotFitNestedSegmentLimits(t *testing.T) {
 }
 
 func TestExportRejectsSessionNestedLimitsBeforeWritingWithSmallLimits(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		configure func(*artifactLimits)
@@ -376,6 +388,8 @@ func TestExportRejectsSessionNestedLimitsBeforeWritingWithSmallLimits(t *testing
 }
 
 func TestExportChunksOnMessageRecordLimit(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -396,6 +410,8 @@ func TestExportChunksOnMessageRecordLimit(t *testing.T) {
 }
 
 func TestExportRejectsOversizedGeneratedManifestBeforePublication(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -415,6 +431,8 @@ func TestExportRejectsOversizedGeneratedManifestBeforePublication(t *testing.T) 
 }
 
 func TestExportRejectsSessionMessageAmplificationBeforePublication(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -436,6 +454,8 @@ func TestExportRejectsSessionMessageAmplificationBeforePublication(t *testing.T)
 }
 
 func TestExportRejectsUsageEventAmplificationBeforePublication(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -461,6 +481,8 @@ func TestExportRejectsUsageEventAmplificationBeforePublication(t *testing.T) {
 }
 
 func TestExportSessionRejectsAggregateLimitsBeforeWritingWithSmallLimits(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		configure func(*artifactLimits)
@@ -509,6 +531,8 @@ func TestExportSessionRejectsAggregateLimitsBeforeWritingWithSmallLimits(t *test
 }
 
 func TestExportChunksLargeMultiMessageSessionInOrder(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -542,6 +566,8 @@ func TestExportChunksLargeMultiMessageSessionInOrder(t *testing.T) {
 }
 
 func TestExportRejectsSingleEncodedRecordAboveReadableLimit(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -567,6 +593,8 @@ func TestExportRejectsSingleEncodedRecordAboveReadableLimit(t *testing.T) {
 }
 
 func TestExportPreservesSmallSingleSegmentHash(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)

--- a/internal/artifact/export_test.go
+++ b/internal/artifact/export_test.go
@@ -382,6 +382,8 @@ func deterministicRejectionBatch(
 }
 
 func TestExportContinuesPastDeterministicRejection(t *testing.T) {
+	t.Parallel()
+
 	database, store, limits := deterministicRejectionBatch(t)
 
 	result, err := exportToStoreWithLimits(
@@ -406,6 +408,8 @@ func TestExportContinuesPastDeterministicRejection(t *testing.T) {
 }
 
 func TestExportContinuesPastInvalidTokenUsage(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	seedSession(t, database, "invalid", "alpha")
@@ -434,6 +438,8 @@ func TestExportContinuesPastInvalidTokenUsage(t *testing.T) {
 }
 
 func TestExportContinuesPastInvalidManifestValue(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	seedSession(t, database, "invalid", "alpha")
@@ -468,6 +474,8 @@ func TestExportContinuesPastInvalidManifestValue(t *testing.T) {
 }
 
 func TestFullExportSkipsPreviouslyRejectedNativeSessionID(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	seedSession(t, database, "invalid~native", "alpha")
@@ -493,6 +501,8 @@ func TestFullExportSkipsPreviouslyRejectedNativeSessionID(t *testing.T) {
 }
 
 func TestFullExportRemovesPublishedNativeSessionIDRejectedByCurrentWire(t *testing.T) {
+	t.Parallel()
+
 	ctx := t.Context()
 	databasePath := filepath.Join(t.TempDir(), "archive.db")
 	database, err := db.Open(databasePath)
@@ -570,6 +580,8 @@ func TestFullExportRemovesPublishedNativeSessionIDRejectedByCurrentWire(t *testi
 }
 
 func TestExportTransientFailureDoesNotReject(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "rejected", "alpha")
 	seedSession(t, database, "valid", "alpha")
@@ -598,6 +610,8 @@ func TestExportTransientFailureDoesNotReject(t *testing.T) {
 }
 
 func TestExportRejectionWaitsForCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	database, filesystem, limits := deterministicRejectionBatch(t)
 	failure := errors.New("injected checkpoint failure")
 	store := &failingArtifactStore{
@@ -621,6 +635,8 @@ func TestExportRejectionWaitsForCheckpoint(t *testing.T) {
 }
 
 func TestExportStaleRejectionCannotConsumeMutation(t *testing.T) {
+	t.Parallel()
+
 	database, filesystem, limits := deterministicRejectionBatch(t)
 	store := &mutateAfterCheckpointStore{
 		ArtifactStore: filesystem, database: database, session: "rejected",
@@ -642,6 +658,8 @@ func TestExportStaleRejectionCannotConsumeMutation(t *testing.T) {
 }
 
 func TestExportToStorePublishesDependenciesBeforeCheckpointAndSkipsUnchanged(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -687,6 +705,8 @@ func TestExportToStorePublishesDependenciesBeforeCheckpointAndSkipsUnchanged(t *
 }
 
 func TestExportKeepsAgentSessionNameSeparateFromUserDisplayName(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	agentName := "Agent-provided title"
@@ -722,6 +742,8 @@ func TestExportKeepsAgentSessionNameSeparateFromUserDisplayName(t *testing.T) {
 }
 
 func TestExportToStorePublishesConfiguredHostnameSession(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	require.NoError(t, database.SetSyncState(
 		"artifact_local_machine_name", "workstation.example",
@@ -742,6 +764,8 @@ func TestExportToStorePublishesConfiguredHostnameSession(t *testing.T) {
 }
 
 func TestExportToStoreFullRepairsMissingDependencyWithoutNewCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -776,6 +800,8 @@ func TestExportToStoreFullRepairsMissingDependencyWithoutNewCheckpoint(t *testin
 }
 
 func TestExportToStoreRecreatesMissingRecordedCheckpointAfterVaultReset(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	first, err := newProtocolTestStore(t.TempDir())
@@ -808,6 +834,8 @@ func TestExportToStoreRecreatesMissingRecordedCheckpointAfterVaultReset(t *testi
 }
 
 func TestExportToStoreChangedBatchDoesNotScanCheckpointHistory(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -837,6 +865,8 @@ func TestExportToStoreChangedBatchDoesNotScanCheckpointHistory(t *testing.T) {
 }
 
 func TestExportToStoreDirtyBatchDefersRecordedFutureCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -898,6 +928,8 @@ func TestExportToStoreDirtyBatchDefersRecordedFutureCheckpoint(t *testing.T) {
 }
 
 func TestExportToStoreUnchangedCheckpointUsesCatalogIdentityOnly(t *testing.T) {
+	t.Parallel()
+
 	for _, size := range []int64{128, 64 << 20} {
 		t.Run(fmt.Sprintf("size-%d", size), func(t *testing.T) {
 			database := testExportDB(t)
@@ -923,6 +955,8 @@ func TestExportToStoreUnchangedCheckpointUsesCatalogIdentityOnly(t *testing.T) {
 }
 
 func TestExportToStoreRecordedCheckpointStatRecovery(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -950,6 +984,8 @@ func TestExportToStoreRecordedCheckpointStatRecovery(t *testing.T) {
 }
 
 func TestExportToStoreBootstrapsMissingDatabaseHeadFromLatestCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -974,6 +1010,8 @@ func TestExportToStoreBootstrapsMissingDatabaseHeadFromLatestCheckpoint(t *testi
 }
 
 func TestExportCheckpointBootstrapPropagatesOperationalOpenErrors(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		name string
 		err  error
@@ -1001,6 +1039,8 @@ func TestExportCheckpointBootstrapPropagatesOperationalOpenErrors(t *testing.T) 
 }
 
 func TestLatestValidCheckpointFallsBackPastSemanticCandidateAndDefersFuture(t *testing.T) {
+	t.Parallel()
+
 	filesystem, err := newProtocolTestStore(t.TempDir())
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
@@ -1063,6 +1103,8 @@ func TestExportSpoolConstructionJoinsCleanupFailures(t *testing.T) {
 }
 
 func TestSpoolArtifactCheckpointEnforcesDecodedSizeBoundary(t *testing.T) {
+	t.Parallel()
+
 	mapSpool, err := os.CreateTemp("", "agentsview-artifact-test-map-*")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closeAndRemoveExportSpool(mapSpool) })
@@ -1091,6 +1133,8 @@ func TestSpoolArtifactCheckpointEnforcesDecodedSizeBoundary(t *testing.T) {
 }
 
 func TestExportToStorePropagatesCheckpointCloseErrorWithoutAcknowledging(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -1115,6 +1159,8 @@ func TestExportToStorePropagatesCheckpointCloseErrorWithoutAcknowledging(t *test
 }
 
 func TestExportToStoreCancellationLeavesQueuePending(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -1133,6 +1179,8 @@ func TestExportToStoreCancellationLeavesQueuePending(t *testing.T) {
 }
 
 func TestExportToStoreFailureKeepsClaimAndCheckpointLast(t *testing.T) {
+	t.Parallel()
+
 	failure := errors.New("injected artifact create failure")
 	tests := []struct {
 		name         string
@@ -1185,6 +1233,8 @@ func TestExportToStoreFailureKeepsClaimAndCheckpointLast(t *testing.T) {
 }
 
 func TestExportToStoreStaleGenerationDoesNotPublishOrAcknowledge(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	stale := &staleClaimExportDB{DB: database}
@@ -1209,6 +1259,8 @@ func TestExportToStoreStaleGenerationDoesNotPublishOrAcknowledge(t *testing.T) {
 }
 
 func TestExportToStoreStaleGenerationAfterCheckpointDoesNotAdvanceHead(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	filesystem, err := newProtocolTestStore(t.TempDir())
@@ -1246,6 +1298,8 @@ func TestExportToStoreStaleGenerationAfterCheckpointDoesNotAdvanceHead(t *testin
 }
 
 func TestExportToStorePublicationRevisionRejectsPhysicallyCreatedStaleCheckpoint(t *testing.T) {
+	t.Parallel()
+
 	path := filepath.Join(t.TempDir(), "archive.db")
 	first, err := db.Open(path)
 	require.NoError(t, err)
@@ -1361,6 +1415,8 @@ func TestExportToStorePublicationRevisionRejectsPhysicallyCreatedStaleCheckpoint
 }
 
 func TestArtifactExportCardinalityLoadsOnlyDirtyBatch(t *testing.T) {
+	t.Parallel()
+
 	for _, archiveSize := range []int{20, 2000} {
 		t.Run(fmt.Sprintf("archive-%d", archiveSize), func(t *testing.T) {
 			database := testExportDB(t)
@@ -1401,6 +1457,8 @@ func TestArtifactExportCardinalityLoadsOnlyDirtyBatch(t *testing.T) {
 }
 
 func TestExportToStoreCardinalityIgnoresUnrelatedArchiveBodies(t *testing.T) {
+	t.Parallel()
+
 	for _, archiveSize := range []int{20, 2000} {
 		t.Run(fmt.Sprintf("archive-%d", archiveSize), func(t *testing.T) {
 			database := testExportDB(t)
@@ -1430,6 +1488,8 @@ func TestExportToStoreCardinalityIgnoresUnrelatedArchiveBodies(t *testing.T) {
 }
 
 func TestExportToStoreIncrementalBatchIsBoundedAndFullStreamsAllBodies(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	const total = artifactExportBatchSize + 5
 	for i := range total {
@@ -1471,6 +1531,8 @@ func TestExportToStoreIncrementalBatchIsBoundedAndFullStreamsAllBodies(t *testin
 }
 
 func TestExportToStoreFullDrainsMoreThanOneClaimPage(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	const total = 1025
 	for i := range total {
@@ -1510,6 +1572,8 @@ func TestExportToStoreFullDrainsMoreThanOneClaimPage(t *testing.T) {
 }
 
 func TestExportToStoreExplicitSessionIDsClaimBeyondOldestQueuePage(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	const total = 1025
 	for i := range total {
@@ -1540,6 +1604,8 @@ func TestExportToStoreExplicitSessionIDsClaimBeyondOldestQueuePage(t *testing.T)
 }
 
 func TestExportToStorePublishesEmptyAndDeletionSets(t *testing.T) {
+	t.Parallel()
+
 	t.Run("empty", func(t *testing.T) {
 		database := testExportDB(t)
 		filesystem, err := newProtocolTestStore(t.TempDir())
@@ -1582,6 +1648,8 @@ func TestExportToStorePublishesEmptyAndDeletionSets(t *testing.T) {
 }
 
 func TestQueuedArtifactExportTreatsOwnershipLossAsDeletion(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	require.NoError(t, database.UpsertSession(db.Session{
 		ID: "moved", Project: "project", Machine: "local", Agent: "claude",
@@ -1610,6 +1678,8 @@ func TestQueuedArtifactExportTreatsOwnershipLossAsDeletion(t *testing.T) {
 }
 
 func TestExportEmitsNewManifestAfterDataVersionChange(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -1640,6 +1710,8 @@ func TestExportEmitsNewManifestAfterDataVersionChange(t *testing.T) {
 }
 
 func TestExportIncludesLocalOwnedSessionClasses(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -1667,6 +1739,8 @@ func TestExportIncludesLocalOwnedSessionClasses(t *testing.T) {
 }
 
 func TestExportScrubsUnstableArtifactIDs(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -1708,6 +1782,8 @@ func TestExportScrubsUnstableArtifactIDs(t *testing.T) {
 }
 
 func TestExportRejectsInvalidOriginBeforeCreatingPaths(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
@@ -1721,6 +1797,8 @@ func TestExportRejectsInvalidOriginBeforeCreatingPaths(t *testing.T) {
 }
 
 func TestExportSkipsDeletedAndForeignSessions(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	store := newTestArtifactStore(t)
 	origin := contractOrigin
@@ -1779,6 +1857,8 @@ func (s *reEnqueueOnBoundaryStore) PendingArtifactExports(
 // when a concurrent writer keeps the queue perpetually non-empty. It must
 // give up after maxExportDrainRounds and still return whatever it exported.
 func TestExportFullDrainCapReturnsAccumulatedResultAfterUnsettledQueue(t *testing.T) {
+	t.Parallel()
+
 	const drainRounds = 3
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
@@ -1838,6 +1918,8 @@ func (s *reEnqueueAfterAcknowledgeStore) requeue(
 }
 
 func TestExportFullDrainCapAppliesToWritesArrivingDuringDrain(t *testing.T) {
+	t.Parallel()
+
 	const drainRounds = 3
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
@@ -1882,6 +1964,8 @@ func (s *finiteReEnqueueBoundaryStore) PendingArtifactExports(
 func TestExportFullDrainCapDoesNotReportMoreAfterFinalDrainSettles(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	store := newTestArtifactStore(t)
@@ -1910,6 +1994,8 @@ func TestExportFullDrainCapDoesNotReportMoreAfterFinalDrainSettles(
 // signal value -- not just non-nil presence -- must survive the encode then
 // decode round trip.
 func TestExportRoundTripsSessionQualitySignals(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)

--- a/internal/artifact/export_test.go
+++ b/internal/artifact/export_test.go
@@ -1073,6 +1073,7 @@ func TestLatestValidCheckpointFallsBackPastSemanticCandidateAndDefersFuture(t *t
 }
 
 func TestExportSpoolConstructionJoinsCleanupFailures(t *testing.T) {
+	// Serial: overrides package-level spool filesystem hooks.
 	chmodFailure := errors.New("injected spool setup failure")
 	cleanupFailure := errors.New("injected spool cleanup failure")
 	previousChmod := exportSpoolChmod

--- a/internal/artifact/format_test.go
+++ b/internal/artifact/format_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestCanonicalCheckpointGolden(t *testing.T) {
+	t.Parallel()
+
 	cp := checkpoint{
 		Version:  checkpointFormatVersion,
 		Origin:   "laptop-a1b2c3",
@@ -32,6 +34,8 @@ func TestCanonicalCheckpointGolden(t *testing.T) {
 }
 
 func TestCanonicalManifestGolden(t *testing.T) {
+	t.Parallel()
+
 	ordinal := 2
 	parent := "parent-1"
 	name := "Fixture"
@@ -104,6 +108,8 @@ func TestCanonicalManifestGolden(t *testing.T) {
 }
 
 func TestDecodeManifestRejectsUnsupportedOlderVersion(t *testing.T) {
+	t.Parallel()
+
 	data := []byte(`{
 		"v": 1,
 		"origin": "laptop-a1b2c3",
@@ -123,6 +129,8 @@ func TestDecodeManifestRejectsUnsupportedOlderVersion(t *testing.T) {
 }
 
 func TestDecodeManifestAcceptsPriorVersionWithoutSessionKind(t *testing.T) {
+	t.Parallel()
+
 	data := []byte(`{
 		"v": 2,
 		"origin": "laptop-a1b2c3",
@@ -144,6 +152,8 @@ func TestDecodeManifestAcceptsPriorVersionWithoutSessionKind(t *testing.T) {
 }
 
 func TestDecodeSegmentAcceptsPriorVersionWithoutPromptSource(t *testing.T) {
+	t.Parallel()
+
 	data := []byte("{\"content\":\"hello\",\"ordinal\":0,\"role\":\"user\",\"v\":1}\n")
 
 	msgs, err := decodeSegmentWithLimits(data, productionArtifactLimits())
@@ -154,6 +164,8 @@ func TestDecodeSegmentAcceptsPriorVersionWithoutPromptSource(t *testing.T) {
 }
 
 func TestCanonicalMessageSegmentGolden(t *testing.T) {
+	t.Parallel()
+
 	msgs := []db.Message{
 		{
 			ID:               99,
@@ -218,6 +230,8 @@ func TestCanonicalMessageSegmentGolden(t *testing.T) {
 }
 
 func TestEncodeSegmentPreservesPromptSource(t *testing.T) {
+	t.Parallel()
+
 	msgs := []db.Message{
 		{
 			ID:            1,
@@ -244,6 +258,8 @@ func TestEncodeSegmentPreservesPromptSource(t *testing.T) {
 }
 
 func TestCanonicalMetadataEventGolden(t *testing.T) {
+	t.Parallel()
+
 	value := json.RawMessage(`{"display_name":"Renamed session"}`)
 	note := "remember this"
 	event := metadataEvent{

--- a/internal/artifact/import_checkpoint_test.go
+++ b/internal/artifact/import_checkpoint_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestReadVerifiedImportArtifactByteBoundaries(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		kind      Kind
@@ -70,6 +72,8 @@ func TestReadVerifiedImportArtifactByteBoundaries(t *testing.T) {
 }
 
 func TestFutureArtifactVersionErrorsIdentifyDependencyKind(t *testing.T) {
+	t.Parallel()
+
 	t.Run("manifest", func(t *testing.T) {
 		_, err := decodeManifestWithLimits(
 			[]byte(`{"origin":"contract-a1b2c3","v":4}`),
@@ -96,6 +100,8 @@ func TestFutureArtifactVersionErrorsIdentifyDependencyKind(t *testing.T) {
 }
 
 func TestFutureSegmentVersionPrecedesCurrentRecordLimit(t *testing.T) {
+	t.Parallel()
+
 	var body strings.Builder
 	for range productionArtifactLimits().segmentMessages + 1 {
 		body.WriteString(
@@ -114,6 +120,8 @@ func TestFutureSegmentVersionPrecedesCurrentRecordLimit(t *testing.T) {
 }
 
 func TestCurrentSegmentRecordLimitPrecedesLaterRecordDecode(t *testing.T) {
+	t.Parallel()
+
 	limits := productionArtifactLimits()
 	limits.segmentMessages = 1
 	body := []byte(
@@ -127,6 +135,8 @@ func TestCurrentSegmentRecordLimitPrecedesLaterRecordDecode(t *testing.T) {
 }
 
 func TestImportCollectionBoundaries(t *testing.T) {
+	t.Parallel()
+
 	t.Run("manifest usage events", func(t *testing.T) {
 		limits := productionArtifactLimits()
 		limits.manifestUsageEvents = 2
@@ -291,6 +301,8 @@ func TestImportCollectionBoundaries(t *testing.T) {
 }
 
 func TestDecodeImportCheckpointAcceptsSemanticCurrentJSON(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	want := importCheckpoint{
 		Version:  1,
@@ -337,6 +349,8 @@ func TestDecodeImportCheckpointAcceptsSemanticCurrentJSON(t *testing.T) {
 }
 
 func TestDecodeImportCheckpointStreamsBoundedSessionPages(t *testing.T) {
+	t.Parallel()
+
 	const sessionCount = 300
 	var body strings.Builder
 	fmt.Fprintf(&body, `{"origin":%q,"seq":7,"sessions":{`, contractOrigin)
@@ -369,6 +383,8 @@ func TestDecodeImportCheckpointStreamsBoundedSessionPages(t *testing.T) {
 }
 
 func TestDecodeImportCheckpointDefersSessionValidationToPages(t *testing.T) {
+	t.Parallel()
+
 	var body strings.Builder
 	fmt.Fprintf(&body, `{"origin":%q,"seq":7,"sessions":{`, contractOrigin)
 	for i := range 128 {
@@ -396,6 +412,8 @@ func TestDecodeImportCheckpointDefersSessionValidationToPages(t *testing.T) {
 }
 
 func TestDecodeImportCheckpointRejectsInvalidCurrentJSON(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	valid := fmt.Sprintf(
 		`{"origin":%q,"seq":7,"sessions":{%q:%q},"v":1}`,
@@ -471,6 +489,8 @@ func TestDecodeImportCheckpointRejectsInvalidCurrentJSON(t *testing.T) {
 }
 
 func TestDecodeImportCheckpointBoundsTopLevelFieldState(t *testing.T) {
+	t.Parallel()
+
 	var body strings.Builder
 	body.WriteByte('{')
 	for i := range 10_000 {
@@ -546,6 +566,8 @@ func TestDecodeImportCheckpointRejectsCurrentExtraFieldBeforeItsValue(
 }
 
 func TestDecodeImportCheckpointDefersExtensibleFutureJSON(t *testing.T) {
+	t.Parallel()
+
 	tests := []string{
 		`{"sessions":"opaque","v":2}`,
 		`{"new_field":{"codec":"v3"},"sessions":[1,2,3],"v":3}`,
@@ -567,6 +589,8 @@ func TestDecodeImportCheckpointDefersExtensibleFutureJSON(t *testing.T) {
 func TestDecodeImportCheckpointFutureVersionDoesNotMaskMalformedJSON(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	_, err := decodeImportCheckpoint(
 		[]byte(`{"sessions":{"broken":},"v":2}`),
 		contractOrigin, "cp-0000000007.json",
@@ -576,6 +600,8 @@ func TestDecodeImportCheckpointFutureVersionDoesNotMaskMalformedJSON(
 }
 
 func TestReadVerifiedImportArtifactUsesExactBoundedIdentity(t *testing.T) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	ref := requireContractRef(
 		t, contractOrigin, KindCheckpoints, "cp-0000000001.json",
@@ -598,6 +624,8 @@ func TestReadVerifiedImportArtifactUsesExactBoundedIdentity(t *testing.T) {
 }
 
 func TestReadVerifiedImportArtifactRejectsOversizeBeforeOpen(t *testing.T) {
+	t.Parallel()
+
 	ref := requireContractRef(
 		t, contractOrigin, KindCheckpoints, "cp-0000000001.json",
 	)
@@ -618,6 +646,8 @@ func TestReadVerifiedImportArtifactRejectsOversizeBeforeOpen(t *testing.T) {
 }
 
 func TestReadVerifiedImportArtifactPreservesOperationalReadError(t *testing.T) {
+	t.Parallel()
+
 	ref := requireContractRef(
 		t, contractOrigin, KindCheckpoints, "cp-0000000001.json",
 	)

--- a/internal/artifact/import_checkpoint_test.go
+++ b/internal/artifact/import_checkpoint_test.go
@@ -515,6 +515,7 @@ func TestDecodeImportCheckpointBoundsTopLevelFieldState(t *testing.T) {
 }
 
 func TestPreflightImportCheckpointVersionBoundsAllocations(t *testing.T) {
+	// Serial: AllocsPerRun measures process-global allocation state.
 	const sessionCount = 1_000
 	var body strings.Builder
 	fmt.Fprintf(&body, `{"origin":%q,"seq":7,"sessions":{`, contractOrigin)
@@ -544,6 +545,7 @@ func TestPreflightImportCheckpointVersionBoundsAllocations(t *testing.T) {
 func TestDecodeImportCheckpointRejectsCurrentExtraFieldBeforeItsValue(
 	t *testing.T,
 ) {
+	// Serial: AllocsPerRun measures process-global allocation state.
 	var body strings.Builder
 	body.WriteString(`{"v":1,"extra":{`)
 	for i := range 10_000 {

--- a/internal/artifact/import_session_test.go
+++ b/internal/artifact/import_session_test.go
@@ -18,6 +18,8 @@ import (
 func TestRewriteManifestForImportClearsLocalStateAndPrefixesRelationships(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	filePath := "/provider/session.jsonl"
 	fileSize := int64(1024)
 	fileMtime := int64(42)
@@ -117,6 +119,8 @@ func TestRewriteManifestForImportClearsLocalStateAndPrefixesRelationships(
 }
 
 func TestLoadImportedSessionCompleteClosure(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	m := importTestManifest("session")
@@ -138,6 +142,8 @@ func TestLoadImportedSessionCompleteClosure(t *testing.T) {
 }
 
 func TestLoadImportedSessionDefersOversizedFutureSegment(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	var segment strings.Builder
@@ -169,6 +175,8 @@ func TestLoadImportedSessionDefersOversizedFutureSegment(t *testing.T) {
 }
 
 func TestLoadImportedSessionDefersMissingAndFutureDependencies(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		prepare    func(*testing.T, ArtifactStore) string
@@ -239,6 +247,8 @@ func TestLoadImportedSessionDefersMissingAndFutureDependencies(t *testing.T) {
 }
 
 func TestLoadImportedSessionQuarantinesInvalidStatDependency(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		kind Kind
@@ -284,6 +294,8 @@ func TestLoadImportedSessionQuarantinesInvalidStatDependency(t *testing.T) {
 func TestLoadImportedSessionQuarantinesPersistenceInvariantViolations(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		prepare func(*testing.T, ArtifactStore) (manifest, string)
@@ -367,6 +379,8 @@ func TestLoadImportedSessionQuarantinesPersistenceInvariantViolations(
 }
 
 func TestLoadImportedSessionQuarantinesInvalidCompleteDependency(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		prepare func(*testing.T, ArtifactStore) (string, Ref)
@@ -437,6 +451,8 @@ func TestLoadImportedSessionQuarantinesInvalidCompleteDependency(t *testing.T) {
 }
 
 func TestLoadImportedSessionAcceptsNoncanonicalManifestAndSegment(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	segment := []byte(
@@ -470,6 +486,8 @@ func TestLoadImportedSessionAcceptsNoncanonicalManifestAndSegment(t *testing.T) 
 }
 
 func TestLoadImportedSessionEnforcesAggregateLimits(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	store := newTestArtifactStore(t)
 	m := importTestManifest("session")
@@ -488,6 +506,8 @@ func TestLoadImportedSessionEnforcesAggregateLimits(t *testing.T) {
 }
 
 func TestLoadImportedSessionAggregateBoundaries(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		configure func(*artifactLimits)
@@ -590,6 +610,8 @@ func TestLoadImportedSessionAggregateBoundaries(t *testing.T) {
 }
 
 func TestLoadImportedSessionPropagatesOperationalStoreError(t *testing.T) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	base := newTestArtifactStore(t)
 	m := importTestManifest("session")

--- a/internal/artifact/import_test.go
+++ b/internal/artifact/import_test.go
@@ -16,6 +16,8 @@ import (
 const importLocalOrigin = "local-b2c3d4"
 
 func TestArtifactImportEndToEndAndReplay(t *testing.T) {
+	t.Parallel()
+
 	source := testExportDB(t)
 	seedSession(t, source, "one", "project")
 	seedSession(t, source, "two", "project")
@@ -97,6 +99,8 @@ func TestArtifactImportEndToEndAndReplay(t *testing.T) {
 }
 
 func TestStoreImportCoordinatorIgnoresLocalOrigin(t *testing.T) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	entry := createImportTestCheckpoint(
 		t, store, contractOrigin, 1, map[string]string{},
@@ -118,6 +122,8 @@ func TestStoreImportCoordinatorIgnoresLocalOrigin(t *testing.T) {
 func TestStoreImportCoordinatorRejectsOutOfRangeCheckpointWithoutAdvancingHead(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	destination := testDB(t)
 	coordinator := NewStoreImportCoordinator(
@@ -155,6 +161,8 @@ func TestStoreImportCoordinatorRejectsOutOfRangeCheckpointWithoutAdvancingHead(
 }
 
 func TestStoreImportCoordinatorRetriesMissingSegmentAfterArrival(t *testing.T) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	segmentBody, err := encodeSegment([]db.Message{{
 		Ordinal: 0, Role: "user", Content: "arrived",
@@ -205,6 +213,8 @@ func TestStoreImportCoordinatorRetriesMissingSegmentAfterArrival(t *testing.T) {
 }
 
 func TestStoreImportCoordinatorTracksIndependentFutureRequirements(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		prepare      func(*testing.T, ArtifactStore) string
@@ -287,6 +297,8 @@ func TestStoreImportCoordinatorTracksIndependentFutureRequirements(t *testing.T)
 func TestStoreImportCoordinatorDefersLargeFutureCheckpointBeforeValidClaim(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	const futureSessionCount = artifactImportDrainLimit*2 + 1
 	store := newTestArtifactStore(t)
 	futureSessions := make(map[string]string, futureSessionCount)
@@ -341,6 +353,8 @@ func TestStoreImportCoordinatorDefersLargeFutureCheckpointBeforeValidClaim(
 func TestStoreImportCoordinatorFinishesSupportedSessionsBeforeFutureGate(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	sessionMap := map[string]string{
 		contractOrigin + "~000-future": createHashedImportArtifact(
@@ -421,6 +435,8 @@ func TestStoreImportCoordinatorFinishesSupportedSessionsBeforeFutureGate(
 func TestStoreImportCoordinatorQuarantinesInvalidCheckpointAndContinues(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	invalidOrigin := "alpha-a1b2c3"
 	invalidRef := requireContractRef(
@@ -462,6 +478,8 @@ func TestStoreImportCoordinatorQuarantinesInvalidCheckpointAndContinues(
 func TestStoreImportCoordinatorRecoversCrashAfterCheckpointQuarantine(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	base := newTestArtifactStore(t)
 	invalidOrigin := "alpha-a1b2c3"
 	invalidRef := requireContractRef(
@@ -507,6 +525,8 @@ func TestStoreImportCoordinatorRecoversCrashAfterCheckpointQuarantine(
 func TestStoreImportCoordinatorDiscardsPartialStageAfterQuarantineCrash(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	base := newTestArtifactStore(t)
 	sessionMap := make(map[string]string, artifactImportDrainLimit+1)
 	for i := range artifactImportDrainLimit {
@@ -563,6 +583,8 @@ func TestStoreImportCoordinatorDiscardsPartialStageAfterQuarantineCrash(
 }
 
 func TestStoreImportCoordinatorRetainsClaimOnOperationalStoreError(t *testing.T) {
+	t.Parallel()
+
 	base := newTestArtifactStore(t)
 	checkpointEntry := createImportTestCheckpoint(
 		t, base, contractOrigin, 1, map[string]string{},
@@ -587,6 +609,8 @@ func TestStoreImportCoordinatorRetainsClaimOnOperationalStoreError(t *testing.T)
 }
 
 func TestStoreImportCoordinatorSuppressesExcludedAndTrashedSessions(t *testing.T) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	sessionMap := make(map[string]string)
 	for _, nativeID := range []string{"excluded", "trashed"} {
@@ -640,6 +664,8 @@ func TestStoreImportCoordinatorSuppressesExcludedAndTrashedSessions(t *testing.T
 }
 
 func TestStoreImportCoordinatorRetriesTrashedManifestAfterRestore(t *testing.T) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	gid := contractOrigin + "~session"
 	firstManifest := importTestManifest("session")
@@ -727,6 +753,8 @@ func TestStoreImportCoordinatorRetriesTrashedManifestAfterRestore(t *testing.T) 
 func TestStoreImportCoordinatorContinuesAfterConcurrentCheckpointSupersession(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	gid := contractOrigin + "~session"
 	firstManifest := importTestManifest("session")
@@ -788,6 +816,8 @@ func TestStoreImportCoordinatorContinuesAfterConcurrentCheckpointSupersession(
 }
 
 func TestStoreImportCoordinatorSuppressesLocalSessionIDCollision(t *testing.T) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	m := importTestManifest("session")
 	manifestHash := createImportTestClosure(t, store, &m, []db.Message{{
@@ -832,6 +862,8 @@ func TestStoreImportCoordinatorSuppressesLocalSessionIDCollision(t *testing.T) {
 func TestStoreImportCoordinatorKeepsCheckpointPendingAfterInvalidDependency(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	segment := []byte("{not-json}\n")
 	segmentHash := createHashedImportArtifact(
@@ -869,6 +901,8 @@ func TestStoreImportCoordinatorKeepsCheckpointPendingAfterInvalidDependency(
 func TestStoreImportCoordinatorDoesNotDeleteSessionOmittedByNewCheckpoint(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	m := importTestManifest("session")
 	manifestHash := createImportTestClosure(t, store, &m, []db.Message{{
@@ -906,6 +940,8 @@ func TestStoreImportCoordinatorDoesNotDeleteSessionOmittedByNewCheckpoint(
 }
 
 func TestStoreImportCoordinatorCrashWindowsConverge(t *testing.T) {
+	t.Parallel()
+
 	injected := errors.New("injected crash")
 	tests := []struct {
 		name      string
@@ -1033,6 +1069,8 @@ func TestStoreImportCoordinatorCrashWindowsConverge(t *testing.T) {
 }
 
 func TestStoreImportCoordinatorBoundsUnchangedCheckpointWork(t *testing.T) {
+	t.Parallel()
+
 	const unchangedSessions = 10_000
 	base := newTestArtifactStore(t)
 	m := importTestManifest("changed")
@@ -1115,6 +1153,8 @@ func TestStoreImportCoordinatorBoundsUnchangedCheckpointWork(t *testing.T) {
 func TestStoreImportCoordinatorPagesLargeChangedCheckpointAcrossDrains(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	const changedSessions = 300
 	base := newTestArtifactStore(t)
 	sessionMap := make(map[string]string, changedSessions)
@@ -1159,6 +1199,8 @@ func TestStoreImportCoordinatorPagesLargeChangedCheckpointAcrossDrains(
 func TestStoreImportCoordinatorPreservesSignalsDuringActiveAttempt(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	const sessionCount = 300
 	store := newTestArtifactStore(t)
 	segmentBody, err := encodeSegment([]db.Message{{
@@ -1226,6 +1268,8 @@ func TestStoreImportCoordinatorPreservesSignalsDuringActiveAttempt(
 func TestStoreImportCoordinatorPreservesSignalDuringCompletedPrune(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	store := newTestArtifactStore(t)
 	destination := testDB(t)
 	coordinator := NewStoreImportCoordinator(
@@ -1253,6 +1297,8 @@ func TestStoreImportCoordinatorPreservesSignalDuringCompletedPrune(
 }
 
 func TestStoreImportCoordinatorRereadsCheckpointOnceAfterRestart(t *testing.T) {
+	t.Parallel()
+
 	const changedSessions = 300
 	base := newTestArtifactStore(t)
 	sessionMap := make(map[string]string, changedSessions)
@@ -1291,6 +1337,8 @@ func TestStoreImportCoordinatorRereadsCheckpointOnceAfterRestart(t *testing.T) {
 }
 
 func TestStoreImportCoordinatorRecoversTerminalCheckpointPage(t *testing.T) {
+	t.Parallel()
+
 	root := t.TempDir()
 	databasePath := filepath.Join(root, "archive.db")
 	storeRoot := filepath.Join(root, "artifacts")
@@ -1367,6 +1415,8 @@ func TestStoreImportCoordinatorRecoversTerminalCheckpointPage(t *testing.T) {
 }
 
 func TestStoreImportCoordinatorDoesNotDoubleImportSignals(t *testing.T) {
+	t.Parallel()
+
 	base := newTestArtifactStore(t)
 	ordinal := 0
 	m := importTestManifest("session")

--- a/internal/artifact/manifest_session_test.go
+++ b/internal/artifact/manifest_session_test.go
@@ -23,6 +23,8 @@ import (
 // contract; otherwise leave the DTO alone and update populateWireFixture's
 // expectations here.
 func TestManifestSessionMatchesDBSessionWireFormat(t *testing.T) {
+	t.Parallel()
+
 	var sess db.Session
 	populateWireFixture(t, reflect.ValueOf(&sess).Elem(), 1)
 
@@ -52,6 +54,8 @@ func TestManifestSessionMatchesDBSessionWireFormat(t *testing.T) {
 }
 
 func TestManifestQualitySignalsMatchesDBWireFormat(t *testing.T) {
+	t.Parallel()
+
 	var qs db.QualitySignals
 	populateWireFixture(t, reflect.ValueOf(&qs).Elem(), 100)
 

--- a/internal/artifact/origin_test.go
+++ b/internal/artifact/origin_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestEnsureOriginPersists(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 
 	first, err := EnsureOrigin(database)
@@ -23,6 +25,8 @@ func TestEnsureOriginPersists(t *testing.T) {
 }
 
 func TestAdoptOriginPersistsConfigOrigin(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 
 	require.NoError(t, AdoptOrigin(database, "desk-a1b2c3"))
@@ -39,6 +43,8 @@ func TestAdoptOriginPersistsConfigOrigin(t *testing.T) {
 }
 
 func TestAdoptOriginIsIdempotent(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 
 	require.NoError(t, AdoptOrigin(database, "desk-a1b2c3"))
@@ -50,6 +56,8 @@ func TestAdoptOriginIsIdempotent(t *testing.T) {
 }
 
 func TestAdoptOriginOverwritesDivergentDBOrigin(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 
 	// Simulate the pre-fix state: the recorder generated a DB-only origin
@@ -66,6 +74,8 @@ func TestAdoptOriginOverwritesDivergentDBOrigin(t *testing.T) {
 }
 
 func TestAdoptOriginRepairsInvalidPersistedOrigin(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	require.NoError(t, database.SetSyncState(originStateKey, "../outside"))
 
@@ -77,6 +87,8 @@ func TestAdoptOriginRepairsInvalidPersistedOrigin(t *testing.T) {
 }
 
 func TestAdoptOriginRejectsInvalidOrigin(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 
 	err := AdoptOrigin(database, "../outside")
@@ -89,6 +101,8 @@ func TestAdoptOriginRejectsInvalidOrigin(t *testing.T) {
 }
 
 func TestEnsureOriginRejectsInvalidPersistedOrigin(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	require.NoError(t, database.SetSyncState(originStateKey, "../outside"))
 
@@ -104,6 +118,8 @@ func TestEnsureOriginRejectsInvalidPersistedOrigin(t *testing.T) {
 // to the origin-gated queue triggers and enqueue hooks, so EnsureOrigin must
 // bootstrap the queue immediately after it persists the origin key.
 func TestEnsureOriginBootstrapsPreExistingLocalSessions(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	seedSession(t, database, "sess-2", "alpha")
@@ -130,6 +146,8 @@ func TestEnsureOriginBootstrapsPreExistingLocalSessions(t *testing.T) {
 // empty, so every owned session must be force-requeued with a bumped
 // generation.
 func TestAdoptOriginRequeuesAllExportsOnDivergentAdoption(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	require.NoError(t, AdoptOrigin(database, "origin-a1b2c3"))
 	seedSession(t, database, "sess-1", "alpha")
@@ -164,6 +182,8 @@ func TestAdoptOriginRequeuesAllExportsOnDivergentAdoption(t *testing.T) {
 }
 
 func TestAdoptOriginRemovesPublicationsThatBecameDeletedWhileOriginWasInactive(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	store, err := newProtocolTestStore(t.TempDir())
 	require.NoError(t, err)
@@ -196,6 +216,8 @@ func TestAdoptOriginRemovesPublicationsThatBecameDeletedWhileOriginWasInactive(t
 }
 
 func TestOriginRejectionLifecycleRemovesRetriesAndRequeues(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	store, err := newProtocolTestStore(t.TempDir())
 	require.NoError(t, err)
@@ -268,6 +290,8 @@ func TestOriginRejectionLifecycleRemovesRetriesAndRequeues(t *testing.T) {
 // case for the AdoptOrigin path (used when a config-declared origin is
 // applied to a database that predates it).
 func TestAdoptOriginBootstrapsPreExistingLocalSessions(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 

--- a/internal/artifact/repository_test.go
+++ b/internal/artifact/repository_test.go
@@ -101,6 +101,7 @@ func TestOpenRepositoryFollowsFinalRootSymlink(t *testing.T) {
 }
 
 func TestOpenRepositoryRetainsAbsoluteCanonicalRoot(t *testing.T) {
+	// Serial: Chdir changes the process-wide working directory.
 	dataDir := t.TempDir()
 	// Chdir to the temp dir's parent so the relative path stays on one
 	// volume; on Windows CI the checkout and temp dirs are on different

--- a/internal/artifact/repository_test.go
+++ b/internal/artifact/repository_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestOpenRepositoryOwnsCompressedDocbankContent(t *testing.T) {
+	t.Parallel()
+
 	dataDir := t.TempDir()
 	repository, err := OpenRepository(t.Context(), dataDir)
 	require.NoError(t, err)
@@ -30,6 +32,8 @@ func TestOpenRepositoryOwnsCompressedDocbankContent(t *testing.T) {
 }
 
 func TestOpenRepositorySupportsDocbankSQLiteDrivers(t *testing.T) {
+	t.Parallel()
+
 	for _, driver := range []docsqlite.Driver{mattn.Driver{}, modernc.Driver{}} {
 		t.Run(driver.Name(), func(t *testing.T) {
 			repository, err := openRepository(t.Context(), t.TempDir(), driver)
@@ -42,6 +46,8 @@ func TestOpenRepositorySupportsDocbankSQLiteDrivers(t *testing.T) {
 }
 
 func TestOpenRepositoryRejectsLegacyLooseLayoutWithoutMutation(t *testing.T) {
+	t.Parallel()
+
 	dataDir := t.TempDir()
 	artifactDir := filepath.Join(dataDir, "artifacts")
 	legacy := filepath.Join(artifactDir, contractOrigin, string(KindCheckpoints), "cp-0000000001.json")
@@ -59,6 +65,8 @@ func TestOpenRepositoryRejectsLegacyLooseLayoutWithoutMutation(t *testing.T) {
 }
 
 func TestOpenRepositoryUsesDocbankHierarchyLock(t *testing.T) {
+	t.Parallel()
+
 	dataDir := t.TempDir()
 	repository, err := OpenRepository(t.Context(), dataDir)
 	require.NoError(t, err)
@@ -74,6 +82,8 @@ func TestOpenRepositoryUsesDocbankHierarchyLock(t *testing.T) {
 }
 
 func TestOpenRepositoryFollowsFinalRootSymlink(t *testing.T) {
+	t.Parallel()
+
 	realDataDir := t.TempDir()
 	realRoot := filepath.Join(realDataDir, "artifacts")
 	realRepository, err := openRepository(t.Context(), realDataDir, modernc.Driver{})
@@ -107,6 +117,8 @@ func TestOpenRepositoryRetainsAbsoluteCanonicalRoot(t *testing.T) {
 }
 
 func TestRepositoryCloseWaitsForReaderAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+
 	repository, err := OpenRepository(t.Context(), t.TempDir())
 	require.NoError(t, err)
 	ref := requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json")

--- a/internal/artifact/store_contract_test.go
+++ b/internal/artifact/store_contract_test.go
@@ -25,6 +25,8 @@ import (
 const contractOrigin = "contract-a1b2c3"
 
 func TestNewRefValidatesCanonicalReferences(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	tests := []struct {
 		name string
@@ -47,6 +49,8 @@ func TestNewRefValidatesCanonicalReferences(t *testing.T) {
 }
 
 func TestNewRefRejectsNoncanonicalReferences(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	tests := []struct {
 		name   string
@@ -72,6 +76,8 @@ func TestNewRefRejectsNoncanonicalReferences(t *testing.T) {
 }
 
 func TestNewIdentityValidatesCanonicalSHA256AndSize(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	identity, err := NewIdentity(hash, 0)
 	require.NoError(t, err)
@@ -96,6 +102,8 @@ func TestNewIdentityValidatesCanonicalSHA256AndSize(t *testing.T) {
 }
 
 func TestArtifactOpErrorPreservesCause(t *testing.T) {
+	t.Parallel()
+
 	ref := requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json")
 	err := &ArtifactOpError{Op: "open", Ref: ref, Err: context.Canceled}
 
@@ -111,6 +119,8 @@ func TestArtifactOpErrorPreservesCause(t *testing.T) {
 type artifactStoreFactory func(t *testing.T) ArtifactStore
 
 func TestArtifactStoreContractDocbank(t *testing.T) {
+	t.Parallel()
+
 	for _, driver := range []docsqlite.Driver{mattn.Driver{}, modernc.Driver{}} {
 		t.Run(driver.Name(), func(t *testing.T) {
 			runArtifactStoreContract(t, func(t *testing.T) ArtifactStore {
@@ -126,6 +136,8 @@ func TestArtifactStoreContractDocbank(t *testing.T) {
 }
 
 func TestArtifactStoreIteratorContractDocbank(t *testing.T) {
+	t.Parallel()
+
 	for _, driver := range []docsqlite.Driver{mattn.Driver{}, modernc.Driver{}} {
 		t.Run(driver.Name(), func(t *testing.T) {
 			store := newContractStore(t, func(t *testing.T) ArtifactStore {

--- a/internal/artifact/store_docbank_test.go
+++ b/internal/artifact/store_docbank_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestDocbankStoreUsesCanonicalNamespaceAndMovesQuarantineNode(t *testing.T) {
+	t.Parallel()
+
 	vault, store := newTestDocbankStore(t, docbank.Config{})
 	ref := requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000042.json")
 	body := []byte(`{"origin":"contract-a1b2c3","sequence":42}`)
@@ -50,6 +52,8 @@ func TestDocbankStoreUsesCanonicalNamespaceAndMovesQuarantineNode(t *testing.T) 
 }
 
 func TestDocbankStoreRejectsReferenceAndNodeIdentityMismatchBeforeRead(t *testing.T) {
+	t.Parallel()
+
 	vault, store := newTestDocbankStore(t, docbank.Config{})
 	body := []byte("catalog-authorized but incorrectly named content")
 	identity := identityForBytes(t, body)
@@ -70,6 +74,8 @@ func TestDocbankStoreRejectsReferenceAndNodeIdentityMismatchBeforeRead(t *testin
 }
 
 func TestDocbankStorePreservesTypedDocbankCauses(t *testing.T) {
+	t.Parallel()
+
 	_, store := newTestDocbankStore(t, docbank.Config{})
 	ref := requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json")
 
@@ -91,6 +97,8 @@ func TestDocbankStorePreservesTypedDocbankCauses(t *testing.T) {
 }
 
 func TestDocbankStoreClosedOperationsReturnErrClosed(t *testing.T) {
+	t.Parallel()
+
 	_, store := newTestDocbankStore(t, docbank.Config{})
 	ref := requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json")
 	body := []byte("closed store")
@@ -109,6 +117,8 @@ func TestDocbankStoreClosedOperationsReturnErrClosed(t *testing.T) {
 }
 
 func TestDocbankStoreIdempotentRetryDoesNotReportPhysicalWrite(t *testing.T) {
+	t.Parallel()
+
 	_, store := newTestDocbankStore(t, docbank.Config{})
 	ref := requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json")
 	body := []byte(`{"origin":"contract-a1b2c3","sequence":1}`)
@@ -127,6 +137,8 @@ func TestDocbankStoreIdempotentRetryDoesNotReportPhysicalWrite(t *testing.T) {
 }
 
 func TestDocbankStoreDistinctReferencesCountOnePhysicalWrite(t *testing.T) {
+	t.Parallel()
+
 	_, store := newTestDocbankStore(t, docbank.Config{})
 
 	body := []byte(`{"origin":"contract-a1b2c3","shared":"physical-content"}`)
@@ -140,6 +152,8 @@ func TestDocbankStoreDistinctReferencesCountOnePhysicalWrite(t *testing.T) {
 }
 
 func TestDocbankIteratorClosesWalkerExactlyOnce(t *testing.T) {
+	t.Parallel()
+
 	t.Run("explicit close", func(t *testing.T) {
 		walker := &docbankWalkerStub{}
 		iterator := &docbankOriginIterator{

--- a/internal/artifact/sync_test.go
+++ b/internal/artifact/sync_test.go
@@ -299,6 +299,8 @@ func TestArtifactSyncDoesNotPublishUnrecordedLocalOriginObjects(t *testing.T) {
 }
 
 func TestArtifactSyncValidatesBeforeCreatingOwnedStorage(t *testing.T) {
+	t.Parallel()
+
 	t.Run("missing target", func(t *testing.T) {
 		dataDir := t.TempDir()
 		_, err := Sync(
@@ -431,6 +433,8 @@ func (replacementQuarantineTransport) QuarantineTransportArtifact(
 }
 
 func TestDrainArtifactSyncExportsReturnsMoreAtRoundBudget(t *testing.T) {
+	t.Parallel()
+
 	database := testDB(t)
 	origin := "local-a1b2c3"
 	require.NoError(t, AdoptOrigin(database, origin))
@@ -458,6 +462,8 @@ func TestDrainArtifactSyncExportsReturnsMoreAtRoundBudget(t *testing.T) {
 func TestDrainArtifactSyncFullExportReturnsMoreWhenQueueDoesNotSettle(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	store := newTestArtifactStore(t)
@@ -489,6 +495,8 @@ func (f *repeatingImportFinalizer) Finalize(context.Context) (ImportResult, erro
 }
 
 func TestDrainArtifactSyncImportsReturnsMoreAtRoundBudget(t *testing.T) {
+	t.Parallel()
+
 	finalizer := &repeatingImportFinalizer{}
 	var result SyncResult
 

--- a/internal/artifact/transport_folder_test.go
+++ b/internal/artifact/transport_folder_test.go
@@ -855,6 +855,8 @@ func TestFolderTransportRejectsSymlinkedWireEntry(t *testing.T) {
 }
 
 func TestFolderTransportPullExchangeWorkStaysBounded(t *testing.T) {
+	t.Parallel()
+
 	target := t.TempDir()
 	opened, err := OpenFolderTransport(target, FolderTransportOptions{})
 	require.NoError(t, err)
@@ -889,6 +891,8 @@ func TestFolderTransportPullExchangeWorkStaysBounded(t *testing.T) {
 }
 
 func TestFolderTransportPullResumesWithinObjectBudget(t *testing.T) {
+	t.Parallel()
+
 	target := t.TempDir()
 	state := &testFolderTransportStateStore{}
 	transport, err := OpenFolderTransport(target, FolderTransportOptions{
@@ -1031,6 +1035,8 @@ func TestFolderTransportPushesWireObjectsBeforeCheckpointAndRetriesUnchanged(
 func TestFolderTransportDirectorySyncFailureStopsPublicationAuthority(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	body := []byte("directory-sync-segment")
 	ref := testContentRef(
 		t,
@@ -1160,6 +1166,8 @@ func TestFolderTransportDirectorySyncFailureStopsPublicationAuthority(
 }
 
 func TestFolderTransportRetrySyncsVisibleObjectBeforeJournal(t *testing.T) {
+	t.Parallel()
+
 	target := t.TempDir()
 	opened, err := OpenFolderTransport(target, FolderTransportOptions{})
 	require.NoError(t, err)
@@ -1227,6 +1235,8 @@ func TestFolderTransportRetrySyncsVisibleObjectBeforeJournal(t *testing.T) {
 }
 
 func TestFolderTransportDirectorySyncFailureStopsSubdirectoryUse(t *testing.T) {
+	t.Parallel()
+
 	target := t.TempDir()
 	opened, err := OpenFolderTransport(target, FolderTransportOptions{})
 	require.NoError(t, err)
@@ -1482,6 +1492,8 @@ func TestFolderTransportQuarantinePreservesDifferentReplacementIdentity(
 }
 
 func TestFolderTransportPushExchangeWorkStaysBounded(t *testing.T) {
+	t.Parallel()
+
 	target := t.TempDir()
 	opened, err := OpenFolderTransport(target, FolderTransportOptions{})
 	require.NoError(t, err)
@@ -1522,6 +1534,8 @@ func TestFolderTransportPushExchangeWorkStaysBounded(t *testing.T) {
 }
 
 func TestFolderTransportPushSharesLimitsAcrossKinds(t *testing.T) {
+	t.Parallel()
+
 	segmentBody := []byte("segment-fills-the-exchange-budget")
 	tests := []struct {
 		name       string
@@ -1579,6 +1593,8 @@ func TestFolderTransportPushSharesLimitsAcrossKinds(t *testing.T) {
 }
 
 func TestFolderTransportExchangeResumesWithinObjectBudget(t *testing.T) {
+	t.Parallel()
+
 	target := t.TempDir()
 	transport, err := OpenFolderTransport(target, FolderTransportOptions{
 		MaxObjects: 2,
@@ -1625,6 +1641,8 @@ func TestFolderTransportExchangeResumesWithinObjectBudget(t *testing.T) {
 }
 
 func TestFolderTransportExchangeCursorSurvivesReopen(t *testing.T) {
+	t.Parallel()
+
 	target := t.TempDir()
 	state := &testFolderTransportStateStore{}
 	store := newTestArtifactStore(t)
@@ -1658,6 +1676,8 @@ func TestFolderTransportExchangeCursorSurvivesReopen(t *testing.T) {
 }
 
 func TestFolderTransportRecoversJournalEventBeforeHeadAdvance(t *testing.T) {
+	t.Parallel()
+
 	target := t.TempDir()
 	transport, err := OpenFolderTransport(target, FolderTransportOptions{})
 	require.NoError(t, err)

--- a/internal/artifact/wire_codec_test.go
+++ b/internal/artifact/wire_codec_test.go
@@ -651,6 +651,7 @@ func TestWireCodecStreamsMultiMegabyteArtifactsWithBoundedBuffers(t *testing.T) 
 }
 
 func TestWireCodecAllocatedBytesStayBoundedAsArtifactsGrow(t *testing.T) {
+	// Serial: Benchmark reads process-global allocation statistics.
 	const (
 		smallSize = int64(32 << 10)
 		largeSize = int64(12 << 20)

--- a/internal/artifact/wire_codec_test.go
+++ b/internal/artifact/wire_codec_test.go
@@ -23,6 +23,8 @@ import (
 const wireCodecTestOrigin = "contract-a1b2c3"
 
 func TestWireRefMappings(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	tests := []struct {
 		name          string
@@ -84,6 +86,8 @@ func TestWireRefMappings(t *testing.T) {
 }
 
 func TestWireRefRejectsInvalidOrNonWireNames(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	tests := []struct {
 		name   string
@@ -110,6 +114,8 @@ func TestWireRefRejectsInvalidOrNonWireNames(t *testing.T) {
 }
 
 func TestWireCodecRoundTripsIdentityAndZstd(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	tests := []struct {
 		name string
@@ -176,6 +182,8 @@ func (r *failingWireReader) Read(p []byte) (int, error) {
 }
 
 func TestWireDecodePreservesSourceReadErrors(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	tests := []struct {
 		name string
@@ -216,6 +224,8 @@ func TestWireDecodePreservesSourceReadErrors(t *testing.T) {
 }
 
 func TestWireDecodeClassifiesCleanTruncationAsCorrupt(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	ref := Ref{Origin: wireCodecTestOrigin, Kind: KindManifests, Name: hash + ".json"}
 	wireRef, err := ToWireRef(ref)
@@ -234,6 +244,8 @@ func TestWireDecodeClassifiesCleanTruncationAsCorrupt(t *testing.T) {
 }
 
 func TestWireDecodePreservesDestinationWriteErrors(t *testing.T) {
+	t.Parallel()
+
 	hash := strings.Repeat("a", 64)
 	tests := []struct {
 		name string
@@ -270,6 +282,8 @@ func TestWireDecodePreservesDestinationWriteErrors(t *testing.T) {
 }
 
 func TestWireZstdEncodingIsDeterministic(t *testing.T) {
+	t.Parallel()
+
 	ref := Ref{
 		Origin: wireCodecTestOrigin,
 		Kind:   KindSegments,
@@ -285,6 +299,8 @@ func TestWireZstdEncodingIsDeterministic(t *testing.T) {
 }
 
 func TestWireDecodeEnforcesEncodedAndDecodedLimits(t *testing.T) {
+	t.Parallel()
+
 	rawRef := Ref{Origin: wireCodecTestOrigin, Kind: KindRaw, Name: strings.Repeat("a", 64)}
 	rawWire, err := ToWireRef(rawRef)
 	require.NoError(t, err)
@@ -334,6 +350,8 @@ func TestWireDecodeEnforcesEncodedAndDecodedLimits(t *testing.T) {
 }
 
 func TestWireDecodeRejectsLargeZstdWindow(t *testing.T) {
+	t.Parallel()
+
 	body := bytes.Repeat([]byte("windowed-record\n"), 700_000)
 	var encoded bytes.Buffer
 	enc, err := zstd.NewWriter(
@@ -361,6 +379,8 @@ func TestWireDecodeRejectsLargeZstdWindow(t *testing.T) {
 }
 
 func TestWireDecodeRejectsCorruptAndTruncatedZstd(t *testing.T) {
+	t.Parallel()
+
 	ref := Ref{
 		Origin: wireCodecTestOrigin,
 		Kind:   KindManifests,
@@ -392,6 +412,8 @@ func TestWireDecodeRejectsCorruptAndTruncatedZstd(t *testing.T) {
 }
 
 func TestWireDecodeRejectsNonPositiveLimits(t *testing.T) {
+	t.Parallel()
+
 	wireRef := requireWireRef(t, Ref{
 		Origin: wireCodecTestOrigin,
 		Kind:   KindRaw,
@@ -443,6 +465,8 @@ func TestWireDecodeRejectsNonPositiveLimits(t *testing.T) {
 }
 
 func TestWireCodecHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
 	ref := Ref{
 		Origin: wireCodecTestOrigin,
 		Kind:   KindSegments,
@@ -514,6 +538,8 @@ func TestWireCodecHonorsCancellation(t *testing.T) {
 }
 
 func TestWireCodecDetectsCancellationDuringFinalSuccessfulWrite(t *testing.T) {
+	t.Parallel()
+
 	body := []byte("one final successful destination write")
 	rawRef := Ref{
 		Origin: wireCodecTestOrigin,
@@ -586,6 +612,8 @@ func TestWireCodecDetectsCancellationDuringFinalSuccessfulWrite(t *testing.T) {
 }
 
 func TestWireCodecStreamsMultiMegabyteArtifactsWithBoundedBuffers(t *testing.T) {
+	t.Parallel()
+
 	const size = int64(6 << 20)
 	ref := Ref{
 		Origin: wireCodecTestOrigin,

--- a/internal/artifact/wire_test.go
+++ b/internal/artifact/wire_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestValidateRawSource(t *testing.T) {
+	t.Parallel()
+
 	validHash := strings.Repeat("ab", 32)
 	cases := []struct {
 		name    string


### PR DESCRIPTION
Runs 197 isolated `internal/artifact` top-level tests in parallel to shorten an
I/O-bound CI package. Five tests that change process-wide state or measure
process-wide allocations remain serial, and subtests are unchanged.

The change only affects test scheduling, not assertions or fixtures.
Parallelism uses more memory and can become slower at very high concurrency
because the fixtures compete for filesystem writes.
