### PR TITLE
fix(opencode): keep the session container off the recursive watch budget

### DIFF
--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1546,7 +1546,7 @@ func TestOpenCodeFormatMissingRootsUseNativeLifecycleWithoutPolling(t *testing.T
 
 			roots, unwatched, _, persistentDirAgents := collectWatchRoots(cfg)
 			require.Len(t, roots, rootCount)
-			results := make([]agentsync.RecursiveWatchResult, rootCount)
+			results := make([]agentsync.RecursiveWatchResult, len(roots))
 			for i := range results {
 				results[i] = agentsync.RecursiveWatchResult{
 					Watched:                   1,
@@ -3369,4 +3369,77 @@ func TestSyncWatchBatchDirectoryRenameDefersUnavailableProviderRoots(t *testing.
 	require.NoError(t, err)
 	assert.NotNil(t, synced,
 		"the available root must still reconcile the rename authoritatively")
+}
+
+// TestOpenCodeSQLiteOnlyRootKeepsItsPollingFallback is the regression that a
+// coverage-unit split can introduce silently. A SQLite-layout OpenCode root
+// never grows a storage/ directory, so a polling obligation probed on that
+// path could never be satisfied, and an unsatisfiable probe defers every other
+// obligation sharing the configured dir. The root would then have neither
+// native coverage nor polling.
+func TestOpenCodeSQLiteOnlyRootKeepsItsPollingFallback(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "opencode")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("db"), 0o600,
+	))
+	require.NoDirExists(t, filepath.Join(root, "storage"))
+
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentOpenCode: {root},
+	}}
+	roots, unwatched, symlinkGated, persistentDirAgents := collectWatchRoots(cfg)
+
+	// Degraded coverage is the only reason this root needs polling at all.
+	// Registration skips a unit that does not exist, so its result stays
+	// zero-valued.
+	results := make([]agentsync.RecursiveWatchResult, len(roots))
+	for i := range results {
+		if roots[i].exists {
+			results[i] = agentsync.RecursiveWatchResult{Unwatched: 1}
+		}
+	}
+	obligations := watchPollingObligations(
+		roots, results, unwatched, persistentDirAgents,
+	)
+	obligations = append(obligations, symlinkPollingObligations(symlinkGated)...)
+
+	local := make([]pollingObligation, 0, len(obligations))
+	for _, obligation := range obligations {
+		local = append(local, syncObligationToPoller(obligation))
+	}
+	scopes := availableUnwatchedPollScopes(local)
+	assert.Equal(t, []string{root}, scopes[parser.AgentOpenCode],
+		"degraded coverage on a SQLite-only root must still reach polling")
+}
+
+// TestOpenCodeAbsentRootPollsTheConfiguredDir covers the cold-start layout:
+// nothing is installed yet, so the plan must leave one satisfiable probe on
+// the configured dir rather than a deeper path that appears only afterwards.
+func TestOpenCodeAbsentRootPollsTheConfiguredDir(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "not-installed")
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentOpenCode: {root},
+	}}
+	roots, unwatched, symlinkGated, persistentDirAgents := collectWatchRoots(cfg)
+
+	obligations := watchPollingObligations(
+		roots, make([]agentsync.RecursiveWatchResult, len(roots)),
+		unwatched, persistentDirAgents,
+	)
+	obligations = append(obligations, symlinkPollingObligations(symlinkGated)...)
+	require.NotEmpty(t, obligations)
+	for _, obligation := range obligations {
+		assert.Equal(t, filepath.Clean(root), filepath.Clean(obligation.Probe),
+			"no obligation may be probed on a path deeper than the configured dir")
+	}
+
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	local := make([]pollingObligation, 0, len(obligations))
+	for _, obligation := range obligations {
+		local = append(local, syncObligationToPoller(obligation))
+	}
+	scopes := availableUnwatchedPollScopes(local)
+	assert.Equal(t, []string{root}, scopes[parser.AgentOpenCode],
+		"the dir must become pollable as soon as it appears")
 }

