### PR TITLE
fix(sync): apply late Codex tool results incrementally

### DIFF
--- a/docs/internal/background-sync-efficiency.md
+++ b/docs/internal/background-sync-efficiency.md
@@ -50,9 +50,14 @@ they are never published as safe cursor boundaries.
 
 Truncation, known file-identity replacement, manual or project refreshes,
 `session_index.jsonl` title changes, and records that retroactively update
-stored messages all fall back to an authoritative full replacement. Safe
-incremental writes preserve the index-folded mtime and lifecycle-derived
-termination status alongside message and token aggregates.
+stored messages all fall back to an authoritative full replacement. Late tool
+results are the exception: the cursor tracks pending tool calls (bounded), so
+a `function_call_output` / `custom_tool_call_output` that refers to a call
+committed in an earlier batch is applied as an idempotent point update
+(`ToolCallResultUpdates`) instead of a full reparse. Agent-scoped and unknown
+calls still fall back. Safe incremental writes preserve the index-folded mtime
+and lifecycle-derived termination status alongside message and token
+aggregates.
 
 ## Append-only limitation
 
@@ -76,6 +81,10 @@ provider's `Fingerprint` hashes the complete source and the engine's
 - `BenchmarkCodexIncrementalSyncReads` in `internal/sync` measures the warm tail
   between the two remaining linear reads. It is PR-gated because
   `internal/sync` is in `BENCH_GATE_PACKAGES`.
+- `BenchmarkCodexIncrementalLateToolOutput` in `internal/sync` measures a
+  stream where every appended batch carries the output for the previous
+  batch's call: the base code reparses the whole transcript per batch, while
+  the incremental path attaches each event to its stored call.
 
 The maintained behavioral gate inventory is in
 [Performance Gates](performance-gates.md).

--- a/docs/internal/performance-gates.md
+++ b/docs/internal/performance-gates.md
@@ -54,10 +54,13 @@ runner noise and fail loudly:
   warm/cold parsing remains equivalent at safe offsets.
 - `TestIncrementalSync_CodexAppend`,
   `TestIncrementalSync_CodexLifecycleTailUpdatesTermination`, the partial-tail
-  tests, and the late-update/title tests in
+  tests, the late tool-result append test
+  (`TestIncrementalSync_CodexExecAppendRetainsEvents`), and the
+  late-update/title tests in
   `internal/sync/engine_integration_test.go` — safe Codex growth appends only
-  new rows while lifecycle metadata, incomplete records, title changes, and
-  retroactive updates preserve full-parse behavior.
+  new rows, late tool results update stored calls in place, and lifecycle
+  metadata, incomplete records, title changes, and other retroactive updates
+  preserve full-parse behavior.
 
 When you fix a performance bug, prefer adding a gate at this layer: expose or
 reuse a counter (`SyncStats`, `PhaseStats`, `AnomalyStats`, a swappable

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3616,6 +3616,79 @@ func TestWriteSessionIncrementalResultOnlyLink(t *testing.T) {
 		"result-only link must not disturb other calls")
 }
 
+func TestWriteSessionIncrementalToolCallResultUpdate(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+	insertMessages(t, d, Message{
+		SessionID:  "s1",
+		Ordinal:    0,
+		Role:       "assistant",
+		HasToolUse: true,
+		ToolCalls: []ToolCall{{
+			SessionID: "s1",
+			ToolName:  "exec_command",
+			Category:  "Bash",
+			ToolUseID: "call_cmd",
+		}},
+	})
+
+	update := IncrementalSessionUpdate{
+		MsgCount:    1,
+		NextOrdinal: 1,
+		ToolCallResultUpdates: []ToolCallResultUpdate{{
+			ToolUseID: "call_cmd",
+			Events: []ToolResultEvent{{
+				ToolUseID:     "call_cmd",
+				Source:        "function_call_output",
+				Content:       "command finished",
+				ContentLength: len("command finished"),
+				Timestamp:     "2026-08-02T09:00:00Z",
+			}},
+		}},
+	}
+	require.NoError(t, d.WriteSessionIncremental("s1", nil, update))
+
+	var result string
+	var resultLen int
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT COALESCE(result_content, ''), result_content_length
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "call_cmd",
+	).Scan(&result, &resultLen))
+	assert.Equal(t, "command finished", result)
+	assert.Equal(t, len("command finished"), resultLen)
+
+	var source, content, timestamp string
+	var eventIndex, eventCount int
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT source, content, COALESCE(timestamp, ''), event_index
+		FROM tool_result_events
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "call_cmd",
+	).Scan(&source, &content, &timestamp, &eventIndex))
+	assert.Equal(t, "function_call_output", source)
+	assert.Equal(t, "command finished", content)
+	assert.Equal(t, "2026-08-02T09:00:00Z", timestamp)
+	assert.Zero(t, eventIndex)
+
+	require.NoError(t, d.WriteSessionIncremental("s1", nil, update),
+		"replaying an identical output must be idempotent")
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT COUNT(*) FROM tool_result_events
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "call_cmd",
+	).Scan(&eventCount))
+	assert.Equal(t, 1, eventCount)
+
+	sess, err := d.GetSession(context.Background(), "s1")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.TranscriptRevision)
+	assert.Equal(t, "2", *sess.TranscriptRevision,
+		"idempotent replay must not bump the transcript revision")
+}
+
 // claude_linear_parse round-trips through upsert and the incremental
 // lookup, stays NULL for legacy rows, and survives an upsert that
 // carries no verdict.

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -94,6 +94,59 @@ type ToolResultEvent struct {
 	EventIndex        int    `json:"event_index"`
 }
 
