### PR TITLE
fix(parser): exclude replayed Codex subagent usage

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -285,13 +285,19 @@ Grok section and remove the explicit registry exception in the coverage test.
   emits.
 - **Agentsview:** `internal/parser/codex.go` and
   `internal/parser/codex_provider.go`; usage is taken from the last-turn
-  counters rather than repeatedly counting cumulative totals. Reverified
-  2026-07-29: the pinned TUI is the evidenced `history.jsonl` producer. No
-  `append_entry` producer call exists under the pinned `app-server` or `exec`
-  trees, so this evidence does not establish IDE, desktop, or `codex exec`
-  activity-hint coverage. Locally observed Codex app builds can write the same
-  schema, but that is observational evidence rather than a public
-  compatibility guarantee. Agentsview derives the hint path as
+  counters rather than repeatedly counting cumulative totals. Fork and
+  subagent rollouts can begin with a re-stamped copy of the parent's
+  transcript, including its `token_count` records. Agentsview recognizes the
+  copied parent `session_meta` and discards that leading replay through the
+  last pre-creation UUIDv7 `turn_id`, preserving only usage produced by the
+  derived session. Child-only subagent transcripts are left unchanged.
+  Reverified 2026-08-11 against locally observed multi-agent rollouts and the
+  pinned format sources; the pinned TUI is the evidenced `history.jsonl`
+  producer. No `append_entry` producer call exists under the pinned
+  `app-server` or `exec` trees, so this evidence does not establish IDE,
+  desktop, or `codex exec` activity-hint coverage. Locally observed Codex app
+  builds can write the same schema, but that is observational evidence rather
+  than a public compatibility guarantee. Agentsview derives the hint path as
   `<configured-sessions-root>/../history.jsonl`; a custom sessions root
   without that sibling, or `HistoryPersistence::None`, degrades to ordinary
   watcher behavior, degraded-coverage polling when applicable, and the daily
@@ -384,20 +390,21 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Format:** Google Takeout `My Activity` HTML containing Gemini Apps activity
   cells. Each compatible `Prompted` record is imported as one one-turn session
   with exactly one user message containing the complete visible plain text;
-  HTML presentation does not infer speaker roles or generate Markdown.
-  Canvas, feedback, and unknown record kinds are counted as skipped. Explicitly
+  HTML presentation does not infer speaker roles or generate Markdown. Canvas,
+  feedback, and unknown record kinds are counted as skipped. Explicitly
   identified cells from other Takeout products are ignored. The current parser
   supports the observed English rendering for Gemini Apps cells and reports
   declared non-English or otherwise unsupported localized Gemini candidates
-  before emitting sessions. Inline code remains inline text, while preformatted
-  text preserves authored spaces, tabs, newlines, and backticks as data.
-  Session IDs use the canonical UTC timestamp plus a zero-based occurrence
-  index among admitted `Prompted` records sharing that timestamp. Records with
-  other timestamps can be inserted or reordered without changing existing IDs;
-  order remains a tie-breaker only for exact timestamp collisions.
+  before emitting sessions. Inline code remains inline text, while
+  preformatted text preserves authored spaces, tabs, newlines, and backticks
+  as data. Session IDs use the canonical UTC timestamp plus a zero-based
+  occurrence index among admitted `Prompted` records sharing that timestamp.
+  Records with other timestamps can be inserted or reordered without changing
+  existing IDs; order remains a tie-breaker only for exact timestamp
+  collisions.
 - **Evidence:** `no-public-source`.
-- **Upstream:** Google's Takeout documentation and public format references
-  were searched 2026-08-01. Google does not publish a versioned Gemini Apps
+- **Upstream:** Google's Takeout documentation and public format references were
+  searched 2026-08-01. Google does not publish a versioned Gemini Apps
   activity HTML schema, so markup, labels, timestamp zones, and future record
   kinds remain observed compatibility evidence from sanitized exports. No
   translated label or timestamp vocabulary is claimed. Timestamp compatibility
