### PR TITLE
fix(config): honor explicit empty agent directory arrays

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -747,8 +747,9 @@ The corresponding fields are `aider_dirs`, `amp_dirs`, `antigravity_dirs`,
 `shelley_dirs`, `traex_sessions_dirs`, `visualstudio_copilot_dirs`,
 `vscode_copilot_dirs`, `windsurf_dirs`, `warp_dirs`,
 `workbuddy_project_dirs`, `zcode_dirs`, `zed_dirs`, and `zencoder_dirs`. Each
-accepts an array of paths. When set, these take precedence over the
-single-directory environment variable and the default path.
+accepts an array of paths. Environment variables take precedence over these
+arrays when both are set; otherwise, a non-empty array replaces the default
+path and an explicit empty array clears the default local directory.
 
 All listed directories are discovered, watched, and synced independently.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -236,6 +236,12 @@ support is deprecated because current Amp releases may keep full threads
 server-side and leave only local stubs; historical local Amp thread JSON files
 can still be parsed.
 
+The matching environment variable and `*_dirs` configuration key override an
+agent's default directories. Environment variables take precedence when both
+are set. Set a `*_dirs` key to an explicit empty array, such as
+`grok_dirs = []`, to disable discovery for that provider. Omitting the key
+keeps its default directories.
+
 | Agent                 | Default Directory                                                                | File Format                                                                                                                     |
 | --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | Aider                 | No default; opt in with `AIDER_DIR` or `aider_dirs`                              | `.aider.chat.history.md` Markdown history files                                                                                 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,9 +238,11 @@ can still be parsed.
 
 The matching environment variable and `*_dirs` configuration key override an
 agent's default directories. Environment variables take precedence when both
