### PR TITLE
fix(sync): stop probing macOS protected folders during discovery

### DIFF
--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -261,6 +261,7 @@ func (b localArchiveQueryBackend) SessionUsage(
 			AgentDirs:               b.cfg.AgentDirs,
 			SourceMachines:          b.cfg.SourceMachines,
 			IncludeCwdPrefixes:      b.cfg.SyncIncludeCwdPrefixes,
+			ScanProtectedPaths:      b.cfg.ScanProtectedPaths,
 			Machine:                 b.cfg.LocalMachineName,
 			BlockedResultCategories: b.cfg.ResultContentBlockedCategories,
 		})

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -938,6 +938,7 @@ func (b *localArchiveWriteBackend) DuckDBPushWatch(
 		AgentDirs:               b.appCfg.AgentDirs,
 		SourceMachines:          b.appCfg.SourceMachines,
 		IncludeCwdPrefixes:      b.appCfg.SyncIncludeCwdPrefixes,
+		ScanProtectedPaths:      b.appCfg.ScanProtectedPaths,
 		Machine:                 b.appCfg.LocalMachineName,
 		BlockedResultCategories: b.appCfg.ResultContentBlockedCategories,
 	})
@@ -1056,6 +1057,7 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 		AgentDirs:               b.appCfg.AgentDirs,
 		SourceMachines:          b.appCfg.SourceMachines,
 		IncludeCwdPrefixes:      b.appCfg.SyncIncludeCwdPrefixes,
+		ScanProtectedPaths:      b.appCfg.ScanProtectedPaths,
 		Machine:                 b.appCfg.LocalMachineName,
 		BlockedResultCategories: b.appCfg.ResultContentBlockedCategories,
 	})

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -298,6 +298,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 			AgentDirs:               cfg.AgentDirs,
 			SourceMachines:          cfg.SourceMachines,
 			IncludeCwdPrefixes:      cfg.SyncIncludeCwdPrefixes,
+			ScanProtectedPaths:      cfg.ScanProtectedPaths,
 			Machine:                 cfg.LocalMachineName,
 			BlockedResultCategories: cfg.ResultContentBlockedCategories,
 			Emitter:                 emitter,
@@ -432,7 +433,8 @@ func runServe(cfg config.Config, opts serveOptions) {
 	identityBackfillEngine := engine
 	if identityBackfillEngine == nil {
 		identityBackfillEngine = sync.NewEngine(database, sync.EngineConfig{
-			Machine: cfg.LocalMachineName,
+			Machine:            cfg.LocalMachineName,
+			ScanProtectedPaths: cfg.ScanProtectedPaths,
 		})
 	}
 	go idleTracker.Do(func() {

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -129,6 +129,7 @@ func doParseDiff(cfg ParseDiffConfig) (failed bool) {
 		AgentDirs:               appCfg.AgentDirs,
 		SourceMachines:          appCfg.SourceMachines,
 		IncludeCwdPrefixes:      appCfg.SyncIncludeCwdPrefixes,
+		ScanProtectedPaths:      appCfg.ScanProtectedPaths,
 		Machine:                 appCfg.LocalMachineName,
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
 	})

--- a/cmd/agentsview/session_sync.go
+++ b/cmd/agentsview/session_sync.go
@@ -76,6 +76,7 @@ func syncService(
 		AgentDirs:          cfg.AgentDirs,
 		SourceMachines:     cfg.SourceMachines,
 		IncludeCwdPrefixes: cfg.SyncIncludeCwdPrefixes,
+		ScanProtectedPaths: cfg.ScanProtectedPaths,
 		Machine:            cfg.LocalMachineName,
 	})
 	// Close the engine before the DB so pending debounced signal

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -935,6 +935,7 @@ func coordinateLocalSync(
 		AgentDirs:               appCfg.AgentDirs,
 		SourceMachines:          appCfg.SourceMachines,
 		IncludeCwdPrefixes:      appCfg.SyncIncludeCwdPrefixes,
+		ScanProtectedPaths:      appCfg.ScanProtectedPaths,
 		Machine:                 appCfg.LocalMachineName,
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
 	})

--- a/cmd/agentsview/sync_worker.go
+++ b/cmd/agentsview/sync_worker.go
@@ -362,6 +362,7 @@ func workerEngineConfig(cfg config.Config) sync.EngineConfig {
 		AgentDirs:               cfg.AgentDirs,
 		SourceMachines:          cfg.SourceMachines,
 		IncludeCwdPrefixes:      cfg.SyncIncludeCwdPrefixes,
+		ScanProtectedPaths:      cfg.ScanProtectedPaths,
 		Machine:                 cfg.LocalMachineName,
 		BlockedResultCategories: cfg.ResultContentBlockedCategories,
 	}

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -347,6 +347,7 @@ func ensureFreshData(
 			AgentDirs:          appCfg.AgentDirs,
 			SourceMachines:     appCfg.SourceMachines,
 			IncludeCwdPrefixes: appCfg.SyncIncludeCwdPrefixes,
+			ScanProtectedPaths: appCfg.ScanProtectedPaths,
 			Machine:            appCfg.LocalMachineName,
 		})
 		defer engine.Close()
@@ -372,6 +373,7 @@ func ensureFreshData(
 		AgentDirs:          appCfg.AgentDirs,
 		SourceMachines:     appCfg.SourceMachines,
 		IncludeCwdPrefixes: appCfg.SyncIncludeCwdPrefixes,
+		ScanProtectedPaths: appCfg.ScanProtectedPaths,
 		Machine:            appCfg.LocalMachineName,
 	})
 	defer engine.Close()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,16 @@ description: Release history for AgentsView
 - Add Prime Agent session discovery, Pi-family conversation parsing, fork
   lineage, and RLM-attributed token usage.
 
+**Bug fixes**
+
+- Stop the macOS app from asking for access to Documents, Downloads, Desktop,
+  iCloud Drive, and cloud-provider folders such as Dropbox. Discovery read Git
+  metadata from every recorded session working directory, so a first sync
+  raised a consent prompt for each guarded folder any session had ever run in.
+  Sessions in those folders now keep path-only project identity; set
+  `scan_protected_paths` to opt back in to Git remote, worktree, and branch
+  detail there.
+
 ---
 
 ## 0.40.1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1015,6 +1015,11 @@ macOS then prompts once per folder on the next sync; granting access restores
 full identity for those sessions, and denying leaves them path-only. The option
 has no effect on other platforms.
 
+Enabling the option applies to sessions parsed after the change. Sessions
+already in the archive keep their path-only identity until their session files
+change; run `agentsview sync --full` to reparse the archive and pick up Git
+detail for existing sessions.
+
 ### Large Watch Trees
 
 The recursive watcher has a hard budget of 8192 directories per process. If a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -998,9 +998,11 @@ AgentsView no longer touches these locations during discovery:
   `~/Dropbox`
 - `~/Library/Mobile Documents` (iCloud Drive)
 
