### PR TITLE
docs: document the 0.41.0 release

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,8 @@ normal clones do not pull screenshots and PNGs into the main history.
 ## Layout
 
 - `*.md` and related public subdirectories: public docs source.
-- `internal/`: maintainer references excluded from the published site.
+- `internal/` and `superpowers/`: maintainer references excluded from the
+  published site.
 - `zensical.toml`: Zensical site configuration and navigation.
 - `pyproject.toml` and `uv.lock`: pinned docs toolchain.
 - `vercel.json` and `vercel-build.sh`: Vercel project configuration.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,15 +5,77 @@ description: Release history for AgentsView
 
 ## Unreleased
 
+**Bug fixes**
+
+- Ignore self-referential subagent spawn edges when linking session
+  hierarchy, and resolve a self-parent claim to the parser-derived parent (or
+  no parent) at ingest and once per archive for rows an earlier build had
+  linked to themselves.
+
+---
+
+## 0.41.0
+
+<small>2026-08-16</small>
+
 **New features**
 
-- Add Prime Agent session discovery, Pi-family conversation parsing, fork
-  lineage, and RLM-attributed token usage.
-- Add DeepSeek Harness session discovery for plain and multi-frame zstd JSONL,
-  including reasoning, tools, lineage, interrupted replies, and token usage.
+- Add session support for **DeepSeek Harness**, **TraeX (TRAE CLI 2.0)**,
+  **Codebuff and Freebuff**, **Prime Agent**, and **Goose**. The new parsers
+  preserve the formats' available reasoning, tool activity, relationships, and
+  usage or recorded costs; Prime Agent also carries Pi-family fork lineage and
+  RLM-attributed usage.
+- Import **Gemini Apps** `Prompted` activity from English-language Google
+  Takeout exports with `agentsview import --type gemini-apps`. Each activity
+  record becomes a one-turn session with its exported timezone preserved.
+- Discover **Qoder IDE** sessions from the platform-specific
+  `SharedClientCache/cli/projects` store in addition to the legacy export
+  directories.
+- Generate insights through a configured OpenAI-compatible
+  `/chat/completions` endpoint as an alternative to local agent CLIs.
+- Let expanded tool results switch between escaped raw text and sanitized,
+  rendered Markdown.
+- Organize model-written reports under **Recall → Generated insights**, add a
+  separate deterministic **Quality** page, expose Recall extraction coverage,
+  and manage extraction generations.
+- Record Amp's model and token counts per inference so model switches retain
+  their own usage rows.
+- Attribute complete delegated-session costs to the session that spawned the
+  work in usage reports, with `--own-only` available for the root session's
+  direct cost.
+- Add versioned JSON output to `agentsview usage statusline` for shell scripts
+  and status integrations.
+
+**Improvements**
+
+- Scale large activity reports with streaming aggregation, bounded pagination,
+  and fewer repeated snapshot scans.
+- Speed up daily usage reporting and duplicate-prompt analysis with narrower
+  indexed queries.
+- Make HTTP sync transfer and parse only sessions whose source files changed.
+- Reduce idle polling CPU and add `disabled_agents` so unused local session
+  sources can be turned off without removing archived sessions.
+- Persist Claude and Codex freshness digests across daemon restarts to avoid
+  reparsing unchanged sessions.
+- Bound startup reconciliation and expose daemon process identity, coverage,
+  and synchronization health in runtime status.
+- Recover from invalid Ollama embedding responses on CPU systems by retrying
+  through the compatible native endpoint.
 
 **Bug fixes**
 
+- Populate working directories for Kimi sessions.
+- Support legacy Zed thread schemas and restore response items from current VS
+  Code Copilot session files.
+- Preserve Codex tool outputs during incremental parsing and associate forked
+  turns with their actual parents.
+- Exclude replayed Codex subagent usage and stop repeatedly parsing titled
+  sessions when `session_index.jsonl` is absent.
+- Remove replayed prefixes from backgrounded Claude sessions and keep
+  IDE-context envelopes out of session previews.
+- Remove stored Claude sessions that a complete current parse no longer emits.
+- Honor explicitly empty agent-directory arrays instead of restoring default
+  discovery roots.
 - Stop the macOS app from asking for access to Documents, Downloads, Desktop,
   iCloud Drive, and cloud-provider folders such as Dropbox. Discovery read Git
   metadata from every recorded session working directory, so a first sync
@@ -21,10 +83,48 @@ description: Release history for AgentsView
   Sessions in those folders now keep path-only project identity; set
   `scan_protected_paths` to opt back in to Git remote, worktree, and branch
   detail there.
