### PR TITLE
fix(activity): avoid repeated snapshot peer scans

### DIFF
--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -4,9 +4,9 @@ import (
 	"cmp"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"go.kenn.io/agentsview/internal/activity"
@@ -666,19 +666,26 @@ func (db *DB) loadActivityReportUsageCandidatesFrom(
 	for _, id := range ids {
 		candidateIDs[id] = struct{}{}
 	}
-	for i := 0; i < len(keys); i += usageVarChunk {
-		end := min(i+usageVarChunk, len(keys))
-		predicates := make([]string, 0, end-i)
-		args := make([]any, 0, (end-i)*2)
-		for _, key := range keys[i:end] {
-			predicates = append(predicates,
-				"(m.claude_message_id = ? AND m.claude_request_id = ?)")
-			args = append(args, key.messageID, key.requestID)
+	if len(keys) > 0 {
+		pairs := make([][2]string, len(keys))
+		for i, key := range keys {
+			pairs[i] = [2]string{key.messageID, key.requestID}
+		}
+		encodedPairs, marshalErr := json.Marshal(pairs)
+		if marshalErr != nil {
+			return nil, nil, fmt.Errorf(
+				"encoding activity report Claude snapshot keys: %w", marshalErr)
 		}
 		rowsSQL := dailyUsageRowsSQLWithWhere(
-			usageMessageEligibility+" AND ("+strings.Join(predicates, " OR ")+")",
+			usageMessageEligibility+` AND m.claude_message_id != ''
+				AND m.claude_request_id != ''
+				AND (m.claude_message_id, m.claude_request_id) IN (
+					SELECT json_extract(peer.value, '$[0]'),
+					       json_extract(peer.value, '$[1]')
+					FROM json_each(?) AS peer
+				)`,
 			usageEventEligibility+" AND 1 = 0")
-		if err := loadRows(rowsSQL, args, candidateIDs); err != nil {
+		if err := loadRows(rowsSQL, []any{string(encodedPairs)}, candidateIDs); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3063,6 +3063,14 @@ func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
 		 WHERE token_usage != ''
 		   AND model != ''
 		   AND model != '<synthetic>'`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_claude_snapshot
+		 ON messages(claude_message_id, claude_request_id,
+		             timestamp, session_id, ordinal)
+		 WHERE token_usage != ''
+		   AND model != ''
+		   AND model != '<synthetic>'
+		   AND claude_message_id != ''
+		   AND claude_request_id != ''`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_has_secret
 		 ON sessions(secret_leak_count) WHERE secret_leak_count > 0`,
 	}

--- a/internal/db/usage_covering_index_test.go
+++ b/internal/db/usage_covering_index_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUsageCoveringIndexMigration(t *testing.T) {
+func TestUsageAndActivityIndexesMigration(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.db")
 
@@ -18,12 +18,15 @@ func TestUsageCoveringIndexMigration(t *testing.T) {
 	d.Close()
 
 	requireIndexPresence(t, path, "idx_messages_usage_covering", 1)
+	requireIndexPresence(t, path, "idx_messages_claude_snapshot", 1)
 	requireIndexPresence(t, path, "idx_messages_usage_timestamp", 0)
 
 	conn, err := sql.Open("sqlite3", path)
 	requireNoError(t, err, "raw open")
 	_, err = conn.Exec(`DROP INDEX IF EXISTS idx_messages_usage_covering`)
 	requireNoError(t, err, "drop covering index")
+	_, err = conn.Exec(`DROP INDEX IF EXISTS idx_messages_claude_snapshot`)
+	requireNoError(t, err, "drop Claude snapshot index")
 	_, err = conn.Exec(`CREATE INDEX idx_messages_usage_timestamp
 		ON messages(timestamp, session_id, ordinal)
 		WHERE token_usage != '' AND model != '' AND model != '<synthetic>'`)
@@ -35,6 +38,7 @@ func TestUsageCoveringIndexMigration(t *testing.T) {
 	defer d.Close()
 
 	requireIndexPresence(t, path, "idx_messages_usage_covering", 1)
+	requireIndexPresence(t, path, "idx_messages_claude_snapshot", 1)
 	requireIndexPresence(t, path, "idx_messages_usage_timestamp", 0)
 
 	var sessions int

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -635,17 +635,19 @@ func (s *Store) activityReportUsage(
 	for _, id := range ids {
 		candidateIDs[id] = struct{}{}
 	}
-	for i := 0; i < len(keys); i += usageChunk {
-		end := min(i+usageChunk, len(keys))
-		predicates := make([]string, 0, end-i)
-		args := make([]any, 0, (end-i)*2+2)
-		for _, key := range keys[i:end] {
-			predicates = append(predicates,
-				"(m.claude_message_id = ? AND m.claude_request_id = ?)")
+	if len(keys) > 0 {
+		pairs := make([]string, 0, len(keys))
+		args := make([]any, 0, len(keys)*2+2)
+		for _, key := range keys {
+			pairs = append(pairs, "(?, ?)")
 			args = append(args, key.messageID, key.requestID)
 		}
-		query := duckActivityReportUsageQuery(
-			"AND ("+strings.Join(predicates, " OR ")+")", "AND FALSE")
+		query := duckActivityReportUsageQuery(`AND EXISTS (
+			SELECT 1
+			FROM (VALUES `+strings.Join(pairs, ", ")+`) AS peer_keys(message_id, request_id)
+			WHERE peer_keys.message_id = m.claude_message_id
+			  AND peer_keys.request_id = m.claude_request_id
+		)`, "AND FALSE")
 		args = append(args, lowerBound, upperBound)
 		if err := loadRows(query, args, candidateIDs); err != nil {
 			return nil, nil, err

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -60,7 +60,8 @@ func (s *Store) GetActivityReport(
 		return activity.Report{}, err
 	}
 
-	usage, pricing, err := s.activityReportUsage(ctx, ids, lowerBound, upperBound, q)
+	usage, pricing, err := s.activityReportUsage(
+		ctx, ids, f, rangeStartUTC, rangeEndUTC, lowerBound, upperBound, q)
 	if err != nil {
 		return activity.Report{}, err
 	}
@@ -386,9 +387,8 @@ func activityReportProjectLabels(sessions []activity.SessionMeta) []string {
 func (s *Store) activityReportSessions(
 	ctx context.Context, f db.AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
 ) ([]activity.SessionMeta, []string, error) {
-	where, args := duckBuildAnalyticsWhere(
-		f, "COALESCE(s.started_at, s.created_at)", "s.", false, false)
-	args = append(args, rangeStartUTC, rangeEndUTC)
+	where, args := duckActivityReportCandidateWhere(
+		f, rangeStartUTC, rangeEndUTC)
 
 	query := `SELECT
 		s.id,
@@ -400,12 +400,7 @@ func (s *Store) activityReportSessions(
 		s.ended_at,
 		COALESCE(s.is_automated, false) AS is_automated
 	FROM sessions s
-	WHERE ` + where + `
-		AND COALESCE(s.ended_at,
-			(SELECT MAX(m.timestamp) FROM messages m
-				WHERE m.session_id = s.id AND m.timestamp IS NOT NULL),
-			s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)
-		AND COALESCE(s.started_at, s.created_at) < CAST(? AS TIMESTAMP)`
+	WHERE ` + where
 
 	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
@@ -436,6 +431,20 @@ func (s *Store) activityReportSessions(
 			"iterating duckdb activity report sessions: %w", err)
 	}
 	return sessions, ids, nil
+}
+
+func duckActivityReportCandidateWhere(
+	f db.AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
+) (string, []any) {
+	where, args := duckBuildAnalyticsWhere(
+		f, "COALESCE(s.started_at, s.created_at)", "s.", false, false)
+	where += `
+		AND COALESCE(s.ended_at,
+			(SELECT MAX(m.timestamp) FROM messages m
+				WHERE m.session_id = s.id AND m.timestamp IS NOT NULL),
+			s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)
+		AND COALESCE(s.started_at, s.created_at) < CAST(? AS TIMESTAMP)`
+	return where, append(args, rangeStartUTC, rangeEndUTC)
 }
 
 // activityReportActivity returns every timestamped message for the
@@ -509,11 +518,17 @@ type duckActivityReportUsageRow struct {
 	costSource        string
 }
 
-// activityReportUsage selects complete snapshots across the padded range,
-// then keeps rows attributed to the candidate sessions. Cost is computed
-// after selection so filtered rows do not affect pricing metadata.
+// activityReportUsage derives the candidate sessions and their Claude snapshot
+// peers inside one DuckDB query. Snapshot key count therefore does not expand
+// the SQL text or bind list. Cost is computed after selection so filtered rows
+// do not affect pricing metadata.
 func (s *Store) activityReportUsage(
-	ctx context.Context, ids []string, lowerBound, upperBound string, q activity.Query,
+	ctx context.Context,
+	ids []string,
+	f db.AnalyticsFilter,
+	rangeStartUTC, rangeEndUTC string,
+	lowerBound, upperBound string,
+	q activity.Query,
 ) ([]activity.UsageRow, *export.PricingBlock, error) {
 	out := []activity.UsageRow{}
 
@@ -540,118 +555,57 @@ func (s *Store) activityReportUsage(
 		ordinal int64
 	}
 	var rowsAcc []ordered
-	loadRows := func(
-		query string, args []any, skipSessionIDs map[string]struct{},
-	) error {
-		rows, queryErr := s.queryContext(ctx, query, args...)
-		if queryErr != nil {
-			return fmt.Errorf("querying duckdb activity report usage: %w", queryErr)
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var r duckActivityReportUsageRow
-			if err := rows.Scan(
-				&r.sessionID, &r.messageOrdinal, &r.ts, &r.source, &r.model,
-				&r.agent, &r.claudeMessageID, &r.claudeRequestID, &r.sourceUUID,
-				&r.usageDedupKey,
-				&r.inputTok, &r.outputTok, &r.cacheCr, &r.cacheRd,
-				&r.reasoningTok, &r.webSearchRequests, &r.cost, &r.costSource,
-			); err != nil {
-				return fmt.Errorf(
-					"scanning duckdb activity report usage: %w", err)
-			}
-			if _, skip := skipSessionIDs[r.sessionID]; skip {
-				continue
-			}
-			tsStr := formatDBTime(r.ts)
-			ord := int64(-1)
-			if o, ok := duckUsageOrdinal(r.messageOrdinal); ok {
-				ord = o
-			}
-			parsedTS, _ := parseTimestamp(tsStr)
-			rowsAcc = append(rowsAcc, ordered{
-				ts:      parsedTS,
-				ordinal: ord,
-				scan:    r,
-				row: activity.UsageRow{
-					SessionID:         r.sessionID,
-					Model:             r.model,
-					Timestamp:         tsStr,
-					OutputTokens:      r.outputTok,
-					WebSearchRequests: r.webSearchRequests,
-					Agent:             r.agent,
-					ClaudeMessageID:   r.claudeMessageID,
-					ClaudeRequestID:   r.claudeRequestID,
-					SourceUUID:        r.sourceUUID,
-					UsageDedupKey:     r.usageDedupKey,
-				},
-			})
-		}
-		return rows.Err()
+	candidateWhere, candidateArgs := duckActivityReportCandidateWhere(
+		f, rangeStartUTC, rangeEndUTC)
+	query := duckActivityReportUsageQuery(candidateWhere)
+	args := make([]any, 0, len(candidateArgs)+2)
+	args = append(args, lowerBound, upperBound)
+	args = append(args, candidateArgs...)
+	rows, err := s.queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"querying duckdb activity report usage: %w", err)
 	}
-
-	const usageChunk = 500
-	for i := 0; i < len(ids); i += usageChunk {
-		end := min(i+usageChunk, len(ids))
-		chunkArgs, placeholders := stringInArgs(ids[i:end])
-		inClause := "(" + strings.Join(placeholders, ",") + ")"
-		query := duckActivityReportUsageQuery(
-			"AND m.session_id IN "+inClause,
-			"AND ue.session_id IN "+inClause)
-		args := make([]any, 0, len(chunkArgs)*2+2)
-		args = append(args, chunkArgs...)
-		args = append(args, chunkArgs...)
-		args = append(args, lowerBound, upperBound)
-		if err := loadRows(query, args, nil); err != nil {
-			return nil, nil, err
+	defer rows.Close()
+	for rows.Next() {
+		var r duckActivityReportUsageRow
+		if err := rows.Scan(
+			&r.sessionID, &r.messageOrdinal, &r.ts, &r.source, &r.model,
+			&r.agent, &r.claudeMessageID, &r.claudeRequestID, &r.sourceUUID,
+			&r.usageDedupKey,
+			&r.inputTok, &r.outputTok, &r.cacheCr, &r.cacheRd,
+			&r.reasoningTok, &r.webSearchRequests, &r.cost, &r.costSource,
+		); err != nil {
+			return nil, nil, fmt.Errorf(
+				"scanning duckdb activity report usage: %w", err)
 		}
-	}
-
-	type snapshotKey struct {
-		messageID string
-		requestID string
-	}
-	keySet := make(map[snapshotKey]struct{})
-	for _, candidate := range rowsAcc {
-		if candidate.row.ClaudeMessageID == "" || candidate.row.ClaudeRequestID == "" {
-			continue
+		tsStr := formatDBTime(r.ts)
+		ord := int64(-1)
+		if o, ok := duckUsageOrdinal(r.messageOrdinal); ok {
+			ord = o
 		}
-		keySet[snapshotKey{
-			messageID: candidate.row.ClaudeMessageID,
-			requestID: candidate.row.ClaudeRequestID,
-		}] = struct{}{}
+		parsedTS, _ := parseTimestamp(tsStr)
+		rowsAcc = append(rowsAcc, ordered{
+			ts:      parsedTS,
+			ordinal: ord,
+			scan:    r,
+			row: activity.UsageRow{
+				SessionID:         r.sessionID,
+				Model:             r.model,
+				Timestamp:         tsStr,
+				OutputTokens:      r.outputTok,
+				WebSearchRequests: r.webSearchRequests,
+				Agent:             r.agent,
+				ClaudeMessageID:   r.claudeMessageID,
+				ClaudeRequestID:   r.claudeRequestID,
+				SourceUUID:        r.sourceUUID,
+				UsageDedupKey:     r.usageDedupKey,
+			},
+		})
 	}
-	keys := make([]snapshotKey, 0, len(keySet))
-	for key := range keySet {
-		keys = append(keys, key)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		if keys[i].messageID != keys[j].messageID {
-			return keys[i].messageID < keys[j].messageID
-		}
-		return keys[i].requestID < keys[j].requestID
-	})
-	candidateIDs := make(map[string]struct{}, len(ids))
-	for _, id := range ids {
-		candidateIDs[id] = struct{}{}
-	}
-	if len(keys) > 0 {
-		pairs := make([]string, 0, len(keys))
-		args := make([]any, 0, len(keys)*2+2)
-		for _, key := range keys {
-			pairs = append(pairs, "(?, ?)")
-			args = append(args, key.messageID, key.requestID)
-		}
-		query := duckActivityReportUsageQuery(`AND EXISTS (
-			SELECT 1
-			FROM (VALUES `+strings.Join(pairs, ", ")+`) AS peer_keys(message_id, request_id)
-			WHERE peer_keys.message_id = m.claude_message_id
-			  AND peer_keys.request_id = m.claude_request_id
-		)`, "AND FALSE")
-		args = append(args, lowerBound, upperBound)
-		if err := loadRows(query, args, candidateIDs); err != nil {
-			return nil, nil, err
-		}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf(
+			"iterating duckdb activity report usage: %w", err)
 	}
 
 	sort.SliceStable(rowsAcc, func(i, j int) bool {
@@ -702,14 +656,23 @@ func (s *Store) activityReportUsage(
 }
 
 // duckActivityReportUsageQuery builds the per-row usage-union SQL across the
-// padded time range. It applies the same message and usage-event
-// eligibility predicates as GetDailyUsage (empty token_usage, empty, and
-// synthetic models excluded) so the daily totals match the Usage
-// dashboard, normalizes the per-source token columns in SQL, and bounds
-// rows to the padded range window. Cost is computed per row in Go.
-func duckActivityReportUsageQuery(messageFilter, eventFilter string) string {
+// padded time range. Candidate sessions, their usage rows, and matching Claude
+// snapshot peers are relations in one statement, so the query shape stays
+// constant as the peer-key set grows. It applies the same message and
+// usage-event eligibility predicates as GetDailyUsage, then normalizes rows in
+// SQL. Cost is computed per row in Go.
+func duckActivityReportUsageQuery(candidateWhere string) string {
 	return fmt.Sprintf(`
-		WITH usage_raw AS (
+		WITH report_bounds AS (
+			SELECT CAST(? AS TIMESTAMP) AS lower_bound,
+				CAST(? AS TIMESTAMP) AS upper_bound
+		),
+		candidate_sessions AS (
+			SELECT s.id
+			FROM sessions s
+			WHERE %[2]s
+		),
+		candidate_messages AS (
 			SELECT m.session_id AS session_id, m.ordinal AS message_ordinal,
 				'message' AS source, COALESCE(m.timestamp, s.started_at) AS ts,
 				m.model AS model, m.token_usage AS token_json,
@@ -724,12 +687,16 @@ func duckActivityReportUsageQuery(messageFilter, eventFilter string) string {
 					NULL AS cost_microdollars, '' AS cost_source
 			FROM messages m
 			JOIN sessions s ON s.id = m.session_id
+			JOIN candidate_sessions candidate ON candidate.id = m.session_id
+			CROSS JOIN report_bounds bounds
 			WHERE m.token_usage != ''
 				AND m.model != ''
 				AND m.model != '<synthetic>'
 				AND s.deleted_at IS NULL
-				%[2]s
-			UNION ALL
+				AND COALESCE(m.timestamp, s.started_at) >= bounds.lower_bound
+				AND COALESCE(m.timestamp, s.started_at) <= bounds.upper_bound
+		),
+		candidate_events AS (
 			SELECT ue.session_id AS session_id, ue.message_ordinal AS message_ordinal,
 				ue.source AS source, COALESCE(ue.occurred_at, s.started_at) AS ts,
 				ue.model AS model, '' AS token_json,
@@ -748,9 +715,52 @@ func duckActivityReportUsageQuery(messageFilter, eventFilter string) string {
 					ue.cost_source AS cost_source
 			FROM usage_events ue
 			JOIN sessions s ON s.id = ue.session_id
+			JOIN candidate_sessions candidate ON candidate.id = ue.session_id
+			CROSS JOIN report_bounds bounds
 			WHERE ue.model != ''
 				AND s.deleted_at IS NULL
-				%[3]s
+				AND COALESCE(ue.occurred_at, s.started_at) >= bounds.lower_bound
+				AND COALESCE(ue.occurred_at, s.started_at) <= bounds.upper_bound
+		),
+		peer_keys AS (
+			SELECT DISTINCT claude_message_id, claude_request_id
+			FROM candidate_messages
+			WHERE claude_message_id != '' AND claude_request_id != ''
+		),
+		peer_messages AS (
+			SELECT m.session_id AS session_id, m.ordinal AS message_ordinal,
+				'message' AS source, COALESCE(m.timestamp, s.started_at) AS ts,
+				m.model AS model, m.token_usage AS token_json,
+				s.agent AS agent,
+				m.claude_message_id AS claude_message_id,
+				m.claude_request_id AS claude_request_id,
+				m.source_uuid AS source_uuid,
+				'' AS usage_dedup_key,
+				0 AS input_tokens, 0 AS output_tokens,
+				0 AS cache_create, 0 AS cache_read,
+				COALESCE(TRY_CAST(json_extract_string(m.token_usage, '$.reasoning_tokens') AS BIGINT), 0) AS reasoning_tokens,
+				NULL AS cost_microdollars, '' AS cost_source
+			FROM messages m
+			JOIN sessions s ON s.id = m.session_id
+			JOIN peer_keys peer
+				ON peer.claude_message_id = m.claude_message_id
+				AND peer.claude_request_id = m.claude_request_id
+			LEFT JOIN candidate_sessions candidate ON candidate.id = m.session_id
+			CROSS JOIN report_bounds bounds
+			WHERE candidate.id IS NULL
+				AND m.token_usage != ''
+				AND m.model != ''
+				AND m.model != '<synthetic>'
+				AND s.deleted_at IS NULL
+				AND COALESCE(m.timestamp, s.started_at) >= bounds.lower_bound
+				AND COALESCE(m.timestamp, s.started_at) <= bounds.upper_bound
+		),
+		usage_raw AS (
+			SELECT * FROM candidate_messages
+			UNION ALL
+			SELECT * FROM candidate_events
+			UNION ALL
+			SELECT * FROM peer_messages
 		),
 		usage_normalized AS (
 			SELECT session_id, message_ordinal, ts, source, model, agent,
@@ -793,10 +803,8 @@ func duckActivityReportUsageQuery(messageFilter, eventFilter string) string {
 				cache_create_norm, cache_read_norm, reasoning_tokens_norm,
 				web_search_requests_norm,
 				cost_microdollars, cost_source
-		FROM usage_normalized
-		WHERE ts >= CAST(? AS TIMESTAMP)
-			AND ts <= CAST(? AS TIMESTAMP)`,
-		db.MaxPlausibleTokens, messageFilter, eventFilter)
+		FROM usage_normalized`,
+		db.MaxPlausibleTokens, candidateWhere)
 }
 
 // duckActivityReportRowStatus computes one usage row's cost and pricing state the same way

--- a/internal/duckdb/activityreport_test.go
+++ b/internal/duckdb/activityreport_test.go
@@ -5,6 +5,7 @@ package duckdb
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -284,6 +285,52 @@ func TestDuckGetActivityReportFiltersAfterCrossSessionSnapshotSelection(
 	assert.Equal(t, 1, childReport.Totals.Sessions)
 	assert.Zero(t, childReport.Totals.OutputTokens,
 		"the child source must not claim usage attributed to the parent")
+}
+
+func TestDuckGetActivityReportSelectsPeersForLargeSnapshotKeySet(t *testing.T) {
+	const pairCount = duckMaxSQLVars + 1
+	ctx := context.Background()
+	candidate := syncSession(
+		"large-candidate", "included-project", "candidate",
+		"2026-06-14T10:00:00.000Z", pairCount)
+	peer := syncSession(
+		"large-peer", "excluded-project", "peer",
+		"2026-06-14T10:01:00.000Z", pairCount)
+	candidateMessages := make([]db.Message, pairCount)
+	peerMessages := make([]db.Message, pairCount)
+	for i := range pairCount {
+		messageID := fmt.Sprintf("large-message-%04d", i)
+		requestID := fmt.Sprintf("large-request-%04d", i)
+		candidateMessages[i] = syncMessage(
+			candidate.ID, i, "assistant", "partial",
+			"2026-06-14T10:00:00.000Z")
+		candidateMessages[i].ClaudeMessageID = messageID
+		candidateMessages[i].ClaudeRequestID = requestID
+		candidateMessages[i].TokenUsage = json.RawMessage(
+			`{"input_tokens":1,"output_tokens":1}`)
+		candidateMessages[i].OutputTokens = 1
+		peerMessages[i] = syncMessage(
+			peer.ID, i, "assistant", "complete",
+			"2026-06-14T10:01:00.000Z")
+		peerMessages[i].ClaudeMessageID = messageID
+		peerMessages[i].ClaudeRequestID = requestID
+		peerMessages[i].TokenUsage = json.RawMessage(
+			`{"input_tokens":1,"output_tokens":10}`)
+		peerMessages[i].OutputTokens = 10
+	}
+	store := activityReportStore(t, []db.SessionBatchWrite{
+		{Session: candidate, Messages: candidateMessages,
+			DataVersion: 1, ReplaceMessages: true},
+		{Session: peer, Messages: peerMessages,
+			DataVersion: 1, ReplaceMessages: true},
+	}, nil)
+
+	report, err := store.GetActivityReport(ctx, db.AnalyticsFilter{
+		Project: "included-project", Timezone: "UTC",
+	}, duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, pairCount*10, report.Totals.OutputTokens,
+		"every complete peer snapshot must remain attributed to the candidate")
 }
 
 func TestDuckGetActivityReportDeduplicatesAfterProjectFilter(t *testing.T) {

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -578,14 +578,18 @@ func (s *Store) activityReportUsage(
 	for i := 0; i < len(keys); i += peerChunk {
 		end := min(i+peerChunk, len(keys))
 		pb := &paramBuilder{}
-		predicates := make([]string, 0, end-i)
+		pairs := make([]string, 0, end-i)
 		for _, key := range keys[i:end] {
-			predicates = append(predicates,
-				"(m.claude_message_id = "+pb.add(key.messageID)+
-					" AND m.claude_request_id = "+pb.add(key.requestID)+")")
+			pairs = append(pairs,
+				"("+pb.add(key.messageID)+", "+pb.add(key.requestID)+")")
 		}
 		rowsSQL := pgDailyUsageRowsSQLWithWhere(
-			pgUsageMessageEligibility+" AND ("+strings.Join(predicates, " OR ")+")",
+			pgUsageMessageEligibility+` AND EXISTS (
+				SELECT 1
+				FROM (VALUES `+strings.Join(pairs, ", ")+`) AS peer_keys(message_id, request_id)
+				WHERE peer_keys.message_id = m.claude_message_id
+				  AND peer_keys.request_id = m.claude_request_id
+			)`,
 			pgUsageEventEligibility+" AND FALSE")
 		if err := loadRows(rowsSQL, pb, candidateIDs); err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Weekly Activity reports could exceed the API timeout because each backend
compared thousands of Claude snapshot keys through wide disjunctive predicates
and repeated scans. The report now presents those keys as relations and uses
set-based lookups while preserving cross-session complete-snapshot attribution.

SQLite binds peer keys once as a JSON rowset and adds a pair-leading partial
index for this access path. PostgreSQL uses bounded values relations. DuckDB
derives candidate sessions, peer keys, and matching snapshots inside one
read-only query, so peer count does not expand its SQL text or bind list and
the same path works for local mirrors and Quack.

For a production-scale week, SQLite dropped from 156.38 seconds to 5.25–6.18
seconds, PostgreSQL from 71.52 seconds to 6.00–6.05 seconds, and DuckDB from
8.45 seconds to 0.73–0.77 seconds. Usage remains unchanged because it already
uses set-based snapshot ranking; the equivalent summary measured 0.91–1.26
seconds on SQLite, 0.98–1.14 seconds on PostgreSQL, and 0.39–0.41 seconds on
DuckDB.
