### PR TITLE
Stop re-parsing titled Codex sessions when session_index.jsonl is absent

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -254,12 +254,16 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 ## Codex (`codex`)
 
-- **Format:** Rollout JSONL files, with a separate JSONL session index used for
-  discovery and metadata. The TUI also maintains an append-oriented
-  `history.jsonl` whose records contain `session_id`, Unix-seconds `ts`, and
-  submitted prompt `text`; configured size enforcement can rewrite a retained
-  tail in place. Agentsview consumes only the first two fields as a
-  live-activity hint.
+- **Format:** Rollout JSONL files, with a separate JSONL session index used by
+  older releases for discovery and metadata. Current releases no longer write
+  `session_index.jsonl`; thread titles live in `thread_history_*.sqlite`
+  databases that agentsview does not read, so an absent index is the normal
+  state, not a rename signal (reverified 2026-08-13 against a live `~/.codex`
+  with no `session_index.jsonl` and a populated `thread_history_1.sqlite`).
+  The TUI also maintains an append-oriented `history.jsonl` whose records
+  contain `session_id`, Unix-seconds `ts`, and submitted prompt `text`;
+  configured size enforcement can rewrite a retained tail in place. Agentsview
+  consumes only the first two fields as a live-activity hint.
 - **Evidence:** `source`.
 - **Upstream:** Clone `https://github.com/openai/codex.git` at
   `406dc9239492aff6d295cca5eebe2a548548d42f`; see the pinned
@@ -1600,41 +1604,38 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Agentsview:** `internal/parser/omnigent.go` and
   `internal/parser/omnigent_provider.go`; fixtures under
   `internal/parser/testdata/omnigent/` provide observed event-shape evidence.
-  
+
 ## Codebuff (`codebuff`)
 
 - **Format:** Per-session JSON files under
   `<root>/<project>/chats/<timestamp>/`. Each session directory contains
