### PR TITLE
Speed up HTTP sync by processing only changed sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,13 +274,21 @@ desktop-linux-appimage:
 # Backward-compatible alias (macOS .app)
 desktop-app: desktop-macos-app
 
-# Run tests
+# Keep local package/test-process fan-out bounded. A plain `go test ./...`
+# otherwise defaults to GOMAXPROCS, which can launch a large number of fresh
+# test binaries at once on a developer machine. Override with `GO_TEST_P=`
+# when an operator intentionally wants the Go default.
+GO_TEST_P ?= 4
+GO_TEST_P_FLAG := $(if $(GO_TEST_P),-p $(GO_TEST_P),)
+
+# Run the cacheable unit/integration suite. The external-service lanes below
+# intentionally retain `-count=1` because they require fresh state.
 test: pricing-snapshot ensure-embed-dir
-	go test -tags "fts5" ./... -v -count=1
+	go test $(GO_TEST_P_FLAG) -tags "fts5" ./... -v
 
 # Run fast tests only
 test-short: pricing-snapshot ensure-embed-dir
-	go test -tags "fts5" ./... -short -count=1
+	go test $(GO_TEST_P_FLAG) -tags "fts5" ./... -short
 
 # Run the quarantined eval-ingest endpoint tests under their build tag.
 # Only internal/server contains evalingest-gated code; every other package is

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -475,8 +475,9 @@ var runLocalSyncWithFallbackCLI = runLocalSyncWithFallback
 var coordinateLocalSyncRunner = coordinateLocalSync
 
 type preparedHTTPRebuildLeaseCLI struct {
-	prepared preparedHTTPRebuildCLI
-	release  func()
+	prepared  preparedHTTPRebuildCLI
+	release   func()
+	committed bool
 }
 
 func (l *preparedHTTPRebuildLeaseCLI) Close() error {
@@ -488,6 +489,21 @@ func (l *preparedHTTPRebuildLeaseCLI) Close() error {
 		l.release = nil
 	}
 	return l.prepared.Close()
+}
+
+func (l *preparedHTTPRebuildLeaseCLI) Commit() error {
+	if l == nil || l.prepared == nil || l.committed {
+		return nil
+	}
+	committer, ok := l.prepared.(sync.RebuildCommitter)
+	if !ok {
+		return nil
+	}
+	if err := committer.Commit(); err != nil {
+		return err
+	}
+	l.committed = true
+	return nil
 }
 
 var runSSHRemoteSync = func(
@@ -522,11 +538,16 @@ var runHTTPRemoteSync = func(
 			rh.Host,
 		)
 	}
+	fullReason := remotesync.FullImportReason("")
+	if full {
+		fullReason = remotesync.FullImportExplicit
+	}
 	return remotesync.HTTPSync{
 		Host:                    rh.Host,
 		URL:                     rh.URL,
 		Token:                   token,
 		Full:                    full,
+		FullReason:              fullReason,
 		DataDir:                 appCfg.DataDir,
 		DB:                      database,
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
@@ -612,6 +633,10 @@ func runConfiguredLocalAndRemotes(
 ) (didResync bool, failures []remoteHostFailure, retErr error) {
 	httpHosts, sshHosts := partitionConfiguredRemoteHosts(hosts)
 	didResync = full || database.NeedsResync()
+	fullReason := remotesync.FullImportDataRebuild
+	if full {
+		fullReason = remotesync.FullImportExplicit
+	}
 	outerOwnsHTTP := didResync && len(httpHosts) > 0
 
 	run := func() (remotesync.SyncStats, error) {
@@ -638,7 +663,7 @@ func runConfiguredLocalAndRemotes(
 			ctx, appCfg, database, full, progress,
 			func() (sync.RebuildOptions, sync.RebuildCleanup, error) {
 				prepared, err := prepareConfiguredHTTPHosts(
-					ctx, appCfg, database, httpHosts, progress,
+					ctx, appCfg, database, httpHosts, fullReason, progress,
 				)
 				if err != nil {
 					return sync.RebuildOptions{}, prepared, err
@@ -719,6 +744,7 @@ func prepareConfiguredHTTPHosts(
 	appCfg config.Config,
 	database *db.DB,
 	hosts []config.RemoteHost,
+	fullReason remotesync.FullImportReason,
 	progress sync.ProgressFunc,
 ) (preparedHTTPRebuildCLI, error) {
 	if len(hosts) == 0 {
@@ -738,6 +764,7 @@ func prepareConfiguredHTTPHosts(
 			URL:                     host.URL,
 			Token:                   host.Token,
 			Full:                    true,
+			FullReason:              fullReason,
 			DataDir:                 appCfg.DataDir,
 			DB:                      database,
 			BlockedResultCategories: appCfg.ResultContentBlockedCategories,

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -39,6 +39,7 @@ type fakeCLIPreparedHTTPRebuild struct {
 	closed        int
 	released      bool
 	closeReleased bool
+	committed     int
 }
 
 type cliLifecycleError struct{ err error }
@@ -56,6 +57,20 @@ func (p *fakeCLIPreparedHTTPRebuild) Close() error {
 	p.closed++
 	p.closeReleased = p.released
 	return nil
+}
+
+func (p *fakeCLIPreparedHTTPRebuild) Commit() error {
+	p.committed++
+	return nil
+}
+
+func TestPreparedHTTPRebuildLeaseCLIForwardsCommitOnce(t *testing.T) {
+	prepared := &fakeCLIPreparedHTTPRebuild{}
+	lease := &preparedHTTPRebuildLeaseCLI{prepared: prepared, release: func() {}}
+	require.NoError(t, lease.Commit())
+	require.NoError(t, lease.Commit())
+	assert.Equal(t, 1, prepared.committed)
+	assert.Zero(t, prepared.closed, "commit must not infer cleanup")
 }
 
 func newDirectSyncFixture(t *testing.T) (config.Config, *db.DB) {
@@ -142,8 +157,10 @@ func TestDoSyncConfiguredFullUsesUnifiedHTTPContributorBeforeSSH(t *testing.T) {
 	}}}
 	originalPrepare := prepareHTTPRebuildCLI
 	prepareHTTPRebuildCLI = func(
-		context.Context, []remotesync.HTTPSync,
+		_ context.Context, syncs []remotesync.HTTPSync,
 	) (preparedHTTPRebuildCLI, error) {
+		require.Len(t, syncs, 1)
+		assert.Equal(t, remotesync.FullImportExplicit, syncs[0].FullReason)
 		order = append(order, "prepare")
 		return prepared, nil
 	}
@@ -293,8 +310,10 @@ func TestDoSyncAutomaticResyncUsesUnifiedHTTPContributor(t *testing.T) {
 	prepareCalls := 0
 	originalPrepare := prepareHTTPRebuildCLI
 	prepareHTTPRebuildCLI = func(
-		context.Context, []remotesync.HTTPSync,
+		_ context.Context, syncs []remotesync.HTTPSync,
 	) (preparedHTTPRebuildCLI, error) {
+		require.Len(t, syncs, 1)
+		assert.Equal(t, remotesync.FullImportDataRebuild, syncs[0].FullReason)
 		prepareCalls++
 		return prepared, nil
 	}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -279,12 +279,21 @@ the list, since remote sessions are namespaced by host.
 
 During HTTP remote sync, the collector prints durable phase lines for resolving
 remote roots, fetching and comparing the manifest, transferring and extracting
-changed files, processing each contributor, rebuilding FTS, and swapping the
-database. Archive downloads also show live compressed-byte progress when the
-remote daemon provides a `Content-Length` header. The new phases and bulk-ingest
-path come from the collector; a spoke upgrade is needed only for manifest-delta
-transfer. If an upgraded binary does not show those phases, restart the local
-collector daemon.
+changed files, planning pending paths, processing affected sources, rebuilding
+FTS, and swapping the database. Pending paths can outnumber processed sources:
+deletions participate in recovery and cache invalidation but usually do not
+produce an import source. Provider fallback is identified explicitly, and its
+discovered sources determine the processing denominator.
+
+The final per-host line reports changed sessions, ordinary unchanged skips, and
+error-suppressed pending entries. A retained-journal line means recovery work
+will be replayed; cancellation, processing failure, cache-persistence failure,
+retirement failure, and a rebuild awaiting its database swap remain distinct.
+Individual source paths are omitted from normal output. Archive downloads also
+show live compressed-byte progress when the remote daemon provides a
+`Content-Length` header. These phases come from the collector; a spoke upgrade
+is needed only for manifest-delta transfer. If an upgraded binary does not show
+them, restart the local collector daemon.
 
 ______________________________________________________________________
 

--- a/docs/internal/background-sync-efficiency.md
+++ b/docs/internal/background-sync-efficiency.md
@@ -26,6 +26,19 @@ lives primarily in `internal/sync/watcher.go`,
 - Shutdown discards pending paths and waits only for an already-running
   callback. Normal discovery on the next startup recovers discarded changes.
 
+## HTTP mirror journal contract
+
+Persistent HTTP mirrors use the same 8,192-entry and 2 MiB path-byte limits for
+their crash-recovery journal. Crossing either limit collapses the path set to a
+full-import marker instead of retaining unbounded path data. Unlike an in-memory
+watch batch, the marker is durable and remains until database processing and
+remote skip-cache persistence complete.
+
+For a proven changed source, classification, fingerprinting, parsing, and
+database writes are independent of unrelated mirror cardinality. An unproven
+path may widen work only to its owning provider's configured roots. Full archive
+transfer caused by the half-manifest heuristic does not widen this import scope.
+
 ## Codex append cursor contract
 
 The Codex provider factory owns one in-memory cursor cache shared by its

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -175,16 +175,24 @@ and continues to copy a full session tree on each run.
    size, and modification time.
 1. The collector walks the mirror and compares file size and modification time
    at microsecond precision. It schedules missing or changed files for fetch and
-   removes mirror files that disappeared from the manifest.
+   removes mirror files that disappeared from the manifest. Before changing the
+   mirror, it durably merges those paths into a bounded recovery journal next to
+   the mirror.
 1. When fewer than half of the manifest's files need fetching, the collector
    requests only that delta. At half or more, it requests a full archive instead
    of sending a large file list. The current collector advertises gzip support
    for both archive modes.
 1. The archive is extracted into the mirror with remote modification times
-   preserved. AgentsView then imports from the complete mirror, so parsers that
-   read sibling files behave the same way they do against a full source tree.
-   The separate database skip cache avoids unnecessary parsing of unchanged
-   sessions during normal syncs.
+   preserved. AgentsView classifies the pending journal paths and imports only
+   their affected sources. A provider whose exact scope cannot be proven falls
+   back to discovery under that provider's roots; it does not widen other
+   providers. The journal is retired only after session writes and the remote
+   skip cache are durable.
+
+Transfer breadth and import breadth are independent. The half-manifest
+heuristic can download a full archive while the collector still processes only
+the changed-source plan. Conversely, an explicit full import reparses the
+complete mirror without forcing unchanged bytes across the network.
 
 For a configured full sync that includes local sources, mirror preparation
 finishes before database work begins. The collector then ingests local sources
@@ -198,9 +206,17 @@ Remote-only syncs, including
 the active archive and do not use the combined rebuild path.
 
 If no directory-scoped files changed, the collector skips the archive request
-and imports directly from the existing mirror. Files that disappear remotely are
-deleted from the mirror, but remote import is intentionally non-destructive:
-sessions already stored in the AgentsView database remain available.
+and, when no recovery work is pending, performs no import. Files that disappear
+remotely are deleted from the mirror, but remote import is intentionally
+non-destructive: sessions already stored in the AgentsView database remain
+available.
+
+If a process stops after mirror mutation, the next sync replays the pending
+journal. Cache invalidation is armed once per observed remote version so a
+same-mtime extraction cannot be hidden by stale cache state. A deterministic
+parse failure is then retained in the existing error-skip cache, retried on
+replay as a skip, and re-armed only when the remote path changes again. Recovery
+work is bounded; overflow collapses to one conservative full import.
 
 Windsurf is a special case. Its state database is sanitized into a curated
 export for every transfer, so the raw tree cannot safely participate in the

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -1409,7 +1409,9 @@ func (d *DB) CopySessionMetadataFrom(
 	// makes journal continuity across the swap worthless, which is why the
 	// publication-revision counters are not copied either — the fresh
 	// database's own trigger-maintained counters stand, and the fresh
-	// journal rows they stamp are only ever consumed relative to them.
+	// journal rows they stamp are only ever consumed relative to them. Remote
+	// import data versions also identify the physical database generation; a
+	// remote contributor must establish them again in the replacement.
 	if oldDBHasTable(ctx, tx, "archive_metadata") {
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO main.archive_metadata (key, value, created_at, updated_at)
@@ -1421,6 +1423,7 @@ func (d *DB) CopySessionMetadataFrom(
 				'session_deletion_publication_revision',
 				'worktree_mapping_publication_revision'
 			)
+			AND key NOT GLOB 'remote_import_data_version:*'
 			ON CONFLICT(key) DO UPDATE SET
 				value = excluded.value,
 				created_at = excluded.created_at,

--- a/internal/db/remote_import_state.go
+++ b/internal/db/remote_import_state.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const remoteImportDataVersionMetadataPrefix = "remote_import_data_version:"
+
+// RemoteImportDataVersion returns the parser data version last imported from
+// host into this physical archive generation. Zero means that no completed
+// import has established the current archive's remote state.
+func (db *DB) RemoteImportDataVersion(
+	ctx context.Context, host string,
+) (int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	key, err := remoteImportDataVersionMetadataKey(host)
+	if err != nil {
+		return 0, err
+	}
+	var raw string
+	err = db.getReader().QueryRowContext(ctx,
+		`SELECT value FROM archive_metadata WHERE key = ?`, key,
+	).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf(
+			"reading remote import data version for %s: %w", host, err,
+		)
+	}
+	version, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || version <= 0 {
+		return 0, fmt.Errorf(
+			"invalid remote import data version %q for %s", raw, host,
+		)
+	}
+	return version, nil
+}
+
+// SetRemoteImportDataVersion records a completed remote import in the current
+// physical archive generation.
+func (db *DB) SetRemoteImportDataVersion(
+	ctx context.Context, host string, version int,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	key, err := remoteImportDataVersionMetadataKey(host)
+	if err != nil {
+		return err
+	}
+	if version <= 0 {
+		return fmt.Errorf("invalid remote import data version %d", version)
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if _, err := db.getWriter().ExecContext(ctx, `
+		INSERT INTO archive_metadata (key, value)
+		VALUES (?, ?)
+		ON CONFLICT(key) DO UPDATE SET
+			value = excluded.value,
+			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')`,
+		key, strconv.Itoa(version),
+	); err != nil {
+		return fmt.Errorf(
+			"recording remote import data version for %s: %w", host, err,
+		)
+	}
+	return nil
+}
+
+func remoteImportDataVersionMetadataKey(host string) (string, error) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", errors.New("remote import host is empty")
+	}
+	return remoteImportDataVersionMetadataPrefix + host, nil
+}

--- a/internal/db/remote_skipped.go
+++ b/internal/db/remote_skipped.go
@@ -1,6 +1,12 @@
 package db
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
 
 // LoadRemoteSkippedFiles returns persisted skip cache entries
 // for the given remote host as a map from path to file_mtime.
@@ -32,6 +38,100 @@ func (db *DB) LoadRemoteSkippedFiles(
 		result[path] = mtime
 	}
 	return result, rows.Err()
+}
+
+// LoadRemoteSkippedFilesForScopes loads only cache families attached to the
+// given exact paths or rooted below the given directory paths. Prefix range
+// probes use the (host, path) primary key; the Go-side check removes lexical
+// neighbors admitted by the range.
+func (db *DB) LoadRemoteSkippedFilesForScopes(
+	ctx context.Context,
+	host string,
+	exactPaths []string,
+	rootPaths []string,
+) (map[string]int64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	exact := make(map[string]struct{}, len(exactPaths))
+	roots := make(map[string]struct{}, len(rootPaths))
+	for _, path := range exactPaths {
+		if path != "" {
+			exact[path] = struct{}{}
+		}
+	}
+	for _, path := range rootPaths {
+		if path != "" {
+			roots[path] = struct{}{}
+		}
+	}
+	prefixes := make([]string, 0, len(exact)+len(roots))
+	for path := range exact {
+		prefixes = append(prefixes, path)
+	}
+	for path := range roots {
+		prefixes = append(prefixes, path)
+	}
+	sort.Strings(prefixes)
+	prefixes = slices.Compact(prefixes)
+
+	result := make(map[string]int64)
+	for _, prefix := range prefixes {
+		rows, err := db.getReader().QueryContext(
+			ctx,
+			`SELECT path, file_mtime FROM remote_skipped_files
+			 WHERE host = ? AND path >= ? AND path < ?`,
+			host, prefix, prefix+"\U0010ffff",
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"loading scoped remote skipped files for %s: %w", host, err,
+			)
+		}
+		for rows.Next() {
+			var path string
+			var mtime int64
+			if err := rows.Scan(&path, &mtime); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf(
+					"scanning scoped remote skipped file: %w", err,
+				)
+			}
+			base := remoteSkippedFileBasePath(path)
+			_, exactMatch := exact[base]
+			if !exactMatch && !remoteSkippedFileWithinAnyRoot(base, roots) {
+				continue
+			}
+			result[path] = mtime
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf(
+				"closing scoped remote skipped file rows: %w", err,
+			)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf(
+				"iterating scoped remote skipped files: %w", err,
+			)
+		}
+	}
+	return result, nil
+}
+
+func remoteSkippedFileBasePath(path string) string {
+	base, _, _ := strings.Cut(path, "?")
+	return base
+}
+
+func remoteSkippedFileWithinAnyRoot(path string, roots map[string]struct{}) bool {
+	path = strings.ReplaceAll(path, `\`, "/")
+	for root := range roots {
+		root = strings.TrimRight(strings.ReplaceAll(root, `\`, "/"), "/")
+		if path == root || strings.HasPrefix(path, root+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // ClearRemoteSkippedFiles removes all skip cache entries for the given host.
@@ -99,5 +199,62 @@ func (db *DB) ReplaceRemoteSkippedFiles(
 		}
 	}
 
+	return tx.Commit()
+}
+
+// ApplyRemoteSkippedFileChanges deletes and upserts selected host cache rows
+// in one transaction. Unmentioned paths and other hosts are left untouched.
+func (db *DB) ApplyRemoteSkippedFileChanges(
+	host string,
+	deletes []string,
+	upserts map[string]int64,
+) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	if len(deletes) == 0 && len(upserts) == 0 {
+		return nil
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return fmt.Errorf("begin remote skip cache update: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	deleteStmt, err := tx.Prepare(
+		"DELETE FROM remote_skipped_files WHERE host = ? AND path = ?",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare remote skip cache delete: %w", err)
+	}
+	defer deleteStmt.Close()
+	for _, path := range deletes {
+		if _, err := deleteStmt.Exec(host, path); err != nil {
+			return fmt.Errorf("deleting remote skipped file %s: %w", path, err)
+		}
+	}
+
+	upsertStmt, err := tx.Prepare(
+		`INSERT INTO remote_skipped_files (host, path, file_mtime)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT(host, path) DO UPDATE SET file_mtime = excluded.file_mtime`,
+	)
+	if err != nil {
+		return fmt.Errorf("prepare remote skip cache upsert: %w", err)
+	}
+	defer upsertStmt.Close()
+	paths := make([]string, 0, len(upserts))
+	for path := range upserts {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		if _, err := upsertStmt.Exec(host, path, upserts[path]); err != nil {
+			return fmt.Errorf("upserting remote skipped file %s: %w", path, err)
+		}
+	}
 	return tx.Commit()
 }

--- a/internal/db/remote_skipped_test.go
+++ b/internal/db/remote_skipped_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"context"
 	"maps"
 	"testing"
 
@@ -96,6 +97,53 @@ func TestRemoteSkippedFiles(t *testing.T) {
 		require.NoError(t, err, "LoadRemoteSkippedFiles replace-other-2")
 		assert.True(t, maps.Equal(loaded2, host2),
 			"replace-other-2: loaded %v, want %v", loaded2, host2)
+	})
+
+	t.Run("scoped load excludes unrelated rows", func(t *testing.T) {
+		entries := map[string]int64{
+			"/sessions/changed.jsonl":                     10,
+			"/sessions/changed.jsonl?agent=claude":        11,
+			"/sessions/changed.jsonl-other":               12,
+			"/sessions/fallback/one.jsonl":                20,
+			"/sessions/fallback/nested/two.jsonl?agent=x": 21,
+			"/sessions/unrelated.jsonl":                   30,
+		}
+		require.NoError(t,
+			d.ReplaceRemoteSkippedFiles("scoped-host", entries))
+
+		loaded, err := d.LoadRemoteSkippedFilesForScopes(
+			context.Background(), "scoped-host",
+			[]string{"/sessions/changed.jsonl"},
+			[]string{"/sessions/fallback"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]int64{
+			"/sessions/changed.jsonl":                     10,
+			"/sessions/changed.jsonl?agent=claude":        11,
+			"/sessions/fallback/one.jsonl":                20,
+			"/sessions/fallback/nested/two.jsonl?agent=x": 21,
+		}, loaded)
+	})
+
+	t.Run("scoped mutation preserves unrelated rows", func(t *testing.T) {
+		require.NoError(t, d.ReplaceRemoteSkippedFiles(
+			"mutate-host", map[string]int64{
+				"/changed.jsonl":   10,
+				"/unchanged.jsonl": 20,
+			},
+		))
+		require.NoError(t, d.ApplyRemoteSkippedFileChanges(
+			"mutate-host", []string{"/changed.jsonl"}, map[string]int64{
+				"/new.jsonl": 30,
+			},
+		))
+
+		loaded, err := d.LoadRemoteSkippedFiles("mutate-host")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]int64{
+			"/unchanged.jsonl": 20,
+			"/new.jsonl":       30,
+		}, loaded)
 	})
 }
 

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	pathpkg "path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -4278,6 +4279,13 @@ func storedSourcePathHintQuery(
 }
 
 func cleanStoredSourcePathHint(path string) string {
+	// Remote source paths are stored with forward slashes even when the
+	// collector runs on Windows. Keep those paths in their stored syntax so a
+	// collector never rewrites a remote host's separators before the indexed
+	// lookup. Native Windows paths contain backslashes and still use filepath.
+	if strings.Contains(path, "/") {
+		return pathpkg.Clean(path)
+	}
 	return filepath.Clean(path)
 }
 

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -62,7 +62,7 @@ type DiscoveredFile struct {
 	ForceParse        bool // caller requires freshness bypass
 	// ForceFullParse also disables append-only processing so a materialized
 	// replacement cannot be mistaken for bytes appended to the stored source.
-	// Callers set ForceParse with it so every other freshness gate is bypassed.
+	// A durable skip-cache entry may suppress it after a previous attempt.
 	ForceFullParse  bool
 	ProviderSource  *SourceRef // provider-owned source identity, when known
 	ProviderProcess bool       // true when this caller may parse via ProviderSource

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -59,9 +59,13 @@ type DiscoveredFile struct {
 	SourceMtime int64     // source object mtime for s3:// sources, UnixNano
 	// SourceFingerprint is a durable object fingerprint for s3:// sources.
 	SourceFingerprint string
-	ForceParse        bool       // caller requires a full source reparse
-	ProviderSource    *SourceRef // provider-owned source identity, when known
-	ProviderProcess   bool       // true when this caller may parse via ProviderSource
+	ForceParse        bool // caller requires freshness bypass
+	// ForceFullParse also disables append-only processing so a materialized
+	// replacement cannot be mistaken for bytes appended to the stored source.
+	// Callers set ForceParse with it so every other freshness gate is bypassed.
+	ForceFullParse  bool
+	ProviderSource  *SourceRef // provider-owned source identity, when known
+	ProviderProcess bool       // true when this caller may parse via ProviderSource
 }
 
 // OpenCodeSourceMode identifies the usable OpenCode storage

--- a/internal/remotesync/delta_import.go
+++ b/internal/remotesync/delta_import.go
@@ -373,6 +373,19 @@ func (pending *PreparedDeltaImport) persistSkipCache(
 	return nil
 }
 
+func (pending *PreparedDeltaImport) persistRetrySafeSkipCache(
+	database *db.DB,
+	engine *syncpkg.Engine,
+) error {
+	remoteCache := remoteRetrySafeEngineSkipCache(engine, pending.layout.paths)
+	if err := database.ReplaceRemoteSkippedFiles(
+		pending.layout.paths.host, remoteCache,
+	); err != nil {
+		return fmt.Errorf("save retry-safe skip cache: %w", err)
+	}
+	return nil
+}
+
 type plannedRemoteSkipCacheScope struct {
 	exact    map[string]map[parser.AgentType]struct{}
 	fallback map[parser.AgentType][]string

--- a/internal/remotesync/delta_import.go
+++ b/internal/remotesync/delta_import.go
@@ -61,6 +61,7 @@ type PreparedDeltaImport struct {
 	layout      importLayout
 	config      syncpkg.EngineConfig
 	plan        syncpkg.ChangedPathPlan
+	forceScope  syncpkg.ChangedPathPruneScope
 	cache       map[string]int64
 	remoteCache map[string]int64
 	full        bool
@@ -77,8 +78,9 @@ func (im Importer) PreparePending(
 	// FullReason can be restored from a retained journal. It preserves the
 	// pending full-import scope and its observable cause, but it must not turn
 	// an ordinary replay into another force-parse attempt. Only the current
-	// invocation's explicit Full request bypasses freshness and failure skips.
-	forceParse := im.Full
+	// invocation's explicit Full request or an armed host-wide invalidation
+	// bypasses freshness and failure skips.
+	forceParse := im.Full || request.Journal.InvalidateAll
 	stats := SyncStats{
 		FullReason:     request.FullReason,
 		JournalOutcome: JournalAbortedBeforeProcessing,
@@ -131,6 +133,7 @@ func (im Importer) PreparePending(
 	}
 	stats.ExactSources = len(plan.Files)
 	stats.FallbackProviders = len(plan.FallbackProviders)
+	forceScope := plan.PruneScope(armedJournalPhysicalPaths(layout, request.Journal))
 
 	full := request.Journal.FullImport || request.FullReason != "" || im.Full
 	ensureVisualStudioCopilotRemoteSkipMigration(im.DB, im.Host)
@@ -188,6 +191,7 @@ func (im Importer) PreparePending(
 		database:        im.DB, layout: layout, config: config, plan: plan,
 		cache:       preparedCache,
 		remoteCache: maps.Clone(pruned),
+		forceScope:  forceScope,
 		full:        full,
 		forceParse:  forceParse,
 		progress:    im.Progress, save: im.saveSkipCache, apply: apply,
@@ -216,8 +220,10 @@ func (pending *PreparedDeltaImport) Execute(
 			engineStats = engine.SyncAll(ctx, progress)
 		}
 	} else {
-		changedResult, processErr = engine.SyncChangedPathPlanContext(
-			ctx, pending.plan, hostProgress(pending.layout.paths.host, pending.progress),
+		changedResult, processErr = engine.SyncChangedPathPlanWithOptionsContext(
+			ctx, pending.plan, syncpkg.ChangedPathSyncOptions{
+				ForceFullParse: pending.forceScope,
+			}, hostProgress(pending.layout.paths.host, pending.progress),
 		)
 		engineStats = changedResult.Stats
 		stats.FilesDiscovered = changedResult.FilesDiscovered
@@ -447,18 +453,7 @@ func pruneRemoteSkipCache(
 	}
 	pruned := make(map[string]int64, len(cache))
 	maps.Copy(pruned, cache)
-	armed := make(map[string]struct{})
-	for _, entry := range journal.Entries {
-		if !entry.InvalidateCache {
-			continue
-		}
-		physical, err := safeLocalArchivePath(
-			layout.paths.root, filepath.FromSlash(entry.Path),
-		)
-		if err == nil {
-			armed[physical] = struct{}{}
-		}
-	}
+	armed := armedJournalPhysicalPaths(layout, journal)
 	scope := plan.PruneScope(armed)
 	stats.ExactScopes = len(scope.Files)
 	stats.ProviderScopes = len(scope.FallbackProviders)
@@ -509,6 +504,25 @@ func pruneRemoteSkipCache(
 		}
 	}
 	return pruned, stats
+}
+
+func armedJournalPhysicalPaths(
+	layout importLayout,
+	journal MirrorChangeJournal,
+) map[string]struct{} {
+	armed := make(map[string]struct{})
+	for _, entry := range journal.Entries {
+		if !entry.InvalidateCache {
+			continue
+		}
+		physical, err := safeLocalArchivePath(
+			layout.paths.root, filepath.FromSlash(entry.Path),
+		)
+		if err == nil {
+			armed[physical] = struct{}{}
+		}
+	}
+	return armed
 }
 
 func remoteCacheFamily(key string) (string, parser.AgentType) {

--- a/internal/remotesync/delta_import.go
+++ b/internal/remotesync/delta_import.go
@@ -57,18 +57,19 @@ type PreparedDeltaImport struct {
 	DisarmedJournal MirrorChangeJournal
 	Stats           SyncStats
 
-	database    *db.DB
-	layout      importLayout
-	config      syncpkg.EngineConfig
-	plan        syncpkg.ChangedPathPlan
-	forceScope  syncpkg.ChangedPathPruneScope
-	cache       map[string]int64
-	remoteCache map[string]int64
-	full        bool
-	forceParse  bool
-	progress    syncpkg.ProgressFunc
-	save        func(*db.DB, *syncpkg.Engine, remotePathMap) error
-	apply       func(string, []string, map[string]int64) error
+	database       *db.DB
+	layout         importLayout
+	config         syncpkg.EngineConfig
+	plan           syncpkg.ChangedPathPlan
+	forceScope     syncpkg.ChangedPathPruneScope
+	cache          map[string]int64
+	remoteCache    map[string]int64
+	full           bool
+	forceParse     bool
+	forceFullParse bool
+	progress       syncpkg.ProgressFunc
+	save           func(*db.DB, *syncpkg.Engine, remotePathMap) error
+	apply          func(string, []string, map[string]int64) error
 }
 
 func (im Importer) PreparePending(
@@ -77,10 +78,12 @@ func (im Importer) PreparePending(
 ) (*PreparedDeltaImport, error) {
 	// FullReason can be restored from a retained journal. It preserves the
 	// pending full-import scope and its observable cause, but it must not turn
-	// an ordinary replay into another force-parse attempt. Only the current
-	// invocation's explicit Full request or an armed host-wide invalidation
-	// bypasses freshness and failure skips.
-	forceParse := im.Full || request.Journal.InvalidateAll
+	// an ordinary replay into another hard force-parse attempt. Only the current
+	// invocation's explicit Full request bypasses durable failure skips. The
+	// journal's separate full-parse intent still bypasses freshness and
+	// incremental append for sources without a post-invalidation skip entry.
+	forceParse := im.Full
+	forceFullParse := request.Journal.ForceFullParseAll
 	stats := SyncStats{
 		FullReason:     request.FullReason,
 		JournalOutcome: JournalAbortedBeforeProcessing,
@@ -133,7 +136,9 @@ func (im Importer) PreparePending(
 	}
 	stats.ExactSources = len(plan.Files)
 	stats.FallbackProviders = len(plan.FallbackProviders)
-	forceScope := plan.PruneScope(armedJournalPhysicalPaths(layout, request.Journal))
+	forceScope := plan.PruneScope(forceFullParseJournalPhysicalPaths(
+		layout, request.Journal,
+	))
 
 	full := request.Journal.FullImport || request.FullReason != "" || im.Full
 	ensureVisualStudioCopilotRemoteSkipMigration(im.DB, im.Host)
@@ -189,12 +194,13 @@ func (im Importer) PreparePending(
 		DisarmedJournal: disarmMirrorChanges(request.Journal),
 		Stats:           stats,
 		database:        im.DB, layout: layout, config: config, plan: plan,
-		cache:       preparedCache,
-		remoteCache: maps.Clone(pruned),
-		forceScope:  forceScope,
-		full:        full,
-		forceParse:  forceParse,
-		progress:    im.Progress, save: im.saveSkipCache, apply: apply,
+		cache:          preparedCache,
+		remoteCache:    maps.Clone(pruned),
+		forceScope:     forceScope,
+		full:           full,
+		forceParse:     forceParse,
+		forceFullParse: forceFullParse,
+		progress:       im.Progress, save: im.saveSkipCache, apply: apply,
 	}, nil
 }
 
@@ -216,6 +222,8 @@ func (pending *PreparedDeltaImport) Execute(
 		progress := hostProgress(pending.layout.paths.host, pending.progress)
 		if pending.forceParse {
 			engineStats = engine.SyncAllForceParse(ctx, progress)
+		} else if pending.forceFullParse {
+			engineStats = engine.SyncAllForceParseAfterCache(ctx, progress)
 		} else {
 			engineStats = engine.SyncAll(ctx, progress)
 		}
@@ -453,7 +461,7 @@ func pruneRemoteSkipCache(
 	}
 	pruned := make(map[string]int64, len(cache))
 	maps.Copy(pruned, cache)
-	armed := armedJournalPhysicalPaths(layout, journal)
+	armed := cacheInvalidationJournalPhysicalPaths(layout, journal)
 	scope := plan.PruneScope(armed)
 	stats.ExactScopes = len(scope.Files)
 	stats.ProviderScopes = len(scope.FallbackProviders)
@@ -506,13 +514,32 @@ func pruneRemoteSkipCache(
 	return pruned, stats
 }
 
-func armedJournalPhysicalPaths(
+func cacheInvalidationJournalPhysicalPaths(
 	layout importLayout,
 	journal MirrorChangeJournal,
 ) map[string]struct{} {
+	return journalPhysicalPaths(layout, journal, func(entry MirrorChangeEntry) bool {
+		return entry.InvalidateCache
+	})
+}
+
+func forceFullParseJournalPhysicalPaths(
+	layout importLayout,
+	journal MirrorChangeJournal,
+) map[string]struct{} {
+	return journalPhysicalPaths(layout, journal, func(entry MirrorChangeEntry) bool {
+		return entry.ForceFullParse
+	})
+}
+
+func journalPhysicalPaths(
+	layout importLayout,
+	journal MirrorChangeJournal,
+	include func(MirrorChangeEntry) bool,
+) map[string]struct{} {
 	armed := make(map[string]struct{})
 	for _, entry := range journal.Entries {
-		if !entry.InvalidateCache {
+		if !include(entry) {
 			continue
 		}
 		physical, err := safeLocalArchivePath(

--- a/internal/remotesync/delta_import.go
+++ b/internal/remotesync/delta_import.go
@@ -43,7 +43,7 @@ type DeltaImportRequest struct {
 	ForceParse               bool
 	ForceFullParseAfterCache bool
 	ResetAttemptCache        bool
-	MarkAttemptCacheReady    bool
+	AttemptCacheDataVersion  int
 }
 
 type CachePruneStats struct {
@@ -61,19 +61,20 @@ type PreparedDeltaImport struct {
 	DisarmedJournal MirrorChangeJournal
 	Stats           SyncStats
 
-	database       *db.DB
-	layout         importLayout
-	config         syncpkg.EngineConfig
-	plan           syncpkg.ChangedPathPlan
-	forceScope     syncpkg.ChangedPathPruneScope
-	cache          map[string]int64
-	remoteCache    map[string]int64
-	full           bool
-	forceParse     bool
-	forceFullParse bool
-	progress       syncpkg.ProgressFunc
-	save           func(*db.DB, *syncpkg.Engine, remotePathMap) error
-	apply          func(string, []string, map[string]int64) error
+	database            *db.DB
+	layout              importLayout
+	config              syncpkg.EngineConfig
+	plan                syncpkg.ChangedPathPlan
+	forceScope          syncpkg.ChangedPathPruneScope
+	cache               map[string]int64
+	remoteCache         map[string]int64
+	full                bool
+	forceParse          bool
+	forceFullParse      bool
+	requiredDataVersion int
+	progress            syncpkg.ProgressFunc
+	save                func(*db.DB, *syncpkg.Engine, remotePathMap) error
+	apply               func(string, []string, map[string]int64) error
 }
 
 func (im Importer) PreparePending(
@@ -203,20 +204,21 @@ func (im Importer) PreparePending(
 		preparedCache = nil
 	}
 	disarmedJournal := disarmMirrorChanges(request.Journal)
-	if request.MarkAttemptCacheReady {
-		disarmedJournal.DataRebuildCacheReady = true
+	if request.AttemptCacheDataVersion > 0 {
+		disarmedJournal.DataRebuildCacheVersion = request.AttemptCacheDataVersion
 	}
 	return &PreparedDeltaImport{
 		DisarmedJournal: disarmedJournal,
 		Stats:           stats,
 		database:        im.DB, layout: layout, config: config, plan: plan,
-		cache:          preparedCache,
-		remoteCache:    maps.Clone(pruned),
-		forceScope:     forceScope,
-		full:           full,
-		forceParse:     forceParse,
-		forceFullParse: forceFullParse,
-		progress:       im.Progress, save: im.saveSkipCache, apply: apply,
+		cache:               preparedCache,
+		remoteCache:         maps.Clone(pruned),
+		forceScope:          forceScope,
+		full:                full,
+		forceParse:          forceParse,
+		forceFullParse:      forceFullParse,
+		requiredDataVersion: request.Journal.RequiredDataVersion,
+		progress:            im.Progress, save: im.saveSkipCache, apply: apply,
 	}, nil
 }
 
@@ -293,10 +295,44 @@ func (pending *PreparedDeltaImport) Execute(
 			)
 		}
 	default:
+		if err := ctx.Err(); err != nil {
+			stats.JournalOutcome = JournalCancelled
+			processErr = err
+			break
+		}
+		versionPersistStart := time.Now()
+		if err := pending.persistImportDataVersion(
+			context.WithoutCancel(ctx), pending.database,
+		); err != nil {
+			stats.CachePersistDuration += time.Since(versionPersistStart)
+			stats.JournalOutcome = JournalCachePersistFailed
+			pending.Stats = stats
+			return stats, err
+		}
+		stats.CachePersistDuration += time.Since(versionPersistStart)
+		if err := ctx.Err(); err != nil {
+			stats.JournalOutcome = JournalCancelled
+			processErr = err
+			break
+		}
 		stats.JournalOutcome = JournalRetired
 	}
 	pending.Stats = stats
 	return stats, processErr
+}
+
+func (pending *PreparedDeltaImport) persistImportDataVersion(
+	ctx context.Context, database *db.DB,
+) error {
+	if pending.requiredDataVersion == 0 {
+		return nil
+	}
+	if err := database.SetRemoteImportDataVersion(
+		ctx, pending.layout.paths.host, pending.requiredDataVersion,
+	); err != nil {
+		return fmt.Errorf("persist remote import data version: %w", err)
+	}
+	return nil
 }
 
 func (pending *PreparedDeltaImport) persistSkipCache(

--- a/internal/remotesync/delta_import.go
+++ b/internal/remotesync/delta_import.go
@@ -38,8 +38,10 @@ func (outcome JournalOutcome) Valid() bool {
 }
 
 type DeltaImportRequest struct {
-	Journal    MirrorChangeJournal
-	FullReason FullImportReason
+	Journal                  MirrorChangeJournal
+	FullReason               FullImportReason
+	ForceParse               bool
+	ForceFullParseAfterCache bool
 }
 
 type CachePruneStats struct {
@@ -82,8 +84,9 @@ func (im Importer) PreparePending(
 	// invocation's explicit Full request bypasses durable failure skips. The
 	// journal's separate full-parse intent still bypasses freshness and
 	// incremental append for sources without a post-invalidation skip entry.
-	forceParse := im.Full
-	forceFullParse := request.Journal.ForceFullParseAll
+	forceParse := request.ForceParse
+	forceFullParse := request.Journal.ForceFullParseAll ||
+		request.ForceFullParseAfterCache
 	stats := SyncStats{
 		FullReason:     request.FullReason,
 		JournalOutcome: JournalAbortedBeforeProcessing,

--- a/internal/remotesync/delta_import.go
+++ b/internal/remotesync/delta_import.go
@@ -42,6 +42,8 @@ type DeltaImportRequest struct {
 	FullReason               FullImportReason
 	ForceParse               bool
 	ForceFullParseAfterCache bool
+	ResetAttemptCache        bool
+	MarkAttemptCacheReady    bool
 }
 
 type CachePruneStats struct {
@@ -86,7 +88,7 @@ func (im Importer) PreparePending(
 	// incremental append for sources without a post-invalidation skip entry.
 	forceParse := request.ForceParse
 	forceFullParse := request.Journal.ForceFullParseAll ||
-		request.ForceFullParseAfterCache
+		request.ForceFullParseAfterCache || journalForcesFullParse(request.Journal)
 	stats := SyncStats{
 		FullReason:     request.FullReason,
 		JournalOutcome: JournalAbortedBeforeProcessing,
@@ -155,6 +157,13 @@ func (im Importer) PreparePending(
 	pruned, pruneStats := pruneRemoteSkipCache(
 		remoteCache, layout, plan, request.Journal,
 	)
+	if request.ResetAttemptCache {
+		pruned = make(map[string]int64)
+		pruneStats = CachePruneStats{
+			HostWideScope: true,
+			HostWide:      len(remoteCache),
+		}
+	}
 	stats.PruningDuration = time.Since(pruningStart)
 	stats.PrunedExact = pruneStats.Exact
 	stats.PrunedProvider = pruneStats.Provider
@@ -174,7 +183,7 @@ func (im Importer) PreparePending(
 	deleted := removedRemoteSkipCacheKeys(remoteCache, pruned)
 	var persistErr error
 	if len(deleted) > 0 {
-		if request.Journal.InvalidateAll {
+		if request.Journal.InvalidateAll || request.ResetAttemptCache {
 			persistErr = replace(im.Host, pruned)
 		} else {
 			persistErr = apply(im.Host, deleted, nil)
@@ -193,8 +202,12 @@ func (im Importer) PreparePending(
 	if forceParse {
 		preparedCache = nil
 	}
+	disarmedJournal := disarmMirrorChanges(request.Journal)
+	if request.MarkAttemptCacheReady {
+		disarmedJournal.DataRebuildCacheReady = true
+	}
 	return &PreparedDeltaImport{
-		DisarmedJournal: disarmMirrorChanges(request.Journal),
+		DisarmedJournal: disarmedJournal,
 		Stats:           stats,
 		database:        im.DB, layout: layout, config: config, plan: plan,
 		cache:          preparedCache,
@@ -205,6 +218,15 @@ func (im Importer) PreparePending(
 		forceFullParse: forceFullParse,
 		progress:       im.Progress, save: im.saveSkipCache, apply: apply,
 	}, nil
+}
+
+func journalForcesFullParse(journal MirrorChangeJournal) bool {
+	for _, entry := range journal.Entries {
+		if entry.ForceFullParse {
+			return true
+		}
+	}
+	return false
 }
 
 func (pending *PreparedDeltaImport) Execute(

--- a/internal/remotesync/delta_import.go
+++ b/internal/remotesync/delta_import.go
@@ -1,0 +1,551 @@
+package remotesync
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+)
+
+type JournalOutcome string
+
+const (
+	JournalRetired                 JournalOutcome = "retired"
+	JournalAbortedBeforeProcessing JournalOutcome = "retained(aborted-before-processing)"
+	JournalProcessingFailures      JournalOutcome = "retained(processing-failures)"
+	JournalCachePersistFailed      JournalOutcome = "retained(cache-persist-failed)"
+	JournalRetirementFailed        JournalOutcome = "retained(retirement-failed)"
+	JournalCancelled               JournalOutcome = "retained(cancelled)"
+	JournalPendingSwap             JournalOutcome = "retained(pending-swap)"
+)
+
+func (outcome JournalOutcome) Valid() bool {
+	switch outcome {
+	case JournalRetired, JournalAbortedBeforeProcessing,
+		JournalProcessingFailures, JournalCachePersistFailed,
+		JournalRetirementFailed, JournalCancelled, JournalPendingSwap:
+		return true
+	default:
+		return false
+	}
+}
+
+type DeltaImportRequest struct {
+	Journal    MirrorChangeJournal
+	FullReason FullImportReason
+}
+
+type CachePruneStats struct {
+	ExactScopes    int
+	ProviderScopes int
+	HostWideScope  bool
+	Exact          int
+	Provider       int
+	HostWide       int
+}
+
+func (s CachePruneStats) Total() int { return s.Exact + s.Provider + s.HostWide }
+
+type PreparedDeltaImport struct {
+	DisarmedJournal MirrorChangeJournal
+	Stats           SyncStats
+
+	database    *db.DB
+	layout      importLayout
+	config      syncpkg.EngineConfig
+	plan        syncpkg.ChangedPathPlan
+	cache       map[string]int64
+	remoteCache map[string]int64
+	full        bool
+	forceParse  bool
+	progress    syncpkg.ProgressFunc
+	save        func(*db.DB, *syncpkg.Engine, remotePathMap) error
+	apply       func(string, []string, map[string]int64) error
+}
+
+func (im Importer) PreparePending(
+	ctx context.Context,
+	request DeltaImportRequest,
+) (*PreparedDeltaImport, error) {
+	// FullReason can be restored from a retained journal. It preserves the
+	// pending full-import scope and its observable cause, but it must not turn
+	// an ordinary replay into another force-parse attempt. Only the current
+	// invocation's explicit Full request bypasses freshness and failure skips.
+	forceParse := im.Full
+	stats := SyncStats{
+		FullReason:     request.FullReason,
+		JournalOutcome: JournalAbortedBeforeProcessing,
+		PendingPaths:   len(request.Journal.Entries),
+	}
+	for _, entry := range request.Journal.Entries {
+		if entry.InvalidateCache {
+			stats.ArmedPaths++
+		}
+	}
+	if request.Journal.FullImportReason != "" {
+		stats.FullReason = request.Journal.FullImportReason
+	}
+	if stats.FullReason != "" && !stats.FullReason.Valid() {
+		return nil, fmt.Errorf("invalid full import reason %q", stats.FullReason)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := validateMirrorChangeJournal(request.Journal); err != nil {
+		return nil, err
+	}
+	if err := validateTargetSetPaths(im.Targets); err != nil {
+		return nil, err
+	}
+	layout, config, err := newImportInputs(
+		im.Host, im.BlockedResultCategories, im.Targets, im.Root,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	physicalPaths := make([]string, 0, len(request.Journal.Entries))
+	for _, entry := range request.Journal.Entries {
+		path, pathErr := safeLocalArchivePath(
+			im.Root, filepath.FromSlash(entry.Path),
+		)
+		if pathErr != nil {
+			return nil, fmt.Errorf("resolve pending mirror path: %w", pathErr)
+		}
+		physicalPaths = append(physicalPaths, path)
+	}
+	planningStart := time.Now()
+	planningEngine := syncpkg.NewEngine(im.DB, config)
+	plan, err := planningEngine.PlanChangedPathsContext(ctx, physicalPaths)
+	planningEngine.Close()
+	stats.PlanningDuration = time.Since(planningStart)
+	if err != nil {
+		return nil, err
+	}
+	stats.ExactSources = len(plan.Files)
+	stats.FallbackProviders = len(plan.FallbackProviders)
+
+	full := request.Journal.FullImport || request.FullReason != "" || im.Full
+	ensureVisualStudioCopilotRemoteSkipMigration(im.DB, im.Host)
+	remoteCache, err := loadPlannedRemoteSkipCache(
+		ctx, im.DB, im.Host, layout, plan, request.Journal, full,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load skip cache: %w", err)
+	}
+	pruningStart := time.Now()
+	pruned, pruneStats := pruneRemoteSkipCache(
+		remoteCache, layout, plan, request.Journal,
+	)
+	stats.PruningDuration = time.Since(pruningStart)
+	stats.PrunedExact = pruneStats.Exact
+	stats.PrunedProvider = pruneStats.Provider
+	stats.PrunedHostWide = pruneStats.HostWide
+	stats.PruneExactScopes = pruneStats.ExactScopes
+	stats.PruneProviderScopes = pruneStats.ProviderScopes
+	stats.PruneHostWideScope = pruneStats.HostWideScope
+	replace := im.replaceRemoteSkippedFiles
+	if replace == nil {
+		replace = im.DB.ReplaceRemoteSkippedFiles
+	}
+	apply := im.applyRemoteSkippedChanges
+	if apply == nil {
+		apply = im.DB.ApplyRemoteSkippedFileChanges
+	}
+	cachePersistStart := time.Now()
+	deleted := removedRemoteSkipCacheKeys(remoteCache, pruned)
+	var persistErr error
+	if len(deleted) > 0 {
+		if request.Journal.InvalidateAll {
+			persistErr = replace(im.Host, pruned)
+		} else {
+			persistErr = apply(im.Host, deleted, nil)
+		}
+	}
+	if persistErr != nil {
+		return nil, fmt.Errorf("persist pruned remote skip cache: %w", persistErr)
+	}
+	stats.CachePersistDuration = time.Since(cachePersistStart)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	preparedCache := translateRemoteCacheToTemp(
+		pruned, layout.paths.remoteDirs, layout.paths.localDirs,
+	)
+	if forceParse {
+		preparedCache = nil
+	}
+	return &PreparedDeltaImport{
+		DisarmedJournal: disarmMirrorChanges(request.Journal),
+		Stats:           stats,
+		database:        im.DB, layout: layout, config: config, plan: plan,
+		cache:       preparedCache,
+		remoteCache: maps.Clone(pruned),
+		full:        full,
+		forceParse:  forceParse,
+		progress:    im.Progress, save: im.saveSkipCache, apply: apply,
+	}, nil
+}
+
+func (pending *PreparedDeltaImport) Execute(
+	ctx context.Context,
+) (SyncStats, error) {
+	if pending == nil {
+		return SyncStats{}, fmt.Errorf("execute nil pending delta import")
+	}
+	stats := pending.Stats
+	engine := syncpkg.NewEngine(pending.database, pending.config)
+	defer engine.Close()
+	engine.InjectSkipCache(pending.cache)
+	processingStart := time.Now()
+	var engineStats syncpkg.SyncStats
+	var changedResult syncpkg.ChangedPathSyncResult
+	var processErr error
+	if pending.full {
+		progress := hostProgress(pending.layout.paths.host, pending.progress)
+		if pending.forceParse {
+			engineStats = engine.SyncAllForceParse(ctx, progress)
+		} else {
+			engineStats = engine.SyncAll(ctx, progress)
+		}
+	} else {
+		changedResult, processErr = engine.SyncChangedPathPlanContext(
+			ctx, pending.plan, hostProgress(pending.layout.paths.host, pending.progress),
+		)
+		engineStats = changedResult.Stats
+		stats.FilesDiscovered = changedResult.FilesDiscovered
+		stats.FilesProcessed = changedResult.FilesProcessed
+		stats.FallbackSources = changedResult.FallbackSources
+		stats.ErrorSuppressed = countDisarmedCachedSuppressions(
+			pending.plan, pending.DisarmedJournal, changedResult,
+		)
+	}
+	stats.ProcessingDuration = time.Since(processingStart)
+	stats.SessionsSynced = engineStats.Synced
+	stats.SessionsTotal = engineStats.TotalSessions
+	stats.Skipped = engineStats.Skipped
+	stats.Failed = engineStats.Failed
+
+	cachePersistStart := time.Now()
+	if err := pending.persistSkipCache(pending.database, engine); err != nil {
+		stats.CachePersistDuration += time.Since(cachePersistStart)
+		stats.JournalOutcome = JournalCachePersistFailed
+		pending.Stats = stats
+		return stats, err
+	}
+	stats.CachePersistDuration += time.Since(cachePersistStart)
+	switch {
+	case ctx.Err() != nil:
+		stats.JournalOutcome = JournalCancelled
+		processErr = ctx.Err()
+	case processErr != nil || engineStats.Aborted || engineStats.Failed > 0:
+		stats.JournalOutcome = JournalProcessingFailures
+		if processErr == nil {
+			processErr = fmt.Errorf(
+				"remote import processing incomplete: aborted=%t failed=%d",
+				engineStats.Aborted, engineStats.Failed,
+			)
+		}
+	default:
+		stats.JournalOutcome = JournalRetired
+	}
+	pending.Stats = stats
+	return stats, processErr
+}
+
+func (pending *PreparedDeltaImport) persistSkipCache(
+	database *db.DB,
+	engine *syncpkg.Engine,
+) error {
+	if pending.save != nil {
+		return pending.save(database, engine, pending.layout.paths)
+	}
+	if pending.full {
+		return saveEngineSkipCache(database, engine, pending.layout.paths)
+	}
+	current := remoteEngineSkipCache(engine, pending.layout.paths)
+	deletes, upserts := diffRemoteSkipCache(pending.remoteCache, current)
+	if database != pending.database {
+		merged, err := pending.database.LoadRemoteSkippedFiles(
+			pending.layout.paths.host,
+		)
+		if err != nil {
+			return fmt.Errorf("load active skip cache for rebuild: %w", err)
+		}
+		for _, key := range deletes {
+			delete(merged, key)
+		}
+		maps.Copy(merged, upserts)
+		if err := database.ReplaceRemoteSkippedFiles(
+			pending.layout.paths.host, merged,
+		); err != nil {
+			return fmt.Errorf("save rebuilt skip cache: %w", err)
+		}
+		return nil
+	}
+	if err := pending.apply(
+		pending.layout.paths.host, deletes, upserts,
+	); err != nil {
+		return fmt.Errorf("save scoped skip cache: %w", err)
+	}
+	return nil
+}
+
+type plannedRemoteSkipCacheScope struct {
+	exact    map[string]map[parser.AgentType]struct{}
+	fallback map[parser.AgentType][]string
+}
+
+func loadPlannedRemoteSkipCache(
+	ctx context.Context,
+	database *db.DB,
+	host string,
+	layout importLayout,
+	plan syncpkg.ChangedPathPlan,
+	journal MirrorChangeJournal,
+	full bool,
+) (map[string]int64, error) {
+	if full {
+		return database.LoadRemoteSkippedFiles(host)
+	}
+	scope := plannedRemoteSkipScope(layout, plan, journal)
+	exactPaths := make([]string, 0, len(scope.exact))
+	for path := range scope.exact {
+		exactPaths = append(exactPaths, path)
+	}
+	var rootPaths []string
+	for _, roots := range scope.fallback {
+		rootPaths = append(rootPaths, roots...)
+	}
+	candidates, err := database.LoadRemoteSkippedFilesForScopes(
+		ctx, host, exactPaths, rootPaths,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cache := make(map[string]int64, len(candidates))
+	for key, mtime := range candidates {
+		path, agent := remoteCacheFamily(key)
+		if agents := scope.exact[path]; agents != nil {
+			if agent == "" {
+				cache[key] = mtime
+				continue
+			}
+			if _, ok := agents[agent]; ok {
+				cache[key] = mtime
+				continue
+			}
+		}
+		for fallbackAgent, roots := range scope.fallback {
+			if agent != "" && agent != fallbackAgent {
+				continue
+			}
+			if remotePathWithinAnyRoot(path, roots) {
+				cache[key] = mtime
+				break
+			}
+		}
+	}
+	return cache, nil
+}
+
+func plannedRemoteSkipScope(
+	layout importLayout,
+	plan syncpkg.ChangedPathPlan,
+	journal MirrorChangeJournal,
+) plannedRemoteSkipCacheScope {
+	allPending := make(map[string]struct{}, len(journal.Entries))
+	for _, entry := range journal.Entries {
+		physical, err := safeLocalArchivePath(
+			layout.paths.root, filepath.FromSlash(entry.Path),
+		)
+		if err == nil {
+			allPending[physical] = struct{}{}
+		}
+	}
+	attributed := plan.PruneScope(allPending)
+	files := append(slices.Clone(plan.Files), attributed.Files...)
+	providers := append(slices.Clone(plan.FallbackProviders), attributed.FallbackProviders...)
+	scope := plannedRemoteSkipCacheScope{
+		exact:    make(map[string]map[parser.AgentType]struct{}),
+		fallback: make(map[parser.AgentType][]string),
+	}
+	for _, file := range files {
+		remotePath, ok := tempPathToRemotePath(
+			file.Path, layout.paths.remoteDirs, layout.paths.localDirs,
+		)
+		if !ok {
+			continue
+		}
+		agents := scope.exact[remotePath]
+		if agents == nil {
+			agents = make(map[parser.AgentType]struct{})
+			scope.exact[remotePath] = agents
+		}
+		agents[file.Agent] = struct{}{}
+	}
+	for _, agent := range providers {
+		for _, localRoot := range layout.engineDirs[agent] {
+			remoteRoot, ok := tempPathToRemotePath(
+				localRoot, layout.paths.remoteDirs, layout.paths.localDirs,
+			)
+			if !ok || slices.Contains(scope.fallback[agent], remoteRoot) {
+				continue
+			}
+			scope.fallback[agent] = append(scope.fallback[agent], remoteRoot)
+		}
+	}
+	return scope
+}
+
+func removedRemoteSkipCacheKeys(
+	before map[string]int64,
+	after map[string]int64,
+) []string {
+	removed := make([]string, 0, len(before))
+	for key := range before {
+		if _, ok := after[key]; !ok {
+			removed = append(removed, key)
+		}
+	}
+	slices.Sort(removed)
+	return removed
+}
+
+func diffRemoteSkipCache(
+	before map[string]int64,
+	after map[string]int64,
+) ([]string, map[string]int64) {
+	deletes := removedRemoteSkipCacheKeys(before, after)
+	upserts := make(map[string]int64)
+	for key, mtime := range after {
+		if previous, ok := before[key]; !ok || previous != mtime {
+			upserts[key] = mtime
+		}
+	}
+	return deletes, upserts
+}
+
+func pruneRemoteSkipCache(
+	cache map[string]int64,
+	layout importLayout,
+	plan syncpkg.ChangedPathPlan,
+	journal MirrorChangeJournal,
+) (map[string]int64, CachePruneStats) {
+	stats := CachePruneStats{}
+	if journal.InvalidateAll {
+		stats.HostWideScope = true
+		stats.HostWide = len(cache)
+		return map[string]int64{}, stats
+	}
+	pruned := make(map[string]int64, len(cache))
+	maps.Copy(pruned, cache)
+	armed := make(map[string]struct{})
+	for _, entry := range journal.Entries {
+		if !entry.InvalidateCache {
+			continue
+		}
+		physical, err := safeLocalArchivePath(
+			layout.paths.root, filepath.FromSlash(entry.Path),
+		)
+		if err == nil {
+			armed[physical] = struct{}{}
+		}
+	}
+	scope := plan.PruneScope(armed)
+	stats.ExactScopes = len(scope.Files)
+	stats.ProviderScopes = len(scope.FallbackProviders)
+	exact := make(map[string]map[parser.AgentType]struct{}, len(scope.Files))
+	for _, file := range scope.Files {
+		remotePath, ok := tempPathToRemotePath(
+			file.Path, layout.paths.remoteDirs, layout.paths.localDirs,
+		)
+		if !ok {
+			continue
+		}
+		agents := exact[remotePath]
+		if agents == nil {
+			agents = make(map[parser.AgentType]struct{})
+			exact[remotePath] = agents
+		}
+		agents[file.Agent] = struct{}{}
+	}
+	fallback := make(map[parser.AgentType][]string, len(scope.FallbackProviders))
+	for _, agent := range scope.FallbackProviders {
+		for _, localRoot := range layout.engineDirs[agent] {
+			if remoteRoot, ok := tempPathToRemotePath(
+				localRoot, layout.paths.remoteDirs, layout.paths.localDirs,
+			); ok {
+				fallback[agent] = append(fallback[agent], remoteRoot)
+			}
+		}
+	}
+	for key := range pruned {
+		path, agent := remoteCacheFamily(key)
+		if agents := exact[path]; agents != nil {
+			_, sameAgent := agents[agent]
+			if agent == "" || sameAgent {
+				delete(pruned, key)
+				stats.Exact++
+				continue
+			}
+		}
+		for fallbackAgent, roots := range fallback {
+			if agent != "" && agent != fallbackAgent {
+				continue
+			}
+			if remotePathWithinAnyRoot(path, roots) {
+				delete(pruned, key)
+				stats.Provider++
+				break
+			}
+		}
+	}
+	return pruned, stats
+}
+
+func remoteCacheFamily(key string) (string, parser.AgentType) {
+	base, _, _ := strings.Cut(key, "?source_hash=")
+	path, suffix := syncpkg.SplitProviderSkipCachePath(base)
+	if suffix == "" {
+		return path, ""
+	}
+	agent := strings.TrimPrefix(suffix, "?agent=")
+	if before, _, ok := strings.Cut(agent, "?"); ok {
+		agent = before
+	}
+	return path, parser.AgentType(agent)
+}
+
+func remotePathWithinAnyRoot(path string, roots []string) bool {
+	return slices.ContainsFunc(roots, func(root string) bool {
+		_, ok := remoteArchiveRel(root, path)
+		return ok
+	})
+}
+
+func countDisarmedCachedSuppressions(
+	plan syncpkg.ChangedPathPlan,
+	journal MirrorChangeJournal,
+	result syncpkg.ChangedPathSyncResult,
+) int {
+	if journal.InvalidateAll {
+		return 0
+	}
+	for _, entry := range journal.Entries {
+		if entry.InvalidateCache {
+			return 0
+		}
+	}
+	armed := make(map[string]struct{})
+	return plan.CountCachedSuppressedInputs(
+		armed, result.CachedSourceKeys, result.CachedFallbackProviders,
+	)
+}

--- a/internal/remotesync/delta_import_test.go
+++ b/internal/remotesync/delta_import_test.go
@@ -1,0 +1,508 @@
+package remotesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+type deltaPlanFactory struct {
+	agent     parser.AgentType
+	relevance parser.ChangedPathRelevance
+}
+
+func (f deltaPlanFactory) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: f.agent, DisplayName: string(f.agent)}
+}
+
+func (f deltaPlanFactory) Capabilities() parser.Capabilities {
+	return parser.Capabilities{Source: parser.SourceCapabilities{
+		ClassifyChangedPath:  parser.CapabilitySupported,
+		ChangedPathRelevance: parser.CapabilitySupported,
+	}}
+}
+
+func (f deltaPlanFactory) NewProvider(cfg parser.ProviderConfig) parser.Provider {
+	return &deltaPlanProvider{ProviderBase: parser.ProviderBase{
+		Def: f.Definition(), Caps: f.Capabilities(), Config: cfg.Clone(),
+	}, relevance: f.relevance}
+}
+
+type deltaPlanProvider struct {
+	parser.ProviderBase
+	relevance parser.ChangedPathRelevance
+}
+
+func (p *deltaPlanProvider) WatchPlan(context.Context) (parser.WatchPlan, error) {
+	return parser.WatchPlan{Roots: []parser.WatchRoot{{Path: p.Config.Roots[0]}}}, nil
+}
+
+func (p *deltaPlanProvider) ChangedPathRelevance(
+	context.Context, parser.ChangedPathRequest,
+) (parser.ChangedPathRelevance, error) {
+	return p.relevance, nil
+}
+
+func (p *deltaPlanProvider) SourcesForChangedPath(
+	_ context.Context, req parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	return []parser.SourceRef{{
+		Provider: p.Definition().Type, Key: req.Path,
+		DisplayPath: req.Path, FingerprintKey: req.Path,
+	}}, nil
+}
+
+func (p *deltaPlanProvider) Parse(context.Context, parser.ParseRequest) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+func TestRemotePathMapStoredResolver(t *testing.T) {
+	root := t.TempDir()
+	remoteDir := "/srv/agent/sessions"
+	localDir := remappedRemotePath(root, remoteDir)
+	paths := remotePathMap{
+		host: "remote", root: root,
+		remoteDirs: []string{remoteDir}, localDirs: []string{localDir},
+	}
+	resolve := paths.storedPathResolver()
+
+	local, ok := resolve("remote:/srv/agent/sessions/project/session.jsonl")
+	require.True(t, ok)
+	assert.Equal(t, filepath.Join(localDir, "project", "session.jsonl"), local)
+	assert.Equal(t, "remote:/srv/agent/sessions/project/session.jsonl", paths.pathRewriter()(local))
+
+	_, ok = resolve("other:/srv/agent/sessions/project/session.jsonl")
+	assert.False(t, ok)
+	_, ok = resolve("remote:/srv/other/session.jsonl")
+	assert.False(t, ok)
+	_, ok = resolve("remote:/srv/agent/sessions/../escape.jsonl")
+	assert.False(t, ok)
+}
+
+func TestPruneRemoteSkipCacheHostWideAndDisarmed(t *testing.T) {
+	root := t.TempDir()
+	remoteDir := "/srv/agent/sessions"
+	layout := importLayout{
+		engineDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {remappedRemotePath(root, remoteDir)},
+		},
+		paths: remotePathMap{
+			host: "remote", root: root,
+			remoteDirs: []string{remoteDir},
+			localDirs:  []string{remappedRemotePath(root, remoteDir)},
+		},
+	}
+	cache := map[string]int64{
+		remoteDir + "/one.jsonl":               1,
+		remoteDir + "/two.jsonl?agent=claude":  2,
+		remoteDir + "/three.jsonl?agent=codex": 3,
+	}
+
+	pruned, stats := pruneRemoteSkipCache(cache, layout, syncpkg.ChangedPathPlan{}, MirrorChangeJournal{
+		Version: mirrorJournalVersion, InvalidateAll: true,
+	})
+	assert.Empty(t, pruned)
+	assert.True(t, stats.HostWideScope)
+	assert.Equal(t, 3, stats.HostWide)
+
+	pruned, stats = pruneRemoteSkipCache(cache, layout, syncpkg.ChangedPathPlan{}, MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+	})
+	assert.Equal(t, cache, pruned)
+	assert.Zero(t, stats.Total())
+}
+
+func TestPruneRemoteSkipCacheExactAndFallbackFamilies(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	root := t.TempDir()
+	remoteDir := "/srv/agent/sessions"
+	localDir := remappedRemotePath(root, remoteDir)
+	agent := parser.AgentType("delta-provider")
+	layout := importLayout{
+		engineDirs: map[parser.AgentType][]string{agent: {localDir}},
+		paths: remotePathMap{
+			host: "remote", root: root,
+			remoteDirs: []string{remoteDir}, localDirs: []string{localDir},
+		},
+	}
+	changed := filepath.Join(localDir, "changed.jsonl")
+	journalPath, err := mirrorRelativeLocalChangePath(root, changed)
+	require.NoError(t, err)
+	journal := MirrorChangeJournal{Version: mirrorJournalVersion, Entries: []MirrorChangeEntry{{
+		Path: journalPath, InvalidateCache: true,
+	}}}
+	cache := map[string]int64{
+		remoteDir + "/changed.jsonl":                                    1,
+		remoteDir + "/changed.jsonl?agent=delta-provider":               2,
+		remoteDir + "/changed.jsonl?agent=delta-provider?source_hash=x": 3,
+		remoteDir + "/changed.jsonl?agent=other":                        4,
+		remoteDir + "/unchanged.jsonl?agent=delta-provider":             5,
+	}
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{agent: {localDir}},
+		Machine:   "remote", Ephemeral: true,
+		ProviderFactories: []parser.ProviderFactory{deltaPlanFactory{
+			agent: agent, relevance: parser.ChangedPathDataBearing,
+		}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	plan, err := engine.PlanChangedPathsContext(t.Context(), []string{changed})
+	require.NoError(t, err)
+
+	pruned, stats := pruneRemoteSkipCache(cache, layout, plan, journal)
+	assert.Equal(t, 1, stats.ExactScopes)
+	assert.Zero(t, stats.ProviderScopes)
+	assert.Equal(t, 3, stats.Exact)
+	assert.Zero(t, stats.Provider)
+	assert.Equal(t, map[string]int64{
+		remoteDir + "/changed.jsonl?agent=other":            4,
+		remoteDir + "/unchanged.jsonl?agent=delta-provider": 5,
+	}, pruned)
+
+	fallbackEngine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{agent: {localDir}},
+		Machine:   "remote", Ephemeral: true,
+		ProviderFactories: []parser.ProviderFactory{deltaPlanFactory{
+			agent: agent, relevance: parser.ChangedPathUnclassified,
+		}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(fallbackEngine.Close)
+	fallbackPlan, err := fallbackEngine.PlanChangedPathsContext(t.Context(), []string{changed})
+	require.NoError(t, err)
+	pruned, stats = pruneRemoteSkipCache(cache, layout, fallbackPlan, journal)
+	assert.Zero(t, stats.ExactScopes)
+	assert.Equal(t, 1, stats.ProviderScopes)
+	assert.Equal(t, 4, stats.Provider)
+	assert.Equal(t, map[string]int64{
+		remoteDir + "/changed.jsonl?agent=other": 4,
+	}, pruned)
+
+	disarmed := disarmMirrorChanges(journal)
+	pruned, stats = pruneRemoteSkipCache(cache, layout, plan, disarmed)
+	assert.Equal(t, cache, pruned)
+	assert.Zero(t, stats.Total())
+}
+
+func TestJournalOutcomeClosedSet(t *testing.T) {
+	want := []JournalOutcome{
+		JournalRetired,
+		JournalAbortedBeforeProcessing,
+		JournalProcessingFailures,
+		JournalCachePersistFailed,
+		JournalRetirementFailed,
+		JournalCancelled,
+		JournalPendingSwap,
+	}
+	for _, outcome := range want {
+		assert.True(t, outcome.Valid(), "outcome %q must be reportable", outcome)
+	}
+	assert.False(t, JournalOutcome("retained(invented)").Valid())
+}
+
+func TestPreparedDeltaImportPoisonProjectionDisarmsAndRearms(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	root := t.TempDir()
+	remoteDir := "/srv/agent/sessions"
+	localDir := remappedRemotePath(root, remoteDir)
+	agent := parser.AgentType("delta-provider")
+	changed := filepath.Join(localDir, "poison.jsonl")
+	journalPath, err := mirrorRelativeLocalChangePath(root, changed)
+	require.NoError(t, err)
+	journal := MirrorChangeJournal{Version: mirrorJournalVersion, Entries: []MirrorChangeEntry{{
+		Path: journalPath, InvalidateCache: true,
+	}}}
+	layout := importLayout{
+		engineDirs: map[parser.AgentType][]string{agent: {localDir}},
+		paths: remotePathMap{
+			host: "remote", root: root,
+			remoteDirs: []string{remoteDir}, localDirs: []string{localDir},
+		},
+	}
+	buildPlan := func(relevance parser.ChangedPathRelevance) syncpkg.ChangedPathPlan {
+		engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{agent: {localDir}},
+			Machine:   "remote", Ephemeral: true,
+			ProviderFactories: []parser.ProviderFactory{deltaPlanFactory{
+				agent: agent, relevance: relevance,
+			}},
+			ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				agent: parser.ProviderMigrationProviderAuthoritative,
+			},
+		})
+		t.Cleanup(engine.Close)
+		plan, planErr := engine.PlanChangedPathsContext(t.Context(), []string{changed})
+		require.NoError(t, planErr)
+		return plan
+	}
+
+	for _, tc := range []struct {
+		name      string
+		relevance parser.ChangedPathRelevance
+		result    syncpkg.ChangedPathSyncResult
+	}{
+		{
+			name: "exact", relevance: parser.ChangedPathDataBearing,
+			result: syncpkg.ChangedPathSyncResult{CachedSourceKeys: map[string]struct{}{
+				string(agent) + "\x00" + changed: {},
+			}},
+		},
+		{
+			name: "fallback", relevance: parser.ChangedPathUnclassified,
+			result: syncpkg.ChangedPathSyncResult{
+				CachedFallbackProviders: map[parser.AgentType]int{agent: 1},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := buildPlan(tc.relevance)
+			cache := map[string]int64{
+				remoteDir + "/poison.jsonl?agent=delta-provider": 42,
+			}
+			_, armedStats := pruneRemoteSkipCache(cache, layout, plan, journal)
+			assert.Equal(t, 1, armedStats.Total())
+
+			disarmed := disarmMirrorChanges(journal)
+			preserved, replayStats := pruneRemoteSkipCache(cache, layout, plan, disarmed)
+			assert.Equal(t, cache, preserved)
+			assert.Zero(t, replayStats.Total())
+			assert.Equal(t, 1, countDisarmedCachedSuppressions(plan, disarmed, tc.result))
+
+			rearmed, _, mergeErr := mergeMirrorChanges(disarmed, []string{journalPath})
+			require.NoError(t, mergeErr)
+			_, rearmedStats := pruneRemoteSkipCache(cache, layout, plan, rearmed)
+			assert.Equal(t, 1, rearmedStats.Total())
+			assert.Zero(t, countDisarmedCachedSuppressions(plan, rearmed, tc.result))
+		})
+	}
+}
+
+func TestPreparedDeltaImportPrepareDoesNotProcess(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	root := t.TempDir()
+	remoteDir := "/srv/agent/sessions"
+	pending, err := (Importer{
+		Host: "remote", DB: database,
+		Targets: TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {remoteDir},
+		}},
+		Root: root,
+	}).PreparePending(t.Context(), DeltaImportRequest{
+		Journal: MirrorChangeJournal{Version: mirrorJournalVersion},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pending)
+	assert.Zero(t, pending.Stats.SessionsSynced)
+	assert.Equal(t, JournalAbortedBeforeProcessing, pending.Stats.JournalOutcome)
+}
+
+func TestPreparePendingExactChangeLoadsOnlyRelevantSkipCache(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	const host = "remote"
+	require.NoError(t, database.SetSyncState(
+		visualStudioCopilotRemoteSkipMigrationKey(host), "done",
+	))
+	root := t.TempDir()
+	remoteDir := "/srv/agent/sessions"
+	localDir := remappedRemotePath(root, remoteDir)
+	changedPath := filepath.Join(localDir, "project", "changed.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(changedPath), 0o755))
+	require.NoError(t, os.WriteFile(changedPath, []byte(
+		testjsonl.NewSessionBuilder().AddClaudeUser(
+			"2026-08-15T10:00:00Z", "bounded cache fixture",
+		).String(),
+	), 0o600))
+	journalPath, err := mirrorRelativeLocalChangePath(root, changedPath)
+	require.NoError(t, err)
+	cache := map[string]int64{
+		remoteDir + "/project/changed.jsonl": 42,
+	}
+	for i := range 256 {
+		cache[fmt.Sprintf("%s/unrelated/session-%03d.jsonl", remoteDir, i)] = int64(i)
+	}
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(host, cache))
+	replaceCalls := 0
+	type mutationCount struct{ deletes, upserts int }
+	var mutations []mutationCount
+
+	pending, err := (Importer{
+		Host: host, DB: database, Root: root,
+		Targets: TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {remoteDir},
+		}},
+		replaceRemoteSkippedFiles: func(string, map[string]int64) error {
+			replaceCalls++
+			return nil
+		},
+		applyRemoteSkippedChanges: func(
+			host string, deletes []string, upserts map[string]int64,
+		) error {
+			mutations = append(mutations, mutationCount{len(deletes), len(upserts)})
+			return database.ApplyRemoteSkippedFileChanges(host, deletes, upserts)
+		},
+	}).PreparePending(t.Context(), DeltaImportRequest{
+		Journal: MirrorChangeJournal{
+			Version: mirrorJournalVersion,
+			Entries: []MirrorChangeEntry{{Path: journalPath}},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pending)
+	assert.Len(t, pending.cache, 1,
+		"unrelated host cache entries must not enter a one-source import")
+	assert.Zero(t, replaceCalls,
+		"a disarmed exact import must not rewrite unchanged cache rows")
+
+	stats, err := pending.Execute(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	assert.Equal(t, []mutationCount{{deletes: 1}}, mutations,
+		"processing must persist only the relevant cache-family change")
+	persisted, err := database.LoadRemoteSkippedFiles(host)
+	require.NoError(t, err)
+	assert.Len(t, persisted, 256)
+	assert.NotContains(t, persisted, remoteDir+"/project/changed.jsonl")
+}
+
+func TestPreparePendingPersistenceFailureAbortsBeforeProcessing(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		"remote", map[string]int64{"/srv/agent/sessions/pending.jsonl": 1},
+	))
+	sentinel := errors.New("prune persistence sentinel")
+	_, err = (Importer{
+		Host: "remote", DB: database, Root: t.TempDir(),
+		Targets: TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {"/srv/agent/sessions"},
+		}},
+		replaceRemoteSkippedFiles: func(string, map[string]int64) error {
+			return sentinel
+		},
+	}).PreparePending(t.Context(), DeltaImportRequest{
+		Journal: MirrorChangeJournal{
+			Version: mirrorJournalVersion, FullImport: true,
+			FullImportReason: FullImportJournalOverflow, InvalidateAll: true,
+		},
+	})
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestPreparePendingRejectsUnknownReasonBeforePersistence(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	persistCalls := 0
+	_, err := (Importer{
+		Host: "remote", DB: database, Root: t.TempDir(),
+		Targets: TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {"/srv/agent/sessions"},
+		}},
+		replaceRemoteSkippedFiles: func(string, map[string]int64) error {
+			persistCalls++
+			return nil
+		},
+	}).PreparePending(t.Context(), DeltaImportRequest{
+		Journal:    MirrorChangeJournal{Version: mirrorJournalVersion},
+		FullReason: FullImportReason("invented"),
+	})
+	require.ErrorContains(t, err, "invalid full import reason")
+	assert.Zero(t, persistCalls)
+}
+
+func TestPreparePendingCancellationDoesNotPruneOrDisarm(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	persistCalls := 0
+	_, err := (Importer{
+		Host: "remote", DB: database, Root: t.TempDir(),
+		Targets: TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {"/srv/agent/sessions"},
+		}},
+		replaceRemoteSkippedFiles: func(string, map[string]int64) error {
+			persistCalls++
+			return nil
+		},
+	}).PreparePending(ctx, DeltaImportRequest{
+		Journal: MirrorChangeJournal{
+			Version: mirrorJournalVersion, FullImport: true,
+			FullImportReason: FullImportJournalOverflow, InvalidateAll: true,
+		},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, persistCalls)
+}
+
+func TestPreparePendingCancellationAfterPrunePersistenceDoesNotReturnFlip(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		"remote", map[string]int64{"/srv/agent/sessions/pending.jsonl": 1},
+	))
+	ctx, cancel := context.WithCancel(t.Context())
+	persistCalls := 0
+	pending, err := (Importer{
+		Host: "remote", DB: database, Root: t.TempDir(),
+		Targets: TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {"/srv/agent/sessions"},
+		}},
+		replaceRemoteSkippedFiles: func(string, map[string]int64) error {
+			persistCalls++
+			cancel()
+			return nil
+		},
+	}).PreparePending(ctx, DeltaImportRequest{
+		Journal: MirrorChangeJournal{
+			Version: mirrorJournalVersion, FullImport: true,
+			FullImportReason: FullImportJournalOverflow, InvalidateAll: true,
+		},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, pending,
+		"the caller must not receive a disarmed journal after cancellation")
+	assert.Equal(t, 1, persistCalls)
+}
+
+func TestPreparedDeltaImportFinalCacheFailureRetainsJournal(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	sentinel := errors.New("final cache sentinel")
+	pending, err := (Importer{
+		Host: "remote", DB: database, Root: t.TempDir(),
+		Targets: TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {"/srv/agent/sessions"},
+		}},
+		saveSkipCache: func(*db.DB, *syncpkg.Engine, remotePathMap) error {
+			return sentinel
+		},
+	}).PreparePending(t.Context(), DeltaImportRequest{
+		Journal: MirrorChangeJournal{Version: mirrorJournalVersion},
+	})
+	require.NoError(t, err)
+	stats, err := pending.Execute(t.Context())
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, JournalCachePersistFailed, stats.JournalOutcome)
+}

--- a/internal/remotesync/extract.go
+++ b/internal/remotesync/extract.go
@@ -28,11 +28,11 @@ const (
 func ExtractTarStream(
 	ctx context.Context, r io.Reader, dst string,
 ) (int, error) {
-	return extractTarStream(ctx, r, dst)
+	return extractTarStream(ctx, r, dst, nil)
 }
 
 func extractTarStream(
-	ctx context.Context, r io.Reader, dst string,
+	ctx context.Context, r io.Reader, dst string, selected map[string]struct{},
 ) (int, error) {
 	endMarkerReader := &tarEndMarkerReader{r: r}
 	tr := tar.NewReader(endMarkerReader)
@@ -55,6 +55,15 @@ func extractTarStream(
 		}
 		if err != nil {
 			return skipped, fmt.Errorf("read tar entry: %w", err)
+		}
+		if _, err := safeJoin(dst, hdr.Name); err != nil {
+			return skipped, err
+		}
+		if selected != nil {
+			name := filepath.ToSlash(filepath.Clean(hdr.Name))
+			if _, ok := selected[name]; !ok {
+				continue
+			}
 		}
 		selfLink, err := extractEntry(tr, dst, hdr)
 		if err != nil {

--- a/internal/remotesync/http.go
+++ b/internal/remotesync/http.go
@@ -32,6 +32,7 @@ type HTTPSync struct {
 	URL                     string
 	Token                   string
 	Full                    bool
+	FullReason              FullImportReason
 	DataDir                 string
 	DB                      *db.DB
 	BlockedResultCategories []string
@@ -107,12 +108,17 @@ func (hs HTTPSync) importRoot(
 	stats, err := Importer{
 		Host:                    hs.Host,
 		Full:                    hs.Full,
+		RequireComplete:         true,
 		DB:                      hs.DB,
 		BlockedResultCategories: hs.BlockedResultCategories,
 		Progress:                hs.Progress,
 	}.ImportExtracted(ctx, targets, root)
+	stats.FullReason = hs.FullReason
+	if stats.FullReason == "" {
+		stats.FullReason = FullImportLegacy
+	}
 	if err != nil {
-		return SyncStats{}, err
+		return stats, err
 	}
 	hs.report(syncpkg.Progress{
 		Detail: fmt.Sprintf(
@@ -236,8 +242,24 @@ func (hs HTTPSync) downloadIntoMirror(
 	if err := RemoveMirrorFetchFiles(mirrorRoot, fetch); err != nil {
 		return err
 	}
-	if err := archive.extract(ctx, mirrorRoot, hs.Progress, extractLabel); err != nil {
-		return fmt.Errorf("extract archive into mirror: %w", err)
+	var extractErr error
+	if full && fetch != nil {
+		selected := make(map[string]struct{}, len(fetch))
+		for _, remotePath := range fetch {
+			name, nameErr := safeRemotePathArchiveName(remotePath)
+			if nameErr != nil {
+				return nameErr
+			}
+			selected[filepath.ToSlash(filepath.Clean(name))] = struct{}{}
+		}
+		extractErr = archive.extractSelected(
+			ctx, mirrorRoot, selected, hs.Progress, extractLabel,
+		)
+	} else {
+		extractErr = archive.extract(ctx, mirrorRoot, hs.Progress, extractLabel)
+	}
+	if extractErr != nil {
+		return fmt.Errorf("extract archive into mirror: %w", extractErr)
 	}
 	return nil
 }

--- a/internal/remotesync/http.go
+++ b/internal/remotesync/http.go
@@ -117,13 +117,12 @@ func (hs HTTPSync) importRoot(
 	ctx context.Context, targets TargetSet, root string,
 ) (SyncStats, error) {
 	stats, err := Importer{
-		Host:                     hs.Host,
-		Full:                     hs.forceParseRequested(),
-		ForceFullParseAfterCache: hs.forceFullParseAfterCacheRequested(),
-		RequireComplete:          true,
-		DB:                       hs.DB,
-		BlockedResultCategories:  hs.BlockedResultCategories,
-		Progress:                 hs.Progress,
+		Host:                    hs.Host,
+		Full:                    hs.Full,
+		RequireComplete:         true,
+		DB:                      hs.DB,
+		BlockedResultCategories: hs.BlockedResultCategories,
+		Progress:                hs.Progress,
 	}.ImportExtracted(ctx, targets, root)
 	stats.FullReason = hs.FullReason
 	if stats.FullReason == "" {

--- a/internal/remotesync/http.go
+++ b/internal/remotesync/http.go
@@ -43,6 +43,17 @@ type HTTPSync struct {
 	removeArchiveSpool      func(string) error
 }
 
+// forceParseRequested distinguishes an operator-requested full sync from a
+// complete source scan required by an automatic data rebuild. A blank reason
+// retains the historical meaning of Full for direct callers.
+func (hs HTTPSync) forceParseRequested() bool {
+	return hs.Full && (hs.FullReason == "" || hs.FullReason == FullImportExplicit)
+}
+
+func (hs HTTPSync) forceFullParseAfterCacheRequested() bool {
+	return hs.Full && !hs.forceParseRequested()
+}
+
 // PreparedCleanupError reports an operation failure while retaining a prepared
 // HTTP source whose cleanup still needs to be retried. RetryCleanup is safe to
 // call more than once. Error matching traverses the original operation and
@@ -106,12 +117,13 @@ func (hs HTTPSync) importRoot(
 	ctx context.Context, targets TargetSet, root string,
 ) (SyncStats, error) {
 	stats, err := Importer{
-		Host:                    hs.Host,
-		Full:                    hs.Full,
-		RequireComplete:         true,
-		DB:                      hs.DB,
-		BlockedResultCategories: hs.BlockedResultCategories,
-		Progress:                hs.Progress,
+		Host:                     hs.Host,
+		Full:                     hs.forceParseRequested(),
+		ForceFullParseAfterCache: hs.forceFullParseAfterCacheRequested(),
+		RequireComplete:          true,
+		DB:                       hs.DB,
+		BlockedResultCategories:  hs.BlockedResultCategories,
+		Progress:                 hs.Progress,
 	}.ImportExtracted(ctx, targets, root)
 	stats.FullReason = hs.FullReason
 	if stats.FullReason == "" {

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"sync"
+	"time"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
 
@@ -19,6 +23,11 @@ var (
 	ErrPreparedInUse       = errors.New("prepared HTTP sources are in use")
 	ErrPreparedClosed      = errors.New("prepared HTTP sources are closing or closed")
 )
+
+type rebuildCachePersistError struct{ err error }
+
+func (e *rebuildCachePersistError) Error() string { return e.err.Error() }
+func (e *rebuildCachePersistError) Unwrap() error { return e.err }
 
 // HostError attributes an HTTP preparation failure to its configured host.
 // The cause remains available to errors.Is and errors.As callers.
@@ -206,19 +215,56 @@ func (p *PreparedHTTPSyncs) Close() error {
 	return cleanupErr
 }
 
+// Commit finalizes each successfully rebuilt persistent source. It is
+// idempotent; a failure leaves every uncommitted source owned for retry.
+func (p *PreparedHTTPSyncs) Commit() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, source := range p.sources {
+		if source == nil {
+			continue
+		}
+		if err := source.Commit(); err != nil {
+			return &HostError{Host: source.sync.Host, Operation: "commit rebuild", Err: err}
+		}
+	}
+	return nil
+}
+
 // PreparedHTTP is a downloaded remote source ready for active import. A
 // persistent mirror remains locked until Close so another process cannot mutate
 // files while the importer reads them. Legacy sources own their temporary root.
 type PreparedHTTP struct {
-	sync        HTTPSync
-	targets     TargetSet
-	root        string
-	lock        *MirrorLockHandle
-	cleanupRoot bool
-	closing     bool
-	closed      bool
-	removeRoot  func(string) error
-	releaseLock func(*MirrorLockHandle) error
+	sync                      HTTPSync
+	targets                   TargetSet
+	root                      string
+	lock                      *MirrorLockHandle
+	cleanupRoot               bool
+	closing                   bool
+	closed                    bool
+	removeRoot                func(string) error
+	releaseLock               func(*MirrorLockHandle) error
+	legacy                    bool
+	mirrorImport              *preparedMirrorImport
+	replaceJournal            func(string, MirrorChangeJournal) error
+	retireJournal             func(string) error
+	replaceRemoteSkippedFiles func(string, map[string]int64) error
+	applyRemoteSkippedChanges func(string, []string, map[string]int64) error
+	commitReady               bool
+	committed                 bool
+}
+
+type preparedMirrorImport struct {
+	journalPath string
+	journal     MirrorChangeJournal
+	mergeStats  JournalMergeStats
+	fullReason  FullImportReason
+	outcome     JournalOutcome
+	reported    bool
+	pending     *PreparedDeltaImport
 }
 
 // Prepare resolves the remote targets and prepares either the persistent
@@ -246,10 +292,14 @@ func (hs HTTPSync) prepare(
 		return nil, err
 	}
 	prepared := &PreparedHTTP{
-		sync:        hs,
-		targets:     targets,
-		removeRoot:  os.RemoveAll,
-		releaseLock: func(lock *MirrorLockHandle) error { return lock.Close() },
+		sync:                      hs,
+		targets:                   targets,
+		removeRoot:                os.RemoveAll,
+		releaseLock:               func(lock *MirrorLockHandle) error { return lock.Close() },
+		replaceJournal:            replaceMirrorChangeJournal,
+		retireJournal:             retireMirrorChangeJournal,
+		replaceRemoteSkippedFiles: hs.DB.ReplaceRemoteSkippedFiles,
+		applyRemoteSkippedChanges: hs.DB.ApplyRemoteSkippedFileChanges,
 	}
 	if configure != nil {
 		configure(prepared)
@@ -269,10 +319,15 @@ func (hs HTTPSync) prepare(
 			return nil, err
 		}
 		prepared.cleanupRoot = true
+		prepared.legacy = true
 		return prepared, nil
 	}
 
-	mirrorRoot := MirrorDir(hs.DataDir, hs.Host)
+	mirrorRoot, err := filepath.Abs(MirrorDir(hs.DataDir, hs.Host))
+	if err != nil {
+		return nil, fmt.Errorf("make persistent mirror root absolute: %w", err)
+	}
+	mirrorRoot = filepath.Clean(mirrorRoot)
 	prepared.lock, err = AcquireMirrorLock(ctx, mirrorRoot)
 	if err != nil {
 		return nil, err
@@ -292,14 +347,15 @@ func (hs HTTPSync) prepare(
 			return nil, err
 		}
 		prepared.cleanupRoot = true
+		prepared.legacy = true
 		return prepared, nil
 	}
 
 	prepared.root = mirrorRoot
-	err = hs.prepareMirror(ctx, client, splitTargets{
+	prepared.mirrorImport, err = hs.prepareMirror(ctx, client, splitTargets{
 		dirScoped:  dirScoped,
 		fileScoped: fileScoped,
-	}, manifest, mirrorRoot)
+	}, manifest, mirrorRoot, prepared)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +373,67 @@ func (p *PreparedHTTP) ImportActive(ctx context.Context) (SyncStats, error) {
 	if p == nil || p.closing || p.closed {
 		return SyncStats{}, fmt.Errorf("prepared HTTP source is closed")
 	}
-	return p.sync.importRoot(ctx, p.targets, p.root)
+	if p.mirrorImport == nil {
+		if p.legacy {
+			return p.sync.importRoot(ctx, p.targets, p.root)
+		}
+		return SyncStats{}, nil
+	}
+	stats, err := p.mirrorImport.pending.Execute(ctx)
+	p.mirrorImport.outcome = stats.JournalOutcome
+	if err != nil || stats.Failed > 0 {
+		p.reportDeltaImport(stats)
+		return stats, err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		stats.JournalOutcome = JournalCancelled
+		p.mirrorImport.outcome = stats.JournalOutcome
+		p.reportDeltaImport(stats)
+		return stats, ctxErr
+	}
+	retireStart := time.Now()
+	if err := p.retireJournal(p.mirrorImport.journalPath); err != nil {
+		stats.RetirementDuration = time.Since(retireStart)
+		stats.JournalOutcome = JournalRetirementFailed
+		p.mirrorImport.outcome = stats.JournalOutcome
+		p.reportDeltaImport(stats)
+		return stats, fmt.Errorf("retire mirror change journal: %w", err)
+	}
+	stats.RetirementDuration = time.Since(retireStart)
+	stats.JournalOutcome = JournalRetired
+	p.mirrorImport.outcome = stats.JournalOutcome
+	p.reportDeltaImport(stats)
+	return stats, nil
+}
+
+func (p *PreparedHTTP) reportDeltaImport(stats SyncStats) {
+	if p.mirrorImport != nil {
+		p.mirrorImport.reported = true
+	}
+	p.sync.reportProgressDetail(fmt.Sprintf(
+		"Synced %d sessions from %s (%d unchanged, %d error-suppressed)",
+		stats.SessionsSynced, p.sync.Host, stats.Skipped, stats.ErrorSuppressed,
+	))
+	if stats.JournalOutcome != JournalRetired {
+		p.sync.reportProgressDetail(fmt.Sprintf(
+			"Pending import from %s %s", p.sync.Host, stats.JournalOutcome,
+		))
+	}
+	log.Printf(
+		"remote sync delta import: host=%s pending_paths=%d pending_new=%d pending_rearmed=%d pending_replayed=%d armed_paths=%d exact_sources=%d fallback_providers=%d fallback_sources=%d files_discovered=%d files_processed=%d prune_exact_scopes=%d prune_provider_scopes=%d prune_host_wide_scope=%t pruned_exact=%d pruned_provider=%d pruned_host_wide=%d sessions_synced=%d sessions_total=%d skipped=%d error_suppressed=%d failed=%d full_reason=%s journal_outcome=%s planning_duration=%s pruning_duration=%s processing_duration=%s cache_persist_duration=%s retirement_duration=%s",
+		p.sync.Host, stats.PendingPaths, stats.PendingNew, stats.PendingRearmed,
+		stats.PendingReplayed, stats.ArmedPaths, stats.ExactSources,
+		stats.FallbackProviders, stats.FallbackSources, stats.FilesDiscovered,
+		stats.FilesProcessed, stats.PruneExactScopes, stats.PruneProviderScopes,
+		stats.PruneHostWideScope, stats.PrunedExact, stats.PrunedProvider,
+		stats.PrunedHostWide, stats.SessionsSynced, stats.SessionsTotal,
+		stats.Skipped, stats.ErrorSuppressed, stats.Failed, stats.FullReason,
+		stats.JournalOutcome, stats.PlanningDuration.Round(time.Millisecond),
+		stats.PruningDuration.Round(time.Millisecond),
+		stats.ProcessingDuration.Round(time.Millisecond),
+		stats.CachePersistDuration.Round(time.Millisecond),
+		stats.RetirementDuration.Round(time.Millisecond),
+	)
 }
 
 // RebuildContributor converts this prepared source into an atomic rebuild
@@ -335,21 +451,90 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 	if err != nil {
 		return syncpkg.RebuildContributor{}, err
 	}
+	persistSkipCache := func(engine *syncpkg.Engine, database *db.DB) error {
+		var err error
+		if p.mirrorImport != nil {
+			err = p.mirrorImport.pending.persistSkipCache(database, engine)
+		} else {
+			err = saveEngineSkipCache(database, engine, layout.paths)
+		}
+		if err != nil {
+			return &rebuildCachePersistError{err: err}
+		}
+		return nil
+	}
 	contributor := syncpkg.RebuildContributor{
-		Name:   p.sync.Host,
-		Config: config,
+		Name:       p.sync.Host,
+		Config:     config,
+		ForceParse: p.sync.Full,
 		Progress: func(progress syncpkg.Progress) syncpkg.Progress {
 			return transformHostProgress(p.sync.Host, progress)
 		},
-		AfterSync: func(engine *syncpkg.Engine, database *db.DB) error {
-			return saveEngineSkipCache(database, engine, layout.paths)
-		},
+		AfterSync:    persistSkipCache,
+		AfterFailure: persistSkipCache,
+	}
+	if p.mirrorImport != nil {
+		contributor.ForceParse = p.mirrorImport.pending.forceParse
+		contributor.Config.InitialSkipCache = p.mirrorImport.pending.cache
 	}
 	if p.sync.Lifecycle != nil {
 		contributor.Started = p.sync.Lifecycle.RebuildStarted
-		contributor.Finished = p.sync.Lifecycle.RebuildFinished
+	}
+	contributor.Finished = func(stats syncpkg.SyncStats, err error) {
+		p.commitReady = err == nil && !stats.Aborted && stats.Failed == 0
+		if p.mirrorImport != nil {
+			pendingStats := &p.mirrorImport.pending.Stats
+			pendingStats.SessionsSynced = stats.Synced
+			pendingStats.SessionsTotal = stats.TotalSessions
+			pendingStats.Skipped = stats.Skipped
+			pendingStats.Failed = stats.Failed
+			if p.commitReady {
+				p.mirrorImport.outcome = JournalPendingSwap
+				pendingStats.JournalOutcome = JournalPendingSwap
+			} else if errors.Is(err, context.Canceled) ||
+				errors.Is(err, context.DeadlineExceeded) {
+				p.mirrorImport.outcome = JournalCancelled
+				pendingStats.JournalOutcome = JournalCancelled
+			} else {
+				var cacheErr *rebuildCachePersistError
+				if errors.As(err, &cacheErr) {
+					p.mirrorImport.outcome = JournalCachePersistFailed
+					pendingStats.JournalOutcome = JournalCachePersistFailed
+				} else if stats.Failed > 0 || stats.Aborted || err != nil {
+					p.mirrorImport.outcome = JournalProcessingFailures
+					pendingStats.JournalOutcome = JournalProcessingFailures
+				}
+			}
+		}
+		if p.sync.Lifecycle != nil && p.sync.Lifecycle.RebuildFinished != nil {
+			p.sync.Lifecycle.RebuildFinished(stats, err)
+		}
 	}
 	return contributor, nil
+}
+
+// Commit retires a processed persistent journal after an atomic rebuild swap.
+func (p *PreparedHTTP) Commit() error {
+	if p == nil || p.mirrorImport == nil || p.committed {
+		return nil
+	}
+	if !p.commitReady {
+		return fmt.Errorf("prepared HTTP journal is not ready to commit")
+	}
+	start := time.Now()
+	if err := p.retireJournal(p.mirrorImport.journalPath); err != nil {
+		p.mirrorImport.pending.Stats.RetirementDuration = time.Since(start)
+		p.mirrorImport.outcome = JournalRetirementFailed
+		p.mirrorImport.pending.Stats.JournalOutcome = JournalRetirementFailed
+		p.reportDeltaImport(p.mirrorImport.pending.Stats)
+		return fmt.Errorf("retire mirror change journal after rebuild: %w", err)
+	}
+	p.committed = true
+	p.mirrorImport.outcome = JournalRetired
+	p.mirrorImport.pending.Stats.JournalOutcome = JournalRetired
+	p.mirrorImport.pending.Stats.RetirementDuration = time.Since(start)
+	p.reportDeltaImport(p.mirrorImport.pending.Stats)
+	return nil
 }
 
 // Close releases the mirror lock and removes an owned legacy root. It is safe
@@ -357,6 +542,12 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 func (p *PreparedHTTP) Close() error {
 	if p == nil || p.closed {
 		return nil
+	}
+	if p.mirrorImport != nil && !p.mirrorImport.reported &&
+		p.mirrorImport.outcome.Valid() && p.mirrorImport.outcome != JournalRetired {
+		stats := p.mirrorImport.pending.Stats
+		stats.JournalOutcome = p.mirrorImport.outcome
+		p.reportDeltaImport(stats)
 	}
 	p.closing = true
 	var cleanupErr, lockErr error
@@ -396,6 +587,67 @@ type splitTargets struct {
 	fileScoped TargetSet
 }
 
+func mergeAgentPaths(
+	base map[parser.AgentType][]string,
+	extra map[parser.AgentType][]string,
+) map[parser.AgentType][]string {
+	merged := make(map[parser.AgentType][]string, len(base)+len(extra))
+	for agent, paths := range base {
+		merged[agent] = append([]string(nil), paths...)
+	}
+	for agent, paths := range extra {
+		for _, path := range paths {
+			if !slices.Contains(merged[agent], path) {
+				merged[agent] = append(merged[agent], path)
+			}
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func addTargetDirs(targets TargetSet, dirs map[parser.AgentType][]string) TargetSet {
+	targets.Dirs = mergeAgentPaths(targets.Dirs, dirs)
+	return targets
+}
+
+func mirrorFileScopedPaths(
+	mirrorRoot string, targets TargetSet,
+) (map[string]struct{}, error) {
+	remotePaths := make([]string, 0)
+	for _, paths := range targets.Files {
+		remotePaths = append(remotePaths, paths...)
+	}
+	remotePaths = append(remotePaths, targets.AllExtraFiles()...)
+	result := make(map[string]struct{}, len(remotePaths))
+	for _, remotePath := range remotePaths {
+		path, err := mirrorRelativeRemoteChangePath(mirrorRoot, remotePath)
+		if err != nil {
+			return nil, err
+		}
+		result[path] = struct{}{}
+	}
+	return result, nil
+}
+
+func mirrorFileScopedRoots(
+	mirrorRoot string, dirs map[parser.AgentType][]string,
+) ([]string, error) {
+	var roots []string
+	for _, remoteDirs := range dirs {
+		for _, remoteDir := range remoteDirs {
+			root, err := safeRemappedRemotePath(mirrorRoot, remoteDir)
+			if err != nil {
+				return nil, err
+			}
+			roots = append(roots, root)
+		}
+	}
+	return roots, nil
+}
+
 // prepareMirror applies the manifest delta to the persistent mirror. The
 // caller holds the mirror lock from before the manifest fetch until the
 // prepared source is closed.
@@ -405,32 +657,187 @@ func (hs HTTPSync) prepareMirror(
 	targets splitTargets,
 	manifest Manifest,
 	mirrorRoot string,
-) error {
+	prepared *PreparedHTTP,
+) (result *preparedMirrorImport, retErr error) {
+	fullReason := hs.FullReason
+	if hs.Full && fullReason == "" {
+		fullReason = FullImportExplicit
+	}
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		hs.reportProgressDetail(fmt.Sprintf(
+			"Pending import from %s %s",
+			hs.Host, JournalAbortedBeforeProcessing,
+		))
+		log.Printf(
+			"remote sync delta import: host=%s full_reason=%s journal_outcome=%s",
+			hs.Host, fullReason, JournalAbortedBeforeProcessing,
+		)
+	}()
+	journalPath := mirrorJournalPath(mirrorRoot)
+	journal, err := loadMirrorChangeJournal(journalPath)
+	if err != nil {
+		if !errors.Is(err, ErrMalformedMirrorJournal) {
+			return nil, err
+		}
+		journal = MirrorChangeJournal{
+			Version: mirrorJournalVersion, FullImport: true,
+			FullImportReason: FullImportJournalRecovery, InvalidateAll: true,
+		}
+		if replaceErr := prepared.replaceJournal(journalPath, journal); replaceErr != nil {
+			return nil, fmt.Errorf("persist mirror journal recovery marker: %w", replaceErr)
+		}
+	}
+	_, mirrorStatErr := os.Stat(mirrorRoot)
+	bootstrap := errors.Is(mirrorStatErr, os.ErrNotExist)
 	delta, err := MirrorDiff(mirrorRoot, manifest)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	hs.reportProgressDetail(fmt.Sprintf(
 		"Compared session manifest from %s: %d total, %d changed, %d deleted",
 		hs.Host, delta.Total, len(delta.Fetch), len(delta.Deletions),
 	))
+	pendingFileScopedDirs := journal.FileScopedDirs
+	fileScopedDirs := targets.fileScoped.Dirs
+	if pendingFileScopedDirs != nil {
+		fileScopedDirs = pendingFileScopedDirs
+		prepared.targets = addTargetDirs(prepared.targets, pendingFileScopedDirs)
+	}
+	fileScopedPaths, err := mirrorFileScopedPaths(mirrorRoot, targets.fileScoped)
+	if err != nil {
+		return nil, err
+	}
+	fileScopedRoots, err := mirrorFileScopedRoots(mirrorRoot, fileScopedDirs)
+	if err != nil {
+		return nil, err
+	}
+	fileScopedChange := func(relativePath string) (bool, error) {
+		if _, exact := fileScopedPaths[relativePath]; exact {
+			return true, nil
+		}
+		localPath, pathErr := safeLocalArchivePath(mirrorRoot, relativePath)
+		if pathErr != nil {
+			return false, pathErr
+		}
+		for _, root := range fileScopedRoots {
+			if within(root, localPath) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	// A disarmed journal represents a mirror snapshot that is already ready to
+	// process. Full journals cannot retain path entries, so their host-wide flag
+	// selects replay while the saved provider roots protect and classify the
+	// sanitized snapshot if the current target response changed.
+	deferFileScopedRefresh := journal.FullImport && !journal.InvalidateAll
+	if !deferFileScopedRefresh {
+		for _, entry := range journal.Entries {
+			fileScoped, classifyErr := fileScopedChange(entry.Path)
+			if classifyErr != nil {
+				return nil, classifyErr
+			}
+			if fileScoped && !entry.InvalidateCache {
+				deferFileScopedRefresh = true
+				break
+			}
+		}
+	}
+	if deferFileScopedRefresh {
+		kept := delta.Deletions[:0]
+		for _, localPath := range delta.Deletions {
+			path, normalizeErr := mirrorRelativeLocalChangePath(
+				mirrorRoot, localPath,
+			)
+			if normalizeErr != nil {
+				return nil, normalizeErr
+			}
+			fileScoped, classifyErr := fileScopedChange(path)
+			if classifyErr != nil {
+				return nil, classifyErr
+			}
+			if fileScoped {
+				continue
+			}
+			kept = append(kept, localPath)
+		}
+		delta.Deletions = kept
+	}
+	refreshFileScoped := !targets.fileScoped.IsEmpty() && !deferFileScopedRefresh
 	mutatesMirror := len(delta.Deletions) > 0 || len(delta.Fetch) > 0 ||
-		!targets.fileScoped.IsEmpty()
-	if !mutatesMirror {
-		return nil
+		refreshFileScoped
+	observed := make([]string, 0, len(delta.Fetch)+len(delta.Deletions))
+	for _, remotePath := range delta.Fetch {
+		path, normalizeErr := mirrorRelativeRemoteChangePath(mirrorRoot, remotePath)
+		if normalizeErr != nil {
+			return nil, normalizeErr
+		}
+		observed = append(observed, path)
 	}
-	if err := hs.DB.ClearRemoteSkippedFiles(hs.Host); err != nil {
-		return fmt.Errorf("clear remote skip cache before mirror mutation: %w", err)
+	for _, localPath := range delta.Deletions {
+		path, normalizeErr := mirrorRelativeLocalChangePath(mirrorRoot, localPath)
+		if normalizeErr != nil {
+			return nil, normalizeErr
+		}
+		observed = append(observed, path)
 	}
-
+	if refreshFileScoped {
+		for path := range fileScopedPaths {
+			observed = append(observed, path)
+		}
+	}
+	journal, mergeStats, err := mergeMirrorChanges(journal, observed)
+	if err != nil {
+		return nil, err
+	}
+	captureCurrentFileScopedDirs := refreshFileScoped ||
+		(deferFileScopedRefresh && pendingFileScopedDirs == nil &&
+			len(targets.fileScoped.Dirs) > 0)
+	if pendingFileScopedDirs != nil || captureCurrentFileScopedDirs {
+		fileScopedSnapshot := mergeAgentPaths(nil, pendingFileScopedDirs)
+		if captureCurrentFileScopedDirs {
+			fileScopedSnapshot = mergeAgentPaths(
+				fileScopedSnapshot, targets.fileScoped.Dirs,
+			)
+		}
+		journal, err = attachFileScopedJournalDirs(journal, fileScopedSnapshot)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if fullReason == FullImportExplicit && !journal.FullImport {
+		journal = MirrorChangeJournal{
+			Version:          mirrorJournalVersion,
+			FullImport:       true,
+			FullImportReason: FullImportExplicit,
+			InvalidateAll:    true,
+			FileScopedDirs:   journal.FileScopedDirs,
+		}
+	}
+	if journal.FullImportReason != "" {
+		fullReason = journal.FullImportReason
+	} else if fullReason == "" && bootstrap {
+		fullReason = FullImportBootstrap
+	}
+	hasPending := journal.FullImport || len(journal.Entries) > 0 ||
+		fullReason != "" || hs.Full
+	if !mutatesMirror && !hasPending {
+		return nil, nil
+	}
+	if err := prepared.replaceJournal(journalPath, journal); err != nil {
+		return nil, fmt.Errorf("persist pending mirror changes: %w", err)
+	}
 	// Deletions precede extraction so remote file/directory type changes cannot
 	// wedge the mirror. File-scoped content is absent from the manifest and is
 	// re-populated by its separate full archive below.
 	if err := ApplyMirrorDeletions(mirrorRoot, delta.Deletions); err != nil {
-		return err
+		return nil, err
 	}
 	if err := RemoveMirrorTypeConflicts(mirrorRoot, delta.Fetch); err != nil {
-		return err
+		return nil, err
 	}
 	if len(delta.Fetch) > 0 {
 		full := len(delta.Fetch)*2 >= delta.Total
@@ -444,15 +851,48 @@ func (hs HTTPSync) prepareMirror(
 			)
 		}
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	if !targets.fileScoped.IsEmpty() {
+	if refreshFileScoped {
 		if err := hs.downloadIntoMirror(
 			ctx, client, targets.fileScoped, nil, true, mirrorRoot,
 		); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	hs.reportProgressDetail(fmt.Sprintf(
+		"Planning import from %s: %d pending paths", hs.Host, len(journal.Entries),
+	))
+	pending, err := (Importer{
+		Host: hs.Host, Full: hs.Full, DB: hs.DB,
+		BlockedResultCategories: hs.BlockedResultCategories,
+		Progress:                hs.Progress, Targets: prepared.targets, Root: mirrorRoot,
+		replaceRemoteSkippedFiles: prepared.replaceRemoteSkippedFiles,
+		applyRemoteSkippedChanges: prepared.applyRemoteSkippedChanges,
+	}).PreparePending(ctx, DeltaImportRequest{Journal: journal, FullReason: fullReason})
+	if err != nil {
+		return nil, err
+	}
+	pending.Stats.PendingNew = mergeStats.New
+	pending.Stats.PendingRearmed = mergeStats.Rearmed
+	pending.Stats.PendingReplayed = mergeStats.Replayed
+	if pending.Stats.FullReason != "" {
+		hs.reportProgressDetail(fmt.Sprintf(
+			"Planned full import from %s (%s)", hs.Host, pending.Stats.FullReason,
+		))
+	} else {
+		hs.reportProgressDetail(fmt.Sprintf(
+			"Planned import from %s: %d exact sources, %d provider fallback",
+			hs.Host, pending.Stats.ExactSources, pending.Stats.FallbackProviders,
+		))
+	}
+	if err := prepared.replaceJournal(journalPath, pending.DisarmedJournal); err != nil {
+		return nil, fmt.Errorf("persist disarmed mirror changes: %w", err)
+	}
+	return &preparedMirrorImport{
+		journalPath: journalPath, journal: pending.DisarmedJournal,
+		mergeStats: mergeStats, fullReason: fullReason,
+		outcome: JournalAbortedBeforeProcessing, pending: pending,
+	}, nil
 }

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -475,6 +475,8 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 	}
 	if p.mirrorImport != nil {
 		contributor.ForceParse = p.mirrorImport.pending.forceParse
+		contributor.ForceFullParseAfterCache =
+			p.mirrorImport.pending.forceFullParse
 		contributor.Config.InitialSkipCache = p.mirrorImport.pending.cache
 	}
 	if p.sync.Lifecycle != nil {
@@ -685,6 +687,7 @@ func (hs HTTPSync) prepareMirror(
 		journal = MirrorChangeJournal{
 			Version: mirrorJournalVersion, FullImport: true,
 			FullImportReason: FullImportJournalRecovery, InvalidateAll: true,
+			ForceFullParseAll: true,
 		}
 		if replaceErr := prepared.replaceJournal(journalPath, journal); replaceErr != nil {
 			return nil, fmt.Errorf("persist mirror journal recovery marker: %w", replaceErr)
@@ -770,12 +773,14 @@ func (hs HTTPSync) prepareMirror(
 	mutatesMirror := len(delta.Deletions) > 0 || len(delta.Fetch) > 0 ||
 		refreshFileScoped
 	observed := make([]string, 0, len(delta.Fetch)+len(delta.Deletions))
+	forceFullParseObserved := make([]string, 0, len(delta.Fetch))
 	for _, remotePath := range delta.Fetch {
 		path, normalizeErr := mirrorRelativeRemoteChangePath(mirrorRoot, remotePath)
 		if normalizeErr != nil {
 			return nil, normalizeErr
 		}
 		observed = append(observed, path)
+		forceFullParseObserved = append(forceFullParseObserved, path)
 	}
 	for _, localPath := range delta.Deletions {
 		path, normalizeErr := mirrorRelativeLocalChangePath(mirrorRoot, localPath)
@@ -787,9 +792,12 @@ func (hs HTTPSync) prepareMirror(
 	if refreshFileScoped {
 		for path := range fileScopedPaths {
 			observed = append(observed, path)
+			forceFullParseObserved = append(forceFullParseObserved, path)
 		}
 	}
-	journal, mergeStats, err := mergeMirrorChanges(journal, observed)
+	journal, mergeStats, err := mergeMirrorChangesWithForce(
+		journal, observed, forceFullParseObserved,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -810,11 +818,12 @@ func (hs HTTPSync) prepareMirror(
 	}
 	if fullReason == FullImportExplicit && !journal.FullImport {
 		journal = MirrorChangeJournal{
-			Version:          mirrorJournalVersion,
-			FullImport:       true,
-			FullImportReason: FullImportExplicit,
-			InvalidateAll:    true,
-			FileScopedDirs:   journal.FileScopedDirs,
+			Version:           mirrorJournalVersion,
+			FullImport:        true,
+			FullImportReason:  FullImportExplicit,
+			InvalidateAll:     true,
+			ForceFullParseAll: true,
+			FileScopedDirs:    journal.FileScopedDirs,
 		}
 	}
 	if journal.FullImportReason != "" {

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -465,14 +465,6 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 	}
 	forceParse := p.sync.forceParseRequested()
 	forceFullParseAfterCache := p.sync.forceFullParseAfterCacheRequested()
-	if p.mirrorImport == nil && forceFullParseAfterCache {
-		config.InitialSkipCache, err = translatedImportSkipCache(
-			p.sync.DB, p.sync.Host, layout,
-		)
-		if err != nil {
-			return syncpkg.RebuildContributor{}, err
-		}
-	}
 	contributor := syncpkg.RebuildContributor{
 		Name:                     p.sync.Host,
 		Config:                   config,
@@ -884,6 +876,7 @@ func (hs HTTPSync) prepareMirror(
 	hs.reportProgressDetail(fmt.Sprintf(
 		"Planning import from %s: %d pending paths", hs.Host, len(journal.Entries),
 	))
+	dataRebuild := hs.forceFullParseAfterCacheRequested()
 	pending, err := (Importer{
 		Host: hs.Host, Full: hs.Full, DB: hs.DB,
 		BlockedResultCategories: hs.BlockedResultCategories,
@@ -893,7 +886,9 @@ func (hs HTTPSync) prepareMirror(
 	}).PreparePending(ctx, DeltaImportRequest{
 		Journal: journal, FullReason: fullReason,
 		ForceParse:               hs.forceParseRequested(),
-		ForceFullParseAfterCache: hs.forceFullParseAfterCacheRequested(),
+		ForceFullParseAfterCache: dataRebuild,
+		ResetAttemptCache:        dataRebuild && !journal.DataRebuildCacheReady,
+		MarkAttemptCacheReady:    dataRebuild,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -463,10 +463,21 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 		}
 		return nil
 	}
+	forceParse := p.sync.forceParseRequested()
+	forceFullParseAfterCache := p.sync.forceFullParseAfterCacheRequested()
+	if p.mirrorImport == nil && forceFullParseAfterCache {
+		config.InitialSkipCache, err = translatedImportSkipCache(
+			p.sync.DB, p.sync.Host, layout,
+		)
+		if err != nil {
+			return syncpkg.RebuildContributor{}, err
+		}
+	}
 	contributor := syncpkg.RebuildContributor{
-		Name:       p.sync.Host,
-		Config:     config,
-		ForceParse: p.sync.Full,
+		Name:                     p.sync.Host,
+		Config:                   config,
+		ForceParse:               forceParse,
+		ForceFullParseAfterCache: forceFullParseAfterCache,
 		Progress: func(progress syncpkg.Progress) syncpkg.Progress {
 			return transformHostProgress(p.sync.Host, progress)
 		},
@@ -879,7 +890,11 @@ func (hs HTTPSync) prepareMirror(
 		Progress:                hs.Progress, Targets: prepared.targets, Root: mirrorRoot,
 		replaceRemoteSkippedFiles: prepared.replaceRemoteSkippedFiles,
 		applyRemoteSkippedChanges: prepared.applyRemoteSkippedChanges,
-	}).PreparePending(ctx, DeltaImportRequest{Journal: journal, FullReason: fullReason})
+	}).PreparePending(ctx, DeltaImportRequest{
+		Journal: journal, FullReason: fullReason,
+		ForceParse:               hs.forceParseRequested(),
+		ForceFullParseAfterCache: hs.forceFullParseAfterCacheRequested(),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -872,17 +872,19 @@ func (hs HTTPSync) prepareMirror(
 			fullReason = FullImportBootstrap
 		}
 	}
-	if fullReason == FullImportExplicit && !journal.FullImport {
-		journal = MirrorChangeJournal{
-			Version:                 mirrorJournalVersion,
-			FullImport:              true,
-			FullImportReason:        FullImportExplicit,
-			InvalidateAll:           true,
-			ForceFullParseAll:       true,
-			RequiredDataVersion:     journal.RequiredDataVersion,
-			DataRebuildCacheVersion: journal.DataRebuildCacheVersion,
-			FileScopedDirs:          journal.FileScopedDirs,
+	if fullReason == FullImportExplicit {
+		if !journal.FullImport {
+			journal = MirrorChangeJournal{
+				Version:                 mirrorJournalVersion,
+				FullImport:              true,
+				FullImportReason:        FullImportExplicit,
+				RequiredDataVersion:     journal.RequiredDataVersion,
+				DataRebuildCacheVersion: journal.DataRebuildCacheVersion,
+				FileScopedDirs:          journal.FileScopedDirs,
+			}
 		}
+		journal.InvalidateAll = true
+		journal.ForceFullParseAll = true
 	}
 	if journal.FullImportReason != "" {
 		fullReason = journal.FullImportReason

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -463,6 +463,22 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 		}
 		return nil
 	}
+	persistSuccessfulImport := func(
+		engine *syncpkg.Engine, database *db.DB,
+	) error {
+		if err := persistSkipCache(engine, database); err != nil {
+			return err
+		}
+		if p.mirrorImport == nil {
+			return nil
+		}
+		if err := p.mirrorImport.pending.persistImportDataVersion(
+			context.Background(), database,
+		); err != nil {
+			return &rebuildCachePersistError{err: err}
+		}
+		return nil
+	}
 	forceParse := p.sync.forceParseRequested()
 	forceFullParseAfterCache := p.sync.forceFullParseAfterCacheRequested()
 	contributor := syncpkg.RebuildContributor{
@@ -473,7 +489,7 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 		Progress: func(progress syncpkg.Progress) syncpkg.Progress {
 			return transformHostProgress(p.sync.Host, progress)
 		},
-		AfterSync:    persistSkipCache,
+		AfterSync:    persistSuccessfulImport,
 		AfterFailure: persistSkipCache,
 	}
 	if p.mirrorImport != nil {
@@ -819,14 +835,38 @@ func (hs HTTPSync) prepareMirror(
 			return nil, err
 		}
 	}
+	currentDataVersion := db.CurrentDataVersion()
+	importedDataVersion, err := hs.DB.RemoteImportDataVersion(ctx, hs.Host)
+	if err != nil {
+		return nil, err
+	}
+	dataRebuildRequested := hs.forceFullParseAfterCacheRequested()
+	dataRebuildPending := importedDataVersion != currentDataVersion ||
+		dataRebuildRequested || journal.RequiredDataVersion != 0
+	if dataRebuildPending && journal.RequiredDataVersion != currentDataVersion {
+		if bootstrap && !dataRebuildRequested && !journal.FullImport {
+			journal.RequiredDataVersion = currentDataVersion
+			journal.DataRebuildCacheVersion = 0
+		} else {
+			journal = requireMirrorDataVersionImport(journal, currentDataVersion)
+		}
+	}
+	if journal.RequiredDataVersion != 0 && fullReason == "" {
+		fullReason = FullImportDataRebuild
+		if bootstrap {
+			fullReason = FullImportBootstrap
+		}
+	}
 	if fullReason == FullImportExplicit && !journal.FullImport {
 		journal = MirrorChangeJournal{
-			Version:           mirrorJournalVersion,
-			FullImport:        true,
-			FullImportReason:  FullImportExplicit,
-			InvalidateAll:     true,
-			ForceFullParseAll: true,
-			FileScopedDirs:    journal.FileScopedDirs,
+			Version:                 mirrorJournalVersion,
+			FullImport:              true,
+			FullImportReason:        FullImportExplicit,
+			InvalidateAll:           true,
+			ForceFullParseAll:       true,
+			RequiredDataVersion:     journal.RequiredDataVersion,
+			DataRebuildCacheVersion: journal.DataRebuildCacheVersion,
+			FileScopedDirs:          journal.FileScopedDirs,
 		}
 	}
 	if journal.FullImportReason != "" {
@@ -876,7 +916,11 @@ func (hs HTTPSync) prepareMirror(
 	hs.reportProgressDetail(fmt.Sprintf(
 		"Planning import from %s: %d pending paths", hs.Host, len(journal.Entries),
 	))
-	dataRebuild := hs.forceFullParseAfterCacheRequested()
+	dataRebuild := journal.RequiredDataVersion != 0
+	attemptCacheDataVersion := 0
+	if dataRebuild {
+		attemptCacheDataVersion = currentDataVersion
+	}
 	pending, err := (Importer{
 		Host: hs.Host, Full: hs.Full, DB: hs.DB,
 		BlockedResultCategories: hs.BlockedResultCategories,
@@ -887,8 +931,9 @@ func (hs HTTPSync) prepareMirror(
 		Journal: journal, FullReason: fullReason,
 		ForceParse:               hs.forceParseRequested(),
 		ForceFullParseAfterCache: dataRebuild,
-		ResetAttemptCache:        dataRebuild && !journal.DataRebuildCacheReady,
-		MarkAttemptCacheReady:    dataRebuild,
+		ResetAttemptCache: dataRebuild &&
+			journal.DataRebuildCacheVersion != currentDataVersion,
+		AttemptCacheDataVersion: attemptCacheDataVersion,
 	})
 	if err != nil {
 		return nil, err
@@ -914,4 +959,18 @@ func (hs HTTPSync) prepareMirror(
 		mergeStats: mergeStats, fullReason: fullReason,
 		outcome: JournalAbortedBeforeProcessing, pending: pending,
 	}, nil
+}
+
+func requireMirrorDataVersionImport(
+	journal MirrorChangeJournal, version int,
+) MirrorChangeJournal {
+	return MirrorChangeJournal{
+		Version:             mirrorJournalVersion,
+		FullImport:          true,
+		FullImportReason:    journal.FullImportReason,
+		InvalidateAll:       true,
+		ForceFullParseAll:   true,
+		RequiredDataVersion: version,
+		FileScopedDirs:      journal.FileScopedDirs,
+	}
 }

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -463,6 +463,21 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 		}
 		return nil
 	}
+	persistRetrySafeSkipCache := func(
+		engine *syncpkg.Engine, database *db.DB,
+	) error {
+		var err error
+		if p.mirrorImport != nil {
+			err = p.mirrorImport.pending.persistRetrySafeSkipCache(database, engine)
+		} else {
+			remoteCache := remoteRetrySafeEngineSkipCache(engine, layout.paths)
+			err = database.ReplaceRemoteSkippedFiles(layout.paths.host, remoteCache)
+		}
+		if err != nil {
+			return &rebuildCachePersistError{err: err}
+		}
+		return nil
+	}
 	persistSuccessfulImport := func(
 		engine *syncpkg.Engine, database *db.DB,
 	) error {
@@ -490,7 +505,7 @@ func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) 
 			return transformHostProgress(p.sync.Host, progress)
 		},
 		AfterSync:    persistSuccessfulImport,
-		AfterFailure: persistSkipCache,
+		AfterFailure: persistRetrySafeSkipCache,
 	}
 	if p.mirrorImport != nil {
 		contributor.ForceParse = p.mirrorImport.pending.forceParse

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -1273,8 +1273,9 @@ func TestHTTPExplicitFullCancellationRetainsScopeForOrdinarySync(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, FullImportExplicit, retried.FullReason)
 	assert.Equal(t, 1, retried.SessionsTotal)
-	assert.Equal(t, 1, retried.Skipped,
-		"ordinary replay retains full scope without restoring force-parse intent")
+	assert.Equal(t, 1, retried.SessionsSynced)
+	assert.Zero(t, retried.Skipped,
+		"a source not reached before cancellation still requires a full parse")
 	assert.NoFileExists(t, journalPath)
 }
 
@@ -1435,10 +1436,11 @@ func TestHTTPDisarmedExplicitFullReplayUsesPersistedSkip(t *testing.T) {
 
 	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
 	require.NoError(t, replaceMirrorChangeJournal(journalPath, MirrorChangeJournal{
-		Version:          mirrorJournalVersion,
-		FullImport:       true,
-		FullImportReason: FullImportExplicit,
-		InvalidateAll:    false,
+		Version:           mirrorJournalVersion,
+		FullImport:        true,
+		FullImportReason:  FullImportExplicit,
+		InvalidateAll:     false,
+		ForceFullParseAll: true,
 	}))
 
 	replayed, err := hs.Run(t.Context())
@@ -3835,6 +3837,61 @@ func TestHTTPMirrorSameMtimeGrowingRewriteFullParses(t *testing.T) {
 		"replacement with a deliberately larger body",
 		messages[0].Content,
 	)
+}
+
+func TestHTTPMirrorInterruptedGrowingRewriteRetainsFullParse(t *testing.T) {
+	for _, mode := range []string{"active import", "rebuild before contributor"} {
+		t.Run(mode, func(t *testing.T) {
+			remote := newMirrorTestRemote(t)
+			mtime := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
+			remote.writeSession(t, "interrupted-rewrite.jsonl", mtime, "old")
+			dataDir := t.TempDir()
+			database, hs := newMirrorSync(t, remote, dataDir)
+			_, err := hs.Run(t.Context())
+			require.NoError(t, err)
+
+			remote.writeSession(
+				t, "interrupted-rewrite.jsonl", mtime,
+				"replacement with a deliberately larger body",
+			)
+			prepared, err := hs.Prepare(t.Context())
+			require.NoError(t, err)
+			cancelled, cancel := context.WithCancel(t.Context())
+			cancel()
+			switch mode {
+			case "active import":
+				_, err = prepared.ImportActive(cancelled)
+			case "rebuild before contributor":
+				contributor, contributorErr := prepared.RebuildContributor()
+				require.NoError(t, contributorErr)
+				local := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+				t.Cleanup(local.Close)
+				_, err = local.ResyncAllWithOptions(
+					cancelled, nil, syncpkg.RebuildOptions{
+						Contributors: []syncpkg.RebuildContributor{contributor},
+					},
+				)
+			default:
+				t.Fatalf("unknown interruption mode %q", mode)
+			}
+			require.ErrorIs(t, err, context.Canceled)
+			require.NoError(t, prepared.Close())
+
+			retried, err := hs.Run(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, 1, retried.SessionsSynced)
+			assert.Zero(t, retried.Skipped)
+			messages, err := database.GetMessages(
+				t.Context(), "devbox~interrupted-rewrite", 0, 10, true,
+			)
+			require.NoError(t, err)
+			require.Len(t, messages, 1)
+			assert.Equal(t,
+				"replacement with a deliberately larger body",
+				messages[0].Content,
+			)
+		})
+	}
 }
 
 func tarWithoutEndMarker(t *testing.T, name, body string) []byte {

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -1087,6 +1087,38 @@ func TestHTTPMirrorJournalRetiresAfterActiveImport(t *testing.T) {
 	assert.NoFileExists(t, journalPath)
 }
 
+func TestHTTPUnchangedMirrorImportsIntoNewDatabaseGeneration(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC),
+		"generation refresh",
+	)
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	first, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, first.SessionsSynced)
+
+	replacement, err := db.Open(filepath.Join(t.TempDir(), "replacement.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, replacement.Close()) })
+	require.NoError(t, replacement.CopySyncStateFrom(database.Path()))
+	require.NoError(t, replacement.CopySessionMetadataFrom(database.Path()))
+	hs.DB = replacement
+
+	second, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportDataRebuild, second.FullReason)
+	assert.Equal(t, 1, second.SessionsSynced,
+		"an unchanged mirror must populate a replacement database")
+	messages, err := replacement.GetMessages(
+		t.Context(), "devbox~session", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "generation refresh", messages[0].Content)
+}
+
 func TestHTTPMirrorJournalFlipFailureRetainsArmedWork(t *testing.T) {
 	remote := newMirrorTestRemote(t)
 	remotePath := remote.writeSession(t, "session.jsonl",
@@ -1576,6 +1608,63 @@ func TestHTTPSyncAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.False(t, stats.Aborted)
+	assert.Zero(t, stats.Failed)
+	assert.Zero(t, stats.Skipped)
+}
+
+func TestHTTPSyncAutomaticDataRebuildRejectsOlderAttemptCache(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	rowlessPath := filepath.Join(remote.dir, "cache-project", "rowless.jsonl")
+	rowlessBody := testjsonl.ClaudeUserJSON(
+		"<command-name>/usage</command-name>\n"+
+			"<command-message>usage</command-message>\n"+
+			"<command-args></command-args>",
+		"2026-08-14T10:00:00Z",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(rowlessPath), 0o755))
+	require.NoError(t, os.WriteFile(rowlessPath, []byte(rowlessBody), 0o644))
+	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(rowlessPath, mtime, mtime))
+
+	database, hs := newMirrorSync(t, remote, t.TempDir())
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	cache, err := database.LoadRemoteSkippedFiles(hs.Host)
+	require.NoError(t, err)
+	require.NotEmpty(t, cache)
+
+	journalPath := mirrorJournalPath(MirrorDir(hs.DataDir, hs.Host))
+	require.NoError(t, replaceMirrorChangeJournal(
+		journalPath, MirrorChangeJournal{
+			Version:                 mirrorJournalVersion,
+			FullImport:              true,
+			FullImportReason:        FullImportJournalRecovery,
+			ForceFullParseAll:       true,
+			RequiredDataVersion:     db.CurrentDataVersion(),
+			DataRebuildCacheVersion: db.CurrentDataVersion() - 1,
+		},
+	))
+	seededJournal, err := loadMirrorChangeJournal(journalPath)
+	require.NoError(t, err)
+	require.False(t, seededJournal.InvalidateAll)
+	hs.Full = true
+	hs.FullReason = FullImportDataRebuild
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	contributor, err := prepared.RebuildContributor()
+	require.NoError(t, err)
+	assert.Empty(t, contributor.Config.InitialSkipCache,
+		"a parser upgrade must not trust an older rebuild attempt cache")
+
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+	t.Cleanup(engine.Close)
+	stats, err := engine.ResyncAllWithOptions(
+		t.Context(), nil, syncpkg.RebuildOptions{
+			Contributors: []syncpkg.RebuildContributor{contributor},
+		},
+	)
+	require.NoError(t, err)
 	assert.Zero(t, stats.Failed)
 	assert.Zero(t, stats.Skipped)
 }

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -1484,52 +1484,42 @@ func TestHTTPDisarmedExplicitFullReplayUsesPersistedSkip(t *testing.T) {
 	assert.NoFileExists(t, journalPath)
 }
 
-func TestHTTPSyncUnifiedRebuildPreservesAttemptCacheForReplay(t *testing.T) {
+func TestHTTPSyncFailedRebuildDoesNotCacheDiscardedParserExclusion(t *testing.T) {
 	remote := newMirrorTestRemote(t)
-	qwenPawRoot := filepath.Join(filepath.Dir(remote.dir), "qwenpaw")
-	sessionDir := filepath.Join(qwenPawRoot, "default", "sessions")
-	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
-	brokenPath := filepath.Join(sessionDir, "broken.json")
-	require.NoError(t, os.WriteFile(brokenPath, []byte("{not valid json"), 0o644))
 	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
-	require.NoError(t, os.Chtimes(brokenPath, mtime, mtime))
-	claudeProject := filepath.Join(remote.dir, "cache-project")
-	require.NoError(t, os.MkdirAll(claudeProject, 0o755))
-	rowlessPath := filepath.Join(claudeProject, "rowless.jsonl")
-	rowlessBody := testjsonl.ClaudeUserJSON(
+	stalePath := remote.writeSession(
+		t, "stale.jsonl", mtime, "session that must be retired",
+	)
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+
+	usageBody := testjsonl.ClaudeUserJSON(
 		"<command-name>/usage</command-name>\n"+
 			"<command-message>usage</command-message>\n"+
 			"<command-args></command-args>",
-		"2026-08-14T10:00:00Z",
+		"2026-08-14T10:01:00Z",
 	)
-	require.NoError(t, os.WriteFile(rowlessPath, []byte(rowlessBody), 0o644))
-	require.NoError(t, os.Chtimes(rowlessPath, mtime, mtime))
-	remote.targets = TargetSet{Dirs: map[parser.AgentType][]string{
-		parser.AgentQwenPaw: {qwenPawRoot},
-		parser.AgentClaude:  {remote.dir},
-	}}
+	require.NoError(t, os.WriteFile(stalePath, []byte(usageBody), 0o644))
+	require.NoError(t, os.Chtimes(stalePath, mtime.Add(time.Second), mtime.Add(time.Second)))
 
-	dataDir := t.TempDir()
-	database, hs := newMirrorSync(t, remote, dataDir)
+	qwenPawRoot := filepath.Join(filepath.Dir(remote.dir), "qwenpaw")
+	brokenDir := filepath.Join(qwenPawRoot, "default", "sessions")
+	require.NoError(t, os.MkdirAll(brokenDir, 0o755))
+	brokenPath := filepath.Join(brokenDir, "broken.json")
+	require.NoError(t, os.WriteFile(brokenPath, []byte("{not valid json"), 0o644))
+	require.NoError(t, os.Chtimes(brokenPath, mtime, mtime))
+	remote.targets.Dirs[parser.AgentQwenPaw] = []string{qwenPawRoot}
+
 	hs.Full = true
 	hs.FullReason = FullImportDataRebuild
-	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
-	require.NoError(t, replaceMirrorChangeJournal(journalPath, MirrorChangeJournal{
-		Version:          mirrorJournalVersion,
-		FullImport:       true,
-		FullImportReason: FullImportJournalRecovery,
-		InvalidateAll:    true,
-	}))
 	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
 	t.Cleanup(engine.Close)
-
 	first, err := hs.Prepare(t.Context())
 	require.NoError(t, err)
 	firstContributor, err := first.RebuildContributor()
 	require.NoError(t, err)
-	assert.False(t, firstContributor.ForceParse)
-	assert.True(t, firstContributor.ForceFullParseAfterCache,
-		"automatic rebuilds must fully parse sources without durable attempt state")
 	firstStats, err := engine.ResyncAllWithOptions(
 		t.Context(), nil,
 		syncpkg.RebuildOptions{Contributors: []syncpkg.RebuildContributor{
@@ -1540,13 +1530,17 @@ func TestHTTPSyncUnifiedRebuildPreservesAttemptCacheForReplay(t *testing.T) {
 	assert.True(t, firstStats.Aborted)
 	assert.Positive(t, firstStats.Failed)
 	require.NoError(t, first.Close())
-	assert.FileExists(t, journalPath)
 
-	remoteCache, err := database.LoadRemoteSkippedFiles(hs.Host)
+	failedCache, err := database.LoadRemoteSkippedFiles(hs.Host)
 	require.NoError(t, err)
-	require.NotEmpty(t, remoteCache,
-		"a failed contributor must persist new skip state before the replacement database is discarded")
+	for key := range failedCache {
+		path, _ := syncpkg.SplitProviderSkipCachePath(key)
+		assert.NotEqual(t, stalePath, path,
+			"a parser exclusion committed only to the discarded database is not retry-safe")
+	}
 
+	delete(remote.targets.Dirs, parser.AgentQwenPaw)
+	require.NoError(t, os.RemoveAll(qwenPawRoot))
 	second, err := hs.Prepare(t.Context())
 	require.NoError(t, err)
 	secondContributor, err := second.RebuildContributor()
@@ -1558,12 +1552,15 @@ func TestHTTPSyncUnifiedRebuildPreservesAttemptCacheForReplay(t *testing.T) {
 		}},
 	)
 	require.NoError(t, err)
-	assert.True(t, secondStats.Aborted)
-	assert.Positive(t, secondStats.Failed)
-	assert.Positive(t, secondStats.Skipped,
-		"an automatic rebuild retry must consume cache state from the aborted attempt")
+	assert.False(t, secondStats.Aborted)
+	assert.Zero(t, secondStats.Failed)
+	require.NoError(t, second.Commit())
 	require.NoError(t, second.Close())
-	assert.FileExists(t, journalPath)
+
+	stored, err := database.GetSessionFull(t.Context(), "devbox~stale")
+	require.NoError(t, err)
+	assert.Nil(t, stored,
+		"retry must apply the parser exclusion instead of orphan-copying the stale row")
 }
 
 func TestHTTPSyncAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T) {

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -1564,7 +1564,8 @@ func TestHTTPSyncAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, contributor.ForceParse)
 	assert.True(t, contributor.ForceFullParseAfterCache)
-	assert.NotEmpty(t, contributor.Config.InitialSkipCache)
+	assert.Empty(t, contributor.Config.InitialSkipCache,
+		"a new rebuild must not trust skip entries from routine imports")
 
 	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
 	t.Cleanup(engine.Close)
@@ -1576,8 +1577,7 @@ func TestHTTPSyncAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, stats.Aborted)
 	assert.Zero(t, stats.Failed)
-	assert.Positive(t, stats.Skipped,
-		"automatic rebuilds must honor durable source-attempt entries")
+	assert.Zero(t, stats.Skipped)
 }
 
 func TestHTTPLegacyAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T) {
@@ -1608,7 +1608,8 @@ func TestHTTPLegacyAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T)
 	require.NoError(t, err)
 	assert.False(t, contributor.ForceParse)
 	assert.True(t, contributor.ForceFullParseAfterCache)
-	assert.NotEmpty(t, contributor.Config.InitialSkipCache)
+	assert.Empty(t, contributor.Config.InitialSkipCache,
+		"legacy rebuilds have no durable attempt generation")
 
 	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
 	t.Cleanup(engine.Close)
@@ -1620,7 +1621,7 @@ func TestHTTPLegacyAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T)
 	require.NoError(t, err)
 	assert.False(t, stats.Aborted)
 	assert.Zero(t, stats.Failed)
-	assert.Positive(t, stats.Skipped)
+	assert.Zero(t, stats.Skipped)
 }
 
 func TestHTTPExplicitFullForceParsesRetainedJournalFullImport(t *testing.T) {
@@ -3924,6 +3925,45 @@ func TestHTTPMirrorSameMtimeGrowingRewriteFullParses(t *testing.T) {
 	assert.Zero(t, second.Skipped)
 	messages, err := database.GetMessages(
 		t.Context(), "devbox~growing-rewrite", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t,
+		"replacement with a deliberately larger body",
+		messages[0].Content,
+	)
+}
+
+func TestHTTPMirrorBootstrapSameMtimeGrowingRewriteFullParses(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	mtime := time.Date(2026, 7, 11, 14, 30, 0, 0, time.UTC)
+	path := remote.writeSession(t, "bootstrap-rewrite.jsonl", mtime, "old")
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+
+	first, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, first.SessionsSynced)
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	remote.writeSession(
+		t, "bootstrap-rewrite.jsonl", mtime,
+		"replacement with a deliberately larger body",
+	)
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Greater(t, after.Size(), before.Size())
+	require.Equal(t, before.ModTime(), after.ModTime())
+	require.NoError(t, os.RemoveAll(MirrorDir(dataDir, hs.Host)))
+
+	second, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportBootstrap, second.FullReason)
+	assert.Equal(t, 1, second.SessionsSynced)
+	assert.Zero(t, second.Skipped)
+	messages, err := database.GetMessages(
+		t.Context(), "devbox~bootstrap-rewrite", 0, 10, true,
 	)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	stdsync "sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,6 +38,27 @@ import (
 // runners can stall a full resync for several seconds; the timeout only
 // delays failure output when the code under test genuinely hangs.
 const backgroundWaitTimeout = 30 * time.Second
+
+type cancelAfterNextErrContext struct {
+	context.Context
+	cancel context.CancelFunc
+	armed  atomic.Bool
+}
+
+func newCancelAfterNextErrContext(parent context.Context) *cancelAfterNextErrContext {
+	ctx, cancel := context.WithCancel(parent)
+	return &cancelAfterNextErrContext{Context: ctx, cancel: cancel}
+}
+
+func (c *cancelAfterNextErrContext) arm() { c.armed.Store(true) }
+
+func (c *cancelAfterNextErrContext) Err() error {
+	if c.armed.CompareAndSwap(true, false) {
+		c.cancel()
+		return nil
+	}
+	return c.Context.Err()
+}
 
 func newCurrentProtocolServer(t *testing.T, handler http.Handler) *httptest.Server {
 	t.Helper()
@@ -210,6 +233,35 @@ func TestHTTPSyncReportsCompressedTransferThenExtraction(t *testing.T) {
 	assert.Equal(t, int64(compressed.Len()), maxBytesTotal(progress))
 }
 
+func TestHTTPSyncFullArchiveExtractsOnlyManifestFetchSet(t *testing.T) {
+	wanted := "/var/lib/agentsview-test/sessions/wanted.jsonl"
+	extra := "/var/lib/agentsview-test/sessions/appeared-after-manifest.jsonl"
+	wantedName, err := safeRemotePathArchiveName(wanted)
+	require.NoError(t, err)
+	extraName, err := safeRemotePathArchiveName(extra)
+	require.NoError(t, err)
+	archive := buildHTTPTestTar(t, map[string]string{
+		wantedName: "wanted", extraName: "not journaled",
+	})
+	ts := newCurrentProtocolServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	t.Cleanup(ts.Close)
+	mirrorRoot := filepath.Join(t.TempDir(), "mirrors", "devbox")
+
+	err = (HTTPSync{Host: "devbox", URL: ts.URL}).downloadIntoMirror(
+		t.Context(), ts.Client(), TargetSet{}, []string{wanted}, true, mirrorRoot,
+	)
+	require.NoError(t, err)
+	wantedLocal, err := safeRemappedRemotePath(mirrorRoot, wanted)
+	require.NoError(t, err)
+	extraLocal, err := safeRemappedRemotePath(mirrorRoot, extra)
+	require.NoError(t, err)
+	assert.FileExists(t, wantedLocal)
+	assert.NoFileExists(t, extraLocal,
+		"a full transfer must not mutate paths absent from the manifest delta")
+}
+
 func TestPrepareHTTPSyncReportsManifestComparisonBeforeTransfer(t *testing.T) {
 	remote := newMirrorTestRemote(t)
 	remote.writeSession(t, "a.jsonl",
@@ -230,6 +282,8 @@ func TestPrepareHTTPSyncReportsManifestComparisonBeforeTransfer(t *testing.T) {
 		"Compared session manifest from devbox: 1 total, 1 changed, 0 deleted",
 		"Downloading session archive from devbox",
 		"Extracting session archive from devbox",
+		"Planning import from devbox: 1 pending paths",
+		"Planned full import from devbox (bootstrap)",
 	}, uniqueProgressDetails(progress))
 }
 
@@ -935,6 +989,43 @@ func (r *mirrorTestRemote) addFileScopedAgent(t *testing.T) string {
 	return path
 }
 
+func (r *mirrorTestRemote) addWindsurfFileScopedAgent(t *testing.T) string {
+	t.Helper()
+	userRoot := filepath.Join(filepath.Dir(r.dir), "Windsurf", "User")
+	workspaceDir := filepath.Join(
+		userRoot, "workspaceStorage", "workspace-replay",
+	)
+	require.NoError(t, os.MkdirAll(workspaceDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workspaceDir, "workspace.json"),
+		[]byte(`{"folder":"file:///work/replay"}`), 0o600,
+	))
+	stateDB := filepath.Join(workspaceDir, parser.WindsurfStateDBName)
+	conn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	_, err = conn.Exec(`CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)`)
+	require.NoError(t, err)
+	_, err = conn.Exec(
+		`INSERT INTO ItemTable (key, value) VALUES (?, ?)`,
+		"workbench.panel.aichat.view.aichat.chatdata",
+		`{"version":1,"sessionId":"replay-session","requests":[{"requestId":"request-1","message":{"text":"Question"},"response":[{"value":"Imported reply"}],"timestamp":1710000000000}]}`,
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	resolved := ResolveTargets(config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentWindsurf: {userRoot},
+		},
+	})
+	r.targets.Dirs[parser.AgentWindsurf] = resolved.Dirs[parser.AgentWindsurf]
+	if r.targets.Files == nil {
+		r.targets.Files = make(map[parser.AgentType][]string)
+	}
+	r.targets.Files[parser.AgentWindsurf] = resolved.Files[parser.AgentWindsurf]
+	return stateDB
+}
+
 // writeSession writes a session file with one user message per text.
 // Message timestamps are deterministic, so writing the same file again
 // with the previous texts plus new ones is a byte-identical prefix
@@ -971,6 +1062,581 @@ func newMirrorSync(t *testing.T, remote *mirrorTestRemote, dataDir string) (*db.
 		DataDir: dataDir,
 		DB:      database,
 	}
+}
+
+func TestHTTPMirrorJournalRetiresAfterActiveImport(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl", time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "journal import")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	disarmed, err := loadMirrorChangeJournal(journalPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, disarmed.Entries)
+	assert.Empty(t, disarmed.FullImportReason,
+		"bootstrap is run-scoped rather than persisted journal state")
+	for _, entry := range disarmed.Entries {
+		assert.False(t, entry.InvalidateCache)
+	}
+
+	stats, err := prepared.ImportActive(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, JournalRetired, stats.JournalOutcome)
+	assert.NoFileExists(t, journalPath)
+}
+
+func TestHTTPMirrorJournalFlipFailureRetainsArmedWork(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remotePath := remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "flip retry")
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		hs.Host, map[string]int64{remotePath: 1},
+	))
+	flipErr := errors.New("journal flip sentinel")
+	writeCalls := 0
+	var details []string
+	hs.Progress = func(progress syncpkg.Progress) {
+		if progress.Detail != "" {
+			details = append(details, progress.Detail)
+		}
+	}
+
+	prepared, err := hs.prepare(t.Context(), func(prepared *PreparedHTTP) {
+		replace := prepared.replaceJournal
+		prepared.replaceJournal = func(path string, journal MirrorChangeJournal) error {
+			writeCalls++
+			if writeCalls == 2 {
+				return flipErr
+			}
+			return replace(path, journal)
+		}
+	})
+	require.ErrorIs(t, err, flipErr)
+	assert.Nil(t, prepared)
+	journal, loadErr := loadMirrorChangeJournal(
+		mirrorJournalPath(MirrorDir(dataDir, hs.Host)),
+	)
+	require.NoError(t, loadErr)
+	require.Len(t, journal.Entries, 1)
+	assert.True(t, journal.Entries[0].InvalidateCache)
+	cache, cacheErr := database.LoadRemoteSkippedFiles(hs.Host)
+	require.NoError(t, cacheErr)
+	assert.Empty(t, cache, "pruning is durable before the failed flip")
+	page, listErr := database.ListSessions(t.Context(), db.SessionFilter{Limit: 10})
+	require.NoError(t, listErr)
+	assert.Empty(t, page.Sessions)
+	assert.Contains(t, strings.Join(details, "\n"),
+		string(JournalAbortedBeforeProcessing))
+
+	stats, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, JournalRetired, stats.JournalOutcome)
+	assert.Equal(t, 1, stats.SessionsSynced)
+}
+
+func TestHTTPMirrorJournalRetirementFailureIsObservable(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "retirement")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	retireErr := errors.New("retirement sentinel")
+	prepared.retireJournal = func(string) error { return retireErr }
+
+	stats, err := prepared.ImportActive(t.Context())
+	require.ErrorIs(t, err, retireErr)
+	assert.Equal(t, JournalRetirementFailed, stats.JournalOutcome)
+	assert.FileExists(t, mirrorJournalPath(MirrorDir(dataDir, hs.Host)))
+}
+
+func TestHTTPMirrorJournalCancellationIsObservable(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "cancel")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	stats, err := prepared.ImportActive(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, JournalCancelled, stats.JournalOutcome)
+	assert.FileExists(t, mirrorJournalPath(MirrorDir(dataDir, hs.Host)))
+}
+
+func TestHTTPMirrorJournalCancellationAfterExecuteIsObservable(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "late cancel")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	ctx := newCancelAfterNextErrContext(t.Context())
+	prepared.mirrorImport.pending.save = func(
+		*db.DB, *syncpkg.Engine, remotePathMap,
+	) error {
+		ctx.arm()
+		return nil
+	}
+
+	stats, err := prepared.ImportActive(ctx)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, JournalCancelled, stats.JournalOutcome)
+	assert.Equal(t, JournalCancelled, prepared.mirrorImport.outcome)
+	assert.FileExists(t, mirrorJournalPath(MirrorDir(dataDir, hs.Host)))
+}
+
+func TestHTTPMirrorJournalAbsentNoWorkSkipsImport(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl", time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "no work")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+
+	first, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	_, err = first.ImportActive(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	second, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+	stats, err := second.ImportActive(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, stats.SessionsTotal)
+	assert.Zero(t, stats.FilesProcessed)
+	assert.NoFileExists(t, mirrorJournalPath(MirrorDir(dataDir, hs.Host)))
+}
+
+func TestHTTPExplicitFullImportsUnchangedMirror(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "explicit full")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	requests := len(remote.archiveRequests)
+
+	hs.Full = true
+	stats, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportExplicit, stats.FullReason)
+	assert.Positive(t, stats.SessionsTotal)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	assert.Zero(t, stats.Skipped,
+		"explicit full must bypass the persisted remote skip cache")
+	assert.Len(t, remote.archiveRequests, requests,
+		"explicit full widens import scope, not transfer scope")
+}
+
+func TestHTTPExplicitFullCancellationRetainsScopeForOrdinarySync(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "original")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+
+	hs.Full = true
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+	stats, err := prepared.ImportActive(cancelled)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, JournalCancelled, stats.JournalOutcome)
+	require.NoError(t, prepared.Close())
+
+	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+	journal, err := loadMirrorChangeJournal(journalPath)
+	require.NoError(t, err)
+	require.True(t, journal.FullImport)
+	assert.Equal(t, FullImportExplicit, journal.FullImportReason)
+
+	hs.Full = false
+	retried, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportExplicit, retried.FullReason)
+	assert.Equal(t, 1, retried.SessionsTotal)
+	assert.Equal(t, 1, retried.Skipped,
+		"ordinary replay retains full scope without restoring force-parse intent")
+	assert.NoFileExists(t, journalPath)
+}
+
+func TestHTTPMirrorWithRelativeDataDirImportsPendingChanges(t *testing.T) {
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "relative data dir")
+	_, hs := newMirrorSync(t, remote, "relative-data")
+
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	assert.True(t, filepath.IsAbs(prepared.Root()),
+		"persistent mirror operations must share one absolute root")
+
+	stats, err := prepared.ImportActive(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	assert.DirExists(t, filepath.Join(workingDir, "relative-data", "remote-mirrors"))
+}
+
+func TestHTTPExplicitFullReparsesEarlierRowsOfAppendedClaudeSession(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	remote.writeSession(t, "session.jsonl", base, "original")
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	_, err = raw.Exec(`
+		UPDATE messages
+		SET content = 'corrupted', content_length = length('corrupted')
+		WHERE session_id = 'devbox~session' AND ordinal = 0`)
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	remote.writeSession(
+		t, "session.jsonl", base.Add(time.Minute), "original", "appended",
+	)
+	hs.Full = true
+	stats, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportExplicit, stats.FullReason)
+
+	var content string
+	require.NoError(t, database.Reader().QueryRow(`
+		SELECT content FROM messages
+		WHERE session_id = 'devbox~session' AND ordinal = 0`,
+	).Scan(&content))
+	assert.Equal(t, "original", content,
+		"explicit full must replace earlier rows, not append onto stale data")
+}
+
+func TestHTTPExplicitFullReparsesUnchangedStreamingProvider(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	warpDir := filepath.Join(filepath.Dir(remote.dir), "warp")
+	require.NoError(t, os.MkdirAll(warpDir, 0o755))
+	warpDB, err := sql.Open("sqlite3", filepath.Join(warpDir, parser.WarpDBFilename))
+	require.NoError(t, err)
+	_, err = warpDB.Exec(`
+		CREATE TABLE agent_conversations (
+			id INTEGER PRIMARY KEY NOT NULL,
+			conversation_id TEXT NOT NULL,
+			conversation_data TEXT NOT NULL,
+			last_modified_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE ai_queries (
+			id INTEGER PRIMARY KEY NOT NULL,
+			exchange_id TEXT NOT NULL,
+			conversation_id TEXT NOT NULL,
+			start_ts DATETIME NOT NULL,
+			input TEXT NOT NULL,
+			working_directory TEXT,
+			output_status TEXT NOT NULL,
+			model_id TEXT NOT NULL DEFAULT '',
+			planning_model_id TEXT NOT NULL DEFAULT '',
+			coding_model_id TEXT NOT NULL DEFAULT ''
+		);
+		INSERT INTO agent_conversations
+			(conversation_id, conversation_data, last_modified_at)
+		VALUES ('conv-001', '{}', '2026-04-07 10:00:00');
+		INSERT INTO ai_queries
+			(exchange_id, conversation_id, start_ts, input, working_directory,
+			 output_status, model_id)
+		VALUES ('ex-001', 'conv-001', '2026-04-07 09:50:00.000000',
+			'[{"Query":{"text":"Reparse this session.","context":[]}}]',
+			'/repo/app', '"Completed"', 'auto-genius');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, warpDB.Close())
+	remote.targets = TargetSet{Dirs: map[parser.AgentType][]string{
+		parser.AgentWarp: {warpDir},
+	}}
+
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	first, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, first.SessionsSynced)
+
+	hs.Full = true
+	full, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportExplicit, full.FullReason)
+	assert.Equal(t, 1, full.SessionsSynced)
+	assert.Zero(t, full.Failed)
+}
+
+func TestHTTPFullImportFailureReturnsErrorAndRetainsJournal(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	warpDir := filepath.Join(filepath.Dir(remote.dir), "warp")
+	require.NoError(t, os.MkdirAll(warpDir, 0o755))
+	brokenPath := filepath.Join(warpDir, parser.WarpDBFilename)
+	require.NoError(t, os.WriteFile(brokenPath, []byte("not sqlite"), 0o644))
+	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(brokenPath, mtime, mtime))
+	remote.targets = TargetSet{Dirs: map[parser.AgentType][]string{
+		parser.AgentWarp: {warpDir},
+	}}
+
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	hs.Full = true
+	stats, err := hs.Run(t.Context())
+
+	require.Error(t, err)
+	assert.Positive(t, stats.Failed)
+	assert.Equal(t, JournalProcessingFailures, stats.JournalOutcome)
+	assert.FileExists(t, mirrorJournalPath(MirrorDir(dataDir, hs.Host)))
+}
+
+func TestHTTPDisarmedExplicitFullReplayUsesPersistedSkip(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	rowlessPath := filepath.Join(remote.dir, "cache-project", "rowless.jsonl")
+	rowlessBody := testjsonl.ClaudeUserJSON(
+		"<command-name>/usage</command-name>\n"+
+			"<command-message>usage</command-message>\n"+
+			"<command-args></command-args>",
+		"2026-08-14T10:00:00Z",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(rowlessPath), 0o755))
+	require.NoError(t, os.WriteFile(rowlessPath, []byte(rowlessBody), 0o644))
+	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(rowlessPath, mtime, mtime))
+
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	cache, err := database.LoadRemoteSkippedFiles(hs.Host)
+	require.NoError(t, err)
+	require.NotEmpty(t, cache)
+
+	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+	require.NoError(t, replaceMirrorChangeJournal(journalPath, MirrorChangeJournal{
+		Version:          mirrorJournalVersion,
+		FullImport:       true,
+		FullImportReason: FullImportExplicit,
+		InvalidateAll:    false,
+	}))
+
+	replayed, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportExplicit, replayed.FullReason)
+	assert.Zero(t, replayed.Failed)
+	assert.Positive(t, replayed.Skipped,
+		"ordinary replay must use the skip persisted before the retained full scope")
+	assert.NoFileExists(t, journalPath)
+}
+
+func TestHTTPSyncUnifiedRebuildPreservesAttemptCacheForReplay(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	qwenPawRoot := filepath.Join(filepath.Dir(remote.dir), "qwenpaw")
+	sessionDir := filepath.Join(qwenPawRoot, "default", "sessions")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	brokenPath := filepath.Join(sessionDir, "broken.json")
+	require.NoError(t, os.WriteFile(brokenPath, []byte("{not valid json"), 0o644))
+	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(brokenPath, mtime, mtime))
+	claudeProject := filepath.Join(remote.dir, "cache-project")
+	require.NoError(t, os.MkdirAll(claudeProject, 0o755))
+	rowlessPath := filepath.Join(claudeProject, "rowless.jsonl")
+	rowlessBody := testjsonl.ClaudeUserJSON(
+		"<command-name>/usage</command-name>\n"+
+			"<command-message>usage</command-message>\n"+
+			"<command-args></command-args>",
+		"2026-08-14T10:00:00Z",
+	)
+	require.NoError(t, os.WriteFile(rowlessPath, []byte(rowlessBody), 0o644))
+	require.NoError(t, os.Chtimes(rowlessPath, mtime, mtime))
+	remote.targets = TargetSet{Dirs: map[parser.AgentType][]string{
+		parser.AgentQwenPaw: {qwenPawRoot},
+		parser.AgentClaude:  {remote.dir},
+	}}
+
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+	require.NoError(t, replaceMirrorChangeJournal(journalPath, MirrorChangeJournal{
+		Version:          mirrorJournalVersion,
+		FullImport:       true,
+		FullImportReason: FullImportJournalRecovery,
+		InvalidateAll:    true,
+	}))
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+	t.Cleanup(engine.Close)
+
+	first, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	firstContributor, err := first.RebuildContributor()
+	require.NoError(t, err)
+	firstStats, err := engine.ResyncAllWithOptions(
+		t.Context(), nil,
+		syncpkg.RebuildOptions{Contributors: []syncpkg.RebuildContributor{
+			firstContributor,
+		}},
+	)
+	require.NoError(t, err)
+	assert.True(t, firstStats.Aborted)
+	assert.Positive(t, firstStats.Failed)
+	require.NoError(t, first.Close())
+	assert.FileExists(t, journalPath)
+
+	remoteCache, err := database.LoadRemoteSkippedFiles(hs.Host)
+	require.NoError(t, err)
+	require.NotEmpty(t, remoteCache,
+		"a failed contributor must persist new skip state before the replacement database is discarded")
+
+	second, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	secondContributor, err := second.RebuildContributor()
+	require.NoError(t, err)
+	secondStats, err := engine.ResyncAllWithOptions(
+		t.Context(), nil,
+		syncpkg.RebuildOptions{Contributors: []syncpkg.RebuildContributor{
+			secondContributor,
+		}},
+	)
+	require.NoError(t, err)
+	assert.True(t, secondStats.Aborted)
+	assert.Positive(t, secondStats.Failed)
+	assert.Positive(t, secondStats.Skipped,
+		"the retry must consume cache state produced by the aborted attempt")
+	require.NoError(t, second.Close())
+	assert.FileExists(t, journalPath)
+}
+
+func TestHTTPExplicitFullForceParsesRetainedJournalFullImport(t *testing.T) {
+	for _, journalReason := range []FullImportReason{
+		FullImportJournalOverflow,
+		FullImportJournalRecovery,
+	} {
+		t.Run(string(journalReason), func(t *testing.T) {
+			remote := newMirrorTestRemote(t)
+			remote.writeSession(t, "session.jsonl",
+				time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC),
+				"explicit full with retained journal",
+			)
+			dataDir := t.TempDir()
+			_, hs := newMirrorSync(t, remote, dataDir)
+			_, err := hs.Run(t.Context())
+			require.NoError(t, err)
+
+			journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+			require.NoError(t, replaceMirrorChangeJournal(
+				journalPath,
+				MirrorChangeJournal{
+					Version:          mirrorJournalVersion,
+					FullImport:       true,
+					FullImportReason: journalReason,
+				},
+			))
+			hs.Full = true
+			stats, err := hs.Run(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, journalReason, stats.FullReason,
+				"the retained journal reason remains observable")
+			assert.Equal(t, 1, stats.SessionsSynced,
+				"operator-requested full import must reparse an unchanged source")
+			assert.Zero(t, stats.Skipped)
+		})
+	}
+}
+
+func TestHTTPDeltaProgressSeparatesTransferPendingAndImportScope(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previousLogOutput) })
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	changed := remote.writeSession(t, "privacy-canary-session.jsonl", base, "before")
+	deleted := remote.writeSession(t, "deleted.jsonl", base, "deleted")
+	remote.writeSession(t, "unchanged.jsonl", base, "unchanged")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	remote.writeSession(t, filepath.Base(changed), base.Add(time.Second), "after")
+	require.NoError(t, os.Remove(deleted))
+	var details []string
+	hs.Progress = func(progress syncpkg.Progress) {
+		if progress.Detail != "" {
+			details = append(details, progress.Detail)
+		}
+	}
+
+	stats, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	joined := strings.Join(details, "\n")
+	assert.Contains(t, joined,
+		"Compared session manifest from devbox: 2 total, 1 changed, 1 deleted")
+	assert.Contains(t, joined, "Planning import from devbox: 2 pending paths")
+	assert.Contains(t, joined, "Planned import from devbox:")
+	assert.Contains(t, joined, "Synced 1 sessions from devbox")
+	assert.NotContains(t, joined, changed)
+	assert.NotContains(t, logs.String(), changed)
+	assert.Equal(t, 2, stats.PendingPaths)
+	assert.Equal(t, 2, stats.FilesProcessed,
+		"deletion uncertainty may expand only the owning provider")
+	assert.Equal(t, 1, stats.FallbackProviders)
+	assert.Equal(t, 2, stats.FallbackSources)
+	assert.Empty(t, stats.FullReason)
+	require.Len(t, remote.archiveRequests, 2)
+	assert.Empty(t, remote.archiveRequests[1].DeltaFiles,
+		"the 50-percent heuristic may widen transfer without widening import")
+}
+
+func TestHTTPJournalRecoveryReplacesMalformedContentBeforeImport(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl", time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "recovery")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+
+	first, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	_, err = first.ImportActive(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+	require.NoError(t, os.WriteFile(journalPath, []byte("{malformed"), 0o600))
+
+	recovered, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, recovered.Close()) })
+	journal, err := loadMirrorChangeJournal(journalPath)
+	require.NoError(t, err)
+	assert.True(t, journal.FullImport)
+	assert.Equal(t, FullImportJournalRecovery, journal.FullImportReason)
+	assert.False(t, journal.InvalidateAll)
+	stats, err := recovered.ImportActive(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportJournalRecovery, stats.FullReason)
+	assert.NoFileExists(t, journalPath)
 }
 
 func TestHTTPSyncMirrorSecondSyncTransfersOnlyDelta(t *testing.T) {
@@ -1180,6 +1846,80 @@ func TestHTTPSyncRejectsMissingManifestEndpoint(t *testing.T) {
 	assert.NoDirExists(t, MirrorDir(dataDir, "devbox"))
 }
 
+func TestHTTPLegacyExplicitFullReplacesAppendedSession(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.manifestStatus = http.StatusNotImplemented
+	base := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	remote.writeSession(t, "session.jsonl", base, "original")
+	database, hs := newMirrorSync(t, remote, t.TempDir())
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	_, err = raw.Exec(`
+		UPDATE messages
+		SET content = 'corrupted', content_length = length('corrupted')
+		WHERE session_id = 'devbox~session' AND ordinal = 0`)
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	remote.writeSession(
+		t, "session.jsonl", base.Add(time.Minute), "original", "appended",
+	)
+	hs.Full = true
+	hs.FullReason = FullImportExplicit
+	stats, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportExplicit, stats.FullReason)
+
+	var content string
+	require.NoError(t, database.Reader().QueryRow(`
+		SELECT content FROM messages
+		WHERE session_id = 'devbox~session' AND ordinal = 0`,
+	).Scan(&content))
+	assert.Equal(t, "original", content,
+		"legacy explicit full must replace earlier rows, not append to them")
+}
+
+func TestHTTPLegacyFullCancellationReturnsError(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.manifestStatus = http.StatusNotImplemented
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "cancel legacy full")
+	_, hs := newMirrorSync(t, remote, t.TempDir())
+	hs.Full = true
+	hs.FullReason = FullImportExplicit
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = prepared.ImportActive(cancelled)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestHTTPLegacyImportFailureReturnsError(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.manifestStatus = http.StatusNotImplemented
+	qwenPawRoot := filepath.Join(filepath.Dir(remote.dir), "qwenpaw-legacy")
+	sessionDir := filepath.Join(qwenPawRoot, "default", "sessions")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "broken.json"), []byte("{not valid json"), 0o644,
+	))
+	remote.targets = TargetSet{Dirs: map[parser.AgentType][]string{
+		parser.AgentQwenPaw: {qwenPawRoot},
+	}}
+	_, hs := newMirrorSync(t, remote, t.TempDir())
+
+	stats, err := hs.Run(t.Context())
+
+	require.Error(t, err)
+	assert.Positive(t, stats.Failed)
+}
+
 func TestHTTPSyncRejectsNonJSONManifest(t *testing.T) {
 	remote := newMirrorTestRemote(t)
 	remote.writeSession(t, "a.jsonl",
@@ -1361,6 +2101,191 @@ func TestHTTPSyncMirrorPartitionsFileScopedAgents(t *testing.T) {
 		"no archive requests when nothing changed and no file-scoped targets remain")
 }
 
+func TestHTTPSyncDisarmedFileScopedReplayDoesNotRearmRefresh(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	stateDB := remote.addWindsurfFileScopedAgent(t)
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+
+	first, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	require.Len(t, remote.archiveRequests, 1)
+	require.NoError(t, first.Close())
+	journal, err := loadMirrorChangeJournal(mirrorJournalPath(MirrorDir(dataDir, hs.Host)))
+	require.NoError(t, err)
+	require.NotEmpty(t, journal.Entries)
+	for _, entry := range journal.Entries {
+		assert.False(t, entry.InvalidateCache)
+	}
+
+	second, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+	assert.Len(t, remote.archiveRequests, 1,
+		"a disarmed pending file-scoped export must replay before another refresh")
+	mirroredStateDB, err := safeRemappedRemotePath(
+		MirrorDir(dataDir, hs.Host), stateDB,
+	)
+	require.NoError(t, err)
+	require.FileExists(t, mirroredStateDB,
+		"deferred refresh must retain the pending sanitized export")
+	stats, err := second.ImportActive(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	session, err := database.GetSession(
+		t.Context(), "devbox~windsurf:replay-session",
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, session,
+		"replay must import the pending sanitized export before retirement")
+}
+
+func TestHTTPSyncDisarmedFullReplayDefersFileScopedRefresh(t *testing.T) {
+	for _, reason := range []FullImportReason{
+		FullImportJournalOverflow,
+		FullImportJournalRecovery,
+	} {
+		t.Run(string(reason), func(t *testing.T) {
+			remote := newMirrorTestRemote(t)
+			stateDB := remote.addWindsurfFileScopedAgent(t)
+			dataDir := t.TempDir()
+			database, hs := newMirrorSync(t, remote, dataDir)
+			journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+			require.NoError(t, replaceMirrorChangeJournal(
+				journalPath,
+				MirrorChangeJournal{
+					Version:          mirrorJournalVersion,
+					FullImport:       true,
+					FullImportReason: reason,
+					InvalidateAll:    true,
+				},
+			))
+
+			first, err := hs.Prepare(t.Context())
+			require.NoError(t, err)
+			require.Len(t, remote.archiveRequests, 1)
+			require.NoError(t, first.Close())
+			disarmed, err := loadMirrorChangeJournal(journalPath)
+			require.NoError(t, err)
+			require.True(t, disarmed.FullImport)
+			assert.False(t, disarmed.InvalidateAll)
+
+			second, err := hs.Prepare(t.Context())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, second.Close()) })
+			assert.Len(t, remote.archiveRequests, 1,
+				"a disarmed full replay must reuse its sanitized export snapshot")
+			mirroredStateDB, err := safeRemappedRemotePath(
+				MirrorDir(dataDir, hs.Host), stateDB,
+			)
+			require.NoError(t, err)
+			require.FileExists(t, mirroredStateDB)
+			replayed, err := loadMirrorChangeJournal(journalPath)
+			require.NoError(t, err)
+			assert.False(t, replayed.InvalidateAll,
+				"file-scoped polling must not re-arm host-wide invalidation")
+
+			stats, err := second.ImportActive(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, reason, stats.FullReason)
+			assert.Equal(t, 1, stats.SessionsSynced)
+			session, err := database.GetSession(
+				t.Context(), "devbox~windsurf:replay-session",
+			)
+			require.NoError(t, err)
+			assert.NotNil(t, session)
+			assert.NoFileExists(t, journalPath)
+		})
+	}
+}
+
+func TestHTTPSyncDisarmedFullReplayKeepsRemovedFileScopedTarget(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	stateDB := remote.addWindsurfFileScopedAgent(t)
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+	require.NoError(t, replaceMirrorChangeJournal(
+		journalPath,
+		MirrorChangeJournal{
+			Version:          mirrorJournalVersion,
+			FullImport:       true,
+			FullImportReason: FullImportJournalRecovery,
+			InvalidateAll:    true,
+		},
+	))
+
+	first, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	require.Len(t, remote.archiveRequests, 1)
+	require.NoError(t, first.Close())
+	delete(remote.targets.Dirs, parser.AgentWindsurf)
+	delete(remote.targets.Files, parser.AgentWindsurf)
+
+	second, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+	assert.Len(t, remote.archiveRequests, 1,
+		"replay must not request a sanitized target that is no longer advertised")
+	mirroredStateDB, err := safeRemappedRemotePath(
+		MirrorDir(dataDir, hs.Host), stateDB,
+	)
+	require.NoError(t, err)
+	require.FileExists(t, mirroredStateDB,
+		"the prepared snapshot must survive current-target deletion handling")
+
+	stats, err := second.ImportActive(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, FullImportJournalRecovery, stats.FullReason)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	session, err := database.GetSession(
+		t.Context(), "devbox~windsurf:replay-session",
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, session,
+		"replay must retain the removed target's provider ownership")
+	assert.NoFileExists(t, journalPath)
+}
+
+func TestHTTPSyncFileScopedOwnershipOverflowFallsBackToFullImport(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.addWindsurfFileScopedAgent(t)
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	mirrorRoot := MirrorDir(dataDir, hs.Host)
+	journalPath := mirrorJournalPath(mirrorRoot)
+
+	_, fileScoped := remote.targets.SplitFileScoped()
+	observed, err := mirrorFileScopedPaths(mirrorRoot, fileScoped)
+	require.NoError(t, err)
+	observedBytes := 0
+	for path := range observed {
+		observedBytes += len(path)
+	}
+	require.Less(t, observedBytes, mirrorJournalMaxPathBytes)
+	nearLimitPath := strings.Repeat(
+		"a", mirrorJournalMaxPathBytes-observedBytes,
+	)
+	require.NoError(t, replaceMirrorChangeJournal(journalPath, MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{
+			Path: nearLimitPath,
+		}},
+	}))
+
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	journal, err := loadMirrorChangeJournal(journalPath)
+	require.NoError(t, err)
+	assert.True(t, journal.FullImport)
+	assert.Equal(t, FullImportJournalOverflow, journal.FullImportReason)
+	assert.False(t, journal.InvalidateAll,
+		"preparation must durably disarm the overflow marker before processing")
+	assert.Equal(t, fileScoped.Dirs, journal.FileScopedDirs,
+		"the overflow marker must retain ownership of the sanitized snapshot")
+}
+
 // addRooCodeAgent writes a RooCode globalStorage tree with taskCount
 // tasks plus an mcp_settings.json secret, registers the resolved
 // verbatim file-scoped targets on the remote, and returns the settings
@@ -1517,6 +2442,8 @@ func TestPrepareHTTPSyncContributorDeltaCardinality(t *testing.T) {
 			t.Cleanup(func() { require.NoError(t, prepared.Close()) })
 			contributor, err := prepared.RebuildContributor()
 			require.NoError(t, err)
+			assert.True(t, contributor.ForceParse,
+				"explicit full-import intent must reach the rebuild contributor")
 			engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
 			stats, err := engine.ResyncAllWithOptions(
 				context.Background(), nil,
@@ -1844,8 +2771,8 @@ func TestPrepareHTTPSyncClearsOnlySelectedHostCacheBeforeMirrorMutation(t *testi
 		require.FailNow(t, "timed out waiting for archive cache snapshot")
 	}
 	require.NoError(t, snapshot.err)
-	assert.Empty(t, snapshot.selected,
-		"selected cache must be clear before archive extraction starts")
+	assert.Equal(t, map[string]int64{changed: 101}, snapshot.selected,
+		"cache pruning follows durable mirror mutation")
 	assert.Equal(t, map[string]int64{"/remote/other.jsonl": 202}, snapshot.other)
 	selected, err := database.LoadRemoteSkippedFiles("devbox")
 	require.NoError(t, err)
@@ -1914,7 +2841,7 @@ func TestPrepareHTTPSyncFailureCleansOwnedResources(t *testing.T) {
 		assertMirrorUnlocked(t, MirrorDir(hs.DataDir, "devbox"))
 	})
 
-	t.Run("failed mirror extraction leaves bytes and invalidated cache", func(t *testing.T) {
+	t.Run("failed mirror extraction leaves bytes and armed cache", func(t *testing.T) {
 		remote := newMirrorTestRemote(t)
 		path := remote.writeSession(t, "a.jsonl",
 			time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
@@ -1939,7 +2866,14 @@ func TestPrepareHTTPSyncFailureCleansOwnedResources(t *testing.T) {
 		assert.Equal(t, "partial mirror", string(body))
 		selected, loadErr := database.LoadRemoteSkippedFiles("devbox")
 		require.NoError(t, loadErr)
-		assert.Empty(t, selected)
+		assert.Equal(t, map[string]int64{path: 404}, selected,
+			"processing never starts, so the armed journal owns retry invalidation")
+		journal, journalErr := loadMirrorChangeJournal(
+			mirrorJournalPath(MirrorDir(hs.DataDir, "devbox")),
+		)
+		require.NoError(t, journalErr)
+		require.Len(t, journal.Entries, 1)
+		assert.True(t, journal.Entries[0].InvalidateCache)
 		other, loadErr := database.LoadRemoteSkippedFiles("other-host")
 		require.NoError(t, loadErr)
 		assert.Equal(t, map[string]int64{"/remote/other.jsonl": 505}, other)
@@ -2752,7 +3686,7 @@ func TestCleanupRegistryRetainsFailedArchiveSpoolCleanup(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
-func TestPrepareHTTPSyncsCacheInvalidationFailureDoesNotMutateMirror(t *testing.T) {
+func TestPrepareHTTPSyncsCacheInvalidationFailureRetainsArmedJournal(t *testing.T) {
 	remote := newMirrorTestRemote(t)
 	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
 	path := remote.writeSession(t, "a.jsonl", base, "original")
@@ -2769,6 +3703,9 @@ func TestPrepareHTTPSyncsCacheInvalidationFailureDoesNotMutateMirror(t *testing.
 	require.NoError(t, err)
 	beforeInfo, err := os.Stat(local)
 	require.NoError(t, err)
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		hs.Host, map[string]int64{path: beforeInfo.ModTime().UnixNano()},
+	))
 	requestsBefore := len(remote.archiveRequests)
 	remote.writeSession(t, "a.jsonl", base.Add(time.Second),
 		"replacement with a different size")
@@ -2788,10 +3725,16 @@ func TestPrepareHTTPSyncsCacheInvalidationFailureDoesNotMutateMirror(t *testing.
 	require.NoError(t, readErr)
 	afterInfo, statErr := os.Stat(local)
 	require.NoError(t, statErr)
-	assert.Equal(t, beforeBytes, afterBytes)
-	assert.Equal(t, beforeInfo.ModTime(), afterInfo.ModTime())
-	assert.Len(t, remote.archiveRequests, requestsBefore,
-		"cache failure must stop before archive download or extraction")
+	assert.NotEqual(t, beforeBytes, afterBytes)
+	assert.NotEqual(t, beforeInfo.ModTime(), afterInfo.ModTime())
+	assert.Len(t, remote.archiveRequests, requestsBefore+1,
+		"mirror mutation precedes scoped cache-prune persistence")
+	journal, journalErr := loadMirrorChangeJournal(
+		mirrorJournalPath(MirrorDir(dataDir, hs.Host)),
+	)
+	require.NoError(t, journalErr)
+	require.Len(t, journal.Entries, 1)
+	assert.True(t, journal.Entries[0].InvalidateCache)
 	assertMirrorUnlocked(t, MirrorDir(dataDir, hs.Host))
 }
 

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -1479,6 +1479,8 @@ func TestHTTPSyncUnifiedRebuildPreservesAttemptCacheForReplay(t *testing.T) {
 
 	dataDir := t.TempDir()
 	database, hs := newMirrorSync(t, remote, dataDir)
+	hs.Full = true
+	hs.FullReason = FullImportDataRebuild
 	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
 	require.NoError(t, replaceMirrorChangeJournal(journalPath, MirrorChangeJournal{
 		Version:          mirrorJournalVersion,
@@ -1493,6 +1495,9 @@ func TestHTTPSyncUnifiedRebuildPreservesAttemptCacheForReplay(t *testing.T) {
 	require.NoError(t, err)
 	firstContributor, err := first.RebuildContributor()
 	require.NoError(t, err)
+	assert.False(t, firstContributor.ForceParse)
+	assert.True(t, firstContributor.ForceFullParseAfterCache,
+		"automatic rebuilds must fully parse sources without durable attempt state")
 	firstStats, err := engine.ResyncAllWithOptions(
 		t.Context(), nil,
 		syncpkg.RebuildOptions{Contributors: []syncpkg.RebuildContributor{
@@ -1524,9 +1529,98 @@ func TestHTTPSyncUnifiedRebuildPreservesAttemptCacheForReplay(t *testing.T) {
 	assert.True(t, secondStats.Aborted)
 	assert.Positive(t, secondStats.Failed)
 	assert.Positive(t, secondStats.Skipped,
-		"the retry must consume cache state produced by the aborted attempt")
+		"an automatic rebuild retry must consume cache state from the aborted attempt")
 	require.NoError(t, second.Close())
 	assert.FileExists(t, journalPath)
+}
+
+func TestHTTPSyncAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	rowlessPath := filepath.Join(remote.dir, "cache-project", "rowless.jsonl")
+	rowlessBody := testjsonl.ClaudeUserJSON(
+		"<command-name>/usage</command-name>\n"+
+			"<command-message>usage</command-message>\n"+
+			"<command-args></command-args>",
+		"2026-08-14T10:00:00Z",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(rowlessPath), 0o755))
+	require.NoError(t, os.WriteFile(rowlessPath, []byte(rowlessBody), 0o644))
+	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(rowlessPath, mtime, mtime))
+
+	database, hs := newMirrorSync(t, remote, t.TempDir())
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	cache, err := database.LoadRemoteSkippedFiles(hs.Host)
+	require.NoError(t, err)
+	require.NotEmpty(t, cache)
+
+	hs.Full = true
+	hs.FullReason = FullImportDataRebuild
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	contributor, err := prepared.RebuildContributor()
+	require.NoError(t, err)
+	assert.False(t, contributor.ForceParse)
+	assert.True(t, contributor.ForceFullParseAfterCache)
+	assert.NotEmpty(t, contributor.Config.InitialSkipCache)
+
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+	t.Cleanup(engine.Close)
+	stats, err := engine.ResyncAllWithOptions(
+		t.Context(), nil, syncpkg.RebuildOptions{
+			Contributors: []syncpkg.RebuildContributor{contributor},
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted)
+	assert.Zero(t, stats.Failed)
+	assert.Positive(t, stats.Skipped,
+		"automatic rebuilds must honor durable source-attempt entries")
+}
+
+func TestHTTPLegacyAutomaticDataRebuildFullParsesAfterAttemptCache(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.manifestStatus = http.StatusNotImplemented
+	rowlessPath := filepath.Join(remote.dir, "cache-project", "rowless.jsonl")
+	rowlessBody := testjsonl.ClaudeUserJSON(
+		"<command-name>/usage</command-name>\n"+
+			"<command-message>usage</command-message>\n"+
+			"<command-args></command-args>",
+		"2026-08-14T10:00:00Z",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(rowlessPath), 0o755))
+	require.NoError(t, os.WriteFile(rowlessPath, []byte(rowlessBody), 0o644))
+	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(rowlessPath, mtime, mtime))
+
+	database, hs := newMirrorSync(t, remote, t.TempDir())
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+
+	hs.Full = true
+	hs.FullReason = FullImportDataRebuild
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	contributor, err := prepared.RebuildContributor()
+	require.NoError(t, err)
+	assert.False(t, contributor.ForceParse)
+	assert.True(t, contributor.ForceFullParseAfterCache)
+	assert.NotEmpty(t, contributor.Config.InitialSkipCache)
+
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+	t.Cleanup(engine.Close)
+	stats, err := engine.ResyncAllWithOptions(
+		t.Context(), nil, syncpkg.RebuildOptions{
+			Contributors: []syncpkg.RebuildContributor{contributor},
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted)
+	assert.Zero(t, stats.Failed)
+	assert.Positive(t, stats.Skipped)
 }
 
 func TestHTTPExplicitFullForceParsesRetainedJournalFullImport(t *testing.T) {

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -1484,6 +1484,54 @@ func TestHTTPDisarmedExplicitFullReplayUsesPersistedSkip(t *testing.T) {
 	assert.NoFileExists(t, journalPath)
 }
 
+func TestHTTPExplicitFullRearmsRetainedFullJournalBeforeExecution(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	rowlessPath := filepath.Join(remote.dir, "cache-project", "rowless.jsonl")
+	rowlessBody := testjsonl.ClaudeUserJSON(
+		"<command-name>/usage</command-name>\n"+
+			"<command-message>usage</command-message>\n"+
+			"<command-args></command-args>",
+		"2026-08-14T10:00:00Z",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(rowlessPath), 0o755))
+	require.NoError(t, os.WriteFile(rowlessPath, []byte(rowlessBody), 0o644))
+	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(rowlessPath, mtime, mtime))
+
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	_, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	cache, err := database.LoadRemoteSkippedFiles(hs.Host)
+	require.NoError(t, err)
+	require.NotEmpty(t, cache)
+
+	journalPath := mirrorJournalPath(MirrorDir(dataDir, hs.Host))
+	require.NoError(t, replaceMirrorChangeJournal(journalPath, MirrorChangeJournal{
+		Version:           mirrorJournalVersion,
+		FullImport:        true,
+		FullImportReason:  FullImportJournalRecovery,
+		ForceFullParseAll: true,
+	}))
+
+	hs.Full = true
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, prepared.Close(),
+		"simulate a rebuild that stops before the remote contributor runs")
+	afterPrepare, err := database.LoadRemoteSkippedFiles(hs.Host)
+	require.NoError(t, err)
+	assert.Empty(t, afterPrepare,
+		"explicit full preparation must durably invalidate retained failure cache state")
+
+	hs.Full = false
+	replayed, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, replayed.Skipped,
+		"ordinary replay must parse sources not reached by the explicit full run")
+	assert.NoFileExists(t, journalPath)
+}
+
 func TestHTTPSyncFailedRebuildDoesNotCacheDiscardedParserExclusion(t *testing.T) {
 	remote := newMirrorTestRemote(t)
 	mtime := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -1030,9 +1030,7 @@ func (r *mirrorTestRemote) addWindsurfFileScopedAgent(t *testing.T) string {
 // Message timestamps are deterministic, so writing the same file again
 // with the previous texts plus new ones is a byte-identical prefix
 // append — the realistic mutation for JSONL session files, and one the
-// engine's incremental parse handles. (In-place rewrites that grow are
-// misread as appends for remote paths — pre-existing engine gap, out
-// of scope here.)
+// engine's incremental parse handles.
 func (r *mirrorTestRemote) writeSession(
 	t *testing.T, name string, mtime time.Time, userTexts ...string,
 ) string {
@@ -3800,6 +3798,43 @@ func TestPrepareHTTPSyncSameMtimeSizeChangeRecoversAfterAbortedRebuild(t *testin
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 	assert.Equal(t, "new", messages[0].Content)
+}
+
+func TestHTTPMirrorSameMtimeGrowingRewriteFullParses(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	mtime := time.Date(2026, 7, 11, 14, 0, 0, 0, time.UTC)
+	path := remote.writeSession(t, "growing-rewrite.jsonl", mtime, "old")
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+
+	first, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, first.SessionsSynced)
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	remote.writeSession(
+		t, "growing-rewrite.jsonl", mtime,
+		"replacement with a deliberately larger body",
+	)
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Greater(t, after.Size(), before.Size())
+	require.Equal(t, before.ModTime(), after.ModTime())
+
+	second, err := hs.Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, second.SessionsSynced)
+	assert.Zero(t, second.Skipped)
+	messages, err := database.GetMessages(
+		t.Context(), "devbox~growing-rewrite", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t,
+		"replacement with a deliberately larger body",
+		messages[0].Content,
+	)
 }
 
 func tarWithoutEndMarker(t *testing.T, name, body string) []byte {

--- a/internal/remotesync/http_transfer.go
+++ b/internal/remotesync/http_transfer.go
@@ -160,6 +160,26 @@ func (a *downloadedArchive) extract(
 	report syncpkg.ProgressFunc,
 	label string,
 ) (err error) {
+	return a.extractWithSelection(ctx, dst, nil, report, label)
+}
+
+func (a *downloadedArchive) extractSelected(
+	ctx context.Context,
+	dst string,
+	selected map[string]struct{},
+	report syncpkg.ProgressFunc,
+	label string,
+) error {
+	return a.extractWithSelection(ctx, dst, selected, report, label)
+}
+
+func (a *downloadedArchive) extractWithSelection(
+	ctx context.Context,
+	dst string,
+	selected map[string]struct{},
+	report syncpkg.ProgressFunc,
+	label string,
+) (err error) {
 	if report != nil {
 		report(syncpkg.Progress{Detail: label})
 	}
@@ -186,7 +206,7 @@ func (a *downloadedArchive) extract(
 		stream = gz
 	}
 	stream = &contextReader{ctx: ctx, r: stream}
-	if _, err := ExtractTarStream(ctx, stream, dst); err != nil {
+	if _, err := extractTarStream(ctx, stream, dst, selected); err != nil {
 		return fmt.Errorf("extract archive: %w", err)
 	}
 	return nil

--- a/internal/remotesync/import.go
+++ b/internal/remotesync/import.go
@@ -42,6 +42,10 @@ func (im Importer) ImportExtracted(
 	var engineStats syncpkg.SyncStats
 	if im.Full {
 		engineStats = engine.SyncAllForceParse(ctx, hostProgress(im.Host, im.Progress))
+	} else if im.ForceFullParseAfterCache {
+		engineStats = engine.SyncAllForceParseAfterCache(
+			ctx, hostProgress(im.Host, im.Progress),
+		)
 	} else {
 		engineStats = engine.SyncAll(ctx, hostProgress(im.Host, im.Progress))
 	}
@@ -187,15 +191,27 @@ func loadImportSkipCache(
 	engine *syncpkg.Engine,
 	layout importLayout,
 ) error {
+	translated, err := translatedImportSkipCache(database, host, layout)
+	if err != nil {
+		return err
+	}
+	engine.InjectSkipCache(translated)
+	return nil
+}
+
+func translatedImportSkipCache(
+	database *db.DB,
+	host string,
+	layout importLayout,
+) (map[string]int64, error) {
 	remoteCache, err := database.LoadRemoteSkippedFiles(host)
 	if err != nil {
-		return fmt.Errorf("load skip cache: %w", err)
+		return nil, fmt.Errorf("load skip cache: %w", err)
 	}
 	remoteCache = migrateVisualStudioCopilotRemoteSkips(database, host, remoteCache)
-	engine.InjectSkipCache(translateRemoteCacheToTemp(
+	return translateRemoteCacheToTemp(
 		remoteCache, layout.paths.remoteDirs, layout.paths.localDirs,
-	))
-	return nil
+	), nil
 }
 
 func hostProgress(host string, progress syncpkg.ProgressFunc) syncpkg.ProgressFunc {

--- a/internal/remotesync/import.go
+++ b/internal/remotesync/import.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
@@ -38,14 +39,28 @@ func (im Importer) ImportExtracted(
 		}
 	}
 
-	engineStats := engine.SyncAll(ctx, hostProgress(im.Host, im.Progress))
-	if err := saveEngineSkipCache(im.DB, engine, layout.paths); err != nil {
-		return stats, err
+	var engineStats syncpkg.SyncStats
+	if im.Full {
+		engineStats = engine.SyncAllForceParse(ctx, hostProgress(im.Host, im.Progress))
+	} else {
+		engineStats = engine.SyncAll(ctx, hostProgress(im.Host, im.Progress))
 	}
 	stats.SessionsSynced = engineStats.Synced
 	stats.SessionsTotal = engineStats.TotalSessions
 	stats.Skipped = engineStats.Skipped
 	stats.Failed = engineStats.Failed
+	if err := saveEngineSkipCache(im.DB, engine, layout.paths); err != nil {
+		return stats, err
+	}
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+	if im.RequireComplete && (engineStats.Aborted || engineStats.Failed > 0) {
+		return stats, fmt.Errorf(
+			"remote import processing incomplete: aborted=%t failed=%d",
+			engineStats.Aborted, engineStats.Failed,
+		)
+	}
 	return stats, nil
 }
 
@@ -126,6 +141,30 @@ func (p remotePathMap) pathRewriter() func(string) string {
 	}
 }
 
+func (p remotePathMap) storedPathResolver() func(string) (string, bool) {
+	return func(stored string) (string, bool) {
+		prefix := p.host + ":"
+		remotePath, ok := strings.CutPrefix(stored, prefix)
+		if !ok || remotePath == "" || hasDotDotPathComponent(
+			strings.ReplaceAll(remotePath, `\`, "/"),
+		) {
+			return "", false
+		}
+		for i, remoteDir := range p.remoteDirs {
+			rel, withinRoot := remoteArchiveRel(remoteDir, remotePath)
+			if !withinRoot {
+				continue
+			}
+			local, err := safeLocalArchivePath(p.localDirs[i], rel)
+			if err != nil {
+				return "", false
+			}
+			return local, true
+		}
+		return "", false
+	}
+}
+
 func importEngineConfig(
 	host string,
 	blockedResultCategories []string,
@@ -136,6 +175,7 @@ func importEngineConfig(
 		Machine:                 host,
 		IDPrefix:                host + "~",
 		PathRewriter:            layout.paths.pathRewriter(),
+		StoredPathResolver:      layout.paths.storedPathResolver(),
 		Ephemeral:               true,
 		BlockedResultCategories: blockedResultCategories,
 	}
@@ -206,6 +246,17 @@ func saveEngineSkipCache(
 	engine *syncpkg.Engine,
 	paths remotePathMap,
 ) error {
+	remoteCache := remoteEngineSkipCache(engine, paths)
+	if err := database.ReplaceRemoteSkippedFiles(paths.host, remoteCache); err != nil {
+		return fmt.Errorf("save skip cache: %w", err)
+	}
+	return nil
+}
+
+func remoteEngineSkipCache(
+	engine *syncpkg.Engine,
+	paths remotePathMap,
+) map[string]int64 {
 	snapshot := engine.SnapshotSkipCache()
 	remoteCache := make(map[string]int64, len(snapshot))
 	for localKey, mtime := range snapshot {
@@ -217,10 +268,20 @@ func saveEngineSkipCache(
 			remoteCache[remotePath+suffix] = mtime
 		}
 	}
-	if err := database.ReplaceRemoteSkippedFiles(paths.host, remoteCache); err != nil {
-		return fmt.Errorf("save skip cache: %w", err)
+	return remoteCache
+}
+
+func ensureVisualStudioCopilotRemoteSkipMigration(database *db.DB, host string) {
+	done, err := database.GetSyncState(visualStudioCopilotRemoteSkipMigrationKey(host))
+	if err != nil || done != "" {
+		return
 	}
-	return nil
+	remoteCache, err := database.LoadRemoteSkippedFiles(host)
+	if err != nil {
+		log.Printf("visual studio copilot remote skip migration (%s): %v", host, err)
+		return
+	}
+	migrateVisualStudioCopilotRemoteSkips(database, host, remoteCache)
 }
 
 // visualStudioCopilotRemoteSkipMigrationKey returns the per-host

--- a/internal/remotesync/import.go
+++ b/internal/remotesync/import.go
@@ -273,7 +273,20 @@ func remoteEngineSkipCache(
 	engine *syncpkg.Engine,
 	paths remotePathMap,
 ) map[string]int64 {
-	snapshot := engine.SnapshotSkipCache()
+	return remoteTempSkipCache(engine.SnapshotSkipCache(), paths)
+}
+
+func remoteRetrySafeEngineSkipCache(
+	engine *syncpkg.Engine,
+	paths remotePathMap,
+) map[string]int64 {
+	return remoteTempSkipCache(engine.SnapshotRetrySafeSkipCache(), paths)
+}
+
+func remoteTempSkipCache(
+	snapshot map[string]int64,
+	paths remotePathMap,
+) map[string]int64 {
 	remoteCache := make(map[string]int64, len(snapshot))
 	for localKey, mtime := range snapshot {
 		localPath, suffix := syncpkg.SplitProviderSkipCachePath(localKey)

--- a/internal/remotesync/import_test.go
+++ b/internal/remotesync/import_test.go
@@ -157,7 +157,8 @@ func TestPreparedHTTPSyncRebuildContributor(t *testing.T) {
 	activeStats, err := prepared.ImportActive(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 0, activeStats.Failed)
-	assert.Equal(t, 1, activeStats.Skipped)
+	assert.Equal(t, 0, activeStats.Skipped,
+		"reusing a prepared bootstrap import must preserve its full-parse scope")
 }
 
 func TestPreparedHTTPSyncRebuildOutcomeClassification(t *testing.T) {

--- a/internal/remotesync/import_test.go
+++ b/internal/remotesync/import_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -112,6 +113,14 @@ func TestPreparedHTTPSyncRebuildContributor(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.False(t, stats.Aborted)
+	journalPath := mirrorJournalPath(MirrorDir(hs.DataDir, hs.Host))
+	assert.FileExists(t, journalPath,
+		"AfterSync runs before swap and must retain the journal")
+	require.NotNil(t, prepared.mirrorImport)
+	assert.Equal(t, JournalPendingSwap, prepared.mirrorImport.outcome)
+	require.NoError(t, prepared.Commit())
+	assert.NoFileExists(t, journalPath)
+	require.NoError(t, prepared.Commit(), "post-swap commit is idempotent")
 
 	full, err := database.GetSessionFull(context.Background(), "devbox~"+sessionID)
 	require.NoError(t, err)
@@ -149,6 +158,64 @@ func TestPreparedHTTPSyncRebuildContributor(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, activeStats.Failed)
 	assert.Equal(t, 1, activeStats.Skipped)
+}
+
+func TestPreparedHTTPSyncRebuildOutcomeClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		err          error
+		cachePersist bool
+		want         JournalOutcome
+	}{
+		{name: "cancelled", err: context.Canceled, want: JournalCancelled},
+		{name: "cache persistence", cachePersist: true, want: JournalCachePersistFailed},
+		{name: "processing", err: errors.New("processing sentinel"), want: JournalProcessingFailures},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			remote := newMirrorTestRemote(t)
+			remote.writeSession(t, "session.jsonl",
+				time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "rebuild outcome")
+			database, hs := newMirrorSync(t, remote, t.TempDir())
+			prepared, err := hs.Prepare(t.Context())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+			contributor, err := prepared.RebuildContributor()
+			require.NoError(t, err)
+
+			outcomeErr := tc.err
+			if tc.cachePersist {
+				engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+				t.Cleanup(engine.Close)
+				replacement, openErr := db.Open(filepath.Join(t.TempDir(), "replacement.db"))
+				require.NoError(t, openErr)
+				require.NoError(t, replacement.Close())
+				outcomeErr = contributor.AfterSync(engine, replacement)
+				require.Error(t, outcomeErr)
+			}
+			contributor.Finished(syncpkg.SyncStats{}, outcomeErr)
+			assert.Equal(t, tc.want, prepared.mirrorImport.outcome)
+			assert.Equal(t, tc.want, prepared.mirrorImport.pending.Stats.JournalOutcome)
+		})
+	}
+}
+
+func TestPreparedHTTPSyncRebuildRetirementFailureRecordsDuration(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC), "rebuild retirement")
+	_, hs := newMirrorSync(t, remote, t.TempDir())
+	prepared, err := hs.Prepare(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	prepared.commitReady = true
+	prepared.retireJournal = func(string) error {
+		time.Sleep(time.Millisecond)
+		return errors.New("retirement sentinel")
+	}
+
+	require.ErrorContains(t, prepared.Commit(), "retirement sentinel")
+	assert.Equal(t, JournalRetirementFailed, prepared.mirrorImport.outcome)
+	assert.Positive(t, prepared.mirrorImport.pending.Stats.RetirementDuration)
 }
 
 func TestPreparedHTTPSyncImportActiveImportsPreparedRoot(t *testing.T) {
@@ -209,6 +276,46 @@ func TestImporterImportsExtractedRemoteFiles(t *testing.T) {
 	require.NotNil(t, full)
 	require.NotNil(t, full.FilePath)
 	assert.Contains(t, *full.FilePath, "devbox:/home/wes/.claude/projects/test-project/session.jsonl")
+}
+
+func TestImporterReturnsPartialStatsWhenOneSourceFails(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	extracted := t.TempDir()
+	claudeRoot := "/remote/claude"
+	claudeDir := filepath.Join(remappedRemotePath(extracted, claudeRoot), "project")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(claudeDir, "healthy.jsonl"),
+		[]byte(testjsonl.NewSessionBuilder().AddClaudeUserWithSessionID(
+			"2026-08-15T10:00:00Z", "healthy remote source", "healthy",
+		).String()),
+		0o644,
+	))
+	qwenPawRoot := "/remote/qwenpaw"
+	qwenPawDir := filepath.Join(
+		remappedRemotePath(extracted, qwenPawRoot), "default", "sessions",
+	)
+	require.NoError(t, os.MkdirAll(qwenPawDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(qwenPawDir, "broken.json"), []byte("{not valid json"), 0o644,
+	))
+
+	stats, err := Importer{Host: "devbox", DB: database}.ImportExtracted(
+		t.Context(), TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentClaude:  {claudeRoot},
+			parser.AgentQwenPaw: {qwenPawRoot},
+		}}, extracted,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	assert.Positive(t, stats.Failed)
+	session, err := database.GetSession(t.Context(), "devbox~healthy")
+	require.NoError(t, err)
+	assert.NotNil(t, session)
 }
 
 func TestImporterImportsEveryRemoteProviderTarget(t *testing.T) {

--- a/internal/remotesync/mirror_journal.go
+++ b/internal/remotesync/mirror_journal.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	mirrorJournalVersion            = 4
+	mirrorJournalVersion            = 5
 	mirrorJournalLegacyVersion      = 1
 	mirrorJournalForceIntentVersion = 2
 	mirrorJournalAttemptVersion     = 3
+	mirrorJournalCacheReadyVersion  = 4
 	mirrorJournalMaxEntries         = 8192
 	mirrorJournalMaxPathBytes       = 2 << 20
 )
@@ -60,14 +61,16 @@ type MirrorChangeEntry struct {
 }
 
 type MirrorChangeJournal struct {
-	Version               int                           `json:"version"`
-	FullImport            bool                          `json:"full_import,omitempty"`
-	FullImportReason      FullImportReason              `json:"full_import_reason,omitempty"`
-	InvalidateAll         bool                          `json:"invalidate_all,omitempty"`
-	ForceFullParseAll     bool                          `json:"force_full_parse_all,omitempty"`
-	DataRebuildCacheReady bool                          `json:"data_rebuild_cache_ready,omitempty"`
-	FileScopedDirs        map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
-	Entries               []MirrorChangeEntry           `json:"entries,omitempty"`
+	Version                     int                           `json:"version"`
+	FullImport                  bool                          `json:"full_import,omitempty"`
+	FullImportReason            FullImportReason              `json:"full_import_reason,omitempty"`
+	InvalidateAll               bool                          `json:"invalidate_all,omitempty"`
+	ForceFullParseAll           bool                          `json:"force_full_parse_all,omitempty"`
+	RequiredDataVersion         int                           `json:"required_data_version,omitempty"`
+	DataRebuildCacheVersion     int                           `json:"data_rebuild_cache_version,omitempty"`
+	LegacyDataRebuildCacheReady bool                          `json:"data_rebuild_cache_ready,omitempty"`
+	FileScopedDirs              map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
+	Entries                     []MirrorChangeEntry           `json:"entries,omitempty"`
 }
 
 type JournalMergeStats struct {
@@ -290,6 +293,7 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 		)
 	}
 	if header.Version != mirrorJournalVersion &&
+		header.Version != mirrorJournalCacheReadyVersion &&
 		header.Version != mirrorJournalAttemptVersion &&
 		header.Version != mirrorJournalForceIntentVersion &&
 		header.Version != mirrorJournalLegacyVersion {
@@ -328,6 +332,10 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 			journal.Entries[i].ForceFullParse = true
 		}
 	}
+	// Version 4's boolean did not identify the parser generation that created
+	// the attempt cache. Treat it as untrusted so the next automatic rebuild
+	// establishes a versioned cache boundary.
+	journal.LegacyDataRebuildCacheReady = false
 	journal.Version = mirrorJournalVersion
 	if err := validateMirrorChangeJournal(journal); err != nil {
 		return MirrorChangeJournal{}, fmt.Errorf(
@@ -355,6 +363,10 @@ func validateMirrorChangeJournal(journal MirrorChangeJournal) error {
 	}
 	if journal.FullImport {
 		switch journal.FullImportReason {
+		case "":
+			if journal.RequiredDataVersion == 0 {
+				return errors.New("full journal has no reason or required data version")
+			}
 		case FullImportExplicit, FullImportJournalOverflow,
 			FullImportJournalRecovery:
 		default:
@@ -368,6 +380,12 @@ func validateMirrorChangeJournal(journal MirrorChangeJournal) error {
 	} else if journal.FullImportReason != "" || journal.InvalidateAll ||
 		journal.ForceFullParseAll {
 		return errors.New("bounded journal has full-import state")
+	}
+	if journal.RequiredDataVersion < 0 || journal.DataRebuildCacheVersion < 0 {
+		return errors.New("journal data versions must not be negative")
+	}
+	if journal.DataRebuildCacheVersion != 0 && journal.RequiredDataVersion == 0 {
+		return errors.New("attempt cache version has no required data version")
 	}
 	fileScopedPathCount := 0
 	fileScopedPathBytes := 0

--- a/internal/remotesync/mirror_journal.go
+++ b/internal/remotesync/mirror_journal.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	mirrorJournalVersion       = 2
-	mirrorJournalLegacyVersion = 1
-	mirrorJournalMaxEntries    = 8192
-	mirrorJournalMaxPathBytes  = 2 << 20
+	mirrorJournalVersion            = 3
+	mirrorJournalLegacyVersion      = 1
+	mirrorJournalForceIntentVersion = 2
+	mirrorJournalMaxEntries         = 8192
+	mirrorJournalMaxPathBytes       = 2 << 20
 )
 
 func (reason FullImportReason) Valid() bool {
@@ -54,15 +55,17 @@ const (
 type MirrorChangeEntry struct {
 	Path            string `json:"path"`
 	InvalidateCache bool   `json:"invalidate_cache,omitempty"`
+	ForceFullParse  bool   `json:"force_full_parse,omitempty"`
 }
 
 type MirrorChangeJournal struct {
-	Version          int                           `json:"version"`
-	FullImport       bool                          `json:"full_import,omitempty"`
-	FullImportReason FullImportReason              `json:"full_import_reason,omitempty"`
-	InvalidateAll    bool                          `json:"invalidate_all,omitempty"`
-	FileScopedDirs   map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
-	Entries          []MirrorChangeEntry           `json:"entries,omitempty"`
+	Version           int                           `json:"version"`
+	FullImport        bool                          `json:"full_import,omitempty"`
+	FullImportReason  FullImportReason              `json:"full_import_reason,omitempty"`
+	InvalidateAll     bool                          `json:"invalidate_all,omitempty"`
+	ForceFullParseAll bool                          `json:"force_full_parse_all,omitempty"`
+	FileScopedDirs    map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
+	Entries           []MirrorChangeEntry           `json:"entries,omitempty"`
 }
 
 type JournalMergeStats struct {
@@ -122,6 +125,14 @@ func mergeMirrorChanges(
 	journal MirrorChangeJournal,
 	observedPaths []string,
 ) (MirrorChangeJournal, JournalMergeStats, error) {
+	return mergeMirrorChangesWithForce(journal, observedPaths, observedPaths)
+}
+
+func mergeMirrorChangesWithForce(
+	journal MirrorChangeJournal,
+	observedPaths []string,
+	forceFullParsePaths []string,
+) (MirrorChangeJournal, JournalMergeStats, error) {
 	if err := validateMirrorChangeJournal(journal); err != nil {
 		return MirrorChangeJournal{}, JournalMergeStats{}, err
 	}
@@ -144,10 +155,26 @@ func mergeMirrorChanges(
 		}
 		observed[path] = struct{}{}
 	}
+	forceFullParse := make(map[string]struct{}, len(forceFullParsePaths))
+	for _, value := range forceFullParsePaths {
+		path, err := normalizeMirrorJournalPath(value)
+		if err != nil {
+			return MirrorChangeJournal{}, JournalMergeStats{}, err
+		}
+		if _, ok := observed[path]; !ok {
+			return MirrorChangeJournal{}, JournalMergeStats{}, fmt.Errorf(
+				"force-full-parse path %q was not observed", value,
+			)
+		}
+		forceFullParse[path] = struct{}{}
+	}
 
 	if journal.FullImport {
 		if len(observed) > 0 {
 			journal.InvalidateAll = true
+			if len(forceFullParse) > 0 {
+				journal.ForceFullParseAll = true
+			}
 		}
 		return journal, JournalMergeStats{Rearmed: len(observed)}, nil
 	}
@@ -166,6 +193,7 @@ func mergeMirrorChanges(
 		}
 		entry.Path = path
 		entry.InvalidateCache = true
+		_, entry.ForceFullParse = forceFullParse[path]
 		entries[path] = entry
 	}
 	for _, entry := range journal.Entries {
@@ -196,10 +224,11 @@ func mergeMirrorChanges(
 
 func overflowMirrorChangeJournal() MirrorChangeJournal {
 	return MirrorChangeJournal{
-		Version:          mirrorJournalVersion,
-		FullImport:       true,
-		FullImportReason: FullImportJournalOverflow,
-		InvalidateAll:    true,
+		Version:           mirrorJournalVersion,
+		FullImport:        true,
+		FullImportReason:  FullImportJournalOverflow,
+		InvalidateAll:     true,
+		ForceFullParseAll: true,
 	}
 }
 
@@ -259,6 +288,7 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 		)
 	}
 	if header.Version != mirrorJournalVersion &&
+		header.Version != mirrorJournalForceIntentVersion &&
 		header.Version != mirrorJournalLegacyVersion {
 		return MirrorChangeJournal{}, fmt.Errorf(
 			"%w: version %d", ErrUnsupportedMirrorJournal, header.Version,
@@ -285,7 +315,16 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 				ErrMalformedMirrorJournal, path,
 			)
 		}
+	}
+	if journal.Version == mirrorJournalLegacyVersion ||
+		journal.Version == mirrorJournalForceIntentVersion {
 		journal.Version = mirrorJournalVersion
+		if journal.FullImport {
+			journal.ForceFullParseAll = true
+		}
+		for i := range journal.Entries {
+			journal.Entries[i].ForceFullParse = true
+		}
 	}
 	if err := validateMirrorChangeJournal(journal); err != nil {
 		return MirrorChangeJournal{}, fmt.Errorf(
@@ -323,7 +362,8 @@ func validateMirrorChangeJournal(journal MirrorChangeJournal) error {
 		if len(journal.Entries) != 0 {
 			return errors.New("full journal must not contain path entries")
 		}
-	} else if journal.FullImportReason != "" || journal.InvalidateAll {
+	} else if journal.FullImportReason != "" || journal.InvalidateAll ||
+		journal.ForceFullParseAll {
 		return errors.New("bounded journal has full-import state")
 	}
 	fileScopedPathCount := 0

--- a/internal/remotesync/mirror_journal.go
+++ b/internal/remotesync/mirror_journal.go
@@ -17,13 +17,9 @@ import (
 )
 
 const (
-	mirrorJournalVersion            = 5
-	mirrorJournalLegacyVersion      = 1
-	mirrorJournalForceIntentVersion = 2
-	mirrorJournalAttemptVersion     = 3
-	mirrorJournalCacheReadyVersion  = 4
-	mirrorJournalMaxEntries         = 8192
-	mirrorJournalMaxPathBytes       = 2 << 20
+	mirrorJournalVersion      = 1
+	mirrorJournalMaxEntries   = 8192
+	mirrorJournalMaxPathBytes = 2 << 20
 )
 
 func (reason FullImportReason) Valid() bool {
@@ -61,16 +57,15 @@ type MirrorChangeEntry struct {
 }
 
 type MirrorChangeJournal struct {
-	Version                     int                           `json:"version"`
-	FullImport                  bool                          `json:"full_import,omitempty"`
-	FullImportReason            FullImportReason              `json:"full_import_reason,omitempty"`
-	InvalidateAll               bool                          `json:"invalidate_all,omitempty"`
-	ForceFullParseAll           bool                          `json:"force_full_parse_all,omitempty"`
-	RequiredDataVersion         int                           `json:"required_data_version,omitempty"`
-	DataRebuildCacheVersion     int                           `json:"data_rebuild_cache_version,omitempty"`
-	LegacyDataRebuildCacheReady bool                          `json:"data_rebuild_cache_ready,omitempty"`
-	FileScopedDirs              map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
-	Entries                     []MirrorChangeEntry           `json:"entries,omitempty"`
+	Version                 int                           `json:"version"`
+	FullImport              bool                          `json:"full_import,omitempty"`
+	FullImportReason        FullImportReason              `json:"full_import_reason,omitempty"`
+	InvalidateAll           bool                          `json:"invalidate_all,omitempty"`
+	ForceFullParseAll       bool                          `json:"force_full_parse_all,omitempty"`
+	RequiredDataVersion     int                           `json:"required_data_version,omitempty"`
+	DataRebuildCacheVersion int                           `json:"data_rebuild_cache_version,omitempty"`
+	FileScopedDirs          map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
+	Entries                 []MirrorChangeEntry           `json:"entries,omitempty"`
 }
 
 type JournalMergeStats struct {
@@ -292,11 +287,7 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 			"%w: decode %q: %v", ErrMalformedMirrorJournal, path, err,
 		)
 	}
-	if header.Version != mirrorJournalVersion &&
-		header.Version != mirrorJournalCacheReadyVersion &&
-		header.Version != mirrorJournalAttemptVersion &&
-		header.Version != mirrorJournalForceIntentVersion &&
-		header.Version != mirrorJournalLegacyVersion {
+	if header.Version != mirrorJournalVersion {
 		return MirrorChangeJournal{}, fmt.Errorf(
 			"%w: version %d", ErrUnsupportedMirrorJournal, header.Version,
 		)
@@ -315,28 +306,6 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 			"%w: decode %q: %v", ErrMalformedMirrorJournal, path, err,
 		)
 	}
-	if journal.Version == mirrorJournalLegacyVersion {
-		if journal.FileScopedDirs != nil {
-			return MirrorChangeJournal{}, fmt.Errorf(
-				"%w: validate %q: legacy journal has file-scoped ownership",
-				ErrMalformedMirrorJournal, path,
-			)
-		}
-	}
-	if journal.Version == mirrorJournalLegacyVersion ||
-		journal.Version == mirrorJournalForceIntentVersion {
-		if journal.FullImport {
-			journal.ForceFullParseAll = true
-		}
-		for i := range journal.Entries {
-			journal.Entries[i].ForceFullParse = true
-		}
-	}
-	// Version 4's boolean did not identify the parser generation that created
-	// the attempt cache. Treat it as untrusted so the next automatic rebuild
-	// establishes a versioned cache boundary.
-	journal.LegacyDataRebuildCacheReady = false
-	journal.Version = mirrorJournalVersion
 	if err := validateMirrorChangeJournal(journal); err != nil {
 		return MirrorChangeJournal{}, fmt.Errorf(
 			"%w: validate %q: %v", ErrMalformedMirrorJournal, path, err,

--- a/internal/remotesync/mirror_journal.go
+++ b/internal/remotesync/mirror_journal.go
@@ -1,0 +1,504 @@
+package remotesync
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+const (
+	mirrorJournalVersion       = 2
+	mirrorJournalLegacyVersion = 1
+	mirrorJournalMaxEntries    = 8192
+	mirrorJournalMaxPathBytes  = 2 << 20
+)
+
+func (reason FullImportReason) Valid() bool {
+	switch reason {
+	case FullImportLegacy, FullImportBootstrap, FullImportExplicit,
+		FullImportDataRebuild, FullImportJournalOverflow,
+		FullImportJournalRecovery:
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	ErrUnsupportedMirrorJournal = errors.New("unsupported mirror journal")
+	ErrUnreadableMirrorJournal  = errors.New("unreadable mirror journal")
+	ErrMalformedMirrorJournal   = errors.New("malformed mirror journal")
+)
+
+type FullImportReason string
+
+const (
+	FullImportLegacy          FullImportReason = "legacy"
+	FullImportBootstrap       FullImportReason = "bootstrap"
+	FullImportExplicit        FullImportReason = "explicit-full"
+	FullImportDataRebuild     FullImportReason = "data-rebuild"
+	FullImportJournalOverflow FullImportReason = "journal-overflow"
+	FullImportJournalRecovery FullImportReason = "journal-recovery"
+)
+
+type MirrorChangeEntry struct {
+	Path            string `json:"path"`
+	InvalidateCache bool   `json:"invalidate_cache,omitempty"`
+}
+
+type MirrorChangeJournal struct {
+	Version          int                           `json:"version"`
+	FullImport       bool                          `json:"full_import,omitempty"`
+	FullImportReason FullImportReason              `json:"full_import_reason,omitempty"`
+	InvalidateAll    bool                          `json:"invalidate_all,omitempty"`
+	FileScopedDirs   map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
+	Entries          []MirrorChangeEntry           `json:"entries,omitempty"`
+}
+
+type JournalMergeStats struct {
+	New      int
+	Rearmed  int
+	Replayed int
+}
+
+func mirrorJournalPath(mirrorRoot string) string {
+	return filepath.Clean(mirrorRoot) + ".changes.json"
+}
+
+func mirrorRelativeRemoteChangePath(
+	mirrorRoot, remotePath string,
+) (string, error) {
+	localPath, err := safeRemappedRemotePath(mirrorRoot, remotePath)
+	if err != nil {
+		return "", fmt.Errorf("normalize remote mirror change: %w", err)
+	}
+	return mirrorRelativeLocalChangePath(mirrorRoot, localPath)
+}
+
+func mirrorRelativeLocalChangePath(
+	mirrorRoot, localPath string,
+) (string, error) {
+	root := filepath.Clean(mirrorRoot)
+	local := filepath.Clean(localPath)
+	if local == root || !within(root, local) {
+		return "", fmt.Errorf(
+			"mirror change %q escapes mirror root %q", localPath, mirrorRoot,
+		)
+	}
+	rel, err := filepath.Rel(root, local)
+	if err != nil {
+		return "", fmt.Errorf("make mirror change relative: %w", err)
+	}
+	return normalizeMirrorJournalPath(filepath.ToSlash(rel))
+}
+
+func normalizeMirrorJournalPath(value string) (string, error) {
+	if value == "" || strings.IndexByte(value, 0) >= 0 {
+		return "", errors.New("mirror journal path is empty or contains NUL")
+	}
+	raw := strings.ReplaceAll(value, `\`, "/")
+	if pathpkg.IsAbs(raw) || hasDotDotPathComponent(raw) {
+		return "", fmt.Errorf("unsafe mirror journal path %q", value)
+	}
+	clean := pathpkg.Clean(raw)
+	if clean == "." || clean == "" || clean == ".." ||
+		strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("unsafe mirror journal path %q", value)
+	}
+	return clean, nil
+}
+
+func mergeMirrorChanges(
+	journal MirrorChangeJournal,
+	observedPaths []string,
+) (MirrorChangeJournal, JournalMergeStats, error) {
+	if err := validateMirrorChangeJournal(journal); err != nil {
+		return MirrorChangeJournal{}, JournalMergeStats{}, err
+	}
+	fileScopedPathCount := 0
+	fileScopedPathBytes := 0
+	if journal.FileScopedDirs != nil {
+		var err error
+		fileScopedPathCount, fileScopedPathBytes, err =
+			validateFileScopedJournalDirs(journal.FileScopedDirs)
+		if err != nil {
+			return MirrorChangeJournal{}, JournalMergeStats{}, err
+		}
+	}
+
+	observed := make(map[string]struct{}, len(observedPaths))
+	for _, value := range observedPaths {
+		path, err := normalizeMirrorJournalPath(value)
+		if err != nil {
+			return MirrorChangeJournal{}, JournalMergeStats{}, err
+		}
+		observed[path] = struct{}{}
+	}
+
+	if journal.FullImport {
+		if len(observed) > 0 {
+			journal.InvalidateAll = true
+		}
+		return journal, JournalMergeStats{Rearmed: len(observed)}, nil
+	}
+
+	entries := make(map[string]MirrorChangeEntry, len(journal.Entries)+len(observed))
+	for _, entry := range journal.Entries {
+		entries[entry.Path] = entry
+	}
+	stats := JournalMergeStats{}
+	for path := range observed {
+		entry, exists := entries[path]
+		if exists {
+			stats.Rearmed++
+		} else {
+			stats.New++
+		}
+		entry.Path = path
+		entry.InvalidateCache = true
+		entries[path] = entry
+	}
+	for _, entry := range journal.Entries {
+		if _, exists := observed[entry.Path]; !exists {
+			stats.Replayed++
+		}
+	}
+
+	paths := make([]string, 0, len(entries))
+	pathBytes := 0
+	for path := range entries {
+		paths = append(paths, path)
+		pathBytes += len(path)
+	}
+	if len(paths)+fileScopedPathCount > mirrorJournalMaxEntries ||
+		pathBytes+fileScopedPathBytes > mirrorJournalMaxPathBytes {
+		overflow := overflowMirrorChangeJournal()
+		overflow.FileScopedDirs = journal.FileScopedDirs
+		return overflow, stats, nil
+	}
+	sort.Strings(paths)
+	journal.Entries = make([]MirrorChangeEntry, 0, len(paths))
+	for _, path := range paths {
+		journal.Entries = append(journal.Entries, entries[path])
+	}
+	return journal, stats, nil
+}
+
+func overflowMirrorChangeJournal() MirrorChangeJournal {
+	return MirrorChangeJournal{
+		Version:          mirrorJournalVersion,
+		FullImport:       true,
+		FullImportReason: FullImportJournalOverflow,
+		InvalidateAll:    true,
+	}
+}
+
+func attachFileScopedJournalDirs(
+	journal MirrorChangeJournal,
+	dirs map[parser.AgentType][]string,
+) (MirrorChangeJournal, error) {
+	pathCount, pathBytes, err := validateFileScopedJournalDirs(dirs)
+	if err != nil {
+		return MirrorChangeJournal{}, err
+	}
+	if pathCount > mirrorJournalMaxEntries || pathBytes > mirrorJournalMaxPathBytes {
+		return MirrorChangeJournal{}, errors.New(
+			"file-scoped journal ownership exceeds path limits",
+		)
+	}
+	for _, entry := range journal.Entries {
+		pathCount++
+		pathBytes += len(entry.Path)
+	}
+	if pathCount > mirrorJournalMaxEntries || pathBytes > mirrorJournalMaxPathBytes {
+		overflow := overflowMirrorChangeJournal()
+		overflow.FileScopedDirs = dirs
+		return overflow, nil
+	}
+	journal.FileScopedDirs = dirs
+	return journal, nil
+}
+
+func disarmMirrorChanges(journal MirrorChangeJournal) MirrorChangeJournal {
+	disarmed := journal
+	disarmed.InvalidateAll = false
+	disarmed.Entries = append([]MirrorChangeEntry(nil), journal.Entries...)
+	for i := range disarmed.Entries {
+		disarmed.Entries[i].InvalidateCache = false
+	}
+	return disarmed
+}
+
+func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return MirrorChangeJournal{Version: mirrorJournalVersion}, nil
+	}
+	if err != nil {
+		return MirrorChangeJournal{}, fmt.Errorf(
+			"%w: read %q: %v", ErrUnreadableMirrorJournal, path, err,
+		)
+	}
+
+	var header struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return MirrorChangeJournal{}, fmt.Errorf(
+			"%w: decode %q: %v", ErrMalformedMirrorJournal, path, err,
+		)
+	}
+	if header.Version != mirrorJournalVersion &&
+		header.Version != mirrorJournalLegacyVersion {
+		return MirrorChangeJournal{}, fmt.Errorf(
+			"%w: version %d", ErrUnsupportedMirrorJournal, header.Version,
+		)
+	}
+
+	var journal MirrorChangeJournal
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&journal); err != nil {
+		return MirrorChangeJournal{}, fmt.Errorf(
+			"%w: decode %q: %v", ErrMalformedMirrorJournal, path, err,
+		)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return MirrorChangeJournal{}, fmt.Errorf(
+			"%w: decode %q: %v", ErrMalformedMirrorJournal, path, err,
+		)
+	}
+	if journal.Version == mirrorJournalLegacyVersion {
+		if journal.FileScopedDirs != nil {
+			return MirrorChangeJournal{}, fmt.Errorf(
+				"%w: validate %q: legacy journal has file-scoped ownership",
+				ErrMalformedMirrorJournal, path,
+			)
+		}
+		journal.Version = mirrorJournalVersion
+	}
+	if err := validateMirrorChangeJournal(journal); err != nil {
+		return MirrorChangeJournal{}, fmt.Errorf(
+			"%w: validate %q: %v", ErrMalformedMirrorJournal, path, err,
+		)
+	}
+	return journal, nil
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	err := decoder.Decode(&trailing)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("unexpected trailing JSON value")
+	}
+	return err
+}
+
+func validateMirrorChangeJournal(journal MirrorChangeJournal) error {
+	if journal.Version != mirrorJournalVersion {
+		return fmt.Errorf("unsupported version %d", journal.Version)
+	}
+	if journal.FullImport {
+		switch journal.FullImportReason {
+		case FullImportExplicit, FullImportJournalOverflow,
+			FullImportJournalRecovery:
+		default:
+			return fmt.Errorf(
+				"full journal has invalid reason %q", journal.FullImportReason,
+			)
+		}
+		if len(journal.Entries) != 0 {
+			return errors.New("full journal must not contain path entries")
+		}
+	} else if journal.FullImportReason != "" || journal.InvalidateAll {
+		return errors.New("bounded journal has full-import state")
+	}
+	fileScopedPathCount := 0
+	fileScopedPathBytes := 0
+	if journal.FileScopedDirs != nil {
+		var err error
+		fileScopedPathCount, fileScopedPathBytes, err =
+			validateFileScopedJournalDirs(journal.FileScopedDirs)
+		if err != nil {
+			return err
+		}
+	}
+
+	pathBytes := fileScopedPathBytes
+	previous := ""
+	for i, entry := range journal.Entries {
+		normalized, err := normalizeMirrorJournalPath(entry.Path)
+		if err != nil || normalized != entry.Path {
+			return fmt.Errorf("invalid entry path %q", entry.Path)
+		}
+		if i > 0 && entry.Path <= previous {
+			return errors.New("journal entries are not sorted and unique")
+		}
+		previous = entry.Path
+		pathBytes += len(entry.Path)
+	}
+	if len(journal.Entries)+fileScopedPathCount > mirrorJournalMaxEntries ||
+		pathBytes > mirrorJournalMaxPathBytes {
+		return errors.New("bounded journal exceeds path limits")
+	}
+	return nil
+}
+
+func validateFileScopedJournalDirs(
+	dirs map[parser.AgentType][]string,
+) (int, int, error) {
+	if len(dirs) == 0 {
+		return 0, 0, errors.New("file-scoped journal ownership is empty")
+	}
+	pathCount := 0
+	pathBytes := 0
+	for agent, roots := range dirs {
+		if _, known := parser.AgentByType(agent); !known ||
+			verbatimFileScopedAgent(agent) ||
+			parser.RemoteSyncExcludedAgent(agent) ||
+			len(roots) == 0 {
+			return 0, 0, fmt.Errorf(
+				"journal agent %s is not sanitized file-scoped", agent,
+			)
+		}
+		for _, root := range roots {
+			name, err := safeRemotePathArchiveName(root)
+			if err != nil {
+				return 0, 0, fmt.Errorf(
+					"invalid file-scoped journal directory %s %q: %w",
+					agent, root, err,
+				)
+			}
+			if name == "" {
+				return 0, 0, fmt.Errorf(
+					"file-scoped journal directory %s is empty", agent,
+				)
+			}
+			pathCount++
+			pathBytes += len(root)
+		}
+	}
+	if pathCount > mirrorJournalMaxEntries || pathBytes > mirrorJournalMaxPathBytes {
+		return 0, 0, errors.New("file-scoped journal ownership exceeds path limits")
+	}
+	return pathCount, pathBytes, nil
+}
+
+type mirrorJournalStore struct {
+	createTemp func(string, string) (*os.File, error)
+	rename     func(string, string) error
+	remove     func(string) error
+	open       func(string) (*os.File, error)
+}
+
+func newMirrorJournalStore() mirrorJournalStore {
+	return mirrorJournalStore{
+		createTemp: os.CreateTemp,
+		rename:     os.Rename,
+		remove:     os.Remove,
+		open:       os.Open,
+	}
+}
+
+func replaceMirrorChangeJournal(
+	path string, journal MirrorChangeJournal,
+) error {
+	return newMirrorJournalStore().replace(path, journal)
+}
+
+func (store mirrorJournalStore) replace(
+	path string, journal MirrorChangeJournal,
+) (retErr error) {
+	if err := validateMirrorChangeJournal(journal); err != nil {
+		return fmt.Errorf("replace mirror journal: %w", err)
+	}
+	data, err := json.Marshal(journal)
+	if err != nil {
+		return fmt.Errorf("replace mirror journal: encode: %w", err)
+	}
+	data = append(data, '\n')
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("replace mirror journal: create directory: %w", err)
+	}
+	temp, err := store.createTemp(dir, ".mirror-changes-*.tmp")
+	if err != nil {
+		return fmt.Errorf("replace mirror journal: create temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() {
+		if tempPath != "" {
+			_ = store.remove(tempPath)
+		}
+	}()
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("replace mirror journal: chmod temp file: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("replace mirror journal: write temp file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("replace mirror journal: sync temp file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("replace mirror journal: close temp file: %w", err)
+	}
+	if err := store.rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace mirror journal: %w", err)
+	}
+	tempPath = ""
+	if err := store.syncDirectory(dir); err != nil {
+		return fmt.Errorf("replace mirror journal: sync directory: %w", err)
+	}
+	return nil
+}
+
+func retireMirrorChangeJournal(path string) error {
+	return newMirrorJournalStore().retire(path)
+}
+
+func (store mirrorJournalStore) retire(path string) error {
+	err := store.remove(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		if err := store.syncDirectory(filepath.Dir(path)); err != nil {
+			return fmt.Errorf("retire mirror journal: sync directory: %w", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("retire mirror journal: %w", err)
+	}
+	if err := store.syncDirectory(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("retire mirror journal: sync directory: %w", err)
+	}
+	return nil
+}
+
+func (store mirrorJournalStore) syncDirectory(path string) (retErr error) {
+	directory, err := store.open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { retErr = errors.Join(retErr, directory.Close()) }()
+	if err := directory.Sync(); err != nil &&
+		!isMirrorJournalDirectorySyncUnsupported(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/remotesync/mirror_journal.go
+++ b/internal/remotesync/mirror_journal.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	mirrorJournalVersion            = 3
+	mirrorJournalVersion            = 4
 	mirrorJournalLegacyVersion      = 1
 	mirrorJournalForceIntentVersion = 2
+	mirrorJournalAttemptVersion     = 3
 	mirrorJournalMaxEntries         = 8192
 	mirrorJournalMaxPathBytes       = 2 << 20
 )
@@ -59,13 +60,14 @@ type MirrorChangeEntry struct {
 }
 
 type MirrorChangeJournal struct {
-	Version           int                           `json:"version"`
-	FullImport        bool                          `json:"full_import,omitempty"`
-	FullImportReason  FullImportReason              `json:"full_import_reason,omitempty"`
-	InvalidateAll     bool                          `json:"invalidate_all,omitempty"`
-	ForceFullParseAll bool                          `json:"force_full_parse_all,omitempty"`
-	FileScopedDirs    map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
-	Entries           []MirrorChangeEntry           `json:"entries,omitempty"`
+	Version               int                           `json:"version"`
+	FullImport            bool                          `json:"full_import,omitempty"`
+	FullImportReason      FullImportReason              `json:"full_import_reason,omitempty"`
+	InvalidateAll         bool                          `json:"invalidate_all,omitempty"`
+	ForceFullParseAll     bool                          `json:"force_full_parse_all,omitempty"`
+	DataRebuildCacheReady bool                          `json:"data_rebuild_cache_ready,omitempty"`
+	FileScopedDirs        map[parser.AgentType][]string `json:"file_scoped_dirs,omitempty"`
+	Entries               []MirrorChangeEntry           `json:"entries,omitempty"`
 }
 
 type JournalMergeStats struct {
@@ -288,6 +290,7 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 		)
 	}
 	if header.Version != mirrorJournalVersion &&
+		header.Version != mirrorJournalAttemptVersion &&
 		header.Version != mirrorJournalForceIntentVersion &&
 		header.Version != mirrorJournalLegacyVersion {
 		return MirrorChangeJournal{}, fmt.Errorf(
@@ -318,7 +321,6 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 	}
 	if journal.Version == mirrorJournalLegacyVersion ||
 		journal.Version == mirrorJournalForceIntentVersion {
-		journal.Version = mirrorJournalVersion
 		if journal.FullImport {
 			journal.ForceFullParseAll = true
 		}
@@ -326,6 +328,7 @@ func loadMirrorChangeJournal(path string) (MirrorChangeJournal, error) {
 			journal.Entries[i].ForceFullParse = true
 		}
 	}
+	journal.Version = mirrorJournalVersion
 	if err := validateMirrorChangeJournal(journal); err != nil {
 		return MirrorChangeJournal{}, fmt.Errorf(
 			"%w: validate %q: %v", ErrMalformedMirrorJournal, path, err,

--- a/internal/remotesync/mirror_journal_sync_other.go
+++ b/internal/remotesync/mirror_journal_sync_other.go
@@ -1,0 +1,5 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package remotesync
+
+func isMirrorJournalDirectorySyncUnsupported(error) bool { return false }

--- a/internal/remotesync/mirror_journal_sync_unix.go
+++ b/internal/remotesync/mirror_journal_sync_unix.go
@@ -1,0 +1,14 @@
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package remotesync
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isMirrorJournalDirectorySyncUnsupported(err error) bool {
+	return errors.Is(err, syscall.EINVAL) ||
+		errors.Is(err, syscall.ENOSYS) ||
+		errors.Is(err, syscall.ENOTSUP)
+}

--- a/internal/remotesync/mirror_journal_sync_windows.go
+++ b/internal/remotesync/mirror_journal_sync_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package remotesync
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isMirrorJournalDirectorySyncUnsupported(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_INVALID_FUNCTION) ||
+		errors.Is(err, windows.ERROR_INVALID_HANDLE) ||
+		errors.Is(err, windows.ERROR_NOT_SUPPORTED)
+}

--- a/internal/remotesync/mirror_journal_test.go
+++ b/internal/remotesync/mirror_journal_test.go
@@ -42,7 +42,7 @@ func TestMirrorChangeJournalMergeSetUnionAndRearm(t *testing.T) {
 		Version: mirrorJournalVersion,
 		Entries: []MirrorChangeEntry{
 			{Path: "a/session.jsonl"},
-			{Path: "b/session.jsonl", InvalidateCache: true},
+			{Path: "b/session.jsonl", InvalidateCache: true, ForceFullParse: true},
 		},
 	}
 
@@ -54,9 +54,9 @@ func TestMirrorChangeJournalMergeSetUnionAndRearm(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, JournalMergeStats{New: 1, Rearmed: 1, Replayed: 1}, stats)
 	assert.Equal(t, []MirrorChangeEntry{
-		{Path: "a/session.jsonl", InvalidateCache: true},
-		{Path: "b/session.jsonl", InvalidateCache: true},
-		{Path: "c/session.jsonl", InvalidateCache: true},
+		{Path: "a/session.jsonl", InvalidateCache: true, ForceFullParse: true},
+		{Path: "b/session.jsonl", InvalidateCache: true, ForceFullParse: true},
+		{Path: "c/session.jsonl", InvalidateCache: true, ForceFullParse: true},
 	}, merged.Entries)
 }
 
@@ -74,26 +74,31 @@ func TestMirrorChangeJournalBoundsAndDisarm(t *testing.T) {
 	overflow, _, err := mergeMirrorChanges(journal, []string{"sessions/overflow"})
 	require.NoError(t, err)
 	assert.Equal(t, MirrorChangeJournal{
-		Version:          mirrorJournalVersion,
-		FullImport:       true,
-		FullImportReason: FullImportJournalOverflow,
-		InvalidateAll:    true,
+		Version:           mirrorJournalVersion,
+		FullImport:        true,
+		FullImportReason:  FullImportJournalOverflow,
+		InvalidateAll:     true,
+		ForceFullParseAll: true,
 	}, overflow)
 
 	disarmed := disarmMirrorChanges(MirrorChangeJournal{
-		Version:          mirrorJournalVersion,
-		FullImport:       true,
-		FullImportReason: FullImportJournalRecovery,
-		InvalidateAll:    true,
+		Version:           mirrorJournalVersion,
+		FullImport:        true,
+		FullImportReason:  FullImportJournalRecovery,
+		InvalidateAll:     true,
+		ForceFullParseAll: true,
 		Entries: []MirrorChangeEntry{{
-			Path: "session.jsonl", InvalidateCache: true,
+			Path: "session.jsonl", InvalidateCache: true, ForceFullParse: true,
 		}},
 	})
 	assert.Equal(t, MirrorChangeJournal{
-		Version:          mirrorJournalVersion,
-		FullImport:       true,
-		FullImportReason: FullImportJournalRecovery,
-		Entries:          []MirrorChangeEntry{{Path: "session.jsonl"}},
+		Version:           mirrorJournalVersion,
+		FullImport:        true,
+		FullImportReason:  FullImportJournalRecovery,
+		ForceFullParseAll: true,
+		Entries: []MirrorChangeEntry{{
+			Path: "session.jsonl", ForceFullParse: true,
+		}},
 	}, disarmed)
 }
 
@@ -204,7 +209,22 @@ func TestMirrorChangeJournalRoundTripAndAbsentUpgrade(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, MirrorChangeJournal{
 		Version: mirrorJournalVersion,
-		Entries: []MirrorChangeEntry{{Path: "sessions/legacy.jsonl"}},
+		Entries: []MirrorChangeEntry{{
+			Path: "sessions/legacy.jsonl", ForceFullParse: true,
+		}},
+	}, upgraded)
+
+	versionTwoPath := filepath.Join(t.TempDir(), "version-two.json")
+	require.NoError(t, os.WriteFile(versionTwoPath, []byte(
+		`{"version":2,"entries":[{"path":"sessions/pending.jsonl"}]}`,
+	), 0o600))
+	upgraded, err = loadMirrorChangeJournal(versionTwoPath)
+	require.NoError(t, err)
+	assert.Equal(t, MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{
+			Path: "sessions/pending.jsonl", ForceFullParse: true,
+		}},
 	}, upgraded)
 }
 

--- a/internal/remotesync/mirror_journal_test.go
+++ b/internal/remotesync/mirror_journal_test.go
@@ -239,6 +239,19 @@ func TestMirrorChangeJournalRoundTripAndAbsentUpgrade(t *testing.T) {
 			Path: "sessions/version-three.jsonl", ForceFullParse: true,
 		}},
 	}, upgraded)
+
+	versionFourPath := filepath.Join(t.TempDir(), "version-four.json")
+	require.NoError(t, os.WriteFile(versionFourPath, []byte(
+		`{"version":4,"full_import":true,"full_import_reason":"journal-recovery","force_full_parse_all":true,"data_rebuild_cache_ready":true}`,
+	), 0o600))
+	upgraded, err = loadMirrorChangeJournal(versionFourPath)
+	require.NoError(t, err)
+	assert.Equal(t, MirrorChangeJournal{
+		Version:           mirrorJournalVersion,
+		FullImport:        true,
+		FullImportReason:  FullImportJournalRecovery,
+		ForceFullParseAll: true,
+	}, upgraded)
 }
 
 func TestMirrorChangeJournalLoadErrorsAreTyped(t *testing.T) {

--- a/internal/remotesync/mirror_journal_test.go
+++ b/internal/remotesync/mirror_journal_test.go
@@ -177,7 +177,7 @@ func TestMirrorChangeJournalCombinedOwnershipPathByteBound(t *testing.T) {
 	require.NoError(t, validateMirrorChangeJournal(overflow))
 }
 
-func TestMirrorChangeJournalRoundTripAndAbsentUpgrade(t *testing.T) {
+func TestMirrorChangeJournalRoundTripAndAbsent(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "mirror")
 	path := mirrorJournalPath(root)
 
@@ -201,57 +201,6 @@ func TestMirrorChangeJournalRoundTripAndAbsentUpgrade(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 	require.NoError(t, retireMirrorChangeJournal(path))
 
-	legacyPath := filepath.Join(t.TempDir(), "legacy.json")
-	require.NoError(t, os.WriteFile(legacyPath, []byte(
-		`{"version":1,"entries":[{"path":"sessions/legacy.jsonl"}]}`,
-	), 0o600))
-	upgraded, err := loadMirrorChangeJournal(legacyPath)
-	require.NoError(t, err)
-	assert.Equal(t, MirrorChangeJournal{
-		Version: mirrorJournalVersion,
-		Entries: []MirrorChangeEntry{{
-			Path: "sessions/legacy.jsonl", ForceFullParse: true,
-		}},
-	}, upgraded)
-
-	versionTwoPath := filepath.Join(t.TempDir(), "version-two.json")
-	require.NoError(t, os.WriteFile(versionTwoPath, []byte(
-		`{"version":2,"entries":[{"path":"sessions/pending.jsonl"}]}`,
-	), 0o600))
-	upgraded, err = loadMirrorChangeJournal(versionTwoPath)
-	require.NoError(t, err)
-	assert.Equal(t, MirrorChangeJournal{
-		Version: mirrorJournalVersion,
-		Entries: []MirrorChangeEntry{{
-			Path: "sessions/pending.jsonl", ForceFullParse: true,
-		}},
-	}, upgraded)
-
-	versionThreePath := filepath.Join(t.TempDir(), "version-three.json")
-	require.NoError(t, os.WriteFile(versionThreePath, []byte(
-		`{"version":3,"entries":[{"path":"sessions/version-three.jsonl","force_full_parse":true}]}`,
-	), 0o600))
-	upgraded, err = loadMirrorChangeJournal(versionThreePath)
-	require.NoError(t, err)
-	assert.Equal(t, MirrorChangeJournal{
-		Version: mirrorJournalVersion,
-		Entries: []MirrorChangeEntry{{
-			Path: "sessions/version-three.jsonl", ForceFullParse: true,
-		}},
-	}, upgraded)
-
-	versionFourPath := filepath.Join(t.TempDir(), "version-four.json")
-	require.NoError(t, os.WriteFile(versionFourPath, []byte(
-		`{"version":4,"full_import":true,"full_import_reason":"journal-recovery","force_full_parse_all":true,"data_rebuild_cache_ready":true}`,
-	), 0o600))
-	upgraded, err = loadMirrorChangeJournal(versionFourPath)
-	require.NoError(t, err)
-	assert.Equal(t, MirrorChangeJournal{
-		Version:           mirrorJournalVersion,
-		FullImport:        true,
-		FullImportReason:  FullImportJournalRecovery,
-		ForceFullParseAll: true,
-	}, upgraded)
 }
 
 func TestMirrorChangeJournalLoadErrorsAreTyped(t *testing.T) {

--- a/internal/remotesync/mirror_journal_test.go
+++ b/internal/remotesync/mirror_journal_test.go
@@ -1,0 +1,329 @@
+package remotesync
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestMirrorRelativeChangePaths(t *testing.T) {
+	mirrorRoot := filepath.Join(t.TempDir(), "mirror")
+
+	remote, err := mirrorRelativeRemoteChangePath(
+		mirrorRoot, "/srv/example/.codex/sessions/a.jsonl",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "srv/example/.codex/sessions/a.jsonl", remote)
+
+	local := filepath.Join(mirrorRoot, "srv", "example", "session.jsonl")
+	rel, err := mirrorRelativeLocalChangePath(mirrorRoot, local)
+	require.NoError(t, err)
+	assert.Equal(t, "srv/example/session.jsonl", rel)
+
+	_, err = mirrorRelativeLocalChangePath(
+		mirrorRoot, filepath.Join(filepath.Dir(mirrorRoot), "escape.jsonl"),
+	)
+	assert.Error(t, err)
+	_, err = mirrorRelativeRemoteChangePath(mirrorRoot, "../../escape.jsonl")
+	assert.Error(t, err)
+	_, err = mirrorRelativeLocalChangePath(mirrorRoot, mirrorRoot)
+	assert.Error(t, err)
+}
+
+func TestMirrorChangeJournalMergeSetUnionAndRearm(t *testing.T) {
+	journal := MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{
+			{Path: "a/session.jsonl"},
+			{Path: "b/session.jsonl", InvalidateCache: true},
+		},
+	}
+
+	merged, stats, err := mergeMirrorChanges(journal, []string{
+		"a/session.jsonl",
+		"a/session.jsonl",
+		"c\\session.jsonl",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, JournalMergeStats{New: 1, Rearmed: 1, Replayed: 1}, stats)
+	assert.Equal(t, []MirrorChangeEntry{
+		{Path: "a/session.jsonl", InvalidateCache: true},
+		{Path: "b/session.jsonl", InvalidateCache: true},
+		{Path: "c/session.jsonl", InvalidateCache: true},
+	}, merged.Entries)
+}
+
+func TestMirrorChangeJournalBoundsAndDisarm(t *testing.T) {
+	entries := make([]string, mirrorJournalMaxEntries)
+	for i := range entries {
+		entries[i] = fmt.Sprintf("sessions/%08d.jsonl", i)
+	}
+	journal, _, err := mergeMirrorChanges(
+		MirrorChangeJournal{Version: mirrorJournalVersion}, entries,
+	)
+	require.NoError(t, err)
+	assert.Len(t, journal.Entries, mirrorJournalMaxEntries)
+
+	overflow, _, err := mergeMirrorChanges(journal, []string{"sessions/overflow"})
+	require.NoError(t, err)
+	assert.Equal(t, MirrorChangeJournal{
+		Version:          mirrorJournalVersion,
+		FullImport:       true,
+		FullImportReason: FullImportJournalOverflow,
+		InvalidateAll:    true,
+	}, overflow)
+
+	disarmed := disarmMirrorChanges(MirrorChangeJournal{
+		Version:          mirrorJournalVersion,
+		FullImport:       true,
+		FullImportReason: FullImportJournalRecovery,
+		InvalidateAll:    true,
+		Entries: []MirrorChangeEntry{{
+			Path: "session.jsonl", InvalidateCache: true,
+		}},
+	})
+	assert.Equal(t, MirrorChangeJournal{
+		Version:          mirrorJournalVersion,
+		FullImport:       true,
+		FullImportReason: FullImportJournalRecovery,
+		Entries:          []MirrorChangeEntry{{Path: "session.jsonl"}},
+	}, disarmed)
+}
+
+func TestMirrorChangeJournalCombinedOwnershipEntryBound(t *testing.T) {
+	ownership := map[parser.AgentType][]string{
+		parser.AgentWindsurf: {"/snapshot"},
+	}
+	paths := make([]string, mirrorJournalMaxEntries-1)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("sessions/%08d.jsonl", i)
+	}
+	exact, _, err := mergeMirrorChanges(MirrorChangeJournal{
+		Version:        mirrorJournalVersion,
+		FileScopedDirs: ownership,
+	}, paths)
+	require.NoError(t, err)
+	assert.False(t, exact.FullImport)
+	require.NoError(t, validateMirrorChangeJournal(exact))
+
+	overflow, _, err := mergeMirrorChanges(exact, []string{"sessions/overflow"})
+	require.NoError(t, err)
+	assert.Equal(t, FullImportJournalOverflow, overflow.FullImportReason)
+	assert.Equal(t, ownership, overflow.FileScopedDirs)
+	require.NoError(t, validateMirrorChangeJournal(overflow))
+}
+
+func TestFullImportReasonClosedSet(t *testing.T) {
+	for _, reason := range []FullImportReason{
+		FullImportLegacy,
+		FullImportBootstrap,
+		FullImportExplicit,
+		FullImportDataRebuild,
+		FullImportJournalOverflow,
+		FullImportJournalRecovery,
+	} {
+		assert.True(t, reason.Valid(), "reason %q must be reportable", reason)
+	}
+	assert.False(t, FullImportReason("transfer-heuristic").Valid(),
+		"transfer mode is not a full-import reason")
+}
+
+func TestMirrorChangeJournalPathByteBound(t *testing.T) {
+	exact := strings.Repeat("a", mirrorJournalMaxPathBytes)
+	journal, _, err := mergeMirrorChanges(
+		MirrorChangeJournal{Version: mirrorJournalVersion}, []string{exact},
+	)
+	require.NoError(t, err)
+	assert.False(t, journal.FullImport)
+
+	overflow, _, err := mergeMirrorChanges(
+		MirrorChangeJournal{Version: mirrorJournalVersion},
+		[]string{strings.Repeat("a", mirrorJournalMaxPathBytes+1)},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, FullImportJournalOverflow, overflow.FullImportReason)
+}
+
+func TestMirrorChangeJournalCombinedOwnershipPathByteBound(t *testing.T) {
+	const root = "/snapshot"
+	ownership := map[parser.AgentType][]string{
+		parser.AgentWindsurf: {root},
+	}
+	exactPath := strings.Repeat("a", mirrorJournalMaxPathBytes-len(root))
+	exact, _, err := mergeMirrorChanges(MirrorChangeJournal{
+		Version:        mirrorJournalVersion,
+		FileScopedDirs: ownership,
+	}, []string{exactPath})
+	require.NoError(t, err)
+	assert.False(t, exact.FullImport)
+	require.NoError(t, validateMirrorChangeJournal(exact))
+
+	overflow, _, err := mergeMirrorChanges(exact, []string{"b"})
+	require.NoError(t, err)
+	assert.Equal(t, FullImportJournalOverflow, overflow.FullImportReason)
+	assert.Equal(t, ownership, overflow.FileScopedDirs)
+	require.NoError(t, validateMirrorChangeJournal(overflow))
+}
+
+func TestMirrorChangeJournalRoundTripAndAbsentUpgrade(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "mirror")
+	path := mirrorJournalPath(root)
+
+	absent, err := loadMirrorChangeJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, MirrorChangeJournal{Version: mirrorJournalVersion}, absent)
+
+	want := MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{
+			Path: "sessions/a.jsonl", InvalidateCache: true,
+		}},
+	}
+	require.NoError(t, replaceMirrorChangeJournal(path, want))
+	got, err := loadMirrorChangeJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	require.NoError(t, retireMirrorChangeJournal(path))
+	_, err = os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	require.NoError(t, retireMirrorChangeJournal(path))
+
+	legacyPath := filepath.Join(t.TempDir(), "legacy.json")
+	require.NoError(t, os.WriteFile(legacyPath, []byte(
+		`{"version":1,"entries":[{"path":"sessions/legacy.jsonl"}]}`,
+	), 0o600))
+	upgraded, err := loadMirrorChangeJournal(legacyPath)
+	require.NoError(t, err)
+	assert.Equal(t, MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{Path: "sessions/legacy.jsonl"}},
+	}, upgraded)
+}
+
+func TestMirrorChangeJournalLoadErrorsAreTyped(t *testing.T) {
+	dir := t.TempDir()
+
+	unsupported := filepath.Join(dir, "unsupported.json")
+	require.NoError(t, os.WriteFile(unsupported, fmt.Appendf(nil,
+		`{"version":%d}`, mirrorJournalVersion+1,
+	), 0o600))
+	_, err := loadMirrorChangeJournal(unsupported)
+	assert.ErrorIs(t, err, ErrUnsupportedMirrorJournal)
+
+	malformed := filepath.Join(dir, "malformed.json")
+	require.NoError(t, os.WriteFile(malformed, []byte(`{"version":1,`), 0o600))
+	_, err = loadMirrorChangeJournal(malformed)
+	assert.ErrorIs(t, err, ErrMalformedMirrorJournal)
+
+	invalid := filepath.Join(dir, "invalid.json")
+	require.NoError(t, os.WriteFile(invalid, []byte(`{"version":1,"entries":[{"path":"../escape"}]}`), 0o600))
+	_, err = loadMirrorChangeJournal(invalid)
+	assert.ErrorIs(t, err, ErrMalformedMirrorJournal)
+
+	invalidOwnership := filepath.Join(dir, "invalid-ownership.json")
+	require.NoError(t, os.WriteFile(invalidOwnership, fmt.Appendf(nil,
+		`{"version":%d,"file_scoped_dirs":{"windsurf":["../escape"]}}`,
+		mirrorJournalVersion,
+	), 0o600))
+	_, err = loadMirrorChangeJournal(invalidOwnership)
+	assert.ErrorIs(t, err, ErrMalformedMirrorJournal)
+
+	unreadable := filepath.Join(dir, "directory")
+	require.NoError(t, os.Mkdir(unreadable, 0o700))
+	_, err = loadMirrorChangeJournal(unreadable)
+	assert.ErrorIs(t, err, ErrUnreadableMirrorJournal)
+}
+
+func TestMirrorChangeJournalFailedRenamePreservesPreviousFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "journal.json")
+	previous := MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{Path: "old.jsonl", InvalidateCache: true}},
+	}
+	require.NoError(t, replaceMirrorChangeJournal(path, previous))
+	before, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	store := newMirrorJournalStore()
+	store.rename = func(string, string) error { return errors.New("rename failed") }
+	err = store.replace(path, MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{Path: "new.jsonl", InvalidateCache: true}},
+	})
+	assert.EqualError(t, err, "replace mirror journal: rename failed")
+	after, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, before, after)
+}
+
+func TestMirrorChangeJournalDirectorySyncFailureMayLeaveReplacement(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "journal.json")
+	previous := MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{Path: "old.jsonl", InvalidateCache: true}},
+	}
+	replacement := MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{Path: "new.jsonl", InvalidateCache: true}},
+	}
+	require.NoError(t, replaceMirrorChangeJournal(path, previous))
+
+	closed, err := os.Open(dir)
+	require.NoError(t, err)
+	require.NoError(t, closed.Close())
+	store := newMirrorJournalStore()
+	store.open = func(string) (*os.File, error) { return closed, nil }
+	require.Error(t, store.replace(path, replacement))
+
+	got, err := loadMirrorChangeJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, replacement, got,
+		"rename can succeed before parent-directory durability fails")
+}
+
+func TestMirrorChangeJournalRetirementRetrySyncsAbsentParentEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "journal.json")
+	require.NoError(t, replaceMirrorChangeJournal(
+		path, MirrorChangeJournal{Version: mirrorJournalVersion},
+	))
+	closed, err := os.Open(dir)
+	require.NoError(t, err)
+	require.NoError(t, closed.Close())
+	store := newMirrorJournalStore()
+	store.open = func(string) (*os.File, error) { return closed, nil }
+	require.Error(t, store.retire(path))
+	assert.NoFileExists(t, path)
+
+	store = newMirrorJournalStore()
+	require.NoError(t, store.retire(path),
+		"an absent journal still requires a successful parent-directory sync")
+}
+
+func TestMirrorJournalPathIsAdjacentAndSurvivesMirrorDeletion(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "mirror")
+	require.NoError(t, os.MkdirAll(root, 0o700))
+	stale := filepath.Join(root, "stale.jsonl")
+	require.NoError(t, os.WriteFile(stale, []byte("stale"), 0o600))
+
+	journalPath := mirrorJournalPath(root)
+	require.NoError(t, replaceMirrorChangeJournal(
+		journalPath, MirrorChangeJournal{Version: mirrorJournalVersion},
+	))
+	require.NoError(t, ApplyMirrorDeletions(root, []string{stale}))
+
+	assert.Equal(t, parent, filepath.Dir(journalPath))
+	_, err := os.Stat(journalPath)
+	assert.NoError(t, err)
+}

--- a/internal/remotesync/mirror_journal_test.go
+++ b/internal/remotesync/mirror_journal_test.go
@@ -226,6 +226,19 @@ func TestMirrorChangeJournalRoundTripAndAbsentUpgrade(t *testing.T) {
 			Path: "sessions/pending.jsonl", ForceFullParse: true,
 		}},
 	}, upgraded)
+
+	versionThreePath := filepath.Join(t.TempDir(), "version-three.json")
+	require.NoError(t, os.WriteFile(versionThreePath, []byte(
+		`{"version":3,"entries":[{"path":"sessions/version-three.jsonl","force_full_parse":true}]}`,
+	), 0o600))
+	upgraded, err = loadMirrorChangeJournal(versionThreePath)
+	require.NoError(t, err)
+	assert.Equal(t, MirrorChangeJournal{
+		Version: mirrorJournalVersion,
+		Entries: []MirrorChangeEntry{{
+			Path: "sessions/version-three.jsonl", ForceFullParse: true,
+		}},
+	}, upgraded)
 }
 
 func TestMirrorChangeJournalLoadErrorsAreTyped(t *testing.T) {

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -279,6 +279,7 @@ func (r *ArchiveRequest) UnmarshalJSON(data []byte) error {
 type Importer struct {
 	Host                      string
 	Full                      bool
+	ForceFullParseAfterCache  bool
 	RequireComplete           bool
 	DB                        *db.DB
 	BlockedResultCategories   []string

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
@@ -12,10 +13,34 @@ import (
 )
 
 type SyncStats struct {
-	SessionsSynced int `json:"sessions_synced"`
-	SessionsTotal  int `json:"sessions_total"`
-	Skipped        int `json:"skipped"`
-	Failed         int `json:"failed"`
+	SessionsSynced       int              `json:"sessions_synced"`
+	SessionsTotal        int              `json:"sessions_total"`
+	Skipped              int              `json:"skipped"`
+	Failed               int              `json:"failed"`
+	PendingNew           int              `json:"pending_new,omitempty"`
+	PendingRearmed       int              `json:"pending_rearmed,omitempty"`
+	PendingReplayed      int              `json:"pending_replayed,omitempty"`
+	PendingPaths         int              `json:"pending_paths,omitempty"`
+	ArmedPaths           int              `json:"armed_paths,omitempty"`
+	ExactSources         int              `json:"exact_sources,omitempty"`
+	FallbackProviders    int              `json:"fallback_providers,omitempty"`
+	FallbackSources      int              `json:"fallback_sources,omitempty"`
+	FilesDiscovered      int              `json:"files_discovered,omitempty"`
+	FilesProcessed       int              `json:"files_processed,omitempty"`
+	PruneExactScopes     int              `json:"prune_exact_scopes,omitempty"`
+	PruneProviderScopes  int              `json:"prune_provider_scopes,omitempty"`
+	PruneHostWideScope   bool             `json:"prune_host_wide_scope,omitempty"`
+	PrunedExact          int              `json:"pruned_exact,omitempty"`
+	PrunedProvider       int              `json:"pruned_provider,omitempty"`
+	PrunedHostWide       int              `json:"pruned_host_wide,omitempty"`
+	ErrorSuppressed      int              `json:"error_suppressed,omitempty"`
+	FullReason           FullImportReason `json:"full_reason,omitempty"`
+	JournalOutcome       JournalOutcome   `json:"journal_outcome,omitempty"`
+	PlanningDuration     time.Duration    `json:"planning_duration,omitempty"`
+	PruningDuration      time.Duration    `json:"pruning_duration,omitempty"`
+	ProcessingDuration   time.Duration    `json:"processing_duration,omitempty"`
+	CachePersistDuration time.Duration    `json:"cache_persist_duration,omitempty"`
+	RetirementDuration   time.Duration    `json:"retirement_duration,omitempty"`
 }
 
 type TargetSet struct {
@@ -252,9 +277,15 @@ func (r *ArchiveRequest) UnmarshalJSON(data []byte) error {
 }
 
 type Importer struct {
-	Host                    string
-	Full                    bool
-	DB                      *db.DB
-	BlockedResultCategories []string
-	Progress                syncpkg.ProgressFunc
+	Host                      string
+	Full                      bool
+	RequireComplete           bool
+	DB                        *db.DB
+	BlockedResultCategories   []string
+	Progress                  syncpkg.ProgressFunc
+	Targets                   TargetSet
+	Root                      string
+	replaceRemoteSkippedFiles func(string, map[string]int64) error
+	applyRemoteSkippedChanges func(string, []string, map[string]int64) error
+	saveSkipCache             func(*db.DB, *syncpkg.Engine, remotePathMap) error
 }

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -84,11 +84,16 @@ var runHTTPRemoteSync = func(
 			rh.Host,
 		)
 	}
+	fullReason := remotesync.FullImportReason("")
+	if full {
+		fullReason = remotesync.FullImportExplicit
+	}
 	return remotesync.HTTPSync{
 		Host:                    rh.Host,
 		URL:                     rh.URL,
 		Token:                   token,
 		Full:                    full,
+		FullReason:              fullReason,
 		DataDir:                 cfg.DataDir,
 		DB:                      local,
 		BlockedResultCategories: cfg.ResultContentBlockedCategories,
@@ -109,8 +114,9 @@ var prepareHTTPRebuild = func(
 }
 
 type preparedHTTPRebuildLease struct {
-	prepared preparedHTTPRebuild
-	release  func()
+	prepared  preparedHTTPRebuild
+	release   func()
+	committed bool
 }
 
 func (l *preparedHTTPRebuildLease) Close() error {
@@ -122,6 +128,21 @@ func (l *preparedHTTPRebuildLease) Close() error {
 		l.release = nil
 	}
 	return l.prepared.Close()
+}
+
+func (l *preparedHTTPRebuildLease) Commit() error {
+	if l == nil || l.prepared == nil || l.committed {
+		return nil
+	}
+	committer, ok := l.prepared.(syncpkg.RebuildCommitter)
+	if !ok {
+		return nil
+	}
+	if err := committer.Commit(); err != nil {
+		return err
+	}
+	l.committed = true
+	return nil
 }
 
 func (s *Server) humaSyncStatus(
@@ -482,6 +503,10 @@ func (s *Server) runRemoteSyncRequest(
 	failures := make([]remoteSyncFailure, 0)
 	var blocked error
 	if req.IncludeLocal {
+		fullReason := remotesync.FullImportDataRebuild
+		if req.Full {
+			fullReason = remotesync.FullImportExplicit
+		}
 		httpHosts, sshHosts := partitionRemoteHosts(req.Hosts)
 		outerOwnsHTTP := len(httpHosts) > 0
 		var httpContributorsStarted time.Time
@@ -511,7 +536,7 @@ func (s *Server) runRemoteSyncRequest(
 						len(httpHosts),
 					)
 					prepared, err := prepareHTTPHosts(
-						ctx, ingestionCfg, local, httpHosts, progress,
+						ctx, ingestionCfg, local, httpHosts, fullReason, progress,
 					)
 					if err != nil {
 						return syncpkg.RebuildOptions{}, prepared, err
@@ -744,6 +769,7 @@ func prepareHTTPHosts(
 	cfg config.Config,
 	local *db.DB,
 	hosts []config.RemoteHost,
+	fullReason remotesync.FullImportReason,
 	progress func(syncpkg.Progress),
 ) (preparedHTTPRebuild, error) {
 	if len(hosts) == 0 {
@@ -763,6 +789,7 @@ func prepareHTTPHosts(
 			URL:                     host.URL,
 			Token:                   host.Token,
 			Full:                    true,
+			FullReason:              fullReason,
 			DataDir:                 cfg.DataDir,
 			DB:                      local,
 			BlockedResultCategories: cfg.ResultContentBlockedCategories,

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -320,6 +320,7 @@ func stubRunHTTPRemoteSync(
 type fakePreparedHTTPRebuild struct {
 	contributors []syncpkg.RebuildContributor
 	closed       int
+	committed    int
 	closeErrors  []error
 }
 
@@ -335,6 +336,20 @@ func (p *fakePreparedHTTPRebuild) Close() error {
 		return p.closeErrors[p.closed-1]
 	}
 	return nil
+}
+
+func (p *fakePreparedHTTPRebuild) Commit() error {
+	p.committed++
+	return nil
+}
+
+func TestPreparedHTTPRebuildLeaseForwardsCommitOnce(t *testing.T) {
+	prepared := &fakePreparedHTTPRebuild{}
+	lease := &preparedHTTPRebuildLease{prepared: prepared, release: func() {}}
+	require.NoError(t, lease.Commit())
+	require.NoError(t, lease.Commit())
+	assert.Equal(t, 1, prepared.committed)
+	assert.Zero(t, prepared.closed, "commit must not infer cleanup")
 }
 
 func TestHTTPCoordinatorFailurePrefersContributorOverCleanupHost(t *testing.T) {
@@ -521,6 +536,7 @@ func TestRunRemoteSyncRequestUnifiedHTTPContributorFailureSkipsSSH(t *testing.T)
 	) (preparedHTTPRebuild, error) {
 		require.Len(t, syncs, 1)
 		assert.Equal(t, "alpha", syncs[0].Host)
+		assert.Equal(t, remotesync.FullImportExplicit, syncs[0].FullReason)
 		return prepared, nil
 	})
 	sshCalls := 0
@@ -1163,8 +1179,10 @@ func TestRunRemoteSyncRequestRemoteOnlyKeepsActiveHTTPPath(t *testing.T) {
 	f := newSyncRouteFixture(t)
 	prepareCalls := 0
 	stubPrepareHTTPRebuild(t, func(
-		context.Context, []remotesync.HTTPSync,
+		_ context.Context, syncs []remotesync.HTTPSync,
 	) (preparedHTTPRebuild, error) {
+		require.Len(t, syncs, 1)
+		assert.Equal(t, remotesync.FullImportDataRebuild, syncs[0].FullReason)
 		prepareCalls++
 		return &fakePreparedHTTPRebuild{}, nil
 	})

--- a/internal/sync/changed_path_plan.go
+++ b/internal/sync/changed_path_plan.go
@@ -1,0 +1,607 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// ChangedPathPlan is the bounded import projection for a set of physical
+// mirror paths. Attribution remains private because paths are debug-only data.
+type ChangedPathPlan struct {
+	Files             []parser.DiscoveredFile
+	FallbackProviders []parser.AgentType
+	attribution       map[string]changedPathAttribution
+}
+
+type changedPathAttribution struct {
+	files             []parser.DiscoveredFile
+	fallbackProviders []parser.AgentType
+	provenIrrelevant  bool
+}
+
+// ChangedPathPruneScope is the cache-invalidation projection of a plan.
+type ChangedPathPruneScope struct {
+	Files             []parser.DiscoveredFile
+	FallbackProviders []parser.AgentType
+}
+
+// PlanChangedPathsContext classifies physical mirror paths without widening a
+// provider-local uncertainty into an all-provider import.
+func (e *Engine) PlanChangedPathsContext(
+	ctx context.Context,
+	physicalPaths []string,
+) (ChangedPathPlan, error) {
+	plan := ChangedPathPlan{attribution: make(map[string]changedPathAttribution, len(physicalPaths))}
+	for _, rawPath := range physicalPaths {
+		path, err := normalizeChangedPhysicalPath(rawPath)
+		if err != nil {
+			return ChangedPathPlan{}, err
+		}
+		if _, exists := plan.attribution[path]; exists {
+			continue
+		}
+		attribution, claimed, err := e.planOneChangedPath(ctx, path)
+		if err != nil {
+			return ChangedPathPlan{}, err
+		}
+		if !claimed {
+			attribution.provenIrrelevant = true
+		}
+		plan.attribution[path] = attribution
+	}
+	if err := e.resolveClaudeDuplicateAttribution(ctx, &plan); err != nil {
+		return ChangedPathPlan{}, err
+	}
+	plan.rebuildAggregates()
+	return plan, nil
+}
+
+func normalizeChangedPhysicalPath(path string) (string, error) {
+	if path == "" || strings.IndexByte(path, 0) >= 0 || !filepath.IsAbs(path) {
+		return "", fmt.Errorf("changed path is not a trusted absolute physical path")
+	}
+	return filepath.Clean(path), nil
+}
+
+func (e *Engine) planOneChangedPath(
+	ctx context.Context,
+	path string,
+) (changedPathAttribution, bool, error) {
+	var attribution changedPathAttribution
+	claimed := false
+	agents := e.sortedAuthoritativeProviderAgents()
+	for _, agent := range agents {
+		roots := e.agentDirs[agent]
+		if len(roots) == 0 {
+			continue
+		}
+		factory := e.providerFactories[agent]
+		if factory == nil {
+			continue
+		}
+		if factory.Definition().Type != agent {
+			return changedPathAttribution{}, false, fmt.Errorf(
+				"changed-path provider ownership mismatch for %s", agent,
+			)
+		}
+		provider := factory.NewProvider(parser.ProviderConfig{
+			Roots: roots, Machine: e.machine, PathRewriter: e.pathRewriter,
+		})
+		watchRoots, err := e.providerChangedPathWatchRoots(ctx, agent, provider, roots)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return changedPathAttribution{}, false, err
+			}
+			if changedPathWithinAnyRoot(path, roots) {
+				claimed = true
+				attribution.addFallback(agent)
+			}
+			continue
+		}
+		if !changedPathWithinAnyRoot(path, roots) &&
+			!changedPathWithinAnyRoot(path, watchRoots) {
+			continue
+		}
+		claimed = true
+		if agent == parser.AgentCodex &&
+			filepath.Base(path) == parser.CodexSessionIndexFilename {
+			// The index is global to every Codex rollout. Reuse the DB-aware
+			// classifier so title-only changes select only changed sessions and
+			// preserve the live/archive copy already tracked by the archive.
+			attribution.files = append(
+				attribution.files, e.classifyCodexIndexPath(path)...,
+			)
+			continue
+		}
+		matchingWatchRoots := matchingChangedPathRoots(path, watchRoots)
+		if len(matchingWatchRoots) == 0 {
+			matchingWatchRoots = matchingChangedPathRoots(path, roots)
+		}
+		if len(matchingWatchRoots) == 0 {
+			return changedPathAttribution{}, false, fmt.Errorf(
+				"cannot determine %s provider ownership for changed path", agent,
+			)
+		}
+		providerUnproven := false
+		for _, watchRoot := range matchingWatchRoots {
+			request := parser.ChangedPathRequest{
+				Path: path, EventKind: providerChangedPathEventKind(path), WatchRoot: watchRoot,
+				AllowWatermarkOnlySources: true,
+			}
+			relevance, relevanceErr := parser.ResolveChangedPathRelevance(ctx, provider, request)
+			if errors.Is(relevanceErr, context.Canceled) ||
+				errors.Is(relevanceErr, context.DeadlineExceeded) {
+				return changedPathAttribution{}, false, relevanceErr
+			}
+			if relevanceErr != nil {
+				providerUnproven = true
+				continue
+			}
+			if relevance == parser.ChangedPathNonData {
+				continue
+			}
+			// Relevance classification is an optional prefilter. An
+			// unclassified path may still map exactly through the provider's
+			// changed-path source classifier.
+			ok, hintErr := e.addPhysicalStoredSourceHints(ctx, provider, &request)
+			if errors.Is(hintErr, context.Canceled) ||
+				errors.Is(hintErr, context.DeadlineExceeded) {
+				return changedPathAttribution{}, false, hintErr
+			}
+			if hintErr != nil || !ok {
+				providerUnproven = true
+				continue
+			}
+			sources, sourceErr := provider.SourcesForChangedPath(ctx, request)
+			if errors.Is(sourceErr, context.Canceled) ||
+				errors.Is(sourceErr, context.DeadlineExceeded) {
+				return changedPathAttribution{}, false, sourceErr
+			}
+			if sourceErr != nil {
+				providerUnproven = true
+				continue
+			}
+			if len(sources) == 0 {
+				providerUnproven = true
+				continue
+			}
+			if agent == parser.AgentOmnigent {
+				sources, sourceErr = e.expandOmnigentInheritedMetadataSources(
+					ctx, provider, sources,
+				)
+				if errors.Is(sourceErr, context.Canceled) ||
+					errors.Is(sourceErr, context.DeadlineExceeded) {
+					return changedPathAttribution{}, false, sourceErr
+				}
+				if sourceErr != nil {
+					providerUnproven = true
+					continue
+				}
+			}
+			exactSources := 0
+			for _, source := range sources {
+				if file, ok := e.changedPathDiscoveredFile(provider, source); ok {
+					// An unclassified provider that maps a removal back to the
+					// removed path has not produced importable exact work. A
+					// distinct owning source (for example a database companion)
+					// remains valid without requiring the deleted path to exist.
+					if relevance == parser.ChangedPathUnclassified &&
+						request.EventKind == "remove" &&
+						filepath.Clean(file.Path) == request.Path {
+						continue
+					}
+					attribution.files = append(attribution.files, file)
+					exactSources++
+				}
+			}
+			if exactSources == 0 {
+				providerUnproven = true
+			}
+		}
+		if providerUnproven {
+			// Unclassified is uncertainty, not proof that the path is metadata.
+			attribution.addFallback(agent)
+		}
+	}
+	attribution.files = dedupeDiscoveredFiles(attribution.files)
+	attribution.normalize()
+	return attribution, claimed, nil
+}
+
+func (e *Engine) resolveClaudeDuplicateAttribution(
+	ctx context.Context,
+	plan *ChangedPathPlan,
+) error {
+	var files []parser.DiscoveredFile
+	for _, attribution := range plan.attribution {
+		files = append(files, attribution.files...)
+	}
+	expanded, err := e.expandAffectedClaudeDuplicateCandidates(ctx, files)
+	if err != nil {
+		return err
+	}
+	expanded = dedupeDiscoveredFiles(expanded)
+	preferredFiles := e.dedupeClaudeDiscoveredFiles(expanded)
+	preferredBySession := make(map[string]parser.DiscoveredFile)
+	for _, file := range preferredFiles {
+		if file.Agent != parser.AgentClaude {
+			continue
+		}
+		sessionID := claudeSessionIDFromPath(file.Path)
+		if sessionID == "" {
+			continue
+		}
+		preferredBySession[claudeDiscoveredFileKey(file, sessionID)] = file
+	}
+	if len(preferredBySession) == 0 {
+		return nil
+	}
+	for path, attribution := range plan.attribution {
+		for i, file := range attribution.files {
+			if file.Agent != parser.AgentClaude {
+				continue
+			}
+			sessionID := claudeSessionIDFromPath(file.Path)
+			key := claudeDiscoveredFileKey(file, sessionID)
+			preferred, ok := preferredBySession[key]
+			if ok {
+				attribution.files[i] = preferred
+			}
+		}
+		attribution.files = dedupeDiscoveredFiles(attribution.files)
+		attribution.normalize()
+		plan.attribution[path] = attribution
+	}
+	return nil
+}
+
+// expandAffectedClaudeDuplicateCandidates resolves the archive's stored source
+// for each exact Claude session in the plan. The changed source and stored
+// source are sufficient for DB-aware preference without invoking corpus-wide
+// project or nested-subagent discovery.
+func (e *Engine) expandAffectedClaudeDuplicateCandidates(
+	ctx context.Context,
+	files []parser.DiscoveredFile,
+) ([]parser.DiscoveredFile, error) {
+	factory := e.providerFactories[parser.AgentClaude]
+	roots := e.agentDirs[parser.AgentClaude]
+	if factory == nil || len(roots) == 0 {
+		return files, nil
+	}
+	provider := factory.NewProvider(parser.ProviderConfig{
+		Roots: roots, Machine: e.machine, PathRewriter: e.pathRewriter,
+	})
+	out := append([]parser.DiscoveredFile(nil), files...)
+	seenSources := make(map[string]struct{}, len(files))
+	seenSessions := make(map[string]struct{})
+	for _, file := range files {
+		seenSources[changedPathSourceKey(file)] = struct{}{}
+	}
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if file.Agent != parser.AgentClaude {
+			continue
+		}
+		sessionID := claudeSessionIDFromPath(file.Path)
+		if sessionID == "" {
+			continue
+		}
+		idPrefix := e.idPrefix
+		if isS3SourcePath(file.Path) {
+			idPrefix = s3SessionIDPrefix(file.Machine)
+		}
+		fullID := applyIDPrefixToID(idPrefix, sessionID)
+		sessionKey := discoveredFileIDPrefix(file) + "\x00" + fullID
+		if _, seen := seenSessions[sessionKey]; seen {
+			continue
+		}
+		seenSessions[sessionKey] = struct{}{}
+
+		storedPath := e.db.GetSessionFilePath(fullID)
+		if storedPath == "" {
+			continue
+		}
+		physicalStoredPath := storedPath
+		if e.pathRewriter != nil {
+			if e.storedPathResolver == nil {
+				continue
+			}
+			var resolved bool
+			physicalStoredPath, resolved = e.storedPathResolver(storedPath)
+			if !resolved {
+				continue
+			}
+		}
+		if physicalStoredPath == "" {
+			continue
+		}
+		request := parser.FindSourceRequest{
+			StoredFilePath:     physicalStoredPath,
+			RequireFreshSource: true, PreferStoredSource: true,
+		}
+		source, found, findErr := provider.FindSource(ctx, request)
+		if errors.Is(findErr, context.Canceled) ||
+			errors.Is(findErr, context.DeadlineExceeded) {
+			return nil, findErr
+		}
+		if findErr != nil || !found {
+			continue
+		}
+		candidate, ok := e.changedPathDiscoveredFile(provider, source)
+		if !ok {
+			continue
+		}
+		key := changedPathSourceKey(candidate)
+		if _, seen := seenSources[key]; seen {
+			continue
+		}
+		seenSources[key] = struct{}{}
+		out = append(out, candidate)
+	}
+	return out, nil
+}
+
+func (e *Engine) sortedAuthoritativeProviderAgents() []parser.AgentType {
+	agents := make([]parser.AgentType, 0, len(e.providerFactories))
+	for agent := range e.providerFactories {
+		if e.providerMigrationModes[agent] == parser.ProviderMigrationProviderAuthoritative {
+			agents = append(agents, agent)
+		}
+	}
+	slices.SortFunc(agents, func(a, b parser.AgentType) int {
+		return strings.Compare(string(a), string(b))
+	})
+	return agents
+}
+
+func matchingChangedPathRoots(path string, roots []string) []string {
+	matching := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if changedPathWithinRoot(path, root) {
+			matching = append(matching, root)
+		}
+	}
+	return matching
+}
+
+func (e *Engine) addPhysicalStoredSourceHints(
+	ctx context.Context,
+	provider parser.Provider,
+	request *parser.ChangedPathRequest,
+) (bool, error) {
+	if provider.Capabilities().Source.StoredSourceHints != parser.CapabilitySupported {
+		return true, nil
+	}
+	resolver, ok := provider.(parser.StoredSourceHintScopeProvider)
+	if !ok {
+		return false, nil
+	}
+	scopes := storedSourceDBHintScopes(resolver.StoredSourceHintScopes(*request))
+	if len(scopes) == 0 {
+		return true, nil
+	}
+	if e.pathRewriter != nil {
+		for i := range scopes {
+			scopes[i].Path = e.pathRewriter(scopes[i].Path)
+		}
+	}
+	stored, err := e.db.ListStoredSourcePathHintsContext(
+		ctx, string(provider.Definition().Type), scopes,
+	)
+	if err != nil {
+		return false, err
+	}
+	physical := make([]string, 0, len(stored))
+	for _, storedPath := range stored {
+		if e.storedPathResolver == nil {
+			return false, nil
+		}
+		path, translated := e.storedPathResolver(storedPath)
+		if !translated {
+			return false, nil
+		}
+		normalized, normalizeErr := normalizeChangedPhysicalPath(path)
+		if normalizeErr != nil {
+			return false, normalizeErr
+		}
+		physical = append(physical, normalized)
+	}
+	request.StoredSourcePaths = physical
+	return true, nil
+}
+
+func (e *Engine) changedPathDiscoveredFile(
+	provider parser.Provider,
+	source parser.SourceRef,
+) (parser.DiscoveredFile, bool) {
+	path := providerDiscoveredPath(source)
+	if path == "" {
+		return parser.DiscoveredFile{}, false
+	}
+	agent := source.Provider
+	if agent == "" {
+		agent = provider.Definition().Type
+	}
+	sourceCopy := source
+	file := parser.DiscoveredFile{
+		Path: path, Project: source.ProjectHint, Agent: agent,
+		ProviderSource: &sourceCopy, ProviderProcess: true,
+	}
+	if !isS3SourcePath(path) {
+		file.Machine = e.machineForProviderSource(agent, source, path)
+	}
+	return file, true
+}
+
+func (a *changedPathAttribution) addFallback(agent parser.AgentType) {
+	if !slices.Contains(a.fallbackProviders, agent) {
+		a.fallbackProviders = append(a.fallbackProviders, agent)
+	}
+}
+
+func (a *changedPathAttribution) normalize() {
+	a.files = sortAndDedupeChangedPathFiles(a.files)
+	slices.SortFunc(a.fallbackProviders, func(x, y parser.AgentType) int {
+		return strings.Compare(string(x), string(y))
+	})
+}
+
+func (plan *ChangedPathPlan) rebuildAggregates() {
+	var files []parser.DiscoveredFile
+	var providers []parser.AgentType
+	for _, attribution := range plan.attribution {
+		files = append(files, attribution.files...)
+		providers = append(providers, attribution.fallbackProviders...)
+	}
+	plan.Files = dedupeDiscoveredFiles(sortAndDedupeChangedPathFiles(files))
+	slices.SortFunc(providers, func(a, b parser.AgentType) int {
+		return strings.Compare(string(a), string(b))
+	})
+	plan.FallbackProviders = slices.Compact(providers)
+}
+
+func sortAndDedupeChangedPathFiles(files []parser.DiscoveredFile) []parser.DiscoveredFile {
+	merged := make(map[string]parser.DiscoveredFile, len(files))
+	keys := make([]string, 0, len(files))
+	for _, file := range files {
+		key := changedPathSourceKey(file)
+		if current, ok := merged[key]; ok {
+			merged[key] = mergeChangedPathDiscoveredFile(current, file)
+			continue
+		}
+		merged[key] = file
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	out := make([]parser.DiscoveredFile, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, merged[key])
+	}
+	return out
+}
+
+func changedPathSourceKey(file parser.DiscoveredFile) string {
+	return string(file.Agent) + "\x00" + file.Path
+}
+
+// PruneScope projects only armed input attribution into invalidation work.
+func (plan ChangedPathPlan) PruneScope(
+	armedPhysicalPaths map[string]struct{},
+) ChangedPathPruneScope {
+	armedPhysicalPaths = normalizeChangedPathSet(armedPhysicalPaths)
+	var files []parser.DiscoveredFile
+	var providers []parser.AgentType
+	for path, attribution := range plan.attribution {
+		if _, armed := armedPhysicalPaths[filepath.Clean(path)]; !armed {
+			continue
+		}
+		files = append(files, attribution.files...)
+		providers = append(providers, attribution.fallbackProviders...)
+	}
+	files = sortAndDedupeChangedPathFiles(files)
+	slices.SortFunc(providers, func(a, b parser.AgentType) int {
+		return strings.Compare(string(a), string(b))
+	})
+	return ChangedPathPruneScope{Files: files, FallbackProviders: slices.Compact(providers)}
+}
+
+// CountCachedSuppressedInputs maps cached source results back to distinct
+// disarmed pending inputs without exposing their paths.
+func (plan ChangedPathPlan) CountCachedSuppressedInputs(
+	armedPhysicalPaths map[string]struct{},
+	cachedSourceKeys map[string]struct{},
+	cachedFallbackProviders map[parser.AgentType]int,
+) int {
+	armedPhysicalPaths = normalizeChangedPathSet(armedPhysicalPaths)
+	count := 0
+	paths := make([]string, 0, len(plan.attribution))
+	for path := range plan.attribution {
+		paths = append(paths, path)
+	}
+	slices.Sort(paths)
+	for _, path := range paths {
+		if _, armed := armedPhysicalPaths[path]; armed {
+			continue
+		}
+		attribution := plan.attribution[path]
+		suppressed := false
+		for _, file := range attribution.files {
+			if _, ok := cachedSourceKeys[changedPathSourceKey(file)]; ok {
+				suppressed = true
+				break
+			}
+		}
+		if !suppressed {
+			for _, agent := range attribution.fallbackProviders {
+				if cachedFallbackProviders[agent] > 0 {
+					suppressed = true
+					break
+				}
+			}
+		}
+		if suppressed {
+			count++
+		}
+	}
+	return count
+}
+
+func normalizeChangedPathSet(paths map[string]struct{}) map[string]struct{} {
+	normalized := make(map[string]struct{}, len(paths))
+	for path := range paths {
+		if clean, err := normalizeChangedPhysicalPath(path); err == nil {
+			normalized[clean] = struct{}{}
+		}
+	}
+	return normalized
+}
+
+func (e *Engine) discoverChangedPathFallbackProviders(
+	ctx context.Context,
+	agents []parser.AgentType,
+) ([]parser.DiscoveredFile, map[parser.AgentType]int, error) {
+	selected := append([]parser.AgentType(nil), agents...)
+	slices.SortFunc(selected, func(a, b parser.AgentType) int {
+		return strings.Compare(string(a), string(b))
+	})
+	selected = slices.Compact(selected)
+	var files []parser.DiscoveredFile
+	counts := make(map[parser.AgentType]int, len(selected))
+	for _, agent := range selected {
+		if e.providerMigrationModes[agent] != parser.ProviderMigrationProviderAuthoritative {
+			return nil, nil, fmt.Errorf("fallback provider %s is not authoritative", agent)
+		}
+		factory := e.providerFactories[agent]
+		roots := e.agentDirs[agent]
+		if factory == nil || len(roots) == 0 {
+			return nil, nil, fmt.Errorf("fallback provider %s is not configured", agent)
+		}
+		provider := factory.NewProvider(parser.ProviderConfig{
+			Roots: roots, Machine: e.machine, PathRewriter: e.pathRewriter,
+		})
+		sources, err := provider.Discover(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("discover fallback provider %s: %w", agent, err)
+		}
+		var providerFiles []parser.DiscoveredFile
+		for _, source := range sources {
+			if file, ok := e.changedPathDiscoveredFile(provider, source); ok {
+				providerFiles = append(providerFiles, file)
+			}
+		}
+		providerFiles = sortAndDedupeChangedPathFiles(providerFiles)
+		providerFiles = e.dedupeClaudeDiscoveredFiles(providerFiles)
+		providerFiles = sortAndDedupeChangedPathFiles(providerFiles)
+		counts[agent] = len(providerFiles)
+		files = append(files, providerFiles...)
+	}
+	return sortAndDedupeChangedPathFiles(files), counts, nil
+}

--- a/internal/sync/changed_path_plan_test.go
+++ b/internal/sync/changed_path_plan_test.go
@@ -1,0 +1,841 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+type changedPathPlanFactory struct {
+	agent    parser.AgentType
+	caps     parser.Capabilities
+	provider func(parser.ProviderConfig) *changedPathPlanProvider
+}
+
+func (f changedPathPlanFactory) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: f.agent, DisplayName: string(f.agent)}
+}
+
+func (f changedPathPlanFactory) Capabilities() parser.Capabilities { return f.caps }
+
+func (f changedPathPlanFactory) NewProvider(cfg parser.ProviderConfig) parser.Provider {
+	p := f.provider(cfg.Clone())
+	p.ProviderBase = parser.ProviderBase{Def: f.Definition(), Caps: f.caps, Config: cfg.Clone()}
+	return p
+}
+
+type changedPathPlanProvider struct {
+	parser.ProviderBase
+	relevance     parser.ChangedPathRelevance
+	relevanceErr  error
+	sources       []parser.SourceRef
+	sourcesErr    error
+	discovered    []parser.SourceRef
+	discoverErr   error
+	discoveries   *int
+	hintScopes    []parser.StoredSourceHintScope
+	requests      *[]parser.ChangedPathRequest
+	reconciled    map[string]parser.SourceRef
+	fingerprints  map[string]parser.SourceFingerprint
+	outcomes      map[string]parser.ParseOutcome
+	parseRequests *[]parser.ParseRequest
+}
+
+func (p *changedPathPlanProvider) WatchPlan(context.Context) (parser.WatchPlan, error) {
+	roots := make([]parser.WatchRoot, 0, len(p.Config.Roots))
+	for _, root := range p.Config.Roots {
+		roots = append(roots, parser.WatchRoot{Path: root})
+	}
+	return parser.WatchPlan{Roots: roots}, nil
+}
+
+func (p *changedPathPlanProvider) ChangedPathRelevance(
+	context.Context, parser.ChangedPathRequest,
+) (parser.ChangedPathRelevance, error) {
+	return p.relevance, p.relevanceErr
+}
+
+func (p *changedPathPlanProvider) SourcesForChangedPath(
+	_ context.Context, req parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	if p.requests != nil {
+		*p.requests = append(*p.requests, req)
+	}
+	return append([]parser.SourceRef(nil), p.sources...), p.sourcesErr
+}
+
+func (p *changedPathPlanProvider) StoredSourceHintScopes(
+	parser.ChangedPathRequest,
+) []parser.StoredSourceHintScope {
+	return append([]parser.StoredSourceHintScope(nil), p.hintScopes...)
+}
+
+func (p *changedPathPlanProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	if p.discoveries != nil {
+		*p.discoveries++
+	}
+	return append([]parser.SourceRef(nil), p.discovered...), p.discoverErr
+}
+
+func (p *changedPathPlanProvider) SourceForReconciliation(
+	_ context.Context, path, _ string,
+) (parser.SourceRef, bool, error) {
+	source, ok := p.reconciled[path]
+	return source, ok, nil
+}
+
+func (p *changedPathPlanProvider) Fingerprint(
+	_ context.Context, source parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return p.fingerprints[source.Key], nil
+}
+
+func (p *changedPathPlanProvider) Parse(
+	_ context.Context, request parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	if p.parseRequests != nil {
+		*p.parseRequests = append(*p.parseRequests, request)
+	}
+	return p.outcomes[request.Source.Key], nil
+}
+
+func changedPathPlanCapabilities() parser.Capabilities {
+	return parser.Capabilities{Source: parser.SourceCapabilities{
+		ClassifyChangedPath:  parser.CapabilitySupported,
+		ChangedPathRelevance: parser.CapabilitySupported,
+		DiscoverSources:      parser.CapabilitySupported,
+	}}
+}
+
+func newChangedPathPlanEngine(
+	t *testing.T,
+	roots map[parser.AgentType][]string,
+	factories ...changedPathPlanFactory,
+) *Engine {
+	t.Helper()
+	modes := make(map[parser.AgentType]parser.ProviderMigrationMode, len(factories))
+	providerFactories := make([]parser.ProviderFactory, 0, len(factories))
+	for _, factory := range factories {
+		modes[factory.agent] = parser.ProviderMigrationProviderAuthoritative
+		providerFactories = append(providerFactories, factory)
+	}
+	return NewEngine(dbtest.OpenTestDB(t), EngineConfig{
+		AgentDirs:              roots,
+		Machine:                "remote",
+		ProviderFactories:      providerFactories,
+		ProviderMigrationModes: modes,
+		StoredPathResolver: func(path string) (string, bool) {
+			return path, true
+		},
+	})
+}
+
+func TestPlanChangedPathsExactIrrelevantAndOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	exactPath := filepath.Join(root, "changed.jsonl")
+	nonDataPath := filepath.Join(root, "metadata.json")
+	sourcePath := filepath.Join(root, "session.jsonl")
+	caps := changedPathPlanCapabilities()
+	factory := changedPathPlanFactory{agent: "plan-exact", caps: caps}
+	factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			relevance: parser.ChangedPathDataBearing,
+			sources: []parser.SourceRef{{
+				Provider: factory.agent, Key: sourcePath,
+				DisplayPath: sourcePath, FingerprintKey: sourcePath,
+			}},
+		}
+	}
+	engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+		factory.agent: {root},
+	}, factory)
+
+	plan, err := engine.PlanChangedPathsContext(t.Context(), []string{exactPath, exactPath})
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, sourcePath, plan.Files[0].Path)
+	assert.Empty(t, plan.FallbackProviders)
+
+	factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{relevance: parser.ChangedPathNonData}
+	}
+	engine = newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+		factory.agent: {root},
+	}, factory)
+	plan, err = engine.PlanChangedPathsContext(t.Context(), []string{
+		nonDataPath, filepath.Join(t.TempDir(), "outside.jsonl"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Files)
+	assert.Empty(t, plan.FallbackProviders)
+}
+
+func TestPlanChangedPathsProviderErrorFallsBackWithoutDroppingExactWork(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	caps := changedPathPlanCapabilities()
+	exactSource := filepath.Join(rootA, "session.jsonl")
+	exactFactory := changedPathPlanFactory{agent: "plan-exact", caps: caps}
+	exactFactory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			relevance: parser.ChangedPathDataBearing,
+			sources: []parser.SourceRef{{
+				Provider: exactFactory.agent, Key: exactSource,
+				DisplayPath: exactSource, FingerprintKey: exactSource,
+			}},
+		}
+	}
+	fallbackFactory := changedPathPlanFactory{agent: "plan-fallback", caps: caps}
+	fallbackFactory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			relevance:  parser.ChangedPathDataBearing,
+			sourcesErr: errors.New("classification unavailable"),
+		}
+	}
+	engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+		exactFactory.agent:    {rootA},
+		fallbackFactory.agent: {rootB},
+	}, exactFactory, fallbackFactory)
+
+	plan, err := engine.PlanChangedPathsContext(t.Context(), []string{
+		filepath.Join(rootA, "changed.jsonl"),
+		filepath.Join(rootB, "changed.jsonl"),
+	})
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, exactSource, plan.Files[0].Path)
+	assert.Equal(t, []parser.AgentType{fallbackFactory.agent}, plan.FallbackProviders)
+}
+
+func TestPlanChangedPathsCancellationAbortsInsteadOfFallingBack(t *testing.T) {
+	for _, sentinel := range []error{context.Canceled, context.DeadlineExceeded} {
+		t.Run(sentinel.Error(), func(t *testing.T) {
+			root := t.TempDir()
+			factory := changedPathPlanFactory{
+				agent: "plan-cancel", caps: changedPathPlanCapabilities(),
+			}
+			factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+				return &changedPathPlanProvider{relevanceErr: sentinel}
+			}
+			engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+				factory.agent: {root},
+			}, factory)
+
+			plan, err := engine.PlanChangedPathsContext(
+				t.Context(), []string{filepath.Join(root, "changed.jsonl")},
+			)
+			require.ErrorIs(t, err, sentinel)
+			assert.Empty(t, plan.Files)
+			assert.Empty(t, plan.FallbackProviders)
+		})
+	}
+}
+
+func TestPlanChangedPathsUnprovenPathsUseOwningProviderFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		relevance parser.ChangedPathRelevance
+	}{
+		{name: "unclassified", relevance: parser.ChangedPathUnclassified},
+		{name: "data-bearing without source", relevance: parser.ChangedPathDataBearing},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			caps := changedPathPlanCapabilities()
+			factory := changedPathPlanFactory{agent: "plan-fallback", caps: caps}
+			factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+				return &changedPathPlanProvider{relevance: tc.relevance}
+			}
+			engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+				factory.agent: {root},
+			}, factory)
+
+			plan, err := engine.PlanChangedPathsContext(
+				t.Context(), []string{filepath.Join(root, "changed.jsonl")},
+			)
+			require.NoError(t, err)
+			assert.Empty(t, plan.Files)
+			assert.Equal(t, []parser.AgentType{factory.agent}, plan.FallbackProviders)
+		})
+	}
+}
+
+func TestPlanChangedPathsClaudeProcessesOnlyChangedSession(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project-a")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	var changedPath string
+	for i := range 12 {
+		path := filepath.Join(projectDir, fmt.Sprintf("session-%02d.jsonl", i))
+		body := testjsonl.NewSessionBuilder().AddClaudeUser(
+			"2026-08-14T10:00:00Z", fmt.Sprintf("message %d", i),
+		).String()
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+		if i == 5 {
+			changedPath = path
+		}
+	}
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "remote",
+	})
+	t.Cleanup(engine.Close)
+
+	plan, err := engine.PlanChangedPathsContext(
+		t.Context(), []string{changedPath},
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, changedPath, plan.Files[0].Path)
+	assert.Empty(t, plan.FallbackProviders)
+
+	result, err := engine.SyncChangedPathPlanContext(t.Context(), plan, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesDiscovered)
+	assert.Equal(t, 1, result.FilesProcessed)
+	assert.Equal(t, 1, result.Stats.Synced)
+	page, err := database.ListSessions(t.Context(), db.SessionFilter{Limit: 20})
+	require.NoError(t, err)
+	require.Len(t, page.Sessions, 1,
+		"bounded processing must not import unrelated Claude sessions")
+	assert.Equal(t, "session-05", page.Sessions[0].ID)
+}
+
+func TestPlanChangedPathsCodexIndexUsesStoredArchivedDuplicate(t *testing.T) {
+	root := t.TempDir()
+	liveRoot := filepath.Join(root, "sessions")
+	archiveRoot := filepath.Join(root, "archived_sessions")
+	require.NoError(t, os.MkdirAll(liveRoot, 0o755))
+	require.NoError(t, os.MkdirAll(archiveRoot, 0o755))
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c122abc"
+	livePath := filepath.Join(
+		liveRoot, "2026", "08", "15",
+		"rollout-2026-08-15T10-00-00-"+uuid+".jsonl",
+	)
+	archivePath := filepath.Join(
+		archiveRoot, "rollout-2026-08-14T10-00-00-"+uuid+".jsonl",
+	)
+	for path, content := range map[string]string{
+		livePath:    "live stale copy",
+		archivePath: "archived tracked copy",
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		body := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON(
+				uuid, "/workspace/project", "codex_cli_rs", "2026-08-15T10:00:00Z",
+			),
+			testjsonl.CodexMsgJSON("user", content, "2026-08-15T10:00:01Z"),
+		)
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	}
+	indexPath := filepath.Join(root, parser.CodexSessionIndexFilename)
+	require.NoError(t, os.WriteFile(indexPath, []byte(
+		`{"id":"`+uuid+`","thread_name":"Renamed title"}`+"\n",
+	), 0o600))
+	database := dbtest.OpenTestDB(t)
+	toStoredPath := func(path string) string {
+		rel, err := filepath.Rel(root, path)
+		if err == nil && !strings.HasPrefix(rel, "..") {
+			return "remote:/codex/" + filepath.ToSlash(rel)
+		}
+		return path
+	}
+	storedPath := toStoredPath(archivePath)
+	oldName := "Old title"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "remote~codex:" + uuid, Agent: string(parser.AgentCodex),
+		Machine: "remote", FilePath: &storedPath, SessionName: &oldName,
+	}))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {liveRoot, archiveRoot},
+		},
+		Machine: "remote", IDPrefix: "remote~", PathRewriter: toStoredPath,
+	})
+	t.Cleanup(engine.Close)
+
+	plan, err := engine.PlanChangedPathsContext(t.Context(), []string{indexPath})
+
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, archivePath, plan.Files[0].Path)
+	assert.Empty(t, plan.FallbackProviders)
+}
+
+func TestSyncChangedPathPlanPrefersLiveCodexDuplicate(t *testing.T) {
+	root := t.TempDir()
+	liveRoot := filepath.Join(root, "sessions")
+	archiveRoot := filepath.Join(root, "archived_sessions")
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c123def"
+	livePath := filepath.Join(
+		liveRoot, "2026", "08", "15",
+		"rollout-2026-08-15T10-00-00-"+uuid+".jsonl",
+	)
+	archivePath := filepath.Join(
+		archiveRoot, "rollout-2026-08-14T10-00-00-"+uuid+".jsonl",
+	)
+	for path, content := range map[string]string{
+		livePath:    "preferred live content",
+		archivePath: "stale archived content",
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		body := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON(
+				uuid, "/workspace/project", "codex_cli_rs", "2026-08-15T10:00:00Z",
+			),
+			testjsonl.CodexMsgJSON("user", content, "2026-08-15T10:00:01Z"),
+		)
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	}
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {liveRoot, archiveRoot},
+		},
+		Machine: "remote",
+	})
+	t.Cleanup(engine.Close)
+
+	plan, err := engine.PlanChangedPathsContext(
+		t.Context(), []string{archivePath, livePath},
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, livePath, plan.Files[0].Path)
+	prune := plan.PruneScope(map[string]struct{}{
+		archivePath: {},
+		livePath:    {},
+	})
+	require.Len(t, prune.Files, 2)
+	assert.ElementsMatch(t, []string{archivePath, livePath}, []string{
+		prune.Files[0].Path,
+		prune.Files[1].Path,
+	})
+
+	result, err := engine.SyncChangedPathPlanContext(t.Context(), plan, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesProcessed)
+	assert.Equal(t, 1, result.Stats.Synced)
+	messages, err := database.GetMessages(
+		t.Context(), "codex:"+uuid, 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "preferred live content", messages[0].Content)
+}
+
+func TestPlanChangedPathsOmnigentIncludesStoredDescendants(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	physicalRoot := t.TempDir()
+	physicalContainer := filepath.Join(physicalRoot, "chat.db")
+	physicalParent := parser.VirtualSourcePath(physicalContainer, "parent")
+	physicalChild := parser.VirtualSourcePath(physicalContainer, "child")
+	storedContainer := "/remote/omnigent/chat.db"
+	storedParent := parser.VirtualSourcePath(storedContainer, "parent")
+	storedChild := parser.VirtualSourcePath(storedContainer, "child")
+	parentID := "remote~omnigent:parent"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: parentID, Agent: string(parser.AgentOmnigent), Machine: "remote",
+		FilePath: &storedParent,
+	}))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "remote~omnigent:child", Agent: string(parser.AgentOmnigent),
+		Machine: "remote", ParentSessionID: &parentID, FilePath: &storedChild,
+	}))
+	parentSource := parser.SourceRef{
+		Provider: parser.AgentOmnigent, Key: physicalParent,
+		DisplayPath: physicalParent, FingerprintKey: physicalParent,
+	}
+	childSource := parser.SourceRef{
+		Provider: parser.AgentOmnigent, Key: physicalChild,
+		DisplayPath: physicalChild, FingerprintKey: physicalChild,
+	}
+	parentResult := processFixtureResult(
+		"omnigent:parent", parser.AgentOmnigent, "project",
+		physicalParent, parser.SourceFingerprint{Key: physicalParent, MTimeNS: 2},
+	)
+	parentResult.Session.Cwd = "/workspace/new"
+	parentResult.Session.GitBranch = "feature"
+	childResult := processFixtureResult(
+		"omnigent:child", parser.AgentOmnigent, "project",
+		physicalChild, parser.SourceFingerprint{Key: physicalChild, MTimeNS: 2},
+	)
+	childResult.Session.Cwd = "/workspace/new"
+	childResult.Session.GitBranch = "feature"
+	childResult.Session.ParentSessionID = "omnigent:parent"
+	var parseRequests []parser.ParseRequest
+	factory := changedPathPlanFactory{
+		agent: parser.AgentOmnigent, caps: changedPathPlanCapabilities(),
+	}
+	factory.caps.Source.CompositeFingerprint = parser.CapabilitySupported
+	factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			relevance: parser.ChangedPathDataBearing,
+			sources:   []parser.SourceRef{parentSource},
+			reconciled: map[string]parser.SourceRef{
+				physicalChild: childSource,
+			},
+			fingerprints: map[string]parser.SourceFingerprint{
+				physicalParent: {Key: physicalParent, MTimeNS: 2},
+				physicalChild:  {Key: physicalChild, MTimeNS: 2},
+			},
+			outcomes: map[string]parser.ParseOutcome{
+				physicalParent: {
+					Results: []parser.ParseResultOutcome{{
+						Result: parentResult, DataVersion: parser.DataVersionCurrent,
+					}},
+					ResultSetComplete: true,
+				},
+				physicalChild: {
+					Results: []parser.ParseResultOutcome{{
+						Result: childResult, DataVersion: parser.DataVersionCurrent,
+					}},
+					ResultSetComplete: true,
+				},
+			},
+			parseRequests: &parseRequests,
+		}
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOmnigent: {physicalRoot},
+		},
+		Machine: "remote", IDPrefix: "remote~",
+		ProviderFactories: []parser.ProviderFactory{factory},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentOmnigent: parser.ProviderMigrationProviderAuthoritative,
+		},
+		StoredPathResolver: func(path string) (string, bool) {
+			if path == storedChild {
+				return physicalChild, true
+			}
+			return "", false
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	plan, err := engine.PlanChangedPathsContext(
+		t.Context(), []string{physicalContainer},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 2)
+	assert.ElementsMatch(t, []string{physicalParent, physicalChild}, []string{
+		plan.Files[0].Path, plan.Files[1].Path,
+	})
+	assert.Empty(t, plan.FallbackProviders)
+
+	result, err := engine.SyncChangedPathPlanContext(t.Context(), plan, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.FilesProcessed)
+	require.Len(t, parseRequests, 2)
+	child, err := database.GetSession(t.Context(), "remote~omnigent:child")
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	assert.Equal(t, "/workspace/new", child.Cwd)
+	assert.Equal(t, "feature", child.GitBranch)
+}
+
+func TestPlanChangedPathsDeletionClassifiesWithoutPhysicalStat(t *testing.T) {
+	root := t.TempDir()
+	deletedPath := filepath.Join(root, "deleted.jsonl")
+	ownerPath := filepath.Join(root, "owner.jsonl")
+	caps := changedPathPlanCapabilities()
+	factory := changedPathPlanFactory{agent: "plan-delete", caps: caps}
+	factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			relevance: parser.ChangedPathDataBearing,
+			sources: []parser.SourceRef{{
+				Provider: factory.agent, Key: ownerPath,
+				DisplayPath: ownerPath, FingerprintKey: ownerPath,
+			}},
+		}
+	}
+	engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+		factory.agent: {root},
+	}, factory)
+	require.NoFileExists(t, deletedPath)
+
+	plan, err := engine.PlanChangedPathsContext(t.Context(), []string{deletedPath})
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, ownerPath, plan.Files[0].Path)
+}
+
+func TestPlanChangedPathsExactUsesPreferredClaudeDuplicate(t *testing.T) {
+	liveRoot := t.TempDir()
+	archiveRoot := t.TempDir()
+	livePath := filepath.Join(liveRoot, "proj-live", "exact-duplicate.jsonl")
+	archivePath := filepath.Join(archiveRoot, "proj-archive", "exact-duplicate.jsonl")
+	for _, path := range []string{livePath, archivePath} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	}
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, older, older))
+	require.NoError(t, os.Chtimes(livePath, newer, newer))
+
+	database := dbtest.OpenTestDB(t)
+	liveInfo, err := os.Stat(livePath)
+	require.NoError(t, err)
+	liveSize := liveInfo.Size()
+	liveMtime := liveInfo.ModTime().UnixNano()
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "exact-duplicate", Agent: string(parser.AgentClaude), Machine: "remote",
+		FilePath: &livePath, FileSize: &liveSize, FileMtime: &liveMtime,
+	}))
+	require.NoError(t, database.SetSessionDataVersion(
+		"exact-duplicate", db.CurrentDataVersion(),
+	))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {liveRoot, archiveRoot},
+		},
+		Machine: "remote",
+	})
+	t.Cleanup(engine.Close)
+	scanCalls := 0
+	engine.claudeProjectSessionFiles = func(string) []parser.DiscoveredFile {
+		scanCalls++
+		return nil
+	}
+
+	plan, err := engine.PlanChangedPathsContext(t.Context(), []string{archivePath})
+	require.NoError(t, err)
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, livePath, plan.Files[0].Path)
+	assert.Zero(t, scanCalls,
+		"exact duplicate lookup must not enumerate the full Claude corpus")
+}
+
+func TestPlanChangedPathsDoesNotScanClaudeCorpusForExactBatch(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "project", "shared-session.jsonl")
+	caps := changedPathPlanCapabilities()
+	factory := changedPathPlanFactory{agent: parser.AgentClaude, caps: caps}
+	factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			relevance: parser.ChangedPathDataBearing,
+			sources: []parser.SourceRef{{
+				Provider: parser.AgentClaude, Key: sourcePath,
+				DisplayPath: sourcePath, FingerprintKey: sourcePath,
+			}},
+		}
+	}
+	engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+		parser.AgentClaude: {root},
+	}, factory)
+	scanCalls := 0
+	engine.claudeProjectSessionFiles = func(string) []parser.DiscoveredFile {
+		scanCalls++
+		return nil
+	}
+	changedPaths := make([]string, 16)
+	for i := range changedPaths {
+		changedPaths[i] = filepath.Join(root, fmt.Sprintf("changed-%02d.jsonl", i))
+	}
+
+	plan, err := engine.PlanChangedPathsContext(t.Context(), changedPaths)
+
+	require.NoError(t, err)
+	assert.Zero(t, scanCalls,
+		"exact planning must not enumerate the full Claude corpus")
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, sourcePath, plan.Files[0].Path)
+	for _, changedPath := range changedPaths {
+		attribution, ok := plan.attribution[changedPath]
+		require.True(t, ok)
+		require.Len(t, attribution.files, 1)
+		assert.Equal(t, sourcePath, attribution.files[0].Path)
+	}
+}
+
+func TestPlanChangedPathsTranslatesStoredHintsOrFallsBack(t *testing.T) {
+	root := t.TempDir()
+	changedPath := filepath.Join(root, "container.db")
+	require.NoError(t, os.WriteFile(changedPath, []byte("fixture"), 0o600))
+	storedPath := "remote:/sessions/container.db#member"
+	physicalHint := changedPath + "#member"
+	storedContainer := "remote:/sessions/container.db"
+	caps := changedPathPlanCapabilities()
+	caps.Source.StoredSourceHints = parser.CapabilitySupported
+	var requests []parser.ChangedPathRequest
+	factory := changedPathPlanFactory{agent: "plan-hints", caps: caps}
+	factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			relevance: parser.ChangedPathDataBearing,
+			hintScopes: []parser.StoredSourceHintScope{{
+				Path: changedPath, IncludeVirtualMembers: true,
+			}},
+			requests: &requests,
+			sources: []parser.SourceRef{{
+				Provider: factory.agent, Key: physicalHint,
+				DisplayPath: physicalHint, FingerprintKey: physicalHint,
+			}},
+		}
+	}
+	database := dbtest.OpenTestDB(t)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "plan-hints:member", Agent: string(factory.agent), Machine: "remote",
+		Project: "fixture", FilePath: &storedPath,
+	}))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{factory.agent: {root}},
+		Machine:   "remote", ProviderFactories: []parser.ProviderFactory{factory},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			factory.agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+		StoredPathResolver: func(path string) (string, bool) {
+			return physicalHint, path == storedPath
+		},
+		PathRewriter: func(path string) string {
+			if path == changedPath {
+				return storedContainer
+			}
+			return path
+		},
+	})
+
+	plan, err := engine.PlanChangedPathsContext(t.Context(), []string{changedPath})
+	require.NoError(t, err)
+	assert.Empty(t, plan.FallbackProviders)
+	require.Len(t, requests, 1)
+	assert.Equal(t, []string{physicalHint}, requests[0].StoredSourcePaths)
+
+	engine.storedPathResolver = func(string) (string, bool) { return "", false }
+	requests = nil
+	plan, err = engine.PlanChangedPathsContext(t.Context(), []string{changedPath})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Files)
+	assert.Equal(t, []parser.AgentType{factory.agent}, plan.FallbackProviders)
+	assert.Empty(t, requests, "untranslated hints must prevent bounded classification")
+}
+
+func TestPlanChangedPathsRejectsUntrustedInputAndOwnership(t *testing.T) {
+	root := t.TempDir()
+	caps := changedPathPlanCapabilities()
+	factory := changedPathPlanFactory{agent: "configured-owner", caps: caps}
+	factory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{relevance: parser.ChangedPathNonData}
+	}
+	engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+		factory.agent: {root},
+	}, factory)
+
+	plan, err := engine.PlanChangedPathsContext(t.Context(), []string{"relative/path"})
+	require.Error(t, err)
+	assert.Empty(t, plan.Files)
+	assert.Empty(t, plan.FallbackProviders)
+
+	mismatched := factory
+	mismatched.agent = "different-owner"
+	engine.providerFactories[factory.agent] = mismatched
+	plan, err = engine.PlanChangedPathsContext(
+		t.Context(), []string{filepath.Join(root, "changed.jsonl")},
+	)
+	require.Error(t, err)
+	assert.Empty(t, plan.Files)
+	assert.Empty(t, plan.FallbackProviders)
+}
+
+func TestChangedPathPlanPruneScopeUsesOnlyArmedAttribution(t *testing.T) {
+	root := t.TempDir()
+	armedPath := filepath.Join(root, "armed.jsonl")
+	disarmedPath := filepath.Join(root, "disarmed.jsonl")
+	armedSource := filepath.Join(root, "armed-session.jsonl")
+	disarmedSource := filepath.Join(root, "disarmed-session.jsonl")
+	agent := parser.AgentType("plan-projection")
+	plan := ChangedPathPlan{
+		Files: []parser.DiscoveredFile{
+			{Agent: agent, Path: armedSource},
+			{Agent: agent, Path: disarmedSource},
+		},
+		FallbackProviders: []parser.AgentType{agent},
+		attribution: map[string]changedPathAttribution{
+			armedPath: {
+				files: []parser.DiscoveredFile{{Agent: agent, Path: armedSource}},
+			},
+			disarmedPath: {
+				files:             []parser.DiscoveredFile{{Agent: agent, Path: disarmedSource}},
+				fallbackProviders: []parser.AgentType{agent},
+			},
+		},
+	}
+
+	nonCanonicalArmedPath := filepath.Join(root, "nested", "..", filepath.Base(armedPath))
+	prune := plan.PruneScope(map[string]struct{}{nonCanonicalArmedPath: {}})
+	require.Len(t, prune.Files, 1)
+	assert.Equal(t, armedSource, prune.Files[0].Path)
+	assert.Empty(t, prune.FallbackProviders)
+	assert.Len(t, plan.Files, 2)
+	assert.Equal(t, []parser.AgentType{agent}, plan.FallbackProviders)
+}
+
+func TestChangedPathPlanCountsEveryDisarmedFallbackInput(t *testing.T) {
+	root := t.TempDir()
+	agent := parser.AgentType("plan-fallback")
+	first := filepath.Join(root, "first.jsonl")
+	second := filepath.Join(root, "second.jsonl")
+	plan := ChangedPathPlan{attribution: map[string]changedPathAttribution{
+		first:  {fallbackProviders: []parser.AgentType{agent}},
+		second: {fallbackProviders: []parser.AgentType{agent}},
+	}}
+
+	assert.Equal(t, 2, plan.CountCachedSuppressedInputs(
+		map[string]struct{}{}, nil, map[parser.AgentType]int{agent: 1},
+	))
+	assert.Equal(t, 1, plan.CountCachedSuppressedInputs(
+		map[string]struct{}{filepath.Join(root, "nested", "..", "first.jsonl"): {}},
+		nil, map[parser.AgentType]int{agent: 1},
+	))
+}
+
+func TestDiscoverChangedPathFallbackIsProviderBounded(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	var discoveriesA, discoveriesB int
+	caps := changedPathPlanCapabilities()
+	source := filepath.Join(rootA, "session.jsonl")
+	factoryA := changedPathPlanFactory{agent: "fallback-a", caps: caps}
+	factoryA.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			discoveries: &discoveriesA,
+			discovered: []parser.SourceRef{
+				{Provider: factoryA.agent, Key: source, DisplayPath: source},
+				{Provider: factoryA.agent, Key: source, DisplayPath: source},
+			},
+		}
+	}
+	factoryB := changedPathPlanFactory{agent: "fallback-b", caps: caps}
+	factoryB.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{discoveries: &discoveriesB}
+	}
+	engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+		factoryA.agent: {rootA}, factoryB.agent: {rootB},
+	}, factoryA, factoryB)
+
+	files, counts, err := engine.discoverChangedPathFallbackProviders(
+		t.Context(), []parser.AgentType{factoryA.agent},
+	)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, source, files[0].Path)
+	assert.Equal(t, map[parser.AgentType]int{factoryA.agent: 1}, counts)
+	assert.Equal(t, 1, discoveriesA)
+	assert.Zero(t, discoveriesB)
+}

--- a/internal/sync/changed_path_sync.go
+++ b/internal/sync/changed_path_sync.go
@@ -22,11 +22,33 @@ type ChangedPathSyncResult struct {
 	CachedFallbackProviders map[parser.AgentType]int `json:"-"`
 }
 
+// ChangedPathSyncOptions controls execution-only behavior for a planned
+// changed-path import. ForceFullParse is the armed journal projection: its
+// exact sources and fallback providers bypass freshness and incremental append
+// for this attempt only.
+type ChangedPathSyncOptions struct {
+	ForceFullParse ChangedPathPruneScope
+}
+
 // SyncChangedPathPlanContext processes exact sources and explicitly selected
 // provider fallbacks without granting deletion authority over missing sources.
 func (e *Engine) SyncChangedPathPlanContext(
 	ctx context.Context,
 	plan ChangedPathPlan,
+	onProgress ProgressFunc,
+) (ChangedPathSyncResult, error) {
+	return e.SyncChangedPathPlanWithOptionsContext(
+		ctx, plan, ChangedPathSyncOptions{}, onProgress,
+	)
+}
+
+// SyncChangedPathPlanWithOptionsContext processes a plan with explicit
+// execution scope. Keeping the armed scope separate from the import plan lets
+// disarmed journal entries remain importable without re-forcing poison paths.
+func (e *Engine) SyncChangedPathPlanWithOptionsContext(
+	ctx context.Context,
+	plan ChangedPathPlan,
+	options ChangedPathSyncOptions,
 	onProgress ProgressFunc,
 ) (ChangedPathSyncResult, error) {
 	result := ChangedPathSyncResult{
@@ -43,6 +65,28 @@ func (e *Engine) SyncChangedPathPlanContext(
 	if err != nil {
 		return result, err
 	}
+	forceSourceKeys := make(map[string]struct{}, len(options.ForceFullParse.Files))
+	for _, file := range options.ForceFullParse.Files {
+		forceSourceKeys[changedPathSourceKey(file)] = struct{}{}
+	}
+	forceProviders := make(map[parser.AgentType]struct{},
+		len(options.ForceFullParse.FallbackProviders))
+	for _, agent := range options.ForceFullParse.FallbackProviders {
+		forceProviders[agent] = struct{}{}
+	}
+	planFiles := append([]parser.DiscoveredFile(nil), plan.Files...)
+	for i := range planFiles {
+		if _, force := forceSourceKeys[changedPathSourceKey(planFiles[i])]; force {
+			planFiles[i].ForceParse = true
+			planFiles[i].ForceFullParse = true
+		}
+	}
+	for i := range fallbackFiles {
+		if _, force := forceProviders[fallbackFiles[i].Agent]; force {
+			fallbackFiles[i].ForceParse = true
+			fallbackFiles[i].ForceFullParse = true
+		}
+	}
 	for _, count := range fallbackCounts {
 		result.FallbackSources += count
 	}
@@ -58,7 +102,7 @@ func (e *Engine) SyncChangedPathPlanContext(
 		}
 	}
 	files := sortAndDedupeChangedPathFiles(append(
-		append([]parser.DiscoveredFile(nil), plan.Files...), fallbackFiles...,
+		planFiles, fallbackFiles...,
 	))
 	result.FilesDiscovered = len(files)
 	if len(files) == 0 {

--- a/internal/sync/changed_path_sync.go
+++ b/internal/sync/changed_path_sync.go
@@ -24,8 +24,9 @@ type ChangedPathSyncResult struct {
 
 // ChangedPathSyncOptions controls execution-only behavior for a planned
 // changed-path import. ForceFullParse is the armed journal projection: its
-// exact sources and fallback providers bypass freshness and incremental append
-// for this attempt only.
+// exact sources and fallback providers bypass freshness and incremental append.
+// A durable skip entry may still suppress a source attempted after the
+// journal's cache invalidation was consumed.
 type ChangedPathSyncOptions struct {
 	ForceFullParse ChangedPathPruneScope
 }
@@ -77,13 +78,15 @@ func (e *Engine) SyncChangedPathPlanWithOptionsContext(
 	planFiles := append([]parser.DiscoveredFile(nil), plan.Files...)
 	for i := range planFiles {
 		if _, force := forceSourceKeys[changedPathSourceKey(planFiles[i])]; force {
-			planFiles[i].ForceParse = true
+			// The journal scope supersedes plan-time ForceParse. Its cache was
+			// already invalidated durably, so a surviving entry is proof of a
+			// later attempt and must be allowed to suppress replay.
+			planFiles[i].ForceParse = false
 			planFiles[i].ForceFullParse = true
 		}
 	}
 	for i := range fallbackFiles {
 		if _, force := forceProviders[fallbackFiles[i].Agent]; force {
-			fallbackFiles[i].ForceParse = true
 			fallbackFiles[i].ForceFullParse = true
 		}
 	}

--- a/internal/sync/changed_path_sync.go
+++ b/internal/sync/changed_path_sync.go
@@ -1,0 +1,166 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"slices"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// ChangedPathSyncResult describes bounded, non-destructive processing of a
+// remote changed-path plan. Cache attribution remains process-local.
+type ChangedPathSyncResult struct {
+	Stats                   SyncStats
+	FilesDiscovered         int
+	FilesProcessed          int
+	FallbackSources         int
+	CachedSourceKeys        map[string]struct{}      `json:"-"`
+	CachedFallbackProviders map[parser.AgentType]int `json:"-"`
+}
+
+// SyncChangedPathPlanContext processes exact sources and explicitly selected
+// provider fallbacks without granting deletion authority over missing sources.
+func (e *Engine) SyncChangedPathPlanContext(
+	ctx context.Context,
+	plan ChangedPathPlan,
+	onProgress ProgressFunc,
+) (ChangedPathSyncResult, error) {
+	result := ChangedPathSyncResult{
+		CachedSourceKeys:        make(map[string]struct{}),
+		CachedFallbackProviders: make(map[parser.AgentType]int),
+	}
+	if e.refuseWriteInForceParse("SyncChangedPathPlan") {
+		return result, nil
+	}
+
+	fallbackFiles, fallbackCounts, err := e.discoverChangedPathFallbackProviders(
+		ctx, plan.FallbackProviders,
+	)
+	if err != nil {
+		return result, err
+	}
+	for _, count := range fallbackCounts {
+		result.FallbackSources += count
+	}
+	exactKeys := make(map[string]struct{}, len(plan.Files))
+	for _, file := range plan.Files {
+		exactKeys[changedPathSourceKey(file)] = struct{}{}
+	}
+	fallbackKeys := make(map[string]parser.AgentType, len(fallbackFiles))
+	for _, file := range fallbackFiles {
+		key := changedPathSourceKey(file)
+		if _, exact := exactKeys[key]; !exact {
+			fallbackKeys[key] = file.Agent
+		}
+	}
+	files := sortAndDedupeChangedPathFiles(append(
+		append([]parser.DiscoveredFile(nil), plan.Files...), fallbackFiles...,
+	))
+	result.FilesDiscovered = len(files)
+	if len(files) == 0 {
+		return result, ctx.Err()
+	}
+
+	e.syncMu.Lock()
+	var stats SyncStats
+	defer func() {
+		if stats.Synced > 0 {
+			e.emit("sessions")
+		}
+	}()
+	defer e.syncMu.Unlock()
+	defer e.clearCurrentProgress()
+	e.resetS3CodexIndexCache()
+	e.anomalies.reset()
+	var processErr error
+
+	physicalPaths := make([]string, 0, len(files))
+	for _, file := range files {
+		physicalPaths = append(physicalPaths, file.Path)
+	}
+	preContainerStates := e.captureSQLiteContainerStates(physicalPaths)
+	e.beginSQLiteContainerPass(files, preContainerStates)
+	processingCtx := context.WithValue(ctx, deferGlobalLinkContextKey{}, true)
+	results := e.startWorkers(processingCtx, files)
+	affectedSessionIDs := make(map[string]struct{})
+	stats = e.collectAndBatchWithOptions(
+		processingCtx, results, len(files), len(files), func(progress Progress) {
+			progress.FallbackProviders = len(plan.FallbackProviders)
+			progress.FallbackSources = result.FallbackSources
+			if onProgress != nil {
+				onProgress(progress)
+			}
+		}, syncWriteDefault, collectAndBatchOptions{
+			preserveMissingSources: true,
+			observeResult: func(job syncJob) {
+				result.FilesProcessed++
+				if job.incremental != nil {
+					affectedSessionIDs[job.incremental.sessionID] = struct{}{}
+				}
+				for _, parsed := range job.results {
+					affectedSessionIDs[applyIDPrefixToID(e.idPrefix, parsed.Session.ID)] = struct{}{}
+				}
+				for _, id := range job.excludedSessionIDs {
+					affectedSessionIDs[applyIDPrefixToID(e.idPrefix, id)] = struct{}{}
+				}
+				if !job.cachedSkip {
+					return
+				}
+				key := changedPathSourceKey(parser.DiscoveredFile{
+					Agent: job.agent, Path: job.path,
+				})
+				if _, exact := exactKeys[key]; exact {
+					result.CachedSourceKeys[key] = struct{}{}
+					return
+				}
+				if agent, fallback := fallbackKeys[key]; fallback {
+					result.CachedFallbackProviders[agent]++
+				}
+			},
+		},
+	)
+	if len(affectedSessionIDs) > 0 && !stats.Aborted {
+		ids := make([]string, 0, len(affectedSessionIDs))
+		for id := range affectedSessionIDs {
+			ids = append(ids, id)
+		}
+		slices.Sort(ids)
+		if err := e.db.LinkSubagentSessionsForSessions(ids); err != nil {
+			stats.RecordFailed()
+			processErr = errors.Join(processErr,
+				fmt.Errorf("link affected subagent sessions: %w", err))
+			if queueErr := e.db.QueueSubagentParentRepairs(ids); queueErr != nil {
+				processErr = errors.Join(processErr,
+					fmt.Errorf("queue affected subagent parent repairs: %w", queueErr))
+			}
+		}
+	}
+	e.finishSQLiteContainerPass(true, false)
+	e.anomalies.applyTo(&stats)
+	if !e.ephemeral {
+		e.persistSkipCache()
+	}
+	e.mu.Lock()
+	e.lastSync = time.Now()
+	e.lastSyncStats = stats
+	e.mu.Unlock()
+	result.Stats = stats
+
+	if stats.Synced > 0 {
+		log.Printf("sync: %d file(s) updated", stats.Synced)
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if stats.Aborted || stats.Failed > 0 || stats.providerFailures > 0 {
+		return result, errors.Join(processErr, fmt.Errorf(
+			"changed-path plan sync incomplete: %d source or archive failures",
+			stats.Failed,
+		))
+	}
+	return result, processErr
+}

--- a/internal/sync/changed_path_sync_test.go
+++ b/internal/sync/changed_path_sync_test.go
@@ -79,12 +79,14 @@ func TestSyncChangedPathPlanReportsOnlyMtimeCacheSuppression(t *testing.T) {
 	assert.NotContains(t, provider.calls, "parse")
 }
 
-func TestSyncChangedPathPlanArmedScopeForcesOneFullParse(t *testing.T) {
+func TestSyncChangedPathPlanFullParseScopeUsesDurableAttemptCache(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		plan     func(parser.DiscoveredFile) ChangedPathPlan
-		options  func(parser.DiscoveredFile) ChangedPathSyncOptions
-		fallback bool
+		name           string
+		plan           func(parser.DiscoveredFile) ChangedPathPlan
+		options        func(parser.DiscoveredFile) ChangedPathSyncOptions
+		fallback       bool
+		cached         bool
+		planForceParse bool
 	}{
 		{
 			name: "exact source",
@@ -110,6 +112,34 @@ func TestSyncChangedPathPlanArmedScopeForcesOneFullParse(t *testing.T) {
 				}}
 			},
 			fallback: true,
+		},
+		{
+			name: "exact source already attempted",
+			plan: func(file parser.DiscoveredFile) ChangedPathPlan {
+				return ChangedPathPlan{Files: []parser.DiscoveredFile{file}}
+			},
+			options: func(file parser.DiscoveredFile) ChangedPathSyncOptions {
+				return ChangedPathSyncOptions{ForceFullParse: ChangedPathPruneScope{
+					Files: []parser.DiscoveredFile{file},
+				}}
+			},
+			cached:         true,
+			planForceParse: true,
+		},
+		{
+			name: "fallback source already attempted",
+			plan: func(parser.DiscoveredFile) ChangedPathPlan {
+				return ChangedPathPlan{FallbackProviders: []parser.AgentType{
+					parser.AgentCowork,
+				}}
+			},
+			options: func(parser.DiscoveredFile) ChangedPathSyncOptions {
+				return ChangedPathSyncOptions{ForceFullParse: ChangedPathPruneScope{
+					FallbackProviders: []parser.AgentType{parser.AgentCowork},
+				}}
+			},
+			fallback: true,
+			cached:   true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -137,11 +167,14 @@ func TestSyncChangedPathPlanArmedScopeForcesOneFullParse(t *testing.T) {
 				},
 			})
 			t.Cleanup(engine.Close)
-			engine.skipCache[providerAgentSkipCacheKey(path, parser.AgentCowork)] =
-				fingerprint.MTimeNS
+			if tc.cached {
+				engine.skipCache[providerAgentSkipCacheKey(path, parser.AgentCowork)] =
+					fingerprint.MTimeNS
+			}
 			file := parser.DiscoveredFile{
 				Path: path, Agent: parser.AgentCowork,
 				ProviderSource: &source, ProviderProcess: true,
+				ForceParse: tc.planForceParse,
 			}
 
 			result, err := engine.SyncChangedPathPlanWithOptionsContext(
@@ -149,9 +182,14 @@ func TestSyncChangedPathPlanArmedScopeForcesOneFullParse(t *testing.T) {
 			)
 			require.NoError(t, err)
 			assert.Equal(t, 1, result.FilesProcessed)
-			assert.Zero(t, result.Stats.Skipped)
-			require.Len(t, provider.parseRequests, 1)
-			assert.True(t, provider.parseRequests[0].ForceParse)
+			if tc.cached {
+				assert.Equal(t, 1, result.Stats.Skipped)
+				assert.Empty(t, provider.parseRequests)
+			} else {
+				assert.Zero(t, result.Stats.Skipped)
+				require.Len(t, provider.parseRequests, 1)
+				assert.True(t, provider.parseRequests[0].ForceParse)
+			}
 		})
 	}
 }

--- a/internal/sync/changed_path_sync_test.go
+++ b/internal/sync/changed_path_sync_test.go
@@ -79,6 +79,83 @@ func TestSyncChangedPathPlanReportsOnlyMtimeCacheSuppression(t *testing.T) {
 	assert.NotContains(t, provider.calls, "parse")
 }
 
+func TestSyncChangedPathPlanArmedScopeForcesOneFullParse(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		plan     func(parser.DiscoveredFile) ChangedPathPlan
+		options  func(parser.DiscoveredFile) ChangedPathSyncOptions
+		fallback bool
+	}{
+		{
+			name: "exact source",
+			plan: func(file parser.DiscoveredFile) ChangedPathPlan {
+				return ChangedPathPlan{Files: []parser.DiscoveredFile{file}}
+			},
+			options: func(file parser.DiscoveredFile) ChangedPathSyncOptions {
+				return ChangedPathSyncOptions{ForceFullParse: ChangedPathPruneScope{
+					Files: []parser.DiscoveredFile{file},
+				}}
+			},
+		},
+		{
+			name: "fallback provider",
+			plan: func(parser.DiscoveredFile) ChangedPathPlan {
+				return ChangedPathPlan{FallbackProviders: []parser.AgentType{
+					parser.AgentCowork,
+				}}
+			},
+			options: func(parser.DiscoveredFile) ChangedPathSyncOptions {
+				return ChangedPathSyncOptions{ForceFullParse: ChangedPathPruneScope{
+					FallbackProviders: []parser.AgentType{parser.AgentCowork},
+				}}
+			},
+			fallback: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := dbtest.OpenTestDB(t)
+			root := t.TempDir()
+			path, fingerprint := writeProcessProviderSource(t, root, "armed.jsonl")
+			source := processFixtureSource(path)
+			provider := newProcessFixtureProvider(
+				source, fingerprint, parser.ParseOutcome{ResultSetComplete: true},
+			)
+			provider.Caps.Sync.SkipCacheFreshWithoutStoredRow = true
+			if tc.fallback {
+				provider.discovered = []parser.SourceRef{source}
+			}
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentCowork: {root},
+				},
+				Machine: "remote", Ephemeral: true,
+				ProviderFactories: []parser.ProviderFactory{
+					processFixtureFactory{provider: provider},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+				},
+			})
+			t.Cleanup(engine.Close)
+			engine.skipCache[providerAgentSkipCacheKey(path, parser.AgentCowork)] =
+				fingerprint.MTimeNS
+			file := parser.DiscoveredFile{
+				Path: path, Agent: parser.AgentCowork,
+				ProviderSource: &source, ProviderProcess: true,
+			}
+
+			result, err := engine.SyncChangedPathPlanWithOptionsContext(
+				t.Context(), tc.plan(file), tc.options(file), nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.FilesProcessed)
+			assert.Zero(t, result.Stats.Skipped)
+			require.Len(t, provider.parseRequests, 1)
+			assert.True(t, provider.parseRequests[0].ForceParse)
+		})
+	}
+}
+
 func TestSyncChangedPathPlanFallbackDiscoveryStaysProviderBounded(t *testing.T) {
 	rootA := t.TempDir()
 	rootB := t.TempDir()

--- a/internal/sync/changed_path_sync_test.go
+++ b/internal/sync/changed_path_sync_test.go
@@ -1,0 +1,228 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestSyncChangedPathPlanDoesNotTombstonePendingDeletion(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	deletedPath := filepath.Join(t.TempDir(), "deleted.jsonl")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "remote:retained", Agent: string(parser.AgentCowork),
+		Project: "fixture", Machine: "remote", FilePath: &deletedPath,
+	}))
+	engine := NewEngine(database, EngineConfig{Machine: "remote", Ephemeral: true})
+	t.Cleanup(engine.Close)
+	plan := ChangedPathPlan{attribution: map[string]changedPathAttribution{
+		deletedPath: {provenIrrelevant: true},
+	}}
+
+	result, err := engine.SyncChangedPathPlanContext(t.Context(), plan, nil)
+	require.NoError(t, err)
+	assert.Zero(t, result.FilesDiscovered)
+	retained, err := database.GetSession(t.Context(), "remote:retained")
+	require.NoError(t, err)
+	require.NotNil(t, retained)
+	assert.Nil(t, retained.DeletedAt)
+}
+
+func TestSyncChangedPathPlanReportsOnlyMtimeCacheSuppression(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "cached.jsonl")
+	fingerprint := parser.SourceFingerprint{Key: path, Size: 7, MTimeNS: 42}
+	source := parser.SourceRef{
+		Provider: parser.AgentCowork, Key: path,
+		DisplayPath: path, FingerprintKey: path,
+	}
+	provider := newProcessFixtureProvider(source, fingerprint, parser.ParseOutcome{})
+	provider.Caps.Sync.SkipCacheFreshWithoutStoredRow = true
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+		Machine:   "remote", Ephemeral: true,
+		ProviderFactories: []parser.ProviderFactory{processFixtureFactory{provider: provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	cacheKey := providerAgentSkipCacheKey(path, parser.AgentCowork)
+	engine.skipCache[cacheKey] = fingerprint.MTimeNS
+	file := parser.DiscoveredFile{
+		Path: path, Agent: parser.AgentCowork,
+		ProviderSource: &source, ProviderProcess: true,
+	}
+	plan := ChangedPathPlan{
+		Files: []parser.DiscoveredFile{file},
+		attribution: map[string]changedPathAttribution{
+			path: {files: []parser.DiscoveredFile{file}},
+		},
+	}
+
+	result, err := engine.SyncChangedPathPlanContext(t.Context(), plan, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesDiscovered)
+	assert.Equal(t, 1, result.FilesProcessed)
+	assert.Equal(t, 1, result.Stats.Skipped)
+	assert.Equal(t, map[string]struct{}{changedPathSourceKey(file): {}}, result.CachedSourceKeys)
+	assert.Empty(t, result.CachedFallbackProviders)
+	assert.NotContains(t, provider.calls, "parse")
+}
+
+func TestSyncChangedPathPlanFallbackDiscoveryStaysProviderBounded(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	var callsA, callsB int
+	caps := changedPathPlanCapabilities()
+	sourcePath := filepath.Join(rootA, "fallback.jsonl")
+	factoryA := changedPathPlanFactory{agent: "fallback-a", caps: caps}
+	factoryA.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{
+			discoveries: &callsA,
+			discovered: []parser.SourceRef{{
+				Provider: factoryA.agent, Key: sourcePath,
+				DisplayPath: sourcePath, FingerprintKey: sourcePath,
+			}},
+		}
+	}
+	factoryB := changedPathPlanFactory{agent: "fallback-b", caps: caps}
+	factoryB.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+		return &changedPathPlanProvider{discoveries: &callsB}
+	}
+	engine := newChangedPathPlanEngine(t, map[parser.AgentType][]string{
+		factoryA.agent: {rootA}, factoryB.agent: {rootB},
+	}, factoryA, factoryB)
+	t.Cleanup(engine.Close)
+	plan := ChangedPathPlan{FallbackProviders: []parser.AgentType{factoryA.agent}}
+
+	result, err := engine.SyncChangedPathPlanContext(t.Context(), plan, nil)
+	require.Error(t, err, "the fake has no fingerprint implementation")
+	assert.Equal(t, 1, result.FilesDiscovered)
+	assert.Equal(t, 1, result.FilesProcessed)
+	assert.Equal(t, 1, result.Stats.Failed)
+	assert.Equal(t, 1, callsA)
+	assert.Zero(t, callsB)
+}
+
+func TestSyncChangedPathPlanRemoteForceReplacePreservesMissingOwnedMember(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	root := t.TempDir()
+	path, fingerprint := writeProcessProviderSource(t, root, "container.jsonl")
+	source := processFixtureSource(path)
+	provider := newProcessFixtureProvider(source, fingerprint, parser.ParseOutcome{
+		SkipReason:        parser.SkipNonInteractive,
+		ResultSetComplete: true,
+		ForceReplace:      true,
+	})
+	storedPath := "remote:" + path
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "cowork:missing", Agent: string(parser.AgentCowork),
+		Project: "fixture-project", Machine: "remote", FilePath: &storedPath,
+	}))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+		Machine:   "remote", Ephemeral: true,
+		ProviderFactories: []parser.ProviderFactory{processFixtureFactory{provider: provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+		},
+		PathRewriter: func(value string) string { return "remote:" + value },
+	})
+	t.Cleanup(engine.Close)
+	file := parser.DiscoveredFile{
+		Path: path, Agent: parser.AgentCowork,
+		ProviderSource: &source, ProviderProcess: true,
+	}
+
+	result, err := engine.SyncChangedPathPlanContext(t.Context(), ChangedPathPlan{
+		Files: []parser.DiscoveredFile{file},
+	}, nil)
+	require.NoError(t, err)
+	assert.Zero(t, result.Stats.Failed)
+	retained, err := database.GetSession(t.Context(), "cowork:missing")
+	require.NoError(t, err)
+	require.NotNil(t, retained)
+	assert.Nil(t, retained.DeletedAt)
+}
+
+func TestRemoteChangedPathWorkBoundedByPlannedSources(t *testing.T) {
+	run := func(t *testing.T, unrelatedRoots int) (
+		providerCalls, unrelatedDiscoveries, globalLinkPasses int,
+	) {
+		t.Helper()
+		database := dbtest.OpenTestDB(t)
+		root := t.TempDir()
+		path := filepath.Join(root, "planned.jsonl")
+		fingerprint := parser.SourceFingerprint{Key: path, Size: 7, MTimeNS: 42}
+		source := parser.SourceRef{
+			Provider: parser.AgentCowork, Key: path,
+			DisplayPath: path, FingerprintKey: path,
+		}
+		provider := newProcessFixtureProvider(source, fingerprint, parser.ParseOutcome{})
+		provider.Caps.Sync.SkipCacheFreshWithoutStoredRow = true
+		unrelatedAgent := parser.AgentType("unrelated-provider")
+		unrelatedFactory := changedPathPlanFactory{
+			agent: unrelatedAgent, caps: changedPathPlanCapabilities(),
+		}
+		unrelatedFactory.provider = func(parser.ProviderConfig) *changedPathPlanProvider {
+			return &changedPathPlanProvider{discoveries: &unrelatedDiscoveries}
+		}
+		roots := make([]string, 0, unrelatedRoots)
+		for i := range unrelatedRoots {
+			roots = append(roots, filepath.Join(root, "unrelated", fmt.Sprintf("%04d", i)))
+		}
+		engine := NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentCowork: {root}, unrelatedAgent: roots,
+			},
+			Machine: "remote", Ephemeral: true,
+			ProviderFactories: []parser.ProviderFactory{
+				processFixtureFactory{provider: provider}, unrelatedFactory,
+			},
+			ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+				unrelatedAgent:     parser.ProviderMigrationProviderAuthoritative,
+			},
+		})
+		t.Cleanup(engine.Close)
+		engine.skipCache[providerAgentSkipCacheKey(path, parser.AgentCowork)] =
+			fingerprint.MTimeNS
+		file := parser.DiscoveredFile{
+			Path: path, Agent: parser.AgentCowork,
+			ProviderSource: &source, ProviderProcess: true,
+		}
+		metrics := &reconciliationRuntimeMetrics{}
+		ctx := context.WithValue(
+			t.Context(), reconciliationMetricsContextKey{}, metrics,
+		)
+		result, err := engine.SyncChangedPathPlanContext(ctx, ChangedPathPlan{
+			Files: []parser.DiscoveredFile{file},
+		}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.FilesProcessed)
+		return len(provider.calls), unrelatedDiscoveries,
+			metrics.snapshot(ReconciliationMetrics{}).GlobalLinkPasses
+	}
+
+	var baselineCalls int
+	for _, cardinality := range []int{1, 1_000, 10_000} {
+		calls, unrelated, globalLinks := run(t, cardinality)
+		if cardinality == 1 {
+			baselineCalls = calls
+		}
+		assert.Equal(t, baselineCalls, calls)
+		assert.Zero(t, unrelated)
+		assert.Zero(t, globalLinks,
+			"bounded changed-path work must not invoke archive-wide linking")
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -388,6 +388,14 @@ type EngineConfig struct {
 	// Used by remote sync to replace temp paths with
 	// "host:/remote/path" references.
 	PathRewriter func(string) string
+	// StoredPathResolver maps a canonical stored source path back to its
+	// physical path under the current mirror. Remote changed-path planning uses
+	// it to make persisted source hints usable by mirror-local providers.
+	StoredPathResolver func(storedPath string) (physicalPath string, ok bool)
+	// InitialSkipCache seeds an ephemeral engine with caller-owned translated
+	// skip state. Rebuild contributors use it because their engine is created
+	// inside the atomic replacement workflow.
+	InitialSkipCache map[string]int64
 	// Ephemeral disables sync-state persistence (timestamps
 	// and skip cache) so remote sync does not interfere with
 	// local sync watermarks or pollute the skipped_files table
@@ -471,6 +479,7 @@ type Engine struct {
 	ephemeral              bool
 	idPrefix               string
 	pathRewriter           func(string) string
+	storedPathResolver     func(string) (string, bool)
 	emitter                Emitter
 	providerFactories      map[parser.AgentType]parser.ProviderFactory
 	providerMigrationModes map[parser.AgentType]parser.ProviderMigrationMode
@@ -520,11 +529,14 @@ type Engine struct {
 	) ([]db.SessionSourceAttribution, error)
 	// workerCountOverride is a test seam for exercising the production worker
 	// floor and cap independently of the host CPU count.
-	workerCountOverride  int
-	parseRetentionOnce   gosync.Once
-	parseRetentionBudget *parseRetentionBudget
-	bulkRetentionOnce    gosync.Once
-	bulkRetentionBudget  *parseRetentionBudget
+	workerCountOverride int
+	// claudeProjectSessionFiles is an observability seam for cardinality tests
+	// around duplicate-session discovery.
+	claudeProjectSessionFiles func(string) []parser.DiscoveredFile
+	parseRetentionOnce        gosync.Once
+	parseRetentionBudget      *parseRetentionBudget
+	bulkRetentionOnce         gosync.Once
+	bulkRetentionBudget       *parseRetentionBudget
 	// activeRetention points at the budget the in-flight pass admits parses
 	// through. Bulk archive passes (full sync, resync rebuild, remote import)
 	// install the unthrottled bulk budget for their duration; when nil,
@@ -537,6 +549,10 @@ type Engine struct {
 	// parse-diff fully re-parses every discovered file. Normal sync
 	// never sets it; behavior must be identical when false.
 	forceParse bool
+	// forceFullParse keeps explicit full-pass intent engine-wide. Full discovery
+	// also marks files ForceParse, but provider-specific paths must still bypass
+	// every freshness gate if that per-file bit is not carried forward.
+	forceFullParse bool
 
 	// phaseStats accumulates per-phase wall-clock time inside the bulk
 	// write path. Exposed via PhaseStats() so a CLI driver can log the
@@ -595,6 +611,14 @@ type Engine struct {
 	reconciliationMu           gosync.RWMutex
 	lastReconciliation         ReconciliationResult
 	reconciliationSpoolFactory func(string) (reconciliationSpoolStore, error)
+}
+
+// forceParseRequested centralizes the parse modes that must bypass every
+// source freshness gate and preserve every parsed result. forceFullParse is
+// engine-scoped because some provider paths do not retain the discovered
+// file's ForceParse bit through their full processing pipeline.
+func (e *Engine) forceParseRequested(file parser.DiscoveredFile) bool {
+	return e.forceParse || e.forceFullParse || file.ForceParse
 }
 
 // ReconciliationResult is the structured acknowledgement for the most recent
@@ -779,6 +803,7 @@ func NewEngine(
 		ephemeral:               cfg.Ephemeral,
 		idPrefix:                cfg.IDPrefix,
 		pathRewriter:            cfg.PathRewriter,
+		storedPathResolver:      cfg.StoredPathResolver,
 		emitter:                 cfg.Emitter,
 		providerFactories:       providerFactoryMap(providerFactories),
 		providerMigrationModes:  providerModes,
@@ -795,6 +820,10 @@ func NewEngine(
 		reconciliationSpoolFactory: func(path string) (reconciliationSpoolStore, error) {
 			return newReconciliationSpool(path)
 		},
+		claudeProjectSessionFiles: parser.ClaudeProjectSessionFiles,
+	}
+	if len(cfg.InitialSkipCache) > 0 {
+		e.InjectSkipCache(cfg.InitialSkipCache)
 	}
 	if !cfg.DeferStartupMaintenance {
 		e.ReleaseStartupMaintenance()
@@ -1597,7 +1626,10 @@ func (e *Engine) classifyPaths(
 			files = append(files, df)
 		}
 	}
-	files = e.expandClaudeDuplicateCandidates(files)
+	files, err := e.expandClaudeDuplicateCandidates(ctx, files)
+	if err != nil {
+		classificationErr = errors.Join(classificationErr, err)
+	}
 	files = dedupeDiscoveredFiles(files)
 	return e.dedupeClaudeDiscoveredFiles(files), classificationErr
 }
@@ -1906,7 +1938,17 @@ func (e *Engine) expandOmnigentInheritedMetadataSources(
 		}
 		paths = append(paths, machinePaths...)
 	}
-	for _, path := range paths {
+	for _, storedPath := range paths {
+		path := storedPath
+		if e.storedPathResolver != nil {
+			resolved, ok := e.storedPathResolver(storedPath)
+			if !ok {
+				return nil, errors.New(
+					"resolve omnigent stored descendant source path",
+				)
+			}
+			path = resolved
+		}
 		if _, exists := seenSources[path]; exists {
 			continue
 		}
@@ -2221,8 +2263,9 @@ func discoveredFileMTime(path string) (int64, bool) {
 }
 
 func (e *Engine) expandClaudeDuplicateCandidates(
+	ctx context.Context,
 	files []parser.DiscoveredFile,
-) []parser.DiscoveredFile {
+) ([]parser.DiscoveredFile, error) {
 	sessionIDs := make(map[string]struct{})
 	seen := make(map[string]struct{}, len(files))
 	for _, file := range files {
@@ -2237,12 +2280,22 @@ func (e *Engine) expandClaudeDuplicateCandidates(
 		sessionIDs[sessionID] = struct{}{}
 	}
 	if len(sessionIDs) == 0 {
-		return files
+		return files, nil
 	}
 
+	listSessionFiles := e.claudeProjectSessionFiles
+	if listSessionFiles == nil {
+		listSessionFiles = parser.ClaudeProjectSessionFiles
+	}
 	out := files
 	for _, claudeDir := range e.agentDirs[parser.AgentClaude] {
-		for _, candidate := range parser.ClaudeProjectSessionFiles(claudeDir) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for _, candidate := range listSessionFiles(claudeDir) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			sessionID := claudeSessionIDFromPath(candidate.Path)
 			if _, ok := sessionIDs[sessionID]; !ok {
 				continue
@@ -2255,7 +2308,7 @@ func (e *Engine) expandClaudeDuplicateCandidates(
 			out = append(out, candidate)
 		}
 	}
-	return out
+	return out, nil
 }
 
 func codexLayoutForPath(path string) parser.CodexLayout {
@@ -2518,7 +2571,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 	preBuildSkipHashKeys := e.skipHashKeys
 	e.skipMu.Unlock()
 
-	stats, err := e.resyncBuildLocked(ctx, onProgress, opts, ops)
+	stats, err := e.resyncBuildLocked(ctx, onProgress, opts, ops, ownedBarrier)
 	if err != nil || stats.Aborted {
 		return stats, err
 	}
@@ -2556,7 +2609,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 // guarantees the original receives no writes for the duration.
 func (e *Engine) resyncBuildLocked(
 	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
-	ops rebuildOperations,
+	ops rebuildOperations, restoreActiveWriterOnAbort bool,
 ) (stats SyncStats, retErr error) {
 	// Rebuild tombstones are committed only inside the replacement, and every
 	// aborted or failed build discards it. Hold them here and publish the
@@ -2842,6 +2895,7 @@ func (e *Engine) resyncBuildLocked(
 		contributorEngine := NewEngine(newDB, contributor.Config)
 		contributorEngine.archiveStore = origDB
 		contributorEngine.archiveStaleClaudeForks = archiveStaleForks
+		contributorEngine.forceFullParse = contributor.ForceParse
 		contributorProgress := func(p Progress) {
 			if contributor.Progress != nil {
 				p = contributor.Progress(p)
@@ -2853,7 +2907,7 @@ func (e *Engine) resyncBuildLocked(
 		}
 		contributorStats := contributorEngine.syncAllLocked(
 			ctx, contributorProgress, time.Time{}, nil,
-			syncWriteBulk, true, false,
+			syncWriteBulk, true, contributor.ForceParse,
 		)
 		contributorEngine.phaseStats.Log("resync contributor " + contributor.Name)
 		phase := phaseSnapshot(contributor.Name, &contributorEngine.phaseStats)
@@ -2871,11 +2925,27 @@ func (e *Engine) resyncBuildLocked(
 		if opts.includePhaseDiagnostics {
 			stats.RebuildPhases = append(stats.RebuildPhases, phase)
 		}
+		runAfterFailure := func() error {
+			if restoreActiveWriterOnAbort && origDB.WriterClosed() {
+				if err := origDB.ReopenWriter(); err != nil {
+					return fmt.Errorf(
+						"reopen active writer for contributor failure: %w", err,
+					)
+				}
+			}
+			if contributor.AfterFailure != nil {
+				return contributor.AfterFailure(contributorEngine, origDB)
+			}
+			return nil
+		}
 		if contributorStats.Aborted || stats.Aborted || ctx.Err() != nil ||
 			contributorSafetyAbort {
+			failureHookErr := runAfterFailure()
 			contributorEngine.Close()
 			if contributor.Finished != nil {
-				contributor.Finished(contributorStats, ctx.Err())
+				contributor.Finished(
+					contributorStats, errors.Join(ctx.Err(), failureHookErr),
+				)
 			}
 			newDB.Close()
 			removeTempDB(tempPath)
@@ -2891,13 +2961,20 @@ func (e *Engine) resyncBuildLocked(
 			if err := ctx.Err(); err != nil {
 				return stats, err
 			}
+			if failureHookErr != nil {
+				return stats, &RebuildContributorError{
+					Contributor: contributor.Name,
+					Err:         failureHookErr,
+				}
+			}
 			return stats, nil
 		}
 		if contributor.AfterSync != nil {
 			if err := contributor.AfterSync(contributorEngine, newDB); err != nil {
+				failureErr := errors.Join(err, runAfterFailure())
 				contributorEngine.Close()
 				if contributor.Finished != nil {
-					contributor.Finished(contributorStats, err)
+					contributor.Finished(contributorStats, failureErr)
 				}
 				newDB.Close()
 				removeTempDB(tempPath)
@@ -2912,7 +2989,7 @@ func (e *Engine) resyncBuildLocked(
 				e.mu.Unlock()
 				return stats, &RebuildContributorError{
 					Contributor: contributor.Name,
-					Err:         err,
+					Err:         failureErr,
 				}
 			}
 		}
@@ -3409,7 +3486,7 @@ func (e *Engine) ResyncBuild(
 	defer e.syncMu.Unlock()
 	defer e.clearCurrentProgress()
 	stats, err := e.resyncBuildLocked(
-		ctx, onProgress, RebuildOptions{}, productionRebuildOperations,
+		ctx, onProgress, RebuildOptions{}, productionRebuildOperations, false,
 	)
 	return e.ResyncTempPath(), stats, err
 }
@@ -3690,6 +3767,12 @@ type RebuildCleanup interface {
 	Close() error
 }
 
+// RebuildCommitter finalizes durable source state only after the replacement
+// archive has been installed successfully.
+type RebuildCommitter interface {
+	Commit() error
+}
+
 type rebuildCleanupError struct {
 	owner RebuildCleanup
 	err   error
@@ -3758,14 +3841,34 @@ func (e *Engine) SyncThenRunWithRebuild(
 		stats, err = e.resyncAllWithOptionsLocked(
 			ctx, onProgress, opts, productionRebuildOperations,
 		)
-		if rebuildDone != nil {
-			rebuildDone(stats, err)
-		}
 		if err != nil {
+			if rebuildDone != nil {
+				rebuildDone(stats, err)
+			}
 			return stats, err
 		}
 		if stats.Aborted {
+			if rebuildDone != nil {
+				rebuildDone(stats, nil)
+			}
 			return stats, nil
+		}
+		if err := ctx.Err(); err != nil {
+			if rebuildDone != nil {
+				rebuildDone(stats, err)
+			}
+			return stats, err
+		}
+		if committer, ok := cleanup.(RebuildCommitter); ok {
+			if err := committer.Commit(); err != nil {
+				if rebuildDone != nil {
+					rebuildDone(stats, err)
+				}
+				return stats, err
+			}
+		}
+		if rebuildDone != nil {
+			rebuildDone(stats, nil)
 		}
 	} else {
 		stats = e.syncAllLocked(
@@ -4071,10 +4174,26 @@ func (e *Engine) ApplyWorktreeProjectMappings(
 func (e *Engine) SyncAll(
 	ctx context.Context, onProgress ProgressFunc,
 ) (stats SyncStats) {
+	return e.syncAll(ctx, onProgress, false)
+}
+
+// SyncAllForceParse discovers all session files and forces each source through
+// parsing, bypassing both the skip cache and database freshness checks.
+func (e *Engine) SyncAllForceParse(
+	ctx context.Context, onProgress ProgressFunc,
+) (stats SyncStats) {
+	return e.syncAll(ctx, onProgress, true)
+}
+
+func (e *Engine) syncAll(
+	ctx context.Context, onProgress ProgressFunc, forceDiscoveredFiles bool,
+) (stats SyncStats) {
 	if e.refuseWriteInForceParse("SyncAll") {
 		return SyncStats{}
 	}
 	e.syncMu.Lock()
+	previousForceFullParse := e.forceFullParse
+	e.forceFullParse = forceDiscoveredFiles
 	defer e.notifyStartupReconciled()
 	// Defers run LIFO: Unlock runs before the emit closure so
 	// Emitter implementations cannot widen the syncMu critical
@@ -4085,10 +4204,12 @@ func (e *Engine) SyncAll(
 		}
 	}()
 	defer e.syncMu.Unlock()
+	defer func() { e.forceFullParse = previousForceFullParse }()
 	defer e.clearCurrentProgress()
 	defer func() { e.recordStartupReconciled(ctx, stats, ctx.Err()) }()
 	stats = e.syncAllLocked(
-		ctx, onProgress, time.Time{}, nil, syncWriteDefault, true, false,
+		ctx, onProgress, time.Time{}, nil, syncWriteDefault, true,
+		forceDiscoveredFiles,
 	)
 	return
 }
@@ -7989,6 +8110,7 @@ func (e *Engine) syncProviderDBBacked(
 			Source:      source,
 			Fingerprint: fingerprint,
 			Machine:     machine,
+			ForceParse:  e.forceParse || e.forceFullParse,
 		})
 		if err != nil {
 			log.Printf("sync %s parse: %v", agent, err)
@@ -8038,7 +8160,7 @@ func (e *Engine) providerDBBackedSourceFresh(
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
 ) bool {
-	if e.forceParse {
+	if e.forceParse || e.forceFullParse {
 		return false
 	}
 	if fingerprint.MTimeNS == 0 {
@@ -8302,6 +8424,24 @@ func (e *Engine) collectAndBatch(
 	results <-chan syncJob, total int, progressTotal int,
 	onProgress ProgressFunc,
 	writeMode syncWriteMode,
+) SyncStats {
+	return e.collectAndBatchWithOptions(
+		ctx, results, total, progressTotal, onProgress, writeMode,
+		collectAndBatchOptions{},
+	)
+}
+
+type collectAndBatchOptions struct {
+	preserveMissingSources bool
+	observeResult          func(syncJob)
+}
+
+func (e *Engine) collectAndBatchWithOptions(
+	ctx context.Context,
+	results <-chan syncJob, total int, progressTotal int,
+	onProgress ProgressFunc,
+	writeMode syncWriteMode,
+	options collectAndBatchOptions,
 ) SyncStats {
 	var stats SyncStats
 	stats.TotalSessions = total
@@ -8656,6 +8796,9 @@ func (e *Engine) collectAndBatch(
 			}
 			break
 		}
+		if options.observeResult != nil {
+			options.observeResult(r)
+		}
 
 		if r.err != nil {
 			// Workers emit ctx.Err() for files skipped
@@ -8783,7 +8926,7 @@ func (e *Engine) collectAndBatch(
 		// unchanged survivors are dropped from r.results before this
 		// point, so the source-wide gate would freeze an allowed
 		// member's deletion whenever everything else was unchanged.
-		if len(r.sourceMissingMembers) > 0 {
+		if len(r.sourceMissingMembers) > 0 && !options.preserveMissingSources {
 			tombstoned, deferred, tombstoneErr := e.reconcileSourceMissingMembers(
 				ctx, r.agent, r.sourceMissingMembers,
 				baselineExactOwnership, rejectExactOwnership,
@@ -9331,6 +9474,10 @@ type processResult struct {
 	// to every result in the source. Per-result retry state stays in
 	// retrySessionIDs so one member cannot demote otherwise valid siblings.
 	providerWideFailureCount int
+	// cachedSkip distinguishes a direct mtime skip-cache hit from other skip
+	// decisions such as DB freshness or container trust. Remote journal replay
+	// uses only this signal for error-suppression telemetry.
+	cachedSkip bool
 	// storageTrustPath/State/Snap carry an OpenCode-family storage
 	// session's pre-parse stat signature and invalidation snapshot to
 	// the write path, which promotes it once the session's batch is
@@ -9404,15 +9551,16 @@ func (e *Engine) processFile(
 
 	// Skip files cached from a previous sync whose mtime and source
 	// fingerprint are unchanged.
-	if cacheSkip && !e.forceParse && !file.ForceParse { // parse-diff: ignore the skip cache
+	if cacheSkip && !e.forceParseRequested(file) {
 		if e.shouldUseCachedSkip(file, mtime, sourceFingerprint) {
 			if e.pathNeedsCachedSkipBypass(file.Agent, file.Path) {
 				e.clearSkip(file.Path)
 			} else {
 				return processResult{
-					skip:      true,
-					mtime:     mtime,
-					cacheSkip: true,
+					skip:       true,
+					mtime:      mtime,
+					cacheSkip:  true,
+					cachedSkip: true,
 				}
 			}
 		}
@@ -9740,7 +9888,7 @@ func (e *Engine) processProviderFile(
 		file, source, fingerprint, providerSemantics,
 	)
 	cacheSkip := e.shouldCacheSkip(file)
-	if cacheSkip && !e.forceParse && !file.ForceParse {
+	if cacheSkip && !e.forceParseRequested(file) {
 		e.skipMu.RLock()
 		cachedMtime, cached := e.skipCache[cacheKey]
 		e.skipMu.RUnlock()
@@ -9822,10 +9970,11 @@ func (e *Engine) processProviderFile(
 						)
 					}
 					return processResult{
-						skip:      true,
-						mtime:     fingerprint.MTimeNS,
-						cacheSkip: true,
-						cacheKey:  cacheKey,
+						skip:       true,
+						mtime:      fingerprint.MTimeNS,
+						cacheSkip:  true,
+						cachedSkip: true,
+						cacheKey:   cacheKey,
 					}, true
 				}
 				// A commit raced cache validation and tracker restoration.
@@ -9861,7 +10010,11 @@ func (e *Engine) processProviderFile(
 		}
 		return incRes, true
 	}
-	incForceReplace := sourceForceReplace || incRes.forceReplace
+	// An explicit full pass must replace the stored message stream after
+	// bypassing incremental append. Otherwise a complete parse can still be
+	// written with append semantics and leave stale earlier rows untouched.
+	incForceReplace := sourceForceReplace || incRes.forceReplace ||
+		e.forceFullParse
 
 	// DB-stored fingerprint skip. The provider has no database handle, so the
 	// engine reproduces the legacy DB-aware skip that single-session JSONL
@@ -9871,7 +10024,7 @@ func (e *Engine) processProviderFile(
 	// engine). For Codex this also folds in the session_index.jsonl sidecar:
 	// a shared index mtime bump that did not change this session's title must
 	// not trigger a reparse.
-	if !incForceReplace && !e.forceParse && !file.ForceParse {
+	if !incForceReplace && !e.forceParseRequested(file) {
 		dbFresh, metadataVerified := e.providerSourceFreshnessByDB(
 			file, fingerprint, providerSemantics,
 		)
@@ -9911,7 +10064,7 @@ func (e *Engine) processProviderFile(
 	// a provider whose fingerprint mtime differs from the stored value simply
 	// reparses, matching the prior behavior. Claude and Cowork have their own
 	// earlier freshness checks; this is the generic fallback for the rest.
-	if !incForceReplace && !e.forceParse && !file.ForceParse &&
+	if !incForceReplace && !e.forceParseRequested(file) &&
 		e.providerSourceUnchangedInDB(
 			ctx, source, fingerprint, providerSemantics, preParseStatHash,
 		) {
@@ -9940,7 +10093,7 @@ func (e *Engine) processProviderFile(
 		Source:      source,
 		Fingerprint: fingerprint,
 		Machine:     machine,
-		ForceParse:  e.forceParse || file.ForceParse,
+		ForceParse:  e.forceParseRequested(file),
 	})
 	if err != nil {
 		return processResult{
@@ -9998,7 +10151,7 @@ func (e *Engine) processProviderFile(
 			omnigentContainerExists :=
 				parser.IsOmnigentContainerSource(source) &&
 					parser.IsRegularFile(providerDiscoveredPath(source))
-			if e.pathRewriter == nil &&
+			if e.pathRewriter != nil ||
 				(providerVirtualSourceContainerExists(file.Path) ||
 					omnigentContainerExists) {
 				// The provider re-resolved this exact virtual member against a
@@ -10096,7 +10249,7 @@ func (e *Engine) processProviderFile(
 		providerStatHash:         preParseStatHash,
 	}
 	if file.Agent == parser.AgentOmnigent && cacheSkip && cleanCache &&
-		!e.forceParse && !file.ForceParse &&
+		!e.forceParseRequested(file) &&
 		outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 &&
 		fingerprint.Hash != "" {
 		// A whole-container omnigent parse may only be skip-cached after its
@@ -10119,7 +10272,7 @@ func (e *Engine) processProviderFile(
 			res.providerFailureCount++
 		}
 	}
-	if e.forceParse || file.ForceParse {
+	if e.forceParseRequested(file) {
 		for _, sourceErr := range outcome.SourceErrors {
 			res.sessionErrs = append(res.sessionErrs, sessionParseError{
 				sessionID:   sourceErr.SessionID,
@@ -10158,7 +10311,7 @@ func (e *Engine) dropUnchangedSharedSQLiteResults(
 	results []parser.ParseResult,
 	policy parser.UnchangedResultPolicy,
 ) []parser.ParseResult {
-	if e.forceParse || file.ForceParse || len(results) == 0 {
+	if e.forceParseRequested(file) || len(results) == 0 {
 		return results
 	}
 	if policy == parser.UnchangedResultNone {
@@ -10906,7 +11059,7 @@ func (e *Engine) providerSourceForDiscoveredFile(
 	return provider.FindSource(ctx, parser.FindSourceRequest{
 		StoredFilePath:     file.Path,
 		FingerprintKey:     file.Path,
-		RequireFreshSource: !e.forceParse && !file.ForceParse,
+		RequireFreshSource: !e.forceParseRequested(file),
 	})
 }
 
@@ -11072,7 +11225,7 @@ func (e *Engine) shouldSkipProviderSource(
 	if !providerSourceSupportsPersistedFreshness(agent) {
 		return false
 	}
-	if e.forceParse || file.ForceParse {
+	if e.forceParseRequested(file) {
 		return false
 	}
 	lookupPath := providerSkipLookupPath(file, source, fingerprint)
@@ -11630,7 +11783,7 @@ func (e *Engine) providerSourceHashFreshDespiteStat(
 func (e *Engine) shouldSkipByPath(
 	path string, info os.FileInfo,
 ) bool {
-	if e.forceParse { // parse-diff: always re-parse
+	if e.forceParse || e.forceFullParse {
 		return false
 	}
 	lookupPath := path
@@ -11691,7 +11844,7 @@ func (e *Engine) providerSingleSessionFresh(
 	// cache) must not defeat the DB-freshness skip: an unchanged session
 	// is still skipped so a single-session resync does not, for example,
 	// reapply a worktree project mapping to a file that has not changed.
-	if e.forceParse {
+	if e.forceParse || e.forceFullParse {
 		return 0, false, false, false
 	}
 	// Claude is the single-physical-file provider that takes the
@@ -11949,7 +12102,7 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 	file parser.DiscoveredFile,
 	preParseStatHash *pendingProviderStatHash,
 ) (int64, bool) {
-	if e.forceParse || file.ForceParse {
+	if e.forceParseRequested(file) {
 		return 0, false
 	}
 	path := providerDiscoveredPath(source)
@@ -12235,12 +12388,12 @@ func (e *Engine) tryProviderIncrementalAppend(
 	file parser.DiscoveredFile,
 	fingerprint parser.SourceFingerprint,
 ) (processResult, bool) {
-	// Match the legacy tryIncrementalJSONL gate, which suppressed append
-	// deltas only under the engine-wide forceParse (parse-diff) flag. A
-	// per-file ForceParse keeps Claude on its incremental path; Codex is the
+	// Match the shared tryIncrementalJSONL gate: parse-diff and an explicit
+	// full import both require a complete replacement rather than an append.
+	// A per-file ForceParse keeps Claude on its incremental path; Codex is the
 	// explicit exception below because a single-session refresh must rebuild
 	// head-derived metadata.
-	if e.forceParse {
+	if e.forceParse || e.forceFullParse {
 		return processResult{}, false
 	}
 	if provider.Capabilities().Source.IncrementalAppend !=
@@ -12355,7 +12508,8 @@ func (e *Engine) tryIncrementalJSONL(
 	agent parser.AgentType,
 	parseFn incrementalParseFunc,
 ) (processResult, bool) {
-	if e.forceParse { // parse-diff: never produce append deltas
+	if e.forceParse || e.forceFullParse {
+		// Parse-diff and explicit full imports never produce append deltas.
 		return processResult{}, false
 	}
 	lookupPath := file.Path
@@ -12415,10 +12569,17 @@ func (e *Engine) tryIncrementalJSONL(
 		}
 	}
 	if currentSize < inc.FileSize {
-		log.Printf(
-			"incremental %s %s: file truncated from %d to %d, full parse",
-			agent, file.Path, inc.FileSize, currentSize,
-		)
+		if e.pathRewriter != nil {
+			log.Printf(
+				"incremental %s remote source: file truncated from %d to %d, full parse",
+				agent, inc.FileSize, currentSize,
+			)
+		} else {
+			log.Printf(
+				"incremental %s %s: file truncated from %d to %d, full parse",
+				agent, file.Path, inc.FileSize, currentSize,
+			)
+		}
 		return processResult{forceReplace: true}, false
 	}
 	if currentSize == inc.FileSize {
@@ -12903,7 +13064,7 @@ func (e *Engine) classifyCodexIndexPath(
 		// A UUID can exist in both sessions/ and archived_sessions/.
 		// Prefer the path the DB already tracks so a title rename does
 		// not reparse a stale duplicate over the stored copy.
-		chosen := pickPreferredCodexDiscoveredFile(e.db, candidates)
+		chosen := e.pickPreferredCodexIndexDiscoveredFile(candidates)
 		// Pin the provider source to the chosen path and route it through the
 		// provider so processProviderFile parses exactly this copy instead of
 		// re-canonicalizing the UUID to the preferred dated layout, which would
@@ -12915,6 +13076,30 @@ func (e *Engine) classifyCodexIndexPath(
 		out = append(out, chosen)
 	}
 	return out
+}
+
+func (e *Engine) pickPreferredCodexIndexDiscoveredFile(
+	candidates []parser.DiscoveredFile,
+) parser.DiscoveredFile {
+	if len(candidates) > 0 {
+		uuid := ""
+		for _, candidate := range candidates {
+			uuid = parser.CodexSessionUUIDFromFilename(filepath.Base(candidate.Path))
+			if uuid != "" {
+				break
+			}
+		}
+		storedPath := e.db.GetSessionFilePath(e.idPrefix + "codex:" + uuid)
+		if uuid != "" && storedPath != "" {
+			storedPath = filepath.Clean(storedPath)
+			for _, candidate := range candidates {
+				if filepath.Clean(e.effectiveSourcePath(candidate.Path)) == storedPath {
+					return candidate
+				}
+			}
+		}
+	}
+	return pickPreferredCodexDiscoveredFile(e.db, candidates)
 }
 
 // codexSourceFileForUUID resolves a Codex session UUID to its on-disk

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -618,7 +618,8 @@ type Engine struct {
 // engine-scoped because some provider paths do not retain the discovered
 // file's ForceParse bit through their full processing pipeline.
 func (e *Engine) forceParseRequested(file parser.DiscoveredFile) bool {
-	return e.forceParse || e.forceFullParse || file.ForceParse
+	return e.forceParse || e.forceFullParse || file.ForceParse ||
+		file.ForceFullParse
 }
 
 // ReconciliationResult is the structured acknowledgement for the most recent
@@ -1639,6 +1640,7 @@ func mergeChangedPathDiscoveredFile(
 	next parser.DiscoveredFile,
 ) parser.DiscoveredFile {
 	current.ForceParse = current.ForceParse || next.ForceParse
+	current.ForceFullParse = current.ForceFullParse || next.ForceFullParse
 	current.ProviderProcess = current.ProviderProcess || next.ProviderProcess
 	if current.Project == "" {
 		current.Project = next.Project
@@ -10014,7 +10016,7 @@ func (e *Engine) processProviderFile(
 	// bypassing incremental append. Otherwise a complete parse can still be
 	// written with append semantics and leave stale earlier rows untouched.
 	incForceReplace := sourceForceReplace || incRes.forceReplace ||
-		e.forceFullParse
+		e.forceFullParse || file.ForceFullParse
 
 	// DB-stored fingerprint skip. The provider has no database handle, so the
 	// engine reproduces the legacy DB-aware skip that single-session JSONL
@@ -11844,7 +11846,7 @@ func (e *Engine) providerSingleSessionFresh(
 	// cache) must not defeat the DB-freshness skip: an unchanged session
 	// is still skipped so a single-session resync does not, for example,
 	// reapply a worktree project mapping to a file that has not changed.
-	if e.forceParse || e.forceFullParse {
+	if e.forceParse || e.forceFullParse || file.ForceFullParse {
 		return 0, false, false, false
 	}
 	// Claude is the single-physical-file provider that takes the
@@ -12393,7 +12395,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 	// A per-file ForceParse keeps Claude on its incremental path; Codex is the
 	// explicit exception below because a single-session refresh must rebuild
 	// head-derived metadata.
-	if e.forceParse || e.forceFullParse {
+	if e.forceParse || e.forceFullParse || file.ForceFullParse {
 		return processResult{}, false
 	}
 	if provider.Capabilities().Source.IncrementalAppend !=
@@ -12508,7 +12510,7 @@ func (e *Engine) tryIncrementalJSONL(
 	agent parser.AgentType,
 	parseFn incrementalParseFunc,
 ) (processResult, bool) {
-	if e.forceParse || e.forceFullParse {
+	if e.forceParse || e.forceFullParse || file.ForceFullParse {
 		// Parse-diff and explicit full imports never produce append deltas.
 		return processResult{}, false
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -467,6 +467,11 @@ type Engine struct {
 	skipMu           gosync.RWMutex
 	skipCache        map[string]int64
 	skipFingerprints map[string]string
+	// retryUnsafeSkipPaths records sources whose successful processing changed
+	// exclusion or source-missing state in the current database. A rebuild that
+	// later fails discards those database changes, so its skip entries cannot be
+	// carried into the next attempt.
+	retryUnsafeSkipPaths map[string]struct{}
 	// skipHashKeys maps a source base path to its one current
 	// ?source_hash= cache key. It is built once when the cache loads so a
 	// watcher mutation never scans unrelated archive entries.
@@ -8853,6 +8858,9 @@ func (e *Engine) collectAndBatchWithOptions(
 			r.releaseRetention()
 			continue
 		}
+		if len(r.excludedSessionIDs) > 0 || len(r.sourceMissingMembers) > 0 {
+			e.markRetryUnsafeSkipSource(r.path)
+		}
 		for range r.providerFailureCount {
 			stats.RecordFailed()
 		}
@@ -11617,6 +11625,36 @@ func (e *Engine) SnapshotSkipCache() map[string]int64 {
 	out := make(map[string]int64, len(e.skipCache))
 	maps.Copy(out, e.skipCache)
 	return out
+}
+
+// SnapshotRetrySafeSkipCache returns cache state that can survive a failed
+// replacement-database rebuild. Entries for sources that changed exclusion or
+// source-missing state are omitted because those changes exist only in the
+// replacement database that will be discarded.
+func (e *Engine) SnapshotRetrySafeSkipCache() map[string]int64 {
+	e.skipMu.RLock()
+	defer e.skipMu.RUnlock()
+	out := make(map[string]int64, len(e.skipCache))
+	for key, mtime := range e.skipCache {
+		path, _ := SplitProviderSkipCachePath(key)
+		if _, unsafe := e.retryUnsafeSkipPaths[path]; unsafe {
+			continue
+		}
+		out[key] = mtime
+	}
+	return out
+}
+
+func (e *Engine) markRetryUnsafeSkipSource(path string) {
+	if path == "" {
+		return
+	}
+	e.skipMu.Lock()
+	if e.retryUnsafeSkipPaths == nil {
+		e.retryUnsafeSkipPaths = make(map[string]struct{})
+	}
+	e.retryUnsafeSkipPaths[path] = struct{}{}
+	e.skipMu.Unlock()
 }
 
 // persistSkipCache writes the in-memory skip cache to the

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -553,6 +553,11 @@ type Engine struct {
 	// also marks files ForceParse, but provider-specific paths must still bypass
 	// every freshness gate if that per-file bit is not carried forward.
 	forceFullParse bool
+	// forceFullParseAllowsCache retains the complete-parse requirement while
+	// allowing a durable error-skip entry to prove that a source was already
+	// attempted. Remote journal replay uses this after cache invalidation was
+	// durably consumed.
+	forceFullParseAllowsCache bool
 
 	// phaseStats accumulates per-phase wall-clock time inside the bulk
 	// write path. Exposed via PhaseStats() so a CLI driver can log the
@@ -613,13 +618,18 @@ type Engine struct {
 	reconciliationSpoolFactory func(string) (reconciliationSpoolStore, error)
 }
 
-// forceParseRequested centralizes the parse modes that must bypass every
-// source freshness gate and preserve every parsed result. forceFullParse is
-// engine-scoped because some provider paths do not retain the discovered
-// file's ForceParse bit through their full processing pipeline.
+// forceParseRequested centralizes the parse modes that require complete source
+// processing and preserve every parsed result. The separate cache predicate
+// lets remote replay suppress sources whose post-invalidation attempt is
+// already durable.
 func (e *Engine) forceParseRequested(file parser.DiscoveredFile) bool {
 	return e.forceParse || e.forceFullParse || file.ForceParse ||
 		file.ForceFullParse
+}
+
+func (e *Engine) forceParseBypassesCache(file parser.DiscoveredFile) bool {
+	return e.forceParse || file.ForceParse ||
+		(e.forceFullParse && !e.forceFullParseAllowsCache)
 }
 
 // ReconciliationResult is the structured acknowledgement for the most recent
@@ -2897,7 +2907,10 @@ func (e *Engine) resyncBuildLocked(
 		contributorEngine := NewEngine(newDB, contributor.Config)
 		contributorEngine.archiveStore = origDB
 		contributorEngine.archiveStaleClaudeForks = archiveStaleForks
-		contributorEngine.forceFullParse = contributor.ForceParse
+		contributorEngine.forceFullParse = contributor.ForceParse ||
+			contributor.ForceFullParseAfterCache
+		contributorEngine.forceFullParseAllowsCache =
+			contributor.ForceFullParseAfterCache && !contributor.ForceParse
 		contributorProgress := func(p Progress) {
 			if contributor.Progress != nil {
 				p = contributor.Progress(p)
@@ -4176,7 +4189,7 @@ func (e *Engine) ApplyWorktreeProjectMappings(
 func (e *Engine) SyncAll(
 	ctx context.Context, onProgress ProgressFunc,
 ) (stats SyncStats) {
-	return e.syncAll(ctx, onProgress, false)
+	return e.syncAll(ctx, onProgress, false, false)
 }
 
 // SyncAllForceParse discovers all session files and forces each source through
@@ -4184,18 +4197,34 @@ func (e *Engine) SyncAll(
 func (e *Engine) SyncAllForceParse(
 	ctx context.Context, onProgress ProgressFunc,
 ) (stats SyncStats) {
-	return e.syncAll(ctx, onProgress, true)
+	return e.syncAll(ctx, onProgress, true, false)
+}
+
+// SyncAllForceParseAfterCache requires a complete parse for each source that
+// does not have a durable skip-cache entry. It is the replay form of a remote
+// full import: sources not reached by an interrupted attempt still parse in
+// full, while deterministic failures already recorded by that attempt remain
+// suppressed.
+func (e *Engine) SyncAllForceParseAfterCache(
+	ctx context.Context, onProgress ProgressFunc,
+) (stats SyncStats) {
+	return e.syncAll(ctx, onProgress, true, true)
 }
 
 func (e *Engine) syncAll(
-	ctx context.Context, onProgress ProgressFunc, forceDiscoveredFiles bool,
+	ctx context.Context,
+	onProgress ProgressFunc,
+	forceFullParse bool,
+	allowCachedFailures bool,
 ) (stats SyncStats) {
 	if e.refuseWriteInForceParse("SyncAll") {
 		return SyncStats{}
 	}
 	e.syncMu.Lock()
 	previousForceFullParse := e.forceFullParse
-	e.forceFullParse = forceDiscoveredFiles
+	previousForceFullParseAllowsCache := e.forceFullParseAllowsCache
+	e.forceFullParse = forceFullParse
+	e.forceFullParseAllowsCache = allowCachedFailures
 	defer e.notifyStartupReconciled()
 	// Defers run LIFO: Unlock runs before the emit closure so
 	// Emitter implementations cannot widen the syncMu critical
@@ -4206,12 +4235,15 @@ func (e *Engine) syncAll(
 		}
 	}()
 	defer e.syncMu.Unlock()
-	defer func() { e.forceFullParse = previousForceFullParse }()
+	defer func() {
+		e.forceFullParse = previousForceFullParse
+		e.forceFullParseAllowsCache = previousForceFullParseAllowsCache
+	}()
 	defer e.clearCurrentProgress()
 	defer func() { e.recordStartupReconciled(ctx, stats, ctx.Err()) }()
 	stats = e.syncAllLocked(
 		ctx, onProgress, time.Time{}, nil, syncWriteDefault, true,
-		forceDiscoveredFiles,
+		forceFullParse && !allowCachedFailures,
 	)
 	return
 }
@@ -9553,7 +9585,7 @@ func (e *Engine) processFile(
 
 	// Skip files cached from a previous sync whose mtime and source
 	// fingerprint are unchanged.
-	if cacheSkip && !e.forceParseRequested(file) {
+	if cacheSkip && !e.forceParseBypassesCache(file) {
 		if e.shouldUseCachedSkip(file, mtime, sourceFingerprint) {
 			if e.pathNeedsCachedSkipBypass(file.Agent, file.Path) {
 				e.clearSkip(file.Path)
@@ -9708,7 +9740,7 @@ func (e *Engine) processProviderFile(
 		// legacy deleted-source handling: complete the source as an empty
 		// force-replace so the engine retires every session that lived in the
 		// removed database instead of failing the sync.
-		if file.ForceParse &&
+		if (file.ForceParse || file.ForceFullParse) &&
 			providerDeletedPhysicalSQLiteSource(file.Agent, file.Path) {
 			return processResult{forceReplace: true}, true
 		}
@@ -9866,7 +9898,7 @@ func (e *Engine) processProviderFile(
 
 	fingerprint, err := provider.Fingerprint(ctx, source)
 	if err != nil {
-		if file.ForceParse &&
+		if (file.ForceParse || file.ForceFullParse) &&
 			providerDeletedPhysicalSQLiteSource(file.Agent, file.Path) &&
 			errors.Is(err, os.ErrNotExist) {
 			excludedSessionIDs, ownershipErr :=
@@ -9890,7 +9922,7 @@ func (e *Engine) processProviderFile(
 		file, source, fingerprint, providerSemantics,
 	)
 	cacheSkip := e.shouldCacheSkip(file)
-	if cacheSkip && !e.forceParseRequested(file) {
+	if cacheSkip && !e.forceParseBypassesCache(file) {
 		e.skipMu.RLock()
 		cachedMtime, cached := e.skipCache[cacheKey]
 		e.skipMu.RUnlock()
@@ -10181,8 +10213,8 @@ func (e *Engine) processProviderFile(
 			providerFailureCount:     providerFailureCount,
 			providerWideFailureCount: providerWideFailureCount,
 		}
-		if file.Agent == parser.AgentClaude && cleanCache && !e.forceParse &&
-			!file.ForceParse {
+		if file.Agent == parser.AgentClaude && cleanCache &&
+			!e.forceParseRequested(file) {
 			skipRes.claudeRowlessFreshnessKey =
 				e.claudeRowlessFreshnessCacheKey(file.Path, fingerprint.Hash)
 		}
@@ -10284,8 +10316,8 @@ func (e *Engine) processProviderFile(
 		}
 	}
 	e.applyProviderFilePathPolicies(ctx, provider, file.Agent, file.Path, &res)
-	if file.Agent == parser.AgentClaude && cleanCache && !e.forceParse &&
-		!file.ForceParse {
+	if file.Agent == parser.AgentClaude && cleanCache &&
+		!e.forceParseRequested(file) {
 		res.claudeRowlessFreshnessKey =
 			e.claudeRowlessFreshnessCacheKey(file.Path, fingerprint.Hash)
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -3335,7 +3335,10 @@ func TestResyncContributorFailureLeavesArchiveUnchanged(t *testing.T) {
 	dbtest.WriteTestFile(t, remotePath, []byte(testjsonl.NewSessionBuilder().
 		AddClaudeUser(tsEarlyS5, "partial remote message").String()))
 
-	sentinel := errors.New("after sync failed")
+	afterSyncErr := errors.New("after sync failed")
+	afterFailureErr := errors.New("after failure failed")
+	var failureDB *db.DB
+	var failureWriterClosed bool
 	stats, err := env.engine.ResyncAllWithOptions(context.Background(), nil,
 		sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
 			Name: "broken-remote",
@@ -3345,16 +3348,33 @@ func TestResyncContributorFailureLeavesArchiveUnchanged(t *testing.T) {
 				IDPrefix:  "broken~",
 				Ephemeral: true,
 			},
-			AfterSync: func(*sync.Engine, *db.DB) error { return sentinel },
+			AfterSync: func(*sync.Engine, *db.DB) error { return afterSyncErr },
+			AfterFailure: func(_ *sync.Engine, activeDB *db.DB) error {
+				failureDB = activeDB
+				failureWriterClosed = activeDB.WriterClosed()
+				if persistErr := activeDB.ReplaceRemoteSkippedFiles(
+					"broken-remote", map[string]int64{"retry.jsonl": 42},
+				); persistErr != nil {
+					return errors.Join(afterFailureErr, persistErr)
+				}
+				return afterFailureErr
+			},
 		}}})
 	require.Error(t, err)
 	assert.True(t, stats.Aborted)
 	var contributorErr *sync.RebuildContributorError
 	require.True(t, errors.As(err, &contributorErr))
 	assert.Equal(t, "broken-remote", contributorErr.Contributor)
-	assert.ErrorIs(t, err, sentinel)
+	assert.ErrorIs(t, err, afterSyncErr)
+	assert.ErrorIs(t, err, afterFailureErr)
 	assert.Contains(t, stats.Warnings,
 		`resync contributor "broken-remote" failed: after sync failed`)
+	assert.Same(t, env.db, failureDB)
+	assert.False(t, failureWriterClosed,
+		"AfterFailure must receive a writable active archive")
+	retryState, loadErr := env.db.LoadRemoteSkippedFiles("broken-remote")
+	require.NoError(t, loadErr)
+	assert.Equal(t, map[string]int64{"retry.jsonl": 42}, retryState)
 
 	oldSession, getErr := env.db.GetSession(context.Background(), "old-session")
 	require.NoError(t, getErr)
@@ -4372,6 +4392,37 @@ func TestSyncAllDedupesClaudeSourcesBySessionID(t *testing.T) {
 		Synced:        0,
 		Skipped:       1,
 	})
+}
+
+func TestSyncChangedPathFallbackDedupesClaudeSourcesBySessionID(t *testing.T) {
+	liveDir := t.TempDir()
+	archiveDir := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{liveDir, archiveDir}))
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "same logical fallback session").
+		String()
+	livePath := env.writeSession(
+		t, liveDir, filepath.Join("proj-live", "fallback-duplicate.jsonl"), content,
+	)
+	archivePath := env.writeSession(
+		t, archiveDir, filepath.Join("proj-archive", "fallback-duplicate.jsonl"), content,
+	)
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, older, older))
+	require.NoError(t, os.Chtimes(livePath, newer, newer))
+
+	result, err := env.engine.SyncChangedPathPlanContext(
+		t.Context(), sync.ChangedPathPlan{
+			FallbackProviders: []parser.AgentType{parser.AgentClaude},
+		}, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesDiscovered)
+	assert.Equal(t, 1, result.FilesProcessed)
+	assert.Equal(t, 1, result.Stats.Synced)
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("fallback-duplicate"))
 }
 
 func TestSyncAllClaudeDuplicateLiveGrowthBeatsUnchangedStoredArchive(t *testing.T) {
@@ -14952,6 +15003,151 @@ func TestSyncSingleSessionIncrementalAppendLinksSpawnedChild(t *testing.T) {
 	assert.Equal(t, "agent-orch", parentSessionIDOf(t, env, "agent-kid"),
 		"an incrementally appended spawn edge must re-link the child in "+
 			"the same single-session sync")
+}
+
+func TestSyncChangedPathPlanIncrementalAppendLinksSpawnedChild(t *testing.T) {
+	env := setupTestEnv(t)
+	env.writeClaudeSession(
+		t, "changed-path-link", "main-changed-path.jsonl",
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T09:00:00Z","uuid":"m1","message":{"content":"root"},"cwd":"/tmp","sessionId":"main-changed-path"}`,
+		),
+	)
+	orchestratorPath := env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"changed-path-link", "main-changed-path", "subagents",
+			"agent-orchestrator.jsonl",
+		),
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"o1","message":{"content":"orchestrate"},"cwd":"/tmp","sessionId":"main-changed-path"}`,
+		),
+	)
+	env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"changed-path-link", "main-changed-path", "subagents",
+			"agent-child.jsonl",
+		),
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T10:30:00Z","uuid":"c1","message":{"content":"child work"},"cwd":"/tmp","sessionId":"main-changed-path"}`,
+		),
+	)
+	require.Equal(t, 3, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.Equal(t, "main-changed-path",
+		parentSessionIDOf(t, env, "agent-child"))
+
+	var firstMessageID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id FROM messages
+		WHERE session_id = ? AND ordinal = 0`,
+		"agent-orchestrator",
+	).Scan(&firstMessageID))
+
+	file, err := os.OpenFile(orchestratorPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, writeErr := file.WriteString(testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:31:00Z","uuid":"o2","parentUuid":"o1","message":{"id":"msg_orchestrator","content":[{"type":"tool_use","id":"toolu_changed_path","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:32:00Z","uuid":"o3","parentUuid":"o2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_changed_path","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"child"}}`,
+	) + "\n")
+	require.NoError(t, file.Close())
+	require.NoError(t, writeErr)
+
+	plan, err := env.engine.PlanChangedPathsContext(
+		t.Context(), []string{orchestratorPath},
+	)
+	require.NoError(t, err)
+	result, err := env.engine.SyncChangedPathPlanContext(t.Context(), plan, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Stats.Synced)
+
+	var gotFirstMessageID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id FROM messages
+		WHERE session_id = ? AND ordinal = 0`,
+		"agent-orchestrator",
+	).Scan(&gotFirstMessageID))
+	assert.Equal(t, firstMessageID, gotFirstMessageID,
+		"the changed-path update must stay on the incremental append path")
+	assert.Equal(t, "agent-orchestrator",
+		parentSessionIDOf(t, env, "agent-child"),
+		"bounded changed-path sync must link children spawned by an append")
+}
+
+func TestSyncChangedPathPlanLinkFailureQueuesDurableRepair(t *testing.T) {
+	env := setupTestEnv(t)
+	env.writeClaudeSession(
+		t, "changed-path-link-retry", "main-changed-path-retry.jsonl",
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T09:00:00Z","uuid":"m1","message":{"content":"root"},"cwd":"/tmp","sessionId":"main-changed-path-retry"}`,
+		),
+	)
+	orchestratorPath := env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"changed-path-link-retry", "main-changed-path-retry", "subagents",
+			"agent-orchestrator-retry.jsonl",
+		),
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"o1","message":{"content":"orchestrate"},"cwd":"/tmp","sessionId":"main-changed-path-retry"}`,
+		),
+	)
+	env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"changed-path-link-retry", "main-changed-path-retry", "subagents",
+			"agent-child-retry.jsonl",
+		),
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T10:30:00Z","uuid":"c1","message":{"content":"child work"},"cwd":"/tmp","sessionId":"main-changed-path-retry"}`,
+		),
+	)
+	require.Equal(t, 3, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.Equal(t, "main-changed-path-retry",
+		parentSessionIDOf(t, env, "agent-child-retry"))
+
+	file, err := os.OpenFile(orchestratorPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, writeErr := file.WriteString(testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:31:00Z","uuid":"o2","parentUuid":"o1","message":{"id":"msg_orchestrator","content":[{"type":"tool_use","id":"toolu_changed_path_retry","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:32:00Z","uuid":"o3","parentUuid":"o2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_changed_path_retry","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"child-retry"}}`,
+	) + "\n")
+	require.NoError(t, file.Close())
+	require.NoError(t, writeErr)
+
+	raw, err := sql.Open("sqlite3", env.db.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`
+		CREATE TRIGGER fail_changed_path_child_link
+		BEFORE UPDATE OF parent_session_id ON sessions
+		WHEN NEW.id = 'agent-child-retry'
+		  AND NEW.parent_session_id = 'agent-orchestrator-retry'
+		BEGIN
+			SELECT RAISE(FAIL, 'injected changed-path link failure');
+		END`)
+	require.NoError(t, err)
+
+	plan, err := env.engine.PlanChangedPathsContext(
+		t.Context(), []string{orchestratorPath},
+	)
+	require.NoError(t, err)
+	_, err = env.engine.SyncChangedPathPlanContext(t.Context(), plan, nil)
+	require.ErrorContains(t, err, "injected changed-path link failure")
+
+	var queued int
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT count(*) FROM subagent_parent_repair_queue
+		WHERE session_id = 'agent-orchestrator-retry'`,
+	).Scan(&queued))
+	require.Equal(t, 1, queued,
+		"the changed spawner must remain queued after scoped linking fails")
+
+	_, err = raw.Exec("DROP TRIGGER fail_changed_path_child_link")
+	require.NoError(t, err)
+	require.NoError(t, env.db.RepairQueuedSubagentParents())
+	assert.Equal(t, "agent-orchestrator-retry",
+		parentSessionIDOf(t, env, "agent-child-retry"))
 }
 
 // TestSyncSingleSessionNewEdgeLinkFailureRetriesFromDurableQueue covers the

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -958,6 +958,7 @@ type directStreamingProvider struct {
 	discoverRelease  <-chan struct{}
 	parseStarted     chan<- struct{}
 	parseRelease     <-chan struct{}
+	parseForce       atomic.Bool
 	source           *parser.SourceRef
 	parseErr         error
 	parseOutcome     parser.ParseOutcome
@@ -1015,7 +1016,7 @@ func (provider *directStreamingProvider) Fingerprint(
 }
 
 func (provider *directStreamingProvider) Parse(
-	ctx context.Context, _ parser.ParseRequest,
+	ctx context.Context, req parser.ParseRequest,
 ) (parser.ParseOutcome, error) {
 	provider.parseCalls.Add(1)
 	if provider.parseStarted != nil {
@@ -1031,6 +1032,7 @@ func (provider *directStreamingProvider) Parse(
 			return parser.ParseOutcome{}, ctx.Err()
 		}
 	}
+	provider.parseForce.Store(req.ForceParse)
 	return provider.parseOutcome, provider.parseErr
 }
 
@@ -1042,6 +1044,109 @@ func (factory directStreamingFactory) Definition() parser.AgentDef {
 
 func (factory directStreamingFactory) Capabilities() parser.Capabilities {
 	return factory.provider.Capabilities()
+}
+
+func TestSyncAllForceParseReparsesFreshStreamingProviderSource(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "session.db#session-1")
+	seedActiveBaselineSource(t, database, parser.AgentWarp, "session-1", path)
+	source := parser.SourceRef{
+		Provider: parser.AgentWarp, Key: path,
+		DisplayPath: path, FingerprintKey: path,
+	}
+	started := time.Unix(1704067200, 0)
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: parser.AgentWarp, FileBased: false},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				StreamingDiscovery: parser.CapabilitySupported,
+			}},
+		},
+		source:      &source,
+		fingerprint: parser.SourceFingerprint{Key: path, MTimeNS: 1},
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: "session-1", Agent: parser.AgentWarp,
+					Project: "project", Machine: "local",
+					StartedAt: started, EndedAt: started,
+					File: parser.FileInfo{Path: path, Mtime: 1},
+				}},
+				DataVersion: parser.DataVersionCurrent,
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentWarp: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentWarp: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	stats := engine.SyncAllForceParse(t.Context(), nil)
+
+	assert.Equal(t, int32(1), provider.parseCalls.Load())
+	assert.True(t, provider.parseForce.Load())
+	assert.Equal(t, 1, stats.Synced)
+}
+
+func TestForceFullParseBypassesPersistedProviderFreshness(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "session.db#session-1")
+	seedActiveBaselineSource(t, database, parser.AgentWarp, "session-1", path)
+	source := parser.SourceRef{
+		Provider: parser.AgentWarp, Key: path,
+		DisplayPath: path, FingerprintKey: path,
+	}
+	started := time.Unix(1704067200, 0)
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: parser.AgentWarp, FileBased: false},
+		},
+		fingerprint: parser.SourceFingerprint{Key: path, MTimeNS: 1},
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: "session-1", Agent: parser.AgentWarp,
+					Project: "project", Machine: "local",
+					StartedAt: started, EndedAt: started,
+					File: parser.FileInfo{Path: path, Mtime: 1},
+				}},
+				DataVersion: parser.DataVersionCurrent,
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentWarp: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentWarp: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	engine.forceFullParse = true
+
+	result := engine.processFile(t.Context(), parser.DiscoveredFile{
+		Path: path, Agent: parser.AgentWarp,
+		ProviderSource: &source, ProviderProcess: true,
+	})
+
+	require.NoError(t, result.err)
+	assert.Equal(t, int32(1), provider.parseCalls.Load())
+	assert.True(t, provider.parseForce.Load())
+	require.Len(t, result.results, 1)
 }
 
 func newChangedPathOutcomeEngine(
@@ -9510,6 +9615,63 @@ func TestEngine_ZeroSyncedSuccessfulResyncEmits(t *testing.T) {
 	}
 }
 
+type recordingRebuildCommitter struct {
+	events    *[]string
+	commitErr error
+}
+
+func (c *recordingRebuildCommitter) Commit() error {
+	*c.events = append(*c.events, "commit")
+	return c.commitErr
+}
+
+func (c *recordingRebuildCommitter) Close() error {
+	*c.events = append(*c.events, "close")
+	return nil
+}
+
+func TestRebuildCommitRunsAfterSwapBeforePostRebuildWork(t *testing.T) {
+	fx := newEngineFixture(t)
+	var events []string
+	cleanup := &recordingRebuildCommitter{events: &events}
+
+	stats, err := fx.engine.SyncThenRunWithRebuild(
+		t.Context(), true, nil,
+		func() (RebuildOptions, RebuildCleanup, error) {
+			return RebuildOptions{}, cleanup, nil
+		},
+		func(SyncStats, error) { events = append(events, "done") },
+		func(bool, bool) error {
+			events = append(events, "work")
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted)
+	assert.Equal(t, []string{"commit", "done", "work", "close"}, events)
+}
+
+func TestRebuildCommitFailurePreventsPostRebuildWork(t *testing.T) {
+	fx := newEngineFixture(t)
+	var events []string
+	sentinel := errors.New("commit sentinel")
+	cleanup := &recordingRebuildCommitter{events: &events, commitErr: sentinel}
+
+	_, err := fx.engine.SyncThenRunWithRebuild(
+		t.Context(), true, nil,
+		func() (RebuildOptions, RebuildCleanup, error) {
+			return RebuildOptions{}, cleanup, nil
+		},
+		func(SyncStats, error) { events = append(events, "done") },
+		func(bool, bool) error {
+			events = append(events, "work")
+			return nil
+		},
+	)
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, []string{"commit", "done", "close"}, events)
+}
+
 func TestEngine_SyncPathsEmitsWhenSessionsChange(t *testing.T) {
 	fx := newEngineFixture(t)
 	em := &fakeEmitter{}
@@ -9552,6 +9714,49 @@ func TestEngine_SyncPathsEmitsAfterSyncMuReleased(t *testing.T) {
 
 	assert.True(t, acquired.Load(),
 		"syncMu was still held when SyncPaths emitted — defer-order regression")
+}
+
+func TestEngine_SyncAllForceParseRestoresModeBeforeQueuedSync(t *testing.T) {
+	fx := newEngineFixture(t)
+	firstEmitting := make(chan struct{})
+	releaseFirstEmitter := make(chan struct{})
+	var emitOnce gosync.Once
+	fx.engineWithEmitter(emitterFunc(func(string) {
+		emitOnce.Do(func() {
+			close(firstEmitting)
+			<-releaseFirstEmitter
+		})
+	}))
+	fx.writeClaudeSession(t, "proj", "s1.jsonl", "hello")
+
+	firstDone := make(chan SyncStats, 1)
+	go func() {
+		firstDone <- fx.engine.SyncAllForceParse(t.Context(), nil)
+	}()
+	<-firstEmitting
+
+	secondProgress := make(chan struct{})
+	releaseSecondSync := make(chan struct{})
+	var progressOnce gosync.Once
+	secondDone := make(chan SyncStats, 1)
+	go func() {
+		secondDone <- fx.engine.SyncAll(t.Context(), func(Progress) {
+			progressOnce.Do(func() {
+				close(secondProgress)
+				<-releaseSecondSync
+			})
+		})
+	}()
+	<-secondProgress
+
+	close(releaseFirstEmitter)
+	firstStats := <-firstDone
+	close(releaseSecondSync)
+	<-secondDone
+
+	require.Equal(t, 1, firstStats.Synced)
+	assert.False(t, fx.engine.forceFullParse,
+		"an overlapping ordinary sync must not restore temporary full-parse mode")
 }
 
 func TestEngine_SyncPathsDoesNotEmitOnNoMatches(t *testing.T) {

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -465,7 +465,7 @@ func (e *Engine) finishStreamingSQLiteContainerDiscovery() {
 // removed storage JSON stops shadowing its same-ID row) without the
 // container state changing; such a row was never verified and must parse.
 func (e *Engine) sqliteContainerSourceFresh(file parser.DiscoveredFile) bool {
-	if e.forceParse || file.ForceParse {
+	if e.forceParseRequested(file) {
 		return false
 	}
 	dbPath, sessionID, ok := sqliteContainerSourceForFile(file)
@@ -509,7 +509,7 @@ func (e *Engine) watermarkOnlySQLiteSourceFresh(
 	source parser.SourceRef,
 	file parser.DiscoveredFile,
 ) (int64, bool) {
-	if e.forceParse || file.ForceParse {
+	if e.forceParseRequested(file) {
 		return 0, false
 	}
 	watermark, ok := parser.SourceWatermarkOnlyMTimeNS(source)

--- a/internal/sync/opencode_storage_gate.go
+++ b/internal/sync/opencode_storage_gate.go
@@ -103,7 +103,7 @@ func (e *Engine) storageTrustSnapshotFor(path string) storageTrustSnapshot {
 func (e *Engine) openCodeStorageSessionGateState(
 	file parser.DiscoveredFile,
 ) (string, storageTrustSnapshot, bool) {
-	if e.forceParse || file.ForceParse {
+	if e.forceParseRequested(file) {
 		return "", storageTrustSnapshot{}, false
 	}
 	sessionPath := e.openCodeStorageSessionPath(file)

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -25,21 +25,23 @@ const defaultProgressStallAfter = 5 * time.Minute
 
 // Progress reports sync progress to listeners.
 type Progress struct {
-	Phase           Phase     `json:"phase"`
-	Detail          string    `json:"detail,omitempty"`
-	Hint            string    `json:"hint,omitempty"`
-	Resync          bool      `json:"resync,omitempty"`
-	StartedAt       time.Time `json:"started_at,omitzero"`
-	UpdatedAt       time.Time `json:"updated_at,omitzero"`
-	Stalled         bool      `json:"stalled,omitempty"`
-	CurrentProject  string    `json:"current_project,omitempty"`
-	ProjectsTotal   int       `json:"projects_total"`
-	ProjectsDone    int       `json:"projects_done"`
-	SessionsTotal   int       `json:"sessions_total"`
-	SessionsDone    int       `json:"sessions_done"`
-	MessagesIndexed int       `json:"messages_indexed"`
-	BytesDone       int64     `json:"bytes_done,omitempty"`
-	BytesTotal      int64     `json:"bytes_total,omitempty"`
+	Phase             Phase     `json:"phase"`
+	Detail            string    `json:"detail,omitempty"`
+	Hint              string    `json:"hint,omitempty"`
+	Resync            bool      `json:"resync,omitempty"`
+	StartedAt         time.Time `json:"started_at,omitzero"`
+	UpdatedAt         time.Time `json:"updated_at,omitzero"`
+	Stalled           bool      `json:"stalled,omitempty"`
+	CurrentProject    string    `json:"current_project,omitempty"`
+	ProjectsTotal     int       `json:"projects_total"`
+	ProjectsDone      int       `json:"projects_done"`
+	SessionsTotal     int       `json:"sessions_total"`
+	SessionsDone      int       `json:"sessions_done"`
+	MessagesIndexed   int       `json:"messages_indexed"`
+	BytesDone         int64     `json:"bytes_done,omitempty"`
+	BytesTotal        int64     `json:"bytes_total,omitempty"`
+	FallbackProviders int       `json:"fallback_providers,omitempty"`
+	FallbackSources   int       `json:"fallback_sources,omitempty"`
 }
 
 // SyncResult describes the outcome of syncing a single session.

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -1761,12 +1761,17 @@ type processFixtureProvider struct {
 	parser.ProviderBase
 
 	source        parser.SourceRef
+	discovered    []parser.SourceRef
 	findFound     bool
 	fingerprint   parser.SourceFingerprint
 	outcome       parser.ParseOutcome
 	calls         []string
 	findRequests  []parser.FindSourceRequest
 	parseRequests []parser.ParseRequest
+}
+
+func (p *processFixtureProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	return append([]parser.SourceRef(nil), p.discovered...), nil
 }
 
 func (p *processFixtureProvider) FindSource(

--- a/internal/sync/provider_sync_semantics_test.go
+++ b/internal/sync/provider_sync_semantics_test.go
@@ -582,10 +582,16 @@ func TestSyncSemanticsUnchangedResultPolicies(t *testing.T) {
 		file, []parser.ParseResult{result},
 		parser.UnchangedResultMTimeAndHash,
 	)
+	engine.forceFullParse = true
+	forced := engine.dropUnchangedSharedSQLiteResults(
+		file, []parser.ParseResult{result}, parser.UnchangedResultMTime,
+	)
 
 	assert.Empty(t, mtimeOnly)
 	require.Len(t, mtimeAndHash, 1)
 	assert.Equal(t, "semantic:member", mtimeAndHash[0].Session.ID)
+	require.Len(t, forced, 1)
+	assert.Equal(t, "semantic:member", forced[0].Session.ID)
 }
 
 func TestOmnigentDependentSourceExpansionPreservesEngineIDPrefixing(

--- a/internal/sync/rebuild_contributor.go
+++ b/internal/sync/rebuild_contributor.go
@@ -26,6 +26,10 @@ type RebuildContributor struct {
 	// explicit-full imports use this to preserve their parsing contract while
 	// participating in a unified replacement-database rebuild.
 	ForceParse bool
+	// ForceFullParseAfterCache preserves full-source parsing for work not
+	// reached by an interrupted remote attempt while allowing its durable
+	// failure-cache entries to suppress sources that were already attempted.
+	ForceFullParseAfterCache bool
 
 	Progress  func(Progress) Progress
 	Started   func()

--- a/internal/sync/rebuild_contributor.go
+++ b/internal/sync/rebuild_contributor.go
@@ -19,12 +19,22 @@ var ErrUnifiedRebuildAborted = errors.New(
 // RebuildContributor adds another configured sync source to an atomic full
 // rebuild. Contributors run sequentially against the same temporary database.
 type RebuildContributor struct {
-	Name      string
-	Config    EngineConfig
+	Name   string
+	Config EngineConfig
+
+	// ForceParse bypasses freshness gates for every contributor source. Remote
+	// explicit-full imports use this to preserve their parsing contract while
+	// participating in a unified replacement-database rebuild.
+	ForceParse bool
+
 	Progress  func(Progress) Progress
 	Started   func()
 	Finished  func(SyncStats, error)
 	AfterSync func(*Engine, *db.DB) error
+	// AfterFailure runs before an incomplete contributor's replacement
+	// database is discarded. The database argument is the active archive, so
+	// callers can preserve retry state produced by the failed attempt.
+	AfterFailure func(*Engine, *db.DB) error
 }
 
 // RebuildOptions configures optional sources for an atomic full rebuild.

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -707,8 +707,9 @@ func TestResyncLocalCancellationPreventsContributors(t *testing.T) {
 
 type staticUsageRebuildProvider struct {
 	parser.ProviderBase
-	source parser.SourceRef
-	result parser.ParseResult
+	source             parser.SourceRef
+	result             parser.ParseResult
+	forceParseRequests []bool
 }
 
 func (p *staticUsageRebuildProvider) Discover(context.Context) ([]parser.SourceRef, error) {
@@ -722,12 +723,47 @@ func (p *staticUsageRebuildProvider) Fingerprint(
 }
 
 func (p *staticUsageRebuildProvider) Parse(
-	context.Context, parser.ParseRequest,
+	_ context.Context, request parser.ParseRequest,
 ) (parser.ParseOutcome, error) {
+	p.forceParseRequests = append(p.forceParseRequests, request.ForceParse)
 	return parser.ParseOutcome{
 		Results:           []parser.ParseResultOutcome{{Result: p.result}},
 		ResultSetComplete: true,
 	}, nil
+}
+
+func TestResyncContributorForceParseReachesProvider(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{})
+	t.Cleanup(engine.Close)
+	provider := newStaticUsageRebuildProvider(
+		"forced-contributor", "forced-contributor.jsonl", 1, 1,
+	)
+
+	stats, err := engine.ResyncAllWithOptions(
+		context.Background(), nil, RebuildOptions{Contributors: []RebuildContributor{{
+			Name:       "forced",
+			ForceParse: true,
+			Config: EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentCowork: {"forced-root"},
+				},
+				Machine: "forced", Ephemeral: true,
+				ProviderFactories: []parser.ProviderFactory{
+					staticUsageRebuildFactory{provider: provider},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+				},
+			},
+		}}},
+	)
+
+	require.NoError(t, err)
+	require.False(t, stats.Aborted, "rebuild aborted: %+v", stats)
+	assert.Equal(t, []bool{true}, provider.forceParseRequests)
 }
 
 type staticUsageRebuildFactory struct{ provider *staticUsageRebuildProvider }

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -397,7 +397,7 @@ func (e *Engine) processS3Session(
 			}
 		}
 		res.sourceMissingMembers = missing
-		if !e.forceParse && !file.ForceParse &&
+		if !e.forceParseRequested(file) &&
 			!res.suppressPresenceSweep && res.providerFailureCount == 0 &&
 			len(res.retrySessionIDs) == 0 && !res.noCacheSkip {
 			res.claudeRowlessFreshnessKey =

--- a/internal/sync/verified_source_gate.go
+++ b/internal/sync/verified_source_gate.go
@@ -174,7 +174,7 @@ func (e *Engine) verifiedProviderSourceState(
 	source parser.SourceRef,
 	file parser.DiscoveredFile,
 ) (verifiedSourceCapture, int64, bool, bool) {
-	if e.forceParse || file.ForceParse || e.pathRewriter != nil ||
+	if e.forceParseRequested(file) || e.pathRewriter != nil ||
 		provider.Capabilities().Source.VerifiedLocalStat !=
 			parser.CapabilitySupported {
 		return verifiedSourceCapture{}, 0, false, false


### PR DESCRIPTION
HTTP sync already downloaded only files that changed, but it still scanned and processed every session in the local mirror afterward. On a large history, even a small update could therefore spend minutes revisiting thousands of unchanged sessions.

This change carries the list of changed files through the import step. When agentsview can identify the affected sessions precisely, it processes only those sessions. When it cannot, it broadens the work only to the relevant agent type instead of rescanning every remote session.

Pending changes are recorded before the mirror is updated, so interrupted syncs can safely continue on the next run. Cache entries are cleared only where needed, including when an archive changes a file without changing its timestamp. Repeated parser failures remain suppressed after one retry instead of causing an endless full replay.

First-time syncs, archive rebuilds, legacy mode, recovery from an oversized or damaged change record, and user-requested full syncs still perform a full import. A user-requested full sync now truly reparses unchanged sources instead of accepting cached freshness results.

Progress output now distinguishes download size, pending changes, planned import work, fallback work, cache cleanup, and whether pending work was completed or retained for another attempt. Routine local Go test commands also reuse the build cache and limit package fan-out to reduce resource pressure.