### PR TITLE
fix(frontend): distinguish action failures from success

### DIFF
--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -13,6 +13,7 @@
     LinkIcon,
     SearchIcon,
     SquareTerminalIcon,
+    TriangleAlertIcon,
   } from "../../icons.js";
   import { onDestroy, onMount } from "svelte";
   import type { Session } from "../../api/types.js";
@@ -74,6 +75,7 @@
   let showOpenMenu = $state(false);
   let openers: Opener[] = $state([]);
   let openFeedback = $state("");
+  let openFeedbackKind = $state<"success" | "error">("success");
   let feedbackTimer: ReturnType<typeof setTimeout> | undefined;
   let sessionDir = $state<string | null>(null);
   const openersRead = new LatestRead();
@@ -490,8 +492,9 @@
     }
   }
 
-  function showFeedback(msg: string) {
+  function showFeedback(msg: string, kind: "success" | "error" = "success") {
     openFeedback = msg;
+    openFeedbackKind = kind;
     clearTimeout(feedbackTimer);
     feedbackTimer = setTimeout(() => { openFeedback = ""; }, 2000);
   }
@@ -518,9 +521,12 @@
       if (resp.command) {
         const cmd = formatResumeResponseCommand(session.agent, resp);
         const ok = cmd ? await copyToClipboard(cmd) : false;
-        showFeedback(ok
-          ? m.session_breadcrumb_command_copied()
-          : m.session_breadcrumb_failed());
+        showFeedback(
+          ok
+            ? m.session_breadcrumb_command_copied()
+            : m.session_breadcrumb_failed(),
+          ok ? "success" : "error",
+        );
         return;
       }
     } catch {
@@ -531,11 +537,14 @@
     });
     if (cmd) {
       const ok = await copyToClipboard(cmd);
-      showFeedback(ok
-        ? m.session_breadcrumb_command_copied()
-        : m.session_breadcrumb_failed());
+      showFeedback(
+        ok
+          ? m.session_breadcrumb_command_copied()
+          : m.session_breadcrumb_failed(),
+        ok ? "success" : "error",
+      );
     } else {
-      showFeedback(m.session_breadcrumb_not_supported());
+      showFeedback(m.session_breadcrumb_not_supported(), "error");
     }
   }
 
@@ -552,9 +561,12 @@
       if (resp.command) {
         const cmd = formatResumeResponseCommand(session.agent, resp);
         const ok = cmd ? await copyToClipboard(cmd) : false;
-        showFeedback(ok
-          ? m.session_breadcrumb_command_copied()
-          : m.session_breadcrumb_failed());
+        showFeedback(
+          ok
+            ? m.session_breadcrumb_command_copied()
+            : m.session_breadcrumb_failed(),
+          ok ? "success" : "error",
+        );
         return;
       }
     } catch {
@@ -565,24 +577,30 @@
     });
     if (cmd) {
       const ok = await copyToClipboard(cmd);
-      showFeedback(ok
-        ? m.session_breadcrumb_command_copied()
-        : m.session_breadcrumb_failed());
+      showFeedback(
+        ok
+          ? m.session_breadcrumb_command_copied()
+          : m.session_breadcrumb_failed(),
+        ok ? "success" : "error",
+      );
     } else {
-      showFeedback(m.session_breadcrumb_not_supported());
+      showFeedback(m.session_breadcrumb_not_supported(), "error");
     }
   }
 
   async function handleCopyFilePath() {
     showOpenMenu = false;
     if (!sessionDir) {
-      showFeedback(m.session_breadcrumb_no_path_available());
+      showFeedback(m.session_breadcrumb_no_path_available(), "error");
       return;
     }
     const ok = await copyToClipboard(sessionDir);
-    showFeedback(ok
-      ? m.session_breadcrumb_path_copied()
-      : m.session_breadcrumb_failed());
+    showFeedback(
+      ok
+        ? m.session_breadcrumb_path_copied()
+        : m.session_breadcrumb_failed(),
+      ok ? "success" : "error",
+    );
   }
 
   async function handleOpenIn(opener: Opener) {
@@ -598,7 +616,7 @@
         target: opener.name,
       }));
     } catch {
-      showFeedback(m.session_breadcrumb_failed_to_open());
+      showFeedback(m.session_breadcrumb_failed_to_open(), "error");
     }
   }
 
