### PR TITLE
test(artifact): serialize deadline-bound drain test

### DIFF
--- a/internal/artifact/sync_test.go
+++ b/internal/artifact/sync_test.go
@@ -462,7 +462,9 @@ func TestDrainArtifactSyncExportsReturnsMoreAtRoundBudget(t *testing.T) {
 func TestDrainArtifactSyncFullExportReturnsMoreWhenQueueDoesNotSettle(
 	t *testing.T,
 ) {
-	t.Parallel()
+	// Serial: this exercises the full drain cap through real SQLite and
+	// Docbank writes under a fixed deadline. Package-wide I/O contention can
+	// otherwise consume the deadline without the drain being stuck.
 
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")


### PR DESCRIPTION
The unsettled-queue full-export test has a 30-second context to catch real stalls, but it also performs repeated real SQLite and Docbank writes. Since the artifact suite was parallelized, shared-runner contention can consume that deadline even while export progresses, failing both plain and race jobs at different write sites.

Keep this single deadline-bound integration test in the serial phase. Its real-store coverage, behavioral assertions, and hang guard remain intact; other artifact tests remain parallel and production behavior is unchanged.