-Sessions whose working directory lives in one of these folders keep **path-only
-project identity**: they are still ingested, listed, searched, and grouped by
-path, but they carry no Git remote, worktree relationship, or branch. Sessions
+Sessions whose working directory lives in one of these folders — including
+directories that only reach one through a symlink — keep **path-only project
+identity**: they are still ingested, listed, searched, and grouped by path, but
+they carry no Git remote, worktree relationship, or branch, and their project
+name comes from the path rather than the enclosing Git repository. Sessions
 anywhere else are unaffected.
 
 If you keep code in one of these folders and want the Git detail, opt in:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,7 @@ chart_palette = "agentsview"
 | `chart_palette`                     | Server-wide categorical chart colors: `"agentsview"` (default) or `"matplotlib"`; also configurable under **Settings > Appearance**                                                                                                                  |
 | `[proxy]`                           | Managed proxy configuration table — see [Remote Access](/remote-access/)                                                                                                                                                                             |
 | `disable_update_check`              | Disable the automatic update check (see [Privacy](#privacy-and-telemetry))                                                                                                                                                                           |
+| `scan_protected_paths`              | Allow Git discovery inside macOS privacy-protected folders, accepting one consent prompt per folder — see [macOS Protected Folders](#macos-protected-folders)                                                                                        |
 | `[pg]`                              | PostgreSQL sync configuration — see [PostgreSQL Sync](/pg-sync/)                                                                                                                                                                                     |
 | `[duckdb]`                          | DuckDB mirror configuration — see [DuckDB Mirror](/duckdb/)                                                                                                                                                                                          |
 | `[vector]`                          | Opt-in semantic-search index; model settings live in `[vector.embeddings]`, named endpoints in `[vector.embeddings.servers.<name>]`, embedding schedule in `[vector.embed]` — see [Semantic Search](/semantic-search/#enabling-vector) for every key |
@@ -979,6 +980,38 @@ Notes:
   sessions explicitly with `agentsview prune`.
 - Remote-host sync is unaffected: the prefixes describe local paths, so they are
   not applied to sessions pulled from `[[remote_hosts]]` entries.
+
+### macOS Protected Folders
+
+To label a session with its Git remote, worktree, and branch, AgentsView reads
+Git metadata from the session's recorded working directory. On macOS some
+locations are guarded by a privacy consent prompt, and reading inside one makes
+macOS attribute the request to the AgentsView app and ask the user for access.
+Because the first sync walks every session in the archive at once, this produced
+a burst of prompts at first launch for folders the user never pointed AgentsView
+at.
+
+AgentsView no longer touches these locations during discovery:
+
+- `~/Desktop`, `~/Documents`, `~/Downloads`, `~/Movies`, `~/Music`, `~/Pictures`
+- `~/Library/CloudStorage` (Dropbox, OneDrive, Google Drive, Box) and
+  `~/Dropbox`
+- `~/Library/Mobile Documents` (iCloud Drive)
+
+Sessions whose working directory lives in one of these folders keep **path-only
+project identity**: they are still ingested, listed, searched, and grouped by
+path, but they carry no Git remote, worktree relationship, or branch. Sessions
+anywhere else are unaffected.
+
+If you keep code in one of these folders and want the Git detail, opt in:
+
+```toml
+scan_protected_paths = true
+```
+
+macOS then prompts once per folder on the next sync; granting access restores
+full identity for those sessions, and denying leaves them path-only. The option
+has no effect on other platforms.
 
 ### Large Watch Trees
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -546,6 +546,16 @@ type Config struct {
 	// paths.
 	SyncIncludeCwdPrefixes []string `json:"-" toml:"sync_include_cwd_prefixes"`
 
+	// ScanProtectedPaths allows local Git discovery to read working
+	// directories inside macOS locations guarded by a TCC consent prompt
+	// (Documents, Downloads, Desktop, iCloud Drive, and cloud-provider
+	// folders such as Dropbox). It defaults to false so a first sync never
+	// asks for access to folders the user did not point us at; sessions
+	// there keep path-only project identity instead of Git remote,
+	// worktree, and branch detail. Setting it accepts one macOS prompt per
+	// location in exchange for that detail. No effect off macOS.
+	ScanProtectedPaths bool `json:"-" toml:"scan_protected_paths"`
+
 	// EventsCoalesceInterval is the minimum wall-clock time between
 	// SSE data_changed broadcasts to connected clients. Emits that
 	// arrive within this window after a prior broadcast are coalesced
@@ -1084,6 +1094,7 @@ func (c *Config) applyConfigTOML(data string) error {
 		Proxy                          ProxyConfig                `toml:"proxy"`
 		WatchExcludePatterns           []string                   `toml:"watch_exclude_patterns"`
 		SyncIncludeCwdPrefixes         []string                   `toml:"sync_include_cwd_prefixes"`
+		ScanProtectedPaths             bool                       `toml:"scan_protected_paths"`
 		ResultContentBlockedCategories []string                   `toml:"result_content_blocked_categories"`
 		Terminal                       TerminalConfig             `toml:"terminal"`
 		AuthToken                      string                     `toml:"auth_token"`
@@ -1165,6 +1176,9 @@ func (c *Config) applyConfigTOML(data string) error {
 	}
 	if file.SyncIncludeCwdPrefixes != nil {
 		c.SyncIncludeCwdPrefixes = file.SyncIncludeCwdPrefixes
+	}
+	if file.ScanProtectedPaths {
+		c.ScanProtectedPaths = true
 	}
 	if file.ResultContentBlockedCategories != nil {
 		c.ResultContentBlockedCategories = file.ResultContentBlockedCategories

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -10,9 +10,11 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"unicode"
 )
 
@@ -807,6 +809,10 @@ func IsAutomountNamespacePath(goos, p string) bool {
 			return true
 		}
 	}
+	if set := registeredAutomountPrefixes.Load(); set != nil &&
+		matchAutomountPrefixes(p, set.folded) {
+		return true
+	}
 	return false
 }
 
@@ -822,6 +828,58 @@ func IsCanonicalAutomountNamespacePath(goos, p string) bool {
 	}
 	for _, ns := range [...]string{"/home", "/net", "/Network/Servers"} {
 		if p == ns || strings.HasPrefix(p, ns+"/") {
+			return true
+		}
+	}
+	if set := registeredAutomountPrefixes.Load(); set != nil &&
+		matchAutomountPrefixes(p, set.canonical) {
+		return true
+	}
+	return false
+}
+
+// automountPrefixSet holds autofs mount prefixes discovered from the live
+// mount table, each with a trailing separator: canonical as reported, folded
+// for the case-insensitive broad predicate.
+type automountPrefixSet struct {
+	canonical []string
+	folded    []string
+}
+
+var registeredAutomountPrefixes atomic.Pointer[automountPrefixSet]
+
+// RegisterAutomountPrefixes records autofs-managed mount prefixes discovered
+// from the host's mount table (trailing separator, data-volume prefix
+// already stripped). The fixed namespaces above cover macOS's default map
+// entries; custom mounts such as /corp/home are host-specific and only
+// discoverable live, and paths inside them must classify as automount so
+// symlinked cwds, siblings, and gitfile targets cannot reach Lstat there.
+func RegisterAutomountPrefixes(prefixes []string) {
+	set := &automountPrefixSet{}
+	for _, prefix := range prefixes {
+		if prefix == "" {
+			continue
+		}
+		set.canonical = append(set.canonical, prefix)
+		set.folded = append(set.folded, strings.ToLower(prefix))
+	}
+	registeredAutomountPrefixes.Store(set)
+}
+
+// RegisteredAutomountPrefixes returns the currently registered canonical
+// prefixes so tests can restore them after overriding.
+func RegisteredAutomountPrefixes() []string {
+	set := registeredAutomountPrefixes.Load()
+	if set == nil {
+		return nil
+	}
+	return slices.Clone(set.canonical)
+}
+
+func matchAutomountPrefixes(p string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(p, prefix) ||
+			p+string(filepath.Separator) == prefix {
 			return true
 		}
 	}

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -854,6 +854,96 @@ func IsProtectedUserDataPath(goos, home, p string) bool {
 	return false
 }
 
+// maxProtectedPathLinkHops bounds symlink resolution in
+// ResolvesIntoProtectedUserDataPath. Hitting the bound treats the path as
+// protected, so a link loop fails toward skipping the probe rather than
+// looping forever or letting the caller resolve the loop itself.
+const maxProtectedPathLinkHops = 40
+
+// ResolvesIntoProtectedUserDataPath reports whether p denotes a location
+// inside a macOS TCC-protected user data folder once symlinks are followed.
+// IsProtectedUserDataPath alone compares lexically, so a working directory
+// like ~/code/proj where ~/code links into ~/Documents would pass it and the
+// caller's own Stat or EvalSymlinks would then reach into the protected
+// folder. This walk resolves one component at a time and checks every
+// candidate lexically before touching it with Lstat, so answering the
+// question never enters a protected location itself. Unresolvable links are
+// treated as protected; a missing path component means nothing beyond it can
+// be opened, so the remainder is reported unprotected.
+func ResolvesIntoProtectedUserDataPath(goos, home, p string) bool {
+	if goos != "darwin" || strings.TrimSpace(home) == "" || !filepath.IsAbs(p) {
+		return false
+	}
+	// Compare against the symlink-resolved home too: once the walk hops
+	// through a link, it continues on resolved prefixes, and a home behind
+	// a symlinked ancestor (e.g. /var -> /private/var) would never match
+	// the unresolved form lexically. Resolving home itself only stats its
+	// ancestors, which are never protected locations.
+	homes := []string{home}
+	if resolved, err := filepath.EvalSymlinks(home); err == nil &&
+		filepath.Clean(resolved) != filepath.Clean(home) {
+		homes = append(homes, resolved)
+	}
+	return resolvesIntoProtectedUserData(goos, homes, p, 0)
+}
+
+func protectedUnderAnyHome(goos string, homes []string, p string) bool {
+	for _, home := range homes {
+		if IsProtectedUserDataPath(goos, home, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvesIntoProtectedUserData(
+	goos string, homes []string, p string, hops int,
+) bool {
+	if hops > maxProtectedPathLinkHops {
+		return true
+	}
+	if protectedUnderAnyHome(goos, homes, p) {
+		return true
+	}
+	rest := splitAbsPathComponents(p)
+	current := string(filepath.Separator)
+	for i, component := range rest {
+		next := filepath.Join(current, component)
+		if protectedUnderAnyHome(goos, homes, next) {
+			return true
+		}
+		info, err := os.Lstat(next)
+		if err != nil {
+			return false
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(next)
+			if err != nil {
+				return true
+			}
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(current, target)
+			}
+			resolved := filepath.Join(
+				append([]string{target}, rest[i+1:]...)...,
+			)
+			return resolvesIntoProtectedUserData(goos, homes, resolved, hops+1)
+		}
+		current = next
+	}
+	return false
+}
+
+func splitAbsPathComponents(p string) []string {
+	trimmed := strings.TrimPrefix(
+		filepath.Clean(p), string(filepath.Separator),
+	)
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, string(filepath.Separator))
+}
+
 func resolveLiveRootPath(cleaned string) (string, bool) {
 	if IsAutomountNamespacePath(runtime.GOOS, cleaned) {
 		return "", false

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -799,12 +799,34 @@ func IsAutomountNamespacePath(goos, p string) bool {
 	if goos != "darwin" {
 		return false
 	}
+	p = trimDataVolumePrefix(p)
 	for _, ns := range [...]string{"/home", "/net", "/Network/Servers"} {
 		if p == ns || strings.HasPrefix(p, ns+"/") {
 			return true
 		}
 	}
 	return false
+}
+
+// dataVolumePrefix is the APFS data-volume mount point. Since macOS Catalina
+// the writable system firmlinks user data there, so
+// /System/Volumes/Data/Users/me/Documents is the physical spelling of
+// ~/Documents and /System/Volumes/Data/home is the autofs home map.
+// Firmlinks are not symlinks — Lstat reports a plain directory — so only
+// lexical canonicalization can equate the two spellings.
+const dataVolumePrefix = "/System/Volumes/Data"
+
+// trimDataVolumePrefix strips the data-volume firmlink prefix so the
+// physical spelling of a path compares equal to its canonical form. Purely
+// lexical; never touches the filesystem.
+func trimDataVolumePrefix(p string) string {
+	if p == dataVolumePrefix {
+		return "/"
+	}
+	if strings.HasPrefix(p, dataVolumePrefix+"/") {
+		return p[len(dataVolumePrefix):]
+	}
+	return p
 }
 
 // protectedUserDataDirs are home-relative locations macOS guards behind a TCC
@@ -842,10 +864,15 @@ func IsProtectedUserDataPath(goos, home, p string) bool {
 	if goos != "darwin" || strings.TrimSpace(home) == "" || !filepath.IsAbs(p) {
 		return false
 	}
-	cleaned := strings.ToLower(filepath.Clean(p))
+	// Strip the data-volume firmlink prefix from both sides so the
+	// physical spelling (/System/Volumes/Data/Users/...) matches a home
+	// recorded in either form. Comparison folds case afterwards because
+	// the startup volume is case-insensitive by default.
+	cleaned := strings.ToLower(trimDataVolumePrefix(filepath.Clean(p)))
 	for _, dir := range protectedUserDataDirs {
 		root := strings.ToLower(filepath.Join(
-			filepath.Clean(home), filepath.FromSlash(dir),
+			trimDataVolumePrefix(filepath.Clean(home)),
+			filepath.FromSlash(dir),
 		))
 		if cleaned == root ||
 			strings.HasPrefix(cleaned, root+string(filepath.Separator)) {

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -896,9 +896,22 @@ func protectedUnderAnyHome(goos string, homes []string, p string) bool {
 	return false
 }
 
+// osLstat is indirected through a var so tests can assert the resolver never
+// touches a namespace it must stay out of. Production code always uses
+// os.Lstat via this binding.
+var osLstat = os.Lstat
+
 func resolvesIntoProtectedUserData(
 	goos string, homes []string, p string, hops int,
 ) bool {
+	// Never walk an automounter namespace: Lstat on /home, /net, or
+	// /Network/Servers wakes automountd on every call (see
+	// IsAutomountNamespacePath), and nothing there is protected user data.
+	// Checked per resolution step so a symlink hopping into the namespace
+	// is refused too, not only a literal /home/... input.
+	if IsAutomountNamespacePath(goos, filepath.Clean(p)) {
+		return false
+	}
 	if hops > maxProtectedPathLinkHops {
 		return true
 	}
@@ -912,7 +925,7 @@ func resolvesIntoProtectedUserData(
 		if protectedUnderAnyHome(goos, homes, next) {
 			return true
 		}
-		info, err := os.Lstat(next)
+		info, err := osLstat(next)
 		if err != nil {
 			return false
 		}

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -918,7 +918,16 @@ const (
 // folder or wakes the automounter itself. Unresolvable links classify as
 // protected; a missing path component means nothing beyond it can be opened,
 // so the remainder is safe.
-func ClassifyLocalPathProbe(goos, home, p string) LocalPathProbeClass {
+//
+// scanProtected mirrors the caller's protected-folder opt-in: when set, the
+// walk continues resolving through protected prefixes — Lstat inside them is
+// exactly what the caller is about to do anyway — so a symlink hidden behind
+// ~/Documents that leads into an automounter namespace still classifies as
+// automount. The opt-in lifts consent prompts, never automountd wakeups.
+// Without it the walk stops at the first protected candidate, untouched.
+func ClassifyLocalPathProbe(
+	goos, home, p string, scanProtected bool,
+) LocalPathProbeClass {
 	if goos != "darwin" || !filepath.IsAbs(p) {
 		return LocalPathProbeSafe
 	}
@@ -927,7 +936,9 @@ func ClassifyLocalPathProbe(goos, home, p string) LocalPathProbeClass {
 	if IsAutomountNamespacePath(goos, filepath.Clean(p)) {
 		return LocalPathProbeAutomountNamespace
 	}
-	return classifyLocalPathProbe(goos, probeHomesFor(goos, home), p, 0)
+	return classifyLocalPathProbe(
+		goos, probeHomesFor(goos, home), p, 0, scanProtected,
+	)
 }
 
 // probeHomesCache memoizes probeHomesFor per (goos, home): home never changes
@@ -1025,7 +1036,7 @@ func protectedUnderAnyHome(goos string, homes []string, p string) bool {
 var osLstat = os.Lstat
 
 func classifyLocalPathProbe(
-	goos string, homes []string, p string, hops int,
+	goos string, homes []string, p string, hops int, scanProtected bool,
 ) LocalPathProbeClass {
 	if hops > maxProtectedPathLinkHops {
 		return LocalPathProbeProtectedUserData
@@ -1037,7 +1048,7 @@ func classifyLocalPathProbe(
 	if IsAutomountNamespacePath(goos, cleaned) {
 		return LocalPathProbeAutomountNamespace
 	}
-	if protectedUnderAnyHome(goos, homes, cleaned) {
+	if !scanProtected && protectedUnderAnyHome(goos, homes, cleaned) {
 		return LocalPathProbeProtectedUserData
 	}
 	// Walk raw components in traversal order. current never contains a
@@ -1046,6 +1057,7 @@ func classifyLocalPathProbe(
 	// collapsing ".." lexically up front instead would drop unresolved
 	// components — home/q/../x with q linked into Documents classifies as
 	// home/x while real resolution reaches Documents/x.
+	sawProtected := false
 	rest := splitRawPathComponents(p)
 	current := string(filepath.Separator)
 	for i, component := range rest {
@@ -1061,26 +1073,43 @@ func classifyLocalPathProbe(
 			return LocalPathProbeAutomountNamespace
 		}
 		if protectedUnderAnyHome(goos, homes, next) {
-			return LocalPathProbeProtectedUserData
+			if !scanProtected {
+				return LocalPathProbeProtectedUserData
+			}
+			sawProtected = true
 		}
 		info, err := osLstat(next)
 		if err != nil {
-			return LocalPathProbeSafe
+			return classWithProtected(LocalPathProbeSafe, sawProtected)
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
 			target, err := os.Readlink(next)
 			if err != nil {
 				return LocalPathProbeProtectedUserData
 			}
-			return classifyLocalPathProbe(
+			class := classifyLocalPathProbe(
 				goos, homes,
 				spliceLinkTarget(current, target, rest[i+1:]),
-				hops+1,
+				hops+1, scanProtected,
 			)
+			return classWithProtected(class, sawProtected)
 		}
 		current = next
 	}
-	return LocalPathProbeSafe
+	return classWithProtected(LocalPathProbeSafe, sawProtected)
+}
+
+// classWithProtected upgrades a safe result to protected when the walk
+// traversed a protected prefix on the way: reaching the final target still
+// passes through the guarded folder. Automount always wins — it must stay
+// refused even under the protected-folder opt-in.
+func classWithProtected(
+	class LocalPathProbeClass, sawProtected bool,
+) LocalPathProbeClass {
+	if class == LocalPathProbeSafe && sawProtected {
+		return LocalPathProbeProtectedUserData
+	}
+	return class
 }
 
 // spliceLinkTarget rebuilds the unresolved remainder of a walk after a

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -860,31 +860,49 @@ func IsProtectedUserDataPath(goos, home, p string) bool {
 // looping forever or letting the caller resolve the loop itself.
 const maxProtectedPathLinkHops = 40
 
-// ResolvesIntoProtectedUserDataPath reports whether p denotes a location
-// inside a macOS TCC-protected user data folder once symlinks are followed.
-// IsProtectedUserDataPath alone compares lexically, so a working directory
-// like ~/code/proj where ~/code links into ~/Documents would pass it and the
-// caller's own Stat or EvalSymlinks would then reach into the protected
-// folder. This walk resolves one component at a time and checks every
-// candidate lexically before touching it with Lstat, so answering the
-// question never enters a protected location itself. Unresolvable links are
-// treated as protected; a missing path component means nothing beyond it can
-// be opened, so the remainder is reported unprotected.
-func ResolvesIntoProtectedUserDataPath(goos, home, p string) bool {
-	if goos != "darwin" || strings.TrimSpace(home) == "" || !filepath.IsAbs(p) {
-		return false
+// LocalPathProbeClass classifies whether passive discovery may touch a local
+// path on disk. Safe paths may be probed. Protected paths raise a macOS TCC
+// consent prompt and may only be probed under an explicit user opt-in.
+// Automount-namespace paths wake automountd on any stat and must never be
+// probed, opt-in or not — the two unsafe classes exist so callers cannot
+// treat one override as permission for the other.
+type LocalPathProbeClass int
+
+const (
+	LocalPathProbeSafe LocalPathProbeClass = iota
+	LocalPathProbeProtectedUserData
+	LocalPathProbeAutomountNamespace
+)
+
+// ClassifyLocalPathProbe classifies p for passive probing once symlinks are
+// followed. IsProtectedUserDataPath and IsAutomountNamespacePath compare
+// lexically, so a working directory like ~/code/proj where ~/code links into
+// ~/Documents or /home would pass them and the caller's own Stat or
+// EvalSymlinks would then reach into the guarded location. This walk resolves
+// one component at a time and checks every candidate lexically before
+// touching it with Lstat, so answering the question never enters a protected
+// folder or wakes the automounter itself. Unresolvable links classify as
+// protected; a missing path component means nothing beyond it can be opened,
+// so the remainder is safe.
+func ClassifyLocalPathProbe(goos, home, p string) LocalPathProbeClass {
+	if goos != "darwin" || !filepath.IsAbs(p) {
+		return LocalPathProbeSafe
 	}
 	// Compare against the symlink-resolved home too: once the walk hops
 	// through a link, it continues on resolved prefixes, and a home behind
 	// a symlinked ancestor (e.g. /var -> /private/var) would never match
 	// the unresolved form lexically. Resolving home itself only stats its
-	// ancestors, which are never protected locations.
-	homes := []string{home}
-	if resolved, err := filepath.EvalSymlinks(home); err == nil &&
-		filepath.Clean(resolved) != filepath.Clean(home) {
-		homes = append(homes, resolved)
+	// ancestors, which are never protected locations. An unresolvable home
+	// leaves the protected checks vacuous; automount checks need no home.
+	var homes []string
+	if strings.TrimSpace(home) != "" {
+		homes = []string{home}
+		if resolved, err := filepath.EvalSymlinks(home); err == nil &&
+			filepath.Clean(resolved) != filepath.Clean(home) {
+			homes = append(homes, resolved)
+		}
 	}
-	return resolvesIntoProtectedUserData(goos, homes, p, 0)
+	return classifyLocalPathProbe(goos, homes, p, 0)
 }
 
 func protectedUnderAnyHome(goos string, homes []string, p string) bool {
@@ -901,38 +919,37 @@ func protectedUnderAnyHome(goos string, homes []string, p string) bool {
 // os.Lstat via this binding.
 var osLstat = os.Lstat
 
-func resolvesIntoProtectedUserData(
+func classifyLocalPathProbe(
 	goos string, homes []string, p string, hops int,
-) bool {
-	// Never walk an automounter namespace: Lstat on /home, /net, or
-	// /Network/Servers wakes automountd on every call (see
-	// IsAutomountNamespacePath), and nothing there is protected user data.
-	// Checked per resolution step so a symlink hopping into the namespace
-	// is refused too, not only a literal /home/... input.
+) LocalPathProbeClass {
+	// The automount check runs per resolution step so a symlink hopping
+	// into /home, /net, or /Network/Servers is caught too, not only a
+	// literal input. A namespace prefix always survives filepath.Clean,
+	// so checking the full path covers every intermediate component.
 	if IsAutomountNamespacePath(goos, filepath.Clean(p)) {
-		return false
+		return LocalPathProbeAutomountNamespace
 	}
 	if hops > maxProtectedPathLinkHops {
-		return true
+		return LocalPathProbeProtectedUserData
 	}
 	if protectedUnderAnyHome(goos, homes, p) {
-		return true
+		return LocalPathProbeProtectedUserData
 	}
 	rest := splitAbsPathComponents(p)
 	current := string(filepath.Separator)
 	for i, component := range rest {
 		next := filepath.Join(current, component)
 		if protectedUnderAnyHome(goos, homes, next) {
-			return true
+			return LocalPathProbeProtectedUserData
 		}
 		info, err := osLstat(next)
 		if err != nil {
-			return false
+			return LocalPathProbeSafe
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
 			target, err := os.Readlink(next)
 			if err != nil {
-				return true
+				return LocalPathProbeProtectedUserData
 			}
 			if !filepath.IsAbs(target) {
 				target = filepath.Join(current, target)
@@ -940,11 +957,11 @@ func resolvesIntoProtectedUserData(
 			resolved := filepath.Join(
 				append([]string{target}, rest[i+1:]...)...,
 			)
-			return resolvesIntoProtectedUserData(goos, homes, resolved, hops+1)
+			return classifyLocalPathProbe(goos, homes, resolved, hops+1)
 		}
 		current = next
 	}
-	return false
+	return LocalPathProbeSafe
 }
 
 func splitAbsPathComponents(p string) []string {

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -799,8 +799,10 @@ func IsAutomountNamespacePath(goos, p string) bool {
 	if goos != "darwin" {
 		return false
 	}
-	p = trimDataVolumePrefix(p)
-	for _, ns := range [...]string{"/home", "/net", "/Network/Servers"} {
+	// Comparison folds case: the startup volume is case-insensitive by
+	// default, so /HOME/x resolves to the same autofs map as /home/x.
+	p = strings.ToLower(trimDataVolumePrefix(p))
+	for _, ns := range [...]string{"/home", "/net", "/network/servers"} {
 		if p == ns || strings.HasPrefix(p, ns+"/") {
 			return true
 		}
@@ -817,13 +819,17 @@ func IsAutomountNamespacePath(goos, p string) bool {
 const dataVolumePrefix = "/System/Volumes/Data"
 
 // trimDataVolumePrefix strips the data-volume firmlink prefix so the
-// physical spelling of a path compares equal to its canonical form. Purely
+// physical spelling of a path compares equal to its canonical form. The
+// prefix match folds case (the startup volume is case-insensitive by
+// default) while the returned suffix keeps its original spelling. Purely
 // lexical; never touches the filesystem.
 func trimDataVolumePrefix(p string) string {
-	if p == dataVolumePrefix {
+	lower := strings.ToLower(p)
+	prefix := strings.ToLower(dataVolumePrefix)
+	if lower == prefix {
 		return "/"
 	}
-	if strings.HasPrefix(p, dataVolumePrefix+"/") {
+	if strings.HasPrefix(lower, prefix+"/") {
 		return p[len(dataVolumePrefix):]
 	}
 	return p
@@ -969,10 +975,23 @@ func resolvePathAvoidingAutomount(
 	if IsAutomountNamespacePath(goos, filepath.Clean(p)) {
 		return "", false
 	}
-	rest := splitAbsPathComponents(p)
+	// Raw components with kernel-order ".." handling, mirroring
+	// classifyLocalPathProbe: current never contains a symlink, so
+	// Dir(current) is the correct physical parent.
+	rest := splitRawPathComponents(p)
 	current := string(filepath.Separator)
 	for i, component := range rest {
+		if component == "" || component == "." {
+			continue
+		}
+		if component == ".." {
+			current = filepath.Dir(current)
+			continue
+		}
 		next := filepath.Join(current, component)
+		if IsAutomountNamespacePath(goos, next) {
+			return "", false
+		}
 		info, err := osLstat(next)
 		if err != nil {
 			return "", false
@@ -982,13 +1001,9 @@ func resolvePathAvoidingAutomount(
 			if err != nil {
 				return "", false
 			}
-			if !filepath.IsAbs(target) {
-				target = filepath.Join(current, target)
-			}
-			respliced := filepath.Join(
-				append([]string{target}, rest[i+1:]...)...,
+			return resolvePathAvoidingAutomount(
+				goos, spliceLinkTarget(current, target, rest[i+1:]), hops+1,
 			)
-			return resolvePathAvoidingAutomount(goos, respliced, hops+1)
 		}
 		current = next
 	}
@@ -1012,23 +1027,39 @@ var osLstat = os.Lstat
 func classifyLocalPathProbe(
 	goos string, homes []string, p string, hops int,
 ) LocalPathProbeClass {
-	// The automount check runs per resolution step so a symlink hopping
-	// into /home, /net, or /Network/Servers is caught too, not only a
-	// literal input. A namespace prefix always survives filepath.Clean,
-	// so checking the full path covers every intermediate component.
-	if IsAutomountNamespacePath(goos, filepath.Clean(p)) {
-		return LocalPathProbeAutomountNamespace
-	}
 	if hops > maxProtectedPathLinkHops {
 		return LocalPathProbeProtectedUserData
 	}
-	if protectedUnderAnyHome(goos, homes, p) {
+	// Fast-path lexical checks on the cleaned form; they can only miss
+	// (".." may collapse a guarded midpoint away), and the component walk
+	// below re-checks every candidate in traversal order.
+	cleaned := filepath.Clean(p)
+	if IsAutomountNamespacePath(goos, cleaned) {
+		return LocalPathProbeAutomountNamespace
+	}
+	if protectedUnderAnyHome(goos, homes, cleaned) {
 		return LocalPathProbeProtectedUserData
 	}
-	rest := splitAbsPathComponents(p)
+	// Walk raw components in traversal order. current never contains a
+	// symlink (each hop restarts the walk on the spliced remainder), so a
+	// ".." component resolves to Dir(current) exactly as the kernel would;
+	// collapsing ".." lexically up front instead would drop unresolved
+	// components — home/q/../x with q linked into Documents classifies as
+	// home/x while real resolution reaches Documents/x.
+	rest := splitRawPathComponents(p)
 	current := string(filepath.Separator)
 	for i, component := range rest {
+		if component == "" || component == "." {
+			continue
+		}
+		if component == ".." {
+			current = filepath.Dir(current)
+			continue
+		}
 		next := filepath.Join(current, component)
+		if IsAutomountNamespacePath(goos, next) {
+			return LocalPathProbeAutomountNamespace
+		}
 		if protectedUnderAnyHome(goos, homes, next) {
 			return LocalPathProbeProtectedUserData
 		}
@@ -1041,27 +1072,42 @@ func classifyLocalPathProbe(
 			if err != nil {
 				return LocalPathProbeProtectedUserData
 			}
-			if !filepath.IsAbs(target) {
-				target = filepath.Join(current, target)
-			}
-			resolved := filepath.Join(
-				append([]string{target}, rest[i+1:]...)...,
+			return classifyLocalPathProbe(
+				goos, homes,
+				spliceLinkTarget(current, target, rest[i+1:]),
+				hops+1,
 			)
-			return classifyLocalPathProbe(goos, homes, resolved, hops+1)
 		}
 		current = next
 	}
 	return LocalPathProbeSafe
 }
 
-func splitAbsPathComponents(p string) []string {
-	trimmed := strings.TrimPrefix(
-		filepath.Clean(p), string(filepath.Separator),
-	)
-	if trimmed == "" {
-		return nil
+// spliceLinkTarget rebuilds the unresolved remainder of a walk after a
+// symlink hop. It concatenates without filepath.Join so "." and ".."
+// components survive for the restarted walk to resolve in traversal order.
+// A relative target resolves against current, the link's fully resolved
+// parent directory.
+func spliceLinkTarget(current, target string, rest []string) string {
+	sep := string(filepath.Separator)
+	base := target
+	if !filepath.IsAbs(target) {
+		base = current + sep + target
 	}
-	return strings.Split(trimmed, string(filepath.Separator))
+	if len(rest) == 0 {
+		return base
+	}
+	return base + sep + strings.Join(rest, sep)
+}
+
+// splitRawPathComponents splits a path into raw components, preserving "."
+// and ".." so the walk resolves them in traversal order. Empty components
+// from doubled separators are kept and skipped by the walkers.
+func splitRawPathComponents(p string) []string {
+	return strings.Split(
+		strings.TrimPrefix(p, string(filepath.Separator)),
+		string(filepath.Separator),
+	)
 }
 
 func resolveLiveRootPath(cleaned string) (string, bool) {

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -806,6 +806,54 @@ func IsAutomountNamespacePath(goos, p string) bool {
 	return false
 }
 
+// protectedUserDataDirs are home-relative locations macOS guards behind a TCC
+// consent prompt. Reading a file under one of them from a bundled app makes
+// macOS attribute the request to the bundle and ask the user for access, so a
+// first sync that probes recorded working directories produces prompts the
+// user has no way to connect to anything they did.
+var protectedUserDataDirs = [...]string{
+	"Desktop",
+	"Documents",
+	"Downloads",
+	"Movies",
+	"Music",
+	"Pictures",
+	// Cloud providers publish their files as File Provider domains under
+	// Library/CloudStorage (Dropbox, OneDrive, Google Drive, Box); iCloud
+	// Drive uses Library/Mobile Documents. Both prompt on first access.
+	"Library/CloudStorage",
+	"Library/Mobile Documents",
+	// Dropbox keeps ~/Dropbox pointing into its File Provider domain, so a
+	// recorded working directory names it without mentioning CloudStorage.
+	"Dropbox",
+}
+
+// IsProtectedUserDataPath reports whether p lies inside a macOS TCC-protected
+// user data location under home. Passive discovery skips these paths so
+// importing an archive cannot trigger consent prompts; the user opts in with
+// scan_protected_paths when they want Git-derived identity there instead.
+//
+// Comparison folds case because the startup volume is case-insensitive by
+// default, so a working directory recorded as ~/documents names the protected
+// folder just as ~/Documents does. goos and home are parameters so the
+// predicate is testable off-darwin.
+func IsProtectedUserDataPath(goos, home, p string) bool {
+	if goos != "darwin" || strings.TrimSpace(home) == "" || !filepath.IsAbs(p) {
+		return false
+	}
+	cleaned := strings.ToLower(filepath.Clean(p))
+	for _, dir := range protectedUserDataDirs {
+		root := strings.ToLower(filepath.Join(
+			filepath.Clean(home), filepath.FromSlash(dir),
+		))
+		if cleaned == root ||
+			strings.HasPrefix(cleaned, root+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
 func resolveLiveRootPath(cleaned string) (string, bool) {
 	if IsAutomountNamespacePath(runtime.GOOS, cleaned) {
 		return "", false

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"unicode"
 )
 
@@ -888,21 +889,83 @@ func ClassifyLocalPathProbe(goos, home, p string) LocalPathProbeClass {
 	if goos != "darwin" || !filepath.IsAbs(p) {
 		return LocalPathProbeSafe
 	}
-	// Compare against the symlink-resolved home too: once the walk hops
-	// through a link, it continues on resolved prefixes, and a home behind
-	// a symlinked ancestor (e.g. /var -> /private/var) would never match
-	// the unresolved form lexically. Resolving home itself only stats its
-	// ancestors, which are never protected locations. An unresolvable home
-	// leaves the protected checks vacuous; automount checks need no home.
-	var homes []string
-	if strings.TrimSpace(home) != "" {
-		homes = []string{home}
-		if resolved, err := filepath.EvalSymlinks(home); err == nil &&
-			filepath.Clean(resolved) != filepath.Clean(home) {
-			homes = append(homes, resolved)
-		}
+	// Classify a literal automount input before resolving home, so a
+	// caller probing /home paths never pays for home resolution at all.
+	if IsAutomountNamespacePath(goos, filepath.Clean(p)) {
+		return LocalPathProbeAutomountNamespace
 	}
-	return classifyLocalPathProbe(goos, homes, p, 0)
+	return classifyLocalPathProbe(goos, probeHomesFor(goos, home), p, 0)
+}
+
+// probeHomesCache memoizes probeHomesFor per (goos, home): home never changes
+// within a process, and classification runs for every session parse and
+// identity-cache miss, so resolving home's symlinks each call is waste.
+var probeHomesCache sync.Map
+
+// probeHomesFor returns home plus its symlink-resolved form for lexical
+// comparison: once the classification walk hops through a link, it continues
+// on resolved prefixes, and a home behind a symlinked ancestor (e.g.
+// /var -> /private/var) would never match the unresolved form. Resolution
+// walks component-by-component and aborts if any candidate lands in an
+// automounter namespace, so a home under /home, or linked through /net,
+// never wakes automountd. An unresolvable home leaves the protected checks
+// comparing the raw form only.
+func probeHomesFor(goos, home string) []string {
+	home = strings.TrimSpace(home)
+	if home == "" || !filepath.IsAbs(home) {
+		return nil
+	}
+	key := goos + "\x00" + home
+	if cached, ok := probeHomesCache.Load(key); ok {
+		homes, _ := cached.([]string)
+		return homes
+	}
+	homes := []string{home}
+	if resolved, ok := resolvePathAvoidingAutomount(goos, home, 0); ok &&
+		filepath.Clean(resolved) != filepath.Clean(home) {
+		homes = append(homes, resolved)
+	}
+	probeHomesCache.Store(key, homes)
+	return homes
+}
+
+// resolvePathAvoidingAutomount resolves p's symlinks one component at a
+// time, refusing (ok=false) as soon as any candidate lies inside a macOS
+// automounter namespace so the resolution itself never wakes automountd.
+// Unresolvable paths also report ok=false; callers fall back to the raw form.
+func resolvePathAvoidingAutomount(
+	goos, p string, hops int,
+) (resolved string, ok bool) {
+	if hops > maxProtectedPathLinkHops {
+		return "", false
+	}
+	if IsAutomountNamespacePath(goos, filepath.Clean(p)) {
+		return "", false
+	}
+	rest := splitAbsPathComponents(p)
+	current := string(filepath.Separator)
+	for i, component := range rest {
+		next := filepath.Join(current, component)
+		info, err := osLstat(next)
+		if err != nil {
+			return "", false
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(next)
+			if err != nil {
+				return "", false
+			}
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(current, target)
+			}
+			respliced := filepath.Join(
+				append([]string{target}, rest[i+1:]...)...,
+			)
+			return resolvePathAvoidingAutomount(goos, respliced, hops+1)
+		}
+		current = next
+	}
+	return current, true
 }
 
 func protectedUnderAnyHome(goos string, homes []string, p string) bool {

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -810,6 +810,24 @@ func IsAutomountNamespacePath(goos, p string) bool {
 	return false
 }
 
+// IsCanonicalAutomountNamespacePath reports whether p names an automounter
+// namespace in its canonical spelling only — exact case, no data-volume
+// prefix. IsAutomountNamespacePath accepts alternate spellings too; a caller
+// that defers to a vetting layer which only examines canonical spellings
+// (the parser's resolved-autofs probe) must use this narrower predicate, or
+// alternate spellings would inherit a clearance they never received.
+func IsCanonicalAutomountNamespacePath(goos, p string) bool {
+	if goos != "darwin" {
+		return false
+	}
+	for _, ns := range [...]string{"/home", "/net", "/Network/Servers"} {
+		if p == ns || strings.HasPrefix(p, ns+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 // dataVolumePrefix is the APFS data-volume mount point. Since macOS Catalina
 // the writable system firmlinks user data there, so
 // /System/Volumes/Data/Users/me/Documents is the physical spelling of

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -608,6 +609,34 @@ func TestResolvesIntoProtectedUserDataPath(t *testing.T) {
 				ResolvesIntoProtectedUserDataPath(tt.goos, home, tt.path))
 		})
 	}
+}
+
+// TestResolvesIntoProtectedUserDataPathSkipsAutomountNamespace pins that the
+// resolver never Lstats inside a macOS automounter namespace, whether the
+// input names it directly or a symlink hops into it mid-walk. On darwin that
+// Lstat wakes automountd on every call, which is the CPU storm the automount
+// safeguards elsewhere in identity capture exist to prevent.
+func TestResolvesIntoProtectedUserDataPathSkipsAutomountNamespace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the predicate compares POSIX home paths built with filepath")
+	}
+	home := t.TempDir()
+	require.NoError(t, os.Symlink("/home", filepath.Join(home, "tohome")))
+	orig := osLstat
+	t.Cleanup(func() { osLstat = orig })
+	osLstat = func(path string) (os.FileInfo, error) {
+		if path == "/home" || strings.HasPrefix(path, "/home/") {
+			assert.Fail(t, "automount namespace must not be walked", path)
+		}
+		return orig(path)
+	}
+
+	assert.False(t, ResolvesIntoProtectedUserDataPath(
+		"darwin", home, "/home/user/repo",
+	), "a direct automount path is not protected user data")
+	assert.False(t, ResolvesIntoProtectedUserDataPath(
+		"darwin", home, filepath.Join(home, "tohome", "user", "repo"),
+	), "a symlink into the automount namespace must stop the walk")
 }
 
 // TestNormalizeStoredRootPathSkipsAutomountNamespace pins that on macOS a

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -513,6 +513,57 @@ func TestIsAutomountNamespacePath(t *testing.T) {
 	}
 }
 
+func TestIsProtectedUserDataPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the predicate compares POSIX home paths built with filepath")
+	}
+	const home = "/Users/tester"
+	tests := []struct {
+		name string
+		goos string
+		home string
+		path string
+		want bool
+	}{
+		{"documents child", "darwin", home, home + "/Documents/proj", true},
+		{"documents root", "darwin", home, home + "/Documents", true},
+		{"downloads child", "darwin", home, home + "/Downloads/repo", true},
+		{"desktop child", "darwin", home, home + "/Desktop/repo", true},
+		{"pictures child", "darwin", home, home + "/Pictures/scan", true},
+		{"dropbox child", "darwin", home, home + "/Dropbox/code/app", true},
+		{
+			"cloud storage child", "darwin", home,
+			home + "/Library/CloudStorage/Dropbox-Personal/app", true,
+		},
+		{
+			"icloud drive child", "darwin", home,
+			home + "/Library/Mobile Documents/com~apple~CloudDocs/app", true,
+		},
+		{
+			"case folded child", "darwin", home,
+			home + "/documents/proj", true,
+		},
+		{"unprotected home child", "darwin", home, home + "/src/app", false},
+		{"library sibling", "darwin", home, home + "/Library/Caches/x", false},
+		{
+			"prefix collision documentation", "darwin", home,
+			home + "/Documentation/proj", false,
+		},
+		{"another user documents", "darwin", home, "/Users/other/Documents", false},
+		{"outside home", "darwin", home, "/opt/src/app", false},
+		{"relative path", "darwin", home, "Documents/proj", false},
+		{"empty home", "darwin", "", home + "/Documents/proj", false},
+		{"linux never matches", "linux", home, home + "/Documents/proj", false},
+		{"windows never matches", "windows", home, home + "/Documents/proj", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want,
+				IsProtectedUserDataPath(tt.goos, tt.home, tt.path))
+		})
+	}
+}
+
 // TestNormalizeStoredRootPathSkipsAutomountNamespace pins that on macOS a
 // stored /home/... root path normalizes to its cleaned form without touching
 // the filesystem: resolving it through the automounter is both futile (the

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -636,7 +636,7 @@ func TestClassifyLocalPathProbe(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want,
-				ClassifyLocalPathProbe(tt.goos, tt.home, tt.path))
+				ClassifyLocalPathProbe(tt.goos, tt.home, tt.path, false))
 		})
 	}
 }
@@ -662,11 +662,9 @@ func TestClassifyLocalPathProbeSkipsAutomountNamespace(t *testing.T) {
 	}
 
 	assert.Equal(t, LocalPathProbeAutomountNamespace, ClassifyLocalPathProbe(
-		"darwin", home, "/home/user/repo",
-	), "a direct automount path must classify as automount")
+		"darwin", home, "/home/user/repo", false), "a direct automount path must classify as automount")
 	assert.Equal(t, LocalPathProbeAutomountNamespace, ClassifyLocalPathProbe(
-		"darwin", home, filepath.Join(home, "tohome", "user", "repo"),
-	), "a symlink into the automount namespace must stop the walk")
+		"darwin", home, filepath.Join(home, "tohome", "user", "repo"), false), "a symlink into the automount namespace must stop the walk")
 }
 
 // TestClassifyLocalPathProbeDotDotTraversalOrder pins that ".." resolves in
@@ -707,9 +705,47 @@ func TestClassifyLocalPathProbeDotDotTraversalOrder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want,
-				ClassifyLocalPathProbe("darwin", home, tt.path))
+				ClassifyLocalPathProbe("darwin", home, tt.path, false))
 		})
 	}
+}
+
+// TestClassifyLocalPathProbeOptInStillRefusesAutomount pins that the
+// protected-folder opt-in continues resolution through protected prefixes:
+// a symlink hidden inside ~/Documents that leads into an automounter
+// namespace must classify as automount, because the opt-in lifts consent
+// prompts, never automountd wakeups. Without the opt-in the walk still
+// stops at the protected prefix untouched.
+func TestClassifyLocalPathProbeOptInStillRefusesAutomount(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the predicate compares POSIX home paths built with filepath")
+	}
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "Documents"), 0o755))
+	require.NoError(t, os.Symlink(
+		"/home/user", filepath.Join(home, "Documents", "tohome"),
+	))
+	hidden := filepath.Join(home, "Documents", "tohome", "repo")
+
+	assert.Equal(t, LocalPathProbeAutomountNamespace,
+		ClassifyLocalPathProbe("darwin", home, hidden, true),
+		"opt-in must keep resolving and find the automount target")
+	assert.Equal(t, LocalPathProbeProtectedUserData,
+		ClassifyLocalPathProbe("darwin", home,
+			filepath.Join(home, "Documents", "proj"), true),
+		"a protected-only path stays protected under the opt-in")
+
+	orig := osLstat
+	t.Cleanup(func() { osLstat = orig })
+	osLstat = func(path string) (os.FileInfo, error) {
+		if strings.HasPrefix(path, filepath.Join(home, "Documents")) {
+			assert.Fail(t, "opt-out must not Lstat inside protected", path)
+		}
+		return orig(path)
+	}
+	assert.Equal(t, LocalPathProbeProtectedUserData,
+		ClassifyLocalPathProbe("darwin", home, hidden, false),
+		"without the opt-in the walk stops at the protected prefix")
 }
 
 // TestClassifyLocalPathProbeAutomountHomeNeverResolved pins that resolving
@@ -735,11 +771,9 @@ func TestClassifyLocalPathProbeAutomountHomeNeverResolved(t *testing.T) {
 	}
 
 	assert.Equal(t, LocalPathProbeSafe, ClassifyLocalPathProbe(
-		"darwin", "/home/user", filepath.Join(outside, "elsewhere"),
-	), "an automount home must not derail classifying an unrelated path")
+		"darwin", "/home/user", filepath.Join(outside, "elsewhere"), false), "an automount home must not derail classifying an unrelated path")
 	assert.Equal(t, LocalPathProbeSafe, ClassifyLocalPathProbe(
-		"darwin", linkedHome, filepath.Join(outside, "elsewhere"),
-	), "resolving a home linked through /net must abort, not follow")
+		"darwin", linkedHome, filepath.Join(outside, "elsewhere"), false), "resolving a home linked through /net must abort, not follow")
 }
 
 // TestNormalizeStoredRootPathSkipsAutomountNamespace pins that on macOS a

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -617,6 +617,57 @@ func TestIsCanonicalAutomountNamespacePath(t *testing.T) {
 	}
 }
 
+// TestRegisteredAutomountPrefixes pins that autofs mounts discovered from
+// the host's mount table classify as automount alongside the fixed
+// namespaces: the broad predicate accepts alternate spellings, the canonical
+// predicate only the mount table's exact form, and the classification walk
+// refuses a symlink into a custom mount without Lstat-ing inside it.
+func TestRegisteredAutomountPrefixes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the predicate compares POSIX home paths built with filepath")
+	}
+	orig := RegisteredAutomountPrefixes()
+	t.Cleanup(func() { RegisterAutomountPrefixes(orig) })
+	RegisterAutomountPrefixes([]string{"/corp/home/"})
+
+	assert.True(t, IsAutomountNamespacePath("darwin", "/corp/home/user"),
+		"a custom autofs mount must classify as automount")
+	assert.True(t, IsAutomountNamespacePath("darwin", "/corp/home"),
+		"the custom mount root itself must classify as automount")
+	assert.True(t, IsAutomountNamespacePath("darwin", "/CORP/Home/user"),
+		"case-folded spellings of a custom mount must match")
+	assert.True(t, IsAutomountNamespacePath(
+		"darwin", "/System/Volumes/Data/corp/home/user",
+	), "the data-volume spelling of a custom mount must match")
+	assert.False(t, IsAutomountNamespacePath("darwin", "/corp/homework"),
+		"prefix matching must respect component boundaries")
+	assert.False(t, IsAutomountNamespacePath("linux", "/corp/home/user"),
+		"custom mounts are darwin-only like the fixed namespaces")
+
+	assert.True(t, IsCanonicalAutomountNamespacePath(
+		"darwin", "/corp/home/user",
+	), "the canonical predicate accepts the mount table's exact form")
+	assert.False(t, IsCanonicalAutomountNamespacePath(
+		"darwin", "/CORP/home/user",
+	), "the canonical predicate must not accept case-folded forms")
+
+	home := t.TempDir()
+	require.NoError(t, os.Symlink(
+		"/corp/home/user", filepath.Join(home, "tocorp"),
+	))
+	origLstat := osLstat
+	t.Cleanup(func() { osLstat = origLstat })
+	osLstat = func(path string) (os.FileInfo, error) {
+		if path == "/corp" || strings.HasPrefix(path, "/corp/") {
+			assert.Fail(t, "custom automount must not be walked", path)
+		}
+		return origLstat(path)
+	}
+	assert.Equal(t, LocalPathProbeAutomountNamespace, ClassifyLocalPathProbe(
+		"darwin", home, filepath.Join(home, "tocorp", "repo"), false,
+	), "a symlink into a custom mount must stop the walk")
+}
+
 // TestClassifyLocalPathProbe pins the tri-state classification, including
 // working directories that only reach a protected folder through a symlink,
 // which the lexical predicates alone cannot see.

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -564,6 +564,52 @@ func TestIsProtectedUserDataPath(t *testing.T) {
 	}
 }
 
+// TestResolvesIntoProtectedUserDataPath pins that the resolving variant
+// catches working directories that only reach a protected folder through a
+// symlink, which the lexical predicate alone cannot see.
+func TestResolvesIntoProtectedUserDataPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the predicate compares POSIX home paths built with filepath")
+	}
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(home, "Documents", "proj"), 0o755,
+	))
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "src", "app"), 0o755))
+	require.NoError(t, os.Symlink(
+		filepath.Join(home, "Documents"), filepath.Join(home, "code"),
+	))
+	require.NoError(t, os.Symlink("./Documents", filepath.Join(home, "rel")))
+	require.NoError(t, os.Symlink(
+		filepath.Join(home, "loop"), filepath.Join(home, "loop"),
+	))
+	outside := t.TempDir()
+	require.NoError(t, os.Symlink(outside, filepath.Join(home, "out")))
+
+	tests := []struct {
+		name string
+		goos string
+		path string
+		want bool
+	}{
+		{"lexically protected", "darwin", filepath.Join(home, "Documents", "proj"), true},
+		{"absolute symlink into protected", "darwin", filepath.Join(home, "code", "proj"), true},
+		{"relative symlink into protected", "darwin", filepath.Join(home, "rel", "proj"), true},
+		{"link loop fails protected", "darwin", filepath.Join(home, "loop", "proj"), true},
+		{"plain unprotected", "darwin", filepath.Join(home, "src", "app"), false},
+		{"symlink to unprotected", "darwin", filepath.Join(home, "out", "app"), false},
+		{"missing unprotected path", "darwin", filepath.Join(home, "src", "gone", "deep"), false},
+		{"linux never matches", "linux", filepath.Join(home, "code", "proj"), false},
+		{"relative path", "darwin", "code/proj", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want,
+				ResolvesIntoProtectedUserDataPath(tt.goos, home, tt.path))
+		})
+	}
+}
+
 // TestNormalizeStoredRootPathSkipsAutomountNamespace pins that on macOS a
 // stored /home/... root path normalizes to its cleaned form without touching
 // the filesystem: resolving it through the automounter is both futile (the

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -506,6 +506,9 @@ func TestIsAutomountNamespacePath(t *testing.T) {
 		{"darwin regular path", "darwin", "/Users/user/repo", false},
 		{"darwin data volume home", "darwin", "/System/Volumes/Data/home/user/repo", true},
 		{"darwin data volume net", "darwin", "/System/Volumes/Data/net/host", true},
+		{"darwin mixed case home", "darwin", "/HOME/user/repo", true},
+		{"darwin mixed case network servers", "darwin", "/network/SERVERS/x", true},
+		{"darwin mixed case data volume", "darwin", "/system/Volumes/DATA/home/user", true},
 		{"darwin data volume users is real", "darwin", "/System/Volumes/Data/Users/user/repo", false},
 		{"darwin data volume root is real", "darwin", "/System/Volumes/Data", false},
 		{"linux home is real", "linux", "/home/user/repo", false},
@@ -560,6 +563,10 @@ func TestIsProtectedUserDataPath(t *testing.T) {
 		{
 			"data volume unprotected", "darwin", home,
 			"/System/Volumes/Data" + home + "/src/app", false,
+		},
+		{
+			"mixed case data volume documents", "darwin", home,
+			"/system/volumes/data" + home + "/Documents/proj", true,
 		},
 		{"unprotected home child", "darwin", home, home + "/src/app", false},
 		{"library sibling", "darwin", home, home + "/Library/Caches/x", false},
@@ -660,6 +667,49 @@ func TestClassifyLocalPathProbeSkipsAutomountNamespace(t *testing.T) {
 	assert.Equal(t, LocalPathProbeAutomountNamespace, ClassifyLocalPathProbe(
 		"darwin", home, filepath.Join(home, "tohome", "user", "repo"),
 	), "a symlink into the automount namespace must stop the walk")
+}
+
+// TestClassifyLocalPathProbeDotDotTraversalOrder pins that ".." resolves in
+// traversal order, after the components before it: collapsing it lexically
+// would drop an unresolved symlink component and classify a path as safe
+// while real filesystem resolution reaches a protected location through it.
+func TestClassifyLocalPathProbeDotDotTraversalOrder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the predicate compares POSIX home paths built with filepath")
+	}
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(home, "Documents", "sub"), 0o755,
+	))
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "src", "app"), 0o755))
+	// q links into Documents; home/q/../x resolves through Documents.
+	require.NoError(t, os.Symlink(
+		filepath.Join(home, "Documents", "sub"), filepath.Join(home, "q"),
+	))
+	// Chained relative target: l1 -> "l2/../safe" where l2 links into
+	// Documents; the kernel resolves l2 before applying "..".
+	require.NoError(t, os.Symlink(
+		filepath.Join(home, "Documents", "sub"), filepath.Join(home, "l2"),
+	))
+	require.NoError(t, os.Symlink("l2/../safe", filepath.Join(home, "l1")))
+
+	tests := []struct {
+		name string
+		path string
+		want LocalPathProbeClass
+	}{
+		{"dotdot after symlink into protected", filepath.Join(home, "q") + "/../x", LocalPathProbeProtectedUserData},
+		{"chained relative target with dotdot", filepath.Join(home, "l1"), LocalPathProbeProtectedUserData},
+		{"dotdot through protected midpoint", home + "/Documents/../src/app", LocalPathProbeProtectedUserData},
+		{"dotdot through automount", "/home/../tmp/x", LocalPathProbeAutomountNamespace},
+		{"dotdot through safe components", home + "/src/app/../app", LocalPathProbeSafe},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want,
+				ClassifyLocalPathProbe("darwin", home, tt.path))
+		})
+	}
 }
 
 // TestClassifyLocalPathProbeAutomountHomeNeverResolved pins that resolving

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -565,10 +565,10 @@ func TestIsProtectedUserDataPath(t *testing.T) {
 	}
 }
 
