### PR TITLE
fix(parser): trim replayed prefix of backgrounded Claude sessions

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -98,18 +98,17 @@ Grok section and remove the explicit registry exception in the coverage test.
   persists verbatim inside the stored usage object. Verified 2026-07-30
   against two local web-search sessions: when the search is driven by the
   **CLI's** `WebSearch` tool, every assistant record carries
-  `server_tool_use: {"web_search_requests": 0, "web_fetch_requests": 0}` —
-  the search itself runs in an out-of-band side call that is **not written to
-  the transcript at all**. The only surviving evidence is the tool-result
-  record's `toolUseResult` object
-  (`{query, results, durationSeconds, searchCount}`), whose `searchCount`
-  matched the wire-billed `web_search_requests` (1 == 1) in both sessions.
-  Agentsview therefore credits the assistant message that issued the
-  `WebSearch` `tool_use` with its linked result's `searchCount`, and uses the
-  message's own counter instead whenever that counter is nonzero (which is
-  what sessions driving the API directly report), so a search is never
-  counted twice. **Known undercount:** the side call's own token usage — tens
-  of thousands of input tokens on `claude-haiku-4-5` per search — is not
+  `server_tool_use: {"web_search_requests": 0, "web_fetch_requests": 0}` — the
+  search itself runs in an out-of-band side call that is **not written to the
+  transcript at all**. The only surviving evidence is the tool-result record's
+  `toolUseResult` object (`{query, results, durationSeconds, searchCount}`),
+  whose `searchCount` matched the wire-billed `web_search_requests` (1 == 1)
+  in both sessions. Agentsview therefore credits the assistant message that
+  issued the `WebSearch` `tool_use` with its linked result's `searchCount`,
+  and uses the message's own counter instead whenever that counter is nonzero
+  (which is what sessions driving the API directly report), so a search is
+  never counted twice. **Known undercount:** the side call's own token usage —
+  tens of thousands of input tokens on `claude-haiku-4-5` per search — is not
   persisted anywhere in the transcript and is not recoverable, so it is
   neither recorded nor estimated. `web_fetch_requests` is recorded when
   present but is not priced. Data version 82 reparses existing Claude archives
@@ -131,37 +130,38 @@ Grok section and remove the explicit registry exception in the coverage test.
   still traversed only to discover nested subagents. Verified 2026-07-30
   against wire-captured billing for three local Claude Code sessions: parents
   with subagents under-reported cost by 45-77% before the presentation-time
-  rollup. Reverified 2026-07-30 with Claude Code 2.1.220: a streaming tool turn
-  can persist several assistant records with one `(message.id, requestId)` pair
-  while `usage.output_tokens` grows from an early partial count to the final
-  billed count (observed examples included `5` then `631` and `6` then `798`).
-  Usage reporting therefore keeps the greatest output-token snapshot for each
-  message/request identity across the included sessions, attributes it to the
-  earliest transcript, and then applies cross-session replay deduplication.
-  Session-owned dimensions and display metadata also come from that earliest
-  transcript. Numeric-string token values remain accepted as compatibility
-  input and are normalized before snapshot comparison on every backend. The
-  SQLite and PostgreSQL read the exact top-level token path and nested
-  server-tool path even in supported malformed legacy JSON. Reverified
-  2026-08-06 with end-truncated objects containing earlier nested decoy keys;
-  PostgreSQL and its Cockroach-compatible helper repair the truncated object
-  before extracting the requested path, while irreparable input contributes no
-  counter rather than an ambiguously scoped value.
-  Equal snapshots are selected deterministically by timestamp, session id, and
-  message ordinal; equivalent RFC3339 spellings use the semantic tie-breakers
-  rather than raw timestamp text. Reverified 2026-08-04 against the
-  cross-backend stored-usage fixtures.
+  rollup. Reverified 2026-07-30 with Claude Code 2.1.220: a streaming tool
+  turn can persist several assistant records with one
+  `(message.id, requestId)` pair while `usage.output_tokens` grows from an
+  early partial count to the final billed count (observed examples included
+  `5` then `631` and `6` then `798`). Usage reporting therefore keeps the
+  greatest output-token snapshot for each message/request identity across the
+  included sessions, attributes it to the earliest transcript, and then
+  applies cross-session replay deduplication. Session-owned dimensions and
+  display metadata also come from that earliest transcript. Numeric-string
+  token values remain accepted as compatibility input and are normalized
+  before snapshot comparison on every backend. The SQLite and PostgreSQL read
+  the exact top-level token path and nested server-tool path even in supported
+  malformed legacy JSON. Reverified 2026-08-06 with end-truncated objects
+  containing earlier nested decoy keys; PostgreSQL and its
+  Cockroach-compatible helper repair the truncated object before extracting
+  the requested path, while irreparable input contributes no counter rather
+  than an ambiguously scoped value. Equal snapshots are selected
+  deterministically by timestamp, session id, and message ordinal; equivalent
+  RFC3339 spellings use the semantic tie-breakers rather than raw timestamp
+  text. Reverified 2026-08-04 against the cross-backend stored-usage fixtures.
   Replaying the three captured sessions after this correction matched all
   transcript-visible output; each full-wire total remained 15 output tokens
-  higher because Claude Code's separate session-title request is not persisted.
-  Reverified 2026-08-06 that session-summary export loads matching snapshots
-  across excluded sessions and pagination before applying the same snapshot,
-  attribution, web-search, and generic deduplication rules. These accounting
-  semantics are exposed by usage, activity, and session-summary schema version
-  5 and reporting schema version 2; reporting version 1 retains its frozen
-  first-seen, token-only semantics. Reverified 2026-08-06 that DuckDB records a
-  web-search-only flat fee as computed pricing provenance, so combining it with
-  a provider-reported cost is labeled `mixed` like the SQLite archive.
+  higher because Claude Code's separate session-title request is not
+  persisted. Reverified 2026-08-06 that session-summary export loads matching
+  snapshots across excluded sessions and pagination before applying the same
+  snapshot, attribution, web-search, and generic deduplication rules. These
+  accounting semantics are exposed by usage, activity, and session-summary
+  schema version 5 and reporting schema version 2; reporting version 1 retains
+  its frozen first-seen, token-only semantics. Reverified 2026-08-06 that
+  DuckDB records a web-search-only flat fee as computed pricing provenance, so
+  combining it with a provider-reported cost is labeled `mixed` like the
+  SQLite archive.
 - **Agentsview:** `internal/parser/claude.go` and
   `internal/parser/claude_provider.go`; local observations and fixtures are
   the implementation evidence for fields not documented upstream. Reverified
@@ -180,6 +180,21 @@ Grok section and remove the explicit registry exception in the coverage test.
   `promptSource` (per user turn, e.g. `"typed"`, `"queued"`, `"system"`,
   `"sdk"`). Neither key is documented upstream or covered by the codeburn
   notes; the evidence remains local observation under `no-public-source`.
