### PR TITLE
feat(insights): support OpenAI-compatible endpoints

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,7 @@ chart_palette = "agentsview"
 | `[duckdb]`                          | DuckDB mirror configuration — see [DuckDB Mirror](/duckdb/)                                                                                                                                                                                          |
 | `[vector]`                          | Opt-in semantic-search index; model settings live in `[vector.embeddings]`, named endpoints in `[vector.embeddings.servers.<name>]`, embedding schedule in `[vector.embed]` — see [Semantic Search](/semantic-search/#enabling-vector) for every key |
 | `[recall.extract]`                  | Opt-in model-backed recall extraction; named endpoints in `[recall.extract.servers.<name>]`, prompt selection in `[recall.extract.prompts]`, request overrides in `[recall.extract.request]` — see [Recall](/recall/#automatic-extraction)           |
+| `[insights]`                        | Optional generated-insights endpoint and model; local loopback HTTP is allowed, remote plaintext requires `allow_http = true`, and endpoint failures do not retry through a CLI — see [Recall](/recall/#current-surface) |
 | `[[remote_hosts]]`                  | Remote machines synced by a bare `agentsview sync` — see [CLI Reference](/commands/#agentsview-sync)                                                                                                                                                 |
 | `[[session_sources]]`               | Additional filesystem session roots with per-root machine labels — see [Filesystem Session Sync](/filesystem-sync/)                                                                                                                                  |
 | `[automated]`                       | Custom automated-session patterns — see [Automated Session Detection](#automated-session-detection)                                                                                                                                                  |
@@ -1162,7 +1163,8 @@ Optional features that send data externally when you enable them:
 - The [DuckDB mirror](/duckdb/) writes a local DuckDB file by default; data only
   leaves the machine if you expose the mirror over a remote Quack endpoint.
 - [Generated insights](/recall/#current-surface) sends scoped session content to
-  the selected agent CLI to generate reports.
+  the configured endpoint when `[insights]` is set, or to the selected agent
+  CLI when it is absent.
 - [Publish to Gist](/usage/#publish-to-gist) uploads a session to GitHub.
 
 The automatic outbound requests are update checks and an anonymous daemon ping:

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -75,6 +75,9 @@ use HTTPS unless `allow_http = true` explicitly opts into plaintext transport.
 The endpoint receives transcript-derived content, so review the provider's
 privacy and retention behavior. API keys stay in the environment and are sent
 only as a bearer header; they are not stored in the AgentsView configuration.
+Canned insight cache keys do not include the endpoint or model. Use the
+force-refresh option after changing `[insights]` if the existing cached report
+must be regenerated with the new provider.
 
 ### Configuring agent binaries
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -57,8 +57,8 @@ Generated insights use the configured OpenAI-compatible endpoint when
 `[insights]` has both an `endpoint` and `model`; otherwise they use the selected
 agent CLI on your machine. Endpoint mode sends one non-streaming
 `POST /chat/completions` request with the generated prompt as a user message.
-It accepts the first choice's string `message.content` and optional response
-`model`. It does not support streaming, `/responses`, legacy completions,
+It accepts the first choice's `assistant` message with string `message.content`
+and optional response `model`. It does not support streaming, `/responses`, legacy completions,
 tool calls, or content-part arrays. An endpoint failure returns an error and
 does not retry through a CLI.
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -53,11 +53,28 @@ links use `/recall?tab=generated&insight=<id>`.
 
 ![Generated insights](/assets/generated/screenshots/recall-generated-insights.png)
 
-Generated insights run through the selected agent CLI on your machine. The CLI
-receives content from sessions matching the visible scope, and the completed
-markdown is saved in the local SQLite archive. AgentsView does not manage the
-CLI's provider credentials; review that agent's privacy behavior before
-generating a report.
+Generated insights use the configured OpenAI-compatible endpoint when
+`[insights]` has both an `endpoint` and `model`; otherwise they use the selected
+agent CLI on your machine. Endpoint mode sends one non-streaming
+`POST /chat/completions` request with the generated prompt as a user message.
+It accepts the first choice's string `message.content` and optional response
+`model`. It does not support streaming, `/responses`, legacy completions,
+tool calls, or content-part arrays. An endpoint failure returns an error and
+does not retry through a CLI.
+
+```toml
+[insights]
+endpoint = "http://127.0.0.1:11434/v1"
+model = "llama3.1"
+api_key_env = "OPENAI_API_KEY" # optional; the value is read at runtime
+# allow_http = true            # required for non-loopback HTTP endpoints
+```
+
+Loopback HTTP endpoints are allowed for local models. Remote endpoints must
+use HTTPS unless `allow_http = true` explicitly opts into plaintext transport.
+The endpoint receives transcript-derived content, so review the provider's
+privacy and retention behavior. API keys stay in the environment and are sent
+only as a bearer header; they are not stored in the AgentsView configuration.
 
 ### Configuring agent binaries
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -54,8 +54,9 @@ links use `/recall?tab=generated&insight=<id>`.
 ![Generated insights](/assets/generated/screenshots/recall-generated-insights.png)
 
 Generated insights use the configured OpenAI-compatible endpoint when
-`[insights]` has both an `endpoint` and `model`; otherwise they use the selected
-agent CLI on your machine. Endpoint mode sends one non-streaming
+`[insights]` has both an `endpoint` and `model`; when `[insights]` is absent,
+they use the selected agent CLI on your machine. Partial endpoint configuration
+is rejected during configuration validation. Endpoint mode sends one non-streaming
 `POST /chat/completions` request with the generated prompt as a user message.
 It accepts the first choice's `assistant` message with string `message.content`
 and optional response `model`. It does not support streaming, `/responses`, legacy completions,
@@ -77,8 +78,9 @@ privacy and retention behavior. API keys stay in the environment and are sent
 only as a bearer header; they are not stored in the AgentsView configuration.
 Canned insight cache keys include the effective backend, model, and a safe
 endpoint identity, so changing `[insights]` after restarting the server selects
-a separate cached report. Force refresh remains available when the same
-provider configuration should regenerate the report.
+a separate cached report. Changes to credentials or transport opt-ins do not
+change that identity; use force refresh when those changes should regenerate a
+report under the same endpoint and model.
 
 ### Configuring agent binaries
 

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -75,9 +75,10 @@ use HTTPS unless `allow_http = true` explicitly opts into plaintext transport.
 The endpoint receives transcript-derived content, so review the provider's
 privacy and retention behavior. API keys stay in the environment and are sent
 only as a bearer header; they are not stored in the AgentsView configuration.
-Canned insight cache keys do not include the endpoint or model. Use the
-force-refresh option after changing `[insights]` if the existing cached report
-must be regenerated with the new provider.
+Canned insight cache keys include the effective backend, model, and a safe
+endpoint identity, so changing `[insights]` after restarting the server selects
+a separate cached report. Force refresh remains available when the same
+provider configuration should regenerate the report.
 
 ### Configuring agent binaries
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -575,8 +575,7 @@ type Config struct {
 	Insights             InsightsConfig         `json:"insights,omitempty" toml:"insights"`
 	Automated            AutomatedConfig        `json:"automated,omitempty" toml:"automated"`
 	Agent                map[string]AgentConfig `json:"agent,omitempty" toml:"agent"`
-	insightsConfigured   bool
-	WriteTimeout         time.Duration `json:"-" toml:"-"`
+	WriteTimeout         time.Duration          `json:"-" toml:"-"`
 	// LocalMachineName is the operating-system hostname used to identify
 	// sessions ingested from this machine. It is runtime-derived rather than
 	// persisted configuration so local and remote source labels share the same
@@ -1427,7 +1426,6 @@ func (c *Config) applyConfigTOML(data string) error {
 		c.Insights.Endpoint = strings.TrimSpace(c.Insights.Endpoint)
 		c.Insights.Model = strings.TrimSpace(c.Insights.Model)
 		c.Insights.APIKeyEnv = strings.TrimSpace(c.Insights.APIKeyEnv)
-		c.insightsConfigured = true
 	}
 	// IsDefined distinguishes "unset" (leave default 10s) from an
 	// explicit "0s" (disable coalescing). Checking != 0 would silently
@@ -1978,12 +1976,8 @@ func finalize(cfg *Config) error {
 	if err := cfg.Recall.Extract.Validate(); err != nil {
 		return err
 	}
-	if cfg.insightsConfigured || cfg.Insights.Endpoint != "" ||
-		cfg.Insights.Model != "" || cfg.Insights.APIKeyEnv != "" ||
-		cfg.Insights.AllowHTTP {
-		if err := cfg.Insights.Validate(); err != nil {
-			return err
-		}
+	if err := cfg.Insights.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -433,6 +433,49 @@ type AgentConfig struct {
 	AllowUnsafe bool   `json:"allow_unsafe,omitempty" toml:"allow_unsafe"`
 }
 
+// InsightsConfig controls an optional OpenAI-compatible chat-completions
+// endpoint for generated insights.
+type InsightsConfig struct {
+	Endpoint  string `json:"endpoint,omitempty" toml:"endpoint"`
+	Model     string `json:"model,omitempty" toml:"model"`
+	APIKeyEnv string `json:"api_key_env,omitempty" toml:"api_key_env"`
+	AllowHTTP bool   `json:"allow_http,omitempty" toml:"allow_http"`
+}
+
+// APIKey reads the configured key from the environment. The key itself is
+// intentionally never part of the serialized configuration.
+func (c InsightsConfig) APIKey() string {
+	if strings.TrimSpace(c.APIKeyEnv) == "" {
+		return ""
+	}
+	return os.Getenv(strings.TrimSpace(c.APIKeyEnv))
+}
+
+// Validate checks endpoint intent and transport safety.
+func (c InsightsConfig) Validate() error {
+	endpoint := strings.TrimSpace(c.Endpoint)
+	model := strings.TrimSpace(c.Model)
+	configured := endpoint != "" || model != "" ||
+		strings.TrimSpace(c.APIKeyEnv) != "" || c.AllowHTTP
+	if !configured {
+		return nil
+	}
+	if endpoint == "" || model == "" {
+		return fmt.Errorf("[insights] endpoint and model are required together")
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("[insights] endpoint %q must be an http(s) URL", RedactedEndpoint(endpoint))
+	}
+	if u.User != nil {
+		return fmt.Errorf("[insights] endpoint must not contain URL credentials: %q", RedactedEndpoint(endpoint))
+	}
+	if err := ValidateExtractTransport(u, c.AllowHTTP); err != nil {
+		return fmt.Errorf("[insights] %w", err)
+	}
+	return nil
+}
+
 type CustomModelRate struct {
 	InputMicrodollarsPerMTok         int64 `json:"input_microdollars_per_mtok" toml:"input_microdollars_per_mtok"`
 	OutputMicrodollarsPerMTok        int64 `json:"output_microdollars_per_mtok" toml:"output_microdollars_per_mtok"`
@@ -529,9 +572,11 @@ type Config struct {
 	DuckDB               DuckDBConfig           `json:"duckdb,omitempty" toml:"duckdb"`
 	Vector               VectorConfig           `json:"vector,omitempty" toml:"vector"`
 	Recall               RecallConfig           `json:"recall,omitempty" toml:"recall"`
+	Insights             InsightsConfig         `json:"insights,omitempty" toml:"insights"`
 	Automated            AutomatedConfig        `json:"automated,omitempty" toml:"automated"`
 	Agent                map[string]AgentConfig `json:"agent,omitempty" toml:"agent"`
-	WriteTimeout         time.Duration          `json:"-" toml:"-"`
+	insightsConfigured   bool
+	WriteTimeout         time.Duration `json:"-" toml:"-"`
 	// LocalMachineName is the operating-system hostname used to identify
 	// sessions ingested from this machine. It is runtime-derived rather than
 	// persisted configuration so local and remote source labels share the same
@@ -1175,6 +1220,7 @@ func (c *Config) applyConfigTOML(data string) error {
 		DuckDB                         DuckDBConfig               `toml:"duckdb"`
 		Vector                         VectorConfig               `toml:"vector"`
 		Recall                         RecallConfig               `toml:"recall"`
+		Insights                       InsightsConfig             `toml:"insights"`
 		Automated                      AutomatedConfig            `toml:"automated"`
 		Agent                          map[string]AgentConfig     `toml:"agent"`
 		EventsCoalesceInterval         time.Duration              `toml:"events_coalesce_interval"`
@@ -1376,6 +1422,13 @@ func (c *Config) applyConfigTOML(data string) error {
 		c.Vector.Embed.BackstopInterval = file.Vector.Embed.BackstopInterval
 	}
 	c.mergeRecallExtractTOML(file.Recall, meta)
+	if meta.IsDefined("insights") {
+		c.Insights = file.Insights
+		c.Insights.Endpoint = strings.TrimSpace(c.Insights.Endpoint)
+		c.Insights.Model = strings.TrimSpace(c.Insights.Model)
+		c.Insights.APIKeyEnv = strings.TrimSpace(c.Insights.APIKeyEnv)
+		c.insightsConfigured = true
+	}
 	// IsDefined distinguishes "unset" (leave default 10s) from an
 	// explicit "0s" (disable coalescing). Checking != 0 would silently
 	// ignore the latter.
@@ -1924,6 +1977,13 @@ func finalize(cfg *Config) error {
 	}
 	if err := cfg.Recall.Extract.Validate(); err != nil {
 		return err
+	}
+	if cfg.insightsConfigured || cfg.Insights.Endpoint != "" ||
+		cfg.Insights.Model != "" || cfg.Insights.APIKeyEnv != "" ||
+		cfg.Insights.AllowHTTP {
+		if err := cfg.Insights.Validate(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/config/config_insight_test.go
+++ b/internal/config/config_insight_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsightsConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  InsightsConfig
+		wantErr string
+	}{
+		{name: "absent"},
+		{name: "loopback", config: InsightsConfig{Endpoint: "http://127.0.0.1:30000/v1", Model: "local"}},
+		{name: "https", config: InsightsConfig{Endpoint: "https://models.example/v1", Model: "remote"}},
+		{name: "remote http opt in", config: InsightsConfig{Endpoint: "http://models.example/v1", Model: "remote", AllowHTTP: true}},
+		{name: "partial endpoint", config: InsightsConfig{Endpoint: "http://127.0.0.1:30000/v1"}, wantErr: "required together"},
+		{name: "partial model", config: InsightsConfig{Model: "local"}, wantErr: "required together"},
+		{name: "userinfo", config: InsightsConfig{Endpoint: "https://user:secret@models.example/v1", Model: "remote"}, wantErr: "credentials"},
+		{name: "remote http", config: InsightsConfig{Endpoint: "http://models.example/v1", Model: "remote"}, wantErr: "plaintext"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestInsightsConfigAPIKey(t *testing.T) {
+	t.Setenv("AGENTSVIEW_TEST_INSIGHTS_KEY", "secret")
+	c := InsightsConfig{APIKeyEnv: " AGENTSVIEW_TEST_INSIGHTS_KEY "}
+	assert.Equal(t, "secret", c.APIKey())
+	t.Setenv("AGENTSVIEW_TEST_INSIGHTS_KEY", "")
+	assert.Empty(t, c.APIKey())
+	assert.NotContains(t, os.Getenv("AGENTSVIEW_TEST_INSIGHTS_KEY"), "secret")
+}

--- a/internal/config/config_insight_test.go
+++ b/internal/config/config_insight_test.go
@@ -44,3 +44,27 @@ func TestInsightsConfigAPIKey(t *testing.T) {
 	assert.Empty(t, c.APIKey())
 	assert.NotContains(t, os.Getenv("AGENTSVIEW_TEST_INSIGHTS_KEY"), "secret")
 }
+
+func TestInsightsConfigTOMLLoadAndFinalize(t *testing.T) {
+	cfg := loadMinimalWithConfig(t, map[string]any{
+		"insights": map[string]any{
+			"endpoint":    " http://127.0.0.1:11434/v1 ",
+			"model":       " llama3.1 ",
+			"api_key_env": " AGENTSVIEW_INSIGHTS_KEY ",
+			"allow_http":  true,
+		},
+	})
+	assert.Equal(t, "http://127.0.0.1:11434/v1", cfg.Insights.Endpoint)
+	assert.Equal(t, "llama3.1", cfg.Insights.Model)
+	assert.Equal(t, "AGENTSVIEW_INSIGHTS_KEY", cfg.Insights.APIKeyEnv)
+	assert.True(t, cfg.Insights.AllowHTTP)
+
+	err := loadMinimalErrWithConfig(t, map[string]any{
+		"insights": map[string]any{
+			"endpoint": "http://models.example/v1",
+			"model":    "remote",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plaintext")
+}

--- a/internal/insight/canned.go
+++ b/internal/insight/canned.go
@@ -286,6 +286,7 @@ func CannedCacheKey(
 	dateFrom, dateTo, project, requestedAgent, focus, aggregateHash string,
 	automatedScope string,
 	filters CannedSessionFilters,
+	generation GenerateOptions,
 ) (string, error) {
 	t, ok := CannedTemplate(kind)
 	if !ok {
@@ -297,18 +298,37 @@ func CannedCacheKey(
 		return "", err
 	}
 	filterSum := sha256.Sum256(filterData)
+	generationBackend := requestedAgent
+	generationModel := ""
+	generationEndpointHash := ""
+	if generation.Endpoint != nil &&
+		strings.TrimSpace(generation.Endpoint.Endpoint) != "" &&
+		strings.TrimSpace(generation.Endpoint.Model) != "" {
+		generationBackend = "openai"
+		generationModel = strings.TrimSpace(generation.Endpoint.Model)
+		endpointSum := sha256.Sum256(
+			[]byte(strings.TrimSpace(generation.Endpoint.Endpoint)),
+		)
+		generationEndpointHash = hex.EncodeToString(endpointSum[:])
+		requestedAgent = ""
+	} else if requestedAgent == "gemini" {
+		generationModel = geminiInsightModel
+	}
 	input := map[string]string{
-		"kind":             string(kind),
-		"date_from":        dateFrom,
-		"date_to":          dateTo,
-		"project":          project,
-		"requested_agent":  requestedAgent,
-		"template_version": t.Version,
-		"schema_version":   CannedSchemaVersion,
-		"aggregate_hash":   aggregateHash,
-		"focus_hash":       hex.EncodeToString(focusSum[:]),
-		"automated_scope":  automatedScope,
-		"filter_hash":      hex.EncodeToString(filterSum[:]),
+		"kind":                     string(kind),
+		"date_from":                dateFrom,
+		"date_to":                  dateTo,
+		"project":                  project,
+		"requested_agent":          requestedAgent,
+		"template_version":         t.Version,
+		"schema_version":           CannedSchemaVersion,
+		"aggregate_hash":           aggregateHash,
+		"focus_hash":               hex.EncodeToString(focusSum[:]),
+		"automated_scope":          automatedScope,
+		"filter_hash":              hex.EncodeToString(filterSum[:]),
+		"generation_backend":       generationBackend,
+		"generation_model":         generationModel,
+		"generation_endpoint_hash": generationEndpointHash,
 	}
 	data, err := canonicalJSON(input)
 	if err != nil {

--- a/internal/insight/canned_cache_test.go
+++ b/internal/insight/canned_cache_test.go
@@ -1,0 +1,44 @@
+package insight
+
+import "testing"
+
+func TestCannedCacheKeyIncludesEffectiveGenerationIdentity(t *testing.T) {
+	key := func(agent, focus string, generation GenerateOptions) string {
+		t.Helper()
+		key, err := CannedCacheKey(
+			CannedPromptMaturityReview,
+			"2026-01-01", "2026-01-31", "project", agent,
+			focus, "aggregate", "all", CannedSessionFilters{}, generation,
+		)
+		if err != nil {
+			t.Fatalf("CannedCacheKey: %v", err)
+		}
+		return key
+	}
+
+	if key("claude", "focus", GenerateOptions{}) ==
+		key("codex", "focus", GenerateOptions{}) {
+		t.Fatal("CLI agent identity must partition the cache")
+	}
+	if key("claude", "focus", GenerateOptions{
+		Endpoint: &EndpointConfig{Endpoint: "https://one.example/v1", Model: "model"},
+	}) == key("claude", "focus", GenerateOptions{
+		Endpoint: &EndpointConfig{Endpoint: "https://two.example/v1", Model: "model"},
+	}) {
+		t.Fatal("endpoint identity must partition the cache")
+	}
+	if key("claude", "focus", GenerateOptions{
+		Endpoint: &EndpointConfig{Endpoint: "https://one.example/v1", Model: "model-a"},
+	}) == key("claude", "focus", GenerateOptions{
+		Endpoint: &EndpointConfig{Endpoint: "https://one.example/v1", Model: "model-b"},
+	}) {
+		t.Fatal("endpoint model must partition the cache")
+	}
+	if key("claude", "focus", GenerateOptions{
+		Endpoint: &EndpointConfig{Endpoint: "https://one.example/v1", Model: "model"},
+	}) != key("codex", "focus", GenerateOptions{
+		Endpoint: &EndpointConfig{Endpoint: "https://one.example/v1", Model: "model"},
+	}) {
+		t.Fatal("selected CLI agent must not partition endpoint-mode cache keys")
+	}
+}

--- a/internal/insight/endpoint.go
+++ b/internal/insight/endpoint.go
@@ -1,0 +1,111 @@
+package insight
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const maxEndpointResponseBytes int64 = 2_000_000
+
+// EndpointConfig is the immutable, validated endpoint choice for one call.
+type EndpointConfig struct {
+	Endpoint string
+	Model    string
+	APIKey   string
+}
+
+type endpointRequest struct {
+	Model    string `json:"model"`
+	Messages []struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	} `json:"messages"`
+	Stream bool `json:"stream"`
+}
+
+type endpointResponse struct {
+	Model   string `json:"model"`
+	Choices []struct {
+		Message struct {
+			Content any `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+func generateEndpoint(ctx context.Context, cfg EndpointConfig, prompt string) (Result, error) {
+	u, err := url.Parse(cfg.Endpoint)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return Result{}, errorsEndpoint("invalid endpoint")
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/chat/completions"
+	u.RawPath = ""
+
+	requestBody := struct {
+		Model    string `json:"model"`
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+		Stream bool `json:"stream"`
+	}{Model: cfg.Model, Stream: false}
+	requestBody.Messages = append(requestBody.Messages, struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}{Role: "user", Content: prompt})
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return Result{}, errorsEndpoint("encode request")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return Result{}, errorsEndpoint("create request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := client.Do(req)
+	if err != nil {
+		return Result{}, errorsEndpoint("request failed")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return Result{}, fmt.Errorf("openai endpoint returned HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxEndpointResponseBytes+1))
+	if err != nil {
+		return Result{}, errorsEndpoint("read response")
+	}
+	if int64(len(data)) > maxEndpointResponseBytes {
+		return Result{}, errorsEndpoint("response too large")
+	}
+	var decoded endpointResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return Result{}, errorsEndpoint("invalid response")
+	}
+	if len(decoded.Choices) == 0 {
+		return Result{}, errorsEndpoint("response has no choices")
+	}
+	content, ok := decoded.Choices[0].Message.Content.(string)
+	if !ok || strings.TrimSpace(content) == "" {
+		return Result{}, errorsEndpoint("response content is empty or invalid")
+	}
+	model := decoded.Model
+	if model == "" {
+		model = cfg.Model
+	}
+	return Result{Content: content, Agent: "openai", Model: model}, nil
+}
+
+func errorsEndpoint(reason string) error {
+	return fmt.Errorf("openai endpoint error: %s", reason)
+}

--- a/internal/insight/endpoint.go
+++ b/internal/insight/endpoint.go
@@ -38,7 +38,8 @@ type endpointResponse struct {
 	Model   string `json:"model"`
 	Choices []struct {
 		Message struct {
-			Content any `json:"content"`
+			Role    string `json:"role"`
+			Content any    `json:"content"`
 		} `json:"message"`
 	} `json:"choices"`
 }
@@ -92,6 +93,9 @@ func generateEndpoint(ctx context.Context, cfg EndpointConfig, prompt string) (R
 	}
 	if len(decoded.Choices) == 0 {
 		return Result{}, errorsEndpoint("response has no choices")
+	}
+	if decoded.Choices[0].Message.Role != "assistant" {
+		return Result{}, errorsEndpoint("response message role is invalid")
 	}
 	content, ok := decoded.Choices[0].Message.Content.(string)
 	if !ok || strings.TrimSpace(content) == "" {

--- a/internal/insight/endpoint.go
+++ b/internal/insight/endpoint.go
@@ -9,24 +9,29 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"go.kenn.io/agentsview/internal/config"
 )
 
 const maxEndpointResponseBytes int64 = 2_000_000
 
 // EndpointConfig is the immutable, validated endpoint choice for one call.
 type EndpointConfig struct {
-	Endpoint string
-	Model    string
-	APIKey   string
+	Endpoint  string
+	Model     string
+	APIKey    string
+	AllowHTTP bool
+}
+
+type endpointMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
 }
 
 type endpointRequest struct {
-	Model    string `json:"model"`
-	Messages []struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
-	} `json:"messages"`
-	Stream bool `json:"stream"`
+	Model    string            `json:"model"`
+	Messages []endpointMessage `json:"messages"`
+	Stream   bool              `json:"stream"`
 }
 
 type endpointResponse struct {
@@ -40,24 +45,17 @@ type endpointResponse struct {
 
 func generateEndpoint(ctx context.Context, cfg EndpointConfig, prompt string) (Result, error) {
 	u, err := url.Parse(cfg.Endpoint)
-	if err != nil || u.Scheme == "" || u.Host == "" {
+	if err != nil || u.Host == "" || u.User != nil {
+		return Result{}, errorsEndpoint("invalid endpoint")
+	}
+	if err := config.ValidateExtractTransport(u, cfg.AllowHTTP); err != nil {
 		return Result{}, errorsEndpoint("invalid endpoint")
 	}
 	u.Path = strings.TrimRight(u.Path, "/") + "/chat/completions"
 	u.RawPath = ""
 
-	requestBody := struct {
-		Model    string `json:"model"`
-		Messages []struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		} `json:"messages"`
-		Stream bool `json:"stream"`
-	}{Model: cfg.Model, Stream: false}
-	requestBody.Messages = append(requestBody.Messages, struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
-	}{Role: "user", Content: prompt})
+	requestBody := endpointRequest{Model: cfg.Model, Stream: false}
+	requestBody.Messages = append(requestBody.Messages, endpointMessage{Role: "user", Content: prompt})
 	body, err := json.Marshal(requestBody)
 	if err != nil {
 		return Result{}, errorsEndpoint("encode request")

--- a/internal/insight/endpoint_test.go
+++ b/internal/insight/endpoint_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateStreamWithOptions_OpenAIEndpoint(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
 	var got endpointRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
@@ -48,6 +50,48 @@ func TestOpenAIEndpoint_BearerAuth(t *testing.T) {
 	defer server.Close()
 	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: server.URL, Model: "m", APIKey: "secret"}, "p")
 	require.NoError(t, err)
+}
+
+func TestOpenAIEndpoint_AnonymousRequestOmitsBearer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer server.Close()
+	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: server.URL, Model: "m"}, "p")
+	require.NoError(t, err)
+}
+
+func TestOpenAIEndpoint_HonorsCancellation(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errs := make(chan error, 1)
+	go func() {
+		_, err := generateEndpoint(ctx, EndpointConfig{Endpoint: server.URL, Model: "m"}, "p")
+		errs <- err
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-errs:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("endpoint request did not honor cancellation")
+	}
+}
+
+func TestOpenAIEndpoint_RejectsUnsafeTransport(t *testing.T) {
+	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: "ftp://models.example/v1", Model: "m"}, "p")
+	require.Error(t, err)
+	_, err = generateEndpoint(context.Background(), EndpointConfig{Endpoint: "http://models.example/v1", Model: "m"}, "p")
+	require.Error(t, err)
 }
 
 func TestOpenAIEndpoint_ResponseContract(t *testing.T) {

--- a/internal/insight/endpoint_test.go
+++ b/internal/insight/endpoint_test.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,9 +16,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	if marker := os.Getenv("AGENTSVIEW_TEST_CLI_MARKER"); marker != "" {
+		_ = os.WriteFile(marker, []byte("invoked"), 0o600)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
 func TestGenerateStreamWithOptions_OpenAIEndpoint(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	var got endpointRequest
+	var got struct {
+		Model    string `json:"model"`
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+		Stream bool `json:"stream"`
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/chat/completions", r.URL.Path)
@@ -24,7 +42,7 @@ func TestGenerateStreamWithOptions_OpenAIEndpoint(t *testing.T) {
 		require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"model":"served-model","choices":[{"message":{"content":"answer"}}]}`))
+		_, _ = w.Write([]byte(`{"model":"served-model","choices":[{"message":{"role":"assistant","content":"answer"}}]}`))
 	}))
 	defer server.Close()
 
@@ -45,7 +63,7 @@ func TestGenerateStreamWithOptions_OpenAIEndpoint(t *testing.T) {
 func TestOpenAIEndpoint_BearerAuth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
-		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
 	}))
 	defer server.Close()
 	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: server.URL, Model: "m", APIKey: "secret"}, "p")
@@ -55,7 +73,7 @@ func TestOpenAIEndpoint_BearerAuth(t *testing.T) {
 func TestOpenAIEndpoint_AnonymousRequestOmitsBearer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Empty(t, r.Header.Get("Authorization"))
-		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
 	}))
 	defer server.Close()
 	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: server.URL, Model: "m"}, "p")
@@ -64,11 +82,20 @@ func TestOpenAIEndpoint_AnonymousRequestOmitsBearer(t *testing.T) {
 
 func TestOpenAIEndpoint_HonorsCancellation(t *testing.T) {
 	started := make(chan struct{})
+	release := make(chan struct{})
+	handlerDone := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		close(started)
-		<-r.Context().Done()
+		<-release
+		close(handlerDone)
 	}))
-	defer server.Close()
+	defer func() {
+		releaseHandler()
+		server.CloseClientConnections()
+		server.Close()
+	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -82,6 +109,9 @@ func TestOpenAIEndpoint_HonorsCancellation(t *testing.T) {
 	select {
 	case err := <-errs:
 		require.Error(t, err)
+		releaseHandler()
+		<-handlerDone
+		server.CloseClientConnections()
 	case <-time.After(time.Second):
 		t.Fatal("endpoint request did not honor cancellation")
 	}
@@ -101,7 +131,8 @@ func TestOpenAIEndpoint_ResponseContract(t *testing.T) {
 		code int
 		bad  bool
 	}{
-		{name: "valid without model", body: `{"choices":[{"message":{"content":"ok"}}]}`},
+		{name: "valid without model", body: `{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`},
+		{name: "wrong role", body: `{"choices":[{"message":{"role":"user","content":"ok"}}]}`, bad: true},
 		{name: "malformed", body: `{`, bad: true},
 		{name: "no choices", body: `{"choices":[]}`, bad: true},
 		{name: "non string", body: `{"choices":[{"message":{"content":[]}}]}`, bad: true},
@@ -163,14 +194,17 @@ func TestOpenAIEndpoint_RejectsOversizedResponse(t *testing.T) {
 }
 
 func TestGenerateStreamWithOptions_EndpointFailureDoesNotFallbackToCLI(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "cli-invoked")
+	t.Setenv("AGENTSVIEW_TEST_CLI_MARKER", marker)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusServiceUnavailable) }))
 	defer server.Close()
 	_, err := GenerateStreamWithOptions(context.Background(), "claude", "prompt", nil, GenerateOptions{
-		Agents:   map[string]AgentConfig{"claude": {Binary: "this-binary-must-not-run"}},
+		Agents:   map[string]AgentConfig{"claude": {Binary: os.Args[0]}},
 		Endpoint: &EndpointConfig{Endpoint: server.URL, Model: "m"},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 503")
+	assert.NoFileExists(t, marker)
 }
 
 func TestGenerateStreamWithOptions_EndpointUnsetUsesCLI(t *testing.T) {

--- a/internal/insight/endpoint_test.go
+++ b/internal/insight/endpoint_test.go
@@ -1,0 +1,138 @@
+package insight
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateStreamWithOptions_OpenAIEndpoint(t *testing.T) {
+	var got endpointRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/chat/completions", r.URL.Path)
+		require.Equal(t, "tenant=local", r.URL.RawQuery)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"served-model","choices":[{"message":{"content":"answer"}}]}`))
+	}))
+	defer server.Close()
+
+	result, err := GenerateStreamWithOptions(context.Background(), "claude", "exact prompt", nil, GenerateOptions{
+		Endpoint: &EndpointConfig{Endpoint: server.URL + "/v1?tenant=local", Model: "configured-model", APIKey: "test-key"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "configured-model", got.Model)
+	assert.Len(t, got.Messages, 1)
+	assert.Equal(t, "user", got.Messages[0].Role)
+	assert.Equal(t, "exact prompt", got.Messages[0].Content)
+	assert.False(t, got.Stream)
+	assert.Equal(t, "answer", result.Content)
+	assert.Equal(t, "openai", result.Agent)
+	assert.Equal(t, "served-model", result.Model)
+}
+
+func TestOpenAIEndpoint_BearerAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer server.Close()
+	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: server.URL, Model: "m", APIKey: "secret"}, "p")
+	require.NoError(t, err)
+}
+
+func TestOpenAIEndpoint_ResponseContract(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		code int
+		bad  bool
+	}{
+		{name: "valid without model", body: `{"choices":[{"message":{"content":"ok"}}]}`},
+		{name: "malformed", body: `{`, bad: true},
+		{name: "no choices", body: `{"choices":[]}`, bad: true},
+		{name: "non string", body: `{"choices":[{"message":{"content":[]}}]}`, bad: true},
+		{name: "empty", body: `{"choices":[{"message":{"content":"  "}}]}`, bad: true},
+		{name: "status", body: `bad`, code: http.StatusBadGateway, bad: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.code != 0 {
+					w.WriteHeader(tt.code)
+				}
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+			_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: server.URL, Model: "m"}, "p")
+			if tt.bad {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOpenAIEndpoint_RefusesRedirect(t *testing.T) {
+	var called bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer target.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer redirect.Close()
+	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: redirect.URL, Model: "m"}, "prompt")
+	require.Error(t, err)
+	assert.False(t, called)
+}
+
+func TestOpenAIEndpoint_RedactsErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("prompt and secret-key"))
+	}))
+	defer server.Close()
+	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: server.URL, Model: "m", APIKey: "secret-key"}, "prompt")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "prompt")
+	assert.NotContains(t, err.Error(), "secret-key")
+}
+
+func TestOpenAIEndpoint_RejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", int(maxEndpointResponseBytes)+1)))
+	}))
+	defer server.Close()
+	_, err := generateEndpoint(context.Background(), EndpointConfig{Endpoint: server.URL, Model: "m"}, "p")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+func TestGenerateStreamWithOptions_EndpointFailureDoesNotFallbackToCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusServiceUnavailable) }))
+	defer server.Close()
+	_, err := GenerateStreamWithOptions(context.Background(), "claude", "prompt", nil, GenerateOptions{
+		Agents:   map[string]AgentConfig{"claude": {Binary: "this-binary-must-not-run"}},
+		Endpoint: &EndpointConfig{Endpoint: server.URL, Model: "m"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 503")
+}
+
+func TestGenerateStreamWithOptions_EndpointUnsetUsesCLI(t *testing.T) {
+	_, err := GenerateStreamWithOptions(context.Background(), "claude", "prompt", nil, GenerateOptions{
+		Agents: map[string]AgentConfig{"claude": {Binary: "missing-cli-for-endpoint-unset-test"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start claude")
+}

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -80,7 +80,8 @@ type AgentConfig struct {
 
 // GenerateOptions holds optional insight generation overrides.
 type GenerateOptions struct {
-	Agents map[string]AgentConfig
+	Agents   map[string]AgentConfig
+	Endpoint *EndpointConfig
 }
 
 // Generate invokes an AI agent CLI to generate an insight.
@@ -112,6 +113,9 @@ func GenerateStreamWithOptions(
 		return Result{}, fmt.Errorf(
 			"unsupported agent: %s", agent,
 		)
+	}
+	if opts.Endpoint != nil {
+		return generateEndpoint(ctx, *opts.Endpoint, prompt)
 	}
 
 	path, err := resolveAgentBinary(agent, opts)

--- a/internal/server/huma_routes_insights_test.go
+++ b/internal/server/huma_routes_insights_test.go
@@ -15,6 +15,7 @@ func TestInsightGenerateOptionsMapsConfig(t *testing.T) {
 			Endpoint:  "http://127.0.0.1:30000/v1",
 			Model:     "local-model",
 			APIKeyEnv: "AGENTSVIEW_INSIGHTS_KEY",
+			AllowHTTP: true,
 		},
 		Agent: map[string]config.AgentConfig{
 			"gemini": {Binary: "gemini-bin", Sandbox: "sandbox", AllowUnsafe: true},
@@ -25,6 +26,7 @@ func TestInsightGenerateOptionsMapsConfig(t *testing.T) {
 	require.Equal(t, "http://127.0.0.1:30000/v1", opts.Endpoint.Endpoint)
 	require.Equal(t, "local-model", opts.Endpoint.Model)
 	require.Equal(t, "key", opts.Endpoint.APIKey)
+	require.True(t, opts.Endpoint.AllowHTTP)
 	require.Equal(t, "gemini-bin", opts.Agents["gemini"].Binary)
 	require.Equal(t, "sandbox", opts.Agents["gemini"].Sandbox)
 	require.True(t, opts.Agents["gemini"].AllowUnsafe)

--- a/internal/server/huma_routes_insights_test.go
+++ b/internal/server/huma_routes_insights_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/config"
+)
+
+func TestInsightGenerateOptionsMapsConfig(t *testing.T) {
+	t.Setenv("AGENTSVIEW_INSIGHTS_KEY", "key")
+	cfg := config.Config{
+		Insights: config.InsightsConfig{
+			Endpoint:  "http://127.0.0.1:30000/v1",
+			Model:     "local-model",
+			APIKeyEnv: "AGENTSVIEW_INSIGHTS_KEY",
+		},
+		Agent: map[string]config.AgentConfig{
+			"gemini": {Binary: "gemini-bin", Sandbox: "sandbox", AllowUnsafe: true},
+		},
+	}
+	opts := insightGenerateOptions(cfg)
+	require.NotNil(t, opts.Endpoint)
+	require.Equal(t, "http://127.0.0.1:30000/v1", opts.Endpoint.Endpoint)
+	require.Equal(t, "local-model", opts.Endpoint.Model)
+	require.Equal(t, "key", opts.Endpoint.APIKey)
+	require.Equal(t, "gemini-bin", opts.Agents["gemini"].Binary)
+	require.Equal(t, "sandbox", opts.Agents["gemini"].Sandbox)
+	require.True(t, opts.Agents["gemini"].AllowUnsafe)
+}

--- a/internal/server/insight_options_internal_test.go
+++ b/internal/server/insight_options_internal_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/insight"
+)
+
+func TestDefaultInsightGenerateStreamUsesContextSnapshot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"snapshot-model","choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer server.Close()
+
+	options := insight.GenerateOptions{
+		Endpoint: &insight.EndpointConfig{
+			Endpoint:  server.URL,
+			Model:     "snapshot-model",
+			AllowHTTP: true,
+		},
+	}
+	ctx := context.WithValue(
+		context.Background(), insightGenerationOptionsContextKey{}, options,
+	)
+
+	result, err := (&Server{}).defaultInsightGenerateStream(
+		ctx, "claude", "prompt", nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "openai", result.Agent)
+	require.Equal(t, "snapshot-model", result.Model)
+	require.Equal(t, "ok", result.Content)
+}

--- a/internal/server/insight_options_internal_test.go
+++ b/internal/server/insight_options_internal_test.go
@@ -4,38 +4,76 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/insight"
 )
 
-func TestDefaultInsightGenerateStreamUsesContextSnapshot(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(
+func TestDefaultInsightGenerateStreamUsesServerConfig(t *testing.T) {
+	endpoint := httptest.NewServer(http.HandlerFunc(func(
 		w http.ResponseWriter, _ *http.Request,
 	) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"model":"snapshot-model","choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
 	}))
-	defer server.Close()
+	defer endpoint.Close()
 
-	options := insight.GenerateOptions{
-		Endpoint: &insight.EndpointConfig{
-			Endpoint:  server.URL,
-			Model:     "snapshot-model",
-			AllowHTTP: true,
-		},
-	}
-	ctx := context.WithValue(
-		context.Background(), insightGenerationOptionsContextKey{}, options,
-	)
-
-	result, err := (&Server{}).defaultInsightGenerateStream(
-		ctx, "claude", "prompt", nil,
+	srv := &Server{}
+	srv.cfg.Insights.Endpoint = endpoint.URL
+	srv.cfg.Insights.Model = "snapshot-model"
+	srv.cfg.Insights.AllowHTTP = true
+	result, err := srv.defaultInsightGenerateStream(
+		context.Background(), "claude", "prompt", nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, "openai", result.Agent)
 	require.Equal(t, "snapshot-model", result.Model)
 	require.Equal(t, "ok", result.Content)
+}
+
+func TestCannedGenerationPassesSnapshotToGenerator(t *testing.T) {
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"snapshot-model","choices":[{"message":{"role":"assistant","content":"{\"schema_version\":\"llm_insight.v1\",\"kind\":\"prompt_maturity_review\",\"summary\":\"ok\",\"confidence\":\"low\",\"recommendations\":[{\"title\":\"ok\",\"rationale\":\"ok\",\"actions\":[\"ok\"],\"evidence_refs\":[\"aggregate:empty\"],\"impact\":\"low\",\"effort\":\"low\"}],\"risks\":[],\"evidence_refs\":[\"aggregate:empty\"]}"}}]}`))
+	}))
+	defer endpoint.Close()
+	mutatedEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"mutated-model","choices":[{"message":{"role":"assistant","content":"wrong"}}]}`))
+	}))
+	defer mutatedEndpoint.Close()
+
+	var srv *Server
+	srv = testServer(t, 30*time.Second, WithGenerateStreamFunc(
+		func(ctx context.Context, agent, prompt string, onLog insight.LogFunc) (insight.Result, error) {
+			srv.mu.Lock()
+			srv.cfg.Insights.Endpoint = mutatedEndpoint.URL
+			srv.cfg.Insights.Model = "mutated-model"
+			srv.mu.Unlock()
+			return srv.defaultInsightGenerateStream(ctx, agent, prompt, onLog)
+		},
+	))
+	srv.cfg.Insights.Endpoint = endpoint.URL
+	srv.cfg.Insights.Model = "snapshot-model"
+	srv.cfg.Insights.AllowHTTP = true
+
+	req := httptest.NewRequest(
+		http.MethodPost, "/api/v1/insights/generate", strings.NewReader(
+			`{"type":"llm_canned","kind":"prompt_maturity_review","date_from":"2025-01-15","date_to":"2025-01-15","agent":"claude","llm_opt_in":true}`,
+		),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	req.Host = "127.0.0.1:0"
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	require.Contains(t, recorder.Body.String(), "snapshot-model")
+	require.Contains(t, recorder.Body.String(), "ok")
+	require.NotContains(t, recorder.Body.String(), "mutated-model")
 }

--- a/internal/server/insights.go
+++ b/internal/server/insights.go
@@ -197,8 +197,9 @@ func (s *Server) generateCannedInsight(
 	if !status("building_payload") {
 		return
 	}
+	generationOptions := s.currentInsightGenerateOptions(ctx)
 	payload, aggregateHash, cacheKey, err := s.buildCannedPayload(
-		ctx, kind, req,
+		ctx, kind, req, generationOptions,
 	)
 	if err != nil {
 		log.Printf("canned insight payload error: %v", err)
@@ -243,6 +244,9 @@ func (s *Server) generateCannedInsight(
 		ctx, 3*time.Minute,
 	)
 	defer cancel()
+	genCtx = context.WithValue(
+		genCtx, insightGenerationOptionsContextKey{}, generationOptions,
+	)
 	result, err := s.generateStreamFunc(
 		genCtx, req.Agent, prompt, nil,
 	)
@@ -393,6 +397,7 @@ func (s *Server) buildCannedPayload(
 	ctx context.Context,
 	kind insight.CannedKind,
 	req generateInsightRequest,
+	generationOptions insight.GenerateOptions,
 ) (insight.CannedAggregatePayload, string, string, error) {
 	filters := insight.CannedSessionFilters{
 		Timezone:       "UTC",
@@ -486,6 +491,7 @@ func (s *Server) buildCannedPayload(
 		req.Agent, req.Prompt, aggregateHash,
 		filters.AutomatedScope,
 		filters,
+		generationOptions,
 	)
 	if err != nil {
 		return insight.CannedAggregatePayload{}, "", "", err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -228,9 +228,10 @@ func insightGenerateOptions(cfg config.Config) insight.GenerateOptions {
 	if strings.TrimSpace(cfg.Insights.Endpoint) != "" &&
 		strings.TrimSpace(cfg.Insights.Model) != "" {
 		opts.Endpoint = &insight.EndpointConfig{
-			Endpoint: cfg.Insights.Endpoint,
-			Model:    cfg.Insights.Model,
-			APIKey:   cfg.Insights.APIKey(),
+			Endpoint:  cfg.Insights.Endpoint,
+			Model:     cfg.Insights.Model,
+			APIKey:    cfg.Insights.APIKey(),
+			AllowHTTP: cfg.Insights.AllowHTTP,
 		}
 	}
 	return opts

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -165,6 +165,28 @@ type Server struct {
 	ensurePricing func(context.Context, *db.DB) error
 }
 
+type insightGenerationOptionsContextKey struct{}
+
+func (s *Server) currentInsightGenerateOptions(
+	ctx context.Context,
+) insight.GenerateOptions {
+	if options, ok := ctx.Value(insightGenerationOptionsContextKey{}).(insight.GenerateOptions); ok {
+		return options
+	}
+	s.mu.RLock()
+	cfg := s.cfg
+	s.mu.RUnlock()
+	return insightGenerateOptions(cfg)
+}
+
+func (s *Server) defaultInsightGenerateStream(
+	ctx context.Context, agent, prompt string, onLog insight.LogFunc,
+) (insight.Result, error) {
+	return insight.GenerateStreamWithOptions(
+		ctx, agent, prompt, onLog, s.currentInsightGenerateOptions(ctx),
+	)
+}
+
 // New creates a new Server.
 func New(
 	cfg config.Config, database db.Store, engine *sync.Engine,
@@ -198,18 +220,10 @@ func New(
 		insightLogDrainTimeout:    defaultInsightLogDrainTimeout,
 		insightLogStopWaitTimeout: defaultInsightLogStopWaitTimeout,
 		ensurePricing:             pricingrefresh.EnsureCurrent,
-		generateStreamFunc: func(
-			ctx context.Context, agent, prompt string,
-			onLog insight.LogFunc,
-		) (insight.Result, error) {
-			return insight.GenerateStreamWithOptions(
-				ctx, agent, prompt, onLog,
-				insightGenerateOptions(cfg),
-			)
-		},
-		spaFS:      dist,
-		spaHandler: http.FileServerFS(dist),
+		spaFS:                     dist,
+		spaHandler:                http.FileServerFS(dist),
 	}
+	s.generateStreamFunc = s.defaultInsightGenerateStream
 	for _, opt := range opts {
 		opt(s)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -204,9 +204,7 @@ func New(
 		) (insight.Result, error) {
 			return insight.GenerateStreamWithOptions(
 				ctx, agent, prompt, onLog,
-				insight.GenerateOptions{
-					Agents: insightAgentConfig(cfg.Agent),
-				},
+				insightGenerateOptions(cfg),
 			)
 		},
 		spaFS:      dist,
@@ -223,6 +221,19 @@ func New(
 	}
 	s.routes()
 	return s
+}
+
+func insightGenerateOptions(cfg config.Config) insight.GenerateOptions {
+	opts := insight.GenerateOptions{Agents: insightAgentConfig(cfg.Agent)}
+	if strings.TrimSpace(cfg.Insights.Endpoint) != "" &&
+		strings.TrimSpace(cfg.Insights.Model) != "" {
+		opts.Endpoint = &insight.EndpointConfig{
+			Endpoint: cfg.Insights.Endpoint,
+			Model:    cfg.Insights.Model,
+			APIKey:   cfg.Insights.APIKey(),
+		}
+	}
+	return opts
 }
 
 // ingestionConfig returns the daemon-start configuration for local filesystem


### PR DESCRIPTION
Insight generation currently depends on one of five agent CLIs, which prevents local endpoint use in containers. Adds a selectable OpenAI-compatible chat-completions endpoint with env-backed credentials, bounded errors, and unchanged CLI behavior when endpoint configuration is absent.

Closes #1363
