### PR TITLE
fix(parser): recover legacy OpenCode session cwd from project metadata

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -605,7 +605,14 @@ missing file does not classify a session as automated.
 - **Agentsview:** `internal/parser/opencode.go`,
   `internal/parser/opencode_provider.go`, and
   `internal/parser/opencode_storage_state.go`; legacy and database layouts are
-  both intentional compatibility targets.
+  both intentional compatibility targets. File-backed snapshots retain the
+  session JSON byte length in parsed session metadata so persisted `file_size`
+  matches the provider fingerprint and an unchanged cold-start sync stops
+  after fingerprinting instead of parsing the storage tree again. Reverified
+  2026-08-19 that legacy project-metadata events use the indexed sessions
+  whose cwd depends on that project. A malformed session path keeps the
+  directory fallback active only until that exact path is successfully
+  re-indexed or deleted.
 
 ## Kilo Code (`kilo`)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -419,7 +419,7 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // the real prompt, instead of leaving the raw wrapper in first_message and
 // the visible transcript. Existing rows need re-parsing so first_message
 // and message content drop the leading markup.)
-const dataVersion = 88
+const dataVersion = 89
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1008,10 +1008,10 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionClaudeIDEEnvelopeSplit(t *testing.T) {
-	assert.Equal(t, 88, CurrentDataVersion(),
-		"version 88 splits Claude IDE envelopes off mixed prompts after "+
-			"the Codex fork replay boundary reparse")
+func TestCurrentDataVersionIncludesOpenCodeProjectMetadataChange(t *testing.T) {
+	assert.Equal(t, 89, CurrentDataVersion(),
+		"version 89 is the data-version boundary for file-backed OpenCode metadata changes")
+	t.Logf("CurrentDataVersion=%d", CurrentDataVersion())
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -343,8 +343,9 @@ func OpenCodeSQLiteVirtualPath(
 func openCodeSessionProject(path string) string {
 	data, err := os.ReadFile(path)
 	if err == nil {
-		if cwd := gjson.GetBytes(data, "directory").Str; cwd != "" {
-			if project := ExtractProjectFromCwd(cwd); project != "" {
+		cwd := gjson.GetBytes(data, "directory").Str
+		if resolved, resolveErr := resolveOpenCodeStorageWorktree(path, cwd); resolveErr == nil {
+			if project := ExtractProjectFromCwd(resolved); project != "" {
 				return project
 			}
 		}

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -470,6 +470,16 @@ func parseOpenCodeDBSession(
 
 	projectWorktree := strings.TrimSpace(projects[s.projectID])
 	cwd := resolveOpenCodeWorktree(s.directory, projectWorktree)
+	if cwd == "" &&
+		(strings.TrimSpace(s.directory) == "" ||
+			strings.TrimSpace(s.directory) == string(filepath.Separator) ||
+			strings.TrimSpace(s.directory) == "/") &&
+		(strings.TrimSpace(projectWorktree) == string(filepath.Separator) ||
+			strings.TrimSpace(projectWorktree) == "/") {
+		// SQLite's global project uses / as its declared worktree. Preserve
+		// that source value; file-backed metadata applies the stricter policy.
+		cwd = "/"
+	}
 	if !openCodeUsableWorktree(projectWorktree) {
 		projectWorktree = cwd
 	}
@@ -488,7 +498,10 @@ func resolveOpenCodeWorktree(
 	if dir := strings.TrimSpace(sessionDirectory); openCodeUsableWorktree(dir) {
 		return dir
 	}
-	return strings.TrimSpace(projectWorktree)
+	if worktree := strings.TrimSpace(projectWorktree); openCodeUsableWorktree(worktree) {
+		return worktree
+	}
+	return ""
 }
 
 func openCodeUsableWorktree(path string) bool {
@@ -499,6 +512,46 @@ func openCodeUsableWorktree(path string) bool {
 	return path != string(filepath.Separator) && path != "/"
 }
 
+type openCodeProjectFile struct {
+	Worktree string `json:"worktree"`
+}
+
+func openCodeProjectPath(sessionPath string) string {
+	root := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(sessionPath))))
+	projectID := filepath.Base(filepath.Dir(sessionPath))
+	return filepath.Join(root, "storage", "project", projectID+".json")
+}
+
+// resolveOpenCodeStorageWorktree applies the file-backed session precedence
+// and reads only the project metadata named by the session path.
+func resolveOpenCodeStorageWorktree(
+	sessionPath, sessionDirectory string,
+) (string, error) {
+	sessionDirectory = strings.TrimSpace(sessionDirectory)
+	if openCodeUsableWorktree(sessionDirectory) {
+		return resolveOpenCodeWorktree(sessionDirectory, ""), nil
+	}
+	projectPath := openCodeProjectPath(sessionPath)
+	projectWorktree := ""
+	raw, err := os.ReadFile(projectPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"reading opencode project file %s: %w", projectPath, err,
+			)
+		}
+	} else {
+		var project openCodeProjectFile
+		if err := json.Unmarshal(raw, &project); err != nil {
+			return "", fmt.Errorf(
+				"decoding opencode project file %s: %w", projectPath, err,
+			)
+		}
+		projectWorktree = project.Worktree
+	}
+	return resolveOpenCodeWorktree(sessionDirectory, projectWorktree), nil
+}
+
 // parseOpenCodeStorageFile parses a file-backed OpenCode storage
 // session rooted at storage/session/<project>/<session>.json. The
 // OpenCode-format provider owns this path; Kilo and MiMoCode reuse it
@@ -506,81 +559,53 @@ func openCodeUsableWorktree(path string) bool {
 func parseOpenCodeStorageFile(
 	sessionPath, machine string,
 ) (*ParsedSession, []ParsedMessage, error) {
-	raw, err := os.ReadFile(sessionPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf(
-			"reading opencode session file %s: %w",
-			sessionPath, err,
-		)
-	}
-
-	var sf openCodeStorageSessionFile
-	if err := json.Unmarshal(raw, &sf); err != nil {
-		return nil, nil, fmt.Errorf(
-			"decoding opencode session file %s: %w",
-			sessionPath, err,
-		)
-	}
-	if sf.ID == "" {
-		return nil, nil, fmt.Errorf(
-			"opencode session file %s missing id",
-			sessionPath,
-		)
-	}
-
-	root := filepath.Dir(filepath.Dir(filepath.Dir(
-		filepath.Dir(sessionPath),
-	)))
-	// OpenCode session sync replaces the full stored transcript.
-	// If a child JSON is truncated mid-write, skipping it here
-	// would silently drop previously persisted content until the
-	// next successful sync, so malformed children abort the parse.
-	msgs, err := loadOpenCodeStorageMessages(root, sf.ID)
+	snapshot, err := loadOpenCodeStorageSnapshot(sessionPath, true)
 	if err != nil {
 		return nil, nil, err
 	}
-	parts, err := loadOpenCodeStorageParts(root, msgs)
-	if err != nil {
-		return nil, nil, err
-	}
-	fileMtime, err := OpenCodeSourceMtime(sessionPath)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	sess, parsed, err := buildOpenCodeParsedSession(
-		openCodeSessionRow{
-			id:          sf.ID,
-			parentID:    sf.ParentID,
-			title:       sf.Title,
-			timeCreated: sf.Time.Created,
-			timeUpdated: sf.Time.Updated,
-		},
-		sf.Directory,
-		sf.Directory,
-		sessionPath,
-		fileMtime,
+		snapshot.session,
+		snapshot.worktree,
+		snapshot.worktree,
+		snapshot.sessionPath,
+		snapshot.fileMtime,
 		machine,
-		msgs,
-		parts,
+		snapshot.messages,
+		snapshot.parts,
 	)
 	if err != nil || sess == nil {
 		return sess, parsed, err
 	}
-	sess.File.Hash = buildOpenCodeSessionFingerprint(
-		openCodeSessionRow{
-			id:          sf.ID,
-			parentID:    sf.ParentID,
-			title:       sf.Title,
-			timeCreated: sf.Time.Created,
-			timeUpdated: sf.Time.Updated,
-		},
-		sf.Directory,
-		sf.Directory,
-		msgs,
-		parts,
-	)
+	sess.File.Size = snapshot.fileSize
+	sess.File.Hash = snapshot.fingerprint()
 	return sess, parsed, nil
+}
+
+// openCodeStorageSessionFingerprint hashes raw storage rows without parsing messages.
+func openCodeStorageSessionFingerprint(sessionPath string) (string, error) {
+	snapshot, err := loadOpenCodeStorageSnapshot(sessionPath, false)
+	if err != nil {
+		return "", err
+	}
+	return openCodeStorageFingerprintFromSnapshot(snapshot)
+}
+
+func openCodeStorageFingerprintFromSnapshot(
+	snapshot openCodeStorageSnapshot,
+) (string, error) {
+	if !snapshot.hasMaterializedMessages() {
+		// Empty or still-in-progress sessions intentionally map to SkipNoSession;
+		// fingerprinting must preserve that normal outcome.
+		return "", nil
+	}
+	hash := snapshot.fingerprint()
+	if !HasOpenCodeStorageFingerprint(hash) {
+		return "", fmt.Errorf(
+			"opencode storage session %s has no content fingerprint",
+			snapshot.sessionPath,
+		)
+	}
+	return hash, nil
 }
 
 func openOpenCodeDB(dbPath string) (*sql.DB, error) {
@@ -1642,6 +1667,119 @@ type openCodeStorageSessionFile struct {
 	Time      openCodeStorageTime `json:"time"`
 }
 
+type openCodeStorageSnapshot struct {
+	sessionPath string
+	fileSize    int64
+	fileMtime   int64
+	session     openCodeSessionRow
+	directory   string
+	worktree    string
+	messages    []openCodeMessageRow
+	parts       map[string][]openCodePartRow
+}
+
+func loadOpenCodeStorageSnapshot(
+	sessionPath string,
+	includeMtime bool,
+) (openCodeStorageSnapshot, error) {
+	raw, err := os.ReadFile(sessionPath)
+	if err != nil {
+		return openCodeStorageSnapshot{}, fmt.Errorf(
+			"reading opencode session file %s: %w",
+			sessionPath, err,
+		)
+	}
+
+	var sf openCodeStorageSessionFile
+	if err := json.Unmarshal(raw, &sf); err != nil {
+		return openCodeStorageSnapshot{}, fmt.Errorf(
+			"decoding opencode session file %s: %w",
+			sessionPath, err,
+		)
+	}
+	if sf.ID == "" {
+		return openCodeStorageSnapshot{}, fmt.Errorf(
+			"opencode session file %s missing id",
+			sessionPath,
+		)
+	}
+
+	root := filepath.Dir(filepath.Dir(filepath.Dir(
+		filepath.Dir(sessionPath),
+	)))
+	msgs, err := loadOpenCodeStorageMessages(root, sf.ID)
+	if err != nil {
+		return openCodeStorageSnapshot{}, err
+	}
+	parts, err := loadOpenCodeStorageParts(root, msgs)
+	if err != nil {
+		return openCodeStorageSnapshot{}, err
+	}
+	var fileMtime int64
+	if includeMtime {
+		fileMtime, err = OpenCodeSourceMtime(sessionPath)
+		if err != nil {
+			return openCodeStorageSnapshot{}, err
+		}
+	}
+	worktree, err := resolveOpenCodeStorageWorktree(sessionPath, sf.Directory)
+	if err != nil {
+		return openCodeStorageSnapshot{}, err
+	}
+
+	return openCodeStorageSnapshot{
+		sessionPath: sessionPath,
+		fileSize:    int64(len(raw)),
+		fileMtime:   fileMtime,
+		session: openCodeSessionRow{
+			id:          sf.ID,
+			parentID:    sf.ParentID,
+			title:       sf.Title,
+			timeCreated: sf.Time.Created,
+			timeUpdated: sf.Time.Updated,
+		},
+		directory: sf.Directory,
+		worktree:  worktree,
+		messages:  msgs,
+		parts:     parts,
+	}, nil
+}
+
+func (s openCodeStorageSnapshot) fingerprint() string {
+	return buildOpenCodeSessionFingerprint(
+		s.session,
+		s.directory,
+		s.worktree,
+		s.messages,
+		s.parts,
+	)
+}
+
+func (s openCodeStorageSnapshot) hasMaterializedMessages() bool {
+	for _, msg := range s.messages {
+		var md openCodeMessageData
+		if json.Unmarshal([]byte(msg.data), &md) != nil ||
+			normalizeOpenCodeRole(md.Role) == "" {
+			continue
+		}
+		for _, part := range s.parts[msg.id] {
+			switch extractOpenCodePartType(part.data) {
+			case "tool":
+				return true
+			case "text":
+				if strings.TrimSpace(extractOpenCodeText(part.data)) != "" {
+					return true
+				}
+			case "reasoning":
+				if extractOpenCodeText(part.data) != "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 type openCodeStorageMessageFile struct {
 	ID         string `json:"id"`
 	SessionID  string `json:"sessionID"`
@@ -2016,6 +2154,15 @@ func openCodeStorageSessionMtime(
 
 	messageDir := filepath.Join(root, "storage", "message", sessionID)
 	fileMtime = max(fileMtime, statMtime(messageDir))
+	var session struct {
+		Directory string `json:"directory"`
+	}
+	if raw, readErr := os.ReadFile(sessionPath); readErr == nil {
+		if json.Unmarshal(raw, &session) == nil &&
+			!openCodeUsableWorktree(strings.TrimSpace(session.Directory)) {
+			fileMtime = max(fileMtime, statMtime(openCodeProjectPath(sessionPath)))
+		}
+	}
 	msgEntries, err := os.ReadDir(messageDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,7 +10,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 )
 
 var _ Provider = (*openCodeFormatProvider)(nil)
@@ -22,35 +25,40 @@ var _ Provider = (*openCodeFormatProvider)(nil)
 const sqliteWALHeaderSize = int64(32)
 
 type openCodeFormatProviderFactory struct {
-	def  AgentDef
-	spec openCodeProviderSpec
+	def   AgentDef
+	spec  openCodeProviderSpec
+	index *openCodeFormatSourceIndex
 }
 
 func newOpenCodeProviderFactory(def AgentDef) ProviderFactory {
 	return openCodeFormatProviderFactory{
-		def:  cloneAgentDef(def),
-		spec: openCodeProviderSpecForAgent(AgentOpenCode),
+		def:   cloneAgentDef(def),
+		spec:  openCodeProviderSpecForAgent(AgentOpenCode),
+		index: newOpenCodeFormatSourceIndex(),
 	}
 }
 
 func newKiloProviderFactory(def AgentDef) ProviderFactory {
 	return openCodeFormatProviderFactory{
-		def:  cloneAgentDef(def),
-		spec: openCodeProviderSpecForAgent(AgentKilo),
+		def:   cloneAgentDef(def),
+		spec:  openCodeProviderSpecForAgent(AgentKilo),
+		index: newOpenCodeFormatSourceIndex(),
 	}
 }
 
 func newMiMoCodeProviderFactory(def AgentDef) ProviderFactory {
 	return openCodeFormatProviderFactory{
-		def:  cloneAgentDef(def),
-		spec: openCodeProviderSpecForAgent(AgentMiMoCode),
+		def:   cloneAgentDef(def),
+		spec:  openCodeProviderSpecForAgent(AgentMiMoCode),
+		index: newOpenCodeFormatSourceIndex(),
 	}
 }
 
 func newIcodemateProviderFactory(def AgentDef) ProviderFactory {
 	return openCodeFormatProviderFactory{
-		def:  cloneAgentDef(def),
-		spec: openCodeProviderSpecForAgent(AgentIcodemate),
+		def:   cloneAgentDef(def),
+		spec:  openCodeProviderSpecForAgent(AgentIcodemate),
+		index: newOpenCodeFormatSourceIndex(),
 	}
 }
 
@@ -71,7 +79,7 @@ func (f openCodeFormatProviderFactory) NewProvider(cfg ProviderConfig) Provider 
 			Config: cfg,
 		},
 		sources: newOpenCodeFormatSourceSet(
-			cfg.Roots, f.spec, cfg.SQLiteContainerUnchangedSinceTrust,
+			cfg.Roots, f.spec, cfg.SQLiteContainerUnchangedSinceTrust, f.index,
 		),
 	}
 }
@@ -164,7 +172,8 @@ func (p *openCodeFormatProvider) Parse(
 		msgs []ParsedMessage
 		err  error
 	)
-	if dbPath, sessionID, ok := p.sources.spec.parseVirtual(path); ok {
+	dbPath, sessionID, sqliteSource := p.sources.spec.parseVirtual(path)
+	if sqliteSource {
 		sess, msgs, err = p.sources.spec.parseSQLite(dbPath, sessionID, machine)
 	} else {
 		sess, msgs, err = p.sources.spec.parseFile(path, machine)
@@ -178,7 +187,7 @@ func (p *openCodeFormatProvider) Parse(
 			SkipReason:        SkipNoSession,
 		}, nil
 	}
-	if req.Fingerprint.Hash != "" {
+	if sqliteSource && req.Fingerprint.Hash != "" {
 		sess.File.Hash = req.Fingerprint.Hash
 	}
 	return ParseOutcome{
@@ -400,6 +409,26 @@ type openCodeFormatSource struct {
 	WatermarkOnly bool
 }
 
+type openCodeFormatSourceIndex struct {
+	projectMetadataSessions map[string]map[string]struct{}
+	projectMetadataIndexed  map[string]struct{}
+	projectMetadataErrors   map[string]map[openCodeMetadataErrorPathKey]struct{}
+	projectMetadataMu       *sync.RWMutex
+}
+
+// openCodeMetadataErrorPathKey keeps per-path recovery state bounded without
+// retaining archive-sized path strings in the factory-owned index.
+type openCodeMetadataErrorPathKey [sha256.Size / 2]byte
+
+func newOpenCodeFormatSourceIndex() *openCodeFormatSourceIndex {
+	return &openCodeFormatSourceIndex{
+		projectMetadataSessions: make(map[string]map[string]struct{}),
+		projectMetadataIndexed:  make(map[string]struct{}),
+		projectMetadataErrors:   make(map[string]map[openCodeMetadataErrorPathKey]struct{}),
+		projectMetadataMu:       &sync.RWMutex{},
+	}
+}
+
 type openCodeFormatSourceSet struct {
 	roots []string
 	spec  openCodeProviderSpec
@@ -410,17 +439,35 @@ type openCodeFormatSourceSet struct {
 	// engine's container gate skips every member before fingerprinting, so
 	// the full child digest would be archive-sized work nothing reads.
 	containerTrusted func(dbPath string) bool
+	// projectMetadataSessions indexes only sessions whose cwd resolution uses
+	// project metadata, so project events do not rescan concrete sessions.
+	projectMetadataSessions map[string]map[string]struct{}
+	projectMetadataIndexed  map[string]struct{}
+	projectMetadataErrors   map[string]map[openCodeMetadataErrorPathKey]struct{}
+	projectMetadataMu       *sync.RWMutex
 }
 
 func newOpenCodeFormatSourceSet(
 	roots []string,
 	spec openCodeProviderSpec,
 	containerTrusted func(dbPath string) bool,
+	sharedIndex ...*openCodeFormatSourceIndex,
 ) openCodeFormatSourceSet {
+	index := (*openCodeFormatSourceIndex)(nil)
+	if len(sharedIndex) > 0 {
+		index = sharedIndex[0]
+	}
+	if index == nil {
+		index = newOpenCodeFormatSourceIndex()
+	}
 	return openCodeFormatSourceSet{
-		roots:            cleanJSONLRoots(roots),
-		spec:             spec,
-		containerTrusted: containerTrusted,
+		roots:                   cleanJSONLRoots(roots),
+		spec:                    spec,
+		containerTrusted:        containerTrusted,
+		projectMetadataSessions: index.projectMetadataSessions,
+		projectMetadataIndexed:  index.projectMetadataIndexed,
+		projectMetadataErrors:   index.projectMetadataErrors,
+		projectMetadataMu:       index.projectMetadataMu,
 	}
 }
 
@@ -435,6 +482,7 @@ func (s openCodeFormatSourceSet) Discover(ctx context.Context) ([]SourceRef, err
 		storageIDs := map[string]struct{}{}
 		if src.Mode == OpenCodeSourceStorage {
 			for _, file := range s.spec.discover(root) {
+				s.indexStorageSession(root, file.Path)
 				source, ok := s.sourceRef(root, file.Path, false)
 				if !ok {
 					continue
@@ -442,6 +490,7 @@ func (s openCodeFormatSourceSet) Discover(ctx context.Context) ([]SourceRef, err
 				source.ProjectHint = file.Project
 				addJSONLSource(source, &sources, seen)
 			}
+			s.markDiscoveredProjectMetadata(root)
 			storageIDs = s.spec.storageIDs(root)
 		}
 		if src.DBPath == "" || !IsRegularFile(src.DBPath) {
@@ -624,6 +673,7 @@ func (s openCodeFormatSourceSet) discoverStorageEach(
 				return nil
 			}
 			path := filepath.Join(projectDir, entry.Name())
+			s.indexStorageSession(root, path)
 			source, ok := s.sourceRef(root, path, false)
 			if !ok {
 				return nil
@@ -646,6 +696,7 @@ func (s openCodeFormatSourceSet) discoverStorageEach(
 		if err != nil {
 			return err
 		}
+		s.markProjectMetadataIndexed(root, project.Name())
 		return nil
 	})
 	if callbackErr != nil {
@@ -1003,11 +1054,21 @@ func (s openCodeFormatSourceSet) Fingerprint(
 	mtime := sourceCarriedMTimeNS(source)
 	composite := sourceCarriedCompositeMTime(source)
 	digest := sourceCarriedChildDigest(source)
+	dbPath, _, sqliteSource := s.spec.parseVirtual(path)
+	var storageSnapshot *openCodeStorageSnapshot
+	if !sqliteSource && mtime == 0 {
+		snapshot, err := loadOpenCodeStorageSnapshot(path, true)
+		if err != nil {
+			return SourceFingerprint{}, err
+		}
+		storageSnapshot = &snapshot
+		mtime = snapshot.fileMtime
+	}
 	// Only re-open the container when a digest is actually expected. A legacy
 	// container reports composite=false and carries an empty digest by design,
 	// so treating "empty" alone as "missing" would reopen and re-query the
 	// shared database once per session on every cold or changed-container pass.
-	if mtime == 0 || (composite && digest == "") {
+	if sqliteSource && (mtime == 0 || (composite && digest == "")) {
 		// Sources rebuilt by FindSource or reconciliation carry no discovery
 		// metadata, and watermark-only changed-path sources carry a
 		// deliberately unresolved digest. Without this the hash would be
@@ -1037,7 +1098,7 @@ func (s openCodeFormatSourceSet) Fingerprint(
 		Key:     firstNonEmptyJSONLString(source.FingerprintKey, source.Key, path),
 		MTimeNS: mtime,
 	}
-	if dbPath, _, ok := s.spec.parseVirtual(path); ok {
+	if sqliteSource {
 		info, err := os.Stat(dbPath)
 		if err != nil {
 			return SourceFingerprint{}, fmt.Errorf("stat %s: %w", dbPath, err)
@@ -1071,13 +1132,20 @@ func (s openCodeFormatSourceSet) Fingerprint(
 		return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", path)
 	}
 	fingerprint.Size = info.Size()
-	// No content hash: no engine freshness gate consumes it for this
-	// family (see providerFingerprintHashRequiredForFreshness), and the
-	// authoritative storage fingerprint is computed by Parse and compared
-	// post-parse by dropUnchangedSharedSQLiteResults. Computing it here
-	// re-read and re-hashed every message and part file of the session on
-	// every fingerprint call — the dominant cost of syncing streaming
-	// storage sessions — for a value nothing read.
+	// Storage sessions must expose the same content fingerprint that Parse
+	// persists. Project metadata is part of that fingerprint, so a metadata
+	// rewrite still invalidates a row whose session size and mtime are stable.
+	if storageSnapshot == nil {
+		snapshot, snapshotErr := loadOpenCodeStorageSnapshot(path, false)
+		if snapshotErr != nil {
+			return SourceFingerprint{}, snapshotErr
+		}
+		storageSnapshot = &snapshot
+	}
+	fingerprint.Hash, err = openCodeStorageFingerprintFromSnapshot(*storageSnapshot)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
 	return fingerprint, nil
 }
 
@@ -1363,10 +1431,13 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 		)
 		return sources, true, err
 	}
-
 	src := s.spec.resolve(root)
 	if src.Mode != OpenCodeSourceStorage {
 		return nil, false, nil
+	}
+	if projectID, ok := openCodeProjectIDFromPath(root, path); ok {
+		sources, err := s.sourcesForProject(root, projectID)
+		return sources, true, err
 	}
 	parts := strings.Split(rel, string(filepath.Separator))
 	sessionSubdir := filepath.Base(src.SessionRoot)
@@ -1376,6 +1447,7 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 		parts[0] == "storage" &&
 		parts[1] == sessionSubdir &&
 		strings.HasSuffix(parts[3], ".json"):
+		s.indexStorageSession(root, path)
 		source, ok := s.sourceRef(root, path, false)
 		if !ok {
 			return nil, true, nil
@@ -1386,6 +1458,7 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 		parts[0] == "storage" &&
 		parts[1] == sessionSubdir &&
 		strings.HasSuffix(parts[3], ".json"):
+		s.removeStorageSession(root, path)
 		source, ok := s.sourceRefFromStoragePath(root, path)
 		if !ok {
 			return nil, true, nil
@@ -1445,6 +1518,245 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 	return nil, false, nil
 }
 
+func (s openCodeFormatSourceSet) sourcesForProject(
+	root, projectID string,
+) ([]SourceRef, error) {
+	if projectID == "" {
+		return nil, nil
+	}
+	src := s.spec.resolve(root)
+	if src.Mode != OpenCodeSourceStorage {
+		return nil, nil
+	}
+	if err := s.ensureProjectMetadataIndex(root, src.SessionRoot, projectID); err != nil {
+		return nil, err
+	}
+	key := projectMetadataIndexKey(root, projectID)
+	s.projectMetadataMu.RLock()
+	paths := make([]string, 0, len(s.projectMetadataSessions[key]))
+	for path := range s.projectMetadataSessions[key] {
+		paths = append(paths, path)
+	}
+	hasErrors := len(s.projectMetadataErrors[key]) > 0
+	s.projectMetadataMu.RUnlock()
+	sort.Strings(paths)
+	sources := make([]SourceRef, 0, len(paths))
+	for _, path := range paths {
+		if !IsRegularFile(path) {
+			s.removeStorageSession(root, path)
+			continue
+		}
+		if source, ok := s.sourceRefFromStoragePath(root, path); ok {
+			sources = append(sources, source)
+		}
+	}
+	if hasErrors {
+		var err error
+		sources, err = s.appendProjectMetadataErrorSources(
+			root, src.SessionRoot, projectID, sources,
+		)
+		if err != nil {
+			return nil, err
+		}
+		sort.Slice(sources, func(i, j int) bool {
+			return sources[i].DisplayPath < sources[j].DisplayPath
+		})
+	}
+	return sources, nil
+}
+
+func (s openCodeFormatSourceSet) appendProjectMetadataErrorSources(
+	root, sessionRoot, projectID string, sources []SourceRef,
+) ([]SourceRef, error) {
+	dir := filepath.Join(sessionRoot, projectID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return sources, nil
+		}
+		return nil, fmt.Errorf("reading opencode session project %s: %w", dir, err)
+	}
+	known := make(map[string]struct{}, len(sources))
+	for _, source := range sources {
+		known[source.DisplayPath] = struct{}{}
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if _, ok := known[path]; ok ||
+			!openCodeStorageSessionUsesProjectMetadata(path) {
+			continue
+		}
+		if source, ok := s.sourceRefFromStoragePath(root, path); ok {
+			sources = append(sources, source)
+			known[path] = struct{}{}
+		}
+	}
+	return sources, nil
+}
+
+func projectMetadataIndexKey(root, projectID string) string {
+	return filepath.Clean(root) + "\x00" + projectID
+}
+
+func projectMetadataErrorPathKey(path string) openCodeMetadataErrorPathKey {
+	digest := sha256.Sum256([]byte(filepath.Clean(path)))
+	var key openCodeMetadataErrorPathKey
+	copy(key[:], digest[:])
+	return key
+}
+
+func (s openCodeFormatSourceSet) indexStorageSession(root, path string) {
+	projectID := filepath.Base(filepath.Dir(path))
+	if projectID == "." || projectID == "" {
+		return
+	}
+	key := projectMetadataIndexKey(root, projectID)
+	errorPathKey := projectMetadataErrorPathKey(path)
+	usesProject, malformed := openCodeStorageSessionIndexState(path)
+	s.projectMetadataMu.Lock()
+	paths := s.projectMetadataSessions[key]
+	if paths == nil {
+		paths = make(map[string]struct{})
+		s.projectMetadataSessions[key] = paths
+	}
+	if malformed {
+		errors := s.projectMetadataErrors[key]
+		if errors == nil {
+			errors = make(map[openCodeMetadataErrorPathKey]struct{})
+			s.projectMetadataErrors[key] = errors
+		}
+		errors[errorPathKey] = struct{}{}
+		delete(paths, path)
+	} else {
+		errors := s.projectMetadataErrors[key]
+		delete(errors, errorPathKey)
+		if len(errors) == 0 {
+			delete(s.projectMetadataErrors, key)
+		}
+		if usesProject {
+			paths[path] = struct{}{}
+		} else {
+			delete(paths, path)
+		}
+	}
+	s.projectMetadataMu.Unlock()
+}
+
+func (s openCodeFormatSourceSet) removeStorageSession(root, path string) {
+	projectID := filepath.Base(filepath.Dir(path))
+	key := projectMetadataIndexKey(root, projectID)
+	errorPathKey := projectMetadataErrorPathKey(path)
+	s.projectMetadataMu.Lock()
+	delete(s.projectMetadataSessions[key], path)
+	errors := s.projectMetadataErrors[key]
+	delete(errors, errorPathKey)
+	if len(errors) == 0 {
+		delete(s.projectMetadataErrors, key)
+	}
+	s.projectMetadataMu.Unlock()
+}
+
+func (s openCodeFormatSourceSet) markProjectMetadataIndexed(
+	root, projectID string,
+) {
+	s.projectMetadataMu.Lock()
+	s.projectMetadataIndexed[projectMetadataIndexKey(root, projectID)] = struct{}{}
+	s.projectMetadataMu.Unlock()
+}
+
+func (s openCodeFormatSourceSet) markDiscoveredProjectMetadata(root string) {
+	s.projectMetadataMu.Lock()
+	defer s.projectMetadataMu.Unlock()
+	for projectID := range s.projectMetadataSessions {
+		prefix := filepath.Clean(root) + "\x00"
+		if strings.HasPrefix(projectID, prefix) {
+			s.projectMetadataIndexed[projectID] = struct{}{}
+		}
+	}
+}
+
+func (s openCodeFormatSourceSet) ensureProjectMetadataIndex(
+	root, sessionRoot, projectID string,
+) error {
+	key := projectMetadataIndexKey(root, projectID)
+	s.projectMetadataMu.RLock()
+	_, indexed := s.projectMetadataIndexed[key]
+	s.projectMetadataMu.RUnlock()
+	if indexed {
+		return nil
+	}
+	dir := filepath.Join(sessionRoot, projectID)
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.markProjectMetadataIndexed(root, projectID)
+			return nil
+		}
+		return fmt.Errorf("stat opencode session project %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("opencode session project %s is not a directory", dir)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.markProjectMetadataIndexed(root, projectID)
+			return nil
+		}
+		return fmt.Errorf("reading opencode session project %s: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		s.indexStorageSession(root, filepath.Join(dir, entry.Name()))
+	}
+	s.markProjectMetadataIndexed(root, projectID)
+	return nil
+}
+
+// Project changes only affect sessions that need project metadata for cwd.
+// Keep unreadable or malformed sessions so their parse errors stay visible.
+func openCodeStorageSessionUsesProjectMetadata(path string) bool {
+	usesProject, _ := openCodeStorageSessionIndexState(path)
+	return usesProject
+}
+
+func openCodeStorageSessionIndexState(path string) (usesProject, malformed bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return true, true
+	}
+	var session struct {
+		ID        string `json:"id"`
+		Directory string `json:"directory"`
+	}
+	if json.Unmarshal(raw, &session) != nil {
+		return true, true
+	}
+	if session.ID == "" {
+		return true, true
+	}
+	return !openCodeUsableWorktree(strings.TrimSpace(session.Directory)), false
+}
+
+func openCodeProjectIDFromPath(root, path string) (string, bool) {
+	rel, ok := relUnder(root, path)
+	if !ok {
+		return "", false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) != 3 || parts[0] != "storage" ||
+		parts[1] != "project" || !strings.HasSuffix(parts[2], ".json") {
+		return "", false
+	}
+	projectID := strings.TrimSuffix(parts[2], ".json")
+	return projectID, projectID != ""
+}
+
 func (s openCodeFormatSourceSet) ChangedPathRelevance(
 	ctx context.Context,
 	req ChangedPathRequest,
@@ -1453,11 +1765,14 @@ func (s openCodeFormatSourceSet) ChangedPathRelevance(
 		return ChangedPathUnclassified, err
 	}
 	if req.WatchRoot != "" {
-		root := filepath.Clean(req.WatchRoot)
-		if !s.hasConfiguredRoot(root) {
-			return ChangedPathUnclassified, nil
+		watchRoot := filepath.Clean(req.WatchRoot)
+		for _, root := range s.roots {
+			if samePath(watchRoot, root) ||
+				samePath(watchRoot, openCodeStorageWatchDir(root)) {
+				return s.changedPathRelevanceInRoot(root, req.Path), nil
+			}
 		}
-		return s.changedPathRelevanceInRoot(root, req.Path), nil
+		return ChangedPathUnclassified, nil
 	}
 	for _, root := range s.roots {
 		if relevance := s.changedPathRelevanceInRoot(root, req.Path); relevance != ChangedPathUnclassified {
@@ -1473,6 +1788,12 @@ func (s openCodeFormatSourceSet) changedPathRelevanceInRoot(
 	rel, ok := relUnder(root, path)
 	if !ok {
 		return ChangedPathUnclassified
+	}
+	src := s.spec.resolve(root)
+	if src.Mode == OpenCodeSourceStorage {
+		if _, ok := openCodeProjectIDFromPath(root, path); ok {
+			return ChangedPathDataBearing
+		}
 	}
 	relevance, _ := s.sqliteChangeRelevance(root, path, rel)
 	return relevance
@@ -1501,15 +1822,6 @@ func (s openCodeFormatSourceSet) sqliteChangeRelevance(
 	default:
 		return ChangedPathUnclassified, false
 	}
-}
-
-func (s openCodeFormatSourceSet) hasConfiguredRoot(root string) bool {
-	for _, configured := range s.roots {
-		if samePath(root, configured) {
-			return true
-		}
-	}
-	return false
 }
 
 func sqliteWALHasFrames(path string) bool {

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -380,12 +380,25 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 	sessionPath := writeOpenCodeProviderStorageSession(
 		t, root, "session", "ses_provider", "opencode-app", "Provider Session",
 	)
+	projectPath := filepath.Join(root, "storage", "project", "global.json")
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": "global", "worktree": "/home/user/code/opencode-app",
+	})
 
 	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
 		Roots:   []string{root},
 		Machine: "devbox",
 	})
 	require.True(t, ok)
+	for i := range 64 {
+		writeOpenCodeStorageFile(t, filepath.Join(
+			root, "storage", "session", "global",
+			fmt.Sprintf("ses_concrete_%02d.json", i),
+		), map[string]any{
+			"id":        fmt.Sprintf("ses_concrete_%02d", i),
+			"directory": fmt.Sprintf("/work/concrete-%02d", i),
+		})
+	}
 
 	plan, err := provider.WatchPlan(context.Background())
 	require.NoError(t, err)
@@ -401,12 +414,46 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
-	require.Len(t, discovered, 1)
-	source := discovered[0]
+	require.Len(t, discovered, 65)
+	var source SourceRef
+	for _, candidate := range discovered {
+		if candidate.DisplayPath == sessionPath {
+			source = candidate
+			break
+		}
+	}
+	require.NotEmpty(t, source.DisplayPath)
 	assert.Equal(t, AgentOpenCode, source.Provider)
 	assert.Equal(t, sessionPath, source.DisplayPath)
 	assert.Equal(t, sessionPath, source.FingerprintKey)
 	assert.Equal(t, "opencode_app", source.ProjectHint)
+	legacySessionPath := filepath.Join(
+		root, "storage", "session", "global", "ses_legacy.json",
+	)
+	writeOpenCodeStorageFile(t, legacySessionPath, map[string]any{
+		"id": "ses_legacy", "title": "Legacy project session",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	legacyChanged, err := provider.SourcesForChangedPath(
+		context.Background(), ChangedPathRequest{
+			Path: legacySessionPath, EventKind: "write",
+			WatchRoot: filepath.Join(root, "storage"),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, legacyChanged, 1)
+	assert.Equal(t, legacySessionPath, legacyChanged[0].DisplayPath)
+	otherSessionPath := filepath.Join(
+		root, "storage", "session", "other-project", "ses_other.json",
+	)
+	writeOpenCodeStorageFile(t, otherSessionPath, map[string]any{
+		"id": "ses_other", "directory": "/home/user/code/other-app",
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "project", "other-project.json",
+	), map[string]any{
+		"id": "other-project", "worktree": "/home/user/code/other-app",
+	})
 
 	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
 		FullSessionID: "remote~opencode:ses_provider",
@@ -441,16 +488,35 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 			assert.Equal(t, sessionPath, changed[0].DisplayPath)
 		})
 	}
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(), ChangedPathRequest{
+			Path: projectPath, EventKind: "write",
+			WatchRoot: filepath.Join(root, "storage"),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, legacySessionPath, changed[0].DisplayPath)
+	assert.Equal(t, "opencode_app", changed[0].ProjectHint)
+	assert.NotEqual(t, sessionPath, changed[0].DisplayPath,
+		"project changes must not fan out to sessions with concrete directories")
+	assert.NotEqual(t, otherSessionPath, changed[0].DisplayPath)
+	t.Logf("project event routed sources=%d ProjectHint=%q unrelated=%q excluded", len(changed), changed[0].ProjectHint, otherSessionPath)
+	relevance, err := ResolveChangedPathRelevance(
+		context.Background(), provider, ChangedPathRequest{
+			Path: projectPath, EventKind: "write",
+			WatchRoot: filepath.Join(root, "storage"),
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, ChangedPathDataBearing, relevance)
 
 	fingerprint, err := provider.Fingerprint(context.Background(), found)
 	require.NoError(t, err)
 	assert.Equal(t, sessionPath, fingerprint.Key)
 	assert.Positive(t, fingerprint.Size)
 	assert.Positive(t, fingerprint.MTimeNS)
-	// Storage-mode Fingerprint is stat-only: the content fingerprint is
-	// computed by Parse, and hashing here would re-read every message and
-	// part file on each fingerprint call.
-	assert.Empty(t, fingerprint.Hash)
+	assert.NotEmpty(t, fingerprint.Hash)
 
 	outcome, err := provider.Parse(context.Background(), ParseRequest{
 		Source:      found,
@@ -467,8 +533,44 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 	assert.Equal(t, "devbox", result.Result.Session.Machine)
 	assert.True(t,
 		HasOpenCodeStorageFingerprint(result.Result.Session.File.Hash),
-		"Parse must compute the storage content fingerprint itself")
+		"Parse must retain the provider content fingerprint")
+	assert.Equal(t, fingerprint.Hash, result.Result.Session.File.Hash)
 	assert.Len(t, result.Result.Messages, 1)
+
+	priorHash := fingerprint.Hash
+	updatedPartPath := filepath.Join(
+		root, "storage", "part", "msg_1", "prt_1.json",
+	)
+	rawPart, err := os.ReadFile(updatedPartPath)
+	require.NoError(t, err)
+	partInfo, err := os.Stat(updatedPartPath)
+	require.NoError(t, err)
+	updatedPart := strings.Replace(
+		string(rawPart), "Hello from storage", "Changed in storage", 1,
+	)
+	require.NotEqual(t, string(rawPart), updatedPart)
+	require.NoError(t, os.WriteFile(
+		updatedPartPath, []byte(updatedPart), 0o644,
+	))
+	require.NoError(t, os.Chtimes(
+		updatedPartPath, partInfo.ModTime(), partInfo.ModTime(),
+	))
+	laterFingerprint, err := provider.Fingerprint(
+		context.Background(), found,
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, priorHash, laterFingerprint.Hash)
+	staleRequestOutcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: found, Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, staleRequestOutcome.Results, 1)
+	assert.Equal(t, "Changed in storage",
+		staleRequestOutcome.Results[0].Result.Messages[0].Content,
+		"file-backed Parse must materialize the later storage snapshot")
+	assert.Equal(t, laterFingerprint.Hash,
+		staleRequestOutcome.Results[0].Result.Session.File.Hash,
+		"file-backed Parse must retain the hash from the snapshot it parsed")
 
 	require.NoError(t, os.Remove(sessionPath), "remove storage session")
 	removed, err := provider.SourcesForChangedPath(
@@ -485,6 +587,278 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 	assert.Equal(t, "global", removed[0].ProjectHint)
 }
 
+func TestOpenCodeProviderProjectIndexSurvivesProviderRecreation(t *testing.T) {
+	root := t.TempDir()
+	projectID := "project-index"
+	projectPath := filepath.Join(
+		root, "storage", "project", projectID+".json",
+	)
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": projectID, "worktree": "/home/user/code/indexed",
+	})
+	for i := range 256 {
+		id := fmt.Sprintf("ses_concrete_%03d", i)
+		writeOpenCodeStorageFile(t, filepath.Join(
+			root, "storage", "session", projectID, id+".json",
+		), map[string]any{
+			"id": id, "directory": "/home/user/code/concrete",
+		})
+	}
+	legacyPath := filepath.Join(
+		root, "storage", "session", projectID, "ses_legacy.json",
+	)
+	writeOpenCodeStorageFile(t, legacyPath, map[string]any{
+		"id": "ses_legacy",
+	})
+
+	factory := newOpenCodeProviderFactory(AgentDef{
+		Type: AgentOpenCode, IDPrefix: "opencode",
+	})
+	config := ProviderConfig{Roots: []string{root}}
+	primingProvider := factory.NewProvider(config)
+	_, err := primingProvider.Discover(t.Context())
+	require.NoError(t, err)
+
+	// Changed-path classification creates fresh providers, so the factory-owned index must persist.
+	changedProvider := factory.NewProvider(config)
+	changed, err := changedProvider.SourcesForChangedPath(
+		t.Context(), ChangedPathRequest{
+			Path: projectPath, EventKind: "write",
+			WatchRoot: filepath.Join(root, "storage"),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, legacyPath, changed[0].DisplayPath)
+}
+
+func TestOpenCodeProviderReturnsSkipNoSessionForEmptyStorageSession(t *testing.T) {
+	root := t.TempDir()
+	const sessionID = "ses_empty"
+	sessionPath := filepath.Join(
+		root, "storage", "session", "global", sessionID+".json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": sessionID, "title": "New session - 2026-01-01T00:00:00Z",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "project", "global.json",
+	), map[string]any{"id": "global", "worktree": "/"})
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	fingerprint, err := provider.Fingerprint(t.Context(), sources[0])
+	require.NoError(t, err)
+	outcome, err := provider.Parse(t.Context(), ParseRequest{
+		Source: sources[0], Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.Equal(t, SkipNoSession, outcome.SkipReason)
+	assert.Empty(t, outcome.Results)
+}
+
+func TestOpenCodeProviderProjectEventRetainsMalformedSession(t *testing.T) {
+	root := t.TempDir()
+	projectID := "malformed-project"
+	projectPath := filepath.Join(root, "storage", "project", projectID+".json")
+	sessionPath := filepath.Join(
+		root, "storage", "session", projectID, "ses_malformed.json",
+	)
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": projectID, "worktree": "/work/malformed-app",
+	})
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte("{"), 0o644))
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path: projectPath, EventKind: "write",
+		WatchRoot: filepath.Join(root, "storage"),
+	})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, sessionPath, sources[0].DisplayPath)
+}
+
+func TestOpenCodeProviderClearsResolvedMalformedSessionsIndividually(t *testing.T) {
+	root := t.TempDir()
+	projectID := "malformed-project"
+	projectPath := filepath.Join(root, "storage", "project", projectID+".json")
+	sessionDir := filepath.Join(root, "storage", "session", projectID)
+	repairedPath := filepath.Join(sessionDir, "ses_repaired.json")
+	removedPath := filepath.Join(sessionDir, "ses_removed.json")
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": projectID, "worktree": "/work/malformed-app",
+	})
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	for _, path := range []string{repairedPath, removedPath} {
+		require.NoError(t, os.WriteFile(path, []byte("{"), 0o644))
+	}
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	projectSources := func() ([]SourceRef, error) {
+		return provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+			Path: projectPath, EventKind: "write",
+			WatchRoot: filepath.Join(root, "storage"),
+		})
+	}
+	sources, err := projectSources()
+	require.NoError(t, err)
+	require.Len(t, sources, 2)
+	assert.Equal(t, removedPath, sources[0].DisplayPath)
+	assert.Equal(t, repairedPath, sources[1].DisplayPath)
+
+	writeOpenCodeStorageFile(t, repairedPath, map[string]any{
+		"id": "ses_repaired", "directory": "/work/repaired-app",
+	})
+	_, err = provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path: repairedPath, EventKind: "write",
+		WatchRoot: filepath.Join(root, "storage"),
+	})
+	require.NoError(t, err)
+	sources, err = projectSources()
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, removedPath, sources[0].DisplayPath,
+		"an unresolved malformed session must keep the fallback active")
+
+	require.NoError(t, os.Remove(removedPath))
+	_, err = provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path: removedPath, EventKind: "remove",
+		WatchRoot: filepath.Join(root, "storage"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(repairedPath))
+	require.NoError(t, os.Remove(sessionDir))
+	require.NoError(t, os.WriteFile(sessionDir, []byte("not a directory"), 0o644))
+
+	sources, err = projectSources()
+	require.NoError(t, err,
+		"resolved malformed sessions must not leave the fallback scan active")
+	assert.Empty(t, sources)
+}
+
+func TestOpenCodeProviderProjectMetadataRefreshAndMalformedReturnsError(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	projectID := "legacy-project"
+	sessionID := "ses_refresh"
+	sessionPath := filepath.Join(
+		root, "storage", "session", projectID, sessionID+".json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": sessionID, "title": "Refresh", "time": map[string]any{
+			"created": int64(1700000000000), "updated": int64(1700000060000),
+		},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "message", sessionID, "msg_1.json",
+	), map[string]any{
+		"id": "msg_1", "sessionID": sessionID, "role": "user",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "part", "msg_1", "part_1.json",
+	), map[string]any{
+		"id": "part_1", "sessionID": sessionID, "messageID": "msg_1",
+		"type": "text", "text": "hello",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	projectPath := filepath.Join(
+		root, "storage", "project", projectID+".json",
+	)
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": projectID, "worktree": "/home/user/code/old-app",
+	})
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discovered, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	parse := func(source SourceRef) (SourceFingerprint, ParsedSession) {
+		fingerprint, err := provider.Fingerprint(t.Context(), source)
+		require.NoError(t, err)
+		outcome, err := provider.Parse(t.Context(), ParseRequest{
+			Source: source, Fingerprint: fingerprint,
+		})
+		require.NoError(t, err)
+		require.Len(t, outcome.Results, 1)
+		return fingerprint, outcome.Results[0].Result.Session
+	}
+
+	priorFingerprint, prior := parse(discovered[0])
+	assert.Equal(t, "/home/user/code/old-app", prior.Cwd)
+	projectInfo, err := os.Stat(projectPath)
+	require.NoError(t, err)
+
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": projectID, "worktree": "/home/user/code/new-app",
+	})
+	afterProjectInfo, err := os.Stat(projectPath)
+	require.NoError(t, err)
+	require.Equal(t, projectInfo.Size(), afterProjectInfo.Size())
+	require.NoError(t, os.Chtimes(
+		projectPath, projectInfo.ModTime(), projectInfo.ModTime(),
+	))
+	changed, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path: projectPath, EventKind: "write",
+		WatchRoot: filepath.Join(root, "storage"),
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	refreshedFingerprint, refreshed := parse(changed[0])
+	assert.Equal(t, "/home/user/code/new-app", refreshed.Cwd)
+	assert.Equal(t, "new_app", refreshed.Project)
+	assert.NotEqual(t, priorFingerprint.Hash, refreshedFingerprint.Hash)
+	assert.Equal(t, refreshedFingerprint.Hash, refreshed.File.Hash)
+	t.Logf(
+		"metadata rewrite changed fingerprint and refreshed Cwd=%q Project=%q",
+		refreshed.Cwd, refreshed.Project,
+	)
+
+	require.NoError(t, os.WriteFile(projectPath, []byte("{"), 0o644))
+	_, err = provider.Fingerprint(t.Context(), changed[0])
+	assert.Error(t, err)
+}
+
+func TestOpenCodeProviderProjectMetadataChangeReportsSessionDirectoryError(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	projectID := "broken-project"
+	projectPath := filepath.Join(root, "storage", "project", projectID+".json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(projectPath), 0o755))
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": projectID, "worktree": "/home/user/code/broken-app",
+	})
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "storage", "session"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "storage", "session", projectID),
+		[]byte("not a directory"), 0o644,
+	))
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	formatProvider, ok := provider.(*openCodeFormatProvider)
+	require.True(t, ok)
+	_, err := formatProvider.sources.sourcesForProject(root, projectID)
+	assert.Error(t, err)
+	_, publicErr := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path: projectPath, EventKind: "write",
+		WatchRoot: filepath.Join(root, "storage"),
+	})
+	assert.Error(t, publicErr)
+}
+
 func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 
 	fixture := openCodeSQLiteProviderReadFixture(t)
