### PR TITLE
Add Qoder IDE SharedClientCache discovery

### DIFF
--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -778,6 +778,23 @@ func IsValidSessionID(id string) bool {
 	return true
 }
 
+// IsValidQoderSessionID reports whether id is a valid Qoder session
+// identifier. Qoder session IDs use the same alphanumeric/dash/underscore
+// charset as other agents, but the SharedClientCache layout (see
+// qoder_paths.go) appends dotted suffixes such as
+// "task-<uuid>.session.execution", so periods are also accepted here.
+func IsValidQoderSessionID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, c := range id {
+		if !isAlphanum(c) && c != '-' && c != '_' && c != '.' {
+			return false
+		}
+	}
+	return true
+}
+
 func isAlphanumOrDashUnderscore(c rune) bool {
 	return isAlphanum(c) ||
 		c == '-' || c == '_'

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -29,6 +29,12 @@ func DiscoverQoderSessions(projectsDir string) []DiscoveredFile {
 	}
 
 	var files []DiscoveredFile
+
+	// SharedClientCache layout: files live directly under projectsDir with
+	// no per-project subdirectory. Discover those flat files first and treat
+	// the root itself as a single virtual project.
+	files = append(files, qoderCollectFlatProject(projectsDir, projects)...)
+
 	for _, projectEntry := range projects {
 		if !isDirOrSymlink(projectEntry, projectsDir) {
 			continue
@@ -44,7 +50,7 @@ func DiscoverQoderSessions(projectsDir string) []DiscoveredFile {
 			if !entry.IsDir() && strings.HasSuffix(name, ".jsonl") {
 				stem := strings.TrimSuffix(name, ".jsonl")
 				if strings.HasPrefix(stem, "agent-") ||
-					!IsValidSessionID(stem) {
+					!IsValidQoderSessionID(stem) {
 					continue
 				}
 				files = append(files, DiscoveredFile{
@@ -54,7 +60,7 @@ func DiscoverQoderSessions(projectsDir string) []DiscoveredFile {
 				})
 				continue
 			}
-			if !isDirOrSymlink(entry, projectDir) || !IsValidSessionID(name) {
+			if !isDirOrSymlink(entry, projectDir) || !IsValidQoderSessionID(name) {
 				continue
 			}
 			subagentsDir := filepath.Join(projectDir, name, "subagents")
@@ -68,7 +74,7 @@ func DiscoverQoderSessions(projectsDir string) []DiscoveredFile {
 				}
 				stem := strings.TrimSuffix(sub.Name(), ".jsonl")
 				if !strings.HasPrefix(stem, "agent-") ||
-					!IsValidSessionID(stem) {
+					!IsValidQoderSessionID(stem) {
 					continue
 				}
 				files = append(files, DiscoveredFile{
@@ -86,23 +92,76 @@ func DiscoverQoderSessions(projectsDir string) []DiscoveredFile {
 	return files
 }
 
+// qoderCollectFlatProject treats the root directory itself as a single
+// virtual project and discovers session .jsonl files written directly
+// under it (the SharedClientCache layout). Files in subdirectories are
+// left to the per-project loop in DiscoverQoderSessions. The project
+// hint is the basename of the root's parent ("cli") when available,
+// otherwise "SharedClientCache".
+func qoderCollectFlatProject(
+	root string, entries []os.DirEntry,
+) []DiscoveredFile {
+	var files []DiscoveredFile
+	var any bool
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		stem := strings.TrimSuffix(entry.Name(), ".jsonl")
+		if strings.HasPrefix(stem, "agent-") ||
+			!IsValidQoderSessionID(stem) {
+			continue
+		}
+		files = append(files, DiscoveredFile{
+			Path:    filepath.Join(root, entry.Name()),
+			Project: qoderFlatProjectHint(root),
+			Agent:   AgentQoder,
+		})
+		any = true
+	}
+	if !any {
+		return nil
+	}
+	return files
+}
+
+// qoderFlatProjectHint picks a stable project label for files discovered
+// directly under a SharedClientCache projects root. Prefers the parent
+// dir's basename (typically "cli") and falls back to "SharedClientCache"
+// when the root has no parent (e.g. user-supplied QODER_PROJECTS_DIR).
+func qoderFlatProjectHint(root string) string {
+	parent := filepath.Base(filepath.Dir(root))
+	if parent == "." || parent == "/" || parent == "" {
+		return "SharedClientCache"
+	}
+	return parent
+}
+
 func FindQoderSourceFile(projectsDir, rawID string) string {
 	if projectsDir == "" {
 		return ""
 	}
 	rawID = strings.TrimPrefix(rawID, qoderIDPrefix)
 	sessionID, subagentID, hasSubagent := strings.Cut(rawID, ":subagent:")
-	if !IsValidSessionID(sessionID) {
+	if !IsValidQoderSessionID(sessionID) {
 		return ""
 	}
 	if hasSubagent &&
-		(!strings.HasPrefix(subagentID, "agent-") || !IsValidSessionID(subagentID)) {
+		(!strings.HasPrefix(subagentID, "agent-") || !IsValidQoderSessionID(subagentID)) {
 		return ""
 	}
 
 	projects, err := os.ReadDir(projectsDir)
 	if err != nil {
 		return ""
+	}
+	// SharedClientCache flat layout: files live directly under projectsDir.
+	// Check the root itself before descending into per-project subdirs.
+	if !hasSubagent {
+		candidate := filepath.Join(projectsDir, sessionID+".jsonl")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
 	}
 	for _, projectEntry := range projects {
 		if !isDirOrSymlink(projectEntry, projectsDir) {
@@ -258,11 +317,11 @@ func qoderPathIDs(path, _ string) (parentID, subagentID string, isSubagent bool)
 		return "", "", false
 	}
 	parent := filepath.Base(filepath.Dir(filepath.Dir(path)))
-	if !IsValidSessionID(parent) {
+	if !IsValidQoderSessionID(parent) {
 		return "", "", false
 	}
 	stem := strings.TrimSuffix(filepath.Base(path), ".jsonl")
-	if !strings.HasPrefix(stem, "agent-") || !IsValidSessionID(stem) {
+	if !strings.HasPrefix(stem, "agent-") || !IsValidQoderSessionID(stem) {
 		return "", "", false
 	}
 	return parent, stem, true

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -130,11 +130,12 @@ func qoderCollectFlatProject(
 // dir's basename (typically "cli") and falls back to "SharedClientCache"
 // when the root has no parent (e.g. user-supplied QODER_PROJECTS_DIR).
 func qoderFlatProjectHint(root string) string {
-	parent := filepath.Base(filepath.Dir(root))
-	if parent == "." || parent == "/" || parent == "" {
+	root = filepath.Clean(root)
+	parentDir := filepath.Dir(root)
+	if parentDir == root || parentDir == "." {
 		return "SharedClientCache"
 	}
-	return parent
+	return filepath.Base(parentDir)
 }
 
 func FindQoderSourceFile(projectsDir, rawID string) string {

--- a/internal/parser/qoder_paths.go
+++ b/internal/parser/qoder_paths.go
@@ -1,0 +1,29 @@
+package parser
+
+// qoderDefaultDirs returns platform-specific default directories that
+// hold Qoder IDE session transcripts. The IDE stores its data under
+// an Electron-style user-data directory per platform:
+//
+//	macOS:   ~/Library/Application Support/Qoder
+//	Linux:   ~/.config/Qoder
+//	Windows: %APPDATA%\Qoder
+//
+// In recent versions Qoder also writes session transcripts to a
+// SharedClientCache path (used as the actual storage location on
+// Windows installs), so we list both. Paths that don't exist on a
+// given platform are skipped silently by discovery.
+//
+//	Windows: %APPDATA%\Qoder\SharedClientCache\cli\projects
+func qoderDefaultDirs() []string {
+	return []string{
+		// Legacy export paths (kept for users who enable the in-IDE export).
+		".qoder/projects",
+		".qoderwork/projects",
+		// macOS
+		"Library/Application Support/Qoder/SharedClientCache/cli/projects",
+		// Linux
+		".config/Qoder/SharedClientCache/cli/projects",
+		// Windows
+		"AppData/Roaming/Qoder/SharedClientCache/cli/projects",
+	}
+}

--- a/internal/parser/qoder_provider.go
+++ b/internal/parser/qoder_provider.go
@@ -59,18 +59,24 @@ func isQoderSourcePath(root, path string) bool {
 		return false
 	}
 	switch len(parts) {
+	case 1:
+		// SharedClientCache flat layout: file directly under root.
+		stem, ok := strings.CutSuffix(parts[0], ".jsonl")
+		return ok &&
+			!strings.HasPrefix(stem, "agent-") &&
+			IsValidQoderSessionID(stem)
 	case 2:
 		stem, ok := strings.CutSuffix(parts[1], ".jsonl")
 		return ok &&
 			!strings.HasPrefix(stem, "agent-") &&
-			IsValidSessionID(stem)
+			IsValidQoderSessionID(stem)
 	case 4:
 		stem, ok := strings.CutSuffix(parts[3], ".jsonl")
 		return ok &&
-			IsValidSessionID(parts[1]) &&
+			IsValidQoderSessionID(parts[1]) &&
 			parts[2] == "subagents" &&
 			strings.HasPrefix(stem, "agent-") &&
-			IsValidSessionID(stem)
+			IsValidQoderSessionID(stem)
 	default:
 		return false
 	}
@@ -78,10 +84,19 @@ func isQoderSourcePath(root, path string) bool {
 
 func qoderProjectHintFromPath(root, path string) string {
 	parts, ok := qoderPathParts(root, path)
-	if !ok || len(parts) < 2 {
+	if !ok {
 		return ""
 	}
-	return DecodeQoderProjectDir(parts[0])
+	switch len(parts) {
+	case 1:
+		// SharedClientCache flat layout: synthesize a project hint
+		// from the parent dir basename (e.g. "cli").
+		return qoderFlatProjectHint(root)
+	case 2, 4:
+		return DecodeQoderProjectDir(parts[0])
+	default:
+		return ""
+	}
 }
 
 func qoderSessionIDFromPath(root, path string) string {
@@ -101,12 +116,12 @@ func isQoderLookupID(rawID string) bool {
 		return false
 	}
 	sessionID, subagentID, hasSubagent := strings.Cut(rawID, ":subagent:")
-	if !IsValidSessionID(sessionID) {
+	if !IsValidQoderSessionID(sessionID) {
 		return false
 	}
 	return !hasSubagent ||
 		strings.HasPrefix(subagentID, "agent-") &&
-			IsValidSessionID(subagentID)
+			IsValidQoderSessionID(subagentID)
 }
 
 func qoderPathParts(root, path string) ([]string, bool) {

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -21,7 +21,15 @@ func TestQoderRegistry(t *testing.T) {
 	assert.Equal(t, qoderIDPrefix, def.IDPrefix)
 	assert.True(t, def.FileBased)
 	assert.False(t, def.ShallowWatch)
-	assert.Equal(t, []string{".qoder/projects", ".qoderwork/projects"}, def.DefaultDirs)
+	// DefaultDirs is sourced from qoderDefaultDirs(); legacy export paths
+	// stay listed alongside the SharedClientCache paths.
+	wantDirs := qoderDefaultDirs()
+	require.NotEmpty(t, wantDirs)
+	assert.Equal(t, wantDirs, def.DefaultDirs)
+	assert.Contains(t, def.DefaultDirs, ".qoder/projects")
+	assert.Contains(t, def.DefaultDirs, ".qoderwork/projects")
+	assert.Contains(t, def.DefaultDirs,
+		"AppData/Roaming/Qoder/SharedClientCache/cli/projects")
 	factory, ok := ProviderFactoryByType(AgentQoder)
 	require.True(t, ok, "AgentQoder provider missing")
 	assert.Equal(t, AgentQoder, factory.Definition().Type)
@@ -328,4 +336,99 @@ func TestDecodeQoderProjectDir(t *testing.T) {
 			assert.Equal(t, tt.want, DecodeQoderProjectDir(tt.name))
 		})
 	}
+}
+
+func TestQoderFlatDiscovery(t *testing.T) {
+	root := t.TempDir()
+	// SharedClientCache-style flat layout: files directly under root with
+	// dotted suffixes such as task-<uuid>.session.execution.jsonl.
+	stem := "task-10f849241e06451d9c9c.session.execution"
+	flatPath := filepath.Join(root, stem+".jsonl")
+	sidecar := strings.TrimSuffix(flatPath, ".jsonl") + "-session.json"
+	// A legacy per-project subtree still needs to be discovered alongside.
+	projRoot := filepath.Join(root, "proj-dir")
+	legacyPath := filepath.Join(projRoot, "22222222-2222-4222-8222-222222222222.jsonl")
+	for _, path := range []string{flatPath, sidecar, legacyPath} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
+	}
+
+	files := DiscoverQoderSessions(root)
+	require.Len(t, files, 2)
+	// results are sorted by path; "proj-dir" (p) sorts before "task-..." (t).
+	assert.Equal(t, legacyPath, files[0].Path)
+	assert.Equal(t, "proj_dir", files[0].Project)
+	assert.Equal(t, AgentQoder, files[0].Agent)
+	assert.Equal(t, flatPath, files[1].Path)
+	// Project hint for flat files comes from the parent dir basename
+	// (the temp dir's parent in t.TempDir ends in a generated name; we
+	// just assert it's non-empty).
+	assert.NotEmpty(t, files[1].Project)
+	assert.Equal(t, AgentQoder, files[1].Agent)
+}
+
+func TestQoderFlatSourceFileLookup(t *testing.T) {
+	root := t.TempDir()
+	stem := "task-abcdef1234567890abcdef1234567890.session.execution"
+	flatPath := filepath.Join(root, stem+".jsonl")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.WriteFile(flatPath, []byte("{}\n"), 0o644))
+
+	assert.Equal(t, flatPath, FindQoderSourceFile(root, "qoder:"+stem))
+	assert.Empty(t, FindQoderSourceFile(root, "qoder:nope"))
+}
+
+func TestIsValidQoderSessionID(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"abc-123", true},
+		{"session_1", true},
+		{"abc123", true},
+		// Dotted suffixes used by SharedClientCache layouts.
+		{"task-10f849241e06451d9c9c.session.execution", true},
+		{"uuid.exec", true},
+		{"a.b.c.d", true},
+		{"", false},
+		{"../etc", false},
+		{"a b", false},
+		{"a/b", false},
+		{"a\\b", false},
+		{"weird:id", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			got := IsValidQoderSessionID(tt.id)
+			assert.Equalf(t, tt.want, got, "IsValidQoderSessionID(%q)", tt.id)
+		})
+	}
+}
+
+func TestQoderDefaultDirs(t *testing.T) {
+	dirs := qoderDefaultDirs()
+	// Legacy export paths retained.
+	assert.Contains(t, dirs, ".qoder/projects")
+	assert.Contains(t, dirs, ".qoderwork/projects")
+	// SharedClientCache paths for the three target platforms.
+	assert.Contains(t, dirs,
+		"Library/Application Support/Qoder/SharedClientCache/cli/projects")
+	assert.Contains(t, dirs,
+		".config/Qoder/SharedClientCache/cli/projects")
+	assert.Contains(t, dirs,
+		"AppData/Roaming/Qoder/SharedClientCache/cli/projects")
+}
+
+func TestQoderFlatProjectHint(t *testing.T) {
+	t.Run("cli parent", func(t *testing.T) {
+		tmp := t.TempDir()
+		cliRoot := filepath.Join(tmp, "Qoder", "SharedClientCache", "cli", "projects")
+		require.NoError(t, os.MkdirAll(cliRoot, 0o755))
+		// Parent dir's basename is the "cli" segment, so flat files
+		// under the SharedClientCache/projects root label as "cli".
+		assert.Equal(t, "cli", qoderFlatProjectHint(cliRoot))
+	})
+	t.Run("root with no parent", func(t *testing.T) {
+		assert.Equal(t, "SharedClientCache", qoderFlatProjectHint("/"))
+	})
 }

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -431,4 +431,7 @@ func TestQoderFlatProjectHint(t *testing.T) {
 	t.Run("root with no parent", func(t *testing.T) {
 		assert.Equal(t, "SharedClientCache", qoderFlatProjectHint("/"))
 	})
+	t.Run("relative root with no parent", func(t *testing.T) {
+		assert.Equal(t, "SharedClientCache", qoderFlatProjectHint("projects"))
+	})
 }

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -763,12 +763,9 @@ var Registry = []AgentDef{
 		DisplayName: "Qoder",
 		EnvVar:      "QODER_PROJECTS_DIR",
 		ConfigKey:   "qoder_project_dirs",
-		DefaultDirs: []string{
-			".qoder/projects",
-			".qoderwork/projects",
-		},
-		IDPrefix:  "qoder:",
-		FileBased: true,
+		DefaultDirs: qoderDefaultDirs(),
+		IDPrefix:    "qoder:",
+		FileBased:   true,
 	},
 	{
 		// Shelley (exe.dev) stores all conversations in a single


### PR DESCRIPTION
Fixes #1233

Qoder IDE on Windows stores session transcripts in SharedClientCache, not in the legacy export paths. This change makes agentsview discover them.

## What this changes

- Adds platform-specific SharedClientCache paths to `qoderDefaultDirs` (Windows, macOS, Linux).
- Adds `IsValidQoderSessionID` (periods allowed) and uses it in the Qoder discovery, lookup, and path helpers so dotted session IDs like `task-<uuid>.session.execution` are accepted. The strict `IsValidSessionID` is unchanged for other agents.
- Adds `qoderCollectFlatProject` so a flat SharedClientCache directory (no per-project subdirectory) is discovered as a single virtual project.
- Wires the flat layout into `isQoderSourcePath`, `qoderProjectHintFromPath`, and `FindQoderSourceFile`.

## Files

- `internal/parser/qoder_paths.go` (new)
- `internal/parser/types.go` — Qoder entry now calls `qoderDefaultDirs()`
- `internal/parser/discovery.go` — new `IsValidQoderSessionID`
- `internal/parser/qoder.go` — flat discovery + dotted IDs
- `internal/parser/qoder_provider.go` — flat path handling
- `internal/parser/qoder_test.go` — new tests for flat layout, dotted IDs, defaults

## Testing

- `go test ./internal/parser/...` passes (full suite, 19.6s)
- `go vet ./...` clean on the modified files
- 5 new tests added: `TestQoderFlatDiscovery`, `TestQoderFlatSourceFileLookup`, `TestIsValidQoderSessionID`, `TestQoderDefaultDirs`, `TestQoderFlatProjectHint`

## Backward compatibility

The legacy `.qoder/projects` and `.qoderwork/projects` paths remain in `qoderDefaultDirs()` for users who have the in-IDE transcript export enabled. Existing tests for the legacy layout continue to pass unchanged.