### PR TITLE
feat(sync): persist Codex parse checkpoints and bound bulk memory

### DIFF
--- a/docs/internal/background-sync-efficiency.md
+++ b/docs/internal/background-sync-efficiency.md
@@ -63,17 +63,36 @@ aggregates.
 
 Cursor correctness assumes that growth is append-only. A same-inode file can
 grow after bytes inside its already-committed prefix have been rewritten. Size,
-identity, and boundary checks do not detect that case, and the current
-full-source fingerprint is not compared with a separately verified stored prefix
-before incremental parsing. Closing this gap would require rolling hash state or
-explicit prefix verification and remains deferred.
+identity, and boundary checks cannot prove the prefix was never modified.
+
+Persisted checkpoints close most of the gap under the documented append-trust
+mode:
+
+- The checkpoint stores a 128 KiB tail anchor of the committed prefix, the
+  file identity, the committed offset, the parser cursor, and a resumable
+  SHA-256 state over the committed prefix.
+- An append is only resumed when the identity matches, the size only grew,
+  and the current bytes at the anchor region match the stored anchor; the
+  full-file fingerprint is then derived by hashing only the appended bytes.
+- An unchanged checkpointed source is skipped on stat alone (no transcript
+  read). An anchor mismatch, identity change, truncation, or undecodable
+  checkpoint forces an authoritative full parse and checkpoint rebuild.
+- A same-size, same-mtime in-place rewrite that preserves the anchor region is
+  trusted (append-trust). Periodic full audits (`ResyncAll`, `--full`,
+  force-reverification passes) still hash the whole source and repair such
+  rewrites. Strict verification remains available by bypassing the checkpoint
+  gate.
 
 ## Cost model and regression evidence
 
 A warm Codex cursor makes continuation-state parsing scale with appended records
-rather than transcript history. End-to-end append sync is still O(file): the
-provider's `Fingerprint` hashes the complete source and the engine's
-`ComputeFileHashPrefix` hashes through the newly committed offset.
+rather than transcript history. With a persisted checkpoint, end-to-end append
+sync is O(d): the engine resumes the SHA-256 state over only the appended
+bytes, verifies the 128 KiB tail anchor, and parses only the new tail. An
+unchanged checkpointed source costs a stat and a DB lookup, not a transcript
+read. Without a checkpoint (legacy sessions, first sync after upgrade) the
+previous O(file) fingerprint and prefix-hash reads still apply until the next
+full parse persists one.
 
 - `BenchmarkCodexIncrementalCursor` in `internal/parser` compares cold prefix
   reconstruction with the exact warm cursor. It is diagnostic because
@@ -84,7 +103,8 @@ provider's `Fingerprint` hashes the complete source and the engine's
 - `BenchmarkCodexIncrementalLateToolOutput` in `internal/sync` measures a
   stream where every appended batch carries the output for the previous
   batch's call: the base code reparses the whole transcript per batch, while
-  the incremental path attaches each event to its stored call.
+  the checkpoint path attaches each event to its stored call and hashes only
+  the appended bytes.
 
 The maintained behavioral gate inventory is in
 [Performance Gates](performance-gates.md).

--- a/docs/internal/background-sync-efficiency.md
+++ b/docs/internal/background-sync-efficiency.md
@@ -50,9 +50,14 @@ they are never published as safe cursor boundaries.
 
 Truncation, known file-identity replacement, manual or project refreshes,
 `session_index.jsonl` title changes, and records that retroactively update
-stored messages all fall back to an authoritative full replacement. Safe
-incremental writes preserve the index-folded mtime and lifecycle-derived
-termination status alongside message and token aggregates.
+stored messages all fall back to an authoritative full replacement. Late tool
+results are the exception: the cursor tracks pending tool calls (bounded), so
+a `function_call_output` / `custom_tool_call_output` that refers to a call
+committed in an earlier batch is applied as an idempotent point update
+(`ToolCallResultUpdates`) instead of a full reparse. Agent-scoped and unknown
+calls still fall back. Safe incremental writes preserve the index-folded mtime
+and lifecycle-derived termination status alongside message and token
+aggregates.
 
 ## Append-only limitation
 
@@ -76,6 +81,10 @@ provider's `Fingerprint` hashes the complete source and the engine's
 - `BenchmarkCodexIncrementalSyncReads` in `internal/sync` measures the warm tail
   between the two remaining linear reads. It is PR-gated because
   `internal/sync` is in `BENCH_GATE_PACKAGES`.
+- `BenchmarkCodexIncrementalLateToolOutput` in `internal/sync` measures a
+  stream where every appended batch carries the output for the previous
+  batch's call: the base code reparses the whole transcript per batch, while
+  the incremental path attaches each event to its stored call.
 
 The maintained behavioral gate inventory is in
 [Performance Gates](performance-gates.md).

--- a/docs/internal/performance-gates.md
+++ b/docs/internal/performance-gates.md
@@ -17,6 +17,7 @@ contracts are documented in
 | Discovery O(sources) root work | Gemini rebuilt its project map per session; positron/vscode-copilot re-read `workspace.json` per session. A large store spent 2m47s in discovery.                                                       | #912                                           |
 | Unchanged sources reparsed     | The provider migration dropped pre-parse DB-freshness skips; every full sync reparsed and rewrote untouched sessions.                                                                                   | `providerSourceUnchangedInDB` (#883 follow-up) |
 | O(history) incremental appends | Every streamed line ran a full signal recompute (reload all messages, secret regex scan) and chunk merges delete+reinserted every message row. ~4,700 session updates/day each paid O(session history). | #954                                           |
+| O(file) warm Codex appends     | A warm append still hashed the full source for the fingerprint and re-hashed the committed prefix after every write; late tool outputs forced a full transcript reparse, and unchanged startup hashed every source before the DB freshness skip. | persisted parser checkpoints (this PR)         |
 | Bulk ingest throughput         | Full resync ran per-row inserts and rebuilt FTS incrementally; 26.7k sessions took 1m17s.                                                                                                               | #411                                           |
 | Event storms                   | One SSE emit per watcher flush drove ~1/s dashboard refetch; SQLite WAL sidecar events fanned out to every session in a shared DB.                                                                      | #367, #956                                     |
 | Per-row query shape            | `GetDailyUsage` ran 1.2M `json_extract` calls per scan and had no date pushdown.                                                                                                                        | #309                                           |
@@ -37,6 +38,18 @@ runner noise and fail loudly:
 - `TestWriteIncrementalDebouncesSignalRecompute` and the rest of
   `internal/sync/signal_schedule_test.go` — streaming appends must debounce
   the O(history) signal recompute.
+- `TestCodexCheckpoint*` in `internal/sync/checkpoint_test.go` — a full Codex
+  parse persists a checkpoint, an append resumes from it and advances it
+  atomically with the delta, truncation/anchor mismatch force an
+  authoritative rebuild, and an unchanged checkpointed source is trusted on
+  stat alone (append-trust; the audit path still catches rewrites).
+- `TestParserCheckpointRoundTrip` and
+  `TestWriteSessionIncrementalPersistsCheckpointInSameTx` (`internal/db`) —
+  checkpoint rows round-trip and are committed in the same transaction as the
+  incremental delta.
+- `TestFullSyncPassIsByteBudgeted`, `TestBulkParseRetentionBudgetUsesWeightedAdmission`,
+  and `TestCollectAndBatchFlushesOnByteCap` (`internal/sync`) — bulk passes
+  and write batches are bounded by estimated bytes, not session count alone.
 - The count-based seam tests in `internal/parser`
   (`discovery_workspace_manifest_test.go`, gemini/antigravity provider tests)
   — root-derived project info is built once per root, not once per source.
@@ -79,9 +92,13 @@ head and its merge base on the same runner, then compares the outputs with
 - `BenchmarkSyncPathsIncrementalAppend` — absorb one appended line into a
   1,000-message session.
 - `BenchmarkCodexIncrementalSyncReads` — a warm Codex cursor append plus the
-  remaining full-source fingerprint and committed-prefix hash reads. See
+  remaining full-source fingerprint and committed-prefix hash reads (the
+  pre-checkpoint cost model). See
   [Background Sync Efficiency](background-sync-efficiency.md) for the
   cost-model boundary.
+- `BenchmarkCodexIncrementalLateToolOutput` — a checkpoint-resumed Codex
+  append stream: the base code reparses the transcript and re-hashes the
+  source per batch, the checkpoint path hashes only the appended bytes.
 - `BenchmarkSyncAllColdArchive` — first-sync ingest throughput through the
   default per-session write path.
 - `BenchmarkResyncBulkIngest` — the same archive through the resync bulk-write

--- a/docs/internal/performance-gates.md
+++ b/docs/internal/performance-gates.md
@@ -54,10 +54,13 @@ runner noise and fail loudly:
   warm/cold parsing remains equivalent at safe offsets.
 - `TestIncrementalSync_CodexAppend`,
   `TestIncrementalSync_CodexLifecycleTailUpdatesTermination`, the partial-tail
-  tests, and the late-update/title tests in
+  tests, the late tool-result append test
+  (`TestIncrementalSync_CodexExecAppendRetainsEvents`), and the
+  late-update/title tests in
   `internal/sync/engine_integration_test.go` — safe Codex growth appends only
-  new rows while lifecycle metadata, incomplete records, title changes, and
-  retroactive updates preserve full-parse behavior.
+  new rows, late tool results update stored calls in place, and lifecycle
+  metadata, incomplete records, title changes, and other retroactive updates
+  preserve full-parse behavior.
 
 When you fix a performance bug, prefer adding a gate at this layer: expose or
 reuse a counter (`SyncStats`, `PhaseStats`, `AnomalyStats`, a swappable

--- a/internal/db/checkpoint.go
+++ b/internal/db/checkpoint.go
@@ -1,0 +1,147 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ParserCheckpointVersion is the codec version for parser_checkpoints rows.
+// Bump it when the cursor or hash-state encoding changes; a version mismatch
+// makes the engine fall back to a full parse instead of resuming.
+const ParserCheckpointVersion = 1
+
+// ParserCheckpoint is the machine-local continuation state needed to resume
+// parsing an append-only transcript without re-reading the committed prefix:
+// the committed byte offset, a tail anchor proving the boundary region is
+// unchanged, the provider cursor, and the resumable SHA-256 state.
+type ParserCheckpoint struct {
+	SessionID   string
+	Agent       string
+	FilePath    string
+	FileInode   uint64
+	FileDevice  uint64
+	FileMTime   int64
+	Offset      int64
+	TailAnchor  []byte
+	Cursor      []byte
+	HashState   []byte
+	Hash        string
+	NextOrdinal int
+	Version     int
+	UpdatedAt   string
+}
+
+// GetParserCheckpoint loads the checkpoint for a session. ok=false means no
+// row exists (legacy session or never checkpointed), which is not an error.
+func (db *DB) GetParserCheckpoint(
+	sessionID string,
+) (*ParserCheckpoint, bool, error) {
+	var cp ParserCheckpoint
+	var inode, device, nextOrdinal int64
+	err := db.getReader().QueryRow(
+		`SELECT agent, file_path, file_inode, file_device, file_mtime,
+		        offset, tail_anchor, cursor, hash_state, hash,
+		        next_ordinal, checkpoint_version, updated_at
+		 FROM parser_checkpoints
+		 WHERE session_id = ?`,
+		sessionID,
+	).Scan(
+		&cp.Agent, &cp.FilePath, &inode, &device, &cp.FileMTime,
+		&cp.Offset, &cp.TailAnchor, &cp.Cursor, &cp.HashState, &cp.Hash,
+		&nextOrdinal, &cp.Version, &cp.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf(
+			"reading parser checkpoint %s: %w", sessionID, err,
+		)
+	}
+	cp.SessionID = sessionID
+	cp.FileInode = uint64(inode)
+	cp.FileDevice = uint64(device)
+	cp.NextOrdinal = int(nextOrdinal)
+	return &cp, true, nil
+}
+
+// DeleteParserCheckpoint removes a session's checkpoint. Used when a source
+// is replaced or deleted so a stale checkpoint can never be resumed.
+func (db *DB) DeleteParserCheckpoint(sessionID string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, err := db.getWriter().Exec(
+		`DELETE FROM parser_checkpoints WHERE session_id = ?`,
+		sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("deleting parser checkpoint %s: %w", sessionID, err)
+	}
+	return nil
+}
+
+// UpsertParserCheckpoint stores or replaces a session checkpoint. The full
+// parse path calls this after its session rows commit; the incremental path
+// writes the checkpoint inside the same transaction as the delta
+// (see WriteSessionIncremental).
+func (db *DB) UpsertParserCheckpoint(cp ParserCheckpoint) error {
+	if cp.Version == 0 {
+		cp.Version = ParserCheckpointVersion
+	}
+	if cp.UpdatedAt == "" {
+		cp.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return upsertParserCheckpointExec(db.getWriter(), cp)
+}
+
+func upsertParserCheckpointTx(tx *sql.Tx, cp ParserCheckpoint) error {
+	return upsertParserCheckpointExec(tx, cp)
+}
+
+type sqlExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+func upsertParserCheckpointExec(exec sqlExecer, cp ParserCheckpoint) error {
+	if cp.Version == 0 {
+		cp.Version = ParserCheckpointVersion
+	}
+	if cp.UpdatedAt == "" {
+		cp.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	_, err := exec.Exec(
+		`INSERT INTO parser_checkpoints (
+		    session_id, agent, file_path, file_inode, file_device, file_mtime,
+		    offset, tail_anchor, cursor, hash_state, hash,
+		    next_ordinal, checkpoint_version, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(session_id) DO UPDATE SET
+		    agent = excluded.agent,
+		    file_path = excluded.file_path,
+		    file_inode = excluded.file_inode,
+		    file_device = excluded.file_device,
+		    file_mtime = excluded.file_mtime,
+		    offset = excluded.offset,
+		    tail_anchor = excluded.tail_anchor,
+		    cursor = excluded.cursor,
+		    hash_state = excluded.hash_state,
+		    hash = excluded.hash,
+		    next_ordinal = excluded.next_ordinal,
+		    checkpoint_version = excluded.checkpoint_version,
+		    updated_at = excluded.updated_at`,
+		cp.SessionID, cp.Agent, cp.FilePath,
+		int64(cp.FileInode), int64(cp.FileDevice), cp.FileMTime,
+		cp.Offset, cp.TailAnchor, cp.Cursor, cp.HashState, cp.Hash,
+		cp.NextOrdinal, cp.Version, cp.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"upserting parser checkpoint %s: %w", cp.SessionID, err,
+		)
+	}
+	return nil
+}

--- a/internal/db/checkpoint_test.go
+++ b/internal/db/checkpoint_test.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserCheckpointRoundTrip(t *testing.T) {
+	d := testDB(t)
+	cp := ParserCheckpoint{
+		SessionID:   "codex:019eb791-cf7d-75c1-8439-9ed74c122b02",
+		Agent:       "codex",
+		FilePath:    "/sessions/rollout-x.jsonl",
+		FileInode:   42,
+		FileDevice:  7,
+		FileMTime:   1234567890,
+		Offset:      4096,
+		TailAnchor:  []byte("anchor-bytes"),
+		Cursor:      []byte("cursor-bytes"),
+		HashState:   []byte("hash-state"),
+		Hash:        "deadbeef",
+		NextOrdinal: 10,
+		Version:     ParserCheckpointVersion,
+	}
+	require.NoError(t, d.UpsertParserCheckpoint(cp))
+
+	got, ok, err := d.GetParserCheckpoint(cp.SessionID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, cp.SessionID, got.SessionID)
+	assert.Equal(t, cp.Agent, got.Agent)
+	assert.Equal(t, cp.FilePath, got.FilePath)
+	assert.Equal(t, cp.FileInode, got.FileInode)
+	assert.Equal(t, cp.FileDevice, got.FileDevice)
+	assert.Equal(t, cp.FileMTime, got.FileMTime)
+	assert.Equal(t, cp.Offset, got.Offset)
+	assert.Equal(t, cp.TailAnchor, got.TailAnchor)
+	assert.Equal(t, cp.Cursor, got.Cursor)
+	assert.Equal(t, cp.HashState, got.HashState)
+	assert.Equal(t, cp.Hash, got.Hash)
+	assert.Equal(t, cp.NextOrdinal, got.NextOrdinal)
+	assert.Equal(t, cp.Version, got.Version)
+	assert.NotEmpty(t, got.UpdatedAt)
+
+	require.NoError(t, d.DeleteParserCheckpoint(cp.SessionID))
+	_, ok, err = d.GetParserCheckpoint(cp.SessionID)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestWriteSessionIncrementalPersistsCheckpointInSameTx(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+	insertMessages(t, d, Message{
+		SessionID:  "s1",
+		Ordinal:    0,
+		Role:       "assistant",
+		HasToolUse: true,
+		ToolCalls: []ToolCall{{
+			SessionID: "s1",
+			ToolName:  "exec_command",
+			Category:  "Bash",
+			ToolUseID: "call_cmd",
+		}},
+	})
+	cp := ParserCheckpoint{
+		SessionID:   "s1",
+		Agent:       "codex",
+		FilePath:    "/sessions/rollout-s1.jsonl",
+		FileInode:   1,
+		FileDevice:  2,
+		FileMTime:   100,
+		Offset:      1024,
+		TailAnchor:  []byte("a"),
+		Cursor:      []byte("c"),
+		HashState:   []byte("h"),
+		Hash:        "abc",
+		NextOrdinal: 2,
+		Version:     ParserCheckpointVersion,
+	}
+	require.NoError(t, d.WriteSessionIncremental("s1", nil, IncrementalSessionUpdate{
+		MsgCount:    1,
+		NextOrdinal: 1,
+		Checkpoint:  &cp,
+	}))
+
+	got, ok, err := d.GetParserCheckpoint("s1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, int64(1024), got.Offset)
+	assert.Equal(t, []byte("c"), got.Cursor)
+
+	// A delta without a checkpoint must not disturb the stored one.
+	require.NoError(t, d.WriteSessionIncremental("s1", nil, IncrementalSessionUpdate{
+		MsgCount:    1,
+		NextOrdinal: 2,
+	}))
+	got, ok, err = d.GetParserCheckpoint("s1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, int64(1024), got.Offset)
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3616,6 +3616,79 @@ func TestWriteSessionIncrementalResultOnlyLink(t *testing.T) {
 		"result-only link must not disturb other calls")
 }
 
+func TestWriteSessionIncrementalToolCallResultUpdate(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+	insertMessages(t, d, Message{
+		SessionID:  "s1",
+		Ordinal:    0,
+		Role:       "assistant",
+		HasToolUse: true,
+		ToolCalls: []ToolCall{{
+			SessionID: "s1",
+			ToolName:  "exec_command",
+			Category:  "Bash",
+			ToolUseID: "call_cmd",
+		}},
+	})
+
+	update := IncrementalSessionUpdate{
+		MsgCount:    1,
+		NextOrdinal: 1,
+		ToolCallResultUpdates: []ToolCallResultUpdate{{
+			ToolUseID: "call_cmd",
+			Events: []ToolResultEvent{{
+				ToolUseID:     "call_cmd",
+				Source:        "function_call_output",
+				Content:       "command finished",
+				ContentLength: len("command finished"),
+				Timestamp:     "2026-08-02T09:00:00Z",
+			}},
+		}},
+	}
+	require.NoError(t, d.WriteSessionIncremental("s1", nil, update))
+
+	var result string
+	var resultLen int
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT COALESCE(result_content, ''), result_content_length
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "call_cmd",
+	).Scan(&result, &resultLen))
+	assert.Equal(t, "command finished", result)
+	assert.Equal(t, len("command finished"), resultLen)
+
+	var source, content, timestamp string
+	var eventIndex, eventCount int
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT source, content, COALESCE(timestamp, ''), event_index
+		FROM tool_result_events
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "call_cmd",
+	).Scan(&source, &content, &timestamp, &eventIndex))
+	assert.Equal(t, "function_call_output", source)
+	assert.Equal(t, "command finished", content)
+	assert.Equal(t, "2026-08-02T09:00:00Z", timestamp)
+	assert.Zero(t, eventIndex)
+
+	require.NoError(t, d.WriteSessionIncremental("s1", nil, update),
+		"replaying an identical output must be idempotent")
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT COUNT(*) FROM tool_result_events
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "call_cmd",
+	).Scan(&eventCount))
+	assert.Equal(t, 1, eventCount)
+
+	sess, err := d.GetSession(context.Background(), "s1")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.TranscriptRevision)
+	assert.Equal(t, "2", *sess.TranscriptRevision,
+		"idempotent replay must not bump the transcript revision")
+}
+
 // claude_linear_parse round-trips through upsert and the incremental
 // lookup, stays NULL for legacy rows, and survives an upsert that
 // carries no verdict.

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -94,6 +94,59 @@ type ToolResultEvent struct {
 	EventIndex        int    `json:"event_index"`
 }
 
