### PR TITLE
Persist Claude and Codex freshness digests across engine restarts

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -316,14 +316,16 @@ Grok section and remove the explicit registry exception in the coverage test.
   trees, so this evidence does not establish IDE, desktop, or `codex exec`
   activity-hint coverage. Locally observed Codex app builds can write the same
   schema, but that is observational evidence rather than a public compatibility
-  guarantee. Agentsview derives the hint path as
-  `<configured-sessions-root>/../history.jsonl`; a custom sessions root
-  without that sibling, or `HistoryPersistence::None`, degrades to ordinary
-  watcher behavior, degraded-coverage polling when applicable, and the daily
-  archive audit. Restart bootstrap reads at most the newest 4 MiB and accepts
-  records from the preceding 24 hours. If a daemon restarts during a longer
-  autonomous run whose last prompt falls outside those bounds, the rollout
-  relies on those fallbacks until its next prompt.
+  guarantee. A missing `session_index.jsonl` is verified as normal absence;
+  read or scan failures remain unverified and cannot earn persisted freshness
+  trust, so a transient failure cannot pin a stale stored title. Agentsview
+  derives the hint path as `<configured-sessions-root>/../history.jsonl`; a
+  custom sessions root without that sibling, or `HistoryPersistence::None`,
+  degrades to ordinary watcher behavior, degraded-coverage polling when
+  applicable, and the daily archive audit. Restart bootstrap reads at most the
+  newest 4 MiB and accepts records from the preceding 24 hours. If a daemon
+  restarts during a longer autonomous run whose last prompt falls outside
+  those bounds, the rollout relies on those fallbacks until its next prompt.
 
 ## TraeX (`traex`)
 

--- a/internal/db/freshness_test.go
+++ b/internal/db/freshness_test.go
@@ -50,3 +50,30 @@ func TestResetAllMtimes_ZeroesMtimesAndClearsFreshness(t *testing.T) {
 		"provider_freshness must be cleared so the stat-digest "+
 			"shortcut cannot defeat the forced re-sync")
 }
+
+func TestRestoreSessionStalesSourceAndClearsFreshness(t *testing.T) {
+	d := testDB(t)
+	ctx := t.Context()
+	path := "/sessions/project/transcript.jsonl"
+
+	insertSessionWithSourcePath(t, d, "restored", "claude", path)
+	require.NoError(t, d.SetSessionDataVersion(
+		"restored", CurrentDataVersion(),
+	))
+	require.NoError(t, d.UpsertProviderStatHash(
+		ctx, parser.AgentClaude, path, 42,
+	))
+	require.NoError(t, d.SoftDeleteSession("restored"))
+
+	restored, err := d.RestoreSession("restored")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, restored)
+	assert.Less(t, d.GetSessionDataVersion("restored"), CurrentDataVersion(),
+		"restoring a source member must force a source reparse")
+	_, present, err := d.GetProviderStatHash(
+		ctx, parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	assert.False(t, present,
+		"restoring a source member must invalidate its source digest")
+}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -4727,9 +4727,10 @@ func (db *DB) SoftDeleteSessions(ids []string) (int, error) {
 	return total, nil
 }
 
