### PR TITLE
fix(activity): restore Grok agent-minutes

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -458,6 +458,9 @@ add an archived or maintained mirror without replacing the original identity.
   wraps each persisted update in a Unix-second timestamp envelope. The
   [conversation types](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-sampling-types/src/conversation.rs)
   confirm that the derived chat rows themselves carry no message timestamps.
+  Agentsview maps timestamped `tool_call` and terminal `tool_call_update`
+  records to the existing tool-result event model, so Activity can use tool
+  completion time without adding derived transcript messages.
 - **Usage and cost:** Durable `turn_completed` updates may carry per-model
   input, output, cache-read, cache-creation, and reasoning tokens plus optional
   `costUsdTicks` (10^10 ticks per USD), as defined by the

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -68,29 +68,6 @@ discovered exact URLs, releases, and queries in the provider entry. If a
 repository or document disappears, retain its original URL and commit hash and
 add an archived or maintained mirror without replacing the original identity.
 
-Grok is temporarily excluded at the user's request because a separate
-format-alignment change owns that provider. Once that alignment lands, add a
-Grok section and remove the explicit registry exception in the coverage test.
-
-The narrow Grok automation-provenance claim is independently verified against
-`xai-org/grok-build` at `d92c5b0b8582fda358de1f97446aa74af44a464f`, checked
-2026-08-18. The first-party
-[headless guide](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-pager/docs/user-guide/14-headless-mode.md)
-defines prompt flags as non-interactive invocation. The producer propagates
-that startup mode into
-[`PromptContext.is_non_interactive`](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L936-L944),
-whose schema identifies headless, SDK, stdio, and generic ACP execution and
-defaults false for interactive or older contexts
-([schema](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L145-L150),
-[default](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L177-L199)).
-The producer then writes that context to the same session directory as
-`prompt_context.json`
-([persistence](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session.rs#L1384-L1404),
-[spawn call](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L1049-L1055)).
-Agentsview treats only an explicit true value in a valid, session-associated
-file as durable automation evidence; file presence, a missing field, or a
-missing file does not classify a session as automated.
-
 ## Claude Code (`claude`)
 
 - **Format:** Project-scoped JSONL transcripts, including subagent JSONL, with
@@ -464,6 +441,48 @@ missing file does not classify a session as automated.
 - **Agentsview:** `internal/parser/gemini_apps_takeout.go` and
   `internal/importer/gemini_apps.go`; the CLI-only import path does not affect
   Gemini CLI discovery or parsing.
+
+## Grok Build (`grok`)
+
+- **Format:** Workspace-scoped session directories containing `summary.json`,
+  a derived `chat_history.jsonl` model-message cache, and an authoritative
+  `updates.jsonl` stream of timestamped ACP and xAI session notifications.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/xai-org/grok-build.git` at
+  `d71f6e0c1f5acc5469e503e192fe14824e6f8c90`. The
+  [session guide](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-pager/docs/user-guide/17-sessions.md)
+  identifies `updates.jsonl` as the authoritative conversation log. The
+  [storage reducer](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-shell/src/session/storage/mod.rs)
+  rebuilds `chat_history.jsonl` from that stream, while the
+  [JSONL adapter](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-shell/src/session/storage/jsonl/mod.rs)
+  wraps each persisted update in a Unix-second timestamp envelope. The
+  [conversation types](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-sampling-types/src/conversation.rs)
+  confirm that the derived chat rows themselves carry no message timestamps.
+- **Usage and cost:** Durable `turn_completed` updates may carry per-model
+  input, output, cache-read, cache-creation, and reasoning tokens plus optional
+  `costUsdTicks` (10^10 ticks per USD), as defined by the
+  [notification schema](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-shell/src/extensions/notification.rs).
+  Agentsview emits one usage event per prompt and model, subtracts cache reads
+  from the full input count, and uses reported cost ticks when present.
+- **Automation:** The first-party
+  [headless guide](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-pager/docs/user-guide/14-headless-mode.md)
+  defines prompt flags as non-interactive invocation. The producer propagates
+  that startup mode into
+  [`PromptContext.is_non_interactive`](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L936-L944),
+  whose schema identifies headless, SDK, stdio, and generic ACP execution and
+  defaults false for interactive or older contexts
+  ([schema](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L145-L150),
+  [default](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L177-L199)).
+  The producer writes that context to the same session directory as
+  `prompt_context.json`
+  ([persistence](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session.rs#L1384-L1404),
+  [spawn call](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L1049-L1055)).
+  Agentsview treats only an explicit true value in a valid, session-associated
+  file as durable automation evidence; file presence, a missing field, or a
+  missing file does not classify a session as automated.
+- **Agentsview:** `internal/parser/grok.go`,
+  `internal/parser/grok_provider.go`, colocated tests, and the sanitized
+  upstream-generated fixtures in `internal/parser/testdata/grok-build`.
 
 ## MiMo Code (`mimocode`)
 

--- a/internal/activity/parity_pgtest_test.go
+++ b/internal/activity/parity_pgtest_test.go
@@ -70,6 +70,9 @@ type parityFixtureSession struct {
 type parityEvent struct {
 	role string
 	ts   string
+	// toolCompletedAt adds one tool execution whose start is this message's
+	// timestamp and whose completion is a non-transcript activity event.
+	toolCompletedAt string
 	// model and outputTokens override the session defaults for this one
 	// assistant message. They exist so the fixture can inject an
 	// ineligible (synthetic-model) usage row that every backend must
@@ -165,6 +168,28 @@ func parityFixture() []parityFixtureSession {
 			},
 		},
 		{
+			// Tool completion is stored outside the transcript. Every backend
+			// must include it in activity without adding a message row.
+			id: "parity-tool", project: "tools", model: "model-x",
+			events: []parityEvent{
+				{role: "user", ts: parityDate + "T15:00:00Z"},
+				{role: "assistant", ts: parityDate + "T15:01:00Z",
+					toolCompletedAt: parityDate + "T15:02:00Z"},
+			},
+		},
+		{
+			// A completion between transcript messages is already covered by
+			// message adjacency and must not add an overlapping interval.
+			id: "parity-tool-inline", project: "tools", model: "model-x",
+			events: []parityEvent{
+				{role: "user", ts: parityDate + "T15:10:00Z"},
+				{role: "assistant", ts: parityDate + "T15:11:00Z",
+					toolCompletedAt: parityDate + "T15:12:00Z"},
+				{role: "assistant", ts: parityDate + "T15:11:30Z"},
+				{role: "assistant", ts: parityDate + "T15:13:00Z"},
+			},
+		},
+		{
 			// Subagent of parity-a: a usage-only single message. Its tokens
 			// must count in every backend (the report includes subagent
 			// sessions so its cost matches daily usage) and its session row
@@ -247,6 +272,11 @@ func seedParitySQLite(t *testing.T) *db.DB {
 func paritySessionWrite(fs parityFixtureSession) db.SessionBatchWrite {
 	first := fs.events[0].ts
 	last := fs.events[len(fs.events)-1].ts
+	for _, event := range fs.events {
+		if event.toolCompletedAt > last {
+			last = event.toolCompletedAt
+		}
+	}
 	firstMsg := "parity " + fs.id
 	relationship := fs.relationship
 	if relationship == "" {
@@ -304,6 +334,22 @@ func paritySessionWrite(fs parityFixtureSession) db.SessionBatchWrite {
 			m.TokenUsage = usage
 			m.OutputTokens = outputTokens
 			m.HasOutputTokens = true
+		}
+		if ev.toolCompletedAt != "" {
+			m.HasToolUse = true
+			m.ToolCalls = []db.ToolCall{{
+				SessionID: fs.id,
+				ToolName:  "sample_tool",
+				Category:  "Other",
+				ToolUseID: fs.id + "-tool",
+				CallIndex: 0,
+				ResultEvents: []db.ToolResultEvent{
+					{ToolUseID: fs.id + "-tool", Source: "tool_execution",
+						Status: "started", Timestamp: ev.ts, EventIndex: 0},
+					{ToolUseID: fs.id + "-tool", Source: "tool_execution",
+						Status: "completed", Timestamp: ev.toolCompletedAt, EventIndex: 1},
+				},
+			}}
 		}
 		msgs = append(msgs, m)
 	}
@@ -500,6 +546,24 @@ func assertCandidateParity(
 		events, q.RangeStart, q.EffectiveEnd,
 		time.Duration(q.GapCapSeconds)*time.Second,
 	)
+	want = append(want, activity.IntervalCandidate{
+		SessionID:    "parity-tool",
+		StartOrdinal: 1,
+		EndOrdinal:   1,
+		Start:        time.Date(2026, 6, 14, 15, 1, 0, 0, time.UTC),
+		End:          time.Date(2026, 6, 14, 15, 2, 0, 0, time.UTC),
+		ClosingRole:  "tool",
+		PriorModel:   "model-x",
+	})
+	sort.Slice(want, func(i, j int) bool {
+		if !want[i].Start.Equal(want[j].Start) {
+			return want[i].Start.Before(want[j].Start)
+		}
+		if want[i].SessionID != want[j].SessionID {
+			return want[i].SessionID < want[j].SessionID
+		}
+		return want[i].StartOrdinal < want[j].StartOrdinal
+	})
 	collect := func(source activity.CandidateSource) []activity.IntervalCandidate {
 		t.Helper()
 		var candidates []activity.IntervalCandidate

--- a/internal/activity/parity_pgtest_test.go
+++ b/internal/activity/parity_pgtest_test.go
@@ -178,15 +178,23 @@ func parityFixture() []parityFixtureSession {
 			},
 		},
 		{
-			// A completion between transcript messages is already covered by
-			// message adjacency and must not add an overlapping interval.
+			// A completion between transcript messages resets the gap cap before
+			// the later message without double-counting the message interval.
 			id: "parity-tool-inline", project: "tools", model: "model-x",
 			events: []parityEvent{
 				{role: "user", ts: parityDate + "T15:10:00Z"},
 				{role: "assistant", ts: parityDate + "T15:11:00Z",
-					toolCompletedAt: parityDate + "T15:12:00Z"},
-				{role: "assistant", ts: parityDate + "T15:11:30Z"},
-				{role: "assistant", ts: parityDate + "T15:13:00Z"},
+					toolCompletedAt: parityDate + "T15:20:00Z"},
+				{role: "assistant", ts: parityDate + "T15:21:00Z"},
+			},
+		},
+		{
+			// A completion just after the report range closes the final message;
+			// aggregation clips the interval at the range boundary.
+			id: "parity-tool-boundary", project: "tools", model: "model-x",
+			events: []parityEvent{
+				{role: "assistant", ts: parityDate + "T23:59:00Z",
+					toolCompletedAt: "2026-06-15T00:01:00Z"},
 			},
 		},
 		{
@@ -554,6 +562,23 @@ func assertCandidateParity(
 		End:          time.Date(2026, 6, 14, 15, 2, 0, 0, time.UTC),
 		ClosingRole:  "tool",
 		PriorModel:   "model-x",
+	}, activity.IntervalCandidate{
+		SessionID:    "parity-tool-inline",
+		StartOrdinal: 1,
+		EndOrdinal:   2,
+		Start:        time.Date(2026, 6, 14, 15, 20, 0, 0, time.UTC),
+		End:          time.Date(2026, 6, 14, 15, 21, 0, 0, time.UTC),
+		ClosingRole:  "assistant",
+		ClosingModel: "model-x",
+		PriorModel:   "model-x",
+	}, activity.IntervalCandidate{
+		SessionID:    "parity-tool-boundary",
+		StartOrdinal: 0,
+		EndOrdinal:   0,
+		Start:        time.Date(2026, 6, 14, 23, 59, 0, 0, time.UTC),
+		End:          time.Date(2026, 6, 15, 0, 1, 0, 0, time.UTC),
+		ClosingRole:  "tool",
+		PriorModel:   "model-x",
 	})
 	sort.Slice(want, func(i, j int) bool {
 		if !want[i].Start.Equal(want[j].Start) {
@@ -611,7 +636,7 @@ func assertParityForCase(
 }
 
 // assertDayMinuteFixtureSanity checks the day-minute report actually exercises
-// the fixture: a full day with peak concurrency 2, twelve sessions, non-zero
+// the fixture: a full day with peak concurrency 2, thirteen sessions, non-zero
 // cost, and exactly 22550 output tokens. The token total proves the
 // synthetic-model usage row (9999 tokens) is excluded, the dedup pair
 // keeps its complete 9000-token snapshot with earlier attribution, the
@@ -623,7 +648,7 @@ func assertDayMinuteFixtureSanity(t *testing.T, r activity.Report) {
 	t.Helper()
 	require.False(t, r.Partial, "fixture day must be a full day")
 	require.Equal(t, 2, r.Peak.Agents, "fixture must reach peak concurrency 2")
-	require.Equal(t, 12, r.Totals.Sessions, "fixture session count")
+	require.Equal(t, 13, r.Totals.Sessions, "fixture session count")
 	require.Positive(t, r.Totals.Cost.Microdollars, "fixture must exercise cost")
 	// 2400 (parity-a) + 1600 (parity-b) + 300 (parity-c; synthetic 9999 row
 	// excluded) + 9000 (parity-d receives parity-e's complete snapshot) +
@@ -656,4 +681,10 @@ func assertDayMinuteFixtureSanity(t *testing.T, r activity.Report) {
 		"the later fractional duplicate is dropped")
 	require.Equal(t, "model-x", bySession["parity-f"].PrimaryModel,
 		"zero-cost usage still reports its known model as primary")
+	require.NotNil(t, bySession["parity-tool-inline"].AgentMinutes)
+	require.InDelta(t, 7.0, *bySession["parity-tool-inline"].AgentMinutes, 1e-9,
+		"inline completion resets the gap cap before the final message")
+	require.NotNil(t, bySession["parity-tool-boundary"].AgentMinutes)
+	require.InDelta(t, 1.0, *bySession["parity-tool-boundary"].AgentMinutes, 1e-9,
+		"post-range completion closes the final in-range message")
 }

--- a/internal/activity/parity_pgtest_test.go
+++ b/internal/activity/parity_pgtest_test.go
@@ -611,7 +611,7 @@ func assertParityForCase(
 }
 
 // assertDayMinuteFixtureSanity checks the day-minute report actually exercises
-// the fixture: a full day with peak concurrency 2, nine sessions, non-zero
+// the fixture: a full day with peak concurrency 2, twelve sessions, non-zero
 // cost, and exactly 22550 output tokens. The token total proves the
 // synthetic-model usage row (9999 tokens) is excluded, the dedup pair
 // keeps its complete 9000-token snapshot with earlier attribution, the
@@ -623,7 +623,7 @@ func assertDayMinuteFixtureSanity(t *testing.T, r activity.Report) {
 	t.Helper()
 	require.False(t, r.Partial, "fixture day must be a full day")
 	require.Equal(t, 2, r.Peak.Agents, "fixture must reach peak concurrency 2")
-	require.Equal(t, 10, r.Totals.Sessions, "fixture session count")
+	require.Equal(t, 12, r.Totals.Sessions, "fixture session count")
 	require.Positive(t, r.Totals.Cost.Microdollars, "fixture must exercise cost")
 	// 2400 (parity-a) + 1600 (parity-b) + 300 (parity-c; synthetic 9999 row
 	// excluded) + 9000 (parity-d receives parity-e's complete snapshot) +

--- a/internal/activity/parity_pgtest_test.go
+++ b/internal/activity/parity_pgtest_test.go
@@ -190,7 +190,8 @@ func parityFixture() []parityFixtureSession {
 		},
 		{
 			// A completion just after the report range closes the final message;
-			// aggregation clips the interval at the range boundary.
+			// aggregation clips the interval at the range boundary. The session
+			// summary predates the terminal event, as real provider metadata can.
 			id: "parity-tool-boundary", project: "tools", model: "model-x",
 			events: []parityEvent{
 				{role: "assistant", ts: parityDate + "T23:59:00Z",
@@ -275,16 +276,11 @@ func seedParitySQLite(t *testing.T) *db.DB {
 }
 
 // paritySessionWrite turns one fixture session into a SessionBatchWrite. The
-// session window spans its first and last event; assistant messages carry the
-// model and token_usage so they feed the usage path.
+// session window spans its first and last transcript event; assistant messages
+// carry the model and token_usage so they feed the usage path.
 func paritySessionWrite(fs parityFixtureSession) db.SessionBatchWrite {
 	first := fs.events[0].ts
 	last := fs.events[len(fs.events)-1].ts
-	for _, event := range fs.events {
-		if event.toolCompletedAt > last {
-			last = event.toolCompletedAt
-		}
-	}
 	firstMsg := "parity " + fs.id
 	relationship := fs.relationship
 	if relationship == "" {
@@ -517,6 +513,51 @@ func TestGetActivityReportParityAcrossBackends(t *testing.T) {
 			if tc.name == "day-minute" {
 				assertDayMinuteFixtureSanity(t, sqliteReport)
 			}
+		})
+	}
+}
+
+func TestGetActivityReportIncludesTerminalAfterSessionEndAcrossBackends(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	local := seedParitySQLite(t)
+	pgStore := pushParityPostgres(t, ctx, local)
+	duckStore := pushParityDuckDB(t, ctx, local)
+
+	q, err := activity.ResolveQuery(activity.QueryInput{
+		Preset: "day", Date: "2026-06-15", Timezone: "UTC",
+	}, time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	filter := db.AnalyticsFilter{Timezone: "UTC"}
+
+	sqliteReport, err := local.GetActivityReport(ctx, filter, q)
+	require.NoError(t, err)
+	pgReport, err := pgStore.GetActivityReport(ctx, filter, q)
+	require.NoError(t, err)
+	duckReport, err := duckStore.GetActivityReport(ctx, filter, q)
+	require.NoError(t, err)
+
+	reports := []struct {
+		name   string
+		report activity.Report
+	}{
+		{name: "sqlite", report: sqliteReport},
+		{name: "postgres", report: pgReport},
+		{name: "duckdb", report: duckReport},
+	}
+	for _, backend := range reports {
+		t.Run(backend.name, func(t *testing.T) {
+			bySession := make(map[string]activity.SessionRow,
+				len(backend.report.BySession))
+			for _, session := range backend.report.BySession {
+				bySession[session.SessionID] = session
+			}
+			require.Contains(t, bySession, "parity-tool-boundary")
+			row := bySession["parity-tool-boundary"]
+			require.NotNil(t, row.AgentMinutes)
+			require.InDelta(t, 1.0, *row.AgentMinutes, 1e-9,
+				"terminal completion after ended_at must close next-day activity")
 		})
 	}
 }

--- a/internal/activity/streaming.go
+++ b/internal/activity/streaming.go
@@ -55,6 +55,54 @@ type CandidateSource func(
 	ctx context.Context, yield func(IntervalCandidate) error,
 ) error
 
+// MergeCandidateSlice merges an ordered candidate slice into an ordered
+// candidate source without retaining the source stream. Equal keys from the
+// source are emitted first, matching storage query event ordering.
+func MergeCandidateSlice(
+	extra []IntervalCandidate, source CandidateSource,
+) CandidateSource {
+	return func(
+		ctx context.Context, yield func(IntervalCandidate) error,
+	) error {
+		next := 0
+		emitExtraBefore := func(candidate IntervalCandidate) error {
+			for next < len(extra) && candidateLess(extra[next], candidate) {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				if err := yield(extra[next]); err != nil {
+					return err
+				}
+				next++
+			}
+			return yield(candidate)
+		}
+		if err := source(ctx, emitExtraBefore); err != nil {
+			return err
+		}
+		for next < len(extra) {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := yield(extra[next]); err != nil {
+				return err
+			}
+			next++
+		}
+		return nil
+	}
+}
+
+func candidateLess(a, b IntervalCandidate) bool {
+	if !a.Start.Equal(b.Start) {
+		return a.Start.Before(b.Start)
+	}
+	if a.SessionID != b.SessionID {
+		return a.SessionID < b.SessionID
+	}
+	return a.StartOrdinal < b.StartOrdinal
+}
+
 // PairActivityEvents is the Go reference implementation for backend pairing.
 // It preserves ordinal adjacency before applying the safe candidate-start
 // pruning window.
@@ -96,15 +144,7 @@ func PairActivityEvents(
 			}
 		}
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if !out[i].Start.Equal(out[j].Start) {
-			return out[i].Start.Before(out[j].Start)
-		}
-		if out[i].SessionID != out[j].SessionID {
-			return out[i].SessionID < out[j].SessionID
-		}
-		return out[i].StartOrdinal < out[j].StartOrdinal
-	})
+	sort.Slice(out, func(i, j int) bool { return candidateLess(out[i], out[j]) })
 	return out
 }
 

--- a/internal/activity/streaming.go
+++ b/internal/activity/streaming.go
@@ -259,6 +259,7 @@ func buildCandidateArtifactsFromSource(
 	heap.Init(&state.ends)
 	aggregates := make(map[string]*sessionIntervalAgg)
 	membership := make(map[string]BucketMembership)
+	sessionEnds := make(map[string]time.Time)
 	words := (len(windows) + 63) / 64
 	var previousStart time.Time
 	err := source(ctx, func(candidate IntervalCandidate) error {
@@ -277,6 +278,14 @@ func buildCandidateArtifactsFromSource(
 			)
 		}
 		previousStart = iv.start
+		if previousEnd, ok := sessionEnds[iv.sessionID]; ok &&
+			previousEnd.After(iv.start) {
+			if !iv.end.After(previousEnd) {
+				return nil
+			}
+			iv.start = previousEnd
+		}
+		sessionEnds[iv.sessionID] = iv.end
 		state.advance(iv.start)
 		state.open(iv)
 		foldCandidateInterval(

--- a/internal/activity/streaming.go
+++ b/internal/activity/streaming.go
@@ -255,11 +255,11 @@ func buildCandidateArtifactsFromSource(
 	state := candidateSweep{
 		report: &report, windows: windows, effectiveEnd: p.EffectiveEnd,
 		last: p.RangeStart, automatedBy: automatedBy,
+		sessionEnds: make(map[string]time.Time),
 	}
 	heap.Init(&state.ends)
 	aggregates := make(map[string]*sessionIntervalAgg)
 	membership := make(map[string]BucketMembership)
-	sessionEnds := make(map[string]time.Time)
 	words := (len(windows) + 63) / 64
 	var previousStart time.Time
 	err := source(ctx, func(candidate IntervalCandidate) error {
@@ -278,16 +278,16 @@ func buildCandidateArtifactsFromSource(
 			)
 		}
 		previousStart = iv.start
-		if previousEnd, ok := sessionEnds[iv.sessionID]; ok &&
-			previousEnd.After(iv.start) {
+		state.advance(iv.start)
+		if previousEnd, ok := state.sessionEnds[iv.sessionID]; ok {
 			if !iv.end.After(previousEnd) {
 				return nil
 			}
 			iv.start = previousEnd
+			state.extend(iv)
+		} else {
+			state.open(iv)
 		}
-		sessionEnds[iv.sessionID] = iv.end
-		state.advance(iv.start)
-		state.open(iv)
 		foldCandidateInterval(
 			&report, windows, membershipWindows, aggregates, membership, words,
 			automatedBy, iv,
@@ -353,6 +353,7 @@ func effectiveCandidateInterval(p Params, candidate IntervalCandidate) (interval
 }
 
 type activeCandidateEnd struct {
+	sessionID string
 	end       time.Time
 	automated bool
 }
@@ -380,6 +381,7 @@ type candidateSweep struct {
 	effectiveEnd time.Time
 	automatedBy  map[string]bool
 	ends         activeCandidateHeap
+	sessionEnds  map[string]time.Time
 	bucket       int
 	last         time.Time
 	live         int
@@ -406,6 +408,11 @@ func (s *candidateSweep) advance(target time.Time) {
 		s.accrue(next)
 		for len(s.ends) > 0 && s.ends[0].end.Equal(next) {
 			ended := heap.Pop(&s.ends).(activeCandidateEnd)
+			currentEnd, ok := s.sessionEnds[ended.sessionID]
+			if !ok || !currentEnd.Equal(ended.end) {
+				continue
+			}
+			delete(s.sessionEnds, ended.sessionID)
 			s.live--
 			if ended.automated {
 				s.liveAuto--
@@ -435,7 +442,10 @@ func (s *candidateSweep) accrue(target time.Time) {
 
 func (s *candidateSweep) open(iv interval) {
 	automated := s.automatedBy[iv.sessionID]
-	heap.Push(&s.ends, activeCandidateEnd{end: iv.end, automated: automated})
+	s.sessionEnds[iv.sessionID] = iv.end
+	heap.Push(&s.ends, activeCandidateEnd{
+		sessionID: iv.sessionID, end: iv.end, automated: automated,
+	})
 	s.live++
 	if automated {
 		s.liveAuto++
@@ -448,6 +458,14 @@ func (s *candidateSweep) open(iv interval) {
 		s.report.Peak.At = &at
 	}
 	s.recordBucketPeak()
+}
+
+func (s *candidateSweep) extend(iv interval) {
+	automated := s.automatedBy[iv.sessionID]
+	s.sessionEnds[iv.sessionID] = iv.end
+	heap.Push(&s.ends, activeCandidateEnd{
+		sessionID: iv.sessionID, end: iv.end, automated: automated,
+	})
 }
 
 func (s *candidateSweep) recordBucketPeak() {

--- a/internal/activity/streaming_test.go
+++ b/internal/activity/streaming_test.go
@@ -53,6 +53,38 @@ func TestPairActivityEventsPreservesOrdinalAdjacencyAtRangeEdges(t *testing.T) {
 	}, got[3], "a successor beyond the right bound remains attached")
 }
 
+func TestMergeCandidateSlicePreservesCandidateOrder(t *testing.T) {
+	at := func(value string) time.Time { return mustStart(t, value) }
+	base := []IntervalCandidate{
+		{SessionID: "b", StartOrdinal: 1, Start: at("2026-06-16T10:00:00Z")},
+		{SessionID: "a", StartOrdinal: 2, Start: at("2026-06-16T10:03:00Z")},
+	}
+	extra := []IntervalCandidate{
+		{SessionID: "a", StartOrdinal: 1, Start: at("2026-06-16T10:00:00Z")},
+		{SessionID: "c", StartOrdinal: 1, Start: at("2026-06-16T10:02:00Z")},
+	}
+	baseSource := func(
+		ctx context.Context, yield func(IntervalCandidate) error,
+	) error {
+		for _, candidate := range base {
+			if err := yield(candidate); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	var got []IntervalCandidate
+	err := MergeCandidateSlice(extra, baseSource)(
+		context.Background(), func(candidate IntervalCandidate) error {
+			got = append(got, candidate)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []IntervalCandidate{extra[0], base[0], extra[1], base[1]}, got)
+}
+
 func TestAggregateCandidatesDifferential(t *testing.T) {
 	p := baseParams(t, "2026-06-16", "UTC")
 	sessions := []SessionMeta{

--- a/internal/activity/streaming_test.go
+++ b/internal/activity/streaming_test.go
@@ -189,6 +189,33 @@ func TestAggregateCandidatesCarriesConcurrencyAcrossBucketBoundary(t *testing.T)
 	assert.Equal(t, 2, got.Peak.Agents)
 }
 
+func TestAggregateCandidatesKeepsTrimmedOverlapInStartOrder(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	at := func(value string) time.Time { return mustStart(t, value) }
+	candidates := []IntervalCandidate{
+		{
+			SessionID: "overlap", StartOrdinal: 0, EndOrdinal: 1,
+			Start: at("2026-06-16T00:00:00Z"), End: at("2026-06-16T00:05:00Z"),
+		},
+		{
+			SessionID: "overlap", StartOrdinal: 1, EndOrdinal: 2,
+			Start: at("2026-06-16T00:01:00Z"), End: at("2026-06-16T00:06:00Z"),
+		},
+		{
+			SessionID: "interleaved", StartOrdinal: 0, EndOrdinal: 1,
+			Start: at("2026-06-16T00:02:00Z"), End: at("2026-06-16T00:03:00Z"),
+		},
+	}
+
+	got, err := AggregateCandidates(context.Background(), p, nil, candidates, nil)
+	require.NoError(t, err)
+	require.Len(t, got.Buckets, 288)
+	assert.Equal(t, 2, got.Buckets[0].MaxAgents,
+		"the interleaved session overlaps in the first bucket")
+	assert.Equal(t, 1, got.Buckets[1].MaxAgents,
+		"the interleaved session must not move with the trimmed overlap")
+}
+
 func TestAggregateCandidatesRandomizedDifferential(t *testing.T) {
 	p := baseParams(t, "2026-06-16", "UTC")
 	random := rand.New(rand.NewSource(42))

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -601,12 +601,13 @@ WHERE m.session_id IN (SELECT value FROM json_each(?))
 ORDER BY agentsview_timestamp_unix_micro(m.timestamp),
 	m.session_id, m.ordinal`
 
-const activityReportTailCandidatesSQL = `WITH
+const activityReportTerminalCandidatesSQL = `WITH
 	session_ids AS (
 		SELECT value AS session_id FROM json_each(?)
 	),
 	terminal_events AS (
-		SELECT tre.session_id, tre.call_index, tre.event_index, tre.timestamp
+		SELECT tre.session_id, tre.tool_call_message_ordinal AS ordinal,
+			tre.call_index, tre.event_index, tre.timestamp
 		FROM tool_result_events tre
 		JOIN session_ids ids ON ids.session_id = tre.session_id
 		WHERE tre.source = 'tool_execution'
@@ -614,9 +615,40 @@ const activityReportTailCandidatesSQL = `WITH
 			AND tre.timestamp IS NOT NULL
 			AND tre.timestamp != ''
 			AND agentsview_timestamp_unix_micro(tre.timestamp) IS NOT NULL
+			AND agentsview_timestamp_unix_micro(tre.timestamp) >= ?
 	),
 	terminal_sessions AS (
 		SELECT DISTINCT session_id FROM terminal_events
+	),
+	ordered_terminal AS (
+		SELECT te.*,
+			LEAD(te.ordinal) OVER terminal_order AS next_terminal_ordinal,
+			LEAD(te.timestamp) OVER terminal_order AS next_terminal_timestamp
+		FROM terminal_events te
+		WINDOW terminal_order AS (
+			PARTITION BY te.session_id
+			ORDER BY agentsview_timestamp_unix_micro(te.timestamp),
+				te.call_index, te.event_index
+		)
+	),
+	terminal_with_message AS (
+		SELECT ot.*, next_message.ordinal AS next_message_ordinal,
+			next_message.timestamp AS next_message_timestamp,
+			next_message.role AS next_message_role,
+			next_message.model AS next_message_model
+		FROM ordered_terminal ot
+		LEFT JOIN messages next_message ON next_message.id = (
+			SELECT next.id
+			FROM messages next INDEXED BY idx_messages_velocity
+			WHERE next.session_id = ot.session_id
+				AND next.ordinal > ot.ordinal
+				AND next.timestamp IS NOT NULL
+				AND next.timestamp != ''
+				AND agentsview_timestamp_unix_micro(next.timestamp) >
+					agentsview_timestamp_unix_micro(ot.timestamp)
+			ORDER BY next.ordinal
+			LIMIT 1
+		)
 	),
 	last_messages AS (
 		SELECT m.session_id, m.ordinal, m.timestamp
@@ -632,49 +664,84 @@ const activityReportTailCandidatesSQL = `WITH
 			LIMIT 1
 		)
 	),
