### PR TITLE
fix(parser): settle unsupported Trae source skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
             'go.kenn.io/agentsview/internal/db'
             'go.kenn.io/agentsview/internal/duckdb'
             'go.kenn.io/agentsview/internal/parser'
+            'go.kenn.io/agentsview/internal/sync'
           )
           $packages = $packages | Where-Object { $_ -notin $isolatedPackages }
           go test -tags "fts5" $packages -count=1 -timeout=20m
@@ -206,8 +207,8 @@ jobs:
         if: runner.os == 'Linux' && steps.codecov.outcome == 'failure'
         run: echo "::warning::Codecov upload failed"
 
-  # Keep the two slowest SQLite-backed packages isolated from each other and
-  # from the remaining Windows package set.
+  # Keep the slowest SQLite-backed packages isolated from each other and from
+  # the remaining Windows package set.
   test-sqlite-packages-windows:
     name: Go Test (windows-latest, ${{ matrix.name }})
     runs-on: windows-latest
@@ -219,6 +220,8 @@ jobs:
             package: ./internal/db
           - name: Parser
             package: ./internal/parser
+          - name: Sync
+            package: ./internal/sync
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -216,12 +216,13 @@ add an archived or maintained mirror without replacing the original identity.
 - **Evidence:** `source`.
 
 - **Upstream:** Clone `https://github.com/Gitlawb/openclaude.git` at
-  `1ddb7d68399a2cd5028d4c5f487676f941879eae`; see the pinned
-  [session JSONL writer](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/utils/sessionStorage.ts),
-
-    [project-directory resolver](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/utils/envUtils.ts),
-    and
-    [assistant message type](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/types/message.ts).
+  `1ddb7d68399a2cd5028d4c5f487676f941879eae`. The pinned
+  [session JSONL writer](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/utils/sessionStorage.ts)
+  records the session. The
+  [project-directory resolver](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/utils/envUtils.ts)
+  maps its project directory. The
+  [assistant message type](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/types/message.ts)
+  defines assistant content.
 
 - **Usage and cost:** Claude-style input, output, cache-creation, and cache-read
   tokens are persisted in each assistant message's API usage object.
@@ -444,8 +445,8 @@ add an archived or maintained mirror without replacing the original identity.
 
 ## Grok Build (`grok`)
 
-- **Format:** Workspace-scoped session directories containing `summary.json`,
-  a derived `chat_history.jsonl` model-message cache, and an authoritative
+- **Format:** Workspace-scoped session directories containing `summary.json`, a
+  derived `chat_history.jsonl` model-message cache, and an authoritative
   `updates.jsonl` stream of timestamped ACP and xAI session notifications.
 - **Evidence:** `source`.
 - **Upstream:** Clone `https://github.com/xai-org/grok-build.git` at
@@ -462,30 +463,31 @@ add an archived or maintained mirror without replacing the original identity.
   records to the existing tool-result event model, so Activity can use tool
   completion time without adding derived transcript messages.
 - **Usage and cost:** Durable `turn_completed` updates may carry per-model
-  input, output, cache-read, cache-creation, and reasoning tokens plus optional
-  `costUsdTicks` (10^10 ticks per USD), as defined by the
+  input, output, cache-read, cache-creation, and reasoning tokens plus
+  optional `costUsdTicks` (10^10 ticks per USD), as defined by the
   [notification schema](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-shell/src/extensions/notification.rs).
-  Agentsview emits one usage event per prompt and model, subtracts cache reads
-  from the full input count, and uses reported cost ticks when present.
+  Agentsview emits one usage event per prompt and model, subtracts cache
+  reads from the full input count, and uses reported cost ticks when present.
 - **Automation:** The first-party
   [headless guide](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-pager/docs/user-guide/14-headless-mode.md)
-  defines prompt flags as non-interactive invocation. The producer propagates
-  that startup mode into
+  defines prompt flags as non-interactive invocation. The producer
+  propagates that startup mode into
   [`PromptContext.is_non_interactive`](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L936-L944),
