### PR TITLE
feat(amp): record per-inference token usage and model

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -665,11 +665,42 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** One JSON thread document per session.
 - **Evidence:** `no-public-source`.
-- **Upstream:** The first-party [Amp manual](https://ampcode.com/manual) and
-  public Sourcegraph/Amp repositories were searched 2026-07-19; no
-  session-file producer or authoritative disk schema was found.
-- **Usage and cost:** The consumed thread documents do not expose token, cache,
-  reasoning, credit, or USD fields to Agentsview.
+- **Upstream:** The first-party [Amp manual](https://ampcode.com/manual), its
+  [appendix](https://ampcode.com/manual/appendix), the
+  [CLI guide](https://github.com/sourcegraph/amp-examples-and-guides/blob/main/guides/cli/README.md),
+  and public Sourcegraph/Amp repositories were searched 2026-07-19 and again
+  2026-08-08; no session-file producer or authoritative disk schema was found.
+  `amp threads export`, which produces the complete thread documents, is
+  itself undocumented. `amp threads raw` is permission-gated (HTTP 403) for
+  non-maintainer accounts.
+- **Usage and cost:** Complete thread documents carry a per-inference `usage`
+  object on assistant messages: `inputTokens`, `outputTokens`,
+  `cacheCreationInputTokens`, `cacheReadInputTokens`, `totalInputTokens`,
+  `maxInputTokens`, and optionally `model`, `timestamp`, and `thinkingBudget`.
+  Amp persists no USD or credit field per thread; `amp threads usage` reports
+  Amp credits only and returns `$0` for customer-managed provider keys, so
+  Agentsview computes cost from tokens. `totalInputTokens` equals the sum of
+  the three input buckets across every record observed (172/172, four threads,
+  three model families), and the parser asserts nothing beyond that shape.
+- **Field availability:** `model` and `timestamp` are absent from older threads
+  — one observed thread carries 67 usage records with no `model` on any of
+  them, and no thread-level fallback (`agentMode` is null and no
+  `debug.lastInferenceUsage` key exists in exports). Those records are
+  recorded as tokens without cost rather than attributed to a guessed model.
+  Only the six token and window counters were present in every observed
+  record. Usage reporting requires a model, so those rows are stored and
+  visible per session but excluded from daily totals and model breakdowns.
+  `timestamp` is likewise absent on older threads; those messages fall back to
+  the session start for date bucketing.
+- **Subagent usage:** Not represented. Threads that invoke `oracle`,
+  `librarian`, or subagents record only main-thread inference; tool results
+  carry no nested usage and no child thread ID, and subagent threads do not
+  appear in `amp threads list`. Those tokens are therefore not counted.
+- **Independent parser:** `illegalstudio/lazyagent` (`internal/amp/process.go`)
+  reads the same `model`, `inputTokens`, `outputTokens`,
+  `cacheCreationInputTokens`, and `cacheReadInputTokens` fields, corroborating
+  the field names from outside this project. It is not Amp's own producer
+  source.
 - **Agentsview:** `internal/parser/amp.go` and
   `internal/parser/amp_provider.go`.
 

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -36,7 +36,7 @@ it's also dramatically faster on large histories (see
     Agent**, **Gemini**,
     **Qwen Code**, **OpenClaw**, **QClaw**, **Hermes**, **WorkBuddy**, **Forge**,
     **Piebald**, **Antigravity IDE/CLI**, **Zed**, **VS Code Copilot**, **Visual
-    Studio Copilot**, **Mistral Vibe**, and **gptme**.
+    Studio Copilot**, **Mistral Vibe**, **gptme**, and **Amp**.
 
     Coverage is opportunistic rather than guaranteed for every session from those
     agents: rows contribute to cost only when the local transcript includes usable
@@ -491,6 +491,31 @@ so the input side of the equation is accurate:
 
 If you upgraded from an earlier version, the first `usage` invocation triggers a
 full resync so these corrections apply to historical sessions.
+
+### Amp Token Metrics
+
+Amp thread documents carry a `usage` object on each assistant message with the
+model and its input, output, cache-creation, and cache-read token counts.
+AgentsView reads them per inference, so a thread that switches models keeps each
+model's own tokens rather than collapsing to one.
+
+Amp routes every prompt token into one of three input buckets. Anthropic-backed
+threads already use Anthropic's cache semantics and are read as-is.
+OpenAI-backed threads report `inputTokens` as zero and classify the whole
+uncached prompt as cache creation; because OpenAI does not bill cache writes,
+those tokens are recorded as uncached input and no cache-creation bucket is
+emitted — the same normalization the Codex parser applies for the same reason.
+
+Two limits are worth knowing. Older threads can omit the model entirely. Usage
+reporting counts only rows that carry a model, so those inferences are absent
+from daily totals and model breakdowns rather than appearing at a guessed rate —
+their tokens are still stored and visible in the session's own usage view. And
+Amp's exports record only main-thread inference, so tokens spent by `oracle`,
+`librarian`, and other subagents are not included in a thread's totals.
+
+Note that recent Amp versions keep complete threads server-side and leave only
+stub files on disk. AgentsView reports usage for whatever complete threads are
+present locally; threads that exist only as stubs have nothing to read.
 
 ## How It Compares to `ccusage`
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -399,7 +399,11 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // fork to its original session as a continuation. Existing Claude rows need
 // re-parsing so already-ingested fork sessions drop their duplicated
 // messages and usage and stop appearing as unrelated top-level sessions.)
-const dataVersion = 83
+// (84: Amp usage accounting. Exported Amp threads carry a per-inference
+// usage object with model and token counts that the parser previously
+// ignored. Existing Amp rows need re-parsing so their model, token
+// usage, and computed cost appear in usage reports.)
+const dataVersion = 84
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1009,8 +1009,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionUsageReparses(t *testing.T) {
-	assert.Equal(t, 83, CurrentDataVersion(),
-		"Claude background-fork lineage requires a full resync so stored fork sessions drop replayed messages")
+	assert.Equal(t, 84, CurrentDataVersion(),
+		"Claude background-fork lineage and Amp usage accounting require sequential reparses")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/amp.go
+++ b/internal/parser/amp.go
@@ -110,7 +110,7 @@ func parseAmpSession(
 			)
 		}
 
-		messages = append(messages, ParsedMessage{
+		parsed := ParsedMessage{
 			Ordinal:       ordinal,
 			Role:          role,
 			Content:       content,
@@ -120,7 +120,10 @@ func parseAmpSession(
 			ContentLength: len(content),
 			ToolCalls:     tcs,
 			ToolResults:   trs,
-		})
+		}
+		applyAmpTokenUsage(&parsed, msg.Get("usage"))
+
+		messages = append(messages, parsed)
 		ordinal++
 		return true
 	})
@@ -159,7 +162,89 @@ func parseAmpSession(
 		},
 	}
 
+	accumulateMessageTokenUsage(sess, messages)
+
 	return sess, messages, nil
+}
+
+// ampFoldsCacheCreationIntoInput reports whether an Amp usage model
+// bills cache writes. Amp routes every prompt token into one of its
+// three input buckets, but only Anthropic-family models are billed a
+// cache-write premium. OpenAI-family threads report inputTokens as 0
+// and classify the whole uncached prompt as cacheCreationInputTokens,
+// so that portion is uncached input rather than a cache write.
+//
+// Only gpt-prefixed names are folded. An unrecognized or absent model
+// keeps Amp's own bucket labels: without a known provider there is no
+// evidence for reinterpreting them, and a model that cannot be priced
+// contributes no cost either way.
+func ampFoldsCacheCreationIntoInput(model string) bool {
+	return strings.HasPrefix(model, "gpt-")
+}
+
+// applyAmpTokenUsage normalizes an Amp per-inference usage object into
+// the Anthropic-style shape expected by the usage and cost queries.
+//
+// Amp reports the prompt split across three buckets plus their total:
+//
+//	totalInputTokens = inputTokens + cacheCreationInputTokens +
+//	                   cacheReadInputTokens
+//
+// Anthropic-family threads already carry Anthropic semantics and pass
+// through unchanged. OpenAI-family threads fold cache creation into
+// uncached input and emit no cache-creation bucket, mirroring
+// applyCodexTokenUsage: the cost formula treats input_tokens as the
+// uncached remainder, and OpenAI does not bill cache writes.
+//
+//	inputTokens (+ cacheCreationInputTokens for gpt-*) → input_tokens
+//	outputTokens                                       → output_tokens
+//	cacheCreationInputTokens                           → cache_creation_input_tokens
+//	cacheReadInputTokens                               → cache_read_input_tokens
+func applyAmpTokenUsage(msg *ParsedMessage, usage gjson.Result) {
+	if !usage.Exists() {
+		return
+	}
+
+	msg.Model = usage.Get("model").Str
+
+	// Each inference carries its own timestamp on newer threads. Without
+	// it every inference in a long-lived thread falls back to the
+	// session start and lands in one daily bucket.
+	if ts := parseTimestamp(usage.Get("timestamp").Str); !ts.IsZero() {
+		msg.Timestamp = ts
+	}
+
+	input := int(usage.Get("inputTokens").Int())
+	output := int(usage.Get("outputTokens").Int())
+	cacheCreation := int(usage.Get("cacheCreationInputTokens").Int())
+	cacheRead := int(usage.Get("cacheReadInputTokens").Int())
+
+	normalized := map[string]int{
+		"input_tokens":            input,
+		"output_tokens":           output,
+		"cache_read_input_tokens": cacheRead,
+	}
+	if ampFoldsCacheCreationIntoInput(msg.Model) {
+		normalized["input_tokens"] = input + cacheCreation
+	} else {
+		normalized["cache_creation_input_tokens"] = cacheCreation
+	}
+
+	j, err := json.Marshal(normalized)
+	if err != nil {
+		return
+	}
+	msg.TokenUsage = j
+
+	msg.OutputTokens = output
+	msg.HasOutputTokens = usage.Get("outputTokens").Exists()
+	// Presence comes from the fields themselves: an inference whose
+	// prompt is entirely cached reports inputTokens as 0, which is
+	// real usage rather than missing data.
+	msg.HasContextTokens = usage.Get("inputTokens").Exists() ||
+		usage.Get("cacheCreationInputTokens").Exists() ||
+		usage.Get("cacheReadInputTokens").Exists()
+	msg.ContextTokens = input + cacheCreation + cacheRead
 }
 
 // AmpThreadID extracts the id field from raw Amp thread JSON

--- a/internal/parser/amp.go
+++ b/internal/parser/amp.go
@@ -99,7 +99,9 @@ func parseAmpSession(
 		content, thinkingText, hasThinking, hasToolUse, tcs, trs :=
 			ExtractTextContent(msg.Get("content"))
 		trs = append(trs, extractAmpToolResults(msg.Get("content"))...)
-		if strings.TrimSpace(content) == "" && len(trs) == 0 {
+		usage := msg.Get("usage")
+		if strings.TrimSpace(content) == "" && len(trs) == 0 &&
+			(role != RoleAssistant || !ampUsageHasTokenCounters(usage)) {
 			return true
 		}
 
@@ -121,7 +123,7 @@ func parseAmpSession(
 			ToolCalls:     tcs,
 			ToolResults:   trs,
 		}
-		applyAmpTokenUsage(&parsed, msg.Get("usage"))
+		applyAmpTokenUsage(&parsed, usage)
 
 		messages = append(messages, parsed)
 		ordinal++
@@ -165,6 +167,13 @@ func parseAmpSession(
 	accumulateMessageTokenUsage(sess, messages)
 
 	return sess, messages, nil
+}
+
+func ampUsageHasTokenCounters(usage gjson.Result) bool {
+	return usage.Get("inputTokens").Exists() ||
+		usage.Get("outputTokens").Exists() ||
+		usage.Get("cacheCreationInputTokens").Exists() ||
+		usage.Get("cacheReadInputTokens").Exists()
 }
 
 // ampFoldsCacheCreationIntoInput reports whether an Amp usage model

--- a/internal/parser/amp_provider.go
+++ b/internal/parser/amp_provider.go
@@ -54,10 +54,12 @@ func ampProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: jsonlFileProviderSourceCapabilities(),
 		Content: ContentCapabilities{
-			FirstMessage: CapabilitySupported,
-			Thinking:     CapabilitySupported,
-			ToolCalls:    CapabilitySupported,
-			ToolResults:  CapabilitySupported,
+			FirstMessage:         CapabilitySupported,
+			Thinking:             CapabilitySupported,
+			ToolCalls:            CapabilitySupported,
+			ToolResults:          CapabilitySupported,
+			PerMessageTokenUsage: CapabilitySupported,
+			Model:                CapabilitySupported,
 		},
 	}
 }

--- a/internal/parser/amp_test.go
+++ b/internal/parser/amp_test.go
@@ -668,3 +668,196 @@ func TestAmpThreadID(t *testing.T) {
 
 	assert.Equal(t, "", AmpThreadID([]byte(`{"v":1}`)))
 }
+
+func ampUsageThread(t *testing.T, messages string) []ParsedMessage {
+	t.Helper()
+	content := `{
+		"v": 1,
+		"id": "T-019ca26f-1111-2222-3333-444444444444",
+		"created": 1704067200000,
+		"messages": [` + messages + `]
+	}`
+	_, msgs, err := runAmpParserTest(t, content)
+	require.NoError(t, err)
+	return msgs
+}
+
+// OpenAI-family threads report inputTokens as 0 and classify the whole
+// uncached prompt as cache creation. That portion is uncached input,
+// and no cache-creation bucket is emitted.
+func TestAmpProviderParsesOpenAIFamilyUsage(t *testing.T) {
+	msgs := ampUsageThread(t, `
+		{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+		{"role": "assistant", "content": [{"type": "text", "text": "hello"}],
+		 "usage": {"model": "gpt-5.6-sol", "inputTokens": 0, "outputTokens": 15,
+			"maxInputTokens": 272000, "totalInputTokens": 18621,
+			"cacheReadInputTokens": 0, "cacheCreationInputTokens": 18621}}`)
+
+	require.Equal(t, 2, len(msgs))
+	assistant := msgs[1]
+
+	assert.Equal(t, "gpt-5.6-sol", assistant.Model)
+	usage := gjson.ParseBytes(assistant.TokenUsage)
+	assert.Equal(t, int64(18621), usage.Get("input_tokens").Int())
+	assert.Equal(t, int64(15), usage.Get("output_tokens").Int())
+	assert.Equal(t, int64(0), usage.Get("cache_read_input_tokens").Int())
+	assert.False(t, usage.Get("cache_creation_input_tokens").Exists())
+
+	assert.Equal(t, 15, assistant.OutputTokens)
+	assert.True(t, assistant.HasOutputTokens)
+	assert.Equal(t, 18621, assistant.ContextTokens)
+	assert.True(t, assistant.HasContextTokens)
+}
+
+// Anthropic-family buckets already carry Anthropic semantics and pass
+// through unchanged.
+func TestAmpProviderParsesAnthropicFamilyUsage(t *testing.T) {
+	msgs := ampUsageThread(t, `
+		{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+		{"role": "assistant", "content": [{"type": "text", "text": "hello"}],
+		 "usage": {"model": "claude-sonnet-4-20250514", "inputTokens": 7,
+			"outputTokens": 87, "maxInputTokens": 968000, "thinkingBudget": 4000,
+			"totalInputTokens": 16050, "cacheReadInputTokens": 15863,
+			"cacheCreationInputTokens": 180}}`)
+
+	require.Equal(t, 2, len(msgs))
+	assistant := msgs[1]
+
+	assert.Equal(t, "claude-sonnet-4-20250514", assistant.Model)
+	usage := gjson.ParseBytes(assistant.TokenUsage)
+	assert.Equal(t, int64(7), usage.Get("input_tokens").Int())
+	assert.Equal(t, int64(87), usage.Get("output_tokens").Int())
+	assert.Equal(t, int64(180), usage.Get("cache_creation_input_tokens").Int())
+	assert.Equal(t, int64(15863), usage.Get("cache_read_input_tokens").Int())
+
+	// 7 + 180 + 15863, matching the thread's own totalInputTokens.
+	assert.Equal(t, 16050, assistant.ContextTokens)
+}
+
+// Older threads omit model entirely. Tokens are still recorded; the
+// buckets keep Amp's own labels because no provider can be determined.
+func TestAmpProviderParsesUsageWithoutModel(t *testing.T) {
+	msgs := ampUsageThread(t, `
+		{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+		{"role": "assistant", "content": [{"type": "text", "text": "hello"}],
+		 "usage": {"inputTokens": 9, "outputTokens": 156, "maxInputTokens": 400000,
+			"thinkingBudget": 4000, "totalInputTokens": 13267,
+			"cacheReadInputTokens": 0, "cacheCreationInputTokens": 13258}}`)
+
+	require.Equal(t, 2, len(msgs))
+	assistant := msgs[1]
+
+	assert.Empty(t, assistant.Model)
+	usage := gjson.ParseBytes(assistant.TokenUsage)
+	assert.Equal(t, int64(9), usage.Get("input_tokens").Int())
+	assert.Equal(t, int64(13258), usage.Get("cache_creation_input_tokens").Int())
+	assert.Equal(t, 13267, assistant.ContextTokens)
+	assert.True(t, assistant.HasContextTokens)
+}
+
+// A fully cached prompt reports inputTokens as 0. Presence must come
+// from the fields, not from a non-zero value.
+func TestAmpProviderParsesFullyCachedUsage(t *testing.T) {
+	msgs := ampUsageThread(t, `
+		{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+		{"role": "assistant", "content": [{"type": "text", "text": "hello"}],
+		 "usage": {"model": "gpt-5.6-sol", "inputTokens": 0, "outputTokens": 33,
+			"totalInputTokens": 18655, "cacheReadInputTokens": 17920,
+			"cacheCreationInputTokens": 735}}`)
+
+	assistant := msgs[1]
+	assert.True(t, assistant.HasContextTokens)
+	assert.Equal(t, 18655, assistant.ContextTokens)
+}
+
+// Assistant messages without a usage object are normal, not corruption.
+func TestAmpProviderParsesMessageWithoutUsage(t *testing.T) {
+	msgs := ampUsageThread(t, `
+		{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+		{"role": "assistant", "content": [{"type": "text", "text": "hello"}]}`)
+
+	require.Equal(t, 2, len(msgs))
+	assistant := msgs[1]
+
+	assert.Empty(t, assistant.Model)
+	assert.Nil(t, assistant.TokenUsage)
+	assert.False(t, assistant.HasContextTokens)
+	assert.False(t, assistant.HasOutputTokens)
+}
+
+// A thread may switch models. Each inference keeps its own, and session
+// totals take peak context with summed output.
+func TestAmpProviderParsesMixedModelsAndAggregates(t *testing.T) {
+	content := `{
+		"v": 1,
+		"id": "T-019ca26f-5555-6666-7777-888888888888",
+		"created": 1704067200000,
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+			{"role": "assistant", "content": [{"type": "text", "text": "first"}],
+			 "usage": {"model": "gpt-5.6-sol", "inputTokens": 0, "outputTokens": 100,
+				"cacheReadInputTokens": 0, "cacheCreationInputTokens": 5000}},
+			{"role": "user", "content": [{"type": "text", "text": "more"}]},
+			{"role": "assistant", "content": [{"type": "text", "text": "second"}],
+			 "usage": {"model": "claude-sonnet-4-20250514", "inputTokens": 10,
+				"outputTokens": 200, "cacheReadInputTokens": 8000,
+				"cacheCreationInputTokens": 40}}
+		]
+	}`
+
+	sess, msgs, err := runAmpParserTest(t, content)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(msgs))
+
+	assert.Equal(t, "gpt-5.6-sol", msgs[1].Model)
+	assert.Equal(t, "claude-sonnet-4-20250514", msgs[3].Model)
+
+	// gpt-* folds cache creation into input; claude-* keeps it split.
+	first := gjson.ParseBytes(msgs[1].TokenUsage)
+	assert.Equal(t, int64(5000), first.Get("input_tokens").Int())
+	assert.False(t, first.Get("cache_creation_input_tokens").Exists())
+
+	second := gjson.ParseBytes(msgs[3].TokenUsage)
+	assert.Equal(t, int64(10), second.Get("input_tokens").Int())
+	assert.Equal(t, int64(40), second.Get("cache_creation_input_tokens").Int())
+
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 300, sess.TotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+	assert.Equal(t, 8050, sess.PeakContextTokens)
+}
+
+// Each inference carries its own timestamp. Without it a long-lived
+// thread collapses into the daily bucket of its session start.
+func TestAmpProviderParsesPerInferenceTimestamps(t *testing.T) {
+	msgs := ampUsageThread(t, `
+		{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+		{"role": "assistant", "content": [{"type": "text", "text": "day one"}],
+		 "usage": {"model": "gpt-5.6-sol", "timestamp": "2026-08-07T19:25:30.151Z",
+			"inputTokens": 0, "outputTokens": 15, "cacheReadInputTokens": 0,
+			"cacheCreationInputTokens": 100}},
+		{"role": "user", "content": [{"type": "text", "text": "later"}]},
+		{"role": "assistant", "content": [{"type": "text", "text": "day two"}],
+		 "usage": {"model": "gpt-5.6-sol", "timestamp": "2026-08-09T04:10:00.000Z",
+			"inputTokens": 0, "outputTokens": 20, "cacheReadInputTokens": 50,
+			"cacheCreationInputTokens": 10}}`)
+
+	require.Equal(t, 4, len(msgs))
+	assertTimestamp(t, msgs[1].Timestamp,
+		time.Date(2026, 8, 7, 19, 25, 30, 151000000, time.UTC))
+	assertTimestamp(t, msgs[3].Timestamp,
+		time.Date(2026, 8, 9, 4, 10, 0, 0, time.UTC))
+}
+
+// Older threads omit the usage timestamp; those messages keep the zero
+// value and fall back to the session start downstream.
+func TestAmpProviderParsesUsageWithoutTimestamp(t *testing.T) {
+	msgs := ampUsageThread(t, `
+		{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+		{"role": "assistant", "content": [{"type": "text", "text": "hello"}],
+		 "usage": {"model": "claude-sonnet-4-20250514", "inputTokens": 7,
+			"outputTokens": 87, "cacheReadInputTokens": 15863,
+			"cacheCreationInputTokens": 180}}`)
+
+	assert.True(t, msgs[1].Timestamp.IsZero())
+}