-// TestResolvesIntoProtectedUserDataPath pins that the resolving variant
-// catches working directories that only reach a protected folder through a
-// symlink, which the lexical predicate alone cannot see.
-func TestResolvesIntoProtectedUserDataPath(t *testing.T) {
+// TestClassifyLocalPathProbe pins the tri-state classification, including
+// working directories that only reach a protected folder through a symlink,
+// which the lexical predicates alone cannot see.
+func TestClassifyLocalPathProbe(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("the predicate compares POSIX home paths built with filepath")
 	}
@@ -590,33 +590,37 @@ func TestResolvesIntoProtectedUserDataPath(t *testing.T) {
 	tests := []struct {
 		name string
 		goos string
+		home string
 		path string
-		want bool
+		want LocalPathProbeClass
 	}{
-		{"lexically protected", "darwin", filepath.Join(home, "Documents", "proj"), true},
-		{"absolute symlink into protected", "darwin", filepath.Join(home, "code", "proj"), true},
-		{"relative symlink into protected", "darwin", filepath.Join(home, "rel", "proj"), true},
-		{"link loop fails protected", "darwin", filepath.Join(home, "loop", "proj"), true},
-		{"plain unprotected", "darwin", filepath.Join(home, "src", "app"), false},
-		{"symlink to unprotected", "darwin", filepath.Join(home, "out", "app"), false},
-		{"missing unprotected path", "darwin", filepath.Join(home, "src", "gone", "deep"), false},
-		{"linux never matches", "linux", filepath.Join(home, "code", "proj"), false},
-		{"relative path", "darwin", "code/proj", false},
+		{"lexically protected", "darwin", home, filepath.Join(home, "Documents", "proj"), LocalPathProbeProtectedUserData},
+		{"absolute symlink into protected", "darwin", home, filepath.Join(home, "code", "proj"), LocalPathProbeProtectedUserData},
+		{"relative symlink into protected", "darwin", home, filepath.Join(home, "rel", "proj"), LocalPathProbeProtectedUserData},
+		{"link loop fails protected", "darwin", home, filepath.Join(home, "loop", "proj"), LocalPathProbeProtectedUserData},
+		{"automount namespace", "darwin", home, "/home/user/repo", LocalPathProbeAutomountNamespace},
+		{"automount without home", "darwin", "", "/net/host/share", LocalPathProbeAutomountNamespace},
+		{"plain unprotected", "darwin", home, filepath.Join(home, "src", "app"), LocalPathProbeSafe},
+		{"symlink to unprotected", "darwin", home, filepath.Join(home, "out", "app"), LocalPathProbeSafe},
+		{"missing unprotected path", "darwin", home, filepath.Join(home, "src", "gone", "deep"), LocalPathProbeSafe},
+		{"empty home protected miss", "darwin", "", filepath.Join(home, "Documents", "proj"), LocalPathProbeSafe},
+		{"linux never restricts", "linux", home, filepath.Join(home, "code", "proj"), LocalPathProbeSafe},
+		{"relative path", "darwin", home, "code/proj", LocalPathProbeSafe},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want,
-				ResolvesIntoProtectedUserDataPath(tt.goos, home, tt.path))
+				ClassifyLocalPathProbe(tt.goos, tt.home, tt.path))
 		})
 	}
 }
 
-// TestResolvesIntoProtectedUserDataPathSkipsAutomountNamespace pins that the
-// resolver never Lstats inside a macOS automounter namespace, whether the
-// input names it directly or a symlink hops into it mid-walk. On darwin that
-// Lstat wakes automountd on every call, which is the CPU storm the automount
-// safeguards elsewhere in identity capture exist to prevent.
-func TestResolvesIntoProtectedUserDataPathSkipsAutomountNamespace(t *testing.T) {
+// TestClassifyLocalPathProbeSkipsAutomountNamespace pins that classification
+// never Lstats inside a macOS automounter namespace, whether the input names
+// it directly or a symlink hops into it mid-walk, and that the namespace is
+// reported as its own class rather than as protected user data — the
+// protected-path opt-in must not become permission to wake automountd.
+func TestClassifyLocalPathProbeSkipsAutomountNamespace(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("the predicate compares POSIX home paths built with filepath")
 	}
@@ -631,10 +635,10 @@ func TestResolvesIntoProtectedUserDataPathSkipsAutomountNamespace(t *testing.T) 
 		return orig(path)
 	}
 
-	assert.False(t, ResolvesIntoProtectedUserDataPath(
+	assert.Equal(t, LocalPathProbeAutomountNamespace, ClassifyLocalPathProbe(
 		"darwin", home, "/home/user/repo",
-	), "a direct automount path is not protected user data")
-	assert.False(t, ResolvesIntoProtectedUserDataPath(
+	), "a direct automount path must classify as automount")
+	assert.Equal(t, LocalPathProbeAutomountNamespace, ClassifyLocalPathProbe(
 		"darwin", home, filepath.Join(home, "tohome", "user", "repo"),
 	), "a symlink into the automount namespace must stop the walk")
 }

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -589,6 +589,34 @@ func TestIsProtectedUserDataPath(t *testing.T) {
 	}
 }
 
+// TestIsCanonicalAutomountNamespacePath pins that the canonical predicate
+// accepts only the exact spellings the parser's resolved-autofs probe
+// examines: alternate spellings the broad predicate recognizes must not
+// inherit that vetting.
+func TestIsCanonicalAutomountNamespacePath(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		path string
+		want bool
+	}{
+		{"canonical home", "darwin", "/home/user/repo", true},
+		{"canonical net", "darwin", "/net/host/share", true},
+		{"canonical network servers", "darwin", "/Network/Servers/x", true},
+		{"data volume spelling", "darwin", "/System/Volumes/Data/home/user", false},
+		{"case folded spelling", "darwin", "/HOME/user", false},
+		{"lowercase network servers", "darwin", "/network/servers/x", false},
+		{"regular path", "darwin", "/Users/user/repo", false},
+		{"linux never matches", "linux", "/home/user/repo", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want,
+				IsCanonicalAutomountNamespacePath(tt.goos, tt.path))
+		})
+	}
+}
+
 // TestClassifyLocalPathProbe pins the tri-state classification, including
 // working directories that only reach a protected folder through a symlink,
 // which the lexical predicates alone cannot see.

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -643,6 +643,36 @@ func TestClassifyLocalPathProbeSkipsAutomountNamespace(t *testing.T) {
 	), "a symlink into the automount namespace must stop the walk")
 }
 
