### PR TITLE
Bring the benchmark gate under 20 minutes and fix GetDailyUsage slowdown

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,8 +1,7 @@
 name: Bench Gate
 
-# The PR dispatcher always calls the main-pinned workflow. That workflow
-# independently routes same-repository Linux jobs to the managed public fleet
-# and fork jobs to GitHub-hosted runners.
+# The PR dispatcher always calls the main-pinned workflow, which runs
+# on GitHub-hosted runners for every PR.
 on:
   pull_request:
     # Docs/frontend-only PRs cannot change the gated Go paths. If

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,7 +40,11 @@ permissions:
 jobs:
   bench-gate:
     name: Benchmark Gate
-    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    # Always GitHub-hosted, unlike the rest of CI: both sides of the
+    # comparison run on the same runner within one job, so absolute
+    # speed is what matters, and ubuntu-latest runs this I/O-heavy
+    # workload 2-4x faster than the managed fleet.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -50,7 +54,6 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
-          cache: ${{ github.repository == 'kenn-io/agentsview' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Run benchmarks (PR head)
         run: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,7 +14,7 @@ name: Bench Gate
 #
 # Both sides run `make bench-gate` — the Makefile is the single
 # source of truth for the gated package list, sample count, and
-# iteration count — and cmd/benchgate compares the outputs. It gates
+# per-tier iteration counts — and cmd/benchgate compares the outputs. It gates
 # on allocs/op and B/op (deterministic on a given machine, tight
 # thresholds) and on ns/op with a loose 2x threshold that only
 # catches algorithmic blowups; both sides run on the same runner
@@ -67,11 +67,13 @@ jobs:
         # exists on both sides. The warning makes the degraded run
         # visible instead of a silently green vacuous pass.
         #
-        # The sample count and fixed iteration count are evaluated
-        # from the PR head's Makefile and passed into the base run:
-        # two benchmarks grow their fixture per iteration, so a PR
-        # that changes BENCH_GATE_COUNT/TIME must not compare against
-        # a baseline measured with the old values. The package list
+        # The sample count, fixed iteration counts, and heavy-tier
+        # regex are evaluated from the PR head's Makefile and passed
+        # into the base run: two benchmarks grow their fixture per
+        # iteration, so a PR that changes BENCH_GATE_COUNT/TIME or
+        # moves a benchmark between tiers must not compare against a
+        # baseline measured with the old values. A base Makefile that
+        # predates a variable simply ignores it. The package list
         # intentionally stays per-side, so growing the gate cannot
         # break the base run.
         run: |
@@ -81,7 +83,9 @@ jobs:
           git worktree add /tmp/bench-base "$base"
           if ! make -s -C /tmp/bench-base bench-gate \
               BENCH_GATE_COUNT="$BENCH_GATE_COUNT" \
-              BENCH_GATE_TIME="$BENCH_GATE_TIME" > /tmp/bench-old.txt; then
+              BENCH_GATE_TIME="$BENCH_GATE_TIME" \
+              BENCH_GATE_HEAVY="$BENCH_GATE_HEAVY" \
+              BENCH_GATE_HEAVY_TIME="$BENCH_GATE_HEAVY_TIME" > /tmp/bench-old.txt; then
             echo "::warning title=Bench Gate::merge-base benchmark run exited non-zero; gating against its partial output"
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -317,16 +317,32 @@ bench-backends: pricing-snapshot ensure-embed-dir
 BENCH_GATE_PACKAGES ?= ./internal/sync ./internal/db ./internal/secrets \
 	./internal/signals
 # Count must stay >= 5: benchgate's time gate needs at least 5
-# candidate samples for its significance test.
-BENCH_GATE_COUNT ?= 6
+# candidate samples for its significance test. Every -count run
+# rebuilds each benchmark's fixture, so this is also the multiplier
+# on the 100k-row seeds below.
+BENCH_GATE_COUNT ?= 5
 # Fixed iterations, not a duration: some gated benchmarks grow their
 # fixture as they iterate, so baseline and candidate must run the
 # same iteration count to measure identical workloads.
 BENCH_GATE_TIME ?= 20x
+# Benchmarks whose single iteration costs hundreds of milliseconds to
+# seconds (100k-row usage and activity-report fixtures, cold-archive
+# ingest) run in a second pass with fewer iterations. Their per-op
+# ratios are stable at that scale, and at BENCH_GATE_TIME these few
+# benchmarks were most of the gate's wall clock. The regex is matched
+# against top-level benchmark names, so sub-benchmarks follow their
+# parent; the cheap benchmarks keep the full iteration count because
+# their millisecond-scale samples are what needs the averaging.
+BENCH_GATE_HEAVY ?= GetDailyUsage|SQLiteActivityReport|SyncAllColdArchive|ResyncBulk
+BENCH_GATE_HEAVY_TIME ?= 5x
 bench-gate: pricing-snapshot ensure-embed-dir
 	CGO_ENABLED=1 go test -tags "fts5" -run '^$$' \
-		-bench . -benchmem \
+		-bench . -skip '$(BENCH_GATE_HEAVY)' -benchmem \
 		-count $(BENCH_GATE_COUNT) -benchtime $(BENCH_GATE_TIME) \
+		-timeout 25m $(BENCH_GATE_PACKAGES)
+	CGO_ENABLED=1 go test -tags "fts5" -run '^$$' \
+		-bench '$(BENCH_GATE_HEAVY)' -benchmem \
+		-count $(BENCH_GATE_COUNT) -benchtime $(BENCH_GATE_HEAVY_TIME) \
 		-timeout 25m $(BENCH_GATE_PACKAGES)
 
 # Prints the gate's sample/iteration configuration in shell-evalable
@@ -336,6 +352,7 @@ bench-gate: pricing-snapshot ensure-embed-dir
 # package list intentionally stays per-side).
 bench-gate-config:
 	@echo "BENCH_GATE_COUNT=$(BENCH_GATE_COUNT) BENCH_GATE_TIME=$(BENCH_GATE_TIME)"
+	@echo "BENCH_GATE_HEAVY='$(BENCH_GATE_HEAVY)' BENCH_GATE_HEAVY_TIME=$(BENCH_GATE_HEAVY_TIME)"
 
 # Start test PostgreSQL container
 postgres-up:

--- a/docs/internal/performance-gates.md
+++ b/docs/internal/performance-gates.md
@@ -70,9 +70,9 @@ sessions" or "the manifest is read once per root regardless of session count".
 ### 2. Benchmark gate (runs on every PR via `bench.yml`)
 
 `.github/workflows/bench.yml` runs `make bench-gate` — the single source of
-truth for the gated package list, sample count, and iteration count — on the PR
-head and its merge base on the same runner, then compares the outputs with
-`cmd/benchgate`:
+truth for the gated package list, sample count, and per-tier iteration counts —
+on the PR head and its merge base on the same runner, then compares the outputs
+with `cmd/benchgate`:
 
 - `BenchmarkSyncAllWarmNoop` — full sync over an already-synced archive (stat +
   skip work only; also self-asserts nothing is re-synced or bulk-rewritten).
@@ -90,7 +90,16 @@ head and its merge base on the same runner, then compares the outputs with
 - `BenchmarkReplaceSessionMessagesStreamingMerge` — the streaming chunk-merge
   diff path (one UPDATE, not a full delete+reinsert).
 - `BenchmarkInsertMessagesBatch` — multi-row batched ingest.
+- `BenchmarkResyncBulkContributorIngest` — the same archive entering the atomic
+  rebuild through a contributor engine.
+- `BenchmarkSearchContentSubstringPage` / `BenchmarkSearchContentFTSPage` — one
+  page of content search through the substring and FTS paths.
 - `BenchmarkGetDailyUsage` — usage aggregation over 100k message rows.
+- `BenchmarkSQLiteActivityReportCandidateSource100K`,
+  `BenchmarkSQLiteActivityReportCandidateSourceLongSession`, and
+  `BenchmarkSQLiteActivityReportArtifacts100K` — activity-report candidate
+  streaming and artifact building over 100k sessions or a 100k-message
+  session.
 - `BenchmarkScan` / `BenchmarkScanDefinite` — secret-scan regex throughput.
 - `BenchmarkCountDuplicatePromptsLargeSession` — duplicate-prompt analysis over
   a long session with shared vocabulary and distinct prompt context.
@@ -131,10 +140,19 @@ older or partial — is reported as not gated.
 The gate always runs with a fixed `-benchtime=Nx` iteration count (not a
 duration): two of the benchmarks grow their fixture as they iterate, so the
 baseline and candidate must run the same number of iterations to measure
-identical workloads. CI evaluates `make bench-gate-config` on the PR head and
-passes the count and benchtime into the merge-base run, so a PR that changes
-those defaults still compares identical workloads; do the same locally if you
-override them.
+identical workloads. Iterations come in two tiers. Benchmarks whose single
+iteration costs hundreds of milliseconds to seconds (the 100k-row usage and
+activity-report fixtures and cold-archive ingest, matched by `BENCH_GATE_HEAVY`)
+run in a second `go test` pass with `BENCH_GATE_HEAVY_TIME` iterations; every
+other benchmark runs with `BENCH_GATE_TIME`. Per-op ratios at that scale do not
+need the averaging that millisecond-scale samples do, and at the full iteration
+count those few benchmarks were most of the gate's wall clock.
+`BENCH_GATE_COUNT` samples are taken per benchmark, and every sample rebuilds
+the fixture, so the count is kept at benchgate's significance minimum. CI
+evaluates `make bench-gate-config` on the PR head and passes the count, both
+iteration counts, and the heavy-tier regex into the merge-base run, so a PR that
+changes those defaults still compares identical workloads; do the same locally
+if you override them.
 
 Report identifiers are package-qualified benchmark names
 (`go.kenn.io/agentsview/internal/db.InsertMessagesBatch-18`) when the captured
@@ -179,7 +197,12 @@ reported without gating; it gates automatically once merged.
    Makefile; each side of the comparison benchmarks its own commit's list, so
    growing the gate cannot break the base run.
 1. Keep per-op cost roughly in the 100µs–100ms band: below the benchgate floors
-   nothing is gated, and far above it the job gets slow.
+   nothing is gated, and far above it the job gets slow. A benchmark that
+   needs a large fixture to expose per-row scaling belongs in
+   `BENCH_GATE_HEAVY` so it runs with the reduced iteration count; a
+   fixture-growing benchmark does not, because its per-op cost depends on the
+   iteration count. Keep fixture seeding cheap too: it is repeated once per
+   `-count` sample.
 1. Keep per-iteration setup out of the timed region (`b.ResetTimer`, pre-built
    fixtures): helper allocations inside the loop are gated as if they were
    product cost and dilute or distort the ratio.

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -790,28 +790,24 @@ func dailyUsageRowSelectFromRows(rowsSQL string) string {
 	return dailyUsageRowSelectFromRowsWithMachine(rowsSQL, false)
 }
 
+// dailyUsageRowColumns names the per-row sources the daily usage select
+// reads: the session a row is attributed to, its billed web-search count,
+// and the session metadata reported alongside it.
+type dailyUsageRowColumns struct {
+	session   string
+	webSearch string
+	project   string
+	agent     string
+	machine   string
+}
+
 func dailyUsageRowSelectFromRowsWithMachine(
 	rowsSQL string, includeMachine bool,
 ) string {
-	return dailyUsageRowSelectFromRowsWithSession(
-		rowsSQL, includeMachine, "u.session_id", false)
-}
-
-func dailyUsageRowSelectFromSnapshotRowsWithMachine(
-	rowsSQL string, includeMachine bool,
-) string {
-	return dailyUsageRowSelectFromRowsWithSession(
-		rowsSQL, includeMachine, "u.snapshot_attribution_session_id", true)
-}
-
-func dailyUsageRowSelectFromRowsWithSession(
-	rowsSQL string, includeMachine bool, sessionColumn string,
-	reloadSessionMetadata bool,
-) string {
-	projectColumn := "u.project"
-	agentColumn := "u.agent"
-	machineColumnExpr := "u.machine"
-	webSearchColumn := `CASE
+	return dailyUsageRowSelectFromRowsWithColumns(
+		rowsSQL, includeMachine, dailyUsageRowColumns{
+			session: "u.session_id",
+			webSearch: `CASE
 		WHEN u.usage_source = 'message' THEN MAX(COALESCE(CASE
 			WHEN json_valid(u.token_usage) THEN CAST(json_extract(
 				u.token_usage, '$.server_tool_use.web_search_requests'
@@ -819,30 +815,46 @@ func dailyUsageRowSelectFromRowsWithSession(
 			ELSE agentsview_usage_web_search_requests(u.token_usage)
 		END, 0), 0)
 		ELSE 0
-	END`
-	metadataJoin := ""
-	if reloadSessionMetadata {
-		metadataJoin = `
-LEFT JOIN sessions attributed
-	ON attributed.id = u.snapshot_attribution_session_id`
-		projectColumn = "CASE WHEN attributed.id IS NULL THEN u.project ELSE attributed.project END"
-		agentColumn = "CASE WHEN attributed.id IS NULL THEN u.agent ELSE attributed.agent END"
-		machineColumnExpr = "CASE WHEN attributed.id IS NULL THEN u.machine ELSE attributed.machine END"
-		webSearchColumn = "u.snapshot_web_search_requests"
-	}
+	END`,
+			project: "u.project",
+			agent:   "u.agent",
+			machine: "u.machine",
+		})
+}
+
+// dailyUsageRowSelectFromSnapshotRowsWithMachine reads rows produced by
+// snapshotRankedDailyUsageRowsSQL, which already carry the attributed
+// session, its metadata, and the partition-wide web-search count (NULL
+// for rows that were not ranked, which the scanner parses in Go).
+func dailyUsageRowSelectFromSnapshotRowsWithMachine(
+	rowsSQL string, includeMachine bool,
+) string {
+	return dailyUsageRowSelectFromRowsWithColumns(
+		rowsSQL, includeMachine, dailyUsageRowColumns{
+			session:   "u.snapshot_attribution_session_id",
+			webSearch: "u.snapshot_web_search_requests",
+			project:   "u.snapshot_project",
+			agent:     "u.snapshot_agent",
+			machine:   "u.snapshot_machine",
+		})
+}
+
+func dailyUsageRowSelectFromRowsWithColumns(
+	rowsSQL string, includeMachine bool, cols dailyUsageRowColumns,
+) string {
 	machineColumn := ""
 	if includeMachine {
-		machineColumn = ",\n\t" + machineColumnExpr
+		machineColumn = ",\n\t" + cols.machine + " AS machine"
 	}
 	return `
 SELECT
-	` + sessionColumn + `,
+	` + cols.session + `,
 	u.message_ordinal,
 	u.usage_source,
 	u.ts,
 	u.model,
 	u.token_usage,
-	` + webSearchColumn + ` AS web_search_requests,
+	` + cols.webSearch + ` AS web_search_requests,
 	u.input_tokens,
 		u.output_tokens,
 		u.cache_creation_input_tokens,
@@ -854,9 +866,9 @@ SELECT
 	u.claude_request_id,
 	u.source_uuid,
 	u.usage_dedup_key,
-	` + projectColumn + ` AS project,
-	` + agentColumn + ` AS agent` + machineColumn + `
-FROM (` + rowsSQL + `) u` + metadataJoin + `
+	` + cols.project + ` AS project,
+	` + cols.agent + ` AS agent` + machineColumn + `
+FROM (` + rowsSQL + `) u
 WHERE 1=1`
 }
 
@@ -1011,10 +1023,11 @@ func usageRowQuery(f UsageFilter) (string, []any) {
 }
 
 func topSessionsUsageRowQuery(f UsageFilter) (string, []any) {
-	rowsSQL, args := usageRowsSQLForBounds(
-		usageSnapshotInputFilter(f), usageBoundsForFilter(f))
-	rowsSQL, snapshotArgs := snapshotRankedDailyUsageRowsSQL(rowsSQL, f)
-	args = append(args, snapshotArgs...)
+	bounds := usageBoundsForFilter(f)
+	rowsSQL, rowsArgs := usageRowsSQLForBounds(
+		usageSnapshotInputFilter(f), bounds)
+	rowsSQL, args := snapshotRankedDailyUsageRowsSQL(
+		rowsSQL, rowsArgs, f, bounds)
 	return dailyUsageRowSelectFromSnapshotRowsWithMachine(rowsSQL, false), args
 }
 
@@ -1129,12 +1142,121 @@ func exactUsageUTCWindow(f UsageFilter) usageBounds {
 	return out
 }
 
-// snapshotRankedDailyUsageRowsSQL keeps the greatest output snapshot and the
-// maximum billed web-search count for each Claude request before rows cross
-// into Go. Rows without complete Claude request identity bypass the window.
+// snapshotRankedDailyUsageRowsSQL wraps rowsSQL so that each Claude request
+// (claude_message_id, claude_request_id) contributes one row: the greatest
+// output snapshot, attributed to the session that streamed the request
+// first, carrying the maximum billed web-search count across its snapshots.
+// Rows without complete Claude request identity bypass the ranking.
+//
+// Only requests that appear more than once are ranked. usage_snapshot_dups
+// finds them with an index-only pass over messages, usage_snapshot_ranked
+// runs the window functions over just those rows, and every other row
+// passes through with itself as attribution and a NULL web-search count that
+// the scanner parses from token_usage in Go. Ranking every row through the
+// window functions cost two to five times the underlying scan, because
+// SQLite sorts and materializes the full-width rows once per window.
+//
+// rowsArgs are the placeholders of rowsSQL; the returned args carry them in
+// position with the ranking's own placeholders. Callers finish with
+// dailyUsageRowSelectFromSnapshotRowsWithMachine.
 func snapshotRankedDailyUsageRowsSQL(
-	rowsSQL string, f UsageFilter,
+	rowsSQL string, rowsArgs []any, f UsageFilter, b usageBounds,
 ) (string, []any) {
+	windowWhere, windowArgs := usageSnapshotWindowWhere(f)
+	dupsSQL, dupsArgs := usageSnapshotDuplicateRequestsSQL(b)
+	claudeRowsSQL, claudeArgs := usageSnapshotClaudeMessageRowsSQL(b)
+	filterWhere := "1=1"
+	var filterArgs []any
+	filterWhere, filterArgs = f.appendUsageSourceFilterClauses(
+		filterWhere, filterArgs, "survivor.model")
+	filterWhere, filterArgs = f.appendUsageSessionFilterClauses(
+		filterWhere, filterArgs)
+	survivorFilter := ""
+	if filterWhere != "1=1" {
+		survivorFilter = `
+		LEFT JOIN sessions s
+			ON s.id = survivor.snapshot_attribution_session_id
+		WHERE survivor.snapshot_attribution_session_id = ''
+			OR (` + filterWhere + `)`
+	}
+	outputTokens := fmt.Sprintf(`MIN(MAX(COALESCE(CASE
+						WHEN json_valid(u.token_usage) THEN CAST(json_extract(
+							u.token_usage, '$.output_tokens') AS INTEGER)
+						ELSE agentsview_usage_output_tokens(u.token_usage)
+					END, 0), 0), %d)`, MaxPlausibleTokens)
+	webSearchRequests := `MAX(COALESCE(CASE
+					WHEN json_valid(u.token_usage) THEN CAST(json_extract(
+						u.token_usage, '$.server_tool_use.web_search_requests'
+					) AS INTEGER)
+					ELSE agentsview_usage_web_search_requests(u.token_usage)
+				END, 0), 0)`
+
+	args := make([]any, 0,
+		len(dupsArgs)+len(claudeArgs)+2*len(windowArgs)+
+			len(rowsArgs)+len(filterArgs))
+	args = append(args, dupsArgs...)
+	args = append(args, claudeArgs...)
+	args = append(args, windowArgs...)
+	args = append(args, rowsArgs...)
+	args = append(args, windowArgs...)
+	args = append(args, filterArgs...)
+	return fmt.Sprintf(`
+		WITH usage_snapshot_dups AS (%[1]s),
+		usage_snapshot_ranked AS (
+			SELECT u.session_id, u.message_ordinal,
+				FIRST_VALUE(u.session_id) OVER attribution
+					AS snapshot_attribution_session_id,
+				FIRST_VALUE(u.project) OVER attribution AS snapshot_project,
+				FIRST_VALUE(u.agent) OVER attribution AS snapshot_agent,
+				FIRST_VALUE(u.machine) OVER attribution AS snapshot_machine,
+				ROW_NUMBER() OVER ranking AS snapshot_rank,
+				MAX(%[5]s) OVER (
+					ranking ROWS BETWEEN UNBOUNDED PRECEDING
+						AND UNBOUNDED FOLLOWING
+				) AS snapshot_web_search_requests
+			FROM (%[2]s) u
+			WHERE %[3]s
+			WINDOW attribution AS (
+				PARTITION BY u.claude_message_id, u.claude_request_id
+				ORDER BY julianday(u.ts) IS NULL ASC,
+					julianday(u.ts) ASC, u.session_id ASC,
+					COALESCE(u.message_ordinal, -1) ASC,
+					CASE WHEN julianday(u.ts) IS NULL THEN u.ts ELSE '' END ASC
+			), ranking AS (
+				PARTITION BY u.claude_message_id, u.claude_request_id
+				ORDER BY %[4]s DESC,
+					julianday(u.ts) IS NULL ASC, julianday(u.ts) DESC,
+					u.session_id DESC, COALESCE(u.message_ordinal, -1) DESC,
+					CASE WHEN julianday(u.ts) IS NULL THEN u.ts ELSE '' END DESC
+			)
+		),
+		usage_snapshot_survivors AS (
+			SELECT u.*,
+				COALESCE(r.snapshot_attribution_session_id, u.session_id)
+					AS snapshot_attribution_session_id,
+				COALESCE(r.snapshot_project, u.project) AS snapshot_project,
+				COALESCE(r.snapshot_agent, u.agent) AS snapshot_agent,
+				COALESCE(r.snapshot_machine, u.machine) AS snapshot_machine,
+				r.snapshot_web_search_requests
+			FROM (%[6]s) u
+			LEFT JOIN usage_snapshot_ranked r
+				ON u.usage_source = 'message'
+				AND r.session_id = u.session_id
+				AND r.message_ordinal = u.message_ordinal
+			WHERE %[3]s
+				AND (r.snapshot_rank IS NULL OR r.snapshot_rank = 1)
+		)
+		SELECT survivor.*
+		FROM usage_snapshot_survivors survivor%[7]s`,
+		dupsSQL, claudeRowsSQL, windowWhere, outputTokens,
+		webSearchRequests, rowsSQL, survivorFilter), args
+}
+
+// usageSnapshotWindowWhere restricts rows to the filter's exact UTC window
+// so snapshots outside the requested dates neither win a partition nor
+// reach the scanner. Rows whose timestamp julianday cannot parse fall back
+// to a date-prefix comparison, mirroring the scanner's local-date filter.
+func usageSnapshotWindowWhere(f UsageFilter) (string, []any) {
 	window := exactUsageUTCWindow(f)
 	where := "1=1"
 	var args []any
@@ -1154,78 +1276,79 @@ func snapshotRankedDailyUsageRowsSQL(
 			)`
 		args = append(args, window.to, f.To)
 	}
-	filterWhere := "1=1"
-	filterWhere, args = f.appendUsageSourceFilterClauses(
-		filterWhere, args, "survivor.model")
-	filterWhere, args = f.appendUsageSessionFilterClauses(filterWhere, args)
-	outputTokens := fmt.Sprintf(`CASE
-				WHEN u.usage_source = 'message'
-					THEN MIN(MAX(COALESCE(CASE
-						WHEN json_valid(u.token_usage) THEN CAST(json_extract(
-							u.token_usage, '$.output_tokens') AS INTEGER)
-						ELSE agentsview_usage_output_tokens(u.token_usage)
-					END, 0), 0), %[1]d)
-				WHEN u.usage_source = 'session'
-					THEN MAX(u.output_tokens, 0)
-				ELSE MIN(MAX(u.output_tokens, 0), %[1]d)
-			END`, MaxPlausibleTokens)
-	webSearchRequests := `CASE
-				WHEN u.usage_source = 'message' THEN MAX(COALESCE(CASE
-					WHEN json_valid(u.token_usage) THEN CAST(json_extract(
-						u.token_usage, '$.server_tool_use.web_search_requests'
-					) AS INTEGER)
-					ELSE agentsview_usage_web_search_requests(u.token_usage)
-				END, 0), 0)
-				ELSE 0
-			END`
-	return fmt.Sprintf(`
-		WITH usage_snapshot_window AS (
-			SELECT u.*, %[1]s AS snapshot_output_tokens,
-				%[5]s AS snapshot_row_web_search_requests
-			FROM (%[2]s) u
-			WHERE %[3]s
-		),
-		usage_snapshot_ranked AS (
-			SELECT usage_snapshot_window.*,
-				FIRST_VALUE(session_id) OVER (
-					PARTITION BY claude_message_id, claude_request_id
-					ORDER BY julianday(ts) IS NULL ASC,
-						julianday(ts) ASC, session_id ASC,
-						COALESCE(message_ordinal, -1) ASC,
-						CASE WHEN julianday(ts) IS NULL THEN ts ELSE '' END ASC
-				) AS snapshot_attribution_session_id,
-				ROW_NUMBER() OVER (
-					PARTITION BY claude_message_id, claude_request_id
-					ORDER BY snapshot_output_tokens DESC,
-						julianday(ts) IS NULL ASC, julianday(ts) DESC,
-						session_id DESC, COALESCE(message_ordinal, -1) DESC,
-						CASE WHEN julianday(ts) IS NULL THEN ts ELSE '' END DESC
-				) AS snapshot_rank,
-				MAX(snapshot_row_web_search_requests) OVER (
-					PARTITION BY claude_message_id, claude_request_id
-				) AS snapshot_web_search_requests
-			FROM usage_snapshot_window
-			WHERE claude_message_id != '' AND claude_request_id != ''
-		),
-		usage_snapshot_survivors AS (
-			SELECT *
-			FROM usage_snapshot_ranked
-			WHERE snapshot_rank = 1
-			UNION ALL
-			SELECT usage_snapshot_window.*,
-				session_id AS snapshot_attribution_session_id,
-				1 AS snapshot_rank,
-				snapshot_row_web_search_requests AS snapshot_web_search_requests
-			FROM usage_snapshot_window
-			WHERE claude_message_id = '' OR claude_request_id = ''
-		)
-		SELECT survivor.*
-		FROM usage_snapshot_survivors survivor
-		LEFT JOIN sessions s
-			ON s.id = survivor.snapshot_attribution_session_id
-		WHERE survivor.snapshot_attribution_session_id = ''
-			OR (%[4]s)`,
-		outputTokens, rowsSQL, where, filterWhere, webSearchRequests), args
+	return where, args
+}
+
+// usageSnapshotClaudeIdentity selects the message rows that carry complete
+// Claude request identity and could enter the usage row source.
+const usageSnapshotClaudeIdentity = usageMessageSourceEligibility + `
+	AND m.claude_message_id != ''
+	AND m.claude_request_id != ''`
+
+// usageSnapshotDuplicateRequestsSQL lists the Claude requests that appear on
+// more than one eligible message. It over-approximates the ranked set (it
+// ignores session eligibility and the fallback session bounds), which only
+// sends extra rows through the ranking; the ranking itself applies the exact
+// row-source predicates. Bounded filters seek idx_messages_usage_covering
+// per timestamp branch so the pass stays proportional to the window;
+// unbounded filters read idx_messages_claude_snapshot in partition order.
+func usageSnapshotDuplicateRequestsSQL(b usageBounds) (string, []any) {
+	const key = `m.claude_message_id, m.claude_request_id`
+	if !b.bounded() {
+		return `
+			SELECT ` + key + `
+			FROM messages m
+			WHERE ` + usageSnapshotClaudeIdentity + `
+			GROUP BY ` + key + `
+			HAVING COUNT(*) > 1`, nil
+	}
+	timestampWhere, args := appendUsageColumnBounds(
+		usageSnapshotClaudeIdentity, "m.timestamp", b, nil)
+	return `
+			SELECT claude_message_id, claude_request_id
+			FROM (
+				SELECT ` + key + `
+				FROM messages m
+				WHERE ` + timestampWhere + `
+				UNION ALL
+				SELECT ` + key + `
+				FROM messages m
+				WHERE ` + usageSnapshotClaudeIdentity + `
+					AND m.timestamp IS NULL
+				UNION ALL
+				SELECT ` + key + `
+				FROM messages m
+				WHERE ` + usageSnapshotClaudeIdentity + `
+					AND m.timestamp = ''
+			)
+			GROUP BY claude_message_id, claude_request_id
+			HAVING COUNT(*) > 1`, args
+}
+
+// usageSnapshotClaudeMessageRowsSQL produces the row-source shape for the
+// messages of duplicated Claude requests, using the same eligibility and
+// bounds as usageRowsSQLForBounds's message branches so the ranked rows are
+// exactly the row source's Claude rows for those requests.
+func usageSnapshotClaudeMessageRowsSQL(b usageBounds) (string, []any) {
+	where := usageMessageEligibility + `
+	AND m.claude_message_id != ''
+	AND m.claude_request_id != ''
+	AND (m.claude_message_id, m.claude_request_id) IN (
+		SELECT claude_message_id, claude_request_id FROM usage_snapshot_dups
+	)`
+	var args []any
+	if b.bounded() {
+		timestampWhere, timestampArgs := appendUsageColumnBounds(
+			"m.timestamp IS NOT NULL AND m.timestamp != ''",
+			"m.timestamp", b, nil)
+		fallbackWhere, fallbackArgs := appendUsageColumnBounds(
+			"NULLIF(m.timestamp, '') IS NULL", "s.started_at", b, nil)
+		where += `
+	AND ((` + timestampWhere + `) OR (` + fallbackWhere + `))`
+		args = append(args, timestampArgs...)
+		args = append(args, fallbackArgs...)
+	}
+	return fmt.Sprintf(dailyUsageMessageRowsSQLTemplate, "messages", where), args
 }
 
 func scanUsageRow(rows *sql.Rows) (usageScanRow, error) {
@@ -2316,9 +2439,10 @@ func (db *DB) GetDailyUsage(
 	// long-lived sessions that span date boundaries are included.
 	// Pad by +/-14h to cover all timezone offsets; the actual
 	// date filtering happens post-query via localDate.
-	query, args := dailyUsageRowsSQLForBounds(f, usageBoundsForFilter(f), db.hasCursorUsageTable())
-	query, snapshotArgs := snapshotRankedDailyUsageRowsSQL(query, f)
-	args = append(args, snapshotArgs...)
+	bounds := usageBoundsForFilter(f)
+	query, rowsArgs := dailyUsageRowsSQLForBounds(
+		f, bounds, db.hasCursorUsageTable())
+	query, args := snapshotRankedDailyUsageRowsSQL(query, rowsArgs, f, bounds)
 	query = dailyUsageRowSelectFromSnapshotRowsWithMachine(
 		query, f.Breakdowns)
 	query += ` ORDER BY u.ts ASC, u.session_id ASC,

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -449,7 +449,7 @@ func TestTopSessionsUsageRowQueryUsesNarrowScan(t *testing.T) {
 	assert.NotContains(t, normalized, "user_message_count")
 	assert.NotContains(t, normalized, "session_activity_at")
 	assert.NotContains(t, normalized, " as started_at")
-	assert.NotContains(t, normalized, "u.machine")
+	assert.NotContains(t, normalized, " as machine")
 	assert.Contains(t, normalized, "m.timestamp is not null")
 	assert.Contains(t, normalized, "m.timestamp != ''")
 	assert.Contains(t, normalized, "ue.occurred_at is not null")
@@ -465,19 +465,21 @@ func TestTopSessionsUsageRowQueryUsesNarrowScan(t *testing.T) {
 	assert.Contains(t, normalized, "ue.occurred_at <= ?")
 	assert.Contains(t, normalized, "julianday(u.ts) >= julianday(?)")
 	assert.Contains(t, normalized, "julianday(u.ts) < julianday(?)")
-	require.Len(t, args, 12)
-	assert.Equal(t, "2024-05-31T10:00:00Z", args[0])
-	assert.Equal(t, "2024-07-01T13:59:59Z", args[1])
-	assert.Equal(t, "2024-05-31T10:00:00Z", args[2])
-	assert.Equal(t, "2024-07-01T13:59:59Z", args[3])
-	assert.Equal(t, "2024-05-31T10:00:00Z", args[4])
-	assert.Equal(t, "2024-07-01T13:59:59Z", args[5])
-	assert.Equal(t, "2024-05-31T10:00:00Z", args[6])
-	assert.Equal(t, "2024-07-01T13:59:59Z", args[7])
-	assert.Equal(t, "2024-06-01T04:00:00Z", args[8])
-	assert.Equal(t, "2024-06-01", args[9])
-	assert.Equal(t, "2024-07-01T04:00:00Z", args[10])
-	assert.Equal(t, "2024-06-30", args[11])
+	padded := []any{"2024-05-31T10:00:00Z", "2024-07-01T13:59:59Z"}
+	window := []any{
+		"2024-06-01T04:00:00Z", "2024-06-01",
+		"2024-07-01T04:00:00Z", "2024-06-30",
+	}
+	var want []any
+	want = append(want, padded...) // duplicate-request pass
+	want = append(want, padded...) // ranked rows: m.timestamp
+	want = append(want, padded...) // ranked rows: s.started_at
+	want = append(want, window...) // ranked rows: exact window
+	for range 4 {                  // row source branches
+		want = append(want, padded...)
+	}
+	want = append(want, window...) // survivors: exact window
+	assert.Equal(t, want, args)
 }
 
 func TestUsageEventsReplaceAndList(t *testing.T) {
@@ -1776,32 +1778,77 @@ func TestGetDailyUsagePrefersTimestampedEqualClaudeSnapshot(t *testing.T) {
 	assert.Equal(t, 100, result.Totals.OutputTokens)
 }
 
+// seedSnapshotTiePair stores one Claude request (msg-tie/req-tie) streamed
+// into two sessions with equal output tokens: z-snapshot carries the larger
+// input count at zTimestamp and a-snapshot the smaller one at aTimestamp.
+func seedSnapshotTiePair(t *testing.T, d *DB, zTimestamp, aTimestamp string) {
+	t.Helper()
+	for _, id := range []string{"z-snapshot", "a-snapshot"} {
+		insertSession(t, d, id, "proj", func(s *Session) {
+			s.Agent = "claude"
+			s.StartedAt = new("2026-05-20T10:00:00Z")
+		})
+	}
+	insertMessages(t, d,
+		Message{
+			SessionID: "z-snapshot", Ordinal: 0, Role: "assistant",
+			Timestamp: zTimestamp, Model: "claude-opus-4-6",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":900,"output_tokens":100}`),
+			OutputTokens: 100, HasOutputTokens: true,
+			ClaudeMessageID: "msg-tie", ClaudeRequestID: "req-tie",
+		},
+		Message{
+			SessionID: "a-snapshot", Ordinal: 0, Role: "assistant",
+			Timestamp: aTimestamp, Model: "claude-opus-4-6",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":10,"output_tokens":100}`),
+			OutputTokens: 100, HasOutputTokens: true,
+			ClaudeMessageID: "msg-tie", ClaudeRequestID: "req-tie",
+		},
+	)
+}
+
+// querySnapshotRankedRows runs the snapshot ranking over the real usage row
+// source for f and returns the surviving rows as
+// (session_id, snapshot_attribution_session_id, token_usage) triples.
+func querySnapshotRankedRows(
+	t *testing.T, d *DB, f UsageFilter,
+) [][3]string {
+	t.Helper()
+	bounds := usageBoundsForFilter(f)
+	rowsSQL, rowsArgs := usageRowsSQLForBounds(
+		usageSnapshotInputFilter(f), bounds)
+	ranked, args := snapshotRankedDailyUsageRowsSQL(
+		rowsSQL, rowsArgs, f, bounds)
+	rows, err := d.getReader().Query(`
+		SELECT session_id, snapshot_attribution_session_id, token_usage
+		FROM (`+ranked+`)
+		ORDER BY session_id`, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out [][3]string
+	for rows.Next() {
+		var row [3]string
+		require.NoError(t, rows.Scan(&row[0], &row[1], &row[2]))
+		out = append(out, row)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
 func TestSnapshotRankedDailyUsageRowsPrefersLatestEqualOutput(t *testing.T) {
 	d := testDB(t)
-	rowsSQL := `
-		SELECT 'z-snapshot' AS session_id, 0 AS message_ordinal,
-			'message' AS usage_source, '2026-05-20T10:31:00Z' AS ts,
-			'{"input_tokens":900,"output_tokens":100}' AS token_usage,
-			0 AS output_tokens, 'msg-tie' AS claude_message_id,
-			'req-tie' AS claude_request_id
-		UNION ALL
-		SELECT 'a-snapshot', 0, 'message', '2026-05-20T10:30:00Z',
-			'{"input_tokens":10,"output_tokens":100}', 0,
-			'msg-tie', 'req-tie'`
-	ranked, args := snapshotRankedDailyUsageRowsSQL(rowsSQL, UsageFilter{})
-	var sessionID, attributionSessionID, tokenJSON string
-	err := d.getReader().QueryRow(`
-		SELECT session_id, snapshot_attribution_session_id, token_usage
-		FROM (`+ranked+`)`, args...).Scan(
-		&sessionID, &attributionSessionID, &tokenJSON)
-	require.NoError(t, err)
-	assert.Equal(t, "z-snapshot", sessionID)
-	assert.Equal(t, "a-snapshot", attributionSessionID)
-	assert.JSONEq(t, `{"input_tokens":900,"output_tokens":100}`, tokenJSON)
+	seedSnapshotTiePair(t, d,
+		"2026-05-20T10:31:00Z", "2026-05-20T10:30:00Z")
+	got := querySnapshotRankedRows(t, d, UsageFilter{})
+	require.Len(t, got, 1)
+	assert.Equal(t, "z-snapshot", got[0][0])
+	assert.Equal(t, "a-snapshot", got[0][1])
+	assert.JSONEq(t, `{"input_tokens":900,"output_tokens":100}`, got[0][2])
 }
 
 func TestSnapshotRankedDailyUsageRowsNormalizesRFC3339Timestamps(t *testing.T) {
-	d := testDB(t)
 	tests := []struct {
 		name         string
 		zTimestamp   string
@@ -1829,32 +1876,70 @@ func TestSnapshotRankedDailyUsageRowsNormalizesRFC3339Timestamps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rowsSQL := `
-				SELECT 'z-snapshot' AS session_id, 0 AS message_ordinal,
-					'message' AS usage_source, ? AS ts,
-					'{"input_tokens":900,"output_tokens":100}' AS token_usage,
-					0 AS output_tokens, 'msg-tie' AS claude_message_id,
-					'req-tie' AS claude_request_id
-				UNION ALL
-				SELECT 'a-snapshot', 0, 'message', ?,
-					'{"input_tokens":10,"output_tokens":100}', 0,
-					'msg-tie', 'req-tie'`
-			ranked, rankArgs := snapshotRankedDailyUsageRowsSQL(
-				rowsSQL, UsageFilter{})
-			args := append([]any{tt.zTimestamp, tt.aTimestamp}, rankArgs...)
-			var sessionID, attributionSessionID, tokenJSON string
-			err := d.getReader().QueryRow(`
-				SELECT session_id, snapshot_attribution_session_id, token_usage
-				FROM (`+ranked+`)`, args...).Scan(
-				&sessionID, &attributionSessionID, &tokenJSON)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantSession, sessionID)
-			assert.Equal(t, tt.wantAttribut, attributionSessionID)
+			d := testDB(t)
+			seedSnapshotTiePair(t, d, tt.zTimestamp, tt.aTimestamp)
+			got := querySnapshotRankedRows(t, d, UsageFilter{})
+			require.Len(t, got, 1)
+			assert.Equal(t, tt.wantSession, got[0][0])
+			assert.Equal(t, tt.wantAttribut, got[0][1])
 			assert.JSONEq(t, fmt.Sprintf(
 				`{"input_tokens":%d,"output_tokens":100}`, tt.wantInput),
-				tokenJSON)
+				got[0][2])
 		})
 	}
+}
+
+// Only duplicated Claude requests pass through the ranking; every other row
+// survives untouched, attributed to its own session, including rows outside
+// the window that the ranking must not drag back in.
+func TestSnapshotRankedDailyUsageRowsRanksOnlyDuplicatedRequests(t *testing.T) {
+	d := testDB(t)
+	seedSnapshotTiePair(t, d,
+		"2026-05-20T10:31:00Z", "2026-05-20T10:30:00Z")
+	insertSession(t, d, "solo", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2026-05-20T10:00:00Z")
+	})
+	insertMessages(t, d,
+		Message{
+			SessionID: "solo", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-05-20T10:32:00Z", Model: "claude-opus-4-6",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":5,"output_tokens":7}`),
+			OutputTokens: 7, HasOutputTokens: true,
+			ClaudeMessageID: "msg-solo", ClaudeRequestID: "req-solo",
+		},
+		Message{
+			SessionID: "solo", Ordinal: 1, Role: "assistant",
+			Timestamp: "2026-05-20T10:33:00Z", Model: "claude-opus-4-6",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":6,"output_tokens":8}`),
+			OutputTokens: 8, HasOutputTokens: true,
+		},
+		Message{
+			SessionID: "solo", Ordinal: 2, Role: "assistant",
+			Timestamp: "2026-05-21T10:00:00Z", Model: "claude-opus-4-6",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":1,"output_tokens":200}`),
+			OutputTokens: 200, HasOutputTokens: true,
+			ClaudeMessageID: "msg-tie", ClaudeRequestID: "req-tie",
+		},
+	)
+
+	got := querySnapshotRankedRows(t, d, UsageFilter{})
+	require.Equal(t, [][3]string{
+		{"solo", "solo", `{"input_tokens":5,"output_tokens":7}`},
+		{"solo", "solo", `{"input_tokens":6,"output_tokens":8}`},
+		{"solo", "a-snapshot", `{"input_tokens":1,"output_tokens":200}`},
+	}, got)
+
+	got = querySnapshotRankedRows(t, d, UsageFilter{
+		From: "2026-05-20", To: "2026-05-20", Timezone: "UTC"})
+	require.Equal(t, [][3]string{
+		{"solo", "solo", `{"input_tokens":5,"output_tokens":7}`},
+		{"solo", "solo", `{"input_tokens":6,"output_tokens":8}`},
+		{"z-snapshot", "a-snapshot", `{"input_tokens":900,"output_tokens":100}`},
+	}, got)
 }
 
 func TestGetDailyUsage_DedupKeyVariants(t *testing.T) {


### PR DESCRIPTION
## Summary

Bring the PR benchmark gate under 20 minutes and fix the `GetDailyUsage`
slowdown from #1314.

## Gate runtime

- `make bench-gate` runs two passes. Large-fixture benchmarks
  (`BENCH_GATE_HEAVY`) run at 5x. All other benchmarks run at 20x.
  `bench.yml` passes the same settings to the merge-base run.
- The gate job runs on `ubuntu-latest` for every PR. Both sides of the
  comparison run on one runner, so only absolute speed matters, and
  `ubuntu-latest` is 2-4x faster on this workload.

## GetDailyUsage fix

`snapshotRankedDailyUsageRowsSQL` ranked every Claude row with window
functions. SQLite scanned the row source twice and sorted full-width rows
once per window. `BenchmarkGetDailyUsage` became 1.65x slower with no
change in allocations, so the gate did not catch it.

The query now:

1. Finds Claude requests that appear more than once with an index-only pass.
2. Ranks only those rows.
3. Joins the survivors back onto the row source.

Rows that are not ranked keep their own session and pass through unchanged.
Behavior is unchanged. Tests now seed real messages instead of literal rows,
and a new test covers ranked, unranked, and out-of-window rows.

PostgreSQL is unchanged. It materializes the shared CTE and does not have
this cost.

## Where to look

- `internal/db/usage.go`: `snapshotRankedDailyUsageRowsSQL` and its helpers
- `Makefile`: `bench-gate`
- `.github/workflows/bench.yml`
