### PR TITLE
fix(parser): repair non-compiling test call on main

### DIFF
--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -634,7 +634,7 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 	t.Run("custom_tool_call_output for a stored call requests full parse", func(t *testing.T) {
 		line := `{"timestamp":"2026-07-08T03:20:43.376Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_abc","output":"Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess."}}`
 
-		b := newCodexSessionBuilder(false)
+		b := newCodexSessionBuilder(false, nil)
 		assert.True(t,
 			b.incrementalOutputNeedsFullParse(gjson.Get(line, "payload")))
 	})


### PR DESCRIPTION
## Summary

Main does not compile for test builds: #1384 added a `codexParentTurnResolver` parameter to `newCodexSessionBuilder`, and #1391 added a test call using the old one-argument form. The two merged cleanly text-wise, so `internal/parser/codex_parser_test.go:637` now fails typecheck, which breaks lint and every Go test job on all pull request runs (the push-on-main workflow does not catch it).

One line: pass a `nil` resolver, matching the neighboring builder test at line 507 that was already resolved this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)