+// TestClassifyLocalPathProbeAutomountHomeNeverResolved pins that resolving
+// the home directory for lexical comparison never touches an automounter
+// namespace: a home under /home (autofs user homes) or reached through a
+// /net link must not wake automountd on every classification call.
+func TestClassifyLocalPathProbeAutomountHomeNeverResolved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the predicate compares POSIX home paths built with filepath")
+	}
+	outside := t.TempDir()
+	linkedHome := filepath.Join(outside, "nethome")
+	require.NoError(t, os.Symlink("/net/host/users/x", linkedHome))
+	orig := osLstat
+	t.Cleanup(func() { osLstat = orig })
+	osLstat = func(path string) (os.FileInfo, error) {
+		for _, ns := range []string{"/home", "/net", "/Network/Servers"} {
+			if path == ns || strings.HasPrefix(path, ns+"/") {
+				assert.Fail(t, "automount namespace must not be walked", path)
+			}
+		}
+		return orig(path)
+	}
+
+	assert.Equal(t, LocalPathProbeSafe, ClassifyLocalPathProbe(
+		"darwin", "/home/user", filepath.Join(outside, "elsewhere"),
+	), "an automount home must not derail classifying an unrelated path")
+	assert.Equal(t, LocalPathProbeSafe, ClassifyLocalPathProbe(
+		"darwin", linkedHome, filepath.Join(outside, "elsewhere"),
+	), "resolving a home linked through /net must abort, not follow")
+}
+
 // TestNormalizeStoredRootPathSkipsAutomountNamespace pins that on macOS a
 // stored /home/... root path normalizes to its cleaned form without touching
 // the filesystem: resolving it through the automounter is both futile (the

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -504,7 +504,12 @@ func TestIsAutomountNamespacePath(t *testing.T) {
 		{"darwin prefix collision homework", "darwin", "/homework/repo", false},
 		{"darwin prefix collision netdata", "darwin", "/netdata", false},
 		{"darwin regular path", "darwin", "/Users/user/repo", false},
+		{"darwin data volume home", "darwin", "/System/Volumes/Data/home/user/repo", true},
+		{"darwin data volume net", "darwin", "/System/Volumes/Data/net/host", true},
+		{"darwin data volume users is real", "darwin", "/System/Volumes/Data/Users/user/repo", false},
+		{"darwin data volume root is real", "darwin", "/System/Volumes/Data", false},
 		{"linux home is real", "linux", "/home/user/repo", false},
+		{"linux data volume ignored", "linux", "/System/Volumes/Data/home/user", false},
 		{"windows never matches", "windows", "/home/user", false},
 	}
 	for _, tt := range tests {
@@ -543,6 +548,18 @@ func TestIsProtectedUserDataPath(t *testing.T) {
 		{
 			"case folded child", "darwin", home,
 			home + "/documents/proj", true,
+		},
+		{
+			"data volume documents", "darwin", home,
+			"/System/Volumes/Data" + home + "/Documents/proj", true,
+		},
+		{
+			"data volume home form", "darwin",
+			"/System/Volumes/Data" + home, home + "/Documents/proj", true,
+		},
+		{
+			"data volume unprotected", "darwin", home,
+			"/System/Volumes/Data" + home + "/src/app", false,
 		},
 		{"unprotected home child", "darwin", home, home + "/src/app", false},
 		{"library sibling", "darwin", home, home + "/Library/Caches/x", false},
@@ -600,6 +617,8 @@ func TestClassifyLocalPathProbe(t *testing.T) {
 		{"link loop fails protected", "darwin", home, filepath.Join(home, "loop", "proj"), LocalPathProbeProtectedUserData},
 		{"automount namespace", "darwin", home, "/home/user/repo", LocalPathProbeAutomountNamespace},
 		{"automount without home", "darwin", "", "/net/host/share", LocalPathProbeAutomountNamespace},
+		{"data volume protected", "darwin", home, "/System/Volumes/Data" + home + "/Documents/proj", LocalPathProbeProtectedUserData},
+		{"data volume automount", "darwin", home, "/System/Volumes/Data/home/user/repo", LocalPathProbeAutomountNamespace},
 		{"plain unprotected", "darwin", home, filepath.Join(home, "src", "app"), LocalPathProbeSafe},
 		{"symlink to unprotected", "darwin", home, filepath.Join(home, "out", "app"), LocalPathProbeSafe},
 		{"missing unprotected path", "darwin", home, filepath.Join(home, "src", "gone", "deep"), LocalPathProbeSafe},

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -117,12 +117,13 @@ func defaultProbeGitfileTarget(cleaned string) bool {
 func defaultProbeGitRootForCwd(cleaned string) bool {
 	switch classifyProbePath(cleaned) {
 	case export.LocalPathProbeAutomountNamespace:
-		// A lexically automount path already passed isForeignOSPath's
-		// resolved-autofs probe before this guard runs (or is a gitfile
-		// target, which previous behavior read directly), so only refuse
-		// when a symlink smuggled the walk into the namespace — that hop
-		// is invisible to the lexical checks and never autofs-vetted.
-		return export.IsAutomountNamespacePath(
+		// Only a canonically spelled automount cwd passed isForeignOSPath's
+		// resolved-autofs probe before this guard runs — that function
+		// matches the mount table's canonical prefixes case-sensitively.
+		// Alternate spellings the classifier recognizes (the data-volume
+		// form, case-folded forms) and symlink-smuggled paths were never
+		// autofs-vetted and stay refused.
+		return export.IsCanonicalAutomountNamespacePath(
 			runtime.GOOS, filepath.Clean(cleaned),
 		)
 	case export.LocalPathProbeProtectedUserData:

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -46,19 +46,31 @@ var probeGitRootForCwd = defaultProbeGitRootForCwd
 // cleaned on disk. The walk stats every ancestor, reads .git file contents,
 // lists sibling directories, and execs git — all attributed to the app
 // bundle on macOS, so a cwd inside a TCC-protected folder would raise a
-// consent prompt during passive parsing. An unresolvable home directory
-// leaves the guard inactive rather than guessing at protected roots.
+// consent prompt during passive parsing. The opt-in only lifts the
+// protected-folder restriction; automounter namespaces stay refused because
+// probing them wakes automountd regardless of any consent. An unresolvable
+// home directory leaves the protected checks vacuous rather than guessing.
 func defaultProbeGitRootForCwd(cleaned string) bool {
-	if allowProtectedPathProbes.Load() {
-		return true
-	}
 	home, err := os.UserHomeDir()
 	if err != nil {
+		home = ""
+	}
+	switch export.ClassifyLocalPathProbe(runtime.GOOS, home, cleaned) {
+	case export.LocalPathProbeAutomountNamespace:
+		// A lexically automount path already passed isForeignOSPath's
+		// resolved-autofs probe before this guard runs (or is a gitfile
+		// target, which previous behavior read directly), so only refuse
+		// when a symlink smuggled the walk into the namespace — that hop
+		// is invisible to the lexical checks and never autofs-vetted.
+		return export.IsAutomountNamespacePath(
+			runtime.GOOS, filepath.Clean(cleaned),
+		)
+	case export.LocalPathProbeProtectedUserData:
+		return allowProtectedPathProbes.Load()
+	case export.LocalPathProbeSafe:
 		return true
 	}
-	return !export.ResolvesIntoProtectedUserDataPath(
-		runtime.GOOS, home, cleaned,
-	)
+	return true
 }
 
 var projectMarkers = []string{
@@ -590,6 +602,14 @@ func findGitRepoRootLocal(dir string) (root string, conservative bool) {
 				return dir, false
 			}
 			if info.Mode().IsRegular() {
+				if !gitFileTargetsProbeable(dir, gitPath) {
+					// The gitfile targets a directory the protected-path
+					// policy refuses. Stop at the worktree itself and do
+					// not report a conservative result: escalating to
+					// gitMainRoot would exec git, which reads inside the
+					// refused target.
+					return dir, false
+				}
 				if root := repoRootFromGitFile(dir, gitPath); root != "" {
 					if root == dir {
 						return root, true
@@ -797,6 +817,29 @@ func repoRootFromGitFile(repoDir, gitFilePath string) string {
 	}
 
 	return repoDir
+}
+
+// gitFileTargetsProbeable reports whether the gitdir target recorded in a
+// linked-worktree .git file, and the common directory that target references,
+// may be read under the protected-path policy. Both come from file contents,
+// not from the vetted cwd, so a worktree in an unguarded directory can point
+// at a main repository inside a protected folder; reading commondir, config,
+// or HEAD there would raise the consent prompt the cwd gate prevented.
+// Reading the .git file itself is safe: it lives in the already-vetted dir.
+func gitFileTargetsProbeable(dir, gitPath string) bool {
+	gitDir := readGitDirFromFile(gitPath)
+	if gitDir == "" {
+		// Nothing parseable means no target will be read from here.
+		return true
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(dir, gitDir)
+	}
+	if !probeGitRootForCwd(filepath.Clean(gitDir)) {
+		return false
+	}
+	commonDir := readCommonDir(gitDir)
+	return commonDir == "" || probeGitRootForCwd(commonDir)
 }
 
 func readGitDirFromFile(path string) string {

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,24 +28,30 @@ var (
 	osLstat = os.Lstat
 )
 
+// errRefusedGitEntry marks a .git entry whose symlink target the
+// protected-path policy refuses. Callers stop at the boundary without
+// following the link or escalating to git, which would traverse the same
+// target.
+var errRefusedGitEntry = errors.New(
+	"git entry target refused by protected-path policy",
+)
+
 // statGitEntry types a .git entry without following a refused symlink: it
 // Lstats first, and only follows (via osStat) when the entry is not a link
 // or its link target passes the gitfile-target guard. A refused link
-// reports refused=true so callers stop at the boundary without escalating
-// to git, which would traverse the same target.
-func statGitEntry(gitPath string) (info os.FileInfo, refused bool, err error) {
-	info, err = osLstat(gitPath)
+// returns errRefusedGitEntry; info is non-nil exactly when err is nil.
+func statGitEntry(gitPath string) (os.FileInfo, error) {
+	info, err := osLstat(gitPath)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if info.Mode()&os.ModeSymlink == 0 {
-		return info, false, nil
+		return info, nil
 	}
 	if !probeGitfileTarget(gitPath) {
-		return nil, true, nil
+		return nil, errRefusedGitEntry
 	}
-	info, err = osStat(gitPath)
-	return info, false, err
+	return osStat(gitPath)
 }
 
 // allowProtectedPathProbes lets project extraction probe recorded working
@@ -647,8 +654,8 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 func findGitRepoRootLocal(dir string) (root string, conservative bool) {
 	for {
 		gitPath := filepath.Join(dir, ".git")
-		info, refused, err := statGitEntry(gitPath)
-		if refused {
+		info, err := statGitEntry(gitPath)
+		if errors.Is(err, errRefusedGitEntry) {
 			// A .git symlink into a refused location marks a repo
 			// boundary we must not look through. Stop here without a
 			// conservative result so the caller cannot escalate to git.
@@ -706,9 +713,11 @@ func gitMainRoot(ctx context.Context, dir string) string {
 // candidates must agree on the same root to avoid
 // misattributing unrelated paths.
 func repoRootFromSiblings(dir, cwd string) string {
-	// If dir is itself a repo or worktree, let the normal
-	// upward walk handle it.
-	if _, err := osStat(filepath.Join(dir, ".git")); err == nil {
+	// If dir is itself a repo or worktree, let the normal upward walk
+	// handle it. A refused .git symlink counts too: it is a boundary the
+	// walk stops at, and typing it must not follow the link.
+	if _, err := statGitEntry(filepath.Join(dir, ".git")); err == nil ||
+		errors.Is(err, errRefusedGitEntry) {
 		return ""
 	}
 	entries, err := os.ReadDir(dir)
@@ -731,8 +740,8 @@ func repoRootFromSiblings(dir, cwd string) string {
 			continue
 		}
 		gitPath := filepath.Join(dir, entry.Name(), ".git")
-		info, refused, err := statGitEntry(gitPath)
-		if refused || err != nil {
+		info, err := statGitEntry(gitPath)
+		if err != nil {
 			continue
 		}
 		if info.IsDir() {
@@ -902,11 +911,23 @@ func gitFileTargetsProbeable(dir, gitPath string) bool {
 	if !filepath.IsAbs(gitDir) {
 		gitDir = filepath.Join(dir, gitDir)
 	}
-	if !probeGitfileTarget(filepath.Clean(gitDir)) {
+	gitDir = filepath.Clean(gitDir)
+	if !probeGitfileTarget(gitDir) {
+		return false
+	}
+	// The commondir and config files sit inside vetted directories, but as
+	// symlinks they can lead anywhere; vet the exact file paths
+	// (classification follows links) before the reads that follow —
+	// readCommonDir here, gitConfigCoreBare in repoRootFromGitFile.
+	if !probeGitfileTarget(filepath.Join(gitDir, "commondir")) {
 		return false
 	}
 	commonDir := readCommonDir(gitDir)
-	return commonDir == "" || probeGitfileTarget(commonDir)
+	if commonDir == "" {
+		return true
+	}
+	return probeGitfileTarget(commonDir) &&
+		probeGitfileTarget(filepath.Join(commonDir, "config"))
 }
 
 func readGitDirFromFile(path string) string {

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -440,7 +440,13 @@ func detectAutofsPrefixes() []string {
 	if err != nil {
 		return nil
 	}
-	return parseMountOutputForAutofs(data)
+	prefixes := parseMountOutputForAutofs(data)
+	// Share the discovered prefixes with the probe classifier: custom
+	// autofs mounts such as /corp/home must classify as automount so
+	// symlinked cwds, siblings, and gitfile targets cannot reach Lstat
+	// inside them; only this package can discover them.
+	export.RegisterAutomountPrefixes(prefixes)
+	return prefixes
 }
 
 // parseMountOutputForAutofs extracts the mount points of autofs

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -740,6 +740,15 @@ func repoRootFromSiblings(dir, cwd string) string {
 			continue
 		}
 		gitPath := filepath.Join(dir, entry.Name(), ".git")
+		// Vet before typing: when the existing ancestor is the home
+		// directory, siblings include Documents and the other guarded
+		// folders, and even an Lstat of <sibling>/.git reaches inside
+		// them — and a guarded sibling holding a real .git directory
+		// would flow into deletedChildIsWorktree's ReadDir. The lexical
+		// check answers without touching the filesystem.
+		if !probeGitfileTarget(gitPath) {
+			continue
+		}
 		info, err := statGitEntry(gitPath)
 		if err != nil {
 			continue

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -9,17 +9,57 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
 	gitrepo "go.kenn.io/kit/git/repo"
 	"golang.org/x/sync/singleflight"
+
+	"go.kenn.io/agentsview/internal/export"
 )
 
 // osStat is indirected through a var so tests can intercept stat
 // calls from the git-root walker. Production code always uses
 // os.Stat via this binding.
 var osStat = os.Stat
+
+// allowProtectedPathProbes lets project extraction probe recorded working
+// directories inside macOS TCC-protected locations. It is package-level
+// because parsers extract project names deep inside per-format code with no
+// engine context to consult. The zero value refuses those probes, so a
+// process that never opts in cannot raise a consent prompt from parsing.
+var allowProtectedPathProbes atomic.Bool
+
+// SetAllowProtectedPathProbes sets whether project extraction may probe
+// macOS TCC-protected working directories for git roots. Wired from the
+// scan_protected_paths config option by the sync engine.
+func SetAllowProtectedPathProbes(allow bool) {
+	allowProtectedPathProbes.Store(allow)
+}
+
+// probeGitRootForCwd is indirected through a var so tests can force the
+// guard's decision without building a real protected home layout.
+var probeGitRootForCwd = defaultProbeGitRootForCwd
+
+// defaultProbeGitRootForCwd reports whether the git-root walk may touch
+// cleaned on disk. The walk stats every ancestor, reads .git file contents,
+// lists sibling directories, and execs git — all attributed to the app
+// bundle on macOS, so a cwd inside a TCC-protected folder would raise a
+// consent prompt during passive parsing. An unresolvable home directory
+// leaves the guard inactive rather than guessing at protected roots.
+func defaultProbeGitRootForCwd(cleaned string) bool {
+	if allowProtectedPathProbes.Load() {
+		return true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return true
+	}
+	return !export.ResolvesIntoProtectedUserDataPath(
+		runtime.GOOS, home, cleaned,
+	)
+}
 
 var projectMarkers = []string{
 	"code", "projects", "repos", "src", "work", "dev",
@@ -127,7 +167,8 @@ func extractProjectFromCwdWithBranch(
 	// an unbacked autofs prefix cascades through automountd into
 	// opendirectoryd (/usr/libexec/od_user_homes), so we probe
 	// the prefix once before walking.
-	if filepath.IsAbs(cleaned) && !isForeignOSPath(cwd, cleaned, winPath) {
+	if filepath.IsAbs(cleaned) && !isForeignOSPath(cwd, cleaned, winPath) &&
+		probeGitRootForCwd(cleaned) {
 		if root := findGitRepoRoot(ctx, cleaned); root != "" {
 			name := filepath.Base(root)
 			if isInvalidPathBase(name) {

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -84,7 +84,9 @@ func classifyProbePath(cleaned string) export.LocalPathProbeClass {
 	if err != nil {
 		home = ""
 	}
-	return export.ClassifyLocalPathProbe(runtime.GOOS, home, cleaned)
+	return export.ClassifyLocalPathProbe(
+		runtime.GOOS, home, cleaned, allowProtectedPathProbes.Load(),
+	)
 }
 
 // defaultProbeGitfileTarget reports whether a path taken from gitfile
@@ -939,7 +941,13 @@ func gitFileTargetsProbeable(dir, gitPath string) bool {
 	}
 	commonDir := readCommonDir(gitDir)
 	if commonDir == "" {
-		return true
+		// No commondir means a submodule-style gitdir: the gitdir is the
+		// effective common directory, and the git fallback the caller may
+		// escalate to reads its config and HEAD. Vet them exactly — inside
+		// a vetted directory, a file symlink can still lead into a
+		// guarded folder.
+		return probeGitfileTarget(filepath.Join(gitDir, "config")) &&
+			probeGitfileTarget(filepath.Join(gitDir, "HEAD"))
 	}
 	return probeGitfileTarget(commonDir) &&
 		probeGitfileTarget(filepath.Join(commonDir, "config"))

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -19,10 +19,33 @@ import (
 	"go.kenn.io/agentsview/internal/export"
 )
 
-// osStat is indirected through a var so tests can intercept stat
-// calls from the git-root walker. Production code always uses
-// os.Stat via this binding.
-var osStat = os.Stat
+// osStat and osLstat are indirected through vars so tests can intercept
+// stat calls from the git-root walker. Production code always uses os.Stat
+// and os.Lstat via these bindings.
+var (
+	osStat  = os.Stat
+	osLstat = os.Lstat
+)
+
+// statGitEntry types a .git entry without following a refused symlink: it
+// Lstats first, and only follows (via osStat) when the entry is not a link
+// or its link target passes the gitfile-target guard. A refused link
+// reports refused=true so callers stop at the boundary without escalating
+// to git, which would traverse the same target.
+func statGitEntry(gitPath string) (info os.FileInfo, refused bool, err error) {
+	info, err = osLstat(gitPath)
+	if err != nil {
+		return nil, false, err
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return info, false, nil
+	}
+	if !probeGitfileTarget(gitPath) {
+		return nil, true, nil
+	}
+	info, err = osStat(gitPath)
+	return info, false, err
+}
 
 // allowProtectedPathProbes lets project extraction probe recorded working
 // directories inside macOS TCC-protected locations. It is package-level
@@ -624,7 +647,13 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 func findGitRepoRootLocal(dir string) (root string, conservative bool) {
 	for {
 		gitPath := filepath.Join(dir, ".git")
-		info, err := osStat(gitPath)
+		info, refused, err := statGitEntry(gitPath)
+		if refused {
+			// A .git symlink into a refused location marks a repo
+			// boundary we must not look through. Stop here without a
+			// conservative result so the caller cannot escalate to git.
+			return dir, false
+		}
 		if err == nil {
 			if info.IsDir() {
 				return dir, false
@@ -702,8 +731,8 @@ func repoRootFromSiblings(dir, cwd string) string {
 			continue
 		}
 		gitPath := filepath.Join(dir, entry.Name(), ".git")
-		info, err := osStat(gitPath)
-		if err != nil {
+		info, refused, err := statGitEntry(gitPath)
+		if refused || err != nil {
 			continue
 		}
 		if info.IsDir() {
@@ -714,6 +743,12 @@ func repoRootFromSiblings(dir, cwd string) string {
 			continue
 		}
 		if !info.Mode().IsRegular() {
+			continue
+		}
+		// Sibling gitfiles and their targets get the same vetting as the
+		// upward walk: repoRootFromGitFile reads commondir and config from
+		// whatever the gitfile names, which the deleted cwd never vetted.
+		if !gitFileTargetsProbeable(filepath.Join(dir, entry.Name()), gitPath) {
 			continue
 		}
 		gitDir := readGitDirFromFile(gitPath)

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -14,7 +14,6 @@ import (
 	"time"
 	"unicode"
 
-	gitrepo "go.kenn.io/kit/git/repo"
 	"golang.org/x/sync/singleflight"
 
 	"go.kenn.io/agentsview/internal/export"
@@ -30,8 +29,7 @@ var (
 
 // errRefusedGitEntry marks a .git entry whose symlink target the
 // protected-path policy refuses. Callers stop at the boundary without
-// following the link or escalating to git, which would traverse the same
-// target.
+// following the link.
 var errRefusedGitEntry = errors.New(
 	"git entry target refused by protected-path policy",
 )
@@ -140,8 +138,8 @@ func defaultProbeGitfileTarget(cleaned string) bool {
 
 // defaultProbeGitRootForCwd reports whether the git-root walk may touch
 // cleaned on disk. The walk stats every ancestor, reads .git file contents,
-// lists sibling directories, and execs git — all attributed to the app
-// bundle on macOS, so a cwd inside a TCC-protected folder would raise a
+// and lists sibling directories — all attributed to the app bundle on
+// macOS, so a cwd inside a TCC-protected folder would raise a
 // consent prompt during passive parsing. The opt-in only lifts the
 // protected-folder restriction; automounter namespaces stay refused because
 // probing them wakes automountd regardless of any consent. An unresolvable
@@ -224,26 +222,26 @@ func ExtractProjectFromCwd(cwd string) string {
 func ExtractProjectFromCwdWithBranch(
 	cwd, gitBranch string,
 ) string {
-	return extractProjectFromCwdWithBranch(context.TODO(), cwd, gitBranch)
+	return extractProjectFromCwdWithBranch(cwd, gitBranch)
 }
 
 // ExtractProjectFromCwdWithBranchContext extracts a canonical project name
-// from cwd and optionally git branch metadata using ctx for git-backed
-// repository resolution.
+// from cwd and optionally git branch metadata. The context parameter is
+// retained for compatibility: extraction no longer execs git — passive
+// discovery must not let git follow config-derived paths such as
+// [include] path into locations the probe policy never vetted — so all
+// resolution is filesystem-local and needs no cancellation.
 func ExtractProjectFromCwdWithBranchContext(
-	ctx context.Context, cwd, gitBranch string,
+	_ context.Context, cwd, gitBranch string,
 ) string {
-	return extractProjectFromCwdWithBranch(ctx, cwd, gitBranch)
+	return extractProjectFromCwdWithBranch(cwd, gitBranch)
 }
 
 func extractProjectFromCwdWithBranch(
-	ctx context.Context, cwd, gitBranch string,
+	cwd, gitBranch string,
 ) string {
 	if cwd == "" {
 		return ""
-	}
-	if ctx == nil {
-		ctx = context.TODO()
 	}
 	winPath := looksLikeWindowsPath(cwd)
 	norm := cwd
@@ -266,7 +264,7 @@ func extractProjectFromCwdWithBranch(
 	// the prefix once before walking.
 	if filepath.IsAbs(cleaned) && !isForeignOSPath(cwd, cleaned, winPath) &&
 		probeGitRootForCwd(cleaned) {
-		if root := findGitRepoRoot(ctx, cleaned); root != "" {
+		if root := findGitRepoRoot(cleaned); root != "" {
 			name := filepath.Base(root)
 			if isInvalidPathBase(name) {
 				return ""
@@ -629,7 +627,7 @@ func isInvalidPathBase(name string) bool {
 // and linked worktrees/submodules (.git file). When cwd no longer
 // exists on disk, sibling directories are checked for worktree
 // .git files that can reveal the true repo root.
-func findGitRepoRoot(ctx context.Context, cwd string) string {
+func findGitRepoRoot(cwd string) string {
 	if cwd == "" {
 		return ""
 	}
@@ -648,7 +646,6 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 		cwdMissing = true
 		dir = filepath.Dir(dir)
 	}
-	startDir := dir
 
 	// When the original path is gone, walk up to the first
 	// existing ancestor and check its children for worktree
@@ -672,15 +669,7 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 		}
 	}
 
-	root, conservative := findGitRepoRootLocal(dir)
-	if root != "" && !conservative {
-		return root
-	}
-	if !cwdMissing {
-		if gitRoot := gitMainRoot(ctx, startDir); gitRoot != "" {
-			return gitRoot
-		}
-	}
+	root, _ := findGitRepoRootLocal(dir)
 	return root
 }
 
@@ -690,8 +679,7 @@ func findGitRepoRootLocal(dir string) (root string, conservative bool) {
 		info, err := statGitEntry(gitPath)
 		if errors.Is(err, errRefusedGitEntry) {
 			// A .git symlink into a refused location marks a repo
-			// boundary we must not look through. Stop here without a
-			// conservative result so the caller cannot escalate to git.
+			// boundary we must not look through.
 			return dir, false
 		}
 		if err == nil {
@@ -701,10 +689,7 @@ func findGitRepoRootLocal(dir string) (root string, conservative bool) {
 			if info.Mode().IsRegular() {
 				if !gitFileTargetsProbeable(dir, gitPath) {
 					// The gitfile targets a directory the protected-path
-					// policy refuses. Stop at the worktree itself and do
-					// not report a conservative result: escalating to
-					// gitMainRoot would exec git, which reads inside the
-					// refused target.
+					// policy refuses. Stop at the worktree itself.
 					return dir, false
 				}
 				if root := repoRootFromGitFile(dir, gitPath); root != "" {
@@ -725,19 +710,6 @@ func findGitRepoRootLocal(dir string) (root string, conservative bool) {
 		}
 		dir = parent
 	}
-}
-
-func gitMainRoot(ctx context.Context, dir string) string {
-	if ctx == nil || dir == "" {
-		return ""
-	}
-	opCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	root, err := gitrepo.MainRoot(opCtx, dir)
-	if err != nil {
-		return ""
-	}
-	return root
 }
 
 // repoRootFromSiblings checks child directories of dir for
@@ -973,10 +945,9 @@ func gitFileTargetsProbeable(dir, gitPath string) bool {
 	commonDir := readCommonDir(gitDir)
 	if commonDir == "" {
 		// No commondir means a submodule-style gitdir: the gitdir is the
-		// effective common directory, and the git fallback the caller may
-		// escalate to reads its config and HEAD. Vet them exactly — inside
-		// a vetted directory, a file symlink can still lead into a
-		// guarded folder.
+		// effective common directory holding config and HEAD. Vet them
+		// exactly — inside a vetted directory, a file symlink can still
+		// lead into a guarded folder.
 		return probeGitfileTarget(filepath.Join(gitDir, "config")) &&
 			probeGitfileTarget(filepath.Join(gitDir, "HEAD"))
 	}

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -38,9 +38,41 @@ func SetAllowProtectedPathProbes(allow bool) {
 	allowProtectedPathProbes.Store(allow)
 }
 
-// probeGitRootForCwd is indirected through a var so tests can force the
-// guard's decision without building a real protected home layout.
-var probeGitRootForCwd = defaultProbeGitRootForCwd
+// probeGitRootForCwd and probeGitfileTarget are indirected through vars so
+// tests can force the guards' decisions without building a real protected
+// home layout.
+var (
+	probeGitRootForCwd = defaultProbeGitRootForCwd
+	probeGitfileTarget = defaultProbeGitfileTarget
+)
+
+// classifyProbePath classifies cleaned for the local process: real GOOS,
+// real home directory. An unresolvable home leaves the protected checks
+// vacuous rather than guessing at protected roots.
+func classifyProbePath(cleaned string) export.LocalPathProbeClass {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+	return export.ClassifyLocalPathProbe(runtime.GOOS, home, cleaned)
+}
+
+// defaultProbeGitfileTarget reports whether a path taken from gitfile
+// contents — a gitdir, a common directory, or the .git entry itself when it
+// is a symlink — may be read. Unlike the cwd guard, automount namespaces are
+// refused outright: targets never pass isForeignOSPath's resolved-autofs
+// probe, so reading one would wake automountd unvetted.
+func defaultProbeGitfileTarget(cleaned string) bool {
+	switch classifyProbePath(cleaned) {
+	case export.LocalPathProbeAutomountNamespace:
+		return false
+	case export.LocalPathProbeProtectedUserData:
+		return allowProtectedPathProbes.Load()
+	case export.LocalPathProbeSafe:
+		return true
+	}
+	return true
+}
 
 // defaultProbeGitRootForCwd reports whether the git-root walk may touch
 // cleaned on disk. The walk stats every ancestor, reads .git file contents,
@@ -51,11 +83,7 @@ var probeGitRootForCwd = defaultProbeGitRootForCwd
 // probing them wakes automountd regardless of any consent. An unresolvable
 // home directory leaves the protected checks vacuous rather than guessing.
 func defaultProbeGitRootForCwd(cleaned string) bool {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		home = ""
-	}
-	switch export.ClassifyLocalPathProbe(runtime.GOOS, home, cleaned) {
+	switch classifyProbePath(cleaned) {
 	case export.LocalPathProbeAutomountNamespace:
 		// A lexically automount path already passed isForeignOSPath's
 		// resolved-autofs probe before this guard runs (or is a gitfile
@@ -824,9 +852,13 @@ func repoRootFromGitFile(repoDir, gitFilePath string) string {
 // may be read under the protected-path policy. Both come from file contents,
 // not from the vetted cwd, so a worktree in an unguarded directory can point
 // at a main repository inside a protected folder; reading commondir, config,
-// or HEAD there would raise the consent prompt the cwd gate prevented.
-// Reading the .git file itself is safe: it lives in the already-vetted dir.
+// or HEAD there would raise the consent prompt the cwd gate prevented. The
+// .git entry itself is vetted first: it lives in the already-vetted dir, but
+// as a symlink it can lead anywhere, and reading it would follow the link.
 func gitFileTargetsProbeable(dir, gitPath string) bool {
+	if !probeGitfileTarget(gitPath) {
+		return false
+	}
 	gitDir := readGitDirFromFile(gitPath)
 	if gitDir == "" {
 		// Nothing parseable means no target will be read from here.
@@ -835,11 +867,11 @@ func gitFileTargetsProbeable(dir, gitPath string) bool {
 	if !filepath.IsAbs(gitDir) {
 		gitDir = filepath.Join(dir, gitDir)
 	}
-	if !probeGitRootForCwd(filepath.Clean(gitDir)) {
+	if !probeGitfileTarget(filepath.Clean(gitDir)) {
 		return false
 	}
 	commonDir := readCommonDir(gitDir)
-	return commonDir == "" || probeGitRootForCwd(commonDir)
+	return commonDir == "" || probeGitfileTarget(commonDir)
 }
 
 func readGitDirFromFile(path string) string {

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -849,6 +849,12 @@ func deletedChildIsWorktree(
 		return false
 	}
 	wtDir := filepath.Join(repoRoot, ".git", "worktrees")
+	// The .git entry was vetted by the sibling scan, but worktrees inside
+	// a real .git directory can itself be a symlink; vet the exact path
+	// (classification follows links) before enumerating through it.
+	if !probeGitfileTarget(wtDir) {
+		return false
+	}
 	entries, err := os.ReadDir(wtDir)
 	if err != nil {
 		return false

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -89,6 +89,38 @@ func classifyProbePath(cleaned string) export.LocalPathProbeClass {
 	)
 }
 
+// automountCwdProbeAllowed decides whether an automount-classified cwd may
+// enter the git-root walk. Canonical spelling alone is not clearance:
+// alternate spellings were never examined by the autofs machinery, an exact
+// namespace root has no first-level entry the probe could have vetted, a
+// network home under /home still carries the user's own guarded folders,
+// and for autofs-managed prefixes the first-level probe must actually have
+// resolved — checked here explicitly (memoized, shared with
+// isForeignOSPath) rather than assumed from call ordering.
+func automountCwdProbeAllowed(cleaned string) bool {
+	if !export.IsCanonicalAutomountNamespacePath(runtime.GOOS, cleaned) {
+		return false
+	}
+	if !allowProtectedPathProbes.Load() {
+		if home, err := os.UserHomeDir(); err == nil &&
+			export.IsProtectedUserDataPath(runtime.GOOS, home, cleaned) {
+			return false
+		}
+	}
+	sep := string(filepath.Separator)
+	for _, prefix := range autofsPrefixes {
+		if cleaned+sep == prefix {
+			return false
+		}
+		if strings.HasPrefix(cleaned, prefix) {
+			return autofsFirstLevelResolves(prefix, cleaned)
+		}
+	}
+	// The namespace is not autofs-managed on this host, so statting it
+	// wakes nothing.
+	return true
+}
+
 // defaultProbeGitfileTarget reports whether a path taken from gitfile
 // contents — a gitdir, a common directory, or the .git entry itself when it
 // is a symlink — may be read. Unlike the cwd guard, automount namespaces are
@@ -117,15 +149,7 @@ func defaultProbeGitfileTarget(cleaned string) bool {
 func defaultProbeGitRootForCwd(cleaned string) bool {
 	switch classifyProbePath(cleaned) {
 	case export.LocalPathProbeAutomountNamespace:
-		// Only a canonically spelled automount cwd passed isForeignOSPath's
-		// resolved-autofs probe before this guard runs — that function
-		// matches the mount table's canonical prefixes case-sensitively.
-		// Alternate spellings the classifier recognizes (the data-volume
-		// form, case-folded forms) and symlink-smuggled paths were never
-		// autofs-vetted and stay refused.
-		return export.IsCanonicalAutomountNamespacePath(
-			runtime.GOOS, filepath.Clean(cleaned),
-		)
+		return automountCwdProbeAllowed(filepath.Clean(cleaned))
 	case export.LocalPathProbeProtectedUserData:
 		return allowProtectedPathProbes.Load()
 	case export.LocalPathProbeSafe:

--- a/internal/parser/project_foreign_test.go
+++ b/internal/parser/project_foreign_test.go
@@ -168,20 +168,26 @@ func TestExtractProjectFromCwd_HomePathWithoutAutofs_StillWalks(t *testing.T) {
 	require.NoError(t, err)
 
 	orig := osStat
-	defer func() { osStat = orig }()
+	origLstat := osLstat
+	defer func() { osStat = orig; osLstat = origLstat }()
 	var count atomic.Int64
 	cwd := "/home/nobody-agentsview-test/code/example"
-	osStat = func(path string) (os.FileInfo, error) {
+	// The walk types .git candidates through osLstat and falls back to
+	// osStat elsewhere; count both so the assertion tracks the walk
+	// regardless of which seam a level uses.
+	statFn := func(path string) (os.FileInfo, error) {
 		count.Add(1)
 		if path == cwd {
 			return realInfo, nil
 		}
 		return nil, os.ErrNotExist
 	}
+	osStat = statFn
+	osLstat = statFn
 
 	_ = ExtractProjectFromCwdWithBranch(cwd, "")
 	assert.GreaterOrEqual(t, count.Load(), int64(2),
-		"osStat never called for /home path with empty "+
+		"stat never called for /home path with empty "+
 			"autofs config; walk must proceed for a real mount")
 }
 

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -177,7 +177,13 @@ func TestExtractProjectFromCwdPlainRepoDoesNotInvokeGit(t *testing.T) {
 	assert.NoFileExists(t, marker, "plain .git directory should resolve without invoking git")
 }
 
-func TestExtractProjectFromCwdFallsBackToGitWhenLocalWalkMisses(t *testing.T) {
+// TestExtractProjectFromCwdNoGitInvocationWhenLocalWalkMisses pins that a
+// cwd with no discoverable .git falls back to its basename without spawning
+// git: passive discovery must not let git follow config-derived paths such
+// as [include] path into locations the probe policy never vetted. The shim
+// would happily resolve the repo, so a reintroduced fallback is caught by
+// both the name and the invocation log.
+func TestExtractProjectFromCwdNoGitInvocationWhenLocalWalkMisses(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a POSIX shell git shim")
 	}
@@ -202,12 +208,18 @@ func TestExtractProjectFromCwdFallsBackToGitWhenLocalWalkMisses(t *testing.T) {
 	require.NoError(t, os.Chmod(fakeGit, 0o755), "chmod fake git")
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	assert.Equal(t, "virtual_repo",
+	assert.Equal(t, "parser",
 		ExtractProjectFromCwdWithBranchContext(context.Background(), cwd, ""))
-	assert.FileExists(t, gitLog, "git fallback should be used when local walk misses")
+	assert.NoFileExists(t, gitLog,
+		"passive discovery must not invoke git when the local walk misses")
 }
 
-func TestExtractProjectFromCwdTriesGitBeforeConservativeGitFileFallback(
+// TestExtractProjectFromCwdConservativeGitFileRootWithoutGit pins that a
+// gitfile whose external gitdir has no commondir resolves to the worktree
+// itself without spawning git. The shim would resolve the main repository,
+// so a reintroduced git fallback is caught by both the name and the
+// invocation log.
+func TestExtractProjectFromCwdConservativeGitFileRootWithoutGit(
 	t *testing.T,
 ) {
 	if runtime.GOOS == "windows" {
@@ -240,10 +252,10 @@ func TestExtractProjectFromCwdTriesGitBeforeConservativeGitFileFallback(
 	require.NoError(t, os.Chmod(fakeGit, 0o755), "chmod fake git")
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	assert.Equal(t, "main_repo",
+	assert.Equal(t, "feature_worktree",
 		ExtractProjectFromCwdWithBranchContext(context.Background(), cwd, ""))
-	assert.FileExists(t, gitLog,
-		"git fallback should run before accepting conservative gitfile root")
+	assert.NoFileExists(t, gitLog,
+		"passive discovery must not invoke git for a conservative gitfile root")
 }
 
 func TestExtractProjectFromCwd_DeletedNestedWorktree(t *testing.T) {

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -262,6 +262,33 @@ func TestExtractProjectFromCwdSymlinkedCommondirFallsBack(t *testing.T) {
 		"a commondir symlink into a guarded location must not be read")
 }
 
+// TestRepoRootFromSiblingsSkipsGuardedSiblings pins that missing-cwd
+// recovery vets each sibling before typing its .git entry: when the first
+// existing ancestor is the home directory, the siblings include Documents
+// and the other guarded folders, and typing them would Lstat inside — while
+// a guarded sibling holding a real .git directory would flow into
+// deletedChildIsWorktree's ReadDir of its worktrees list. The fixture makes
+// Documents exactly that sibling, with the deleted child registered as its
+// worktree, so a missing vet is caught by "Documents" becoming the name.
+func TestRepoRootFromSiblingsSkipsGuardedSiblings(t *testing.T) {
+	home := t.TempDir()
+	worktreesDir := filepath.Join(home, "Documents", ".git", "worktrees")
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(worktreesDir, "gone-child"), 0o755,
+	))
+
+	origGuard := probeGitfileTarget
+	t.Cleanup(func() { probeGitfileTarget = origGuard })
+	probeGitfileTarget = func(cleaned string) bool {
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+			export.LocalPathProbeSafe
+	}
+
+	deleted := filepath.Join(home, "gone-child", "sub")
+	assert.Equal(t, "sub", ExtractProjectFromCwd(deleted),
+		"a guarded sibling must not be typed or recovered as the root")
+}
+
 // TestDefaultProbeGitfileTargetRefusesAutomount pins the asymmetry between
 // the two default guards on macOS: a literal automount cwd stays probeable
 // because isForeignOSPath vetted it with the resolved-autofs probe before

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -109,7 +109,7 @@ func TestExtractProjectFromCwdSymlinkedGitFileFallsBack(t *testing.T) {
 	origGuard := probeGitfileTarget
 	t.Cleanup(func() { probeGitfileTarget = origGuard })
 	probeGitfileTarget = func(cleaned string) bool {
-		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned, false) ==
 			export.LocalPathProbeSafe
 	}
 
@@ -201,7 +201,7 @@ func TestRepoRootFromSiblingsBoundaryCheckDoesNotFollowRefusedSymlink(t *testing
 	origGuard := probeGitfileTarget
 	t.Cleanup(func() { probeGitfileTarget = origGuard })
 	probeGitfileTarget = func(cleaned string) bool {
-		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned, false) ==
 			export.LocalPathProbeSafe
 	}
 	origStat := osStat
@@ -254,7 +254,7 @@ func TestExtractProjectFromCwdSymlinkedCommondirFallsBack(t *testing.T) {
 	origGuard := probeGitfileTarget
 	t.Cleanup(func() { probeGitfileTarget = origGuard })
 	probeGitfileTarget = func(cleaned string) bool {
-		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned, false) ==
 			export.LocalPathProbeSafe
 	}
 
@@ -280,7 +280,7 @@ func TestRepoRootFromSiblingsSkipsGuardedSiblings(t *testing.T) {
 	origGuard := probeGitfileTarget
 	t.Cleanup(func() { probeGitfileTarget = origGuard })
 	probeGitfileTarget = func(cleaned string) bool {
-		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned, false) ==
 			export.LocalPathProbeSafe
 	}
 
@@ -315,13 +315,56 @@ func TestDeletedChildIsWorktreeSkipsSymlinkedWorktreesDir(t *testing.T) {
 	origGuard := probeGitfileTarget
 	t.Cleanup(func() { probeGitfileTarget = origGuard })
 	probeGitfileTarget = func(cleaned string) bool {
-		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned, false) ==
 			export.LocalPathProbeSafe
 	}
 
 	deleted := filepath.Join(parent, "gone-child", "sub")
 	assert.Equal(t, "sub", ExtractProjectFromCwd(deleted),
 		"a symlinked worktrees directory must not be enumerated")
+}
+
+// TestGitFileTargetsProbeableVetsSubmoduleConfig pins that a gitfile target
+// without a commondir — the submodule layout — vets the gitdir's own config
+// and HEAD: the conservative result would otherwise escalate to gitMainRoot,
+// whose git exec reads them, so a config symlink into a guarded folder would
+// be read through despite the vetted gitdir.
+func TestGitFileTargetsProbeableVetsSubmoduleConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
+	home := t.TempDir()
+	gitDir := filepath.Join(home, "src", "parent", ".git", "modules", "sub")
+	require.NoError(t, os.MkdirAll(gitDir, 0o755))
+	guardedConfig := filepath.Join(home, "Documents", "config-target")
+	require.NoError(t, os.MkdirAll(filepath.Dir(guardedConfig), 0o755))
+	require.NoError(t, os.WriteFile(guardedConfig, []byte("[core]\n"), 0o644))
+	worktree := filepath.Join(home, "src", "parent", "sub")
+	require.NoError(t, os.MkdirAll(worktree, 0o755))
+	gitPath := filepath.Join(worktree, ".git")
+	require.NoError(t, os.WriteFile(
+		gitPath, []byte("gitdir: "+gitDir+"\n"), 0o644,
+	))
+
+	origGuard := probeGitfileTarget
+	t.Cleanup(func() { probeGitfileTarget = origGuard })
+	probeGitfileTarget = func(cleaned string) bool {
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned, false) ==
+			export.LocalPathProbeSafe
+	}
+
+	require.NoError(t, os.Symlink(
+		guardedConfig, filepath.Join(gitDir, "config"),
+	))
+	assert.False(t, gitFileTargetsProbeable(worktree, gitPath),
+		"a guarded config symlink must refuse the submodule gitdir")
+
+	require.NoError(t, os.Remove(filepath.Join(gitDir, "config")))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(gitDir, "config"), []byte("[core]\n"), 0o644,
+	))
+	assert.True(t, gitFileTargetsProbeable(worktree, gitPath),
+		"a plain submodule gitdir stays probeable")
 }
 
 // TestDefaultProbeGitfileTargetRefusesAutomount pins the asymmetry between

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -83,6 +83,9 @@ func TestExtractProjectFromCwdProtectedGitdirTargetFallsBack(t *testing.T) {
 // valid gitfile pointing at a safe main repository, so a missing vet is
 // caught by the main repository's name leaking into the result.
 func TestExtractProjectFromCwdSymlinkedGitFileFallsBack(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
 	home := t.TempDir()
 	mainGitDir := filepath.Join(home, "src", "main-repo", ".git")
 	worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "wt")
@@ -139,6 +142,41 @@ func TestDefaultProbeGitRootForCwdHonorsProtectedHome(t *testing.T) {
 	t.Cleanup(func() { SetAllowProtectedPathProbes(false) })
 	assert.True(t, defaultProbeGitRootForCwd(protected),
 		"opting in must allow protected cwd probes")
+}
+
+// TestRepoRootFromSiblingsSkipsRefusedGitfileTargets pins that missing-cwd
+// recovery applies the same gitfile-target vetting as the upward walk: a
+// sibling worktree whose gitfile targets a refused location must not have
+// its commondir read or its main repository's name recovered. The deleted
+// cwd falls back to its own basename instead.
+func TestRepoRootFromSiblingsSkipsRefusedGitfileTargets(t *testing.T) {
+	root := t.TempDir()
+	guarded := filepath.Join(root, "guarded")
+	mainGitDir := filepath.Join(guarded, "main-docs", ".git")
+	worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "wt1")
+	require.NoError(t, os.MkdirAll(worktreeGitDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreeGitDir, "commondir"), []byte("../..\n"), 0o644,
+	))
+	parent := filepath.Join(root, "worktrees")
+	sibling := filepath.Join(parent, "wt1")
+	require.NoError(t, os.MkdirAll(sibling, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sibling, ".git"),
+		[]byte("gitdir: "+worktreeGitDir+"\n"), 0o644,
+	))
+
+	origGuard := probeGitfileTarget
+	t.Cleanup(func() { probeGitfileTarget = origGuard })
+	probeGitfileTarget = func(cleaned string) bool {
+		return !strings.HasPrefix(cleaned, guarded)
+	}
+
+	// The recorded cwd is a deleted child of parent, so recovery scans
+	// parent's siblings for linked-worktree gitfiles.
+	deleted := filepath.Join(parent, "wt2", "src")
+	assert.Equal(t, "src", ExtractProjectFromCwd(deleted),
+		"a refused sibling gitfile target must not name the main repository")
 }
 
 // TestDefaultProbeGitfileTargetRefusesAutomount pins the asymmetry between

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -379,5 +379,9 @@ func TestDefaultProbeGitfileTargetRefusesAutomount(t *testing.T) {
 	assert.False(t, defaultProbeGitfileTarget("/home/user/repo/.git"),
 		"an automount gitfile target must be refused")
 	assert.True(t, defaultProbeGitRootForCwd("/home/user/repo"),
-		"a literal automount cwd defers to isForeignOSPath's autofs probe")
+		"a canonical automount cwd defers to isForeignOSPath's autofs probe")
+	assert.False(t, defaultProbeGitRootForCwd("/System/Volumes/Data/home/user"),
+		"the data-volume spelling was never autofs-vetted and stays refused")
+	assert.False(t, defaultProbeGitRootForCwd("/HOME/user/repo"),
+		"a case-folded spelling was never autofs-vetted and stays refused")
 }

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/export"
 )
 
 // TestExtractProjectFromCwdGuardedCwdSkipsGitWalk pins that when the
@@ -64,14 +66,52 @@ func TestExtractProjectFromCwdProtectedGitdirTargetFallsBack(t *testing.T) {
 		[]byte("gitdir: "+worktreeGitDir+"\n"), 0o644,
 	))
 
-	origGuard := probeGitRootForCwd
-	t.Cleanup(func() { probeGitRootForCwd = origGuard })
-	probeGitRootForCwd = func(cleaned string) bool {
+	origGuard := probeGitfileTarget
+	t.Cleanup(func() { probeGitfileTarget = origGuard })
+	probeGitfileTarget = func(cleaned string) bool {
 		return !strings.HasPrefix(cleaned, guarded)
 	}
 
 	assert.Equal(t, "wt_checkout", ExtractProjectFromCwd(worktree),
 		"a refused gitdir target must fall back to the worktree basename")
+}
+
+// TestExtractProjectFromCwdSymlinkedGitFileFallsBack pins that a .git entry
+// which is itself a symlink into a guarded location is refused before being
+// read: the walker's type probe sees a regular file through the link, and
+// reading it would traverse into the guarded folder. The link target is a
+// valid gitfile pointing at a safe main repository, so a missing vet is
+// caught by the main repository's name leaking into the result.
+func TestExtractProjectFromCwdSymlinkedGitFileFallsBack(t *testing.T) {
+	home := t.TempDir()
+	mainGitDir := filepath.Join(home, "src", "main-repo", ".git")
+	worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "wt")
+	require.NoError(t, os.MkdirAll(worktreeGitDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreeGitDir, "commondir"), []byte("../..\n"), 0o644,
+	))
+	guardedFile := filepath.Join(home, "Documents", "redirect.git")
+	require.NoError(t, os.MkdirAll(filepath.Dir(guardedFile), 0o755))
+	require.NoError(t, os.WriteFile(
+		guardedFile, []byte("gitdir: "+worktreeGitDir+"\n"), 0o644,
+	))
+	worktree := filepath.Join(home, "work", "wt-link")
+	require.NoError(t, os.MkdirAll(worktree, 0o755))
+	require.NoError(t, os.Symlink(
+		guardedFile, filepath.Join(worktree, ".git"),
+	))
+
+	// Exercise the real classifier with an injected darwin home so the
+	// symlink is resolved and refused on any host platform.
+	origGuard := probeGitfileTarget
+	t.Cleanup(func() { probeGitfileTarget = origGuard })
+	probeGitfileTarget = func(cleaned string) bool {
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+			export.LocalPathProbeSafe
+	}
+
+	assert.Equal(t, "wt_link", ExtractProjectFromCwd(worktree),
+		"a .git symlink into a guarded location must not be read")
 }
 
 // TestDefaultProbeGitRootForCwdHonorsProtectedHome pins the default guard's
@@ -99,4 +139,19 @@ func TestDefaultProbeGitRootForCwdHonorsProtectedHome(t *testing.T) {
 	t.Cleanup(func() { SetAllowProtectedPathProbes(false) })
 	assert.True(t, defaultProbeGitRootForCwd(protected),
 		"opting in must allow protected cwd probes")
+}
+
+// TestDefaultProbeGitfileTargetRefusesAutomount pins the asymmetry between
+// the two default guards on macOS: a literal automount cwd stays probeable
+// because isForeignOSPath vetted it with the resolved-autofs probe before
+// the guard runs, but a gitfile target under the same namespace was never
+// autofs-vetted and must be refused so reading it cannot wake automountd.
+func TestDefaultProbeGitfileTargetRefusesAutomount(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("the default guards only restrict paths on darwin")
+	}
+	assert.False(t, defaultProbeGitfileTarget("/home/user/repo/.git"),
+		"an automount gitfile target must be refused")
+	assert.True(t, defaultProbeGitRootForCwd("/home/user/repo"),
+		"a literal automount cwd defers to isForeignOSPath's autofs probe")
 }

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -426,3 +426,37 @@ func TestAutomountCwdProbeAllowed(t *testing.T) {
 	assert.True(t, automountCwdProbeAllowed("/home/user/repo"),
 		"an unmanaged namespace has no automountd to wake")
 }
+
+// TestAutomountCwdProbeAllowedCustomPrefix pins the same clearance rules for
+// a custom autofs mount discovered from the mount table: registration makes
+// it classify as automount, and clearance still requires a resolving
+// first-level probe and refuses the mount root.
+func TestAutomountCwdProbeAllowedCustomPrefix(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("the guard reads runtime.GOOS")
+	}
+	origRegistered := export.RegisteredAutomountPrefixes()
+	t.Cleanup(func() { export.RegisterAutomountPrefixes(origRegistered) })
+	export.RegisterAutomountPrefixes([]string{"/corp/home/"})
+	origPrefixes := autofsPrefixes
+	t.Cleanup(func() { autofsPrefixes = origPrefixes; resetAutofsProbes() })
+	autofsPrefixes = []string{"/corp/home/"}
+	resetAutofsProbes()
+	origStat := osStat
+	t.Cleanup(func() { osStat = origStat })
+	realInfo, err := os.Stat(t.TempDir())
+	require.NoError(t, err)
+	osStat = func(path string) (os.FileInfo, error) {
+		if path == "/corp/home/user" {
+			return realInfo, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	assert.True(t, automountCwdProbeAllowed("/corp/home/user/repo"),
+		"a resolving custom-mount entry clears the walk")
+	assert.False(t, automountCwdProbeAllowed("/corp/home/ghost/repo"),
+		"an unresolved custom-mount entry must stay refused")
+	assert.False(t, automountCwdProbeAllowed("/corp/home"),
+		"the custom mount root has no first-level entry to vet")
+}

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -378,10 +378,51 @@ func TestDefaultProbeGitfileTargetRefusesAutomount(t *testing.T) {
 	}
 	assert.False(t, defaultProbeGitfileTarget("/home/user/repo/.git"),
 		"an automount gitfile target must be refused")
-	assert.True(t, defaultProbeGitRootForCwd("/home/user/repo"),
-		"a canonical automount cwd defers to isForeignOSPath's autofs probe")
-	assert.False(t, defaultProbeGitRootForCwd("/System/Volumes/Data/home/user"),
-		"the data-volume spelling was never autofs-vetted and stays refused")
-	assert.False(t, defaultProbeGitRootForCwd("/HOME/user/repo"),
-		"a case-folded spelling was never autofs-vetted and stays refused")
+}
+
+// TestAutomountCwdProbeAllowed pins the clearance rules for automount cwds:
+// spelling alone is never enough. Clearance requires the canonical spelling,
+// an actually resolving autofs first-level probe (or no autofs management at
+// all), a non-root path, and — without the opt-in — a path outside the
+// network home's own guarded folders.
+func TestAutomountCwdProbeAllowed(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("the guard reads runtime.GOOS")
+	}
+	origPrefixes := autofsPrefixes
+	t.Cleanup(func() { autofsPrefixes = origPrefixes; resetAutofsProbes() })
+	autofsPrefixes = []string{"/home/"}
+	resetAutofsProbes()
+	origStat := osStat
+	t.Cleanup(func() { osStat = origStat })
+	realInfo, err := os.Stat(t.TempDir())
+	require.NoError(t, err)
+	osStat = func(path string) (os.FileInfo, error) {
+		if path == "/home/user" {
+			return realInfo, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	t.Setenv("HOME", "/home/user")
+
+	assert.True(t, automountCwdProbeAllowed("/home/user/repo"),
+		"a resolving first-level entry clears the walk")
+	assert.False(t, automountCwdProbeAllowed("/home/ghost/repo"),
+		"an unresolved first-level entry must stay refused")
+	assert.False(t, automountCwdProbeAllowed("/home"),
+		"the namespace root has no first-level entry to vet")
+	assert.False(t, automountCwdProbeAllowed("/System/Volumes/Data/home/user"),
+		"the data-volume spelling was never autofs-examined")
+	assert.False(t, automountCwdProbeAllowed("/HOME/user/repo"),
+		"a case-folded spelling was never autofs-examined")
+	assert.False(t, automountCwdProbeAllowed("/home/user/Documents/proj"),
+		"a network home's guarded folders stay refused")
+	SetAllowProtectedPathProbes(true)
+	t.Cleanup(func() { SetAllowProtectedPathProbes(false) })
+	assert.True(t, automountCwdProbeAllowed("/home/user/Documents/proj"),
+		"the opt-in lifts the guarded-folder refusal for network homes")
+
+	autofsPrefixes = nil
+	assert.True(t, automountCwdProbeAllowed("/home/user/repo"),
+		"an unmanaged namespace has no automountd to wake")
 }

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -179,6 +179,89 @@ func TestRepoRootFromSiblingsSkipsRefusedGitfileTargets(t *testing.T) {
 		"a refused sibling gitfile target must not name the main repository")
 }
 
+// TestRepoRootFromSiblingsBoundaryCheckDoesNotFollowRefusedSymlink pins that
+// the ancestor boundary check in missing-cwd recovery types a refused .git
+// symlink without following it: the old following stat traversed the link
+// into the guarded target before any vet ran.
+func TestRepoRootFromSiblingsBoundaryCheckDoesNotFollowRefusedSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
+	home := t.TempDir()
+	guarded := filepath.Join(home, "Documents", "main", ".git")
+	require.NoError(t, os.MkdirAll(guarded, 0o755))
+	ancestor := filepath.Join(home, "work")
+	require.NoError(t, os.MkdirAll(ancestor, 0o755))
+	gitLink := filepath.Join(ancestor, ".git")
+	require.NoError(t, os.Symlink(guarded, gitLink))
+
+	// Exercise the real classifier with an injected darwin home: the guard
+	// receives the symlink's own path and must refuse it by resolving to
+	// the guarded target.
+	origGuard := probeGitfileTarget
+	t.Cleanup(func() { probeGitfileTarget = origGuard })
+	probeGitfileTarget = func(cleaned string) bool {
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+			export.LocalPathProbeSafe
+	}
+	origStat := osStat
+	t.Cleanup(func() { osStat = origStat })
+	osStat = func(path string) (os.FileInfo, error) {
+		if path == gitLink {
+			assert.Fail(t, "a refused .git symlink must not be stat-followed", path)
+		}
+		return origStat(path)
+	}
+
+	// The recorded cwd is a deleted child of ancestor, so recovery reaches
+	// the boundary check with ancestor's refused .git symlink. The refused
+	// entry marks ancestor as the repo boundary, so its basename becomes
+	// the path-only name; the stat spy above is what catches a regression
+	// back to a following stat.
+	deleted := filepath.Join(ancestor, "gone", "sub")
+	assert.Equal(t, "work", ExtractProjectFromCwd(deleted),
+		"a refused boundary must name the boundary directory, unread")
+}
+
+// TestExtractProjectFromCwdSymlinkedCommondirFallsBack pins the exact-file
+// vet on the parser side: a vetted gitdir whose commondir file is a symlink
+// into a guarded location must not be read through, so the main repository
+// it names cannot be recovered.
+func TestExtractProjectFromCwdSymlinkedCommondirFallsBack(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
+	home := t.TempDir()
+	mainRepo := filepath.Join(home, "src", "main-repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(mainRepo, ".git"), 0o755))
+	gitStore := filepath.Join(home, "gitstore", "wt-git")
+	require.NoError(t, os.MkdirAll(gitStore, 0o755))
+	target := filepath.Join(home, "Documents", "commondir-target")
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+	require.NoError(t, os.WriteFile(
+		target, []byte(filepath.Join(mainRepo, ".git")+"\n"), 0o644,
+	))
+	require.NoError(t, os.Symlink(
+		target, filepath.Join(gitStore, "commondir"),
+	))
+	worktree := filepath.Join(home, "work", "wt-x")
+	require.NoError(t, os.MkdirAll(worktree, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktree, ".git"),
+		[]byte("gitdir: "+gitStore+"\n"), 0o644,
+	))
+
+	origGuard := probeGitfileTarget
+	t.Cleanup(func() { probeGitfileTarget = origGuard })
+	probeGitfileTarget = func(cleaned string) bool {
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+			export.LocalPathProbeSafe
+	}
+
+	assert.Equal(t, "wt_x", ExtractProjectFromCwd(worktree),
+		"a commondir symlink into a guarded location must not be read")
+}
+
 // TestDefaultProbeGitfileTargetRefusesAutomount pins the asymmetry between
 // the two default guards on macOS: a literal automount cwd stays probeable
 // because isForeignOSPath vetted it with the resolved-autofs probe before

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -289,6 +289,41 @@ func TestRepoRootFromSiblingsSkipsGuardedSiblings(t *testing.T) {
 		"a guarded sibling must not be typed or recovered as the root")
 }
 
+// TestDeletedChildIsWorktreeSkipsSymlinkedWorktreesDir pins that verifying a
+// deleted worktree vets the exact worktrees path before enumerating it: the
+// sibling's .git directory is vetted and real, but worktrees inside it can
+// be a symlink into a guarded folder, and ReadDir through it is exactly the
+// enumeration macOS gates behind a consent prompt. The guarded store lists
+// the deleted child, so a missing vet is caught by the sibling's name being
+// recovered.
+func TestDeletedChildIsWorktreeSkipsSymlinkedWorktreesDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
+	home := t.TempDir()
+	store := filepath.Join(home, "Documents", "wt-store")
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(store, "gone-child"), 0o755,
+	))
+	parent := filepath.Join(home, "work")
+	mainRepo := filepath.Join(parent, "mainrepo")
+	require.NoError(t, os.MkdirAll(filepath.Join(mainRepo, ".git"), 0o755))
+	require.NoError(t, os.Symlink(
+		store, filepath.Join(mainRepo, ".git", "worktrees"),
+	))
+
+	origGuard := probeGitfileTarget
+	t.Cleanup(func() { probeGitfileTarget = origGuard })
+	probeGitfileTarget = func(cleaned string) bool {
+		return export.ClassifyLocalPathProbe("darwin", home, cleaned) ==
+			export.LocalPathProbeSafe
+	}
+
+	deleted := filepath.Join(parent, "gone-child", "sub")
+	assert.Equal(t, "sub", ExtractProjectFromCwd(deleted),
+		"a symlinked worktrees directory must not be enumerated")
+}
+
 // TestDefaultProbeGitfileTargetRefusesAutomount pins the asymmetry between
 // the two default guards on macOS: a literal automount cwd stays probeable
 // because isForeignOSPath vetted it with the resolved-autofs probe before

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -1,0 +1,70 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractProjectFromCwdGuardedCwdSkipsGitWalk pins that when the
+// protected-path guard refuses a cwd, project extraction falls back to the
+// path basename without touching the cwd's subtree on disk. The fixture is a
+// real git repo whose root name differs from the cwd basename, so a missing
+// guard is caught twice: the stat spy fires and the extracted name flips to
+// the repo root's.
+func TestExtractProjectFromCwdGuardedCwdSkipsGitWalk(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "guarded-repo")
+	cwd := filepath.Join(repo, "nested")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	require.NoError(t, os.MkdirAll(cwd, 0o755))
+
+	origGuard := probeGitRootForCwd
+	t.Cleanup(func() { probeGitRootForCwd = origGuard })
+	probeGitRootForCwd = func(cleaned string) bool {
+		return cleaned != filepath.Clean(cwd)
+	}
+	origStat := osStat
+	t.Cleanup(func() { osStat = origStat })
+	osStat = func(path string) (os.FileInfo, error) {
+		if strings.HasPrefix(path, repo) {
+			assert.Fail(t, "guarded cwd must not be stat-ed", path)
+		}
+		return origStat(path)
+	}
+
+	assert.Equal(t, "nested", ExtractProjectFromCwd(cwd),
+		"a guarded cwd must fall back to its basename")
+}
+
+// TestDefaultProbeGitRootForCwdHonorsProtectedHome pins the default guard's
+// wiring on macOS: a cwd under $HOME/Documents is refused until
+// SetAllowProtectedPathProbes opts in. Darwin-only because the guard reads
+// runtime.GOOS; the resolution logic itself is covered cross-platform in
+// internal/export.
+func TestDefaultProbeGitRootForCwdHonorsProtectedHome(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("the default guard only restricts paths on darwin")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	protected := filepath.Join(home, "Documents", "proj")
+	require.NoError(t, os.MkdirAll(protected, 0o755))
+	plain := filepath.Join(home, "src", "proj")
+	require.NoError(t, os.MkdirAll(plain, 0o755))
+
+	assert.False(t, defaultProbeGitRootForCwd(protected),
+		"protected cwd must be refused by default")
+	assert.True(t, defaultProbeGitRootForCwd(plain),
+		"unprotected cwd must stay probeable")
+
+	SetAllowProtectedPathProbes(true)
+	t.Cleanup(func() { SetAllowProtectedPathProbes(false) })
+	assert.True(t, defaultProbeGitRootForCwd(protected),
+		"opting in must allow protected cwd probes")
+}

--- a/internal/parser/project_protected_test.go
+++ b/internal/parser/project_protected_test.go
@@ -42,6 +42,38 @@ func TestExtractProjectFromCwdGuardedCwdSkipsGitWalk(t *testing.T) {
 		"a guarded cwd must fall back to its basename")
 }
 
+// TestExtractProjectFromCwdProtectedGitdirTargetFallsBack pins that a linked
+// worktree in an unguarded directory whose .git file targets a refused gitdir
+// stops at the worktree itself: following the target would read commondir and
+// config inside the refused location, and escalating to gitMainRoot would
+// exec git, which reads the same target. The main repository name must not
+// leak into the result.
+func TestExtractProjectFromCwdProtectedGitdirTargetFallsBack(t *testing.T) {
+	root := t.TempDir()
+	guarded := filepath.Join(root, "guarded")
+	mainGitDir := filepath.Join(guarded, "main", ".git")
+	worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "wt")
+	require.NoError(t, os.MkdirAll(worktreeGitDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreeGitDir, "commondir"), []byte("../..\n"), 0o644,
+	))
+	worktree := filepath.Join(root, "work", "wt-checkout")
+	require.NoError(t, os.MkdirAll(worktree, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktree, ".git"),
+		[]byte("gitdir: "+worktreeGitDir+"\n"), 0o644,
+	))
+
+	origGuard := probeGitRootForCwd
+	t.Cleanup(func() { probeGitRootForCwd = origGuard })
+	probeGitRootForCwd = func(cleaned string) bool {
+		return !strings.HasPrefix(cleaned, guarded)
+	}
+
+	assert.Equal(t, "wt_checkout", ExtractProjectFromCwd(worktree),
+		"a refused gitdir target must fall back to the worktree basename")
+}
+
 // TestDefaultProbeGitRootForCwdHonorsProtectedHome pins the default guard's
 // wiring on macOS: a cwd under $HOME/Documents is refused until
 // SetAllowProtectedPathProbes opts in. Darwin-only because the guard reads

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -188,6 +188,7 @@ func (s *Server) syncEngineForLocal(local *db.DB) *syncpkg.Engine {
 		AgentDirs:               s.cfg.AgentDirs,
 		SourceMachines:          s.cfg.SourceMachines,
 		IncludeCwdPrefixes:      s.cfg.SyncIncludeCwdPrefixes,
+		ScanProtectedPaths:      s.cfg.ScanProtectedPaths,
 		Machine:                 s.cfg.LocalMachineName,
 		BlockedResultCategories: s.cfg.ResultContentBlockedCategories,
 		Emitter:                 emitter,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -563,6 +563,15 @@ func NewEngine(
 		maps.Copy(providerModes, cfg.ProviderMigrationModes)
 	}
 
+	if cfg.ScanProtectedPaths {
+		// Parsers extract project names by probing recorded cwds for git
+		// roots; that guard is package-level because extraction runs deep
+		// inside per-format code with no engine to consult. The opt-in only
+		// ever enables it: engines built without the option (remote sync,
+		// the identity backfill) must not revoke the user's process-wide
+		// choice.
+		parser.SetAllowProtectedPathProbes(true)
+	}
 	e := &Engine{
 		db:                      database,
 		stat:                    os.Stat,
@@ -11299,11 +11308,13 @@ func userHomeDirOrEmpty() string {
 // Working directories inside macOS TCC-protected locations stay untouched
 // unless the user set scan_protected_paths, so importing an archive cannot
 // raise consent prompts for Documents, Downloads, or a cloud-provider folder.
+// The check follows symlinks, so a cwd that merely links into a protected
+// folder is refused before Stat or EvalSymlinks can enter it.
 func (e *Engine) mayProbeLocalPath(p string) bool {
 	if e.scanProtectedPaths {
 		return true
 	}
-	return !export.IsProtectedUserDataPath(e.goos, e.homeDir, p)
+	return !export.ResolvesIntoProtectedUserDataPath(e.goos, e.homeDir, p)
 }
 
 // isLocalMachineAttribution recognizes empty and the legacy "local" sentinel

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -268,6 +268,14 @@ type EngineConfig struct {
 	// remote sync leaves it empty because the prefixes describe
 	// local paths.
 	IncludeCwdPrefixes []string
+	// ScanProtectedPaths lets local Git discovery read working directories
+	// inside macOS TCC-protected locations (Documents, Downloads, Desktop,
+	// iCloud Drive, and cloud-provider folders). It defaults to false so a
+	// first sync cannot raise consent prompts the user cannot explain;
+	// sessions there keep path-only project identity. Populated from the
+	// scan_protected_paths config option. The safe default belongs to the
+	// zero value so an engine built without the option never prompts.
+	ScanProtectedPaths bool
 	// IDPrefix is prepended to all session IDs. Used by
 	// remote sync to namespace IDs by host (e.g. "host~").
 	IDPrefix string
@@ -315,11 +323,18 @@ type Engine struct {
 	machine                 string
 	blockedResultCategories map[string]bool
 	cwdFilter               cwdPrefixFilter
-	syncMu                  gosync.Mutex // serializes all sync operations
-	mu                      gosync.RWMutex
-	lastSync                time.Time
-	lastSyncStats           SyncStats
-	currentProgress         *Progress
+	// scanProtectedPaths, homeDir, and goos gate passive probing of macOS
+	// TCC-protected locations. homeDir is empty when the home directory
+	// cannot be resolved, which disables the gate rather than guessing.
+	// goos mirrors runtime.GOOS so the gate is testable off-darwin.
+	scanProtectedPaths bool
+	homeDir            string
+	goos               string
+	syncMu             gosync.Mutex // serializes all sync operations
+	mu                 gosync.RWMutex
+	lastSync           time.Time
+	lastSyncStats      SyncStats
+	currentProgress    *Progress
 	// skipCache tracks paths that should be skipped on
 	// subsequent syncs, keyed by path with the file mtime
 	// at time of caching. Covers parse errors and
@@ -557,6 +572,9 @@ func NewEngine(
 		machine:                 cfg.Machine,
 		blockedResultCategories: blockedCategorySet(cfg.BlockedResultCategories),
 		cwdFilter:               newCwdPrefixFilter(cfg.IncludeCwdPrefixes),
+		scanProtectedPaths:      cfg.ScanProtectedPaths,
+		homeDir:                 userHomeDirOrEmpty(),
+		goos:                    runtime.GOOS,
 		skipCache:               skipCache,
 		skipFingerprints:        make(map[string]string),
 		skipHashKeys:            skipHashKeys,
@@ -11181,6 +11199,27 @@ func (e *Engine) loadWorktreeProjectResolver() worktreeProjectResolver {
 	}
 }
 
+// skipSourceProjectProbe reports whether pw's working directory must not be
+// stat-ed to decide whether its source project is still available. Remote and
+// unverified sessions describe another machine's paths, automounter namespaces
+// wake automountd, and macOS TCC-protected locations raise a consent prompt.
+// Skipping leaves the stored project untouched, which is what an unreachable
+// working directory would produce anyway.
+func (e *Engine) skipSourceProjectProbe(pw *pendingWrite) bool {
+	sess := &pw.sess
+	if sess.ID == "" || sess.Cwd == "" || pw.sourceIdentityUnverified {
+		return true
+	}
+	if !e.isLocalMachineAttribution(sess.Machine) ||
+		!safeLocalAbsolutePath(sess.Cwd) {
+		return true
+	}
+	if export.IsAutomountNamespacePath(runtime.GOOS, filepath.Clean(sess.Cwd)) {
+		return true
+	}
+	return !e.mayProbeLocalPath(sess.Cwd)
+}
+
 func (e *Engine) preserveUnavailableSourceProjects(
 	ctx context.Context,
 	batch []pendingWrite,
@@ -11192,11 +11231,7 @@ func (e *Engine) preserveUnavailableSourceProjects(
 			continue
 		}
 		sess := batch[i].sess
-		if sess.ID == "" || sess.Cwd == "" ||
-			batch[i].sourceIdentityUnverified ||
-			!e.isLocalMachineAttribution(sess.Machine) ||
-			!safeLocalAbsolutePath(sess.Cwd) ||
-			export.IsAutomountNamespacePath(runtime.GOOS, filepath.Clean(sess.Cwd)) {
+		if e.skipSourceProjectProbe(&batch[i]) {
 			batch[i].sourceProjectResolved = true
 			continue
 		}
@@ -11247,6 +11282,28 @@ func (e *Engine) preserveUnavailableSourceProjects(
 		}
 	}
 	return batch, nil
+}
+
+// userHomeDirOrEmpty returns the current user's home directory, or "" when it
+// cannot be resolved. An empty result leaves protected-path gating inactive,
+// which keeps discovery working on systems with no usable home directory.
+func userHomeDirOrEmpty() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return home
+}
+
+// mayProbeLocalPath reports whether passive discovery may touch p on disk.
+// Working directories inside macOS TCC-protected locations stay untouched
+// unless the user set scan_protected_paths, so importing an archive cannot
+// raise consent prompts for Documents, Downloads, or a cloud-provider folder.
+func (e *Engine) mayProbeLocalPath(p string) bool {
+	if e.scanProtectedPaths {
+		return true
+	}
+	return !export.IsProtectedUserDataPath(e.goos, e.homeDir, p)
 }
 
 // isLocalMachineAttribution recognizes empty and the legacy "local" sentinel
@@ -12454,8 +12511,10 @@ func (e *Engine) cachedProjectIdentity(machine, rootPath string) projectIdentity
 	// wakes the /home automounter — with tens of thousands of remote
 	// sessions and a one-minute cache TTL that becomes a sustained
 	// automountd/opendirectoryd CPU storm.
+	// mayProbeLocalPath also guards export.NormalizeRootPath below, which
+	// resolves symlinks and would reach into a protected location on its own.
 	if e.idPrefix == "" && e.pathRewriter == nil &&
-		e.isLocalMachineAttribution(machine) {
+		e.isLocalMachineAttribution(machine) && e.mayProbeLocalPath(rootPath) {
 		if normalized, ok, err := export.NormalizeRootPath(rootPath); err == nil && ok {
 			identity.rootPath = normalized
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11308,13 +11308,20 @@ func userHomeDirOrEmpty() string {
 // Working directories inside macOS TCC-protected locations stay untouched
 // unless the user set scan_protected_paths, so importing an archive cannot
 // raise consent prompts for Documents, Downloads, or a cloud-provider folder.
-// The check follows symlinks, so a cwd that merely links into a protected
-// folder is refused before Stat or EvalSymlinks can enter it.
+// Automounter namespaces stay untouched regardless of the opt-in: consenting
+// to consent prompts is not consenting to waking automountd. The check
+// follows symlinks, so a path that merely links into either kind of location
+// is refused before Stat or EvalSymlinks can enter it.
 func (e *Engine) mayProbeLocalPath(p string) bool {
-	if e.scanProtectedPaths {
+	switch export.ClassifyLocalPathProbe(e.goos, e.homeDir, p) {
+	case export.LocalPathProbeAutomountNamespace:
+		return false
+	case export.LocalPathProbeProtectedUserData:
+		return e.scanProtectedPaths
+	case export.LocalPathProbeSafe:
 		return true
 	}
-	return !export.ResolvesIntoProtectedUserDataPath(e.goos, e.homeDir, p)
+	return true
 }
 
 // isLocalMachineAttribution recognizes empty and the legacy "local" sentinel
@@ -12529,7 +12536,9 @@ func (e *Engine) cachedProjectIdentity(machine, rootPath string) projectIdentity
 		if normalized, ok, err := export.NormalizeRootPath(rootPath); err == nil && ok {
 			identity.rootPath = normalized
 		}
-		if discovered := discoverLocalGitIdentity(rootPath); discovered.rootPath != "" {
+		if discovered := discoverLocalGitIdentity(
+			rootPath, e.mayProbeLocalPath,
+		); discovered.rootPath != "" {
 			identity.rootPath = discovered.rootPath
 			identity.repositoryPath = discovered.repositoryPath
 			identity.gitDir = discovered.gitDir
@@ -12657,7 +12666,9 @@ func countNormalizedRemoteCandidates(remotes map[string]string) int {
 	return len(unique)
 }
 
-func discoverLocalGitIdentity(cwd string) localGitIdentity {
+func discoverLocalGitIdentity(
+	cwd string, mayProbe func(string) bool,
+) localGitIdentity {
 	if !safeLocalAbsolutePath(cwd) {
 		return localGitIdentity{}
 	}
@@ -12675,14 +12686,16 @@ func discoverLocalGitIdentity(cwd string) localGitIdentity {
 	if root == "" {
 		return localGitIdentity{}
 	}
-	gitDir, commonDir, relationship := gitDirectoryContext(root)
+	gitDir, commonDir, relationship := gitDirectoryContext(root, mayProbe)
 	result := localGitIdentity{
 		rootPath:       root,
-		repositoryPath: repositoryPathForGitContext(root, commonDir),
+		repositoryPath: repositoryPathForGitContext(root, commonDir, mayProbe),
 		gitDir:         gitDir,
 		worktreeKind:   relationship,
 	}
-	if commonDir != "" {
+	// The common directory comes from gitfile contents and can point
+	// anywhere, including a protected location the vetted cwd never named.
+	if commonDir != "" && mayProbe(commonDir) {
 		result.remotes = readGitRemotes(filepath.Join(commonDir, "config"))
 	}
 	return result
@@ -12739,7 +12752,7 @@ func findLocalGitRoot(start string) string {
 }
 
 func gitDirectoryContext(
-	root string,
+	root string, mayProbe func(string) bool,
 ) (gitDir, commonDir string, relationship export.WorktreeRelationship) {
 	gitPath := filepath.Join(root, ".git")
 	if info, err := os.Stat(gitPath); err == nil && info.IsDir() {
@@ -12758,6 +12771,13 @@ func gitDirectoryContext(
 	if !filepath.IsAbs(line) {
 		line = filepath.Join(root, line)
 	}
+	// The gitfile target comes from file contents, not from the vetted
+	// cwd: a linked worktree in an unguarded directory can point at a
+	// main repository inside a protected folder, and reading commondir or
+	// HEAD there would raise the consent prompt the cwd gate prevented.
+	if !mayProbe(line) {
+		return "", "", export.WorktreeUnknown
+	}
 	commonDir = line
 	relationship = export.WorktreeMain
 	if data, err := os.ReadFile(filepath.Join(line, "commondir")); err == nil {
@@ -12772,12 +12792,19 @@ func gitDirectoryContext(
 	return filepath.Clean(line), filepath.Clean(commonDir), relationship
 }
 
-func repositoryPathForGitContext(root, commonDir string) string {
+func repositoryPathForGitContext(
+	root, commonDir string, mayProbe func(string) bool,
+) string {
 	repositoryPath := commonDir
 	if commonDir == "" {
 		repositoryPath = root
 	} else if filepath.Base(commonDir) == ".git" {
 		repositoryPath = filepath.Dir(commonDir)
+	}
+	// Storing the path string is harmless; resolving its symlinks is a
+	// filesystem walk that must respect the protected-path policy.
+	if !mayProbe(repositoryPath) {
+		return filepath.Clean(repositoryPath)
 	}
 	if resolved, err := filepath.EvalSymlinks(repositoryPath); err == nil {
 		return resolved

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -12495,7 +12495,9 @@ func (e *Engine) projectIdentityObservation(
 	if obs.GitBranch != "" {
 		obs.CheckoutState = export.CheckoutBranch
 	} else {
-		obs.CheckoutState, obs.GitBranch = readGitCheckout(cached.gitDir)
+		obs.CheckoutState, obs.GitBranch = readGitCheckout(
+			cached.gitDir, e.mayProbeLocalPath,
+		)
 	}
 	return obs, true
 }
@@ -12694,9 +12696,14 @@ func discoverLocalGitIdentity(
 		worktreeKind:   relationship,
 	}
 	// The common directory comes from gitfile contents and can point
-	// anywhere, including a protected location the vetted cwd never named.
-	if commonDir != "" && mayProbe(commonDir) {
-		result.remotes = readGitRemotes(filepath.Join(commonDir, "config"))
+	// anywhere, including a protected location the vetted cwd never named,
+	// and the config file inside a vetted one can itself be a symlink out;
+	// vetting the exact file path covers both.
+	if commonDir != "" {
+		configPath := filepath.Join(commonDir, "config")
+		if mayProbe(configPath) {
+			result.remotes = readGitRemotes(configPath)
+		}
 	}
 	return result
 }
@@ -12738,22 +12745,8 @@ func looksWindowsDrivePath(p string) bool {
 func findLocalGitRoot(start string, mayProbe func(string) bool) string {
 	dir := filepath.Clean(start)
 	for {
-		gitPath := filepath.Join(dir, ".git")
-		info, err := os.Lstat(gitPath)
-		if err == nil && info.Mode()&os.ModeSymlink != 0 {
-			// A .git symlink into a refused location marks a repo
-			// boundary we must not look through: return the directory
-			// without following the link; gitDirectoryContext refuses
-			// the reads under it.
-			if !mayProbe(gitPath) {
-				return dir
-			}
-			info, err = os.Stat(gitPath)
-		}
-		if err == nil {
-			if info.IsDir() || info.Mode().IsRegular() {
-				return dir
-			}
+		if gitEntryMarksRoot(filepath.Join(dir, ".git"), mayProbe) {
+			return dir
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -12761,6 +12754,28 @@ func findLocalGitRoot(start string, mayProbe func(string) bool) string {
 		}
 		dir = parent
 	}
+}
+
+// gitEntryMarksRoot reports whether gitPath denotes a git directory or
+// gitfile, following a symlink only when its target passes mayProbe. A
+// refused link still marks a root: it is a repo boundary we must not look
+// through, and gitDirectoryContext refuses the reads under it.
+func gitEntryMarksRoot(gitPath string, mayProbe func(string) bool) bool {
+	info, err := os.Lstat(gitPath)
+	if err != nil {
+		return false
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		if !mayProbe(gitPath) {
+			return true
+		}
+		followed, err := os.Stat(gitPath)
+		if err != nil {
+			return false
+		}
+		return followed.IsDir() || followed.Mode().IsRegular()
+	}
+	return info.IsDir() || info.Mode().IsRegular()
 }
 
 func gitDirectoryContext(
@@ -12800,7 +12815,14 @@ func gitDirectoryContext(
 	}
 	commonDir = line
 	relationship = export.WorktreeMain
-	if data, err := os.ReadFile(filepath.Join(line, "commondir")); err == nil {
+	// The commondir file sits inside the vetted gitdir, but as a symlink
+	// it can lead anywhere; vet the exact path (classification follows
+	// links) before reading through it.
+	commondirPath := filepath.Join(line, "commondir")
+	if !mayProbe(commondirPath) {
+		return filepath.Clean(line), filepath.Clean(commonDir), relationship
+	}
+	if data, err := os.ReadFile(commondirPath); err == nil {
 		common := strings.TrimSpace(string(data))
 		if filepath.IsAbs(common) {
 			commonDir = common
@@ -12832,11 +12854,19 @@ func repositoryPathForGitContext(
 	return filepath.Clean(repositoryPath)
 }
 
-func readGitCheckout(gitDir string) (export.CheckoutState, string) {
+func readGitCheckout(
+	gitDir string, mayProbe func(string) bool,
+) (export.CheckoutState, string) {
 	if gitDir == "" {
 		return export.CheckoutUnknown, ""
 	}
-	data, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	// HEAD sits inside the vetted git directory, but as a symlink it can
+	// lead anywhere; vet the exact path before reading through it.
+	headPath := filepath.Join(gitDir, "HEAD")
+	if !mayProbe(headPath) {
+		return export.CheckoutUnknown, ""
+	}
+	data, err := os.ReadFile(headPath)
 	if err != nil {
 		return export.CheckoutUnknown, ""
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -12755,6 +12755,14 @@ func gitDirectoryContext(
 	root string, mayProbe func(string) bool,
 ) (gitDir, commonDir string, relationship export.WorktreeRelationship) {
 	gitPath := filepath.Join(root, ".git")
+	// root is vetted, but the .git entry itself can be a symlink into a
+	// guarded location; classification follows links, so vetting the exact
+	// path keeps both the type probe and the gitfile read (and every later
+	// HEAD, config, and commondir read under the returned directories)
+	// from traversing into it.
+	if !mayProbe(gitPath) {
+		return "", "", export.WorktreeUnknown
+	}
 	if info, err := os.Stat(gitPath); err == nil && info.IsDir() {
 		return gitPath, gitPath, export.WorktreeMain
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11284,7 +11284,7 @@ func (e *Engine) preserveUnavailableSourceProjects(
 		for _, i := range indexes[id] {
 			sess := &batch[i].sess
 			if !e.sameLocalMachineAttribution(snapshot.Machine, sess.Machine) ||
-				!pathContains(snapshot.RootPath, sess.Cwd) {
+				!e.snapshotRootContainsCwd(snapshot.RootPath, sess.Cwd) {
 				continue
 			}
 			sess.Project = snapshot.Project
@@ -11335,10 +11335,26 @@ func (e *Engine) sameLocalMachineAttribution(left, right string) bool {
 		(e.isLocalMachineAttribution(left) && e.isLocalMachineAttribution(right))
 }
 
+// snapshotRootContainsCwd reports whether the durable snapshot's root
+// contains the session cwd. The cwd was vetted by skipSourceProjectProbe,
+// but the snapshot root is stored data that can predate protected-path
+// gating and name a guarded folder; resolving its symlinks would walk
+// inside it, so a refused root falls back to lexical containment.
+func (e *Engine) snapshotRootContainsCwd(root, cwd string) bool {
+	if !e.mayProbeLocalPath(root) {
+		return lexicalPathContains(root, cwd)
+	}
+	return pathContains(root, cwd)
+}
+
 func pathContains(root, path string) bool {
 	root = resolveExistingPathPrefix(root)
 	path = resolveExistingPathPrefix(path)
-	rel, err := filepath.Rel(root, path)
+	return lexicalPathContains(root, path)
+}
+
+func lexicalPathContains(root, path string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
 	if err != nil {
 		return false
 	}
@@ -11346,12 +11362,17 @@ func pathContains(root, path string) bool {
 		(rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
+// evalSymlinks is indirected through a var so tests can assert prefix
+// resolution never walks a refused root. Production code always uses
+// filepath.EvalSymlinks via this binding.
+var evalSymlinks = filepath.EvalSymlinks
+
 func resolveExistingPathPrefix(path string) string {
 	cleaned := filepath.Clean(path)
 	current := cleaned
 	var missingTail []string
 	for {
-		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+		if resolved, err := evalSymlinks(current); err == nil {
 			for _, v := range slices.Backward(missingTail) {
 				resolved = filepath.Join(resolved, v)
 			}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11313,7 +11313,9 @@ func userHomeDirOrEmpty() string {
 // follows symlinks, so a path that merely links into either kind of location
 // is refused before Stat or EvalSymlinks can enter it.
 func (e *Engine) mayProbeLocalPath(p string) bool {
-	switch export.ClassifyLocalPathProbe(e.goos, e.homeDir, p) {
+	switch export.ClassifyLocalPathProbe(
+		e.goos, e.homeDir, p, e.scanProtectedPaths,
+	) {
 	case export.LocalPathProbeAutomountNamespace:
 		return false
 	case export.LocalPathProbeProtectedUserData:

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -12682,7 +12682,7 @@ func discoverLocalGitIdentity(
 	if err != nil {
 		return localGitIdentity{}
 	}
-	root := findLocalGitRoot(resolved)
+	root := findLocalGitRoot(resolved, mayProbe)
 	if root == "" {
 		return localGitIdentity{}
 	}
@@ -12735,10 +12735,22 @@ func looksWindowsDrivePath(p string) bool {
 	return p[2] == '\\' || p[2] == '/'
 }
 
-func findLocalGitRoot(start string) string {
+func findLocalGitRoot(start string, mayProbe func(string) bool) string {
 	dir := filepath.Clean(start)
 	for {
-		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		gitPath := filepath.Join(dir, ".git")
+		info, err := os.Lstat(gitPath)
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			// A .git symlink into a refused location marks a repo
+			// boundary we must not look through: return the directory
+			// without following the link; gitDirectoryContext refuses
+			// the reads under it.
+			if !mayProbe(gitPath) {
+				return dir
+			}
+			info, err = os.Stat(gitPath)
+		}
+		if err == nil {
 			if info.IsDir() || info.Mode().IsRegular() {
 				return dir
 			}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5721,6 +5721,14 @@ func TestMayProbeLocalPathRefusesAutomountDespiteOptIn(t *testing.T) {
 	assert.True(t, engine.mayProbeLocalPath(
 		filepath.Join(home, "Documents", "proj"),
 	), "the opt-in must still lift the protected-folder restriction")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "Documents"), 0o755))
+	require.NoError(t, os.Symlink(
+		"/home/user", filepath.Join(home, "Documents", "hidden"),
+	))
+	assert.False(t, engine.mayProbeLocalPath(
+		filepath.Join(home, "Documents", "hidden", "repo"),
+	), "an automount target hidden behind a protected prefix stays refused")
 }
 
 // TestProjectIdentityObservationSkipsProtectedGitdirTarget pins that a linked

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5635,6 +5635,128 @@ func TestProjectIdentityObservationSkipsSymlinkedProtectedCwd(t *testing.T) {
 		"root path must stay the raw cwd, not a resolved protected root")
 }
 
+// TestMayProbeLocalPathRefusesAutomountDespiteOptIn pins that
+// scan_protected_paths lifts only the protected-folder restriction: an
+// automounter-namespace path — named directly or reached through a symlink —
+// stays refused, because consenting to macOS consent prompts is not
+// consenting to waking automountd on every identity-cache miss.
+func TestMayProbeLocalPathRefusesAutomountDespiteOptIn(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.Symlink("/home", filepath.Join(home, "tohome")))
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		Machine: "current-machine", ScanProtectedPaths: true,
+	})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	assert.False(t, engine.mayProbeLocalPath("/home/user/repo"),
+		"a literal automount path must stay refused under the opt-in")
+	assert.False(t, engine.mayProbeLocalPath(
+		filepath.Join(home, "tohome", "user", "repo"),
+	), "a symlink into the automount namespace must stay refused too")
+	assert.True(t, engine.mayProbeLocalPath(
+		filepath.Join(home, "Documents", "proj"),
+	), "the opt-in must still lift the protected-folder restriction")
+}
+
+// TestProjectIdentityObservationSkipsProtectedGitdirTarget pins that a linked
+// worktree in an unguarded directory whose .git file targets a gitdir inside
+// a protected folder yields no git detail: reading commondir, config, or
+// HEAD from that target would raise the consent prompt the cwd gate
+// prevented. The worktree relationship stays unknown because classifying it
+// requires the refused commondir read.
+func TestProjectIdentityObservationSkipsProtectedGitdirTarget(t *testing.T) {
+	database := openTestDB(t)
+	home := t.TempDir()
+	mainGitDir := filepath.Join(home, "Documents", "main", ".git")
+	worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "wt")
+	require.NoError(t, os.MkdirAll(worktreeGitDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktreeGitDir, "commondir"), []byte("../..\n"), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(mainGitDir, "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/docs.git\n"),
+		0o644,
+	))
+	worktree := filepath.Join(home, "src", "wt")
+	require.NoError(t, os.MkdirAll(worktree, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktree, ".git"),
+		[]byte("gitdir: "+worktreeGitDir+"\n"), 0o644,
+	))
+	engine := NewEngine(database, EngineConfig{Machine: "current-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-protected-gitdir", Project: "gitdir-project",
+			Machine: "current-machine", Agent: "codex", Cwd: worktree,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"gitdir-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Empty(t, observations[0].GitRemote,
+		"a protected gitdir target must not be read for remotes")
+	assert.Equal(t, export.WorktreeUnknown,
+		observations[0].WorktreeRelationship,
+		"classifying the worktree requires the refused commondir read")
+}
+
+// TestProjectIdentityObservationSkipsProtectedCommonDir pins the second hop
+// of the same leak: a gitfile target outside protected folders whose
+// commondir points into one. The gitdir itself may be read, but the common
+// directory's config must not be.
+func TestProjectIdentityObservationSkipsProtectedCommonDir(t *testing.T) {
+	database := openTestDB(t)
+	home := t.TempDir()
+	protectedGit := filepath.Join(home, "Documents", "main", ".git")
+	require.NoError(t, os.MkdirAll(protectedGit, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(protectedGit, "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/docs.git\n"),
+		0o644,
+	))
+	gitDir := filepath.Join(home, "gitstore", "wt-git")
+	require.NoError(t, os.MkdirAll(gitDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(gitDir, "commondir"), []byte(protectedGit+"\n"), 0o644,
+	))
+	worktree := filepath.Join(home, "src", "wt")
+	require.NoError(t, os.MkdirAll(worktree, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktree, ".git"), []byte("gitdir: "+gitDir+"\n"), 0o644,
+	))
+	engine := NewEngine(database, EngineConfig{Machine: "current-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-protected-commondir", Project: "commondir-project",
+			Machine: "current-machine", Agent: "codex", Cwd: worktree,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"commondir-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Empty(t, observations[0].GitRemote,
+		"a protected common directory must not be read for remotes")
+}
+
 // TestProjectIdentityObservationScansProtectedPathWhenOptedIn pins that
 // scan_protected_paths restores full git identity for users who keep code in
 // Documents and accept the macOS prompt.

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5711,6 +5711,53 @@ func TestProjectIdentityObservationSkipsProtectedGitdirTarget(t *testing.T) {
 		"classifying the worktree requires the refused commondir read")
 }
 
+// TestProjectIdentityObservationSkipsSymlinkedGitDir pins that a .git entry
+// which is itself a symlink into a protected folder is refused before being
+// read: the type probe would follow the link, and the HEAD and config reads
+// under the returned git directory would traverse into the protected
+// location. The link target is a real git directory with a branch and a
+// remote, so a missing vet is caught by either leaking into the observation.
+func TestProjectIdentityObservationSkipsSymlinkedGitDir(t *testing.T) {
+	database := openTestDB(t)
+	home := t.TempDir()
+	realGit := filepath.Join(home, "Documents", "main", ".git")
+	require.NoError(t, os.MkdirAll(realGit, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(realGit, "HEAD"),
+		[]byte("ref: refs/heads/docs-branch\n"), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(realGit, "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/docs.git\n"),
+		0o644,
+	))
+	repo := filepath.Join(home, "src", "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	require.NoError(t, os.Symlink(realGit, filepath.Join(repo, ".git")))
+	engine := NewEngine(database, EngineConfig{Machine: "current-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-symlinked-gitdir", Project: "gitlink-project",
+			Machine: "current-machine", Agent: "codex", Cwd: repo,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"gitlink-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Empty(t, observations[0].GitRemote,
+		"config must not be read through a protected .git symlink")
+	assert.Empty(t, observations[0].GitBranch,
+		"HEAD must not be read through a protected .git symlink")
+}
+
 // TestProjectIdentityObservationSkipsProtectedCommonDir pins the second hop
 // of the same leak: a gitfile target outside protected folders whose
 // commondir points into one. The gitdir itself may be read, but the common

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -202,6 +202,39 @@ func TestPreserveUnavailableSourceProjectsUsesDurableSnapshot(
 	}
 }
 
+// TestPreserveUnavailableSourceProjectsSkipsProtectedPath pins that deciding
+// whether a session's working directory still exists never stats a path in a
+// macOS TCC-protected location. This probe runs for every unresolved local
+// session in a sync batch, so on a first sync it would prompt once per
+// guarded folder before any git metadata is read.
+func TestPreserveUnavailableSourceProjectsSkipsProtectedPath(t *testing.T) {
+	database := openTestDB(t)
+	home := t.TempDir()
+	cwd := filepath.Join(home, "Downloads", "checkout")
+	require.NoError(t, os.MkdirAll(cwd, 0o755))
+	engine := NewEngine(database, EngineConfig{Machine: "test-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+	engine.stat = func(got string) (os.FileInfo, error) {
+		assert.Fail(t, "stat must not touch a protected location", got)
+		return nil, os.ErrNotExist
+	}
+
+	result, err := engine.preserveUnavailableSourceProjects(
+		t.Context(), []pendingWrite{{sess: parser.ParsedSession{
+			ID: "protected-source", Project: "protected-project",
+			Machine: "test-machine", Agent: parser.AgentClaude, Cwd: cwd,
+		}}},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.True(t, result[0].sourceProjectResolved,
+		"an unprobed session must be treated as resolved, not retried")
+	assert.Equal(t, "protected-project", result[0].sess.Project)
+}
+
 func TestWriteBatchRelabelRecoversUnavailableSourceProject(t *testing.T) {
 	const (
 		sessionID       = "relabel-unavailable-source"
@@ -5516,6 +5549,122 @@ func TestProjectIdentityObservationSkipsDiscoveryForRemoteMachine(t *testing.T) 
 		"foreign-machine cwd must not be probed for a local git identity")
 	assert.Equal(t, cwd, observations[0].RootPath,
 		"root path must stay the raw cwd, not a locally resolved git root")
+}
+
+// protectedPathIdentityRepo builds a git repo with an origin remote under
+// <home>/Documents and returns the fake home plus the session cwd inside it.
+func protectedPathIdentityRepo(t *testing.T) (home, cwd string) {
+	t.Helper()
+	home = t.TempDir()
+	root := filepath.Join(home, "Documents", "proj")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ".git", "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/docs.git\n"),
+		0o644,
+	))
+	cwd = filepath.Join(root, "subdir")
+	require.NoError(t, os.Mkdir(cwd, 0o755))
+	return home, cwd
+}
+
+// TestProjectIdentityObservationSkipsProtectedPathByDefault pins that a cwd
+// inside a macOS TCC-protected location is never probed on disk. Probing it
+// makes macOS raise a consent prompt for Documents during the first sync,
+// which is what issue #1364 reported. The cwd here is a real git repo, so a
+// discovered remote would prove the filesystem was read.
+func TestProjectIdentityObservationSkipsProtectedPathByDefault(t *testing.T) {
+	database := openTestDB(t)
+	home, cwd := protectedPathIdentityRepo(t)
+	engine := NewEngine(database, EngineConfig{Machine: "current-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-protected-skip", Project: "protected-project",
+			Machine: "current-machine", Agent: "codex", Cwd: cwd,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"protected-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Empty(t, observations[0].GitRemote,
+		"a protected-location cwd must not be probed for a git identity")
+	assert.Equal(t, cwd, observations[0].RootPath,
+		"root path must stay the raw cwd, not a resolved git root")
+}
+
+// TestProjectIdentityObservationScansProtectedPathWhenOptedIn pins that
+// scan_protected_paths restores full git identity for users who keep code in
+// Documents and accept the macOS prompt.
+func TestProjectIdentityObservationScansProtectedPathWhenOptedIn(t *testing.T) {
+	database := openTestDB(t)
+	home, cwd := protectedPathIdentityRepo(t)
+	engine := NewEngine(database, EngineConfig{
+		Machine: "current-machine", ScanProtectedPaths: true,
+	})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-protected-optin", Project: "protected-optin-project",
+			Machine: "current-machine", Agent: "codex", Cwd: cwd,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"protected-optin-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Equal(t, "https://github.com/acme/docs.git",
+		observations[0].GitRemote,
+		"opting in must restore git discovery inside protected locations")
+}
+
+// TestProjectIdentityObservationScansUnprotectedPath pins that the protected
+// -path gate does not disturb the ordinary case: a cwd outside the guarded
+// locations still gets full git identity with the default configuration.
+func TestProjectIdentityObservationScansUnprotectedPath(t *testing.T) {
+	database := openTestDB(t)
+	home := t.TempDir()
+	root := filepath.Join(home, "src", "proj")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ".git", "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/src.git\n"),
+		0o644,
+	))
+	engine := NewEngine(database, EngineConfig{Machine: "current-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-unprotected", Project: "unprotected-project",
+			Machine: "current-machine", Agent: "codex", Cwd: root,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"unprotected-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Equal(t, "https://github.com/acme/src.git",
+		observations[0].GitRemote,
+		"paths outside protected locations must still be discovered")
 }
 
 func TestProjectIdentityObservationDiscoversForLegacyLocalMachine(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -235,6 +235,63 @@ func TestPreserveUnavailableSourceProjectsSkipsProtectedPath(t *testing.T) {
 	assert.Equal(t, "protected-project", result[0].sess.Project)
 }
 
+// TestPreserveUnavailableSourceProjectsSkipsProtectedSnapshotRoot pins that
+// containment against a durable snapshot's root never resolves symlinks
+// inside a guarded folder: the session cwd is vetted upstream, but the
+// snapshot root is stored data that can predate protected-path gating. A
+// refused root falls back to lexical containment, so the reconciliation
+// completes without EvalSymlinks ever walking the guarded path.
+func TestPreserveUnavailableSourceProjectsSkipsProtectedSnapshotRoot(t *testing.T) {
+	database := openTestDB(t)
+	home := t.TempDir()
+	protectedRoot := filepath.Join(home, "Documents", "proj")
+	cwd := filepath.Join(home, "src", "gone")
+	const sessionID = "protected-snapshot-source"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: sessionID, Project: "snapshot-project",
+		Machine: "test-machine", Agent: string(parser.AgentClaude), Cwd: cwd,
+	}))
+	require.NoError(t,
+		database.UpsertProjectIdentityObservationWithSnapshotProject(
+			t.Context(), export.ProjectIdentityObservation{
+				SessionID: sessionID, Project: "snapshot-project",
+				Machine: "test-machine", RootPath: protectedRoot,
+				GitRemote:        "https://example.com/team/project.git",
+				RemoteResolution: export.ProjectResolutionResolved,
+				ObservedAt: time.Date(
+					2026, 8, 9, 12, 0, 0, 0, time.UTC,
+				),
+			}, "snapshot-project",
+		))
+	engine := NewEngine(database, EngineConfig{Machine: "test-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	origEval := evalSymlinks
+	t.Cleanup(func() { evalSymlinks = origEval })
+	evalSymlinks = func(path string) (string, error) {
+		if strings.HasPrefix(path, filepath.Join(home, "Documents")) {
+			assert.Fail(t, "a protected snapshot root must not be resolved", path)
+		}
+		return origEval(path)
+	}
+
+	result, err := engine.preserveUnavailableSourceProjects(
+		t.Context(), []pendingWrite{{sess: parser.ParsedSession{
+			ID: sessionID, Project: "parser-fallback",
+			Machine: "test-machine", Agent: parser.AgentClaude, Cwd: cwd,
+		}}},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.True(t, result[0].sourceProjectResolved)
+	assert.Equal(t, "parser-fallback", result[0].sess.Project,
+		"a refused snapshot root that does not contain the cwd lexically "+
+			"must leave the parsed project untouched")
+}
+
 func TestWriteBatchRelabelRecoversUnavailableSourceProject(t *testing.T) {
 	const (
 		sessionID       = "relabel-unavailable-source"

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5813,6 +5813,143 @@ func TestProjectIdentityObservationSkipsProtectedCommonDir(t *testing.T) {
 		"a protected common directory must not be read for remotes")
 }
 
+// TestProjectIdentityObservationSkipsSymlinkedMetadataFiles pins that the
+// exact metadata-file paths are vetted before reading: HEAD, config, and
+// commondir sit inside vetted directories, but as symlinks they can lead
+// into a protected folder, and reading through one would raise the consent
+// prompt every directory-level vet already prevented. Each protected target
+// holds real git data, so a missing vet is caught by that data leaking into
+// the observation.
+func TestProjectIdentityObservationSkipsSymlinkedMetadataFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
+	tests := []struct {
+		name  string
+		build func(t *testing.T, home, gitDir string)
+		check func(t *testing.T, obs export.ProjectIdentityObservation)
+	}{
+		{
+			name: "HEAD symlink",
+			build: func(t *testing.T, home, gitDir string) {
+				t.Helper()
+				target := filepath.Join(home, "Documents", "head-target")
+				require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+				require.NoError(t, os.WriteFile(
+					target, []byte("ref: refs/heads/leak-branch\n"), 0o644,
+				))
+				require.NoError(t, os.Symlink(
+					target, filepath.Join(gitDir, "HEAD"),
+				))
+			},
+			check: func(t *testing.T, obs export.ProjectIdentityObservation) {
+				t.Helper()
+				assert.Empty(t, obs.GitBranch,
+					"HEAD must not be read through a protected symlink")
+			},
+		},
+		{
+			name: "config symlink",
+			build: func(t *testing.T, home, gitDir string) {
+				t.Helper()
+				target := filepath.Join(home, "Documents", "config-target")
+				require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+				require.NoError(t, os.WriteFile(
+					target,
+					[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/leak.git\n"),
+					0o644,
+				))
+				require.NoError(t, os.Symlink(
+					target, filepath.Join(gitDir, "config"),
+				))
+			},
+			check: func(t *testing.T, obs export.ProjectIdentityObservation) {
+				t.Helper()
+				assert.Empty(t, obs.GitRemote,
+					"config must not be read through a protected symlink")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := openTestDB(t)
+			home := t.TempDir()
+			repo := filepath.Join(home, "src", "repo")
+			gitDir := filepath.Join(repo, ".git")
+			require.NoError(t, os.MkdirAll(gitDir, 0o755))
+			tt.build(t, home, gitDir)
+			engine := NewEngine(database, EngineConfig{
+				Machine: "current-machine",
+			})
+			t.Cleanup(engine.Close)
+			engine.goos = "darwin"
+			engine.homeDir = home
+
+			project := "meta-" + strings.ReplaceAll(tt.name, " ", "-")
+			require.NoError(t, engine.writeProjectIdentityObservation(
+				t.Context(), db.Session{
+					ID: "identity-" + project, Project: project,
+					Machine: "current-machine", Agent: "codex", Cwd: repo,
+					StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+				},
+			))
+
+			observations, err := database.ListProjectIdentityObservations(
+				t.Context(), []string{project},
+			)
+			require.NoError(t, err)
+			require.Len(t, observations, 1)
+			tt.check(t, observations[0])
+		})
+	}
+}
+
+// TestProjectIdentityObservationSkipsSymlinkedCommondirFile pins the same
+// vet for the commondir file inside a linked worktree's gitdir: reading it
+// through a protected symlink would both touch the protected folder and
+// misclassify the worktree as linked.
+func TestProjectIdentityObservationSkipsSymlinkedCommondirFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
+	database := openTestDB(t)
+	home := t.TempDir()
+	gitStore := filepath.Join(home, "gitstore", "wt-git")
+	require.NoError(t, os.MkdirAll(gitStore, 0o755))
+	target := filepath.Join(home, "Documents", "commondir-target")
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+	require.NoError(t, os.WriteFile(target, []byte("../..\n"), 0o644))
+	require.NoError(t, os.Symlink(
+		target, filepath.Join(gitStore, "commondir"),
+	))
+	worktree := filepath.Join(home, "src", "wt")
+	require.NoError(t, os.MkdirAll(worktree, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(worktree, ".git"),
+		[]byte("gitdir: "+gitStore+"\n"), 0o644,
+	))
+	engine := NewEngine(database, EngineConfig{Machine: "current-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-commondir-link", Project: "commondir-link-project",
+			Machine: "current-machine", Agent: "codex", Cwd: worktree,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"commondir-link-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Equal(t, export.WorktreeMain, observations[0].WorktreeRelationship,
+		"an unread commondir must leave the gitdir classified as main")
+}
+
 // TestProjectIdentityObservationScansProtectedPathWhenOptedIn pins that
 // scan_protected_paths restores full git identity for users who keep code in
 // Documents and accept the macOS prompt.

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5605,6 +5605,9 @@ func TestProjectIdentityObservationSkipsProtectedPathByDefault(t *testing.T) {
 // lexical-only gate would pass it, and the discovery's own EvalSymlinks and
 // git reads would then enter the protected folder.
 func TestProjectIdentityObservationSkipsSymlinkedProtectedCwd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
 	database := openTestDB(t)
 	home, _ := protectedPathIdentityRepo(t)
 	require.NoError(t, os.Symlink(
@@ -5641,6 +5644,9 @@ func TestProjectIdentityObservationSkipsSymlinkedProtectedCwd(t *testing.T) {
 // stays refused, because consenting to macOS consent prompts is not
 // consenting to waking automountd on every identity-cache miss.
 func TestMayProbeLocalPathRefusesAutomountDespiteOptIn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
 	home := t.TempDir()
 	require.NoError(t, os.Symlink("/home", filepath.Join(home, "tohome")))
 	engine := NewEngine(openTestDB(t), EngineConfig{
@@ -5718,6 +5724,9 @@ func TestProjectIdentityObservationSkipsProtectedGitdirTarget(t *testing.T) {
 // location. The link target is a real git directory with a branch and a
 // remote, so a missing vet is caught by either leaking into the observation.
 func TestProjectIdentityObservationSkipsSymlinkedGitDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the probe classifier walks POSIX paths and symlinks")
+	}
 	database := openTestDB(t)
 	home := t.TempDir()
 	realGit := filepath.Join(home, "Documents", "main", ".git")

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5600,6 +5600,41 @@ func TestProjectIdentityObservationSkipsProtectedPathByDefault(t *testing.T) {
 		"root path must stay the raw cwd, not a resolved git root")
 }
 
+// TestProjectIdentityObservationSkipsSymlinkedProtectedCwd pins that a cwd
+// reaching a protected location only through a symlink is refused too: a
+// lexical-only gate would pass it, and the discovery's own EvalSymlinks and
+// git reads would then enter the protected folder.
+func TestProjectIdentityObservationSkipsSymlinkedProtectedCwd(t *testing.T) {
+	database := openTestDB(t)
+	home, _ := protectedPathIdentityRepo(t)
+	require.NoError(t, os.Symlink(
+		filepath.Join(home, "Documents"), filepath.Join(home, "code"),
+	))
+	cwd := filepath.Join(home, "code", "proj", "subdir")
+	engine := NewEngine(database, EngineConfig{Machine: "current-machine"})
+	t.Cleanup(engine.Close)
+	engine.goos = "darwin"
+	engine.homeDir = home
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-protected-symlink", Project: "symlinked-project",
+			Machine: "current-machine", Agent: "codex", Cwd: cwd,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"symlinked-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Empty(t, observations[0].GitRemote,
+		"a cwd symlinked into a protected location must not be probed")
+	assert.Equal(t, cwd, observations[0].RootPath,
+		"root path must stay the raw cwd, not a resolved protected root")
+}
+
 // TestProjectIdentityObservationScansProtectedPathWhenOptedIn pins that
 // scan_protected_paths restores full git identity for users who keep code in
 // Documents and accept the macOS prompt.


### PR DESCRIPTION
Closes #1364.

## Problem

On first open, the macOS app asked for access to Documents, Downloads, and Dropbox. The app requests no special entitlements — the prompts came from background sync reading files inside those folders:

- Every session's recorded working directory gets probed for git info (repo root, remote, branch).
- The first sync probes every session in the archive at once.
- macOS shows one consent prompt per protected folder that any session ever ran in.

## Fix

- New path classifier decides, before touching anything: **safe**, **protected** (Documents, Downloads, Desktop, Movies, Music, Pictures, iCloud Drive, cloud folders like Dropbox), or **automount** (`/home`, `/net`).
- Protected paths are not probed. Sessions there are still ingested, listed, and searchable — they just show a path-based name with no git remote, worktree, or branch info.
- Every probe checks the classifier first: git-root walks, gitfile targets, metadata files (`HEAD`, `config`, `commondir`), deleted-session recovery, and stored snapshot roots.
- The classifier follows symlinks and `..` in real traversal order, folds case, and recognizes the `/System/Volumes/Data` firmlink spelling — without itself entering protected folders or waking automountd.
- Custom autofs mounts from the host's mount table (e.g. `/corp/home`) count as automount too.
- Passive discovery never runs the `git` binary: git follows config-derived paths (`[include] path`) that no vetting can constrain. All git-layout resolution is filesystem-local; rare layouts only git could resolve now get path-based names.

## Opting back in

- Set `scan_protected_paths = true` in `config.toml` to restore full git info for code kept in protected folders. macOS prompts once per folder.
- The opt-in never allows automount probing (that would cause CPU churn, not a prompt).
- Applies to sessions parsed after the change; run `agentsview sync --full` to refresh existing ones.

## Known limits

- The protected-folder list is fixed; a cloud app that mounts a folder directly in `$HOME` (outside `~/Library/CloudStorage`) would still prompt.
- An old-style real `~/Dropbox` folder (not cloud-mounted) loses git info it didn't have to; the opt-in restores it.

## Where to look

- `internal/export/project_identity.go` — the classifier
- `internal/sync/engine.go` — identity capture gates
- `internal/parser/project.go` — project-name extraction gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
