### PR TITLE
docs: promote changelog in navigation

### DIFF
--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -13,6 +13,7 @@ extra_javascript = ["javascripts/lightbox.js"]
 use_directory_urls = true
 nav = [
   {"Quick Start" = "quickstart.md"},
+  {"Changelog" = "changelog.md"},
   {"Contributing" = "contributing.md"},
   {"Configuration" = "configuration.md"},
   {"Usage Guide" = "usage.md"},
@@ -37,7 +38,6 @@ nav = [
   {"Filesystem Session Sync" = "filesystem-sync.md"},
   {"PostgreSQL Sync" = "pg-sync.md"},
   {"DuckDB Mirror" = "duckdb.md"},
-  {"Changelog" = "changelog.md"},
 ]
 
 [project.extra]


### PR DESCRIPTION
The changelog was at the end of the documentation navigation, which made release history harder to discover. This moves it directly below Quick Start so readers can find recent changes near the main entry point. All existing page labels and routes remain unchanged.
