### PR TITLE
fix(sync): report stalled syncs as unhealthy

### DIFF
--- a/cmd/agentsview/archive_audit_test.go
+++ b/cmd/agentsview/archive_audit_test.go
@@ -70,6 +70,80 @@ func TestArchiveAuditRetriesWithBackoffOnFailure(t *testing.T) {
 		"the audit must never run an in-process sync pass")
 }
 
+func TestArchiveAuditPublishesAndClearsWorkerProgress(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		ProgressStallAfter: time.Nanosecond,
+	})
+	t.Cleanup(engine.Close)
+	workerStarted := make(chan struct{})
+	emitProgress := make(chan struct{}, 1)
+	progressSeen := make(chan struct{})
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case emitProgress <- struct{}{}:
+		default:
+		}
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	sentinel := errors.New("audit worker stopped")
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, mode string, onLine func(workerLine),
+	) (workerResult, error) {
+		assert.Equal(t, "audit", mode)
+		close(workerStarted)
+		<-emitProgress
+		if onLine != nil {
+			onLine(workerLine{Progress: &sync.Progress{
+				Phase: sync.PhaseSyncing, SessionsTotal: 9, SessionsDone: 4,
+			}})
+		}
+		close(progressSeen)
+		<-release
+		return workerResult{}, sentinel
+	})
+	defer restore()
+	done := make(chan error, 1)
+	go func() {
+		done <- runArchiveAudit(t.Context(), cfg, engine, database, lock, nil)
+	}()
+	select {
+	case <-workerStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "audit worker did not start")
+	}
+
+	progress, active := engine.CurrentProgress()
+	require.True(t, active,
+		"daemon health must observe an audit blocked in its worker pass")
+	assert.Equal(t, sync.PhaseDiscovering, progress.Phase)
+	assert.True(t, progress.Stalled)
+
+	emitProgress <- struct{}{}
+	select {
+	case <-progressSeen:
+	case <-time.After(time.Second):
+		require.FailNow(t, "audit worker did not publish progress")
+	}
+	progress, active = engine.CurrentProgress()
+	require.True(t, active,
+		"daemon health must receive progress from the audit worker")
+	assert.Equal(t, sync.PhaseSyncing, progress.Phase)
+	assert.Equal(t, 9, progress.SessionsTotal)
+	assert.Equal(t, 4, progress.SessionsDone)
+
+	release <- struct{}{}
+	require.ErrorIs(t, <-done, sentinel)
+	_, active = engine.CurrentProgress()
+	assert.False(t, active,
+		"completed audit pass must clear daemon-visible progress")
+}
+
 // TestArchiveAuditEmitsOnDataChange asserts a successful audit that changed data
 // emits the sessions scope so connected clients refresh.
 func TestArchiveAuditEmitsOnDataChange(t *testing.T) {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1042,15 +1042,23 @@ func runWorkerResyncBuild(
 	database *db.DB,
 	progress func(sync.Progress),
 ) (workerResult, error, bool) {
-	relay := func(l workerLine) {
-		if l.Progress != nil && progress != nil {
-			progress(*l.Progress)
-		}
-	}
 	var result workerResult
 	var launchErr error
 	var doneStats sync.SyncStats
 	barrierErr := engine.RunExclusive(func() error {
+		engine.UpdateProgress(sync.Progress{
+			Phase:  sync.PhasePreparingResync,
+			Detail: "Starting resync worker",
+		})
+		defer engine.FinishProgress()
+		relay := func(line workerLine) {
+			if line.Progress != nil {
+				engine.UpdateProgress(*line.Progress)
+			}
+			if progress != nil && line.Progress != nil {
+				progress(*line.Progress)
+			}
+		}
 		if cerr := closeWriterForPass(
 			recoveryCtx, database, "resync build",
 		); cerr != nil {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -939,8 +939,8 @@ func newForegroundSyncRunner(
 			// closes before the exclusive lock is released, and last-sync
 			// state plus the "sync" emit fire after it, so /sync/status and
 			// SSE subscribers observe the worker-backed pass.
-			stats, _, err := runWorkerSyncPass(
-				ctx, daemonCtx, cfg, engine, database, lock, false, onLine,
+			stats, _, err := runForegroundWorkerSyncPass(
+				ctx, daemonCtx, cfg, engine, database, lock, onLine,
 			)
 			if err == nil || !workerNeverRan(err) {
 				return stats, err

--- a/cmd/agentsview/sync_worker.go
+++ b/cmd/agentsview/sync_worker.go
@@ -197,7 +197,7 @@ func runSyncWorkerStartup(
 		var auditErr error
 		if auditRoots := reconcileRootPaths(cfg); len(auditRoots) > 0 {
 			stats, tombstoned, auditErr = engine.ReconcileWatchRootsWithStats(
-				ctx, auditRoots, false,
+				ctx, auditRoots, false, onProgress,
 			)
 		}
 		result = workerResultFromStats(ctx, stats)

--- a/cmd/agentsview/sync_worker_test.go
+++ b/cmd/agentsview/sync_worker_test.go
@@ -99,6 +99,28 @@ func TestSyncWorkerStartupModeSyncsAndEmitsTerminalResult(t *testing.T) {
 		"public SyncStats fields must survive the NDJSON protocol")
 }
 
+func TestSyncWorkerAuditModeForwardsReconciliationProgress(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "audit", &out))
+
+	sawActiveProgress := false
+	sc := bufio.NewScanner(&out)
+	for sc.Scan() {
+		var line workerLine
+		require.NoError(t, json.Unmarshal(sc.Bytes(), &line),
+			"every stdout line must be a workerLine JSON object")
+		if line.Progress != nil &&
+			line.Progress.Phase == sync.PhaseSyncing &&
+			line.Progress.SessionsDone > 0 {
+			sawActiveProgress = true
+		}
+	}
+	require.NoError(t, sc.Err())
+	assert.True(t, sawActiveProgress,
+		"audit worker must forward active reconciliation progress")
+}
+
 func TestSyncWorkerStartupUsesConfiguredSourceMachine(t *testing.T) {
 	cfg := testConfigWithClaudeFixture(t)
 	claudeRoot := cfg.AgentDirs[parser.AgentClaude][0]

--- a/cmd/agentsview/worker_pass.go
+++ b/cmd/agentsview/worker_pass.go
@@ -141,13 +141,61 @@ func runWorkerSyncPass(
 	skipIfReconciled bool,
 	onLine func(workerLine),
 ) (stats sync.SyncStats, ran bool, err error) {
+	return runWorkerSyncPassExclusive(
+		ctx, recoveryCtx, cfg, engine, database, lock, skipIfReconciled,
+		onLine, engine.RunExclusive,
+	)
+}
+
+// runForegroundWorkerSyncPass keeps a user-triggered sync from waiting behind
+// an existing sync or maintenance pass. The worker handoff is unchanged once
+// the lock is acquired.
+func runForegroundWorkerSyncPass(
+	ctx context.Context,
+	recoveryCtx context.Context,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	lock *writeOwnerLock,
+	onLine func(workerLine),
+) (stats sync.SyncStats, ran bool, err error) {
+	return runWorkerSyncPassExclusive(
+		ctx, recoveryCtx, cfg, engine, database, lock, false, onLine,
+		engine.TryRunExclusive,
+	)
+}
+
+func runWorkerSyncPassExclusive(
+	ctx context.Context,
+	recoveryCtx context.Context,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	lock *writeOwnerLock,
+	skipIfReconciled bool,
+	onLine func(workerLine),
+	runExclusive func(func() error) error,
+) (stats sync.SyncStats, ran bool, err error) {
 	recorded := false
-	err = engine.RunExclusive(func() error {
+	err = runExclusive(func() error {
 		if skipIfReconciled && engine.StartupReconciled() {
 			return nil
 		}
+		engine.UpdateProgress(sync.Progress{
+			Phase:  sync.PhaseDiscovering,
+			Detail: "Starting sync worker",
+		})
+		defer engine.FinishProgress()
+		relayLine := func(line workerLine) {
+			if line.Progress != nil {
+				engine.UpdateProgress(*line.Progress)
+			}
+			if onLine != nil {
+				onLine(line)
+			}
+		}
 		result, workerErr := workerWritePassLocked(
-			ctx, recoveryCtx, cfg, engine, database, lock, "sync", onLine,
+			ctx, recoveryCtx, cfg, engine, database, lock, "sync", relayLine,
 		)
 		if workerNeverRan(workerErr) {
 			return workerErr

--- a/cmd/agentsview/worker_pass.go
+++ b/cmd/agentsview/worker_pass.go
@@ -111,9 +111,22 @@ func runWorkerWritePass(
 ) (workerResult, error) {
 	var result workerResult
 	err := engine.RunExclusive(func() error {
+		engine.UpdateProgress(sync.Progress{
+			Phase:  sync.PhaseDiscovering,
+			Detail: "Starting " + mode + " worker",
+		})
+		defer engine.FinishProgress()
+		relayLine := func(line workerLine) {
+			if line.Progress != nil {
+				engine.UpdateProgress(*line.Progress)
+			}
+			if onLine != nil {
+				onLine(line)
+			}
+		}
 		var workerErr error
 		result, workerErr = workerWritePassLocked(
-			ctx, recoveryCtx, cfg, engine, database, lock, mode, onLine,
+			ctx, recoveryCtx, cfg, engine, database, lock, mode, relayLine,
 		)
 		return workerErr
 	})

--- a/cmd/agentsview/worker_pass_test.go
+++ b/cmd/agentsview/worker_pass_test.go
@@ -482,6 +482,86 @@ func TestRunForegroundWorkerSyncPassPublishesAndClearsWorkerProgress(
 		"completed worker pass must clear daemon-visible progress")
 }
 
+func TestRunWorkerResyncBuildPublishesAndClearsWorkerProgress(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, _ := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	t.Cleanup(engine.Close)
+	workerStarted := make(chan struct{})
+	emitProgress := make(chan struct{}, 1)
+	progressSeen := make(chan struct{})
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case emitProgress <- struct{}{}:
+		default:
+		}
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	sentinel := errors.New("resync worker stopped")
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, mode string, onLine func(workerLine),
+	) (workerResult, error) {
+		assert.Equal(t, "resync-build", mode)
+		close(workerStarted)
+		<-emitProgress
+		onLine(workerLine{Progress: &sync.Progress{
+			Phase: sync.PhaseSyncing, SessionsTotal: 8, SessionsDone: 3,
+		}})
+		close(progressSeen)
+		<-release
+		return workerResult{}, sentinel
+	})
+	defer restore()
+	type buildResult struct {
+		err         error
+		spawnFailed bool
+	}
+	done := make(chan buildResult, 1)
+	go func() {
+		_, err, spawnFailed := runWorkerResyncBuild(
+			t.Context(), t.Context(), cfg, engine, database, nil,
+		)
+		done <- buildResult{err: err, spawnFailed: spawnFailed}
+	}()
+	select {
+	case <-workerStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "resync worker did not start")
+	}
+
+	current, active := engine.CurrentProgress()
+	require.True(t, active,
+		"daemon health must observe resync before its first worker update")
+	assert.Equal(t, sync.PhasePreparingResync, current.Phase)
+	assert.False(t, current.StartedAt.IsZero())
+	assert.False(t, current.UpdatedAt.IsZero())
+
+	emitProgress <- struct{}{}
+	select {
+	case <-progressSeen:
+	case <-time.After(time.Second):
+		require.FailNow(t, "resync worker did not publish progress")
+	}
+	current, active = engine.CurrentProgress()
+	require.True(t, active,
+		"daemon health must receive progress from the resync worker")
+	assert.Equal(t, sync.PhaseSyncing, current.Phase)
+	assert.Equal(t, 8, current.SessionsTotal)
+	assert.Equal(t, 3, current.SessionsDone)
+
+	release <- struct{}{}
+	result := <-done
+	require.ErrorIs(t, result.err, sentinel)
+	assert.False(t, result.spawnFailed)
+	_, active = engine.CurrentProgress()
+	assert.False(t, active,
+		"completed resync worker must clear daemon-visible progress")
+}
+
 // TestRunWorkerSyncPassNoWorkerRecordsNothing pins first-attempt semantics for
 // every failure mode in which no worker process ran: a pre-launch writer-close
 // failure, a pre-launch lock-release failure, and a spawn failure. The pass

--- a/cmd/agentsview/worker_pass_test.go
+++ b/cmd/agentsview/worker_pass_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/sync"
 )
 
@@ -373,6 +374,112 @@ func TestRunWorkerSyncPassRecordsSyncBookkeeping(t *testing.T) {
 	default:
 		require.FailNow(t, "a worker-backed sync with changes must emit the sync event")
 	}
+}
+
+func TestRunForegroundWorkerSyncPassRejectsBusyEngineBeforeWorkerLaunch(
+	t *testing.T,
+) {
+	engine := sync.NewEngine(dbtest.OpenTestDB(t), sync.EngineConfig{})
+	t.Cleanup(engine.Close)
+	entered := make(chan struct{})
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	done := make(chan error, 1)
+	go func() {
+		done <- engine.RunExclusive(func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "first exclusive sync did not acquire the lock")
+	}
+	restore := stubLaunchSyncWorker(t, func(
+		context.Context, config.Config, string, func(workerLine),
+	) (workerResult, error) {
+		t.Error("busy foreground sync must not launch another worker")
+		return workerResult{}, nil
+	})
+	defer restore()
+
+	_, ran, err := runForegroundWorkerSyncPass(
+		t.Context(), t.Context(), config.Config{}, engine, nil, nil, nil,
+	)
+
+	require.ErrorIs(t, err, sync.ErrSyncInProgress)
+	assert.False(t, ran)
+	release <- struct{}{}
+	require.NoError(t, <-done)
+}
+
+func TestRunForegroundWorkerSyncPassPublishesAndClearsWorkerProgress(
+	t *testing.T,
+) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	t.Cleanup(engine.Close)
+	progressSeen := make(chan struct{})
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, onLine func(workerLine),
+	) (workerResult, error) {
+		onLine(workerLine{Progress: &sync.Progress{
+			Phase: sync.PhaseSyncing, SessionsTotal: 4, SessionsDone: 1,
+		}})
+		close(progressSeen)
+		<-release
+		return workerResult{Status: "ok", DiscoveryComplete: true}, nil
+	})
+	defer restore()
+	type passResult struct {
+		ran bool
+		err error
+	}
+	done := make(chan passResult, 1)
+	go func() {
+		_, ran, err := runForegroundWorkerSyncPass(
+			t.Context(), t.Context(), cfg, engine, database, lock,
+			func(workerLine) {},
+		)
+		done <- passResult{ran: ran, err: err}
+	}()
+	select {
+	case <-progressSeen:
+	case <-time.After(time.Second):
+		require.FailNow(t, "worker did not publish progress")
+	}
+
+	current, active := engine.CurrentProgress()
+	require.True(t, active,
+		"daemon health must observe progress from the worker process")
+	assert.Equal(t, sync.PhaseSyncing, current.Phase)
+	assert.Equal(t, 4, current.SessionsTotal)
+	assert.Equal(t, 1, current.SessionsDone)
+	assert.False(t, current.StartedAt.IsZero())
+	assert.False(t, current.UpdatedAt.IsZero())
+
+	release <- struct{}{}
+	result := <-done
+	require.NoError(t, result.err)
+	assert.True(t, result.ran)
+	_, active = engine.CurrentProgress()
+	assert.False(t, active,
+		"completed worker pass must clear daemon-visible progress")
 }
 
 // TestRunWorkerSyncPassNoWorkerRecordsNothing pins first-attempt semantics for

--- a/frontend/src/lib/api/generated/models/PingInfo.ts
+++ b/frontend/src/lib/api/generated/models/PingInfo.ts
@@ -2,10 +2,13 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { SyncProgress } from './SyncProgress';
 export type PingInfo = {
+  healthy: boolean;
   ok: boolean;
   pid?: number;
   service?: string;
+  sync?: SyncProgress;
   version?: string;
 };
 

--- a/frontend/src/lib/api/generated/models/SyncProgress.ts
+++ b/frontend/src/lib/api/generated/models/SyncProgress.ts
@@ -15,5 +15,8 @@ export type SyncProgress = {
   resync?: boolean;
   sessions_done: number;
   sessions_total: number;
+  stalled?: boolean;
+  started_at?: string;
+  updated_at?: string;
 };
 

--- a/frontend/src/lib/api/types/sync.ts
+++ b/frontend/src/lib/api/types/sync.ts
@@ -4,6 +4,9 @@ export interface SyncProgress {
   detail?: string;
   hint?: string;
   resync?: boolean;
+  stalled?: boolean;
+  started_at?: string;
+  updated_at?: string;
   current_project?: string;
   projects_total: number;
   projects_done: number;

--- a/internal/server/huma_routes_health.go
+++ b/internal/server/huma_routes_health.go
@@ -4,8 +4,17 @@ import (
 	"context"
 	"os"
 
-	"go.kenn.io/kit/daemon"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
+
+type PingInfo struct {
+	OK      bool              `json:"ok"`
+	Healthy bool              `json:"healthy"`
+	Service string            `json:"service,omitempty"`
+	Version string            `json:"version,omitempty"`
+	PID     int               `json:"pid,omitempty"`
+	Sync    *syncpkg.Progress `json:"sync,omitempty"`
+}
 
 func (s *Server) registerHealthRoutes() {
 	group := newRouteGroup(s.api, "/api", "Health")
@@ -16,13 +25,23 @@ func (s *Server) registerHealthRoutes() {
 func (s *Server) humaPing(
 	_ context.Context,
 	_ *emptyInput,
-) (*jsonOutput[daemon.PingInfo], error) {
-	return &jsonOutput[daemon.PingInfo]{
-		Body: daemon.PingInfo{
+) (*jsonOutput[PingInfo], error) {
+	healthy := true
+	var progress *syncpkg.Progress
+	if engine := s.syncStatusEngine(); engine != nil {
+		if current, ok := engine.CurrentProgress(); ok {
+			progress = &current
+			healthy = !current.Stalled
+		}
+	}
+	return &jsonOutput[PingInfo]{
+		Body: PingInfo{
 			OK:      true,
+			Healthy: healthy,
 			Service: daemonService,
 			Version: s.version.Version,
 			PID:     os.Getpid(),
+			Sync:    progress,
 		},
 	}, nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3259,6 +3259,11 @@ func TestPingReportsStalledSyncWithoutLosingDaemonIdentity(t *testing.T) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "sync did not publish progress")
 	}
+	require.Eventually(t, func() bool {
+		progress, active := engine.CurrentProgress()
+		return active && progress.Stalled
+	}, time.Second, time.Millisecond,
+		"sync progress did not age into the stalled state")
 
 	stalled := decode[pingResponse](t, te.get(t, "/api/ping"))
 	assert.True(t, stalled.OK,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3209,6 +3209,78 @@ func TestAuthRequiredProtectsPing(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 }
 
+func TestPingReportsStalledSyncWithoutLosingDaemonIdentity(t *testing.T) {
+	dir := tempDirWithRetryCleanup(t)
+	cfg := config.Config{
+		Host: "127.0.0.1", Port: 0, DataDir: dir,
+		DBPath: filepath.Join(dir, "test.db"), WriteTimeout: 30 * time.Second,
+	}
+	database := dbtest.OpenTestDBAt(t, cfg.DBPath)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		Machine: "test", ProgressStallAfter: time.Nanosecond,
+	})
+	t.Cleanup(engine.Close)
+	te := &testEnv{
+		srv: server.New(cfg, database, engine), db: database, engine: engine,
+		dataDir: dir,
+	}
+	te.handler = wrapTestHandler(cfg, te.srv.Handler())
+	type pingResponse struct {
+		OK      bool `json:"ok"`
+		Healthy bool `json:"healthy"`
+		Sync    *struct {
+			Phase     sync.Phase `json:"phase"`
+			Stalled   bool       `json:"stalled"`
+			StartedAt string     `json:"started_at"`
+			UpdatedAt string     `json:"updated_at"`
+		} `json:"sync,omitempty"`
+	}
+
+	healthy := decode[pingResponse](t, te.get(t, "/api/ping"))
+	assert.True(t, healthy.OK)
+	assert.True(t, healthy.Healthy)
+	assert.Nil(t, healthy.Sync)
+
+	progressSeen := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce stdlibsync.Once
+	defer releaseOnce.Do(func() { close(release) })
+	done := make(chan struct{})
+	var once stdlibsync.Once
+	go func() {
+		engine.SyncAll(t.Context(), func(sync.Progress) {
+			once.Do(func() { close(progressSeen) })
+			<-release
+		})
+		close(done)
+	}()
+	select {
+	case <-progressSeen:
+	case <-time.After(time.Second):
+		require.FailNow(t, "sync did not publish progress")
+	}
+
+	stalled := decode[pingResponse](t, te.get(t, "/api/ping"))
+	assert.True(t, stalled.OK,
+		"ping must keep proving the running daemon's identity")
+	assert.False(t, stalled.Healthy)
+	require.NotNil(t, stalled.Sync)
+	assert.Equal(t, sync.PhaseDiscovering, stalled.Sync.Phase)
+	assert.True(t, stalled.Sync.Stalled)
+	assert.NotEmpty(t, stalled.Sync.StartedAt)
+	assert.NotEmpty(t, stalled.Sync.UpdatedAt)
+
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.FailNow(t, "sync did not finish after progress callback returned")
+	}
+	finished := decode[pingResponse](t, te.get(t, "/api/ping"))
+	assert.True(t, finished.Healthy)
+	assert.Nil(t, finished.Sync)
+}
+
 func TestGetGithubConfig(t *testing.T) {
 	t.Setenv("AGENTSVIEW_GITHUB_TOKEN", "")
 	t.Setenv("PATH", t.TempDir())

--- a/internal/sync/codebuff_integration_test.go
+++ b/internal/sync/codebuff_integration_test.go
@@ -1101,7 +1101,7 @@ func TestSyncCodebuffTombstoneClearsProviderStatHash(t *testing.T) {
 			"still consider the source present")
 
 	_, _, err = engine.ReconcileWatchRootsWithStats(
-		context.Background(), []string{root}, true,
+		context.Background(), []string{root}, true, nil,
 	)
 	require.NoError(t, err,
 		"reconcile must complete; an error here would mask whether "+

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -308,6 +308,10 @@ type EngineConfig struct {
 	// startup discovery completed authoritatively. Failed, cancelled, and
 	// aborted attempts leave it eligible for a later successful owner.
 	OnStartupReconciled func(SyncStats, error)
+	// ProgressStallAfter controls when CurrentProgress marks an active pass as
+	// stalled. Zero uses the production default. Tests and embedders may use a
+	// shorter interval without changing the daemon-wide policy.
+	ProgressStallAfter time.Duration
 	// ProviderFactories and ProviderMigrationModes select which concrete
 	// providers own discovery and parsing for their agents. Nil uses the
 	// parser package registry/manifest.
@@ -343,6 +347,7 @@ type Engine struct {
 	lastSync           time.Time
 	lastSyncStats      SyncStats
 	currentProgress    *Progress
+	progressStallAfter time.Duration
 	// skipCache tracks paths that should be skipped on
 	// subsequent syncs, keyed by path with the file mtime
 	// at time of caching. Covers parse errors and
@@ -648,6 +653,10 @@ func NewEngine(
 		// choice.
 		parser.SetAllowProtectedPathProbes(true)
 	}
+	progressStallAfter := cfg.ProgressStallAfter
+	if progressStallAfter <= 0 {
+		progressStallAfter = defaultProgressStallAfter
+	}
 	e := &Engine{
 		db:                      database,
 		stat:                    os.Stat,
@@ -680,6 +689,7 @@ func NewEngine(
 		startupReconciledReady:  make(chan struct{}),
 		startupAttemptReady:     make(chan struct{}),
 		onStartupReconciled:     cfg.OnStartupReconciled,
+		progressStallAfter:      progressStallAfter,
 		reconciliationSpoolFactory: func(path string) (reconciliationSpoolStore, error) {
 			return newReconciliationSpool(path)
 		},
@@ -1210,14 +1220,41 @@ func (e *Engine) CurrentProgress() (Progress, bool) {
 	if e.currentProgress == nil {
 		return Progress{}, false
 	}
-	return *e.currentProgress, true
+	p := *e.currentProgress
+	if !p.UpdatedAt.IsZero() && e.progressStallAfter > 0 &&
+		time.Since(p.UpdatedAt) >= e.progressStallAfter {
+		p.Stalled = true
+	}
+	return p, true
+}
+
+// UpdateProgress records progress produced by work running outside the engine,
+// such as the isolated sync worker process.
+func (e *Engine) UpdateProgress(p Progress) {
+	e.reportProgress(nil, p)
+}
+
+// FinishProgress clears progress produced by work running outside the engine.
+func (e *Engine) FinishProgress() {
+	e.clearCurrentProgress()
 }
 
 func (e *Engine) reportProgress(
 	onProgress ProgressFunc, p Progress,
 ) {
+	now := time.Now()
 	e.mu.Lock()
-	e.currentProgress = &p
+	tracked := p
+	if tracked.StartedAt.IsZero() {
+		if e.currentProgress != nil && !e.currentProgress.StartedAt.IsZero() {
+			tracked.StartedAt = e.currentProgress.StartedAt
+		} else {
+			tracked.StartedAt = now
+		}
+	}
+	tracked.UpdatedAt = now
+	tracked.Stalled = false
+	e.currentProgress = &tracked
 	e.mu.Unlock()
 	if onProgress != nil {
 		onProgress(p)
@@ -3765,6 +3802,27 @@ func (e *Engine) RunExclusive(work func() error) error {
 	return work()
 }
 
+// ErrSyncInProgress reports that non-blocking foreground sync coordination
+// found another sync or maintenance pass holding the exclusive engine lock.
+var ErrSyncInProgress = errors.New("sync already in progress")
+
+// TryRunExclusive is the non-blocking foreground counterpart to RunExclusive.
+// Background work keeps using RunExclusive so scheduled obligations are not
+// lost; user-triggered sync requests use this method to fail promptly instead
+// of waiting behind a filesystem operation that may be stalled.
+func (e *Engine) TryRunExclusive(work func() error) error {
+	if e.refuseWriteInForceParse("TryRunExclusive") {
+		return errors.New(
+			"TryRunExclusive refused on report-only parse-diff engine",
+		)
+	}
+	if !e.syncMu.TryLock() {
+		return ErrSyncInProgress
+	}
+	defer e.syncMu.Unlock()
+	return work()
+}
+
 // RunExclusiveFlushed runs work while holding the exclusive sync lock, after
 // flushing deferred signal recomputes inline. It is the push half of
 // SyncThenRun for daemon push routes whose sync or resync already ran through
@@ -3939,6 +3997,11 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 	func() {
 		e.syncMu.Lock()
 		defer e.syncMu.Unlock()
+		defer e.clearCurrentProgress()
+		e.reportProgress(nil, Progress{
+			Phase:  PhaseDiscovering,
+			Detail: "Reconciling watched session roots",
+		})
 		linkEligible := false
 		persistEligible := false
 		for _, group := range groups {
@@ -3994,6 +4057,11 @@ func (e *Engine) reconcileScopedWatchRoots(
 	stats, tombstoned, _, err := func() (SyncStats, int, passEpilogueEligibility, error) {
 		e.syncMu.Lock()
 		defer e.syncMu.Unlock()
+		defer e.clearCurrentProgress()
+		e.reportProgress(nil, Progress{
+			Phase:  PhaseDiscovering,
+			Detail: "Reconciling watched session roots",
+		})
 		return e.reconcileScopedWatchRootsLocked(ctx, agent, roots, full, force)
 	}()
 	// Emit outside syncMu so an Emitter implementation cannot widen the

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1358,6 +1358,11 @@ func (e *Engine) applyChangedPathSyncLocked(
 	// Begin a container pass so an already-trusted, unchanged container
 	// still gates its fan-out, but never promote from a changed-path subset.
 	e.beginSQLiteContainerPass(prepared.files, prepared.preContainerStates)
+	e.reportProgress(nil, Progress{
+		Phase:         PhaseSyncing,
+		Detail:        "Syncing changed session paths",
+		SessionsTotal: len(prepared.files),
+	})
 	results := e.startWorkers(ctx, prepared.files)
 	stats := e.collectAndBatch(
 		ctx, results, len(prepared.files), len(prepared.files), nil,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3998,10 +3998,6 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 		e.syncMu.Lock()
 		defer e.syncMu.Unlock()
 		defer e.clearCurrentProgress()
-		e.reportProgress(nil, Progress{
-			Phase:  PhaseDiscovering,
-			Detail: "Reconciling watched session roots",
-		})
 		linkEligible := false
 		persistEligible := false
 		for _, group := range groups {
@@ -4058,10 +4054,6 @@ func (e *Engine) reconcileScopedWatchRoots(
 		e.syncMu.Lock()
 		defer e.syncMu.Unlock()
 		defer e.clearCurrentProgress()
-		e.reportProgress(nil, Progress{
-			Phase:  PhaseDiscovering,
-			Detail: "Reconciling watched session roots",
-		})
 		return e.reconcileScopedWatchRootsLocked(ctx, agent, roots, full, force)
 	}()
 	// Emit outside syncMu so an Emitter implementation cannot widen the
@@ -4080,6 +4072,10 @@ func (e *Engine) reconcileScopedWatchRoots(
 func (e *Engine) reconcileScopedWatchRootsLocked(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
 ) (SyncStats, int, passEpilogueEligibility, error) {
+	e.reportProgress(nil, Progress{
+		Phase:  PhaseDiscovering,
+		Detail: "Reconciling watched session roots",
+	})
 	fullCoverage := full || (agent == "" && len(roots) == 0)
 	plans, excludedRemoteRoots := e.resolveReconciliationPlans(
 		ctx, agent, roots, full, fullCoverage,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3952,19 +3952,23 @@ func (e *Engine) ReconcileWatchRoots(
 	return e.reconcileWatchRoots(ctx, roots, full, false)
 }
 
-// ReconcileWatchRootsWithStats is ReconcileWatchRoots plus the pass outcome:
-// the archive-audit worker uses it so synced and tombstoned counts reach the
-// daemon through the worker protocol.
+// ReconcileWatchRootsWithStats is ReconcileWatchRoots plus the pass outcome and
+// progress callback: the archive-audit worker uses it so progress and synced or
+// tombstoned counts reach the daemon through the worker protocol.
 func (e *Engine) ReconcileWatchRootsWithStats(
-	ctx context.Context, roots []string, full bool,
+	ctx context.Context, roots []string, full bool, onProgress ProgressFunc,
 ) (SyncStats, int, error) {
-	return e.reconcileScopedWatchRoots(ctx, "", roots, full, false)
+	return e.reconcileScopedWatchRoots(
+		ctx, "", roots, full, false, onProgress,
+	)
 }
 
 func (e *Engine) reconcileWatchRoots(
 	ctx context.Context, roots []string, full, force bool,
 ) error {
-	_, _, err := e.reconcileScopedWatchRoots(ctx, "", roots, full, force)
+	_, _, err := e.reconcileScopedWatchRoots(
+		ctx, "", roots, full, force, nil,
+	)
 	return err
 }
 
@@ -3979,7 +3983,9 @@ func (e *Engine) ReconcileProviderRoots(
 	if agent == "" {
 		return e.reconcileWatchRoots(ctx, roots, false, false)
 	}
-	_, _, err := e.reconcileScopedWatchRoots(ctx, agent, roots, false, false)
+	_, _, err := e.reconcileScopedWatchRoots(
+		ctx, agent, roots, false, false, nil,
+	)
 	return err
 }
 
@@ -4025,7 +4031,7 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 				break
 			}
 			stats, tombstoned, eligibility, err := e.reconcileScopedWatchRootsLocked(
-				deferredCtx, group.Agent, group.Roots, false, false,
+				deferredCtx, group.Agent, group.Roots, false, false, nil,
 			)
 			changed = changed || stats.Synced > 0 || tombstoned > 0
 			linkEligible = linkEligible || eligibility.link
@@ -4069,12 +4075,15 @@ func (e *Engine) ReconcileProviderRootsGrouped(
 
 func (e *Engine) reconcileScopedWatchRoots(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
+	onProgress ProgressFunc,
 ) (SyncStats, int, error) {
 	stats, tombstoned, _, err := func() (SyncStats, int, passEpilogueEligibility, error) {
 		e.syncMu.Lock()
 		defer e.syncMu.Unlock()
 		defer e.clearCurrentProgress()
-		return e.reconcileScopedWatchRootsLocked(ctx, agent, roots, full, force)
+		return e.reconcileScopedWatchRootsLocked(
+			ctx, agent, roots, full, force, onProgress,
+		)
 	}()
 	// Emit outside syncMu so an Emitter implementation cannot widen the
 	// critical section or deadlock by re-entering sync code (see SyncAll).
@@ -4091,8 +4100,9 @@ func (e *Engine) reconcileScopedWatchRoots(
 // exactly when the pass itself would have.
 func (e *Engine) reconcileScopedWatchRootsLocked(
 	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
+	onProgress ProgressFunc,
 ) (SyncStats, int, passEpilogueEligibility, error) {
-	e.reportProgress(nil, Progress{
+	e.reportProgress(onProgress, Progress{
 		Phase:  PhaseDiscovering,
 		Detail: "Reconciling watched session roots",
 	})
@@ -4112,7 +4122,7 @@ func (e *Engine) reconcileScopedWatchRootsLocked(
 		return SyncStats{}, 0, passEpilogueEligibility{}, nil
 	}
 	stats, metrics, tombstoned, eligibility, err := e.reconcileWatchRootsStreamedLocked(
-		ctx, plans, fullCoverage, force,
+		ctx, plans, fullCoverage, force, onProgress,
 	)
 	metrics.ExcludedRemoteRoots = excludedRemoteRoots
 	complete := err == nil && ctx.Err() == nil && !stats.Aborted &&
@@ -4275,7 +4285,7 @@ func reconciliationPlansNeedPass(plans []providerReconciliationPlan) bool {
 // provider scope resolution with a string slice.
 func (e *Engine) reconcileWatchRootsStreamedLocked(
 	ctx context.Context, plans []providerReconciliationPlan,
-	fullCoverage, force bool,
+	fullCoverage, force bool, onProgress ProgressFunc,
 ) (
 	stats SyncStats, metrics ReconciliationMetrics, tombstoned int,
 	eligibility passEpilogueEligibility, retErr error,
@@ -4412,7 +4422,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 			ctx, reconciliationBaselineContextKey{}, baselineTracker,
 		)
 		pageStats := e.collectAndBatch(
-			pageCtx, e.startWorkers(pageCtx, files), len(files), len(files), nil,
+			pageCtx, e.startWorkers(pageCtx, files), len(files), len(files), onProgress,
 			syncWriteDefault,
 		)
 		mergeReconciliationSyncStats(&stats, pageStats)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1347,6 +1347,21 @@ func (e *Engine) prepareChangedPathSync(
 	return prepared
 }
 
+// syncChangedPathsLocked tracks changed-path preparation and application as
+// one owned pass. The caller holds syncMu, so this progress cannot overwrite a
+// different pass while waiting to enter the serialized sync path.
+func (e *Engine) syncChangedPathsLocked(
+	ctx context.Context, paths []string,
+) (SyncStats, int, error) {
+	e.reportProgress(nil, Progress{
+		Phase:  PhaseDiscovering,
+		Detail: "Preparing changed session paths",
+	})
+	return e.applyChangedPathSyncLocked(
+		ctx, e.prepareChangedPathSync(ctx, paths),
+	)
+}
+
 func (e *Engine) applyChangedPathSyncLocked(
 	ctx context.Context, prepared preparedChangedPathSync,
 ) (SyncStats, int, error) {
@@ -1408,14 +1423,12 @@ func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) error {
 	if e.refuseWriteInForceParse("SyncPaths") {
 		return nil
 	}
-	prepared := e.prepareChangedPathSync(ctx, paths)
-	if prepared.empty() {
-		return prepared.classificationErr
-	}
-	e.syncMu.Lock()
-	stats, tombstoned, err := e.applyChangedPathSyncLocked(ctx, prepared)
-	e.clearCurrentProgress()
-	e.syncMu.Unlock()
+	stats, tombstoned, err := func() (SyncStats, int, error) {
+		e.syncMu.Lock()
+		defer e.syncMu.Unlock()
+		defer e.clearCurrentProgress()
+		return e.syncChangedPathsLocked(ctx, paths)
+	}()
 	if stats.Synced > 0 || tombstoned > 0 ||
 		stats.sourceMissingTombstoned > 0 {
 		e.emit("sessions")
@@ -3498,6 +3511,7 @@ func (e *Engine) syncThenRunLocked(
 	// deferred signal recomputes first (inline: syncMu is held) or
 	// pushed sessions could carry stale signal/secret fields.
 	e.signalSched.flushAllInline()
+	e.clearCurrentProgress()
 	if err := work(full || didResync); err != nil {
 		return stats, err
 	}
@@ -3598,6 +3612,7 @@ func (e *Engine) SyncThenRunWithRebuild(
 		return stats, err
 	}
 	e.signalSched.flushAllInline()
+	e.clearCurrentProgress()
 	if err := work(full || didResync, didResync); err != nil {
 		return stats, err
 	}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -9231,6 +9231,21 @@ func TestEngine_ReconcileWatchRootsClearsCurrentProgress(t *testing.T) {
 		"completed reconciliation must not leave the daemon reporting an active sync")
 }
 
+func requireStalledCurrentProgress(t *testing.T, engine *Engine) Progress {
+	t.Helper()
+	var progress Progress
+	require.Eventually(t, func() bool {
+		current, active := engine.CurrentProgress()
+		if !active || !current.Stalled {
+			return false
+		}
+		progress = current
+		return true
+	}, time.Second, time.Millisecond,
+		"active progress did not age into the stalled state")
+	return progress
+}
+
 func TestEngine_ReconcileWatchRootsReportsProgressBeforeDiscoveryReturns(t *testing.T) {
 	const agent parser.AgentType = "blocked-discovery"
 	root := t.TempDir()
@@ -9276,11 +9291,8 @@ func TestEngine_ReconcileWatchRootsReportsProgressBeforeDiscoveryReturns(t *test
 		require.FailNow(t, "reconciliation did not enter discovery")
 	}
 
-	progress, active := engine.CurrentProgress()
-	require.True(t, active,
-		"health must observe reconciliation blocked before its first source")
+	progress := requireStalledCurrentProgress(t, engine)
 	assert.Equal(t, PhaseDiscovering, progress.Phase)
-	assert.True(t, progress.Stalled)
 
 	release <- struct{}{}
 	select {
@@ -9323,11 +9335,8 @@ func TestEngine_SyncPathsReportsProgressBeforeChangedPathStatReturns(t *testing.
 		require.FailNow(t, "changed-path sync did not enter source stat")
 	}
 
-	progress, active := fx.engine.CurrentProgress()
-	require.True(t, active,
-		"health must observe changed-path preparation blocked in source stat")
+	progress := requireStalledCurrentProgress(t, fx.engine)
 	assert.Equal(t, PhaseDiscovering, progress.Phase)
-	assert.True(t, progress.Stalled)
 
 	release <- struct{}{}
 	select {
@@ -9336,7 +9345,7 @@ func TestEngine_SyncPathsReportsProgressBeforeChangedPathStatReturns(t *testing.
 	case <-time.After(time.Second):
 		require.FailNow(t, "changed-path sync did not finish after stat resumed")
 	}
-	_, active = fx.engine.CurrentProgress()
+	_, active := fx.engine.CurrentProgress()
 	assert.False(t, active)
 }
 

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -9291,6 +9291,104 @@ func TestEngine_ReconcileWatchRootsReportsProgressBeforeDiscoveryReturns(t *test
 	}
 }
 
+func TestEngine_SyncPathsReportsProgressBeforeChangedPathStatReturns(t *testing.T) {
+	fx := newEngineFixture(t)
+	path := fx.writeClaudeSession(t, "proj", "blocked-stat.jsonl", "hello")
+	fx.engine.progressStallAfter = time.Nanosecond
+	started := make(chan struct{}, 1)
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	realLstat := fx.engine.lstat
+	var calls atomic.Int32
+	fx.engine.lstat = func(got string) (os.FileInfo, error) {
+		if calls.Add(1) == 1 {
+			assert.Equal(t, path, got)
+			started <- struct{}{}
+			<-release
+		}
+		return realLstat(got)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- fx.engine.SyncPathsContext(t.Context(), []string{path})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "changed-path sync did not enter source stat")
+	}
+
+	progress, active := fx.engine.CurrentProgress()
+	require.True(t, active,
+		"health must observe changed-path preparation blocked in source stat")
+	assert.Equal(t, PhaseDiscovering, progress.Phase)
+	assert.True(t, progress.Stalled)
+
+	release <- struct{}{}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "changed-path sync did not finish after stat resumed")
+	}
+	_, active = fx.engine.CurrentProgress()
+	assert.False(t, active)
+}
+
+func TestEngine_CoordinatedSyncClearsProgressBeforePostSyncWork(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*Engine, func() error) error
+	}{
+		{
+			name: "sync then run",
+			run: func(engine *Engine, work func() error) error {
+				_, err := engine.SyncThenRun(
+					t.Context(), false, nil, func(bool) error { return work() },
+				)
+				return err
+			},
+		},
+		{
+			name: "sync then run with rebuild",
+			run: func(engine *Engine, work func() error) error {
+				_, err := engine.SyncThenRunWithRebuild(
+					t.Context(), false, nil,
+					func() (RebuildOptions, RebuildCleanup, error) {
+						return RebuildOptions{}, nil, nil
+					},
+					nil,
+					func(bool, bool) error { return work() },
+				)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fx := newEngineFixture(t)
+			fx.writeClaudeSession(t, "proj", "post-sync.jsonl", "hello")
+			workCalled := false
+
+			err := tt.run(fx.engine, func() error {
+				workCalled = true
+				_, active := fx.engine.CurrentProgress()
+				assert.False(t, active,
+					"post-sync work must not inherit completed sync progress")
+				return nil
+			})
+
+			require.NoError(t, err)
+			assert.True(t, workCalled)
+		})
+	}
+}
+
 func TestEngine_TryRunExclusiveRejectsBusySyncWithoutRunningWork(t *testing.T) {
 	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
 	t.Cleanup(engine.Close)

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -956,6 +956,8 @@ type directStreamingProvider struct {
 	parseCalls       atomic.Int32
 	discoverStarted  chan<- struct{}
 	discoverRelease  <-chan struct{}
+	parseStarted     chan<- struct{}
+	parseRelease     <-chan struct{}
 	source           *parser.SourceRef
 	parseErr         error
 	parseOutcome     parser.ParseOutcome
@@ -1013,9 +1015,22 @@ func (provider *directStreamingProvider) Fingerprint(
 }
 
 func (provider *directStreamingProvider) Parse(
-	context.Context, parser.ParseRequest,
+	ctx context.Context, _ parser.ParseRequest,
 ) (parser.ParseOutcome, error) {
 	provider.parseCalls.Add(1)
+	if provider.parseStarted != nil {
+		select {
+		case provider.parseStarted <- struct{}{}:
+		default:
+		}
+	}
+	if provider.parseRelease != nil {
+		select {
+		case <-provider.parseRelease:
+		case <-ctx.Done():
+			return parser.ParseOutcome{}, ctx.Err()
+		}
+	}
 	return provider.parseOutcome, provider.parseErr
 }
 

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -954,6 +954,8 @@ type directStreamingProvider struct {
 	discoverCalls    atomic.Int32
 	changedPathCalls atomic.Int32
 	parseCalls       atomic.Int32
+	discoverStarted  chan<- struct{}
+	discoverRelease  <-chan struct{}
 	source           *parser.SourceRef
 	parseErr         error
 	parseOutcome     parser.ParseOutcome
@@ -970,6 +972,19 @@ func (provider *directStreamingProvider) DiscoverEach(
 ) error {
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	if provider.discoverStarted != nil {
+		select {
+		case provider.discoverStarted <- struct{}{}:
+		default:
+		}
+	}
+	if provider.discoverRelease != nil {
+		select {
+		case <-provider.discoverRelease:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 	if provider.source != nil {
 		return yield(*provider.source)
@@ -9185,6 +9200,117 @@ func TestEngine_SyncAllDoesNotEmitOnEmptyRun(t *testing.T) {
 	stats := fx.engine.SyncAll(context.Background(), nil)
 	require.Zero(t, stats.Synced)
 	assert.Empty(t, em.got(), "expected no emissions")
+}
+
+func TestEngine_ReconcileWatchRootsClearsCurrentProgress(t *testing.T) {
+	fx := newEngineFixture(t)
+	fx.writeClaudeSession(t, "proj", "s1.jsonl", "hello")
+
+	err := fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	)
+
+	require.NoError(t, err)
+	_, active := fx.engine.CurrentProgress()
+	assert.False(t, active,
+		"completed reconciliation must not leave the daemon reporting an active sync")
+}
+
+func TestEngine_ReconcileWatchRootsReportsProgressBeforeDiscoveryReturns(t *testing.T) {
+	const agent parser.AgentType = "blocked-discovery"
+	root := t.TempDir()
+	started := make(chan struct{}, 1)
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+			}},
+		},
+		discoverStarted: started,
+		discoverRelease: release,
+	}
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs:          map[parser.AgentType][]string{agent: {root}},
+		Machine:            "local",
+		ProgressStallAfter: time.Nanosecond,
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	done := make(chan error, 1)
+	go func() {
+		done <- engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "reconciliation did not enter discovery")
+	}
+
+	progress, active := engine.CurrentProgress()
+	require.True(t, active,
+		"health must observe reconciliation blocked before its first source")
+	assert.Equal(t, PhaseDiscovering, progress.Phase)
+	assert.True(t, progress.Stalled)
+
+	release <- struct{}{}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "reconciliation did not finish after discovery resumed")
+	}
+}
+
+func TestEngine_TryRunExclusiveRejectsBusySyncWithoutRunningWork(t *testing.T) {
+	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+	entered := make(chan struct{})
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	done := make(chan error, 1)
+	go func() {
+		done <- engine.RunExclusive(func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "first exclusive sync did not acquire the lock")
+	}
+
+	workRan := false
+	err := engine.TryRunExclusive(func() error {
+		workRan = true
+		return nil
+	})
+
+	require.ErrorIs(t, err, ErrSyncInProgress)
+	assert.False(t, workRan)
+	release <- struct{}{}
+	require.NoError(t, <-done)
 }
 
 func TestEngine_ZeroSyncedSuccessfulResyncEmits(t *testing.T) {

--- a/internal/sync/hermes_archive_test.go
+++ b/internal/sync/hermes_archive_test.go
@@ -753,7 +753,7 @@ func TestReconcileHermesSiblingMemberChangeBoundsUnchangedMemberWork(
 		require.NoError(t, os.Chtimes(stateDB, bumped, bumped))
 
 		stats, _, err := engine.ReconcileWatchRootsWithStats(
-			t.Context(), []string{sessionsDir}, false,
+			t.Context(), []string{sessionsDir}, false, nil,
 		)
 		require.NoError(t, err)
 		scans = engine.LastReconciliationResult().Metrics.SharedContainerScans

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -1,6 +1,9 @@
 package sync
 
-import gosync "sync"
+import (
+	gosync "sync"
+	"time"
+)
 
 // Phase describes the current sync phase.
 type Phase string
@@ -18,20 +21,25 @@ const (
 	PhaseDone             Phase = "done"
 )
 
+const defaultProgressStallAfter = 5 * time.Minute
+
 // Progress reports sync progress to listeners.
 type Progress struct {
-	Phase           Phase  `json:"phase"`
-	Detail          string `json:"detail,omitempty"`
-	Hint            string `json:"hint,omitempty"`
-	Resync          bool   `json:"resync,omitempty"`
-	CurrentProject  string `json:"current_project,omitempty"`
-	ProjectsTotal   int    `json:"projects_total"`
-	ProjectsDone    int    `json:"projects_done"`
-	SessionsTotal   int    `json:"sessions_total"`
-	SessionsDone    int    `json:"sessions_done"`
-	MessagesIndexed int    `json:"messages_indexed"`
-	BytesDone       int64  `json:"bytes_done,omitempty"`
-	BytesTotal      int64  `json:"bytes_total,omitempty"`
+	Phase           Phase     `json:"phase"`
+	Detail          string    `json:"detail,omitempty"`
+	Hint            string    `json:"hint,omitempty"`
+	Resync          bool      `json:"resync,omitempty"`
+	StartedAt       time.Time `json:"started_at,omitzero"`
+	UpdatedAt       time.Time `json:"updated_at,omitzero"`
+	Stalled         bool      `json:"stalled,omitempty"`
+	CurrentProject  string    `json:"current_project,omitempty"`
+	ProjectsTotal   int       `json:"projects_total"`
+	ProjectsDone    int       `json:"projects_done"`
+	SessionsTotal   int       `json:"sessions_total"`
+	SessionsDone    int       `json:"sessions_done"`
+	MessagesIndexed int       `json:"messages_indexed"`
+	BytesDone       int64     `json:"bytes_done,omitempty"`
+	BytesTotal      int64     `json:"bytes_total,omitempty"`
 }
 
 // SyncResult describes the outcome of syncing a single session.

--- a/internal/sync/watch_batch_sync.go
+++ b/internal/sync/watch_batch_sync.go
@@ -331,7 +331,7 @@ func (e *Engine) SyncWatchBatchThenRun(
 	if len(reconcileRoots) > 0 {
 		reconcileStats, tombstoned, _, reconcileErr :=
 			e.reconcileScopedWatchRootsLocked(
-				ctx, "", reconcileRoots, false, plan.lostEvents,
+				ctx, "", reconcileRoots, false, plan.lostEvents, nil,
 			)
 		mergeSyncStats(&stats, reconcileStats)
 		changed = changed || reconcileStats.Synced > 0 || tombstoned > 0

--- a/internal/sync/watch_batch_sync.go
+++ b/internal/sync/watch_batch_sync.go
@@ -20,6 +20,12 @@ type WatchBatchSyncer interface {
 	ReconcileWatchRootsAfterLostEvents(context.Context, []string, bool) error
 }
 
+type ownedWatchBatchSyncer interface {
+	SyncWatchBatchThenRun(
+		context.Context, WatchBatch, *WatchRecoveryScope, func() error,
+	) (SyncStats, error)
+}
+
 // ValidateWatchBatch rejects malformed or ambiguous public watcher scope
 // before any archive work begins.
 func ValidateWatchBatch(batch WatchBatch, recovery *WatchRecoveryScope) error {
@@ -119,7 +125,10 @@ func watchBatchReconciliationError(
 }
 
 func planWatchBatch(
-	engine WatchBatchSyncer, batch WatchBatch, recovery *WatchRecoveryScope,
+	engine WatchBatchSyncer,
+	batch WatchBatch,
+	recovery *WatchRecoveryScope,
+	statPath func(string) (os.FileInfo, error),
 ) (watchBatchPlan, error) {
 	plan := watchBatchPlan{
 		paths:          append([]string(nil), batch.Paths...),
@@ -159,7 +168,7 @@ func planWatchBatch(
 			authoritativeRenames[owner] = struct{}{}
 			plan.paths = watchRemoveString(plan.paths, rename.Path)
 		case ItemIsUnknown:
-			info, err := os.Stat(rename.Path)
+			info, err := statPath(rename.Path)
 			if err == nil {
 				if info.IsDir() {
 					promoteDirectoryRename(rename)
@@ -206,7 +215,11 @@ func ApplyWatchBatch(
 	if err := ValidateWatchBatch(batch, recovery); err != nil {
 		return err
 	}
-	plan, err := planWatchBatch(engine, batch, recovery)
+	if owned, ok := engine.(ownedWatchBatchSyncer); ok {
+		_, err := owned.SyncWatchBatchThenRun(ctx, batch, recovery, nil)
+		return err
+	}
+	plan, err := planWatchBatch(engine, batch, recovery, os.Stat)
 	if err != nil {
 		return err
 	}
@@ -272,10 +285,6 @@ func (e *Engine) SyncWatchBatchThenRun(
 	if err := ValidateWatchBatch(batch, recovery); err != nil {
 		return SyncStats{}, err
 	}
-	plan, err := planWatchBatch(e, batch, recovery)
-	if err != nil {
-		return SyncStats{}, err
-	}
 	changed := false
 	e.syncMu.Lock()
 	defer func() {
@@ -285,6 +294,18 @@ func (e *Engine) SyncWatchBatchThenRun(
 			e.emit("sessions")
 		}
 	}()
+	e.reportProgress(nil, Progress{
+		Phase:  PhaseDiscovering,
+		Detail: "Planning watcher batch",
+	})
+	statPath := e.stat
+	if statPath == nil {
+		statPath = os.Stat
+	}
+	plan, err := planWatchBatch(e, batch, recovery, statPath)
+	if err != nil {
+		return SyncStats{}, err
+	}
 
 	if len(plan.paths) > 0 {
 		pathStats, tombstoned, pathErr := e.syncChangedPathsLocked(ctx, plan.paths)

--- a/internal/sync/watch_batch_sync.go
+++ b/internal/sync/watch_batch_sync.go
@@ -276,11 +276,6 @@ func (e *Engine) SyncWatchBatchThenRun(
 	if err != nil {
 		return SyncStats{}, err
 	}
-	var prepared preparedChangedPathSync
-	if len(plan.paths) > 0 {
-		prepared = e.prepareChangedPathSync(ctx, plan.paths)
-	}
-
 	changed := false
 	e.syncMu.Lock()
 	defer func() {
@@ -292,7 +287,7 @@ func (e *Engine) SyncWatchBatchThenRun(
 	}()
 
 	if len(plan.paths) > 0 {
-		pathStats, tombstoned, pathErr := e.applyChangedPathSyncLocked(ctx, prepared)
+		pathStats, tombstoned, pathErr := e.syncChangedPathsLocked(ctx, plan.paths)
 		mergeSyncStats(&stats, pathStats)
 		changed = changed || pathStats.Synced > 0 || tombstoned > 0 ||
 			pathStats.sourceMissingTombstoned > 0
@@ -329,6 +324,7 @@ func (e *Engine) SyncWatchBatchThenRun(
 		return stats, err
 	}
 	e.signalSched.flushAllInline()
+	e.clearCurrentProgress()
 	if work != nil {
 		if err := work(); err != nil {
 			return stats, err

--- a/internal/sync/watch_batch_sync_test.go
+++ b/internal/sync/watch_batch_sync_test.go
@@ -253,6 +253,79 @@ func TestSyncWatchBatchThenRunReportsProgressBeforeReconciliationDiscoveryReturn
 	}
 }
 
+func TestSyncWatchBatchThenRunReportsProgressBeforeChangedPathParseReturns(
+	t *testing.T,
+) {
+	const agent parser.AgentType = "watch-batch-blocked-changed-path"
+	root := t.TempDir()
+	path := filepath.Join(root, "source.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	started := make(chan struct{}, 1)
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	source := parser.SourceRef{
+		Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+	}
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+				FindSource:         parser.CapabilitySupported,
+			}},
+		},
+		source:       &source,
+		parseStarted: started,
+		parseRelease: release,
+		parseOutcome: parser.ParseOutcome{ResultSetComplete: true},
+	}
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs:          map[parser.AgentType][]string{agent: {root}},
+		Machine:            "local",
+		ProgressStallAfter: time.Nanosecond,
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	done := make(chan error, 1)
+	go func() {
+		_, err := engine.SyncWatchBatchThenRun(
+			t.Context(), WatchBatch{Paths: []string{path}}, nil, nil,
+		)
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch batch did not enter changed-path parsing")
+	}
+
+	progress, active := engine.CurrentProgress()
+	require.True(t, active,
+		"health must observe a watch batch blocked in changed-path parsing")
+	assert.Equal(t, PhaseSyncing, progress.Phase)
+	assert.True(t, progress.Stalled)
+
+	release <- struct{}{}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch batch did not finish after parsing resumed")
+	}
+}
+
 func TestValidateWatchBatchAcceptsBoundedAndAuthoritativeScopes(t *testing.T) {
 	root := t.TempDir()
 	other := t.TempDir()

--- a/internal/sync/watch_batch_sync_test.go
+++ b/internal/sync/watch_batch_sync_test.go
@@ -350,6 +350,65 @@ func TestSyncWatchBatchThenRunClearsProgressBeforePostSyncWork(t *testing.T) {
 	assert.True(t, workCalled)
 }
 
+func TestApplyWatchBatchReportsProgressBeforeUnknownRenameStatReturns(
+	t *testing.T,
+) {
+	const agent parser.AgentType = "watch-batch-blocked-rename-plan"
+	_, engine, _, _, path := newChangedPathOutcomeEngine(
+		t, agent, func(string) parser.ParseOutcome {
+			return parser.ParseOutcome{ResultSetComplete: true}
+		},
+	)
+	engine.progressStallAfter = time.Nanosecond
+	started := make(chan struct{}, 1)
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	realStat := engine.stat
+	engine.stat = func(got string) (os.FileInfo, error) {
+		assert.Equal(t, path, got)
+		started <- struct{}{}
+		<-release
+		return realStat(got)
+	}
+	done := make(chan error, 1)
+	go func() {
+		err := ApplyWatchBatch(
+			t.Context(), engine, WatchBatch{Renames: []WatchRename{{
+				Path: path, Agent: string(agent), ItemType: ItemIsUnknown,
+			}}}, &WatchRecoveryScope{},
+		)
+		done <- err
+	}()
+	select {
+	case <-started:
+	case err := <-done:
+		require.FailNow(t, "watch batch bypassed the owned planning stat", "%v", err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch batch did not enter rename planning stat")
+	}
+
+	progress, active := engine.CurrentProgress()
+	require.True(t, active,
+		"health must observe watch-batch planning blocked in source stat")
+	assert.Equal(t, PhaseDiscovering, progress.Phase)
+	assert.True(t, progress.Stalled)
+
+	release <- struct{}{}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch batch did not finish after planning resumed")
+	}
+	_, active = engine.CurrentProgress()
+	assert.False(t, active)
+}
+
 func TestValidateWatchBatchAcceptsBoundedAndAuthoritativeScopes(t *testing.T) {
 	root := t.TempDir()
 	other := t.TempDir()

--- a/internal/sync/watch_batch_sync_test.go
+++ b/internal/sync/watch_batch_sync_test.go
@@ -188,6 +188,71 @@ func TestSyncWatchBatchThenRunMissingPathTombstoneIsCardinalityBounded(t *testin
 	assert.Equal(t, int32(1), classifications[0])
 }
 
+func TestSyncWatchBatchThenRunReportsProgressBeforeReconciliationDiscoveryReturns(
+	t *testing.T,
+) {
+	const agent parser.AgentType = "watch-batch-blocked-discovery"
+	root := t.TempDir()
+	started := make(chan struct{}, 1)
+	release := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}()
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+			}},
+		},
+		discoverStarted: started,
+		discoverRelease: release,
+	}
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs:          map[parser.AgentType][]string{agent: {root}},
+		Machine:            "local",
+		ProgressStallAfter: time.Nanosecond,
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	done := make(chan error, 1)
+	go func() {
+		_, err := engine.SyncWatchBatchThenRun(
+			t.Context(), WatchBatch{ReconcileRoots: []string{root}}, nil, nil,
+		)
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch batch did not enter reconciliation discovery")
+	}
+
+	progress, active := engine.CurrentProgress()
+	require.True(t, active,
+		"health must observe a watch batch blocked in reconciliation discovery")
+	assert.Equal(t, PhaseDiscovering, progress.Phase)
+	assert.True(t, progress.Stalled)
+
+	release <- struct{}{}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "watch batch did not finish after discovery resumed")
+	}
+}
+
 func TestValidateWatchBatchAcceptsBoundedAndAuthoritativeScopes(t *testing.T) {
 	root := t.TempDir()
 	other := t.TempDir()

--- a/internal/sync/watch_batch_sync_test.go
+++ b/internal/sync/watch_batch_sync_test.go
@@ -238,11 +238,8 @@ func TestSyncWatchBatchThenRunReportsProgressBeforeReconciliationDiscoveryReturn
 		require.FailNow(t, "watch batch did not enter reconciliation discovery")
 	}
 
-	progress, active := engine.CurrentProgress()
-	require.True(t, active,
-		"health must observe a watch batch blocked in reconciliation discovery")
+	progress := requireStalledCurrentProgress(t, engine)
 	assert.Equal(t, PhaseDiscovering, progress.Phase)
-	assert.True(t, progress.Stalled)
 
 	release <- struct{}{}
 	select {
@@ -311,11 +308,8 @@ func TestSyncWatchBatchThenRunReportsProgressBeforeChangedPathParseReturns(
 		require.FailNow(t, "watch batch did not enter changed-path parsing")
 	}
 
-	progress, active := engine.CurrentProgress()
-	require.True(t, active,
-		"health must observe a watch batch blocked in changed-path parsing")
+	progress := requireStalledCurrentProgress(t, engine)
 	assert.Equal(t, PhaseSyncing, progress.Phase)
-	assert.True(t, progress.Stalled)
 
 	release <- struct{}{}
 	select {
@@ -392,11 +386,8 @@ func TestApplyWatchBatchReportsProgressBeforeUnknownRenameStatReturns(
 		require.FailNow(t, "watch batch did not enter rename planning stat")
 	}
 
-	progress, active := engine.CurrentProgress()
-	require.True(t, active,
-		"health must observe watch-batch planning blocked in source stat")
+	progress := requireStalledCurrentProgress(t, engine)
 	assert.Equal(t, PhaseDiscovering, progress.Phase)
-	assert.True(t, progress.Stalled)
 
 	release <- struct{}{}
 	select {
@@ -405,7 +396,7 @@ func TestApplyWatchBatchReportsProgressBeforeUnknownRenameStatReturns(
 	case <-time.After(time.Second):
 		require.FailNow(t, "watch batch did not finish after planning resumed")
 	}
-	_, active = engine.CurrentProgress()
+	_, active := engine.CurrentProgress()
 	assert.False(t, active)
 }
 

--- a/internal/sync/watch_batch_sync_test.go
+++ b/internal/sync/watch_batch_sync_test.go
@@ -326,6 +326,30 @@ func TestSyncWatchBatchThenRunReportsProgressBeforeChangedPathParseReturns(
 	}
 }
 
+func TestSyncWatchBatchThenRunClearsProgressBeforePostSyncWork(t *testing.T) {
+	const agent parser.AgentType = "watch-batch-post-sync-work"
+	_, engine, _, _, path := newChangedPathOutcomeEngine(
+		t, agent, func(string) parser.ParseOutcome {
+			return parser.ParseOutcome{ResultSetComplete: true}
+		},
+	)
+	workCalled := false
+
+	_, err := engine.SyncWatchBatchThenRun(
+		t.Context(), WatchBatch{Paths: []string{path}}, nil,
+		func() error {
+			workCalled = true
+			_, active := engine.CurrentProgress()
+			assert.False(t, active,
+				"post-sync work must not inherit completed sync progress")
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, workCalled)
+}
+
 func TestValidateWatchBatchAcceptsBoundedAndAuthoritativeScopes(t *testing.T) {
 	root := t.TempDir()
 	other := t.TempDir()


### PR DESCRIPTION
Fixes #1403.

A failed network mount can leave the daemon alive while a sync pass is blocked
inside a filesystem call. Ping now preserves `ok: true` for daemon identity but
reports `healthy: false` with stalled sync details after five minutes without
progress. Sync status exposes the same timestamps and stalled flag.

In-process and worker-backed passes publish progress through the parent daemon.
Worker resyncs and daily archive audits are visible before their first worker
event and relay subsequent updates. Watcher batches acquire sync ownership
before rename planning, source preparation, discovery, or parsing. Coordinated
syncs clear progress after signal flushing and before PostgreSQL or DuckDB mirror
callbacks, so post-sync work is not mislabeled as stalled. New foreground sync
requests still fail promptly while another pass owns the engine; background work
remains serialized.

This detects the blocked state rather than attempting to cancel an uninterruptible
filesystem call. Operators can recognize and recover an unhealthy daemon without
clients treating the live process as missing and starting a duplicate.