-  whose schema identifies headless, SDK, stdio, and generic ACP execution and
-  defaults false for interactive or older contexts
-  ([schema](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L145-L150),
-  [default](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L177-L199)).
-  The producer writes that context to the same session directory as
-  `prompt_context.json`
-  ([persistence](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session.rs#L1384-L1404),
-  [spawn call](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L1049-L1055)).
-  Agentsview treats only an explicit true value in a valid, session-associated
-  file as durable automation evidence; file presence, a missing field, or a
-  missing file does not classify a session as automated.
-- **Agentsview:** `internal/parser/grok.go`,
-  `internal/parser/grok_provider.go`, colocated tests, and the sanitized
-  upstream-generated fixtures in `internal/parser/testdata/grok-build`.
+  whose
+  [schema](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L145-L150)
+  identifies headless, SDK, stdio, and generic ACP execution. Its
+  [default implementation](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L177-L199)
+  defaults false for interactive or older contexts. The
+  [persistence implementation](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session.rs#L1384-L1404)
+  writes that context to the same session directory as
+  `prompt_context.json`, and the
+  [spawn call](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L1049-L1055)
+  supplies it. Agentsview treats only an explicit true value in a valid,
+  session-associated file as durable automation evidence; file presence, a
+  missing field, or a missing file does not classify a session as automated.
+- **Agentsview:** `internal/parser/grok.go`, `internal/parser/grok_provider.go`,
+  colocated tests, and the sanitized upstream-generated fixtures in
+  `internal/parser/testdata/grok-build`.
 
 ## MiMo Code (`mimocode`)
 
@@ -852,6 +854,11 @@ add an archived or maintained mirror without replacing the original identity.
   usage and cost unavailable rather than estimating them.
 - **Agentsview:** `internal/parser/trae_provider.go`; the storage key and JSON
   shape are based on observed local databases and controlled fixtures.
+  Reverified 2026-08-19 with a controlled two-session database reduced to one
+  session and then zero sessions, plus a deleted container: complete parses
+  retain emitted members and mark removed members source-missing, missing
+  whole containers preserve archived members, and unsupported encrypted
+  layouts remain non-authoritative for archive reconciliation.
 
 ## Visual Studio Copilot (`visualstudio-copilot`)
 

--- a/frontend/e2e/session-timing.spec.ts
+++ b/frontend/e2e/session-timing.spec.ts
@@ -26,7 +26,12 @@ async function gotoShowcase(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem("agentsview-session-vitals", "true");
   });
-  await page.goto(`/sessions/${SHOWCASE}`);
+  // The panel and its first call are the readiness contract below. Waiting
+  // for WebKit's full load event also waits on unrelated page resources and
+  // can exhaust the whole test timeout before either assertion runs.
+  await page.goto(`/sessions/${SHOWCASE}`, {
+    waitUntil: "domcontentloaded",
+  });
   await expect(page.locator("aside.vitals")).toBeVisible({
     timeout: 5_000,
   });

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -4009,6 +4009,36 @@ func (db *DB) RemoveSessionSourceOwnershipBaselines(
 	return nil
 }
 
+// RemoveSessionSourceBaselines revokes deletion proof for the supplied source
+// paths across every stored machine attribution.
+func (db *DB) RemoveSessionSourceBaselines(
+	ctx context.Context,
+	sources []SessionSourcePath,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(sources) == 0 {
+		return nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting source baseline removal: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := deleteSessionSourceBaselinesAcrossMachinesTx(
+		ctx, tx, sources, "rejected",
+	); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing source baseline removal: %w", err)
+	}
+	return nil
+}
+
 // ReplaceActiveSessionSourceBaselines makes admitted the exact subset of a
 // bounded candidate page that carries deletion proof. Machine is an exact
 // stored key, including the empty key retained by legacy sessions. Existing
@@ -4193,6 +4223,31 @@ func deleteSessionSourceBaselinesTx(
 		); err != nil {
 			return fmt.Errorf(
 				"removing %s session source baselines: %w", what, err,
+			)
+		}
+	}
+	return nil
+}
+
+func deleteSessionSourceBaselinesAcrossMachinesTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	sources []SessionSourcePath,
+	what string,
+) error {
+	for start := 0; start < len(sources); start += baselinePairChunk {
+		end := min(start+baselinePairChunk, len(sources))
+		filter, args, ok := buildSourcePairFilter(sources[start:end])
+		if !ok {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM local_session_source_baselines
+			WHERE `+filter, args...,
+		); err != nil {
+			return fmt.Errorf(
+				"removing %s session source baselines across machines: %w",
+				what, err,
 			)
 		}
 	}

--- a/internal/parser/trae_layout_test.go
+++ b/internal/parser/trae_layout_test.go
@@ -90,7 +90,7 @@ func TestTraeLayoutStateMatrix(t *testing.T) {
 			},
 			check: func(t *testing.T, outcome ParseOutcome) {
 				assert.Equal(t, SkipUnsupportedSource, outcome.SkipReason)
-				assert.False(t, outcome.ResultSetComplete)
+				assert.True(t, outcome.ResultSetComplete)
 				assert.False(t, outcome.ForceReplace)
 			},
 		},

--- a/internal/parser/trae_provider.go
+++ b/internal/parser/trae_provider.go
@@ -183,20 +183,27 @@ func traeParseContainerOutcome(
 	src multiSessionSource,
 	req ParseRequest,
 ) (ParseOutcome, error) {
+	if _, err := os.Stat(src.Container); err != nil {
+		if os.IsNotExist(err) {
+			return ParseOutcome{
+				ResultSetComplete: true,
+				SkipReason:        SkipNoSession,
+			}, nil
+		}
+		return ParseOutcome{}, fmt.Errorf("stat trae container %s: %w", src.Container, err)
+	}
 	snapshot, err := traeLoadSessionSnapshot(src.Container)
 	if err != nil {
 		return ParseOutcome{}, err
 	}
 	state := classifyTraeLayout(src.Root, snapshot)
+	if state == traeLayoutUnsupported {
+		return unsupportedMultiSessionOutcome(), nil
+	}
 	if !snapshot.authoritative {
 		return ParseOutcome{
 			ResultSetComplete: false,
-			SkipReason: func() SkipReason {
-				if state == traeLayoutUnsupported {
-					return SkipUnsupportedSource
-				}
-				return SkipNoSession
-			}(),
+			SkipReason:        SkipNoSession,
 		}, nil
 	}
 	results := make([]ParseResultOutcome, 0, len(snapshot.records))
@@ -214,14 +221,9 @@ func traeParseContainerOutcome(
 	}
 	if len(results) == 0 {
 		return ParseOutcome{
-			ResultSetComplete: state != traeLayoutUnsupported && snapshot.complete,
-			ForceReplace:      state != traeLayoutUnsupported && snapshot.complete,
-			SkipReason: func() SkipReason {
-				if state == traeLayoutUnsupported {
-					return SkipUnsupportedSource
-				}
-				return SkipNoSession
-			}(),
+			ResultSetComplete: snapshot.complete,
+			ForceReplace:      snapshot.complete,
+			SkipReason:        SkipNoSession,
 		}, nil
 	}
 	return ParseOutcome{
@@ -675,6 +677,7 @@ func traeRecordHash(raw, projectHint string) string {
 func traeProviderCapabilities() Capabilities {
 	caps := windsurfProviderCapabilities()
 	caps.Source = multiSessionContainerSourceCapabilities(CapabilitySupported, CapabilitySupported)
+	caps.Source.PersistentArchive = CapabilitySupported
 	caps.Source.CompositeFingerprint = CapabilitySupported
 	caps.Content.AggregateUsageEvents = CapabilityUnsupported
 	caps.Content.ToolCalls = CapabilityUnsupported

--- a/internal/parser/trae_provider_test.go
+++ b/internal/parser/trae_provider_test.go
@@ -360,6 +360,33 @@ func TestTraeValidEmptyStoreReturnsCompleteNoSessionOutcome(t *testing.T) {
 	assert.True(t, outcome.ResultSetComplete)
 }
 
+func TestTraeMissingContainerReturnsCompleteNoSessionOutcome(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "globalStorage", traeStateDBName)
+	writeTraeDB(t, path, traeStoreValue(t, []any{
+		map[string]any{
+			"sessionId": "session-1",
+			"createdAt": 1715340600000,
+			"messages":  []any{map[string]any{"role": "user", "content": "archived"}},
+		},
+	}), "memento/unrelated-chat-storage")
+
+	factory, ok := ProviderFactoryByType(AgentTrae)
+	require.True(t, ok)
+	provider := factory.NewProvider(ProviderConfig{Roots: []string{root}})
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	require.NoError(t, os.Remove(path))
+
+	outcome, err := provider.Parse(t.Context(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	assert.Equal(t, SkipNoSession, outcome.SkipReason)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.False(t, outcome.ForceReplace)
+}
+
 func TestTraeUnknownStoragePreservesArchiveUntilExplicitList(t *testing.T) {
 	for _, value := range []string{`{}`, `{"list":null}`} {
 		t.Run(value, func(t *testing.T) {
@@ -523,7 +550,9 @@ func TestTraeEncryptedLayoutOutcomeUnsupported(t *testing.T) {
 			outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
 			require.NoError(t, err)
 			assert.Equal(t, SkipUnsupportedSource, outcome.SkipReason)
-			assert.False(t, outcome.ResultSetComplete)
+			assert.True(t, outcome.ResultSetComplete)
+			assert.Empty(t, outcome.Results)
+			assert.Empty(t, outcome.SourceErrors)
 			assert.False(t, outcome.ForceReplace)
 		})
 	}

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -3210,31 +3210,29 @@ func TestPrepareHTTPSyncsOrdersConcurrentCallersByMirrorLockPath(t *testing.T) {
 	syncB.DB = database
 	assert.Less(t, MirrorDir(dataDirA, syncA.Host), MirrorDir(dataDirB, syncB.Host))
 
-	firstA := make(chan struct{})
-	firstB := make(chan struct{})
-	var onceA, onceB stdsync.Once
+	callerOneAtA := make(chan struct{})
+	releaseCallerOneA := make(chan struct{})
+	var callerOneAtAOnce stdsync.Once
 	var orderMu stdsync.Mutex
 	orders := map[string][]string{}
-	record := func(
-		caller, mirror string, ownOnce *stdsync.Once,
-		own chan struct{}, other <-chan struct{},
-	) {
+	record := func(caller, mirror string) {
 		orderMu.Lock()
 		orders[caller] = append(orders[caller], mirror)
 		orderMu.Unlock()
-		ownOnce.Do(func() { close(own) })
-		select {
-		case <-other:
-		case <-time.After(50 * time.Millisecond):
-		}
 	}
 	remoteA.onManifestRequest = func(r *http.Request) {
-		record(r.Header.Get("Authorization"), "mirror-a",
-			&onceA, firstA, firstB)
+		caller := r.Header.Get("Authorization")
+		record(caller, "mirror-a")
+		if caller == "Bearer caller-one" {
+			callerOneAtAOnce.Do(func() { close(callerOneAtA) })
+			select {
+			case <-releaseCallerOneA:
+			case <-r.Context().Done():
+			}
+		}
 	}
 	remoteB.onManifestRequest = func(r *http.Request) {
-		record(r.Header.Get("Authorization"), "mirror-b",
-			&onceB, firstB, firstA)
+		record(r.Header.Get("Authorization"), "mirror-b")
 	}
 
 	callerOne := []HTTPSync{syncB, syncA}
@@ -3248,24 +3246,25 @@ func TestPrepareHTTPSyncsOrdersConcurrentCallersByMirrorLockPath(t *testing.T) {
 		prepared *PreparedHTTPSyncs
 		err      error
 	}
-	// The timeout is a deadlock watchdog, not a latency budget: a real
-	// lock-order deadlock never resolves, while a loaded Windows CI runner
-	// has taken over 4s to finish both preparations legitimately.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), backgroundWaitTimeout)
 	defer cancel()
-	start := make(chan struct{})
 	results := make(chan result, 2)
-	for caller, syncs := range map[string][]HTTPSync{
-		"caller-one": callerOne,
-		"caller-two": callerTwo,
-	} {
-		go func() {
-			<-start
-			prepared, err := PrepareHTTPSyncs(ctx, syncs)
-			results <- result{caller: caller, prepared: prepared, err: err}
-		}()
+	prepare := func(caller string, syncs []HTTPSync) {
+		prepared, err := PrepareHTTPSyncs(ctx, syncs)
+		results <- result{caller: caller, prepared: prepared, err: err}
 	}
-	close(start)
+	go prepare("caller-one", callerOne)
+	select {
+	case <-callerOneAtA:
+	case <-ctx.Done():
+		orderMu.Lock()
+		observedOrders := fmt.Sprint(orders)
+		orderMu.Unlock()
+		require.FailNow(t, "caller one did not reach its first canonical mirror",
+			"orders=%s", observedOrders)
+	}
+	go prepare("caller-two", callerTwo)
+	close(releaseCallerOneA)
 
 	got := make(map[string]error, 2)
 	for range 2 {

--- a/internal/sync/cwd_filter_test.go
+++ b/internal/sync/cwd_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
 	"runtime"
 	"testing"
 
@@ -584,8 +585,12 @@ func TestReconcileWatchRootsRevokesRejectedBaselineOnPageFailure(
 ) {
 	fx := newEngineFixture(t)
 	path := fx.writeClaudeSession(t, "project", "reconcile-filtered.jsonl", "first")
-	require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+	filteredPath := fx.writeClaudeSession(
+		t, "project", "reconcile-source-filtered.jsonl", "first",
+	)
+	require.Equal(t, 2, fx.engine.SyncAll(t.Context(), nil).Synced)
 	primaryID := fx.sessionIDFor(t, path)
+	filteredID := fx.sessionIDFor(t, filteredPath)
 
 	rejectedID, failingID := seedPartialSourceMissingFailure(
 		t, fx.db, primaryID, path,
@@ -600,6 +605,13 @@ func TestReconcileWatchRootsRevokesRejectedBaselineOnPageFailure(
 			END
 			WHERE id IN (?, ?)`,
 			rejectedID, failingID, rejectedID, failingID,
+		)
+		return err
+	}))
+	require.NoError(t, fx.db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"UPDATE sessions SET cwd = '/outside/project' WHERE id = ?",
+			filteredID,
 		)
 		return err
 	}))