-	tail_events AS (
-		SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
-			0 AS call_index, 0 AS event_index, lm.timestamp
-		FROM last_messages lm
-		UNION ALL
-		SELECT lm.session_id, lm.ordinal, 1,
-			te.call_index, te.event_index, te.timestamp
+	first_tail_events AS (
+		SELECT lm.session_id, lm.ordinal, lm.timestamp,
+			te.call_index, te.event_index, te.timestamp AS terminal_timestamp,
+			ROW_NUMBER() OVER (
+				PARTITION BY lm.session_id
+				ORDER BY agentsview_timestamp_unix_micro(te.timestamp),
+					te.call_index, te.event_index
+			) AS row_num
 		FROM last_messages lm
 		JOIN terminal_events te ON te.session_id = lm.session_id
 		WHERE agentsview_timestamp_unix_micro(te.timestamp) >
 				agentsview_timestamp_unix_micro(lm.timestamp)
 	),
-	ordered_tail AS (
-		SELECT e.*,
-			LEAD(e.ordinal) OVER tail_order AS successor_ordinal,
-			LEAD(e.timestamp) OVER tail_order AS successor_timestamp
-		FROM tail_events e
-		WINDOW tail_order AS (
-			PARTITION BY e.session_id
-			ORDER BY agentsview_timestamp_unix_micro(e.timestamp),
-				e.event_kind, e.call_index, e.event_index
-		)
+	candidates AS (
+		SELECT twm.session_id, twm.ordinal AS start_ordinal,
+			CASE
+				WHEN twm.next_terminal_timestamp IS NOT NULL AND
+					(twm.next_message_timestamp IS NULL OR
+					 agentsview_timestamp_unix_micro(twm.next_terminal_timestamp) <
+					 agentsview_timestamp_unix_micro(twm.next_message_timestamp))
+				THEN twm.next_terminal_ordinal
+				ELSE twm.next_message_ordinal
+			END AS end_ordinal,
+			twm.timestamp AS start_timestamp,
+			CASE
+				WHEN twm.next_terminal_timestamp IS NOT NULL AND
+					(twm.next_message_timestamp IS NULL OR
+					 agentsview_timestamp_unix_micro(twm.next_terminal_timestamp) <
+					 agentsview_timestamp_unix_micro(twm.next_message_timestamp))
+				THEN twm.next_terminal_timestamp
+				ELSE twm.next_message_timestamp
+			END AS end_timestamp,
+			CASE
+				WHEN twm.next_terminal_timestamp IS NOT NULL AND
+					(twm.next_message_timestamp IS NULL OR
+					 agentsview_timestamp_unix_micro(twm.next_terminal_timestamp) <
+					 agentsview_timestamp_unix_micro(twm.next_message_timestamp))
+				THEN 'tool'
+				ELSE twm.next_message_role
+			END AS closing_role,
+			CASE
+				WHEN twm.next_terminal_timestamp IS NOT NULL AND
+					(twm.next_message_timestamp IS NULL OR
+					 agentsview_timestamp_unix_micro(twm.next_terminal_timestamp) <
+					 agentsview_timestamp_unix_micro(twm.next_message_timestamp))
+				THEN ''
+				ELSE twm.next_message_model
+			END AS closing_model,
+			twm.call_index, twm.event_index
+		FROM terminal_with_message twm
+
+		UNION ALL
+
+		SELECT fte.session_id, fte.ordinal, fte.ordinal,
+			fte.timestamp, fte.terminal_timestamp, 'tool', '',
+			fte.call_index, fte.event_index
+		FROM first_tail_events fte
+		WHERE fte.row_num = 1
 	)
-SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
-	tail.timestamp, tail.successor_timestamp,
-	'tool', '',
+SELECT candidate.session_id, candidate.start_ordinal, candidate.end_ordinal,
+	candidate.start_timestamp, candidate.end_timestamp,
+	candidate.closing_role, candidate.closing_model,
 	COALESCE((
 		SELECT prior.model
 		FROM messages prior
-		WHERE prior.session_id = tail.session_id
-			AND prior.ordinal <= tail.ordinal
+		WHERE prior.session_id = candidate.session_id
+			AND prior.ordinal <= candidate.start_ordinal
 			AND prior.role = 'assistant'
 			AND prior.model != ''
 		ORDER BY prior.ordinal DESC
 		LIMIT 1
 	), 'unknown')
-FROM ordered_tail tail
-WHERE tail.successor_timestamp IS NOT NULL
-	AND agentsview_timestamp_unix_micro(tail.timestamp) >= ?
-	AND agentsview_timestamp_unix_micro(tail.timestamp) < ?
-ORDER BY agentsview_timestamp_unix_micro(tail.timestamp),
-	tail.session_id, tail.ordinal,
-	tail.event_kind, tail.call_index, tail.event_index`
+FROM candidates candidate
+WHERE candidate.end_timestamp IS NOT NULL
+	AND agentsview_timestamp_unix_micro(candidate.start_timestamp) < ?
+ORDER BY agentsview_timestamp_unix_micro(candidate.start_timestamp),
+	candidate.session_id, candidate.start_ordinal,
+	candidate.call_index, candidate.event_index`
 
 func (db *DB) activityReportCandidateSource(
 	ids []string, q activity.Query,
@@ -726,26 +793,27 @@ func (db *DB) activityReportCandidateSource(
 			return candidate, nil
 		}
 
-		tailRows, err := db.getReader().QueryContext(
-			ctx, activityReportTailCandidatesSQL, string(encodedIDs), lower, upper,
+		terminalRows, err := db.getReader().QueryContext(
+			ctx, activityReportTerminalCandidatesSQL,
+			string(encodedIDs), lower, upper,
 		)
 		if err != nil {
-			return fmt.Errorf("querying activity report tail candidates: %w", err)
+			return fmt.Errorf("querying activity report terminal candidates: %w", err)
 		}
-		var tail []activity.IntervalCandidate
-		for tailRows.Next() {
-			candidate, scanErr := scanCandidate(tailRows)
+		var terminal []activity.IntervalCandidate
+		for terminalRows.Next() {
+			candidate, scanErr := scanCandidate(terminalRows)
 			if scanErr != nil {
-				tailRows.Close()
+				terminalRows.Close()
 				return scanErr
 			}
-			tail = append(tail, candidate)
+			terminal = append(terminal, candidate)
 		}
-		if err := tailRows.Err(); err != nil {
-			tailRows.Close()
+		if err := terminalRows.Err(); err != nil {
+			terminalRows.Close()
 			return err
 		}
-		if err := tailRows.Close(); err != nil {
+		if err := terminalRows.Close(); err != nil {
 			return err
 		}
 
@@ -776,7 +844,7 @@ func (db *DB) activityReportCandidateSource(
 			}
 			return rows.Err()
 		}
-		return activity.MergeCandidateSlice(tail, messageSource)(ctx, yield)
+		return activity.MergeCandidateSlice(terminal, messageSource)(ctx, yield)
 	}
 }
 

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -549,27 +549,88 @@ func (db *DB) activityReportCandidates(
 	return out, err
 }
 
-const activityReportCandidatesSQL = `WITH
+const activityReportCandidatesSQL = `SELECT
+	m.session_id, m.ordinal, successor.ordinal,
+	m.timestamp, successor.timestamp,
+	successor.role, successor.model,
+	COALESCE((
+		SELECT prior.model
+		FROM messages prior
+		WHERE prior.session_id = m.session_id
+			AND prior.ordinal <= m.ordinal
+			AND prior.role = 'assistant'
+			AND prior.model != ''
+			AND prior.timestamp IS NOT NULL
+			AND prior.timestamp != ''
+			AND agentsview_timestamp_unix_micro(prior.timestamp) IS NOT NULL
+			AND agentsview_timestamp_unix_micro(prior.timestamp) > (
+				SELECT agentsview_timestamp_unix_micro(prior_previous.timestamp)
+				FROM messages prior_previous
+				WHERE prior_previous.session_id = prior.session_id
+					AND prior_previous.ordinal < prior.ordinal
+					AND prior_previous.timestamp IS NOT NULL
+					AND prior_previous.timestamp != ''
+					AND agentsview_timestamp_unix_micro(
+						prior_previous.timestamp) IS NOT NULL
+				ORDER BY prior_previous.ordinal DESC
+				LIMIT 1
+			)
+		ORDER BY prior.ordinal DESC
+		LIMIT 1
+	), 'unknown')
+FROM messages m INDEXED BY idx_messages_velocity
+JOIN messages successor ON successor.id = (
+	SELECT next.id
+	FROM messages next
+	WHERE next.session_id = m.session_id
+		AND next.ordinal > m.ordinal
+		AND next.timestamp IS NOT NULL
+		AND next.timestamp != ''
+		AND agentsview_timestamp_unix_micro(next.timestamp) IS NOT NULL
+	ORDER BY next.ordinal
+	LIMIT 1
+)
+WHERE m.session_id IN (SELECT value FROM json_each(?))
+	AND m.timestamp IS NOT NULL
+	AND m.timestamp != ''
+	AND m.timestamp >= ?
+	AND m.timestamp < ?
+	AND agentsview_timestamp_unix_micro(m.timestamp) IS NOT NULL
+	AND agentsview_timestamp_unix_micro(m.timestamp) >= ?
+	AND agentsview_timestamp_unix_micro(m.timestamp) < ?
+ORDER BY agentsview_timestamp_unix_micro(m.timestamp),
+	m.session_id, m.ordinal`
+
+const activityReportTailCandidatesSQL = `WITH
 	session_ids AS (
 		SELECT value AS session_id FROM json_each(?)
 	),
-	bounds AS (
-		SELECT ? AS padded_lower, ? AS padded_upper,
-			? AS lower_micro, ? AS upper_micro
+	terminal_events AS (
+		SELECT tre.session_id, tre.call_index, tre.event_index, tre.timestamp
+		FROM tool_result_events tre
+		JOIN session_ids ids ON ids.session_id = tre.session_id
+		WHERE tre.source = 'tool_execution'
+			AND tre.status IN ('completed', 'errored')
+			AND tre.timestamp IS NOT NULL
+			AND tre.timestamp != ''
+			AND agentsview_timestamp_unix_micro(tre.timestamp) IS NOT NULL
+	),
+	terminal_sessions AS (
+		SELECT DISTINCT session_id FROM terminal_events
 	),
 	last_messages AS (
-		SELECT * FROM (
-			SELECT m.session_id, m.ordinal, m.timestamp,
-				ROW_NUMBER() OVER (
-					PARTITION BY m.session_id ORDER BY m.ordinal DESC
-				) AS row_num
-			FROM messages m
-			JOIN session_ids ids ON ids.session_id = m.session_id
-			WHERE m.timestamp IS NOT NULL
-				AND m.timestamp != ''
-				AND agentsview_timestamp_unix_micro(m.timestamp) IS NOT NULL
-		) ranked
-		WHERE row_num = 1
+		SELECT m.session_id, m.ordinal, m.timestamp
+		FROM terminal_sessions ts
+		JOIN messages m ON m.id = (
+			SELECT latest.id
+			FROM messages latest INDEXED BY idx_messages_velocity
+			WHERE latest.session_id = ts.session_id
+				AND latest.timestamp IS NOT NULL
+				AND latest.timestamp != ''
+				AND agentsview_timestamp_unix_micro(latest.timestamp) IS NOT NULL
+			ORDER BY latest.ordinal DESC
+			LIMIT 1
+		)
 	),
 	tail_events AS (
 		SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
@@ -577,15 +638,10 @@ const activityReportCandidatesSQL = `WITH
 		FROM last_messages lm
 		UNION ALL
 		SELECT lm.session_id, lm.ordinal, 1,
-			tre.call_index, tre.event_index, tre.timestamp
+			te.call_index, te.event_index, te.timestamp
 		FROM last_messages lm
-		JOIN tool_result_events tre ON tre.session_id = lm.session_id
-		WHERE tre.source = 'tool_execution'
-			AND tre.status IN ('completed', 'errored')
-			AND tre.timestamp IS NOT NULL
-			AND tre.timestamp != ''
-			AND agentsview_timestamp_unix_micro(tre.timestamp) IS NOT NULL
-			AND agentsview_timestamp_unix_micro(tre.timestamp) >
+		JOIN terminal_events te ON te.session_id = lm.session_id
+		WHERE agentsview_timestamp_unix_micro(te.timestamp) >
 				agentsview_timestamp_unix_micro(lm.timestamp)
 	),
 	ordered_tail AS (
@@ -598,91 +654,27 @@ const activityReportCandidatesSQL = `WITH
 			ORDER BY agentsview_timestamp_unix_micro(e.timestamp),
 				e.event_kind, e.call_index, e.event_index
 		)
-	),
-	candidates AS (
-		SELECT
-			m.session_id, m.ordinal AS start_ordinal,
-			successor.ordinal AS end_ordinal,
-			m.timestamp AS start_timestamp,
-			successor.timestamp AS end_timestamp,
-			successor.role AS closing_role,
-			successor.model AS closing_model,
-			COALESCE((
-				SELECT prior.model
-				FROM messages prior
-				WHERE prior.session_id = m.session_id
-					AND prior.ordinal <= m.ordinal
-					AND prior.role = 'assistant'
-					AND prior.model != ''
-					AND prior.timestamp IS NOT NULL
-					AND prior.timestamp != ''
-					AND agentsview_timestamp_unix_micro(prior.timestamp) IS NOT NULL
-					AND agentsview_timestamp_unix_micro(prior.timestamp) > (
-						SELECT agentsview_timestamp_unix_micro(prior_previous.timestamp)
-						FROM messages prior_previous
-						WHERE prior_previous.session_id = prior.session_id
-							AND prior_previous.ordinal < prior.ordinal
-							AND prior_previous.timestamp IS NOT NULL
-							AND prior_previous.timestamp != ''
-							AND agentsview_timestamp_unix_micro(
-								prior_previous.timestamp) IS NOT NULL
-						ORDER BY prior_previous.ordinal DESC
-						LIMIT 1
-					)
-				ORDER BY prior.ordinal DESC
-				LIMIT 1
-			), 'unknown') AS prior_model,
-			0 AS event_kind, 0 AS call_index, 0 AS event_index
-		FROM messages m INDEXED BY idx_messages_velocity
-		JOIN messages successor ON successor.id = (
-			SELECT next.id
-			FROM messages next
-			WHERE next.session_id = m.session_id
-				AND next.ordinal > m.ordinal
-				AND next.timestamp IS NOT NULL
-				AND next.timestamp != ''
-				AND agentsview_timestamp_unix_micro(next.timestamp) IS NOT NULL
-			ORDER BY next.ordinal
-			LIMIT 1
-		)
-		JOIN session_ids ids ON ids.session_id = m.session_id
-		CROSS JOIN bounds b
-		WHERE m.timestamp IS NOT NULL
-			AND m.timestamp != ''
-			AND m.timestamp >= b.padded_lower
-			AND m.timestamp < b.padded_upper
-			AND agentsview_timestamp_unix_micro(m.timestamp) IS NOT NULL
-
-		UNION ALL
-
-		SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
-			tail.timestamp, tail.successor_timestamp,
-			'tool', '',
-			COALESCE((
-				SELECT prior.model
-				FROM messages prior
-				WHERE prior.session_id = tail.session_id
-					AND prior.ordinal <= tail.ordinal
-					AND prior.role = 'assistant'
-					AND prior.model != ''
-				ORDER BY prior.ordinal DESC
-				LIMIT 1
-			), 'unknown'),
-			tail.event_kind, tail.call_index, tail.event_index
-		FROM ordered_tail tail
-		WHERE tail.successor_timestamp IS NOT NULL
 	)
-SELECT
-	c.session_id, c.start_ordinal, c.end_ordinal,
-	c.start_timestamp, c.end_timestamp,
-	c.closing_role, c.closing_model, c.prior_model
-FROM candidates c
-CROSS JOIN bounds b
-WHERE agentsview_timestamp_unix_micro(c.start_timestamp) >= b.lower_micro
-	AND agentsview_timestamp_unix_micro(c.start_timestamp) < b.upper_micro
-ORDER BY agentsview_timestamp_unix_micro(c.start_timestamp),
-	c.session_id, c.start_ordinal,
-	c.event_kind, c.call_index, c.event_index`
+SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
+	tail.timestamp, tail.successor_timestamp,
+	'tool', '',
+	COALESCE((
+		SELECT prior.model
+		FROM messages prior
+		WHERE prior.session_id = tail.session_id
+			AND prior.ordinal <= tail.ordinal
+			AND prior.role = 'assistant'
+			AND prior.model != ''
+		ORDER BY prior.ordinal DESC
+		LIMIT 1
+	), 'unknown')
+FROM ordered_tail tail
+WHERE tail.successor_timestamp IS NOT NULL
+	AND agentsview_timestamp_unix_micro(tail.timestamp) >= ?
+	AND agentsview_timestamp_unix_micro(tail.timestamp) < ?
+ORDER BY agentsview_timestamp_unix_micro(tail.timestamp),
+	tail.session_id, tail.ordinal,
+	tail.event_kind, tail.call_index, tail.event_index`
 
 func (db *DB) activityReportCandidateSource(
 	ids []string, q activity.Query,
@@ -705,44 +697,86 @@ func (db *DB) activityReportCandidateSource(
 		upper := upperTime.UnixMicro()
 		paddedLower := paddedUTCBound(lowerTime.Format(time.RFC3339), -14)
 		paddedUpper := paddedUTCBound(upperTime.Format(time.RFC3339), 14)
-		args := []any{string(encodedIDs), paddedLower, paddedUpper, lower, upper}
-		rows, err := db.getReader().QueryContext(
-			ctx, activityReportCandidatesSQL, args...,
-		)
-		if err != nil {
-			return fmt.Errorf("querying activity report candidates: %w", err)
-		}
-		defer rows.Close()
-		for rows.Next() {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
+		scanCandidate := func(
+			row interface{ Scan(dest ...any) error },
+		) (activity.IntervalCandidate, error) {
 			var candidate activity.IntervalCandidate
 			var start, end string
-			if err := rows.Scan(
+			if err := row.Scan(
 				&candidate.SessionID, &candidate.StartOrdinal,
 				&candidate.EndOrdinal, &start, &end,
 				&candidate.ClosingRole, &candidate.ClosingModel,
 				&candidate.PriorModel,
 			); err != nil {
-				return fmt.Errorf("scanning activity report candidate: %w", err)
+				return candidate, fmt.Errorf(
+					"scanning activity report candidate: %w", err)
 			}
-			var err error
 			candidate.Start, err = time.Parse(time.RFC3339Nano, start)
 			if err != nil {
-				return fmt.Errorf("parsing activity candidate start: %w", err)
+				return candidate, fmt.Errorf(
+					"parsing activity candidate start: %w", err)
 			}
 			candidate.End, err = time.Parse(time.RFC3339Nano, end)
 			if err != nil {
-				return fmt.Errorf("parsing activity candidate end: %w", err)
+				return candidate, fmt.Errorf(
+					"parsing activity candidate end: %w", err)
 			}
 			candidate.Start = candidate.Start.UTC()
 			candidate.End = candidate.End.UTC()
-			if err := yield(candidate); err != nil {
-				return err
-			}
+			return candidate, nil
 		}
-		return rows.Err()
+
+		tailRows, err := db.getReader().QueryContext(
+			ctx, activityReportTailCandidatesSQL, string(encodedIDs), lower, upper,
+		)
+		if err != nil {
+			return fmt.Errorf("querying activity report tail candidates: %w", err)
+		}
+		var tail []activity.IntervalCandidate
+		for tailRows.Next() {
+			candidate, scanErr := scanCandidate(tailRows)
+			if scanErr != nil {
+				tailRows.Close()
+				return scanErr
+			}
+			tail = append(tail, candidate)
+		}
+		if err := tailRows.Err(); err != nil {
+			tailRows.Close()
+			return err
+		}
+		if err := tailRows.Close(); err != nil {
+			return err
+		}
+
+		messageSource := func(
+			ctx context.Context,
+			yield func(activity.IntervalCandidate) error,
+		) error {
+			rows, queryErr := db.getReader().QueryContext(
+				ctx, activityReportCandidatesSQL,
+				string(encodedIDs), paddedLower, paddedUpper, lower, upper,
+			)
+			if queryErr != nil {
+				return fmt.Errorf(
+					"querying activity report candidates: %w", queryErr)
+			}
+			defer rows.Close()
+			for rows.Next() {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				candidate, scanErr := scanCandidate(rows)
+				if scanErr != nil {
+					return scanErr
+				}
+				if err := yield(candidate); err != nil {
+					return err
+				}
+			}
+			return rows.Err()
+		}
+		return activity.MergeCandidateSlice(tail, messageSource)(ctx, yield)
 	}
 }
 

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -400,6 +400,8 @@ func activityReportProjectLabels(
 // partially-parsed session that began before the range but has messages
 // inside it is not dropped. COALESCE short-circuits, so the correlated
 // MAX subquery runs only for the rare sessions missing an ended_at.
+// A terminal tool event can outlive ended_at metadata, so it independently
+// keeps the session eligible when it reaches the report range.
 func (db *DB) activityReportSessions(
 	ctx context.Context, f AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
 ) ([]activity.SessionMeta, []string, error) {
@@ -415,7 +417,7 @@ func (db *DB) activityReportSessionsFrom(
 	rangeStartUTC, rangeEndUTC string,
 ) ([]activity.SessionMeta, []string, error) {
 	where, args := f.buildWhereWithDate("", false, "s.id")
-	args = append(args, rangeStartUTC, rangeEndUTC)
+	args = append(args, rangeStartUTC, rangeStartUTC, rangeEndUTC)
 
 	// Each Title candidate is NULLIF'd independently (not a nested
 	// COALESCE-then-NULLIF) so an empty display_name cannot mask a real
@@ -432,10 +434,20 @@ func (db *DB) activityReportSessionsFrom(
 		COALESCE(s.is_automated, 0)
 	FROM sessions s
 	WHERE ` + where + `
-		AND COALESCE(NULLIF(s.ended_at, ''),
-			(SELECT MAX(m.timestamp) FROM messages m
-				WHERE m.session_id = s.id AND m.timestamp != ''),
-			NULLIF(s.started_at, ''), s.created_at) >= ?
+		AND (COALESCE(NULLIF(s.ended_at, ''),
+				(SELECT MAX(m.timestamp) FROM messages m
+					WHERE m.session_id = s.id AND m.timestamp != ''),
+				NULLIF(s.started_at, ''), s.created_at) >= ?
+			OR EXISTS (
+				SELECT 1 FROM tool_result_events tre
+				WHERE tre.session_id = s.id
+					AND tre.source = 'tool_execution'
+					AND tre.status IN ('completed', 'errored')
+					AND tre.timestamp IS NOT NULL
+					AND tre.timestamp != ''
+					AND agentsview_timestamp_unix_micro(tre.timestamp) IS NOT NULL
+					AND tre.timestamp >= ?
+			))
 		AND COALESCE(NULLIF(s.started_at, ''), s.created_at) < ?`
 
 	rows, err := q.QueryContext(ctx, query, args...)

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -549,57 +549,140 @@ func (db *DB) activityReportCandidates(
 	return out, err
 }
 
-const activityReportCandidatesSQL = `SELECT
-	m.session_id, m.ordinal, successor.ordinal,
-	m.timestamp, successor.timestamp,
-	successor.role, successor.model,
-	COALESCE((
-		SELECT prior.model
-		FROM messages prior
-		WHERE prior.session_id = m.session_id
-			AND prior.ordinal <= m.ordinal
-			AND prior.role = 'assistant'
-			AND prior.model != ''
-			AND prior.timestamp IS NOT NULL
-			AND prior.timestamp != ''
-			AND agentsview_timestamp_unix_micro(prior.timestamp) IS NOT NULL
-			AND agentsview_timestamp_unix_micro(prior.timestamp) > (
-				SELECT agentsview_timestamp_unix_micro(prior_previous.timestamp)
-				FROM messages prior_previous
-				WHERE prior_previous.session_id = prior.session_id
-					AND prior_previous.ordinal < prior.ordinal
-					AND prior_previous.timestamp IS NOT NULL
-					AND prior_previous.timestamp != ''
-					AND agentsview_timestamp_unix_micro(
-						prior_previous.timestamp) IS NOT NULL
-				ORDER BY prior_previous.ordinal DESC
+const activityReportCandidatesSQL = `WITH
+	session_ids AS (
+		SELECT value AS session_id FROM json_each(?)
+	),
+	bounds AS (
+		SELECT ? AS padded_lower, ? AS padded_upper,
+			? AS lower_micro, ? AS upper_micro
+	),
+	last_messages AS (
+		SELECT * FROM (
+			SELECT m.session_id, m.ordinal, m.timestamp,
+				ROW_NUMBER() OVER (
+					PARTITION BY m.session_id ORDER BY m.ordinal DESC
+				) AS row_num
+			FROM messages m
+			JOIN session_ids ids ON ids.session_id = m.session_id
+			WHERE m.timestamp IS NOT NULL
+				AND m.timestamp != ''
+				AND agentsview_timestamp_unix_micro(m.timestamp) IS NOT NULL
+		) ranked
+		WHERE row_num = 1
+	),
+	tail_events AS (
+		SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
+			0 AS call_index, 0 AS event_index, lm.timestamp
+		FROM last_messages lm
+		UNION ALL
+		SELECT lm.session_id, lm.ordinal, 1,
+			tre.call_index, tre.event_index, tre.timestamp
+		FROM last_messages lm
+		JOIN tool_result_events tre ON tre.session_id = lm.session_id
+		WHERE tre.source = 'tool_execution'
+			AND tre.status IN ('completed', 'errored')
+			AND tre.timestamp IS NOT NULL
+			AND tre.timestamp != ''
+			AND agentsview_timestamp_unix_micro(tre.timestamp) IS NOT NULL
+			AND agentsview_timestamp_unix_micro(tre.timestamp) >
+				agentsview_timestamp_unix_micro(lm.timestamp)
+	),
+	ordered_tail AS (
+		SELECT e.*,
+			LEAD(e.ordinal) OVER tail_order AS successor_ordinal,
+			LEAD(e.timestamp) OVER tail_order AS successor_timestamp
+		FROM tail_events e
+		WINDOW tail_order AS (
+			PARTITION BY e.session_id
+			ORDER BY agentsview_timestamp_unix_micro(e.timestamp),
+				e.event_kind, e.call_index, e.event_index
+		)
+	),
+	candidates AS (
+		SELECT
+			m.session_id, m.ordinal AS start_ordinal,
+			successor.ordinal AS end_ordinal,
+			m.timestamp AS start_timestamp,
+			successor.timestamp AS end_timestamp,
+			successor.role AS closing_role,
+			successor.model AS closing_model,
+			COALESCE((
+				SELECT prior.model
+				FROM messages prior
+				WHERE prior.session_id = m.session_id
+					AND prior.ordinal <= m.ordinal
+					AND prior.role = 'assistant'
+					AND prior.model != ''
+					AND prior.timestamp IS NOT NULL
+					AND prior.timestamp != ''
+					AND agentsview_timestamp_unix_micro(prior.timestamp) IS NOT NULL
+					AND agentsview_timestamp_unix_micro(prior.timestamp) > (
+						SELECT agentsview_timestamp_unix_micro(prior_previous.timestamp)
+						FROM messages prior_previous
+						WHERE prior_previous.session_id = prior.session_id
+							AND prior_previous.ordinal < prior.ordinal
+							AND prior_previous.timestamp IS NOT NULL
+							AND prior_previous.timestamp != ''
+							AND agentsview_timestamp_unix_micro(
+								prior_previous.timestamp) IS NOT NULL
+						ORDER BY prior_previous.ordinal DESC
+						LIMIT 1
+					)
+				ORDER BY prior.ordinal DESC
 				LIMIT 1
-			)
-		ORDER BY prior.ordinal DESC
-		LIMIT 1
-	), 'unknown')
-FROM messages m INDEXED BY idx_messages_velocity
-JOIN messages successor ON successor.id = (
-	SELECT next.id
-	FROM messages next
-	WHERE next.session_id = m.session_id
-		AND next.ordinal > m.ordinal
-		AND next.timestamp IS NOT NULL
-		AND next.timestamp != ''
-		AND agentsview_timestamp_unix_micro(next.timestamp) IS NOT NULL
-	ORDER BY next.ordinal
-	LIMIT 1
-)
-WHERE m.session_id IN (SELECT value FROM json_each(?))
-	AND m.timestamp IS NOT NULL
-	AND m.timestamp != ''
-	AND m.timestamp >= ?
-	AND m.timestamp < ?
-	AND agentsview_timestamp_unix_micro(m.timestamp) IS NOT NULL
-	AND agentsview_timestamp_unix_micro(m.timestamp) >= ?
-	AND agentsview_timestamp_unix_micro(m.timestamp) < ?
-ORDER BY agentsview_timestamp_unix_micro(m.timestamp),
-	m.session_id, m.ordinal`
+			), 'unknown') AS prior_model,
+			0 AS event_kind, 0 AS call_index, 0 AS event_index
+		FROM messages m INDEXED BY idx_messages_velocity
+		JOIN messages successor ON successor.id = (
+			SELECT next.id
+			FROM messages next
+			WHERE next.session_id = m.session_id
+				AND next.ordinal > m.ordinal
+				AND next.timestamp IS NOT NULL
+				AND next.timestamp != ''
+				AND agentsview_timestamp_unix_micro(next.timestamp) IS NOT NULL
+			ORDER BY next.ordinal
+			LIMIT 1
+		)
+		JOIN session_ids ids ON ids.session_id = m.session_id
+		CROSS JOIN bounds b
+		WHERE m.timestamp IS NOT NULL
+			AND m.timestamp != ''
+			AND m.timestamp >= b.padded_lower
+			AND m.timestamp < b.padded_upper
+			AND agentsview_timestamp_unix_micro(m.timestamp) IS NOT NULL
+
+		UNION ALL
+
+		SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
+			tail.timestamp, tail.successor_timestamp,
+			'tool', '',
+			COALESCE((
+				SELECT prior.model
+				FROM messages prior
+				WHERE prior.session_id = tail.session_id
+					AND prior.ordinal <= tail.ordinal
+					AND prior.role = 'assistant'
+					AND prior.model != ''
+				ORDER BY prior.ordinal DESC
+				LIMIT 1
+			), 'unknown'),
+			tail.event_kind, tail.call_index, tail.event_index
+		FROM ordered_tail tail
+		WHERE tail.successor_timestamp IS NOT NULL
+	)
+SELECT
+	c.session_id, c.start_ordinal, c.end_ordinal,
+	c.start_timestamp, c.end_timestamp,
+	c.closing_role, c.closing_model, c.prior_model
+FROM candidates c
+CROSS JOIN bounds b
+WHERE agentsview_timestamp_unix_micro(c.start_timestamp) >= b.lower_micro
+	AND agentsview_timestamp_unix_micro(c.start_timestamp) < b.upper_micro
+ORDER BY agentsview_timestamp_unix_micro(c.start_timestamp),
+	c.session_id, c.start_ordinal,
+	c.event_kind, c.call_index, c.event_index`
 
 func (db *DB) activityReportCandidateSource(
 	ids []string, q activity.Query,

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -156,6 +156,54 @@ func TestSQLiteActivityReportCandidateSourceDoesNotRequireGlobalTimestampIndex(
 	require.Len(t, candidates, 1)
 }
 
+func TestGetActivityReport_InlineToolCompletionResetsGapCap(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "inline-completion", "tools", func(s *Session) {
+		s.Agent = "grok"
+		s.StartedAt = Ptr("2026-06-16T10:00:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:11:00Z")
+	})
+	seedMessage(t, d, "inline-completion", 0, "user",
+		"2026-06-16T10:00:00Z", "")
+	seedMessage(t, d, "inline-completion", 1, "assistant",
+		"2026-06-16T10:01:00Z", "model-x")
+	seedMessage(t, d, "inline-completion", 2, "assistant",
+		"2026-06-16T10:11:00Z", "model-x")
+	timingInsertToolResultEvent(t, d, "inline-completion", 1, 0,
+		"sample-call", "completed", "2026-06-16T10:10:00Z", 1)
+
+	report, err := d.GetActivityReport(
+		context.Background(), AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"),
+	)
+	require.NoError(t, err)
+	require.Len(t, report.BySession, 1)
+	require.NotNil(t, report.BySession[0].AgentMinutes)
+	assert.InDelta(t, 7.0, *report.BySession[0].AgentMinutes, 1e-9)
+}
+
+func TestGetActivityReport_ToolCompletionAfterRangeClosesFinalMessage(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "completion-after-range", "tools", func(s *Session) {
+		s.Agent = "grok"
+		s.StartedAt = Ptr("2026-06-16T23:59:00Z")
+		s.EndedAt = Ptr("2026-06-17T00:01:00Z")
+	})
+	seedMessage(t, d, "completion-after-range", 0, "assistant",
+		"2026-06-16T23:59:00Z", "model-x")
+	timingInsertToolResultEvent(t, d, "completion-after-range", 0, 0,
+		"sample-call", "completed", "2026-06-17T00:01:00Z", 1)
+
+	report, err := d.GetActivityReport(
+		context.Background(), AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"),
+	)
+	require.NoError(t, err)
+	require.Len(t, report.BySession, 1)
+	require.NotNil(t, report.BySession[0].AgentMinutes)
+	assert.InDelta(t, 1.0, *report.BySession[0].AgentMinutes, 1e-9)
+}
+
 func BenchmarkSQLiteActivityReportCandidateSource100K(b *testing.B) {
 	d, ids, q := seedSQLiteActivityReportBenchmark(b)
 	source := d.activityReportCandidateSource(ids, q)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -419,7 +419,13 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // the real prompt, instead of leaving the raw wrapper in first_message and
 // the visible transcript. Existing rows need re-parsing so first_message
 // and message content drop the leading markup.)
-const dataVersion = 89
+// (89: OpenCode project metadata recovery. Existing file-backed sessions need
+// re-parsing so missing or unusable working directories can be recovered from
+// their project metadata.)
+// (90: Grok message timestamp backfill. Grok chat-history rows do not carry
+// timestamps; re-parsing enriches them from the authoritative timestamped
+// updates stream so existing sessions participate in activity aggregation.)
+const dataVersion = 90
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1009,9 +1009,14 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionIncludesOpenCodeProjectMetadataChange(t *testing.T) {
-	assert.Equal(t, 89, CurrentDataVersion(),
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 89,
 		"version 89 is the data-version boundary for file-backed OpenCode metadata changes")
 	t.Logf("CurrentDataVersion=%d", CurrentDataVersion())
+}
+
+func TestCurrentDataVersionGrokMessageTimestamps(t *testing.T) {
+	assert.Equal(t, 90, CurrentDataVersion(),
+		"Grok message timestamps require a sequential backfill")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -486,12 +486,19 @@ func duckActivityReportCandidateWhere(
 	where, args := duckBuildAnalyticsWhere(
 		f, "COALESCE(s.started_at, s.created_at)", "s.", false, false)
 	where += `
-		AND COALESCE(s.ended_at,
-			(SELECT MAX(m.timestamp) FROM messages m
-				WHERE m.session_id = s.id AND m.timestamp IS NOT NULL),
-			s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)
+		AND (COALESCE(s.ended_at,
+				(SELECT MAX(m.timestamp) FROM messages m
+					WHERE m.session_id = s.id AND m.timestamp IS NOT NULL),
+				s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)
+			OR EXISTS (
+				SELECT 1 FROM tool_result_events tre
+				WHERE tre.session_id = s.id
+					AND tre.source = 'tool_execution'
+					AND tre.status IN ('completed', 'errored')
+					AND tre.timestamp >= CAST(? AS TIMESTAMP)
+			))
 		AND COALESCE(s.started_at, s.created_at) < CAST(? AS TIMESTAMP)`
-	return where, append(args, rangeStartUTC, rangeEndUTC)
+	return where, append(args, rangeStartUTC, rangeStartUTC, rangeEndUTC)
 }
 
 func (s *Store) activityReportCandidateSource(

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -507,31 +507,36 @@ func (s *Store) activityReportCandidateSource(
 		lower := q.RangeStart.Add(
 			-time.Duration(q.GapCapSeconds) * time.Second,
 		)
-		query := `WITH last_messages AS (
-			SELECT session_id, ordinal, timestamp
-			FROM (
-				SELECT m.session_id, m.ordinal, m.timestamp,
-					ROW_NUMBER() OVER (
-						PARTITION BY m.session_id ORDER BY m.ordinal DESC
-					) AS row_num
+		tailQuery := `WITH terminal_events AS (
+			SELECT tre.session_id, tre.call_index, tre.event_index, tre.timestamp
+			FROM tool_result_events tre
+			WHERE tre.session_id IN (SELECT unnest(?))
+				AND tre.source = 'tool_execution'
+				AND tre.status IN ('completed', 'errored')
+				AND tre.timestamp IS NOT NULL
+		), terminal_sessions AS (
+			SELECT DISTINCT session_id FROM terminal_events
+		), last_messages AS (
+			SELECT latest.session_id, latest.ordinal, latest.timestamp
+			FROM terminal_sessions ts
+			JOIN LATERAL (
+				SELECT m.session_id, m.ordinal, m.timestamp
 				FROM messages m
-				WHERE m.session_id IN (SELECT unnest(?))
+				WHERE m.session_id = ts.session_id
 					AND m.timestamp IS NOT NULL
-			) ranked
-			WHERE row_num = 1
+				ORDER BY m.ordinal DESC
+				LIMIT 1
+			) latest ON TRUE
 		), tail_events AS (
 			SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
 				0 AS call_index, 0 AS event_index, lm.timestamp
 			FROM last_messages lm
 			UNION ALL
 			SELECT lm.session_id, lm.ordinal, 1,
-				tre.call_index, tre.event_index, tre.timestamp
+				te.call_index, te.event_index, te.timestamp
 			FROM last_messages lm
-			JOIN tool_result_events tre ON tre.session_id = lm.session_id
-			WHERE tre.source = 'tool_execution'
-				AND tre.status IN ('completed', 'errored')
-				AND tre.timestamp IS NOT NULL
-				AND tre.timestamp > lm.timestamp
+			JOIN terminal_events te ON te.session_id = lm.session_id
+			WHERE te.timestamp > lm.timestamp
 		), ordered_tail AS (
 			SELECT e.*,
 				LEAD(e.ordinal) OVER tail_order AS successor_ordinal,
@@ -542,14 +547,90 @@ func (s *Store) activityReportCandidateSource(
 				ORDER BY e.timestamp, e.event_kind,
 					e.call_index, e.event_index
 			)
-		), candidates AS (
-			SELECT
-				m.session_id, m.ordinal AS start_ordinal,
-				successor.ordinal AS end_ordinal,
-				m.timestamp AS start_timestamp,
-				successor.timestamp AS end_timestamp,
-				successor.role AS closing_role,
-				successor.model AS closing_model,
+		)
+		SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
+			tail.timestamp, tail.successor_timestamp,
+			'tool', '',
+			COALESCE((
+				SELECT prior.model
+				FROM messages prior
+				WHERE prior.session_id = tail.session_id
+					AND prior.ordinal <= tail.ordinal
+					AND prior.role = 'assistant'
+					AND prior.model != ''
+				ORDER BY prior.ordinal DESC
+				LIMIT 1
+			), 'unknown')
+		FROM ordered_tail tail
+		WHERE tail.successor_timestamp IS NOT NULL
+			AND tail.timestamp >= CAST(? AS TIMESTAMP)
+			AND tail.timestamp < CAST(? AS TIMESTAMP)
+		ORDER BY tail.timestamp, tail.session_id, tail.ordinal,
+			tail.event_kind, tail.call_index, tail.event_index`
+		scanCandidate := func(
+			row interface{ Scan(dest ...any) error },
+		) (activity.IntervalCandidate, error) {
+			var candidate activity.IntervalCandidate
+			var start, end any
+			if err := row.Scan(
+				&candidate.SessionID, &candidate.StartOrdinal,
+				&candidate.EndOrdinal, &start, &end,
+				&candidate.ClosingRole, &candidate.ClosingModel,
+				&candidate.PriorModel,
+			); err != nil {
+				return candidate, fmt.Errorf(
+					"scanning duckdb activity report candidate: %w", err)
+			}
+			startText, endText := formatDBTime(start), formatDBTime(end)
+			var err error
+			candidate.Start, err = time.Parse(time.RFC3339Nano, startText)
+			if err != nil {
+				return candidate, fmt.Errorf(
+					"parsing duckdb activity candidate start: %w", err)
+			}
+			candidate.End, err = time.Parse(time.RFC3339Nano, endText)
+			if err != nil {
+				return candidate, fmt.Errorf(
+					"parsing duckdb activity candidate end: %w", err)
+			}
+			candidate.Start = candidate.Start.UTC()
+			candidate.End = candidate.End.UTC()
+			return candidate, nil
+		}
+
+		tailRows, err := s.queryContext(
+			ctx, tailQuery, ids,
+			lower.UTC().Format(time.RFC3339Nano),
+			q.EffectiveEnd.UTC().Format(time.RFC3339Nano),
+		)
+		if err != nil {
+			return fmt.Errorf("querying duckdb activity report tail candidates: %w", err)
+		}
+		var tail []activity.IntervalCandidate
+		for tailRows.Next() {
+			candidate, scanErr := scanCandidate(tailRows)
+			if scanErr != nil {
+				tailRows.Close()
+				return scanErr
+			}
+			tail = append(tail, candidate)
+		}
+		if err := tailRows.Err(); err != nil {
+			tailRows.Close()
+			return err
+		}
+		if err := tailRows.Close(); err != nil {
+			return err
+		}
+
+		messageSource := func(
+			ctx context.Context,
+			yield func(activity.IntervalCandidate) error,
+		) error {
+			query := `SELECT
+				m.session_id, m.ordinal, successor.ordinal,
+				m.timestamp, successor.timestamp,
+				successor.role, successor.model,
 				COALESCE((
 					SELECT prior.model
 					FROM messages prior
@@ -569,8 +650,7 @@ func (s *Store) activityReportCandidateSource(
 						)
 					ORDER BY prior.ordinal DESC
 					LIMIT 1
-				), 'unknown') AS prior_model,
-				0 AS event_kind, 0 AS call_index, 0 AS event_index
+				), 'unknown')
 			FROM messages m
 			JOIN messages successor
 				ON successor.session_id = m.session_id
@@ -587,75 +667,32 @@ func (s *Store) activityReportCandidateSource(
 				AND m.timestamp IS NOT NULL
 				AND m.timestamp >= CAST(? AS TIMESTAMP)
 				AND m.timestamp < CAST(? AS TIMESTAMP)
-
-			UNION ALL
-
-			SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
-				tail.timestamp, tail.successor_timestamp,
-				'tool', '',
-				COALESCE((
-					SELECT prior.model
-					FROM messages prior
-					WHERE prior.session_id = tail.session_id
-						AND prior.ordinal <= tail.ordinal
-						AND prior.role = 'assistant'
-						AND prior.model != ''
-					ORDER BY prior.ordinal DESC
-					LIMIT 1
-				), 'unknown'),
-				tail.event_kind, tail.call_index, tail.event_index
-			FROM ordered_tail tail
-			WHERE tail.successor_timestamp IS NOT NULL
-		)
-		SELECT session_id, start_ordinal, end_ordinal,
-			start_timestamp, end_timestamp,
-			closing_role, closing_model, prior_model
-		FROM candidates
-		WHERE start_timestamp >= CAST(? AS TIMESTAMP)
-			AND start_timestamp < CAST(? AS TIMESTAMP)
-		ORDER BY start_timestamp, session_id, start_ordinal,
-			event_kind, call_index, event_index`
-		rows, err := s.queryContext(
-			ctx, query, ids, ids,
-			lower.UTC().Format(time.RFC3339Nano),
-			q.EffectiveEnd.UTC().Format(time.RFC3339Nano),
-			lower.UTC().Format(time.RFC3339Nano),
-			q.EffectiveEnd.UTC().Format(time.RFC3339Nano),
-		)
-		if err != nil {
-			return fmt.Errorf("querying duckdb activity report candidates: %w", err)
+			ORDER BY m.timestamp, m.session_id, m.ordinal`
+			rows, queryErr := s.queryContext(
+				ctx, query, ids,
+				lower.UTC().Format(time.RFC3339Nano),
+				q.EffectiveEnd.UTC().Format(time.RFC3339Nano),
+			)
+			if queryErr != nil {
+				return fmt.Errorf(
+					"querying duckdb activity report candidates: %w", queryErr)
+			}
+			defer rows.Close()
+			for rows.Next() {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				candidate, scanErr := scanCandidate(rows)
+				if scanErr != nil {
+					return scanErr
+				}
+				if err := yield(candidate); err != nil {
+					return err
+				}
+			}
+			return rows.Err()
 		}
-		defer rows.Close()
-		for rows.Next() {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			var candidate activity.IntervalCandidate
-			var start, end any
-			if err := rows.Scan(
-				&candidate.SessionID, &candidate.StartOrdinal,
-				&candidate.EndOrdinal, &start, &end,
-				&candidate.ClosingRole, &candidate.ClosingModel,
-				&candidate.PriorModel,
-			); err != nil {
-				return fmt.Errorf("scanning duckdb activity report candidate: %w", err)
-			}
-			startText, endText := formatDBTime(start), formatDBTime(end)
-			candidate.Start, err = time.Parse(time.RFC3339Nano, startText)
-			if err != nil {
-				return fmt.Errorf("parsing duckdb activity candidate start: %w", err)
-			}
-			candidate.End, err = time.Parse(time.RFC3339Nano, endText)
-			if err != nil {
-				return fmt.Errorf("parsing duckdb activity candidate end: %w", err)
-			}
-			candidate.Start = candidate.Start.UTC()
-			candidate.End = candidate.End.UTC()
-			if err := yield(candidate); err != nil {
-				return err
-			}
-		}
-		return rows.Err()
+		return activity.MergeCandidateSlice(tail, messageSource)(ctx, yield)
 	}
 }
 

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -507,49 +507,118 @@ func (s *Store) activityReportCandidateSource(
 		lower := q.RangeStart.Add(
 			-time.Duration(q.GapCapSeconds) * time.Second,
 		)
-		query := `SELECT
-			m.session_id, m.ordinal, successor.ordinal,
-			m.timestamp, successor.timestamp,
-			successor.role, successor.model,
-			COALESCE((
-				SELECT prior.model
-				FROM messages prior
-				WHERE prior.session_id = m.session_id
-					AND prior.ordinal <= m.ordinal
-					AND prior.role = 'assistant'
-					AND prior.model != ''
-					AND prior.timestamp IS NOT NULL
-					AND prior.timestamp > (
-						SELECT prior_previous.timestamp
-						FROM messages prior_previous
-						WHERE prior_previous.session_id = prior.session_id
-							AND prior_previous.ordinal < prior.ordinal
-							AND prior_previous.timestamp IS NOT NULL
-						ORDER BY prior_previous.ordinal DESC
-						LIMIT 1
-					)
-				ORDER BY prior.ordinal DESC
-				LIMIT 1
-			), 'unknown')
-		FROM messages m
-		JOIN messages successor
-			ON successor.session_id = m.session_id
-			AND successor.ordinal = (
-				SELECT next.ordinal
-				FROM messages next
-				WHERE next.session_id = m.session_id
-					AND next.ordinal > m.ordinal
-					AND next.timestamp IS NOT NULL
-				ORDER BY next.ordinal
-				LIMIT 1
+		query := `WITH last_messages AS (
+			SELECT session_id, ordinal, timestamp
+			FROM (
+				SELECT m.session_id, m.ordinal, m.timestamp,
+					ROW_NUMBER() OVER (
+						PARTITION BY m.session_id ORDER BY m.ordinal DESC
+					) AS row_num
+				FROM messages m
+				WHERE m.session_id IN (SELECT unnest(?))
+					AND m.timestamp IS NOT NULL
+			) ranked
+			WHERE row_num = 1
+		), tail_events AS (
+			SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
+				0 AS call_index, 0 AS event_index, lm.timestamp
+			FROM last_messages lm
+			UNION ALL
+			SELECT lm.session_id, lm.ordinal, 1,
+				tre.call_index, tre.event_index, tre.timestamp
+			FROM last_messages lm
+			JOIN tool_result_events tre ON tre.session_id = lm.session_id
+			WHERE tre.source = 'tool_execution'
+				AND tre.status IN ('completed', 'errored')
+				AND tre.timestamp IS NOT NULL
+				AND tre.timestamp > lm.timestamp
+		), ordered_tail AS (
+			SELECT e.*,
+				LEAD(e.ordinal) OVER tail_order AS successor_ordinal,
+				LEAD(e.timestamp) OVER tail_order AS successor_timestamp
+			FROM tail_events e
+			WINDOW tail_order AS (
+				PARTITION BY e.session_id
+				ORDER BY e.timestamp, e.event_kind,
+					e.call_index, e.event_index
 			)
-		WHERE m.session_id IN (SELECT unnest(?))
-			AND m.timestamp IS NOT NULL
-			AND m.timestamp >= CAST(? AS TIMESTAMP)
-			AND m.timestamp < CAST(? AS TIMESTAMP)
-		ORDER BY m.timestamp, m.session_id, m.ordinal`
+		), candidates AS (
+			SELECT
+				m.session_id, m.ordinal AS start_ordinal,
+				successor.ordinal AS end_ordinal,
+				m.timestamp AS start_timestamp,
+				successor.timestamp AS end_timestamp,
+				successor.role AS closing_role,
+				successor.model AS closing_model,
+				COALESCE((
+					SELECT prior.model
+					FROM messages prior
+					WHERE prior.session_id = m.session_id
+						AND prior.ordinal <= m.ordinal
+						AND prior.role = 'assistant'
+						AND prior.model != ''
+						AND prior.timestamp IS NOT NULL
+						AND prior.timestamp > (
+							SELECT prior_previous.timestamp
+							FROM messages prior_previous
+							WHERE prior_previous.session_id = prior.session_id
+								AND prior_previous.ordinal < prior.ordinal
+								AND prior_previous.timestamp IS NOT NULL
+							ORDER BY prior_previous.ordinal DESC
+							LIMIT 1
+						)
+					ORDER BY prior.ordinal DESC
+					LIMIT 1
+				), 'unknown') AS prior_model,
+				0 AS event_kind, 0 AS call_index, 0 AS event_index
+			FROM messages m
+			JOIN messages successor
+				ON successor.session_id = m.session_id
+				AND successor.ordinal = (
+					SELECT next.ordinal
+					FROM messages next
+					WHERE next.session_id = m.session_id
+						AND next.ordinal > m.ordinal
+						AND next.timestamp IS NOT NULL
+					ORDER BY next.ordinal
+					LIMIT 1
+				)
+			WHERE m.session_id IN (SELECT unnest(?))
+				AND m.timestamp IS NOT NULL
+				AND m.timestamp >= CAST(? AS TIMESTAMP)
+				AND m.timestamp < CAST(? AS TIMESTAMP)
+
+			UNION ALL
+
+			SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
+				tail.timestamp, tail.successor_timestamp,
+				'tool', '',
+				COALESCE((
+					SELECT prior.model
+					FROM messages prior
+					WHERE prior.session_id = tail.session_id
+						AND prior.ordinal <= tail.ordinal
+						AND prior.role = 'assistant'
+						AND prior.model != ''
+					ORDER BY prior.ordinal DESC
+					LIMIT 1
+				), 'unknown'),
+				tail.event_kind, tail.call_index, tail.event_index
+			FROM ordered_tail tail
+			WHERE tail.successor_timestamp IS NOT NULL
+		)
+		SELECT session_id, start_ordinal, end_ordinal,
+			start_timestamp, end_timestamp,
+			closing_role, closing_model, prior_model
+		FROM candidates
+		WHERE start_timestamp >= CAST(? AS TIMESTAMP)
+			AND start_timestamp < CAST(? AS TIMESTAMP)
+		ORDER BY start_timestamp, session_id, start_ordinal,
+			event_kind, call_index, event_index`
 		rows, err := s.queryContext(
-			ctx, query, ids,
+			ctx, query, ids, ids,
+			lower.UTC().Format(time.RFC3339Nano),
+			q.EffectiveEnd.UTC().Format(time.RFC3339Nano),
 			lower.UTC().Format(time.RFC3339Nano),
 			q.EffectiveEnd.UTC().Format(time.RFC3339Nano),
 		)

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -507,15 +507,42 @@ func (s *Store) activityReportCandidateSource(
 		lower := q.RangeStart.Add(
 			-time.Duration(q.GapCapSeconds) * time.Second,
 		)
-		tailQuery := `WITH terminal_events AS (
-			SELECT tre.session_id, tre.call_index, tre.event_index, tre.timestamp
+		terminalQuery := `WITH terminal_events AS (
+			SELECT tre.session_id, tre.tool_call_message_ordinal AS ordinal,
+				tre.call_index, tre.event_index, tre.timestamp
 			FROM tool_result_events tre
 			WHERE tre.session_id IN (SELECT unnest(?))
 				AND tre.source = 'tool_execution'
 				AND tre.status IN ('completed', 'errored')
 				AND tre.timestamp IS NOT NULL
+				AND tre.timestamp >= CAST(? AS TIMESTAMP)
 		), terminal_sessions AS (
 			SELECT DISTINCT session_id FROM terminal_events
+		), ordered_terminal AS (
+			SELECT te.*,
+				LEAD(te.ordinal) OVER terminal_order AS next_terminal_ordinal,
+				LEAD(te.timestamp) OVER terminal_order AS next_terminal_timestamp
+			FROM terminal_events te
+			WINDOW terminal_order AS (
+				PARTITION BY te.session_id
+				ORDER BY te.timestamp, te.call_index, te.event_index
+			)
+		), terminal_with_message AS (
+			SELECT ot.*, next_message.ordinal AS next_message_ordinal,
+				next_message.timestamp AS next_message_timestamp,
+				next_message.role AS next_message_role,
+				next_message.model AS next_message_model
+			FROM ordered_terminal ot
+			LEFT JOIN LATERAL (
+				SELECT next.ordinal, next.timestamp, next.role, next.model
+				FROM messages next
+				WHERE next.session_id = ot.session_id
+					AND next.ordinal > ot.ordinal
+					AND next.timestamp IS NOT NULL
+					AND next.timestamp > ot.timestamp
+				ORDER BY next.ordinal
+				LIMIT 1
+			) next_message ON TRUE
 		), last_messages AS (
 			SELECT latest.session_id, latest.ordinal, latest.timestamp
 			FROM terminal_sessions ts
@@ -527,46 +554,77 @@ func (s *Store) activityReportCandidateSource(
 				ORDER BY m.ordinal DESC
 				LIMIT 1
 			) latest ON TRUE
-		), tail_events AS (
-			SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
-				0 AS call_index, 0 AS event_index, lm.timestamp
-			FROM last_messages lm
-			UNION ALL
-			SELECT lm.session_id, lm.ordinal, 1,
-				te.call_index, te.event_index, te.timestamp
+		), first_tail_events AS (
+			SELECT lm.session_id, lm.ordinal, lm.timestamp,
+				te.call_index, te.event_index, te.timestamp AS terminal_timestamp,
+				ROW_NUMBER() OVER (
+					PARTITION BY lm.session_id
+					ORDER BY te.timestamp, te.call_index, te.event_index
+				) AS row_num
 			FROM last_messages lm
 			JOIN terminal_events te ON te.session_id = lm.session_id
 			WHERE te.timestamp > lm.timestamp
-		), ordered_tail AS (
-			SELECT e.*,
-				LEAD(e.ordinal) OVER tail_order AS successor_ordinal,
-				LEAD(e.timestamp) OVER tail_order AS successor_timestamp
-			FROM tail_events e
-			WINDOW tail_order AS (
-				PARTITION BY e.session_id
-				ORDER BY e.timestamp, e.event_kind,
-					e.call_index, e.event_index
-			)
+		), candidates AS (
+			SELECT twm.session_id, twm.ordinal AS start_ordinal,
+				CASE
+					WHEN twm.next_terminal_timestamp IS NOT NULL AND
+						(twm.next_message_timestamp IS NULL OR
+						 twm.next_terminal_timestamp < twm.next_message_timestamp)
+					THEN twm.next_terminal_ordinal
+					ELSE twm.next_message_ordinal
+				END AS end_ordinal,
+				twm.timestamp AS start_timestamp,
+				CASE
+					WHEN twm.next_terminal_timestamp IS NOT NULL AND
+						(twm.next_message_timestamp IS NULL OR
+						 twm.next_terminal_timestamp < twm.next_message_timestamp)
+					THEN twm.next_terminal_timestamp
+					ELSE twm.next_message_timestamp
+				END AS end_timestamp,
+				CASE
+					WHEN twm.next_terminal_timestamp IS NOT NULL AND
+						(twm.next_message_timestamp IS NULL OR
+						 twm.next_terminal_timestamp < twm.next_message_timestamp)
+					THEN 'tool'
+					ELSE twm.next_message_role
+				END AS closing_role,
+				CASE
+					WHEN twm.next_terminal_timestamp IS NOT NULL AND
+						(twm.next_message_timestamp IS NULL OR
+						 twm.next_terminal_timestamp < twm.next_message_timestamp)
+					THEN ''
+					ELSE twm.next_message_model
+				END AS closing_model,
+				twm.call_index, twm.event_index
+			FROM terminal_with_message twm
+
+			UNION ALL
+
+			SELECT fte.session_id, fte.ordinal, fte.ordinal,
+				fte.timestamp, fte.terminal_timestamp, 'tool', '',
+				fte.call_index, fte.event_index
+			FROM first_tail_events fte
+			WHERE fte.row_num = 1
 		)
-		SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
-			tail.timestamp, tail.successor_timestamp,
-			'tool', '',
+		SELECT candidate.session_id, candidate.start_ordinal,
+			candidate.end_ordinal, candidate.start_timestamp,
+			candidate.end_timestamp, candidate.closing_role,
+			candidate.closing_model,
 			COALESCE((
 				SELECT prior.model
 				FROM messages prior
-				WHERE prior.session_id = tail.session_id
-					AND prior.ordinal <= tail.ordinal
+				WHERE prior.session_id = candidate.session_id
+					AND prior.ordinal <= candidate.start_ordinal
 					AND prior.role = 'assistant'
 					AND prior.model != ''
 				ORDER BY prior.ordinal DESC
 				LIMIT 1
 			), 'unknown')
-		FROM ordered_tail tail
-		WHERE tail.successor_timestamp IS NOT NULL
-			AND tail.timestamp >= CAST(? AS TIMESTAMP)
-			AND tail.timestamp < CAST(? AS TIMESTAMP)
-		ORDER BY tail.timestamp, tail.session_id, tail.ordinal,
-			tail.event_kind, tail.call_index, tail.event_index`
+		FROM candidates candidate
+		WHERE candidate.end_timestamp IS NOT NULL
+			AND candidate.start_timestamp < CAST(? AS TIMESTAMP)
+		ORDER BY candidate.start_timestamp, candidate.session_id,
+			candidate.start_ordinal, candidate.call_index, candidate.event_index`
 		scanCandidate := func(
 			row interface{ Scan(dest ...any) error },
 		) (activity.IntervalCandidate, error) {
@@ -598,28 +656,28 @@ func (s *Store) activityReportCandidateSource(
 			return candidate, nil
 		}
 
-		tailRows, err := s.queryContext(
-			ctx, tailQuery, ids,
+		terminalRows, err := s.queryContext(
+			ctx, terminalQuery, ids,
 			lower.UTC().Format(time.RFC3339Nano),
 			q.EffectiveEnd.UTC().Format(time.RFC3339Nano),
 		)
 		if err != nil {
-			return fmt.Errorf("querying duckdb activity report tail candidates: %w", err)
+			return fmt.Errorf("querying duckdb activity report terminal candidates: %w", err)
 		}
-		var tail []activity.IntervalCandidate
-		for tailRows.Next() {
-			candidate, scanErr := scanCandidate(tailRows)
+		var terminal []activity.IntervalCandidate
+		for terminalRows.Next() {
+			candidate, scanErr := scanCandidate(terminalRows)
 			if scanErr != nil {
-				tailRows.Close()
+				terminalRows.Close()
 				return scanErr
 			}
-			tail = append(tail, candidate)
+			terminal = append(terminal, candidate)
 		}
-		if err := tailRows.Err(); err != nil {
-			tailRows.Close()
+		if err := terminalRows.Err(); err != nil {
+			terminalRows.Close()
 			return err
 		}
-		if err := tailRows.Close(); err != nil {
+		if err := terminalRows.Close(); err != nil {
 			return err
 		}
 
@@ -692,7 +750,7 @@ func (s *Store) activityReportCandidateSource(
 			}
 			return rows.Err()
 		}
-		return activity.MergeCandidateSlice(tail, messageSource)(ctx, yield)
+		return activity.MergeCandidateSlice(terminal, messageSource)(ctx, yield)
 	}
 }
 

--- a/internal/duckdb/activityreport_test.go
+++ b/internal/duckdb/activityreport_test.go
@@ -106,6 +106,92 @@ func TestActivityReportCandidateSourcePreservesRangeEdgePairs(t *testing.T) {
 		"left pruning and right successor lookup must preserve adjacency")
 }
 
+func TestDuckActivityReportIncludesToolCompletionEvents(t *testing.T) {
+	const sessionID = "tool-completion"
+	started := "2026-06-14T10:00:00Z"
+	called := "2026-06-14T10:01:00Z"
+	completed := "2026-06-14T10:02:00Z"
+	session := syncSession(sessionID, "tools", "tool timing", started, 2)
+	session.EndedAt = &completed
+	callMessage := syncMessage(
+		sessionID, 1, "assistant", "", called,
+	)
+	callMessage.Model = "model-x"
+	callMessage.HasToolUse = true
+	callMessage.ToolCalls = []db.ToolCall{{
+		SessionID: sessionID,
+		ToolName:  "sample_tool",
+		Category:  "Other",
+		ToolUseID: "sample-call",
+		CallIndex: 0,
+		ResultEvents: []db.ToolResultEvent{
+			{ToolUseID: "sample-call", Source: "tool_execution",
+				Status: "started", Timestamp: called, EventIndex: 0},
+			{ToolUseID: "sample-call", Source: "tool_execution",
+				Status: "completed", Timestamp: completed, EventIndex: 1},
+		},
+	}}
+	store := activityReportStore(t, []db.SessionBatchWrite{{
+		Session: session,
+		Messages: []db.Message{
+			syncMessage(sessionID, 0, "user", "run the sample", started),
+			callMessage,
+		},
+		DataVersion: 1, ReplaceMessages: true,
+	}}, nil)
+
+	report, err := store.GetActivityReport(
+		context.Background(), db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"),
+	)
+	require.NoError(t, err)
+	require.Len(t, report.BySession, 1)
+	require.NotNil(t, report.BySession[0].AgentMinutes)
+	assert.InDelta(t, 2.0, *report.BySession[0].AgentMinutes, 1e-9)
+}
+
+func TestDuckActivityReportDoesNotDoubleCountInlineToolCompletion(t *testing.T) {
+	const sessionID = "inline-tool-completion"
+	started := "2026-06-14T10:00:00Z"
+	called := "2026-06-14T10:01:00Z"
+	continued := "2026-06-14T10:01:30Z"
+	completed := "2026-06-14T10:02:00Z"
+	ended := "2026-06-14T10:03:00Z"
+	session := syncSession(sessionID, "tools", "inline tool timing", started, 4)
+	session.EndedAt = &ended
+	callMessage := syncMessage(sessionID, 1, "assistant", "", called)
+	callMessage.HasToolUse = true
+	callMessage.ToolCalls = []db.ToolCall{{
+		SessionID: sessionID, ToolName: "sample_tool", Category: "Other",
+		ToolUseID: "sample-call", CallIndex: 0,
+		ResultEvents: []db.ToolResultEvent{
+			{ToolUseID: "sample-call", Source: "tool_execution",
+				Status: "started", Timestamp: called, EventIndex: 0},
+			{ToolUseID: "sample-call", Source: "tool_execution",
+				Status: "completed", Timestamp: completed, EventIndex: 1},
+		},
+	}}
+	store := activityReportStore(t, []db.SessionBatchWrite{{
+		Session: session,
+		Messages: []db.Message{
+			syncMessage(sessionID, 0, "user", "run the sample", started),
+			callMessage,
+			syncMessage(sessionID, 2, "assistant", "continuing", continued),
+			syncMessage(sessionID, 3, "assistant", "finished", ended),
+		},
+		DataVersion: 1, ReplaceMessages: true,
+	}}, nil)
+
+	report, err := store.GetActivityReport(
+		context.Background(), db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"),
+	)
+	require.NoError(t, err)
+	require.Len(t, report.BySession, 1)
+	require.NotNil(t, report.BySession[0].AgentMinutes)
+	assert.InDelta(t, 3.0, *report.BySession[0].AgentMinutes, 1e-9)
+}
+
 func TestDuckGetActivityReportBasicConcurrency(t *testing.T) {
 	ctx := context.Background()
 	// Two overlapping sessions on 2026-06-14 (UTC), each two timestamped

--- a/internal/parser/format_sources_test.go
+++ b/internal/parser/format_sources_test.go
@@ -49,11 +49,8 @@ func TestSessionFormatSourcesCoverRegistry(t *testing.T) {
 		documented[agent] = true
 	}
 
-	expected := make(map[AgentType]bool, len(Registry)-1)
+	expected := make(map[AgentType]bool, len(Registry))
 	for _, def := range Registry {
-		if def.Type == AgentGrok {
-			continue
-		}
 		expected[def.Type] = true
 	}
 

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -675,12 +675,20 @@ func grokTimestampAnchorMatches(
 		return false
 	}
 	if len(message.ToolCalls) > 0 && len(anchor.toolCallIDs) > 0 {
+		hasComparableIDs := false
 		for _, call := range message.ToolCalls {
 			for _, id := range anchor.toolCallIDs {
-				if call.ToolUseID != "" && call.ToolUseID == id {
+				if call.ToolUseID == "" || id == "" {
+					continue
+				}
+				hasComparableIDs = true
+				if call.ToolUseID == id {
 					return true
 				}
 			}
+		}
+		if hasComparableIDs {
+			return false
 		}
 	}
 	switch message.Role {

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -505,7 +505,7 @@ func parseGrokChatHistory(path string) ([]ParsedMessage, int, error) {
 			}
 			messages = append(messages, ParsedMessage{
 				Ordinal:       ordinal,
-				Role:          RoleUser,
+				Role:          RoleTool,
 				ContentLength: contentLen,
 				ToolResults: []ParsedToolResult{{
 					ToolUseID:     toolCallID,
@@ -635,7 +635,7 @@ func parseGrokUpdateTimestampAnchors(
 			builder.flush()
 			if id := strings.TrimSpace(update.Get("toolCallId").Str); id != "" {
 				builder.anchors = append(builder.anchors, grokTimestampAnchor{
-					role:         RoleUser,
+					role:         RoleTool,
 					timestamp:    timestamp,
 					toolResultID: id,
 				})

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -617,10 +617,15 @@ func parseGrokUpdateTimestampAnchors(
 			}
 
 		case "tool_call":
-			builder.start(RoleAssistant, timestamp)
-			if id := strings.TrimSpace(update.Get("toolCallId").Str); id != "" {
-				builder.toolCallIDs = append(builder.toolCallIDs, id)
+			builder.flush()
+			anchor := grokTimestampAnchor{
+				role:      RoleAssistant,
+				timestamp: timestamp,
 			}
+			if id := strings.TrimSpace(update.Get("toolCallId").Str); id != "" {
+				anchor.toolCallIDs = []string{id}
+			}
+			builder.anchors = append(builder.anchors, anchor)
 
 		case "tool_call_update":
 			status := update.Get("status").Str

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -95,6 +95,13 @@ func ParseGrokSummary(
 	if transcriptErr != nil && !os.IsNotExist(transcriptErr) {
 		return ParseResult{}, transcriptErr
 	}
+	timestampAnchors, timestampErr := parseGrokUpdateTimestampAnchors(
+		filepath.Join(sessionDir, "updates.jsonl"),
+	)
+	if timestampErr != nil && !errors.Is(timestampErr, os.ErrNotExist) {
+		return ParseResult{}, timestampErr
+	}
+	enrichGrokMessageTimestamps(messages, timestampAnchors)
 
 	firstPrompt := ""
 	for _, msg := range messages {
@@ -519,6 +526,180 @@ func parseGrokChatHistory(path string) ([]ParsedMessage, int, error) {
 	return messages, malformed, nil
 }
 
+type grokTimestampAnchor struct {
+	role         RoleType
+	content      string
+	timestamp    time.Time
+	toolCallIDs  []string
+	toolResultID string
+}
+
+type grokTimestampAnchorBuilder struct {
+	anchors     []grokTimestampAnchor
+	role        RoleType
+	content     strings.Builder
+	timestamp   time.Time
+	toolCallIDs []string
+}
+
+func (b *grokTimestampAnchorBuilder) flush() {
+	if b.role == "" {
+		return
+	}
+	b.anchors = append(b.anchors, grokTimestampAnchor{
+		role:        b.role,
+		content:     b.content.String(),
+		timestamp:   b.timestamp,
+		toolCallIDs: append([]string(nil), b.toolCallIDs...),
+	})
+	b.role = ""
+	b.content.Reset()
+	b.timestamp = time.Time{}
+	b.toolCallIDs = b.toolCallIDs[:0]
+}
+
+func (b *grokTimestampAnchorBuilder) start(role RoleType, timestamp time.Time) {
+	if b.role != role {
+		b.flush()
+		b.role = role
+	}
+	if b.timestamp.IsZero() && !timestamp.IsZero() {
+		b.timestamp = timestamp
+	}
+}
+
+func (b *grokTimestampAnchorBuilder) addUserText(text string) {
+	if text == "" {
+		return
+	}
+	if b.content.Len() > 0 {
+		b.content.WriteByte('\n')
+	}
+	b.content.WriteString(text)
+}
+
+func parseGrokUpdateTimestampAnchors(
+	path string,
+) ([]grokTimestampAnchor, error) {
+	var builder grokTimestampAnchorBuilder
+	_, err := readJSONLFrom(path, 0, func(line string) {
+		if !gjson.Valid(line) {
+			return
+		}
+		root := gjson.Parse(line)
+		update := root.Get("params.update")
+		if !update.Exists() {
+			update = root.Get("update")
+		}
+		if !update.Exists() {
+			return
+		}
+		timestamp := hermesUnixTime(root.Get("timestamp").Float())
+		switch update.Get("sessionUpdate").Str {
+		case "user_message_chunk":
+			if update.Get("_meta.hostTurn").Bool() {
+				builder.flush()
+				return
+			}
+			builder.start(RoleUser, timestamp)
+			if update.Get("content.type").Str == "text" {
+				builder.addUserText(update.Get("content.text").Str)
+			}
+
+		case "agent_message_chunk":
+			if update.Get("_meta.hostTurn").Bool() {
+				builder.flush()
+				return
+			}
+			builder.start(RoleAssistant, timestamp)
+			if update.Get("content.type").Str == "text" {
+				builder.content.WriteString(update.Get("content.text").Str)
+			}
+
+		case "tool_call":
+			builder.start(RoleAssistant, timestamp)
+			if id := strings.TrimSpace(update.Get("toolCallId").Str); id != "" {
+				builder.toolCallIDs = append(builder.toolCallIDs, id)
+			}
+
+		case "tool_call_update":
+			status := update.Get("status").Str
+			if status != "completed" && status != "failed" {
+				return
+			}
+			builder.flush()
+			if id := strings.TrimSpace(update.Get("toolCallId").Str); id != "" {
+				builder.anchors = append(builder.anchors, grokTimestampAnchor{
+					role:         RoleUser,
+					timestamp:    timestamp,
+					toolResultID: id,
+				})
+			}
+
+		case "compaction_checkpoint":
+			builder = grokTimestampAnchorBuilder{}
+		}
+	})
+	builder.flush()
+	return builder.anchors, err
+}
+
+func enrichGrokMessageTimestamps(
+	messages []ParsedMessage, anchors []grokTimestampAnchor,
+) {
+	anchorIndex := 0
+	for i := range messages {
+		for j := anchorIndex; j < len(anchors); j++ {
+			if !grokTimestampAnchorMatches(messages[i], anchors[j]) {
+				continue
+			}
+			messages[i].Timestamp = anchors[j].timestamp
+			anchorIndex = j + 1
+			break
+		}
+	}
+}
+
+func grokTimestampAnchorMatches(
+	message ParsedMessage, anchor grokTimestampAnchor,
+) bool {
+	if message.Role != anchor.role {
+		return false
+	}
+	if len(message.ToolResults) > 0 {
+		for _, result := range message.ToolResults {
+			if result.ToolUseID != "" && result.ToolUseID == anchor.toolResultID {
+				return true
+			}
+		}
+		return false
+	}
+	if len(message.ToolCalls) > 0 && len(anchor.toolCallIDs) > 0 {
+		for _, call := range message.ToolCalls {
+			for _, id := range anchor.toolCallIDs {
+				if call.ToolUseID != "" && call.ToolUseID == id {
+					return true
+				}
+			}
+		}
+	}
+	switch message.Role {
+	case RoleUser:
+		return message.Content == grokNormalizeUserText(anchor.content)
+	case RoleAssistant:
+		content := message.Content
+		if message.HasThinking {
+			content = strings.TrimPrefix(
+				content,
+				"[Thinking]\n"+message.ThinkingText+"\n[/Thinking]\n",
+			)
+		}
+		return content == strings.TrimSpace(anchor.content)
+	default:
+		return false
+	}
+}
+
 func grokChatRowKind(root gjson.Result) string {
 	switch kind := strings.TrimSpace(root.Get("type").Str); kind {
 	case "system", "user", "reasoning", "backend_tool_call", "assistant", "tool_result":
@@ -668,6 +849,10 @@ func grokUserContent(content gjson.Result) string {
 	default:
 		return ""
 	}
+	return grokNormalizeUserText(text)
+}
+
+func grokNormalizeUserText(text string) string {
 	text = strings.TrimSpace(text)
 	if text == "" {
 		return ""

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -102,6 +102,7 @@ func ParseGrokSummary(
 		return ParseResult{}, timestampErr
 	}
 	enrichGrokMessageTimestamps(messages, timestampAnchors)
+	enrichGrokToolResultEvents(messages, timestampAnchors)
 
 	firstPrompt := ""
 	for _, msg := range messages {
@@ -505,7 +506,7 @@ func parseGrokChatHistory(path string) ([]ParsedMessage, int, error) {
 			}
 			messages = append(messages, ParsedMessage{
 				Ordinal:       ordinal,
-				Role:          RoleTool,
+				Role:          RoleUser,
 				ContentLength: contentLen,
 				ToolResults: []ParsedToolResult{{
 					ToolUseID:     toolCallID,
@@ -532,6 +533,7 @@ type grokTimestampAnchor struct {
 	timestamp    time.Time
 	toolCallIDs  []string
 	toolResultID string
+	toolStatus   string
 }
 
 type grokTimestampAnchorBuilder struct {
@@ -634,10 +636,13 @@ func parseGrokUpdateTimestampAnchors(
 			}
 			builder.flush()
 			if id := strings.TrimSpace(update.Get("toolCallId").Str); id != "" {
+				if status == "failed" {
+					status = "errored"
+				}
 				builder.anchors = append(builder.anchors, grokTimestampAnchor{
-					role:         RoleTool,
 					timestamp:    timestamp,
 					toolResultID: id,
+					toolStatus:   status,
 				})
 			}
 
@@ -662,6 +667,54 @@ func enrichGrokMessageTimestamps(
 			anchorIndex = j + 1
 			break
 		}
+	}
+}
+
+func enrichGrokToolResultEvents(
+	messages []ParsedMessage, anchors []grokTimestampAnchor,
+) {
+	calls := make(map[string]*ParsedToolCall)
+	results := make(map[string]string)
+	for i := range messages {
+		for j := range messages[i].ToolCalls {
+			call := &messages[i].ToolCalls[j]
+			if id := strings.TrimSpace(call.ToolUseID); id != "" {
+				calls[id] = call
+			}
+		}
+		for _, result := range messages[i].ToolResults {
+			if id := strings.TrimSpace(result.ToolUseID); id != "" {
+				results[id] = DecodeContent(result.ContentRaw)
+			}
+		}
+	}
+	for _, anchor := range anchors {
+		for _, id := range anchor.toolCallIDs {
+			call := calls[id]
+			if call == nil {
+				continue
+			}
+			call.ResultEvents = append(call.ResultEvents, ParsedToolResultEvent{
+				ToolUseID: id,
+				Source:    "tool_execution",
+				Status:    "started",
+				Timestamp: anchor.timestamp,
+			})
+		}
+		if anchor.toolResultID == "" {
+			continue
+		}
+		call := calls[anchor.toolResultID]
+		if call == nil {
+			continue
+		}
+		call.ResultEvents = append(call.ResultEvents, ParsedToolResultEvent{
+			ToolUseID: anchor.toolResultID,
+			Source:    "tool_execution",
+			Status:    anchor.toolStatus,
+			Content:   results[anchor.toolResultID],
+			Timestamp: anchor.timestamp,
+		})
 	}
 }
 

--- a/internal/parser/grok_provider.go
+++ b/internal/parser/grok_provider.go
@@ -246,6 +246,7 @@ func grokProviderCapabilities() Capabilities {
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			SessionName:          CapabilitySupported,
+			ToolResultEvents:     CapabilitySupported,
 			TerminationStatus:    CapabilityNotApplicable,
 			MalformedLineCount:   CapabilityNotApplicable,
 			AggregateUsageEvents: CapabilitySupported,

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -888,8 +888,9 @@ func TestGrokProviderUpdateTimestampsFollowToolBoundaries(t *testing.T) {
 		filepath.Join(sessionDir, "chat_history.jsonl"),
 		strings.Join([]string{
 			`{"type":"user","content":"inspect the sample"}`,
-			`{"type":"assistant","content":"","tool_calls":[{"id":"call-sample","name":"read_file","arguments":"{\"target_file\":\"sample.txt\"}"}]}`,
+			`{"type":"assistant","content":"","tool_calls":[{"id":"call-sample","name":"read_file","arguments":"{\"target_file\":\"sample.txt\"}"},{"id":"call-reference","name":"read_file","arguments":"{\"target_file\":\"reference.txt\"}"}]}`,
 			`{"type":"tool_result","tool_call_id":"call-sample","content":"example contents"}`,
+			`{"type":"tool_result","tool_call_id":"call-reference","content":"reference contents"}`,
 			`{"type":"assistant","content":"inspection complete"}`,
 		}, "\n")+"\n",
 	)
@@ -899,7 +900,9 @@ func TestGrokProviderUpdateTimestampsFollowToolBoundaries(t *testing.T) {
 		strings.Join([]string{
 			`{"timestamp":1700000000,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"inspect the sample"}}}}`,
 			`{"timestamp":1700000010,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call","toolCallId":"call-sample","title":"read_file"}}}`,
+			`{"timestamp":1700000012,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call","toolCallId":"call-reference","title":"read_file"}}}`,
 			`{"timestamp":1700000020,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-sample","status":"completed"}}}`,
+			`{"timestamp":1700000022,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-reference","status":"completed"}}}`,
 			`{"timestamp":1700000030,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"inspection complete"}}}}`,
 		}, "\n")+"\n",
 	)
@@ -908,11 +911,12 @@ func TestGrokProviderUpdateTimestampsFollowToolBoundaries(t *testing.T) {
 		filepath.Join(sessionDir, "summary.json"), "sample-project", "test-machine",
 	)
 	require.NoError(t, err)
-	require.Len(t, result.Messages, 4)
+	require.Len(t, result.Messages, 5)
 	for i, seconds := range []int64{
 		1_700_000_000,
 		1_700_000_010,
 		1_700_000_020,
+		1_700_000_022,
 		1_700_000_030,
 	} {
 		assert.Equal(t, time.Unix(seconds, 0).UTC(), result.Messages[i].Timestamp)
@@ -958,6 +962,56 @@ func TestGrokProviderUpdateTimestampsRejectMismatchedToolIDs(t *testing.T) {
 	assert.Equal(
 		t, time.Unix(1_700_000_010, 0).UTC(), result.Messages[3].Timestamp,
 	)
+}
+
+func TestGrokProviderUpdateTimestampsSeparateParallelBackendTools(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "workspace-key", "session-parallel-tools")
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "summary.json"), `{
+		"info":{"id":"session-parallel-tools","cwd":"/workspace/sample-project"},
+		"session_summary":"parallel tool conversation",
+		"created_at":"2023-11-14T22:13:20Z",
+		"updated_at":"2023-11-14T22:15:20Z"
+	}`)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(sessionDir, "chat_history.jsonl"),
+		strings.Join([]string{
+			`{"type":"user","content":"compare two examples"}`,
+			`{"type":"backend_tool_call","kind":{"tool_type":"web_search","id":"search-first","status":"completed","action":{"type":"search","query":"first example","sources":[]}}}`,
+			`{"type":"backend_tool_call","kind":{"tool_type":"web_search","id":"search-second","status":"completed","action":{"type":"search","query":"second example","sources":[]}}}`,
+			`{"type":"assistant","content":"comparison complete"}`,
+		}, "\n")+"\n",
+	)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(sessionDir, "updates.jsonl"),
+		strings.Join([]string{
+			`{"timestamp":1700000000,"method":"session/update","params":{"sessionId":"session-parallel-tools","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"compare two examples"}}}}`,
+			`{"timestamp":1700000010,"method":"session/update","params":{"sessionId":"session-parallel-tools","update":{"sessionUpdate":"tool_call","toolCallId":"search-first","title":"Web search:"}}}`,
+			`{"timestamp":1700000012,"method":"session/update","params":{"sessionId":"session-parallel-tools","update":{"sessionUpdate":"tool_call","toolCallId":"search-second","title":"Web search:"}}}`,
+			`{"timestamp":1700000020,"method":"session/update","params":{"sessionId":"session-parallel-tools","update":{"sessionUpdate":"tool_call_update","toolCallId":"search-first","status":"completed"}}}`,
+			`{"timestamp":1700000022,"method":"session/update","params":{"sessionId":"session-parallel-tools","update":{"sessionUpdate":"tool_call_update","toolCallId":"search-second","status":"completed"}}}`,
+			`{"timestamp":1700000030,"method":"session/update","params":{"sessionId":"session-parallel-tools","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"comparison complete"}}}}`,
+		}, "\n")+"\n",
+	)
+
+	result, err := ParseGrokSummary(
+		filepath.Join(sessionDir, "summary.json"), "sample-project", "test-machine",
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 4)
+	assert.Equal(t, []time.Time{
+		time.Unix(1_700_000_000, 0).UTC(),
+		time.Unix(1_700_000_010, 0).UTC(),
+		time.Unix(1_700_000_012, 0).UTC(),
+		time.Unix(1_700_000_030, 0).UTC(),
+	}, []time.Time{
+		result.Messages[0].Timestamp,
+		result.Messages[1].Timestamp,
+		result.Messages[2].Timestamp,
+		result.Messages[3].Timestamp,
+	})
 }
 
 func TestGrokProviderUnwrapsOpenAIStyleToolArguments(t *testing.T) {

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -919,6 +919,47 @@ func TestGrokProviderUpdateTimestampsFollowToolBoundaries(t *testing.T) {
 	}
 }
 
+func TestGrokProviderUpdateTimestampsRejectMismatchedToolIDs(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "workspace-key", "session-tool-mismatch")
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "summary.json"), `{
+		"info":{"id":"session-tool-mismatch","cwd":"/workspace/sample-project"},
+		"session_summary":"tool conversation",
+		"created_at":"2023-11-14T22:13:20Z",
+		"updated_at":"2023-11-14T22:15:20Z"
+	}`)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(sessionDir, "chat_history.jsonl"),
+		strings.Join([]string{
+			`{"type":"user","content":"inspect the sample"}`,
+			`{"type":"assistant","content":"","tool_calls":[{"id":"call-missing","name":"read_file","arguments":"{\"target_file\":\"missing.txt\"}"}]}`,
+			`{"type":"tool_result","tool_call_id":"call-missing","content":"missing result"}`,
+			`{"type":"assistant","content":"","tool_calls":[{"id":"call-current","name":"read_file","arguments":"{\"target_file\":\"current.txt\"}"}]}`,
+			`{"type":"tool_result","tool_call_id":"call-current","content":"current result"}`,
+		}, "\n")+"\n",
+	)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(sessionDir, "updates.jsonl"),
+		strings.Join([]string{
+			`{"timestamp":1700000000,"method":"session/update","params":{"sessionId":"session-tool-mismatch","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"inspect the sample"}}}}`,
+			`{"timestamp":1700000010,"method":"session/update","params":{"sessionId":"session-tool-mismatch","update":{"sessionUpdate":"tool_call","toolCallId":"call-current","title":"read_file"}}}`,
+			`{"timestamp":1700000020,"method":"session/update","params":{"sessionId":"session-tool-mismatch","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-current","status":"completed"}}}`,
+		}, "\n")+"\n",
+	)
+
+	result, err := ParseGrokSummary(
+		filepath.Join(sessionDir, "summary.json"), "sample-project", "test-machine",
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 5)
+	assert.True(t, result.Messages[1].Timestamp.IsZero())
+	assert.Equal(
+		t, time.Unix(1_700_000_010, 0).UTC(), result.Messages[3].Timestamp,
+	)
+}
+
 func TestGrokProviderUnwrapsOpenAIStyleToolArguments(t *testing.T) {
 	// OpenAI-style tool calls nest name/arguments under "function" and encode
 	// arguments as a JSON string. InputJSON must be the decoded object so

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -814,7 +814,7 @@ func TestGrokProviderParsesChatHistoryTranscript(t *testing.T) {
 	assert.JSONEq(t, `{"target_file":"SKILL.md"}`, result.Messages[1].ToolCalls[0].InputJSON)
 	assert.Equal(t, "grok-4.5", result.Messages[1].Model)
 
-	assert.Equal(t, RoleUser, result.Messages[2].Role)
+	assert.Equal(t, RoleTool, result.Messages[2].Role)
 	require.Len(t, result.Messages[2].ToolResults, 1)
 	assert.Equal(t, "call-1", result.Messages[2].ToolResults[0].ToolUseID)
 	assert.Equal(t, 10, result.Messages[2].ToolResults[0].ContentLength)

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -814,7 +814,7 @@ func TestGrokProviderParsesChatHistoryTranscript(t *testing.T) {
 	assert.JSONEq(t, `{"target_file":"SKILL.md"}`, result.Messages[1].ToolCalls[0].InputJSON)
 	assert.Equal(t, "grok-4.5", result.Messages[1].Model)
 
-	assert.Equal(t, RoleTool, result.Messages[2].Role)
+	assert.Equal(t, RoleUser, result.Messages[2].Role)
 	require.Len(t, result.Messages[2].ToolResults, 1)
 	assert.Equal(t, "call-1", result.Messages[2].ToolResults[0].ToolUseID)
 	assert.Equal(t, 10, result.Messages[2].ToolResults[0].ContentLength)
@@ -902,7 +902,7 @@ func TestGrokProviderUpdateTimestampsFollowToolBoundaries(t *testing.T) {
 			`{"timestamp":1700000010,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call","toolCallId":"call-sample","title":"read_file"}}}`,
 			`{"timestamp":1700000012,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call","toolCallId":"call-reference","title":"read_file"}}}`,
 			`{"timestamp":1700000020,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-sample","status":"completed"}}}`,
-			`{"timestamp":1700000022,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-reference","status":"completed"}}}`,
+			`{"timestamp":1700000022,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-reference","status":"failed"}}}`,
 			`{"timestamp":1700000030,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"inspection complete"}}}}`,
 		}, "\n")+"\n",
 	)
@@ -912,14 +912,24 @@ func TestGrokProviderUpdateTimestampsFollowToolBoundaries(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Messages, 5)
-	for i, seconds := range []int64{
-		1_700_000_000,
-		1_700_000_010,
-		1_700_000_020,
-		1_700_000_022,
-		1_700_000_030,
+	assert.Equal(t, time.Unix(1_700_000_000, 0).UTC(), result.Messages[0].Timestamp)
+	assert.Equal(t, time.Unix(1_700_000_010, 0).UTC(), result.Messages[1].Timestamp)
+	assert.True(t, result.Messages[2].Timestamp.IsZero())
+	assert.True(t, result.Messages[3].Timestamp.IsZero())
+	assert.Equal(t, time.Unix(1_700_000_030, 0).UTC(), result.Messages[4].Timestamp)
+	require.Len(t, result.Messages[1].ToolCalls, 2)
+	for i, want := range []struct {
+		started, completed int64
+		status             string
+	}{
+		{1_700_000_010, 1_700_000_020, "completed"},
+		{1_700_000_012, 1_700_000_022, "errored"},
 	} {
-		assert.Equal(t, time.Unix(seconds, 0).UTC(), result.Messages[i].Timestamp)
+		require.Len(t, result.Messages[1].ToolCalls[i].ResultEvents, 2)
+		assert.Equal(t, "started", result.Messages[1].ToolCalls[i].ResultEvents[0].Status)
+		assert.Equal(t, time.Unix(want.started, 0).UTC(), result.Messages[1].ToolCalls[i].ResultEvents[0].Timestamp)
+		assert.Equal(t, want.status, result.Messages[1].ToolCalls[i].ResultEvents[1].Status)
+		assert.Equal(t, time.Unix(want.completed, 0).UTC(), result.Messages[1].ToolCalls[i].ResultEvents[1].Timestamp)
 	}
 }
 

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -823,6 +824,99 @@ func TestGrokProviderParsesChatHistoryTranscript(t *testing.T) {
 
 	assert.Equal(t, RoleUser, result.Messages[4].Role)
 	assert.Equal(t, "fix the issues", result.Messages[4].Content)
+}
+
+func TestGrokProviderEnrichesTranscriptWithUpdateTimestamps(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "workspace-key", "session-timing")
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "summary.json"), `{
+		"info":{"id":"session-timing","cwd":"/workspace/sample-project"},
+		"session_summary":"sample conversation",
+		"created_at":"2023-11-14T22:13:20Z",
+		"updated_at":"2023-11-14T22:15:20Z"
+	}`)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(sessionDir, "chat_history.jsonl"),
+		strings.Join([]string{
+			`{"type":"user","content":"first request"}`,
+			`{"type":"assistant","content":"first response"}`,
+			`{"type":"user","content":"follow-up request"}`,
+			`{"type":"assistant","content":"second response"}`,
+		}, "\n")+"\n",
+	)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(sessionDir, "updates.jsonl"),
+		strings.Join([]string{
+			`{"timestamp":1700000000,"method":"session/update","params":{"sessionId":"session-timing","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"first request"}}}}`,
+			`{"timestamp":1700000010,"method":"session/update","params":{"sessionId":"session-timing","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"first response"}}}}`,
+			`{"timestamp":1700000060,"method":"session/update","params":{"sessionId":"session-timing","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"follow-up request"}}}}`,
+			`{"timestamp":1700000075,"method":"session/update","params":{"sessionId":"session-timing","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"second response"}}}}`,
+		}, "\n")+"\n",
+	)
+
+	result, err := ParseGrokSummary(
+		filepath.Join(sessionDir, "summary.json"), "sample-project", "test-machine",
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 4)
+	assert.Equal(t, []time.Time{
+		time.Unix(1_700_000_000, 0).UTC(),
+		time.Unix(1_700_000_010, 0).UTC(),
+		time.Unix(1_700_000_060, 0).UTC(),
+		time.Unix(1_700_000_075, 0).UTC(),
+	}, []time.Time{
+		result.Messages[0].Timestamp,
+		result.Messages[1].Timestamp,
+		result.Messages[2].Timestamp,
+		result.Messages[3].Timestamp,
+	})
+}
+
+func TestGrokProviderUpdateTimestampsFollowToolBoundaries(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "workspace-key", "session-tools")
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "summary.json"), `{
+		"info":{"id":"session-tools","cwd":"/workspace/sample-project"},
+		"session_summary":"tool conversation",
+		"created_at":"2023-11-14T22:13:20Z",
+		"updated_at":"2023-11-14T22:15:20Z"
+	}`)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(sessionDir, "chat_history.jsonl"),
+		strings.Join([]string{
+			`{"type":"user","content":"inspect the sample"}`,
+			`{"type":"assistant","content":"","tool_calls":[{"id":"call-sample","name":"read_file","arguments":"{\"target_file\":\"sample.txt\"}"}]}`,
+			`{"type":"tool_result","tool_call_id":"call-sample","content":"example contents"}`,
+			`{"type":"assistant","content":"inspection complete"}`,
+		}, "\n")+"\n",
+	)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(sessionDir, "updates.jsonl"),
+		strings.Join([]string{
+			`{"timestamp":1700000000,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"inspect the sample"}}}}`,
+			`{"timestamp":1700000010,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call","toolCallId":"call-sample","title":"read_file"}}}`,
+			`{"timestamp":1700000020,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-sample","status":"completed"}}}`,
+			`{"timestamp":1700000030,"method":"session/update","params":{"sessionId":"session-tools","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"inspection complete"}}}}`,
+		}, "\n")+"\n",
+	)
+
+	result, err := ParseGrokSummary(
+		filepath.Join(sessionDir, "summary.json"), "sample-project", "test-machine",
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 4)
+	for i, seconds := range []int64{
+		1_700_000_000,
+		1_700_000_010,
+		1_700_000_020,
+		1_700_000_030,
+	} {
+		assert.Equal(t, time.Unix(seconds, 0).UTC(), result.Messages[i].Timestamp)
+	}
 }
 
 func TestGrokProviderUnwrapsOpenAIStyleToolArguments(t *testing.T) {

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -396,6 +396,8 @@ func activityReportProjectLabels(sessions []activity.SessionMeta) []string {
 // that began before the range but has messages inside it is not dropped,
 // matching SQLite and DuckDB. COALESCE short-circuits, so the correlated
 // MAX subquery runs only for the rare sessions missing an ended_at.
+// A terminal tool event can outlive ended_at metadata, so it independently
+// keeps the session eligible when it reaches the report range.
 func (s *Store) activityReportSessions(
 	ctx context.Context, f db.AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
 ) ([]activity.SessionMeta, []string, error) {
@@ -418,11 +420,18 @@ func (s *Store) activityReportSessions(
 		COALESCE(s.is_automated, false) AS is_automated
 	FROM sessions s
 	WHERE ` + where + `
-		AND COALESCE(s.ended_at,
-			(SELECT MAX(m.timestamp) FROM messages m
-				WHERE m.session_id = s.id AND m.timestamp IS NOT NULL),
-			s.started_at, s.created_at) >= ` +
+		AND (COALESCE(s.ended_at,
+				(SELECT MAX(m.timestamp) FROM messages m
+					WHERE m.session_id = s.id AND m.timestamp IS NOT NULL),
+				s.started_at, s.created_at) >= ` +
 		lower + `::timestamptz
+			OR EXISTS (
+				SELECT 1 FROM tool_result_events tre
+				WHERE tre.session_id = s.id
+					AND tre.source = 'tool_execution'
+					AND tre.status IN ('completed', 'errored')
+					AND tre.timestamp >= ` + lower + `::timestamptz
+			))
 		AND COALESCE(s.started_at, s.created_at) < ` +
 		upper + `::timestamptz`
 

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -470,15 +470,42 @@ func (s *Store) activityReportCandidateSource(
 		lower := q.RangeStart.Add(
 			-time.Duration(q.GapCapSeconds) * time.Second,
 		)
-		tailQuery := `WITH terminal_events AS (
-			SELECT tre.session_id, tre.call_index, tre.event_index, tre.timestamp
+		terminalQuery := `WITH terminal_events AS (
+			SELECT tre.session_id, tre.tool_call_message_ordinal AS ordinal,
+				tre.call_index, tre.event_index, tre.timestamp
 			FROM tool_result_events tre
 			WHERE tre.session_id = ANY($1)
 				AND tre.source = 'tool_execution'
 				AND tre.status IN ('completed', 'errored')
 				AND tre.timestamp IS NOT NULL
+				AND tre.timestamp >= $2
 		), terminal_sessions AS (
 			SELECT DISTINCT session_id FROM terminal_events
+		), ordered_terminal AS (
+			SELECT te.*,
+				LEAD(te.ordinal) OVER terminal_order AS next_terminal_ordinal,
+				LEAD(te.timestamp) OVER terminal_order AS next_terminal_timestamp
+			FROM terminal_events te
+			WINDOW terminal_order AS (
+				PARTITION BY te.session_id
+				ORDER BY te.timestamp, te.call_index, te.event_index
+			)
+		), terminal_with_message AS (
+			SELECT ot.*, next_message.ordinal AS next_message_ordinal,
+				next_message.timestamp AS next_message_timestamp,
+				next_message.role AS next_message_role,
+				next_message.model AS next_message_model
+			FROM ordered_terminal ot
+			LEFT JOIN LATERAL (
+				SELECT next.ordinal, next.timestamp, next.role, next.model
+				FROM messages next
+				WHERE next.session_id = ot.session_id
+					AND next.ordinal > ot.ordinal
+					AND next.timestamp IS NOT NULL
+					AND next.timestamp > ot.timestamp
+				ORDER BY next.ordinal
+				LIMIT 1
+			) next_message ON TRUE
 		), last_messages AS (
 			SELECT latest.session_id, latest.ordinal, latest.timestamp
 			FROM terminal_sessions ts
@@ -490,46 +517,77 @@ func (s *Store) activityReportCandidateSource(
 				ORDER BY m.ordinal DESC
 				LIMIT 1
 			) latest ON TRUE
-		), tail_events AS (
-			SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
-				0 AS call_index, 0 AS event_index, lm.timestamp
-			FROM last_messages lm
-			UNION ALL
-			SELECT lm.session_id, lm.ordinal, 1,
-				te.call_index, te.event_index, te.timestamp
+		), first_tail_events AS (
+			SELECT lm.session_id, lm.ordinal, lm.timestamp,
+				te.call_index, te.event_index, te.timestamp AS terminal_timestamp,
+				ROW_NUMBER() OVER (
+					PARTITION BY lm.session_id
+					ORDER BY te.timestamp, te.call_index, te.event_index
+				) AS row_num
 			FROM last_messages lm
 			JOIN terminal_events te ON te.session_id = lm.session_id
 			WHERE te.timestamp > lm.timestamp
-		), ordered_tail AS (
-			SELECT e.*,
-				LEAD(e.ordinal) OVER tail_order AS successor_ordinal,
-				LEAD(e.timestamp) OVER tail_order AS successor_timestamp
-			FROM tail_events e
-			WINDOW tail_order AS (
-				PARTITION BY e.session_id
-				ORDER BY e.timestamp, e.event_kind,
-					e.call_index, e.event_index
-			)
+		), candidates AS (
+			SELECT twm.session_id, twm.ordinal AS start_ordinal,
+				CASE
+					WHEN twm.next_terminal_timestamp IS NOT NULL AND
+						(twm.next_message_timestamp IS NULL OR
+						 twm.next_terminal_timestamp < twm.next_message_timestamp)
+					THEN twm.next_terminal_ordinal
+					ELSE twm.next_message_ordinal
+				END AS end_ordinal,
+				twm.timestamp AS start_timestamp,
+				CASE
+					WHEN twm.next_terminal_timestamp IS NOT NULL AND
+						(twm.next_message_timestamp IS NULL OR
+						 twm.next_terminal_timestamp < twm.next_message_timestamp)
+					THEN twm.next_terminal_timestamp
+					ELSE twm.next_message_timestamp
+				END AS end_timestamp,
+				CASE
+					WHEN twm.next_terminal_timestamp IS NOT NULL AND
+						(twm.next_message_timestamp IS NULL OR
+						 twm.next_terminal_timestamp < twm.next_message_timestamp)
+					THEN 'tool'
+					ELSE twm.next_message_role
+				END AS closing_role,
+				CASE
+					WHEN twm.next_terminal_timestamp IS NOT NULL AND
+						(twm.next_message_timestamp IS NULL OR
+						 twm.next_terminal_timestamp < twm.next_message_timestamp)
+					THEN ''
+					ELSE twm.next_message_model
+				END AS closing_model,
+				twm.call_index, twm.event_index
+			FROM terminal_with_message twm
+
+			UNION ALL
+
+			SELECT fte.session_id, fte.ordinal, fte.ordinal,
+				fte.timestamp, fte.terminal_timestamp, 'tool', '',
+				fte.call_index, fte.event_index
+			FROM first_tail_events fte
+			WHERE fte.row_num = 1
 		)
-		SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
-			tail.timestamp, tail.successor_timestamp,
-			'tool', '',
+		SELECT candidate.session_id, candidate.start_ordinal,
+			candidate.end_ordinal, candidate.start_timestamp,
+			candidate.end_timestamp, candidate.closing_role,
+			candidate.closing_model,
 			COALESCE((
 				SELECT prior.model
 				FROM messages prior
-				WHERE prior.session_id = tail.session_id
-					AND prior.ordinal <= tail.ordinal
+				WHERE prior.session_id = candidate.session_id
+					AND prior.ordinal <= candidate.start_ordinal
 					AND prior.role = 'assistant'
 					AND prior.model != ''
 				ORDER BY prior.ordinal DESC
 				LIMIT 1
 			), 'unknown')
-		FROM ordered_tail tail
-		WHERE tail.successor_timestamp IS NOT NULL
-			AND tail.timestamp >= $2
-			AND tail.timestamp < $3
-		ORDER BY tail.timestamp, tail.session_id, tail.ordinal,
-			tail.event_kind, tail.call_index, tail.event_index`
+		FROM candidates candidate
+		WHERE candidate.end_timestamp IS NOT NULL
+			AND candidate.start_timestamp < $3
+		ORDER BY candidate.start_timestamp, candidate.session_id,
+			candidate.start_ordinal, candidate.call_index, candidate.event_index`
 		scanCandidate := func(
 			row interface{ Scan(dest ...any) error },
 		) (activity.IntervalCandidate, error) {
@@ -548,26 +606,26 @@ func (s *Store) activityReportCandidateSource(
 			return candidate, nil
 		}
 
-		tailRows, err := s.pg.QueryContext(
-			ctx, tailQuery, ids, lower, q.EffectiveEnd,
+		terminalRows, err := s.pg.QueryContext(
+			ctx, terminalQuery, ids, lower, q.EffectiveEnd,
 		)
 		if err != nil {
-			return fmt.Errorf("querying pg activity report tail candidates: %w", err)
+			return fmt.Errorf("querying pg activity report terminal candidates: %w", err)
 		}
-		var tail []activity.IntervalCandidate
-		for tailRows.Next() {
-			candidate, scanErr := scanCandidate(tailRows)
+		var terminal []activity.IntervalCandidate
+		for terminalRows.Next() {
+			candidate, scanErr := scanCandidate(terminalRows)
 			if scanErr != nil {
-				tailRows.Close()
+				terminalRows.Close()
 				return scanErr
 			}
-			tail = append(tail, candidate)
+			terminal = append(terminal, candidate)
 		}
-		if err := tailRows.Err(); err != nil {
-			tailRows.Close()
+		if err := terminalRows.Err(); err != nil {
+			terminalRows.Close()
 			return err
 		}
-		if err := tailRows.Close(); err != nil {
+		if err := terminalRows.Close(); err != nil {
 			return err
 		}
 
@@ -638,7 +696,7 @@ func (s *Store) activityReportCandidateSource(
 			}
 			return rows.Err()
 		}
-		return activity.MergeCandidateSlice(tail, messageSource)(ctx, yield)
+		return activity.MergeCandidateSlice(terminal, messageSource)(ctx, yield)
 	}
 }
 

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -470,26 +470,36 @@ func (s *Store) activityReportCandidateSource(
 		lower := q.RangeStart.Add(
 			-time.Duration(q.GapCapSeconds) * time.Second,
 		)
-		query := `WITH last_messages AS (
-			SELECT DISTINCT ON (m.session_id)
-				m.session_id, m.ordinal, m.timestamp
-			FROM messages m
-			WHERE m.session_id = ANY($1)
-				AND m.timestamp IS NOT NULL
-			ORDER BY m.session_id, m.ordinal DESC
+		tailQuery := `WITH terminal_events AS (
+			SELECT tre.session_id, tre.call_index, tre.event_index, tre.timestamp
+			FROM tool_result_events tre
+			WHERE tre.session_id = ANY($1)
+				AND tre.source = 'tool_execution'
+				AND tre.status IN ('completed', 'errored')
+				AND tre.timestamp IS NOT NULL
+		), terminal_sessions AS (
+			SELECT DISTINCT session_id FROM terminal_events
+		), last_messages AS (
+			SELECT latest.session_id, latest.ordinal, latest.timestamp
+			FROM terminal_sessions ts
+			JOIN LATERAL (
+				SELECT m.session_id, m.ordinal, m.timestamp
+				FROM messages m
+				WHERE m.session_id = ts.session_id
+					AND m.timestamp IS NOT NULL
+				ORDER BY m.ordinal DESC
+				LIMIT 1
+			) latest ON TRUE
 		), tail_events AS (
 			SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
 				0 AS call_index, 0 AS event_index, lm.timestamp
 			FROM last_messages lm
 			UNION ALL
 			SELECT lm.session_id, lm.ordinal, 1,
-				tre.call_index, tre.event_index, tre.timestamp
+				te.call_index, te.event_index, te.timestamp
 			FROM last_messages lm
-			JOIN tool_result_events tre ON tre.session_id = lm.session_id
-			WHERE tre.source = 'tool_execution'
-				AND tre.status IN ('completed', 'errored')
-				AND tre.timestamp IS NOT NULL
-				AND tre.timestamp > lm.timestamp
+			JOIN terminal_events te ON te.session_id = lm.session_id
+			WHERE te.timestamp > lm.timestamp
 		), ordered_tail AS (
 			SELECT e.*,
 				LEAD(e.ordinal) OVER tail_order AS successor_ordinal,
@@ -500,14 +510,75 @@ func (s *Store) activityReportCandidateSource(
 				ORDER BY e.timestamp, e.event_kind,
 					e.call_index, e.event_index
 			)
-		), candidates AS (
-			SELECT
-				m.session_id, m.ordinal AS start_ordinal,
-				successor.ordinal AS end_ordinal,
-				m.timestamp AS start_timestamp,
-				successor.timestamp AS end_timestamp,
-				successor.role AS closing_role,
-				successor.model AS closing_model,
+		)
+		SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
+			tail.timestamp, tail.successor_timestamp,
+			'tool', '',
+			COALESCE((
+				SELECT prior.model
+				FROM messages prior
+				WHERE prior.session_id = tail.session_id
+					AND prior.ordinal <= tail.ordinal
+					AND prior.role = 'assistant'
+					AND prior.model != ''
+				ORDER BY prior.ordinal DESC
+				LIMIT 1
+			), 'unknown')
+		FROM ordered_tail tail
+		WHERE tail.successor_timestamp IS NOT NULL
+			AND tail.timestamp >= $2
+			AND tail.timestamp < $3
+		ORDER BY tail.timestamp, tail.session_id, tail.ordinal,
+			tail.event_kind, tail.call_index, tail.event_index`
+		scanCandidate := func(
+			row interface{ Scan(dest ...any) error },
+		) (activity.IntervalCandidate, error) {
+			var candidate activity.IntervalCandidate
+			if err := row.Scan(
+				&candidate.SessionID, &candidate.StartOrdinal,
+				&candidate.EndOrdinal, &candidate.Start, &candidate.End,
+				&candidate.ClosingRole, &candidate.ClosingModel,
+				&candidate.PriorModel,
+			); err != nil {
+				return candidate, fmt.Errorf(
+					"scanning pg activity report candidate: %w", err)
+			}
+			candidate.Start = candidate.Start.UTC()
+			candidate.End = candidate.End.UTC()
+			return candidate, nil
+		}
+
+		tailRows, err := s.pg.QueryContext(
+			ctx, tailQuery, ids, lower, q.EffectiveEnd,
+		)
+		if err != nil {
+			return fmt.Errorf("querying pg activity report tail candidates: %w", err)
+		}
+		var tail []activity.IntervalCandidate
+		for tailRows.Next() {
+			candidate, scanErr := scanCandidate(tailRows)
+			if scanErr != nil {
+				tailRows.Close()
+				return scanErr
+			}
+			tail = append(tail, candidate)
+		}
+		if err := tailRows.Err(); err != nil {
+			tailRows.Close()
+			return err
+		}
+		if err := tailRows.Close(); err != nil {
+			return err
+		}
+
+		messageSource := func(
+			ctx context.Context,
+			yield func(activity.IntervalCandidate) error,
+		) error {
+			query := `SELECT
+				m.session_id, m.ordinal, successor.ordinal,
+				m.timestamp, successor.timestamp,
+				successor.role, successor.model,
 				COALESCE((
 					SELECT prior.model
 					FROM messages prior
@@ -527,8 +598,7 @@ func (s *Store) activityReportCandidateSource(
 						)
 					ORDER BY prior.ordinal DESC
 					LIMIT 1
-				), 'unknown') AS prior_model,
-				0 AS event_kind, 0 AS call_index, 0 AS event_index
+				), 'unknown')
 			FROM messages m
 			JOIN messages successor
 				ON successor.session_id = m.session_id
@@ -545,59 +615,30 @@ func (s *Store) activityReportCandidateSource(
 				AND m.timestamp IS NOT NULL
 				AND m.timestamp >= $2
 				AND m.timestamp < $3
-
-			UNION ALL
-
-			SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
-				tail.timestamp, tail.successor_timestamp,
-				'tool', '',
-				COALESCE((
-					SELECT prior.model
-					FROM messages prior
-					WHERE prior.session_id = tail.session_id
-						AND prior.ordinal <= tail.ordinal
-						AND prior.role = 'assistant'
-						AND prior.model != ''
-					ORDER BY prior.ordinal DESC
-					LIMIT 1
-				), 'unknown'),
-				tail.event_kind, tail.call_index, tail.event_index
-			FROM ordered_tail tail
-			WHERE tail.successor_timestamp IS NOT NULL
-		)
-		SELECT session_id, start_ordinal, end_ordinal,
-			start_timestamp, end_timestamp,
-			closing_role, closing_model, prior_model
-		FROM candidates
-		WHERE start_timestamp >= $2
-			AND start_timestamp < $3
-		ORDER BY start_timestamp, session_id, start_ordinal,
-			event_kind, call_index, event_index`
-		rows, err := s.pg.QueryContext(ctx, query, ids, lower, q.EffectiveEnd)
-		if err != nil {
-			return fmt.Errorf("querying pg activity report candidates: %w", err)
+			ORDER BY m.timestamp, m.session_id, m.ordinal`
+			rows, queryErr := s.pg.QueryContext(
+				ctx, query, ids, lower, q.EffectiveEnd,
+			)
+			if queryErr != nil {
+				return fmt.Errorf(
+					"querying pg activity report candidates: %w", queryErr)
+			}
+			defer rows.Close()
+			for rows.Next() {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				candidate, scanErr := scanCandidate(rows)
+				if scanErr != nil {
+					return scanErr
+				}
+				if err := yield(candidate); err != nil {
+					return err
+				}
+			}
+			return rows.Err()
 		}
-		defer rows.Close()
-		for rows.Next() {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			var candidate activity.IntervalCandidate
-			if err := rows.Scan(
-				&candidate.SessionID, &candidate.StartOrdinal,
-				&candidate.EndOrdinal, &candidate.Start, &candidate.End,
-				&candidate.ClosingRole, &candidate.ClosingModel,
-				&candidate.PriorModel,
-			); err != nil {
-				return fmt.Errorf("scanning pg activity report candidate: %w", err)
-			}
-			candidate.Start = candidate.Start.UTC()
-			candidate.End = candidate.End.UTC()
-			if err := yield(candidate); err != nil {
-				return err
-			}
-		}
-		return rows.Err()
+		return activity.MergeCandidateSlice(tail, messageSource)(ctx, yield)
 	}
 }
 

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -470,47 +470,109 @@ func (s *Store) activityReportCandidateSource(
 		lower := q.RangeStart.Add(
 			-time.Duration(q.GapCapSeconds) * time.Second,
 		)
-		query := `SELECT
-			m.session_id, m.ordinal, successor.ordinal,
-			m.timestamp, successor.timestamp,
-			successor.role, successor.model,
-			COALESCE((
-				SELECT prior.model
-				FROM messages prior
-				WHERE prior.session_id = m.session_id
-					AND prior.ordinal <= m.ordinal
-					AND prior.role = 'assistant'
-					AND prior.model != ''
-					AND prior.timestamp IS NOT NULL
-					AND prior.timestamp > (
-						SELECT prior_previous.timestamp
-						FROM messages prior_previous
-						WHERE prior_previous.session_id = prior.session_id
-							AND prior_previous.ordinal < prior.ordinal
-							AND prior_previous.timestamp IS NOT NULL
-						ORDER BY prior_previous.ordinal DESC
-						LIMIT 1
-					)
-				ORDER BY prior.ordinal DESC
-				LIMIT 1
-			), 'unknown')
-		FROM messages m
-		JOIN messages successor
-			ON successor.session_id = m.session_id
-			AND successor.ordinal = (
-				SELECT next.ordinal
-				FROM messages next
-				WHERE next.session_id = m.session_id
-					AND next.ordinal > m.ordinal
-					AND next.timestamp IS NOT NULL
-				ORDER BY next.ordinal
-				LIMIT 1
+		query := `WITH last_messages AS (
+			SELECT DISTINCT ON (m.session_id)
+				m.session_id, m.ordinal, m.timestamp
+			FROM messages m
+			WHERE m.session_id = ANY($1)
+				AND m.timestamp IS NOT NULL
+			ORDER BY m.session_id, m.ordinal DESC
+		), tail_events AS (
+			SELECT lm.session_id, lm.ordinal, 0 AS event_kind,
+				0 AS call_index, 0 AS event_index, lm.timestamp
+			FROM last_messages lm
+			UNION ALL
+			SELECT lm.session_id, lm.ordinal, 1,
+				tre.call_index, tre.event_index, tre.timestamp
+			FROM last_messages lm
+			JOIN tool_result_events tre ON tre.session_id = lm.session_id
+			WHERE tre.source = 'tool_execution'
+				AND tre.status IN ('completed', 'errored')
+				AND tre.timestamp IS NOT NULL
+				AND tre.timestamp > lm.timestamp
+		), ordered_tail AS (
+			SELECT e.*,
+				LEAD(e.ordinal) OVER tail_order AS successor_ordinal,
+				LEAD(e.timestamp) OVER tail_order AS successor_timestamp
+			FROM tail_events e
+			WINDOW tail_order AS (
+				PARTITION BY e.session_id
+				ORDER BY e.timestamp, e.event_kind,
+					e.call_index, e.event_index
 			)
-		WHERE m.session_id = ANY($1)
-			AND m.timestamp IS NOT NULL
-			AND m.timestamp >= $2
-			AND m.timestamp < $3
-		ORDER BY m.timestamp, m.session_id, m.ordinal`
+		), candidates AS (
+			SELECT
+				m.session_id, m.ordinal AS start_ordinal,
+				successor.ordinal AS end_ordinal,
+				m.timestamp AS start_timestamp,
+				successor.timestamp AS end_timestamp,
+				successor.role AS closing_role,
+				successor.model AS closing_model,
+				COALESCE((
+					SELECT prior.model
+					FROM messages prior
+					WHERE prior.session_id = m.session_id
+						AND prior.ordinal <= m.ordinal
+						AND prior.role = 'assistant'
+						AND prior.model != ''
+						AND prior.timestamp IS NOT NULL
+						AND prior.timestamp > (
+							SELECT prior_previous.timestamp
+							FROM messages prior_previous
+							WHERE prior_previous.session_id = prior.session_id
+								AND prior_previous.ordinal < prior.ordinal
+								AND prior_previous.timestamp IS NOT NULL
+							ORDER BY prior_previous.ordinal DESC
+							LIMIT 1
+						)
+					ORDER BY prior.ordinal DESC
+					LIMIT 1
+				), 'unknown') AS prior_model,
+				0 AS event_kind, 0 AS call_index, 0 AS event_index
+			FROM messages m
+			JOIN messages successor
+				ON successor.session_id = m.session_id
+				AND successor.ordinal = (
+					SELECT next.ordinal
+					FROM messages next
+					WHERE next.session_id = m.session_id
+						AND next.ordinal > m.ordinal
+						AND next.timestamp IS NOT NULL
+					ORDER BY next.ordinal
+					LIMIT 1
+				)
+			WHERE m.session_id = ANY($1)
+				AND m.timestamp IS NOT NULL
+				AND m.timestamp >= $2
+				AND m.timestamp < $3
+
+			UNION ALL
+
+			SELECT tail.session_id, tail.ordinal, tail.successor_ordinal,
+				tail.timestamp, tail.successor_timestamp,
+				'tool', '',
+				COALESCE((
+					SELECT prior.model
+					FROM messages prior
+					WHERE prior.session_id = tail.session_id
+						AND prior.ordinal <= tail.ordinal
+						AND prior.role = 'assistant'
+						AND prior.model != ''
+					ORDER BY prior.ordinal DESC
+					LIMIT 1
+				), 'unknown'),
+				tail.event_kind, tail.call_index, tail.event_index
+			FROM ordered_tail tail
+			WHERE tail.successor_timestamp IS NOT NULL
+		)
+		SELECT session_id, start_ordinal, end_ordinal,
+			start_timestamp, end_timestamp,
+			closing_role, closing_model, prior_model
+		FROM candidates
+		WHERE start_timestamp >= $2
+			AND start_timestamp < $3
+		ORDER BY start_timestamp, session_id, start_ordinal,
+			event_kind, call_index, event_index`
 		rows, err := s.pg.QueryContext(ctx, query, ids, lower, q.EffectiveEnd)
 		if err != nil {
 			return fmt.Errorf("querying pg activity report candidates: %w", err)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -455,9 +455,79 @@ func TestGrokToolCompletionContributesToActivity(t *testing.T) {
 		context.Background(), "grok:session-tool-completion", 0, 100, true,
 	)
 	require.NoError(t, err)
-	require.Len(t, messages, 3)
-	assert.Equal(t, "tool", messages[2].Role)
-	assert.Equal(t, "2023-11-14T22:14:30Z", messages[2].Timestamp)
+	require.Len(t, messages, 2)
+	require.Len(t, messages[1].ToolCalls, 1)
+	require.Len(t, messages[1].ToolCalls[0].ResultEvents, 2)
+	assert.Equal(t, "started", messages[1].ToolCalls[0].ResultEvents[0].Status)
+	assert.Equal(t, "2023-11-14T22:13:30Z", messages[1].ToolCalls[0].ResultEvents[0].Timestamp)
+	assert.Equal(t, "completed", messages[1].ToolCalls[0].ResultEvents[1].Status)
+	assert.Equal(t, "2023-11-14T22:14:30Z", messages[1].ToolCalls[0].ResultEvents[1].Timestamp)
+
+	query, err := activity.ResolveQuery(activity.QueryInput{
+		Preset: "day", Date: "2023-11-14", Timezone: "UTC",
+	}, time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	report, err := database.GetActivityReport(
+		context.Background(), db.AnalyticsFilter{Timezone: "UTC"}, query,
+	)
+	require.NoError(t, err)
+	require.Len(t, report.BySession, 1)
+	require.NotNil(t, report.BySession[0].AgentMinutes)
+	assert.InDelta(t, 70.0/60.0, *report.BySession[0].AgentMinutes, 1e-9)
+}
+
+func TestGrokBackendToolCompletionContributesToActivity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "workspace-key", "session-backend-tool")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "summary.json"),
+		[]byte(`{
+			"info":{"id":"session-backend-tool","cwd":"/workspace/sample-project"},
+			"session_summary":"backend tool timing",
+			"created_at":"2023-11-14T22:13:20Z",
+			"updated_at":"2023-11-14T22:14:30Z"
+		}`),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "chat_history.jsonl"),
+		[]byte(strings.Join([]string{
+			`{"type":"user","content":"search for an example"}`,
+			`{"type":"backend_tool_call","kind":{"tool_type":"web_search","id":"search-sample","status":"completed","action":{"type":"search","query":"example query","sources":[]}}}`,
+		}, "\n")+"\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "updates.jsonl"),
+		[]byte(strings.Join([]string{
+			`{"timestamp":1700000000,"method":"session/update","params":{"sessionId":"session-backend-tool","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"search for an example"}}}}`,
+			`{"timestamp":1700000010,"method":"session/update","params":{"sessionId":"session-backend-tool","update":{"sessionUpdate":"tool_call","toolCallId":"search-sample","title":"Web search:"}}}`,
+			`{"timestamp":1700000070,"method":"session/update","params":{"sessionId":"session-backend-tool","update":{"sessionUpdate":"tool_call_update","toolCallId":"search-sample","status":"completed"}}}`,
+		}, "\n")+"\n"),
+		0o644,
+	))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentGrok: {root}},
+		Machine:   "test-machine",
+	})
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced)
+
+	messages, err := database.GetMessages(
+		context.Background(), "grok:session-backend-tool", 0, 100, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	require.Len(t, messages[1].ToolCalls, 1)
+	require.Len(t, messages[1].ToolCalls[0].ResultEvents, 2)
+	assert.Equal(t, "started", messages[1].ToolCalls[0].ResultEvents[0].Status)
+	assert.Equal(t, "completed", messages[1].ToolCalls[0].ResultEvents[1].Status)
 
 	query, err := activity.ResolveQuery(activity.QueryInput{
 		Preset: "day", Date: "2023-11-14", Timezone: "UTC",

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"go.kenn.io/agentsview/internal/activity"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/export"
@@ -404,6 +405,71 @@ func TestGrokSummaryCountsSurviveSync(t *testing.T) {
 	assert.Equal(t, 122,
 		exported.Rows[0].ModelUsage.ByModel["grok-4.5-build"].ReasoningTokens,
 	)
+}
+
+func TestGrokToolCompletionContributesToActivity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "workspace-key", "session-tool-completion")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "summary.json"),
+		[]byte(`{
+			"info":{"id":"session-tool-completion","cwd":"/workspace/sample-project"},
+			"session_summary":"tool completion timing",
+			"created_at":"2023-11-14T22:13:20Z",
+			"updated_at":"2023-11-14T22:14:30Z"
+		}`),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "chat_history.jsonl"),
+		[]byte(strings.Join([]string{
+			`{"type":"user","content":"inspect the sample"}`,
+			`{"type":"assistant","content":"","tool_calls":[{"id":"call-sample","name":"read_file","arguments":"{\"target_file\":\"sample.txt\"}"}],"model_id":"grok-test"}`,
+			`{"type":"tool_result","tool_call_id":"call-sample","content":"example contents"}`,
+		}, "\n")+"\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "updates.jsonl"),
+		[]byte(strings.Join([]string{
+			`{"timestamp":1700000000,"method":"session/update","params":{"sessionId":"session-tool-completion","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"inspect the sample"}}}}`,
+			`{"timestamp":1700000010,"method":"session/update","params":{"sessionId":"session-tool-completion","update":{"sessionUpdate":"tool_call","toolCallId":"call-sample","title":"read_file"}}}`,
+			`{"timestamp":1700000070,"method":"session/update","params":{"sessionId":"session-tool-completion","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-sample","status":"completed"}}}`,
+		}, "\n")+"\n"),
+		0o644,
+	))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentGrok: {root}},
+		Machine:   "test-machine",
+	})
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced)
+
+	messages, err := database.GetMessages(
+		context.Background(), "grok:session-tool-completion", 0, 100, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 3)
+	assert.Equal(t, "tool", messages[2].Role)
+	assert.Equal(t, "2023-11-14T22:14:30Z", messages[2].Timestamp)
+
+	query, err := activity.ResolveQuery(activity.QueryInput{
+		Preset: "day", Date: "2023-11-14", Timezone: "UTC",
+	}, time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	report, err := database.GetActivityReport(
+		context.Background(), db.AnalyticsFilter{Timezone: "UTC"}, query,
+	)
+	require.NoError(t, err)
+	require.Len(t, report.BySession, 1)
+	require.NotNil(t, report.BySession[0].AgentMinutes)
+	assert.InDelta(t, 70.0/60.0, *report.BySession[0].AgentMinutes, 1e-9)
 }
 
 type openCodeFamilySQLiteCase struct {


### PR DESCRIPTION
Restores Grok activity timing by enriching chat-history messages from the timestamped authoritative update stream. Matching follows Grok turn boundaries, keeps parallel tool-call starts separate, uses populated tool identifiers as authoritative, and falls back to exact content only when identifiers are unavailable.

Grok tool starts and terminal updates now use the existing tool-result event model. Activity treats terminal completions as sparse timeline anchors: they extend activity after the final transcript message and reset the gap cap before later messages without adding hidden or visible transcript rows, including for backend tools. Same-session overlaps are unioned, and post-range completions remain eligible successors so report-boundary clipping stays correct.

The report keeps transcript pairing on its indexed query path and merges sparse completion candidates afterward, avoiding full-transcript scans for ordinary sessions. The parser data version is bumped to reparse existing archives, and the public Grok session-format evidence is documented. Regression coverage uses only synthetic, provider-shaped fixtures.