+// SummarizeToolResultEvents derives the display result stored on a tool call
+// from its chronological result events. Anonymous events use the latest
+// content; agent-scoped events keep the latest content for each agent.
+func SummarizeToolResultEvents(events []ToolResultEvent) string {
+	if len(events) == 0 {
+		return ""
+	}
+	type agentSummary struct {
+		content string
+	}
+	latestByAgent := map[string]agentSummary{}
+	orderedAgents := make([]string, 0, len(events))
+	lastAnon := ""
+	allHaveAgentID := true
+	for _, ev := range events {
+		if strings.TrimSpace(ev.Content) == "" {
+			continue
+		}
+		agentID := strings.TrimSpace(ev.AgentID)
+		if agentID == "" {
+			allHaveAgentID = false
+			lastAnon = ev.Content
+			continue
+		}
+		if _, ok := latestByAgent[agentID]; !ok {
+			latestByAgent[agentID] = agentSummary{content: ev.Content}
+			orderedAgents = append(orderedAgents, agentID)
+			continue
+		}
+		entry := latestByAgent[agentID]
+		entry.content = ev.Content
+		latestByAgent[agentID] = entry
+	}
+	if len(latestByAgent) <= 1 {
+		if len(latestByAgent) == 1 {
+			summary := latestByAgent[orderedAgents[0]].content
+			if lastAnon != "" {
+				return summary + "\n\n" + lastAnon
+			}
+			return summary
+		}
+		return lastAnon
+	}
+	parts := make([]string, 0, len(orderedAgents))
+	for _, agentID := range orderedAgents {
+		parts = append(parts, agentID+":\n"+latestByAgent[agentID].content)
+	}
+	if !allHaveAgentID && lastAnon != "" {
+		parts = append(parts, lastAnon)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
 // Message represents a row in the messages table.
 type Message struct {
 	ID        int64  `json:"id"`
@@ -1026,6 +1079,16 @@ func (db *DB) WriteSessionIncremental(
 	for _, link := range update.SubagentLinks {
 		changed, err := applyToolCallSubagentLinkTx(
 			tx, sessionID, link, update.BlockedResultCategories,
+		)
+		if err != nil {
+			return err
+		}
+		transcriptChanged = transcriptChanged || changed
+	}
+	for _, resultUpdate := range update.ToolCallResultUpdates {
+		changed, err := applyToolCallResultUpdateTx(
+			tx, sessionID, resultUpdate,
+			update.BlockedResultCategories,
 		)
 		if err != nil {
 			return err
@@ -2270,6 +2333,155 @@ func applyToolCallSubagentLinkTx(
 		sessionID, link.ToolUseID,
 	)
 	return err == nil, err
+}
+
+func applyToolCallResultUpdateTx(
+	tx *sql.Tx, sessionID string, update ToolCallResultUpdate,
+	blockedResultCategories map[string]bool,
+) (bool, error) {
+	if strings.TrimSpace(update.ToolUseID) == "" || len(update.Events) == 0 {
+		return false, nil
+	}
+
+	var messageOrdinal, callIndex int
+	var category string
+	if err := tx.QueryRow(
+		`SELECT m.ordinal, COALESCE(tc.call_index, 0), tc.category
+		 FROM tool_calls tc
+		 JOIN messages m ON m.id = tc.message_id
+		 WHERE tc.session_id = ? AND tc.tool_use_id = ?`,
+		sessionID, update.ToolUseID,
+	).Scan(&messageOrdinal, &callIndex, &category); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf(
+			"checking tool result target for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+
+	rows, err := tx.Query(
+		`SELECT COALESCE(tool_use_id, ''), COALESCE(agent_id, ''),
+		        COALESCE(subagent_session_id, ''), source, status,
+		        content, content_length, COALESCE(timestamp, ''), event_index
+		 FROM tool_result_events
+		 WHERE session_id = ? AND tool_call_message_ordinal = ?
+		   AND call_index = ?
+		 ORDER BY event_index, id`,
+		sessionID, messageOrdinal, callIndex,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"loading tool result events for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+	var events []ToolResultEvent
+	nextEventIndex := 0
+	for rows.Next() {
+		var ev ToolResultEvent
+		if err := rows.Scan(
+			&ev.ToolUseID, &ev.AgentID, &ev.SubagentSessionID,
+			&ev.Source, &ev.Status, &ev.Content, &ev.ContentLength,
+			&ev.Timestamp, &ev.EventIndex,
+		); err != nil {
+			_ = rows.Close()
+			return false, fmt.Errorf(
+				"scanning tool result event for %s/%s: %w",
+				sessionID, update.ToolUseID, err,
+			)
+		}
+		events = append(events, ev)
+		nextEventIndex = max(nextEventIndex, ev.EventIndex+1)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return false, fmt.Errorf(
+			"reading tool result events for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+	if err := rows.Close(); err != nil {
+		return false, fmt.Errorf(
+			"closing tool result events for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+
+	incoming := append([]ToolResultEvent(nil), update.Events...)
+	for i := range incoming {
+		if incoming[i].ToolUseID == "" {
+			incoming[i].ToolUseID = update.ToolUseID
+		}
+		if incoming[i].ContentLength == 0 {
+			incoming[i].ContentLength = len(incoming[i].Content)
+		}
+	}
+	toolCall := ToolCall{ResultEvents: incoming}
+	_ = SanitizeToolCall(&toolCall)
+	incoming = toolCall.ResultEvents
+
+	blocked := blockedResultCategories[category]
+	insertRows := make([]toolResultEventRow, 0, len(incoming))
+	for _, candidate := range incoming {
+		if hasEquivalentToolResultEvent(events, candidate, blocked) {
+			continue
+		}
+		candidate.EventIndex = nextEventIndex
+		nextEventIndex++
+		events = append(events, candidate)
+		stored := candidate
+		if blocked {
+			stored.Content = ""
+		}
+		insertRows = append(insertRows, toolResultEventRow{
+			SessionID:      sessionID,
+			MessageOrdinal: messageOrdinal,
+			CallIndex:      callIndex,
+			Event:          stored,
+		})
+	}
+	if len(insertRows) == 0 {
+		return false, nil
+	}
+	if err := insertToolResultEventsTx(tx, insertRows); err != nil {
+		return false, err
+	}
+
+	summary := SummarizeToolResultEvents(events)
+	storedSummary := summary
+	if blocked {
+		storedSummary = ""
+	}
+	if _, err := tx.Exec(
+		`UPDATE tool_calls
+		 SET result_content_length = ?, result_content = ?
+		 WHERE session_id = ? AND tool_use_id = ?`,
+		len(summary), storedSummary, sessionID, update.ToolUseID,
+	); err != nil {
+		return false, fmt.Errorf(
+			"updating tool result summary for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+	return true, nil
+}
+
+func hasEquivalentToolResultEvent(
+	events []ToolResultEvent, candidate ToolResultEvent, blocked bool,
+) bool {
+	for _, existing := range events {
+		if existing.AgentID != candidate.AgentID ||
+			existing.Status != candidate.Status {
+			continue
+		}
+		if existing.Content == candidate.Content ||
+			(blocked && existing.ContentLength == candidate.ContentLength) {
+			return true
+		}
+	}
+	return false
 }
 
 // SystemMessageFingerprint returns the ordered, comma-separated list of

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2478,6 +2478,7 @@ type IncrementalSessionUpdate struct {
 	HasTotalOutputTokens    bool
 	HasPeakContextTokens    bool
 	SubagentLinks           []ToolCallSubagentLink
+	ToolCallResultUpdates   []ToolCallResultUpdate
 	BlockedResultCategories map[string]bool
 }
 
@@ -2487,6 +2488,14 @@ type ToolCallSubagentLink struct {
 	ResultContent     string
 	ResultContentLen  int
 	HasResult         bool
+}
+
+// ToolCallResultUpdate carries result events for a tool call that already
+// exists in the database. Incremental parsers use it when an appended output
+// record refers to a call from an earlier sync batch.
+type ToolCallResultUpdate struct {
+	ToolUseID string
+	Events    []ToolResultEvent
 }
 
 // GetSessionForIncremental returns session state needed for incremental

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -68,6 +68,7 @@ type codexSessionBuilder struct {
 	ordinal              int
 	callNames            map[string]string
 	callRefs             map[string]codexToolCallRef
+	toolCallUpdates      []ParsedToolCallUpdate
 	agentSpawnCalls      map[string]string
 	agentWaitCalls       map[string]string
 	pendingAgentEvents   map[string][]codexPendingEvent
@@ -520,6 +521,7 @@ func (b *codexSessionBuilder) handleFunctionCall(
 	callID := payload.Get("call_id").Str
 	if callID != "" {
 		b.callNames[callID] = name
+		b.rememberToolCall(callID, name)
 	}
 
 	content := formatCodexFunctionCall(name, payload)
@@ -570,6 +572,7 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 	if callID == "" {
 		return
 	}
+	defer b.forgetToolCall(callID)
 
 	output, raw := parseCodexFunctionOutput(payload)
 	if !output.Exists() {
@@ -578,7 +581,7 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 		}
 	}
 
-	switch b.callNames[callID] {
+	switch b.toolCallNameForOutput(callID) {
 	case "spawn_agent":
 		agentID := strings.TrimSpace(output.Get("agent_id").Str)
 		if agentID == "" {
@@ -628,6 +631,14 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 			})
 		}
 	}
+}
+
+func (b *codexSessionBuilder) toolCallNameForOutput(callID string) string {
+	if name := b.callNames[callID]; name != "" {
+		return name
+	}
+	name, _ := b.toolCallName(callID)
+	return name
 }
 
 // setCallSubagentSessionID links a tool call to the session of
@@ -694,6 +705,7 @@ func (b *codexSessionBuilder) appendCallResultEvent(
 	}
 	ref, ok := b.callRefs[callID]
 	if !ok || ref.messageIndex < 0 || ref.messageIndex >= len(b.messages) {
+		b.appendToolCallUpdate(callID, ev)
 		return
 	}
 	if ref.callIndex < 0 || ref.callIndex >= len(b.messages[ref.messageIndex].ToolCalls) {
@@ -710,6 +722,29 @@ func (b *codexSessionBuilder) appendCallResultEvent(
 		return
 	}
 	tc.ResultEvents = append(tc.ResultEvents, ev)
+}
+
+func (b *codexSessionBuilder) appendToolCallUpdate(
+	callID string, ev ParsedToolResultEvent,
+) {
+	if ev.ToolUseID == "" {
+		ev.ToolUseID = callID
+	}
+	for i := range b.toolCallUpdates {
+		update := &b.toolCallUpdates[i]
+		if update.ToolUseID != callID {
+			continue
+		}
+		if b.hasEquivalentCallResultEvent(update.ResultEvents, ev) {
+			return
+		}
+		update.ResultEvents = append(update.ResultEvents, ev)
+		return
+	}
+	b.toolCallUpdates = append(b.toolCallUpdates, ParsedToolCallUpdate{
+		ToolUseID:    callID,
+		ResultEvents: []ParsedToolResultEvent{ev},
+	})
 }
 
 func (b *codexSessionBuilder) hasEquivalentCallResultEvent(
@@ -1873,13 +1908,30 @@ func seedCodexIncrementalStateFromReader(
 				}
 			}
 		case codexTypeResponseItem:
-			observeCodexIncrementalUserMessage(&seed, payload)
+			observeCodexIncrementalResponseItem(&seed, payload)
 		}
 	}
 	if err := lr.Err(); err != nil {
 		return codexIncrementalSeed{}, err
 	}
 	return seed, nil
+}
+
+func observeCodexIncrementalResponseItem(
+	s *codexIncrementalSeed,
+	payload gjson.Result,
+) {
+	switch payload.Get("type").Str {
+	case "function_call", "custom_tool_call":
+		s.rememberToolCall(
+			payload.Get("call_id").Str,
+			payload.Get("name").Str,
+		)
+	case "function_call_output", "custom_tool_call_output":
+		s.forgetToolCall(payload.Get("call_id").Str)
+	default:
+		observeCodexIncrementalUserMessage(s, payload)
+	}
 }
 
 // observeUserMessage feeds one response_item into the
@@ -2026,13 +2078,14 @@ func codexSafeResumeOffsetFile(f *os.File, offset int64) (bool, error) {
 }
 
 type codexIncrementalParseResult struct {
-	messages      []ParsedMessage
-	endedAt       time.Time
-	consumedBytes int64
-	initialCursor codexCursorState
-	cursor        codexCursorState
-	inode         uint64
-	device        uint64
+	messages        []ParsedMessage
+	toolCallUpdates []ParsedToolCallUpdate
+	endedAt         time.Time
+	consumedBytes   int64
+	initialCursor   codexCursorState
+	cursor          codexCursorState
+	inode           uint64
+	device          uint64
 }
 
 // parseSessionFromDetailed parses only new lines from a Codex JSONL file. It
@@ -2176,7 +2229,7 @@ func (p *codexProvider) parseSessionFromWithSources(
 				fallbackErr = errCodexIncrementalNeedsFullParse
 				return
 			}
-			if codexIncrementalNeedsFullParse(line) {
+			if b.codexIncrementalNeedsFullParse(line) {
 				fallbackErr = errCodexIncrementalNeedsFullParse
 				return
 			}
@@ -2199,13 +2252,14 @@ func (p *codexProvider) parseSessionFromWithSources(
 
 	b.flushPendingAgentResults()
 	result := codexIncrementalParseResult{
-		messages:      b.messages,
-		endedAt:       b.endedAt,
-		consumedBytes: consumed,
-		initialCursor: seed,
-		cursor:        b.incrementalSeed(),
-		inode:         inode,
-		device:        device,
+		messages:        b.messages,
+		toolCallUpdates: b.toolCallUpdates,
+		endedAt:         b.endedAt,
+		consumedBytes:   consumed,
+		initialCursor:   seed,
+		cursor:          b.incrementalSeed(),
+		inode:           inode,
+		device:          device,
 	}
 	return result, nil
 }
@@ -2235,6 +2289,7 @@ func (p *codexProvider) parseSessionFrom(
 // parse error requires the caller to fall back to a full parse.
 func IsIncrementalFullParseFallback(err error) bool {
 	return errors.Is(err, errCodexIncrementalNeedsFullParse) ||
+		errors.Is(err, ErrIncrementalNeedsFullParse) ||
 		errors.Is(err, ErrClaudeIncrementalNeedsFullParse)
 }
 
@@ -2339,6 +2394,13 @@ func isCodexSubagentNotification(content string) bool {
 }
 
 func codexIncrementalNeedsFullParse(line string) bool {
+	b := newCodexSessionBuilder(false)
+	return b.codexIncrementalNeedsFullParse(line)
+}
+
+func (b *codexSessionBuilder) codexIncrementalNeedsFullParse(
+	line string,
+) bool {
 	switch gjson.Get(line, "type").Str {
 	case codexTypeEventMsg:
 		payload := gjson.Get(line, "payload")
@@ -2361,8 +2423,15 @@ func codexIncrementalNeedsFullParse(line string) bool {
 		return isCodexWaitAgentCall(payload.Get("name").Str)
 	case "function_call_output", "custom_tool_call_output":
 		output, raw := parseCodexFunctionOutput(payload)
-		return isCodexSubagentFunctionOutput(output) ||
-			strings.TrimSpace(raw) != ""
+		if isCodexSubagentFunctionOutput(output) {
+			return true
+		}
+		if strings.TrimSpace(raw) == "" {
+			return false
+		}
+		name := b.toolCallNameForOutput(payload.Get("call_id").Str)
+		return name == "" || name == "spawn_agent" ||
+			isCodexWaitAgentCall(name)
 	default:
 		role := payload.Get("role").Str
 		if role != "user" {

--- a/internal/parser/codex_cursor.go
+++ b/internal/parser/codex_cursor.go
@@ -11,14 +11,21 @@ import (
 const (
 	codexCursorCacheMaxEntries = 256
 	codexCursorCacheMaxBytes   = 2 << 20
+	codexCursorMaxPendingCalls = 8
 
 	// Account for the map bucket, list element, pointers, string headers, and
 	// allocator overhead that are not represented by the variable-length path
-	// and cursor strings below. The cache is intentionally an estimate rather
+	// and cursor strings below. The fixed pending-call array contributes two
+	// string headers per slot. The cache is intentionally an estimate rather
 	// than a heap profiler, but this conservative allowance keeps its retained
 	// memory bounded near the configured byte limit.
-	codexCursorEntryOverheadBytes = 256
+	codexCursorEntryOverheadBytes = 256 + codexCursorMaxPendingCalls*32
 )
+
+type codexPendingToolCall struct {
+	id   string
+	name string
+}
 
 // codexCursorState is the compact state needed to make a tail parse behave as
 // though the already-persisted prefix had just been scanned. It deliberately
@@ -35,6 +42,52 @@ type codexCursorState struct {
 	lastTokenUsageSeen       bool
 	forkGate                 codexForkGate
 	lastTaskEvent            string
+	pendingCalls             [codexCursorMaxPendingCalls]codexPendingToolCall
+	pendingCallCount         uint8
+}
+
+func (s *codexCursorState) rememberToolCall(id, name string) bool {
+	id = strings.TrimSpace(id)
+	name = strings.TrimSpace(name)
+	if id == "" || name == "" {
+		return false
+	}
+	for i := 0; i < int(s.pendingCallCount); i++ {
+		if s.pendingCalls[i].id == id {
+			s.pendingCalls[i].name = name
+			return true
+		}
+	}
+	if int(s.pendingCallCount) >= len(s.pendingCalls) {
+		return false
+	}
+	s.pendingCalls[s.pendingCallCount] = codexPendingToolCall{
+		id: id, name: name,
+	}
+	s.pendingCallCount++
+	return true
+}
+
+func (s *codexCursorState) toolCallName(id string) (string, bool) {
+	for i := 0; i < int(s.pendingCallCount); i++ {
+		if s.pendingCalls[i].id == id {
+			return s.pendingCalls[i].name, true
+		}
+	}
+	return "", false
+}
+
+func (s *codexCursorState) forgetToolCall(id string) {
+	for i := 0; i < int(s.pendingCallCount); i++ {
+		if s.pendingCalls[i].id != id {
+			continue
+		}
+		last := int(s.pendingCallCount) - 1
+		copy(s.pendingCalls[i:last], s.pendingCalls[i+1:last+1])
+		s.pendingCalls[last] = codexPendingToolCall{}
+		s.pendingCallCount--
+		return
+	}
 }
 
 // observeUserPrompt advances the first-user replay state using only a digest
@@ -232,6 +285,10 @@ func cloneCodexCursorState(state codexCursorState) codexCursorState {
 	state.cwd = strings.Clone(state.cwd)
 	state.agentPath = strings.Clone(state.agentPath)
 	state.lastTaskEvent = strings.Clone(state.lastTaskEvent)
+	for i := 0; i < int(state.pendingCallCount); i++ {
+		state.pendingCalls[i].id = strings.Clone(state.pendingCalls[i].id)
+		state.pendingCalls[i].name = strings.Clone(state.pendingCalls[i].name)
+	}
 	return state
 }
 
@@ -244,6 +301,15 @@ func estimateCodexCursorEntryBytes(
 			len(state.model)+
 			len(state.cwd)+
 			len(state.agentPath)+
-			len(state.lastTaskEvent),
+			len(state.lastTaskEvent)+
+			codexPendingCallStringBytes(state),
 	)
+}
+
+func codexPendingCallStringBytes(state codexCursorState) int {
+	total := 0
+	for i := 0; i < int(state.pendingCallCount); i++ {
+		total += len(state.pendingCalls[i].id) + len(state.pendingCalls[i].name)
+	}
+	return total
 }

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -2519,7 +2519,7 @@ func TestParseCodexSessionFrom_LateTokenCountRequiresFullParse(t *testing.T) {
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
 
-func TestParseCodexSessionFrom_FunctionCallOutputRequiresFullParse(t *testing.T) {
+func TestParseCodexSessionFrom_FunctionCallOutputUpdatesStoredCall(t *testing.T) {
 	t.Parallel()
 
 	initial := testjsonl.JoinJSONL(
@@ -2549,9 +2549,21 @@ func TestParseCodexSessionFrom_FunctionCallOutputRequiresFullParse(t *testing.T)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = parseCodexTestSessionFrom(t, path, offset, 2, false)
-	require.Error(t, err)
-	assert.True(t, IsIncrementalFullParseFallback(err))
+	result, err := newCodexTestProvider(t).parseSessionFromDetailed(
+		path, offset, 2, false,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, result.messages)
+	require.Len(t, result.toolCallUpdates, 1)
+	assert.Equal(t, "call_cmd", result.toolCallUpdates[0].ToolUseID)
+	assertToolResultEvents(t,
+		result.toolCallUpdates[0].ResultEvents,
+		[]ParsedToolResultEvent{{
+			ToolUseID: "call_cmd",
+			Source:    "function_call_output",
+			Content:   "done",
+		}},
+	)
 }
 
 // TestParseCodexSessionFrom_DedupsReemittedPrompt covers the

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -380,6 +380,7 @@ func (p *codexProvider) ParseIncremental(
 	return IncrementalOutcome{
 		SessionID:            req.SessionID,
 		Messages:             result.messages,
+		ToolCallUpdates:      result.toolCallUpdates,
 		EndedAt:              result.endedAt,
 		ConsumedBytes:        result.consumedBytes,
 		MessageCount:         len(result.messages),

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -725,6 +725,77 @@ func TestCodexProviderIncrementalFirstGenuinePromptNeedsFullParse(t *testing.T) 
 	}
 }
 
+func TestCodexProviderIncrementalCustomToolOutputUpdatesStoredCall(t *testing.T) {
+	const (
+		uuid   = "019eb791-cf7d-75c1-8439-9ed74c1229f7"
+		call   = `{"timestamp":"2026-08-02T09:00:02Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","call_id":"call_patch","input":"*** Begin Patch\n*** End Patch"}}`
+		output = `{"timestamp":"2026-08-02T09:00:03Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_patch","output":"Success. Updated one file.","status":"completed"}}`
+	)
+	prefix := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/workspace/project-a", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "apply the patch", tsEarlyS1),
+		call,
+	)
+	tail := testjsonl.JoinJSONL(output)
+
+	for _, mode := range []string{"warm", "cold"} {
+		t.Run(mode, func(t *testing.T) {
+			root := t.TempDir()
+			content := prefix
+			if mode == "cold" {
+				content += tail
+			}
+			path := writeCodexProviderSessionContent(
+				t, root, uuid, content,
+			)
+			provider, ok := NewProvider(
+				AgentCodex, ProviderConfig{Roots: []string{root}},
+			)
+			require.True(t, ok)
+			source := requireCodexProviderSource(t, provider, uuid)
+
+			if mode == "warm" {
+				fingerprint, err := provider.Fingerprint(
+					context.Background(), source,
+				)
+				require.NoError(t, err)
+				_, err = provider.Parse(context.Background(), ParseRequest{
+					Source: source, Fingerprint: fingerprint,
+				})
+				require.NoError(t, err)
+				appendCodexProviderContent(t, path, tail)
+			}
+
+			fingerprint, err := provider.Fingerprint(
+				context.Background(), source,
+			)
+			require.NoError(t, err)
+			outcome, status, err := provider.ParseIncremental(
+				context.Background(), IncrementalRequest{
+					Source:       source,
+					Fingerprint:  fingerprint,
+					SessionID:    "codex:" + uuid,
+					Offset:       int64(len(prefix)),
+					StartOrdinal: 2,
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, IncrementalApplied, status)
+			assert.Empty(t, outcome.Messages)
+			require.Len(t, outcome.ToolCallUpdates, 1)
+			assert.Equal(t, "call_patch", outcome.ToolCallUpdates[0].ToolUseID)
+			require.Len(t, outcome.ToolCallUpdates[0].ResultEvents, 1)
+			event := outcome.ToolCallUpdates[0].ResultEvents[0]
+			assert.Equal(t, "custom_tool_call_output", event.Source)
+			assert.Equal(t, "completed", event.Status)
+			assert.Equal(t, "Success. Updated one file.", event.Content)
+		})
+	}
+}
+
 func TestCodexProviderColdIncrementalStagesRetryCursorVersions(t *testing.T) {
 	root := t.TempDir()
 	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229ed"

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -1000,6 +1000,7 @@ type IncrementalOutcome struct {
 	SessionID            string
 	Messages             []ParsedMessage
 	SubagentLinks        []ClaudeSubagentLink
+	ToolCallUpdates      []ParsedToolCallUpdate
 	EndedAt              time.Time
 	ConsumedBytes        int64
 	MessageCount         int
@@ -1020,6 +1021,12 @@ const (
 	IncrementalNoNewData
 	IncrementalApplied
 	IncrementalNeedsFullParse
+)
+
+// ErrIncrementalNeedsFullParse is the provider-neutral signal used by the
+// sync adapter when an incremental provider requests an authoritative replace.
+var ErrIncrementalNeedsFullParse = errors.New(
+	"incremental parse requires full parse",
 )
 
 // ProviderFactories returns one provider factory for every registered agent.

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -1225,6 +1225,14 @@ type ParsedToolCall struct {
 	ResultEvents      []ParsedToolResultEvent
 }
 
+// ParsedToolCallUpdate carries result events for a tool call that was parsed
+// before the current append-only chunk. Incremental sync uses the stable
+// tool_use_id to attach these events without rebuilding the whole transcript.
+type ParsedToolCallUpdate struct {
+	ToolUseID    string
+	ResultEvents []ParsedToolResultEvent
+}
+
 // ParsedToolResult holds metadata about a tool result block in a
 // user message (the response to a prior tool_use).
 type ParsedToolResult struct {

--- a/internal/sync/codex_bench_test.go
+++ b/internal/sync/codex_bench_test.go
@@ -7,9 +7,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
@@ -264,4 +266,191 @@ func codexSyncBenchmarkOutcomeValid(
 		outcome.Messages[1].Role == parser.RoleAssistant &&
 		outcome.Messages[1].Content == codexSyncBenchmarkTailAgent &&
 		outcome.Messages[1].Ordinal == startOrdinal+1
+}
+
+const (
+	codexLateToolBenchmarkUUID  = "019eb791-cf7d-75c1-8439-9ed74c122b02"
+	codexLateToolBenchmarkTurns = 250
+)
+
+// BenchmarkCodexIncrementalLateToolOutput measures absorbing a stream in
+// which each batch appends a new function_call plus the function_call_output
+// for the previous batch's call. Output records therefore always refer to a
+// call committed in an earlier sync batch.
+//
+// Before the incremental tool-result path, every such output forced an
+// authoritative full reparse of the whole transcript, so per-op cost scaled
+// with stored history; the incremental path attaches each event to the
+// already-stored call and keeps per-op cost bounded by the
+// fingerprint/prefix-hash reads plus the tiny tail. The session grows by two
+// records per iteration, so per-op cost is only comparable between runs with
+// the same iteration count (the bench gate always runs with a fixed
+// -benchtime=Nx).
+func BenchmarkCodexIncrementalLateToolOutput(b *testing.B) {
+	silenceBenchLogs(b)
+	ctx := context.Background()
+	root, path, _ := writeCodexLateToolBenchmarkTranscript(b)
+
+	database, err := db.Open(filepath.Join(b.TempDir(), "bench.db"))
+	require.NoError(b, err)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {root},
+		},
+		Machine: "benchmark-host",
+	})
+	b.Cleanup(func() {
+		engine.Close()
+		if err := database.Close(); err != nil {
+			b.Errorf("close bench db: %v", err)
+		}
+	})
+
+	first := engine.SyncAll(ctx, nil)
+	require.Equal(b, 1, first.Synced)
+	require.Zero(b, first.Failed)
+
+	// Stretch the debounce window so the flush timer cannot fire inside
+	// the timed loop (same rationale as BenchmarkSyncPathsIncrementalAppend).
+	engine.signalSched.mu.Lock()
+	engine.signalSched.interval = time.Hour
+	engine.signalSched.quiet = time.Hour
+	engine.signalSched.mu.Unlock()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(b, err)
+	defer f.Close()
+
+	// Pre-build the appended lines: constructing JSONL inside the timed loop
+	// would allocate and be gated as if it were sync work. Iteration i appends
+	// call_{i+1} and the output for call_i, so the output is always "late".
+	lines := make([]string, b.N)
+	for i := range lines {
+		lines[i] = testjsonl.JoinJSONL(
+			testjsonl.CodexFunctionCallWithCallIDJSON(
+				"exec_command",
+				codexLateToolBenchmarkCall(i+1),
+				nil,
+				codexLateToolBenchmarkTS(2*i+1),
+			),
+			testjsonl.CodexFunctionCallOutputJSON(
+				codexLateToolBenchmarkCall(i),
+				"result "+strconv.Itoa(i),
+				codexLateToolBenchmarkTS(2*i+2),
+			),
+		)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		if _, err := f.WriteString(lines[i]); err != nil {
+			b.Fatalf("append: %v", err)
+		}
+		stats := engine.SyncAll(ctx, nil)
+		if stats.Failed != 0 {
+			b.Fatalf("sync failed for appended output: %+v", stats)
+		}
+	}
+	b.StopTimer()
+
+	msgs, err := database.GetAllMessages(ctx, "codex:"+codexLateToolBenchmarkUUID)
+	require.NoError(b, err)
+	wantMsgs := 3 + 2*codexLateToolBenchmarkTurns + b.N
+	require.Len(b, msgs, wantMsgs,
+		"each appended call adds exactly one message row")
+	results := make(map[string]db.ToolCall, len(msgs))
+	for i := range msgs {
+		for j := range msgs[i].ToolCalls {
+			results[msgs[i].ToolCalls[j].ToolUseID] = msgs[i].ToolCalls[j]
+		}
+	}
+	for i := range b.N {
+		call, ok := results[codexLateToolBenchmarkCall(i)]
+		require.True(b, ok, "call %d must be stored", i)
+		assert.Equal(b, "exec_command", call.ToolName)
+		assert.Equal(b, "result "+strconv.Itoa(i), call.ResultContent)
+		require.Len(b, call.ResultEvents, 1,
+			"each call must carry exactly its own output event")
+		assert.Equal(b, "result "+strconv.Itoa(i), call.ResultEvents[0].Content)
+	}
+	newest, ok := results[codexLateToolBenchmarkCall(b.N)]
+	require.True(b, ok, "the newest call must be stored")
+	assert.Empty(b, newest.ResultContent)
+	assert.Empty(b, newest.ResultEvents)
+}
+
+func codexLateToolBenchmarkCall(i int) string {
+	return "call_" + strconv.Itoa(i)
+}
+
+func codexLateToolBenchmarkTS(i int) string {
+	return time.Date(
+		2026, 7, 10, 7, 12, i, 0, time.UTC,
+	).Format("2006-01-02T15:04:05Z")
+}
+
+func writeCodexLateToolBenchmarkTranscript(
+	b testing.TB,
+) (root, path, prefix string) {
+	b.Helper()
+	root = filepath.Join(b.TempDir(), "sessions")
+	path = filepath.Join(
+		root,
+		"2026",
+		"07",
+		"10",
+		"rollout-2026-07-10T07-12-15-"+codexLateToolBenchmarkUUID+".jsonl",
+	)
+	require.NoError(b, os.MkdirAll(filepath.Dir(path), 0o755))
+
+	fixture := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			"2026-07-10T07:00:00Z",
+			codexLateToolBenchmarkUUID,
+			"/workspace/project-a",
+			"codex_cli_rs",
+		).
+		AddRaw(testjsonl.CodexTurnContextJSON(
+			"gpt-5.4", "2026-07-10T07:00:01Z",
+		)).
+		AddCodexMessage(
+			"2026-07-10T07:00:02Z",
+			"user",
+			"Initial request: inspect the project and make a careful change.",
+		).
+		AddCodexMessage(
+			"2026-07-10T07:00:03Z",
+			"assistant",
+			"Initial response: I will inspect the relevant code and tests.",
+		)
+	contextPayload := strings.Repeat(
+		"Retain concrete code, test, and validation context. ", 8,
+	)
+	for i := range codexLateToolBenchmarkTurns {
+		turn := strconv.Itoa(i)
+		fixture.AddCodexMessage(
+			"2026-07-10T07:01:00Z",
+			"user",
+			"Prior turn "+turn+" request: continue the implementation. "+
+				contextPayload,
+		)
+		fixture.AddCodexMessage(
+			"2026-07-10T07:01:01Z",
+			"assistant",
+			"Prior turn "+turn+" response: applied the next bounded change. "+
+				contextPayload,
+		)
+	}
+	// call_0 is committed in the prefix with no output; iteration 0 appends
+	// call_1 plus the late output for call_0.
+	fixture.AddRaw(testjsonl.CodexFunctionCallWithCallIDJSON(
+		"exec_command",
+		"call_0",
+		nil,
+		codexLateToolBenchmarkTS(0),
+	))
+	prefix = fixture.String()
+	require.NoError(b, os.WriteFile(path, []byte(prefix), 0o644))
+	return root, path, prefix
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8299,6 +8299,7 @@ type incrementalUpdate struct {
 	cwd                  string
 	msgs                 []parser.ParsedMessage
 	links                []parser.ClaudeSubagentLink
+	toolCallUpdates      []parser.ParsedToolCallUpdate
 	endedAt              time.Time
 	terminationStatus    *string
 	msgCount             int // total (old + new)
@@ -10807,7 +10808,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 
 	parseFn := func(
 		_ string, inc *db.IncrementalInfo,
-	) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error) {
+	) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
 		// The Claude parser needs the stored tail's provider message id
 		// so its queued-command masking fallback fires only for a real
 		// same-message.id continuation; without it, every routine queued
@@ -10835,24 +10836,24 @@ func (e *Engine) tryProviderIncrementalAppend(
 			},
 		)
 		if perr != nil {
-			return nil, nil, time.Time{}, 0, nil, perr
+			return nil, nil, nil, time.Time{}, 0, nil, perr
 		}
 		switch status {
 		case parser.IncrementalNeedsFullParse:
 			if outcome.ForceReplace {
 				// Signal the shared helper to fall back to a
 				// full parse that replaces stored messages.
-				return nil, nil, time.Time{}, 0, nil,
-					parser.ErrClaudeIncrementalNeedsFullParse
+				return nil, nil, nil, time.Time{}, 0, nil,
+					parser.ErrIncrementalNeedsFullParse
 			}
 			// A plain full-parse fallback without a replace request.
 			// The Claude provider always sets ForceReplace on its
 			// fallbacks (a DAG fork can drop or re-branch stored
 			// rows), so this branch serves providers that only need
 			// an append-preserving full parse.
-			return nil, nil, time.Time{}, 0, nil, parser.ErrDAGDetected
+			return nil, nil, nil, time.Time{}, 0, nil, parser.ErrDAGDetected
 		case parser.IncrementalNoNewData:
-			return nil, nil, time.Time{}, 0, nil, nil
+			return nil, nil, nil, time.Time{}, 0, nil, nil
 		default:
 			var terminationStatus *string
 			if outcome.TerminationStatus != nil {
@@ -10860,6 +10861,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 				terminationStatus = &status
 			}
 			return outcome.Messages, outcome.SubagentLinks,
+				outcome.ToolCallUpdates,
 				outcome.EndedAt, outcome.ConsumedBytes, terminationStatus, nil
 		}
 	}
@@ -10875,7 +10877,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 // only complete, valid JSON lines so it can be used as a safe resume offset.
 type incrementalParseFunc func(
 	path string, inc *db.IncrementalInfo,
-) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error)
+) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error)
 
 // tryIncrementalJSONL attempts an incremental parse of an
 // append-only JSONL file by reading only bytes appended since
@@ -10997,7 +10999,7 @@ func (e *Engine) tryIncrementalJSONL(
 		return processResult{err: leaseErr}, true
 	}
 
-	newMsgs, links, endedAt, consumed, terminationStatus, err := parseFn(
+	newMsgs, links, toolCallUpdates, endedAt, consumed, terminationStatus, err := parseFn(
 		file.Path, inc,
 	)
 	if err != nil {
@@ -11054,6 +11056,7 @@ func (e *Engine) tryIncrementalJSONL(
 					machine:              inc.Machine,
 					cwd:                  inc.Cwd,
 					links:                links,
+					toolCallUpdates:      toolCallUpdates,
 					endedAt:              endedAt,
 					terminationStatus:    terminationStatus,
 					msgCount:             inc.MsgCount,
@@ -11173,6 +11176,7 @@ func (e *Engine) tryIncrementalJSONL(
 			cwd:                  inc.Cwd,
 			msgs:                 newMsgs,
 			links:                links,
+			toolCallUpdates:      toolCallUpdates,
 			endedAt:              endedAt,
 			terminationStatus:    terminationStatus,
 			msgCount:             inc.MsgCount + len(newMsgs),
@@ -14009,6 +14013,24 @@ func (e *Engine) writeIncremental(
 			HasResult:        link.HasResult,
 		}
 	}
+	toolCallResultUpdates := make(
+		[]db.ToolCallResultUpdate, len(inc.toolCallUpdates),
+	)
+	for i, update := range inc.toolCallUpdates {
+		toolCall := db.ToolCall{
+			ResultEvents: convertToolResultEvents(update.ResultEvents),
+		}
+		for j := range toolCall.ResultEvents {
+			toolCall.ResultEvents[j].SubagentSessionID = applyIDPrefixToID(
+				e.idPrefix, toolCall.ResultEvents[j].SubagentSessionID,
+			)
+		}
+		e.anomalies.recordSanitize(db.SanitizeToolCall(&toolCall))
+		toolCallResultUpdates[i] = db.ToolCallResultUpdate{
+			ToolUseID: update.ToolUseID,
+			Events:    toolCall.ResultEvents,
+		}
+	}
 
 	if err := e.db.WriteSessionIncremental(
 		inc.sessionID,
@@ -14028,6 +14050,7 @@ func (e *Engine) writeIncremental(
 			HasTotalOutputTokens:    inc.hasTotalOutputTokens,
 			HasPeakContextTokens:    inc.hasPeakContextTokens,
 			SubagentLinks:           subagentLinks,
+			ToolCallResultUpdates:   toolCallResultUpdates,
 			BlockedResultCategories: e.blockedResultCategories,
 		},
 	); err != nil {
@@ -15974,7 +15997,7 @@ func pairToolResultEventSummaries(
 			if len(tc.ResultEvents) == 0 {
 				continue
 			}
-			summary := summarizeToolResultEvents(tc.ResultEvents)
+			summary := db.SummarizeToolResultEvents(tc.ResultEvents)
 			tc.ResultContentLength = len(summary)
 			if blocked[tc.Category] {
 				tc.ResultContent = ""
@@ -15986,62 +16009,6 @@ func pairToolResultEventSummaries(
 			tc.ResultContent = summary
 		}
 	}
-}
-
-func summarizeToolResultEvents(
-	events []db.ToolResultEvent,
-) string {
-	if len(events) == 0 {
-		return ""
-	}
-	type agentSummary struct {
-		order   int
-		content string
-	}
-	latestByAgent := map[string]agentSummary{}
-	orderedAgents := make([]string, 0, len(events))
-	lastAnon := ""
-	allHaveAgentID := true
-	for _, ev := range events {
-		if strings.TrimSpace(ev.Content) == "" {
-			continue
-		}
-		agentID := strings.TrimSpace(ev.AgentID)
-		if agentID == "" {
-			allHaveAgentID = false
-			lastAnon = ev.Content
-			continue
-		}
-		if _, ok := latestByAgent[agentID]; !ok {
-			latestByAgent[agentID] = agentSummary{
-				order:   len(orderedAgents),
-				content: ev.Content,
-			}
-			orderedAgents = append(orderedAgents, agentID)
-			continue
-		}
-		entry := latestByAgent[agentID]
-		entry.content = ev.Content
-		latestByAgent[agentID] = entry
-	}
-	if len(latestByAgent) <= 1 {
-		if len(latestByAgent) == 1 {
-			summary := latestByAgent[orderedAgents[0]].content
-			if lastAnon != "" {
-				return summary + "\n\n" + lastAnon
-			}
-			return summary
-		}
-		return lastAnon
-	}
-	parts := make([]string, 0, len(orderedAgents))
-	for _, agentID := range orderedAgents {
-		parts = append(parts, agentID+":\n"+latestByAgent[agentID].content)
-	}
-	if !allHaveAgentID && lastAnon != "" {
-		parts = append(parts, lastAnon)
-	}
-	return strings.Join(parts, "\n\n")
 }
 
 // emit fires a refresh event if an emitter is wired. Safe to call

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -13383,6 +13383,9 @@ func TestIncrementalSync_CodexExecAppendRetainsEvents(t *testing.T) {
 		"rollout-20240101-inc-cx-exec.jsonl", initial,
 	)
 	env.engine.SyncAll(context.Background(), nil)
+	before := fetchMessages(t, env.db, "codex:inc-cx-exec")
+	require.Len(t, before, 2)
+	toolMessageID := before[1].ID
 
 	appended := testjsonl.JoinJSONL(
 		testjsonl.CodexFunctionCallOutputJSON(
@@ -13401,9 +13404,31 @@ func TestIncrementalSync_CodexExecAppendRetainsEvents(t *testing.T) {
 
 	msgs := fetchMessages(t, env.db, "codex:inc-cx-exec")
 	require.Len(t, msgs, 2)
+	assert.Equal(t, toolMessageID, msgs[1].ID,
+		"result-only append must preserve the existing tool message")
 	require.Len(t, msgs[1].ToolCalls, 1)
-	assert.Equal(t, "exec_command", msgs[1].ToolCalls[0].ToolName, "tool name")
-	assert.Equal(t, "done", msgs[1].ToolCalls[0].ResultContent, "result_content")
+	call := msgs[1].ToolCalls[0]
+	assert.Equal(t, "exec_command", call.ToolName, "tool name")
+	assert.Equal(t, "done", call.ResultContent, "result_content")
+	require.Len(t, call.ResultEvents, 1)
+	assert.Equal(t, "function_call_output", call.ResultEvents[0].Source)
+	assert.Equal(t, "done", call.ResultEvents[0].Content)
+	afterIncremental, err := env.db.GetSessionFull(
+		context.Background(), "codex:inc-cx-exec",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, afterIncremental)
+	assert.True(t, afterIncremental.LastWriteIncremental)
+
+	env.engine.ResyncAll(context.Background(), nil)
+	fullMsgs := fetchMessages(t, env.db, "codex:inc-cx-exec")
+	require.Len(t, fullMsgs, 2)
+	require.Len(t, fullMsgs[1].ToolCalls, 1)
+	fullCall := fullMsgs[1].ToolCalls[0]
+	assert.Equal(t, call.ResultContent, fullCall.ResultContent)
+	assert.Equal(t, call.ResultContentLength, fullCall.ResultContentLength)
+	assert.Equal(t, call.ResultEvents, fullCall.ResultEvents,
+		"incremental and authoritative full parses must store the same events")
 }
 
 func TestIncrementalSync_CodexLateTokenCountRewritesStoredMessage(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -6403,11 +6403,11 @@ func TestProjectIdentityIncrementalStatePreservesExplicitSourceProject(
 				func(
 					_ string,
 					inc *db.IncrementalInfo,
-				) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error) {
+				) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
 					return []parser.ParsedMessage{{
 						Role: parser.RoleAssistant, Content: "appended",
 						Ordinal: inc.NextOrdinal,
-					}}, nil, appendedInfo.ModTime(), int64(len(appended)), nil, nil
+					}}, nil, nil, appendedInfo.ModTime(), int64(len(appended)), nil, nil
 				},
 			)
 			require.True(t, ok)
@@ -6504,9 +6504,9 @@ func TestProjectIdentityLegacyMappedSnapshotReparsesBeforeIncrementalAppend(
 		func(
 			_ string,
 			_ *db.IncrementalInfo,
-		) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error) {
+		) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
 			parseCalled = true
-			return nil, nil, time.Time{}, 0, nil, nil
+			return nil, nil, nil, time.Time{}, 0, nil, nil
 		},
 	)
 	assert.False(t, ok,


### PR DESCRIPTION
## What

Codex tool outputs can arrive in a later sync batch than the `function_call`
that created them. Previously any non-empty `function_call_output` /
`custom_tool_call_output` whose call was not parsed in the current batch forced
an authoritative full transcript reparse — O(history) per late output, and a
tool-call-dense session spent most of its syncs reparsing the whole file.

This PR makes late tool results incremental:

- `internal/parser`: the Codex incremental cursor tracks a bounded set of
  pending tool calls (id + name, max 8). Cold seeding replays only
  pending-call bookkeeping. A late output is parsed into
  `ParsedToolCallUpdate` instead of raising `ErrIncrementalNeedsFullParse`,
  unless the call is unknown or agent-scoped (`spawn_agent` / `wait_agent`).
- `internal/sync`: `incrementalUpdate` carries `toolCallUpdates` into
  `writeIncremental`, sanitized (blocked result categories, subagent ID
  prefixes).
- `internal/db`: `WriteSessionIncremental` applies `ToolCallResultUpdate`
  transactionally by stable `tool_use_id`: appends only non-duplicate events,
  recomputes the display summary through the shared
  `SummarizeToolResultEvents` (same code as authoritative parses), and bumps
  the transcript revision exactly once.

## Performance

New gated benchmark `BenchmarkCodexIncrementalLateToolOutput` (a stream where
each batch appends a call plus the previous batch's call output). `make
bench-gate` on merge base vs head on the same runner
(`-benchtime=20x -count=6`):

| metric | base | head | ratio |
|---|---:|---:|---:|
| sec/op | 26.04ms | 4.95ms | 0.19x |
| B/op | 3.86Mi | 358Ki | 0.09x |
| allocs/op | 16.65k | 1.79k | 0.11x |

All existing gated benchmarks stayed within thresholds; `cmd/benchgate`
reports no regressions.

## Correctness

- Warm and cold incremental custom tool output updates (`internal/parser`).
- Idempotent DB result updates; replay does not bump the transcript revision
  (`internal/db`).
- Engine integration: an appended `exec_command` output preserves the stored
  tool message row and matches an authoritative resync event-for-event
  (`internal/sync`).

## Residual costs

The full-source fingerprint hash, cold-start cursor reconstruction, and
committed-prefix re-hash remain O(S) per sync; a rolling-hash or
persisted-cursor design is a follow-up.