-// RestoreSession clears deleted_at, making the session visible again.
-// Returns the number of rows affected (0 if session doesn't exist
-// or is not in trash).
+// RestoreSession clears deleted_at, makes the session visible again, and
+// invalidates source freshness so changes made while it was trashed are parsed.
+// Returns the number of rows affected (0 if session doesn't exist or is not in
+// trash).
 func (db *DB) RestoreSession(id string) (int64, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -4742,10 +4743,11 @@ func (db *DB) RestoreSession(id string) (int64, error) {
 		`UPDATE sessions
 		 SET deleted_at = NULL,
 		     deletion_cause = NULL,
+		     data_version = ?,
 		     local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
 		 WHERE id = ? AND deleted_at IS NOT NULL
 		   AND deletion_cause IS NULL`,
-		id,
+		max(CurrentDataVersion()-1, 0), id,
 	)
 	if err != nil {
 		return 0, err
@@ -4757,6 +4759,19 @@ func (db *DB) RestoreSession(id string) (int64, error) {
 	if n > 0 {
 		if _, err := tx.Exec(
 			"DELETE FROM local_session_source_baselines WHERE session_id = ?", id,
+		); err != nil {
+			return 0, err
+		}
+		// The source may have changed while this member was in trash. Force the
+		// next sync to reparse it instead of trusting a digest persisted while
+		// the member was intentionally skipped. Delete by path because a path can
+		// have provider aliases in the freshness table.
+		if _, err := tx.Exec(
+			`DELETE FROM provider_freshness
+			 WHERE file_path = (
+				SELECT file_path FROM sessions WHERE id = ?
+			 )`,
+			id,
 		); err != nil {
 			return 0, err
 		}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2393,6 +2393,70 @@ func (db *DB) SetSessionDataVersion(id string, version int) error {
 	return nil
 }
 
+// SetSessionDataVersions atomically stamps the parser data_version on every
+// listed session. This is used when several session rows represent one source:
+// either every member becomes current, or all remain eligible for retry.
+func (db *DB) SetSessionDataVersions(ids []string, version int) error {
+	return db.setSessionDataVersions(ids, version, true)
+}
+
+// SetExistingSessionDataVersions atomically stamps every listed session that
+// already exists, ignoring IDs that have not been inserted yet.
+func (db *DB) SetExistingSessionDataVersions(ids []string, version int) error {
+	return db.setSessionDataVersions(ids, version, false)
+}
+
+func (db *DB) setSessionDataVersions(
+	ids []string, version int, requireAll bool,
+) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return fmt.Errorf("beginning data version update: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, id := range ids {
+		result, err := tx.Exec(
+			`UPDATE sessions SET
+				data_version = ?,
+				local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+			 WHERE id = ?`,
+			version, id,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"setting data_version for %s: %w", id, err,
+			)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf(
+				"checking data_version update for %s: %w", id, err,
+			)
+		}
+		if rows == 0 && !requireAll {
+			continue
+		}
+		if rows != 1 {
+			return fmt.Errorf(
+				"setting data_version for %s: session not found", id,
+			)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing data version update: %w", err)
+	}
+	return nil
+}
+
 // GetSessionMessageCount returns the message_count for a
 // session. Returns (0, false) when the session does not exist.
 func (db *DB) GetSessionMessageCount(

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -285,6 +286,47 @@ func TestUpsertSessionDoesNotAdvanceDataVersion(t *testing.T) {
 	}), "UpsertSession (update)")
 	assert.Equal(t, CurrentDataVersion(), d.GetSessionDataVersion("dv-1"),
 		"after re-upsert, data_version (must be preserved across UpsertSession)")
+}
+
+func TestSetSessionDataVersionsIsAtomic(t *testing.T) {
+	d := testDB(t)
+	for _, id := range []string{"source-main", "source-fork"} {
+		require.NoError(t, d.UpsertSession(Session{
+			ID: id, Project: "p", Machine: "m", Agent: "claude",
+		}))
+		require.NoError(t, d.SetSessionDataVersion(id, 1))
+	}
+
+	raw, err := sql.Open("sqlite3", d.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`
+		CREATE TRIGGER fail_fork_promotion
+		BEFORE UPDATE OF data_version ON sessions
+		WHEN NEW.id = 'source-fork' AND NEW.data_version > OLD.data_version
+		BEGIN
+			SELECT RAISE(FAIL, 'injected fork promotion failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	err = d.SetSessionDataVersions(
+		[]string{"source-main", "source-fork"}, CurrentDataVersion(),
+	)
+	require.ErrorContains(t, err, "injected fork promotion failure")
+	assert.Equal(t, 1, d.GetSessionDataVersion("source-main"),
+		"a later member failure must roll back an earlier promotion")
+	assert.Equal(t, 1, d.GetSessionDataVersion("source-fork"))
+
+	_, err = raw.Exec(`DROP TRIGGER fail_fork_promotion`)
+	require.NoError(t, err)
+	require.NoError(t, d.SetSessionDataVersions(
+		[]string{"source-main", "source-fork"}, CurrentDataVersion(),
+	))
+	assert.Equal(t, CurrentDataVersion(),
+		d.GetSessionDataVersion("source-main"))
+	assert.Equal(t, CurrentDataVersion(),
+		d.GetSessionDataVersion("source-fork"))
 }
 
 func TestSessionTranscriptFidelityRoundTrips(t *testing.T) {

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -78,6 +78,17 @@ func (p *claudeProvider) Fingerprint(
 	return p.sources.Fingerprint(ctx, source)
 }
 
+// ComputeMultiFileStatHash implements parser.MultiFileStatHasher for the
+// single-file Claude transcript. Claude has no sibling companions; the
+// digest exists so stat-verified freshness persists in provider_freshness
+// across process restarts, sparing a fresh engine (daemon restart or a
+// one-shot CLI sync) the full-content hash that Fingerprint performs for
+// every unchanged transcript. The ctime term in the tuple preserves the
+// in-place-rewrite detection the content hash provided.
+func (p *claudeProvider) ComputeMultiFileStatHash(chatPath string) uint64 {
+	return fileStatTupleDigest(0xC1, chatPath)
+}
+
 func (p *claudeProvider) Parse(
 	ctx context.Context,
 	req ParseRequest,
@@ -665,6 +676,7 @@ func claudeProviderCapabilities() Capabilities {
 			ExcludedSessions:     CapabilitySupported,
 			ForceReplaceOnParse:  CapabilitySupported,
 			VerifiedLocalStat:    CapabilitySupported,
+			MultiFileStatHash:    CapabilitySupported,
 		},
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1753,19 +1753,50 @@ func LookupCodexThreadName(sessionPath, sessionID string) string {
 func LookupCodexThreadNameEntry(
 	sessionPath, sessionID string,
 ) (string, bool) {
+	name, ok, _ := ReadCodexThreadNameEntry(sessionPath, sessionID)
+	return name, ok
+}
+
+// ReadCodexThreadNameEntry returns the session_index.jsonl title for the
+// session, whether the index holds an entry, and any read or scan failure.
+// A missing index is a verified absence and returns no error; modern Codex
+// releases no longer create this file. Callers that persist freshness state
+// use the error to distinguish that normal absence from a transient failure.
+func ReadCodexThreadNameEntry(
+	sessionPath, sessionID string,
+) (string, bool, error) {
 	if strings.TrimSpace(sessionID) == "" {
-		return "", false
+		return "", false, nil
 	}
 	indexPath := codexSessionIndexPath(sessionPath)
 	if indexPath == "" {
-		return "", false
+		return "", false, nil
 	}
 	titles, err := loadCodexSessionIndex(indexPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
 	if err != nil {
-		return "", false
+		return "", false, err
 	}
 	title, ok := titles[sessionID]
-	return strings.TrimSpace(title), ok
+	return strings.TrimSpace(title), ok, nil
+}
+
+// VerifyCodexSessionIndex reports whether the title index associated with a
+// rollout was read successfully or confirmed absent. It preserves non-ENOENT
+// failures so callers cannot persist a freshness digest for unchecked title
+// metadata.
+func VerifyCodexSessionIndex(sessionPath string) error {
+	indexPath := codexSessionIndexPath(sessionPath)
+	if indexPath == "" {
+		return nil
+	}
+	_, err := loadCodexSessionIndex(indexPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 // CodexEffectiveMtime returns the effective mtime for a Codex session file,

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -634,7 +634,7 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 	t.Run("custom_tool_call_output for a stored call requests full parse", func(t *testing.T) {
 		line := `{"timestamp":"2026-07-08T03:20:43.376Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_abc","output":"Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess."}}`
 
-		b := newCodexSessionBuilder(false)
+		b := newCodexSessionBuilder(false, nil)
 		assert.True(t,
 			b.incrementalOutputNeedsFullParse(gjson.Get(line, "payload")))
 	})

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -235,6 +235,20 @@ func (p *codexProvider) Fingerprint(
 	return p.sources.Fingerprint(ctx, source)
 }
 
+// ComputeMultiFileStatHash implements parser.MultiFileStatHasher over the
+// rollout transcript plus its session_index.jsonl sidecar, mirroring the
+// sidecar folding of the verified-source gate: an index-only change (a
+// thread title rename) breaks the digest even when the transcript is
+// byte-identical, so the warm short-circuit can never mask a metadata
+// refresh. An absent index contributes a stable (0, 0, 0) tuple, which
+// matches modern Codex releases that no longer write the index. The
+// digest persists stat-verified freshness in provider_freshness across
+// process restarts, sparing a fresh engine the full-content hash that
+// Fingerprint performs for every unchanged rollout.
+func (p *codexProvider) ComputeMultiFileStatHash(chatPath string) uint64 {
+	return fileStatTupleDigest(0xC2, chatPath, codexSessionIndexPath(chatPath))
+}
+
 func (p *codexProvider) Parse(
 	ctx context.Context,
 	req ParseRequest,
@@ -964,6 +978,7 @@ func codexProviderCapabilities() Capabilities {
 			ExcludedSessions:     CapabilityNotApplicable,
 			ForceReplaceOnParse:  CapabilitySupported,
 			VerifiedLocalStat:    CapabilitySupported,
+			MultiFileStatHash:    CapabilitySupported,
 		},
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -239,9 +239,12 @@ type StoredSourceHintScopeProvider interface {
 //
 // Implementations live on the provider implementation; the engine type-
 // asserts a constructed provider against MultiFileStatHasher and caches
-// the result. Providers that do not implement this interface take the
-// existing stat-only composite path, which is the right default for
-// single-file agents (Claude, Codex, etc.).
+// the result. Single-file providers whose Fingerprint content-hashes the
+// source (Claude, Codex) also implement it: their digest folds the
+// change-time term, so a persisted stat digest preserves in-place-rewrite
+// detection across process restarts without re-reading unchanged content
+// on every pass. Providers that implement neither behavior take the
+// existing stat-only composite path.
 type MultiFileStatHasher interface {
 	// ComputeMultiFileStatHash stats the chat path plus any companion
 	// siblings declared by the provider and returns a stable per-source

--- a/internal/parser/stat_digest.go
+++ b/internal/parser/stat_digest.go
@@ -1,0 +1,37 @@
+package parser
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"os"
+)
+
+// fileStatTupleDigest computes an FNV-1a 64 digest over (size, mtime,
+// ctime) tuples for the given files, prefixed with a per-provider domain
+// separator so digests from different providers never collide. Missing or
+// unreadable files are encoded as (0, 0, 0), and the change-time term
+// degrades to 0 on platforms without a reliable ctime, keeping the tuple
+// stable there — the same conventions as the Codebuff companion digest.
+// The ctime term is what lets a matching digest rule out a same-size,
+// same-mtime in-place rewrite: any content write bumps ctime even when
+// mtime is carried over or falls in the same coarse granule.
+func fileStatTupleDigest(sep byte, paths ...string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte{sep})
+	var buf [24]byte
+	for _, path := range paths {
+		var size, mtime, ctime int64
+		if path != "" {
+			if info, err := os.Stat(path); err == nil {
+				size = info.Size()
+				mtime = info.ModTime().UnixNano()
+				ctime, _ = codexIndexChangeTime(path, info)
+			}
+		}
+		binary.LittleEndian.PutUint64(buf[:8], uint64(size))
+		binary.LittleEndian.PutUint64(buf[8:16], uint64(mtime))
+		binary.LittleEndian.PutUint64(buf[16:24], uint64(ctime))
+		_, _ = h.Write(buf[:])
+	}
+	return h.Sum64()
+}

--- a/internal/parser/stat_digest.go
+++ b/internal/parser/stat_digest.go
@@ -9,13 +9,20 @@ import (
 // fileStatTupleDigest computes an FNV-1a 64 digest over (size, mtime,
 // ctime) tuples for the given files, prefixed with a per-provider domain
 // separator so digests from different providers never collide. Missing or
-// unreadable files are encoded as (0, 0, 0), and the change-time term
-// degrades to 0 on platforms without a reliable ctime, keeping the tuple
-// stable there — the same conventions as the Codebuff companion digest.
-// The ctime term is what lets a matching digest rule out a same-size,
-// same-mtime in-place rewrite: any content write bumps ctime even when
-// mtime is carried over or falls in the same coarse granule.
+// unreadable files are encoded as (0, 0, 0). An existing file without a
+// reliable change-time makes the whole digest unverified (0), because its
+// size and mtime alone cannot rule out a same-size, mtime-preserving rewrite.
 func fileStatTupleDigest(sep byte, paths ...string) uint64 {
+	return fileStatTupleDigestWithChangeTime(
+		codexIndexChangeTime, sep, paths...,
+	)
+}
+
+func fileStatTupleDigestWithChangeTime(
+	changeTime func(string, os.FileInfo) (int64, bool),
+	sep byte,
+	paths ...string,
+) uint64 {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte{sep})
 	var buf [24]byte
@@ -25,7 +32,11 @@ func fileStatTupleDigest(sep byte, paths ...string) uint64 {
 			if info, err := os.Stat(path); err == nil {
 				size = info.Size()
 				mtime = info.ModTime().UnixNano()
-				ctime, _ = codexIndexChangeTime(path, info)
+				var verified bool
+				ctime, verified = changeTime(path, info)
+				if !verified {
+					return 0
+				}
 			}
 		}
 		binary.LittleEndian.PutUint64(buf[:8], uint64(size))

--- a/internal/parser/stat_digest_test.go
+++ b/internal/parser/stat_digest_test.go
@@ -1,0 +1,77 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeStatDigestFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func TestClaudeProviderComputesMultiFileStatHash(t *testing.T) {
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Machine: "local",
+	})
+	require.True(t, ok)
+	hasher, ok := provider.(MultiFileStatHasher)
+	require.True(t, ok, "claude provider must implement MultiFileStatHasher")
+	assert.Equal(t, CapabilitySupported,
+		provider.Capabilities().Source.MultiFileStatHash,
+		"claude must declare MultiFileStatHash so the engine registers the hasher")
+
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	writeStatDigestFile(t, path, "line one\n")
+
+	first := hasher.ComputeMultiFileStatHash(path)
+	require.NotZero(t, first)
+	assert.Equal(t, first, hasher.ComputeMultiFileStatHash(path),
+		"digest must be stable while the transcript stat is unchanged")
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("line two\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	assert.NotEqual(t, first, hasher.ComputeMultiFileStatHash(path),
+		"an appended transcript must change the digest")
+}
+
+func TestCodexProviderComputesMultiFileStatHash(t *testing.T) {
+	root := t.TempDir()
+	provider := newCodexTestProvider(t, root)
+	hasher, ok := any(provider).(MultiFileStatHasher)
+	require.True(t, ok, "codex provider must implement MultiFileStatHasher")
+	assert.Equal(t, CapabilitySupported,
+		provider.Capabilities().Source.MultiFileStatHash,
+		"codex must declare MultiFileStatHash so the engine registers the hasher")
+
+	path := filepath.Join(root, "sessions", "rollout-2026-01-01.jsonl")
+	writeStatDigestFile(t, path, "{}\n")
+
+	first := hasher.ComputeMultiFileStatHash(path)
+	require.NotZero(t, first)
+	assert.Equal(t, first, hasher.ComputeMultiFileStatHash(path),
+		"digest must be stable while transcript and index stats are unchanged")
+
+	// A session_index.jsonl change (e.g. a thread title rename) must break
+	// the digest even when the transcript itself is untouched, so the warm
+	// short-circuit can never mask an index-only metadata refresh.
+	indexPath := filepath.Join(root, CodexSessionIndexFilename)
+	writeStatDigestFile(t, indexPath, `{"id":"x","name":"Renamed"}`+"\n")
+	withIndex := hasher.ComputeMultiFileStatHash(path)
+	assert.NotEqual(t, first, withIndex,
+		"an appearing session index must change the digest")
+
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(indexPath, future, future))
+	assert.NotEqual(t, withIndex, hasher.ComputeMultiFileStatHash(path),
+		"an index mtime change must change the digest")
+}

--- a/internal/parser/stat_digest_test.go
+++ b/internal/parser/stat_digest_test.go
@@ -16,6 +16,22 @@ func writeStatDigestFile(t *testing.T, path, content string) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }
 
+func TestFileStatTupleDigestRejectsUnavailableChangeTime(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	writeStatDigestFile(t, path, "unchanged\n")
+
+	digest := fileStatTupleDigestWithChangeTime(
+		func(string, os.FileInfo) (int64, bool) {
+			return 0, false
+		},
+		0xC1,
+		path,
+	)
+
+	assert.Zero(t, digest,
+		"size and mtime alone must not produce a trusted digest")
+}
+
 func TestClaudeProviderComputesMultiFileStatHash(t *testing.T) {
 	provider, ok := NewProvider(AgentClaude, ProviderConfig{
 		Machine: "local",
@@ -31,6 +47,13 @@ func TestClaudeProviderComputesMultiFileStatHash(t *testing.T) {
 	writeStatDigestFile(t, path, "line one\n")
 
 	first := hasher.ComputeMultiFileStatHash(path)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	if _, changeTimeOK := codexIndexChangeTime(path, info); !changeTimeOK {
+		assert.Zero(t, first,
+			"unavailable change-time must disable the stat digest")
+		return
+	}
 	require.NotZero(t, first)
 	assert.Equal(t, first, hasher.ComputeMultiFileStatHash(path),
 		"digest must be stable while the transcript stat is unchanged")
@@ -57,6 +80,13 @@ func TestCodexProviderComputesMultiFileStatHash(t *testing.T) {
 	writeStatDigestFile(t, path, "{}\n")
 
 	first := hasher.ComputeMultiFileStatHash(path)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	if _, changeTimeOK := codexIndexChangeTime(path, info); !changeTimeOK {
+		assert.Zero(t, first,
+			"unavailable change-time must disable the stat digest")
+		return
+	}
 	require.NotZero(t, first)
 	assert.Equal(t, first, hasher.ComputeMultiFileStatHash(path),
 		"digest must be stable while transcript and index stats are unchanged")
@@ -67,6 +97,15 @@ func TestCodexProviderComputesMultiFileStatHash(t *testing.T) {
 	indexPath := filepath.Join(root, CodexSessionIndexFilename)
 	writeStatDigestFile(t, indexPath, `{"id":"x","name":"Renamed"}`+"\n")
 	withIndex := hasher.ComputeMultiFileStatHash(path)
+	indexInfo, err := os.Stat(indexPath)
+	require.NoError(t, err)
+	if _, changeTimeOK := codexIndexChangeTime(
+		indexPath, indexInfo,
+	); !changeTimeOK {
+		assert.Zero(t, withIndex,
+			"an existing sidecar without change-time must disable the digest")
+		return
+	}
 	assert.NotEqual(t, first, withIndex,
 		"an appearing session index must change the digest")
 

--- a/internal/postgres/session_mgmt_pgtest_test.go
+++ b/internal/postgres/session_mgmt_pgtest_test.go
@@ -45,6 +45,10 @@ func TestStoreSessionManagementCRUD(t *testing.T) {
 			 '2026-03-12T14:30:00Z'::timestamptz, 2, 1)
 	`, project)
 	require.NoError(t, err, "inserting session rows")
+	_, err = store.DB().Exec(`
+		UPDATE sessions SET data_version = $1 WHERE id = 'mgmt-trash'
+	`, db.CurrentDataVersion())
+	require.NoError(t, err, "marking restore target current")
 
 	renamed := "Renamed by PG store"
 	require.NoError(t, store.RenameSession("mgmt-rename", &renamed),
@@ -67,6 +71,8 @@ func TestStoreSessionManagementCRUD(t *testing.T) {
 	sess, err = store.GetSession(ctx, "mgmt-trash")
 	require.NoError(t, err, "GetSession after restore")
 	require.NotNil(t, sess)
+	assert.Less(t, sess.DataVersion, db.CurrentDataVersion(),
+		"restoring a session must force a source reparse")
 
 	require.NoError(t, store.SoftDeleteSession("mgmt-delete"),
 		"SoftDeleteSession delete target")

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -462,16 +462,18 @@ func (s *Store) SoftDeleteSessions(ids []string) (int, error) {
 	return total, nil
 }
 
-// RestoreSession restores a trashed session.
+// RestoreSession restores a trashed session and invalidates source freshness
+// so changes made while it was trashed are parsed.
 func (s *Store) RestoreSession(id string) (int64, error) {
 	res, err := s.pg.Exec(
 		`UPDATE sessions
 		 SET deleted_at = NULL,
 		     deletion_cause = NULL,
+		     data_version = $2,
 		     updated_at = NOW()
 		 WHERE id = $1 AND deleted_at IS NOT NULL
 		   AND deletion_cause IS NULL`,
-		id,
+		id, max(db.CurrentDataVersion()-1, 0),
 	)
 	if err != nil {
 		return 0, mapPGWriteError(

--- a/internal/sync/claude_stat_hash_write_failure_test.go
+++ b/internal/sync/claude_stat_hash_write_failure_test.go
@@ -1,0 +1,174 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+// TestSyncClaudeForkWriteFailureRetriesWholeSource proves that freshness is a
+// source-level outcome for Claude DAG transcripts. One committed branch cannot
+// make the shared transcript fresh while another branch still needs a write.
+func TestSyncClaudeForkWriteFailureRetriesWholeSource(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project-a")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	path := filepath.Join(projectDir, "forked.jsonl")
+	builder := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:00Z", "start", "a", "",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:01Z", "ok", "b", "a",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:02Z", "main-2", "c", "b",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:03Z", "ok-2", "d", "c",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:04Z", "main-3", "e", "d",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:05Z", "ok-3", "f", "e",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:06Z", "main-4", "g", "f",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:07Z", "ok-4", "h", "g",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:08Z", "main-5", "k", "h",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:09Z", "ok-5", "l", "k",
+		)
+	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o644))
+
+	initialEngine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(initialEngine.Close)
+	initial := initialEngine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, initial.Synced)
+	require.Zero(t, initial.Failed)
+	require.Equal(t, db.CurrentDataVersion(),
+		database.GetSessionDataVersion("forked"))
+
+	builder.AddClaudeUserWithUUID(
+		"2024-01-01T10:01:00Z", "fork", "i", "b",
+	).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:01:01Z", "fork-ok", "j", "i",
+		)
+	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o644))
+
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`
+		CREATE TRIGGER fail_claude_fork_insert
+		BEFORE INSERT ON sessions
+		WHEN NEW.id = 'forked-i'
+		BEGIN
+			SELECT RAISE(FAIL, 'injected Claude fork write failure');
+		END;
+		CREATE TRIGGER fail_claude_main_demotion
+		BEFORE UPDATE OF data_version ON sessions
+		WHEN NEW.id = 'forked'
+		 AND OLD.data_version > NEW.data_version
+		BEGIN
+			SELECT RAISE(FAIL, 'injected Claude main demotion failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	failedDemotion := engine.SyncAll(context.Background(), nil)
+	require.Zero(t, failedDemotion.Synced)
+	require.Equal(t, 1, failedDemotion.Failed)
+	require.Equal(t, db.CurrentDataVersion(),
+		database.GetSessionDataVersion("forked"),
+		"a rejected pre-write demotion must abort before changing the row")
+	_, hasDigest, err := database.GetProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	assert.False(t, hasDigest,
+		"a rejected source demotion must revoke the old digest")
+
+	_, err = raw.Exec(`DROP TRIGGER fail_claude_main_demotion`)
+	require.NoError(t, err)
+	partialEngine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(partialEngine.Close)
+	failed := partialEngine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, failed.Synced)
+	require.Equal(t, 1, failed.Failed)
+	main, err := database.GetSession(t.Context(), "forked")
+	require.NoError(t, err)
+	require.NotNil(t, main, "the first DAG branch must commit before the failure")
+	assert.Less(t, main.DataVersion, db.CurrentDataVersion(),
+		"the committed main branch must remain retryable")
+	fork, err := database.GetSession(t.Context(), "forked-i")
+	require.NoError(t, err)
+	assert.Nil(t, fork, "the injected fork write must leave the branch absent")
+
+	_, hasDigest, err = database.GetProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	assert.False(t, hasDigest,
+		"a partial DAG write must not mark the shared source fresh")
+
+	_, err = raw.Exec(`DROP TRIGGER fail_claude_fork_insert`)
+	require.NoError(t, err)
+	restarted := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(restarted.Close)
+
+	retry := restarted.SyncAll(context.Background(), nil)
+	require.Equal(t, 2, retry.Synced,
+		"the unchanged DAG source must retry every branch after a partial write")
+	require.Zero(t, retry.Failed)
+	fork, err = database.GetSession(t.Context(), "forked-i")
+	require.NoError(t, err)
+	require.NotNil(t, fork, "the retry must restore the missing fork")
+
+	_, hasDigest, err = database.GetProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	assert.True(t, hasDigest,
+		"the digest may persist after every branch commits")
+}

--- a/internal/sync/claude_stat_hash_write_failure_test.go
+++ b/internal/sync/claude_stat_hash_write_failure_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +16,46 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
+
+type digestFingerprintCountingProvider struct {
+	parser.Provider
+	calls atomic.Int64
+}
+
+func (p *digestFingerprintCountingProvider) Fingerprint(
+	ctx context.Context, source parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	p.calls.Add(1)
+	return p.Provider.Fingerprint(ctx, source)
+}
+
+func (p *digestFingerprintCountingProvider) ComputeMultiFileStatHash(
+	path string,
+) uint64 {
+	hasher, ok := p.Provider.(parser.MultiFileStatHasher)
+	if !ok {
+		return 0
+	}
+	return hasher.ComputeMultiFileStatHash(path)
+}
+
+type digestFingerprintCountingFactory struct {
+	provider *digestFingerprintCountingProvider
+}
+
+func (f digestFingerprintCountingFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f digestFingerprintCountingFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f digestFingerprintCountingFactory) NewProvider(
+	parser.ProviderConfig,
+) parser.Provider {
+	return f.provider
+}
 
 // TestSyncClaudeForkWriteFailureRetriesWholeSource proves that freshness is a
 // source-level outcome for Claude DAG transcripts. One committed branch cannot
@@ -137,6 +178,90 @@ func TestSyncClaudeForkWriteFailureRetriesWholeSource(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, hasDigest,
 		"the digest may persist after every branch commits")
+}
+
+func TestRestartedDigestGateIgnoresStaleTrashedClaudeMembers(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		trashMainToo bool
+	}{
+		{name: "active main with trashed fork"},
+		{name: "all members trashed", trashMainToo: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := openTestDB(t)
+			root := t.TempDir()
+			projectDir := filepath.Join(root, "project-a")
+			require.NoError(t, os.MkdirAll(projectDir, 0o755))
+			path := filepath.Join(projectDir, "forked.jsonl")
+			require.NoError(t, os.WriteFile(
+				path, []byte(newClaudeDAGBuilder(true).String()), 0o644,
+			))
+
+			initial := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentClaude: {root},
+				},
+				Machine: "local",
+			})
+			require.Equal(t, 2, initial.SyncAll(t.Context(), nil).Synced)
+			initial.Close()
+			_, hasDigest, err := database.GetProviderStatHash(
+				t.Context(), parser.AgentClaude, path,
+			)
+			require.NoError(t, err)
+			require.True(t, hasDigest)
+
+			require.NoError(t, database.SoftDeleteSession("forked-i"))
+			require.NoError(t, database.SetSessionDataVersion(
+				"forked-i", db.CurrentDataVersion()-1,
+			))
+			if tc.trashMainToo {
+				require.NoError(t, database.SoftDeleteSession("forked"))
+				require.NoError(t, database.SetSessionDataVersion(
+					"forked", db.CurrentDataVersion()-1,
+				))
+			}
+
+			innerFactory, ok := parser.ProviderFactoryByType(parser.AgentClaude)
+			require.True(t, ok)
+			inner := innerFactory.NewProvider(parser.ProviderConfig{
+				Roots: []string{root}, Machine: "local",
+			})
+			require.NotNil(t, inner)
+			counting := &digestFingerprintCountingProvider{Provider: inner}
+			restarted := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentClaude: {root},
+				},
+				Machine: "local",
+				ProviderFactories: []parser.ProviderFactory{
+					digestFingerprintCountingFactory{provider: counting},
+				},
+			})
+			t.Cleanup(restarted.Close)
+			var contentHashCalls atomic.Int64
+			originalComputeFileHashPrefix := computeFileHashPrefix
+			computeFileHashPrefix = func(
+				path string, size int64,
+			) (string, error) {
+				contentHashCalls.Add(1)
+				return originalComputeFileHashPrefix(path, size)
+			}
+			t.Cleanup(func() {
+				computeFileHashPrefix = originalComputeFileHashPrefix
+			})
+
+			stats := restarted.SyncAll(t.Context(), nil)
+
+			assert.Zero(t, stats.Synced)
+			assert.Zero(t, stats.Failed)
+			assert.Zero(t, counting.calls.Load(),
+				"stale trashed members must not defeat the persisted digest")
+			assert.Zero(t, contentHashCalls.Load(),
+				"stale trashed members must not force a transcript hash")
+		})
+	}
 }
 
 func TestSyncClaudeDAGIntentionalSkipCompletesActiveMembers(t *testing.T) {

--- a/internal/sync/claude_stat_hash_write_failure_test.go
+++ b/internal/sync/claude_stat_hash_write_failure_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -235,10 +236,44 @@ func TestSyncClaudeDAGIntentionalSkipCompletesActiveMembers(t *testing.T) {
 			assert.False(t, hasDigest,
 				"restoring a fork must invalidate the source digest")
 
-			restoredSync := restarted.SyncAll(context.Background(), nil)
-			require.Zero(t, restoredSync.Failed)
-			assert.Equal(t, 2, restoredSync.Synced,
-				"restoring a fork must reparse the complete DAG")
+			// Pin the source stat to the current main row. The restored fork's
+			// stale data version must still defeat the stem-based Claude gate.
+			// Normalize the project and unavailable file identity so this does
+			// not depend on temporary-directory naming or inode reuse by the host.
+			raw, err := sql.Open("sqlite3", database.Path())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, raw.Close()) })
+			_, err = raw.Exec(
+				`UPDATE sessions
+				 SET project = ?, file_inode = 0, file_device = 0
+				 WHERE file_path = ?`,
+				"project-a", path,
+			)
+			require.NoError(t, err)
+			mainSession, err := database.GetSession(t.Context(), "forked")
+			require.NoError(t, err)
+			require.NotNil(t, mainSession)
+			require.Equal(t, "project-a", mainSession.Project)
+			require.Equal(t, path, database.GetSessionFilePath("forked"))
+			storedSize, storedMtime, ok := database.GetSessionFileInfo("forked")
+			require.True(t, ok)
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			require.Equal(t, storedSize, info.Size())
+			storedTime := time.Unix(0, storedMtime)
+			require.NoError(t, os.Chtimes(path, storedTime, storedTime))
+			info, err = os.Stat(path)
+			require.NoError(t, err)
+			require.Equal(t, storedMtime, info.ModTime().UnixNano())
+
+			if tc.syncSingle {
+				require.NoError(t, restarted.SyncSingleSession("forked"))
+			} else {
+				restoredSync := restarted.SyncAll(context.Background(), nil)
+				require.Zero(t, restoredSync.Failed)
+				assert.Equal(t, 2, restoredSync.Synced,
+					"restoring a fork must reparse the complete DAG")
+			}
 			assert.Equal(t, db.CurrentDataVersion(),
 				database.GetSessionDataVersion("forked-i"))
 		})

--- a/internal/sync/claude_stat_hash_write_failure_test.go
+++ b/internal/sync/claude_stat_hash_write_failure_test.go
@@ -24,37 +24,7 @@ func TestSyncClaudeForkWriteFailureRetriesWholeSource(t *testing.T) {
 	projectDir := filepath.Join(root, "project-a")
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
 	path := filepath.Join(projectDir, "forked.jsonl")
-	builder := testjsonl.NewSessionBuilder().
-		AddClaudeUserWithUUID(
-			"2024-01-01T10:00:00Z", "start", "a", "",
-		).
-		AddClaudeAssistantWithUUID(
-			"2024-01-01T10:00:01Z", "ok", "b", "a",
-		).
-		AddClaudeUserWithUUID(
-			"2024-01-01T10:00:02Z", "main-2", "c", "b",
-		).
-		AddClaudeAssistantWithUUID(
-			"2024-01-01T10:00:03Z", "ok-2", "d", "c",
-		).
-		AddClaudeUserWithUUID(
-			"2024-01-01T10:00:04Z", "main-3", "e", "d",
-		).
-		AddClaudeAssistantWithUUID(
-			"2024-01-01T10:00:05Z", "ok-3", "f", "e",
-		).
-		AddClaudeUserWithUUID(
-			"2024-01-01T10:00:06Z", "main-4", "g", "f",
-		).
-		AddClaudeAssistantWithUUID(
-			"2024-01-01T10:00:07Z", "ok-4", "h", "g",
-		).
-		AddClaudeUserWithUUID(
-			"2024-01-01T10:00:08Z", "main-5", "k", "h",
-		).
-		AddClaudeAssistantWithUUID(
-			"2024-01-01T10:00:09Z", "ok-5", "l", "k",
-		)
+	builder := newClaudeDAGBuilder(false)
 	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o644))
 
 	initialEngine := NewEngine(database, EngineConfig{
@@ -70,12 +40,7 @@ func TestSyncClaudeForkWriteFailureRetriesWholeSource(t *testing.T) {
 	require.Equal(t, db.CurrentDataVersion(),
 		database.GetSessionDataVersion("forked"))
 
-	builder.AddClaudeUserWithUUID(
-		"2024-01-01T10:01:00Z", "fork", "i", "b",
-	).
-		AddClaudeAssistantWithUUID(
-			"2024-01-01T10:01:01Z", "fork-ok", "j", "i",
-		)
+	addClaudeDAGFork(builder)
 	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o644))
 
 	raw, err := sql.Open("sqlite3", database.Path())
@@ -171,4 +136,157 @@ func TestSyncClaudeForkWriteFailureRetriesWholeSource(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, hasDigest,
 		"the digest may persist after every branch commits")
+}
+
+func TestSyncClaudeDAGIntentionalSkipCompletesActiveMembers(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		trashed    bool
+		syncSingle bool
+	}{
+		{name: "sync_all/excluded"},
+		{name: "sync_all/trashed", trashed: true},
+		{name: "sync_single/excluded", syncSingle: true},
+		{name: "sync_single/trashed", trashed: true, syncSingle: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := openTestDB(t)
+			root := t.TempDir()
+			projectDir := filepath.Join(root, "project-a")
+			require.NoError(t, os.MkdirAll(projectDir, 0o755))
+			path := filepath.Join(projectDir, "forked.jsonl")
+			builder := newClaudeDAGBuilder(true)
+			require.NoError(t,
+				os.WriteFile(path, []byte(builder.String()), 0o644))
+
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentClaude: {root},
+				},
+				Machine: "local",
+			})
+			t.Cleanup(engine.Close)
+			initial := engine.SyncAll(context.Background(), nil)
+			require.Equal(t, 2, initial.Synced)
+			require.Zero(t, initial.Failed)
+			if tc.trashed {
+				require.NoError(t, database.SoftDeleteSession("forked-i"))
+			} else {
+				require.NoError(t, database.DeleteSession("forked-i"))
+			}
+
+			builder.AddClaudeUserWithUUID(
+				"2024-01-01T10:02:00Z", "main-6", "m", "l",
+			).AddClaudeAssistantWithUUID(
+				"2024-01-01T10:02:01Z", "ok-6", "n", "m",
+			)
+			require.NoError(t, os.Remove(path))
+			require.NoError(t,
+				os.WriteFile(path, []byte(builder.String()), 0o644))
+
+			if tc.syncSingle {
+				require.NoError(t, engine.SyncSingleSession("forked"))
+			} else {
+				changed := engine.SyncAll(context.Background(), nil)
+				require.Equal(t, 1, changed.Synced)
+				require.Zero(t, changed.Failed)
+			}
+			assert.Equal(t, db.CurrentDataVersion(),
+				database.GetSessionDataVersion("forked"))
+			if tc.trashed {
+				assert.Equal(t, db.CurrentDataVersion(),
+					database.GetSessionDataVersion("forked-i"),
+					"the trashed fork must not be demoted")
+			}
+			_, hasDigest, err := database.GetProviderStatHash(
+				t.Context(), parser.AgentClaude, path,
+			)
+			require.NoError(t, err)
+			assert.True(t, hasDigest,
+				"an intentional fork skip must not block source freshness")
+
+			restarted := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentClaude: {root},
+				},
+				Machine: "local",
+			})
+			t.Cleanup(restarted.Close)
+			noop := restarted.SyncAll(context.Background(), nil)
+			assert.Zero(t, noop.Synced,
+				"a completed active branch must not rewrite on restart")
+			assert.Zero(t, noop.Failed)
+
+			if !tc.trashed {
+				return
+			}
+			restoredCount, err := database.RestoreSession("forked-i")
+			require.NoError(t, err)
+			require.EqualValues(t, 1, restoredCount)
+			assert.Less(t,
+				database.GetSessionDataVersion("forked-i"),
+				db.CurrentDataVersion(),
+				"a restored fork must be eligible for source reparse",
+			)
+			_, hasDigest, err = database.GetProviderStatHash(
+				t.Context(), parser.AgentClaude, path,
+			)
+			require.NoError(t, err)
+			assert.False(t, hasDigest,
+				"restoring a fork must invalidate the source digest")
+
+			restoredSync := restarted.SyncAll(context.Background(), nil)
+			require.Zero(t, restoredSync.Failed)
+			assert.Equal(t, 2, restoredSync.Synced,
+				"restoring a fork must reparse the complete DAG")
+			assert.Equal(t, db.CurrentDataVersion(),
+				database.GetSessionDataVersion("forked-i"))
+		})
+	}
+}
+
+func newClaudeDAGBuilder(includeFork bool) *testjsonl.SessionBuilder {
+	builder := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:00Z", "start", "a", "",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:01Z", "ok", "b", "a",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:02Z", "main-2", "c", "b",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:03Z", "ok-2", "d", "c",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:04Z", "main-3", "e", "d",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:05Z", "ok-3", "f", "e",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:06Z", "main-4", "g", "f",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:07Z", "ok-4", "h", "g",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:08Z", "main-5", "k", "h",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:09Z", "ok-5", "l", "k",
+		)
+	if includeFork {
+		addClaudeDAGFork(builder)
+	}
+	return builder
+}
+
+func addClaudeDAGFork(builder *testjsonl.SessionBuilder) {
+	builder.AddClaudeUserWithUUID(
+		"2024-01-01T10:01:00Z", "fork", "i", "b",
+	).AddClaudeAssistantWithUUID(
+		"2024-01-01T10:01:01Z", "fork-ok", "j", "i",
+	)
 }

--- a/internal/sync/codebuff_integration_test.go
+++ b/internal/sync/codebuff_integration_test.go
@@ -1428,7 +1428,10 @@ func TestSyncCodebuffSingleSessionWritesProviderStatHash(t *testing.T) {
 //
 // The test does not depend on any Codebuff fixture; constructing an
 // engine with the default registry must produce a non-nil entry only
-// for Codebuff (and any future agent that opts in via the capability).
+// for the agents that opt in via the capability: Codebuff, plus the
+// content-hashing single-file providers (Claude, Codex, TraeX) whose
+// persisted stat digest spares a full-content fingerprint on every
+// fresh-process sweep.
 func TestSyncEngineProviderStatHashersRegistrationIsCapabilityGated(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -1443,22 +1446,27 @@ func TestSyncEngineProviderStatHashersRegistrationIsCapabilityGated(t *testing.T
 	})
 	t.Cleanup(engine.Close)
 
-	require.NotNil(t,
-		engine.ProviderStatHasher(parser.AgentCodebuff),
-		"Codebuff declares Source.MultiFileStatHash=Supported and "+
-			"must land in providerStatHashers; a nil here means the "+
-			"capability gate is missing or codebuffProviderCapabilities "+
-			"lost the override")
 	for _, agent := range []parser.AgentType{
+		parser.AgentCodebuff,
 		parser.AgentClaude,
 		parser.AgentCodex,
+		parser.AgentTraeX,
+	} {
+		require.NotNil(t, engine.ProviderStatHasher(agent),
+			"%s declares Source.MultiFileStatHash=Supported and "+
+				"must land in providerStatHashers; a nil here means the "+
+				"capability gate dropped it or its provider capabilities "+
+				"lost the override",
+			agent)
+	}
+	for _, agent := range []parser.AgentType{
 		parser.AgentRooCode,
 		parser.AgentKiloLegacy,
 		parser.AgentGemini,
 		parser.AgentCopilot,
 	} {
 		assert.Nil(t, engine.ProviderStatHasher(agent),
-			"%s is a single-file (non-multi-file) agent and must "+
+			"%s does not declare Source.MultiFileStatHash and must "+
 				"NOT be registered in providerStatHashers; a non-nil "+
 				"entry means the SourceSetProvider forwarding method "+
 				"is registering 0-returning stubs that would falsely "+

--- a/internal/sync/cwd_filter_test.go
+++ b/internal/sync/cwd_filter_test.go
@@ -148,6 +148,47 @@ func TestCollectAndBatchGatesParserExclusionsByCwdFilter(t *testing.T) {
 	})
 }
 
+func TestCollectAndBatchKeepsAllowedSourceSiblingCurrent(t *testing.T) {
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/allowed"},
+	})
+	results := make(chan syncJob, 1)
+	results <- syncJob{
+		agent: parser.AgentCowork,
+		path:  "/src/shared.jsonl",
+		processResult: processResult{results: []parser.ParseResult{
+			{Session: parser.ParsedSession{
+				ID: "cowork:allowed", Agent: parser.AgentCowork,
+				Machine: "local", Project: "proj", Cwd: "/allowed/repo",
+				File: parser.FileInfo{Path: "/src/shared.jsonl"},
+			}},
+			{Session: parser.ParsedSession{
+				ID: "cowork:filtered", Agent: parser.AgentCowork,
+				Machine: "local", Project: "proj", Cwd: "/outside/repo",
+				File: parser.FileInfo{Path: "/src/shared.jsonl"},
+			}},
+		}},
+	}
+	close(results)
+
+	stats := engine.collectAndBatch(
+		context.Background(), results, 1, 1, nil, syncWriteDefault,
+	)
+
+	assert.Equal(t, 1, stats.Synced)
+	assert.Equal(t, 1, stats.cwdFilteredSessions)
+	allowed, err := database.GetSession(context.Background(), "cowork:allowed")
+	require.NoError(t, err)
+	require.NotNil(t, allowed)
+	assert.Equal(t, db.CurrentDataVersion(), allowed.DataVersion,
+		"a sibling's cwd veto must not leave the allowed session stale")
+	filtered, err := database.GetSession(context.Background(), "cowork:filtered")
+	require.NoError(t, err)
+	assert.Nil(t, filtered)
+}
+
 func TestShouldAbortResyncSwap(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10462,17 +10462,25 @@ func (e *Engine) providerIncrementalContentChanged(
 // rule the provider's cold-write fingerprint uses. Codebuff/Freebuff
 // delegate to parser.CodebuffCompanionMtime, which is the single
 // source of truth for the max(chat, run-state, chat-meta) derivation;
-// other MultiFileStatHasher agents fall through to chat-only since
-// they have no sibling companions to fold in.
+// Codex folds session_index.jsonl exactly as its fingerprint stamps
+// file_mtime (parser.CodexEffectiveMtime), so a cold→warm cycle does
+// not drift; other MultiFileStatHasher agents fall through to
+// chat-only since they have no sibling companions to fold in.
 func providerStatFreshnessMtime(
 	agent parser.AgentType,
 	lookupPath string,
 	chatInfo os.FileInfo,
 ) int64 {
-	if agent != parser.AgentCodebuff && agent != parser.AgentFreebuff {
+	switch agent {
+	case parser.AgentCodebuff, parser.AgentFreebuff:
+		return parser.CodebuffCompanionMtime(lookupPath, chatInfo)
+	case parser.AgentCodex:
+		return parser.CodexEffectiveMtime(
+			lookupPath, chatInfo.ModTime().UnixNano(),
+		)
+	default:
 		return chatInfo.ModTime().UnixNano()
 	}
-	return parser.CodebuffCompanionMtime(lookupPath, chatInfo)
 }
 
 // providerFreshDigestSourceCurrentInDB reports whether the stored session

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8700,12 +8700,34 @@ func (e *Engine) processProviderFile(
 		)
 	}
 
+	// Persisted stat-digest skip. This runs before the single-session
+	// content guard below on purpose: a matching digest (size, mtime,
+	// ctime per component) plus a current stored row proves the source
+	// unchanged without opening it, so a fresh process (daemon restart or
+	// one-shot CLI sync) skips on stats alone instead of re-hashing the
+	// full transcript through providerIncrementalContentChanged. Any real
+	// change -- including a same-size same-mtime in-place rewrite --
+	// bumps a ctime and breaks the digest, falling through to the
+	// content-verified gates.
+	if freshMtime, fresh := e.providerSourceFreshBeforeFingerprint(
+		ctx, source, file, preParseStatHash,
+	); fresh {
+		return processResult{
+			skip:  true,
+			mtime: freshMtime,
+		}, true
+	}
+
 	// DB-freshness skip for single-session JSONL providers (Claude):
 	// when the stored session's size, mtime, and data version already
 	// match the source and its project does not need reparse, skip the
 	// parse entirely. This reproduces the legacy process arm's
 	// shouldSkipFile gate so an unchanged session is not re-parsed on
-	// every full sync.
+	// every full sync. A content-verified skip confirmed the current
+	// bytes against the stored row hash, so it backfills the stat digest
+	// for rows that predate the side-table (or whose digest an index or
+	// companion touch invalidated); without the stamp those rows would
+	// re-hash on every fresh process forever, since a skip never writes.
 	sourceForceReplace := false
 	if mtime, fresh, forceReplace, contentVerified := e.providerSingleSessionFresh(
 		ctx, provider, source, file,
@@ -8713,6 +8735,11 @@ func (e *Engine) processProviderFile(
 		if !verifiedStateOK || contentVerified {
 			if verifiedStateOK {
 				e.promoteVerifiedSource(verifiedCapture)
+			}
+			if contentVerified {
+				e.stampProviderStatHashForConfirmedSource(
+					ctx, preParseStatHash,
+				)
 			}
 			return processResult{
 				skip:  true,
@@ -8725,14 +8752,6 @@ func (e *Engine) processProviderFile(
 		// ever earning verified-source trust.
 	} else if forceReplace {
 		sourceForceReplace = true
-	}
-	if freshMtime, fresh := e.providerSourceFreshBeforeFingerprint(
-		ctx, source, file, preParseStatHash,
-	); fresh {
-		return processResult{
-			skip:  true,
-			mtime: freshMtime,
-		}, true
 	}
 
 	// Watermark-only shared-container sources (changed-path classification)
@@ -8783,12 +8802,13 @@ func (e *Engine) processProviderFile(
 			// self-healing (e.g. a parser data-version bump or generated
 			// roborev CI worktree project): clear the entry and fall through
 			// to a full reparse, mirroring the legacy process arm.
-			if !e.providerSkipCacheEntryFreshInDB(
+			cacheFresh, cacheRowHashVerified := e.providerSkipCacheEntryFreshInDB(
 				file,
 				source,
 				fingerprint,
 				providerSemantics,
-			) {
+			)
+			if !cacheFresh {
 				e.clearSkip(cacheKey)
 			} else if e.pathNeedsCachedSkipBypass(file.Agent, file.Path) {
 				e.clearSkip(cacheKey)
@@ -8839,6 +8859,16 @@ func (e *Engine) processProviderFile(
 							file, fingerprint, providerSemantics,
 						) {
 						e.promoteVerifiedSource(verifiedCapture)
+					}
+					// The fingerprint just content-hashed the current
+					// source and matched the stored row, so this skip may
+					// backfill or refresh the stat digest for rows that
+					// predate the side-table or whose digest a shared
+					// index touch invalidated.
+					if cacheRowHashVerified {
+						e.stampProviderStatHashForConfirmedSource(
+							ctx, preParseStatHash,
+						)
 					}
 					return processResult{
 						skip:      true,
@@ -8893,6 +8923,14 @@ func (e *Engine) processProviderFile(
 		if verifiedStateOK {
 			e.promoteVerifiedSource(verifiedCapture)
 		}
+		// The Codex-family fingerprint content-hashed the rollout and
+		// shouldSkipCodexFingerprint verified it against the stored row
+		// (hash, project, data version, index title), so this skip may
+		// backfill or refresh the stat digest: rows that predate the
+		// side-table, and rollouts whose digest a shared index touch
+		// invalidated without changing their own title, would otherwise
+		// re-hash on every fresh process forever.
+		e.stampProviderStatHashForConfirmedSource(ctx, preParseStatHash)
 		return processResult{
 			skip:        true,
 			mtime:       fingerprint.MTimeNS,
@@ -9664,19 +9702,26 @@ func providerProcessCacheKeyWithHash(
 	return key + "?source_hash=" + fingerprint.Hash
 }
 
+// providerSkipCacheEntryFreshInDB reports whether a skip-cache hit is
+// still consistent with the archive. rowHashVerified additionally reports
+// that the current fingerprint's content hash was compared against a
+// stored session row and matched -- the only cache outcome strong enough
+// to stamp a provider_freshness digest, since the other fresh returns
+// (hash-free semantics, whole-container identity, no stored row yet)
+// never consult a row.
 func (e *Engine) providerSkipCacheEntryFreshInDB(
 	file parser.DiscoveredFile,
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
 	providerSemantics parser.ProviderSyncSemantics,
-) bool {
+) (fresh, rowHashVerified bool) {
 	agent := file.Agent
 	if agent == "" {
 		agent = source.Provider
 	}
 	if fingerprint.Hash == "" ||
 		!providerSemantics.FingerprintHashRequiredForFreshness {
-		return true
+		return true, false
 	}
 	if parser.IsOmnigentContainerSource(source) {
 		// A whole-container omnigent source has only virtual member rows in
@@ -9686,7 +9731,7 @@ func (e *Engine) providerSkipCacheEntryFreshInDB(
 		// ProviderSyncSemantics.SkipCacheFreshWithoutStoredRow below, which
 		// trusts an entry only while NO row exists yet and resumes stored-row
 		// hash validation once the provider persists one.
-		return true
+		return true, false
 	}
 	lookupPath := providerSkipLookupPath(file, source, fingerprint)
 	if e.pathRewriter != nil {
@@ -9702,13 +9747,14 @@ func (e *Engine) providerSkipCacheEntryFreshInDB(
 			// mtime/source-signal based until a row exists: a same-mtime rewrite
 			// cannot be distinguished in this no-row state. Hash validation applies
 			// once a session has actually been stored.
-			return true
+			return true, false
 		}
 	}
-	return e.providerFingerprintHashMatchesDB(
+	matched := e.providerFingerprintHashMatchesDB(
 		agent, lookupPath, fingerprint,
 		providerSemantics.FingerprintHashRequiredForFreshness,
 	)
+	return matched, matched
 }
 
 func processFileUsesProvider(agent parser.AgentType) bool {
@@ -10199,12 +10245,14 @@ func (e *Engine) providerSourceUnchangedInDB(
 }
 
 // stampProviderStatHashForConfirmedSource persists the pre-parse
-// per-component stat digest for a source whose provider.Fingerprint was
-// just verified against an existing current session row (the
-// providerSourceUnchangedInDB skip). This is the only pre-write moment a
-// digest may safely be written: a transient failure between an eager stamp
-// and the fingerprint/parse/write that follows would leave a matching
-// digest that permanently suppresses every later retry. The digest is the
+// per-component stat digest for a source whose current content was just
+// verified against an existing current session row: the Claude
+// content-verified single-session skip, the hash-validated cache skip,
+// the Codex-family DB-fingerprint skip, and providerSourceUnchangedInDB.
+// These are the only pre-write moments a digest may safely be written: a
+// transient failure between an eager stamp and the fingerprint/parse/write
+// that follows would leave a matching digest that permanently suppresses
+// every later retry. The digest is the
 // pre-parse snapshot captured in processProviderFile, so it describes
 // exactly the file state the fingerprint verified, and the DB key uses the
 // pathRewriter's logical key, mirroring the write path. Providers without
@@ -10483,21 +10531,52 @@ func providerStatFreshnessMtime(
 	}
 }
 
+// providerFreshnessAgents returns the stored-agent labels a provider's
+// sessions may carry for digest-currency checks. Codebuff relabels
+// free-tier sessions to Freebuff while discovery and the
+// provider_freshness side-table stay keyed on Codebuff, so both labels
+// are this provider's own rows; every other hasher stores under its
+// discovery label.
+func providerFreshnessAgents(agent parser.AgentType) []parser.AgentType {
+	if agent == parser.AgentCodebuff {
+		return []parser.AgentType{parser.AgentCodebuff, parser.AgentFreebuff}
+	}
+	return []parser.AgentType{agent}
+}
+
 // providerFreshDigestSourceCurrentInDB reports whether the stored session
 // row for a digest-matched source is still current: the row exists, its
 // data version is current, and it does not need a project reparse. A
 // matching provider_freshness digest proves only that the file stat is
 // unchanged; these checks are what allow the digest short-circuit to skip
-// safely, mirroring the tail guards of providerSourceUnchangedInDB.
-func (e *Engine) providerFreshDigestSourceCurrentInDB(lookupPath string) bool {
-	if _, _, ok := e.db.GetFileInfoByPath(lookupPath); !ok {
-		return false
+// safely, mirroring the tail guards of providerSourceUnchangedInDB. Every
+// lookup is scoped to the provider's own stored-agent labels: Codex and
+// TraeX can index the same rollout path, and a path-only lookup would let
+// this agent's skip borrow the other agent's newer row and hide a repair
+// (e.g. a stale generated project) on its own row.
+func (e *Engine) providerFreshDigestSourceCurrentInDB(
+	agent parser.AgentType, lookupPath string,
+) bool {
+	rowFound := false
+	for _, owned := range providerFreshnessAgents(agent) {
+		if _, _, ok := e.db.GetFileInfoByAgentPath(
+			lookupPath, string(owned),
+		); !ok {
+			continue
+		}
+		rowFound = true
+		if project, ok := e.db.GetProjectByAgentPath(
+			lookupPath, string(owned),
+		); ok && parser.NeedsProjectReparse(project) {
+			return false
+		}
+		if e.db.GetDataVersionByAgentPath(
+			lookupPath, string(owned),
+		) < db.CurrentDataVersion() {
+			return false
+		}
 	}
-	if project, ok := e.db.GetProjectByPath(lookupPath); ok &&
-		parser.NeedsProjectReparse(project) {
-		return false
-	}
-	return e.db.GetDataVersionByPath(lookupPath) >= db.CurrentDataVersion()
+	return rowFound
 }
 
 func (e *Engine) providerSourceFreshBeforeFingerprint(
@@ -10542,10 +10621,13 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 	// cancel out in sum-of-sizes). The side-table is populated
 	// only after an outcome the engine can trust: a successful
 	// write's flushPending, a single-session writeSessionFull
-	// commit, or the DB-confirmed unchanged skip in processFile
-	// (stampProviderStatHashForConfirmedSource, which runs only
-	// after the current fingerprint was verified against an
-	// existing current session row). Nothing here ever persists
+	// commit, or a confirmed-unchanged skip in processProviderFile
+	// (stampProviderStatHashForConfirmedSource at the Claude
+	// content-verified skip, the hash-validated cache skip, the
+	// Codex-family DB-fingerprint skip, and
+	// providerSourceUnchangedInDB — each runs only after the
+	// current source content was verified against an existing
+	// current session row). Nothing here ever persists
 	// the digest before fingerprinting, parsing, or session
 	// writing succeeds — a transient failure must not leave a
 	// matching digest that suppresses every later retry.
@@ -10579,10 +10661,13 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 			// old cold-stamp): a transient failure after the stamp
 			// would leave a matching digest that suppresses every
 			// later retry. Instead the loop is closed at the
-			// DB-confirmed unchanged skip in processFile, which runs
-			// after provider.Fingerprint verified the current source
-			// against an existing current session row — the only
-			// pre-write moment the digest may safely be persisted.
+			// confirmed-unchanged skips in processProviderFile
+			// (Claude content-verified, hash-validated cache,
+			// Codex-family DB-fingerprint, providerSourceUnchangedInDB),
+			// each of which runs only after the current source content
+			// was verified against an existing current session row —
+			// the only pre-write moments the digest may safely be
+			// persisted.
 			// A genuinely new or changed source flows through a
 			// successful write whose flushPending (or writeSessionFull)
 			// persists the digest; CWD-filtered sources stay absent
@@ -10609,7 +10694,9 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 			// because this short-circuit never reaches fingerprinting or
 			// parsing. Defer to the fingerprint path whenever the stored
 			// row is missing, stale, or needs project reclassification.
-			if !e.providerFreshDigestSourceCurrentInDB(lookupPath) {
+			if !e.providerFreshDigestSourceCurrentInDB(
+				file.Agent, lookupPath,
+			) {
 				return 0, false
 			}
 			return providerStatFreshnessMtime(file.Agent, lookupPath, info), true

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10825,6 +10825,12 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 	// writing succeeds — a transient failure must not leave a
 	// matching digest that suppresses every later retry.
 	if preParseStatHash != nil {
+		// Zero is the hasher's unverified sentinel. Do not consult the
+		// side-table: even a corrupt or legacy zero row must not turn an
+		// unavailable change-time into trusted freshness.
+		if preParseStatHash.digest == 0 {
+			return 0, false
+		}
 		stored, hasStored, hashErr :=
 			e.db.GetProviderStatHash(ctx, file.Agent, lookupPath)
 		switch {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -993,6 +993,27 @@ func (e *Engine) clearProviderSourceFreshness(
 	}
 }
 
+// partitionIntentionalSourceSkips separates active source members from rows
+// that user policy permanently excludes or keeps in trash. Those policy skips
+// already resolve the member for source freshness and must not make active
+// Claude DAG branches stale.
+func (e *Engine) partitionIntentionalSourceSkips(
+	ids []string,
+) (active []string, skipped map[string]bool) {
+	active = make([]string, 0, len(ids))
+	for _, id := range ids {
+		if e.db.IsSessionExcluded(id) || e.db.IsSessionTrashed(id) {
+			if skipped == nil {
+				skipped = make(map[string]bool)
+			}
+			skipped[id] = true
+			continue
+		}
+		active = append(active, id)
+	}
+	return active, skipped
+}
+
 // migrateLegacyCodexExecSkips removes skip cache entries
 // created by older agentsview builds that excluded Codex exec
 // sessions from bulk sync. The scrub runs once per database:
@@ -7822,11 +7843,13 @@ func (e *Engine) collectAndBatch(
 					failedSessions:  failedSessions,
 					cwdFiltered:     cwdFiltered,
 					written:         make([]bool, len(pending)),
+					resolved:        make([]bool, len(pending)),
 				}
 				if failedSessions == 0 && cwdFiltered == 0 &&
 					writtenSessions == len(pending) {
 					for i := range outcome.written {
 						outcome.written[i] = true
+						outcome.resolved[i] = true
 					}
 				}
 			} else {
@@ -7834,9 +7857,9 @@ func (e *Engine) collectAndBatch(
 			}
 			// Claude can emit several session rows from one DAG transcript.
 			// Those rows are initially written below the current data version,
-			// then promoted together only after every member succeeds. A crash,
-			// veto, or failed member therefore cannot make the primary row hide
-			// unfinished forks on the next pass.
+			// then promoted together only after every active member succeeds.
+			// User-excluded and trashed members are already resolved by policy;
+			// a crash, veto, or failed active member still leaves the source stale.
 			for i, pw := range pending {
 				if pw.sourceWriteCount == 0 {
 					continue
@@ -7845,13 +7868,23 @@ func (e *Engine) collectAndBatch(
 				sourceComplete := pw.sourceCompletionEligible &&
 					end <= len(pending) && end <= len(outcome.written)
 				for j := i; j < min(end, len(pending)); j++ {
-					if j >= len(outcome.written) || !outcome.written[j] {
+					memberResolved := pending[j].sourceCompletionSkipped
+					if j < len(outcome.written) && outcome.written[j] {
+						memberResolved = true
+					}
+					if j < len(outcome.resolved) && outcome.resolved[j] {
+						memberResolved = true
+					}
+					if !memberResolved {
 						sourceComplete = false
 					}
 				}
 				if sourceComplete && pw.promoteSourceOnComplete {
 					ids := make([]string, 0, pw.sourceWriteCount)
 					for j := i; j < end; j++ {
+						if !outcome.written[j] {
+							continue
+						}
 						ids = append(ids, applyIDPrefixToID(
 							e.idPrefix, pending[j].sess.ID,
 						))
@@ -8016,10 +8049,14 @@ func (e *Engine) collectAndBatch(
 			continue
 		}
 		claudeDAG := r.agent == parser.AgentClaude && len(r.results) > 1
+		var sourceCompletionSkipped map[string]bool
 		if claudeDAG {
+			activeResultIDs, skipped :=
+				e.partitionIntentionalSourceSkips(resultIDs)
+			sourceCompletionSkipped = skipped
 			staleVersion := max(db.CurrentDataVersion()-1, 0)
 			if err := e.db.SetExistingSessionDataVersions(
-				resultIDs, staleVersion,
+				activeResultIDs, staleVersion,
 			); err != nil {
 				e.clearProviderSourceFreshness(ctx, r.providerStatHash)
 				log.Printf("stage Claude source data versions: %v", err)
@@ -8186,15 +8223,16 @@ func (e *Engine) collectAndBatch(
 					r.needsRetryForSession(pr.Session.ID)
 				needsRetry := sessionNeedsRetry || claudeDAG
 				pw := pendingWrite{
-					sess:              pr.Session,
-					msgs:              pr.Messages,
-					usageEvents:       pr.UsageEvents,
-					needsRetry:        needsRetry,
-					forceReplace:      r.forceReplace,
-					baselineEligible:  !sessionNeedsRetry,
-					storageTrustPath:  r.storageTrustPath,
-					storageTrustState: r.storageTrustState,
-					storageTrustSnap:  r.storageTrustSnap,
+					sess:                    pr.Session,
+					msgs:                    pr.Messages,
+					usageEvents:             pr.UsageEvents,
+					needsRetry:              needsRetry,
+					forceReplace:            r.forceReplace,
+					baselineEligible:        !sessionNeedsRetry,
+					storageTrustPath:        r.storageTrustPath,
+					storageTrustState:       r.storageTrustState,
+					storageTrustSnap:        r.storageTrustSnap,
+					sourceCompletionSkipped: sourceCompletionSkipped[applyIDPrefixToID(e.idPrefix, pr.Session.ID)],
 				}
 				if i == 0 &&
 					(r.agent == parser.AgentClaude || r.providerStatHash != nil) {
@@ -8398,6 +8436,7 @@ type incrementalUpdate struct {
 	peakContextTokens    int // absolute max(old, new)
 	hasTotalOutputTokens bool
 	hasPeakContextTokens bool
+	providerStatHash     *pendingProviderStatHash
 }
 
 // sessionParseError is a per-session parse failure inside a shared
@@ -9005,6 +9044,10 @@ func (e *Engine) processProviderFile(
 		incRes.mtime = fingerprint.MTimeNS
 		incRes.cacheSkip = cacheSkip
 		incRes.cacheKey = cacheKey
+		if incRes.incremental != nil &&
+			incRes.incremental.fileSize == fingerprint.Size {
+			incRes.incremental.providerStatHash = preParseStatHash
+		}
 		return incRes, true
 	}
 	incForceReplace := sourceForceReplace || incRes.forceReplace
@@ -12200,6 +12243,9 @@ type pendingWrite struct {
 	sourceWriteCount         int
 	sourceCompletionEligible bool
 	promoteSourceOnComplete  bool
+	// sourceCompletionSkipped marks a user-excluded or trashed member that
+	// resolves source completeness without requiring a write or promotion.
+	sourceCompletionSkipped bool
 	// storageTrustPath/State/Snap promote the session's OpenCode
 	// storage-gate trust after its batch is confirmed fully written.
 	// Empty for everything else.
@@ -12347,6 +12393,9 @@ type writeBatchOutcome struct {
 	failedSessions  int
 	cwdFiltered     int
 	written         []bool
+	// resolved includes actual writes plus user-excluded or trashed sessions.
+	// It stays separate from written so stats and baselines count real writes.
+	resolved []bool
 }
 
 type skipCacheWrite struct {
@@ -12642,7 +12691,10 @@ func (e *Engine) writeBatchWithOutcome(
 	)
 	if err != nil {
 		log.Printf("normalize pending write machines: %v", err)
-		outcome := writeBatchOutcome{written: make([]bool, len(batch))}
+		outcome := writeBatchOutcome{
+			written:  make([]bool, len(batch)),
+			resolved: make([]bool, len(batch)),
+		}
 		for _, pw := range batch {
 			e.markStaleFailedMemberWrite(pw)
 		}
@@ -12654,7 +12706,10 @@ func (e *Engine) writeBatchWithOutcome(
 	)
 	if err != nil {
 		log.Printf("preserve unavailable source projects: %v", err)
-		outcome := writeBatchOutcome{written: make([]bool, len(batch))}
+		outcome := writeBatchOutcome{
+			written:  make([]bool, len(batch)),
+			resolved: make([]bool, len(batch)),
+		}
 		for _, pw := range batch {
 			e.markStaleFailedMemberWrite(pw)
 		}
@@ -12665,7 +12720,10 @@ func (e *Engine) writeBatchWithOutcome(
 		return e.writeBatchBulkWithOutcome(batch, forceReplace)
 	}
 
-	outcome := writeBatchOutcome{written: make([]bool, len(batch))}
+	outcome := writeBatchOutcome{
+		written:  make([]bool, len(batch)),
+		resolved: make([]bool, len(batch)),
+	}
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
 	for i, pw := range batch {
 		s, msgs, verdict := e.prepareSessionWrite(
@@ -12698,6 +12756,7 @@ func (e *Engine) writeBatchWithOutcome(
 			e.upsertSessionPendingContentForWrite(pw, s)
 		if err != nil {
 			if isIntentionalSessionSkip(err) {
+				outcome.resolved[i] = true
 				if pw.sess.File.Path != "" {
 					e.cacheSkip(
 						pw.sess.File.Path,
@@ -12781,6 +12840,7 @@ func (e *Engine) writeBatchWithOutcome(
 		outcome.writtenSessions++
 		outcome.writtenMessages += len(msgs)
 		outcome.written[i] = true
+		outcome.resolved[i] = true
 	}
 	return outcome
 }
@@ -13617,11 +13677,15 @@ type localGitIdentity struct {
 func (e *Engine) writeBatchBulkWithOutcome(
 	batch []pendingWrite, forceReplace bool,
 ) writeBatchOutcome {
-	outcome := writeBatchOutcome{written: make([]bool, len(batch))}
+	outcome := writeBatchOutcome{
+		written:  make([]bool, len(batch)),
+		resolved: make([]bool, len(batch)),
+	}
 	writes := make([]db.SessionBatchWrite, 0, len(batch))
 	pendingIndexes := make([]int, 0, len(batch))
 	sources := make(map[string]batchSourceFile, len(batch))
 	pendingByID := make(map[string]pendingWrite, len(batch))
+	pendingIndexByID := make(map[string]int, len(batch))
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
 
 	for pendingIndex, pw := range batch {
@@ -13658,6 +13722,7 @@ func (e *Engine) writeBatchBulkWithOutcome(
 		})
 		pendingIndexes = append(pendingIndexes, pendingIndex)
 		pendingByID[s.ID] = pw
+		pendingIndexByID[s.ID] = pendingIndex
 		if pw.sess.File.Path != "" {
 			sources[s.ID] = batchSourceFile{
 				path:        pw.sess.File.Path,
@@ -13686,7 +13751,9 @@ func (e *Engine) writeBatchBulkWithOutcome(
 	}
 	for _, writtenIndex := range result.WrittenIndexes {
 		if writtenIndex >= 0 && writtenIndex < len(pendingIndexes) {
-			outcome.written[pendingIndexes[writtenIndex]] = true
+			pendingIndex := pendingIndexes[writtenIndex]
+			outcome.written[pendingIndex] = true
+			outcome.resolved[pendingIndex] = true
 		}
 	}
 	for _, id := range result.FailedIDs {
@@ -13695,6 +13762,9 @@ func (e *Engine) writeBatchBulkWithOutcome(
 		}
 	}
 	for _, id := range result.ExcludedIDs {
+		if pendingIndex, ok := pendingIndexByID[id]; ok {
+			outcome.resolved[pendingIndex] = true
+		}
 		if source, ok := sources[id]; ok && source.path != "" {
 			e.cacheSkip(
 				source.path, source.mtime, source.fingerprint,
@@ -14369,6 +14439,11 @@ func (e *Engine) writeIncremental(
 	// errors are logged inside recomputeSignalsFromDB and are
 	// non-fatal; a later write or flush retries.
 	e.signalSched.markDirty(inc.sessionID)
+	if inc.providerStatHash != nil {
+		e.recordProviderStatHash(
+			context.Background(), *inc.providerStatHash,
+		)
+	}
 
 	return nil
 }
@@ -15845,10 +15920,14 @@ func (e *Engine) processAndWriteSessionFile(
 		return false, fmt.Errorf("queue subagent parent repairs: %w", err)
 	}
 	claudeDAG := file.Agent == parser.AgentClaude && len(res.results) > 1
+	var sourceCompletionSkipped map[string]bool
 	if claudeDAG {
+		activeResultIDs, skipped :=
+			e.partitionIntentionalSourceSkips(resultIDs)
+		sourceCompletionSkipped = skipped
 		staleVersion := max(db.CurrentDataVersion()-1, 0)
 		if err := e.db.SetExistingSessionDataVersions(
-			resultIDs, staleVersion,
+			activeResultIDs, staleVersion,
 		); err != nil {
 			e.clearProviderSourceFreshness(ctx, res.providerStatHash)
 			return false, fmt.Errorf(
@@ -15954,7 +16033,8 @@ func (e *Engine) processAndWriteSessionFile(
 
 	sourceNeedsRetry := res.providerFailureCount > 0 ||
 		len(res.retrySessionIDs) > 0
-	written := 0
+	resolved := 0
+	writtenIDs := make([]string, 0, len(res.results))
 	markSourceIncomplete := func() {
 		if file.Agent == parser.AgentClaude {
 			e.clearProviderSourceFreshness(ctx, res.providerStatHash)
@@ -15983,16 +16063,21 @@ func (e *Engine) processAndWriteSessionFile(
 		}
 		repairQueued = true
 		writeErr := e.writeSessionFull(write)
+		memberPolicySkipped := sourceCompletionSkipped[resultIDs[i]]
 		// Full-write stages commit independently. Message content (and a new
 		// spawn edge) can persist even when a later usage, data-version, or
 		// sibling write fails, so discover and queue children after every
 		// attempt rather than waiting for the entire result set to finish.
 		queueErr := queueWrittenChildren([]string{resultIDs[i]})
 		if writeErr == nil {
-			written++
+			resolved++
+			writtenIDs = append(writtenIDs, resultIDs[i])
+		} else if isIntentionalSessionSkip(writeErr) || memberPolicySkipped {
+			resolved++
 		}
 		if writeErr != nil &&
 			!isIntentionalSessionSkip(writeErr) &&
+			!memberPolicySkipped &&
 			!errors.Is(writeErr, errSessionPreserved) {
 			// Mirror the batch write paths: a partial write (session
 			// row updated, messages or usage not) must demote the
@@ -16010,14 +16095,15 @@ func (e *Engine) processAndWriteSessionFile(
 			markSourceIncomplete()
 			return false, queueErr
 		}
-		if errors.Is(writeErr, errSessionPreserved) {
+		if !memberPolicySkipped && errors.Is(writeErr, errSessionPreserved) {
 			preserved = true
 		}
 	}
-	// A source-level digest is valid only when every emitted result and its
-	// hierarchy links committed without retry state or archive preservation.
-	// Claude DAG members remain stale until that source-level decision succeeds.
-	sourceComplete := written == len(res.results) &&
+	// A source-level digest is valid only when every active result and its
+	// hierarchy links commit without retry state or archive preservation.
+	// User-excluded and trashed members are resolved without writes; the other
+	// Claude DAG members stay stale until the source-level decision succeeds.
+	sourceComplete := resolved == len(res.results) &&
 		!preserved && !sourceNeedsRetry
 	if !sourceComplete {
 		markSourceIncomplete()
@@ -16028,7 +16114,7 @@ func (e *Engine) processAndWriteSessionFile(
 	}
 	if sourceComplete && claudeDAG {
 		if err := e.db.SetSessionDataVersions(
-			resultIDs, db.CurrentDataVersion(),
+			writtenIDs, db.CurrentDataVersion(),
 		); err != nil {
 			markSourceIncomplete()
 			return false, fmt.Errorf(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -973,6 +973,26 @@ func providerStatHashMetadataVerified(hash pendingProviderStatHash) bool {
 	return true
 }
 
+// clearProviderSourceFreshness removes a digest that no longer represents a
+// completely committed provider source. Claude DAG members are written stale
+// up front, so correctness does not depend on cleanup succeeding after a
+// partial write.
+func (e *Engine) clearProviderSourceFreshness(
+	ctx context.Context,
+	statHash *pendingProviderStatHash,
+) {
+	if statHash != nil {
+		if err := e.db.DeleteProviderStatHash(
+			ctx, statHash.agent, statHash.targetKey,
+		); err != nil {
+			log.Printf(
+				"delete incomplete provider freshness for %s/%s: %v",
+				statHash.agent, statHash.targetKey, err,
+			)
+		}
+	}
+}
+
 // migrateLegacyCodexExecSkips removes skip cache entries
 // created by older agentsview builds that excluded Codex exec
 // sessions from bulk sync. The scrub runs once per database:
@@ -7812,6 +7832,51 @@ func (e *Engine) collectAndBatch(
 			} else {
 				outcome = e.writeBatchWithOutcome(pending, writeMode, false)
 			}
+			// Claude can emit several session rows from one DAG transcript.
+			// Those rows are initially written below the current data version,
+			// then promoted together only after every member succeeds. A crash,
+			// veto, or failed member therefore cannot make the primary row hide
+			// unfinished forks on the next pass.
+			for i, pw := range pending {
+				if pw.sourceWriteCount == 0 {
+					continue
+				}
+				end := i + pw.sourceWriteCount
+				sourceComplete := pw.sourceCompletionEligible &&
+					end <= len(pending) && end <= len(outcome.written)
+				for j := i; j < min(end, len(pending)); j++ {
+					if j >= len(outcome.written) || !outcome.written[j] {
+						sourceComplete = false
+					}
+				}
+				if sourceComplete && pw.promoteSourceOnComplete {
+					ids := make([]string, 0, pw.sourceWriteCount)
+					for j := i; j < end; j++ {
+						ids = append(ids, applyIDPrefixToID(
+							e.idPrefix, pending[j].sess.ID,
+						))
+					}
+					if err := e.db.SetSessionDataVersions(
+						ids, db.CurrentDataVersion(),
+					); err != nil {
+						log.Printf(
+							"complete provider source data versions: %v", err,
+						)
+						sourceComplete = false
+						outcome.failedSessions++
+						for j := i; j < end; j++ {
+							outcome.written[j] = false
+						}
+					}
+				}
+				if !sourceComplete {
+					e.clearProviderSourceFreshness(ctx, pw.providerStatHash)
+					continue
+				}
+				if pw.providerStatHash != nil {
+					e.recordProviderStatHash(ctx, *pw.providerStatHash)
+				}
+			}
 			baselineErr := e.baselinePendingWriteSources(
 				ctx, pending, outcome.written,
 			)
@@ -7840,30 +7905,6 @@ func (e *Engine) collectAndBatch(
 			stats.cwdFilteredSessions += outcome.cwdFiltered
 			progress.MessagesIndexed += outcome.writtenMessages
 			stats.messagesIndexed = progress.MessagesIndexed
-			// Persist per-component freshness digests for the per-row
-			// entries whose write succeeded. outcome.written[i]
-			// is the authoritative per-source success flag:
-			// writeBatchWithOutcome sets it to false for any row
-			// that was CWD-filtered or whose session upsert failed,
-			// so a single failing row in a mixed batch correctly
-			// suppresses only its own digest persist. Successful
-			// rows in the same batch still get their digests
-			// stamped; a pendingStatHash source whose whole session
-			// row committed is exactly the invariant the side-table
-			// needs to recognize on the next warm pass. A pending
-			// row with no matching written entry fails closed:
-			// without a per-row success flag the write cannot be
-			// confirmed, and an unconfirmed digest persist could
-			// mark an absent session as fresh forever.
-			for i, pw := range pending {
-				if pw.providerStatHash == nil {
-					continue
-				}
-				if i >= len(outcome.written) || !outcome.written[i] {
-					continue
-				}
-				e.recordProviderStatHash(ctx, *pw.providerStatHash)
-			}
 		}()
 		pending = pending[:0]
 		pendingLeases = pendingLeases[:0]
@@ -7973,6 +8014,20 @@ func (e *Engine) collectAndBatch(
 			e.noteSQLiteContainerResult(r.path, false)
 			r.releaseRetention()
 			continue
+		}
+		claudeDAG := r.agent == parser.AgentClaude && len(r.results) > 1
+		if claudeDAG {
+			staleVersion := max(db.CurrentDataVersion()-1, 0)
+			if err := e.db.SetExistingSessionDataVersions(
+				resultIDs, staleVersion,
+			); err != nil {
+				e.clearProviderSourceFreshness(ctx, r.providerStatHash)
+				log.Printf("stage Claude source data versions: %v", err)
+				stats.RecordFailed()
+				e.noteSQLiteContainerResult(r.path, false)
+				r.releaseRetention()
+				continue
+			}
 		}
 		excludedSessionIDs, err := e.deleteParserExcludedSessions(
 			r.processResult, sourceAllowsParserExclusions,
@@ -8094,6 +8149,7 @@ func (e *Engine) collectAndBatch(
 			r.path, vetoed == 0 && len(r.retrySessionIDs) == 0,
 		)
 		if vetoed > 0 && len(allowed) == 0 {
+			e.clearProviderSourceFreshness(ctx, r.providerStatHash)
 			stats.cwdFilteredFiles++
 			if r.providerFailureCount == 0 {
 				baselineProcessedSource(r, false)
@@ -8123,27 +8179,36 @@ func (e *Engine) collectAndBatch(
 			stats.messagesIndexed = progress.MessagesIndexed
 			r.releaseRetention()
 		} else {
+			sourceNeedsRetry := vetoed > 0 ||
+				r.providerFailureCount > 0 || len(r.retrySessionIDs) > 0
 			for i, pr := range allowed {
-				needsRetry := r.providerFailureCount > 0 ||
+				sessionNeedsRetry := sourceNeedsRetry ||
 					r.needsRetryForSession(pr.Session.ID)
+				needsRetry := sessionNeedsRetry || claudeDAG
 				pw := pendingWrite{
 					sess:              pr.Session,
 					msgs:              pr.Messages,
 					usageEvents:       pr.UsageEvents,
 					needsRetry:        needsRetry,
 					forceReplace:      r.forceReplace,
-					baselineEligible:  vetoed == 0 && r.providerFailureCount == 0 && !needsRetry,
+					baselineEligible:  !sessionNeedsRetry,
 					storageTrustPath:  r.storageTrustPath,
 					storageTrustState: r.storageTrustState,
 					storageTrustSnap:  r.storageTrustSnap,
 				}
-				// The source's per-component digest (providerStatHash) is
-				// a one-row side-table entry keyed by (agent, file_path),
-				// so tagging only the first allowed result is enough.
-				// The flush path below persists it after the matching
-				// session row commits successfully.
-				if i == 0 && r.providerStatHash != nil {
+				if i == 0 &&
+					(r.agent == parser.AgentClaude || r.providerStatHash != nil) {
+					// Claude can emit several DAG branches from one transcript.
+					// Carry their contiguous write count so the flush can make
+					// one source-level completion decision. Other digest-backed
+					// providers currently emit one result per source.
+					pw.sourceWriteCount = 1
+					if r.agent == parser.AgentClaude {
+						pw.sourceWriteCount = len(allowed)
+					}
 					pw.providerStatHash = r.providerStatHash
+					pw.sourceCompletionEligible = !sourceNeedsRetry
+					pw.promoteSourceOnComplete = claudeDAG
 				}
 				pending = append(pending, pw)
 				if runtimeMetrics != nil {
@@ -8154,7 +8219,7 @@ func (e *Engine) collectAndBatch(
 				pendingLeases = append(pendingLeases, r.retentionLease)
 				r.retentionLease = nil
 			}
-			if r.cacheAfterWrite && vetoed == 0 && len(r.retrySessionIDs) == 0 {
+			if r.cacheAfterWrite && !sourceNeedsRetry {
 				pendingCacheWrites = append(pendingCacheWrites, skipCacheWrite{
 					agent:             r.agent,
 					key:               r.skipCacheKey(),
@@ -12127,12 +12192,14 @@ type pendingWrite struct {
 	// outcome is safe to make deletion-eligible after this write succeeds.
 	baselineEligible bool
 	// providerStatHash is set on the first allowed ParseResult of a
-	// source whose processResult staged a per-component freshness
-	// digest. The flush path persists it after the matching session
-	// row commits successfully, so a downstream write failure or a
-	// CWD-filter veto never marks an absent or stale session as
-	// fresh. nil when the source is not a multi-file hasher agent.
-	providerStatHash *pendingProviderStatHash
+	// source whose processResult staged a per-component freshness digest.
+	// sourceWriteCount tells the flush how many contiguous results must commit
+	// before it may persist the digest. Claude uses the full DAG result count;
+	// other digest-backed providers currently use one.
+	providerStatHash         *pendingProviderStatHash
+	sourceWriteCount         int
+	sourceCompletionEligible bool
+	promoteSourceOnComplete  bool
 	// storageTrustPath/State/Snap promote the session's OpenCode
 	// storage-gate trust after its batch is confirmed fully written.
 	// Empty for everything else.
@@ -15777,6 +15844,18 @@ func (e *Engine) processAndWriteSessionFile(
 	if err := e.db.QueueSubagentParentCleanupRepairs(priorChildren); err != nil {
 		return false, fmt.Errorf("queue subagent parent repairs: %w", err)
 	}
+	claudeDAG := file.Agent == parser.AgentClaude && len(res.results) > 1
+	if claudeDAG {
+		staleVersion := max(db.CurrentDataVersion()-1, 0)
+		if err := e.db.SetExistingSessionDataVersions(
+			resultIDs, staleVersion,
+		); err != nil {
+			e.clearProviderSourceFreshness(ctx, res.providerStatHash)
+			return false, fmt.Errorf(
+				"stage Claude source data versions: %w", err,
+			)
+		}
+	}
 	// Always attempt queued work after mutations begin, including when a later
 	// write or scoped link fails. Post-write capture below expands this flag
 	// when the write introduces children that did not exist before it.
@@ -15873,13 +15952,21 @@ func (e *Engine) processAndWriteSessionFile(
 		return false, nil
 	}
 
+	sourceNeedsRetry := res.providerFailureCount > 0 ||
+		len(res.retrySessionIDs) > 0
 	written := 0
+	markSourceIncomplete := func() {
+		if file.Agent == parser.AgentClaude {
+			e.clearProviderSourceFreshness(ctx, res.providerStatHash)
+		}
+	}
 	for i, pr := range res.results {
 		write := pendingWrite{
-			sess:         pr.Session,
-			msgs:         pr.Messages,
-			usageEvents:  pr.UsageEvents,
-			needsRetry:   res.needsRetryForSession(pr.Session.ID),
+			sess:        pr.Session,
+			msgs:        pr.Messages,
+			usageEvents: pr.UsageEvents,
+			needsRetry: sourceNeedsRetry || claudeDAG ||
+				res.needsRetryForSession(pr.Session.ID),
 			forceReplace: res.forceReplace,
 		}
 		// The session upsert commits parser-derived parent provenance before
@@ -15889,6 +15976,7 @@ func (e *Engine) processAndWriteSessionFile(
 		if err := e.db.QueueSubagentParentRepairs(
 			[]string{resultIDs[i]},
 		); err != nil {
+			markSourceIncomplete()
 			return false, fmt.Errorf(
 				"queue attempted session parent repair: %w", err,
 			)
@@ -15901,9 +15989,6 @@ func (e *Engine) processAndWriteSessionFile(
 		// attempt rather than waiting for the entire result set to finish.
 		queueErr := queueWrittenChildren([]string{resultIDs[i]})
 		if writeErr == nil {
-			// A nil writeSessionFull is the single-session analog of
-			// outcome.written[i]=true in flushPending; only counted
-			// successes advance the persisted-digest gate below.
 			written++
 		}
 		if writeErr != nil &&
@@ -15917,30 +16002,42 @@ func (e *Engine) processAndWriteSessionFile(
 			if queueErr != nil {
 				writeErr = errors.Join(writeErr, queueErr)
 			}
+			markSourceIncomplete()
 			return false, fmt.Errorf("write session %s: %w",
 				pr.Session.ID, writeErr)
 		}
 		if queueErr != nil {
+			markSourceIncomplete()
 			return false, queueErr
 		}
 		if errors.Is(writeErr, errSessionPreserved) {
 			preserved = true
 		}
 	}
-	// Persist staged digest only when at least one session row
-	// actually committed. Mirrors the per-row gate in flushPending:
-	// a session-trashed, parser-excluded, or otherwise skipped
-	// batch must NOT stamp provider_freshness with a digest whose
-	// matching session row was not actually persisted. Without this
-	// the single-session sync path would leave provider_freshness
-	// empty for Codebuff/Freebuff forever, leaving the digest gate
-	// un-armed on the next warm pass and a stale session row
-	// unrepaired by the per-component digest.
-	if written > 0 && res.providerStatHash != nil {
-		e.recordProviderStatHash(ctx, *res.providerStatHash)
+	// A source-level digest is valid only when every emitted result and its
+	// hierarchy links committed without retry state or archive preservation.
+	// Claude DAG members remain stale until that source-level decision succeeds.
+	sourceComplete := written == len(res.results) &&
+		!preserved && !sourceNeedsRetry
+	if !sourceComplete {
+		markSourceIncomplete()
 	}
 	if err := e.db.LinkSubagentSessionsForSessions(resultIDs); err != nil {
+		markSourceIncomplete()
 		return false, fmt.Errorf("link changed subagent sessions: %w", err)
+	}
+	if sourceComplete && claudeDAG {
+		if err := e.db.SetSessionDataVersions(
+			resultIDs, db.CurrentDataVersion(),
+		); err != nil {
+			markSourceIncomplete()
+			return false, fmt.Errorf(
+				"complete Claude source data versions: %w", err,
+			)
+		}
+	}
+	if sourceComplete && res.providerStatHash != nil {
+		e.recordProviderStatHash(ctx, *res.providerStatHash)
 	}
 
 	return preserved, nil

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8219,16 +8219,15 @@ func (e *Engine) collectAndBatch(
 			sourceNeedsRetry := vetoed > 0 ||
 				r.providerFailureCount > 0 || len(r.retrySessionIDs) > 0
 			for i, pr := range allowed {
-				sessionNeedsRetry := sourceNeedsRetry ||
+				sessionNeedsRetry := r.providerWideFailureCount > 0 ||
 					r.needsRetryForSession(pr.Session.ID)
-				needsRetry := sessionNeedsRetry || claudeDAG
 				pw := pendingWrite{
 					sess:                    pr.Session,
 					msgs:                    pr.Messages,
 					usageEvents:             pr.UsageEvents,
-					needsRetry:              needsRetry,
+					needsRetry:              sessionNeedsRetry || claudeDAG,
 					forceReplace:            r.forceReplace,
-					baselineEligible:        !sessionNeedsRetry,
+					baselineEligible:        !sourceNeedsRetry,
 					storageTrustPath:        r.storageTrustPath,
 					storageTrustState:       r.storageTrustState,
 					storageTrustSnap:        r.storageTrustSnap,
@@ -8520,6 +8519,10 @@ type processResult struct {
 	// valid partial writes. Reconciliation may persist the valid results, but
 	// must not acknowledge the pass as complete.
 	providerFailureCount int
+	// providerWideFailureCount is the subset of provider failures that applies
+	// to every result in the source. Per-result retry state stays in
+	// retrySessionIDs so one member cannot demote otherwise valid siblings.
+	providerWideFailureCount int
 	// storageTrustPath/State/Snap carry an OpenCode-family storage
 	// session's pre-parse stat signature and invalidation snapshot to
 	// the write path, which promotes it once the session's batch is
@@ -9158,10 +9161,11 @@ func (e *Engine) processProviderFile(
 	}
 	applyProviderFingerprintFileInfo(file.Agent, fingerprint, outcome.Results)
 	cleanCache := providerOutcomeAllowsCleanSkipCache(outcome)
-	providerFailureCount := len(outcome.SourceErrors)
+	providerWideFailureCount := len(outcome.SourceErrors)
 	if !outcome.ResultSetComplete {
-		providerFailureCount++
+		providerWideFailureCount++
 	}
+	providerFailureCount := providerWideFailureCount
 	if outcome.SkipReason != parser.SkipNone {
 		if outcome.SkipReason == parser.SkipUnsupportedSource {
 			e.anomalies.recordUnsupportedSourceLayout(string(file.Agent), file.Path)
@@ -9202,16 +9206,17 @@ func (e *Engine) processProviderFile(
 			}
 		}
 		skipRes := processResult{
-			skip:                  !outcome.ForceReplace,
-			excludedSessionIDs:    excludedSessionIDs,
-			sourceMissingMembers:  missingMembers,
-			mtime:                 fingerprint.MTimeNS,
-			cacheSkip:             cacheSkip,
-			cacheKey:              cacheKey,
-			noCacheSkip:           !cleanCache,
-			forceReplace:          outcome.ForceReplace,
-			suppressPresenceSweep: !outcome.ResultSetComplete,
-			providerFailureCount:  providerFailureCount,
+			skip:                     !outcome.ForceReplace,
+			excludedSessionIDs:       excludedSessionIDs,
+			sourceMissingMembers:     missingMembers,
+			mtime:                    fingerprint.MTimeNS,
+			cacheSkip:                cacheSkip,
+			cacheKey:                 cacheKey,
+			noCacheSkip:              !cleanCache,
+			forceReplace:             outcome.ForceReplace,
+			suppressPresenceSweep:    !outcome.ResultSetComplete,
+			providerFailureCount:     providerFailureCount,
+			providerWideFailureCount: providerWideFailureCount,
 		}
 		// A SkipReason outcome without a force-replace carries no parsed data,
 		// so it stays a lease-free skip; a force-replace is parse-bearing.
@@ -9247,18 +9252,19 @@ func (e *Engine) processProviderFile(
 		file, parsedResults, providerSemantics.UnchangedResults,
 	)
 	res := processResult{
-		results:               filteredResults,
-		excludedSessionIDs:    excludedSessionIDs,
-		sourceMissingMembers:  missingMembers,
-		mtime:                 fingerprint.MTimeNS,
-		cacheSkip:             cacheSkip,
-		cacheKey:              cacheKey,
-		noCacheSkip:           !cleanCache,
-		forceReplace:          outcome.ForceReplace || incForceReplace,
-		suppressPresenceSweep: !outcome.ResultSetComplete,
-		providerFailureCount:  providerFailureCount,
-		retentionLease:        lease,
-		providerStatHash:      preParseStatHash,
+		results:                  filteredResults,
+		excludedSessionIDs:       excludedSessionIDs,
+		sourceMissingMembers:     missingMembers,
+		mtime:                    fingerprint.MTimeNS,
+		cacheSkip:                cacheSkip,
+		cacheKey:                 cacheKey,
+		noCacheSkip:              !cleanCache,
+		forceReplace:             outcome.ForceReplace || incForceReplace,
+		suppressPresenceSweep:    !outcome.ResultSetComplete,
+		providerFailureCount:     providerFailureCount,
+		providerWideFailureCount: providerWideFailureCount,
+		retentionLease:           lease,
+		providerStatHash:         preParseStatHash,
 	}
 	if file.Agent == parser.AgentOmnigent && cacheSkip && cleanCache &&
 		!e.forceParse && !file.ForceParse &&
@@ -16051,12 +16057,13 @@ func (e *Engine) processAndWriteSessionFile(
 		}
 	}
 	for i, pr := range res.results {
+		sessionNeedsRetry := res.providerWideFailureCount > 0 ||
+			res.needsRetryForSession(pr.Session.ID)
 		write := pendingWrite{
-			sess:        pr.Session,
-			msgs:        pr.Messages,
-			usageEvents: pr.UsageEvents,
-			needsRetry: sourceNeedsRetry || claudeDAG ||
-				res.needsRetryForSession(pr.Session.ID),
+			sess:         pr.Session,
+			msgs:         pr.Messages,
+			usageEvents:  pr.UsageEvents,
+			needsRetry:   sessionNeedsRetry || claudeDAG,
 			forceReplace: res.forceReplace,
 		}
 		// The session upsert commits parser-derived parent provenance before

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8657,16 +8657,35 @@ func (e *Engine) processProviderFile(
 		source.ProjectHint = file.Project
 	}
 
+	verifiedCapture, verifiedMtime, verifiedFresh, verifiedStateOK :=
+		e.verifiedProviderSourceState(provider, source, file)
+	if verifiedStateOK && verifiedFresh {
+		if e.verifiedProviderSourceFreshInDB(
+			verifiedCapture.key.agent, source,
+			verifiedCapture.signature.size, verifiedMtime,
+		) {
+			return processResult{
+				skip:  true,
+				mtime: verifiedMtime,
+			}, true
+		}
+		e.invalidateVerifiedSource(
+			verifiedCapture.key.agent, verifiedCapture.key.path,
+		)
+	}
+
 	// Capture the per-component stat digest from the same pre-parse
 	// snapshot that gates freshness, BEFORE fingerprinting or parsing
-	// reads the source. Persisting a digest computed after the parse
-	// would race a concurrent companion rewrite: the stored digest would
-	// describe the new file state while the session row holds the old
-	// parse payload, so every later warm sync would short-circuit on the
-	// new digest and the stale row would never be refreshed. This single
-	// snapshot feeds the warm-match comparison in
-	// providerSourceFreshBeforeFingerprint, the confirmed-unchanged-skip
-	// stamp, and the write-path staging, so all three always agree.
+	// reads the source. The in-memory verified-source gate runs first so
+	// a warm engine does not pay for a second stat snapshot it will never
+	// consult. Persisting a digest computed after the parse would race a
+	// concurrent companion rewrite: the stored digest would describe the
+	// new file state while the session row holds the old parse payload,
+	// so every later warm sync would short-circuit on the new digest and
+	// the stale row would never be refreshed. This single snapshot feeds
+	// the warm-match comparison in providerSourceFreshBeforeFingerprint,
+	// the confirmed-unchanged-skip stamp, and the write-path staging, so
+	// all three always agree.
 	//
 	// providerStatDigestEligible withholds the capture for
 	// content-authority providers under a pathRewriter: materialized
@@ -8689,23 +8708,6 @@ func (e *Engine) processProviderFile(
 		}
 	}
 
-	verifiedCapture, verifiedMtime, verifiedFresh, verifiedStateOK :=
-		e.verifiedProviderSourceState(provider, source, file)
-	if verifiedStateOK && verifiedFresh {
-		if e.verifiedProviderSourceFreshInDB(
-			verifiedCapture.key.agent, source,
-			verifiedCapture.signature.size, verifiedMtime,
-		) {
-			return processResult{
-				skip:  true,
-				mtime: verifiedMtime,
-			}, true
-		}
-		e.invalidateVerifiedSource(
-			verifiedCapture.key.agent, verifiedCapture.key.path,
-		)
-	}
-
 	// Persisted stat-digest skip. This runs before the single-session
 	// content guard below on purpose: a matching digest (size, mtime,
 	// ctime per component) plus a current stored row proves the source
@@ -8718,6 +8720,9 @@ func (e *Engine) processProviderFile(
 	if freshMtime, fresh := e.providerSourceFreshBeforeFingerprint(
 		ctx, source, file, preParseStatHash,
 	); fresh {
+		if verifiedStateOK {
+			e.promoteVerifiedSource(verifiedCapture)
+		}
 		return processResult{
 			skip:  true,
 			mtime: freshMtime,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10733,9 +10733,10 @@ func providerFreshnessAgents(agent parser.AgentType) []parser.AgentType {
 	return []parser.AgentType{agent}
 }
 
-// providerFreshDigestSourceCurrentInDB reports whether the stored session
-// row for a digest-matched source is still current: the row exists, its
-// data version is current, and it does not need a project reparse. A
+// providerFreshDigestSourceCurrentInDB reports whether the active stored
+// sessions for a digest-matched source are still current. User-trashed rows
+// are resolved until restoration invalidates the digest and marks the row
+// stale, so they do not participate in the repair check. A
 // matching provider_freshness digest proves only that the file stat is
 // unchanged; these checks are what allow the digest short-circuit to skip
 // safely, mirroring the tail guards of providerSourceUnchangedInDB. Every
@@ -10754,14 +10755,17 @@ func (e *Engine) providerFreshDigestSourceCurrentInDB(
 			continue
 		}
 		rowFound = true
-		if project, ok := e.db.GetProjectByAgentPath(
-			lookupPath, string(owned),
-		); ok && parser.NeedsProjectReparse(project) {
+		project, dataVersion, _, _, active :=
+			e.db.GetSourceRepairStateByAgentPath(
+				lookupPath, string(owned),
+			)
+		if !active {
+			continue
+		}
+		if parser.NeedsProjectReparse(project) {
 			return false
 		}
-		if e.db.GetDataVersionByAgentPath(
-			lookupPath, string(owned),
-		) < db.CurrentDataVersion() {
+		if dataVersion < db.CurrentDataVersion() {
 			return false
 		}
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10524,13 +10524,13 @@ func (f fakeSnapshotInfo) Sys() any    { return nil }
 
 // providerSingleSessionFresh reports whether a single-session JSONL
 // provider's source (Claude) maps to a stored session that is already
-// up to date: the source size and mtime match what is stored, the row
-// is at the current parser data version, and its project does not need
-// reparse. It reproduces the legacy Claude process arm's shouldSkipFile
-// gate so an unchanged session is skipped instead of re-parsed every
-// full sync. Providers without incremental append, multi-session
-// sources, or sources that are not a single physical file are never
-// considered fresh here and always fall through to the full parse.
+// up to date: the source size and mtime match what is stored, every active row
+// for the source is at the current parser data version, and the main row's
+// project does not need reparse. It reproduces the legacy Claude process arm's
+// shouldSkipFile gate so an unchanged session is skipped instead of re-parsed
+// every full sync. Providers without incremental append, multi-session sources,
+// or sources that are not a single physical file are never considered fresh
+// here and always fall through to the full parse.
 func (e *Engine) providerSingleSessionFresh(
 	ctx context.Context,
 	provider parser.Provider,
@@ -10591,6 +10591,16 @@ func (e *Engine) providerSingleSessionFresh(
 		}
 	}
 	if !e.shouldSkipFile(sessionID, info) {
+		return 0, false, false, false
+	}
+	// Claude transcripts can fan out into several active DAG sessions. The
+	// filename stem identifies only the main row, so its current version cannot
+	// hide a stale restored fork that shares the same source path.
+	_, sourceDataVersion, _, _, sourceFound :=
+		e.db.GetSourceRepairStateByAgentPath(
+			lookupPath, string(parser.AgentClaude),
+		)
+	if !sourceFound || sourceDataVersion < db.CurrentDataVersion() {
 		return 0, false, false, false
 	}
 	if e.providerIncrementalIdentityChanged(lookupPath, info) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -942,6 +942,9 @@ func (e *Engine) recordProviderStatHash(
 	if _, ok := e.providerStatHashers[hash.agent]; !ok {
 		return
 	}
+	if !providerStatHashMetadataVerified(hash) {
+		return
+	}
 	if err := e.db.UpsertProviderStatHash(
 		ctx, hash.agent, hash.targetKey, hash.digest,
 	); err != nil {
@@ -950,6 +953,24 @@ func (e *Engine) recordProviderStatHash(
 			hash.agent, hash.targetKey, err,
 		)
 	}
+}
+
+// providerStatHashMetadataVerified prevents Codex freshness from outrunning
+// its title sidecar. A missing session_index.jsonl is normal and verified;
+// read and scan failures are transient and must leave the previous digest in
+// place so a later pass retries the title check.
+func providerStatHashMetadataVerified(hash pendingProviderStatHash) bool {
+	if hash.agent != parser.AgentCodex {
+		return true
+	}
+	if err := parser.VerifyCodexSessionIndex(hash.physicalPath); err != nil {
+		log.Printf(
+			"verify Codex title index before freshness write for %s: %v",
+			hash.physicalPath, err,
+		)
+		return false
+	}
+	return true
 }
 
 // migrateLegacyCodexExecSkips removes skip cache entries
@@ -8819,12 +8840,16 @@ func (e *Engine) processProviderFile(
 				fingerprint,
 				providerSemantics,
 			)
+			indexChanged, indexVerified := false, true
+			if file.Agent == parser.AgentCodex {
+				indexChanged, indexVerified =
+					e.codexCachedIndexSessionNameState(file.Path)
+			}
 			if !cacheFresh {
 				e.clearSkip(cacheKey)
 			} else if e.pathNeedsCachedSkipBypass(file.Agent, file.Path) {
 				e.clearSkip(cacheKey)
-			} else if file.Agent == parser.AgentCodex &&
-				e.codexCachedIndexSessionNameChanged(file.Path) {
+			} else if indexChanged {
 				// The transcript fingerprint can remain byte-for-byte identical
 				// while session_index.jsonl changes this session's title. Do not
 				// let a pre-existing transcript skip entry hide that metadata
@@ -8865,7 +8890,7 @@ func (e *Engine) processProviderFile(
 					}
 				}
 				if cacheStillFresh {
-					if verifiedStateOK &&
+					if verifiedStateOK && indexVerified &&
 						e.shouldSkipProviderSourceByDB(
 							file, fingerprint, providerSemantics,
 						) {
@@ -8876,7 +8901,7 @@ func (e *Engine) processProviderFile(
 					// backfill or refresh the stat digest for rows that
 					// predate the side-table or whose digest a shared
 					// index touch invalidated.
-					if cacheRowHashVerified {
+					if cacheRowHashVerified && indexVerified {
 						e.stampProviderStatHashForConfirmedSource(
 							ctx, preParseStatHash,
 						)
@@ -8927,11 +8952,11 @@ func (e *Engine) processProviderFile(
 	// engine). For Codex this also folds in the session_index.jsonl sidecar:
 	// a shared index mtime bump that did not change this session's title must
 	// not trigger a reparse.
-	if !incForceReplace && !e.forceParse && !file.ForceParse &&
-		e.shouldSkipProviderSourceByDB(
+	if !incForceReplace && !e.forceParse && !file.ForceParse {
+		dbFresh, metadataVerified := e.providerSourceFreshnessByDB(
 			file, fingerprint, providerSemantics,
-		) {
-		if verifiedStateOK {
+		)
+		if dbFresh && verifiedStateOK && metadataVerified {
 			e.promoteVerifiedSource(verifiedCapture)
 		}
 		// The Codex-family fingerprint content-hashed the rollout and
@@ -8941,14 +8966,20 @@ func (e *Engine) processProviderFile(
 		// side-table, and rollouts whose digest a shared index touch
 		// invalidated without changing their own title, would otherwise
 		// re-hash on every fresh process forever.
-		e.stampProviderStatHashForConfirmedSource(ctx, preParseStatHash)
-		return processResult{
-			skip:        true,
-			mtime:       fingerprint.MTimeNS,
-			cacheSkip:   cacheSkip,
-			cacheKey:    cacheKey,
-			noCacheSkip: true,
-		}, true
+		if dbFresh {
+			if metadataVerified {
+				e.stampProviderStatHashForConfirmedSource(
+					ctx, preParseStatHash,
+				)
+			}
+			return processResult{
+				skip:        true,
+				mtime:       fingerprint.MTimeNS,
+				cacheSkip:   cacheSkip,
+				cacheKey:    cacheKey,
+				noCacheSkip: true,
+			}, true
+		}
 	}
 
 	// DB-stored-file-info skip: a session whose persisted file_size/file_mtime
@@ -10276,6 +10307,9 @@ func (e *Engine) stampProviderStatHashForConfirmedSource(
 	if statHash == nil || statHash.digest == 0 {
 		return
 	}
+	if !providerStatHashMetadataVerified(*statHash) {
+		return
+	}
 	if err := e.db.UpsertProviderStatHash(
 		ctx, statHash.agent, statHash.targetKey, statHash.digest,
 	); err != nil {
@@ -11334,10 +11368,23 @@ func (e *Engine) shouldSkipProviderSourceByDB(
 	fingerprint parser.SourceFingerprint,
 	semantics parser.ProviderSyncSemantics,
 ) bool {
+	fresh, _ := e.providerSourceFreshnessByDB(file, fingerprint, semantics)
+	return fresh
+}
+
+// providerSourceFreshnessByDB returns the Codex-family DB freshness decision
+// and whether all metadata needed to persist local stat trust was verified.
+// A transient Codex title-index failure may still skip unchanged transcript
+// content, but it cannot promote in-memory trust or stamp a stat digest.
+func (e *Engine) providerSourceFreshnessByDB(
+	file parser.DiscoveredFile,
+	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
+) (fresh, metadataVerified bool) {
 	if !isCodexFormatAgent(file.Agent) {
-		return false
+		return false, false
 	}
-	return e.shouldSkipCodexFingerprint(
+	return e.codexFingerprintFreshness(
 		file.Agent, file.Path, fingerprint, semantics,
 	)
 }
@@ -11359,6 +11406,18 @@ func (e *Engine) shouldSkipCodexFingerprint(
 	fingerprint parser.SourceFingerprint,
 	semantics parser.ProviderSyncSemantics,
 ) bool {
+	fresh, _ := e.codexFingerprintFreshness(
+		agent, path, fingerprint, semantics,
+	)
+	return fresh
+}
+
+func (e *Engine) codexFingerprintFreshness(
+	agent parser.AgentType,
+	path string,
+	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
+) (fresh, metadataVerified bool) {
 	lookupPath := path
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
@@ -11367,47 +11426,53 @@ func (e *Engine) shouldSkipCodexFingerprint(
 		lookupPath, string(agent),
 	)
 	if !ok || storedSize != fingerprint.Size {
-		return false
+		return false, false
 	}
 	if !e.providerFingerprintHashMatchesDB(
 		agent, lookupPath,
 		fingerprint,
 		semantics.FingerprintHashRequiredForFreshness,
 	) {
-		return false
+		return false, false
 	}
 	if project, ok := e.db.GetProjectByAgentPath(
 		lookupPath, string(agent),
 	); ok &&
 		parser.NeedsProjectReparse(project) {
-		return false
+		return false, false
 	}
 	if e.db.GetDataVersionByAgentPath(lookupPath, string(agent)) <
 		db.CurrentDataVersion() {
-		return false
+		return false, false
 	}
 	effectiveMtime := fingerprint.MTimeNS
-	if storedMtime == effectiveMtime {
-		return true
-	}
 	if agent != parser.AgentCodex {
-		return false
+		return storedMtime == effectiveMtime, true
 	}
+	statFresh := storedMtime == effectiveMtime
 	if effectiveMtime < storedMtime {
 		indexPath := parser.CodexSessionIndexPath(path)
 		if indexPath != "" {
 			if _, err := os.Stat(indexPath); errors.Is(err, os.ErrNotExist) {
-				return true
+				statFresh = true
 			}
 		}
 	}
-	fileMtime := effectiveMtime
-	if info, err := os.Stat(path); err == nil {
-		fileMtime = info.ModTime().UnixNano()
+	if effectiveMtime > storedMtime {
+		fileMtime := effectiveMtime
+		if info, err := os.Stat(path); err == nil {
+			fileMtime = info.ModTime().UnixNano()
+		}
+		statFresh = fileMtime <= storedMtime
 	}
-	return effectiveMtime > storedMtime &&
-		fileMtime <= storedMtime &&
-		!e.codexIndexSessionNameChanged(path)
+	if !statFresh {
+		return false, false
+	}
+	changed, verified := e.codexIndexSessionNameState(path)
+	if !verified {
+		return true, false
+	}
+	return !changed, true
 }
 
 // codexIndexNeedsRefreshSince reports whether a Codex session whose transcript
@@ -11435,40 +11500,53 @@ func (e *Engine) codexIndexNeedsRefreshSince(
 }
 
 func (e *Engine) codexIndexSessionNameChanged(path string) bool {
+	changed, _ := e.codexIndexSessionNameState(path)
+	return changed
+}
+
+func (e *Engine) codexIndexSessionNameState(
+	path string,
+) (changed, verified bool) {
 	uuid := parser.CodexSessionUUIDFromFilename(filepath.Base(path))
 	if uuid == "" {
-		return false
+		return false, false
 	}
-	currentName, ok := parser.LookupCodexThreadNameEntry(path, uuid)
+	currentName, ok, err := parser.ReadCodexThreadNameEntry(path, uuid)
+	if err != nil {
+		return false, false
+	}
 	if !ok {
 		// No index entry means no rename signal, not a rename to empty.
 		// Modern Codex releases stopped writing session_index.jsonl; a
 		// stored title compared against the absent index would force a
 		// full re-parse of every titled session on every sync, and the
 		// rewrite preserves the title, so the loop could never converge.
-		return false
+		return false, true
 	}
 	storedName, found, err := e.db.GetSessionName(
 		context.Background(), e.idPrefix+"codex:"+uuid,
 	)
 	if err != nil || !found {
-		return true
+		return true, true
 	}
-	return codexSessionNameDiffers(storedName, currentName)
+	return codexSessionNameDiffers(storedName, currentName), true
 }
 
-// codexCachedIndexSessionNameChanged limits title-based cache invalidation to
-// sources that already have stored session state. A cached parse failure has no
-// title to refresh and must retain its retry-suppression semantics.
-func (e *Engine) codexCachedIndexSessionNameChanged(path string) bool {
+// codexCachedIndexSessionNameState limits title-based cache invalidation to
+// sources that already have stored session state. A cached parse failure has
+// no title to refresh and its missing row counts as verified for cache-only
+// retry suppression; no digest can be stamped without a stored row hash.
+func (e *Engine) codexCachedIndexSessionNameState(
+	path string,
+) (changed, verified bool) {
 	lookupPath := path
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
 	}
 	if _, _, ok := e.db.GetFileInfoByPath(lookupPath); !ok {
-		return false
+		return false, true
 	}
-	return e.codexIndexSessionNameChanged(path)
+	return e.codexIndexSessionNameState(path)
 }
 
 // classifyCodexIndexPath maps a Codex session_index.jsonl change to the

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8667,8 +8667,14 @@ func (e *Engine) processProviderFile(
 	// snapshot feeds the warm-match comparison in
 	// providerSourceFreshBeforeFingerprint, the confirmed-unchanged-skip
 	// stamp, and the write-path staging, so all three always agree.
+	//
+	// providerStatDigestEligible withholds the capture for
+	// content-authority providers under a pathRewriter: materialized
+	// remote stats cannot prove a re-download unchanged, so their remote
+	// freshness stays content-hash arbitrated.
 	var preParseStatHash *pendingProviderStatHash
-	if hasher, ok := e.providerStatHashers[file.Agent]; ok {
+	if hasher, ok := e.providerStatHashers[file.Agent]; ok &&
+		e.providerStatDigestEligible(file.Agent) {
 		if physicalPath := providerDiscoveredPath(source); physicalPath != "" {
 			targetKey := physicalPath
 			if e.pathRewriter != nil {
@@ -9527,12 +9533,12 @@ func (e *Engine) applyProviderFilePathPolicies(
 		// veto, a failed upsert, or a parser-skipped session all bypass
 		// the persist call and keep the side-table clean.
 		// Fallback staging for results that bypassed processProviderFile's
-		// pre-parse capture (res.providerStatHash == nil). Today only
-		// Codebuff/Freebuff register a MultiFileStatHasher and their
-		// provider-authoritative path always captures, so this recomputes
-		// post-parse only for hypothetical non-processProviderFile
-		// producers; it is not the hot path.
-		if res.providerStatHash == nil {
+		// pre-parse capture (res.providerStatHash == nil), applying the
+		// same digest-eligibility rule so a path-rewritten import of a
+		// content-authority provider never re-stages what the pre-parse
+		// site deliberately withheld.
+		if res.providerStatHash == nil &&
+			e.providerStatDigestEligible(agent) {
 			if hasher, ok := e.providerStatHashers[agent]; ok {
 				targetKey := filePath
 				if e.pathRewriter != nil {
@@ -10529,6 +10535,26 @@ func providerStatFreshnessMtime(
 	default:
 		return chatInfo.ModTime().UnixNano()
 	}
+}
+
+// providerStatDigestEligible reports whether this engine may stage,
+// stamp, or consult a provider_freshness stat digest for the agent. The
+// content-hashing single-file JSONL providers (Claude, Codex family) are
+// ineligible under a pathRewriter: a remote import materializes a fresh
+// physical file whose mtime is copied from the remote and whose ctime is
+// the import clock, so a same-stat different-content re-download can
+// collide with a stored digest inside one coarse filesystem timestamp
+// tick and skip a real rewrite. Their remote freshness stays
+// content-hash arbitrated, matching the pathRewriter carve-outs in
+// providerIncrementalIdentityChanged. Codebuff stays eligible
+// everywhere: its remote flow deliberately stamps the per-component
+// composite under the logical key (see
+// TestSyncCodebuffProviderStatHashRemoteStoresUnderLogicalKey).
+func (e *Engine) providerStatDigestEligible(agent parser.AgentType) bool {
+	if e.pathRewriter == nil {
+		return true
+	}
+	return agent != parser.AgentClaude && !isCodexFormatAgent(agent)
 }
 
 // providerFreshnessAgents returns the stored-agent labels a provider's

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -14886,3 +14886,100 @@ func TestSyncSingleSessionChildCaptureFailurePreservesEdges(t *testing.T) {
 	assert.Equal(t, 1, edgeCount,
 		"failed capture must not remove the sole spawn edge")
 }
+
+// A successful Claude write stamps a provider_freshness stat digest, so a
+// fresh engine (daemon restart or a one-shot CLI sync) skips the unchanged
+// transcript on its first pass without content-hashing it.
+func TestSyncAllPersistsClaudeStatDigestAcrossEngineRestart(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "digest me", "/workspace/api").
+		String()
+	path := env.writeClaudeSession(
+		t, "-workspace-api", "digest-sess.jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	digest, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok,
+		"successful write must stamp a provider_freshness digest")
+	require.NotZero(t, digest)
+
+	restarted := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {env.claudeDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(restarted.Close)
+	stats := restarted.SyncAll(t.Context(), nil)
+	assert.Equal(t, 0, stats.Synced,
+		"fresh engine must skip the unchanged transcript")
+}
+
+// The Codex stat digest folds session_index.jsonl, so a title rename can
+// never hide behind a warm digest match across an engine restart: the
+// index change breaks the digest and the rename is picked up.
+func TestRestartedEngineCodexIndexRenameNotMaskedByStatDigest(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e3"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Rename me later").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+	indexPath := filepath.Join(root, parser.CodexSessionIndexFilename)
+	indexLine := func(title string) []byte {
+		return fmt.Appendf(nil,
+			`{"id":"%s","thread_name":"%s","updated_at":"2026-06-11T17:34:20Z"}`+"\n",
+			uuid, title,
+		)
+	}
+	require.NoError(t, os.WriteFile(indexPath, indexLine("Original title"), 0o644))
+	transcriptTime := time.Now().Add(-3 * time.Hour)
+	indexTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
+	require.NoError(t, os.Chtimes(indexPath, indexTime, indexTime))
+
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	digest, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentCodex, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok,
+		"successful write must stamp a provider_freshness digest")
+	require.NotZero(t, digest)
+
+	restarted := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {codexDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(restarted.Close)
+
+	renamedTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.WriteFile(indexPath, indexLine("Renamed title"), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, renamedTime, renamedTime))
+
+	require.Equal(t, 1, restarted.SyncAll(t.Context(), nil).Synced,
+		"index rename must defeat the persisted digest")
+	sess, err := env.db.GetSessionFull(t.Context(), "codex:"+uuid)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	if assert.NotNil(t, sess.SessionName) {
+		assert.Equal(t, "Renamed title", *sess.SessionName)
+	}
+}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -14920,6 +14920,161 @@ func TestSyncAllPersistsClaudeStatDigestAcrossEngineRestart(t *testing.T) {
 		"fresh engine must skip the unchanged transcript")
 }
 
+// A Claude row that predates the stat-digest side-table (no
+// provider_freshness row) is confirmed unchanged by the content-verified
+// single-session skip. That skip must backfill the digest so the next
+// fresh process can skip on stats alone; without the stamp the row would
+// pay a full content hash on every restart forever, since a skip never
+// writes and only writes stamped the digest.
+func TestRestartedEngineBackfillsClaudeStatDigestOnVerifiedSkip(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "backfill me", "/workspace/api").
+		String()
+	path := env.writeClaudeSession(
+		t, "-workspace-api", "backfill-sess.jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, env.db.DeleteProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	), "simulate a row written before the digest side-table existed")
+
+	restarted := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {env.claudeDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(restarted.Close)
+	stats := restarted.SyncAll(t.Context(), nil)
+	require.Equal(t, 0, stats.Synced,
+		"unchanged transcript must skip, not rewrite")
+
+	digest, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	assert.True(t, ok,
+		"a content-verified unchanged skip must backfill the digest; "+
+			"without it every restart re-hashes the transcript")
+	assert.NotZero(t, digest)
+}
+
+// A Codex row without a provider_freshness digest returns through the
+// validated cache-skip or DB-fingerprint skip, both of which verify the
+// current content hash against the stored row. Those skips must backfill
+// the digest so pre-digest archives stop content-hashing on every fresh
+// process.
+func TestRestartedEngineBackfillsCodexStatDigestOnConfirmedSkip(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e4"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "backfill my digest").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, env.db.DeleteProviderStatHash(
+		t.Context(), parser.AgentCodex, path,
+	), "simulate a row written before the digest side-table existed")
+
+	restarted := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {codexDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(restarted.Close)
+	stats := restarted.SyncAll(t.Context(), nil)
+	require.Equal(t, 0, stats.Synced,
+		"unchanged rollout must skip, not rewrite")
+
+	digest, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentCodex, path,
+	)
+	require.NoError(t, err)
+	assert.True(t, ok,
+		"a DB-confirmed unchanged skip must backfill the digest; "+
+			"without it every restart re-hashes the rollout")
+	assert.NotZero(t, digest)
+}
+
+// A session_index.jsonl touch (any title change elsewhere) breaks every
+// rollout's stored digest at once. Rollouts whose own title did not change
+// are confirmed unchanged by the fingerprint-path skips, which must
+// refresh the stored digest to fold the new index stat; otherwise the
+// whole archive re-hashes after every restart until something rewrites it.
+func TestRestartedEngineCodexIndexTouchRefreshesStoredDigest(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e5"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "keep my title").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+	indexPath := filepath.Join(root, parser.CodexSessionIndexFilename)
+	indexContent := fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Stable title","updated_at":"2026-06-11T17:34:20Z"}`+"\n",
+		uuid,
+	)
+	require.NoError(t, os.WriteFile(indexPath, indexContent, 0o644))
+	transcriptTime := time.Now().Add(-3 * time.Hour)
+	indexTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
+	require.NoError(t, os.Chtimes(indexPath, indexTime, indexTime))
+
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	staleDigest, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentCodex, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Same index content, newer mtime: another session's rename would look
+	// like this to a rollout whose own title is unchanged.
+	touchedTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.WriteFile(indexPath, indexContent, 0o644))
+	require.NoError(t, os.Chtimes(indexPath, touchedTime, touchedTime))
+
+	restarted := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {codexDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(restarted.Close)
+	stats := restarted.SyncAll(t.Context(), nil)
+	require.Equal(t, 0, stats.Synced,
+		"an index touch without a title change must not rewrite the rollout")
+
+	refreshed, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentCodex, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.NotEqual(t, staleDigest, refreshed,
+		"the confirmed-unchanged skip must refresh the digest to the new "+
+			"index stat; a stale digest re-hashes the archive every restart")
+}
+
 // The Codex stat digest folds session_index.jsonl, so a title rename can
 // never hide behind a warm digest match across an engine restart: the
 // index change breaks the digest and the rename is picked up.

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -15377,6 +15377,131 @@ func TestRestartedEngineCodexIndexTouchRefreshesStoredDigest(t *testing.T) {
 			"index stat; a stale digest re-hashes the archive every restart")
 }
 