--- a/internal/parser/amp_test.go
+++ b/internal/parser/amp_test.go
@@ -770,6 +770,45 @@ func TestAmpProviderParsesFullyCachedUsage(t *testing.T) {
 	assert.Equal(t, 18655, assistant.ContextTokens)
 }
 
+func TestAmpProviderPreservesUsageOnlyAssistantMessage(t *testing.T) {
+	content := `{
+		"v": 1,
+		"id": "T-usage-only-response",
+		"created": 1704067200000,
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+			{"role": "assistant", "content": [],
+			 "usage": {"model": "gpt-5.6-sol", "inputTokens": 0,
+				"outputTokens": 0, "cacheReadInputTokens": 75,
+				"cacheCreationInputTokens": 25}}
+		]
+	}`
+
+	sess, msgs, err := runAmpParserTest(t, content)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 2)
+
+	assistant := msgs[1]
+	assert.Equal(t, RoleAssistant, assistant.Role)
+	assert.Empty(t, assistant.Content)
+	assert.Equal(t, "gpt-5.6-sol", assistant.Model)
+	assert.JSONEq(t, `{
+		"input_tokens": 25,
+		"output_tokens": 0,
+		"cache_read_input_tokens": 75
+	}`, string(assistant.TokenUsage))
+	assert.True(t, assistant.HasContextTokens)
+	assert.Equal(t, 100, assistant.ContextTokens)
+	assert.True(t, assistant.HasOutputTokens)
+	assert.Zero(t, assistant.OutputTokens)
+
+	assert.True(t, sess.HasPeakContextTokens)
+	assert.Equal(t, 100, sess.PeakContextTokens)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Zero(t, sess.TotalOutputTokens)
+}
+
 // Assistant messages without a usage object are normal, not corruption.
 func TestAmpProviderParsesMessageWithoutUsage(t *testing.T) {
 	msgs := ampUsageThread(t, `


### PR DESCRIPTION
Amp thread exports include per-inference usage and timestamps, but AgentsView previously ignored them. Exported Amp sessions now show model-specific token use, cost, and accurate daily attribution.

- Records each inference’s model, timestamp, input/output tokens, and cache buckets.
- Preserves Anthropic-family semantics and treats OpenAI-family cache-creation tokens as uncached input to avoid inflated cost.
- Reprocesses existing Amp sessions with data version 84 and documents the format evidence.

This reads complete thread documents already on disk; it does not fetch server-side threads. Amp exports also omit subagent usage, so those tokens remain unavailable.

Review focus: `internal/parser/amp.go`, `internal/parser/amp_provider.go`, and the Amp fixtures in `internal/parser/amp_test.go`.