### PR TITLE
fix(parser): support legacy Zed thread schemas

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1435,6 +1435,10 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** `threads/threads.db`, whose thread payload is JSON or zstd-
   compressed JSON depending on generation.
+- **Compatibility:** Agentsview accepts the legacy five-column `threads` table
+  (`id`, `summary`, `updated_at`, `data_type`, and `data`). Modern lineage and
+  metadata columns are optional; a present `parent_id` continues to exclude
+  child threads.
 - **Evidence:** `source`.
 - **Upstream:** Clone `https://github.com/zed-industries/zed.git` at
   `f14fea9bf3c93797d5161f7440ed418655bc6c57`; see

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -165,7 +165,8 @@ type multiSessionConfig struct {
 	// parseContainer parses every member of a container into one result each.
 	// The full ParseRequest is passed so a closure can read req.Machine and
 	// per-request hints such as req.Source.ProjectHint.
-	parseContainer func(src multiSessionSource, req ParseRequest) ([]ParseResult, error)
+	parseContainer        func(src multiSessionSource, req ParseRequest) ([]ParseResult, error)
+	parseContainerContext func(context.Context, multiSessionSource, ParseRequest) ([]ParseResult, error)
 	// parseMember parses a single member; a nil result is a clean no-session.
 	parseMember        func(src multiSessionSource, req ParseRequest) (*ParseResult, error)
 	parseMemberContext func(context.Context, multiSessionSource, ParseRequest) (*ParseResult, error)
@@ -277,6 +278,12 @@ func WithContainerParse(
 	return func(c *multiSessionConfig) { c.parseContainer = fn }
 }
 
+func WithContextContainerParse(
+	fn func(context.Context, multiSessionSource, ParseRequest) ([]ParseResult, error),
+) MultiSessionOption {
+	return func(c *multiSessionConfig) { c.parseContainerContext = fn }
+}
+
 func WithContainerParseOutcome(
 	fn func(src multiSessionSource, req ParseRequest) (ParseOutcome, error),
 ) MultiSessionOption {
@@ -335,7 +342,7 @@ func NewMultiSessionContainerSourceSet(
 		panic("multi-session container: missing WithMemberLookup")
 	case cfg.fingerprint == nil && cfg.fingerprintContext == nil:
 		panic("multi-session container: missing WithFingerprint")
-	case cfg.parseContainer == nil && cfg.parseContainerOutcome == nil:
+	case cfg.parseContainer == nil && cfg.parseContainerContext == nil && cfg.parseContainerOutcome == nil:
 		panic("multi-session container: missing WithContainerParse or WithContainerParseOutcome")
 	case cfg.parseMember == nil && cfg.parseMemberContext == nil:
 		panic("multi-session container: missing WithMemberParse")
@@ -779,7 +786,13 @@ func (s multiSessionContainerSourceSet) parse(
 		return outcome, nil
 	}
 
-	results, err := s.cfg.parseContainer(src, req)
+	var results []ParseResult
+	var err error
+	if s.cfg.parseContainerContext != nil {
+		results, err = s.cfg.parseContainerContext(ctx, src, req)
+	} else {
+		results, err = s.cfg.parseContainer(src, req)
+	}
 	if err != nil {
 		return ParseOutcome{}, err
 	}

--- a/internal/parser/testdata/zed-legacy-threads.sql
+++ b/internal/parser/testdata/zed-legacy-threads.sql
@@ -1,0 +1,7 @@
+CREATE TABLE threads (
+  id TEXT PRIMARY KEY,
+  summary TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  data_type TEXT NOT NULL,
+  data BLOB NOT NULL
+);

--- a/internal/parser/zed.go
+++ b/internal/parser/zed.go
@@ -32,16 +32,12 @@ func ZedSQLiteSessionExists(dbPath, sessionID string) bool {
 		return false
 	}
 	defer db.Close()
-
+	shape, err := inspectZedSchema(db)
+	if err != nil {
+		return false
+	}
 	var found int
-	err = db.QueryRow(
-		`SELECT 1
-		   FROM threads
-		  WHERE id = ?
-		    AND COALESCE(parent_id, '') = ''
-		  LIMIT 1`,
-		sessionID,
-	).Scan(&found)
+	err = db.QueryRow(fmt.Sprintf(`SELECT 1 FROM threads WHERE id = ? %s LIMIT 1`, shape.parentFilter()), sessionID).Scan(&found)
 	return err == nil
 }
 
@@ -57,16 +53,12 @@ func ZedSQLiteSourceMtime(path string) (int64, error) {
 		return 0, err
 	}
 	defer db.Close()
-
+	shape, err := inspectZedSchema(db)
+	if err != nil {
+		return 0, err
+	}
 	var updatedAt string
-	err = db.QueryRow(
-		`SELECT COALESCE(updated_at, '')
-		   FROM threads
-		  WHERE id = ?
-		    AND COALESCE(parent_id, '') = ''
-		  LIMIT 1`,
-		sessionID,
-	).Scan(&updatedAt)
+	err = db.QueryRow(fmt.Sprintf(`SELECT COALESCE(updated_at, '') FROM threads WHERE id = ? %s LIMIT 1`, shape.parentFilter()), sessionID).Scan(&updatedAt)
 	if err != nil {
 		return 0, fmt.Errorf("loading zed thread mtime %s: %w", sessionID, err)
 	}
@@ -98,12 +90,90 @@ func ForEachZedThreadMeta(
 	ctx context.Context, conn *sql.DB, dbPath string,
 	yield func(ZedThreadMeta) error,
 ) error {
-	rows, err := conn.QueryContext(ctx,
-		`SELECT id, COALESCE(updated_at, '')
-		   FROM threads
-		  WHERE COALESCE(parent_id, '') = ''
-		  ORDER BY updated_at, id`,
-	)
+	shape, err := inspectZedSchema(conn)
+	if err != nil {
+		return fmt.Errorf("listing zed thread metas: %w", err)
+	}
+	return forEachZedThreadMeta(ctx, conn, dbPath, shape, yield)
+}
+
+type zedSchema struct {
+	hasParent, hasFolderPaths, hasCreatedAt bool
+}
+
+func inspectZedSchema(conn *sql.DB) (zedSchema, error) {
+	var shape zedSchema
+	var table int
+	if err := conn.QueryRow(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'threads'`).Scan(&table); err != nil {
+		if err == sql.ErrNoRows {
+			return shape, fmt.Errorf("missing Zed threads table")
+		}
+		return shape, fmt.Errorf("inspecting Zed threads table: %w", err)
+	}
+	required := map[string]bool{"id": false, "summary": false, "updated_at": false, "data_type": false, "data": false}
+	rows, err := conn.Query(`PRAGMA table_info(threads)`)
+	if err != nil {
+		return shape, fmt.Errorf("inspecting Zed threads schema: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull, primaryKey int
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return shape, fmt.Errorf("scanning Zed threads schema: %w", err)
+		}
+		switch name {
+		case "parent_id":
+			shape.hasParent = true
+		case "folder_paths":
+			shape.hasFolderPaths = true
+		case "created_at":
+			shape.hasCreatedAt = true
+		}
+		if _, ok := required[name]; ok {
+			required[name] = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return shape, fmt.Errorf("reading Zed threads schema: %w", err)
+	}
+	for name, present := range required {
+		if !present {
+			return shape, fmt.Errorf("missing required Zed threads column %s", name)
+		}
+	}
+	return shape, nil
+}
+
+func (s zedSchema) parentFilter() string {
+	if s.hasParent {
+		return ` AND COALESCE(parent_id, '') = ''`
+	}
+	return ""
+}
+func (s zedSchema) parentExpr() string {
+	if s.hasParent {
+		return `COALESCE(parent_id, '')`
+	}
+	return `''`
+}
+func (s zedSchema) folderExpr() string {
+	if s.hasFolderPaths {
+		return `COALESCE(folder_paths, '')`
+	}
+	return `''`
+}
+func (s zedSchema) createdExpr() string {
+	if s.hasCreatedAt {
+		return `COALESCE(created_at, '')`
+	}
+	return `''`
+}
+
+func forEachZedThreadMeta(ctx context.Context, conn *sql.DB, dbPath string, shape zedSchema, yield func(ZedThreadMeta) error) error {
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`SELECT id, COALESCE(updated_at, '') FROM threads WHERE 1=1%s ORDER BY updated_at, id`, shape.parentFilter()))
 	if err != nil {
 		return fmt.Errorf("listing zed thread metas: %w", err)
 	}
@@ -135,15 +205,21 @@ func ForEachZedThreadMeta(
 func parseZedThreadFromDB(
 	conn *sql.DB, dbPath, rawID, machine string, dbInfo os.FileInfo,
 ) (*ParseResult, error) {
+	shape, err := inspectZedSchema(conn)
+	if err != nil {
+		return nil, fmt.Errorf("loading zed thread %s: %w", rawID, err)
+	}
+	return parseZedThreadFromDBWithSchema(conn, dbPath, rawID, machine, dbInfo, shape)
+}
+
+func parseZedThreadFromDBWithSchema(
+	conn *sql.DB, dbPath, rawID, machine string, dbInfo os.FileInfo, shape zedSchema,
+) (*ParseResult, error) {
 	var row zedThreadRow
 	row.id = rawID
-	err := conn.QueryRow(
-		`SELECT COALESCE(summary, ''), COALESCE(updated_at, ''),
-		        COALESCE(data_type, ''), data, COALESCE(parent_id, ''),
-		        COALESCE(folder_paths, ''), COALESCE(created_at, '')
-		   FROM threads
-		  WHERE id = ?
-		    AND COALESCE(parent_id, '') = ''`,
+	err := conn.QueryRow(fmt.Sprintf(
+		`SELECT COALESCE(summary, ''), COALESCE(updated_at, ''), COALESCE(data_type, ''), data, %s, %s, %s FROM threads WHERE id = ?%s`,
+		shape.parentExpr(), shape.folderExpr(), shape.createdExpr(), shape.parentFilter()),
 		rawID,
 	).Scan(
 		&row.summary, &row.updatedAt, &row.dataType, &row.data,

--- a/internal/parser/zed.go
+++ b/internal/parser/zed.go
@@ -44,6 +44,10 @@ func ZedSQLiteSessionExists(dbPath, sessionID string) bool {
 // ZedSQLiteSourceMtime resolves the per-thread updated_at timestamp
 // for a virtual Zed SQLite source path.
 func ZedSQLiteSourceMtime(path string) (int64, error) {
+	return ZedSQLiteSourceMtimeContext(context.Background(), path)
+}
+
+func ZedSQLiteSourceMtimeContext(ctx context.Context, path string) (int64, error) {
 	dbPath, sessionID, ok := parseZedVirtualPath(path)
 	if !ok {
 		return 0, fmt.Errorf("not a zed sqlite virtual path: %s", path)
@@ -53,12 +57,12 @@ func ZedSQLiteSourceMtime(path string) (int64, error) {
 		return 0, err
 	}
 	defer db.Close()
-	shape, err := inspectZedSchema(context.Background(), db)
+	shape, err := inspectZedSchema(ctx, db)
 	if err != nil {
 		return 0, err
 	}
 	var updatedAt string
-	err = db.QueryRow(fmt.Sprintf(`SELECT COALESCE(updated_at, '') FROM threads WHERE id = ? %s LIMIT 1`, shape.parentFilter()), sessionID).Scan(&updatedAt)
+	err = db.QueryRowContext(ctx, fmt.Sprintf(`SELECT COALESCE(updated_at, '') FROM threads WHERE id = ? %s LIMIT 1`, shape.parentFilter()), sessionID).Scan(&updatedAt)
 	if err != nil {
 		return 0, fmt.Errorf("loading zed thread mtime %s: %w", sessionID, err)
 	}
@@ -222,15 +226,15 @@ func parseZedThreadFromDB(
 	if err != nil {
 		return nil, wrapZedLoadingError(rawID, err)
 	}
-	return parseZedThreadFromDBWithSchema(conn, dbPath, rawID, machine, dbInfo, shape)
+	return parseZedThreadFromDBWithSchema(context.Background(), conn, dbPath, rawID, machine, dbInfo, shape)
 }
 
 func parseZedThreadFromDBWithSchema(
-	conn *sql.DB, dbPath, rawID, machine string, dbInfo os.FileInfo, shape zedSchema,
+	ctx context.Context, conn *sql.DB, dbPath, rawID, machine string, dbInfo os.FileInfo, shape zedSchema,
 ) (*ParseResult, error) {
 	var row zedThreadRow
 	row.id = rawID
-	err := conn.QueryRow(fmt.Sprintf(
+	err := conn.QueryRowContext(ctx, fmt.Sprintf(
 		`SELECT COALESCE(summary, ''), COALESCE(updated_at, ''), COALESCE(data_type, ''), data, %s, %s, %s FROM threads WHERE id = ?%s`,
 		shape.parentExpr(), shape.folderExpr(), shape.createdExpr(), shape.parentFilter()),
 		rawID,

--- a/internal/parser/zed.go
+++ b/internal/parser/zed.go
@@ -32,7 +32,7 @@ func ZedSQLiteSessionExists(dbPath, sessionID string) bool {
 		return false
 	}
 	defer db.Close()
-	shape, err := inspectZedSchema(db)
+	shape, err := inspectZedSchema(context.Background(), db)
 	if err != nil {
 		return false
 	}
@@ -53,7 +53,7 @@ func ZedSQLiteSourceMtime(path string) (int64, error) {
 		return 0, err
 	}
 	defer db.Close()
-	shape, err := inspectZedSchema(db)
+	shape, err := inspectZedSchema(context.Background(), db)
 	if err != nil {
 		return 0, err
 	}
@@ -90,9 +90,9 @@ func ForEachZedThreadMeta(
 	ctx context.Context, conn *sql.DB, dbPath string,
 	yield func(ZedThreadMeta) error,
 ) error {
-	shape, err := inspectZedSchema(conn)
+	shape, err := inspectZedSchema(ctx, conn)
 	if err != nil {
-		return fmt.Errorf("listing zed thread metas: %w", err)
+		return wrapZedListingError(err)
 	}
 	return forEachZedThreadMeta(ctx, conn, dbPath, shape, yield)
 }
@@ -101,17 +101,30 @@ type zedSchema struct {
 	hasParent, hasFolderPaths, hasCreatedAt bool
 }
 
-func inspectZedSchema(conn *sql.DB) (zedSchema, error) {
+const (
+	zedListingError = "listing zed thread metas"
+	zedLoadingError = "loading zed thread"
+)
+
+func wrapZedListingError(err error) error {
+	return fmt.Errorf("%s: %w", zedListingError, err)
+}
+
+func wrapZedLoadingError(rawID string, err error) error {
+	return fmt.Errorf("%s %s: %w", zedLoadingError, rawID, err)
+}
+
+func inspectZedSchema(ctx context.Context, conn *sql.DB) (zedSchema, error) {
 	var shape zedSchema
 	var table int
-	if err := conn.QueryRow(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'threads'`).Scan(&table); err != nil {
+	if err := conn.QueryRowContext(ctx, `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'threads'`).Scan(&table); err != nil {
 		if err == sql.ErrNoRows {
 			return shape, fmt.Errorf("missing Zed threads table")
 		}
 		return shape, fmt.Errorf("inspecting Zed threads table: %w", err)
 	}
 	required := map[string]bool{"id": false, "summary": false, "updated_at": false, "data_type": false, "data": false}
-	rows, err := conn.Query(`PRAGMA table_info(threads)`)
+	rows, err := conn.QueryContext(ctx, `PRAGMA table_info(threads)`)
 	if err != nil {
 		return shape, fmt.Errorf("inspecting Zed threads schema: %w", err)
 	}
@@ -175,7 +188,7 @@ func (s zedSchema) createdExpr() string {
 func forEachZedThreadMeta(ctx context.Context, conn *sql.DB, dbPath string, shape zedSchema, yield func(ZedThreadMeta) error) error {
 	rows, err := conn.QueryContext(ctx, fmt.Sprintf(`SELECT id, COALESCE(updated_at, '') FROM threads WHERE 1=1%s ORDER BY updated_at, id`, shape.parentFilter()))
 	if err != nil {
-		return fmt.Errorf("listing zed thread metas: %w", err)
+		return wrapZedListingError(err)
 	}
 	defer rows.Close()
 
@@ -205,9 +218,9 @@ func forEachZedThreadMeta(ctx context.Context, conn *sql.DB, dbPath string, shap
 func parseZedThreadFromDB(
 	conn *sql.DB, dbPath, rawID, machine string, dbInfo os.FileInfo,
 ) (*ParseResult, error) {
-	shape, err := inspectZedSchema(conn)
+	shape, err := inspectZedSchema(context.Background(), conn)
 	if err != nil {
-		return nil, fmt.Errorf("loading zed thread %s: %w", rawID, err)
+		return nil, wrapZedLoadingError(rawID, err)
 	}
 	return parseZedThreadFromDBWithSchema(conn, dbPath, rawID, machine, dbInfo, shape)
 }
@@ -229,7 +242,7 @@ func parseZedThreadFromDBWithSchema(
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("loading zed thread %s: %w", rawID, err)
+		return nil, wrapZedLoadingError(rawID, err)
 	}
 	result, ok := buildZedParseResult(row, dbPath, dbInfo, machine)
 	if !ok {

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -49,7 +49,11 @@ func zedDiscoverEach(
 		return err
 	}
 	defer conn.Close()
-	return ForEachZedThreadMeta(ctx, conn, dbPath, func(meta ZedThreadMeta) error {
+	shape, err := inspectZedSchema(conn)
+	if err != nil {
+		return fmt.Errorf("listing zed thread metas: %w", err)
+	}
+	return forEachZedThreadMeta(ctx, conn, dbPath, shape, func(meta ZedThreadMeta) error {
 		return yield(multiSessionMatch{
 			Path: meta.VirtualPath, Container: dbPath, MemberID: meta.RawID,
 		})
@@ -177,8 +181,12 @@ func zedParseMember(
 		return nil, err
 	}
 	defer conn.Close()
-	return parseZedThreadFromDB(
-		conn, src.Container, src.MemberID, req.Machine, dbInfo,
+	shape, err := inspectZedSchema(conn)
+	if err != nil {
+		return nil, err
+	}
+	return parseZedThreadFromDBWithSchema(
+		conn, src.Container, src.MemberID, req.Machine, dbInfo, shape,
 	)
 }
 
@@ -197,7 +205,15 @@ func zedParseContainer(
 		return nil, err
 	}
 	defer conn.Close()
-	metas, err := ListZedThreadMetas(conn, src.Container)
+	shape, err := inspectZedSchema(conn)
+	if err != nil {
+		return nil, err
+	}
+	var metas []ZedThreadMeta
+	err = forEachZedThreadMeta(context.Background(), conn, src.Container, shape, func(meta ZedThreadMeta) error {
+		metas = append(metas, meta)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +224,8 @@ func zedParseContainer(
 	dbHash, _ := hashJSONLSourceFile(src.Container)
 	results := make([]ParseResult, 0, len(metas))
 	for _, meta := range metas {
-		result, err := parseZedThreadFromDB(
-			conn, src.Container, meta.RawID, req.Machine, dbInfo,
+		result, err := parseZedThreadFromDBWithSchema(
+			conn, src.Container, meta.RawID, req.Machine, dbInfo, shape,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -49,9 +49,9 @@ func zedDiscoverEach(
 		return err
 	}
 	defer conn.Close()
-	shape, err := inspectZedSchema(conn)
+	shape, err := inspectZedSchema(ctx, conn)
 	if err != nil {
-		return fmt.Errorf("listing zed thread metas: %w", err)
+		return wrapZedListingError(err)
 	}
 	return forEachZedThreadMeta(ctx, conn, dbPath, shape, func(meta ZedThreadMeta) error {
 		return yield(multiSessionMatch{
@@ -181,9 +181,9 @@ func zedParseMember(
 		return nil, err
 	}
 	defer conn.Close()
-	shape, err := inspectZedSchema(conn)
+	shape, err := inspectZedSchema(context.Background(), conn)
 	if err != nil {
-		return nil, err
+		return nil, wrapZedLoadingError(src.MemberID, err)
 	}
 	return parseZedThreadFromDBWithSchema(
 		conn, src.Container, src.MemberID, req.Machine, dbInfo, shape,
@@ -205,9 +205,9 @@ func zedParseContainer(
 		return nil, err
 	}
 	defer conn.Close()
-	shape, err := inspectZedSchema(conn)
+	shape, err := inspectZedSchema(context.Background(), conn)
 	if err != nil {
-		return nil, err
+		return nil, wrapZedListingError(err)
 	}
 	var metas []ZedThreadMeta
 	err = forEachZedThreadMeta(context.Background(), conn, src.Container, shape, func(meta ZedThreadMeta) error {

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -27,9 +27,9 @@ func newZedProviderFactory(def AgentDef) ProviderFactory {
 				WithWatchRoots(zedWatchRoots),
 				WithChangedPathClassifier(zedClassifyPath),
 				WithMemberLookup(zedFindMember),
-				WithFingerprint(zedFingerprintSource),
-				WithContainerParse(zedParseContainer),
-				WithMemberParse(zedParseMember),
+				WithContextFingerprint(zedFingerprintSource),
+				WithContextContainerParse(zedParseContainer),
+				WithContextMemberParse(zedParseMember),
 				WithMemberPresence(zedMemberPresent),
 			)
 		},
@@ -110,7 +110,7 @@ func zedFindMember(root, rawID string) (multiSessionMatch, bool) {
 	}, true
 }
 
-func zedFingerprintSource(src multiSessionSource) (SourceFingerprint, error) {
+func zedFingerprintSource(ctx context.Context, src multiSessionSource) (SourceFingerprint, error) {
 	info, err := os.Stat(src.Container)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -120,8 +120,10 @@ func zedFingerprintSource(src multiSessionSource) (SourceFingerprint, error) {
 	}
 	mtime := info.ModTime().UnixNano()
 	if src.MemberID != "" {
-		sessionMtime, err := ZedSQLiteSourceMtime(src.Path)
+		sessionMtime, err := ZedSQLiteSourceMtimeContext(ctx, src.Path)
 		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			return SourceFingerprint{}, err
 		case errors.Is(err, sql.ErrNoRows):
 			// The thread row is gone but threads.db is still present. Return a
 			// keyed-empty fingerprint without error (matching the Shelley and
@@ -164,7 +166,7 @@ func zedMemberPresent(src multiSessionSource) bool {
 }
 
 func zedParseMember(
-	src multiSessionSource, req ParseRequest,
+	ctx context.Context, src multiSessionSource, req ParseRequest,
 ) (*ParseResult, error) {
 	dbInfo, err := os.Stat(src.Container)
 	if err != nil {
@@ -181,17 +183,17 @@ func zedParseMember(
 		return nil, err
 	}
 	defer conn.Close()
-	shape, err := inspectZedSchema(context.Background(), conn)
+	shape, err := inspectZedSchema(ctx, conn)
 	if err != nil {
 		return nil, wrapZedLoadingError(src.MemberID, err)
 	}
 	return parseZedThreadFromDBWithSchema(
-		conn, src.Container, src.MemberID, req.Machine, dbInfo, shape,
+		ctx, conn, src.Container, src.MemberID, req.Machine, dbInfo, shape,
 	)
 }
 
 func zedParseContainer(
-	src multiSessionSource, req ParseRequest,
+	ctx context.Context, src multiSessionSource, req ParseRequest,
 ) ([]ParseResult, error) {
 	dbInfo, err := os.Stat(src.Container)
 	if err != nil {
@@ -205,12 +207,12 @@ func zedParseContainer(
 		return nil, err
 	}
 	defer conn.Close()
-	shape, err := inspectZedSchema(context.Background(), conn)
+	shape, err := inspectZedSchema(ctx, conn)
 	if err != nil {
 		return nil, wrapZedListingError(err)
 	}
 	var metas []ZedThreadMeta
-	err = forEachZedThreadMeta(context.Background(), conn, src.Container, shape, func(meta ZedThreadMeta) error {
+	err = forEachZedThreadMeta(ctx, conn, src.Container, shape, func(meta ZedThreadMeta) error {
 		metas = append(metas, meta)
 		return nil
 	})
@@ -225,7 +227,7 @@ func zedParseContainer(
 	results := make([]ParseResult, 0, len(metas))
 	for _, meta := range metas {
 		result, err := parseZedThreadFromDBWithSchema(
-			conn, src.Container, meta.RawID, req.Machine, dbInfo, shape,
+			ctx, conn, src.Container, meta.RawID, req.Machine, dbInfo, shape,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -135,10 +135,9 @@ func zedFingerprintSource(ctx context.Context, src multiSessionSource) (SourceFi
 			return SourceFingerprint{}, nil
 		case err == nil:
 			mtime = sessionMtime
+		default:
+			return SourceFingerprint{}, err
 		}
-		// A non-ErrNoRows error (unreadable DB, non-virtual path) keeps the
-		// physical DB mtime fallback, preserving the prior behavior for
-		// transient failures.
 	} else if compositeMtime, err := sqliteDBCompositeMtime(
 		src.Container, sqliteDBJournalSuffixes,
 	); err == nil {

--- a/internal/parser/zed_shelley_provider_test.go
+++ b/internal/parser/zed_shelley_provider_test.go
@@ -123,6 +123,42 @@ func TestZedProviderParsePhysicalAndVirtualSources(t *testing.T) {
 	assert.Len(t, oneOutcome.Results[0].Result.Messages, 1)
 }
 
+func TestZedProviderLegacySchemaPhysicalAndVirtual(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, zedThreadsDBRelPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	artifact, err := os.ReadFile("testdata/zed-legacy-threads.sql")
+	require.NoError(t, err)
+	_, err = db.Exec(string(artifact))
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO threads (id, summary, updated_at, data_type, data) VALUES (?, ?, ?, ?, ?)`,
+		"legacy", "Legacy", "2026-06-08T09:14:10Z", "json", []byte(`{"messages":[{"User":{"content":[{"Text":"hello"}]}}]}`))
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	provider, ok := NewProvider(AgentZed, ProviderConfig{Roots: []string{root}, Machine: "devbox"})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	physical, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, physical.Results, 1)
+	assert.Equal(t, "zed:legacy", physical.Results[0].Result.Session.ID)
+
+	virtual, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: "legacy"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	fingerprint, err := provider.Fingerprint(context.Background(), virtual)
+	require.NoError(t, err)
+	parsed, err := provider.Parse(context.Background(), ParseRequest{Source: virtual, Fingerprint: fingerprint})
+	require.NoError(t, err)
+	require.Len(t, parsed.Results, 1)
+	assert.Equal(t, "zed:legacy", parsed.Results[0].Result.Session.ID)
+}
+
 func TestZedProviderFingerprintIncludesWALSiblings(t *testing.T) {
 
 	root := t.TempDir()

--- a/internal/parser/zed_shelley_provider_test.go
+++ b/internal/parser/zed_shelley_provider_test.go
@@ -180,6 +180,12 @@ func TestZedProviderMalformedSchemaReturnsError(t *testing.T) {
 	sources, err := provider.Discover(context.Background())
 	require.NoError(t, err)
 	require.Len(t, sources, 1)
+	_, err = zedFingerprintSource(context.Background(), multiSessionSource{
+		Root: root, Path: ZedSQLiteVirtualPath(dbPath, "malformed"),
+		Container: dbPath, MemberID: "malformed",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required Zed threads column data")
 	_, err = provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required Zed threads column data")

--- a/internal/parser/zed_shelley_provider_test.go
+++ b/internal/parser/zed_shelley_provider_test.go
@@ -159,6 +159,31 @@ func TestZedProviderLegacySchemaPhysicalAndVirtual(t *testing.T) {
 	assert.Equal(t, "zed:legacy", parsed.Results[0].Result.Session.ID)
 }
 
+func TestZedProviderMalformedSchemaReturnsError(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, zedThreadsDBRelPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE threads (
+		id TEXT PRIMARY KEY,
+		summary TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		data_type TEXT NOT NULL
+	)`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	provider, ok := NewProvider(AgentZed, ProviderConfig{Roots: []string{root}, Machine: "devbox"})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	_, err = provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required Zed threads column data")
+}
+
 func TestZedProviderFingerprintIncludesWALSiblings(t *testing.T) {
 
 	root := t.TempDir()

--- a/internal/parser/zed_shelley_provider_test.go
+++ b/internal/parser/zed_shelley_provider_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -182,6 +183,37 @@ func TestZedProviderMalformedSchemaReturnsError(t *testing.T) {
 	_, err = provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required Zed threads column data")
+}
+
+func TestZedProviderPropagatesParseAndFingerprintContext(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, zedThreadsDBRelPath)
+	threadID := "10431c84-c47b-4e6c-b2df-f9f3b9ad025b"
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	createZedThreadsDBAt(t, dbPath, []zedTestThread{{
+		id: threadID, summary: "Context", updatedAt: "2026-06-08T09:14:10Z",
+		dataType: "json", data: []byte(`{"messages":[]}`),
+	}})
+	src := multiSessionSource{
+		Root: root, Path: ZedSQLiteVirtualPath(dbPath, threadID),
+		Container: dbPath, MemberID: threadID,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := zedParseContainer(ctx, multiSessionSource{
+		Root: root, Path: dbPath, Container: dbPath,
+	}, ParseRequest{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, err = zedParseMember(ctx, src, ParseRequest{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, err = zedFingerprintSource(ctx, src)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "fingerprint error = %v", err)
 }
 
 func TestZedProviderFingerprintIncludesWALSiblings(t *testing.T) {

--- a/internal/parser/zed_test.go
+++ b/internal/parser/zed_test.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/klauspost/compress/zstd"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // parseZedAll parses every top-level thread in a Zed threads.db using the same
@@ -242,6 +245,45 @@ func TestParseZedSessions_ZstdAndFiltersChildren(t *testing.T) {
 	if results[0].Messages[0].Content != "Hello" {
 		t.Fatalf("message = %+v", results[0].Messages[0])
 	}
+}
+
+func TestParseZedSessions_LegacyFiveColumnSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "threads.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	artifact, err := os.ReadFile(filepath.Join("testdata", "zed-legacy-threads.sql"))
+	require.NoError(t, err)
+	_, err = db.Exec(string(artifact))
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO threads (id, summary, updated_at, data_type, data) VALUES (?, ?, ?, ?, ?)`,
+		"legacy", "Legacy thread", "2026-06-08T09:14:10Z", "json", []byte(`{"messages":[{"User":{"content":[{"Text":"hello"}]}}]}`))
+	require.NoError(t, err)
+
+	results, err := parseZedAll(dbPath, "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	sess := results[0].Session
+	assert.Equal(t, "zed:legacy", sess.ID)
+	assert.Equal(t, "Legacy thread", sess.SessionName)
+	assert.Equal(t, "", sess.ParentSessionID)
+	assert.Equal(t, "", sess.Cwd)
+	assert.Equal(t, "unknown", sess.Project)
+	assert.Equal(t, "2026-06-08T09:14:10Z", sess.StartedAt.Format(time.RFC3339))
+}
+
+func TestZedLegacyCompatibilityRequiresCoreColumns(t *testing.T) {
+	dbPath := createZedThreadsDB(t, nil)
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`ALTER TABLE threads RENAME TO old_threads`)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE threads (id TEXT, summary TEXT, updated_at TEXT, data_type TEXT)`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	_, err = parseZedAll(dbPath, "local")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required Zed threads column data")
 }
 
 func TestParseZedSessions_SkipsUnsupportedDataType(t *testing.T) {

--- a/internal/sync/zed_integration_test.go
+++ b/internal/sync/zed_integration_test.go
@@ -73,6 +73,18 @@ func TestSyncAllZedLegacySchemaPreservesOtherProviders(t *testing.T) {
 	_, err = db.Exec(string(artifact))
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
+	provider, ok := parser.NewProvider(parser.AgentZed, parser.ProviderConfig{
+		Roots: []string{zedDir}, Machine: "local",
+	})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	parsed, err := provider.Parse(t.Context(), parser.ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	assert.True(t, parsed.ResultSetComplete)
+	assert.Equal(t, parser.SkipNoSession, parsed.SkipReason)
+	assert.Empty(t, parsed.Results)
 
 	aiderDir := filepath.Join(root, "aider", "repo")
 	require.NoError(t, os.MkdirAll(aiderDir, 0o755))

--- a/internal/sync/zed_integration_test.go
+++ b/internal/sync/zed_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	dbpkg "go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
@@ -58,6 +59,45 @@ func TestSyncSingleSessionZedUsesVirtualSourcePath(t *testing.T) {
 	other, err := database.GetSession(t.Context(), "zed:other")
 	require.NoError(t, err)
 	assert.Nil(t, other)
+}
+
+func TestSyncAllZedLegacySchemaPreservesOtherProviders(t *testing.T) {
+	root := t.TempDir()
+	zedDir := filepath.Join(root, "zed")
+	dbPath := filepath.Join(zedDir, "threads", "threads.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	artifact, err := os.ReadFile(filepath.Join("..", "parser", "testdata", "zed-legacy-threads.sql"))
+	require.NoError(t, err)
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(string(artifact))
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO threads (id, summary, updated_at, data_type, data) VALUES (?, ?, ?, ?, ?)`,
+		"legacy", "Legacy", "2026-06-08T09:14:10Z", "json", []byte(`{"messages":[{"User":{"content":[{"Text":"hello"}]}}]}`))
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	aiderDir := filepath.Join(root, "aider", "repo")
+	require.NoError(t, os.MkdirAll(aiderDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(aiderDir, parser.AiderHistoryFileName()),
+		[]byte("# aider chat started at 2026-06-09 14:01:00\n#### prompt\nanswer\n"), 0o644))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentZed: {zedDir}, parser.AgentAider: {filepath.Join(root, "aider")},
+		},
+		Machine: "local",
+	})
+	stats := engine.SyncAll(t.Context(), nil)
+	assert.Zero(t, stats.Failed)
+	assert.GreaterOrEqual(t, stats.Synced, 2)
+	zed, err := database.GetSession(t.Context(), "zed:legacy")
+	require.NoError(t, err)
+	assert.NotNil(t, zed)
+	page, err := database.ListSessions(t.Context(), dbpkg.SessionFilter{Agent: string(parser.AgentAider), Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, 1)
 }
 
 func TestSyncSingleSessionZedForceRewritesUnchangedSession(t *testing.T) {

--- a/internal/sync/zed_integration_test.go
+++ b/internal/sync/zed_integration_test.go
@@ -72,9 +72,6 @@ func TestSyncAllZedLegacySchemaPreservesOtherProviders(t *testing.T) {
 	require.NoError(t, err)
 	_, err = db.Exec(string(artifact))
 	require.NoError(t, err)
-	_, err = db.Exec(`INSERT INTO threads (id, summary, updated_at, data_type, data) VALUES (?, ?, ?, ?, ?)`,
-		"legacy", "Legacy", "2026-06-08T09:14:10Z", "json", []byte(`{"messages":[{"User":{"content":[{"Text":"hello"}]}}]}`))
-	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
 	aiderDir := filepath.Join(root, "aider", "repo")
@@ -91,10 +88,10 @@ func TestSyncAllZedLegacySchemaPreservesOtherProviders(t *testing.T) {
 	})
 	stats := engine.SyncAll(t.Context(), nil)
 	assert.Zero(t, stats.Failed)
-	assert.GreaterOrEqual(t, stats.Synced, 2)
+	assert.Equal(t, 1, stats.Synced)
 	zed, err := database.GetSession(t.Context(), "zed:legacy")
 	require.NoError(t, err)
-	assert.NotNil(t, zed)
+	assert.Nil(t, zed)
 	page, err := database.ListSessions(t.Context(), dbpkg.SessionFilter{Agent: string(parser.AgentAider), Limit: 10})
 	require.NoError(t, err)
 	assert.Len(t, page.Sessions, 1)


### PR DESCRIPTION
Older Zed `threads.db` files can omit `parent_id`, so every Zed listing query fails and makes sync non-authoritative. This detects optional columns once, defaults only absent projections, and keeps modern parent filtering and hard errors for unsupported schemas.

Closes #1371
