### PR TITLE
test(e2e): report failed runtime requests

### DIFF
--- a/frontend/e2e/helpers/runtime-error-monitor.ts
+++ b/frontend/e2e/helpers/runtime-error-monitor.ts
@@ -7,6 +7,7 @@ import type { Page } from "@playwright/test";
  */
 export class RuntimeErrorMonitor {
   private readonly errors: string[] = [];
+  private readonly networkDiagnostics: string[] = [];
 
   constructor(page: Page) {
     page.on("pageerror", (err) => {
@@ -14,8 +15,30 @@ export class RuntimeErrorMonitor {
     });
     page.on("console", (msg) => {
       if (msg.type() === "error") {
-        this.errors.push(msg.text());
+        const location = msg.location();
+        const suffix = location.url
+          ? ` (${formatURL(location.url, page.url())}:${location.line + 1}:${location.column + 1})`
+          : "";
+        this.errors.push(`${msg.text()}${suffix}`);
       }
+    });
+    page.on("response", (response) => {
+      if (response.status() < 400 || !isMonitoredOrigin(response.url(), page)) {
+        return;
+      }
+      const request = response.request();
+      this.networkDiagnostics.push(
+        `HTTP ${response.status()} ${request.method()} ${formatURL(response.url(), page.url())} [${request.resourceType()}]`,
+      );
+    });
+    page.on("requestfailed", (request) => {
+      if (!isMonitoredOrigin(request.url(), page)) {
+        return;
+      }
+      const errorText = request.failure()?.errorText ?? "unknown error";
+      this.networkDiagnostics.push(
+        `REQUEST FAILED ${request.method()} ${formatURL(request.url(), page.url())} [${request.resourceType()}]: ${errorText}`,
+      );
     });
   }
 
@@ -38,5 +61,43 @@ export class RuntimeErrorMonitor {
       pattern.lastIndex = 0;
       return !pattern.test(m);
     });
+  }
+
+  /** Failed HTTP responses and requests observed while the test ran. */
+  diagnostics(): readonly string[] {
+    return this.networkDiagnostics;
+  }
+
+  /** Network context suitable for an assertion failure message. */
+  diagnosticSummary(): string {
+    if (this.networkDiagnostics.length === 0) {
+      return "Network diagnostics: none recorded";
+    }
+    return `Network diagnostics:\n${this.networkDiagnostics.join("\n")}`;
+  }
+}
+
+function isMonitoredOrigin(rawURL: string, page: Page): boolean {
+  try {
+    const requestURL = new URL(rawURL);
+    const pageURL = new URL(page.url());
+    return requestURL.origin === pageURL.origin;
+  } catch {
+    return false;
+  }
+}
+
+function formatURL(rawURL: string, pageURL: string): string {
+  try {
+    const url = new URL(rawURL);
+    const current = new URL(pageURL);
+    const origin = url.origin === current.origin ? "" : url.origin;
+    const query = Array.from(
+      url.searchParams.keys(),
+      (key) => `${encodeURIComponent(key)}=[redacted]`,
+    ).join("&");
+    return `${origin}${url.pathname}${query ? `?${query}` : ""}`;
+  } catch {
+    return rawURL;
   }
 }

--- a/frontend/e2e/runtime-error-monitor.spec.ts
+++ b/frontend/e2e/runtime-error-monitor.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+import { RuntimeErrorMonitor } from "./helpers/runtime-error-monitor";
+
+test.describe("Runtime error diagnostics", () => {
+  test("adds a source location to console errors", async ({ page }) => {
+    const monitor = new RuntimeErrorMonitor(page);
+    await page.route("**/diagnostic-console-error.js", async (route) => {
+      await route.fulfill({
+        contentType: "application/javascript",
+        body: 'console.error("diagnostic console failure");',
+      });
+    });
+    await page.goto("/");
+
+    await page.evaluate(async () => {
+      const script = document.createElement("script");
+      script.src = "/diagnostic-console-error.js";
+      const loaded = new Promise<void>((resolve, reject) => {
+        script.addEventListener("load", () => resolve());
+        script.addEventListener("error", () =>
+          reject(new Error("diagnostic script failed to load")),
+        );
+      });
+      document.head.append(script);
+      await loaded;
+    });
+
+    await expect
+      .poll(() =>
+        monitor
+          .all()
+          .some((message) =>
+            /^diagnostic console failure \(\/diagnostic-console-error\.js:\d+:\d+\)$/.test(message),
+          ),
+      )
+      .toBe(true);
+  });
+
+  test("identifies a failed HTTP response", async ({ page }) => {
+    const monitor = new RuntimeErrorMonitor(page);
+    await page.route("**/diagnostic-http-failure*", async (route) => {
+      await route.fulfill({ status: 404, body: "missing" });
+    });
+    await page.goto("/");
+
+    const status = await page.evaluate(async () => {
+      const response = await fetch("/diagnostic-http-failure?token=private-value");
+      return response.status;
+    });
+
+    expect(status).toBe(404);
+    await expect
+      .poll(() => monitor.diagnostics())
+      .toContain("HTTP 404 GET /diagnostic-http-failure?token=[redacted] [fetch]");
+  });
+
+  test("identifies a request without an HTTP response", async ({ page }) => {
+    const monitor = new RuntimeErrorMonitor(page);
+    await page.route("**/diagnostic-network-failure", async (route) => {
+      await route.abort("failed");
+    });
+    await page.goto("/");
+
+    await page.evaluate(async () => {
+      await fetch("/diagnostic-network-failure").catch(() => undefined);
+    });
+
+    await expect
+      .poll(() =>
+        monitor
+          .diagnostics()
+          .some((message) =>
+            /^REQUEST FAILED GET \/diagnostic-network-failure \[fetch\]: .+/.test(message),
+          ),
+      )
+      .toBe(true);
+  });
+});

--- a/frontend/e2e/runtime-stability.spec.ts
+++ b/frontend/e2e/runtime-stability.spec.ts
@@ -45,7 +45,7 @@ test.describe("Runtime stability", () => {
           throw error;
         }
         throw new Error(
-          `session startup failed after browser errors:\n${startupErrors.join("\n")}`,
+          `session startup failed after browser errors:\n${startupErrors.join("\n")}\n${monitor.diagnosticSummary()}`,
           { cause: error },
         );
       }
@@ -75,7 +75,7 @@ test.describe("Runtime stability", () => {
       const otherErrors = monitor
         .excluding(DEPTH_ERROR_RE)
         .filter((m) => !KNOWN_SVELTE_WARNINGS_RE.test(m));
-      expect(otherErrors).toEqual([]);
+      expect(otherErrors, monitor.diagnosticSummary()).toEqual([]);
     },
   );
 });


### PR DESCRIPTION
Opaque browser console failures currently report messages such as a bare 404 without identifying the request. This adds same-origin HTTP and transport diagnostics to the E2E runtime monitor, redacts query values, and includes the context in runtime-stability assertion failures.

It also attaches console source locations when available and adds Chromium/WebKit coverage for HTTP errors, aborted requests, and console locations. Network diagnostics remain context only, so the existing pass/fail behavior is unchanged.