+// A successful transcript write must not stamp a stat digest when its title
+// index could not be read. The session remains useful without title metadata,
+// but the next pass must retry the index rather than trust unchecked state.
+func TestSyncAllCodexUnreadableIndexDoesNotPersistStatDigest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions are required to force an index read error")
+	}
+
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e7"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/workspace/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "sync without title metadata").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+	indexPath := filepath.Join(root, parser.CodexSessionIndexFilename)
+	indexContent := fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Unchecked title","updated_at":"2026-06-11T17:34:20Z"}`+"\n",
+		uuid,
+	)
+	require.NoError(t, os.WriteFile(indexPath, indexContent, 0o600))
+	require.NoError(t, os.Chmod(indexPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(indexPath, 0o600) })
+	if f, openErr := os.Open(indexPath); openErr == nil {
+		_ = f.Close()
+		require.NoError(t, os.Chmod(indexPath, 0o600))
+		t.Skip("test process can read mode-000 files")
+	}
+
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	_, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentCodex, path,
+	)
+	require.NoError(t, err)
+	assert.False(t, ok,
+		"a write with unchecked title metadata must not persist a digest")
+}
+
+// A transient session_index.jsonl read failure must not earn the new stat
+// digest. The rollout content hash can still prove the transcript unchanged,
+// but it cannot prove the stored title current. Persisting the unreadable
+// index's digest would let the next fresh engine skip the title check forever.
+func TestRestartedEngineCodexIndexReadFailureDoesNotRefreshStoredDigest(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions are required to force an index read error")
+	}
+
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e6"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/workspace/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "do not lose my title").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+	indexPath := filepath.Join(root, parser.CodexSessionIndexFilename)
+	indexContent := fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original title","updated_at":"2026-06-11T17:34:20Z"}`+"\n",
+		uuid,
+	)
+	require.NoError(t, os.WriteFile(indexPath, indexContent, 0o600))
+	transcriptTime := time.Now().Add(-3 * time.Hour)
+	indexTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
+	require.NoError(t, os.Chtimes(indexPath, indexTime, indexTime))
+
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	storedDigest, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentCodex, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// A rename or unrelated index update advances the stat tuple, but a
+	// transient permission failure prevents the title map from being checked.
+	require.NoError(t, os.Chtimes(
+		indexPath, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour),
+	))
+	require.NoError(t, os.Chmod(indexPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(indexPath, 0o600) })
+	if f, openErr := os.Open(indexPath); openErr == nil {
+		_ = f.Close()
+		require.NoError(t, os.Chmod(indexPath, 0o600))
+		t.Skip("test process can read mode-000 files")
+	}
+
+	restarted := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {codexDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(restarted.Close)
+	stats := restarted.SyncAll(t.Context(), nil)
+	require.Equal(t, 0, stats.Synced,
+		"an unreadable title index does not change transcript content")
+
+	digestAfterFailure, ok, err := env.db.GetProviderStatHash(
+		t.Context(), parser.AgentCodex, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, storedDigest, digestAfterFailure,
+		"an unreadable title index must not stamp its new stat digest")
+}
+
 // The Codex stat digest folds session_index.jsonl, so a title rename can
 // never hide behind a warm digest match across an engine restart: the
 // index change breaks the digest and the rename is picked up.

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -15164,6 +15164,64 @@ func TestSyncAllPersistsClaudeStatDigestAcrossEngineRestart(t *testing.T) {
 		"fresh engine must skip the unchanged transcript")
 }
 
