### PR TITLE
ci: retry failed Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,29 @@ jobs:
             org.opencontainers.image.description=Local web viewer for AI agent sessions
 
       - name: Build and push Docker image
+        id: build
+        continue-on-error: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.vars.outputs.version }}
+            COMMIT=${{ steps.vars.outputs.commit }}
+            BUILD_DATE=${{ steps.vars.outputs.build_date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Wait before retrying Docker build
+        if: steps.build.outcome == 'failure'
+        run: sleep 15
+
+      - name: Retry build and push Docker image
+        if: steps.build.outcome == 'failure'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .


### PR DESCRIPTION
Transient container registry errors could stop image publication before the
Dockerfile starts. The Docker workflow now retries the full multi-platform
build once after a 15-second delay with the same image configuration.

Deterministic failures may take one extra attempt to surface. A second failure
still fails the job; registry mirrors and Dockerfile changes remain out of
scope.
