### PR TITLE
Make daily usage snapshot selection planner-independent

### DIFF
--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -1275,7 +1275,7 @@ func snapshotRankedDailyUsageRowsSQL(
 // length prefix keeps the encoding injective for any identifier content.
 // prefix qualifies the column references, for example "u.".
 func usageSnapshotRequestKey(prefix string) string {
-	return "length(" + prefix + "claude_message_id) || ':' || " +
+	return "length(CAST(" + prefix + "claude_message_id AS BLOB)) || ':' || " +
 		prefix + "claude_message_id || " + prefix + "claude_request_id"
 }
 

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.kenn.io/agentsview/internal/activity"
 	"go.kenn.io/agentsview/internal/export"
@@ -1156,6 +1157,13 @@ func exactUsageUTCWindow(f UsageFilter) usageBounds {
 // window functions cost two to five times the underlying scan, because
 // SQLite sorts and materializes the full-width rows once per window.
 //
+// The pass-through rows are selected with an IN probe against
+// usage_snapshot_dups rather than a LEFT JOIN onto usage_snapshot_ranked.
+// SQLite always builds an ephemeral index for an IN subquery, whereas
+// joining onto a materialized CTE relies on the planner choosing an
+// automatic index; if it scans instead, the join is quadratic in the row
+// source. The ranked survivors are appended with UNION ALL.
+//
 // rowsArgs are the placeholders of rowsSQL; the returned args carry them in
 // position with the ranking's own placeholders. Callers finish with
 // dailyUsageRowSelectFromSnapshotRowsWithMachine.
@@ -1203,17 +1211,17 @@ func snapshotRankedDailyUsageRowsSQL(
 	return fmt.Sprintf(`
 		WITH usage_snapshot_dups AS (%[1]s),
 		usage_snapshot_ranked AS (
-			SELECT u.session_id, u.message_ordinal,
+			SELECT u.*,
 				FIRST_VALUE(u.session_id) OVER attribution
 					AS snapshot_attribution_session_id,
 				FIRST_VALUE(u.project) OVER attribution AS snapshot_project,
 				FIRST_VALUE(u.agent) OVER attribution AS snapshot_agent,
 				FIRST_VALUE(u.machine) OVER attribution AS snapshot_machine,
-				ROW_NUMBER() OVER ranking AS snapshot_rank,
 				MAX(%[5]s) OVER (
 					ranking ROWS BETWEEN UNBOUNDED PRECEDING
 						AND UNBOUNDED FOLLOWING
-				) AS snapshot_web_search_requests
+				) AS snapshot_web_search_requests,
+				ROW_NUMBER() OVER ranking AS snapshot_rank
 			FROM (%[2]s) u
 			WHERE %[3]s
 			WINDOW attribution AS (
@@ -1232,24 +1240,43 @@ func snapshotRankedDailyUsageRowsSQL(
 		),
 		usage_snapshot_survivors AS (
 			SELECT u.*,
-				COALESCE(r.snapshot_attribution_session_id, u.session_id)
-					AS snapshot_attribution_session_id,
-				COALESCE(r.snapshot_project, u.project) AS snapshot_project,
-				COALESCE(r.snapshot_agent, u.agent) AS snapshot_agent,
-				COALESCE(r.snapshot_machine, u.machine) AS snapshot_machine,
-				r.snapshot_web_search_requests
+				u.session_id AS snapshot_attribution_session_id,
+				u.project AS snapshot_project,
+				u.agent AS snapshot_agent,
+				u.machine AS snapshot_machine,
+				NULL AS snapshot_web_search_requests,
+				1 AS snapshot_rank
 			FROM (%[6]s) u
-			LEFT JOIN usage_snapshot_ranked r
-				ON u.usage_source = 'message'
-				AND r.session_id = u.session_id
-				AND r.message_ordinal = u.message_ordinal
 			WHERE %[3]s
-				AND (r.snapshot_rank IS NULL OR r.snapshot_rank = 1)
+				AND NOT (
+					u.usage_source = 'message'
+					AND u.claude_message_id != ''
+					AND u.claude_request_id != ''
+					AND (%[8]s) IN (
+						SELECT %[9]s FROM usage_snapshot_dups
+					)
+				)
+			UNION ALL
+			SELECT r.*
+			FROM usage_snapshot_ranked r
+			WHERE r.snapshot_rank = 1
 		)
 		SELECT survivor.*
 		FROM usage_snapshot_survivors survivor%[7]s`,
 		dupsSQL, claudeRowsSQL, windowWhere, outputTokens,
-		webSearchRequests, rowsSQL, survivorFilter), args
+		webSearchRequests, rowsSQL, survivorFilter,
+		usageSnapshotRequestKey("u."), usageSnapshotRequestKey("")), args
+}
+
+// usageSnapshotRequestKey encodes a Claude request identity as one text
+// value so the pass-through IN probe hashes a single column: SQLite builds
+// a Bloom filter for a single-column IN list but not for a row-value IN,
+// which made the probe cost more than the ranking it guards. The
+// length prefix keeps the encoding injective for any identifier content.
+// prefix qualifies the column references, for example "u.".
+func usageSnapshotRequestKey(prefix string) string {
+	return "length(" + prefix + "claude_message_id) || ':' || " +
+		prefix + "claude_message_id || " + prefix + "claude_request_id"
 }
 
 // usageSnapshotWindowWhere restricts rows to the filter's exact UTC window
@@ -1645,18 +1672,30 @@ func skipJSONSpace(tokenJSON string, i int) int {
 	return i
 }
 
+// parseJSONString reads the JSON string literal starting at tokenJSON[i]
+// and returns its decoded value and the index after the closing quote.
+// Literals without escapes or control characters, which is every usage key
+// and nearly every value, are returned as a substring so the hot per-row
+// scan does not allocate; anything else goes through encoding/json so the
+// result matches json.Unmarshal exactly.
 func parseJSONString(tokenJSON string, i int) (string, int, bool) {
 	if i >= len(tokenJSON) || tokenJSON[i] != '"' {
 		return "", i, false
 	}
+	plain := true
 	for j := i + 1; j < len(tokenJSON); j++ {
-		switch tokenJSON[j] {
-		case '\\':
+		c := tokenJSON[j]
+		switch {
+		case c == '\\':
 			if j+1 >= len(tokenJSON) {
 				return "", len(tokenJSON), false
 			}
+			plain = false
 			j++
-		case '"':
+		case c == '"':
+			if plain && utf8.ValidString(tokenJSON[i+1:j]) {
+				return tokenJSON[i+1 : j], j + 1, true
+			}
 			raw := tokenJSON[i : j+1]
 			var value string
 			err := json.Unmarshal([]byte(raw), &value)
@@ -1664,6 +1703,8 @@ func parseJSONString(tokenJSON string, i int) (string, int, bool) {
 				return "", j + 1, false
 			}
 			return value, j + 1, true
+		case c < 0x20:
+			plain = false
 		}
 	}
 	return "", len(tokenJSON), false

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -1533,10 +1533,13 @@ func TestParseJSONStringMatchesEncodingJSON(t *testing.T) {
 			assert.Equal(t, tc.ok, ok, "ok")
 			assert.Equal(t, tc.next, next, "next")
 			assert.Equal(t, tc.want, got, "value")
-			if !tc.ok || tc.next > len(tc.input) {
+			var want string
+			if !tc.ok {
+				require.Error(t,
+					json.Unmarshal([]byte(tc.input), &want),
+					"json.Unmarshal parity")
 				return
 			}
-			var want string
 			require.NoError(t, json.Unmarshal(
 				[]byte(tc.input[:tc.next]), &want))
 			assert.Equal(t, want, got, "json.Unmarshal parity")
@@ -1655,6 +1658,46 @@ func TestGetDailyUsage_DedupesByClaudeMessageAndRequestID(t *testing.T) {
 	assert.Equal(t, 580, day.OutputTokens, "output")
 	assert.Equal(t, 1200, day.CacheCreationTokens, "cache_cr")
 	assert.Equal(t, 55000, day.CacheReadTokens, "cache_rd")
+}
+
+func TestGetDailyUsage_DistinguishesClaudeIDsContainingNUL(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "nul-identities", "project", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2026-04-10T10:00:00Z")
+	})
+
+	insertMessages(t, d,
+		Message{
+			SessionID: "nul-identities", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-04-10T10:01:00Z", Model: "model",
+			ClaudeMessageID: "a\x00", ClaudeRequestID: "x",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":100,"output_tokens":10}`),
+		},
+		Message{
+			SessionID: "nul-identities", Ordinal: 1, Role: "assistant",
+			Timestamp: "2026-04-10T10:02:00Z", Model: "model",
+			ClaudeMessageID: "a\x00", ClaudeRequestID: "x",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":200,"output_tokens":20}`),
+		},
+		Message{
+			SessionID: "nul-identities", Ordinal: 2, Role: "assistant",
+			Timestamp: "2026-04-10T10:03:00Z", Model: "model",
+			ClaudeMessageID: "a", ClaudeRequestID: "\x00x",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":300,"output_tokens":30}`),
+		},
+	)
+
+	result, err := d.GetDailyUsage(t.Context(), UsageFilter{
+		From: "2026-04-10", To: "2026-04-10", Timezone: "UTC",
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Daily, 1)
+	assert.Equal(t, 500, result.Daily[0].InputTokens)
+	assert.Equal(t, 50, result.Daily[0].OutputTokens)
 }
 
 func TestUsageAggregatesPreferCompleteClaudeSnapshotAcrossSessions(t *testing.T) {
@@ -3903,51 +3946,11 @@ func TestExcludeModelFilter(t *testing.T) {
 	}
 }
 
-// BenchmarkGetDailyUsage seeds 500 sessions with 200 messages each, spread
-// over 60 days, and times the daily usage query over 1-, 7-, 30-, and 60-day
-// windows. Claude sessions carry request identities and every tenth Claude
-// request is repeated by the next Claude session as a lower-output
-// streaming snapshot, so the snapshot ranking has duplicated requests to
-// rank and the pass-through rows have a non-empty set to probe against.
-// The window set checks that the query scales with the window rather than
-// with the archive.
+// BenchmarkGetDailyUsage retains the original 100,000-row fixture and name
+// so benchgate can compare this branch directly with its merge base.
 func BenchmarkGetDailyUsage(b *testing.B) {
 	d := testDB(b)
 	ctx := context.Background()
-	seedDailyUsageBenchmark(b, d)
-
-	windows := []struct {
-		name string
-		from string
-	}{
-		{"window=1d", "2024-07-30"},
-		{"window=7d", "2024-07-24"},
-		{"window=30d", "2024-07-01"},
-		{"window=60d", "2024-06-01"},
-	}
-	for _, w := range windows {
-		b.Run(w.name, func(b *testing.B) {
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_, err := d.GetDailyUsage(ctx, UsageFilter{
-					From:     w.from,
-					To:       "2024-07-30",
-					Timezone: "UTC",
-				})
-				if err != nil {
-					b.Fatalf("GetDailyUsage: %v", err)
-				}
-			}
-		})
-	}
-}
-
-// seedDailyUsageBenchmark populates d with the BenchmarkGetDailyUsage
-// fixture: pricing for four models and 500 sessions of 200 messages each
-// spread over 60 days from 2024-06-01, plus a streaming snapshot for every
-// tenth Claude request repeated in the next Claude session.
-func seedDailyUsageBenchmark(tb testing.TB, d *DB) {
-	tb.Helper()
 	origLog := log.Writer()
 	log.SetOutput(io.Discard)
 	defer log.SetOutput(origLog)
@@ -3966,7 +3969,7 @@ func seedDailyUsageBenchmark(tb testing.TB, d *DB) {
 			InputPerMTok: money.MustParseDollars("1.25"), OutputPerMTok: money.MustParseDollars("5.0"),
 			CacheCreationPerMTok: money.MustParseDollars("1.25"), CacheReadPerMTok: money.MustParseDollars("0.125")},
 	}); err != nil {
-		tb.Fatalf("UpsertModelPricing: %v", err)
+		b.Fatalf("UpsertModelPricing: %v", err)
 	}
 
 	projects := []string{
@@ -3975,28 +3978,25 @@ func seedDailyUsageBenchmark(tb testing.TB, d *DB) {
 		"dotfiles", "playground",
 	}
 	agents := []string{"claude", "codex", "openhands"}
-	claudeModels := []string{
+	models := []string{
 		"claude-sonnet-4-20250514",
 		"claude-opus-4-20250514",
+		"gpt-5",
+		"gemini-2.5-pro",
 	}
-	otherModels := []string{"gpt-5", "gemini-2.5-pro"}
 
 	// 500 sessions × 200 messages each = 100k rows.
 	const sessionCount = 500
 	const msgsPerSession = 200
-	const snapshotEvery = 10
 
 	tokenUsage := `{"input_tokens":1200,"output_tokens":480,` +
-		`"cache_creation_input_tokens":300,` +
-		`"cache_read_input_tokens":2400}`
-	snapshotTokenUsage := `{"input_tokens":1200,"output_tokens":120,` +
 		`"cache_creation_input_tokens":300,` +
 		`"cache_read_input_tokens":2400}`
 
 	// Pre-parse the anchor timestamp once; the seed loop offsets from it.
 	startTime, err := time.Parse(time.RFC3339, "2024-06-01T00:00:00Z")
 	if err != nil {
-		tb.Fatalf("parsing start time: %v", err)
+		b.Fatalf("parsing start time: %v", err)
 	}
 
 	for i := range sessionCount {
@@ -4005,28 +4005,207 @@ func seedDailyUsageBenchmark(tb testing.TB, d *DB) {
 		agent := agents[i%len(agents)]
 		// Spread sessions across a 60-day window.
 		dayOffset := i % 60
-		day := startTime.AddDate(0, 0, dayOffset)
 		s := Session{
 			ID:           id,
 			Project:      project,
 			Machine:      defaultMachine,
 			Agent:        agent,
 			MessageCount: msgsPerSession,
-			StartedAt:    new(day.Format(time.RFC3339)),
+			StartedAt:    new(startTime.Format(time.RFC3339)),
 		}
 		if err := d.UpsertSession(s); err != nil {
-			tb.Fatalf("UpsertSession: %v", err)
+			b.Fatalf("UpsertSession: %v", err)
 		}
-		msgs := make([]Message, 0, msgsPerSession)
+		msgs := make([]Message, msgsPerSession)
+		for j := range msgsPerSession {
+			msgs[j] = Message{
+				SessionID:  id,
+				Ordinal:    j,
+				Role:       "assistant",
+				Timestamp:  startTime.AddDate(0, 0, dayOffset).Format(time.RFC3339),
+				Model:      models[(i+j)%len(models)],
+				TokenUsage: json.RawMessage(tokenUsage),
+			}
+		}
+		if err := d.InsertMessages(msgs); err != nil {
+			b.Fatalf("InsertMessages: %v", err)
+		}
+	}
+
+	log.SetOutput(origLog)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := d.GetDailyUsage(ctx, UsageFilter{
+			From: "2024-06-01",
+			To:   "2024-08-01",
+		})
+		if err != nil {
+			b.Fatalf("GetDailyUsage: %v", err)
+		}
+	}
+}
+
+// BenchmarkGetDailyUsageSnapshotWindows measures the ordinary CLI query
+// shape over bounded windows with duplicated Claude streaming snapshots.
+func BenchmarkGetDailyUsageSnapshotWindows(b *testing.B) {
+	d := testDB(b)
+	seedDailyUsageSnapshotBenchmark(b, d)
+
+	windows := []struct {
+		name string
+		from string
+		want benchmarkDailyUsageExpectation
+	}{
+		{"window=1d", "2024-07-30", benchmarkDailyUsageExpectation{
+			days: 1, input: 1_920_000, output: 768_000,
+			cacheCreation: 480_000, cacheRead: 3_840_000,
+		}},
+		{"window=7d", "2024-07-24", benchmarkDailyUsageExpectation{
+			days: 7, input: 13_440_000, output: 5_376_000,
+			cacheCreation: 3_360_000, cacheRead: 26_880_000,
+		}},
+		{"window=30d", "2024-07-01", benchmarkDailyUsageExpectation{
+			days: 30, input: 57_600_000, output: 23_040_000,
+			cacheCreation: 14_400_000, cacheRead: 115_200_000,
+		}},
+		{"window=60d", "2024-06-01", benchmarkDailyUsageExpectation{
+			days: 60, input: 120_000_000, output: 48_000_000,
+			cacheCreation: 30_000_000, cacheRead: 240_000_000,
+		}},
+	}
+	for _, window := range windows {
+		b.Run(window.name, func(b *testing.B) {
+			benchmarkDailyUsageSnapshotWindow(
+				b, d, window.from, window.want,
+			)
+		})
+	}
+}
+
+// BenchmarkGetDailyUsageSnapshotAutomaticIndexOff keeps the survivor query
+// fast even when SQLite cannot create an automatic join index.
+func BenchmarkGetDailyUsageSnapshotAutomaticIndexOff(b *testing.B) {
+	d := testDB(b)
+	seedDailyUsageSnapshotBenchmark(b, d)
+	reader := d.rawReader()
+	reader.SetMaxOpenConns(1)
+	_, err := reader.ExecContext(b.Context(), "PRAGMA automatic_index = OFF")
+	require.NoError(b, err)
+	var automaticIndex int
+	require.NoError(b,
+		reader.QueryRowContext(b.Context(), "PRAGMA automatic_index").
+			Scan(&automaticIndex))
+	require.Zero(b, automaticIndex)
+
+	benchmarkDailyUsageSnapshotWindow(
+		b, d, "2024-07-01", benchmarkDailyUsageExpectation{
+			days: 30, input: 57_600_000, output: 23_040_000,
+			cacheCreation: 14_400_000, cacheRead: 115_200_000,
+		},
+	)
+}
+
+type benchmarkDailyUsageExpectation struct {
+	days          int
+	input         int
+	output        int
+	cacheCreation int
+	cacheRead     int
+}
+
+func benchmarkDailyUsageSnapshotWindow(
+	b *testing.B,
+	d *DB,
+	from string,
+	want benchmarkDailyUsageExpectation,
+) {
+	b.Helper()
+	ctx := context.Background()
+	filter := UsageFilter{
+		From: from, To: "2024-07-30", Timezone: "UTC",
+		SkipSessionCounts: true,
+	}
+
+	result, err := d.GetDailyUsage(ctx, filter)
+	require.NoError(b, err)
+	require.Len(b, result.Daily, want.days)
+	assert.Equal(b, want.input, result.Totals.InputTokens)
+	assert.Equal(b, want.output, result.Totals.OutputTokens)
+	assert.Equal(b, want.cacheCreation, result.Totals.CacheCreationTokens)
+	assert.Equal(b, want.cacheRead, result.Totals.CacheReadTokens)
+	assert.Zero(b, result.SessionCounts.Total)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := d.GetDailyUsage(ctx, filter)
+		if err != nil {
+			b.Fatalf("GetDailyUsage: %v", err)
+		}
+	}
+}
+
+// seedDailyUsageSnapshotBenchmark adds 100,000 base messages and 3,320
+// lower-output snapshots across 500 sessions and 60 days.
+func seedDailyUsageSnapshotBenchmark(tb testing.TB, d *DB) {
+	tb.Helper()
+	origLog := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(origLog)
+
+	require.NoError(tb, d.UpsertModelPricing([]ModelPricing{
+		{ModelPattern: "claude-sonnet-4-20250514",
+			InputPerMTok: money.MustParseDollars("3.0"), OutputPerMTok: money.MustParseDollars("15.0"),
+			CacheCreationPerMTok: money.MustParseDollars("3.75"), CacheReadPerMTok: money.MustParseDollars("0.30")},
+		{ModelPattern: "claude-opus-4-20250514",
+			InputPerMTok: money.MustParseDollars("15.0"), OutputPerMTok: money.MustParseDollars("75.0"),
+			CacheCreationPerMTok: money.MustParseDollars("18.75"), CacheReadPerMTok: money.MustParseDollars("1.50")},
+		{ModelPattern: "gpt-5",
+			InputPerMTok: money.MustParseDollars("2.5"), OutputPerMTok: money.MustParseDollars("10.0"),
+			CacheCreationPerMTok: money.MustParseDollars("2.5"), CacheReadPerMTok: money.MustParseDollars("0.25")},
+		{ModelPattern: "gemini-2.5-pro",
+			InputPerMTok: money.MustParseDollars("1.25"), OutputPerMTok: money.MustParseDollars("5.0"),
+			CacheCreationPerMTok: money.MustParseDollars("1.25"), CacheReadPerMTok: money.MustParseDollars("0.125")},
+	}))
+
+	projects := []string{
+		"agentsview", "quokka", "arrow-rs", "side-quests",
+		"infrastructure", "blog", "experiments", "docs",
+		"dotfiles", "playground",
+	}
+	agents := []string{"claude", "codex", "openhands"}
+	claudeModels := []string{
+		"claude-sonnet-4-20250514", "claude-opus-4-20250514",
+	}
+	otherModels := []string{"gpt-5", "gemini-2.5-pro"}
+
+	const sessionCount = 500
+	const msgsPerSession = 200
+	const snapshotEvery = 10
+	tokenUsage := json.RawMessage(
+		`{"input_tokens":1200,"output_tokens":480,` +
+			`"cache_creation_input_tokens":300,` +
+			`"cache_read_input_tokens":2400}`)
+	snapshotTokenUsage := json.RawMessage(
+		`{"input_tokens":1200,"output_tokens":120,` +
+			`"cache_creation_input_tokens":300,` +
+			`"cache_read_input_tokens":2400}`)
+	startTime, err := time.Parse(time.RFC3339, "2024-06-01T00:00:00Z")
+	require.NoError(tb, err)
+
+	for i := range sessionCount {
+		id := "bench-sess-" + strconv.Itoa(i)
+		agent := agents[i%len(agents)]
+		day := startTime.AddDate(0, 0, i%60)
+		msgs := make([]Message, 0, msgsPerSession+msgsPerSession/snapshotEvery)
 		for j := range msgsPerSession {
 			ts := day.Add(time.Duration(j) * time.Minute)
 			msg := Message{
-				SessionID:  id,
-				Ordinal:    len(msgs),
-				Role:       "assistant",
+				SessionID: id, Ordinal: len(msgs), Role: "assistant",
 				Timestamp:  ts.Format(time.RFC3339),
 				Model:      otherModels[(i+j)%len(otherModels)],
-				TokenUsage: json.RawMessage(tokenUsage),
+				TokenUsage: tokenUsage,
 			}
 			if agent == "claude" {
 				msg.Model = claudeModels[(i+j)%len(claudeModels)]
@@ -4036,29 +4215,47 @@ func seedDailyUsageBenchmark(tb testing.TB, d *DB) {
 				msg.HasOutputTokens = true
 			}
 			msgs = append(msgs, msg)
-			// Repeat every tenth request of the previous Claude session
-			// as a streaming snapshot: same identity, smaller output,
-			// later timestamp, in this session.
+
 			prev := i - len(agents)
 			if agent == "claude" && prev >= 0 && j%snapshotEvery == 0 {
+				prevDay := startTime.AddDate(0, 0, prev%60)
 				msgs = append(msgs, Message{
-					SessionID:       id,
-					Ordinal:         len(msgs),
-					Role:            "assistant",
-					Timestamp:       ts.Add(30 * time.Second).Format(time.RFC3339),
+					SessionID: id, Ordinal: len(msgs), Role: "assistant",
+					Timestamp: prevDay.Add(time.Duration(j)*time.Minute +
+						30*time.Second).Format(time.RFC3339),
 					Model:           claudeModels[(prev+j)%len(claudeModels)],
-					TokenUsage:      json.RawMessage(snapshotTokenUsage),
+					TokenUsage:      snapshotTokenUsage,
 					ClaudeMessageID: benchClaudeID("msg", prev, j),
 					ClaudeRequestID: benchClaudeID("req", prev, j),
-					OutputTokens:    120,
-					HasOutputTokens: true,
+					OutputTokens:    120, HasOutputTokens: true,
 				})
 			}
 		}
-		if err := d.InsertMessages(msgs); err != nil {
-			tb.Fatalf("InsertMessages: %v", err)
-		}
+
+		require.NoError(tb, d.UpsertSession(Session{
+			ID: id, Project: projects[i%len(projects)],
+			Machine: defaultMachine, Agent: agent,
+			MessageCount: len(msgs), StartedAt: new(day.Format(time.RFC3339)),
+		}))
+		require.NoError(tb, d.InsertMessages(msgs))
 	}
+
+	var messageRows, recordedMessages, duplicateRequests int
+	require.NoError(tb, d.rawWriter().QueryRow(
+		`SELECT COUNT(*) FROM messages`).Scan(&messageRows))
+	require.NoError(tb, d.rawWriter().QueryRow(
+		`SELECT SUM(message_count) FROM sessions`).Scan(&recordedMessages))
+	require.NoError(tb, d.rawWriter().QueryRow(`
+		SELECT COUNT(*) FROM (
+			SELECT claude_message_id, claude_request_id
+			FROM messages
+			WHERE claude_message_id != '' AND claude_request_id != ''
+			GROUP BY claude_message_id, claude_request_id
+			HAVING COUNT(*) > 1
+		)`).Scan(&duplicateRequests))
+	require.Equal(tb, 103_320, messageRows)
+	require.Equal(tb, 103_320, recordedMessages)
+	require.Equal(tb, 3_320, duplicateRequests)
 }
 
 func benchClaudeID(kind string, session, ordinal int) string {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -1504,6 +1504,46 @@ func TestParseUsageTokenCounters(t *testing.T) {
 	assert.Zero(t, cacheRead)
 }
 
+// TestParseJSONStringMatchesEncodingJSON pins the string scanner to
+// json.Unmarshal: the escape-free fast path and the encoding/json fallback
+// must decode identically and reject the same input.
+func TestParseJSONStringMatchesEncodingJSON(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+		next  int
+		ok    bool
+	}{
+		{"plain", `"input_tokens":1`, "input_tokens", 14, true},
+		{"empty", `""`, "", 2, true},
+		{"escaped quote", `"a\"b"`, `a"b`, 6, true},
+		{"escaped slash", `"https:\/\/x"`, "https://x", 13, true},
+		{"unicode escape", `"\u00e9"`, "é", 8, true},
+		{"raw utf8", `"é"`, "é", 4, true},
+		{"trailing escape", `"abc\`, "", 5, false},
+		{"unterminated", `"abc`, "", 4, false},
+		{"not a string", `123`, "", 0, false},
+		{"raw control char", "\"a\tb\"", "", 5, false},
+		{"invalid utf8", "\"a\xffb\"", "a\ufffdb", 5, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, next, ok := parseJSONString(tc.input, 0)
+			assert.Equal(t, tc.ok, ok, "ok")
+			assert.Equal(t, tc.next, next, "next")
+			assert.Equal(t, tc.want, got, "value")
+			if !tc.ok || tc.next > len(tc.input) {
+				return
+			}
+			var want string
+			require.NoError(t, json.Unmarshal(
+				[]byte(tc.input[:tc.next]), &want))
+			assert.Equal(t, want, got, "json.Unmarshal parity")
+		})
+	}
+}
+
 func TestUsageAggregationClampsMessageTokenJSON(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
@@ -3863,9 +3903,51 @@ func TestExcludeModelFilter(t *testing.T) {
 	}
 }
 
+// BenchmarkGetDailyUsage seeds 500 sessions with 200 messages each, spread
+// over 60 days, and times the daily usage query over 1-, 7-, 30-, and 60-day
+// windows. Claude sessions carry request identities and every tenth Claude
+// request is repeated by the next Claude session as a lower-output
+// streaming snapshot, so the snapshot ranking has duplicated requests to
+// rank and the pass-through rows have a non-empty set to probe against.
+// The window set checks that the query scales with the window rather than
+// with the archive.
 func BenchmarkGetDailyUsage(b *testing.B) {
 	d := testDB(b)
 	ctx := context.Background()
+	seedDailyUsageBenchmark(b, d)
+
+	windows := []struct {
+		name string
+		from string
+	}{
+		{"window=1d", "2024-07-30"},
+		{"window=7d", "2024-07-24"},
+		{"window=30d", "2024-07-01"},
+		{"window=60d", "2024-06-01"},
+	}
+	for _, w := range windows {
+		b.Run(w.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := d.GetDailyUsage(ctx, UsageFilter{
+					From:     w.from,
+					To:       "2024-07-30",
+					Timezone: "UTC",
+				})
+				if err != nil {
+					b.Fatalf("GetDailyUsage: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// seedDailyUsageBenchmark populates d with the BenchmarkGetDailyUsage
+// fixture: pricing for four models and 500 sessions of 200 messages each
+// spread over 60 days from 2024-06-01, plus a streaming snapshot for every
+// tenth Claude request repeated in the next Claude session.
+func seedDailyUsageBenchmark(tb testing.TB, d *DB) {
+	tb.Helper()
 	origLog := log.Writer()
 	log.SetOutput(io.Discard)
 	defer log.SetOutput(origLog)
@@ -3884,7 +3966,7 @@ func BenchmarkGetDailyUsage(b *testing.B) {
 			InputPerMTok: money.MustParseDollars("1.25"), OutputPerMTok: money.MustParseDollars("5.0"),
 			CacheCreationPerMTok: money.MustParseDollars("1.25"), CacheReadPerMTok: money.MustParseDollars("0.125")},
 	}); err != nil {
-		b.Fatalf("UpsertModelPricing: %v", err)
+		tb.Fatalf("UpsertModelPricing: %v", err)
 	}
 
 	projects := []string{
@@ -3893,25 +3975,28 @@ func BenchmarkGetDailyUsage(b *testing.B) {
 		"dotfiles", "playground",
 	}
 	agents := []string{"claude", "codex", "openhands"}
-	models := []string{
+	claudeModels := []string{
 		"claude-sonnet-4-20250514",
 		"claude-opus-4-20250514",
-		"gpt-5",
-		"gemini-2.5-pro",
 	}
+	otherModels := []string{"gpt-5", "gemini-2.5-pro"}
 
 	// 500 sessions × 200 messages each = 100k rows.
 	const sessionCount = 500
 	const msgsPerSession = 200
+	const snapshotEvery = 10
 
 	tokenUsage := `{"input_tokens":1200,"output_tokens":480,` +
+		`"cache_creation_input_tokens":300,` +
+		`"cache_read_input_tokens":2400}`
+	snapshotTokenUsage := `{"input_tokens":1200,"output_tokens":120,` +
 		`"cache_creation_input_tokens":300,` +
 		`"cache_read_input_tokens":2400}`
 
 	// Pre-parse the anchor timestamp once; the seed loop offsets from it.
 	startTime, err := time.Parse(time.RFC3339, "2024-06-01T00:00:00Z")
 	if err != nil {
-		b.Fatalf("parsing start time: %v", err)
+		tb.Fatalf("parsing start time: %v", err)
 	}
 
 	for i := range sessionCount {
@@ -3920,45 +4005,65 @@ func BenchmarkGetDailyUsage(b *testing.B) {
 		agent := agents[i%len(agents)]
 		// Spread sessions across a 60-day window.
 		dayOffset := i % 60
+		day := startTime.AddDate(0, 0, dayOffset)
 		s := Session{
 			ID:           id,
 			Project:      project,
 			Machine:      defaultMachine,
 			Agent:        agent,
 			MessageCount: msgsPerSession,
-			StartedAt:    new(startTime.Format(time.RFC3339)),
+			StartedAt:    new(day.Format(time.RFC3339)),
 		}
 		if err := d.UpsertSession(s); err != nil {
-			b.Fatalf("UpsertSession: %v", err)
+			tb.Fatalf("UpsertSession: %v", err)
 		}
-		msgs := make([]Message, msgsPerSession)
+		msgs := make([]Message, 0, msgsPerSession)
 		for j := range msgsPerSession {
-			msgs[j] = Message{
+			ts := day.Add(time.Duration(j) * time.Minute)
+			msg := Message{
 				SessionID:  id,
-				Ordinal:    j,
+				Ordinal:    len(msgs),
 				Role:       "assistant",
-				Timestamp:  startTime.AddDate(0, 0, dayOffset).Format(time.RFC3339),
-				Model:      models[(i+j)%len(models)],
+				Timestamp:  ts.Format(time.RFC3339),
+				Model:      otherModels[(i+j)%len(otherModels)],
 				TokenUsage: json.RawMessage(tokenUsage),
+			}
+			if agent == "claude" {
+				msg.Model = claudeModels[(i+j)%len(claudeModels)]
+				msg.ClaudeMessageID = benchClaudeID("msg", i, j)
+				msg.ClaudeRequestID = benchClaudeID("req", i, j)
+				msg.OutputTokens = 480
+				msg.HasOutputTokens = true
+			}
+			msgs = append(msgs, msg)
+			// Repeat every tenth request of the previous Claude session
+			// as a streaming snapshot: same identity, smaller output,
+			// later timestamp, in this session.
+			prev := i - len(agents)
+			if agent == "claude" && prev >= 0 && j%snapshotEvery == 0 {
+				msgs = append(msgs, Message{
+					SessionID:       id,
+					Ordinal:         len(msgs),
+					Role:            "assistant",
+					Timestamp:       ts.Add(30 * time.Second).Format(time.RFC3339),
+					Model:           claudeModels[(prev+j)%len(claudeModels)],
+					TokenUsage:      json.RawMessage(snapshotTokenUsage),
+					ClaudeMessageID: benchClaudeID("msg", prev, j),
+					ClaudeRequestID: benchClaudeID("req", prev, j),
+					OutputTokens:    120,
+					HasOutputTokens: true,
+				})
 			}
 		}
 		if err := d.InsertMessages(msgs); err != nil {
-			b.Fatalf("InsertMessages: %v", err)
+			tb.Fatalf("InsertMessages: %v", err)
 		}
 	}
+}
 
-	log.SetOutput(origLog)
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err := d.GetDailyUsage(ctx, UsageFilter{
-			From: "2024-06-01",
-			To:   "2024-08-01",
-		})
-		if err != nil {
-			b.Fatalf("GetDailyUsage: %v", err)
-		}
-	}
+func benchClaudeID(kind string, session, ordinal int) string {
+	return kind + "-bench-" + strconv.Itoa(session) + "-" +
+		strconv.Itoa(ordinal)
 }
 
 func TestGetDailyUsage_PricingPrecedence(t *testing.T) {


### PR DESCRIPTION
Daily usage on large SQLite archives no longer depends on SQLite choosing an automatic index for the Claude snapshot-survivor join. Pass-through rows now use an indexed single-column request-key probe, while ranked survivors are appended directly. This keeps the query linear when the planner would otherwise scan the materialized ranking for every usage row.

The request key counts identifier bytes, so embedded NUL characters cannot make distinct Claude request identities collide. The hot JSON scanner also returns ordinary escape-free strings without an `encoding/json` round trip; on the preserved 100,000-row benchmark this reduced allocations by about 44% and allocated bytes by about 52%.

The planner-independent query adds about 13–21% SQL time on the synthetic snapshot fixture when the old automatic-index plan cooperates. In exchange, disabling automatic indexes changed the 30-day case from about 8.6 seconds with the old join to about 0.25 seconds with the new probe. Wall-clock results on the full benchmark were noisy, while both benchmark-gate orderings remained within the configured threshold.

Benchmark coverage now keeps the original merge-base-comparable case and adds validated 1-, 7-, 30-, and 60-day CLI-shaped windows with duplicated snapshots, plus an explicit automatic-index-disabled case. PostgreSQL remains on its existing backend-specific query. DuckDB `sqlite_scan` and the separate offline database-open cost remain deferred.
