### PR TITLE
ci: path-filter docker.yml and ci-macos-main.yml push triggers

### DIFF
--- a/.github/workflows/ci-macos-main.yml
+++ b/.github/workflows/ci-macos-main.yml
@@ -6,6 +6,13 @@ on:
   # this exact workflow path only from refs/heads/main.
   push:
     branches: [main]
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'testdata/golden/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/ci-macos-main.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
     tags:
       - 'v*'
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'frontend/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-entrypoint.sh'
+      - '.github/workflows/docker.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Docs-only and other unrelated pushes to `main` no longer rebuild and publish the Docker image or occupy the self-hosted macOS runner. Each workflow now runs only when a changed file can affect its output.

## Design

- The Docker workflow watches the backend, frontend, Go module files, container inputs, and its own workflow file.
- The macOS workflow watches Go code, module files, the golden fixtures used by its tests, and its own workflow file. Frontend changes are intentionally excluded because this job does not build the frontend.
- Release tags still build the Docker image because GitHub does not apply path filters to tag pushes.
- Manual Docker builds remain available through `workflow_dispatch`.