-  `chat-messages.json` (JSON array of user/ai/error message objects with
-  text, tool, agent, mode-divider, plan, ask-user, and image blocks),
-  `run-state.json` (agent type, context token count, credits used, cwd,
-  and skill catalog), and optional `chat-meta.json` (message count,
-  first prompt, and messages size). Freebuff sessions share the same
-  layout and are distinguished by the `agentType` field containing
-  `"free"`.
+  `chat-messages.json` (JSON array of user/ai/error message objects with text,
+  tool, agent, mode-divider, plan, ask-user, and image blocks),
+  `run-state.json` (agent type, context token count, credits used, cwd, and
+  skill catalog), and optional `chat-meta.json` (message count, first prompt,
+  and messages size). Freebuff sessions share the same layout and are
+  distinguished by the `agentType` field containing `"free"`.
 - **Evidence:** `source`.
 - **Upstream:** Clone `https://github.com/CodebuffAI/codebuff.git` at
   `b285b562b9ef3a3f35272ed32718eeb74dd86283`; see
   [chat.ts](https://github.com/CodebuffAI/codebuff/blob/b285b562b9ef3a3f35272ed32718eeb74dd86283/cli/src/types/chat.ts)
-  for the `ChatMessage` and `ContentBlock` type definitions that define
-  the on-disk format, and
+  for the `ChatMessage` and `ContentBlock` type definitions that define the
+  on-disk format, and
   [session-state.ts](https://github.com/CodebuffAI/codebuff/blob/b285b562b9ef3a3f35272ed32718eeb74dd86283/common/src/types/session-state.ts)
   for the `AgentState` type that defines `contextTokenCount` and
-  `creditsUsed`. Freebuff shares the same layout and is distinguished by
-  the `agentType` field in `run-state.json`.
-- **Usage and cost:** The `contextTokenCount` field in
-  `run-state.json` provides context window token counts (updated per
-  API step). The `creditsUsed` and `directCreditsUsed` fields provide
-  session-level billing totals (1 credit = $0.01). The `agentType` field
-  records the agent template name (e.g. `base2-deepseek`,
-  `base2-free-mimo`), which encodes the model family but is not the
-  actual LLM model -- the real model is selected server-side and can
-  change mid-session; mid-session model switches are not detectable from
-  the on-disk format. Per-message token breakdown (input/output/cache)
-  is not available; only context window size and billing credits are
-  persisted. Freebuff (free tier) has no credits -- it is ad-supported
-  with daily session limits.
+  `creditsUsed`. Freebuff shares the same layout and is distinguished by the
+  `agentType` field in `run-state.json`.
+- **Usage and cost:** The `contextTokenCount` field in `run-state.json` provides
+  context window token counts (updated per API step). The `creditsUsed` and
+  `directCreditsUsed` fields provide session-level billing totals (1 credit =
+  $0.01). The `agentType` field records the agent template name (e.g.
+  `base2-deepseek`, `base2-free-mimo`), which encodes the model family but is
+  not the actual LLM model -- the real model is selected server-side and can
+  change mid-session; mid-session model switches are not detectable from the
+  on-disk format. Per-message token breakdown (input/output/cache) is not
+  available; only context window size and billing credits are persisted.
+  Freebuff (free tier) has no credits -- it is ad-supported with daily session
+  limits.
 - **Agentsview:** `internal/parser/codebuff.go` and
-  `internal/parser/codebuff_provider.go`; single-file provider with
-  JSON array parsing.
-
+  `internal/parser/codebuff_provider.go`; single-file provider with JSON array
+  parsing.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -3076,18 +3076,20 @@ func (db *DB) ListSessionIDsByFilePath(path, agent string) ([]string, error) {
 
 const sessionMachineBatchSize = 500
 
-// SessionWriteIdentity is the stored evidence used to decide whether a copied
-// source may reuse the session's machine for local project identity discovery.
+// SessionWriteIdentity is the stored state used to preserve immutable source
+// attribution and parser-owned Codex titles across session writes and rebuilds.
 type SessionWriteIdentity struct {
-	Machine  string
-	Agent    string
-	FilePath string
-	FileHash string
+	Machine     string
+	Agent       string
+	FilePath    string
+	FileHash    string
+	SessionName *string
 }
 
-// ListSessionWriteIdentitiesByID returns stored source evidence for each
-// requested session, including tombstoned rows that may be revived by a later
-// successful parse. Requests are chunked below SQLite's bind-variable limit.
+// ListSessionWriteIdentitiesByID returns stored source attribution and parser
+// title state for each requested session, including tombstoned rows that may be
+// revived by a later successful parse. Requests are chunked below SQLite's
+// bind-variable limit.
 func (db *DB) ListSessionWriteIdentitiesByID(
 	ctx context.Context,
 	ids []string,
@@ -3118,7 +3120,8 @@ func (db *DB) ListSessionWriteIdentitiesByID(
 		}
 		rows, err := db.getReader().QueryContext(ctx, `
 			SELECT id, machine, agent,
-			       COALESCE(file_path, ''), COALESCE(file_hash, '')
+			       COALESCE(file_path, ''), COALESCE(file_hash, ''),
+			       session_name
 			FROM sessions
 			WHERE id IN (`+placeholders+`)
 			ORDER BY id`, args...)
@@ -3130,7 +3133,7 @@ func (db *DB) ListSessionWriteIdentitiesByID(
 			var identity SessionWriteIdentity
 			if err := rows.Scan(
 				&id, &identity.Machine, &identity.Agent,
-				&identity.FilePath, &identity.FileHash,
+				&identity.FilePath, &identity.FileHash, &identity.SessionName,
 			); err != nil {
 				_ = rows.Close()
 				return nil, fmt.Errorf(

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -372,6 +372,12 @@ type Session struct {
 	LocalModifiedAt      *string `json:"local_modified_at,omitempty"`
 	TranscriptRevision   *string `json:"transcript_revision,omitempty"`
 	CreatedAt            string  `json:"created_at"`
+
+	// PreserveSessionName is transient write intent. Parser write paths set it
+	// when a provider supplied no authoritative title signal, so an upsert
+	// retains an existing session_name while a new row can still use the
+	// parser's fallback name.
+	PreserveSessionName bool `json:"-"`
 }
 
 // SessionCursor is the opaque pagination token. EndedAt carries the
@@ -1365,7 +1371,9 @@ const upsertSessionBaseSQL = insertSessionSQL + `
 			entrypoint = excluded.entrypoint,
 			session_kind = excluded.session_kind,
 			first_message = excluded.first_message,
-			-- session_name is always overwritten by re-parse; display_name
+			-- Parser writes resolve session_name before this statement: an
+			-- explicit title (including blank) replaces it, while an absent
+			-- provider signal may carry the existing value forward. display_name
 			-- is the user override and is only touched by RenameSession.
 			session_name = excluded.session_name,
 			started_at = excluded.started_at,
@@ -1521,10 +1529,14 @@ func upsertSessionExec(
 		return sessionUpsertResult{}, ErrSessionExcluded
 	}
 	var previousProject string
+	var previousSessionName sql.NullString
 	var deletedAt, deletionCause sql.NullString
 	err = queryRow(
-		"SELECT project, deleted_at, deletion_cause FROM sessions WHERE id = ?", s.ID,
-	).Scan(&previousProject, &deletedAt, &deletionCause)
+		"SELECT project, session_name, deleted_at, deletion_cause "+
+			"FROM sessions WHERE id = ?", s.ID,
+	).Scan(
+		&previousProject, &previousSessionName, &deletedAt, &deletionCause,
+	)
 	result := sessionUpsertResult{
 		inserted:        errors.Is(err, sql.ErrNoRows),
 		previousProject: previousProject,
@@ -1533,6 +1545,14 @@ func upsertSessionExec(
 	if err != nil && !result.inserted {
 		return sessionUpsertResult{},
 			fmt.Errorf("checking session %s: %w", s.ID, err)
+	}
+	if s.PreserveSessionName && !result.inserted {
+		if previousSessionName.Valid {
+			name := previousSessionName.String
+			s.SessionName = &name
+		} else {
+			s.SessionName = nil
+		}
 	}
 	if deletedAt.Valid &&
 		(!deletionCause.Valid || deletionCause.String != deletionCauseSourceMissing) {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1527,8 +1527,11 @@ func (p *codexProvider) parseSessionSnapshot(
 	}
 
 	sessionName := ""
+	sessionNamePresent := false
 	if p.spec.agent == AgentCodex {
-		sessionName = LookupCodexThreadName(path, b.sessionID)
+		sessionName, sessionNamePresent = LookupCodexThreadNameEntry(
+			path, b.sessionID,
+		)
 	}
 	if sessionName == "" && b.firstMessage == "" &&
 		b.relationshipType == RelSubagent {
@@ -1536,20 +1539,21 @@ func (p *codexProvider) parseSessionSnapshot(
 	}
 
 	sess := &ParsedSession{
-		ID:                sessionID,
-		Project:           b.project,
-		Machine:           machine,
-		Agent:             AgentCodex,
-		ParentSessionID:   b.parentSessionID,
-		RelationshipType:  b.relationshipType,
-		Cwd:               b.cwd,
-		FirstMessage:      b.firstMessage,
-		SessionName:       sessionName,
-		StartedAt:         b.startedAt,
-		EndedAt:           b.endedAt,
-		MessageCount:      len(b.messages),
-		UserMessageCount:  userCount,
-		TerminationStatus: classifyCodexTermination(b.lastTaskEvent),
+		ID:                 sessionID,
+		Project:            b.project,
+		Machine:            machine,
+		Agent:              AgentCodex,
+		ParentSessionID:    b.parentSessionID,
+		RelationshipType:   b.relationshipType,
+		Cwd:                b.cwd,
+		FirstMessage:       b.firstMessage,
+		SessionName:        sessionName,
+		SessionNamePresent: sessionNamePresent,
+		StartedAt:          b.startedAt,
+		EndedAt:            b.endedAt,
+		MessageCount:       len(b.messages),
+		UserMessageCount:   userCount,
+		TerminationStatus:  classifyCodexTermination(b.lastTaskEvent),
 		File: FileInfo{
 			Path:   path,
 			Size:   info.Size(),

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1533,7 +1533,7 @@ func (p *codexProvider) parseSessionSnapshot(
 			path, b.sessionID,
 		)
 	}
-	if sessionName == "" && b.firstMessage == "" &&
+	if !sessionNamePresent && sessionName == "" && b.firstMessage == "" &&
 		b.relationshipType == RelSubagent {
 		sessionName = codexAgentPathLeaf(b.agentPath)
 	}

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1610,18 +1610,31 @@ func EvictCodexSessionIndexForSession(sessionPath string) {
 // LookupCodexThreadName returns the current Codex thread name for a session
 // from the session_index.jsonl file next to the session root.
 func LookupCodexThreadName(sessionPath, sessionID string) string {
+	name, _ := LookupCodexThreadNameEntry(sessionPath, sessionID)
+	return name
+}
+
+// LookupCodexThreadNameEntry returns the session_index.jsonl title for the
+// session and whether the index actually holds an entry for it. A missing or
+// unreadable index, or an index without this session, reports ok=false so
+// callers can distinguish "renamed to empty" from "no rename signal at all" —
+// modern Codex releases no longer write session_index.jsonl.
+func LookupCodexThreadNameEntry(
+	sessionPath, sessionID string,
+) (string, bool) {
 	if strings.TrimSpace(sessionID) == "" {
-		return ""
+		return "", false
 	}
 	indexPath := codexSessionIndexPath(sessionPath)
 	if indexPath == "" {
-		return ""
+		return "", false
 	}
 	titles, err := loadCodexSessionIndex(indexPath)
 	if err != nil {
-		return ""
+		return "", false
 	}
-	return strings.TrimSpace(titles[sessionID])
+	title, ok := titles[sessionID]
+	return strings.TrimSpace(title), ok
 }
 
 // CodexEffectiveMtime returns the effective mtime for a Codex session file,

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1720,7 +1720,8 @@ func loadCodexSessionIndex(indexPath string) (map[string]string, error) {
 }
 
 // ParseCodexSessionIndexTitles reads a Codex session_index.jsonl stream and
-// returns session UUIDs mapped to non-empty thread titles.
+// returns session UUIDs mapped to their thread titles. Explicit blank titles
+// remain present so callers can distinguish them from absent entries.
 func ParseCodexSessionIndexTitles(r io.Reader) (map[string]string, error) {
 	titles := make(map[string]string)
 	s := bufio.NewScanner(r)
@@ -1731,11 +1732,11 @@ func ParseCodexSessionIndexTitles(r io.Reader) (map[string]string, error) {
 			continue
 		}
 		id := gjson.Get(line, "id").Str
-		title := strings.TrimSpace(gjson.Get(line, "thread_name").Str)
-		if id == "" || title == "" {
+		threadName := gjson.Get(line, "thread_name")
+		if id == "" || !threadName.Exists() {
 			continue
 		}
-		titles[id] = title
+		titles[id] = strings.TrimSpace(threadName.Str)
 	}
 	if err := s.Err(); err != nil {
 		return nil, err

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -309,6 +309,8 @@ func TestParseCodexSession_UsesThreadNameFromSessionIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sess)
 	assert.Equal(t, "Renamed from Codex", sess.SessionName)
+	assert.True(t, sess.SessionNamePresent,
+		"an index entry must remain authoritative at the write boundary")
 	assert.Equal(t, "Add rate limiting", sess.FirstMessage)
 	assert.Len(t, msgs, 2)
 }
@@ -330,6 +332,8 @@ func TestParseCodexSession_LeavesSessionNameEmptyWithoutThreadName(t *testing.T)
 	require.NoError(t, err)
 	require.NotNil(t, sess)
 	assert.Empty(t, sess.SessionName)
+	assert.False(t, sess.SessionNamePresent,
+		"a missing thread_name field must not become a clearing signal")
 	assert.Equal(t, "Add rate limiting", sess.FirstMessage)
 }
 

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -270,6 +270,39 @@ func TestParseCodexSession_EncryptedAgentMessageUsesTaskName(t *testing.T) {
 	assert.Equal(t, "I completed the encrypted task.", msgs[0].Content)
 }
 
+func TestParseCodexSession_ExplicitBlankSubagentTitleSuppressesFallback(
+	t *testing.T,
+) {
+	const encrypted = "gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "sessions", "2026", "08", "13")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	sessionPath := filepath.Join(
+		sessionDir, "rollout-2026-08-13T12-00-00-child.jsonl",
+	)
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			"child", "parent", "/tmp/project", "user", tsEarly,
+		),
+		testjsonl.CodexAgentMessageJSON(
+			"/root", "/root/worker", "Task received from parent.",
+			encrypted, tsEarlyS1,
+		),
+	)
+	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, CodexSessionIndexFilename),
+		[]byte(`{"id":"child","thread_name":"   "}`+"\n"), 0o644,
+	))
+
+	sess, _, err := parseCodexTestSession(t, sessionPath, "local", false)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.True(t, sess.SessionNamePresent)
+	assert.Empty(t, sess.SessionName,
+		"an explicit blank title must suppress the subagent leaf fallback")
+}
+
 func TestParseCodexSession_FernetPrefixPlaintextRemainsVisible(t *testing.T) {
 	const prompt = "gAAAAA is only a prefix here, not an encrypted token."
 	content := testjsonl.JoinJSONL(

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -333,6 +333,20 @@ func TestParseCodexSession_LeavesSessionNameEmptyWithoutThreadName(t *testing.T)
 	assert.Equal(t, "Add rate limiting", sess.FirstMessage)
 }
 
+func TestParseCodexSessionIndexTitlesPreservesExplicitBlankTitle(t *testing.T) {
+	titles, err := ParseCodexSessionIndexTitles(strings.NewReader(
+		`{"id":"clear-me","thread_name":"   "}` + "\n" +
+			`{"id":"missing-field"}` + "\n",
+	))
+	require.NoError(t, err)
+
+	title, ok := titles["clear-me"]
+	require.True(t, ok, "an explicit blank title must remain a present entry")
+	assert.Empty(t, title)
+	assert.NotContains(t, titles, "missing-field",
+		"a row without thread_name must not become a clearing signal")
+}
+
 func TestParseCodexSession_UsesThreadNameFromArchivedSessions(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := filepath.Join(root, "archived_sessions")

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -1169,11 +1169,16 @@ type ParsedSession struct {
 	IsTruncated             bool
 	FirstMessage            string
 	SessionName             string
-	StartedAt               time.Time
-	EndedAt                 time.Time
-	MessageCount            int
-	UserMessageCount        int
-	File                    FileInfo
+	// SessionNamePresent distinguishes an explicitly present provider title
+	// (including a blank title) from no title signal. Codex needs this because
+	// current releases may omit session_index.jsonl entirely, while an older
+	// index entry with a blank thread_name explicitly clears a stored title.
+	SessionNamePresent bool
+	StartedAt          time.Time
+	EndedAt            time.Time
+	MessageCount       int
+	UserMessageCount   int
+	File               FileInfo
 
 	// TerminationStatus describes how the session appears to have
 	// ended. Empty string = unknown (parser did not classify, or

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11225,6 +11225,8 @@ func (e *Engine) shouldSkipProviderSourceByDB(
 //   - an effective mtime ahead of the stored mtime driven only by the index
 //     (the raw transcript mtime is still at or below the stored mtime) skips
 //     unless this session's stored title differs from the current index title.
+//   - an effective mtime below the stored mtime skips when the index is absent,
+//     because removing a newer index reveals the unchanged transcript mtime.
 func (e *Engine) shouldSkipCodexFingerprint(
 	agent parser.AgentType,
 	path string,
@@ -11264,6 +11266,14 @@ func (e *Engine) shouldSkipCodexFingerprint(
 	}
 	if agent != parser.AgentCodex {
 		return false
+	}
+	if effectiveMtime < storedMtime {
+		indexPath := parser.CodexSessionIndexPath(path)
+		if indexPath != "" {
+			if _, err := os.Stat(indexPath); errors.Is(err, os.ErrNotExist) {
+				return true
+			}
+		}
 	}
 	fileMtime := effectiveMtime
 	if info, err := os.Stat(path); err == nil {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -12042,6 +12042,18 @@ func (e *Engine) normalizePendingWriteMachines(
 				batch[i].sourceIdentityUnverified =
 					!sessionWriteIdentitySupportsStoredAttribution(stored, incoming)
 				batch[i].sess.Machine = stored.Machine
+				// A rebuild writes into a fresh database, so the upsert cannot
+				// preserve a title from the destination row. Carry the archived
+				// nullable title into index-less Codex parses; an explicitly
+				// present blank remains authoritative and bypasses this path.
+				if e.archiveStore != nil &&
+					batch[i].sess.Agent == parser.AgentCodex &&
+					!batch[i].sess.SessionNamePresent {
+					batch[i].sess.SessionName = ""
+					if stored.SessionName != nil {
+						batch[i].sess.SessionName = *stored.SessionName
+					}
+				}
 			}
 			continue
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11303,7 +11303,15 @@ func (e *Engine) codexIndexSessionNameChanged(path string) bool {
 	if uuid == "" {
 		return false
 	}
-	currentName := parser.LookupCodexThreadName(path, uuid)
+	currentName, ok := parser.LookupCodexThreadNameEntry(path, uuid)
+	if !ok {
+		// No index entry means no rename signal, not a rename to empty.
+		// Modern Codex releases stopped writing session_index.jsonl; a
+		// stored title compared against the absent index would force a
+		// full re-parse of every titled session on every sync, and the
+		// rewrite preserves the title, so the loop could never converge.
+		return false
+	}
 	storedName, found, err := e.db.GetSessionName(
 		context.Background(), e.idPrefix+"codex:"+uuid,
 	)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -14592,6 +14592,8 @@ func toDBSession(pw pendingWrite) db.Session {
 		s.FirstMessage = &pw.sess.FirstMessage
 	}
 	s.SessionName = db.ParsedSessionName(pw.sess)
+	s.PreserveSessionName = pw.sess.Agent == parser.AgentCodex &&
+		!pw.sess.SessionNamePresent
 	if !pw.sess.StartedAt.IsZero() {
 		s.StartedAt = timeutil.Ptr(pw.sess.StartedAt)
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5396,9 +5396,9 @@ func TestSyncAllSinceCodexIndexRenameBelowStoredMtimeRefreshesName(t *testing.T)
 // Codex-upgrade scenario behind the eternal reparse loop: a session gains a
 // title while session_index.jsonl exists, then a newer Codex release stops
 // writing the index file. The next full sync of the untouched transcript must
-// skip; treating the absent index as a rename force-replaced every titled
-// session on every sync, and the rewrite preserved the title so the loop
-// never converged.
+// skip even though removing the newer index regresses the effective mtime;
+// treating that regression as stale force-replaced every titled session and
+// cleared its stored title.
 func TestSyncAllSkipsUnchangedTitledCodexSessionAfterIndexRemoval(t *testing.T) {
 	root := t.TempDir()
 	codexDir := filepath.Join(root, "sessions")
@@ -5417,16 +5417,16 @@ func TestSyncAllSkipsUnchangedTitledCodexSessionAfterIndexRemoval(t *testing.T) 
 		content,
 	)
 
-	// The index is older than the transcript so the stored file_mtime is the
-	// raw transcript mtime, matching an archive whose sessions were last
-	// rewritten after the index disappeared.
+	// The index is newer than the transcript, so its mtime becomes the stored
+	// effective watermark. Removing it later regresses the effective mtime to
+	// the untouched transcript mtime.
 	indexPath := filepath.Join(root, "session_index.jsonl")
 	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
 		`{"id":"%s","thread_name":"Sticky title","updated_at":"2026-06-11T12:50:00Z"}`+"\n",
 		uuid,
 	), 0o644))
 	transcriptTime := time.Now().Add(-2 * time.Hour)
-	indexTime := transcriptTime.Add(-time.Hour)
+	indexTime := transcriptTime.Add(time.Hour)
 	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
 	require.NoError(t, os.Chtimes(indexPath, indexTime, indexTime))
 
@@ -5450,6 +5450,57 @@ func TestSyncAllSkipsUnchangedTitledCodexSessionAfterIndexRemoval(t *testing.T) 
 	if assert.NotNil(t, sess.SessionName, "stored title must survive the skip") {
 		assert.Equal(t, "Sticky title", *sess.SessionName)
 	}
+}
+
+func TestSyncAllCodexExplicitBlankIndexTitleClearsStoredTitle(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e3"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/repo", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Clear my title").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+	transcriptTime := time.Now().Add(-3 * time.Hour)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
+
+	indexPath := filepath.Join(root, parser.CodexSessionIndexFilename)
+	writeIndex := func(title string, mtime time.Time) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+			`{"id":"%s","thread_name":"%s","updated_at":"2026-06-11T12:50:00Z"}`+"\n",
+			uuid, title,
+		), 0o644))
+		require.NoError(t, os.Chtimes(indexPath, mtime, mtime))
+		parser.EvictCodexSessionIndex(indexPath)
+	}
+
+	writeIndex("Stored title", transcriptTime.Add(time.Hour))
+	first := env.engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, first.Synced)
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	if assert.NotNil(t, sess.SessionName) {
+		assert.Equal(t, "Stored title", *sess.SessionName)
+	}
+
+	writeIndex("", transcriptTime.Add(2*time.Hour))
+	second := env.engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, second.Synced,
+		"an explicit blank index title must trigger a refresh")
+	sess, err = env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Nil(t, sess.SessionName, "the stored title must be cleared")
 }
 
 func TestSyncAllWarmGateCodexIndexSameStatRenameRefreshesName(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5452,6 +5452,105 @@ func TestSyncAllSkipsUnchangedTitledCodexSessionAfterIndexRemoval(t *testing.T) 
 	}
 }
 
+func TestCodexRequiredReparseWithoutIndexPreservesStoredTitle(t *testing.T) {
+	tests := []struct {
+		name        string
+		wantReparse bool
+		resync      func(
+			t *testing.T, env *testEnv, sessionID, indexPath string,
+		)
+	}{
+		{
+			name: "removed index through SyncPaths",
+			resync: func(
+				t *testing.T, env *testEnv, _, indexPath string,
+			) {
+				t.Helper()
+				require.NoError(t, env.engine.SyncPathsContext(
+					context.Background(), []string{indexPath},
+				))
+			},
+		},
+		{
+			name:        "stale data version",
+			wantReparse: true,
+			resync: func(
+				t *testing.T, env *testEnv, sessionID, _ string,
+			) {
+				t.Helper()
+				require.Greater(t, db.CurrentDataVersion(), 1)
+				require.NoError(t, env.db.SetSessionDataVersion(
+					sessionID, db.CurrentDataVersion()-1,
+				))
+				stats := env.engine.SyncAll(context.Background(), nil)
+				require.Equal(t, 1, stats.Synced,
+					"stale data version must force a full reparse")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			codexDir := filepath.Join(root, "sessions")
+			require.NoError(t, os.MkdirAll(codexDir, 0o755))
+			env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+			uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e4"
+			sessionID := "codex:" + uuid
+			content := testjsonl.NewSessionBuilder().
+				AddCodexMeta(tsEarly, uuid, "/repo", "user").
+				AddCodexMessage(tsEarlyS1, "user", "Keep my title").
+				String()
+			path := env.writeCodexSession(
+				t,
+				filepath.Join("2026", "06", "11"),
+				"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+				content,
+			)
+
+			indexPath := filepath.Join(root, parser.CodexSessionIndexFilename)
+			require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+				`{"id":"%s","thread_name":"Sticky title"}`+"\n", uuid,
+			), 0o644))
+			transcriptTime := time.Now().Add(-2 * time.Hour)
+			indexTime := transcriptTime.Add(time.Hour)
+			require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
+			require.NoError(t, os.Chtimes(indexPath, indexTime, indexTime))
+
+			first := env.engine.SyncAll(context.Background(), nil)
+			require.Equal(t, 1, first.Synced)
+			sess, err := env.db.GetSessionFull(context.Background(), sessionID)
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+			require.NotNil(t, sess.SessionName)
+			require.Equal(t, "Sticky title", *sess.SessionName)
+			require.NotNil(t, sess.FileMtime)
+			require.Equal(t, indexTime.UnixNano(), *sess.FileMtime)
+
+			require.NoError(t, os.Remove(indexPath))
+			tt.resync(t, env, sessionID, indexPath)
+
+			sess, err = env.db.GetSessionFull(context.Background(), sessionID)
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+			if assert.NotNil(t, sess.SessionName,
+				"a missing index entry must not erase the stored title") {
+				assert.Equal(t, "Sticky title", *sess.SessionName)
+			}
+			require.NotNil(t, sess.FileMtime)
+			if tt.wantReparse {
+				assert.Equal(t, transcriptTime.UnixNano(), *sess.FileMtime,
+					"the transcript must have been reparsed and persisted")
+			} else {
+				assert.Equal(t, indexTime.UnixNano(), *sess.FileMtime,
+					"the removed-index event may leave an unchanged transcript skipped")
+			}
+			assert.Equal(t, db.CurrentDataVersion(), sess.DataVersion)
+		})
+	}
+}
+
 func TestSyncAllCodexExplicitBlankIndexTitleClearsStoredTitle(t *testing.T) {
 	root := t.TempDir()
 	codexDir := filepath.Join(root, "sessions")

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5487,6 +5487,18 @@ func TestCodexRequiredReparseWithoutIndexPreservesStoredTitle(t *testing.T) {
 					"stale data version must force a full reparse")
 			},
 		},
+		{
+			name:        "ResyncAll rebuild",
+			wantReparse: true,
+			resync: func(
+				t *testing.T, env *testEnv, _, _ string,
+			) {
+				t.Helper()
+				stats := env.engine.ResyncAll(context.Background(), nil)
+				require.False(t, stats.Aborted, "ResyncAll aborted: %v", stats.Warnings)
+				require.Equal(t, 1, stats.Synced)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -5551,7 +5563,7 @@ func TestCodexRequiredReparseWithoutIndexPreservesStoredTitle(t *testing.T) {
 	}
 }
 
-func TestSyncAllCodexExplicitBlankIndexTitleClearsStoredTitle(t *testing.T) {
+func TestCodexExplicitBlankIndexTitleClearsStoredTitle(t *testing.T) {
 	root := t.TempDir()
 	codexDir := filepath.Join(root, "sessions")
 	require.NoError(t, os.MkdirAll(codexDir, 0o755))
@@ -5600,6 +5612,28 @@ func TestSyncAllCodexExplicitBlankIndexTitleClearsStoredTitle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sess)
 	assert.Nil(t, sess.SessionName, "the stored title must be cleared")
+
+	// Rebuilds parse into a fresh database and seed absent titles from the old
+	// archive. Prove that an explicitly present blank still bypasses that carry
+	// forward instead of resurrecting the archived title.
+	writeIndex("Stored title", transcriptTime.Add(3*time.Hour))
+	restored := env.engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, restored.Synced)
+	sess, err = env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.SessionName)
+	require.Equal(t, "Stored title", *sess.SessionName)
+
+	writeIndex("", transcriptTime.Add(4*time.Hour))
+	rebuilt := env.engine.ResyncAll(context.Background(), nil)
+	require.False(t, rebuilt.Aborted, "ResyncAll aborted: %v", rebuilt.Warnings)
+	require.Equal(t, 1, rebuilt.Synced)
+	sess, err = env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Nil(t, sess.SessionName,
+		"an explicit blank title must clear through a fresh-database rebuild")
 }
 
 func TestSyncAllWarmGateCodexIndexSameStatRenameRefreshesName(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5392,6 +5392,66 @@ func TestSyncAllSinceCodexIndexRenameBelowStoredMtimeRefreshesName(t *testing.T)
 	}
 }
 
+// TestSyncAllSkipsUnchangedTitledCodexSessionAfterIndexRemoval replays the
+// Codex-upgrade scenario behind the eternal reparse loop: a session gains a
+// title while session_index.jsonl exists, then a newer Codex release stops
+// writing the index file. The next full sync of the untouched transcript must
+// skip; treating the absent index as a rename force-replaced every titled
+// session on every sync, and the rewrite preserved the title so the loop
+// never converged.
+func TestSyncAllSkipsUnchangedTitledCodexSessionAfterIndexRemoval(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e2"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Keep my title").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+
+	// The index is older than the transcript so the stored file_mtime is the
+	// raw transcript mtime, matching an archive whose sessions were last
+	// rewritten after the index disappeared.
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Sticky title","updated_at":"2026-06-11T12:50:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	transcriptTime := time.Now().Add(-2 * time.Hour)
+	indexTime := transcriptTime.Add(-time.Hour)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
+	require.NoError(t, os.Chtimes(indexPath, indexTime, indexTime))
+
+	env.engine.SyncAll(context.Background(), nil)
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "expected Codex session to sync")
+	require.NotNil(t, sess.SessionName, "expected session_name to be imported")
+	require.Equal(t, "Sticky title", *sess.SessionName)
+
+	// A Codex upgrade removes session_index.jsonl; the transcript is untouched.
+	require.NoError(t, os.Remove(indexPath))
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	assert.Equal(t, 0, stats.Synced,
+		"an unchanged titled session must skip once the index is gone")
+
+	sess, err = env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull after index removal")
+	require.NotNil(t, sess, "expected Codex session to remain")
+	if assert.NotNil(t, sess.SessionName, "stored title must survive the skip") {
+		assert.Equal(t, "Sticky title", *sess.SessionName)
+	}
+}
+
 func TestSyncAllWarmGateCodexIndexSameStatRenameRefreshesName(t *testing.T) {
 	root := t.TempDir()
 	codexDir := filepath.Join(root, "sessions")

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -10866,6 +10866,36 @@ func TestCodexIndexSessionNameChangedDetectsTitleRenameBelowStoredMtime(t *testi
 		"title-only rename at or below stored watermark must report a change")
 }
 
+// TestCodexIndexSessionNameChangedIgnoresAbsentIndexEntry pins the reparse-loop
+// fix: a stored title with no session_index.jsonl entry to compare against is
+// not a rename signal. Modern Codex releases no longer write
+// session_index.jsonl at all, so treating the absent index as "renamed to
+// empty" made every titled session force a full re-parse on every sync,
+// forever — the full parse preserves the stored title, so the check could
+// never converge.
+func TestCodexIndexSessionNameChangedIgnoresAbsentIndexEntry(t *testing.T) {
+	t.Run("index file removed", func(t *testing.T) {
+		database := openTestDB(t)
+		f := seedCodexRenameCase(t, database)
+		idxPath := filepath.Join(f.root, parser.CodexSessionIndexFilename)
+		require.NoError(t, os.Remove(idxPath))
+
+		assert.False(t, f.e.codexIndexSessionNameChanged(f.path),
+			"a missing index must not report a stored title as renamed")
+	})
+
+	t.Run("index has no entry for this session", func(t *testing.T) {
+		database := openTestDB(t)
+		f := seedCodexRenameCase(t, database)
+		writeCodexIndexForTest(t, f.root,
+			"99999999-8888-7777-6666-555555555555", "Other Session",
+			time.Unix(0, f.effectiveMtime))
+
+		assert.False(t, f.e.codexIndexSessionNameChanged(f.path),
+			"an index without this session's entry must not report a rename")
+	})
+}
+
 func TestCodexStoredNameDiffersPreservesMissingSemantics(t *testing.T) {
 	database := openTestDB(t)
 	require.NoError(t, database.UpsertSession(db.Session{

--- a/internal/sync/s3_source.go
+++ b/internal/sync/s3_source.go
@@ -205,7 +205,7 @@ func (e *Engine) s3CodexIndexNeedsRefreshSince(
 		return false
 	}
 	if snapshot.missing {
-		return e.s3CodexStoredNameDiffers(file, uuid, "")
+		return false
 	}
 	if snapshot.mtime < cutoffNs {
 		return false
@@ -216,13 +216,16 @@ func (e *Engine) s3CodexIndexNeedsRefreshSince(
 		return true
 	}
 	if snapshot.missing {
-		return e.s3CodexStoredNameDiffers(file, uuid, "")
+		return false
 	}
 	if !snapshot.titlesLoaded {
 		return false
 	}
 
-	title := snapshot.titles[uuid]
+	title, ok := snapshot.titles[uuid]
+	if !ok {
+		return false
+	}
 	return e.s3CodexStoredNameDiffers(file, uuid, title)
 }
 
@@ -238,12 +241,15 @@ func (e *Engine) s3CodexIndexSessionNameChanged(
 		return false, snapshot.err
 	}
 	if snapshot.missing {
-		return e.s3CodexStoredNameDiffers(file, uuid, ""), nil
+		return false, nil
 	}
 	if !snapshot.statOK || !snapshot.titlesLoaded {
 		return false, nil
 	}
-	title := snapshot.titles[uuid]
+	title, ok := snapshot.titles[uuid]
+	if !ok {
+		return false, nil
+	}
 	return e.s3CodexStoredNameDiffers(file, uuid, title), nil
 }
 

--- a/internal/sync/s3_source_test.go
+++ b/internal/sync/s3_source_test.go
@@ -27,13 +27,14 @@ func TestProcessFileS3UsesObjectMetadataToSkipBeforeFetch(t *testing.T) {
 	mtime := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC).UnixNano()
 
 	sess := db.Session{
-		ID:        "laptop~codex:" + uuid,
-		Project:   "agentsview",
-		Machine:   "laptop",
-		Agent:     "codex",
-		FilePath:  strPtr(path),
-		FileSize:  int64Ptr(size),
-		FileMtime: int64Ptr(mtime),
+		ID:          "laptop~codex:" + uuid,
+		Project:     "agentsview",
+		Machine:     "laptop",
+		Agent:       "codex",
+		FilePath:    strPtr(path),
+		FileSize:    int64Ptr(size),
+		FileMtime:   int64Ptr(mtime),
+		SessionName: strPtr("Stored title"),
 	}
 	require.NoError(t, database.UpsertSession(sess))
 	require.NoError(t, database.SetSessionDataVersion(
@@ -513,7 +514,7 @@ func TestFilterFilesByMtimeKeepsS3CodexIndexFetchError(t *testing.T) {
 	assert.Equal(t, 1, fetchCalls)
 }
 
-func TestFilterFilesByMtimeKeepsS3CodexClearedIndexTitle(t *testing.T) {
+func TestFilterFilesByMtimeKeepsS3CodexExplicitBlankIndexTitle(t *testing.T) {
 	database := openTestDB(t)
 	const uuid = "11111111-1111-4111-8111-111111111111"
 	root := "s3://bucket/laptop/raw/codex"
@@ -538,56 +539,42 @@ func TestFilterFilesByMtimeKeepsS3CodexClearedIndexTitle(t *testing.T) {
 		"laptop~codex:"+uuid, db.CurrentDataVersion(),
 	))
 
-	for _, tc := range []struct {
-		name, index string
-	}{
-		{
-			name:  "blank title",
-			index: `{"id":"` + uuid + `","thread_name":"","updated_at":"2026-06-24T12:30:00Z"}` + "\n",
-		},
-		{
-			name:  "missing title row",
-			index: `{"id":"22222222-2222-4222-8222-222222222222","thread_name":"Other","updated_at":"2026-06-24T12:30:00Z"}` + "\n",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			oldStat := statS3Object
-			oldFetch := fetchS3Object
-			t.Cleanup(func() {
-				statS3Object = oldStat
-				fetchS3Object = oldFetch
-			})
-			statS3Object = func(got string) (parser.S3Object, error) {
-				require.Equal(t, indexPath, got)
-				return parser.S3Object{
-					URI:          indexPath,
-					Size:         int64(len(tc.index)),
-					LastModified: indexMtime,
-					Fingerprint:  "s3:fingerprint:index",
-				}, nil
-			}
-			fetchS3Object = func(got string) (io.ReadCloser, error) {
-				require.Equal(t, indexPath, got)
-				return io.NopCloser(strings.NewReader(tc.index)), nil
-			}
-
-			e := &Engine{db: database}
-			got := e.filterFilesByMtime(context.Background(), []parser.DiscoveredFile{{
-				Agent:             parser.AgentCodex,
-				Path:              path,
-				Machine:           "laptop",
-				SourceSize:        101,
-				SourceMtime:       mtime,
-				SourceFingerprint: "s3:fingerprint:rollout",
-			}}, indexMtime.Add(-time.Minute))
-
-			require.Len(t, got, 1)
-			assert.Equal(t, path, got[0].Path)
-		})
+	index := `{"id":"` + uuid + `","thread_name":"","updated_at":"2026-06-24T12:30:00Z"}` + "\n"
+	oldStat := statS3Object
+	oldFetch := fetchS3Object
+	t.Cleanup(func() {
+		statS3Object = oldStat
+		fetchS3Object = oldFetch
+	})
+	statS3Object = func(got string) (parser.S3Object, error) {
+		require.Equal(t, indexPath, got)
+		return parser.S3Object{
+			URI:          indexPath,
+			Size:         int64(len(index)),
+			LastModified: indexMtime,
+			Fingerprint:  "s3:fingerprint:index",
+		}, nil
 	}
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, indexPath, got)
+		return io.NopCloser(strings.NewReader(index)), nil
+	}
+
+	e := &Engine{db: database}
+	got := e.filterFilesByMtime(context.Background(), []parser.DiscoveredFile{{
+		Agent:             parser.AgentCodex,
+		Path:              path,
+		Machine:           "laptop",
+		SourceSize:        101,
+		SourceMtime:       mtime,
+		SourceFingerprint: "s3:fingerprint:rollout",
+	}}, indexMtime.Add(-time.Minute))
+
+	require.Len(t, got, 1)
+	assert.Equal(t, path, got[0].Path)
 }
 
-func TestFilterFilesByMtimeKeepsS3CodexMissingIndexWhenTitleStored(t *testing.T) {
+func TestFilterFilesByMtimeSkipsS3CodexAbsentIndexSignals(t *testing.T) {
 	database := openTestDB(t)
 	const uuid = "11111111-1111-4111-8111-111111111111"
 	root := "s3://bucket/laptop/raw/codex"
@@ -611,35 +598,60 @@ func TestFilterFilesByMtimeKeepsS3CodexMissingIndexWhenTitleStored(t *testing.T)
 		"laptop~codex:"+uuid, db.CurrentDataVersion(),
 	))
 
-	oldStat := statS3Object
-	oldFetch := fetchS3Object
-	t.Cleanup(func() {
-		statS3Object = oldStat
-		fetchS3Object = oldFetch
-	})
-	var fetchCalls int
-	statS3Object = func(got string) (parser.S3Object, error) {
-		require.Equal(t, indexPath, got)
-		return parser.S3Object{}, missingS3ObjectError()
-	}
-	fetchS3Object = func(got string) (io.ReadCloser, error) {
-		fetchCalls++
-		return nil, missingS3ObjectError()
-	}
+	for _, tc := range []struct {
+		name  string
+		index string
+	}{
+		{name: "index missing"},
+		{
+			name:  "session entry missing",
+			index: `{"id":"22222222-2222-4222-8222-222222222222","thread_name":"Other"}` + "\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oldStat := statS3Object
+			oldFetch := fetchS3Object
+			t.Cleanup(func() {
+				statS3Object = oldStat
+				fetchS3Object = oldFetch
+			})
+			var fetchCalls int
+			statS3Object = func(got string) (parser.S3Object, error) {
+				require.Equal(t, indexPath, got)
+				if tc.index == "" {
+					return parser.S3Object{}, missingS3ObjectError()
+				}
+				return parser.S3Object{
+					URI:          indexPath,
+					Size:         int64(len(tc.index)),
+					LastModified: time.Unix(0, mtime).Add(time.Minute),
+				}, nil
+			}
+			fetchS3Object = func(got string) (io.ReadCloser, error) {
+				require.Equal(t, indexPath, got)
+				fetchCalls++
+				return io.NopCloser(strings.NewReader(tc.index)), nil
+			}
 
-	e := &Engine{db: database}
-	got := e.filterFilesByMtime(context.Background(), []parser.DiscoveredFile{{
-		Agent:             parser.AgentCodex,
-		Path:              path,
-		Machine:           "laptop",
-		SourceSize:        101,
-		SourceMtime:       mtime,
-		SourceFingerprint: "s3:fingerprint:rollout",
-	}}, time.Unix(0, mtime).Add(time.Nanosecond))
+			e := &Engine{db: database}
+			got := e.filterFilesByMtime(context.Background(), []parser.DiscoveredFile{{
+				Agent:             parser.AgentCodex,
+				Path:              path,
+				Machine:           "laptop",
+				SourceSize:        101,
+				SourceMtime:       mtime,
+				SourceFingerprint: "s3:fingerprint:rollout",
+			}}, time.Unix(0, mtime).Add(time.Nanosecond))
 
-	require.Len(t, got, 1)
-	assert.Equal(t, path, got[0].Path)
-	assert.Equal(t, 0, fetchCalls)
+			assert.Empty(t, got,
+				"an absent index signal must not reparse an unchanged session")
+			if tc.index == "" {
+				assert.Equal(t, 0, fetchCalls)
+			} else {
+				assert.Equal(t, 1, fetchCalls)
+			}
+		})
+	}
 }
 
 func TestPickPreferredCodexDiscoveredFileUsesS3MachinePrefix(t *testing.T) {

--- a/internal/sync/s3_test.go
+++ b/internal/sync/s3_test.go
@@ -395,7 +395,7 @@ func TestProcessS3CodexClearedSessionIndexTitleBypassesStoredSkip(t *testing.T) 
 	assert.Empty(t, res.results[0].Session.SessionName)
 }
 
-func TestProcessS3CodexMissingSessionIndexBypassesStoredSkip(t *testing.T) {
+func TestProcessS3CodexMissingSessionIndexUsesStoredSkip(t *testing.T) {
 	database := openTestDB(t)
 	const uuid = "11111111-1111-4111-8111-111111111111"
 	path := "s3://bucket/laptop/raw/codex/2026/06/24/" +
@@ -457,10 +457,18 @@ func TestProcessS3CodexMissingSessionIndexBypassesStoredSkip(t *testing.T) {
 	})
 
 	require.NoError(t, res.err)
-	require.False(t, res.skip)
-	require.True(t, fetchedRollout)
-	require.Len(t, res.results, 1)
-	assert.Empty(t, res.results[0].Session.SessionName)
+	require.True(t, res.skip)
+	assert.False(t, fetchedRollout)
+	assert.Empty(t, res.results)
+
+	sess, err := database.GetSessionFull(
+		context.Background(), "laptop~codex:"+uuid,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	if assert.NotNil(t, sess.SessionName) {
+		assert.Equal(t, "Old title", *sess.SessionName)
+	}
 }
 
 func TestProcessS3ClaudeSubagentPreservesParentLayout(t *testing.T) {


### PR DESCRIPTION
## Summary

Routine incremental syncs were rewriting every titled Codex session on every sweep — on a large real archive, ~1,600 sessions and ~117k messages per sync, with the work never converging.

Root cause: modern Codex releases no longer write `session_index.jsonl` (thread titles moved into `thread_history_*.sqlite`, which agentsview does not read). `codexIndexSessionNameChanged` compared each stored `session_name` against the absent index via `LookupCodexThreadName`, which returns an empty string when the index is missing, so every titled session read as "renamed to empty". That verdict flows into the codex pre-gate in the incremental path as `forceReplace: true`, which bypasses both DB freshness skips and forces a full parse and rewrite. The rewrite preserves the stored title, so the same sessions were re-flagged on the next sweep, forever.

The fix adds `parser.LookupCodexThreadNameEntry`, which reports whether the index actually holds an entry for the session, and makes `codexIndexSessionNameChanged` treat a missing or unreadable index — or an index without this session's entry — as "no rename signal" rather than a rename to empty. Sessions whose index entry is present keep the existing rename-detection behavior. Validated against a clone of the affected archive: per-sweep writes dropped from ~1,634 sessions / ~117k messages to steady-state noise.

The provenance notes in `docs/internal/session-format-sources.md` now record the upstream removal of `session_index.jsonl` (reverified 2026-08-13). The doc commit also picks up mdformat hook fixes to the Codebuff section, which had landed with non-canonical wrapping.

Where to look:

- `internal/sync/engine.go` — `codexIndexSessionNameChanged` now distinguishes "no index entry" from "renamed to empty"
- `internal/parser/codex.go` — new presence-aware `LookupCodexThreadNameEntry`; `LookupCodexThreadName` delegates to it
- `internal/sync/engine_test.go` / `engine_integration_test.go` — unit coverage for removed index and missing entry, plus an end-to-end test that a titled session stays skipped after index removal

Limits: this restores the freshness skip; it does not add a reader for `thread_history_*.sqlite`, so titles created by current Codex releases are still not ingested (stored titles from older releases are preserved).