### PR TITLE
Tombstone stored Claude sessions a complete full parse no longer emits

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -754,14 +754,18 @@ func deferStartupMaintenance(skipInitialSync, workerSyncDone bool) bool {
 func statsFromWorkerResult(r workerResult) sync.SyncStats {
 	if r.Stats != nil {
 		stats := *r.Stats
+		if r.Tombstoned > stats.Tombstoned {
+			stats.Tombstoned = r.Tombstoned
+		}
 		stats.Aborted = !r.DiscoveryComplete
 		return stats
 	}
 	return sync.SyncStats{
-		Synced:  r.Synced,
-		Skipped: r.Skipped,
-		Failed:  r.Failed,
-		Aborted: !r.DiscoveryComplete,
+		Synced:     r.Synced,
+		Skipped:    r.Skipped,
+		Failed:     r.Failed,
+		Tombstoned: r.Tombstoned,
+		Aborted:    !r.DiscoveryComplete,
 	}
 }
 
@@ -1078,7 +1082,17 @@ func runWorkerResyncBuild(
 			}
 			return launchErr
 		}
-		if serr := engine.SwapResyncDatabase(engine.ResyncTempPath()); serr != nil {
+		installed, serr := engine.SwapResyncDatabase(engine.ResyncTempPath())
+		if serr != nil {
+			if !installed {
+				// The replacement was discarded, so its tombstones never
+				// reached the archive. A post-install failure keeps them:
+				// the replacement is the live archive there.
+				result.Tombstoned = 0
+				if result.Stats != nil {
+					result.Stats.Tombstoned = 0
+				}
+			}
 			// Swap failures happen at or after CloseConnections closed the
 			// reader pool, so when the swap's own recovery did not restore
 			// the archive only a full Reopen brings reads back; ReopenWriter

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/importer"
 	"go.kenn.io/agentsview/internal/parser"
@@ -926,23 +925,21 @@ func TestParseDiff_JSONSessionsAndDBPath(t *testing.T) {
 
 // TestDoParseDiff_FailOnChangeDirections exercises both directions of
 // the exit-code conjunction (cfg.FailOnChange && report.HasFailures()).
-// A stored session at the current data version whose source file no
-// longer emits it is a presence change, so HasFailures() is true; the
-// flag then decides the exit. Staging it via a valid source file plus a
-// phantom stored row keeps the test independent of the parser's session
-// ID derivation.
+// A stored session whose first message differs from a fresh parse makes
+// HasFailures() true; the flag then decides the exit.
 func TestDoParseDiff_FailOnChangeDirections(t *testing.T) {
 	// Isolate every other agent's directory env var to a temp path so an
 	// inherited dir from the developer or CI environment cannot be scanned and
 	// trip --fail-on-change with an unrelated parse error. The data dir and
-	// Claude dir are then overridden to the paths this test controls.
+	// Claude dir is then overridden to the path this test controls.
 	isolateParseDiffEnv(t)
 	dataDir := os.Getenv("AGENTSVIEW_DATA_DIR")
 	require.NotEmpty(t, dataDir)
 	claudeDir := t.TempDir()
 	t.Setenv("CLAUDE_PROJECTS_DIR", claudeDir)
 
-	// A valid Claude source file so discovery and parse succeed.
+	// Sync a valid Claude source so the stored file fingerprint exactly matches
+	// the source that parse-diff will inspect.
 	projDir := filepath.Join(claudeDir, "-home-proj")
 	require.NoError(t, os.MkdirAll(projDir, 0o755))
 	srcPath := filepath.Join(projDir, "real-session.jsonl")
@@ -952,17 +949,23 @@ func TestDoParseDiff_FailOnChangeDirections(t *testing.T) {
 		String()
 	require.NoError(t, os.WriteFile(srcPath, []byte(content), 0o644))
 
-	// A phantom stored row under that file at the current data version:
-	// the re-parse never emits this id, so it reports as a presence
-	// change (HasFailures() == true).
 	d := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
-	require.NoError(t, d.UpsertSession(db.Session{
-		ID: "phantom-session", Project: "proj", Machine: "m",
-		Agent: "claude", MessageCount: 4, UserMessageCount: 2,
-		FilePath: &srcPath,
+	engine := sync.NewEngine(d, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeDir},
+		},
+		Machine: "local",
+	})
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced, "one session synced")
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"UPDATE sessions SET first_message = ? WHERE id = ?",
+			"drifted first message", "real-session",
+		)
+		return err
 	}))
-	require.NoError(t,
-		d.SetSessionDataVersion("phantom-session", db.CurrentDataVersion()))
+	engine.Close()
 	require.NoError(t, d.Close())
 
 	var failBuf bytes.Buffer
@@ -970,7 +973,7 @@ func TestDoParseDiff_FailOnChangeDirections(t *testing.T) {
 		FailOnChange: true, Stdout: &failBuf, Stderr: &failBuf,
 	})
 	assert.True(t, failed,
-		"a presence change with --fail-on-change must fail")
+		"a changed session with --fail-on-change must fail")
 	assert.Contains(t, failBuf.String(), "sessions changed")
 
 	var cleanBuf bytes.Buffer

