### PR TITLE
chore: update Go to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci
 COPY frontend/ ./
 RUN npm run build
 
-FROM golang:1.26.3-bookworm AS build
+FROM golang:1.26.6-bookworm AS build
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential ca-certificates \

--- a/docs/screenshots/Dockerfile
+++ b/docs/screenshots/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build agentsview binary
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.26.6-bookworm AS builder
 
 ARG AV_VERSION=dev
 ARG AV_COMMIT=unknown

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.kenn.io/agentsview
 
-go 1.26.3
+go 1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
Go 1.26.6 is now the required Go release for agentsview builds. This release
fixes a checksum database bypass and module-cache attacks described in the
[Go 1.26.6 security advisory](https://freenode.net/article/go-1-26-6-and-1-25-13-fix-sumdb-bypass-and-module-cache-attacks).

CI continues to derive its toolchain from `go.mod`. The production and
screenshot-builder images now use the same patch release, so those builds do
not fall back to an older or floating Go 1.26 image.

This change is limited to active toolchain pins. It does not update dependencies
or rewrite historical implementation notes.
