### PR TITLE
Log incremental full-parse fallbacks with a provider-agnostic error

### DIFF
--- a/internal/artifact/sync_test.go
+++ b/internal/artifact/sync_test.go
@@ -500,14 +500,15 @@ func TestDrainArtifactSyncFullExportReturnsMoreWhenQueueDoesNotSettle(
 	t *testing.T,
 ) {
 	// Serial: this exercises the full drain cap through real SQLite and
-	// Docbank writes under a fixed deadline. Package-wide I/O contention can
-	// otherwise consume the deadline without the drain being stuck.
+	// Docbank writes under a fixed deadline. The race job runs other packages
+	// concurrently, so leave enough headroom for cross-package I/O contention
+	// while retaining a guard against a stuck drain.
 
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")
 	store := newTestArtifactStore(t)
 	concurrent := &reEnqueueOnBoundaryStore{DB: database}
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 
 	result, more, err := drainArtifactSyncExportsWithRounds(

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -2235,7 +2235,8 @@ func (p *codexProvider) parseSessionFrom(
 // parse error requires the caller to fall back to a full parse.
 func IsIncrementalFullParseFallback(err error) bool {
 	return errors.Is(err, errCodexIncrementalNeedsFullParse) ||
-		errors.Is(err, ErrClaudeIncrementalNeedsFullParse)
+		errors.Is(err, ErrClaudeIncrementalNeedsFullParse) ||
+		errors.Is(err, ErrIncrementalNeedsFullParse)
 }
 
 func isCodexSystemMessage(content string) bool {

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -1022,6 +1022,14 @@ const (
 	IncrementalNeedsFullParse
 )
 
+// ErrIncrementalNeedsFullParse signals that a provider declined the
+// appended tail and the caller must fall back to a full parse that
+// replaces stored rows. It is provider-agnostic; parser-internal
+// fallbacks (Claude, Codex) are mapped to it at the provider seam.
+var ErrIncrementalNeedsFullParse = fmt.Errorf(
+	"incremental parse: appended lines require a replacing full parse",
+)
+
 // ProviderFactories returns one provider factory for every registered agent.
 func ProviderFactories() []ProviderFactory {
 	factories := make([]ProviderFactory, 0, len(Registry))

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10843,7 +10843,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 				// Signal the shared helper to fall back to a
 				// full parse that replaces stored messages.
 				return nil, nil, time.Time{}, 0, nil,
-					parser.ErrClaudeIncrementalNeedsFullParse
+					parser.ErrIncrementalNeedsFullParse
 			}
 			// A plain full-parse fallback without a replace request.
 			// The Claude provider always sets ForceReplace on its

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2525,12 +2525,12 @@ func TestSyncEngineWorktreeProjectWhenPathMissing(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
 
 	mainContent := testjsonl.NewSessionBuilder().
-		AddRaw(`{"type":"user","timestamp":"2024-01-01T10:00:00Z","cwd":"/Users/wesm/code/agentsview","gitBranch":"main","message":{"content":"hello"}}`).
+		AddRaw(`{"type":"user","timestamp":"2024-01-01T10:00:00Z","cwd":"/workspace/agentsview","gitBranch":"main","message":{"content":"hello"}}`).
 		AddClaudeAssistant(tsEarlyS5, "ok").
 		String()
 
 	worktreeContent := testjsonl.NewSessionBuilder().
-		AddRaw(`{"type":"user","timestamp":"2024-01-01T10:00:00Z","cwd":"/Users/wesm/code/agentsview-worktree-tool-call-arguments","gitBranch":"worktree-tool-call-arguments","message":{"content":"hello"}}`).
+		AddRaw(`{"type":"user","timestamp":"2024-01-01T10:00:00Z","cwd":"/workspace/agentsview-worktree-tool-call-arguments","gitBranch":"worktree-tool-call-arguments","message":{"content":"hello"}}`).
 		AddClaudeAssistant(tsEarlyS5, "ok").
 		String()
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12105,6 +12106,62 @@ func TestIncrementalSync_ClaudeAgentIDLinksIncrementally(t *testing.T) {
 	require.Len(t, msgs[1].ToolCalls, 1)
 	assert.Equal(t, "done", msgs[1].ToolCalls[0].ResultContent)
 	assert.Equal(t, len("done"), msgs[1].ToolCalls[0].ResultContentLength)
+}
+
+// lockedLogBuffer captures process-global log output; the engine may log
+// from background goroutines while a sync runs.
+type lockedLogBuffer struct {
+	mu  gosync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// A Codex incremental decline must be logged with a provider-agnostic
+// fallback reason, not as appended Claude lines.
+func TestIncrementalSync_CodexFallbackLogIsProviderAgnostic(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentCodex)
+	uuid := "c1d2e3f4-1234-4abc-9def-0123456789ab"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/workspace/project", "user").
+		AddCodexMessage(tsEarlyS1, "user", "hello").
+		String()
+	path := env.writeCodexSession(
+		t, filepath.Join("2026", "07", "14"),
+		"rollout-2026-07-14T12-00-00-"+uuid+".jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	spawnEnd := `{"timestamp":"2024-01-01T10:01:05Z","type":"event_msg","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn","new_thread_id":"11111111-2222-4333-8444-555555555555","status":"pending_init"}}`
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(spawnEnd + "\n")
+	f.Close()
+	require.NoError(t, writeErr, "append")
+
+	var logBuf lockedLogBuffer
+	prev := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	env.engine.SyncPaths([]string{path})
+	log.SetOutput(prev)
+
+	logs := logBuf.String()
+	require.Contains(t, logs, "explicit full parse fallback",
+		"appended spawn-end event should force the full-parse fallback")
+	assert.NotContains(t, logs, "Claude",
+		"codex fallback must not be described as appended Claude lines")
 }
 
 // A plain tool_result (no toolUseResult.agentId) appended after its


### PR DESCRIPTION
## Summary

When any provider's incremental parse declines an appended tail with a
ForceReplace fallback, the sync engine wrapped the decline in
`ErrClaudeIncrementalNeedsFullParse`. Debug logs for Codex and other providers
therefore described the content as appended Claude lines and pointed
investigations at the wrong parser.

The engine now signals this fallback with the provider-agnostic
`parser.ErrIncrementalNeedsFullParse`. The shared fallback classifier recognizes
that error alongside the parser-internal Claude and Codex errors. This changes
only how the fallback is reported at the provider seam; it does not change when
the parsers request a full replacement.

The race-detector job also exercises a bounded artifact full-export test whose
30-second context could expire while concurrent package I/O was still making
progress. Its explicit guard is now two minutes, which keeps the drain bounded
well inside the suite timeout while allowing for observed shared-runner
contention.

The touched sync fixture now uses a generic workspace path, so the new public
blob does not carry a machine-specific home path. The fixture's missing-path and
worktree-name behavior is unchanged.