@@ -623,9 +641,12 @@
       if (resp.command) {
         const cmd = formatResumeResponseCommand(session.agent, resp);
         const ok = cmd ? await copyToClipboard(cmd) : false;
-        showFeedback(ok
-          ? m.session_breadcrumb_command_copied()
-          : m.session_breadcrumb_failed());
+        showFeedback(
+          ok
+            ? m.session_breadcrumb_command_copied()
+            : m.session_breadcrumb_failed(),
+          ok ? "success" : "error",
+        );
         return;
       }
     } catch {
@@ -636,11 +657,14 @@
     });
     if (cmd) {
       const ok = await copyToClipboard(cmd);
-      showFeedback(ok
-        ? m.session_breadcrumb_command_copied()
-        : m.session_breadcrumb_failed());
+      showFeedback(
+        ok
+          ? m.session_breadcrumb_command_copied()
+          : m.session_breadcrumb_failed(),
+        ok ? "success" : "error",
+      );
     } else {
-      showFeedback(m.session_breadcrumb_not_supported());
+      showFeedback(m.session_breadcrumb_not_supported(), "error");
     }
   }
 
@@ -842,7 +866,8 @@
         <span class="open-group">
           <button
             class="resume-btn"
-            class:has-feedback={openFeedback !== ""}
+            class:has-feedback-success={openFeedback !== "" && openFeedbackKind === "success"}
+            class:has-feedback-error={openFeedback !== "" && openFeedbackKind === "error"}
             onclick={(e) => { e.stopPropagation(); showOpenMenu = !showOpenMenu; }}
             title={canResume
               ? m.session_breadcrumb_resume_session_in_terminal()
@@ -852,7 +877,11 @@
               : m.session_breadcrumb_session_actions()}
           >
             {#if openFeedback}
-              <CheckIcon size="11" strokeWidth="2.4" aria-hidden="true" />
+              {#if openFeedbackKind === "error"}
+                <TriangleAlertIcon size="11" strokeWidth="2.2" aria-hidden="true" />
+              {:else}
+                <CheckIcon size="11" strokeWidth="2.4" aria-hidden="true" />
+              {/if}
               {openFeedback}
             {:else}
               {canResume
@@ -1312,8 +1341,12 @@
     background: var(--bg-surface-hover);
   }
 
-  .resume-btn.has-feedback {
+  .resume-btn.has-feedback-success {
     color: var(--accent-green, #2ea043);
+  }
+
+  .resume-btn.has-feedback-error {
+    color: var(--accent-red, #e55);
   }
 
   .open-menu {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -190,6 +190,7 @@ async function flushPromises() {
 
 beforeEach(() => {
   generateForSession.mockReset();
+  vi.mocked(copyToClipboard).mockReset().mockResolvedValue(true);
   openersService.getApiV1Openers.mockReset().mockResolvedValue({ openers: [] });
   sessionsService.getApiV1SessionsIdDirectory.mockReset().mockResolvedValue({ path: "" });
   sessionsService.getApiV1SessionsIdUsage.mockReset().mockResolvedValue(makeUsage());
@@ -326,6 +327,46 @@ describe("SessionBreadcrumb", () => {
 
     expect(document.body.textContent).toContain("重命名");
     expect(document.body.textContent).toContain("删除");
+
+    unmount(component);
+  });
+
+  it("shows clipboard failures as errors when copying the directory path", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue(false);
+    sessionsService.getApiV1SessionsIdDirectory.mockResolvedValue({
+      path: "/tmp/project",
+    });
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude", {
+          file_path: "/tmp/project/session.jsonl",
+        }),
+        onBack: () => {},
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector(".resume-btn")).toBeTruthy();
+    });
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+
+    const copyPathButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Copy directory path"));
+    expect(copyPathButton).toBeTruthy();
+    copyPathButton!.click();
+
+    await vi.waitFor(() => {
+      const feedback = document.querySelector<HTMLButtonElement>(".resume-btn");
+      expect(feedback?.textContent?.trim()).toBe("Failed");
+      expect(feedback?.classList.contains("has-feedback-error")).toBe(true);
+      expect(feedback?.classList.contains("has-feedback-success")).toBe(false);
+      expect(feedback?.querySelector(".lucide-triangle-alert")).toBeTruthy();
+      expect(feedback?.querySelector(".lucide-check")).toBeNull();
+    });
 
     unmount(component);
   });


### PR DESCRIPTION
Copying a session directory could fail while the session action button still showed a green check. Clipboard failures now use a red alert state, while successful session actions keep the existing green confirmation.

The feedback state lives in the app's session breadcrumb, so this does not require a kit-ui change. Other failures already shown through the same action button now use the same error treatment instead of appearing successful.

![Directory copy failure shown as a red alert](https://github.com/user-attachments/assets/02646847-89d5-4df5-92d7-777fc2edb15b)

Closes #1350