@@ -1663,41 +1670,38 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Agentsview:** `internal/parser/omnigent.go` and
   `internal/parser/omnigent_provider.go`; fixtures under
   `internal/parser/testdata/omnigent/` provide observed event-shape evidence.
-  
+
 ## Codebuff (`codebuff`)
 
 - **Format:** Per-session JSON files under
   `<root>/<project>/chats/<timestamp>/`. Each session directory contains
-  `chat-messages.json` (JSON array of user/ai/error message objects with
-  text, tool, agent, mode-divider, plan, ask-user, and image blocks),
-  `run-state.json` (agent type, context token count, credits used, cwd,
-  and skill catalog), and optional `chat-meta.json` (message count,
-  first prompt, and messages size). Freebuff sessions share the same
-  layout and are distinguished by the `agentType` field containing
-  `"free"`.
+  `chat-messages.json` (JSON array of user/ai/error message objects with text,
+  tool, agent, mode-divider, plan, ask-user, and image blocks),
+  `run-state.json` (agent type, context token count, credits used, cwd, and
+  skill catalog), and optional `chat-meta.json` (message count, first prompt,
+  and messages size). Freebuff sessions share the same layout and are
+  distinguished by the `agentType` field containing `"free"`.
 - **Evidence:** `source`.
 - **Upstream:** Clone `https://github.com/CodebuffAI/codebuff.git` at
   `b285b562b9ef3a3f35272ed32718eeb74dd86283`; see
   [chat.ts](https://github.com/CodebuffAI/codebuff/blob/b285b562b9ef3a3f35272ed32718eeb74dd86283/cli/src/types/chat.ts)
-  for the `ChatMessage` and `ContentBlock` type definitions that define
-  the on-disk format, and
+  for the `ChatMessage` and `ContentBlock` type definitions that define the
+  on-disk format, and
   [session-state.ts](https://github.com/CodebuffAI/codebuff/blob/b285b562b9ef3a3f35272ed32718eeb74dd86283/common/src/types/session-state.ts)
   for the `AgentState` type that defines `contextTokenCount` and
-  `creditsUsed`. Freebuff shares the same layout and is distinguished by
-  the `agentType` field in `run-state.json`.
-- **Usage and cost:** The `contextTokenCount` field in
-  `run-state.json` provides context window token counts (updated per
-  API step). The `creditsUsed` and `directCreditsUsed` fields provide
-  session-level billing totals (1 credit = $0.01). The `agentType` field
-  records the agent template name (e.g. `base2-deepseek`,
-  `base2-free-mimo`), which encodes the model family but is not the
-  actual LLM model -- the real model is selected server-side and can
-  change mid-session; mid-session model switches are not detectable from
-  the on-disk format. Per-message token breakdown (input/output/cache)
-  is not available; only context window size and billing credits are
-  persisted. Freebuff (free tier) has no credits -- it is ad-supported
-  with daily session limits.
+  `creditsUsed`. Freebuff shares the same layout and is distinguished by the
+  `agentType` field in `run-state.json`.
+- **Usage and cost:** The `contextTokenCount` field in `run-state.json` provides
+  context window token counts (updated per API step). The `creditsUsed` and
+  `directCreditsUsed` fields provide session-level billing totals (1 credit =
+  $0.01). The `agentType` field records the agent template name (e.g.
+  `base2-deepseek`, `base2-free-mimo`), which encodes the model family but is
+  not the actual LLM model -- the real model is selected server-side and can
+  change mid-session; mid-session model switches are not detectable from the
+  on-disk format. Per-message token breakdown (input/output/cache) is not
+  available; only context window size and billing credits are persisted.
+  Freebuff (free tier) has no credits -- it is ad-supported with daily session
+  limits.
 - **Agentsview:** `internal/parser/codebuff.go` and
-  `internal/parser/codebuff_provider.go`; single-file provider with
-  JSON array parsing.
-
+  `internal/parser/codebuff_provider.go`; single-file provider with JSON array
+  parsing.

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -290,14 +290,18 @@ Grok section and remove the explicit registry exception in the coverage test.
   transcript, including its `token_count` records. Agentsview recognizes the
   copied parent `session_meta` and discards that leading replay through the
   last pre-creation UUIDv7 `turn_id`, preserving only usage produced by the
-  derived session. Child-only subagent transcripts are left unchanged.
-  Reverified 2026-08-11 against locally observed multi-agent rollouts and the
-  pinned format sources; the pinned TUI is the evidenced `history.jsonl`
-  producer. No `append_entry` producer call exists under the pinned
-  `app-server` or `exec` trees, so this evidence does not establish IDE,
-  desktop, or `codex exec` activity-hint coverage. Locally observed Codex app
-  builds can write the same schema, but that is observational evidence rather
-  than a public compatibility guarantee. Agentsview derives the hint path as
+  derived session. Child-only subagent transcripts are left unchanged. An
+  appended `session_meta` after an incremental-sync offset forces an
+  authoritative replacement of that derived session, because the metadata can
+  be the copied parent record that activates replay filtering. The original
+  parent session remains valid and is not reparsed. Reverified 2026-08-12
+  against locally observed multi-agent rollouts and the pinned format sources;
+  the pinned TUI is the evidenced `history.jsonl` producer. No `append_entry`
+  producer call exists under the pinned `app-server` or `exec` trees, so this
+  evidence does not establish IDE, desktop, or `codex exec` activity-hint
+  coverage. Locally observed Codex app builds can write the same schema, but
+  that is observational evidence rather than a public compatibility guarantee.
+  Agentsview derives the hint path as
   `<configured-sessions-root>/../history.jsonl`; a custom sessions root
   without that sibling, or `HistoryPersistence::None`, degrades to ordinary
   watcher behavior, degraded-coverage polling when applicable, and the daily

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -403,7 +403,11 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // usage object with model and token counts that the parser previously
 // ignored. Existing Amp rows need re-parsing so their model, token
 // usage, and computed cost appear in usage reports.)
-const dataVersion = 84
+// (85: Codex subagent replay accounting. Codex can copy a parent's complete
+// rollout prefix into a newly spawned subagent file, re-stamping messages and
+// token_count events at child creation. Existing Codex-format rows need
+// re-parsing so derived sessions retain only child-owned messages and usage.)
+const dataVersion = 85
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1009,8 +1009,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionUsageReparses(t *testing.T) {
-	assert.Equal(t, 84, CurrentDataVersion(),
-		"Claude background-fork lineage and Amp usage accounting require sequential reparses")
+	assert.Equal(t, 85, CurrentDataVersion(),
+		"Amp usage and Codex subagent replay accounting require sequential reparses")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -75,36 +75,40 @@ type codexSessionBuilder struct {
 	unattachedTokenUsage bool
 }
 
-// codexForkGate drops the replayed parent history at the top of a
-// forked Codex rollout (#643).
+// codexForkGate drops replayed parent history at the top of a Codex
+// fork or subagent rollout (#643).
 //
-// `codex fork` copies the parent's lines — its session_meta, turns,
-// messages and token_count events — into the new file with re-stamped
-// envelope timestamps, so the same usage exists in two session files
-// and gets counted twice. Envelope timestamps cannot locate the
-// boundary (the replay is re-stamped at fork creation), but turn ids
-// are UUIDv7 values minted when the turn originally ran: every
-// replayed turn predates the fork instant, and the first genuine turn
+// Codex copies the parent's lines — its session_meta, turns, messages
+// and token_count events — into both kinds of derived rollout with
+// re-stamped envelope timestamps, so the same usage exists in multiple
+// session files and gets counted repeatedly. Envelope timestamps cannot
+// locate the boundary (the replay is re-stamped at child creation), but
+// turn ids are UUIDv7 values minted when the turn originally ran: every
+// replayed turn predates the child instant, and the first genuine turn
 // is minted at or after it. The gate stays closed until the first
-// turn_context whose turn_id timestamp is >= the fork's own creation
+// turn_context whose turn_id timestamp is >= the child's own creation
 // time, then everything flows normally.
 //
 // Replayed turn_context entries from parents recorded before Codex
 // stamped turn ids carry no turn_id at all; a CLI new enough to write
-// forked_from_id always stamps genuine turns, so a missing turn_id
-// while gated means replayed history. An unparseable turn_id fails
-// open (pre-#643 behaviour) rather than risk dropping live data.
+// forked_from_id or subagent parent metadata always stamps genuine
+// turns, so a missing turn_id while gated means replayed history. An
+// unparseable turn_id fails open (pre-#643 behaviour) rather than risk
+// dropping live data.
 type codexForkGate struct {
-	active    bool
-	createdMs int64
+	active           bool
+	createdMs        int64
+	subagentParentID string
 }
 
 // armFromMeta activates the gate when the session_meta belongs to a
-// forked session and its creation instant can be anchored: from the
-// fork's UUIDv7 id, the payload timestamp, or the JSONL envelope
-// timestamp, in that order.
+// forked or subagent session and its creation instant can be anchored:
+// from the child's UUIDv7 id, the payload timestamp, or the JSONL
+// envelope timestamp, in that order.
 func (g *codexForkGate) armFromMeta(payload gjson.Result, envelopeTS time.Time) {
-	if payload.Get("forked_from_id").Str == "" {
+	forked := payload.Get("forked_from_id").Str != ""
+	parentID := codexSubagentParentThreadID(payload)
+	if !forked && parentID == "" {
 		return
 	}
 	ms := uuidV7Millis(payload.Get("id").Str)
@@ -119,8 +123,40 @@ func (g *codexForkGate) armFromMeta(payload gjson.Result, envelopeTS time.Time) 
 	if ms == 0 {
 		return // no anchor for the boundary — fail open
 	}
-	g.active = true
 	g.createdMs = ms
+	if forked {
+		g.active = true
+		return
+	}
+	// Parent metadata alone also appears in child-only transcripts. Wait
+	// for the copied parent's session_meta before suppressing anything.
+	g.subagentParentID = parentID
+}
+
+// suppressesSessionMeta identifies the copied parent session_meta that
+// positively distinguishes a replay-prefix subagent from a child-only
+// transcript. Explicit forks are already active when their copied meta
+// arrives.
+func (g *codexForkGate) suppressesSessionMeta(payload gjson.Result) bool {
+	if g.active {
+		return true
+	}
+	if g.subagentParentID == "" ||
+		payload.Get("id").Str != g.subagentParentID {
+		return false
+	}
+	g.active = true
+	return true
+}
+
+func codexSubagentParentThreadID(payload gjson.Result) string {
+	parentID := strings.TrimSpace(
+		payload.Get("source.subagent.thread_spawn.parent_thread_id").Str,
+	)
+	if parentID == "" && payload.Get("thread_source").Str == "subagent" {
+		parentID = strings.TrimSpace(payload.Get("parent_thread_id").Str)
+	}
+	return parentID
 }
 
 // suppresses reports whether the line is replayed parent history.
@@ -128,6 +164,9 @@ func (g *codexForkGate) armFromMeta(payload gjson.Result, envelopeTS time.Time) 
 // or after the fork instant.
 func (g *codexForkGate) suppresses(lineType string, payload gjson.Result) bool {
 	if !g.active {
+		// A child-owned event before a copied parent session_meta proves
+		// this is a child-only transcript, not a replay prefix.
+		g.subagentParentID = ""
 		return false
 	}
 	if lineType != codexTypeTurnContext {
@@ -141,6 +180,7 @@ func (g *codexForkGate) suppresses(lineType string, payload gjson.Result) bool {
 		return true
 	}
 	g.active = false
+	g.subagentParentID = ""
 	return false
 }
 
@@ -211,7 +251,7 @@ func (b *codexSessionBuilder) processLine(
 
 	switch gjson.Get(line, "type").Str {
 	case codexTypeSessionMeta:
-		if b.forkGate.active {
+		if b.forkGate.suppressesSessionMeta(payload) {
 			// A forked rollout replays the parent's session_meta
 			// too — the fork's own meta came first and wins.
 			return false
@@ -246,15 +286,7 @@ func (b *codexSessionBuilder) handleSessionMeta(
 			payload.Get("source.subagent.thread_spawn.agent_path").Str,
 		)
 	}
-	b.parentSessionID = strings.TrimSpace(
-		payload.Get("source.subagent.thread_spawn.parent_thread_id").Str,
-	)
-	if b.parentSessionID == "" &&
-		payload.Get("thread_source").Str == "subagent" {
-		b.parentSessionID = strings.TrimSpace(
-			payload.Get("parent_thread_id").Str,
-		)
-	}
+	b.parentSessionID = codexSubagentParentThreadID(payload)
 	if b.parentSessionID != "" {
 		b.parentSessionID = codexSubagentSessionID(b.parentSessionID)
 		b.relationshipType = RelSubagent
@@ -1806,7 +1838,7 @@ func seedCodexIncrementalStateFromReader(
 			// Mirror processLine: the fork's own meta arms the
 			// gate and supplies cwd, and replayed parent metas are
 			// dropped while it is active.
-			if !seed.forkGate.active {
+			if !seed.forkGate.suppressesSessionMeta(payload) {
 				if cwd := payload.Get("cwd").Str; cwd != "" {
 					seed.cwd = cwd
 				}

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -2168,10 +2168,12 @@ func (p *codexProvider) parseSessionFromWithSources(
 			if fallbackErr != nil {
 				return
 			}
-			// Skip session_meta — already processed in
-			// the initial full parse.
+			// A session_meta after the persisted offset can change fork or
+			// subagent replay classification. Rebuild the current session
+			// authoritatively instead of appending against stale gate state.
 			if gjson.Get(line, "type").Str ==
 				codexTypeSessionMeta {
+				fallbackErr = errCodexIncrementalNeedsFullParse
 				return
 			}
 			if codexIncrementalNeedsFullParse(line) {

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1626,6 +1626,83 @@ func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
 	})
 }
 
+func TestParseCodexSession_SubagentSessionSkipsReplayedHistory(t *testing.T) {
+	childCreatedMs := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli()
+	childID := testUUIDv7(childCreatedMs, 1)
+	parentID := testUUIDv7(childCreatedMs-3600_000, 2)
+	parentTurnID := testUUIDv7(childCreatedMs-1800_000, 3)
+	childTurnID := testUUIDv7(childCreatedMs+1000, 4)
+
+	tests := []struct {
+		name string
+		meta string
+	}{
+		{
+			name: "current nested parent metadata",
+			meta: testjsonl.CodexSubagentSessionMetaJSON(
+				childID, parentID, "/tmp/project", "user", tsEarly,
+			),
+		},
+		{
+			name: "legacy top-level parent metadata",
+			meta: fmt.Sprintf(
+				`{"timestamp":%q,"type":"session_meta","payload":{"id":%q,"cwd":"/tmp/project","thread_source":"subagent","parent_thread_id":%q}}`,
+				tsEarly, childID, parentID,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := testjsonl.JoinJSONL(
+				tt.meta,
+				// Codex copies and re-stamps the parent's transcript at
+				// subagent creation, including its usage events.
+				testjsonl.CodexSessionMetaJSON(
+					parentID, "/tmp/project", "user", tsEarly,
+				),
+				testjsonl.CodexTurnContextWithIDJSON(
+					"gpt-5.4", parentTurnID, tsEarly,
+				),
+				testjsonl.CodexMsgJSON(
+					"user", "replayed parent question", tsEarly,
+				),
+				testjsonl.CodexMsgJSON(
+					"assistant", "replayed parent answer", tsEarly,
+				),
+				testjsonl.CodexTokenCountJSON(
+					tsEarly, 50_000, 9_000, 0,
+				),
+				// The child's first turn marks the end of the copied prefix.
+				testjsonl.CodexTurnContextWithIDJSON(
+					"gpt-5.5", childTurnID, tsEarlyS1,
+				),
+				testjsonl.CodexMsgJSON(
+					"user", "genuine child task", tsEarlyS1,
+				),
+				testjsonl.CodexMsgJSON(
+					"assistant", "genuine child answer", tsEarlyS5,
+				),
+				testjsonl.CodexTokenCountJSON(
+					tsEarlyS5, 10_000, 500, 6_000,
+				),
+			)
+
+			sess, msgs := runCodexParserTest(
+				t, "subagent.jsonl", content, false,
+			)
+			require.NotNil(t, sess)
+			assert.Equal(t, "codex:"+childID, sess.ID)
+			assert.Equal(t, "codex:"+parentID, sess.ParentSessionID)
+			require.Len(t, msgs, 2)
+			assert.Equal(t, "genuine child task", msgs[0].Content)
+			assert.Equal(t, "genuine child answer", msgs[1].Content)
+			assert.Equal(t, 500, sess.TotalOutputTokens)
+			assert.Equal(t, 10_000, sess.PeakContextTokens)
+		})
+	}
+}
+
 // TestParseCodexSessionFrom_ForkReplaySpansOffset covers the
 // incremental case of the fork replay gate (#643): a sync boundary
 // lands inside the replayed parent history, so the rest of the replay
@@ -1684,6 +1761,77 @@ func TestParseCodexSessionFrom_ForkReplaySpansOffset(t *testing.T) {
 	assert.Equal(t, "genuine question", newMsgs[0].Content)
 	assert.Equal(t, "genuine answer", newMsgs[1].Content)
 	assert.Equal(t, "gpt-5.5", newMsgs[1].Model)
+	assert.Equal(t, 500, newMsgs[1].OutputTokens)
+}
+
+func TestParseCodexSessionFrom_SubagentReplaySpansOffset(t *testing.T) {
+	t.Parallel()
+
+	childCreatedMs := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli()
+	childID := testUUIDv7(childCreatedMs, 1)
+	parentID := testUUIDv7(childCreatedMs-3600_000, 2)
+	parentTurnID := testUUIDv7(childCreatedMs-1800_000, 3)
+	childTurnID := testUUIDv7(childCreatedMs+1000, 4)
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			childID, parentID, "/tmp/project", "user", tsEarly,
+		),
+		testjsonl.CodexSessionMetaJSON(
+			parentID, "/tmp/project", "user", tsEarly,
+		),
+		testjsonl.CodexTurnContextWithIDJSON(
+			"gpt-5.4", parentTurnID, tsEarly,
+		),
+		testjsonl.CodexMsgJSON(
+			"user", "replayed parent question", tsEarly,
+		),
+	)
+	path := createTestFile(t, "subagent-incremental.jsonl", initial)
+
+	sess, msgs, err := parseCodexTestSession(t, path, "local", false)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "codex:"+childID, sess.ID)
+	require.Empty(t, msgs)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON(
+			"assistant", "replayed parent answer", tsEarly,
+		),
+		testjsonl.CodexTokenCountJSON(
+			tsEarly, 50_000, 9_000, 0,
+		),
+		testjsonl.CodexTurnContextWithIDJSON(
+			"gpt-5.5", childTurnID, tsEarlyS1,
+		),
+		testjsonl.CodexMsgJSON(
+			"user", "genuine child task", tsEarlyS1,
+		),
+		testjsonl.CodexMsgJSON(
+			"assistant", "genuine child answer", tsEarlyS5,
+		),
+		testjsonl.CodexTokenCountJSON(
+			tsEarlyS5, 10_000, 500, 6_000,
+		),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := parseCodexTestSessionFrom(
+		t, path, offset, 0, false,
+	)
+	require.NoError(t, err)
+	require.Len(t, newMsgs, 2)
+	assert.Equal(t, "genuine child task", newMsgs[0].Content)
+	assert.Equal(t, "genuine child answer", newMsgs[1].Content)
 	assert.Equal(t, 500, newMsgs[1].OutputTokens)
 }
 

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -2691,11 +2691,11 @@ func TestParseCodexSessionFrom_DedupsReemittedPrompt(t *testing.T) {
 	})
 }
 
-func TestParseCodexSessionFrom_SkipsSessionMeta(t *testing.T) {
+func TestParseCodexSessionFrom_SessionMetaNeedsFullParse(t *testing.T) {
 	t.Parallel()
 
-	// File where session_meta appears after the offset
-	// (shouldn't happen in practice but should be skipped).
+	// A session_meta after the offset can be copied parent metadata that
+	// activates subagent replay filtering, so the incremental result is stale.
 	initial := testjsonl.JoinJSONL(
 		testjsonl.CodexSessionMetaJSON(
 			"meta-2", "/tmp", "codex_cli_rs", tsEarly,
@@ -2722,13 +2722,10 @@ func TestParseCodexSessionFrom_SkipsSessionMeta(t *testing.T) {
 	f.WriteString(extra)
 	f.Close()
 
-	newMsgs, _, _, err := parseCodexTestSessionFrom(t,
+	_, _, _, err := parseCodexTestSessionFrom(t,
 		path, offset, 5, false,
 	)
-	require.NoError(t, err)
-	// Only the assistant message, not the session_meta.
-	assert.Equal(t, 1, len(newMsgs))
-	assert.Equal(t, 5, newMsgs[0].Ordinal)
+	require.ErrorIs(t, err, errCodexIncrementalNeedsFullParse)
 }
 
 func TestParseCodexSessionFrom_NoNewData(t *testing.T) {

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -528,6 +528,50 @@ func TestCodexProviderIncrementalSnapshotKeepsCapturedEOFConservative(t *testing
 	assert.False(t, newStaged)
 }
 
+func TestCodexProviderIncrementalAppendedSessionMetaNeedsFullParse(t *testing.T) {
+	root := t.TempDir()
+	childID := "019eb791-cf7d-75c1-8439-9ed74c1229f3"
+	parentID := "019eb791-cb95-7a14-830f-9968e582f290"
+	prefix := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			childID, parentID, "/workspace/project-a", "codex_cli_rs", tsEarly,
+		),
+	)
+	path := writeCodexProviderSessionContent(t, root, childID, prefix)
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source := requireCodexProviderSource(t, provider, childID)
+	initialFingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	appendCodexProviderContent(t, path, testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			parentID, "/workspace/project-a", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON(
+			"assistant", "replayed parent answer", tsEarlyS5,
+		),
+	))
+	currentFingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	outcome, status, err := provider.ParseIncremental(
+		context.Background(),
+		IncrementalRequest{
+			Source:       source,
+			Fingerprint:  currentFingerprint,
+			SessionID:    "codex:" + childID,
+			Offset:       initialFingerprint.Size,
+			StartOrdinal: 0,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, IncrementalNeedsFullParse, status)
+	assert.True(t, outcome.ForceReplace)
+	assert.Empty(t, outcome.Messages)
+}
+
 func TestCodexProviderIncrementalRejectsFingerprintIdentityMismatch(t *testing.T) {
 	root := t.TempDir()
 	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229f3"


### PR DESCRIPTION
Codex subagent rollouts can begin with a re-stamped copy of the parent transcript, including historical `token_count` events. Agentsview treated that copied prefix as fresh child work, which duplicated cost and attributed old usage to the child creation hour.

This change extends the existing Codex fork replay gate to subagents only after the copied parent `session_meta` positively identifies a replay prefix. It drops parent turns until the first child-owned UUIDv7 `turn_id`. Direct child-only transcripts remain unchanged. Incremental parsing preserves an active replay boundary across offsets and requests an authoritative replacement of the current child when copied metadata first appears after a saved offset; the parent remains untouched.

Data version 85 triggers the normal full archive resync so already stored Codex-format duplicates are repaired after upgrade. The same parser behavior also applies to TraeX because it shares the Codex rollout format.
