### PR TITLE
fix(parser): match Codex fork turns to parents

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -287,21 +287,24 @@ Grok section and remove the explicit registry exception in the coverage test.
   `internal/parser/codex_provider.go`; usage is taken from the last-turn
   counters rather than repeatedly counting cumulative totals. Fork and
   subagent rollouts can begin with a re-stamped copy of the parent's
-  transcript, including its `token_count` records. Agentsview recognizes the
-  copied parent `session_meta` and discards that leading replay through the
-  last pre-creation UUIDv7 `turn_id`, preserving only usage produced by the
-  derived session. Child-only subagent transcripts are left unchanged. An
-  appended `session_meta` after an incremental-sync offset forces an
+  transcript, including its `token_count` records. Agentsview follows the
+  explicit parent id, compares the ordered `turn_context.turn_id` sequence as
+  opaque identifiers, and discards the leading turns also present in the
+  parent. UUID versions and identifier bytes carry no chronological meaning;
+  the first turn id absent from the parent begins child-owned usage. Missing
+  parents fail open, and child-only subagent transcripts are left unchanged.
+  An appended `session_meta` after an incremental-sync offset forces an
   authoritative replacement of that derived session, because the metadata can
   be the copied parent record that activates replay filtering. The original
   parent session remains valid and is not reparsed. Reverified 2026-08-12
-  against locally observed multi-agent rollouts and the pinned format sources;
-  the pinned TUI is the evidenced `history.jsonl` producer. No `append_entry`
-  producer call exists under the pinned `app-server` or `exec` trees, so this
-  evidence does not establish IDE, desktop, or `codex exec` activity-hint
-  coverage. Locally observed Codex app builds can write the same schema, but
-  that is observational evidence rather than a public compatibility guarantee.
-  Agentsview derives the hint path as
+  against locally observed multi-agent rollouts that replayed differently
+  shaped opaque turn ids before the first child-owned turn, and against the
+  pinned format sources; the pinned TUI is the evidenced `history.jsonl`
+  producer. No `append_entry` producer call exists under the pinned
+  `app-server` or `exec` trees, so this evidence does not establish IDE,
+  desktop, or `codex exec` activity-hint coverage. Locally observed Codex app
+  builds can write the same schema, but that is observational evidence rather
+  than a public compatibility guarantee. Agentsview derives the hint path as
   `<configured-sessions-root>/../history.jsonl`; a custom sessions root
   without that sibling, or `HistoryPersistence::None`, degrades to ordinary
   watcher behavior, degraded-coverage polling when applicable, and the daily

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -293,18 +293,26 @@ Grok section and remove the explicit registry exception in the coverage test.
   parent. UUID versions and identifier bytes carry no chronological meaning;
   the first turn id absent from the parent begins child-owned usage. Missing
   parents fail open, and child-only subagent transcripts are left unchanged.
-  An appended `session_meta` after an incremental-sync offset forces an
-  authoritative replacement of that derived session, because the metadata can
-  be the copied parent record that activates replay filtering. The original
-  parent session remains valid and is not reparsed. Reverified 2026-08-12
-  against locally observed multi-agent rollouts that replayed differently
-  shaped opaque turn ids before the first child-owned turn, and against the
-  pinned format sources; the pinned TUI is the evidenced `history.jsonl`
-  producer. No `append_entry` producer call exists under the pinned
-  `app-server` or `exec` trees, so this evidence does not establish IDE,
-  desktop, or `codex exec` activity-hint coverage. Locally observed Codex app
-  builds can write the same schema, but that is observational evidence rather
-  than a public compatibility guarantee. Agentsview derives the hint path as
+  S3 imports list the child's configured Codex root for its explicitly named
+  parent and materialize only that one parent beside the child. When the
+  parent is not yet available or has no turns, the child remains visible but
+  is stored below the current data version so a later unchanged-object sync
+  retries and corrects the overcount. Reverified 2026-08-13 against the
+  materialized-S3 parser-to-SQLite path: the first missing-parent pass kept
+  replayed content as retryable, and the next pass fetched only the named
+  parent and replaced it with child-owned messages and usage. An appended
+  `session_meta` after an incremental-sync offset forces an authoritative
+  replacement of that derived session, because the metadata can be the copied
+  parent record that activates replay filtering. The original parent session
+  remains valid and is not reparsed. Reverified 2026-08-12 against locally
+  observed multi-agent rollouts that replayed differently shaped opaque turn
+  ids before the first child-owned turn, and against the pinned format
+  sources; the pinned TUI is the evidenced `history.jsonl` producer. No
+  `append_entry` producer call exists under the pinned `app-server` or `exec`
+  trees, so this evidence does not establish IDE, desktop, or `codex exec`
+  activity-hint coverage. Locally observed Codex app builds can write the same
+  schema, but that is observational evidence rather than a public compatibility
+  guarantee. Agentsview derives the hint path as
   `<configured-sessions-root>/../history.jsonl`; a custom sessions root
   without that sibling, or `HistoryPersistence::None`, degrades to ordinary
   watcher behavior, degraded-coverage polling when applicable, and the daily

--- a/docs/superpowers/plans/2026-08-13-codex-s3-fork-replay.md
+++ b/docs/superpowers/plans/2026-08-13-codex-s3-fork-replay.md
@@ -1,0 +1,307 @@
+# Codex S3 Fork Replay Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans
+> to implement this plan directly in the current agent, task-by-task. Never use
+> subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Exclude replayed parent messages and usage from Codex forks imported
+through S3, while keeping unresolved children eligible for a later corrective
+sync.
+
+**Approved spec/design:**
+`docs/superpowers/specs/2026-08-13-codex-s3-fork-replay-design.md`
+
+**Architecture:** The parser package identifies the canonical Codex S3 root and
+locates a parent rollout by opaque session ID. The sync S3 seam fetches only
+that parent and materializes it beside the child, so the existing file-backed
+turn-membership resolver remains authoritative. The Codex provider reports an
+unresolved parent as `DataVersionNeedsRetry`, which the existing sync write path
+persists below the current version.
+
+**Tech Stack:** Go 1.26, JSONL, S3-compatible object storage, Testify, SQLite
+sync integration tests.
+
+## Global Constraints
+
+- Compare Codex `turn_context.turn_id` values only as opaque equality keys.
+- Fetch at most the one named parent rollout per child parse; never materialize
+  an S3 archive wholesale.
+- Fail open for content so unresolved parents cannot erase child work, but mark
+  the result retryable so the overcount is not accepted as current.
+- Do not add a persisted dependency graph or timestamp fallback.
+- Keep production relationship classification unchanged.
+- Update the Codex format provenance entry with the supported S3 behavior.
+
+______________________________________________________________________
+
+### Task 1: Locate a Codex Parent Within Its S3 Root
+
+**Files:**
+
+- Modify: `internal/parser/s3source.go`
+- Test: `internal/parser/s3source_test.go`
+
+**Interfaces:**
+
+- Consumes: a child rollout URI and opaque parent session ID.
+
+- Produces:
+  `FindCodexS3ParentSessionURI(childURI, parentID string) (string, bool)`.
+
+- [x] **Step 1: Write the failing URI lookup tests**
+
+    Add a table-driven test that stubs `listS3Objects` and covers:
+
+    - a dated parent under `s3://bucket/machine/raw/codex/2026/08/12/`;
+    - a parent under `sessions/YYYY/MM/DD`;
+    - a flat parent under `archived_sessions`;
+    - a live and archived duplicate, where the live rollout must win;
+    - a supported configured root without the `raw/codex` convention;
+    - an unrelated object whose filename does not carry the exact parent ID;
+    - an empty, shortened, or path-like parent ID, which must not list or match
+      anything.
+
+    Assert the exact matching URI and that listing is scoped to the canonical
+    `s3://bucket/machine/raw/codex` root.
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+    Run:
+
+    ```bash
+    go test ./internal/parser -run TestFindCodexS3ParentSessionURI -count=1
+    ```
+
+    Expected: FAIL because `FindCodexS3ParentSessionURI` does not exist.
+
+- [x] **Step 3: Implement the bounded metadata lookup**
+
+    Add a private helper that derives the canonical Codex root from the child URI,
+    accepting the existing raw, `sessions`, `archived_sessions`, and dated
+    layouts. Reject parent IDs containing `/`, `\\`, or surrounding whitespace.
+    List that root through `listS3Objects`, keep only valid Codex rollout
+    filenames, and return the first object whose
+    `CodexSessionUUIDFromFilename(path.Base(uri))` equals `parentID` exactly.
+    Return `("", false)` on invalid input, listing failure, or no match.
+
+- [x] **Step 4: Run the focused test and verify GREEN**
+
+    Run the command from Step 2. Expected: PASS.
+
+### Task 2: Hydrate the Named Parent and Retry Unresolved Children
+
+**Files:**
+
+- Modify: `internal/parser/codex.go`
+- Modify: `internal/parser/codex_provider.go`
+- Modify: `internal/sync/s3.go`
+- Test: `internal/parser/codex_provider_test.go`
+- Test: `internal/sync/s3_test.go`
+
+**Interfaces:**
+
+- Consumes: `FindCodexS3ParentSessionURI`, the materialized child path, and the
+  existing `ParseResultOutcome.DataVersion` contract.
+
+- Produces: a private `hydrateS3CodexParent(childPath, childURI string) bool` in
+  `internal/sync/s3.go`, and a Codex parse result whose data-version state is
+  `DataVersionNeedsRetry` when an explicit parent cannot provide any turn IDs.
+
+- [x] **Step 1: Write the failing provider retry test**
+
+    Add a provider test with a fork child whose `forked_from_id` names no file in
+    the provider root. Assert that parsing still returns the child's visible
+    messages, but the sole `ParseResultOutcome` has `DataVersionNeedsRetry` and
+    a non-empty retry reason naming unresolved parent turns. Repeat with valid
+    final-line metadata that has no trailing newline.
+
+- [x] **Step 2: Write the failing S3 replay and eventual-retry test**
+
+    In `internal/sync/s3_test.go`, hand-build a parent rollout with one parent
+    turn and a child rollout that replays that turn before one child-owned turn.
+    Stub `listS3Objects` and `fetchS3Object` for the child, parent, and optional
+    session index.
+
+    First process the child with parent lookup unavailable. Write it through
+    `pendingWrite{needsRetry: res.needsRetryForSession(childID)}` and assert:
+
+    - replayed and child messages remain visible (fail-open);
+    - stored data version is below `db.CurrentDataVersion()`.
+
+    Then expose the parent without changing child metadata, process and write the
+    same child again, and assert:
+
+    - only the two child-owned messages remain;
+    - replayed token usage is absent;
+    - stored data version equals `db.CurrentDataVersion()`;
+    - only the named parent object was fetched in addition to the child and
+      session index.
+
+- [x] **Step 3: Run both focused tests and verify RED**
+
+    Run:
+
+    ```bash
+    go test ./internal/parser ./internal/sync \
+      -run 'TestCodexProviderUnresolvedParentNeedsRetry|TestProcessS3CodexForkRetriesUntilParentAvailable' \
+      -count=1
+    ```
+
+    Expected: FAIL because unresolved Codex parents are reported current and the
+    S3 seam never hydrates the parent.
+
+- [x] **Step 4: Preflight parent resolution in the Codex provider**
+
+    Add a private
+    `codexParentResolution(path string) (parentID string, resolved bool)`
+    method. It scans the first valid session metadata, extracts `forked_from_id`
+    or the existing subagent parent field, and uses `parentTurnResolver(path)`
+    to require a non-empty parent turn set. In `codexProvider.Parse`, keep the
+    existing fail-open parse result, but set its data-version state to
+    `DataVersionNeedsRetry` with a concrete retry reason when explicit lineage
+    is present and the parent is unresolved. Preserve `DataVersionCurrent` for
+    non-derived sessions and resolved parents. Do not change `parseSession`
+    signatures or production relationship classification.
+
+- [x] **Step 5: Hydrate one named parent in the S3 parse seam**
+
+    After writing the child temp file and before provider parsing, read the first
+    valid `session_meta` to obtain `forked_from_id` or the existing subagent
+    parent field. Call `FindCodexS3ParentSessionURI`. When it returns a URI,
+    fetch that object and stream it to a path under the same temporary root
+    using `safeS3TempRelPath` with an `AgentCodex` discovered file. Treat a
+    missing or unreadable parent as unresolved rather than as a fatal child
+    parse error. Return whether hydration succeeded so tests can distinguish
+    current from retryable parsing without introducing a second parent parser.
+
+- [x] **Step 6: Preserve per-result retry state through S3 conversion**
+
+    Change `parseMaterializedS3Source` to translate each
+    `ParseResultOutcome.DataVersionNeedsRetry` into
+    `processResult.retrySessionIDs` keyed by the unprefixed parser session ID.
+    After applying the S3 machine prefix, rewrite those map keys with the same
+    prefix. Keep `ForceReplace` and excluded IDs unchanged.
+
+- [x] **Step 7: Run focused tests and verify GREEN**
+
+    Run the command from Step 3. Expected: PASS.
+
+### Task 3: Include Explicit Forks in Captured Full Replay Validation
+
+**Files:**
+
+- Modify: `internal/parser/codex_replay_simulator_test.go`
+
+**Interfaces:**
+
+- Consumes: the first `session_meta` record in each captured rollout.
+
+- Produces: full-replay totals over exactly the five explicit fork children,
+  independent of production `RelationshipType` classification.
+
+- [x] **Step 1: Change full-replay selection to source metadata**
+
+    Before parsing totals, partition the six captured files by non-empty
+    `payload.forked_from_id` in their first line, as the line-by-line companion
+    test already does. Assert `require.Len(t, children, 5)` and iterate only
+    those children. Remove the `RelationshipType` filter.
+
+- [x] **Step 2: Run captured validation when evidence is available**
+
+    Run:
+
+    ```bash
+    go test ./internal/parser -run 'TestCodexCapturedFork(Replay|LineReplay)Totals' -count=1
+    ```
+
+    Expected without `AGENTSVIEW_CODEX_REPLAY_ROOT`: both tests SKIP cleanly. When
+    the configured evidence root is available, both tests must select five
+    children and retain the existing literal message, token, and cost totals.
+
+### Task 4: Record Provenance and Verify the Approved Batch
+
+**Files:**
+
+- Modify: `docs/internal/session-format-sources.md`
+- Modify: `docs/superpowers/plans/2026-08-13-codex-s3-fork-replay.md`
+
+**Interfaces:**
+
+- Consumes: the approved design and passing behavioral tests.
+
+- Produces: an updated Codex evidence entry and completed implementation record.
+
+- [x] **Step 1: Update Codex format provenance**
+
+    State that S3 forks hydrate only their explicitly named parent into the
+    temporary parse tree, unresolved parents fail open with a retryable data
+    version, and later unchanged-object syncs can correct the stored overcount.
+    Record the 2026-08-13 re-verification against the materialized-S3 tests.
+
+- [x] **Step 2: Run focused and repository verification**
+
+    Run in isolated scratch HOME/XDG state with the pinned Go 1.26.5 binary:
+
+    ```bash
+    go fmt ./...
+    go test -tags fts5 ./internal/parser ./internal/sync ./internal/db -count=1
+    go vet ./...
+    git diff --check
+    ```
+
+    Expected: all commands pass with no warnings or formatting errors.
+
+- [x] **Step 3: Review scope and private-data safety**
+
+    Inspect `git status --short`, `git diff HEAD`, and every introduced blob.
+    Confirm only the approved S3 lookup, hydration, retry propagation, captured
+    test selection, provenance, and plan changed. Block publication on real
+    credentials, private paths, or internal endpoints.
+
+- [x] **Step 4: Mark this plan complete and commit the implementation**
+
+    Change every task checkbox to `[x]`. Stage only the intended files and use the
+    mandatory commit skill. Do not bypass hooks and do not amend existing
+    commits.
+
+### Task 5: Push and Record Triage Outcomes
+
+**Files:** None.
+
+**Interfaces:**
+
+- Consumes: the verified implementation commit and triage ledger decisions.
+
+- Produces: a pushed exact head, local roborev outcome records when same-head
+  jobs exist, and resolved minimization of the fully addressed trusted
+  roborev-ci comment.
+
+- [ ] **Step 1: Inspect the complete base-to-head history**
+
+    Fetch `origin/main`, inspect diff, commit metadata, patches, and introduced
+    blobs, and verify the PR title/body still describe the current result.
+
+- [ ] **Step 2: Push the branch normally**
+
+    Run `git push origin HEAD:fix/codex-fork-parent-membership`. Wait until the
+    GitHub head OID matches local HEAD.
+
+- [ ] **Step 3: Reinspect every exact-head evidence surface**
+
+    Wait for all selected non-review checks, trusted same-head roborev-ci, and
+    enabled local roborev jobs. Do not create a review. If new findings appear,
+    return to one-at-a-time user triage before editing.
+
+- [ ] **Step 4: Record approved outcomes**
+
+    For existing local roborev jobs covering these findings, add one idempotent
+    `triage-pr` comment per finding and close a job only when all its findings
+    are fixed or recorded not-an-issue. When every finding in the current
+    roborev-ci comment is verified absent, minimize that comment as `RESOLVED`.
+    Do not post, edit, resolve, or delete human review comments or threads.
+
+- [ ] **Step 5: Apply the exact-head completion gate**
+
+    Confirm local, remote, and GitHub heads match; the worktree is clean; merge
+    state is clean; CI passes; all review findings are decided and verified; and
+    no deferred finding or changes-requested review remains.

