### PR TITLE
docs: document the 0.41.1 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,12 +5,30 @@ description: Release history for AgentsView
 
 ## Unreleased
 
+---
+
+## 0.41.1
+
+<small>2026-08-18</small>
+
+**New features**
+
+- Add Windows system tray support with proper lifecycle behavior.
+
 **Bug fixes**
 
-- Ignore self-referential subagent spawn edges when linking session
-  hierarchy, and resolve a self-parent claim to the parser-derived parent (or
-  no parent) at ingest and once per archive for rows an earlier build had
-  linked to themselves.
+- Keep oversized VS Code Copilot snapshots searchable and indexable.
+- Make daily usage snapshots reliable regardless of database query planning.
+- Ignore invalid self-referential subagent links.
+
+**Acknowledgements**
+
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for Windows
+  system tray support.
+- Thanks to [Rod Boev](https://github.com/rodboev) for keeping oversized VS Code
+  Copilot snapshots indexable and ignoring self-referential subagent links.
+- Thanks to [Wes McKinney](https://github.com/wesm) for reliable daily usage
+  snapshots and release documentation.
 
 ---
 


### PR DESCRIPTION
AgentsView 0.41.1 shipped Windows system tray support and three reliability
fixes, but the published changelog did not yet describe the release as a
complete, dated entry.

This documents the shipped behavior and credits the contributors responsible
for the Windows lifecycle, VS Code Copilot indexing, daily usage snapshots,
and subagent-link fixes. The change is limited to release text; existing
screenshot assets remain unchanged.