@@ -497,6 +871,16 @@ func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 		Machine: "devbox",
 	})
 	require.True(t, ok)
+	relevance, err := ResolveChangedPathRelevance(
+		context.Background(), provider, ChangedPathRequest{
+			Path:      filepath.Join(root, "storage", "project", "global.json"),
+			EventKind: "write",
+			WatchRoot: root,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, ChangedPathUnclassified, relevance,
+		"SQLite-only roots must ignore file-backed project metadata events")
 
 	plan, err := provider.WatchPlan(context.Background())
 	require.NoError(t, err)
@@ -1129,6 +1513,55 @@ func TestOpenCodeFamilyProviderRelabelsForks(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, removed, 1)
 			assert.Equal(t, sessionPath, removed[0].DisplayPath)
+		})
+	}
+}
+
+func TestOpenCodeFamilyProviderFallsBackToProjectMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		agent         AgentType
+		sessionSubdir string
+		prefix        string
+	}{
+		{agent: AgentKilo, sessionSubdir: "session", prefix: "kilo:"},
+		{agent: AgentMiMoCode, sessionSubdir: "session_diff", prefix: "mimocode:"},
+		{agent: AgentIcodemate, sessionSubdir: "session_diff", prefix: "icodemate:"},
+	} {
+		t.Run(string(tc.agent), func(t *testing.T) {
+			root := t.TempDir()
+			const projectID = "global"
+			const sessionID = "ses-project-fallback"
+			sessionPath := writeOpenCodeProviderStorageSession(
+				t, root, tc.sessionSubdir, sessionID, "fork-app", "Fallback",
+			)
+			writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+				"id": sessionID, "projectID": projectID, "title": "Fallback",
+				"time": map[string]any{
+					"created": int64(1700000000000),
+					"updated": int64(1700000060000),
+				},
+			})
+			writeOpenCodeStorageFile(t, filepath.Join(
+				root, "storage", "project", projectID+".json",
+			), map[string]any{
+				"id": projectID, "worktree": "/home/user/code/fork-app",
+			})
+
+			provider, ok := NewProvider(tc.agent, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			discovered, err := provider.Discover(t.Context())
+			require.NoError(t, err)
+			require.Len(t, discovered, 1)
+			source := discovered[0]
+			assert.Equal(t, "fork_app", source.ProjectHint)
+			outcome, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+			require.NoError(t, err)
+			require.Len(t, outcome.Results, 1)
+			result := outcome.Results[0].Result
+			assert.Equal(t, tc.agent, result.Session.Agent)
+			assert.Equal(t, tc.prefix+sessionID, result.Session.ID)
+			assert.Equal(t, "/home/user/code/fork-app", result.Session.Cwd)
+			assert.Equal(t, "fork_app", result.Session.Project)
 		})
 	}
 }