--- a/internal/parser/opencode_coverage_units_test.go
+++ b/internal/parser/opencode_coverage_units_test.go
@@ -1,0 +1,282 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func openCodeUnitProvider(t *testing.T, root string) Provider {
+	t.Helper()
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	return provider
+}
+
+// TestOpenCodeWatchPlanKeepsTheContainerOffTheRecursiveBudget is the reported
+// failure: one recursive unit made the SQLite container and the storage
+// archive draw on the same shared budget, so a root reached after that budget
+// was spent registered no native watch at all and the live container went
+// uncovered. A shallow unit never draws on it.
+func TestOpenCodeWatchPlanKeepsTheContainerOffTheRecursiveBudget(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("db"), 0o600,
+	))
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(root, "storage", "session", "project"), 0o755,
+	))
+
+	plan, err := openCodeUnitProvider(t, root).WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 2)
+
+	container := plan.Roots[0]
+	assert.Equal(t, root, container.Path)
+	assert.False(t, container.Recursive,
+		"the container unit must never enter the recursive budget")
+	assert.Equal(t, []string{"opencode.db", "opencode.db-wal"}, container.IncludeGlobs)
+
+	storage := plan.Roots[1]
+	assert.Equal(t, filepath.Join(root, "storage"), storage.Path)
+	assert.True(t, storage.Recursive)
+	assert.Equal(t, []string{"*.json"}, storage.IncludeGlobs)
+
+	assert.NotEqual(t, container.DebounceKey, storage.DebounceKey,
+		"units sharing a configured root need independent debounce keys")
+}
+
+// TestOpenCodeWatchPlanStaysWholeWhileStorageIsAbsent keeps the plan from
+// naming a watch root that does not exist. A planned root the watcher cannot
+// establish carries a polling obligation probed on that path, and a probe that
+// can never be satisfied defers every other obligation on the same configured
+// dir, leaving it with neither native coverage nor polling. The single
+// recursive unit costs one native watch and still covers a storage tree
+// created later.
+func TestOpenCodeWatchPlanStaysWholeWhileStorageIsAbsent(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("db"), 0o600,
+	))
+	require.NoDirExists(t, filepath.Join(root, "storage"))
+
+	plan, err := openCodeUnitProvider(t, root).WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, root, plan.Roots[0].Path)
+	assert.True(t, plan.Roots[0].Recursive)
+}
+
+// TestOpenCodeWatchPlanNamesNoAbsentRootForAnUninstalledAgent is the cold-start
+// layout: the configured dir itself does not exist yet, so the plan must leave
+// exactly one probe, on the dir, rather than a deeper path that appears only
+// afterwards.
+func TestOpenCodeWatchPlanNamesNoAbsentRootForAnUninstalledAgent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "not-installed")
+	require.NoDirExists(t, root)
+
+	plan, err := openCodeUnitProvider(t, root).WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, root, plan.Roots[0].Path)
+}
+
+// TestOpenCodeWatchPlanKeepsASymlinkedRootRecursive preserves the daemon's
+// symlink policy. It refuses to watch a recursive root through a symlink and
+// gates the configured dir's reconciliation on the link target instead, and
+// that check reads the unit's Recursive flag. A shallow container unit would
+// slip past it while the storage unit walked the link's target anyway, leaving
+// the dir recursively watched through the link with no availability probe.
+func TestOpenCodeWatchPlanKeepsASymlinkedRootRecursive(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "target")
+	require.NoError(t, os.MkdirAll(filepath.Join(target, "storage"), 0o755))
+	link := filepath.Join(base, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	plan, err := openCodeUnitProvider(t, link).WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, link, plan.Roots[0].Path)
+	assert.True(t, plan.Roots[0].Recursive)
+
+	// The single unit must still claim its own paths, or the symlinked root
+	// would be watched and then classify nothing.
+	set := newOpenCodeFormatSourceSet(
+		[]string{link}, openCodeProviderSpecForAgent(AgentOpenCode), nil,
+	)
+	assert.True(t, set.unitScopeAllows(ChangedPathRequest{
+		Path: filepath.Join(link, "storage", "session", "p", "s.json"), WatchRoot: link,
+	}))
+	assert.True(t, set.unitScopeAllows(ChangedPathRequest{
+		Path: filepath.Join(link, "opencode.db-wal"), WatchRoot: link,
+	}))
+}
+
+// TestOpenCodeNestedConfiguredRootsClaimEachPathOnce covers configured roots
+// that nest. Every containing root's units would otherwise claim the path, so
+// the deepest root owns it and the ancestor's units stand down.
+func TestOpenCodeNestedConfiguredRootsClaimEachPathOnce(t *testing.T) {
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "nested")
+	require.NoError(t, os.MkdirAll(filepath.Join(inner, "storage"), 0o755))
+
+	set := newOpenCodeFormatSourceSet(
+		[]string{outer, inner}, openCodeProviderSpecForAgent(AgentOpenCode), nil,
+	)
+	innerWAL := filepath.Join(inner, "opencode.db-wal")
+
+	assert.True(t, set.unitScopeAllows(ChangedPathRequest{
+		Path: innerWAL, WatchRoot: inner,
+	}))
+	assert.False(t, set.unitScopeAllows(ChangedPathRequest{
+		Path: innerWAL, WatchRoot: outer,
+	}), "the outer container unit must not re-run the inner root's fan-out")
+
+	innerSession := filepath.Join(inner, "storage", "session", "p", "s.json")
+	assert.True(t, set.unitScopeAllows(ChangedPathRequest{
+		Path: innerSession, WatchRoot: filepath.Join(inner, "storage"),
+	}))
+	assert.False(t, set.unitScopeAllows(ChangedPathRequest{
+		Path: innerSession, WatchRoot: outer,
+	}))
+}
+
+// TestOpenCodeChangedPathClaimedByExactlyOneUnit covers the fan-out the split
+// would otherwise double. The engine dispatches every event once per emitted
+// watch root, so a WAL write reaching both units would run the whole
+// container's session listing twice for one change. Storage paths are not
+// scoped this way; see TestOpenCodeStorageSessionSurvivesAStaleDispatchSet.
+func TestOpenCodeChangedPathClaimedByExactlyOneUnit(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	seedHybridSQLiteDB(t, dbPath, "ses_container")
+	storage := filepath.Join(root, "storage")
+	sessionDir := filepath.Join(storage, "session", "project")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	sessionPath := filepath.Join(sessionDir, "ses_unit.json")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(`{"id":"ses_unit"}`), 0o600))
+
+	provider := openCodeUnitProvider(t, root)
+	ctx := context.Background()
+
+	walPath := filepath.Join(root, "opencode.db-wal")
+	require.NoError(t, os.WriteFile(walPath, make([]byte, 4096), 0o600))
+
+	fromStorageUnit, err := provider.SourcesForChangedPath(ctx, ChangedPathRequest{
+		Path: walPath, EventKind: "write", WatchRoot: storage,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, fromStorageUnit,
+		"the storage unit must not claim a change outside its own subtree")
+
+	fromContainerUnit, err := provider.SourcesForChangedPath(ctx, ChangedPathRequest{
+		Path: walPath, EventKind: "write", WatchRoot: root,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, fromContainerUnit,
+		"the container unit owns its database and WAL")
+
+	sessionFromStorage, err := provider.SourcesForChangedPath(ctx, ChangedPathRequest{
+		Path: sessionPath, EventKind: "write", WatchRoot: storage,
+	})
+	require.NoError(t, err)
+	require.Len(t, sessionFromStorage, 1)
+	assert.Equal(t, sessionPath, sessionFromStorage[0].DisplayPath)
+}
+
+// TestOpenCodeStorageSessionSurvivesAStaleDispatchSet is the skew case. The
+// engine resolves each provider's watch roots once and reuses that set for the
+// life of the process, so a storage tree created afterwards is still
+// dispatched only against the configured root. Deferring storage paths to the
+// storage unit would leave them claimed by no unit at all until the next
+// daemon start.
+func TestOpenCodeStorageSessionSurvivesAStaleDispatchSet(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("db"), 0o600,
+	))
+	provider := openCodeUnitProvider(t, root)
+
+	// The dispatch set the engine caches: storage does not exist yet, so the
+	// plan is the single recursive unit at the configured root.
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	cachedWatchRoot := plan.Roots[0].Path
+
+	sessionDir := filepath.Join(root, "storage", "session", "project")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	sessionPath := filepath.Join(sessionDir, "ses_skew.json")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(`{"id":"ses_skew"}`), 0o600))
+
+	refreshed, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, refreshed.Roots, 2, "the live plan has split by now")
+
+	sources, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path: sessionPath, EventKind: "write", WatchRoot: cachedWatchRoot,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, sessionPath, sources[0].DisplayPath)
+}
+
+// TestOpenCodeUnscopedChangedPathStaysUnfiltered keeps callers that do not
+// dispatch per watch root working. Reconciliation rehydration and poll-driven
+// classification both send an empty WatchRoot, and gating them would drop
+// every source they resolve.
+func TestOpenCodeUnscopedChangedPathStaysUnfiltered(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("db"), 0o600,
+	))
+	sessionDir := filepath.Join(root, "storage", "session", "project")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	sessionPath := filepath.Join(sessionDir, "ses_unscoped.json")
+	require.NoError(t, os.WriteFile(
+		sessionPath, []byte(`{"id":"ses_unscoped"}`), 0o600,
+	))
+
+	sources, err := openCodeUnitProvider(t, root).SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: sessionPath, EventKind: "write"},
+	)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, sessionPath, sources[0].DisplayPath)
+}
+
+// TestOpenCodeVirtualMemberScopesToItsContainerUnit pins the virtual spelling.
+// A member path is <dbPath>#<sessionID>, which lies under no watch root as
+// written, so the scope check must resolve it to the physical container first
+// or the container unit would drop every member event it owns.
+func TestOpenCodeVirtualMemberScopesToItsContainerUnit(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("db"), 0o600))
+
+	set := newOpenCodeFormatSourceSet(
+		[]string{root}, openCodeProviderSpecForAgent(AgentOpenCode), nil,
+	)
+	virtual := OpenCodeSQLiteVirtualPath(dbPath, "ses_virtual")
+
+	assert.True(t, set.unitScopeAllows(ChangedPathRequest{
+		Path: virtual, WatchRoot: root,
+	}))
+	assert.False(t, set.unitScopeAllows(ChangedPathRequest{
+		Path: virtual, WatchRoot: filepath.Join(root, "storage"),
+	}))
+}

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -333,12 +333,6 @@ func (spec openCodeProviderSpec) find(root, sessionID string) string {
 	return findOpenCodeFormatSourceFile(spec.format, root, sessionID)
 }
 
