### PR TITLE
feat(usage): add JSON output to usage statusline

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -550,9 +550,11 @@ func newUsageStatuslineCommand() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			cfg.JSON = outputFormat(cmd) == "json"
 			runUsageStatusline(cfg)
 		},
 	}
+	registerFormatFlags(cmd.Flags())
 	cmd.Flags().StringVar(&cfg.Agent, "agent", "", "Filter by agent name")
 	cmd.Flags().BoolVar(&cfg.Offline, "offline", false, "Use fallback pricing only")
 	cmd.Flags().BoolVar(&cfg.NoSync, "no-sync", false, "Skip on-demand sync before querying")

--- a/cmd/agentsview/output_format_test.go
+++ b/cmd/agentsview/output_format_test.go
@@ -50,6 +50,7 @@ var machineOutputCommandPaths = [][]string{
 	{"projects"},
 	{"health"},
 	{"usage", "daily"},
+	{"usage", "statusline"},
 	{"activity", "report"},
 	{"stats"},
 	{"secrets", "list"},

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -219,9 +219,21 @@ func noTokenDataNote(agent string, totals db.UsageTotals) string {
 }
 
 type UsageStatuslineConfig struct {
+	JSON    bool
 	Agent   string
 	Offline bool
 	NoSync  bool
+}
+
+// usageStatuslineReport is the machine-readable form of the statusline. It
+// carries the same facts as the human line and nothing more: today's cost,
+// the day it covers, and the agent filter that produced it. Cost stays a
+// money.Money so callers read exact microdollars instead of scraping the
+// formatted string.
+type usageStatuslineReport struct {
+	Date  string      `json:"date"`
+	Cost  money.Money `json:"cost"`
+	Agent string      `json:"agent,omitempty"`
 }
 
 func runUsageStatusline(cfg UsageStatuslineConfig) {
@@ -256,7 +268,28 @@ func runUsageStatusline(cfg UsageStatuslineConfig) {
 		os.Exit(1)
 	}
 
+	if cfg.JSON {
+		printUsageStatuslineJSON(result, cfg.Agent, today)
+		return
+	}
+
 	printUsageStatusline(result, cfg.Agent)
+}
+
+func printUsageStatuslineJSON(
+	result db.DailyUsageResult, agent, date string,
+) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	report := usageStatuslineReport{
+		Date:  date,
+		Cost:  result.Totals.TotalCost,
+		Agent: agent,
+	}
+	if err := enc.Encode(report); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func printUsageStatusline(result db.DailyUsageResult, agent string) {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -64,6 +64,76 @@ func TestFmtCost(t *testing.T) {
 	}
 }
 
+func TestPrintUsageStatuslineJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent string
+		cost  string
+		want  usageStatuslineReport
+	}{
+		{
+			name: "no agent filter omits the agent field",
+			cost: "9.61",
+			want: usageStatuslineReport{
+				Date: "2026-08-04",
+				Cost: money.Money{Microdollars: 9_610_000},
+			},
+		},
+		{
+			name:  "agent filter is reported",
+			agent: "claude",
+			cost:  "6.42",
+			want: usageStatuslineReport{
+				Date:  "2026-08-04",
+				Cost:  money.Money{Microdollars: 6_420_000},
+				Agent: "claude",
+			},
+		},
+		{
+			name: "an empty day still reports a zero cost",
+			cost: "0",
+			want: usageStatuslineReport{
+				Date: "2026-08-04",
+				Cost: money.Money{},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := db.DailyUsageResult{
+				Totals: db.UsageTotals{
+					TotalCost: money.MustParseDollars(tc.cost),
+				},
+			}
+			out := captureStdout(t, func() {
+				printUsageStatuslineJSON(result, tc.agent, "2026-08-04")
+			})
+
+			var got usageStatuslineReport
+			require.NoError(t, json.Unmarshal([]byte(out), &got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The documented budget check reads .cost.microdollars, so the cost has to
+// stay an exact integer: a formatted or rounded value would make a threshold
+// comparison silently wrong.
+func TestPrintUsageStatuslineJSONKeepsExactMicrodollars(t *testing.T) {
+	result := db.DailyUsageResult{
+		Totals: db.UsageTotals{
+			TotalCost: money.Money{Microdollars: 25_000_001},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		printUsageStatuslineJSON(result, "", "2026-08-04")
+	})
+
+	assert.Contains(t, out, `"microdollars": 25000001`)
+	assert.NotContains(t, out, "25.000001")
+}
+
 func TestUsageDailyGolden(t *testing.T) {
 	setupExportGoldenDataDir(t)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -413,6 +413,8 @@ agentsview usage statusline [flags]
 
 | Flag        | Default | Description                        |
 | ----------- | ------- | ---------------------------------- |
+| `--format`  | `human` | Output format: `human` or `json`   |
+| `--json`    | `false` | Alias for `--format json`          |
 | `--agent`   |         | Filter by agent name               |
 | `--offline` | `false` | Use embedded fallback pricing only |
 | `--no-sync` | `false` | Skip on-demand sync                |
@@ -422,6 +424,16 @@ agentsview usage statusline [flags]
 ```bash
 $ agentsview usage statusline
 $9.61 today
+```
+
+```bash
+$ agentsview usage statusline --json
+{
+  "date": "2026-08-04",
+  "cost": {
+    "microdollars": 9610000
+  }
+}
 ```
 
 See [Token Usage & Costs](/token-usage/#agentsview-usage-statusline) for

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -814,6 +814,8 @@ agentsview usage statusline [flags]
 
 | Flag        | Default | Description                        |
 | ----------- | ------- | ---------------------------------- |
+| `--format`  | `human` | Output format: `human` or `json`   |
+| `--json`    | `false` | Alias for `--format json`          |
 | `--agent`   |         | Filter by agent name               |
 | `--offline` | `false` | Use embedded fallback pricing only |
 | `--no-sync` | `false` | Skip on-demand sync                |
@@ -829,6 +831,20 @@ With `--agent claude`:
 ```
 $6.42 today (claude)
 ```
+
+With `--json`, the same facts are emitted for scripts, with the cost as exact
+microdollars rather than a formatted string:
+
+```json
+{
+  "date": "2026-08-04",
+  "cost": {
+    "microdollars": 9610000
+  }
+}
+```
+
+`agent` is included when `--agent` filtered the query.
 
 The command always scopes to the current local-time day. Use
 `agentsview usage daily --since $(date +%Y-%m-%d)` if you want the full row
@@ -896,11 +912,14 @@ for prompt modules that must stay snappy.
 
 **Monthly spend for the current month:**
 
+Costs are reported as `money` objects, so read `.microdollars` and divide when
+you want dollars:
+
 ```bash
 agentsview usage daily \
   --since "$(date +%Y-%m-01)" \
   --json \
-  | jq '.totals.totalCost'
+  | jq '.totals.totalCost.microdollars / 1000000'
 ```
 
 **Per-agent totals for the last 7 days:**
@@ -917,7 +936,7 @@ for a in claude codex copilot gemini; do
     --since "$since" \
     --agent "$a" \
     --json 2>/dev/null \
-    | jq '.totals.totalCost')
+    | jq -r '.totals.totalCost.microdollars / 1000000 | tostring')
   printf "%-8s  \$%s\n" "$a" "$total"
 done
 ```
@@ -926,13 +945,20 @@ done
 
 The script writes to stderr and exits non-zero so you can wire it into whatever
 notifier fits your OS — cron's `MAILTO`, launchd's `StandardErrorPath`, a
-systemd timer's journal, or a Windows Task Scheduler action:
+systemd timer's journal, or a Windows Task Scheduler action.
+
+`--json` reports the cost as exact microdollars, so the threshold is an integer
+comparison instead of a parse of the formatted line. `jq -e` fails the script
+when the value is missing, so a broken read cannot pass for an under-budget
+day:
 
 ```bash
-today=$(agentsview usage statusline --offline --no-sync \
-  | tr -dc '0-9.')
-if awk -v t="$today" 'BEGIN {exit !(t+0 > 25)}'; then
-  echo "AgentsView: AI spend \$$today today (> \$25)" >&2
+budget_usd=25
+spent=$(agentsview usage statusline --json --offline --no-sync \
+  | jq -e '.cost.microdollars') || exit 1
+if [ "$spent" -gt $((budget_usd * 1000000)) ]; then
+  printf 'AgentsView: $%d.%02d today (over $%d)\n' \
+    $((spent / 1000000)) $((spent % 1000000 / 10000)) "$budget_usd" >&2
   exit 1
 fi
 ```


### PR DESCRIPTION
`usage statusline` is the only reporting command in the `usage` group without
the shared `--format`/`--json` pair, so anything consuming it has to read the
human line. The budget example in `docs/token-usage.md` does exactly that:

```bash
today=$(agentsview usage statusline --offline --no-sync | tr -dc '0-9.')
```

That strips every non-digit, so it only works while the line happens to carry
no other digit. `--agent` is echoed into the line verbatim, so `--agent gpt-4`
already turns `$6.42 today (gpt-4)` into `6.424`, and any later change to the
format breaks it the same way. It fails by returning a plausible wrong number
rather than an error, which is the worst failure mode for a spend guard.

This registers the existing `registerFormatFlags`/`outputFormat` pair on
`statusline` and emits the same facts the human line carries, nothing more:

```json
{
  "date": "2026-08-04",
  "cost": { "microdollars": 9610000 },
  "agent": "claude"
}
```

`cost` stays a `money.Money` rather than a float of dollars, following the
type's documented role as the sole machine-readable representation of a
monetary value, so the documented threshold check becomes exact integer
arithmetic. `agent` is omitted when no filter was applied.

Two design notes, in case either should go the other way:

- The payload is deliberately unversioned, alongside the other small CLI
  payloads (`projects`, `health`, `skills list`); `usage daily` stays the
  versioned contract surface for this group.
- The key is `cost`, matching `ModelBreakdown.Cost`, rather than `totalCost`
  as in `usage daily`'s totals. Either is defensible; `cost` reads better on a
  payload that only ever carries one figure.

The same section's other scripting examples read `.totals.totalCost`, which is
also a money object, so they printed `{"microdollars": N}` into a `printf`.
They now read `.microdollars` and divide, which is the same class of fix. The
JSON *output* samples further up the guide still show pre-money floats; those
are a larger doc pass and are left alone here.

Tradeoff: this deliberately does not move budget thresholds or notifications
into the tool. The scripting recipe stays where the policy lives; it just gets
an input that cannot silently drift. The human line is untouched, so existing
prompts and tmux status lines are unaffected.

Related to #1185, which asked for a built-in guardrail; this is the smaller
composable piece of it.

Reviewers: `newUsageStatuslineCommand` in `cmd/agentsview/cli.go` for the flag
wiring, `usageStatuslineReport` in `cmd/agentsview/usage.go` for the payload
shape, and the updated budget example in `docs/token-usage.md`.