--- a/internal/parser/opencode_storage_state.go
+++ b/internal/parser/opencode_storage_state.go
@@ -4,7 +4,9 @@ package parser
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,6 +43,34 @@ func StatOpenCodeStorageSessionState(sessionPath string) (string, bool) {
 		"session", filepath.Base(sessionPath),
 		info.Size(), info.ModTime().UnixNano(),
 	)
+	var session struct {
+		Directory string `json:"directory"`
+	}
+	raw, err := os.ReadFile(sessionPath)
+	if err != nil || json.Unmarshal(raw, &session) != nil {
+		return "", false
+	}
+	if !openCodeUsableWorktree(strings.TrimSpace(session.Directory)) {
+		projectPath := openCodeProjectPath(sessionPath)
+		projectInfo, projectErr := os.Stat(projectPath)
+		if projectErr == nil {
+			if !projectInfo.Mode().IsRegular() {
+				return "", false
+			}
+			projectRaw, err := os.ReadFile(projectPath)
+			if err != nil {
+				return "", false
+			}
+			record("project", filepath.Base(projectPath),
+				projectInfo.Size(), projectInfo.ModTime().UnixNano())
+			record("project-content", filepath.Base(projectPath),
+				int64(len(projectRaw)), int64(crc32.ChecksumIEEE(projectRaw)))
+		} else if !os.IsNotExist(projectErr) {
+			return "", false
+		} else {
+			record("project-missing", filepath.Base(projectPath), 0, 0)
+		}
+	}
 
 	root := filepath.Dir(filepath.Dir(filepath.Dir(
 		filepath.Dir(sessionPath),

--- a/internal/parser/opencode_storage_state_test.go
+++ b/internal/parser/opencode_storage_state_test.go
@@ -15,6 +15,17 @@ func TestStatOpenCodeStorageSessionState(t *testing.T) {
 	sessionPath := writeOpenCodeProviderStorageSession(
 		t, root, "session", "ses_state", "state-app", "State Session",
 	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": "ses_state", "title": "State Session",
+		"time": map[string]any{
+			"created": int64(1700000000000),
+			"updated": int64(1700000060000),
+		},
+	})
+	projectPath := filepath.Join(root, "storage", "project", "global.json")
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": "state-app", "worktree": "/home/user/code/state-app",
+	})
 
 	state, ok := StatOpenCodeStorageSessionState(sessionPath)
 	require.True(t, ok, "state capture must succeed")
@@ -23,6 +34,17 @@ func TestStatOpenCodeStorageSessionState(t *testing.T) {
 	again, ok := StatOpenCodeStorageSessionState(sessionPath)
 	require.True(t, ok)
 	assert.Equal(t, state, again, "untouched tree must produce equal states")
+
+	t.Run("project content changes state", func(t *testing.T) {
+		writeOpenCodeStorageFile(t, projectPath, map[string]any{
+			"id": "state-app", "worktree": "/home/user/code/changed-app",
+		})
+		next, ok := StatOpenCodeStorageSessionState(sessionPath)
+		require.True(t, ok)
+		assert.NotEqual(t, state, next,
+			"project metadata content must invalidate the session state")
+		state = next
+	})
 
 	t.Run("added part changes state", func(t *testing.T) {
 		writeOpenCodeStorageFile(t, filepath.Join(
@@ -108,4 +130,21 @@ func TestStatOpenCodeStorageSessionStateWithoutMessages(t *testing.T) {
 	again, ok := StatOpenCodeStorageSessionState(sessionPath)
 	require.True(t, ok)
 	assert.Equal(t, state, again)
+}
+
+func TestStatOpenCodeStorageSessionStateSkipsUnusedProjectMetadata(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	sessionPath := writeOpenCodeProviderStorageSession(
+		t, root, "session", "ses_directory", "directory-app", "Directory Session",
+	)
+	projectPath := filepath.Join(root, "storage", "project", "global.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(projectPath), 0o755))
+	require.NoError(t, os.WriteFile(projectPath, []byte("{"), 0o644))
+
+	state, ok := StatOpenCodeStorageSessionState(sessionPath)
+	require.True(t, ok,
+		"a usable session directory must not depend on unused project metadata")
+	require.NotEmpty(t, state)
 }

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -293,6 +294,65 @@ func writeOpenCodeStorageFile(
 	require.NoError(t, os.WriteFile(path, raw, 0o644), "write %s", path)
 }
 
+func BenchmarkOpenCodeStorageSessionFingerprint(b *testing.B) {
+	for _, messageCount := range []int{1, 100, 1000} {
+		b.Run(fmt.Sprintf("messages_%d", messageCount), func(b *testing.B) {
+			root := b.TempDir()
+			sessionPath := filepath.Join(
+				root, "storage", "session", "benchmark-project", "ses_benchmark.json",
+			)
+			writeFile := func(path string, data []byte) {
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					b.Fatal(err)
+				}
+				if err := os.WriteFile(path, data, 0o644); err != nil {
+					b.Fatal(err)
+				}
+			}
+			writeFile(sessionPath, []byte(`{"id":"ses_benchmark","directory":"/work/benchmark","title":"Benchmark","time":{"created":1700000000000,"updated":1700000060000}}`))
+			for messageIndex := range messageCount {
+				messageID := fmt.Sprintf("msg_%04d", messageIndex)
+				writeFile(
+					filepath.Join(root, "storage", "message", "ses_benchmark", messageID+".json"),
+					fmt.Appendf(nil,
+						`{"id":%q,"sessionID":"ses_benchmark","role":%q,"time":{"created":%d}}`,
+						messageID,
+						map[bool]string{true: "assistant", false: "user"}[messageIndex%2 == 1],
+						1700000000000+int64(messageIndex)*1000,
+					),
+				)
+				for partIndex := range 4 {
+					partID := fmt.Sprintf("part_%04d_%d", messageIndex, partIndex)
+					partType := "text"
+					if partIndex == 3 {
+						partType = "reasoning"
+					}
+					writeFile(
+						filepath.Join(root, "storage", "part", messageID, partID+".json"),
+						fmt.Appendf(nil,
+							`{"id":%q,"sessionID":"ses_benchmark","messageID":%q,"type":%q,"text":"benchmark content","time":{"created":%d}}`,
+							partID, messageID, partType,
+							1700000000000+int64(messageIndex)*1000+int64(partIndex),
+						),
+					)
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				hash, err := openCodeStorageSessionFingerprint(sessionPath)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if hash == "" {
+					b.Fatal("expected fingerprint")
+				}
+			}
+		})
+	}
+}
+
 func TestParseOpenCodeDB_StandardSession(t *testing.T) {
 	dbPath, seeder, db := newTestDB(t)
 	defer db.Close()
@@ -444,6 +504,10 @@ func TestParseOpenCodeFile_StorageSession(t *testing.T) {
 	assertEq(t, "File.Mtime", sess.File.Mtime > 0, true)
 
 	assertEq(t, "messages len", len(msgs), 2)
+	fingerprint, err := openCodeStorageSessionFingerprint(sessionPath)
+	require.NoError(t, err)
+	assert.Equal(t, sess.File.Hash, fingerprint,
+		"fingerprinting and parsing must stamp the same raw storage identity")
 	assertEq(t, "msg[0].Role", msgs[0].Role, RoleUser)
 	assertEq(t, "msg[0].Content", msgs[0].Content, "Hello from storage")
 	assertEq(t, "msg[1].Role", msgs[1].Role, RoleAssistant)
@@ -459,6 +523,489 @@ func TestParseOpenCodeFile_StorageSession(t *testing.T) {
 		ToolUseID: "call_storage",
 		InputJSON: `{"file_path":"main.go"}`,
 	}})
+}
+
+func TestOpenCodeStorageEmptySessionKeepsSkipAndFingerprint(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "storage", "session", "global", "ses_empty.json")
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": "ses_empty",
+		"time": map[string]any{
+			"created": int64(1700000000000),
+			"updated": int64(1700000000000),
+		},
+	})
+
+	sess, messages, err := parseOpenCodeStorageFile(sessionPath, "")
+	require.NoError(t, err)
+	assert.Nil(t, sess)
+	assert.Empty(t, messages)
+
+	fingerprint, err := openCodeStorageSessionFingerprint(sessionPath)
+	require.NoError(t, err)
+	assert.Empty(t, fingerprint)
+
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "message", "ses_empty", "msg_in_progress.json",
+	), map[string]any{
+		"id": "msg_in_progress", "sessionID": "ses_empty", "role": "user",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	sess, messages, err = parseOpenCodeStorageFile(sessionPath, "")
+	require.NoError(t, err)
+	assert.Nil(t, sess)
+	assert.Empty(t, messages)
+	fingerprint, err = openCodeStorageSessionFingerprint(sessionPath)
+	require.NoError(t, err)
+	assert.Empty(t, fingerprint)
+
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "part", "msg_in_progress", "part_whitespace.json",
+	), map[string]any{
+		"id": "part_whitespace", "sessionID": "ses_empty",
+		"messageID": "msg_in_progress", "type": "text", "text": "   ",
+	})
+	sess, messages, err = parseOpenCodeStorageFile(sessionPath, "")
+	require.NoError(t, err)
+	assert.Nil(t, sess)
+	assert.Empty(t, messages)
+	fingerprint, err = openCodeStorageSessionFingerprint(sessionPath)
+	require.NoError(t, err)
+	assert.Empty(t, fingerprint)
+}
+
+func TestOpenCodeStorageFingerprintSerializationIsStable(t *testing.T) {
+	got := buildOpenCodeSessionFingerprint(
+		openCodeSessionRow{
+			id: "ses_fixed", timeCreated: 100, timeUpdated: 200,
+		},
+		"/work/fixed", "/work/fixed",
+		[]openCodeMessageRow{{
+			id: "msg_1", data: `{"role":"user"}`, timeCreated: 300,
+		}},
+		map[string][]openCodePartRow{
+			"msg_1": {{
+				id: "part_1", data: `{"type":"text","text":"hello"}`,
+				timeCreated: 301,
+			}},
+		},
+	)
+	assert.Equal(t,
+		`opencode-storage:v1:{"session":{"id":"ses_fixed","directory":"/work/fixed","worktree":"/work/fixed","time_created":100,"time_updated":200},"messages":[{"id":"msg_1","time":300,"hash":"6b3061507ef8cc2ca95320f790a9f9ccb3c850ae081df4b6f6e56e40d57203e4","parts":[{"id":"part_1","time":301,"hash":"59aeafa564efb2dec1ad26be01872d3ac132e96fc9cb3b53cba4c62cde0dc188"}]}]}`,
+		got,
+	)
+}
+
+func TestOpenCodeStorageFingerprintAvoidsNormalizedParseAllocations(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	sessionPath := writeOpenCodeProviderStorageSession(
+		t, root, "session", "ses_allocations", "allocations-app", "Allocations",
+	)
+
+	fingerprintAllocs := testing.AllocsPerRun(5, func() {
+		hash, err := openCodeStorageSessionFingerprint(sessionPath)
+		if err != nil {
+			t.Fatalf("fingerprint: %v", err)
+		}
+		if hash == "" {
+			t.Fatal("expected fingerprint")
+		}
+	})
+	parseAllocs := testing.AllocsPerRun(5, func() {
+		sess, _, err := parseOpenCodeStorageFile(sessionPath, "testmachine")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if sess == nil {
+			t.Fatal("expected parsed session")
+		}
+	})
+
+	assert.Less(t, fingerprintAllocs, parseAllocs,
+		"raw fingerprinting should avoid normalized session allocation")
+}
+
+func TestParseOpenCodeFile_LegacySessionUsesProjectWorktree(t *testing.T) {
+	const projectID = "legacy-project"
+	const sessionID = "ses_legacy"
+	root := t.TempDir()
+	sessionPath := filepath.Join(
+		root, "storage", "session", projectID, sessionID+".json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": sessionID, "title": "Legacy", "time": map[string]any{
+			"created": int64(1700000000000), "updated": int64(1700000060000),
+		},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "project", projectID+".json",
+	), map[string]any{
+		"id": projectID, "vcs": "git", "worktree": "/home/user/code/legacy-app",
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(root, "storage", "message", "ses_legacy", "msg_1.json"), map[string]any{
+		"id": "msg_1", "sessionID": "ses_legacy", "role": "user",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(root, "storage", "part", "msg_1", "part_1.json"), map[string]any{
+		"id": "part_1", "sessionID": "ses_legacy", "messageID": "msg_1",
+		"type": "text", "text": "hello", "time": map[string]any{"created": int64(1700000000000)},
+	})
+
+	sess, _, err := parseOpenCodeStorageFile(sessionPath, "machine")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "/home/user/code/legacy-app", sess.Cwd)
+	assert.Equal(t, "legacy_app", sess.Project)
+
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": "ses_legacy", "directory": "/home/user/code/session-app", "title": "Legacy",
+		"time": map[string]any{"created": int64(1700000000000), "updated": int64(1700000060000)},
+	})
+	sess, _, err = parseOpenCodeStorageFile(sessionPath, "machine")
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/code/session-app", sess.Cwd)
+	assert.Equal(t, "session_app", sess.Project)
+}
+
+func TestOpenCodeStorageFingerprintTracksRawRows(t *testing.T) {
+	root := t.TempDir()
+	const (
+		projectID = "fingerprint-project"
+		sessionID = "ses_fingerprint"
+	)
+	sessionPath := filepath.Join(
+		root, "storage", "session", projectID, sessionID+".json",
+	)
+	projectPath := filepath.Join(
+		root, "storage", "project", projectID+".json",
+	)
+	messagePath := filepath.Join(
+		root, "storage", "message", sessionID, "msg_1.json",
+	)
+	partPath := filepath.Join(
+		root, "storage", "part", "msg_1", "part_1.json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": sessionID, "title": "Fingerprint session",
+		"time": map[string]any{
+			"created": int64(1700000000000),
+			"updated": int64(1700000060000),
+		},
+	})
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": projectID, "worktree": "/work/fingerprint-app",
+	})
+	writeOpenCodeStorageFile(t, messagePath, map[string]any{
+		"id": "msg_1", "sessionID": sessionID, "role": "user",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	writeOpenCodeStorageFile(t, partPath, map[string]any{
+		"id": "part_1", "sessionID": sessionID, "messageID": "msg_1",
+		"type": "text", "text": "fingerprint content",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+
+	baseline, err := openCodeStorageSessionFingerprint(sessionPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, baseline)
+	sess, _, err := parseOpenCodeStorageFile(sessionPath, "testmachine")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, baseline, sess.File.Hash)
+
+	tests := []struct {
+		name string
+		path string
+		data map[string]any
+	}{
+		{
+			name: "session",
+			path: sessionPath,
+			data: map[string]any{
+				"id": sessionID, "title": "Changed fingerprint session",
+				"time": map[string]any{
+					"created": int64(1700000000000),
+					"updated": int64(1700000060000),
+				},
+			},
+		},
+		{
+			name: "project",
+			path: projectPath,
+			data: map[string]any{
+				"id": projectID, "worktree": "/work/changed-fingerprint-app",
+			},
+		},
+		{
+			name: "message",
+			path: messagePath,
+			data: map[string]any{
+				"id": "msg_1", "sessionID": sessionID, "role": "assistant",
+				"time": map[string]any{"created": int64(1700000000000)},
+			},
+		},
+		{
+			name: "part",
+			path: partPath,
+			data: map[string]any{
+				"id": "part_1", "sessionID": sessionID, "messageID": "msg_1",
+				"type": "text", "text": "changed fingerprint content",
+				"time": map[string]any{"created": int64(1700000000000)},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			original, err := os.ReadFile(tc.path)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, os.WriteFile(tc.path, original, 0o644))
+			})
+			writeOpenCodeStorageFile(t, tc.path, tc.data)
+			changed, err := openCodeStorageSessionFingerprint(sessionPath)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseline, changed)
+		})
+	}
+}
+
+func TestResolveOpenCodeWorktreeUsesSharedPrecedence(t *testing.T) {
+	tests := []struct {
+		name             string
+		sessionDirectory string
+		projectWorktree  string
+		want             string
+	}{
+		{
+			name:             "session directory wins",
+			sessionDirectory: "/work/session",
+			projectWorktree:  "/work/project",
+			want:             "/work/session",
+		},
+		{
+			name:            "project fallback",
+			projectWorktree: "/work/project",
+			want:            "/work/project",
+		},
+		{
+			name:             "trimmed root falls back to project",
+			sessionDirectory: " / ",
+			projectWorktree:  "/work/project",
+			want:             "/work/project",
+		},
+		{
+			name:            "global root is unusable",
+			projectWorktree: "/",
+			want:            "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, resolveOpenCodeWorktree(
+				test.sessionDirectory, test.projectWorktree,
+			))
+		})
+	}
+}
+
+func TestResolveOpenCodeStorageWorktreeTrimsSessionDirectory(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(
+		root, "storage", "session", "legacy-project", "ses_legacy.json",
+	)
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "project", "legacy-project.json",
+	), map[string]any{
+		"worktree": "/work/project",
+	})
+
+	got, err := resolveOpenCodeStorageWorktree(sessionPath, " / ")
+	require.NoError(t, err)
+	assert.Equal(t, "/work/project", got)
+}
+
+func TestParseOpenCodeFile_LegacySessionMissingProjectFallback(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "storage", "session", "legacy-project", "ses_legacy.json")
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": "ses_legacy", "title": "Legacy", "time": map[string]any{
+			"created": int64(1700000000000), "updated": int64(1700000060000),
+		},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(root, "storage", "message", "ses_legacy", "msg_1.json"), map[string]any{
+		"id": "msg_1", "sessionID": "ses_legacy", "role": "user",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(root, "storage", "part", "msg_1", "part_1.json"), map[string]any{
+		"id": "part_1", "sessionID": "ses_legacy", "messageID": "msg_1",
+		"type": "text", "text": "hello", "time": map[string]any{"created": int64(1700000000000)},
+	})
+
+	sess, _, err := parseOpenCodeStorageFile(sessionPath, "machine")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Empty(t, sess.Cwd)
+	assert.Equal(t, "unknown", sess.Project)
+}
+
+func TestParseOpenCodeFile_LegacySessionMalformedProjectReturnsScopedError(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "storage", "session", "legacy-project", "ses_legacy.json")
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": "ses_legacy", "title": "Legacy", "time": map[string]any{
+			"created": int64(1700000000000), "updated": int64(1700000060000),
+		},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(root, "storage", "message", "ses_legacy", "msg_1.json"), map[string]any{
+		"id": "msg_1", "sessionID": "ses_legacy", "role": "user",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(root, "storage", "part", "msg_1", "part_1.json"), map[string]any{
+		"id": "part_1", "sessionID": "ses_legacy", "messageID": "msg_1",
+		"type": "text", "text": "hello", "time": map[string]any{"created": int64(1700000000000)},
+	})
+	require.NoError(t, os.MkdirAll(filepath.Dir(openCodeProjectPath(sessionPath)), 0o755))
+	writeOpenCodeStorageFile(t, openCodeProjectPath(sessionPath), map[string]any{
+		"id": "legacy-project", "worktree": "/home/user/code/legacy-app",
+	})
+
+	require.NoError(t, os.WriteFile(
+		openCodeProjectPath(sessionPath), []byte("{"), 0o644,
+	))
+
+	sess, msgs, err := parseOpenCodeStorageFile(sessionPath, "machine")
+	assert.Error(t, err)
+	assert.Nil(t, sess)
+	assert.Nil(t, msgs)
+	_, fingerprintErr := openCodeStorageSessionFingerprint(sessionPath)
+	assert.Error(t, fingerprintErr)
+	assert.Contains(t, fingerprintErr.Error(), "decoding opencode project file")
+}
+
+func TestParseOpenCodeFile_LegacySessionUnreadableProjectReturnsScopedError(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(
+		root, "storage", "session", "legacy-project", "ses_legacy.json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": "ses_legacy", "title": "Legacy", "time": map[string]any{
+			"created": int64(1700000000000), "updated": int64(1700000060000),
+		},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "message", "ses_legacy", "msg_1.json",
+	), map[string]any{
+		"id": "msg_1", "sessionID": "ses_legacy", "role": "user",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "part", "msg_1", "part_1.json",
+	), map[string]any{
+		"id": "part_1", "sessionID": "ses_legacy", "messageID": "msg_1",
+		"type": "text", "text": "hello",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	projectPath := openCodeProjectPath(sessionPath)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+
+	sess, msgs, err := parseOpenCodeStorageFile(sessionPath, "machine")
+	assert.Error(t, err)
+	assert.Nil(t, sess)
+	assert.Nil(t, msgs)
+	assert.Contains(t, err.Error(), "reading opencode project file")
+	_, fingerprintErr := openCodeStorageSessionFingerprint(sessionPath)
+	assert.Error(t, fingerprintErr)
+	assert.Contains(t, fingerprintErr.Error(), "reading opencode project file")
+}
+
+func TestOpenCodeStorageMtimeUsesProjectOnlyForFallback(t *testing.T) {
+	concreteRoot := t.TempDir()
+	concretePath := writeOpenCodeProviderStorageSession(
+		t, concreteRoot, "session", "ses_directory_mtime", "directory-app", "Directory",
+	)
+	concreteProjectPath := openCodeProjectPath(concretePath)
+	writeOpenCodeStorageFile(t, concreteProjectPath, map[string]any{
+		"id": "global", "worktree": "/work/unused",
+	})
+	concreteBefore, err := OpenCodeSourceMtime(concretePath)
+	require.NoError(t, err)
+	future := time.Unix(1810000000, 123456789)
+	require.NoError(t, os.Chtimes(
+		concreteProjectPath, future, future,
+	))
+	concreteAfter, err := OpenCodeSourceMtime(concretePath)
+	require.NoError(t, err)
+	assert.Equal(t, concreteBefore, concreteAfter,
+		"unused project metadata must not refresh a session with a concrete directory")
+
+	fallbackRoot := t.TempDir()
+	fallbackPath := filepath.Join(
+		fallbackRoot, "storage", "session", "global", "ses_fallback_mtime.json",
+	)
+	fallbackProjectPath := openCodeProjectPath(fallbackPath)
+	writeOpenCodeStorageFile(t, fallbackPath, map[string]any{
+		"id":   "ses_fallback_mtime",
+		"time": map[string]any{"created": int64(1700000000000)},
+	})
+	writeOpenCodeStorageFile(t, fallbackProjectPath, map[string]any{
+		"id": "global", "worktree": "/work/fallback",
+	})
+	fallbackBefore, err := OpenCodeSourceMtime(fallbackPath)
+	require.NoError(t, err)
+	future = time.Unix(1810000100, 123456789)
+	require.NoError(t, os.Chtimes(
+		fallbackProjectPath, future, future,
+	))
+	fallbackAfter, err := OpenCodeSourceMtime(fallbackPath)
+	require.NoError(t, err)
+	assert.Greater(t, fallbackAfter, fallbackBefore,
+		"project metadata must refresh a legacy session without a directory")
+}
+
+func TestStatOpenCodeStorageSessionStateTracksProjectContentRewrite(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(
+		root, "storage", "session", "legacy-project", "ses_state.json",
+	)
+	projectPath := filepath.Join(
+		root, "storage", "project", "legacy-project.json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id": "ses_state", "time": map[string]any{
+			"created": int64(1700000000000), "updated": int64(1700000060000),
+		},
+	})
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": "legacy-project", "worktree": "/home/user/code/old-app",
+	})
+
+	before, ok := StatOpenCodeStorageSessionState(sessionPath)
+	require.True(t, ok)
+	info, err := os.Stat(projectPath)
+	require.NoError(t, err)
+	writeOpenCodeStorageFile(t, projectPath, map[string]any{
+		"id": "legacy-project", "worktree": "/home/user/code/new-app",
+	})
+	afterInfo, err := os.Stat(projectPath)
+	require.NoError(t, err)
+	require.Equal(t, info.Size(), afterInfo.Size())
+	require.NoError(t, os.Chtimes(
+		projectPath, info.ModTime(), info.ModTime(),
+	))
+
+	after, ok := StatOpenCodeStorageSessionState(sessionPath)
+	require.True(t, ok)
+	assert.NotEqual(t, before, after,
+		"project content must invalidate equal-size, preserved-mtime state")
+	t.Logf("project state changed after equal-size rewrite with preserved mtime")
 }
 
 func TestParseOpenCodeFile_StorageSessionInvalidChildFails(
@@ -518,6 +1065,9 @@ func TestParseOpenCodeFile_StorageSessionInvalidChildFails(
 	require.Error(t, err, "expected parseOpenCodeStorageFile error")
 	assert.Nil(t, sess, "session, want nil")
 	assert.Nil(t, msgs, "msgs, want nil")
+	_, fingerprintErr := openCodeStorageSessionFingerprint(sessionPath)
+	assert.Error(t, fingerprintErr)
+	assert.Contains(t, fingerprintErr.Error(), "decoding opencode message file")
 }
 
 func TestParseOpenCodeFile_MissingPartDirAllowed(t *testing.T) {
@@ -584,6 +1134,9 @@ func TestParseOpenCodeFile_StorageMessageMissingIDFails(t *testing.T) {
 	require.Error(t, err, "expected parseOpenCodeStorageFile error")
 	assert.Nil(t, sess, "session, want nil")
 	assert.Nil(t, msgs, "msgs, want nil")
+	_, fingerprintErr := openCodeStorageSessionFingerprint(sessionPath)
+	assert.Error(t, fingerprintErr)
+	assert.Contains(t, fingerprintErr.Error(), "missing id")
 }
 
 func TestParseOpenCodeFile_StoragePartMissingIDFails(t *testing.T) {
@@ -627,6 +1180,9 @@ func TestParseOpenCodeFile_StoragePartMissingIDFails(t *testing.T) {
 	require.Error(t, err, "expected parseOpenCodeStorageFile error")
 	assert.Nil(t, sess, "session, want nil")
 	assert.Nil(t, msgs, "msgs, want nil")
+	_, fingerprintErr := openCodeStorageSessionFingerprint(sessionPath)
+	assert.Error(t, fingerprintErr)
+	assert.Contains(t, fingerprintErr.Error(), "missing id")
 }
 
 func TestParseOpenCodeFile_StoragePartOrderingUsesStartTime(
@@ -1226,10 +1782,10 @@ func TestResolveOpenCodeWorktree(t *testing.T) {
 			want:    "/home/user/code/myapp",
 		},
 		{
-			name:    "keeps project root when session unusable",
+			name:    "normalizes project root when session unusable",
 			session: "/",
 			project: "/",
-			want:    "/",
+			want:    "",
 		},
 	}
 	for _, tt := range tests {
@@ -1326,6 +1882,54 @@ func TestParseOpenCodeDB_EmptySessionDirectoryUsesProjectWorktree(t *testing.T) 
 	s := sessions[0].Session
 	assert.Equal(t, "/home/user/code/myapp", s.Cwd)
 	assert.Equal(t, "myapp", s.Project)
+}
+
+func TestParseOpenCodeDB_EmptySessionDirectoryPreservesSQLiteRootWorktree(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_global", "/")
+	seeder.AddSessionDirectory(
+		"ses_global", "prj_global", "", "Global Project", "",
+		1700000000000, 1700000010000,
+	)
+	seeder.AddMessage("msg_global", "ses_global", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart(
+		"prt_global", "msg_global", "ses_global", 1700000000000, 1700000000000,
+		`{"type":"text","text":"hello"}`,
+	)
+
+	sessions, err := parseOpenCodeAll(dbPath, "testmachine")
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "/", sessions[0].Session.Cwd)
+}
+
+func TestParseOpenCodeDB_RootSessionDirectoryPreservesSQLiteRootWorktree(
+	t *testing.T,
+) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_global", "/")
+	seeder.AddSessionDirectory(
+		"ses_global_root", "prj_global", "", "Global Project", "/",
+		1700000000000, 1700000010000,
+	)
+	seeder.AddMessage(
+		"msg_global_root", "ses_global_root", 1700000000000,
+		1700000000000, `{"role":"user"}`,
+	)
+	seeder.AddPart(
+		"prt_global_root", "msg_global_root", "ses_global_root",
+		1700000000000, 1700000000000,
+		`{"type":"text","text":"hello"}`,
+	)
+
+	sessions, err := parseOpenCodeAll(dbPath, "testmachine")
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "/", sessions[0].Session.Cwd)
 }
 
 // openCodeSchemaLegacy omits session.directory, matching older OpenCode-family

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	gosync "sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1112,6 +1113,95 @@ func TestSyncEngineOpenCodeStorageWatcherEventDoesNotRewriteUnchanged(
 	final := openCodeLocalModifiedSnapshot(t, env.db, fullID)
 	assert.NotEqual(t, after[fullID], final[fullID],
 		"a real content change must rewrite the session")
+}
+
+type openCodeStorageParseCountingProvider struct {
+	parser.Provider
+	parseCalls atomic.Int64
+}
+
+func (p *openCodeStorageParseCountingProvider) Parse(
+	ctx context.Context, req parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	p.parseCalls.Add(1)
+	return p.Provider.Parse(ctx, req)
+}
+
+type openCodeStorageParseCountingFactory struct {
+	provider *openCodeStorageParseCountingProvider
+}
+
+func (f openCodeStorageParseCountingFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f openCodeStorageParseCountingFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f openCodeStorageParseCountingFactory) NewProvider(
+	parser.ProviderConfig,
+) parser.Provider {
+	return f.provider
+}
+
+// A fresh engine has no in-memory storage-tree trust, so it fingerprints each
+// legacy OpenCode session once. The persisted source metadata must then prove
+// an unchanged session fresh without parsing the storage tree a second time.
+func TestSyncAllOpenCodeStorageColdStartSkipsUnchangedParse(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-storage-cold-start"
+	sessionPath := storage.addSession(
+		t, "global", sessionID,
+		"/workspace/oc-app", "Storage Cold Start",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"steady storage reply", 1704067201000,
+	)
+
+	first := env.engine.SyncAll(t.Context(), nil)
+	require.False(t, first.Aborted, "first sync aborted: %+v", first)
+	require.Equal(t, 1, first.Synced, "first sync writes the session")
+
+	innerFactory, ok := parser.ProviderFactoryByType(parser.AgentOpenCode)
+	require.True(t, ok, "OpenCode provider factory registered")
+	inner := innerFactory.NewProvider(parser.ProviderConfig{
+		Roots:   []string{env.opencodeDir},
+		Machine: "local",
+	})
+	counting := &openCodeStorageParseCountingProvider{Provider: inner}
+	restarted := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {env.opencodeDir},
+		},
+		Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{
+			openCodeStorageParseCountingFactory{provider: counting},
+		},
+	})
+	t.Cleanup(restarted.Close)
+
+	stats := restarted.SyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted, "restart sync aborted: %+v", stats)
+	assert.Zero(t, stats.Synced, "unchanged restart must not rewrite the session")
+	assert.Zero(t, counting.parseCalls.Load(),
+		"unchanged restart must stop after fingerprinting")
+
+	stored, err := env.db.GetSessionFull(t.Context(), "opencode:"+sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.NotNil(t, stored.FileSize, "stored file_size")
+	info, err := os.Stat(sessionPath)
+	require.NoError(t, err)
+	assert.Equal(t, info.Size(), *stored.FileSize,
+		"stored file_size must match the fingerprinted session JSON")
 }
 
 // TestSyncEngineOpenCodeStorageStatIdenticalEventStillReemits pins the
