### PR TITLE
ci: isolate slow Windows Go packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,13 +174,18 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          # DuckDB runs in its own job below so its CGo-heavy package does not
-          # occupy one of this four-core runner's package workers for minutes.
+          # SQLite-heavy packages run in their own jobs below so they do not
+          # compete for this runner's package workers and timeout budget.
           $packages = @(go list ./...)
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
-          $packages = $packages | Where-Object { $_ -ne 'go.kenn.io/agentsview/internal/duckdb' }
+          $isolatedPackages = @(
+            'go.kenn.io/agentsview/internal/db'
+            'go.kenn.io/agentsview/internal/duckdb'
+            'go.kenn.io/agentsview/internal/parser'
+          )
+          $packages = $packages | Where-Object { $_ -notin $isolatedPackages }
           go test -tags "fts5" $packages -count=1 -timeout=20m
         env:
           CGO_ENABLED: "1"
@@ -200,6 +205,56 @@ jobs:
       - name: Warn on coverage upload failure
         if: runner.os == 'Linux' && steps.codecov.outcome == 'failure'
         run: echo "::warning::Codecov upload failed"
+
+  # Keep the two slowest SQLite-backed packages isolated from each other and
+  # from the remaining Windows package set.
+  test-sqlite-packages-windows:
+    name: Go Test (windows-latest, ${{ matrix.name }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Database
+            package: ./internal/db
+          - name: Parser
+            package: ./internal/parser
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Setup MinGW
+        id: setup_mingw
+        continue-on-error: true
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: mingw-w64-x86_64-gcc
+          path-type: inherit
+
+      - name: Setup MinGW (retry on transient failure)
+        if: steps.setup_mingw.outcome == 'failure'
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: mingw-w64-x86_64-gcc
+          path-type: inherit
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
+
+      - name: Run ${{ matrix.name }} tests
+        run: go test -tags "fts5" ${{ matrix.package }} -count=1 -timeout=20m
+        env:
+          CGO_ENABLED: "1"
 
   # Keep the derived-mirror suite concurrent with the main Windows package set.
   test-duckdb-windows:


### PR DESCRIPTION
Hosted Windows runners intermittently slow SQLite-heavy packages enough that internal/db and internal/parser can exhaust their 20-minute package timeouts together. This moves those packages to separate matrix runners and removes them from the shared Windows package set; DuckDB remains isolated in its existing job.

The split retains the current fts5 flags and timeouts. It trades two additional Windows jobs for lower package contention and more precise failure attribution. Review the package exclusion list and test-sqlite-packages-windows matrix.