--- a/cmd/agentsview/pricing_schedule_test.go
+++ b/cmd/agentsview/pricing_schedule_test.go
@@ -105,7 +105,7 @@ func TestStartPeriodicPricingRefreshWaitsForResyncSwap(t *testing.T) {
 		swapDone <- engine.RunExclusive(func() error {
 			close(swapEntered)
 			<-releaseSwap
-			if err := engine.SwapResyncDatabase(
+			if _, err := engine.SwapResyncDatabase(
 				engine.ResyncTempPath(),
 			); err != nil {
 				return err
@@ -191,7 +191,7 @@ func TestSeedPricingWaitsForResyncSwap(t *testing.T) {
 		swapDone <- engine.RunExclusive(func() error {
 			close(swapEntered)
 			<-releaseSwap
-			if err := engine.SwapResyncDatabase(
+			if _, err := engine.SwapResyncDatabase(
 				engine.ResyncTempPath(),
 			); err != nil {
 				return err

--- a/cmd/agentsview/sync_worker.go
+++ b/cmd/agentsview/sync_worker.go
@@ -279,6 +279,7 @@ func resyncBuildResultFromStats(
 		Synced:            stats.Synced,
 		Skipped:           stats.Skipped,
 		Failed:            stats.Failed,
+		Tombstoned:        stats.Tombstoned,
 		DiscoveryComplete: stats.AuthoritativeDiscoveryComplete(),
 		Stats:             &statsCopy,
 	}
@@ -326,6 +327,7 @@ func workerResultFromStats(
 		Synced:            stats.Synced,
 		Skipped:           stats.Skipped,
 		Failed:            stats.Failed,
+		Tombstoned:        stats.Tombstoned,
 		DiscoveryComplete: stats.AuthoritativeDiscoveryComplete(),
 		Stats:             &statsCopy,
 	}

--- a/cmd/agentsview/sync_worker_test.go
+++ b/cmd/agentsview/sync_worker_test.go
@@ -155,6 +155,22 @@ func TestSyncWorkerReportsAbortAsFailure(t *testing.T) {
 	assert.False(t, result.DiscoveryComplete)
 }
 
+func TestWorkerResultPreservesTombstonesAcrossProtocol(t *testing.T) {
+	result := workerResultFromStats(context.Background(), sync.SyncStats{
+		Tombstoned: 2,
+		Aborted:    true,
+	})
+	var wire bytes.Buffer
+	require.NoError(t, json.NewEncoder(&wire).Encode(workerLine{Result: &result}))
+
+	decoded, err := readWorkerResult(&wire, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, decoded.Tombstoned,
+		"the terminal summary must carry committed tombstones")
+	assert.Equal(t, 2, statsFromWorkerResult(decoded).Tombstoned,
+		"the daemon-side stats must retain tombstones after JSON decoding")
+}
+
 func TestSyncWorkerFailsWhenWriteLockHeld(t *testing.T) {
 	cfg := testConfigWithClaudeFixture(t)
 	holdWriteOwnerLockForTest(t, cfg.DataDir) // hold db.write.lock like a daemon

--- a/cmd/agentsview/worker_pass_test.go
+++ b/cmd/agentsview/worker_pass_test.go
@@ -698,7 +698,9 @@ func TestRunWorkerSyncPassWorkerFailureStillRecords(t *testing.T) {
 	cfg := testConfigWithClaudeFixture(t)
 	database, lock := openTestWriteDB(t, cfg)
 	reconciled := make(chan error, 1)
+	em := &scopedEmitter{scopes: make(chan string, 1)}
 	engine := sync.NewEngine(database, sync.EngineConfig{
+		Emitter: em,
 		OnStartupReconciled: func(_ sync.SyncStats, err error) {
 			reconciled <- err
 		},
@@ -709,7 +711,7 @@ func TestRunWorkerSyncPassWorkerFailureStillRecords(t *testing.T) {
 	restore := stubLaunchSyncWorker(t, func(
 		context.Context, config.Config, string, func(workerLine),
 	) (workerResult, error) {
-		return workerResult{Status: "failed"}, workerErr
+		return workerResult{Status: "failed", Tombstoned: 1}, workerErr
 	})
 	defer restore()
 
@@ -723,6 +725,13 @@ func TestRunWorkerSyncPassWorkerFailureStillRecords(t *testing.T) {
 		"an incomplete worker pass must surface as aborted stats")
 	assert.Equal(t, stats, engine.LastSyncStats(),
 		"the failed pass must reach last-sync bookkeeping")
+	select {
+	case scope := <-em.scopes:
+		assert.Equal(t, "sync", scope)
+	default:
+		require.FailNow(t,
+			"committed worker tombstones must emit despite a later failure")
+	}
 	select {
 	case cbErr := <-reconciled:
 		assert.ErrorIs(t, cbErr, workerErr,
@@ -1152,4 +1161,43 @@ func TestRunWorkerWritePassShutdownStopsPersistentRecovery(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("recovery kept retrying past daemon shutdown")
 	}
+}
+
+// TestRunWorkerResyncBuildDropsTombstonesWhenSwapFailsBeforeInstall pins the
+// daemon-side counterpart of the in-process rule: a worker build's tombstones
+// live only in the staged replacement, so a swap that fails before the rename
+// must not report them.
+func TestRunWorkerResyncBuildDropsTombstonesWhenSwapFailsBeforeInstall(
+	t *testing.T,
+) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, _ := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, mode string, _ func(workerLine),
+	) (workerResult, error) {
+		assert.Equal(t, "resync-build", mode)
+		// Report a build that tombstoned a row but stage no replacement, so
+		// the daemon's swap fails at the rename with the original intact.
+		return workerResult{
+			Status: "ok", DiscoveryComplete: true, Tombstoned: 1,
+			Stats: &sync.SyncStats{Tombstoned: 1},
+		}, nil
+	})
+	defer restore()
+
+	result, err, spawnFailed := runWorkerResyncBuild(
+		context.Background(), context.Background(), cfg, engine, database, nil,
+	)
+	require.False(t, spawnFailed)
+	require.ErrorContains(t, err, "swap resync database")
+	assert.Zero(t, result.Tombstoned,
+		"a discarded replacement's tombstones must not be reported")
+	require.NotNil(t, result.Stats)
+	assert.Zero(t, result.Stats.Tombstoned,
+		"the worker stats payload must not carry discarded tombstones")
+	assert.NoError(t, writeOneSession(database),
+		"writes must recover without a daemon restart")
 }

--- a/internal/db/freshness_test.go
+++ b/internal/db/freshness_test.go
@@ -77,3 +77,42 @@ func TestRestoreSessionStalesSourceAndClearsFreshness(t *testing.T) {
 	assert.False(t, present,
 		"restoring a source member must invalidate its source digest")
 }
+
+func TestGetSessionFilePathNotSourceMissing(t *testing.T) {
+	d := testDB(t)
+	ctx := t.Context()
+	path := "/sessions/project/transcript.jsonl"
+	insertSessionWithSourcePath(t, d, "active", "claude", path)
+	insertSessionWithSourcePath(t, d, "trashed", "claude", path)
+	require.NoError(t, d.SoftDeleteSession("trashed"))
+	insertSessionWithSourcePath(t, d, "missing", "claude", path,
+		func(s *Session) { s.Machine = "local" })
+	require.NoError(t, d.BaselineActiveSessionSourceOwnerships(
+		ctx, []SessionSourceOwnership{{
+			ID: "missing", Machine: "local", Agent: "claude", FilePath: path,
+		}},
+	))
+	tombstoned, err := d.SoftDeleteSessionSourceOwnership(
+		ctx, "local", "claude", "missing", path,
+	)
+	require.NoError(t, err)
+	require.True(t, tombstoned)
+	require.Equal(t, path, d.GetSessionFilePath("missing"),
+		"the unfiltered lookup still returns tombstoned paths")
+
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "active row keeps its path", id: "active", want: path},
+		{name: "user-trashed row keeps its path", id: "trashed", want: path},
+		{name: "source-missing row reads as absent", id: "missing", want: ""},
+		{name: "unknown id reads as absent", id: "unknown", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, d.GetSessionFilePathNotSourceMissing(tt.id))
+		})
+	}
+}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2210,6 +2210,26 @@ func (db *DB) GetSessionFileHash(id string) (hash string, ok bool) {
 	return h.String, true
 }
 
+// GetSessionFilePathNotSourceMissing returns the stored file_path for a
+// session unless the row is tombstoned as source-missing. Freshness gates use
+// it to decide whether a canonical primary row still vouches for its source: a
+// source-missing tombstone must not, or a rowless source could never be marked
+// fresh, while a user-trashed row keeps its path so trash handling is
+// unchanged. It returns "" when no eligible row exists or file_path is NULL.
+func (db *DB) GetSessionFilePathNotSourceMissing(id string) string {
+	var fp sql.NullString
+	err := db.getReader().QueryRow(
+		"SELECT file_path FROM sessions WHERE id = ?"+
+			" AND (deletion_cause IS NULL"+
+			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')",
+		id,
+	).Scan(&fp)
+	if err != nil || !fp.Valid {
+		return ""
+	}
+	return fp.String
+}
+
 // GetSessionFilePath returns the stored file_path for a session,
 // or empty string if not found or NULL.
 func (db *DB) GetSessionFilePath(id string) string {
@@ -3142,6 +3162,87 @@ func (db *DB) ListSessionIDsByFilePath(path, agent string) ([]string, error) {
 	return ids, nil
 }
 
+// ListStaleForkSessionOwnerships returns every active fork row written by an
+// older parser data version for one agent, with its stored machine and source
+// path. A rebuild loads this once from the write-barriered original archive so
+// per-file legacy fork checks read memory instead of opening archive
+// connections while the replacement database is being written.
+func (db *DB) ListStaleForkSessionOwnerships(
+	agent string,
+) ([]SessionSourceOwnership, error) {
+	rows, err := db.getReader().Query(
+		"SELECT id, machine, file_path FROM sessions"+
+			" WHERE agent = ? AND deleted_at IS NULL"+
+			" AND relationship_type = 'fork' AND data_version < ?"+
+			" AND file_path IS NOT NULL"+
+			" ORDER BY file_path, id",
+		agent, dataVersion,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing stale fork session ownerships: %w", err)
+	}
+	defer rows.Close()
+
+	var ownerships []SessionSourceOwnership
+	for rows.Next() {
+		var ownership SessionSourceOwnership
+		if err := rows.Scan(
+			&ownership.ID, &ownership.Machine, &ownership.FilePath,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"scanning stale fork session ownership: %w", err,
+			)
+		}
+		ownership.Agent = agent
+		ownerships = append(ownerships, ownership)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating stale fork session ownerships: %w", err,
+		)
+	}
+	return ownerships, nil
+}
+
+// ListStaleForkSessionIDsByFilePath returns active fork rows written by an
+// older parser data version for one provider-owned source path. Both signals
+// are required before a caller may treat a row omitted by a current complete
+// parse as a legacy fork artifact rather than parser presence drift.
+func (db *DB) ListStaleForkSessionIDsByFilePath(
+	path, agent string,
+) ([]string, error) {
+	rows, err := db.getReader().Query(
+		"SELECT id FROM sessions"+
+			" WHERE file_path = ? AND agent = ? AND deleted_at IS NULL"+
+			" AND relationship_type = 'fork' AND data_version < ?"+
+			" ORDER BY id",
+		path, agent, dataVersion,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"listing stale fork session IDs by file path: %w", err,
+		)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf(
+				"scanning stale fork session ID by file path: %w", err,
+			)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating stale fork session IDs by file path: %w", err,
+		)
+	}
+	return ids, nil
+}
+
 const sessionMachineBatchSize = 500
 
 // SessionWriteIdentity is the stored state used to preserve immutable source
@@ -3550,6 +3651,140 @@ func (db *DB) BaselineActiveSessionSourcePaths(
 	return nil
 }
 
+// BaselineActiveSessionSourceOwnerships marks only the supplied exact active
+// ownerships as observed. It is used when source-wide admission would include
+// archived members that a per-session policy deliberately rejects.
+func (db *DB) BaselineActiveSessionSourceOwnerships(
+	ctx context.Context,
+	ownerships []SessionSourceOwnership,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(ownerships) == 0 {
+		return nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting exact source baseline transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := baselineActiveSessionSourceOwnershipsTx(
+		ctx, tx, ownerships,
+	); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing exact source baselines: %w", err)
+	}
+	return nil
+}
+
+// CopySessionSourceOwnershipBaselinesFrom copies deletion proof from another
+// archive only for the supplied exact active ownerships. Rebuilds use this for
+// admitted archive-only members without granting proof to unrelated or
+// policy-rejected orphaned sessions.
+func (db *DB) CopySessionSourceOwnershipBaselinesFrom(
+	ctx context.Context,
+	sourcePath string,
+	ownerships []SessionSourceOwnership,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(ownerships) == 0 {
+		return nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	conn, err := db.getWriter().Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring source baseline copy connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(
+		ctx, "ATTACH DATABASE ? AS old_db", sourcePath,
+	); err != nil {
+		return fmt.Errorf("attaching source baseline archive: %w", err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "DETACH DATABASE old_db")
+	}()
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting source baseline copy transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if oldDBHasTable(ctx, tx, "local_session_source_baselines") {
+		for _, ownership := range ownerships {
+			if ownership.ID == "" || ownership.Agent == "" || ownership.FilePath == "" {
+				continue
+			}
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO main.local_session_source_baselines
+					(session_id, machine, agent, file_path)
+				SELECT b.session_id, b.machine, b.agent, b.file_path
+				FROM old_db.local_session_source_baselines AS b
+				JOIN main.sessions AS s
+				  ON s.id = b.session_id
+				 AND s.machine = b.machine
+				 AND s.agent = b.agent
+				 AND s.file_path = b.file_path
+				WHERE b.session_id = ? AND b.machine = ?
+				  AND b.agent = ? AND b.file_path = ?
+				  AND s.deleted_at IS NULL
+				ON CONFLICT(session_id) DO UPDATE SET
+					machine = excluded.machine,
+					agent = excluded.agent,
+					file_path = excluded.file_path`,
+				ownership.ID, ownership.Machine,
+				ownership.Agent, ownership.FilePath,
+			); err != nil {
+				return fmt.Errorf(
+					"copying exact session source baseline: %w", err,
+				)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing source baseline copy: %w", err)
+	}
+	return nil
+}
+
+// RemoveSessionSourceOwnershipBaselines revokes deletion proof only for the
+// supplied exact ownerships. It preserves other active rows sharing the same
+// source path.
+func (db *DB) RemoveSessionSourceOwnershipBaselines(
+	ctx context.Context,
+	ownerships []SessionSourceOwnership,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(ownerships) == 0 {
+		return nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting exact source baseline removal: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := removeSessionSourceOwnershipBaselinesTx(
+		ctx, tx, ownerships,
+	); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing exact source baseline removal: %w", err)
+	}
+	return nil
+}
+
 // ReplaceActiveSessionSourceBaselines makes admitted the exact subset of a
 // bounded candidate page that carries deletion proof. Machine is an exact
 // stored key, including the empty key retained by legacy sessions. Existing
@@ -3567,10 +3802,28 @@ func (db *DB) ReplaceActiveSessionSourceBaselines(
 	candidates []SessionSourcePath,
 	admitted []SessionSourcePath,
 ) error {
+	return db.ReplaceActiveSessionSourceBaselinesWithExceptions(
+		ctx, machine, candidates, admitted, nil, nil,
+	)
+}
+
+// ReplaceActiveSessionSourceBaselinesWithExceptions replaces source-wide
+// deletion proof and applies per-session CWD exceptions in one transaction.
+// This prevents a canceled or failed pass from committing broad proof before
+// it revokes proof from rejected members of the same source.
+func (db *DB) ReplaceActiveSessionSourceBaselinesWithExceptions(
+	ctx context.Context,
+	machine string,
+	candidates []SessionSourcePath,
+	admitted []SessionSourcePath,
+	exactAdmitted []SessionSourceOwnership,
+	exactRejected []SessionSourceOwnership,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if len(candidates) == 0 {
+	if len(candidates) == 0 && len(exactAdmitted) == 0 &&
+		len(exactRejected) == 0 {
 		return nil
 	}
 	rejected := rejectedSourceCandidates(candidates, admitted)
@@ -3604,8 +3857,71 @@ func (db *DB) ReplaceActiveSessionSourceBaselines(
 	); err != nil {
 		return err
 	}
+	if err := removeSessionSourceOwnershipBaselinesTx(
+		ctx, tx, exactRejected,
+	); err != nil {
+		return err
+	}
+	if err := baselineActiveSessionSourceOwnershipsTx(
+		ctx, tx, exactAdmitted,
+	); err != nil {
+		return err
+	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("committing source baseline replacement: %w", err)
+	}
+	return nil
+}
+
+func baselineActiveSessionSourceOwnershipsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	ownerships []SessionSourceOwnership,
+) error {
+	for _, ownership := range ownerships {
+		if ownership.ID == "" || ownership.Agent == "" || ownership.FilePath == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO local_session_source_baselines
+				(session_id, machine, agent, file_path)
+			SELECT id, machine, agent, file_path
+			FROM sessions
+			WHERE id = ? AND machine = ? AND agent = ? AND file_path = ?
+			  AND deleted_at IS NULL
+			ON CONFLICT(session_id) DO UPDATE SET
+				machine = excluded.machine,
+				agent = excluded.agent,
+				file_path = excluded.file_path
+			WHERE local_session_source_baselines.machine IS NOT excluded.machine
+			   OR local_session_source_baselines.agent IS NOT excluded.agent
+			   OR local_session_source_baselines.file_path IS NOT excluded.file_path`,
+			ownership.ID, ownership.Machine,
+			ownership.Agent, ownership.FilePath,
+		); err != nil {
+			return fmt.Errorf("baselining exact active session ownership: %w", err)
+		}
+	}
+	return nil
+}
+
+func removeSessionSourceOwnershipBaselinesTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	ownerships []SessionSourceOwnership,
+) error {
+	for _, ownership := range ownerships {
+		if ownership.ID == "" || ownership.Agent == "" || ownership.FilePath == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM local_session_source_baselines
+			WHERE session_id = ? AND machine = ? AND agent = ? AND file_path = ?`,
+			ownership.ID, ownership.Machine,
+			ownership.Agent, ownership.FilePath,
+		); err != nil {
+			return fmt.Errorf("removing exact session source baseline: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/db/source_path_hints_test.go
+++ b/internal/db/source_path_hints_test.go
@@ -1068,6 +1068,38 @@ func TestReplaceActiveSessionSourceBaselinesWarmPassWritesBounded(t *testing.T) 
 	}
 }
 
+func TestReplaceActiveSessionSourceBaselinesRollsBackBroadProofWhenExceptionFails(
+	t *testing.T,
+) {
+	d := testDB(t)
+	path := filepath.Join(t.TempDir(), "mixed.jsonl")
+	insertSessionWithSourcePath(t, d, "allowed", "claude", path)
+	insertSessionWithSourcePath(t, d, "rejected", "claude", path)
+	_, err := d.getWriter().Exec(`
+		CREATE TRIGGER fail_rejected_baseline_removal
+		BEFORE DELETE ON local_session_source_baselines
+		WHEN OLD.session_id = 'rejected'
+		BEGIN
+			SELECT RAISE(FAIL, 'injected exact baseline failure');
+		END;
+	`)
+	require.NoError(t, err)
+	source := SessionSourcePath{Agent: "claude", FilePath: path}
+
+	err = d.ReplaceActiveSessionSourceBaselinesWithExceptions(
+		t.Context(), defaultMachine,
+		[]SessionSourcePath{source}, []SessionSourcePath{source}, nil,
+		[]SessionSourceOwnership{{
+			ID: "rejected", Machine: defaultMachine,
+			Agent: "claude", FilePath: path,
+		}},
+	)
+
+	require.ErrorContains(t, err, "injected exact baseline failure")
+	assert.Empty(t, listBaselineOwnership(t, d, defaultMachine),
+		"a failed exception must roll back the source-wide baseline grant")
+}
+
 func TestListActiveSessionSourceAttributionsReturnsEveryMachine(t *testing.T) {
 	d := testDB(t)
 	root := t.TempDir()
@@ -1171,4 +1203,43 @@ func insertSessionsWithSourcePaths(
 	result, err := d.WriteSessionBatchAtomic(writes)
 	require.NoError(t, err, "insert source path sessions")
 	require.Equal(t, len(seeds), result.WrittenSessions, "WrittenSessions")
+}
+
+func TestListStaleForkSessionOwnerships(t *testing.T) {
+	d := testDB(t)
+	path := "/sessions/project/transcript.jsonl"
+	otherPath := "/sessions/project/other.jsonl"
+	parentID := "primary"
+	fork := func(id, machine, p string, opts ...func(*Session)) {
+		t.Helper()
+		insertSessionWithSourcePath(t, d, id, "claude", p, append([]func(*Session){
+			func(s *Session) {
+				s.Machine = machine
+				s.ParentSessionID = &parentID
+				s.RelationshipType = "fork"
+			},
+		}, opts...)...)
+	}
+	insertSessionWithSourcePath(t, d, parentID, "claude", path)
+	fork("stale-a", "local", path)
+	fork("stale-b", "remote", otherPath)
+	fork("stale-deleted", "local", path)
+	fork("stale-codex", "local", path, func(s *Session) { s.Agent = "codex" })
+	fork("current", "local", path)
+	for _, id := range []string{"stale-a", "stale-b", "stale-deleted", "stale-codex"} {
+		require.NoError(t, d.SetSessionDataVersion(id, 0))
+	}
+	require.NoError(t, d.SoftDeleteSession("stale-deleted"))
+	require.NoError(t, d.SetSessionDataVersion("current", CurrentDataVersion()))
+
+	got, err := d.ListStaleForkSessionOwnerships("claude")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []SessionSourceOwnership{
+		{ID: "stale-a", Machine: "local", Agent: "claude", FilePath: path},
+		{ID: "stale-b", Machine: "remote", Agent: "claude", FilePath: otherPath},
+	}, got, "only active stale fork rows for the agent are listed")
+
+	none, err := d.ListStaleForkSessionOwnerships("gemini")
+	require.NoError(t, err)
+	assert.Empty(t, none)
 }

--- a/internal/sync/cwd_filter.go
+++ b/internal/sync/cwd_filter.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -113,7 +114,11 @@ func (e *Engine) missingMemberTombstoneAllowed(
 	if e.cwdFilter.empty() {
 		return true, nil
 	}
-	sess, err := e.db.GetSession(ctx, sessionID)
+	store := db.Store(e.db)
+	if e.archiveStore != nil {
+		store = e.archiveStore
+	}
+	sess, err := store.GetSession(ctx, sessionID)
 	if err != nil {
 		return false, fmt.Errorf(
 			"read archived cwd for missing member %s: %w", sessionID, err,

--- a/internal/sync/cwd_filter_integration_test.go
+++ b/internal/sync/cwd_filter_integration_test.go
@@ -2,7 +2,10 @@ package sync_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -261,6 +264,538 @@ func TestSyncAllCwdFilterChangeRevokesSkippedSourceDeletionProof(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "outside-periodic", 2)
 }
 
+func TestCwdFilterBaselinesOnlyAdmittedStaleClaudeForkAfterZeroResultParse(
+	t *testing.T,
+) {
+	for _, reconcile := range []bool{false, true} {
+		name := "full sync"
+		if reconcile {
+			name = "watch reconciliation"
+		}
+		t.Run(name, func(t *testing.T) {
+			env := setupClaudeEnvWithCwdPrefixes(
+				t, []string{"/workspace/work"},
+			)
+			pureReplay := strings.Join([]string{
+				`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"fork-2222","sessionKind":"bg","message":{"content":"first question"}}`,
+				`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"fork-2222","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+			}, "\n") + "\n"
+			path := env.writeClaudeSession(
+				t, "project", "fork-2222.jsonl", pureReplay,
+			)
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			fileSize := info.Size()
+			fileMtime := info.ModTime().UnixNano()
+			fileHash := fmt.Sprintf("%x", sha256.Sum256([]byte(pureReplay)))
+			parentID := "fork-2222"
+			allowedID := parentID + "-11111111-2222-4333-8444-555555555555"
+			disallowedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+			for id, cwd := range map[string]string{
+				allowedID:    "/workspace/work/project",
+				disallowedID: "/workspace/personal/project",
+			} {
+				require.NoError(t, env.db.UpsertSession(db.Session{
+					ID:               id,
+					Project:          "project",
+					Machine:          "local",
+					Agent:            "claude",
+					Cwd:              cwd,
+					ParentSessionID:  &parentID,
+					RelationshipType: "fork",
+					FilePath:         &path,
+					FileSize:         &fileSize,
+					FileMtime:        &fileMtime,
+					FileHash:         &fileHash,
+				}))
+				require.NoError(t, env.db.SetSessionDataVersion(id, 0))
+			}
+			syncSource := func() {
+				if reconcile {
+					require.NoError(t, env.engine.ReconcileWatchRootsAfterLostEvents(
+						t.Context(), []string{env.claudeDir}, false,
+					))
+					return
+				}
+				stats := env.engine.SyncAll(t.Context(), nil)
+				require.Zero(t, stats.Failed)
+			}
+
+			syncSource()
+			for id, want := range map[string]int{
+				allowedID: 1, disallowedID: 0,
+			} {
+				var got int
+				require.NoError(t, env.db.Reader().QueryRow(`
+					SELECT count(*) FROM local_session_source_baselines
+					WHERE session_id = ?`, id,
+				).Scan(&got))
+				assert.Equal(t, want, got,
+					"only the CWD-admitted stale member may gain deletion proof")
+			}
+
+			syncSource()
+			allowed, err := env.db.GetSessionFull(t.Context(), allowedID)
+			require.NoError(t, err)
+			require.NotNil(t, allowed)
+			require.NotNil(t, allowed.DeletionCause,
+				"the admitted stale fork must converge after baseline establishment")
+			assert.Equal(t, "source_missing", *allowed.DeletionCause)
+			disallowed, err := env.db.GetSession(t.Context(), disallowedID)
+			require.NoError(t, err)
+			assert.NotNil(t, disallowed,
+				"a stale fork outside the CWD allow-list must remain active")
+
+			if !reconcile {
+				env.engine.Close()
+				env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+					AgentDirs: map[parser.AgentType][]string{
+						parser.AgentClaude: {env.claudeDir},
+					},
+					Machine:            "local",
+					IncludeCwdPrefixes: []string{"/workspace/work"},
+				})
+				steady := env.engine.SyncAll(t.Context(), nil)
+				require.Zero(t, steady.Failed)
+				assert.Equal(t, 1, steady.Skipped,
+					"a persisted current-version rowless marker must restore source freshness")
+
+				env.engine.Close()
+				env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+					AgentDirs: map[parser.AgentType][]string{
+						parser.AgentClaude: {env.claudeDir},
+					},
+					Machine:            "local",
+					IncludeCwdPrefixes: []string{"/workspace/personal"},
+				})
+				t.Cleanup(env.engine.Close)
+				broadened := env.engine.SyncAll(t.Context(), nil)
+				require.Zero(t, broadened.Failed)
+				assert.Zero(t, broadened.Skipped,
+					"a broader CWD filter must revoke the freshness exemption")
+				require.Zero(t, env.engine.SyncAll(t.Context(), nil).Failed)
+				disallowed, err = env.db.GetSessionFull(t.Context(), disallowedID)
+				require.NoError(t, err)
+				require.NotNil(t, disallowed)
+				require.NotNil(t, disallowed.DeletionCause,
+					"the newly admitted stale fork must resume reconciliation")
+			}
+		})
+	}
+}
+
+func TestSyncSingleSessionBaselinesOnlyAdmittedStaleClaudeFork(t *testing.T) {
+	env := setupClaudeEnvWithCwdPrefixes(
+		t, []string{"/workspace/work"},
+	)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello", "/workspace/work/project").
+		String()
+	path := env.writeClaudeSession(
+		t, "project", "single-cwd.jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	parentID := "single-cwd"
+	allowedID := parentID + "-11111111-2222-4333-8444-555555555555"
+	disallowedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	for id, cwd := range map[string]string{
+		allowedID:    "/workspace/work/project",
+		disallowedID: "/workspace/personal/project",
+	} {
+		require.NoError(t, env.db.UpsertSession(db.Session{
+			ID:               id,
+			Project:          "project",
+			Machine:          "local",
+			Agent:            "claude",
+			Cwd:              cwd,
+			ParentSessionID:  &parentID,
+			RelationshipType: "fork",
+			FilePath:         &path,
+		}))
+		require.NoError(t, env.db.SetSessionDataVersion(id, 0))
+	}
+	require.NoError(t, env.db.ReplaceActiveSessionSourceBaselines(
+		t.Context(), "local",
+		[]db.SessionSourcePath{{Agent: "claude", FilePath: path}}, nil,
+	))
+
+	require.NoError(t, env.engine.SyncSingleSession(parentID))
+	for id, want := range map[string]int{allowedID: 1, disallowedID: 0} {
+		var got int
+		require.NoError(t, env.db.Reader().QueryRow(`
+			SELECT count(*) FROM local_session_source_baselines
+			WHERE session_id = ?`, id,
+		).Scan(&got))
+		assert.Equal(t, want, got,
+			"single-session sync must baseline only CWD-admitted stale forks")
+	}
+
+	require.NoError(t, env.engine.SyncSingleSession(parentID))
+	allowed, err := env.db.GetSessionFull(t.Context(), allowedID)
+	require.NoError(t, err)
+	require.NotNil(t, allowed)
+	require.NotNil(t, allowed.DeletionCause,
+		"a later single-session sync must retire the admitted stale fork")
+	assert.Equal(t, "source_missing", *allowed.DeletionCause)
+	disallowed, err := env.db.GetSession(t.Context(), disallowedID)
+	require.NoError(t, err)
+	assert.NotNil(t, disallowed,
+		"single-session sync must preserve a filtered stale fork")
+}
+
+func TestSyncSingleSessionEmitsSessionsForStaleClaudeForkTombstone(
+	t *testing.T,
+) {
+	emitter := &fakeEmitter{}
+	env := &testEnv{db: dbtest.OpenTestDB(t), claudeDir: t.TempDir()}
+	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {env.claudeDir},
+		},
+		Machine: "local",
+		Emitter: emitter,
+	})
+	t.Cleanup(env.engine.Close)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello", "/workspace/work/project").
+		String()
+	path := env.writeClaudeSession(
+		t, "project", "single-notify.jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	emitter.mu.Lock()
+	emitter.scopes = nil
+	emitter.mu.Unlock()
+
+	parentID := "single-notify"
+	staleID := parentID + "-11111111-2222-4333-8444-555555555555"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "project",
+		Machine:          "local",
+		Agent:            "claude",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &path,
+	}))
+	require.NoError(t, env.db.SetSessionDataVersion(staleID, 0))
+	require.NoError(t, env.db.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: staleID, Machine: "local", Agent: "claude", FilePath: path,
+		}},
+	))
+
+	require.NoError(t, env.engine.SyncSingleSession(parentID))
+	assert.Equal(t, []string{"messages", "sessions"}, emitter.got(),
+		"single-session fork cleanup must refresh messages and the session index")
+	stale, err := env.db.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	require.NotNil(t, stale.DeletionCause)
+	assert.Equal(t, "source_missing", *stale.DeletionCause)
+}
+
+func TestSyncSingleSessionFreshnessSkipReconcilesNarrowedCwdBaselines(
+	t *testing.T,
+) {
+	env := setupClaudeEnvWithCwdPrefixes(t, nil)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello", "/workspace/work/project").
+		String()
+	path := env.writeClaudeSession(
+		t, "project", "single-fresh-cwd.jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	parentID := "single-fresh-cwd"
+	rejectedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:               rejectedID,
+		Project:          "project",
+		Machine:          "local",
+		Agent:            "claude",
+		Cwd:              "/workspace/personal/project",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &path,
+	}))
+	require.NoError(t, env.db.SetSessionDataVersion(rejectedID, 0))
+	require.NoError(t, env.db.BaselineActiveSessionSourcePaths(
+		t.Context(), "local",
+		[]db.SessionSourcePath{{Agent: "claude", FilePath: path}},
+	))
+
+	env.engine.Close()
+	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {env.claudeDir},
+		},
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/work"},
+	})
+	t.Cleanup(env.engine.Close)
+
+	require.NoError(t, env.engine.SyncSingleSession(parentID))
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, env.engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{env.claudeDir}, false,
+	))
+
+	primary, err := env.db.GetSessionFull(t.Context(), parentID)
+	require.NoError(t, err)
+	require.NotNil(t, primary)
+	require.NotNil(t, primary.DeletionCause,
+		"the admitted primary must retain exact deletion proof")
+	assert.Equal(t, "source_missing", *primary.DeletionCause)
+	rejected, err := env.db.GetSession(t.Context(), rejectedID)
+	require.NoError(t, err)
+	assert.NotNil(t, rejected,
+		"a fresh single-session skip must revoke the rejected fork's old proof")
+}
+
+func TestSyncAllCwdRejectedStaleClaudeForkReturnsToFreshnessSkip(
+	t *testing.T,
+) {
+	env := setupClaudeEnvWithCwdPrefixes(
+		t, []string{"/workspace/work"},
+	)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello", "/workspace/work/project").
+		String()
+	path := env.writeClaudeSession(
+		t, "project", "freshness-cwd.jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	parentID := "freshness-cwd"
+	allowedID := parentID + "-11111111-2222-4333-8444-555555555555"
+	disallowedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	for id, cwd := range map[string]string{
+		allowedID:    "/workspace/work/project",
+		disallowedID: "/workspace/personal/project",
+	} {
+		require.NoError(t, env.db.UpsertSession(db.Session{
+			ID:               id,
+			Project:          "project",
+			Machine:          "local",
+			Agent:            "claude",
+			Cwd:              cwd,
+			ParentSessionID:  &parentID,
+			RelationshipType: "fork",
+			FilePath:         &path,
+		}))
+		require.NoError(t, env.db.SetSessionDataVersion(id, 0))
+	}
+
+	first := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, first.Failed)
+	second := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, second.Failed)
+	allowed, err := env.db.GetSessionFull(t.Context(), allowedID)
+	require.NoError(t, err)
+	require.NotNil(t, allowed)
+	require.NotNil(t, allowed.DeletionCause,
+		"the admitted stale fork must be retired before testing freshness")
+	assert.Equal(t, "source_missing", *allowed.DeletionCause)
+	disallowed, err := env.db.GetSession(t.Context(), disallowedID)
+	require.NoError(t, err)
+	require.NotNil(t, disallowed,
+		"the CWD-rejected stale fork must remain active")
+
+	third := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, third.Failed)
+	assert.Zero(t, third.Synced,
+		"a rejected stale fork must not force an unchanged source to reparse")
+	assert.Equal(t, 1, third.Skipped,
+		"the unchanged source must return to the Claude freshness path")
+
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, env.engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{env.claudeDir}, false,
+	))
+	primary, err := env.db.GetSessionFull(t.Context(), parentID)
+	require.NoError(t, err)
+	require.NotNil(t, primary)
+	require.NotNil(t, primary.DeletionCause,
+		"the admitted primary must retain proof through the mixed-CWD skip")
+	assert.Equal(t, "source_missing", *primary.DeletionCause)
+	disallowed, err = env.db.GetSession(t.Context(), disallowedID)
+	require.NoError(t, err)
+	assert.NotNil(t, disallowed,
+		"the mixed-CWD skip must not grant proof to the rejected fork")
+}
+
+func TestSyncAllParsesPrimaryBeforeTrustingPreservedClaudeForkFreshness(
+	t *testing.T,
+) {
+	env := setupClaudeEnvWithCwdPrefixes(
+		t, []string{"/workspace/work"},
+	)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "new primary", "/workspace/work/project").
+		String()
+	path := env.writeClaudeSession(
+		t, "project", "upgrade-primary.jsonl", content,
+	)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	fileSize := info.Size()
+	fileMtime := info.ModTime().UnixNano()
+	fileHash := fmt.Sprintf("%x", sha256.Sum256([]byte(content)))
+	parentID := "upgrade-primary"
+	staleID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "project",
+		Machine:          "local",
+		Agent:            "claude",
+		Cwd:              "/workspace/personal/project",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &path,
+		FileSize:         &fileSize,
+		FileMtime:        &fileMtime,
+		FileHash:         &fileHash,
+	}))
+	require.NoError(t, env.db.SetSessionDataVersion(staleID, 0))
+
+	stats := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, stats.Failed)
+	assert.Equal(t, 1, stats.Synced,
+		"legacy fork metadata must not suppress the current parser's first pass")
+	primary, err := env.db.GetSession(t.Context(), parentID)
+	require.NoError(t, err)
+	assert.NotNil(t, primary,
+		"the newly parseable primary session must be archived")
+	stale, err := env.db.GetSession(t.Context(), staleID)
+	require.NoError(t, err)
+	assert.NotNil(t, stale,
+		"the CWD-rejected legacy fork must remain preserved")
+}
+
+func TestReconcileWatchRootsReportsSourceMissingClaudeForkTombstone(
+	t *testing.T,
+) {
+	emitter := &fakeEmitter{}
+	env := &testEnv{db: dbtest.OpenTestDB(t), claudeDir: t.TempDir()}
+	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {env.claudeDir},
+		},
+		Machine: "local",
+		Emitter: emitter,
+	})
+	t.Cleanup(env.engine.Close)
+	original := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"audit-original","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"audit-original","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	pureReplay := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"audit-replay","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"audit-replay","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	env.writeClaudeSession(
+		t, "project", "audit-original.jsonl", original,
+	)
+	path := env.writeClaudeSession(
+		t, "project", "audit-replay.jsonl", pureReplay,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced,
+		"the original transcript should seed without writing the replay")
+	emitter.mu.Lock()
+	emitter.scopes = nil
+	emitter.mu.Unlock()
+	parentID := "audit-replay"
+	staleID := parentID + "-11111111-2222-4333-8444-555555555555"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "project",
+		Machine:          "local",
+		Agent:            "claude",
+		Cwd:              "/workspace/work/project",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &path,
+	}))
+	require.NoError(t, env.db.SetSessionDataVersion(staleID, 0))
+	require.NoError(t, env.db.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: staleID, Machine: "local", Agent: "claude", FilePath: path,
+		}},
+	))
+
+	stats, tombstoned, err := env.engine.ReconcileWatchRootsWithStats(
+		t.Context(), []string{env.claudeDir}, false, nil,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, stats.Synced,
+		"a zero-result replay should not report an ordinary session write")
+	assert.Equal(t, 1, tombstoned,
+		"the audit-facing reconciliation result must report the member tombstone")
+	assert.Equal(t, []string{"sessions"}, emitter.got(),
+		"member-only reconciliation changes must emit a sessions event")
+	stale, err := env.db.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	require.NotNil(t, stale.DeletionCause)
+	assert.Equal(t, "source_missing", *stale.DeletionCause)
+}
+
+func TestWatchReconcilePreservesCwdRejectedForkAfterMixedSourceDeleted(
+	t *testing.T,
+) {
+	env := setupClaudeEnvWithCwdPrefixes(
+		t, []string{"/workspace/work"},
+	)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello", "/workspace/work/project").
+		String()
+	path := env.writeClaudeSession(
+		t, "project", "deleted-mixed-cwd.jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	parentID := "deleted-mixed-cwd"
+	disallowedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:               disallowedID,
+		Project:          "project",
+		Machine:          "local",
+		Agent:            "claude",
+		Cwd:              "/workspace/personal/project",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &path,
+	}))
+	require.NoError(t, env.db.SetSessionDataVersion(disallowedID, 0))
+
+	changed := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello", "/workspace/work/project").
+		AddClaudeAssistant(tsEarlyS5, "changed").
+		String()
+	require.NoError(t, os.WriteFile(path, []byte(changed), 0o644))
+	parsed := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, parsed.Failed)
+	require.Equal(t, 1, parsed.Synced,
+		"the changed mixed-CWD source must take the full write path")
+
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, env.engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{env.claudeDir}, false,
+	))
+	primary, err := env.db.GetSessionFull(t.Context(), parentID)
+	require.NoError(t, err)
+	require.NotNil(t, primary)
+	require.NotNil(t, primary.DeletionCause,
+		"the admitted primary must retain deletion proof")
+	assert.Equal(t, "source_missing", *primary.DeletionCause)
+	disallowed, err := env.db.GetSession(t.Context(), disallowedID)
+	require.NoError(t, err)
+	assert.NotNil(t, disallowed,
+		"source-wide admission must not authorize deleting the rejected fork")
+}
+
 // A full resync where the cwd allow-list vetoes every discovered
 // session is an intentional result, not a broken rebuild: the swap
 // must proceed and the orphan copy must restore the archived rows
@@ -322,4 +857,70 @@ func TestResyncAllProceedsWhenAllSessionsCwdFiltered(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "filtered-two", 2)
 	assert.False(t, env.db.NeedsResync(),
 		"completed resync must clear the needs-resync marker")
+}
+
+func TestSyncAllSourceMissingPrimaryWithRejectedForkReturnsToFreshnessSkip(
+	t *testing.T,
+) {
+	env := setupClaudeEnvWithCwdPrefixes(
+		t, []string{"/workspace/work"},
+	)
+	pureReplay := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"missing-primary","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"missing-primary","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	path := env.writeClaudeSession(
+		t, "project", "missing-primary.jsonl", pureReplay,
+	)
+
+	parentID := "missing-primary"
+	rejectedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:       parentID,
+		Project:  "project",
+		Machine:  "local",
+		Agent:    "claude",
+		Cwd:      "/workspace/work/project",
+		FilePath: &path,
+	}))
+	require.NoError(t, env.db.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: parentID, Machine: "local", Agent: "claude", FilePath: path,
+		}},
+	))
+	tombstoned, err := env.db.SoftDeleteSessionSourceOwnership(
+		t.Context(), "local", "claude", parentID, path,
+	)
+	require.NoError(t, err)
+	require.True(t, tombstoned, "seed a source-missing canonical primary")
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:               rejectedID,
+		Project:          "project",
+		Machine:          "local",
+		Agent:            "claude",
+		Cwd:              "/workspace/personal/project",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &path,
+	}))
+	require.NoError(t, env.db.SetSessionDataVersion(rejectedID, 0))
+
+	first := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, first.Failed)
+	second := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, second.Failed)
+	assert.Zero(t, second.Synced)
+	assert.Equal(t, 1, second.Skipped,
+		"a source-missing primary must not defeat the rowless freshness skip")
+
+	primary, err := env.db.GetSessionFull(t.Context(), parentID)
+	require.NoError(t, err)
+	require.NotNil(t, primary)
+	require.NotNil(t, primary.DeletionCause,
+		"the source-missing primary must stay tombstoned")
+	assert.Equal(t, "source_missing", *primary.DeletionCause)
+	rejected, err := env.db.GetSession(t.Context(), rejectedID)
+	require.NoError(t, err)
+	assert.NotNil(t, rejected,
+		"the CWD-rejected stale fork must remain active")
 }

--- a/internal/sync/cwd_filter_test.go
+++ b/internal/sync/cwd_filter_test.go
@@ -2,6 +2,8 @@ package sync
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"runtime"
 	"testing"
 
