### PR TITLE
perf(usage): serve usage reports from an exact daily rollup cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ BENCH_GATE_TIME ?= 20x
 # against top-level benchmark names, so sub-benchmarks follow their
 # parent; the cheap benchmarks keep the full iteration count because
 # their millisecond-scale samples are what needs the averaging.
-BENCH_GATE_HEAVY ?= GetDailyUsage|SQLiteActivityReport|SyncAllColdArchive|ResyncBulk
+BENCH_GATE_HEAVY ?= GetDailyUsage|UsageRollup|SQLiteActivityReport|SyncAllColdArchive|ResyncBulk
 BENCH_GATE_HEAVY_TIME ?= 5x
 bench-gate: pricing-snapshot ensure-embed-dir
 	CGO_ENABLED=1 go test -tags "fts5" -run '^$$' \

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -610,9 +610,6 @@ func runServe(cfg config.Config, opts serveOptions) {
 type usageCacheBackfiller interface {
 	StartUsageCacheBackfill(context.Context) error
 	WaitUsageCacheBackfill(context.Context) error
-}
-
-type usageCacheBackfillStartObserver interface {
 	SetUsageCacheBackfillStarted(func())
 }
 
@@ -620,42 +617,22 @@ func startDaemonUsageCacheBackfill(
 	ctx context.Context, backfiller usageCacheBackfiller,
 	idleTracker *server.IdleTracker,
 ) {
-	if observed, ok := backfiller.(usageCacheBackfillStartObserver); ok {
-		observed.SetUsageCacheBackfillStarted(func() {
-			done, ok := idleTracker.BeginWork()
-			if !ok {
-				return
+	backfiller.SetUsageCacheBackfillStarted(func() {
+		done, ok := idleTracker.BeginWork()
+		if !ok {
+			return
+		}
+		go func() {
+			defer done()
+			if err := backfiller.WaitUsageCacheBackfill(ctx); err != nil &&
+				ctx.Err() == nil {
+				log.Printf("usage cache backfill: %v", err)
 			}
-			go func() {
-				defer done()
-				if err := backfiller.WaitUsageCacheBackfill(ctx); err != nil &&
-					ctx.Err() == nil {
-					log.Printf("usage cache backfill: %v", err)
-				}
-			}()
-		})
-		if err := backfiller.StartUsageCacheBackfill(ctx); err != nil && ctx.Err() == nil {
-			log.Printf("usage cache backfill: %v", err)
-		}
-		return
+		}()
+	})
+	if err := backfiller.StartUsageCacheBackfill(ctx); err != nil && ctx.Err() == nil {
+		log.Printf("usage cache backfill: %v", err)
 	}
-	done, ok := idleTracker.BeginWork()
-	if !ok {
-		return
-	}
-	if err := backfiller.StartUsageCacheBackfill(ctx); err != nil {
-		done()
-		if ctx.Err() == nil {
-			log.Printf("usage cache backfill: %v", err)
-		}
-		return
-	}
-	go func() {
-		defer done()
-		if err := backfiller.WaitUsageCacheBackfill(ctx); err != nil && ctx.Err() == nil {
-			log.Printf("usage cache backfill: %v", err)
-		}
-	}()
 }
 
 func runDeferredStartupSyncFallback(

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -540,6 +540,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		idleTracker.Touch()
 		go idleTracker.Run(ctx)
 	}
+	startDaemonUsageCacheBackfill(ctx, database, idleTracker)
 	if engine != nil && opts.SkipInitialSync {
 		go func() {
 			timer := time.NewTimer(deferredStartupSyncGracePeriod)
@@ -604,6 +605,57 @@ func runServe(cfg config.Config, opts serveOptions) {
 	if err := waitForServerRuntime(ctx, srv, rt); err != nil {
 		fatal("%v", err)
 	}
+}
+
+type usageCacheBackfiller interface {
+	StartUsageCacheBackfill(context.Context) error
+	WaitUsageCacheBackfill(context.Context) error
+}
+
+type usageCacheBackfillStartObserver interface {
+	SetUsageCacheBackfillStarted(func())
+}
+
+func startDaemonUsageCacheBackfill(
+	ctx context.Context, backfiller usageCacheBackfiller,
+	idleTracker *server.IdleTracker,
+) {
+	if observed, ok := backfiller.(usageCacheBackfillStartObserver); ok {
+		observed.SetUsageCacheBackfillStarted(func() {
+			done, ok := idleTracker.BeginWork()
+			if !ok {
+				return
+			}
+			go func() {
+				defer done()
+				if err := backfiller.WaitUsageCacheBackfill(ctx); err != nil &&
+					ctx.Err() == nil {
+					log.Printf("usage cache backfill: %v", err)
+				}
+			}()
+		})
+		if err := backfiller.StartUsageCacheBackfill(ctx); err != nil && ctx.Err() == nil {
+			log.Printf("usage cache backfill: %v", err)
+		}
+		return
+	}
+	done, ok := idleTracker.BeginWork()
+	if !ok {
+		return
+	}
+	if err := backfiller.StartUsageCacheBackfill(ctx); err != nil {
+		done()
+		if ctx.Err() == nil {
+			log.Printf("usage cache backfill: %v", err)
+		}
+		return
+	}
+	go func() {
+		defer done()
+		if err := backfiller.WaitUsageCacheBackfill(ctx); err != nil && ctx.Err() == nil {
+			log.Printf("usage cache backfill: %v", err)
+		}
+	}()
 }
 
 func runDeferredStartupSyncFallback(

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -39,15 +39,25 @@ type cursorSecretRecorder struct {
 }
 
 type usageCacheBackfillRecorder struct {
-	started chan struct{}
-	release chan struct{}
-	waited  chan struct{}
+	started  chan struct{}
+	release  chan struct{}
+	waited   chan struct{}
+	observer func()
+}
+
+func (recorder *usageCacheBackfillRecorder) SetUsageCacheBackfillStarted(
+	observer func(),
+) {
+	recorder.observer = observer
 }
 
 func (recorder *usageCacheBackfillRecorder) StartUsageCacheBackfill(
 	context.Context,
 ) error {
 	close(recorder.started)
+	if recorder.observer != nil {
+		recorder.observer()
+	}
 	return nil
 }
 

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -38,6 +38,47 @@ type cursorSecretRecorder struct {
 	secret []byte
 }
 
+type usageCacheBackfillRecorder struct {
+	started chan struct{}
+	release chan struct{}
+	waited  chan struct{}
+}
+
+func (recorder *usageCacheBackfillRecorder) StartUsageCacheBackfill(
+	context.Context,
+) error {
+	close(recorder.started)
+	return nil
+}
+
+func (recorder *usageCacheBackfillRecorder) WaitUsageCacheBackfill(
+	context.Context,
+) error {
+	close(recorder.waited)
+	<-recorder.release
+	return nil
+}
+
+func TestServeStartsUsageCacheBackfill(t *testing.T) {
+	recorder := &usageCacheBackfillRecorder{
+		started: make(chan struct{}), release: make(chan struct{}),
+		waited: make(chan struct{}),
+	}
+	idle := server.NewIdleTracker(time.Minute, func() {})
+	startDaemonUsageCacheBackfill(context.Background(), recorder, idle)
+	select {
+	case <-recorder.started:
+	case <-time.After(time.Second):
+		t.Fatal("usage cache backfill did not start")
+	}
+	select {
+	case <-recorder.waited:
+	case <-time.After(time.Second):
+		t.Fatal("usage cache backfill was not joined by tracked work")
+	}
+	close(recorder.release)
+}
+
 func (recorder *cursorSecretRecorder) SetCursorSecret(secret []byte) {
 	recorder.secret = append([]byte(nil), secret...)
 }

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -89,6 +89,27 @@ func TestServeStartsUsageCacheBackfill(t *testing.T) {
 	close(recorder.release)
 }
 
+// Foreground servers and daemons with idle timeout disabled pass a nil
+// tracker; the backfill must still start and join its wait goroutine.
+func TestServeStartsUsageCacheBackfillWithoutIdleTracker(t *testing.T) {
+	recorder := &usageCacheBackfillRecorder{
+		started: make(chan struct{}), release: make(chan struct{}),
+		waited: make(chan struct{}),
+	}
+	startDaemonUsageCacheBackfill(context.Background(), recorder, nil)
+	select {
+	case <-recorder.started:
+	case <-time.After(time.Second):
+		t.Fatal("usage cache backfill did not start")
+	}
+	select {
+	case <-recorder.waited:
+	case <-time.After(time.Second):
+		t.Fatal("usage cache backfill was not awaited without an idle tracker")
+	}
+	close(recorder.release)
+}
+
 func (recorder *cursorSecretRecorder) SetCursorSecret(secret []byte) {
 	recorder.secret = append([]byte(nil), secret...)
 }

--- a/docs/agents/background-work.md
+++ b/docs/agents/background-work.md
@@ -20,3 +20,34 @@ long-running background work. Also read it before investigating memory growth.
 - Observe retention long enough to reproduce the reported growth window. On
   macOS, record `vmmap` physical footprint and dirty memory. Use portable Go
   allocation and heap metrics on Linux and Windows.
+
+## Usage cache backfill
+
+- Start usage-cache backfill only after the writable archive transaction that
+  changed a session has committed. Mutation hooks enqueue session IDs; they
+  never fill while holding the archive writer.
+- Foreground fills are per-session single-flight and detached from request
+  cancellation. Cancelling one waiter must not cancel shared progress.
+- A writable daemon runs one newest-usage-first coverage pass after HTTP
+  readiness. It installs at most 256 sessions per cache transaction and yields
+  between batches. The pass fills normalized facts and daily rollups for the
+  process-local timezone plus up to eight retained recently requested explicit
+  timezones. Installed source and aggregate fingerprints, not a progress
+  cursor, are the authoritative coverage records.
+- Sweep the archive deletion journal before and after the pass and between
+  install batches. Queries also inner-join current archive sessions before
+  ranking, so tombstone processing is hygiene rather than a correctness
+  dependency.
+- Run incremental vacuum between batches only when the cache freelist exceeds
+  4,096 pages, and reclaim at most 256 pages per call.
+- Run `PRAGMA optimize` between substantial batches and after install-heavy
+  foreground fills. Run full `ANALYZE` after generation creation and complete
+  initial backfill, not after every batch.
+- Backfill logs aggregate counts and elapsed time only. Do not log session IDs,
+  projects, paths, prompts, or fact contents.
+- Keep newest-first fact plus process-local-rollup coverage within 30 seconds
+  and complete fact plus process-local-rollup archive coverage within five
+  minutes on the protected production-scale benchmark clone. These are release
+  gates, not reasons to delay daemon readiness. A foreground request for an
+  unbuilt timezone or all-history coverage remains exact and may pay the
+  remaining `fill facts -> build rollups -> read` cold cost.

--- a/docs/agents/background-work.md
+++ b/docs/agents/background-work.md
@@ -28,6 +28,9 @@ long-running background work. Also read it before investigating memory growth.
   never fill while holding the archive writer.
 - Foreground fills are per-session single-flight and detached from request
   cancellation. Cancelling one waiter must not cancel shared progress.
+- Detached fills and rollup builds hold their own cache-generation lease.
+  Retirement cancels their coordinator context and waits for those leases
+  before closing SQLite handles.
 - A writable daemon runs one newest-usage-first coverage pass after HTTP
   readiness. It installs at most 256 sessions per cache transaction and yields
   between batches. The pass fills normalized facts and daily rollups for the

--- a/docs/agents/background-work.md
+++ b/docs/agents/background-work.md
@@ -34,6 +34,10 @@ long-running background work. Also read it before investigating memory growth.
   process-local timezone plus up to eight retained recently requested explicit
   timezones. Installed source and aggregate fingerprints, not a progress
   cursor, are the authoritative coverage records.
+- If a source fingerprint changes during a pass, recapture and restart the
+  snapshot pass at most three times. Already installed current fingerprints
+  make stable batches reusable; never pair facts from the newer source with
+  rollup metadata from the older snapshot.
 - Sweep the archive deletion journal before and after the pass and between
   install batches. Queries also inner-join current archive sessions before
   ranking, so tombstone processing is hygiene rather than a correctness

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -45,6 +45,12 @@ session `agent` and `started_at`, because those fields affect deduplication and
 day bucketing. All other session metadata and filters come from the archive read
 snapshot. Do not widen or narrow this live/baked boundary implicitly.
 
+The cache format version is also the extractor compatibility version. Bump
+`usageCacheFormatVersion` whenever fact extraction, `priceUsageFact`, web-search
+fees, deduplication, or rollup semantics change. Catalog and user-pricing
+changes are covered separately by the pricing content digest; do not add a
+write-only extractor-version metadata key.
+
 Daily rows exclude every fact that can participate in snapshot or general
 deduplication. A timezone-specific exception tier resolves those narrow rows at
 read time. This conservative boundary covers cross-day, cross-model,
@@ -73,6 +79,34 @@ data. `cached_at` is diagnostic only.
 recomputes the maximum of mutable timestamp fields, so it can decrease. A fill
 must recheck the full source fingerprint before installation. Do not replace
 that recheck with ordering comparisons.
+
+### Usage archive indexes
+
+The usage cache discovers bounded-window candidates through
+`idx_messages_usage_timestamp` and `idx_messages_activity_timestamp`, then
+extracts each selected session through the index-only
+`idx_messages_usage_session_covering` scan. The global activity index is for
+usage-cache candidate discovery, not the Activity report; that report continues
+to avoid a global timestamp scan. Keep these indexes narrow except for the
+single session-keyed covering index that carries `token_usage`.
+
+Changing any of these index column lists rebuilds the affected archive index on
+the next writable open, before HTTP readiness, and must log that startup is
+waiting for the migration. Read-only opens require the current indexes and may
+therefore reject an archive that has not first been opened by the matching
+writable version. Treat this as executable/archive version skew, not as a reason
+to mutate the archive from a read-only command.
+
+### Transcript usage identity
+
+Token usage, Claude message/request identities, and source UUID participate in
+transcript revision equality. Finalizing a streamed message can therefore bump
+`transcript_revision` and `local_modified_at`, invalidate secret-scan freshness,
+mark the session updated for read-progress/UI purposes, and enqueue the normal
+artifact, recall, PostgreSQL, and DuckDB refreshes. Full resync reconciliation
+must compare the same fields so incremental and resync paths agree. A no-op
+message replacement preserves existing secret findings; changed transcript
+content clears them for a fresh scan.
 
 ## DuckDB Mirror
 

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -23,6 +23,57 @@ atomically. Preserve sessions even when their source files no longer exist.
   explain why and preserve the same behavior.
 - DuckDB is a derived mirror and is not part of this parity rule.
 
+### Usage cache divergence
+
+SQLite's aggregate usage APIs read timezone-specific daily rollups from a
+disposable sibling database. Normalized, unpriced facts in the same database are
+the exact build substrate, not the warm aggregate read path. Per-session detail
+remains on the live row path, and PostgreSQL continues to aggregate its live
+normalized archive rows. The live path is never a fallback for a failed or stale
+SQLite aggregate read. Both implementations are co-maintained under the same
+behavior contract: daily usage, top sessions, billed session counts, relaxed
+matching counts, and per-session usage must remain observably equal. The
+`pgtest` complete-result parity fixture is the acceptance boundary. Track the
+PostgreSQL-native optimization in
+[issue #1451](https://github.com/kenn-io/agentsview/issues/1451).
+
+The usage cache filename is derived from its format version and the archive
+`database_id`. A format or database-ID change selects a new generation; it does
+not migrate or rewrite the archive. Facts contain only message- and
+usage-event-derived data. Aggregate fingerprints additionally bake the exact
+session `agent` and `started_at`, because those fields affect deduplication and
+day bucketing. All other session metadata and filters come from the archive read
+snapshot. Do not widen or narrow this live/baked boundary implicitly.
+
+Daily rows exclude every fact that can participate in snapshot or general
+deduplication. A timezone-specific exception tier resolves those narrow rows at
+read time. This conservative boundary covers cross-day, cross-model,
+cross-session, and snapshot-to-general cases without a second dependency graph,
+while preserving current window-scoped dedup semantics.
+
+Treat a usage-cache file as identifiable only after both its SQLite
+`application_id` and `usage_cache_metadata.cache_kind` match. Filename matching
+alone never permits deletion or replacement, and generations are not removed
+automatically because an SQLite transaction lock cannot prove that no other
+process holds an idle handle. If persistent cache storage is unavailable or the
+current generation is incompatible, use the same schema and query path in a
+process-owned temporary file and warn that the cache will rebuild after restart.
+
+Usage reads are exact. A cold aggregate request fills facts, builds the required
+timezone rollups, then reads them in one pinned cache transaction. Verify every
+candidate session's facts fingerprint, exact baked metadata, canonical pricing
+digest, resolved rate hashes, and Cursor high-water mark. Recheck each changed
+source session before installing it. A result is no older than the archive
+snapshot captured when the read began. A session confirmed deleted during fill
+is dropped from the request. Other fingerprint movement or archive-busy races
+are retried at most three times and then fail clearly rather than serving stale
+data. `cached_at` is diagnostic only.
+
+`sync_marker` is a fingerprint component, not a monotonic version: its trigger
+recomputes the maximum of mutable timestamp fields, so it can decrease. A fill
+must recheck the full source fingerprint before installation. Do not replace
+that recheck with ordering comparisons.
+
 ## DuckDB Mirror
 
 - Treat DuckDB as a disposable read mirror of SQLite, never as a system of

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -51,11 +51,26 @@ fees, deduplication, or rollup semantics change. Catalog and user-pricing
 changes are covered separately by the pricing content digest; do not add a
 write-only extractor-version metadata key.
 
-Daily rows exclude every fact that can participate in snapshot or general
-deduplication. A timezone-specific exception tier resolves those narrow rows at
-read time. This conservative boundary covers cross-day, cross-model,
-cross-session, and snapshot-to-general cases without a second dependency graph,
-while preserving current window-scoped dedup semantics.
+Deduplication groups are classified per group at rollup build time. A group is
+finalized into daily rows only when its resolution provably cannot vary with the
+query window or live filters: every member shares one source session and one
+local date, general (`source:`/`usage:`) groups additionally share one model and
+headless state, no member links snapshot and general dedup, no member carries a
+Copilot authoritative cost, and the group's identity appears in no other cached
+session (nor, for usage keys, in the Cursor fact store). Only the remaining
+irreducible groups go to the timezone-specific exception tier that resolves
+narrow rows at read time, preserving the window-scoped dedup semantics. Cursor
+facts stay entirely on the exception tier. Because query windows are whole local
+days, a single-date group is inside or outside any window as a unit.
+
+Cross-session identity checks are conservative and served by dedicated
+`usage_facts` identity indexes, not a membership table. Whenever a fill, Cursor
+batch, or deletion changes the set of dedup identities a session (or the Cursor
+store) contributes, it must, in the same cache transaction, delete the timezone
+rollup installs of every other session holding a changed identity; rollup
+installation re-verifies inside its transaction that no finalized identity
+gained an outside member and retries as a moved source otherwise. A finalized
+daily row must never survive gaining a sibling.
 
 Treat a usage-cache file as identifiable only after both its SQLite
 `application_id` and `usage_cache_metadata.cache_kind` match. Filename matching

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -78,7 +78,7 @@ data. `cached_at` is diagnostic only.
 Timezone rollup identity includes both the resolved zone name and its rule
 fingerprint. Cache-generation retirement cancels detached work immediately but
 keeps immutable coordinator pointers and the cache database alive until active
-query and backfill leases drain.
+query, backfill, fill, and rollup leases drain.
 
 `sync_marker` is a fingerprint component, not a monotonic version: its trigger
 recomputes the maximum of mutable timestamp fields, so it can decrease. A fill

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -75,6 +75,11 @@ is dropped from the request. Other fingerprint movement or archive-busy races
 are retried at most three times and then fail clearly rather than serving stale
 data. `cached_at` is diagnostic only.
 
+Timezone rollup identity includes both the resolved zone name and its rule
+fingerprint. Cache-generation retirement cancels detached work immediately but
+keeps immutable coordinator pointers and the cache database alive until active
+query and backfill leases drain.
+
 `sync_marker` is a fingerprint component, not a monotonic version: its trigger
 recomputes the maximum of mutable timestamp fields, so it can decrease. A fill
 must recheck the full source fingerprint before installation. Do not replace

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -117,6 +117,11 @@ therefore reject an archive that has not first been opened by the matching
 writable version. Treat this as executable/archive version skew, not as a reason
 to mutate the archive from a read-only command.
 
+Full resync drops these indexes in the temporary database during the bulk load
+(the FTS trade: one post-load build instead of per-row B-tree maintenance) and
+must rebuild them before the swap; a failed rebuild aborts the swap because
+read-only opens require the indexes.
+
 ### Transcript usage identity
 
 Token usage, Claude message/request identities, and source UUID participate in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,6 @@
----
-title: Configuration
-description: Config file, default paths, and runtime settings
----
+______________________________________________________________________
+
+## title: Configuration description: Config file, default paths, and runtime settings
 
 ## Data Directory
 
@@ -10,20 +9,28 @@ AgentsView stores all persistent data under a single directory, defaulting to
 
 !!! note
 
-    `AGENT_VIEWER_DATA_DIR` is still accepted as a legacy fallback when
-    `AGENTSVIEW_DATA_DIR` is unset, but new setups should use
-    `AGENTSVIEW_DATA_DIR`.
+```
+`AGENT_VIEWER_DATA_DIR` is still accepted as a legacy fallback when
+`AGENTSVIEW_DATA_DIR` is unset, but new setups should use
+`AGENTSVIEW_DATA_DIR`.
+```
 
 ```
 ~/.agentsview/
 ├── sessions.db      # SQLite database (WAL mode)
 ├── vectors.db       # Semantic-search vector index (when [vector] is enabled)
+├── usage-cache-v1-<id>.db # Disposable usage-aggregate cache
 ├── config.toml      # Configuration file
 ├── config.toml.lock # Serializes concurrent config writers
 ├── db.write.lock    # Per-data-dir SQLite write-owner lock
 ├── serve.log        # Detached daemon log
 └── uploads/         # Uploaded session files
 ```
+
+`usage-cache-v1-<id>.db` is a derived cache of usage aggregates, not user data.
+It is safe to delete when no AgentsView process is running; the next usage query
+rebuilds it automatically. `sessions.db` remains the only file that needs
+backing up.
 
 The desktop app and CLI share a detached local daemon for fresh reads and
 writes. A running daemon owns local SQLite writes for this data directory and
@@ -45,9 +52,11 @@ stores persistent settings that survive restarts.
 
 !!! note
 
-    The config format changed from JSON to TOML. Existing `config.json` files
-    are automatically migrated to `config.toml` on first run (the JSON file is
-    renamed to `config.json.bak`).
+```
+The config format changed from JSON to TOML. Existing `config.json` files
+are automatically migrated to `config.toml` on first run (the JSON file is
+renamed to `config.json.bak`).
+```
 
 ```toml
 cursor_secret = "base64-encoded-secret"
@@ -72,7 +81,7 @@ chart_palette = "agentsview"
 | `public_origins`                    | Array of additional trusted CORS origins                                                                                                                                                                                                             |
 | `daemon_idle_timeout`               | Idle timeout for detached writable daemons; set to `"0s"` to keep them alive                                                                                                                                                                         |
 | `chart_palette`                     | Server-wide categorical chart colors: `"agentsview"` (default) or `"matplotlib"`; also configurable under **Settings > Appearance**                                                                                                                  |
-| `disabled_agents`                   | Session providers to exclude from local filesystem scanning; changes require a daemon restart — see [Disabling Session Providers](#disabling-session-providers)                                                                                     |
+| `disabled_agents`                   | Session providers to exclude from local filesystem scanning; changes require a daemon restart — see [Disabling Session Providers](#disabling-session-providers)                                                                                      |
 | `[proxy]`                           | Managed proxy configuration table — see [Remote Access](/remote-access/)                                                                                                                                                                             |
 | `disable_update_check`              | Disable the automatic update check (see [Privacy](#privacy-and-telemetry))                                                                                                                                                                           |
 | `scan_protected_paths`              | Allow Git discovery inside macOS privacy-protected folders, accepting one consent prompt per folder — see [macOS Protected Folders](#macos-protected-folders)                                                                                        |
@@ -80,7 +89,7 @@ chart_palette = "agentsview"
 | `[duckdb]`                          | DuckDB mirror configuration — see [DuckDB Mirror](/duckdb/)                                                                                                                                                                                          |
 | `[vector]`                          | Opt-in semantic-search index; model settings live in `[vector.embeddings]`, named endpoints in `[vector.embeddings.servers.<name>]`, embedding schedule in `[vector.embed]` — see [Semantic Search](/semantic-search/#enabling-vector) for every key |
 | `[recall.extract]`                  | Opt-in model-backed recall extraction; named endpoints in `[recall.extract.servers.<name>]`, prompt selection in `[recall.extract.prompts]`, request overrides in `[recall.extract.request]` — see [Recall](/recall/#automatic-extraction)           |
-| `[insights]`                        | Optional generated-insights endpoint and model; local loopback HTTP is allowed, remote plaintext requires `allow_http = true`, and endpoint failures do not retry through a CLI — see [Recall](/recall/#current-surface) |
+| `[insights]`                        | Optional generated-insights endpoint and model; local loopback HTTP is allowed, remote plaintext requires `allow_http = true`, and endpoint failures do not retry through a CLI — see [Recall](/recall/#current-surface)                             |
 | `[[remote_hosts]]`                  | Remote machines synced by a bare `agentsview sync` — see [CLI Reference](/commands/#agentsview-sync)                                                                                                                                                 |
 | `[[session_sources]]`               | Additional filesystem session roots with per-root machine labels — see [Filesystem Session Sync](/filesystem-sync/)                                                                                                                                  |
 | `[automated]`                       | Custom automated-session patterns — see [Automated Session Detection](#automated-session-detection)                                                                                                                                                  |
@@ -107,9 +116,11 @@ both are set.
 
 !!! note
 
-    Older configs may still contain `remote_access = true`. AgentsView still
-    reads that legacy key for backward compatibility, but new setups should use
-    `require_auth = true`.
+```
+Older configs may still contain `remote_access = true`. AgentsView still
+reads that legacy key for backward compatibility, but new setups should use
+`require_auth = true`.
+```
 
 ## Remote Hosts
 
@@ -146,12 +157,12 @@ deltas when fewer than half of the manifest files need fetching; see
 [Remote Access — Incremental Sync](/remote-access/#incremental-sync).
 
 When a full or automatic data-version rebuild includes local sources, configured
-HTTP hosts join the same temporary-database bulk ingest and atomic swap. `--full`
-reparses the complete local and remote corpus without retransferring unchanged
-files from manifest-capable spokes. HTTP remote sync requires the collector and
-remote daemon to use the same remote-sync protocol version. After upgrading
-either host, upgrade the other before syncing again; incompatible peers fail
-before targets or archive data are exchanged.
+HTTP hosts join the same temporary-database bulk ingest and atomic swap.
+`--full` reparses the complete local and remote corpus without retransferring
+unchanged files from manifest-capable spokes. HTTP remote sync requires the
+collector and remote daemon to use the same remote-sync protocol version. After
+upgrading either host, upgrade the other before syncing again; incompatible
+peers fail before targets or archive data are exchanged.
 
 Each `remote_hosts.host` value must be unique and stable. It namespaces imported
 session IDs, the database skip cache, and the persistent mirror; changing it for
@@ -161,9 +172,8 @@ can reuse stale state. A configured HTTP host can be selected later with
 without a matching configured host, `--host` remains an SSH remote sync. HTTP
 remote sync is the recommended transport. SSH remote sync is deprecated and
 receives only critical fixes. HTTP failures are summarized with actionable
-messages for common cases such as token
-rejection, missing remote archive endpoints, connection refusal, DNS failures,
-and timeouts.
+messages for common cases such as token rejection, missing remote archive
+endpoints, connection refusal, DNS failures, and timeouts.
 
 Set `interval` to a positive duration such as `"5m"` to have a running collector
 daemon sync that host periodically. Zero or omitted disables the per-host
@@ -238,74 +248,75 @@ server-side and leave only local stubs; historical local Amp thread JSON files
 can still be parsed.
 
 The matching environment variable and `*_dirs` configuration key override an
-agent's default directories. Environment variables take precedence when both
-are set. An explicit empty `*_dirs` array, such as `grok_dirs = []`, clears that
+agent's default directories. Environment variables take precedence when both are
+set. An explicit empty `*_dirs` array, such as `grok_dirs = []`, clears that
 agent's default local directories, so local discovery finds nothing there.
 Matching `session_sources` entries for that agent still apply. Provider-wide
-exclusion is documented under [Disabling Session Providers](#disabling-session-providers).
-Omitting the key keeps its default directories.
+exclusion is documented under
+[Disabling Session Providers](#disabling-session-providers). Omitting the key
+keeps its default directories.
 
-| Agent                 | Default Directory                                                                | File Format                                                                                                                     |
-| --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Aider                 | No default; opt in with `AIDER_DIR` or `aider_dirs`                              | `.aider.chat.history.md` Markdown history files                                                                                 |
-| Amp (deprecated)      | `~/.local/share/amp/threads/`                                                    | Historical local JSON thread files                                                                                              |
-| Antigravity (IDE)     | `~/.gemini/antigravity/`                                                         | SQLite database per session                                                                                                     |
-| Antigravity CLI       | `~/.gemini/antigravity-cli/`                                                     | SQLite `conversations/<uuid>.db`, `<uuid>.trajectory.json` sidecars, or encrypted `.pb` files plus `brain/` and `history.jsonl` |
-| Claude Code           | `~/.claude/projects/`                                                            | JSONL per session                                                                                                               |
-| OpenClaude            | `~/.openclaude/projects/`                                                        | JSONL per session                                                                                                               |
-| Claude Cowork         | (platform-specific, see below)                                                   | Claude Desktop cowork sessions                                                                                                  |
-| Codebuff / Freebuff   | `~/.config/manicode/projects/`                                                   | Per-session `chat-messages.json` + `run-state.json` with subagent transcripts                                                  |
-| Codex                 | `~/.codex/sessions/` and `~/.codex/archived_sessions/`                           | JSONL per session                                                                                                               |
-| Command Code          | `~/.commandcode/projects/`                                                       | JSONL per session, optional `.meta.json` sidecar                                                                                |
-| Copilot CLI           | `~/.copilot/`                                                                    | JSONL per session under `session-state/`                                                                                        |
-| Devin CLI             | `~/.local/share/devin/` (Linux), `~/Library/Application Support/devin/` (macOS)  | Local CLI data rooted at the directory that contains `cli/`; session data is discovered under `<root>/cli/...`                  |
-| Cortex Code           | `~/.snowflake/cortex/conversations/`                                             | JSON / JSONL per session                                                                                                        |
-| Cursor                | `~/.cursor/projects/`                                                            | JSONL or plain-text transcripts                                                                                                 |
-| DeepSeek TUI          | `~/.codewhale/sessions/` and `~/.deepseek/sessions/`                             | JSON per session                                                                                                                |
-| DeepSeek Harness      | `~/.dsh/sessions/` (or `$DSH_HOME/sessions/`)                                    | Plain or multi-frame zstd JSONL per session                                                                                     |
-| Forge                 | `~/.forge/`                                                                      | SQLite database (`.forge.db`)                                                                                                   |
-| Gemini CLI            | `~/.gemini/`                                                                     | JSONL in `tmp/` subdirectory                                                                                                    |
-| Goose                 | (platform-specific, see below)                                                   | SQLite `sessions.db` with transcripts, tool activity, relationships, usage, and recorded costs                                  |
-| gptme                 | `~/.local/share/gptme/logs/`                                                     | JSONL logs                                                                                                                      |
-| Grok                  | `~/.grok/sessions/`                                                              | `summary.json` + optional `signals.json` + `chat_history.jsonl` transcript when present                                         |
-| Hermes Agent          | `~/.hermes/sessions/`                                                            | JSONL / JSON per session                                                                                                        |
-| iFlow                 | `~/.iflow/projects/`                                                             | JSONL per session                                                                                                               |
-| Kilo                  | `~/.local/share/kilo/`                                                           | SQLite DB or `storage/` JSON files                                                                                              |
-| Kimi                  | `~/.kimi/sessions/` and `~/.kimi-code/sessions/`                                 | JSONL per session                                                                                                               |
-| Kimi Work             | (platform-specific, see below)                                                   | JSONL per session (kimi-code kernel wire logs)                                                                                  |
-| Kiro CLI              | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/`                           | JSONL per session and SQLite database                                                                                           |
-| Kiro IDE              | (platform-specific, see below)                                                   | JSON / chat files                                                                                                               |
-| Kilo (legacy)         | (platform-specific, see below)                                                   | `tasks/<uuid>/{task_metadata.json,ui_messages.json,api_conversation_history.json}`                                              |
-| MiMoCode              | `~/.local/share/mimocode/`                                                       | SQLite DB or `storage/` JSON files                                                                                              |
-| Mistral Vibe          | `~/.vibe/logs/session/`                                                          | Per-session `messages.jsonl` plus `meta.json`                                                                                   |
-| OhMyPi                | `~/.omp/agent/sessions/`                                                         | JSONL per session                                                                                                               |
-| OpenClaw              | `~/.openclaw/assets/static/agents/` and `~/.kimi_openclaw/assets/static/agents/` | JSONL per session                                                                                                               |
-| OpenCode              | `~/.local/share/opencode/`                                                       | SQLite DB or `storage/` JSON files                                                                                              |
-| OpenHands CLI         | `~/.openhands/conversations/`                                                    | Per-conversation `base_state.json` + `events/*.json`                                                                            |
-| Omnigent              | `~/.omnigent/`                                                                   | SQLite `chat.db`, one session per conversation                                                                                  |
-| Pi                    | `~/.pi/agent/sessions/`                                                          | JSONL per session                                                                                                               |
-| Prime Agent           | `~/.prime/agent/sessions/`                                                       | Flat Pi-family JSONL sessions                                                                                                   |
-| Poolside              | `~/Library/Application Support/poolside/trajectories/` (macOS), `~/.local/state/poolside/trajectories/` (Linux), `%APPDATA%\\poolside\\trajectories\\` (Windows) | NDJSON trajectory files                                                                                                         |
-| Piebald               | `~/.local/share/piebald/`                                                        | SQLite database (`app.db`)                                                                                                      |
-| Posit Assistant       | `~/.posit/assistant/workspaces/`                                                 | Per-conversation `conversation.json` tree plus `lm-messages.jsonl` transcript                                                   |
-| Positron Assistant    | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
-| QClaw                 | `~/.qclaw/assets/static/agents/`                                                 | JSONL per session                                                                                                               |
-| Qoder                 | Legacy export roots plus platform-specific `SharedClientCache` (see below)       | JSONL project transcripts plus sidecar metadata                                                                                 |
-| Qwen Code             | `~/.qwen/projects/`                                                              | JSONL per session                                                                                                               |
-| QwenPaw               | `~/.copaw/workspaces/`                                                           | JSON session files                                                                                                              |
-| Reasonix              | `~/.reasonix/` and `~/AppData/Roaming/reasonix/`                                 | JSONL sessions plus `.jsonl.meta` sidecars                                                                                      |
-| RooCode               | (platform-specific, see below)                                                   | `history_item.json` + `ui_messages.json` per task                                                                              |
-| Shelley               | `~/.config/shelley/`                                                             | SQLite database (`shelley.db`)                                                                                                  |
-| Visual Studio Copilot | (platform-specific, see below)                                                   | Trace JSONL files                                                                                                               |
-| VS Code Copilot       | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
-| Windsurf              | (platform-specific, see below)                                                   | SQLite `workspaceStorage/<hash>/state.vscdb` workspace chat data                                                                |
-| Trae                  | (platform-specific, see below)                                                   | Legacy inline chat data in SQLite `workspaceStorage/<hash>/state.vscdb` and `globalStorage/state.vscdb`; modern encrypted layouts are detected as unsupported |
-| TraeX (TRAE CLI)      | `~/.trae/cli/sessions/` and `~/.trae/cli/archived_sessions/`                     | Codex-compatible rollout JSONL per session                                                                                      |
-| Warp                  | (platform-specific, see below)                                                   | SQLite database                                                                                                                 |
-| WorkBuddy             | `~/.workbuddy/projects/`                                                         | JSONL per session                                                                                                               |
-| ZCode                 | `~/.zcode/cli/db/` or `~/.zcode/cli/`                                            | SQLite database (`db.sqlite`) with usage rows                                                                                   |
-| Zed                   | (platform-specific, see below)                                                   | SQLite database (`threads/threads.db`)                                                                                          |
-| Zencoder              | `~/.zencoder/sessions/`                                                          | JSONL per session                                                                                                               |
+| Agent                 | Default Directory                                                                                                                                                | File Format                                                                                                                                                   |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Aider                 | No default; opt in with `AIDER_DIR` or `aider_dirs`                                                                                                              | `.aider.chat.history.md` Markdown history files                                                                                                               |
+| Amp (deprecated)      | `~/.local/share/amp/threads/`                                                                                                                                    | Historical local JSON thread files                                                                                                                            |
+| Antigravity (IDE)     | `~/.gemini/antigravity/`                                                                                                                                         | SQLite database per session                                                                                                                                   |
+| Antigravity CLI       | `~/.gemini/antigravity-cli/`                                                                                                                                     | SQLite `conversations/<uuid>.db`, `<uuid>.trajectory.json` sidecars, or encrypted `.pb` files plus `brain/` and `history.jsonl`                               |
+| Claude Code           | `~/.claude/projects/`                                                                                                                                            | JSONL per session                                                                                                                                             |
+| OpenClaude            | `~/.openclaude/projects/`                                                                                                                                        | JSONL per session                                                                                                                                             |
+| Claude Cowork         | (platform-specific, see below)                                                                                                                                   | Claude Desktop cowork sessions                                                                                                                                |
+| Codebuff / Freebuff   | `~/.config/manicode/projects/`                                                                                                                                   | Per-session `chat-messages.json` + `run-state.json` with subagent transcripts                                                                                 |
+| Codex                 | `~/.codex/sessions/` and `~/.codex/archived_sessions/`                                                                                                           | JSONL per session                                                                                                                                             |
+| Command Code          | `~/.commandcode/projects/`                                                                                                                                       | JSONL per session, optional `.meta.json` sidecar                                                                                                              |
+| Copilot CLI           | `~/.copilot/`                                                                                                                                                    | JSONL per session under `session-state/`                                                                                                                      |
+| Devin CLI             | `~/.local/share/devin/` (Linux), `~/Library/Application Support/devin/` (macOS)                                                                                  | Local CLI data rooted at the directory that contains `cli/`; session data is discovered under `<root>/cli/...`                                                |
+| Cortex Code           | `~/.snowflake/cortex/conversations/`                                                                                                                             | JSON / JSONL per session                                                                                                                                      |
+| Cursor                | `~/.cursor/projects/`                                                                                                                                            | JSONL or plain-text transcripts                                                                                                                               |
+| DeepSeek TUI          | `~/.codewhale/sessions/` and `~/.deepseek/sessions/`                                                                                                             | JSON per session                                                                                                                                              |
+| DeepSeek Harness      | `~/.dsh/sessions/` (or `$DSH_HOME/sessions/`)                                                                                                                    | Plain or multi-frame zstd JSONL per session                                                                                                                   |
+| Forge                 | `~/.forge/`                                                                                                                                                      | SQLite database (`.forge.db`)                                                                                                                                 |
+| Gemini CLI            | `~/.gemini/`                                                                                                                                                     | JSONL in `tmp/` subdirectory                                                                                                                                  |
+| Goose                 | (platform-specific, see below)                                                                                                                                   | SQLite `sessions.db` with transcripts, tool activity, relationships, usage, and recorded costs                                                                |
+| gptme                 | `~/.local/share/gptme/logs/`                                                                                                                                     | JSONL logs                                                                                                                                                    |
+| Grok                  | `~/.grok/sessions/`                                                                                                                                              | `summary.json` + optional `signals.json` + `chat_history.jsonl` transcript when present                                                                       |
+| Hermes Agent          | `~/.hermes/sessions/`                                                                                                                                            | JSONL / JSON per session                                                                                                                                      |
+| iFlow                 | `~/.iflow/projects/`                                                                                                                                             | JSONL per session                                                                                                                                             |
+| Kilo                  | `~/.local/share/kilo/`                                                                                                                                           | SQLite DB or `storage/` JSON files                                                                                                                            |
+| Kimi                  | `~/.kimi/sessions/` and `~/.kimi-code/sessions/`                                                                                                                 | JSONL per session                                                                                                                                             |
+| Kimi Work             | (platform-specific, see below)                                                                                                                                   | JSONL per session (kimi-code kernel wire logs)                                                                                                                |
+| Kiro CLI              | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/`                                                                                                           | JSONL per session and SQLite database                                                                                                                         |
+| Kiro IDE              | (platform-specific, see below)                                                                                                                                   | JSON / chat files                                                                                                                                             |
+| Kilo (legacy)         | (platform-specific, see below)                                                                                                                                   | `tasks/<uuid>/{task_metadata.json,ui_messages.json,api_conversation_history.json}`                                                                            |
+| MiMoCode              | `~/.local/share/mimocode/`                                                                                                                                       | SQLite DB or `storage/` JSON files                                                                                                                            |
+| Mistral Vibe          | `~/.vibe/logs/session/`                                                                                                                                          | Per-session `messages.jsonl` plus `meta.json`                                                                                                                 |
+| OhMyPi                | `~/.omp/agent/sessions/`                                                                                                                                         | JSONL per session                                                                                                                                             |
+| OpenClaw              | `~/.openclaw/assets/static/agents/` and `~/.kimi_openclaw/assets/static/agents/`                                                                                 | JSONL per session                                                                                                                                             |
+| OpenCode              | `~/.local/share/opencode/`                                                                                                                                       | SQLite DB or `storage/` JSON files                                                                                                                            |
+| OpenHands CLI         | `~/.openhands/conversations/`                                                                                                                                    | Per-conversation `base_state.json` + `events/*.json`                                                                                                          |
+| Omnigent              | `~/.omnigent/`                                                                                                                                                   | SQLite `chat.db`, one session per conversation                                                                                                                |
+| Pi                    | `~/.pi/agent/sessions/`                                                                                                                                          | JSONL per session                                                                                                                                             |
+| Prime Agent           | `~/.prime/agent/sessions/`                                                                                                                                       | Flat Pi-family JSONL sessions                                                                                                                                 |
+| Poolside              | `~/Library/Application Support/poolside/trajectories/` (macOS), `~/.local/state/poolside/trajectories/` (Linux), `%APPDATA%\\poolside\\trajectories\\` (Windows) | NDJSON trajectory files                                                                                                                                       |
+| Piebald               | `~/.local/share/piebald/`                                                                                                                                        | SQLite database (`app.db`)                                                                                                                                    |
+| Posit Assistant       | `~/.posit/assistant/workspaces/`                                                                                                                                 | Per-conversation `conversation.json` tree plus `lm-messages.jsonl` transcript                                                                                 |
+| Positron Assistant    | (platform-specific, see below)                                                                                                                                   | JSON / JSONL per session                                                                                                                                      |
+| QClaw                 | `~/.qclaw/assets/static/agents/`                                                                                                                                 | JSONL per session                                                                                                                                             |
+| Qoder                 | Legacy export roots plus platform-specific `SharedClientCache` (see below)                                                                                       | JSONL project transcripts plus sidecar metadata                                                                                                               |
+| Qwen Code             | `~/.qwen/projects/`                                                                                                                                              | JSONL per session                                                                                                                                             |
+| QwenPaw               | `~/.copaw/workspaces/`                                                                                                                                           | JSON session files                                                                                                                                            |
+| Reasonix              | `~/.reasonix/` and `~/AppData/Roaming/reasonix/`                                                                                                                 | JSONL sessions plus `.jsonl.meta` sidecars                                                                                                                    |
+| RooCode               | (platform-specific, see below)                                                                                                                                   | `history_item.json` + `ui_messages.json` per task                                                                                                             |
+| Shelley               | `~/.config/shelley/`                                                                                                                                             | SQLite database (`shelley.db`)                                                                                                                                |
+| Visual Studio Copilot | (platform-specific, see below)                                                                                                                                   | Trace JSONL files                                                                                                                                             |
+| VS Code Copilot       | (platform-specific, see below)                                                                                                                                   | JSON / JSONL per session                                                                                                                                      |
+| Windsurf              | (platform-specific, see below)                                                                                                                                   | SQLite `workspaceStorage/<hash>/state.vscdb` workspace chat data                                                                                              |
+| Trae                  | (platform-specific, see below)                                                                                                                                   | Legacy inline chat data in SQLite `workspaceStorage/<hash>/state.vscdb` and `globalStorage/state.vscdb`; modern encrypted layouts are detected as unsupported |
+| TraeX (TRAE CLI)      | `~/.trae/cli/sessions/` and `~/.trae/cli/archived_sessions/`                                                                                                     | Codex-compatible rollout JSONL per session                                                                                                                    |
+| Warp                  | (platform-specific, see below)                                                                                                                                   | SQLite database                                                                                                                                               |
+| WorkBuddy             | `~/.workbuddy/projects/`                                                                                                                                         | JSONL per session                                                                                                                                             |
+| ZCode                 | `~/.zcode/cli/db/` or `~/.zcode/cli/`                                                                                                                            | SQLite database (`db.sqlite`) with usage rows                                                                                                                 |
+| Zed                   | (platform-specific, see below)                                                                                                                                   | SQLite database (`threads/threads.db`)                                                                                                                        |
+| Zencoder              | `~/.zencoder/sessions/`                                                                                                                                          | JSONL per session                                                                                                                                             |
 
 DeepSeek Harness sessions are read from its default JSONL persistence backend,
 including plain `session.jsonl` and multi-frame `session.jsonl.zstd` files.
@@ -315,9 +326,9 @@ directly at one or more session roots. The optional SQLite persistence backend
 is not supported.
 
 Prime Agent support targets the current flat session layout in v0.7.0. That
-release migrates the older per-project layout when Prime Agent opens its
-session store, so open the current Prime Agent once before syncing a legacy
-archive with AgentsView.
+release migrates the older per-project layout when Prime Agent opens its session
+store, so open the current Prime Agent once before syncing a legacy archive with
+AgentsView.
 
 **Qoder default directories** include the legacy `~/.qoder/projects/` and
 `~/.qoderwork/projects/` export roots plus the current IDE store:
@@ -331,10 +342,10 @@ Set `QODER_PROJECTS_DIR` or `qoder_project_dirs` to replace these defaults with
 one or more explicit roots.
 
 Grok sessions are read from `summary.json` (title, timestamps, project),
-optional `signals.json` (token counters), and `chat_history.jsonl` when
-present for the full transcript (user turns, assistant replies, thinking,
-and tool calls). If `chat_history.jsonl` is missing, AgentsView falls back
-to summary-only mode. Set `GROK_DIR` or `grok_dirs` to override the default
+optional `signals.json` (token counters), and `chat_history.jsonl` when present
+for the full transcript (user turns, assistant replies, thinking, and tool
+calls). If `chat_history.jsonl` is missing, AgentsView falls back to
+summary-only mode. Set `GROK_DIR` or `grok_dirs` to override the default
 directory.
 
 **Goose default directories** are:
@@ -344,18 +355,18 @@ directory.
 
 `GOOSE_PATH_ROOT` follows Goose's own path-root convention and resolves
 `<root>/data/sessions/sessions.db`. A `goose_dirs` entry may instead point
-directly to that sessions directory, its parent data directory, or the
-database file.
+directly to that sessions directory, its parent data directory, or the database
+file.
 
 Omnigent sessions are read from `~/.omnigent/chat.db`. Set `OMNIGENT_DIR` or
 `omnigent_dirs` to override the default directory. AgentsView creates one
-session per conversation and supports the split text-ID and current
-binary-UUID schema generations; the older single-table schema is detected and
-reported as unsupported without losing sessions already synced from it.
-Remote HTTP and SSH sync stay disabled for Omnigent because `chat.db`
-co-locates transcripts with authentication secrets. A metadata-only edit made
-directly in `chat.db` can be deferred by the immediate filesystem-event sync;
-the next scheduled reconciliation pass or an explicit resync picks it up.
+session per conversation and supports the split text-ID and current binary-UUID
+schema generations; the older single-table schema is detected and reported as
+unsupported without losing sessions already synced from it. Remote HTTP and SSH
+sync stay disabled for Omnigent because `chat.db` co-locates transcripts with
+authentication secrets. A metadata-only edit made directly in `chat.db` can be
+deferred by the immediate filesystem-event sync; the next scheduled
+reconciliation pass or an explicit resync picks it up.
 
 **VS Code Copilot default directories** vary by platform:
 
@@ -386,31 +397,35 @@ Windsurf stores workspace chats in `workspaceStorage/<hash>/state.vscdb`.
 
 **Trae default directories** vary by platform:
 
-- **macOS:** `~/Library/Application Support/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
+- **macOS:** `~/Library/Application Support/Trae/User/`, `Trae CN/User/`, and
+  `TRAE SOLO CN/User/`
 - **Linux:** `~/.config/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
 - **Windows:** `%APPDATA%/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
 
 Trae stores chats in `workspaceStorage/<hash>/state.vscdb` and
 `globalStorage/state.vscdb`. Override these roots with `TRAE_DIR` or the
-`trae_dirs` configuration key.
-AgentsView watches `workspaceStorage` and `globalStorage`, then reads chat
-records from those SQLite stores.
+`trae_dirs` configuration key. AgentsView watches `workspaceStorage` and
+`globalStorage`, then reads chat records from those SQLite stores.
 
 Trae legacy inline-message parsing is supported. Modern encrypted transcript
 layouts are detected and reported as unsupported. Remote HTTP and SSH target
-resolution is still disabled. A Trae root is a full user profile, and AgentsView does not
-archive or ship that profile wholesale. The follow-up path is Windsurf-style
-curated file targets only: `state.vscdb`, `state.vscdb-wal`, and
+resolution is still disabled. A Trae root is a full user profile, and AgentsView
+does not archive or ship that profile wholesale. The follow-up path is
+Windsurf-style curated file targets only: `state.vscdb`, `state.vscdb-wal`, and
 `workspace.json` for each supported workspace store.
 
 **Kimi Work default directories** vary by platform. Kimi Work is the
 kimi-desktop app (the "daimon" runtime); it stores conversations as kimi-code
-kernel wire logs under `<root>/wd_<workspace>_<hash>/<session>/agents/<agent>/wire.jsonl`:
+kernel wire logs under
+`<root>/wd_<workspace>_<hash>/<session>/agents/<agent>/wire.jsonl`:
 
-- **macOS:** `~/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
-- **Linux:** `~/.config/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **macOS:**
+  `~/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **Linux:**
+  `~/.config/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
   (or `~/.local/share/...` on some installs)
-- **Windows:** `%APPDATA%/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **Windows:**
+  `%APPDATA%/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
 
 Only `conv-*` session directories are user conversations; auxiliary internal
 sessions (`ctitle-*`, `sklsum-*`, `dvlt-*`) are excluded from discovery. Set
@@ -463,28 +478,25 @@ independently.
 
 Subagent tool calls (basher, code-searcher, file-picker, code-reviewer, etc.)
 are parsed from the AI message blocks and displayed inline in the transcript
-view. The agent template (e.g. `base2-free-deepseek`, `base2-free-mimo`) is
-read from run-state.json's `agentType` field and shown in the session
-detail header. This is the classification label used server-side to pick
-the per-step LLM; the literal LLM is not persisted by the CLI and is
-not visible in the UI.
-Project names are derived from the session's working directory via git-root
-detection.
+view. The agent template (e.g. `base2-free-deepseek`, `base2-free-mimo`) is read
+from run-state.json's `agentType` field and shown in the session detail header.
+This is the classification label used server-side to pick the per-step LLM; the
+literal LLM is not persisted by the CLI and is not visible in the UI. Project
+names are derived from the session's working directory via git-root detection.
 
-Codebuff and Freebuff sessions report cost only. The CLI's on-disk
-format does not persist per-message input/output/cache tokens, so the
-daily usage model breakdown shows the cost-attributed agent template
-(e.g. `base2-deepseek`, `base2-free-minimax-m3`) without per-message
-token figures. Reported-cost rows ride as microdollars on `money.Money`
-like every other agent, and per-model rates for `base2-*` templates are
-not in the embedded pricing tables, so cache savings for these rows
-resolve to zero by design rather than an aggregator bug.
+Codebuff and Freebuff sessions report cost only. The CLI's on-disk format does
+not persist per-message input/output/cache tokens, so the daily usage model
+breakdown shows the cost-attributed agent template (e.g. `base2-deepseek`,
+`base2-free-minimax-m3`) without per-message token figures. Reported-cost rows
+ride as microdollars on `money.Money` like every other agent, and per-model
+rates for `base2-*` templates are not in the embedded pricing tables, so cache
+savings for these rows resolve to zero by design rather than an aggregator bug.
 
 Freebuff does not have its own environment variable or config key — it shares
-the Codebuff provider for discovery and the parser auto-classifies sessions.
-Set `CODEBUFF_DIR` or `codebuff_dirs` when manicode stores its projects
-directory somewhere other than `~/.config/manicode/projects`; this covers both
-Codebuff and Freebuff sessions.
+the Codebuff provider for discovery and the parser auto-classifies sessions. Set
+`CODEBUFF_DIR` or `codebuff_dirs` when manicode stores its projects directory
+somewhere other than `~/.config/manicode/projects`; this covers both Codebuff
+and Freebuff sessions.
 
 **OpenHands CLI shallow watch:** OpenHands stores each conversation in its own
 subdirectory, which would consume one recursive file watch per session and can
@@ -563,17 +575,18 @@ names and per-request token usage.
 - **macOS:**
   `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
 - **Linux:** `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
-- **Windows:** `~/AppData/Roaming/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
+- **Windows:**
+  `~/AppData/Roaming/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
 
-RooCode (rooveterinaryinc.roo-cline) is a VSCode extension that stores
-sessions under `tasks/<taskId>/` in VSCode's globalStorage directory. Each task
-directory contains `history_item.json` (metadata including task description,
-model name, workspace path, token counts, and recorded cost) and
-`ui_messages.json` (the Cline-format transcript with user prompts, assistant
-responses, reasoning blocks, and tool calls). AgentsView parses the
-`apiConfigName` field from `history_item.json` as the session model, extracts
-project names from the workspace path via git-root detection, and emits the
-recorded `totalCost` as a usage event for cost tracking.
+RooCode (rooveterinaryinc.roo-cline) is a VSCode extension that stores sessions
+under `tasks/<taskId>/` in VSCode's globalStorage directory. Each task directory
+contains `history_item.json` (metadata including task description, model name,
+workspace path, token counts, and recorded cost) and `ui_messages.json` (the
+Cline-format transcript with user prompts, assistant responses, reasoning
+blocks, and tool calls). AgentsView parses the `apiConfigName` field from
+`history_item.json` as the session model, extracts project names from the
+workspace path via git-root detection, and emits the recorded `totalCost` as a
+usage event for cost tracking.
 
 RooCode was shut down on May 15, 2026. ZooCode (Zoo-CodeInc.zoo-cline) is the
 active community fork and will be supported separately. Set `ROOCODE_DIR` or
@@ -583,7 +596,8 @@ active community fork and will be supported separately. Set `ROOCODE_DIR` or
 canonical lowercase `kilocode.kilo-code` global storage directory that VSCode
 writes on disk:
 
-- **macOS:** `~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code/`
+- **macOS:**
+  `~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code/`
 - **Linux:** `~/.config/Code/User/globalStorage/kilocode.kilo-code/`
 - **Windows:** `%APPDATA%/Code/User/globalStorage/kilocode.kilo-code/`
 
@@ -597,16 +611,15 @@ a reparse. Sessions are parsed through RooCode-descended Cline message handling
 linking). Set `KILO_LEGACY_DIR` or `kilo_legacy_dirs` when the legacy extension
 stores its data outside the standard locations.
 
-**Kilo (legacy) vs Kilo.** These are two different agents. *Kilo* (the
-`kilo` agent) is the OpenCode-based core at `~/.local/share/kilo/`; it
-covers both the Kilo CLI and the rebuilt Kilo Code VS Code extension,
-which share that same `kilo.db`. *Kilo (legacy)* (the `kilo-legacy` agent)
-is the legacy RooCode-derived VS Code extension that wrote per-task JSON
-under `kilocode.kilo-code/tasks/` and stopped receiving new sessions after
-Kilo rebuilt the extension on OpenCode (public beta 2026-03-10, GA
-2026-04-02). The `kilo-legacy` agent is frozen at that legacy format and
-only archives older sessions; newer Kilo VS Code activity appears under
-`kilo`.
+**Kilo (legacy) vs Kilo.** These are two different agents. *Kilo* (the `kilo`
+agent) is the OpenCode-based core at `~/.local/share/kilo/`; it covers both the
+Kilo CLI and the rebuilt Kilo Code VS Code extension, which share that same
+`kilo.db`. *Kilo (legacy)* (the `kilo-legacy` agent) is the legacy
+RooCode-derived VS Code extension that wrote per-task JSON under
+`kilocode.kilo-code/tasks/` and stopped receiving new sessions after Kilo
+rebuilt the extension on OpenCode (public beta 2026-03-10, GA 2026-04-02). The
+`kilo-legacy` agent is frozen at that legacy format and only archives older
+sessions; newer Kilo VS Code activity appears under `kilo`.
 
 **Antigravity CLI transcript sources:** Antigravity CLI has used both SQLite
 databases and AES-encrypted `.pb` files. AgentsView reads whichever source is
@@ -756,22 +769,23 @@ codex_sessions_dirs = [
 
 The corresponding fields are `aider_dirs`, `amp_dirs`, `antigravity_dirs`,
 `antigravity_cli_dirs`, `claude_project_dirs`, `openclaude_project_dirs`,
-`cowork_dirs`, `devin_dirs`, `codebuff_dirs`, `codex_sessions_dirs`, `commandcode_project_dirs`,
-`copilot_dirs`, `cortex_dirs`, `cursor_project_dirs`,
-`deepseek_harness_sessions_dirs`, `deepseek_tui_sessions_dirs`, `forge_dirs`,
-`gemini_dirs`, `goose_dirs`,
+`cowork_dirs`, `devin_dirs`, `codebuff_dirs`, `codex_sessions_dirs`,
+`commandcode_project_dirs`, `copilot_dirs`, `cortex_dirs`,
+`cursor_project_dirs`, `deepseek_harness_sessions_dirs`,
+`deepseek_tui_sessions_dirs`, `forge_dirs`, `gemini_dirs`, `goose_dirs`,
 `gptme_dirs`, `grok_dirs`, `hermes_sessions_dirs`, `iflow_dirs`, `kilo_dirs`,
 `kilo_legacy_dirs`, `kimi_dirs`, `kimi_work_dirs`, `kiro_dirs`, `kiro_ide_dirs`,
 `mimocode_dirs`, `vibe_session_dirs`, `omp_dirs`, `openclaw_dirs`,
-`opencode_dirs`, `openhands_dirs`, `pi_dirs`, `prime_agent_dirs`, `piebald_dirs`,
-`posit_assistant_dirs`, `positron_dirs`, `qclaw_dirs`, `qoder_project_dirs`,
-`qwen_project_dirs`, `qwenpaw_dirs`, `reasonix_dirs`, `roocode_dirs`,
-`shelley_dirs`, `traex_sessions_dirs`, `visualstudio_copilot_dirs`,
-`vscode_copilot_dirs`, `windsurf_dirs`, `warp_dirs`,
-`workbuddy_project_dirs`, `zcode_dirs`, `zed_dirs`, and `zencoder_dirs`. Each
-accepts an array of paths. Environment variables take precedence over these
-arrays when both are set; otherwise, a non-empty array replaces the default
-path and an explicit empty array clears the default local directory.
+`opencode_dirs`, `openhands_dirs`, `pi_dirs`, `prime_agent_dirs`,
+`piebald_dirs`, `posit_assistant_dirs`, `positron_dirs`, `qclaw_dirs`,
+`qoder_project_dirs`, `qwen_project_dirs`, `qwenpaw_dirs`, `reasonix_dirs`,
+`roocode_dirs`, `shelley_dirs`, `traex_sessions_dirs`,
+`visualstudio_copilot_dirs`, `vscode_copilot_dirs`, `windsurf_dirs`,
+`warp_dirs`, `workbuddy_project_dirs`, `zcode_dirs`, `zed_dirs`, and
+`zencoder_dirs`. Each accepts an array of paths. Environment variables take
+precedence over these arrays when both are set; otherwise, a non-empty array
+replaces the default path and an explicit empty array clears the default local
+directory.
 
 All listed directories are discovered, watched, and synced independently.
 
@@ -792,10 +806,10 @@ the per-agent arrays, defaults, and environment variables above. Equivalent
 roots are deduplicated; a structured entry supplies the machine label when it
 duplicates a shorthand root. An omitted `machine` uses the local hostname.
 
-Machine attribution is captured when each session is first ingested. Changing
-an entry's `machine` value affects newly discovered sessions but does not
-relabel existing sessions during ordinary syncs or `agentsview sync --full`.
-Changing attribution for existing sessions is not currently supported.
+Machine attribution is captured when each session is first ingested. Changing an
+entry's `machine` value affects newly discovered sessions but does not relabel
+existing sessions during ordinary syncs or `agentsview sync --full`. Changing
+attribution for existing sessions is not currently supported.
 
 See [Filesystem Session Sync](/filesystem-sync/) for multi-machine examples,
 transport safety, ID deduplication, watcher behavior, and the comparison with
@@ -869,21 +883,20 @@ manual sync, and the periodic directory scan.
 The parser infers a session's project from its `cwd`. It recognizes common
 worktree manager layouts, including the generic
 `worktrees/github.com/<owner>/<repository>/<worktree>` convention, where the
-repository segment becomes the project. Layouts it does not recognize — such
-as `~/code/{project}.worktrees/feat/<branch>/` — otherwise group sessions
-under `<branch>` rather than `{project}`. For those, register manual
-**path-prefix → project** rules from the **Rules** view on the
-[Data page](/data/#rules), or let the
-[mapping editor](/data/#create-a-project-mapping) create one from a project's
-observed session folders:
+repository segment becomes the project. Layouts it does not recognize — such as
+`~/code/{project}.worktrees/feat/<branch>/` — otherwise group sessions under
+`<branch>` rather than `{project}`. For those, register manual **path-prefix →
+project** rules from the **Rules** view on the [Data page](/data/#rules), or let
+the [mapping editor](/data/#create-a-project-mapping) create one from a
+project's observed session folders:
 
 ![Worktree mapping rules on the Data page](/assets/generated/screenshots/worktree-mappings.png)
 
 - Mappings are explicit; there is no auto-discovery.
-- Each rule is scoped to one machine. The machine selector manages rules for
-  the local machine and for any remotely synced machine. Rules live in the
-  writable archive that ingests that machine's sessions, which may be the
-  source machine's local SQLite archive or a separate collector archive.
+- Each rule is scoped to one machine. The machine selector manages rules for the
+  local machine and for any remotely synced machine. Rules live in the writable
+  archive that ingests that machine's sessions, which may be the source
+  machine's local SQLite archive or a separate collector archive.
 - Each rule applies whenever a session's `cwd` falls under the configured
   prefix, on both new sessions as they sync and (via the **Apply** button)
   already-imported sessions. Prefixes match on directory boundaries, so
@@ -895,10 +908,10 @@ observed session folders:
   the first path segment under the prefix when it is named `<repo>.worktrees`,
   so a path like `/code/agentsview.worktrees/feature/frontend` resolves to
   project `agentsview`.
-- Rules created from the Data mapping editor record the mislabeled
-  project they corrected, shown as the rule's **original label**. The value is
-  informational and set once; to manually revert a reclassification, edit the
-  rule's target back to that original label and apply again.
+- Rules created from the Data mapping editor record the mislabeled project they
+  corrected, shown as the rule's **original label**. The value is informational
+  and set once; to manually revert a reclassification, edit the rule's target
+  back to that original label and apply again.
 - Disabling or deleting a rule does not rewrite sessions by itself. Sessions
   whose source files still exist revert to parser-derived names on a later
   reparse or full resync, while orphaned sessions keep their stored
@@ -1010,17 +1023,15 @@ native watcher and periodic-sync freshness behavior. AgentsView reads only
 session identity and timestamp metadata from accepted hint records and neither
 stores nor logs submitted prompt text.
 
-For each configured local Codex session root, AgentsView probes
-`history.jsonl` in the cleaned root's parent. For example, a custom
-`/data/custom/sessions` root probes `/data/custom/history.jsonl`. It does not
-search ancestors or the rollout archive for another history file. Missing hint
-files remain cheap probes.
+For each configured local Codex session root, AgentsView probes `history.jsonl`
+in the cleaned root's parent. For example, a custom `/data/custom/sessions` root
+probes `/data/custom/history.jsonl`. It does not search ancestors or the rollout
+archive for another history file. Missing hint files remain cheap probes.
 
 The initial daemon poll bootstraps at most the newest 4 MiB of each history file
 and accepts records at most 24 hours old. If AgentsView restarts during a long
 autonomous run whose last persisted prompt is outside either bound, that rollout
-uses native-watcher freshness until another persisted prompt makes it hot
-again.
+uses native-watcher freshness until another persisted prompt makes it hot again.
 
 For `s3://` Claude and Codex roots, change detection uses object size,
 `LastModified`, and available object fingerprints such as ETag, version ID, and
@@ -1183,8 +1194,8 @@ Optional features that send data externally when you enable them:
 - The [DuckDB mirror](/duckdb/) writes a local DuckDB file by default; data only
   leaves the machine if you expose the mirror over a remote Quack endpoint.
 - [Generated insights](/recall/#current-surface) sends scoped session content to
-  the configured endpoint when `[insights]` is set, or to the selected agent
-  CLI when it is absent.
+  the configured endpoint when `[insights]` is set, or to the selected agent CLI
+  when it is absent.
 - [Publish to Gist](/usage/#publish-to-gist) uploads a session to GitHub.
 
 The automatic outbound requests are update checks and an anonymous daemon ping:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,7 @@
-______________________________________________________________________
-
-## title: Configuration description: Config file, default paths, and runtime settings
+---
+title: Configuration
+description: Config file, default paths, and runtime settings
+---
 
 ## Data Directory
 
@@ -9,11 +10,9 @@ AgentsView stores all persistent data under a single directory, defaulting to
 
 !!! note
 
-```
-`AGENT_VIEWER_DATA_DIR` is still accepted as a legacy fallback when
-`AGENTSVIEW_DATA_DIR` is unset, but new setups should use
-`AGENTSVIEW_DATA_DIR`.
-```
+    `AGENT_VIEWER_DATA_DIR` is still accepted as a legacy fallback when
+    `AGENTSVIEW_DATA_DIR` is unset, but new setups should use
+    `AGENTSVIEW_DATA_DIR`.
 
 ```
 ~/.agentsview/
@@ -27,10 +26,10 @@ AgentsView stores all persistent data under a single directory, defaulting to
 └── uploads/         # Uploaded session files
 ```
 
-`usage-cache-v1-<id>.db` is a derived cache of usage aggregates, not user data.
-It is safe to delete when no AgentsView process is running; the next usage query
-rebuilds it automatically. `sessions.db` remains the only file that needs
-backing up.
+`usage-cache-v1-<id>.db` is a derived cache of usage aggregates, not user
+data. It is safe to delete when no AgentsView process is running; the next
+usage query rebuilds it automatically. `sessions.db` remains the only file
+that needs backing up.
 
 The desktop app and CLI share a detached local daemon for fresh reads and
 writes. A running daemon owns local SQLite writes for this data directory and
@@ -52,11 +51,9 @@ stores persistent settings that survive restarts.
 
 !!! note
 
-```
-The config format changed from JSON to TOML. Existing `config.json` files
-are automatically migrated to `config.toml` on first run (the JSON file is
-renamed to `config.json.bak`).
-```
+    The config format changed from JSON to TOML. Existing `config.json` files
+    are automatically migrated to `config.toml` on first run (the JSON file is
+    renamed to `config.json.bak`).
 
 ```toml
 cursor_secret = "base64-encoded-secret"
@@ -81,7 +78,7 @@ chart_palette = "agentsview"
 | `public_origins`                    | Array of additional trusted CORS origins                                                                                                                                                                                                             |
 | `daemon_idle_timeout`               | Idle timeout for detached writable daemons; set to `"0s"` to keep them alive                                                                                                                                                                         |
 | `chart_palette`                     | Server-wide categorical chart colors: `"agentsview"` (default) or `"matplotlib"`; also configurable under **Settings > Appearance**                                                                                                                  |
-| `disabled_agents`                   | Session providers to exclude from local filesystem scanning; changes require a daemon restart — see [Disabling Session Providers](#disabling-session-providers)                                                                                      |
+| `disabled_agents`                   | Session providers to exclude from local filesystem scanning; changes require a daemon restart — see [Disabling Session Providers](#disabling-session-providers)                                                                                     |
 | `[proxy]`                           | Managed proxy configuration table — see [Remote Access](/remote-access/)                                                                                                                                                                             |
 | `disable_update_check`              | Disable the automatic update check (see [Privacy](#privacy-and-telemetry))                                                                                                                                                                           |
 | `scan_protected_paths`              | Allow Git discovery inside macOS privacy-protected folders, accepting one consent prompt per folder — see [macOS Protected Folders](#macos-protected-folders)                                                                                        |
@@ -89,7 +86,7 @@ chart_palette = "agentsview"
 | `[duckdb]`                          | DuckDB mirror configuration — see [DuckDB Mirror](/duckdb/)                                                                                                                                                                                          |
 | `[vector]`                          | Opt-in semantic-search index; model settings live in `[vector.embeddings]`, named endpoints in `[vector.embeddings.servers.<name>]`, embedding schedule in `[vector.embed]` — see [Semantic Search](/semantic-search/#enabling-vector) for every key |
 | `[recall.extract]`                  | Opt-in model-backed recall extraction; named endpoints in `[recall.extract.servers.<name>]`, prompt selection in `[recall.extract.prompts]`, request overrides in `[recall.extract.request]` — see [Recall](/recall/#automatic-extraction)           |
-| `[insights]`                        | Optional generated-insights endpoint and model; local loopback HTTP is allowed, remote plaintext requires `allow_http = true`, and endpoint failures do not retry through a CLI — see [Recall](/recall/#current-surface)                             |
+| `[insights]`                        | Optional generated-insights endpoint and model; local loopback HTTP is allowed, remote plaintext requires `allow_http = true`, and endpoint failures do not retry through a CLI — see [Recall](/recall/#current-surface) |
 | `[[remote_hosts]]`                  | Remote machines synced by a bare `agentsview sync` — see [CLI Reference](/commands/#agentsview-sync)                                                                                                                                                 |
 | `[[session_sources]]`               | Additional filesystem session roots with per-root machine labels — see [Filesystem Session Sync](/filesystem-sync/)                                                                                                                                  |
 | `[automated]`                       | Custom automated-session patterns — see [Automated Session Detection](#automated-session-detection)                                                                                                                                                  |
@@ -116,11 +113,9 @@ both are set.
 
 !!! note
 
-```
-Older configs may still contain `remote_access = true`. AgentsView still
-reads that legacy key for backward compatibility, but new setups should use
-`require_auth = true`.
-```
+    Older configs may still contain `remote_access = true`. AgentsView still
+    reads that legacy key for backward compatibility, but new setups should use
+    `require_auth = true`.
 
 ## Remote Hosts
 
@@ -157,12 +152,12 @@ deltas when fewer than half of the manifest files need fetching; see
 [Remote Access — Incremental Sync](/remote-access/#incremental-sync).
 
 When a full or automatic data-version rebuild includes local sources, configured
-HTTP hosts join the same temporary-database bulk ingest and atomic swap.
-`--full` reparses the complete local and remote corpus without retransferring
-unchanged files from manifest-capable spokes. HTTP remote sync requires the
-collector and remote daemon to use the same remote-sync protocol version. After
-upgrading either host, upgrade the other before syncing again; incompatible
-peers fail before targets or archive data are exchanged.
+HTTP hosts join the same temporary-database bulk ingest and atomic swap. `--full`
+reparses the complete local and remote corpus without retransferring unchanged
+files from manifest-capable spokes. HTTP remote sync requires the collector and
+remote daemon to use the same remote-sync protocol version. After upgrading
+either host, upgrade the other before syncing again; incompatible peers fail
+before targets or archive data are exchanged.
 
 Each `remote_hosts.host` value must be unique and stable. It namespaces imported
 session IDs, the database skip cache, and the persistent mirror; changing it for
@@ -172,8 +167,9 @@ can reuse stale state. A configured HTTP host can be selected later with
 without a matching configured host, `--host` remains an SSH remote sync. HTTP
 remote sync is the recommended transport. SSH remote sync is deprecated and
 receives only critical fixes. HTTP failures are summarized with actionable
-messages for common cases such as token rejection, missing remote archive
-endpoints, connection refusal, DNS failures, and timeouts.
+messages for common cases such as token
+rejection, missing remote archive endpoints, connection refusal, DNS failures,
+and timeouts.
 
 Set `interval` to a positive duration such as `"5m"` to have a running collector
 daemon sync that host periodically. Zero or omitted disables the per-host
@@ -248,75 +244,74 @@ server-side and leave only local stubs; historical local Amp thread JSON files
 can still be parsed.
 
 The matching environment variable and `*_dirs` configuration key override an
-agent's default directories. Environment variables take precedence when both are
-set. An explicit empty `*_dirs` array, such as `grok_dirs = []`, clears that
+agent's default directories. Environment variables take precedence when both
+are set. An explicit empty `*_dirs` array, such as `grok_dirs = []`, clears that
 agent's default local directories, so local discovery finds nothing there.
 Matching `session_sources` entries for that agent still apply. Provider-wide
-exclusion is documented under
-[Disabling Session Providers](#disabling-session-providers). Omitting the key
-keeps its default directories.
+exclusion is documented under [Disabling Session Providers](#disabling-session-providers).
+Omitting the key keeps its default directories.
 
-| Agent                 | Default Directory                                                                                                                                                | File Format                                                                                                                                                   |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Aider                 | No default; opt in with `AIDER_DIR` or `aider_dirs`                                                                                                              | `.aider.chat.history.md` Markdown history files                                                                                                               |
-| Amp (deprecated)      | `~/.local/share/amp/threads/`                                                                                                                                    | Historical local JSON thread files                                                                                                                            |
-| Antigravity (IDE)     | `~/.gemini/antigravity/`                                                                                                                                         | SQLite database per session                                                                                                                                   |
-| Antigravity CLI       | `~/.gemini/antigravity-cli/`                                                                                                                                     | SQLite `conversations/<uuid>.db`, `<uuid>.trajectory.json` sidecars, or encrypted `.pb` files plus `brain/` and `history.jsonl`                               |
-| Claude Code           | `~/.claude/projects/`                                                                                                                                            | JSONL per session                                                                                                                                             |
-| OpenClaude            | `~/.openclaude/projects/`                                                                                                                                        | JSONL per session                                                                                                                                             |
-| Claude Cowork         | (platform-specific, see below)                                                                                                                                   | Claude Desktop cowork sessions                                                                                                                                |
-| Codebuff / Freebuff   | `~/.config/manicode/projects/`                                                                                                                                   | Per-session `chat-messages.json` + `run-state.json` with subagent transcripts                                                                                 |
-| Codex                 | `~/.codex/sessions/` and `~/.codex/archived_sessions/`                                                                                                           | JSONL per session                                                                                                                                             |
-| Command Code          | `~/.commandcode/projects/`                                                                                                                                       | JSONL per session, optional `.meta.json` sidecar                                                                                                              |
-| Copilot CLI           | `~/.copilot/`                                                                                                                                                    | JSONL per session under `session-state/`                                                                                                                      |
-| Devin CLI             | `~/.local/share/devin/` (Linux), `~/Library/Application Support/devin/` (macOS)                                                                                  | Local CLI data rooted at the directory that contains `cli/`; session data is discovered under `<root>/cli/...`                                                |
-| Cortex Code           | `~/.snowflake/cortex/conversations/`                                                                                                                             | JSON / JSONL per session                                                                                                                                      |
-| Cursor                | `~/.cursor/projects/`                                                                                                                                            | JSONL or plain-text transcripts                                                                                                                               |
-| DeepSeek TUI          | `~/.codewhale/sessions/` and `~/.deepseek/sessions/`                                                                                                             | JSON per session                                                                                                                                              |
-| DeepSeek Harness      | `~/.dsh/sessions/` (or `$DSH_HOME/sessions/`)                                                                                                                    | Plain or multi-frame zstd JSONL per session                                                                                                                   |
-| Forge                 | `~/.forge/`                                                                                                                                                      | SQLite database (`.forge.db`)                                                                                                                                 |
-| Gemini CLI            | `~/.gemini/`                                                                                                                                                     | JSONL in `tmp/` subdirectory                                                                                                                                  |
-| Goose                 | (platform-specific, see below)                                                                                                                                   | SQLite `sessions.db` with transcripts, tool activity, relationships, usage, and recorded costs                                                                |
-| gptme                 | `~/.local/share/gptme/logs/`                                                                                                                                     | JSONL logs                                                                                                                                                    |
-| Grok                  | `~/.grok/sessions/`                                                                                                                                              | `summary.json` + optional `signals.json` + `chat_history.jsonl` transcript when present                                                                       |
-| Hermes Agent          | `~/.hermes/sessions/`                                                                                                                                            | JSONL / JSON per session                                                                                                                                      |
-| iFlow                 | `~/.iflow/projects/`                                                                                                                                             | JSONL per session                                                                                                                                             |
-| Kilo                  | `~/.local/share/kilo/`                                                                                                                                           | SQLite DB or `storage/` JSON files                                                                                                                            |
-| Kimi                  | `~/.kimi/sessions/` and `~/.kimi-code/sessions/`                                                                                                                 | JSONL per session                                                                                                                                             |
-| Kimi Work             | (platform-specific, see below)                                                                                                                                   | JSONL per session (kimi-code kernel wire logs)                                                                                                                |
-| Kiro CLI              | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/`                                                                                                           | JSONL per session and SQLite database                                                                                                                         |
-| Kiro IDE              | (platform-specific, see below)                                                                                                                                   | JSON / chat files                                                                                                                                             |
-| Kilo (legacy)         | (platform-specific, see below)                                                                                                                                   | `tasks/<uuid>/{task_metadata.json,ui_messages.json,api_conversation_history.json}`                                                                            |
-| MiMoCode              | `~/.local/share/mimocode/`                                                                                                                                       | SQLite DB or `storage/` JSON files                                                                                                                            |
-| Mistral Vibe          | `~/.vibe/logs/session/`                                                                                                                                          | Per-session `messages.jsonl` plus `meta.json`                                                                                                                 |
-| OhMyPi                | `~/.omp/agent/sessions/`                                                                                                                                         | JSONL per session                                                                                                                                             |
-| OpenClaw              | `~/.openclaw/assets/static/agents/` and `~/.kimi_openclaw/assets/static/agents/`                                                                                 | JSONL per session                                                                                                                                             |
-| OpenCode              | `~/.local/share/opencode/`                                                                                                                                       | SQLite DB or `storage/` JSON files                                                                                                                            |
-| OpenHands CLI         | `~/.openhands/conversations/`                                                                                                                                    | Per-conversation `base_state.json` + `events/*.json`                                                                                                          |
-| Omnigent              | `~/.omnigent/`                                                                                                                                                   | SQLite `chat.db`, one session per conversation                                                                                                                |
-| Pi                    | `~/.pi/agent/sessions/`                                                                                                                                          | JSONL per session                                                                                                                                             |
-| Prime Agent           | `~/.prime/agent/sessions/`                                                                                                                                       | Flat Pi-family JSONL sessions                                                                                                                                 |
-| Poolside              | `~/Library/Application Support/poolside/trajectories/` (macOS), `~/.local/state/poolside/trajectories/` (Linux), `%APPDATA%\\poolside\\trajectories\\` (Windows) | NDJSON trajectory files                                                                                                                                       |
-| Piebald               | `~/.local/share/piebald/`                                                                                                                                        | SQLite database (`app.db`)                                                                                                                                    |
-| Posit Assistant       | `~/.posit/assistant/workspaces/`                                                                                                                                 | Per-conversation `conversation.json` tree plus `lm-messages.jsonl` transcript                                                                                 |
-| Positron Assistant    | (platform-specific, see below)                                                                                                                                   | JSON / JSONL per session                                                                                                                                      |
-| QClaw                 | `~/.qclaw/assets/static/agents/`                                                                                                                                 | JSONL per session                                                                                                                                             |
-| Qoder                 | Legacy export roots plus platform-specific `SharedClientCache` (see below)                                                                                       | JSONL project transcripts plus sidecar metadata                                                                                                               |
-| Qwen Code             | `~/.qwen/projects/`                                                                                                                                              | JSONL per session                                                                                                                                             |
-| QwenPaw               | `~/.copaw/workspaces/`                                                                                                                                           | JSON session files                                                                                                                                            |
-| Reasonix              | `~/.reasonix/` and `~/AppData/Roaming/reasonix/`                                                                                                                 | JSONL sessions plus `.jsonl.meta` sidecars                                                                                                                    |
-| RooCode               | (platform-specific, see below)                                                                                                                                   | `history_item.json` + `ui_messages.json` per task                                                                                                             |
-| Shelley               | `~/.config/shelley/`                                                                                                                                             | SQLite database (`shelley.db`)                                                                                                                                |
-| Visual Studio Copilot | (platform-specific, see below)                                                                                                                                   | Trace JSONL files                                                                                                                                             |
-| VS Code Copilot       | (platform-specific, see below)                                                                                                                                   | JSON / JSONL per session                                                                                                                                      |
-| Windsurf              | (platform-specific, see below)                                                                                                                                   | SQLite `workspaceStorage/<hash>/state.vscdb` workspace chat data                                                                                              |
-| Trae                  | (platform-specific, see below)                                                                                                                                   | Legacy inline chat data in SQLite `workspaceStorage/<hash>/state.vscdb` and `globalStorage/state.vscdb`; modern encrypted layouts are detected as unsupported |
-| TraeX (TRAE CLI)      | `~/.trae/cli/sessions/` and `~/.trae/cli/archived_sessions/`                                                                                                     | Codex-compatible rollout JSONL per session                                                                                                                    |
-| Warp                  | (platform-specific, see below)                                                                                                                                   | SQLite database                                                                                                                                               |
-| WorkBuddy             | `~/.workbuddy/projects/`                                                                                                                                         | JSONL per session                                                                                                                                             |
-| ZCode                 | `~/.zcode/cli/db/` or `~/.zcode/cli/`                                                                                                                            | SQLite database (`db.sqlite`) with usage rows                                                                                                                 |
-| Zed                   | (platform-specific, see below)                                                                                                                                   | SQLite database (`threads/threads.db`)                                                                                                                        |
-| Zencoder              | `~/.zencoder/sessions/`                                                                                                                                          | JSONL per session                                                                                                                                             |
+| Agent                 | Default Directory                                                                | File Format                                                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Aider                 | No default; opt in with `AIDER_DIR` or `aider_dirs`                              | `.aider.chat.history.md` Markdown history files                                                                                 |
+| Amp (deprecated)      | `~/.local/share/amp/threads/`                                                    | Historical local JSON thread files                                                                                              |
+| Antigravity (IDE)     | `~/.gemini/antigravity/`                                                         | SQLite database per session                                                                                                     |
+| Antigravity CLI       | `~/.gemini/antigravity-cli/`                                                     | SQLite `conversations/<uuid>.db`, `<uuid>.trajectory.json` sidecars, or encrypted `.pb` files plus `brain/` and `history.jsonl` |
+| Claude Code           | `~/.claude/projects/`                                                            | JSONL per session                                                                                                               |
+| OpenClaude            | `~/.openclaude/projects/`                                                        | JSONL per session                                                                                                               |
+| Claude Cowork         | (platform-specific, see below)                                                   | Claude Desktop cowork sessions                                                                                                  |
+| Codebuff / Freebuff   | `~/.config/manicode/projects/`                                                   | Per-session `chat-messages.json` + `run-state.json` with subagent transcripts                                                  |
+| Codex                 | `~/.codex/sessions/` and `~/.codex/archived_sessions/`                           | JSONL per session                                                                                                               |
+| Command Code          | `~/.commandcode/projects/`                                                       | JSONL per session, optional `.meta.json` sidecar                                                                                |
+| Copilot CLI           | `~/.copilot/`                                                                    | JSONL per session under `session-state/`                                                                                        |
+| Devin CLI             | `~/.local/share/devin/` (Linux), `~/Library/Application Support/devin/` (macOS)  | Local CLI data rooted at the directory that contains `cli/`; session data is discovered under `<root>/cli/...`                  |
+| Cortex Code           | `~/.snowflake/cortex/conversations/`                                             | JSON / JSONL per session                                                                                                        |
+| Cursor                | `~/.cursor/projects/`                                                            | JSONL or plain-text transcripts                                                                                                 |
+| DeepSeek TUI          | `~/.codewhale/sessions/` and `~/.deepseek/sessions/`                             | JSON per session                                                                                                                |
+| DeepSeek Harness      | `~/.dsh/sessions/` (or `$DSH_HOME/sessions/`)                                    | Plain or multi-frame zstd JSONL per session                                                                                     |
+| Forge                 | `~/.forge/`                                                                      | SQLite database (`.forge.db`)                                                                                                   |
+| Gemini CLI            | `~/.gemini/`                                                                     | JSONL in `tmp/` subdirectory                                                                                                    |
+| Goose                 | (platform-specific, see below)                                                   | SQLite `sessions.db` with transcripts, tool activity, relationships, usage, and recorded costs                                  |
+| gptme                 | `~/.local/share/gptme/logs/`                                                     | JSONL logs                                                                                                                      |
+| Grok                  | `~/.grok/sessions/`                                                              | `summary.json` + optional `signals.json` + `chat_history.jsonl` transcript when present                                         |
+| Hermes Agent          | `~/.hermes/sessions/`                                                            | JSONL / JSON per session                                                                                                        |
+| iFlow                 | `~/.iflow/projects/`                                                             | JSONL per session                                                                                                               |
+| Kilo                  | `~/.local/share/kilo/`                                                           | SQLite DB or `storage/` JSON files                                                                                              |
+| Kimi                  | `~/.kimi/sessions/` and `~/.kimi-code/sessions/`                                 | JSONL per session                                                                                                               |
+| Kimi Work             | (platform-specific, see below)                                                   | JSONL per session (kimi-code kernel wire logs)                                                                                  |
+| Kiro CLI              | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/`                           | JSONL per session and SQLite database                                                                                           |
+| Kiro IDE              | (platform-specific, see below)                                                   | JSON / chat files                                                                                                               |
+| Kilo (legacy)         | (platform-specific, see below)                                                   | `tasks/<uuid>/{task_metadata.json,ui_messages.json,api_conversation_history.json}`                                              |
+| MiMoCode              | `~/.local/share/mimocode/`                                                       | SQLite DB or `storage/` JSON files                                                                                              |
+| Mistral Vibe          | `~/.vibe/logs/session/`                                                          | Per-session `messages.jsonl` plus `meta.json`                                                                                   |
+| OhMyPi                | `~/.omp/agent/sessions/`                                                         | JSONL per session                                                                                                               |
+| OpenClaw              | `~/.openclaw/assets/static/agents/` and `~/.kimi_openclaw/assets/static/agents/` | JSONL per session                                                                                                               |
+| OpenCode              | `~/.local/share/opencode/`                                                       | SQLite DB or `storage/` JSON files                                                                                              |
+| OpenHands CLI         | `~/.openhands/conversations/`                                                    | Per-conversation `base_state.json` + `events/*.json`                                                                            |
+| Omnigent              | `~/.omnigent/`                                                                   | SQLite `chat.db`, one session per conversation                                                                                  |
+| Pi                    | `~/.pi/agent/sessions/`                                                          | JSONL per session                                                                                                               |
+| Prime Agent           | `~/.prime/agent/sessions/`                                                       | Flat Pi-family JSONL sessions                                                                                                   |
+| Poolside              | `~/Library/Application Support/poolside/trajectories/` (macOS), `~/.local/state/poolside/trajectories/` (Linux), `%APPDATA%\\poolside\\trajectories\\` (Windows) | NDJSON trajectory files                                                                                                         |
+| Piebald               | `~/.local/share/piebald/`                                                        | SQLite database (`app.db`)                                                                                                      |
+| Posit Assistant       | `~/.posit/assistant/workspaces/`                                                 | Per-conversation `conversation.json` tree plus `lm-messages.jsonl` transcript                                                   |
+| Positron Assistant    | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
+| QClaw                 | `~/.qclaw/assets/static/agents/`                                                 | JSONL per session                                                                                                               |
+| Qoder                 | Legacy export roots plus platform-specific `SharedClientCache` (see below)       | JSONL project transcripts plus sidecar metadata                                                                                 |
+| Qwen Code             | `~/.qwen/projects/`                                                              | JSONL per session                                                                                                               |
+| QwenPaw               | `~/.copaw/workspaces/`                                                           | JSON session files                                                                                                              |
+| Reasonix              | `~/.reasonix/` and `~/AppData/Roaming/reasonix/`                                 | JSONL sessions plus `.jsonl.meta` sidecars                                                                                      |
+| RooCode               | (platform-specific, see below)                                                   | `history_item.json` + `ui_messages.json` per task                                                                              |
+| Shelley               | `~/.config/shelley/`                                                             | SQLite database (`shelley.db`)                                                                                                  |
+| Visual Studio Copilot | (platform-specific, see below)                                                   | Trace JSONL files                                                                                                               |
+| VS Code Copilot       | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
+| Windsurf              | (platform-specific, see below)                                                   | SQLite `workspaceStorage/<hash>/state.vscdb` workspace chat data                                                                |
+| Trae                  | (platform-specific, see below)                                                   | Legacy inline chat data in SQLite `workspaceStorage/<hash>/state.vscdb` and `globalStorage/state.vscdb`; modern encrypted layouts are detected as unsupported |
+| TraeX (TRAE CLI)      | `~/.trae/cli/sessions/` and `~/.trae/cli/archived_sessions/`                     | Codex-compatible rollout JSONL per session                                                                                      |
+| Warp                  | (platform-specific, see below)                                                   | SQLite database                                                                                                                 |
+| WorkBuddy             | `~/.workbuddy/projects/`                                                         | JSONL per session                                                                                                               |
+| ZCode                 | `~/.zcode/cli/db/` or `~/.zcode/cli/`                                            | SQLite database (`db.sqlite`) with usage rows                                                                                   |
+| Zed                   | (platform-specific, see below)                                                   | SQLite database (`threads/threads.db`)                                                                                          |
+| Zencoder              | `~/.zencoder/sessions/`                                                          | JSONL per session                                                                                                               |
 
 DeepSeek Harness sessions are read from its default JSONL persistence backend,
 including plain `session.jsonl` and multi-frame `session.jsonl.zstd` files.
@@ -326,9 +321,9 @@ directly at one or more session roots. The optional SQLite persistence backend
 is not supported.
 
 Prime Agent support targets the current flat session layout in v0.7.0. That
-release migrates the older per-project layout when Prime Agent opens its session
-store, so open the current Prime Agent once before syncing a legacy archive with
-AgentsView.
+release migrates the older per-project layout when Prime Agent opens its
+session store, so open the current Prime Agent once before syncing a legacy
+archive with AgentsView.
 
 **Qoder default directories** include the legacy `~/.qoder/projects/` and
 `~/.qoderwork/projects/` export roots plus the current IDE store:
@@ -342,10 +337,10 @@ Set `QODER_PROJECTS_DIR` or `qoder_project_dirs` to replace these defaults with
 one or more explicit roots.
 
 Grok sessions are read from `summary.json` (title, timestamps, project),
-optional `signals.json` (token counters), and `chat_history.jsonl` when present
-for the full transcript (user turns, assistant replies, thinking, and tool
-calls). If `chat_history.jsonl` is missing, AgentsView falls back to
-summary-only mode. Set `GROK_DIR` or `grok_dirs` to override the default
+optional `signals.json` (token counters), and `chat_history.jsonl` when
+present for the full transcript (user turns, assistant replies, thinking,
+and tool calls). If `chat_history.jsonl` is missing, AgentsView falls back
+to summary-only mode. Set `GROK_DIR` or `grok_dirs` to override the default
 directory.
 
 **Goose default directories** are:
@@ -355,18 +350,18 @@ directory.
 
 `GOOSE_PATH_ROOT` follows Goose's own path-root convention and resolves
 `<root>/data/sessions/sessions.db`. A `goose_dirs` entry may instead point
-directly to that sessions directory, its parent data directory, or the database
-file.
+directly to that sessions directory, its parent data directory, or the
+database file.
 
 Omnigent sessions are read from `~/.omnigent/chat.db`. Set `OMNIGENT_DIR` or
 `omnigent_dirs` to override the default directory. AgentsView creates one
-session per conversation and supports the split text-ID and current binary-UUID
-schema generations; the older single-table schema is detected and reported as
-unsupported without losing sessions already synced from it. Remote HTTP and SSH
-sync stay disabled for Omnigent because `chat.db` co-locates transcripts with
-authentication secrets. A metadata-only edit made directly in `chat.db` can be
-deferred by the immediate filesystem-event sync; the next scheduled
-reconciliation pass or an explicit resync picks it up.
+session per conversation and supports the split text-ID and current
+binary-UUID schema generations; the older single-table schema is detected and
+reported as unsupported without losing sessions already synced from it.
+Remote HTTP and SSH sync stay disabled for Omnigent because `chat.db`
+co-locates transcripts with authentication secrets. A metadata-only edit made
+directly in `chat.db` can be deferred by the immediate filesystem-event sync;
+the next scheduled reconciliation pass or an explicit resync picks it up.
 
 **VS Code Copilot default directories** vary by platform:
 
@@ -397,35 +392,31 @@ Windsurf stores workspace chats in `workspaceStorage/<hash>/state.vscdb`.
 
 **Trae default directories** vary by platform:
 
-- **macOS:** `~/Library/Application Support/Trae/User/`, `Trae CN/User/`, and
-  `TRAE SOLO CN/User/`
+- **macOS:** `~/Library/Application Support/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
 - **Linux:** `~/.config/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
 - **Windows:** `%APPDATA%/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
 
 Trae stores chats in `workspaceStorage/<hash>/state.vscdb` and
 `globalStorage/state.vscdb`. Override these roots with `TRAE_DIR` or the
-`trae_dirs` configuration key. AgentsView watches `workspaceStorage` and
-`globalStorage`, then reads chat records from those SQLite stores.
+`trae_dirs` configuration key.
+AgentsView watches `workspaceStorage` and `globalStorage`, then reads chat
+records from those SQLite stores.
 
 Trae legacy inline-message parsing is supported. Modern encrypted transcript
 layouts are detected and reported as unsupported. Remote HTTP and SSH target
-resolution is still disabled. A Trae root is a full user profile, and AgentsView
-does not archive or ship that profile wholesale. The follow-up path is
-Windsurf-style curated file targets only: `state.vscdb`, `state.vscdb-wal`, and
+resolution is still disabled. A Trae root is a full user profile, and AgentsView does not
+archive or ship that profile wholesale. The follow-up path is Windsurf-style
+curated file targets only: `state.vscdb`, `state.vscdb-wal`, and
 `workspace.json` for each supported workspace store.
 
 **Kimi Work default directories** vary by platform. Kimi Work is the
 kimi-desktop app (the "daimon" runtime); it stores conversations as kimi-code
-kernel wire logs under
-`<root>/wd_<workspace>_<hash>/<session>/agents/<agent>/wire.jsonl`:
+kernel wire logs under `<root>/wd_<workspace>_<hash>/<session>/agents/<agent>/wire.jsonl`:
 
-- **macOS:**
-  `~/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
-- **Linux:**
-  `~/.config/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **macOS:** `~/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **Linux:** `~/.config/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
   (or `~/.local/share/...` on some installs)
-- **Windows:**
-  `%APPDATA%/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **Windows:** `%APPDATA%/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
 
 Only `conv-*` session directories are user conversations; auxiliary internal
 sessions (`ctitle-*`, `sklsum-*`, `dvlt-*`) are excluded from discovery. Set
@@ -478,25 +469,28 @@ independently.
 
 Subagent tool calls (basher, code-searcher, file-picker, code-reviewer, etc.)
 are parsed from the AI message blocks and displayed inline in the transcript
-view. The agent template (e.g. `base2-free-deepseek`, `base2-free-mimo`) is read
-from run-state.json's `agentType` field and shown in the session detail header.
-This is the classification label used server-side to pick the per-step LLM; the
-literal LLM is not persisted by the CLI and is not visible in the UI. Project
-names are derived from the session's working directory via git-root detection.
+view. The agent template (e.g. `base2-free-deepseek`, `base2-free-mimo`) is
+read from run-state.json's `agentType` field and shown in the session
+detail header. This is the classification label used server-side to pick
+the per-step LLM; the literal LLM is not persisted by the CLI and is
+not visible in the UI.
+Project names are derived from the session's working directory via git-root
+detection.
 
-Codebuff and Freebuff sessions report cost only. The CLI's on-disk format does
-not persist per-message input/output/cache tokens, so the daily usage model
-breakdown shows the cost-attributed agent template (e.g. `base2-deepseek`,
-`base2-free-minimax-m3`) without per-message token figures. Reported-cost rows
-ride as microdollars on `money.Money` like every other agent, and per-model
-rates for `base2-*` templates are not in the embedded pricing tables, so cache
-savings for these rows resolve to zero by design rather than an aggregator bug.
+Codebuff and Freebuff sessions report cost only. The CLI's on-disk
+format does not persist per-message input/output/cache tokens, so the
+daily usage model breakdown shows the cost-attributed agent template
+(e.g. `base2-deepseek`, `base2-free-minimax-m3`) without per-message
+token figures. Reported-cost rows ride as microdollars on `money.Money`
+like every other agent, and per-model rates for `base2-*` templates are
+not in the embedded pricing tables, so cache savings for these rows
+resolve to zero by design rather than an aggregator bug.
 
 Freebuff does not have its own environment variable or config key — it shares
-the Codebuff provider for discovery and the parser auto-classifies sessions. Set
-`CODEBUFF_DIR` or `codebuff_dirs` when manicode stores its projects directory
-somewhere other than `~/.config/manicode/projects`; this covers both Codebuff
-and Freebuff sessions.
+the Codebuff provider for discovery and the parser auto-classifies sessions.
+Set `CODEBUFF_DIR` or `codebuff_dirs` when manicode stores its projects
+directory somewhere other than `~/.config/manicode/projects`; this covers both
+Codebuff and Freebuff sessions.
 
 **OpenHands CLI shallow watch:** OpenHands stores each conversation in its own
 subdirectory, which would consume one recursive file watch per session and can
@@ -575,18 +569,17 @@ names and per-request token usage.
 - **macOS:**
   `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
 - **Linux:** `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
-- **Windows:**
-  `~/AppData/Roaming/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
+- **Windows:** `~/AppData/Roaming/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
 
-RooCode (rooveterinaryinc.roo-cline) is a VSCode extension that stores sessions
-under `tasks/<taskId>/` in VSCode's globalStorage directory. Each task directory
-contains `history_item.json` (metadata including task description, model name,
-workspace path, token counts, and recorded cost) and `ui_messages.json` (the
-Cline-format transcript with user prompts, assistant responses, reasoning
-blocks, and tool calls). AgentsView parses the `apiConfigName` field from
-`history_item.json` as the session model, extracts project names from the
-workspace path via git-root detection, and emits the recorded `totalCost` as a
-usage event for cost tracking.
+RooCode (rooveterinaryinc.roo-cline) is a VSCode extension that stores
+sessions under `tasks/<taskId>/` in VSCode's globalStorage directory. Each task
+directory contains `history_item.json` (metadata including task description,
+model name, workspace path, token counts, and recorded cost) and
+`ui_messages.json` (the Cline-format transcript with user prompts, assistant
+responses, reasoning blocks, and tool calls). AgentsView parses the
+`apiConfigName` field from `history_item.json` as the session model, extracts
+project names from the workspace path via git-root detection, and emits the
+recorded `totalCost` as a usage event for cost tracking.
 
 RooCode was shut down on May 15, 2026. ZooCode (Zoo-CodeInc.zoo-cline) is the
 active community fork and will be supported separately. Set `ROOCODE_DIR` or
@@ -596,8 +589,7 @@ active community fork and will be supported separately. Set `ROOCODE_DIR` or
 canonical lowercase `kilocode.kilo-code` global storage directory that VSCode
 writes on disk:
 
-- **macOS:**
-  `~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code/`
+- **macOS:** `~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code/`
 - **Linux:** `~/.config/Code/User/globalStorage/kilocode.kilo-code/`
 - **Windows:** `%APPDATA%/Code/User/globalStorage/kilocode.kilo-code/`
 
@@ -611,15 +603,16 @@ a reparse. Sessions are parsed through RooCode-descended Cline message handling
 linking). Set `KILO_LEGACY_DIR` or `kilo_legacy_dirs` when the legacy extension
 stores its data outside the standard locations.
 
-**Kilo (legacy) vs Kilo.** These are two different agents. *Kilo* (the `kilo`
-agent) is the OpenCode-based core at `~/.local/share/kilo/`; it covers both the
-Kilo CLI and the rebuilt Kilo Code VS Code extension, which share that same
-`kilo.db`. *Kilo (legacy)* (the `kilo-legacy` agent) is the legacy
-RooCode-derived VS Code extension that wrote per-task JSON under
-`kilocode.kilo-code/tasks/` and stopped receiving new sessions after Kilo
-rebuilt the extension on OpenCode (public beta 2026-03-10, GA 2026-04-02). The
-`kilo-legacy` agent is frozen at that legacy format and only archives older
-sessions; newer Kilo VS Code activity appears under `kilo`.
+**Kilo (legacy) vs Kilo.** These are two different agents. *Kilo* (the
+`kilo` agent) is the OpenCode-based core at `~/.local/share/kilo/`; it
+covers both the Kilo CLI and the rebuilt Kilo Code VS Code extension,
+which share that same `kilo.db`. *Kilo (legacy)* (the `kilo-legacy` agent)
+is the legacy RooCode-derived VS Code extension that wrote per-task JSON
+under `kilocode.kilo-code/tasks/` and stopped receiving new sessions after
+Kilo rebuilt the extension on OpenCode (public beta 2026-03-10, GA
+2026-04-02). The `kilo-legacy` agent is frozen at that legacy format and
+only archives older sessions; newer Kilo VS Code activity appears under
+`kilo`.
 
 **Antigravity CLI transcript sources:** Antigravity CLI has used both SQLite
 databases and AES-encrypted `.pb` files. AgentsView reads whichever source is
@@ -769,23 +762,22 @@ codex_sessions_dirs = [
 
 The corresponding fields are `aider_dirs`, `amp_dirs`, `antigravity_dirs`,
 `antigravity_cli_dirs`, `claude_project_dirs`, `openclaude_project_dirs`,
-`cowork_dirs`, `devin_dirs`, `codebuff_dirs`, `codex_sessions_dirs`,
-`commandcode_project_dirs`, `copilot_dirs`, `cortex_dirs`,
-`cursor_project_dirs`, `deepseek_harness_sessions_dirs`,
-`deepseek_tui_sessions_dirs`, `forge_dirs`, `gemini_dirs`, `goose_dirs`,
+`cowork_dirs`, `devin_dirs`, `codebuff_dirs`, `codex_sessions_dirs`, `commandcode_project_dirs`,
+`copilot_dirs`, `cortex_dirs`, `cursor_project_dirs`,
+`deepseek_harness_sessions_dirs`, `deepseek_tui_sessions_dirs`, `forge_dirs`,
+`gemini_dirs`, `goose_dirs`,
 `gptme_dirs`, `grok_dirs`, `hermes_sessions_dirs`, `iflow_dirs`, `kilo_dirs`,
 `kilo_legacy_dirs`, `kimi_dirs`, `kimi_work_dirs`, `kiro_dirs`, `kiro_ide_dirs`,
 `mimocode_dirs`, `vibe_session_dirs`, `omp_dirs`, `openclaw_dirs`,
-`opencode_dirs`, `openhands_dirs`, `pi_dirs`, `prime_agent_dirs`,
-`piebald_dirs`, `posit_assistant_dirs`, `positron_dirs`, `qclaw_dirs`,
-`qoder_project_dirs`, `qwen_project_dirs`, `qwenpaw_dirs`, `reasonix_dirs`,
-`roocode_dirs`, `shelley_dirs`, `traex_sessions_dirs`,
-`visualstudio_copilot_dirs`, `vscode_copilot_dirs`, `windsurf_dirs`,
-`warp_dirs`, `workbuddy_project_dirs`, `zcode_dirs`, `zed_dirs`, and
-`zencoder_dirs`. Each accepts an array of paths. Environment variables take
-precedence over these arrays when both are set; otherwise, a non-empty array
-replaces the default path and an explicit empty array clears the default local
-directory.
+`opencode_dirs`, `openhands_dirs`, `pi_dirs`, `prime_agent_dirs`, `piebald_dirs`,
+`posit_assistant_dirs`, `positron_dirs`, `qclaw_dirs`, `qoder_project_dirs`,
+`qwen_project_dirs`, `qwenpaw_dirs`, `reasonix_dirs`, `roocode_dirs`,
+`shelley_dirs`, `traex_sessions_dirs`, `visualstudio_copilot_dirs`,
+`vscode_copilot_dirs`, `windsurf_dirs`, `warp_dirs`,
+`workbuddy_project_dirs`, `zcode_dirs`, `zed_dirs`, and `zencoder_dirs`. Each
+accepts an array of paths. Environment variables take precedence over these
+arrays when both are set; otherwise, a non-empty array replaces the default
+path and an explicit empty array clears the default local directory.
 
 All listed directories are discovered, watched, and synced independently.
 
@@ -806,10 +798,10 @@ the per-agent arrays, defaults, and environment variables above. Equivalent
 roots are deduplicated; a structured entry supplies the machine label when it
 duplicates a shorthand root. An omitted `machine` uses the local hostname.
 
-Machine attribution is captured when each session is first ingested. Changing an
-entry's `machine` value affects newly discovered sessions but does not relabel
-existing sessions during ordinary syncs or `agentsview sync --full`. Changing
-attribution for existing sessions is not currently supported.
+Machine attribution is captured when each session is first ingested. Changing
+an entry's `machine` value affects newly discovered sessions but does not
+relabel existing sessions during ordinary syncs or `agentsview sync --full`.
+Changing attribution for existing sessions is not currently supported.
 
 See [Filesystem Session Sync](/filesystem-sync/) for multi-machine examples,
 transport safety, ID deduplication, watcher behavior, and the comparison with
@@ -883,20 +875,21 @@ manual sync, and the periodic directory scan.
 The parser infers a session's project from its `cwd`. It recognizes common
 worktree manager layouts, including the generic
 `worktrees/github.com/<owner>/<repository>/<worktree>` convention, where the
-repository segment becomes the project. Layouts it does not recognize — such as
-`~/code/{project}.worktrees/feat/<branch>/` — otherwise group sessions under
-`<branch>` rather than `{project}`. For those, register manual **path-prefix →
-project** rules from the **Rules** view on the [Data page](/data/#rules), or let
-the [mapping editor](/data/#create-a-project-mapping) create one from a
-project's observed session folders:
+repository segment becomes the project. Layouts it does not recognize — such
+as `~/code/{project}.worktrees/feat/<branch>/` — otherwise group sessions
+under `<branch>` rather than `{project}`. For those, register manual
+**path-prefix → project** rules from the **Rules** view on the
+[Data page](/data/#rules), or let the
+[mapping editor](/data/#create-a-project-mapping) create one from a project's
+observed session folders:
 
 ![Worktree mapping rules on the Data page](/assets/generated/screenshots/worktree-mappings.png)
 
 - Mappings are explicit; there is no auto-discovery.
-- Each rule is scoped to one machine. The machine selector manages rules for the
-  local machine and for any remotely synced machine. Rules live in the writable
-  archive that ingests that machine's sessions, which may be the source
-  machine's local SQLite archive or a separate collector archive.
+- Each rule is scoped to one machine. The machine selector manages rules for
+  the local machine and for any remotely synced machine. Rules live in the
+  writable archive that ingests that machine's sessions, which may be the
+  source machine's local SQLite archive or a separate collector archive.
 - Each rule applies whenever a session's `cwd` falls under the configured
   prefix, on both new sessions as they sync and (via the **Apply** button)
   already-imported sessions. Prefixes match on directory boundaries, so
@@ -908,10 +901,10 @@ project's observed session folders:
   the first path segment under the prefix when it is named `<repo>.worktrees`,
   so a path like `/code/agentsview.worktrees/feature/frontend` resolves to
   project `agentsview`.
-- Rules created from the Data mapping editor record the mislabeled project they
-  corrected, shown as the rule's **original label**. The value is informational
-  and set once; to manually revert a reclassification, edit the rule's target
-  back to that original label and apply again.
+- Rules created from the Data mapping editor record the mislabeled
+  project they corrected, shown as the rule's **original label**. The value is
+  informational and set once; to manually revert a reclassification, edit the
+  rule's target back to that original label and apply again.
 - Disabling or deleting a rule does not rewrite sessions by itself. Sessions
   whose source files still exist revert to parser-derived names on a later
   reparse or full resync, while orphaned sessions keep their stored
@@ -1023,15 +1016,17 @@ native watcher and periodic-sync freshness behavior. AgentsView reads only
 session identity and timestamp metadata from accepted hint records and neither
 stores nor logs submitted prompt text.
 
-For each configured local Codex session root, AgentsView probes `history.jsonl`
-in the cleaned root's parent. For example, a custom `/data/custom/sessions` root
-probes `/data/custom/history.jsonl`. It does not search ancestors or the rollout
-archive for another history file. Missing hint files remain cheap probes.
+For each configured local Codex session root, AgentsView probes
+`history.jsonl` in the cleaned root's parent. For example, a custom
+`/data/custom/sessions` root probes `/data/custom/history.jsonl`. It does not
+search ancestors or the rollout archive for another history file. Missing hint
+files remain cheap probes.
 
 The initial daemon poll bootstraps at most the newest 4 MiB of each history file
 and accepts records at most 24 hours old. If AgentsView restarts during a long
 autonomous run whose last persisted prompt is outside either bound, that rollout
-uses native-watcher freshness until another persisted prompt makes it hot again.
+uses native-watcher freshness until another persisted prompt makes it hot
+again.
 
 For `s3://` Claude and Codex roots, change detection uses object size,
 `LastModified`, and available object fingerprints such as ETag, version ID, and
@@ -1194,8 +1189,8 @@ Optional features that send data externally when you enable them:
 - The [DuckDB mirror](/duckdb/) writes a local DuckDB file by default; data only
   leaves the machine if you expose the mirror over a remote Quack endpoint.
 - [Generated insights](/recall/#current-surface) sends scoped session content to
-  the configured endpoint when `[insights]` is set, or to the selected agent CLI
-  when it is absent.
+  the configured endpoint when `[insights]` is set, or to the selected agent
+  CLI when it is absent.
 - [Publish to Gist](/usage/#publish-to-gist) uploads a session to GitHub.
 
 The automatic outbound requests are update checks and an anonymous daemon ping:

--- a/docs/internal/performance-gates.md
+++ b/docs/internal/performance-gates.md
@@ -20,6 +20,7 @@ contracts are documented in
 | Bulk ingest throughput         | Full resync ran per-row inserts and rebuilt FTS incrementally; 26.7k sessions took 1m17s.                                                                                                               | #411                                           |
 | Event storms                   | One SSE emit per watcher flush drove ~1/s dashboard refetch; SQLite WAL sidecar events fanned out to every session in a shared DB.                                                                      | #367, #956                                     |
 | Per-row query shape            | `GetDailyUsage` ran 1.2M `json_extract` calls per scan and had no date pushdown.                                                                                                                        | #309                                           |
+| Usage archive scaling          | Normalized facts removed JSON parsing but warm requests still ranked and priced hundreds of thousands of rows instead of reading daily aggregates.                                                      | Usage aggregate cache                          |
 
 ## Two layers of gates
 
@@ -94,7 +95,10 @@ with `cmd/benchgate`:
   rebuild through a contributor engine.
 - `BenchmarkSearchContentSubstringPage` / `BenchmarkSearchContentFTSPage` — one
   page of content search through the substring and FTS paths.
-- `BenchmarkGetDailyUsage` — usage aggregation over 100k message rows.
+- `BenchmarkGetDailyUsage` — usage aggregation over 100k message rows. The usage
+  aggregate implementation keeps this benchmark name so the gate compares it
+  with the merge-base request path. Its warm cases must scan no normalized
+  facts and scale with aggregate plus exceptional rows.
 - `BenchmarkSQLiteActivityReportCandidateSource100K`,
   `BenchmarkSQLiteActivityReportCandidateSourceLongSession`, and
   `BenchmarkSQLiteActivityReportArtifacts100K` — activity-report candidate
@@ -174,6 +178,26 @@ go run ./cmd/benchgate -old old.txt -new new.txt
 
 Cross-backend query benchmarks live separately in `internal/backendbench`
 (`make bench-backends`, requires Docker) and are not part of the PR gate.
+
+## Usage aggregate release gates
+
+CI uses fixture-based work invariants and benchmark ratios. Machine-specific
+targets are manual release gates on the protected production-scale clone. Run
+them after cache statistics maintenance so planner state does not exaggerate the
+aggregate tier's benefit.
+
+- Complete warm 30-day CLI result: at most two seconds.
+- Warm in-process 30-day result: target 1.5 seconds.
+- Report warm 1-day, 7-day, 30-day, and all-history results.
+- Report cold timezone/component construction and steady-state rebuild
+  throughput separately.
+- Report exception group and row counts plus exception-resolution time for
+  30-day and all-history reads.
+- Newest-first facts plus process-local rollups: complete within 30 seconds.
+- Full facts plus process-local rollup coverage: complete within five minutes.
+
+The detailed architecture and oracle requirements are in
+[Usage Aggregate Cache](usage-aggregate-cache.md).
 
 `BenchmarkCodexIncrementalCursor` lives in `internal/parser` and compares cold
 prefix reconstruction with an exact warm cursor. It is diagnostic rather than

--- a/docs/internal/usage-aggregate-cache-implementation.md
+++ b/docs/internal/usage-aggregate-cache-implementation.md
@@ -1,0 +1,94 @@
+# Usage Aggregate Cache Implementation Plan
+
+## Outcome
+
+Replace request-time normalized-fact aggregation with exact daily rollups while
+keeping the facts cache as a disposable build substrate. Daily usage, top
+sessions, billed counts, and relaxed matching counts use rollups. Session detail
+and PostgreSQL keep the live implementation. Aggregate cache failure is an
+error, never a live-path fallback.
+
+## Constraints
+
+- Preserve arbitrary date ranges, timezones, filters, window-scoped dedup,
+  per-row money rounding, authoritative allocation, and Cursor behavior.
+- A live transcript change or resync must invalidate its source-session facts
+  and every timezone rollup built from them before the next result.
+- Bake exactly `agent` and `started_at`; join other session metadata live.
+- Resolve pricing in Go and fingerprint the canonical effective pricing data.
+- Recheck full source fingerprints before install. Do not order by
+  `sync_marker`, which can decrease.
+- Keep the SQLite/PostgreSQL complete-result parity test.
+- Warm 30-day CLI release gate: at most two seconds on the protected clone.
+
+## Execution record
+
+### 1. Disposable schema and identities
+
+- Add timezone records and exact local-day UTC intervals.
+- Add per-session rollup installs keyed by source fingerprint, fact revision,
+  baked metadata, pricing digest, and install revision.
+- Add daily, activity, and narrow exception rows with covering window indexes.
+- Use canonical IANA identity or a stable rule fingerprint for anonymous local
+  zones.
+- Keep fail-closed file recognition and database-ID/schema generations.
+
+### 2. Go builder
+
+- Load only narrow normalized facts for stale source sessions.
+- Convert ordinary token facts directly to `(session, day, model, rate)` daily
+  rows using existing Go pricing and money functions.
+- Store every dedup-capable fact in the exception tier. This subsumes the more
+  complicated connected-component classifier while preserving exact
+  window-scoped semantics.
+- Build model-aware user activity rows and a synthetic Cursor exception install.
+- Replace each source session atomically after the archive fingerprint recheck.
+
+### 3. Aggregate reads
+
+- Ensure candidate facts, then requested-timezone rollups.
+- Verify required installs in one pinned cache transaction.
+- Read indexed daily rows and only in-window exception rows.
+- Resolve snapshot/general dedup and price exception survivors in Go.
+- Apply live filters and authoritative session-cost allocation.
+- Route all aggregate consumers to this path; retain the bounded live path for
+  session detail and PostgreSQL.
+
+### 4. Background lifecycle
+
+- Backfill newest sessions first in 256-session batches after daemon readiness.
+- Rewarm process-local plus eight most recently requested named timezones.
+- Share detached foreground/background fills and retry moving fingerprints at
+  most three times.
+- Sweep deletion hygiene, optimize between batches, incrementally vacuum a large
+  freelist, and analyze after complete backfill.
+
+### 5. Remove superseded machinery
+
+- Delete the request-time normalized-facts SQL engine and its temp-table
+  population.
+- Delete SQLite pricing UDFs and SQL-specific rounding tests.
+- Keep fact extraction/invalidation tests because facts remain the build
+  substrate.
+- Repoint public consumer and PostgreSQL parity tests at rollup-served SQLite
+  results.
+
+### 6. Verification
+
+- Run focused lifecycle, mutation, randomized parity, and aggregate consumer
+  tests.
+- Run `go fmt ./...`, `go vet ./...`, the full fts5 test suite, and lint.
+- Run `BenchmarkGetDailyUsage` and the benchmark gate.
+- On the protected clone, require byte-identical 7-day, 30-day, and all-history
+  output and measure cold/warm 1-, 7-, 30-day, and all-history behavior.
+- Run the explicitly requested `roborev-fix` pass and address actionable
+  findings before delivery.
+
+## Measured result
+
+The final warm CLI path reuses rollups across processes. The canonical pricing
+digest fixes nondeterministic whole-cache invalidation, and stable process-local
+identity prevents one daemon backfill from splitting across timezone keys.
+Observed protected-clone warm CLI times are approximately 0.19 seconds (1 day),
+0.35 seconds (7 days), and 0.85 seconds (30 days). Cold construction and
+all-history remain separately reported background-scale work.

--- a/docs/internal/usage-aggregate-cache.md
+++ b/docs/internal/usage-aggregate-cache.md
@@ -1,0 +1,145 @@
+# Usage Aggregate Cache
+
+## Purpose
+
+SQLite aggregate usage reads use a disposable sibling database so a warm request
+does not rank, price, and transfer every token-bearing message. The archive
+remains authoritative; deleting a recognized cache generation loses no user
+data.
+
+The cache serves daily usage, top sessions, billed-session counts, and relaxed
+matching counts. Per-session detail remains on the bounded live path. PostgreSQL
+keeps its live implementation and is checked against SQLite by the
+complete-result `pgtest` fixture.
+
+The release target is a complete warm 30-day CLI result in at most two seconds
+on the protected production-scale clone, with byte-identical results before and
+after cache construction.
+
+## Derived data
+
+The cache has two internal layers:
+
+1. Narrow, timezone-neutral facts contain parsed message and usage-event fields
+   but no transcript content. They make rebuilding another timezone
+   independent of the 39 GB archive and its JSON columns.
+1. Timezone rollups contain daily contributions at logical grain
+   `(session_id, local_day, model)` plus activity rows and narrow dedup
+   exceptions.
+
+The facts layer is a build substrate only. Warm aggregate requests read rollups
+and exceptions; they never fall back to the live aggregate path.
+
+### Daily rows
+
+Each daily row stores token categories, web-search requests, pricing identity,
+per-row-rounded estimated cost, savings, authoritative cost markers, request
+counts, and discarded-snapshot output. Go owns model resolution, rate-band
+selection, money rounding, and result assembly.
+
+Project, machine, automation state, termination state, curation fields, and
+other filters remain live archive metadata. Rollup installs bake only `agent`
+and `started_at`: `agent` participates in general dedup keys, while `started_at`
+supplies the date for facts without their own timestamp. Both exact values are
+verified on every read.
+
+### Dedup exceptions
+
+Any fact that can participate in Claude snapshot deduplication or general
+`source:`/`usage:` deduplication is stored as a narrow exception instead of a
+daily contribution. This conservative boundary makes cross-day, cross-model,
+cross-session, and snapshot-to-general cases exact without a second
+component-classification system.
+
+At read time the query loads only exception rows intersecting the requested
+window from the currently verified candidate sessions. It then applies the
+existing window-scoped ranking, attribution, filtering, and pricing rules in Go.
+Ordinary facts stay on the indexed daily path.
+
+Because exceptions are installed per source session, changing one transcript
+rebuilds only that session. A cross-session winner still changes immediately:
+the next request verifies every candidate session and resolves the group from
+the latest exception rows of all members.
+
+Cursor usage uses the same exception representation under a synthetic source
+install keyed by the Cursor high-water mark. User-message activity has compact
+`(session_id, day, model)` rows for relaxed counts.
+
+## Freshness contract
+
+An aggregate request:
+
+1. captures the archive database ID, candidate sessions, source fingerprints,
+   exact `agent` and `started_at`, live filter metadata, pricing rows, Cursor
+   high-water mark, and requested timezone;
+1. closes the archive snapshot before acquiring cache write locks;
+1. opens the generation named by cache format and archive database ID;
+1. fills missing or stale normalized facts for only the candidate sessions;
+1. builds missing or stale rollups for the requested timezone;
+1. rechecks source fingerprints and baked metadata before installing; and
+1. verifies all required installs inside one pinned cache read transaction
+   before assembling the result.
+
+The pricing generation uses the canonical, order-independent effective-pricing
+digest. Daily rows also retain the resolved per-model rate hash. Pricing changes
+therefore invalidate the appropriate derived data without relying on a
+timestamp.
+
+`sync_marker` is not a monotonic version: its trigger recomputes a maximum of
+mutable timestamp fields and the value can decrease. Installation compares the
+complete source fingerprint after extraction rather than ordering marker values.
+A hard-deleted session is dropped as newer state. Other moving-source or
+archive-busy races retry at most three times, then fail instead of returning
+stale usage.
+
+Request cancellation detaches the waiter from shared fill work. The fill keeps
+running so retry storms converge. `cached_at` is diagnostic only.
+
+## Files and generations
+
+The filename contains the cache schema version and archive `database_id`. Schema
+or database-ID changes select a fresh generation rather than migrating the
+archive. Before deleting or replacing any generation, both SQLite
+`application_id` and `usage_cache_metadata.cache_kind` must identify it as an
+agentsview usage cache; a filename match is insufficient.
+
+If the sibling directory is unwritable, the process uses the same schema and
+read path in a temporary database and warns that it will rebuild after restart.
+
+Timezone identity is stable across request windows. Named zones use their IANA
+name. When the process-local zone reports only `Local`, agentsview resolves the
+platform zoneinfo symlink when possible and otherwise fingerprints timezone
+rules from 1970 through 2100. This prevents lazy `time.Local` initialization or
+a different request range from creating another generation.
+
+## Background maintenance
+
+After HTTP readiness, a writable daemon fills sessions newest-first in batches
+of at most 256. It builds the process-local rollups and up to eight most
+recently requested named timezones. Mutation work is enqueued only after archive
+commit; the cache is never filled inside an archive write transaction.
+
+The worker runs `PRAGMA optimize` between batches, performs bounded incremental
+vacuum when the freelist is large, and runs full `ANALYZE` after generation
+creation and completed backfill. Deletion-journal sweeps are hygiene; aggregate
+reads require current archive candidates and cannot expose orphaned cache rows.
+
+## Verification and gates
+
+Correctness tests compare public rollup results with the permanent live oracle
+over seeded random windows, timezones, filters, DST boundaries, pricing bands,
+reported costs, Cursor rows, null timestamps, and cross-session dedup groups.
+Mutation tests cover transcript replacement, resync fingerprints, pricing,
+`agent`, `started_at`, deletion, schema generation, and database-ID changes.
+
+The protected-clone release check compares 7-day, 30-day, and all-history
+results byte for byte. Performance reporting separates cold construction from
+warm reads and reports 1-day, 7-day, 30-day, and all-history results. The warm
+path must not scan normalized facts.
+
+Current protected-clone measurements after canonical pricing and timezone
+identity fixes are approximately 0.19 seconds for 1 day, 0.35 seconds for 7
+days, and 0.85 seconds for 30 days through the offline CLI. All-history warm
+reads are approximately six seconds. Cold construction remains proportional to
+uncached candidate-session history and is intentionally handled newest-first in
+the background.

--- a/docs/internal/usage-aggregate-cache.md
+++ b/docs/internal/usage-aggregate-cache.md
@@ -62,8 +62,10 @@ the next request verifies every candidate session and resolves the group from
 the latest exception rows of all members.
 
 Cursor usage uses the same exception representation under a synthetic source
-install keyed by the Cursor high-water mark. User-message activity has compact
-`(session_id, day, model)` rows for relaxed counts.
+install keyed by the Cursor high-water mark. Matching-session activity has
+compact `(session_id, day, model)` rows for relaxed counts. An eligible fact
+with neither its own timestamp nor a session start is retained with an empty
+day: unbounded matching counts include it, while bounded reads exclude it.
 
 ## Freshness contract
 
@@ -125,6 +127,9 @@ The worker runs `PRAGMA optimize` between batches, performs bounded incremental
 vacuum when the freelist is large, and runs full `ANALYZE` after generation
 creation and completed backfill. Deletion-journal sweeps are hygiene; aggregate
 reads require current archive candidates and cannot expose orphaned cache rows.
+If source data moves during a pass, the worker recaptures and retries the whole
+snapshot at most three times. Installed fingerprints let unchanged batches be
+reused across attempts.
 
 ## Verification and gates
 

--- a/docs/internal/usage-aggregate-cache.md
+++ b/docs/internal/usage-aggregate-cache.md
@@ -106,11 +106,13 @@ agentsview usage cache; a filename match is insufficient.
 If the sibling directory is unwritable, the process uses the same schema and
 read path in a temporary database and warns that it will rebuild after restart.
 
-Timezone identity is stable across request windows. Named zones use their IANA
-name. When the process-local zone reports only `Local`, agentsview resolves the
-platform zoneinfo symlink when possible and otherwise fingerprints timezone
-rules from 1970 through 2100. This prevents lazy `time.Local` initialization or
-a different request range from creating another generation.
+Timezone identity is stable across request windows. Named zones combine their
+IANA name with a fingerprint of timezone rules from 1970 through 2100, so a
+zoneinfo update cannot reuse obsolete day buckets. When the process-local zone
+reports only `Local`, agentsview resolves the platform zoneinfo symlink when
+possible and otherwise uses the same rule fingerprint. This prevents lazy
+`time.Local` initialization or a different request range from creating another
+generation.
 
 ## Background maintenance
 

--- a/docs/internal/usage-aggregate-cache.md
+++ b/docs/internal/usage-aggregate-cache.md
@@ -45,21 +45,49 @@ verified on every read.
 
 ### Dedup exceptions
 
-Any fact that can participate in Claude snapshot deduplication or general
-`source:`/`usage:` deduplication is stored as a narrow exception instead of a
-daily contribution. This conservative boundary makes cross-day, cross-model,
-cross-session, and snapshot-to-general cases exact without a second
-component-classification system.
+Deduplication groups are classified per group when a session's rollup is built.
+A group is finalized into daily rows only when its resolution provably cannot
+vary with the query window or live filters:
+
+- every member belongs to the building session and shares one local date (query
+  windows are whole local days, so such a group is inside or outside any
+  window as a unit);
+- for general `source:`/`usage:` groups, every member also shares one model and
+  headless state, because live model and automation filters apply before
+  general ranking;
+- no member links snapshot and general dedup (a snapshot survivor carrying a
+  usage key re-enters general ranking at read time);
+- no member carries a Copilot authoritative cost, whose per-session selection is
+  order-dependent across the whole window; and
+- the group's identity appears in no other cached session and, for usage keys,
+  not in the Cursor fact store. Partial identity indexes on `usage_facts`
+  serve this check conservatively (for example, `source:` identity ignores the
+  baked agent).
+
+Finalization applies the same ranking rules as the read path: the
+greatest-output snapshot wins, attribution follows the earliest row, the maximum
+web-search count carries over, and losing snapshot output is recorded as
+discarded. Only irreducible groups are stored as narrow exceptions, so exception
+volume scales with genuine cross-session, cross-day, and cross-model duplicates
+rather than with token-bearing messages. Cursor facts stay entirely on the
+exception tier: their keys may collide with session usage keys and their filters
+depend on per-row headless state.
 
 At read time the query loads only exception rows intersecting the requested
 window from the currently verified candidate sessions. It then applies the
 existing window-scoped ranking, attribution, filtering, and pricing rules in Go.
-Ordinary facts stay on the indexed daily path.
+Finalized groups and ordinary facts stay on the indexed daily path.
 
-Because exceptions are installed per source session, changing one transcript
-rebuilds only that session. A cross-session winner still changes immediately:
-the next request verifies every candidate session and resolves the group from
-the latest exception rows of all members.
+Because rollups are installed per source session, changing one transcript
+rebuilds that session. Whenever a fill, Cursor batch, or deletion changes the
+set of dedup identities a session contributes, the same cache transaction
+deletes the timezone rollup installs of every other session holding a changed
+identity, and rollup installation re-verifies inside its transaction that no
+finalized identity gained an outside member, retrying as a moved source
+otherwise. A finalized daily row therefore never survives gaining a sibling, and
+a cross-session winner still changes immediately: the next request verifies
+every candidate session and resolves the group from the latest exception rows of
+all members.
 
 Cursor usage uses the same exception representation under a synthetic source
 install keyed by the Cursor high-water mark. Matching-session activity has
@@ -144,9 +172,10 @@ results byte for byte. Performance reporting separates cold construction from
 warm reads and reports 1-day, 7-day, 30-day, and all-history results. The warm
 path must not scan normalized facts.
 
-Current protected-clone measurements after canonical pricing and timezone
-identity fixes are approximately 0.19 seconds for 1 day, 0.35 seconds for 7
-days, and 0.85 seconds for 30 days through the offline CLI. All-history warm
-reads are approximately six seconds. Cold construction remains proportional to
-uncached candidate-session history and is intentionally handled newest-first in
-the background.
+Warm reads must scale with daily rows and genuine duplicate groups, not with
+token-bearing messages; the release check reports exception cardinality along
+with timings. Slow foreground requests log privacy-safe phase timings and row
+counts. Cold construction remains proportional to uncached candidate-session
+history and is intentionally handled newest-first in the background.
+Protected-clone timings are re-measured for each release against the two-second
+warm 30-day gate rather than recorded here.

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -1,7 +1,6 @@
----
-title: Token Usage & Costs
-description: Fast token usage and cost reports from your local AgentsView database
----
+______________________________________________________________________
+
+## title: Token Usage & Costs description: Fast token usage and cost reports from your local AgentsView database
 
 AgentsView records token usage while ingesting messages and usage events from
 agents that write model and token metadata to their local logs. The database
@@ -20,30 +19,34 @@ it's also dramatically faster on large histories (see
 
 !!! warning "Experimental"
 
-    Token usage and cost reporting is a newer area of AgentsView and is still
-    maturing. The Usage dashboard and the `agentsview usage` CLI may have rough
-    edges, especially around agents whose parsers were recently taught to emit token
-    counts. Bug reports and feature requests are very welcome — please
-    [open an issue](https://github.com/kenn-io/agentsview/issues).
+```
+Token usage and cost reporting is a newer area of AgentsView and is still
+maturing. The Usage dashboard and the `agentsview usage` CLI may have rough
+edges, especially around agents whose parsers were recently taught to emit token
+counts. Bug reports and feature requests are very welcome — please
+[open an issue](https://github.com/kenn-io/agentsview/issues).
+```
 
 ## Agent Coverage
 
 !!! note
 
-    **As of 0.34.0**, usage totals are populated when the source session includes
-    token metadata for **Claude Code**, **Codex**, **Copilot CLI**, **OpenCode** and
-    OpenCode-format forks such as **Kilo** and **MiMoCode**, **Pi**, **Prime
-    Agent**, **Gemini**,
-    **Qwen Code**, **OpenClaw**, **QClaw**, **Hermes**, **WorkBuddy**, **Forge**,
-    **Piebald**, **Antigravity IDE/CLI**, **Zed**, **VS Code Copilot**, **Visual
-    Studio Copilot**, **Mistral Vibe**, **gptme**, and **Amp**.
+```
+**As of 0.34.0**, usage totals are populated when the source session includes
+token metadata for **Claude Code**, **Codex**, **Copilot CLI**, **OpenCode** and
+OpenCode-format forks such as **Kilo** and **MiMoCode**, **Pi**, **Prime
+Agent**, **Gemini**,
+**Qwen Code**, **OpenClaw**, **QClaw**, **Hermes**, **WorkBuddy**, **Forge**,
+**Piebald**, **Antigravity IDE/CLI**, **Zed**, **VS Code Copilot**, **Visual
+Studio Copilot**, **Mistral Vibe**, **gptme**, and **Amp**.
 
-    Coverage is opportunistic rather than guaranteed for every session from those
-    agents: rows contribute to cost only when the local transcript includes usable
-    token counts and a model name that can be priced. Other supported agents still
-    appear in the session browser, search, and analytics even when their local logs
-    do not expose token usage. Warp records session-level totals, but those totals
-    are not yet folded into the per-message cost report.
+Coverage is opportunistic rather than guaranteed for every session from those
+agents: rows contribute to cost only when the local transcript includes usable
+token counts and a model name that can be priced. Other supported agents still
+appear in the session browser, search, and analytics even when their local logs
+do not expose token usage. Warp records session-level totals, but those totals
+are not yet folded into the per-message cost report.
+```
 
 When an agent filter selects only agents that do not expose per-message token
 rows, AgentsView reports that as an unsupported usage state instead of silently
@@ -287,15 +290,20 @@ populates per-project, per-agent, and per-machine breakdown arrays for every
 day, making costs from shared multi-machine archives separable without another
 query.
 
+On large archives, aggregate usage reads are served from a local cache of daily
+totals that stays exact as sessions sync. The first query after an install,
+upgrade, or cache deletion is slower while that cache builds; subsequent queries
+are fast.
+
 ## How Costs Are Computed
 
 Every message parsed from a session file stores its raw `token_usage` JSON
 (input, output, cache creation, cache read) and the model name reported by the
 agent. The usage command:
 
-1. Loads `model_pricing` and its `model_pricing_bands` children into memory
-   once per invocation. They hold base per-million-token rates and any
-   whole-request input thresholds published by the pricing catalog.
+1. Loads `model_pricing` and its `model_pricing_bands` children into memory once
+   per invocation. They hold base per-million-token rates and any whole-request
+   input thresholds published by the pricing catalog.
 1. Scans `messages` filtered by the requested date range and agent, parsing each
    row's `token_usage` blob in Go with `gjson` — faster than SQLite's per-row
    `json_extract`.
@@ -314,9 +322,11 @@ The default window is the last 30 days; pass `--all` to scan the full history.
 
 !!! note
 
-    AgentsView does not mint usage events on your behalf. It can only report token
-    usage that the agent wrote to its own session files. Agents that don't emit
-    token counts (or that strip them from local logs) won't show up.
+```
+AgentsView does not mint usage events on your behalf. It can only report token
+usage that the agent wrote to its own session files. Agents that don't emit
+token counts (or that strip them from local logs) won't show up.
+```
 
 ### Pricing Source
 
@@ -329,17 +339,16 @@ layered underneath for models LiteLLM does not list. Both are fetched together
 an OpenRouter row is dropped once LiteLLM picks the model up. If the LiteLLM
 fetch fails, AgentsView keeps the last stored rates; if only the OpenRouter
 fetch fails, the fresh LiteLLM rates are still stored and the stored OpenRouter
-rates are kept. Fresh databases are seeded from
-an embedded LiteLLM snapshot so offline use works before any refresh completes.
-Pass `--offline` to skip the fetch entirely and always use the embedded
-fallback.
+rates are kept. Fresh databases are seeded from an embedded LiteLLM snapshot so
+offline use works before any refresh completes. Pass `--offline` to skip the
+fetch entirely and always use the embedded fallback.
 
 The embedded fallback is updated with AgentsView releases, so the numbers are as
 current as your installed version. For up-to-the-minute rates, leave `--offline`
 off.
 
-LiteLLM's standard whole-request 200K and 272K token rates are preserved in
-both fetched and embedded catalogs. Processing variants such as Batch, Flex,
+LiteLLM's standard whole-request 200K and 272K token rates are preserved in both
+fetched and embedded catalogs. Processing variants such as Batch, Flex,
 Priority, regional, and one-hour cache pricing are not inferred when the stored
 usage does not identify that service tier.
 
@@ -350,17 +359,17 @@ Anthropic charges a flat
 on top of tokens. That fee is not a per-token rate, so it lives outside the
 `model_pricing` catalog as a fixed $0.01 per request. AgentsView adds it to any
 usage row whose stored `token_usage` reports
-`server_tool_use.web_search_requests`, and `session usage --format json`
-reports the per-row count as `web_search_requests` so the charge is auditable.
-A row that carries an authoritative reported cost is left alone, since that
-cost already settles the whole row.
+`server_tool_use.web_search_requests`, and `session usage --format json` reports
+the per-row count as `web_search_requests` so the charge is auditable. A row
+that carries an authoritative reported cost is left alone, since that cost
+already settles the whole row.
 
 Claude Code runs each `WebSearch` in an out-of-band side call and writes a zero
 counter on the assistant message, so AgentsView takes the count from the linked
 tool result instead. That side call's own tokens — tens of thousands of input
 tokens on a Haiku model per search — are not written to the transcript at all
-and are therefore a known undercount: AgentsView records the fee, not the
-hidden tokens.
+and are therefore a known undercount: AgentsView records the fee, not the hidden
+tokens.
 
 As of 0.32.0, the embedded fallback includes `claude-opus-4-7` at the same Opus
 tier used for 4.6 and 4.8, so offline reports and fresh installs price Opus 4.7
@@ -543,11 +552,13 @@ an M5 Max, median of 5 steady-state runs:
 
 !!! note
 
-    These numbers are from a large local database (22k sessions, 310k token-bearing
-    messages). The speedup scales with session count — smaller databases will see
-    smaller absolute differences because `ccusage` has less JSONL to re-parse, but
-    AgentsView stays in the sub-second range either way. The ratios above are an
-    upper bound, not a universal guarantee.
+```
+These numbers are from a large local database (22k sessions, 310k token-bearing
+messages). The speedup scales with session count — smaller databases will see
+smaller absolute differences because `ccusage` has less JSONL to re-parse, but
+AgentsView stays in the sub-second range either way. The ratios above are an
+upper bound, not a universal guarantee.
+```
 
 Apples-to-apples: `ccusage` scans all history by default, so the `--all` row is
 the matched comparison. The default 30-day window is faster still because most
@@ -559,11 +570,10 @@ Beyond raw speed, `agentsview usage`:
 
 - **Works beyond Claude Code** — coverage includes Claude Code, Codex, Copilot
   CLI, OpenCode-format tools, Pi, Prime Agent, Gemini, Qwen Code,
-  OpenClaw/QClaw, Hermes,
-  WorkBuddy, Forge, Piebald, Antigravity, Zed, VS Code Copilot, Visual Studio
-  Copilot, Mistral Vibe, and gptme from the same database and command whenever
-  those sessions log token metadata. Filter with `--agent <name>` when you want
-  a single-agent view.
+  OpenClaw/QClaw, Hermes, WorkBuddy, Forge, Piebald, Antigravity, Zed, VS Code
+  Copilot, Visual Studio Copilot, Mistral Vibe, and gptme from the same database
+  and command whenever those sessions log token metadata. Filter with
+  `--agent <name>` when you want a single-agent view.
 - **Shares one database with the UI** — the same data powers
   [Analytics](/usage/#dashboard) and session detail views, so there's no second
   index to keep fresh.
@@ -823,8 +833,7 @@ exactly `model_pattern`, `input_per_mtok`, `output_per_mtok`,
 exactly `above_input_tokens`, `input_per_mtok`, `output_per_mtok`,
 `cache_write_per_mtok`, `cache_read_per_mtok`, and `updated_at`. Application
 counts describe one report and are deliberately excluded from the catalog
-digest.
-`updated_at` is `null` or a UTC RFC3339 timestamp such as
+digest. `updated_at` is `null` or a UTC RFC3339 timestamp such as
 `2026-07-03T12:00:00Z`. Digest canonicalization errors fail the export instead
 of emitting an empty digest. The digest uses the resolver's internal canonical
 pricing-row keys; the public `pricing.models` block uses the `*_cost_per_mtok`
@@ -1004,8 +1013,7 @@ systemd timer's journal, or a Windows Task Scheduler action.
 
 `--json` reports the cost as exact microdollars, so the threshold is an integer
 comparison instead of a parse of the formatted line. `jq -e` fails the script
-when the value is missing, so a broken read cannot pass for an under-budget
-day:
+when the value is missing, so a broken read cannot pass for an under-budget day:
 
 ```bash
 budget_usd=25

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -1,6 +1,7 @@
-______________________________________________________________________
-
-## title: Token Usage & Costs description: Fast token usage and cost reports from your local AgentsView database
+---
+title: Token Usage & Costs
+description: Fast token usage and cost reports from your local AgentsView database
+---
 
 AgentsView records token usage while ingesting messages and usage events from
 agents that write model and token metadata to their local logs. The database
@@ -19,34 +20,30 @@ it's also dramatically faster on large histories (see
 
 !!! warning "Experimental"
 
-```
-Token usage and cost reporting is a newer area of AgentsView and is still
-maturing. The Usage dashboard and the `agentsview usage` CLI may have rough
-edges, especially around agents whose parsers were recently taught to emit token
-counts. Bug reports and feature requests are very welcome — please
-[open an issue](https://github.com/kenn-io/agentsview/issues).
-```
+    Token usage and cost reporting is a newer area of AgentsView and is still
+    maturing. The Usage dashboard and the `agentsview usage` CLI may have rough
+    edges, especially around agents whose parsers were recently taught to emit token
+    counts. Bug reports and feature requests are very welcome — please
+    [open an issue](https://github.com/kenn-io/agentsview/issues).
 
 ## Agent Coverage
 
 !!! note
 
-```
-**As of 0.34.0**, usage totals are populated when the source session includes
-token metadata for **Claude Code**, **Codex**, **Copilot CLI**, **OpenCode** and
-OpenCode-format forks such as **Kilo** and **MiMoCode**, **Pi**, **Prime
-Agent**, **Gemini**,
-**Qwen Code**, **OpenClaw**, **QClaw**, **Hermes**, **WorkBuddy**, **Forge**,
-**Piebald**, **Antigravity IDE/CLI**, **Zed**, **VS Code Copilot**, **Visual
-Studio Copilot**, **Mistral Vibe**, **gptme**, and **Amp**.
+    **As of 0.34.0**, usage totals are populated when the source session includes
+    token metadata for **Claude Code**, **Codex**, **Copilot CLI**, **OpenCode** and
+    OpenCode-format forks such as **Kilo** and **MiMoCode**, **Pi**, **Prime
+    Agent**, **Gemini**,
+    **Qwen Code**, **OpenClaw**, **QClaw**, **Hermes**, **WorkBuddy**, **Forge**,
+    **Piebald**, **Antigravity IDE/CLI**, **Zed**, **VS Code Copilot**, **Visual
+    Studio Copilot**, **Mistral Vibe**, **gptme**, and **Amp**.
 
-Coverage is opportunistic rather than guaranteed for every session from those
-agents: rows contribute to cost only when the local transcript includes usable
-token counts and a model name that can be priced. Other supported agents still
-appear in the session browser, search, and analytics even when their local logs
-do not expose token usage. Warp records session-level totals, but those totals
-are not yet folded into the per-message cost report.
-```
+    Coverage is opportunistic rather than guaranteed for every session from those
+    agents: rows contribute to cost only when the local transcript includes usable
+    token counts and a model name that can be priced. Other supported agents still
+    appear in the session browser, search, and analytics even when their local logs
+    do not expose token usage. Warp records session-level totals, but those totals
+    are not yet folded into the per-message cost report.
 
 When an agent filter selects only agents that do not expose per-message token
 rows, AgentsView reports that as an unsupported usage state instead of silently
@@ -301,9 +298,9 @@ Every message parsed from a session file stores its raw `token_usage` JSON
 (input, output, cache creation, cache read) and the model name reported by the
 agent. The usage command:
 
-1. Loads `model_pricing` and its `model_pricing_bands` children into memory once
-   per invocation. They hold base per-million-token rates and any whole-request
-   input thresholds published by the pricing catalog.
+1. Loads `model_pricing` and its `model_pricing_bands` children into memory
+   once per invocation. They hold base per-million-token rates and any
+   whole-request input thresholds published by the pricing catalog.
 1. Scans `messages` filtered by the requested date range and agent, parsing each
    row's `token_usage` blob in Go with `gjson` — faster than SQLite's per-row
    `json_extract`.
@@ -322,11 +319,9 @@ The default window is the last 30 days; pass `--all` to scan the full history.
 
 !!! note
 
-```
-AgentsView does not mint usage events on your behalf. It can only report token
-usage that the agent wrote to its own session files. Agents that don't emit
-token counts (or that strip them from local logs) won't show up.
-```
+    AgentsView does not mint usage events on your behalf. It can only report token
+    usage that the agent wrote to its own session files. Agents that don't emit
+    token counts (or that strip them from local logs) won't show up.
 
 ### Pricing Source
 
@@ -339,16 +334,17 @@ layered underneath for models LiteLLM does not list. Both are fetched together
 an OpenRouter row is dropped once LiteLLM picks the model up. If the LiteLLM
 fetch fails, AgentsView keeps the last stored rates; if only the OpenRouter
 fetch fails, the fresh LiteLLM rates are still stored and the stored OpenRouter
-rates are kept. Fresh databases are seeded from an embedded LiteLLM snapshot so
-offline use works before any refresh completes. Pass `--offline` to skip the
-fetch entirely and always use the embedded fallback.
+rates are kept. Fresh databases are seeded from
+an embedded LiteLLM snapshot so offline use works before any refresh completes.
+Pass `--offline` to skip the fetch entirely and always use the embedded
+fallback.
 
 The embedded fallback is updated with AgentsView releases, so the numbers are as
 current as your installed version. For up-to-the-minute rates, leave `--offline`
 off.
 
-LiteLLM's standard whole-request 200K and 272K token rates are preserved in both
-fetched and embedded catalogs. Processing variants such as Batch, Flex,
+LiteLLM's standard whole-request 200K and 272K token rates are preserved in
+both fetched and embedded catalogs. Processing variants such as Batch, Flex,
 Priority, regional, and one-hour cache pricing are not inferred when the stored
 usage does not identify that service tier.
 
@@ -359,17 +355,17 @@ Anthropic charges a flat
 on top of tokens. That fee is not a per-token rate, so it lives outside the
 `model_pricing` catalog as a fixed $0.01 per request. AgentsView adds it to any
 usage row whose stored `token_usage` reports
-`server_tool_use.web_search_requests`, and `session usage --format json` reports
-the per-row count as `web_search_requests` so the charge is auditable. A row
-that carries an authoritative reported cost is left alone, since that cost
-already settles the whole row.
+`server_tool_use.web_search_requests`, and `session usage --format json`
+reports the per-row count as `web_search_requests` so the charge is auditable.
+A row that carries an authoritative reported cost is left alone, since that
+cost already settles the whole row.
 
 Claude Code runs each `WebSearch` in an out-of-band side call and writes a zero
 counter on the assistant message, so AgentsView takes the count from the linked
 tool result instead. That side call's own tokens — tens of thousands of input
 tokens on a Haiku model per search — are not written to the transcript at all
-and are therefore a known undercount: AgentsView records the fee, not the hidden
-tokens.
+and are therefore a known undercount: AgentsView records the fee, not the
+hidden tokens.
 
 As of 0.32.0, the embedded fallback includes `claude-opus-4-7` at the same Opus
 tier used for 4.6 and 4.8, so offline reports and fresh installs price Opus 4.7
@@ -552,13 +548,11 @@ an M5 Max, median of 5 steady-state runs:
 
 !!! note
 
-```
-These numbers are from a large local database (22k sessions, 310k token-bearing
-messages). The speedup scales with session count — smaller databases will see
-smaller absolute differences because `ccusage` has less JSONL to re-parse, but
-AgentsView stays in the sub-second range either way. The ratios above are an
-upper bound, not a universal guarantee.
-```
+    These numbers are from a large local database (22k sessions, 310k token-bearing
+    messages). The speedup scales with session count — smaller databases will see
+    smaller absolute differences because `ccusage` has less JSONL to re-parse, but
+    AgentsView stays in the sub-second range either way. The ratios above are an
+    upper bound, not a universal guarantee.
 
 Apples-to-apples: `ccusage` scans all history by default, so the `--all` row is
 the matched comparison. The default 30-day window is faster still because most
@@ -570,10 +564,11 @@ Beyond raw speed, `agentsview usage`:
 
 - **Works beyond Claude Code** — coverage includes Claude Code, Codex, Copilot
   CLI, OpenCode-format tools, Pi, Prime Agent, Gemini, Qwen Code,
-  OpenClaw/QClaw, Hermes, WorkBuddy, Forge, Piebald, Antigravity, Zed, VS Code
-  Copilot, Visual Studio Copilot, Mistral Vibe, and gptme from the same database
-  and command whenever those sessions log token metadata. Filter with
-  `--agent <name>` when you want a single-agent view.
+  OpenClaw/QClaw, Hermes,
+  WorkBuddy, Forge, Piebald, Antigravity, Zed, VS Code Copilot, Visual Studio
+  Copilot, Mistral Vibe, and gptme from the same database and command whenever
+  those sessions log token metadata. Filter with `--agent <name>` when you want
+  a single-agent view.
 - **Shares one database with the UI** — the same data powers
   [Analytics](/usage/#dashboard) and session detail views, so there's no second
   index to keep fresh.
@@ -833,7 +828,8 @@ exactly `model_pattern`, `input_per_mtok`, `output_per_mtok`,
 exactly `above_input_tokens`, `input_per_mtok`, `output_per_mtok`,
 `cache_write_per_mtok`, `cache_read_per_mtok`, and `updated_at`. Application
 counts describe one report and are deliberately excluded from the catalog
-digest. `updated_at` is `null` or a UTC RFC3339 timestamp such as
+digest.
+`updated_at` is `null` or a UTC RFC3339 timestamp such as
 `2026-07-03T12:00:00Z`. Digest canonicalization errors fail the export instead
 of emitting an empty digest. The digest uses the resolver's internal canonical
 pricing-row keys; the public `pricing.models` block uses the `*_cost_per_mtok`
@@ -1013,7 +1009,8 @@ systemd timer's journal, or a Windows Task Scheduler action.
 
 `--json` reports the cost as exact microdollars, so the threshold is an integer
 comparison instead of a parse of the formatted line. `jq -e` fails the script
-when the value is missing, so a broken read cannot pass for an under-budget day:
+when the value is missing, so a broken read cannot pass for an under-budget
+day:
 
 ```bash
 budget_usd=25

--- a/internal/db/cursor_usage_events.go
+++ b/internal/db/cursor_usage_events.go
@@ -118,7 +118,11 @@ func (db *DB) InsertCursorUsageEvents(
 		}
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	db.notifyCursorUsage()
+	return nil
 }
 
 // CursorUsageEventDedupKey returns the stable cross-backend identity for a

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1651,6 +1651,7 @@ func checkReadOnlySchemaCompatibility(conn *sql.DB) error {
 		}
 	}
 	for _, index := range []string{
+		"idx_messages_usage_timestamp",
 		"idx_messages_usage_session_covering",
 		"idx_messages_activity_timestamp",
 	} {
@@ -3120,7 +3121,7 @@ func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
 			return fmt.Errorf("creating index: %w", err)
 		}
 	}
-	if err := ensureUsageCoveringIndexLocked(w); err != nil {
+	if err := ensureUsageIndexesLocked(w); err != nil {
 		return err
 	}
 	var sourceIndexColumns sql.NullString
@@ -3159,11 +3160,6 @@ func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
 		return fmt.Errorf("creating active session source index: %w", err)
 	}
 	if _, err := w.Exec(
-		`DROP INDEX IF EXISTS idx_messages_usage_timestamp`,
-	); err != nil {
-		return fmt.Errorf("dropping legacy usage index: %w", err)
-	}
-	if _, err := w.Exec(
 		`DROP INDEX IF EXISTS idx_artifact_checkpoint_stage_pending`,
 	); err != nil {
 		return fmt.Errorf("dropping superseded artifact stage index: %w", err)
@@ -3192,52 +3188,63 @@ func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
 	return nil
 }
 
-var usageCoveringIndexColumns = []string{
-	"timestamp", "session_id", "ordinal", "role", "model",
+var usageSessionCoveringIndexColumns = []string{
+	"session_id", "ordinal", "timestamp", "role", "model",
 	"claude_message_id", "claude_request_id", "token_usage", "source_uuid",
 }
 
-func ensureUsageCoveringIndexLocked(w *writerHandle) error {
-	var columns sql.NullString
-	if err := w.QueryRow(`
-		SELECT group_concat(name, ',')
-		FROM (
-			SELECT name
-			FROM pragma_index_info('idx_messages_usage_covering')
-			ORDER BY seqno
-		)`).Scan(&columns); err != nil {
-		return fmt.Errorf("probing usage covering index: %w", err)
+func ensureUsageIndexesLocked(w *writerHandle) error {
+	if _, err := w.Exec(`DROP INDEX IF EXISTS idx_messages_usage_covering`); err != nil {
+		return fmt.Errorf("dropping superseded usage covering index: %w", err)
 	}
-	if columns.String != strings.Join(usageCoveringIndexColumns, ",") {
-		if _, err := w.Exec(
-			`DROP INDEX IF EXISTS idx_messages_usage_covering`,
-		); err != nil {
-			return fmt.Errorf("dropping stale usage covering index: %w", err)
-		}
-		if _, err := w.Exec(`
-			CREATE INDEX IF NOT EXISTS idx_messages_usage_covering
-			ON messages(timestamp, session_id, ordinal, role, model,
-			            claude_message_id, claude_request_id, token_usage, source_uuid)
-			WHERE token_usage != ''
-			  AND model != ''
-			  AND model != '<synthetic>'`); err != nil {
-			return fmt.Errorf("creating usage covering index: %w", err)
-		}
+	if err := ensureUsageIndexColumnsLocked(
+		w, "idx_messages_usage_timestamp", []string{"timestamp", "session_id"},
+		`CREATE INDEX IF NOT EXISTS idx_messages_usage_timestamp
+		 ON messages(timestamp, session_id)
+		 WHERE token_usage != '' AND model != '' AND model != '<synthetic>'`,
+	); err != nil {
+		return err
 	}
-	if _, err := w.Exec(`
-		CREATE INDEX IF NOT EXISTS idx_messages_usage_session_covering
-		ON messages(session_id, ordinal, timestamp, role, model,
-		            claude_message_id, claude_request_id, token_usage, source_uuid)
-		WHERE token_usage != ''
-		  AND model != ''
-		  AND model != '<synthetic>'`); err != nil {
-		return fmt.Errorf("creating session usage covering index: %w", err)
+	if err := ensureUsageIndexColumnsLocked(
+		w, "idx_messages_usage_session_covering", usageSessionCoveringIndexColumns,
+		`CREATE INDEX IF NOT EXISTS idx_messages_usage_session_covering
+		 ON messages(session_id, ordinal, timestamp, role, model,
+		             claude_message_id, claude_request_id, token_usage, source_uuid)
+		 WHERE token_usage != '' AND model != '' AND model != '<synthetic>'`,
+	); err != nil {
+		return err
 	}
 	if _, err := w.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_messages_activity_timestamp
 		ON messages(timestamp, session_id, ordinal, model)
 		WHERE role = 'assistant' AND model != '<synthetic>'`); err != nil {
 		return fmt.Errorf("creating usage activity index: %w", err)
+	}
+	return nil
+}
+
+func ensureUsageIndexColumnsLocked(
+	w *writerHandle, name string, want []string, ddl string,
+) error {
+	var columns sql.NullString
+	if err := w.QueryRow(fmt.Sprintf(`
+		SELECT group_concat(name, ',')
+		FROM (
+			SELECT name
+			FROM pragma_index_info('%s')
+			ORDER BY seqno
+		)`, name)).Scan(&columns); err != nil {
+		return fmt.Errorf("probing usage index %s: %w", name, err)
+	}
+	if columns.String != strings.Join(want, ",") {
+		if _, err := w.Exec(
+			`DROP INDEX IF EXISTS ` + name,
+		); err != nil {
+			return fmt.Errorf("dropping stale usage index %s: %w", name, err)
+		}
+		if _, err := w.Exec(ddl); err != nil {
+			return fmt.Errorf("creating usage index %s: %w", name, err)
+		}
 	}
 	return nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4060,6 +4060,34 @@ func (db *DB) RebuildFTS() error {
 	return nil
 }
 
+// DropUsageMessageIndexes drops the archive usage and activity
+// message indexes so bulk message loads avoid per-row B-tree
+// maintenance. Call RebuildUsageMessageIndexes before the archive
+// is served again: read-only opens require these indexes.
+func (db *DB) DropUsageMessageIndexes() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	w := db.getWriter()
+	for _, name := range []string{
+		"idx_messages_usage_timestamp",
+		"idx_messages_usage_session_covering",
+		"idx_messages_activity_timestamp",
+	} {
+		if _, err := w.Exec(`DROP INDEX IF EXISTS ` + name); err != nil {
+			return fmt.Errorf("dropping usage index %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// RebuildUsageMessageIndexes recreates the archive usage and
+// activity message indexes after a bulk load that dropped them.
+func (db *DB) RebuildUsageMessageIndexes() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return ensureUsageIndexesLocked(db.getWriter())
+}
+
 // HasFTS checks if Full Text Search is available.
 func (db *DB) HasFTS() bool {
 	// We need to actually try to access the table, because it might exist

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -619,6 +619,10 @@ type DB struct {
 	usageBackfillDone    chan struct{}
 	usageBackfillErr     error
 	usageBackfillStarted func()
+	// usageBackfillEnabled records that this process explicitly started
+	// background backfill (the daemon lifecycle). Reopen restarts a pass
+	// only then, so CLI resyncs never trigger an unrequested archive scan.
+	usageBackfillEnabled bool
 	mu                   sync.Mutex // serializes writes
 	connMu               sync.RWMutex
 	retired              []*sql.DB // old pools kept open for in-flight reads
@@ -4502,6 +4506,15 @@ func (db *DB) Reopen() error {
 	}
 	if err := db.usageCache.RetireExcept(databaseID); err != nil {
 		return fmt.Errorf("retiring old usage cache generation: %w", err)
+	}
+	// Restart backfill only when this process explicitly enabled it
+	// (daemon lifecycle). A CLI resync reopening the archive must not
+	// kick off a full background scan of the replacement.
+	db.usageBackfillMu.Lock()
+	enabled := db.usageBackfillEnabled
+	db.usageBackfillMu.Unlock()
+	if !enabled {
+		return nil
 	}
 	return db.StartUsageCacheBackfill(context.Background())
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -610,12 +610,18 @@ END;
 // concurrent HTTP handler goroutines can safely read while
 // Reopen/CloseConnections swap the underlying *sql.DB.
 type DB struct {
-	path    string
-	writer  atomic.Pointer[sql.DB]
-	reader  atomic.Pointer[sql.DB]
-	mu      sync.Mutex // serializes writes
-	connMu  sync.RWMutex
-	retired []*sql.DB // old pools kept open for in-flight reads
+	path                 string
+	writer               atomic.Pointer[sql.DB]
+	reader               atomic.Pointer[sql.DB]
+	usageCache           *usageCacheManager
+	usageBackfillMu      sync.Mutex
+	usageBackfillCancel  context.CancelFunc
+	usageBackfillDone    chan struct{}
+	usageBackfillErr     error
+	usageBackfillStarted func()
+	mu                   sync.Mutex // serializes writes
+	connMu               sync.RWMutex
+	retired              []*sql.DB // old pools kept open for in-flight reads
 	// undrainedPools holds closed pools whose connections had not drained
 	// when CloseWriter or CloseConnections gave up. They must drain before
 	// a later close reports success, or write ownership could be released
@@ -724,6 +730,12 @@ func (r *readerHandle) BeginTx(
 	r.owner.connMu.RLock()
 	defer r.owner.connMu.RUnlock()
 	return r.current().BeginTx(ctx, opts)
+}
+
+func (r *readerHandle) Conn(ctx context.Context) (*sql.Conn, error) {
+	r.owner.connMu.RLock()
+	defer r.owner.connMu.RUnlock()
+	return r.current().Conn(ctx)
 }
 
 func (w *writerHandle) current() (*sql.DB, error) {
@@ -1444,7 +1456,11 @@ func OpenReadOnly(path string) (*DB, error) {
 		return nil, err
 	}
 
-	db := &DB{path: path, readOnly: true}
+	db := &DB{
+		path: path, readOnly: true,
+		usageCache: newUsageCacheManager(path),
+	}
+	db.usageCache.attachArchive(db)
 	db.reader.Store(reader)
 	db.cursorSecret = make([]byte, 32)
 	if _, err := rand.Read(db.cursorSecret); err != nil {
@@ -1590,9 +1606,13 @@ func tableColumns(
 type SchemaUpgradeRequiredError struct {
 	Table  string
 	Column string
+	Index  string
 }
 
 func (e *SchemaUpgradeRequiredError) Error() string {
+	if e.Index != "" {
+		return "opening read-only database: schema missing index " + e.Index
+	}
 	return fmt.Sprintf(
 		"opening read-only database: schema missing %s.%s",
 		e.Table, e.Column,
@@ -1628,6 +1648,19 @@ func checkReadOnlySchemaCompatibility(conn *sql.DB) error {
 					Column: column,
 				}
 			}
+		}
+	}
+	for _, index := range []string{
+		"idx_messages_usage_session_covering",
+		"idx_messages_activity_timestamp",
+	} {
+		var present bool
+		if err := conn.QueryRow(`SELECT EXISTS(SELECT 1 FROM sqlite_master
+			WHERE type = 'index' AND name = ?)`, index).Scan(&present); err != nil {
+			return fmt.Errorf("checking read-only index %s: %w", index, err)
+		}
+		if !present {
+			return &SchemaUpgradeRequiredError{Index: index}
 		}
 	}
 	return nil
@@ -3071,12 +3104,6 @@ func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
 		 ON messages(session_id) WHERE is_sidechain = 1`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_source_uuid
 		 ON messages(source_uuid) WHERE source_uuid != ''`,
-		`CREATE INDEX IF NOT EXISTS idx_messages_usage_covering
-		 ON messages(timestamp, session_id, ordinal, model,
-		             claude_message_id, claude_request_id, token_usage)
-		 WHERE token_usage != ''
-		   AND model != ''
-		   AND model != '<synthetic>'`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_claude_snapshot
 		 ON messages(claude_message_id, claude_request_id,
 		             timestamp, session_id, ordinal)
@@ -3092,6 +3119,9 @@ func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
 		if _, err := w.Exec(ddl); err != nil {
 			return fmt.Errorf("creating index: %w", err)
 		}
+	}
+	if err := ensureUsageCoveringIndexLocked(w); err != nil {
+		return err
 	}
 	var sourceIndexColumns sql.NullString
 	if err := w.QueryRow(`
@@ -3158,6 +3188,56 @@ func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
 		 ON insights(type, date_from, date_to, project)`,
 	); err != nil {
 		return fmt.Errorf("recreating idx_insights_lookup: %w", err)
+	}
+	return nil
+}
+
+var usageCoveringIndexColumns = []string{
+	"timestamp", "session_id", "ordinal", "role", "model",
+	"claude_message_id", "claude_request_id", "token_usage", "source_uuid",
+}
+
+func ensureUsageCoveringIndexLocked(w *writerHandle) error {
+	var columns sql.NullString
+	if err := w.QueryRow(`
+		SELECT group_concat(name, ',')
+		FROM (
+			SELECT name
+			FROM pragma_index_info('idx_messages_usage_covering')
+			ORDER BY seqno
+		)`).Scan(&columns); err != nil {
+		return fmt.Errorf("probing usage covering index: %w", err)
+	}
+	if columns.String != strings.Join(usageCoveringIndexColumns, ",") {
+		if _, err := w.Exec(
+			`DROP INDEX IF EXISTS idx_messages_usage_covering`,
+		); err != nil {
+			return fmt.Errorf("dropping stale usage covering index: %w", err)
+		}
+		if _, err := w.Exec(`
+			CREATE INDEX IF NOT EXISTS idx_messages_usage_covering
+			ON messages(timestamp, session_id, ordinal, role, model,
+			            claude_message_id, claude_request_id, token_usage, source_uuid)
+			WHERE token_usage != ''
+			  AND model != ''
+			  AND model != '<synthetic>'`); err != nil {
+			return fmt.Errorf("creating usage covering index: %w", err)
+		}
+	}
+	if _, err := w.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_messages_usage_session_covering
+		ON messages(session_id, ordinal, timestamp, role, model,
+		            claude_message_id, claude_request_id, token_usage, source_uuid)
+		WHERE token_usage != ''
+		  AND model != ''
+		  AND model != '<synthetic>'`); err != nil {
+		return fmt.Errorf("creating session usage covering index: %w", err)
+	}
+	if _, err := w.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_messages_activity_timestamp
+		ON messages(timestamp, session_id, ordinal, model)
+		WHERE role = 'assistant' AND model != '<synthetic>'`); err != nil {
+		return fmt.Errorf("creating usage activity index: %w", err)
 	}
 	return nil
 }
@@ -3758,7 +3838,8 @@ func openAndInit(path string, schemaRepairNeeded bool) (*DB, error) {
 	}
 	configureReaderPool(reader)
 
-	db := &DB{path: path}
+	db := &DB{path: path, usageCache: newUsageCacheManager(path)}
+	db.usageCache.attachArchive(db)
 	db.writer.Store(writer)
 	db.reader.Store(reader)
 
@@ -4138,6 +4219,11 @@ func (db *DB) init() error {
 // error, and the undrained pools are retained so a retry cannot succeed
 // before they actually drain.
 func (db *DB) Close() error {
+	db.StopUsageCacheBackfill()
+	var cacheErr error
+	if db.usageCache != nil {
+		cacheErr = db.usageCache.Close()
+	}
 	db.stopWALCheckpointLoop()
 	db.mu.Lock()
 	db.connMu.Lock()
@@ -4153,7 +4239,7 @@ func (db *DB) Close() error {
 	// Close the writer last: SQLite checkpoints and removes the WAL when
 	// the final connection closes, and the reader pool is mode=ro so its
 	// close cannot perform that checkpoint.
-	var errs []error
+	errs := []error{cacheErr}
 	closed := make([]*sql.DB, 0, len(retired)+len(undrained)+2)
 	for _, p := range retired {
 		errs = append(errs, p.Close())
@@ -4212,6 +4298,7 @@ func (db *DB) CloseConnections() error {
 	if db.readOnly {
 		return ErrReadOnly
 	}
+	db.StopUsageCacheBackfill()
 	db.stopWALCheckpointLoop()
 	// db.mu stays held through the drain: a concurrent Reopen or
 	// ReopenWriter would open fresh handles on the same path, letting this
@@ -4343,13 +4430,18 @@ func (db *DB) Reopen() error {
 	if db.readOnly {
 		return ErrReadOnly
 	}
+	db.StopUsageCacheBackfill()
 	db.mu.Lock()
-	defer db.mu.Unlock()
 	if err := db.reopenLocked(); err != nil {
+		db.mu.Unlock()
 		return err
 	}
 	db.startWALCheckpointLoop()
-	return nil
+	db.mu.Unlock()
+	// Reopen can follow a full archive replacement. The next snapshot derives
+	// the matching generation from database_id; existing generation handles
+	// stay alive so concurrent readers are never closed underneath a query.
+	return db.StartUsageCacheBackfill(context.Background())
 }
 
 // reopenLocked performs the reopen while db.mu is already

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3194,6 +3194,17 @@ var usageSessionCoveringIndexColumns = []string{
 }
 
 func ensureUsageIndexesLocked(w *writerHandle) error {
+	var supersededUsageIndex int
+	if err := w.QueryRow(`
+		SELECT EXISTS(
+			SELECT 1 FROM sqlite_master
+			WHERE type = 'index' AND name = 'idx_messages_usage_covering'
+		)`).Scan(&supersededUsageIndex); err != nil {
+		return fmt.Errorf("probing superseded usage covering index: %w", err)
+	}
+	if supersededUsageIndex != 0 {
+		log.Printf("rebuilding SQLite usage indexes; startup continues after the archive index migration completes")
+	}
 	if _, err := w.Exec(`DROP INDEX IF EXISTS idx_messages_usage_covering`); err != nil {
 		return fmt.Errorf("dropping superseded usage covering index: %w", err)
 	}
@@ -3214,11 +3225,14 @@ func ensureUsageIndexesLocked(w *writerHandle) error {
 	); err != nil {
 		return err
 	}
-	if _, err := w.Exec(`
-		CREATE INDEX IF NOT EXISTS idx_messages_activity_timestamp
-		ON messages(timestamp, session_id, ordinal, model)
-		WHERE role = 'assistant' AND model != '<synthetic>'`); err != nil {
-		return fmt.Errorf("creating usage activity index: %w", err)
+	if err := ensureUsageIndexColumnsLocked(
+		w, "idx_messages_activity_timestamp",
+		[]string{"timestamp", "session_id", "ordinal", "model"},
+		`CREATE INDEX IF NOT EXISTS idx_messages_activity_timestamp
+		 ON messages(timestamp, session_id, ordinal, model)
+		 WHERE role = 'assistant' AND model != '<synthetic>'`,
+	); err != nil {
+		return err
 	}
 	return nil
 }
@@ -3237,6 +3251,12 @@ func ensureUsageIndexColumnsLocked(
 		return fmt.Errorf("probing usage index %s: %w", name, err)
 	}
 	if columns.String != strings.Join(want, ",") {
+		if columns.Valid && columns.String != "" {
+			log.Printf(
+				"rebuilding stale SQLite usage index %s; startup continues after the archive index migration completes",
+				name,
+			)
+		}
 		if _, err := w.Exec(
 			`DROP INDEX IF EXISTS ` + name,
 		); err != nil {
@@ -4445,9 +4465,16 @@ func (db *DB) Reopen() error {
 	}
 	db.startWALCheckpointLoop()
 	db.mu.Unlock()
-	// Reopen can follow a full archive replacement. The next snapshot derives
-	// the matching generation from database_id; existing generation handles
-	// stay alive so concurrent readers are never closed underneath a query.
+	// Reopen can follow a full archive replacement. Retire cache generations
+	// tied to the old database ID so their notification workers do not keep
+	// querying the replacement archive or retain SQLite pools indefinitely.
+	databaseID, err := db.GetDatabaseID(context.Background())
+	if err != nil {
+		return fmt.Errorf("reading reopened database ID: %w", err)
+	}
+	if err := db.usageCache.RetireExcept(databaseID); err != nil {
+		return fmt.Errorf("retiring old usage cache generation: %w", err)
+	}
 	return db.StartUsageCacheBackfill(context.Background())
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5230,6 +5230,7 @@ func TestCopyOrphanedDataFromReconcilesTranscriptRevisions(t *testing.T) {
 	ids := []string{
 		"unchanged", "changed", "tool-changed",
 		"compact-changed", "subtype-changed",
+		"usage-changed", "claude-identity-changed", "source-identity-changed",
 	}
 	for _, id := range ids {
 		insertSession(t, srcDB, id, "proj")
@@ -5240,11 +5241,23 @@ func TestCopyOrphanedDataFromReconcilesTranscriptRevisions(t *testing.T) {
 		asstMsg("tool-changed", 0, "tool"),
 		userMsg("compact-changed", 0, "boundary"),
 		userMsg("subtype-changed", 0, "system event"),
+		asstMsg("usage-changed", 0, "same response"),
+		asstMsg("claude-identity-changed", 0, "same response"),
+		asstMsg("source-identity-changed", 0, "same response"),
 	)
 	_, err := srcDB.getWriter().Exec(`
 		UPDATE messages SET is_system = 1
 		WHERE session_id = 'subtype-changed'`)
 	requireNoError(t, err, "mark source system message")
+	_, err = srcDB.getWriter().Exec(`
+		UPDATE messages SET token_usage = '{"input_tokens":10}'
+		WHERE session_id = 'usage-changed';
+		UPDATE messages
+		SET claude_message_id = 'msg-old', claude_request_id = 'req-old'
+		WHERE session_id = 'claude-identity-changed';
+		UPDATE messages SET source_uuid = 'source-old'
+		WHERE session_id = 'source-identity-changed'`)
+	requireNoError(t, err, "seed source usage identities")
 	_, err = srcDB.getWriter().Exec(`
 		INSERT INTO tool_calls
 			(message_id, session_id, tool_name, category, input_json, call_index)
@@ -5269,6 +5282,9 @@ func TestCopyOrphanedDataFromReconcilesTranscriptRevisions(t *testing.T) {
 		asstMsg("tool-changed", 0, "tool"),
 		userMsg("compact-changed", 0, "boundary"),
 		userMsg("subtype-changed", 0, "system event"),
+		asstMsg("usage-changed", 0, "same response"),
+		asstMsg("claude-identity-changed", 0, "same response"),
+		asstMsg("source-identity-changed", 0, "same response"),
 	)
 	_, err = dstDB.getWriter().Exec(`
 		UPDATE messages
@@ -5276,7 +5292,14 @@ func TestCopyOrphanedDataFromReconcilesTranscriptRevisions(t *testing.T) {
 		WHERE session_id = 'compact-changed';
 		UPDATE messages
 		SET is_system = 1, source_subtype = 'resume'
-		WHERE session_id = 'subtype-changed'`)
+		WHERE session_id = 'subtype-changed';
+		UPDATE messages SET token_usage = '{"input_tokens":20}'
+		WHERE session_id = 'usage-changed';
+		UPDATE messages
+		SET claude_message_id = 'msg-new', claude_request_id = 'req-new'
+		WHERE session_id = 'claude-identity-changed';
+		UPDATE messages SET source_uuid = 'source-new'
+		WHERE session_id = 'source-identity-changed'`)
 	requireNoError(t, err, "change destination display fields")
 	_, err = dstDB.getWriter().Exec(`
 		INSERT INTO tool_calls
@@ -5309,7 +5332,10 @@ func TestCopyOrphanedDataFromReconcilesTranscriptRevisions(t *testing.T) {
 	require.NotNil(t, toolChanged.TranscriptRevision)
 	assert.Equal(t, "8", *toolChanged.TranscriptRevision)
 
-	for _, id := range []string{"compact-changed", "subtype-changed"} {
+	for _, id := range []string{
+		"compact-changed", "subtype-changed", "usage-changed",
+		"claude-identity-changed", "source-identity-changed",
+	} {
 		session, err := dstDB.GetSession(context.Background(), id)
 		requireNoError(t, err, "GetSession "+id)
 		require.NotNil(t, session)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -8424,7 +8424,7 @@ func TestSessionsTerminationStatusIndex(t *testing.T) {
 		count)
 }
 
-func TestMessagesUsageCoveringIndex(t *testing.T) {
+func TestMessagesUsageIndexes(t *testing.T) {
 	d := testDB(t)
 
 	var count int
@@ -8434,17 +8434,17 @@ func TestMessagesUsageCoveringIndex(t *testing.T) {
 	).Scan(&count)
 	requireNoError(t, err, "probing idx_messages_usage_covering")
 
-	require.Equal(t, 1, count,
-		"expected idx_messages_usage_covering to exist, got count=%d",
+	require.Equal(t, 0, count,
+		"expected superseded idx_messages_usage_covering to be absent, got count=%d",
 		count)
 
 	err = d.getReader().QueryRow(
 		`SELECT count(*) FROM sqlite_master
 		 WHERE type = 'index' AND name = 'idx_messages_usage_timestamp'`,
 	).Scan(&count)
-	requireNoError(t, err, "probing legacy idx_messages_usage_timestamp")
-	require.Equal(t, 0, count,
-		"expected idx_messages_usage_timestamp to be dropped")
+	requireNoError(t, err, "probing idx_messages_usage_timestamp")
+	require.Equal(t, 1, count,
+		"expected idx_messages_usage_timestamp to exist")
 }
 
 // TestMigration_TerminationStatusColumn simulates upgrading from a

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -942,7 +942,8 @@ func (db *DB) InsertMessages(msgs []Message) error {
 	if err := insertToolResultEventsTx(tx, events); err != nil {
 		return err
 	}
-	for _, sessionID := range messageSessionIDs(msgs) {
+	sessionIDs := messageSessionIDs(msgs)
+	for _, sessionID := range sessionIDs {
 		if err := bumpTranscriptRevisionTx(tx, sessionID); err != nil {
 			return err
 		}
@@ -955,7 +956,11 @@ func (db *DB) InsertMessages(msgs []Message) error {
 			return err
 		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	db.notifyUsageSessions(sessionIDs)
+	return nil
 }
 
 // invalidateSessionSignalsTx zeroes quality_signal_version so the
@@ -1049,6 +1054,7 @@ func (db *DB) WriteSessionIncremental(
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("committing incremental write tx: %w", err)
 	}
+	db.notifyUsageSessions([]string{sessionID})
 	return nil
 }
 
@@ -1216,8 +1222,10 @@ func (db *DB) ReplaceSessionMessages(
 	// clear them and reset the scan state (empty version => secrets scan
 	// --backfill re-scans). ReplaceSessionContent does not call this method; it
 	// supplies fresh findings via replaceSecretFindingsTx directly.
-	if err := replaceSecretFindingsTx(tx, sessionID, nil, 0, ""); err != nil {
-		return err
+	if transcriptChanged {
+		if err := replaceSecretFindingsTx(tx, sessionID, nil, 0, ""); err != nil {
+			return err
+		}
 	}
 	if err := invalidateSessionSignalsTx(tx, sessionID); err != nil {
 		return err
@@ -1230,6 +1238,7 @@ func (db *DB) ReplaceSessionMessages(
 	if err := tx.Commit(); err != nil {
 		return err
 	}
+	db.notifyUsageSessions([]string{sessionID})
 	pendingRecallRevocations.flush()
 	return nil
 }
@@ -1281,6 +1290,7 @@ func bumpTranscriptRevisionTx(tx *sql.Tx, sessionID string) error {
 		 SET transcript_revision = CAST(
 			CAST(transcript_revision AS INTEGER) + 1 AS TEXT
 		 ),
+		     local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
 		     secrets_rules_version = ''
 		 WHERE id = ?`,
 		sessionID,
@@ -1457,6 +1467,7 @@ func (db *DB) ReplaceSessionContent(
 	if err := tx.Commit(); err != nil {
 		return err
 	}
+	db.notifyUsageSessions([]string{sessionID})
 	pendingRecallRevocations.flush()
 	return nil
 }
@@ -2385,24 +2396,14 @@ func (db *DB) SetToolCallSubagentSession(
 		if err := bumpTranscriptRevisionTx(tx, sessionID); err != nil {
 			return err
 		}
-		// Bump local_modified_at so the sync_marker trigger fires and push
-		// targets re-select the session: the linkage lands in mirrored
-		// data (tool_calls.subagent_session_id and transcript_revision)
-		// but touches no sync_marker signal on its own (see
-		// LinkSubagentSessions for the same pattern).
-		if _, err := tx.Exec(
-			`UPDATE sessions
-			    SET local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-			  WHERE id = ?`,
-			sessionID,
-		); err != nil {
-			return fmt.Errorf(
-				"bumping local_modified_at for %s after subagent link: %w",
-				sessionID, err,
-			)
-		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if changed {
+		db.notifyUsageSessions([]string{sessionID})
+	}
+	return nil
 }
 
 func applyToolCallSubagentLinkTx(

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1278,23 +1278,46 @@ func replaceSessionMessagesTx(
 	return restorePinsTx(tx, sessionID, pins)
 }
 
+// bumpTranscriptRevisionTx advances the transcript revision for a
+// mutated existing session. Touching local_modified_at fires the
+// sync_marker trigger so push targets re-select the session.
 func bumpTranscriptRevisionTx(tx *sql.Tx, sessionID string) error {
+	return bumpTranscriptRevision(tx, sessionID, true)
+}
+
+// bumpInsertedTranscriptRevisionTx advances the revision for a session
+// inserted in this same transaction. The INSERT trigger already stamped
+// sync_marker, so skipping the local_modified_at touch avoids a
+// redundant trigger recompute on every bulk-loaded session.
+func bumpInsertedTranscriptRevisionTx(tx *sql.Tx, sessionID string) error {
+	return bumpTranscriptRevision(tx, sessionID, false)
+}
+
+func bumpTranscriptRevision(
+	tx *sql.Tx, sessionID string, touchModified bool,
+) error {
 	// Advancing the revision also revokes secret-scan freshness in the same
 	// transaction: the mutated transcript has content the recorded scan
 	// never saw, and consumers that require a current scan (extraction's
 	// privacy boundary) must fail closed until a rescan re-stamps it. The
 	// incremental sync path re-scans in a separate later write; the atomic
 	// replace path re-stamps inside this same transaction.
-	result, err := tx.Exec(
-		`UPDATE sessions
+	query := `UPDATE sessions
 		 SET transcript_revision = CAST(
 			CAST(transcript_revision AS INTEGER) + 1 AS TEXT
 		 ),
 		     local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
 		     secrets_rules_version = ''
-		 WHERE id = ?`,
-		sessionID,
-	)
+		 WHERE id = ?`
+	if !touchModified {
+		query = `UPDATE sessions
+		 SET transcript_revision = CAST(
+			CAST(transcript_revision AS INTEGER) + 1 AS TEXT
+		 ),
+		     secrets_rules_version = ''
+		 WHERE id = ?`
+	}
+	result, err := tx.Exec(query, sessionID)
 	if err != nil {
 		return fmt.Errorf(
 			"bumping transcript revision for %s: %w", sessionID, err,

--- a/internal/db/messages_diff.go
+++ b/internal/db/messages_diff.go
@@ -151,11 +151,7 @@ func transcriptMessageEqual(a, b Message) bool {
 	comparableTranscriptMessage := func(msg Message) Message {
 		msg.ID = 0
 		msg.ContentLength = 0
-		msg.TokenUsage = nil
-		msg.ClaudeMessageID = ""
-		msg.ClaudeRequestID = ""
 		msg.SourceType = ""
-		msg.SourceUUID = ""
 		msg.SourceParentUUID = ""
 		msg.IsSidechain = false
 		msg.ToolCalls = append([]ToolCall(nil), msg.ToolCalls...)

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -1736,8 +1736,9 @@ func orphanSessionCols(ctx context.Context, tx *sql.Tx) string {
 // reconcileTranscriptRevisionsTx preserves read-progress identity across a
 // full resync. Reparsed sessions start with fresh local counters, so matching
 // transcript rows inherit the old counter and changed rows advance it once.
-// The comparison covers the user-visible message and tool-result fields while
-// deliberately excluding session metadata and token/source bookkeeping.
+// The comparison covers the same persisted transcript identity used by the
+// incremental message-diff path, including usage and provider dedup identities.
+// Session metadata and parser-only source bookkeeping remain excluded.
 func reconcileTranscriptRevisionsTx(
 	ctx context.Context, tx *sql.Tx,
 ) error {
@@ -1747,6 +1748,8 @@ func reconcileTranscriptRevisionsTx(
 	for table, columns := range map[string][]string{
 		"messages": {
 			"thinking_text", "is_system", "model",
+			"token_usage", "claude_message_id", "claude_request_id",
+			"source_uuid",
 			"context_tokens", "output_tokens",
 			"has_context_tokens", "has_output_tokens",
 			"source_subtype", "prompt_source", "is_compact_boundary",
@@ -1774,14 +1777,16 @@ func reconcileTranscriptRevisionsTx(
 			SELECT CASE WHEN
 				NOT EXISTS (
 					SELECT ordinal, role, content, thinking_text, timestamp,
-						has_thinking, has_tool_use, is_system, model,
+						has_thinking, has_tool_use, is_system, model, token_usage,
+						claude_message_id, claude_request_id, source_uuid,
 						context_tokens, output_tokens, has_context_tokens,
 						has_output_tokens, source_subtype, prompt_source,
 						is_compact_boundary
 					FROM main.messages WHERE session_id = current.id
 					EXCEPT
 					SELECT ordinal, role, content, thinking_text, timestamp,
-						has_thinking, has_tool_use, is_system, model,
+						has_thinking, has_tool_use, is_system, model, token_usage,
+						claude_message_id, claude_request_id, source_uuid,
 						context_tokens, output_tokens, has_context_tokens,
 						has_output_tokens, source_subtype, prompt_source,
 						is_compact_boundary
@@ -1789,14 +1794,16 @@ func reconcileTranscriptRevisionsTx(
 				)
 				AND NOT EXISTS (
 					SELECT ordinal, role, content, thinking_text, timestamp,
-						has_thinking, has_tool_use, is_system, model,
+						has_thinking, has_tool_use, is_system, model, token_usage,
+						claude_message_id, claude_request_id, source_uuid,
 						context_tokens, output_tokens, has_context_tokens,
 						has_output_tokens, source_subtype, prompt_source,
 						is_compact_boundary
 					FROM old_db.messages WHERE session_id = current.id
 					EXCEPT
 					SELECT ordinal, role, content, thinking_text, timestamp,
-						has_thinking, has_tool_use, is_system, model,
+						has_thinking, has_tool_use, is_system, model, token_usage,
+						claude_message_id, claude_request_id, source_uuid,
 						context_tokens, output_tokens, has_context_tokens,
 						has_output_tokens, source_subtype, prompt_source,
 						is_compact_boundary

--- a/internal/db/prepared_testdb_test.go
+++ b/internal/db/prepared_testdb_test.go
@@ -27,7 +27,8 @@ func OpenPreparedTestDB(path string) (*DB, error) {
 	}
 	reader.SetMaxOpenConns(4)
 
-	db := &DB{path: path}
+	db := &DB{path: path, usageCache: newUsageCacheManager(path)}
+	db.usageCache.attachArchive(db)
 	db.writer.Store(writer)
 	db.reader.Store(reader)
 

--- a/internal/db/read_only_test.go
+++ b/internal/db/read_only_test.go
@@ -281,6 +281,19 @@ func TestOpenReadOnlyRejectsMissingMigratedColumn(t *testing.T) {
 	requireOpenReadOnlyFails(t, path, "schema missing sessions.deletion_cause")
 }
 
+func TestOpenReadOnlyRejectsMissingUsageCacheIndexes(t *testing.T) {
+	for _, index := range []string{
+		"idx_messages_usage_session_covering",
+		"idx_messages_activity_timestamp",
+	} {
+		t.Run(index, func(t *testing.T) {
+			path := createClosedTestDB(t, tempDBPath(t, "sessions.db"), nil)
+			execRawSQLite(t, path, "DROP INDEX "+index)
+			requireOpenReadOnlyFails(t, path, "schema missing index "+index)
+		})
+	}
+}
+
 func TestReadOnlySchemaCompatibilityRejectsMissingReadColumn(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/db/read_only_test.go
+++ b/internal/db/read_only_test.go
@@ -283,6 +283,7 @@ func TestOpenReadOnlyRejectsMissingMigratedColumn(t *testing.T) {
 
 func TestOpenReadOnlyRejectsMissingUsageCacheIndexes(t *testing.T) {
 	for _, index := range []string{
+		"idx_messages_usage_timestamp",
 		"idx_messages_usage_session_covering",
 		"idx_messages_activity_timestamp",
 	} {

--- a/internal/db/secret_findings_test.go
+++ b/internal/db/secret_findings_test.go
@@ -111,6 +111,43 @@ func TestReplaceSessionMessagesResetsSecretState(t *testing.T) {
 	assert.Empty(t, ver, "secrets_rules_version (forces backfill rescan)")
 }
 
+func TestReplaceSessionMessagesPreservesSecretStateWhenTranscriptIsUnchanged(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "proj")
+	messages := []Message{{
+		SessionID: "s1", Ordinal: 0, Role: "user", Content: "same content",
+	}}
+	require.NoError(t, d.ReplaceSessionMessages("s1", messages), "seed messages")
+	findings := []SecretFinding{{
+		SessionID: "s1", RuleName: "test-rule", Confidence: "definite",
+		LocationKind: "message", MessageOrdinal: 0, MatchStart: 0, MatchEnd: 4,
+		MatchIndex: 0, RedactedMatch: "same",
+	}}
+	require.NoError(t,
+		d.ReplaceSessionSecretFindings("s1", findings, 1, "rules-v1"),
+		"seed findings",
+	)
+
+	require.NoError(t, d.ReplaceSessionMessages("s1", messages), "no-op replace")
+
+	got, err := d.SessionSecretFindings(ctx, "s1")
+	require.NoError(t, err, "read findings")
+	require.Len(t, got, 1, "no-op replace must preserve current findings")
+	assert.Equal(t, "test-rule", got[0].RuleName)
+	var leak int
+	var version string
+	err = d.getReader().QueryRow(`
+		SELECT secret_leak_count, secrets_rules_version
+		FROM sessions WHERE id = 's1'`,
+	).Scan(&leak, &version)
+	require.NoError(t, err, "read scan state")
+	assert.Equal(t, 1, leak)
+	assert.Equal(t, "rules-v1", version)
+}
+
 func TestOrphanCopyPreservesSecretFindings(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -452,7 +452,11 @@ func writeOneSessionBatchTx(
 		}
 	}
 	if transcriptChanged {
-		if err := bumpTranscriptRevisionTx(tx, write.Session.ID); err != nil {
+		bump := bumpTranscriptRevisionTx
+		if !sessionExists {
+			bump = bumpInsertedTranscriptRevisionTx
+		}
+		if err := bump(tx, write.Session.ID); err != nil {
 			return 0, err
 		}
 	}

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -83,6 +83,7 @@ func (db *DB) WriteSessionBatch(
 	}
 	defer func() { _ = tx.Rollback() }()
 	var pendingRecallRevocations recallEvidenceRevocationEvents
+	var writtenUsageIDs []string
 
 	for i, write := range writes {
 		write = sanitizeSessionBatchWrite(write)
@@ -114,6 +115,7 @@ func (db *DB) WriteSessionBatch(
 			result.WrittenSessions++
 			result.WrittenMessages += messagesWritten
 			result.WrittenIndexes = append(result.WrittenIndexes, i)
+			writtenUsageIDs = append(writtenUsageIDs, write.Session.ID)
 		case errors.Is(err, ErrSessionExcluded),
 			errors.Is(err, ErrSessionTrashed):
 			if rerr := rollbackSavepoint(tx, savepoint); rerr != nil {
@@ -137,6 +139,7 @@ func (db *DB) WriteSessionBatch(
 	if err := tx.Commit(); err != nil {
 		return result, fmt.Errorf("committing batch tx: %w", err)
 	}
+	db.notifyUsageSessions(writtenUsageIDs)
 	pendingRecallRevocations.flush()
 	return result, nil
 }
@@ -165,6 +168,7 @@ func (db *DB) WriteSessionBatchAtomic(
 	}
 	defer func() { _ = tx.Rollback() }()
 	var pendingRecallRevocations recallEvidenceRevocationEvents
+	var writtenUsageIDs []string
 
 	for i, write := range writes {
 		write = sanitizeSessionBatchWrite(write)
@@ -194,6 +198,7 @@ func (db *DB) WriteSessionBatchAtomic(
 		result.WrittenSessions++
 		result.WrittenMessages += messagesWritten
 		result.WrittenIndexes = append(result.WrittenIndexes, i)
+		writtenUsageIDs = append(writtenUsageIDs, write.Session.ID)
 	}
 
 	if len(beforeCommit) > 0 && beforeCommit[0] != nil {
@@ -208,6 +213,7 @@ func (db *DB) WriteSessionBatchAtomic(
 	if err := tx.Commit(); err != nil {
 		return result, fmt.Errorf("committing batch tx: %w", err)
 	}
+	db.notifyUsageSessions(writtenUsageIDs)
 	pendingRecallRevocations.flush()
 	return result, nil
 }

--- a/internal/db/session_batch_test.go
+++ b/internal/db/session_batch_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -153,4 +154,52 @@ func TestWriteSessionBatchMessageCountDecisionIsSerialized(t *testing.T) {
 	require.Equal(t, 120, shorter.ExistingMessages)
 	require.Equal(t, 24, shorter.IncomingMessages)
 	requireSessionMessageCount(t, d, "session", 120)
+}
+
+func TestWriteSessionBatchInsertSkipsRedundantModifiedTouch(t *testing.T) {
+	d := testDB(t)
+	_, err := d.getWriter().Exec(`
+		CREATE TABLE modified_touch_log(session_id TEXT);
+		CREATE TRIGGER trg_modified_touch_log
+		AFTER UPDATE OF local_modified_at ON sessions
+		BEGIN
+			INSERT INTO modified_touch_log VALUES (NEW.id);
+		END`)
+	require.NoError(t, err, "install touch-counting trigger")
+	touches := func() int {
+		var count int
+		require.NoError(t, d.getReader().QueryRow(
+			`SELECT count(*) FROM modified_touch_log`,
+		).Scan(&count), "count local_modified_at touches")
+		return count
+	}
+	resetTouches := func() {
+		_, err := d.getWriter().Exec(`DELETE FROM modified_touch_log`)
+		require.NoError(t, err, "reset touch log")
+	}
+
+	// A newly inserted session already fires the sync_marker INSERT
+	// trigger, so its revision bump must not touch local_modified_at.
+	// Replacing an existing transcript must add exactly that one touch
+	// so push targets re-select the session.
+	_, err = d.WriteSessionBatchAtomic([]SessionBatchWrite{
+		messageCountWrite("session", 4),
+	})
+	require.NoError(t, err)
+	insertTouches := touches()
+
+	resetTouches()
+	_, err = d.WriteSessionBatchAtomic([]SessionBatchWrite{
+		messageCountWrite("session", 6),
+	})
+	require.NoError(t, err)
+	require.Equal(t, insertTouches+1, touches(),
+		"revision bump must touch local_modified_at only for replacements")
+
+	var modifiedAt sql.NullString
+	require.NoError(t, d.getReader().QueryRow(
+		`SELECT local_modified_at FROM sessions WHERE id = 'session'`,
+	).Scan(&modifiedAt), "read local_modified_at")
+	require.True(t, modifiedAt.Valid && modifiedAt.String != "",
+		"batch-written session must carry local_modified_at")
 }

--- a/internal/db/sessions_sync_marker_test.go
+++ b/internal/db/sessions_sync_marker_test.go
@@ -4,11 +4,158 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type usageVersion struct {
+	revision string
+	marker   string
+}
+
+func readUsageVersion(t *testing.T, database *DB, id string) usageVersion {
+	t.Helper()
+	var got usageVersion
+	require.NoError(t, database.getReader().QueryRow(
+		`SELECT transcript_revision, sync_marker FROM sessions WHERE id = ?`, id,
+	).Scan(&got.revision, &got.marker))
+	return got
+}
+
+func freezeUsageVersionSignals(t *testing.T, database *DB, id string) usageVersion {
+	t.Helper()
+	_, err := database.getWriter().Exec(
+		`UPDATE sessions
+		 SET created_at = '2026-07-01T10:00:00.000Z',
+		     local_modified_at = '2026-07-01T10:00:00.000Z',
+		     started_at = NULL, ended_at = NULL, file_mtime = 0
+		 WHERE id = ?`, id,
+	)
+	require.NoError(t, err)
+	return readUsageVersion(t, database, id)
+}
+
+func usageVersionMessage(id string, tokenUsage string) Message {
+	return Message{
+		SessionID: id, Ordinal: 0, Role: "assistant", Content: "answer",
+		ContentLength: len("answer"), Model: "model-x",
+		TokenUsage: json.RawMessage(tokenUsage),
+	}
+}
+
+func TestMessageMutationAdvancesUsageVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, *DB, string, Message)
+		write func(*testing.T, *DB, string, Message)
+	}{
+		{
+			name: "InsertMessages",
+			setup: func(t *testing.T, d *DB, id string, _ Message) {
+				insertSession(t, d, id, "proj")
+			},
+			write: func(t *testing.T, d *DB, _ string, changed Message) {
+				require.NoError(t, d.InsertMessages([]Message{changed}))
+			},
+		},
+		{
+			name: "WriteSessionIncremental",
+			setup: func(t *testing.T, d *DB, id string, _ Message) {
+				insertSession(t, d, id, "proj")
+			},
+			write: func(t *testing.T, d *DB, id string, changed Message) {
+				require.NoError(t, d.WriteSessionIncremental(
+					id, []Message{changed}, IncrementalSessionUpdate{},
+				))
+			},
+		},
+		{
+			name: "ReplaceSessionMessages",
+			setup: func(t *testing.T, d *DB, id string, original Message) {
+				insertSession(t, d, id, "proj")
+				insertMessages(t, d, original)
+			},
+			write: func(t *testing.T, d *DB, id string, changed Message) {
+				require.NoError(t, d.ReplaceSessionMessages(id, []Message{changed}))
+			},
+		},
+		{
+			name: "ReplaceSessionContent",
+			setup: func(t *testing.T, d *DB, id string, original Message) {
+				insertSession(t, d, id, "proj")
+				insertMessages(t, d, original)
+			},
+			write: func(t *testing.T, d *DB, id string, changed Message) {
+				require.NoError(t, d.ReplaceSessionContent(
+					id, []Message{changed}, SessionSignalUpdate{}, nil,
+				))
+			},
+		},
+		{
+			name: "WriteSessionBatch",
+			setup: func(t *testing.T, d *DB, id string, original Message) {
+				insertSession(t, d, id, "proj")
+				insertMessages(t, d, original)
+			},
+			write: func(t *testing.T, d *DB, id string, changed Message) {
+				result, err := d.WriteSessionBatch([]SessionBatchWrite{{
+					Session:  Session{ID: id, Project: "proj", Machine: "m", Agent: "a"},
+					Messages: []Message{changed}, ReplaceMessages: true,
+				}})
+				require.NoError(t, err)
+				require.Equal(t, 1, result.WrittenSessions)
+			},
+		},
+		{
+			name: "WriteSessionBatchAtomic",
+			setup: func(t *testing.T, d *DB, id string, original Message) {
+				insertSession(t, d, id, "proj")
+				insertMessages(t, d, original)
+			},
+			write: func(t *testing.T, d *DB, id string, changed Message) {
+				result, err := d.WriteSessionBatchAtomic([]SessionBatchWrite{{
+					Session:  Session{ID: id, Project: "proj", Machine: "m", Agent: "a"},
+					Messages: []Message{changed}, ReplaceMessages: true,
+				}})
+				require.NoError(t, err)
+				require.Equal(t, 1, result.WrittenSessions)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			database := testDB(t)
+			id := "usage-version-" + tc.name
+			original := usageVersionMessage(id, `{"input_tokens":1}`)
+			changed := usageVersionMessage(id, `{"input_tokens":2}`)
+			tc.setup(t, database, id, original)
+			before := freezeUsageVersionSignals(t, database, id)
+
+			tc.write(t, database, id, changed)
+
+			after := readUsageVersion(t, database, id)
+			assert.NotEqual(t, before.revision, after.revision)
+			assert.Greater(t, after.marker, before.marker)
+		})
+	}
+}
+
+func TestMessageNoOpPreservesUsageVersion(t *testing.T) {
+	database := testDB(t)
+	id := "usage-noop-replacement"
+	msg := usageVersionMessage(id, `{"input_tokens":1}`)
+	insertSession(t, database, id, "proj")
+	insertMessages(t, database, msg)
+	before := freezeUsageVersionSignals(t, database, id)
+
+	require.NoError(t, database.ReplaceSessionMessages(id, []Message{msg}))
+
+	assert.Equal(t, before, readUsageVersion(t, database, id))
+}
 
 func TestSyncMarkerMaintainedByTriggers(t *testing.T) {
 	database := testDB(t)

--- a/internal/db/token_clamp.go
+++ b/internal/db/token_clamp.go
@@ -1,19 +1,14 @@
 package db
 
+import "go.kenn.io/agentsview/internal/usagefacts"
+
 // MaxPlausibleTokens bounds a single parsed token count. Session totals may
 // legitimately exceed this by summing many rows, but one row-level token field
 // above this limit is treated as corrupt input.
-const MaxPlausibleTokens = 2_000_000
+const MaxPlausibleTokens = usagefacts.MaxPlausibleTokens
 
 // ClampPlausibleTokens bounds a single token count to the accepted row-level
 // range. Negative counts are floored at zero.
 func ClampPlausibleTokens(v int64) int {
-	switch {
-	case v < 0:
-		return 0
-	case v > MaxPlausibleTokens:
-		return MaxPlausibleTokens
-	default:
-		return int(v)
-	}
+	return int(usagefacts.ClampPlausibleTokens(v))
 }

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -7,16 +7,15 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"go.kenn.io/agentsview/internal/activity"
 	"go.kenn.io/agentsview/internal/export"
 	"go.kenn.io/agentsview/internal/money"
 	"go.kenn.io/agentsview/internal/parser"
 	pricingpkg "go.kenn.io/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/usagefacts"
 )
 
 // CopilotReportedCostSource identifies the authoritative cumulative cost
@@ -1452,200 +1451,22 @@ func scanDailyUsageRowWithMachine(
 func parseUsageTokenCounters(
 	tokenJSON string,
 ) (inputTok, outputTok, cacheCrTok, cacheRdTok int) {
-	inputTok, outputTok, cacheCrTok, cacheRdTok, _ =
-		parseUsageTokenCountersWithReasoning(tokenJSON)
-	return
+	parsed := usagefacts.ParseTokenUsage(tokenJSON)
+	return int(parsed.InputTokens), int(parsed.OutputTokens),
+		int(parsed.CacheCreationTokens), int(parsed.CacheReadTokens)
 }
 
 func parseUsageTokenCountersWithReasoning(
 	tokenJSON string,
 ) (inputTok, outputTok, cacheCrTok, cacheRdTok, reasoningTok int) {
-	i := skipJSONSpace(tokenJSON, 0)
-	if i >= len(tokenJSON) || tokenJSON[i] != '{' {
-		return
-	}
-	i++
-	for i < len(tokenJSON) {
-		i = skipJSONSpace(tokenJSON, i)
-		if i >= len(tokenJSON) || tokenJSON[i] == '}' {
-			break
-		}
-		if tokenJSON[i] == ',' {
-			i++
-			continue
-		}
-		if tokenJSON[i] != '"' {
-			next, ok := skipJSONValue(tokenJSON, i)
-			if !ok || next <= i {
-				i++
-			} else {
-				i = next
-			}
-			continue
-		}
-		key, next, ok := parseJSONString(tokenJSON, i)
-		if !ok {
-			break
-		}
-		i = skipJSONSpace(tokenJSON, next)
-		if i >= len(tokenJSON) || tokenJSON[i] != ':' {
-			continue
-		}
-		i = skipJSONSpace(tokenJSON, i+1)
-		if isUsageTokenCounterKey(key) {
-			value, valueNext, ok := parseUsageTokenInt(tokenJSON, i)
-			if ok {
-				switch key {
-				case "input_tokens":
-					inputTok = value
-				case "output_tokens":
-					outputTok = value
-				case "cache_creation_input_tokens":
-					cacheCrTok = value
-				case "cache_read_input_tokens":
-					cacheRdTok = value
-				case "reasoning_tokens":
-					reasoningTok = value
-				}
-			}
-			if valueNext <= i {
-				i++
-			} else {
-				i = valueNext
-			}
-			continue
-		}
-		valueNext, ok := skipJSONValue(tokenJSON, i)
-		if !ok {
-			break
-		}
-		i = valueNext
-	}
-	return
+	parsed := usagefacts.ParseTokenUsage(tokenJSON)
+	return int(parsed.InputTokens), int(parsed.OutputTokens),
+		int(parsed.CacheCreationTokens), int(parsed.CacheReadTokens),
+		int(parsed.ReasoningTokens)
 }
 
-func isUsageTokenCounterKey(key string) bool {
-	switch key {
-	case "input_tokens", "output_tokens",
-		"cache_creation_input_tokens", "cache_read_input_tokens",
-		"reasoning_tokens":
-		return true
-	default:
-		return false
-	}
-}
-
-// usageServerToolUseKey is the nested object Anthropic reports server tool
-// use under, and usageWebSearchRequestsKey the billed web search count
-// inside it. Only Anthropic's wire format uses these names, so their
-// presence is what identifies a row as carrying Anthropic web search spend.
-const (
-	usageServerToolUseKey     = "server_tool_use"
-	usageWebSearchRequestsKey = "web_search_requests"
-)
-
-// parseUsageWebSearchRequests reads server_tool_use.web_search_requests out
-// of a stored token_usage blob. It is a separate scan from
-// parseUsageTokenCountersWithReasoning because the value is nested and is
-// not a token count: it must never be clamped or summed as tokens. Blobs
-// without the key exit on a substring check before any parsing.
 func parseUsageWebSearchRequests(tokenJSON string) int {
-	if !strings.Contains(tokenJSON, usageServerToolUseKey) {
-		return 0
-	}
-	serverToolUse, ok := usageObjectRawValue(tokenJSON, usageServerToolUseKey)
-	if !ok {
-		return 0
-	}
-	requests, ok := usageObjectInt(serverToolUse, usageWebSearchRequestsKey)
-	if !ok || requests < 0 {
-		return 0
-	}
-	return requests
-}
-
-// usageObjectRawValue returns the raw JSON text of want's value in a
-// top-level JSON object.
-func usageObjectRawValue(
-	tokenJSON, want string,
-) (string, bool) {
-	i := skipJSONSpace(tokenJSON, 0)
-	if i >= len(tokenJSON) || tokenJSON[i] != '{' {
-		return "", false
-	}
-	i++
-	for i < len(tokenJSON) {
-		i = skipJSONSpace(tokenJSON, i)
-		if i >= len(tokenJSON) || tokenJSON[i] == '}' {
-			return "", false
-		}
-		if tokenJSON[i] == ',' {
-			i++
-			continue
-		}
-		if tokenJSON[i] != '"' {
-			return "", false
-		}
-		key, next, ok := parseJSONString(tokenJSON, i)
-		if !ok {
-			return "", false
-		}
-		i = skipJSONSpace(tokenJSON, next)
-		if i >= len(tokenJSON) || tokenJSON[i] != ':' {
-			return "", false
-		}
-		i = skipJSONSpace(tokenJSON, i+1)
-		valueNext, ok := skipJSONValue(tokenJSON, i)
-		if !ok || valueNext <= i {
-			return "", false
-		}
-		if key == want {
-			return tokenJSON[i:valueNext], true
-		}
-		i = valueNext
-	}
-	return "", false
-}
-
-// usageObjectInt reads want's integer value out of a flat JSON object.
-func usageObjectInt(obj, want string) (int, bool) {
-	i := skipJSONSpace(obj, 0)
-	if i >= len(obj) || obj[i] != '{' {
-		return 0, false
-	}
-	i++
-	for i < len(obj) {
-		i = skipJSONSpace(obj, i)
-		if i >= len(obj) || obj[i] == '}' {
-			return 0, false
-		}
-		if obj[i] == ',' {
-			i++
-			continue
-		}
-		if obj[i] != '"' {
-			return 0, false
-		}
-		key, next, ok := parseJSONString(obj, i)
-		if !ok {
-			return 0, false
-		}
-		i = skipJSONSpace(obj, next)
-		if i >= len(obj) || obj[i] != ':' {
-			return 0, false
-		}
-		i = skipJSONSpace(obj, i+1)
-		if key == want {
-			value, _, ok := parseUsageTokenInt(obj, i)
-			return value, ok
-		}
-		valueNext, ok := skipJSONValue(obj, i)
-		if !ok || valueNext <= i {
-			return 0, false
-		}
-		i = valueNext
-	}
-	return 0, false
+	return int(usagefacts.ParseTokenUsage(tokenJSON).WebSearchRequests)
 }
 
 // usageRowWebSearchRequests returns how many billed Anthropic server-side
@@ -1663,208 +1484,6 @@ func dailyUsageRowWebSearchRequests(r dailyUsageScanRow) int {
 		return max(int(r.webSearchRequests.Int64), 0)
 	}
 	return usageRowWebSearchRequests(r.usageSource, r.tokenJSON)
-}
-
-func skipJSONSpace(tokenJSON string, i int) int {
-	for i < len(tokenJSON) && isJSONSpace(tokenJSON[i]) {
-		i++
-	}
-	return i
-}
-
-// parseJSONString reads the JSON string literal starting at tokenJSON[i]
-// and returns its decoded value and the index after the closing quote.
-// Literals without escapes or control characters, which is every usage key
-// and nearly every value, are returned as a substring so the hot per-row
-// scan does not allocate; anything else goes through encoding/json so the
-// result matches json.Unmarshal exactly.
-func parseJSONString(tokenJSON string, i int) (string, int, bool) {
-	if i >= len(tokenJSON) || tokenJSON[i] != '"' {
-		return "", i, false
-	}
-	plain := true
-	for j := i + 1; j < len(tokenJSON); j++ {
-		c := tokenJSON[j]
-		switch {
-		case c == '\\':
-			if j+1 >= len(tokenJSON) {
-				return "", len(tokenJSON), false
-			}
-			plain = false
-			j++
-		case c == '"':
-			if plain && utf8.ValidString(tokenJSON[i+1:j]) {
-				return tokenJSON[i+1 : j], j + 1, true
-			}
-			raw := tokenJSON[i : j+1]
-			var value string
-			err := json.Unmarshal([]byte(raw), &value)
-			if err != nil {
-				return "", j + 1, false
-			}
-			return value, j + 1, true
-		case c < 0x20:
-			plain = false
-		}
-	}
-	return "", len(tokenJSON), false
-}
-
-func parseUsageTokenInt(tokenJSON string, i int) (int, int, bool) {
-	if i >= len(tokenJSON) {
-		return 0, i, false
-	}
-	if tokenJSON[i] == '"' {
-		value, next, ok := parseJSONString(tokenJSON, i)
-		if !ok {
-			return 0, next, false
-		}
-		parsed, ok := parseUsageTokenIntLiteral(strings.TrimSpace(value))
-		return parsed, next, ok
-	}
-	start := i
-	if tokenJSON[i] == '-' {
-		i++
-	}
-	digitStart := i
-	for i < len(tokenJSON) && tokenJSON[i] >= '0' && tokenJSON[i] <= '9' {
-		i++
-	}
-	if i == digitStart {
-		next, ok := skipJSONValue(tokenJSON, start)
-		if ok {
-			return 0, next, false
-		}
-		return 0, start, false
-	}
-	parsed, ok := parseUsageTokenIntLiteral(tokenJSON[start:i])
-	return parsed, i, ok
-}
-
-func parseUsageTokenIntLiteral(value string) (int, bool) {
-	parsed, err := strconv.ParseInt(value, 10, 0)
-	if err == nil {
-		return int(parsed), true
-	}
-	if numErr, ok := err.(*strconv.NumError); ok && numErr.Err == strconv.ErrRange {
-		if strings.HasPrefix(value, "-") {
-			return -int(^uint(0)>>1) - 1, true
-		}
-		return int(^uint(0) >> 1), true
-	}
-	return 0, false
-}
-
-func skipJSONValue(tokenJSON string, i int) (int, bool) {
-	i = skipJSONSpace(tokenJSON, i)
-	if i >= len(tokenJSON) {
-		return i, false
-	}
-	switch tokenJSON[i] {
-	case '"':
-		_, next, ok := parseJSONString(tokenJSON, i)
-		return next, ok
-	case '{', '[':
-		return skipJSONComposite(tokenJSON, i)
-	case 't':
-		if strings.HasPrefix(tokenJSON[i:], "true") {
-			return i + len("true"), true
-		}
-	case 'f':
-		if strings.HasPrefix(tokenJSON[i:], "false") {
-			return i + len("false"), true
-		}
-	case 'n':
-		if strings.HasPrefix(tokenJSON[i:], "null") {
-			return i + len("null"), true
-		}
-	default:
-		return skipJSONNumber(tokenJSON, i)
-	}
-	return i, false
-}
-
-func skipJSONComposite(tokenJSON string, i int) (int, bool) {
-	var stack []byte
-	switch tokenJSON[i] {
-	case '{':
-		stack = append(stack, '}')
-	case '[':
-		stack = append(stack, ']')
-	default:
-		return i, false
-	}
-	i++
-	for i < len(tokenJSON) {
-		switch tokenJSON[i] {
-		case '"':
-			_, next, ok := parseJSONString(tokenJSON, i)
-			if !ok {
-				return next, false
-			}
-			i = next
-		case '{':
-			stack = append(stack, '}')
-			i++
-		case '[':
-			stack = append(stack, ']')
-			i++
-		case '}', ']':
-			if len(stack) == 0 || tokenJSON[i] != stack[len(stack)-1] {
-				return i + 1, false
-			}
-			stack = stack[:len(stack)-1]
-			i++
-			if len(stack) == 0 {
-				return i, true
-			}
-		default:
-			i++
-		}
-	}
-	return len(tokenJSON), false
-}
-
-func skipJSONNumber(tokenJSON string, i int) (int, bool) {
-	start := i
-	if tokenJSON[i] == '-' {
-		i++
-	}
-	digitStart := i
-	for i < len(tokenJSON) && tokenJSON[i] >= '0' && tokenJSON[i] <= '9' {
-		i++
-	}
-	if i == digitStart {
-		return start, false
-	}
-	if i < len(tokenJSON) && tokenJSON[i] == '.' {
-		i++
-		fracStart := i
-		for i < len(tokenJSON) && tokenJSON[i] >= '0' && tokenJSON[i] <= '9' {
-			i++
-		}
-		if i == fracStart {
-			return start, false
-		}
-	}
-	if i < len(tokenJSON) && (tokenJSON[i] == 'e' || tokenJSON[i] == 'E') {
-		i++
-		if i < len(tokenJSON) && (tokenJSON[i] == '+' || tokenJSON[i] == '-') {
-			i++
-		}
-		expStart := i
-		for i < len(tokenJSON) && tokenJSON[i] >= '0' && tokenJSON[i] <= '9' {
-			i++
-		}
-		if i == expStart {
-			return start, false
-		}
-	}
-	return i, true
-}
-
-func isJSONSpace(b byte) bool {
-	return b == ' ' || b == '\n' || b == '\r' || b == '\t'
 }
 
 func clampedUsageRowTokens(
@@ -1940,91 +1559,74 @@ func dailyUsageAmounts(
 	cost, savings money.Money,
 	err error,
 ) {
-	reasoningTok := 0
-	inputTok, outputTok, cacheCrTok, cacheRdTok, reasoningTok =
-		dailyUsageRowTokens(r)
-
-	pricedModel, lookup := pricing.Resolve(
-		r.model, usageLookupModel(r.model, r.ts))
-	rates := lookup.Rates
-	requestScoped := usageRowIsRequestScoped(r.usageSource, r.messageOrdinal)
-	if r.cost.Valid && r.costSource != CopilotReportedCostSource {
-		cost = money.Money{Microdollars: r.cost.Int64}
-		pricing.RecordResolvedReported(r.model, pricedModel, lookup)
+	fact, _ := dailyUsageFact(r)
+	if r.webSearchRequests.Valid {
+		fact.WebSearchRequests = int64(max(int(r.webSearchRequests.Int64), 0))
+	}
+	inputTok = int(fact.InputTokens)
+	outputTok = int(fact.OutputTokens)
+	cacheCrTok = int(fact.CacheCreationTokens)
+	cacheRdTok = int(fact.CacheReadTokens)
+	priced, err := priceUsageFact(usagePriceInput{
+		Fact: fact, Timestamp: r.ts, ReportedModel: r.model,
+	}, pricing)
+	if err != nil {
+		return 0, 0, 0, 0, money.Money{}, money.Money{}, err
+	}
+	_, lookup := pricing.Resolve(r.model, usageLookupModel(r.model, r.ts))
+	if priced.Reported > 0 {
+		pricing.RecordResolvedReported(r.model, priced.PricedModel, lookup)
 	} else {
-		cost, err = rates.CostForTokensScoped(
-			requestScoped,
-			inputTok, outputTok, reasoningTok, cacheCrTok, cacheRdTok)
-		if err != nil {
-			return 0, 0, 0, 0, money.Money{}, money.Money{},
-				fmt.Errorf("pricing usage row for model %q: %w", r.model, err)
-		}
-		// Anthropic bills server-side web search per request on top of
-		// tokens; see sessionRowCost for why a reported cost skips it.
-		cost, err = export.AddWebSearchFee(
-			cost, dailyUsageRowWebSearchRequests(r))
-		if err != nil {
-			return 0, 0, 0, 0, money.Money{}, money.Money{},
-				fmt.Errorf("pricing usage row for model %q: %w", r.model, err)
-		}
 		recordComputedUsagePricing(
-			pricing,
-			r.model,
-			pricedModel,
-			lookup,
-			requestScoped,
-			inputTok,
-			cacheCrTok,
-			cacheRdTok,
+			pricing, r.model, priced.PricedModel, lookup, fact.RequestScoped,
+			inputTok, cacheCrTok, cacheRdTok,
 		)
 	}
-
-	selectedRates := rates
-	if requestScoped {
-		selectedRates = rates.RatesForTokens(inputTok, cacheCrTok, cacheRdTok)
-	}
-	readRate, err := money.Sub(
-		selectedRates.InputPerMTok,
-		selectedRates.CacheReadPerMTok,
-	)
-	if err != nil {
-		return 0, 0, 0, 0, money.Money{}, money.Money{},
-			fmt.Errorf("deriving cache read rate for model %q: %w", r.model, err)
-	}
-	creationRate, err := money.Sub(
-		selectedRates.InputPerMTok,
-		selectedRates.CacheWritePerMTok,
-	)
-	if err != nil {
-		return 0, 0, 0, 0, money.Money{}, money.Money{},
-			fmt.Errorf("deriving cache creation rate for model %q: %w", r.model, err)
-	}
-	savings, err = money.SignedCostPerMillion([]money.RatedTokens{
-		{Tokens: int64(cacheRdTok), Rate: readRate},
-		{Tokens: int64(cacheCrTok), Rate: creationRate},
-	})
-	if err != nil {
-		return 0, 0, 0, 0, money.Money{}, money.Money{},
-			fmt.Errorf("pricing cache savings for model %q: %w", r.model, err)
-	}
+	cost = priced.Cost
+	savings = priced.Savings
 	return
 }
 
 func dailyUsageRowTokens(
 	r dailyUsageScanRow,
 ) (inputTok, outputTok, cacheCrTok, cacheRdTok, reasoningTok int) {
-	reasoningTok = r.reasoningTokens
+	fact, _ := dailyUsageFact(r)
+	return int(fact.InputTokens), int(fact.OutputTokens),
+		int(fact.CacheCreationTokens), int(fact.CacheReadTokens),
+		int(fact.ReasoningTokens)
+}
+
+func dailyUsageFact(r dailyUsageScanRow) (usagefacts.Fact, bool) {
 	if r.usageSource == "message" {
-		inputTok, outputTok, cacheCrTok, cacheRdTok, reasoningTok =
-			clampedUsageTokenCountersWithReasoning(r.tokenJSON)
-	} else {
-		inputTok, outputTok, cacheCrTok, cacheRdTok =
-			usageEventRowTokens(
-				r.usageSource,
-				r.inputTokens, r.outputTokens,
-				r.cacheCreationInputTokens, r.cacheReadInputTokens)
+		return usagefacts.FromMessage(usagefacts.MessageInput{
+			Ordinal: int(r.messageOrdinal.Int64), Role: "assistant",
+			Timestamp: r.ts, Model: r.model, TokenUsage: r.tokenJSON,
+			ClaudeMessageID: r.claudeMessageID,
+			ClaudeRequestID: r.claudeRequestID,
+			SourceUUID:      r.sourceUUID,
+		})
 	}
-	return
+	var ordinal *int
+	if r.messageOrdinal.Valid {
+		value := int(r.messageOrdinal.Int64)
+		ordinal = &value
+	}
+	var reportedCost *int64
+	if r.cost.Valid {
+		value := r.cost.Int64
+		reportedCost = &value
+	}
+	return usagefacts.FromEvent(usagefacts.EventInput{
+		MessageOrdinal: ordinal, Source: r.usageSource,
+		Timestamp: r.ts, Model: r.model,
+		CostSource: r.costSource, DedupKey: r.usageDedupKey,
+		InputTokens:              int64(r.inputTokens),
+		OutputTokens:             int64(r.outputTokens),
+		ReasoningTokens:          int64(r.reasoningTokens),
+		CacheCreationTokens:      int64(r.cacheCreationInputTokens),
+		CacheReadTokens:          int64(r.cacheReadInputTokens),
+		ReportedCostMicrodollars: reportedCost,
+	})
 }
 
 func usageRowIsRequestScoped(
@@ -2459,12 +2061,9 @@ func paddedUTCBound(ts string, hours int) string {
 	return t.Add(time.Duration(hours) * time.Hour).Format(time.RFC3339)
 }
 
-// GetDailyUsage returns token usage and cost aggregated by day.
-// It scans messages with non-empty token_usage JSON blobs,
-// parses them in Go (faster than SQLite's json_extract per row),
-// joins against an in-memory pricing map, and buckets by
-// local date.
-func (db *DB) GetDailyUsage(
+// getDailyUsageLegacy is the wide-row test oracle for the facts-backed path.
+// Production callers enter through GetDailyUsage in usage_cache_daily.go.
+func (db *DB) getDailyUsageLegacy(
 	ctx context.Context, f UsageFilter,
 ) (DailyUsageResult, error) {
 	loc := f.location()
@@ -3124,10 +2723,8 @@ func SortAndLimitTopSessions(
 	return result
 }
 
-// GetTopSessionsByCost returns sessions ranked by total cost, or by total
-// tokens when f.TopSessionsSort is "tokens",
-// over the filter range. Default limit 20, max 100.
-func (db *DB) GetTopSessionsByCost(
+// getTopSessionsByCostLegacy is the wide-row test oracle for the facts path.
+func (db *DB) getTopSessionsByCostLegacy(
 	ctx context.Context, f UsageFilter, limit int,
 ) ([]TopSessionEntry, error) {
 	pricing, err := db.loadPricingMap(ctx)
@@ -3474,8 +3071,8 @@ func sessionUsageBreakdownLabel(r usageScanRow) string {
 		nullInt64Pointer(r.messageOrdinal), r.usageSource)
 }
 
-// GetSessionUsage returns one session's token totals and cost
-// estimate. It starts from GetSession (so metadata and session-level
+// getSessionUsageLegacy is the wide-row test oracle. It starts from GetSession
+// (so metadata and session-level
 // token aggregates are reported even when there are no per-message
 // usage rows), then aggregates cost over the session's own usage
 // rows. Dedup is intra-session only; this reports the session's own
@@ -3484,7 +3081,7 @@ func sessionUsageBreakdownLabel(r usageScanRow) string {
 // the session does not exist. BreakdownCount is always populated;
 // per-row Breakdown entries are built only when includeBreakdown is
 // true so callers that need just the totals avoid the row payload.
-func (db *DB) GetSessionUsage(
+func (db *DB) getSessionUsageLegacy(
 	ctx context.Context, sessionID string, includeBreakdown bool,
 ) (*SessionUsage, error) {
 	sess, err := db.GetSession(ctx, sessionID)
@@ -3695,15 +3292,15 @@ func NewUsageSessionCounts(
 	return out
 }
 
-// GetUsageSessionCounts returns distinct session counts grouped
-// by project and agent. Sessions spanning multiple days count
+// getUsageSessionCountsLegacy is the wide-row test oracle. Sessions spanning
+// multiple days count
 // once. Soft-deleted sessions are excluded via
 // usageMessageEligibility.
 //
 // Like GetDailyUsage and GetTopSessionsByCost, this query pads
 // the UTC bounds by +/-14h and applies a post-query localDate
 // filter so timezone-boundary messages are counted correctly.
-func (db *DB) GetUsageSessionCounts(
+func (db *DB) getUsageSessionCountsLegacy(
 	ctx context.Context, f UsageFilter,
 ) (UsageSessionCounts, error) {
 	query, args := topSessionsUsageRowQuery(f)
@@ -3792,14 +3389,15 @@ func (db *DB) GetUsageSessionCounts(
 	return out, nil
 }
 
-// GetUsageMatchingSessionCount counts sessions that match the usage filter
+// getUsageMatchingSessionCountLegacy is the wide-row test oracle for sessions
+// that match the usage filter
 // even when they have no token-bearing usage rows. Bounded ranges are
 // resolved against the timestamps of the sessions' messages/usage_events
 // rows (falling back to s.started_at for rows with no timestamp of their
 // own), the same shape usageRowsSQLForBounds uses, so a session whose
 // started_at/ended_at fall outside the window but whose message activity
 // falls inside it is still counted.
-func (db *DB) GetUsageMatchingSessionCount(
+func (db *DB) getUsageMatchingSessionCountLegacy(
 	ctx context.Context, f UsageFilter,
 ) (int, error) {
 	bounds := usageBoundsForFilter(f)

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"go.kenn.io/agentsview/internal/activity"
@@ -339,15 +340,21 @@ func buildUsageTerminationPredSQLite(status string) (string, []any) {
 }
 
 // location loads the timezone or returns the system local timezone.
+var usageLocationCache sync.Map
+
 func (f UsageFilter) location() *time.Location {
 	if f.Timezone == "" {
 		return time.Local
+	}
+	if cached, ok := usageLocationCache.Load(f.Timezone); ok {
+		return cached.(*time.Location)
 	}
 	loc, err := time.LoadLocation(f.Timezone)
 	if err != nil {
 		return time.Local
 	}
-	return loc
+	actual, _ := usageLocationCache.LoadOrStore(f.Timezone, loc)
+	return actual.(*time.Location)
 }
 
 // usageMessageEligibility is the WHERE-clause fragment that selects
@@ -1315,7 +1322,7 @@ const usageSnapshotClaudeIdentity = usageMessageSourceEligibility + `
 // more than one eligible message. It over-approximates the ranked set (it
 // ignores session eligibility and the fallback session bounds), which only
 // sends extra rows through the ranking; the ranking itself applies the exact
-// row-source predicates. Bounded filters seek idx_messages_usage_covering
+// row-source predicates. Bounded filters seek idx_messages_usage_timestamp
 // per timestamp branch so the pass stays proportional to the window;
 // unbounded filters read idx_messages_claude_snapshot in partition order.
 func usageSnapshotDuplicateRequestsSQL(b usageBounds) (string, []any) {

--- a/internal/db/usage_cache_background.go
+++ b/internal/db/usage_cache_background.go
@@ -131,6 +131,9 @@ func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if cache == nil || cache.fill == nil || cache.rollup == nil {
+		return fmt.Errorf("usage cache generation is not attached to the archive")
+	}
 	locations, err := usageBackfillLocations(ctx, cache, snapshot.location)
 	if err != nil {
 		return err
@@ -263,7 +266,7 @@ func (db *DB) usageBackfillActivity(ctx context.Context) (map[string]string, err
 	rows, err := db.getReader().QueryContext(ctx, `
 		SELECT session_id, MAX(activity_at) FROM (
 			SELECT m.session_id, m.timestamp AS activity_at
-			FROM messages m INDEXED BY idx_messages_usage_covering
+			FROM messages m INDEXED BY idx_messages_usage_timestamp
 			WHERE `+usageMessageSourceEligibility+`
 			UNION ALL
 			SELECT m.session_id, m.timestamp AS activity_at

--- a/internal/db/usage_cache_background.go
+++ b/internal/db/usage_cache_background.go
@@ -1,0 +1,415 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"runtime"
+	"sort"
+	"strconv"
+	"time"
+
+	"go.kenn.io/agentsview/internal/export"
+)
+
+// Match the install transaction bound so foreground waiters are released as
+// soon as each committed batch is available.
+const usageCacheBackfillBatchSize = usageFillInstallBatchSize
+
+const (
+	usageCacheVacuumFreelistThreshold = 4096
+	usageCacheVacuumPages             = 256
+)
+
+// StartUsageCacheBackfill starts one newest-first cache population pass.
+// Installed session versions remain the source of truth, so restarting a pass
+// naturally skips completed work.
+func (db *DB) StartUsageCacheBackfill(ctx context.Context) error {
+	if db.readOnly {
+		return fmt.Errorf("usage cache background backfill requires a writable archive")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db.usageBackfillMu.Lock()
+	if db.usageBackfillDone != nil {
+		select {
+		case <-db.usageBackfillDone:
+			db.usageBackfillDone = nil
+		default:
+			db.usageBackfillMu.Unlock()
+			return nil
+		}
+	}
+	workerCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	db.usageBackfillCancel = cancel
+	db.usageBackfillDone = done
+	db.usageBackfillErr = nil
+	started := db.usageBackfillStarted
+	db.usageBackfillMu.Unlock()
+
+	go func() {
+		err := db.runUsageCacheBackfill(workerCtx)
+		db.usageBackfillMu.Lock()
+		db.usageBackfillErr = err
+		close(done)
+		db.usageBackfillMu.Unlock()
+	}()
+	if started != nil {
+		started()
+	}
+	return nil
+}
+
+// SetUsageCacheBackfillStarted records a callback for daemon lifecycle
+// integration. The callback must return promptly; it runs after each new pass
+// starts, including passes restarted after an archive reopen.
+func (db *DB) SetUsageCacheBackfillStarted(started func()) {
+	db.usageBackfillMu.Lock()
+	db.usageBackfillStarted = started
+	active := false
+	if db.usageBackfillDone != nil {
+		select {
+		case <-db.usageBackfillDone:
+		default:
+			active = true
+		}
+	}
+	db.usageBackfillMu.Unlock()
+	if active && started != nil {
+		started()
+	}
+}
+
+// WaitUsageCacheBackfill waits for the current pass, if any.
+func (db *DB) WaitUsageCacheBackfill(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db.usageBackfillMu.Lock()
+	done := db.usageBackfillDone
+	db.usageBackfillMu.Unlock()
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+	}
+	db.usageBackfillMu.Lock()
+	err := db.usageBackfillErr
+	db.usageBackfillMu.Unlock()
+	return err
+}
+
+// StopUsageCacheBackfill cancels and joins the active pass before cache handles
+// are closed.
+func (db *DB) StopUsageCacheBackfill() {
+	db.usageBackfillMu.Lock()
+	cancel := db.usageBackfillCancel
+	done := db.usageBackfillDone
+	db.usageBackfillMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
+	started := time.Now()
+	snapshot, err := db.captureUsageQuery(
+		ctx, UsageFilter{}, usageQueryKindActivity)
+	if err != nil {
+		return err
+	}
+	cache, err := db.usageCache.Generation(ctx, snapshot.DatabaseID)
+	if err != nil {
+		return err
+	}
+	locations, err := usageBackfillLocations(ctx, cache, snapshot.location)
+	if err != nil {
+		return err
+	}
+	if err := cache.sweepDeletionJournal(ctx, db); err != nil {
+		return err
+	}
+	activity, err := db.usageBackfillActivity(ctx)
+	if err != nil {
+		return err
+	}
+	orderUsageBackfillSnapshot(&snapshot, activity)
+	resolver := export.NewPricingResolver(snapshot.PricingRows)
+	covered, deleted := 0, 0
+	for start := 0; start < len(snapshot.Versions); start += usageCacheBackfillBatchSize {
+		end := min(start+usageCacheBackfillBatchSize, len(snapshot.Versions))
+		cursorTarget := int64(0)
+		if start == 0 {
+			cursorTarget = snapshot.CursorHighWater
+		}
+		results, fillErr := cache.fill.FillBackground(
+			ctx, snapshot.Versions[start:end], cursorTarget)
+		if fillErr != nil {
+			return fillErr
+		}
+		batch := snapshot
+		batch.Sessions = snapshot.Sessions[start:end]
+		batch.Versions = snapshot.Versions[start:end]
+		batch.CursorHighWater = cursorTarget
+		for _, location := range locations {
+			zoned := batch
+			zoned.location = location
+			if _, _, err := cache.rollup.Ensure(ctx, zoned, results, resolver); err != nil {
+				return fmt.Errorf("building usage rollups during backfill: %w", err)
+			}
+		}
+		if _, err := cache.db.ExecContext(ctx, `PRAGMA optimize`); err != nil {
+			return fmt.Errorf("optimizing usage cache during backfill: %w", err)
+		}
+		if end < len(snapshot.Versions) {
+			cache.fill.maintainBetweenInstallBatches(ctx)
+		}
+		for _, result := range results {
+			if result.Deleted {
+				deleted++
+			} else {
+				covered++
+			}
+		}
+		if _, err := cache.db.ExecContext(ctx, `
+			UPDATE usage_cache_metadata SET value = ? WHERE key = ?`,
+			snapshot.Versions[end-1].SessionID,
+			usageCacheMetadataBackfillProgress,
+		); err != nil {
+			return fmt.Errorf("recording usage cache backfill progress: %w", err)
+		}
+	}
+	if len(snapshot.Versions) == 0 {
+		results, err := cache.fill.FillBackground(ctx, nil, snapshot.CursorHighWater)
+		if err != nil {
+			return err
+		}
+		for _, location := range locations {
+			zoned := snapshot
+			zoned.location = location
+			if _, _, err := cache.rollup.Ensure(ctx, zoned, results, resolver); err != nil {
+				return fmt.Errorf("building Cursor usage rollups during backfill: %w", err)
+			}
+		}
+	}
+	if err := cache.sweepDeletionJournal(ctx, db); err != nil {
+		return err
+	}
+	if _, err := cache.incrementalVacuum(
+		ctx, usageCacheVacuumFreelistThreshold, usageCacheVacuumPages,
+	); err != nil {
+		return err
+	}
+	if _, err := cache.db.ExecContext(ctx, `ANALYZE`); err != nil {
+		return fmt.Errorf("analyzing completed usage cache: %w", err)
+	}
+	if _, err := cache.db.ExecContext(ctx, `
+		UPDATE usage_cache_metadata SET value = ? WHERE key = ?`,
+		time.Now().UTC().Format(time.RFC3339Nano),
+		usageCacheMetadataBackfillCompletedAt,
+	); err != nil {
+		return fmt.Errorf("recording usage cache completion time: %w", err)
+	}
+	log.Printf("usage cache backfill: covered %d sessions (%d deleted) in %s",
+		covered, deleted, time.Since(started).Round(time.Millisecond))
+	return nil
+}
+
+func usageBackfillLocations(
+	ctx context.Context, cache *usageCache, local *time.Location,
+) ([]*time.Location, error) {
+	localIdentity := usageTimezoneIdentityFor(local, nil)
+	rows, err := cache.db.QueryContext(ctx, `SELECT timezone_name
+		FROM usage_rollup_timezones
+		WHERE timezone_key != ? AND timezone_name NOT IN ('', 'Local')
+		ORDER BY last_requested_at DESC LIMIT 8`, localIdentity.Key)
+	if err != nil {
+		return nil, fmt.Errorf("reading recent usage timezones: %w", err)
+	}
+	defer rows.Close()
+	locations := []*time.Location{local}
+	seen := map[string]bool{localIdentity.Key: true}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		location, err := time.LoadLocation(name)
+		if err != nil {
+			continue
+		}
+		key := usageTimezoneIdentityFor(location, nil).Key
+		if !seen[key] {
+			seen[key] = true
+			locations = append(locations, location)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return locations, nil
+}
+
+func (db *DB) usageBackfillActivity(ctx context.Context) (map[string]string, error) {
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT session_id, MAX(activity_at) FROM (
+			SELECT m.session_id, m.timestamp AS activity_at
+			FROM messages m INDEXED BY idx_messages_usage_covering
+			WHERE `+usageMessageSourceEligibility+`
+			UNION ALL
+			SELECT m.session_id, m.timestamp AS activity_at
+			FROM messages m INDEXED BY idx_messages_activity_timestamp
+			WHERE m.role = 'assistant' AND m.model != '<synthetic>'
+			UNION ALL
+			SELECT ue.session_id, ue.occurred_at AS activity_at
+			FROM usage_events ue INDEXED BY idx_usage_events_session
+			WHERE ue.model != ''
+		) WHERE activity_at IS NOT NULL AND activity_at != ''
+		GROUP BY session_id`)
+	if err != nil {
+		return nil, fmt.Errorf("ordering usage cache backfill: %w", err)
+	}
+	defer rows.Close()
+	activity := make(map[string]string)
+	for rows.Next() {
+		var sessionID, timestamp string
+		if err := rows.Scan(&sessionID, &timestamp); err != nil {
+			return nil, err
+		}
+		activity[sessionID] = timestamp
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return activity, nil
+}
+
+func orderUsageBackfillSnapshot(
+	snapshot *usageQuerySnapshot, activity map[string]string,
+) {
+	type record struct {
+		session usageQuerySession
+		version usageSourceVersion
+		latest  string
+	}
+	records := make([]record, len(snapshot.Sessions))
+	for index, session := range snapshot.Sessions {
+		latest := maxTimestampText(
+			activity[session.ID], session.EndedAt, session.StartedAt)
+		if latest == "" {
+			latest = session.CreatedAt
+		}
+		records[index] = record{
+			session: session, version: snapshot.Versions[index], latest: latest,
+		}
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].latest != records[j].latest {
+			return records[i].latest > records[j].latest
+		}
+		return records[i].session.ID < records[j].session.ID
+	})
+	for index, record := range records {
+		snapshot.Sessions[index] = record.session
+		snapshot.Versions[index] = record.version
+	}
+}
+
+func maxTimestampText(values ...string) string {
+	var result string
+	for _, value := range values {
+		if value > result {
+			result = value
+		}
+	}
+	return result
+}
+
+func (cache *usageCache) sweepDeletionJournal(ctx context.Context, archive *DB) error {
+	var raw string
+	if err := cache.db.QueryRowContext(ctx, `
+		SELECT value FROM usage_cache_metadata WHERE key = ?`,
+		usageCacheMetadataDeletionRevision,
+	).Scan(&raw); err != nil {
+		return err
+	}
+	after, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || after < 0 {
+		return fmt.Errorf("invalid usage cache deletion revision %q", raw)
+	}
+	through, err := archive.SessionDeletionPublicationRevision(ctx)
+	if err != nil || through == after {
+		return err
+	}
+	tombstones, err := archive.LoadSessionDeletionDelta(
+		ctx, after, through, nil, nil)
+	if err != nil {
+		return err
+	}
+	tx, err := cache.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, tombstone := range tombstones {
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
+			tombstone.SessionID,
+		); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE usage_cache_metadata
+		SET value = CAST(MAX(CAST(value AS INTEGER), ?) AS TEXT)
+		WHERE key = ?`, through, usageCacheMetadataDeletionRevision,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (cache *usageCache) incrementalVacuum(
+	ctx context.Context, threshold, pages int,
+) (bool, error) {
+	if threshold < 0 || pages <= 0 {
+		return false, fmt.Errorf("invalid usage cache vacuum bounds")
+	}
+	var freelist int
+	if err := cache.db.QueryRowContext(ctx, `PRAGMA freelist_count`).Scan(&freelist); err != nil {
+		return false, err
+	}
+	if freelist <= threshold {
+		return false, nil
+	}
+	if _, err := cache.db.ExecContext(ctx,
+		fmt.Sprintf("PRAGMA incremental_vacuum(%d)", pages)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (c *usageFillCoordinator) maintainBetweenInstallBatches(ctx context.Context) {
+	if err := c.cache.sweepDeletionJournal(ctx, c.archive); err != nil &&
+		!errors.Is(err, context.Canceled) {
+		log.Printf("usage cache deletion sweep: %v", err)
+	}
+	if _, err := c.cache.incrementalVacuum(
+		ctx, usageCacheVacuumFreelistThreshold, usageCacheVacuumPages,
+	); err != nil && !errors.Is(err, context.Canceled) {
+		log.Printf("usage cache incremental vacuum: %v", err)
+	}
+	if c.observer.afterMaintenance != nil {
+		c.observer.afterMaintenance()
+	}
+	runtime.Gosched()
+}

--- a/internal/db/usage_cache_background.go
+++ b/internal/db/usage_cache_background.go
@@ -148,6 +148,7 @@ func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
 	orderUsageBackfillSnapshot(&snapshot, activity)
 	resolver := export.NewPricingResolver(snapshot.PricingRows)
 	covered, deleted := 0, 0
+	var dailyRows, exceptionGroups, exceptionRows int64
 	for start := 0; start < len(snapshot.Versions); start += usageCacheBackfillBatchSize {
 		end := min(start+usageCacheBackfillBatchSize, len(snapshot.Versions))
 		cursorTarget := int64(0)
@@ -166,8 +167,12 @@ func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
 		for _, location := range locations {
 			zoned := batch
 			zoned.location = location
-			if _, _, err := cache.rollup.Ensure(ctx, zoned, results, resolver); err != nil {
+			if _, metrics, err := cache.rollup.Ensure(ctx, zoned, results, resolver); err != nil {
 				return fmt.Errorf("building usage rollups during backfill: %w", err)
+			} else {
+				dailyRows += metrics.DailyRows
+				exceptionGroups += metrics.ExceptionGroups
+				exceptionRows += metrics.ExceptionRows
 			}
 		}
 		if _, err := cache.db.ExecContext(ctx, `PRAGMA optimize`); err != nil {
@@ -183,13 +188,6 @@ func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
 				covered++
 			}
 		}
-		if _, err := cache.db.ExecContext(ctx, `
-			UPDATE usage_cache_metadata SET value = ? WHERE key = ?`,
-			snapshot.Versions[end-1].SessionID,
-			usageCacheMetadataBackfillProgress,
-		); err != nil {
-			return fmt.Errorf("recording usage cache backfill progress: %w", err)
-		}
 	}
 	if len(snapshot.Versions) == 0 {
 		results, err := cache.fill.FillBackground(ctx, nil, snapshot.CursorHighWater)
@@ -199,8 +197,12 @@ func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
 		for _, location := range locations {
 			zoned := snapshot
 			zoned.location = location
-			if _, _, err := cache.rollup.Ensure(ctx, zoned, results, resolver); err != nil {
+			if _, metrics, err := cache.rollup.Ensure(ctx, zoned, results, resolver); err != nil {
 				return fmt.Errorf("building Cursor usage rollups during backfill: %w", err)
+			} else {
+				dailyRows += metrics.DailyRows
+				exceptionGroups += metrics.ExceptionGroups
+				exceptionRows += metrics.ExceptionRows
 			}
 		}
 	}
@@ -222,8 +224,9 @@ func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
 	); err != nil {
 		return fmt.Errorf("recording usage cache completion time: %w", err)
 	}
-	log.Printf("usage cache backfill: covered %d sessions (%d deleted) in %s",
-		covered, deleted, time.Since(started).Round(time.Millisecond))
+	log.Printf("usage cache backfill: covered %d sessions (%d deleted), built %d daily rows and %d exception rows in %d groups in %s",
+		covered, deleted, dailyRows, exceptionRows, exceptionGroups,
+		time.Since(started).Round(time.Millisecond))
 	return nil
 }
 
@@ -364,6 +367,12 @@ func (cache *usageCache) sweepDeletionJournal(ctx context.Context, archive *DB) 
 	}
 	defer func() { _ = tx.Rollback() }()
 	for _, tombstone := range tombstones {
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM usage_rollup_installs WHERE session_id = ?`,
+			tombstone.SessionID,
+		); err != nil {
+			return err
+		}
 		if _, err := tx.ExecContext(ctx,
 			`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
 			tombstone.SessionID,

--- a/internal/db/usage_cache_background.go
+++ b/internal/db/usage_cache_background.go
@@ -122,6 +122,21 @@ func (db *DB) StopUsageCacheBackfill() {
 
 func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
 	started := time.Now()
+	var lastErr error
+	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
+		lastErr = db.runUsageCacheBackfillPass(ctx, started)
+		if !errors.Is(lastErr, errUsageCacheSourceChanged) {
+			return lastErr
+		}
+	}
+	return fmt.Errorf(
+		"usage cache backfill could not stabilize after %d attempts: %w",
+		usageFillMaxAttempts, lastErr)
+}
+
+func (db *DB) runUsageCacheBackfillPass(
+	ctx context.Context, started time.Time,
+) error {
 	snapshot, err := db.captureUsageQuery(
 		ctx, UsageFilter{}, usageQueryKindActivity)
 	if err != nil {

--- a/internal/db/usage_cache_background.go
+++ b/internal/db/usage_cache_background.go
@@ -382,19 +382,34 @@ func (cache *usageCache) sweepDeletionJournal(ctx context.Context, archive *DB) 
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
+	tombstoneIDs := make([]string, 0, len(tombstones))
 	for _, tombstone := range tombstones {
+		tombstoneIDs = append(tombstoneIDs, tombstone.SessionID)
+	}
+	removed, err := usageFactIdentitiesForSessions(ctx, tx, tombstoneIDs)
+	if err != nil {
+		return err
+	}
+	excluded := make(map[string]bool, len(tombstoneIDs))
+	for _, sessionID := range tombstoneIDs {
+		excluded[sessionID] = true
 		if _, err := tx.ExecContext(ctx,
 			`DELETE FROM usage_rollup_installs WHERE session_id = ?`,
-			tombstone.SessionID,
+			sessionID,
 		); err != nil {
 			return err
 		}
 		if _, err := tx.ExecContext(ctx,
 			`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
-			tombstone.SessionID,
+			sessionID,
 		); err != nil {
 			return err
 		}
+	}
+	// Rebuild the survivors' rollups so groups the deleted sessions kept
+	// irreducible can finalize again.
+	if err := invalidateUsageDedupSharers(ctx, tx, removed, excluded); err != nil {
+		return err
 	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE usage_cache_metadata

--- a/internal/db/usage_cache_background.go
+++ b/internal/db/usage_cache_background.go
@@ -127,10 +127,11 @@ func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	cache, err := db.usageCache.Generation(ctx, snapshot.DatabaseID)
+	cache, release, err := db.usageCache.acquireGeneration(ctx, snapshot.DatabaseID)
 	if err != nil {
 		return err
 	}
+	defer release()
 	if cache == nil || cache.fill == nil || cache.rollup == nil {
 		return fmt.Errorf("usage cache generation is not attached to the archive")
 	}

--- a/internal/db/usage_cache_background.go
+++ b/internal/db/usage_cache_background.go
@@ -33,6 +33,7 @@ func (db *DB) StartUsageCacheBackfill(ctx context.Context) error {
 		ctx = context.Background()
 	}
 	db.usageBackfillMu.Lock()
+	db.usageBackfillEnabled = true
 	if db.usageBackfillDone != nil {
 		select {
 		case <-db.usageBackfillDone:
@@ -165,6 +166,7 @@ func (db *DB) runUsageCacheBackfillPass(
 	resolver := export.NewPricingResolver(snapshot.PricingRows)
 	covered, deleted := 0, 0
 	var dailyRows, exceptionGroups, exceptionRows int64
+	allResults := make(map[string]usageFillResult, len(snapshot.Versions))
 	for start := 0; start < len(snapshot.Versions); start += usageCacheBackfillBatchSize {
 		end := min(start+usageCacheBackfillBatchSize, len(snapshot.Versions))
 		cursorTarget := int64(0)
@@ -197,11 +199,32 @@ func (db *DB) runUsageCacheBackfillPass(
 		if end < len(snapshot.Versions) {
 			cache.fill.maintainBetweenInstallBatches(ctx)
 		}
-		for _, result := range results {
+		for id, result := range results {
+			allResults[id] = result
 			if result.Deleted {
 				deleted++
 			} else {
 				covered++
+			}
+		}
+	}
+	// Filling a later batch can invalidate a rollup install from an
+	// earlier batch when the filled session adds a sibling for an
+	// identity the earlier batch had finalized. Re-verify the whole
+	// snapshot once after every fact is filled, so the pass never
+	// completes with rollups it deleted itself.
+	if len(snapshot.Versions) > usageCacheBackfillBatchSize {
+		for _, location := range locations {
+			zoned := snapshot
+			zoned.location = location
+			if _, metrics, err := cache.rollup.Ensure(
+				ctx, zoned, allResults, resolver); err != nil {
+				return fmt.Errorf(
+					"rebuilding invalidated usage rollups during backfill: %w", err)
+			} else {
+				dailyRows += metrics.DailyRows
+				exceptionGroups += metrics.ExceptionGroups
+				exceptionRows += metrics.ExceptionRows
 			}
 		}
 	}
@@ -377,29 +400,41 @@ func (cache *usageCache) sweepDeletionJournal(ctx context.Context, archive *DB) 
 	if err != nil {
 		return err
 	}
-	tx, err := cache.db.BeginTx(ctx, nil)
+	conn, err := cache.db.Conn(ctx)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	// BEGIN IMMEDIATE: this transaction reads identities before its first
+	// delete, so a deferred begin could fail with SQLITE_BUSY_SNAPSHOT
+	// under a concurrent fill or install commit.
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return fmt.Errorf("locking usage cache for deletion sweep: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
 	tombstoneIDs := make([]string, 0, len(tombstones))
 	for _, tombstone := range tombstones {
 		tombstoneIDs = append(tombstoneIDs, tombstone.SessionID)
 	}
-	removed, err := usageFactIdentitiesForSessions(ctx, tx, tombstoneIDs)
+	removed, err := usageFactIdentitiesForSessions(ctx, conn, tombstoneIDs)
 	if err != nil {
 		return err
 	}
 	excluded := make(map[string]bool, len(tombstoneIDs))
 	for _, sessionID := range tombstoneIDs {
 		excluded[sessionID] = true
-		if _, err := tx.ExecContext(ctx,
+		if _, err := conn.ExecContext(ctx,
 			`DELETE FROM usage_rollup_installs WHERE session_id = ?`,
 			sessionID,
 		); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx,
+		if _, err := conn.ExecContext(ctx,
 			`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
 			sessionID,
 		); err != nil {
@@ -408,17 +443,21 @@ func (cache *usageCache) sweepDeletionJournal(ctx context.Context, archive *DB) 
 	}
 	// Rebuild the survivors' rollups so groups the deleted sessions kept
 	// irreducible can finalize again.
-	if err := invalidateUsageDedupSharers(ctx, tx, removed, excluded); err != nil {
+	if err := invalidateUsageDedupSharers(ctx, conn, removed, excluded); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `
+	if _, err := conn.ExecContext(ctx, `
 		UPDATE usage_cache_metadata
 		SET value = CAST(MAX(CAST(value AS INTEGER), ?) AS TEXT)
 		WHERE key = ?`, through, usageCacheMetadataDeletionRevision,
 	); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return fmt.Errorf("committing usage cache deletion sweep: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func (cache *usageCache) incrementalVacuum(

--- a/internal/db/usage_cache_background_test.go
+++ b/internal/db/usage_cache_background_test.go
@@ -1,0 +1,314 @@
+//go:build fts5
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsageCacheBackfillNewestFirstAndResumesInstalledCoverage(t *testing.T) {
+	database := testDB(t)
+	for _, fixture := range []struct {
+		id, timestamp string
+	}{
+		{"old", "2026-08-01T10:00:00Z"},
+		{"new", "2026-08-10T10:00:00Z"},
+		{"middle", "2026-08-05T10:00:00Z"},
+	} {
+		insertSession(t, database, fixture.id, "project", func(session *Session) {
+			session.StartedAt = &fixture.timestamp
+			session.EndedAt = &fixture.timestamp
+		})
+		require.NoError(t, database.InsertMessages([]Message{{
+			SessionID: fixture.id, Ordinal: 0, Role: "assistant",
+			Timestamp: fixture.timestamp, Model: "model",
+			TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+		}}))
+	}
+
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	activity, err := database.usageBackfillActivity(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "2026-08-10T10:00:00Z", activity["new"])
+	assert.Equal(t, "2026-08-05T10:00:00Z", activity["middle"])
+	var extracted [][]string
+	cache.fill.observer.beforeExtract = func(versions []usageSourceVersion) {
+		ids := make([]string, len(versions))
+		for index, version := range versions {
+			ids[index] = version.SessionID
+		}
+		extracted = append(extracted, ids)
+	}
+
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	require.Equal(t, [][]string{{"new", "middle", "old"}}, extracted)
+	assert.Equal(t, 3, usageCacheCount(t, cache, "usage_cached_sessions"))
+	assert.Equal(t, 3, usageCacheCount(t, cache, "usage_rollup_installs"))
+	assert.Equal(t, 3, usageCacheCount(t, cache, "usage_daily_rollups"))
+
+	extracted = nil
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	assert.Empty(t, extracted, "installed versions are coverage truth on restart")
+}
+
+func TestUsageCacheBackfillBatchesNewestSessionsFirst(t *testing.T) {
+	database := testDB(t)
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	messages := make([]Message, 0, usageCacheBackfillBatchSize+1)
+	for i := range usageCacheBackfillBatchSize + 1 {
+		id := fmt.Sprintf("batch-%03d", i)
+		timestamp := base.Add(time.Duration(i) * time.Minute).Format(time.RFC3339)
+		insertSession(t, database, id, "project", func(session *Session) {
+			session.StartedAt = &timestamp
+			session.EndedAt = &timestamp
+		})
+		messages = append(messages, Message{
+			SessionID: id, Ordinal: 0, Role: "assistant",
+			Timestamp: timestamp, Model: "model",
+			TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+		})
+	}
+	require.NoError(t, database.InsertMessages(messages))
+
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	var extracted [][]string
+	maintenanceCalls := 0
+	cache.fill.observer.beforeExtract = func(versions []usageSourceVersion) {
+		ids := make([]string, len(versions))
+		for index, version := range versions {
+			ids[index] = version.SessionID
+		}
+		extracted = append(extracted, ids)
+	}
+	cache.fill.observer.afterMaintenance = func() { maintenanceCalls++ }
+
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	require.Len(t, extracted, 2)
+	assert.Equal(t, 1, maintenanceCalls,
+		"the outer backfill must maintain the cache between batches")
+	assert.Equal(t, 1, usageCacheCount(t, cache, "usage_rollup_timezones"),
+		"one backfill pass must use one process-local timezone generation")
+	assert.Len(t, extracted[0], usageCacheBackfillBatchSize)
+	assert.Equal(t, fmt.Sprintf("batch-%03d", usageCacheBackfillBatchSize),
+		extracted[0][0])
+	assert.Equal(t, "batch-001", extracted[0][usageCacheBackfillBatchSize-1])
+	assert.Equal(t, []string{"batch-000"}, extracted[1])
+}
+
+func TestUsageCacheBackfillRewarmsEightRecentExplicitTimezones(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T10:00:00Z"
+	insertSession(t, database, "recent-zone", "project", func(session *Session) {
+		session.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "recent-zone", Ordinal: 0, Role: "assistant",
+		Timestamp: started, Model: "model",
+		TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+	}}))
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	for index := 1; index <= 9; index++ {
+		name := fmt.Sprintf("Etc/GMT+%d", index)
+		_, err := cache.db.Exec(`INSERT INTO usage_rollup_timezones(
+			timezone_key, timezone_name, interval_fingerprint, last_requested_at
+		) VALUES (?, ?, ?, ?)`, name, name, name,
+			fmt.Sprintf("2026-08-%02dT00:00:00Z", index))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+
+	assert.Equal(t, 10, usageCacheCount(t, cache, "usage_rollup_timezones"))
+	assert.Equal(t, 9, usageCacheCount(t, cache, "usage_rollup_installs"),
+		"the local zone plus eight explicit zones should be warmed")
+	var oldestInstalls int
+	require.NoError(t, cache.db.QueryRow(`SELECT COUNT(*)
+		FROM usage_rollup_installs i JOIN usage_rollup_timezones tz
+		  ON tz.id = i.timezone_id
+		WHERE tz.timezone_key = 'Etc/GMT+1'`).Scan(&oldestInstalls))
+	assert.Zero(t, oldestInstalls, "the ninth explicit zone should not be rewarmed")
+}
+
+func TestUsageCacheBackfillObserverAttachesToActivePass(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "active", "project")
+	started := make(chan struct{})
+	release := make(chan struct{})
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	cache.fill.observer.beforeExtract = func([]usageSourceVersion) {
+		close(started)
+		<-release
+	}
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	<-started
+	observed := make(chan struct{}, 1)
+	database.SetUsageCacheBackfillStarted(func() { observed <- struct{}{} })
+	select {
+	case <-observed:
+	case <-time.After(time.Second):
+		t.Fatal("observer did not attach to the active backfill")
+	}
+	close(release)
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+}
+
+func TestUsageCacheBackfillSweepsHardDeletionTombstones(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "deleted", "project", func(session *Session) {
+		session.StartedAt = Ptr("2026-08-10T10:00:00Z")
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "deleted", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T10:00:00Z", Model: "model",
+		TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+	}}))
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, usageCacheCount(t, cache, "usage_cached_sessions"))
+	require.NoError(t, database.DeleteSession("deleted"))
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	assert.Zero(t, usageCacheCount(t, cache, "usage_cached_sessions"))
+}
+
+func TestUsageMatchingCountDiscoversWritesAfterCompletedBackfill(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	_, err := database.getWriter().Exec(`
+		INSERT INTO sessions(id, project, machine, agent, started_at)
+		VALUES ('external-activity', 'project', 'machine', 'claude',
+		        '2026-08-12T10:00:00Z');
+		INSERT INTO messages(session_id, ordinal, role, content, timestamp, model)
+		VALUES ('external-activity', 0, 'assistant', 'answer',
+		        '2026-08-12T10:01:00Z', 'model')`)
+	require.NoError(t, err)
+	count, err := database.GetUsageMatchingSessionCount(
+		context.Background(), UsageFilter{
+			From: "2026-08-12", To: "2026-08-12", Timezone: "UTC",
+		})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestUsageCacheIncrementalVacuumThreshold(t *testing.T) {
+	database := testDB(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+
+	ran, err := cache.incrementalVacuum(context.Background(), 4096, 256)
+	require.NoError(t, err)
+	assert.False(t, ran)
+	_, err = cache.db.Exec(`CREATE TABLE vacuum_fixture(value BLOB)`)
+	require.NoError(t, err)
+	for range 4200 {
+		_, err = cache.db.Exec(
+			`INSERT INTO vacuum_fixture VALUES (zeroblob(4096))`)
+		require.NoError(t, err)
+	}
+	_, err = cache.db.Exec(`DELETE FROM vacuum_fixture`)
+	require.NoError(t, err)
+	ran, err = cache.incrementalVacuum(context.Background(), 4096, 256)
+	require.NoError(t, err)
+	assert.True(t, ran)
+}
+
+func TestUsageCacheBackfillStopJoinsWorker(t *testing.T) {
+	database := testDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, database.StartUsageCacheBackfill(ctx))
+	database.StopUsageCacheBackfill()
+	done := make(chan struct{})
+	go func() {
+		_ = database.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not join usage cache backfill")
+	}
+}
+
+func TestCloseConnectionsStopsUsageCacheBackfill(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	cache.fill.observer.beforeExtract = func([]usageSourceVersion) {
+		close(started)
+		<-release
+	}
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	<-started
+	closed := make(chan error, 1)
+	go func() { closed <- database.CloseConnections() }()
+	var earlyErr error
+	returnedEarly := false
+	select {
+	case earlyErr = <-closed:
+		returnedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	if returnedEarly {
+		require.NoError(t, earlyErr)
+		t.Fatal("CloseConnections returned before backfill stopped")
+	}
+	select {
+	case err = <-closed:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("CloseConnections did not join cancelled usage cache backfill")
+	}
+	cache.fill.observer = usageFillObserver{}
+	require.NoError(t, database.Reopen())
+}

--- a/internal/db/usage_cache_background_test.go
+++ b/internal/db/usage_cache_background_test.go
@@ -176,7 +176,7 @@ func TestUsageCacheBackfillObserverAttachesToActivePass(t *testing.T) {
 	database.SetUsageCacheBackfillStarted(func() { observed <- struct{}{} })
 	select {
 	case <-observed:
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("observer did not attach to the active backfill")
 	}
 	close(release)
@@ -207,6 +207,8 @@ func TestUsageCacheBackfillSweepsHardDeletionTombstones(t *testing.T) {
 	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
 	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
 	assert.Zero(t, usageCacheCount(t, cache, "usage_cached_sessions"))
+	assert.Zero(t, usageCacheCount(t, cache, "usage_rollup_installs"),
+		"deletion hygiene must reclaim every timezone rollup for the session")
 }
 
 func TestUsageMatchingCountDiscoversWritesAfterCompletedBackfill(t *testing.T) {
@@ -268,7 +270,7 @@ func TestUsageCacheBackfillStopJoinsWorker(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("Close did not join usage cache backfill")
 	}
 }
@@ -306,7 +308,7 @@ func TestCloseConnectionsStopsUsageCacheBackfill(t *testing.T) {
 	select {
 	case err = <-closed:
 		require.NoError(t, err)
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("CloseConnections did not join cancelled usage cache backfill")
 	}
 	cache.fill.observer = usageFillObserver{}

--- a/internal/db/usage_cache_background_test.go
+++ b/internal/db/usage_cache_background_test.go
@@ -132,11 +132,19 @@ func TestUsageCacheBackfillRewarmsEightRecentExplicitTimezones(t *testing.T) {
 	cache, err := database.usageCache.Generation(
 		context.Background(), snapshot.DatabaseID)
 	require.NoError(t, err)
+	oldestKey := ""
 	for index := 1; index <= 9; index++ {
 		name := fmt.Sprintf("Etc/GMT+%d", index)
-		_, err := cache.db.Exec(`INSERT INTO usage_rollup_timezones(
+		location, err := time.LoadLocation(name)
+		require.NoError(t, err)
+		identity := usageTimezoneIdentityFor(location, nil)
+		if index == 1 {
+			oldestKey = identity.Key
+		}
+		_, err = cache.db.Exec(`INSERT INTO usage_rollup_timezones(
 			timezone_key, timezone_name, interval_fingerprint, last_requested_at
-		) VALUES (?, ?, ?, ?)`, name, name, name,
+		) VALUES (?, ?, ?, ?)`, identity.Key, identity.Name,
+			identity.IntervalFingerprint,
 			fmt.Sprintf("2026-08-%02dT00:00:00Z", index))
 		require.NoError(t, err)
 	}
@@ -151,7 +159,7 @@ func TestUsageCacheBackfillRewarmsEightRecentExplicitTimezones(t *testing.T) {
 	require.NoError(t, cache.db.QueryRow(`SELECT COUNT(*)
 		FROM usage_rollup_installs i JOIN usage_rollup_timezones tz
 		  ON tz.id = i.timezone_id
-		WHERE tz.timezone_key = 'Etc/GMT+1'`).Scan(&oldestInstalls))
+		WHERE tz.timezone_key = ?`, oldestKey).Scan(&oldestInstalls))
 	assert.Zero(t, oldestInstalls, "the ninth explicit zone should not be rewarmed")
 }
 

--- a/internal/db/usage_cache_background_test.go
+++ b/internal/db/usage_cache_background_test.go
@@ -371,3 +371,74 @@ func TestCloseConnectionsStopsUsageCacheBackfill(t *testing.T) {
 	cache.fill.observer = usageFillObserver{}
 	require.NoError(t, database.Reopen())
 }
+
+func TestUsageCacheBackfillRebuildsRollupsInvalidatedByLaterBatches(t *testing.T) {
+	database := testDB(t)
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	messages := make([]Message, 0, usageCacheBackfillBatchSize+1)
+	newest := fmt.Sprintf("batch-%03d", usageCacheBackfillBatchSize)
+	for i := range usageCacheBackfillBatchSize + 1 {
+		id := fmt.Sprintf("batch-%03d", i)
+		timestamp := base.Add(time.Duration(i) * time.Minute).Format(time.RFC3339)
+		insertSession(t, database, id, "project", func(session *Session) {
+			session.StartedAt = &timestamp
+			session.EndedAt = &timestamp
+		})
+		message := Message{
+			SessionID: id, Ordinal: 0, Role: "assistant",
+			Timestamp: timestamp, Model: "model",
+			TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+		}
+		// The newest session (first batch) and the oldest session (last
+		// batch) share one snapshot identity: filling the oldest batch
+		// invalidates the rollup already installed for the newest.
+		if i == 0 || id == newest {
+			message.ClaudeMessageID = "shared-batch-message"
+			message.ClaudeRequestID = "shared-batch-request"
+		}
+		messages = append(messages, message)
+	}
+	require.NoError(t, database.InsertMessages(messages))
+
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+
+	assert.Equal(t, usageCacheBackfillBatchSize+1,
+		usageCacheCount(t, cache, "usage_rollup_installs"),
+		"backfill must rebuild rollups its later batches invalidated")
+	var missing int
+	require.NoError(t, cache.db.QueryRow(`SELECT count(*)
+		FROM usage_cached_sessions c
+		WHERE NOT EXISTS (
+			SELECT 1 FROM usage_rollup_installs i
+			WHERE i.session_id = c.session_id
+		)`).Scan(&missing))
+	assert.Zero(t, missing, "every cached session must keep a rollup install")
+}
+
+func TestReopenRestartsUsageBackfillOnlyWhenPreviouslyStarted(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.Reopen())
+	database.usageBackfillMu.Lock()
+	done := database.usageBackfillDone
+	database.usageBackfillMu.Unlock()
+	require.Nil(t, done,
+		"reopen must not start a backfill pass nothing enabled")
+
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.Reopen())
+	database.usageBackfillMu.Lock()
+	done = database.usageBackfillDone
+	database.usageBackfillMu.Unlock()
+	require.NotNil(t, done,
+		"reopen must restart backfill once it was explicitly started")
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+}

--- a/internal/db/usage_cache_background_test.go
+++ b/internal/db/usage_cache_background_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -63,6 +64,54 @@ func TestUsageCacheBackfillNewestFirstAndResumesInstalledCoverage(t *testing.T) 
 	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
 	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
 	assert.Empty(t, extracted, "installed versions are coverage truth on restart")
+}
+
+func TestUsageCacheBackfillRecapturesChangedSource(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "moving-backfill", "project", func(session *Session) {
+		session.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "moving-backfill", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T09:00:00Z", Model: "model",
+		TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+	}}))
+
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	var mutations atomic.Int32
+	var mutationErr atomic.Value
+	cache.fill.observer.afterExtract = func([]usageSourceVersion) {
+		if mutations.Add(1) != 1 {
+			return
+		}
+		_, updateErr := database.getWriter().Exec(`
+			UPDATE messages SET token_usage = '{"input_tokens":9}'
+			WHERE session_id = 'moving-backfill';
+			UPDATE sessions SET transcript_revision = 'later'
+			WHERE id = 'moving-backfill'`)
+		if updateErr != nil {
+			mutationErr.Store(updateErr)
+		}
+	}
+
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	if stored := mutationErr.Load(); stored != nil {
+		require.NoError(t, stored.(error))
+	}
+	require.Positive(t, mutations.Load())
+
+	daily, err := database.GetDailyUsage(context.Background(), UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", SkipSessionCounts: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 9, daily.Totals.InputTokens)
 }
 
 func TestUsageCacheBackfillBatchesNewestSessionsFirst(t *testing.T) {

--- a/internal/db/usage_cache_candidates.go
+++ b/internal/db/usage_cache_candidates.go
@@ -1,0 +1,385 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/usagefacts"
+)
+
+type usageQueryKind int
+
+const (
+	usageQueryKindToken usageQueryKind = iota
+	usageQueryKindActivity
+)
+
+type usageSourceVersion struct {
+	SessionID             string
+	SyncMarker            string
+	TranscriptRevision    string
+	UsageEventFingerprint string
+}
+
+func (v usageSourceVersion) Equal(other usageSourceVersion) bool {
+	return v.SessionID == other.SessionID &&
+		v.SyncMarker == other.SyncMarker &&
+		v.TranscriptRevision == other.TranscriptRevision &&
+		v.UsageEventFingerprint == other.UsageEventFingerprint
+}
+
+type usageQuerySession struct {
+	ID                string
+	Project           string
+	Machine           string
+	Agent             string
+	GitBranch         string
+	CreatedAt         string
+	StartedAt         string
+	EndedAt           string
+	DisplayName       string
+	StartedAtMillis   *int64
+	StartedAtNanos    *int64
+	UserMessageCount  int
+	TotalOutputTokens int
+	PeakContextTokens int
+	HasTotalOutput    bool
+	HasPeakContext    bool
+	IsAutomated       bool
+	TerminationStatus string
+	PassesFilter      bool
+}
+
+type usageQueryInterval struct {
+	FromMillis    int64
+	ToMillis      int64
+	FromLocalDate string
+	ToLocalDate   string
+}
+
+type usageQuerySnapshot struct {
+	DatabaseID      string
+	Sessions        []usageQuerySession
+	Versions        []usageSourceVersion
+	Intervals       []usageQueryInterval
+	CursorHighWater int64
+	PricingRows     []export.EffectivePricingRow
+	location        *time.Location
+}
+
+// Close exists to make the snapshot boundary explicit to callers. Capture
+// copies every value and closes its archive transaction before returning.
+func (usageQuerySnapshot) Close() error { return nil }
+
+type usageQuerySessionRecord struct {
+	session usageQuerySession
+	version usageSourceVersion
+}
+
+func (db *DB) captureUsageQuery(
+	ctx context.Context, filter UsageFilter, kind usageQueryKind,
+) (usageQuerySnapshot, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	conn, err := db.getReader().Conn(ctx)
+	if err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("pinning usage archive connection: %w", err)
+	}
+	defer conn.Close()
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("starting usage archive snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var snapshot usageQuerySnapshot
+	snapshot.location = filter.location()
+	if err := tx.QueryRowContext(ctx,
+		`SELECT value FROM archive_metadata WHERE key = ?`,
+		archiveMetadataDatabaseIDKey,
+	).Scan(&snapshot.DatabaseID); err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("reading usage snapshot database id: %w", err)
+	}
+	pricingRows, err := db.loadPricingMapFrom(ctx, tx)
+	if err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("reading usage snapshot pricing: %w", err)
+	}
+	snapshot.PricingRows = pricingRows
+
+	bounds := usageCandidateBoundsForFilter(filter)
+	query, args := usageCandidateDiscoverySQL(bounds, kind)
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("discovering usage candidates: %w", err)
+	}
+	var candidateIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return usageQuerySnapshot{}, fmt.Errorf("scanning usage candidate: %w", err)
+		}
+		candidateIDs = append(candidateIDs, id)
+	}
+	if err := rows.Close(); err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("closing usage candidate rows: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("iterating usage candidates: %w", err)
+	}
+
+	records, err := loadUsageQuerySessionRecords(ctx, tx, candidateIDs, filter)
+	if err != nil {
+		return usageQuerySnapshot{}, err
+	}
+	fingerprints, err := usageEventFingerprintsWithQuerier(ctx, tx, candidateIDs)
+	if err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("fingerprinting usage events: %w", err)
+	}
+	for i := range records {
+		records[i].version.UsageEventFingerprint =
+			fingerprints[records[i].session.ID]
+		snapshot.Sessions = append(snapshot.Sessions, records[i].session)
+		snapshot.Versions = append(snapshot.Versions, records[i].version)
+	}
+	snapshot.Intervals = usageQueryIntervals(filter)
+	var hasCursorTable bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM sqlite_master
+		WHERE type = 'table' AND name = 'cursor_usage_events'
+	)`).Scan(&hasCursorTable); err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("checking Cursor usage table: %w", err)
+	}
+	if hasCursorTable {
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COALESCE(MAX(id), 0) FROM cursor_usage_events`,
+		).Scan(&snapshot.CursorHighWater); err != nil {
+			return usageQuerySnapshot{}, fmt.Errorf("reading Cursor usage high-water mark: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return usageQuerySnapshot{}, fmt.Errorf("closing usage archive snapshot: %w", err)
+	}
+	return snapshot, nil
+}
+
+// usageCandidateBoundsForFilter converts local calendar-day filters to their
+// exact UTC instants before padding for the full range of RFC3339 offsets that
+// may appear in stored timestamp text. The result is deliberately a superset;
+// exact membership is applied against cached parsed timestamps later.
+func usageCandidateBoundsForFilter(filter UsageFilter) usageBounds {
+	location := filter.location()
+	var bounds usageBounds
+	if filter.From != "" {
+		if day, err := time.ParseInLocation("2006-01-02", filter.From, location); err == nil {
+			bounds.from = day.UTC().Add(-14 * time.Hour).Format(time.RFC3339)
+		}
+	}
+	if filter.To != "" {
+		if day, err := time.ParseInLocation("2006-01-02", filter.To, location); err == nil {
+			bounds.to = day.AddDate(0, 0, 1).UTC().Add(14*time.Hour - time.Nanosecond).
+				Format(time.RFC3339Nano)
+		}
+	}
+	return bounds
+}
+
+func usageCandidateDiscoverySQL(
+	bounds usageBounds, kind usageQueryKind,
+) (string, []any) {
+	if !bounds.bounded() {
+		return `SELECT s.id FROM sessions s
+			WHERE s.deleted_at IS NULL ORDER BY s.id`, nil
+	}
+
+	var branches []string
+	var args []any
+	appendBranch := func(prefix, column string) {
+		where, branchArgs := appendUsageColumnBounds("1=1", column, bounds, nil)
+		branches = append(branches, prefix+"\n AND "+where)
+		args = append(args, branchArgs...)
+	}
+	appendBranch(`SELECT m.session_id
+		FROM messages AS m INDEXED BY idx_messages_usage_covering
+		JOIN sessions s ON s.id = m.session_id
+		WHERE `+usageMessageSourceEligibility+`
+		  AND s.deleted_at IS NULL
+		  AND m.timestamp IS NOT NULL AND m.timestamp != ''`, "m.timestamp")
+	appendBranch(`SELECT m.session_id
+		FROM messages AS m INDEXED BY idx_messages_usage_covering
+		JOIN sessions s ON s.id = m.session_id
+		WHERE `+usageMessageSourceEligibility+`
+		  AND s.deleted_at IS NULL AND m.timestamp IS NULL`, "s.started_at")
+	appendBranch(`SELECT m.session_id
+		FROM messages AS m INDEXED BY idx_messages_usage_covering
+		JOIN sessions s ON s.id = m.session_id
+		WHERE `+usageMessageSourceEligibility+`
+		  AND s.deleted_at IS NULL AND m.timestamp = ''`, "s.started_at")
+	appendBranch(`SELECT ue.session_id
+		FROM usage_events AS ue INDEXED BY idx_usage_events_occurred
+		JOIN sessions s ON s.id = ue.session_id
+		WHERE `+usageEventSourceEligibility+`
+		  AND s.deleted_at IS NULL
+		  AND ue.occurred_at IS NOT NULL AND ue.occurred_at != ''`, "ue.occurred_at")
+	appendBranch(`SELECT ue.session_id
+		FROM usage_events ue
+		JOIN sessions s ON s.id = ue.session_id
+		WHERE `+usageEventSourceEligibility+`
+		  AND s.deleted_at IS NULL
+		  AND (ue.occurred_at IS NULL OR ue.occurred_at = '')`, "s.started_at")
+
+	if kind == usageQueryKindActivity {
+		appendBranch(`SELECT m.session_id
+			FROM messages AS m INDEXED BY idx_messages_activity_timestamp
+			JOIN sessions s ON s.id = m.session_id
+			WHERE m.role = 'assistant' AND m.model != '<synthetic>'
+			  AND s.deleted_at IS NULL
+			  AND m.timestamp IS NOT NULL AND m.timestamp != ''`, "m.timestamp")
+		appendBranch(`SELECT m.session_id
+			FROM messages AS m INDEXED BY idx_messages_activity_timestamp
+			JOIN sessions s ON s.id = m.session_id
+			WHERE m.role = 'assistant' AND m.model != '<synthetic>'
+			  AND s.deleted_at IS NULL AND m.timestamp IS NULL`, "s.started_at")
+		appendBranch(`SELECT m.session_id
+			FROM messages AS m INDEXED BY idx_messages_activity_timestamp
+			JOIN sessions s ON s.id = m.session_id
+			WHERE m.role = 'assistant' AND m.model != '<synthetic>'
+			  AND s.deleted_at IS NULL AND m.timestamp = ''`, "s.started_at")
+	}
+
+	return `SELECT DISTINCT candidate.session_id
+		FROM (` + strings.Join(branches, "\nUNION ALL\n") + `) candidate
+		ORDER BY candidate.session_id`, args
+}
+
+func loadUsageQuerySessionRecords(
+	ctx context.Context, tx *sql.Tx, candidateIDs []string, filter UsageFilter,
+) ([]usageQuerySessionRecord, error) {
+	if len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	const batchSize = 900
+	records := make([]usageQuerySessionRecord, 0, len(candidateIDs))
+	filterWhere, filterArgs := filter.appendUsageSessionFilterClauses("1=1", nil)
+	for start := 0; start < len(candidateIDs); start += batchSize {
+		end := min(start+batchSize, len(candidateIDs))
+		ids := candidateIDs[start:end]
+		placeholders := make([]string, len(ids))
+		idArgs := make([]any, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			idArgs[i] = id
+		}
+		query := `SELECT
+			s.id, s.project, s.machine, s.agent, COALESCE(s.git_branch, ''),
+			COALESCE(s.created_at, ''), COALESCE(s.started_at, ''),
+			COALESCE(s.ended_at, ''),
+			COALESCE(NULLIF(COALESCE(s.display_name, s.session_name), ''),
+			         NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id),
+			s.user_message_count, s.total_output_tokens, s.peak_context_tokens,
+			COALESCE(s.has_total_output_tokens, 0),
+			COALESCE(s.has_peak_context_tokens, 0),
+			COALESCE(s.is_automated, 0),
+			COALESCE(s.termination_status, ''),
+			CASE WHEN (` + filterWhere + `) THEN 1 ELSE 0 END,
+			COALESCE(s.sync_marker, ''), COALESCE(s.transcript_revision, '0')
+		FROM sessions s
+		WHERE s.deleted_at IS NULL AND s.id IN (` +
+			strings.Join(placeholders, ",") + `)
+		ORDER BY s.id`
+		args := append(append([]any(nil), filterArgs...), idArgs...)
+		rows, err := tx.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("loading usage candidate metadata: %w", err)
+		}
+		for rows.Next() {
+			var record usageQuerySessionRecord
+			var passes, automated, hasTotalOutput, hasPeakContext int
+			if err := rows.Scan(
+				&record.session.ID, &record.session.Project,
+				&record.session.Machine, &record.session.Agent,
+				&record.session.GitBranch, &record.session.CreatedAt,
+				&record.session.StartedAt, &record.session.EndedAt,
+				&record.session.DisplayName, &record.session.UserMessageCount,
+				&record.session.TotalOutputTokens,
+				&record.session.PeakContextTokens,
+				&hasTotalOutput, &hasPeakContext,
+				&automated, &record.session.TerminationStatus, &passes,
+				&record.version.SyncMarker, &record.version.TranscriptRevision,
+			); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scanning usage candidate metadata: %w", err)
+			}
+			record.session.IsAutomated = automated != 0
+			record.session.HasTotalOutput = hasTotalOutput != 0
+			record.session.HasPeakContext = hasPeakContext != 0
+			record.session.PassesFilter = passes != 0
+			if millis, _, _ := usagefacts.ParseTimestamp(record.session.StartedAt); millis != nil {
+				record.session.StartedAtMillis = millis
+				record.session.StartedAtNanos = usagefacts.ParseTimestampNanos(
+					record.session.StartedAt)
+			}
+			record.version.SessionID = record.session.ID
+			records = append(records, record)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("closing usage candidate metadata: %w", err)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterating usage candidate metadata: %w", err)
+		}
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].session.ID < records[j].session.ID
+	})
+	return records, nil
+}
+
+func usageQueryIntervals(filter UsageFilter) []usageQueryInterval {
+	if filter.From == "" && filter.To == "" {
+		return nil
+	}
+	location := filter.location()
+	parseDate := func(value string) (time.Time, bool) {
+		parsed, err := time.ParseInLocation("2006-01-02", value, location)
+		return parsed, err == nil
+	}
+	from, hasFrom := parseDate(filter.From)
+	to, hasTo := parseDate(filter.To)
+	if filter.From != "" && !hasFrom || filter.To != "" && !hasTo {
+		return nil
+	}
+	if hasFrom && hasTo {
+		if from.After(to) {
+			return nil
+		}
+		var intervals []usageQueryInterval
+		for day := from; !day.After(to); day = day.AddDate(0, 0, 1) {
+			next := day.AddDate(0, 0, 1)
+			date := day.Format("2006-01-02")
+			intervals = append(intervals, usageQueryInterval{
+				FromMillis: day.UTC().UnixMilli(), ToMillis: next.UTC().UnixMilli(),
+				FromLocalDate: date, ToLocalDate: date,
+			})
+		}
+		return intervals
+	}
+	if hasFrom {
+		return []usageQueryInterval{{
+			FromMillis: from.UTC().UnixMilli(), ToMillis: math.MaxInt64,
+			FromLocalDate: filter.From,
+		}}
+	}
+	next := to.AddDate(0, 0, 1)
+	return []usageQueryInterval{{
+		FromMillis: math.MinInt64, ToMillis: next.UTC().UnixMilli(),
+		ToLocalDate: filter.To,
+	}}
+}

--- a/internal/db/usage_cache_candidates.go
+++ b/internal/db/usage_cache_candidates.go
@@ -207,18 +207,18 @@ func usageCandidateDiscoverySQL(
 		args = append(args, branchArgs...)
 	}
 	appendBranch(`SELECT m.session_id
-		FROM messages AS m INDEXED BY idx_messages_usage_covering
+		FROM messages AS m INDEXED BY idx_messages_usage_timestamp
 		JOIN sessions s ON s.id = m.session_id
 		WHERE `+usageMessageSourceEligibility+`
 		  AND s.deleted_at IS NULL
 		  AND m.timestamp IS NOT NULL AND m.timestamp != ''`, "m.timestamp")
 	appendBranch(`SELECT m.session_id
-		FROM messages AS m INDEXED BY idx_messages_usage_covering
+		FROM messages AS m INDEXED BY idx_messages_usage_timestamp
 		JOIN sessions s ON s.id = m.session_id
 		WHERE `+usageMessageSourceEligibility+`
 		  AND s.deleted_at IS NULL AND m.timestamp IS NULL`, "s.started_at")
 	appendBranch(`SELECT m.session_id
-		FROM messages AS m INDEXED BY idx_messages_usage_covering
+		FROM messages AS m INDEXED BY idx_messages_usage_timestamp
 		JOIN sessions s ON s.id = m.session_id
 		WHERE `+usageMessageSourceEligibility+`
 		  AND s.deleted_at IS NULL AND m.timestamp = ''`, "s.started_at")

--- a/internal/db/usage_cache_candidates_test.go
+++ b/internal/db/usage_cache_candidates_test.go
@@ -106,7 +106,7 @@ func TestUsageCandidateDiscoveryQueryPlans(t *testing.T) {
 
 	tokenSQL, tokenArgs := usageCandidateDiscoverySQL(bounds, usageQueryKindToken)
 	tokenPlan := explainUsageCandidatePlan(t, database, tokenSQL, tokenArgs)
-	assert.Contains(t, tokenPlan, "idx_messages_usage_covering")
+	assert.Contains(t, tokenPlan, "idx_messages_usage_timestamp")
 
 	activitySQL, activityArgs := usageCandidateDiscoverySQL(
 		bounds, usageQueryKindActivity,

--- a/internal/db/usage_cache_candidates_test.go
+++ b/internal/db/usage_cache_candidates_test.go
@@ -1,0 +1,240 @@
+//go:build fts5
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureUsageQueryBoundedCandidatesAndMetadata(t *testing.T) {
+	database := usageCandidateFixture(t)
+	filter := UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+		Project: "keep", Model: "model-x",
+	}
+
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), filter, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	require.NoError(t, snapshot.Close())
+
+	assert.NotEmpty(t, snapshot.DatabaseID)
+	assert.Equal(t, int64(1), snapshot.CursorHighWater)
+	assert.Equal(t, []usageQueryInterval{{
+		FromMillis: 1786320000000, ToMillis: 1786406400000,
+		FromLocalDate: "2026-08-10", ToLocalDate: "2026-08-10",
+	}}, snapshot.Intervals)
+
+	assert.Equal(t, []string{
+		"blank-message", "event", "filtered-competitor", "inside-message",
+		"model-filtered",
+	}, usageQuerySessionIDs(snapshot.Sessions))
+	byID := make(map[string]usageQuerySession, len(snapshot.Sessions))
+	for _, session := range snapshot.Sessions {
+		byID[session.ID] = session
+	}
+	assert.Equal(t, usageQuerySession{
+		ID: "inside-message", Project: "keep", Machine: "machine-a",
+		Agent: "claude", GitBranch: "main",
+		CreatedAt:   "2026-08-01T00:00:00.000Z",
+		StartedAt:   "2026-08-01T00:00:00Z",
+		DisplayName: "Inside", StartedAtMillis: new(int64(1785542400000)),
+		StartedAtNanos:   new(int64(0)),
+		UserMessageCount: 2, PassesFilter: true,
+	}, byID["inside-message"])
+	assert.False(t, byID["filtered-competitor"].PassesFilter,
+		"session filters must be recorded, not applied to candidate discovery")
+	assert.True(t, byID["model-filtered"].PassesFilter,
+		"model filters apply to facts after ranking, not session metadata")
+
+	assert.Equal(t, usageQuerySessionIDs(snapshot.Sessions),
+		usageSourceVersionIDs(snapshot.Versions))
+	versionByID := make(map[string]usageSourceVersion, len(snapshot.Versions))
+	for _, version := range snapshot.Versions {
+		versionByID[version.SessionID] = version
+		assert.NotEmpty(t, version.SyncMarker)
+		assert.NotEmpty(t, version.TranscriptRevision)
+	}
+	assert.Equal(t,
+		"false|0|7:session|7:model-x|1|2|0|0|0|false|0|0:|0:|20:2026-08-10T12:00:00Z|2:e1;",
+		versionByID["event"].UsageEventFingerprint)
+	assert.Empty(t, versionByID["inside-message"].UsageEventFingerprint)
+
+	// The returned value owns no live archive transaction.
+	require.NoError(t, database.RenameSession("inside-message", new("renamed")))
+}
+
+func TestCaptureUsageQueryRelaxedAndAllHistoryCandidates(t *testing.T) {
+	database := usageCandidateFixture(t)
+	filter := UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	}
+
+	relaxed, err := database.captureUsageQuery(
+		context.Background(), filter, usageQueryKindActivity,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"blank-message", "event", "filtered-competitor", "inside-message",
+		"model-filtered", "relaxed",
+	}, usageQuerySessionIDs(relaxed.Sessions))
+
+	allHistory, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"all-empty", "blank-message", "event", "filtered-competitor",
+		"inside-message", "model-filtered", "outside", "relaxed", "user-only",
+	}, usageQuerySessionIDs(allHistory.Sessions))
+	assert.Empty(t, allHistory.Intervals)
+}
+
+func TestUsageCandidateDiscoveryQueryPlans(t *testing.T) {
+	database := usageCandidateFixture(t)
+	bounds := usageBoundsForFilter(UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	})
+
+	tokenSQL, tokenArgs := usageCandidateDiscoverySQL(bounds, usageQueryKindToken)
+	tokenPlan := explainUsageCandidatePlan(t, database, tokenSQL, tokenArgs)
+	assert.Contains(t, tokenPlan, "idx_messages_usage_covering")
+
+	activitySQL, activityArgs := usageCandidateDiscoverySQL(
+		bounds, usageQueryKindActivity,
+	)
+	activityPlan := explainUsageCandidatePlan(t, database, activitySQL, activityArgs)
+	assert.Contains(t, activityPlan,
+		"SEARCH m USING COVERING INDEX idx_messages_activity_timestamp (timestamp>")
+}
+
+func TestUsageCandidateDiscoveryCoversOppositeDateLineOffsets(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-08T23:00:00-12:00"
+	insertSession(t, database, "date-line", "project", func(session *Session) {
+		session.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "date-line", Ordinal: 0, Role: "assistant",
+		Timestamp: started, Model: "model",
+		TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+	}}))
+	snapshot, err := database.captureUsageQuery(context.Background(), UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "Pacific/Kiritimati",
+	}, usageQueryKindToken)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"date-line"}, usageQuerySessionIDs(snapshot.Sessions))
+}
+
+func usageCandidateFixture(t *testing.T) *DB {
+	t.Helper()
+	database := testDB(t)
+	seedSession := func(
+		id, project, started string, userMessages int, name string,
+	) {
+		t.Helper()
+		insertSession(t, database, id, project, func(session *Session) {
+			session.Machine = "machine-a"
+			session.Agent = "claude"
+			session.GitBranch = "main"
+			session.StartedAt = &started
+			session.UserMessageCount = userMessages
+			session.SessionName = &name
+		})
+		_, err := database.getWriter().Exec(
+			`UPDATE sessions SET created_at = '2026-08-01T00:00:00.000Z' WHERE id = ?`, id)
+		require.NoError(t, err)
+	}
+	tokenMessage := func(id, timestamp, model string) Message {
+		return Message{
+			SessionID: id, Ordinal: 0, Role: "assistant", Timestamp: timestamp,
+			Model: model, TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+			Content: "answer", ContentLength: 6,
+		}
+	}
+
+	seedSession("inside-message", "keep", "2026-08-01T00:00:00Z", 2, "Inside")
+	insertMessages(t, database,
+		tokenMessage("inside-message", "2026-08-10T10:00:00Z", "model-x"))
+	seedSession("blank-message", "keep", "2026-08-10T09:00:00Z", 2, "Blank")
+	insertMessages(t, database, tokenMessage("blank-message", "", "model-x"))
+	seedSession("event", "keep", "2026-08-01T00:00:00Z", 2, "Event")
+	require.NoError(t, database.ReplaceSessionUsageEvents("event", []UsageEvent{{
+		Source: "session", Model: "model-x", InputTokens: 1, OutputTokens: 2,
+		OccurredAt: "2026-08-10T12:00:00Z", DedupKey: "e1",
+	}}))
+	seedSession("filtered-competitor", "drop", "2026-08-01T00:00:00Z", 2, "Drop")
+	insertMessages(t, database,
+		tokenMessage("filtered-competitor", "2026-08-10T11:00:00Z", "other-model"))
+	seedSession("model-filtered", "keep", "2026-08-01T00:00:00Z", 2, "Model")
+	insertMessages(t, database,
+		tokenMessage("model-filtered", "2026-08-10T11:30:00Z", "other-model"))
+	seedSession("outside", "keep", "2026-08-01T00:00:00Z", 2, "Outside")
+	insertMessages(t, database,
+		tokenMessage("outside", "2026-08-20T10:00:00Z", "model-x"))
+	seedSession("relaxed", "keep", "2026-08-01T00:00:00Z", 2, "Relaxed")
+	insertMessages(t, database, Message{
+		SessionID: "relaxed", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T13:00:00Z", Content: "answer", ContentLength: 6,
+	})
+	seedSession("user-only", "keep", "2026-08-10T08:00:00Z", 1, "User")
+	insertMessages(t, database, Message{
+		SessionID: "user-only", Ordinal: 0, Role: "user",
+		Timestamp: "2026-08-10T08:00:00Z", Content: "question", ContentLength: 8,
+	})
+	seedSession("all-empty", "keep", "2026-08-10T07:00:00Z", 0, "Empty")
+	seedSession("deleted", "keep", "2026-08-10T06:00:00Z", 2, "Deleted")
+	insertMessages(t, database,
+		tokenMessage("deleted", "2026-08-10T06:00:00Z", "model-x"))
+	_, err := database.getWriter().Exec(
+		`UPDATE sessions SET deleted_at = '2026-08-10T14:00:00Z' WHERE id = 'deleted'`)
+	require.NoError(t, err)
+
+	require.NoError(t, database.InsertCursorUsageEvents([]CursorUsageEvent{{
+		OccurredAt: "2026-08-10T15:00:00Z", Model: "cursor-model", DedupKey: "cursor-1",
+	}}))
+	return database
+}
+
+func usageQuerySessionIDs(sessions []usageQuerySession) []string {
+	ids := make([]string, len(sessions))
+	for i, session := range sessions {
+		ids[i] = session.ID
+	}
+	return ids
+}
+
+func usageSourceVersionIDs(versions []usageSourceVersion) []string {
+	ids := make([]string, len(versions))
+	for i, version := range versions {
+		ids[i] = version.SessionID
+	}
+	return ids
+}
+
+func explainUsageCandidatePlan(
+	t *testing.T, database *DB, query string, args []any,
+) string {
+	t.Helper()
+	rows, err := database.getReader().Query("EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	var details []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	sort.Strings(details)
+	return strings.Join(details, "\n")
+}

--- a/internal/db/usage_cache_consumers.go
+++ b/internal/db/usage_cache_consumers.go
@@ -1,0 +1,170 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+func (db *DB) queryUsageRollups(
+	ctx context.Context, filter UsageFilter, kind usageQueryKind,
+) (usageQuerySnapshot, usageFactsResult, *export.PricingResolver, error) {
+	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
+		snapshot, captureErr := db.captureUsageQuery(ctx, filter, kind)
+		if captureErr != nil {
+			return usageQuerySnapshot{}, usageFactsResult{}, nil, captureErr
+		}
+		snapshot.CursorHighWater = 0
+		cache, generationErr := db.usageCache.Generation(ctx, snapshot.DatabaseID)
+		if generationErr != nil {
+			return usageQuerySnapshot{}, usageFactsResult{}, nil, generationErr
+		}
+		if sweepErr := cache.sweepDeletionJournal(ctx, db); sweepErr != nil {
+			return usageQuerySnapshot{}, usageFactsResult{}, nil, sweepErr
+		}
+		fills, fillErr := cache.fill.Ensure(
+			ctx, snapshot.Versions, snapshot.CursorHighWater,
+		)
+		if fillErr != nil {
+			if errors.Is(fillErr, errUsageCacheSourceChanged) &&
+				attempt < usageFillMaxAttempts {
+				continue
+			}
+			return usageQuerySnapshot{}, usageFactsResult{}, nil, fillErr
+		}
+		snapshot.dropDeleted(fills)
+		resolver := export.NewPricingResolver(snapshot.PricingRows)
+		installs, _, rollupErr := cache.rollup.Ensure(
+			ctx, snapshot, fills, resolver)
+		if rollupErr != nil {
+			if errors.Is(rollupErr, errUsageCacheSourceChanged) &&
+				attempt < usageFillMaxAttempts {
+				continue
+			}
+			return usageQuerySnapshot{}, usageFactsResult{}, nil, rollupErr
+		}
+		var facts usageFactsResult
+		var queryErr error
+		if kind == usageQueryKindActivity {
+			var matching map[string]UsageSessionInfo
+			matching, queryErr = cache.usageRollupActivityQuery(
+				ctx, snapshot, filter, installs)
+			facts.MatchingSessions = matching
+		} else {
+			facts, queryErr = cache.usageRollupQuery(
+				ctx, snapshot, filter, installs, resolver)
+		}
+		if queryErr == nil {
+			return snapshot, facts, resolver, nil
+		}
+		if !usageCacheReadShouldRecapture(queryErr) || attempt == usageFillMaxAttempts {
+			return usageQuerySnapshot{}, usageFactsResult{}, nil, queryErr
+		}
+	}
+	return usageQuerySnapshot{}, usageFactsResult{}, nil, fmt.Errorf(
+		"usage cache read could not stabilize after %d attempts",
+		usageFillMaxAttempts,
+	)
+}
+
+// GetTopSessionsByCost returns filtered sessions ranked by cost or tokens.
+func (db *DB) GetTopSessionsByCost(
+	ctx context.Context, filter UsageFilter, limit int,
+) ([]TopSessionEntry, error) {
+	snapshot, facts, _, err := db.queryUsageRollups(
+		ctx, filter, usageQueryKindToken)
+	if err != nil {
+		return nil, err
+	}
+	type totals struct {
+		input, output, cacheWrite, cacheRead int
+		cost                                 money.Money
+		authoritative                        *money.Money
+	}
+	bySession := make(map[string]*totals)
+	for _, group := range facts.Groups {
+		if group.SessionID == "" {
+			continue
+		}
+		current := bySession[group.SessionID]
+		if current == nil {
+			current = &totals{}
+			bySession[group.SessionID] = current
+		}
+		current.input += int(group.InputTokens)
+		current.output += int(group.OutputTokens)
+		current.cacheWrite += int(group.CacheCreationTokens)
+		current.cacheRead += int(group.CacheReadTokens)
+		current.cost, err = money.Add(current.cost,
+			money.Money{Microdollars: group.CostMicrodollars})
+		if err != nil {
+			return nil, fmt.Errorf("summing top-session cost: %w", err)
+		}
+		if filter.Model == "" && filter.ExcludeModel == "" &&
+			group.AuthoritativeCostMicrodollars != nil {
+			value := money.Money{Microdollars: *group.AuthoritativeCostMicrodollars}
+			current.authoritative = &value
+		}
+	}
+	metadata := make(map[string]usageQuerySession, len(snapshot.Sessions))
+	for _, session := range snapshot.Sessions {
+		metadata[session.ID] = session
+	}
+	result := make([]TopSessionEntry, 0, len(bySession))
+	for sessionID, value := range bySession {
+		cost := value.cost
+		if value.authoritative != nil {
+			cost = *value.authoritative
+		}
+		entry := TopSessionEntry{
+			SessionID: sessionID, DisplayName: sessionID,
+			InputTokens: value.input, OutputTokens: value.output,
+			CacheCreationTokens: value.cacheWrite,
+			CacheReadTokens:     value.cacheRead,
+			TotalTokens:         value.input + value.output + value.cacheWrite + value.cacheRead,
+			Cost:                cost,
+		}
+		if session, ok := metadata[sessionID]; ok {
+			entry.DisplayName = session.DisplayName
+			entry.Agent = session.Agent
+			entry.Project = session.Project
+			entry.StartedAt = session.StartedAt
+		}
+		result = append(result, entry)
+	}
+	return SortAndLimitTopSessions(
+		result, limit, filter.TopSessionsSort, filter.TopSessionsTokenTypes,
+	), nil
+}
+
+// GetUsageSessionCounts returns distinct billed survivor owners by metadata.
+func (db *DB) GetUsageSessionCounts(
+	ctx context.Context, filter UsageFilter,
+) (UsageSessionCounts, error) {
+	_, facts, _, err := db.queryUsageRollups(ctx, filter, usageQueryKindToken)
+	if err != nil {
+		return UsageSessionCounts{}, err
+	}
+	return NewUsageSessionCounts(facts.MatchingSessions), nil
+}
+
+// GetUsageMatchingSessionCount counts sessions with eligible usage activity.
+func (db *DB) GetUsageMatchingSessionCount(
+	ctx context.Context, filter UsageFilter,
+) (int, error) {
+	_, facts, _, err := db.queryUsageRollups(ctx, filter, usageQueryKindActivity)
+	if err != nil {
+		return 0, err
+	}
+	return len(facts.MatchingSessions), nil
+}
+
+// GetSessionUsage returns one session's exact, intra-session usage summary.
+func (db *DB) GetSessionUsage(
+	ctx context.Context, sessionID string, includeBreakdown bool,
+) (*SessionUsage, error) {
+	return db.getSessionUsageLegacy(ctx, sessionID, includeBreakdown)
+}

--- a/internal/db/usage_cache_consumers.go
+++ b/internal/db/usage_cache_consumers.go
@@ -11,13 +11,16 @@ import (
 
 func (db *DB) queryUsageRollups(
 	ctx context.Context, filter UsageFilter, kind usageQueryKind,
+	includeCursor bool,
 ) (usageQuerySnapshot, usageFactsResult, *export.PricingResolver, error) {
 	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
 		snapshot, captureErr := db.captureUsageQuery(ctx, filter, kind)
 		if captureErr != nil {
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, captureErr
 		}
-		snapshot.CursorHighWater = 0
+		if !includeCursor || !usageCursorIncluded(filter) {
+			snapshot.CursorHighWater = 0
+		}
 		cache, generationErr := db.usageCache.Generation(ctx, snapshot.DatabaseID)
 		if generationErr != nil {
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, generationErr
@@ -75,7 +78,7 @@ func (db *DB) GetTopSessionsByCost(
 	ctx context.Context, filter UsageFilter, limit int,
 ) ([]TopSessionEntry, error) {
 	snapshot, facts, _, err := db.queryUsageRollups(
-		ctx, filter, usageQueryKindToken)
+		ctx, filter, usageQueryKindToken, false)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +147,8 @@ func (db *DB) GetTopSessionsByCost(
 func (db *DB) GetUsageSessionCounts(
 	ctx context.Context, filter UsageFilter,
 ) (UsageSessionCounts, error) {
-	_, facts, _, err := db.queryUsageRollups(ctx, filter, usageQueryKindToken)
+	_, facts, _, err := db.queryUsageRollups(
+		ctx, filter, usageQueryKindToken, false)
 	if err != nil {
 		return UsageSessionCounts{}, err
 	}
@@ -155,7 +159,8 @@ func (db *DB) GetUsageSessionCounts(
 func (db *DB) GetUsageMatchingSessionCount(
 	ctx context.Context, filter UsageFilter,
 ) (int, error) {
-	_, facts, _, err := db.queryUsageRollups(ctx, filter, usageQueryKindActivity)
+	_, facts, _, err := db.queryUsageRollups(
+		ctx, filter, usageQueryKindActivity, false)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/usage_cache_consumers.go
+++ b/internal/db/usage_cache_consumers.go
@@ -4,20 +4,54 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"time"
 
 	"go.kenn.io/agentsview/internal/export"
 	"go.kenn.io/agentsview/internal/money"
 )
+
+// usageRollupSlowRequestThreshold gates the privacy-safe phase-timing log so
+// warm reads stay silent and slow requests explain where the time went.
+const usageRollupSlowRequestThreshold = 2 * time.Second
+
+type usageRollupRequestTimings struct {
+	capture, sweep, fill, read time.Duration
+	rollup                     usageRollupMetrics
+	candidates                 int
+}
+
+func (timings usageRollupRequestTimings) logIfSlow(started time.Time) {
+	total := time.Since(started)
+	if total < usageRollupSlowRequestThreshold {
+		return
+	}
+	round := func(value time.Duration) time.Duration {
+		return value.Round(time.Millisecond)
+	}
+	log.Printf("usage rollup read took %s: capture %s, deletion sweep %s, "+
+		"fact fill %s, rollup build %s, rollup install %s, cache read %s "+
+		"(%d candidate sessions; built %d daily rows, %d exception rows in %d groups)",
+		round(total), round(timings.capture), round(timings.sweep),
+		round(timings.fill), round(timings.rollup.BuildDuration),
+		round(timings.rollup.InstallDuration), round(timings.read),
+		timings.candidates, timings.rollup.DailyRows,
+		timings.rollup.ExceptionRows, timings.rollup.ExceptionGroups)
+}
 
 func (db *DB) queryUsageRollups(
 	ctx context.Context, filter UsageFilter, kind usageQueryKind,
 	includeCursor bool,
 ) (usageQuerySnapshot, usageFactsResult, *export.PricingResolver, error) {
 	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
+		started := time.Now()
+		var timings usageRollupRequestTimings
 		snapshot, captureErr := db.captureUsageQuery(ctx, filter, kind)
 		if captureErr != nil {
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, captureErr
 		}
+		timings.capture = time.Since(started)
+		timings.candidates = len(snapshot.Versions)
 		if !includeCursor || !usageCursorIncluded(filter) {
 			snapshot.CursorHighWater = 0
 		}
@@ -30,10 +64,13 @@ func (db *DB) queryUsageRollups(
 			}
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, generationErr
 		}
+		sweepStarted := time.Now()
 		if sweepErr := cache.sweepDeletionJournal(ctx, db); sweepErr != nil {
 			release()
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, sweepErr
 		}
+		timings.sweep = time.Since(sweepStarted)
+		fillStarted := time.Now()
 		fills, fillErr := cache.fill.Ensure(
 			ctx, snapshot.Versions, snapshot.CursorHighWater,
 		)
@@ -45,9 +82,10 @@ func (db *DB) queryUsageRollups(
 			}
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, fillErr
 		}
+		timings.fill = time.Since(fillStarted)
 		snapshot.dropDeleted(fills)
 		resolver := export.NewPricingResolver(snapshot.PricingRows)
-		installs, _, rollupErr := cache.rollup.Ensure(
+		installs, rollupMetrics, rollupErr := cache.rollup.Ensure(
 			ctx, snapshot, fills, resolver)
 		if rollupErr != nil {
 			release()
@@ -57,6 +95,8 @@ func (db *DB) queryUsageRollups(
 			}
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, rollupErr
 		}
+		timings.rollup = rollupMetrics
+		readStarted := time.Now()
 		var facts usageFactsResult
 		var queryErr error
 		if kind == usageQueryKindActivity {
@@ -68,8 +108,10 @@ func (db *DB) queryUsageRollups(
 			facts, queryErr = cache.usageRollupQuery(
 				ctx, snapshot, filter, installs, resolver)
 		}
+		timings.read = time.Since(readStarted)
 		if queryErr == nil {
 			release()
+			timings.logIfSlow(started)
 			return snapshot, facts, resolver, nil
 		}
 		release()

--- a/internal/db/usage_cache_consumers.go
+++ b/internal/db/usage_cache_consumers.go
@@ -21,17 +21,24 @@ func (db *DB) queryUsageRollups(
 		if !includeCursor || !usageCursorIncluded(filter) {
 			snapshot.CursorHighWater = 0
 		}
-		cache, generationErr := db.usageCache.Generation(ctx, snapshot.DatabaseID)
+		cache, release, generationErr := db.usageCache.acquireGeneration(
+			ctx, snapshot.DatabaseID)
 		if generationErr != nil {
+			if errors.Is(generationErr, errUsageCacheSourceChanged) &&
+				attempt < usageFillMaxAttempts {
+				continue
+			}
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, generationErr
 		}
 		if sweepErr := cache.sweepDeletionJournal(ctx, db); sweepErr != nil {
+			release()
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, sweepErr
 		}
 		fills, fillErr := cache.fill.Ensure(
 			ctx, snapshot.Versions, snapshot.CursorHighWater,
 		)
 		if fillErr != nil {
+			release()
 			if errors.Is(fillErr, errUsageCacheSourceChanged) &&
 				attempt < usageFillMaxAttempts {
 				continue
@@ -43,6 +50,7 @@ func (db *DB) queryUsageRollups(
 		installs, _, rollupErr := cache.rollup.Ensure(
 			ctx, snapshot, fills, resolver)
 		if rollupErr != nil {
+			release()
 			if errors.Is(rollupErr, errUsageCacheSourceChanged) &&
 				attempt < usageFillMaxAttempts {
 				continue
@@ -61,8 +69,10 @@ func (db *DB) queryUsageRollups(
 				ctx, snapshot, filter, installs, resolver)
 		}
 		if queryErr == nil {
+			release()
 			return snapshot, facts, resolver, nil
 		}
+		release()
 		if !usageCacheReadShouldRecapture(queryErr) || attempt == usageFillMaxAttempts {
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, queryErr
 		}

--- a/internal/db/usage_cache_consumers_test.go
+++ b/internal/db/usage_cache_consumers_test.go
@@ -1,0 +1,137 @@
+//go:build fts5
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopSessionsRollupMatchesLegacy(t *testing.T) {
+	database := openDailyUsageFixtureDB(t)
+	ctx := context.Background()
+	for _, filter := range []UsageFilter{
+		{From: "2024-06-01", To: "2024-07-31", Timezone: "UTC"},
+		{From: "2024-06-01", To: "2024-07-31", Timezone: "UTC",
+			TopSessionsSort:       TopSessionsSortTokens,
+			TopSessionsTokenTypes: UsageTokenTypeInput | UsageTokenTypeOutput},
+		{From: "2024-06-01", To: "2024-07-31", Timezone: "UTC",
+			Project: "proj-a", Model: "model-a"},
+	} {
+		legacy, err := database.getTopSessionsByCostLegacy(ctx, filter, 3)
+		require.NoError(t, err)
+		facts, err := database.GetTopSessionsByCost(ctx, filter, 3)
+		require.NoError(t, err)
+		assert.Equal(t, legacy, facts)
+	}
+}
+
+func TestUsageSessionCountsRollupMatchesLegacy(t *testing.T) {
+	database := openDailyUsageFixtureDB(t)
+	ctx := context.Background()
+	for _, filter := range []UsageFilter{
+		{From: "2024-06-01", To: "2024-07-31", Timezone: "UTC"},
+		{From: "2024-06-01", To: "2024-06-30", Timezone: "UTC",
+			Agent: "claude", Model: "gpt-5"},
+	} {
+		legacy, err := database.getUsageSessionCountsLegacy(ctx, filter)
+		require.NoError(t, err)
+		facts, err := database.GetUsageSessionCounts(ctx, filter)
+		require.NoError(t, err)
+		assert.Equal(t, legacy, facts)
+	}
+}
+
+func TestUsageMatchingSessionCountRollupMatchesLegacy(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "relaxed", "project", func(session *Session) {
+		session.Agent = "copilot"
+		session.StartedAt = Ptr("2026-08-10T08:00:00Z")
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "relaxed", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T09:00:00Z", Model: "",
+	}}))
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+	legacy, err := database.getUsageMatchingSessionCountLegacy(
+		context.Background(), filter)
+	require.NoError(t, err)
+	facts, err := database.GetUsageMatchingSessionCount(
+		context.Background(), filter)
+	require.NoError(t, err)
+	assert.Equal(t, legacy, facts)
+}
+
+func TestUsageMatchingSessionCountRollupCountsDuplicateActivityOwners(t *testing.T) {
+	database := testDB(t)
+	for _, id := range []string{"first", "second"} {
+		insertSession(t, database, id, "project", func(session *Session) {
+			session.Agent = "claude"
+			session.StartedAt = Ptr("2026-08-10T08:00:00Z")
+		})
+		require.NoError(t, database.InsertMessages([]Message{{
+			SessionID: id, Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-10T09:00:00Z", Model: "model",
+			TokenUsage:      json.RawMessage(`{"input_tokens":1,"output_tokens":1}`),
+			ClaudeMessageID: "shared-message", ClaudeRequestID: "shared-request",
+		}}))
+	}
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+	legacy, err := database.getUsageMatchingSessionCountLegacy(
+		context.Background(), filter)
+	require.NoError(t, err)
+	facts, err := database.GetUsageMatchingSessionCount(
+		context.Background(), filter)
+	require.NoError(t, err)
+	assert.Equal(t, legacy, facts)
+}
+
+func TestUsageMatchingSessionCountRollupCountsUsageEventSessions(t *testing.T) {
+	database := testDB(t)
+	for _, id := range []string{"first-event", "second-event"} {
+		insertSession(t, database, id, "project", func(session *Session) {
+			session.Agent = "copilot"
+			session.StartedAt = Ptr("2026-08-10T08:00:00Z")
+		})
+		require.NoError(t, database.ReplaceSessionUsageEvents(id, []UsageEvent{{
+			Source: "session", Model: "model", InputTokens: 1,
+			OccurredAt: "2026-08-10T09:00:00Z", DedupKey: "event",
+		}}))
+	}
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+	legacy, err := database.getUsageMatchingSessionCountLegacy(
+		context.Background(), filter)
+	require.NoError(t, err)
+	require.Equal(t, 2, legacy)
+	facts, err := database.GetUsageMatchingSessionCount(
+		context.Background(), filter)
+	require.NoError(t, err)
+	assert.Equal(t, legacy, facts)
+}
+
+func TestDailyUsageFactsDoesNotDeduplicateSourceUUIDWithoutAgent(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "blank-agent", "project", func(session *Session) {
+		session.Agent = ""
+		session.StartedAt = Ptr("2026-08-10T08:00:00Z")
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "blank-agent", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T09:00:00Z", Model: "model",
+		TokenUsage: []byte(`{"input_tokens":3,"output_tokens":4}`),
+		SourceUUID: "source",
+	}}))
+	filter := UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+		SkipSessionCounts: true,
+	}
+	legacy, err := database.getDailyUsageLegacy(context.Background(), filter)
+	require.NoError(t, err)
+	facts, err := database.GetDailyUsage(context.Background(), filter)
+	require.NoError(t, err)
+	assert.Equal(t, legacy.Totals, facts.Totals)
+}

--- a/internal/db/usage_cache_consumers_test.go
+++ b/internal/db/usage_cache_consumers_test.go
@@ -66,6 +66,33 @@ func TestUsageMatchingSessionCountRollupMatchesLegacy(t *testing.T) {
 	assert.Equal(t, legacy, facts)
 }
 
+func TestUsageMatchingSessionCountRollupPreservesUndatedActivity(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "undated", "project")
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "undated", Ordinal: 0, Role: "assistant",
+	}}))
+
+	ctx := context.Background()
+	unbounded := UsageFilter{}
+	legacy, err := database.getUsageMatchingSessionCountLegacy(ctx, unbounded)
+	require.NoError(t, err)
+	require.Equal(t, 1, legacy)
+	got, err := database.GetUsageMatchingSessionCount(ctx, unbounded)
+	require.NoError(t, err)
+	assert.Equal(t, legacy, got)
+
+	bounded := UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	}
+	legacy, err = database.getUsageMatchingSessionCountLegacy(ctx, bounded)
+	require.NoError(t, err)
+	require.Zero(t, legacy)
+	got, err = database.GetUsageMatchingSessionCount(ctx, bounded)
+	require.NoError(t, err)
+	assert.Equal(t, legacy, got)
+}
+
 func TestUsageMatchingSessionCountRollupCountsDuplicateActivityOwners(t *testing.T) {
 	database := testDB(t)
 	for _, id := range []string{"first", "second"} {

--- a/internal/db/usage_cache_daily.go
+++ b/internal/db/usage_cache_daily.go
@@ -1,0 +1,426 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+type usageDailyFactsBucket struct {
+	input, output, cacheWrite, cacheRead int
+	cost                                 money.Money
+}
+
+type usageDailyFactsSessionCost struct {
+	estimated     map[usageCostAllocationKey]money.Money
+	authoritative *money.Money
+}
+
+// GetDailyUsage serves exact daily usage from normalized facts. Archive state
+// is captured first, missing facts are filled without holding that snapshot,
+// and one cache read transaction verifies and aggregates the installed rows.
+func (db *DB) GetDailyUsage(
+	ctx context.Context, filter UsageFilter,
+) (DailyUsageResult, error) {
+	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
+		snapshot, captureErr := db.captureUsageQuery(ctx, filter, usageQueryKindToken)
+		if captureErr != nil {
+			return DailyUsageResult{}, captureErr
+		}
+		if !usageCursorIncluded(filter) {
+			snapshot.CursorHighWater = 0
+		}
+		cache, generationErr := db.usageCache.Generation(ctx, snapshot.DatabaseID)
+		if generationErr != nil {
+			return DailyUsageResult{}, generationErr
+		}
+		if sweepErr := cache.sweepDeletionJournal(ctx, db); sweepErr != nil {
+			return DailyUsageResult{}, sweepErr
+		}
+		fills, fillErr := cache.fill.Ensure(
+			ctx, snapshot.Versions, snapshot.CursorHighWater,
+		)
+		if fillErr != nil {
+			if errors.Is(fillErr, errUsageCacheSourceChanged) &&
+				attempt < usageFillMaxAttempts {
+				continue
+			}
+			return DailyUsageResult{}, fillErr
+		}
+		snapshot.dropDeleted(fills)
+		resolver := export.NewPricingResolver(snapshot.PricingRows)
+		installs, _, rollupErr := cache.rollup.Ensure(
+			ctx, snapshot, fills, resolver)
+		if rollupErr != nil {
+			if errors.Is(rollupErr, errUsageCacheSourceChanged) &&
+				attempt < usageFillMaxAttempts {
+				continue
+			}
+			return DailyUsageResult{}, rollupErr
+		}
+		facts, queryErr := cache.usageRollupQuery(
+			ctx, snapshot, filter, installs, resolver)
+		if queryErr == nil {
+			return db.assembleDailyUsageFacts(ctx, filter, facts, resolver)
+		}
+		if !usageCacheReadShouldRecapture(queryErr) || attempt == usageFillMaxAttempts {
+			return DailyUsageResult{}, queryErr
+		}
+	}
+	return DailyUsageResult{}, fmt.Errorf(
+		"usage cache read could not stabilize after %d attempts",
+		usageFillMaxAttempts,
+	)
+}
+
+func (snapshot *usageQuerySnapshot) dropDeleted(
+	results map[string]usageFillResult,
+) {
+	if len(results) == 0 {
+		return
+	}
+	sessions := snapshot.Sessions[:0]
+	for _, session := range snapshot.Sessions {
+		if !results[session.ID].Deleted {
+			sessions = append(sessions, session)
+		}
+	}
+	versions := snapshot.Versions[:0]
+	for _, version := range snapshot.Versions {
+		if !results[version.SessionID].Deleted {
+			versions = append(versions, version)
+		} else {
+			delete(results, version.SessionID)
+		}
+	}
+	snapshot.Sessions = sessions
+	snapshot.Versions = versions
+}
+
+func (db *DB) assembleDailyUsageFacts(
+	ctx context.Context, filter UsageFilter, facts usageFactsResult,
+	resolver *export.PricingResolver,
+) (DailyUsageResult, error) {
+	accum := make(map[usageCostAllocationKey]*usageDailyFactsBucket)
+	sessionCosts := make(map[string]usageDailyFactsSessionCost)
+	projectLabels := make(map[string]struct{})
+	useAuthoritative := filter.Model == "" && filter.ExcludeModel == ""
+	var totalSavings money.Money
+
+	for _, group := range facts.Groups {
+		key := usageCostAllocationKey{
+			date: group.Date, project: group.Project, agent: group.Agent,
+			machine: group.Machine, model: group.Model,
+		}
+		bucket := accum[key]
+		if bucket == nil {
+			bucket = &usageDailyFactsBucket{}
+			accum[key] = bucket
+		}
+		bucket.input += int(group.InputTokens)
+		bucket.output += int(group.OutputTokens)
+		bucket.cacheWrite += int(group.CacheCreationTokens)
+		bucket.cacheRead += int(group.CacheReadTokens)
+
+		groupCost := money.Money{Microdollars: group.CostMicrodollars}
+		session := sessionCosts[group.SessionID]
+		if session.estimated == nil {
+			session.estimated = make(map[usageCostAllocationKey]money.Money)
+		}
+		var addErr error
+		session.estimated[key], addErr = money.Add(session.estimated[key], groupCost)
+		if addErr != nil {
+			return DailyUsageResult{}, fmt.Errorf(
+				"summing daily usage session cost: %w", addErr)
+		}
+		if useAuthoritative && group.AuthoritativeCostMicrodollars != nil {
+			value := money.Money{Microdollars: *group.AuthoritativeCostMicrodollars}
+			session.authoritative = &value
+		}
+		sessionCosts[group.SessionID] = session
+
+		totalSavings, addErr = money.Add(totalSavings,
+			money.Money{Microdollars: group.SavingsMicrodollars})
+		if addErr != nil {
+			return DailyUsageResult{}, fmt.Errorf(
+				"summing daily usage cache savings: %w", addErr)
+		}
+		if group.Project != "" {
+			projectLabels[group.Project] = struct{}{}
+		}
+		recordUsageFactsPricing(resolver, group)
+	}
+
+	sessionIDs := make([]string, 0, len(sessionCosts))
+	for sessionID := range sessionCosts {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	sort.Strings(sessionIDs)
+	for _, sessionID := range sessionIDs {
+		session := sessionCosts[sessionID]
+		costs := session.estimated
+		if session.authoritative != nil {
+			costs = allocateUsageCostByKey(*session.authoritative, session.estimated)
+			resolver.RecordUnattributedReported()
+		}
+		for key, cost := range costs {
+			var addErr error
+			accum[key].cost, addErr = money.Add(accum[key].cost, cost)
+			if addErr != nil {
+				return DailyUsageResult{}, fmt.Errorf(
+					"summing daily usage cost: %w", addErr)
+			}
+		}
+	}
+
+	daily, totals, err := buildDailyUsageFactsEntries(accum, filter.Breakdowns)
+	if err != nil {
+		return DailyUsageResult{}, err
+	}
+	totals.CacheSavings = totalSavings
+	for key, bucket := range accum {
+		totals.CopilotAICredits += AICreditsFromCost(key.agent, bucket.cost)
+	}
+
+	var sessionCounts UsageSessionCounts
+	if !filter.SkipSessionCounts {
+		sessionCounts = NewUsageSessionCounts(facts.MatchingSessions)
+	}
+	projects, err := db.BuildProjectIdentityMap(ctx, sortedSetKeys(projectLabels))
+	if err != nil {
+		return DailyUsageResult{}, err
+	}
+	projectRows := DailyUsageResult{Daily: daily, SessionCounts: sessionCounts}
+	SanitizeDailyUsageProjectLabelsWithCatalog(&projectRows, projects)
+	pricingBlock, err := resolver.BuildBlock()
+	if err != nil {
+		return DailyUsageResult{}, fmt.Errorf("building pricing block: %w", err)
+	}
+	return DailyUsageResult{
+		SchemaVersion: export.UsageDailySchemaVersion,
+		Pricing:       &pricingBlock,
+		Projects:      export.ProjectMapForWire(projects),
+		Daily:         projectRows.Daily,
+		Totals:        totals,
+		SessionCounts: projectRows.SessionCounts,
+	}, nil
+}
+
+func recordUsageFactsPricing(
+	resolver *export.PricingResolver, group usageFactsGroup,
+) {
+	_, lookup := resolver.Resolve(group.Model, group.PricedModel)
+	for range group.ReportedCount {
+		resolver.RecordResolvedReported(group.Model, group.PricedModel, lookup)
+	}
+	for range group.ComputedAggregateCount {
+		resolver.RecordResolvedComputedAggregate(
+			group.Model, group.PricedModel, lookup)
+	}
+	requestCount := group.ComputedRequestCount
+	if group.BandThreshold == nil {
+		requestCount = group.BaseRequestCount
+	}
+	inputTokens := 0
+	if group.BandThreshold != nil {
+		inputTokens = *group.BandThreshold + 1
+	}
+	for range requestCount {
+		resolver.RecordResolvedComputedRequest(
+			group.Model, group.PricedModel, lookup, inputTokens, 0, 0)
+	}
+}
+
+func buildDailyUsageFactsEntries(
+	accum map[usageCostAllocationKey]*usageDailyFactsBucket,
+	breakdowns bool,
+) ([]DailyUsageEntry, UsageTotals, error) {
+	type dayFacts struct {
+		models, projects, agents, machines map[string]usageDailyFactsBucket
+	}
+	days := make(map[string]*dayFacts)
+	for key, bucket := range accum {
+		day := days[key.date]
+		if day == nil {
+			day = &dayFacts{models: make(map[string]usageDailyFactsBucket)}
+			if breakdowns {
+				day.projects = make(map[string]usageDailyFactsBucket)
+				day.agents = make(map[string]usageDailyFactsBucket)
+				day.machines = make(map[string]usageDailyFactsBucket)
+			}
+			days[key.date] = day
+		}
+		var err error
+		day.models[key.model], err = addUsageDailyFactsBucket(day.models[key.model], *bucket)
+		if err != nil {
+			return nil, UsageTotals{}, err
+		}
+		if breakdowns {
+			day.projects[key.project], err = addUsageDailyFactsBucket(
+				day.projects[key.project], *bucket)
+			if err == nil {
+				day.agents[key.agent], err = addUsageDailyFactsBucket(
+					day.agents[key.agent], *bucket)
+			}
+			if err == nil {
+				day.machines[key.machine], err = addUsageDailyFactsBucket(
+					day.machines[key.machine], *bucket)
+			}
+			if err != nil {
+				return nil, UsageTotals{}, err
+			}
+		}
+	}
+
+	dates := make([]string, 0, len(days))
+	for date := range days {
+		dates = append(dates, date)
+	}
+	sort.Strings(dates)
+	daily := make([]DailyUsageEntry, 0, len(dates))
+	var totals UsageTotals
+	for _, date := range dates {
+		day := days[date]
+		entry := DailyUsageEntry{Date: date}
+		models := sortedUsageDailyBucketNames(day.models)
+		entry.ModelsUsed = append([]string(nil), models...)
+		for _, model := range models {
+			bucket := day.models[model]
+			if err := addUsageDailyFactsEntryTotals(&entry, bucket); err != nil {
+				return nil, UsageTotals{}, err
+			}
+			entry.ModelBreakdowns = append(entry.ModelBreakdowns, ModelBreakdown{
+				ModelName: model, InputTokens: bucket.input,
+				OutputTokens: bucket.output, CacheCreationTokens: bucket.cacheWrite,
+				CacheReadTokens: bucket.cacheRead, Cost: bucket.cost,
+			})
+		}
+		if breakdowns {
+			entry.ProjectBreakdowns = usageDailyProjectBreakdowns(day.projects)
+			entry.AgentBreakdowns = usageDailyAgentBreakdowns(day.agents)
+			entry.MachineBreakdowns = usageDailyMachineBreakdowns(day.machines)
+		}
+		var err error
+		totals.TotalCost, err = money.Add(totals.TotalCost, entry.TotalCost)
+		if err != nil {
+			return nil, UsageTotals{}, fmt.Errorf("summing daily usage total: %w", err)
+		}
+		totals.InputTokens += entry.InputTokens
+		totals.OutputTokens += entry.OutputTokens
+		totals.CacheCreationTokens += entry.CacheCreationTokens
+		totals.CacheReadTokens += entry.CacheReadTokens
+		daily = append(daily, entry)
+	}
+	return daily, totals, nil
+}
+
+func addUsageDailyFactsBucket(
+	left, right usageDailyFactsBucket,
+) (usageDailyFactsBucket, error) {
+	left.input += right.input
+	left.output += right.output
+	left.cacheWrite += right.cacheWrite
+	left.cacheRead += right.cacheRead
+	var err error
+	left.cost, err = money.Add(left.cost, right.cost)
+	if err != nil {
+		return usageDailyFactsBucket{}, fmt.Errorf("summing daily breakdown cost: %w", err)
+	}
+	return left, nil
+}
+
+func addUsageDailyFactsEntryTotals(
+	entry *DailyUsageEntry, bucket usageDailyFactsBucket,
+) error {
+	entry.InputTokens += bucket.input
+	entry.OutputTokens += bucket.output
+	entry.CacheCreationTokens += bucket.cacheWrite
+	entry.CacheReadTokens += bucket.cacheRead
+	var err error
+	entry.TotalCost, err = money.Add(entry.TotalCost, bucket.cost)
+	if err != nil {
+		return fmt.Errorf("summing daily entry cost: %w", err)
+	}
+	return nil
+}
+
+func sortedUsageDailyBucketNames(
+	buckets map[string]usageDailyFactsBucket,
+) []string {
+	names := make([]string, 0, len(buckets))
+	for name := range buckets {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		left, right := buckets[names[i]], buckets[names[j]]
+		if left.cost.Microdollars != right.cost.Microdollars {
+			return left.cost.Microdollars > right.cost.Microdollars
+		}
+		return names[i] < names[j]
+	})
+	return names
+}
+
+func usageDailyProjectBreakdowns(
+	buckets map[string]usageDailyFactsBucket,
+) []ProjectBreakdown {
+	result := make([]ProjectBreakdown, 0, len(buckets))
+	for name, bucket := range buckets {
+		result = append(result, ProjectBreakdown{
+			Project: name, InputTokens: bucket.input, OutputTokens: bucket.output,
+			CacheCreationTokens: bucket.cacheWrite,
+			CacheReadTokens:     bucket.cacheRead, Cost: bucket.cost,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Cost.Microdollars != result[j].Cost.Microdollars {
+			return result[i].Cost.Microdollars > result[j].Cost.Microdollars
+		}
+		return result[i].Project < result[j].Project
+	})
+	return result
+}
+
+func usageDailyAgentBreakdowns(
+	buckets map[string]usageDailyFactsBucket,
+) []AgentBreakdown {
+	result := make([]AgentBreakdown, 0, len(buckets))
+	for name, bucket := range buckets {
+		result = append(result, AgentBreakdown{
+			Agent: name, InputTokens: bucket.input, OutputTokens: bucket.output,
+			CacheCreationTokens: bucket.cacheWrite,
+			CacheReadTokens:     bucket.cacheRead, Cost: bucket.cost,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Cost.Microdollars != result[j].Cost.Microdollars {
+			return result[i].Cost.Microdollars > result[j].Cost.Microdollars
+		}
+		return result[i].Agent < result[j].Agent
+	})
+	return result
+}
+
+func usageDailyMachineBreakdowns(
+	buckets map[string]usageDailyFactsBucket,
+) []MachineBreakdown {
+	result := make([]MachineBreakdown, 0, len(buckets))
+	for name, bucket := range buckets {
+		result = append(result, MachineBreakdown{
+			MachineName: name, InputTokens: bucket.input,
+			OutputTokens: bucket.output, CacheCreationTokens: bucket.cacheWrite,
+			CacheReadTokens: bucket.cacheRead, Cost: bucket.cost,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Cost.Microdollars != result[j].Cost.Microdollars {
+			return result[i].Cost.Microdollars > result[j].Cost.Microdollars
+		}
+		return result[i].MachineName < result[j].MachineName
+	})
+	return result
+}

--- a/internal/db/usage_cache_daily.go
+++ b/internal/db/usage_cache_daily.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 
@@ -20,61 +19,18 @@ type usageDailyFactsSessionCost struct {
 	authoritative *money.Money
 }
 
-// GetDailyUsage serves exact daily usage from normalized facts. Archive state
-// is captured first, missing facts are filled without holding that snapshot,
-// and one cache read transaction verifies and aggregates the installed rows.
+// GetDailyUsage serves exact daily usage from timezone rollups. Archive state
+// is captured first, missing facts and rollups are built without holding that
+// snapshot, and one cache read transaction verifies the installed rows.
 func (db *DB) GetDailyUsage(
 	ctx context.Context, filter UsageFilter,
 ) (DailyUsageResult, error) {
-	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
-		snapshot, captureErr := db.captureUsageQuery(ctx, filter, usageQueryKindToken)
-		if captureErr != nil {
-			return DailyUsageResult{}, captureErr
-		}
-		if !usageCursorIncluded(filter) {
-			snapshot.CursorHighWater = 0
-		}
-		cache, generationErr := db.usageCache.Generation(ctx, snapshot.DatabaseID)
-		if generationErr != nil {
-			return DailyUsageResult{}, generationErr
-		}
-		if sweepErr := cache.sweepDeletionJournal(ctx, db); sweepErr != nil {
-			return DailyUsageResult{}, sweepErr
-		}
-		fills, fillErr := cache.fill.Ensure(
-			ctx, snapshot.Versions, snapshot.CursorHighWater,
-		)
-		if fillErr != nil {
-			if errors.Is(fillErr, errUsageCacheSourceChanged) &&
-				attempt < usageFillMaxAttempts {
-				continue
-			}
-			return DailyUsageResult{}, fillErr
-		}
-		snapshot.dropDeleted(fills)
-		resolver := export.NewPricingResolver(snapshot.PricingRows)
-		installs, _, rollupErr := cache.rollup.Ensure(
-			ctx, snapshot, fills, resolver)
-		if rollupErr != nil {
-			if errors.Is(rollupErr, errUsageCacheSourceChanged) &&
-				attempt < usageFillMaxAttempts {
-				continue
-			}
-			return DailyUsageResult{}, rollupErr
-		}
-		facts, queryErr := cache.usageRollupQuery(
-			ctx, snapshot, filter, installs, resolver)
-		if queryErr == nil {
-			return db.assembleDailyUsageFacts(ctx, filter, facts, resolver)
-		}
-		if !usageCacheReadShouldRecapture(queryErr) || attempt == usageFillMaxAttempts {
-			return DailyUsageResult{}, queryErr
-		}
+	_, facts, resolver, err := db.queryUsageRollups(
+		ctx, filter, usageQueryKindToken, true)
+	if err != nil {
+		return DailyUsageResult{}, err
 	}
-	return DailyUsageResult{}, fmt.Errorf(
-		"usage cache read could not stabilize after %d attempts",
-		usageFillMaxAttempts,
-	)
+	return db.assembleDailyUsageFacts(ctx, filter, facts, resolver)
 }
 
 func (snapshot *usageQuerySnapshot) dropDeleted(

--- a/internal/db/usage_cache_daily.go
+++ b/internal/db/usage_cache_daily.go
@@ -168,8 +168,13 @@ func (db *DB) assembleDailyUsageFacts(
 			resolver.RecordUnattributedReported()
 		}
 		for key, cost := range costs {
+			bucket := accum[key]
+			if bucket == nil {
+				return DailyUsageResult{}, fmt.Errorf(
+					"daily usage cost has no token bucket")
+			}
 			var addErr error
-			accum[key].cost, addErr = money.Add(accum[key].cost, cost)
+			bucket.cost, addErr = money.Add(bucket.cost, cost)
 			if addErr != nil {
 				return DailyUsageResult{}, fmt.Errorf(
 					"summing daily usage cost: %w", addErr)
@@ -285,6 +290,10 @@ func buildDailyUsageFactsEntries(
 	var totals UsageTotals
 	for _, date := range dates {
 		day := days[date]
+		if day == nil {
+			return nil, UsageTotals{}, fmt.Errorf(
+				"daily usage date %q has no aggregate", date)
+		}
 		entry := DailyUsageEntry{Date: date}
 		models := sortedUsageDailyBucketNames(day.models)
 		entry.ModelsUsed = append([]string(nil), models...)

--- a/internal/db/usage_cache_fill.go
+++ b/internal/db/usage_cache_fill.go
@@ -5,11 +5,14 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"maps"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"go.kenn.io/agentsview/internal/usagefacts"
 )
@@ -17,6 +20,7 @@ import (
 const usageFillMaxAttempts = 3
 const usageFillInstallBatchSize = 256
 const usageCursorCopyBatchSize = 1_000
+const usageFillNotificationDebounce = 100 * time.Millisecond
 
 var errUsageCacheSourceChanged = errors.New("usage cache source archive changed")
 
@@ -833,8 +837,7 @@ func installSpoolSessions(
 			session_id TEXT PRIMARY KEY, source_sync_marker TEXT NOT NULL,
 			source_transcript_rev TEXT NOT NULL,
 			usage_event_fingerprint TEXT NOT NULL,
-			install_revision INTEGER NOT NULL, fact_count INTEGER NOT NULL DEFAULT 0,
-			min_fact_timestamp_ms INTEGER, max_fact_timestamp_ms INTEGER
+			install_revision INTEGER NOT NULL
 		) WITHOUT ROWID;
 		DELETE FROM usage_install_sessions`); err != nil {
 		return nil, err
@@ -861,35 +864,18 @@ func installSpoolSessions(
 		return nil, err
 	}
 	if _, err := cacheConn.ExecContext(ctx, `
-		UPDATE usage_install_sessions AS install SET
-			fact_count = (SELECT COUNT(*) FROM usage_fill_spool.facts f
-			              WHERE f.session_id = install.session_id),
-			min_fact_timestamp_ms = (SELECT MIN(timestamp_ms)
-			              FROM usage_fill_spool.facts f
-			              WHERE f.session_id = install.session_id),
-			max_fact_timestamp_ms = (SELECT MAX(timestamp_ms)
-			              FROM usage_fill_spool.facts f
-			              WHERE f.session_id = install.session_id)`); err != nil {
-		return nil, err
-	}
-	if _, err := cacheConn.ExecContext(ctx, `
 		INSERT INTO usage_cached_sessions(
 			session_id, source_sync_marker, source_transcript_rev,
-			usage_event_fingerprint, install_revision, fact_count,
-			min_fact_timestamp_ms, max_fact_timestamp_ms
+			usage_event_fingerprint, install_revision
 		)
 		SELECT session_id, source_sync_marker, source_transcript_rev,
-		       usage_event_fingerprint, install_revision, fact_count,
-		       min_fact_timestamp_ms, max_fact_timestamp_ms
+		       usage_event_fingerprint, install_revision
 		FROM usage_install_sessions WHERE 1
 		ON CONFLICT(session_id) DO UPDATE SET
 			source_sync_marker=excluded.source_sync_marker,
 			source_transcript_rev=excluded.source_transcript_rev,
 			usage_event_fingerprint=excluded.usage_event_fingerprint,
-			install_revision=excluded.install_revision,
-			fact_count=excluded.fact_count,
-			min_fact_timestamp_ms=excluded.min_fact_timestamp_ms,
-			max_fact_timestamp_ms=excluded.max_fact_timestamp_ms`); err != nil {
+			install_revision=excluded.install_revision`); err != nil {
 		return nil, err
 	}
 	if _, err := cacheConn.ExecContext(ctx, `
@@ -995,13 +981,12 @@ func (c *usageFillCoordinator) fillCursor() {
 }
 
 type usageCursorInstall struct {
-	id, charged, fee  int64
-	timestamp         string
-	model, kind       string
-	userID, userEmail string
-	dedup             string
-	headless          int
-	fact              usagefacts.Fact
+	id, charged int64
+	timestamp   string
+	model       string
+	dedup       string
+	headless    int
+	fact        usagefacts.Fact
 }
 
 func (c *usageFillCoordinator) copyCursorThrough(ctx context.Context, target int64) error {
@@ -1050,9 +1035,8 @@ func (c *usageFillCoordinator) readCursorBatch(
 			fmt.Errorf("%w while copying Cursor usage", errUsageCacheSourceChanged)
 	}
 	rows, err := archiveTx.QueryContext(ctx, `
-		SELECT id, occurred_at, model, kind, input_tokens, output_tokens,
+		SELECT id, occurred_at, model, input_tokens, output_tokens,
 		       cache_write_tokens, cache_read_tokens, charged_microdollars,
-		       cursor_token_fee_microdollars, user_id, user_email,
 		       is_headless, dedup_key
 		FROM cursor_usage_events WHERE id > ? AND id <= ?
 		ORDER BY id LIMIT ?`, from, target, usageCursorCopyBatchSize)
@@ -1064,9 +1048,8 @@ func (c *usageFillCoordinator) readCursorBatch(
 		var install usageCursorInstall
 		var input, output, cacheWrite, cacheRead int64
 		if err := rows.Scan(
-			&install.id, &install.timestamp, &install.model, &install.kind,
+			&install.id, &install.timestamp, &install.model,
 			&input, &output, &cacheWrite, &cacheRead, &install.charged,
-			&install.fee, &install.userID, &install.userEmail,
 			&install.headless, &install.dedup,
 		); err != nil {
 			_ = rows.Close()
@@ -1101,17 +1084,15 @@ func (c *usageFillCoordinator) installCursorBatch(
 	defer func() { _ = tx.Rollback() }()
 	for _, install := range installs {
 		if _, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO cursor_usage_facts(
-			source_id, timestamp_ms, timestamp_ns, raw_timestamp, model, kind,
+			source_id, timestamp_ms, raw_timestamp, model,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-			charged_microdollars, cursor_token_fee_microdollars,
-			user_id, user_email, is_headless, dedup_key
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			install.id, install.fact.TimestampMillis, install.fact.TimestampNanos,
-			install.timestamp, install.model, install.kind,
+			charged_microdollars, is_headless, dedup_key
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			install.id, install.fact.TimestampMillis,
+			install.timestamp, install.model,
 			install.fact.InputTokens, install.fact.OutputTokens,
 			install.fact.CacheCreationTokens, install.fact.CacheReadTokens,
-			install.charged, install.fee, install.userID, install.userEmail,
-			install.headless, install.dedup,
+			install.charged, install.headless, install.dedup,
 		); err != nil {
 			return err
 		}
@@ -1176,30 +1157,116 @@ func (db *DB) notifyCursorUsage() {
 
 func (c *usageFillCoordinator) runNotifications() {
 	defer close(c.done)
+	pending := make(map[string]bool)
+	var cursorPending bool
+	var timer *time.Timer
+	var timerC <-chan time.Time
 	for {
 		select {
 		case <-c.ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
 			return
 		case notification := <-c.notify:
 			if notification.cursor {
-				var target int64
-				if err := c.archive.getReader().QueryRowContext(c.ctx,
-					`SELECT COALESCE(MAX(id), 0) FROM cursor_usage_events`,
-				).Scan(&target); err == nil && target > 0 {
-					_, _ = c.Ensure(c.ctx, nil, target)
-				}
-				continue
+				cursorPending = true
+			} else if notification.sessionID != "" {
+				pending[notification.sessionID] = true
 			}
-			versions, err := c.recheckSourceVersions(c.ctx,
-				[]usageSourceVersion{{SessionID: notification.sessionID}})
-			version, exists := versions[notification.sessionID]
-			if err == nil && exists {
-				_, _ = c.Ensure(c.ctx, []usageSourceVersion{version}, 0)
-			} else if err == nil {
-				_, _ = c.cache.db.ExecContext(c.ctx,
-					`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
-					notification.sessionID)
+			if timer == nil {
+				timer = time.NewTimer(usageFillNotificationDebounce)
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(usageFillNotificationDebounce)
+			}
+			timerC = timer.C
+		case <-timerC:
+			timerC = nil
+			c.processNotificationBatch(pending, cursorPending)
+			clear(pending)
+			cursorPending = false
+		}
+	}
+}
+
+func (c *usageFillCoordinator) processNotificationBatch(
+	pending map[string]bool, cursorPending bool,
+) {
+	if len(pending) > 0 {
+		ids := make([]string, 0, len(pending))
+		for id := range pending {
+			ids = append(ids, id)
+		}
+		slices.Sort(ids)
+		requested := make([]usageSourceVersion, len(ids))
+		for index, id := range ids {
+			requested[index].SessionID = id
+		}
+		versions, err := c.recheckSourceVersions(c.ctx, requested)
+		if err != nil {
+			if c.ctx.Err() == nil {
+				log.Printf("usage cache notification source check: %v", err)
+			}
+		} else {
+			current := make([]usageSourceVersion, 0, len(versions))
+			deleted := make([]string, 0, len(ids)-len(versions))
+			for _, id := range ids {
+				if version, exists := versions[id]; exists {
+					current = append(current, version)
+					continue
+				}
+				deleted = append(deleted, id)
+			}
+			if len(deleted) > 0 {
+				if err := c.deleteNotificationSessions(deleted); err != nil &&
+					c.ctx.Err() == nil {
+					log.Printf("usage cache notification delete: %v", err)
+				}
+			}
+			if len(current) > 0 {
+				if _, err := c.Ensure(c.ctx, current, 0); err != nil && c.ctx.Err() == nil {
+					log.Printf("usage cache notification fill: %v", err)
+				}
 			}
 		}
 	}
+	if cursorPending {
+		var target int64
+		err := c.archive.getReader().QueryRowContext(c.ctx,
+			`SELECT COALESCE(MAX(id), 0) FROM cursor_usage_events`,
+		).Scan(&target)
+		if err == nil && target > 0 {
+			_, err = c.Ensure(c.ctx, nil, target)
+		}
+		if err != nil && c.ctx.Err() == nil {
+			log.Printf("usage cache Cursor notification fill: %v", err)
+		}
+	}
+}
+
+func (c *usageFillCoordinator) deleteNotificationSessions(ids []string) error {
+	tx, err := c.cache.db.BeginTx(c.ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, id := range ids {
+		if _, err := tx.ExecContext(c.ctx,
+			`DELETE FROM usage_rollup_installs WHERE session_id = ?`, id,
+		); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(c.ctx,
+			`DELETE FROM usage_cached_sessions WHERE session_id = ?`, id,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }

--- a/internal/db/usage_cache_fill.go
+++ b/internal/db/usage_cache_fill.go
@@ -1,0 +1,1205 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"go.kenn.io/agentsview/internal/usagefacts"
+)
+
+const usageFillMaxAttempts = 3
+const usageFillInstallBatchSize = 256
+const usageCursorCopyBatchSize = 1_000
+
+var errUsageCacheSourceChanged = errors.New("usage cache source archive changed")
+
+type usageFillResult struct {
+	InstallRevision int64
+	Deleted         bool
+	source          usageSourceVersion
+}
+
+type usageFillCall struct {
+	done   chan struct{}
+	result usageFillResult
+	err    error
+}
+
+type usageCursorFillCall struct {
+	done chan struct{}
+	err  error
+}
+
+// usageFillObserver exposes lifecycle boundaries to deterministic tests. Its
+// callbacks must never be used for production work.
+type usageFillObserver struct {
+	beforeExtract    func([]usageSourceVersion)
+	afterExtract     func([]usageSourceVersion)
+	beforeInstall    func([]usageSourceVersion)
+	afterMaintenance func()
+}
+
+type usageFillCoordinator struct {
+	archive *DB
+	cache   *usageCache
+	ctx     context.Context
+	cancel  context.CancelFunc
+
+	mu           sync.Mutex
+	calls        map[string]*usageFillCall
+	cursorCall   *usageCursorFillCall
+	cursorTarget int64
+	observer     usageFillObserver
+	notify       chan usageFillNotification
+	done         chan struct{}
+}
+
+type usageFillNotification struct {
+	sessionID string
+	cursor    bool
+}
+
+func newUsageFillCoordinator(
+	parent context.Context, archive *DB, cache *usageCache,
+) *usageFillCoordinator {
+	ctx, cancel := context.WithCancel(parent)
+	c := &usageFillCoordinator{
+		archive: archive, cache: cache, ctx: ctx, cancel: cancel,
+		calls:  make(map[string]*usageFillCall),
+		notify: make(chan usageFillNotification, 1024),
+		done:   make(chan struct{}),
+	}
+	go c.runNotifications()
+	return c
+}
+
+func (c *usageFillCoordinator) Close() {
+	c.cancel()
+	<-c.done
+}
+
+// Ensure makes the requested source versions and Cursor prefix available in
+// the cache. Fill work uses the coordinator context, so cancelling a waiter
+// detaches that waiter without cancelling shared progress.
+func (c *usageFillCoordinator) Ensure(
+	ctx context.Context, versions []usageSourceVersion, cursorHighWater int64,
+) (map[string]usageFillResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	results := make(map[string]usageFillResult, len(versions))
+	waiting := make(map[string]*usageFillCall)
+	owned := make([]usageSourceVersion, 0, len(versions))
+	for _, version := range versions {
+		cached, ok, err := c.cachedSession(version.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		if ok && cached.source.Equal(version) {
+			results[version.SessionID] = cached
+			continue
+		}
+
+		c.mu.Lock()
+		key := usageFillCallKey(version)
+		call := c.calls[key]
+		if call == nil {
+			call = &usageFillCall{done: make(chan struct{})}
+			c.calls[key] = call
+			owned = append(owned, version)
+		}
+		waiting[version.SessionID] = call
+		c.mu.Unlock()
+	}
+	if len(owned) > 0 {
+		go c.fillSessions(owned)
+	}
+
+	for id, call := range waiting {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-call.done:
+			if call.err != nil {
+				return nil, call.err
+			}
+			results[id] = call.result
+		}
+	}
+	for _, version := range versions {
+		result, ok := results[version.SessionID]
+		if ok && !result.Deleted && !result.source.Equal(version) {
+			return nil, fmt.Errorf(
+				"%w while filling session %s",
+				errUsageCacheSourceChanged, version.SessionID,
+			)
+		}
+	}
+	if cursorHighWater > 0 {
+		if err := c.ensureCursor(ctx, cursorHighWater); err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
+
+func usageFillCallKey(version usageSourceVersion) string {
+	return strings.Join([]string{
+		version.SessionID, version.SyncMarker, version.TranscriptRevision,
+		version.UsageEventFingerprint,
+	}, "\x00")
+}
+
+func (c *usageFillCoordinator) cachedSession(
+	sessionID string,
+) (usageFillResult, bool, error) {
+	var result usageFillResult
+	err := c.cache.db.QueryRow(`
+		SELECT source_sync_marker, source_transcript_rev,
+		       usage_event_fingerprint, install_revision
+		FROM usage_cached_sessions WHERE session_id = ?`, sessionID).Scan(
+		&result.source.SyncMarker, &result.source.TranscriptRevision,
+		&result.source.UsageEventFingerprint, &result.InstallRevision,
+	)
+	result.source.SessionID = sessionID
+	if errors.Is(err, sql.ErrNoRows) {
+		return usageFillResult{}, false, nil
+	}
+	if err != nil {
+		return usageFillResult{}, false,
+			fmt.Errorf("reading cached usage session %s: %w", sessionID, err)
+	}
+	return result, true, nil
+}
+
+func (c *usageFillCoordinator) fillSessions(versions []usageSourceVersion) {
+	results, err := c.fillSessionsDetached(c.ctx, versions)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, version := range versions {
+		key := usageFillCallKey(version)
+		call := c.calls[key]
+		if call == nil {
+			continue
+		}
+		call.result = results[version.SessionID]
+		call.err = err
+		delete(c.calls, key)
+		close(call.done)
+	}
+}
+
+func (c *usageFillCoordinator) fillSessionsDetached(
+	ctx context.Context,
+	versions []usageSourceVersion,
+) (map[string]usageFillResult, error) {
+	pending := append([]usageSourceVersion(nil), versions...)
+	results := make(map[string]usageFillResult, len(versions))
+	var spool *usageFactSpool
+	for attempt := 1; len(pending) > 0 && attempt <= usageFillMaxAttempts; attempt++ {
+		if spool == nil {
+			if c.observer.beforeExtract != nil {
+				c.observer.beforeExtract(append([]usageSourceVersion(nil), pending...))
+			}
+			var err error
+			spool, err = c.extractSessions(ctx, pending)
+			if err != nil {
+				return nil, err
+			}
+			if c.observer.afterExtract != nil {
+				c.observer.afterExtract(append([]usageSourceVersion(nil), pending...))
+			}
+		}
+		if c.observer.beforeInstall != nil {
+			c.observer.beforeInstall(append([]usageSourceVersion(nil), pending...))
+		}
+		installed, retry, err := c.installSpool(ctx, spool, pending)
+		if err != nil && isUsageCacheBusy(err) {
+			continue
+		}
+		closeErr := spool.Close()
+		spool = nil
+		if err != nil {
+			return nil, errors.Join(err, closeErr)
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+		maps.Copy(results, installed)
+		pending = retry
+	}
+	if spool != nil {
+		_ = spool.Close()
+	}
+	if len(pending) != 0 {
+		return nil, fmt.Errorf(
+			"usage cache fill could not verify archive state after %d attempts for %d sessions",
+			usageFillMaxAttempts, len(pending),
+		)
+	}
+	return results, nil
+}
+
+// FillBackground performs cancellable, non-single-flight work for the daemon
+// coverage pass. Foreground requests therefore never inherit the background
+// owner's cancellation and can independently prioritize the sessions they
+// need.
+func (c *usageFillCoordinator) FillBackground(
+	ctx context.Context, versions []usageSourceVersion, cursorHighWater int64,
+) (map[string]usageFillResult, error) {
+	results := make(map[string]usageFillResult, len(versions))
+	pending := make([]usageSourceVersion, 0, len(versions))
+	for _, version := range versions {
+		cached, ok, err := c.cachedSession(version.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		if ok && cached.source.Equal(version) {
+			results[version.SessionID] = cached
+			continue
+		}
+		pending = append(pending, version)
+	}
+	installed, err := c.fillSessionsDetached(ctx, pending)
+	if err != nil {
+		return nil, err
+	}
+	maps.Copy(results, installed)
+	if cursorHighWater > 0 {
+		if err := c.copyCursorThrough(ctx, cursorHighWater); err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
+
+func isUsageCacheBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "database is locked") ||
+		strings.Contains(message, "database table is locked") ||
+		strings.Contains(message, "sqlite_busy")
+}
+
+type usageFactSpool struct {
+	db   *sql.DB
+	path string
+}
+
+func newUsageFactSpool() (*usageFactSpool, error) {
+	file, err := os.CreateTemp("", "agentsview-usage-facts-spool-*.db")
+	if err != nil {
+		return nil, fmt.Errorf("creating usage fact spool: %w", err)
+	}
+	path := file.Name()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("securing usage fact spool: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("closing usage fact spool: %w", err)
+	}
+	database, err := sql.Open("sqlite3", makeDSN(path, false))
+	if err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	database.SetMaxOpenConns(1)
+	if _, err := database.Exec(`
+		PRAGMA journal_mode=MEMORY;
+		PRAGMA synchronous=OFF;
+		PRAGMA temp_store=MEMORY`); err != nil {
+		_ = database.Close()
+		_ = removeUsageCacheFiles(path)
+		return nil, fmt.Errorf("configuring usage fact spool: %w", err)
+	}
+	if _, err := database.Exec(`
+		CREATE TABLE facts (
+			session_id TEXT NOT NULL, fact_index INTEGER NOT NULL,
+			source TEXT NOT NULL, message_ordinal INTEGER,
+			timestamp_ms INTEGER, timestamp_ns INTEGER, raw_timestamp TEXT NOT NULL,
+			uses_session_start INTEGER NOT NULL, model TEXT NOT NULL,
+			input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL,
+			reasoning_tokens INTEGER NOT NULL,
+			cache_creation_tokens INTEGER NOT NULL,
+			cache_read_tokens INTEGER NOT NULL,
+			web_search_requests INTEGER NOT NULL,
+			reported_cost_microdollars INTEGER, cost_source TEXT NOT NULL,
+			request_scoped INTEGER NOT NULL,
+			claude_message_id TEXT NOT NULL, claude_request_id TEXT NOT NULL,
+			source_uuid TEXT NOT NULL, usage_dedup_key TEXT NOT NULL,
+			token_eligible INTEGER NOT NULL, activity_eligible INTEGER NOT NULL,
+			PRIMARY KEY(session_id, fact_index)
+		) WITHOUT ROWID`); err != nil {
+		_ = database.Close()
+		_ = removeUsageCacheFiles(path)
+		return nil, fmt.Errorf("initializing usage fact spool: %w", err)
+	}
+	return &usageFactSpool{db: database, path: path}, nil
+}
+
+func (s *usageFactSpool) Close() error {
+	return errors.Join(s.db.Close(), removeUsageCacheFiles(s.path))
+}
+
+func (c *usageFillCoordinator) extractSessions(
+	ctx context.Context, versions []usageSourceVersion,
+) (*usageFactSpool, error) {
+	spool, err := newUsageFactSpool()
+	if err != nil {
+		return nil, err
+	}
+	fail := true
+	defer func() {
+		if fail {
+			_ = spool.Close()
+		}
+	}()
+	conn, err := c.archive.getReader().Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pinning archive usage fill connection: %w", err)
+	}
+	defer conn.Close()
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("starting archive usage fill snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx,
+		`CREATE TEMP TABLE IF NOT EXISTS usage_fill_sessions(
+			session_id TEXT PRIMARY KEY
+		) WITHOUT ROWID;
+		DELETE FROM usage_fill_sessions`,
+	); err != nil {
+		return nil, fmt.Errorf("creating usage fill session set: %w", err)
+	}
+	insert, err := tx.PrepareContext(ctx,
+		`INSERT INTO usage_fill_sessions(session_id) VALUES (?)`)
+	if err != nil {
+		return nil, err
+	}
+	for _, version := range versions {
+		if _, err := insert.ExecContext(ctx, version.SessionID); err != nil {
+			_ = insert.Close()
+			return nil, err
+		}
+	}
+	if err := insert.Close(); err != nil {
+		return nil, err
+	}
+
+	spoolTx, err := spool.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = spoolTx.Rollback() }()
+	indexes := make(map[string]int, len(versions))
+	spoolWriter := usageFactSpoolWriter{ctx: ctx, tx: spoolTx}
+	if err := extractUsageMessageFacts(ctx, tx, &spoolWriter, indexes); err != nil {
+		return nil, err
+	}
+	if err := extractUsageActivityFacts(ctx, tx, &spoolWriter, indexes); err != nil {
+		return nil, err
+	}
+	if err := extractUsageEventFacts(ctx, tx, &spoolWriter, indexes); err != nil {
+		return nil, err
+	}
+	if err := spoolWriter.Flush(); err != nil {
+		return nil, err
+	}
+	if err := spoolTx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing usage fact spool: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("closing archive usage fill snapshot: %w", err)
+	}
+	fail = false
+	return spool, nil
+}
+
+func extractUsageMessageFacts(
+	ctx context.Context, archive *sql.Tx, spool *usageFactSpoolWriter,
+	indexes map[string]int,
+) error {
+	rows, err := archive.QueryContext(ctx, usageFillMessageFactsSQL)
+	if err != nil {
+		return fmt.Errorf("extracting token usage messages: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sessionID string
+		var input usagefacts.MessageInput
+		if err := rows.Scan(
+			&sessionID, &input.Ordinal, &input.Role, &input.Timestamp,
+			&input.Model, &input.TokenUsage, &input.ClaudeMessageID,
+			&input.ClaudeRequestID, &input.SourceUUID,
+		); err != nil {
+			return err
+		}
+		fact, ok := usagefacts.FromMessage(input)
+		if ok {
+			if err := spool.Add(sessionID, indexes[sessionID], fact); err != nil {
+				return err
+			}
+			indexes[sessionID]++
+		}
+	}
+	return rows.Err()
+}
+
+func extractUsageActivityFacts(
+	ctx context.Context, archive *sql.Tx, spool *usageFactSpoolWriter,
+	indexes map[string]int,
+) error {
+	rows, err := archive.QueryContext(ctx, usageFillActivityFactsSQL)
+	if err != nil {
+		return fmt.Errorf("extracting relaxed activity messages: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sessionID string
+		var input usagefacts.MessageInput
+		if err := rows.Scan(
+			&sessionID, &input.Ordinal, &input.Role, &input.Timestamp,
+			&input.Model,
+		); err != nil {
+			return err
+		}
+		fact, ok := usagefacts.FromMessage(input)
+		if ok {
+			if err := spool.Add(sessionID, indexes[sessionID], fact); err != nil {
+				return err
+			}
+			indexes[sessionID]++
+		}
+	}
+	return rows.Err()
+}
+
+func extractUsageEventFacts(
+	ctx context.Context, archive *sql.Tx, spool *usageFactSpoolWriter,
+	indexes map[string]int,
+) error {
+	rows, err := archive.QueryContext(ctx, usageFillEventFactsSQL)
+	if err != nil {
+		return fmt.Errorf("extracting usage events: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sessionID string
+		var ordinal, cost sql.NullInt64
+		var eventID int64
+		var rawDedupKey string
+		var input usagefacts.EventInput
+		if err := rows.Scan(
+			&eventID, &sessionID, &ordinal, &input.Source, &input.Model,
+			&input.InputTokens, &input.OutputTokens, &input.CacheCreationTokens,
+			&input.CacheReadTokens, &input.ReasoningTokens, &cost,
+			&input.CostSource, &input.Timestamp, &rawDedupKey,
+		); err != nil {
+			return err
+		}
+		input.DedupKey = usagefacts.EventDedupKey(
+			sessionID, input.Source, rawDedupKey, eventID,
+		)
+		if ordinal.Valid {
+			value := int(ordinal.Int64)
+			input.MessageOrdinal = &value
+		}
+		if cost.Valid {
+			value := cost.Int64
+			input.ReportedCostMicrodollars = &value
+		}
+		fact, ok := usagefacts.FromEvent(input)
+		if ok {
+			if err := spool.Add(sessionID, indexes[sessionID], fact); err != nil {
+				return err
+			}
+			indexes[sessionID]++
+		}
+	}
+	return rows.Err()
+}
+
+const usageFactSpoolBatchSize = 1_000
+
+type usageFactSpoolRow struct {
+	sessionID string
+	index     int
+	fact      usagefacts.Fact
+}
+
+type usageFactSpoolWriter struct {
+	ctx  context.Context
+	tx   *sql.Tx
+	rows []usageFactSpoolRow
+}
+
+func (w *usageFactSpoolWriter) Add(
+	sessionID string, index int, fact usagefacts.Fact,
+) error {
+	w.rows = append(w.rows, usageFactSpoolRow{
+		sessionID: sessionID, index: index, fact: fact,
+	})
+	if len(w.rows) < usageFactSpoolBatchSize {
+		return nil
+	}
+	return w.Flush()
+}
+
+func (w *usageFactSpoolWriter) Flush() error {
+	if len(w.rows) == 0 {
+		return nil
+	}
+	const prefix = `INSERT INTO facts(
+		session_id, fact_index, source, message_ordinal, timestamp_ms, timestamp_ns,
+		raw_timestamp, uses_session_start, model, input_tokens, output_tokens,
+		reasoning_tokens, cache_creation_tokens, cache_read_tokens,
+		web_search_requests, reported_cost_microdollars, cost_source,
+		request_scoped, claude_message_id, claude_request_id, source_uuid,
+		usage_dedup_key, token_eligible, activity_eligible
+	) VALUES `
+	const placeholders = `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	var query strings.Builder
+	query.Grow(len(prefix) + len(w.rows)*(len(placeholders)+1))
+	query.WriteString(prefix)
+	args := make([]any, 0, len(w.rows)*24)
+	for rowIndex, row := range w.rows {
+		if rowIndex > 0 {
+			query.WriteByte(',')
+		}
+		query.WriteString(placeholders)
+		fact := row.fact
+		args = append(args,
+			row.sessionID, row.index, fact.Source, fact.MessageOrdinal,
+			fact.TimestampMillis, fact.TimestampNanos, fact.RawTimestamp,
+			boolInt(fact.UsesSessionStart),
+			fact.Model, fact.InputTokens, fact.OutputTokens, fact.ReasoningTokens,
+			fact.CacheCreationTokens, fact.CacheReadTokens, fact.WebSearchRequests,
+			fact.ReportedCostMicrodollars, fact.CostSource,
+			boolInt(fact.RequestScoped), fact.ClaudeMessageID,
+			fact.ClaudeRequestID, fact.SourceUUID, fact.UsageDedupKey,
+			boolInt(fact.TokenEligible), boolInt(fact.ActivityEligible),
+		)
+	}
+	_, err := w.tx.ExecContext(w.ctx, query.String(), args...)
+	if err != nil {
+		return fmt.Errorf("spooling %d usage facts: %w", len(w.rows), err)
+	}
+	w.rows = w.rows[:0]
+	return nil
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+const usageFillMessageFactsSQL = `
+	SELECT m.session_id, m.ordinal, m.role, COALESCE(m.timestamp, ''),
+	       m.model, m.token_usage, m.claude_message_id,
+	       m.claude_request_id, m.source_uuid
+	FROM usage_fill_sessions f
+	CROSS JOIN messages m INDEXED BY idx_messages_usage_session_covering
+	  ON m.session_id = f.session_id
+	WHERE m.token_usage != '' AND m.model != '' AND m.model != '<synthetic>'
+	ORDER BY m.timestamp, m.session_id, m.ordinal`
+
+const usageFillActivityFactsSQL = `
+	SELECT m.session_id, m.ordinal, m.role, COALESCE(m.timestamp, ''), m.model
+	FROM usage_fill_sessions f
+	CROSS JOIN messages m INDEXED BY idx_messages_session_role
+	  ON m.session_id = f.session_id
+	WHERE m.role = 'assistant' AND m.model != '<synthetic>'
+	  AND NOT (m.token_usage != '' AND m.model != '')
+	ORDER BY m.session_id, m.ordinal`
+
+const usageFillEventFactsSQL = `
+	SELECT e.id, e.session_id, e.message_ordinal, e.source, e.model,
+	       e.input_tokens, e.output_tokens, e.cache_creation_input_tokens,
+	       e.cache_read_input_tokens, e.reasoning_tokens,
+	       e.cost_microdollars, e.cost_source, COALESCE(e.occurred_at, ''),
+	       e.dedup_key
+	FROM usage_fill_sessions f
+	CROSS JOIN usage_events e INDEXED BY idx_usage_events_session
+	  ON e.session_id = f.session_id
+	WHERE e.model != ''
+	ORDER BY e.session_id, COALESCE(e.occurred_at, ''), e.id`
+
+func (c *usageFillCoordinator) installSpool(
+	ctx context.Context, spool *usageFactSpool, versions []usageSourceVersion,
+) (map[string]usageFillResult, []usageSourceVersion, error) {
+	installed := make(map[string]usageFillResult, len(versions))
+	var retry []usageSourceVersion
+	for start := 0; start < len(versions); start += usageFillInstallBatchSize {
+		end := min(start+usageFillInstallBatchSize, len(versions))
+		batchInstalled, batchRetry, err := c.installSpoolBatch(
+			ctx, spool, versions[start:end],
+		)
+		if err != nil {
+			return nil, versions, err
+		}
+		maps.Copy(installed, batchInstalled)
+		retry = append(retry, batchRetry...)
+		if end < len(versions) {
+			c.maintainBetweenInstallBatches(ctx)
+		}
+	}
+	return installed, retry, nil
+}
+
+func (c *usageFillCoordinator) installSpoolBatch(
+	ctx context.Context, spool *usageFactSpool, versions []usageSourceVersion,
+) (map[string]usageFillResult, []usageSourceVersion, error) {
+	conn, err := c.cache.db.Conn(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx,
+		`ATTACH DATABASE ? AS usage_fill_spool`, spool.path,
+	); err != nil {
+		return nil, nil, fmt.Errorf("attaching usage fact spool: %w", err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(context.Background(),
+			`DETACH DATABASE usage_fill_spool`)
+	}()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return nil, versions, fmt.Errorf("locking usage cache for fill: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+
+	results := make(map[string]usageFillResult, len(versions))
+	var retry []usageSourceVersion
+	stable := make([]usageSourceVersion, 0, len(versions))
+	currentVersions, err := c.recheckSourceVersions(ctx, versions)
+	if err != nil {
+		return nil, versions, err
+	}
+	for _, observed := range versions {
+		current, exists := currentVersions[observed.SessionID]
+		if !exists {
+			if _, err := conn.ExecContext(ctx,
+				`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
+				observed.SessionID,
+			); err != nil {
+				return nil, versions, err
+			}
+			results[observed.SessionID] = usageFillResult{Deleted: true}
+			continue
+		}
+		if !current.Equal(observed) {
+			retry = append(retry, current)
+			continue
+		}
+		stable = append(stable, current)
+	}
+	stableResults, err := installSpoolSessions(ctx, conn, stable)
+	if err != nil {
+		return nil, versions, err
+	}
+	maps.Copy(results, stableResults)
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return nil, versions, fmt.Errorf("committing usage cache fill: %w", err)
+	}
+	committed = true
+	return results, retry, nil
+}
+
+func (c *usageFillCoordinator) recheckSourceVersions(
+	ctx context.Context, observed []usageSourceVersion,
+) (map[string]usageSourceVersion, error) {
+	conn, err := c.archive.getReader().Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	var priorBusyTimeout int
+	if err := conn.QueryRowContext(ctx, `PRAGMA busy_timeout`).Scan(
+		&priorBusyTimeout); err != nil {
+		return nil, err
+	}
+	if _, err := conn.ExecContext(ctx, `PRAGMA busy_timeout=0`); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_, _ = conn.ExecContext(context.Background(),
+			`PRAGMA busy_timeout=`+strconv.Itoa(priorBusyTimeout))
+	}()
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var databaseID string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT value FROM archive_metadata WHERE key = ?`,
+		archiveMetadataDatabaseIDKey,
+	).Scan(&databaseID); err != nil {
+		return nil, err
+	}
+	if databaseID != c.cache.databaseID {
+		return nil, fmt.Errorf("%w during session fill", errUsageCacheSourceChanged)
+	}
+	ids := make([]string, 0, len(observed))
+	for _, version := range observed {
+		ids = append(ids, version.SessionID)
+	}
+	current := make(map[string]usageSourceVersion, len(ids))
+	if err := queryChunked(ids, func(chunk []string) error {
+		placeholders, args := inPlaceholders(chunk)
+		rows, queryErr := tx.QueryContext(ctx, `
+			SELECT id, COALESCE(sync_marker, ''),
+			       COALESCE(transcript_revision, '0')
+			FROM sessions WHERE deleted_at IS NULL AND id IN `+placeholders,
+			args...)
+		if queryErr != nil {
+			return queryErr
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var version usageSourceVersion
+			if scanErr := rows.Scan(&version.SessionID, &version.SyncMarker,
+				&version.TranscriptRevision); scanErr != nil {
+				return scanErr
+			}
+			current[version.SessionID] = version
+		}
+		return rows.Err()
+	}); err != nil {
+		return nil, err
+	}
+	foundIDs := make([]string, 0, len(current))
+	for _, id := range ids {
+		if _, ok := current[id]; ok {
+			foundIDs = append(foundIDs, id)
+		}
+	}
+	fingerprints, err := usageEventFingerprintsWithQuerier(
+		ctx, tx, foundIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for id, version := range current {
+		version.UsageEventFingerprint = fingerprints[id]
+		current[id] = version
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+func installSpoolSessions(
+	ctx context.Context, cacheConn *sql.Conn, versions []usageSourceVersion,
+) (map[string]usageFillResult, error) {
+	results := make(map[string]usageFillResult, len(versions))
+	if len(versions) == 0 {
+		return results, nil
+	}
+	var revisionText string
+	if err := cacheConn.QueryRowContext(ctx,
+		`SELECT value FROM usage_cache_metadata WHERE key = ?`,
+		usageCacheMetadataNextInstallRevision,
+	).Scan(&revisionText); err != nil {
+		return nil, err
+	}
+	revision, err := strconv.ParseInt(revisionText, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parsing usage install revision: %w", err)
+	}
+	if _, err := cacheConn.ExecContext(ctx, `
+		CREATE TEMP TABLE IF NOT EXISTS usage_install_sessions(
+			session_id TEXT PRIMARY KEY, source_sync_marker TEXT NOT NULL,
+			source_transcript_rev TEXT NOT NULL,
+			usage_event_fingerprint TEXT NOT NULL,
+			install_revision INTEGER NOT NULL, fact_count INTEGER NOT NULL DEFAULT 0,
+			min_fact_timestamp_ms INTEGER, max_fact_timestamp_ms INTEGER
+		) WITHOUT ROWID;
+		DELETE FROM usage_install_sessions`); err != nil {
+		return nil, err
+	}
+	var statement strings.Builder
+	statement.WriteString(`INSERT INTO usage_install_sessions(
+		session_id, source_sync_marker, source_transcript_rev,
+		usage_event_fingerprint, install_revision) VALUES `)
+	args := make([]any, 0, len(versions)*5)
+	for i, version := range versions {
+		if i > 0 {
+			statement.WriteByte(',')
+		}
+		statement.WriteString(`(?, ?, ?, ?, ?)`)
+		installRevision := revision + int64(i)
+		args = append(args, version.SessionID, version.SyncMarker,
+			version.TranscriptRevision, version.UsageEventFingerprint,
+			installRevision)
+		results[version.SessionID] = usageFillResult{
+			InstallRevision: installRevision, source: version,
+		}
+	}
+	if _, err := cacheConn.ExecContext(ctx, statement.String(), args...); err != nil {
+		return nil, err
+	}
+	if _, err := cacheConn.ExecContext(ctx, `
+		UPDATE usage_install_sessions AS install SET
+			fact_count = (SELECT COUNT(*) FROM usage_fill_spool.facts f
+			              WHERE f.session_id = install.session_id),
+			min_fact_timestamp_ms = (SELECT MIN(timestamp_ms)
+			              FROM usage_fill_spool.facts f
+			              WHERE f.session_id = install.session_id),
+			max_fact_timestamp_ms = (SELECT MAX(timestamp_ms)
+			              FROM usage_fill_spool.facts f
+			              WHERE f.session_id = install.session_id)`); err != nil {
+		return nil, err
+	}
+	if _, err := cacheConn.ExecContext(ctx, `
+		INSERT INTO usage_cached_sessions(
+			session_id, source_sync_marker, source_transcript_rev,
+			usage_event_fingerprint, install_revision, fact_count,
+			min_fact_timestamp_ms, max_fact_timestamp_ms
+		)
+		SELECT session_id, source_sync_marker, source_transcript_rev,
+		       usage_event_fingerprint, install_revision, fact_count,
+		       min_fact_timestamp_ms, max_fact_timestamp_ms
+		FROM usage_install_sessions WHERE 1
+		ON CONFLICT(session_id) DO UPDATE SET
+			source_sync_marker=excluded.source_sync_marker,
+			source_transcript_rev=excluded.source_transcript_rev,
+			usage_event_fingerprint=excluded.usage_event_fingerprint,
+			install_revision=excluded.install_revision,
+			fact_count=excluded.fact_count,
+			min_fact_timestamp_ms=excluded.min_fact_timestamp_ms,
+			max_fact_timestamp_ms=excluded.max_fact_timestamp_ms`); err != nil {
+		return nil, err
+	}
+	if _, err := cacheConn.ExecContext(ctx, `
+		DELETE FROM usage_facts WHERE cached_session_id IN (
+			SELECT cached.id FROM usage_cached_sessions cached
+			JOIN usage_install_sessions install
+			  ON install.session_id = cached.session_id
+		)`); err != nil {
+		return nil, err
+	}
+	if _, err := cacheConn.ExecContext(ctx, `INSERT INTO usage_facts(
+		cached_session_id, fact_index, source, message_ordinal, timestamp_ms,
+		timestamp_ns, raw_timestamp, uses_session_start, model, input_tokens, output_tokens,
+		reasoning_tokens, cache_creation_tokens, cache_read_tokens,
+		web_search_requests, reported_cost_microdollars, cost_source,
+		request_scoped, claude_message_id, claude_request_id, source_uuid,
+		usage_dedup_key, token_eligible, activity_eligible
+	)
+	SELECT cached.id, facts.fact_index, facts.source, facts.message_ordinal,
+	       facts.timestamp_ms, facts.timestamp_ns,
+	       raw_timestamp, uses_session_start, model, input_tokens, output_tokens,
+	       reasoning_tokens, cache_creation_tokens, cache_read_tokens,
+	       web_search_requests, reported_cost_microdollars, cost_source,
+	       request_scoped, claude_message_id, claude_request_id, source_uuid,
+	       usage_dedup_key, token_eligible, activity_eligible
+	FROM usage_fill_spool.facts facts
+	JOIN usage_install_sessions install
+	  ON install.session_id = facts.session_id
+	JOIN usage_cached_sessions cached
+	  ON cached.session_id = install.session_id
+	ORDER BY cached.id, facts.fact_index`,
+	); err != nil {
+		return nil, err
+	}
+	if _, err := cacheConn.ExecContext(ctx, `
+		UPDATE usage_cache_metadata SET value = ? WHERE key = ?`,
+		strconv.FormatInt(revision+int64(len(versions)), 10),
+		usageCacheMetadataNextInstallRevision,
+	); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (c *usageFillCoordinator) ensureCursor(ctx context.Context, target int64) error {
+	for {
+		current, err := c.cursorHighWater(ctx)
+		if err != nil || current >= target {
+			return err
+		}
+		c.mu.Lock()
+		if target > c.cursorTarget {
+			c.cursorTarget = target
+		}
+		call := c.cursorCall
+		if call == nil {
+			call = &usageCursorFillCall{done: make(chan struct{})}
+			c.cursorCall = call
+			go c.fillCursor()
+		}
+		c.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-call.done:
+			if call.err != nil {
+				return call.err
+			}
+		}
+	}
+}
+
+func (c *usageFillCoordinator) cursorHighWater(ctx context.Context) (int64, error) {
+	var text string
+	if err := c.cache.db.QueryRowContext(ctx,
+		`SELECT value FROM usage_cache_metadata WHERE key = ?`,
+		usageCacheMetadataCursorHighWaterMark,
+	).Scan(&text); err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(text, 10, 64)
+}
+
+func (c *usageFillCoordinator) fillCursor() {
+	var err error
+	for err == nil {
+		c.mu.Lock()
+		target := c.cursorTarget
+		c.mu.Unlock()
+		err = c.copyCursorThrough(c.ctx, target)
+		c.mu.Lock()
+		if err != nil || c.cursorTarget == target {
+			call := c.cursorCall
+			c.cursorCall = nil
+			c.cursorTarget = 0
+			call.err = err
+			close(call.done)
+			c.mu.Unlock()
+			return
+		}
+		c.mu.Unlock()
+	}
+}
+
+type usageCursorInstall struct {
+	id, charged, fee  int64
+	timestamp         string
+	model, kind       string
+	userID, userEmail string
+	dedup             string
+	headless          int
+	fact              usagefacts.Fact
+}
+
+func (c *usageFillCoordinator) copyCursorThrough(ctx context.Context, target int64) error {
+	from, err := c.cursorHighWater(ctx)
+	if err != nil || from >= target {
+		return err
+	}
+	for from < target {
+		installs, complete, err := c.readCursorBatch(ctx, from, target)
+		if err != nil {
+			return err
+		}
+		committedThrough := from
+		if len(installs) > 0 {
+			committedThrough = installs[len(installs)-1].id
+		}
+		if complete {
+			committedThrough = target
+		}
+		if err := c.installCursorBatch(ctx, installs, committedThrough); err != nil {
+			return err
+		}
+		from = committedThrough
+	}
+	return nil
+}
+
+func (c *usageFillCoordinator) readCursorBatch(
+	ctx context.Context, from, target int64,
+) ([]usageCursorInstall, bool, error) {
+	archiveTx, err := c.archive.getReader().BeginTx(
+		ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, false, fmt.Errorf("starting Cursor usage snapshot: %w", err)
+	}
+	defer func() { _ = archiveTx.Rollback() }()
+	var databaseID string
+	if err := archiveTx.QueryRowContext(ctx, `
+		SELECT value FROM archive_metadata WHERE key = ?`,
+		archiveMetadataDatabaseIDKey,
+	).Scan(&databaseID); err != nil {
+		return nil, false, fmt.Errorf("reading Cursor source database ID: %w", err)
+	}
+	if databaseID != c.cache.databaseID {
+		return nil, false,
+			fmt.Errorf("%w while copying Cursor usage", errUsageCacheSourceChanged)
+	}
+	rows, err := archiveTx.QueryContext(ctx, `
+		SELECT id, occurred_at, model, kind, input_tokens, output_tokens,
+		       cache_write_tokens, cache_read_tokens, charged_microdollars,
+		       cursor_token_fee_microdollars, user_id, user_email,
+		       is_headless, dedup_key
+		FROM cursor_usage_events WHERE id > ? AND id <= ?
+		ORDER BY id LIMIT ?`, from, target, usageCursorCopyBatchSize)
+	if err != nil {
+		return nil, false, fmt.Errorf("extracting Cursor usage facts: %w", err)
+	}
+	installs := make([]usageCursorInstall, 0, usageCursorCopyBatchSize)
+	for rows.Next() {
+		var install usageCursorInstall
+		var input, output, cacheWrite, cacheRead int64
+		if err := rows.Scan(
+			&install.id, &install.timestamp, &install.model, &install.kind,
+			&input, &output, &cacheWrite, &cacheRead, &install.charged,
+			&install.fee, &install.userID, &install.userEmail,
+			&install.headless, &install.dedup,
+		); err != nil {
+			_ = rows.Close()
+			return nil, false, err
+		}
+		install.fact, _ = usagefacts.FromEvent(usagefacts.EventInput{
+			Source: "cursor", Timestamp: install.timestamp, Model: install.model,
+			InputTokens: input, OutputTokens: output,
+			CacheCreationTokens: cacheWrite, CacheReadTokens: cacheRead,
+		})
+		installs = append(installs, install)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, false, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	if err := archiveTx.Commit(); err != nil {
+		return nil, false, fmt.Errorf("closing Cursor usage snapshot: %w", err)
+	}
+	return installs, len(installs) < usageCursorCopyBatchSize, nil
+}
+
+func (c *usageFillCoordinator) installCursorBatch(
+	ctx context.Context, installs []usageCursorInstall, committedThrough int64,
+) error {
+	tx, err := c.cache.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, install := range installs {
+		if _, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO cursor_usage_facts(
+			source_id, timestamp_ms, timestamp_ns, raw_timestamp, model, kind,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			charged_microdollars, cursor_token_fee_microdollars,
+			user_id, user_email, is_headless, dedup_key
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			install.id, install.fact.TimestampMillis, install.fact.TimestampNanos,
+			install.timestamp, install.model, install.kind,
+			install.fact.InputTokens, install.fact.OutputTokens,
+			install.fact.CacheCreationTokens, install.fact.CacheReadTokens,
+			install.charged, install.fee, install.userID, install.userEmail,
+			install.headless, install.dedup,
+		); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE usage_cache_metadata
+		SET value = CAST(MAX(CAST(value AS INTEGER), ?) AS TEXT)
+		WHERE key = ?`, committedThrough, usageCacheMetadataCursorHighWaterMark,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (m *usageCacheManager) NotifySessions(sessionIDs []string) {
+	m.mu.Lock()
+	coordinators := make([]*usageFillCoordinator, 0, len(m.generations))
+	for _, cache := range m.generations {
+		if cache.fill != nil {
+			coordinators = append(coordinators, cache.fill)
+		}
+	}
+	m.mu.Unlock()
+	for _, coordinator := range coordinators {
+		for _, id := range sessionIDs {
+			select {
+			case coordinator.notify <- usageFillNotification{sessionID: id}:
+			default:
+			}
+		}
+	}
+}
+
+func (m *usageCacheManager) NotifyCursorUsage() {
+	m.mu.Lock()
+	coordinators := make([]*usageFillCoordinator, 0, len(m.generations))
+	for _, cache := range m.generations {
+		if cache.fill != nil {
+			coordinators = append(coordinators, cache.fill)
+		}
+	}
+	m.mu.Unlock()
+	for _, coordinator := range coordinators {
+		select {
+		case coordinator.notify <- usageFillNotification{cursor: true}:
+		default:
+		}
+	}
+}
+
+func (db *DB) notifyUsageSessions(sessionIDs []string) {
+	if db.usageCache != nil && len(sessionIDs) > 0 {
+		db.usageCache.NotifySessions(sessionIDs)
+	}
+}
+
+func (db *DB) notifyCursorUsage() {
+	if db.usageCache != nil {
+		db.usageCache.NotifyCursorUsage()
+	}
+}
+
+func (c *usageFillCoordinator) runNotifications() {
+	defer close(c.done)
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case notification := <-c.notify:
+			if notification.cursor {
+				var target int64
+				if err := c.archive.getReader().QueryRowContext(c.ctx,
+					`SELECT COALESCE(MAX(id), 0) FROM cursor_usage_events`,
+				).Scan(&target); err == nil && target > 0 {
+					_, _ = c.Ensure(c.ctx, nil, target)
+				}
+				continue
+			}
+			versions, err := c.recheckSourceVersions(c.ctx,
+				[]usageSourceVersion{{SessionID: notification.sessionID}})
+			version, exists := versions[notification.sessionID]
+			if err == nil && exists {
+				_, _ = c.Ensure(c.ctx, []usageSourceVersion{version}, 0)
+			} else if err == nil {
+				_, _ = c.cache.db.ExecContext(c.ctx,
+					`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
+					notification.sessionID)
+			}
+		}
+	}
+}

--- a/internal/db/usage_cache_fill.go
+++ b/internal/db/usage_cache_fill.go
@@ -706,6 +706,7 @@ func (c *usageFillCoordinator) installSpoolBatch(
 
 	results := make(map[string]usageFillResult, len(versions))
 	var retry []usageSourceVersion
+	var deleted []string
 	stable := make([]usageSourceVersion, 0, len(versions))
 	currentVersions, err := c.recheckSourceVersions(ctx, versions)
 	if err != nil {
@@ -714,12 +715,7 @@ func (c *usageFillCoordinator) installSpoolBatch(
 	for _, observed := range versions {
 		current, exists := currentVersions[observed.SessionID]
 		if !exists {
-			if _, err := conn.ExecContext(ctx,
-				`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
-				observed.SessionID,
-			); err != nil {
-				return nil, versions, err
-			}
+			deleted = append(deleted, observed.SessionID)
 			results[observed.SessionID] = usageFillResult{Deleted: true}
 			continue
 		}
@@ -729,16 +725,67 @@ func (c *usageFillCoordinator) installSpoolBatch(
 		}
 		stable = append(stable, current)
 	}
+	affected := append([]string(nil), deleted...)
+	for _, version := range stable {
+		affected = append(affected, version.SessionID)
+	}
+	oldIdentities, err := usageFactIdentitiesForSessions(ctx, conn, affected)
+	if err != nil {
+		return nil, versions, err
+	}
+	for _, sessionID := range deleted {
+		for _, query := range []string{
+			`DELETE FROM usage_rollup_installs WHERE session_id = ?`,
+			`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
+		} {
+			if _, err := conn.ExecContext(ctx, query, sessionID); err != nil {
+				return nil, versions, err
+			}
+		}
+	}
 	stableResults, err := installSpoolSessions(ctx, conn, stable)
 	if err != nil {
 		return nil, versions, err
 	}
 	maps.Copy(results, stableResults)
+	if err := c.invalidateChangedIdentitySharers(
+		ctx, conn, oldIdentities, stable, affected,
+	); err != nil {
+		return nil, versions, err
+	}
 	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
 		return nil, versions, fmt.Errorf("committing usage cache fill: %w", err)
 	}
 	committed = true
 	return results, retry, nil
+}
+
+// invalidateChangedIdentitySharers compares the dedup identities a fill
+// replaced with the ones it installed and invalidates the timezone rollups of
+// every other session sharing a changed identity, so their groups reclassify
+// against the new membership.
+func (c *usageFillCoordinator) invalidateChangedIdentitySharers(
+	ctx context.Context, conn *sql.Conn, oldIdentities usageDedupIdentitySet,
+	stable []usageSourceVersion, affected []string,
+) error {
+	if len(affected) == 0 {
+		return nil
+	}
+	stableIDs := make([]string, 0, len(stable))
+	for _, version := range stable {
+		stableIDs = append(stableIDs, version.SessionID)
+	}
+	newIdentities, err := usageSpoolIdentitiesForSessions(ctx, conn, stableIDs)
+	if err != nil {
+		return err
+	}
+	changed := newUsageDedupIdentitySet()
+	changed.mergeDifferences(oldIdentities, newIdentities)
+	excluded := make(map[string]bool, len(affected))
+	for _, sessionID := range affected {
+		excluded[sessionID] = true
+	}
+	return invalidateUsageDedupSharers(ctx, conn, changed, excluded)
 }
 
 func (c *usageFillCoordinator) recheckSourceVersions(
@@ -1102,7 +1149,9 @@ func (c *usageFillCoordinator) installCursorBatch(
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
+	arrived := newUsageDedupIdentitySet()
 	for _, install := range installs {
+		arrived.add("", "", "", install.dedup)
 		if _, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO cursor_usage_facts(
 			source_id, timestamp_ms, raw_timestamp, model,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
@@ -1116,6 +1165,11 @@ func (c *usageFillCoordinator) installCursorBatch(
 		); err != nil {
 			return err
 		}
+	}
+	// A session usage key equal to a newly arrived Cursor key must fall back
+	// to the exception tier, so its finalized rollups are invalidated here.
+	if err := invalidateUsageDedupSharers(ctx, tx, arrived, nil); err != nil {
+		return err
 	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE usage_cache_metadata
@@ -1276,7 +1330,13 @@ func (c *usageFillCoordinator) deleteNotificationSessions(ids []string) error {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
+	removed, err := usageFactIdentitiesForSessions(c.ctx, tx, ids)
+	if err != nil {
+		return err
+	}
+	excluded := make(map[string]bool, len(ids))
 	for _, id := range ids {
+		excluded[id] = true
 		if _, err := tx.ExecContext(c.ctx,
 			`DELETE FROM usage_rollup_installs WHERE session_id = ?`, id,
 		); err != nil {
@@ -1287,6 +1347,11 @@ func (c *usageFillCoordinator) deleteNotificationSessions(ids []string) error {
 		); err != nil {
 			return err
 		}
+	}
+	// Rebuild the survivors' rollups so groups the deleted sessions kept
+	// irreducible can finalize again.
+	if err := invalidateUsageDedupSharers(c.ctx, tx, removed, excluded); err != nil {
+		return err
 	}
 	return tx.Commit()
 }

--- a/internal/db/usage_cache_fill.go
+++ b/internal/db/usage_cache_fill.go
@@ -1325,24 +1325,36 @@ func (c *usageFillCoordinator) processNotificationBatch(
 }
 
 func (c *usageFillCoordinator) deleteNotificationSessions(ids []string) error {
-	tx, err := c.cache.db.BeginTx(c.ctx, nil)
+	conn, err := c.cache.db.Conn(c.ctx)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = tx.Rollback() }()
-	removed, err := usageFactIdentitiesForSessions(c.ctx, tx, ids)
+	defer conn.Close()
+	// BEGIN IMMEDIATE: this transaction reads identities before its first
+	// delete, so a deferred begin could fail with SQLITE_BUSY_SNAPSHOT
+	// under a concurrent fill or install commit.
+	if _, err := conn.ExecContext(c.ctx, `BEGIN IMMEDIATE`); err != nil {
+		return fmt.Errorf("locking usage cache for session delete: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+	removed, err := usageFactIdentitiesForSessions(c.ctx, conn, ids)
 	if err != nil {
 		return err
 	}
 	excluded := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		excluded[id] = true
-		if _, err := tx.ExecContext(c.ctx,
+		if _, err := conn.ExecContext(c.ctx,
 			`DELETE FROM usage_rollup_installs WHERE session_id = ?`, id,
 		); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(c.ctx,
+		if _, err := conn.ExecContext(c.ctx,
 			`DELETE FROM usage_cached_sessions WHERE session_id = ?`, id,
 		); err != nil {
 			return err
@@ -1350,8 +1362,12 @@ func (c *usageFillCoordinator) deleteNotificationSessions(ids []string) error {
 	}
 	// Rebuild the survivors' rollups so groups the deleted sessions kept
 	// irreducible can finalize again.
-	if err := invalidateUsageDedupSharers(c.ctx, tx, removed, excluded); err != nil {
+	if err := invalidateUsageDedupSharers(c.ctx, conn, removed, excluded); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if _, err := conn.ExecContext(c.ctx, `COMMIT`); err != nil {
+		return fmt.Errorf("committing usage cache session delete: %w", err)
+	}
+	committed = true
+	return nil
 }

--- a/internal/db/usage_cache_fill.go
+++ b/internal/db/usage_cache_fill.go
@@ -123,7 +123,11 @@ func (c *usageFillCoordinator) Ensure(
 		c.mu.Unlock()
 	}
 	if len(owned) > 0 {
-		go c.fillSessions(owned)
+		if !c.cache.startDetachedWork(func() { c.fillSessions(owned) }) {
+			c.completeSessionCalls(owned, nil, fmt.Errorf(
+				"%w before starting detached fill", errUsageCacheSourceChanged,
+			))
+		}
 	}
 
 	for id, call := range waiting {
@@ -185,6 +189,12 @@ func (c *usageFillCoordinator) cachedSession(
 
 func (c *usageFillCoordinator) fillSessions(versions []usageSourceVersion) {
 	results, err := c.fillSessionsDetached(c.ctx, versions)
+	c.completeSessionCalls(versions, results, err)
+}
+
+func (c *usageFillCoordinator) completeSessionCalls(
+	versions []usageSourceVersion, results map[string]usageFillResult, err error,
+) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, version := range versions {
@@ -193,7 +203,9 @@ func (c *usageFillCoordinator) fillSessions(versions []usageSourceVersion) {
 		if call == nil {
 			continue
 		}
-		call.result = results[version.SessionID]
+		if results != nil {
+			call.result = results[version.SessionID]
+		}
 		call.err = err
 		delete(c.calls, key)
 		close(call.done)
@@ -934,7 +946,15 @@ func (c *usageFillCoordinator) ensureCursor(ctx context.Context, target int64) e
 		if call == nil {
 			call = &usageCursorFillCall{done: make(chan struct{})}
 			c.cursorCall = call
-			go c.fillCursor()
+			if !c.cache.startDetachedWork(c.fillCursor) {
+				c.cursorCall = nil
+				c.cursorTarget = 0
+				call.err = fmt.Errorf(
+					"%w before starting detached Cursor fill",
+					errUsageCacheSourceChanged,
+				)
+				close(call.done)
+			}
 		}
 		c.mu.Unlock()
 		select {

--- a/internal/db/usage_cache_fill_test.go
+++ b/internal/db/usage_cache_fill_test.go
@@ -209,7 +209,7 @@ func TestUsageFillCoordinatorDoesNotJoinOlderSourceVersion(t *testing.T) {
 	}()
 	select {
 	case <-newStarted:
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("newer source version joined an older in-flight fill")
 	}
 	close(releaseOld)
@@ -538,10 +538,53 @@ func TestUsageCacheNotificationIsNonblocking(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("usage cache notification blocked on fill work")
 	}
 	close(blocked)
+}
+
+func TestUsageCacheNotificationsCoalesceChangedSessions(t *testing.T) {
+	database := testDB(t)
+	for _, id := range []string{"notify-a", "notify-b"} {
+		insertSession(t, database, id, "project")
+		require.NoError(t, database.InsertMessages([]Message{{
+			SessionID: id, Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-10T09:00:00Z", Model: "model",
+			TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+		}}))
+	}
+	snapshot, err := database.captureUsageQuery(
+		t.Context(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	_, err = cache.fill.Ensure(t.Context(), snapshot.Versions, 0)
+	require.NoError(t, err)
+
+	batch := make(chan []usageSourceVersion, 1)
+	cache.fill.observer = usageFillObserver{
+		beforeExtract: func(versions []usageSourceVersion) { batch <- versions },
+	}
+	_, err = database.getWriter().Exec(`UPDATE sessions
+		SET transcript_revision = '2'
+		WHERE id IN ('notify-a', 'notify-b')`)
+	require.NoError(t, err)
+	database.usageCache.NotifySessions([]string{"notify-a"})
+	database.usageCache.NotifySessions([]string{"notify-a"})
+	database.usageCache.NotifySessions([]string{"notify-b"})
+
+	select {
+	case versions := <-batch:
+		require.Len(t, versions, 2)
+	case <-time.After(30 * time.Second):
+		t.Fatal("coalesced usage cache fill did not start")
+	}
+	select {
+	case versions := <-batch:
+		t.Fatalf("duplicate notification started another fill: %#v", versions)
+	case <-time.After(3 * usageFillNotificationDebounce):
+	}
 }
 
 func TestUsageCacheNotificationObservesOnlyCommittedWrites(t *testing.T) {
@@ -585,7 +628,7 @@ func TestUsageCacheNotificationObservesOnlyCommittedWrites(t *testing.T) {
 	select {
 	case got := <-observed:
 		assert.JSONEq(t, `{"input_tokens":9}`, got)
-	case <-time.After(2 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("committed message write did not notify the usage cache")
 	}
 

--- a/internal/db/usage_cache_fill_test.go
+++ b/internal/db/usage_cache_fill_test.go
@@ -1,0 +1,637 @@
+//go:build fts5
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/usagefacts"
+)
+
+func TestUsageCacheFillInstallsCompleteSessionFacts(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "fill-session", "project", func(s *Session) {
+		s.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{
+		{SessionID: "fill-session", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-07-01T09:00:00Z", Model: "model-old",
+			TokenUsage:      json.RawMessage(`{"input_tokens":2,"output_tokens":3}`),
+			ClaudeMessageID: "message-id", ClaudeRequestID: "request-id",
+			SourceUUID: "source-id"},
+		{SessionID: "fill-session", Ordinal: 1, Role: "assistant",
+			Timestamp: "2026-08-10T09:00:00Z", Model: "model-new"},
+	}))
+	require.NoError(t, database.ReplaceSessionUsageEvents("fill-session", []UsageEvent{{
+		Source: "session", Model: "event-model", InputTokens: 5,
+		OccurredAt: "2026-06-01T09:00:00Z", DedupKey: "event-1",
+	}}))
+
+	snapshot, err := database.captureUsageQuery(context.Background(), UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	}, usageQueryKindActivity)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	results, err := cache.fill.Ensure(
+		context.Background(), snapshot.Versions, snapshot.CursorHighWater,
+	)
+	require.NoError(t, err)
+	assert.False(t, results["fill-session"].Deleted)
+	assert.Positive(t, results["fill-session"].InstallRevision)
+
+	rows, err := cache.db.Query(`
+		SELECT source, message_ordinal, model, token_eligible, activity_eligible,
+		       claude_message_id, claude_request_id, source_uuid
+		FROM usage_facts ORDER BY fact_index`)
+	require.NoError(t, err)
+	defer rows.Close()
+	type row struct {
+		source, model                    string
+		ordinal                          *int
+		token, active                    int
+		messageID, requestID, sourceUUID string
+	}
+	var got []row
+	for rows.Next() {
+		var item row
+		require.NoError(t, rows.Scan(
+			&item.source, &item.ordinal, &item.model, &item.token, &item.active,
+			&item.messageID, &item.requestID, &item.sourceUUID,
+		))
+		got = append(got, item)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"model-old", "model-new", "event-model"},
+		[]string{got[0].model, got[1].model, got[2].model})
+	assert.Equal(t, []int{1, 0, 1}, []int{got[0].token, got[1].token, got[2].token})
+	assert.Equal(t, "message-id", got[0].messageID)
+	assert.Equal(t, "request-id", got[0].requestID)
+	assert.Equal(t, "source-id", got[0].sourceUUID)
+}
+
+func TestUsageCacheFillExtractionUsesNarrowIndexes(t *testing.T) {
+	database := usageCandidateFixture(t)
+	conn, err := database.getReader().Conn(context.Background())
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.ExecContext(context.Background(), `
+		CREATE TEMP TABLE usage_fill_sessions(
+			session_id TEXT PRIMARY KEY
+		) WITHOUT ROWID;
+		INSERT INTO usage_fill_sessions VALUES ('inside-message')`)
+	require.NoError(t, err)
+
+	plan := func(query string) string {
+		t.Helper()
+		rows, queryErr := conn.QueryContext(
+			context.Background(), `EXPLAIN QUERY PLAN `+query,
+		)
+		require.NoError(t, queryErr)
+		defer rows.Close()
+		var details []string
+		for rows.Next() {
+			var id, parent, unused int
+			var detail string
+			require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+			details = append(details, detail)
+		}
+		require.NoError(t, rows.Err())
+		return strings.Join(details, "\n")
+	}
+	assert.Contains(t, plan(usageFillMessageFactsSQL),
+		"SEARCH m USING COVERING INDEX idx_messages_usage_session_covering")
+	assert.Contains(t, plan(usageFillActivityFactsSQL),
+		"idx_messages_session_role")
+	assert.Contains(t, plan(usageFillEventFactsSQL),
+		"idx_usage_events_session")
+}
+
+func TestUsageFillCoordinatorSharesDetachedSessionWork(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var extractions atomic.Int32
+	cache.fill.observer = usageFillObserver{
+		beforeExtract: func([]usageSourceVersion) {
+			if extractions.Add(1) == 1 {
+				close(started)
+				<-release
+			}
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	firstDone := make(chan error, 1)
+	go func() {
+		_, fillErr := cache.fill.Ensure(ctx, snapshot.Versions[:1], 0)
+		firstDone <- fillErr
+	}()
+	<-started
+	secondDone := make(chan error, 1)
+	go func() {
+		_, fillErr := cache.fill.Ensure(
+			context.Background(), snapshot.Versions[:1], 0,
+		)
+		secondDone <- fillErr
+	}()
+	cancel()
+	close(release)
+	assert.ErrorIs(t, <-firstDone, context.Canceled)
+	require.NoError(t, <-secondDone)
+	assert.Equal(t, int32(1), extractions.Load())
+}
+
+func TestUsageFillCoordinatorDoesNotJoinOlderSourceVersion(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	oldVersion := snapshot.Versions[0]
+	oldStarted := make(chan struct{})
+	newStarted := make(chan struct{})
+	releaseOld := make(chan struct{})
+	cache.fill.observer.beforeExtract = func(versions []usageSourceVersion) {
+		if versions[0].TranscriptRevision == oldVersion.TranscriptRevision {
+			select {
+			case <-oldStarted:
+			default:
+				close(oldStarted)
+			}
+			<-releaseOld
+			return
+		}
+		select {
+		case <-newStarted:
+		default:
+			close(newStarted)
+		}
+	}
+	oldDone := make(chan error, 1)
+	go func() {
+		_, fillErr := cache.fill.Ensure(
+			context.Background(), []usageSourceVersion{oldVersion}, 0)
+		oldDone <- fillErr
+	}()
+	<-oldStarted
+	_, err = database.getWriter().Exec(`
+		UPDATE sessions SET transcript_revision = 'newer' WHERE id = ?`,
+		oldVersion.SessionID)
+	require.NoError(t, err)
+	current, err := cache.fill.recheckSourceVersions(
+		context.Background(), []usageSourceVersion{{SessionID: oldVersion.SessionID}})
+	require.NoError(t, err)
+	newVersion := current[oldVersion.SessionID]
+	newDone := make(chan error, 1)
+	go func() {
+		_, fillErr := cache.fill.Ensure(
+			context.Background(), []usageSourceVersion{newVersion}, 0)
+		newDone <- fillErr
+	}()
+	select {
+	case <-newStarted:
+	case <-time.After(time.Second):
+		t.Fatal("newer source version joined an older in-flight fill")
+	}
+	close(releaseOld)
+	require.NoError(t, <-newDone)
+	require.ErrorIs(t, <-oldDone, errUsageCacheSourceChanged)
+}
+
+func TestUsageFillRecheckRestoresReaderBusyTimeout(t *testing.T) {
+	database := usageCandidateFixture(t)
+	database.reader.Load().SetMaxOpenConns(1)
+	conn, err := database.getReader().Conn(context.Background())
+	require.NoError(t, err)
+	_, err = conn.ExecContext(context.Background(), `PRAGMA busy_timeout=4321`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	_, err = cache.fill.recheckSourceVersions(context.Background(), snapshot.Versions[:1])
+	require.NoError(t, err)
+	var timeout int
+	require.NoError(t, database.getReader().QueryRow(
+		`PRAGMA busy_timeout`).Scan(&timeout))
+	assert.Equal(t, 4321, timeout)
+}
+
+func TestUsageCacheFillReportsDeletedSession(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	version := snapshot.Versions[0]
+
+	var deleteErr error
+	cache.fill.observer = usageFillObserver{
+		afterExtract: func([]usageSourceVersion) {
+			_, deleteErr = database.getWriter().Exec(
+				`DELETE FROM sessions WHERE id = ?`, version.SessionID,
+			)
+		},
+	}
+	results, err := cache.fill.Ensure(context.Background(), []usageSourceVersion{version}, 0)
+	require.NoError(t, err)
+	require.NoError(t, deleteErr)
+	assert.True(t, results[version.SessionID].Deleted)
+}
+
+func TestUsageCacheFillRetriesChangedFingerprint(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	version := snapshot.Versions[0]
+	var mutations atomic.Int32
+	var mutationErr atomic.Value
+	cache.fill.observer = usageFillObserver{
+		afterExtract: func([]usageSourceVersion) {
+			if mutations.Add(1) != 1 {
+				return
+			}
+			_, updateErr := database.getWriter().Exec(`
+				UPDATE sessions SET transcript_revision = 'later'
+				WHERE id = ?`, version.SessionID)
+			if updateErr != nil {
+				mutationErr.Store(updateErr)
+			}
+		},
+	}
+	results, err := cache.fill.Ensure(
+		context.Background(), []usageSourceVersion{version}, 0,
+	)
+	require.ErrorIs(t, err, errUsageCacheSourceChanged)
+	if stored := mutationErr.Load(); stored != nil {
+		require.NoError(t, stored.(error))
+	}
+	assert.Equal(t, int32(2), mutations.Load())
+	assert.Nil(t, results)
+}
+
+func TestDailyUsageRecapturesChangedFillSource(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "moving", "keep", func(session *Session) {
+		session.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "moving", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T09:00:00Z", Model: "model",
+		TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+	}}))
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	var mutations atomic.Int32
+	var mutationErr atomic.Value
+	cache.fill.observer.afterExtract = func([]usageSourceVersion) {
+		if mutations.Add(1) != 1 {
+			return
+		}
+		_, updateErr := database.getWriter().Exec(`
+			UPDATE messages SET token_usage = '{"input_tokens":9}'
+			WHERE session_id = 'moving';
+			UPDATE sessions SET project = 'drop', transcript_revision = 'later'
+			WHERE id = 'moving'`)
+		if updateErr != nil {
+			mutationErr.Store(updateErr)
+		}
+	}
+	daily, err := database.GetDailyUsage(context.Background(), UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+		Project: "keep", SkipSessionCounts: true,
+	})
+	require.NoError(t, err)
+	if stored := mutationErr.Load(); stored != nil {
+		require.NoError(t, stored.(error))
+	}
+	assert.Zero(t, daily.Totals.InputTokens)
+}
+
+func TestUsageCacheFillBoundsMovingFingerprintRetries(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	version := snapshot.Versions[0]
+	var mutations atomic.Int32
+	cache.fill.observer = usageFillObserver{
+		afterExtract: func([]usageSourceVersion) {
+			n := mutations.Add(1)
+			_, _ = database.getWriter().Exec(`
+				UPDATE sessions SET transcript_revision = ? WHERE id = ?`,
+				fmt.Sprintf("moving-%d", n), version.SessionID)
+		},
+	}
+	_, err = cache.fill.Ensure(context.Background(), []usageSourceVersion{version}, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"usage cache fill could not verify archive state after 3 attempts")
+	assert.Equal(t, int32(3), mutations.Load())
+}
+
+func TestUsageCacheFillTwoHandlesRaceIdempotently(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	first, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	secondManager := newUsageCacheManager(database.path)
+	secondManager.attachArchive(database)
+	t.Cleanup(func() { require.NoError(t, secondManager.Close()) })
+	second, err := secondManager.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+
+	errorsCh := make(chan error, 2)
+	for _, cache := range []*usageCache{first, second} {
+		go func(cache *usageCache) {
+			_, fillErr := cache.fill.Ensure(context.Background(), snapshot.Versions, 0)
+			errorsCh <- fillErr
+		}(cache)
+	}
+	require.NoError(t, <-errorsCh)
+	require.NoError(t, <-errorsCh)
+	assert.Equal(t, len(snapshot.Versions),
+		usageCacheCount(t, first, "usage_cached_sessions"))
+}
+
+func TestUsageCacheFillTokenCoverageRepairIsByteEquivalent(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "repair", "project", func(s *Session) {
+		s.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "repair", Ordinal: 0, Role: "assistant", Model: "model",
+		Timestamp:  "2026-08-10T09:00:00Z",
+		TokenUsage: json.RawMessage(`{"input_tokens":2,"output_tokens":3}`),
+	}}))
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	_, err = cache.fill.Ensure(context.Background(), snapshot.Versions, 0)
+	require.NoError(t, err)
+	before := dumpCachedFacts(t, cache, "repair")
+
+	_, err = database.getWriter().Exec(`
+		UPDATE messages SET has_context_tokens = 0, has_output_tokens = 0
+		WHERE session_id = 'repair';
+		DELETE FROM stats WHERE key = ?`, tokenCoverageRepairStatsKey)
+	require.NoError(t, err)
+	database.mu.Lock()
+	require.NoError(t, database.backfillTokenCoverageFlagsLocked(database.getWriter()))
+	require.NoError(t, database.markTokenCoverageRepairDoneLocked(database.getWriter()))
+	database.mu.Unlock()
+	afterRepair, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	_, err = cache.fill.Ensure(context.Background(), afterRepair.Versions, 0)
+	require.NoError(t, err)
+	assert.Equal(t, before, dumpCachedFacts(t, cache, "repair"))
+}
+
+func TestUsageCursorFactsResumeAtRequestedHighWater(t *testing.T) {
+	database := usageCandidateFixture(t)
+	require.NoError(t, database.InsertCursorUsageEvents([]CursorUsageEvent{{
+		OccurredAt: "2026-08-11T00:00:00Z", Model: "cursor-2",
+		InputTokens: 4, DedupKey: "cursor-2",
+	}}))
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+
+	_, err = cache.fill.Ensure(context.Background(), nil, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, usageCacheCount(t, cache, "cursor_usage_facts"))
+	_, err = cache.fill.Ensure(context.Background(), nil, snapshot.CursorHighWater)
+	require.NoError(t, err)
+	assert.Equal(t, 2, usageCacheCount(t, cache, "cursor_usage_facts"))
+}
+
+func TestUsageCursorFactsRetainBoundedBatchProgress(t *testing.T) {
+	database := testDB(t)
+	const batchSize = usageCursorCopyBatchSize
+	events := make([]CursorUsageEvent, 0, batchSize+1)
+	for index := range batchSize + 1 {
+		events = append(events, CursorUsageEvent{
+			OccurredAt: "2026-08-11T00:00:00Z", Model: "cursor-model",
+			InputTokens: 1, DedupKey: fmt.Sprintf("cursor-batch-%04d", index),
+		})
+	}
+	require.NoError(t, database.InsertCursorUsageEvents(events))
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	_, err = cache.db.Exec(fmt.Sprintf(`
+		CREATE TRIGGER reject_late_cursor_fact
+		BEFORE INSERT ON cursor_usage_facts
+		WHEN NEW.source_id > %d
+		BEGIN
+			SELECT RAISE(ABORT, 'stop after one bounded batch');
+		END`, batchSize))
+	require.NoError(t, err)
+
+	_, err = cache.fill.Ensure(context.Background(), nil, snapshot.CursorHighWater)
+	require.Error(t, err)
+	assert.Equal(t, batchSize, usageCacheCount(t, cache, "cursor_usage_facts"))
+	assert.Equal(t, fmt.Sprint(batchSize), readUsageCacheMetadata(
+		t, cache.db)[usageCacheMetadataCursorHighWaterMark])
+
+	_, err = cache.db.Exec(`DROP TRIGGER reject_late_cursor_fact`)
+	require.NoError(t, err)
+	_, err = cache.fill.Ensure(context.Background(), nil, snapshot.CursorHighWater)
+	require.NoError(t, err)
+	assert.Equal(t, batchSize+1, usageCacheCount(t, cache, "cursor_usage_facts"))
+}
+
+func TestUsageCursorFactsRejectChangedArchiveGeneration(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	_, err = database.getWriter().Exec(`
+		UPDATE archive_metadata SET value = 'replacement-database'
+		WHERE key = ?`, archiveMetadataDatabaseIDKey)
+	require.NoError(t, err)
+	_, err = cache.fill.Ensure(context.Background(), nil, snapshot.CursorHighWater)
+	require.ErrorIs(t, err, errUsageCacheSourceChanged)
+	assert.Zero(t, usageCacheCount(t, cache, "cursor_usage_facts"))
+}
+
+func TestUsageCursorFactsNormalizeRequestCounters(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.InsertCursorUsageEvents([]CursorUsageEvent{{
+		OccurredAt: "2026-08-11T00:00:00Z", Model: "cursor-model",
+		InputTokens: -1, OutputTokens: usagefacts.MaxPlausibleTokens + 1,
+		DedupKey: "cursor-normalized",
+	}}))
+	daily, err := database.GetDailyUsage(context.Background(), UsageFilter{})
+	require.NoError(t, err)
+	assert.Zero(t, daily.Totals.InputTokens)
+	assert.Equal(t, usagefacts.MaxPlausibleTokens, daily.Totals.OutputTokens)
+}
+
+func TestUsageCacheNotificationIsNonblocking(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	blocked := make(chan struct{})
+	cache.fill.observer = usageFillObserver{
+		beforeExtract: func([]usageSourceVersion) { <-blocked },
+	}
+
+	done := make(chan struct{})
+	go func() {
+		database.usageCache.NotifySessions([]string{snapshot.Versions[0].SessionID})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("usage cache notification blocked on fill work")
+	}
+	close(blocked)
+}
+
+func TestUsageCacheNotificationObservesOnlyCommittedWrites(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "notify", "project", func(s *Session) {
+		s.StartedAt = &started
+	})
+	initial := Message{
+		SessionID: "notify", Ordinal: 0, Role: "assistant", Model: "model",
+		Timestamp:  "2026-08-10T09:00:00Z",
+		TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+	}
+	require.NoError(t, database.InsertMessages([]Message{initial}))
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken,
+	)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	_, err = cache.fill.Ensure(context.Background(), snapshot.Versions, 0)
+	require.NoError(t, err)
+
+	observed := make(chan string, 1)
+	cache.fill.observer = usageFillObserver{
+		beforeExtract: func([]usageSourceVersion) {
+			var tokenUsage string
+			queryErr := database.getReader().QueryRow(`
+				SELECT token_usage FROM messages
+				WHERE session_id = 'notify' AND ordinal = 0`).Scan(&tokenUsage)
+			if queryErr != nil {
+				observed <- queryErr.Error()
+				return
+			}
+			observed <- tokenUsage
+		},
+	}
+	updated := initial
+	updated.TokenUsage = json.RawMessage(`{"input_tokens":9}`)
+	require.NoError(t, database.ReplaceSessionMessages("notify", []Message{updated}))
+	select {
+	case got := <-observed:
+		assert.JSONEq(t, `{"input_tokens":9}`, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("committed message write did not notify the usage cache")
+	}
+
+	duplicate := updated
+	duplicate.TokenUsage = json.RawMessage(`{"input_tokens":10}`)
+	require.Error(t, database.InsertMessages([]Message{duplicate}))
+	select {
+	case value := <-observed:
+		t.Fatalf("rolled-back message write emitted usage notification: %s", value)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func usageCacheCount(t *testing.T, cache *usageCache, table string) int {
+	t.Helper()
+	var count int
+	require.NoError(t, cache.db.QueryRow(`SELECT count(*) FROM `+table).Scan(&count))
+	return count
+}
+
+func dumpCachedFacts(t *testing.T, cache *usageCache, sessionID string) [][]any {
+	t.Helper()
+	rows, err := cache.db.Query(`
+		SELECT f.fact_index, f.source, f.message_ordinal, f.timestamp_ms,
+		       f.raw_timestamp, f.uses_session_start, f.model,
+		       f.input_tokens, f.output_tokens, f.reasoning_tokens,
+		       f.cache_creation_tokens, f.cache_read_tokens,
+		       f.web_search_requests, f.reported_cost_microdollars,
+		       f.cost_source, f.request_scoped, f.claude_message_id,
+		       f.claude_request_id, f.source_uuid, f.usage_dedup_key,
+		       f.token_eligible, f.activity_eligible
+		FROM usage_facts f
+		JOIN usage_cached_sessions s ON s.id = f.cached_session_id
+		WHERE s.session_id = ? ORDER BY f.fact_index`, sessionID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var result [][]any
+	for rows.Next() {
+		values := make([]any, 22)
+		pointers := make([]any, len(values))
+		for index := range values {
+			pointers[index] = &values[index]
+		}
+		require.NoError(t, rows.Scan(pointers...))
+		result = append(result, values)
+	}
+	require.NoError(t, rows.Err())
+	return result
+}

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -301,6 +301,9 @@ func (m *usageCacheManager) Generation(
 			return nil, fmt.Errorf("opening temporary usage cache: %w", err)
 		}
 	}
+	if cache == nil {
+		return nil, fmt.Errorf("opening usage cache returned no database")
+	}
 	m.generations[databaseID] = cache
 	if m.archive != nil {
 		cache.fill = newUsageFillCoordinator(m.ctx, m.archive, cache)
@@ -327,7 +330,7 @@ func (m *usageCacheManager) openPersistentGeneration(
 		if published {
 			return cache, nil
 		}
-		probe = probeUsageCache(ctx, path)
+		probe = probeUsageCacheWithBusyTimeout(ctx, path, 5000)
 		if probe.Err != nil {
 			return nil, probe.Err
 		}
@@ -497,6 +500,12 @@ func openUsageCacheDatabase(path string) (*sql.DB, error) {
 }
 
 func probeUsageCache(ctx context.Context, path string) usageCacheProbe {
+	return probeUsageCacheWithBusyTimeout(ctx, path, 0)
+}
+
+func probeUsageCacheWithBusyTimeout(
+	ctx context.Context, path string, busyTimeoutMillis int,
+) usageCacheProbe {
 	probe := usageCacheProbe{}
 	if ctx == nil {
 		ctx = context.Background()
@@ -509,7 +518,8 @@ func probeUsageCache(ctx context.Context, path string) usageCacheProbe {
 		return probe
 	}
 	probe.Exists = true
-	dsn := strings.Replace(makeDSN(path, true), "_busy_timeout=5000", "_busy_timeout=0", 1)
+	dsn := strings.Replace(makeDSN(path, true), "_busy_timeout=5000",
+		"_busy_timeout="+strconv.Itoa(busyTimeoutMillis), 1)
 	database, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		probe.Err = fmt.Errorf("probing usage cache %s: %w", path, err)

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -1,0 +1,705 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	usageCacheFormatVersion = 7
+	usageCacheApplicationID = 0x41565543
+	usageCacheKind          = "agentsview-usage-facts"
+
+	usageCacheMetadataKind                = "cache_kind"
+	usageCacheMetadataFormatVersion       = "format_version"
+	usageCacheMetadataExtractorVersion    = "extractor_version"
+	usageCacheMetadataSourceDatabaseID    = "source_database_id"
+	usageCacheMetadataNextInstallRevision = "next_install_revision"
+	usageCacheMetadataNextRollupRevision  = "next_rollup_install_revision"
+	usageCacheMetadataDeletionRevision    = "deletion_revision"
+	usageCacheMetadataCursorHighWaterMark = "cursor_high_water_mark"
+	usageCacheMetadataBackfillProgress    = "backfill_progress_session_id"
+	usageCacheMetadataBackfillCompletedAt = "backfill_completed_at"
+)
+
+const usageCacheSchemaSQL = `
+CREATE TABLE usage_cache_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE TABLE usage_cached_sessions (
+    id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL UNIQUE,
+    source_sync_marker TEXT NOT NULL,
+    source_transcript_rev TEXT NOT NULL,
+    usage_event_fingerprint TEXT NOT NULL,
+    install_revision INTEGER NOT NULL,
+    fact_count INTEGER NOT NULL,
+    min_fact_timestamp_ms INTEGER,
+    max_fact_timestamp_ms INTEGER
+);
+CREATE TABLE usage_facts (
+    cached_session_id INTEGER NOT NULL REFERENCES usage_cached_sessions(id)
+        ON DELETE CASCADE,
+    fact_index INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    message_ordinal INTEGER,
+    timestamp_ms INTEGER,
+    timestamp_ns INTEGER,
+    raw_timestamp TEXT NOT NULL DEFAULT '',
+    uses_session_start INTEGER NOT NULL CHECK (uses_session_start IN (0, 1)),
+    model TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    reasoning_tokens INTEGER NOT NULL,
+    cache_creation_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL,
+    web_search_requests INTEGER NOT NULL,
+    reported_cost_microdollars INTEGER,
+    cost_source TEXT NOT NULL DEFAULT '',
+    request_scoped INTEGER NOT NULL CHECK (request_scoped IN (0, 1)),
+    claude_message_id TEXT NOT NULL DEFAULT '',
+    claude_request_id TEXT NOT NULL DEFAULT '',
+    source_uuid TEXT NOT NULL DEFAULT '',
+    usage_dedup_key TEXT NOT NULL DEFAULT '',
+    token_eligible INTEGER NOT NULL CHECK (token_eligible IN (0, 1)),
+    activity_eligible INTEGER NOT NULL CHECK (activity_eligible IN (0, 1)),
+    PRIMARY KEY (cached_session_id, fact_index)
+) WITHOUT ROWID;
+CREATE INDEX usage_facts_timestamp
+ON usage_facts(timestamp_ms, cached_session_id, fact_index)
+WHERE timestamp_ms IS NOT NULL;
+CREATE INDEX usage_facts_snapshot
+ON usage_facts(claude_message_id, claude_request_id, timestamp_ms,
+               cached_session_id, fact_index)
+WHERE token_eligible = 1
+  AND claude_message_id != '' AND claude_request_id != '';
+CREATE INDEX usage_facts_session_start
+ON usage_facts(cached_session_id, fact_index) WHERE uses_session_start = 1;
+CREATE INDEX usage_facts_raw_timestamp
+ON usage_facts(raw_timestamp, cached_session_id, fact_index)
+WHERE timestamp_ms IS NULL AND uses_session_start = 0 AND raw_timestamp != '';
+CREATE TABLE cursor_usage_facts (
+    source_id INTEGER PRIMARY KEY,
+    timestamp_ms INTEGER,
+    timestamp_ns INTEGER,
+    raw_timestamp TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT '',
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    cache_creation_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL,
+    charged_microdollars INTEGER NOT NULL,
+    cursor_token_fee_microdollars INTEGER NOT NULL,
+    user_id TEXT NOT NULL DEFAULT '',
+    user_email TEXT NOT NULL DEFAULT '',
+    is_headless INTEGER NOT NULL CHECK (is_headless IN (0, 1)),
+    dedup_key TEXT NOT NULL
+);
+CREATE TABLE usage_rollup_timezones (
+    id INTEGER PRIMARY KEY,
+    timezone_key TEXT NOT NULL UNIQUE,
+    timezone_name TEXT NOT NULL,
+    interval_fingerprint TEXT NOT NULL,
+    last_requested_at TEXT NOT NULL,
+    build_completed_at TEXT
+);
+CREATE TABLE usage_rollup_days (
+    timezone_id INTEGER NOT NULL REFERENCES usage_rollup_timezones(id)
+        ON DELETE CASCADE,
+    local_date TEXT NOT NULL,
+    from_ms INTEGER NOT NULL,
+    to_ms INTEGER NOT NULL,
+    PRIMARY KEY (timezone_id, local_date)
+) WITHOUT ROWID;
+CREATE TABLE usage_rollup_installs (
+    id INTEGER PRIMARY KEY,
+    timezone_id INTEGER NOT NULL REFERENCES usage_rollup_timezones(id)
+        ON DELETE CASCADE,
+    session_id TEXT NOT NULL,
+    source_sync_marker TEXT NOT NULL,
+    source_transcript_rev TEXT NOT NULL,
+    usage_event_fingerprint TEXT NOT NULL,
+    fact_install_revision INTEGER NOT NULL,
+    baked_agent TEXT NOT NULL,
+    baked_started_at TEXT NOT NULL,
+	pricing_hash TEXT NOT NULL,
+    install_revision INTEGER NOT NULL,
+    cached_at TEXT NOT NULL,
+    UNIQUE (timezone_id, session_id)
+);
+CREATE TABLE usage_daily_rollups (
+    rollup_install_id INTEGER NOT NULL REFERENCES usage_rollup_installs(id)
+        ON DELETE CASCADE,
+    local_date TEXT NOT NULL,
+    reported_model TEXT NOT NULL,
+    priced_model TEXT NOT NULL,
+    matched_pattern TEXT NOT NULL,
+    rate_ok INTEGER NOT NULL CHECK (rate_ok IN (0, 1)),
+    rate_hash TEXT NOT NULL,
+    band_threshold INTEGER NOT NULL DEFAULT -1,
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    reasoning_tokens INTEGER NOT NULL,
+    cache_creation_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL,
+    web_search_requests INTEGER NOT NULL,
+    estimated_cost_microdollars INTEGER NOT NULL,
+    savings_microdollars INTEGER NOT NULL,
+    authoritative_cost_microdollars INTEGER,
+    computed_request_count INTEGER NOT NULL,
+    computed_aggregate_count INTEGER NOT NULL,
+    reported_count INTEGER NOT NULL,
+    base_request_count INTEGER NOT NULL,
+    discarded_snapshot_output_tokens INTEGER NOT NULL,
+    PRIMARY KEY (
+        rollup_install_id, local_date, reported_model,
+        rate_hash, band_threshold
+    )
+) WITHOUT ROWID;
+CREATE INDEX usage_daily_rollups_window
+    ON usage_daily_rollups (local_date, rollup_install_id);
+CREATE TABLE usage_activity_rollups (
+    rollup_install_id INTEGER NOT NULL REFERENCES usage_rollup_installs(id)
+        ON DELETE CASCADE,
+    local_date TEXT NOT NULL,
+	model TEXT NOT NULL,
+    user_message_count INTEGER NOT NULL,
+    PRIMARY KEY (rollup_install_id, local_date, model)
+) WITHOUT ROWID;
+CREATE TABLE usage_rollup_exceptions (
+    rollup_install_id INTEGER NOT NULL REFERENCES usage_rollup_installs(id)
+        ON DELETE CASCADE,
+    group_kind TEXT NOT NULL CHECK (group_kind IN ('snapshot', 'general')),
+    group_key TEXT NOT NULL,
+    cached_session_id INTEGER NOT NULL,
+    fact_index INTEGER NOT NULL,
+    source_session_id TEXT NOT NULL,
+    local_date TEXT NOT NULL,
+    source TEXT NOT NULL,
+    message_ordinal INTEGER,
+    timestamp_ms INTEGER,
+    timestamp_ns INTEGER,
+    raw_timestamp TEXT NOT NULL,
+    uses_session_start INTEGER NOT NULL CHECK (uses_session_start IN (0, 1)),
+    model TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    reasoning_tokens INTEGER NOT NULL,
+    cache_creation_tokens INTEGER NOT NULL,
+    cache_read_tokens INTEGER NOT NULL,
+    web_search_requests INTEGER NOT NULL,
+    reported_cost_microdollars INTEGER,
+    cost_source TEXT NOT NULL,
+    request_scoped INTEGER NOT NULL CHECK (request_scoped IN (0, 1)),
+    claude_message_id TEXT NOT NULL,
+    claude_request_id TEXT NOT NULL,
+    source_uuid TEXT NOT NULL,
+    usage_dedup_key TEXT NOT NULL,
+    PRIMARY KEY (
+        rollup_install_id, group_kind, group_key, cached_session_id, fact_index
+    )
+) WITHOUT ROWID;
+CREATE INDEX usage_rollup_exceptions_window
+    ON usage_rollup_exceptions (
+        local_date, rollup_install_id, group_kind, group_key
+    );`
+
+type usageCache struct {
+	db         *sql.DB
+	path       string
+	temporary  bool
+	databaseID string
+	fill       *usageFillCoordinator
+	rollup     *usageRollupCoordinator
+}
+
+type usageCacheProbe struct {
+	Exists           bool
+	Recognized       bool
+	Compatible       bool
+	FormatVersion    int
+	SourceDatabaseID string
+	Err              error
+}
+
+type usageCacheManager struct {
+	archivePath string
+	archive     *DB
+	ctx         context.Context
+	cancel      context.CancelFunc
+
+	mu          sync.Mutex
+	generations map[string]*usageCache
+	closed      bool
+}
+
+func newUsageCacheManager(archivePath string) *usageCacheManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &usageCacheManager{
+		archivePath: archivePath,
+		generations: make(map[string]*usageCache),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+}
+
+func (m *usageCacheManager) attachArchive(archive *DB) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.archive = archive
+}
+
+func usageCacheGenerationPath(
+	archivePath string, formatVersion int, databaseID string,
+) string {
+	digest := sha256.Sum256([]byte(databaseID))
+	name := fmt.Sprintf(
+		"usage-cache-v%d-%x.db", formatVersion, digest[:16],
+	)
+	return filepath.Join(filepath.Dir(archivePath), name)
+}
+
+func (m *usageCacheManager) Generation(
+	ctx context.Context, databaseID string,
+) (*usageCache, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	databaseID = strings.TrimSpace(databaseID)
+	if databaseID == "" {
+		return nil, fmt.Errorf("usage cache source database id is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil, fmt.Errorf("usage cache manager is closed")
+	}
+	if cache := m.generations[databaseID]; cache != nil {
+		return cache, nil
+	}
+
+	cache, err := m.openPersistentGeneration(ctx, databaseID)
+	if err != nil {
+		log.Printf(
+			"warning: usage cache is non-persistent because %s is unavailable: %v",
+			filepath.Dir(m.archivePath), err,
+		)
+		cache, err = openTemporaryUsageCache(ctx, databaseID)
+		if err != nil {
+			return nil, fmt.Errorf("opening temporary usage cache: %w", err)
+		}
+	}
+	m.generations[databaseID] = cache
+	if m.archive != nil {
+		cache.fill = newUsageFillCoordinator(m.ctx, m.archive, cache)
+		cache.rollup = newUsageRollupCoordinator(m.ctx, m.archive, cache)
+	}
+	return cache, nil
+}
+
+func (m *usageCacheManager) openPersistentGeneration(
+	ctx context.Context, databaseID string,
+) (*usageCache, error) {
+	path := usageCacheGenerationPath(
+		m.archivePath, usageCacheFormatVersion, databaseID,
+	)
+	probe := probeUsageCache(ctx, path)
+	if probe.Err != nil {
+		return nil, probe.Err
+	}
+	if !probe.Exists {
+		cache, published, err := publishUsageCache(ctx, path, databaseID)
+		if err != nil {
+			return nil, err
+		}
+		if published {
+			return cache, nil
+		}
+		probe = probeUsageCache(ctx, path)
+		if probe.Err != nil {
+			return nil, probe.Err
+		}
+	}
+	if !probe.Recognized {
+		return nil, fmt.Errorf("usage cache path is foreign or unverifiable: %s", path)
+	}
+	if probe.SourceDatabaseID != databaseID {
+		return nil, fmt.Errorf("usage cache source database id mismatch at %s", path)
+	}
+	if probe.Compatible {
+		return openUsageCache(ctx, path, databaseID, false)
+	}
+	return nil, fmt.Errorf("usage cache generation is incompatible: %s", path)
+}
+
+func publishUsageCache(
+	ctx context.Context, path, databaseID string,
+) (*usageCache, bool, error) {
+	file, err := os.CreateTemp(filepath.Dir(path), ".usage-cache-init-*.db")
+	if err != nil {
+		return nil, false, fmt.Errorf("creating usage cache generation: %w", err)
+	}
+	temporaryPath := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(temporaryPath)
+		return nil, false, err
+	}
+	_ = os.Remove(temporaryPath)
+	cache, err := initializeUsageCache(ctx, temporaryPath, databaseID, false)
+	if err != nil {
+		_ = removeUsageCacheFiles(temporaryPath)
+		return nil, false, err
+	}
+	if err := cache.db.Close(); err != nil {
+		_ = removeUsageCacheFiles(temporaryPath)
+		return nil, false, err
+	}
+	if err := os.Link(temporaryPath, path); err != nil {
+		_ = removeUsageCacheFiles(temporaryPath)
+		if errors.Is(err, os.ErrExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("publishing usage cache %s: %w", path, err)
+	}
+	if err := removeUsageCacheFiles(temporaryPath); err != nil {
+		return nil, false, err
+	}
+	cache, err = openUsageCache(ctx, path, databaseID, false)
+	return cache, true, err
+}
+
+func openTemporaryUsageCache(
+	ctx context.Context, databaseID string,
+) (*usageCache, error) {
+	file, err := os.CreateTemp("", "agentsview-usage-cache-*.db")
+	if err != nil {
+		return nil, err
+	}
+	path := file.Name()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	cache, err := initializeUsageCache(ctx, path, databaseID, true)
+	if err != nil {
+		_ = removeUsageCacheFiles(path)
+	}
+	return cache, err
+}
+
+func initializeUsageCache(
+	ctx context.Context, path, databaseID string, temporary bool,
+) (*usageCache, error) {
+	database, err := openUsageCacheDatabase(path)
+	if err != nil {
+		return nil, err
+	}
+	failed := true
+	defer func() {
+		if failed {
+			_ = database.Close()
+		}
+	}()
+	if _, err := database.ExecContext(ctx,
+		`PRAGMA auto_vacuum=INCREMENTAL; VACUUM`); err != nil {
+		return nil, fmt.Errorf("configuring usage cache auto-vacuum: %w", err)
+	}
+	if _, err := database.ExecContext(ctx,
+		fmt.Sprintf("PRAGMA application_id=%d", usageCacheApplicationID)); err != nil {
+		return nil, fmt.Errorf("identifying usage cache: %w", err)
+	}
+	if _, err := database.ExecContext(ctx, usageCacheSchemaSQL); err != nil {
+		return nil, fmt.Errorf("creating usage cache schema: %w", err)
+	}
+
+	tx, err := database.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("starting usage cache metadata transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	metadata := []struct{ key, value string }{
+		{usageCacheMetadataKind, usageCacheKind},
+		{usageCacheMetadataFormatVersion, strconv.Itoa(usageCacheFormatVersion)},
+		{usageCacheMetadataExtractorVersion, "1"},
+		{usageCacheMetadataSourceDatabaseID, databaseID},
+		{usageCacheMetadataNextInstallRevision, "1"},
+		{usageCacheMetadataNextRollupRevision, "1"},
+		{usageCacheMetadataDeletionRevision, "0"},
+		{usageCacheMetadataCursorHighWaterMark, "0"},
+		{usageCacheMetadataBackfillProgress, ""},
+		{usageCacheMetadataBackfillCompletedAt, ""},
+	}
+	for _, item := range metadata {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO usage_cache_metadata(key, value) VALUES (?, ?)`,
+			item.key, item.value,
+		); err != nil {
+			return nil, fmt.Errorf("writing usage cache metadata %s: %w", item.key, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing usage cache metadata: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return nil, fmt.Errorf("securing usage cache: %w", err)
+	}
+	failed = false
+	return &usageCache{
+		db: database, path: path, temporary: temporary, databaseID: databaseID,
+	}, nil
+}
+
+func openUsageCache(
+	ctx context.Context, path, databaseID string, temporary bool,
+) (*usageCache, error) {
+	database, err := openUsageCacheDatabase(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := database.PingContext(ctx); err != nil {
+		_ = database.Close()
+		return nil, fmt.Errorf("opening usage cache %s: %w", path, err)
+	}
+	return &usageCache{
+		db: database, path: path, temporary: temporary, databaseID: databaseID,
+	}, nil
+}
+
+func openUsageCacheDatabase(path string) (*sql.DB, error) {
+	database, err := sql.Open(sqliteUsageDriverName, makeDSN(path, false))
+	if err != nil {
+		return nil, fmt.Errorf("opening usage cache %s: %w", path, err)
+	}
+	database.SetMaxOpenConns(readerMaxOpenConns)
+	database.SetMaxIdleConns(readerMaxOpenConns)
+	if err := database.Ping(); err != nil {
+		_ = database.Close()
+		return nil, fmt.Errorf("opening usage cache %s: %w", path, err)
+	}
+	return database, nil
+}
+
+func probeUsageCache(ctx context.Context, path string) usageCacheProbe {
+	probe := usageCacheProbe{}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return probe
+		}
+		probe.Err = fmt.Errorf("checking usage cache %s: %w", path, err)
+		return probe
+	}
+	probe.Exists = true
+	dsn := strings.Replace(makeDSN(path, true), "_busy_timeout=5000", "_busy_timeout=0", 1)
+	database, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		probe.Err = fmt.Errorf("probing usage cache %s: %w", path, err)
+		return probe
+	}
+	database.SetMaxOpenConns(1)
+	defer database.Close()
+	if err := database.PingContext(ctx); err != nil {
+		probe.Err = fmt.Errorf("probing usage cache %s: %w", path, err)
+		return probe
+	}
+	var applicationID int
+	if err := database.QueryRowContext(ctx, `PRAGMA application_id`).Scan(&applicationID); err != nil {
+		probe.Err = fmt.Errorf("reading usage cache application id: %w", err)
+		return probe
+	}
+	if applicationID != usageCacheApplicationID {
+		return probe
+	}
+	var kind string
+	if err := database.QueryRowContext(ctx,
+		`SELECT value FROM usage_cache_metadata WHERE key = ?`,
+		usageCacheMetadataKind,
+	).Scan(&kind); err != nil {
+		if errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "no such table") {
+			return probe
+		}
+		probe.Err = fmt.Errorf("reading usage cache kind: %w", err)
+		return probe
+	}
+	if kind != usageCacheKind {
+		return probe
+	}
+	probe.Recognized = true
+	var formatText string
+	formatErr := database.QueryRowContext(ctx,
+		`SELECT value FROM usage_cache_metadata WHERE key = ?`,
+		usageCacheMetadataFormatVersion,
+	).Scan(&formatText)
+	if formatErr != nil && !errors.Is(formatErr, sql.ErrNoRows) {
+		probe.Err = fmt.Errorf("reading usage cache format version: %w", formatErr)
+		return probe
+	}
+	probe.FormatVersion, _ = strconv.Atoi(formatText)
+	sourceErr := database.QueryRowContext(ctx,
+		`SELECT value FROM usage_cache_metadata WHERE key = ?`,
+		usageCacheMetadataSourceDatabaseID,
+	).Scan(&probe.SourceDatabaseID)
+	if sourceErr != nil && !errors.Is(sourceErr, sql.ErrNoRows) {
+		probe.Err = fmt.Errorf("reading usage cache source database id: %w", sourceErr)
+		return probe
+	}
+	probe.Compatible = probe.FormatVersion == usageCacheFormatVersion &&
+		probe.SourceDatabaseID != "" && usageCacheSchemaComplete(ctx, database)
+	return probe
+}
+
+func usageCacheSchemaComplete(ctx context.Context, database *sql.DB) bool {
+	var metadataCount int
+	if err := database.QueryRowContext(ctx, `
+		SELECT count(*) FROM usage_cache_metadata
+		WHERE key IN (
+			'cache_kind', 'format_version', 'extractor_version',
+			'source_database_id', 'next_install_revision',
+			'next_rollup_install_revision',
+			'deletion_revision', 'cursor_high_water_mark',
+			'backfill_progress_session_id', 'backfill_completed_at'
+		)`).Scan(&metadataCount); err != nil || metadataCount != 10 {
+		return false
+	}
+	queries := []string{
+		`SELECT key, value FROM usage_cache_metadata LIMIT 0`,
+		`SELECT id, session_id, source_sync_marker, source_transcript_rev,
+		        usage_event_fingerprint, install_revision, fact_count,
+		        min_fact_timestamp_ms, max_fact_timestamp_ms
+		 FROM usage_cached_sessions LIMIT 0`,
+		`SELECT cached_session_id, fact_index, source, message_ordinal,
+		        timestamp_ms, timestamp_ns, raw_timestamp, uses_session_start, model,
+		        input_tokens, output_tokens, reasoning_tokens,
+		        cache_creation_tokens, cache_read_tokens, web_search_requests,
+		        reported_cost_microdollars, cost_source, request_scoped,
+		        claude_message_id, claude_request_id, source_uuid,
+		        usage_dedup_key, token_eligible, activity_eligible
+		 FROM usage_facts LIMIT 0`,
+		`SELECT source_id, timestamp_ms, timestamp_ns, raw_timestamp, model, kind,
+		        input_tokens, output_tokens, cache_creation_tokens,
+		        cache_read_tokens, charged_microdollars,
+		        cursor_token_fee_microdollars, user_id, user_email,
+		        is_headless, dedup_key
+		 FROM cursor_usage_facts LIMIT 0`,
+		`SELECT id, timezone_key, timezone_name, interval_fingerprint,
+		        last_requested_at, build_completed_at
+		 FROM usage_rollup_timezones LIMIT 0`,
+		`SELECT timezone_id, local_date, from_ms, to_ms
+		 FROM usage_rollup_days LIMIT 0`,
+		`SELECT id, timezone_id, session_id, source_sync_marker,
+		        source_transcript_rev, usage_event_fingerprint,
+		        fact_install_revision, baked_agent, baked_started_at,
+		        pricing_hash, install_revision, cached_at
+		 FROM usage_rollup_installs LIMIT 0`,
+		`SELECT rollup_install_id, local_date, reported_model, priced_model,
+		        matched_pattern, rate_ok, rate_hash, band_threshold,
+		        input_tokens, output_tokens, reasoning_tokens,
+		        cache_creation_tokens, cache_read_tokens, web_search_requests,
+		        estimated_cost_microdollars, savings_microdollars,
+		        authoritative_cost_microdollars, computed_request_count,
+		        computed_aggregate_count, reported_count, base_request_count,
+		        discarded_snapshot_output_tokens
+		 FROM usage_daily_rollups LIMIT 0`,
+		`SELECT rollup_install_id, local_date, model, user_message_count
+		 FROM usage_activity_rollups LIMIT 0`,
+		`SELECT rollup_install_id, group_kind, group_key, cached_session_id,
+		        fact_index, source_session_id, local_date, source,
+		        message_ordinal, timestamp_ms, timestamp_ns, raw_timestamp,
+		        uses_session_start, model, input_tokens, output_tokens,
+		        reasoning_tokens, cache_creation_tokens, cache_read_tokens,
+		        web_search_requests, reported_cost_microdollars, cost_source,
+		        request_scoped, claude_message_id, claude_request_id,
+		        source_uuid, usage_dedup_key
+		 FROM usage_rollup_exceptions LIMIT 0`,
+	}
+	for _, query := range queries {
+		rows, err := database.QueryContext(ctx, query)
+		if err != nil {
+			return false
+		}
+		if err := rows.Close(); err != nil {
+			return false
+		}
+	}
+	for _, index := range []string{
+		"usage_facts_timestamp", "usage_facts_snapshot", "usage_facts_session_start",
+		"usage_facts_raw_timestamp", "usage_daily_rollups_window",
+		"usage_rollup_exceptions_window",
+	} {
+		var exists bool
+		if err := database.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='index' AND name=?)`,
+			index,
+		).Scan(&exists); err != nil || !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func removeUsageCacheFiles(path string) error {
+	var errs []error
+	for _, candidate := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Remove(candidate); err != nil && !errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *usageCacheManager) resetLocked() error {
+	var errs []error
+	for databaseID, cache := range m.generations {
+		cache.rollup = nil
+		if cache.fill != nil {
+			cache.fill.Close()
+		}
+		if cache.db != nil {
+			errs = append(errs, cache.db.Close())
+		}
+		if cache.temporary {
+			errs = append(errs, removeUsageCacheFiles(cache.path))
+		}
+		delete(m.generations, databaseID)
+	}
+	return errors.Join(errs...)
+}
+
+func (m *usageCacheManager) Reset() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil
+	}
+	return m.resetLocked()
+}
+
+func (m *usageCacheManager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil
+	}
+	m.closed = true
+	m.cancel()
+	return m.resetLocked()
+}

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -15,19 +15,17 @@ import (
 )
 
 const (
-	usageCacheFormatVersion = 7
+	usageCacheFormatVersion = 8
 	usageCacheApplicationID = 0x41565543
 	usageCacheKind          = "agentsview-usage-facts"
 
 	usageCacheMetadataKind                = "cache_kind"
 	usageCacheMetadataFormatVersion       = "format_version"
-	usageCacheMetadataExtractorVersion    = "extractor_version"
 	usageCacheMetadataSourceDatabaseID    = "source_database_id"
 	usageCacheMetadataNextInstallRevision = "next_install_revision"
 	usageCacheMetadataNextRollupRevision  = "next_rollup_install_revision"
 	usageCacheMetadataDeletionRevision    = "deletion_revision"
 	usageCacheMetadataCursorHighWaterMark = "cursor_high_water_mark"
-	usageCacheMetadataBackfillProgress    = "backfill_progress_session_id"
 	usageCacheMetadataBackfillCompletedAt = "backfill_completed_at"
 )
 
@@ -42,10 +40,7 @@ CREATE TABLE usage_cached_sessions (
     source_sync_marker TEXT NOT NULL,
     source_transcript_rev TEXT NOT NULL,
     usage_event_fingerprint TEXT NOT NULL,
-    install_revision INTEGER NOT NULL,
-    fact_count INTEGER NOT NULL,
-    min_fact_timestamp_ms INTEGER,
-    max_fact_timestamp_ms INTEGER
+    install_revision INTEGER NOT NULL
 );
 CREATE TABLE usage_facts (
     cached_session_id INTEGER NOT NULL REFERENCES usage_cached_sessions(id)
@@ -75,34 +70,16 @@ CREATE TABLE usage_facts (
     activity_eligible INTEGER NOT NULL CHECK (activity_eligible IN (0, 1)),
     PRIMARY KEY (cached_session_id, fact_index)
 ) WITHOUT ROWID;
-CREATE INDEX usage_facts_timestamp
-ON usage_facts(timestamp_ms, cached_session_id, fact_index)
-WHERE timestamp_ms IS NOT NULL;
-CREATE INDEX usage_facts_snapshot
-ON usage_facts(claude_message_id, claude_request_id, timestamp_ms,
-               cached_session_id, fact_index)
-WHERE token_eligible = 1
-  AND claude_message_id != '' AND claude_request_id != '';
-CREATE INDEX usage_facts_session_start
-ON usage_facts(cached_session_id, fact_index) WHERE uses_session_start = 1;
-CREATE INDEX usage_facts_raw_timestamp
-ON usage_facts(raw_timestamp, cached_session_id, fact_index)
-WHERE timestamp_ms IS NULL AND uses_session_start = 0 AND raw_timestamp != '';
 CREATE TABLE cursor_usage_facts (
     source_id INTEGER PRIMARY KEY,
     timestamp_ms INTEGER,
-    timestamp_ns INTEGER,
     raw_timestamp TEXT NOT NULL DEFAULT '',
     model TEXT NOT NULL,
-    kind TEXT NOT NULL DEFAULT '',
     input_tokens INTEGER NOT NULL,
     output_tokens INTEGER NOT NULL,
     cache_creation_tokens INTEGER NOT NULL,
     cache_read_tokens INTEGER NOT NULL,
     charged_microdollars INTEGER NOT NULL,
-    cursor_token_fee_microdollars INTEGER NOT NULL,
-    user_id TEXT NOT NULL DEFAULT '',
-    user_email TEXT NOT NULL DEFAULT '',
     is_headless INTEGER NOT NULL CHECK (is_headless IN (0, 1)),
     dedup_key TEXT NOT NULL
 );
@@ -111,8 +88,7 @@ CREATE TABLE usage_rollup_timezones (
     timezone_key TEXT NOT NULL UNIQUE,
     timezone_name TEXT NOT NULL,
     interval_fingerprint TEXT NOT NULL,
-    last_requested_at TEXT NOT NULL,
-    build_completed_at TEXT
+    last_requested_at TEXT NOT NULL
 );
 CREATE TABLE usage_rollup_days (
     timezone_id INTEGER NOT NULL REFERENCES usage_rollup_timezones(id)
@@ -202,6 +178,7 @@ CREATE TABLE usage_rollup_exceptions (
     reported_cost_microdollars INTEGER,
     cost_source TEXT NOT NULL,
     request_scoped INTEGER NOT NULL CHECK (request_scoped IN (0, 1)),
+    is_headless INTEGER NOT NULL CHECK (is_headless IN (0, 1)),
     claude_message_id TEXT NOT NULL,
     claude_request_id TEXT NOT NULL,
     source_uuid TEXT NOT NULL,
@@ -440,13 +417,11 @@ func initializeUsageCache(
 	metadata := []struct{ key, value string }{
 		{usageCacheMetadataKind, usageCacheKind},
 		{usageCacheMetadataFormatVersion, strconv.Itoa(usageCacheFormatVersion)},
-		{usageCacheMetadataExtractorVersion, "1"},
 		{usageCacheMetadataSourceDatabaseID, databaseID},
 		{usageCacheMetadataNextInstallRevision, "1"},
 		{usageCacheMetadataNextRollupRevision, "1"},
 		{usageCacheMetadataDeletionRevision, "0"},
 		{usageCacheMetadataCursorHighWaterMark, "0"},
-		{usageCacheMetadataBackfillProgress, ""},
 		{usageCacheMetadataBackfillCompletedAt, ""},
 	}
 	for _, item := range metadata {
@@ -582,19 +557,18 @@ func usageCacheSchemaComplete(ctx context.Context, database *sql.DB) bool {
 	if err := database.QueryRowContext(ctx, `
 		SELECT count(*) FROM usage_cache_metadata
 		WHERE key IN (
-			'cache_kind', 'format_version', 'extractor_version',
+			'cache_kind', 'format_version',
 			'source_database_id', 'next_install_revision',
 			'next_rollup_install_revision',
 			'deletion_revision', 'cursor_high_water_mark',
-			'backfill_progress_session_id', 'backfill_completed_at'
-		)`).Scan(&metadataCount); err != nil || metadataCount != 10 {
+			'backfill_completed_at'
+		)`).Scan(&metadataCount); err != nil || metadataCount != 8 {
 		return false
 	}
 	queries := []string{
 		`SELECT key, value FROM usage_cache_metadata LIMIT 0`,
 		`SELECT id, session_id, source_sync_marker, source_transcript_rev,
-		        usage_event_fingerprint, install_revision, fact_count,
-		        min_fact_timestamp_ms, max_fact_timestamp_ms
+		        usage_event_fingerprint, install_revision
 		 FROM usage_cached_sessions LIMIT 0`,
 		`SELECT cached_session_id, fact_index, source, message_ordinal,
 		        timestamp_ms, timestamp_ns, raw_timestamp, uses_session_start, model,
@@ -604,14 +578,13 @@ func usageCacheSchemaComplete(ctx context.Context, database *sql.DB) bool {
 		        claude_message_id, claude_request_id, source_uuid,
 		        usage_dedup_key, token_eligible, activity_eligible
 		 FROM usage_facts LIMIT 0`,
-		`SELECT source_id, timestamp_ms, timestamp_ns, raw_timestamp, model, kind,
+		`SELECT source_id, timestamp_ms, raw_timestamp, model,
 		        input_tokens, output_tokens, cache_creation_tokens,
 		        cache_read_tokens, charged_microdollars,
-		        cursor_token_fee_microdollars, user_id, user_email,
 		        is_headless, dedup_key
 		 FROM cursor_usage_facts LIMIT 0`,
 		`SELECT id, timezone_key, timezone_name, interval_fingerprint,
-		        last_requested_at, build_completed_at
+		        last_requested_at
 		 FROM usage_rollup_timezones LIMIT 0`,
 		`SELECT timezone_id, local_date, from_ms, to_ms
 		 FROM usage_rollup_days LIMIT 0`,
@@ -637,7 +610,7 @@ func usageCacheSchemaComplete(ctx context.Context, database *sql.DB) bool {
 		        uses_session_start, model, input_tokens, output_tokens,
 		        reasoning_tokens, cache_creation_tokens, cache_read_tokens,
 		        web_search_requests, reported_cost_microdollars, cost_source,
-		        request_scoped, claude_message_id, claude_request_id,
+		        request_scoped, is_headless, claude_message_id, claude_request_id,
 		        source_uuid, usage_dedup_key
 		 FROM usage_rollup_exceptions LIMIT 0`,
 	}
@@ -651,9 +624,7 @@ func usageCacheSchemaComplete(ctx context.Context, database *sql.DB) bool {
 		}
 	}
 	for _, index := range []string{
-		"usage_facts_timestamp", "usage_facts_snapshot", "usage_facts_session_start",
-		"usage_facts_raw_timestamp", "usage_daily_rollups_window",
-		"usage_rollup_exceptions_window",
+		"usage_daily_rollups_window", "usage_rollup_exceptions_window",
 	} {
 		var exists bool
 		if err := database.QueryRowContext(ctx,
@@ -701,6 +672,33 @@ func (m *usageCacheManager) Reset() error {
 		return nil
 	}
 	return m.resetLocked()
+}
+
+func (m *usageCacheManager) RetireExcept(databaseID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil
+	}
+	var errs []error
+	for cachedID, cache := range m.generations {
+		if cachedID == databaseID {
+			continue
+		}
+		cache.rollup = nil
+		if cache.fill != nil {
+			cache.fill.Close()
+			cache.fill = nil
+		}
+		if cache.db != nil {
+			errs = append(errs, cache.db.Close())
+		}
+		if cache.temporary {
+			errs = append(errs, removeUsageCacheFiles(cache.path))
+		}
+		delete(m.generations, cachedID)
+	}
+	return errors.Join(errs...)
 }
 
 func (m *usageCacheManager) Close() error {

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	usageCacheFormatVersion = 9
+	usageCacheFormatVersion = 1
 	usageCacheApplicationID = 0x41565543
 	usageCacheKind          = "agentsview-usage-facts"
 

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -199,6 +199,12 @@ type usageCache struct {
 	databaseID string
 	fill       *usageFillCoordinator
 	rollup     *usageRollupCoordinator
+	cancel     context.CancelFunc
+
+	lifecycleMu sync.Mutex
+	users       int
+	retiring    bool
+	retired     chan struct{}
 }
 
 type usageCacheProbe struct {
@@ -218,6 +224,7 @@ type usageCacheManager struct {
 
 	mu          sync.Mutex
 	generations map[string]*usageCache
+	currentID   string
 	closed      bool
 }
 
@@ -263,6 +270,10 @@ func (m *usageCacheManager) Generation(
 	if m.closed {
 		return nil, fmt.Errorf("usage cache manager is closed")
 	}
+	if m.currentID != "" && databaseID != m.currentID {
+		return nil, fmt.Errorf("%w before opening generation %s",
+			errUsageCacheSourceChanged, databaseID)
+	}
 	if cache := m.generations[databaseID]; cache != nil {
 		return cache, nil
 	}
@@ -281,12 +292,67 @@ func (m *usageCacheManager) Generation(
 	if cache == nil {
 		return nil, fmt.Errorf("opening usage cache returned no database")
 	}
+	cacheContext, cancel := context.WithCancel(m.ctx)
+	cache.cancel = cancel
+	cache.retired = make(chan struct{})
 	m.generations[databaseID] = cache
 	if m.archive != nil {
-		cache.fill = newUsageFillCoordinator(m.ctx, m.archive, cache)
-		cache.rollup = newUsageRollupCoordinator(m.ctx, m.archive, cache)
+		cache.fill = newUsageFillCoordinator(cacheContext, m.archive, cache)
+		cache.rollup = newUsageRollupCoordinator(cacheContext, m.archive, cache)
 	}
 	return cache, nil
+}
+
+func (m *usageCacheManager) acquireGeneration(
+	ctx context.Context, databaseID string,
+) (*usageCache, func(), error) {
+	cache, err := m.Generation(ctx, databaseID)
+	if err != nil {
+		return nil, nil, err
+	}
+	release, ok := cache.acquire()
+	if !ok {
+		return nil, nil, fmt.Errorf("%w while acquiring generation %s",
+			errUsageCacheSourceChanged, databaseID)
+	}
+	return cache, release, nil
+}
+
+func (cache *usageCache) acquire() (func(), bool) {
+	cache.lifecycleMu.Lock()
+	defer cache.lifecycleMu.Unlock()
+	if cache.retiring {
+		return nil, false
+	}
+	cache.users++
+	var once sync.Once
+	return func() {
+		once.Do(cache.release)
+	}, true
+}
+
+func (cache *usageCache) release() {
+	cache.lifecycleMu.Lock()
+	defer cache.lifecycleMu.Unlock()
+	cache.users--
+	if cache.retiring && cache.users == 0 {
+		close(cache.retired)
+	}
+}
+
+func (cache *usageCache) beginRetirement() <-chan struct{} {
+	cache.lifecycleMu.Lock()
+	defer cache.lifecycleMu.Unlock()
+	if !cache.retiring {
+		cache.retiring = true
+		if cache.cancel != nil {
+			cache.cancel()
+		}
+		if cache.users == 0 {
+			close(cache.retired)
+		}
+	}
+	return cache.retired
 }
 
 func (m *usageCacheManager) openPersistentGeneration(
@@ -647,10 +713,14 @@ func removeUsageCacheFiles(path string) error {
 	return errors.Join(errs...)
 }
 
-func (m *usageCacheManager) resetLocked() error {
+func retireUsageCaches(caches []*usageCache) error {
+	retired := make([]<-chan struct{}, len(caches))
+	for index, cache := range caches {
+		retired[index] = cache.beginRetirement()
+	}
 	var errs []error
-	for databaseID, cache := range m.generations {
-		cache.rollup = nil
+	for index, cache := range caches {
+		<-retired[index]
 		if cache.fill != nil {
 			cache.fill.Close()
 		}
@@ -660,54 +730,59 @@ func (m *usageCacheManager) resetLocked() error {
 		if cache.temporary {
 			errs = append(errs, removeUsageCacheFiles(cache.path))
 		}
-		delete(m.generations, databaseID)
 	}
 	return errors.Join(errs...)
+}
+
+func (m *usageCacheManager) detachAllLocked() []*usageCache {
+	caches := make([]*usageCache, 0, len(m.generations))
+	for databaseID, cache := range m.generations {
+		caches = append(caches, cache)
+		delete(m.generations, databaseID)
+	}
+	return caches
 }
 
 func (m *usageCacheManager) Reset() error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.closed {
+		m.mu.Unlock()
 		return nil
 	}
-	return m.resetLocked()
+	m.currentID = ""
+	caches := m.detachAllLocked()
+	m.mu.Unlock()
+	return retireUsageCaches(caches)
 }
 
 func (m *usageCacheManager) RetireExcept(databaseID string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.closed {
+		m.mu.Unlock()
 		return nil
 	}
-	var errs []error
+	m.currentID = databaseID
+	caches := make([]*usageCache, 0, len(m.generations))
 	for cachedID, cache := range m.generations {
 		if cachedID == databaseID {
 			continue
 		}
-		cache.rollup = nil
-		if cache.fill != nil {
-			cache.fill.Close()
-			cache.fill = nil
-		}
-		if cache.db != nil {
-			errs = append(errs, cache.db.Close())
-		}
-		if cache.temporary {
-			errs = append(errs, removeUsageCacheFiles(cache.path))
-		}
+		caches = append(caches, cache)
 		delete(m.generations, cachedID)
 	}
-	return errors.Join(errs...)
+	m.mu.Unlock()
+	return retireUsageCaches(caches)
 }
 
 func (m *usageCacheManager) Close() error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.closed {
+		m.mu.Unlock()
 		return nil
 	}
 	m.closed = true
 	m.cancel()
-	return m.resetLocked()
+	caches := m.detachAllLocked()
+	m.mu.Unlock()
+	return retireUsageCaches(caches)
 }

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -331,6 +331,18 @@ func (cache *usageCache) acquire() (func(), bool) {
 	}, true
 }
 
+func (cache *usageCache) startDetachedWork(work func()) bool {
+	release, ok := cache.acquire()
+	if !ok {
+		return false
+	}
+	go func() {
+		defer release()
+		work()
+	}()
+	return true
+}
+
 func (cache *usageCache) release() {
 	cache.lifecycleMu.Lock()
 	defer cache.lifecycleMu.Unlock()

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -70,6 +70,13 @@ CREATE TABLE usage_facts (
     activity_eligible INTEGER NOT NULL CHECK (activity_eligible IN (0, 1)),
     PRIMARY KEY (cached_session_id, fact_index)
 ) WITHOUT ROWID;
+CREATE INDEX usage_facts_claude_identity
+    ON usage_facts (claude_message_id, claude_request_id)
+    WHERE claude_message_id != '' AND claude_request_id != '';
+CREATE INDEX usage_facts_source_uuid
+    ON usage_facts (source_uuid) WHERE source_uuid != '';
+CREATE INDEX usage_facts_usage_dedup_key
+    ON usage_facts (usage_dedup_key) WHERE usage_dedup_key != '';
 CREATE TABLE cursor_usage_facts (
     source_id INTEGER PRIMARY KEY,
     timestamp_ms INTEGER,
@@ -83,6 +90,8 @@ CREATE TABLE cursor_usage_facts (
     is_headless INTEGER NOT NULL CHECK (is_headless IN (0, 1)),
     dedup_key TEXT NOT NULL
 );
+CREATE INDEX cursor_usage_facts_dedup_key
+    ON cursor_usage_facts (dedup_key);
 CREATE TABLE usage_rollup_timezones (
     id INTEGER PRIMARY KEY,
     timezone_key TEXT NOT NULL UNIQUE,
@@ -703,6 +712,8 @@ func usageCacheSchemaComplete(ctx context.Context, database *sql.DB) bool {
 	}
 	for _, index := range []string{
 		"usage_daily_rollups_window", "usage_rollup_exceptions_window",
+		"usage_facts_claude_identity", "usage_facts_source_uuid",
+		"usage_facts_usage_dedup_key", "cursor_usage_facts_dedup_key",
 	} {
 		var exists bool
 		if err := database.QueryRowContext(ctx,

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	usageCacheFormatVersion = 8
+	usageCacheFormatVersion = 9
 	usageCacheApplicationID = 0x41565543
 	usageCacheKind          = "agentsview-usage-facts"
 

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -1,0 +1,392 @@
+//go:build fts5
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "sessions.db")
+	manager := newUsageCacheManager(archivePath)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+
+	cache, err := manager.Generation(context.Background(), "database-id-one")
+	require.NoError(t, err)
+	require.False(t, cache.temporary)
+	assert.Equal(t, filepath.Join(filepath.Dir(archivePath),
+		"usage-cache-v7-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
+
+	info, err := os.Stat(cache.path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	var applicationID, autoVacuum int
+	require.NoError(t, cache.db.QueryRow(`PRAGMA application_id`).Scan(&applicationID))
+	require.NoError(t, cache.db.QueryRow(`PRAGMA auto_vacuum`).Scan(&autoVacuum))
+	assert.Equal(t, 1096176963, applicationID)
+	assert.Equal(t, 2, autoVacuum, "INCREMENTAL auto-vacuum")
+
+	metadata := readUsageCacheMetadata(t, cache.db)
+	assert.Equal(t, "agentsview-usage-facts", metadata[usageCacheMetadataKind])
+	assert.Equal(t, "7", metadata[usageCacheMetadataFormatVersion])
+	assert.Equal(t, "database-id-one", metadata[usageCacheMetadataSourceDatabaseID])
+	assert.Equal(t, "1", metadata[usageCacheMetadataNextInstallRevision])
+	assert.Equal(t, "1", metadata[usageCacheMetadataNextRollupRevision])
+	assert.Equal(t, "0", metadata[usageCacheMetadataDeletionRevision])
+	assert.Equal(t, "0", metadata[usageCacheMetadataCursorHighWaterMark])
+
+	for _, table := range []string{
+		"usage_cache_metadata", "usage_cached_sessions",
+		"usage_facts", "cursor_usage_facts",
+	} {
+		var found bool
+		require.NoError(t, cache.db.QueryRow(
+			`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?)`,
+			table,
+		).Scan(&found))
+		assert.True(t, found, table)
+	}
+	for _, index := range []string{
+		"usage_facts_timestamp", "usage_facts_snapshot", "usage_facts_session_start",
+		"usage_facts_raw_timestamp",
+	} {
+		var found bool
+		require.NoError(t, cache.db.QueryRow(
+			`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='index' AND name=?)`,
+			index,
+		).Scan(&found))
+		assert.True(t, found, index)
+	}
+
+	result, err := cache.db.Exec(`INSERT INTO usage_cached_sessions(
+		session_id, source_sync_marker, source_transcript_rev,
+		usage_event_fingerprint, install_revision, fact_count
+	) VALUES ('s1', 'm1', 'r1', 'e1', 1, 1)`)
+	require.NoError(t, err)
+	cachedSessionID, err := result.LastInsertId()
+	require.NoError(t, err)
+	_, err = cache.db.Exec(`INSERT INTO usage_facts(
+		cached_session_id, fact_index, source, uses_session_start, model,
+		input_tokens, output_tokens, reasoning_tokens,
+		cache_creation_tokens, cache_read_tokens, web_search_requests,
+		request_scoped, token_eligible, activity_eligible
+	) VALUES (?, 0, 'message', 2, 'model', 0, 0, 0, 0, 0, 0, 1, 1, 1)`,
+		cachedSessionID)
+	require.Error(t, err, "boolean checks must reject invalid facts")
+	_, err = cache.db.Exec(`INSERT INTO usage_facts(
+		cached_session_id, fact_index, source, uses_session_start, model,
+		input_tokens, output_tokens, reasoning_tokens,
+		cache_creation_tokens, cache_read_tokens, web_search_requests,
+		request_scoped, token_eligible, activity_eligible
+	) VALUES (?, 0, 'message', 0, 'model', 0, 0, 0, 0, 0, 0, 1, 1, 1)`,
+		cachedSessionID)
+	require.NoError(t, err)
+	_, err = cache.db.Exec(`DELETE FROM usage_cached_sessions WHERE id = ?`, cachedSessionID)
+	require.NoError(t, err)
+	var remainingFacts int
+	require.NoError(t, cache.db.QueryRow(
+		`SELECT count(*) FROM usage_facts WHERE cached_session_id = ?`, cachedSessionID,
+	).Scan(&remainingFacts))
+	assert.Zero(t, remainingFacts, "deleting a cached session must cascade to facts")
+
+	probe := probeUsageCache(context.Background(), cache.path)
+	require.NoError(t, probe.Err)
+	assert.True(t, probe.Recognized)
+	assert.True(t, probe.Compatible)
+	assert.Equal(t, "database-id-one", probe.SourceDatabaseID)
+}
+
+func TestUsageCacheSchemaIncludesRollupTier(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "sessions.db")
+	manager := newUsageCacheManager(archivePath)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+
+	cache, err := manager.Generation(context.Background(), "database-a")
+	require.NoError(t, err)
+	for _, name := range []string{
+		"usage_rollup_timezones", "usage_rollup_days",
+		"usage_rollup_installs", "usage_daily_rollups",
+		"usage_activity_rollups", "usage_rollup_exceptions",
+		"usage_daily_rollups_window", "usage_rollup_exceptions_window",
+	} {
+		var found bool
+		require.NoError(t, cache.db.QueryRow(
+			`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = ?)`, name,
+		).Scan(&found))
+		assert.True(t, found, name)
+	}
+}
+
+func TestUsageCacheProbeFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		seed func(*testing.T, string)
+	}{
+		{
+			name: "wrong application id",
+			seed: func(t *testing.T, path string) {
+				conn := openRawUsageCacheTestDB(t, path)
+				defer conn.Close()
+				_, err := conn.Exec(`PRAGMA application_id = 1234;
+					CREATE TABLE sentinel(value TEXT);
+					INSERT INTO sentinel VALUES ('foreign')`)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "missing cache kind",
+			seed: func(t *testing.T, path string) {
+				conn := openRawUsageCacheTestDB(t, path)
+				defer conn.Close()
+				_, err := conn.Exec(`PRAGMA application_id = 1096176963;
+					CREATE TABLE usage_cache_metadata(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+					INSERT INTO usage_cache_metadata VALUES ('sentinel', 'foreign')`)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "corrupt unrecognized file",
+			seed: func(t *testing.T, path string) {
+				require.NoError(t, os.WriteFile(path, []byte("not sqlite"), 0o600))
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			archivePath := filepath.Join(dir, "sessions.db")
+			path := usageCacheGenerationPath(
+				archivePath, usageCacheFormatVersion, "database-id-one")
+			tc.seed(t, path)
+			before, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			manager := newUsageCacheManager(archivePath)
+			cache, err := manager.Generation(context.Background(), "database-id-one")
+			require.NoError(t, err)
+			require.True(t, cache.temporary)
+			require.NoError(t, manager.Close())
+
+			after, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, before, after, "foreign or unverifiable file changed")
+		})
+	}
+}
+
+func TestUsageCacheGenerationPreservesRecognizedIncompleteCache(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "sessions.db")
+	path := usageCacheGenerationPath(
+		archivePath, usageCacheFormatVersion, "database-id-one")
+	seedRecognizedUsageCache(t, path, usageCacheFormatVersion, "database-id-one")
+
+	manager := newUsageCacheManager(archivePath)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+	cache, err := manager.Generation(context.Background(), "database-id-one")
+	require.NoError(t, err)
+	require.True(t, cache.temporary)
+
+	probe := probeUsageCache(context.Background(), path)
+	require.NoError(t, probe.Err)
+	assert.True(t, probe.Recognized)
+	assert.False(t, probe.Compatible)
+}
+
+func TestUsageCacheGenerationChangesWithFormatAndDatabaseID(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "sessions.db")
+	oldPath := usageCacheGenerationPath(archivePath, 6, "database-id-one")
+	seedRecognizedUsageCache(t, oldPath, 6, "database-id-one")
+
+	manager := newUsageCacheManager(archivePath)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+	first, err := manager.Generation(context.Background(), "database-id-one")
+	require.NoError(t, err)
+	assert.NotEqual(t, oldPath, first.path, "format bump must open a new generation")
+	_, err = os.Stat(oldPath)
+	require.NoError(t, err, "format bump must preserve the old generation")
+
+	second, err := manager.Generation(context.Background(), "database-id-two")
+	require.NoError(t, err)
+	assert.NotEqual(t, first.path, second.path,
+		"source database id change must open a new generation")
+	assert.Equal(t, "database-id-two",
+		readUsageCacheMetadata(t, second.db)[usageCacheMetadataSourceDatabaseID])
+}
+
+func TestUsageCacheGenerationPublishesConcurrently(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "sessions.db")
+	managers := []*usageCacheManager{
+		newUsageCacheManager(archivePath), newUsageCacheManager(archivePath),
+	}
+	t.Cleanup(func() {
+		for _, manager := range managers {
+			require.NoError(t, manager.Close())
+		}
+	})
+	var wait sync.WaitGroup
+	wait.Add(len(managers))
+	errors := make(chan error, len(managers))
+	paths := make(chan string, len(managers))
+	temporary := make(chan bool, len(managers))
+	for _, manager := range managers {
+		go func(manager *usageCacheManager) {
+			defer wait.Done()
+			cache, err := manager.Generation(context.Background(), "database-id")
+			if err == nil {
+				paths <- cache.path
+				temporary <- cache.temporary
+			}
+			errors <- err
+		}(manager)
+	}
+	wait.Wait()
+	close(errors)
+	close(paths)
+	close(temporary)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+	for value := range temporary {
+		assert.False(t, value)
+	}
+	var expected string
+	for path := range paths {
+		if expected == "" {
+			expected = path
+		}
+		assert.Equal(t, expected, path)
+	}
+	probe := probeUsageCache(context.Background(), expected)
+	require.NoError(t, probe.Err)
+	assert.True(t, probe.Compatible)
+}
+
+func TestUsageCacheGenerationDoesNotDeleteHeldOldGeneration(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "sessions.db")
+	oldPath := usageCacheGenerationPath(archivePath, 0, "old-database-id")
+	seedRecognizedUsageCache(t, oldPath, 0, "old-database-id")
+	held := openRawUsageCacheTestDB(t, oldPath)
+	t.Cleanup(func() { require.NoError(t, held.Close()) })
+	_, err := held.Exec(`BEGIN IMMEDIATE`)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = held.Exec(`ROLLBACK`) })
+
+	manager := newUsageCacheManager(archivePath)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+	_, err = manager.Generation(context.Background(), "new-database-id")
+	require.NoError(t, err)
+	assert.FileExists(t, oldPath)
+}
+
+func TestUsageCacheTemporaryFallbackUsesSameSchema(t *testing.T) {
+	dir := t.TempDir()
+	blockedParent := filepath.Join(dir, "not-a-directory")
+	require.NoError(t, os.WriteFile(blockedParent, []byte("blocked"), 0o600))
+	manager := newUsageCacheManager(filepath.Join(blockedParent, "sessions.db"))
+
+	cache, err := manager.Generation(context.Background(), "database-id-one")
+	require.NoError(t, err)
+	require.True(t, cache.temporary)
+	tempPath := cache.path
+	assert.Equal(t, "agentsview-usage-facts",
+		readUsageCacheMetadata(t, cache.db)[usageCacheMetadataKind])
+	require.NoError(t, manager.Close())
+	assert.NoFileExists(t, tempPath)
+}
+
+func TestUsageCacheLifecycleFollowsArchiveReopenAndClose(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "sessions.db")
+	database, err := Open(archivePath)
+	require.NoError(t, err)
+	databaseID, err := database.GetDatabaseID(context.Background())
+	require.NoError(t, err)
+
+	first, err := database.usageCache.Generation(context.Background(), databaseID)
+	require.NoError(t, err)
+	require.NoError(t, first.db.Ping())
+	started := make(chan struct{}, 1)
+	database.SetUsageCacheBackfillStarted(func() { started <- struct{}{} })
+
+	require.NoError(t, database.Reopen())
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("reopen backfill did not notify lifecycle observer")
+	}
+	require.NoError(t, first.db.Ping(), "reopen must preserve active cache readers")
+	second, err := database.usageCache.Generation(context.Background(), databaseID)
+	require.NoError(t, err)
+	require.Same(t, first, second)
+	require.NoError(t, second.db.Ping())
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	assert.NotEmpty(t, readUsageCacheMetadata(t, second.db)[usageCacheMetadataBackfillCompletedAt])
+
+	require.NoError(t, database.Close())
+	require.Error(t, second.db.Ping(), "archive close must close its cache first")
+
+	readOnly, err := OpenReadOnly(archivePath)
+	require.NoError(t, err)
+	readOnlyCache, err := readOnly.usageCache.Generation(
+		context.Background(), databaseID,
+	)
+	require.NoError(t, err)
+	require.False(t, readOnlyCache.temporary)
+	require.NoError(t, readOnly.Close())
+}
+
+func readUsageCacheMetadata(t *testing.T, conn *sql.DB) map[string]string {
+	t.Helper()
+	rows, err := conn.Query(`SELECT key, value FROM usage_cache_metadata`)
+	require.NoError(t, err)
+	defer rows.Close()
+	result := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		require.NoError(t, rows.Scan(&key, &value))
+		result[key] = value
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+func openRawUsageCacheTestDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", makeDSN(path, false))
+	require.NoError(t, err)
+	conn.SetMaxOpenConns(1)
+	require.NoError(t, conn.Ping())
+	return conn
+}
+
+func seedRecognizedUsageCache(
+	t *testing.T, path string, format int, databaseID string,
+) {
+	t.Helper()
+	conn := openRawUsageCacheTestDB(t, path)
+	defer conn.Close()
+	_, err := conn.Exec(`PRAGMA application_id = 1096176963;
+		CREATE TABLE usage_cache_metadata(key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
+	require.NoError(t, err)
+	for key, value := range map[string]any{
+		usageCacheMetadataKind:             usageCacheKind,
+		usageCacheMetadataFormatVersion:    format,
+		usageCacheMetadataSourceDatabaseID: databaseID,
+	} {
+		_, err = conn.Exec(
+			`INSERT INTO usage_cache_metadata(key, value) VALUES (?, ?)`, key, value)
+		require.NoError(t, err)
+	}
+}

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -28,7 +29,9 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 
 	info, err := os.Stat(cache.path)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 
 	var applicationID, autoVacuum int
 	require.NoError(t, cache.db.QueryRow(`PRAGMA application_id`).Scan(&applicationID))

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -25,7 +25,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cache.temporary)
 	assert.Equal(t, filepath.Join(filepath.Dir(archivePath),
-		"usage-cache-v7-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
+		"usage-cache-v8-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
 
 	info, err := os.Stat(cache.path)
 	require.NoError(t, err)
@@ -41,12 +41,34 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 
 	metadata := readUsageCacheMetadata(t, cache.db)
 	assert.Equal(t, "agentsview-usage-facts", metadata[usageCacheMetadataKind])
-	assert.Equal(t, "7", metadata[usageCacheMetadataFormatVersion])
+	assert.Equal(t, "8", metadata[usageCacheMetadataFormatVersion])
 	assert.Equal(t, "database-id-one", metadata[usageCacheMetadataSourceDatabaseID])
 	assert.Equal(t, "1", metadata[usageCacheMetadataNextInstallRevision])
 	assert.Equal(t, "1", metadata[usageCacheMetadataNextRollupRevision])
 	assert.Equal(t, "0", metadata[usageCacheMetadataDeletionRevision])
 	assert.Equal(t, "0", metadata[usageCacheMetadataCursorHighWaterMark])
+	assert.NotContains(t, metadata, "extractor_version")
+	assert.NotContains(t, metadata, "backfill_progress_session_id")
+
+	for table, columns := range map[string][]string{
+		"usage_cached_sessions": {
+			"fact_count", "min_fact_timestamp_ms", "max_fact_timestamp_ms",
+		},
+		"cursor_usage_facts": {
+			"timestamp_ns", "kind", "cursor_token_fee_microdollars",
+			"user_id", "user_email",
+		},
+		"usage_rollup_timezones": {"build_completed_at"},
+	} {
+		for _, column := range columns {
+			var found bool
+			require.NoError(t, cache.db.QueryRow(
+				`SELECT EXISTS(SELECT 1 FROM pragma_table_info(?) WHERE name = ?)`,
+				table, column,
+			).Scan(&found))
+			assert.False(t, found, table+"."+column)
+		}
+	}
 
 	for _, table := range []string{
 		"usage_cache_metadata", "usage_cached_sessions",
@@ -68,13 +90,13 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 			`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='index' AND name=?)`,
 			index,
 		).Scan(&found))
-		assert.True(t, found, index)
+		assert.False(t, found, index)
 	}
 
 	result, err := cache.db.Exec(`INSERT INTO usage_cached_sessions(
 		session_id, source_sync_marker, source_transcript_rev,
-		usage_event_fingerprint, install_revision, fact_count
-	) VALUES ('s1', 'm1', 'r1', 'e1', 1, 1)`)
+		usage_event_fingerprint, install_revision
+	) VALUES ('s1', 'm1', 'r1', 'e1', 1)`)
 	require.NoError(t, err)
 	cachedSessionID, err := result.LastInsertId()
 	require.NoError(t, err)
@@ -326,7 +348,7 @@ func TestUsageCacheLifecycleFollowsArchiveReopenAndClose(t *testing.T) {
 	require.NoError(t, database.Reopen())
 	select {
 	case <-started:
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("reopen backfill did not notify lifecycle observer")
 	}
 	require.NoError(t, first.db.Ping(), "reopen must preserve active cache readers")
@@ -348,6 +370,32 @@ func TestUsageCacheLifecycleFollowsArchiveReopenAndClose(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, readOnlyCache.temporary)
 	require.NoError(t, readOnly.Close())
+}
+
+func TestUsageCacheReopenRetiresMismatchedGeneration(t *testing.T) {
+	database := testDB(t)
+	originalID, err := database.GetDatabaseID(t.Context())
+	require.NoError(t, err)
+	original, err := database.usageCache.Generation(t.Context(), originalID)
+	require.NoError(t, err)
+	require.NotNil(t, original.fill)
+	originalDone := original.fill.done
+
+	const replacementID = "replacement-database-id"
+	_, err = database.getWriter().Exec(`UPDATE archive_metadata SET value = ?
+		WHERE key = ?`, replacementID, archiveMetadataDatabaseIDKey)
+	require.NoError(t, err)
+	require.NoError(t, database.Reopen())
+
+	select {
+	case <-originalDone:
+	default:
+		t.Fatal("reopen left the mismatched usage fill coordinator running")
+	}
+	require.Error(t, original.db.Ping())
+	replacement, err := database.usageCache.Generation(t.Context(), replacementID)
+	require.NoError(t, err)
+	require.NotSame(t, original, replacement)
 }
 
 func readUsageCacheMetadata(t *testing.T, conn *sql.DB) map[string]string {

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/export"
 )
 
 func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
@@ -430,6 +432,126 @@ func TestUsageCacheRetirementWaitsForActiveGeneration(t *testing.T) {
 	require.Error(t, cache.db.PingContext(t.Context()))
 	_, _, err = database.usageCache.acquireGeneration(t.Context(), databaseID)
 	require.ErrorIs(t, err, errUsageCacheSourceChanged)
+}
+
+func TestUsageCacheRetirementWaitsForDetachedFill(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "detached-fill", "project")
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "detached-fill", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T09:00:00Z", Model: "model",
+		TokenUsage: []byte(`{"input_tokens":1}`),
+	}}))
+	snapshot, err := database.captureUsageQuery(
+		t.Context(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, releaseGeneration, err := database.usageCache.acquireGeneration(
+		t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	releaseWork := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseDetachedWork := func() {
+		releaseOnce.Do(func() { close(releaseWork) })
+	}
+	t.Cleanup(releaseDetachedWork)
+	cache.fill.observer.beforeExtract = func([]usageSourceVersion) {
+		close(started)
+		<-releaseWork
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	fillDone := make(chan error, 1)
+	go func() {
+		_, fillErr := cache.fill.Ensure(ctx, snapshot.Versions, 0)
+		fillDone <- fillErr
+	}()
+	<-started
+	assert.Equal(t, 2, usageCacheActiveUsers(cache),
+		"the caller and detached fill must each pin the generation")
+
+	cancel()
+	require.ErrorIs(t, <-fillDone, context.Canceled)
+	releaseGeneration()
+	assert.Equal(t, 1, usageCacheActiveUsers(cache),
+		"caller cancellation must leave the detached fill pinned")
+
+	retireDone := make(chan error, 1)
+	go func() {
+		retireDone <- database.usageCache.RetireExcept("replacement-database-id")
+	}()
+	<-cache.fill.ctx.Done()
+	select {
+	case <-cache.retired:
+		assert.Fail(t, "retirement ignored detached fill")
+	default:
+	}
+	require.NoError(t, cache.db.PingContext(t.Context()))
+	releaseDetachedWork()
+	require.NoError(t, <-retireDone)
+	require.Error(t, cache.db.PingContext(t.Context()))
+}
+
+func TestUsageCacheRetirementWaitsForDetachedRollup(t *testing.T) {
+	database := testDB(t)
+	databaseID, err := database.GetDatabaseID(t.Context())
+	require.NoError(t, err)
+	cache, releaseGeneration, err := database.usageCache.acquireGeneration(
+		t.Context(), databaseID)
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	releaseWork := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseDetachedWork := func() {
+		releaseOnce.Do(func() { close(releaseWork) })
+	}
+	t.Cleanup(releaseDetachedWork)
+	cache.rollup.observer.beforeEnsure = func() {
+		close(started)
+		<-releaseWork
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	rollupDone := make(chan error, 1)
+	go func() {
+		_, _, rollupErr := cache.rollup.Ensure(
+			ctx,
+			usageQuerySnapshot{DatabaseID: databaseID, location: time.UTC},
+			nil,
+			export.NewPricingResolver(nil),
+		)
+		rollupDone <- rollupErr
+	}()
+	<-started
+	assert.Equal(t, 2, usageCacheActiveUsers(cache),
+		"the caller and detached rollup must each pin the generation")
+
+	cancel()
+	require.ErrorIs(t, <-rollupDone, context.Canceled)
+	releaseGeneration()
+	assert.Equal(t, 1, usageCacheActiveUsers(cache),
+		"caller cancellation must leave the detached rollup pinned")
+
+	retireDone := make(chan error, 1)
+	go func() {
+		retireDone <- database.usageCache.RetireExcept("replacement-database-id")
+	}()
+	<-cache.rollup.ctx.Done()
+	select {
+	case <-cache.retired:
+		assert.Fail(t, "retirement ignored detached rollup")
+	default:
+	}
+	require.NoError(t, cache.db.PingContext(t.Context()))
+	releaseDetachedWork()
+	require.NoError(t, <-retireDone)
+	require.Error(t, cache.db.PingContext(t.Context()))
+}
+
+func usageCacheActiveUsers(cache *usageCache) int {
+	cache.lifecycleMu.Lock()
+	defer cache.lifecycleMu.Unlock()
+	return cache.users
 }
 
 func readUsageCacheMetadata(t *testing.T, conn *sql.DB) map[string]string {

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -25,7 +25,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cache.temporary)
 	assert.Equal(t, filepath.Join(filepath.Dir(archivePath),
-		"usage-cache-v8-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
+		"usage-cache-v1-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
 
 	info, err := os.Stat(cache.path)
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 
 	metadata := readUsageCacheMetadata(t, cache.db)
 	assert.Equal(t, "agentsview-usage-facts", metadata[usageCacheMetadataKind])
-	assert.Equal(t, "8", metadata[usageCacheMetadataFormatVersion])
+	assert.Equal(t, "1", metadata[usageCacheMetadataFormatVersion])
 	assert.Equal(t, "database-id-one", metadata[usageCacheMetadataSourceDatabaseID])
 	assert.Equal(t, "1", metadata[usageCacheMetadataNextInstallRevision])
 	assert.Equal(t, "1", metadata[usageCacheMetadataNextRollupRevision])

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -346,6 +346,15 @@ func TestUsageCacheLifecycleFollowsArchiveReopenAndClose(t *testing.T) {
 	require.NoError(t, first.db.Ping())
 	started := make(chan struct{}, 1)
 	database.SetUsageCacheBackfillStarted(func() { started <- struct{}{} })
+	// Reopen restarts backfill only after the daemon lifecycle
+	// explicitly enabled it.
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	select {
+	case <-started:
+	case <-time.After(30 * time.Second):
+		t.Fatal("explicit backfill start did not notify lifecycle observer")
+	}
 
 	require.NoError(t, database.Reopen())
 	select {

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -398,6 +398,40 @@ func TestUsageCacheReopenRetiresMismatchedGeneration(t *testing.T) {
 	require.NotSame(t, original, replacement)
 }
 
+func TestUsageCacheRetirementWaitsForActiveGeneration(t *testing.T) {
+	database := testDB(t)
+	databaseID, err := database.GetDatabaseID(t.Context())
+	require.NoError(t, err)
+	cache, release, err := database.usageCache.acquireGeneration(
+		t.Context(), databaseID)
+	require.NoError(t, err)
+	fill, rollup := cache.fill, cache.rollup
+
+	retired := make(chan error, 1)
+	go func() {
+		retired <- database.usageCache.RetireExcept("replacement-database-id")
+	}()
+	select {
+	case <-fill.ctx.Done():
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "generation retirement did not cancel background work")
+	}
+	select {
+	case err := <-retired:
+		require.FailNow(t, "retirement closed an actively pinned generation", "%v", err)
+	default:
+	}
+	assert.Same(t, fill, cache.fill)
+	assert.Same(t, rollup, cache.rollup)
+	require.NoError(t, cache.db.PingContext(t.Context()))
+
+	release()
+	require.NoError(t, <-retired)
+	require.Error(t, cache.db.PingContext(t.Context()))
+	_, _, err = database.usageCache.acquireGeneration(t.Context(), databaseID)
+	require.ErrorIs(t, err, errUsageCacheSourceChanged)
+}
+
 func readUsageCacheMetadata(t *testing.T, conn *sql.DB) map[string]string {
 	t.Helper()
 	rows, err := conn.Query(`SELECT key, value FROM usage_cache_metadata`)

--- a/internal/db/usage_covering_index_test.go
+++ b/internal/db/usage_covering_index_test.go
@@ -3,10 +3,75 @@ package db
 import (
 	"database/sql"
 	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestUsageCoveringIndexColumns(t *testing.T) {
+	database := testDB(t)
+
+	rows, err := database.getReader().Query(
+		`SELECT name FROM pragma_index_info('idx_messages_usage_covering')
+		 ORDER BY seqno`,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		got = append(got, name)
+	}
+	require.NoError(t, rows.Err())
+
+	want := []string{
+		"timestamp", "session_id", "ordinal", "role", "model",
+		"claude_message_id", "claude_request_id", "token_usage", "source_uuid",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestUsageCoveringIndexConcurrentRepair(t *testing.T) {
+	database := testDB(t)
+	_, err := database.getWriter().Exec(`
+		DROP INDEX idx_messages_usage_covering;
+		CREATE INDEX idx_messages_usage_covering
+		ON messages(timestamp, session_id, ordinal, model)
+		WHERE token_usage != '' AND model != '' AND model != '<synthetic>'`)
+	require.NoError(t, err)
+	database.writer.Load().SetMaxOpenConns(2)
+	start := make(chan struct{})
+	errors := make(chan error, 2)
+	var wait sync.WaitGroup
+	for range 2 {
+		wait.Go(func() {
+			<-start
+			errors <- ensureUsageCoveringIndexLocked(database.getWriter())
+		})
+	}
+	close(start)
+	wait.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+	rows, err := database.getReader().Query(
+		`SELECT name FROM pragma_index_info('idx_messages_usage_covering')
+		 ORDER BY seqno`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var columns []string
+	for rows.Next() {
+		var column string
+		require.NoError(t, rows.Scan(&column))
+		columns = append(columns, column)
+	}
+	assert.Equal(t, usageCoveringIndexColumns, columns)
+}
 
 func TestUsageIndexesMigration(t *testing.T) {
 	dir := t.TempDir()
@@ -19,13 +84,19 @@ func TestUsageIndexesMigration(t *testing.T) {
 
 	requireIndexPresence(t, path, "idx_messages_usage_covering", 1)
 	requireIndexPresence(t, path, "idx_messages_claude_snapshot", 1)
-	requireIndexPresence(t, path, "idx_messages_activity_timestamp", 0)
+	requireIndexPresence(t, path, "idx_messages_activity_timestamp", 1)
+	requireIndexPresence(t, path, "idx_messages_usage_session_covering", 1)
 	requireIndexPresence(t, path, "idx_messages_usage_timestamp", 0)
 
 	conn, err := sql.Open("sqlite3", path)
 	requireNoError(t, err, "raw open")
 	_, err = conn.Exec(`DROP INDEX IF EXISTS idx_messages_usage_covering`)
 	requireNoError(t, err, "drop covering index")
+	_, err = conn.Exec(`CREATE INDEX idx_messages_usage_covering
+		ON messages(timestamp, session_id, ordinal, model,
+		            claude_message_id, claude_request_id, token_usage)
+		WHERE token_usage != '' AND model != '' AND model != '<synthetic>'`)
+	requireNoError(t, err, "recreate stale covering index")
 	_, err = conn.Exec(`DROP INDEX IF EXISTS idx_messages_claude_snapshot`)
 	requireNoError(t, err, "drop Claude snapshot index")
 	_, err = conn.Exec(`CREATE INDEX idx_messages_usage_timestamp
@@ -40,8 +111,27 @@ func TestUsageIndexesMigration(t *testing.T) {
 
 	requireIndexPresence(t, path, "idx_messages_usage_covering", 1)
 	requireIndexPresence(t, path, "idx_messages_claude_snapshot", 1)
-	requireIndexPresence(t, path, "idx_messages_activity_timestamp", 0)
+	requireIndexPresence(t, path, "idx_messages_activity_timestamp", 1)
+	requireIndexPresence(t, path, "idx_messages_usage_session_covering", 1)
 	requireIndexPresence(t, path, "idx_messages_usage_timestamp", 0)
+
+	rows, err := d.getReader().Query(
+		`SELECT name FROM pragma_index_info('idx_messages_usage_covering')
+		 ORDER BY seqno`,
+	)
+	requireNoError(t, err, "read migrated covering columns")
+	defer rows.Close()
+	var columns []string
+	for rows.Next() {
+		var name string
+		requireNoError(t, rows.Scan(&name), "scan migrated covering column")
+		columns = append(columns, name)
+	}
+	requireNoError(t, rows.Err(), "iterate migrated covering columns")
+	require.Equal(t, []string{
+		"timestamp", "session_id", "ordinal", "role", "model",
+		"claude_message_id", "claude_request_id", "token_usage", "source_uuid",
+	}, columns)
 
 	var sessions int
 	row := d.reader.Load().QueryRow(`SELECT count(*) FROM sessions`)

--- a/internal/db/usage_covering_index_test.go
+++ b/internal/db/usage_covering_index_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUsageCoveringIndexColumns(t *testing.T) {
+func TestUsageSessionCoveringIndexColumns(t *testing.T) {
 	database := testDB(t)
 
 	rows, err := database.getReader().Query(
-		`SELECT name FROM pragma_index_info('idx_messages_usage_covering')
+		`SELECT name FROM pragma_index_info('idx_messages_usage_session_covering')
 		 ORDER BY seqno`,
 	)
 	require.NoError(t, err)
@@ -29,18 +29,18 @@ func TestUsageCoveringIndexColumns(t *testing.T) {
 	require.NoError(t, rows.Err())
 
 	want := []string{
-		"timestamp", "session_id", "ordinal", "role", "model",
+		"session_id", "ordinal", "timestamp", "role", "model",
 		"claude_message_id", "claude_request_id", "token_usage", "source_uuid",
 	}
 	assert.Equal(t, want, got)
 }
 
-func TestUsageCoveringIndexConcurrentRepair(t *testing.T) {
+func TestUsageIndexesConcurrentRepair(t *testing.T) {
 	database := testDB(t)
 	_, err := database.getWriter().Exec(`
-		DROP INDEX idx_messages_usage_covering;
-		CREATE INDEX idx_messages_usage_covering
-		ON messages(timestamp, session_id, ordinal, model)
+		DROP INDEX idx_messages_usage_session_covering;
+		CREATE INDEX idx_messages_usage_session_covering
+		ON messages(session_id, ordinal, timestamp, model)
 		WHERE token_usage != '' AND model != '' AND model != '<synthetic>'`)
 	require.NoError(t, err)
 	database.writer.Load().SetMaxOpenConns(2)
@@ -50,7 +50,7 @@ func TestUsageCoveringIndexConcurrentRepair(t *testing.T) {
 	for range 2 {
 		wait.Go(func() {
 			<-start
-			errors <- ensureUsageCoveringIndexLocked(database.getWriter())
+			errors <- ensureUsageIndexesLocked(database.getWriter())
 		})
 	}
 	close(start)
@@ -60,7 +60,7 @@ func TestUsageCoveringIndexConcurrentRepair(t *testing.T) {
 		require.NoError(t, err)
 	}
 	rows, err := database.getReader().Query(
-		`SELECT name FROM pragma_index_info('idx_messages_usage_covering')
+		`SELECT name FROM pragma_index_info('idx_messages_usage_session_covering')
 		 ORDER BY seqno`)
 	require.NoError(t, err)
 	defer rows.Close()
@@ -70,7 +70,7 @@ func TestUsageCoveringIndexConcurrentRepair(t *testing.T) {
 		require.NoError(t, rows.Scan(&column))
 		columns = append(columns, column)
 	}
-	assert.Equal(t, usageCoveringIndexColumns, columns)
+	assert.Equal(t, usageSessionCoveringIndexColumns, columns)
 }
 
 func TestUsageIndexesMigration(t *testing.T) {
@@ -82,11 +82,11 @@ func TestUsageIndexesMigration(t *testing.T) {
 	insertSession(t, d, "s1", "proj")
 	d.Close()
 
-	requireIndexPresence(t, path, "idx_messages_usage_covering", 1)
+	requireIndexPresence(t, path, "idx_messages_usage_covering", 0)
 	requireIndexPresence(t, path, "idx_messages_claude_snapshot", 1)
 	requireIndexPresence(t, path, "idx_messages_activity_timestamp", 1)
 	requireIndexPresence(t, path, "idx_messages_usage_session_covering", 1)
-	requireIndexPresence(t, path, "idx_messages_usage_timestamp", 0)
+	requireIndexPresence(t, path, "idx_messages_usage_timestamp", 1)
 
 	conn, err := sql.Open("sqlite3", path)
 	requireNoError(t, err, "raw open")
@@ -99,6 +99,8 @@ func TestUsageIndexesMigration(t *testing.T) {
 	requireNoError(t, err, "recreate stale covering index")
 	_, err = conn.Exec(`DROP INDEX IF EXISTS idx_messages_claude_snapshot`)
 	requireNoError(t, err, "drop Claude snapshot index")
+	_, err = conn.Exec(`DROP INDEX IF EXISTS idx_messages_usage_timestamp`)
+	requireNoError(t, err, "drop current timestamp index")
 	_, err = conn.Exec(`CREATE INDEX idx_messages_usage_timestamp
 		ON messages(timestamp, session_id, ordinal)
 		WHERE token_usage != '' AND model != '' AND model != '<synthetic>'`)
@@ -109,14 +111,14 @@ func TestUsageIndexesMigration(t *testing.T) {
 	requireNoError(t, err, "reopen")
 	defer d.Close()
 
-	requireIndexPresence(t, path, "idx_messages_usage_covering", 1)
+	requireIndexPresence(t, path, "idx_messages_usage_covering", 0)
 	requireIndexPresence(t, path, "idx_messages_claude_snapshot", 1)
 	requireIndexPresence(t, path, "idx_messages_activity_timestamp", 1)
 	requireIndexPresence(t, path, "idx_messages_usage_session_covering", 1)
-	requireIndexPresence(t, path, "idx_messages_usage_timestamp", 0)
+	requireIndexPresence(t, path, "idx_messages_usage_timestamp", 1)
 
 	rows, err := d.getReader().Query(
-		`SELECT name FROM pragma_index_info('idx_messages_usage_covering')
+		`SELECT name FROM pragma_index_info('idx_messages_usage_session_covering')
 		 ORDER BY seqno`,
 	)
 	requireNoError(t, err, "read migrated covering columns")
@@ -129,7 +131,7 @@ func TestUsageIndexesMigration(t *testing.T) {
 	}
 	requireNoError(t, rows.Err(), "iterate migrated covering columns")
 	require.Equal(t, []string{
-		"timestamp", "session_id", "ordinal", "role", "model",
+		"session_id", "ordinal", "timestamp", "role", "model",
 		"claude_message_id", "claude_request_id", "token_usage", "source_uuid",
 	}, columns)
 

--- a/internal/db/usage_covering_index_test.go
+++ b/internal/db/usage_covering_index_test.go
@@ -105,6 +105,12 @@ func TestUsageIndexesMigration(t *testing.T) {
 		ON messages(timestamp, session_id, ordinal)
 		WHERE token_usage != '' AND model != '' AND model != '<synthetic>'`)
 	requireNoError(t, err, "recreate legacy index")
+	_, err = conn.Exec(`DROP INDEX IF EXISTS idx_messages_activity_timestamp`)
+	requireNoError(t, err, "drop current activity index")
+	_, err = conn.Exec(`CREATE INDEX idx_messages_activity_timestamp
+		ON messages(timestamp, session_id, ordinal)
+		WHERE role = 'assistant' AND model != '<synthetic>'`)
+	requireNoError(t, err, "recreate stale activity index")
 	conn.Close()
 
 	d, err = Open(path)
@@ -134,11 +140,29 @@ func TestUsageIndexesMigration(t *testing.T) {
 		"session_id", "ordinal", "timestamp", "role", "model",
 		"claude_message_id", "claude_request_id", "token_usage", "source_uuid",
 	}, columns)
+	assertUsageIndexColumns(t, d, "idx_messages_activity_timestamp",
+		[]string{"timestamp", "session_id", "ordinal", "model"})
 
 	var sessions int
 	row := d.reader.Load().QueryRow(`SELECT count(*) FROM sessions`)
 	requireNoError(t, row.Scan(&sessions), "count sessions")
 	require.Equal(t, 1, sessions, "session row must survive migration")
+}
+
+func assertUsageIndexColumns(t *testing.T, d *DB, index string, want []string) {
+	t.Helper()
+	rows, err := d.getReader().Query(
+		`SELECT name FROM pragma_index_info(?) ORDER BY seqno`, index)
+	requireNoError(t, err, "read index columns")
+	defer rows.Close()
+	var got []string
+	for rows.Next() {
+		var name string
+		requireNoError(t, rows.Scan(&name), "scan index column")
+		got = append(got, name)
+	}
+	requireNoError(t, rows.Err(), "iterate index columns")
+	require.Equal(t, want, got, "index %s columns", index)
 }
 
 func requireIndexPresence(t *testing.T, path, name string, want int) {

--- a/internal/db/usage_covering_index_test.go
+++ b/internal/db/usage_covering_index_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"encoding/json"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -147,6 +148,62 @@ func TestUsageIndexesMigration(t *testing.T) {
 	row := d.reader.Load().QueryRow(`SELECT count(*) FROM sessions`)
 	requireNoError(t, row.Scan(&sessions), "count sessions")
 	require.Equal(t, 1, sessions, "session row must survive migration")
+}
+
+func TestDropAndRebuildUsageMessageIndexes(t *testing.T) {
+	database := testDB(t)
+	usageIndexes := []string{
+		"idx_messages_usage_timestamp",
+		"idx_messages_usage_session_covering",
+		"idx_messages_activity_timestamp",
+	}
+	countIndex := func(name string) int {
+		var got int
+		require.NoError(t, database.getReader().QueryRow(
+			`SELECT count(*) FROM sqlite_master
+			 WHERE type = 'index' AND name = ?`, name,
+		).Scan(&got), "query sqlite_master for %s", name)
+		return got
+	}
+	for _, name := range usageIndexes {
+		require.Equal(t, 1, countIndex(name), "index %s before drop", name)
+	}
+
+	require.NoError(t, database.DropUsageMessageIndexes())
+	for _, name := range usageIndexes {
+		assert.Equal(t, 0, countIndex(name), "index %s after drop", name)
+	}
+
+	insertSession(t, database, "s1", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:30:00Z")
+	})
+	insertMessages(t, database, Message{
+		SessionID:  "s1",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "x",
+		Timestamp:  "2026-06-16T10:30:00Z",
+		Model:      "claude-sonnet-4-20250514",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	require.NoError(t, database.RebuildUsageMessageIndexes())
+	for _, name := range usageIndexes {
+		assert.Equal(t, 1, countIndex(name), "index %s after rebuild", name)
+	}
+	assertUsageIndexColumns(t, database,
+		"idx_messages_usage_session_covering", usageSessionCoveringIndexColumns)
+
+	var indexed int
+	require.NoError(t, database.getReader().QueryRow(
+		`SELECT count(*) FROM messages
+		 INDEXED BY idx_messages_usage_session_covering
+		 WHERE session_id = 's1'
+		   AND token_usage != '' AND model != '' AND model != '<synthetic>'`,
+	).Scan(&indexed), "count via rebuilt covering index")
+	assert.Equal(t, 1, indexed,
+		"row inserted while dropped must be served by the rebuilt index")
 }
 
 func assertUsageIndexColumns(t *testing.T, d *DB, index string, want []string) {

--- a/internal/db/usage_events.go
+++ b/internal/db/usage_events.go
@@ -80,7 +80,11 @@ func (db *DB) ReplaceSessionUsageEvents(
 		return err
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	db.notifyUsageSessions([]string{sessionID})
+	return nil
 }
 
 func replaceSessionUsageEventsTx(
@@ -164,6 +168,14 @@ func replaceSessionUsageEventsTx(
 func (db *DB) UsageEventFingerprints(
 	sessionIDs []string,
 ) (map[string]string, error) {
+	return usageEventFingerprintsWithQuerier(
+		context.Background(), db.getReader(), sessionIDs,
+	)
+}
+
+func usageEventFingerprintsWithQuerier(
+	ctx context.Context, q messageRowsQuerier, sessionIDs []string,
+) (map[string]string, error) {
 	out := make(map[string]string, len(sessionIDs))
 	if len(sessionIDs) == 0 {
 		return out, nil
@@ -175,8 +187,8 @@ func (db *DB) UsageEventFingerprints(
 	const batchSize = 900
 	for start := 0; start < len(sessionIDs); start += batchSize {
 		end := min(start+batchSize, len(sessionIDs))
-		if err := db.appendUsageEventFingerprints(
-			out, sessionIDs[start:end],
+		if err := appendUsageEventFingerprints(
+			ctx, q, out, sessionIDs[start:end],
 		); err != nil {
 			return nil, err
 		}
@@ -184,7 +196,8 @@ func (db *DB) UsageEventFingerprints(
 	return out, nil
 }
 
-func (db *DB) appendUsageEventFingerprints(
+func appendUsageEventFingerprints(
+	ctx context.Context, q messageRowsQuerier,
 	out map[string]string, sessionIDs []string,
 ) error {
 	placeholders := make([]string, len(sessionIDs))
@@ -193,7 +206,7 @@ func (db *DB) appendUsageEventFingerprints(
 		placeholders[i] = "?"
 		args[i] = id
 	}
-	rows, err := db.getReader().Query(`
+	rows, err := q.QueryContext(ctx, `
 		SELECT session_id, message_ordinal, source, model,
 			input_tokens, output_tokens,
 			cache_creation_input_tokens, cache_read_input_tokens,

--- a/internal/db/usage_legacy_test.go
+++ b/internal/db/usage_legacy_test.go
@@ -1,0 +1,62 @@
+//go:build fts5
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDailyUsageFactsMatchesLegacy(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter UsageFilter
+	}{
+		{name: "one day", filter: UsageFilter{
+			From: "2024-06-15", To: "2024-06-15", Timezone: "UTC",
+		}},
+		{name: "seven days", filter: UsageFilter{
+			From: "2024-06-09", To: "2024-06-15", Timezone: "UTC",
+		}},
+		{name: "thirty days", filter: UsageFilter{
+			From: "2024-05-17", To: "2024-06-15", Timezone: "UTC",
+		}},
+		{name: "all history", filter: UsageFilter{Timezone: "UTC"}},
+		{name: "breakdowns", filter: UsageFilter{
+			From: "2024-06-01", To: "2024-07-31", Timezone: "UTC",
+			Breakdowns: true,
+		}},
+		{name: "project", filter: UsageFilter{
+			From: "2024-06-01", To: "2024-07-31", Timezone: "UTC",
+			Project: "proj-a",
+		}},
+		{name: "model", filter: UsageFilter{
+			From: "2024-06-01", To: "2024-07-31", Timezone: "UTC",
+			Model: "gpt-5",
+		}},
+		{name: "skip counts", filter: UsageFilter{
+			From: "2024-06-01", To: "2024-07-31", Timezone: "UTC",
+			SkipSessionCounts: true,
+		}},
+		{name: "empty", filter: UsageFilter{
+			From: "2025-01-01", To: "2025-01-07", Timezone: "UTC",
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			database := openDailyUsageFixtureDB(t)
+			legacy, err := database.getDailyUsageLegacy(
+				context.Background(), test.filter,
+			)
+			require.NoError(t, err)
+			facts, err := database.GetDailyUsage(
+				context.Background(), test.filter,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, legacy, facts)
+		})
+	}
+}

--- a/internal/db/usage_perf_test.go
+++ b/internal/db/usage_perf_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -19,7 +20,7 @@ import (
 // TestRealDBUsagePayload measures the JSON payload the dashboard must
 // serialize, transfer, parse, and render — the cost query timing hides.
 //
-//	REAL_DB=/Users/wesm/.agentsview/sessions.db \
+//	REAL_DB=/path/to/protected/sessions.db \
 //	  CGO_ENABLED=1 go test -tags fts5 -run TestRealDBUsagePayload \
 //	  -v -timeout 600s ./internal/db/
 func TestRealDBUsagePayload(t *testing.T) {
@@ -35,6 +36,9 @@ func TestRealDBUsagePayload(t *testing.T) {
 	defer reader.Close()
 	d := &DB{path: path}
 	d.reader.Store(reader)
+	d.usageCache = newUsageCacheManager(filepath.Join(t.TempDir(), "sessions.db"))
+	d.usageCache.attachArchive(d)
+	defer d.usageCache.Close()
 	ctx := context.Background()
 	tz := "America/New_York"
 
@@ -75,7 +79,7 @@ func TestRealDBUsagePayload(t *testing.T) {
 // TestRealDBUsagePerf times every query the usage dashboard triggers,
 // against a real prod DB. Gated behind REAL_DB so it never runs in CI.
 //
-//	REAL_DB=/Users/wesm/.agentsview/sessions.db \
+//	REAL_DB=/path/to/protected/sessions.db \
 //	  CGO_ENABLED=1 go test -tags fts5 -run TestRealDBUsagePerf \
 //	  -v -timeout 1200s ./internal/db/
 func TestRealDBUsagePerf(t *testing.T) {
@@ -95,12 +99,14 @@ func TestRealDBUsagePerf(t *testing.T) {
 
 	d := &DB{path: path}
 	d.reader.Store(reader)
+	d.usageCache = newUsageCacheManager(filepath.Join(t.TempDir(), "sessions.db"))
+	d.usageCache.attachArchive(d)
+	defer d.usageCache.Close()
 	ctx := context.Background()
 	tz := "America/New_York"
 
 	walActive := fileExists(path + "-wal")
-	t.Logf("DB=%s  reader_pool=4  wal_active=%v (writes in flight inflate reads)",
-		path, walActive)
+	t.Logf("DB=protected-clone  reader_pool=4  wal_active=%v", walActive)
 
 	allHist := UsageFilter{From: "2000-01-01", To: "2035-01-01", Timezone: tz}
 	win30 := UsageFilter{
@@ -218,6 +224,111 @@ func TestRealDBUsagePerf(t *testing.T) {
 		},
 		func() error { _, e := d.GetTopSessionsByCost(ctx, allHist, 20); return e },
 	})
+}
+
+// TestRealDBUsageRollupOracle compares the rollup path with the legacy wide-row
+// implementation on a protected archive clone. It never opens the archive for
+// writing, and its cache generation always lives in the test's temporary
+// directory.
+//
+//	REAL_DB=/path/to/protected/sessions.db \
+//	  CGO_ENABLED=1 go test -tags fts5 -run TestRealDBUsageRollupOracle \
+//	  -v -timeout 1200s ./internal/db/
+func TestRealDBUsageRollupOracle(t *testing.T) {
+	path := os.Getenv("REAL_DB")
+	if path == "" {
+		t.Skip("set REAL_DB to a protected sessions.db clone")
+	}
+	reader, err := sql.Open(sqliteUsageDriverName, makeDSN(path, true))
+	require.NoError(t, err, "open protected reader")
+	reader.SetMaxOpenConns(4)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+	database := &DB{path: path}
+	database.reader.Store(reader)
+	database.usageCache = newUsageCacheManager(
+		filepath.Join(t.TempDir(), "sessions.db"))
+	database.usageCache.attachArchive(database)
+	t.Cleanup(func() { require.NoError(t, database.usageCache.Close()) })
+
+	now := time.Now()
+	filters := []struct {
+		name   string
+		filter UsageFilter
+	}{
+		{
+			"7d", UsageFilter{
+				From: now.AddDate(0, 0, -6).Format("2006-01-02"),
+				To:   now.Format("2006-01-02"), Timezone: "America/New_York",
+				Breakdowns: true,
+			}},
+		{
+			"30d", UsageFilter{
+				From: now.AddDate(0, 0, -29).Format("2006-01-02"),
+				To:   now.Format("2006-01-02"), Timezone: "America/New_York",
+				Breakdowns: true,
+			}},
+		{"all", UsageFilter{Timezone: "America/New_York", Breakdowns: true}},
+	}
+	ctx := context.Background()
+	for _, test := range filters {
+		t.Run(test.name, func(t *testing.T) {
+			discoveryStart := time.Now()
+			snapshot, captureErr := database.captureUsageQuery(
+				ctx, test.filter, usageQueryKindToken)
+			require.NoError(t, captureErr, "candidate discovery")
+			discoveryElapsed := time.Since(discoveryStart)
+
+			legacyStart := time.Now()
+			legacy, legacyErr := database.getDailyUsageLegacy(ctx, test.filter)
+			require.NoError(t, legacyErr, "legacy usage")
+			legacyElapsed := time.Since(legacyStart)
+
+			cache, cacheErr := database.usageCache.Generation(
+				ctx, snapshot.DatabaseID)
+			require.NoError(t, cacheErr, "open usage cache")
+			clearUsageFactsBenchmarkCache(t, cache)
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+			coldStart := time.Now()
+			rollup, rollupErr := database.GetDailyUsage(ctx, test.filter)
+			require.NoError(t, rollupErr, "rollup usage")
+			coldElapsed := time.Since(coldStart)
+			runtime.ReadMemStats(&after)
+
+			legacyJSON, marshalErr := json.Marshal(legacy)
+			require.NoError(t, marshalErr, "marshal legacy result")
+			rollupJSON, marshalErr := json.Marshal(rollup)
+			require.NoError(t, marshalErr, "marshal rollup result")
+			require.Equal(t, legacyJSON, rollupJSON,
+				"rollup and legacy results must be byte-equivalent")
+
+			warmStart := time.Now()
+			warm, warmErr := database.GetDailyUsage(ctx, test.filter)
+			require.NoError(t, warmErr, "warm rollup usage")
+			warmElapsed := time.Since(warmStart)
+			warmJSON, marshalErr := json.Marshal(warm)
+			require.NoError(t, marshalErr, "marshal warm facts result")
+			require.Equal(t, rollupJSON, warmJSON,
+				"cold and warm rollup results must be byte-equivalent")
+
+			t.Logf(
+				"%s: candidates=%d discovery=%s legacy=%s cold=%s warm=%s cache=%.1fMB alloc=%.1fMB heap-inuse-delta=%.1fMB",
+				test.name, len(snapshot.Sessions), round(discoveryElapsed),
+				round(legacyElapsed), round(coldElapsed), round(warmElapsed),
+				float64(usageCacheDiskBytes(cache.path))/(1<<20),
+				float64(after.TotalAlloc-before.TotalAlloc)/(1<<20),
+				float64(signedUint64Delta(after.HeapInuse, before.HeapInuse))/(1<<20),
+			)
+		})
+	}
+}
+
+func signedUint64Delta(after, before uint64) int64 {
+	if after >= before {
+		return int64(after - before)
+	}
+	return -int64(before - after)
 }
 
 func TestDumpSidebarJSONRejectsDBAndSidecars(t *testing.T) {

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -1,0 +1,624 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+const usageRollupCursorSessionID = "\x00cursor"
+
+type usageTimezoneIdentity struct {
+	Key, Name, IntervalFingerprint string
+}
+
+type usageRollupInstall struct {
+	ID, FactRevision, InstallRevision int64
+	SessionID, CachedAt, PricingHash  string
+}
+
+type usageRollupMetrics struct {
+	DailyRows, ExceptionGroups, ExceptionRows int64
+	BuildDuration, InstallDuration            time.Duration
+}
+
+func usageTimezoneIdentityFor(
+	location *time.Location, _ []usageQueryInterval,
+) usageTimezoneIdentity {
+	if location == nil {
+		location = time.Local
+	}
+	name := usageLocationName(location)
+	digest := sha256.New()
+	writeUsageHashString(digest, name)
+	// Anonymous process-local locations need a stable identity independent of
+	// the requested window. Weekly probes cover historical and near-future rule
+	// transitions without relying on a platform-specific zoneinfo path.
+	for day := time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC); day.Year() <= 2100; day = day.AddDate(0, 0, 7) {
+		zone, offset := day.In(location).Zone()
+		writeUsageHashString(digest, zone)
+		writeUsageHashInt64(digest, int64(offset))
+	}
+	fingerprint := hex.EncodeToString(digest.Sum(nil))
+	key := name
+	if key == "" || key == "Local" {
+		key = "local:" + fingerprint
+	}
+	return usageTimezoneIdentity{Key: key, Name: name, IntervalFingerprint: fingerprint}
+}
+
+func usageLocationName(location *time.Location) string {
+	name := location.String()
+	if location != time.Local || (name != "" && name != "Local") {
+		return name
+	}
+	resolved, err := filepath.EvalSymlinks("/etc/localtime")
+	if err != nil {
+		return name
+	}
+	normalized := filepath.ToSlash(resolved)
+	const marker = "/zoneinfo/"
+	index := strings.LastIndex(normalized, marker)
+	if index < 0 {
+		return name
+	}
+	candidate := normalized[index+len(marker):]
+	if _, err := time.LoadLocation(candidate); err != nil {
+		return name
+	}
+	return candidate
+}
+
+func usageRateHash(
+	model, pricedModel, pattern string, ok bool, rates export.ModelRates,
+) string {
+	digest := sha256.New()
+	writeUsageHashString(digest, model)
+	writeUsageHashString(digest, pricedModel)
+	writeUsageHashString(digest, pattern)
+	writeUsageHashBool(digest, ok)
+	writeUsageRatesHash(digest, rates)
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func writeUsageRatesHash(digest hash.Hash, rates export.ModelRates) {
+	writeUsageHashString(digest, string(rates.Source))
+	if rates.UpdatedAt != nil {
+		writeUsageHashString(digest, rates.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	} else {
+		writeUsageHashString(digest, "")
+	}
+	for _, value := range []int64{
+		rates.InputPerMTok.Microdollars, rates.OutputPerMTok.Microdollars,
+		rates.CacheWritePerMTok.Microdollars, rates.CacheReadPerMTok.Microdollars,
+		int64(len(rates.Bands)),
+	} {
+		writeUsageHashInt64(digest, value)
+	}
+	for _, band := range rates.Bands {
+		if band.UpdatedAt != nil {
+			writeUsageHashString(digest, band.UpdatedAt.UTC().Format(time.RFC3339Nano))
+		} else {
+			writeUsageHashString(digest, "")
+		}
+		for _, value := range []int64{
+			int64(band.AboveInputTokens), band.InputPerMTok.Microdollars,
+			band.OutputPerMTok.Microdollars, band.CacheWritePerMTok.Microdollars,
+			band.CacheReadPerMTok.Microdollars,
+		} {
+			writeUsageHashInt64(digest, value)
+		}
+	}
+}
+
+func usageBandRates(rates export.ModelRates) []export.ModelRates {
+	result := make([]export.ModelRates, 0, len(rates.Bands))
+	for _, band := range rates.Bands {
+		result = append(result, export.ModelRates{
+			InputPerMTok: band.InputPerMTok, OutputPerMTok: band.OutputPerMTok,
+			CacheWritePerMTok: band.CacheWritePerMTok,
+			CacheReadPerMTok:  band.CacheReadPerMTok,
+		})
+	}
+	return result
+}
+
+func validateNonnegativeUsageRates(rates export.ModelRates) error {
+	for _, item := range append([]export.ModelRates{rates}, usageBandRates(rates)...) {
+		if item.InputPerMTok.Microdollars < 0 || item.OutputPerMTok.Microdollars < 0 ||
+			item.CacheWritePerMTok.Microdollars < 0 || item.CacheReadPerMTok.Microdollars < 0 {
+			return money.ErrNegative
+		}
+	}
+	return nil
+}
+
+type usageRollupCall struct {
+	done     chan struct{}
+	installs map[string]usageRollupInstall
+	metrics  usageRollupMetrics
+	err      error
+}
+
+type usageRollupCoordinator struct {
+	archive *DB
+	cache   *usageCache
+	ctx     context.Context
+	mu      sync.Mutex
+	calls   map[string]*usageRollupCall
+}
+
+func newUsageRollupCoordinator(
+	ctx context.Context, archive *DB, cache *usageCache,
+) *usageRollupCoordinator {
+	return &usageRollupCoordinator{
+		archive: archive, cache: cache, ctx: ctx,
+		calls: make(map[string]*usageRollupCall),
+	}
+}
+
+func (c *usageRollupCoordinator) Ensure(
+	ctx context.Context, snapshot usageQuerySnapshot,
+	fills map[string]usageFillResult, resolver *export.PricingResolver,
+) (map[string]usageRollupInstall, usageRollupMetrics, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pricingHash, err := export.EffectivePricingDigest(snapshot.PricingRows)
+	if err != nil {
+		return nil, usageRollupMetrics{}, fmt.Errorf("hashing usage pricing: %w", err)
+	}
+	key := usageRollupCallKey(snapshot, fills, pricingHash)
+	c.mu.Lock()
+	call := c.calls[key]
+	if call == nil {
+		call = &usageRollupCall{done: make(chan struct{})}
+		c.calls[key] = call
+		go func() {
+			call.installs, call.metrics, call.err = c.ensureNow(
+				c.ctx, snapshot, fills, resolver, pricingHash)
+			close(call.done)
+			c.mu.Lock()
+			delete(c.calls, key)
+			c.mu.Unlock()
+		}()
+	}
+	c.mu.Unlock()
+	select {
+	case <-ctx.Done():
+		return nil, usageRollupMetrics{}, ctx.Err()
+	case <-call.done:
+		return call.installs, call.metrics, call.err
+	}
+}
+
+func (c *usageRollupCoordinator) ensureNow(
+	ctx context.Context, snapshot usageQuerySnapshot,
+	fills map[string]usageFillResult, resolver *export.PricingResolver,
+	pricingHash string,
+) (map[string]usageRollupInstall, usageRollupMetrics, error) {
+	identity := usageTimezoneIdentityFor(snapshot.location, snapshot.Intervals)
+	conn, err := c.cache.db.Conn(ctx)
+	if err != nil {
+		return nil, usageRollupMetrics{}, err
+	}
+	defer conn.Close()
+	installs, stale, err := readUsageRollupInstalls(
+		ctx, conn, identity, snapshot, fills, pricingHash)
+	if err != nil || len(stale) == 0 {
+		cursorCurrent := installs[usageRollupCursorSessionID].FactRevision >=
+			snapshot.CursorHighWater
+		if err != nil || cursorCurrent {
+			return installs, usageRollupMetrics{}, err
+		}
+	}
+	staleSessions := make(map[string]usageQuerySession, len(stale))
+	staleVersions := make(map[string]usageSourceVersion, len(stale))
+	staleFills := make(map[string]usageFillResult, len(stale))
+	for _, session := range snapshot.Sessions {
+		if stale[session.ID] {
+			staleSessions[session.ID] = session
+		}
+	}
+	for _, version := range snapshot.Versions {
+		if stale[version.SessionID] {
+			staleVersions[version.SessionID] = version
+			staleFills[version.SessionID] = fills[version.SessionID]
+		}
+	}
+	started := time.Now()
+	facts, err := loadUsageRollupFacts(ctx, conn, staleSessions)
+	if err != nil {
+		return nil, usageRollupMetrics{}, err
+	}
+	builds, err := buildUsageRollupSessions(
+		facts, staleSessions, staleVersions, staleFills, snapshot.location,
+		resolver, pricingHash)
+	if err != nil {
+		return nil, usageRollupMetrics{}, err
+	}
+	if installs[usageRollupCursorSessionID].FactRevision < snapshot.CursorHighWater {
+		cursorBuild, cursorErr := loadCursorUsageRollupBuild(
+			ctx, conn, snapshot.CursorHighWater, snapshot.location, pricingHash)
+		if cursorErr != nil {
+			return nil, usageRollupMetrics{}, cursorErr
+		}
+		builds = append(builds, cursorBuild)
+	}
+	metrics := usageRollupMetrics{BuildDuration: time.Since(started)}
+	for _, build := range builds {
+		metrics.DailyRows += int64(len(build.Daily))
+		metrics.ExceptionRows += int64(len(build.Exceptions))
+		groups := make(map[string]bool)
+		for _, row := range build.Exceptions {
+			groups[row.GroupKind+"\x00"+row.GroupKey] = true
+		}
+		metrics.ExceptionGroups += int64(len(groups))
+	}
+	if err := c.recheck(ctx, staleVersions, staleSessions); err != nil {
+		return nil, metrics, err
+	}
+	installStarted := time.Now()
+	if err := installUsageRollupBuilds(ctx, conn, identity, snapshot.location, builds); err != nil {
+		return nil, metrics, err
+	}
+	metrics.InstallDuration = time.Since(installStarted)
+	installs, stale, err = readUsageRollupInstalls(
+		ctx, conn, identity, snapshot, fills, pricingHash)
+	if err != nil {
+		return nil, metrics, err
+	}
+	if len(stale) != 0 {
+		return nil, metrics, fmt.Errorf("usage rollup install did not verify")
+	}
+	if installs[usageRollupCursorSessionID].FactRevision < snapshot.CursorHighWater {
+		return nil, metrics, fmt.Errorf("Cursor usage rollup install did not verify")
+	}
+	return installs, metrics, nil
+}
+
+func readUsageRollupInstalls(
+	ctx context.Context, conn *sql.Conn, identity usageTimezoneIdentity,
+	snapshot usageQuerySnapshot, fills map[string]usageFillResult,
+	pricingHash string,
+) (map[string]usageRollupInstall, map[string]bool, error) {
+	rows, err := conn.QueryContext(ctx, `SELECT i.id, i.session_id,
+		i.fact_install_revision, i.install_revision, i.cached_at,
+		i.source_sync_marker, i.source_transcript_rev, i.usage_event_fingerprint,
+		i.baked_agent, i.baked_started_at, i.pricing_hash
+		FROM usage_rollup_timezones tz JOIN usage_rollup_installs i
+		  ON i.timezone_id = tz.id WHERE tz.timezone_key = ?`, identity.Key)
+	if err != nil {
+		return nil, nil, err
+	}
+	installs := make(map[string]usageRollupInstall)
+	sources := make(map[string]usageSourceVersion)
+	baked := make(map[string][2]string)
+	pricing := make(map[string]string)
+	for rows.Next() {
+		var item usageRollupInstall
+		var source usageSourceVersion
+		var agent, startedAt, installedPricing string
+		if err := rows.Scan(&item.ID, &item.SessionID, &item.FactRevision,
+			&item.InstallRevision, &item.CachedAt, &source.SyncMarker,
+			&source.TranscriptRevision, &source.UsageEventFingerprint,
+			&agent, &startedAt, &installedPricing); err != nil {
+			_ = rows.Close()
+			return nil, nil, err
+		}
+		source.SessionID = item.SessionID
+		item.PricingHash = installedPricing
+		installs[item.SessionID], sources[item.SessionID] = item, source
+		baked[item.SessionID] = [2]string{agent, startedAt}
+		pricing[item.SessionID] = installedPricing
+	}
+	if err := rows.Close(); err != nil {
+		return nil, nil, err
+	}
+	sessions := make(map[string]usageQuerySession, len(snapshot.Sessions))
+	for _, session := range snapshot.Sessions {
+		sessions[session.ID] = session
+	}
+	stale := make(map[string]bool)
+	for _, version := range snapshot.Versions {
+		fill := fills[version.SessionID]
+		item, ok := installs[version.SessionID]
+		session := sessions[version.SessionID]
+		if fill.Deleted {
+			continue
+		}
+		if !ok || item.FactRevision != fill.InstallRevision ||
+			!sources[version.SessionID].Equal(version) ||
+			baked[version.SessionID] != [2]string{session.Agent, session.StartedAt} ||
+			pricing[version.SessionID] != pricingHash {
+			stale[version.SessionID] = true
+		}
+	}
+	return installs, stale, nil
+}
+
+func (c *usageRollupCoordinator) recheck(
+	ctx context.Context, versions map[string]usageSourceVersion,
+	sessions map[string]usageQuerySession,
+) error {
+	observed := make([]usageSourceVersion, 0, len(versions))
+	for _, version := range versions {
+		observed = append(observed, version)
+	}
+	slices.SortFunc(observed, func(a, b usageSourceVersion) int {
+		return compareStrings(a.SessionID, b.SessionID)
+	})
+	current, err := c.cache.fill.recheckSourceVersions(ctx, observed)
+	if err != nil {
+		return err
+	}
+	for _, version := range observed {
+		if value, ok := current[version.SessionID]; !ok || !value.Equal(version) {
+			return fmt.Errorf("%w during rollup build", errUsageCacheSourceChanged)
+		}
+	}
+	metadata, err := c.currentMetadata(ctx, observed)
+	if err != nil {
+		return err
+	}
+	for id, session := range sessions {
+		if metadata[id] != [2]string{session.Agent, session.StartedAt} {
+			return fmt.Errorf("%w during rollup metadata check", errUsageCacheSourceChanged)
+		}
+	}
+	return nil
+}
+
+func (c *usageRollupCoordinator) currentMetadata(
+	ctx context.Context, versions []usageSourceVersion,
+) (map[string][2]string, error) {
+	ids := make([]string, 0, len(versions))
+	for _, version := range versions {
+		ids = append(ids, version.SessionID)
+	}
+	result := make(map[string][2]string, len(ids))
+	err := queryChunked(ids, func(chunk []string) error {
+		placeholders, args := inPlaceholders(chunk)
+		rows, err := c.archive.getReader().QueryContext(ctx, `SELECT id, agent,
+			COALESCE(started_at, '') FROM sessions
+			WHERE deleted_at IS NULL AND id IN `+placeholders, args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id, agent, startedAt string
+			if err := rows.Scan(&id, &agent, &startedAt); err != nil {
+				return err
+			}
+			result[id] = [2]string{agent, startedAt}
+		}
+		return rows.Err()
+	})
+	return result, err
+}
+
+func installUsageRollupBuilds(
+	ctx context.Context, conn *sql.Conn, identity usageTimezoneIdentity,
+	location *time.Location, builds []usageRollupBuild,
+) error {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO usage_rollup_timezones(
+		timezone_key, timezone_name, interval_fingerprint, last_requested_at
+	) VALUES (?, ?, ?, ?) ON CONFLICT(timezone_key) DO UPDATE SET
+		timezone_name=excluded.timezone_name,
+		interval_fingerprint=excluded.interval_fingerprint,
+		last_requested_at=excluded.last_requested_at`,
+		identity.Key, identity.Name, identity.IntervalFingerprint, now); err != nil {
+		return err
+	}
+	var timezoneID int64
+	if err := tx.QueryRowContext(ctx, `SELECT id FROM usage_rollup_timezones
+		WHERE timezone_key = ?`, identity.Key).Scan(&timezoneID); err != nil {
+		return err
+	}
+	var revisionText string
+	if err := tx.QueryRowContext(ctx, `SELECT value FROM usage_cache_metadata
+		WHERE key = ?`, usageCacheMetadataNextRollupRevision).Scan(&revisionText); err != nil {
+		return err
+	}
+	nextRevision, err := strconv.ParseInt(revisionText, 10, 64)
+	if err != nil {
+		return err
+	}
+	dates := make(map[string]bool)
+	for _, build := range builds {
+		var installID int64
+		err := tx.QueryRowContext(ctx, `SELECT id FROM usage_rollup_installs
+			WHERE timezone_id = ? AND session_id = ?`, timezoneID, build.SessionID).Scan(&installID)
+		if err != nil && err != sql.ErrNoRows {
+			return err
+		}
+		if err == nil {
+			for _, table := range []string{
+				"usage_daily_rollups", "usage_activity_rollups", "usage_rollup_exceptions",
+			} {
+				if _, err := tx.ExecContext(ctx, `DELETE FROM `+table+
+					` WHERE rollup_install_id = ?`, installID); err != nil {
+					return err
+				}
+			}
+			_, err = tx.ExecContext(ctx, `UPDATE usage_rollup_installs SET
+				source_sync_marker=?, source_transcript_rev=?, usage_event_fingerprint=?,
+				fact_install_revision=?, baked_agent=?, baked_started_at=?,
+				pricing_hash=?, install_revision=?, cached_at=? WHERE id=?`,
+				build.Source.SyncMarker, build.Source.TranscriptRevision,
+				build.Source.UsageEventFingerprint, build.FactRevision,
+				build.Agent, build.StartedAt, build.PricingHash,
+				nextRevision, now, installID)
+		} else {
+			result, insertErr := tx.ExecContext(ctx, `INSERT INTO usage_rollup_installs(
+				timezone_id, session_id, source_sync_marker, source_transcript_rev,
+				usage_event_fingerprint, fact_install_revision, baked_agent,
+				baked_started_at, pricing_hash, install_revision, cached_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, timezoneID, build.SessionID,
+				build.Source.SyncMarker, build.Source.TranscriptRevision,
+				build.Source.UsageEventFingerprint, build.FactRevision,
+				build.Agent, build.StartedAt, build.PricingHash, nextRevision, now)
+			if insertErr != nil {
+				return insertErr
+			}
+			installID, err = result.LastInsertId()
+		}
+		if err != nil {
+			return err
+		}
+		if err := installUsageRollupRows(ctx, tx, installID, build, dates); err != nil {
+			return err
+		}
+		nextRevision++
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE usage_cache_metadata SET value=?
+		WHERE key=?`, strconv.FormatInt(nextRevision, 10),
+		usageCacheMetadataNextRollupRevision); err != nil {
+		return err
+	}
+	if err := installUsageRollupDays(ctx, tx, timezoneID, location, dates); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func installUsageRollupRows(
+	ctx context.Context, tx *sql.Tx, installID int64,
+	build usageRollupBuild, dates map[string]bool,
+) error {
+	for _, row := range build.Daily {
+		band := -1
+		if row.BandThreshold != nil {
+			band = *row.BandThreshold
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO usage_daily_rollups VALUES(
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			installID, row.LocalDate, row.ReportedModel, row.PricedModel,
+			row.MatchedPattern, boolInt(row.RateOK), row.RateHash, band,
+			row.InputTokens, row.OutputTokens, row.ReasoningTokens,
+			row.CacheCreationTokens, row.CacheReadTokens, row.WebSearchRequests,
+			row.CostMicrodollars, row.SavingsMicrodollars,
+			row.AuthoritativeCostMicrodollars, row.ComputedRequestCount,
+			row.ComputedAggregateCount, row.ReportedCount, row.BaseRequestCount,
+			row.DiscardedSnapshotOutputTokens)
+		if err != nil {
+			return err
+		}
+		dates[row.LocalDate] = true
+	}
+	for _, row := range build.Activity {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO usage_activity_rollups VALUES(?, ?, ?, ?)`,
+			installID, row.LocalDate, row.Model, row.UserMessageCount); err != nil {
+			return err
+		}
+		dates[row.LocalDate] = true
+	}
+	for _, row := range build.Exceptions {
+		fact := row.Fact
+		_, err := tx.ExecContext(ctx, `INSERT INTO usage_rollup_exceptions VALUES(
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			installID, row.GroupKind, row.GroupKey, fact.CachedSessionID,
+			fact.FactIndex, fact.SourceSessionID, fact.LocalDate, fact.Fact.Source,
+			fact.Fact.MessageOrdinal, fact.Fact.TimestampMillis, fact.Fact.TimestampNanos,
+			fact.Fact.RawTimestamp, boolInt(fact.Fact.UsesSessionStart), fact.Model,
+			fact.Fact.InputTokens, fact.Fact.OutputTokens, fact.Fact.ReasoningTokens,
+			fact.Fact.CacheCreationTokens, fact.Fact.CacheReadTokens,
+			fact.Fact.WebSearchRequests, fact.Fact.ReportedCostMicrodollars,
+			fact.Fact.CostSource, boolInt(fact.Fact.RequestScoped),
+			fact.Fact.ClaudeMessageID, fact.Fact.ClaudeRequestID,
+			fact.Fact.SourceUUID, fact.Fact.UsageDedupKey)
+		if err != nil {
+			return err
+		}
+		dates[fact.LocalDate] = true
+	}
+	return nil
+}
+
+func installUsageRollupDays(
+	ctx context.Context, tx *sql.Tx, timezoneID int64,
+	location *time.Location, dates map[string]bool,
+) error {
+	if location == nil {
+		location = time.Local
+	}
+	for date := range dates {
+		day, err := time.ParseInLocation(time.DateOnly, date, location)
+		if err != nil {
+			continue
+		}
+		next := day.AddDate(0, 0, 1)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO usage_rollup_days VALUES(?, ?, ?, ?)
+			ON CONFLICT(timezone_id, local_date) DO UPDATE SET
+			from_ms=excluded.from_ms, to_ms=excluded.to_ms`, timezoneID, date,
+			day.UTC().UnixMilli(), next.UTC().UnixMilli()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func usageRollupCallKey(
+	snapshot usageQuerySnapshot, fills map[string]usageFillResult,
+	pricingHash string,
+) string {
+	digest := sha256.New()
+	writeUsageHashString(digest,
+		usageTimezoneIdentityFor(snapshot.location, snapshot.Intervals).Key)
+	writeUsageHashString(digest, pricingHash)
+	writeUsageHashInt64(digest, snapshot.CursorHighWater)
+	for _, version := range snapshot.Versions {
+		writeUsageHashString(digest, usageFillCallKey(version))
+		writeUsageHashInt64(digest, fills[version.SessionID].InstallRevision)
+	}
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func writeUsageHashString(digest hash.Hash, value string) {
+	writeUsageHashInt64(digest, int64(len(value)))
+	_, _ = digest.Write([]byte(value))
+}
+
+func writeUsageHashInt64(digest hash.Hash, value int64) {
+	var buffer [8]byte
+	binary.BigEndian.PutUint64(buffer[:], uint64(value))
+	_, _ = digest.Write(buffer[:])
+}
+
+func writeUsageHashBool(digest hash.Hash, value bool) {
+	if value {
+		writeUsageHashInt64(digest, 1)
+	} else {
+		writeUsageHashInt64(digest, 0)
+	}
+}
+
+func compareStrings(left, right string) int {
+	if left < right {
+		return -1
+	}
+	if left > right {
+		return 1
+	}
+	return 0
+}

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -545,7 +545,7 @@ func installUsageRollupRows(
 	for _, row := range build.Exceptions {
 		fact := row.Fact
 		_, err := tx.ExecContext(ctx, `INSERT INTO usage_rollup_exceptions VALUES(
-			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			installID, row.GroupKind, row.GroupKey, fact.CachedSessionID,
 			fact.FactIndex, fact.SourceSessionID, fact.LocalDate, fact.Fact.Source,
 			fact.Fact.MessageOrdinal, fact.Fact.TimestampMillis, fact.Fact.TimestampNanos,
@@ -553,7 +553,7 @@ func installUsageRollupRows(
 			fact.Fact.InputTokens, fact.Fact.OutputTokens, fact.Fact.ReasoningTokens,
 			fact.Fact.CacheCreationTokens, fact.Fact.CacheReadTokens,
 			fact.Fact.WebSearchRequests, fact.Fact.ReportedCostMicrodollars,
-			fact.Fact.CostSource, boolInt(fact.Fact.RequestScoped),
+			fact.Fact.CostSource, boolInt(fact.Fact.RequestScoped), boolInt(fact.IsHeadless),
 			fact.Fact.ClaudeMessageID, fact.Fact.ClaudeRequestID,
 			fact.Fact.SourceUUID, fact.Fact.UsageDedupKey)
 		if err != nil {

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -35,11 +35,16 @@ type usageRollupMetrics struct {
 	BuildDuration, InstallDuration            time.Duration
 }
 
+var usageTimezoneIdentityCache sync.Map
+
 func usageTimezoneIdentityFor(
 	location *time.Location, _ []usageQueryInterval,
 ) usageTimezoneIdentity {
 	if location == nil {
 		location = time.Local
+	}
+	if cached, ok := usageTimezoneIdentityCache.Load(location); ok {
+		return cached.(usageTimezoneIdentity)
 	}
 	name := usageLocationName(location)
 	digest := sha256.New()
@@ -57,7 +62,11 @@ func usageTimezoneIdentityFor(
 	if key == "" || key == "Local" {
 		key = "local:" + fingerprint
 	}
-	return usageTimezoneIdentity{Key: key, Name: name, IntervalFingerprint: fingerprint}
+	identity := usageTimezoneIdentity{
+		Key: key, Name: name, IntervalFingerprint: fingerprint,
+	}
+	actual, _ := usageTimezoneIdentityCache.LoadOrStore(location, identity)
+	return actual.(usageTimezoneIdentity)
 }
 
 func usageLocationName(location *time.Location) string {

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -162,12 +162,17 @@ type usageRollupCall struct {
 	err      error
 }
 
+type usageRollupObserver struct {
+	beforeEnsure func()
+}
+
 type usageRollupCoordinator struct {
-	archive *DB
-	cache   *usageCache
-	ctx     context.Context
-	mu      sync.Mutex
-	calls   map[string]*usageRollupCall
+	archive  *DB
+	cache    *usageCache
+	ctx      context.Context
+	mu       sync.Mutex
+	calls    map[string]*usageRollupCall
+	observer usageRollupObserver
 }
 
 func newUsageRollupCoordinator(
@@ -196,14 +201,23 @@ func (c *usageRollupCoordinator) Ensure(
 	if call == nil {
 		call = &usageRollupCall{done: make(chan struct{})}
 		c.calls[key] = call
-		go func() {
+		if !c.cache.startDetachedWork(func() {
+			if c.observer.beforeEnsure != nil {
+				c.observer.beforeEnsure()
+			}
 			call.installs, call.metrics, call.err = c.ensureNow(
 				c.ctx, snapshot, fills, resolver, pricingHash)
 			close(call.done)
 			c.mu.Lock()
 			delete(c.calls, key)
 			c.mu.Unlock()
-		}()
+		}) {
+			delete(c.calls, key)
+			c.mu.Unlock()
+			return nil, usageRollupMetrics{}, fmt.Errorf(
+				"%w before starting detached rollup", errUsageCacheSourceChanged,
+			)
+		}
 	}
 	c.mu.Unlock()
 	select {

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -267,9 +267,13 @@ func (c *usageRollupCoordinator) ensureNow(
 	if err != nil {
 		return nil, usageRollupMetrics{}, err
 	}
+	cross, err := loadUsageRollupCrossIdentities(ctx, conn)
+	if err != nil {
+		return nil, usageRollupMetrics{}, err
+	}
 	builds, err := buildUsageRollupSessions(
 		facts, staleSessions, staleVersions, staleFills, snapshot.location,
-		resolver, pricingHash)
+		resolver, pricingHash, cross)
 	if err != nil {
 		return nil, usageRollupMetrics{}, err
 	}
@@ -295,7 +299,8 @@ func (c *usageRollupCoordinator) ensureNow(
 		return nil, metrics, err
 	}
 	installStarted := time.Now()
-	if err := installUsageRollupBuilds(ctx, conn, identity, snapshot.location, builds); err != nil {
+	if err := installUsageRollupBuilds(
+		ctx, conn, identity, snapshot.location, builds, cross); err != nil {
 		return nil, metrics, err
 	}
 	metrics.InstallDuration = time.Since(installStarted)
@@ -437,12 +442,26 @@ func (c *usageRollupCoordinator) currentMetadata(
 func installUsageRollupBuilds(
 	ctx context.Context, conn *sql.Conn, identity usageTimezoneIdentity,
 	location *time.Location, builds []usageRollupBuild,
+	buildCross usageDedupIdentitySet,
 ) error {
 	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
+	// A fill committing between classification and this install can add a
+	// sibling for an identity that was finalized into a daily row. Abort on
+	// new crossness; crossness that disappeared keeps the conservative
+	// exception rows exact.
+	currentCross, err := loadUsageRollupCrossIdentities(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if !currentCross.subsetOf(buildCross) {
+		return fmt.Errorf(
+			"%w: dedup identities gained members during rollup build",
+			errUsageCacheSourceChanged)
+	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	if _, err := tx.ExecContext(ctx, `INSERT INTO usage_rollup_timezones(
 		timezone_key, timezone_name, interval_fingerprint, last_requested_at

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -43,21 +43,16 @@ func usageTimezoneIdentityFor(
 	if location == nil {
 		location = time.Local
 	}
-	if cached, ok := usageTimezoneIdentityCache.Load(location); ok {
+	// Production locations come from time.LoadLocation or time.Local, so one
+	// zone name maps to one rule set for the life of the process. Keying by
+	// name keeps the cache bounded even though LoadLocation returns a fresh
+	// *time.Location on every call.
+	cacheKey := location.String()
+	if cached, ok := usageTimezoneIdentityCache.Load(cacheKey); ok {
 		return cached.(usageTimezoneIdentity)
 	}
 	name := usageLocationName(location)
-	digest := sha256.New()
-	writeUsageHashString(digest, name)
-	// Anonymous process-local locations need a stable identity independent of
-	// the requested window. Weekly probes cover historical and near-future rule
-	// transitions without relying on a platform-specific zoneinfo path.
-	for day := time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC); day.Year() <= 2100; day = day.AddDate(0, 0, 7) {
-		zone, offset := day.In(location).Zone()
-		writeUsageHashString(digest, zone)
-		writeUsageHashInt64(digest, int64(offset))
-	}
-	fingerprint := hex.EncodeToString(digest.Sum(nil))
+	fingerprint := usageTimezoneRuleFingerprint(name, location)
 	key := name + ":" + fingerprint
 	if name == "" || name == "Local" {
 		key = "local:" + fingerprint
@@ -65,8 +60,31 @@ func usageTimezoneIdentityFor(
 	identity := usageTimezoneIdentity{
 		Key: key, Name: name, IntervalFingerprint: fingerprint,
 	}
-	actual, _ := usageTimezoneIdentityCache.LoadOrStore(location, identity)
+	actual, _ := usageTimezoneIdentityCache.LoadOrStore(cacheKey, identity)
 	return actual.(usageTimezoneIdentity)
+}
+
+func usageTimezoneRuleFingerprint(name string, location *time.Location) string {
+	digest := sha256.New()
+	writeUsageHashString(digest, name)
+	// Hash every rule regime and its exact end instant from 1970 through 2100
+	// so any zoneinfo update that adds, removes, or moves a transition in that
+	// range selects a new rollup generation. Usage timestamps outside the range
+	// would be clock skew, so rule changes beyond it are out of scope.
+	end := time.Date(2101, 1, 1, 0, 0, 0, 0, time.UTC)
+	for cursor := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC); cursor.Before(end); {
+		localized := cursor.In(location)
+		zone, offset := localized.Zone()
+		writeUsageHashString(digest, zone)
+		writeUsageHashInt64(digest, int64(offset))
+		_, regimeEnd := localized.ZoneBounds()
+		if regimeEnd.IsZero() || !regimeEnd.After(cursor) {
+			break
+		}
+		writeUsageHashInt64(digest, regimeEnd.Unix())
+		cursor = regimeEnd
+	}
+	return hex.EncodeToString(digest.Sum(nil))
 }
 
 func usageLocationName(location *time.Location) string {

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -444,16 +444,25 @@ func installUsageRollupBuilds(
 	location *time.Location, builds []usageRollupBuild,
 	buildCross usageDedupIdentitySet,
 ) error {
-	tx, err := conn.BeginTx(ctx, nil)
-	if err != nil {
-		return err
+	// Take the cache write lock up front. A deferred transaction that
+	// reads before its first write fails with SQLITE_BUSY_SNAPSHOT
+	// when a concurrent fill or install commits after the read
+	// snapshot forms; BEGIN IMMEDIATE serializes writers through the
+	// busy timeout instead.
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return fmt.Errorf("locking usage cache for rollup install: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
 	// A fill committing between classification and this install can add a
 	// sibling for an identity that was finalized into a daily row. Abort on
 	// new crossness; crossness that disappeared keeps the conservative
 	// exception rows exact.
-	currentCross, err := loadUsageRollupCrossIdentities(ctx, tx)
+	currentCross, err := loadUsageRollupCrossIdentities(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -463,7 +472,7 @@ func installUsageRollupBuilds(
 			errUsageCacheSourceChanged)
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO usage_rollup_timezones(
+	if _, err := conn.ExecContext(ctx, `INSERT INTO usage_rollup_timezones(
 		timezone_key, timezone_name, interval_fingerprint, last_requested_at
 	) VALUES (?, ?, ?, ?) ON CONFLICT(timezone_key) DO UPDATE SET
 		timezone_name=excluded.timezone_name,
@@ -473,12 +482,12 @@ func installUsageRollupBuilds(
 		return err
 	}
 	var timezoneID int64
-	if err := tx.QueryRowContext(ctx, `SELECT id FROM usage_rollup_timezones
+	if err := conn.QueryRowContext(ctx, `SELECT id FROM usage_rollup_timezones
 		WHERE timezone_key = ?`, identity.Key).Scan(&timezoneID); err != nil {
 		return err
 	}
 	var revisionText string
-	if err := tx.QueryRowContext(ctx, `SELECT value FROM usage_cache_metadata
+	if err := conn.QueryRowContext(ctx, `SELECT value FROM usage_cache_metadata
 		WHERE key = ?`, usageCacheMetadataNextRollupRevision).Scan(&revisionText); err != nil {
 		return err
 	}
@@ -489,7 +498,7 @@ func installUsageRollupBuilds(
 	dates := make(map[string]bool)
 	for _, build := range builds {
 		var installID int64
-		err := tx.QueryRowContext(ctx, `SELECT id FROM usage_rollup_installs
+		err := conn.QueryRowContext(ctx, `SELECT id FROM usage_rollup_installs
 			WHERE timezone_id = ? AND session_id = ?`, timezoneID, build.SessionID).Scan(&installID)
 		if err != nil && err != sql.ErrNoRows {
 			return err
@@ -498,12 +507,12 @@ func installUsageRollupBuilds(
 			for _, table := range []string{
 				"usage_daily_rollups", "usage_activity_rollups", "usage_rollup_exceptions",
 			} {
-				if _, err := tx.ExecContext(ctx, `DELETE FROM `+table+
+				if _, err := conn.ExecContext(ctx, `DELETE FROM `+table+
 					` WHERE rollup_install_id = ?`, installID); err != nil {
 					return err
 				}
 			}
-			_, err = tx.ExecContext(ctx, `UPDATE usage_rollup_installs SET
+			_, err = conn.ExecContext(ctx, `UPDATE usage_rollup_installs SET
 				source_sync_marker=?, source_transcript_rev=?, usage_event_fingerprint=?,
 				fact_install_revision=?, baked_agent=?, baked_started_at=?,
 				pricing_hash=?, install_revision=?, cached_at=? WHERE id=?`,
@@ -512,7 +521,7 @@ func installUsageRollupBuilds(
 				build.Agent, build.StartedAt, build.PricingHash,
 				nextRevision, now, installID)
 		} else {
-			result, insertErr := tx.ExecContext(ctx, `INSERT INTO usage_rollup_installs(
+			result, insertErr := conn.ExecContext(ctx, `INSERT INTO usage_rollup_installs(
 				timezone_id, session_id, source_sync_marker, source_transcript_rev,
 				usage_event_fingerprint, fact_install_revision, baked_agent,
 				baked_started_at, pricing_hash, install_revision, cached_at
@@ -528,24 +537,28 @@ func installUsageRollupBuilds(
 		if err != nil {
 			return err
 		}
-		if err := installUsageRollupRows(ctx, tx, installID, build, dates); err != nil {
+		if err := installUsageRollupRows(ctx, conn, installID, build, dates); err != nil {
 			return err
 		}
 		nextRevision++
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE usage_cache_metadata SET value=?
+	if _, err := conn.ExecContext(ctx, `UPDATE usage_cache_metadata SET value=?
 		WHERE key=?`, strconv.FormatInt(nextRevision, 10),
 		usageCacheMetadataNextRollupRevision); err != nil {
 		return err
 	}
-	if err := installUsageRollupDays(ctx, tx, timezoneID, location, dates); err != nil {
+	if err := installUsageRollupDays(ctx, conn, timezoneID, location, dates); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return fmt.Errorf("committing usage rollup install: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func installUsageRollupRows(
-	ctx context.Context, tx *sql.Tx, installID int64,
+	ctx context.Context, conn *sql.Conn, installID int64,
 	build usageRollupBuild, dates map[string]bool,
 ) error {
 	for _, row := range build.Daily {
@@ -553,7 +566,7 @@ func installUsageRollupRows(
 		if row.BandThreshold != nil {
 			band = *row.BandThreshold
 		}
-		_, err := tx.ExecContext(ctx, `INSERT INTO usage_daily_rollups VALUES(
+		_, err := conn.ExecContext(ctx, `INSERT INTO usage_daily_rollups VALUES(
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			installID, row.LocalDate, row.ReportedModel, row.PricedModel,
 			row.MatchedPattern, boolInt(row.RateOK), row.RateHash, band,
@@ -569,7 +582,7 @@ func installUsageRollupRows(
 		dates[row.LocalDate] = true
 	}
 	for _, row := range build.Activity {
-		if _, err := tx.ExecContext(ctx, `INSERT INTO usage_activity_rollups VALUES(?, ?, ?, ?)`,
+		if _, err := conn.ExecContext(ctx, `INSERT INTO usage_activity_rollups VALUES(?, ?, ?, ?)`,
 			installID, row.LocalDate, row.Model, row.UserMessageCount); err != nil {
 			return err
 		}
@@ -577,7 +590,7 @@ func installUsageRollupRows(
 	}
 	for _, row := range build.Exceptions {
 		fact := row.Fact
-		_, err := tx.ExecContext(ctx, `INSERT INTO usage_rollup_exceptions VALUES(
+		_, err := conn.ExecContext(ctx, `INSERT INTO usage_rollup_exceptions VALUES(
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			installID, row.GroupKind, row.GroupKey, fact.CachedSessionID,
 			fact.FactIndex, fact.SourceSessionID, fact.LocalDate, fact.Fact.Source,
@@ -598,7 +611,7 @@ func installUsageRollupRows(
 }
 
 func installUsageRollupDays(
-	ctx context.Context, tx *sql.Tx, timezoneID int64,
+	ctx context.Context, conn *sql.Conn, timezoneID int64,
 	location *time.Location, dates map[string]bool,
 ) error {
 	if location == nil {
@@ -610,7 +623,7 @@ func installUsageRollupDays(
 			continue
 		}
 		next := day.AddDate(0, 0, 1)
-		if _, err := tx.ExecContext(ctx, `INSERT INTO usage_rollup_days VALUES(?, ?, ?, ?)
+		if _, err := conn.ExecContext(ctx, `INSERT INTO usage_rollup_days VALUES(?, ?, ?, ?)
 			ON CONFLICT(timezone_id, local_date) DO UPDATE SET
 			from_ms=excluded.from_ms, to_ms=excluded.to_ms`, timezoneID, date,
 			day.UTC().UnixMilli(), next.UTC().UnixMilli()); err != nil {

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -58,8 +58,8 @@ func usageTimezoneIdentityFor(
 		writeUsageHashInt64(digest, int64(offset))
 	}
 	fingerprint := hex.EncodeToString(digest.Sum(nil))
-	key := name
-	if key == "" || key == "Local" {
+	key := name + ":" + fingerprint
+	if name == "" || name == "Local" {
 		key = "local:" + fingerprint
 	}
 	identity := usageTimezoneIdentity{
@@ -596,9 +596,16 @@ func usageRollupCallKey(
 		usageTimezoneIdentityFor(snapshot.location, snapshot.Intervals).Key)
 	writeUsageHashString(digest, pricingHash)
 	writeUsageHashInt64(digest, snapshot.CursorHighWater)
+	sessions := make(map[string]usageQuerySession, len(snapshot.Sessions))
+	for _, session := range snapshot.Sessions {
+		sessions[session.ID] = session
+	}
 	for _, version := range snapshot.Versions {
 		writeUsageHashString(digest, usageFillCallKey(version))
 		writeUsageHashInt64(digest, fills[version.SessionID].InstallRevision)
+		session := sessions[version.SessionID]
+		writeUsageHashString(digest, session.Agent)
+		writeUsageHashString(digest, session.StartedAt)
 	}
 	return hex.EncodeToString(digest.Sum(nil))
 }

--- a/internal/db/usage_rollup_build.go
+++ b/internal/db/usage_rollup_build.go
@@ -1,0 +1,593 @@
+package db
+
+import (
+	"cmp"
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/money"
+	"go.kenn.io/agentsview/internal/usagefacts"
+)
+
+type usagePriceInput struct {
+	Fact                     usagefacts.Fact
+	Timestamp, ReportedModel string
+}
+
+type usagePriceResult struct {
+	PricedModel, MatchedPattern, RateHash string
+	RateOK                                bool
+	Cost, Savings                         money.Money
+	AuthoritativeCost                     *money.Money
+	BandThreshold                         *int
+	ComputedRequest, ComputedAggregate    int
+	Reported, BaseRequest                 int
+}
+
+type usageRollupFact struct {
+	CachedSessionID      int64
+	FactIndex            int
+	SourceSessionID      string
+	AttributionSessionID string
+	LocalDate            string
+	Model                string
+	Agent                string
+	EffectiveMillis      *int64
+	EffectiveNanos       *int64
+	DedupTimestamp       string
+	Fact                 usagefacts.Fact
+}
+
+type usageDailyContribution struct {
+	AttributedSessionID, LocalDate             string
+	ReportedModel, PricedModel, MatchedPattern string
+	RateOK                                     bool
+	RateHash                                   string
+	BandThreshold                              *int
+	InputTokens, OutputTokens, ReasoningTokens int64
+	CacheCreationTokens, CacheReadTokens       int64
+	WebSearchRequests                          int64
+	CostMicrodollars, SavingsMicrodollars      int64
+	AuthoritativeCostMicrodollars              *int64
+	ComputedRequestCount                       int
+	ComputedAggregateCount                     int
+	ReportedCount, BaseRequestCount            int
+	DiscardedSnapshotOutputTokens              int64
+}
+
+type usageActivityContribution struct {
+	AttributedSessionID, LocalDate, Model string
+	UserMessageCount                      int
+}
+
+type usageExceptionRow struct {
+	GroupKind, GroupKey string
+	Fact                usageRollupFact
+}
+
+type usageRollupBuild struct {
+	SessionID, Agent, StartedAt, PricingHash string
+	Source                                   usageSourceVersion
+	FactRevision                             int64
+	Daily                                    []usageDailyContribution
+	Activity                                 []usageActivityContribution
+	Exceptions                               []usageExceptionRow
+}
+
+func isUsageRollupException(fact usageRollupFact) bool {
+	return usageRollupSnapshotKey(fact) != "" || usageRollupGeneralKey(fact) != ""
+}
+
+func priceUsageFact(
+	input usagePriceInput, resolver *export.PricingResolver,
+) (usagePriceResult, error) {
+	model := input.ReportedModel
+	if model == "" {
+		model = input.Fact.Model
+	}
+	pricedModel, lookup := resolver.Resolve(model, usageLookupModel(model, input.Timestamp))
+	if err := validateNonnegativeUsageRates(lookup.Rates); err != nil {
+		return usagePriceResult{}, fmt.Errorf("pricing usage row for model %q: %w", model, err)
+	}
+	result := usagePriceResult{
+		PricedModel: pricedModel, MatchedPattern: lookup.Pattern,
+		RateHash: usageRateHash(
+			model, pricedModel, lookup.Pattern, lookup.OK, lookup.Rates),
+		RateOK: lookup.OK,
+	}
+	selectedRates := lookup.Rates
+	if input.Fact.RequestScoped {
+		selectedRates, result.BandThreshold = usageRatesAndBandForFact(
+			lookup.Rates, input.Fact)
+	}
+	var err error
+	reported := input.Fact.ReportedCostMicrodollars
+	if reported != nil && input.Fact.CostSource != CopilotReportedCostSource {
+		result.Cost = money.Money{Microdollars: *reported}
+		result.Reported = 1
+	} else {
+		result.Cost, err = selectedRates.CostForTokensScoped(
+			false, int(input.Fact.InputTokens), int(input.Fact.OutputTokens),
+			int(input.Fact.ReasoningTokens), int(input.Fact.CacheCreationTokens),
+			int(input.Fact.CacheReadTokens))
+		if err != nil {
+			return usagePriceResult{}, fmt.Errorf("pricing usage row for model %q: %w", model, err)
+		}
+		result.Cost, err = export.AddWebSearchFee(
+			result.Cost, int(input.Fact.WebSearchRequests))
+		if err != nil {
+			return usagePriceResult{}, fmt.Errorf("pricing usage row for model %q: %w", model, err)
+		}
+		if input.Fact.RequestScoped {
+			result.ComputedRequest = 1
+			if result.BandThreshold == nil {
+				result.BaseRequest = 1
+			}
+		} else {
+			result.ComputedAggregate = 1
+		}
+		if reported != nil {
+			value := money.Money{Microdollars: *reported}
+			result.AuthoritativeCost = &value
+		}
+	}
+	readRate, err := money.Sub(selectedRates.InputPerMTok, selectedRates.CacheReadPerMTok)
+	if err != nil {
+		return usagePriceResult{}, fmt.Errorf("deriving cache read rate for model %q: %w", model, err)
+	}
+	writeRate, err := money.Sub(selectedRates.InputPerMTok, selectedRates.CacheWritePerMTok)
+	if err != nil {
+		return usagePriceResult{}, fmt.Errorf("deriving cache creation rate for model %q: %w", model, err)
+	}
+	result.Savings, err = money.SignedCostPerMillion([]money.RatedTokens{
+		{Tokens: input.Fact.CacheReadTokens, Rate: readRate},
+		{Tokens: input.Fact.CacheCreationTokens, Rate: writeRate},
+	})
+	if err != nil {
+		return usagePriceResult{}, fmt.Errorf("pricing cache savings for model %q: %w", model, err)
+	}
+	return result, nil
+}
+
+func usageRatesAndBandForFact(
+	rates export.ModelRates, fact usagefacts.Fact,
+) (export.ModelRates, *int) {
+	totalInput := fact.InputTokens + fact.CacheCreationTokens + fact.CacheReadTokens
+	var threshold *int
+	for _, band := range rates.Bands {
+		if totalInput > int64(band.AboveInputTokens) &&
+			(threshold == nil || band.AboveInputTokens > *threshold) {
+			value := band.AboveInputTokens
+			threshold = &value
+		}
+	}
+	if threshold == nil {
+		return rates, nil
+	}
+	return rates.RatesForTokens(
+		int(fact.InputTokens), int(fact.CacheCreationTokens),
+		int(fact.CacheReadTokens)), threshold
+}
+
+func buildUsageDailyContributions(
+	facts []usageRollupFact, resolver *export.PricingResolver,
+) ([]usageDailyContribution, []usageRollupFact, error) {
+	type key struct {
+		session, date, model, priced, pattern, rateHash string
+		rateOK                                          bool
+		band                                            int
+	}
+	rows := make(map[key]*usageDailyContribution)
+	var exceptions []usageRollupFact
+	for _, fact := range facts {
+		if !fact.Fact.TokenEligible {
+			continue
+		}
+		if isUsageRollupException(fact) {
+			exceptions = append(exceptions, fact)
+			continue
+		}
+		timestamp := fact.Fact.RawTimestamp
+		if timestamp == "" {
+			timestamp = fact.DedupTimestamp
+		}
+		priced, err := priceUsageFact(usagePriceInput{
+			Fact: fact.Fact, Timestamp: timestamp, ReportedModel: fact.Model,
+		}, resolver)
+		if err != nil {
+			return nil, nil, err
+		}
+		band := -1
+		if priced.BandThreshold != nil {
+			band = *priced.BandThreshold
+		}
+		itemKey := key{
+			session: fact.AttributionSessionID, date: fact.LocalDate,
+			model: fact.Model, priced: priced.PricedModel,
+			pattern: priced.MatchedPattern, rateHash: priced.RateHash,
+			rateOK: priced.RateOK, band: band,
+		}
+		row := rows[itemKey]
+		if row == nil {
+			row = &usageDailyContribution{
+				AttributedSessionID: fact.AttributionSessionID,
+				LocalDate:           fact.LocalDate, ReportedModel: fact.Model,
+				PricedModel: priced.PricedModel, MatchedPattern: priced.MatchedPattern,
+				RateOK: priced.RateOK, RateHash: priced.RateHash,
+				BandThreshold: priced.BandThreshold,
+			}
+			rows[itemKey] = row
+		}
+		if err := addUsageFactToDailyContribution(row, fact, priced); err != nil {
+			return nil, nil, err
+		}
+	}
+	result := make([]usageDailyContribution, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, *row)
+	}
+	slices.SortFunc(result, compareUsageDailyContribution)
+	slices.SortFunc(exceptions, compareUsageRollupFactIdentity)
+	return result, exceptions, nil
+}
+
+func addUsageFactToDailyContribution(
+	row *usageDailyContribution, fact usageRollupFact, priced usagePriceResult,
+) error {
+	fields := []struct {
+		target *int64
+		value  int64
+		name   string
+	}{
+		{&row.InputTokens, fact.Fact.InputTokens, "input tokens"},
+		{&row.OutputTokens, fact.Fact.OutputTokens, "output tokens"},
+		{&row.ReasoningTokens, fact.Fact.ReasoningTokens, "reasoning tokens"},
+		{&row.CacheCreationTokens, fact.Fact.CacheCreationTokens, "cache creation tokens"},
+		{&row.CacheReadTokens, fact.Fact.CacheReadTokens, "cache read tokens"},
+		{&row.WebSearchRequests, fact.Fact.WebSearchRequests, "web search requests"},
+		{&row.CostMicrodollars, priced.Cost.Microdollars, "cost"},
+		{&row.SavingsMicrodollars, priced.Savings.Microdollars, "savings"},
+	}
+	for _, field := range fields {
+		value, err := addUsageInt64(*field.target, field.value)
+		if err != nil {
+			return fmt.Errorf("summing usage %s: %w", field.name, err)
+		}
+		*field.target = value
+	}
+	if priced.AuthoritativeCost != nil &&
+		(row.AuthoritativeCostMicrodollars == nil ||
+			priced.AuthoritativeCost.Microdollars > *row.AuthoritativeCostMicrodollars) {
+		value := priced.AuthoritativeCost.Microdollars
+		row.AuthoritativeCostMicrodollars = &value
+	}
+	row.ComputedRequestCount += priced.ComputedRequest
+	row.ComputedAggregateCount += priced.ComputedAggregate
+	row.ReportedCount += priced.Reported
+	row.BaseRequestCount += priced.BaseRequest
+	return nil
+}
+
+func loadUsageRollupFacts(
+	ctx context.Context, conn *sql.Conn, sessions map[string]usageQuerySession,
+) ([]usageRollupFact, error) {
+	if _, err := conn.ExecContext(ctx, `CREATE TEMP TABLE IF NOT EXISTS
+		usage_rollup_build_sessions(session_id TEXT PRIMARY KEY) WITHOUT ROWID;
+		DELETE FROM usage_rollup_build_sessions`); err != nil {
+		return nil, fmt.Errorf("preparing rollup build sessions: %w", err)
+	}
+	ids := make([]string, 0, len(sessions))
+	for id := range sessions {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	for start := 0; start < len(ids); start += usageFillInstallBatchSize {
+		end := min(start+usageFillInstallBatchSize, len(ids))
+		query := `INSERT INTO usage_rollup_build_sessions(session_id) VALUES ` +
+			strings.TrimSuffix(strings.Repeat("(?),", end-start), ",")
+		args := make([]any, 0, end-start)
+		for _, id := range ids[start:end] {
+			args = append(args, id)
+		}
+		if _, err := conn.ExecContext(ctx, query, args...); err != nil {
+			return nil, err
+		}
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT f.cached_session_id, f.fact_index,
+		cs.session_id, f.source, f.message_ordinal, f.timestamp_ms, f.timestamp_ns,
+		f.raw_timestamp, f.uses_session_start, f.model, f.input_tokens,
+		f.output_tokens, f.reasoning_tokens, f.cache_creation_tokens,
+		f.cache_read_tokens, f.web_search_requests, f.reported_cost_microdollars,
+		f.cost_source, f.request_scoped, f.claude_message_id, f.claude_request_id,
+		f.source_uuid, f.usage_dedup_key, f.token_eligible, f.activity_eligible
+		FROM usage_rollup_build_sessions selected
+		JOIN usage_cached_sessions cs ON cs.session_id = selected.session_id
+		JOIN usage_facts f ON f.cached_session_id = cs.id
+		ORDER BY cs.session_id, f.fact_index`)
+	if err != nil {
+		return nil, fmt.Errorf("loading rollup facts: %w", err)
+	}
+	defer rows.Close()
+	var facts []usageRollupFact
+	for rows.Next() {
+		var item usageRollupFact
+		var ordinal, millis, nanos, reported sql.NullInt64
+		var usesStart, requestScoped, tokenEligible, activityEligible int
+		if err := rows.Scan(
+			&item.CachedSessionID, &item.FactIndex, &item.SourceSessionID,
+			&item.Fact.Source, &ordinal, &millis, &nanos, &item.Fact.RawTimestamp,
+			&usesStart, &item.Fact.Model, &item.Fact.InputTokens,
+			&item.Fact.OutputTokens, &item.Fact.ReasoningTokens,
+			&item.Fact.CacheCreationTokens, &item.Fact.CacheReadTokens,
+			&item.Fact.WebSearchRequests, &reported, &item.Fact.CostSource,
+			&requestScoped, &item.Fact.ClaudeMessageID, &item.Fact.ClaudeRequestID,
+			&item.Fact.SourceUUID, &item.Fact.UsageDedupKey,
+			&tokenEligible, &activityEligible); err != nil {
+			return nil, err
+		}
+		if ordinal.Valid {
+			value := int(ordinal.Int64)
+			item.Fact.MessageOrdinal = &value
+		}
+		if millis.Valid {
+			value := millis.Int64
+			item.Fact.TimestampMillis = &value
+		}
+		if nanos.Valid {
+			value := nanos.Int64
+			item.Fact.TimestampNanos = &value
+		}
+		if reported.Valid {
+			value := reported.Int64
+			item.Fact.ReportedCostMicrodollars = &value
+		}
+		item.Fact.UsesSessionStart = usesStart != 0
+		item.Fact.RequestScoped = requestScoped != 0
+		item.Fact.TokenEligible = tokenEligible != 0
+		item.Fact.ActivityEligible = activityEligible != 0
+		session := sessions[item.SourceSessionID]
+		item.AttributionSessionID = item.SourceSessionID
+		item.Agent, item.Model = session.Agent, item.Fact.Model
+		item.EffectiveMillis, item.EffectiveNanos = item.Fact.TimestampMillis, item.Fact.TimestampNanos
+		item.DedupTimestamp = item.Fact.RawTimestamp
+		if item.Fact.UsesSessionStart {
+			item.EffectiveMillis, item.EffectiveNanos = session.StartedAtMillis, session.StartedAtNanos
+			item.DedupTimestamp = session.StartedAt
+		}
+		facts = append(facts, item)
+	}
+	return facts, rows.Err()
+}
+
+func loadCursorUsageRollupBuild(
+	ctx context.Context, conn *sql.Conn, highWater int64,
+	location *time.Location, pricingHash string,
+) (usageRollupBuild, error) {
+	build := usageRollupBuild{
+		SessionID: usageRollupCursorSessionID, Agent: "cursor",
+		PricingHash: pricingHash,
+		Source: usageSourceVersion{
+			SessionID:  usageRollupCursorSessionID,
+			SyncMarker: strconv.FormatInt(highWater, 10),
+		},
+		FactRevision: highWater,
+	}
+	rows, err := conn.QueryContext(ctx, `SELECT source_id, timestamp_ms,
+		timestamp_ns, raw_timestamp, model, input_tokens, output_tokens,
+		cache_creation_tokens, cache_read_tokens, charged_microdollars,
+		dedup_key FROM cursor_usage_facts WHERE source_id <= ? ORDER BY source_id`,
+		highWater)
+	if err != nil {
+		return build, err
+	}
+	defer rows.Close()
+	var facts []usageRollupFact
+	for rows.Next() {
+		var fact usageRollupFact
+		var sourceID int64
+		var millis, nanos sql.NullInt64
+		var charged int64
+		if err := rows.Scan(&sourceID, &millis, &nanos, &fact.Fact.RawTimestamp,
+			&fact.Model, &fact.Fact.InputTokens, &fact.Fact.OutputTokens,
+			&fact.Fact.CacheCreationTokens, &fact.Fact.CacheReadTokens, &charged,
+			&fact.Fact.UsageDedupKey); err != nil {
+			return build, err
+		}
+		fact.FactIndex = int(sourceID)
+		fact.Fact.Source = "cursor"
+		fact.Fact.Model = fact.Model
+		fact.Fact.CostSource = "cursor-reported"
+		fact.Fact.RequestScoped = true
+		fact.Fact.TokenEligible = true
+		fact.Fact.ReportedCostMicrodollars = &charged
+		if millis.Valid {
+			value := millis.Int64
+			fact.Fact.TimestampMillis, fact.EffectiveMillis = &value, &value
+		}
+		if nanos.Valid {
+			value := nanos.Int64
+			fact.Fact.TimestampNanos, fact.EffectiveNanos = &value, &value
+		}
+		fact.DedupTimestamp = fact.Fact.RawTimestamp
+		fact.LocalDate = usageRollupLocalDate(fact, location)
+		facts = append(facts, fact)
+	}
+	if err := rows.Err(); err != nil {
+		return build, err
+	}
+	daily, exceptions, err := buildUsageDailyContributions(facts, nil)
+	if err != nil {
+		return build, err
+	}
+	// Cursor rows always carry a dedup key, so pricing remains deferred until
+	// their general-dedup group is resolved with session exceptions.
+	if len(daily) != 0 {
+		return build, fmt.Errorf("Cursor rollup unexpectedly produced daily rows")
+	}
+	build.Exceptions = usageRollupExceptionRows(exceptions)
+	return build, nil
+}
+
+func buildUsageRollupSessions(
+	facts []usageRollupFact, sessions map[string]usageQuerySession,
+	versions map[string]usageSourceVersion, fills map[string]usageFillResult,
+	location *time.Location, resolver *export.PricingResolver, pricingHash string,
+) ([]usageRollupBuild, error) {
+	if location == nil {
+		location = time.Local
+	}
+	for index := range facts {
+		facts[index].LocalDate = usageRollupLocalDate(facts[index], location)
+	}
+	ids := make([]string, 0, len(sessions))
+	for id := range sessions {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	builds := make([]usageRollupBuild, 0, len(ids))
+	factIndex := 0
+	for _, id := range ids {
+		start := factIndex
+		for factIndex < len(facts) && facts[factIndex].SourceSessionID == id {
+			factIndex++
+		}
+		sessionFacts := facts[start:factIndex]
+		daily, exceptions, err := buildUsageDailyContributions(sessionFacts, resolver)
+		if err != nil {
+			return nil, err
+		}
+		builds = append(builds, usageRollupBuild{
+			SessionID: id, Agent: sessions[id].Agent, StartedAt: sessions[id].StartedAt,
+			PricingHash: pricingHash,
+			Source:      versions[id], FactRevision: fills[id].InstallRevision,
+			Daily: daily, Activity: usageRollupActivityContributions(id, sessionFacts),
+			Exceptions: usageRollupExceptionRows(exceptions),
+		})
+	}
+	return builds, nil
+}
+
+func usageRollupSnapshotKey(fact usageRollupFact) string {
+	if fact.Fact.ClaudeMessageID == "" || fact.Fact.ClaudeRequestID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%d:%s%s", len(fact.Fact.ClaudeMessageID),
+		fact.Fact.ClaudeMessageID, fact.Fact.ClaudeRequestID)
+}
+
+func usageRollupGeneralKey(fact usageRollupFact) string {
+	if fact.Fact.Source == "message" && fact.Agent != "" &&
+		fact.Fact.SourceUUID != "" && usageRollupSnapshotKey(fact) == "" {
+		return fmt.Sprintf("source:%d:%s%s", len(fact.Agent), fact.Agent, fact.Fact.SourceUUID)
+	}
+	if fact.Fact.UsageDedupKey != "" {
+		return "usage:" + fact.Fact.UsageDedupKey
+	}
+	return ""
+}
+
+func usageRollupExceptionRows(facts []usageRollupFact) []usageExceptionRow {
+	var rows []usageExceptionRow
+	for _, fact := range facts {
+		for _, group := range []struct{ kind, key string }{
+			{"snapshot", usageRollupSnapshotKey(fact)},
+			{"general", usageRollupGeneralKey(fact)},
+		} {
+			if group.key != "" {
+				rows = append(rows, usageExceptionRow{
+					GroupKind: group.kind, GroupKey: group.key, Fact: fact})
+			}
+		}
+	}
+	return rows
+}
+
+func usageRollupActivityContributions(
+	sessionID string, facts []usageRollupFact,
+) []usageActivityContribution {
+	type key struct{ date, model string }
+	counts := make(map[key]int)
+	for _, fact := range facts {
+		if fact.Fact.ActivityEligible && fact.LocalDate != "" {
+			counts[key{fact.LocalDate, fact.Fact.Model}]++
+		}
+	}
+	keys := make([]key, 0, len(counts))
+	for item := range counts {
+		keys = append(keys, item)
+	}
+	slices.SortFunc(keys, func(left, right key) int {
+		if order := cmp.Compare(left.date, right.date); order != 0 {
+			return order
+		}
+		return cmp.Compare(left.model, right.model)
+	})
+	result := make([]usageActivityContribution, 0, len(keys))
+	for _, item := range keys {
+		result = append(result, usageActivityContribution{
+			AttributedSessionID: sessionID,
+			LocalDate:           item.date, Model: item.model,
+			UserMessageCount: counts[item]})
+	}
+	return result
+}
+
+func usageRollupLocalDate(fact usageRollupFact, location *time.Location) string {
+	if millis := fact.effectiveMillis(); millis != nil {
+		return time.UnixMilli(*millis).In(location).Format(time.DateOnly)
+	}
+	raw := fact.DedupTimestamp
+	if raw == "" {
+		raw = fact.Fact.RawTimestamp
+	}
+	if len(raw) >= len(time.DateOnly) {
+		return raw[:len(time.DateOnly)]
+	}
+	return ""
+}
+
+func (fact usageRollupFact) effectiveMillis() *int64 {
+	if fact.EffectiveMillis != nil {
+		return fact.EffectiveMillis
+	}
+	return fact.Fact.TimestampMillis
+}
+
+func compareUsageRollupFactIdentity(left, right usageRollupFact) int {
+	if order := cmp.Compare(left.CachedSessionID, right.CachedSessionID); order != 0 {
+		return order
+	}
+	return cmp.Compare(left.FactIndex, right.FactIndex)
+}
+
+func compareUsageDailyContribution(left, right usageDailyContribution) int {
+	for _, values := range [][2]string{
+		{left.AttributedSessionID, right.AttributedSessionID},
+		{left.LocalDate, right.LocalDate}, {left.ReportedModel, right.ReportedModel},
+		{left.RateHash, right.RateHash},
+	} {
+		if order := cmp.Compare(values[0], values[1]); order != 0 {
+			return order
+		}
+	}
+	return 0
+}
+
+func usageRollupFactIdentity(fact usageRollupFact) string {
+	return fmt.Sprintf("%d:%d", fact.CachedSessionID, fact.FactIndex)
+}
+
+func addUsageInt64(left, right int64) (int64, error) {
+	if (right > 0 && left > math.MaxInt64-right) ||
+		(right < 0 && left < math.MinInt64-right) {
+		return 0, money.ErrOverflow
+	}
+	return left + right, nil
+}

--- a/internal/db/usage_rollup_build.go
+++ b/internal/db/usage_rollup_build.go
@@ -39,6 +39,7 @@ type usageRollupFact struct {
 	LocalDate            string
 	Model                string
 	Agent                string
+	IsHeadless           bool
 	EffectiveMillis      *int64
 	EffectiveNanos       *int64
 	DedupTimestamp       string
@@ -380,9 +381,10 @@ func loadCursorUsageRollupBuild(
 		FactRevision: highWater,
 	}
 	rows, err := conn.QueryContext(ctx, `SELECT source_id, timestamp_ms,
-		timestamp_ns, raw_timestamp, model, input_tokens, output_tokens,
+		raw_timestamp, model, input_tokens, output_tokens,
 		cache_creation_tokens, cache_read_tokens, charged_microdollars,
-		dedup_key FROM cursor_usage_facts WHERE source_id <= ? ORDER BY source_id`,
+		is_headless, dedup_key
+		FROM cursor_usage_facts WHERE source_id <= ? ORDER BY source_id`,
 		highWater)
 	if err != nil {
 		return build, err
@@ -392,14 +394,16 @@ func loadCursorUsageRollupBuild(
 	for rows.Next() {
 		var fact usageRollupFact
 		var sourceID int64
-		var millis, nanos sql.NullInt64
+		var millis sql.NullInt64
 		var charged int64
-		if err := rows.Scan(&sourceID, &millis, &nanos, &fact.Fact.RawTimestamp,
+		var isHeadless int
+		if err := rows.Scan(&sourceID, &millis, &fact.Fact.RawTimestamp,
 			&fact.Model, &fact.Fact.InputTokens, &fact.Fact.OutputTokens,
 			&fact.Fact.CacheCreationTokens, &fact.Fact.CacheReadTokens, &charged,
-			&fact.Fact.UsageDedupKey); err != nil {
+			&isHeadless, &fact.Fact.UsageDedupKey); err != nil {
 			return build, err
 		}
+		fact.IsHeadless = isHeadless != 0
 		fact.FactIndex = int(sourceID)
 		fact.Fact.Source = "cursor"
 		fact.Fact.Model = fact.Model
@@ -410,10 +414,6 @@ func loadCursorUsageRollupBuild(
 		if millis.Valid {
 			value := millis.Int64
 			fact.Fact.TimestampMillis, fact.EffectiveMillis = &value, &value
-		}
-		if nanos.Valid {
-			value := nanos.Int64
-			fact.Fact.TimestampNanos, fact.EffectiveNanos = &value, &value
 		}
 		fact.DedupTimestamp = fact.Fact.RawTimestamp
 		fact.LocalDate = usageRollupLocalDate(fact, location)

--- a/internal/db/usage_rollup_build.go
+++ b/internal/db/usage_rollup_build.go
@@ -82,10 +82,6 @@ type usageRollupBuild struct {
 	Exceptions                               []usageExceptionRow
 }
 
-func isUsageRollupException(fact usageRollupFact) bool {
-	return usageRollupSnapshotKey(fact) != "" || usageRollupGeneralKey(fact) != ""
-}
-
 func priceUsageFact(
 	input usagePriceInput, resolver *export.PricingResolver,
 ) (usagePriceResult, error) {
@@ -178,23 +174,16 @@ func usageRatesAndBandForFact(
 }
 
 func buildUsageDailyContributions(
-	facts []usageRollupFact, resolver *export.PricingResolver,
-) ([]usageDailyContribution, []usageRollupFact, error) {
+	survivors []usageRollupSurvivor, resolver *export.PricingResolver,
+) ([]usageDailyContribution, error) {
 	type key struct {
 		session, date, model, priced, pattern, rateHash string
 		rateOK                                          bool
 		band                                            int
 	}
 	rows := make(map[key]*usageDailyContribution)
-	var exceptions []usageRollupFact
-	for _, fact := range facts {
-		if !fact.Fact.TokenEligible {
-			continue
-		}
-		if isUsageRollupException(fact) {
-			exceptions = append(exceptions, fact)
-			continue
-		}
+	for _, survivor := range survivors {
+		fact := survivor.Fact
 		timestamp := fact.Fact.RawTimestamp
 		if timestamp == "" {
 			timestamp = fact.DedupTimestamp
@@ -203,7 +192,7 @@ func buildUsageDailyContributions(
 			Fact: fact.Fact, Timestamp: timestamp, ReportedModel: fact.Model,
 		}, resolver)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		band := -1
 		if priced.BandThreshold != nil {
@@ -227,16 +216,21 @@ func buildUsageDailyContributions(
 			rows[itemKey] = row
 		}
 		if err := addUsageFactToDailyContribution(row, fact, priced); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
+		discarded, err := addUsageInt64(row.DiscardedSnapshotOutputTokens,
+			survivor.DiscardedSnapshotOutputTokens)
+		if err != nil {
+			return nil, fmt.Errorf("summing discarded snapshot output: %w", err)
+		}
+		row.DiscardedSnapshotOutputTokens = discarded
 	}
 	result := make([]usageDailyContribution, 0, len(rows))
 	for _, row := range rows {
 		result = append(result, *row)
 	}
 	slices.SortFunc(result, compareUsageDailyContribution)
-	slices.SortFunc(exceptions, compareUsageRollupFactIdentity)
-	return result, exceptions, nil
+	return result, nil
 }
 
 func addUsageFactToDailyContribution(
@@ -422,16 +416,16 @@ func loadCursorUsageRollupBuild(
 	if err := rows.Err(); err != nil {
 		return build, err
 	}
-	daily, exceptions, err := buildUsageDailyContributions(facts, nil)
-	if err != nil {
-		return build, err
+	// Cursor rows stay on the exception tier: their keys may collide with
+	// session usage keys and their filters depend on per-row headless state,
+	// so pricing remains deferred to the request-time group resolution.
+	for _, fact := range facts {
+		if usageRollupGeneralKey(fact) == "" {
+			return build, fmt.Errorf(
+				"Cursor usage fact %d has no dedup identity", fact.FactIndex)
+		}
 	}
-	// Cursor rows always carry a dedup key, so pricing remains deferred until
-	// their general-dedup group is resolved with session exceptions.
-	if len(daily) != 0 {
-		return build, fmt.Errorf("Cursor rollup unexpectedly produced daily rows")
-	}
-	build.Exceptions = usageRollupExceptionRows(exceptions)
+	build.Exceptions = usageRollupExceptionRows(facts)
 	return build, nil
 }
 
@@ -439,6 +433,7 @@ func buildUsageRollupSessions(
 	facts []usageRollupFact, sessions map[string]usageQuerySession,
 	versions map[string]usageSourceVersion, fills map[string]usageFillResult,
 	location *time.Location, resolver *export.PricingResolver, pricingHash string,
+	cross usageDedupIdentitySet,
 ) ([]usageRollupBuild, error) {
 	if location == nil {
 		location = time.Local
@@ -459,7 +454,8 @@ func buildUsageRollupSessions(
 			factIndex++
 		}
 		sessionFacts := facts[start:factIndex]
-		daily, exceptions, err := buildUsageDailyContributions(sessionFacts, resolver)
+		survivors, exceptions := classifyUsageRollupFacts(sessionFacts, cross)
+		daily, err := buildUsageDailyContributions(survivors, resolver)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/usage_rollup_build.go
+++ b/internal/db/usage_rollup_build.go
@@ -515,7 +515,7 @@ func usageRollupActivityContributions(
 	type key struct{ date, model string }
 	counts := make(map[key]int)
 	for _, fact := range facts {
-		if fact.Fact.ActivityEligible && fact.LocalDate != "" {
+		if fact.Fact.ActivityEligible {
 			counts[key{fact.LocalDate, fact.Fact.Model}]++
 		}
 	}

--- a/internal/db/usage_rollup_build_test.go
+++ b/internal/db/usage_rollup_build_test.go
@@ -1,0 +1,224 @@
+//go:build fts5
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/money"
+	"go.kenn.io/agentsview/internal/usagefacts"
+)
+
+func TestUsageRollupExceptionClassification(t *testing.T) {
+	ordinary := rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10)
+	ordinary.Fact.ClaudeMessageID = ""
+	ordinary.Fact.ClaudeRequestID = ""
+	assert.False(t, isUsageRollupException(ordinary))
+	assert.True(t, isUsageRollupException(
+		rollupSnapshotFact(1, 1, "session-a", "2026-08-01", "model-a", 20)))
+	assert.True(t, isUsageRollupException(
+		rollupGeneralFact(1, 2, "session-a", "2026-08-01", "model-a", "shared", 30)))
+}
+
+func TestPriceUsageFactRoundsEachSurvivor(t *testing.T) {
+	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
+		ModelPattern: "model-a",
+		Rates: export.ModelRates{
+			InputPerMTok: money.Money{Microdollars: 1},
+		},
+	}})
+	input := usagePriceInput{ReportedModel: "model-a", Fact: usagefacts.Fact{
+		Model: "model-a", InputTokens: 500_000, RequestScoped: true,
+	}}
+
+	first, err := priceUsageFact(input, resolver)
+	require.NoError(t, err)
+	second, err := priceUsageFact(input, resolver)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), first.Cost.Microdollars)
+	assert.Equal(t, int64(2), first.Cost.Microdollars+second.Cost.Microdollars)
+}
+
+func TestPriceUsageFactSelectsRequestBand(t *testing.T) {
+	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
+		ModelPattern: "model-a",
+		Rates: export.ModelRates{
+			InputPerMTok: money.Money{Microdollars: 1_000_000},
+			Bands: []export.PricingBand{{
+				AboveInputTokens: 100,
+				InputPerMTok:     money.Money{Microdollars: 2_000_000},
+			}},
+		},
+	}})
+
+	got, err := priceUsageFact(usagePriceInput{
+		ReportedModel: "model-a",
+		Fact: usagefacts.Fact{
+			Model: "model-a", InputTokens: 101, RequestScoped: true,
+		},
+	}, resolver)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.BandThreshold)
+	assert.Equal(t, 100, *got.BandThreshold)
+	assert.Equal(t, int64(202), got.Cost.Microdollars)
+	assert.Equal(t, 1, got.ComputedRequest)
+	assert.Equal(t, 0, got.BaseRequest)
+}
+
+func TestPriceUsageFactPreservesReportedAndAuthoritativeCosts(t *testing.T) {
+	resolver := export.NewPricingResolver(nil)
+	reported := int64(77)
+
+	ordinary, err := priceUsageFact(usagePriceInput{
+		ReportedModel: "model-a",
+		Fact: usagefacts.Fact{
+			Model: "model-a", ReportedCostMicrodollars: &reported,
+			CostSource: "provider-reported",
+		},
+	}, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, int64(77), ordinary.Cost.Microdollars)
+	assert.Nil(t, ordinary.AuthoritativeCost)
+	assert.Equal(t, 1, ordinary.Reported)
+
+	authoritative, err := priceUsageFact(usagePriceInput{
+		ReportedModel: "model-a",
+		Fact: usagefacts.Fact{
+			Model: "model-a", ReportedCostMicrodollars: &reported,
+			CostSource: CopilotReportedCostSource,
+		},
+	}, resolver)
+	require.NoError(t, err)
+	require.NotNil(t, authoritative.AuthoritativeCost)
+	assert.Equal(t, int64(77), authoritative.AuthoritativeCost.Microdollars)
+	assert.Equal(t, 1, authoritative.ComputedAggregate)
+}
+
+func TestPriceUsageFactPricesReasoningAsOutputWhenOutputIsZero(t *testing.T) {
+	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
+		ModelPattern: "model-a",
+		Rates: export.ModelRates{
+			OutputPerMTok: money.Money{Microdollars: 1_000_000},
+		},
+	}})
+
+	got, err := priceUsageFact(usagePriceInput{
+		ReportedModel: "model-a",
+		Fact: usagefacts.Fact{
+			Model: "model-a", ReasoningTokens: 7, RequestScoped: true,
+		},
+	}, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), got.Cost.Microdollars)
+}
+
+func TestPriceUsageFactComputesCacheSavingsAndWebSearchFee(t *testing.T) {
+	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
+		ModelPattern: "model-a",
+		Rates: export.ModelRates{
+			InputPerMTok:     money.Money{Microdollars: 2_000_000},
+			CacheReadPerMTok: money.Money{Microdollars: 500_000},
+		},
+	}})
+
+	got, err := priceUsageFact(usagePriceInput{
+		ReportedModel: "model-a",
+		Fact: usagefacts.Fact{
+			Model: "model-a", CacheReadTokens: 1_000_000,
+			WebSearchRequests: 2, RequestScoped: true,
+		},
+	}, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, int64(500_000)+2*export.WebSearchRequestMicrodollars,
+		got.Cost.Microdollars)
+	assert.Equal(t, int64(1_500_000), got.Savings.Microdollars)
+}
+
+func TestBuildUsageDailyContributionsDefersSnapshotsToExceptionQuery(t *testing.T) {
+	first := rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10)
+	first.Fact.WebSearchRequests = 3
+	second := rollupSnapshotFact(2, 0, "session-b", "2026-08-01", "model-a", 20)
+	second.Fact.WebSearchRequests = 1
+	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
+		ModelPattern: "model-a",
+		Rates: export.ModelRates{
+			OutputPerMTok: money.Money{Microdollars: 1_000_000},
+		},
+	}})
+
+	daily, exceptions, err := buildUsageDailyContributions(
+		[]usageRollupFact{second, first}, resolver,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, daily)
+	assert.Equal(t, []string{"1:0", "2:0"}, rollupFactIDs(exceptions))
+}
+
+func TestBuildUsageDailyContributionsPricesBeforeSumming(t *testing.T) {
+	first := rollupGeneralFact(1, 0, "session-a", "2026-08-01", "model-a", "", 1)
+	first.Fact.InputTokens = 500_000
+	second := rollupGeneralFact(1, 1, "session-a", "2026-08-01", "model-a", "", 1)
+	second.Fact.InputTokens = 500_000
+	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
+		ModelPattern: "model-a",
+		Rates: export.ModelRates{
+			InputPerMTok: money.Money{Microdollars: 1},
+		},
+	}})
+
+	daily, _, err := buildUsageDailyContributions(
+		[]usageRollupFact{first, second}, resolver,
+	)
+	require.NoError(t, err)
+	require.Len(t, daily, 1)
+	assert.Equal(t, int64(2), daily[0].CostMicrodollars)
+}
+
+func rollupSnapshotFact(
+	cachedID int64, factIndex int, sessionID, date, model string, output int64,
+) usageRollupFact {
+	millis := int64(factIndex + 1)
+	ordinal := factIndex
+	return usageRollupFact{
+		CachedSessionID: cachedID, FactIndex: factIndex,
+		SourceSessionID: sessionID, AttributionSessionID: sessionID,
+		LocalDate: date, Model: model, Agent: "claude",
+		Fact: usagefacts.Fact{
+			Source: "message", MessageOrdinal: &ordinal, TimestampMillis: &millis,
+			RawTimestamp: "2026-08-01T00:00:00Z", Model: model,
+			OutputTokens: output, ClaudeMessageID: "message-id",
+			ClaudeRequestID: "request-id", TokenEligible: true,
+		},
+	}
+}
+
+func rollupGeneralFact(
+	cachedID int64, factIndex int, sessionID, date, model, dedup string, output int64,
+) usageRollupFact {
+	millis := int64(factIndex + 1)
+	ordinal := factIndex
+	return usageRollupFact{
+		CachedSessionID: cachedID, FactIndex: factIndex,
+		SourceSessionID: sessionID, AttributionSessionID: sessionID,
+		LocalDate: date, Model: model, Agent: "codex",
+		Fact: usagefacts.Fact{
+			Source: "usage", MessageOrdinal: &ordinal, TimestampMillis: &millis,
+			RawTimestamp: "2026-08-01T00:00:00Z", Model: model,
+			OutputTokens: output, UsageDedupKey: dedup, TokenEligible: true,
+		},
+	}
+}
+
+func rollupFactIDs(facts []usageRollupFact) []string {
+	result := make([]string, 0, len(facts))
+	for _, fact := range facts {
+		result = append(result, usageRollupFactIdentity(fact))
+	}
+	return result
+}

--- a/internal/db/usage_rollup_build_test.go
+++ b/internal/db/usage_rollup_build_test.go
@@ -24,6 +24,14 @@ func TestUsageRollupExceptionClassification(t *testing.T) {
 		rollupGeneralFact(1, 2, "session-a", "2026-08-01", "model-a", "shared", 30)))
 }
 
+func TestCompareUsageFactTiesUsesAscendingIdentity(t *testing.T) {
+	left := rollupGeneralFact(1, 0, "session-a", "2026-08-01", "model-a", "key", 1)
+	right := rollupGeneralFact(2, 0, "session-b", "2026-08-01", "model-a", "key", 1)
+
+	assert.Negative(t, compareUsageFactTies(left, right))
+	assert.Positive(t, compareUsageFactTies(right, left))
+}
+
 func TestPriceUsageFactRoundsEachSurvivor(t *testing.T) {
 	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
 		ModelPattern: "model-a",

--- a/internal/db/usage_rollup_build_test.go
+++ b/internal/db/usage_rollup_build_test.go
@@ -13,15 +13,162 @@ import (
 	"go.kenn.io/agentsview/internal/usagefacts"
 )
 
-func TestUsageRollupExceptionClassification(t *testing.T) {
-	ordinary := rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10)
-	ordinary.Fact.ClaudeMessageID = ""
-	ordinary.Fact.ClaudeRequestID = ""
-	assert.False(t, isUsageRollupException(ordinary))
-	assert.True(t, isUsageRollupException(
-		rollupSnapshotFact(1, 1, "session-a", "2026-08-01", "model-a", 20)))
-	assert.True(t, isUsageRollupException(
-		rollupGeneralFact(1, 2, "session-a", "2026-08-01", "model-a", "shared", 30)))
+func TestClassifyUsageRollupFactsFinalizesSafeGroups(t *testing.T) {
+	plain := rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 5)
+	plain.Fact.ClaudeMessageID = ""
+	plain.Fact.ClaudeRequestID = ""
+	singleton := rollupSnapshotFact(1, 1, "session-a", "2026-08-01", "model-a", 10)
+	loser := rollupSnapshotFact(1, 2, "session-a", "2026-08-01", "model-a", 20)
+	loser.Fact.ClaudeMessageID = "duplicated"
+	loser.Fact.WebSearchRequests = 4
+	winner := rollupSnapshotFact(1, 3, "session-a", "2026-08-01", "model-a", 30)
+	winner.Fact.ClaudeMessageID = "duplicated"
+	winner.Fact.WebSearchRequests = 1
+
+	survivors, exceptions := classifyUsageRollupFacts(
+		[]usageRollupFact{plain, singleton, loser, winner},
+		newUsageDedupIdentitySet(),
+	)
+
+	assert.Empty(t, exceptions)
+	require.Len(t, survivors, 3)
+	assert.Equal(t, "1:0", usageRollupFactIdentity(survivors[0].Fact))
+	assert.Equal(t, "1:1", usageRollupFactIdentity(survivors[1].Fact))
+	assert.Zero(t, survivors[1].DiscardedSnapshotOutputTokens)
+	ranked := survivors[2]
+	assert.Equal(t, "1:3", usageRollupFactIdentity(ranked.Fact),
+		"the greater output snapshot must win")
+	assert.Equal(t, int64(20), ranked.DiscardedSnapshotOutputTokens)
+	assert.Equal(t, int64(4), ranked.Fact.Fact.WebSearchRequests,
+		"the maximum web-search count must carry across snapshots")
+	assert.Equal(t, "session-a", ranked.Fact.AttributionSessionID)
+}
+
+func TestClassifyUsageRollupFactsFinalizesSafeGeneralGroups(t *testing.T) {
+	early := rollupGeneralFact(1, 0, "session-a", "2026-08-01", "model-a", "shared", 10)
+	early.Fact.RawTimestamp = "2026-08-01T01:00:00Z"
+	early.DedupTimestamp = early.Fact.RawTimestamp
+	late := rollupGeneralFact(1, 1, "session-a", "2026-08-01", "model-a", "shared", 20)
+	late.Fact.RawTimestamp = "2026-08-01T02:00:00Z"
+	late.DedupTimestamp = late.Fact.RawTimestamp
+
+	survivors, exceptions := classifyUsageRollupFacts(
+		[]usageRollupFact{late, early}, newUsageDedupIdentitySet(),
+	)
+
+	assert.Empty(t, exceptions)
+	require.Len(t, survivors, 1)
+	assert.Equal(t, "1:0", usageRollupFactIdentity(survivors[0].Fact),
+		"the earliest row must win general dedup")
+}
+
+func TestClassifyUsageRollupFactsKeepsIrreducibleGroups(t *testing.T) {
+	crossSnapshot := newUsageDedupIdentitySet()
+	crossSnapshot.add("message-id", "request-id", "", "")
+	crossSource := newUsageDedupIdentitySet()
+	crossSource.add("", "", "shared-uuid", "")
+	crossUsage := newUsageDedupIdentitySet()
+	crossUsage.add("", "", "", "shared-key")
+
+	sourceFact := func(cachedID int64, index int, date, model string) usageRollupFact {
+		fact := rollupGeneralFact(cachedID, index, "session-a", date, model, "", 10)
+		fact.Fact.Source = "message"
+		fact.Fact.SourceUUID = "shared-uuid"
+		fact.Agent = "codex"
+		return fact
+	}
+	copilot := rollupGeneralFact(1, 0, "session-a", "2026-08-01", "model-a", "cp", 10)
+	reported := int64(55)
+	copilot.Fact.ReportedCostMicrodollars = &reported
+	copilot.Fact.CostSource = CopilotReportedCostSource
+	undated := rollupGeneralFact(1, 0, "session-a", "", "model-a", "shared", 10)
+	undated.Fact.RawTimestamp = ""
+	undated.DedupTimestamp = ""
+
+	cases := []struct {
+		name       string
+		facts      []usageRollupFact
+		cross      usageDedupIdentitySet
+		exceptions int
+	}{
+		{"cross-session snapshot identity",
+			[]usageRollupFact{rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10)},
+			crossSnapshot, 1},
+		{"snapshot group spanning days", []usageRollupFact{
+			rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10),
+			rollupSnapshotFact(1, 1, "session-a", "2026-08-02", "model-a", 20),
+		}, newUsageDedupIdentitySet(), 2},
+		{"cross-session source identity",
+			[]usageRollupFact{sourceFact(1, 0, "2026-08-01", "model-a")},
+			crossSource, 1},
+		{"general group spanning models", []usageRollupFact{
+			rollupGeneralFact(1, 0, "session-a", "2026-08-01", "model-a", "shared", 10),
+			rollupGeneralFact(1, 1, "session-a", "2026-08-01", "model-b", "shared", 20),
+		}, newUsageDedupIdentitySet(), 2},
+		{"general group spanning days", []usageRollupFact{
+			rollupGeneralFact(1, 0, "session-a", "2026-08-01", "model-a", "shared", 10),
+			rollupGeneralFact(1, 1, "session-a", "2026-08-02", "model-a", "shared", 20),
+		}, newUsageDedupIdentitySet(), 2},
+		{"cross usage key",
+			[]usageRollupFact{rollupGeneralFact(1, 0, "session-a", "2026-08-01", "model-a", "shared-key", 10)},
+			crossUsage, 1},
+		{"authoritative copilot cost",
+			[]usageRollupFact{copilot}, newUsageDedupIdentitySet(), 1},
+		{"general group with mixed empty dates", []usageRollupFact{
+			undated,
+			rollupGeneralFact(1, 1, "session-a", "2026-08-01", "model-a", "shared", 20),
+		}, newUsageDedupIdentitySet(), 2},
+	}
+	for _, item := range cases {
+		t.Run(item.name, func(t *testing.T) {
+			survivors, exceptions := classifyUsageRollupFacts(item.facts, item.cross)
+			assert.Empty(t, survivors)
+			assert.Len(t, exceptions, item.exceptions)
+		})
+	}
+}
+
+func TestClassifyUsageRollupFactsFinalizesUndatedSameKeyGroup(t *testing.T) {
+	first := rollupGeneralFact(1, 0, "session-a", "", "model-a", "shared", 10)
+	first.Fact.RawTimestamp = ""
+	first.DedupTimestamp = ""
+	second := rollupGeneralFact(1, 1, "session-a", "", "model-a", "shared", 20)
+	second.Fact.RawTimestamp = ""
+	second.DedupTimestamp = ""
+
+	survivors, exceptions := classifyUsageRollupFacts(
+		[]usageRollupFact{first, second}, newUsageDedupIdentitySet(),
+	)
+
+	assert.Empty(t, exceptions)
+	require.Len(t, survivors, 1)
+	assert.Equal(t, "1:0", usageRollupFactIdentity(survivors[0].Fact))
+}
+
+func TestClassifyUsageRollupFactsClosesSnapshotToGeneralEdges(t *testing.T) {
+	snapshotWithKey := rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10)
+	snapshotWithKey.Fact.UsageDedupKey = "linked"
+	general := rollupGeneralFact(1, 1, "session-a", "2026-08-01", "model-a", "linked", 20)
+
+	survivors, exceptions := classifyUsageRollupFacts(
+		[]usageRollupFact{snapshotWithKey, general}, newUsageDedupIdentitySet(),
+	)
+
+	assert.Empty(t, survivors,
+		"a snapshot fact linked into a general group is irreducible")
+	assert.Len(t, exceptions, 2)
+}
+
+func TestClassifyUsageRollupFactsSkipsNonTokenFacts(t *testing.T) {
+	activity := rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10)
+	activity.Fact.TokenEligible = false
+
+	survivors, exceptions := classifyUsageRollupFacts(
+		[]usageRollupFact{activity}, newUsageDedupIdentitySet(),
+	)
+
+	assert.Empty(t, survivors)
+	assert.Empty(t, exceptions)
 }
 
 func TestCompareUsageFactTiesUsesAscendingIdentity(t *testing.T) {
@@ -148,11 +295,9 @@ func TestPriceUsageFactComputesCacheSavingsAndWebSearchFee(t *testing.T) {
 	assert.Equal(t, int64(1_500_000), got.Savings.Microdollars)
 }
 
-func TestBuildUsageDailyContributionsDefersSnapshotsToExceptionQuery(t *testing.T) {
-	first := rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10)
-	first.Fact.WebSearchRequests = 3
-	second := rollupSnapshotFact(2, 0, "session-b", "2026-08-01", "model-a", 20)
-	second.Fact.WebSearchRequests = 1
+func TestBuildUsageDailyContributionsRecordsDiscardedSnapshots(t *testing.T) {
+	loser := rollupSnapshotFact(1, 0, "session-a", "2026-08-01", "model-a", 10)
+	winner := rollupSnapshotFact(1, 1, "session-a", "2026-08-01", "model-a", 20)
 	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
 		ModelPattern: "model-a",
 		Rates: export.ModelRates{
@@ -160,12 +305,15 @@ func TestBuildUsageDailyContributionsDefersSnapshotsToExceptionQuery(t *testing.
 		},
 	}})
 
-	daily, exceptions, err := buildUsageDailyContributions(
-		[]usageRollupFact{second, first}, resolver,
+	survivors, exceptions := classifyUsageRollupFacts(
+		[]usageRollupFact{loser, winner}, newUsageDedupIdentitySet(),
 	)
+	require.Empty(t, exceptions)
+	daily, err := buildUsageDailyContributions(survivors, resolver)
 	require.NoError(t, err)
-	assert.Empty(t, daily)
-	assert.Equal(t, []string{"1:0", "2:0"}, rollupFactIDs(exceptions))
+	require.Len(t, daily, 1)
+	assert.Equal(t, int64(20), daily[0].OutputTokens)
+	assert.Equal(t, int64(10), daily[0].DiscardedSnapshotOutputTokens)
 }
 
 func TestBuildUsageDailyContributionsPricesBeforeSumming(t *testing.T) {
@@ -180,8 +328,8 @@ func TestBuildUsageDailyContributionsPricesBeforeSumming(t *testing.T) {
 		},
 	}})
 
-	daily, _, err := buildUsageDailyContributions(
-		[]usageRollupFact{first, second}, resolver,
+	daily, err := buildUsageDailyContributions(
+		[]usageRollupSurvivor{{Fact: first}, {Fact: second}}, resolver,
 	)
 	require.NoError(t, err)
 	require.Len(t, daily, 1)
@@ -221,12 +369,4 @@ func rollupGeneralFact(
 			OutputTokens: output, UsageDedupKey: dedup, TokenEligible: true,
 		},
 	}
-}
-
-func rollupFactIDs(facts []usageRollupFact) []string {
-	result := make([]string, 0, len(facts))
-	for _, fact := range facts {
-		result = append(result, usageRollupFactIdentity(fact))
-	}
-	return result
 }

--- a/internal/db/usage_rollup_classify.go
+++ b/internal/db/usage_rollup_classify.go
@@ -1,0 +1,539 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// usageCacheStatementRunner runs statements on the usage cache through a
+// connection, transaction, or pool handle.
+type usageCacheStatementRunner interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// usageDedupIdentitySet holds distinct deduplication identities: Claude
+// snapshot pairs, message source UUIDs, and usage-event dedup keys.
+type usageDedupIdentitySet struct {
+	snapshot   map[[2]string]bool
+	sourceUUID map[string]bool
+	usageKey   map[string]bool
+}
+
+func newUsageDedupIdentitySet() usageDedupIdentitySet {
+	return usageDedupIdentitySet{
+		snapshot:   make(map[[2]string]bool),
+		sourceUUID: make(map[string]bool),
+		usageKey:   make(map[string]bool),
+	}
+}
+
+func (set usageDedupIdentitySet) add(
+	messageID, requestID, sourceUUID, usageKey string,
+) {
+	if messageID != "" && requestID != "" {
+		set.snapshot[[2]string{messageID, requestID}] = true
+	}
+	if sourceUUID != "" {
+		set.sourceUUID[sourceUUID] = true
+	}
+	if usageKey != "" {
+		set.usageKey[usageKey] = true
+	}
+}
+
+func (set usageDedupIdentitySet) isEmpty() bool {
+	return len(set.snapshot) == 0 && len(set.sourceUUID) == 0 &&
+		len(set.usageKey) == 0
+}
+
+func (set usageDedupIdentitySet) subsetOf(other usageDedupIdentitySet) bool {
+	for identity := range set.snapshot {
+		if !other.snapshot[identity] {
+			return false
+		}
+	}
+	for identity := range set.sourceUUID {
+		if !other.sourceUUID[identity] {
+			return false
+		}
+	}
+	for identity := range set.usageKey {
+		if !other.usageKey[identity] {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeDifferences adds every identity present in exactly one of left and
+// right, accumulating the symmetric difference of a fact replacement.
+func (set usageDedupIdentitySet) mergeDifferences(
+	left, right usageDedupIdentitySet,
+) {
+	for identity := range left.snapshot {
+		if !right.snapshot[identity] {
+			set.snapshot[identity] = true
+		}
+	}
+	for identity := range right.snapshot {
+		if !left.snapshot[identity] {
+			set.snapshot[identity] = true
+		}
+	}
+	for identity := range left.sourceUUID {
+		if !right.sourceUUID[identity] {
+			set.sourceUUID[identity] = true
+		}
+	}
+	for identity := range right.sourceUUID {
+		if !left.sourceUUID[identity] {
+			set.sourceUUID[identity] = true
+		}
+	}
+	for identity := range left.usageKey {
+		if !right.usageKey[identity] {
+			set.usageKey[identity] = true
+		}
+	}
+	for identity := range right.usageKey {
+		if !left.usageKey[identity] {
+			set.usageKey[identity] = true
+		}
+	}
+}
+
+func (set usageDedupIdentitySet) containsSnapshotIdentity(fact usageRollupFact) bool {
+	return set.snapshot[[2]string{
+		fact.Fact.ClaudeMessageID, fact.Fact.ClaudeRequestID,
+	}]
+}
+
+func (set usageDedupIdentitySet) containsGeneralIdentity(fact usageRollupFact) bool {
+	if usageRollupGeneralKeyIsSource(fact) {
+		return set.sourceUUID[fact.Fact.SourceUUID]
+	}
+	if fact.Fact.UsageDedupKey != "" {
+		return set.usageKey[fact.Fact.UsageDedupKey]
+	}
+	return false
+}
+
+// usageRollupSurvivor is one build-time-finalized daily contribution: the
+// deduplication winner plus the output tokens its group discarded.
+type usageRollupSurvivor struct {
+	Fact                          usageRollupFact
+	DiscardedSnapshotOutputTokens int64
+}
+
+// classifyUsageRollupFacts splits one session's facts into contributions that
+// finalize into daily rows and irreducible deduplication exceptions. A group
+// finalizes only when its resolution cannot vary with the query window or
+// live filters: every member shares one local date (and one model and
+// headless state for general dedup), no member's identity appears outside the
+// session, no member links snapshot and general dedup, and no member carries
+// a Copilot authoritative cost whose per-session selection is
+// order-dependent. Query windows are whole local days, so a single-date group
+// is inside or outside any window as a unit.
+func classifyUsageRollupFacts(
+	facts []usageRollupFact, cross usageDedupIdentitySet,
+) ([]usageRollupSurvivor, []usageRollupFact) {
+	snapshots := make(map[string][]int)
+	generals := make(map[string][]int)
+	var plain []int
+	for index := range facts {
+		if !facts[index].Fact.TokenEligible {
+			continue
+		}
+		snapshotKey := usageRollupSnapshotKey(facts[index])
+		generalKey := usageRollupGeneralKey(facts[index])
+		if snapshotKey == "" && generalKey == "" {
+			plain = append(plain, index)
+			continue
+		}
+		if snapshotKey != "" {
+			snapshots[snapshotKey] = append(snapshots[snapshotKey], index)
+		}
+		if generalKey != "" {
+			generals[generalKey] = append(generals[generalKey], index)
+		}
+	}
+
+	unsafeSnapshots := make(map[string]bool)
+	unsafeGenerals := make(map[string]bool)
+	for key, members := range snapshots {
+		for _, index := range members {
+			fact := facts[index]
+			if cross.containsSnapshotIdentity(fact) ||
+				fact.LocalDate != facts[members[0]].LocalDate {
+				unsafeSnapshots[key] = true
+			}
+			// A snapshot survivor carrying a usage dedup key re-enters
+			// general ranking at read time, so both linked groups stay on
+			// the exception tier.
+			if generalKey := usageRollupGeneralKey(fact); generalKey != "" {
+				unsafeSnapshots[key] = true
+				unsafeGenerals[generalKey] = true
+			}
+		}
+	}
+	for key, members := range generals {
+		for _, index := range members {
+			fact := facts[index]
+			first := facts[members[0]]
+			if cross.containsGeneralIdentity(fact) ||
+				fact.LocalDate != first.LocalDate ||
+				fact.Model != first.Model ||
+				fact.IsHeadless != first.IsHeadless ||
+				usageFactHasAuthoritativeCost(fact) {
+				unsafeGenerals[key] = true
+			}
+		}
+	}
+
+	exceptional := make(map[int]bool)
+	var survivors []usageRollupSurvivor
+	for _, index := range plain {
+		survivors = append(survivors, usageRollupSurvivor{Fact: facts[index]})
+	}
+	for _, key := range usageSortedMapKeys(snapshots) {
+		members := snapshots[key]
+		if len(members) == 0 {
+			continue
+		}
+		if unsafeSnapshots[key] {
+			for _, index := range members {
+				exceptional[index] = true
+			}
+			continue
+		}
+		survivors = append(survivors, rankSafeSnapshotGroup(facts, members))
+	}
+	for _, key := range usageSortedMapKeys(generals) {
+		members := generals[key]
+		if len(members) == 0 {
+			continue
+		}
+		if unsafeGenerals[key] {
+			for _, index := range members {
+				exceptional[index] = true
+			}
+			continue
+		}
+		winner := members[0]
+		for _, index := range members[1:] {
+			if compareUsageGeneralWinner(facts[index], facts[winner]) < 0 {
+				winner = index
+			}
+		}
+		survivors = append(survivors, usageRollupSurvivor{Fact: facts[winner]})
+	}
+
+	exceptions := make([]usageRollupFact, 0, len(exceptional))
+	for index := range exceptional {
+		exceptions = append(exceptions, facts[index])
+	}
+	slices.SortFunc(exceptions, compareUsageRollupFactIdentity)
+	slices.SortFunc(survivors, func(left, right usageRollupSurvivor) int {
+		return compareUsageRollupFactIdentity(left.Fact, right.Fact)
+	})
+	return survivors, exceptions
+}
+
+// rankSafeSnapshotGroup applies the request-time snapshot ranking rules to a
+// group proven safe to finalize: greatest-output winner, earliest-row
+// attribution, maximum web-search count, and discarded losing output.
+func rankSafeSnapshotGroup(
+	facts []usageRollupFact, members []int,
+) usageRollupSurvivor {
+	winnerIndex, attributionIndex := members[0], members[0]
+	webSearch := facts[members[0]].Fact.WebSearchRequests
+	for _, index := range members[1:] {
+		if compareUsageSnapshotWinner(facts[index], facts[winnerIndex]) > 0 {
+			winnerIndex = index
+		}
+		if compareUsageSnapshotAttribution(facts[index], facts[attributionIndex]) < 0 {
+			attributionIndex = index
+		}
+		webSearch = max(webSearch, facts[index].Fact.WebSearchRequests)
+	}
+	survivor := usageRollupSurvivor{Fact: facts[winnerIndex]}
+	survivor.Fact.AttributionSessionID = facts[attributionIndex].SourceSessionID
+	survivor.Fact.Fact.WebSearchRequests = webSearch
+	for _, index := range members {
+		if index != winnerIndex {
+			survivor.DiscardedSnapshotOutputTokens += facts[index].Fact.OutputTokens
+		}
+	}
+	return survivor
+}
+
+func usageFactHasAuthoritativeCost(fact usageRollupFact) bool {
+	return fact.Fact.ReportedCostMicrodollars != nil &&
+		fact.Fact.CostSource == CopilotReportedCostSource
+}
+
+func usageRollupGeneralKeyIsSource(fact usageRollupFact) bool {
+	return fact.Fact.Source == "message" && fact.Agent != "" &&
+		fact.Fact.SourceUUID != "" && usageRollupSnapshotKey(fact) == ""
+}
+
+// Cross-identity discovery requires the usage_rollup_build_sessions temp
+// table populated by loadUsageRollupFacts on the same connection. The
+// redundant non-empty terms inside EXISTS let SQLite prove the partial
+// indexes usable.
+const usageRollupCrossSnapshotSQL = `SELECT DISTINCT
+	f.claude_message_id, f.claude_request_id
+	FROM usage_rollup_build_sessions selected
+	JOIN usage_cached_sessions cs ON cs.session_id = selected.session_id
+	JOIN usage_facts f ON f.cached_session_id = cs.id
+	WHERE f.claude_message_id != '' AND f.claude_request_id != ''
+	  AND EXISTS (SELECT 1 FROM usage_facts other
+		WHERE other.claude_message_id = f.claude_message_id
+		  AND other.claude_request_id = f.claude_request_id
+		  AND other.claude_message_id != '' AND other.claude_request_id != ''
+		  AND other.cached_session_id != f.cached_session_id)`
+
+const usageRollupCrossSourceUUIDSQL = `SELECT DISTINCT f.source_uuid
+	FROM usage_rollup_build_sessions selected
+	JOIN usage_cached_sessions cs ON cs.session_id = selected.session_id
+	JOIN usage_facts f ON f.cached_session_id = cs.id
+	WHERE f.source_uuid != ''
+	  AND EXISTS (SELECT 1 FROM usage_facts other
+		WHERE other.source_uuid = f.source_uuid AND other.source_uuid != ''
+		  AND other.cached_session_id != f.cached_session_id)`
+
+const usageRollupCrossUsageKeySQL = `SELECT DISTINCT f.usage_dedup_key
+	FROM usage_rollup_build_sessions selected
+	JOIN usage_cached_sessions cs ON cs.session_id = selected.session_id
+	JOIN usage_facts f ON f.cached_session_id = cs.id
+	WHERE f.usage_dedup_key != ''
+	  AND (EXISTS (SELECT 1 FROM usage_facts other
+			WHERE other.usage_dedup_key = f.usage_dedup_key
+			  AND other.usage_dedup_key != ''
+			  AND other.cached_session_id != f.cached_session_id)
+		OR EXISTS (SELECT 1 FROM cursor_usage_facts cursor_fact
+			WHERE cursor_fact.dedup_key = f.usage_dedup_key))`
+
+// loadUsageRollupCrossIdentities returns the dedup identities of the sessions
+// selected in usage_rollup_build_sessions that also appear in another cached
+// session or in the Cursor fact store. Their groups cannot be finalized by a
+// per-session build.
+func loadUsageRollupCrossIdentities(
+	ctx context.Context, runner usageCacheStatementRunner,
+) (usageDedupIdentitySet, error) {
+	cross := newUsageDedupIdentitySet()
+	if err := scanUsageIdentityRows(ctx, runner, usageRollupCrossSnapshotSQL,
+		func(first, second string) {
+			cross.add(first, second, "", "")
+		}); err != nil {
+		return cross, fmt.Errorf("loading cross-session snapshot identities: %w", err)
+	}
+	if err := scanUsageIdentityColumn(ctx, runner, usageRollupCrossSourceUUIDSQL,
+		func(value string) {
+			cross.add("", "", value, "")
+		}); err != nil {
+		return cross, fmt.Errorf("loading cross-session source identities: %w", err)
+	}
+	if err := scanUsageIdentityColumn(ctx, runner, usageRollupCrossUsageKeySQL,
+		func(value string) {
+			cross.add("", "", "", value)
+		}); err != nil {
+		return cross, fmt.Errorf("loading cross-session usage keys: %w", err)
+	}
+	return cross, nil
+}
+
+func scanUsageIdentityRows(
+	ctx context.Context, runner usageCacheStatementRunner, query string,
+	record func(first, second string),
+) error {
+	rows, err := runner.QueryContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var first, second string
+		if err := rows.Scan(&first, &second); err != nil {
+			return err
+		}
+		record(first, second)
+	}
+	return rows.Err()
+}
+
+func scanUsageIdentityColumn(
+	ctx context.Context, runner usageCacheStatementRunner, query string,
+	record func(value string),
+) error {
+	rows, err := runner.QueryContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var value string
+		if err := rows.Scan(&value); err != nil {
+			return err
+		}
+		record(value)
+	}
+	return rows.Err()
+}
+
+// usageFactIdentitiesForSessions returns the distinct dedup identities the
+// cache currently stores for the given source sessions.
+func usageFactIdentitiesForSessions(
+	ctx context.Context, runner usageCacheStatementRunner, sessionIDs []string,
+) (usageDedupIdentitySet, error) {
+	set := newUsageDedupIdentitySet()
+	err := queryChunked(sessionIDs, func(chunk []string) error {
+		placeholders, args := inPlaceholders(chunk)
+		return scanUsageIdentityFactRows(ctx, runner, `SELECT DISTINCT
+			f.claude_message_id, f.claude_request_id, f.source_uuid,
+			f.usage_dedup_key
+			FROM usage_cached_sessions cs
+			JOIN usage_facts f ON f.cached_session_id = cs.id
+			WHERE cs.session_id IN `+placeholders, args, set)
+	})
+	if err != nil {
+		return set, fmt.Errorf("collecting cached usage identities: %w", err)
+	}
+	return set, nil
+}
+
+// usageSpoolIdentitiesForSessions returns the distinct dedup identities the
+// attached fill spool carries for the given source sessions.
+func usageSpoolIdentitiesForSessions(
+	ctx context.Context, runner usageCacheStatementRunner, sessionIDs []string,
+) (usageDedupIdentitySet, error) {
+	set := newUsageDedupIdentitySet()
+	err := queryChunked(sessionIDs, func(chunk []string) error {
+		placeholders, args := inPlaceholders(chunk)
+		return scanUsageIdentityFactRows(ctx, runner, `SELECT DISTINCT
+			claude_message_id, claude_request_id, source_uuid, usage_dedup_key
+			FROM usage_fill_spool.facts
+			WHERE session_id IN `+placeholders, args, set)
+	})
+	if err != nil {
+		return set, fmt.Errorf("collecting spooled usage identities: %w", err)
+	}
+	return set, nil
+}
+
+func scanUsageIdentityFactRows(
+	ctx context.Context, runner usageCacheStatementRunner, query string,
+	args []any, set usageDedupIdentitySet,
+) error {
+	rows, err := runner.QueryContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var messageID, requestID, sourceUUID, usageKey string
+		if err := rows.Scan(&messageID, &requestID, &sourceUUID, &usageKey); err != nil {
+			return err
+		}
+		set.add(messageID, requestID, sourceUUID, usageKey)
+	}
+	return rows.Err()
+}
+
+// invalidateUsageDedupSharers deletes every timezone rollup install of the
+// sessions, other than the excluded ones, that store a fact matching one of
+// the changed dedup identities. Their next read reclassifies groups whose
+// membership changed, so a finalized daily row can never survive gaining a
+// sibling.
+func invalidateUsageDedupSharers(
+	ctx context.Context, runner usageCacheStatementRunner,
+	changed usageDedupIdentitySet, excluded map[string]bool,
+) error {
+	if changed.isEmpty() {
+		return nil
+	}
+	if _, err := runner.ExecContext(ctx, `CREATE TEMP TABLE IF NOT EXISTS
+		usage_changed_identities(
+			kind INTEGER NOT NULL, first TEXT NOT NULL, second TEXT NOT NULL,
+			PRIMARY KEY (kind, first, second)
+		) WITHOUT ROWID;
+		DELETE FROM usage_changed_identities`); err != nil {
+		return fmt.Errorf("preparing changed usage identities: %w", err)
+	}
+	rows := make([][3]any, 0,
+		len(changed.snapshot)+len(changed.sourceUUID)+len(changed.usageKey))
+	for identity := range changed.snapshot {
+		rows = append(rows, [3]any{0, identity[0], identity[1]})
+	}
+	for identity := range changed.sourceUUID {
+		rows = append(rows, [3]any{1, identity, ""})
+	}
+	for identity := range changed.usageKey {
+		rows = append(rows, [3]any{2, identity, ""})
+	}
+	const insertBatch = 300
+	for start := 0; start < len(rows); start += insertBatch {
+		end := min(start+insertBatch, len(rows))
+		query := `INSERT OR IGNORE INTO usage_changed_identities(kind, first, second)
+			VALUES ` + strings.TrimSuffix(strings.Repeat("(?, ?, ?),", end-start), ",")
+		args := make([]any, 0, (end-start)*3)
+		for _, row := range rows[start:end] {
+			args = append(args, row[0], row[1], row[2])
+		}
+		if _, err := runner.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("recording changed usage identities: %w", err)
+		}
+	}
+	sharerRows, err := runner.QueryContext(ctx, `
+		SELECT DISTINCT cs.session_id
+		FROM usage_changed_identities c
+		JOIN usage_facts f ON c.kind = 0
+			AND f.claude_message_id = c.first AND f.claude_request_id = c.second
+			AND f.claude_message_id != '' AND f.claude_request_id != ''
+		JOIN usage_cached_sessions cs ON cs.id = f.cached_session_id
+		UNION
+		SELECT DISTINCT cs.session_id
+		FROM usage_changed_identities c
+		JOIN usage_facts f ON c.kind = 1
+			AND f.source_uuid = c.first AND f.source_uuid != ''
+		JOIN usage_cached_sessions cs ON cs.id = f.cached_session_id
+		UNION
+		SELECT DISTINCT cs.session_id
+		FROM usage_changed_identities c
+		JOIN usage_facts f ON c.kind = 2
+			AND f.usage_dedup_key = c.first AND f.usage_dedup_key != ''
+		JOIN usage_cached_sessions cs ON cs.id = f.cached_session_id`)
+	if err != nil {
+		return fmt.Errorf("finding usage dedup sharers: %w", err)
+	}
+	var sharers []string
+	for sharerRows.Next() {
+		var sessionID string
+		if err := sharerRows.Scan(&sessionID); err != nil {
+			_ = sharerRows.Close()
+			return err
+		}
+		if !excluded[sessionID] {
+			sharers = append(sharers, sessionID)
+		}
+	}
+	if err := sharerRows.Close(); err != nil {
+		return err
+	}
+	if err := sharerRows.Err(); err != nil {
+		return err
+	}
+	return queryChunked(sharers, func(chunk []string) error {
+		placeholders, args := inPlaceholders(chunk)
+		if _, err := runner.ExecContext(ctx,
+			`DELETE FROM usage_rollup_installs WHERE session_id IN `+placeholders,
+			args...); err != nil {
+			return fmt.Errorf("invalidating usage dedup sharers: %w", err)
+		}
+		return nil
+	})
+}

--- a/internal/db/usage_rollup_lifecycle_test.go
+++ b/internal/db/usage_rollup_lifecycle_test.go
@@ -172,15 +172,26 @@ func TestUsageQuerySnapshotPinsPricingRows(t *testing.T) {
 func TestUsageRollupAgentChangeInvalidatesInstalledRows(t *testing.T) {
 	database := testDB(t)
 	started := "2026-08-10T08:00:00Z"
-	insertSession(t, database, "rollup-session", "project-a", func(session *Session) {
-		session.Agent = "codex"
-		session.StartedAt = &started
-	})
-	require.NoError(t, database.InsertMessages([]Message{{
-		SessionID: "rollup-session", Ordinal: 0, Role: "assistant",
-		Timestamp: "2026-08-10T09:00:00Z", Model: "model-a",
-		TokenUsage: json.RawMessage(`{"input_tokens":2,"output_tokens":3}`),
-	}}))
+	for _, id := range []string{"rollup-session", "rollup-peer"} {
+		insertSession(t, database, id, "project-a", func(session *Session) {
+			session.Agent = "codex"
+			session.StartedAt = &started
+		})
+	}
+	require.NoError(t, database.InsertMessages([]Message{
+		{
+			SessionID: "rollup-session", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-10T09:00:00Z", Model: "model-a",
+			TokenUsage: json.RawMessage(`{"input_tokens":2,"output_tokens":3}`),
+			SourceUUID: "shared-source",
+		},
+		{
+			SessionID: "rollup-peer", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-10T09:01:00Z", Model: "model-a",
+			TokenUsage: json.RawMessage(`{"input_tokens":2,"output_tokens":3}`),
+			SourceUUID: "shared-source",
+		},
+	}))
 
 	firstSnapshot, firstFills, cache := prepareUsageRollupTest(t, database)
 	first, _, err := cache.rollup.Ensure(
@@ -189,14 +200,36 @@ func TestUsageRollupAgentChangeInvalidatesInstalledRows(t *testing.T) {
 	)
 	require.NoError(t, err)
 	firstInstall := first["rollup-session"]
+	filter := UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	}
+	beforeDaily, err := database.GetDailyUsage(t.Context(), filter)
+	require.NoError(t, err)
+	assert.Equal(t, 2, beforeDaily.Totals.InputTokens,
+		"same-agent source identities deduplicate")
+	assert.Equal(t, 3, beforeDaily.Totals.OutputTokens)
 
-	beforeVersion := firstSnapshot.Versions[0]
+	var beforeVersion usageSourceVersion
+	for _, version := range firstSnapshot.Versions {
+		if version.SessionID == "rollup-session" {
+			beforeVersion = version
+			break
+		}
+	}
+	require.Equal(t, "rollup-session", beforeVersion.SessionID)
 	_, err = database.getWriter().Exec(`UPDATE sessions SET agent = 'claude'
 		WHERE id = 'rollup-session'`)
 	require.NoError(t, err)
 	secondSnapshot, secondFills, _ := prepareUsageRollupTest(t, database)
-	require.Len(t, secondSnapshot.Versions, 1)
-	assert.True(t, beforeVersion.Equal(secondSnapshot.Versions[0]),
+	var afterVersion usageSourceVersion
+	for _, version := range secondSnapshot.Versions {
+		if version.SessionID == "rollup-session" {
+			afterVersion = version
+			break
+		}
+	}
+	require.Equal(t, "rollup-session", afterVersion.SessionID)
+	assert.True(t, beforeVersion.Equal(afterVersion),
 		"agent is intentionally outside the normalized-facts fingerprint")
 
 	second, _, err := cache.rollup.Ensure(
@@ -206,6 +239,11 @@ func TestUsageRollupAgentChangeInvalidatesInstalledRows(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, second["rollup-session"].InstallRevision,
 		firstInstall.InstallRevision)
+	afterDaily, err := database.GetDailyUsage(t.Context(), filter)
+	require.NoError(t, err)
+	assert.Equal(t, 4, afterDaily.Totals.InputTokens,
+		"changing the baked agent must split the source identity groups")
+	assert.Equal(t, 6, afterDaily.Totals.OutputTokens)
 }
 
 func TestUsageRollupStartedAtChangeInvalidatesInstalledRows(t *testing.T) {
@@ -230,8 +268,15 @@ func TestUsageRollupStartedAtChangeInvalidatesInstalledRows(t *testing.T) {
 		export.NewPricingResolver(firstSnapshot.PricingRows),
 	)
 	require.NoError(t, err)
+	filter := UsageFilter{
+		From: "2026-08-10", To: "2026-08-11", Timezone: "UTC",
+	}
+	beforeDaily, err := database.GetDailyUsage(t.Context(), filter)
+	require.NoError(t, err)
+	require.Len(t, beforeDaily.Daily, 1)
+	assert.Equal(t, "2026-08-10", beforeDaily.Daily[0].Date)
 	_, err = database.getWriter().Exec(`UPDATE sessions
-		SET started_at = '2026-08-10T08:30:00Z' WHERE id = 'rollup-start'`)
+		SET started_at = '2026-08-11T08:30:00Z' WHERE id = 'rollup-start'`)
 	require.NoError(t, err)
 	secondSnapshot, secondFills, _ := prepareUsageRollupTest(t, database)
 	assert.True(t, firstSnapshot.Versions[0].Equal(secondSnapshot.Versions[0]),
@@ -244,6 +289,11 @@ func TestUsageRollupStartedAtChangeInvalidatesInstalledRows(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, second["rollup-start"].InstallRevision,
 		first["rollup-start"].InstallRevision)
+	afterDaily, err := database.GetDailyUsage(t.Context(), filter)
+	require.NoError(t, err)
+	require.Len(t, afterDaily.Daily, 1)
+	assert.Equal(t, "2026-08-11", afterDaily.Daily[0].Date,
+		"null-timestamp usage must move with the rebuilt session start")
 }
 
 func TestUsageRollupPricingChangeInvalidatesInstalledRows(t *testing.T) {

--- a/internal/db/usage_rollup_lifecycle_test.go
+++ b/internal/db/usage_rollup_lifecycle_test.go
@@ -1,0 +1,370 @@
+//go:build fts5
+
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+func TestUsageTimezoneIdentityUsesNamedZone(t *testing.T) {
+	loc, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err)
+	intervals := usageQueryIntervals(UsageFilter{
+		From: "2026-03-07", To: "2026-03-09", Timezone: "America/Chicago",
+	})
+
+	got := usageTimezoneIdentityFor(loc, intervals)
+
+	assert.Equal(t, "America/Chicago", got.Name)
+	assert.Equal(t, "America/Chicago", got.Key)
+	assert.NotEmpty(t, got.IntervalFingerprint)
+}
+
+func TestUsageTimezoneIdentitySeparatesAnonymousLocalIntervals(t *testing.T) {
+	left := usageTimezoneIdentityFor(time.FixedZone("Local", -6*60*60),
+		[]usageQueryInterval{{
+			FromMillis: 0, ToMillis: 86_400_000,
+			FromLocalDate: "2026-01-01", ToLocalDate: "2026-01-01",
+		}})
+	right := usageTimezoneIdentityFor(time.FixedZone("Local", 9*60*60),
+		[]usageQueryInterval{{
+			FromMillis: 54_000_000, ToMillis: 140_400_000,
+			FromLocalDate: "2026-01-01", ToLocalDate: "2026-01-01",
+		}})
+
+	assert.NotEqual(t, left.Key, right.Key)
+	assert.NotEqual(t, left.IntervalFingerprint, right.IntervalFingerprint)
+}
+
+func TestUsageTimezoneIdentityIsIndependentOfQueryWindow(t *testing.T) {
+	location := time.FixedZone("Local", -6*60*60)
+	short := usageTimezoneIdentityFor(location, []usageQueryInterval{{
+		FromMillis: 0, ToMillis: 86_400_000,
+		FromLocalDate: "2026-01-01", ToLocalDate: "2026-01-01",
+	}})
+	long := usageTimezoneIdentityFor(location, []usageQueryInterval{{
+		FromMillis: 0, ToMillis: 2_592_000_000,
+		FromLocalDate: "2026-01-01", ToLocalDate: "2026-01-30",
+	}})
+	assert.Equal(t, short, long)
+}
+
+func TestUsageLocationNameDoesNotRewriteAnonymousFixedZone(t *testing.T) {
+	assert.Equal(t, "Local", usageLocationName(time.FixedZone("Local", -6*60*60)))
+}
+
+func TestUsageTimezoneIdentitySurvivesLocalInitialization(t *testing.T) {
+	before := usageTimezoneIdentityFor(time.Local, nil)
+	_, _ = time.Now().In(time.Local).Zone()
+	after := usageTimezoneIdentityFor(time.Local, nil)
+	assert.Equal(t, before, after)
+}
+
+func TestUsageRollupCallKeyIncludesCursorHighWater(t *testing.T) {
+	snapshot := usageQuerySnapshot{CursorHighWater: 1, location: time.UTC}
+	first := usageRollupCallKey(snapshot, nil, "pricing")
+	snapshot.CursorHighWater = 2
+	second := usageRollupCallKey(snapshot, nil, "pricing")
+	assert.NotEqual(t, first, second)
+}
+
+func TestUsagePricingHashTracksPricingSemantics(t *testing.T) {
+	base := []export.EffectivePricingRow{{
+		ModelPattern: "model-*",
+		Rates: export.ModelRates{
+			InputPerMTok:      money.Money{Microdollars: 1_000_000},
+			OutputPerMTok:     money.Money{Microdollars: 2_000_000},
+			CacheWritePerMTok: money.Money{Microdollars: 3_000_000},
+			CacheReadPerMTok:  money.Money{Microdollars: 4_000_000},
+			Source:            export.PricingRowSourceCustom,
+			Bands: []export.PricingBand{{
+				AboveInputTokens: 200_000,
+				InputPerMTok:     money.Money{Microdollars: 5_000_000},
+				OutputPerMTok:    money.Money{Microdollars: 6_000_000},
+			}},
+		},
+	}}
+	original, err := export.EffectivePricingDigest(base)
+	require.NoError(t, err)
+	identical, err := export.EffectivePricingDigest(cloneEffectivePricingRowsForTest(base))
+	require.NoError(t, err)
+	assert.Equal(t, original, identical)
+	reordered := cloneEffectivePricingRowsForTest(base)
+	reordered = append(reordered, export.EffectivePricingRow{
+		ModelPattern: "another-*",
+		Rates: export.ModelRates{
+			InputPerMTok: money.Money{Microdollars: 7_000_000},
+		},
+	})
+	forward, err := export.EffectivePricingDigest(reordered)
+	require.NoError(t, err)
+	slices.Reverse(reordered)
+	reversed, err := export.EffectivePricingDigest(reordered)
+	require.NoError(t, err)
+	assert.Equal(t, forward, reversed, "pricing order must not invalidate rollups")
+
+	tests := map[string]func([]export.EffectivePricingRow){
+		"pattern": func(rows []export.EffectivePricingRow) {
+			rows[0].ModelPattern = "other-*"
+		},
+		"input rate": func(rows []export.EffectivePricingRow) {
+			rows[0].Rates.InputPerMTok.Microdollars++
+		},
+		"band threshold": func(rows []export.EffectivePricingRow) {
+			rows[0].Rates.Bands[0].AboveInputTokens++
+		},
+		"band rate": func(rows []export.EffectivePricingRow) {
+			rows[0].Rates.Bands[0].OutputPerMTok.Microdollars++
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			changed := cloneEffectivePricingRowsForTest(base)
+			mutate(changed)
+			got, err := export.EffectivePricingDigest(changed)
+			require.NoError(t, err)
+			assert.NotEqual(t, original, got)
+		})
+	}
+}
+
+func TestUsageQuerySnapshotPinsPricingRows(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.UpsertModelPricing([]ModelPricing{{
+		ModelPattern: "snapshot-model",
+		InputPerMTok: money.Money{Microdollars: 1_000_000},
+	}}))
+
+	before, err := database.captureUsageQuery(t.Context(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	beforeRate := effectivePricingRateForTest(t, before.PricingRows, "snapshot-model")
+
+	require.NoError(t, database.UpsertModelPricing([]ModelPricing{{
+		ModelPattern: "snapshot-model",
+		InputPerMTok: money.Money{Microdollars: 9_000_000},
+	}}))
+	after, err := database.captureUsageQuery(t.Context(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	afterRate := effectivePricingRateForTest(t, after.PricingRows, "snapshot-model")
+
+	assert.Equal(t, int64(1_000_000), beforeRate.InputPerMTok.Microdollars)
+	assert.Equal(t, int64(9_000_000), afterRate.InputPerMTok.Microdollars)
+}
+
+func TestUsageRollupAgentChangeInvalidatesInstalledRows(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "rollup-session", "project-a", func(session *Session) {
+		session.Agent = "codex"
+		session.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "rollup-session", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T09:00:00Z", Model: "model-a",
+		TokenUsage: json.RawMessage(`{"input_tokens":2,"output_tokens":3}`),
+	}}))
+
+	firstSnapshot, firstFills, cache := prepareUsageRollupTest(t, database)
+	first, _, err := cache.rollup.Ensure(
+		t.Context(), firstSnapshot, firstFills,
+		export.NewPricingResolver(firstSnapshot.PricingRows),
+	)
+	require.NoError(t, err)
+	firstInstall := first["rollup-session"]
+
+	beforeVersion := firstSnapshot.Versions[0]
+	_, err = database.getWriter().Exec(`UPDATE sessions SET agent = 'claude'
+		WHERE id = 'rollup-session'`)
+	require.NoError(t, err)
+	secondSnapshot, secondFills, _ := prepareUsageRollupTest(t, database)
+	require.Len(t, secondSnapshot.Versions, 1)
+	assert.True(t, beforeVersion.Equal(secondSnapshot.Versions[0]),
+		"agent is intentionally outside the normalized-facts fingerprint")
+
+	second, _, err := cache.rollup.Ensure(
+		t.Context(), secondSnapshot, secondFills,
+		export.NewPricingResolver(secondSnapshot.PricingRows),
+	)
+	require.NoError(t, err)
+	assert.Greater(t, second["rollup-session"].InstallRevision,
+		firstInstall.InstallRevision)
+}
+
+func TestUsageRollupStartedAtChangeInvalidatesInstalledRows(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "rollup-start", "project-a", func(session *Session) {
+		session.Agent = "codex"
+		session.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "rollup-start", Ordinal: 0, Role: "assistant",
+		Model:      "model-a",
+		TokenUsage: json.RawMessage(`{"input_tokens":2,"output_tokens":3}`),
+	}}))
+	_, err := database.getWriter().Exec(`UPDATE sessions
+		SET file_mtime = '2099-01-01T00:00:00Z' WHERE id = 'rollup-start'`)
+	require.NoError(t, err)
+
+	firstSnapshot, firstFills, cache := prepareUsageRollupTest(t, database)
+	first, _, err := cache.rollup.Ensure(
+		t.Context(), firstSnapshot, firstFills,
+		export.NewPricingResolver(firstSnapshot.PricingRows),
+	)
+	require.NoError(t, err)
+	_, err = database.getWriter().Exec(`UPDATE sessions
+		SET started_at = '2026-08-10T08:30:00Z' WHERE id = 'rollup-start'`)
+	require.NoError(t, err)
+	secondSnapshot, secondFills, _ := prepareUsageRollupTest(t, database)
+	assert.True(t, firstSnapshot.Versions[0].Equal(secondSnapshot.Versions[0]),
+		"a later file_mtime masks the started_at change in sync_marker")
+
+	second, _, err := cache.rollup.Ensure(
+		t.Context(), secondSnapshot, secondFills,
+		export.NewPricingResolver(secondSnapshot.PricingRows),
+	)
+	require.NoError(t, err)
+	assert.Greater(t, second["rollup-start"].InstallRevision,
+		first["rollup-start"].InstallRevision)
+}
+
+func TestUsageRollupPricingChangeInvalidatesInstalledRows(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "rollup-price", "project-a", func(session *Session) {
+		session.StartedAt = &started
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "rollup-price", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T09:00:00Z", Model: "priced-model",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000000}`),
+	}}))
+	require.NoError(t, database.UpsertModelPricing([]ModelPricing{{
+		ModelPattern: "priced-model",
+		InputPerMTok: money.Money{Microdollars: 1_000_000},
+	}}))
+
+	firstSnapshot, firstFills, cache := prepareUsageRollupTest(t, database)
+	first, _, err := cache.rollup.Ensure(t.Context(), firstSnapshot, firstFills,
+		export.NewPricingResolver(firstSnapshot.PricingRows))
+	require.NoError(t, err)
+	require.NoError(t, database.UpsertModelPricing([]ModelPricing{{
+		ModelPattern: "priced-model",
+		InputPerMTok: money.Money{Microdollars: 2_000_000},
+	}}))
+	secondSnapshot, secondFills, _ := prepareUsageRollupTest(t, database)
+	second, _, err := cache.rollup.Ensure(t.Context(), secondSnapshot, secondFills,
+		export.NewPricingResolver(secondSnapshot.PricingRows))
+	require.NoError(t, err)
+	assert.Greater(t, second["rollup-price"].InstallRevision,
+		first["rollup-price"].InstallRevision)
+
+	daily, err := database.GetDailyUsage(t.Context(), UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2_000_000), daily.Totals.TotalCost.Microdollars)
+}
+
+func TestUsageRollupConnectedSnapshotChangeRebuildsOnlyChangedSession(t *testing.T) {
+	database := testDB(t)
+	for index, id := range []string{"session-a", "session-b"} {
+		started := []string{"2026-08-10T08:00:00Z", "2026-08-10T08:01:00Z"}[index]
+		insertSession(t, database, id, "project-a", func(session *Session) {
+			session.Agent = "claude"
+			session.StartedAt = &started
+		})
+	}
+	message := func(sessionID string, output int) Message {
+		return Message{
+			SessionID: sessionID, Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-10T09:00:00Z", Model: "model-a",
+			TokenUsage: json.RawMessage(fmt.Sprintf(
+				`{"input_tokens":2,"output_tokens":%d}`, output)),
+			ClaudeMessageID: "message-id", ClaudeRequestID: "request-id",
+		}
+	}
+	require.NoError(t, database.InsertMessages([]Message{
+		message("session-a", 10), message("session-b", 20),
+	}))
+
+	firstSnapshot, firstFills, cache := prepareUsageRollupTest(t, database)
+	first, _, err := cache.rollup.Ensure(
+		t.Context(), firstSnapshot, firstFills,
+		export.NewPricingResolver(firstSnapshot.PricingRows),
+	)
+	require.NoError(t, err)
+	require.NoError(t, database.ReplaceSessionMessages(
+		"session-b", []Message{message("session-b", 30)},
+	))
+	secondSnapshot, secondFills, _ := prepareUsageRollupTest(t, database)
+	second, _, err := cache.rollup.Ensure(
+		t.Context(), secondSnapshot, secondFills,
+		export.NewPricingResolver(secondSnapshot.PricingRows),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, first["session-a"].InstallRevision,
+		second["session-a"].InstallRevision)
+	assert.Greater(t, second["session-b"].InstallRevision,
+		first["session-b"].InstallRevision)
+
+	daily, err := database.GetDailyUsage(t.Context(), UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, daily.Totals.InputTokens)
+	assert.Equal(t, 30, daily.Totals.OutputTokens,
+		"the changed sibling must immediately replace the snapshot winner")
+}
+
+func prepareUsageRollupTest(
+	t *testing.T, database *DB,
+) (usageQuerySnapshot, map[string]usageFillResult, *usageCache) {
+	t.Helper()
+	snapshot, err := database.captureUsageQuery(t.Context(), UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	fills, err := cache.fill.Ensure(
+		t.Context(), snapshot.Versions, snapshot.CursorHighWater,
+	)
+	require.NoError(t, err)
+	return snapshot, fills, cache
+}
+
+func cloneEffectivePricingRowsForTest(
+	rows []export.EffectivePricingRow,
+) []export.EffectivePricingRow {
+	cloned := append([]export.EffectivePricingRow(nil), rows...)
+	for index := range cloned {
+		cloned[index].Rates.Bands = append(
+			[]export.PricingBand(nil), rows[index].Rates.Bands...,
+		)
+	}
+	return cloned
+}
+
+func effectivePricingRateForTest(
+	t *testing.T, rows []export.EffectivePricingRow, pattern string,
+) export.ModelRates {
+	t.Helper()
+	for _, row := range rows {
+		if row.ModelPattern == pattern {
+			return row.Rates
+		}
+	}
+	require.FailNow(t, "pricing row not found", pattern)
+	return export.ModelRates{}
+}

--- a/internal/db/usage_rollup_lifecycle_test.go
+++ b/internal/db/usage_rollup_lifecycle_test.go
@@ -30,6 +30,14 @@ func TestUsageTimezoneIdentityUsesNamedZone(t *testing.T) {
 	assert.NotEmpty(t, got.IntervalFingerprint)
 }
 
+func TestUsageTimezoneIdentityTracksNamedZoneRules(t *testing.T) {
+	left := usageTimezoneIdentityFor(time.FixedZone("Named/Zone", -6*60*60), nil)
+	right := usageTimezoneIdentityFor(time.FixedZone("Named/Zone", 9*60*60), nil)
+
+	assert.Equal(t, left.Name, right.Name)
+	assert.NotEqual(t, left.IntervalFingerprint, right.IntervalFingerprint)
+}
+
 func TestUsageTimezoneIdentitySeparatesAnonymousLocalIntervals(t *testing.T) {
 	left := usageTimezoneIdentityFor(time.FixedZone("Local", -6*60*60),
 		[]usageQueryInterval{{

--- a/internal/db/usage_rollup_lifecycle_test.go
+++ b/internal/db/usage_rollup_lifecycle_test.go
@@ -3,6 +3,8 @@
 package db
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -30,34 +32,63 @@ func TestUsageTimezoneIdentityUsesNamedZone(t *testing.T) {
 	assert.Equal(t, "America/Chicago:"+got.IntervalFingerprint, got.Key)
 }
 
-func TestUsageTimezoneIdentityTracksNamedZoneRules(t *testing.T) {
-	left := usageTimezoneIdentityFor(time.FixedZone("Named/Zone", -6*60*60), nil)
-	right := usageTimezoneIdentityFor(time.FixedZone("Named/Zone", 9*60*60), nil)
+func TestUsageTimezoneRuleFingerprintTracksNamedZoneRules(t *testing.T) {
+	left := usageTimezoneRuleFingerprint(
+		"Named/Zone", time.FixedZone("Named/Zone", -6*60*60))
+	right := usageTimezoneRuleFingerprint(
+		"Named/Zone", time.FixedZone("Named/Zone", 9*60*60))
 
-	assert.Equal(t, left.Name, right.Name)
-	assert.NotEqual(t, left.IntervalFingerprint, right.IntervalFingerprint)
-	assert.NotEqual(t, left.Key, right.Key,
+	assert.NotEqual(t, left, right,
 		"changed named-zone rules must select a new rollup generation")
 }
 
-func TestUsageTimezoneIdentitySeparatesAnonymousLocalIntervals(t *testing.T) {
-	left := usageTimezoneIdentityFor(time.FixedZone("Local", -6*60*60),
-		[]usageQueryInterval{{
-			FromMillis: 0, ToMillis: 86_400_000,
-			FromLocalDate: "2026-01-01", ToLocalDate: "2026-01-01",
-		}})
-	right := usageTimezoneIdentityFor(time.FixedZone("Local", 9*60*60),
-		[]usageQueryInterval{{
-			FromMillis: 54_000_000, ToMillis: 140_400_000,
-			FromLocalDate: "2026-01-01", ToLocalDate: "2026-01-01",
-		}})
+// testTZifSingleTransition builds a TZif v1 zone that switches from UTC+0
+// "AAA" to UTC+1 "BBB" at the given Unix instant.
+func testTZifSingleTransition(t *testing.T, transition int64) *time.Location {
+	t.Helper()
+	var buf bytes.Buffer
+	buf.WriteString("TZif")
+	buf.Write(make([]byte, 16))
+	for _, count := range []uint32{0, 0, 0, 1, 2, 8} {
+		require.NoError(t, binary.Write(&buf, binary.BigEndian, count))
+	}
+	require.NoError(t, binary.Write(&buf, binary.BigEndian, int32(transition)))
+	buf.WriteByte(1)
+	require.NoError(t, binary.Write(&buf, binary.BigEndian, int32(0)))
+	buf.Write([]byte{0, 0})
+	require.NoError(t, binary.Write(&buf, binary.BigEndian, int32(3600)))
+	buf.Write([]byte{1, 4})
+	buf.WriteString("AAA\x00BBB\x00")
+	location, err := time.LoadLocationFromTZData("Test/Zone", buf.Bytes())
+	require.NoError(t, err)
+	return location
+}
 
-	assert.NotEqual(t, left.Key, right.Key)
-	assert.NotEqual(t, left.IntervalFingerprint, right.IntervalFingerprint)
+func TestUsageTimezoneRuleFingerprintTracksTransitionInstants(t *testing.T) {
+	tuesday := time.Date(1990, 6, 12, 3, 0, 0, 0, time.UTC).Unix()
+	wednesday := time.Date(1990, 6, 13, 3, 0, 0, 0, time.UTC).Unix()
+
+	left := usageTimezoneRuleFingerprint(
+		"Test/Zone", testTZifSingleTransition(t, tuesday))
+	right := usageTimezoneRuleFingerprint(
+		"Test/Zone", testTZifSingleTransition(t, wednesday))
+
+	assert.NotEqual(t, left, right,
+		"a zoneinfo update that moves a transition must change the fingerprint")
+}
+
+func TestUsageTimezoneRuleFingerprintSeparatesAnonymousLocalRules(t *testing.T) {
+	left := usageTimezoneRuleFingerprint(
+		"Local", time.FixedZone("Local", -6*60*60))
+	right := usageTimezoneRuleFingerprint(
+		"Local", time.FixedZone("Local", 9*60*60))
+
+	assert.NotEqual(t, left, right)
 }
 
 func TestUsageTimezoneIdentityIsIndependentOfQueryWindow(t *testing.T) {
-	location := time.FixedZone("Local", -6*60*60)
+	location, err := time.LoadLocation("America/Denver")
+	require.NoError(t, err)
 	short := usageTimezoneIdentityFor(location, []usageQueryInterval{{
 		FromMillis: 0, ToMillis: 86_400_000,
 		FromLocalDate: "2026-01-01", ToLocalDate: "2026-01-01",
@@ -71,6 +102,27 @@ func TestUsageTimezoneIdentityIsIndependentOfQueryWindow(t *testing.T) {
 
 func TestUsageLocationNameDoesNotRewriteAnonymousFixedZone(t *testing.T) {
 	assert.Equal(t, "Local", usageLocationName(time.FixedZone("Local", -6*60*60)))
+}
+
+func TestUsageTimezoneIdentityCachesPerZoneNameNotPerPointer(t *testing.T) {
+	first, err := time.LoadLocation("Pacific/Chatham")
+	require.NoError(t, err)
+	second, err := time.LoadLocation("Pacific/Chatham")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		usageTimezoneIdentityFor(first, nil),
+		usageTimezoneIdentityFor(second, nil))
+
+	entries := 0
+	usageTimezoneIdentityCache.Range(func(_, value any) bool {
+		if value.(usageTimezoneIdentity).Name == "Pacific/Chatham" {
+			entries++
+		}
+		return true
+	})
+	assert.Equal(t, 1, entries,
+		"repeated LoadLocation calls for one zone must share a cache entry")
 }
 
 func TestUsageTimezoneIdentitySurvivesLocalInitialization(t *testing.T) {

--- a/internal/db/usage_rollup_lifecycle_test.go
+++ b/internal/db/usage_rollup_lifecycle_test.go
@@ -26,8 +26,8 @@ func TestUsageTimezoneIdentityUsesNamedZone(t *testing.T) {
 	got := usageTimezoneIdentityFor(loc, intervals)
 
 	assert.Equal(t, "America/Chicago", got.Name)
-	assert.Equal(t, "America/Chicago", got.Key)
 	assert.NotEmpty(t, got.IntervalFingerprint)
+	assert.Equal(t, "America/Chicago:"+got.IntervalFingerprint, got.Key)
 }
 
 func TestUsageTimezoneIdentityTracksNamedZoneRules(t *testing.T) {
@@ -36,6 +36,8 @@ func TestUsageTimezoneIdentityTracksNamedZoneRules(t *testing.T) {
 
 	assert.Equal(t, left.Name, right.Name)
 	assert.NotEqual(t, left.IntervalFingerprint, right.IntervalFingerprint)
+	assert.NotEqual(t, left.Key, right.Key,
+		"changed named-zone rules must select a new rollup generation")
 }
 
 func TestUsageTimezoneIdentitySeparatesAnonymousLocalIntervals(t *testing.T) {
@@ -84,6 +86,28 @@ func TestUsageRollupCallKeyIncludesCursorHighWater(t *testing.T) {
 	snapshot.CursorHighWater = 2
 	second := usageRollupCallKey(snapshot, nil, "pricing")
 	assert.NotEqual(t, first, second)
+}
+
+func TestUsageRollupCallKeyIncludesBakedSessionMetadata(t *testing.T) {
+	snapshot := usageQuerySnapshot{
+		location: time.UTC,
+		Versions: []usageSourceVersion{{SessionID: "session-a"}},
+		Sessions: []usageQuerySession{{
+			ID: "session-a", Agent: "codex", StartedAt: "2026-08-10T08:00:00Z",
+		}},
+	}
+	fills := map[string]usageFillResult{
+		"session-a": {InstallRevision: 1},
+	}
+
+	original := usageRollupCallKey(snapshot, fills, "pricing")
+	snapshot.Sessions[0].Agent = "claude"
+	agentChanged := usageRollupCallKey(snapshot, fills, "pricing")
+	snapshot.Sessions[0].StartedAt = "2026-08-11T08:00:00Z"
+	startedAtChanged := usageRollupCallKey(snapshot, fills, "pricing")
+
+	assert.NotEqual(t, original, agentChanged)
+	assert.NotEqual(t, agentChanged, startedAtChanged)
 }
 
 func TestUsagePricingHashTracksPricingSemantics(t *testing.T) {

--- a/internal/db/usage_rollup_query.go
+++ b/internal/db/usage_rollup_query.go
@@ -238,7 +238,7 @@ func readUsageRollupExceptions(
 		e.cache_creation_tokens, e.cache_read_tokens, e.web_search_requests,
 		e.reported_cost_microdollars, e.cost_source, e.request_scoped,
 		e.claude_message_id, e.claude_request_id, e.source_uuid,
-		e.usage_dedup_key
+		e.usage_dedup_key, COUNT(*) OVER ()
 		FROM usage_rollup_exceptions e
 		JOIN usage_rollup_installs i ON i.id = e.rollup_install_id
 		WHERE i.timezone_id = ? AND (? = '' OR e.local_date >= ?)
@@ -257,7 +257,7 @@ func readUsageRollupExceptions(
 	for rows.Next() {
 		var fact usageRollupFact
 		var ordinal, millis, nanos, reported sql.NullInt64
-		var usesStart, requestScoped int
+		var usesStart, requestScoped, resultCount int
 		if err := rows.Scan(&fact.CachedSessionID, &fact.FactIndex,
 			&fact.SourceSessionID, &fact.LocalDate, &fact.Fact.Source, &ordinal,
 			&millis, &nanos, &fact.Fact.RawTimestamp, &usesStart, &fact.Model,
@@ -266,8 +266,11 @@ func readUsageRollupExceptions(
 			&fact.Fact.CacheReadTokens, &fact.Fact.WebSearchRequests, &reported,
 			&fact.Fact.CostSource, &requestScoped, &fact.Fact.ClaudeMessageID,
 			&fact.Fact.ClaudeRequestID, &fact.Fact.SourceUUID,
-			&fact.Fact.UsageDedupKey); err != nil {
+			&fact.Fact.UsageDedupKey, &resultCount); err != nil {
 			return nil, err
+		}
+		if result == nil && resultCount > 0 {
+			result = make([]usageRollupFact, 0, resultCount)
 		}
 		if _, ok := sessions[fact.SourceSessionID]; !ok &&
 			fact.SourceSessionID != "" {
@@ -434,43 +437,108 @@ func aggregateUsageRollupExceptions(
 func rankUsageRollupSnapshots(
 	facts []usageRollupFact,
 ) (plain, general []usageRollupFact, discarded int64) {
-	bySnapshot := make(map[string][]usageRollupFact)
-	for _, fact := range facts {
-		key := usageRollupSnapshotKey(fact)
+	type survivorRef struct {
+		index   int
+		general bool
+	}
+	type snapshotGroup struct {
+		first int
+		rest  []int
+	}
+	// Keep only indexes in the grouping map. usageRollupFact is intentionally
+	// wide enough to resolve every dedup edge; copying it into each group made
+	// warm aggregate reads allocate another full exception set.
+	bySnapshot := make(map[string]snapshotGroup)
+	survivors := make([]survivorRef, 0, len(facts))
+	for index := range facts {
+		key := usageRollupSnapshotKey(facts[index])
 		if key == "" {
-			general = append(general, fact)
+			survivors = append(survivors, survivorRef{index: index, general: true})
 			continue
 		}
-		bySnapshot[key] = append(bySnapshot[key], fact)
+		group, exists := bySnapshot[key]
+		if !exists {
+			bySnapshot[key] = snapshotGroup{first: index}
+			continue
+		}
+		group.rest = append(group.rest, index)
+		bySnapshot[key] = group
 	}
 	keys := usageSortedMapKeys(bySnapshot)
 	for _, key := range keys {
-		members := bySnapshot[key]
-		if len(members) == 1 {
-			if usageRollupGeneralKey(members[0]) == "" {
-				plain = append(plain, members[0])
-			} else {
-				general = append(general, members[0])
-			}
+		group := bySnapshot[key]
+		if len(group.rest) == 0 {
+			member := facts[group.first]
+			survivors = append(survivors, survivorRef{
+				index: group.first, general: usageRollupGeneralKey(member) != "",
+			})
 			continue
 		}
-		attribution := slices.MinFunc(members, compareUsageSnapshotAttribution)
-		winner := slices.MaxFunc(members, compareUsageSnapshotWinner)
+		attribution := facts[group.first]
+		winnerIndex := group.first
+		winner := attribution
+		for _, index := range group.rest {
+			member := facts[index]
+			if compareUsageSnapshotAttribution(member, attribution) < 0 {
+				attribution = member
+			}
+			if compareUsageSnapshotWinner(member, winner) > 0 {
+				winnerIndex = index
+				winner = member
+			}
+		}
 		winner.AttributionSessionID = attribution.SourceSessionID
-		for _, member := range members {
+		first := facts[group.first]
+		winner.Fact.WebSearchRequests = max(
+			winner.Fact.WebSearchRequests, first.Fact.WebSearchRequests)
+		if usageRollupFactIdentity(first) != usageRollupFactIdentity(winner) {
+			discarded += first.Fact.OutputTokens
+		}
+		for _, index := range group.rest {
+			member := facts[index]
 			winner.Fact.WebSearchRequests = max(
 				winner.Fact.WebSearchRequests, member.Fact.WebSearchRequests)
 			if usageRollupFactIdentity(member) != usageRollupFactIdentity(winner) {
 				discarded += member.Fact.OutputTokens
 			}
 		}
-		if winner.Fact.UsageDedupKey == "" {
-			plain = append(plain, winner)
-		} else {
-			general = append(general, winner)
+		facts[winnerIndex] = winner
+		survivors = append(survivors, survivorRef{
+			index: winnerIndex, general: winner.Fact.UsageDedupKey != "",
+		})
+	}
+
+	// Compact survivors into the input backing array in source order. The nth
+	// survivor's source index is always at least n, so no unread survivor is
+	// overwritten. Partitioning that compacted prefix then gives both result
+	// slices without allocating another wide-fact backing array.
+	slices.SortFunc(survivors, func(a, b survivorRef) int {
+		return cmp.Compare(a.index, b.index)
+	})
+	classes := make([]bool, len(survivors))
+	plainCount := 0
+	for output, survivor := range survivors {
+		facts[output] = facts[survivor.index]
+		classes[output] = survivor.general
+		if !survivor.general {
+			plainCount++
 		}
 	}
-	return plain, general, discarded
+	left, right := 0, len(survivors)-1
+	for left < plainCount {
+		if !classes[left] {
+			left++
+			continue
+		}
+		for classes[right] {
+			right--
+		}
+		facts[left], facts[right] = facts[right], facts[left]
+		classes[left], classes[right] = classes[right], classes[left]
+		left++
+		right--
+	}
+	return facts[:plainCount], facts[plainCount:len(survivors)], discarded
 }
 
 func filterUsageRollupOwners(

--- a/internal/db/usage_rollup_query.go
+++ b/internal/db/usage_rollup_query.go
@@ -1,0 +1,669 @@
+package db
+
+import (
+	"cmp"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/export"
+)
+
+type usageFactsGroup struct {
+	SessionID, Date, Project, Agent, Machine     string
+	Model, PricedModel, MatchedPattern           string
+	RateOK                                       bool
+	InputTokens, OutputTokens, ReasoningTokens   int64
+	CacheCreationTokens, CacheReadTokens         int64
+	CostMicrodollars, SavingsMicrodollars        int64
+	AuthoritativeCostMicrodollars                *int64
+	ComputedRequestCount, ComputedAggregateCount int
+	ReportedCount, BaseRequestCount              int
+	BandThreshold                                *int
+	DiscardedSnapshotOutputTokens                int64
+}
+
+type usageFactsResult struct {
+	Groups           []usageFactsGroup
+	MatchingSessions map[string]UsageSessionInfo
+}
+
+type usageCacheMissingSessionError struct{ SessionID string }
+
+func (err *usageCacheMissingSessionError) Error() string {
+	return "required usage cache session is missing: " + err.SessionID
+}
+
+func usageCacheReadShouldRecapture(err error) bool {
+	if errors.Is(err, errUsageCacheSourceChanged) {
+		return true
+	}
+	var missing *usageCacheMissingSessionError
+	return errors.As(err, &missing)
+}
+
+func usageCursorIncluded(filter UsageFilter) bool {
+	_, _, ok := cursorUsageRowsSQLForBounds(
+		filter, usageBoundsForFilter(filter))
+	return ok
+}
+
+// usageRollupQuery reads compact daily rows and resolves only facts whose
+// deduplication can depend on the requested window or live session filters.
+func (cache *usageCache) usageRollupQuery(
+	ctx context.Context, snapshot usageQuerySnapshot, filter UsageFilter,
+	installs map[string]usageRollupInstall, resolver *export.PricingResolver,
+) (usageFactsResult, error) {
+	if len(snapshot.Sessions) == 0 && snapshot.CursorHighWater == 0 {
+		return usageFactsResult{
+			MatchingSessions: make(map[string]UsageSessionInfo),
+		}, nil
+	}
+	conn, err := cache.db.Conn(ctx)
+	if err != nil {
+		return usageFactsResult{}, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN`); err != nil {
+		return usageFactsResult{}, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+	identity := usageTimezoneIdentityFor(snapshot.location, snapshot.Intervals)
+	timezoneID, err := verifyUsageRollupQuery(
+		ctx, conn, identity.Key, snapshot, installs)
+	if err != nil {
+		return usageFactsResult{}, err
+	}
+	result, err := readUsageDailyRollups(
+		ctx, conn, timezoneID, snapshot, filter)
+	if err != nil {
+		return usageFactsResult{}, err
+	}
+	exceptions, err := readUsageRollupExceptions(
+		ctx, conn, timezoneID, snapshot, filter)
+	if err != nil {
+		return usageFactsResult{}, err
+	}
+	exceptionGroups, err := aggregateUsageRollupExceptions(
+		exceptions, snapshot, filter, resolver)
+	if err != nil {
+		return usageFactsResult{}, err
+	}
+	result.Groups = append(result.Groups, exceptionGroups...)
+	slices.SortFunc(result.Groups, compareUsageFactsGroup)
+	for _, group := range exceptionGroups {
+		if group.SessionID != "" {
+			result.MatchingSessions[group.SessionID] = UsageSessionInfo{
+				Project: group.Project, Agent: group.Agent,
+			}
+		}
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return usageFactsResult{}, err
+	}
+	committed = true
+	return result, nil
+}
+
+func verifyUsageRollupQuery(
+	ctx context.Context, conn *sql.Conn, timezoneKey string,
+	snapshot usageQuerySnapshot, installs map[string]usageRollupInstall,
+) (int64, error) {
+	var timezoneID int64
+	if err := conn.QueryRowContext(ctx, `SELECT id FROM usage_rollup_timezones
+		WHERE timezone_key = ?`, timezoneKey).Scan(&timezoneID); err != nil {
+		return 0, err
+	}
+	for _, session := range snapshot.Sessions {
+		if err := verifyUsageRollupInstall(
+			ctx, conn, timezoneID, session.ID, installs,
+		); err != nil {
+			return 0, err
+		}
+	}
+	if snapshot.CursorHighWater > 0 {
+		if err := verifyUsageRollupInstall(
+			ctx, conn, timezoneID, usageRollupCursorSessionID, installs,
+		); err != nil {
+			return 0, err
+		}
+	}
+	return timezoneID, nil
+}
+
+func verifyUsageRollupInstall(
+	ctx context.Context, conn *sql.Conn, timezoneID int64, sessionID string,
+	installs map[string]usageRollupInstall,
+) error {
+	required, ok := installs[sessionID]
+	if !ok {
+		return &usageCacheMissingSessionError{SessionID: sessionID}
+	}
+	var revision int64
+	var pricingHash string
+	if err := conn.QueryRowContext(ctx, `SELECT install_revision, pricing_hash
+		FROM usage_rollup_installs WHERE id = ? AND timezone_id = ?`,
+		required.ID, timezoneID).Scan(&revision, &pricingHash); err != nil {
+		if err == sql.ErrNoRows {
+			return &usageCacheMissingSessionError{SessionID: sessionID}
+		}
+		return err
+	}
+	if revision != required.InstallRevision || pricingHash != required.PricingHash {
+		return fmt.Errorf("%w: usage rollup session %s changed before read",
+			errUsageCacheSourceChanged, sessionID)
+	}
+	return nil
+}
+
+func readUsageDailyRollups(
+	ctx context.Context, conn *sql.Conn, timezoneID int64,
+	snapshot usageQuerySnapshot, filter UsageFilter,
+) (usageFactsResult, error) {
+	from, to := usageRollupDateBounds(snapshot)
+	rows, err := conn.QueryContext(ctx, `SELECT i.session_id, r.local_date,
+		r.reported_model, r.priced_model, r.matched_pattern, r.rate_ok,
+		r.input_tokens, r.output_tokens, r.reasoning_tokens,
+		r.cache_creation_tokens, r.cache_read_tokens,
+		r.estimated_cost_microdollars, r.savings_microdollars,
+		r.authoritative_cost_microdollars, r.computed_request_count,
+		r.computed_aggregate_count, r.reported_count, r.base_request_count,
+		r.band_threshold, r.discarded_snapshot_output_tokens
+		FROM usage_daily_rollups r
+		JOIN usage_rollup_installs i ON i.id = r.rollup_install_id
+		WHERE i.timezone_id = ? AND (? = '' OR r.local_date >= ?)
+		  AND (? = '' OR r.local_date <= ?)
+		ORDER BY r.local_date, i.session_id, r.reported_model, r.band_threshold`,
+		timezoneID, from, from, to, to)
+	if err != nil {
+		return usageFactsResult{}, err
+	}
+	defer rows.Close()
+	sessions := usageRollupSessionMap(snapshot)
+	result := usageFactsResult{MatchingSessions: make(map[string]UsageSessionInfo)}
+	for rows.Next() {
+		var group usageFactsGroup
+		var rateOK int
+		var authoritative, band sql.NullInt64
+		if err := rows.Scan(&group.SessionID, &group.Date, &group.Model,
+			&group.PricedModel, &group.MatchedPattern, &rateOK,
+			&group.InputTokens, &group.OutputTokens, &group.ReasoningTokens,
+			&group.CacheCreationTokens, &group.CacheReadTokens,
+			&group.CostMicrodollars, &group.SavingsMicrodollars, &authoritative,
+			&group.ComputedRequestCount, &group.ComputedAggregateCount,
+			&group.ReportedCount, &group.BaseRequestCount, &band,
+			&group.DiscardedSnapshotOutputTokens); err != nil {
+			return usageFactsResult{}, err
+		}
+		session, ok := sessions[group.SessionID]
+		if !ok || !session.PassesFilter || !usageRollupModelPasses(filter, group.Model) {
+			continue
+		}
+		group.Project, group.Agent, group.Machine =
+			session.Project, session.Agent, session.Machine
+		group.RateOK = rateOK != 0
+		if authoritative.Valid {
+			value := authoritative.Int64
+			group.AuthoritativeCostMicrodollars = &value
+		}
+		if band.Valid && band.Int64 >= 0 {
+			value := int(band.Int64)
+			group.BandThreshold = &value
+		}
+		result.Groups = append(result.Groups, group)
+		result.MatchingSessions[group.SessionID] = UsageSessionInfo{
+			Project: group.Project, Agent: group.Agent,
+		}
+	}
+	return result, rows.Err()
+}
+
+func readUsageRollupExceptions(
+	ctx context.Context, conn *sql.Conn, timezoneID int64,
+	snapshot usageQuerySnapshot, filter UsageFilter,
+) ([]usageRollupFact, error) {
+	from, to := usageRollupDateBounds(snapshot)
+	rows, err := conn.QueryContext(ctx, `SELECT e.cached_session_id, e.fact_index,
+		e.source_session_id, e.local_date, e.source, e.message_ordinal,
+		e.timestamp_ms, e.timestamp_ns, e.raw_timestamp, e.uses_session_start,
+		e.model, e.input_tokens, e.output_tokens, e.reasoning_tokens,
+		e.cache_creation_tokens, e.cache_read_tokens, e.web_search_requests,
+		e.reported_cost_microdollars, e.cost_source, e.request_scoped,
+		e.claude_message_id, e.claude_request_id, e.source_uuid,
+		e.usage_dedup_key
+		FROM usage_rollup_exceptions e
+		JOIN usage_rollup_installs i ON i.id = e.rollup_install_id
+		WHERE i.timezone_id = ? AND (? = '' OR e.local_date >= ?)
+		  AND (? = '' OR e.local_date <= ?)
+		  AND (i.session_id != ? OR e.fact_index <= ?)
+		GROUP BY e.rollup_install_id, e.cached_session_id, e.fact_index
+		ORDER BY e.cached_session_id, e.fact_index`,
+		timezoneID, from, from, to, to, usageRollupCursorSessionID,
+		snapshot.CursorHighWater)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	sessions := usageRollupSessionMap(snapshot)
+	var result []usageRollupFact
+	for rows.Next() {
+		var fact usageRollupFact
+		var ordinal, millis, nanos, reported sql.NullInt64
+		var usesStart, requestScoped int
+		if err := rows.Scan(&fact.CachedSessionID, &fact.FactIndex,
+			&fact.SourceSessionID, &fact.LocalDate, &fact.Fact.Source, &ordinal,
+			&millis, &nanos, &fact.Fact.RawTimestamp, &usesStart, &fact.Model,
+			&fact.Fact.InputTokens, &fact.Fact.OutputTokens,
+			&fact.Fact.ReasoningTokens, &fact.Fact.CacheCreationTokens,
+			&fact.Fact.CacheReadTokens, &fact.Fact.WebSearchRequests, &reported,
+			&fact.Fact.CostSource, &requestScoped, &fact.Fact.ClaudeMessageID,
+			&fact.Fact.ClaudeRequestID, &fact.Fact.SourceUUID,
+			&fact.Fact.UsageDedupKey); err != nil {
+			return nil, err
+		}
+		if _, ok := sessions[fact.SourceSessionID]; !ok &&
+			fact.SourceSessionID != "" {
+			continue
+		}
+		if ordinal.Valid {
+			value := int(ordinal.Int64)
+			fact.Fact.MessageOrdinal = &value
+		}
+		if millis.Valid {
+			value := millis.Int64
+			fact.Fact.TimestampMillis = &value
+			fact.EffectiveMillis = &value
+		}
+		if nanos.Valid {
+			value := nanos.Int64
+			fact.Fact.TimestampNanos = &value
+			fact.EffectiveNanos = &value
+		}
+		if reported.Valid {
+			value := reported.Int64
+			fact.Fact.ReportedCostMicrodollars = &value
+		}
+		fact.Fact.UsesSessionStart = usesStart != 0
+		fact.Fact.RequestScoped = requestScoped != 0
+		fact.Fact.TokenEligible = true
+		fact.DedupTimestamp = fact.Fact.RawTimestamp
+		session := sessions[fact.SourceSessionID]
+		fact.Agent = session.Agent
+		fact.AttributionSessionID = fact.SourceSessionID
+		if fact.Fact.UsesSessionStart {
+			fact.EffectiveMillis, fact.EffectiveNanos =
+				session.StartedAtMillis, session.StartedAtNanos
+			fact.DedupTimestamp = session.StartedAt
+		}
+		result = append(result, fact)
+	}
+	return result, rows.Err()
+}
+
+func (cache *usageCache) usageRollupActivityQuery(
+	ctx context.Context, snapshot usageQuerySnapshot, filter UsageFilter,
+	installs map[string]usageRollupInstall,
+) (map[string]UsageSessionInfo, error) {
+	if len(snapshot.Sessions) == 0 {
+		return make(map[string]UsageSessionInfo), nil
+	}
+	conn, err := cache.db.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN`); err != nil {
+		return nil, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+	identity := usageTimezoneIdentityFor(snapshot.location, snapshot.Intervals)
+	timezoneID, err := verifyUsageRollupQuery(
+		ctx, conn, identity.Key, snapshot, installs)
+	if err != nil {
+		return nil, err
+	}
+	from, to := usageRollupDateBounds(snapshot)
+	rows, err := conn.QueryContext(ctx, `SELECT i.session_id, a.model
+		FROM usage_activity_rollups a
+		JOIN usage_rollup_installs i ON i.id = a.rollup_install_id
+		WHERE i.timezone_id = ? AND (? = '' OR a.local_date >= ?)
+		  AND (? = '' OR a.local_date <= ?)
+		GROUP BY i.session_id, a.model`, timezoneID, from, from, to, to)
+	if err != nil {
+		return nil, err
+	}
+	sessions := usageRollupSessionMap(snapshot)
+	result := make(map[string]UsageSessionInfo)
+	for rows.Next() {
+		var sessionID, model string
+		if err := rows.Scan(&sessionID, &model); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		session, ok := sessions[sessionID]
+		if ok && session.PassesFilter && usageRollupModelPasses(filter, model) {
+			result[sessionID] = UsageSessionInfo{
+				Project: session.Project, Agent: session.Agent,
+			}
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return nil, err
+	}
+	committed = true
+	return result, nil
+}
+
+func aggregateUsageRollupExceptions(
+	facts []usageRollupFact, snapshot usageQuerySnapshot, filter UsageFilter,
+	resolver *export.PricingResolver,
+) ([]usageFactsGroup, error) {
+	sessions := usageRollupSessionMap(snapshot)
+	plain, general, discarded := rankUsageRollupSnapshots(facts)
+	plain = filterUsageRollupOwners(plain, sessions, filter)
+	general = filterUsageRollupOwners(general, sessions, filter)
+	general = deduplicateUsageRollupGeneral(general)
+	survivors := append(plain, general...)
+	type key struct {
+		session, date, model, priced, pattern, rateHash string
+		rateOK                                          bool
+		band                                            int
+	}
+	groups := make(map[key]*usageFactsGroup)
+	for _, fact := range survivors {
+		priced, err := priceUsageFact(usagePriceInput{
+			Fact: fact.Fact, Timestamp: fact.DedupTimestamp,
+			ReportedModel: fact.Model,
+		}, resolver)
+		if err != nil {
+			return nil, err
+		}
+		band := -1
+		if priced.BandThreshold != nil {
+			band = *priced.BandThreshold
+		}
+		itemKey := key{fact.AttributionSessionID, fact.LocalDate, fact.Model,
+			priced.PricedModel, priced.MatchedPattern, priced.RateHash,
+			priced.RateOK, band}
+		group := groups[itemKey]
+		if group == nil {
+			session := sessions[fact.AttributionSessionID]
+			if fact.AttributionSessionID == "" {
+				session.Agent = "cursor"
+			}
+			group = &usageFactsGroup{
+				SessionID: fact.AttributionSessionID, Date: fact.LocalDate,
+				Project: session.Project, Agent: session.Agent, Machine: session.Machine,
+				Model: fact.Model, PricedModel: priced.PricedModel,
+				MatchedPattern: priced.MatchedPattern, RateOK: priced.RateOK,
+				BandThreshold:                 priced.BandThreshold,
+				DiscardedSnapshotOutputTokens: discarded,
+			}
+			groups[itemKey] = group
+		}
+		if err := addUsageFactToGroup(group, fact, priced); err != nil {
+			return nil, err
+		}
+	}
+	result := make([]usageFactsGroup, 0, len(groups))
+	for _, group := range groups {
+		result = append(result, *group)
+	}
+	return result, nil
+}
+
+func rankUsageRollupSnapshots(
+	facts []usageRollupFact,
+) (plain, general []usageRollupFact, discarded int64) {
+	bySnapshot := make(map[string][]usageRollupFact)
+	for _, fact := range facts {
+		key := usageRollupSnapshotKey(fact)
+		if key == "" {
+			general = append(general, fact)
+			continue
+		}
+		bySnapshot[key] = append(bySnapshot[key], fact)
+	}
+	keys := usageSortedMapKeys(bySnapshot)
+	for _, key := range keys {
+		members := bySnapshot[key]
+		if len(members) == 1 {
+			if usageRollupGeneralKey(members[0]) == "" {
+				plain = append(plain, members[0])
+			} else {
+				general = append(general, members[0])
+			}
+			continue
+		}
+		attribution := slices.MinFunc(members, compareUsageSnapshotAttribution)
+		winner := slices.MaxFunc(members, compareUsageSnapshotWinner)
+		winner.AttributionSessionID = attribution.SourceSessionID
+		for _, member := range members {
+			winner.Fact.WebSearchRequests = max(
+				winner.Fact.WebSearchRequests, member.Fact.WebSearchRequests)
+			if usageRollupFactIdentity(member) != usageRollupFactIdentity(winner) {
+				discarded += member.Fact.OutputTokens
+			}
+		}
+		if winner.Fact.UsageDedupKey == "" {
+			plain = append(plain, winner)
+		} else {
+			general = append(general, winner)
+		}
+	}
+	return plain, general, discarded
+}
+
+func filterUsageRollupOwners(
+	facts []usageRollupFact, sessions map[string]usageQuerySession,
+	filter UsageFilter,
+) []usageRollupFact {
+	result := facts[:0]
+	for _, fact := range facts {
+		if fact.AttributionSessionID == "" {
+			if usageCursorIncluded(filter) && usageRollupModelPasses(filter, fact.Model) {
+				fact.Agent = "cursor"
+				result = append(result, fact)
+			}
+			continue
+		}
+		owner, ok := sessions[fact.AttributionSessionID]
+		if ok && owner.PassesFilter && usageRollupModelPasses(filter, fact.Model) {
+			fact.Agent = owner.Agent
+			result = append(result, fact)
+		}
+	}
+	return result
+}
+
+func deduplicateUsageRollupGeneral(facts []usageRollupFact) []usageRollupFact {
+	byKey := make(map[string][]usageRollupFact)
+	for _, fact := range facts {
+		byKey[usageRollupGeneralKey(fact)] = append(
+			byKey[usageRollupGeneralKey(fact)], fact)
+	}
+	keys := usageSortedMapKeys(byKey)
+	result := make([]usageRollupFact, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, slices.MinFunc(byKey[key], compareUsageGeneralWinner))
+	}
+	return result
+}
+
+func addUsageFactToGroup(
+	group *usageFactsGroup, fact usageRollupFact, priced usagePriceResult,
+) error {
+	row := usageDailyContribution{}
+	if err := addUsageFactToDailyContribution(&row, fact, priced); err != nil {
+		return err
+	}
+	fields := []struct {
+		target *int64
+		value  int64
+	}{
+		{&group.InputTokens, row.InputTokens},
+		{&group.OutputTokens, row.OutputTokens},
+		{&group.ReasoningTokens, row.ReasoningTokens},
+		{&group.CacheCreationTokens, row.CacheCreationTokens},
+		{&group.CacheReadTokens, row.CacheReadTokens},
+		{&group.CostMicrodollars, row.CostMicrodollars},
+		{&group.SavingsMicrodollars, row.SavingsMicrodollars},
+	}
+	for _, field := range fields {
+		value, err := addUsageInt64(*field.target, field.value)
+		if err != nil {
+			return err
+		}
+		*field.target = value
+	}
+	if row.AuthoritativeCostMicrodollars != nil &&
+		(group.AuthoritativeCostMicrodollars == nil ||
+			*row.AuthoritativeCostMicrodollars > *group.AuthoritativeCostMicrodollars) {
+		value := *row.AuthoritativeCostMicrodollars
+		group.AuthoritativeCostMicrodollars = &value
+	}
+	group.ComputedRequestCount += row.ComputedRequestCount
+	group.ComputedAggregateCount += row.ComputedAggregateCount
+	group.ReportedCount += row.ReportedCount
+	group.BaseRequestCount += row.BaseRequestCount
+	return nil
+}
+
+func compareUsageSnapshotAttribution(left, right usageRollupFact) int {
+	if order := compareNullableInt64(left.effectiveMillis(), right.effectiveMillis(), true); order != 0 {
+		return order
+	}
+	if order := compareNullableInt64(left.EffectiveNanos, right.EffectiveNanos, true); order != 0 {
+		return order
+	}
+	return compareUsageFactTies(left, right, false)
+}
+
+func compareUsageSnapshotWinner(left, right usageRollupFact) int {
+	if order := cmp.Compare(left.Fact.OutputTokens, right.Fact.OutputTokens); order != 0 {
+		return order
+	}
+	if order := compareNullableInt64(left.effectiveMillis(), right.effectiveMillis(), false); order != 0 {
+		return order
+	}
+	if order := compareNullableInt64(left.EffectiveNanos, right.EffectiveNanos, false); order != 0 {
+		return order
+	}
+	return compareUsageFactTies(left, right, true)
+}
+
+func compareUsageGeneralWinner(left, right usageRollupFact) int {
+	if order := cmp.Compare(left.DedupTimestamp, right.DedupTimestamp); order != 0 {
+		return order
+	}
+	return compareUsageFactTies(left, right, false)
+}
+
+func compareUsageFactTies(left, right usageRollupFact, descending bool) int {
+	values := [][2]string{{left.SourceSessionID, right.SourceSessionID},
+		{left.Fact.Source, right.Fact.Source}, {left.Fact.SourceUUID, right.Fact.SourceUUID},
+		{left.Fact.UsageDedupKey, right.Fact.UsageDedupKey}}
+	leftOrdinal, rightOrdinal := -1, -1
+	if left.Fact.MessageOrdinal != nil {
+		leftOrdinal = *left.Fact.MessageOrdinal
+	}
+	if right.Fact.MessageOrdinal != nil {
+		rightOrdinal = *right.Fact.MessageOrdinal
+	}
+	orders := []int{cmp.Compare(values[0][0], values[0][1]),
+		cmp.Compare(leftOrdinal, rightOrdinal)}
+	for _, pair := range values[1:] {
+		orders = append(orders, cmp.Compare(pair[0], pair[1]))
+	}
+	orders = append(orders, cmp.Compare(left.FactIndex, right.FactIndex))
+	for _, order := range orders {
+		if order != 0 {
+			if descending {
+				return order
+			}
+			return order
+		}
+	}
+	return 0
+}
+
+func compareNullableInt64(left, right *int64, nilHigh bool) int {
+	if left == nil || right == nil {
+		if left == right {
+			return 0
+		}
+		if left == nil {
+			if nilHigh {
+				return 1
+			}
+			return -1
+		}
+		if nilHigh {
+			return -1
+		}
+		return 1
+	}
+	return cmp.Compare(*left, *right)
+}
+
+func compareUsageFactsGroup(left, right usageFactsGroup) int {
+	for _, pair := range [][2]string{{left.Date, right.Date},
+		{left.SessionID, right.SessionID}, {left.Model, right.Model}} {
+		if order := cmp.Compare(pair[0], pair[1]); order != 0 {
+			return order
+		}
+	}
+	return 0
+}
+
+func usageRollupModelPasses(filter UsageFilter, model string) bool {
+	if filter.Model != "" && !slices.Contains(strings.Split(filter.Model, ","), model) {
+		return false
+	}
+	return filter.ExcludeModel == "" ||
+		!slices.Contains(strings.Split(filter.ExcludeModel, ","), model)
+}
+
+func usageRollupSessionMap(snapshot usageQuerySnapshot) map[string]usageQuerySession {
+	result := make(map[string]usageQuerySession, len(snapshot.Sessions))
+	for _, session := range snapshot.Sessions {
+		result[session.ID] = session
+	}
+	return result
+}
+
+func usageRollupDateBounds(snapshot usageQuerySnapshot) (string, string) {
+	if len(snapshot.Intervals) == 0 {
+		return "", ""
+	}
+	return snapshot.Intervals[0].FromLocalDate,
+		snapshot.Intervals[len(snapshot.Intervals)-1].ToLocalDate
+}
+
+func usageSortedMapKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/internal/db/usage_rollup_query.go
+++ b/internal/db/usage_rollup_query.go
@@ -237,7 +237,7 @@ func readUsageRollupExceptions(
 		e.model, e.input_tokens, e.output_tokens, e.reasoning_tokens,
 		e.cache_creation_tokens, e.cache_read_tokens, e.web_search_requests,
 		e.reported_cost_microdollars, e.cost_source, e.request_scoped,
-		e.claude_message_id, e.claude_request_id, e.source_uuid,
+		e.is_headless, e.claude_message_id, e.claude_request_id, e.source_uuid,
 		e.usage_dedup_key, COUNT(*) OVER ()
 		FROM usage_rollup_exceptions e
 		JOIN usage_rollup_installs i ON i.id = e.rollup_install_id
@@ -257,14 +257,15 @@ func readUsageRollupExceptions(
 	for rows.Next() {
 		var fact usageRollupFact
 		var ordinal, millis, nanos, reported sql.NullInt64
-		var usesStart, requestScoped, resultCount int
+		var usesStart, requestScoped, isHeadless, resultCount int
 		if err := rows.Scan(&fact.CachedSessionID, &fact.FactIndex,
 			&fact.SourceSessionID, &fact.LocalDate, &fact.Fact.Source, &ordinal,
 			&millis, &nanos, &fact.Fact.RawTimestamp, &usesStart, &fact.Model,
 			&fact.Fact.InputTokens, &fact.Fact.OutputTokens,
 			&fact.Fact.ReasoningTokens, &fact.Fact.CacheCreationTokens,
 			&fact.Fact.CacheReadTokens, &fact.Fact.WebSearchRequests, &reported,
-			&fact.Fact.CostSource, &requestScoped, &fact.Fact.ClaudeMessageID,
+			&fact.Fact.CostSource, &requestScoped, &isHeadless,
+			&fact.Fact.ClaudeMessageID,
 			&fact.Fact.ClaudeRequestID, &fact.Fact.SourceUUID,
 			&fact.Fact.UsageDedupKey, &resultCount); err != nil {
 			return nil, err
@@ -296,6 +297,7 @@ func readUsageRollupExceptions(
 		}
 		fact.Fact.UsesSessionStart = usesStart != 0
 		fact.Fact.RequestScoped = requestScoped != 0
+		fact.IsHeadless = isHeadless != 0
 		fact.Fact.TokenEligible = true
 		fact.DedupTimestamp = fact.Fact.RawTimestamp
 		session := sessions[fact.SourceSessionID]
@@ -392,6 +394,12 @@ func aggregateUsageRollupExceptions(
 		band                                            int
 	}
 	groups := make(map[key]*usageFactsGroup)
+	type authoritativeCandidate struct {
+		fact  usageRollupFact
+		cost  int64
+		group *usageFactsGroup
+	}
+	authoritative := make(map[string]authoritativeCandidate)
 	for _, fact := range survivors {
 		priced, err := priceUsageFact(usagePriceInput{
 			Fact: fact.Fact, Timestamp: fact.DedupTimestamp,
@@ -426,12 +434,47 @@ func aggregateUsageRollupExceptions(
 		if err := addUsageFactToGroup(group, fact, priced); err != nil {
 			return nil, err
 		}
+		if priced.AuthoritativeCost != nil {
+			candidate, exists := authoritative[fact.AttributionSessionID]
+			if !exists || compareUsageAuthoritativeOrder(candidate.fact, fact) < 0 {
+				authoritative[fact.AttributionSessionID] = authoritativeCandidate{
+					fact: fact, cost: priced.AuthoritativeCost.Microdollars, group: group,
+				}
+			}
+		}
+	}
+	for _, group := range groups {
+		group.AuthoritativeCostMicrodollars = nil
+	}
+	for _, candidate := range authoritative {
+		value := candidate.cost
+		candidate.group.AuthoritativeCostMicrodollars = &value
 	}
 	result := make([]usageFactsGroup, 0, len(groups))
 	for _, group := range groups {
 		result = append(result, *group)
 	}
 	return result, nil
+}
+
+func compareUsageAuthoritativeOrder(left, right usageRollupFact) int {
+	if order := cmp.Compare(left.DedupTimestamp, right.DedupTimestamp); order != 0 {
+		return order
+	}
+	if order := cmp.Compare(left.SourceSessionID, right.SourceSessionID); order != 0 {
+		return order
+	}
+	leftOrdinal, rightOrdinal := -1, -1
+	if left.Fact.MessageOrdinal != nil {
+		leftOrdinal = *left.Fact.MessageOrdinal
+	}
+	if right.Fact.MessageOrdinal != nil {
+		rightOrdinal = *right.Fact.MessageOrdinal
+	}
+	if order := cmp.Compare(leftOrdinal, rightOrdinal); order != 0 {
+		return order
+	}
+	return compareUsageRollupFactIdentity(left, right)
 }
 
 func rankUsageRollupSnapshots(
@@ -548,7 +591,9 @@ func filterUsageRollupOwners(
 	result := facts[:0]
 	for _, fact := range facts {
 		if fact.AttributionSessionID == "" {
-			if usageCursorIncluded(filter) && usageRollupModelPasses(filter, fact.Model) {
+			if usageCursorIncluded(filter) &&
+				usageCursorAutomatedScopePasses(filter, fact.IsHeadless) &&
+				usageRollupModelPasses(filter, fact.Model) {
 				fact.Agent = "cursor"
 				result = append(result, fact)
 			}
@@ -561,6 +606,17 @@ func filterUsageRollupOwners(
 		}
 	}
 	return result
+}
+
+func usageCursorAutomatedScopePasses(filter UsageFilter, isHeadless bool) bool {
+	switch normalizeAutomatedScope(filter.AutomatedScope, filter.ExcludeAutomated) {
+	case "human":
+		return !isHeadless
+	case "automated":
+		return isHeadless
+	default:
+		return true
+	}
 }
 
 func deduplicateUsageRollupGeneral(facts []usageRollupFact) []usageRollupFact {
@@ -623,7 +679,7 @@ func compareUsageSnapshotAttribution(left, right usageRollupFact) int {
 	if order := compareNullableInt64(left.EffectiveNanos, right.EffectiveNanos, true); order != 0 {
 		return order
 	}
-	return compareUsageFactTies(left, right, false)
+	return compareUsageFactTies(left, right)
 }
 
 func compareUsageSnapshotWinner(left, right usageRollupFact) int {
@@ -636,17 +692,17 @@ func compareUsageSnapshotWinner(left, right usageRollupFact) int {
 	if order := compareNullableInt64(left.EffectiveNanos, right.EffectiveNanos, false); order != 0 {
 		return order
 	}
-	return compareUsageFactTies(left, right, true)
+	return compareUsageFactTies(left, right)
 }
 
 func compareUsageGeneralWinner(left, right usageRollupFact) int {
 	if order := cmp.Compare(left.DedupTimestamp, right.DedupTimestamp); order != 0 {
 		return order
 	}
-	return compareUsageFactTies(left, right, false)
+	return compareUsageFactTies(left, right)
 }
 
-func compareUsageFactTies(left, right usageRollupFact, descending bool) int {
+func compareUsageFactTies(left, right usageRollupFact) int {
 	values := [][2]string{{left.SourceSessionID, right.SourceSessionID},
 		{left.Fact.Source, right.Fact.Source}, {left.Fact.SourceUUID, right.Fact.SourceUUID},
 		{left.Fact.UsageDedupKey, right.Fact.UsageDedupKey}}
@@ -665,9 +721,6 @@ func compareUsageFactTies(left, right usageRollupFact, descending bool) int {
 	orders = append(orders, cmp.Compare(left.FactIndex, right.FactIndex))
 	for _, order := range orders {
 		if order != 0 {
-			if descending {
-				return order
-			}
 			return order
 		}
 	}

--- a/internal/db/usage_rollup_query_test.go
+++ b/internal/db/usage_rollup_query_test.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"math/rand"
 	"strconv"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/export"
+	"go.kenn.io/agentsview/internal/money"
 )
 
 func TestUsageRollupDailyMatchesFacts(t *testing.T) {
@@ -61,6 +63,185 @@ func TestUsageRollupDailyMatchesFactsForCrossSessionSnapshots(t *testing.T) {
 		facts := getDailyUsageLegacyForRollupTest(t, database, filter)
 		rollup := getDailyUsageRollupForTest(t, database, filter)
 		assert.Equal(t, facts, rollup)
+	}
+}
+
+func TestUsageRollupDailyMatchesCursorAutomatedScope(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.InsertCursorUsageEvents([]CursorUsageEvent{
+		{
+			OccurredAt: "2026-08-10T09:00:00Z", Model: "model-a",
+			InputTokens: 10, Charged: money.MustParseDollars("0.10"),
+			DedupKey: "interactive", IsHeadless: false,
+		},
+		{
+			OccurredAt: "2026-08-10T10:00:00Z", Model: "model-a",
+			InputTokens: 20, Charged: money.MustParseDollars("0.70"),
+			DedupKey: "headless", IsHeadless: true,
+		},
+	}))
+
+	for _, filter := range []UsageFilter{
+		{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+			ExcludeAutomated: true},
+		{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+			AutomatedScope: "automated"},
+	} {
+		legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+		rollup := getDailyUsageRollupForTest(t, database, filter)
+		assert.Equal(t, legacy, rollup)
+	}
+}
+
+func TestUsageRollupDailyMatchesLastCopilotReportedCost(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "copilot:reported", "project", func(session *Session) {
+		session.Agent = "copilot"
+		session.StartedAt = Ptr("2026-08-10T08:00:00Z")
+	})
+	first := money.MustParseDollars("5.00")
+	last := money.MustParseDollars("3.00")
+	require.NoError(t, database.ReplaceSessionUsageEvents(
+		"copilot:reported", []UsageEvent{
+			{
+				Source: "shutdown", Model: "model-a", InputTokens: 10,
+				Cost: &first, CostStatus: "exact", CostSource: CopilotReportedCostSource,
+				OccurredAt: "2026-08-10T09:00:00Z", DedupKey: "first",
+			},
+			{
+				Source: "shutdown", Model: "model-a", InputTokens: 20,
+				Cost: &last, CostStatus: "exact", CostSource: CopilotReportedCostSource,
+				OccurredAt: "2026-08-10T10:00:00Z", DedupKey: "last",
+			},
+		},
+	))
+	filter := UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	}
+
+	legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+	rollup := getDailyUsageRollupForTest(t, database, filter)
+	assert.Equal(t, money.MustParseDollars("3.00"), legacy.Totals.TotalCost)
+	assert.Equal(t, legacy, rollup)
+}
+
+func TestUsageRollupWarmReadDoesNotScanFacts(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "warm", "project",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	filter := UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	}
+	want, err := database.GetDailyUsage(t.Context(), filter)
+	require.NoError(t, err, "warm rollup")
+	snapshot, err := database.captureUsageQuery(
+		t.Context(), filter, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	_, err = cache.db.Exec(`DROP TABLE usage_facts`)
+	require.NoError(t, err, "make any facts access fail")
+
+	got, err := database.GetDailyUsage(t.Context(), filter)
+	require.NoError(t, err, "read warmed rollup")
+	assert.Equal(t, want, got)
+}
+
+func TestUsageRollupSeededRandomParitySweep(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.UpsertModelPricing([]ModelPricing{
+		{ModelPattern: "model-a", InputPerMTok: money.MustParseDollars("2"),
+			OutputPerMTok: money.MustParseDollars("8")},
+		{ModelPattern: "model-b", InputPerMTok: money.MustParseDollars("3"),
+			OutputPerMTok: money.MustParseDollars("12")},
+	}))
+
+	type seededSession struct {
+		id, project, agent, timestamp, model string
+		automated                            bool
+	}
+	fixtures := []seededSession{
+		{"claude-a", "project-a", "claude", "2026-10-31T23:30:00Z", "model-a", false},
+		{"claude-b", "project-b", "claude", "2026-11-01T07:30:00Z", "model-a", true},
+		{"codex-a", "project-a", "codex", "2026-11-01T06:30:00Z", "model-a", false},
+		{"codex-b", "project-b", "codex", "2026-11-02T01:30:00Z", "model-b", true},
+		{"plain-a", "project-a", "openhands", "2026-11-03T12:00:00Z", "model-b", false},
+	}
+	for index, fixture := range fixtures {
+		started := fixture.timestamp
+		insertSession(t, database, fixture.id, fixture.project, func(session *Session) {
+			session.Agent = fixture.agent
+			session.StartedAt = &started
+			session.IsAutomated = fixture.automated
+		})
+		message := Message{
+			SessionID: fixture.id, Ordinal: 0, Role: "assistant",
+			Timestamp: fixture.timestamp, Model: fixture.model,
+			TokenUsage: []byte(`{"input_tokens":100,"output_tokens":25}`),
+		}
+		switch fixture.agent {
+		case "claude":
+			message.ClaudeMessageID = "cross-day-message"
+			message.ClaudeRequestID = "cross-day-request"
+			message.OutputTokens = 25 + index
+			message.HasOutputTokens = true
+		case "codex":
+			message.SourceUUID = "cross-session-source"
+		}
+		require.NoError(t, database.InsertMessages([]Message{message}))
+	}
+	// Keep automation deterministic regardless of transcript classifier rules.
+	_, err := database.getWriter().Exec(`
+		UPDATE sessions SET is_automated = CASE id
+			WHEN 'claude-b' THEN 1 WHEN 'codex-b' THEN 1 ELSE 0 END`)
+	require.NoError(t, err)
+	reported := money.MustParseDollars("0.25")
+	require.NoError(t, database.ReplaceSessionUsageEvents("plain-a", []UsageEvent{{
+		Source: "provider", Model: "model-b", InputTokens: 50,
+		Cost: &reported, CostStatus: "exact", CostSource: "provider",
+		OccurredAt: "2026-11-01T05:30:00Z", DedupKey: "event-one",
+	}}))
+	require.NoError(t, database.InsertCursorUsageEvents([]CursorUsageEvent{
+		{OccurredAt: "2026-11-01T06:15:00Z", Model: "model-a",
+			InputTokens: 30, DedupKey: "cursor-human", IsHeadless: false},
+		{OccurredAt: "2026-11-01T07:15:00Z", Model: "model-b",
+			InputTokens: 40, DedupKey: "cursor-headless", IsHeadless: true},
+	}))
+	for _, filter := range []UsageFilter{
+		{From: "2026-11-01", To: "2026-11-01", Timezone: "America/Chicago"},
+		{From: "2026-10-31", To: "2026-11-02", Timezone: "UTC",
+			Project: "project-a", Model: "model-a"},
+	} {
+		legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+		rollup := getDailyUsageRollupForTest(t, database, filter)
+		assert.Equal(t, legacy, rollup, "required filter %#v", filter)
+	}
+
+	random := rand.New(rand.NewSource(1454)) //nolint:gosec // deterministic test sweep
+	from := []string{"2026-10-31", "2026-11-01", "2026-11-02", ""}
+	to := []string{"2026-11-01", "2026-11-02", "2026-11-03", ""}
+	zones := []string{"UTC", "America/Chicago", "Asia/Tokyo"}
+	projects := []string{"", "project-a", "project-b"}
+	agents := []string{"", "claude", "codex", "cursor"}
+	models := []string{"", "model-a", "model-b"}
+	scopes := []string{"", "human", "automated"}
+	for iteration := range 36 {
+		fromIndex := random.Intn(len(from))
+		toIndex := random.Intn(len(to))
+		filter := UsageFilter{
+			From: from[fromIndex], To: to[toIndex],
+			Timezone:       zones[random.Intn(len(zones))],
+			Project:        projects[random.Intn(len(projects))],
+			Agent:          agents[random.Intn(len(agents))],
+			Model:          models[random.Intn(len(models))],
+			AutomatedScope: scopes[random.Intn(len(scopes))],
+		}
+		if filter.From != "" && filter.To != "" && filter.From > filter.To {
+			filter.From, filter.To = filter.To, filter.From
+		}
+		legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+		rollup := getDailyUsageRollupForTest(t, database, filter)
+		assert.Equal(t, legacy, rollup, "iteration %d filter %#v", iteration, filter)
 	}
 }
 

--- a/internal/db/usage_rollup_query_test.go
+++ b/internal/db/usage_rollup_query_test.go
@@ -1,0 +1,129 @@
+//go:build fts5
+
+package db
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/export"
+)
+
+func TestUsageRollupDailyMatchesFacts(t *testing.T) {
+	database := openDailyUsageFixtureDB(t)
+	for _, filter := range []UsageFilter{
+		{From: "2024-06-01", To: "2024-07-31", Timezone: "UTC"},
+		{From: "2024-06-01", To: "2024-07-31", Timezone: "UTC",
+			Project: "proj-a", Model: "model-a"},
+		{From: "2024-06-01", To: "2024-06-30", Timezone: "America/Chicago",
+			ExcludeAgent: "codex"},
+	} {
+		facts := getDailyUsageLegacyForRollupTest(t, database, filter)
+		rollup := getDailyUsageRollupForTest(t, database, filter)
+		assert.Equal(t, facts, rollup)
+	}
+}
+
+func seedUsageSnapshotSession(
+	t *testing.T, database *DB, id, project, timestamp string,
+	ordinal, output int, model string,
+) {
+	t.Helper()
+	started := timestamp
+	insertSession(t, database, id, project, func(session *Session) {
+		session.StartedAt = &started
+		session.Agent = "claude"
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: id, Ordinal: ordinal, Role: "assistant", Timestamp: timestamp,
+		Model: model, TokenUsage: []byte(
+			`{"output_tokens":` + strconv.Itoa(output) + `}`),
+		ClaudeMessageID: "shared-message", ClaudeRequestID: "shared-request",
+	}}))
+}
+
+func TestUsageRollupDailyMatchesFactsForCrossSessionSnapshots(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "earlier", "project-a",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	seedUsageSnapshotSession(t, database, "later", "project-b",
+		"2026-08-10T10:00:00Z", 0, 20, "model-a")
+	for _, filter := range []UsageFilter{
+		{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"},
+		{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+			Project: "project-a"},
+		{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+			Project: "project-b"},
+	} {
+		facts := getDailyUsageLegacyForRollupTest(t, database, filter)
+		rollup := getDailyUsageRollupForTest(t, database, filter)
+		assert.Equal(t, facts, rollup)
+	}
+}
+
+func TestUsageRollupQueryRecapturesAfterConcurrentInstall(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "session-a", "project-a",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+	snapshot, err := database.captureUsageQuery(t.Context(), filter, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	fills, err := cache.fill.Ensure(t.Context(), snapshot.Versions, 0)
+	require.NoError(t, err)
+	resolver := export.NewPricingResolver(snapshot.PricingRows)
+	installs, _, err := cache.rollup.Ensure(t.Context(), snapshot, fills, resolver)
+	require.NoError(t, err)
+	required := installs["session-a"]
+	_, err = cache.db.Exec(`UPDATE usage_rollup_installs
+		SET install_revision = install_revision + 1 WHERE id = ?`, required.ID)
+	require.NoError(t, err)
+
+	_, err = cache.usageRollupQuery(t.Context(), snapshot, filter, installs, resolver)
+	assert.ErrorIs(t, err, errUsageCacheSourceChanged)
+	_, err = cache.db.Exec(`UPDATE usage_rollup_installs
+		SET install_revision = ?, pricing_hash = 'changed' WHERE id = ?`,
+		required.InstallRevision, required.ID)
+	require.NoError(t, err)
+	_, err = cache.usageRollupQuery(t.Context(), snapshot, filter, installs, resolver)
+	assert.ErrorIs(t, err, errUsageCacheSourceChanged)
+}
+
+func getDailyUsageLegacyForRollupTest(
+	t *testing.T, database *DB, filter UsageFilter,
+) DailyUsageResult {
+	t.Helper()
+	daily, err := database.getDailyUsageLegacy(t.Context(), filter)
+	require.NoError(t, err)
+	return daily
+}
+
+func getDailyUsageRollupForTest(
+	t *testing.T, database *DB, filter UsageFilter,
+) DailyUsageResult {
+	t.Helper()
+	snapshot, err := database.captureUsageQuery(
+		t.Context(), filter, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	fills, err := cache.fill.Ensure(
+		t.Context(), snapshot.Versions, snapshot.CursorHighWater)
+	require.NoError(t, err)
+	snapshot.dropDeleted(fills)
+	resolver := export.NewPricingResolver(snapshot.PricingRows)
+	installs, _, err := cache.rollup.Ensure(
+		t.Context(), snapshot, fills, resolver)
+	require.NoError(t, err)
+	result, err := cache.usageRollupQuery(
+		t.Context(), snapshot, filter, installs, resolver)
+	require.NoError(t, err)
+	daily, err := database.assembleDailyUsageFacts(
+		t.Context(), filter, result, resolver)
+	require.NoError(t, err)
+	return daily
+}

--- a/internal/db/usage_rollup_query_test.go
+++ b/internal/db/usage_rollup_query_test.go
@@ -5,6 +5,7 @@ package db
 import (
 	"math/rand"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,6 +126,135 @@ func TestUsageRollupDailyMatchesLastCopilotReportedCost(t *testing.T) {
 	assert.Equal(t, legacy, rollup)
 }
 
+func countUsageRollupExceptionRows(t *testing.T, database *DB) int {
+	t.Helper()
+	snapshot, err := database.captureUsageQuery(
+		t.Context(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	var count int
+	require.NoError(t, cache.db.QueryRow(
+		`SELECT COUNT(*) FROM usage_rollup_exceptions`).Scan(&count))
+	return count
+}
+
+func TestUsageRollupUniqueClaudeSessionStoresNoExceptions(t *testing.T) {
+	database := testDB(t)
+	started := "2026-08-10T08:00:00Z"
+	insertSession(t, database, "unique-claude", "project", func(session *Session) {
+		session.Agent = "claude"
+		session.StartedAt = &started
+	})
+	messages := make([]Message, 0, 6)
+	for index := range 6 {
+		messages = append(messages, Message{
+			SessionID: "unique-claude", Ordinal: index, Role: "assistant",
+			Timestamp: "2026-08-10T09:00:00Z", Model: "model-a",
+			TokenUsage:      []byte(`{"input_tokens":3,"output_tokens":7}`),
+			ClaudeMessageID: "message-" + strconv.Itoa(index),
+			ClaudeRequestID: "request-" + strconv.Itoa(index),
+		})
+	}
+	require.NoError(t, database.InsertMessages(messages))
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+
+	legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+	rollup := getDailyUsageRollupForTest(t, database, filter)
+
+	assert.Equal(t, legacy, rollup)
+	assert.Equal(t, 42, rollup.Totals.OutputTokens)
+	assert.Zero(t, countUsageRollupExceptionRows(t, database),
+		"unique Claude identities must aggregate into daily rows")
+}
+
+func TestUsageRollupSameDaySnapshotDuplicateAggregates(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "same-day", "project",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "same-day", Ordinal: 1, Role: "assistant",
+		Timestamp: "2026-08-10T09:05:00Z", Model: "model-a",
+		TokenUsage:      []byte(`{"output_tokens":25}`),
+		ClaudeMessageID: "shared-message", ClaudeRequestID: "shared-request",
+	}}))
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+
+	legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+	rollup := getDailyUsageRollupForTest(t, database, filter)
+
+	assert.Equal(t, legacy, rollup)
+	assert.Equal(t, 25, rollup.Totals.OutputTokens,
+		"only the winning snapshot output may count")
+	assert.Zero(t, countUsageRollupExceptionRows(t, database),
+		"a same-day, same-session snapshot group must finalize at build time")
+}
+
+func TestUsageRollupSiblingArrivalInvalidatesFinalizedAggregate(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "original", "project-a",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+	warm := getDailyUsageRollupForTest(t, database, filter)
+	require.Equal(t, 10, warm.Totals.OutputTokens)
+	require.Zero(t, countUsageRollupExceptionRows(t, database))
+
+	seedUsageSnapshotSession(t, database, "sibling", "project-b",
+		"2026-08-10T10:00:00Z", 0, 20, "model-a")
+
+	legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+	rollup := getDailyUsageRollupForTest(t, database, filter)
+	assert.Equal(t, legacy, rollup,
+		"a new cross-session sibling must invalidate the finalized aggregate")
+	assert.Equal(t, 20, rollup.Totals.OutputTokens)
+}
+
+func TestUsageRollupSiblingRemovalRestoresFinalizedAggregate(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "original", "project-a",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	seedUsageSnapshotSession(t, database, "sibling", "project-b",
+		"2026-08-10T10:00:00Z", 0, 20, "model-a")
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+	warm := getDailyUsageRollupForTest(t, database, filter)
+	require.Equal(t, 20, warm.Totals.OutputTokens)
+	require.Positive(t, countUsageRollupExceptionRows(t, database))
+
+	require.NoError(t, database.ReplaceSessionMessages("sibling", []Message{{
+		SessionID: "sibling", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T10:00:00Z", Model: "model-a",
+		TokenUsage:      []byte(`{"output_tokens":20}`),
+		ClaudeMessageID: "unrelated-message", ClaudeRequestID: "unrelated-request",
+	}}))
+
+	legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+	rollup := getDailyUsageRollupForTest(t, database, filter)
+	assert.Equal(t, legacy, rollup)
+	assert.Equal(t, 30, rollup.Totals.OutputTokens,
+		"both requests must count once the identities no longer collide")
+	assert.Zero(t, countUsageRollupExceptionRows(t, database),
+		"separated identities must become daily rows again")
+}
+
+func TestUsageRollupSessionDeletionRestoresFinalizedAggregate(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "original", "project-a",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	seedUsageSnapshotSession(t, database, "sibling", "project-b",
+		"2026-08-10T10:00:00Z", 0, 20, "model-a")
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+	warm := getDailyUsageRollupForTest(t, database, filter)
+	require.Equal(t, 20, warm.Totals.OutputTokens)
+
+	require.NoError(t, database.DeleteSession("sibling"))
+
+	legacy := getDailyUsageLegacyForRollupTest(t, database, filter)
+	rollup := getDailyUsageRollupForTest(t, database, filter)
+	assert.Equal(t, legacy, rollup)
+	assert.Equal(t, 10, rollup.Totals.OutputTokens,
+		"a deleted sibling must stop competing immediately")
+}
+
 func TestUsageRollupWarmReadDoesNotScanFacts(t *testing.T) {
 	database := testDB(t)
 	seedUsageSnapshotSession(t, database, "warm", "project",
@@ -145,6 +275,46 @@ func TestUsageRollupWarmReadDoesNotScanFacts(t *testing.T) {
 	got, err := database.GetDailyUsage(t.Context(), filter)
 	require.NoError(t, err, "read warmed rollup")
 	assert.Equal(t, want, got)
+}
+
+func TestUsageRollupCrossIdentityQueriesUseIndexes(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "plan", "project",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	snapshot, err := database.captureUsageQuery(
+		t.Context(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	conn, err := cache.db.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.ExecContext(t.Context(), `CREATE TEMP TABLE IF NOT EXISTS
+		usage_rollup_build_sessions(session_id TEXT PRIMARY KEY) WITHOUT ROWID`)
+	require.NoError(t, err)
+
+	plan := func(query string) string {
+		t.Helper()
+		rows, err := conn.QueryContext(t.Context(), `EXPLAIN QUERY PLAN `+query)
+		require.NoError(t, err)
+		defer rows.Close()
+		var details []string
+		for rows.Next() {
+			var id, parent, unused int
+			var detail string
+			require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+			details = append(details, detail)
+		}
+		require.NoError(t, rows.Err())
+		return strings.Join(details, "\n")
+	}
+	assert.Contains(t, plan(usageRollupCrossSnapshotSQL),
+		"usage_facts_claude_identity")
+	assert.Contains(t, plan(usageRollupCrossSourceUUIDSQL),
+		"usage_facts_source_uuid")
+	usageKeyPlan := plan(usageRollupCrossUsageKeySQL)
+	assert.Contains(t, usageKeyPlan, "usage_facts_usage_dedup_key")
+	assert.Contains(t, usageKeyPlan, "cursor_usage_facts_dedup_key")
 }
 
 func TestUsageRollupSeededRandomParitySweep(t *testing.T) {
@@ -201,6 +371,43 @@ func TestUsageRollupSeededRandomParitySweep(t *testing.T) {
 		Cost: &reported, CostStatus: "exact", CostSource: "provider",
 		OccurredAt: "2026-11-01T05:30:00Z", DedupKey: "event-one",
 	}}))
+	sameDayStarted := "2026-11-01T09:00:00Z"
+	insertSession(t, database, "claude-c", "project-a", func(session *Session) {
+		session.Agent = "claude"
+		session.StartedAt = &sameDayStarted
+	})
+	sameDayMessage := func(ordinal, output int, messageID string) Message {
+		return Message{
+			SessionID: "claude-c", Ordinal: ordinal, Role: "assistant",
+			Timestamp: "2026-11-01T09:0" + strconv.Itoa(ordinal) + ":00Z",
+			Model:     "model-a",
+			TokenUsage: []byte(`{"input_tokens":10,"output_tokens":` +
+				strconv.Itoa(output) + `}`),
+			ClaudeMessageID: messageID, ClaudeRequestID: "same-day-request",
+		}
+	}
+	require.NoError(t, database.InsertMessages([]Message{
+		sameDayMessage(0, 11, "same-day-message"),
+		sameDayMessage(1, 44, "same-day-message"),
+		sameDayMessage(2, 7, "same-day-unique"),
+	}))
+	copilotStarted := "2026-11-01T10:00:00Z"
+	insertSession(t, database, "copilot-a", "project-b", func(session *Session) {
+		session.Agent = "copilot"
+		session.StartedAt = &copilotStarted
+	})
+	firstShutdown := money.MustParseDollars("4.00")
+	lastShutdown := money.MustParseDollars("6.50")
+	require.NoError(t, database.ReplaceSessionUsageEvents("copilot-a", []UsageEvent{
+		{Source: "shutdown", Model: "model-a", InputTokens: 15,
+			Cost: &firstShutdown, CostStatus: "exact",
+			CostSource: CopilotReportedCostSource,
+			OccurredAt: "2026-11-01T11:00:00Z", DedupKey: "shutdown-one"},
+		{Source: "shutdown", Model: "model-b", InputTokens: 25,
+			Cost: &lastShutdown, CostStatus: "exact",
+			CostSource: CopilotReportedCostSource,
+			OccurredAt: "2026-11-02T11:00:00Z", DedupKey: "shutdown-two"},
+	}))
 	require.NoError(t, database.InsertCursorUsageEvents([]CursorUsageEvent{
 		{OccurredAt: "2026-11-01T06:15:00Z", Model: "model-a",
 			InputTokens: 30, DedupKey: "cursor-human", IsHeadless: false},
@@ -222,7 +429,7 @@ func TestUsageRollupSeededRandomParitySweep(t *testing.T) {
 	to := []string{"2026-11-01", "2026-11-02", "2026-11-03", ""}
 	zones := []string{"UTC", "America/Chicago", "Asia/Tokyo"}
 	projects := []string{"", "project-a", "project-b"}
-	agents := []string{"", "claude", "codex", "cursor"}
+	agents := []string{"", "claude", "codex", "cursor", "copilot"}
 	models := []string{"", "model-a", "model-b"}
 	scopes := []string{"", "human", "automated"}
 	for iteration := range 36 {

--- a/internal/db/usage_rollup_query_test.go
+++ b/internal/db/usage_rollup_query_test.go
@@ -3,10 +3,12 @@
 package db
 
 import (
+	"context"
 	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -514,4 +516,53 @@ func getDailyUsageRollupForTest(
 		t.Context(), filter, result, resolver)
 	require.NoError(t, err)
 	return daily
+}
+
+func TestUsageRollupInstallWaitsForHeldCacheWriteLock(t *testing.T) {
+	database := testDB(t)
+	ctx := context.Background()
+	require.NoError(t, database.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "model-a",
+		InputPerMTok:  money.MustParseDollars("1.0"),
+		OutputPerMTok: money.MustParseDollars("2.0"),
+	}}))
+	seedUsageSnapshotSession(t, database, "held-session", "proj",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	filter := UsageFilter{From: "2026-08-10", To: "2026-08-10", Timezone: "UTC"}
+	warm, err := database.GetDailyUsage(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, warm.Daily, 1)
+
+	// A pricing change leaves facts current but forces a rollup
+	// reinstall on the next read.
+	require.NoError(t, database.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "model-a",
+		InputPerMTok:  money.MustParseDollars("1.0"),
+		OutputPerMTok: money.MustParseDollars("4.0"),
+	}}))
+	databaseID, err := database.GetDatabaseID(ctx)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(ctx, databaseID)
+	require.NoError(t, err)
+
+	// Hold the cache write lock on a separate connection while the
+	// query runs: the rollup install must wait it out through the busy
+	// timeout instead of failing with a stale-snapshot write error.
+	held := openRawUsageCacheTestDB(t, cache.path)
+	t.Cleanup(func() { require.NoError(t, held.Close()) })
+	_, err = held.Exec(`BEGIN IMMEDIATE`)
+	require.NoError(t, err)
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(300 * time.Millisecond)
+		_, _ = held.Exec(`COMMIT`)
+	}()
+
+	result, err := database.GetDailyUsage(ctx, filter)
+	<-released
+	require.NoError(t, err,
+		"rollup install must wait for the held cache write lock")
+	require.Len(t, result.Daily, 1)
+	assert.Equal(t, 10, result.Daily[0].OutputTokens)
 }

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -4174,10 +4174,14 @@ func BenchmarkUsageRollup(b *testing.B) {
 			require.NoError(b, queryErr)
 			requireDailyUsageBenchmarkResult(b, result, cold.want)
 			requireUsageFactsCount(b, cache, cold.wantFacts)
+			exceptionRows, exceptionGroups := usageRollupExceptionMetrics(
+				b, cache, cold.filter)
 			clearUsageFactsBenchmarkCache(b, cache)
 			b.ReportAllocs()
-			b.ReportMetric(float64(cold.wantFacts), "facts/op")
 			b.ResetTimer()
+			b.ReportMetric(float64(cold.wantFacts), "facts/op")
+			b.ReportMetric(float64(exceptionRows), "exception-rows/op")
+			b.ReportMetric(float64(exceptionGroups), "exception-groups/op")
 			for range b.N {
 				b.StopTimer()
 				clearUsageFactsBenchmarkCache(b, cache)
@@ -4199,13 +4203,65 @@ func BenchmarkUsageRollup(b *testing.B) {
 			result, queryErr := database.GetDailyUsage(ctx, window.filter)
 			require.NoError(b, queryErr)
 			requireDailyUsageBenchmarkResult(b, result, window.want)
+			exceptionRows, exceptionGroups := usageRollupExceptionMetrics(
+				b, cache, window.filter)
+			cacheBytes := usageCacheDiskBytes(cache.path)
 			b.ReportAllocs()
-			b.ReportMetric(float64(usageCacheDiskBytes(cache.path)), "cache-bytes")
 			b.ResetTimer()
+			b.ReportMetric(float64(exceptionRows), "exception-rows/op")
+			b.ReportMetric(float64(exceptionGroups), "exception-groups/op")
+			b.ReportMetric(float64(cacheBytes), "cache-bytes")
 			for range b.N {
 				if _, queryErr = database.GetDailyUsage(
 					ctx, window.filter); queryErr != nil {
 					b.Fatal(queryErr)
+				}
+			}
+		})
+	}
+	for _, window := range windows[2:] {
+		b.Run("exceptions/"+window.name, func(b *testing.B) {
+			snapshot, captureErr := database.captureUsageQuery(
+				ctx, window.filter, usageQueryKindToken)
+			require.NoError(b, captureErr)
+			resolver := export.NewPricingResolver(snapshot.PricingRows)
+			conn, connErr := cache.db.Conn(ctx)
+			require.NoError(b, connErr)
+			defer conn.Close()
+			identity := usageTimezoneIdentityFor(
+				snapshot.location, snapshot.Intervals)
+			var timezoneID int64
+			require.NoError(b, conn.QueryRowContext(ctx,
+				`SELECT id FROM usage_rollup_timezones WHERE timezone_key = ?`,
+				identity.Key,
+			).Scan(&timezoneID))
+			exceptions, readErr := readUsageRollupExceptions(
+				ctx, conn, timezoneID, snapshot, window.filter)
+			require.NoError(b, readErr)
+			groups, aggregateErr := aggregateUsageRollupExceptions(
+				exceptions, snapshot, window.filter, resolver)
+			require.NoError(b, aggregateErr)
+			exceptionRows := len(exceptions)
+			exceptionGroups := len(groups)
+			require.NotZero(b, exceptionRows)
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.ReportMetric(float64(exceptionRows), "exception-rows/op")
+			b.ReportMetric(float64(exceptionGroups), "resolved-groups/op")
+			for range b.N {
+				exceptions, readErr = readUsageRollupExceptions(
+					ctx, conn, timezoneID, snapshot, window.filter)
+				if readErr != nil {
+					b.Fatal(readErr)
+				}
+				groups, aggregateErr = aggregateUsageRollupExceptions(
+					exceptions, snapshot, window.filter, resolver)
+				if aggregateErr != nil {
+					b.Fatal(aggregateErr)
+				}
+				if len(groups) != exceptionGroups {
+					b.Fatalf("exception groups = %d, want %d",
+						len(groups), exceptionGroups)
 				}
 			}
 		})
@@ -4284,6 +4340,25 @@ func requireUsageFactsCount(tb testing.TB, cache *usageCache, want int) {
 	var got int
 	require.NoError(tb, cache.db.QueryRow(`SELECT COUNT(*) FROM usage_facts`).Scan(&got))
 	require.Equal(tb, want, got, "usage facts")
+}
+
+func usageRollupExceptionMetrics(
+	tb testing.TB, cache *usageCache, filter UsageFilter,
+) (int64, int64) {
+	tb.Helper()
+	identity := usageTimezoneIdentityFor(filter.location(), nil)
+	var rows, groups int64
+	require.NoError(tb, cache.db.QueryRow(`SELECT COUNT(*),
+		COUNT(DISTINCT e.group_kind || char(0) || e.group_key)
+		FROM usage_rollup_exceptions e
+		JOIN usage_rollup_installs i ON i.id = e.rollup_install_id
+		JOIN usage_rollup_timezones z ON z.id = i.timezone_id
+		WHERE z.timezone_key = ?
+		  AND (? = '' OR e.local_date >= ?)
+		  AND (? = '' OR e.local_date <= ?)`,
+		identity.Key, filter.From, filter.From, filter.To, filter.To,
+	).Scan(&rows, &groups))
+	return rows, groups
 }
 
 func usageCacheDiskBytes(path string) int64 {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -1028,6 +1028,15 @@ func TestGetDailyUsageSkipsCursorUsageEventsForExcludeOneShot(t *testing.T) {
 	assert.Empty(t, result.Daily, "daily entries should be empty")
 	assert.Zero(t, result.Totals.InputTokens, "InputTokens")
 	assert.Zero(t, result.SessionCounts.Total, "cursor rows should not count as sessions")
+	databaseID, err := d.GetDatabaseID(ctx)
+	require.NoError(t, err)
+	cache, err := d.usageCache.Generation(ctx, databaseID)
+	require.NoError(t, err)
+	var cursorFacts int
+	require.NoError(t, cache.db.QueryRow(
+		`SELECT COUNT(*) FROM cursor_usage_facts`).Scan(&cursorFacts))
+	assert.Zero(t, cursorFacts,
+		"a filtered request must not copy unrelated Cursor history")
 }
 
 func TestGetDailyUsageSkipsCursorUsageEventsForTerminationFilter(t *testing.T) {
@@ -1480,7 +1489,7 @@ func TestParseUsageTokenCounters(t *testing.T) {
 		`{"input_tokens":"-5","cache_read_input_tokens":"100",` +
 			`"output_tokens":"42"}`,
 	)
-	assert.Equal(t, -5, in)
+	assert.Zero(t, in)
 	assert.Equal(t, 42, out)
 	assert.Zero(t, cacheCreate)
 	assert.Equal(t, 100, cacheRead)
@@ -1502,49 +1511,6 @@ func TestParseUsageTokenCounters(t *testing.T) {
 	assert.Equal(t, 42, out)
 	assert.Zero(t, cacheCreate)
 	assert.Zero(t, cacheRead)
-}
-
-// TestParseJSONStringMatchesEncodingJSON pins the string scanner to
-// json.Unmarshal: the escape-free fast path and the encoding/json fallback
-// must decode identically and reject the same input.
-func TestParseJSONStringMatchesEncodingJSON(t *testing.T) {
-	cases := []struct {
-		name  string
-		input string
-		want  string
-		next  int
-		ok    bool
-	}{
-		{"plain", `"input_tokens":1`, "input_tokens", 14, true},
-		{"empty", `""`, "", 2, true},
-		{"escaped quote", `"a\"b"`, `a"b`, 6, true},
-		{"escaped slash", `"https:\/\/x"`, "https://x", 13, true},
-		{"unicode escape", `"\u00e9"`, "é", 8, true},
-		{"raw utf8", `"é"`, "é", 4, true},
-		{"trailing escape", `"abc\`, "", 5, false},
-		{"unterminated", `"abc`, "", 4, false},
-		{"not a string", `123`, "", 0, false},
-		{"raw control char", "\"a\tb\"", "", 5, false},
-		{"invalid utf8", "\"a\xffb\"", "a\ufffdb", 5, true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, next, ok := parseJSONString(tc.input, 0)
-			assert.Equal(t, tc.ok, ok, "ok")
-			assert.Equal(t, tc.next, next, "next")
-			assert.Equal(t, tc.want, got, "value")
-			var want string
-			if !tc.ok {
-				require.Error(t,
-					json.Unmarshal([]byte(tc.input), &want),
-					"json.Unmarshal parity")
-				return
-			}
-			require.NoError(t, json.Unmarshal(
-				[]byte(tc.input[:tc.next]), &want))
-			assert.Equal(t, want, got, "json.Unmarshal parity")
-		})
-	}
 }
 
 func TestUsageAggregationClampsMessageTokenJSON(t *testing.T) {
@@ -4083,27 +4049,240 @@ func BenchmarkGetDailyUsageSnapshotWindows(b *testing.B) {
 	}
 }
 
-// BenchmarkGetDailyUsageSnapshotAutomaticIndexOff keeps the survivor query
-// fast even when SQLite cannot create an automatic join index.
-func BenchmarkGetDailyUsageSnapshotAutomaticIndexOff(b *testing.B) {
-	d := testDB(b)
-	seedDailyUsageSnapshotBenchmark(b, d)
-	reader := d.rawReader()
-	reader.SetMaxOpenConns(1)
-	_, err := reader.ExecContext(b.Context(), "PRAGMA automatic_index = OFF")
-	require.NoError(b, err)
-	var automaticIndex int
-	require.NoError(b,
-		reader.QueryRowContext(b.Context(), "PRAGMA automatic_index").
-			Scan(&automaticIndex))
-	require.Zero(b, automaticIndex)
-
-	benchmarkDailyUsageSnapshotWindow(
-		b, d, "2024-07-01", benchmarkDailyUsageExpectation{
-			days: 30, input: 57_600_000, output: 23_040_000,
-			cacheCreation: 14_400_000, cacheRead: 115_200_000,
+func BenchmarkUsageRollup(b *testing.B) {
+	database := testDB(b)
+	seedDailyUsageSnapshotBenchmark(b, database)
+	seedLongLivedUsageBenchmark(b, database)
+	ctx := context.Background()
+	windows := []struct {
+		name         string
+		filter       UsageFilter
+		wantSessions int
+		want         benchmarkDailyUsageExpectation
+	}{
+		{
+			name: "1d", filter: usageFactsBenchmarkFilter("2024-07-30"),
+			wantSessions: 13,
+			want: benchmarkDailyUsageExpectation{
+				days: 1, input: 1_920_500, output: 768_250,
+				cacheCreation: 480_000, cacheRead: 3_840_000,
+			},
 		},
-	)
+		{
+			name: "7d", filter: usageFactsBenchmarkFilter("2024-07-24"),
+			wantSessions: 69,
+			want: benchmarkDailyUsageExpectation{
+				days: 7, input: 13_443_500, output: 5_377_750,
+				cacheCreation: 3_360_000, cacheRead: 26_880_000,
+			},
+		},
+		{
+			name: "30d", filter: usageFactsBenchmarkFilter("2024-07-01"),
+			wantSessions: 253,
+			want: benchmarkDailyUsageExpectation{
+				days: 30, input: 57_615_000, output: 23_047_500,
+				cacheCreation: 14_400_000, cacheRead: 115_200_000,
+			},
+		},
+		{
+			name:         "all",
+			filter:       UsageFilter{Timezone: "UTC", SkipSessionCounts: true},
+			wantSessions: 505,
+			want: benchmarkDailyUsageExpectation{
+				days: 366, input: 120_183_000, output: 48_091_500,
+				cacheCreation: 30_000_000, cacheRead: 240_000_000,
+			},
+		},
+	}
+	allSnapshot, err := database.captureUsageQuery(
+		ctx, windows[len(windows)-1].filter, usageQueryKindToken)
+	require.NoError(b, err, "capture all-history snapshot")
+	require.Len(b, allSnapshot.Sessions, 505)
+	cache, err := database.usageCache.Generation(ctx, allSnapshot.DatabaseID)
+	require.NoError(b, err)
+
+	for _, window := range windows {
+		b.Run("candidate/"+window.name, func(b *testing.B) {
+			captured, captureErr := database.captureUsageQuery(
+				ctx, window.filter, usageQueryKindToken)
+			require.NoError(b, captureErr)
+			require.Len(b, captured.Sessions, window.wantSessions)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				captured, captureErr = database.captureUsageQuery(
+					ctx, window.filter, usageQueryKindToken)
+				if captureErr != nil {
+					b.Fatal(captureErr)
+				}
+				if len(captured.Sessions) != window.wantSessions {
+					b.Fatalf("candidate sessions = %d, want %d",
+						len(captured.Sessions), window.wantSessions)
+				}
+			}
+		})
+	}
+
+	coldCases := []struct {
+		name      string
+		filter    UsageFilter
+		want      benchmarkDailyUsageExpectation
+		wantFacts int
+	}{
+		{"30d", windows[2].filter, windows[2].want, 53_190},
+		{
+			"long-lived-30d",
+			UsageFilter{
+				From: "2024-07-01", To: "2024-07-30", Timezone: "UTC",
+				Project: "long-lived", SkipSessionCounts: true,
+			},
+			benchmarkDailyUsageExpectation{
+				days: 30, input: 15_000, output: 7_500,
+			},
+			53_190,
+		},
+		{"all", windows[3].filter, windows[3].want, 105_150},
+	}
+	for _, cold := range coldCases {
+		b.Run("cold/"+cold.name, func(b *testing.B) {
+			clearUsageFactsBenchmarkCache(b, cache)
+			result, queryErr := database.GetDailyUsage(ctx, cold.filter)
+			require.NoError(b, queryErr)
+			requireDailyUsageBenchmarkResult(b, result, cold.want)
+			requireUsageFactsCount(b, cache, cold.wantFacts)
+			clearUsageFactsBenchmarkCache(b, cache)
+			b.ReportAllocs()
+			b.ReportMetric(float64(cold.wantFacts), "facts/op")
+			b.ResetTimer()
+			for range b.N {
+				b.StopTimer()
+				clearUsageFactsBenchmarkCache(b, cache)
+				b.StartTimer()
+				_, queryErr = database.GetDailyUsage(ctx, cold.filter)
+				if queryErr != nil {
+					b.Fatal(queryErr)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(usageCacheDiskBytes(cache.path)), "cache-bytes")
+		})
+	}
+
+	_, err = database.GetDailyUsage(ctx, windows[3].filter)
+	require.NoError(b, err, "warm all facts")
+	for _, window := range windows {
+		b.Run("warm/"+window.name, func(b *testing.B) {
+			result, queryErr := database.GetDailyUsage(ctx, window.filter)
+			require.NoError(b, queryErr)
+			requireDailyUsageBenchmarkResult(b, result, window.want)
+			b.ReportAllocs()
+			b.ReportMetric(float64(usageCacheDiskBytes(cache.path)), "cache-bytes")
+			b.ResetTimer()
+			for range b.N {
+				if _, queryErr = database.GetDailyUsage(
+					ctx, window.filter); queryErr != nil {
+					b.Fatal(queryErr)
+				}
+			}
+		})
+	}
+
+	b.Run("fill-throughput", func(b *testing.B) {
+		clearUsageFactsBenchmarkCache(b, cache)
+		fills, fillErr := cache.fill.Ensure(
+			ctx, allSnapshot.Versions, allSnapshot.CursorHighWater)
+		require.NoError(b, fillErr)
+		require.Len(b, fills, 505)
+		requireUsageFactsCount(b, cache, 105_150)
+		clearUsageFactsBenchmarkCache(b, cache)
+		b.ReportAllocs()
+		b.ReportMetric(105_150, "facts/op")
+		b.ResetTimer()
+		for range b.N {
+			b.StopTimer()
+			clearUsageFactsBenchmarkCache(b, cache)
+			b.StartTimer()
+			if _, fillErr = cache.fill.Ensure(
+				ctx, allSnapshot.Versions, allSnapshot.CursorHighWater,
+			); fillErr != nil {
+				b.Fatal(fillErr)
+			}
+		}
+		b.StopTimer()
+		b.ReportMetric(
+			float64(105_150*b.N)/b.Elapsed().Seconds(), "facts/s")
+		b.ReportMetric(float64(usageCacheDiskBytes(cache.path)), "cache-bytes")
+	})
+
+	b.Run("relaxed-discovery", func(b *testing.B) {
+		filter := windows[2].filter
+		captured, captureErr := database.captureUsageQuery(
+			ctx, filter, usageQueryKindActivity)
+		require.NoError(b, captureErr)
+		require.Len(b, captured.Sessions, 253)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			captured, captureErr = database.captureUsageQuery(
+				ctx, filter, usageQueryKindActivity)
+			if captureErr != nil {
+				b.Fatal(captureErr)
+			}
+			if len(captured.Sessions) != 253 {
+				b.Fatalf("relaxed candidates = %d, want 253",
+					len(captured.Sessions))
+			}
+		}
+	})
+}
+
+func usageFactsBenchmarkFilter(from string) UsageFilter {
+	return UsageFilter{
+		From: from, To: "2024-07-30", Timezone: "UTC",
+		SkipSessionCounts: true,
+	}
+}
+
+func requireDailyUsageBenchmarkResult(
+	tb testing.TB, result DailyUsageResult, want benchmarkDailyUsageExpectation,
+) {
+	tb.Helper()
+	require.Len(tb, result.Daily, want.days)
+	assert.Equal(tb, want.input, result.Totals.InputTokens)
+	assert.Equal(tb, want.output, result.Totals.OutputTokens)
+	assert.Equal(tb, want.cacheCreation, result.Totals.CacheCreationTokens)
+	assert.Equal(tb, want.cacheRead, result.Totals.CacheReadTokens)
+	assert.Zero(tb, result.SessionCounts.Total)
+}
+
+func requireUsageFactsCount(tb testing.TB, cache *usageCache, want int) {
+	tb.Helper()
+	var got int
+	require.NoError(tb, cache.db.QueryRow(`SELECT COUNT(*) FROM usage_facts`).Scan(&got))
+	require.Equal(tb, want, got, "usage facts")
+}
+
+func usageCacheDiskBytes(path string) int64 {
+	var size int64
+	for _, candidate := range []string{path, path + "-wal"} {
+		if info, err := os.Stat(candidate); err == nil {
+			size += info.Size()
+		}
+	}
+	return size
+}
+
+func clearUsageFactsBenchmarkCache(tb testing.TB, cache *usageCache) {
+	tb.Helper()
+	_, err := cache.db.Exec(`
+		DELETE FROM usage_rollup_timezones;
+		DELETE FROM usage_cached_sessions;
+		DELETE FROM cursor_usage_facts;
+		UPDATE usage_cache_metadata SET value = '0'
+		WHERE key = 'cursor_high_water_mark';
+		UPDATE usage_cache_metadata SET value = '1'
+		WHERE key IN ('next_install_revision', 'next_rollup_install_revision')`)
+	require.NoError(tb, err)
 }
 
 type benchmarkDailyUsageExpectation struct {
@@ -4256,6 +4435,37 @@ func seedDailyUsageSnapshotBenchmark(tb testing.TB, d *DB) {
 	require.Equal(tb, 103_320, messageRows)
 	require.Equal(tb, 103_320, recordedMessages)
 	require.Equal(tb, 3_320, duplicateRequests)
+}
+
+// seedLongLivedUsageBenchmark adds sessions whose full-history extraction is
+// much larger than their 30-day query contribution. This guards the cold-fill
+// cost that activity-bound candidate discovery alone cannot predict.
+func seedLongLivedUsageBenchmark(tb testing.TB, database *DB) {
+	tb.Helper()
+	const (
+		sessionCount = 5
+		messageCount = 366
+	)
+	start, err := time.Parse(time.RFC3339, "2023-07-31T12:00:00Z")
+	require.NoError(tb, err)
+	usage := json.RawMessage(`{"input_tokens":100,"output_tokens":50}`)
+	for sessionIndex := range sessionCount {
+		sessionID := "bench-long-lived-" + strconv.Itoa(sessionIndex)
+		messages := make([]Message, messageCount)
+		for ordinal := range messageCount {
+			messages[ordinal] = Message{
+				SessionID: sessionID, Ordinal: ordinal, Role: "assistant",
+				Timestamp: start.AddDate(0, 0, ordinal).Format(time.RFC3339),
+				Model:     "gpt-5", TokenUsage: usage,
+			}
+		}
+		startedAt := start.Format(time.RFC3339)
+		require.NoError(tb, database.UpsertSession(Session{
+			ID: sessionID, Project: "long-lived", Machine: defaultMachine,
+			Agent: "codex", StartedAt: &startedAt, MessageCount: messageCount,
+		}))
+		require.NoError(tb, database.InsertMessages(messages))
+	}
 }
 
 func benchClaudeID(kind string, session, ordinal int) string {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -3998,14 +3998,15 @@ func BenchmarkGetDailyUsage(b *testing.B) {
 		}
 	}
 
+	filter := UsageFilter{From: "2024-06-01", To: "2024-08-01"}
+	if _, err := d.GetDailyUsage(ctx, filter); err != nil {
+		b.Fatalf("warming GetDailyUsage: %v", err)
+	}
 	log.SetOutput(origLog)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, err := d.GetDailyUsage(ctx, UsageFilter{
-			From: "2024-06-01",
-			To:   "2024-08-01",
-		})
+		_, err := d.GetDailyUsage(ctx, filter)
 		if err != nil {
 			b.Fatalf("GetDailyUsage: %v", err)
 		}
@@ -4047,6 +4048,29 @@ func BenchmarkGetDailyUsageSnapshotWindows(b *testing.B) {
 			)
 		})
 	}
+}
+
+// BenchmarkGetDailyUsageSnapshotAutomaticIndexOff keeps the cache query fast
+// when SQLite automatic indexes are unavailable.
+func BenchmarkGetDailyUsageSnapshotAutomaticIndexOff(b *testing.B) {
+	d := testDB(b)
+	seedDailyUsageSnapshotBenchmark(b, d)
+	reader := d.rawReader()
+	reader.SetMaxOpenConns(1)
+	_, err := reader.ExecContext(b.Context(), "PRAGMA automatic_index = OFF")
+	require.NoError(b, err)
+	var automaticIndex int
+	require.NoError(b,
+		reader.QueryRowContext(b.Context(), "PRAGMA automatic_index").
+			Scan(&automaticIndex))
+	require.Zero(b, automaticIndex)
+
+	benchmarkDailyUsageSnapshotWindow(
+		b, d, "2024-07-01", benchmarkDailyUsageExpectation{
+			days: 30, input: 57_600_000, output: 23_040_000,
+			cacheCreation: 14_400_000, cacheRead: 115_200_000,
+		},
+	)
 }
 
 func BenchmarkUsageRollup(b *testing.B) {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -4002,7 +4002,9 @@ func BenchmarkGetDailyUsage(b *testing.B) {
 	if _, err := d.GetDailyUsage(ctx, filter); err != nil {
 		b.Fatalf("warming GetDailyUsage: %v", err)
 	}
-	log.SetOutput(origLog)
+	// Logs stay discarded through the timed loop: a slow-request log
+	// line interleaving with the benchmark result line corrupts the
+	// bench-gate capture (see silenceBenchLogs in internal/sync).
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -4074,6 +4076,12 @@ func BenchmarkGetDailyUsageSnapshotAutomaticIndexOff(b *testing.B) {
 }
 
 func BenchmarkUsageRollup(b *testing.B) {
+	// Cold sub-benchmarks exceed the slow-request threshold on CI
+	// runners; the resulting log line would interleave with benchmark
+	// result lines and corrupt the bench-gate capture.
+	origLog := log.Writer()
+	log.SetOutput(io.Discard)
+	b.Cleanup(func() { log.SetOutput(origLog) })
 	database := testDB(b)
 	seedDailyUsageSnapshotBenchmark(b, database)
 	seedLongLivedUsageBenchmark(b, database)

--- a/internal/postgres/usage_facts_parity_pgtest_test.go
+++ b/internal/postgres/usage_facts_parity_pgtest_test.go
@@ -1,0 +1,290 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+type usageParitySnapshot struct {
+	Daily                usageParityDaily
+	Top                  []usageParityTopSession
+	Counts               db.UsageSessionCounts
+	MatchingSessionCount int
+	Session              usageParitySession
+}
+
+type usageParityDaily struct {
+	Dates               []string
+	InputTokens         int
+	OutputTokens        int
+	CacheCreationTokens int
+	CacheReadTokens     int
+	CostMicrodollars    int64
+	Models              []string
+	SessionCounts       db.UsageSessionCounts
+}
+
+type usageParityTopSession struct {
+	SessionID        string
+	InputTokens      int
+	OutputTokens     int
+	TotalTokens      int
+	CostMicrodollars int64
+}
+
+type usageParitySession struct {
+	SessionID         string
+	TotalOutputTokens int
+	PeakContextTokens int
+	HasTokenData      bool
+	CostMicrodollars  int64
+	HasCost           bool
+	Models            []string
+	UnpricedModels    []string
+	BreakdownCount    int
+	Breakdown         []usageParityBreakdown
+}
+
+type usageParityBreakdown struct {
+	Source           string
+	Timestamp        string
+	Model            string
+	InputTokens      int
+	OutputTokens     int
+	CostMicrodollars int64
+	HasCost          bool
+}
+
+func TestSQLiteFactsAndPostgresLiveUsageParity(t *testing.T) {
+	const schema = "agentsview_usage_facts_parity_test"
+	pgURL := testPGURL(t)
+	cleanNamedPGSchema(t, pgURL, schema)
+	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
+
+	local := testDB(t)
+	seedUsageParityFixture(t, local)
+
+	syncer, err := New(
+		pgURL, schema, local, "parity-machine", true, SyncOptions{},
+	)
+	require.NoError(t, err, "create PostgreSQL sync")
+	t.Cleanup(func() { require.NoError(t, syncer.Close()) })
+	_, err = syncer.Push(t.Context(), false, nil)
+	require.NoError(t, err, "push parity fixture")
+
+	remote, err := NewStore(pgURL, schema, true)
+	require.NoError(t, err, "open PostgreSQL store")
+	t.Cleanup(func() { require.NoError(t, remote.Close()) })
+
+	want := usageParitySnapshot{
+		Daily: usageParityDaily{
+			Dates:       []string{"2026-08-12"},
+			InputTokens: 57, OutputTokens: 18,
+			CacheCreationTokens: 2, CacheReadTokens: 3,
+			CostMicrodollars: 260_040,
+			Models:           []string{"model-priced", "model-reported", "model-unpriced"},
+			SessionCounts: db.UsageSessionCounts{
+				Total:   3,
+				ByAgent: map[string]int{"claude": 2, "hermes": 1},
+			},
+		},
+		Top: []usageParityTopSession{
+			{SessionID: "reported", InputTokens: 30, OutputTokens: 5, TotalTokens: 40, CostMicrodollars: 250_000},
+			{SessionID: "snapshot-loser", InputTokens: 20, OutputTokens: 10, TotalTokens: 30, CostMicrodollars: 10_040},
+			{SessionID: "blank-timestamp", InputTokens: 7, OutputTokens: 3, TotalTokens: 10},
+		},
+		Counts: db.UsageSessionCounts{
+			Total:     3,
+			ByProject: map[string]int{"project-a": 1, "project-c": 1, "project-d": 1},
+			ByAgent:   map[string]int{"claude": 2, "hermes": 1},
+		},
+		MatchingSessionCount: 5,
+		Session: usageParitySession{
+			SessionID: "snapshot-winner", TotalOutputTokens: 10,
+			PeakContextTokens: 20, HasTokenData: true,
+			CostMicrodollars: 10_040, HasCost: true,
+			Models: []string{"model-priced"}, BreakdownCount: 1,
+			Breakdown: []usageParityBreakdown{{
+				Source: "message", Timestamp: "2026-08-12T10:01:00Z",
+				Model: "model-priced", InputTokens: 20, OutputTokens: 10,
+				CostMicrodollars: 10_040, HasCost: true,
+			}},
+		},
+	}
+
+	filter := db.UsageFilter{
+		From: "2026-08-12", To: "2026-08-12", Timezone: "UTC",
+	}
+	localGot := captureUsageParitySnapshot(t, local, filter)
+	remoteGot := captureUsageParitySnapshot(t, remote, filter)
+	require.Equal(t, want, localGot, "SQLite facts result")
+	require.Equal(t, want, remoteGot, "PostgreSQL live result")
+	require.Equal(t, localGot, remoteGot, "cross-backend result")
+	requireCompleteUsageParity(t, local, remote, filter)
+}
+
+func requireCompleteUsageParity(
+	t *testing.T, local, remote db.Store, filter db.UsageFilter,
+) {
+	t.Helper()
+	ctx := context.Background()
+	localDaily, err := local.GetDailyUsage(ctx, filter)
+	require.NoError(t, err)
+	remoteDaily, err := remote.GetDailyUsage(ctx, filter)
+	require.NoError(t, err)
+	require.Equal(t, localDaily, remoteDaily, "complete daily result")
+	localTop, err := local.GetTopSessionsByCost(ctx, filter, 10)
+	require.NoError(t, err)
+	remoteTop, err := remote.GetTopSessionsByCost(ctx, filter, 10)
+	require.NoError(t, err)
+	require.Equal(t, localTop, remoteTop, "complete top-session result")
+	localSession, err := local.GetSessionUsage(ctx, "snapshot-winner", true)
+	require.NoError(t, err)
+	remoteSession, err := remote.GetSessionUsage(ctx, "snapshot-winner", true)
+	require.NoError(t, err)
+	require.Equal(t, localSession, remoteSession, "complete session result")
+}
+
+func seedUsageParityFixture(t *testing.T, local *db.DB) {
+	t.Helper()
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{
+		{
+			ModelPattern:  "model-priced",
+			InputPerMTok:  money.Money{Microdollars: 1_000_000},
+			OutputPerMTok: money.Money{Microdollars: 2_000_000},
+		},
+		{
+			ModelPattern:  "model-reported",
+			InputPerMTok:  money.Money{Microdollars: 1_000_000},
+			OutputPerMTok: money.Money{Microdollars: 1_000_000},
+		},
+	}), "seed pricing")
+
+	sessions := []db.Session{
+		usageParitySessionFixture("snapshot-loser", "project-a", "claude", "2026-08-12T10:00:00Z", 5, 10),
+		usageParitySessionFixture("snapshot-winner", "project-b", "claude", "2026-08-12T10:01:00Z", 10, 20),
+		usageParitySessionFixture("reported", "project-c", "hermes", "2026-08-12T11:00:00Z", 5, 30),
+		usageParitySessionFixture("blank-timestamp", "project-d", "claude", "2026-08-12T12:00:00Z", 3, 7),
+		usageParitySessionFixture("activity-only", "project-e", "claude", "2026-08-12T13:00:00Z", 0, 0),
+	}
+	for i := range sessions {
+		require.NoError(t, local.UpsertSession(sessions[i]),
+			"seed session %s", sessions[i].ID)
+	}
+
+	require.NoError(t, local.InsertMessages([]db.Message{
+		{
+			SessionID: "snapshot-loser", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-12T10:00:00Z", Model: "model-priced",
+			TokenUsage:      json.RawMessage(`{"input_tokens":10,"output_tokens":5}`),
+			ClaudeMessageID: "shared-message", ClaudeRequestID: "shared-request",
+		},
+		{
+			SessionID: "snapshot-winner", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-12T10:01:00Z", Model: "model-priced",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":20,"output_tokens":10,"server_tool_use":{"web_search_requests":1}}`),
+			ClaudeMessageID: "shared-message", ClaudeRequestID: "shared-request",
+		},
+		{
+			SessionID: "blank-timestamp", Ordinal: 0, Role: "assistant",
+			Model:      "model-unpriced",
+			TokenUsage: json.RawMessage(`{"input_tokens":7,"output_tokens":3}`),
+		},
+		{
+			SessionID: "activity-only", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-12T13:01:00Z", Model: "model-activity",
+		},
+	}), "seed messages")
+
+	reportedCost := money.Money{Microdollars: 250_000}
+	require.NoError(t, local.ReplaceSessionUsageEvents("reported", []db.UsageEvent{{
+		SessionID: "reported", Source: "provider", Model: "model-reported",
+		InputTokens: 30, OutputTokens: 5,
+		CacheCreationInputTokens: 2, CacheReadInputTokens: 3, Cost: &reportedCost,
+		OccurredAt: "2026-08-12T11:05:00Z", DedupKey: "reported-usage",
+	}}), "seed reported usage")
+}
+
+func usageParitySessionFixture(
+	id, project, agent, startedAt string, outputTokens, contextTokens int,
+) db.Session {
+	return db.Session{
+		ID: id, Project: project, Machine: "parity-machine", Agent: agent,
+		StartedAt: &startedAt, MessageCount: 1, UserMessageCount: 1,
+		TotalOutputTokens: outputTokens, PeakContextTokens: contextTokens,
+		HasTotalOutputTokens: true, HasPeakContextTokens: true,
+	}
+}
+
+func captureUsageParitySnapshot(
+	t *testing.T, store db.Store, filter db.UsageFilter,
+) usageParitySnapshot {
+	t.Helper()
+	ctx := context.Background()
+	daily, err := store.GetDailyUsage(ctx, filter)
+	require.NoError(t, err, "daily usage")
+	top, err := store.GetTopSessionsByCost(ctx, filter, 10)
+	require.NoError(t, err, "top sessions")
+	counts, err := store.GetUsageSessionCounts(ctx, filter)
+	require.NoError(t, err, "usage session counts")
+	matching, err := store.GetUsageMatchingSessionCount(ctx, filter)
+	require.NoError(t, err, "matching session count")
+	session, err := store.GetSessionUsage(ctx, "snapshot-winner", true)
+	require.NoError(t, err, "session usage")
+	require.NotNil(t, session, "session usage result")
+
+	out := usageParitySnapshot{
+		Daily: usageParityDaily{
+			InputTokens:         daily.Totals.InputTokens,
+			OutputTokens:        daily.Totals.OutputTokens,
+			CacheCreationTokens: daily.Totals.CacheCreationTokens,
+			CacheReadTokens:     daily.Totals.CacheReadTokens,
+			CostMicrodollars:    daily.Totals.TotalCost.Microdollars,
+			SessionCounts: db.UsageSessionCounts{
+				Total:   daily.SessionCounts.Total,
+				ByAgent: daily.SessionCounts.ByAgent,
+			},
+		},
+		Counts: counts, MatchingSessionCount: matching,
+		Session: usageParitySession{
+			SessionID:         session.SessionID,
+			TotalOutputTokens: session.TotalOutputTokens,
+			PeakContextTokens: session.PeakContextTokens,
+			HasTokenData:      session.HasTokenData,
+			CostMicrodollars:  session.Cost.Microdollars,
+			HasCost:           session.HasCost, Models: session.Models,
+			UnpricedModels: session.UnpricedModels,
+			BreakdownCount: session.BreakdownCount,
+		},
+	}
+	for _, day := range daily.Daily {
+		out.Daily.Dates = append(out.Daily.Dates, day.Date)
+		out.Daily.Models = append(out.Daily.Models, day.ModelsUsed...)
+	}
+	sort.Strings(out.Daily.Models)
+	for _, entry := range top {
+		out.Top = append(out.Top, usageParityTopSession{
+			SessionID: entry.SessionID, InputTokens: entry.InputTokens,
+			OutputTokens: entry.OutputTokens, TotalTokens: entry.TotalTokens,
+			CostMicrodollars: entry.Cost.Microdollars,
+		})
+	}
+	for _, entry := range session.Breakdown {
+		out.Session.Breakdown = append(out.Session.Breakdown, usageParityBreakdown{
+			Source: entry.Source, Timestamp: entry.Timestamp, Model: entry.Model,
+			InputTokens: entry.InputTokens, OutputTokens: entry.OutputTokens,
+			CostMicrodollars: entry.Cost.Microdollars, HasCost: entry.HasCost,
+		})
+	}
+	return out
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2839,6 +2839,29 @@ func (e *Engine) resyncBuildLocked(
 		)
 	}
 
+	// Same trade as FTS: the usage and activity message indexes are
+	// pure derived state, so skip their per-row maintenance during the
+	// bulk load and build each B-tree once before the swap. Read-only
+	// opens require these indexes, so the rebuild must succeed before
+	// the replacement is installed.
+	if err := newDB.DropUsageMessageIndexes(); err != nil {
+		log.Printf("resync: drop temp usage indexes: %v", err)
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		stats = SyncStats{
+			Aborted: true,
+			Warnings: []string{
+				"resync failed: drop temp usage indexes: " +
+					err.Error(),
+			},
+		}
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats, err
+	}
+
 	// 3. Point engine at newDB and sync into it. Report discovery as its
 	// own phase first: syncAllLocked walks every source before emitting
 	// its first syncing event, and on a large archive that walk takes
@@ -3365,6 +3388,35 @@ func (e *Engine) resyncBuildLocked(
 			time.Since(tFTS).Round(time.Millisecond),
 		)
 	}
+
+	tUsageIndexes := time.Now()
+	reportResyncPhase(
+		PhaseRebuildingSearch,
+		"Rebuilding usage indexes",
+		"",
+	)
+	if err := ops.rebuildUsageIndexes(newDB); err != nil {
+		log.Printf("resync: rebuild usage indexes: %v", err)
+		stats.Aborted = true
+		stats.Warnings = append(stats.Warnings,
+			"usage index rebuild failed, aborting swap: "+
+				err.Error(),
+		)
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		if rerr := origDB.Reopen(); rerr != nil {
+			log.Printf("resync: recovery reopen: %v", rerr)
+		}
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats, err
+	}
+	log.Printf(
+		"resync: rebuild usage indexes: %s",
+		time.Since(tUsageIndexes).Round(time.Millisecond),
+	)
 
 	// Persist the fresh skip state into the replacement so the post-swap engine
 	// loads warm state: this engine after an in-process swap, or the daemon

--- a/internal/sync/engine_bench_test.go
+++ b/internal/sync/engine_bench_test.go
@@ -40,8 +40,8 @@ import (
 // AGENTSVIEW_BENCH_SYNC_MESSAGES for larger local runs.
 
 const (
-	defaultBenchSyncSessions = 40
-	defaultBenchSyncMessages = 30
+	defaultBenchSyncSessions = 60
+	defaultBenchSyncMessages = 100
 	benchLargeSessionLines   = 1000
 )
 
@@ -90,9 +90,19 @@ func writeBenchClaudeArchive(
 			builder.AddClaudeUser(ts, fmt.Sprintf(
 				"user message %d in session %d", m, s,
 			))
-			builder.AddClaudeAssistant(ts, fmt.Sprintf(
+			// Unique per-turn identity and token usage, matching real
+			// Claude transcripts: assistant rows must land in the
+			// partial usage/activity indexes or bulk-ingest benchmarks
+			// never exercise their per-row maintenance cost.
+			builder.AddClaudeAssistantUsage(ts, fmt.Sprintf(
 				"assistant reply %d in session %d", m, s,
-			))
+			), testjsonl.ClaudeAssistantUsage{
+				MessageID:    fmt.Sprintf("msg_bench_%04d_%04d", s, m),
+				RequestID:    fmt.Sprintf("req_bench_%04d_%04d", s, m),
+				Model:        "claude-sonnet-4-20250514",
+				InputTokens:  1000 + m,
+				OutputTokens: 500 + m,
+			})
 		}
 		path := filepath.Join(
 			proj, fmt.Sprintf("bench-%04d.jsonl", s),

--- a/internal/sync/engine_bench_test.go
+++ b/internal/sync/engine_bench_test.go
@@ -40,9 +40,13 @@ import (
 // AGENTSVIEW_BENCH_SYNC_MESSAGES for larger local runs.
 
 const (
-	defaultBenchSyncSessions = 60
-	defaultBenchSyncMessages = 100
-	benchLargeSessionLines   = 1000
+	defaultBenchSyncSessions = 40
+	defaultBenchSyncMessages = 30
+	// The usage-bearing fixture is larger so the partial usage-index
+	// B-trees see enough rows for per-row maintenance costs to show.
+	defaultBenchSyncUsageSessions = 60
+	defaultBenchSyncUsageMessages = 100
+	benchLargeSessionLines        = 1000
 )
 
 // silenceBenchLogs discards the engine's global log output for the
@@ -90,10 +94,44 @@ func writeBenchClaudeArchive(
 			builder.AddClaudeUser(ts, fmt.Sprintf(
 				"user message %d in session %d", m, s,
 			))
-			// Unique per-turn identity and token usage, matching real
-			// Claude transcripts: assistant rows must land in the
-			// partial usage/activity indexes or bulk-ingest benchmarks
-			// never exercise their per-row maintenance cost.
+			builder.AddClaudeAssistant(ts, fmt.Sprintf(
+				"assistant reply %d in session %d", m, s,
+			))
+		}
+		path := filepath.Join(
+			proj, fmt.Sprintf("bench-%04d.jsonl", s),
+		)
+		if err := os.WriteFile(
+			path, []byte(builder.String()), 0o644,
+		); err != nil {
+			b.Fatalf("WriteFile %s: %v", path, err)
+		}
+	}
+}
+
+// writeBenchClaudeUsageArchive is the usage-bearing variant: every
+// assistant line carries model, unique message/request identity, and
+// token usage, the shape billed turns take in real Claude transcripts.
+// Those rows land in the partial usage/activity archive indexes, so
+// ingest benchmarks over this fixture exercise their per-row
+// maintenance cost.
+func writeBenchClaudeUsageArchive(
+	b *testing.B, dir string, sessions, perSession int,
+) {
+	b.Helper()
+	proj := filepath.Join(dir, "bench-project")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		b.Fatalf("MkdirAll: %v", err)
+	}
+	for s := range sessions {
+		builder := testjsonl.NewSessionBuilder()
+		for m := 0; m < perSession; m += 2 {
+			ts := fmt.Sprintf(
+				"2026-06-20T10:%02d:%02dZ", (m/2/60)%60, (m/2)%60,
+			)
+			builder.AddClaudeUser(ts, fmt.Sprintf(
+				"user message %d in session %d", m, s,
+			))
 			builder.AddClaudeAssistantUsage(ts, fmt.Sprintf(
 				"assistant reply %d in session %d", m, s,
 			), testjsonl.ClaudeAssistantUsage{
@@ -195,9 +233,25 @@ func BenchmarkSyncAllWarmNoop(b *testing.B) {
 // staying flat as the session grows is exactly the invariant this
 // benchmark protects.
 func BenchmarkSyncPathsIncrementalAppend(b *testing.B) {
+	benchSyncPathsIncrementalAppend(b, false)
+}
+
+// BenchmarkSyncPathsIncrementalAppendUsage appends usage-bearing
+// assistant lines to a usage-bearing session, the shape live Claude
+// streaming takes: each absorbed line maintains the partial usage
+// indexes and notifies the usage cache.
+func BenchmarkSyncPathsIncrementalAppendUsage(b *testing.B) {
+	benchSyncPathsIncrementalAppend(b, true)
+}
+
+func benchSyncPathsIncrementalAppend(b *testing.B, withUsage bool) {
 	silenceBenchLogs(b)
 	dir := b.TempDir()
-	writeBenchClaudeArchive(b, dir, 1, benchLargeSessionLines)
+	writeArchive := writeBenchClaudeArchive
+	if withUsage {
+		writeArchive = writeBenchClaudeUsageArchive
+	}
+	writeArchive(b, dir, 1, benchLargeSessionLines)
 	engine, database := openBenchEngine(b, dir)
 	ctx := context.Background()
 
@@ -245,6 +299,20 @@ func BenchmarkSyncPathsIncrementalAppend(b *testing.B) {
 	// loop that helper cost would be gated as if it were sync work.
 	lines := make([]string, b.N)
 	for i := range lines {
+		if withUsage {
+			lines[i] = testjsonl.NewSessionBuilder().AddClaudeAssistantUsage(
+				"2026-06-20T11:00:00Z",
+				fmt.Sprintf("streamed line %d", i),
+				testjsonl.ClaudeAssistantUsage{
+					MessageID:    fmt.Sprintf("msg_bench_append_%06d", i),
+					RequestID:    fmt.Sprintf("req_bench_append_%06d", i),
+					Model:        "claude-sonnet-4-20250514",
+					InputTokens:  1000 + i,
+					OutputTokens: 500 + i,
+				},
+			).String()
+			continue
+		}
 		lines[i] = testjsonl.NewSessionBuilder().AddClaudeUser(
 			"2026-06-20T11:00:00Z",
 			fmt.Sprintf("streamed line %d", i),
@@ -277,21 +345,31 @@ func BenchmarkSyncPathsIncrementalAppend(b *testing.B) {
 // benchColdArchive is the shared cold-ingest loop: each iteration
 // syncs the same archive into a fresh database via syncOnce, then
 // verify checks the iteration's outcome with the timer stopped.
+// withUsage selects the usage-bearing fixture and its larger default
+// size.
 func benchColdArchive(
-	b *testing.B,
+	b *testing.B, withUsage bool,
 	syncOnce func(*Engine) SyncStats,
 	verify func(*Engine, SyncStats, int),
 ) {
 	b.Helper()
 	silenceBenchLogs(b)
+	defaultSessions, defaultMessages := defaultBenchSyncSessions,
+		defaultBenchSyncMessages
+	writeArchive := writeBenchClaudeArchive
+	if withUsage {
+		defaultSessions, defaultMessages = defaultBenchSyncUsageSessions,
+			defaultBenchSyncUsageMessages
+		writeArchive = writeBenchClaudeUsageArchive
+	}
 	sessions := benchIntFromEnv(
-		"AGENTSVIEW_BENCH_SYNC_SESSIONS", defaultBenchSyncSessions,
+		"AGENTSVIEW_BENCH_SYNC_SESSIONS", defaultSessions,
 	)
 	perSession := benchIntFromEnv(
-		"AGENTSVIEW_BENCH_SYNC_MESSAGES", defaultBenchSyncMessages,
+		"AGENTSVIEW_BENCH_SYNC_MESSAGES", defaultMessages,
 	)
 	dir := b.TempDir()
-	writeBenchClaudeArchive(b, dir, sessions, perSession)
+	writeArchive(b, dir, sessions, perSession)
 	dbDir := b.TempDir()
 
 	b.ReportAllocs()
@@ -339,8 +417,19 @@ func benchColdArchive(
 // through the public SyncAll path: parse plus the default
 // per-session writes a user's first sync performs.
 func BenchmarkSyncAllColdArchive(b *testing.B) {
+	benchSyncAllColdArchive(b, false)
+}
+
+// BenchmarkSyncAllColdArchiveUsage is the same ingest over the
+// usage-bearing fixture, so archive usage-index maintenance and
+// token-field extraction are part of the gated cost.
+func BenchmarkSyncAllColdArchiveUsage(b *testing.B) {
+	benchSyncAllColdArchive(b, true)
+}
+
+func benchSyncAllColdArchive(b *testing.B, withUsage bool) {
 	ctx := context.Background()
-	benchColdArchive(b,
+	benchColdArchive(b, withUsage,
 		func(engine *Engine) SyncStats {
 			return engine.SyncAll(ctx, nil)
 		},
@@ -363,8 +452,18 @@ func BenchmarkSyncAllColdArchive(b *testing.B) {
 // self-asserts that every session really went through the batch
 // pipeline so the benchmark cannot silently measure the wrong path.
 func BenchmarkResyncBulkIngest(b *testing.B) {
+	benchResyncBulkIngest(b, false)
+}
+
+// BenchmarkResyncBulkIngestUsage runs the bulk-write pipeline over the
+// usage-bearing fixture so per-row usage-index maintenance is gated.
+func BenchmarkResyncBulkIngestUsage(b *testing.B) {
+	benchResyncBulkIngest(b, true)
+}
+
+func benchResyncBulkIngest(b *testing.B, withUsage bool) {
 	ctx := context.Background()
-	benchColdArchive(b,
+	benchColdArchive(b, withUsage,
 		func(engine *Engine) SyncStats {
 			engine.syncMu.Lock()
 			defer engine.syncMu.Unlock()
@@ -393,8 +492,19 @@ func BenchmarkResyncBulkIngest(b *testing.B) {
 // BenchmarkResyncBulkContributorIngest measures the same cold archive shape
 // when it enters the atomic rebuild through a contributor engine.
 func BenchmarkResyncBulkContributorIngest(b *testing.B) {
+	benchResyncBulkContributorIngest(b, false)
+}
+
+// BenchmarkResyncBulkContributorIngestUsage is the contributor rebuild
+// over the usage-bearing fixture, covering the full ResyncAll path
+// including the usage-index drop and rebuild.
+func BenchmarkResyncBulkContributorIngestUsage(b *testing.B) {
+	benchResyncBulkContributorIngest(b, true)
+}
+
+func benchResyncBulkContributorIngest(b *testing.B, withUsage bool) {
 	ctx := context.Background()
-	benchColdArchive(b,
+	benchColdArchive(b, withUsage,
 		func(engine *Engine) SyncStats {
 			dir := engine.agentDirs[parser.AgentClaude][0]
 			engine.agentDirs = nil

--- a/internal/sync/rebuild_contributor.go
+++ b/internal/sync/rebuild_contributor.go
@@ -77,6 +77,7 @@ func (e *RebuildContributorError) Unwrap() error { return e.Err }
 
 type rebuildOperations struct {
 	rebuildFTS                        func(*db.DB) error
+	rebuildUsageIndexes               func(*db.DB) error
 	reopen                            func(*db.DB) error
 	listActiveWorktreeMappingMachines func(context.Context, *db.DB) ([]string, error)
 	applyWorktreeMappings             func(context.Context, *db.DB, string) (db.ApplyWorktreeProjectMappingsResult, error)
@@ -84,7 +85,10 @@ type rebuildOperations struct {
 
 var productionRebuildOperations = rebuildOperations{
 	rebuildFTS: func(database *db.DB) error { return database.RebuildFTS() },
-	reopen:     func(database *db.DB) error { return database.Reopen() },
+	rebuildUsageIndexes: func(database *db.DB) error {
+		return database.RebuildUsageMessageIndexes()
+	},
+	reopen: func(database *db.DB) error { return database.Reopen() },
 	listActiveWorktreeMappingMachines: func(
 		ctx context.Context, database *db.DB,
 	) ([]string, error) {
@@ -100,6 +104,9 @@ var productionRebuildOperations = rebuildOperations{
 func (ops rebuildOperations) withDefaults() rebuildOperations {
 	if ops.rebuildFTS == nil {
 		ops.rebuildFTS = productionRebuildOperations.rebuildFTS
+	}
+	if ops.rebuildUsageIndexes == nil {
+		ops.rebuildUsageIndexes = productionRebuildOperations.rebuildUsageIndexes
 	}
 	if ops.reopen == nil {
 		ops.reopen = productionRebuildOperations.reopen

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/testjsonl"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1063,4 +1065,90 @@ func TestResyncPreInstallSwapFailureDoesNotReportDiscardedTombstones(
 	stale, err := database.GetSession(context.Background(), staleID)
 	require.NoError(t, err)
 	assert.NotNil(t, stale, "the original archive keeps the stale fork active")
+}
+
+func countArchiveUsageIndexes(t *testing.T, path string) int {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open %s for usage index count", path)
+	defer conn.Close()
+	var count int
+	require.NoError(t, conn.QueryRow(
+		`SELECT count(*) FROM sqlite_master
+		 WHERE type = 'index' AND name IN (
+			'idx_messages_usage_timestamp',
+			'idx_messages_usage_session_covering',
+			'idx_messages_activity_timestamp'
+		 )`,
+	).Scan(&count), "count usage indexes in %s", path)
+	return count
+}
+
+func TestResyncDropsAndRebuildsUsageIndexes(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	path := filepath.Join(root, "proj", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "usage index resync").String()), 0o644))
+
+	rebuildCalls := 0
+	duringRebuild := -1
+	stats, err := engine.resyncAllWithOptionsAndOperations(
+		context.Background(), nil, RebuildOptions{}, rebuildOperations{
+			rebuildUsageIndexes: func(newDB *db.DB) error {
+				rebuildCalls++
+				duringRebuild = countArchiveUsageIndexes(t, newDB.Path())
+				return newDB.RebuildUsageMessageIndexes()
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+	assert.Equal(t, 1, rebuildCalls, "usage indexes rebuilt once")
+	assert.Equal(t, 0, duringRebuild,
+		"usage indexes must stay dropped during the bulk load")
+	assert.Equal(t, 3, countArchiveUsageIndexes(t, database.Path()),
+		"swapped archive must carry rebuilt usage indexes")
+}
+
+func TestResyncUsageIndexRebuildFailureAbortsSwap(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	oldPath := filepath.Join(root, "old", "old.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
+	require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "archive survives usage failure").String()), 0o644))
+	require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
+
+	sentinel := errors.New("usage index sentinel")
+	stats, err := engine.resyncAllWithOptionsAndOperations(
+		context.Background(), nil, RebuildOptions{}, rebuildOperations{
+			rebuildUsageIndexes: func(*db.DB) error { return sentinel },
+		},
+	)
+	require.ErrorIs(t, err, sentinel)
+	assert.True(t, stats.Aborted)
+	page, listErr := database.ListSessions(context.Background(), db.SessionFilter{})
+	require.NoError(t, listErr)
+	require.Len(t, page.Sessions, 1, "original archive must stay intact")
+	assert.Equal(t, 3, countArchiveUsageIndexes(t, database.Path()),
+		"original archive must keep its usage indexes")
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
 }

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -541,6 +541,42 @@ func (b *SessionBuilder) AddClaudeAssistant(
 	return b
 }
 
+// ClaudeAssistantUsage carries the token-usage identity fields for
+// AddClaudeAssistantUsage.
+type ClaudeAssistantUsage struct {
+	MessageID    string
+	RequestID    string
+	Model        string
+	InputTokens  int
+	OutputTokens int
+}
+
+// AddClaudeAssistantUsage appends a Claude assistant message line
+// carrying model, message/request identity, and token usage, the
+// shape billed API turns take in real Claude Code transcripts.
+func (b *SessionBuilder) AddClaudeAssistantUsage(
+	timestamp, text string, usage ClaudeAssistantUsage,
+) *SessionBuilder {
+	m := map[string]any{
+		"type":      "assistant",
+		"timestamp": timestamp,
+		"requestId": usage.RequestID,
+		"message": map[string]any{
+			"id":    usage.MessageID,
+			"model": usage.Model,
+			"content": []map[string]string{
+				{"type": "text", "text": text},
+			},
+			"usage": map[string]any{
+				"input_tokens":  usage.InputTokens,
+				"output_tokens": usage.OutputTokens,
+			},
+		},
+	}
+	b.lines = append(b.lines, mustMarshal(m))
+	return b
+}
+
 // AddCodexMeta appends a Codex session_meta line.
 func (b *SessionBuilder) AddCodexMeta(
 	timestamp, id, cwd, originator string,

--- a/internal/usagefacts/fact.go
+++ b/internal/usagefacts/fact.go
@@ -1,0 +1,559 @@
+// Package usagefacts normalizes provider usage rows without pricing them or
+// attaching mutable session metadata.
+package usagefacts
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// MaxPlausibleTokens bounds one request-level token counter. Aggregate session
+// totals may legitimately exceed it.
+const MaxPlausibleTokens = 2_000_000
+
+// MessageInput is the session-independent message shape used for extraction.
+type MessageInput struct {
+	Ordinal                            int
+	Role, Timestamp, Model, TokenUsage string
+	ClaudeMessageID, ClaudeRequestID   string
+	SourceUUID                         string
+}
+
+// EventInput is the session-independent usage-event shape used for extraction.
+type EventInput struct {
+	MessageOrdinal            *int
+	Source, Timestamp, Model  string
+	CostSource, DedupKey      string
+	InputTokens, OutputTokens int64
+	ReasoningTokens           int64
+	CacheCreationTokens       int64
+	CacheReadTokens           int64
+	ReportedCostMicrodollars  *int64
+}
+
+// ParsedTokenUsage is the sanitized token and billable tool-use payload.
+type ParsedTokenUsage struct {
+	InputTokens         int64
+	OutputTokens        int64
+	ReasoningTokens     int64
+	CacheCreationTokens int64
+	CacheReadTokens     int64
+	WebSearchRequests   int64
+}
+
+// Fact is one normalized, unpriced usage or activity row.
+type Fact struct {
+	Source                   string
+	MessageOrdinal           *int
+	TimestampMillis          *int64
+	TimestampNanos           *int64
+	RawTimestamp             string
+	UsesSessionStart         bool
+	Model                    string
+	InputTokens              int64
+	OutputTokens             int64
+	ReasoningTokens          int64
+	CacheCreationTokens      int64
+	CacheReadTokens          int64
+	WebSearchRequests        int64
+	ReportedCostMicrodollars *int64
+	CostSource               string
+	RequestScoped            bool
+	ClaudeMessageID          string
+	ClaudeRequestID          string
+	SourceUUID               string
+	UsageDedupKey            string
+	TokenEligible            bool
+	ActivityEligible         bool
+}
+
+// FromMessage returns a normalized fact for a usage- or activity-eligible row.
+func FromMessage(in MessageInput) (Fact, bool) {
+	tokenEligible := in.TokenUsage != "" && in.Model != "" &&
+		in.Model != "<synthetic>"
+	activityEligible := in.Role == "assistant" && in.Model != "<synthetic>"
+	if !tokenEligible && !activityEligible {
+		return Fact{}, false
+	}
+	parsed := ParseTokenUsage(in.TokenUsage)
+	ordinal := in.Ordinal
+	millis, nanos, raw, fallback := parseTimestamp(in.Timestamp)
+	return Fact{
+		Source: "message", MessageOrdinal: &ordinal,
+		TimestampMillis: millis, TimestampNanos: nanos, RawTimestamp: raw,
+		UsesSessionStart: fallback, Model: in.Model,
+		InputTokens: parsed.InputTokens, OutputTokens: parsed.OutputTokens,
+		ReasoningTokens:     parsed.ReasoningTokens,
+		CacheCreationTokens: parsed.CacheCreationTokens,
+		CacheReadTokens:     parsed.CacheReadTokens,
+		WebSearchRequests:   parsed.WebSearchRequests,
+		RequestScoped:       true,
+		ClaudeMessageID:     in.ClaudeMessageID,
+		ClaudeRequestID:     in.ClaudeRequestID,
+		SourceUUID:          in.SourceUUID,
+		TokenEligible:       tokenEligible, ActivityEligible: activityEligible,
+	}, true
+}
+
+// FromEvent returns a normalized fact for an eligible usage event.
+func FromEvent(in EventInput) (Fact, bool) {
+	eligible := in.Model != ""
+	if !eligible {
+		return Fact{}, false
+	}
+	millis, nanos, raw, fallback := parseTimestamp(in.Timestamp)
+	clamp := clampTokens
+	if in.Source == "session" {
+		clamp = floorTokens
+	}
+	return Fact{
+		Source: in.Source, MessageOrdinal: in.MessageOrdinal,
+		TimestampMillis: millis, TimestampNanos: nanos, RawTimestamp: raw,
+		UsesSessionStart: fallback, Model: in.Model,
+		InputTokens:  clamp(in.InputTokens),
+		OutputTokens: clamp(in.OutputTokens),
+		// Existing usage-event consumers normalize the four request counters
+		// but preserve the provider's reasoning field verbatim.
+		ReasoningTokens:          in.ReasoningTokens,
+		CacheCreationTokens:      clamp(in.CacheCreationTokens),
+		CacheReadTokens:          clamp(in.CacheReadTokens),
+		ReportedCostMicrodollars: in.ReportedCostMicrodollars,
+		CostSource:               in.CostSource,
+		RequestScoped:            in.MessageOrdinal != nil || sourceIsRequestScoped(in.Source),
+		UsageDedupKey:            in.DedupKey,
+		TokenEligible:            eligible, ActivityEligible: eligible,
+	}, true
+}
+
+// EventDedupKey reproduces the archive row identity used to deduplicate
+// session usage events against other usage sources such as Cursor imports.
+func EventDedupKey(sessionID, source, dedupKey string, eventID int64) string {
+	prefix := sessionID + ":" + source + ":"
+	if dedupKey != "" {
+		return prefix + dedupKey
+	}
+	return prefix + "id:" + strconv.FormatInt(eventID, 10)
+}
+
+// ParseTimestamp preserves malformed values, normalizes valid values to Unix
+// milliseconds, and marks blank values for live session-start fallback.
+func ParseTimestamp(value string) (millis *int64, raw string, usesSessionStart bool) {
+	millis, _, raw, usesSessionStart = parseTimestamp(value)
+	return millis, raw, usesSessionStart
+}
+
+// ParseTimestampNanos returns the sub-millisecond nanosecond component for a
+// valid timestamp. Combined with ParseTimestamp's Unix milliseconds, this is
+// an exact ordering key across the full RFC3339 year range.
+func ParseTimestampNanos(value string) *int64 {
+	_, nanos, _, _ := parseTimestamp(value)
+	return nanos
+}
+
+func parseTimestamp(
+	value string,
+) (millis, nanos *int64, raw string, usesSessionStart bool) {
+	if value == "" {
+		return nil, nil, "", true
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return nil, nil, value, false
+	}
+	valueMillis := parsed.UnixMilli()
+	valueNanos := int64(parsed.Nanosecond() % int(time.Millisecond))
+	return &valueMillis, &valueNanos, value, false
+}
+
+// ParseTokenUsage extracts and clamps usage counters from the stored provider
+// payload. Leading complete fields remain available in a truncated payload.
+func ParseTokenUsage(tokenJSON string) ParsedTokenUsage {
+	var result ParsedTokenUsage
+	i := skipJSONSpace(tokenJSON, 0)
+	if i >= len(tokenJSON) || tokenJSON[i] != '{' {
+		return result
+	}
+	i++
+	for i < len(tokenJSON) {
+		i = skipJSONSpace(tokenJSON, i)
+		if i >= len(tokenJSON) || tokenJSON[i] == '}' {
+			break
+		}
+		if tokenJSON[i] == ',' {
+			i++
+			continue
+		}
+		if tokenJSON[i] != '"' {
+			next, ok := skipJSONValue(tokenJSON, i)
+			if !ok || next <= i {
+				i++
+			} else {
+				i = next
+			}
+			continue
+		}
+		key, next, ok := parseJSONString(tokenJSON, i)
+		if !ok {
+			break
+		}
+		i = skipJSONSpace(tokenJSON, next)
+		if i >= len(tokenJSON) || tokenJSON[i] != ':' {
+			continue
+		}
+		i = skipJSONSpace(tokenJSON, i+1)
+		if isTokenCounterKey(key) {
+			value, valueNext, valid := parseTokenInt(tokenJSON, i)
+			if valid {
+				value = clampTokens(value)
+				switch key {
+				case "input_tokens":
+					result.InputTokens = value
+				case "output_tokens":
+					result.OutputTokens = value
+				case "reasoning_tokens":
+					result.ReasoningTokens = value
+				case "cache_creation_input_tokens":
+					result.CacheCreationTokens = value
+				case "cache_read_input_tokens":
+					result.CacheReadTokens = value
+				}
+			}
+			if valueNext <= i {
+				i++
+			} else {
+				i = valueNext
+			}
+			continue
+		}
+		valueNext, valid := skipJSONValue(tokenJSON, i)
+		if !valid {
+			break
+		}
+		i = valueNext
+	}
+	result.WebSearchRequests = parseWebSearchRequests(tokenJSON)
+	return result
+}
+
+func clampTokens(value int64) int64 {
+	switch {
+	case value < 0:
+		return 0
+	case value > MaxPlausibleTokens:
+		return MaxPlausibleTokens
+	default:
+		return value
+	}
+}
+
+// ClampPlausibleTokens bounds a request-level token count and floors negatives.
+func ClampPlausibleTokens(value int64) int64 {
+	return clampTokens(value)
+}
+
+func floorTokens(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func sourceIsRequestScoped(source string) bool {
+	return source == "message" || source == "goose-request" ||
+		source == "deepseek-harness"
+}
+
+func isTokenCounterKey(key string) bool {
+	switch key {
+	case "input_tokens", "output_tokens", "reasoning_tokens",
+		"cache_creation_input_tokens", "cache_read_input_tokens":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseWebSearchRequests(tokenJSON string) int64 {
+	const serverToolUseKey = "server_tool_use"
+	if !strings.Contains(tokenJSON, serverToolUseKey) {
+		return 0
+	}
+	serverToolUse, ok := objectRawValue(tokenJSON, serverToolUseKey)
+	if !ok {
+		return 0
+	}
+	requests, ok := objectInt(serverToolUse, "web_search_requests")
+	if !ok || requests < 0 {
+		return 0
+	}
+	return requests
+}
+
+func objectRawValue(tokenJSON, want string) (string, bool) {
+	i := skipJSONSpace(tokenJSON, 0)
+	if i >= len(tokenJSON) || tokenJSON[i] != '{' {
+		return "", false
+	}
+	for i++; i < len(tokenJSON); {
+		i = skipJSONSpace(tokenJSON, i)
+		if i >= len(tokenJSON) || tokenJSON[i] == '}' {
+			return "", false
+		}
+		if tokenJSON[i] == ',' {
+			i++
+			continue
+		}
+		if tokenJSON[i] != '"' {
+			return "", false
+		}
+		key, next, ok := parseJSONString(tokenJSON, i)
+		if !ok {
+			return "", false
+		}
+		i = skipJSONSpace(tokenJSON, next)
+		if i >= len(tokenJSON) || tokenJSON[i] != ':' {
+			return "", false
+		}
+		i = skipJSONSpace(tokenJSON, i+1)
+		valueNext, ok := skipJSONValue(tokenJSON, i)
+		if !ok || valueNext <= i {
+			return "", false
+		}
+		if key == want {
+			return tokenJSON[i:valueNext], true
+		}
+		i = valueNext
+	}
+	return "", false
+}
+
+func objectInt(object, want string) (int64, bool) {
+	i := skipJSONSpace(object, 0)
+	if i >= len(object) || object[i] != '{' {
+		return 0, false
+	}
+	for i++; i < len(object); {
+		i = skipJSONSpace(object, i)
+		if i >= len(object) || object[i] == '}' {
+			return 0, false
+		}
+		if object[i] == ',' {
+			i++
+			continue
+		}
+		if object[i] != '"' {
+			return 0, false
+		}
+		key, next, ok := parseJSONString(object, i)
+		if !ok {
+			return 0, false
+		}
+		i = skipJSONSpace(object, next)
+		if i >= len(object) || object[i] != ':' {
+			return 0, false
+		}
+		i = skipJSONSpace(object, i+1)
+		if key == want {
+			value, _, valid := parseTokenInt(object, i)
+			return value, valid
+		}
+		valueNext, valid := skipJSONValue(object, i)
+		if !valid || valueNext <= i {
+			return 0, false
+		}
+		i = valueNext
+	}
+	return 0, false
+}
+
+func parseJSONString(input string, i int) (string, int, bool) {
+	if i >= len(input) || input[i] != '"' {
+		return "", i, false
+	}
+	plain := true
+	for j := i + 1; j < len(input); j++ {
+		switch c := input[j]; {
+		case c == '\\':
+			if j+1 >= len(input) {
+				return "", len(input), false
+			}
+			plain = false
+			j++
+		case c == '"':
+			if plain && utf8.ValidString(input[i+1:j]) {
+				return input[i+1 : j], j + 1, true
+			}
+			var value string
+			if err := json.Unmarshal([]byte(input[i:j+1]), &value); err != nil {
+				return "", j + 1, false
+			}
+			return value, j + 1, true
+		case c < 0x20:
+			plain = false
+		}
+	}
+	return "", len(input), false
+}
+
+func parseTokenInt(input string, i int) (int64, int, bool) {
+	if i >= len(input) {
+		return 0, i, false
+	}
+	if input[i] == '"' {
+		value, next, ok := parseJSONString(input, i)
+		if !ok {
+			return 0, next, false
+		}
+		parsed, valid := parseTokenIntLiteral(strings.TrimSpace(value))
+		return parsed, next, valid
+	}
+	start := i
+	if input[i] == '-' {
+		i++
+	}
+	digitStart := i
+	for i < len(input) && input[i] >= '0' && input[i] <= '9' {
+		i++
+	}
+	if i == digitStart {
+		next, ok := skipJSONValue(input, start)
+		if ok {
+			return 0, next, false
+		}
+		return 0, start, false
+	}
+	parsed, ok := parseTokenIntLiteral(input[start:i])
+	return parsed, i, ok
+}
+
+func parseTokenIntLiteral(value string) (int64, bool) {
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		return parsed, true
+	}
+	if numErr, ok := err.(*strconv.NumError); ok && numErr.Err == strconv.ErrRange {
+		if strings.HasPrefix(value, "-") {
+			return -1 << 63, true
+		}
+		return 1<<63 - 1, true
+	}
+	return 0, false
+}
+
+func skipJSONSpace(input string, i int) int {
+	for i < len(input) && (input[i] == ' ' || input[i] == '\n' ||
+		input[i] == '\r' || input[i] == '\t') {
+		i++
+	}
+	return i
+}
+
+func skipJSONValue(input string, i int) (int, bool) {
+	i = skipJSONSpace(input, i)
+	if i >= len(input) {
+		return i, false
+	}
+	switch input[i] {
+	case '"':
+		_, next, ok := parseJSONString(input, i)
+		return next, ok
+	case '{', '[':
+		return skipJSONComposite(input, i)
+	case 't':
+		if strings.HasPrefix(input[i:], "true") {
+			return i + len("true"), true
+		}
+	case 'f':
+		if strings.HasPrefix(input[i:], "false") {
+			return i + len("false"), true
+		}
+	case 'n':
+		if strings.HasPrefix(input[i:], "null") {
+			return i + len("null"), true
+		}
+	default:
+		return skipJSONNumber(input, i)
+	}
+	return i, false
+}
+
+func skipJSONComposite(input string, i int) (int, bool) {
+	var stack []byte
+	switch input[i] {
+	case '{':
+		stack = append(stack, '}')
+	case '[':
+		stack = append(stack, ']')
+	default:
+		return i, false
+	}
+	for i++; i < len(input); {
+		switch input[i] {
+		case '"':
+			_, next, ok := parseJSONString(input, i)
+			if !ok {
+				return next, false
+			}
+			i = next
+		case '{':
+			stack = append(stack, '}')
+			i++
+		case '[':
+			stack = append(stack, ']')
+			i++
+		case '}', ']':
+			if len(stack) == 0 || input[i] != stack[len(stack)-1] {
+				return i + 1, false
+			}
+			stack = stack[:len(stack)-1]
+			i++
+			if len(stack) == 0 {
+				return i, true
+			}
+		default:
+			i++
+		}
+	}
+	return len(input), false
+}
+
+func skipJSONNumber(input string, i int) (int, bool) {
+	start := i
+	if input[i] == '-' {
+		i++
+	}
+	digitStart := i
+	for i < len(input) && input[i] >= '0' && input[i] <= '9' {
+		i++
+	}
+	if i == digitStart {
+		return start, false
+	}
+	if i < len(input) && input[i] == '.' {
+		i++
+		fractionStart := i
+		for i < len(input) && input[i] >= '0' && input[i] <= '9' {
+			i++
+		}
+		if i == fractionStart {
+			return start, false
+		}
+	}
+	if i < len(input) && (input[i] == 'e' || input[i] == 'E') {
+		i++
+		if i < len(input) && (input[i] == '+' || input[i] == '-') {
+			i++
+		}
+		exponentStart := i
+		for i < len(input) && input[i] >= '0' && input[i] <= '9' {
+			i++
+		}
+		if i == exponentStart {
+			return start, false
+		}
+	}
+	return i, true
+}

--- a/internal/usagefacts/fact_test.go
+++ b/internal/usagefacts/fact_test.go
@@ -1,0 +1,213 @@
+package usagefacts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseJSONStringMatchesEncodingJSON(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+		next  int
+		ok    bool
+	}{
+		{"plain", `"input_tokens":1`, "input_tokens", 14, true},
+		{"empty", `""`, "", 2, true},
+		{"escaped quote", `"a\"b"`, `a"b`, 6, true},
+		{"escaped slash", `"https:\/\/x"`, "https://x", 13, true},
+		{"unicode escape", `"\u00e9"`, "é", 8, true},
+		{"raw utf8", `"é"`, "é", 4, true},
+		{"trailing escape", `"abc\`, "", 5, false},
+		{"unterminated", `"abc`, "", 4, false},
+		{"not a string", `123`, "", 0, false},
+		{"raw control char", "\"a\tb\"", "", 5, false},
+		{"invalid utf8", "\"a\xffb\"", "a\ufffdb", 5, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, next, ok := parseJSONString(tc.input, 0)
+			assert.Equal(t, tc.ok, ok, "ok")
+			assert.Equal(t, tc.next, next, "next")
+			assert.Equal(t, tc.want, got, "value")
+			var want string
+			if !tc.ok {
+				require.Error(t, json.Unmarshal([]byte(tc.input), &want))
+				return
+			}
+			require.NoError(t, json.Unmarshal([]byte(tc.input[:tc.next]), &want))
+			assert.Equal(t, want, got, "json.Unmarshal parity")
+		})
+	}
+}
+
+func TestParseTokenUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want ParsedTokenUsage
+	}{
+		{
+			name: "all counters and web search",
+			raw: `{"input_tokens":100,"output_tokens":"50",` +
+				`"reasoning_tokens":25,"cache_creation_input_tokens":20,` +
+				`"cache_read_input_tokens":300,"server_tool_use":` +
+				`{"web_fetch_requests":9,"web_search_requests":"3"}}`,
+			want: ParsedTokenUsage{
+				InputTokens: 100, OutputTokens: 50, ReasoningTokens: 25,
+				CacheCreationTokens: 20, CacheReadTokens: 300,
+				WebSearchRequests: 3,
+			},
+		},
+		{
+			name: "leading fields survive truncation",
+			raw:  `{"input_tokens":9999,"output_tokens":42,"cache`,
+			want: ParsedTokenUsage{InputTokens: 9999, OutputTokens: 42},
+		},
+		{
+			name: "negative and implausible counters are clamped",
+			raw: `{"input_tokens":-5,"output_tokens":9999999999999,` +
+				`"reasoning_tokens":"-2","cache_read_input_tokens":2000001,` +
+				`"server_tool_use":{"web_search_requests":-4}}`,
+			want: ParsedTokenUsage{
+				OutputTokens:    MaxPlausibleTokens,
+				CacheReadTokens: MaxPlausibleTokens,
+			},
+		},
+		{
+			name: "malformed JSON",
+			raw:  `not-json`,
+			want: ParsedTokenUsage{},
+		},
+		{
+			name: "invalid utf8 in unrelated value",
+			raw:  "{\"note\":\"a\xffb\",\"output_tokens\":7}",
+			want: ParsedTokenUsage{OutputTokens: 7},
+		},
+		{
+			name: "reasoning only",
+			raw:  `{"reasoning_tokens":17}`,
+			want: ParsedTokenUsage{ReasoningTokens: 17},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ParseTokenUsage(tc.raw))
+		})
+	}
+}
+
+func TestFromMessage(t *testing.T) {
+	fact, ok := FromMessage(MessageInput{
+		Ordinal: 4, Role: "assistant", Timestamp: "2024-01-01T00:00:00Z",
+		Model: "claude-test", TokenUsage: `{"input_tokens":10,"reasoning_tokens":2}`,
+		ClaudeMessageID: "msg-1", ClaudeRequestID: "req-1", SourceUUID: "source-1",
+	})
+	require.True(t, ok)
+	ordinal := 4
+	millis := int64(1704067200000)
+	nanos := int64(0)
+	assert.Equal(t, Fact{
+		Source: "message", MessageOrdinal: &ordinal,
+		TimestampMillis: &millis, TimestampNanos: &nanos,
+		RawTimestamp: "2024-01-01T00:00:00Z",
+		Model:        "claude-test",
+		InputTokens:  10, ReasoningTokens: 2,
+		RequestScoped:   true,
+		ClaudeMessageID: "msg-1", ClaudeRequestID: "req-1",
+		SourceUUID: "source-1", TokenEligible: true, ActivityEligible: true,
+	}, fact)
+
+	activity, ok := FromMessage(MessageInput{
+		Ordinal: 7, Role: "assistant", Timestamp: "", Model: "",
+	})
+	require.True(t, ok)
+	ordinal = 7
+	assert.Equal(t, Fact{
+		Source: "message", MessageOrdinal: &ordinal,
+		UsesSessionStart: true, RequestScoped: true, ActivityEligible: true,
+	}, activity)
+
+	malformed, ok := FromMessage(MessageInput{
+		Ordinal: 8, Role: "assistant", Timestamp: "not-a-time",
+	})
+	require.True(t, ok)
+	assert.Nil(t, malformed.TimestampMillis)
+	assert.Equal(t, "not-a-time", malformed.RawTimestamp)
+	assert.False(t, malformed.UsesSessionStart)
+
+	_, ok = FromMessage(MessageInput{Role: "user"})
+	assert.False(t, ok)
+	_, ok = FromMessage(MessageInput{
+		Role: "assistant", Model: "<synthetic>", TokenUsage: `{"input_tokens":1}`,
+	})
+	assert.False(t, ok)
+}
+
+func TestFromEvent(t *testing.T) {
+	ordinal := 3
+	reportedCost := int64(123456)
+	fact, ok := FromEvent(EventInput{
+		MessageOrdinal: &ordinal, Source: "goose-request",
+		Timestamp: "", Model: "model-x", CostSource: "provider",
+		DedupKey:    "session-1:goose-request:event-key",
+		InputTokens: -1, OutputTokens: 2_000_001,
+		ReasoningTokens: 4, CacheCreationTokens: 5, CacheReadTokens: 6,
+		ReportedCostMicrodollars: &reportedCost,
+	})
+	require.True(t, ok)
+	assert.Equal(t, Fact{
+		Source: "goose-request", MessageOrdinal: &ordinal,
+		UsesSessionStart: true, Model: "model-x",
+		OutputTokens: MaxPlausibleTokens, ReasoningTokens: 4,
+		CacheCreationTokens: 5, CacheReadTokens: 6,
+		ReportedCostMicrodollars: &reportedCost, CostSource: "provider",
+		RequestScoped: true,
+		UsageDedupKey: "session-1:goose-request:event-key",
+		TokenEligible: true, ActivityEligible: true,
+	}, fact)
+
+	session, ok := FromEvent(EventInput{
+		Source: "session", Model: "model-x", InputTokens: 3_000_000,
+		OutputTokens: -2,
+	})
+	require.True(t, ok)
+	assert.Equal(t, int64(3_000_000), session.InputTokens,
+		"authoritative session totals may exceed the per-request clamp")
+	assert.Zero(t, session.OutputTokens)
+	assert.False(t, session.RequestScoped)
+	assert.Equal(t, "session-1:session:key",
+		EventDedupKey("session-1", "session", "key", 10))
+	assert.Equal(t, "session-1:session:id:10",
+		EventDedupKey("session-1", "session", "", 10))
+
+	_, ok = FromEvent(EventInput{Source: "session"})
+	assert.False(t, ok)
+}
+
+func TestParseTimestamp(t *testing.T) {
+	millis, raw, fallback := ParseTimestamp("2024-01-01T00:00:00.123456Z")
+	require.NotNil(t, millis)
+	assert.Equal(t, int64(1704067200123), *millis)
+	assert.Equal(t, "2024-01-01T00:00:00.123456Z", raw)
+	require.NotNil(t, ParseTimestampNanos("2024-01-01T00:00:00.123456Z"))
+	assert.Equal(t, int64(456000),
+		*ParseTimestampNanos("2024-01-01T00:00:00.123456Z"))
+	assert.Equal(t, int64(999999),
+		*ParseTimestampNanos("2500-01-01T00:00:00.123999999Z"))
+	assert.False(t, fallback)
+
+	millis, raw, fallback = ParseTimestamp("")
+	assert.Nil(t, millis)
+	assert.Empty(t, raw)
+	assert.True(t, fallback)
+
+	millis, raw, fallback = ParseTimestamp("not-a-time")
+	assert.Nil(t, millis)
+	assert.Equal(t, "not-a-time", raw)
+	assert.False(t, fallback)
+}


### PR DESCRIPTION
SQLite aggregate usage reads (`usage daily`, top sessions, billed and matching
session counts) are now served from a disposable cache of daily rollups
instead of ranking and pricing every token-bearing message on each request.
Warm 30-day reads on a production-scale archive complete in under a second,
down from several seconds. Results are byte-identical to the live path.

**How it works**

- A sibling database (`usage-cache-v1-<id>.db`) holds timezone-neutral
  normalized facts as a build substrate plus per-timezone daily rollup rows at
  `(session, local day, model)` grain.
- Dedup groups are classified per group at build time. Groups whose resolution
  cannot vary with the query window or live filters are finalized into daily
  rows with exact winner, attribution, and web-search semantics. Irreducible
  groups (cross-session, cross-day, cross-model, Copilot authoritative costs,
  Cursor events) stay in a narrow exception tier resolved at read time, so
  exception volume scales with genuine duplicates, not with messages.
- Every read captures archive fingerprints, pricing, and Cursor high-water
  state, then verifies all required installs in one pinned cache transaction.
  When a fill, Cursor batch, or deletion changes a session's dedup identities,
  the same cache transaction invalidates every other session sharing a changed
  identity, so a finalized daily row never survives gaining a sibling.
- Stale or racing reads retry up to three times, then fail clearly. The cache
  never falls back to stale or live aggregate results.
- A writable daemon backfills newest sessions first and warms the local plus
  recently requested timezones. Requests slower than two seconds log
  privacy-safe per-phase timings.

**Archive changes**

- The first writable open builds three usage discovery/covering indexes on
  `messages`; upgrading a large archive blocks startup while they build, and
  the wait is logged. Read-only binaries require these indexes.
- Full resync drops those indexes in the temporary database during the bulk
  load and rebuilds each once before the swap, and newly inserted sessions
  skip a redundant sync-marker touch, so resync throughput does not regress.
- Finalizing streamed usage now participates in transcript identity (revision
  bump, mirror refresh, secret-scan invalidation on real changes).

**Limits and tradeoffs**

- The cache is derived data: safe to delete when nothing is running, rebuilt
  automatically. The first query after install, upgrade, or deletion pays a
  cold build; background backfill covers it afterward.
- Cursor usage events stay entirely on the exception tier (their keys and
  per-row headless filters are not window-independent).
- PostgreSQL keeps its live implementation under complete-result parity
  coverage; the PG-native optimization is tracked in #1451.

**Where to look**

- `internal/db/usage_rollup_classify.go`: group classification and
  cross-session identity checks
- `internal/db/usage_cache_fill.go`: fill, notification, and sibling
  invalidation
- `internal/sync/engine.go`: resync index drop/rebuild
- `docs/internal/usage-aggregate-cache.md` and `docs/agents/storage.md`:
  durable contracts