@@ -7066,6 +7156,86 @@ func TestSyncEngineOpenCodeDataVersionRefreshesUnchangedCwdProject(
 	assertSessionState(t, env.db, agentviewID, func(sess *db.Session) {
 		assert.Equal(t, "/home/user/code/lonely-app", sess.Cwd)
 		assert.Equal(t, "lonely_app", sess.Project)
+		assert.Equal(t, db.CurrentDataVersion(), sess.DataVersion)
+	})
+}
+
+func TestSyncEngineOpenCodeStorageMalformedProjectPreservesArchive(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-storage-malformed-project"
+	oc.addSession(
+		t, "legacy-project", sessionID, "", "Malformed Project",
+		1704067200000, 1704067205000,
+	)
+	oc.addMessage(t, sessionID, "msg-user", "user", 1704067200000, nil)
+	oc.addTextPart(t, sessionID, "msg-user", "part-user", "question", 1704067200000)
+	projectPath := filepath.Join(
+		env.opencodeDir, "storage", "project", "legacy-project.json",
+	)
+	oc.writeJSON(t, projectPath, map[string]any{
+		"id": "legacy-project", "worktree": "/home/user/code/legacy-app",
+	})
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted)
+	require.Equal(t, 1, stats.Synced)
+	assertSessionState(t, env.db, "opencode:"+sessionID, func(sess *db.Session) {
+		assert.Equal(t, "/home/user/code/legacy-app", sess.Cwd)
+		assert.Equal(t, "legacy_app", sess.Project)
+	})
+
+	require.NoError(t, os.WriteFile(projectPath, []byte("{"), 0o644))
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(projectPath, future, future))
+	err := env.engine.SyncPathsContext(
+		context.Background(), []string{projectPath},
+	)
+	require.Error(t, err, "malformed project metadata must be reported by scoped sync")
+	assertSessionState(t, env.db, "opencode:"+sessionID, func(sess *db.Session) {
+		assert.Equal(t, "/home/user/code/legacy-app", sess.Cwd)
+		assert.Equal(t, "legacy_app", sess.Project)
+	})
+}
+
+func TestSyncEngineOpenCodeStorageDataVersionRefreshesArchivedCwdProject(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-storage-data-version-project"
+	oc.addSession(
+		t, "legacy-project", sessionID, "", "Data Version Project",
+		1704067200000, 1704067205000,
+	)
+	oc.addMessage(t, sessionID, "msg-user", "user", 1704067200000, nil)
+	oc.addTextPart(t, sessionID, "msg-user", "part-user", "question", 1704067200000)
+	projectPath := filepath.Join(
+		env.opencodeDir, "storage", "project", "legacy-project.json",
+	)
+	oc.writeJSON(t, projectPath, map[string]any{
+		"id": "legacy-project", "worktree": "/home/user/code/legacy-app",
+	})
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1, Skipped: 0,
+	})
+	stored := openCodeStoredSession(t, env.db, "opencode:"+sessionID)
+	stored.Cwd = ""
+	stored.Project = "unknown"
+	require.NoError(t, env.db.UpsertSession(*stored))
+	require.NoError(t, env.db.SetSessionDataVersion(
+		"opencode:"+sessionID, db.CurrentDataVersion()-1,
+	))
+
+	require.NoError(t, env.engine.SyncPathsContext(
+		context.Background(), []string{projectPath},
+	))
+	assertSessionState(t, env.db, "opencode:"+sessionID, func(sess *db.Session) {
+		assert.Equal(t, "/home/user/code/legacy-app", sess.Cwd)
+		assert.Equal(t, "legacy_app", sess.Project)
 		assert.Equal(t, db.CurrentDataVersion(), sess.DataVersion)
 	})
 }


### PR DESCRIPTION
Legacy OpenCode sessions now use the matching project metadata worktree when their session file has no directory, so cwd and project are restored. File-backed storage fingerprints derive their identity from raw session, project, message, and part rows before normalization, so cold freshness checks do not build a discarded transcript before parsing the session. The provider-factory-owned project index keeps project refreshes bounded across provider instances, and sources with carried discovery mtime avoid a second composite-mtime traversal. Existing session-directory precedence, provider labels, SQLite behavior, and project-scoped refreshes remain intact.

Closes #1248