+// SummarizeToolResultEvents derives the display result stored on a tool call
+// from its chronological result events. Anonymous events use the latest
+// content; agent-scoped events keep the latest content for each agent.
+func SummarizeToolResultEvents(events []ToolResultEvent) string {
+	if len(events) == 0 {
+		return ""
+	}
+	type agentSummary struct {
+		content string
+	}
+	latestByAgent := map[string]agentSummary{}
+	orderedAgents := make([]string, 0, len(events))
+	lastAnon := ""
+	allHaveAgentID := true
+	for _, ev := range events {
+		if strings.TrimSpace(ev.Content) == "" {
+			continue
+		}
+		agentID := strings.TrimSpace(ev.AgentID)
+		if agentID == "" {
+			allHaveAgentID = false
+			lastAnon = ev.Content
+			continue
+		}
+		if _, ok := latestByAgent[agentID]; !ok {
+			latestByAgent[agentID] = agentSummary{content: ev.Content}
+			orderedAgents = append(orderedAgents, agentID)
+			continue
+		}
+		entry := latestByAgent[agentID]
+		entry.content = ev.Content
+		latestByAgent[agentID] = entry
+	}
+	if len(latestByAgent) <= 1 {
+		if len(latestByAgent) == 1 {
+			summary := latestByAgent[orderedAgents[0]].content
+			if lastAnon != "" {
+				return summary + "\n\n" + lastAnon
+			}
+			return summary
+		}
+		return lastAnon
+	}
+	parts := make([]string, 0, len(orderedAgents))
+	for _, agentID := range orderedAgents {
+		parts = append(parts, agentID+":\n"+latestByAgent[agentID].content)
+	}
+	if !allHaveAgentID && lastAnon != "" {
+		parts = append(parts, lastAnon)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
 // Message represents a row in the messages table.
 type Message struct {
 	ID        int64  `json:"id"`
@@ -1026,6 +1079,16 @@ func (db *DB) WriteSessionIncremental(
 	for _, link := range update.SubagentLinks {
 		changed, err := applyToolCallSubagentLinkTx(
 			tx, sessionID, link, update.BlockedResultCategories,
+		)
+		if err != nil {
+			return err
+		}
+		transcriptChanged = transcriptChanged || changed
+	}
+	for _, resultUpdate := range update.ToolCallResultUpdates {
+		changed, err := applyToolCallResultUpdateTx(
+			tx, sessionID, resultUpdate,
+			update.BlockedResultCategories,
 		)
 		if err != nil {
 			return err
@@ -2270,6 +2333,155 @@ func applyToolCallSubagentLinkTx(
 		sessionID, link.ToolUseID,
 	)
 	return err == nil, err
+}
+
+func applyToolCallResultUpdateTx(
+	tx *sql.Tx, sessionID string, update ToolCallResultUpdate,
+	blockedResultCategories map[string]bool,
+) (bool, error) {
+	if strings.TrimSpace(update.ToolUseID) == "" || len(update.Events) == 0 {
+		return false, nil
+	}
+
+	var messageOrdinal, callIndex int
+	var category string
+	if err := tx.QueryRow(
+		`SELECT m.ordinal, COALESCE(tc.call_index, 0), tc.category
+		 FROM tool_calls tc
+		 JOIN messages m ON m.id = tc.message_id
+		 WHERE tc.session_id = ? AND tc.tool_use_id = ?`,
+		sessionID, update.ToolUseID,
+	).Scan(&messageOrdinal, &callIndex, &category); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf(
+			"checking tool result target for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+
+	rows, err := tx.Query(
+		`SELECT COALESCE(tool_use_id, ''), COALESCE(agent_id, ''),
+		        COALESCE(subagent_session_id, ''), source, status,
+		        content, content_length, COALESCE(timestamp, ''), event_index
+		 FROM tool_result_events
+		 WHERE session_id = ? AND tool_call_message_ordinal = ?
+		   AND call_index = ?
+		 ORDER BY event_index, id`,
+		sessionID, messageOrdinal, callIndex,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"loading tool result events for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+	var events []ToolResultEvent
+	nextEventIndex := 0
+	for rows.Next() {
+		var ev ToolResultEvent
+		if err := rows.Scan(
+			&ev.ToolUseID, &ev.AgentID, &ev.SubagentSessionID,
+			&ev.Source, &ev.Status, &ev.Content, &ev.ContentLength,
+			&ev.Timestamp, &ev.EventIndex,
+		); err != nil {
+			_ = rows.Close()
+			return false, fmt.Errorf(
+				"scanning tool result event for %s/%s: %w",
+				sessionID, update.ToolUseID, err,
+			)
+		}
+		events = append(events, ev)
+		nextEventIndex = max(nextEventIndex, ev.EventIndex+1)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return false, fmt.Errorf(
+			"reading tool result events for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+	if err := rows.Close(); err != nil {
+		return false, fmt.Errorf(
+			"closing tool result events for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+
+	incoming := append([]ToolResultEvent(nil), update.Events...)
+	for i := range incoming {
+		if incoming[i].ToolUseID == "" {
+			incoming[i].ToolUseID = update.ToolUseID
+		}
+		if incoming[i].ContentLength == 0 {
+			incoming[i].ContentLength = len(incoming[i].Content)
+		}
+	}
+	toolCall := ToolCall{ResultEvents: incoming}
+	_ = SanitizeToolCall(&toolCall)
+	incoming = toolCall.ResultEvents
+
+	blocked := blockedResultCategories[category]
+	insertRows := make([]toolResultEventRow, 0, len(incoming))
+	for _, candidate := range incoming {
+		if hasEquivalentToolResultEvent(events, candidate, blocked) {
+			continue
+		}
+		candidate.EventIndex = nextEventIndex
+		nextEventIndex++
+		events = append(events, candidate)
+		stored := candidate
+		if blocked {
+			stored.Content = ""
+		}
+		insertRows = append(insertRows, toolResultEventRow{
+			SessionID:      sessionID,
+			MessageOrdinal: messageOrdinal,
+			CallIndex:      callIndex,
+			Event:          stored,
+		})
+	}
+	if len(insertRows) == 0 {
+		return false, nil
+	}
+	if err := insertToolResultEventsTx(tx, insertRows); err != nil {
+		return false, err
+	}
+
+	summary := SummarizeToolResultEvents(events)
+	storedSummary := summary
+	if blocked {
+		storedSummary = ""
+	}
+	if _, err := tx.Exec(
+		`UPDATE tool_calls
+		 SET result_content_length = ?, result_content = ?
+		 WHERE session_id = ? AND tool_use_id = ?`,
+		len(summary), storedSummary, sessionID, update.ToolUseID,
+	); err != nil {
+		return false, fmt.Errorf(
+			"updating tool result summary for %s/%s: %w",
+			sessionID, update.ToolUseID, err,
+		)
+	}
+	return true, nil
+}
+
+func hasEquivalentToolResultEvent(
+	events []ToolResultEvent, candidate ToolResultEvent, blocked bool,
+) bool {
+	for _, existing := range events {
+		if existing.AgentID != candidate.AgentID ||
+			existing.Status != candidate.Status {
+			continue
+		}
+		if existing.Content == candidate.Content ||
+			(blocked && existing.ContentLength == candidate.ContentLength) {
+			return true
+		}
+	}
+	return false
 }
 
 // SystemMessageFingerprint returns the ordered, comma-separated list of

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1103,6 +1103,11 @@ func (db *DB) WriteSessionIncremental(
 	if err := updateSessionIncrementalTx(tx, sessionID, update); err != nil {
 		return err
 	}
+	if update.Checkpoint != nil {
+		if err := upsertParserCheckpointTx(tx, *update.Checkpoint); err != nil {
+			return err
+		}
+	}
 	if err := updateSessionAutomationFromMessagesTx(tx, sessionID); err != nil {
 		return err
 	}

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -1322,3 +1322,24 @@ CREATE TABLE IF NOT EXISTS artifact_imported_sessions (
     ),
     PRIMARY KEY (origin, gid)
 );
+
+-- Machine-local parse checkpoints. SQLite-only, never mirrored to
+-- PostgreSQL or DuckDB: parsers never run against those read-side stores,
+-- and a copy that drops this table degrades to the conservative no-checkpoint
+-- behavior (full parse / prefix rescan), never to a wrong resume.
+CREATE TABLE IF NOT EXISTS parser_checkpoints (
+    session_id         TEXT PRIMARY KEY,
+    agent              TEXT NOT NULL,
+    file_path          TEXT NOT NULL,
+    file_inode         INTEGER NOT NULL,
+    file_device        INTEGER NOT NULL,
+    file_mtime         INTEGER NOT NULL,
+    offset             INTEGER NOT NULL,
+    tail_anchor        BLOB NOT NULL,
+    cursor             BLOB NOT NULL,
+    hash_state         BLOB,
+    hash               TEXT NOT NULL,
+    next_ordinal       INTEGER NOT NULL,
+    checkpoint_version INTEGER NOT NULL,
+    updated_at         TEXT NOT NULL
+);

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2464,21 +2464,24 @@ type IncrementalInfo struct {
 }
 
 type IncrementalSessionUpdate struct {
-	EndedAt                 *string
-	TerminationStatus       *string
-	MsgCount                int
-	UserMsgCount            int
-	FileSize                int64
-	FileMtime               int64
-	FileHash                *string
-	NextOrdinal             int
-	LastEntryUUID           string
-	TotalOutputTokens       int
-	PeakContextTokens       int
-	HasTotalOutputTokens    bool
-	HasPeakContextTokens    bool
-	SubagentLinks           []ToolCallSubagentLink
-	ToolCallResultUpdates   []ToolCallResultUpdate
+	EndedAt               *string
+	TerminationStatus     *string
+	MsgCount              int
+	UserMsgCount          int
+	FileSize              int64
+	FileMtime             int64
+	FileHash              *string
+	NextOrdinal           int
+	LastEntryUUID         string
+	TotalOutputTokens     int
+	PeakContextTokens     int
+	HasTotalOutputTokens  bool
+	HasPeakContextTokens  bool
+	SubagentLinks         []ToolCallSubagentLink
+	ToolCallResultUpdates []ToolCallResultUpdate
+	// Checkpoint is the machine-local parser checkpoint to persist in the
+	// same transaction as this delta. nil keeps any existing checkpoint.
+	Checkpoint              *ParserCheckpoint
 	BlockedResultCategories map[string]bool
 }
 
@@ -2764,6 +2767,27 @@ func (db *DB) GetFileInfoByAgentPath(
 		return 0, 0, false
 	}
 	return s.Int64, m.Int64, true
+}
+
+// GetFileIdentityByAgentPath extends GetFileInfoByAgentPath with the stored
+// file identity (inode/device), used by the stat-only freshness gate that
+// skips a checkpointed Codex source without hashing its transcript.
+func (db *DB) GetFileIdentityByAgentPath(
+	path, agent string,
+) (size int64, mtime int64, inode, device uint64, ok bool) {
+	var s, m, i, d sql.NullInt64
+	err := db.getReader().QueryRow(
+		"SELECT file_size, file_mtime, file_inode, file_device FROM sessions"+
+			" WHERE file_path = ? AND agent = ?"+
+			" AND (deletion_cause IS NULL"+
+			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')"+
+			" ORDER BY file_mtime DESC LIMIT 1",
+		path, agent,
+	).Scan(&s, &m, &i, &d)
+	if err != nil || !s.Valid || !m.Valid || !i.Valid || !d.Valid {
+		return 0, 0, 0, 0, false
+	}
+	return s.Int64, m.Int64, uint64(i.Int64), uint64(d.Int64), true
 }
 
 // VirtualContainerMemberFreshness is one stored virtual member's freshness

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2478,6 +2478,7 @@ type IncrementalSessionUpdate struct {
 	HasTotalOutputTokens    bool
 	HasPeakContextTokens    bool
 	SubagentLinks           []ToolCallSubagentLink
+	ToolCallResultUpdates   []ToolCallResultUpdate
 	BlockedResultCategories map[string]bool
 }
 
@@ -2487,6 +2488,14 @@ type ToolCallSubagentLink struct {
 	ResultContent     string
 	ResultContentLen  int
 	HasResult         bool
+}
+
+// ToolCallResultUpdate carries result events for a tool call that already
+// exists in the database. Incremental parsers use it when an appended output
+// record refers to a call from an earlier sync batch.
+type ToolCallResultUpdate struct {
+	ToolUseID string
+	Events    []ToolResultEvent
 }
 
 // GetSessionForIncremental returns session state needed for incremental

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -68,6 +68,7 @@ type codexSessionBuilder struct {
 	ordinal              int
 	callNames            map[string]string
 	callRefs             map[string]codexToolCallRef
+	toolCallUpdates      []ParsedToolCallUpdate
 	agentSpawnCalls      map[string]string
 	agentWaitCalls       map[string]string
 	pendingAgentEvents   map[string][]codexPendingEvent
@@ -520,6 +521,7 @@ func (b *codexSessionBuilder) handleFunctionCall(
 	callID := payload.Get("call_id").Str
 	if callID != "" {
 		b.callNames[callID] = name
+		b.rememberToolCall(callID, name)
 	}
 
 	content := formatCodexFunctionCall(name, payload)
@@ -570,6 +572,7 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 	if callID == "" {
 		return
 	}
+	defer b.forgetToolCall(callID)
 
 	output, raw := parseCodexFunctionOutput(payload)
 	if !output.Exists() {
@@ -578,7 +581,7 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 		}
 	}
 
-	switch b.callNames[callID] {
+	switch b.toolCallNameForOutput(callID) {
 	case "spawn_agent":
 		agentID := strings.TrimSpace(output.Get("agent_id").Str)
 		if agentID == "" {
@@ -628,6 +631,14 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 			})
 		}
 	}
+}
+
+func (b *codexSessionBuilder) toolCallNameForOutput(callID string) string {
+	if name := b.callNames[callID]; name != "" {
+		return name
+	}
+	name, _ := b.toolCallName(callID)
+	return name
 }
 
 // setCallSubagentSessionID links a tool call to the session of
@@ -694,6 +705,7 @@ func (b *codexSessionBuilder) appendCallResultEvent(
 	}
 	ref, ok := b.callRefs[callID]
 	if !ok || ref.messageIndex < 0 || ref.messageIndex >= len(b.messages) {
+		b.appendToolCallUpdate(callID, ev)
 		return
 	}
 	if ref.callIndex < 0 || ref.callIndex >= len(b.messages[ref.messageIndex].ToolCalls) {
@@ -710,6 +722,29 @@ func (b *codexSessionBuilder) appendCallResultEvent(
 		return
 	}
 	tc.ResultEvents = append(tc.ResultEvents, ev)
+}
+
+func (b *codexSessionBuilder) appendToolCallUpdate(
+	callID string, ev ParsedToolResultEvent,
+) {
+	if ev.ToolUseID == "" {
+		ev.ToolUseID = callID
+	}
+	for i := range b.toolCallUpdates {
+		update := &b.toolCallUpdates[i]
+		if update.ToolUseID != callID {
+			continue
+		}
+		if b.hasEquivalentCallResultEvent(update.ResultEvents, ev) {
+			return
+		}
+		update.ResultEvents = append(update.ResultEvents, ev)
+		return
+	}
+	b.toolCallUpdates = append(b.toolCallUpdates, ParsedToolCallUpdate{
+		ToolUseID:    callID,
+		ResultEvents: []ParsedToolResultEvent{ev},
+	})
 }
 
 func (b *codexSessionBuilder) hasEquivalentCallResultEvent(
@@ -1873,13 +1908,30 @@ func seedCodexIncrementalStateFromReader(
 				}
 			}
 		case codexTypeResponseItem:
-			observeCodexIncrementalUserMessage(&seed, payload)
+			observeCodexIncrementalResponseItem(&seed, payload)
 		}
 	}
 	if err := lr.Err(); err != nil {
 		return codexIncrementalSeed{}, err
 	}
 	return seed, nil
+}
+
+func observeCodexIncrementalResponseItem(
+	s *codexIncrementalSeed,
+	payload gjson.Result,
+) {
+	switch payload.Get("type").Str {
+	case "function_call", "custom_tool_call":
+		s.rememberToolCall(
+			payload.Get("call_id").Str,
+			payload.Get("name").Str,
+		)
+	case "function_call_output", "custom_tool_call_output":
+		s.forgetToolCall(payload.Get("call_id").Str)
+	default:
+		observeCodexIncrementalUserMessage(s, payload)
+	}
 }
 
 // observeUserMessage feeds one response_item into the
@@ -2026,13 +2078,14 @@ func codexSafeResumeOffsetFile(f *os.File, offset int64) (bool, error) {
 }
 
 type codexIncrementalParseResult struct {
-	messages      []ParsedMessage
-	endedAt       time.Time
-	consumedBytes int64
-	initialCursor codexCursorState
-	cursor        codexCursorState
-	inode         uint64
-	device        uint64
+	messages        []ParsedMessage
+	toolCallUpdates []ParsedToolCallUpdate
+	endedAt         time.Time
+	consumedBytes   int64
+	initialCursor   codexCursorState
+	cursor          codexCursorState
+	inode           uint64
+	device          uint64
 }
 
 // parseSessionFromDetailed parses only new lines from a Codex JSONL file. It
@@ -2176,7 +2229,7 @@ func (p *codexProvider) parseSessionFromWithSources(
 				fallbackErr = errCodexIncrementalNeedsFullParse
 				return
 			}
-			if codexIncrementalNeedsFullParse(line) {
+			if b.codexIncrementalNeedsFullParse(line) {
 				fallbackErr = errCodexIncrementalNeedsFullParse
 				return
 			}
@@ -2199,13 +2252,14 @@ func (p *codexProvider) parseSessionFromWithSources(
 
 	b.flushPendingAgentResults()
 	result := codexIncrementalParseResult{
-		messages:      b.messages,
-		endedAt:       b.endedAt,
-		consumedBytes: consumed,
-		initialCursor: seed,
-		cursor:        b.incrementalSeed(),
-		inode:         inode,
-		device:        device,
+		messages:        b.messages,
+		toolCallUpdates: b.toolCallUpdates,
+		endedAt:         b.endedAt,
+		consumedBytes:   consumed,
+		initialCursor:   seed,
+		cursor:          b.incrementalSeed(),
+		inode:           inode,
+		device:          device,
 	}
 	return result, nil
 }
@@ -2235,6 +2289,7 @@ func (p *codexProvider) parseSessionFrom(
 // parse error requires the caller to fall back to a full parse.
 func IsIncrementalFullParseFallback(err error) bool {
 	return errors.Is(err, errCodexIncrementalNeedsFullParse) ||
+		errors.Is(err, ErrIncrementalNeedsFullParse) ||
 		errors.Is(err, ErrClaudeIncrementalNeedsFullParse)
 }
 
@@ -2339,6 +2394,13 @@ func isCodexSubagentNotification(content string) bool {
 }
 
 func codexIncrementalNeedsFullParse(line string) bool {
+	b := newCodexSessionBuilder(false)
+	return b.codexIncrementalNeedsFullParse(line)
+}
+
+func (b *codexSessionBuilder) codexIncrementalNeedsFullParse(
+	line string,
+) bool {
 	switch gjson.Get(line, "type").Str {
 	case codexTypeEventMsg:
 		payload := gjson.Get(line, "payload")
@@ -2361,8 +2423,15 @@ func codexIncrementalNeedsFullParse(line string) bool {
 		return isCodexWaitAgentCall(payload.Get("name").Str)
 	case "function_call_output", "custom_tool_call_output":
 		output, raw := parseCodexFunctionOutput(payload)
-		return isCodexSubagentFunctionOutput(output) ||
-			strings.TrimSpace(raw) != ""
+		if isCodexSubagentFunctionOutput(output) {
+			return true
+		}
+		if strings.TrimSpace(raw) == "" {
+			return false
+		}
+		name := b.toolCallNameForOutput(payload.Get("call_id").Str)
+		return name == "" || name == "spawn_agent" ||
+			isCodexWaitAgentCall(name)
 	default:
 		role := payload.Get("role").Str
 		if role != "user" {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1528,6 +1528,27 @@ func (p *codexProvider) parseSession(
 	)
 }
 
+// parseSessionWithCursor is parseSession plus the end-of-snapshot
+// continuation cursor (and whether the end is a safe resume boundary).
+func (p *codexProvider) parseSessionWithCursor(
+	path, machine string, includeExec bool,
+) (*ParsedSession, []ParsedMessage, codexCursorState, bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, codexCursorState{}, false,
+			fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, nil, codexCursorState{}, false,
+			fmt.Errorf("stat %s: %w", path, err)
+	}
+	return p.parseSessionSnapshotWithCursor(
+		path, machine, includeExec, f, info,
+	)
+}
+
 // parseSessionSnapshot parses exactly the raw-size snapshot captured from f.
 // Limiting the reader prevents an append racing the scan from being folded into
 // a cursor keyed by the earlier size.
@@ -1537,6 +1558,22 @@ func (p *codexProvider) parseSessionSnapshot(
 	f *os.File,
 	info os.FileInfo,
 ) (*ParsedSession, []ParsedMessage, error) {
+	sess, msgs, _, _, err := p.parseSessionSnapshotWithCursor(
+		path, machine, includeExec, f, info,
+	)
+	return sess, msgs, err
+}
+
+// parseSessionSnapshotWithCursor is parseSessionSnapshot plus the
+// continuation state at the end of the parsed snapshot. safe reports whether
+// the file's end is a safe resume boundary; a false safe means the returned
+// cursor must not be persisted.
+func (p *codexProvider) parseSessionSnapshotWithCursor(
+	path, machine string,
+	includeExec bool,
+	f *os.File,
+	info os.FileInfo,
+) (*ParsedSession, []ParsedMessage, codexCursorState, bool, error) {
 	lr := newLineReader(io.LimitReader(f, info.Size()), maxLineSize)
 	defer releaseLineReader(lr)
 	b := newCodexSessionBuilder(includeExec)
@@ -1550,25 +1587,29 @@ func (p *codexProvider) parseSessionSnapshot(
 			continue
 		}
 		if b.processLine(line) {
-			return nil, nil, nil
+			return nil, nil, codexCursorState{}, false, nil
 		}
 	}
 
 	if err := lr.Err(); err != nil {
 		return nil, nil,
+			codexCursorState{}, false,
 			fmt.Errorf("reading codex %s: %w", path, err)
 	}
 
 	b.flushPendingAgentResults()
 	b.normalizeOrdinals()
+	seed := b.incrementalSeed()
 	inode, device := sourceFileIdentity(info)
-	if safe, safeErr := codexSafeResumeOffsetFile(f, info.Size()); safeErr == nil && safe {
+	safe := false
+	if safeCheck, safeErr := codexSafeResumeOffsetFile(f, info.Size()); safeErr == nil && safeCheck {
+		safe = true
 		p.cursorCache.Put(
 			path,
 			info.Size(),
 			inode,
 			device,
-			b.incrementalSeed(),
+			seed,
 		)
 	}
 
@@ -1628,7 +1669,7 @@ func (p *codexProvider) parseSessionSnapshot(
 
 	accumulateMessageTokenUsage(sess, b.messages)
 
-	return sess, b.messages, nil
+	return sess, b.messages, seed, safe, nil
 }
 
 // CodexSessionIndexFilename is the name of the Codex index file that maps
@@ -2139,6 +2180,34 @@ func (p *codexProvider) parseSessionFromSnapshot(
 			return seedCodexIncrementalStateFromReader(
 				io.NewSectionReader(f, 0, offset),
 			)
+		},
+	)
+}
+
+// parseSessionFromCheckpoint is parseSessionFromSnapshot with the committed
+// prefix's continuation state supplied from a persisted checkpoint instead
+// of a prefix rescan.
+func (p *codexProvider) parseSessionFromCheckpoint(
+	path string,
+	offset int64,
+	startOrdinal int,
+	includeExec bool,
+	f *os.File,
+	info os.FileInfo,
+	limit int64,
+	seed codexCursorState,
+) (codexIncrementalParseResult, error) {
+	return p.parseSessionFromWithSources(
+		path,
+		offset,
+		startOrdinal,
+		includeExec,
+		info,
+		func(fn func(string)) (int64, error) {
+			return readCodexJSONLSection(f, offset, limit, fn)
+		},
+		func() (codexIncrementalSeed, error) {
+			return seed, nil
 		},
 	)
 }

--- a/internal/parser/codex_checkpoint_test.go
+++ b/internal/parser/codex_checkpoint_test.go
@@ -1,0 +1,121 @@
+package parser
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+func TestCodexCursorStateCheckpointRoundTrip(t *testing.T) {
+	seed := codexCursorState{
+		model:                    "gpt-5.6-luna",
+		cwd:                      "/workspace/project-a",
+		agentPath:                "/home/chris/.codex/agents/a",
+		firstUserSeen:            true,
+		sawUserTurnAfterFirst:    true,
+		mayReplayFirstUserPrompt: false,
+		lastTokenUsageSeen:       true,
+		lastTokenUsageDigest:     [sha256.Size]byte{1, 2, 3},
+		forkGate: codexForkGate{
+			active:           true,
+			createdMs:        123456789,
+			subagentParentID: "019f0000-0000-7000-8000-000000000000",
+		},
+		lastTaskEvent: "task_complete",
+	}
+	seed.rememberToolCall("call_1", "exec_command")
+	seed.rememberToolCall("call_2", "apply_patch")
+
+	blob, err := seed.MarshalBinary()
+	require.NoError(t, err)
+
+	var got codexCursorState
+	require.NoError(t, got.UnmarshalBinary(blob))
+	assert.Equal(t, seed, got)
+}
+
+func TestCodexCursorStateCheckpointRejectsBadPayloads(t *testing.T) {
+	var state codexCursorState
+
+	// Wrong version.
+	blob, err := state.MarshalBinary()
+	require.NoError(t, err)
+	blob[0] = 99
+	require.Error(t, state.UnmarshalBinary(blob))
+
+	// Truncated payload.
+	blob, err = state.MarshalBinary()
+	require.NoError(t, err)
+	require.Error(t, state.UnmarshalBinary(blob[:len(blob)-3]))
+
+	// Oversized pending-call count.
+	blob, err = state.MarshalBinary()
+	require.NoError(t, err)
+	blob[len(blob)-1] = 200
+	require.Error(t, state.UnmarshalBinary(blob))
+}
+
+func TestCodexProviderIncrementalResumesFromCheckpointSeed(t *testing.T) {
+	const (
+		uuid   = "019eb791-cf7d-75c1-8439-9ed74c122a01"
+		callID = "call_checkpoint"
+	)
+	prefix := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/workspace/project-a", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "run the command", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command", callID, nil, tsEarlyS5,
+		),
+	)
+	root := t.TempDir()
+	path := writeCodexProviderSessionContent(
+		t, root, uuid, prefix,
+	)
+	provider, ok := NewProvider(
+		AgentCodex, ProviderConfig{Roots: []string{root}},
+	)
+	require.True(t, ok)
+	source := requireCodexProviderSource(t, provider, uuid)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: source, Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	checkpoint := outcome.Results[0].Result.Checkpoint
+	require.NotEmpty(t, checkpoint,
+		"a full parse of a safe-offset transcript must produce a checkpoint")
+
+	tail := testjsonl.JoinJSONL(testjsonl.CodexFunctionCallOutputJSON(
+		callID, "done", "2026-08-02T09:00:03Z",
+	))
+	appendCodexProviderContent(t, path, tail)
+
+	fingerprint, err = provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	incOutcome, status, err := provider.ParseIncremental(
+		context.Background(), IncrementalRequest{
+			Source:       source,
+			Fingerprint:  fingerprint,
+			SessionID:    "codex:" + uuid,
+			Offset:       int64(len(prefix)),
+			StartOrdinal: 2,
+			Seed:         checkpoint,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, IncrementalApplied, status)
+	assert.Empty(t, incOutcome.Messages)
+	require.Len(t, incOutcome.ToolCallUpdates, 1)
+	assert.Equal(t, callID, incOutcome.ToolCallUpdates[0].ToolUseID)
+	assert.NotEmpty(t, incOutcome.NextCursor,
+		"an applied incremental parse must advance the cursor")
+}

--- a/internal/parser/codex_cursor.go
+++ b/internal/parser/codex_cursor.go
@@ -1,8 +1,12 @@
 package parser
 
 import (
+	"bytes"
 	"container/list"
 	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -12,6 +16,11 @@ const (
 	codexCursorCacheMaxEntries = 256
 	codexCursorCacheMaxBytes   = 2 << 20
 	codexCursorMaxPendingCalls = 8
+	// codexCursorCheckpointVersion is the wire version for the persisted
+	// cursor encoding. Bump when the encoding changes; decode failures fall
+	// back to a full parse.
+	codexCursorCheckpointVersion   = 1
+	codexCursorCheckpointMaxString = 1 << 20
 
 	// Account for the map bucket, list element, pointers, string headers, and
 	// allocator overhead that are not represented by the variable-length path
@@ -44,6 +53,173 @@ type codexCursorState struct {
 	lastTaskEvent            string
 	pendingCalls             [codexCursorMaxPendingCalls]codexPendingToolCall
 	pendingCallCount         uint8
+}
+
+// MarshalBinary encodes the compact continuation state for persistence.
+// The encoding is versioned and intentionally bounded: strings are
+// length-prefixed and capped on decode, and the pending-call array is
+// fixed-size.
+func (s *codexCursorState) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	write := func(v any) error {
+		return binary.Write(&buf, binary.LittleEndian, v)
+	}
+	writeStr := func(str string) error {
+		if err := write(uint32(len(str))); err != nil {
+			return err
+		}
+		_, err := buf.WriteString(str)
+		return err
+	}
+	if err := write(uint8(codexCursorCheckpointVersion)); err != nil {
+		return nil, err
+	}
+	for _, str := range []string{s.model, s.cwd, s.agentPath} {
+		if err := writeStr(str); err != nil {
+			return nil, err
+		}
+	}
+	if err := write(s.firstUserDigest); err != nil {
+		return nil, err
+	}
+	flags := uint8(0)
+	if s.firstUserSeen {
+		flags |= 1 << 0
+	}
+	if s.sawUserTurnAfterFirst {
+		flags |= 1 << 1
+	}
+	if s.mayReplayFirstUserPrompt {
+		flags |= 1 << 2
+	}
+	if s.lastTokenUsageSeen {
+		flags |= 1 << 3
+	}
+	if s.forkGate.active {
+		flags |= 1 << 4
+	}
+	if err := write(flags); err != nil {
+		return nil, err
+	}
+	if err := write(s.lastTokenUsageDigest); err != nil {
+		return nil, err
+	}
+	if err := write(s.forkGate.createdMs); err != nil {
+		return nil, err
+	}
+	if err := writeStr(s.forkGate.subagentParentID); err != nil {
+		return nil, err
+	}
+	if err := writeStr(s.lastTaskEvent); err != nil {
+		return nil, err
+	}
+	if err := write(uint8(s.pendingCallCount)); err != nil {
+		return nil, err
+	}
+	for i := 0; i < int(s.pendingCallCount); i++ {
+		if err := writeStr(s.pendingCalls[i].id); err != nil {
+			return nil, err
+		}
+		if err := writeStr(s.pendingCalls[i].name); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary restores the state written by MarshalBinary. Any version,
+// length, or structure mismatch returns an error so the caller falls back
+// to an authoritative full parse.
+func (s *codexCursorState) UnmarshalBinary(data []byte) error {
+	r := bytes.NewReader(data)
+	read := func(v any) error {
+		return binary.Read(r, binary.LittleEndian, v)
+	}
+	readStr := func() (string, error) {
+		var n uint32
+		if err := read(&n); err != nil {
+			return "", err
+		}
+		if n > codexCursorCheckpointMaxString {
+			return "", fmt.Errorf(
+				"codex cursor string length %d exceeds bound %d",
+				n, codexCursorCheckpointMaxString,
+			)
+		}
+		b := make([]byte, n)
+		if _, err := io.ReadFull(r, b); err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+
+	var version uint8
+	if err := read(&version); err != nil {
+		return err
+	}
+	if version != codexCursorCheckpointVersion {
+		return fmt.Errorf(
+			"unsupported codex cursor version %d", version,
+		)
+	}
+	*s = codexCursorState{}
+	var err error
+	if s.model, err = readStr(); err != nil {
+		return err
+	}
+	if s.cwd, err = readStr(); err != nil {
+		return err
+	}
+	if s.agentPath, err = readStr(); err != nil {
+		return err
+	}
+	if err := read(&s.firstUserDigest); err != nil {
+		return err
+	}
+	var flags uint8
+	if err := read(&flags); err != nil {
+		return err
+	}
+	s.firstUserSeen = flags&(1<<0) != 0
+	s.sawUserTurnAfterFirst = flags&(1<<1) != 0
+	s.mayReplayFirstUserPrompt = flags&(1<<2) != 0
+	s.lastTokenUsageSeen = flags&(1<<3) != 0
+	s.forkGate.active = flags&(1<<4) != 0
+	if err := read(&s.lastTokenUsageDigest); err != nil {
+		return err
+	}
+	if err := read(&s.forkGate.createdMs); err != nil {
+		return err
+	}
+	if s.forkGate.subagentParentID, err = readStr(); err != nil {
+		return err
+	}
+	if s.lastTaskEvent, err = readStr(); err != nil {
+		return err
+	}
+	var count uint8
+	if err := read(&count); err != nil {
+		return err
+	}
+	if count > codexCursorMaxPendingCalls {
+		return fmt.Errorf(
+			"codex cursor pending call count %d exceeds bound %d",
+			count, codexCursorMaxPendingCalls,
+		)
+	}
+	s.pendingCallCount = count
+	for i := 0; i < int(count); i++ {
+		if s.pendingCalls[i].id, err = readStr(); err != nil {
+			return err
+		}
+		if s.pendingCalls[i].name, err = readStr(); err != nil {
+			return err
+		}
+	}
+	if r.Len() != 0 {
+		return fmt.Errorf("codex cursor trailing bytes: %d", r.Len())
+	}
+	return nil
 }
 
 func (s *codexCursorState) rememberToolCall(id, name string) bool {

--- a/internal/parser/codex_cursor.go
+++ b/internal/parser/codex_cursor.go
@@ -11,14 +11,21 @@ import (
 const (
 	codexCursorCacheMaxEntries = 256
 	codexCursorCacheMaxBytes   = 2 << 20
+	codexCursorMaxPendingCalls = 8
 
 	// Account for the map bucket, list element, pointers, string headers, and
 	// allocator overhead that are not represented by the variable-length path
-	// and cursor strings below. The cache is intentionally an estimate rather
+	// and cursor strings below. The fixed pending-call array contributes two
+	// string headers per slot. The cache is intentionally an estimate rather
 	// than a heap profiler, but this conservative allowance keeps its retained
 	// memory bounded near the configured byte limit.
-	codexCursorEntryOverheadBytes = 256
+	codexCursorEntryOverheadBytes = 256 + codexCursorMaxPendingCalls*32
 )
+
+type codexPendingToolCall struct {
+	id   string
+	name string
+}
 
 // codexCursorState is the compact state needed to make a tail parse behave as
 // though the already-persisted prefix had just been scanned. It deliberately
@@ -35,6 +42,52 @@ type codexCursorState struct {
 	lastTokenUsageSeen       bool
 	forkGate                 codexForkGate
 	lastTaskEvent            string
+	pendingCalls             [codexCursorMaxPendingCalls]codexPendingToolCall
+	pendingCallCount         uint8
+}
+
+func (s *codexCursorState) rememberToolCall(id, name string) bool {
+	id = strings.TrimSpace(id)
+	name = strings.TrimSpace(name)
+	if id == "" || name == "" {
+		return false
+	}
+	for i := 0; i < int(s.pendingCallCount); i++ {
+		if s.pendingCalls[i].id == id {
+			s.pendingCalls[i].name = name
+			return true
+		}
+	}
+	if int(s.pendingCallCount) >= len(s.pendingCalls) {
+		return false
+	}
+	s.pendingCalls[s.pendingCallCount] = codexPendingToolCall{
+		id: id, name: name,
+	}
+	s.pendingCallCount++
+	return true
+}
+
+func (s *codexCursorState) toolCallName(id string) (string, bool) {
+	for i := 0; i < int(s.pendingCallCount); i++ {
+		if s.pendingCalls[i].id == id {
+			return s.pendingCalls[i].name, true
+		}
+	}
+	return "", false
+}
+
+func (s *codexCursorState) forgetToolCall(id string) {
+	for i := 0; i < int(s.pendingCallCount); i++ {
+		if s.pendingCalls[i].id != id {
+			continue
+		}
+		last := int(s.pendingCallCount) - 1
+		copy(s.pendingCalls[i:last], s.pendingCalls[i+1:last+1])
+		s.pendingCalls[last] = codexPendingToolCall{}
+		s.pendingCallCount--
+		return
+	}
 }
 
 // observeUserPrompt advances the first-user replay state using only a digest
@@ -232,6 +285,10 @@ func cloneCodexCursorState(state codexCursorState) codexCursorState {
 	state.cwd = strings.Clone(state.cwd)
 	state.agentPath = strings.Clone(state.agentPath)
 	state.lastTaskEvent = strings.Clone(state.lastTaskEvent)
+	for i := 0; i < int(state.pendingCallCount); i++ {
+		state.pendingCalls[i].id = strings.Clone(state.pendingCalls[i].id)
+		state.pendingCalls[i].name = strings.Clone(state.pendingCalls[i].name)
+	}
 	return state
 }
 
@@ -244,6 +301,15 @@ func estimateCodexCursorEntryBytes(
 			len(state.model)+
 			len(state.cwd)+
 			len(state.agentPath)+
-			len(state.lastTaskEvent),
+			len(state.lastTaskEvent)+
+			codexPendingCallStringBytes(state),
 	)
+}
+
+func codexPendingCallStringBytes(state codexCursorState) int {
+	total := 0
+	for i := 0; i < int(state.pendingCallCount); i++ {
+		total += len(state.pendingCalls[i].id) + len(state.pendingCalls[i].name)
+	}
+	return total
 }

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -2519,7 +2519,7 @@ func TestParseCodexSessionFrom_LateTokenCountRequiresFullParse(t *testing.T) {
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
 
-func TestParseCodexSessionFrom_FunctionCallOutputRequiresFullParse(t *testing.T) {
+func TestParseCodexSessionFrom_FunctionCallOutputUpdatesStoredCall(t *testing.T) {
 	t.Parallel()
 
 	initial := testjsonl.JoinJSONL(
@@ -2549,9 +2549,21 @@ func TestParseCodexSessionFrom_FunctionCallOutputRequiresFullParse(t *testing.T)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = parseCodexTestSessionFrom(t, path, offset, 2, false)
-	require.Error(t, err)
-	assert.True(t, IsIncrementalFullParseFallback(err))
+	result, err := newCodexTestProvider(t).parseSessionFromDetailed(
+		path, offset, 2, false,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, result.messages)
+	require.Len(t, result.toolCallUpdates, 1)
+	assert.Equal(t, "call_cmd", result.toolCallUpdates[0].ToolUseID)
+	assertToolResultEvents(t,
+		result.toolCallUpdates[0].ResultEvents,
+		[]ParsedToolResultEvent{{
+			ToolUseID: "call_cmd",
+			Source:    "function_call_output",
+			Content:   "done",
+		}},
+	)
 }
 
 // TestParseCodexSessionFrom_DedupsReemittedPrompt covers the

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -250,7 +250,9 @@ func (p *codexProvider) Parse(
 		EvictCodexSessionIndexForSession(path)
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
-	sess, msgs, err := p.parseSession(path, machine, false)
+	sess, msgs, cursor, safe, err := p.parseSessionWithCursor(
+		path, machine, false,
+	)
 	if err != nil {
 		return ParseOutcome{}, err
 	}
@@ -266,11 +268,21 @@ func (p *codexProvider) Parse(
 	if req.Fingerprint.Hash != "" {
 		sess.File.Hash = req.Fingerprint.Hash
 	}
+	var checkpoint []byte
+	if safe {
+		checkpoint, err = cursor.MarshalBinary()
+		if err != nil {
+			return ParseOutcome{}, fmt.Errorf(
+				"encoding codex checkpoint %s: %w", path, err,
+			)
+		}
+	}
 	return ParseOutcome{
 		Results: []ParseResultOutcome{{
 			Result: ParseResult{
-				Session:  *sess,
-				Messages: msgs,
+				Session:    *sess,
+				Messages:   msgs,
+				Checkpoint: checkpoint,
 			},
 			DataVersion: DataVersionCurrent,
 		}},
@@ -329,15 +341,36 @@ func (p *codexProvider) ParseIncremental(
 		return IncrementalOutcome{}, IncrementalNoNewData, nil
 	}
 
-	result, err := p.parseSessionFromSnapshot(
-		path,
-		req.Offset,
-		req.StartOrdinal,
-		false,
-		f,
-		info,
-		req.Fingerprint.Size,
-	)
+	var result codexIncrementalParseResult
+	if len(req.Seed) > 0 {
+		var seed codexCursorState
+		if err := seed.UnmarshalBinary(req.Seed); err != nil {
+			// A persisted cursor the current binary cannot decode must not
+			// resume; rebuild the transcript authoritatively.
+			return IncrementalOutcome{ForceReplace: true},
+				IncrementalNeedsFullParse, nil
+		}
+		result, err = p.parseSessionFromCheckpoint(
+			path,
+			req.Offset,
+			req.StartOrdinal,
+			false,
+			f,
+			info,
+			req.Fingerprint.Size,
+			seed,
+		)
+	} else {
+		result, err = p.parseSessionFromSnapshot(
+			path,
+			req.Offset,
+			req.StartOrdinal,
+			false,
+			f,
+			info,
+			req.Fingerprint.Size,
+		)
+	}
 	if err != nil {
 		if IsIncrementalFullParseFallback(err) {
 			return IncrementalOutcome{ForceReplace: true},
@@ -377,10 +410,17 @@ func (p *codexProvider) ParseIncremental(
 	totalOut, peakCtx, hasTotalOut, hasPeakCtx :=
 		codexProviderTokenTotals(result.messages)
 	termination := codexIncrementalTermination(result.cursor.lastTaskEvent)
+	nextCursor, err := result.cursor.MarshalBinary()
+	if err != nil {
+		return IncrementalOutcome{}, IncrementalNeedsFullParse, fmt.Errorf(
+			"encoding codex cursor %s: %w", path, err,
+		)
+	}
 	return IncrementalOutcome{
 		SessionID:            req.SessionID,
 		Messages:             result.messages,
 		ToolCallUpdates:      result.toolCallUpdates,
+		NextCursor:           nextCursor,
 		EndedAt:              result.endedAt,
 		ConsumedBytes:        result.consumedBytes,
 		MessageCount:         len(result.messages),

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -380,6 +380,7 @@ func (p *codexProvider) ParseIncremental(
 	return IncrementalOutcome{
 		SessionID:            req.SessionID,
 		Messages:             result.messages,
+		ToolCallUpdates:      result.toolCallUpdates,
 		EndedAt:              result.endedAt,
 		ConsumedBytes:        result.consumedBytes,
 		MessageCount:         len(result.messages),

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -725,6 +725,77 @@ func TestCodexProviderIncrementalFirstGenuinePromptNeedsFullParse(t *testing.T) 
 	}
 }
 
+func TestCodexProviderIncrementalCustomToolOutputUpdatesStoredCall(t *testing.T) {
+	const (
+		uuid   = "019eb791-cf7d-75c1-8439-9ed74c1229f7"
+		call   = `{"timestamp":"2026-08-02T09:00:02Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","call_id":"call_patch","input":"*** Begin Patch\n*** End Patch"}}`
+		output = `{"timestamp":"2026-08-02T09:00:03Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_patch","output":"Success. Updated one file.","status":"completed"}}`
+	)
+	prefix := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/workspace/project-a", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "apply the patch", tsEarlyS1),
+		call,
+	)
+	tail := testjsonl.JoinJSONL(output)
+
+	for _, mode := range []string{"warm", "cold"} {
+		t.Run(mode, func(t *testing.T) {
+			root := t.TempDir()
+			content := prefix
+			if mode == "cold" {
+				content += tail
+			}
+			path := writeCodexProviderSessionContent(
+				t, root, uuid, content,
+			)
+			provider, ok := NewProvider(
+				AgentCodex, ProviderConfig{Roots: []string{root}},
+			)
+			require.True(t, ok)
+			source := requireCodexProviderSource(t, provider, uuid)
+
+			if mode == "warm" {
+				fingerprint, err := provider.Fingerprint(
+					context.Background(), source,
+				)
+				require.NoError(t, err)
+				_, err = provider.Parse(context.Background(), ParseRequest{
+					Source: source, Fingerprint: fingerprint,
+				})
+				require.NoError(t, err)
+				appendCodexProviderContent(t, path, tail)
+			}
+
+			fingerprint, err := provider.Fingerprint(
+				context.Background(), source,
+			)
+			require.NoError(t, err)
+			outcome, status, err := provider.ParseIncremental(
+				context.Background(), IncrementalRequest{
+					Source:       source,
+					Fingerprint:  fingerprint,
+					SessionID:    "codex:" + uuid,
+					Offset:       int64(len(prefix)),
+					StartOrdinal: 2,
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, IncrementalApplied, status)
+			assert.Empty(t, outcome.Messages)
+			require.Len(t, outcome.ToolCallUpdates, 1)
+			assert.Equal(t, "call_patch", outcome.ToolCallUpdates[0].ToolUseID)
+			require.Len(t, outcome.ToolCallUpdates[0].ResultEvents, 1)
+			event := outcome.ToolCallUpdates[0].ResultEvents[0]
+			assert.Equal(t, "custom_tool_call_output", event.Source)
+			assert.Equal(t, "completed", event.Status)
+			assert.Equal(t, "Success. Updated one file.", event.Content)
+		})
+	}
+}
+
 func TestCodexProviderColdIncrementalStagesRetryCursorVersions(t *testing.T) {
 	root := t.TempDir()
 	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229ed"

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -1000,6 +1000,7 @@ type IncrementalOutcome struct {
 	SessionID            string
 	Messages             []ParsedMessage
 	SubagentLinks        []ClaudeSubagentLink
+	ToolCallUpdates      []ParsedToolCallUpdate
 	EndedAt              time.Time
 	ConsumedBytes        int64
 	MessageCount         int
@@ -1020,6 +1021,12 @@ const (
 	IncrementalNoNewData
 	IncrementalApplied
 	IncrementalNeedsFullParse
+)
+
+// ErrIncrementalNeedsFullParse is the provider-neutral signal used by the
+// sync adapter when an incremental provider requests an authoritative replace.
+var ErrIncrementalNeedsFullParse = errors.New(
+	"incremental parse requires full parse",
 )
 
 // ProviderFactories returns one provider factory for every registered agent.

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -963,6 +963,12 @@ type IncrementalRequest struct {
 	Offset       int64
 	StartOrdinal int
 	Machine      string
+	// Seed is opaque provider continuation state persisted by the sync
+	// engine (a parser checkpoint). A provider that recognizes the format
+	// resumes from it instead of rescanning the committed prefix; empty
+	// means cold-start reconstruction. A seed the provider cannot decode
+	// must be treated as IncrementalNeedsFullParse.
+	Seed []byte
 	// LastEntryUUID is the UUID of the last entry stored for this
 	// session, used by DAG-aware parsers (Claude) to detect when an
 	// appended tail forks away from the stored tip and must trigger a
@@ -997,10 +1003,13 @@ type IncrementalRequest struct {
 
 // IncrementalOutcome is the append-only parse output.
 type IncrementalOutcome struct {
-	SessionID            string
-	Messages             []ParsedMessage
-	SubagentLinks        []ClaudeSubagentLink
-	ToolCallUpdates      []ParsedToolCallUpdate
+	SessionID       string
+	Messages        []ParsedMessage
+	SubagentLinks   []ClaudeSubagentLink
+	ToolCallUpdates []ParsedToolCallUpdate
+	// NextCursor is the provider's continuation state after consuming the
+	// appended tail, for persistence alongside the committed offset.
+	NextCursor           []byte
 	EndedAt              time.Time
 	ConsumedBytes        int64
 	MessageCount         int

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -1489,6 +1489,11 @@ type ParseResult struct {
 	Session     ParsedSession
 	Messages    []ParsedMessage
 	UsageEvents []ParsedUsageEvent
+	// Checkpoint is opaque provider continuation state (a parser
+	// checkpoint) that the sync engine persists after this result's
+	// session rows commit, so later appends can resume without rescanning
+	// the transcript prefix. Empty for providers without checkpoints.
+	Checkpoint []byte
 }
 
 // InferRelationshipTypes sets RelationshipType on results that have

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -1225,6 +1225,14 @@ type ParsedToolCall struct {
 	ResultEvents      []ParsedToolResultEvent
 }
 
+// ParsedToolCallUpdate carries result events for a tool call that was parsed
+// before the current append-only chunk. Incremental sync uses the stable
+// tool_use_id to attach these events without rebuilding the whole transcript.
+type ParsedToolCallUpdate struct {
+	ToolUseID    string
+	ResultEvents []ParsedToolResultEvent
+}
+
 // ParsedToolResult holds metadata about a tool result block in a
 // user message (the response to a prior tool_use).
 type ParsedToolResult struct {

--- a/internal/sync/checkpoint.go
+++ b/internal/sync/checkpoint.go
@@ -1,0 +1,393 @@
+package sync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+const (
+	codexCheckpointVersion    = 1
+	codexCheckpointAnchorSize = 128 << 10
+)
+
+type codexCheckpointDecision int
+
+const (
+	// codexCheckpointFallback means the checkpoint cannot prove a safe
+	// resume; the caller uses the existing fingerprint/full-parse path.
+	codexCheckpointFallback codexCheckpointDecision = iota
+	// codexCheckpointUnchanged means stat + checkpoint prove the transcript
+	// is byte-identical to the committed prefix; the caller skips without
+	// hashing anything.
+	codexCheckpointUnchanged
+	// codexCheckpointAppend means the checkpoint proves a safe append-only
+	// growth; the caller parses only the new tail and resumes the hash.
+	codexCheckpointAppend
+	// codexCheckpointInvalid means a checkpoint exists but its proof failed
+	// (identity changed, truncation, anchor mismatch, missing hash state).
+	// The caller must authoritatively reparse and replace stored rows —
+	// never resume and never append against the unverified prefix.
+	codexCheckpointInvalid
+)
+
+type codexCheckpointResult struct {
+	fingerprint parser.SourceFingerprint
+	checkpoint  *db.ParserCheckpoint
+	decision    codexCheckpointDecision
+	// hashState is the resumable SHA-256 state after hashing through the
+	// current file size, ready for the next checkpoint.
+	hashState []byte
+}
+
+// codexCheckpointFingerprint tries to resolve a Codex source fingerprint and
+// its persisted checkpoint without reading the transcript prefix:
+//
+//   - unchanged: stat identity + size match the checkpoint offset, so the
+//     committed prefix is trusted (append-trust mode) and the file is skipped;
+//   - append: identity matches, the file only grew, the tail anchor matches,
+//     and a resumable SHA-256 state exists, so the full-file fingerprint is
+//     derived by hashing only [offset, size);
+//   - otherwise fallback, which keeps every existing conservative path.
+func (e *Engine) codexCheckpointFingerprint(
+	ctx context.Context,
+	source parser.SourceRef,
+	file parser.DiscoveredFile,
+) (codexCheckpointResult, error) {
+	res := codexCheckpointResult{decision: codexCheckpointFallback}
+	if e.forceParse || file.ForceParse {
+		return res, nil
+	}
+	path := providerDiscoveredPath(source)
+	if path == "" {
+		return res, nil
+	}
+	uuid := parser.CodexSessionUUIDFromFilename(filepath.Base(path))
+	if uuid == "" {
+		return res, nil
+	}
+	sessionID := applyIDPrefixToID(e.idPrefix, "codex:"+uuid)
+	cp, ok, err := e.db.GetParserCheckpoint(sessionID)
+	if err != nil {
+		return res, fmt.Errorf("loading checkpoint %s: %w", sessionID, err)
+	}
+	if !ok || cp.Version != codexCheckpointVersion {
+		return res, nil
+	}
+	lookupPath := path
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(path)
+	}
+	if cp.FilePath != e.effectiveSourcePath(path) ||
+		cp.Agent != string(file.Agent) {
+		return res, nil
+	}
+	if e.db.GetDataVersionByAgentPath(lookupPath, string(file.Agent)) <
+		db.CurrentDataVersion() {
+		return res, nil
+	}
+	if e.pathNeedsProjectReparse(file.Agent, path) {
+		return res, nil
+	}
+	if file.Agent == parser.AgentCodex && e.codexIndexSessionNameChanged(path) {
+		return res, nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return res, nil // missing/raced source: existing path handles it
+	}
+	inode, device := getFileIdentity(path, info)
+	if inode != int64(cp.FileInode) || device != int64(cp.FileDevice) {
+		res.decision = codexCheckpointInvalid
+		return res, nil
+	}
+	rawMtime := info.ModTime().UnixNano()
+	effectiveMtime := rawMtime
+	if file.Agent == parser.AgentCodex {
+		effectiveMtime = parser.CodexEffectiveMtime(path, rawMtime)
+	}
+
+	if info.Size() == cp.Offset {
+		// The mtime gate applies only to the unchanged branch: an append
+		// naturally moves the mtime, and the append branch is proven by
+		// identity + tail anchor + monotonic size instead. An index-only
+		// mtime bump (transcript mtime unchanged) is safe to skip when the
+		// title did not change, mirroring shouldSkipCodexFingerprint.
+		indexOnlyBump := effectiveMtime != cp.FileMTime &&
+			rawMtime <= cp.FileMTime
+		if effectiveMtime != cp.FileMTime && !indexOnlyBump {
+			return res, nil
+		}
+		res.decision = codexCheckpointUnchanged
+		res.fingerprint = parser.SourceFingerprint{
+			Key:     codexCheckpointFingerprintKey(source, path),
+			Size:    info.Size(),
+			MTimeNS: effectiveMtime,
+			Inode:   uint64(inode),
+			Device:  uint64(device),
+			Hash:    cp.Hash,
+		}
+		return res, nil
+	}
+	if info.Size() < cp.Offset {
+		res.decision = codexCheckpointInvalid // truncation: never resume
+		return res, nil
+	}
+	if len(cp.HashState) == 0 || len(cp.TailAnchor) == 0 {
+		res.decision = codexCheckpointInvalid
+		return res, nil
+	}
+	matches, err := codexCheckpointAnchorMatches(path, cp)
+	if err != nil || !matches {
+		res.decision = codexCheckpointInvalid
+		return res, nil
+	}
+	_, hash, err := codexResumeHash(
+		path, cp.Offset, info.Size(), cp.HashState,
+	)
+	if err != nil {
+		res.decision = codexCheckpointInvalid
+		return res, nil
+	}
+	res.decision = codexCheckpointAppend
+	res.checkpoint = cp
+	// The incremental path resumes from the OLD state through the committed
+	// safe offset (which may stop before a partial tail at EOF); the
+	// full-file hash above is only the fingerprint. Advancing the state here
+	// would double-count the tail when newOffset < info.Size().
+	res.hashState = cp.HashState
+	res.fingerprint = parser.SourceFingerprint{
+		Key:     codexCheckpointFingerprintKey(source, path),
+		Size:    info.Size(),
+		MTimeNS: effectiveMtime,
+		Inode:   uint64(inode),
+		Device:  uint64(device),
+		Hash:    hash,
+	}
+	return res, nil
+}
+
+func codexCheckpointFingerprintKey(
+	source parser.SourceRef, path string,
+) string {
+	for _, candidate := range []string{
+		source.FingerprintKey, source.Key,
+	} {
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return path
+}
+
+// codexCheckpointTailAnchor returns the last min(anchorSize, offset) bytes of
+// the committed prefix [0, offset).
+func codexCheckpointTailAnchor(
+	path string, offset int64,
+) ([]byte, error) {
+	if offset <= 0 {
+		return nil, nil
+	}
+	start := offset - codexCheckpointAnchorSize
+	if start < 0 {
+		start = 0
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return nil, err
+	}
+	anchor, err := io.ReadAll(io.LimitReader(f, offset-start))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(anchor)) != offset-start {
+		return nil, fmt.Errorf(
+			"short anchor read for %s: got %d want %d",
+			path, len(anchor), offset-start,
+		)
+	}
+	return anchor, nil
+}
+
+func codexCheckpointAnchorMatches(
+	path string, cp *db.ParserCheckpoint,
+) (bool, error) {
+	anchor, err := codexCheckpointTailAnchor(path, cp.Offset)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(anchor, cp.TailAnchor), nil
+}
+
+// codexResumeHash continues a persisted SHA-256 state over [offset, size) and
+// returns the new state plus the full-file digest.
+func codexResumeHash(
+	path string, offset, size int64, state []byte,
+) ([]byte, string, error) {
+	h := sha256.New()
+	unmarshaler, ok := h.(encoding.BinaryUnmarshaler)
+	if !ok {
+		return nil, "", fmt.Errorf("sha256 does not support state restore")
+	}
+	if err := unmarshaler.UnmarshalBinary(state); err != nil {
+		return nil, "", fmt.Errorf("restoring hash state: %w", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer f.Close()
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, "", err
+	}
+	if _, err := io.CopyN(h, f, size-offset); err != nil {
+		return nil, "", fmt.Errorf(
+			"hashing appended bytes %d..%d of %s: %w",
+			offset, size, path, err,
+		)
+	}
+	newState, err := h.(encoding.BinaryMarshaler).MarshalBinary()
+	if err != nil {
+		return nil, "", fmt.Errorf("marshaling hash state: %w", err)
+	}
+	return newState, hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// codexBuildInitialHashState hashes the whole file once and returns the
+// resumable SHA-256 state. Called when persisting a checkpoint after a full
+// parse; the full parse already read the file, so this is the one-time cost
+// that makes every later append Θ(d).
+func codexBuildInitialHashState(
+	path string, size int64,
+) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.CopyN(h, f, size); err != nil {
+		return nil, fmt.Errorf(
+			"hashing full source %s: %w", path, err,
+		)
+	}
+	marshaler, ok := h.(encoding.BinaryMarshaler)
+	if !ok {
+		return nil, fmt.Errorf("sha256 does not support state capture")
+	}
+	return marshaler.MarshalBinary()
+}
+
+// persistFullParseCheckpoint stores a session's checkpoint after its full
+// parse rows committed. It re-reads the committed file size and next ordinal
+// from the database so the checkpoint always matches what a future
+// incremental parse will see.
+func (e *Engine) persistFullParseCheckpoint(
+	ctx context.Context, pw pendingWrite,
+) {
+	if len(pw.checkpoint) == 0 {
+		return
+	}
+	path := pw.sess.File.Path
+	if path == "" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Printf("checkpoint stat %s: %v", path, err)
+		return
+	}
+	hashState, err := codexBuildInitialHashState(path, info.Size())
+	if err != nil {
+		log.Printf("checkpoint hash %s: %v", path, err)
+		return
+	}
+	mtime := info.ModTime().UnixNano()
+	if pw.sess.Agent == parser.AgentCodex {
+		mtime = parser.CodexEffectiveMtime(path, mtime)
+	}
+	lookupPath := path
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(path)
+	}
+	inc, ok := e.db.GetSessionForIncremental(
+		lookupPath, string(pw.sess.Agent),
+	)
+	if !ok {
+		// The session row committed but has no incremental bookkeeping
+		// (e.g. zero messages); do not persist a resume state that could
+		// disagree with the stored cursor.
+		return
+	}
+	cp, buildErr := buildCodexCheckpoint(
+		inc.ID,
+		string(pw.sess.Agent),
+		e.effectiveSourcePath(path),
+		info,
+		inc.FileSize,
+		mtime,
+		pw.checkpoint,
+		hashState,
+		pw.sess.File.Hash,
+		inc.NextOrdinal,
+	)
+	if buildErr != nil {
+		log.Printf("checkpoint build %s: %v", path, buildErr)
+		return
+	}
+	if err := e.db.UpsertParserCheckpoint(*cp); err != nil {
+		log.Printf("checkpoint persist %s: %v", path, err)
+	}
+}
+
+// buildCodexCheckpoint constructs the next checkpoint for a committed prefix
+// of size newOffset with the given cursor/hash continuation state.
+func buildCodexCheckpoint(
+	sessionID, agent, storedPath string,
+	info os.FileInfo,
+	newOffset int64,
+	mtime int64,
+	cursor []byte,
+	hashState []byte,
+	hash string,
+	nextOrdinal int,
+) (*db.ParserCheckpoint, error) {
+	anchor, err := codexCheckpointTailAnchor(storedPath, newOffset)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"building checkpoint anchor %s at %d: %w",
+			storedPath, newOffset, err,
+		)
+	}
+	inode, device := getFileIdentity(storedPath, info)
+	return &db.ParserCheckpoint{
+		SessionID:   sessionID,
+		Agent:       agent,
+		FilePath:    storedPath,
+		FileInode:   uint64(inode),
+		FileDevice:  uint64(device),
+		FileMTime:   mtime,
+		Offset:      newOffset,
+		TailAnchor:  anchor,
+		Cursor:      cursor,
+		HashState:   hashState,
+		Hash:        hash,
+		NextOrdinal: nextOrdinal,
+		Version:     codexCheckpointVersion,
+	}, nil
+}

--- a/internal/sync/checkpoint_test.go
+++ b/internal/sync/checkpoint_test.go
@@ -1,0 +1,205 @@
+package sync_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+const checkpointTestUUID = "019eb791-cf7d-75c1-8439-9ed74c122c01"
+
+func writeCheckpointCodexSession(
+	t *testing.T, env *testEnv, content string,
+) string {
+	t.Helper()
+	return env.writeCodexSession(
+		t,
+		filepath.Join("2024", "01", "01"),
+		"rollout-2024-01-01T10-00-00-"+checkpointTestUUID+".jsonl",
+		content,
+	)
+}
+
+func checkpointCodexInitial() string {
+	return testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			checkpointTestUUID, "/tmp/proj", "codex_cli_rs",
+			"2024-01-01T10:00:00Z",
+		),
+		testjsonl.CodexMsgJSON(
+			"user", "run command", "2024-01-01T10:00:01Z",
+		),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command", "call_cp", nil, "2024-01-01T10:00:02Z",
+		),
+	)
+}
+
+func TestCodexCheckpointFullParsePersistsCheckpoint(t *testing.T) {
+	env := setupTestEnv(t)
+	initial := checkpointCodexInitial()
+	writeCheckpointCodexSession(t, env, initial)
+
+	env.engine.SyncAll(context.Background(), nil)
+
+	cp, ok, err := env.db.GetParserCheckpoint("codex:" + checkpointTestUUID)
+	require.NoError(t, err)
+	require.True(t, ok, "a full Codex parse must persist a checkpoint")
+	assert.Equal(t, int64(len(initial)), cp.Offset)
+	assert.NotEmpty(t, cp.Cursor)
+	assert.NotEmpty(t, cp.HashState)
+	assert.NotEmpty(t, cp.Hash)
+	assert.Equal(t, 2, cp.NextOrdinal)
+	assert.Equal(t, db.ParserCheckpointVersion, cp.Version)
+}
+
+func TestCodexCheckpointIncrementalResumeAdvancesCheckpoint(t *testing.T) {
+	env := setupTestEnv(t)
+	ctx := context.Background()
+	initial := checkpointCodexInitial()
+	path := writeCheckpointCodexSession(t, env, initial)
+	env.engine.SyncAll(ctx, nil)
+	before, ok, err := env.db.GetParserCheckpoint("codex:" + checkpointTestUUID)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	appended := testjsonl.JoinJSONL(testjsonl.CodexFunctionCallOutputJSON(
+		"call_cp", "done", "2024-01-01T10:00:03Z",
+	))
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	stats := env.engine.SyncAll(ctx, nil)
+	require.Equal(t, 1, stats.Synced)
+
+	sess, err := env.db.GetSessionFull(ctx, "codex:"+checkpointTestUUID)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.True(t, sess.LastWriteIncremental,
+		"a checkpoint-resumed append must stay incremental")
+
+	msgs := fetchMessages(t, env.db, "codex:"+checkpointTestUUID)
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "done", msgs[1].ToolCalls[0].ResultContent)
+	require.Len(t, msgs[1].ToolCalls[0].ResultEvents, 1)
+
+	after, ok, err := env.db.GetParserCheckpoint("codex:" + checkpointTestUUID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, before.Offset+int64(len(appended)), after.Offset)
+	assert.NotEqual(t, before.Cursor, after.Cursor)
+	assert.NotEqual(t, before.HashState, after.HashState)
+	assert.NotEqual(t, before.Hash, after.Hash,
+		"the checkpointed hash must advance to the new full-file hash")
+	require.NotNil(t, sess.FileHash)
+	assert.Equal(t, after.Hash, *sess.FileHash,
+		"stored hash must equal the checkpointed full-file hash")
+}
+
+func TestCodexCheckpointTruncationFallsBackToFullParse(t *testing.T) {
+	env := setupTestEnv(t)
+	ctx := context.Background()
+	initial := checkpointCodexInitial()
+	path := writeCheckpointCodexSession(t, env, initial)
+	env.engine.SyncAll(ctx, nil)
+	_, ok, err := env.db.GetParserCheckpoint("codex:" + checkpointTestUUID)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Truncate at a safe line boundary (drop the final function_call line,
+	// keeping the newline-terminated user message) so the rebuilt checkpoint
+	// is a legal resume offset.
+	truncated := int64(strings.LastIndex(initial, "\n") + 1)
+	require.NoError(t, os.Truncate(path, truncated))
+
+	stats := env.engine.SyncAll(ctx, nil)
+	require.Equal(t, 1, stats.Synced,
+		"a truncated transcript must be authoritatively reparsed")
+	cp, ok, err := env.db.GetParserCheckpoint("codex:" + checkpointTestUUID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, truncated, cp.Offset,
+		"the checkpoint must be rebuilt for the truncated file")
+}
+
+func TestCodexCheckpointAnchorMismatchFallsBackToFullParse(t *testing.T) {
+	env := setupTestEnv(t)
+	ctx := context.Background()
+	initial := checkpointCodexInitial()
+	path := writeCheckpointCodexSession(t, env, initial)
+	env.engine.SyncAll(ctx, nil)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	origMtime := info.ModTime()
+
+	// Corrupt one byte inside the anchor region while keeping the JSON valid
+	// (call_cp -> call_cX), then append a real message so the size grows and
+	// EOF stays a safe boundary. Restoring the mtime isolates the anchor
+	// check: stat and identity look safe, the anchor must not.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	idx := bytes.Index(raw, []byte(`"call_cp"`))
+	require.Positive(t, idx)
+	raw[idx+7] = 'X'
+	raw = append(raw, []byte(testjsonl.JoinJSONL(testjsonl.CodexMsgJSON(
+		"user", "after corruption", "2024-01-01T10:00:04Z",
+	)))...)
+	require.NoError(t, os.WriteFile(path, raw, 0o644))
+	require.NoError(t, os.Chtimes(path, time.Now(), origMtime))
+
+	env.engine.SyncPaths([]string{path})
+	cp, ok, err := env.db.GetParserCheckpoint("codex:" + checkpointTestUUID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, int64(len(raw)), cp.Offset)
+	msgs := fetchMessages(t, env.db, "codex:"+checkpointTestUUID)
+	require.Len(t, msgs, 3)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "call_cX", msgs[1].ToolCalls[0].ToolUseID,
+		"the corrupted call id must come from the authoritative full parse")
+}
+
+func TestCodexCheckpointInPlaceRewriteSameSizeSameMtimeIsTrusted(t *testing.T) {
+	env := setupTestEnv(t)
+	ctx := context.Background()
+	initial := checkpointCodexInitial()
+	path := writeCheckpointCodexSession(t, env, initial)
+	env.engine.SyncAll(ctx, nil)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	origMtime := info.ModTime()
+
+	// In-place rewrite, same size, same mtime: append-trust mode skips it via
+	// the checkpoint stat gate. This is the documented tradeoff; a periodic
+	// full audit catches such rewrites.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	raw[0] ^= 0x01
+	require.NoError(t, os.WriteFile(path, raw, 0o644))
+	require.NoError(t, os.Chtimes(path, time.Now(), origMtime))
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "codex:"+checkpointTestUUID)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "run command", msgs[0].Content,
+		"the trusted skip must not rewrite stored messages")
+	cp, ok, err := env.db.GetParserCheckpoint("codex:" + checkpointTestUUID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, int64(len(initial)), cp.Offset,
+		"the trusted skip must not advance the checkpoint")
+}

--- a/internal/sync/codex_bench_test.go
+++ b/internal/sync/codex_bench_test.go
@@ -7,9 +7,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
@@ -264,4 +266,191 @@ func codexSyncBenchmarkOutcomeValid(
 		outcome.Messages[1].Role == parser.RoleAssistant &&
 		outcome.Messages[1].Content == codexSyncBenchmarkTailAgent &&
 		outcome.Messages[1].Ordinal == startOrdinal+1
+}
+
+const (
+	codexLateToolBenchmarkUUID  = "019eb791-cf7d-75c1-8439-9ed74c122b02"
+	codexLateToolBenchmarkTurns = 250
+)
+
+// BenchmarkCodexIncrementalLateToolOutput measures absorbing a stream in
+// which each batch appends a new function_call plus the function_call_output
+// for the previous batch's call. Output records therefore always refer to a
+// call committed in an earlier sync batch.
+//
+// Before the incremental tool-result path, every such output forced an
+// authoritative full reparse of the whole transcript, so per-op cost scaled
+// with stored history; the incremental path attaches each event to the
+// already-stored call and keeps per-op cost bounded by the
+// fingerprint/prefix-hash reads plus the tiny tail. The session grows by two
+// records per iteration, so per-op cost is only comparable between runs with
+// the same iteration count (the bench gate always runs with a fixed
+// -benchtime=Nx).
+func BenchmarkCodexIncrementalLateToolOutput(b *testing.B) {
+	silenceBenchLogs(b)
+	ctx := context.Background()
+	root, path, _ := writeCodexLateToolBenchmarkTranscript(b)
+
+	database, err := db.Open(filepath.Join(b.TempDir(), "bench.db"))
+	require.NoError(b, err)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {root},
+		},
+		Machine: "benchmark-host",
+	})
+	b.Cleanup(func() {
+		engine.Close()
+		if err := database.Close(); err != nil {
+			b.Errorf("close bench db: %v", err)
+		}
+	})
+
+	first := engine.SyncAll(ctx, nil)
+	require.Equal(b, 1, first.Synced)
+	require.Zero(b, first.Failed)
+
+	// Stretch the debounce window so the flush timer cannot fire inside
+	// the timed loop (same rationale as BenchmarkSyncPathsIncrementalAppend).
+	engine.signalSched.mu.Lock()
+	engine.signalSched.interval = time.Hour
+	engine.signalSched.quiet = time.Hour
+	engine.signalSched.mu.Unlock()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(b, err)
+	defer f.Close()
+
+	// Pre-build the appended lines: constructing JSONL inside the timed loop
+	// would allocate and be gated as if it were sync work. Iteration i appends
+	// call_{i+1} and the output for call_i, so the output is always "late".
+	lines := make([]string, b.N)
+	for i := range lines {
+		lines[i] = testjsonl.JoinJSONL(
+			testjsonl.CodexFunctionCallWithCallIDJSON(
+				"exec_command",
+				codexLateToolBenchmarkCall(i+1),
+				nil,
+				codexLateToolBenchmarkTS(2*i+1),
+			),
+			testjsonl.CodexFunctionCallOutputJSON(
+				codexLateToolBenchmarkCall(i),
+				"result "+strconv.Itoa(i),
+				codexLateToolBenchmarkTS(2*i+2),
+			),
+		)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		if _, err := f.WriteString(lines[i]); err != nil {
+			b.Fatalf("append: %v", err)
+		}
+		stats := engine.SyncAll(ctx, nil)
+		if stats.Failed != 0 {
+			b.Fatalf("sync failed for appended output: %+v", stats)
+		}
+	}
+	b.StopTimer()
+
+	msgs, err := database.GetAllMessages(ctx, "codex:"+codexLateToolBenchmarkUUID)
+	require.NoError(b, err)
+	wantMsgs := 3 + 2*codexLateToolBenchmarkTurns + b.N
+	require.Len(b, msgs, wantMsgs,
+		"each appended call adds exactly one message row")
+	results := make(map[string]db.ToolCall, len(msgs))
+	for i := range msgs {
+		for j := range msgs[i].ToolCalls {
+			results[msgs[i].ToolCalls[j].ToolUseID] = msgs[i].ToolCalls[j]
+		}
+	}
+	for i := range b.N {
+		call, ok := results[codexLateToolBenchmarkCall(i)]
+		require.True(b, ok, "call %d must be stored", i)
+		assert.Equal(b, "exec_command", call.ToolName)
+		assert.Equal(b, "result "+strconv.Itoa(i), call.ResultContent)
+		require.Len(b, call.ResultEvents, 1,
+			"each call must carry exactly its own output event")
+		assert.Equal(b, "result "+strconv.Itoa(i), call.ResultEvents[0].Content)
+	}
+	newest, ok := results[codexLateToolBenchmarkCall(b.N)]
+	require.True(b, ok, "the newest call must be stored")
+	assert.Empty(b, newest.ResultContent)
+	assert.Empty(b, newest.ResultEvents)
+}
+
+func codexLateToolBenchmarkCall(i int) string {
+	return "call_" + strconv.Itoa(i)
+}
+
+func codexLateToolBenchmarkTS(i int) string {
+	return time.Date(
+		2026, 7, 10, 7, 12, i, 0, time.UTC,
+	).Format("2006-01-02T15:04:05Z")
+}
+
+func writeCodexLateToolBenchmarkTranscript(
+	b testing.TB,
+) (root, path, prefix string) {
+	b.Helper()
+	root = filepath.Join(b.TempDir(), "sessions")
+	path = filepath.Join(
+		root,
+		"2026",
+		"07",
+		"10",
+		"rollout-2026-07-10T07-12-15-"+codexLateToolBenchmarkUUID+".jsonl",
+	)
+	require.NoError(b, os.MkdirAll(filepath.Dir(path), 0o755))
+
+	fixture := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			"2026-07-10T07:00:00Z",
+			codexLateToolBenchmarkUUID,
+			"/workspace/project-a",
+			"codex_cli_rs",
+		).
+		AddRaw(testjsonl.CodexTurnContextJSON(
+			"gpt-5.4", "2026-07-10T07:00:01Z",
+		)).
+		AddCodexMessage(
+			"2026-07-10T07:00:02Z",
+			"user",
+			"Initial request: inspect the project and make a careful change.",
+		).
+		AddCodexMessage(
+			"2026-07-10T07:00:03Z",
+			"assistant",
+			"Initial response: I will inspect the relevant code and tests.",
+		)
+	contextPayload := strings.Repeat(
+		"Retain concrete code, test, and validation context. ", 8,
+	)
+	for i := range codexLateToolBenchmarkTurns {
+		turn := strconv.Itoa(i)
+		fixture.AddCodexMessage(
+			"2026-07-10T07:01:00Z",
+			"user",
+			"Prior turn "+turn+" request: continue the implementation. "+
+				contextPayload,
+		)
+		fixture.AddCodexMessage(
+			"2026-07-10T07:01:01Z",
+			"assistant",
+			"Prior turn "+turn+" response: applied the next bounded change. "+
+				contextPayload,
+		)
+	}
+	// call_0 is committed in the prefix with no output; iteration 0 appends
+	// call_1 plus the late output for call_0.
+	fixture.AddRaw(testjsonl.CodexFunctionCallWithCallIDJSON(
+		"exec_command",
+		"call_0",
+		nil,
+		codexLateToolBenchmarkTS(0),
+	))
+	prefix = fixture.String()
+	require.NoError(b, os.WriteFile(path, []byte(prefix), 0o644))
+	return root, path, prefix
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8299,6 +8299,7 @@ type incrementalUpdate struct {
 	cwd                  string
 	msgs                 []parser.ParsedMessage
 	links                []parser.ClaudeSubagentLink
+	toolCallUpdates      []parser.ParsedToolCallUpdate
 	endedAt              time.Time
 	terminationStatus    *string
 	msgCount             int // total (old + new)
@@ -10807,7 +10808,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 
 	parseFn := func(
 		_ string, inc *db.IncrementalInfo,
-	) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error) {
+	) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
 		// The Claude parser needs the stored tail's provider message id
 		// so its queued-command masking fallback fires only for a real
 		// same-message.id continuation; without it, every routine queued
@@ -10835,24 +10836,24 @@ func (e *Engine) tryProviderIncrementalAppend(
 			},
 		)
 		if perr != nil {
-			return nil, nil, time.Time{}, 0, nil, perr
+			return nil, nil, nil, time.Time{}, 0, nil, perr
 		}
 		switch status {
 		case parser.IncrementalNeedsFullParse:
 			if outcome.ForceReplace {
 				// Signal the shared helper to fall back to a
 				// full parse that replaces stored messages.
-				return nil, nil, time.Time{}, 0, nil,
-					parser.ErrClaudeIncrementalNeedsFullParse
+				return nil, nil, nil, time.Time{}, 0, nil,
+					parser.ErrIncrementalNeedsFullParse
 			}
 			// A plain full-parse fallback without a replace request.
 			// The Claude provider always sets ForceReplace on its
 			// fallbacks (a DAG fork can drop or re-branch stored
 			// rows), so this branch serves providers that only need
 			// an append-preserving full parse.
-			return nil, nil, time.Time{}, 0, nil, parser.ErrDAGDetected
+			return nil, nil, nil, time.Time{}, 0, nil, parser.ErrDAGDetected
 		case parser.IncrementalNoNewData:
-			return nil, nil, time.Time{}, 0, nil, nil
+			return nil, nil, nil, time.Time{}, 0, nil, nil
 		default:
 			var terminationStatus *string
 			if outcome.TerminationStatus != nil {
@@ -10860,6 +10861,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 				terminationStatus = &status
 			}
 			return outcome.Messages, outcome.SubagentLinks,
+				outcome.ToolCallUpdates,
 				outcome.EndedAt, outcome.ConsumedBytes, terminationStatus, nil
 		}
 	}
@@ -10875,7 +10877,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 // only complete, valid JSON lines so it can be used as a safe resume offset.
 type incrementalParseFunc func(
 	path string, inc *db.IncrementalInfo,
-) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error)
+) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error)
 
 // tryIncrementalJSONL attempts an incremental parse of an
 // append-only JSONL file by reading only bytes appended since
@@ -10997,7 +10999,7 @@ func (e *Engine) tryIncrementalJSONL(
 		return processResult{err: leaseErr}, true
 	}
 
-	newMsgs, links, endedAt, consumed, terminationStatus, err := parseFn(
+	newMsgs, links, toolCallUpdates, endedAt, consumed, terminationStatus, err := parseFn(
 		file.Path, inc,
 	)
 	if err != nil {
@@ -11054,6 +11056,7 @@ func (e *Engine) tryIncrementalJSONL(
 					machine:              inc.Machine,
 					cwd:                  inc.Cwd,
 					links:                links,
+					toolCallUpdates:      toolCallUpdates,
 					endedAt:              endedAt,
 					terminationStatus:    terminationStatus,
 					msgCount:             inc.MsgCount,
@@ -11173,6 +11176,7 @@ func (e *Engine) tryIncrementalJSONL(
 			cwd:                  inc.Cwd,
 			msgs:                 newMsgs,
 			links:                links,
+			toolCallUpdates:      toolCallUpdates,
 			endedAt:              endedAt,
 			terminationStatus:    terminationStatus,
 			msgCount:             inc.MsgCount + len(newMsgs),
@@ -14009,6 +14013,24 @@ func (e *Engine) writeIncremental(
 			HasResult:        link.HasResult,
 		}
 	}
+	toolCallResultUpdates := make(
+		[]db.ToolCallResultUpdate, len(inc.toolCallUpdates),
+	)
+	for i, update := range inc.toolCallUpdates {
+		toolCall := db.ToolCall{
+			ResultEvents: convertToolResultEvents(update.ResultEvents),
+		}
+		for j := range toolCall.ResultEvents {
+			toolCall.ResultEvents[j].SubagentSessionID = applyIDPrefixToID(
+				e.idPrefix, toolCall.ResultEvents[j].SubagentSessionID,
+			)
+		}
+		e.anomalies.recordSanitize(db.SanitizeToolCall(&toolCall))
+		toolCallResultUpdates[i] = db.ToolCallResultUpdate{
+			ToolUseID: update.ToolUseID,
+			Events:    toolCall.ResultEvents,
+		}
+	}
 
 	if err := e.db.WriteSessionIncremental(
 		inc.sessionID,
@@ -14028,6 +14050,7 @@ func (e *Engine) writeIncremental(
 			HasTotalOutputTokens:    inc.hasTotalOutputTokens,
 			HasPeakContextTokens:    inc.hasPeakContextTokens,
 			SubagentLinks:           subagentLinks,
+			ToolCallResultUpdates:   toolCallResultUpdates,
 			BlockedResultCategories: e.blockedResultCategories,
 		},
 	); err != nil {
@@ -15974,7 +15997,7 @@ func pairToolResultEventSummaries(
 			if len(tc.ResultEvents) == 0 {
 				continue
 			}
-			summary := summarizeToolResultEvents(tc.ResultEvents)
+			summary := db.SummarizeToolResultEvents(tc.ResultEvents)
 			tc.ResultContentLength = len(summary)
 			if blocked[tc.Category] {
 				tc.ResultContent = ""
@@ -15986,62 +16009,6 @@ func pairToolResultEventSummaries(
 			tc.ResultContent = summary
 		}
 	}
-}
-
-func summarizeToolResultEvents(
-	events []db.ToolResultEvent,
-) string {
-	if len(events) == 0 {
-		return ""
-	}
-	type agentSummary struct {
-		order   int
-		content string
-	}
-	latestByAgent := map[string]agentSummary{}
-	orderedAgents := make([]string, 0, len(events))
-	lastAnon := ""
-	allHaveAgentID := true
-	for _, ev := range events {
-		if strings.TrimSpace(ev.Content) == "" {
-			continue
-		}
-		agentID := strings.TrimSpace(ev.AgentID)
-		if agentID == "" {
-			allHaveAgentID = false
-			lastAnon = ev.Content
-			continue
-		}
-		if _, ok := latestByAgent[agentID]; !ok {
-			latestByAgent[agentID] = agentSummary{
-				order:   len(orderedAgents),
-				content: ev.Content,
-			}
-			orderedAgents = append(orderedAgents, agentID)
-			continue
-		}
-		entry := latestByAgent[agentID]
-		entry.content = ev.Content
-		latestByAgent[agentID] = entry
-	}
-	if len(latestByAgent) <= 1 {
-		if len(latestByAgent) == 1 {
-			summary := latestByAgent[orderedAgents[0]].content
-			if lastAnon != "" {
-				return summary + "\n\n" + lastAnon
-			}
-			return summary
-		}
-		return lastAnon
-	}
-	parts := make([]string, 0, len(orderedAgents))
-	for _, agentID := range orderedAgents {
-		parts = append(parts, agentID+":\n"+latestByAgent[agentID].content)
-	}
-	if !allHaveAgentID && lastAnon != "" {
-		parts = append(parts, lastAnon)
-	}
-	return strings.Join(parts, "\n\n")
 }
 
 // emit fires a refresh event if an emitter is wired. Safe to call

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7572,13 +7572,13 @@ func (e *Engine) retentionBudget() *parseRetentionBudget {
 	return e.parseRetentionBudget
 }
 
-// beginBulkRetentionPass installs the unthrottled bulk retention budget for
+// beginBulkRetentionPass installs the byte-bounded bulk retention budget for
 // the duration of an archive-scale pass and returns the restore func the
 // caller must defer. Bulk passes (full sync, resync rebuild, remote import
-// processing) run at full worker parallelism; the memory they retain is
-// returned to the OS by the end-of-pass scavenge instead of being bounded
-// per source. The caller holds syncMu, so no other pass can observe the
-// switched budget.
+// processing) use the same weighted byte admission as daemon passes: large
+// sources run exclusively, small sources share the capacity, and batches
+// flush on count or estimated bytes. The caller holds syncMu, so no other
+// pass can observe the switched budget.
 func (e *Engine) beginBulkRetentionPass() func() {
 	e.bulkRetentionOnce.Do(func() {
 		if e.bulkRetentionBudget == nil {
@@ -7620,6 +7620,7 @@ func (e *Engine) collectAndBatch(
 	}
 
 	var pending []pendingWrite
+	var pendingBytes int64
 	var pendingLeases []*parseRetentionLease
 	var pendingCacheWrites []skipCacheWrite
 	baselineCacheWrites := make(
@@ -7843,8 +7844,22 @@ func (e *Engine) collectAndBatch(
 				}
 				e.recordProviderStatHash(ctx, *pw.providerStatHash)
 			}
+			// Persist full-parse checkpoints only for rows whose session
+			// commit succeeded, mirroring the providerStatHash gate: an
+			// unconfirmed checkpoint would let a later append resume from a
+			// prefix that was never durably parsed.
+			for i, pw := range pending {
+				if len(pw.checkpoint) == 0 {
+					continue
+				}
+				if i >= len(outcome.written) || !outcome.written[i] {
+					continue
+				}
+				e.persistFullParseCheckpoint(ctx, pw)
+			}
 		}()
 		pending = pending[:0]
+		pendingBytes = 0
 		pendingLeases = pendingLeases[:0]
 		pendingCacheWrites = pendingCacheWrites[:0]
 	}
@@ -8109,6 +8124,8 @@ func (e *Engine) collectAndBatch(
 					sess:              pr.Session,
 					msgs:              pr.Messages,
 					usageEvents:       pr.UsageEvents,
+					sourceBytes:       r.sourceBytes,
+					checkpoint:        pr.Checkpoint,
 					needsRetry:        needsRetry,
 					forceReplace:      r.forceReplace,
 					baselineEligible:  vetoed == 0 && r.providerFailureCount == 0 && !needsRetry,
@@ -8125,6 +8142,7 @@ func (e *Engine) collectAndBatch(
 					pw.providerStatHash = r.providerStatHash
 				}
 				pending = append(pending, pw)
+				pendingBytes += pw.sourceBytes
 				if runtimeMetrics != nil {
 					runtimeMetrics.pendingWrites(len(pending))
 				}
@@ -8141,7 +8159,8 @@ func (e *Engine) collectAndBatch(
 					sourceFingerprint: r.sourceFingerprint,
 				})
 			}
-			if len(pending) >= batchSize || budget.underPressure() {
+			if len(pending) >= batchSize || budget.underPressure() ||
+				pendingBytes >= parseBatchBytesLimit {
 				flushPending()
 			}
 			// A Kiro SQLite store is discovered as one container source
@@ -8292,14 +8311,18 @@ func drainResults(results <-chan syncJob, remaining int) {
 // incremental JSONL parse, used to partially update the
 // session row without overwriting unrelated columns.
 type incrementalUpdate struct {
-	sessionID            string
-	project              string
-	sourceProject        string
-	machine              string
-	cwd                  string
-	msgs                 []parser.ParsedMessage
-	links                []parser.ClaudeSubagentLink
-	toolCallUpdates      []parser.ParsedToolCallUpdate
+	sessionID       string
+	project         string
+	sourceProject   string
+	machine         string
+	cwd             string
+	msgs            []parser.ParsedMessage
+	links           []parser.ClaudeSubagentLink
+	toolCallUpdates []parser.ParsedToolCallUpdate
+	// checkpoint is the machine-local parser checkpoint to persist in the
+	// same transaction as this incremental delta. nil keeps the existing
+	// checkpoint (or leaves none).
+	checkpoint           *db.ParserCheckpoint
 	endedAt              time.Time
 	terminationStatus    *string
 	msgCount             int // total (old + new)
@@ -8335,6 +8358,10 @@ type sourceMissingMember struct {
 }
 
 type processResult struct {
+	// sourceBytes is the physical source size used to acquire the retention
+	// lease and to account this result against the pending write batch byte
+	// cap. Zero on lease-free skips.
+	sourceBytes        int64
 	results            []parser.ParseResult
 	excludedSessionIDs []string
 	// sourceMissingMembers carries stored sessions whose virtual member
@@ -8749,27 +8776,66 @@ func (e *Engine) processProviderFile(
 		}, true
 	}
 
-	fingerprint, err := provider.Fingerprint(ctx, source)
-	if err != nil {
-		if file.ForceParse &&
-			providerDeletedPhysicalSQLiteSource(file.Agent, file.Path) &&
-			errors.Is(err, os.ErrNotExist) {
-			excludedSessionIDs, ownershipErr :=
-				e.providerSourceSessionIDsForForceReplace(
-					ctx, provider, source,
-				)
-			if ownershipErr != nil {
+	// Codex checkpoint gate: when a persisted checkpoint proves the source is
+	// unchanged (stat-trust) or safely append-only (tail anchor + resumable
+	// hash), resolve the fingerprint without hashing the transcript prefix.
+	// Anything the checkpoint cannot prove falls through to provider.Fingerprint.
+	var fingerprint parser.SourceFingerprint
+	var codexCheckpoint *db.ParserCheckpoint
+	var codexSeed []byte
+	var codexFullHash string
+	var codexHashState []byte
+	codexForceFullParse := false
+	if isCodexFormatAgent(file.Agent) {
+		cpResult, cpErr := e.codexCheckpointFingerprint(ctx, source, file)
+		if cpErr != nil {
+			log.Printf("codex checkpoint %s: %v", file.Path, cpErr)
+		} else {
+			switch cpResult.decision {
+			case codexCheckpointUnchanged:
 				return processResult{
-					err:         ownershipErr,
+					skip:        true,
+					mtime:       cpResult.fingerprint.MTimeNS,
 					noCacheSkip: true,
 				}, true
+			case codexCheckpointAppend:
+				fingerprint = cpResult.fingerprint
+				codexCheckpoint = cpResult.checkpoint
+				codexSeed = cpResult.checkpoint.Cursor
+				codexFullHash = cpResult.fingerprint.Hash
+				codexHashState = cpResult.hashState
+			case codexCheckpointInvalid:
+				// The persisted checkpoint exists but cannot prove the
+				// committed prefix. Never append against it: rebuild the
+				// session authoritatively and replace stored rows.
+				codexForceFullParse = true
 			}
-			return processResult{
-				excludedSessionIDs: excludedSessionIDs,
-				forceReplace:       true,
-			}, true
 		}
-		return processResult{err: err}, true
+	}
+	if codexCheckpoint == nil {
+		var err error
+		fingerprint, err = provider.Fingerprint(ctx, source)
+		if err != nil {
+			if file.ForceParse &&
+				providerDeletedPhysicalSQLiteSource(file.Agent, file.Path) &&
+				errors.Is(err, os.ErrNotExist) {
+				excludedSessionIDs, ownershipErr :=
+					e.providerSourceSessionIDsForForceReplace(
+						ctx, provider, source,
+					)
+				if ownershipErr != nil {
+					return processResult{
+						err:         ownershipErr,
+						noCacheSkip: true,
+					}, true
+				}
+				return processResult{
+					excludedSessionIDs: excludedSessionIDs,
+					forceReplace:       true,
+				}, true
+			}
+			return processResult{err: err}, true
+		}
 	}
 	cacheKey := providerProcessCacheKey(
 		file, source, fingerprint, providerSemantics,
@@ -8868,9 +8934,16 @@ func (e *Engine) processProviderFile(
 	// When the incremental path declines but signals forceReplace,
 	// carry the flag onto the full parse so the write path replaces
 	// stored messages instead of appending on top of stale rows.
-	incRes, incOK := e.tryProviderIncrementalAppend(
-		ctx, provider, source, file, fingerprint,
-	)
+	var incRes processResult
+	var incOK bool
+	if codexForceFullParse {
+		incRes = processResult{forceReplace: true}
+	} else {
+		incRes, incOK = e.tryProviderIncrementalAppend(
+			ctx, provider, source, file, fingerprint,
+			codexSeed, codexFullHash, codexHashState, codexCheckpoint,
+		)
+	}
 	if incOK {
 		incRes.mtime = fingerprint.MTimeNS
 		incRes.cacheSkip = cacheSkip
@@ -8929,7 +9002,8 @@ func (e *Engine) processProviderFile(
 	// here the provider parses the source, so acquire the retention lease that
 	// bounds the parsed payload and attach it to every result carrying that
 	// data. A result still classified as a skip below releases it immediately.
-	lease, err := e.retentionBudget().acquire(ctx, parseRetentionSourceBytes(file))
+	sourceBytes := parseRetentionSourceBytes(file)
+	lease, err := e.retentionBudget().acquire(ctx, sourceBytes)
 	if err != nil {
 		return processResult{err: err}, true
 	}
@@ -9018,6 +9092,7 @@ func (e *Engine) processProviderFile(
 			skip:                  !outcome.ForceReplace,
 			excludedSessionIDs:    excludedSessionIDs,
 			sourceMissingMembers:  missingMembers,
+			sourceBytes:           sourceBytes,
 			mtime:                 fingerprint.MTimeNS,
 			cacheSkip:             cacheSkip,
 			cacheKey:              cacheKey,
@@ -9063,6 +9138,7 @@ func (e *Engine) processProviderFile(
 		results:               filteredResults,
 		excludedSessionIDs:    excludedSessionIDs,
 		sourceMissingMembers:  missingMembers,
+		sourceBytes:           sourceBytes,
 		mtime:                 fingerprint.MTimeNS,
 		cacheSkip:             cacheSkip,
 		cacheKey:              cacheKey,
@@ -10770,6 +10846,10 @@ func (e *Engine) tryProviderIncrementalAppend(
 	source parser.SourceRef,
 	file parser.DiscoveredFile,
 	fingerprint parser.SourceFingerprint,
+	seed []byte,
+	fullHash string,
+	hashState []byte,
+	checkpoint *db.ParserCheckpoint,
 ) (processResult, bool) {
 	// Match the legacy tryIncrementalJSONL gate, which suppressed append
 	// deltas only under the engine-wide forceParse (parse-diff) flag. A
@@ -10808,7 +10888,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 
 	parseFn := func(
 		_ string, inc *db.IncrementalInfo,
-	) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
+	) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, []byte, error) {
 		// The Claude parser needs the stored tail's provider message id
 		// so its queued-command masking fallback fires only for a real
 		// same-message.id continuation; without it, every routine queued
@@ -10827,6 +10907,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 				Offset:                    inc.FileSize,
 				StartOrdinal:              inc.NextOrdinal,
 				Machine:                   inc.Machine,
+				Seed:                      seed,
 				LastEntryUUID:             inc.LastEntryUUID,
 				StoredAgentLabel:          inc.AgentLabel,
 				StoredEntrypoint:          inc.Entrypoint,
@@ -10836,14 +10917,14 @@ func (e *Engine) tryProviderIncrementalAppend(
 			},
 		)
 		if perr != nil {
-			return nil, nil, nil, time.Time{}, 0, nil, perr
+			return nil, nil, nil, time.Time{}, 0, nil, nil, perr
 		}
 		switch status {
 		case parser.IncrementalNeedsFullParse:
 			if outcome.ForceReplace {
 				// Signal the shared helper to fall back to a
 				// full parse that replaces stored messages.
-				return nil, nil, nil, time.Time{}, 0, nil,
+				return nil, nil, nil, time.Time{}, 0, nil, nil,
 					parser.ErrIncrementalNeedsFullParse
 			}
 			// A plain full-parse fallback without a replace request.
@@ -10851,9 +10932,9 @@ func (e *Engine) tryProviderIncrementalAppend(
 			// fallbacks (a DAG fork can drop or re-branch stored
 			// rows), so this branch serves providers that only need
 			// an append-preserving full parse.
-			return nil, nil, nil, time.Time{}, 0, nil, parser.ErrDAGDetected
+			return nil, nil, nil, time.Time{}, 0, nil, nil, parser.ErrDAGDetected
 		case parser.IncrementalNoNewData:
-			return nil, nil, nil, time.Time{}, 0, nil, nil
+			return nil, nil, nil, time.Time{}, 0, nil, nil, nil
 		default:
 			var terminationStatus *string
 			if outcome.TerminationStatus != nil {
@@ -10862,11 +10943,15 @@ func (e *Engine) tryProviderIncrementalAppend(
 			}
 			return outcome.Messages, outcome.SubagentLinks,
 				outcome.ToolCallUpdates,
-				outcome.EndedAt, outcome.ConsumedBytes, terminationStatus, nil
+				outcome.EndedAt, outcome.ConsumedBytes, terminationStatus,
+				outcome.NextCursor, nil
 		}
 	}
 
-	return e.tryIncrementalJSONL(ctx, file, info, file.Agent, parseFn)
+	return e.tryIncrementalJSONL(
+		ctx, file, info, file.Agent, parseFn,
+		checkpoint, fullHash, hashState,
+	)
 }
 
 // incrementalParseFunc reads new JSONL lines from a file
@@ -10877,7 +10962,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 // only complete, valid JSON lines so it can be used as a safe resume offset.
 type incrementalParseFunc func(
 	path string, inc *db.IncrementalInfo,
-) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error)
+) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, []byte, error)
 
 // tryIncrementalJSONL attempts an incremental parse of an
 // append-only JSONL file by reading only bytes appended since
@@ -10891,6 +10976,9 @@ func (e *Engine) tryIncrementalJSONL(
 	info os.FileInfo,
 	agent parser.AgentType,
 	parseFn incrementalParseFunc,
+	checkpoint *db.ParserCheckpoint,
+	fullHash string,
+	hashState []byte,
 ) (processResult, bool) {
 	if e.forceParse { // parse-diff: never produce append deltas
 		return processResult{}, false
@@ -10992,14 +11080,13 @@ func (e *Engine) tryIncrementalJSONL(
 	// retention lease that bounds the parsed payload. It is attached to the
 	// incremental results below and released on every decline (fall-through to
 	// a full parse re-acquires at the provider parse seam) or skip return.
-	lease, leaseErr := e.retentionBudget().acquire(
-		ctx, parseRetentionSourceBytes(file),
-	)
+	sourceBytes := parseRetentionSourceBytes(file)
+	lease, leaseErr := e.retentionBudget().acquire(ctx, sourceBytes)
 	if leaseErr != nil {
 		return processResult{err: leaseErr}, true
 	}
 
-	newMsgs, links, toolCallUpdates, endedAt, consumed, terminationStatus, err := parseFn(
+	newMsgs, links, toolCallUpdates, endedAt, consumed, terminationStatus, cursor, err := parseFn(
 		file.Path, inc,
 	)
 	if err != nil {
@@ -11035,9 +11122,55 @@ func (e *Engine) tryIncrementalJSONL(
 	// providerSingleSessionFresh can compare the stored hash against the
 	// on-disk bytes and catch a same-size, same-mtime, same-inode in-place
 	// rewrite that the size/mtime/identity skip signals cannot see.
-	if isCodexFormatAgent(agent) || agent == parser.AgentClaude {
+	if fullHash != "" {
+		// The stored fingerprint must cover only the committed safe prefix,
+		// not an unfinished partial tail at EOF. Resume the hash state
+		// through newOffset (the last complete record) rather than trusting
+		// the full-file hash computed by the checkpoint gate.
+		if state, hash, hashErr := codexResumeHash(
+			file.Path, inc.FileSize, newOffset, hashState,
+		); hashErr == nil {
+			incHash = hash
+			hashState = state
+		} else {
+			log.Printf(
+				"resuming codex hash for %s at %d: %v",
+				file.Path, newOffset, hashErr,
+			)
+			incHash = fullHash
+		}
+	} else if isCodexFormatAgent(agent) || agent == parser.AgentClaude {
 		if hash, err := ComputeFileHashPrefix(file.Path, newOffset); err == nil {
 			incHash = hash
+		}
+	}
+
+	// Persist the advanced parser checkpoint in the same transaction as the
+	// delta when this append was resumed from one.
+	var nextCheckpoint *db.ParserCheckpoint
+	if checkpoint != nil && len(cursor) > 0 && hashState != nil {
+		cpNextOrdinal := inc.NextOrdinal
+		if len(newMsgs) > 0 {
+			cpNextOrdinal = nextParsedOrdinal(inc.NextOrdinal, newMsgs)
+		}
+		built, buildErr := buildCodexCheckpoint(
+			inc.ID,
+			string(agent),
+			e.effectiveSourcePath(file.Path),
+			info,
+			newOffset,
+			incMtime,
+			cursor,
+			hashState,
+			incHash,
+			cpNextOrdinal,
+		)
+		if buildErr != nil {
+			log.Printf(
+				"building codex checkpoint %s: %v", file.Path, buildErr,
+			)
+		} else {
+			nextCheckpoint = built
 		}
 	}
 
@@ -11049,6 +11182,7 @@ func (e *Engine) tryIncrementalJSONL(
 		// with non-message timestamps (e.g. progress).
 		if consumed > 0 {
 			return processResult{
+				sourceBytes: sourceBytes,
 				incremental: &incrementalUpdate{
 					sessionID:            inc.ID,
 					project:              inc.Project,
@@ -11057,6 +11191,7 @@ func (e *Engine) tryIncrementalJSONL(
 					cwd:                  inc.Cwd,
 					links:                links,
 					toolCallUpdates:      toolCallUpdates,
+					checkpoint:           nextCheckpoint,
 					endedAt:              endedAt,
 					terminationStatus:    terminationStatus,
 					msgCount:             inc.MsgCount,
@@ -11168,6 +11303,7 @@ func (e *Engine) tryIncrementalJSONL(
 	}
 
 	return processResult{
+		sourceBytes: sourceBytes,
 		incremental: &incrementalUpdate{
 			sessionID:            inc.ID,
 			project:              inc.Project,
@@ -11177,6 +11313,7 @@ func (e *Engine) tryIncrementalJSONL(
 			msgs:                 newMsgs,
 			links:                links,
 			toolCallUpdates:      toolCallUpdates,
+			checkpoint:           nextCheckpoint,
 			endedAt:              endedAt,
 			terminationStatus:    terminationStatus,
 			msgCount:             inc.MsgCount + len(newMsgs),
@@ -11892,9 +12029,18 @@ func (e *Engine) recomputeSignalsFromDB(
 }
 
 type pendingWrite struct {
-	sess         parser.ParsedSession
-	msgs         []parser.ParsedMessage
-	usageEvents  []parser.ParsedUsageEvent
+	sess        parser.ParsedSession
+	msgs        []parser.ParsedMessage
+	usageEvents []parser.ParsedUsageEvent
+	// sourceBytes is the physical source size carried from the parse result;
+	// collectAndBatch uses it to flush batches on estimated bytes as well as
+	// session count.
+	sourceBytes int64
+	// checkpoint is the provider's persisted continuation cursor for a full
+	// parse. The flush path persists it as a parser_checkpoints row after the
+	// session rows commit, so later appends can resume without rescanning the
+	// transcript prefix. Empty for providers without checkpoints.
+	checkpoint   []byte
 	needsRetry   bool
 	forceReplace bool
 	// sourceIdentityUnverified marks a copy that shares a native session ID
@@ -14051,6 +14197,7 @@ func (e *Engine) writeIncremental(
 			HasPeakContextTokens:    inc.hasPeakContextTokens,
 			SubagentLinks:           subagentLinks,
 			ToolCallResultUpdates:   toolCallResultUpdates,
+			Checkpoint:              inc.checkpoint,
 			BlockedResultCategories: e.blockedResultCategories,
 		},
 	); err != nil {
@@ -14220,6 +14367,9 @@ func (e *Engine) writeSessionFullWithResolver(
 	if err := e.db.ReviveSourceMissingSession(s.ID); err != nil {
 		log.Printf("revive source-missing session %s: %v", s.ID, err)
 		return err
+	}
+	if len(pw.checkpoint) > 0 {
+		e.persistFullParseCheckpoint(context.Background(), pw)
 	}
 
 	return nil
@@ -15666,6 +15816,7 @@ func (e *Engine) processAndWriteSessionFile(
 			sess:         pr.Session,
 			msgs:         pr.Messages,
 			usageEvents:  pr.UsageEvents,
+			checkpoint:   pr.Checkpoint,
 			needsRetry:   res.needsRetryForSession(pr.Session.ID),
 			forceReplace: res.forceReplace,
 		}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -12587,7 +12587,7 @@ func TestIncrementalSync_CodexAppend(t *testing.T) {
 	assert.Equal(t, 1, sess.UserMessageCount)
 }
 
-func TestSyncPathsCodexSameStatInPlaceRewriteUsesContentHash(t *testing.T) {
+func TestSyncPathsCodexSameStatInPlaceRewriteTrustedByCheckpoint(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentCodex)
 
 	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229f5"
@@ -12633,17 +12633,31 @@ func TestSyncPathsCodexSameStatInPlaceRewriteUsesContentHash(t *testing.T) {
 
 	msgs := fetchMessages(t, env.db, "codex:"+uuid)
 	require.Len(t, msgs, 1)
-	assert.Equal(t, "bravo request", msgs[0].Content)
+	assert.Equal(t, "alpha request", msgs[0].Content,
+		"append-trust mode trusts the checkpoint stat gate over a same-stat rewrite")
 	after, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
 	require.NoError(t, err)
 	require.NotNil(t, after)
 	require.NotNil(t, after.FileHash)
-	assert.False(t, after.LastWriteIncremental,
-		"same-size rewrite must use a full replacement")
-	assert.NotEqual(t, beforeHash, *after.FileHash)
-	wantHash, err := sync.ComputeFileHash(path)
+	assert.Equal(t, beforeHash, *after.FileHash,
+		"a trusted skip must not rewrite the stored hash")
+	cp, ok, err := env.db.GetParserCheckpoint("codex:" + uuid)
 	require.NoError(t, err)
-	assert.Equal(t, wantHash, *after.FileHash)
+	require.True(t, ok)
+	assert.Equal(t, int64(len(original)), cp.Offset,
+		"a trusted skip must not advance the checkpoint")
+
+	// The periodic audit (an authoritative rebuild) still catches the
+	// in-place rewrite and re-establishes strong freshness.
+	env.engine.ResyncAll(context.Background(), nil)
+	msgs = fetchMessages(t, env.db, "codex:"+uuid)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "bravo request", msgs[0].Content)
+	audited, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err)
+	require.NotNil(t, audited)
+	require.NotNil(t, audited.FileHash)
+	assert.NotEqual(t, beforeHash, *audited.FileHash)
 }
 
 func TestSyncAllCodexPathRewriterSameStatRewriteUsesContentHash(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -13383,6 +13383,9 @@ func TestIncrementalSync_CodexExecAppendRetainsEvents(t *testing.T) {
 		"rollout-20240101-inc-cx-exec.jsonl", initial,
 	)
 	env.engine.SyncAll(context.Background(), nil)
+	before := fetchMessages(t, env.db, "codex:inc-cx-exec")
+	require.Len(t, before, 2)
+	toolMessageID := before[1].ID
 
 	appended := testjsonl.JoinJSONL(
 		testjsonl.CodexFunctionCallOutputJSON(
@@ -13401,9 +13404,31 @@ func TestIncrementalSync_CodexExecAppendRetainsEvents(t *testing.T) {
 
 	msgs := fetchMessages(t, env.db, "codex:inc-cx-exec")
 	require.Len(t, msgs, 2)
+	assert.Equal(t, toolMessageID, msgs[1].ID,
+		"result-only append must preserve the existing tool message")
 	require.Len(t, msgs[1].ToolCalls, 1)
-	assert.Equal(t, "exec_command", msgs[1].ToolCalls[0].ToolName, "tool name")
-	assert.Equal(t, "done", msgs[1].ToolCalls[0].ResultContent, "result_content")
+	call := msgs[1].ToolCalls[0]
+	assert.Equal(t, "exec_command", call.ToolName, "tool name")
+	assert.Equal(t, "done", call.ResultContent, "result_content")
+	require.Len(t, call.ResultEvents, 1)
+	assert.Equal(t, "function_call_output", call.ResultEvents[0].Source)
+	assert.Equal(t, "done", call.ResultEvents[0].Content)
+	afterIncremental, err := env.db.GetSessionFull(
+		context.Background(), "codex:inc-cx-exec",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, afterIncremental)
+	assert.True(t, afterIncremental.LastWriteIncremental)
+
+	env.engine.ResyncAll(context.Background(), nil)
+	fullMsgs := fetchMessages(t, env.db, "codex:inc-cx-exec")
+	require.Len(t, fullMsgs, 2)
+	require.Len(t, fullMsgs[1].ToolCalls, 1)
+	fullCall := fullMsgs[1].ToolCalls[0]
+	assert.Equal(t, call.ResultContent, fullCall.ResultContent)
+	assert.Equal(t, call.ResultContentLength, fullCall.ResultContentLength)
+	assert.Equal(t, call.ResultEvents, fullCall.ResultEvents,
+		"incremental and authoritative full parses must store the same events")
 }
 
 func TestIncrementalSync_CodexLateTokenCountRewritesStoredMessage(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -6403,11 +6403,11 @@ func TestProjectIdentityIncrementalStatePreservesExplicitSourceProject(
 				func(
 					_ string,
 					inc *db.IncrementalInfo,
-				) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error) {
+				) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
 					return []parser.ParsedMessage{{
 						Role: parser.RoleAssistant, Content: "appended",
 						Ordinal: inc.NextOrdinal,
-					}}, nil, appendedInfo.ModTime(), int64(len(appended)), nil, nil
+					}}, nil, nil, appendedInfo.ModTime(), int64(len(appended)), nil, nil
 				},
 			)
 			require.True(t, ok)
@@ -6504,9 +6504,9 @@ func TestProjectIdentityLegacyMappedSnapshotReparsesBeforeIncrementalAppend(
 		func(
 			_ string,
 			_ *db.IncrementalInfo,
-		) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error) {
+		) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
 			parseCalled = true
-			return nil, nil, time.Time{}, 0, nil, nil
+			return nil, nil, nil, time.Time{}, 0, nil, nil
 		},
 	)
 	assert.False(t, ok,

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -6403,12 +6403,13 @@ func TestProjectIdentityIncrementalStatePreservesExplicitSourceProject(
 				func(
 					_ string,
 					inc *db.IncrementalInfo,
-				) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
+				) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, []byte, error) {
 					return []parser.ParsedMessage{{
 						Role: parser.RoleAssistant, Content: "appended",
 						Ordinal: inc.NextOrdinal,
-					}}, nil, nil, appendedInfo.ModTime(), int64(len(appended)), nil, nil
+					}}, nil, nil, appendedInfo.ModTime(), int64(len(appended)), nil, nil, nil
 				},
+				nil, "", nil,
 			)
 			require.True(t, ok)
 			require.NotNil(t, result.incremental)
@@ -6504,10 +6505,11 @@ func TestProjectIdentityLegacyMappedSnapshotReparsesBeforeIncrementalAppend(
 		func(
 			_ string,
 			_ *db.IncrementalInfo,
-		) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, error) {
+		) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, []parser.ParsedToolCallUpdate, time.Time, int64, *string, []byte, error) {
 			parseCalled = true
-			return nil, nil, nil, time.Time{}, 0, nil, nil
+			return nil, nil, nil, time.Time{}, 0, nil, nil, nil
 		},
+		nil, "", nil,
 	)
 	assert.False(t, ok,
 		"legacy snapshots must fall through to a source-aware full parse")
@@ -7974,6 +7976,7 @@ func TestTryProviderIncrementalAppendPassesPersistedSessionID(t *testing.T) {
 			Size:    info.Size(),
 			MTimeNS: info.ModTime().UnixNano(),
 		},
+		nil, "", nil, nil,
 	)
 
 	require.True(t, applied)

--- a/internal/sync/parse_retention.go
+++ b/internal/sync/parse_retention.go
@@ -16,6 +16,10 @@ const (
 	parseRetentionFixedBytes        = int64(64 << 10)
 	parseRetentionMultiplier        = int64(4)
 	parseRetentionScavengeThreshold = int64(16 << 20)
+	// parseBatchBytesLimit bounds a pending write batch by estimated source
+	// bytes as well as by session count: a 5KiB session and a 945MiB session
+	// must not both count as "1". Batches flush when either limit is reached.
+	parseBatchBytesLimit = defaultParseRetentionBytes
 )
 
 type parseRetentionBudget struct {
@@ -43,28 +47,20 @@ func newParseRetentionBudget(capacity int64) *parseRetentionBudget {
 }
 
 // newBulkParseRetentionBudget returns the budget archive-scale passes use
-// (full sync, resync rebuild, remote import processing). It never throttles
-// parse admission: peak memory during a bulk pass is bounded by worker
-// parallelism, not by a byte budget. Instead it releases the pass's retained
-// memory back to the OS in one scavenge once the pass completes, keeping the
-// long-running daemon's settled footprint low without serializing the pass.
+// (full sync, resync rebuild, remote import processing). Bulk passes are
+// byte-budgeted like every other pass: large sources acquire the whole
+// capacity and run exclusively, small sources share it, and batches flush
+// when the pending estimated bytes reach the capacity. This keeps a bulk
+// pass's peak parse memory bounded by the configured budget plus one
+// oversized parse instead of by worker parallelism. The pass still releases
+// retained memory back to the OS in one scavenge once it completes.
 func newBulkParseRetentionBudget() *parseRetentionBudget {
-	return &parseRetentionBudget{
-		pressure: make(chan struct{}, 1),
-		scavenge: debug.FreeOSMemory,
-	}
+	return newParseRetentionBudget(defaultParseRetentionBytes)
 }
 
 func (budget *parseRetentionBudget) acquire(
 	ctx context.Context, sourceBytes int64,
 ) (*parseRetentionLease, error) {
-	if budget.weighted == nil {
-		// Bulk pass: admit immediately and remember that parsed payloads
-		// were retained so the end-of-pass scavenge runs exactly once.
-		budget.scavengePending.Store(true)
-		budget.acquired.Add(1)
-		return &parseRetentionLease{}, nil
-	}
 	weight := budget.weight(sourceBytes)
 	if budget.weighted.TryAcquire(weight) {
 		budget.noteKnownLargeSource(sourceBytes)

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -62,7 +62,7 @@ func TestWarmNoopSyncAcquiresNoRetentionLeases(t *testing.T) {
 		"warm no-op pass must not acquire parse-retention leases")
 }
 
-func TestFullSyncPassIsUnthrottledAndScavengesOnce(t *testing.T) {
+func TestFullSyncPassIsByteBudgeted(t *testing.T) {
 	e, ctx := newWarmBenchEngine(t)
 	var scavenges int
 	e.bulkRetentionBudget = newBulkParseRetentionBudget()
@@ -72,16 +72,18 @@ func TestFullSyncPassIsUnthrottledAndScavengesOnce(t *testing.T) {
 	acquired := e.bulkRetentionBudget.acquired.Load()
 	require.Positive(t, acquired,
 		"full pass must admit parses through the bulk budget")
+	require.NotNil(t, e.bulkRetentionBudget.weighted,
+		"bulk pass must run under the weighted byte budget")
 	if e.parseRetentionBudget != nil {
 		assert.Zero(t, e.parseRetentionBudget.acquired.Load(),
 			"full pass must not consume the bounded daemon budget")
 	}
-	assert.Equal(t, 1, scavenges,
-		"a parse-bearing bulk pass must release memory once at the end")
+	assert.Zero(t, scavenges,
+		"small sources do not set the scavenge flag (covered by the large-source test)")
 
 	stats := e.SyncAll(ctx, nil) // warm pass: everything skips
 	require.Equal(t, 0, stats.Synced)
-	assert.Equal(t, 1, scavenges,
+	assert.Zero(t, scavenges,
 		"a warm no-op pass must not force another scavenge")
 	assert.Nil(t, e.activeRetention.Load(),
 		"bulk budget must be uninstalled after the pass")
@@ -100,20 +102,23 @@ func TestScopedSyncKeepsBoundedRetentionBudget(t *testing.T) {
 		"a cutoff-scoped pass must not create the bulk budget")
 }
 
-func TestBulkParseRetentionBudgetNeverBlocks(t *testing.T) {
+func TestBulkParseRetentionBudgetUsesWeightedAdmission(t *testing.T) {
 	budget := newBulkParseRetentionBudget()
 	first, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
 	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	_, err = budget.acquire(ctx, defaultParseRetentionBytes)
+	assert.ErrorIs(t, err, context.DeadlineExceeded,
+		"a second oversized bulk admission must wait for capacity")
+	first.Release()
 	second, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
 	require.NoError(t, err)
-	assert.False(t, budget.underPressure(),
-		"bulk admissions must never report pressure")
-	first.Release()
 	second.Release()
 	assert.Equal(t, int64(2), budget.acquired.Load())
 }
 
-func TestBulkParseRetentionBudgetScavengesOncePerParseBearingPass(t *testing.T) {
+func TestBulkParseRetentionBudgetScavengesOnceAfterLargeSource(t *testing.T) {
 	budget := newBulkParseRetentionBudget()
 	var scavenges int
 	budget.scavenge = func() { scavenges++ }
@@ -121,13 +126,51 @@ func TestBulkParseRetentionBudgetScavengesOncePerParseBearingPass(t *testing.T) 
 	budget.scavengeIfNeeded()
 	assert.Zero(t, scavenges, "a pass with no parses must not scavenge")
 
-	lease, err := budget.acquire(t.Context(), 1)
+	lease, err := budget.acquire(
+		t.Context(), parseRetentionScavengeThreshold,
+	)
 	require.NoError(t, err)
 	lease.Release()
 	budget.scavengeIfNeeded()
 	budget.scavengeIfNeeded()
 	assert.Equal(t, 1, scavenges,
 		"one parse-bearing pass needs exactly one end-of-pass scavenge")
+}
+
+func TestCollectAndBatchFlushesOnByteCap(t *testing.T) {
+	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+	var batchLengths []int
+	engine.writeBatchOverride = func(
+		batch []pendingWrite, _ syncWriteMode, _ bool,
+	) (int, int, int, int) {
+		batchLengths = append(batchLengths, len(batch))
+		return len(batch), 0, 0, 0
+	}
+	results := make(chan syncJob, 2)
+	for i := range 2 {
+		results <- syncJob{
+			path: fmt.Sprintf("/sessions/large-%d.jsonl", i),
+			processResult: processResult{
+				sourceBytes: parseBatchBytesLimit,
+				results: []parser.ParseResult{{
+					Session: parser.ParsedSession{
+						ID:    fmt.Sprintf("byte-cap-%d", i),
+						Agent: parser.AgentClaude,
+					},
+				}},
+			},
+		}
+	}
+	close(results)
+
+	stats := engine.collectAndBatch(
+		t.Context(), results, 2, 2, nil, syncWriteDefault,
+	)
+
+	assert.Equal(t, []int{1, 1}, batchLengths,
+		"each oversized pending result must flush its own batch")
+	assert.Equal(t, 2, stats.Synced)
 }
 
 func TestParseRetentionBudgetBoundsConcurrentSourceWeight(t *testing.T) {

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -244,7 +244,8 @@ func (e *Engine) processS3Session(
 	// so acquire the retention lease that bounds the materialized-and-parsed
 	// payload just before the object is fetched and parsed. Every result from
 	// here carries the lease; releaseRetention frees it after consumption.
-	lease, err := e.retentionBudget().acquire(ctx, parseRetentionSourceBytes(file))
+	sourceBytes := parseRetentionSourceBytes(file)
+	lease, err := e.retentionBudget().acquire(ctx, sourceBytes)
 	if err != nil {
 		return processResult{err: err}
 	}
@@ -316,6 +317,7 @@ func (e *Engine) processS3Session(
 	res.excludedSessionIDs = applyIDPrefixToIDs(
 		idPrefix, res.excludedSessionIDs,
 	)
+	res.sourceBytes = sourceBytes
 	res.retentionLease = lease
 	return res
 }


### PR DESCRIPTION
## What

Two layers from the Codex sync performance plan:

### P0 — byte-bounded bulk passes

Full/resync passes previously installed an unthrottled parse budget
(`weighted == nil` admitted every parse immediately), so peak memory during a
bulk pass was bounded only by worker parallelism. Bulk passes now use the same
weighted byte admission as daemon passes: large sources acquire the whole
capacity and run exclusively, and pending write batches flush on session count
**or** estimated source bytes (64MiB), not count alone.

### P1 — persisted Codex parse checkpoints

A machine-local `parser_checkpoints` row per session stores: file identity,
committed byte offset, a 128KiB tail anchor of the committed prefix, a
versioned parser cursor, a resumable SHA-256 state, the full prefix hash, and
the next ordinal.

- Full parses attach the end cursor to `ParseResult.Checkpoint`; the engine
  persists it after the session rows commit.
- Incremental parses resume from `IncrementalRequest.Seed` instead of
  rescanning `[0, offset)`, so a cold worker no longer pays Θ(S) to rebuild
  the cursor.
- An unchanged checkpointed source is skipped on stat alone (0 transcript
  bytes read), turning unchanged startup into Θ(N) metadata checks.
- An append verifies identity + monotonic size + tail anchor, then derives
  the full-file fingerprint by hashing only `[offset, size)` through the
  resumable SHA-256 state — no full-source fingerprint read, no committed
  prefix re-hash.
- The advanced checkpoint commits in the same SQLite transaction as the
  incremental delta, so a crash cannot persist a delta without its cursor.
- Any failed proof (identity change, truncation, anchor mismatch, missing or
  undecodable cursor/hash state) forces an authoritative full rebuild —
  never an append against an unverified prefix.

Default mode is append-trust: a same-stat in-place rewrite is trusted until a
periodic full audit (`ResyncAll`, force-reverification) hashes the source and
repairs it.

## Performance

`make bench-gate` on merge base vs head (same runner, `-benchtime=20x
-count=6`), new gated benchmark `BenchmarkCodexIncrementalLateToolOutput`
(checkpoint-resumed append stream):

| metric | base | head | ratio |
|---|---:|---:|---:|
| sec/op | 25.77ms | 3.50ms | 0.14x |
| B/op | 3.854Mi | 1.086Mi | 0.28x |
| allocs/op | 16.65k | 2.04k | 0.12x |

All existing gated benchmarks stayed within thresholds; `cmd/benchgate`
reports no regressions.

## Correctness

- Parser: versioned cursor round-trip, corrupt/truncated/oversized payloads
  rejected, and incremental resume from a persisted seed (`internal/parser`).
- DB: checkpoint round-trip and same-transaction persistence with
  `WriteSessionIncremental` (`internal/db`).
- Engine: full parse persists a checkpoint; append resumes and advances it;
  truncation and anchor mismatch force authoritative rebuilds; stat-trust
  skip is asserted and the audit path still catches in-place rewrites
  (`internal/sync`).
- `go test -tags fts5 ./internal/parser ./internal/db ./internal/sync` passes;
  `go vet` clean.

## Follow-ups (not in this PR)

- Streaming full parse to a scratch DB so a single 945MiB session's parse
  peak memory is bounded (P3 of the plan).
- Unifying token/subagent/title updates into one explicit delta contract (P2).
