### PR TITLE
Keep in-chunk Codex tool outputs on the incremental parse path

### DIFF
--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -2168,17 +2168,28 @@ func (p *codexProvider) parseSessionFromWithSources(
 			if fallbackErr != nil {
 				return
 			}
+			lineType := gjson.Get(line, "type").Str
 			// A session_meta after the persisted offset can change fork or
 			// subagent replay classification. Rebuild the current session
 			// authoritatively instead of appending against stale gate state.
-			if gjson.Get(line, "type").Str ==
-				codexTypeSessionMeta {
+			if lineType == codexTypeSessionMeta {
 				fallbackErr = errCodexIncrementalNeedsFullParse
 				return
 			}
 			if codexIncrementalNeedsFullParse(line) {
 				fallbackErr = errCodexIncrementalNeedsFullParse
 				return
+			}
+			if lineType == codexTypeResponseItem {
+				payload := gjson.Get(line, "payload")
+				switch payload.Get("type").Str {
+				case "function_call_output",
+					"custom_tool_call_output":
+					if b.incrementalOutputNeedsFullParse(payload) {
+						fallbackErr = errCodexIncrementalNeedsFullParse
+						return
+					}
+				}
 			}
 			b.processLine(line)
 			if b.unattachedTokenUsage {
@@ -2359,10 +2370,6 @@ func codexIncrementalNeedsFullParse(line string) bool {
 	switch payload.Get("type").Str {
 	case "function_call", "custom_tool_call":
 		return isCodexWaitAgentCall(payload.Get("name").Str)
-	case "function_call_output", "custom_tool_call_output":
-		output, raw := parseCodexFunctionOutput(payload)
-		return isCodexSubagentFunctionOutput(output) ||
-			strings.TrimSpace(raw) != ""
 	default:
 		role := payload.Get("role").Str
 		if role != "user" {
@@ -2373,4 +2380,35 @@ func codexIncrementalNeedsFullParse(line string) bool {
 		)
 		return agentID != "" && text != ""
 	}
+}
+
+// incrementalOutputNeedsFullParse reports whether an appended
+// function_call_output / custom_tool_call_output line cannot be
+// represented by an append-only incremental write. Subagent outputs
+// repair lineage on rows outside the append, and an output whose call
+// is not part of this appended chunk belongs to an already-stored tool
+// call; both need a replacing full parse. An output paired with its
+// call in the same chunk attaches in memory exactly as a full parse
+// would, so it stays on the incremental path.
+func (b *codexSessionBuilder) incrementalOutputNeedsFullParse(
+	payload gjson.Result,
+) bool {
+	output, raw := parseCodexFunctionOutput(payload)
+	if isCodexSubagentFunctionOutput(output) {
+		return true
+	}
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+	callID := payload.Get("call_id").Str
+	if callID == "" {
+		// A full parse drops outputs without a call id too.
+		return false
+	}
+	switch b.callNames[callID] {
+	case "spawn_agent", "wait", "wait_agent":
+		return true
+	}
+	_, attachable := b.callRefs[callID]
+	return !attachable
 }

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
@@ -577,10 +578,12 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		assert.False(t, msgs[0].HasToolUse)
 	})
 
-	t.Run("custom_tool_call_output requests full parse", func(t *testing.T) {
+	t.Run("custom_tool_call_output for a stored call requests full parse", func(t *testing.T) {
 		line := `{"timestamp":"2026-07-08T03:20:43.376Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_abc","output":"Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess."}}`
 
-		assert.True(t, codexIncrementalNeedsFullParse(line))
+		b := newCodexSessionBuilder(false)
+		assert.True(t,
+			b.incrementalOutputNeedsFullParse(gjson.Get(line, "payload")))
 	})
 
 	t.Run("write_stdin formats with session and chars", func(t *testing.T) {
@@ -2552,6 +2555,55 @@ func TestParseCodexSessionFrom_FunctionCallOutputRequiresFullParse(t *testing.T)
 	_, _, _, err = parseCodexTestSessionFrom(t, path, offset, 2, false)
 	require.Error(t, err)
 	assert.True(t, IsIncrementalFullParseFallback(err))
+}
+
+// A tool call and its output that both arrive in the same appended
+// chunk are fully representable by an append: the builder pairs them
+// in memory exactly as a full parse would, so no fallback is needed.
+func TestParseCodexSessionFrom_InChunkFunctionCallOutputParsesIncrementally(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"inc-in-chunk-output", "/projects/api",
+			"codex_exec", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "run command", tsEarlyS1),
+	)
+	path := createTestFile(t, "in-chunk-call-output.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.JoinJSONL(
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command", "call_cmd",
+			map[string]any{"cmd": "ls"}, tsEarlyS5,
+		),
+		testjsonl.CodexFunctionCallOutputJSON(
+			"call_cmd", "done", tsLate,
+		),
+	))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	msgs, _, _, err := parseCodexTestSessionFrom(t, path, offset, 1, false)
+	require.NoError(t,
+		err, "an in-chunk call and output pair must parse incrementally")
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].ToolCalls, 1)
+	assert.Equal(t, "call_cmd", msgs[0].ToolCalls[0].ToolUseID)
+	assertToolResultEvents(t,
+		msgs[0].ToolCalls[0].ResultEvents, []ParsedToolResultEvent{{
+			ToolUseID: "call_cmd",
+			Source:    "function_call_output",
+			Content:   "done",
+		}})
 }
 
 // TestParseCodexSessionFrom_DedupsReemittedPrompt covers the


### PR DESCRIPTION
## Summary

Since #162/#800, any appended non-empty `function_call_output` or `custom_tool_call_output` line forced the Codex incremental parser to fall back to a full re-parse of the entire rollout. The fallback exists because an output whose call was stored in a previous sync cannot be stitched into the already-written tool-call row by the append-only writer. But the check was stateless, so it also fired when the call and its output arrived together in the same appended chunk — the overwhelmingly common case on active sessions, where nearly every watcher-debounced sync window contains at least one tool output. In practice incremental appends almost never survived on busy rollouts, and each sweep re-parsed the full multi-megabyte transcript (2,809 fallbacks observed in 13 hours of watcher churn on one machine).

The narrowing: an in-chunk call+output pair is fully representable by an append, because the shared session builder pairs them in memory (`callRefs` is chunk-local) exactly as a full parse would. The stateless per-line check is replaced with a builder-aware `incrementalOutputNeedsFullParse` consulted during the incremental read, after the builder has seen the chunk's earlier lines. Fallback still fires for everything that genuinely needs it: outputs whose call is in the stored prefix, subagent (`spawn_agent`) outputs, and `wait`/`wait_agent` outputs, which repair lineage on rows outside the append. `wait` calls, spawn-end events, sub-agent activity events, and late `session_meta` lines keep their existing fallback triggers.

Where to look:

- `internal/parser/codex.go` — `incrementalOutputNeedsFullParse` and the incremental read loop; the output case is removed from the stateless `codexIncrementalNeedsFullParse`
- `internal/parser/codex_parser_test.go` — new test proving an in-chunk call+output pair parses incrementally with the result attached; the cross-chunk fallback tests are unchanged and still pass

Limits: a chunk boundary that lands between a call and its output (sync fires mid-turn) still falls back to a full parse, as before.