### PR TITLE
chore: remove dead code and unused frontend exports

### DIFF
--- a/frontend/e2e/helpers/virtual-list-helpers.ts
+++ b/frontend/e2e/helpers/virtual-list-helpers.ts
@@ -13,7 +13,7 @@ export function getScrollTop(locator: Locator): Promise<number> {
 }
 
 /** Returns the current scrollHeight of a scrollable container. */
-export function getScrollHeight(locator: Locator): Promise<number> {
+function getScrollHeight(locator: Locator): Promise<number> {
   return locator.evaluate((el) => el.scrollHeight);
 }
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -319,7 +319,7 @@ export function getExportUrl(sessionId: string): string {
   return `${getBase()}/sessions/${encodeURIComponent(sessionId)}/export`;
 }
 
-export function getInsightExportUrl(insightId: number): string {
+function getInsightExportUrl(insightId: number): string {
   return `${getBase()}/insights/${insightId}/export`;
 }
 

--- a/frontend/src/lib/api/runtime.ts
+++ b/frontend/src/lib/api/runtime.ts
@@ -82,7 +82,7 @@ export class ApiError extends Error {
   }
 }
 
-export function apiErrorMessage(status: number, body: string): string {
+function apiErrorMessage(status: number, body: string): string {
   const text = body.trim();
   if (!text) return `API ${status}`;
 
@@ -131,7 +131,7 @@ export function generatedErrorMessage(err: GeneratedApiError): string {
   return err.message || `API ${err.status}`;
 }
 
-export function generatedErrorCode(err: GeneratedApiError): string | undefined {
+function generatedErrorCode(err: GeneratedApiError): string | undefined {
   if (
     err.body !== null &&
     typeof err.body === "object" &&
@@ -167,7 +167,7 @@ export interface CancelableLike<T> extends Promise<T> {
   cancel: () => void;
 }
 
-export function isCancelable<T>(value: Promise<T>): value is CancelableLike<T> {
+function isCancelable<T>(value: Promise<T>): value is CancelableLike<T> {
   return typeof (value as { cancel?: unknown }).cancel === "function";
 }
 

--- a/frontend/src/lib/branchFilters.ts
+++ b/frontend/src/lib/branchFilters.ts
@@ -1,6 +1,5 @@
 // Keep these in sync with internal/db branch token separators.
 export const BRANCH_TOKEN_SEP = "\u001f";
-export const BRANCH_LIST_SEP = "\u001e";
 
 export function branchFilterToken(project: string, branch: string): string {
   return project + BRANCH_TOKEN_SEP + branch;

--- a/frontend/src/lib/branchFilters.ts
+++ b/frontend/src/lib/branchFilters.ts
@@ -1,11 +1,11 @@
 // Keep these in sync with internal/db branch token separators.
-export const BRANCH_TOKEN_SEP = "\u001f";
+const BRANCH_TOKEN_SEP = "\u001f";
 
 export function branchFilterToken(project: string, branch: string): string {
   return project + BRANCH_TOKEN_SEP + branch;
 }
 
-export function splitBranchFilterToken(token: string): {
+function splitBranchFilterToken(token: string): {
   project: string;
   branch: string;
 } {

--- a/frontend/src/lib/components/quality/QualityPage.integration.test.ts
+++ b/frontend/src/lib/components/quality/QualityPage.integration.test.ts
@@ -159,22 +159,6 @@ async function flushEffects() {
   await tick();
 }
 
-async function selectRelativeRange(days: number) {
-  const trigger = document.querySelector<HTMLButtonElement>(
-    ".kit-date-range-picker__trigger",
-  );
-  expect(trigger).not.toBeNull();
-  trigger!.click();
-  await flushEffects();
-
-  const preset = [
-    ...document.querySelectorAll<HTMLButtonElement>("button"),
-  ].find((button) => button.textContent?.trim() === `${days}d`);
-  expect(preset).not.toBeUndefined();
-  preset!.click();
-  await flushEffects();
-}
-
 async function selectCustomRange(fromLabel: string, toLabel: string) {
   const trigger = document.querySelector<HTMLButtonElement>(
     ".kit-date-range-picker__trigger",

--- a/frontend/src/lib/components/shared/dateRangeSelector.ts
+++ b/frontend/src/lib/components/shared/dateRangeSelector.ts
@@ -14,7 +14,7 @@ export interface DateRangePreset {
   days: number;
 }
 
-export const DATE_RANGE_PRESETS: DateRangePreset[] = [
+const DATE_RANGE_PRESETS: DateRangePreset[] = [
   { label: "7d", days: 7 },
   { label: "30d", days: 30 },
   { label: "90d", days: 90 },

--- a/frontend/src/lib/components/shared/rangeSelection.ts
+++ b/frontend/src/lib/components/shared/rangeSelection.ts
@@ -183,5 +183,4 @@ export function selectionFromRange(
   return { mode: "custom", from, to };
 }
 
-export { allFromDate, daysAgo, localDateStr, todayStr };
 export type { DateRange };

--- a/frontend/src/lib/components/sidebar/session-list-utils.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.ts
@@ -4,8 +4,8 @@ import type {
 } from "../../stores/sessions.svelte.js";
 
 export const ITEM_HEIGHT = 42;
-export const CHILD_ITEM_HEIGHT = 34;
-export const TEAM_HEADER_HEIGHT = 28;
+const CHILD_ITEM_HEIGHT = 34;
+const TEAM_HEADER_HEIGHT = 28;
 export const HEADER_HEIGHT = 28;
 export const OVERSCAN = 10;
 export const STORAGE_KEY = "agentsview-group-by-agent";

--- a/frontend/src/lib/components/sidebar/session-list-utils.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.ts
@@ -116,14 +116,6 @@ export function buildGroupSections(
     .map(([label, groups]) => ({ label, groups }));
 }
 
-/** @deprecated Use buildGroupSections */
-export function buildAgentSections(
-  groups: SessionGroup[],
-  groupByAgent: boolean,
-): GroupSection[] {
-  return buildGroupSections(groups, groupByAgent ? "agent" : "none");
-}
-
 /** Check if a session is a teammate (received a <teammate-message>). */
 function isTeammateByMessage(s: SessionGroupInput): boolean {
   return s.is_teammate

--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -9,14 +9,6 @@ export function moneyFromMicrodollars(microdollars: number): Money {
   return { microdollars };
 }
 
-export function addMoney(left: Money, right: Money): Money {
-  return moneyFromMicrodollars(left.microdollars + right.microdollars);
-}
-
-export function subtractMoney(left: Money, right: Money): Money {
-  return moneyFromMicrodollars(left.microdollars - right.microdollars);
-}
-
 export function divideMoney(value: Money, divisor: number): Money {
   if (divisor === 0) return ZERO_MONEY;
   return moneyFromMicrodollars(Math.round(value.microdollars / divisor));

--- a/frontend/src/lib/stores/sessionRouteParams.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.ts
@@ -121,7 +121,7 @@ export function sessionRouteParamsForFilters(
   return next;
 }
 
-export function currentSessionRouteParams(
+function currentSessionRouteParams(
   currentParams: Record<string, string>,
 ): Record<string, string> {
   const next: Record<string, string> = {};

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1675,12 +1675,6 @@ setInterval(() => {
   now = Date.now();
 }, 30_000);
 
-export function isRecentlyActive(session: Session): boolean {
-  const key = recencyKey(session);
-  const ts = new Date(key).getTime();
-  return now - ts < RECENTLY_ACTIVE_MS;
-}
-
 export type SessionStatus =
   | "working"
   | "waiting"

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -125,7 +125,7 @@ export function agentColor(agent: string): string {
   return agentColorMap.get(agent) ?? defaultFillColor;
 }
 
-export function accentForeground(color: string): string {
+function accentForeground(color: string): string {
   return accentForegroundMap.get(color) ?? "var(--accent-blue-foreground)";
 }
 

--- a/frontend/src/lib/utils/csv-export.ts
+++ b/frontend/src/lib/utils/csv-export.ts
@@ -198,7 +198,7 @@ export function generateAnalyticsCSV(
     .join("\n\n");
 }
 
-export function downloadCSV(
+function downloadCSV(
   csv: string,
   filename: string,
 ): void {

--- a/frontend/src/lib/utils/messages.ts
+++ b/frontend/src/lib/utils/messages.ts
@@ -87,14 +87,6 @@ function isGoalContextMessage(trimmedContent: string): boolean {
   return GOAL_CONTEXT_SOURCE_ATTR_RE.test(openTag);
 }
 
-/**
- * Returns true when a message represents an explicit compact
- * boundary inserted by the agent runtime.
- */
-export function isCompactBoundary(m: Message): boolean {
-  return Boolean(m.is_compact_boundary);
-}
-
 export interface MessagePreview {
   /** Display text, with Claude Code shell-shortcut wrappers
    *  replaced: `<bash-input>cmd</bash-input>` becomes `!cmd`,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -51,19 +51,6 @@ function requestOriginMatchesLoopbackDevServer(
   }
 }
 
-function isViteDevOrigin(
-  origin: string | undefined,
-  host: string | undefined,
-): boolean {
-  if (!origin || !host) return false;
-  try {
-    const u = new URL(origin);
-    return u.protocol === "http:" && u.host === host;
-  } catch {
-    return false;
-  }
-}
-
 export default defineConfig({
   fmt: {},
   lint: {

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -722,17 +722,6 @@ func usageDedupTokenForRow(u UsageRow) (usageDedupToken, bool) {
 	return usageDedupToken{}, false
 }
 
-// ClaudeSnapshotSurvivorMask returns a same-length mask that keeps the most
-// complete output-token snapshot for each Claude request across the supplied
-// rows.
-// Claude Code can persist several assistant rows with the same message and
-// request IDs while a tool turn streams; the final row carries the full output
-// count. Equal snapshots retain their latest occurrence.
-func ClaudeSnapshotSurvivorMask(usage []UsageRow) []bool {
-	mask, _, _ := ClaudeSnapshotSurvivorSelection(usage)
-	return mask
-}
-
 // ClaudeSnapshotSurvivorSelection also returns the earliest session and the
 // maximum billed web-search count for each surviving snapshot. Callers use the
 // former for attribution and the latter when pricing the selected token row.
@@ -843,14 +832,6 @@ func LegacyUsageSurvivorMask(
 		}
 		mask[i] = true
 	}
-	return mask
-}
-
-// UsageSurvivorMask returns a same-length mask for rows that survive the
-// report's range, effective-end, complete-snapshot, and cross-session dedup
-// filters.
-func UsageSurvivorMask(start, end, effEnd time.Time, usage []UsageRow) []bool {
-	mask, _, _ := UsageSurvivorSelection(start, end, effEnd, usage)
 	return mask
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -924,22 +924,6 @@ func LoadPFlags(fs *pflag.FlagSet) (Config, error) {
 	return cfg, nil
 }
 
-// LoadPGServe builds a Config for `pg serve` by preserving
-// shared and PG settings from defaults/env/config file while
-// resetting serve-specific network/browser settings to defaults.
-// Only explicitly provided serve flags are applied on top.
-func LoadPGServe(fs *flag.FlagSet) (Config, error) {
-	cfg, err := loadPGServeBase()
-	if err != nil {
-		return cfg, err
-	}
-	applyFlags(&cfg, fs)
-	if err := finalize(&cfg); err != nil {
-		return cfg, err
-	}
-	return cfg, nil
-}
-
 // LoadPGServePFlags builds a PG serve config from a parsed Cobra/pflag FlagSet.
 func LoadPGServePFlags(fs *pflag.FlagSet) (Config, error) {
 	cfg, err := loadPGServeBase()
@@ -2757,11 +2741,6 @@ func IsEnvDependentURL(s string) bool {
 // bareEnvWarned tracks which bare $VAR names have already been warned
 // about, so each distinct variable triggers a warning at most once.
 var bareEnvWarned sync.Map
-
-// ResetBareEnvWarned clears the warning dedup state. Exported for tests.
-func ResetBareEnvWarned() {
-	bareEnvWarned.Range(func(k, _ any) bool { bareEnvWarned.Delete(k); return true })
-}
 
 // expandBracedEnv expands ${VAR} references in s. As a convenience,
 // if the entire string is a single bare $VAR (e.g. "$PGURL"), it is

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -5336,10 +5336,6 @@ func signalValue(r SignalRow, signal string) int {
 	return 0
 }
 
-func SignalValue(r SignalRow, signal string) int {
-	return signalValue(r, signal)
-}
-
 func isIncompleteOrLowQuality(r SignalRow) bool {
 	if r.Outcome == "errored" || r.Outcome == "abandoned" {
 		return true

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -297,18 +297,6 @@ type AutomationTextEvidence struct {
 	Valid          bool
 }
 
-// AutomationVerdictFromEvidence combines the first stored user message and
-// fallback first_message using the same ordering and single-turn rule as the
-// full-text classifier. An inconclusive result requires full-text fallback.
-func AutomationVerdictFromEvidence(
-	userMessageCount int,
-	firstUser, firstMessage AutomationTextEvidence,
-) (matched, conclusive bool) {
-	return SnapshotAutomationClassifier().VerdictFromEvidence(
-		userMessageCount, firstUser, firstMessage,
-	)
-}
-
 // VerdictFromEvidence classifies bounded evidence using this snapshot.
 func (classifier AutomationClassifier) VerdictFromEvidence(
 	userMessageCount int,

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -404,15 +404,6 @@ func (b *QueryBuilder) Limit(limit int) string {
 	return "LIMIT " + b.Add(limit)
 }
 
-// NullsLast returns an ORDER BY expression with dialect-appropriate NULL
-// placement when the backend supports it.
-func (d QueryDialect) NullsLast(expr string) string {
-	if d.nullsLast {
-		return expr + " NULLS LAST"
-	}
-	return expr
-}
-
 // EscapeLikePattern escapes SQL LIKE wildcard characters so a bind parameter
 // is treated as literal user text.
 func EscapeLikePattern(s string) string {
@@ -464,10 +455,6 @@ func (d QueryDialect) CanonicalChildRelationshipsSQL() string {
 		quoted = append(quoted, "'"+rel+"'")
 	}
 	return strings.Join(quoted, ", ")
-}
-
-func SidebarChildRelationshipPredicate(dialect QueryDialect, sessionAlias string) string {
-	return sessionAlias + ".relationship_type IN (" + dialect.SidebarChildRelationshipsSQL() + ")"
 }
 
 func CanonicalChildRelationshipPredicate(dialect QueryDialect, sessionAlias string) string {

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -269,11 +269,6 @@ func WithMessageCount(n int) func(*db.Session) {
 	return func(s *db.Session) { s.MessageCount = n }
 }
 
-// WithUserMessageCount sets the session's user message count.
-func WithUserMessageCount(n int) func(*db.Session) {
-	return func(s *db.Session) { s.UserMessageCount = n }
-}
-
 // WithMessageCounts sets the session's total and user message counts.
 func WithMessageCounts(total, user int) func(*db.Session) {
 	return func(s *db.Session) {

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -727,19 +727,6 @@ func BuildProjectsMapWithScope(
 	return out
 }
 
-func PublicProjectIdentityFromStored(stored StoredProjectIdentity) (ProjectIdentity, bool) {
-	if stored.KeySource != ProjectIdentityKeySourceGitRemote || stored.NormalizedRemote == "" {
-		return ProjectIdentity{}, false
-	}
-	repositoryKey := scopedProjectKey("repo1", "agentsview/repository/git/v1", stored.NormalizedRemote)
-	return ProjectIdentity{
-		Key:              scopedProjectKey("p1", "agentsview/project/git/v1", stored.NormalizedRemote),
-		Kind:             ProjectKindGitRemote,
-		NormalizedRemote: stored.NormalizedRemote,
-		RepositoryKey:    repositoryKey,
-	}, true
-}
-
 func projectIdentityKey(source, normalized string) string {
 	sum := sha256.Sum256([]byte(source + "\n" + normalized))
 	return "sha256:" + fmt.Sprintf("%x", sum)

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -83,25 +83,6 @@ type GenerateOptions struct {
 	Agents map[string]AgentConfig
 }
 
-// Generate invokes an AI agent CLI to generate an insight.
-// The agent parameter selects which CLI to use (claude,
-// codex, gemini). The prompt is passed via stdin.
-func Generate(
-	ctx context.Context, agent, prompt string,
-) (Result, error) {
-	return GenerateStream(ctx, agent, prompt, nil)
-}
-
-// GenerateStream invokes an AI agent CLI to generate an
-// insight while optionally streaming process logs.
-func GenerateStream(
-	ctx context.Context, agent, prompt string, onLog LogFunc,
-) (Result, error) {
-	return GenerateStreamWithOptions(
-		ctx, agent, prompt, onLog, GenerateOptions{},
-	)
-}
-
 // GenerateStreamWithOptions invokes an AI agent CLI to generate an
 // insight, using configured binary paths before falling back to PATH.
 func GenerateStreamWithOptions(

--- a/internal/parser/trae_provider.go
+++ b/internal/parser/trae_provider.go
@@ -626,7 +626,6 @@ func traeAssistantFallback(raw json.RawMessage) string {
 
 func traeVirtualPath(path, id string) string                  { return path + "#" + id }
 func SplitTraeVirtualPath(path string) (string, string, bool) { return splitTraeVirtualPath(path) }
-func TraeDBPathForEvent(root, path string) (string, bool)     { return traeDBPathForEvent(root, path) }
 func splitTraeVirtualPath(path string) (string, string, bool) {
 	return ParseVirtualSourcePathForBase(path, traeStateDBName)
 }

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -963,17 +963,6 @@ var Registry = []AgentDef{
 	},
 }
 
-// NonFileBackedAgents returns agent types where FileBased is false.
-func NonFileBackedAgents() []AgentType {
-	var agents []AgentType
-	for _, def := range Registry {
-		if !def.FileBased {
-			agents = append(agents, def.Type)
-		}
-	}
-	return agents
-}
-
 // AgentByType returns the AgentDef for the given type.
 func AgentByType(t AgentType) (AgentDef, bool) {
 	for _, def := range Registry {

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -133,30 +133,8 @@ func zcodeDBPath(dir string) string {
 	return path
 }
 
-func zcodeVirtualPathParts(path string) (string, string, bool) {
-	return ParseVirtualSourcePathForBase(path, zcodeDBName)
-}
-
 func ZCodeSQLiteVirtualPath(dbPath, sessionID string) string {
 	return VirtualSourcePath(dbPath, sessionID)
-}
-
-func ZCodeSQLiteSourceMtime(path string) (int64, error) {
-	dbPath, sessionID, ok := zcodeVirtualPathParts(path)
-	if !ok {
-		return 0, fmt.Errorf("not a zcode sqlite virtual path: %s", path)
-	}
-	db, err := openZCodeDB(dbPath)
-	if err != nil {
-		return 0, err
-	}
-	defer db.Close()
-
-	row, err := loadZCodeSessionRow(db, sessionID)
-	if err != nil {
-		return 0, err
-	}
-	return zcodeSessionFileMtime(dbPath, db, row), nil
 }
 
 func forEachZCodeSessionMeta(

--- a/internal/pricingrefresh/refresh.go
+++ b/internal/pricingrefresh/refresh.go
@@ -94,21 +94,6 @@ func SeedFallback(database *db.DB) error {
 	return database.SetPricingMeta(pricingStorageMetaKey, pricingStorageVersion)
 }
 
-// Refresh fetches and stores the upstream pricing catalog immediately.
-func Refresh(
-	database *db.DB,
-	fetch func() ([]pricing.ModelPricing, error),
-) error {
-	prices, err := fetch()
-	if err != nil {
-		return fmt.Errorf("litellm fetch failed: %w", err)
-	}
-	if err := upsert(database, prices); err != nil {
-		return fmt.Errorf("upsert failed: %w", err)
-	}
-	return nil
-}
-
 // RefreshIfStale refreshes when the last attempt is older than cooldown.
 func RefreshIfStale(
 	database *db.DB,

--- a/internal/recall/extract/prompts.go
+++ b/internal/recall/extract/prompts.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 )
 
@@ -268,15 +267,4 @@ func Fingerprint(
 	}
 	sum := sha256.Sum256(canonical)
 	return hex.EncodeToString(sum[:]), nil
-}
-
-// ProfileNames lists the built-in profiles for error messages and doctor
-// output, sorted for stable display.
-func ProfileNames() []string {
-	names := make([]string, 0, len(builtinProfiles))
-	for _, profile := range builtinProfiles {
-		names = append(names, profile.Name)
-	}
-	sort.Strings(names)
-	return names
 }

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -16,21 +16,6 @@ type SSEStream struct {
 	f http.Flusher
 }
 
-// NewSSEStream initializes an SSE connection by setting the
-// required headers and flushing them to the client. Returns an
-// error if the ResponseWriter does not support streaming.
-func NewSSEStream(w http.ResponseWriter) (*SSEStream, error) {
-	f, ok := w.(http.Flusher)
-	if !ok {
-		return nil, fmt.Errorf("streaming not supported")
-	}
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	f.Flush()
-	return &SSEStream{w: w, f: f}, nil
-}
-
 // Send writes an SSE event with the given name and string data.
 // It returns false when the write fails.
 func (s *SSEStream) Send(event, data string) bool {

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -589,14 +589,6 @@ func parseResolvedDirs(
 	return dirs, extraFiles, err
 }
 
-// ParseResolvedTargetsForTest exposes SSH resolver output parsing to
-// internal/remotesync parity tests.
-func ParseResolvedTargetsForTest(
-	output string,
-) (map[parser.AgentType][]string, []string, error) {
-	return parseResolvedDirs(output)
-}
-
 // ParseResolvedTargetsWithFilesForTest exposes SSH resolver output parsing
 // to internal/remotesync parity tests, discarding forbidden roots that
 // those tests don't assert on.

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -90,18 +90,6 @@ func WithOpenCodeDirs(dirs []string) TestEnvOption {
 	}
 }
 
-func WithKiloDirs(dirs []string) TestEnvOption {
-	return func(o *testEnvOpts) {
-		o.kiloDirs = dirs
-	}
-}
-
-func WithKiroDirs(dirs []string) TestEnvOption {
-	return func(o *testEnvOpts) {
-		o.kiroDirs = dirs
-	}
-}
-
 func WithEmitter(em sync.Emitter) TestEnvOption {
 	return func(o *testEnvOpts) {
 		o.emitter = em

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -560,17 +560,6 @@ func (b *SessionBuilder) AddCodexMessage(
 	return b
 }
 
-// AddCodexFunctionCall appends a Codex function_call line.
-func (b *SessionBuilder) AddCodexFunctionCall(
-	timestamp, name, summary string,
-) *SessionBuilder {
-	b.lines = append(
-		b.lines,
-		CodexFunctionCallJSON(name, summary, timestamp),
-	)
-	return b
-}
-
 // AddRaw appends an arbitrary raw line.
 func (b *SessionBuilder) AddRaw(line string) *SessionBuilder {
 	b.lines = append(b.lines, line)
@@ -683,18 +672,6 @@ func GeminiAssistantMsg(
 		m["toolCalls"] = tcs
 	}
 	return m
-}
-
-// GeminiInfoMsg builds a Gemini info/system message object.
-func GeminiInfoMsg(
-	id, timestamp, content, msgType string,
-) map[string]any {
-	return map[string]any{
-		"id":        id,
-		"timestamp": timestamp,
-		"type":      msgType,
-		"content":   content,
-	}
 }
 
 // GeminiSessionJSON builds a complete Gemini session JSON


### PR DESCRIPTION
Whole-program analysis found internal APIs and test helpers that neither
production nor test binaries could reach. This removes those declarations and
narrows handwritten frontend exports to symbols with external consumers.

Generated API output and the C-to-Go FSEvents callback path remain unchanged.
Runtime behavior is preserved; the change reduces obsolete supported-looking
surface and makes future reachability reports more useful.