@@ -187,6 +189,526 @@ func TestCollectAndBatchKeepsAllowedSourceSiblingCurrent(t *testing.T) {
 	filtered, err := database.GetSession(context.Background(), "cowork:filtered")
 	require.NoError(t, err)
 	assert.Nil(t, filtered)
+}
+
+func TestCollectAndBatchBaselinesAllowedMissingMemberForMixedCwdSource(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	database := openTestDB(t)
+	path := "/src/mixed.jsonl"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "stale-allowed", Project: "proj", Machine: "local", Agent: "claude",
+		Cwd: "/allowed/stale", FilePath: &path,
+	}))
+	engine := NewEngine(database, EngineConfig{
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/allowed"},
+	})
+
+	syncSource := func() SyncStats {
+		results := make(chan syncJob, 1)
+		results <- syncJob{
+			agent:   parser.AgentClaude,
+			path:    path,
+			machine: "local",
+			processResult: processResult{
+				results: []parser.ParseResult{
+					{Session: parser.ParsedSession{
+						ID: "replacement-allowed", Agent: parser.AgentClaude,
+						Machine: "local", Project: "proj", Cwd: "/allowed/new",
+						File: parser.FileInfo{Path: path},
+					}},
+					{Session: parser.ParsedSession{
+						ID: "replacement-filtered", Agent: parser.AgentClaude,
+						Machine: "local", Project: "proj", Cwd: "/outside/new",
+						File: parser.FileInfo{Path: path},
+					}},
+				},
+				sourceMissingMembers: []sourceMissingMember{{
+					sessionID: "stale-allowed",
+					filePath:  path,
+					machine:   "local",
+				}},
+			},
+		}
+		close(results)
+		return engine.collectAndBatch(
+			ctx, results, 1, 1, nil, syncWriteDefault,
+		)
+	}
+
+	first := syncSource()
+	require.Zero(t, first.Failed)
+	var baselineCount int
+	require.NoError(t, database.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = 'stale-allowed'`,
+	).Scan(&baselineCount))
+	assert.Equal(t, 1, baselineCount,
+		"an allowed missing member needs exact proof when a sibling is filtered")
+
+	second := syncSource()
+	require.Zero(t, second.Failed)
+	stale, err := database.GetSessionFull(ctx, "stale-allowed")
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	require.NotNil(t, stale.DeletionCause,
+		"the next mixed-CWD parse must retire the admitted missing member")
+	assert.Equal(t, "source_missing", *stale.DeletionCause)
+}
+
+func TestCollectAndBatchCancellationRevokesRejectedMissingMemberBaseline(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	path := "/src/cancelled-mixed.jsonl"
+	parentID := "cancelled-mixed"
+	allowedID := parentID + "-11111111-2222-4333-8444-555555555555"
+	rejectedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	for id, cwd := range map[string]string{
+		allowedID:  "/workspace/work/project",
+		rejectedID: "/workspace/personal/project",
+	} {
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+			Cwd: cwd, ParentSessionID: &parentID, RelationshipType: "fork",
+			FilePath: &path,
+		}))
+		require.NoError(t, database.SetSessionDataVersion(id, 0))
+	}
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local",
+		[]db.SessionSourcePath{{Agent: "claude", FilePath: path}},
+	))
+
+	engine := NewEngine(database, EngineConfig{
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/work"},
+	})
+	t.Cleanup(engine.Close)
+	ctx, cancel := context.WithCancel(t.Context())
+	results := make(chan syncJob, 2)
+	results <- syncJob{
+		agent: parser.AgentClaude, path: path, machine: "local",
+		processResult: processResult{sourceMissingMembers: []sourceMissingMember{
+			{sessionID: allowedID, machine: "local", filePath: path},
+			{sessionID: rejectedID, machine: "local", filePath: path},
+		}},
+	}
+	results <- syncJob{processResult: processResult{err: context.Canceled}}
+	close(results)
+
+	stats := engine.collectAndBatch(
+		ctx, results, 2, 2,
+		func(progress Progress) {
+			if progress.SessionsDone == 1 {
+				cancel()
+			}
+		},
+		syncWriteDefault,
+	)
+
+	assert.True(t, stats.Aborted)
+	var rejectedBaseline int
+	require.NoError(t, database.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, rejectedID,
+	).Scan(&rejectedBaseline))
+	assert.Zero(t, rejectedBaseline,
+		"cancellation must not leave deletion proof on a CWD-rejected member")
+	rejected, err := database.GetSession(t.Context(), rejectedID)
+	require.NoError(t, err)
+	assert.NotNil(t, rejected,
+		"the CWD-rejected stale fork must remain active")
+}
+
+func TestCollectAndBatchFailureRevokesOnlyRejectedMissingMemberBaseline(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	path := "/src/failed-mixed.jsonl"
+	parentID := "failed-mixed"
+	failingID := parentID + "-11111111-2222-4333-8444-555555555555"
+	rejectedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	for id, cwd := range map[string]string{
+		failingID:  "/workspace/work/project",
+		rejectedID: "/workspace/personal/project",
+	} {
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+			Cwd: cwd, ParentSessionID: &parentID, RelationshipType: "fork",
+			FilePath: &path,
+		}))
+		require.NoError(t, database.SetSessionDataVersion(id, 0))
+	}
+	require.NoError(t, database.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{
+			{ID: failingID, Machine: "local", Agent: "claude", FilePath: path},
+			{ID: rejectedID, Machine: "local", Agent: "claude", FilePath: path},
+		},
+	))
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			CREATE TRIGGER fail_first_source_missing_tombstone
+			BEFORE UPDATE OF deleted_at ON sessions
+			WHEN NEW.id = 'failed-mixed-11111111-2222-4333-8444-555555555555'
+			 AND NEW.deletion_cause = 'source_missing'
+			BEGIN
+				SELECT RAISE(FAIL, 'injected first-member tombstone failure');
+			END`)
+		return err
+	}))
+
+	engine := NewEngine(database, EngineConfig{
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/work"},
+	})
+	t.Cleanup(engine.Close)
+	results := make(chan syncJob, 1)
+	results <- syncJob{
+		agent: parser.AgentClaude, path: path, machine: "local",
+		processResult: processResult{sourceMissingMembers: []sourceMissingMember{
+			{sessionID: failingID, machine: "local", filePath: path},
+			{sessionID: rejectedID, machine: "local", filePath: path},
+		}},
+	}
+	close(results)
+
+	stats := engine.collectAndBatch(
+		t.Context(), results, 1, 1, nil, syncWriteDefault,
+	)
+
+	assert.Equal(t, 1, stats.Failed)
+	var failingBaseline, rejectedBaseline int
+	require.NoError(t, database.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, failingID,
+	).Scan(&failingBaseline))
+	require.NoError(t, database.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, rejectedID,
+	).Scan(&rejectedBaseline))
+	assert.Equal(t, 1, failingBaseline,
+		"exact cleanup must preserve proof for the admitted member whose write failed")
+	assert.Zero(t, rejectedBaseline,
+		"an earlier write failure must not preserve proof for a later CWD rejection")
+}
+
+func seedPartialSourceMissingFailure(
+	t *testing.T, database *db.DB, parentID, path string,
+) (string, string) {
+	t.Helper()
+	firstID := "partial-success-a"
+	failingID := "partial-success-b"
+	for _, id := range []string{firstID, failingID} {
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+			ParentSessionID: &parentID, RelationshipType: "fork", FilePath: &path,
+		}))
+		require.NoError(t, database.SetSessionDataVersion(id, 0))
+	}
+	require.NoError(t, database.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{
+			{ID: firstID, Machine: "local", Agent: "claude", FilePath: path},
+			{ID: failingID, Machine: "local", Agent: "claude", FilePath: path},
+		},
+	))
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			CREATE TRIGGER fail_second_source_missing_tombstone
+			BEFORE UPDATE OF deleted_at ON sessions
+			WHEN NEW.id = 'partial-success-b'
+			 AND NEW.deletion_cause = 'source_missing'
+			BEGIN
+				SELECT RAISE(FAIL, 'injected later-member tombstone failure');
+			END`)
+		return err
+	}))
+	return firstID, failingID
+}
+
+func TestSyncAllCountsAndEmitsPartialSourceMissingTombstones(t *testing.T) {
+	fx := newEngineFixture(t)
+	emitter := &fakeEmitter{}
+	fx.engineWithEmitter(emitter)
+	path := fx.writeClaudeSession(t, "project", "partial-batch.jsonl", "first")
+	require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+	emitter.mu.Lock()
+	emitter.scopes = nil
+	emitter.mu.Unlock()
+
+	firstID, failingID := seedPartialSourceMissingFailure(
+		t, fx.db, fx.sessionIDFor(t, path), path,
+	)
+	fx.appendClaudeMessage(t, path, "changed")
+	stats := fx.engine.SyncAll(t.Context(), nil)
+
+	assert.Equal(t, 1, stats.Failed)
+	assert.Equal(t, 1, stats.Tombstoned,
+		"a committed tombstone must remain visible in failed-pass statistics")
+	assert.Equal(t, []string{"sessions"}, emitter.got(),
+		"a failed pass must notify clients about its committed tombstone")
+	first, err := fx.db.GetSessionFull(t.Context(), firstID)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.NotNil(t, first.DeletionCause)
+	assert.Equal(t, "source_missing", *first.DeletionCause)
+	failing, err := fx.db.GetSession(t.Context(), failingID)
+	require.NoError(t, err)
+	assert.NotNil(t, failing, "the member that failed to tombstone must remain active")
+}
+
+func TestSyncThenRunEmitsPartialSourceMissingTombstones(t *testing.T) {
+	fx := newEngineFixture(t)
+	emitter := &fakeEmitter{}
+	fx.engineWithEmitter(emitter)
+	path := fx.writeClaudeSession(t, "project", "partial-coordinated.jsonl", "first")
+	require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+	emitter.mu.Lock()
+	emitter.scopes = nil
+	emitter.mu.Unlock()
+
+	firstID, failingID := seedPartialSourceMissingFailure(
+		t, fx.db, fx.sessionIDFor(t, path), path,
+	)
+	fx.appendClaudeMessage(t, path, "changed")
+	stats, err := fx.engine.SyncThenRun(
+		t.Context(), false, nil, func(bool) error { return nil },
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Failed)
+	assert.Equal(t, 1, stats.Tombstoned,
+		"a committed tombstone must survive coordinated completion")
+	assert.Equal(t, []string{"sync"}, emitter.got(),
+		"coordinated completion must notify clients about its committed tombstone")
+	first, err := fx.db.GetSessionFull(t.Context(), firstID)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.NotNil(t, first.DeletionCause)
+	assert.Equal(t, "source_missing", *first.DeletionCause)
+	failing, err := fx.db.GetSession(t.Context(), failingID)
+	require.NoError(t, err)
+	assert.NotNil(t, failing, "the member that failed to tombstone must remain active")
+}
+
+func TestSyncSingleSessionEmitsPartialSourceMissingTombstones(t *testing.T) {
+	fx := newEngineFixture(t)
+	emitter := &fakeEmitter{}
+	fx.engineWithEmitter(emitter)
+	path := fx.writeClaudeSession(t, "project", "partial-single.jsonl", "first")
+	require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+	emitter.mu.Lock()
+	emitter.scopes = nil
+	emitter.mu.Unlock()
+
+	firstID, failingID := seedPartialSourceMissingFailure(
+		t, fx.db, fx.sessionIDFor(t, path), path,
+	)
+	fx.appendClaudeMessage(t, path, "changed")
+	err := fx.engine.SyncSingleSession(fx.sessionIDFor(t, path))
+
+	require.ErrorContains(t, err, "injected later-member tombstone failure")
+	assert.Equal(t, []string{"sessions"}, emitter.got(),
+		"a failed single-session sync must notify clients about its committed tombstone")
+	first, err := fx.db.GetSessionFull(t.Context(), firstID)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.NotNil(t, first.DeletionCause)
+	assert.Equal(t, "source_missing", *first.DeletionCause)
+	failing, err := fx.db.GetSession(t.Context(), failingID)
+	require.NoError(t, err)
+	assert.NotNil(t, failing, "the member that failed to tombstone must remain active")
+}
+
+func TestSyncSingleSessionRevokesRejectedBaselineOnLaterMemberFailure(
+	t *testing.T,
+) {
+	fx := newEngineFixture(t)
+	path := fx.writeClaudeSession(t, "project", "partial-filtered.jsonl", "first")
+	require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+
+	rejectedID, failingID := seedPartialSourceMissingFailure(
+		t, fx.db, fx.sessionIDFor(t, path), path,
+	)
+	require.NoError(t, fx.db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			UPDATE sessions
+			SET cwd = CASE id
+				WHEN ? THEN '/outside/project'
+				WHEN ? THEN '/workspace/allowed/project'
+				ELSE cwd
+			END
+			WHERE id IN (?, ?)`,
+			rejectedID, failingID, rejectedID, failingID,
+		)
+		return err
+	}))
+	fx.engine.Close()
+	fx.engine = NewEngine(fx.db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {fx.claudeDir},
+		},
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/allowed"},
+	})
+	t.Cleanup(fx.engine.Close)
+
+	fx.appendClaudeMessage(t, path, "changed")
+	err := fx.engine.SyncSingleSession(fx.sessionIDFor(t, path))
+
+	require.ErrorContains(t, err, "injected later-member tombstone failure")
+	var rejectedBaseline int
+	require.NoError(t, fx.db.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, rejectedID,
+	).Scan(&rejectedBaseline))
+	assert.Zero(t, rejectedBaseline,
+		"a later member failure must not retain deletion proof for a CWD-rejected fork")
+	var primaryBaseline int
+	require.NoError(t, fx.db.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, fx.sessionIDFor(t, path),
+	).Scan(&primaryBaseline))
+	assert.Equal(t, 1, primaryBaseline,
+		"exact exception cleanup must preserve unrelated source ownership proof")
+	rejected, err := fx.db.GetSession(t.Context(), rejectedID)
+	require.NoError(t, err)
+	assert.NotNil(t, rejected,
+		"the CWD-rejected stale fork must remain active")
+}
+
+func TestReconcileWatchRootsRevokesRejectedBaselineOnPageFailure(
+	t *testing.T,
+) {
+	fx := newEngineFixture(t)
+	path := fx.writeClaudeSession(t, "project", "reconcile-filtered.jsonl", "first")
+	require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+	primaryID := fx.sessionIDFor(t, path)
+
+	rejectedID, failingID := seedPartialSourceMissingFailure(
+		t, fx.db, primaryID, path,
+	)
+	require.NoError(t, fx.db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			UPDATE sessions
+			SET cwd = CASE id
+				WHEN ? THEN '/outside/project'
+				WHEN ? THEN '/workspace/allowed/project'
+				ELSE cwd
+			END
+			WHERE id IN (?, ?)`,
+			rejectedID, failingID, rejectedID, failingID,
+		)
+		return err
+	}))
+	require.NoError(t, fx.db.RemoveSessionSourceOwnershipBaselines(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: primaryID, Machine: "local", Agent: "claude", FilePath: path,
+		}},
+	))
+	fx.engine.Close()
+	fx.engine = NewEngine(fx.db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {fx.claudeDir},
+		},
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/allowed"},
+	})
+	t.Cleanup(fx.engine.Close)
+
+	fx.appendClaudeMessage(t, path, "changed")
+	err := fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	)
+
+	require.ErrorContains(t, err, "failed processing page: 1 failures")
+	var rejectedBaseline int
+	require.NoError(t, fx.db.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, rejectedID,
+	).Scan(&rejectedBaseline))
+	assert.Zero(t, rejectedBaseline,
+		"a failed page must revoke proof from a CWD-rejected fork")
+	var primaryBaseline int
+	require.NoError(t, fx.db.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, primaryID,
+	).Scan(&primaryBaseline))
+	assert.Zero(t, primaryBaseline,
+		"failed-page cleanup must not grant new source proof")
+	rejected, err := fx.db.GetSession(t.Context(), rejectedID)
+	require.NoError(t, err)
+	assert.NotNil(t, rejected,
+		"the CWD-rejected stale fork must remain active")
+}
+
+func TestReconcileWatchRootsRevokesRejectedBaselineOnFinalizationFailure(
+	t *testing.T,
+) {
+	fx := newEngineFixture(t)
+	path := fx.writeClaudeSession(t, "project", "finalize-filtered.jsonl", "first")
+	require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+	primaryID := fx.sessionIDFor(t, path)
+	rejectedID := primaryID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	require.NoError(t, fx.db.UpsertSession(db.Session{
+		ID: rejectedID, Project: "project", Machine: "local", Agent: "claude",
+		Cwd: "/outside/project", ParentSessionID: &primaryID,
+		RelationshipType: "fork", FilePath: &path,
+	}))
+	require.NoError(t, fx.db.SetSessionDataVersion(rejectedID, 0))
+	require.NoError(t, fx.db.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: rejectedID, Machine: "local", Agent: "claude", FilePath: path,
+		}},
+	))
+	fx.engine.Close()
+	fx.engine = NewEngine(fx.db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {fx.claudeDir},
+		},
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/allowed"},
+	})
+	t.Cleanup(fx.engine.Close)
+	lookupErr := errors.New("injected baseline attribution failure")
+	lookupCalls := 0
+	fx.engine.sourceAttributionLookupOverride = func(
+		_ context.Context, requested []db.SessionSourcePath,
+	) ([]db.SessionSourceAttribution, error) {
+		lookupCalls++
+		assert.Equal(t, []db.SessionSourcePath{{
+			Agent: "claude", FilePath: path,
+		}}, requested)
+		return nil, lookupErr
+	}
+
+	fx.appendClaudeMessage(t, path, "changed")
+	err := fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	)
+
+	require.ErrorIs(t, err, lookupErr)
+	assert.Equal(t, 1, lookupCalls)
+	var rejectedBaseline int
+	require.NoError(t, fx.db.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, rejectedID,
+	).Scan(&rejectedBaseline))
+	assert.Zero(t, rejectedBaseline,
+		"failed finalization must revoke proof from a CWD-rejected fork")
+	var primaryBaseline int
+	require.NoError(t, fx.db.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, primaryID,
+	).Scan(&primaryBaseline))
+	assert.Equal(t, 1, primaryBaseline,
+		"reject-only cleanup must preserve admitted source proof")
+	rejected, err := fx.db.GetSession(t.Context(), rejectedID)
+	require.NoError(t, err)
+	assert.NotNil(t, rejected,
+		"the CWD-rejected stale fork must remain active")
 }
 
 func TestShouldAbortResyncSwap(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -69,8 +70,10 @@ type passEpilogueEligibility struct {
 }
 
 type reconciliationBaselineTracker struct {
-	sources     map[machineSessionSource]struct{}
-	cacheWrites map[string]skipCacheWrite
+	sources                 map[machineSessionSource]struct{}
+	exactOwnerships         map[db.SessionSourceOwnership]struct{}
+	rejectedExactOwnerships map[db.SessionSourceOwnership]struct{}
+	cacheWrites             map[string]skipCacheWrite
 }
 
 type machineSessionSource struct {
@@ -78,6 +81,41 @@ type machineSessionSource struct {
 	// sessions written before machine attribution was introduced.
 	Machine string
 	Source  db.SessionSourcePath
+}
+
+func matchingBaselineOwnerships(
+	sources []machineSessionSource,
+	ownerships map[db.SessionSourceOwnership]struct{},
+) []db.SessionSourceOwnership {
+	if len(sources) == 0 || len(ownerships) == 0 {
+		return nil
+	}
+	sourceSet := make(map[machineSessionSource]struct{}, len(sources))
+	for _, source := range sources {
+		sourceSet[source] = struct{}{}
+	}
+	matched := make([]db.SessionSourceOwnership, 0, len(ownerships))
+	for ownership := range ownerships {
+		source := machineSessionSource{
+			Machine: ownership.Machine,
+			Source: db.SessionSourcePath{
+				Agent: ownership.Agent, FilePath: ownership.FilePath,
+			},
+		}
+		if _, ok := sourceSet[source]; ok {
+			matched = append(matched, ownership)
+		}
+	}
+	return matched
+}
+
+func consumeBaselineOwnerships(
+	ownerships map[db.SessionSourceOwnership]struct{},
+	consumed []db.SessionSourceOwnership,
+) {
+	for _, ownership := range consumed {
+		delete(ownerships, ownership)
+	}
 }
 
 func newReconciliationBaselineTracker() *reconciliationBaselineTracker {
@@ -134,6 +172,66 @@ func (tracker *reconciliationBaselineTracker) list() []machineSessionSource {
 		sources = append(sources, source)
 	}
 	return sources
+}
+
+func (tracker *reconciliationBaselineTracker) addExactOwnership(
+	ownership db.SessionSourceOwnership,
+) {
+	if ownership.ID == "" || ownership.Agent == "" || ownership.FilePath == "" {
+		return
+	}
+	if tracker.exactOwnerships == nil {
+		tracker.exactOwnerships = make(map[db.SessionSourceOwnership]struct{})
+	}
+	tracker.exactOwnerships[ownership] = struct{}{}
+}
+
+func (tracker *reconciliationBaselineTracker) listExactOwnerships() []db.SessionSourceOwnership {
+	ownerships := make(
+		[]db.SessionSourceOwnership, 0, len(tracker.exactOwnerships),
+	)
+	for ownership := range tracker.exactOwnerships {
+		ownerships = append(ownerships, ownership)
+	}
+	return ownerships
+}
+
+func (tracker *reconciliationBaselineTracker) rejectExactOwnership(
+	ownership db.SessionSourceOwnership,
+) {
+	if ownership.ID == "" || ownership.Agent == "" || ownership.FilePath == "" {
+		return
+	}
+	if tracker.rejectedExactOwnerships == nil {
+		tracker.rejectedExactOwnerships = make(
+			map[db.SessionSourceOwnership]struct{},
+		)
+	}
+	tracker.rejectedExactOwnerships[ownership] = struct{}{}
+}
+
+func (tracker *reconciliationBaselineTracker) listRejectedExactOwnerships() []db.SessionSourceOwnership {
+	ownerships := make(
+		[]db.SessionSourceOwnership, 0, len(tracker.rejectedExactOwnerships),
+	)
+	for ownership := range tracker.rejectedExactOwnerships {
+		ownerships = append(ownerships, ownership)
+	}
+	return ownerships
+}
+
+func (e *Engine) revokeRejectedReconciliationBaselines(
+	ctx context.Context,
+	ownerships []db.SessionSourceOwnership,
+) error {
+	if err := e.db.RemoveSessionSourceOwnershipBaselines(
+		context.WithoutCancel(ctx), ownerships,
+	); err != nil {
+		return fmt.Errorf(
+			"revoke rejected source baseline exceptions: %w", err,
+		)
+	}
+	return nil
 }
 
 type reconciliationRuntimeMetrics struct {
@@ -328,7 +426,11 @@ type Engine struct {
 	// sessions for the preserve guards in prepareSessionWrite.
 	// During a resync/rebuild it points at the original DB while
 	// e.db points at the fresh one; nil means e.db is the archive.
-	archiveStore            db.Store
+	archiveStore db.Store
+	// archiveStaleClaudeForks snapshots the original archive's stale Claude
+	// fork rows for one rebuild; nil outside a rebuild, where e.db is queried
+	// per source path instead.
+	archiveStaleClaudeForks *archiveStaleClaudeForkIndex
 	agentDirs               map[parser.AgentType][]string
 	sourceMachines          map[parser.AgentType]map[string]string
 	preserveAgents          []parser.AgentType
@@ -1429,8 +1531,7 @@ func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) error {
 		defer e.clearCurrentProgress()
 		return e.syncChangedPathsLocked(ctx, paths)
 	}()
-	if stats.Synced > 0 || tombstoned > 0 ||
-		stats.sourceMissingTombstoned > 0 {
+	if stats.Synced > 0 || tombstoned > 0 || stats.Tombstoned > 0 {
 		e.emit("sessions")
 	}
 	return err
@@ -2428,12 +2529,14 @@ func (e *Engine) resyncAllWithOptionsLocked(
 	if swapErr != nil {
 		if !installed {
 			// The original archive is still in place; drop the discarded
-			// replacement's skip entries. A post-install failure keeps the
-			// fresh cache: the replacement is the live archive there.
+			// replacement's skip entries and its tombstone count. A
+			// post-install failure keeps both: the replacement is the live
+			// archive there.
 			e.skipMu.Lock()
 			e.skipCache = preBuildSkipCache
 			e.skipHashKeys = preBuildSkipHashKeys
 			e.skipMu.Unlock()
+			stats.Tombstoned = 0
 		}
 		e.setLastSyncStats(stats)
 		return stats, swapErr
@@ -2455,6 +2558,11 @@ func (e *Engine) resyncBuildLocked(
 	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
 	ops rebuildOperations,
 ) (stats SyncStats, retErr error) {
+	// Rebuild tombstones are committed only inside the replacement, and every
+	// aborted or failed build discards it. Hold them here and publish the
+	// count only on the successful return, so no failure branch stores or
+	// returns removals that never reached the archive.
+	pendingTombstoned := 0
 	reportResyncProgress := func(p Progress) {
 		p.Resync = true
 		if p.Phase == PhaseSyncing && p.Detail == "" {
@@ -2666,7 +2774,29 @@ func (e *Engine) resyncBuildLocked(
 	// its first syncing event, and on a large archive that walk takes
 	// minutes. Without this marker the progress printer credits that
 	// silent time to the preceding (instant) "Disabling ..." phase.
+	// The archive is write-barriered for the whole rebuild, so one snapshot of
+	// its stale Claude fork rows serves every parsed file. Querying the archive
+	// per file would open cold reader connections while workers are busy,
+	// which SQLite's busy handler turns into sleeps on every open.
+	archiveStaleForks, err := loadArchiveStaleClaudeForkIndex(origDB)
+	if err != nil {
+		log.Printf("resync: snapshot stale claude forks: %v", err)
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		stats = SyncStats{
+			Aborted: true,
+			Warnings: []string{
+				"resync failed: snapshot stale claude forks: " + err.Error(),
+			},
+		}
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats, err
+	}
 	e.archiveStore = origDB
+	e.archiveStaleClaudeForks = archiveStaleForks
 	e.db = newDB
 	reportResyncPhase(
 		PhaseDiscovering,
@@ -2678,6 +2808,9 @@ func (e *Engine) resyncBuildLocked(
 	)
 	e.db = origDB // restore immediately
 	e.archiveStore = nil
+	e.archiveStaleClaudeForks = nil
+	pendingTombstoned += stats.Tombstoned
+	stats.Tombstoned = 0
 	e.phaseStats.Log("resync")
 	if opts.includePhaseDiagnostics {
 		stats.RebuildPhases = append(stats.RebuildPhases,
@@ -2708,6 +2841,7 @@ func (e *Engine) resyncBuildLocked(
 		}
 		contributorEngine := NewEngine(newDB, contributor.Config)
 		contributorEngine.archiveStore = origDB
+		contributorEngine.archiveStaleClaudeForks = archiveStaleForks
 		contributorProgress := func(p Progress) {
 			if contributor.Progress != nil {
 				p = contributor.Progress(p)
@@ -2732,6 +2866,8 @@ func (e *Engine) resyncBuildLocked(
 			contributorStats.Aborted = true
 		}
 		mergeSyncStats(&stats, contributorStats)
+		pendingTombstoned += stats.Tombstoned
+		stats.Tombstoned = 0
 		if opts.includePhaseDiagnostics {
 			stats.RebuildPhases = append(stats.RebuildPhases, phase)
 		}
@@ -3062,6 +3198,30 @@ func (e *Engine) resyncBuildLocked(
 		}
 	}
 
+	// Metadata restoration deliberately copies user-owned deletion state from
+	// the original archive. Reconcile archive-only Claude members afterwards so
+	// an active legacy fork cannot overwrite the source_missing tombstone that
+	// this rebuild just established.
+	deferredTombstoned, err := e.reconcileCopiedSourceMissingMembers(
+		ctx, newDB, origPath, stats.sourceMissingArchiveMembers,
+	)
+	if err != nil {
+		log.Printf("resync: tombstone copied source-missing sessions: %v", err)
+		stats.Aborted = true
+		stats.Warnings = append(stats.Warnings,
+			"copied source-missing reconciliation failed, aborting swap: "+
+				err.Error(),
+		)
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats, err
+	}
+	pendingTombstoned += deferredTombstoned
+
 	// Reclassify is_automated across every row. Orphan-copied
 	// rows carry is_automated values computed against the OLD
 	// DB's classifier set; the temp DB's at-Open backfill ran on
@@ -3130,6 +3290,7 @@ func (e *Engine) resyncBuildLocked(
 		e.mu.Unlock()
 		return stats, err
 	}
+	stats.Tombstoned = pendingTombstoned
 	return stats, nil
 }
 
@@ -3256,13 +3417,17 @@ func (e *Engine) ResyncBuild(
 // SwapResyncDatabase installs a replacement archive built at tempPath: it closes
 // connections, removes WAL sidecars, renames, reopens, marks data current, and
 // checkpoints. It is the daemon's swap tail after a worker build. The caller
-// serializes it against sync (the daemon holds the write barrier).
-func (e *Engine) SwapResyncDatabase(tempPath string) error {
+// serializes it against sync (the daemon holds the write barrier). The
+// installed result tells a failing caller whether the rename replaced the
+// original, so pre-install failures can discard the build's tombstone counts
+// while post-install failures keep them.
+func (e *Engine) SwapResyncDatabase(
+	tempPath string,
+) (installed bool, err error) {
 	var stats SyncStats
-	_, err := e.swapResyncDatabaseLocked(
+	return e.swapResyncDatabaseLocked(
 		context.Background(), nil, tempPath, productionRebuildOperations, &stats,
 	)
-	return err
 }
 
 // ResetCachesAfterSwap re-baselines every parent-side cache keyed to the
@@ -3915,7 +4080,7 @@ func (e *Engine) SyncAll(
 	// Emitter implementations cannot widen the syncMu critical
 	// section or deadlock by re-entering sync code.
 	defer func() {
-		if stats.Synced > 0 {
+		if stats.Synced > 0 || stats.Tombstoned > 0 {
 			e.emit("sessions")
 		}
 	}()
@@ -4427,10 +4592,17 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 		)
 		mergeReconciliationSyncStats(&stats, pageStats)
 		if pageStats.Aborted || pageStats.Failed > 0 {
+			cleanupErr := e.revokeRejectedReconciliationBaselines(
+				ctx,
+				baselineTracker.listRejectedExactOwnerships(),
+			)
 			stats.Aborted = true
-			retErr = fmt.Errorf(
-				"watch root reconciliation failed processing page: %d failures",
-				pageStats.Failed,
+			retErr = errors.Join(
+				fmt.Errorf(
+					"watch root reconciliation failed processing page: %d failures",
+					pageStats.Failed,
+				),
+				cleanupErr,
 			)
 			break
 		}
@@ -4438,13 +4610,35 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 			page, baselineTracker.list(), authoritativeProviders,
 		)
 		cacheWrites := baselineTracker.listCacheWrites()
+		exactOwnerships := baselineTracker.listExactOwnerships()
+		exactOwnerships = slices.DeleteFunc(
+			exactOwnerships,
+			func(ownership db.SessionSourceOwnership) bool {
+				agent := parser.AgentType(ownership.Agent)
+				_, eligible := authoritativeProviders[agent]
+				return !eligible
+			},
+		)
+		rejectedExactOwnerships := baselineTracker.listRejectedExactOwnerships()
+		rejectedExactOwnerships = slices.DeleteFunc(
+			rejectedExactOwnerships,
+			func(ownership db.SessionSourceOwnership) bool {
+				agent := parser.AgentType(ownership.Agent)
+				_, eligible := authoritativeProviders[agent]
+				return !eligible
+			},
+		)
 		if err := e.baselineReconciliationCandidates(
 			ctx, baselineCandidates, baselineAdmitted,
+			exactOwnerships, rejectedExactOwnerships,
 		); err != nil {
 			e.rejectSkipCacheWrites(cacheWrites)
+			cleanupErr := e.revokeRejectedReconciliationBaselines(
+				ctx, rejectedExactOwnerships,
+			)
 			stats.RecordFailed()
 			stats.Aborted = true
-			retErr = err
+			retErr = errors.Join(err, cleanupErr)
 			break
 		}
 		eligibleCacheWrites := cacheWrites[:0]
@@ -4550,6 +4744,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 		retErr = errors.Join(retErr, cleanupErr)
 	}
 	cleaned = true
+	tombstoned += stats.Tombstoned
 	return stats, metrics, tombstoned, eligibility, retErr
 }
 
@@ -4581,6 +4776,8 @@ func (e *Engine) baselineReconciliationCandidates(
 	ctx context.Context,
 	candidates []reconciliationCandidate,
 	admitted []machineSessionSource,
+	exactAdmitted []db.SessionSourceOwnership,
+	exactRejected []db.SessionSourceOwnership,
 ) error {
 	sources := make([]machineSessionSource, 0, len(candidates))
 	for _, candidate := range candidates {
@@ -4613,8 +4810,8 @@ func (e *Engine) baselineReconciliationCandidates(
 	if err != nil {
 		return fmt.Errorf("load reconciliation source attributions: %w", err)
 	}
-	if err := e.replaceActiveSessionSourceBaselinesByMachine(
-		ctx, sources, admitted,
+	if err := e.replaceActiveSessionSourceBaselinesWithExceptionsByMachine(
+		ctx, sources, admitted, exactAdmitted, exactRejected,
 	); err != nil {
 		return fmt.Errorf("reconcile source baseline page: %w", err)
 	}
@@ -4647,8 +4844,22 @@ func (e *Engine) replaceActiveSessionSourceBaselinesByMachine(
 	candidates []machineSessionSource,
 	admitted []machineSessionSource,
 ) error {
+	return e.replaceActiveSessionSourceBaselinesWithExceptionsByMachine(
+		ctx, candidates, admitted, nil, nil,
+	)
+}
+
+func (e *Engine) replaceActiveSessionSourceBaselinesWithExceptionsByMachine(
+	ctx context.Context,
+	candidates []machineSessionSource,
+	admitted []machineSessionSource,
+	exactAdmitted []db.SessionSourceOwnership,
+	exactRejected []db.SessionSourceOwnership,
+) error {
 	candidatesByMachine := make(map[string]map[db.SessionSourcePath]struct{})
 	admittedByMachine := make(map[string]map[db.SessionSourcePath]struct{})
+	var exactAdmittedByMachine map[string][]db.SessionSourceOwnership
+	var exactRejectedByMachine map[string][]db.SessionSourceOwnership
 	add := func(
 		byMachine map[string]map[db.SessionSourcePath]struct{},
 		source machineSessionSource,
@@ -4671,6 +4882,38 @@ func (e *Engine) replaceActiveSessionSourceBaselinesByMachine(
 		// machine so replacement visits that machine as well.
 		add(candidatesByMachine, source)
 	}
+	for _, ownership := range exactAdmitted {
+		if exactAdmittedByMachine == nil {
+			exactAdmittedByMachine = make(
+				map[string][]db.SessionSourceOwnership,
+			)
+		}
+		exactAdmittedByMachine[ownership.Machine] = append(
+			exactAdmittedByMachine[ownership.Machine], ownership,
+		)
+		add(candidatesByMachine, machineSessionSource{
+			Machine: ownership.Machine,
+			Source: db.SessionSourcePath{
+				Agent: ownership.Agent, FilePath: ownership.FilePath,
+			},
+		})
+	}
+	for _, ownership := range exactRejected {
+		if exactRejectedByMachine == nil {
+			exactRejectedByMachine = make(
+				map[string][]db.SessionSourceOwnership,
+			)
+		}
+		exactRejectedByMachine[ownership.Machine] = append(
+			exactRejectedByMachine[ownership.Machine], ownership,
+		)
+		add(candidatesByMachine, machineSessionSource{
+			Machine: ownership.Machine,
+			Source: db.SessionSourcePath{
+				Agent: ownership.Agent, FilePath: ownership.FilePath,
+			},
+		})
+	}
 	machines := make([]string, 0, len(candidatesByMachine))
 	for machine := range candidatesByMachine {
 		machines = append(machines, machine)
@@ -4687,8 +4930,55 @@ func (e *Engine) replaceActiveSessionSourceBaselinesByMachine(
 		for source := range admittedByMachine[machine] {
 			admittedSources = append(admittedSources, source)
 		}
-		if err := e.db.ReplaceActiveSessionSourceBaselines(
+		if err := e.db.ReplaceActiveSessionSourceBaselinesWithExceptions(
 			ctx, machine, sources, admittedSources,
+			exactAdmittedByMachine[machine], exactRejectedByMachine[machine],
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *Engine) replaceSessionSourceBaselineExceptionsByMachine(
+	ctx context.Context,
+	exactAdmitted []db.SessionSourceOwnership,
+	exactRejected []db.SessionSourceOwnership,
+) error {
+	type exceptionSet struct {
+		admitted []db.SessionSourceOwnership
+		rejected []db.SessionSourceOwnership
+	}
+	byMachine := make(map[string]exceptionSet)
+	add := func(ownership db.SessionSourceOwnership, admitted bool) {
+		if ownership.Agent == "" || ownership.FilePath == "" ||
+			ownership.ID == "" {
+			return
+		}
+		set := byMachine[ownership.Machine]
+		if admitted {
+			set.admitted = append(set.admitted, ownership)
+			byMachine[ownership.Machine] = set
+			return
+		}
+		set.rejected = append(set.rejected, ownership)
+		byMachine[ownership.Machine] = set
+	}
+	for _, ownership := range exactAdmitted {
+		add(ownership, true)
+	}
+	for _, ownership := range exactRejected {
+		add(ownership, false)
+	}
+	machines := make([]string, 0, len(byMachine))
+	for machine := range byMachine {
+		machines = append(machines, machine)
+	}
+	slices.Sort(machines)
+	for _, machine := range machines {
+		set := byMachine[machine]
+		if err := e.db.ReplaceActiveSessionSourceBaselinesWithExceptions(
+			ctx, machine, nil, nil, set.admitted, set.rejected,
 		); err != nil {
 			return err
 		}
@@ -5330,6 +5620,10 @@ func mergeReconciliationSyncStats(dst *SyncStats, src SyncStats) {
 	dst.messagesIndexed += src.messagesIndexed
 	dst.parserExcludedFiles += src.parserExcludedFiles
 	dst.parserExcludedIDs = append(dst.parserExcludedIDs, src.parserExcludedIDs...)
+	dst.Tombstoned += src.Tombstoned
+	dst.sourceMissingArchiveMembers = append(
+		dst.sourceMissingArchiveMembers, src.sourceMissingArchiveMembers...,
+	)
 	dst.cwdFilteredSessions += src.cwdFilteredSessions
 	dst.cwdFilteredFiles += src.cwdFilteredFiles
 	dst.Aborted = dst.Aborted || src.Aborted
@@ -5849,6 +6143,152 @@ func (e *Engine) tombstoneSessionSourceOwnership(
 	return true, nil
 }
 
+// reconcileSourceMissingMembers applies the per-member CWD decision shared by
+// batch and single-session writes. A member without deletion proof cannot be
+// tombstoned yet, so baseline records only that exact admitted ownership; the
+// caller persists those records at the correct point in its write ordering.
+func (e *Engine) reconcileSourceMissingMembers(
+	ctx context.Context,
+	agent parser.AgentType,
+	members []sourceMissingMember,
+	baseline func(db.SessionSourceOwnership),
+	reject func(db.SessionSourceOwnership),
+) (int, []sourceMissingMember, error) {
+	admitted := make([]bool, len(members))
+	for i, member := range members {
+		allowed, err := e.missingMemberTombstoneAllowed(
+			ctx, member.sessionID,
+		)
+		if err != nil {
+			return 0, nil, err
+		}
+		if allowed {
+			admitted[i] = true
+			continue
+		}
+		if reject != nil {
+			reject(db.SessionSourceOwnership{
+				Machine:  member.machine,
+				Agent:    string(agent),
+				ID:       member.sessionID,
+				FilePath: member.filePath,
+			})
+		}
+	}
+
+	tombstoned := 0
+	var deferred []sourceMissingMember
+	for i, member := range members {
+		if !admitted[i] {
+			continue
+		}
+		ownership := db.SessionSourceOwnership{
+			Machine:  member.machine,
+			Agent:    string(agent),
+			ID:       member.sessionID,
+			FilePath: member.filePath,
+		}
+		if e.archiveStore != nil {
+			replacement, err := e.db.GetSession(ctx, member.sessionID)
+			if err != nil {
+				return tombstoned, deferred, fmt.Errorf(
+					"read replacement source-missing member %s: %w",
+					member.sessionID, err,
+				)
+			}
+			if replacement == nil {
+				deferred = append(deferred, member)
+				continue
+			}
+		}
+		changed, err := e.tombstoneSessionSourceOwnership(
+			ctx, member.machine, string(agent),
+			member.sessionID, member.filePath,
+		)
+		if err != nil {
+			return tombstoned, deferred, err
+		}
+		if changed {
+			tombstoned++
+			continue
+		}
+		if baseline != nil {
+			baseline(ownership)
+		}
+	}
+	return tombstoned, deferred, nil
+}
+
+// reconcileCopiedSourceMissingMembers completes rebuild-time reconciliation
+// after orphan copy has materialized archive-only rows in the replacement.
+// Exact baselines copied from the archive authorize an immediate guarded
+// tombstone.
+// Baseline-free legacy rows remain active for this pass but gain exact proof,
+// preserving the normal two-pass upgrade safety rule.
+func (e *Engine) reconcileCopiedSourceMissingMembers(
+	ctx context.Context,
+	target *db.DB,
+	archivePath string,
+	members []sourceMissingMember,
+) (int, error) {
+	tombstoned := 0
+	ownerships := make([]db.SessionSourceOwnership, 0, len(members))
+	for _, member := range members {
+		ownerships = append(ownerships, db.SessionSourceOwnership{
+			ID:       member.sessionID,
+			Machine:  member.machine,
+			Agent:    string(parser.AgentClaude),
+			FilePath: member.filePath,
+		})
+	}
+	if err := target.CopySessionSourceOwnershipBaselinesFrom(
+		ctx, archivePath, ownerships,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"copy admitted source-missing baselines: %w", err,
+		)
+	}
+	var needsBaseline []db.SessionSourceOwnership
+	for i, member := range members {
+		e.clearSkipInMemory(member.filePath)
+		e.clearSkipInMemory(providerAgentSkipCacheKey(
+			member.filePath, parser.AgentClaude,
+		))
+		if err := target.DeleteProviderStatHash(
+			ctx, parser.AgentClaude, member.filePath,
+		); err != nil {
+			return tombstoned, fmt.Errorf(
+				"clear copied source freshness for %s: %w",
+				member.sessionID, err,
+			)
+		}
+		changed, err := target.SoftDeleteSessionSourceOwnership(
+			ctx, member.machine, string(parser.AgentClaude),
+			member.sessionID, member.filePath,
+		)
+		if err != nil {
+			return tombstoned, fmt.Errorf(
+				"tombstone copied source-missing member %s: %w",
+				member.sessionID, err,
+			)
+		}
+		if changed {
+			tombstoned++
+			e.invalidateVerifiedSource(parser.AgentClaude, member.filePath)
+			continue
+		}
+		needsBaseline = append(needsBaseline, ownerships[i])
+	}
+	if err := target.BaselineActiveSessionSourceOwnerships(
+		ctx, needsBaseline,
+	); err != nil {
+		return tombstoned, fmt.Errorf(
+			"baseline copied source-missing members: %w", err,
+		)
+	}
+	return tombstoned, nil
+}
+
 func (e *Engine) buildReconciliationReplacementIndex(
 	ctx context.Context, provider parser.Provider, configuredRoots []string,
 ) (result reconciliationSpoolStore, retErr error) {
@@ -5912,7 +6352,7 @@ func (e *Engine) SyncAllSince(
 	}
 	e.syncMu.Lock()
 	defer func() {
-		if stats.Synced > 0 {
+		if stats.Synced > 0 || stats.Tombstoned > 0 {
 			e.emit("sessions")
 		}
 	}()
@@ -5936,7 +6376,7 @@ func (e *Engine) SyncRootsSince(
 	}
 	e.syncMu.Lock()
 	defer func() {
-		if stats.Synced > 0 {
+		if stats.Synced > 0 || stats.Tombstoned > 0 {
 			e.emit("sessions")
 		}
 	}()
@@ -7890,6 +8330,8 @@ func (e *Engine) collectAndBatch(
 	baselineCandidates := make([]machineSessionSource, 0, baselineHint)
 	baselineAdmitted := make([]machineSessionSource, 0, baselineHint)
 	baselineAdmission := make(map[machineSessionSource]bool, baselineHint)
+	var exactBaselineOwnerships map[db.SessionSourceOwnership]struct{}
+	var rejectedBaselineOwnerships map[db.SessionSourceOwnership]struct{}
 	runtimeMetrics := reconciliationRuntimeMetricsFor(ctx)
 	baselineSourceForJob := func(job syncJob) (machineSessionSource, bool) {
 		source := machineSessionSource{
@@ -7922,13 +8364,26 @@ func (e *Engine) collectAndBatch(
 			}
 			delete(baselineCacheWrites, source)
 		}
+		baselineCtx := ctx
+		if ctx.Err() != nil &&
+			(len(exactBaselineOwnerships) > 0 ||
+				len(rejectedBaselineOwnerships) > 0) {
+			baselineCtx = context.WithoutCancel(ctx)
+		}
 		resolvedCandidates, resolvedAdmitted, err :=
 			e.expandSourceBaselinesByStoredAttribution(
-				ctx, baselineCandidates, baselineAdmitted,
+				baselineCtx, baselineCandidates, baselineAdmitted,
 			)
+		exactOwnerships := matchingBaselineOwnerships(
+			resolvedCandidates, exactBaselineOwnerships,
+		)
+		rejectedOwnerships := matchingBaselineOwnerships(
+			resolvedCandidates, rejectedBaselineOwnerships,
+		)
 		if err == nil {
-			err = e.replaceActiveSessionSourceBaselinesByMachine(
-				ctx, resolvedCandidates, resolvedAdmitted,
+			err = e.replaceActiveSessionSourceBaselinesWithExceptionsByMachine(
+				baselineCtx, resolvedCandidates, resolvedAdmitted,
+				exactOwnerships, rejectedOwnerships,
 			)
 		}
 		if err != nil {
@@ -7937,6 +8392,12 @@ func (e *Engine) collectAndBatch(
 			e.poisonSQLiteContainerPass()
 			e.rejectSkipCacheWrites(cacheWrites)
 		} else {
+			consumeBaselineOwnerships(
+				exactBaselineOwnerships, exactOwnerships,
+			)
+			consumeBaselineOwnerships(
+				rejectedBaselineOwnerships, rejectedOwnerships,
+			)
 			e.promoteSkipCacheWrites(cacheWrites)
 		}
 		baselineCandidates = baselineCandidates[:0]
@@ -7996,6 +8457,38 @@ func (e *Engine) collectAndBatch(
 		if len(baselineCandidates) == reconciliationPageSize {
 			flushBaselineSources()
 		}
+	}
+	baselineExactOwnership := func(ownership db.SessionSourceOwnership) {
+		if tracker := reconciliationBaselineTrackerFor(ctx); tracker != nil {
+			tracker.addExactOwnership(ownership)
+			return
+		}
+		if runtimeMetrics != nil || ownership.ID == "" ||
+			ownership.Agent == "" || ownership.FilePath == "" {
+			return
+		}
+		if exactBaselineOwnerships == nil {
+			exactBaselineOwnerships = make(
+				map[db.SessionSourceOwnership]struct{},
+			)
+		}
+		exactBaselineOwnerships[ownership] = struct{}{}
+	}
+	rejectExactOwnership := func(ownership db.SessionSourceOwnership) {
+		if tracker := reconciliationBaselineTrackerFor(ctx); tracker != nil {
+			tracker.rejectExactOwnership(ownership)
+			return
+		}
+		if runtimeMetrics != nil || ownership.ID == "" ||
+			ownership.Agent == "" || ownership.FilePath == "" {
+			return
+		}
+		if rejectedBaselineOwnerships == nil {
+			rejectedBaselineOwnerships = make(
+				map[db.SessionSourceOwnership]struct{},
+			)
+		}
+		rejectedBaselineOwnerships[ownership] = struct{}{}
 	}
 	stageNoWriteCache := func(job syncJob, write skipCacheWrite) {
 		if write.key == "" {
@@ -8106,6 +8599,7 @@ func (e *Engine) collectAndBatch(
 			}
 			baselineErr := e.baselinePendingWriteSources(
 				ctx, pending, outcome.written,
+				exactBaselineOwnerships, rejectedBaselineOwnerships,
 			)
 			if baselineErr != nil {
 				log.Printf("baseline parsed session sources: %v", baselineErr)
@@ -8186,19 +8680,25 @@ func (e *Engine) collectAndBatch(
 			stats.RecordFailed()
 		}
 		if r.skip {
-			if r.cacheSkip && r.mtime != 0 && !r.noCacheSkip {
+			rowlessCached := e.cacheClaudeRowlessFreshness(ctx, r)
+			if !rowlessCached && r.cacheSkip && r.mtime != 0 &&
+				!r.noCacheSkip {
 				e.cacheSkip(r.skipCacheKey(), r.mtime)
 			}
 			stats.RecordSkip()
 			e.noteSQLiteContainerResult(r.path, true)
 			if r.providerFailureCount == 0 {
-				admitted, err := e.skippedSourceAllowsCwdFilter(ctx, r)
+				admitted, exactOwnerships, err :=
+					e.skippedSourceAllowsCwdFilter(ctx, r)
 				if err != nil {
 					log.Printf("check skipped source cwd admission: %v", err)
 					stats.RecordFailed()
 					e.poisonSQLiteContainerPass()
 				} else {
 					baselineProcessedSource(r, admitted)
+					for _, ownership := range exactOwnerships {
+						baselineExactOwnership(ownership)
+					}
 				}
 			}
 			progress.SessionsDone++
@@ -8284,30 +8784,11 @@ func (e *Engine) collectAndBatch(
 		// point, so the source-wide gate would freeze an allowed
 		// member's deletion whenever everything else was unchanged.
 		if len(r.sourceMissingMembers) > 0 {
-			tombstoneErr := error(nil)
-			for _, member := range r.sourceMissingMembers {
-				allowed, err := e.missingMemberTombstoneAllowed(
-					ctx, member.sessionID,
-				)
-				if err != nil {
-					tombstoneErr = err
-					break
-				}
-				if !allowed {
-					continue
-				}
-				changed, err := e.tombstoneSessionSourceOwnership(
-					ctx, member.machine, string(r.agent),
-					member.sessionID, member.filePath,
-				)
-				if err != nil {
-					tombstoneErr = err
-					break
-				}
-				if changed {
-					stats.sourceMissingTombstoned++
-				}
-			}
+			tombstoned, deferred, tombstoneErr := e.reconcileSourceMissingMembers(
+				ctx, r.agent, r.sourceMissingMembers,
+				baselineExactOwnership, rejectExactOwnership,
+			)
+			stats.Tombstoned += tombstoned
 			if tombstoneErr != nil {
 				log.Printf(
 					"tombstone source-missing members: %v", tombstoneErr,
@@ -8317,6 +8798,9 @@ func (e *Engine) collectAndBatch(
 				r.releaseRetention()
 				continue
 			}
+			stats.sourceMissingArchiveMembers = append(
+				stats.sourceMissingArchiveMembers, deferred...,
+			)
 		}
 		if len(r.results) == 0 && r.incremental == nil {
 			if len(r.excludedSessionIDs) > 0 ||
@@ -8324,7 +8808,8 @@ func (e *Engine) collectAndBatch(
 				stats.filesOK++
 				stats.parserExcludedFiles++
 			}
-			if r.cacheSkip && !r.noCacheSkip {
+			if !e.cacheClaudeRowlessFreshness(ctx, r) &&
+				r.cacheSkip && !r.noCacheSkip {
 				if r.agent == parser.AgentOmnigent {
 					// An omnigent rowless container entry can vouch for the
 					// source with no stored rows at all (see the
@@ -8381,6 +8866,12 @@ func (e *Engine) collectAndBatch(
 		)
 		if vetoed > 0 && len(allowed) == 0 {
 			e.clearProviderSourceFreshness(ctx, r.providerStatHash)
+			// Claude can emit a synthetic base result for a replay-only
+			// transcript. If the active CWD filter rejects that result while a
+			// stale fork is also preserved, record the successful complete parse
+			// under a filter-scoped marker. This restores steady-state freshness
+			// without letting a later filter configuration inherit the proof.
+			e.cacheClaudeRowlessFreshness(ctx, r)
 			stats.cwdFilteredFiles++
 			if r.providerFailureCount == 0 {
 				baselineProcessedSource(r, false)
@@ -8482,6 +8973,32 @@ func (e *Engine) collectAndBatch(
 flush:
 	flushPending()
 	flushBaselineSources()
+	if len(exactBaselineOwnerships) > 0 ||
+		len(rejectedBaselineOwnerships) > 0 {
+		exactOwnerships := make(
+			[]db.SessionSourceOwnership, 0, len(exactBaselineOwnerships),
+		)
+		for ownership := range exactBaselineOwnerships {
+			exactOwnerships = append(exactOwnerships, ownership)
+		}
+		rejectedOwnerships := make(
+			[]db.SessionSourceOwnership, 0, len(rejectedBaselineOwnerships),
+		)
+		for ownership := range rejectedBaselineOwnerships {
+			rejectedOwnerships = append(rejectedOwnerships, ownership)
+		}
+		baselineCtx := ctx
+		if ctx.Err() != nil {
+			baselineCtx = context.WithoutCancel(ctx)
+		}
+		if err := e.replaceSessionSourceBaselineExceptionsByMachine(
+			baselineCtx, exactOwnerships, rejectedOwnerships,
+		); err != nil {
+			log.Printf("replace exact source baseline exceptions: %v", err)
+			stats.RecordFailed()
+			e.poisonSQLiteContainerPass()
+		}
+	}
 
 	// Link subagent child sessions to their parents via
 	// tool_calls.subagent_session_id references. Run once
@@ -8504,6 +9021,8 @@ flush:
 
 func (e *Engine) baselinePendingWriteSources(
 	ctx context.Context, pending []pendingWrite, written []bool,
+	exactBaselineOwnerships map[db.SessionSourceOwnership]struct{},
+	rejectedBaselineOwnerships map[db.SessionSourceOwnership]struct{},
 ) error {
 	eligible := make(
 		map[machineSessionSource]bool,
@@ -8546,23 +9065,39 @@ func (e *Engine) baselinePendingWriteSources(
 		return nil
 	}
 
-	if err := e.replaceActiveSessionSourceBaselinesByMachine(
-		ctx, candidates, admitted,
+	exactOwnerships := matchingBaselineOwnerships(
+		candidates, exactBaselineOwnerships,
+	)
+	rejectedOwnerships := matchingBaselineOwnerships(
+		candidates, rejectedBaselineOwnerships,
+	)
+	baselineCtx := ctx
+	if ctx.Err() != nil &&
+		(len(exactOwnerships) > 0 || len(rejectedOwnerships) > 0) {
+		baselineCtx = context.WithoutCancel(ctx)
+	}
+	if err := e.replaceActiveSessionSourceBaselinesWithExceptionsByMachine(
+		baselineCtx, candidates, admitted,
+		exactOwnerships, rejectedOwnerships,
 	); err != nil {
 		return fmt.Errorf("replace parsed source baseline batch: %w", err)
 	}
+	consumeBaselineOwnerships(exactBaselineOwnerships, exactOwnerships)
+	consumeBaselineOwnerships(rejectedBaselineOwnerships, rejectedOwnerships)
 	return nil
 }
 
 // skippedSourceAllowsCwdFilter determines whether an unchanged source may
-// retain deletion proof after a configuration restart. A freshness skip has no
-// parser output to run through sourceAllowsParserExclusions, so use the active
-// archived rows for that exact source as the admission evidence instead.
+// retain source-wide deletion proof after a configuration restart. A freshness
+// skip has no parser output to run through sourceAllowsParserExclusions, so use
+// the active archived rows for that exact source as the admission evidence. A
+// mixed-CWD source rejects broad proof and returns only its admitted exact
+// ownerships so filtered siblings remain protected.
 func (e *Engine) skippedSourceAllowsCwdFilter(
 	ctx context.Context, job syncJob,
-) (bool, error) {
+) (bool, []db.SessionSourceOwnership, error) {
 	if e.cwdFilter.empty() {
-		return true, nil
+		return true, nil, nil
 	}
 	path := e.effectiveSourcePath(job.path)
 	// Freebuff shares the Codebuff provider. Query both agent types
@@ -8571,22 +9106,96 @@ func (e *Engine) skippedSourceAllowsCwdFilter(
 	if job.agent == parser.AgentCodebuff {
 		agentsToQuery = append(agentsToQuery, string(parser.AgentFreebuff))
 	}
+	var admittedOwnerships []db.SessionSourceOwnership
+	sourceWideAllowed := true
 	for _, agentStr := range agentsToQuery {
 		ids, err := e.db.ListSessionIDsByFilePath(path, agentStr)
 		if err != nil {
-			return false, err
+			return false, nil, err
 		}
 		for _, id := range ids {
 			session, err := e.db.GetSession(ctx, id)
 			if err != nil {
-				return false, err
+				return false, nil, err
 			}
-			if session != nil && !e.cwdFilter.allows(session.Cwd) {
-				return false, nil
+			if session == nil {
+				continue
 			}
+			if !e.cwdFilter.allows(session.Cwd) {
+				sourceWideAllowed = false
+				continue
+			}
+			admittedOwnerships = append(
+				admittedOwnerships,
+				db.SessionSourceOwnership{
+					ID:       session.ID,
+					Machine:  session.Machine,
+					Agent:    session.Agent,
+					FilePath: path,
+				},
+			)
 		}
 	}
-	return true, nil
+	if sourceWideAllowed {
+		return true, nil, nil
+	}
+	return false, admittedOwnerships, nil
+}
+
+// reconcileSkippedSingleSessionSourceBaselines refreshes deletion proof for a
+// fresh single-session source before its early return. A CWD filter may have
+// narrowed since the source last parsed, so broad proof must be replaced with
+// exact proof for only the currently admitted archived rows.
+func (e *Engine) reconcileSkippedSingleSessionSourceBaselines(
+	ctx context.Context, file parser.DiscoveredFile,
+) error {
+	job := syncJob{
+		agent:   file.Agent,
+		path:    file.Path,
+		machine: file.Machine,
+	}
+	sourceWideAllowed, exactOwnerships, err :=
+		e.skippedSourceAllowsCwdFilter(ctx, job)
+	if err != nil {
+		return err
+	}
+
+	path := e.effectiveSourcePath(file.Path)
+	agents := []parser.AgentType{file.Agent}
+	if file.Agent == parser.AgentCodebuff {
+		agents = append(agents, parser.AgentFreebuff)
+	}
+	candidates := make([]machineSessionSource, 0, len(agents))
+	admitted := make([]machineSessionSource, 0, len(agents))
+	for _, agent := range agents {
+		source := machineSessionSource{
+			Machine: file.Machine,
+			Source: db.SessionSourcePath{
+				Agent: string(agent), FilePath: path,
+			},
+		}
+		candidates = append(candidates, source)
+		if sourceWideAllowed {
+			admitted = append(admitted, source)
+		}
+	}
+	candidates, admitted, err = e.expandSourceBaselinesByStoredAttribution(
+		ctx, candidates, admitted,
+	)
+	if err != nil {
+		return err
+	}
+	if err := e.replaceActiveSessionSourceBaselinesByMachine(
+		ctx, candidates, admitted,
+	); err != nil {
+		return err
+	}
+	if err := e.db.BaselineActiveSessionSourceOwnerships(
+		ctx, exactOwnerships,
+	); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (e *Engine) linkSubagentSessions(ctx context.Context) error {
@@ -8678,6 +9287,11 @@ type processResult struct {
 	// kept results.
 	providerStatHash *pendingProviderStatHash
 	cacheSkip        bool
+	// claudeRowlessFreshnessKey is staged by a successful complete Claude
+	// parse. The collector promotes it only when the parse leaves no admitted
+	// session row and a CWD-rejected stale fork still needs filter-scoped
+	// freshness, after source-missing reconciliation and CWD filtering succeed.
+	claudeRowlessFreshnessKey string
 	// cacheAfterWrite records a successful, complete rowless container parse
 	// after its member writes commit. Unlike ordinary provider results, these
 	// containers have no physical-path session row that can make the next full
@@ -9412,6 +10026,11 @@ func (e *Engine) processProviderFile(
 			providerFailureCount:     providerFailureCount,
 			providerWideFailureCount: providerWideFailureCount,
 		}
+		if file.Agent == parser.AgentClaude && cleanCache && !e.forceParse &&
+			!file.ForceParse {
+			skipRes.claudeRowlessFreshnessKey =
+				e.claudeRowlessFreshnessCacheKey(file.Path, fingerprint.Hash)
+		}
 		// A SkipReason outcome without a force-replace carries no parsed data,
 		// so it stays a lease-free skip; a force-replace is parse-bearing.
 		if skipRes.skip {
@@ -9430,6 +10049,22 @@ func (e *Engine) processProviderFile(
 		missingMembers, err =
 			e.providerSourceMissingSessionOwnershipsForCompleteResult(
 				ctx, provider, source, parsedResults,
+			)
+		if err != nil {
+			return processResult{
+				err:            err,
+				mtime:          fingerprint.MTimeNS,
+				cacheSkip:      cacheSkip,
+				cacheKey:       cacheKey,
+				noCacheSkip:    true,
+				retentionLease: lease,
+			}, true
+		}
+	} else if file.Agent == parser.AgentClaude &&
+		outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 {
+		missingMembers, err =
+			e.claudeSourceMissingSessionOwnershipsForCompleteResult(
+				ctx, file.Path, outcome.ExcludedSessionIDs, parsedResults,
 			)
 		if err != nil {
 			return processResult{
@@ -9494,6 +10129,11 @@ func (e *Engine) processProviderFile(
 		}
 	}
 	e.applyProviderFilePathPolicies(ctx, provider, file.Agent, file.Path, &res)
+	if file.Agent == parser.AgentClaude && cleanCache && !e.forceParse &&
+		!file.ForceParse {
+		res.claudeRowlessFreshnessKey =
+			e.claudeRowlessFreshnessCacheKey(file.Path, fingerprint.Hash)
+	}
 	if storageStateOK {
 		e.stageOpenCodeStorageTrust(
 			&res, file.Path, storageState, storageSnap,
@@ -9682,6 +10322,308 @@ func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResult(
 		missing = append(missing, member)
 	}
 	return missing, nil
+}
+
+// claudeSourceMissingSessionOwnershipsForCompleteResult lists stored active
+// Claude fork sessions written by an older parser version under this
+// transcript's exact stored path that a complete full parse no longer derives
+// from it. The stale data version and fork relationship together prove the row
+// is a legacy DAG branch artifact rather than a current parser presence
+// regression. Such rows can never be re-stamped by re-parsing the file, so
+// they pin the path's minimum data_version at a stale value and defeat the
+// unchanged-source skip on every sweep. Tombstoning them as source-missing
+// lets the skip converge; a later parse that re-emits an ID revives the row.
+// Unlike the provider-scope variant above, the lookup is bound to the results'
+// own file paths: a Claude source scope must never widen to sibling
+// transcripts, whose sessions are legitimately absent from this parse.
+func (e *Engine) claudeSourceMissingSessionOwnershipsForCompleteResult(
+	ctx context.Context,
+	sourcePath string,
+	excludedSessionIDs []string,
+	results []parser.ParseResult,
+) ([]sourceMissingMember, error) {
+	present := make(map[string]struct{}, len(results))
+	paths := make(map[string]struct{}, 1)
+	for _, result := range results {
+		if id := applyIDPrefixToID(e.idPrefix, result.Session.ID); id != "" {
+			present[id] = struct{}{}
+		}
+		path := result.Session.File.Path
+		if path == "" {
+			continue
+		}
+		if e.pathRewriter != nil {
+			path = e.pathRewriter(path)
+		}
+		paths[path] = struct{}{}
+	}
+	if len(paths) == 0 && sourcePath != "" {
+		paths[e.effectiveSourcePath(sourcePath)] = struct{}{}
+	}
+	// Excluded IDs are owned by the parser-exclusion deletion path.
+	for _, id := range e.applyIDPrefixToSessionIDs(excludedSessionIDs) {
+		present[id] = struct{}{}
+	}
+	if index := e.archiveStaleClaudeForks; index != nil {
+		return index.missingMembers(paths, present), nil
+	}
+	var members []sourceMissingMember
+	var sessionIDs []string
+	for path := range paths {
+		storedIDs, err := e.db.ListStaleForkSessionIDsByFilePath(
+			path, string(parser.AgentClaude),
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"list stale claude fork sessions for %s: %w", path, err,
+			)
+		}
+		for _, id := range storedIDs {
+			if _, ok := present[id]; ok {
+				continue
+			}
+			members = append(members, sourceMissingMember{
+				sessionID: id,
+				filePath:  path,
+			})
+			sessionIDs = append(sessionIDs, id)
+		}
+	}
+	if len(members) == 0 {
+		return nil, nil
+	}
+	storedMachines, err := e.db.ListSessionMachinesByID(ctx, sessionIDs)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list stored claude session machines: %w", err,
+		)
+	}
+	for i := range members {
+		members[i].machine = storedMachines[members[i].sessionID]
+	}
+	return members, nil
+}
+
+// archiveStaleClaudeForkIndex is a rebuild-scoped snapshot of the original
+// archive's stale Claude fork rows keyed by stored source path. The archive
+// takes no writes while a rebuild reads it, so the snapshot stays exact.
+type archiveStaleClaudeForkIndex struct {
+	byPath map[string][]db.SessionSourceOwnership
+}
+
+func loadArchiveStaleClaudeForkIndex(
+	archive *db.DB,
+) (*archiveStaleClaudeForkIndex, error) {
+	ownerships, err := archive.ListStaleForkSessionOwnerships(
+		string(parser.AgentClaude),
+	)
+	if err != nil {
+		return nil, err
+	}
+	index := &archiveStaleClaudeForkIndex{
+		byPath: make(map[string][]db.SessionSourceOwnership),
+	}
+	for _, ownership := range ownerships {
+		index.byPath[ownership.FilePath] = append(
+			index.byPath[ownership.FilePath], ownership,
+		)
+	}
+	return index, nil
+}
+
+// missingMembers returns the snapshotted stale forks under paths that a
+// complete parse did not re-emit, in a stable path-then-ID order.
+func (index *archiveStaleClaudeForkIndex) missingMembers(
+	paths map[string]struct{},
+	present map[string]struct{},
+) []sourceMissingMember {
+	var members []sourceMissingMember
+	for path := range paths {
+		for _, ownership := range index.byPath[path] {
+			if _, ok := present[ownership.ID]; ok {
+				continue
+			}
+			members = append(members, sourceMissingMember{
+				sessionID: ownership.ID,
+				filePath:  path,
+				machine:   ownership.Machine,
+			})
+		}
+	}
+	slices.SortFunc(members, func(a, b sourceMissingMember) int {
+		if c := strings.Compare(a.filePath, b.filePath); c != 0 {
+			return c
+		}
+		return strings.Compare(a.sessionID, b.sessionID)
+	})
+	return members
+}
+
+// claudeSourceNeedsStaleForkReconciliation reports whether a freshness skip
+// would strand an actionable legacy fork on this exact stored source path.
+// Forks rejected by the CWD filter are intentionally preserved and do not
+// require another parse. A read error still defeats freshness so cleanup can
+// retry instead of silently preserving stale data.
+func (e *Engine) claudeSourceNeedsStaleForkReconciliation(
+	ctx context.Context, path string,
+) bool {
+	storedIDs, err := e.db.ListStaleForkSessionIDsByFilePath(
+		path, string(parser.AgentClaude),
+	)
+	if err != nil {
+		return true
+	}
+	for _, id := range storedIDs {
+		allowed, err := e.missingMemberTombstoneAllowed(ctx, id)
+		if err != nil || allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// claudeSourceHasOnlyPreservedStaleForks reports whether every active Claude
+// row at path is a stale legacy fork that the current CWD filter intentionally
+// preserves. Such rows must not keep an otherwise unchanged source permanently
+// stale: the filter decision is re-evaluated on every pass, so a later engine
+// with a broader filter will resume reconciliation instead of inheriting a
+// durable cache exemption. Any lookup error fails closed and reparses.
+func (e *Engine) claudeSourceHasOnlyPreservedStaleForks(
+	ctx context.Context, path string,
+) bool {
+	return e.claudeSourceStaleRowsArePreservedForks(ctx, path, false)
+}
+
+// claudeSourceStaleRowsArePreservedForks verifies that every stale row under
+// path is a legacy fork rejected by the current CWD filter. When
+// allowCurrentRows is true, current primary or fork rows may share the source.
+func (e *Engine) claudeSourceStaleRowsArePreservedForks(
+	ctx context.Context, path string, allowCurrentRows bool,
+) bool {
+	staleIDs, err := e.db.ListStaleForkSessionIDsByFilePath(
+		path, string(parser.AgentClaude),
+	)
+	if err != nil || len(staleIDs) == 0 {
+		return false
+	}
+	activeIDs, err := e.db.ListSessionIDsByFilePath(
+		path, string(parser.AgentClaude),
+	)
+	if err != nil || len(activeIDs) < len(staleIDs) {
+		return false
+	}
+	stale := make(map[string]struct{}, len(staleIDs))
+	for _, id := range staleIDs {
+		stale[id] = struct{}{}
+	}
+	for _, id := range activeIDs {
+		if _, ok := stale[id]; !ok {
+			if !allowCurrentRows {
+				return false
+			}
+			session, err := e.db.GetSession(ctx, id)
+			if err != nil || session == nil ||
+				session.DataVersion < db.CurrentDataVersion() {
+				return false
+			}
+			continue
+		}
+		allowed, err := e.missingMemberTombstoneAllowed(ctx, id)
+		if err != nil || allowed {
+			return false
+		}
+	}
+	return true
+}
+
+// claudeSourceFreshWithoutPrimary verifies an unchanged Claude source through
+// exact-path metadata when its canonical primary session is absent and only
+// CWD-rejected stale forks remain. The stale forks' old data versions and file
+// metadata are ignored only when a current-content-, data-version-, and
+// CWD-filter-keyed marker proves the parser completed cleanly without producing
+// an admitted primary row.
+func (e *Engine) claudeSourceFreshWithoutPrimary(
+	ctx context.Context,
+	lookupPath string,
+	physicalPath string,
+	info os.FileInfo,
+	sourceFingerprint string,
+) (fresh, contentVerified bool) {
+	if !e.claudeSourceHasOnlyPreservedStaleForks(ctx, lookupPath) {
+		return false, false
+	}
+	project, ok := e.db.GetProjectByAgentPath(
+		lookupPath, string(parser.AgentClaude),
+	)
+	if !ok || project == "" || parser.NeedsProjectReparse(project) {
+		return false, false
+	}
+	currentHash := sourceFingerprint
+	if currentHash == "" {
+		var err error
+		currentHash, err = computeFileHashPrefix(physicalPath, info.Size())
+		if err != nil {
+			return false, false
+		}
+	}
+	if !e.claudeRowlessFreshnessMarked(
+		lookupPath, physicalPath, currentHash, info.ModTime().UnixNano(),
+	) {
+		return false, false
+	}
+	return true, true
+}
+
+func (e *Engine) claudeRowlessFreshnessCacheKey(
+	path, contentHash string,
+) string {
+	if path == "" || contentHash == "" {
+		return ""
+	}
+	prefixes := append([]string(nil), e.cwdFilter.prefixes...)
+	slices.Sort(prefixes)
+	filterHash := sha256.Sum256([]byte(strings.Join(prefixes, "\x00")))
+	return providerAgentSkipCacheKey(path, parser.AgentClaude) +
+		sourceHashSkipMarker + contentHash +
+		"&data_version=" + strconv.Itoa(db.CurrentDataVersion()) +
+		"&cwd_filter=" + fmt.Sprintf("%x", filterHash)
+}
+
+func (e *Engine) cacheClaudeRowlessFreshness(
+	ctx context.Context, job syncJob,
+) bool {
+	if job.claudeRowlessFreshnessKey == "" || job.mtime == 0 ||
+		job.noCacheSkip {
+		return false
+	}
+	if !e.claudeSourceHasOnlyPreservedStaleForks(
+		ctx, e.effectiveSourcePath(job.path),
+	) {
+		return false
+	}
+	e.cacheSkip(
+		job.claudeRowlessFreshnessKey, job.mtime, job.sourceFingerprint,
+	)
+	return true
+}
+
+func (e *Engine) claudeRowlessFreshnessMarked(
+	lookupPath, physicalPath, contentHash string,
+	mtime int64,
+) bool {
+	paths := []string{lookupPath}
+	if physicalPath != lookupPath {
+		paths = append(paths, physicalPath)
+	}
+	e.skipMu.RLock()
+	defer e.skipMu.RUnlock()
+	for _, path := range paths {
+		key := e.claudeRowlessFreshnessCacheKey(path, contentHash)
+		if key != "" && e.skipCache[key] == mtime {
+			return true
+		}
+	}
+	return false
 }
 
 // applyProviderFilePathPolicies reproduces the DB-aware, file-path-scoped
@@ -10375,8 +11317,9 @@ func (e *Engine) clearSkip(path string) int {
 	return work
 }
 
-func (e *Engine) clearSkipPersistent(path string) (int, error) {
+func (e *Engine) clearSkipInMemory(path string) int {
 	e.skipMu.Lock()
+	defer e.skipMu.Unlock()
 	work := e.removeSkipHashSiblingsLocked(path)
 	delete(e.skipCache, path)
 	delete(e.skipFingerprints, path)
@@ -10386,7 +11329,12 @@ func (e *Engine) clearSkipPersistent(path string) (int, error) {
 		delete(e.skipCache, legacyPath)
 		delete(e.skipFingerprints, legacyPath)
 	}
-	e.skipMu.Unlock()
+	return work
+}
+
+func (e *Engine) clearSkipPersistent(path string) (int, error) {
+	work := e.clearSkipInMemory(path)
+	legacyPath := legacyProviderSkipCacheKey(path)
 	if e.ephemeral {
 		return work, nil
 	}
@@ -10770,13 +11718,6 @@ func (e *Engine) providerSingleSessionFresh(
 		lookupPath = e.pathRewriter(path)
 	}
 	fullID := applyIDPrefixToID(e.idPrefix, sessionID)
-	if e.db.GetSessionFilePath(fullID) != lookupPath {
-		// A directory rename can preserve size, mtime, inode, and content.
-		// Freshness by session ID alone would keep the vanished source path
-		// forever instead of parsing the discovered destination and updating
-		// source ownership.
-		return 0, false, false, false
-	}
 	// statPath is the on-disk file the stat came from: lookupPath when it
 	// resolves (local sync, where lookupPath == path), otherwise the physical
 	// source path (remote sync rewrites path to a non-local logical key). The
@@ -10790,17 +11731,46 @@ func (e *Engine) providerSingleSessionFresh(
 			return 0, false, false, false
 		}
 	}
+	// A source-missing primary tombstone must read as absent here: it cannot
+	// vouch for the source (shouldSkipFile ignores it), so only the rowless
+	// marker can prove an unchanged source that no longer admits a primary.
+	primaryPath := e.db.GetSessionFilePathNotSourceMissing(fullID)
+	if primaryPath == "" {
+		fresh, contentVerified := e.claudeSourceFreshWithoutPrimary(
+			ctx, lookupPath, statPath, info, "",
+		)
+		if !fresh {
+			return 0, false, false, false
+		}
+		if e.providerIncrementalIdentityChanged(lookupPath, info) {
+			return 0, false, true, false
+		}
+		return info.ModTime().UnixNano(), true, false, contentVerified
+	}
+	if primaryPath != lookupPath {
+		// A directory rename can preserve size, mtime, inode, and content.
+		// Freshness by session ID alone would keep the vanished source path
+		// forever instead of parsing the discovered destination and updating
+		// source ownership.
+		return 0, false, false, false
+	}
 	if !e.shouldSkipFile(sessionID, info) {
 		return 0, false, false, false
 	}
 	// Claude transcripts can fan out into several active DAG sessions. The
 	// filename stem identifies only the main row, so its current version cannot
-	// hide a stale restored fork that shares the same source path.
+	// hide a stale restored fork that shares the same source path. Forks the CWD
+	// filter intentionally preserves are the exception: the filter-scoped
+	// cleanup guard below re-evaluates them on every pass.
 	_, sourceDataVersion, _, _, sourceFound :=
 		e.db.GetSourceRepairStateByAgentPath(
 			lookupPath, string(parser.AgentClaude),
 		)
-	if !sourceFound || sourceDataVersion < db.CurrentDataVersion() {
+	if !sourceFound ||
+		(sourceDataVersion < db.CurrentDataVersion() &&
+			!e.claudeSourceStaleRowsArePreservedForks(
+				ctx, lookupPath, true,
+			)) {
 		return 0, false, false, false
 	}
 	if e.providerIncrementalIdentityChanged(lookupPath, info) {
@@ -10811,6 +11781,13 @@ func (e *Engine) providerSingleSessionFresh(
 	)
 	if contentChanged {
 		return 0, false, true, contentVerified
+	}
+	if sourceDataVersion < db.CurrentDataVersion() &&
+		e.claudeSourceNeedsStaleForkReconciliation(ctx, lookupPath) {
+		// A baseline-free upgrade parse can refresh the primary row before it
+		// has authority to tombstone an omitted legacy fork. Keep parsing this
+		// exact source until a later baseline-backed pass finishes cleanup.
+		return 0, false, false, false
 	}
 	sess, _ := e.db.GetSession(ctx, fullID)
 	return info.ModTime().UnixNano(), sess != nil &&
@@ -15889,12 +16866,16 @@ func (e *Engine) SyncSingleSessionContext(
 	}
 	e.syncMu.Lock()
 	preserved := false
+	sessionsChanged := false
 	// Defers run LIFO: unlock runs first (releasing syncMu), then
 	// emit. Keep emission outside the critical section so a future
 	// Emitter implementation can't widen the lock's scope.
 	defer func() {
 		if err == nil && !preserved {
 			e.emit("messages")
+		}
+		if sessionsChanged {
+			e.emit("sessions")
 		}
 	}()
 	defer e.syncMu.Unlock()
@@ -16066,7 +17047,9 @@ func (e *Engine) SyncSingleSessionContext(
 		}
 	}
 
-	preserved, err = e.processAndWriteSessionFile(ctx, file, sessionID)
+	preserved, sessionsChanged, err = e.processAndWriteSessionFile(
+		ctx, file, sessionID,
+	)
 	return err
 }
 
@@ -16078,7 +17061,7 @@ func (e *Engine) SyncSingleSessionContext(
 // change event. The caller must hold syncMu.
 func (e *Engine) processAndWriteSessionFile(
 	ctx context.Context, file parser.DiscoveredFile, requestedSessionID string,
-) (preserved bool, err error) {
+) (preserved bool, sessionsChanged bool, err error) {
 	path := file.Path
 	res := e.processFile(ctx, file)
 	defer e.retentionBudget().scavengeIfNeeded()
@@ -16087,11 +17070,20 @@ func (e *Engine) processAndWriteSessionFile(
 		if res.cacheSkip && res.mtime != 0 && !res.noCacheSkip {
 			e.cacheSkip(res.skipCacheKey(path), res.mtime, res.sourceFingerprint)
 		}
-		return false, res.err
+		return false, sessionsChanged, res.err
 	}
 	if res.skip {
+		if err := e.reconcileSkippedSingleSessionSourceBaselines(
+			ctx, file,
+		); err != nil {
+			return false, sessionsChanged, fmt.Errorf(
+				"reconcile fresh source baselines: %w", err,
+			)
+		}
 		if err := e.db.RepairQueuedSubagentParents(); err != nil {
-			return false, fmt.Errorf("repair queued subagent parents: %w", err)
+			return false, sessionsChanged, fmt.Errorf(
+				"repair queued subagent parents: %w", err,
+			)
 		}
 		// A previous write may have stored a new spawn edge but failed
 		// before its child could be durably queued. The requested session is
@@ -16100,9 +17092,11 @@ func (e *Engine) processAndWriteSessionFile(
 		if err := e.db.LinkSubagentSessionsForSessions(
 			[]string{requestedSessionID},
 		); err != nil {
-			return false, fmt.Errorf("link fresh subagent sessions: %w", err)
+			return false, sessionsChanged, fmt.Errorf(
+				"link fresh subagent sessions: %w", err,
+			)
 		}
-		return false, nil
+		return false, sessionsChanged, nil
 	}
 	if res.cacheSkip {
 		e.clearSkip(res.skipCacheKey(path))
@@ -16127,17 +17121,21 @@ func (e *Engine) processAndWriteSessionFile(
 		append(append([]string{}, excluded...), resultIDs...),
 	)
 	if childErr != nil {
-		return false, fmt.Errorf(
+		return false, sessionsChanged, fmt.Errorf(
 			"list pre-write subagent children: %w", childErr)
 	}
 	// A prior sync may have removed an edge and then failed before repairing
 	// its child. Retry that durable work after this sync's read-only capture
 	// but before making any new mutations.
 	if err := e.db.RepairQueuedSubagentParents(); err != nil {
-		return false, fmt.Errorf("repair queued subagent parents: %w", err)
+		return false, sessionsChanged, fmt.Errorf(
+			"repair queued subagent parents: %w", err,
+		)
 	}
 	if err := e.db.QueueSubagentParentCleanupRepairs(priorChildren); err != nil {
-		return false, fmt.Errorf("queue subagent parent repairs: %w", err)
+		return false, sessionsChanged, fmt.Errorf(
+			"queue subagent parent repairs: %w", err,
+		)
 	}
 	claudeDAG := file.Agent == parser.AgentClaude && len(res.results) > 1
 	var sourceCompletionSkipped map[string]bool
@@ -16150,7 +17148,7 @@ func (e *Engine) processAndWriteSessionFile(
 			activeResultIDs, staleVersion,
 		); err != nil {
 			e.clearProviderSourceFreshness(ctx, res.providerStatHash)
-			return false, fmt.Errorf(
+			return false, sessionsChanged, fmt.Errorf(
 				"stage Claude source data versions: %w", err,
 			)
 		}
@@ -16194,7 +17192,7 @@ func (e *Engine) processAndWriteSessionFile(
 	if _, err := e.deleteParserExcludedSessions(
 		res, sourceAllowsParserExclusions,
 	); err != nil {
-		return false, fmt.Errorf(
+		return false, sessionsChanged, fmt.Errorf(
 			"delete parser-excluded sessions: %w", err,
 		)
 	}
@@ -16205,25 +17203,40 @@ func (e *Engine) processAndWriteSessionFile(
 	// freeze is judged per member against the archived cwd, matching
 	// the batch path.
 	if len(res.sourceMissingMembers) > 0 {
-		for _, member := range res.sourceMissingMembers {
-			allowed, err := e.missingMemberTombstoneAllowed(
-				ctx, member.sessionID,
-			)
-			if err != nil {
-				return false, err
-			}
-			if !allowed {
-				continue
-			}
-			if _, err := e.tombstoneSessionSourceOwnership(
-				ctx, member.machine, string(file.Agent),
-				member.sessionID, member.filePath,
-			); err != nil {
-				return false, fmt.Errorf(
-					"tombstone source-missing member %s: %w",
-					member.sessionID, err,
+		var exactOwnerships []db.SessionSourceOwnership
+		var rejectedExactOwnerships []db.SessionSourceOwnership
+		tombstoned, _, err := e.reconcileSourceMissingMembers(
+			ctx, file.Agent, res.sourceMissingMembers,
+			func(ownership db.SessionSourceOwnership) {
+				exactOwnerships = append(exactOwnerships, ownership)
+			},
+			func(ownership db.SessionSourceOwnership) {
+				rejectedExactOwnerships = append(
+					rejectedExactOwnerships, ownership,
 				)
-			}
+			},
+		)
+		sessionsChanged = sessionsChanged || tombstoned > 0
+		baselineCtx := ctx
+		if ctx.Err() != nil {
+			baselineCtx = context.WithoutCancel(ctx)
+		}
+		baselineErr := e.replaceSessionSourceBaselineExceptionsByMachine(
+			baselineCtx, exactOwnerships, rejectedExactOwnerships,
+		)
+		if baselineErr != nil {
+			baselineErr = fmt.Errorf(
+				"persist source-missing baseline exceptions: %w", baselineErr,
+			)
+		}
+		if err != nil {
+			return false, sessionsChanged, errors.Join(
+				fmt.Errorf("reconcile source-missing members: %w", err),
+				baselineErr,
+			)
+		}
+		if baselineErr != nil {
+			return false, sessionsChanged, baselineErr
 		}
 	}
 
@@ -16231,24 +17244,24 @@ func (e *Engine) processAndWriteSessionFile(
 	// append-only JSONL that was already synced).
 	if res.incremental != nil {
 		if err := e.writeIncremental(res.incremental); err != nil {
-			return false, err
+			return false, sessionsChanged, err
 		}
 		if err := queueWrittenChildren(
 			[]string{res.incremental.sessionID},
 		); err != nil {
-			return false, err
+			return false, sessionsChanged, err
 		}
 		if err := e.db.LinkSubagentSessionsForSessions(
 			[]string{res.incremental.sessionID},
 		); err != nil {
-			return false, fmt.Errorf(
+			return false, sessionsChanged, fmt.Errorf(
 				"link incremental subagent sessions: %w", err)
 		}
-		return false, nil
+		return false, sessionsChanged, nil
 	}
 
 	if len(res.results) == 0 {
-		return false, nil
+		return false, sessionsChanged, nil
 	}
 
 	sourceNeedsRetry := res.providerFailureCount > 0 ||
@@ -16278,7 +17291,7 @@ func (e *Engine) processAndWriteSessionFile(
 			[]string{resultIDs[i]},
 		); err != nil {
 			markSourceIncomplete()
-			return false, fmt.Errorf(
+			return false, sessionsChanged, fmt.Errorf(
 				"queue attempted session parent repair: %w", err,
 			)
 		}
@@ -16309,12 +17322,12 @@ func (e *Engine) processAndWriteSessionFile(
 				writeErr = errors.Join(writeErr, queueErr)
 			}
 			markSourceIncomplete()
-			return false, fmt.Errorf("write session %s: %w",
+			return false, sessionsChanged, fmt.Errorf("write session %s: %w",
 				pr.Session.ID, writeErr)
 		}
 		if queueErr != nil {
 			markSourceIncomplete()
-			return false, queueErr
+			return false, sessionsChanged, queueErr
 		}
 		if !memberPolicySkipped && errors.Is(writeErr, errSessionPreserved) {
 			preserved = true
@@ -16331,14 +17344,16 @@ func (e *Engine) processAndWriteSessionFile(
 	}
 	if err := e.db.LinkSubagentSessionsForSessions(resultIDs); err != nil {
 		markSourceIncomplete()
-		return false, fmt.Errorf("link changed subagent sessions: %w", err)
+		return false, sessionsChanged, fmt.Errorf(
+			"link changed subagent sessions: %w", err,
+		)
 	}
 	if sourceComplete && claudeDAG {
 		if err := e.db.SetSessionDataVersions(
 			writtenIDs, db.CurrentDataVersion(),
 		); err != nil {
 			markSourceIncomplete()
-			return false, fmt.Errorf(
+			return false, sessionsChanged, fmt.Errorf(
 				"complete Claude source data versions: %w", err,
 			)
 		}
@@ -16347,7 +17362,7 @@ func (e *Engine) processAndWriteSessionFile(
 		e.recordProviderStatHash(ctx, *res.providerStatHash)
 	}
 
-	return preserved, nil
+	return preserved, sessionsChanged, nil
 }
 
 func (e *Engine) applyWorktreeMappingToSingleSession(

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -3444,6 +3444,120 @@ func TestResyncAllExcludesExistingClaudeUsageProbe(t *testing.T) {
 		"parser exclusions must not become permanent user deletions")
 }
 
+func TestResyncAllTombstonesOmittedStaleClaudeFork(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+	original := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"orig-resync","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"orig-resync","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	pureReplay := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"fork-resync","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"fork-resync","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	env.writeClaudeSession(t, "project", "orig-resync.jsonl", original)
+	forkPath := env.writeClaudeSession(
+		t, "project", "fork-resync.jsonl", pureReplay,
+	)
+
+	parentID := "fork-resync"
+	staleID := parentID + "-11111111-2222-4333-8444-555555555555"
+	result, err := env.db.WriteSessionBatch([]db.SessionBatchWrite{{
+		Session: db.Session{
+			ID:               staleID,
+			Project:          "project",
+			Machine:          "local",
+			Agent:            "claude",
+			ParentSessionID:  &parentID,
+			RelationshipType: "fork",
+			FilePath:         &forkPath,
+		},
+		Messages: []db.Message{{
+			SessionID: staleID,
+			Ordinal:   0,
+			Role:      "user",
+			Content:   "archived fork message",
+		}},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.WrittenSessions)
+	require.NoError(t, env.db.SetSessionDataVersion(staleID, 0))
+	require.NoError(t, env.db.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: staleID, Machine: "local", Agent: "claude", FilePath: forkPath,
+		}},
+	))
+
+	stats := env.engine.ResyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted, "ResyncAll aborted: %+v", stats)
+
+	stale, err := env.db.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale,
+		"the archived fork must remain available as a revivable tombstone")
+	require.NotNil(t, stale.DeletedAt,
+		"the complete rebuild parse must retire the omitted stale fork")
+	require.NotNil(t, stale.DeletionCause)
+	assert.Equal(t, "source_missing", *stale.DeletionCause)
+	messages, err := env.db.GetAllMessages(t.Context(), staleID)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "archived fork message", messages[0].Content)
+}
+
+func TestResyncContributorTombstonesOmittedStaleClaudeFork(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentClaude, []string{localRoot})
+	dbtest.WriteTestFile(t, filepath.Join(localRoot, "local", "local.jsonl"),
+		[]byte(testjsonl.NewSessionBuilder().AddClaudeUser(tsZero, "local").String()))
+	pureReplay := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"fork-remote","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"fork-remote","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	remotePath := filepath.Join(remoteRoot, "remote", "fork-remote.jsonl")
+	dbtest.WriteTestFile(t, remotePath, []byte(pureReplay))
+	storedPath := "remote:" + remotePath
+
+	parentID := "remote~fork-remote"
+	staleID := parentID + "-11111111-2222-4333-8444-555555555555"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "remote",
+		Machine:          "remote",
+		Agent:            "claude",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &storedPath,
+	}))
+	require.NoError(t, env.db.SetSessionDataVersion(staleID, 0))
+	require.NoError(t, env.db.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: staleID, Machine: "remote", Agent: "claude", FilePath: storedPath,
+		}},
+	))
+
+	stats, err := env.engine.ResyncAllWithOptions(context.Background(), nil,
+		sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
+			Name: "remote",
+			Config: sync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {remoteRoot}},
+				Machine:   "remote", IDPrefix: "remote~", Ephemeral: true,
+				PathRewriter: func(path string) string { return "remote:" + path },
+			},
+		}}})
+	require.NoError(t, err)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+
+	stale, err := env.db.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale,
+		"the archived contributor fork must remain a revivable tombstone")
+	require.NotNil(t, stale.DeletedAt,
+		"the contributor rebuild parse must retire the omitted stale fork")
+	require.NotNil(t, stale.DeletionCause)
+	assert.Equal(t, "source_missing", *stale.DeletionCause)
+}
+
 func TestResyncContributorExclusionIsNotRestoredAsOrphan(t *testing.T) {
 	localRoot := t.TempDir()
 	remoteRoot := t.TempDir()
@@ -15119,12 +15233,12 @@ func TestSyncSingleSessionRepairFailurePersistsFormerChildForRetry(t *testing.T)
 		"retry must repair a child no longer discoverable from the removed edge")
 }
 
-// TestSyncSingleSessionChildCaptureFailurePreservesEdges pins the fail-closed
+// TestSyncSingleSessionPreWriteReadFailurePreservesEdges pins the fail-closed
 // boundary before a full rewrite. The rewritten spawner transcript is about to
-// remove its sole spawn edge; if the engine cannot first capture the affected
-// child, it must return that read failure before any exclusion or replacement
-// can erase the evidence needed to repair the hierarchy.
-func TestSyncSingleSessionChildCaptureFailurePreservesEdges(t *testing.T) {
+// remove its sole spawn edge; if any pre-write archive read fails, the engine
+// must return before an exclusion or replacement can erase the evidence needed
+// to repair the hierarchy.
+func TestSyncSingleSessionPreWriteReadFailurePreservesEdges(t *testing.T) {
 	env := setupTestEnv(t)
 
 	env.writeClaudeSession(
@@ -15174,7 +15288,7 @@ func TestSyncSingleSessionChildCaptureFailurePreservesEdges(t *testing.T) {
 	require.NoError(t, env.db.CloseConnections(), "close database connections")
 	syncErr := env.engine.SyncSingleSession("agent-spawner")
 	require.NoError(t, env.db.Reopen(), "reopen database")
-	require.ErrorContains(t, syncErr, "list pre-write subagent children")
+	require.ErrorContains(t, syncErr, "database is closed")
 
 	spawner, err := env.db.GetSession(context.Background(), "agent-spawner")
 	require.NoError(t, err, "get spawner after failed sync")
@@ -15620,5 +15734,344 @@ func TestRestartedEngineCodexIndexRenameNotMaskedByStatDigest(t *testing.T) {
 	require.NotNil(t, sess)
 	if assert.NotNil(t, sess.SessionName) {
 		assert.Equal(t, "Renamed title", *sess.SessionName)
+	}
+}
+
+// A stored Claude session the current parser no longer derives from its
+// transcript (e.g. a fork branch an older parser split out) makes the
+// path map to multiple DB sessions, so GetSessionForIncremental declines
+// and every append full-parses the whole file, forever — re-parsing can
+// never re-emit the stale ID. A complete full parse must tombstone such
+// rows as source-missing so the incremental path recovers; a later parse
+// that re-emits the ID revives the row.
+func TestSyncAllTombstonesStaleClaudeForkRow(t *testing.T) {
+	env := setupTestEnv(t)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello there", "/workspace/api").
+		String()
+	path := env.writeClaudeSession(
+		t, "-workspace-api", "main-sess.jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	staleID := "main-sess-11111111-2222-4333-8444-555555555555"
+	parentID := "main-sess"
+	result, err := env.db.WriteSessionBatch([]db.SessionBatchWrite{{
+		Session: db.Session{
+			ID:               staleID,
+			Project:          "api",
+			Machine:          "local",
+			Agent:            "claude",
+			ParentSessionID:  &parentID,
+			RelationshipType: "fork",
+			FilePath:         &path,
+		},
+	}})
+	require.NoError(t, err, "seed stale fork row")
+	require.Equal(t, 1, result.WrittenSessions, "seed stale fork row")
+	// Zero data_version mirrors fork rows written before data-version
+	// stamping existed.
+	require.NoError(t, env.db.SetSessionDataVersion(staleID, 0))
+	// Real fork rows carry a source-ownership baseline from earlier
+	// discovery passes; the tombstone requires that deletion authority.
+	require.NoError(t, env.db.BaselineActiveSessionSourcePaths(
+		t.Context(), "local",
+		[]db.SessionSourcePath{{Agent: "claude", FilePath: path}},
+	))
+
+	appendLine := func(line string) {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		require.NoError(t, err, "open transcript for append")
+		_, writeErr := f.WriteString(line + "\n")
+		f.Close()
+		require.NoError(t, writeErr, "append transcript line")
+	}
+
+	// The stale sibling forces this append onto the full-parse path; the
+	// complete parse no longer emits the fork ID and must tombstone it.
+	appendLine(testjsonl.ClaudeAssistantJSON(
+		[]map[string]any{{"type": "text", "text": "first append"}},
+		tsEarlyS1,
+	))
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	var deletedAt, cause sql.NullString
+	require.NoError(t, env.db.Reader().QueryRow(
+		`SELECT deleted_at, deletion_cause FROM sessions WHERE id = ?`,
+		staleID,
+	).Scan(&deletedAt, &cause), "query stale fork row")
+	assert.True(t, deletedAt.Valid,
+		"stale fork row should be tombstoned as source-missing")
+	assert.Equal(t, "source_missing", cause.String)
+
+	// With the transcript mapping to a single active session again, the
+	// next append stays on the incremental path instead of re-parsing
+	// the whole file.
+	appendLine(testjsonl.ClaudeAssistantJSON(
+		[]map[string]any{{"type": "text", "text": "second append"}},
+		tsEarlyS5,
+	))
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	var lastWriteIncremental bool
+	require.NoError(t, env.db.Reader().QueryRow(
+		`SELECT last_write_incremental FROM sessions WHERE id = ?`,
+		"main-sess",
+	).Scan(&lastWriteIncremental), "query incremental marker")
+	assert.True(t, lastWriteIncremental,
+		"append after tombstone should take the incremental path")
+}
+
+func TestSyncAllRetriesStaleClaudeForkCleanupAfterEstablishingBaseline(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello there", "/workspace/api").
+		String()
+	path := env.writeClaudeSession(
+		t, "-workspace-api", "upgrade-sess.jsonl", content,
+	)
+
+	staleID := "upgrade-sess-11111111-2222-4333-8444-555555555555"
+	parentID := "upgrade-sess"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "api",
+		Machine:          "local",
+		Agent:            "claude",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &path,
+	}))
+	require.NoError(t, env.db.SetSessionDataVersion(staleID, 0))
+
+	// An archive created before source baselines existed cannot authorize
+	// deletion on its first upgrade parse. That pass writes the current primary
+	// row and establishes the baseline needed by the next pass.
+	first := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, first.Failed)
+	stale, err := env.db.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	assert.Nil(t, stale.DeletedAt,
+		"the first pass must preserve a fork without deletion authority")
+
+	// The unchanged primary row must not hide the still-active stale fork.
+	second := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, second.Failed)
+	stale, err = env.db.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	require.NotNil(t, stale.DeletedAt,
+		"the second pass must retry and tombstone the stale fork")
+	require.NotNil(t, stale.DeletionCause)
+	assert.Equal(t, "source_missing", *stale.DeletionCause)
+}
+
+func TestSyncAllTombstonesStaleClaudeForkAfterZeroResultParse(t *testing.T) {
+	env := setupTestEnv(t)
+	original := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"orig-1111","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"orig-1111","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	pureReplay := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"fork-2222","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"fork-2222","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	env.writeClaudeSession(t, "project", "orig-1111.jsonl", original)
+	forkPath := env.writeClaudeSession(
+		t, "project", "fork-2222.jsonl", pureReplay,
+	)
+
+	legacyForkID := "fork-2222-11111111-2222-4333-8444-555555555555"
+	parentID := "fork-2222"
+	result, err := env.db.WriteSessionBatch([]db.SessionBatchWrite{{
+		Session: db.Session{
+			ID:               legacyForkID,
+			Project:          "project",
+			Machine:          "local",
+			Agent:            "claude",
+			ParentSessionID:  &parentID,
+			RelationshipType: "fork",
+			FilePath:         &forkPath,
+		},
+	}})
+	require.NoError(t, err, "seed legacy fork row")
+	require.Equal(t, 1, result.WrittenSessions, "seed legacy fork row")
+	require.NoError(t, env.db.SetSessionDataVersion(legacyForkID, 0))
+	require.NoError(t, env.db.BaselineActiveSessionSourcePaths(
+		t.Context(), "local",
+		[]db.SessionSourcePath{{Agent: "claude", FilePath: forkPath}},
+	))
+
+	stats := env.engine.SyncAll(t.Context(), nil)
+	assert.Equal(t, 1, stats.Synced,
+		"the original session should sync while the replay is excluded")
+
+	var deletedAt, cause sql.NullString
+	require.NoError(t, env.db.Reader().QueryRow(
+		`SELECT deleted_at, deletion_cause FROM sessions WHERE id = ?`,
+		legacyForkID,
+	).Scan(&deletedAt, &cause), "query legacy fork row")
+	assert.True(t, deletedAt.Valid,
+		"legacy fork should be tombstoned after a complete zero-result parse")
+	assert.Equal(t, "source_missing", cause.String)
+
+	steady := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, steady.Failed)
+	assert.Equal(t, 2, steady.Skipped,
+		"the unchanged original and rowless replay should both use source freshness")
+}
+
+func TestFullSyncEntryPointsEmitForZeroResultClaudeForkTombstone(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testEnv, context.Context) sync.SyncStats
+	}{
+		{
+			name: "SyncAll",
+			run: func(env *testEnv, ctx context.Context) sync.SyncStats {
+				return env.engine.SyncAll(ctx, nil)
+			},
+		},
+		{
+			name: "SyncAllSince",
+			run: func(env *testEnv, ctx context.Context) sync.SyncStats {
+				return env.engine.SyncAllSince(ctx, time.Time{}, nil)
+			},
+		},
+		{
+			name: "SyncRootsSince",
+			run: func(env *testEnv, ctx context.Context) sync.SyncStats {
+				return env.engine.SyncRootsSince(
+					ctx, []string{env.claudeDir}, time.Time{}, nil,
+				)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			emitter := &fakeEmitter{}
+			env := setupTestEnv(t, WithEmitter(emitter))
+			original := strings.Join([]string{
+				`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"notify-original","message":{"content":"first question"}}`,
+				`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"notify-original","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+			}, "\n") + "\n"
+			pureReplay := strings.Join([]string{
+				`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"notify-replay","sessionKind":"bg","message":{"content":"first question"}}`,
+				`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"notify-replay","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+			}, "\n") + "\n"
+			env.writeClaudeSession(
+				t, "project", "notify-original.jsonl", original,
+			)
+			forkPath := env.writeClaudeSession(
+				t, "project", "notify-replay.jsonl", pureReplay,
+			)
+			require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+			emitter.mu.Lock()
+			emitter.scopes = nil
+			emitter.mu.Unlock()
+
+			parentID := "notify-replay"
+			staleID := parentID + "-11111111-2222-4333-8444-555555555555"
+			require.NoError(t, env.db.UpsertSession(db.Session{
+				ID:               staleID,
+				Project:          "project",
+				Machine:          "local",
+				Agent:            "claude",
+				ParentSessionID:  &parentID,
+				RelationshipType: "fork",
+				FilePath:         &forkPath,
+			}))
+			require.NoError(t, env.db.SetSessionDataVersion(staleID, 0))
+			require.NoError(t, env.db.BaselineActiveSessionSourcePaths(
+				t.Context(), "local",
+				[]db.SessionSourcePath{{Agent: "claude", FilePath: forkPath}},
+			))
+
+			stats := tt.run(env, t.Context())
+			assert.Zero(t, stats.Synced,
+				"the replay tombstone must not count as an ordinary sync write")
+			assert.Equal(t, []string{"sessions"}, emitter.got(),
+				"a member-only tombstone must notify connected clients")
+			stale, err := env.db.GetSessionFull(t.Context(), staleID)
+			require.NoError(t, err)
+			require.NotNil(t, stale)
+			require.NotNil(t, stale.DeletionCause)
+			assert.Equal(t, "source_missing", *stale.DeletionCause)
+		})
+	}
+}
+
+func TestSyncAllPreservesUnprovenClaudeMissingRows(t *testing.T) {
+	tests := []struct {
+		name             string
+		relationshipType string
+		dataVersion      int
+	}{
+		{
+			name:             "current fork",
+			relationshipType: "fork",
+			dataVersion:      db.CurrentDataVersion(),
+		},
+		{
+			name:             "stale root",
+			relationshipType: "root",
+			dataVersion:      0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := setupTestEnv(t)
+			content := testjsonl.NewSessionBuilder().
+				AddClaudeUser(tsEarly, "hello there", "/workspace/api").
+				String()
+			path := env.writeClaudeSession(
+				t, "-workspace-api", "main-sess.jsonl", content,
+			)
+			require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+			missingID := "missing-session"
+			parentID := "main-sess"
+			result, err := env.db.WriteSessionBatch([]db.SessionBatchWrite{{
+				Session: db.Session{
+					ID:               missingID,
+					Project:          "api",
+					Machine:          "local",
+					Agent:            "claude",
+					ParentSessionID:  &parentID,
+					RelationshipType: tt.relationshipType,
+					FilePath:         &path,
+				},
+			}})
+			require.NoError(t, err, "seed missing row")
+			require.Equal(t, 1, result.WrittenSessions, "seed missing row")
+			require.NoError(t,
+				env.db.SetSessionDataVersion(missingID, tt.dataVersion))
+			require.NoError(t, env.db.BaselineActiveSessionSourcePaths(
+				t.Context(), "local",
+				[]db.SessionSourcePath{{Agent: "claude", FilePath: path}},
+			))
+
+			f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+			require.NoError(t, err, "open transcript for append")
+			_, writeErr := f.WriteString(testjsonl.ClaudeAssistantJSON(
+				[]map[string]any{{"type": "text", "text": "append"}},
+				tsEarlyS1,
+			) + "\n")
+			require.NoError(t, f.Close(), "close transcript")
+			require.NoError(t, writeErr, "append transcript line")
+			require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+			var deletedAt, cause sql.NullString
+			require.NoError(t, env.db.Reader().QueryRow(
+				`SELECT deleted_at, deletion_cause FROM sessions WHERE id = ?`,
+				missingID,
+			).Scan(&deletedAt, &cause), "query preserved row")
+			assert.False(t, deletedAt.Valid,
+				"missing row without both legacy and fork evidence must survive")
+			assert.False(t, cause.Valid, "preserved row must not gain a cause")
+		})
 	}
 }

--- a/internal/sync/engine_resync_split_test.go
+++ b/internal/sync/engine_resync_split_test.go
@@ -58,7 +58,9 @@ func TestResyncBuildThenSwapMatchesResyncAll(t *testing.T) {
 	require.False(t, stats.Aborted)
 	require.FileExists(t, tempPath)
 
-	require.NoError(t, e.SwapResyncDatabase(tempPath))
+	installed, err := e.SwapResyncDatabase(tempPath)
+	require.NoError(t, err)
+	assert.True(t, installed)
 	require.NoError(t, e.ResetCachesAfterSwap())
 
 	assert.False(t, database.NeedsResync())
@@ -87,7 +89,9 @@ func TestSwapWindowRejectsDirectWrites(t *testing.T) {
 	// proceeds while the writer is closed. The swap reopens the writer.
 	tempPath, _, err := e.ResyncBuild(context.Background(), nil)
 	require.NoError(t, err)
-	require.NoError(t, e.SwapResyncDatabase(tempPath))
+	installed, err := e.SwapResyncDatabase(tempPath)
+	require.NoError(t, err)
+	assert.True(t, installed)
 	require.NoError(t, e.ResetCachesAfterSwap())
 
 	starred, err := database.ListStarredSessionIDs(context.Background())

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -3357,6 +3357,7 @@ func TestReconciliationSourceBaselineUsesStoredPathRewrite(t *testing.T) {
 			Machine: "host",
 			Source:  db.SessionSourcePath{Agent: "claude", FilePath: storedPath},
 		}},
+		nil, nil,
 	))
 	changed, err := database.SoftDeleteSessionSourceOwnership(
 		t.Context(), "host", "claude", "session", storedPath,

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -949,14 +949,27 @@ func (e *Engine) parseDiffCollectFile(
 	}
 
 	// Virtual members gone from a still-existing shared container are
-	// tombstone-bound on a real sync; mark them visited so the presence
-	// sweep does not misreport them as parser drift.
+	// tombstone-bound on a real sync only when their archived CWD passes the
+	// active allow-list. Mark both tombstone-bound and policy-preserved members
+	// visited so the presence sweep does not misreport them as parser drift.
 	for _, member := range job.sourceMissingMembers {
 		stored := storedByID[member.sessionID]
 		if stored == nil {
 			continue
 		}
 		visited[stored.ID] = true
+		if !e.cwdFilter.allows(stored.Cwd) {
+			report.Sessions = append(report.Sessions, SessionDiff{
+				SessionID:         stored.ID,
+				Agent:             stored.Agent,
+				FilePath:          member.filePath,
+				Class:             DiffSkipped,
+				Reason:            "member source missing (policy-preserved by CWD filter)",
+				StoredDataVersion: stored.DataVersion,
+			})
+			report.Totals.Skipped++
+			continue
+		}
 		report.Sessions = append(report.Sessions, SessionDiff{
 			SessionID:         stored.ID,
 			Agent:             stored.Agent,

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -2284,9 +2284,8 @@ func TestParseDiffEngineRefusesWrites(t *testing.T) {
 		"refused scans must not persist secret findings")
 }
 
-func TestParseDiffPresenceSweep(t *testing.T) {
-
-	t.Run("current-version row no longer emitted", func(t *testing.T) {
+func TestParseDiffClaudeMissingRowsRequireLegacyForkEvidence(t *testing.T) {
+	t.Run("current-version fork is presence drift", func(t *testing.T) {
 		env := setupSingleAgentTestEnv(t, parser.AgentClaude)
 		path := env.writeClaudeSession(t, "test-proj", "pd-real.jsonl",
 			parseDiffClaudeContent("real prompt", "real reply"))
@@ -2294,11 +2293,12 @@ func TestParseDiffPresenceSweep(t *testing.T) {
 			TotalSessions: 1, Synced: 1,
 		})
 
-		// A current-version row under the same source file with an ID
-		// today's parser never derives: the loudest drift signal.
+		// A current-version fork row under the same transcript has already
+		// been accepted by this parser version. Its unexplained absence must
+		// stay visible as parser drift.
 		require.NoError(t, env.db.UpsertSession(db.Session{
 			ID: "pd-phantom", Project: "test-proj", Machine: "local",
-			Agent: "claude", FilePath: &path,
+			Agent: "claude", RelationshipType: "fork", FilePath: &path,
 		}), "insert phantom session")
 		require.NoError(t,
 			env.db.SetSessionDataVersion(
@@ -2318,10 +2318,10 @@ func TestParseDiffPresenceSweep(t *testing.T) {
 		assert.Contains(t, sessionDiffFieldNames(sd, false),
 			sync.FieldPresence, "presence diff")
 		assert.True(t, report.HasFailures(),
-			"a current-version presence drop is parser drift")
+			"a current-version missing fork is parser drift")
 	})
 
-	t.Run("stale row no longer emitted is pending resync", func(t *testing.T) {
+	t.Run("stale non-fork is pending resync", func(t *testing.T) {
 		env := setupSingleAgentTestEnv(t, parser.AgentClaude)
 		path := env.writeClaudeSession(t, "test-proj", "pd-real.jsonl",
 			parseDiffClaudeContent("real prompt", "real reply"))
@@ -2329,11 +2329,11 @@ func TestParseDiffPresenceSweep(t *testing.T) {
 			TotalSessions: 1, Synced: 1,
 		})
 
-		// Data version 0: an incomplete write preserved by the
-		// archive (e.g. a transient fork row left by a live sync).
+		// Data version 0: an incomplete non-fork write preserved by the
+		// archive. Staleness alone is not enough deletion evidence.
 		require.NoError(t, env.db.UpsertSession(db.Session{
 			ID: "pd-zombie", Project: "test-proj", Machine: "local",
-			Agent: "claude", FilePath: &path,
+			Agent: "claude", RelationshipType: "root", FilePath: &path,
 		}), "insert zombie session")
 
 		report := runParseDiff(t, env, sync.ParseDiffOptions{})
@@ -2347,9 +2347,84 @@ func TestParseDiffPresenceSweep(t *testing.T) {
 		require.NotNil(t, sd, "zombie session not listed")
 		assert.Equal(t, sync.DiffPendingResync, sd.Class, "class")
 		assert.Contains(t, sessionDiffFieldNames(sd, true),
-			sync.FieldPresence,
-			"presence field attached for drill-down")
+			sync.FieldPresence, "presence field attached for drill-down")
 		assert.False(t, report.HasFailures(),
 			"stale rows must not trip --fail-on-change")
+	})
+
+	t.Run("stale fork is tombstone-bound", func(t *testing.T) {
+		env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+		path := env.writeClaudeSession(t, "test-proj", "pd-real.jsonl",
+			parseDiffClaudeContent("real prompt", "real reply"))
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+
+		parentID := "pd-real"
+		require.NoError(t, env.db.UpsertSession(db.Session{
+			ID: "pd-legacy-fork", Project: "test-proj", Machine: "local",
+			Agent: "claude", ParentSessionID: &parentID,
+			RelationshipType: "fork", FilePath: &path,
+		}), "insert legacy fork")
+
+		report := runParseDiff(t, env, sync.ParseDiffOptions{})
+		assert.Equal(t, sync.ParseDiffTotals{
+			Examined: 1, Identical: 1, ExcludedByParser: 1,
+		}, report.Totals, "totals")
+		assert.Empty(t, report.FieldCounts,
+			"tombstone-bound rows are not parser drift")
+
+		sd := findSessionDiff(report, "pd-legacy-fork")
+		require.NotNil(t, sd, "legacy fork not listed")
+		assert.Equal(t, sync.DiffExcluded, sd.Class, "class")
+		assert.Equal(t, "member source missing (would tombstone)", sd.Reason)
+		assert.False(t, report.HasFailures(),
+			"an intentional source-missing tombstone must not trip --fail-on-change")
+	})
+
+	t.Run("stale fork outside CWD filter is policy-preserved", func(t *testing.T) {
+		env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+		content := testjsonl.NewSessionBuilder().
+			AddClaudeUser(
+				tsEarly, "real prompt", "/workspace/work/project",
+			).
+			AddClaudeAssistant(tsEarlyS5, "real reply").
+			String()
+		path := env.writeClaudeSession(
+			t, "test-proj", "pd-real.jsonl", content,
+		)
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+
+		parentID := "pd-real"
+		require.NoError(t, env.db.UpsertSession(db.Session{
+			ID: "pd-filtered-fork", Project: "test-proj", Machine: "local",
+			Agent: "claude", Cwd: "/workspace/personal/project",
+			ParentSessionID: &parentID, RelationshipType: "fork", FilePath: &path,
+		}), "insert filtered legacy fork")
+
+		diffEngine := sync.NewDiffEngine(env.db, sync.EngineConfig{
+			AgentDirs:          parseDiffAgentDirs(env),
+			Machine:            "local",
+			IncludeCwdPrefixes: []string{"/workspace/work"},
+		})
+		t.Cleanup(diffEngine.Close)
+		report, err := diffEngine.ParseDiff(
+			t.Context(), sync.ParseDiffOptions{},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, report)
+
+		assert.Equal(t, sync.ParseDiffTotals{
+			Examined: 1, Identical: 1, Skipped: 1,
+		}, report.Totals, "totals")
+		sd := findSessionDiff(report, "pd-filtered-fork")
+		require.NotNil(t, sd, "filtered legacy fork not listed")
+		assert.Equal(t, sync.DiffSkipped, sd.Class, "class")
+		assert.Equal(t, "member source missing (policy-preserved by CWD filter)",
+			sd.Reason)
+		assert.False(t, report.HasFailures(),
+			"a CWD-preserved fork must not trip --fail-on-change")
 	})
 }

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -35,9 +35,9 @@ const (
 	// sidecar); differences are expected and not parser drift.
 	DiffNeedsRetry DiffClass = "transient_needs_retry"
 	// DiffSkipped: a stored session whose source was never re-parsed.
-	// Reason says why: source missing (archive-only), remote session,
-	// trashed, import-only agent, database-backed agent, not sampled
-	// (--limit), or not discovered.
+	// Reason says why: source missing (archive-only), policy-preserved by the
+	// CWD filter, remote session, trashed, import-only agent, database-backed
+	// agent, not sampled (--limit), or not discovered.
 	DiffSkipped DiffClass = "skipped"
 	// DiffRaced: the comparison detected a non-informational change, but
 	// the on-disk source file's mtime advanced past the snapshot's stored

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -67,6 +67,10 @@ type SyncStats struct {
 	Warnings       []string            `json:"warnings,omitempty"`
 	Aborted        bool                `json:"aborted,omitempty"`
 	RebuildPhases  []RebuildPhaseStats `json:"rebuild_phases,omitempty"`
+	// Tombstoned counts committed session removals that are not ordinary sync
+	// writes. It remains meaningful on a partially failed or aborted pass: a
+	// later retry cannot rediscover an already-tombstoned row to notify clients.
+	Tombstoned int `json:"tombstoned,omitempty"`
 
 	// Anomalies aggregates per-run parser/sanitizer anomaly signals
 	// surfaced in the CLI sync summary. These are live per-run counters
@@ -75,12 +79,12 @@ type SyncStats struct {
 	Anomalies AnomalyStats `json:"anomalies,omitzero"`
 
 	filesOK int // unexported: file-level success counter
-	// sourceMissingTombstoned counts stored virtual members tombstoned
-	// during this run because their member source vanished from a
-	// still-existing shared container. Changed-path syncs use it to emit
-	// a sessions event even when nothing else was written.
-	sourceMissingTombstoned int
-	filesDiscovered         int // file-based total, excludes DB-backed agents
+	// sourceMissingArchiveMembers carries members discovered in the original
+	// archive while a full resync writes into its replacement. Orphan copy must
+	// materialize them before the rebuild can apply the same guarded tombstone
+	// transition used by an in-place sync.
+	sourceMissingArchiveMembers []sourceMissingMember
+	filesDiscovered             int // file-based total, excludes DB-backed agents
 	// nonContainerDiscovered counts discovered files that are not part of
 	// a self-preserving container store (OpenCode-format storage and its
 	// SQLite virtual paths). The resync empty-discovery guard uses it so a
@@ -110,7 +114,8 @@ type SyncStats struct {
 }
 
 func (s SyncStats) shouldEmitSync() bool {
-	return !s.Aborted && (s.Synced > 0 || s.ArchiveRebuilt)
+	return s.Tombstoned > 0 ||
+		(!s.Aborted && (s.Synced > 0 || s.ArchiveRebuilt))
 }
 
 // AnomalyStats aggregates parser-output anomaly signals observed during a

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -600,7 +600,7 @@ func TestSyncSingleSessionKeepsRetryStatePerResult(t *testing.T) {
 	)
 	engine := newProcessFixtureEngine(t, root, provider)
 
-	_, err := engine.processAndWriteSessionFile(
+	_, _, err := engine.processAndWriteSessionFile(
 		context.Background(),
 		parser.DiscoveredFile{Path: sourcePath, Agent: parser.AgentCowork},
 		"cowork:current",

--- a/internal/sync/rebuild_contributor.go
+++ b/internal/sync/rebuild_contributor.go
@@ -119,6 +119,7 @@ func mergeSyncStats(dst *SyncStats, src SyncStats) {
 	dst.Skipped += src.Skipped
 	dst.Failed += src.Failed
 	dst.OrphanedCopied += src.OrphanedCopied
+	dst.Tombstoned += src.Tombstoned
 	dst.Warnings = append(dst.Warnings, src.Warnings...)
 	dst.Aborted = dst.Aborted || src.Aborted
 	dst.RebuildPhases = append(dst.RebuildPhases, src.RebuildPhases...)
@@ -129,6 +130,9 @@ func mergeSyncStats(dst *SyncStats, src SyncStats) {
 	dst.messagesIndexed += src.messagesIndexed
 	dst.parserExcludedFiles += src.parserExcludedFiles
 	dst.parserExcludedIDs = append(dst.parserExcludedIDs, src.parserExcludedIDs...)
+	dst.sourceMissingArchiveMembers = append(
+		dst.sourceMissingArchiveMembers, src.sourceMissingArchiveMembers...,
+	)
 	dst.cwdFilteredSessions += src.cwdFilteredSessions
 	dst.cwdFilteredFiles += src.cwdFilteredFiles
 }

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,16 +22,20 @@ import (
 func TestMergeSyncStatsIncludesAdditiveRebuildFields(t *testing.T) {
 	dst := SyncStats{
 		OrphanedCopied: 2,
+		Tombstoned:     1,
 		RebuildPhases:  []RebuildPhaseStats{{Contributor: "local", BatchedWrites: 1}},
 	}
 	src := SyncStats{
 		OrphanedCopied: 3,
+		Tombstoned:     2,
 		RebuildPhases:  []RebuildPhaseStats{{Contributor: "remote", BatchedWrites: 2}},
 	}
 
 	mergeSyncStats(&dst, src)
 
 	assert.Equal(t, 5, dst.OrphanedCopied)
+	assert.Equal(t, 3, dst.Tombstoned,
+		"contributor and watch-batch tombstones must survive aggregation")
 	assert.Equal(t, []RebuildPhaseStats{
 		{Contributor: "local", BatchedWrites: 1},
 		{Contributor: "remote", BatchedWrites: 2},
@@ -912,4 +917,114 @@ func TestResyncContributorParserFailuresAbortAndCleanTempDB(t *testing.T) {
 	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
 	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
 	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
+}
+
+// seedRebuildStaleForkFixture writes a replay-only Claude transcript and stores
+// a baselined stale fork row under it, so a complete rebuild would tombstone
+// the fork once the replacement archive is installed.
+func seedRebuildStaleForkFixture(
+	t *testing.T, root string, database *db.DB,
+) string {
+	t.Helper()
+	pureReplay := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"fork-abort","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"fork-abort","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	path := filepath.Join(root, "project", "fork-abort.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(pureReplay), 0o644))
+	parentID := "fork-abort"
+	staleID := parentID + "-11111111-2222-4333-8444-555555555555"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "project",
+		Machine:          "local",
+		Agent:            "claude",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         &path,
+	}))
+	require.NoError(t, database.SetSessionDataVersion(staleID, 0))
+	require.NoError(t, database.BaselineActiveSessionSourceOwnerships(
+		context.Background(), []db.SessionSourceOwnership{{
+			ID: staleID, Machine: "local", Agent: "claude", FilePath: path,
+		}},
+	))
+	return staleID
+}
+
+func TestResyncBuildFailureDoesNotReportDiscardedTombstones(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	emitter := &fakeEmitter{}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+		Emitter:   emitter,
+	})
+	t.Cleanup(engine.Close)
+	staleID := seedRebuildStaleForkFixture(t, root, database)
+
+	sentinel := errors.New("fts sentinel")
+	stats, err := engine.resyncAllWithOptionsAndOperations(
+		context.Background(), nil, RebuildOptions{}, rebuildOperations{
+			rebuildFTS: func(*db.DB) error { return sentinel },
+		},
+	)
+	require.ErrorIs(t, err, sentinel)
+	require.True(t, stats.Aborted)
+	assert.Zero(t, stats.Tombstoned,
+		"tombstones in a discarded replacement must not be reported")
+	assert.Zero(t, engine.LastSyncStats().Tombstoned,
+		"recorded failure stats must not carry discarded tombstones")
+	assert.Empty(t, emitter.got(),
+		"a discarded replacement must not publish a sync event")
+	stale, err := database.GetSession(context.Background(), staleID)
+	require.NoError(t, err)
+	assert.NotNil(t, stale, "the original archive keeps the stale fork active")
+}
+
+func TestResyncPreInstallSwapFailureDoesNotReportDiscardedTombstones(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	emitter := &fakeEmitter{}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+		Emitter:   emitter,
+	})
+	t.Cleanup(engine.Close)
+	staleID := seedRebuildStaleForkFixture(t, root, database)
+
+	restore := db.SetCloseDrainTimeoutForTest(100 * time.Millisecond)
+	defer restore()
+	pinned, err := database.Reader().Query("SELECT 1")
+	require.NoError(t, err)
+	pinnedOpen := true
+	defer func() {
+		if pinnedOpen {
+			require.NoError(t, pinned.Close())
+		}
+	}()
+
+	stats := engine.ResyncAll(context.Background(), nil)
+	require.True(t, stats.Aborted,
+		"a failed close before the swap must abort the resync")
+	require.NoError(t, pinned.Close())
+	pinnedOpen = false
+	assert.Zero(t, stats.Tombstoned,
+		"tombstones in a discarded replacement must not be reported")
+	assert.Zero(t, engine.LastSyncStats().Tombstoned,
+		"recorded failure stats must not carry discarded tombstones")
+	assert.Empty(t, emitter.got(),
+		"a discarded replacement must not publish a sync event")
+	stale, err := database.GetSession(context.Background(), staleID)
+	require.NoError(t, err)
+	assert.NotNil(t, stale, "the original archive keeps the stale fork active")
 }

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -234,10 +234,20 @@ func (e *Engine) processS3Session(
 	case parser.AgentClaude:
 		sessionID := strings.TrimSuffix(sourceInfo.Name(), ".jsonl")
 		fullID := applyIDPrefixToID(idPrefix, sessionID)
+		primaryPath := e.db.GetSessionFilePathNotSourceMissing(fullID)
+		if primaryPath == "" && !e.forceParse {
+			fresh, _ := e.claudeSourceFreshWithoutPrimary(
+				ctx, file.Path, file.Path, sourceInfo, sourceFingerprint,
+			)
+			if fresh {
+				return processResult{skip: true}
+			}
+		}
 		if e.shouldSkipFileWithPrefix(
 			idPrefix, sessionID, sourceInfo, sourceFingerprint,
 		) &&
-			e.db.GetSessionFilePath(fullID) == file.Path {
+			primaryPath == file.Path &&
+			!e.claudeSourceNeedsStaleForkReconciliation(ctx, file.Path) {
 			sess, _ := e.db.GetSession(ctx, fullID)
 			if sess != nil &&
 				sess.Project != "" &&
@@ -372,6 +382,28 @@ func (e *Engine) processS3Session(
 	res.excludedSessionIDs = applyIDPrefixToIDs(
 		idPrefix, res.excludedSessionIDs,
 	)
+	if file.Agent == parser.AgentClaude {
+		missing, err := e.claudeSourceMissingSessionOwnershipsForCompleteResult(
+			ctx,
+			file.Path,
+			res.excludedSessionIDs,
+			res.results,
+		)
+		if err != nil {
+			return processResult{
+				err:            err,
+				noCacheSkip:    true,
+				retentionLease: lease,
+			}
+		}
+		res.sourceMissingMembers = missing
+		if !e.forceParse && !file.ForceParse &&
+			!res.suppressPresenceSweep && res.providerFailureCount == 0 &&
+			len(res.retrySessionIDs) == 0 && !res.noCacheSkip {
+			res.claudeRowlessFreshnessKey =
+				e.claudeRowlessFreshnessCacheKey(file.Path, sourceFingerprint)
+		}
+	}
 	res.retentionLease = lease
 	return res
 }

--- a/internal/sync/s3_source.go
+++ b/internal/sync/s3_source.go
@@ -401,11 +401,15 @@ func (e *Engine) SyncClaudeS3SubagentTranscriptsContext(
 	}
 	e.syncMu.Lock()
 	synced := false
+	sessionsChanged := false
 	// Defers run LIFO: emit runs after syncMu.Unlock, matching the
 	// other sync entry points.
 	defer func() {
 		if synced {
 			e.emit("messages")
+		}
+		if sessionsChanged {
+			e.emit("sessions")
 		}
 	}()
 	defer e.syncMu.Unlock()
@@ -435,7 +439,10 @@ func (e *Engine) SyncClaudeS3SubagentTranscriptsContext(
 		if file.Project == "" {
 			file.Project = parentProject
 		}
-		preserved, err := e.processAndWriteSessionFile(ctx, file, childID)
+		preserved, sourceSessionsChanged, err := e.processAndWriteSessionFile(
+			ctx, file, childID,
+		)
+		sessionsChanged = sessionsChanged || sourceSessionsChanged
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf(
 				"sync subagent transcript %s: %w", p, err))

--- a/internal/sync/s3_source_test.go
+++ b/internal/sync/s3_source_test.go
@@ -69,6 +69,130 @@ func TestProcessFileS3UsesObjectMetadataToSkipBeforeFetch(t *testing.T) {
 	assert.False(t, fetched, "unchanged S3 object should not be fetched")
 }
 
+func TestProcessS3ClaudeForceParseBypassesPrimarylessFreshness(t *testing.T) {
+	database := openTestDB(t)
+	const uri = "s3://bucket/root/claude/project/force-replay.jsonl"
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"force-replay","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"force-replay","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	mtime := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC).UnixNano()
+	fingerprint := "s3:fingerprint:force-replay"
+	parentID := "remote-box~force-replay"
+	staleID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "project",
+		Machine:          "remote-box",
+		Agent:            "claude",
+		Cwd:              "/workspace/personal/project",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         strPtr(uri),
+		FileSize:         int64Ptr(int64(len(content))),
+		FileMtime:        int64Ptr(mtime),
+		FileHash:         strPtr(fingerprint),
+	}))
+	require.NoError(t, database.SetSessionDataVersion(staleID, 0))
+
+	oldFetch := fetchS3Object
+	t.Cleanup(func() { fetchS3Object = oldFetch })
+	fetched := false
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, uri, got)
+		fetched = true
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+
+	engine := NewDiffEngine(database, EngineConfig{
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/work"},
+	})
+	t.Cleanup(engine.Close)
+	marker := engine.claudeRowlessFreshnessCacheKey(uri, fingerprint)
+	engine.cacheSkip(marker, mtime)
+	file := parser.DiscoveredFile{
+		Agent:             parser.AgentClaude,
+		Path:              uri,
+		Machine:           "remote-box",
+		SourceSize:        int64(len(content)),
+		SourceMtime:       mtime,
+		SourceFingerprint: fingerprint,
+	}
+	info, err := s3SourceFileInfo(file)
+	require.NoError(t, err)
+
+	res := engine.processS3Session(t.Context(), file, info)
+	require.NoError(t, res.err)
+	assert.True(t, fetched,
+		"parse-diff must fetch and parse a primary-less S3 Claude source")
+}
+
+func TestProcessS3ClaudeChangedPrimarylessSourceUsesCurrentRowlessMarker(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	const uri = "s3://bucket/root/claude/project/changed-replay.jsonl"
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"changed-replay","sessionKind":"bg","message":{"content":"current question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"changed-replay","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"current answer"}]}}`,
+	}, "\n") + "\n"
+	currentMtime := time.Date(2026, 8, 14, 14, 0, 0, 0, time.UTC).UnixNano()
+	const currentFingerprint = "s3:fingerprint:changed-replay"
+	parentID := "remote-box~changed-replay"
+	staleID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	oldSize := int64(17)
+	oldMtime := currentMtime - int64(time.Hour)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: staleID, Project: "project", Machine: "remote-box", Agent: "claude",
+		Cwd: "/workspace/personal/project", ParentSessionID: &parentID,
+		RelationshipType: "fork", FilePath: strPtr(uri),
+		FileSize: &oldSize, FileMtime: &oldMtime, FileHash: strPtr("old-hash"),
+	}))
+	require.NoError(t, database.SetSessionDataVersion(staleID, 0))
+
+	oldFetch := fetchS3Object
+	t.Cleanup(func() { fetchS3Object = oldFetch })
+	var fetches int
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, uri, got)
+		fetches++
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+
+	engine := NewEngine(database, EngineConfig{
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/work"},
+	})
+	t.Cleanup(engine.Close)
+	file := parser.DiscoveredFile{
+		Agent: parser.AgentClaude, Path: uri, Project: "project",
+		Machine: "remote-box", SourceSize: int64(len(content)),
+		SourceMtime: currentMtime, SourceFingerprint: currentFingerprint,
+	}
+
+	first := engine.processFile(t.Context(), file)
+	require.NoError(t, first.err)
+	require.Equal(t, 1, fetches)
+	jobs := make(chan syncJob, 1)
+	jobs <- syncJob{
+		path: file.Path, agent: file.Agent, machine: file.Machine,
+		processResult: first,
+	}
+	close(jobs)
+	stats := engine.collectAndBatch(
+		t.Context(), jobs, 1, 1, nil, syncWriteDefault,
+	)
+	require.Zero(t, stats.Failed)
+
+	second := engine.processFile(t.Context(), file)
+	require.NoError(t, second.err)
+	assert.True(t, second.skip,
+		"the current rowless marker must skip an unchanged replay-only source")
+	assert.Equal(t, 1, fetches,
+		"rowless freshness must avoid downloading the unchanged S3 object again")
+}
+
 func TestProcessFileS3SameMetadataDifferentFingerprintFetches(t *testing.T) {
 	database := openTestDB(t)
 	path := "s3://bucket/laptop/raw/claude/test-proj/fingerprint.jsonl"
@@ -1591,4 +1715,287 @@ func TestSyncRootsSinceScopedRemoteRootSyncsNewObject(t *testing.T) {
 	require.NotNil(t, sess.FilePath)
 	assert.Equal(t, uri, *sess.FilePath,
 		"the stored source must be the s3:// URI, not a temp path")
+}
+
+func TestSyncRootsSinceTombstonesStaleClaudeS3Fork(t *testing.T) {
+	database := openTestDB(t)
+	const remoteRoot = "s3://bucket/remote-box/raw/claude"
+	const uri = remoteRoot + "/test-proj/new-session.jsonl"
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "Hello from S3").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "Hi.").
+		String()
+	mtime := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC).UnixNano()
+	staleID := "remote-box~new-session-11111111-2222-4333-8444-555555555555"
+	parentID := "remote-box~new-session"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "test-proj",
+		Machine:          "remote-box",
+		Agent:            "claude",
+		ParentSessionID:  &parentID,
+		RelationshipType: "fork",
+		FilePath:         strPtr(uri),
+	}))
+	require.NoError(t, database.SetSessionDataVersion(staleID, 0))
+
+	oldFetch := fetchS3Object
+	oldStat := statS3Object
+	t.Cleanup(func() {
+		fetchS3Object = oldFetch
+		statS3Object = oldStat
+	})
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, uri, got)
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+	statS3Object = func(string) (parser.S3Object, error) {
+		return parser.S3Object{}, missingS3ObjectError()
+	}
+
+	factory := &scopeRecordingS3Factory{source: parser.SourceRef{
+		Provider:       parser.AgentClaude,
+		Key:            uri,
+		DisplayPath:    uri,
+		FingerprintKey: uri,
+		ProjectHint:    "test-proj",
+		Opaque: parser.S3DiscoveredSource{
+			URI:         uri,
+			Project:     "test-proj",
+			Machine:     "remote-box",
+			Size:        int64(len(content)),
+			MtimeNS:     mtime,
+			Fingerprint: "s3:fingerprint:new-session",
+		},
+	}}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {remoteRoot},
+		},
+		Machine:           "local",
+		ProviderFactories: []parser.ProviderFactory{factory},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentClaude: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	first := engine.SyncRootsSince(
+		t.Context(), []string{remoteRoot}, time.Time{}, nil,
+	)
+	require.Zero(t, first.Failed)
+	stale, err := database.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	assert.Nil(t, stale.DeletedAt,
+		"the first pass must preserve a fork without deletion authority")
+
+	second := engine.SyncRootsSince(
+		t.Context(), []string{remoteRoot}, time.Time{}, nil,
+	)
+	require.Zero(t, second.Failed)
+	stale, err = database.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	require.NotNil(t, stale.DeletedAt,
+		"the omitted S3 fork must be tombstoned")
+	require.NotNil(t, stale.DeletionCause)
+	assert.Equal(t, "source_missing", *stale.DeletionCause)
+}
+
+func TestSyncRootsSinceSkipsZeroResultClaudeS3SourceWithOnlyRejectedFork(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	const remoteRoot = "s3://bucket/remote-box/raw/claude"
+	const uri = remoteRoot + "/test-proj/replay-session.jsonl"
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"replay-session","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"replay-session","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	mtime := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC).UnixNano()
+	parentID := "remote-box~replay-session"
+	allowedID := parentID + "-11111111-2222-4333-8444-555555555555"
+	rejectedID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	for id, cwd := range map[string]string{
+		allowedID:  "/workspace/work/project",
+		rejectedID: "/workspace/personal/project",
+	} {
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID:               id,
+			Project:          "test-proj",
+			Machine:          "remote-box",
+			Agent:            "claude",
+			Cwd:              cwd,
+			ParentSessionID:  &parentID,
+			RelationshipType: "fork",
+			FilePath:         strPtr(uri),
+			FileSize:         int64Ptr(int64(len(content))),
+			FileMtime:        int64Ptr(mtime),
+			FileHash:         strPtr("s3:fingerprint:replay-session"),
+		}))
+		require.NoError(t, database.SetSessionDataVersion(id, 0))
+	}
+	require.NoError(t, database.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID:       allowedID,
+			Machine:  "remote-box",
+			Agent:    "claude",
+			FilePath: uri,
+		}},
+	))
+
+	oldFetch := fetchS3Object
+	oldStat := statS3Object
+	t.Cleanup(func() {
+		fetchS3Object = oldFetch
+		statS3Object = oldStat
+	})
+	fetches := 0
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, uri, got)
+		fetches++
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+	statS3Object = func(string) (parser.S3Object, error) {
+		return parser.S3Object{}, missingS3ObjectError()
+	}
+
+	factory := &scopeRecordingS3Factory{source: parser.SourceRef{
+		Provider:       parser.AgentClaude,
+		Key:            uri,
+		DisplayPath:    uri,
+		FingerprintKey: uri,
+		ProjectHint:    "test-proj",
+		Opaque: parser.S3DiscoveredSource{
+			URI:         uri,
+			Project:     "test-proj",
+			Machine:     "remote-box",
+			Size:        int64(len(content)),
+			MtimeNS:     mtime,
+			Fingerprint: "s3:fingerprint:replay-session",
+		},
+	}}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {remoteRoot},
+		},
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/work"},
+		ProviderFactories:  []parser.ProviderFactory{factory},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentClaude: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	first := engine.SyncRootsSince(
+		t.Context(), []string{remoteRoot}, time.Time{}, nil,
+	)
+	require.Zero(t, first.Failed)
+	require.Equal(t, 1, fetches,
+		"an actionable stale fork must force a complete source parse")
+	allowed, err := database.GetSessionFull(t.Context(), allowedID)
+	require.NoError(t, err)
+	require.NotNil(t, allowed)
+	require.NotNil(t, allowed.DeletionCause,
+		"the admitted stale fork must be retired before steady state")
+
+	second := engine.SyncRootsSince(
+		t.Context(), []string{remoteRoot}, time.Time{}, nil,
+	)
+	require.Zero(t, second.Failed)
+	assert.Equal(t, 1, second.Skipped)
+	assert.Equal(t, 1, fetches,
+		"unchanged source freshness must prevent another S3 download")
+	stale, err := database.GetSession(t.Context(), rejectedID)
+	require.NoError(t, err)
+	assert.NotNil(t, stale,
+		"the CWD-rejected stale fork must remain active")
+}
+
+func TestProcessS3ClaudeSourceMissingPrimaryUsesRowlessMarker(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	const uri = "s3://bucket/root/claude/project/missing-primary.jsonl"
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"missing-primary","sessionKind":"bg","message":{"content":"current question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"missing-primary","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"current answer"}]}}`,
+	}, "\n") + "\n"
+	currentMtime := time.Date(2026, 8, 14, 14, 0, 0, 0, time.UTC).UnixNano()
+	const currentFingerprint = "s3:fingerprint:missing-primary"
+	parentID := "remote-box~missing-primary"
+	staleID := parentID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	oldSize := int64(17)
+	oldMtime := currentMtime - int64(time.Hour)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: parentID, Project: "project", Machine: "remote-box",
+		Agent: "claude", Cwd: "/workspace/work/project", FilePath: strPtr(uri),
+		FileSize: &oldSize, FileMtime: &oldMtime, FileHash: strPtr("old-hash"),
+	}))
+	require.NoError(t, database.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: parentID, Machine: "remote-box", Agent: "claude", FilePath: uri,
+		}},
+	))
+	tombstoned, err := database.SoftDeleteSessionSourceOwnership(
+		t.Context(), "remote-box", "claude", parentID, uri,
+	)
+	require.NoError(t, err)
+	require.True(t, tombstoned, "seed a source-missing canonical primary")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: staleID, Project: "project", Machine: "remote-box", Agent: "claude",
+		Cwd: "/workspace/personal/project", ParentSessionID: &parentID,
+		RelationshipType: "fork", FilePath: strPtr(uri),
+		FileSize: &oldSize, FileMtime: &oldMtime, FileHash: strPtr("old-hash"),
+	}))
+	require.NoError(t, database.SetSessionDataVersion(staleID, 0))
+
+	oldFetch := fetchS3Object
+	t.Cleanup(func() { fetchS3Object = oldFetch })
+	var fetches int
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, uri, got)
+		fetches++
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+
+	engine := NewEngine(database, EngineConfig{
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/work"},
+	})
+	t.Cleanup(engine.Close)
+	file := parser.DiscoveredFile{
+		Agent: parser.AgentClaude, Path: uri, Project: "project",
+		Machine: "remote-box", SourceSize: int64(len(content)),
+		SourceMtime: currentMtime, SourceFingerprint: currentFingerprint,
+	}
+
+	first := engine.processFile(t.Context(), file)
+	require.NoError(t, first.err)
+	require.Equal(t, 1, fetches)
+	jobs := make(chan syncJob, 1)
+	jobs <- syncJob{
+		path: file.Path, agent: file.Agent, machine: file.Machine,
+		processResult: first,
+	}
+	close(jobs)
+	stats := engine.collectAndBatch(
+		t.Context(), jobs, 1, 1, nil, syncWriteDefault,
+	)
+	require.Zero(t, stats.Failed)
+
+	second := engine.processFile(t.Context(), file)
+	require.NoError(t, second.err)
+	assert.True(t, second.skip,
+		"a source-missing primary must not hide the rowless marker")
+	assert.Equal(t, 1, fetches,
+		"rowless freshness must avoid downloading the unchanged S3 object again")
+	primary, err := database.GetSessionFull(t.Context(), parentID)
+	require.NoError(t, err)
+	require.NotNil(t, primary)
+	require.NotNil(t, primary.DeletionCause,
+		"the source-missing primary must stay tombstoned")
+	assert.Equal(t, "source_missing", *primary.DeletionCause)
 }

--- a/internal/sync/s3_test.go
+++ b/internal/sync/s3_test.go
@@ -704,6 +704,87 @@ func TestSyncClaudeS3SubagentTranscriptsContextPreservesStoredParentNamespace(
 	assert.Nil(t, rawChild, "the child must not collide with a local session")
 }
 
+func TestSyncClaudeS3SubagentTranscriptsEmitsSessionsForForkTombstone(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	const root = "s3://bucket/laptop/raw/claude"
+	const childPath = root +
+		"/-home-proj/parent-uuid/subagents/agent-replay.jsonl"
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","parentUuid":null,"timestamp":"2026-01-01T10:00:00Z","sessionId":"agent-replay","sessionKind":"bg","message":{"content":"first question"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T10:00:05Z","sessionId":"agent-replay","sessionKind":"bg","message":{"id":"msg_01","content":[{"type":"text","text":"first answer"}]}}`,
+	}, "\n") + "\n"
+	mtime := time.Date(2026, 5, 20, 10, 2, 0, 0, time.UTC)
+
+	oldFetch := fetchS3Object
+	oldStat := statClaudeS3Session
+	t.Cleanup(func() {
+		fetchS3Object = oldFetch
+		statClaudeS3Session = oldStat
+	})
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, childPath, got)
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+	statClaudeS3Session = func(got string) (parser.S3Object, error) {
+		require.Equal(t, childPath, got)
+		return parser.S3Object{
+			URI:          childPath,
+			Size:         int64(len(content)),
+			LastModified: mtime,
+			Fingerprint:  "s3-meta:agent-replay",
+		}, nil
+	}
+
+	parentPath := root + "/-home-proj/parent-uuid.jsonl"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:       "laptop~parent-uuid",
+		Project:  "proj",
+		Machine:  "laptop",
+		Agent:    "claude",
+		FilePath: &parentPath,
+	}))
+	replayID := "laptop~agent-replay"
+	staleID := replayID + "-11111111-2222-4333-8444-555555555555"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:               staleID,
+		Project:          "proj",
+		Machine:          "laptop",
+		Agent:            "claude",
+		ParentSessionID:  &replayID,
+		RelationshipType: "fork",
+		FilePath:         strPtr(childPath),
+		FileSize:         int64Ptr(int64(len(content))),
+		FileMtime:        int64Ptr(mtime.UnixNano()),
+		FileHash:         strPtr("s3-meta:agent-replay"),
+	}))
+	require.NoError(t, database.SetSessionDataVersion(staleID, 0))
+	require.NoError(t, database.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: staleID, Machine: "laptop", Agent: "claude", FilePath: childPath,
+		}},
+	))
+
+	emitter := &fakeEmitter{}
+	engine := NewEngine(database, EngineConfig{
+		Machine: "central",
+		Emitter: emitter,
+	})
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.SyncClaudeS3SubagentTranscriptsContext(
+		t.Context(), "laptop~parent-uuid", []string{childPath},
+	))
+
+	assert.Equal(t, []string{"messages", "sessions"}, emitter.got(),
+		"S3 fork cleanup must refresh messages and the session index")
+	stale, err := database.GetSessionFull(t.Context(), staleID)
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	require.NotNil(t, stale.DeletionCause)
+	assert.Equal(t, "source_missing", *stale.DeletionCause)
+}
+
 func TestSyncClaudeS3SubagentTranscriptsContextUsesPrefixedChildProject(
 	t *testing.T,
 ) {

--- a/internal/sync/watch_batch_sync.go
+++ b/internal/sync/watch_batch_sync.go
@@ -311,7 +311,7 @@ func (e *Engine) SyncWatchBatchThenRun(
 		pathStats, tombstoned, pathErr := e.syncChangedPathsLocked(ctx, plan.paths)
 		mergeSyncStats(&stats, pathStats)
 		changed = changed || pathStats.Synced > 0 || tombstoned > 0 ||
-			pathStats.sourceMissingTombstoned > 0
+			pathStats.Tombstoned > 0
 		if pathErr != nil {
 			retry := WatchBatch{FullSync: plan.full, LostEvents: plan.lostEvents}
 			if !plan.full {


### PR DESCRIPTION
## Outcome

- Claude transcripts with legacy fork rows sync by append again. They no longer re-parse the whole file on each change.
- Legacy fork rows that the current parser no longer produces become source-missing tombstones. Nothing is hard-deleted. A later parse that emits the ID revives the row.
- Full rebuilds also retire these rows, and they do not slow down. The rebuild reads the archive's legacy fork rows once, not once per file.
- Clients refresh when a sync only tombstones rows.

## Why

Older parser versions split Claude transcripts into fork-branch rows that share the parent's file path. One real archive holds about 13,900 such rows. Today's parser never emits them, so no parse can refresh or remove them. While they exist, the incremental path refuses the transcript, and the path's minimum data version stays stale.

## What changed

- After a complete Claude parse, the sync compares the parsed sessions with the stored stale fork rows for that file. Rows that the parse did not produce become source-missing tombstones. This uses the existing baseline gate, so rows without deletion authority stay until a later pass proves it.
- The same check runs for zero-result transcripts, S3 sources, and rebuilds. A rebuild snapshots the archive's stale fork rows before it starts. The archive takes no writes during a rebuild, so the snapshot is exact.
- Stale forks that the CWD filter rejects stay in place. An unchanged source that holds only such rows is fresh, so it does not re-parse on every pass. A primary row tombstoned as source-missing counts as absent for this check.
- Deletion baselines can now be exact per session and path. A failed or canceled pass revokes only the rejected entries.
- `SyncStats.Tombstoned` is exported. Sync entry points emit a sessions event when it is non-zero.

## Limits

- Only fork rows with a data version below the current one are candidates. Primary rows and current forks are not touched.
- The rowless freshness marker is keyed on the CWD filter. A wider filter always re-parses.
- `engine.go` grows by about 1,000 lines. Some large functions gained branches instead of being split. A follow-up can extract the exact-baseline bookkeeping.