-- Ignore self-referential subagent spawn edges when linking session
-  hierarchy, and resolve a self-parent claim to the parser-derived parent (or
-  no parent) at ingest and once per archive for rows an earlier build had
-  linked to themselves.
+- Keep OpenCode's session container from consuming recursive watch capacity.
+- Keep root-session navigation unfiltered when returning from a child session.
+- Distinguish failed frontend actions from successful ones.
+- Start reliably when IPv4 and IPv6 listeners encounter port collisions.
+- Report stalled synchronization as unhealthy.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for Recall extraction
+  progress and generation management; Generated insights and Quality; protected
+  path discovery; Codex and Claude freshness, parsing, and cleanup fixes; daemon
+  identity and health; HTTP sync, bounded startup, and activity scaling; usage
+  performance; and release documentation.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for Prime
+  Agent support, Ollama CPU recovery, Codex replay and fork fixes, accurate
+  frontend action outcomes, bounded activity scans, lower idle CPU, and
+  agent-source controls.
+- Thanks to [Rod Boev](https://github.com/rodboev) for Gemini Apps import,
+  OpenCode watcher capacity, explicitly empty directory settings, raw and
+  formatted tool output, legacy Zed support, OpenAI-compatible insight
+  endpoints, Kimi working directories, and related documentation.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for complete delegated
+  session cost attribution.
+- Thanks to [Stephen Cross](https://github.com/scross01) for Codebuff and
+  Freebuff support.
+- Thanks to [Joonas Bergius](https://github.com/joonas) for Goose support.
+- Thanks to [GhostFlying](https://github.com/GhostFlying) for TraeX support.
+- Thanks to [Shrivatsa](https://github.com/shrivatsas) for Amp per-inference
+  model and token usage.
+- Thanks to [Wahaj Ahmed](https://github.com/wahajahmed010) for Qoder
+  SharedClientCache discovery.
+- Thanks to [Weng Jialin](https://github.com/Stool233) for DeepSeek Harness
+  support.
+- Thanks to [kai](https://github.com/dpanbug) for JSON statusline output.
+- Thanks to [Adam Malcontenti-Wilson](https://github.com/adammw) for keeping
+  Claude IDE context out of session previews.
+- Thanks to [Naveen Jain](https://github.com/naveenspark) for indexed duplicate
+  prompt comparisons.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for stronger end-to-end
+  request failure reporting and more reliable Windows CI coverage.
+- Thanks to [Elliot Murphy](https://github.com/statik) for Windows-compatible
+  parser fixtures.
 
 ---
 

--- a/docs/chat-import.md
+++ b/docs/chat-import.md
@@ -3,7 +3,7 @@ title: Chat Import
 description: Import Claude.ai, ChatGPT, and Gemini Apps conversations into AgentsView
 ---
 
-AgentsView can import your conversation history from Claude.ai
+AgentsView can import your conversation history from Claude.ai,
 ChatGPT, and Gemini Apps. These services let you export your data as a zip
 file — AgentsView reads these exports and adds the conversations
 to your local database alongside your agent coding sessions.
@@ -43,6 +43,9 @@ unsupported localized Gemini candidates and malformed zone tokens are reported
 as unsupported before any sessions are emitted.
 
 ## Importing via the UI
+
+The web import dialog currently supports Claude.ai and ChatGPT. Import Gemini
+Apps exports with the [CLI](#importing-via-the-cli).
 
 Click the **Import conversations** button in the header
 (the upload icon in the top-right area) to open the import

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1283,7 +1283,7 @@ agentsview help
 | `POSIT_ASSISTANT_DIR`             | `~/.posit/assistant/workspaces`                      | Posit Assistant workspaces directory                                                                |
 | `POSITRON_DIR`                    | (platform-specific)                                  | Positron Assistant user directory                                                                   |
 | `QCLAW_DIR`                       | `~/.qclaw/agents`                                    | QClaw agents directory                                                                              |
-| `QODER_PROJECTS_DIR`              | `~/.qoder/projects` and `~/.qoderwork/projects`      | Qoder projects directory                                                                            |
+| `QODER_PROJECTS_DIR`              | Legacy and platform-specific roots                   | Qoder projects directory; see [Session Discovery](/configuration/#session-discovery)                 |
 | `QWEN_PROJECTS_DIR`               | `~/.qwen/projects`                                   | Qwen Code projects directory                                                                        |
 | `QWENPAW_DIR`                     | `~/.copaw/workspaces`                                | QwenPaw workspaces directory                                                                        |
 | `REASONIX_DIR`                    | `~/.reasonix` and `~/AppData/Roaming/reasonix`       | Reasonix data directory                                                                             |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,7 +290,7 @@ Omitting the key keeps its default directories.
 | Posit Assistant       | `~/.posit/assistant/workspaces/`                                                 | Per-conversation `conversation.json` tree plus `lm-messages.jsonl` transcript                                                   |
 | Positron Assistant    | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
 | QClaw                 | `~/.qclaw/assets/static/agents/`                                                 | JSONL per session                                                                                                               |
-| Qoder                 | `~/.qoder/projects/` and `~/.qoderwork/projects/`                                | JSONL project transcripts plus sidecar metadata                                                                                 |
+| Qoder                 | Legacy export roots plus platform-specific `SharedClientCache` (see below)       | JSONL project transcripts plus sidecar metadata                                                                                 |
 | Qwen Code             | `~/.qwen/projects/`                                                              | JSONL per session                                                                                                               |
 | QwenPaw               | `~/.copaw/workspaces/`                                                           | JSON session files                                                                                                              |
 | Reasonix              | `~/.reasonix/` and `~/AppData/Roaming/reasonix/`                                 | JSONL sessions plus `.jsonl.meta` sidecars                                                                                      |
@@ -318,6 +318,17 @@ Prime Agent support targets the current flat session layout in v0.7.0. That
 release migrates the older per-project layout when Prime Agent opens its
 session store, so open the current Prime Agent once before syncing a legacy
 archive with AgentsView.
+
+**Qoder default directories** include the legacy `~/.qoder/projects/` and
+`~/.qoderwork/projects/` export roots plus the current IDE store:
+
+- **macOS:**
+  `~/Library/Application Support/Qoder/SharedClientCache/cli/projects/`
+- **Linux:** `~/.config/Qoder/SharedClientCache/cli/projects/`
+- **Windows:** `%APPDATA%\Qoder\SharedClientCache\cli\projects\`
+
+Set `QODER_PROJECTS_DIR` or `qoder_project_dirs` to replace these defaults with
+one or more explicit roots.
 
 Grok sessions are read from `summary.json` (title, timestamps, project),
 optional `signals.json` (token counters), and `chat_history.jsonl` when

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,8 +71,10 @@ across every project, model, and tool.
   <a class="agent-chip" data-agent="zcode" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Zc</span><span class="agent-chip__name">ZCode</span></a>
   <a class="agent-chip" data-agent="zencoder" href="https://zencoder.ai" target="_blank" rel="noopener"><span class="agent-chip__glyph agent-chip__glyph--mono">Ze</span><span class="agent-chip__name">Zencoder</span></a>
   <a class="agent-chip" data-agent="commandcode" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Cc</span><span class="agent-chip__name">Command Code</span></a>
+  <a class="agent-chip" data-agent="codebuff" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Cb</span><span class="agent-chip__name">Codebuff</span></a>
   <a class="agent-chip" data-agent="cortex-code" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Cx</span><span class="agent-chip__name">Cortex Code</span></a>
   <a class="agent-chip" data-agent="forge" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Fo</span><span class="agent-chip__name">Forge</span></a>
+  <a class="agent-chip" data-agent="freebuff" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Fb</span><span class="agent-chip__name">Freebuff</span></a>
   <a class="agent-chip" data-agent="goose" href="https://goose-docs.ai/" target="_blank" rel="noopener"><span class="agent-chip__glyph agent-chip__glyph--mono">Go</span><span class="agent-chip__name">Goose</span></a>
   <a class="agent-chip" data-agent="grok" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Gr</span><span class="agent-chip__name">Grok</span></a>
   <a class="agent-chip" data-agent="hermes" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">He</span><span class="agent-chip__name">Hermes</span></a>
@@ -85,11 +87,13 @@ across every project, model, and tool.
   <a class="agent-chip" data-agent="piebald" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Pb</span><span class="agent-chip__name">Piebald</span></a>
   <a class="agent-chip" data-agent="poolside" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Po</span><span class="agent-chip__name">Poolside</span></a>
   <a class="agent-chip" data-agent="qclaw" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Qc</span><span class="agent-chip__name">QClaw</span></a>
+  <a class="agent-chip" data-agent="qoder" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Qd</span><span class="agent-chip__name">Qoder</span></a>
   <a class="agent-chip" data-agent="qwenpaw" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Qp</span><span class="agent-chip__name">QwenPaw</span></a>
   <a class="agent-chip" data-agent="reasonix" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Rx</span><span class="agent-chip__name">Reasonix</span></a>
   <a class="agent-chip" data-agent="roocode" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Ro</span><span class="agent-chip__name">RooCode</span></a>
   <a class="agent-chip" data-agent="shelley" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Sh</span><span class="agent-chip__name">Shelley</span></a>
   <a class="agent-chip" data-agent="trae" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Tr</span><span class="agent-chip__name">Trae</span></a>
+  <a class="agent-chip" data-agent="traex" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Tx</span><span class="agent-chip__name">TraeX</span></a>
   <a class="agent-chip" data-agent="workbuddy" href="/configuration/#session-discovery"><span class="agent-chip__glyph agent-chip__glyph--mono">Wb</span><span class="agent-chip__name">WorkBuddy</span></a>
 </div>
 
@@ -274,18 +278,19 @@ read [out-of-band filesystem copies](/filesystem-sync/), or
 
     Works with [dozens of AI coding session sources](/configuration/#session-discovery)
     including Claude Code, OpenClaude, Codex, Copilot, Cursor,
-    Gemini, OpenHands, Aider, Claude Cowork, DeepSeek TUI, DeepSeek Harness, Goose,
-    gptme, Grok, Kilo, Kilo (legacy), Kimi Work, MiMoCode, Mistral Vibe,
-    OhMyPi, Omnigent, Poolside, Prime Agent, QwenPaw, Reasonix, RooCode, Shelley,
-    Trae, Visual Studio Copilot, and ZCode. Auto-discovers session
+    Gemini, OpenHands, Aider, Claude Cowork, Codebuff, DeepSeek TUI,
+    DeepSeek Harness, Freebuff, Goose, gptme, Grok, Kilo, Kilo (legacy),
+    Kimi Work, MiMoCode, Mistral Vibe, OhMyPi, Omnigent, Poolside, Prime Agent,
+    Qoder, QwenPaw, Reasonix, RooCode, Shelley, Trae, TraeX, Visual Studio
+    Copilot, and ZCode. Auto-discovers session
     directories so there's nothing to configure.
 
 -   **Import Chat History**
 
-    Import your [Claude.ai and ChatGPT](/chat-import/)
-    conversations — including images. Upload a zip export
-    and browse everything in one place alongside your
-    agent coding sessions.
+    Import your [Claude.ai, ChatGPT, and Gemini Apps](/chat-import/)
+    conversations. The web dialog handles Claude.ai and ChatGPT exports,
+    including images; the CLI also imports Gemini Apps activity from Google
+    Takeout.
 
 -   **Runs Locally**
 

--- a/docs/screenshots/run.sh
+++ b/docs/screenshots/run.sh
@@ -90,31 +90,37 @@ else
   echo "Warning: no session with thinking blocks found; thinking-blocks screenshot may be skipped"
 fi
 
-# Resolve a session whose early tool activity includes result content so the
-# raw/formatted output screenshot does not depend on whichever session happens
-# to appear third in the sidebar. Prefer output with Markdown syntax because it
-# makes the formatted state visually distinct.
-TOOL_OUTPUT_SESSION_ID=$(sqlite3 "$CONTEXT/test-sessions.db" \
-  "SELECT tc.session_id
+# Resolve the exact message whose tool activity includes result content so the
+# raw/formatted output screenshot can navigate through the virtualized transcript
+# without depending on whichever messages are initially mounted. Prefer output
+# with Markdown syntax because it makes the formatted state visually distinct.
+TOOL_OUTPUT_TARGET=$(sqlite3 -separator $'\t' "$CONTEXT/test-sessions.db" \
+  "SELECT tc.session_id, m.ordinal
    FROM tool_calls tc
    JOIN messages m ON m.id = tc.message_id
    WHERE COALESCE(tc.result_content, '') != ''
      AND trim(tc.result_content) NOT LIKE '[%'
      AND trim(tc.result_content) NOT LIKE '{%'
-   GROUP BY tc.session_id
-   ORDER BY MAX(
-     CASE WHEN tc.result_content LIKE '%\`\`\`%'
-            OR tc.result_content LIKE '%**%'
-            OR tc.result_content LIKE '%# %'
-          THEN 1 ELSE 0 END
-   ) DESC,
-   MIN(m.ordinal),
+   ORDER BY CASE WHEN tc.result_content LIKE '%\`\`\`%'
+                       OR tc.result_content LIKE '%**%'
+                       OR tc.result_content LIKE '%# %'
+                     THEN 1 ELSE 0 END DESC,
+   m.ordinal,
    tc.session_id
    LIMIT 1" 2>/dev/null || true)
-if [ -n "$TOOL_OUTPUT_SESSION_ID" ]; then
-  echo "Tool-output session: $TOOL_OUTPUT_SESSION_ID"
+TOOL_OUTPUT_SESSION_ID=""
+TOOL_OUTPUT_MESSAGE_ORDINAL=""
+if [ -n "$TOOL_OUTPUT_TARGET" ]; then
+  IFS=$'\t' read -r TOOL_OUTPUT_SESSION_ID TOOL_OUTPUT_MESSAGE_ORDINAL \
+    <<< "$TOOL_OUTPUT_TARGET"
+fi
+if [ -n "$TOOL_OUTPUT_SESSION_ID" ] &&
+  [[ "$TOOL_OUTPUT_MESSAGE_ORDINAL" =~ ^[0-9]+$ ]]; then
+  echo "Tool-output target: $TOOL_OUTPUT_SESSION_ID message $TOOL_OUTPUT_MESSAGE_ORDINAL"
 else
-  echo "Warning: no session with tool output found; formatted tool-output screenshot may fail"
+  TOOL_OUTPUT_SESSION_ID=""
+  TOOL_OUTPUT_MESSAGE_ORDINAL=""
+  echo "Warning: no message with tool output found; formatted tool-output screenshot may fail"
 fi
 
 # Resolve a session with a fenced Markdown code block. Recent sidebar rows do
@@ -161,6 +167,7 @@ docker run --rm \
   -v "$OUTPUT_DIR:/output" \
   -e SCREENSHOT_THINKING_SESSION_ID="$THINKING_SESSION_ID" \
   -e SCREENSHOT_TOOL_OUTPUT_SESSION_ID="$TOOL_OUTPUT_SESSION_ID" \
+  -e SCREENSHOT_TOOL_OUTPUT_MESSAGE_ORDINAL="$TOOL_OUTPUT_MESSAGE_ORDINAL" \
   -e SCREENSHOT_CODE_BLOCK_SESSION_ID="$CODE_BLOCK_SESSION_ID" \
   "$IMAGE_NAME" "$@"
 

--- a/docs/screenshots/run.sh
+++ b/docs/screenshots/run.sh
@@ -90,6 +90,52 @@ else
   echo "Warning: no session with thinking blocks found; thinking-blocks screenshot may be skipped"
 fi
 
+# Resolve a session whose early tool activity includes result content so the
+# raw/formatted output screenshot does not depend on whichever session happens
+# to appear third in the sidebar. Prefer output with Markdown syntax because it
+# makes the formatted state visually distinct.
+TOOL_OUTPUT_SESSION_ID=$(sqlite3 "$CONTEXT/test-sessions.db" \
+  "SELECT tc.session_id
+   FROM tool_calls tc
+   JOIN messages m ON m.id = tc.message_id
+   WHERE COALESCE(tc.result_content, '') != ''
+     AND trim(tc.result_content) NOT LIKE '[%'
+     AND trim(tc.result_content) NOT LIKE '{%'
+   GROUP BY tc.session_id
+   ORDER BY MAX(
+     CASE WHEN tc.result_content LIKE '%\`\`\`%'
+            OR tc.result_content LIKE '%**%'
+            OR tc.result_content LIKE '%# %'
+          THEN 1 ELSE 0 END
+   ) DESC,
+   MIN(m.ordinal),
+   tc.session_id
+   LIMIT 1" 2>/dev/null || true)
+if [ -n "$TOOL_OUTPUT_SESSION_ID" ]; then
+  echo "Tool-output session: $TOOL_OUTPUT_SESSION_ID"
+else
+  echo "Warning: no session with tool output found; formatted tool-output screenshot may fail"
+fi
+
+# Resolve a session with a fenced Markdown code block. Recent sidebar rows do
+# not reliably contain one, so the code-block copy screenshot navigates to a
+# known match in the privacy-filtered fixture.
+CODE_BLOCK_SESSION_ID=$(sqlite3 "$CONTEXT/test-sessions.db" \
+  "SELECT m.session_id
+   FROM messages m
+   JOIN sessions s ON s.id = m.session_id
+   WHERE instr(m.content, char(10) || char(96) || char(96) || char(96)) > 0
+     AND COALESCE(m.is_system, 0) = 0
+     AND m.content NOT LIKE '[%'
+     AND s.message_count <= 12
+   ORDER BY length(m.content), m.session_id
+   LIMIT 1" 2>/dev/null || true)
+if [ -n "$CODE_BLOCK_SESSION_ID" ]; then
+  echo "Code-block session: $CODE_BLOCK_SESSION_ID"
+else
+  echo "Warning: no session with a fenced code block found; code-block screenshot may be skipped"
+fi
+
 # Copy screenshot pipeline files
 cp -r "$ROOT/screenshots/" "$CONTEXT/screenshots/"
 cp "$ROOT/screenshots/Dockerfile" "$CONTEXT/Dockerfile"
@@ -114,6 +160,8 @@ echo "Running screenshot capture..."
 docker run --rm \
   -v "$OUTPUT_DIR:/output" \
   -e SCREENSHOT_THINKING_SESSION_ID="$THINKING_SESSION_ID" \
+  -e SCREENSHOT_TOOL_OUTPUT_SESSION_ID="$TOOL_OUTPUT_SESSION_ID" \
+  -e SCREENSHOT_CODE_BLOCK_SESSION_ID="$CODE_BLOCK_SESSION_ID" \
   "$IMAGE_NAME" "$@"
 
 echo ""

--- a/docs/screenshots/tests/screenshots.spec.ts
+++ b/docs/screenshots/tests/screenshots.spec.ts
@@ -782,32 +782,25 @@ test.describe('Message viewer', () => {
   }
 
   async function findVisibleToolBlockWithOutput(
-    page: Page
+    scope: Page | Locator
   ): Promise<Locator> {
-    const rows = page.locator('.message, .virtual-row');
-    const count = await rows.count();
-    for (let i = 0; i < Math.min(count, 80); i++) {
-      await rows.nth(i).scrollIntoViewIfNeeded();
-      await page.waitForTimeout(100);
+    const tools = scope.locator('.tool-block');
+    const toolCount = await tools.count();
+    for (let i = 0; i < toolCount; i++) {
+      const tool = tools.nth(i);
+      if (!(await tool.isVisible())) continue;
 
-      const tools = page.locator('.tool-block');
-      const toolCount = await tools.count();
-      for (let j = 0; j < toolCount; j++) {
-        const tool = tools.nth(j);
-        if (!(await tool.isVisible())) continue;
-
-        const header = tool.locator('.tool-header');
-        const isExpanded =
-          (await tool.locator('.tool-chevron.open').count()) > 0;
-        if (!isExpanded && (await header.count()) > 0) {
-          await header.click();
-          await page.waitForTimeout(100);
-        }
-        if (
-          await tool.locator('.output-header').isVisible().catch(() => false)
-        ) {
-          return tool;
-        }
+      const header = tool.locator('.tool-header');
+      const isExpanded =
+        (await tool.locator('.tool-chevron.open').count()) > 0;
+      if (!isExpanded && (await header.count()) > 0) {
+        await header.click();
+        await tool.page().waitForTimeout(100);
+      }
+      if (
+        await tool.locator('.output-header').isVisible().catch(() => false)
+      ) {
+        return tool;
       }
     }
 
@@ -919,15 +912,31 @@ test.describe('Message viewer', () => {
 
   test('formatted tool output', async ({ page }) => {
     const toolOutputId = process.env.SCREENSHOT_TOOL_OUTPUT_SESSION_ID;
-    if (toolOutputId) {
-      await page.goto('/sessions/' + encodeURIComponent(toolOutputId));
-      await page.waitForSelector('.tool-block', { timeout: 15_000 });
-      await page.waitForTimeout(500);
+    const toolOutputOrdinal =
+      process.env.SCREENSHOT_TOOL_OUTPUT_MESSAGE_ORDINAL;
+    let toolScope: Page | Locator = page;
+    if (toolOutputId || toolOutputOrdinal) {
+      if (!toolOutputId || toolOutputOrdinal === undefined) {
+        throw new Error(
+          'tool-output screenshot requires both session id and message ordinal'
+        );
+      }
+      const ordinal = Number(toolOutputOrdinal);
+      if (!Number.isSafeInteger(ordinal) || ordinal < 0) {
+        throw new Error('tool-output screenshot ordinal must be non-negative');
+      }
+      await page.goto(
+        '/sessions/' + encodeURIComponent(toolOutputId) +
+          '?msg=' + encodeURIComponent(String(ordinal))
+      );
+      const selectedRow = page.locator('.virtual-row.selected');
+      await expect(selectedRow).toBeVisible({ timeout: 15_000 });
+      toolScope = selectedRow;
     } else {
       await selectRichSession(page);
     }
 
-    const tool = await findVisibleToolBlockWithOutput(page);
+    const tool = await findVisibleToolBlockWithOutput(toolScope);
 
     const outputHeader = tool.locator('.output-header');
     await expect(outputHeader).toBeVisible({ timeout: 5_000 });

--- a/docs/screenshots/tests/screenshots.spec.ts
+++ b/docs/screenshots/tests/screenshots.spec.ts
@@ -24,6 +24,34 @@ async function snapEl(loc: Locator, name: string) {
   });
 }
 
+async function snapRange(
+  page: Page,
+  first: Locator,
+  last: Locator,
+  name: string
+) {
+  const firstBox = await first.boundingBox();
+  const lastBox = await last.boundingBox();
+  if (!firstBox || !lastBox) {
+    throw new Error(`cannot resolve screenshot bounds for ${name}`);
+  }
+  const x = Math.min(firstBox.x, lastBox.x);
+  const right = Math.max(
+    firstBox.x + firstBox.width,
+    lastBox.x + lastBox.width
+  );
+  await page.screenshot({
+    path: join(DIR, `${name}.png`),
+    type: 'png',
+    clip: {
+      x,
+      y: firstBox.y,
+      width: right - x,
+      height: lastBox.y + lastBox.height - firstBox.y,
+    },
+  });
+}
+
 async function waitForApp(page: Page) {
   await page.goto('/');
   await page.waitForSelector('.session-item', {
@@ -753,6 +781,41 @@ test.describe('Message viewer', () => {
     throw new Error('no visible .tool-block found in selected session');
   }
 
+  async function findVisibleToolBlockWithOutput(
+    page: Page
+  ): Promise<Locator> {
+    const rows = page.locator('.message, .virtual-row');
+    const count = await rows.count();
+    for (let i = 0; i < Math.min(count, 80); i++) {
+      await rows.nth(i).scrollIntoViewIfNeeded();
+      await page.waitForTimeout(100);
+
+      const tools = page.locator('.tool-block');
+      const toolCount = await tools.count();
+      for (let j = 0; j < toolCount; j++) {
+        const tool = tools.nth(j);
+        if (!(await tool.isVisible())) continue;
+
+        const header = tool.locator('.tool-header');
+        const isExpanded =
+          (await tool.locator('.tool-chevron.open').count()) > 0;
+        if (!isExpanded && (await header.count()) > 0) {
+          await header.click();
+          await page.waitForTimeout(100);
+        }
+        if (
+          await tool.locator('.output-header').isVisible().catch(() => false)
+        ) {
+          return tool;
+        }
+      }
+    }
+
+    throw new Error(
+      'no visible .tool-block with output found in selected session'
+    );
+  }
+
   test('full message view', async ({ page }) => {
     await selectRichSession(page);
     await snap(page, 'message-viewer');
@@ -852,6 +915,43 @@ test.describe('Message viewer', () => {
         }
       }
     }
+  });
+
+  test('formatted tool output', async ({ page }) => {
+    const toolOutputId = process.env.SCREENSHOT_TOOL_OUTPUT_SESSION_ID;
+    if (toolOutputId) {
+      await page.goto('/sessions/' + encodeURIComponent(toolOutputId));
+      await page.waitForSelector('.tool-block', { timeout: 15_000 });
+      await page.waitForTimeout(500);
+    } else {
+      await selectRichSession(page);
+    }
+
+    const tool = await findVisibleToolBlockWithOutput(page);
+
+    const outputHeader = tool.locator('.output-header');
+    await expect(outputHeader).toBeVisible({ timeout: 5_000 });
+    if (!(await tool.locator('.output-mode').isVisible().catch(() => false))) {
+      await outputHeader.click();
+      await page.waitForTimeout(300);
+    }
+
+    const formatted = tool.getByRole('radio', {
+      name: 'Formatted',
+      exact: true,
+    });
+    await expect(formatted).toBeVisible({ timeout: 5_000 });
+    await formatted.click();
+    await expect(tool.locator('.formatted-output')).toBeVisible({
+      timeout: 5_000,
+    });
+    await page.waitForTimeout(500);
+    await snapRange(
+      page,
+      tool.locator('.output-header-row'),
+      tool.locator('.formatted-output'),
+      'tool-output-formatted'
+    );
   });
 
   test('copy buttons on tool block', async ({ page }) => {
@@ -965,27 +1065,36 @@ test.describe('Message viewer', () => {
   });
 
   test('copy button on code block', async ({ page }) => {
+    const codeBlockId = process.env.SCREENSHOT_CODE_BLOCK_SESSION_ID;
+    if (codeBlockId) {
+      await page.goto('/sessions/' + encodeURIComponent(codeBlockId));
+      await page.waitForSelector('.code-block', { timeout: 15_000 });
+      await page.waitForTimeout(500);
+    }
+
     // Walk sessions until we find one with at least one fenced
     // code block. We scan more aggressively than selectRichSession
     // because most sessions have only inline code or no code at
     // all, and we need a `.code-block` (CodeBlock.svelte:34) for
     // this test to be meaningful.
-    const items = page.locator('.session-item');
-    const total = await items.count();
-    const max = Math.min(40, total);
-    let found = false;
-    for (let i = 0; i < max; i++) {
-      await items.nth(i).click();
-      await page.waitForSelector('.message', { timeout: 10_000 });
-      await page.waitForTimeout(400);
-      if (await page.locator('.code-block').first().count() > 0) {
-        found = true;
-        break;
+    if (!codeBlockId) {
+      const items = page.locator('.session-item');
+      const total = await items.count();
+      const max = Math.min(40, total);
+      let found = false;
+      for (let i = 0; i < max; i++) {
+        await items.nth(i).click();
+        await page.waitForSelector('.message', { timeout: 10_000 });
+        await page.waitForTimeout(400);
+        if (await page.locator('.code-block').first().count() > 0) {
+          found = true;
+          break;
+        }
       }
-    }
-    if (!found) {
-      test.skip(true,
-        `No .code-block found in the first ${max} sessions`);
+      if (!found) {
+        test.skip(true,
+          `No .code-block found in the first ${max} sessions`);
+      }
     }
 
     // Capture just the top of a code block where the copy

--- a/docs/screenshots/update-generated-assets-branch.sh
+++ b/docs/screenshots/update-generated-assets-branch.sh
@@ -79,6 +79,7 @@ expected_assets=(
   "screenshots/tool-block-copy-btn.png"
   "screenshots/tool-blocks.png"
   "screenshots/tool-groups.png"
+  "screenshots/tool-output-formatted.png"
   "screenshots/tool-usage.png"
   "screenshots/top-sessions.png"
   "screenshots/top-skills.png"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -676,6 +676,14 @@ heredocs that would otherwise be truncated. Tool result content
 is stored alongside the tool call when available, giving a
 complete view of input and output.
 
+Expanded outputs start in **Raw** mode, which preserves the exact escaped text
+recorded by the agent. Switch to **Formatted** to render Markdown, including
+headings, lists, tables, and highlighted fenced code; HTML is sanitized before
+display. The mode changes presentation only—the stored result and copy button
+continue to use the raw output.
+
+![Formatted tool output](/assets/generated/screenshots/tool-output-formatted.png)
+
 Hover or focus a tool block to reveal copy buttons for the
 structured input and, when present, the tool output.
 

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -70,6 +70,7 @@ tmp_config_base=""
     --exclude './.zensical-build.*' \
     --exclude './.ruff_cache' \
     --exclude './.mypy_cache' \
+    --exclude './superpowers' \
     --exclude './internal' \
     --exclude './overrides' \
     --exclude './scripts' \

--- a/scripts/docs_assets_test.go
+++ b/scripts/docs_assets_test.go
@@ -566,6 +566,7 @@ func writeGeneratedAssets(t *testing.T, dir, content string) {
 		"screenshots/tool-block-copy-btn.png",
 		"screenshots/tool-blocks.png",
 		"screenshots/tool-groups.png",
+		"screenshots/tool-output-formatted.png",
 		"screenshots/tool-usage.png",
 		"screenshots/top-sessions.png",
 		"screenshots/top-skills.png",


### PR DESCRIPTION
AgentsView 0.41.0 shipped substantial parser, import, generated-insight,
usage, synchronization, and daemon changes that were not yet represented
consistently in the published documentation.

This updates the release history to match the shipped behavior and credits
every human contributor in the release range. It also clarifies Qoder's current
discovery paths, the CLI-only Gemini Apps import flow, and raw versus formatted
tool output.

The generated screenshot set now reflects the Quality and Recall organization
and includes formatted tool output. Screenshot selection is deterministic
against the privacy-filtered docs fixture, while generated PNGs remain on the
separate docs asset branch instead of entering the main repository history.