--- a/docs/superpowers/specs/2026-08-13-codex-s3-fork-replay-design.md
+++ b/docs/superpowers/specs/2026-08-13-codex-s3-fork-replay-design.md
@@ -25,13 +25,16 @@ into the same temporary Codex directory tree. The existing file-backed parent
 turn resolver will then compare opaque `turn_context.turn_id` values without a
 second parsing implementation.
 
-If the parent object is missing, unreadable, or not complete enough to resolve
-the child's replay prefix, parse fail-open so child-owned data cannot be lost,
-but return the child with `DataVersionNeedsRetry`. The sync layer must persist
-that retry marker rather than treating the possibly inflated result as current.
-A later audit or source sync will revisit the unchanged child and replace it
-once its parent can be resolved. This is the narrow eventual-correction
-mechanism; no dependency index is introduced.
+If the parent object is missing, unreadable, or has no turn identifiers, parse
+fail-open so child-owned data cannot be lost, but return the child with
+`DataVersionNeedsRetry`. The sync layer must persist that retry marker rather
+than treating the possibly inflated result as current. A later audit or source
+sync will revisit the unchanged child and replace it once its parent can be
+resolved. This is the narrow eventual-correction mechanism; no dependency index
+is introduced. A non-empty parent is authoritative for the current parse. The
+format has no marker that can distinguish a later replay turn omitted from a
+parent snapshot from the child's first real turn, so tracking future parent
+growth remains outside this repair.
 
 Parent hydration must remain bounded to one named object per child and must use
 the existing safe S3 path and temporary-file rules. A malformed parent ID or a

--- a/docs/superpowers/specs/2026-08-13-codex-s3-fork-replay-design.md
+++ b/docs/superpowers/specs/2026-08-13-codex-s3-fork-replay-design.md
@@ -1,0 +1,57 @@
+# Codex S3 Fork Replay Repair
+
+## Goal
+
+Keep Codex fork messages and usage correct when rollouts arrive through S3,
+including when a child is imported before its parent is available.
+
+## Scope
+
+This repair covers the three findings approved during PR #1384 triage:
+
+- resolve a fork's parent while parsing a materialized S3 child;
+- keep a child retryable when its parent cannot yet be resolved; and
+- make captured full-replay validation include explicit forks.
+
+It does not add a general persisted parent-child dependency graph or restore
+timestamp interpretation for opaque turn identifiers.
+
+## Design
+
+Before parsing a materialized Codex S3 child, read its explicit parent session
+identifier from `session_meta`. Derive the parent object's URI from the child's
+configured S3 root and Codex archive layout, then fetch only that named parent
+into the same temporary Codex directory tree. The existing file-backed parent
+turn resolver will then compare opaque `turn_context.turn_id` values without a
+second parsing implementation.
+
+If the parent object is missing, unreadable, or not complete enough to resolve
+the child's replay prefix, parse fail-open so child-owned data cannot be lost,
+but return the child with `DataVersionNeedsRetry`. The sync layer must persist
+that retry marker rather than treating the possibly inflated result as current.
+A later audit or source sync will revisit the unchanged child and replace it
+once its parent can be resolved. This is the narrow eventual-correction
+mechanism; no dependency index is introduced.
+
+Parent hydration must remain bounded to one named object per child and must use
+the existing safe S3 path and temporary-file rules. A malformed parent ID or a
+parent URI outside the child's configured Codex root fails open and leaves the
+child retryable.
+
+The captured full-replay test will select explicit fork children from the
+rollout's `session_meta.forked_from_id`, matching the line-by-line replay test.
+Production relationship classification remains unchanged.
+
+## Verification
+
+Behavioral tests will protect these contracts:
+
+- the materialized S3 path fetches a named parent and excludes its replayed
+  messages and token usage from the child;
+- a missing parent stores a retryable child, and a later sync with the parent
+  available replaces the inflated result with child-owned data only;
+- captured full replay includes all explicit fork rollouts instead of filtering
+  them through `RelationshipType`.
+
+The focused parser, S3 sync, and database tests must pass, followed by
+`go fmt ./...`, `go vet ./...`, and the repository's normal commit hooks.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -411,7 +411,10 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // inline reference, and terminal command fields in shapes the parser previously
 // skipped. Existing VS Code Copilot and Positron rows need re-parsing so their
 // structured tool calls and visible file references are restored.)
-const dataVersion = 86
+// (87: Codex fork replay boundary correction. Turn identifiers are opaque;
+// existing Codex-format rows need re-parsing so copied parent turns with any
+// identifier shape remain excluded until the first child-owned turn.)
+const dataVersion = 87
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1009,8 +1009,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionUsageReparses(t *testing.T) {
-	assert.Equal(t, 86, CurrentDataVersion(),
-		"Codex replay accounting and VS Code Copilot response items require sequential reparses")
+	assert.Equal(t, 87, CurrentDataVersion(),
+		"Codex replay accounting, VS Code Copilot response items, and opaque Codex fork boundaries require sequential reparses")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -361,7 +361,7 @@ func (s claudeSourceSet) discoveredSourceRef(
 	root string, file DiscoveredFile,
 ) (SourceRef, bool) {
 	if strings.HasPrefix(file.Path, "s3://") {
-		return s3SourceRefFromDiscoveredFile(file), true
+		return s3SourceRefFromDiscoveredFile(root, file), true
 	}
 	return s.sourceRef(root, file.Path)
 }

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1533,6 +1533,61 @@ func (p *codexProvider) parentTurnResolver(
 	}
 }
 
