### PR TITLE
Fix Kimi Work tool-step usage and K2.6 pricing

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -756,12 +756,19 @@ Grok section and remove the explicit registry exception in the coverage test.
   the desktop directory wrapper and auxiliary-session prefixes.
 - **Usage and cost:** The shared wire records expose input, output, cache-read,
   and cache-creation token counts. Kimi Work can report the internal model
-  aliases `daimon-kimi-code`, `daimon-kimi-messages`, and `k3-agent`; Agentsview
-  catalog-prices those tokens. The date-ambiguous `daimon-*` aliases resolve to
-  K2.6 before the 2026-07-19 UTC cutoff and K3 at or after it. When a transcript
-  omits model metadata, Agentsview uses the date-ambiguous `daimon-kimi-code`
-  alias so the same timestamp rule applies instead of assuming one model era. No
-  authoritative persisted USD cost is consumed.
+  aliases `daimon-kimi-code`, `daimon-kimi-messages`, `k2d6-agent`, and
+  `k3-agent`; Agentsview catalog-prices those tokens. The explicit
+  `k2d6-agent` alias resolves to K2.6. The date-ambiguous `daimon-*` aliases
+  resolve to K2.6 before the 2026-07-19 UTC cutoff and K3 at or after it. When a
+  transcript omits model metadata, Agentsview uses the date-ambiguous
+  `daimon-kimi-code` alias so the same timestamp rule applies instead of
+  assuming one model era. No authoritative persisted USD cost is consumed.
+- **Event ordering reverified 2026-08-03:** observed protocol-1.4 transcripts
+  can persist `tool.call`, then `tool.result`, then `step.end` for one model
+  step. The following `usage.record` repeats the same native usage values.
+  Agentsview keeps the assistant tool-call message as the pending usage target
+  across the user-role tool result, attaches the trailing `step.end` usage, and
+  treats `usage.record` only as a fallback so the step is counted once.
 - **Agentsview:** `internal/parser/kimi_work_provider.go` constrains discovery
   to user conversations, delegates wire decoding to `internal/parser/kimi.go`,
   and rewrites the provider identity and aggregate usage-event keys to

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -364,7 +364,11 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (79: Claude launch/prompt provenance. Re-parsing populates the new
 // sessions.session_kind and messages.prompt_source columns from top-level
 // sessionKind and promptSource fields on existing Claude rows.)
-const dataVersion = 79
+// (80: Kimi Code tool-step usage reparse. Protocol-1.4 transcripts can persist
+// tool.result before step.end, so existing Kimi and Kimi Work rows may omit
+// per-message usage for tool-calling steps. Re-parsing attaches the trailing
+// step usage to the assistant tool-call message.)
+const dataVersion = 80
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1008,9 +1008,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionClaudeLaunchProvenance(t *testing.T) {
-	assert.Equal(t, 79, CurrentDataVersion(),
-		"session_kind/prompt_source backfill requires a data version bump")
+func TestCurrentDataVersionKimiToolUsage(t *testing.T) {
+	assert.Equal(t, 80, CurrentDataVersion(),
+		"Kimi tool-step usage backfill requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -1447,8 +1447,8 @@ func clampedUsageTokenCountersWithReasoning(
 }
 
 // usageLookupModel returns the canonical model used to price a usage row.
-// Date-ambiguous Kimi aliases resolve according to the row timestamp; all
-// other model names pass through unchanged.
+// Kimi runtime aliases resolve to their fixed or timestamp-selected model;
+// all other model names pass through unchanged.
 func usageLookupModel(model, ts string) string {
 	if canonical := pricingpkg.CanonicalModelForTimestamp(model, ts); canonical != "" {
 		return canonical

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -4185,14 +4185,13 @@ func TestAICreditsFromCost(t *testing.T) {
 	}
 }
 
-// TestGetDailyUsage_KimiDateAliasPricing proves the date-based pricing
-// path end to end on SQLite: the date-ambiguous Kimi aliases
+// TestGetDailyUsage_KimiAliasPricing proves Kimi alias pricing end to end on
+// SQLite: the date-ambiguous aliases
 // (kimi-for-coding, daimon-kimi-code, daimon-kimi-messages) price each
 // row by its timestamp — K2.6 rates before the 2026-07-19T00:00:00Z
-// UTC cutoff, K3 rates at and after it — while the static k3/k3-agent
-// rows price flat at K3 regardless of date, including before the
-// cutoff (proving the static rows don't break date-based precedence).
-func TestGetDailyUsage_KimiDateAliasPricing(t *testing.T) {
+// UTC cutoff and K3 rates at and after it. The explicit k2d6-agent alias stays
+// on K2.6, while static k3/k3-agent rows price flat at K3.
+func TestGetDailyUsage_KimiAliasPricing(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
 
@@ -4294,6 +4293,13 @@ func TestGetDailyUsage_KimiDateAliasPricing(t *testing.T) {
 			name:           "provider-prefixed alias before cutoff",
 			model:          "kimi-code/kimi-for-coding",
 			ts:             "2026-07-18T12:00:00Z",
+			wantCost:       k26Cost,
+			wantPriceModel: "moonshot/kimi-k2.6",
+		},
+		{
+			name:           "explicit k2d6-agent stays K2.6 after cutoff",
+			model:          "k2d6-agent",
+			ts:             "2026-07-20T12:00:00Z",
 			wantCost:       k26Cost,
 			wantPriceModel: "moonshot/kimi-k2.6",
 		},

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3460,9 +3460,14 @@ func duckDailyUsageCTE(f db.UsageFilter) (string, []any) {
 	return duckUsageCTEFromRaw(f, rawSQL, args)
 }
 
-// duckPriceModelCaseSQL renders the timestamp-aware Kimi canonicalization as
-// SQL so each usage row carries the model whose rates apply to that instant.
+// duckPriceModelCaseSQL renders Kimi alias canonicalization as SQL so each
+// usage row carries the fixed or timestamp-selected model whose rates apply.
 func duckPriceModelCaseSQL() string {
+	fixedK26Aliases := pricingpkg.KimiK26Aliases()
+	fixedK26Quoted := make([]string, len(fixedK26Aliases))
+	for i, alias := range fixedK26Aliases {
+		fixedK26Quoted[i] = "'" + alias + "'"
+	}
 	aliases := pricingpkg.DateAliasedModels()
 	quoted := make([]string, len(aliases))
 	for i, alias := range aliases {
@@ -3471,14 +3476,16 @@ func duckPriceModelCaseSQL() string {
 	cutoff := pricingpkg.KimiModelEraCutoff.UTC().Format("2006-01-02 15:04:05")
 	return fmt.Sprintf(`CASE
 		WHEN regexp_replace(model, '^.*/', '') IN (%[1]s)
-			AND (ts IS NULL OR ts >= TIMESTAMP '%[2]s')
-			THEN '%[3]s'
-		WHEN regexp_replace(model, '^.*/', '') IN (%[1]s)
-			THEN '%[4]s'
+			THEN '%[2]s'
+		WHEN regexp_replace(model, '^.*/', '') IN (%[3]s)
+			AND (ts IS NULL OR ts >= TIMESTAMP '%[4]s')
+			THEN '%[5]s'
+		WHEN regexp_replace(model, '^.*/', '') IN (%[3]s)
+			THEN '%[2]s'
 		ELSE model
 	END`,
-		strings.Join(quoted, ", "), cutoff,
-		pricingpkg.KimiK3Canonical, pricingpkg.KimiK26Canonical,
+		strings.Join(fixedK26Quoted, ", "), pricingpkg.KimiK26Canonical,
+		strings.Join(quoted, ", "), cutoff, pricingpkg.KimiK3Canonical,
 	)
 }
 

--- a/internal/duckdb/usage_pricing_test.go
+++ b/internal/duckdb/usage_pricing_test.go
@@ -127,6 +127,55 @@ func TestDailyUsageKimiDateAliasPricing(t *testing.T) {
 	assert.NotContains(t, got.Pricing.Models, "kimi-k3")
 }
 
+func TestDailyUsageKimiFixedK26AliasPricing(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern: "moonshot/kimi-k2.6",
+		InputPerMTok: money.MustParseDollars("0.95"),
+	}}), "UpsertModelPricing")
+
+	session := syncSession(
+		"duck-kimi-k2d6", "alpha", "fixed K2.6 alias",
+		"2026-07-20T12:00:00.000Z", 1)
+	session.Agent = "kimi-work"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: session,
+		Messages: []db.Message{{
+			SessionID: "duck-kimi-k2d6",
+			Ordinal:   0,
+			Role:      "assistant",
+			Timestamp: "2026-07-20T12:00:00.000Z",
+			Model:     "k2d6-agent",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":1000000,"output_tokens":0}`),
+		}},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, createSchema(ctx, syncer.DB()))
+	_, err = syncer.pushEverything(ctx, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	got, err := store.GetDailyUsage(ctx, db.UsageFilter{
+		From:     "2026-07-20",
+		To:       "2026-07-20",
+		Timezone: "UTC",
+		Model:    "k2d6-agent",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, money.MustParseDollars("0.95"), got.Totals.TotalCost)
+	require.NotNil(t, got.Pricing)
+	resolutions := got.Pricing.Models["k2d6-agent"].Resolutions
+	require.Len(t, resolutions, 1)
+	assert.Equal(t, "moonshot/kimi-k2.6", resolutions[0].PricedModel)
+}
+
 // TestSessionUsageKimiDateAliasPricing proves the per-row session
 // usage path (breakdown rows) applies the same date-based mapping as
 // the aggregate path.

--- a/internal/parser/kimi.go
+++ b/internal/parser/kimi.go
@@ -178,8 +178,10 @@ func parseKimiSessionWithFallbackModel(
 		pendingHasContextTokens bool
 		pendingHasOutputTokens  bool
 		pendingStopReason       string
-		hasThinking             bool
-		hasToolUse              bool
+		// Kimi Work can write tool.result before the step's trailing usage.
+		pendingUsageMessageIndex = -1
+		hasThinking              bool
+		hasToolUse               bool
 
 		// Track token usage from StatusUpdate.
 		totalOutputTokens    int
@@ -211,12 +213,12 @@ func parseKimiSessionWithFallbackModel(
 		hasToolUse = false
 	}
 
-	flushAssistantTurn := func() {
+	flushAssistantTurn := func() int {
 		content := strings.Join(pendingText, "\n")
 		if strings.TrimSpace(content) == "" &&
 			len(pendingToolCall) == 0 {
 			resetAssistantTurn()
-			return
+			return -1
 		}
 
 		// Kimi wire logs often omit the model; fall back to the current
@@ -226,6 +228,7 @@ func parseKimiSessionWithFallbackModel(
 			turnModel = currentModel
 		}
 
+		messageIndex := len(messages)
 		messages = append(messages, ParsedMessage{
 			Ordinal:          ordinal,
 			Role:             RoleAssistant,
@@ -246,6 +249,30 @@ func parseKimiSessionWithFallbackModel(
 		})
 		ordinal++
 		resetAssistantTurn()
+		return messageIndex
+	}
+
+	hasPendingAssistantTurn := func() bool {
+		return strings.TrimSpace(strings.Join(pendingText, "\n")) != "" ||
+			len(pendingToolCall) > 0
+	}
+
+	attachPendingTurn := func(message *ParsedMessage) {
+		if pendingModel != "" {
+			message.Model = pendingModel
+		} else if message.Model == "" {
+			message.Model = currentModel
+		}
+		if len(message.TokenUsage) == 0 && len(pendingTokenUsage) > 0 {
+			message.TokenUsage = pendingTokenUsage
+			message.OutputTokens = pendingOutputTokens
+			message.ContextTokens = pendingContextTokens
+			message.HasOutputTokens = pendingHasOutputTokens
+			message.HasContextTokens = pendingHasContextTokens
+		}
+		if pendingStopReason != "" {
+			message.StopReason = pendingStopReason
+		}
 	}
 
 	for {
@@ -287,6 +314,7 @@ func parseKimiSessionWithFallbackModel(
 
 			case "turn.prompt", "turn.steer":
 				flushAssistantTurn()
+				pendingUsageMessageIndex = -1
 
 				userText := kimiContentPartsText(root.Get("input"))
 				if userText == "" {
@@ -367,7 +395,9 @@ func parseKimiSessionWithFallbackModel(
 						formatKimiToolUse(fnName, argsResult))
 
 				case "tool.result":
-					flushAssistantTurn()
+					if index := flushAssistantTurn(); index >= 0 {
+						pendingUsageMessageIndex = index
+					}
 
 					toolCallID := event.Get("toolCallId").Str
 					result := event.Get("result")
@@ -424,10 +454,23 @@ func parseKimiSessionWithFallbackModel(
 							}
 						}
 					}
-					flushAssistantTurn()
+					if !hasPendingAssistantTurn() &&
+						pendingUsageMessageIndex >= 0 &&
+						pendingUsageMessageIndex < len(messages) {
+						target := &messages[pendingUsageMessageIndex]
+						attachPendingTurn(target)
+						hasAttachedUsage := len(target.TokenUsage) > 0
+						resetAssistantTurn()
+						if hasAttachedUsage {
+							pendingUsageMessageIndex = -1
+						}
+					} else {
+						flushAssistantTurn()
+						pendingUsageMessageIndex = -1
+					}
 
 				case "step.begin":
-					// Informational; no action needed.
+					pendingUsageMessageIndex = -1
 				}
 
 			case "usage.record":
@@ -436,18 +479,28 @@ func parseKimiSessionWithFallbackModel(
 				}
 				if usage := root.Get("usage"); usage.Exists() &&
 					len(messages) > 0 {
+					var target *ParsedMessage
 					last := &messages[len(messages)-1]
-					if last.Role == RoleAssistant &&
-						len(last.TokenUsage) == 0 {
+					if last.Role == RoleAssistant && len(last.TokenUsage) == 0 {
+						target = last
+					} else if pendingUsageMessageIndex >= 0 &&
+						pendingUsageMessageIndex < len(messages) {
+						candidate := &messages[pendingUsageMessageIndex]
+						if candidate.Role == RoleAssistant &&
+							len(candidate.TokenUsage) == 0 {
+							target = candidate
+						}
+					}
+					if target != nil {
 						tokenUsage, outputTokens, contextTokens,
 							hasOutput, hasContext :=
 							kimiNativeTokenUsage(usage)
-						last.Model = currentModel
-						last.TokenUsage = tokenUsage
-						last.OutputTokens = outputTokens
-						last.ContextTokens = contextTokens
-						last.HasOutputTokens = hasOutput
-						last.HasContextTokens = hasContext
+						target.Model = currentModel
+						target.TokenUsage = tokenUsage
+						target.OutputTokens = outputTokens
+						target.ContextTokens = contextTokens
+						target.HasOutputTokens = hasOutput
+						target.HasContextTokens = hasContext
 						if hasOutput {
 							hasTotalOutputTokens = true
 							totalOutputTokens += outputTokens
@@ -457,6 +510,9 @@ func parseKimiSessionWithFallbackModel(
 							if contextTokens > peakContextTokens {
 								peakContextTokens = contextTokens
 							}
+						}
+						if len(tokenUsage) > 0 {
+							pendingUsageMessageIndex = -1
 						}
 					}
 				}

--- a/internal/parser/kimi_test.go
+++ b/internal/parser/kimi_test.go
@@ -766,6 +766,81 @@ func TestParseKimiSession_NativeKimiCodeToolCall(t *testing.T) {
 	assert.Equal(t, 75, msgs[3].ContextTokens)
 }
 
+func TestParseKimiSession_NativeKimiCodeToolResultsBeforeStepEnd(
+	t *testing.T,
+) {
+	path := writeKimiCodeWireJSONL(t,
+		"wd_myproject_a1b2c3d4", "session_uuid-late-usage", "main",
+		[]string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1785720000000}`,
+			`{"type":"config.update","modelAlias":"k3-agent","time":1785720000001}`,
+			`{"type":"turn.prompt","input":[{"type":"text","text":"Run tools"}],"time":1785720000002}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-1"},"time":1785720000003}`,
+			`{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"tool-1","name":"Shell","args":{"command":"first"}},"time":1785720000004}`,
+			`{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"tool-2","name":"Shell","args":{"command":"second"}},"time":1785720000005}`,
+			`{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"tool-1","result":{"output":"one","isError":false}},"time":1785720000006}`,
+			`{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"tool-2","result":{"output":"two","isError":false}},"time":1785720000007}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-1","finishReason":"tool_use","usage":{"inputOther":100,"output":20,"inputCacheRead":300,"inputCacheCreation":4}},"time":1785720000008}`,
+			`{"type":"usage.record","model":"k3-agent","usage":{"inputOther":100,"output":20,"inputCacheRead":300,"inputCacheCreation":4},"usageScope":"turn","time":1785720000008}`,
+		},
+	)
+
+	sess, msgs, err := parseKimiSessionForTest(t, path, "myproject", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 4)
+
+	toolStep := msgs[1]
+	require.Equal(t, RoleAssistant, toolStep.Role)
+	require.Len(t, toolStep.ToolCalls, 2)
+	assert.Equal(t, "k3-agent", toolStep.Model)
+	assert.Equal(t, "tool_use", toolStep.StopReason)
+	assert.True(t, toolStep.HasOutputTokens)
+	assert.True(t, toolStep.HasContextTokens)
+	assert.Equal(t, 20, toolStep.OutputTokens)
+	assert.Equal(t, 404, toolStep.ContextTokens)
+	assert.JSONEq(t,
+		`{"input_tokens":100,"output_tokens":20,"cache_read_input_tokens":300,"cache_creation_input_tokens":4}`,
+		string(toolStep.TokenUsage))
+	assert.Equal(t, 20, sess.TotalOutputTokens)
+	assert.Equal(t, 404, sess.PeakContextTokens)
+	assert.Empty(t, sess.UsageEvents,
+		"the following usage.record must not double-count step.end usage")
+}
+
+func TestParseKimiSession_NativeKimiCodeUsageRecordAfterToolResult(
+	t *testing.T,
+) {
+	path := writeKimiCodeWireJSONL(t,
+		"wd_myproject_a1b2c3d4", "session_uuid-usage-fallback", "main",
+		[]string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1785720000000}`,
+			`{"type":"turn.prompt","input":[{"type":"text","text":"Run a tool"}],"time":1785720000001}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-1"},"time":1785720000002}`,
+			`{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"tool-1","name":"Shell","args":{}},"time":1785720000003}`,
+			`{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"tool-1","result":{"output":"ok","isError":false}},"time":1785720000004}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-1","finishReason":"tool_use"},"time":1785720000005}`,
+			`{"type":"usage.record","model":"k3-agent","usage":{"inputOther":10,"output":11,"inputCacheRead":12,"inputCacheCreation":13},"usageScope":"turn","time":1785720000005}`,
+		},
+	)
+
+	sess, msgs, err := parseKimiSessionForTest(t, path, "myproject", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 3)
+
+	toolStep := msgs[1]
+	assert.Equal(t, "k3-agent", toolStep.Model)
+	assert.Equal(t, "tool_use", toolStep.StopReason)
+	assert.Equal(t, 11, toolStep.OutputTokens)
+	assert.Equal(t, 35, toolStep.ContextTokens)
+	assert.JSONEq(t,
+		`{"input_tokens":10,"output_tokens":11,"cache_read_input_tokens":12,"cache_creation_input_tokens":13}`,
+		string(toolStep.TokenUsage))
+	assert.Equal(t, 11, sess.TotalOutputTokens)
+	assert.Equal(t, 35, sess.PeakContextTokens)
+}
+
 func TestParseKimiSession_NewLayout_AgentZero(t *testing.T) {
 	path := writeKimiCodeWireJSONL(t,
 		"wd_myproject_a1b2c3d4", "session_uuid-5678", "agent-0",

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -937,8 +937,8 @@ func pgFloorNegativeTokens(v int) int {
 	return v
 }
 
-// pgUsageLookupModel mirrors internal/db usage pricing: date-ambiguous Kimi
-// aliases resolve according to the usage row timestamp.
+// pgUsageLookupModel mirrors internal/db usage pricing: Kimi runtime aliases
+// resolve to their fixed or timestamp-selected canonical model.
 func pgUsageLookupModel(model string, ts sql.NullTime) string {
 	var timestamp time.Time
 	if ts.Valid {

--- a/internal/pricing/supplemental.go
+++ b/internal/pricing/supplemental.go
@@ -49,6 +49,12 @@ var kimiAmbiguousDateAliases = []string{
 	"kimi-for-coding",
 }
 
+// kimiK26Aliases are explicit K2.6 model names reported by Kimi runtimes.
+// Unlike the aliases above, these never cross the K2.6/K3 date boundary.
+var kimiK26Aliases = []string{
+	"k2d6-agent",
+}
+
 // DateAliasedModels returns the sorted unqualified date-ambiguous
 // alias names, copied for caller safety. Used by the pricing seed
 // (deleting stale flat rows) and by SQL backends that must compute the
@@ -57,26 +63,40 @@ func DateAliasedModels() []string {
 	return slices.Clone(kimiAmbiguousDateAliases)
 }
 
+// KimiK26Aliases returns the sorted unqualified aliases that always resolve
+// to the canonical K2.6 pricing model.
+func KimiK26Aliases() []string {
+	return slices.Clone(kimiK26Aliases)
+}
+
 // isDateAliasedModel reports whether model is one of the
 // date-ambiguous aliases. A provider prefix is ignored
 // ("kimi-code/kimi-for-coding" is the same alias), matching how
 // ResolveMatch strips provider prefixes in its canonical fallback.
 func isDateAliasedModel(model string) bool {
-	name := model
-	if idx := strings.LastIndex(name, "/"); idx != -1 {
-		name = name[idx+1:]
-	}
-	return slices.Contains(kimiAmbiguousDateAliases, name)
+	return slices.Contains(kimiAmbiguousDateAliases, kimiAliasName(model))
 }
 
-// CanonicalModelForDate maps a date-ambiguous alias to the canonical
-// pricing model for timestamp t: KimiK26Canonical before
-// KimiModelEraCutoff, KimiK3Canonical at or after it. It returns ""
-// for any other model. A zero time (missing or unparseable row
-// timestamp) falls back to the post-cutoff K3 model so aggregated
-// paths without a usable timestamp price at current rates rather than
-// silently using the retired K2.6 era.
+func isKimiK26Alias(model string) bool {
+	return slices.Contains(kimiK26Aliases, kimiAliasName(model))
+}
+
+func kimiAliasName(model string) string {
+	if idx := strings.LastIndex(model, "/"); idx != -1 {
+		return model[idx+1:]
+	}
+	return model
+}
+
+// CanonicalModelForDate maps a Kimi runtime alias to its canonical pricing
+// model. Explicit K2.6 aliases always map to KimiK26Canonical. Date-ambiguous
+// aliases map to KimiK26Canonical before KimiModelEraCutoff and KimiK3Canonical
+// at or after it. It returns "" for any other model. A zero time falls back to
+// the post-cutoff K3 model only for date-ambiguous aliases.
 func CanonicalModelForDate(model string, t time.Time) string {
+	if isKimiK26Alias(model) {
+		return KimiK26Canonical
+	}
 	if !isDateAliasedModel(model) {
 		return ""
 	}
@@ -86,11 +106,14 @@ func CanonicalModelForDate(model string, t time.Time) string {
 	return KimiK26Canonical
 }
 
-// CanonicalModelForTimestamp is CanonicalModelForDate for rows whose
-// timestamp is stored as an RFC3339/RFC3339Nano string. An empty or
-// unparseable timestamp falls back to the post-cutoff K3 model, same
-// as a zero time.
+// CanonicalModelForTimestamp is CanonicalModelForDate for rows whose timestamp
+// is stored as RFC3339/RFC3339Nano. Fixed aliases do not require a timestamp;
+// an empty or unparseable timestamp falls back to K3 only for date-ambiguous
+// aliases.
 func CanonicalModelForTimestamp(model, ts string) string {
+	if isKimiK26Alias(model) {
+		return KimiK26Canonical
+	}
 	if !isDateAliasedModel(model) {
 		return ""
 	}

--- a/internal/pricing/supplemental_test.go
+++ b/internal/pricing/supplemental_test.go
@@ -59,6 +59,10 @@ func TestDateAliasedModels(t *testing.T) {
 	}, DateAliasedModels())
 }
 
+func TestKimiK26Aliases(t *testing.T) {
+	assert.Equal(t, []string{"k2d6-agent"}, KimiK26Aliases())
+}
+
 func TestCanonicalModelForDate(t *testing.T) {
 	pre := time.Date(2026, 7, 18, 23, 59, 59, 0, time.UTC)
 	at := time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC)
@@ -84,6 +88,9 @@ func TestCanonicalModelForDate(t *testing.T) {
 		{"daimon-kimi-messages after cutoff", "daimon-kimi-messages", post, KimiK3Canonical},
 		{"provider-prefixed alias before cutoff", "kimi-code/kimi-for-coding", pre, KimiK26Canonical},
 		{"provider-prefixed alias after cutoff", "kimi-code/kimi-for-coding", post, KimiK3Canonical},
+		{"explicit K2.6 agent alias before cutoff", "k2d6-agent", pre, KimiK26Canonical},
+		{"explicit K2.6 agent alias after cutoff", "k2d6-agent", post, KimiK26Canonical},
+		{"provider-prefixed explicit K2.6 alias", "daimon/k2d6-agent", post, KimiK26Canonical},
 		{"flat k3 alias is not date-ambiguous", "k3", pre, ""},
 		{"flat k3-agent alias is not date-ambiguous", "k3-agent", pre, ""},
 		{"canonical k2.6 model passes through", KimiK26Canonical, pre, ""},
@@ -112,6 +119,7 @@ func TestCanonicalModelForTimestamp(t *testing.T) {
 		{"offset timestamp at cutoff instant", "kimi-for-coding", "2026-07-18T20:00:00-04:00", KimiK3Canonical},
 		{"empty timestamp falls back to K3", "kimi-for-coding", "", KimiK3Canonical},
 		{"garbage timestamp falls back to K3", "kimi-for-coding", "not-a-time", KimiK3Canonical},
+		{"explicit K2.6 alias ignores timestamp", "k2d6-agent", "not-a-time", KimiK26Canonical},
 		{"non-alias passes through", "k3", "2026-07-18T12:00:00Z", ""},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #1337.

Kimi Code protocol 1.4 tool steps can persist tool results before the trailing step-end usage record. Preserve the flushed assistant tool-call message as the usage target so step-end or usage.record fallback populates token data exactly once.

Also canonicalize Kimi Work's explicit k2d6-agent model alias to the existing K2.6 pricing row across SQLite, PostgreSQL, and DuckDB, and bump the parser data version so existing sessions are repaired on resync.

Review focus: the post-tool-result state transition in internal/parser/kimi.go and DuckDB SQL parity for fixed aliases.