+  Reverified 2026-08-09 against controlled `--resume <session> --fork-session`
+  reproductions and inspection of the Claude Code 2.1.226 bundle
+  ([#1370](https://github.com/kenn-io/agentsview/issues/1370)): the background
+  handoff (left-arrow picker, Ctrl+B, `/background`) spawns
+  `claude --resume <transcript> --fork-session` with
+  `CLAUDE_CODE_SESSION_KIND=bg`. The forked process re-persists the entire
+  prior message chain into a new transcript in the same project directory;
+  replayed chain entries are byte-identical to the originals (same `uuid`,
+  `parentUuid`, `timestamp`, `requestId`, `message.id`, and usage) except for
+  a rewritten `sessionId` and, when spawned by the background launcher, an
+  injected `sessionKind:"bg"` on every chain entry. The new transcript carries
+  no pointer back to the original session (no Codex-style `forked_from_id`),
+  so `internal/parser/claude_lineage.go` establishes lineage from sibling
+  content overlap anchored on the asymmetric `bg` stamp. Evidence remains
+  `no-public-source`.
 
 ## OpenClaude (`openclaude`)
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -198,7 +198,12 @@ Grok section and remove the explicit registry exception in the coverage test.
   attachment: only uuid-bearing chain entries are replayed into the fork;
   uuid-less records (queued commands, queue-operations, ai-title, mode) never
   appear in the replay region, so every uuid-less line in a fork transcript is
-  the fork's own. Evidence remains `no-public-source`.
+  the fork's own. Reverified 2026-08-09 by forking a fully bg-marked transcript
+  with a plain non-bg `--fork-session` process: every replayed line in the new
+  transcript carries no `sessionKind` — the writer re-stamps the current
+  process's kind on each persisted line, overwriting the copied value, so the
+  bg marker reflects the forking process and cannot be inherited through
+  replayed entries. Evidence remains `no-public-source`.
 
 ## OpenClaude (`openclaude`)
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -193,8 +193,12 @@ Grok section and remove the explicit registry exception in the coverage test.
   injected `sessionKind:"bg"` on every chain entry. The new transcript carries
   no pointer back to the original session (no Codex-style `forked_from_id`),
   so `internal/parser/claude_lineage.go` establishes lineage from sibling
-  content overlap anchored on the asymmetric `bg` stamp. Evidence remains
-  `no-public-source`.
+  content overlap anchored on the asymmetric `bg` stamp. Reverified 2026-08-09
+  by fork-resuming a transcript containing a uuid-less `queued_command`
+  attachment: only uuid-bearing chain entries are replayed into the fork;
+  uuid-less records (queued commands, queue-operations, ai-title, mode) never
+  appear in the replay region, so every uuid-less line in a fork transcript is
+  the fork's own. Evidence remains `no-public-source`.
 
 ## OpenClaude (`openclaude`)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -375,7 +375,12 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // when the message's own server_tool_use counter is zero. Existing Claude
 // rows need re-parsing so historical web searches are charged the
 // per-request fee.)
-const dataVersion = 82
+// (83: Claude background-fork lineage. The parser now trims the replayed
+// prefix a background handoff copies into its new transcript and links the
+// fork to its original session as a continuation. Existing Claude rows need
+// re-parsing so already-ingested fork sessions drop their duplicated
+// messages and usage and stop appearing as unrelated top-level sessions.)
+const dataVersion = 83
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1009,8 +1009,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionUsageReparses(t *testing.T) {
-	assert.Equal(t, 82, CurrentDataVersion(),
-		"Pi cacheWrite usage and Claude web-search accounting require sequential backfills")
+	assert.Equal(t, 83, CurrentDataVersion(),
+		"Claude background-fork lineage requires a full resync so stored fork sessions drop replayed messages")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -88,14 +88,13 @@ func claudeParseFile(
 
 	// Background-fork lineage: when the transcript is a bg-marked fork
 	// that replays a non-bg sibling, drop the replayed prefix and link
-	// the fork to its parent. A fork with no entries of its own yet is
-	// an exact copy of the parent and is excluded outright.
+	// the fork to its parent. Whether the fork is still an exact copy
+	// of the parent is decided after parsing: uuid-less fork-own
+	// records (a prompt queued at handoff) can carry the fork's only
+	// message.
 	var lineage *claudeLineagePlan
 	if opts.siblingLineage {
 		lineage = claudeResolveSiblingLineage(path)
-		if lineage.pureReplay() {
-			return nil, []string{sessionID}, nil
-		}
 	}
 
 	f, err := os.Open(path)
@@ -412,11 +411,16 @@ func claudeParseFile(
 	// Drop content-free /usage probe sessions (e.g. CodexBar's
 	// ClaudeProbe) after the queued-command splice so both inline
 	// and queued /usage prompts are visible to the check. They never
-	// enter the archive.
+	// enter the archive. A background fork whose trimmed result holds
+	// no messages of its own is still an exact copy of its parent and
+	// is excluded the same way, retiring any previously stored
+	// untrimmed row.
 	kept := results[:0]
 	var excluded []string
 	for _, r := range results {
-		if isUsageProbeSession(r.Messages) {
+		if isUsageProbeSession(r.Messages) ||
+			(lineage != nil && r.Session.ID == sessionID &&
+				len(r.Messages) == 0) {
 			excluded = append(excluded, r.Session.ID)
 			continue
 		}

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -73,12 +73,30 @@ type claudeQueuedCommand struct {
 func claudeParseWithExclusions(
 	path, project, machine string,
 ) ([]ParseResult, []string, error) {
+	return claudeParseFile(path, project, machine, claudeParseOptions{})
+}
+
+func claudeParseFile(
+	path, project, machine string, opts claudeParseOptions,
+) ([]ParseResult, []string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
 	}
 
 	sessionID := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+
+	// Background-fork lineage: when the transcript is a bg-marked fork
+	// that replays a non-bg sibling, drop the replayed prefix and link
+	// the fork to its parent. A fork with no entries of its own yet is
+	// an exact copy of the parent and is excluded outright.
+	var lineage *claudeLineagePlan
+	if opts.siblingLineage {
+		lineage = claudeResolveSiblingLineage(path)
+		if lineage.pureReplay() {
+			return nil, []string{sessionID}, nil
+		}
+	}
 
 	f, err := os.Open(path)
 	if err != nil {
@@ -103,6 +121,7 @@ func claudeParseWithExclusions(
 		sessionKind     string
 		foundParentSID  bool
 		lineIndex       int
+		uuidLineOrdinal int
 		malformedLines  int
 		lastLineHasData bool
 		lastLineValid   bool
@@ -112,6 +131,9 @@ func claudeParseWithExclusions(
 	)
 	allHaveUUID = true
 	parentSessionID = claudeCompanionParentSessionID(path, sessionID)
+	if lineage != nil {
+		parentSessionID = lineage.parentSessionID
+	}
 
 	lr := newLineReader(f, maxLineSize)
 	defer releaseLineReader(lr)
@@ -129,6 +151,18 @@ func claudeParseWithExclusions(
 			continue
 		}
 		lastLineFailed = false
+
+		// Drop the contiguous leading replay region of a background
+		// fork before any metadata, timestamp, or attachment
+		// collection: replayed records belong to the parent session.
+		if lineage != nil &&
+			gjson.GetBytes(lineBytes, "uuid").Str != "" {
+			ordinal := uuidLineOrdinal
+			uuidLineOrdinal++
+			if ordinal < lineage.dropCount {
+				continue
+			}
+		}
 
 		entryType := gjson.GetBytes(lineBytes, "type").Str
 		if agentLabel == "" {
@@ -257,6 +291,14 @@ func claudeParseWithExclusions(
 
 		uuid := gjson.Get(line, "uuid").Str
 		parentUuid := gjson.Get(line, "parentUuid").Str
+		if lineage != nil && parentUuid != "" {
+			if _, dropped := lineage.dropUUIDs[parentUuid]; dropped {
+				// The replay boundary entry references a dropped
+				// record; re-root it so DAG processing still sees a
+				// single-root chain.
+				parentUuid = ""
+			}
+		}
 
 		if uuid != "" {
 			hasAnyUUID = true
@@ -344,6 +386,13 @@ func claudeParseWithExclusions(
 	// the original conversation timeline (results[0]).
 	if len(queuedCommands) > 0 && len(results) > 0 {
 		results[0] = applyQueuedCommands(results[0], queuedCommands)
+	}
+
+	// An established background-fork lineage is a continuation of the
+	// parent transcript. In-file DAG forks (results[1:]) keep their
+	// fork relationship to the main branch.
+	if lineage != nil && len(results) > 0 {
+		results[0].Session.RelationshipType = RelContinuation
 	}
 
 	// Classify termination status for each result. All forks

--- a/internal/parser/claude_lineage.go
+++ b/internal/parser/claude_lineage.go
@@ -1,0 +1,276 @@
+// ABOUTME: Resolves Claude background-fork lineage against sibling transcripts.
+// ABOUTME: Plans the replayed-prefix trim for background-forked session files (#1370).
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/tidwall/gjson"
+)
+
+// Claude Code's background handoff (left-arrow picker, Ctrl+B,
+// /background) spawns `claude --resume <transcript> --fork-session` with
+// CLAUDE_CODE_SESSION_KIND=bg. The forked process re-persists the entire
+// prior message chain into a new transcript in the same project
+// directory: replayed entries keep their original uuid, timestamp,
+// message id, and usage, while sessionId is rewritten and
+// sessionKind:"bg" is stamped on every chain entry. The original
+// interactive transcript carries no sessionKind and no pointer to the
+// fork, so lineage can only be established from content overlap.
+//
+// Direction is anchored on the asymmetric bg stamp: only a transcript
+// whose root chain entry is bg-marked is ever considered a fork, and
+// only non-bg siblings qualify as its ancestor. Anything ambiguous
+// (bg-to-bg pairs, unmarked manual --fork-session copies, missing or
+// divergent siblings) fails open: no trim and no relationship is
+// emitted, leaving the status-quo duplicate rather than risking a
+// wrongly-oriented trim.
+
+const (
+	// claudeLineageSniffMaxLines bounds how many leading lines are
+	// scanned for a transcript's first chain entry. Real transcripts
+	// carry at most a few non-chain records (summaries, ai-title,
+	// mode, queue-operations) before the first uuid-bearing entry.
+	claudeLineageSniffMaxLines = 256
+	// claudeSniffCacheMaxEntries bounds the shared sniff memo. The
+	// cache is rebuilt lazily after a reset, so overflow only costs
+	// re-reads of transcript heads.
+	claudeSniffCacheMaxEntries = 8192
+)
+
+// claudeHeadSniff summarizes the first uuid-bearing chain entry of a
+// transcript head.
+type claudeHeadSniff struct {
+	rootUUID string
+	rootIsBG bool
+	ok       bool
+}
+
+type claudeSniffCacheEntry struct {
+	size    int64
+	mtimeNS int64
+	sniff   claudeHeadSniff
+}
+
+// The sniff memo is package-level because providers are re-instantiated
+// for every classification and parse pass; per-instance state would
+// never get cache hits.
+var (
+	claudeSniffMu    sync.Mutex
+	claudeSniffCache = map[string]claudeSniffCacheEntry{}
+)
+
+// claudeParseOptions gates opt-in parse behaviors that only the local
+// Claude provider enables. Uploads, Cowork, and Qoder reuse the Claude
+// parse body and must keep every option off.
+type claudeParseOptions struct {
+	// siblingLineage enables background-fork lineage resolution
+	// against sibling transcripts in the same directory.
+	siblingLineage bool
+}
+
+// claudeLineagePlan describes an established fork lineage: the leading
+// dropCount uuid-bearing lines of the fork transcript are a replay of
+// the parent transcript and are dropped from the parse.
+type claudeLineagePlan struct {
+	parentSessionID string
+	dropCount       int
+	totalUUIDLines  int
+	// dropUUIDs holds the replayed uuids so retained entries whose
+	// parentUuid points into the dropped region can be re-rooted.
+	dropUUIDs map[string]struct{}
+}
+
+// pureReplay reports whether the fork holds no chain entries beyond the
+// replayed prefix, i.e. it is currently an exact copy of its parent.
+func (p *claudeLineagePlan) pureReplay() bool {
+	return p != nil && p.dropCount == p.totalUUIDLines
+}
+
+func claudeSniffHead(path string) claudeHeadSniff {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return claudeHeadSniff{}
+	}
+	claudeSniffMu.Lock()
+	if e, ok := claudeSniffCache[path]; ok &&
+		e.size == info.Size() && e.mtimeNS == info.ModTime().UnixNano() {
+		claudeSniffMu.Unlock()
+		return e.sniff
+	}
+	claudeSniffMu.Unlock()
+
+	sniff := claudeSniffHeadUncached(path)
+
+	claudeSniffMu.Lock()
+	if len(claudeSniffCache) >= claudeSniffCacheMaxEntries {
+		claudeSniffCache = map[string]claudeSniffCacheEntry{}
+	}
+	claudeSniffCache[path] = claudeSniffCacheEntry{
+		size:    info.Size(),
+		mtimeNS: info.ModTime().UnixNano(),
+		sniff:   sniff,
+	}
+	claudeSniffMu.Unlock()
+	return sniff
+}
+
+func claudeSniffHeadUncached(path string) claudeHeadSniff {
+	f, err := os.Open(path)
+	if err != nil {
+		return claudeHeadSniff{}
+	}
+	defer f.Close()
+	lr := newLineReader(f, maxLineSize)
+	defer releaseLineReader(lr)
+	for range claudeLineageSniffMaxLines {
+		lineBytes, ok := lr.nextBytes()
+		if !ok {
+			return claudeHeadSniff{}
+		}
+		if !gjson.ValidBytes(lineBytes) {
+			continue
+		}
+		uuid := gjson.GetBytes(lineBytes, "uuid").Str
+		if uuid == "" {
+			continue
+		}
+		// The first chain entry of a well-formed transcript (or of a
+		// replayed copy, which starts at the conversation root) has no
+		// parentUuid. Any other head shape is unexpected: fail open.
+		if gjson.GetBytes(lineBytes, "parentUuid").Str != "" {
+			return claudeHeadSniff{}
+		}
+		return claudeHeadSniff{
+			rootUUID: uuid,
+			rootIsBG: gjson.GetBytes(lineBytes, "sessionKind").Str == "bg",
+			ok:       true,
+		}
+	}
+	return claudeHeadSniff{}
+}
+
+// claudeScanUUIDs streams every uuid-bearing line of a transcript in
+// order. Errors and malformed lines are skipped; lineage resolution
+// fails open on incomplete data.
+func claudeScanUUIDs(path string, visit func(uuid string)) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	lr := newLineReader(f, maxLineSize)
+	defer releaseLineReader(lr)
+	for {
+		lineBytes, ok := lr.nextBytes()
+		if !ok {
+			break
+		}
+		if !gjson.ValidBytes(lineBytes) {
+			continue
+		}
+		if uuid := gjson.GetBytes(lineBytes, "uuid").Str; uuid != "" {
+			visit(uuid)
+		}
+	}
+	return lr.Err() == nil
+}
+
+// claudeResolveSiblingLineage establishes the background-fork lineage
+// for path, or returns nil when no lineage can be positively oriented.
+// Sibling discovery is head-sniff only (memoized per size and mtime);
+// the qualifying candidates' full uuid sets are read once per full
+// parse of a bg-marked fork.
+func claudeResolveSiblingLineage(path string) *claudeLineagePlan {
+	self := claudeSniffHead(path)
+	if !self.ok || !self.rootIsBG {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	base := filepath.Base(path)
+	type candidate struct {
+		path string
+		stem string
+	}
+	var candidates []candidate
+	for _, de := range dirEntries {
+		name := de.Name()
+		if de.IsDir() || name == base ||
+			!strings.HasSuffix(name, ".jsonl") ||
+			strings.HasPrefix(name, "agent-") {
+			continue
+		}
+		sibling := claudeSniffHead(filepath.Join(dir, name))
+		if !sibling.ok || sibling.rootIsBG ||
+			sibling.rootUUID != self.rootUUID {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			path: filepath.Join(dir, name),
+			stem: strings.TrimSuffix(name, ".jsonl"),
+		})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].stem < candidates[j].stem
+	})
+
+	var forkSeq []string
+	if !claudeScanUUIDs(path, func(uuid string) {
+		forkSeq = append(forkSeq, uuid)
+	}) || len(forkSeq) == 0 {
+		return nil
+	}
+
+	// Pick the candidate whose uuid set covers the longest contiguous
+	// leading run of the fork: with chained ancestors sharing one
+	// root, the deepest ancestor is the one the fork replayed.
+	bestRun := 0
+	bestStem := ""
+	var bestSet map[string]struct{}
+	for _, c := range candidates {
+		set := make(map[string]struct{})
+		if !claudeScanUUIDs(c.path, func(uuid string) {
+			set[uuid] = struct{}{}
+		}) {
+			continue
+		}
+		run := 0
+		for _, uuid := range forkSeq {
+			if _, ok := set[uuid]; !ok {
+				break
+			}
+			run++
+		}
+		if run > bestRun {
+			bestRun = run
+			bestStem = c.stem
+			bestSet = set
+		}
+	}
+	if bestRun == 0 {
+		return nil
+	}
+	dropUUIDs := make(map[string]struct{}, bestRun)
+	for _, uuid := range forkSeq[:bestRun] {
+		if _, ok := bestSet[uuid]; ok {
+			dropUUIDs[uuid] = struct{}{}
+		}
+	}
+	return &claudeLineagePlan{
+		parentSessionID: bestStem,
+		dropCount:       bestRun,
+		totalUUIDLines:  len(forkSeq),
+		dropUUIDs:       dropUUIDs,
+	}
+}

--- a/internal/parser/claude_lineage.go
+++ b/internal/parser/claude_lineage.go
@@ -23,12 +23,16 @@ import (
 // fork, so lineage can only be established from content overlap.
 //
 // Direction is anchored on the asymmetric bg stamp: only a transcript
-// whose root chain entry is bg-marked is ever considered a fork, and
-// only non-bg siblings qualify as its ancestor. Anything ambiguous
-// (bg-to-bg pairs, unmarked manual --fork-session copies, missing or
-// divergent siblings) fails open: no trim and no relationship is
-// emitted, leaving the status-quo duplicate rather than risking a
-// wrongly-oriented trim.
+// whose root chain entry is bg-marked is ever considered a fork. Both
+// non-bg and bg siblings qualify as ancestors, so chained backgrounding
+// trims each link against its nearest ancestor, but a bg candidate must
+// be a strict subset of the fork: a candidate that fully covers the
+// fork is either its descendant or an identical twin, and trimming
+// against it could erase the ancestor. Anything ambiguous (unmarked
+// manual --fork-session copies, missing or divergent siblings, a fork
+// fully covered by a bg sibling, several branches at the replay
+// boundary) fails open: no trim and no relationship is emitted, leaving
+// the status-quo duplicate rather than risking a wrongly-oriented trim.
 
 const (
 	// claudeLineageSniffMaxLines bounds how many leading lines are
@@ -147,10 +151,20 @@ func claudeSniffHeadUncached(path string) claudeHeadSniff {
 	return claudeHeadSniff{}
 }
 
+// claudeForkLine is one uuid-bearing line of a fork transcript.
+type claudeForkLine struct {
+	uuid       string
+	parentUUID string
+	// chainEntry marks user/assistant records — the ones the parser
+	// collects into DAG entries and whose parent links matter for
+	// boundary re-rooting.
+	chainEntry bool
+}
+
 // claudeScanUUIDs streams every uuid-bearing line of a transcript in
 // order. Errors and malformed lines are skipped; lineage resolution
 // fails open on incomplete data.
-func claudeScanUUIDs(path string, visit func(uuid string)) bool {
+func claudeScanUUIDs(path string, visit func(line claudeForkLine)) bool {
 	f, err := os.Open(path)
 	if err != nil {
 		return false
@@ -166,9 +180,16 @@ func claudeScanUUIDs(path string, visit func(uuid string)) bool {
 		if !gjson.ValidBytes(lineBytes) {
 			continue
 		}
-		if uuid := gjson.GetBytes(lineBytes, "uuid").Str; uuid != "" {
-			visit(uuid)
+		uuid := gjson.GetBytes(lineBytes, "uuid").Str
+		if uuid == "" {
+			continue
 		}
+		entryType := gjson.GetBytes(lineBytes, "type").Str
+		visit(claudeForkLine{
+			uuid:       uuid,
+			parentUUID: gjson.GetBytes(lineBytes, "parentUuid").Str,
+			chainEntry: entryType == "user" || entryType == "assistant",
+		})
 	}
 	return lr.Err() == nil
 }
@@ -192,6 +213,7 @@ func claudeResolveSiblingLineage(path string) *claudeLineagePlan {
 	type candidate struct {
 		path string
 		stem string
+		bg   bool
 	}
 	var candidates []candidate
 	for _, de := range dirEntries {
@@ -202,48 +224,59 @@ func claudeResolveSiblingLineage(path string) *claudeLineagePlan {
 			continue
 		}
 		sibling := claudeSniffHead(filepath.Join(dir, name))
-		if !sibling.ok || sibling.rootIsBG ||
-			sibling.rootUUID != self.rootUUID {
+		if !sibling.ok || sibling.rootUUID != self.rootUUID {
 			continue
 		}
 		candidates = append(candidates, candidate{
 			path: filepath.Join(dir, name),
 			stem: strings.TrimSuffix(name, ".jsonl"),
+			bg:   sibling.rootIsBG,
 		})
 	}
 	if len(candidates) == 0 {
 		return nil
 	}
+	// Non-bg candidates first so an interactive original wins a run
+	// tie against an unrelated bg fork of the same original.
 	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].bg != candidates[j].bg {
+			return !candidates[i].bg
+		}
 		return candidates[i].stem < candidates[j].stem
 	})
 
-	var forkSeq []string
-	if !claudeScanUUIDs(path, func(uuid string) {
-		forkSeq = append(forkSeq, uuid)
+	var forkSeq []claudeForkLine
+	if !claudeScanUUIDs(path, func(line claudeForkLine) {
+		forkSeq = append(forkSeq, line)
 	}) || len(forkSeq) == 0 {
 		return nil
 	}
 
 	// Pick the candidate whose uuid set covers the longest contiguous
 	// leading run of the fork: with chained ancestors sharing one
-	// root, the deepest ancestor is the one the fork replayed.
+	// root, the nearest ancestor is the one the fork replayed. A bg
+	// candidate must remain a strict subset of the fork — full
+	// coverage means it is the fork's descendant or twin, where
+	// direction is unknowable.
 	bestRun := 0
 	bestStem := ""
 	var bestSet map[string]struct{}
 	for _, c := range candidates {
 		set := make(map[string]struct{})
-		if !claudeScanUUIDs(c.path, func(uuid string) {
-			set[uuid] = struct{}{}
+		if !claudeScanUUIDs(c.path, func(line claudeForkLine) {
+			set[line.uuid] = struct{}{}
 		}) {
 			continue
 		}
 		run := 0
-		for _, uuid := range forkSeq {
-			if _, ok := set[uuid]; !ok {
+		for _, line := range forkSeq {
+			if _, ok := set[line.uuid]; !ok {
 				break
 			}
 			run++
+		}
+		if c.bg && run == len(forkSeq) {
+			continue
 		}
 		if run > bestRun {
 			bestRun = run
@@ -255,10 +288,27 @@ func claudeResolveSiblingLineage(path string) *claudeLineagePlan {
 		return nil
 	}
 	dropUUIDs := make(map[string]struct{}, bestRun)
-	for _, uuid := range forkSeq[:bestRun] {
-		if _, ok := bestSet[uuid]; ok {
-			dropUUIDs[uuid] = struct{}{}
+	for _, line := range forkSeq[:bestRun] {
+		if _, ok := bestSet[line.uuid]; ok {
+			dropUUIDs[line.uuid] = struct{}{}
 		}
+	}
+	// More than one retained chain entry hanging off the dropped
+	// region means the replay boundary carries retry or fork
+	// branches. Re-rooting them all would collapse the DAG into a
+	// linear merge, so the trim fails open and the intact DAG keeps
+	// its branch semantics.
+	danglingChildren := 0
+	for _, line := range forkSeq[bestRun:] {
+		if !line.chainEntry {
+			continue
+		}
+		if _, dropped := dropUUIDs[line.parentUUID]; dropped {
+			danglingChildren++
+		}
+	}
+	if danglingChildren > 1 {
+		return nil
 	}
 	return &claudeLineagePlan{
 		parentSessionID: bestStem,

--- a/internal/parser/claude_lineage.go
+++ b/internal/parser/claude_lineage.go
@@ -23,16 +23,20 @@ import (
 // fork, so lineage can only be established from content overlap.
 //
 // Direction is anchored on the asymmetric bg stamp: only a transcript
-// whose root chain entry is bg-marked is ever considered a fork. Both
-// non-bg and bg siblings qualify as ancestors, so chained backgrounding
-// trims each link against its nearest ancestor, but a bg candidate must
-// be a strict subset of the fork: a candidate that fully covers the
-// fork is either its descendant or an identical twin, and trimming
-// against it could erase the ancestor. Anything ambiguous (unmarked
-// manual --fork-session copies, missing or divergent siblings, a fork
-// fully covered by a bg sibling, several branches at the replay
-// boundary) fails open: no trim and no relationship is emitted, leaving
-// the status-quo duplicate rather than risking a wrongly-oriented trim.
+// whose root chain entry is bg-marked is ever considered a fork. The
+// stamp is process-derived — the writer re-stamps sessionKind from the
+// current process on every persisted line, so a non-bg fork of a bg
+// transcript carries no marker and never trims. Both non-bg and bg
+// siblings qualify as ancestors, so chained backgrounding trims each
+// link against its nearest ancestor, but a bg candidate that strictly
+// contains the fork never wins: it is the fork's descendant or an
+// extension, and trimming against it could erase the ancestor. Equal
+// uuid content (a fork that is a pure copy of a bg sibling) elects
+// direction deterministically by stem. Anything else ambiguous
+// (unmarked manual --fork-session copies, missing or divergent
+// siblings, several branches at the replay boundary) fails open: no
+// trim and no relationship is emitted, leaving the status-quo
+// duplicate rather than risking a wrongly-oriented trim.
 
 const (
 	// claudeLineageSniffMaxLines bounds how many leading lines are
@@ -255,9 +259,16 @@ func claudeResolveSiblingLineage(path string) *claudeLineagePlan {
 	// Pick the candidate whose uuid set covers the longest contiguous
 	// leading run of the fork: with chained ancestors sharing one
 	// root, the nearest ancestor is the one the fork replayed. A bg
-	// candidate must remain a strict subset of the fork — full
-	// coverage means it is the fork's descendant or twin, where
-	// direction is unknowable.
+	// candidate that fully covers the fork is its descendant or twin,
+	// where content gives no direction. A strict superset never wins.
+	// Equal-set twins elect direction deterministically by stem: the
+	// larger stem trims against the smaller, never the reverse, so
+	// the smaller twin keeps the content and no cycle can form.
+	forkStem := strings.TrimSuffix(base, ".jsonl")
+	forkUUIDs := make(map[string]struct{}, len(forkSeq))
+	for _, line := range forkSeq {
+		forkUUIDs[line.uuid] = struct{}{}
+	}
 	bestRun := 0
 	bestStem := ""
 	var bestSet map[string]struct{}
@@ -275,7 +286,8 @@ func claudeResolveSiblingLineage(path string) *claudeLineagePlan {
 			}
 			run++
 		}
-		if c.bg && run == len(forkSeq) {
+		if c.bg && run == len(forkSeq) &&
+			(len(set) != len(forkUUIDs) || forkStem < c.stem) {
 			continue
 		}
 		if run > bestRun {

--- a/internal/parser/claude_lineage.go
+++ b/internal/parser/claude_lineage.go
@@ -79,16 +79,9 @@ type claudeParseOptions struct {
 type claudeLineagePlan struct {
 	parentSessionID string
 	dropCount       int
-	totalUUIDLines  int
 	// dropUUIDs holds the replayed uuids so retained entries whose
 	// parentUuid points into the dropped region can be re-rooted.
 	dropUUIDs map[string]struct{}
-}
-
-// pureReplay reports whether the fork holds no chain entries beyond the
-// replayed prefix, i.e. it is currently an exact copy of its parent.
-func (p *claudeLineagePlan) pureReplay() bool {
-	return p != nil && p.dropCount == p.totalUUIDLines
 }
 
 func claudeSniffHead(path string) claudeHeadSniff {
@@ -270,7 +263,6 @@ func claudeResolveSiblingLineage(path string) *claudeLineagePlan {
 	return &claudeLineagePlan{
 		parentSessionID: bestStem,
 		dropCount:       bestRun,
-		totalUUIDLines:  len(forkSeq),
 		dropUUIDs:       dropUUIDs,
 	}
 }

--- a/internal/parser/claude_lineage_test.go
+++ b/internal/parser/claude_lineage_test.go
@@ -169,6 +169,90 @@ func TestClaudeBackgroundForkPureReplayExcluded(t *testing.T) {
 	assert.Equal(t, []string{"fork-2222"}, excluded)
 }
 
+func TestClaudeBackgroundForkChainTrimsAgainstNearestBgAncestor(t *testing.T) {
+	t.Parallel()
+	// Chained backgrounding: A (interactive) -> B (bg fork of A with
+	// its own turns) -> C (bg fork of B with its own turns). C must
+	// trim B's full replay and link to B, not partially trim against
+	// A and keep B's turns duplicated. B still trims against A.
+	aContent := lineageOriginalContent()
+	bContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "bbbb-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "bbbb-2222", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "bbbb-2222", "bg", "second question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "bbbb-2222", "bg", "msg_02", "second answer", 4),
+	}, "\n") + "\n"
+	cContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "cccc-3333", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "cccc-3333", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "cccc-3333", "bg", "second question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "cccc-3333", "bg", "msg_02", "second answer", 4),
+		lineageUserLine("u5", "a2", "2026-01-01T12:00:00Z", "cccc-3333", "bg", "third question"),
+		lineageAssistantLine("a5", "u5", "2026-01-01T12:00:05Z", "cccc-3333", "bg", "msg_03", "third answer", 3),
+	}, "\n") + "\n"
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "orig-1111.jsonl"), []byte(aContent), 0o644))
+	bPath := filepath.Join(dir, "bbbb-2222.jsonl")
+	require.NoError(t, os.WriteFile(bPath, []byte(bContent), 0o644))
+	cPath := filepath.Join(dir, "cccc-3333.jsonl")
+	require.NoError(t, os.WriteFile(cPath, []byte(cContent), 0o644))
+
+	cResults, _, err := claudeParseFile(
+		cPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, cResults, 1)
+	require.Len(t, cResults[0].Messages, 2)
+	assert.Equal(t, "third question", cResults[0].Messages[0].Content)
+	assert.Equal(t, "bbbb-2222", cResults[0].Session.ParentSessionID)
+
+	bResults, _, err := claudeParseFile(
+		bPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, bResults, 1)
+	require.Len(t, bResults[0].Messages, 2)
+	assert.Equal(t, "second question", bResults[0].Messages[0].Content)
+	assert.Equal(t, "orig-1111", bResults[0].Session.ParentSessionID)
+}
+
+func TestClaudeBackgroundForkBoundaryRetryFailsOpen(t *testing.T) {
+	t.Parallel()
+	// Two retained entries parented at the replay leaf (a retry right
+	// after the handoff) cannot be re-rooted without collapsing the
+	// retry branches into a linear merge. The trim fails open so the
+	// intact DAG keeps retry semantics: only the latest branch shows.
+	forkContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+		lineageAssistantLine("x1", "a1", "2026-01-01T11:00:00Z", "fork-2222", "bg", "msg_02", "abandoned retry", 2),
+		lineageAssistantLine("x2", "a1", "2026-01-01T11:00:05Z", "fork-2222", "bg", "msg_03", "final answer", 6),
+	}, "\n") + "\n"
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", forkContent,
+	)
+
+	results, excluded, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, excluded)
+	assert.Empty(t, results[0].Session.ParentSessionID)
+	var contents []string
+	for _, m := range results[0].Messages {
+		contents = append(contents, m.Content)
+	}
+	assert.Contains(t, contents, "first question")
+	assert.Contains(t, contents, "final answer")
+	assert.NotContains(t, contents, "abandoned retry")
+}
+
 func TestClaudeBackgroundForkKeepsQueuedCommandWithoutNewChainEntry(t *testing.T) {
 	t.Parallel()
 	// A prompt queued at handoff lands as a fork-own uuid-less
@@ -229,13 +313,22 @@ func TestClaudeBackgroundForkFailOpen(t *testing.T) {
 			forkContent: lineageForkContent(),
 		},
 		{
-			name:     "ancestor also bg marked",
-			origName: "orig-1111.jsonl",
+			// A bg transcript fully covered by a bg sibling is either
+			// that sibling's ancestor or its idle copy — direction is
+			// unknowable, so it must not trim.
+			name:     "fork is subset of bg sibling",
+			origName: "long-3333.jsonl",
 			origContent: strings.Join([]string{
-				lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "orig-1111", "bg", "first question"),
-				lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "orig-1111", "bg", "msg_01", "first answer", 20),
+				lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "long-3333", "bg", "first question"),
+				lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "long-3333", "bg", "msg_01", "first answer", 20),
+				lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "long-3333", "bg", "continued question"),
+				lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "long-3333", "bg", "msg_02", "continued answer", 7),
 			}, "\n") + "\n",
-			forkContent: lineageForkContent(),
+			forkContent: strings.Join([]string{
+				lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+				lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+				lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "fork-2222", "bg", "continued question"),
+			}, "\n") + "\n",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/parser/claude_lineage_test.go
+++ b/internal/parser/claude_lineage_test.go
@@ -44,14 +44,16 @@ func lineageAssistantLine(uuid, parentUUID, ts, sessionID, kind, msgID, text str
 	)
 }
 
-func lineageQueuedCommandLine(uuid, ts, sessionID, kind, prompt string) string {
-	kindField := ""
-	if kind != "" {
-		kindField = fmt.Sprintf(`"sessionKind":%q,`, kind)
-	}
+// lineageQueuedCommandLine mirrors the real queued_command attachment
+// shape: these records carry no uuid. Verified against controlled
+// fork-resume reproductions that Claude Code never replays uuid-less
+// records into a fork transcript — only uuid-bearing chain entries are
+// re-persisted — so a queued_command in a fork file is always the
+// fork's own.
+func lineageQueuedCommandLine(ts, sessionID, prompt string) string {
 	return fmt.Sprintf(
-		`{"type":"attachment","uuid":%q,"timestamp":%q,"sessionId":%q,%s"attachment":{"type":"queued_command","commandMode":"prompt","prompt":%q}}`,
-		uuid, ts, sessionID, kindField, prompt,
+		`{"type":"attachment","timestamp":%q,"sessionId":%q,"attachment":{"type":"queued_command","commandMode":"prompt","prompt":%q}}`,
+		ts, sessionID, prompt,
 	)
 }
 
@@ -332,19 +334,27 @@ func TestClaudeBackgroundForkPicksLongestReplayCandidate(t *testing.T) {
 	assert.Equal(t, "long-3333", results[0].Session.ParentSessionID)
 }
 
-func TestClaudeBackgroundForkDropsReplayedQueuedCommand(t *testing.T) {
+func TestClaudeBackgroundForkKeepsOwnUUIDLessRecords(t *testing.T) {
 	t.Parallel()
+	// Claude Code never replays uuid-less records into a fork
+	// transcript, so every uuid-less line in a fork is the fork's own:
+	// spawn-time queue-operations interleaved before the replayed
+	// chain, and queued_command attachments typed into the fork later.
+	// Trimming must leave all of them alone — a position-based trim
+	// that discarded everything through the replay boundary would eat
+	// the fork's own head records.
 	origContent := strings.Join([]string{
 		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "orig-1111", "", "first question"),
-		lineageQueuedCommandLine("qc1", "2026-01-01T10:00:02Z", "orig-1111", "", "queued in original"),
+		lineageQueuedCommandLine("2026-01-01T10:00:02Z", "orig-1111", "queued in original"),
 		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "orig-1111", "", "msg_01", "first answer", 20),
 	}, "\n") + "\n"
 	forkContent := strings.Join([]string{
+		// Fork-own spawn-time records precede the replayed chain.
+		`{"type":"queue-operation","operation":"enqueue","timestamp":"2026-01-01T11:00:00Z","sessionId":"fork-2222","content":"{\"tool_use_id\":\"tu-1\",\"task_id\":\"task-1\"}"}`,
 		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
-		lineageQueuedCommandLine("qc1", "2026-01-01T10:00:02Z", "fork-2222", "bg", "queued in original"),
 		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
-		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "fork-2222", "bg", "continued question"),
-		lineageQueuedCommandLine("qc2", "2026-01-01T11:00:02Z", "fork-2222", "bg", "queued in fork"),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:01Z", "fork-2222", "bg", "continued question"),
+		lineageQueuedCommandLine("2026-01-01T11:00:02Z", "fork-2222", "queued in fork"),
 		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "fork-2222", "bg", "msg_02", "continued answer", 7),
 	}, "\n") + "\n"
 	_, forkPath := writeLineageFixture(t,
@@ -362,9 +372,29 @@ func TestClaudeBackgroundForkDropsReplayedQueuedCommand(t *testing.T) {
 	for _, m := range results[0].Messages {
 		prompts = append(prompts, m.Content)
 	}
-	assert.NotContains(t, prompts, "queued in original")
 	assert.Contains(t, prompts, "queued in fork")
 	assert.Contains(t, prompts, "continued question")
+	assert.NotContains(t, prompts, "first question")
+	assert.Equal(t, "orig-1111", results[0].Session.ParentSessionID)
+	// The fork-own enqueue record written before the replayed chain
+	// survives the trim: its spawn timestamp is the session start.
+	wantStart := time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)
+	assert.True(t, results[0].Session.StartedAt.Equal(wantStart),
+		"StartedAt = %v", results[0].Session.StartedAt)
+
+	// The original still splices its own queued command.
+	origResults, _, err := claudeParseFile(
+		filepath.Join(filepath.Dir(forkPath), "orig-1111.jsonl"),
+		"my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, origResults, 1)
+	var origPrompts []string
+	for _, m := range origResults[0].Messages {
+		origPrompts = append(origPrompts, m.Content)
+	}
+	assert.Contains(t, origPrompts, "queued in original")
 }
 
 func TestClaudeUploadParseIgnoresSiblingLineage(t *testing.T) {

--- a/internal/parser/claude_lineage_test.go
+++ b/internal/parser/claude_lineage_test.go
@@ -219,6 +219,101 @@ func TestClaudeBackgroundForkChainTrimsAgainstNearestBgAncestor(t *testing.T) {
 	assert.Equal(t, "orig-1111", bResults[0].Session.ParentSessionID)
 }
 
+func TestClaudeBackgroundForkQueuedOnlyChainTrimsAgainstEqualBgSibling(t *testing.T) {
+	t.Parallel()
+	// C replays B fully and holds only a uuid-less queued prompt, so
+	// its uuid content equals B's exactly. Direction between equal
+	// bg twins is elected deterministically by stem — the larger stem
+	// trims against the smaller — so C must link to B and keep just
+	// its queued prompt, not partially trim against A and duplicate
+	// B's turns.
+	aContent := lineageOriginalContent()
+	bContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "bbbb-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "bbbb-2222", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "bbbb-2222", "bg", "second question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "bbbb-2222", "bg", "msg_02", "second answer", 4),
+	}, "\n") + "\n"
+	cContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "cccc-3333", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "cccc-3333", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "cccc-3333", "bg", "second question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "cccc-3333", "bg", "msg_02", "second answer", 4),
+		lineageQueuedCommandLine("2026-01-01T12:00:00Z", "cccc-3333", "queued in c"),
+	}, "\n") + "\n"
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "orig-1111.jsonl"), []byte(aContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bbbb-2222.jsonl"), []byte(bContent), 0o644))
+	cPath := filepath.Join(dir, "cccc-3333.jsonl")
+	require.NoError(t, os.WriteFile(cPath, []byte(cContent), 0o644))
+
+	results, excluded, err := claudeParseFile(
+		cPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, excluded)
+	require.Len(t, results[0].Messages, 1)
+	assert.Equal(t, "queued in c", results[0].Messages[0].Content)
+	assert.Equal(t, "bbbb-2222", results[0].Session.ParentSessionID)
+}
+
+func TestClaudeBackgroundForkEqualBgTwinsElectKeeperByStem(t *testing.T) {
+	t.Parallel()
+	// Reverse stem order: the queued-only fork has the smaller stem,
+	// so it never trims against its equal twin. The larger-stem twin
+	// trims fully against the smaller and is excluded (it has no
+	// content of its own), while the smaller falls back to the
+	// interactive original. Every message is stored exactly once.
+	aContent := lineageOriginalContent()
+	smallContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "cccc-3333", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "cccc-3333", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "cccc-3333", "bg", "second question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "cccc-3333", "bg", "msg_02", "second answer", 4),
+		lineageQueuedCommandLine("2026-01-01T12:00:00Z", "cccc-3333", "queued in c"),
+	}, "\n") + "\n"
+	largeContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "dddd-4444", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "dddd-4444", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "dddd-4444", "bg", "second question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "dddd-4444", "bg", "msg_02", "second answer", 4),
+	}, "\n") + "\n"
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "orig-1111.jsonl"), []byte(aContent), 0o644))
+	smallPath := filepath.Join(dir, "cccc-3333.jsonl")
+	require.NoError(t, os.WriteFile(smallPath, []byte(smallContent), 0o644))
+	largePath := filepath.Join(dir, "dddd-4444.jsonl")
+	require.NoError(t, os.WriteFile(largePath, []byte(largeContent), 0o644))
+
+	largeResults, largeExcluded, err := claudeParseFile(
+		largePath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, largeResults)
+	assert.Equal(t, []string{"dddd-4444"}, largeExcluded)
+
+	smallResults, smallExcluded, err := claudeParseFile(
+		smallPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, smallResults, 1)
+	assert.Empty(t, smallExcluded)
+	var contents []string
+	for _, m := range smallResults[0].Messages {
+		contents = append(contents, m.Content)
+	}
+	assert.Contains(t, contents, "second question")
+	assert.Contains(t, contents, "queued in c")
+	assert.NotContains(t, contents, "first question")
+	assert.Equal(t, "orig-1111", smallResults[0].Session.ParentSessionID)
+}
+
 func TestClaudeBackgroundForkBoundaryRetryFailsOpen(t *testing.T) {
 	t.Parallel()
 	// Two retained entries parented at the replay leaf (a retry right

--- a/internal/parser/claude_lineage_test.go
+++ b/internal/parser/claude_lineage_test.go
@@ -169,6 +169,36 @@ func TestClaudeBackgroundForkPureReplayExcluded(t *testing.T) {
 	assert.Equal(t, []string{"fork-2222"}, excluded)
 }
 
+func TestClaudeBackgroundForkKeepsQueuedCommandWithoutNewChainEntry(t *testing.T) {
+	t.Parallel()
+	// A prompt queued at handoff lands as a fork-own uuid-less
+	// queued_command before any new chain entry exists. Even though
+	// every uuid-bearing line is replayed, the fork holds a real user
+	// message and must be kept and linked, not excluded.
+	forkContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+		lineageQueuedCommandLine("2026-01-01T11:00:00Z", "fork-2222", "queued at handoff"),
+	}, "\n") + "\n"
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", forkContent,
+	)
+
+	results, excluded, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, excluded)
+	require.Len(t, results[0].Messages, 1)
+	assert.Equal(t, "queued at handoff", results[0].Messages[0].Content)
+	assert.Equal(t, "orig-1111", results[0].Session.ParentSessionID)
+	assert.Equal(t, RelContinuation, results[0].Session.RelationshipType)
+	assert.Equal(t, 1, results[0].Session.MessageCount)
+}
+
 func TestClaudeBackgroundForkFailOpen(t *testing.T) {
 	t.Parallel()
 	// Every ambiguous case must parse untrimmed and unlinked: the

--- a/internal/parser/claude_lineage_test.go
+++ b/internal/parser/claude_lineage_test.go
@@ -1,0 +1,489 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Fixture lines mirror the verified on-disk shape of a Claude Code
+// background handoff (issue #1370): the fork transcript replays the
+// original's chain entries byte-identically except for a rewritten
+// sessionId and an injected sessionKind:"bg", then appends its own
+// turns. The original interactive transcript carries no sessionKind.
+
+func lineageUserLine(uuid, parentUUID, ts, sessionID, kind, content string) string {
+	parent := "null"
+	if parentUUID != "" {
+		parent = fmt.Sprintf("%q", parentUUID)
+	}
+	kindField := ""
+	if kind != "" {
+		kindField = fmt.Sprintf(`"sessionKind":%q,`, kind)
+	}
+	return fmt.Sprintf(
+		`{"type":"user","uuid":%q,"parentUuid":%s,"timestamp":%q,"sessionId":%q,%s"message":{"content":%q}}`,
+		uuid, parent, ts, sessionID, kindField, content,
+	)
+}
+
+func lineageAssistantLine(uuid, parentUUID, ts, sessionID, kind, msgID, text string, outputTokens int) string {
+	kindField := ""
+	if kind != "" {
+		kindField = fmt.Sprintf(`"sessionKind":%q,`, kind)
+	}
+	return fmt.Sprintf(
+		`{"type":"assistant","uuid":%q,"parentUuid":%q,"timestamp":%q,"sessionId":%q,%s"message":{"id":%q,"content":[{"type":"text","text":%q}],"usage":{"input_tokens":10,"output_tokens":%d}}}`,
+		uuid, parentUUID, ts, sessionID, kindField, msgID, text, outputTokens,
+	)
+}
+
+func lineageQueuedCommandLine(uuid, ts, sessionID, kind, prompt string) string {
+	kindField := ""
+	if kind != "" {
+		kindField = fmt.Sprintf(`"sessionKind":%q,`, kind)
+	}
+	return fmt.Sprintf(
+		`{"type":"attachment","uuid":%q,"timestamp":%q,"sessionId":%q,%s"attachment":{"type":"queued_command","commandMode":"prompt","prompt":%q}}`,
+		uuid, ts, sessionID, kindField, prompt,
+	)
+}
+
+// writeLineageFixture writes original + fork transcripts into one
+// directory and returns their paths.
+func writeLineageFixture(t *testing.T, origName, origContent, forkName, forkContent string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	origPath := filepath.Join(dir, origName)
+	forkPath := filepath.Join(dir, forkName)
+	require.NoError(t, os.WriteFile(origPath, []byte(origContent), 0o644))
+	require.NoError(t, os.WriteFile(forkPath, []byte(forkContent), 0o644))
+	return origPath, forkPath
+}
+
+func lineageOriginalContent() string {
+	return strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "orig-1111", "", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "orig-1111", "", "msg_01", "first answer", 20),
+	}, "\n") + "\n"
+}
+
+func lineageForkContent() string {
+	return strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "fork-2222", "bg", "continued question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "fork-2222", "bg", "msg_02", "continued answer", 7),
+	}, "\n") + "\n"
+}
+
+func TestClaudeBackgroundForkTrimsReplayAndLinksParent(t *testing.T) {
+	t.Parallel()
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", lineageForkContent(),
+	)
+
+	results, excluded, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, excluded)
+
+	sess := results[0].Session
+	msgs := results[0].Messages
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "continued question", msgs[0].Content)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "continued answer", msgs[1].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+
+	assert.Equal(t, "orig-1111", sess.ParentSessionID)
+	assert.Equal(t, RelContinuation, sess.RelationshipType)
+	assert.Equal(t, "fork-2222", sess.ID)
+	assert.Equal(t, "continued question", sess.FirstMessage)
+	assert.Equal(t, 2, sess.MessageCount)
+	assert.Equal(t, 1, sess.UserMessageCount)
+
+	// Session bounds and usage come only from retained records.
+	wantStart := time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 1, 1, 11, 0, 5, 0, time.UTC)
+	assert.True(t, sess.StartedAt.Equal(wantStart), "StartedAt = %v", sess.StartedAt)
+	assert.True(t, sess.EndedAt.Equal(wantEnd), "EndedAt = %v", sess.EndedAt)
+	assert.Equal(t, 7, sess.TotalOutputTokens)
+}
+
+func TestClaudeOriginalUnaffectedBySiblingFork(t *testing.T) {
+	t.Parallel()
+	origPath, _ := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", lineageForkContent(),
+	)
+
+	results, excluded, err := claudeParseFile(
+		origPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, excluded)
+
+	sess := results[0].Session
+	require.Len(t, results[0].Messages, 2)
+	assert.Equal(t, "first question", results[0].Messages[0].Content)
+	assert.Empty(t, sess.ParentSessionID)
+	assert.Equal(t, RelNone, sess.RelationshipType)
+	assert.Equal(t, 2, sess.MessageCount)
+}
+
+func TestClaudeBackgroundForkPureReplayExcluded(t *testing.T) {
+	t.Parallel()
+	// The fork is a byte-level replay with no post-handoff turns: it
+	// duplicates the original entirely and must be excluded rather
+	// than stored as a second copy of the conversation.
+	forkContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+	}, "\n") + "\n"
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", forkContent,
+	)
+
+	results, excluded, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.Equal(t, []string{"fork-2222"}, excluded)
+}
+
+func TestClaudeBackgroundForkFailOpen(t *testing.T) {
+	t.Parallel()
+	// Every ambiguous case must parse untrimmed and unlinked: the
+	// worst allowed outcome is the status quo duplicate, never a
+	// wrongly-oriented trim.
+	tests := []struct {
+		name        string
+		origName    string
+		origContent string
+		forkContent string
+	}{
+		{
+			name:        "fork not bg marked",
+			origName:    "orig-1111.jsonl",
+			origContent: lineageOriginalContent(),
+			forkContent: strings.Join([]string{
+				lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "", "first question"),
+				lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "", "msg_01", "first answer", 20),
+				lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "fork-2222", "", "continued question"),
+			}, "\n") + "\n",
+		},
+		{
+			name:     "sibling has different root",
+			origName: "orig-1111.jsonl",
+			origContent: strings.Join([]string{
+				lineageUserLine("z9", "", "2026-01-01T09:00:00Z", "orig-1111", "", "unrelated"),
+			}, "\n") + "\n",
+			forkContent: lineageForkContent(),
+		},
+		{
+			name:     "ancestor also bg marked",
+			origName: "orig-1111.jsonl",
+			origContent: strings.Join([]string{
+				lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "orig-1111", "bg", "first question"),
+				lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "orig-1111", "bg", "msg_01", "first answer", 20),
+			}, "\n") + "\n",
+			forkContent: lineageForkContent(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, forkPath := writeLineageFixture(t,
+				tt.origName, tt.origContent,
+				"fork-2222.jsonl", tt.forkContent,
+			)
+			results, excluded, err := claudeParseFile(
+				forkPath, "my_app", "local",
+				claudeParseOptions{siblingLineage: true},
+			)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Empty(t, excluded)
+			sess := results[0].Session
+			assert.Empty(t, sess.ParentSessionID)
+			assert.Equal(t, RelNone, sess.RelationshipType)
+			// Untrimmed: the replayed head is retained.
+			assert.Equal(t, "first question",
+				firstMessageContent(results[0].Messages))
+		})
+	}
+}
+
+func TestClaudeBackgroundForkNoSiblingFailsOpen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	forkPath := filepath.Join(dir, "fork-2222.jsonl")
+	require.NoError(t, os.WriteFile(forkPath, []byte(lineageForkContent()), 0o644))
+
+	results, excluded, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, excluded)
+	assert.Empty(t, results[0].Session.ParentSessionID)
+	require.Len(t, results[0].Messages, 4)
+}
+
+// firstNonEmpty returns the first message content, requiring at least
+// one message.
+func firstMessageContent(msgs []ParsedMessage) string {
+	for _, m := range msgs {
+		if m.Content != "" {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+func TestClaudeBackgroundForkKeepsPostBoundaryCoincidentalMatch(t *testing.T) {
+	t.Parallel()
+	// Only the contiguous leading replay region is trimmed. An entry
+	// after the boundary whose uuid also appears in the ancestor must
+	// be retained.
+	origContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "orig-1111", "", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "orig-1111", "", "msg_01", "first answer", 20),
+		lineageAssistantLine("x1", "a1", "2026-01-01T10:00:06Z", "orig-1111", "", "msg_0x", "stray original tail", 3),
+	}, "\n") + "\n"
+	forkContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u3", "a1", "2026-01-01T11:00:00Z", "fork-2222", "bg", "own turn"),
+		lineageAssistantLine("x1", "u3", "2026-01-01T11:00:05Z", "fork-2222", "bg", "msg_03", "post boundary reuse", 5),
+	}, "\n") + "\n"
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", origContent,
+		"fork-2222.jsonl", forkContent,
+	)
+
+	results, _, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	msgs := results[0].Messages
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "own turn", msgs[0].Content)
+	assert.Equal(t, "post boundary reuse", msgs[1].Content)
+	assert.Equal(t, "orig-1111", results[0].Session.ParentSessionID)
+}
+
+func TestClaudeBackgroundForkPicksLongestReplayCandidate(t *testing.T) {
+	t.Parallel()
+	// Two interactive transcripts share the same root (a manual
+	// interactive fork). The bg fork replays the longer one; its
+	// parent must be the candidate whose replay run is longest.
+	shortContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "orig-1111", "", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "orig-1111", "", "msg_01", "first answer", 20),
+	}, "\n") + "\n"
+	longContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "long-3333", "", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "long-3333", "", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T10:30:00Z", "long-3333", "", "second question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T10:30:05Z", "long-3333", "", "msg_02", "second answer", 4),
+	}, "\n") + "\n"
+	forkContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T10:30:00Z", "fork-2222", "bg", "second question"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T10:30:05Z", "fork-2222", "bg", "msg_02", "second answer", 4),
+		lineageUserLine("u5", "a2", "2026-01-01T11:00:00Z", "fork-2222", "bg", "fork only turn"),
+	}, "\n") + "\n"
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "orig-1111.jsonl"), []byte(shortContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "long-3333.jsonl"), []byte(longContent), 0o644))
+	forkPath := filepath.Join(dir, "fork-2222.jsonl")
+	require.NoError(t, os.WriteFile(forkPath, []byte(forkContent), 0o644))
+
+	results, _, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Messages, 1)
+	assert.Equal(t, "fork only turn", results[0].Messages[0].Content)
+	assert.Equal(t, "long-3333", results[0].Session.ParentSessionID)
+}
+
+func TestClaudeBackgroundForkDropsReplayedQueuedCommand(t *testing.T) {
+	t.Parallel()
+	origContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "orig-1111", "", "first question"),
+		lineageQueuedCommandLine("qc1", "2026-01-01T10:00:02Z", "orig-1111", "", "queued in original"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "orig-1111", "", "msg_01", "first answer", 20),
+	}, "\n") + "\n"
+	forkContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		lineageQueuedCommandLine("qc1", "2026-01-01T10:00:02Z", "fork-2222", "bg", "queued in original"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "fork-2222", "bg", "continued question"),
+		lineageQueuedCommandLine("qc2", "2026-01-01T11:00:02Z", "fork-2222", "bg", "queued in fork"),
+		lineageAssistantLine("a2", "u2", "2026-01-01T11:00:05Z", "fork-2222", "bg", "msg_02", "continued answer", 7),
+	}, "\n") + "\n"
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", origContent,
+		"fork-2222.jsonl", forkContent,
+	)
+
+	results, _, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	var prompts []string
+	for _, m := range results[0].Messages {
+		prompts = append(prompts, m.Content)
+	}
+	assert.NotContains(t, prompts, "queued in original")
+	assert.Contains(t, prompts, "queued in fork")
+	assert.Contains(t, prompts, "continued question")
+}
+
+func TestClaudeUploadParseIgnoresSiblingLineage(t *testing.T) {
+	t.Parallel()
+	// Uploaded transcripts are parsed under a user-chosen project and
+	// must never trim against whatever directory they landed in.
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", lineageForkContent(),
+	)
+
+	results, err := parseClaudeSession(forkPath, "my_app", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Session.ParentSessionID)
+	require.Len(t, results[0].Messages, 4)
+}
+
+func TestClaudeProviderParseTrimsBackgroundFork(t *testing.T) {
+	t.Parallel()
+	// End-to-end through the local provider: project-level sources
+	// resolve sibling lineage.
+	root := t.TempDir()
+	projDir := filepath.Join(root, "-home-user-proj")
+	require.NoError(t, os.MkdirAll(projDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projDir, "orig-1111.jsonl"),
+		[]byte(lineageOriginalContent()), 0o644))
+	forkPath := filepath.Join(projDir, "fork-2222.jsonl")
+	require.NoError(t, os.WriteFile(forkPath, []byte(lineageForkContent()), 0o644))
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "local",
+	})
+	require.True(t, ok)
+
+	sources := newClaudeSourceSet([]string{root})
+	source, ok := sources.sourceRef(root, forkPath)
+	require.True(t, ok)
+
+	outcome, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	sess := outcome.Results[0].Result.Session
+	assert.Equal(t, "orig-1111", sess.ParentSessionID)
+	assert.Equal(t, RelContinuation, sess.RelationshipType)
+	assert.Equal(t, 2, len(outcome.Results[0].Result.Messages))
+}
+
+func TestClaudeBackgroundForkIncrementalAppendContinuesFromTrim(t *testing.T) {
+	t.Parallel()
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", lineageForkContent(),
+	)
+
+	results, _, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Messages, 2)
+
+	info, err := os.Stat(forkPath)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := lineageUserLine("u9", "a2", "2026-01-01T12:00:00Z", "fork-2222", "bg", "appended turn") + "\n"
+	f, err := os.OpenFile(forkPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Stored identity mirrors what the engine persists from the full
+	// parse; without it the identity-fill fallback escalates every
+	// bg-marked append to a full parse.
+	msgs, _, _, _, err := claudeParseSessionFrom(forkPath, offset, claudeIncrementalScan{
+		startOrdinal:  2,
+		lastEntryUUID: "a2",
+		stored:        claudeStoredIdentity{sessionKind: "bg"},
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "appended turn", msgs[0].Content)
+	// Ordinals continue from the trimmed message count, not the raw
+	// replayed line count.
+	assert.Equal(t, 2, msgs[0].Ordinal)
+}
+
+func TestClaudeLineageSniffGivesUpAfterBoundedPreamble(t *testing.T) {
+	t.Parallel()
+	// A fork whose bg root sits past the sniff bound fails open: the
+	// resolver must not scan unbounded preamble looking for a chain
+	// root.
+	var preamble []string
+	for i := range 400 {
+		preamble = append(preamble,
+			fmt.Sprintf(`{"type":"summary","summary":"noise %d","leafUuid":"leaf-%d"}`, i, i))
+	}
+	forkLines := append(preamble,
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("u2", "a1", "2026-01-01T11:00:00Z", "fork-2222", "bg", "continued question"),
+	)
+	forkContent := strings.Join(forkLines, "\n") + "\n"
+	_, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", forkContent,
+	)
+
+	results, _, err := claudeParseFile(
+		forkPath, "my_app", "local",
+		claudeParseOptions{siblingLineage: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Session.ParentSessionID)
+	assert.Equal(t, "first question", firstMessageContent(results[0].Messages))
+}

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -91,7 +91,10 @@ func (p *claudeProvider) Parse(
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
 	project := claudeProviderProject(ctx, req.Source.ProjectHint, path)
-	results, excludedIDs, err := claudeParseWithExclusions(path, project, machine)
+	opts := claudeParseOptions{
+		siblingLineage: claudeSourceIsProjectLevel(req.Source, path),
+	}
+	results, excludedIDs, err := claudeParseFile(path, project, machine, opts)
 	if err != nil {
 		return ParseOutcome{}, err
 	}
@@ -218,6 +221,35 @@ func (p *claudeProvider) ParseIncremental(
 type claudeSource struct {
 	Root string
 	Path string
+}
+
+// claudeSourceIsProjectLevel reports whether a discovered local source
+// is a top-level project transcript (root/<project>/<session>.jsonl).
+// Only those participate in background-fork sibling lineage: subagent
+// transcripts, materialized s3 objects, and uploads never do.
+func claudeSourceIsProjectLevel(source SourceRef, path string) bool {
+	var root string
+	switch src := source.Opaque.(type) {
+	case claudeSource:
+		root = src.Root
+	case *claudeSource:
+		if src == nil {
+			return false
+		}
+		root = src.Root
+	default:
+		return false
+	}
+	if root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	return len(parts) == 2 && strings.HasSuffix(parts[1], ".jsonl") &&
+		!strings.HasPrefix(parts[1], "agent-")
 }
 
 type claudeSourceSet struct {


### PR DESCRIPTION
Fixes #1370.

Backgrounding a Claude Code session (left-arrow picker, Ctrl+B, `/background`) copies the whole conversation into a new transcript with a new session id and no back-reference. agentsview ingested both files as unrelated sessions: the conversation showed up twice in the sidebar and its usage was counted twice.

Verified against controlled reproductions and the Claude Code 2.1.226 bundle: copied lines are byte-identical except a rewritten `sessionId` and an injected `sessionKind:"bg"`; only uuid-bearing chain entries are replayed; the marker is process-derived, so ordinary interactive forks carry none.

## Fix (`internal/parser/claude_lineage.go`)

- A bg-marked transcript finds the same-directory sibling that shares its root uuid and covers the longest prefix — its nearest ancestor — drops that replayed prefix, and links to it as a `continuation` (nested in the sidebar).
- Chains trim link by link. A candidate that strictly contains the fork is its descendant and never wins; exact-equal twins pick a deterministic direction by stem.
- A fork with no content of its own is excluded; a prompt queued at handoff counts as content.
- Everything ambiguous fails open (no trim, no link): unmarked manual forks, missing or divergent siblings, branches at the replay boundary. Worst case is the status-quo duplicate.
- Data version 83 re-parses existing archives to repair old duplicates.

## Limits

- Root-to-root matching only: sessions compacted before backgrounding stay duplicated for now.
- Lineage reads on-disk state at parse time; a sibling appearing after a fork was stored is picked up at the next resync.
- Only the local Claude provider participates; uploads, Cowork, Qoder, subagents, and s3 sources are untouched.