### PR TITLE
fix(parser): use transcript identity for rooted uploads

### DIFF
--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -64,12 +64,9 @@ type claudeQueuedCommand struct {
 // and also returns session IDs intentionally excluded from the
 // archive, such as content-free /usage probes. Sync uses those IDs
 // during full resync so orphan preservation does not restore rows the
-// current parser deliberately dropped. This is the provider-owned
-// parse body shared by the Claude provider (both its discovered-session
-// Parse path and its ParseUploadedTranscript entry) and the Cowork
-// parser (which reuses the Claude transcript format); it carries no
-// legacy entrypoint naming so the provider can call it without shimming
-// a Parse* free function.
+// current parser deliberately dropped. This is the zero-option parse body
+// used by Claude discovered-session parsing and the Cowork/Qoder parsers;
+// upload parsing calls claudeParseFile with its upload option.
 func claudeParseWithExclusions(
 	path, project, machine string,
 ) ([]ParseResult, []string, error) {
@@ -119,6 +116,10 @@ func claudeParseFile(
 		entrypoint      string
 		sessionKind     string
 		foundParentSID  bool
+		uploadSessionID string
+		uploadRoot      bool
+		uploadSidechain bool
+		uploadEvidence  = true
 		lineIndex       int
 		uuidLineOrdinal int
 		malformedLines  int
@@ -129,7 +130,9 @@ func claudeParseFile(
 		globalEnd       time.Time
 	)
 	allHaveUUID = true
-	parentSessionID = claudeCompanionParentSessionID(path, sessionID)
+	if !opts.uploadIdentity {
+		parentSessionID = claudeCompanionParentSessionID(path, sessionID)
+	}
 	if lineage != nil {
 		parentSessionID = lineage.parentSessionID
 	}
@@ -260,6 +263,23 @@ func claudeParseFile(
 		if entryType != "user" && entryType != "assistant" {
 			continue
 		}
+		if opts.uploadIdentity {
+			sid := gjson.GetBytes(lineBytes, "sessionId").Str
+			if sid == "" || !isValidClaudeUploadIdentity(sid) ||
+				(uploadSessionID != "" && uploadSessionID != sid) {
+				uploadEvidence = false
+			} else if uploadSessionID == "" {
+				uploadSessionID = strings.Clone(sid)
+			}
+			marker := gjson.GetBytes(lineBytes, "isSidechain")
+			if marker.Type != gjson.True && marker.Type != gjson.False {
+				uploadEvidence = false
+			} else if marker.Bool() {
+				uploadSidechain = true
+			} else {
+				uploadRoot = true
+			}
+		}
 		line := resolveClaudePersistedToolResults(
 			path, compactClaudeEntry(lineBytes),
 		)
@@ -320,6 +340,13 @@ func claudeParseFile(
 
 	if err := lr.Err(); err != nil {
 		return nil, nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if opts.uploadIdentity && uploadEvidence && uploadRoot &&
+		!uploadSidechain && uploadSessionID != "" {
+		sessionID = uploadSessionID
+		if parentSessionID == sessionID {
+			parentSessionID = ""
+		}
 	}
 
 	// Detect truncation: last line is non-empty, invalid JSON,
@@ -427,6 +454,22 @@ func claudeParseFile(
 		kept = append(kept, r)
 	}
 	return kept, excluded, nil
+}
+
+func isValidClaudeUploadIdentity(id string) bool {
+	// Reserve the .jsonl suffix within common 255-byte component limits.
+	if len(id) > 249 || !IsValidSessionID(id) {
+		return false
+	}
+	upper := strings.ToUpper(id)
+	switch upper {
+	case "CON", "PRN", "AUX", "NUL":
+		return false
+	}
+	if len(upper) == 4 && (strings.HasPrefix(upper, "COM") || strings.HasPrefix(upper, "LPT")) {
+		return upper[3] < '1' || upper[3] > '9'
+	}
+	return true
 }
 
 type claudeCompactField struct {

--- a/internal/parser/claude_lineage.go
+++ b/internal/parser/claude_lineage.go
@@ -79,6 +79,8 @@ type claudeParseOptions struct {
 	// siblingLineage enables background-fork lineage resolution
 	// against sibling transcripts in the same directory.
 	siblingLineage bool
+	// uploadIdentity enables adoption of explicit rooted transcript IDs.
+	uploadIdentity bool
 }
 
 // claudeLineagePlan describes an established fork lineage: the leading

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -148,7 +148,9 @@ func (p *claudeProvider) ParseUploadedTranscript(
 	path, project, machine string,
 ) ([]ParseResult, error) {
 	machine = firstNonEmptyJSONLString(machine, p.Config.Machine)
-	results, _, err := claudeParseWithExclusions(path, project, machine)
+	results, _, err := claudeParseFile(path, project, machine, claudeParseOptions{
+		uploadIdentity: true,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/parser/claude_upload_identity_test.go
+++ b/internal/parser/claude_upload_identity_test.go
@@ -1,0 +1,130 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func uploadIdentityTranscript(sessionID, marker, secondID string) string {
+	markerField := ""
+	if marker != "" {
+		markerField = `,"isSidechain":` + marker
+	}
+	if secondID == "" {
+		secondID = sessionID
+	}
+	return fmt.Sprintf(
+		`{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00Z","sessionId":%q%s,"message":{"content":"hello"}}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z","sessionId":%q%s,"message":{"content":[{"type":"text","text":"hi"}]}}`+"\n",
+		sessionID, markerField, secondID, markerField,
+	)
+}
+
+func parseClaudeUploadIdentityFixture(t *testing.T, filename, content string) []ParseResult {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), filename+".jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	results, _, err := claudeParseFile(path, "project", "remote", claudeParseOptions{uploadIdentity: true})
+	require.NoError(t, err)
+	return results
+}
+
+func TestClaudeUploadIdentityAdoptsExplicitRootAndDerivesFork(t *testing.T) {
+	lines := []string{
+		`{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00Z","sessionId":"root-stable","isSidechain":false,"message":{"content":"root"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z","sessionId":"root-stable","isSidechain":false,"message":{"content":[{"type":"text","text":"root answer"}]}}`,
+	}
+	for _, branch := range []string{"b", "c"} {
+		parent := "a1"
+		for i := 1; i <= 4; i++ {
+			uuid := branch + fmt.Sprint(i)
+			lines = append(lines, fmt.Sprintf(`{"type":"user","uuid":%q,"parentUuid":%q,"timestamp":"2026-01-01T00:00:%02dZ","sessionId":"root-stable","isSidechain":false,"message":{"content":"%s"}}`, uuid, parent, i+1, uuid))
+			assistant := branch + "a" + fmt.Sprint(i)
+			lines = append(lines, fmt.Sprintf(`{"type":"assistant","uuid":%q,"parentUuid":%q,"timestamp":"2026-01-01T00:00:%02dZ","sessionId":"root-stable","isSidechain":false,"message":{"content":[{"type":"text","text":"answer"}]}}`, assistant, uuid, i+1))
+			parent = assistant
+		}
+	}
+	results := parseClaudeUploadIdentityFixture(t, "transport-name", strings.Join(lines, "\n")+"\n")
+	require.Len(t, results, 2)
+	assert.Equal(t, "root-stable", results[0].Session.ID)
+	assert.Empty(t, results[0].Session.ParentSessionID)
+	assert.Equal(t, "root-stable-c1", results[1].Session.ID)
+	assert.Equal(t, "root-stable", results[1].Session.ParentSessionID)
+	assert.Equal(t, RelFork, results[1].Session.RelationshipType)
+}
+
+func TestClaudeUploadIdentityRequiresStableStrictRootEvidence(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"sidechain", uploadIdentityTranscript("parent", "true", "parent")},
+		{"markerless", uploadIdentityTranscript("root", "", "root")},
+		{"mixed IDs", uploadIdentityTranscript("root", "false", "other")},
+		{"invalid ID", uploadIdentityTranscript("bad/id", "false", "bad/id")},
+		{"missing ID", strings.Replace(uploadIdentityTranscript("root", "false", "root"), `,"sessionId":"root","isSidechain"`, `,"isSidechain"`, 1)},
+		{"string marker", uploadIdentityTranscript("root", `"false"`, "root")},
+		{"null marker", uploadIdentityTranscript("root", "null", "root")},
+		{"reserved device", uploadIdentityTranscript("CON", "false", "CON")},
+		{"reserved COM1", uploadIdentityTranscript("COM1", "false", "COM1")},
+		{"reserved LPT9", uploadIdentityTranscript("LPT9", "false", "LPT9")},
+		{"too long", uploadIdentityTranscript(strings.Repeat("a", 250), "false", strings.Repeat("a", 250))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := parseClaudeUploadIdentityFixture(t, "transport-name", tt.content)
+			require.Len(t, results, 1)
+			assert.Equal(t, "transport-name", results[0].Session.ID)
+		})
+	}
+}
+
+func TestClaudeUploadIdentityAllows249ByteID(t *testing.T) {
+	id := strings.Repeat("a", 249)
+	results := parseClaudeUploadIdentityFixture(t, "transport-name", uploadIdentityTranscript(id, "false", id))
+	require.Len(t, results, 1)
+	assert.Equal(t, id, results[0].Session.ID)
+}
+
+func TestClaudeUploadIdentityIgnoresStagedCompanionPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "project", "subagents")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "agent-root.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(uploadIdentityTranscript("root-stable", "false", "root-stable")), 0o644))
+	results, _, err := claudeParseFile(path, "project", "remote", claudeParseOptions{uploadIdentity: true})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Session.ParentSessionID)
+	assert.Equal(t, RelNone, results[0].Session.RelationshipType)
+}
+
+func TestClaudeUploadIdentityAllowsNonReservedDevicePrefixes(t *testing.T) {
+	for _, id := range []string{"COM0", "COMA", "LPT0", "LPTA"} {
+		results := parseClaudeUploadIdentityFixture(t, "transport-name", uploadIdentityTranscript(id, "false", id))
+		require.Len(t, results, 1)
+		assert.Equal(t, id, results[0].Session.ID)
+	}
+}
+
+func TestClaudeLocalProviderPreservesFilenameIdentity(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "-Users-dev-demo", "transport-name.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(uploadIdentityTranscript("embedded", "false", "embedded")), 0o644))
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{root}, Machine: "local"})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, "transport-name", outcome.Results[0].Result.Session.ID)
+}

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -1089,6 +1089,10 @@ func (s *Server) humaUploadSession(
 	if len(results) == 0 {
 		return nil, apiError(http.StatusBadRequest, "no sessions parsed from upload")
 	}
+	stem := strings.TrimSuffix(safeName, ".jsonl")
+	if results[0].Session.ID != stem && parser.IsValidSessionID(results[0].Session.ID) {
+		upload.finalPath = filepath.Join(filepath.Dir(upload.finalPath), results[0].Session.ID+".jsonl")
+	}
 	for i := range results {
 		results[i].Session.File.Path = upload.finalPath
 	}

--- a/internal/server/upload_failure_test.go
+++ b/internal/server/upload_failure_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -184,4 +185,82 @@ func TestUploadSession_DBCommitFailureAfterReplacingFileRestoresPrevious(
 	got, err := os.ReadFile(finalPath)
 	require.NoError(t, err)
 	assert.Equal(t, previous, got, "restored file differs")
+}
+
+func TestUploadSession_RetargetedCommitFailureRestoresPrevious(t *testing.T) {
+	dir := t.TempDir()
+	const (
+		project  = "myproj"
+		filename = "transport.jsonl"
+		embedded = "embedded-target"
+	)
+	finalPath := filepath.Join(dir, "uploads", project, embedded+".jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(finalPath), 0o755))
+	previous := []byte("previous target bytes")
+	require.NoError(t, os.WriteFile(finalPath, previous, 0o644))
+	srv := server.New(config.Config{
+		Host: "127.0.0.1", Port: 0, DataDir: dir, WriteTimeout: 30 * time.Second,
+	}, uploadCommitFailStore{err: errors.New("commit failed")}, nil)
+	content := fmt.Sprintf(
+		`{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00Z","sessionId":"%s","isSidechain":false,"message":{"content":"hello"}}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z","sessionId":"%s","isSidechain":false,"message":{"content":[{"type":"text","text":"hi"}]}}`+"\n", embedded, embedded)
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", filename)
+	require.NoError(t, err)
+	_, err = fw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/upload?project="+project, &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	req.Host = "127.0.0.1:0"
+	req.RemoteAddr = "127.0.0.1:1234"
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	assertStatus(t, w, http.StatusInternalServerError)
+	got, err := os.ReadFile(finalPath)
+	require.NoError(t, err)
+	assert.Equal(t, previous, got)
+}
+
+func TestUploadSession_ExplicitIdentityRetargetsCollision(t *testing.T) {
+	te := setup(t)
+	transcript := func(id, text string) string {
+		return fmt.Sprintf(
+			`{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00Z","sessionId":%q,"isSidechain":false,"message":{"content":%q}}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z","sessionId":%q,"isSidechain":false,"message":{"content":[{"type":"text","text":"answer"}]}}`+"\n",
+			id, text, id,
+		)
+	}
+	oldContent := transcript("archived-old", "old")
+	w := te.upload(t, "collision.jsonl", oldContent, "project=myproj&machine=remote")
+	assertStatus(t, w, http.StatusOK)
+	oldBefore, err := te.db.GetSessionFull(context.Background(), "archived-old")
+	require.NoError(t, err)
+	require.NotNil(t, oldBefore)
+	newContent := transcript("archived-new", "new")
+	w = te.upload(t, "collision.jsonl", newContent, "project=myproj&machine=remote")
+	assertStatus(t, w, http.StatusOK)
+	response := decode[struct {
+		SessionID string `json:"session_id"`
+	}](t, w)
+	assert.Equal(t, "archived-new", response.SessionID)
+	oldPath := filepath.Join(te.dataDir, "uploads", "myproj", "archived-old.jsonl")
+	newPath := filepath.Join(te.dataDir, "uploads", "myproj", "archived-new.jsonl")
+	gotOld, err := os.ReadFile(oldPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(oldContent), gotOld)
+	gotNew, err := os.ReadFile(newPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(newContent), gotNew)
+	old, err := te.db.GetSessionFull(context.Background(), "archived-old")
+	require.NoError(t, err)
+	require.NotNil(t, old)
+	assert.Equal(t, oldBefore, old)
+	newSession, err := te.db.GetSessionFull(context.Background(), "archived-new")
+	require.NoError(t, err)
+	require.NotNil(t, newSession)
+	require.NotNil(t, newSession.FilePath)
+	assert.Equal(t, newPath, *newSession.FilePath)
 }


### PR DESCRIPTION
Renamed Claude root uploads can collide with an existing archive because the multipart filename supplies session identity. Uploads whose transcript carries one stable archive-safe ID with explicit root markers now select that ID during the existing Claude parse, and the staged file follows it. Sidechain, markerless, mixed-ID, and local discovery parses keep their current identity rules.

Replacement semantics, existing filename-keyed rows, case-equivalent names, and concurrent-writer handling are unchanged.

Refs #1333