-// watchRoots returns the directories that should be watched for live
-// updates under a configured root.
-func (spec openCodeProviderSpec) watchRoots(root string) []string {
-	return resolveOpenCodeFormatWatchRoots(spec.format, root)
-}
-
 // storageIDs returns the set of session IDs present as storage JSON
 // under a root, used to skip duplicate SQLite metas in hybrid roots.
 func (spec openCodeProviderSpec) storageIDs(root string) map[string]struct{} {
@@ -664,22 +658,105 @@ func (s openCodeFormatSourceSet) discoverStorageEach(
 }
 
 func (s openCodeFormatSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
-	roots := make([]WatchRoot, 0, len(s.roots))
+	roots := make([]WatchRoot, 0, 2*len(s.roots))
 	for _, root := range s.roots {
-		for _, watchRoot := range s.spec.watchRoots(root) {
-			roots = append(roots, WatchRoot{
-				Path:      watchRoot,
-				Recursive: true,
-				IncludeGlobs: []string{
-					"*.json",
-					s.spec.dbName,
-					s.spec.dbName + "-wal",
-				},
-				DebounceKey: string(s.spec.agent) + ":opencode:" + watchRoot,
-			})
-		}
+		roots = append(roots, s.watchUnits(root)...)
 	}
 	return WatchPlan{Roots: roots}, nil
+}
+
+// watchUnits returns the coverage units for one configured root. The database
+// and its WAL are direct children of the root, so a shallow container unit
+// covers them, and a shallow watch never draws on the shared recursive budget.
+// Under one recursive unit the archive and the container shared that budget:
+// once earlier roots had spent it, the whole root registered with no native
+// watch at all, so a large archive elsewhere in the plan could leave a live
+// SQLite container uncovered. Exhaustion inside this root's own walk also
+// marked the container's coverage degraded along with the archive's, although
+// the root's watch had already been installed.
+func (s openCodeFormatSourceSet) watchUnits(root string) []WatchRoot {
+	if !s.splitsCoverageUnits(root) {
+		return []WatchRoot{{
+			Path:      root,
+			Recursive: true,
+			IncludeGlobs: []string{
+				"*.json",
+				s.spec.dbName,
+				s.spec.dbName + "-wal",
+			},
+			DebounceKey: string(s.spec.agent) + ":opencode:" + root,
+		}}
+	}
+	return []WatchRoot{
+		{
+			Path:      root,
+			Recursive: false,
+			IncludeGlobs: []string{
+				s.spec.dbName,
+				s.spec.dbName + "-wal",
+			},
+			DebounceKey: string(s.spec.agent) + ":container:" + root,
+		},
+		{
+			Path:         openCodeStorageWatchDir(root),
+			Recursive:    true,
+			IncludeGlobs: []string{"*.json"},
+			DebounceKey:  string(s.spec.agent) + ":storage:" + root,
+		},
+	}
+}
+
+// splitsCoverageUnits reports whether a configured root plans separate
+// container and storage units.
+//
+// The split needs an existing storage directory. Naming an absent one would
+// plan a watch root that cannot be established, and its polling obligation
+// probes a path that may never appear, which defers every other obligation on
+// the same configured dir. While storage is absent the single recursive unit
+// costs one native watch and still covers the tree if it is created later, and
+// the root's own watch is installed first so a growing archive can no longer
+// starve the database.
+//
+// A symlinked root also keeps the single unit. The daemon refuses to watch a
+// recursive root through a symlink and gates the configured dir's
+// reconciliation on the link target instead, and that check reads the unit's
+// Recursive flag: a shallow container unit would slip past it while the
+// storage unit walked the link's target anyway.
+//
+// The split is forfeited when another provider plans a recursive root at the
+// same path. The daemon keeps one watch root per path and merges a shallow
+// unit into a recursive one, so the merged root's walk covers the archive
+// again and the two share a budget once more. The merged root still gets its
+// own native watch, so nothing is left uncovered; only the isolation is lost,
+// and only for a directory two providers were configured to share.
+func (s openCodeFormatSourceSet) splitsCoverageUnits(root string) bool {
+	return !isSymlinkWatchPath(root) &&
+		isDirWatchPath(openCodeStorageWatchDir(root))
+}
+
+// isSymlinkWatchPath reports whether path is itself a symbolic link, without
+// resolving it.
+func isSymlinkWatchPath(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil || info == nil {
+		return false
+	}
+	return info.Mode()&os.ModeSymlink != 0
+}
+
+// isDirWatchPath reports whether path resolves to a directory.
+func isDirWatchPath(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info == nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+// openCodeStorageWatchDir is the recursive storage unit's path for a
+// configured root.
+func openCodeStorageWatchDir(root string) string {
+	return filepath.Join(root, "storage")
 }
 
 // reconciliationContainer maps a requested path to the SQLite container that
@@ -715,6 +792,9 @@ func (s openCodeFormatSourceSet) SourcesForChangedPath(
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	if !s.unitScopeAllows(req) {
+		return nil, nil
+	}
 	if dbPath, _, virtual := s.spec.parseVirtual(req.Path); virtual {
 		for _, root := range s.roots {
 			if _, under := relUnder(root, dbPath); !under {
@@ -744,6 +824,71 @@ func (s openCodeFormatSourceSet) SourcesForChangedPath(
 		}
 	}
 	return nil, nil
+}
+
+// unitScopeAllows scopes changed-path classification to the coverage units of
+// the configured root that owns the path. The engine calls
+// SourcesForChangedPath once per emitted watch root per event, so with two
+// units per configured root an unscoped WAL event would run the whole SQLite
+// fan-out twice. A request whose path (or, for a virtual path, its physical
+// database path) lies outside req.WatchRoot belongs to another unit and yields
+// no sources, and configured roots can nest, so only the most specific
+// containing root's units claim it.
+//
+// The container unit does not defer storage paths to the storage unit, even
+// though only one of the two watches them. Whether the storage unit exists is
+// a filesystem fact, and the engine resolves each provider's watch roots once
+// and reuses that set for the life of the process: a storage tree created
+// after that set was cached would be dispatched only against the container
+// root while the scope rule had already handed it to a root the caller never
+// passes, so no unit would claim it at all. Classifying a storage path twice
+// costs one repeated source lookup. The expensive claim, the shared
+// container's session listing, still cannot double, because a storage watch
+// root never contains the database or its WAL.
+//
+// An empty req.WatchRoot preserves unscoped behavior for callers that do not
+// dispatch per watch root.
+func (s openCodeFormatSourceSet) unitScopeAllows(req ChangedPathRequest) bool {
+	if req.WatchRoot == "" {
+		return true
+	}
+	path := req.Path
+	if dbPath, _, virtual := s.spec.parseVirtual(req.Path); virtual {
+		path = dbPath
+	}
+	if !pathAtOrUnder(req.WatchRoot, path) {
+		return false
+	}
+	owner, owned := s.mostSpecificRootFor(path)
+	if !owned {
+		return true
+	}
+	return reconciliationScopeSamePath(req.WatchRoot, owner) ||
+		reconciliationScopeSamePath(req.WatchRoot, openCodeStorageWatchDir(owner))
+}
+
+// mostSpecificRootFor returns the deepest configured root containing path.
+func (s openCodeFormatSourceSet) mostSpecificRootFor(path string) (string, bool) {
+	best := ""
+	for _, root := range s.roots {
+		clean := filepath.Clean(root)
+		if !pathAtOrUnder(clean, path) {
+			continue
+		}
+		if len(clean) > len(best) {
+			best = clean
+		}
+	}
+	return best, best != ""
+}
+
+// pathAtOrUnder reports whether path is root itself or lies within it.
+func pathAtOrUnder(root, path string) bool {
+	if filepath.Clean(root) == filepath.Clean(path) {
+		return true
+	}
+	_, under := relUnder(root, path)
+	return under
 }
 
 func (s openCodeFormatSourceSet) SourceForReconciliation(

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -389,9 +389,15 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 
 	plan, err := provider.WatchPlan(context.Background())
 	require.NoError(t, err)
-	require.Len(t, plan.Roots, 1)
-	assert.Equal(t, filepath.Join(root, "storage"), plan.Roots[0].Path)
-	assert.True(t, plan.Roots[0].Recursive)
+	require.Len(t, plan.Roots, 2)
+	assert.Equal(t, root, plan.Roots[0].Path)
+	assert.False(t, plan.Roots[0].Recursive)
+	assert.Equal(t, []string{
+		"opencode.db", "opencode.db-wal",
+	}, plan.Roots[0].IncludeGlobs)
+	assert.Equal(t, filepath.Join(root, "storage"), plan.Roots[1].Path)
+	assert.True(t, plan.Roots[1].Recursive)
+	assert.Equal(t, []string{"*.json"}, plan.Roots[1].IncludeGlobs)
 
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
@@ -494,6 +500,8 @@ func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 
 	plan, err := provider.WatchPlan(context.Background())
 	require.NoError(t, err)
+	// A SQLite-layout root has no storage tree, so it keeps the single
+	// recursive unit and plans no watch root that does not exist.
 	require.Len(t, plan.Roots, 1)
 	assert.Equal(t, root, plan.Roots[0].Path)
 	assert.True(t, plan.Roots[0].Recursive)

--- a/internal/sync/watch_backend.go
+++ b/internal/sync/watch_backend.go
@@ -78,7 +78,7 @@ func (w *Watcher) RegisterRoots(
 			continue
 		}
 		results[i] = w.backend.AddRecursive(root.Path, remaining)
-		remaining -= results[i].Watched
+		remaining -= results[i].Allocated
 	}
 	return results
 }

--- a/internal/sync/watch_backend_fsnotify.go
+++ b/internal/sync/watch_backend_fsnotify.go
@@ -114,7 +114,14 @@ func (b *fsnotifyBackend) AddRecursive(root string, budget int) RecursiveWatchRe
 				result.Watched++
 				return nil
 			}
-			if remaining <= 0 {
+			// The root's own directory is the mandatory part of a recursive
+			// registration and its subtree is the discretionary part. A
+			// shallow unit's watch is installed unconditionally, so a plan
+			// that merges one into a recursive unit at the same path would
+			// lose that coverage the moment the budget ran out. The subtree
+			// below still reports BudgetExhausted and hands off to polling.
+			mandatory := path == root
+			if remaining <= 0 && !mandatory {
 				result.BudgetExhausted = true
 				return filepath.SkipAll
 			}
@@ -127,11 +134,18 @@ func (b *fsnotifyBackend) AddRecursive(root string, budget int) RecursiveWatchRe
 				}
 				return nil
 			}
-			b.watchBudgetCost[path]++
+			// A mandatory watch installed past the budget sits outside the
+			// accounting entirely, the way a shallow root already does: it is
+			// not charged, so removing it must not refund a slot the process
+			// never spent. Charging it and refunding it would leave headroom
+			// above the cap that runtime subtree adds could then claim.
+			if remaining > 0 {
+				b.watchBudgetCost[path]++
+				remaining--
+				result.Allocated++
+			}
 			b.addWatchOwner(path, root)
-			remaining--
 			result.Watched++
-			result.Allocated++
 			return nil
 		})
 	if errors.Is(result.Err, filepath.SkipAll) {

--- a/internal/sync/watch_backend_fsnotify.go
+++ b/internal/sync/watch_backend_fsnotify.go
@@ -105,6 +105,15 @@ func (b *fsnotifyBackend) AddRecursive(root string, budget int) RecursiveWatchRe
 			if path != root && b.shouldExcludeForRoot(path, root) {
 				return filepath.SkipDir
 			}
+			// A directory an earlier root already watches natively is shared,
+			// not installed again: the kernel watch is already paid for, so
+			// settle reuse before the budget check or an overlapping root
+			// would be refused coverage that already exists.
+			if len(b.watchOwners[path]) > 0 {
+				b.addWatchOwner(path, root)
+				result.Watched++
+				return nil
+			}
 			if remaining <= 0 {
 				result.BudgetExhausted = true
 				return filepath.SkipAll
@@ -122,6 +131,7 @@ func (b *fsnotifyBackend) AddRecursive(root string, budget int) RecursiveWatchRe
 			b.addWatchOwner(path, root)
 			remaining--
 			result.Watched++
+			result.Allocated++
 			return nil
 		})
 	if errors.Is(result.Err, filepath.SkipAll) {

--- a/internal/sync/watch_backend_fsnotify_test.go
+++ b/internal/sync/watch_backend_fsnotify_test.go
@@ -374,8 +374,14 @@ func TestFSNotifyBackendRuntimeDegradationPreservesOverlappingRootScopes(t *test
 			Path: nested, Recursive: true, Exists: true,
 			Scopes: []WatchScope{{Agent: "cursor", SyncDir: nestedScope}},
 		},
-	}, 3)
+		// Two native watches cover both roots: nested is inside parent, so the
+		// nested root reuses the watch parent already installed instead of
+		// charging the shared budget for it a second time.
+	}, 2)
 	require.Len(t, results, 2)