-are set. Set a `*_dirs` key to an explicit empty array, such as
-`grok_dirs = []`, to disable discovery for that provider. Omitting the key
-keeps its default directories.
+are set. An explicit empty `*_dirs` array, such as `grok_dirs = []`, clears that
+agent's default local directories, so local discovery finds nothing there.
+Matching `session_sources` entries for that agent still apply. Provider-wide
+exclusion is documented under [Disabling Session Providers](#disabling-session-providers).
+Omitting the key keeps its default directories.
 
 | Agent                 | Default Directory                                                                | File Format                                                                                                                     |
 | --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1459,6 +1459,7 @@ func (c *Config) applyConfigTOML(data string) error {
 			continue
 		}
 		dirs := make([]string, 0, len(rawSlice))
+		valid := true
 		for _, v := range rawSlice {
 			s, ok := v.(string)
 			if !ok {
@@ -1466,12 +1467,12 @@ func (c *Config) applyConfigTOML(data string) error {
 					"config: %s: expected string array: element is %T",
 					def.ConfigKey, v,
 				)
-				dirs = nil
+				valid = false
 				break
 			}
 			dirs = append(dirs, s)
 		}
-		if len(dirs) > 0 {
+		if valid {
 			c.AgentDirs[def.Type] = dirs
 			c.agentDirSource[def.Type] = dirFile
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -855,6 +855,123 @@ func TestLoadFile_ReadsDirArrays(t *testing.T) {
 	assert.True(t, cfg.IsUserConfigured(parser.AgentAider))
 }
 
+func TestAgentDirsExplicitEmptyArrayOverridesDefaults(t *testing.T) {
+	t.Setenv("GROK_DIR", "")
+	t.Setenv("COPILOT_DIR", "")
+	defaults, err := Default()
+	require.NoError(t, err)
+	require.NotEmpty(t, defaults.ResolveDirs(parser.AgentGrok))
+	require.NotEmpty(t, defaults.ResolveDirs(parser.AgentCopilot))
+
+	cfg := loadMinimalWithConfig(t, map[string]any{
+		"grok_dirs":    []string{},
+		"copilot_dirs": []string{},
+	})
+
+	assert.Empty(t, cfg.ResolveDirs(parser.AgentGrok))
+	assert.True(t, cfg.IsUserConfigured(parser.AgentGrok))
+	assert.Empty(t, cfg.ResolveDirs(parser.AgentCopilot))
+	assert.True(t, cfg.IsUserConfigured(parser.AgentCopilot))
+}
+
+func TestAgentDirsEnvBeatsExplicitEmptyArray(t *testing.T) {
+	f := newConfigFixture(t)
+	f.WriteConfigText(t, "grok_dirs = []\n")
+	t.Setenv("GROK_DIR", "/from/env/grok")
+
+	cfg := f.LoadMinimal(t)
+
+	assert.Equal(t, []string{"/from/env/grok"}, cfg.ResolveDirs(parser.AgentGrok))
+	assert.True(t, cfg.IsUserConfigured(parser.AgentGrok))
+}
+
+func TestAgentDirsArrayPresenceTable(t *testing.T) {
+	t.Setenv("GROK_DIR", "")
+	tests := []struct {
+		name     string
+		config   string
+		wantUser bool
+		want     []string
+		empty    bool
+	}{
+		{name: "omitted retains defaults"},
+		{name: "non-empty replaces defaults", config: `grok_dirs = ["/from/config"]`, wantUser: true, want: []string{"/from/config"}},
+		{name: "empty clears defaults", config: "grok_dirs = []", wantUser: true, empty: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newConfigFixture(t)
+			f.WriteConfigText(t, tt.config)
+			cfg := f.LoadMinimal(t)
+
+			dirs := cfg.ResolveDirs(parser.AgentGrok)
+			assert.Equal(t, tt.wantUser, cfg.IsUserConfigured(parser.AgentGrok))
+			switch {
+			case tt.empty:
+				assert.Empty(t, dirs)
+			case tt.want != nil:
+				assert.Equal(t, tt.want, dirs)
+			default:
+				assert.NotEmpty(t, dirs)
+			}
+		})
+	}
+}
+
+func TestAgentDirsMalformedValuePreservesDefaults(t *testing.T) {
+	t.Setenv("GROK_DIR", "")
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{name: "non-array", config: `grok_dirs = "not-an-array"`},
+		{name: "non-string element", config: "grok_dirs = [\"/valid\", 7]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newConfigFixture(t)
+			f.WriteConfigText(t, tt.config)
+			cfg := f.LoadMinimal(t)
+
+			assert.NotEmpty(t, cfg.ResolveDirs(parser.AgentGrok))
+			assert.False(t, cfg.IsUserConfigured(parser.AgentGrok))
+		})
+	}
+}
+
+func TestAgentDirsNonexistentOverrideAndBlankEntry(t *testing.T) {
+	t.Setenv("GROK_DIR", "")
+	f := newConfigFixture(t)
+	f.WriteConfigText(t, "grok_dirs = [\"  \", \"C:/path/that/does/not/exist\"]\n")
+
+	cfg := f.LoadMinimal(t)
+
+	assert.Equal(t, []string{"C:/path/that/does/not/exist"},
+		cfg.ResolveDirs(parser.AgentGrok))
+	assert.True(t, cfg.IsUserConfigured(parser.AgentGrok))
+}
+
+func TestAgentDirsEmptyArrayWithSessionSource(t *testing.T) {
+	t.Setenv("GROK_DIR", "")
+	f := newConfigFixture(t)
+	f.WriteConfigText(t, `grok_dirs = []
+
+[[session_sources]]
+agent = "grok"
+dir = "/sessions/archive"
+machine = "archivebox"
+`)
+
+	cfg := f.LoadMinimal(t)
+
+	assert.Equal(t, []string{"/sessions/archive"}, cfg.ResolveDirs(parser.AgentGrok))
+	assert.Equal(t, "archivebox",
+		cfg.SourceMachines[parser.AgentGrok]["/sessions/archive"])
+	assert.True(t, cfg.IsUserConfigured(parser.AgentGrok))
+}
+
 func TestLoadFileSessionSourcesAreAdditiveAndOverrideDuplicateMachine(t *testing.T) {
 	f := newConfigFixture(t)
 	f.WriteConfigText(t, `


### PR DESCRIPTION
An explicit empty `*_dirs` array, such as `grok_dirs = []`, clears that agent's default local directories, so local discovery finds nothing there. Matching `session_sources` entries for that agent still apply. Provider-wide exclusion is documented under Disabling Session Providers.

The decoder treats every present, well-formed array as authoritative, including an empty array; malformed values preserve the existing configuration and environment variables retain precedence.

Closes #1417
