### PR TITLE
fix(parser): restore VS Code Copilot response items

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -730,7 +730,14 @@ Grok section and remove the explicit registry exception in the coverage test.
   the consumed shape. Copilot credits are not treated as currency.
 - **Agentsview:** `internal/parser/vscode_copilot.go` and
   `internal/parser/vscode_copilot_provider.go`; both compact snapshots and
-  operation logs are supported.
+  operation logs are supported. Reverified 2026-08-12 against the VS Code
+  1.132 JSONL artifact from
+  [#1351](https://github.com/kenn-io/agentsview/issues/1351): completed tools
+  can persist object-valued `isConfirmed`, terminal commands under
+  `toolSpecificData.commandLine.original`, and ordered `inlineReference`
+  response items. Agentsview consumes the final response array, which also
+  preserves display order, rather than the duplicate tool calls under
+  `result.metadata.toolCallRounds`.
 
 ## Windsurf (`windsurf`)
 

--- a/docs/superpowers/plans/2026-08-12-vscode-copilot-response-items.md
+++ b/docs/superpowers/plans/2026-08-12-vscode-copilot-response-items.md
@@ -1,0 +1,216 @@
+# VS Code Copilot Response Item Parsing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans
+> to implement this plan directly in the current agent, task-by-task. Never use
+> subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore structured tool calls, nested terminal commands, and visible
+file references from VS Code 1.132 Copilot sessions.
+
+**Approved spec/design:**
+`docs/superpowers/specs/2026-08-12-vscode-copilot-response-items-design.md`
+
+**Architecture:** Keep `request.response` as the authoritative ordered source.
+Decode unused status fields without fixed scalar types, convert inline file
+references to visible inline-code text, and support both flat and nested
+terminal command fields in the shared VS Code/Positron parser.
+
+**Tech Stack:** Go, `encoding/json`, Testify, VS Code JSONL session logs.
+
+## Global Constraints
+
+- Do not parse `result.metadata.toolCallRounds`; duplicate calls already exist
+  in `request.response`.
+- Preserve old flat `toolSpecificData.command` support.
+- Render references as visible inline code, not local `file://` links.
+- Derive the test fixture by hand from issue #1351 and assert parsed behavior.
+- Update `docs/internal/session-format-sources.md` with the VS Code 1.132
+  evidence.
+
+______________________________________________________________________
+
+### Task 1: Add the VS Code 1.132 Regression Test
+
+**Files:**
+
+- Modify: `internal/parser/vscode_copilot_test.go`
+
+**Interfaces:**
+
+- Consumes: `parseVSCodeCopilotTestSession(t, path, project, machine)`.
+
+- Produces: A regression test for the observable `[]ParsedMessage` contract.
+
+- [x] **Step 1: Write the failing JSONL parser test**
+
+    Add `TestParseVSCodeCopilotSession_VSCode132ResponseItems`. Write a temporary
+    JSONL session with one initial operation and one request push. Its response
+    must contain two `copilot_readFile` calls and one `run_in_terminal` call,
+    each with `"isConfirmed":{"type":1}`. Put `uname -a` in
+    `toolSpecificData.commandLine.original`, and put `inlineReference` items for
+    `/workspace/test.txt` between the text fragments `"I'll read "`,
+    `" first. "`, and `" contains the command."`.
+
+    Assert these literal outcomes:
+
+    ```go
+    require.Len(t, msgs, 2, "user and assistant messages")
+    assistant := msgs[1]
+    assert.True(t, assistant.HasToolUse)
+    require.Len(t, assistant.ToolCalls, 3)
+    assert.Equal(t, []string{"copilot_readFile", "copilot_readFile", "run_in_terminal"}, []string{
+        assistant.ToolCalls[0].ToolName,
+        assistant.ToolCalls[1].ToolName,
+        assistant.ToolCalls[2].ToolName,
+    })
+    assert.JSONEq(t, `{"command":"uname -a","message":"Running uname"}`, assistant.ToolCalls[2].InputJSON)
+    assert.Contains(t, assistant.Content, "I'll read `/workspace/test.txt` first.")
+    assert.Contains(t, assistant.Content, "`/workspace/test.txt` contains the command.")
+    ```
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+    Run:
+
+    ```bash
+    go test ./internal/parser -run TestParseVSCodeCopilotSession_VSCode132ResponseItems -count=1
+    ```
+
+    Expected: FAIL because `isConfirmed` cannot unmarshal into `bool`; the
+    assistant has no tool calls, its nested command is absent, and inline
+    references are missing.
+
+### Task 2: Parse Flexible Status, References, and Nested Commands
+
+**Files:**
+
+- Modify: `internal/parser/vscode_copilot.go`
+- Test: `internal/parser/vscode_copilot_test.go`
+
+**Interfaces:**
+
+- Consumes: `vscodeCopilotResponseItem` and raw `inlineReference` /
+  `toolSpecificData` JSON.
+
+- Produces: `extractVSCodeInlineReference(json.RawMessage) string` and extended
+  `extractVSCopilotInputJSON(...) string` behavior.
+
+- [x] **Step 1: Make status fields schema-tolerant**
+
+    Remove the unused boolean `IsConfirmed` and `IsComplete` fields from
+    `vscodeCopilotResponseItem`. `encoding/json` ignores those producer fields,
+    so their scalar or object representation cannot invalidate the stable fields
+    that Agentsview consumes.
+
+- [x] **Step 2: Add inline-reference extraction**
+
+    Add a small struct containing `FSPath`, `Path`, and `External`. Implement
+    `extractVSCodeInlineReference` to prefer `fsPath`, then `path`, then strip
+    the `file://` prefix from `external`. Return "`" + path + "`" for a
+    non-empty path and `""` for malformed or empty input. In the
+    `inlineReference` switch case, append that string to `textParts` when
+    non-empty.
+
+- [x] **Step 3: Support nested terminal command data**
+
+    Extend `vscodeCopilotToolData` with:
+
+    ```go
+    CommandLine struct {
+        Original string `json:"original"`
+    } `json:"commandLine,omitempty"`
+    ```
+
+    In `extractVSCopilotInputJSON`, prefer the existing non-empty `Command`, then
+    use `CommandLine.Original`. Store the selected value under the existing
+    `command` key.
+
+- [x] **Step 4: Run focused VS Code and Positron parser tests and verify GREEN**
+
+    Run:
+
+    ```bash
+    go test ./internal/parser -run 'TestParseVSCodeCopilotSession|TestExtractVSCopilotInputJSON|TestPositron' -count=1
+    ```
+
+    Expected: PASS. The new test proves the three issue behaviors, while existing
+    tests prove the older boolean/flat-command shapes still parse.
+
+### Task 3: Record Format Provenance and Verify the Change
+
+**Files:**
+
+- Modify: `docs/internal/session-format-sources.md`
+- Modify: `internal/db/db.go`
+- Test: `internal/db/db_test.go`
+- Modify: `docs/superpowers/plans/2026-08-12-vscode-copilot-response-items.md`
+
+**Interfaces:**
+
+- Consumes: The observed issue #1351 session artifact and focused test result.
+
+- Produces: An updated VS Code Copilot evidence entry and completed plan record.
+
+- [x] **Step 1: Update the VS Code Copilot evidence entry**
+
+    Add a concise note to the `VS Code Copilot (vscode-copilot)` section. State
+    that issue #1351's VS Code 1.132 JSONL artifact was checked on 2026-08-12
+    and records object-valued `isConfirmed`, nested
+    `toolSpecificData.commandLine.original`, and ordered `inlineReference`
+    items. State that Agentsview consumes the final response array rather than
+    duplicate metadata tool-call rounds.
+
+- [x] **Step 2: Format and verify**
+
+    Set `dataVersion` to 86 and update its contract test so unchanged archived
+    sessions are rebuilt through the existing non-destructive full-resync path.
+    Document that version 86 reparses VS Code Copilot and Positron sessions to
+    restore response items.
+
+    Run:
+
+    ```bash
+    gofmt -w internal/parser/vscode_copilot.go internal/parser/vscode_copilot_test.go
+    go test ./internal/parser -count=1
+    go vet ./...
+    git diff --check
+    ```
+
+    Expected: all commands pass with no warnings or formatting errors.
+
+- [x] **Step 3: Review the complete diff**
+
+    Run:
+
+    ```bash
+    git status --short
+    git diff HEAD
+    ```
+
+    Confirm the diff contains only the approved parser behavior, regression test,
+    provenance note, and implementation plan. Confirm no private paths from the
+    supplied session appear in tracked files.
+
+- [x] **Step 4: Mark this plan complete and commit**
+
+    Change every task checkbox in this plan to `[x]`. Re-run `git diff --check`,
+    stage only the parser, data-version, provenance, and plan files, and commit
+    with:
+
+    ```bash
+    git commit -m "fix(parser): restore VS Code Copilot response items" \
+      -m "VS Code 1.132 changed persisted status, terminal command, and inline-reference shapes. Accept those shapes so archived sessions retain structured tool calls and readable file references without duplicating metadata tool-call rounds."
+    ```
+
+    Do not bypass hooks. If a hook changes files, inspect and restage the intended
+    changes before retrying.
+
+## Verification Result
+
+The affected parser and data-version packages pass with the project's `fts5` tag
+in an isolated scratch HOME. Repository-wide tagged `go vet` also passes in
+isolated state. `make test-short` reaches and passes `internal/parser`, but the
+whole target remains red because native macOS file events do not arrive in the
+test environment. The same timeouts reproduce when `internal/fsevents` and the
+real-watcher tests in `internal/sync` run independently; neither package is
+modified by this change.

--- a/docs/superpowers/specs/2026-08-12-vscode-copilot-response-items-design.md
+++ b/docs/superpowers/specs/2026-08-12-vscode-copilot-response-items-design.md
@@ -1,0 +1,69 @@
+# VS Code Copilot Response Item Parsing
+
+## Problem
+
+VS Code 1.132 persists completed Copilot response items with shapes that the
+current parser does not accept. `isConfirmed` can be an object instead of a
+boolean, terminal commands can be nested below `toolSpecificData.commandLine`,
+and file references are represented as `inlineReference` items between text
+items.
+
+The parser currently unmarshals each whole item into a struct with a boolean
+`isConfirmed` field. An object value makes that unmarshal fail, so the parser
+silently skips the entire tool invocation. It also deliberately skips inline
+references, which joins the surrounding text without the referenced file name.
+
+## Design
+
+Keep the final `request.response` array as the authoritative ordered response.
+Do not recover tool calls from `result.metadata.toolCallRounds`, because the
+same calls appear in both representations and reconciliation would introduce a
+duplicate-counting path.
+
+Make fields that are not used to construct parsed output schema-tolerant so a
+new representation cannot invalidate the rest of a response item. Preserve an
+`inlineReference` item as inline-code text containing its file path. This keeps
+the reference visible at its exact position without exposing a local-only
+`file://` link that would not work for remote viewers.
+
+Read terminal commands from both supported locations:
+
+- `toolSpecificData.command` for existing session files.
+- `toolSpecificData.commandLine.original` for VS Code 1.132 session files.
+
+Keep existing tool-name normalization and display formatting. Populate the tool
+call input with the recovered command so the structured tool call and its
+rendered block both show the command.
+
+## Data Flow
+
+For each response item, decode its stable fields and retain flexible raw JSON
+for fields whose producer shape varies. Text items append their value. Inline
+references append a backtick-delimited file path. Tool invocation items create
+one `ParsedToolCall`, extracting the invocation label and terminal command from
+the supported shapes. The request then produces one assistant message with the
+tool calls and ordered display text.
+
+Malformed or unknown response items continue to be skipped. A malformed inline
+reference contributes no text. A tool invocation without a tool ID contributes
+no tool call. These match the parser's current error policy.
+
+## Test Strategy
+
+Add a hand-reduced JSONL fixture inside the parser test. Derive its values from
+the supplied issue session, but include only the response shapes needed for the
+regression:
+
+- Object-valued `isConfirmed` on completed read and terminal tools.
+- Two read tools and one terminal tool.
+- A terminal command under `commandLine.original`.
+- Inline references between assistant text fragments.
+
+Assert the public parsed result: one assistant message has three structured tool
+calls, the terminal call contains `uname -a`, and the assistant prose retains
+the visible `test.txt` references. This test would fail if object-valued status
+again invalidates item decoding, nested command extraction is removed, or file
+references are discarded.
+
+Update the VS Code Copilot session-format inventory with the observed 1.132
+shapes and the issue artifact as implementation evidence.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -407,7 +407,11 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // rollout prefix into a newly spawned subagent file, re-stamping messages and
 // token_count events at child creation. Existing Codex-format rows need
 // re-parsing so derived sessions retain only child-owned messages and usage.)
-const dataVersion = 85
+// (86: VS Code Copilot response item parsing. VS Code 1.132 persists status,
+// inline reference, and terminal command fields in shapes the parser previously
+// skipped. Existing VS Code Copilot and Positron rows need re-parsing so their
+// structured tool calls and visible file references are restored.)
+const dataVersion = 86
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1009,8 +1009,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionUsageReparses(t *testing.T) {
-	assert.Equal(t, 85, CurrentDataVersion(),
-		"Amp usage and Codex subagent replay accounting require sequential reparses")
+	assert.Equal(t, 86, CurrentDataVersion(),
+		"Codex replay accounting and VS Code Copilot response items require sequential reparses")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/vscode_copilot.go
+++ b/internal/parser/vscode_copilot.go
@@ -88,8 +88,6 @@ type vscodeCopilotResponseItem struct {
 	Value             string          `json:"value,omitempty"`
 	ToolID            string          `json:"toolId,omitempty"`
 	ToolCallID        string          `json:"toolCallId,omitempty"`
-	IsConfirmed       bool            `json:"isConfirmed,omitempty"`
-	IsComplete        bool            `json:"isComplete,omitempty"`
 	InvocationMessage json.RawMessage `json:"invocationMessage,omitempty"`
 	PastTenseMessage  json.RawMessage `json:"pastTenseMessage,omitempty"`
 	ToolName          string          `json:"toolName,omitempty"`
@@ -99,14 +97,23 @@ type vscodeCopilotResponseItem struct {
 
 // vscodeCopilotToolData holds terminal-specific tool data.
 type vscodeCopilotToolData struct {
-	Kind     string `json:"kind"`
-	Language string `json:"language,omitempty"`
-	Command  string `json:"command,omitempty"`
+	Kind        string `json:"kind"`
+	Language    string `json:"language,omitempty"`
+	Command     string `json:"command,omitempty"`
+	CommandLine struct {
+		Original string `json:"original"`
+	} `json:"commandLine,omitempty"`
 }
 
 // vscodeCopilotInvocationMsg holds a structured invocation message.
 type vscodeCopilotInvocationMsg struct {
 	Value string `json:"value"`
+}
+
+type vscodeCopilotInlineReference struct {
+	FSPath   string `json:"fsPath"`
+	Path     string `json:"path"`
+	External string `json:"external"`
 }
 
 // vscodeCopilotWorkspace holds the workspace.json manifest.
@@ -379,8 +386,13 @@ func parseVSCodeCopilotResponse(
 			}
 		case "prepareToolInvocation":
 			// Skip, the actual invocation comes later.
-		case "inlineReference", "undoStop",
-			"codeblockUri", "textEditGroup":
+		case "inlineReference":
+			if ref := extractVSCodeInlineReference(
+				item.InlineReference,
+			); ref != "" {
+				textParts = append(textParts, ref)
+			}
+		case "undoStop", "codeblockUri", "textEditGroup":
 			// Skip non-text items.
 		case "":
 			// Items without a kind are markdown text
@@ -397,6 +409,25 @@ func parseVSCodeCopilotResponse(
 
 	text := strings.TrimSpace(strings.Join(textParts, ""))
 	return text, toolCalls
+}
+
+func extractVSCodeInlineReference(raw json.RawMessage) string {
+	var ref vscodeCopilotInlineReference
+	if err := json.Unmarshal(raw, &ref); err != nil {
+		return ""
+	}
+
+	path := ref.FSPath
+	if path == "" {
+		path = ref.Path
+	}
+	if path == "" {
+		path = strings.TrimPrefix(ref.External, "file://")
+	}
+	if path == "" {
+		return ""
+	}
+	return "`" + path + "`"
 }
 
 // normalizeVSCodeToolName maps VSCode Copilot tool IDs to
@@ -544,8 +575,12 @@ func extractVSCopilotInputJSON(
 	if len(toolData) > 0 {
 		var td vscodeCopilotToolData
 		if err := json.Unmarshal(toolData, &td); err == nil {
-			if td.Command != "" {
-				result["command"] = td.Command
+			command := td.Command
+			if command == "" {
+				command = td.CommandLine.Original
+			}
+			if command != "" {
+				result["command"] = command
 			}
 		}
 	}

--- a/internal/parser/vscode_copilot_test.go
+++ b/internal/parser/vscode_copilot_test.go
@@ -264,6 +264,46 @@ func TestParseVSCodeCopilotSession_TerminalToolData(t *testing.T) {
 		"content should contain command, got: %s", assistant.Content)
 }
 
+func TestParseVSCodeCopilotSession_VSCode132ResponseItems(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vscode-132.jsonl")
+	lines := []string{
+		`{"kind":0,"v":{"version":3,"sessionId":"vscode-132","creationDate":1786000235709,"requests":[]}}`,
+		`{"kind":2,"k":["requests"],"v":[{"requestId":"request-1","timestamp":1786000291425,"message":{"text":"Read test.txt and run its command."},"response":[{"value":"I'll read "},{"kind":"inlineReference","inlineReference":{"fsPath":"/workspace/test.txt","external":"file:///workspace/test.txt","path":"/workspace/test.txt","scheme":"file"}},{"value":" first. "},{"kind":"toolInvocationSerialized","pastTenseMessage":{"value":"Read instructions"},"isConfirmed":{"type":1},"isComplete":true,"toolCallId":"call-read-instructions","toolId":"copilot_readFile"},{"kind":"toolInvocationSerialized","pastTenseMessage":{"value":"Read test.txt"},"isConfirmed":{"type":1},"isComplete":true,"toolCallId":"call-read-test","toolId":"copilot_readFile"},{"kind":"inlineReference","inlineReference":{"fsPath":"/workspace/test.txt","external":"file:///workspace/test.txt","path":"/workspace/test.txt","scheme":"file"}},{"value":" contains the command."},{"kind":"toolInvocationSerialized","pastTenseMessage":{"value":"Running uname"},"isConfirmed":{"type":1},"isComplete":true,"toolSpecificData":{"kind":"terminal","commandLine":{"original":"uname -a","forDisplay":"uname -a"}},"toolCallId":"call-terminal","toolId":"run_in_terminal"},{"value":" Done."}],"modelId":"gpt-5.6-terra"}]}`,
+	}
+	require.NoError(t, os.WriteFile(
+		path, []byte(strings.Join(lines, "\n")+"\n"), 0o644,
+	))
+
+	_, msgs, err := parseVSCodeCopilotTestSession(
+		t, path, "project", "machine",
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2, "user and assistant messages")
+
+	assistant := msgs[1]
+	assert.True(t, assistant.HasToolUse)
+	require.Len(t, assistant.ToolCalls, 3)
+	assert.Equal(t,
+		[]string{"copilot_readFile", "copilot_readFile", "run_in_terminal"},
+		[]string{
+			assistant.ToolCalls[0].ToolName,
+			assistant.ToolCalls[1].ToolName,
+			assistant.ToolCalls[2].ToolName,
+		},
+	)
+	assert.JSONEq(t,
+		`{"command":"uname -a","message":"Running uname"}`,
+		assistant.ToolCalls[2].InputJSON,
+	)
+	assert.Contains(t, assistant.Content,
+		"I'll read `/workspace/test.txt` first.",
+	)
+	assert.Contains(t, assistant.Content,
+		"`/workspace/test.txt` contains the command.",
+	)
+}
+
 func TestExtractProjectFromURI(t *testing.T) {
 	tests := []struct {
 		uri  string


### PR DESCRIPTION
VS Code 1.132 Copilot sessions can persist completed tool status as an object. Agentsview decoded that field as a boolean, so it skipped the entire response item and lost structured tool calls. It also discarded inline file references, which joined surrounding prose without the referenced path.

The parser now accepts the new response shapes, recovers nested terminal commands, and keeps inline file references visible as code-formatted paths. The final response array remains authoritative, avoiding duplicate calls from the metadata copy of the same tool rounds.

Data version 86 rebuilds existing VS Code Copilot and Positron sessions through the normal safe archive resync path, so stored affected sessions receive the correction.

Closes #1351.

<sup>generated by a clanker</sup>
