### PR TITLE
fix(parser): populate Kimi session cwd

### DIFF
--- a/.git-commit-message.txt
+++ b/.git-commit-message.txt
@@ -1,0 +1,1 @@
+test(parser): cover Kimi empty cwd and usage identity (#1418)

--- a/.git-commit-message.txt
+++ b/.git-commit-message.txt
@@ -1,1 +1,0 @@
-test(parser): cover Kimi empty cwd and usage identity (#1418)

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1062,6 +1062,11 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Format:** Session directories containing `wire.jsonl`, with both current and
   legacy wire layouts.
 
+- **Working directory:** Native Kimi Code `config.update` records can carry the
+  provider-emitted absolute `cwd`; Agentsview preserves the last non-empty
+  value for sync filtering. The exact issue artifact is covered by
+  `internal/parser/testdata/kimi-config-update-cwd.jsonl`.
+
 - **Evidence:** `source`.
 
 - **Upstream:** Clone `https://github.com/MoonshotAI/kimi-cli.git` at

--- a/internal/parser/kimi.go
+++ b/internal/parser/kimi.go
@@ -182,6 +182,7 @@ func parseKimiSessionWithFallbackModel(
 		pendingUsageMessageIndex = -1
 		hasThinking              bool
 		hasToolUse               bool
+		cwd                      string
 
 		// Track token usage from StatusUpdate.
 		totalOutputTokens    int
@@ -310,6 +311,9 @@ func parseKimiSessionWithFallbackModel(
 			case "config.update":
 				if model := root.Get("modelAlias").Str; model != "" {
 					currentModel = model
+				}
+				if value := root.Get("cwd").Str; value != "" {
+					cwd = value
 				}
 
 			case "turn.prompt", "turn.steer":
@@ -695,6 +699,7 @@ func parseKimiSessionWithFallbackModel(
 		Project:                     displayProject,
 		Machine:                     machine,
 		Agent:                       AgentKimi,
+		Cwd:                         cwd,
 		FirstMessage:                firstMessage,
 		StartedAt:                   startTime,
 		EndedAt:                     endTime,

--- a/internal/parser/kimi_provider.go
+++ b/internal/parser/kimi_provider.go
@@ -140,6 +140,7 @@ func kimiProviderCapabilities() Capabilities {
 			Thinking:     CapabilitySupported,
 			ToolCalls:    CapabilitySupported,
 			ToolResults:  CapabilitySupported,
+			Cwd:          CapabilitySupported,
 		},
 	}
 }

--- a/internal/parser/kimi_provider_test.go
+++ b/internal/parser/kimi_provider_test.go
@@ -150,6 +150,28 @@ func TestKimiProviderParse(t *testing.T) {
 	assert.Len(t, outcome.Results[0].Result.Messages, 2)
 }
 
+func TestKimiProviderCwdCapabilityAndParse(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(
+		root, "wd_kimi-code_057f5c09ee3f", "session_uuid-cwd",
+		"agents", "main", "wire.jsonl",
+	)
+	writeSourceFile(t, sourcePath, kimiConfigUpdateCwdLine(t)+"\n"+
+		`{"type":"turn.prompt","input":[{"type":"text","text":"cwd"}]}`+"\n")
+
+	provider, ok := NewProvider(AgentKimi, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	assert.Equal(t, CapabilitySupported, provider.Capabilities().Content.Cwd)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, "/Users/helix/Code/mcp-hub", outcome.Results[0].Result.Session.Cwd)
+}
+
 func TestKimiProviderParseNewLayoutRoundTrip(t *testing.T) {
 	root := t.TempDir()
 	rawID := "wd_kimi-code_057f5c09ee3f:main:session_uuid-2"

--- a/internal/parser/kimi_test.go
+++ b/internal/parser/kimi_test.go
@@ -52,6 +52,18 @@ func parseKimiSessionForTest(
 	return parseKimiSession(path, project, machine)
 }
 
+func kimiConfigUpdateCwdLine(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/kimi-config-update-cwd.jsonl")
+	require.NoError(t, err)
+	line := strings.TrimSpace(string(raw))
+	require.Equal(t,
+		`{"type":"config.update","cwd":"/Users/helix/Code/mcp-hub","modelAlias":"kimi-code/kimi-for-coding"}`,
+		line,
+	)
+	return line
+}
+
 func TestParseKimiSession_Basic(t *testing.T) {
 	path := writeKimiWireJSONL(t,
 		"abc123", "sess-uuid-1234",
@@ -705,6 +717,7 @@ func TestParseKimiSession_NativeKimiCodeEvents(t *testing.T) {
 	assert.Contains(t, msgs[1].Content,
 		"Hello! How can I help you today?")
 	assert.Equal(t, "kimi-code/kimi-for-coding", msgs[1].Model)
+	assert.Empty(t, sess.Cwd)
 	assert.Equal(t, "end_turn", msgs[1].StopReason)
 	assert.True(t, msgs[1].HasOutputTokens)
 	assert.True(t, msgs[1].HasContextTokens)
@@ -716,6 +729,54 @@ func TestParseKimiSession_NativeKimiCodeEvents(t *testing.T) {
 	)
 	assertTimestamp(t, msgs[1].Timestamp,
 		time.UnixMilli(1782012668557))
+}
+
+func TestParseKimiSession_ConfigUpdateCwd(t *testing.T) {
+	cwdLine := kimiConfigUpdateCwdLine(t)
+	tests := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{
+			name:  "present",
+			lines: []string{cwdLine},
+			want:  "/Users/helix/Code/mcp-hub",
+		},
+		{
+			name:  "absent",
+			lines: []string{`{"type":"config.update","modelAlias":"kimi-code/kimi-for-coding"}`},
+		},
+		{
+			name:  "empty",
+			lines: []string{`{"type":"config.update","cwd":"","modelAlias":"kimi-code/kimi-for-coding"}`},
+		},
+		{
+			name: "last non-empty value wins",
+			lines: []string{
+				cwdLine,
+				`{"type":"config.update","cwd":"/Users/helix/Code/other"}`,
+				`{"type":"config.update","modelAlias":"kimi-code/kimi-for-coding"}`,
+			},
+			want: "/Users/helix/Code/other",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeKimiCodeWireJSONL(t,
+				"wd_myproject_a1b2c3d4", "session-cwd", "main",
+				append(tt.lines,
+					`{"type":"turn.prompt","input":[{"type":"text","text":"hello"}]}`,
+				),
+			)
+			sess, msgs, err := parseKimiSessionForTest(t, path, "myproject", "local")
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+			assert.Equal(t, tt.want, sess.Cwd)
+			require.NotEmpty(t, msgs)
+		})
+	}
 }
 
 func TestParseKimiSession_NativeKimiCodeToolCall(t *testing.T) {

--- a/internal/parser/kimi_test.go
+++ b/internal/parser/kimi_test.go
@@ -756,6 +756,7 @@ func TestParseKimiSession_ConfigUpdateCwd(t *testing.T) {
 			lines: []string{
 				cwdLine,
 				`{"type":"config.update","cwd":"/Users/helix/Code/other"}`,
+				`{"type":"config.update","cwd":""}`,
 				`{"type":"config.update","modelAlias":"kimi-code/kimi-for-coding"}`,
 			},
 			want: "/Users/helix/Code/other",

--- a/internal/parser/kimi_work_provider_test.go
+++ b/internal/parser/kimi_work_provider_test.go
@@ -220,6 +220,27 @@ func TestKimiWorkProviderParse(t *testing.T) {
 	}
 }
 
+func TestKimiWorkProviderParseRetainsProviderCwd(t *testing.T) {
+	root := t.TempDir()
+	wd := "wd_agentsview_e901f41e2366"
+	sessionDir := "conv-cwd"
+	sourcePath := filepath.Join(
+		root, wd, sessionDir, "agents", "main", "wire.jsonl",
+	)
+	writeSourceFile(t, sourcePath, kimiConfigUpdateCwdLine(t)+"\n"+
+		kimiWorkFixture("provider cwd"))
+
+	provider, ok := NewProvider(AgentKimiWork, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, "/Users/helix/Code/mcp-hub", outcome.Results[0].Result.Session.Cwd)
+}
+
 func TestKimiWorkProviderMissingModelUsesDateAmbiguousAlias(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/parser/kimi_work_provider_test.go
+++ b/internal/parser/kimi_work_provider_test.go
@@ -19,6 +19,13 @@ func kimiWorkFixture(firstMessage string) string {
 	return kimiWorkFixtureAt(firstMessage, 1704067200)
 }
 
+func kimiWorkSessionUsageFixture() string {
+	return `{"timestamp":1704067200.0,"message":{"type":"TurnBegin","payload":{"user_input":[{"type":"text","text":"usage question"}]}}}` + "\n" +
+		`{"timestamp":1704067201.0,"message":{"type":"ContentPart","payload":{"type":"text","text":"Done."}}}` + "\n" +
+		`{"timestamp":1704067202.0,"message":{"type":"StatusUpdate","payload":{"token_usage":{"output":42}}}}` + "\n" +
+		`{"timestamp":1704067203.0,"message":{"type":"TurnEnd","payload":{}}}` + "\n"
+}
+
 func kimiWorkFixtureAt(firstMessage string, timestamp int64) string {
 	return fmt.Sprintf(
 		`{"type":"metadata","protocol_version":"1.4","created_at":%d}`+"\n"+
@@ -228,7 +235,7 @@ func TestKimiWorkProviderParseRetainsProviderCwd(t *testing.T) {
 		root, wd, sessionDir, "agents", "main", "wire.jsonl",
 	)
 	writeSourceFile(t, sourcePath, kimiConfigUpdateCwdLine(t)+"\n"+
-		kimiWorkFixture("provider cwd"))
+		kimiWorkSessionUsageFixture())
 
 	provider, ok := NewProvider(AgentKimiWork, ProviderConfig{Roots: []string{root}})
 	require.True(t, ok)
@@ -238,7 +245,12 @@ func TestKimiWorkProviderParseRetainsProviderCwd(t *testing.T) {
 	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
 	require.NoError(t, err)
 	require.Len(t, outcome.Results, 1)
-	assert.Equal(t, "/Users/helix/Code/mcp-hub", outcome.Results[0].Result.Session.Cwd)
+	result := outcome.Results[0].Result
+	assert.Equal(t, "/Users/helix/Code/mcp-hub", result.Session.Cwd)
+	require.Len(t, result.Session.UsageEvents, 1)
+	assert.Equal(t, result.Session.ID, result.Session.UsageEvents[0].SessionID)
+	assert.Equal(t, "kimi-work:session:"+wd+":main:"+sessionDir, result.Session.UsageEvents[0].DedupKey)
+	assert.Equal(t, 42, result.Session.UsageEvents[0].OutputTokens)
 }
 
 func TestKimiWorkProviderMissingModelUsesDateAmbiguousAlias(t *testing.T) {

--- a/internal/parser/testdata/kimi-config-update-cwd.jsonl
+++ b/internal/parser/testdata/kimi-config-update-cwd.jsonl
@@ -1,0 +1,1 @@
+{"type":"config.update","cwd":"/Users/helix/Code/mcp-hub","modelAlias":"kimi-code/kimi-for-coding"}

--- a/internal/sync/kimi_integration_test.go
+++ b/internal/sync/kimi_integration_test.go
@@ -6,12 +6,47 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
 )
+
+func TestSyncKimiConfigUpdateCwdPrefix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	kimiDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs:          map[parser.AgentType][]string{parser.AgentKimi: {kimiDir}},
+		IncludeCwdPrefixes: []string{"/Users/helix/Code"},
+		Machine:            "local",
+	})
+
+	workdirDir := "wd_kimi-code_057f5c09ee3f"
+	sessionDir := "session_uuid-cwd"
+	wirePath := filepath.Join(kimiDir, workdirDir, sessionDir, "wire.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(wirePath), 0o755))
+	fixture, err := os.ReadFile(filepath.Join(
+		"..", "parser", "testdata", "kimi-config-update-cwd.jsonl",
+	))
+	require.NoError(t, err)
+	content := append(fixture,
+		[]byte(`{"type":"turn.prompt","input":[{"type":"text","text":"cwd"}]}`+"\n")...)
+	require.NoError(t, os.WriteFile(wirePath, content, 0o644))
+
+	sessionID := "kimi:" + workdirDir + ":" + sessionDir
+	engine.SyncPaths([]string{wirePath})
+
+	session, err := testDB.GetSession(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, "/Users/helix/Code/mcp-hub", session.Cwd)
+}
 
 // TestSyncPathsAndSingleSession_KimiNewLayout pins down both engine
 // sites that previously broke for the new .kimi-code layout:


### PR DESCRIPTION
Kimi Code records the working directory in top-level `config.update` records, but the parser drops it, so `sync_include_cwd_prefixes` rejects matching sessions. This records the provider cwd in `ParsedSession.Cwd` and advertises the existing capability, preserving Kimi Work and the global filter.

Refs #1418