+// A path-rewritten (remote import) engine must not stamp stat digests for
+// content-authority providers (Claude, Codex family): each import
+// materializes a fresh physical file whose mtime is copied from the
+// remote and whose ctime comes from the import clock, so a same-stat
+// different-content re-download can collide with a stored digest inside
+// one coarse filesystem timestamp tick and skip a real rewrite. With no
+// digest row, the content hash always arbitrates remote freshness.
+func TestPathRewriterEngineDoesNotStampCodexStatDigest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	database := dbtest.OpenTestDB(t)
+	root := filepath.Join(t.TempDir(), "sessions")
+	const (
+		uuid       = "019eb791-cf7d-75c1-8439-9ed74c1229f7"
+		remoteRoot = "/home/test/.codex/sessions"
+	)
+	relPath := filepath.Join(
+		"2024", "01", "01",
+		"rollout-2024-01-01T10-00-00-"+uuid+".jsonl",
+	)
+	path := filepath.Join(root, relPath)
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/tmp/proj", "codex_cli_rs").
+		AddCodexMessage(tsEarlyS1, "user", "remote request").
+		String()
+	dbtest.WriteTestFile(t, path, []byte(content))
+
+	logicalPath := "host:" + filepath.ToSlash(
+		filepath.Join(remoteRoot, relPath),
+	)
+	rewriter := func(p string) string {
+		rel, relErr := filepath.Rel(root, p)
+		if relErr == nil && !strings.HasPrefix(rel, "..") {
+			return "host:" + filepath.ToSlash(filepath.Join(remoteRoot, rel))
+		}
+		return "host:" + filepath.ToSlash(p)
+	}
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCodex: {root}},
+		Machine:   "host", IDPrefix: "host~", PathRewriter: rewriter,
+		Ephemeral: true,
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+
+	for _, key := range []string{logicalPath, path} {
+		_, ok, err := database.GetProviderStatHash(
+			t.Context(), parser.AgentCodex, key,
+		)
+		require.NoError(t, err)
+		assert.False(t, ok,
+			"a path-rewritten import must not stamp a stat digest under "+
+				"%q: materialized stats cannot prove a re-download "+
+				"unchanged, only the content hash can", key)
+	}
+}
+
 // A Claude row that predates the stat-digest side-table (no
 // provider_freshness row) is confirmed unchanged by the content-verified
 // single-session skip. That skip must backfill the digest so the next

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -521,7 +521,6 @@ func TestProcessFileProviderAuthoritativeUsesInjectedProvider(t *testing.T) {
 }
 
 func TestProcessFileProviderAuthoritativeKeepsRetryStatePerResult(t *testing.T) {
-
 	root := t.TempDir()
 	sourcePath, fingerprint := writeProcessProviderSource(t, root, "retry.jsonl")
 	provider := newProcessFixtureProvider(
@@ -565,6 +564,54 @@ func TestProcessFileProviderAuthoritativeKeepsRetryStatePerResult(t *testing.T) 
 	assert.False(t, res.needsRetryForSession("cowork:current"))
 	assert.True(t, res.needsRetryForSession("cowork:retry"))
 	assert.False(t, res.suppressesPresenceSweepForRetry())
+}
+
+func TestSyncSingleSessionKeepsRetryStatePerResult(t *testing.T) {
+	root := t.TempDir()
+	sourcePath, fingerprint := writeProcessProviderSource(t, root, "retry.jsonl")
+	provider := newProcessFixtureProvider(
+		processFixtureSource(sourcePath),
+		fingerprint,
+		parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{
+				{
+					Result: processFixtureResult(
+						"cowork:current",
+						parser.AgentCowork,
+						"fixture-project",
+						sourcePath,
+						fingerprint,
+					),
+					DataVersion: parser.DataVersionCurrent,
+				},
+				{
+					Result: processFixtureResult(
+						"cowork:retry",
+						parser.AgentCowork,
+						"fixture-project",
+						sourcePath,
+						fingerprint,
+					),
+					DataVersion: parser.DataVersionNeedsRetry,
+				},
+			},
+			ResultSetComplete: true,
+		},
+	)
+	engine := newProcessFixtureEngine(t, root, provider)
+
+	_, err := engine.processAndWriteSessionFile(
+		context.Background(),
+		parser.DiscoveredFile{Path: sourcePath, Agent: parser.AgentCowork},
+		"cowork:current",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, db.CurrentDataVersion(),
+		engine.db.GetSessionDataVersion("cowork:current"),
+		"a sibling retry must not leave the valid session stale")
+	assert.Less(t, engine.db.GetSessionDataVersion("cowork:retry"),
+		db.CurrentDataVersion(),
+		"the retrying session must remain stale")
 }
 
 func TestSyncSingleSessionPartialFullWritesQueueNewChild(t *testing.T) {

--- a/internal/sync/provider_stat_hash_incremental_test.go
+++ b/internal/sync/provider_stat_hash_incremental_test.go
@@ -1,0 +1,85 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+func TestClaudeIncrementalWritePersistsCompleteSourceStatHash(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project-a")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	path := filepath.Join(projectDir, "incremental-hash.jsonl")
+	builder := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:00Z", "start", "a", "",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:00:01Z", "ok", "b", "a",
+		)
+	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o644))
+
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	initial := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, initial.Synced)
+	require.Zero(t, initial.Failed)
+	hasher := engine.providerStatHashers[parser.AgentClaude]
+	require.NotNil(t, hasher)
+	initialDigest, ok, err := database.GetProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Consume one complete record while leaving an unfinished record at EOF.
+	// The cursor may advance, but the digest must continue to describe the last
+	// completely consumed source snapshot.
+	builder.AddClaudeUserWithUUID(
+		"2024-01-01T10:00:02Z", "next", "c", "b",
+	)
+	require.NoError(t, os.WriteFile(
+		path, []byte(builder.String()+`{"type":"assistant"`), 0o644,
+	))
+	partial := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, partial.Synced)
+	require.Zero(t, partial.Failed)
+	partialDigest, ok, err := database.GetProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, initialDigest, partialDigest)
+	assert.NotEqual(t, hasher.ComputeMultiFileStatHash(path), partialDigest)
+
+	// Replacing the unfinished tail with a complete record lets the
+	// incremental parser consume the full fingerprinted source. Its successful
+	// write must advance the digest in the same pass.
+	builder.AddClaudeAssistantWithUUID(
+		"2024-01-01T10:00:03Z", "done", "d", "c",
+	)
+	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o644))
+	complete := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, complete.Synced)
+	require.Zero(t, complete.Failed)
+	completeDigest, ok, err := database.GetProviderStatHash(
+		t.Context(), parser.AgentClaude, path,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, hasher.ComputeMultiFileStatHash(path), completeDigest)
+}