+	require.Equal(t, 2, results[0].Allocated)
+	require.Zero(t, results[1].Allocated)
+	require.False(t, results[1].BudgetExhausted)
 	require.Zero(t, backend.runtimeBudget)
 
 	created := filepath.Join(nested, "created-after-startup")

--- a/internal/sync/watch_coverage_units_test.go
+++ b/internal/sync/watch_coverage_units_test.go
@@ -1,0 +1,80 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterRootsChargesSharedNativeWatchesOnce pins the budget accounting a
+// shallow container unit plus a recursive sibling depends on: a directory an
+// earlier root already watches natively costs nothing to share, so the shared
+// budget must fund the union of the roots rather than the sum of their walks.
+func TestRegisterRootsChargesSharedNativeWatchesOnce(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	parent := t.TempDir()
+	nested := filepath.Join(parent, "nested")
+	require.NoError(t, os.Mkdir(nested, 0o755))
+	sibling := filepath.Join(parent, "sibling")
+	require.NoError(t, os.Mkdir(sibling, 0o755))
+
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000, WatcherOptions{},
+	)
+	require.NoError(t, err)
+
+	// parent, nested, and sibling are three distinct directories, so three
+	// native watches cover both roots even though the walks visit four.
+	results := watcher.RegisterRoots([]WatchRoot{
+		{Path: parent, Recursive: true, Exists: true},
+		{Path: nested, Recursive: true, Exists: true},
+	}, 3)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, 3, results[0].Allocated)
+	assert.Equal(t, 3, results[0].Watched)
+	assert.Zero(t, results[1].Allocated,
+		"the nested root reuses the watch the parent root installed")
+	assert.Equal(t, 1, results[1].Watched,
+		"reuse still reports the directory as covered")
+	assert.False(t, results[1].BudgetExhausted,
+		"a root that installs nothing cannot exhaust the budget")
+	assert.NoError(t, results[1].Err)
+	assert.Contains(t, backend.watcher.WatchList(), nested)
+}
+
+// TestRegisterRootsReusesNativeWatchesAfterTheBudgetIsSpent is the starvation
+// case: the shared budget is already gone when the second root registers, and
+// every directory it needs is one the first root watches. Refusing it would
+// report an uncovered root while the kernel is already delivering its events.
+func TestRegisterRootsReusesNativeWatchesAfterTheBudgetIsSpent(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	parent := t.TempDir()
+	nested := filepath.Join(parent, "nested")
+	require.NoError(t, os.Mkdir(nested, 0o755))
+
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000, WatcherOptions{},
+	)
+	require.NoError(t, err)
+
+	results := watcher.RegisterRoots([]WatchRoot{
+		{Path: parent, Recursive: true, Exists: true},
+		{Path: nested, Recursive: true, Exists: true},
+	}, 2)
+	require.Len(t, results, 2)
+	require.Zero(t, backend.runtimeBudget)
+
+	assert.False(t, results[1].BudgetExhausted)
+	assert.Zero(t, results[1].Unwatched)
+	assert.Equal(t, 1, results[1].Watched)
+	assert.Contains(t, backend.watchOwners[nested], nested,
+		"the reusing root must own the shared watch, or removing the first "+
+			"root would drop coverage the second still needs")
+}