@@ -638,31 +650,57 @@ func TestReconcileWatchRootsRevokesRejectedBaselineOnPageFailure(
 	).Scan(&primaryBaseline))
 	assert.Zero(t, primaryBaseline,
 		"failed-page cleanup must not grant new source proof")
+	var filteredBaseline int
+	require.NoError(t, fx.db.Reader().QueryRow(`
+		SELECT count(*) FROM local_session_source_baselines
+		WHERE session_id = ?`, filteredID,
+	).Scan(&filteredBaseline))
+	assert.Zero(t, filteredBaseline,
+		"a mixed page failure must revoke source-wide proof rejected by CWD")
 	rejected, err := fx.db.GetSession(t.Context(), rejectedID)
 	require.NoError(t, err)
 	assert.NotNil(t, rejected,
 		"the CWD-rejected stale fork must remain active")
+
+	require.NoError(t, fx.db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec("DROP TRIGGER fail_second_source_missing_tombstone")
+		return err
+	}))
+	require.NoError(t, os.Remove(filteredPath))
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	preserved, err := fx.db.GetSession(t.Context(), filteredID)
+	require.NoError(t, err)
+	assert.NotNil(t, preserved,
+		"a source removed before retry must not tombstone its filtered session")
 }
 
-func TestReconcileWatchRootsRevokesRejectedBaselineOnFinalizationFailure(
+func TestReconcileWatchRootsRevokesSourceWideRejectedBaselineOnFinalizationFailure(
 	t *testing.T,
 ) {
 	fx := newEngineFixture(t)
 	path := fx.writeClaudeSession(t, "project", "finalize-filtered.jsonl", "first")
 	require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
 	primaryID := fx.sessionIDFor(t, path)
-	rejectedID := primaryID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
-	require.NoError(t, fx.db.UpsertSession(db.Session{
-		ID: rejectedID, Project: "project", Machine: "local", Agent: "claude",
-		Cwd: "/outside/project", ParentSessionID: &primaryID,
-		RelationshipType: "fork", FilePath: &path,
+	require.NoError(t, fx.db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			UPDATE sessions
+			SET cwd = '/outside/project', machine = 'legacy-machine'
+			WHERE id = ?`,
+			primaryID,
+		)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(`
+			UPDATE local_session_source_baselines
+			SET machine = 'legacy-machine'
+			WHERE session_id = ?`,
+			primaryID,
+		)
+		return err
 	}))
-	require.NoError(t, fx.db.SetSessionDataVersion(rejectedID, 0))
-	require.NoError(t, fx.db.BaselineActiveSessionSourceOwnerships(
-		t.Context(), []db.SessionSourceOwnership{{
-			ID: rejectedID, Machine: "local", Agent: "claude", FilePath: path,
-		}},
-	))
 	fx.engine.Close()
 	fx.engine = NewEngine(fx.db, EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
@@ -684,31 +722,199 @@ func TestReconcileWatchRootsRevokesRejectedBaselineOnFinalizationFailure(
 		return nil, lookupErr
 	}
 
-	fx.appendClaudeMessage(t, path, "changed")
 	err := fx.engine.ReconcileWatchRoots(
 		t.Context(), []string{fx.claudeDir}, false,
 	)
 
 	require.ErrorIs(t, err, lookupErr)
-	assert.Equal(t, 1, lookupCalls)
-	var rejectedBaseline int
-	require.NoError(t, fx.db.Reader().QueryRow(`
-		SELECT count(*) FROM local_session_source_baselines
-		WHERE session_id = ?`, rejectedID,
-	).Scan(&rejectedBaseline))
-	assert.Zero(t, rejectedBaseline,
-		"failed finalization must revoke proof from a CWD-rejected fork")
+	assert.NotZero(t, lookupCalls)
 	var primaryBaseline int
 	require.NoError(t, fx.db.Reader().QueryRow(`
 		SELECT count(*) FROM local_session_source_baselines
 		WHERE session_id = ?`, primaryID,
 	).Scan(&primaryBaseline))
-	assert.Equal(t, 1, primaryBaseline,
-		"reject-only cleanup must preserve admitted source proof")
-	rejected, err := fx.db.GetSession(t.Context(), rejectedID)
+	assert.Zero(t, primaryBaseline,
+		"failed finalization must revoke source-wide proof rejected by CWD")
+
+	fx.engine.sourceAttributionLookupOverride = nil
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	preserved, err := fx.db.GetSession(t.Context(), primaryID)
 	require.NoError(t, err)
-	assert.NotNil(t, rejected,
-		"the CWD-rejected stale fork must remain active")
+	assert.NotNil(t, preserved,
+		"a source removed before retry must not tombstone its filtered session")
+}
+
+func TestReconcileWatchRootsRevokesRejectedBaselineOnSpoolFailure(
+	t *testing.T,
+) {
+	for _, tc := range []struct {
+		name      string
+		failWrite bool
+	}{
+		{name: "marker write", failWrite: true},
+		{name: "marker query"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newEngineFixture(t)
+			path := fx.writeClaudeSession(t, "project", "spool-filtered.jsonl", "first")
+			require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+			primaryID := fx.sessionIDFor(t, path)
+			rejectedID := primaryID + "-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+			require.NoError(t, fx.db.UpsertSession(db.Session{
+				ID: rejectedID, Project: "project", Machine: "local", Agent: "claude",
+				Cwd: "/outside/project", ParentSessionID: &primaryID,
+				RelationshipType: "fork", FilePath: &path,
+			}))
+			require.NoError(t, fx.db.SetSessionDataVersion(rejectedID, 0))
+			require.NoError(t, fx.db.BaselineActiveSessionSourceOwnerships(
+				t.Context(), []db.SessionSourceOwnership{{
+					ID: rejectedID, Machine: "local", Agent: "claude", FilePath: path,
+				}},
+			))
+			fx.engine.Close()
+			fx.engine = NewEngine(fx.db, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentClaude: {fx.claudeDir},
+				},
+				Machine:            "local",
+				IncludeCwdPrefixes: []string{"/workspace/allowed"},
+			})
+			t.Cleanup(fx.engine.Close)
+			injected := errors.New("injected non-authoritative spool failure")
+			fx.engine.reconciliationSpoolFactory = func(
+				path string,
+			) (reconciliationSpoolStore, error) {
+				spool, err := newReconciliationSpool(path)
+				if err != nil {
+					return nil, err
+				}
+				return &nonAuthoritativeFailureSpool{
+					reconciliationSpoolStore: spool,
+					err:                      injected,
+					failWrite:                tc.failWrite,
+				}, nil
+			}
+
+			fx.appendClaudeMessage(t, path, "changed")
+			err := fx.engine.ReconcileWatchRoots(
+				t.Context(), []string{fx.claudeDir}, false,
+			)
+
+			require.ErrorIs(t, err, injected)
+			var rejectedBaseline int
+			require.NoError(t, fx.db.Reader().QueryRow(`
+				SELECT count(*) FROM local_session_source_baselines
+				WHERE session_id = ?`, rejectedID,
+			).Scan(&rejectedBaseline))
+			assert.Zero(t, rejectedBaseline,
+				"a spool failure must revoke proof from a CWD-rejected fork")
+			rejected, getErr := fx.db.GetSession(t.Context(), rejectedID)
+			require.NoError(t, getErr)
+			assert.NotNil(t, rejected,
+				"the CWD-rejected stale fork must remain active")
+		})
+	}
+}
+
+func TestReconcileWatchRootsRevokesSourceWideRejectedBaselineOnSpoolFailure(
+	t *testing.T,
+) {
+	for _, tc := range []struct {
+		name      string
+		failWrite bool
+	}{
+		{name: "marker write", failWrite: true},
+		{name: "marker query"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newEngineFixture(t)
+			path := fx.writeClaudeSession(
+				t, "project", "spool-source-filtered.jsonl", "first",
+			)
+			require.Equal(t, 1, fx.engine.SyncAll(t.Context(), nil).Synced)
+			sessionID := fx.sessionIDFor(t, path)
+			require.NoError(t, fx.db.Update(func(tx *sql.Tx) error {
+				_, err := tx.Exec(
+					"UPDATE sessions SET cwd = '/outside/project' WHERE id = ?",
+					sessionID,
+				)
+				return err
+			}))
+			fx.engine.Close()
+			fx.engine = NewEngine(fx.db, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentClaude: {fx.claudeDir},
+				},
+				Machine:            "local",
+				IncludeCwdPrefixes: []string{"/workspace/allowed"},
+			})
+			t.Cleanup(fx.engine.Close)
+			defaultFactory := fx.engine.reconciliationSpoolFactory
+			injected := errors.New("injected non-authoritative spool failure")
+			fx.engine.reconciliationSpoolFactory = func(
+				path string,
+			) (reconciliationSpoolStore, error) {
+				spool, err := defaultFactory(path)
+				if err != nil {
+					return nil, err
+				}
+				return &nonAuthoritativeFailureSpool{
+					reconciliationSpoolStore: spool,
+					err:                      injected,
+					failWrite:                tc.failWrite,
+				}, nil
+			}
+
+			err := fx.engine.ReconcileWatchRoots(
+				t.Context(), []string{fx.claudeDir}, false,
+			)
+			require.ErrorIs(t, err, injected)
+			var baselineCount int
+			require.NoError(t, fx.db.Reader().QueryRow(`
+				SELECT count(*) FROM local_session_source_baselines
+				WHERE session_id = ?`, sessionID,
+			).Scan(&baselineCount))
+			assert.Zero(t, baselineCount,
+				"a spool failure must revoke source-wide proof rejected by CWD")
+
+			fx.engine.reconciliationSpoolFactory = defaultFactory
+			require.NoError(t, os.Remove(path))
+			require.NoError(t, fx.engine.ReconcileWatchRoots(
+				t.Context(), []string{fx.claudeDir}, false,
+			))
+			preserved, getErr := fx.db.GetSession(t.Context(), sessionID)
+			require.NoError(t, getErr)
+			assert.NotNil(t, preserved,
+				"a source removed before retry must not tombstone its filtered session")
+		})
+	}
+}
+
+type nonAuthoritativeFailureSpool struct {
+	reconciliationSpoolStore
+	err       error
+	failWrite bool
+}
+
+func (spool *nonAuthoritativeFailureSpool) AddNonAuthoritativeScopes(
+	ctx context.Context, scopes []reconciliationSourceScope,
+) error {
+	if spool.failWrite {
+		return spool.err
+	}
+	return spool.reconciliationSpoolStore.AddNonAuthoritativeScopes(ctx, scopes)
+}
+
+func (spool *nonAuthoritativeFailureSpool) HasNonAuthoritativeScopes(
+	ctx context.Context, agent parser.AgentType,
+) (bool, error) {
+	if !spool.failWrite {
+		return false, spool.err
+	}
+	return spool.reconciliationSpoolStore.HasNonAuthoritativeScopes(ctx, agent)
 }
 
 func TestShouldAbortResyncSwap(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -71,9 +71,11 @@ type passEpilogueEligibility struct {
 
 type reconciliationBaselineTracker struct {
 	sources                 map[machineSessionSource]struct{}
+	rejectedSources         map[machineSessionSource]struct{}
 	exactOwnerships         map[db.SessionSourceOwnership]struct{}
 	rejectedExactOwnerships map[db.SessionSourceOwnership]struct{}
 	cacheWrites             map[string]skipCacheWrite
+	nonAuthoritativeScopes  map[reconciliationSourceScope]struct{}
 }
 
 type machineSessionSource struct {
@@ -120,8 +122,9 @@ func consumeBaselineOwnerships(
 
 func newReconciliationBaselineTracker() *reconciliationBaselineTracker {
 	return &reconciliationBaselineTracker{
-		sources:     make(map[machineSessionSource]struct{}, reconciliationPageSize),
-		cacheWrites: make(map[string]skipCacheWrite),
+		sources:                make(map[machineSessionSource]struct{}, reconciliationPageSize),
+		cacheWrites:            make(map[string]skipCacheWrite),
+		nonAuthoritativeScopes: make(map[reconciliationSourceScope]struct{}),
 	}
 }
 
@@ -163,6 +166,9 @@ func (tracker *reconciliationBaselineTracker) add(
 	if source.Source.Agent == "" || source.Source.FilePath == "" {
 		return
 	}
+	if _, rejected := tracker.rejectedSources[source]; rejected {
+		return
+	}
 	tracker.sources[source] = struct{}{}
 }
 
@@ -172,6 +178,48 @@ func (tracker *reconciliationBaselineTracker) list() []machineSessionSource {
 		sources = append(sources, source)
 	}
 	return sources
+}
+
+func (tracker *reconciliationBaselineTracker) reject(
+	source machineSessionSource,
+) {
+	if source.Source.Agent == "" || source.Source.FilePath == "" {
+		return
+	}
+	if tracker.rejectedSources == nil {
+		tracker.rejectedSources = make(map[machineSessionSource]struct{})
+	}
+	delete(tracker.sources, source)
+	tracker.rejectedSources[source] = struct{}{}
+}
+
+func (tracker *reconciliationBaselineTracker) listRejected() []machineSessionSource {
+	sources := make([]machineSessionSource, 0, len(tracker.rejectedSources))
+	for source := range tracker.rejectedSources {
+		sources = append(sources, source)
+	}
+	return sources
+}
+
+func (tracker *reconciliationBaselineTracker) addNonAuthoritativeScope(
+	agent parser.AgentType, path string,
+) {
+	path = validatedProviderSourceStatPath(path)
+	if agent == "" || path == "" {
+		return
+	}
+	tracker.nonAuthoritativeScopes[reconciliationSourceScope{
+		Provider: agent,
+		Path:     canonicalReconciliationSourceIdentity(path),
+	}] = struct{}{}
+}
+
+func (tracker *reconciliationBaselineTracker) listNonAuthoritativeScopes() []reconciliationSourceScope {
+	scopes := make([]reconciliationSourceScope, 0, len(tracker.nonAuthoritativeScopes))
+	for scope := range tracker.nonAuthoritativeScopes {
+		scopes = append(scopes, scope)
+	}
+	return scopes
 }
 
 func (tracker *reconciliationBaselineTracker) addExactOwnership(
@@ -222,16 +270,29 @@ func (tracker *reconciliationBaselineTracker) listRejectedExactOwnerships() []db
 
 func (e *Engine) revokeRejectedReconciliationBaselines(
 	ctx context.Context,
+	sources []machineSessionSource,
 	ownerships []db.SessionSourceOwnership,
 ) error {
-	if err := e.db.RemoveSessionSourceOwnershipBaselines(
-		context.WithoutCancel(ctx), ownerships,
+	cleanupCtx := context.WithoutCancel(ctx)
+	rejectedSources := make([]db.SessionSourcePath, 0, len(sources))
+	for _, source := range sources {
+		rejectedSources = append(rejectedSources, source.Source)
+	}
+	var sourceErr error
+	if err := e.db.RemoveSessionSourceBaselines(
+		cleanupCtx, rejectedSources,
 	); err != nil {
-		return fmt.Errorf(
+		sourceErr = fmt.Errorf("revoke rejected source baselines: %w", err)
+	}
+	var ownershipErr error
+	if err := e.db.RemoveSessionSourceOwnershipBaselines(
+		cleanupCtx, ownerships,
+	); err != nil {
+		ownershipErr = fmt.Errorf(
 			"revoke rejected source baseline exceptions: %w", err,
 		)
 	}
-	return nil
+	return errors.Join(sourceErr, ownershipErr)
 }
 
 type reconciliationRuntimeMetrics struct {
@@ -4782,6 +4843,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 		if pageStats.Aborted || pageStats.Failed > 0 {
 			cleanupErr := e.revokeRejectedReconciliationBaselines(
 				ctx,
+				baselineTracker.listRejected(),
 				baselineTracker.listRejectedExactOwnerships(),
 			)
 			stats.Aborted = true
@@ -4794,10 +4856,45 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 			)
 			break
 		}
-		baselineCandidates, baselineAdmitted := eligibleReconciliationBaselines(
+		if err := spool.AddNonAuthoritativeScopes(
+			ctx, baselineTracker.listNonAuthoritativeScopes(),
+		); err != nil {
+			cleanupErr := e.revokeRejectedReconciliationBaselines(
+				ctx, baselineTracker.listRejected(),
+				baselineTracker.listRejectedExactOwnerships(),
+			)
+			stats.RecordFailed()
+			stats.Aborted = true
+			retErr = errors.Join(
+				fmt.Errorf(
+					"persist non-authoritative reconciliation scopes: %w", err,
+				),
+				cleanupErr,
+			)
+			break
+		}
+		baselineCandidates, baselineAdmitted, err := eligibleReconciliationBaselines(
+			ctx,
 			page, baselineTracker.list(), authoritativeProviders,
+			spool,
 		)
 		cacheWrites := baselineTracker.listCacheWrites()
+		if err != nil {
+			e.rejectSkipCacheWrites(cacheWrites)
+			cleanupErr := e.revokeRejectedReconciliationBaselines(
+				ctx, baselineTracker.listRejected(),
+				baselineTracker.listRejectedExactOwnerships(),
+			)
+			stats.RecordFailed()
+			stats.Aborted = true
+			retErr = errors.Join(
+				fmt.Errorf(
+					"query non-authoritative reconciliation scopes: %w", err,
+				),
+				cleanupErr,
+			)
+			break
+		}
 		exactOwnerships := baselineTracker.listExactOwnerships()
 		exactOwnerships = slices.DeleteFunc(
 			exactOwnerships,
@@ -4822,7 +4919,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 		); err != nil {
 			e.rejectSkipCacheWrites(cacheWrites)
 			cleanupErr := e.revokeRejectedReconciliationBaselines(
-				ctx, rejectedExactOwnerships,
+				ctx, baselineTracker.listRejected(), rejectedExactOwnerships,
 			)
 			stats.RecordFailed()
 			stats.Aborted = true
@@ -4840,7 +4937,6 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 		e.promoteSkipCacheWrites(eligibleCacheWrites)
 		cursor = page[len(page)-1].Cursor()
 	}
-
 	// Page writes committed cleanly when the paging loop finished without an
 	// error or a failed write; provider discovery failures are layered on
 	// below and must not suppress work that only depends on committed writes.
@@ -5007,14 +5103,41 @@ func (e *Engine) baselineReconciliationCandidates(
 }
 
 func eligibleReconciliationBaselines(
+	ctx context.Context,
 	candidates []reconciliationCandidate,
 	admitted []machineSessionSource,
 	eligibleProviders map[parser.AgentType]struct{},
-) ([]reconciliationCandidate, []machineSessionSource) {
+	spool reconciliationSpoolStore,
+) ([]reconciliationCandidate, []machineSessionSource, error) {
 	eligibleCandidates := make([]reconciliationCandidate, 0, len(candidates))
+	providersWithScopes := make(map[parser.AgentType]bool)
+	queriedProviders := make(map[parser.AgentType]struct{})
 	for _, candidate := range candidates {
 		if _, eligible := eligibleProviders[candidate.Provider]; !eligible {
 			continue
+		}
+		if spool != nil {
+			if _, queried := queriedProviders[candidate.Provider]; !queried {
+				hasScopes, err := spool.HasNonAuthoritativeScopes(ctx, candidate.Provider)
+				if err != nil {
+					return nil, nil, err
+				}
+				providersWithScopes[candidate.Provider] = hasScopes
+				queriedProviders[candidate.Provider] = struct{}{}
+			}
+			if providersWithScopes[candidate.Provider] {
+				physicalPath := validatedProviderSourceStatPath(candidate.Path)
+				canonicalPath := canonicalReconciliationSourceIdentity(physicalPath)
+				withheld, err := spool.ContainsNonAuthoritativeScope(
+					ctx, candidate.Provider, canonicalPath,
+				)
+				if err != nil {
+					return nil, nil, err
+				}
+				if withheld {
+					continue
+				}
+			}
 		}
 		eligibleCandidates = append(eligibleCandidates, candidate)
 	}
@@ -5024,7 +5147,7 @@ func eligibleReconciliationBaselines(
 			eligibleAdmitted = append(eligibleAdmitted, source)
 		}
 	}
-	return eligibleCandidates, eligibleAdmitted
+	return eligibleCandidates, eligibleAdmitted, nil
 }
 
 func (e *Engine) replaceActiveSessionSourceBaselinesByMachine(
@@ -5731,6 +5854,20 @@ func reconciliationProofCoversContainerMembership(
 	return false
 }
 
+func reconciliationOwnershipWithinNonAuthoritativeContainer(
+	ctx context.Context,
+	spool reconciliationSpoolStore,
+	agent parser.AgentType,
+	ownership db.SessionSourceOwnership,
+) (bool, error) {
+	if spool == nil {
+		return false, nil
+	}
+	physicalPath := validatedProviderSourceStatPath(ownership.FilePath)
+	canonicalPath := canonicalReconciliationSourceIdentity(physicalPath)
+	return spool.ContainsNonAuthoritativeScope(ctx, agent, canonicalPath)
+}
+
 // aggregateOwnedMemberGone reports whether an ownership row whose stored
 // FilePath is a still-present multi-member container has lost its member.
 // Container discovery records the container path itself for every member,
@@ -5909,6 +6046,15 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 		var provider parser.Provider
 		var replacementIndex reconciliationSpoolStore
 		ownsReplacementIndex := false
+		hasNonAuthoritativeScopes := false
+		if spool != nil {
+			hasNonAuthoritativeScopes, err = spool.HasNonAuthoritativeScopes(ctx, agent)
+			if err != nil {
+				return deleted, fmt.Errorf(
+					"query %s non-authoritative reconciliation scopes: %w", agent, err,
+				)
+			}
+		}
 		allProviderRootsCovered := reconciliationCoverageComplete(agentScopes)
 		if factory := e.providerFactories[agent]; factory != nil {
 			provider = factory.NewProvider(parser.ProviderConfig{
@@ -5962,6 +6108,20 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 					}
 					missingByPath := make(map[string]bool, len(page))
 					for _, ownership := range page {
+						if hasNonAuthoritativeScopes {
+							withheld, err := reconciliationOwnershipWithinNonAuthoritativeContainer(
+								ctx, spool, agent, ownership,
+							)
+							if err != nil {
+								return deleted, fmt.Errorf(
+									"query %s non-authoritative source %q: %w",
+									agent, ownership.FilePath, err,
+								)
+							}
+							if withheld {
+								continue
+							}
+						}
 						if !db.StoredSourcePathHintScopesContain(
 							ownership.FilePath, ownershipScopes,
 						) {
@@ -8684,6 +8844,8 @@ func (e *Engine) collectAndBatchWithOptions(
 		if tracker := reconciliationBaselineTrackerFor(ctx); tracker != nil {
 			if admitted {
 				tracker.add(source)
+			} else {
+				tracker.reject(source)
 			}
 			return
 		}
@@ -8942,6 +9104,11 @@ func (e *Engine) collectAndBatchWithOptions(
 			if cwdChanged && e.deferredSourceCwd == nil {
 				stats.RecordCwdUpdated(1)
 			}
+			if r.suppressPresenceSweep {
+				if tracker := reconciliationBaselineTrackerFor(ctx); tracker != nil {
+					tracker.addNonAuthoritativeScope(r.agent, r.path)
+				}
+			}
 			rowlessCached := e.cacheClaudeRowlessFreshness(ctx, r)
 			if !rowlessCached && r.cacheSkip && r.mtime != 0 &&
 				!r.noCacheSkip {
@@ -8949,7 +9116,7 @@ func (e *Engine) collectAndBatchWithOptions(
 			}
 			stats.RecordSkip()
 			e.noteSQLiteContainerResult(r.path, true)
-			if r.providerFailureCount == 0 {
+			if r.providerFailureCount == 0 && !r.suppressPresenceSweep {
 				admitted, exactOwnerships, err :=
 					e.skippedSourceAllowsCwdFilter(ctx, r)
 				if err != nil {
@@ -9344,14 +9511,17 @@ func (e *Engine) baselinePendingWriteSources(
 	tracker := reconciliationBaselineTrackerFor(ctx)
 	for source, ok := range eligible {
 		candidates = append(candidates, source)
-		if !ok {
-			continue
-		}
 		if tracker != nil {
-			tracker.add(source)
+			if ok {
+				tracker.add(source)
+			} else {
+				tracker.reject(source)
+			}
 			continue
 		}
-		admitted = append(admitted, source)
+		if ok {
+			admitted = append(admitted, source)
+		}
 	}
 	if tracker != nil || len(candidates) == 0 {
 		return nil
@@ -9613,8 +9783,8 @@ type processResult struct {
 	// retrySessionIDs carries provider per-result data-version state.
 	// Legacy parsers use needsRetry as a source-wide fallback.
 	retrySessionIDs map[string]bool
-	// suppressPresenceSweep marks an incomplete source result where
-	// missing stored sessions are expected rather than parser drift.
+	// suppressPresenceSweep marks a source result that must not authorize
+	// presence or tombstone reconciliation, including clean unsupported skips.
 	suppressPresenceSweep bool
 	// providerFailureCount carries non-fatal partial outcome failures through
 	// valid partial writes. Reconciliation may persist the valid results, but
@@ -10410,12 +10580,14 @@ func (e *Engine) processProviderFile(
 			omnigentContainerExists :=
 				parser.IsOmnigentContainerSource(source) &&
 					parser.IsRegularFile(providerDiscoveredPath(source))
+			traeContainerExists := file.Agent == parser.AgentTrae &&
+				parser.IsRegularFile(providerDiscoveredPath(source))
 			if e.pathRewriter != nil ||
 				(providerVirtualSourceContainerExists(file.Path) ||
-					omnigentContainerExists) {
+					omnigentContainerExists || traeContainerExists) {
 				// The provider re-resolved this exact virtual member against a
 				// still-present shared container, or authoritatively parsed an
-				// empty omnigent container. The member was removed from the
+				// empty Omnigent or Trae container. The member was removed from the
 				// container, not the container from disk. Carry the stored
 				// ownership to the revivable tombstone seam.
 				missingMembers = owned
@@ -10426,15 +10598,16 @@ func (e *Engine) processProviderFile(
 			}
 		}
 		skipRes := processResult{
-			skip:                     !outcome.ForceReplace,
-			excludedSessionIDs:       excludedSessionIDs,
-			sourceMissingMembers:     missingMembers,
-			mtime:                    fingerprint.MTimeNS,
-			cacheSkip:                cacheSkip,
-			cacheKey:                 cacheKey,
-			noCacheSkip:              !cleanCache,
-			forceReplace:             outcome.ForceReplace,
-			suppressPresenceSweep:    !outcome.ResultSetComplete,
+			skip:                 !outcome.ForceReplace,
+			excludedSessionIDs:   excludedSessionIDs,
+			sourceMissingMembers: missingMembers,
+			mtime:                fingerprint.MTimeNS,
+			cacheSkip:            cacheSkip,
+			cacheKey:             cacheKey,
+			noCacheSkip:          !cleanCache,
+			forceReplace:         outcome.ForceReplace,
+			suppressPresenceSweep: outcome.SkipReason == parser.SkipUnsupportedSource ||
+				!outcome.ResultSetComplete,
 			providerFailureCount:     providerFailureCount,
 			providerWideFailureCount: providerWideFailureCount,
 		}
@@ -10456,7 +10629,11 @@ func (e *Engine) processProviderFile(
 	parsedCount := len(parsedResults)
 	excludedSessionIDs := append([]string(nil), outcome.ExcludedSessionIDs...)
 	var missingMembers []sourceMissingMember
-	if file.Agent == parser.AgentOmnigent && outcome.ForceReplace &&
+	// Parse-diff intentionally reports a removed Trae member through its
+	// presence sweep. It never filters unchanged results or writes tombstones,
+	// so ownership reconciliation is needed only by real sync engines.
+	if ((file.Agent == parser.AgentOmnigent && outcome.ForceReplace) ||
+		(file.Agent == parser.AgentTrae && !e.forceParse)) &&
 		outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 {
 		missingMembers, err =
 			e.providerSourceMissingSessionOwnershipsForCompleteResult(
@@ -10493,15 +10670,16 @@ func (e *Engine) processProviderFile(
 		file, parsedResults, providerSemantics.UnchangedResults,
 	)
 	res := processResult{
-		results:                  filteredResults,
-		excludedSessionIDs:       excludedSessionIDs,
-		sourceMissingMembers:     missingMembers,
-		mtime:                    fingerprint.MTimeNS,
-		cacheSkip:                cacheSkip,
-		cacheKey:                 cacheKey,
-		noCacheSkip:              !cleanCache,
-		forceReplace:             outcome.ForceReplace || incForceReplace,
-		suppressPresenceSweep:    !outcome.ResultSetComplete,
+		results:              filteredResults,
+		excludedSessionIDs:   excludedSessionIDs,
+		sourceMissingMembers: missingMembers,
+		mtime:                fingerprint.MTimeNS,
+		cacheSkip:            cacheSkip,
+		cacheKey:             cacheKey,
+		noCacheSkip:          !cleanCache,
+		forceReplace:         outcome.ForceReplace || incForceReplace,
+		suppressPresenceSweep: outcome.SkipReason == parser.SkipUnsupportedSource ||
+			!outcome.ResultSetComplete,
 		providerFailureCount:     providerFailureCount,
 		providerWideFailureCount: providerWideFailureCount,
 		retentionLease:           lease,

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1419,6 +1419,7 @@ func TestCollectAndBatchBaselinesHealthySourceBesideFailedSource(t *testing.T) {
 type manyStreamingProvider struct {
 	parser.ProviderBase
 	sources       []parser.SourceRef
+	parseOutcome  *parser.ParseOutcome
 	discoverCalls atomic.Int32
 	streamCalls   atomic.Int32
 }
@@ -1464,9 +1465,12 @@ func (*manyStreamingProvider) WatchPlan(context.Context) (parser.WatchPlan, erro
 	return parser.WatchPlan{}, nil
 }
 
-func (*manyStreamingProvider) Parse(
+func (provider *manyStreamingProvider) Parse(
 	_ context.Context, req parser.ParseRequest,
 ) (parser.ParseOutcome, error) {
+	if provider.parseOutcome != nil {
+		return *provider.parseOutcome, nil
+	}
 	path := req.Source.DisplayPath
 	id := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	started := time.Unix(1704067200, 0)
@@ -1480,6 +1484,56 @@ func (*manyStreamingProvider) Parse(
 		}},
 		ResultSetComplete: true,
 	}, nil
+}
+
+func TestReconcileUnsupportedSourceMarkersStayPageBounded(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	const agent parser.AgentType = "unsupported-streaming"
+	const sourceCount = reconciliationPageSize*2 + 17
+	sources := make([]parser.SourceRef, sourceCount)
+	for i := range sources {
+		path := filepath.Join(root, fmt.Sprintf("container-%03d", i), "state.vscdb")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("unsupported"), 0o600))
+		sources[i] = parser.SourceRef{
+			Provider: agent,
+			Key:      path, DisplayPath: path, FingerprintKey: path,
+		}
+	}
+	unsupported := parser.ParseOutcome{
+		SkipReason: parser.SkipUnsupportedSource, ResultSetComplete: true,
+	}
+	provider := &manyStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+			}},
+		},
+		sources: sources, parseOutcome: &unsupported,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{agent: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			manyStreamingFactory{provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Complete)
+	assert.Equal(t, reconciliationPageSize, result.Metrics.MaxSpoolPageRows)
+	assert.Equal(t, reconciliationPageSize,
+		result.Metrics.MaxNonAuthoritativeScopeRows,
+		"unsupported source cardinality must not create pass-wide in-memory state")
 }
 
 func (*manyStreamingProvider) Fingerprint(

--- a/internal/sync/reconciliation_spool.go
+++ b/internal/sync/reconciliation_spool.go
@@ -47,16 +47,17 @@ type reconciliationCursor struct {
 // ReconciliationMetrics reports the largest bounded batches retained while a
 // watcher-forced reconciliation was running.
 type ReconciliationMetrics struct {
-	MaxSpoolPageRows         int
-	MaxProviderBuffered      int
-	MaxRehydratedSources     int
-	MaxWorkerResults         int
-	MaxPendingWrites         int
-	ExcludedRemoteRoots      int
-	GlobalLinkPasses         int
-	MaxProviderRetainedBytes int64
-	SharedContainerScans     int
-	OpenCodeSQLiteParses     int
+	MaxSpoolPageRows             int
+	MaxNonAuthoritativeScopeRows int
+	MaxProviderBuffered          int
+	MaxRehydratedSources         int
+	MaxWorkerResults             int
+	MaxPendingWrites             int
+	ExcludedRemoteRoots          int
+	GlobalLinkPasses             int
+	MaxProviderRetainedBytes     int64
+	SharedContainerScans         int
+	OpenCodeSQLiteParses         int
 	// CodexReplacementIndexBuilds counts uuid-to-path replacement index
 	// builds during missing-path tombstoning. A streamed pass answers
 	// replacement lookups from its discovery spool, so this stays zero;
@@ -77,12 +78,20 @@ type reconciliationSpool struct {
 
 type reconciliationSpoolStore interface {
 	Add(context.Context, reconciliationCandidate) error
+	AddNonAuthoritativeScopes(context.Context, []reconciliationSourceScope) error
 	Candidate(context.Context, parser.AgentType, string) (reconciliationCandidate, bool, error)
 	ContainsSource(context.Context, parser.AgentType, string) (bool, error)
 	ContainsSourceIdentity(context.Context, parser.AgentType, string, string) (bool, error)
+	HasNonAuthoritativeScopes(context.Context, parser.AgentType) (bool, error)
+	ContainsNonAuthoritativeScope(context.Context, parser.AgentType, string) (bool, error)
 	Page(context.Context, reconciliationCursor, int) ([]reconciliationCandidate, error)
 	Metrics() ReconciliationMetrics
 	CloseAndRemove() error
+}
+
+type reconciliationSourceScope struct {
+	Provider parser.AgentType
+	Path     string
 }
 
 func (spool *reconciliationSpool) Candidate(
@@ -247,12 +256,113 @@ func (spool *reconciliationSpool) initialize() error {
 		) WITHOUT ROWID;
 		CREATE INDEX candidates_by_stored_path
 			ON candidates(provider, stored_path, member_identity);
+		CREATE TABLE non_authoritative_scopes (
+			provider TEXT NOT NULL,
+			path TEXT NOT NULL,
+			PRIMARY KEY (provider, path)
+		) WITHOUT ROWID;
 		BEGIN IMMEDIATE;
 	`)
 	if err != nil {
 		return fmt.Errorf("initialize reconciliation spool: %w", err)
 	}
 	return nil
+}
+
+func (spool *reconciliationSpool) AddNonAuthoritativeScopes(
+	ctx context.Context, scopes []reconciliationSourceScope,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(scopes) == 0 {
+		return nil
+	}
+	if err := spool.seal(ctx); err != nil {
+		return err
+	}
+	tx, err := spool.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin non-authoritative reconciliation scope batch: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, scope := range scopes {
+		if scope.Provider == "" || scope.Path == "" {
+			continue
+		}
+		path := canonicalReconciliationSourceIdentity(
+			validatedProviderSourceStatPath(scope.Path),
+		)
+		if path == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO non_authoritative_scopes(provider, path)
+			VALUES (?, ?)
+		`, string(scope.Provider), path); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return fmt.Errorf("write non-authoritative reconciliation scope: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("commit non-authoritative reconciliation scopes: %w", err)
+	}
+	spool.mu.Lock()
+	spool.metrics.MaxNonAuthoritativeScopeRows = max(
+		spool.metrics.MaxNonAuthoritativeScopeRows, len(scopes),
+	)
+	spool.mu.Unlock()
+	return nil
+}
+
+func (spool *reconciliationSpool) HasNonAuthoritativeScopes(
+	ctx context.Context, provider parser.AgentType,
+) (bool, error) {
+	return spool.queryNonAuthoritativeScope(ctx, provider, "", false)
+}
+
+func (spool *reconciliationSpool) ContainsNonAuthoritativeScope(
+	ctx context.Context, provider parser.AgentType, path string,
+) (bool, error) {
+	path = canonicalReconciliationSourceIdentity(validatedProviderSourceStatPath(path))
+	return spool.queryNonAuthoritativeScope(ctx, provider, path, true)
+}
+
+func (spool *reconciliationSpool) queryNonAuthoritativeScope(
+	ctx context.Context, provider parser.AgentType, path string, exact bool,
+) (bool, error) {
+	if err := spool.seal(ctx); err != nil {
+		return false, err
+	}
+	query := `
+		SELECT 1 FROM non_authoritative_scopes
+		WHERE provider = ? LIMIT 1
+	`
+	args := []any{string(provider)}
+	if exact {
+		query = `
+			SELECT 1 FROM non_authoritative_scopes
+			WHERE provider = ? AND path = ? LIMIT 1
+		`
+		args = append(args, path)
+	}
+	var found int
+	err := spool.db.QueryRowContext(ctx, query, args...).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		return false, fmt.Errorf("query non-authoritative reconciliation scope: %w", err)
+	}
+	return true, nil
 }
 
 func (spool *reconciliationSpool) Add(

--- a/internal/sync/reconciliation_spool_test.go
+++ b/internal/sync/reconciliation_spool_test.go
@@ -139,6 +139,51 @@ func TestReconciliationSpoolPagesStayBoundedAndCleanup(t *testing.T) {
 	}
 }
 
+func TestReconciliationSpoolNonAuthoritativeScopesStayPageBounded(t *testing.T) {
+	spool, err := newReconciliationSpool(filepath.Join(t.TempDir(), "sessions.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, spool.CloseAndRemove()) })
+
+	ctx := t.Context()
+	require.NoError(t, spool.Add(ctx, reconciliationCandidate{
+		Provider: parser.AgentTrae,
+		Identity: "candidate",
+		Path:     "/trae/candidate/state.vscdb",
+	}))
+	_, err = spool.Page(ctx, reconciliationCursor{}, reconciliationPageSize)
+	require.NoError(t, err, "candidate paging must seal the discovery transaction")
+
+	const scopeCount = reconciliationPageSize*3 + 17
+	for start := 0; start < scopeCount; start += reconciliationPageSize {
+		end := min(start+reconciliationPageSize, scopeCount)
+		scopes := make([]reconciliationSourceScope, 0, end-start)
+		for i := start; i < end; i++ {
+			scopes = append(scopes, reconciliationSourceScope{
+				Provider: parser.AgentTrae,
+				Path:     filepath.Join("/trae", assertSessionIdentity(i), "state.vscdb"),
+			})
+		}
+		require.NoError(t, spool.AddNonAuthoritativeScopes(ctx, scopes))
+	}
+
+	for _, i := range []int{0, reconciliationPageSize, scopeCount - 1} {
+		present, queryErr := spool.ContainsNonAuthoritativeScope(
+			ctx, parser.AgentTrae,
+			filepath.Join("/trae", assertSessionIdentity(i), "state.vscdb"),
+		)
+		require.NoError(t, queryErr)
+		assert.True(t, present, "scope %d must remain queryable from disk", i)
+	}
+	present, err := spool.ContainsNonAuthoritativeScope(
+		ctx, parser.AgentTrae, filepath.Join("/trae", "absent", "state.vscdb"),
+	)
+	require.NoError(t, err)
+	assert.False(t, present)
+	assert.Equal(t, reconciliationPageSize,
+		spool.Metrics().MaxNonAuthoritativeScopeRows,
+		"disk-backed cardinality may grow, but one retained write batch must stay page-bounded")
+}
+
 func TestReconciliationSpoolCancellationAndClosedErrors(t *testing.T) {
 	spool, err := newReconciliationSpool(filepath.Join(t.TempDir(), "sessions.db"))
 	require.NoError(t, err)

--- a/internal/sync/trae_integration_test.go
+++ b/internal/sync/trae_integration_test.go
@@ -157,6 +157,9 @@ func TestTraeEncryptedLayoutReportsUnsupportedSource(t *testing.T) {
 			require.NoError(t, res.err)
 			assert.True(t, res.skip)
 			assert.False(t, res.forceReplace)
+			assert.True(t, res.suppressPresenceSweep)
+			assert.Zero(t, res.providerFailureCount)
+			assert.Zero(t, res.providerWideFailureCount)
 			assert.Empty(t, res.results)
 
 			var stats SyncStats
@@ -165,6 +168,217 @@ func TestTraeEncryptedLayoutReportsUnsupportedSource(t *testing.T) {
 			assert.Equal(t, 1, stats.Anomalies.UnsupportedSourceLayoutsByAgent[string(parser.AgentTrae)])
 		})
 	}
+}
+
+func TestReconcileTraeUnsupportedSiblingPreservesArchiveAuthority(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Trae", "User")
+	globalPath := filepath.Join(root, "globalStorage", "state.vscdb")
+	unsupportedPath := filepath.Join(root, "workspaceStorage", "unsupported", "state.vscdb")
+	writeTraeSyncDB(t, globalPath, "supported reply")
+	writeTraeSyncDB(t, unsupportedPath, "unsupported reply")
+	workspaceInfo, err := os.Stat(unsupportedPath)
+	require.NoError(t, err)
+	setTraeSyncDBSessions(t, unsupportedPath, []any{
+		traeSyncSession("unsupported", "unsupported reply"),
+	}, workspaceInfo.ModTime())
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	t.Cleanup(engine.Close)
+
+	initial := engine.SyncAll(t.Context(), nil)
+	assert.Equal(t, 2, initial.Synced, "both siblings must be discovered and synced")
+	assert.Zero(t, initial.Failed)
+	supported, err := database.GetSession(t.Context(), "trae:rewrite")
+	require.NoError(t, err)
+	assert.NotNil(t, supported, "supported sibling must be seeded")
+	unsupported, err := database.GetSession(t.Context(), "trae:unsupported")
+	require.NoError(t, err)
+	assert.NotNil(t, unsupported, "unsupported sibling must be seeded")
+
+	require.NoError(t, os.Remove(unsupportedPath))
+	writeTraeSyncDBWithoutStorageKey(t, unsupportedPath)
+	writeTraeSyncModularData(t, root)
+
+	stats, _, err := engine.ReconcileWatchRootsWithStats(
+		t.Context(), nil, true, nil,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, stats.Failed)
+	assert.Zero(t, engine.LastReconciliationResult().ProviderFailures)
+	assert.Equal(t, 1, stats.Anomalies.UnsupportedSourceLayoutsTotal)
+	unsupported, err = database.GetSession(t.Context(), "trae:unsupported")
+	require.NoError(t, err)
+	assert.NotNil(t, unsupported, "unsupported container member must remain active")
+
+	globalInfo, err := os.Stat(globalPath)
+	require.NoError(t, err)
+	setTraeSyncDBSessions(t, globalPath, []any{}, globalInfo.ModTime().Add(time.Second))
+
+	stats, _, err = engine.ReconcileWatchRootsWithStats(
+		t.Context(), nil, true, nil,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, stats.Failed)
+	assert.Zero(t, engine.LastReconciliationResult().ProviderFailures)
+
+	supported, err = database.GetSession(t.Context(), "trae:rewrite")
+	require.NoError(t, err)
+	assert.Nil(t, supported, "supported sibling removal must tombstone")
+	unsupported, err = database.GetSession(t.Context(), "trae:unsupported")
+	require.NoError(t, err)
+	assert.NotNil(t, unsupported, "unsupported container member must remain active")
+}
+
+func TestReconcileTraeUnsupportedContainerRemovalPreservesArchive(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Trae", "User")
+	globalPath := filepath.Join(root, "globalStorage", "state.vscdb")
+	unsupportedPath := filepath.Join(root, "workspaceStorage", "unsupported", "state.vscdb")
+	writeTraeSyncDB(t, globalPath, "supported reply")
+	writeTraeSyncDB(t, unsupportedPath, "unsupported reply")
+	workspaceInfo, err := os.Stat(unsupportedPath)
+	require.NoError(t, err)
+	setTraeSyncDBSessions(t, unsupportedPath, []any{
+		traeSyncSession("unsupported", "unsupported reply"),
+	}, workspaceInfo.ModTime())
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	t.Cleanup(engine.Close)
+
+	initial := engine.SyncAll(t.Context(), nil)
+	assert.Equal(t, 2, initial.Synced)
+	assert.Zero(t, initial.Failed)
+	seeded, err := database.GetSession(t.Context(), "trae:unsupported")
+	require.NoError(t, err)
+	assert.NotNil(t, seeded)
+
+	require.NoError(t, os.Remove(unsupportedPath))
+	stats, _, err := engine.ReconcileWatchRootsWithStats(
+		t.Context(), nil, true, nil,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, stats.Failed)
+	assert.Zero(t, engine.LastReconciliationResult().ProviderFailures)
+
+	preserved, err := database.GetSession(t.Context(), "trae:unsupported")
+	require.NoError(t, err)
+	assert.NotNil(t, preserved, "vanished unsupported container must preserve its archive member")
+}
+
+func TestWatchBatchTraeMissingContainerPreservesArchive(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Trae", "User")
+	path := filepath.Join(root, "globalStorage", "state.vscdb")
+	writeTraeSyncDB(t, path, "archived reply")
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	t.Cleanup(engine.Close)
+
+	initial := engine.SyncAll(t.Context(), nil)
+	require.Equal(t, 1, initial.Synced)
+	require.Zero(t, initial.Failed)
+	require.NoError(t, os.Remove(path))
+
+	err := ApplyWatchBatch(t.Context(), engine, WatchBatch{
+		Paths: []string{path, path + "-wal"},
+	}, nil)
+	require.NoError(t, err)
+	assert.Zero(t, engine.LastSyncStats().Failed)
+
+	active, err := database.GetSession(t.Context(), "trae:rewrite")
+	require.NoError(t, err)
+	assert.NotNil(t, active,
+		"a vanished persistent container cannot prove member deletion")
+	archived, err := database.GetSessionFull(t.Context(), "trae:rewrite")
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	assert.Nil(t, archived.DeletionCause)
+}
+
+func TestReconcileTraeCompleteContainerTombstonesRemovedMember(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Trae", "User")
+	path := filepath.Join(root, "globalStorage", "state.vscdb")
+	writeTraeSyncDB(t, path, "first reply")
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	setTraeSyncDBSessions(t, path, []any{
+		traeSyncSession("removed", "first reply"),
+		traeSyncSession("kept", "second reply"),
+	}, info.ModTime())
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	t.Cleanup(engine.Close)
+
+	initial := engine.SyncAll(t.Context(), nil)
+	assert.Equal(t, 2, initial.Synced)
+	assert.Zero(t, initial.Failed)
+
+	info, err = os.Stat(path)
+	require.NoError(t, err)
+	setTraeSyncDBSessions(t, path, []any{
+		traeSyncSession("kept", "second reply"),
+	}, info.ModTime().Add(time.Second))
+	stats, _, err := engine.ReconcileWatchRootsWithStats(
+		t.Context(), nil, true, nil,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, stats.Failed)
+
+	kept, err := database.GetSession(t.Context(), "trae:kept")
+	require.NoError(t, err)
+	assert.NotNil(t, kept, "remaining container member must stay active")
+	removed, err := database.GetSession(t.Context(), "trae:removed")
+	require.NoError(t, err)
+	assert.Nil(t, removed, "removed container member must not stay active")
+	archived, err := database.GetSessionFull(t.Context(), "trae:removed")
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+}
+
+func TestReconcileTraeEmptyContainerTombstonesLastMember(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Trae", "User")
+	path := filepath.Join(root, "globalStorage", "state.vscdb")
+	writeTraeSyncDB(t, path, "last reply")
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	t.Cleanup(engine.Close)
+
+	initial := engine.SyncAll(t.Context(), nil)
+	assert.Equal(t, 1, initial.Synced)
+	assert.Zero(t, initial.Failed)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	setTraeSyncDBSessions(t, path, []any{}, info.ModTime().Add(time.Second))
+	stats, _, err := engine.ReconcileWatchRootsWithStats(
+		t.Context(), nil, true, nil,
+	)
+	require.NoError(t, err)
+	assert.Zero(t, stats.Failed)
+
+	active, err := database.GetSession(t.Context(), "trae:rewrite")
+	require.NoError(t, err)
+	assert.Nil(t, active, "last removed member must not stay active")
+	archived, err := database.GetSessionFull(t.Context(), "trae:rewrite")
+	require.NoError(t, err)
+	require.NotNil(t, archived, "last removed member must remain archived")
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
 }
 
 func TestProcessFileProviderTraeSameSizeSameMtimeRewriteReparses(t *testing.T) {


### PR DESCRIPTION
Trae's encrypted layouts can leave `state.vscdb` with an empty or absent session index, so AgentsView repeatedly retries an unreadable source. This treats known-unsupported layouts as clean skips with no failure or presence authority, preserving archived members while supported legacy sessions, valid empty stores, malformed layouts, and anomaly reporting keep their current behavior.

The measured layout comes from @Helix-lyh's issue report and the captured international Trae corpus.

Closes #1416