--- a/internal/sync/provider_stat_hash_incremental_test.go
+++ b/internal/sync/provider_stat_hash_incremental_test.go
@@ -9,9 +9,51 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
+
+func TestProviderSourceFreshBeforeFingerprintRejectsUnverifiedStatDigest(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("unchanged\n"), 0o644))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:        "session",
+		Agent:     string(parser.AgentClaude),
+		Project:   "project-a",
+		Machine:   "local",
+		FilePath:  strPtr(path),
+		FileSize:  int64Ptr(info.Size()),
+		FileMtime: int64Ptr(info.ModTime().UnixNano()),
+	}))
+	require.NoError(t, database.SetSessionDataVersion(
+		"session", db.CurrentDataVersion(),
+	))
+	require.NoError(t, database.UpsertProviderStatHash(
+		t.Context(), parser.AgentClaude, path, 0,
+	))
+
+	engine := &Engine{db: database}
+	_, fresh := engine.providerSourceFreshBeforeFingerprint(
+		t.Context(),
+		parser.SourceRef{Provider: parser.AgentClaude, DisplayPath: path},
+		parser.DiscoveredFile{Agent: parser.AgentClaude, Path: path},
+		&pendingProviderStatHash{
+			agent:        parser.AgentClaude,
+			physicalPath: path,
+			targetKey:    path,
+			digest:       0,
+		},
+	)
+
+	assert.False(t, fresh,
+		"an unverified stat digest must not accept persisted freshness")
+}
 
 func TestClaudeIncrementalWritePersistsCompleteSourceStatHash(t *testing.T) {
 	database := openTestDB(t)

--- a/internal/sync/provider_sync_semantics_test.go
+++ b/internal/sync/provider_sync_semantics_test.go
@@ -346,7 +346,7 @@ func TestOmnigentContainerSkipCacheEntryFreshWithoutStoredRow(t *testing.T) {
 		FingerprintHashRequiredForFreshness: true,
 	}
 
-	containerFresh := engine.providerSkipCacheEntryFreshInDB(
+	containerFresh, containerHashVerified := engine.providerSkipCacheEntryFreshInDB(
 		parser.DiscoveredFile{Path: container, Agent: parser.AgentOmnigent},
 		parser.SourceRef{
 			Provider: parser.AgentOmnigent, Key: container,
@@ -355,7 +355,7 @@ func TestOmnigentContainerSkipCacheEntryFreshWithoutStoredRow(t *testing.T) {
 		parser.SourceFingerprint{Key: container, Hash: "container-hash"},
 		providerSemantics,
 	)
-	memberFresh := engine.providerSkipCacheEntryFreshInDB(
+	memberFresh, _ := engine.providerSkipCacheEntryFreshInDB(
 		parser.DiscoveredFile{Path: memberPath, Agent: parser.AgentOmnigent},
 		parser.SourceRef{
 			Provider: parser.AgentOmnigent, Key: memberPath,
@@ -367,6 +367,9 @@ func TestOmnigentContainerSkipCacheEntryFreshWithoutStoredRow(t *testing.T) {
 
 	assert.True(t, containerFresh,
 		"a whole-container entry needs no stored physical-path row")
+	assert.False(t, containerHashVerified,
+		"container identity freshness never compares a stored row hash, "+
+			"so it must not authorize a stat-digest stamp")
 	assert.False(t, memberFresh,
 		"a virtual member entry must still validate against its stored row")
 }

--- a/internal/sync/s3_source_test.go
+++ b/internal/sync/s3_source_test.go
@@ -231,6 +231,93 @@ func TestProcessFileS3ChangedFingerprintBypassesMtimeSkipCache(t *testing.T) {
 	require.Len(t, res.results, 1)
 }
 
+func TestProcessFileS3RestoredSessionBypassesSkipCache(t *testing.T) {
+	database := openTestDB(t)
+	path := "s3://bucket/laptop/raw/claude/test-proj/restored.jsonl"
+	first := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "Before").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "old reply").
+		String()
+	second := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "After!").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "new reply").
+		String()
+	require.Len(t, second, len(first), "test fixture must keep size stable")
+	mtime := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC).UnixNano()
+	const fingerprint = "s3:fingerprint:stable"
+
+	var content atomic.Value
+	content.Store(first)
+	oldFetch := fetchS3Object
+	t.Cleanup(func() { fetchS3Object = oldFetch })
+	var fetchCalls atomic.Int64
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, path, got)
+		fetchCalls.Add(1)
+		return io.NopCloser(strings.NewReader(content.Load().(string))), nil
+	}
+
+	e := &Engine{
+		db:               database,
+		ephemeral:        true,
+		skipCache:        make(map[string]int64),
+		skipFingerprints: make(map[string]string),
+		skipHashKeys:     make(map[string]string),
+	}
+	file := parser.DiscoveredFile{
+		Agent:             parser.AgentClaude,
+		Path:              path,
+		Project:           "test-proj",
+		Machine:           "laptop",
+		SourceSize:        int64(len(first)),
+		SourceMtime:       mtime,
+		SourceFingerprint: fingerprint,
+	}
+	initial := e.processFile(t.Context(), file)
+	require.NoError(t, initial.err)
+	require.Len(t, initial.results, 1)
+	written, _, failed, _ := e.writeBatch([]pendingWrite{{
+		sess:         initial.results[0].Session,
+		msgs:         initial.results[0].Messages,
+		forceReplace: initial.forceReplace,
+	}}, syncWriteDefault, false)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	e.cacheSkip(path, mtime, fingerprint)
+
+	require.NoError(t, database.SoftDeleteSession("laptop~restored"))
+	content.Store(second)
+	restored, err := database.RestoreSession("laptop~restored")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, restored)
+	require.Less(t, database.GetSessionDataVersion("laptop~restored"),
+		db.CurrentDataVersion())
+	fetchCalls.Store(0)
+
+	result := e.processFile(t.Context(), file)
+
+	require.NoError(t, result.err)
+	assert.False(t, result.skip,
+		"restore-invalidated data must bypass an unchanged S3 cache entry")
+	assert.EqualValues(t, 1, fetchCalls.Load())
+	require.Len(t, result.results, 1)
+	require.Len(t, result.results[0].Messages, 2)
+	assert.Equal(t, "After!", result.results[0].Messages[0].Content)
+	written, _, failed, _ = e.writeBatch([]pendingWrite{{
+		sess:         result.results[0].Session,
+		msgs:         result.results[0].Messages,
+		forceReplace: result.forceReplace,
+	}}, syncWriteDefault, false)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	stored, err := database.GetAllMessages(t.Context(), "laptop~restored")
+	require.NoError(t, err)
+	require.Len(t, stored, 2)
+	assert.Equal(t, "After!", stored[0].Content)
+	assert.Equal(t, db.CurrentDataVersion(),
+		database.GetSessionDataVersion("laptop~restored"))
+}
+
 func TestFilterFilesByMtimeKeepsS3ChangedFingerprint(t *testing.T) {
 	database := openTestDB(t)
 	path := "s3://bucket/laptop/raw/claude/test-proj/fingerprint.jsonl"


### PR DESCRIPTION
## Summary

Persist file-stat digests for Claude and Codex so syncs after an engine restart
can skip unchanged transcripts without reopening and hashing them.

- Digests cover size, mtime, and ctime; Codex also includes
  `session_index.jsonl`, so title-only changes still resync.
- Digests are stored only after a committed write or a content-verified skip,
  and existing rows are backfilled on their first verified pass.
- Remote imports remain content-hash based because copied filesystem timestamps
  are not a reliable freshness signal.

On a 55k-session archive, a fresh-process sweep fell from more than 30 minutes
to about 39 seconds. Warm-process sweeps remain behaviorally unchanged.

The main implementation is in `internal/parser/stat_digest.go` and
`internal/sync/engine.go`, with restart and index-change coverage in the parser
and sync integration tests.