+func (p *codexProvider) codexParentResolution(
+	childPath string,
+) (string, bool) {
+	parentID, resolutionNeeded := CodexReplayParentID(childPath)
+	if parentID == "" || !resolutionNeeded {
+		return "", false
+	}
+	turnIDs, resolved := p.parentTurnResolver(childPath)(parentID)
+	return parentID, resolved && len(turnIDs) > 0
+}
+
+// CodexReplayParentID returns the explicit parent only when the rollout has a
+// positive replay-prefix signal: forked_from_id, or a copied parent
+// session_meta after subagent lineage metadata. Child-only subagents return no
+// replay parent and remain current without resolving their parent transcript.
+func CodexReplayParentID(childPath string) (string, bool) {
+	f, err := os.Open(childPath)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	parentID := ""
+	resolutionNeeded := false
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !gjson.Valid(line) {
+			continue
+		}
+		if resolutionNeeded || gjson.Get(line, "type").Str != codexTypeSessionMeta {
+			continue
+		}
+		payload := gjson.Get(line, "payload")
+		forkedFromID := strings.TrimSpace(payload.Get("forked_from_id").Str)
+		if forkedFromID != "" {
+			parentID = forkedFromID
+			resolutionNeeded = true
+			continue
+		}
+		if parentID == "" {
+			parentID = codexSubagentParentThreadID(payload)
+			continue
+		}
+		if payload.Get("id").Str == parentID {
+			resolutionNeeded = true
+		}
+	}
+	if scanner.Err() != nil || parentID == "" || !resolutionNeeded {
+		return "", false
+	}
+	return parentID, true
+}
+
 // parseSessionSnapshot parses exactly the raw-size snapshot captured from f.
 // Limiting the reader prevents an append racing the scan from being folded into
 // a cursor keyed by the earlier size.

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -57,6 +57,8 @@ type codexSessionIndexEntry struct {
 // JSONL session file line by line.
 type codexSessionBuilder struct {
 	codexCursorState
+	resolveParentTurns   codexParentTurnResolver
+	parentTurnIDs        map[string]struct{}
 	messages             []ParsedMessage
 	firstMessage         string
 	startedAt            time.Time
@@ -82,55 +84,39 @@ type codexSessionBuilder struct {
 // and token_count events — into both kinds of derived rollout with
 // re-stamped envelope timestamps, so the same usage exists in multiple
 // session files and gets counted repeatedly. Envelope timestamps cannot
-// locate the boundary (the replay is re-stamped at child creation), but
-// turn ids are UUIDv7 values minted when the turn originally ran: every
-// replayed turn predates the child instant, and the first genuine turn
-// is minted at or after it. The gate stays closed until the first
-// turn_context whose turn_id timestamp is >= the child's own creation
-// time, then everything flows normally.
-//
-// Replayed turn_context entries from parents recorded before Codex
-// stamped turn ids carry no turn_id at all; a CLI new enough to write
-// forked_from_id or subagent parent metadata always stamps genuine
-// turns, so a missing turn_id while gated means replayed history. An
-// unparseable turn_id fails open (pre-#643 behaviour) rather than risk
-// dropping live data.
+// locate the boundary. The referenced parent transcript can: while the
+// gate is active, turn ids also present in that parent are replayed and
+// the first turn id absent from it belongs to the child. Turn ids are
+// opaque equality keys here; their UUID version and bytes have no
+// chronological meaning.
 type codexForkGate struct {
-	active           bool
-	createdMs        int64
-	subagentParentID string
+	active          bool
+	parentSessionID string
+	parentResolved  bool
 }
 
-// armFromMeta activates the gate when the session_meta belongs to a
-// forked or subagent session and its creation instant can be anchored:
-// from the child's UUIDv7 id, the payload timestamp, or the JSONL
-// envelope timestamp, in that order.
-func (g *codexForkGate) armFromMeta(payload gjson.Result, envelopeTS time.Time) {
-	forked := payload.Get("forked_from_id").Str != ""
+type codexParentTurnResolver func(string) (map[string]struct{}, bool)
+
+// armFromMeta records explicit lineage and activates replay filtering only
+// when the referenced parent transcript was resolved. Missing parents fail
+// open so an incomplete source archive cannot erase child data.
+func (g *codexForkGate) armFromMeta(payload gjson.Result, parentResolved bool) {
+	forkedFromID := strings.TrimSpace(payload.Get("forked_from_id").Str)
 	parentID := codexSubagentParentThreadID(payload)
-	if !forked && parentID == "" {
+	if forkedFromID == "" && parentID == "" {
 		return
 	}
-	ms := uuidV7Millis(payload.Get("id").Str)
-	if ms == 0 {
-		if t := parseTimestamp(payload.Get("timestamp").Str); !t.IsZero() {
-			ms = t.UnixMilli()
-		}
+	if forkedFromID != "" {
+		parentID = forkedFromID
 	}
-	if ms == 0 && !envelopeTS.IsZero() {
-		ms = envelopeTS.UnixMilli()
-	}
-	if ms == 0 {
-		return // no anchor for the boundary — fail open
-	}
-	g.createdMs = ms
-	if forked {
-		g.active = true
+	g.parentSessionID = parentID
+	g.parentResolved = parentResolved
+	if forkedFromID != "" {
+		g.active = parentResolved
 		return
 	}
 	// Parent metadata alone also appears in child-only transcripts. Wait
 	// for the copied parent's session_meta before suppressing anything.
-	g.subagentParentID = parentID
 }
 
 // suppressesSessionMeta identifies the copied parent session_meta that
@@ -141,11 +127,11 @@ func (g *codexForkGate) suppressesSessionMeta(payload gjson.Result) bool {
 	if g.active {
 		return true
 	}
-	if g.subagentParentID == "" ||
-		payload.Get("id").Str != g.subagentParentID {
+	parentID := payload.Get("id").Str
+	if parentID == "" || parentID != g.parentSessionID {
 		return false
 	}
-	g.active = true
+	g.active = g.parentResolved
 	return true
 }
 
@@ -160,42 +146,26 @@ func codexSubagentParentThreadID(payload gjson.Result) string {
 }
 
 // suppresses reports whether the line is replayed parent history.
-// turn_context lines open the gate when their turn id was minted at
-// or after the fork instant.
-func (g *codexForkGate) suppresses(lineType string, payload gjson.Result) bool {
+// Parent turn ids are opaque membership keys. Once the first turn id
+// absent from the parent appears, every later line belongs to the child.
+func (g *codexForkGate) suppresses(
+	lineType string,
+	payload gjson.Result,
+	parentTurnIDs map[string]struct{},
+) bool {
 	if !g.active {
-		// A child-owned event before a copied parent session_meta proves
-		// this is a child-only transcript, not a replay prefix.
-		g.subagentParentID = ""
 		return false
 	}
 	if lineType != codexTypeTurnContext {
 		return true
 	}
 	tid := payload.Get("turn_id").Str
-	if tid == "" {
-		return true // pre-turn_id parent history
-	}
-	if ms := uuidV7Millis(tid); ms != 0 && ms < g.createdMs {
+	if _, replayed := parentTurnIDs[tid]; replayed {
 		return true
 	}
 	g.active = false
-	g.subagentParentID = ""
+	g.parentResolved = false
 	return false
-}
-
-// uuidV7Millis extracts the millisecond timestamp embedded in a
-// UUIDv7, returning 0 for anything that is not a v7 UUID.
-func uuidV7Millis(id string) int64 {
-	hex := strings.ReplaceAll(id, "-", "")
-	if len(hex) != 32 || hex[12] != '7' {
-		return 0
-	}
-	ms, err := strconv.ParseInt(hex[:12], 16, 64)
-	if err != nil {
-		return 0
-	}
-	return ms
 }
 
 type codexToolCallRef struct {
@@ -214,8 +184,10 @@ type codexPendingEvent struct {
 
 func newCodexSessionBuilder(
 	_ bool,
+	resolveParentTurns codexParentTurnResolver,
 ) *codexSessionBuilder {
 	return &codexSessionBuilder{
+		resolveParentTurns:   resolveParentTurns,
 		project:              "unknown",
 		callNames:            make(map[string]string),
 		callRefs:             make(map[string]codexToolCallRef),
@@ -224,6 +196,30 @@ func newCodexSessionBuilder(
 		pendingAgentEvents:   make(map[string][]codexPendingEvent),
 		orphanNotificationIx: make(map[string]int),
 	}
+}
+
+func (b *codexSessionBuilder) armForkGate(payload gjson.Result) {
+	parentID := strings.TrimSpace(payload.Get("forked_from_id").Str)
+	if parentID == "" {
+		parentID = codexSubagentParentThreadID(payload)
+	}
+	resolved := false
+	if parentID != "" && b.resolveParentTurns != nil {
+		b.parentTurnIDs, resolved = b.resolveParentTurns(parentID)
+	}
+	b.forkGate.armFromMeta(payload, resolved)
+}
+
+func (b *codexSessionBuilder) suppresses(
+	lineType string,
+	payload gjson.Result,
+) bool {
+	if b.forkGate.active && b.parentTurnIDs == nil &&
+		b.resolveParentTurns != nil {
+		b.parentTurnIDs, _ =
+			b.resolveParentTurns(b.forkGate.parentSessionID)
+	}
+	return b.forkGate.suppresses(lineType, payload, b.parentTurnIDs)
 }
 
 func (b *codexSessionBuilder) incrementalSeed() codexIncrementalSeed {
@@ -258,17 +254,17 @@ func (b *codexSessionBuilder) processLine(
 		}
 		return b.handleSessionMeta(payload, ts)
 	case codexTypeTurnContext:
-		if b.forkGate.suppresses(codexTypeTurnContext, payload) {
+		if b.suppresses(codexTypeTurnContext, payload) {
 			return false
 		}
 		b.model = payload.Get("model").Str
 	case codexTypeResponseItem:
-		if b.forkGate.suppresses(codexTypeResponseItem, payload) {
+		if b.suppresses(codexTypeResponseItem, payload) {
 			return false
 		}
 		b.handleResponseItem(payload, ts)
 	case codexTypeEventMsg:
-		if b.forkGate.suppresses(codexTypeEventMsg, payload) {
+		if b.suppresses(codexTypeEventMsg, payload) {
 			return false
 		}
 		b.handleEventMsg(payload)
@@ -302,7 +298,7 @@ func (b *codexSessionBuilder) handleSessionMeta(
 		}
 	}
 
-	b.forkGate.armFromMeta(payload, envelopeTS)
+	b.armForkGate(payload)
 
 	return false
 }
@@ -1493,6 +1489,50 @@ func (p *codexProvider) parseSession(
 	)
 }
 
+func (p *codexProvider) parentTurnResolver(
+	childPath string,
+) codexParentTurnResolver {
+	return func(parentID string) (map[string]struct{}, bool) {
+		parentKey := strings.Join(p.sources.roots, "\x00") + "\x00" + parentID
+		if turnIDs, ok := p.parentTurnCache.GetParent(parentKey); ok {
+			return turnIDs, true
+		}
+		parentPath := ""
+		for _, root := range p.sources.roots {
+			candidate := p.sources.findSourceFile(root, parentID)
+			if candidate == "" || filepath.Clean(candidate) == filepath.Clean(childPath) {
+				continue
+			}
+			parentPath = candidate
+			break
+		}
+		if parentPath == "" {
+			return nil, false
+		}
+		info, err := os.Stat(parentPath)
+		if err != nil || info.IsDir() {
+			return nil, false
+		}
+		cacheKey := codexParentTurnCacheKeyFor(parentPath, info)
+		if turnIDs, ok := p.parentTurnCache.Get(cacheKey); ok {
+			return turnIDs, true
+		}
+
+		turnIDs := make(map[string]struct{})
+		_, err = readCodexJSONLFrom(parentPath, 0, func(line string) {
+			if gjson.Get(line, "type").Str != codexTypeTurnContext {
+				return
+			}
+			turnIDs[gjson.Get(line, "payload.turn_id").Str] = struct{}{}
+		})
+		if err != nil && !errors.Is(err, errCodexIncrementalNeedsFullParse) {
+			return nil, false
+		}
+		p.parentTurnCache.PutParent(parentKey, cacheKey, turnIDs)
+		return turnIDs, true
+	}
+}
+
 // parseSessionSnapshot parses exactly the raw-size snapshot captured from f.
 // Limiting the reader prevents an append racing the scan from being folded into
 // a cursor keyed by the earlier size.
@@ -1504,7 +1544,7 @@ func (p *codexProvider) parseSessionSnapshot(
 ) (*ParsedSession, []ParsedMessage, error) {
 	lr := newLineReader(io.LimitReader(f, info.Size()), maxLineSize)
 	defer releaseLineReader(lr)
-	b := newCodexSessionBuilder(includeExec)
+	b := newCodexSessionBuilder(includeExec, p.parentTurnResolver(path))
 
 	for {
 		line, ok := lr.next()
@@ -1797,7 +1837,7 @@ type codexIncrementalSeed = codexCursorState
 // still active at the end of the scan means the stored offset landed
 // inside the replayed parent history of a forked rollout, so the
 // incremental parse must keep suppressing appended replay lines.
-func seedCodexIncrementalState(
+func (p *codexProvider) seedCodexIncrementalState(
 	path string, offset int64,
 ) (codexIncrementalSeed, error) {
 	f, err := os.Open(path)
@@ -1809,6 +1849,7 @@ func seedCodexIncrementalState(
 	defer f.Close()
 	seed, err := seedCodexIncrementalStateFromReader(
 		io.LimitReader(f, offset),
+		p.parentTurnResolver(path),
 	)
 	if err != nil {
 		return codexIncrementalSeed{}, fmt.Errorf(
@@ -1820,8 +1861,9 @@ func seedCodexIncrementalState(
 
 func seedCodexIncrementalStateFromReader(
 	r io.Reader,
+	resolveParentTurns codexParentTurnResolver,
 ) (codexIncrementalSeed, error) {
-	var seed codexIncrementalSeed
+	b := newCodexSessionBuilder(false, resolveParentTurns)
 	lr := newLineReader(r, maxLineSize)
 	defer releaseLineReader(lr)
 	for {
@@ -1838,48 +1880,45 @@ func seedCodexIncrementalStateFromReader(
 			// Mirror processLine: the fork's own meta arms the
 			// gate and supplies cwd, and replayed parent metas are
 			// dropped while it is active.
-			if !seed.forkGate.suppressesSessionMeta(payload) {
+			if !b.forkGate.suppressesSessionMeta(payload) {
 				if cwd := payload.Get("cwd").Str; cwd != "" {
-					seed.cwd = cwd
+					b.cwd = cwd
 				}
-				seed.agentPath = strings.TrimSpace(
+				b.agentPath = strings.TrimSpace(
 					payload.Get("agent_path").Str,
 				)
-				if seed.agentPath == "" {
-					seed.agentPath = strings.TrimSpace(payload.Get(
+				if b.agentPath == "" {
+					b.agentPath = strings.TrimSpace(payload.Get(
 						"source.subagent.thread_spawn.agent_path",
 					).Str)
 				}
-				seed.forkGate.armFromMeta(
-					payload,
-					parseTimestamp(gjson.Get(line, "timestamp").Str),
-				)
+				b.armForkGate(payload)
 			}
 			continue
 		}
-		if seed.forkGate.suppresses(lineType, payload) {
+		if b.suppresses(lineType, payload) {
 			continue
 		}
 		switch lineType {
 		case codexTypeTurnContext:
-			seed.model = payload.Get("model").Str
+			b.model = payload.Get("model").Str
 		case codexTypeEventMsg:
 			eventType := payload.Get("type").Str
-			seed.observeTaskEvent(eventType)
+			b.observeTaskEvent(eventType)
 			if eventType == "token_count" {
 				raw := payload.Get("info.last_token_usage").Raw
 				if raw != "" {
-					seed.observeTokenUsage(raw)
+					b.observeTokenUsage(raw)
 				}
 			}
 		case codexTypeResponseItem:
-			observeCodexIncrementalUserMessage(&seed, payload)
+			observeCodexIncrementalUserMessage(&b.codexCursorState, payload)
 		}
 	}
 	if err := lr.Err(); err != nil {
 		return codexIncrementalSeed{}, err
 	}
-	return seed, nil
+	return b.codexCursorState, nil
 }
 
 // observeUserMessage feeds one response_item into the
@@ -2085,6 +2124,7 @@ func (p *codexProvider) parseSessionFromSnapshot(
 		func() (codexIncrementalSeed, error) {
 			return seedCodexIncrementalStateFromReader(
 				io.NewSectionReader(f, 0, offset),
+				p.parentTurnResolver(path),
 			)
 		},
 	)
@@ -2103,7 +2143,7 @@ func (p *codexProvider) parseSessionFromWithReader(
 		startOrdinal,
 		includeExec,
 		readLines,
-		seedCodexIncrementalState,
+		p.seedCodexIncrementalState,
 	)
 }
 
@@ -2158,7 +2198,7 @@ func (p *codexProvider) parseSessionFromWithSources(
 		}
 	}
 
-	b := newCodexSessionBuilder(includeExec)
+	b := newCodexSessionBuilder(includeExec, p.parentTurnResolver(path))
 	b.ordinal = startOrdinal
 	b.codexCursorState = seed
 	var fallbackErr error

--- a/internal/parser/codex_cursor.go
+++ b/internal/parser/codex_cursor.go
@@ -232,6 +232,9 @@ func cloneCodexCursorState(state codexCursorState) codexCursorState {
 	state.cwd = strings.Clone(state.cwd)
 	state.agentPath = strings.Clone(state.agentPath)
 	state.lastTaskEvent = strings.Clone(state.lastTaskEvent)
+	state.forkGate.parentSessionID = strings.Clone(
+		state.forkGate.parentSessionID,
+	)
 	return state
 }
 
@@ -244,6 +247,7 @@ func estimateCodexCursorEntryBytes(
 			len(state.model)+
 			len(state.cwd)+
 			len(state.agentPath)+
-			len(state.lastTaskEvent),
+			len(state.lastTaskEvent)+
+			len(state.forkGate.parentSessionID),
 	)
 }

--- a/internal/parser/codex_cursor_test.go
+++ b/internal/parser/codex_cursor_test.go
@@ -22,8 +22,9 @@ func TestCodexCursorCache(t *testing.T) {
 		sawUserTurnAfterFirst:    false,
 		mayReplayFirstUserPrompt: true,
 		forkGate: codexForkGate{
-			active:    true,
-			createdMs: 1720000000000,
+			active:          true,
+			parentSessionID: "parent-1",
+			parentResolved:  true,
 		},
 		lastTaskEvent: "turn_aborted",
 	}

--- a/internal/parser/codex_parent_turn_cache.go
+++ b/internal/parser/codex_parent_turn_cache.go
@@ -1,0 +1,143 @@
+package parser
+
+import (
+	"container/list"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const codexParentTurnCacheMaxEntries = 64
+
+type codexParentTurnCacheKey struct {
+	path   string
+	size   int64
+	mtime  int64
+	inode  uint64
+	device uint64
+}
+
+type codexParentTurnCacheEntry struct {
+	key     codexParentTurnCacheKey
+	turnIDs map[string]struct{}
+}
+
+type codexParentTurnCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	entries    map[codexParentTurnCacheKey]*list.Element
+	parents    map[string]codexParentTurnCacheKey
+	recent     *list.List
+}
+
+func newCodexParentTurnCache(maxEntries int) *codexParentTurnCache {
+	return &codexParentTurnCache{
+		maxEntries: maxEntries,
+		entries:    make(map[codexParentTurnCacheKey]*list.Element),
+		parents:    make(map[string]codexParentTurnCacheKey),
+		recent:     list.New(),
+	}
+}
+
+func (c *codexParentTurnCache) GetParent(
+	parentKey string,
+) (map[string]struct{}, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	key, ok := c.parents[parentKey]
+	c.mu.Unlock()
+	if !ok {
+		return nil, false
+	}
+	info, err := os.Stat(key.path)
+	if err != nil || codexParentTurnCacheKeyFor(key.path, info) != key {
+		c.mu.Lock()
+		delete(c.parents, parentKey)
+		c.mu.Unlock()
+		return nil, false
+	}
+	return c.Get(key)
+}
+
+func newCodexProductionParentTurnCache() *codexParentTurnCache {
+	return newCodexParentTurnCache(codexParentTurnCacheMaxEntries)
+}
+
+func codexParentTurnCacheKeyFor(
+	path string,
+	info os.FileInfo,
+) codexParentTurnCacheKey {
+	inode, device := sourceFileIdentity(info)
+	return codexParentTurnCacheKey{
+		path:   filepath.Clean(path),
+		size:   info.Size(),
+		mtime:  info.ModTime().UnixNano(),
+		inode:  inode,
+		device: device,
+	}
+}
+
+func (c *codexParentTurnCache) Get(
+	key codexParentTurnCacheKey,
+) (map[string]struct{}, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	elem, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	c.recent.MoveToFront(elem)
+	return elem.Value.(codexParentTurnCacheEntry).turnIDs, true
+}
+
+func (c *codexParentTurnCache) Put(
+	key codexParentTurnCacheKey,
+	turnIDs map[string]struct{},
+) {
+	if c == nil || c.maxEntries <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem, ok := c.entries[key]; ok {
+		elem.Value = codexParentTurnCacheEntry{key: key, turnIDs: turnIDs}
+		c.recent.MoveToFront(elem)
+		return
+	}
+	elem := c.recent.PushFront(codexParentTurnCacheEntry{
+		key: key, turnIDs: turnIDs,
+	})
+	c.entries[key] = elem
+	for len(c.entries) > c.maxEntries {
+		oldest := c.recent.Back()
+		entry := oldest.Value.(codexParentTurnCacheEntry)
+		delete(c.entries, entry.key)
+		for parentKey, key := range c.parents {
+			if key == entry.key {
+				delete(c.parents, parentKey)
+			}
+		}
+		c.recent.Remove(oldest)
+	}
+}
+
+func (c *codexParentTurnCache) PutParent(
+	parentKey string,
+	key codexParentTurnCacheKey,
+	turnIDs map[string]struct{},
+) {
+	c.Put(key, turnIDs)
+	if c == nil || c.maxEntries <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.entries[key]; ok {
+		c.parents[parentKey] = key
+	}
+}

--- a/internal/parser/codex_parent_turn_cache_test.go
+++ b/internal/parser/codex_parent_turn_cache_test.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexParentTurnCache(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "parent.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("one\n"), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	key := codexParentTurnCacheKeyFor(path, info)
+	turns := map[string]struct{}{"opaque-turn": {}}
+
+	cache := newCodexParentTurnCache(1)
+	cache.PutParent("root\x00parent", key, turns)
+	got, ok := cache.Get(key)
+	require.True(t, ok)
+	assert.Equal(t, turns, got)
+	got, ok = cache.GetParent("root\x00parent")
+	require.True(t, ok)
+	assert.Equal(t, turns, got)
+
+	other := key
+	other.path = filepath.Join(filepath.Dir(path), "other.jsonl")
+	cache.Put(other, map[string]struct{}{"other": {}})
+	_, kept := cache.Get(key)
+	assert.False(t, kept)
+	_, kept = cache.GetParent("root\x00parent")
+	assert.False(t, kept)
+}

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -49,7 +49,9 @@ func parseCodexTestSession(
 	t *testing.T, path, machine string, includeExec bool,
 ) (*ParsedSession, []ParsedMessage, error) {
 	t.Helper()
-	return newCodexTestProvider(t).parseSession(path, machine, includeExec)
+	return newCodexTestProvider(t, filepath.Dir(path)).parseSession(
+		path, machine, includeExec,
+	)
 }
 
 // parseCodexTestSessionFrom parses appended Codex lines through the
@@ -450,7 +452,7 @@ func TestParseCodexSession_ExecOriginator(t *testing.T) {
 }
 
 func TestCodexInsertMessage_PreservesChronologyOnSameOrdinal(t *testing.T) {
-	b := newCodexSessionBuilder(false)
+	b := newCodexSessionBuilder(false, nil)
 	b.messages = []ParsedMessage{{
 		Ordinal:   2,
 		Role:      RoleAssistant,
@@ -1514,19 +1516,40 @@ func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
 	// `codex fork` replays the parent's history — its session_meta,
 	// turns, messages and token_count events — into the top of the new
 	// rollout with re-stamped envelope timestamps, so the same usage
-	// lives in two files and was counted twice (#643). Turn ids are
-	// UUIDv7 values minted when the turn originally ran, which is what
-	// locates the replay/genuine boundary.
+	// lives in two files and was counted twice (#643). The referenced
+	// parent's ordered turn ids locate the replay/genuine boundary
+	// without assigning chronological meaning to an identifier.
 	forkCreatedMs := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli() // == tsEarly
 	forkID := testUUIDv7(forkCreatedMs, 1)
-	parentTurnID := testUUIDv7(forkCreatedMs-3600_000, 2) // minted an hour earlier
+	parentID := testUUIDv7(forkCreatedMs-7200_000, 0)
+	parentTurnID := testUUIDv7(forkCreatedMs-3600_000, 2)
 	genuineTurnID := testUUIDv7(forkCreatedMs+1000, 3)
+	root := t.TempDir()
+	parent := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+		testjsonl.CodexTurnContextJSON("gpt-5.3", tsEarly),
+	)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "rollout-2024-01-01T08-00-00-"+parentID+".jsonl"),
+		[]byte(parent), 0o600,
+	))
+	parse := func(t *testing.T, content string) (*ParsedSession, []ParsedMessage) {
+		t.Helper()
+		path := filepath.Join(root, strings.ReplaceAll(t.Name(), "/", "-")+"-fork.jsonl")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		sess, msgs, err := newCodexTestProvider(t, root).parseSession(
+			path, "local", false,
+		)
+		require.NoError(t, err)
+		return sess, msgs
+	}
 
 	t.Run("replayed history is dropped, genuine turns kept", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
-			testjsonl.CodexForkedSessionMetaJSON(forkID, "parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexForkedSessionMetaJSON(forkID, parentID, "/tmp", "user", tsEarly),
 			// Replayed parent history (all re-stamped at fork creation):
-			testjsonl.CodexSessionMetaJSON("parent-1", "/other-project", "user", tsEarly),
+			testjsonl.CodexSessionMetaJSON(parentID, "/other-project", "user", tsEarly),
 			testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
 			testjsonl.CodexMsgJSON("user", "replayed question", tsEarly),
 			testjsonl.CodexMsgJSON("assistant", "replayed answer", tsEarly),
@@ -1540,7 +1563,7 @@ func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
 			testjsonl.CodexMsgJSON("assistant", "genuine answer", tsEarlyS5),
 			testjsonl.CodexTokenCountJSON(tsEarlyS5, 10_000, 500, 6_000),
 		)
-		sess, msgs := runCodexParserTest(t, "fork.jsonl", content, false)
+		sess, msgs := parse(t, content)
 		require.NotNil(t, sess)
 
 		// The fork keeps its own identity — the replayed parent
@@ -1560,27 +1583,24 @@ func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
 
 	t.Run("fork with no genuine turns yields no messages", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
-			testjsonl.CodexForkedSessionMetaJSON(forkID, "parent-1", "/tmp", "user", tsEarly),
-			testjsonl.CodexSessionMetaJSON("parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexForkedSessionMetaJSON(forkID, parentID, "/tmp", "user", tsEarly),
+			testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
 			testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
 			testjsonl.CodexMsgJSON("user", "replayed question", tsEarly),
 			testjsonl.CodexMsgJSON("assistant", "replayed answer", tsEarly),
 			testjsonl.CodexTokenCountJSON(tsEarly, 50_000, 9_000, 0),
 		)
-		sess, msgs := runCodexParserTest(t, "fork.jsonl", content, false)
+		sess, msgs := parse(t, content)
 		require.NotNil(t, sess)
 		assert.Equal(t, "codex:"+forkID, sess.ID)
 		assert.Empty(t, msgs)
 		assert.Equal(t, 0, sess.TotalOutputTokens)
 	})
 
-	t.Run("non-v7 fork id anchors the boundary from the envelope timestamp", func(t *testing.T) {
-		// Neither the fork id nor the payload carries a usable
-		// timestamp here — the gate must fall back to the JSONL
-		// envelope timestamp and still suppress the replay.
+	t.Run("fork id shape does not affect the boundary", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
-			testjsonl.CodexForkedSessionMetaJSON("fork-plain-1", "parent-1", "/tmp", "user", tsEarly),
-			testjsonl.CodexSessionMetaJSON("parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexForkedSessionMetaJSON("fork-plain-1", parentID, "/tmp", "user", tsEarly),
+			testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
 			testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
 			testjsonl.CodexMsgJSON("user", "replayed question", tsEarly),
 			testjsonl.CodexMsgJSON("assistant", "replayed answer", tsEarly),
@@ -1590,7 +1610,7 @@ func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
 			testjsonl.CodexMsgJSON("assistant", "genuine answer", tsEarlyS5),
 			testjsonl.CodexTokenCountJSON(tsEarlyS5, 10_000, 500, 6_000),
 		)
-		sess, msgs := runCodexParserTest(t, "fork.jsonl", content, false)
+		sess, msgs := parse(t, content)
 		require.NotNil(t, sess)
 		assert.Equal(t, "codex:fork-plain-1", sess.ID)
 		require.Len(t, msgs, 2)
@@ -1598,14 +1618,14 @@ func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
 		assert.Equal(t, 500, sess.TotalOutputTokens)
 	})
 
-	t.Run("unparseable turn_id fails open instead of dropping live data", func(t *testing.T) {
+	t.Run("child turn id absent from parent opens the gate", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
-			testjsonl.CodexForkedSessionMetaJSON(forkID, "parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexForkedSessionMetaJSON(forkID, parentID, "/tmp", "user", tsEarly),
 			testjsonl.CodexTurnContextWithIDJSON("gpt-5.5", "not-a-uuid", tsEarlyS1),
 			testjsonl.CodexMsgJSON("user", "kept question", tsEarlyS1),
 			testjsonl.CodexMsgJSON("assistant", "kept answer", tsEarlyS5),
 		)
-		_, msgs := runCodexParserTest(t, "fork.jsonl", content, false)
+		_, msgs := parse(t, content)
 		require.Len(t, msgs, 2)
 		assert.Equal(t, "kept question", msgs[0].Content)
 	})
@@ -1626,12 +1646,73 @@ func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
 	})
 }
 
+func TestParseCodexSession_ForkBoundaryTreatsTurnIDsAsOpaque(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	parentID := "019fc451-42d5-7dc1-9186-e6e41a43461d"
+	childID := "019ff37b-7bda-76c0-9120-81a7ffc8cf19"
+	parentTurnID := "bba37251-227f-4546-9246-8dc55d47907e"
+	childTurnID := "child-owned-turn"
+	parent := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+		testjsonl.CodexMsgJSON("user", "parent question", tsEarly),
+		testjsonl.CodexMsgJSON("assistant", "parent answer", tsEarly),
+		testjsonl.CodexTokenCountJSON(tsEarly, 50_000, 9_000, 0),
+	)
+	parentPath := filepath.Join(
+		root,
+		"rollout-2024-01-01T09-00-00-"+parentID+".jsonl",
+	)
+	require.NoError(t, os.WriteFile(parentPath, []byte(parent), 0o600))
+
+	child := testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(
+			childID, parentID, "/tmp", "user", tsEarly,
+		),
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+		testjsonl.CodexMsgJSON("user", "replayed parent question", tsEarly),
+		testjsonl.CodexMsgJSON("assistant", "replayed parent answer", tsEarly),
+		testjsonl.CodexTokenCountJSON(tsEarly, 50_000, 9_000, 0),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.5", childTurnID, tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "genuine child task", tsEarlyS1),
+		testjsonl.CodexMsgJSON("assistant", "genuine child answer", tsEarlyS5),
+		testjsonl.CodexTokenCountJSON(tsEarlyS5, 10_000, 500, 6_000),
+	)
+	childPath := filepath.Join(
+		root,
+		"rollout-2024-01-01T10-00-00-"+childID+".jsonl",
+	)
+	require.NoError(t, os.WriteFile(childPath, []byte(child), 0o600))
+
+	sess, msgs, err := newCodexTestProvider(t, root).parseSession(
+		childPath, "local", false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "genuine child task", msgs[0].Content)
+	assert.Equal(t, "genuine child answer", msgs[1].Content)
+	assert.Equal(t, 500, sess.TotalOutputTokens)
+}
+
 func TestParseCodexSession_SubagentSessionSkipsReplayedHistory(t *testing.T) {
 	childCreatedMs := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli()
 	childID := testUUIDv7(childCreatedMs, 1)
 	parentID := testUUIDv7(childCreatedMs-3600_000, 2)
 	parentTurnID := testUUIDv7(childCreatedMs-1800_000, 3)
 	childTurnID := testUUIDv7(childCreatedMs+1000, 4)
+	root := t.TempDir()
+	parent := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp/project", "user", tsEarly),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+	)
+	parentPath := filepath.Join(
+		root, "rollout-2024-01-01T08-00-00-"+parentID+".jsonl",
+	)
+	require.NoError(t, os.WriteFile(parentPath, []byte(parent), 0o600))
 
 	tests := []struct {
 		name string
@@ -1688,9 +1769,15 @@ func TestParseCodexSession_SubagentSessionSkipsReplayedHistory(t *testing.T) {
 				),
 			)
 
-			sess, msgs := runCodexParserTest(
-				t, "subagent.jsonl", content, false,
+			path := filepath.Join(
+				root,
+				strings.ReplaceAll(t.Name(), "/", "-")+"-"+childID+".jsonl",
 			)
+			require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+			sess, msgs, err := newCodexTestProvider(t, root).parseSession(
+				path, "local", false,
+			)
+			require.NoError(t, err)
 			require.NotNil(t, sess)
 			assert.Equal(t, "codex:"+childID, sess.ID)
 			assert.Equal(t, "codex:"+parentID, sess.ParentSessionID)
@@ -1714,19 +1801,31 @@ func TestParseCodexSessionFrom_ForkReplaySpansOffset(t *testing.T) {
 
 	forkCreatedMs := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli() // == tsEarly
 	forkID := testUUIDv7(forkCreatedMs, 1)
+	parentID := testUUIDv7(forkCreatedMs-7200_000, 0)
 	parentTurnID := testUUIDv7(forkCreatedMs-3600_000, 2)
 	genuineTurnID := testUUIDv7(forkCreatedMs+1000, 3)
+	root := t.TempDir()
+	parent := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+	)
+	parentPath := filepath.Join(
+		root, "rollout-2024-01-01T08-00-00-"+parentID+".jsonl",
+	)
+	require.NoError(t, os.WriteFile(parentPath, []byte(parent), 0o600))
 
 	// The initial sync sees only part of the replayed parent history.
 	initial := testjsonl.JoinJSONL(
-		testjsonl.CodexForkedSessionMetaJSON(forkID, "parent-1", "/tmp", "user", tsEarly),
-		testjsonl.CodexSessionMetaJSON("parent-1", "/tmp", "user", tsEarly),
+		testjsonl.CodexForkedSessionMetaJSON(forkID, parentID, "/tmp", "user", tsEarly),
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
 		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
 		testjsonl.CodexMsgJSON("user", "replayed question", tsEarly),
 	)
-	path := createTestFile(t, "fork-incremental.jsonl", initial)
+	path := filepath.Join(root, "rollout-2024-01-01T10-00-00-"+forkID+".jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(initial), 0o600))
+	provider := newCodexTestProvider(t, root)
 
-	sess, msgs, err := parseCodexTestSession(t, path, "local", false)
+	sess, msgs, err := provider.parseSession(path, "local", false)
 	require.NoError(t, err)
 	require.NotNil(t, sess)
 	assert.Equal(t, "codex:"+forkID, sess.ID)
@@ -1752,7 +1851,7 @@ func TestParseCodexSessionFrom_ForkReplaySpansOffset(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, _, err := parseCodexTestSessionFrom(t, path, offset, 0, false)
+	newMsgs, _, _, err := provider.parseSessionFrom(path, offset, 0, false)
 	require.NoError(t, err)
 
 	// Only the genuine turn survives; the replayed assistant answer
@@ -1764,6 +1863,60 @@ func TestParseCodexSessionFrom_ForkReplaySpansOffset(t *testing.T) {
 	assert.Equal(t, 500, newMsgs[1].OutputTokens)
 }
 
+func TestParseCodexSessionFrom_ForkReplayOpaqueTurnSpansOffset(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	parentID := "019fc451-42d5-7dc1-9186-e6e41a43461d"
+	childID := "019ff37b-7bda-76c0-9120-81a7ffc8cf19"
+	parentTurnID := "bba37251-227f-4546-9246-8dc55d47907e"
+	childTurnID := "child-owned-turn"
+	parent := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+	)
+	parentPath := filepath.Join(
+		root, "rollout-2024-01-01T08-00-00-"+parentID+".jsonl",
+	)
+	require.NoError(t, os.WriteFile(parentPath, []byte(parent), 0o600))
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(
+			childID, parentID, "/tmp", "user", tsEarly,
+		),
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp", "user", tsEarly),
+	)
+	childPath := filepath.Join(
+		root, "rollout-2024-01-01T10-00-00-"+childID+".jsonl",
+	)
+	require.NoError(t, os.WriteFile(childPath, []byte(initial), 0o600))
+	provider := newCodexTestProvider(t, root)
+
+	sess, messages, err := provider.parseSession(childPath, "local", false)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Empty(t, messages)
+	offset := sess.File.Size
+
+	appendCodexProviderContent(t, childPath, testjsonl.JoinJSONL(
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+		testjsonl.CodexMsgJSON("assistant", "replayed parent answer", tsEarly),
+		testjsonl.CodexTokenCountJSON(tsEarly, 50_000, 9_000, 0),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.5", childTurnID, tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "genuine child task", tsEarlyS1),
+		testjsonl.CodexMsgJSON("assistant", "genuine child answer", tsEarlyS5),
+		testjsonl.CodexTokenCountJSON(tsEarlyS5, 10_000, 500, 6_000),
+	))
+
+	newMessages, _, _, err := provider.parseSessionFrom(
+		childPath, offset, 0, false,
+	)
+	require.NoError(t, err)
+	require.Len(t, newMessages, 2)
+	assert.Equal(t, "genuine child task", newMessages[0].Content)
+	assert.Equal(t, 500, newMessages[1].OutputTokens)
+}
+
 func TestParseCodexSessionFrom_SubagentReplaySpansOffset(t *testing.T) {
 	t.Parallel()
 
@@ -1772,6 +1925,15 @@ func TestParseCodexSessionFrom_SubagentReplaySpansOffset(t *testing.T) {
 	parentID := testUUIDv7(childCreatedMs-3600_000, 2)
 	parentTurnID := testUUIDv7(childCreatedMs-1800_000, 3)
 	childTurnID := testUUIDv7(childCreatedMs+1000, 4)
+	root := t.TempDir()
+	parent := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp/project", "user", tsEarly),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+	)
+	parentPath := filepath.Join(
+		root, "rollout-2024-01-01T08-00-00-"+parentID+".jsonl",
+	)
+	require.NoError(t, os.WriteFile(parentPath, []byte(parent), 0o600))
 
 	initial := testjsonl.JoinJSONL(
 		testjsonl.CodexSubagentSessionMetaJSON(
@@ -1787,9 +1949,11 @@ func TestParseCodexSessionFrom_SubagentReplaySpansOffset(t *testing.T) {
 			"user", "replayed parent question", tsEarly,
 		),
 	)
-	path := createTestFile(t, "subagent-incremental.jsonl", initial)
+	path := filepath.Join(root, "rollout-2024-01-01T10-00-00-"+childID+".jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(initial), 0o600))
+	provider := newCodexTestProvider(t, root)
 
-	sess, msgs, err := parseCodexTestSession(t, path, "local", false)
+	sess, msgs, err := provider.parseSession(path, "local", false)
 	require.NoError(t, err)
 	require.NotNil(t, sess)
 	assert.Equal(t, "codex:"+childID, sess.ID)
@@ -1825,9 +1989,7 @@ func TestParseCodexSessionFrom_SubagentReplaySpansOffset(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, _, err := parseCodexTestSessionFrom(
-		t, path, offset, 0, false,
-	)
+	newMsgs, _, _, err := provider.parseSessionFrom(path, offset, 0, false)
 	require.NoError(t, err)
 	require.Len(t, newMsgs, 2)
 	assert.Equal(t, "genuine child task", newMsgs[0].Content)
@@ -3136,7 +3298,7 @@ func TestSeedCodexIncrementalState_SkipsInvalidJSON(
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	seed, err := seedCodexIncrementalState(path, info.Size())
+	seed, err := newCodexTestProvider(t).seedCodexIncrementalState(path, info.Size())
 	require.NoError(t, err)
 	got := seed.model
 	assert.Equal(t, "gpt-5.4", got,
@@ -3167,21 +3329,21 @@ func TestSeedCodexIncrementalState_Model(t *testing.T) {
 	t.Run("full file returns last model", func(t *testing.T) {
 		info, err := os.Stat(path)
 		require.NoError(t, err)
-		seed, err := seedCodexIncrementalState(path, info.Size())
+		seed, err := newCodexTestProvider(t).seedCodexIncrementalState(path, info.Size())
 		require.NoError(t, err)
 		got := seed.model
 		assert.Equal(t, "gpt-5.4", got)
 	})
 
 	t.Run("zero offset returns empty", func(t *testing.T) {
-		seed, err := seedCodexIncrementalState(path, 0)
+		seed, err := newCodexTestProvider(t).seedCodexIncrementalState(path, 0)
 		require.NoError(t, err)
 		got := seed.model
 		assert.Equal(t, "", got)
 	})
 
 	t.Run("nonexistent file returns error", func(t *testing.T) {
-		_, err := seedCodexIncrementalState("/no/such/file", 100)
+		_, err := newCodexTestProvider(t).seedCodexIncrementalState("/no/such/file", 100)
 		require.Error(t, err)
 	})
 }
@@ -3191,6 +3353,7 @@ func TestSeedCodexIncrementalStatePropagatesReaderError(t *testing.T) {
 
 	_, err := seedCodexIncrementalStateFromReader(
 		iotest.ErrReader(wantErr),
+		nil,
 	)
 
 	require.ErrorIs(t, err, wantErr)

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -255,6 +255,7 @@ func (p *codexProvider) Parse(
 		EvictCodexSessionIndexForSession(path)
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
+	parentID, parentResolved := p.codexParentResolution(path)
 	sess, msgs, err := p.parseSession(path, machine, false)
 	if err != nil {
 		return ParseOutcome{}, err
@@ -271,14 +272,19 @@ func (p *codexProvider) Parse(
 	if req.Fingerprint.Hash != "" {
 		sess.File.Hash = req.Fingerprint.Hash
 	}
+	result := ParseResultOutcome{
+		Result: ParseResult{
+			Session:  *sess,
+			Messages: msgs,
+		},
+		DataVersion: DataVersionCurrent,
+	}
+	if parentID != "" && !parentResolved {
+		result.DataVersion = DataVersionNeedsRetry
+		result.RetryReason = "codex parent turns unresolved for " + parentID
+	}
 	return ParseOutcome{
-		Results: []ParseResultOutcome{{
-			Result: ParseResult{
-				Session:  *sess,
-				Messages: msgs,
-			},
-			DataVersion: DataVersionCurrent,
-		}},
+		Results:           []ParseResultOutcome{result},
 		ResultSetComplete: true,
 		// A requested full parse is the authoritative message set, so
 		// force-replace the stored rows; this remains distinct from the provider's
@@ -445,7 +451,7 @@ func (s codexSourceSet) DiscoverEach(
 				continue
 			}
 			for _, file := range discoverCodexS3(root) {
-				if err := yield(s3SourceRefFromDiscoveredFile(file)); err != nil {
+				if err := yield(s3SourceRefFromDiscoveredFile(root, file)); err != nil {
 					return err
 				}
 			}
@@ -499,7 +505,7 @@ func (s codexSourceSet) discover(
 				continue
 			}
 			for _, file := range discoverCodexS3(root) {
-				source := s3SourceRefFromDiscoveredFile(file)
+				source := s3SourceRefFromDiscoveredFile(root, file)
 				if _, ok := byKey[source.Key]; ok {
 					continue
 				}

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -42,16 +42,18 @@ func codexProviderSpecForAgent(agent AgentType) codexProviderSpec {
 }
 
 type codexProviderFactory struct {
-	def         AgentDef
-	spec        codexProviderSpec
-	cursorCache *codexCursorCache
+	def             AgentDef
+	spec            codexProviderSpec
+	cursorCache     *codexCursorCache
+	parentTurnCache *codexParentTurnCache
 }
 
 func newCodexProviderFactory(def AgentDef) ProviderFactory {
 	return &codexProviderFactory{
-		def:         cloneAgentDef(def),
-		spec:        codexProviderSpecForAgent(AgentCodex),
-		cursorCache: newProductionCodexCursorCache(),
+		def:             cloneAgentDef(def),
+		spec:            codexProviderSpecForAgent(AgentCodex),
+		cursorCache:     newProductionCodexCursorCache(),
+		parentTurnCache: newCodexProductionParentTurnCache(),
 	}
 }
 
@@ -59,9 +61,10 @@ func newCodexProviderFactory(def AgentDef) ProviderFactory {
 // provider, relabeling every parsed session onto the traex: ID prefix.
 func newTraeXProviderFactory(def AgentDef) ProviderFactory {
 	return &codexProviderFactory{
-		def:         cloneAgentDef(def),
-		spec:        codexProviderSpecForAgent(AgentTraeX),
-		cursorCache: newProductionCodexCursorCache(),
+		def:             cloneAgentDef(def),
+		spec:            codexProviderSpecForAgent(AgentTraeX),
+		cursorCache:     newProductionCodexCursorCache(),
+		parentTurnCache: newCodexProductionParentTurnCache(),
 	}
 }
 
@@ -81,17 +84,19 @@ func (f *codexProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 			Caps:   codexProviderCapabilities(),
 			Config: cfg,
 		},
-		spec:        f.spec,
-		sources:     newCodexSourceSet(f.spec.agent, cfg.Roots),
-		cursorCache: f.cursorCache,
+		spec:            f.spec,
+		sources:         newCodexSourceSet(f.spec.agent, cfg.Roots),
+		cursorCache:     f.cursorCache,
+		parentTurnCache: f.parentTurnCache,
 	}
 }
 
 type codexProvider struct {
 	ProviderBase
-	spec        codexProviderSpec
-	sources     codexSourceSet
-	cursorCache *codexCursorCache
+	spec            codexProviderSpec
+	sources         codexSourceSet
+	cursorCache     *codexCursorCache
+	parentTurnCache *codexParentTurnCache
 }
 
 func (p *codexProvider) Discover(ctx context.Context) ([]SourceRef, error) {

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,6 +96,79 @@ func TestCodexProviderSourceMethods(t *testing.T) {
 	assert.Equal(t, "Renamed title", result.Result.Session.SessionName)
 	assert.Equal(t, fingerprint.Hash, result.Result.Session.File.Hash)
 	assert.Len(t, result.Result.Messages, 1)
+}
+
+func TestCodexProviderUnresolvedParentNeedsRetry(t *testing.T) {
+	root := t.TempDir()
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(
+			childID, parentID, "/workspace/project", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", "child-turn", tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "child task", tsEarlyS1),
+		testjsonl.CodexMsgJSON("assistant", "child answer", tsEarlyS5),
+	)
+	writeCodexProviderSessionContent(t, root, childID, content)
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source := requireCodexProviderSource(t, provider, childID)
+
+	outcome, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0]
+	assert.Equal(t, DataVersionNeedsRetry, result.DataVersion)
+	assert.Contains(t, result.RetryReason, "parent turns")
+	require.Len(t, result.Result.Messages, 2)
+	assert.Equal(t, "child task", result.Result.Messages[0].Content)
+	assert.Equal(t, "child answer", result.Result.Messages[1].Content)
+}
+
+func TestCodexProviderUnresolvedParentWithoutFinalNewlineNeedsRetry(t *testing.T) {
+	root := t.TempDir()
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	content := strings.TrimSuffix(testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(
+			childID, parentID, "/workspace/project", "codex_cli_rs", tsEarly,
+		),
+	), "\n")
+	writeCodexProviderSessionContent(t, root, childID, content)
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source := requireCodexProviderSource(t, provider, childID)
+
+	outcome, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, DataVersionNeedsRetry, outcome.Results[0].DataVersion)
+}
+
+func TestCodexProviderChildOnlySubagentWithoutParentStaysCurrent(t *testing.T) {
+	root := t.TempDir()
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			childID, parentID, "/workspace/project", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", "child-turn", tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "child task", tsEarlyS1),
+	)
+	writeCodexProviderSessionContent(t, root, childID, content)
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source := requireCodexProviderSource(t, provider, childID)
+
+	outcome, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, DataVersionCurrent, outcome.Results[0].DataVersion)
 }
 
 func TestCodexActivityHintsUseConfiguredRootParent(t *testing.T) {

--- a/internal/parser/codex_replay_simulator_test.go
+++ b/internal/parser/codex_replay_simulator_test.go
@@ -25,6 +25,8 @@ func TestCodexCapturedForkReplayTotals(t *testing.T) {
 	files, err := filepath.Glob(filepath.Join(root, "*.jsonl"))
 	require.NoError(t, err)
 	require.Len(t, files, 6)
+	children := capturedCodexForkChildren(t, files)
+	require.Len(t, children, 5)
 
 	provider := newCodexTestProvider(t, root)
 	var totalOutput int
@@ -56,12 +58,9 @@ func TestCodexCapturedForkReplayTotals(t *testing.T) {
 		})
 	}
 	resolver := export.NewPricingResolver(rows)
-	for _, path := range files {
+	for _, path := range children {
 		sess, messages, parseErr := provider.parseSession(path, "local", false)
 		require.NoError(t, parseErr)
-		if sess.RelationshipType != RelFork && sess.RelationshipType != RelSubagent {
-			continue
-		}
 		for _, message := range messages {
 			totalOutput += message.OutputTokens
 			if len(message.TokenUsage) != 0 {
@@ -96,6 +95,20 @@ func TestCodexCapturedForkReplayTotals(t *testing.T) {
 	assert.Equal(t, money.Money{Microdollars: 15_403_799}, totalCost)
 }
 
+func capturedCodexForkChildren(t *testing.T, files []string) []string {
+	t.Helper()
+	var children []string
+	for _, sourcePath := range files {
+		data, err := os.ReadFile(sourcePath)
+		require.NoError(t, err)
+		firstLine, _, _ := strings.Cut(string(data), "\n")
+		if gjson.Get(firstLine, "payload.forked_from_id").Str != "" {
+			children = append(children, sourcePath)
+		}
+	}
+	return children
+}
+
 func TestCodexCapturedForkLineReplayTotals(t *testing.T) {
 	sourceRoot := os.Getenv("AGENTSVIEW_CODEX_REPLAY_ROOT")
 	if sourceRoot == "" {
@@ -106,7 +119,8 @@ func TestCodexCapturedForkLineReplayTotals(t *testing.T) {
 	require.Len(t, files, 6)
 
 	replayRoot := t.TempDir()
-	var children []string
+	children := capturedCodexForkChildren(t, files)
+	require.Len(t, children, 5)
 	for _, sourcePath := range files {
 		data, readErr := os.ReadFile(sourcePath)
 		require.NoError(t, readErr)
@@ -114,11 +128,8 @@ func TestCodexCapturedForkLineReplayTotals(t *testing.T) {
 		firstLine, _, _ := strings.Cut(string(data), "\n")
 		if gjson.Get(firstLine, "payload.forked_from_id").Str == "" {
 			require.NoError(t, os.WriteFile(targetPath, data, 0o600))
-			continue
 		}
-		children = append(children, sourcePath)
 	}
-	require.Len(t, children, 5)
 
 	provider := newCodexTestProvider(t, replayRoot)
 	var totalOutput int

--- a/internal/parser/codex_replay_simulator_test.go
+++ b/internal/parser/codex_replay_simulator_test.go
@@ -1,0 +1,182 @@
+package parser
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/money"
+	"go.kenn.io/agentsview/internal/pricing"
+)
+
+func TestCodexCapturedForkReplayTotals(t *testing.T) {
+	root := os.Getenv("AGENTSVIEW_CODEX_REPLAY_ROOT")
+	if root == "" {
+		t.Skip("set AGENTSVIEW_CODEX_REPLAY_ROOT to run captured fork replay")
+	}
+
+	files, err := filepath.Glob(filepath.Join(root, "*.jsonl"))
+	require.NoError(t, err)
+	require.Len(t, files, 6)
+
+	provider := newCodexTestProvider(t, root)
+	var totalOutput int
+	var totalMessages int
+	var totalInput int
+	var totalCacheRead int
+	var totalCost money.Money
+	rows := make([]export.EffectivePricingRow, 0, len(pricing.FallbackPricing()))
+	for _, row := range pricing.FallbackPricing() {
+		bands := make([]export.PricingBand, len(row.Bands))
+		for i, band := range row.Bands {
+			bands[i] = export.PricingBand{
+				AboveInputTokens:  band.AboveInputTokens,
+				InputPerMTok:      band.InputPerMTok,
+				OutputPerMTok:     band.OutputPerMTok,
+				CacheWritePerMTok: band.CacheCreationPerMTok,
+				CacheReadPerMTok:  band.CacheReadPerMTok,
+			}
+		}
+		rows = append(rows, export.EffectivePricingRow{
+			ModelPattern: row.ModelPattern,
+			Rates: export.ModelRates{
+				InputPerMTok:      row.InputPerMTok,
+				OutputPerMTok:     row.OutputPerMTok,
+				CacheWritePerMTok: row.CacheCreationPerMTok,
+				CacheReadPerMTok:  row.CacheReadPerMTok,
+				Bands:             bands,
+			},
+		})
+	}
+	resolver := export.NewPricingResolver(rows)
+	for _, path := range files {
+		sess, messages, parseErr := provider.parseSession(path, "local", false)
+		require.NoError(t, parseErr)
+		if sess.RelationshipType != RelFork && sess.RelationshipType != RelSubagent {
+			continue
+		}
+		for _, message := range messages {
+			totalOutput += message.OutputTokens
+			if len(message.TokenUsage) != 0 {
+				var usage struct {
+					Input      int `json:"input_tokens"`
+					Output     int `json:"output_tokens"`
+					CacheRead  int `json:"cache_read_input_tokens"`
+					CacheWrite int `json:"cache_creation_input_tokens"`
+				}
+				require.NoError(t, json.Unmarshal(message.TokenUsage, &usage))
+				totalInput += usage.Input
+				totalCacheRead += usage.CacheRead
+				lookup := resolver.Lookup(message.Model)
+				require.True(t, lookup.OK, "pricing %s", message.Model)
+				cost, costErr := lookup.Rates.CostForTokens(
+					usage.Input, usage.Output, 0, usage.CacheWrite, usage.CacheRead,
+				)
+				require.NoError(t, costErr)
+				totalCost, costErr = money.Add(totalCost, cost)
+				require.NoError(t, costErr)
+			}
+		}
+		totalMessages += len(messages)
+		t.Logf("%s: messages=%d output=%d first=%q", filepath.Base(path),
+			len(messages), sess.TotalOutputTokens, sess.FirstMessage)
+	}
+
+	assert.Equal(t, 96_476, totalOutput)
+	assert.Equal(t, 907_715, totalInput)
+	assert.Equal(t, 15_941_888, totalCacheRead)
+	assert.Equal(t, 171, totalMessages)
+	assert.Equal(t, money.Money{Microdollars: 15_403_799}, totalCost)
+}
+
+func TestCodexCapturedForkLineReplayTotals(t *testing.T) {
+	sourceRoot := os.Getenv("AGENTSVIEW_CODEX_REPLAY_ROOT")
+	if sourceRoot == "" {
+		t.Skip("set AGENTSVIEW_CODEX_REPLAY_ROOT to run captured fork replay")
+	}
+	files, err := filepath.Glob(filepath.Join(sourceRoot, "*.jsonl"))
+	require.NoError(t, err)
+	require.Len(t, files, 6)
+
+	replayRoot := t.TempDir()
+	var children []string
+	for _, sourcePath := range files {
+		data, readErr := os.ReadFile(sourcePath)
+		require.NoError(t, readErr)
+		targetPath := filepath.Join(replayRoot, filepath.Base(sourcePath))
+		firstLine, _, _ := strings.Cut(string(data), "\n")
+		if gjson.Get(firstLine, "payload.forked_from_id").Str == "" {
+			require.NoError(t, os.WriteFile(targetPath, data, 0o600))
+			continue
+		}
+		children = append(children, sourcePath)
+	}
+	require.Len(t, children, 5)
+
+	provider := newCodexTestProvider(t, replayRoot)
+	var totalOutput int
+	var totalMessages int
+	for _, sourcePath := range children {
+		targetPath := filepath.Join(replayRoot, filepath.Base(sourcePath))
+		source, openErr := os.Open(sourcePath)
+		require.NoError(t, openErr)
+		scanner := bufio.NewScanner(source)
+		scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
+
+		var messages []ParsedMessage
+		var offset int64
+		for scanner.Scan() {
+			line := append(append([]byte(nil), scanner.Bytes()...), '\n')
+			file, fileErr := os.OpenFile(
+				targetPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600,
+			)
+			require.NoError(t, fileErr)
+			_, fileErr = file.Write(line)
+			require.NoError(t, fileErr)
+			require.NoError(t, file.Close())
+
+			if offset == 0 {
+				_, messages, fileErr = provider.parseSession(
+					targetPath, "local", false,
+				)
+				require.NoError(t, fileErr)
+				offset = int64(len(line))
+				continue
+			}
+
+			result, parseErr := provider.parseSessionFromDetailed(
+				targetPath, offset, len(messages), false,
+			)
+			if IsIncrementalFullParseFallback(parseErr) {
+				_, messages, parseErr = provider.parseSession(
+					targetPath, "local", false,
+				)
+				require.NoError(t, parseErr)
+				offset += int64(len(line))
+				continue
+			}
+			require.NoError(t, parseErr)
+			messages = append(messages, result.messages...)
+			offset += result.consumedBytes
+			provider.cursorCache.Put(
+				targetPath, offset, result.inode, result.device, result.cursor,
+			)
+		}
+		require.NoError(t, scanner.Err())
+		require.NoError(t, source.Close())
+		for _, message := range messages {
+			totalOutput += message.OutputTokens
+		}
+		totalMessages += len(messages)
+	}
+
+	assert.Equal(t, 96_476, totalOutput)
+	assert.Equal(t, 171, totalMessages)
+}

--- a/internal/parser/s3source.go
+++ b/internal/parser/s3source.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path"
 	"slices"
 	"sort"
 	"strings"
@@ -356,9 +357,10 @@ type S3DiscoveredSource struct {
 // enumerated by a source set's discovery. The s3 URI is the stable identity
 // across Key, DisplayPath, and FingerprintKey, and the durable object metadata
 // rides in the Opaque payload for the engine to thread into the DiscoveredFile.
-func s3SourceRefFromDiscoveredFile(file DiscoveredFile) SourceRef {
+func s3SourceRefFromDiscoveredFile(root string, file DiscoveredFile) SourceRef {
 	return SourceRef{
 		Provider:       file.Agent,
+		ConfiguredRoot: root,
 		Key:            file.Path,
 		DisplayPath:    file.Path,
 		FingerprintKey: file.Path,
@@ -533,6 +535,84 @@ func discoverCodexS3(root string) []DiscoveredFile {
 			return isCodexSessionFilename(segs[len(segs)-1])
 		},
 	})
+}
+
+// FindCodexS3ParentSessionURI locates one explicitly named parent rollout
+// under the same configured Codex S3 root as childURI. It lists metadata only;
+// callers decide whether and where to materialize the matching object.
+func FindCodexS3ParentSessionURI(
+	configuredRoot, childURI, parentID string,
+) (string, bool) {
+	if parentID == "" || strings.TrimSpace(parentID) != parentID ||
+		strings.ContainsAny(parentID, `/\\`) ||
+		CodexSessionUUIDFromFilename("rollout-x-"+parentID+".jsonl") != parentID {
+		return "", false
+	}
+	root, ok := codexS3RootURI(configuredRoot, childURI)
+	if !ok {
+		return "", false
+	}
+	objects, err := listS3Objects(root)
+	if err != nil {
+		return "", false
+	}
+	var matches []string
+	for _, obj := range objects {
+		if _, withinRoot := s3RelativePath(root, obj.URI); !withinRoot {
+			continue
+		}
+		name := path.Base(obj.URI)
+		if CodexSessionUUIDFromFilename(name) == parentID {
+			matches = append(matches, obj.URI)
+		}
+	}
+	if len(matches) == 0 {
+		return "", false
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		iArchived := strings.Contains(matches[i], "/archived_sessions/")
+		jArchived := strings.Contains(matches[j], "/archived_sessions/")
+		if iArchived != jArchived {
+			return !iArchived
+		}
+		return matches[i] < matches[j]
+	})
+	return matches[0], true
+}
+
+func codexS3RootURI(configuredRoot, sessionURI string) (string, bool) {
+	if !strings.HasPrefix(sessionURI, "s3://") {
+		return "", false
+	}
+	if configuredRoot != "" {
+		configuredRoot = strings.TrimSuffix(configuredRoot, "/")
+		if !strings.HasPrefix(configuredRoot, "s3://") {
+			return "", false
+		}
+		if _, ok := s3RelativePath(configuredRoot, sessionURI); !ok {
+			return "", false
+		}
+		return configuredRoot, true
+	}
+	parts := strings.Split(strings.TrimPrefix(sessionURI, "s3://"), "/")
+	if len(parts) < 2 || !isCodexSessionFilename(parts[len(parts)-1]) {
+		return "", false
+	}
+	for i := len(parts) - 3; i >= 1; i-- {
+		if parts[i] == "raw" && parts[i+1] == "codex" {
+			return "s3://" + strings.Join(parts[:i+2], "/"), true
+		}
+	}
+	for i := len(parts) - 2; i >= 1; i-- {
+		if parts[i] == "sessions" || parts[i] == "archived_sessions" {
+			return "s3://" + strings.Join(parts[:i], "/"), true
+		}
+	}
+	if len(parts) >= 5 && IsDigits(parts[len(parts)-4]) &&
+		IsDigits(parts[len(parts)-3]) && IsDigits(parts[len(parts)-2]) {
+		return "s3://" + strings.Join(parts[:len(parts)-4], "/"), true
+	}
+	return "s3://" + strings.Join(parts[:len(parts)-1], "/"), true
 }
 
 // CodexS3SessionIndexURI returns the session_index.jsonl URI adjacent to the

--- a/internal/parser/s3source_test.go
+++ b/internal/parser/s3source_test.go
@@ -212,6 +212,142 @@ func TestCodexS3SessionIndexURIPrefersRawCodexLayout(t *testing.T) {
 	)
 }
 
+func TestFindCodexS3ParentSessionURI(t *testing.T) {
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	const root = "s3://bucket/laptop/raw/codex"
+	parentDated := root + "/2026/08/12/rollout-2026-08-12T00-00-00-" +
+		parentID + ".jsonl"
+	parentSessions := root + "/sessions/2026/08/12/" +
+		"rollout-2026-08-12T00-00-00-" + parentID + ".jsonl"
+	parentArchived := root + "/archived_sessions/" +
+		"rollout-2026-08-12T00-00-00-" + parentID + ".jsonl"
+	customRoot := "s3://bucket/root/codex"
+	customParent := customRoot + "/team/b/" +
+		"rollout-2026-08-12T00-00-00-" + parentID + ".jsonl"
+
+	tests := []struct {
+		name     string
+		childURI string
+		parentID string
+		objects  []S3Object
+		want     string
+		wantRoot string
+		wantList bool
+	}{
+		{
+			name: "dated parent",
+			childURI: root + "/2026/08/13/rollout-2026-08-13T00-00-00-" +
+				"22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: parentID,
+			objects:  []S3Object{{URI: parentDated}},
+			want:     parentDated,
+			wantList: true,
+		},
+		{
+			name: "sessions parent",
+			childURI: root + "/sessions/2026/08/13/" +
+				"rollout-2026-08-13T00-00-00-22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: parentID,
+			objects:  []S3Object{{URI: parentSessions}},
+			want:     parentSessions,
+			wantList: true,
+		},
+		{
+			name: "archived parent",
+			childURI: root + "/archived_sessions/" +
+				"rollout-2026-08-13T00-00-00-22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: parentID,
+			objects:  []S3Object{{URI: parentArchived}},
+			want:     parentArchived,
+			wantList: true,
+		},
+		{
+			name: "live layout wins over archived duplicate",
+			childURI: root + "/sessions/2026/08/13/" +
+				"rollout-2026-08-13T00-00-00-22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: parentID,
+			objects: []S3Object{
+				{URI: parentArchived},
+				{URI: parentSessions},
+			},
+			want:     parentSessions,
+			wantList: true,
+		},
+		{
+			name: "custom configured root at arbitrary depth",
+			childURI: customRoot + "/team/a/" +
+				"rollout-2026-08-13T00-00-00-22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: parentID,
+			objects:  []S3Object{{URI: customParent}},
+			want:     customParent,
+			wantRoot: customRoot,
+			wantList: true,
+		},
+		{
+			name:     "child outside configured root",
+			childURI: "s3://bucket/other/rollout-2026-08-13T00-00-00-22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: parentID,
+			wantRoot: customRoot,
+		},
+		{
+			name: "exact id only",
+			childURI: root + "/2026/08/13/rollout-2026-08-13T00-00-00-" +
+				"22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: parentID,
+			objects: []S3Object{{URI: root + "/2026/08/12/" +
+				"rollout-2026-08-12T00-00-00-11111111-1111-4111-8111-111111111110.jsonl"}},
+			wantList: true,
+		},
+		{
+			name: "empty parent id",
+			childURI: root + "/2026/08/13/rollout-2026-08-13T00-00-00-" +
+				"22222222-2222-4222-8222-222222222222.jsonl",
+		},
+		{
+			name: "path-like parent id",
+			childURI: root + "/2026/08/13/rollout-2026-08-13T00-00-00-" +
+				"22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: "../" + parentID,
+		},
+		{
+			name: "short parent id suffix",
+			childURI: root + "/2026/08/13/rollout-2026-08-13T00-00-00-" +
+				"22222222-2222-4222-8222-222222222222.jsonl",
+			parentID: "111111111111",
+			objects:  []S3Object{{URI: parentDated}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldList := listS3Objects
+			t.Cleanup(func() { listS3Objects = oldList })
+			listed := false
+			listS3Objects = func(got string) ([]S3Object, error) {
+				listed = true
+				wantRoot := tt.wantRoot
+				if wantRoot == "" {
+					wantRoot = root
+				}
+				require.Equal(t, wantRoot, got)
+				return tt.objects, nil
+			}
+
+			configuredRoot := tt.wantRoot
+			if configuredRoot == "" {
+				configuredRoot = root
+			}
+			got, ok := FindCodexS3ParentSessionURI(
+				configuredRoot, tt.childURI, tt.parentID,
+			)
+
+			assert.Equal(t, tt.want != "", ok)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantList, listed)
+		})
+	}
+}
+
 func TestDiscoverClaudeS3FoldsToolResultMetadata(t *testing.T) {
 	oldList := listS3Objects
 	t.Cleanup(func() { listS3Objects = oldList })
@@ -297,11 +433,14 @@ func TestS3SourceRefFromDiscoveredFile(t *testing.T) {
 		SourceFingerprint: "fp-1",
 	}
 
-	ref := s3SourceRefFromDiscoveredFile(file)
+	ref := s3SourceRefFromDiscoveredFile(
+		"s3://bucket/laptop/raw/codex", file,
+	)
 
 	// The s3 URI is the stable identity across every key field so dedup and
 	// fingerprinting agree on one source.
 	assert.Equal(t, AgentCodex, ref.Provider)
+	assert.Equal(t, "s3://bucket/laptop/raw/codex", ref.ConfiguredRoot)
 	assert.Equal(t, uri, ref.Key)
 	assert.Equal(t, uri, ref.DisplayPath)
 	assert.Equal(t, uri, ref.FingerprintKey)

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -12,6 +12,8 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 )
 
+var findCodexS3ParentSessionURI = parser.FindCodexS3ParentSessionURI
+
 func s3SessionIDPrefix(machine string) string {
 	if machine == "" {
 		return ""
@@ -170,6 +172,48 @@ func localCodexSessionIndexPath(sessionPath string) string {
 	return ""
 }
 
+func hydrateS3CodexParent(
+	tempDir, childPath, configuredRoot, childURI string,
+) bool {
+	parentID, resolutionNeeded := parser.CodexReplayParentID(childPath)
+	if !resolutionNeeded {
+		return false
+	}
+	parentURI, ok := findCodexS3ParentSessionURI(
+		configuredRoot, childURI, parentID,
+	)
+	if !ok || parentURI == childURI {
+		return false
+	}
+	relPath, err := safeS3TempRelPath(parser.DiscoveredFile{
+		Agent: parser.AgentCodex,
+		Path:  parentURI,
+	})
+	if err != nil {
+		return false
+	}
+	rc, err := fetchS3Object(parentURI)
+	if err != nil {
+		return false
+	}
+	defer rc.Close()
+	parentPath := filepath.Join(tempDir, filepath.Base(relPath))
+	if err := os.MkdirAll(filepath.Dir(parentPath), 0o755); err != nil {
+		return false
+	}
+	out, err := os.Create(parentPath)
+	if err != nil {
+		return false
+	}
+	_, copyErr := io.Copy(out, rc)
+	closeErr := out.Close()
+	if copyErr != nil || closeErr != nil {
+		_ = os.Remove(parentPath)
+		return false
+	}
+	return true
+}
+
 // processS3Session reads a Claude/Codex session JSONL directly from object
 // storage (in-process, no persistent local mirror): download the object's
 // bytes, buffer them to a transient temp file so the existing path-based
@@ -286,6 +330,11 @@ func (e *Engine) processS3Session(
 		hydratedToolResults = rewrote
 		sawPersistedToolResults = sawPersisted
 	case parser.AgentCodex:
+		configuredRoot := ""
+		if file.ProviderSource != nil {
+			configuredRoot = file.ProviderSource.ConfiguredRoot
+		}
+		hydrateS3CodexParent(dir, tmp, configuredRoot, file.Path)
 		indexPath, err := hydrateS3CodexSessionIndex(tmp, file.Path)
 		if err != nil {
 			return processResult{err: err, noCacheSkip: true, retentionLease: lease}
@@ -309,6 +358,13 @@ func (e *Engine) processS3Session(
 		if sourceFingerprint != "" {
 			res.results[i].Session.File.Hash = sourceFingerprint
 		}
+	}
+	if len(res.retrySessionIDs) > 0 && idPrefix != "" {
+		prefixed := make(map[string]bool, len(res.retrySessionIDs))
+		for id := range res.retrySessionIDs {
+			prefixed[applyIDPrefixToID(idPrefix, id)] = true
+		}
+		res.retrySessionIDs = prefixed
 	}
 	if sourceChanged || hydratedToolResults || sawPersistedToolResults {
 		res.forceReplace = true
@@ -363,6 +419,15 @@ func (e *Engine) parseMaterializedS3Source(
 	if err != nil {
 		return processResult{}, err
 	}
+	retrySessionIDs := make(map[string]bool)
+	for _, result := range outcome.Results {
+		if result.DataVersion == parser.DataVersionNeedsRetry {
+			retrySessionIDs[result.Result.Session.ID] = true
+		}
+	}
+	if len(retrySessionIDs) == 0 {
+		retrySessionIDs = nil
+	}
 	// Do not short-circuit on an empty Results slice: a content-free source can
 	// still carry ExcludedSessionIDs (a Claude /usage probe parses to no live
 	// session but excludes its ID), and the caller needs those IDs to drop the
@@ -371,5 +436,6 @@ func (e *Engine) parseMaterializedS3Source(
 		results:            parseOutcomeResults(outcome.Results),
 		excludedSessionIDs: append([]string(nil), outcome.ExcludedSessionIDs...),
 		forceReplace:       outcome.ForceReplace,
+		retrySessionIDs:    retrySessionIDs,
 	}, nil
 }

--- a/internal/sync/s3_test.go
+++ b/internal/sync/s3_test.go
@@ -106,6 +106,124 @@ func TestProcessS3CodexNamespacesIDsBySourceMachine(t *testing.T) {
 	assert.Nil(t, raw)
 }
 
+func TestProcessS3CodexForkRetriesUntilParentAvailable(t *testing.T) {
+	database := openTestDB(t)
+	const root = "s3://bucket/laptop/raw/codex"
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentTurnID = "parent-turn"
+	const childTurnID = "child-turn"
+	parentPath := root + "/2026/08/12/rollout-2026-08-12T00-00-00-" +
+		parentID + ".jsonl"
+	childPath := root + "/2026/08/13/rollout-2026-08-13T00-00-00-" +
+		childID + ".jsonl"
+	indexPath := "s3://bucket/laptop/raw/session_index.jsonl"
+	parent := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			parentID, "/workspace/project", "codex_cli_rs", "2024-01-01T10:00:00Z",
+		),
+		testjsonl.CodexTurnContextWithIDJSON(
+			"gpt-5.4", parentTurnID, "2024-01-01T10:00:00Z",
+		),
+	)
+	child := testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(
+			childID, parentID, "/workspace/project", "codex_cli_rs", "2024-01-01T10:00:00Z",
+		),
+		testjsonl.CodexSessionMetaJSON(
+			parentID, "/workspace/project", "codex_cli_rs", "2024-01-01T10:00:00Z",
+		),
+		testjsonl.CodexTurnContextWithIDJSON(
+			"gpt-5.4", parentTurnID, "2024-01-01T10:00:00Z",
+		),
+		testjsonl.CodexMsgJSON("user", "replayed parent task", "2024-01-01T10:00:00Z"),
+		testjsonl.CodexMsgJSON("assistant", "replayed parent answer", "2024-01-01T10:00:00Z"),
+		testjsonl.CodexTokenCountJSON("2024-01-01T10:00:00Z", 50_000, 9_000, 0),
+		testjsonl.CodexTurnContextWithIDJSON(
+			"gpt-5.5", childTurnID, "2024-01-01T10:00:01Z",
+		),
+		testjsonl.CodexMsgJSON("user", "child task", "2024-01-01T10:00:01Z"),
+		testjsonl.CodexMsgJSON("assistant", "child answer", "2024-01-01T10:00:05Z"),
+		testjsonl.CodexTokenCountJSON("2024-01-01T10:00:05Z", 10_000, 500, 6_000),
+	)
+	mtime := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC).UnixNano()
+
+	oldFetch := fetchS3Object
+	oldFindParent := findCodexS3ParentSessionURI
+	t.Cleanup(func() {
+		fetchS3Object = oldFetch
+		findCodexS3ParentSessionURI = oldFindParent
+	})
+	parentAvailable := false
+	var fetched []string
+	findCodexS3ParentSessionURI = func(
+		gotRoot, gotChild, gotParent string,
+	) (string, bool) {
+		require.Empty(t, gotRoot)
+		require.Equal(t, childPath, gotChild)
+		require.Equal(t, parentID, gotParent)
+		if !parentAvailable {
+			return "", false
+		}
+		return parentPath, true
+	}
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		fetched = append(fetched, got)
+		switch got {
+		case childPath:
+			return io.NopCloser(strings.NewReader(child)), nil
+		case parentPath:
+			return io.NopCloser(strings.NewReader(parent)), nil
+		case indexPath:
+			return nil, missingS3ObjectError()
+		default:
+			return nil, missingS3ObjectError()
+		}
+	}
+
+	e := &Engine{db: database, machine: "central"}
+	file := parser.DiscoveredFile{
+		Agent: parser.AgentCodex, Path: childPath, Machine: "laptop",
+		SourceSize: int64(len(child)), SourceMtime: mtime,
+	}
+	first := e.processFile(t.Context(), file)
+	require.NoError(t, first.err)
+	require.Len(t, first.results, 1)
+	require.Len(t, first.results[0].Messages, 4)
+	fullChildID := "laptop~codex:" + childID
+	written, _, failed, _ := e.writeBatch([]pendingWrite{{
+		sess:         first.results[0].Session,
+		msgs:         first.results[0].Messages,
+		needsRetry:   first.needsRetryForSession(fullChildID),
+		forceReplace: first.forceReplace,
+	}}, syncWriteDefault, first.forceReplace)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	assert.Less(t, database.GetSessionDataVersion(fullChildID), db.CurrentDataVersion())
+
+	parentAvailable = true
+	fetched = nil
+	second := e.processFile(t.Context(), file)
+	require.NoError(t, second.err)
+	require.Len(t, second.results, 1)
+	require.Len(t, second.results[0].Messages, 2)
+	assert.Equal(t, "child task", second.results[0].Messages[0].Content)
+	assert.Equal(t, 500, second.results[0].Messages[1].OutputTokens)
+	written, _, failed, _ = e.writeBatch([]pendingWrite{{
+		sess:         second.results[0].Session,
+		msgs:         second.results[0].Messages,
+		needsRetry:   second.needsRetryForSession(fullChildID),
+		forceReplace: second.forceReplace,
+	}}, syncWriteDefault, second.forceReplace)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	assert.Equal(t, db.CurrentDataVersion(), database.GetSessionDataVersion(fullChildID))
+	storedMessages, err := database.GetAllMessages(t.Context(), fullChildID)
+	require.NoError(t, err)
+	require.Len(t, storedMessages, 2)
+	assert.Equal(t, []string{childPath, parentPath, indexPath}, fetched)
+}
+
 func TestProcessS3CodexUsesSessionIndex(t *testing.T) {
 	database := openTestDB(t)
 	const uuid = "11111111-1111-4111-8111-111111111111"


### PR DESCRIPTION
Codex fork and subagent rollouts now resolve their explicit parent transcript
and compare `turn_context.turn_id` values only as opaque equality keys. Replayed
parent messages and token usage stay suppressed regardless of identifier shape;
the first turn absent from the parent starts child-owned work.

S3 imports hydrate only the explicitly named parent within the configured
Codex root. A missing or zero-turn parent leaves the child visible but marks its
stored data version for retry, so a later unchanged-object sync can replace the
temporary overcount. Child-only subagent transcripts remain unchanged.

The parent lookup uses bounded, file-versioned caching. Data version 87 triggers
the normal non-destructive archive rebuild so existing inflated rows are
corrected after the version-86 VS Code Copilot reparse.

Captured full and line-by-line replay of the five affected rollouts converges to
$15.403799 instead of $683.120437.

<sup>generated by a clanker</sup>
