### PR TITLE
docs: prepare the 0.40.1 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ description: Release history for AgentsView
 
 ## 0.40.1
 
-<small>2026-08-03</small>
+<small>2026-08-04</small>
 
 **Bug fixes**
 
@@ -17,8 +17,9 @@ description: Release history for AgentsView
   the step's trailing usage record, and price the explicit `k2d6-agent` model
   alias at K2.6 rates across SQLite, PostgreSQL, and DuckDB. Existing affected
   sessions are repaired on resync.
-- Keep PostgreSQL serve startup audits compatible with valid multibyte text in
-  compressed rows on affected PostgreSQL minor releases.
+- Prevent `agentsview pg serve` from failing its startup automation audit with
+  an invalid UTF-8 error when affected PostgreSQL minor releases slice
+  compressed multibyte session text.
 
 **Acknowledgements**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,10 +5,27 @@ description: Release history for AgentsView
 
 ## Unreleased
 
+---
+
+## 0.40.1
+
+<small>2026-08-03</small>
+
 **Bug fixes**
 
+- Preserve Kimi Work token usage when protocol 1.4 writes a tool result before
+  the step's trailing usage record, and price the explicit `k2d6-agent` model
+  alias at K2.6 rates across SQLite, PostgreSQL, and DuckDB. Existing affected
+  sessions are repaired on resync.
 - Keep PostgreSQL serve startup audits compatible with valid multibyte text in
   compressed rows on affected PostgreSQL minor releases.
+
+**Acknowledgements**
+
+- Thanks to [Cafeynman](https://github.com/Cafeynman) for preserving Kimi Work
+  tool-step usage and correcting K2.6 alias pricing.
+- Thanks to [Wes McKinney](https://github.com/wesm) for PostgreSQL startup
+  compatibility and release documentation.
 
 ---
 


### PR DESCRIPTION
v0.40.1 needs a narrow release boundary for two correctness fixes that landed after v0.40.0. Kimi Work protocol 1.4 can persist tool results before trailing usage, which previously left affected tool turns without usage and could price explicit `k2d6-agent` reports incorrectly. PostgreSQL servers on affected minor releases could also fail their startup audit when compressed multibyte text was sliced by the database.

This promotes those fixes from Unreleased into dated 0.40.1 notes and credits their contributors. Internal CI path filters and documentation-only changes since v0.40.0 are intentionally absent from the user-facing notes. AgentsView derives its version from the Git tag, so no checked-in binary version changes in this PR; after merge, `v0.40.1` should be tagged from `main`.