--- a/internal/sync/watch_coverage_units_test.go
+++ b/internal/sync/watch_coverage_units_test.go
@@ -78,3 +78,49 @@ func TestRegisterRootsReusesNativeWatchesAfterTheBudgetIsSpent(t *testing.T) {
 		"the reusing root must own the shared watch, or removing the first "+
 			"root would drop coverage the second still needs")
 }
+
+// TestRegisterRootsAlwaysWatchesARecursiveRootItself covers the coverage a
+// shallow unit loses when the plan merges it into a recursive unit at the same
+// path. Two providers can name one directory, one shallowly and one
+// recursively, and the daemon keeps a single root for it. A shallow watch is
+// installed unconditionally, so refusing the merged root once the budget is
+// spent would silently drop coverage the shallow unit guaranteed.
+func TestRegisterRootsAlwaysWatchesARecursiveRootItself(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	first := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(first, "child"), 0o755))
+	shared := t.TempDir()
+	sharedChild := filepath.Join(shared, "child")
+	require.NoError(t, os.Mkdir(sharedChild, 0o755))
+
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000, WatcherOptions{},
+	)
+	require.NoError(t, err)
+
+	// The first root consumes the whole budget, so the merged root registers
+	// with nothing left to spend.
+	results := watcher.RegisterRoots([]WatchRoot{
+		{Path: first, Recursive: true, Exists: true},
+		{Path: shared, Recursive: true, Exists: true},
+	}, 2)
+	require.Len(t, results, 2)
+	require.Equal(t, 2, results[0].Allocated,
+		"the fixture must actually spend the budget, or the guard is vacuous")
+	require.False(t, results[0].BudgetExhausted)
+	require.Zero(t, backend.runtimeBudget)
+
+	assert.Contains(t, backend.watcher.WatchList(), shared,
+		"a recursive root must still watch its own directory")
+	assert.True(t, results[1].BudgetExhausted,
+		"the subtree below it stays discretionary and hands off to polling")
+	assert.NotContains(t, backend.watcher.WatchList(), sharedChild)
+
+	// The mandatory watch is off the books like a shallow root's, so removing
+	// it must not hand back a slot the process never spent.
+	assert.Zero(t, results[1].Allocated)
+	require.NoError(t, backend.Remove(shared))
+	assert.Zero(t, backend.runtimeBudget,
+		"an uncharged watch cannot refund budget above the cap")
+}

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -16,7 +16,14 @@ import (
 )
 
 type RecursiveWatchResult struct {
-	Watched   int
+	Watched int
+	// Allocated counts the native watches this registration installed. Watched
+	// counts every directory the root covers, which includes directories an
+	// earlier root already watches natively. Charging those to the shared
+	// budget again spends capacity the process is not paying for, so a later
+	// root that overlaps an earlier one can be refused coverage the kernel
+	// already provides.
+	Allocated int
 	Unwatched int
 	Err       error
 	// MissingRootLifecycleOwned reports that the backend has durable native


### PR DESCRIPTION
OpenCode's SQLite container, its WAL, and its storage archive share one recursive watch unit over the configured root, so the live container draws on the same shared recursive budget as the archive. A root reached after that budget is spent registers no native watch at all, and exhaustion inside the root's own walk marks the container's coverage degraded along with the archive's.

This separates each OpenCode-family root into a shallow container unit covering the database and its WAL and a recursive unit at `<root>/storage`. A shallow watch never draws on the recursive budget, so the container's coverage no longer depends on the archive's size. The split applies only where it is representable: a root with no storage directory keeps the single recursive unit, because naming an absent watch root would plan a polling obligation probed on a path that may never appear, and a probe that cannot be satisfied defers every other obligation on the same configured dir. A symlinked root also keeps it, since the daemon refuses to watch a recursive root through a symlink and gates the configured dir's reconciliation on the link target instead.

A native watch shared by overlapping roots is now charged to the shared budget once. `RecursiveWatchResult.Watched` still counts the directories a root covers; `Allocated` counts the watches a registration installed, and registration subtracts that. Reuse is settled before the budget check, so a root whose directories are already watched registers cleanly against an exhausted budget and records its ownership, and reclaiming a shared watch returns one budget slot rather than one per root that walked it.

Two units share one configured root and the engine dispatches every changed path once per emitted watch root, so `unitScopeAllows` scopes classification to the units of the root that owns the path; without it a WAL write would run the shared container's whole session listing twice. Configured roots can nest, so the deepest one containing the path owns it, and a virtual member path resolves to its physical container before the check. The container unit still claims storage paths: whether the storage unit exists is a filesystem fact, while the engine resolves each provider's watch roots once and reuses that set, so deferring would leave a storage tree created afterwards claimed by nothing. That costs one repeated source lookup per storage event, which the engine's per-pass source set discards; the database fan-out cannot double, because a storage watch root never contains the database or its WAL.

This PR stands alone and supersedes PR #1318, whose conditional storage-unit split covered the same provider topology. Portable lifecycle ownership of a missing watch root is not attempted here. The bounded parser feed that motivated PR #1331 is abandoned rather than shipped: OpenCode exposes no producer-owned cross-drain journal cursor, so that work was closed and this slice is the salvage.

Refs #1208
