### PR TITLE
fix(parser): restore Codex test compilation

### DIFF
--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -634,7 +634,7 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 	t.Run("custom_tool_call_output for a stored call requests full parse", func(t *testing.T) {
 		line := `{"timestamp":"2026-07-08T03:20:43.376Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_abc","output":"Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess."}}`
 
-		b := newCodexSessionBuilder(false)
+		b := newCodexSessionBuilder(false, nil)
 		assert.True(t,
 			b.incrementalOutputNeedsFullParse(gjson.Get(line, "payload")))
 	})


### PR DESCRIPTION
Main could no longer compile the Codex parser tests after two independent parser changes merged with incompatible constructor calls. This restores all Go test and lint jobs by supplying the intentionally unused parent-turn resolver argument.

The change is limited to the affected test. Runtime parser behavior is unchanged.

<sup>generated by a clanker</sup>
