### PR TITLE
fix(sync): bound startup reconciliation and expose daemon identity

### DIFF
--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -417,6 +417,25 @@ func daemonPersistentStartupError(
 	)
 }
 
+// startupStateStopRecord turns a pre-runtime startup snapshot into the
+// identity-bearing record used by daemon stop and restart. Older snapshots
+// without an OS process create time remain deliberately un-stoppable: a PID
+// alone is not enough evidence to signal a process safely.
+func startupStateStopRecord(st *startupState) (daemon.RuntimeRecord, bool) {
+	if st == nil || st.PID <= 0 || st.CreateTime == "" {
+		return daemon.RuntimeRecord{}, false
+	}
+	return daemon.RuntimeRecord{
+		PID:       st.PID,
+		Service:   daemonService,
+		Version:   st.Version,
+		StartedAt: st.StartedAt,
+		Metadata: map[string]string{
+			runtimeCreateTime: st.CreateTime,
+		},
+	}, true
+}
+
 func writeDaemonStartResult(w io.Writer, result backgroundLaunchResult, restarted bool) {
 	if result.Runtime != nil && !result.Started {
 		fmt.Fprintf(w, "agentsview already running at %s (pid %d)\n", urlFromDaemonRuntime(result.Runtime), result.Runtime.Record.PID)
@@ -615,20 +634,31 @@ func runDaemonStop(w io.Writer, deps daemonCommandDeps) error {
 	if err := validateLockedDataDir(dataDir, cfg.DataDir); err != nil {
 		return fmt.Errorf("daemon stop: %w", err)
 	}
+	starting := deps.isStarting(cfg.DataDir)
+	startupSnapshot := deps.readStartupState(cfg.DataDir)
 	records, err := deps.writableRecords(cfg.DataDir, cfg.AuthToken)
 	if err != nil {
 		fallback := writableRuntimeFallbackForCommand(cfg, deps)
 		if fallback == nil {
-			return fmt.Errorf("daemon stop: inspecting runtime store: %w", err)
+			if startupRecord, ok := startupStateStopRecord(startupSnapshot); starting && ok {
+				records = []daemon.RuntimeRecord{startupRecord}
+			} else {
+				return fmt.Errorf("daemon stop: inspecting runtime store: %w", err)
+			}
+		} else {
+			records = []daemon.RuntimeRecord{fallback.Record}
 		}
-		records = []daemon.RuntimeRecord{fallback.Record}
 	} else {
 		var fallback bool
 		records, fallback = writableDaemonRecordsWithFallback(records, func() *DaemonRuntime {
 			return writableRuntimeFallbackForCommand(cfg, deps)
 		})
-		if !fallback && deps.isStarting(cfg.DataDir) {
-			return daemonPersistentStartupError("daemon stop", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
+		if !fallback && starting {
+			if startupRecord, ok := startupStateStopRecord(startupSnapshot); ok && len(records) == 0 {
+				records = []daemon.RuntimeRecord{startupRecord}
+			} else {
+				return daemonPersistentStartupError("daemon stop", cfg.DataDir, startupSnapshot, deps.now())
+			}
 		}
 	}
 	if len(records) == 0 {
@@ -675,9 +705,16 @@ func runDaemonRestartWithPolicy(
 	if err := validateLockedDataDir(dataDir, cfg.DataDir); err != nil {
 		return fmt.Errorf("daemon restart: %w", err)
 	}
+	starting := deps.isStarting(cfg.DataDir)
+	startupSnapshot := deps.readStartupState(cfg.DataDir)
 	fallback := writableRuntimeFallbackForCommand(cfg, deps)
-	if fallback == nil && deps.isStarting(cfg.DataDir) {
-		return daemonPersistentStartupError("daemon restart", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
+	var startupRecord *daemon.RuntimeRecord
+	if fallback == nil && starting {
+		rec, ok := startupStateStopRecord(startupSnapshot)
+		if !ok {
+			return daemonPersistentStartupError("daemon restart", cfg.DataDir, startupSnapshot, deps.now())
+		}
+		startupRecord = &rec
 	}
 	if err := deps.validateConfig(cfg); err != nil {
 		return fmt.Errorf("daemon restart: invalid config: %w", err)
@@ -687,12 +724,17 @@ func runDaemonRestartWithPolicy(
 	}
 	records, err := deps.writableRecords(cfg.DataDir, cfg.AuthToken)
 	if err != nil {
-		if fallback == nil {
+		if fallback == nil && startupRecord == nil {
 			return fmt.Errorf("daemon restart: inspecting runtime store: %w", err)
 		}
 	}
 	if fallback != nil {
 		records = []daemon.RuntimeRecord{fallback.Record}
+	} else if startupRecord != nil {
+		if len(records) > 0 {
+			return daemonPersistentStartupError("daemon restart", cfg.DataDir, startupSnapshot, deps.now())
+		}
+		records = []daemon.RuntimeRecord{*startupRecord}
 	}
 	wasRunning := len(records) > 0
 	if wasRunning {

--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -425,7 +426,7 @@ func startupStateStopRecord(st *startupState) (daemon.RuntimeRecord, bool) {
 	if st == nil || st.PID <= 0 || st.CreateTime == "" {
 		return daemon.RuntimeRecord{}, false
 	}
-	return daemon.RuntimeRecord{
+	rec := daemon.RuntimeRecord{
 		PID:       st.PID,
 		Service:   daemonService,
 		Version:   st.Version,
@@ -433,7 +434,14 @@ func startupStateStopRecord(st *startupState) (daemon.RuntimeRecord, bool) {
 		Metadata: map[string]string{
 			runtimeCreateTime: st.CreateTime,
 		},
-	}, true
+	}
+	if st.CaddyPID > 0 {
+		rec.Metadata[runtimeCaddyPID] = strconv.Itoa(st.CaddyPID)
+	}
+	if st.CaddyCreateTime != "" {
+		rec.Metadata[runtimeCaddyCreateTime] = st.CaddyCreateTime
+	}
+	return rec, true
 }
 
 func writeDaemonStartResult(w io.Writer, result backgroundLaunchResult, restarted bool) {

--- a/cmd/agentsview/daemon_test.go
+++ b/cmd/agentsview/daemon_test.go
@@ -250,11 +250,14 @@ func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
 	deps, out := daemonCommandTestDeps(t)
 	deps.isStarting = func(string) bool { return true }
 	deps.readStartupState = func(string) *startupState {
-		return &startupState{PID: 77, Phase: "starting HTTP server"}
+		return &startupState{
+			PID: 77, Version: "v1.2.3-test", CreateTime: "123456789",
+			Phase: "starting HTTP server",
+		}
 	}
 	var stopped daemon.RuntimeRecord
-	deps.writableRuntime = func(string, string) *DaemonRuntime {
-		return &DaemonRuntime{Record: testWritableRecord(77, ""), RuntimeFallback: true}
+	deps.stopTargetConfirmed = func(rec daemon.RuntimeRecord, _ string) bool {
+		return rec.PID == 77 && rec.Metadata[runtimeCreateTime] == "123456789"
 	}
 	deps.stopProcess = func(rec daemon.RuntimeRecord, _ time.Duration) error {
 		stopped = rec
@@ -264,6 +267,7 @@ func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
 	err := executeDaemonCommand(t, *deps, out, "stop")
 	require.NoError(t, err)
 	assert.Equal(t, 77, stopped.PID)
+	assert.Equal(t, "v1.2.3-test", stopped.Version)
 	assert.Contains(t, out.String(), "Stopped agentsview (pid 77).")
 	assert.NotContains(t, out.String(), "starting up")
 }
@@ -441,9 +445,12 @@ func TestDaemonStatusRendersStoppedStartingReadOnlyAndIncompatible(t *testing.T)
 		{name: "starting", setup: func(d *daemonCommandDeps) {
 			d.isStarting = func(string) bool { return true }
 			d.readStartupState = func(string) *startupState {
-				return &startupState{PID: 9, StartedAt: time.Unix(100, 0), Phase: "sync", LogPath: "/tmp/log"}
+				return &startupState{
+					PID: 9, Version: "v1.2.3-starting", StartedAt: time.Unix(100, 0),
+					Phase: "sync", LogPath: "/tmp/log",
+				}
 			}
-		}, wanted: []string{"starting", "pid:     9", "phase:   sync", "/tmp/log"}},
+		}, wanted: []string{"starting", "pid:     9", "version: v1.2.3-starting", "phase:   sync", "/tmp/log"}},
 		{name: "read only", setup: func(d *daemonCommandDeps) {
 			d.statusRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
 				rec := testWritableRecord(10, "/runtime/10.json")
@@ -1047,13 +1054,14 @@ func TestDaemonRestartFailurePathsSignalNobody(t *testing.T) {
 func TestDaemonRestartUsesStartupStateFallbackWhileStarting(t *testing.T) {
 	deps, out := daemonCommandTestDeps(t)
 	deps.isStarting = func(string) bool { return true }
-	deps.writableRuntime = func(string, string) *DaemonRuntime {
-		return &DaemonRuntime{
-			Record:          testWritableRecord(113, ""),
-			Host:            "127.0.0.1",
-			Port:            8113,
-			RuntimeFallback: true,
+	deps.readStartupState = func(string) *startupState {
+		return &startupState{
+			PID: 113, Version: "v1.2.3-test", CreateTime: "987654321",
+			Phase: "initial sync",
 		}
+	}
+	deps.stopTargetConfirmed = func(rec daemon.RuntimeRecord, _ string) bool {
+		return rec.PID == 113 && rec.Metadata[runtimeCreateTime] == "987654321"
 	}
 	var stopped daemon.RuntimeRecord
 	deps.stopProcess = func(rec daemon.RuntimeRecord, _ time.Duration) error {

--- a/cmd/agentsview/daemon_test.go
+++ b/cmd/agentsview/daemon_test.go
@@ -252,7 +252,8 @@ func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
 	deps.readStartupState = func(string) *startupState {
 		return &startupState{
 			PID: 77, Version: "v1.2.3-test", CreateTime: "123456789",
-			Phase: "starting HTTP server",
+			Phase: "starting HTTP server", CaddyPID: 88,
+			CaddyCreateTime: "222222222",
 		}
 	}
 	var stopped daemon.RuntimeRecord
@@ -263,11 +264,18 @@ func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
 		stopped = rec
 		return nil
 	}
+	var cleaned daemon.RuntimeRecord
+	deps.stopCaddy = func(_ io.Writer, rec daemon.RuntimeRecord) error {
+		cleaned = rec
+		return nil
+	}
 
 	err := executeDaemonCommand(t, *deps, out, "stop")
 	require.NoError(t, err)
 	assert.Equal(t, 77, stopped.PID)
 	assert.Equal(t, "v1.2.3-test", stopped.Version)
+	assert.Equal(t, "88", cleaned.Metadata[runtimeCaddyPID])
+	assert.Equal(t, "222222222", cleaned.Metadata[runtimeCaddyCreateTime])
 	assert.Contains(t, out.String(), "Stopped agentsview (pid 77).")
 	assert.NotContains(t, out.String(), "starting up")
 }

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -455,8 +455,9 @@ func runServe(cfg config.Config, opts serveOptions) {
 	go startPeriodicPricingRefresh(ctx, database, pricingRefreshRunner)
 
 	rtOpts := serveRuntimeOptions{
-		Mode:          "serve",
-		RequestedPort: cfg.Port,
+		Mode:           "serve",
+		RequestedPort:  cfg.Port,
+		OnCaddyStarted: startupProgress.SetCaddyProcess,
 	}
 	preparedCfg, prepErr := prepareServeRuntimeConfig(cfg, rtOpts)
 	if prepErr != nil {

--- a/cmd/agentsview/managed_caddy.go
+++ b/cmd/agentsview/managed_caddy.go
@@ -298,6 +298,7 @@ func startManagedCaddy(
 	parent context.Context,
 	cfg config.Config,
 	mode string,
+	onStarted func(int),
 ) (*managedCaddy, error) {
 	configPath, content, err := prepareManagedCaddyConfig(
 		cfg,
@@ -345,6 +346,9 @@ func startManagedCaddy(
 	if err := cmd.Start(); err != nil {
 		cancel()
 		return nil, fmt.Errorf("starting managed caddy: %w", err)
+	}
+	if onStarted != nil {
+		onStarted(cmd.Process.Pid)
 	}
 
 	// Bind Caddy's lifetime to this server process so it cannot outlive a

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -229,6 +229,9 @@ func serveStartingStatusLines(st *startupState, now time.Time) []string {
 	if st.PID > 0 {
 		lines = append(lines, fmt.Sprintf("  pid:     %d", st.PID))
 	}
+	if st.Version != "" {
+		lines = append(lines, "  version: "+st.Version)
+	}
 	if !st.StartedAt.IsZero() {
 		if elapsed := now.Sub(st.StartedAt).Round(time.Second); elapsed >= 0 {
 			lines = append(lines, fmt.Sprintf("  elapsed: %s", elapsed))

--- a/cmd/agentsview/serve_runtime.go
+++ b/cmd/agentsview/serve_runtime.go
@@ -12,8 +12,9 @@ import (
 )
 
 type serveRuntimeOptions struct {
-	Mode          string
-	RequestedPort int
+	Mode           string
+	RequestedPort  int
+	OnCaddyStarted func(int)
 }
 
 type serveRuntime struct {
@@ -90,7 +91,9 @@ func startServerWithOptionalCaddy(
 	var caddy *managedCaddy
 	if cfg.Proxy.Mode == "caddy" {
 		var err error
-		caddy, err = startManagedCaddy(ctx, cfg, opts.Mode)
+		caddy, err = startManagedCaddy(
+			ctx, cfg, opts.Mode, opts.OnCaddyStarted,
+		)
 		if err != nil {
 			shutdownCtx, cancel := context.WithTimeout(
 				context.Background(), 5*time.Second,

--- a/cmd/agentsview/startup_state.go
+++ b/cmd/agentsview/startup_state.go
@@ -105,6 +105,24 @@ func (w *startupStateWriter) SetPhase(phase string) {
 	w.write()
 }
 
+// SetCaddyProcess publishes the managed proxy identity as soon as it starts,
+// before the daemon runtime record exists. This lets daemon stop clean up the
+// proxy even when startup is interrupted before runtime publication.
+func (w *startupStateWriter) SetCaddyProcess(pid int) {
+	if w == nil || pid <= 0 {
+		return
+	}
+	createTime := ""
+	if created, ok := processCreateTimeMillis(pid); ok {
+		createTime = strconv.FormatInt(created, 10)
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.state.CaddyPID = pid
+	w.state.CaddyCreateTime = createTime
+	w.write()
+}
+
 // SetDetail records fine-grained progress within the current phase,
 // persisted at most once per startupDetailThrottle.
 func (w *startupStateWriter) SetDetail(detail string) {

--- a/cmd/agentsview/startup_state.go
+++ b/cmd/agentsview/startup_state.go
@@ -26,6 +26,7 @@ const startupDetailThrottle = time.Second
 
 type startupState struct {
 	PID              int       `json:"pid"`
+	Version          string    `json:"version,omitempty"`
 	StartedAt        time.Time `json:"started_at"`
 	Phase            string    `json:"phase"`
 	Detail           string    `json:"detail,omitempty"`
@@ -75,7 +76,11 @@ func newStartupStateWriter(
 		now:  now,
 	}
 	w.state.PID = os.Getpid()
+	w.state.Version = version
 	w.state.StartedAt = now()
+	if createTime, ok := processCreateTimeMillis(w.state.PID); ok {
+		w.state.CreateTime = strconv.FormatInt(createTime, 10)
+	}
 	if runningAsBackgroundChild() {
 		// Only a background child's output lands in serve.log; a
 		// foreground serve prints to the invoking terminal.

--- a/cmd/agentsview/startup_state_test.go
+++ b/cmd/agentsview/startup_state_test.go
@@ -19,6 +19,7 @@ func fakeClock(start time.Time) (now func() time.Time, step func(time.Duration))
 }
 
 func TestStartupStateRoundTrip(t *testing.T) {
+	setTestVersion(t, "v1.2.3-test")
 	dir := t.TempDir()
 	base := time.Date(2026, 7, 2, 22, 0, 0, 0, time.UTC)
 	now, _ := fakeClock(base)
@@ -29,6 +30,9 @@ func TestStartupStateRoundTrip(t *testing.T) {
 	st := readStartupState(dir)
 	require.NotNil(t, st, "state must be readable after SetPhase")
 	assert.Equal(t, os.Getpid(), st.PID)
+	assert.Equal(t, "v1.2.3-test", st.Version)
+	assert.NotEmpty(t, st.CreateTime)
+	assert.True(t, processCreateTimeMatches(st.PID, st.CreateTime))
 	assert.Equal(t, "opening database", st.Phase)
 	assert.Empty(t, st.Detail)
 	assert.True(t, st.StartedAt.Equal(base), "started_at = %v", st.StartedAt)
@@ -122,6 +126,7 @@ func TestServeStartingStatusLines(t *testing.T) {
 			name: "full state",
 			st: &startupState{
 				PID:       48151,
+				Version:   "v1.2.3-test",
 				StartedAt: base,
 				Phase:     "full resync",
 				Detail:    "claude: 12/38 sessions (32%)",
@@ -129,6 +134,7 @@ func TestServeStartingStatusLines(t *testing.T) {
 			},
 			want: []string{
 				"  pid:     48151",
+				"  version: v1.2.3-test",
 				"  elapsed: 1m12s",
 				"  phase:   full resync: claude: 12/38 sessions (32%)",
 				"  log:     " + logPath,

--- a/cmd/agentsview/startup_state_test.go
+++ b/cmd/agentsview/startup_state_test.go
@@ -77,6 +77,18 @@ func TestStartupStateDetailThrottle(t *testing.T) {
 	assert.Empty(t, st.Detail)
 }
 
+func TestStartupStatePublishesManagedCaddyIdentity(t *testing.T) {
+	dir := t.TempDir()
+	w := newStartupStateWriter(dir, time.Now)
+	w.SetCaddyProcess(os.Getpid())
+
+	st := readStartupState(dir)
+	require.NotNil(t, st)
+	assert.Equal(t, os.Getpid(), st.CaddyPID)
+	assert.NotEmpty(t, st.CaddyCreateTime)
+	assert.True(t, processCreateTimeMatches(st.CaddyPID, st.CaddyCreateTime))
+}
+
 func TestReadStartupStateMissingOrCorrupt(t *testing.T) {
 	dir := t.TempDir()
 	assert.Nil(t, readStartupState(dir), "missing file must read as nil")

--- a/internal/db/session_freshness_query_test.go
+++ b/internal/db/session_freshness_query_test.go
@@ -1,0 +1,36 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentScopedFreshnessQueriesSeekByFilePath(t *testing.T) {
+	database := testDB(t)
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "file metadata", query: getFileInfoByAgentPathQuery},
+		{name: "file hash", query: getFileHashByAgentPathQuery},
+		{name: "data version", query: getDataVersionByAgentPathQuery},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plan := queryPlanOf(
+				t, database, test.query, "/sessions/example.jsonl", "codex",
+			)
+
+			assert.Contains(t, plan,
+				"USING INDEX idx_sessions_file_path (file_path=?)",
+				"freshness work must be bounded by one source path\n%s", plan,
+			)
+			assert.NotContains(t, plan,
+				"idx_sessions_agent (agent=?)",
+				"agent-wide scans make reconciliation quadratic\n%s", plan,
+			)
+		})
+	}
+}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2758,19 +2758,22 @@ func (db *DB) GetFileInfoByPath(
 }
 
 // GetFileInfoByAgentPath is GetFileInfoByPath scoped to the agent that owns
-// the source path.
+// the source path. Agent-scoped freshness queries force the path index because
+// SQLite otherwise prefers idx_sessions_agent and scans every session for the
+// agent once per discovered source, making archive reconciliation quadratic.
+const getFileInfoByAgentPathQuery = "SELECT file_size, file_mtime FROM sessions" +
+	" INDEXED BY idx_sessions_file_path" +
+	" WHERE file_path = ? AND agent = ?" +
+	" AND (deletion_cause IS NULL" +
+	" OR deletion_cause <> '" + deletionCauseSourceMissing + "')" +
+	" ORDER BY file_mtime DESC LIMIT 1"
+
 func (db *DB) GetFileInfoByAgentPath(
 	path, agent string,
 ) (size int64, mtime int64, ok bool) {
 	var s, m sql.NullInt64
-	err := db.getReader().QueryRow(
-		"SELECT file_size, file_mtime FROM sessions"+
-			" WHERE file_path = ? AND agent = ?"+
-			" AND (deletion_cause IS NULL"+
-			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')"+
-			" ORDER BY file_mtime DESC LIMIT 1",
-		path, agent,
-	).Scan(&s, &m)
+	err := db.getReader().QueryRow(getFileInfoByAgentPathQuery, path, agent).
+		Scan(&s, &m)
 	if err != nil {
 		return 0, 0, false
 	}
@@ -3027,18 +3030,19 @@ func (db *DB) GetFileHashByPath(path string) (hash string, ok bool) {
 
 // GetFileHashByAgentPath is GetFileHashByPath scoped to the agent that owns
 // the source path.
+const getFileHashByAgentPathQuery = "SELECT file_hash FROM sessions" +
+	" INDEXED BY idx_sessions_file_path" +
+	" WHERE file_path = ? AND agent = ?" +
+	" AND (deletion_cause IS NULL" +
+	" OR deletion_cause <> '" + deletionCauseSourceMissing + "')" +
+	" ORDER BY file_mtime DESC LIMIT 1"
+
 func (db *DB) GetFileHashByAgentPath(
 	path, agent string,
 ) (hash string, ok bool) {
 	var h sql.NullString
-	err := db.getReader().QueryRow(
-		"SELECT file_hash FROM sessions"+
-			" WHERE file_path = ? AND agent = ?"+
-			" AND (deletion_cause IS NULL"+
-			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')"+
-			" ORDER BY file_mtime DESC LIMIT 1",
-		path, agent,
-	).Scan(&h)
+	err := db.getReader().QueryRow(getFileHashByAgentPathQuery, path, agent).
+		Scan(&h)
 	if err != nil {
 		return "", false
 	}
@@ -4015,15 +4019,16 @@ func (db *DB) GetDataVersionByPath(path string) int {
 
 // GetDataVersionByAgentPath is GetDataVersionByPath scoped to the agent that
 // owns the source path.
+const getDataVersionByAgentPathQuery = "SELECT MIN(data_version) FROM sessions" +
+	" INDEXED BY idx_sessions_file_path" +
+	" WHERE file_path = ? AND agent = ?" +
+	" AND (deletion_cause IS NULL" +
+	" OR deletion_cause <> '" + deletionCauseSourceMissing + "')"
+
 func (db *DB) GetDataVersionByAgentPath(path, agent string) int {
 	var v int
-	err := db.getReader().QueryRow(
-		"SELECT MIN(data_version) FROM sessions"+
-			" WHERE file_path = ? AND agent = ?"+
-			" AND (deletion_cause IS NULL"+
-			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')",
-		path, agent,
-	).Scan(&v)
+	err := db.getReader().QueryRow(getDataVersionByAgentPathQuery, path, agent).
+		Scan(&v)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
Warm startup reconciliation could consume several CPU cores for tens of
minutes on large archives. The agent-scoped freshness query shape introduced
in #1349 allowed SQLite to choose the broad agent index, so each discovered
source could scan every stored session for that provider. These lookups now
require the existing source-path index, keeping the reconciliation path and
the digest-backed freshness path from #1393 bounded by the matching source
rows without adding an index migration.

Long startup is now identifiable and controllable before runtime publication.
Startup state includes the daemon build version and operating-system process
create time; status displays that version, while stop and restart can safely
target the exact starting process. Managed Caddy identity is published at
launch so forced startup shutdown also cleans up the proxy. Legacy startup
snapshots without process identity remain protected from signaling.

This is independent of #1374, which changes provider controls and watcher
scheduling but does not change these database lookups or startup-state
lifecycle behavior.
