### PR TITLE
fix(sync): keep fsnotify event reader off native Add and Remove

### DIFF
--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path"
@@ -8,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -594,10 +596,22 @@ func skipScriptPathEqualityOnWindows(t *testing.T) {
 
 func runResolveScriptForTest(t *testing.T, env ...string) []byte {
 	t.Helper()
-	cmd := exec.Command("sh")
-	cmd.Stdin = strings.NewReader(buildResolveScript())
-	cmd.Env = env
-	out, err := cmd.CombinedOutput()
+	var out []byte
+	var err error
+	for range 3 {
+		cmd := exec.Command("sh")
+		cmd.Stdin = strings.NewReader(buildResolveScript())
+		cmd.Env = env
+		out, err = cmd.CombinedOutput()
+		if err == nil || !bytes.Contains(out, []byte("*** fatal error")) {
+			break
+		}
+		// MSYS bash on Windows runners occasionally dies during process
+		// initialization, before the script runs, with errors such as
+		// "fatal error - add_item (...) failed, errno 1". Retry the
+		// transient launch failure.
+		time.Sleep(time.Second)
+	}
 	require.NoError(t, err, "resolve script failed: output: %s", out)
 	return out
 }

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -1703,6 +1703,12 @@ func (b *darwinWatchBackend) handleKqueueEvent(
 	if b.collectFallbackEvent(event) {
 		return backendEvent{}, false
 	}
+	// A lost-events full sync carries no path, so it never matches a root.
+	// It stands in for kqueue events that were dropped and must reach the
+	// consumer regardless of root ownership.
+	if event.Op&backendOpFullSync != 0 {
+		return event, true
+	}
 	if b.fallbackPhaseValue() == darwinFallbackOpen {
 		if !ok {
 			return backendEvent{}, false

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -1705,8 +1705,17 @@ func (b *darwinWatchBackend) handleKqueueEvent(
 	}
 	// A lost-events full sync carries no path, so it never matches a root.
 	// It stands in for kqueue events that were dropped and must reach the
-	// consumer regardless of root ownership.
+	// consumer regardless of root ownership. The dropped events can include
+	// a shallow root's own removal, which normally signals loss here, so
+	// every active kqueue-backed root is marked lost and revalidated by
+	// lifecycle recovery.
 	if event.Op&backendOpFullSync != 0 {
+		for _, root := range snapshot.activeRoots() {
+			if !root.recursive && root.state != nil {
+				root.state.signal.Or(darwinRootSignalLoss)
+			}
+		}
+		b.signalLifecycle()
 		return event, true
 	}
 	if b.fallbackPhaseValue() == darwinFallbackOpen {
@@ -1973,6 +1982,13 @@ func (b *darwinWatchBackend) removeRootLocked(root string, recursive bool) {
 		},
 	)}
 	b.roots.Store(next)
+}
+
+func (s *darwinRootSnapshot) activeRoots() []darwinWatchRoot {
+	if s == nil {
+		return nil
+	}
+	return s.roots
 }
 
 func (s *darwinRootSnapshot) mostSpecificRoot(path string) (darwinWatchRoot, bool) {

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -1700,15 +1700,14 @@ func (b *darwinWatchBackend) handleKqueueEvent(
 	if ok {
 		event.Root = owner.logicalPath
 	}
-	if b.collectFallbackEvent(event) {
-		return backendEvent{}, false
-	}
 	// A lost-events full sync carries no path, so it never matches a root.
 	// It stands in for kqueue events that were dropped and must reach the
 	// consumer regardless of root ownership. The dropped events can include
 	// a shallow root's own removal, which normally signals loss here, so
 	// every active kqueue-backed root is marked lost and revalidated by
-	// lifecycle recovery.
+	// lifecycle recovery. The marking runs before fallback collection:
+	// buffered events replay without passing through here again, so
+	// deferring it would lose the signal.
 	if event.Op&backendOpFullSync != 0 {
 		for _, root := range snapshot.activeRoots() {
 			if !root.recursive && root.state != nil {
@@ -1716,7 +1715,13 @@ func (b *darwinWatchBackend) handleKqueueEvent(
 			}
 		}
 		b.signalLifecycle()
+		if b.collectFallbackEvent(event) {
+			return backendEvent{}, false
+		}
 		return event, true
+	}
+	if b.collectFallbackEvent(event) {
+		return backendEvent{}, false
 	}
 	if b.fallbackPhaseValue() == darwinFallbackOpen {
 		if !ok {

--- a/internal/sync/watch_backend_fsnotify.go
+++ b/internal/sync/watch_backend_fsnotify.go
@@ -17,8 +17,10 @@ import (
 
 type fsnotifyBackend struct {
 	watcher           *fsnotify.Watcher
+	eventInput        <-chan fsnotify.Event
 	errorInput        <-chan error
 	watchOps          fsnotifyWatchOps
+	queue             *nativeEventQueue
 	events            chan backendEvent
 	errors            chan error
 	excludes          []string
@@ -36,8 +38,97 @@ type fsnotifyBackend struct {
 	lifecycleMu       sync.Mutex
 	lifecycle         fsnotifyBackendLifecycle
 	stop              chan struct{}
+	pumpStop          chan struct{}
+	pumpDone          chan struct{}
 	done              chan struct{}
 	finishOnce        sync.Once
+}
+
+// nativeEventQueueLimit bounds events held between the native reader and the
+// translating loop. It matches inotify's default max_queued_events; past it
+// the queue drops pending events and reports an overflow, which the loop
+// already turns into a lost-events full sync.
+const nativeEventQueueLimit = 16384
+
+type nativeItem struct {
+	event fsnotify.Event
+	err   error
+}
+
+// nativeEventQueue decouples reading the native watcher from translating its
+// events. fsnotify's Windows backend services Add and Remove on the same
+// goroutine that delivers events over an unbuffered channel, so the goroutine
+// that consumes events must never be the one waiting on Add or Remove.
+type nativeEventQueue struct {
+	mu       sync.Mutex
+	items    []nativeItem
+	overflow bool
+	closed   bool
+	signal   chan struct{}
+}
+
+func newNativeEventQueue() *nativeEventQueue {
+	return &nativeEventQueue{signal: make(chan struct{}, 1)}
+}
+
+func (q *nativeEventQueue) push(item nativeItem) {
+	q.mu.Lock()
+	if len(q.items) >= nativeEventQueueLimit {
+		q.items = nil
+		q.overflow = true
+	} else {
+		q.items = append(q.items, item)
+	}
+	q.mu.Unlock()
+	q.wake()
+}
+
+func (q *nativeEventQueue) close() {
+	q.mu.Lock()
+	q.closed = true
+	q.mu.Unlock()
+	q.wake()
+}
+
+func (q *nativeEventQueue) wake() {
+	select {
+	case q.signal <- struct{}{}:
+	default:
+	}
+}
+
+// next blocks until an item is available, the queue is closed and drained, or
+// stop is closed. An overflow surfaces as fsnotify.ErrEventOverflow ahead of
+// anything queued after it.
+func (q *nativeEventQueue) next(stop <-chan struct{}) (nativeItem, bool) {
+	for {
+		q.mu.Lock()
+		if q.overflow {
+			q.overflow = false
+			q.mu.Unlock()
+			return nativeItem{err: fsnotify.ErrEventOverflow}, true
+		}
+		if len(q.items) > 0 {
+			item := q.items[0]
+			q.items[0] = nativeItem{}
+			q.items = q.items[1:]
+			if len(q.items) == 0 {
+				q.items = nil
+			}
+			q.mu.Unlock()
+			return item, true
+		}
+		closed := q.closed
+		q.mu.Unlock()
+		if closed {
+			return nativeItem{}, false
+		}
+		select {
+		case <-q.signal:
+		case <-stop:
+			return nativeItem{}, false
+		}
+	}
 }
 
 type fsnotifyWatchOps interface {
@@ -60,8 +151,10 @@ func newFSNotifyBackend(excludes []string) (*fsnotifyBackend, error) {
 	}
 	return &fsnotifyBackend{
 		watcher:         watcher,
+		eventInput:      watcher.Events,
 		errorInput:      watcher.Errors,
 		watchOps:        watcher,
+		queue:           newNativeEventQueue(),
 		events:          make(chan backendEvent),
 		errors:          make(chan error, 1),
 		excludes:        normalizeExcludePatterns(excludes),
@@ -70,6 +163,8 @@ func newFSNotifyBackend(excludes []string) (*fsnotifyBackend, error) {
 		rootScopes:      make(map[string][]PollingScope),
 		degradedRoots:   make(map[string]struct{}),
 		stop:            make(chan struct{}),
+		pumpStop:        make(chan struct{}),
+		pumpDone:        make(chan struct{}),
 		done:            make(chan struct{}),
 	}, nil
 }
@@ -256,10 +351,15 @@ func (b *fsnotifyBackend) Start() error {
 		return nil
 	}
 	b.lifecycle = fsnotifyBackendRunning
+	go b.pump()
 	go b.loop()
 	return nil
 }
 
+// Stop ends event delivery and closes the native watcher. When the loop is
+// running it owns the shutdown order: it closes the native watcher only after
+// it has left any in-flight Add or Remove, so a pending request cannot be
+// abandoned by fsnotify's Close, then releases the pump.
 func (b *fsnotifyBackend) Stop() {
 	b.lifecycleMu.Lock()
 	if b.lifecycle == fsnotifyBackendStopped {
@@ -271,8 +371,8 @@ func (b *fsnotifyBackend) Stop() {
 	wasRunning := b.lifecycle == fsnotifyBackendRunning
 	b.lifecycle = fsnotifyBackendStopped
 	close(b.stop)
-	_ = b.watcher.Close()
 	if !wasRunning {
+		_ = b.watcher.Close()
 		b.finish()
 	}
 	done := b.done
@@ -282,43 +382,75 @@ func (b *fsnotifyBackend) Stop() {
 
 func (b *fsnotifyBackend) Name() string { return "fsnotify" }
 
-func (b *fsnotifyBackend) loop() {
-	defer b.finish()
+// pump is the sole reader of the native watcher's channels. It never calls
+// back into the native watcher, so fsnotify's reader is never left blocked
+// delivering an event while the loop waits on Add or Remove.
+func (b *fsnotifyBackend) pump() {
+	defer close(b.pumpDone)
+	defer b.queue.close()
 	for {
 		select {
-		case <-b.stop:
+		case <-b.pumpStop:
 			return
-		case event, ok := <-b.watcher.Events:
+		case event, ok := <-b.eventInput:
 			if !ok {
 				return
 			}
-			translated, relevant := b.translateEvent(event)
-			if !relevant {
-				continue
-			}
-			select {
-			case b.events <- translated:
-			case <-b.stop:
-				return
-			}
+			b.queue.push(nativeItem{event: event})
 		case err, ok := <-b.errorInput:
 			if !ok {
 				return
 			}
-			if errors.Is(err, fsnotify.ErrEventOverflow) {
-				select {
-				case b.events <- backendEvent{Op: backendOpFullSync}:
-				case <-b.stop:
-					return
-				}
-				continue
-			}
-			select {
-			case b.errors <- err:
-			case <-b.stop:
+			b.queue.push(nativeItem{err: err})
+		}
+	}
+}
+
+func (b *fsnotifyBackend) loop() {
+	defer func() {
+		_ = b.watcher.Close()
+		close(b.pumpStop)
+		<-b.pumpDone
+		b.finish()
+	}()
+	for {
+		item, ok := b.queue.next(b.stop)
+		if !ok {
+			return
+		}
+		if item.err != nil {
+			if !b.forwardNativeError(item.err) {
 				return
 			}
+			continue
 		}
+		translated, relevant := b.translateEvent(item.event)
+		if !relevant {
+			continue
+		}
+		select {
+		case b.events <- translated:
+		case <-b.stop:
+			return
+		}
+	}
+}
+
+// forwardNativeError reports false when the backend is stopping.
+func (b *fsnotifyBackend) forwardNativeError(err error) bool {
+	if errors.Is(err, fsnotify.ErrEventOverflow) {
+		select {
+		case b.events <- backendEvent{Op: backendOpFullSync}:
+			return true
+		case <-b.stop:
+			return false
+		}
+	}
+	select {
+	case b.errors <- err:
+		return true
+	case <-b.stop:
+		return false
 	}
 }
 

--- a/internal/sync/watch_backend_fsnotify.go
+++ b/internal/sync/watch_backend_fsnotify.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/fsnotify/fsnotify"
@@ -38,6 +39,8 @@ type fsnotifyBackend struct {
 	lifecycleMu       sync.Mutex
 	lifecycle         fsnotifyBackendLifecycle
 	stop              chan struct{}
+	pumpOnce          sync.Once
+	pumpStarted       atomic.Bool
 	pumpStop          chan struct{}
 	pumpDone          chan struct{}
 	done              chan struct{}
@@ -173,6 +176,7 @@ func (b *fsnotifyBackend) Events() <-chan backendEvent { return b.events }
 func (b *fsnotifyBackend) Errors() <-chan error        { return b.errors }
 
 func (b *fsnotifyBackend) AddRecursive(root string, budget int) RecursiveWatchResult {
+	b.startPump()
 	b.watchMu.Lock()
 	defer b.watchMu.Unlock()
 
@@ -284,6 +288,7 @@ func (b *fsnotifyBackend) bindPollingOwnership(
 }
 
 func (b *fsnotifyBackend) AddShallow(root string) error {
+	b.startPump()
 	b.watchMu.Lock()
 	defer b.watchMu.Unlock()
 
@@ -297,6 +302,7 @@ func (b *fsnotifyBackend) AddShallow(root string) error {
 }
 
 func (b *fsnotifyBackend) Remove(root string) error {
+	b.startPump()
 	b.watchMu.Lock()
 	defer b.watchMu.Unlock()
 
@@ -351,7 +357,7 @@ func (b *fsnotifyBackend) Start() error {
 		return nil
 	}
 	b.lifecycle = fsnotifyBackendRunning
-	go b.pump()
+	b.startPump()
 	go b.loop()
 	return nil
 }
@@ -359,7 +365,8 @@ func (b *fsnotifyBackend) Start() error {
 // Stop ends event delivery and closes the native watcher. When the loop is
 // running it owns the shutdown order: it closes the native watcher only after
 // it has left any in-flight Add or Remove, so a pending request cannot be
-// abandoned by fsnotify's Close, then releases the pump.
+// abandoned by fsnotify's Close, then releases the pump. When the loop never
+// ran, Stop releases the pump itself before closing the native watcher.
 func (b *fsnotifyBackend) Stop() {
 	b.lifecycleMu.Lock()
 	if b.lifecycle == fsnotifyBackendStopped {
@@ -372,6 +379,10 @@ func (b *fsnotifyBackend) Stop() {
 	b.lifecycle = fsnotifyBackendStopped
 	close(b.stop)
 	if !wasRunning {
+		close(b.pumpStop)
+		if b.pumpStarted.Load() {
+			<-b.pumpDone
+		}
 		_ = b.watcher.Close()
 		b.finish()
 	}
@@ -382,22 +393,39 @@ func (b *fsnotifyBackend) Stop() {
 
 func (b *fsnotifyBackend) Name() string { return "fsnotify" }
 
+// startPump runs the native reader before the first native Add or Remove.
+// On Windows, fsnotify services those requests on the goroutine that
+// delivers events over an unbuffered channel, and registration installs
+// watches before Start runs, so an event arriving between registration Adds
+// would block the next Add forever if nothing consumed events yet. The input
+// channels are captured here so a test seam assigned before the first native
+// operation is never read concurrently with the pump.
+func (b *fsnotifyBackend) startPump() {
+	b.pumpOnce.Do(func() {
+		b.pumpStarted.Store(true)
+		go b.pump(b.eventInput, b.errorInput)
+	})
+}
+
 // pump is the sole reader of the native watcher's channels. It never calls
 // back into the native watcher, so fsnotify's reader is never left blocked
 // delivering an event while the loop waits on Add or Remove.
-func (b *fsnotifyBackend) pump() {
+func (b *fsnotifyBackend) pump(
+	eventInput <-chan fsnotify.Event,
+	errorInput <-chan error,
+) {
 	defer close(b.pumpDone)
 	defer b.queue.close()
 	for {
 		select {
 		case <-b.pumpStop:
 			return
-		case event, ok := <-b.eventInput:
+		case event, ok := <-eventInput:
 			if !ok {
 				return
 			}
 			b.queue.push(nativeItem{event: event})
-		case err, ok := <-b.errorInput:
+		case err, ok := <-errorInput:
 			if !ok {
 				return
 			}
@@ -439,6 +467,11 @@ func (b *fsnotifyBackend) loop() {
 // forwardNativeError reports false when the backend is stopping.
 func (b *fsnotifyBackend) forwardNativeError(err error) bool {
 	if errors.Is(err, fsnotify.ErrEventOverflow) {
+		// Overflow dropped raw events before their watch-maintenance side
+		// effects ran, so creates under recursive roots may have left
+		// subtrees without native watches. The full sync recovers the data
+		// but not the watches; polling covers the lost subtrees.
+		b.requireRuntimePolling(b.recursiveRootsSnapshot())
 		select {
 		case b.events <- backendEvent{Op: backendOpFullSync}:
 			return true
@@ -704,6 +737,12 @@ func normalizeExcludePatterns(patterns []string) []string {
 		}
 	}
 	return out
+}
+
+func (b *fsnotifyBackend) recursiveRootsSnapshot() []string {
+	b.rootsMu.RLock()
+	defer b.rootsMu.RUnlock()
+	return append([]string(nil), b.recursive...)
 }
 
 func (b *fsnotifyBackend) addRecursiveRoot(root string) {

--- a/internal/sync/watch_backend_fsnotify.go
+++ b/internal/sync/watch_backend_fsnotify.go
@@ -470,8 +470,10 @@ func (b *fsnotifyBackend) forwardNativeError(err error) bool {
 		// Overflow dropped raw events before their watch-maintenance side
 		// effects ran, so creates under recursive roots may have left
 		// subtrees without native watches. The full sync recovers the data
-		// but not the watches; polling covers the lost subtrees.
+		// but not the watches; polling covers the lost subtrees. Shallow
+		// roots are revalidated in place instead.
 		b.requireRuntimePolling(b.recursiveRootsSnapshot())
+		b.reinstallShallowWatches()
 		select {
 		case b.events <- backendEvent{Op: backendOpFullSync}:
 			return true
@@ -737,6 +739,26 @@ func normalizeExcludePatterns(patterns []string) []string {
 		}
 	}
 	return out
+}
+
+// reinstallShallowWatches revalidates shallow-root coverage after overflow.
+// A dropped removal loses the native watch even when the directory was
+// recreated, so every shallow root is re-added; a root that cannot be
+// re-added moves to polling exactly as an observed removal would.
+func (b *fsnotifyBackend) reinstallShallowWatches() {
+	b.rootsMu.RLock()
+	shallow := append([]string(nil), b.shallow...)
+	b.rootsMu.RUnlock()
+	lost := make([]string, 0, len(shallow))
+	for _, root := range shallow {
+		b.watchMu.Lock()
+		err := b.watchOps.Add(root)
+		b.watchMu.Unlock()
+		if err != nil {
+			lost = append(lost, root)
+		}
+	}
+	b.requireRuntimePolling(lost)
 }
 
 func (b *fsnotifyBackend) recursiveRootsSnapshot() []string {

--- a/internal/sync/watch_backend_fsnotify_test.go
+++ b/internal/sync/watch_backend_fsnotify_test.go
@@ -592,3 +592,171 @@ func TestFSNotifyBackendAddRecursiveCountsUnreadableSubtreeAsUnwatched(
 	assert.Positive(t, result.Unwatched,
 		"an unenumerable subtree must count as degraded coverage")
 }
+
+// serialNativeWatcher models fsnotify's Windows backend contract: one reader
+// goroutine delivers events on an unbuffered channel and is the only thing
+// that services Add and Remove requests, and it does so only between
+// deliveries. A request issued while the reader is blocked delivering the
+// next event completes only after that event is consumed.
+type serialNativeWatcher struct {
+	events   chan fsnotify.Event
+	requests chan chan struct{}
+	deliver  chan []fsnotify.Event
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+func newSerialNativeWatcher() *serialNativeWatcher {
+	return &serialNativeWatcher{
+		events:   make(chan fsnotify.Event),
+		requests: make(chan chan struct{}, 1),
+		deliver:  make(chan []fsnotify.Event),
+		stop:     make(chan struct{}),
+	}
+}
+
+func (w *serialNativeWatcher) run() {
+	for {
+		select {
+		case <-w.stop:
+			return
+		case reply := <-w.requests:
+			close(reply)
+		case batch := <-w.deliver:
+			for _, event := range batch {
+				select {
+				case w.events <- event:
+				case <-w.stop:
+					return
+				}
+			}
+		}
+	}
+}
+
+func (w *serialNativeWatcher) Stop() { w.stopOnce.Do(func() { close(w.stop) }) }
+
+func (w *serialNativeWatcher) Add(string) error    { return w.request() }
+func (w *serialNativeWatcher) Remove(string) error { return w.request() }
+
+func (w *serialNativeWatcher) request() error {
+	reply := make(chan struct{})
+	select {
+	case w.requests <- reply:
+	case <-w.stop:
+		return errors.New("native watcher stopped")
+	}
+	select {
+	case <-reply:
+		return nil
+	case <-w.stop:
+		return errors.New("native watcher stopped")
+	}
+}
+
+// A directory removal that arrives in the same native batch as another event
+// must not deadlock the backend: the event loop calls Remove on the native
+// watcher, and on Windows that call is serviced by the same goroutine that is
+// blocked delivering the next event to the loop.
+func TestFSNotifyBackendRemoveDuringBatchDoesNotDeadlockEventLoop(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	native := newSerialNativeWatcher()
+	go native.run()
+	t.Cleanup(native.Stop)
+	backend.watchOps = native
+	backend.eventInput = native.events
+
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+	result := backend.AddRecursive(root, 8)
+	require.NoError(t, result.Err)
+	require.Equal(t, 2, result.Watched)
+	require.NoError(t, backend.Start())
+
+	file := filepath.Join(root, "session.jsonl")
+	native.deliver <- []fsnotify.Event{
+		{Name: sub, Op: fsnotify.Remove},
+		{Name: file, Op: fsnotify.Write},
+	}
+
+	first := requireReceiveWithin(t, backend.Events(), 2*time.Second)
+	assert.Equal(t, sub, first.Path)
+	assert.Equal(t, backendOpRemove, first.Op)
+	second := requireReceiveWithin(t, backend.Events(), 2*time.Second)
+	assert.Equal(t, file, second.Path)
+	assert.Equal(t, backendOpWrite, second.Op)
+
+	stopped := make(chan struct{})
+	go func() {
+		backend.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fsnotify backend Stop hung after a Remove during a native batch")
+	}
+}
+
+func TestNativeEventQueueOverflowSurfacesLostEventsOnce(t *testing.T) {
+	queue := newNativeEventQueue()
+	stop := make(chan struct{})
+	for range nativeEventQueueLimit + 1 {
+		queue.push(nativeItem{event: fsnotify.Event{Name: "before", Op: fsnotify.Write}})
+	}
+	queue.push(nativeItem{event: fsnotify.Event{Name: "after", Op: fsnotify.Write}})
+
+	first, ok := queue.next(stop)
+	require.True(t, ok)
+	assert.ErrorIs(t, first.err, fsnotify.ErrEventOverflow)
+	remaining := []string{}
+	for {
+		item, ok := queue.next(stop)
+		if !ok {
+			break
+		}
+		require.NoError(t, item.err, "overflow must be reported once")
+		remaining = append(remaining, item.event.Name)
+		if item.event.Name == "after" {
+			break
+		}
+	}
+	assert.Equal(t, []string{"after"}, remaining, "events after the overflow survive")
+
+	queue.close()
+	_, ok = queue.next(stop)
+	assert.False(t, ok, "a closed and drained queue reports no more items")
+}
+
+func TestFSNotifyBackendQueueOverflowRequestsFullSync(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	native := newSerialNativeWatcher()
+	go native.run()
+	t.Cleanup(native.Stop)
+	backend.watchOps = native
+	backend.eventInput = native.events
+	require.NoError(t, backend.Start())
+
+	root := t.TempDir()
+	burst := make([]fsnotify.Event, 0, nativeEventQueueLimit+8)
+	for range cap(burst) {
+		burst = append(burst, fsnotify.Event{Name: filepath.Join(root, "f"), Op: fsnotify.Write})
+	}
+	native.deliver <- burst
+	// The loop is parked on its first forward because nothing reads events
+	// yet, so the pump alone must absorb the rest of the burst. A second
+	// batch is accepted only once the first has been fully delivered.
+	native.deliver <- nil
+
+	sawFullSync := false
+	deadline := time.After(5 * time.Second)
+	for !sawFullSync {
+		select {
+		case event := <-backend.Events():
+			sawFullSync = event.Op == backendOpFullSync
+		case <-deadline:
+			t.Fatal("queue overflow did not request a full sync")
+		}
+	}
+}

--- a/internal/sync/watch_backend_fsnotify_test.go
+++ b/internal/sync/watch_backend_fsnotify_test.go
@@ -699,6 +699,69 @@ func TestFSNotifyBackendRemoveDuringBatchDoesNotDeadlockEventLoop(t *testing.T) 
 	}
 }
 
+// On Windows, fsnotify delivers events and services Add on the same
+// goroutine, and registration installs watches before Start runs. An event
+// arriving between registration Adds must not block the next Add until Start:
+// the pump has to consume native events as soon as watches exist.
+func TestFSNotifyBackendEventBeforeStartDoesNotBlockRegistration(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	native := newSerialNativeWatcher()
+	go native.run()
+	t.Cleanup(native.Stop)
+	backend.watchOps = native
+	backend.eventInput = native.events
+
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+
+	file := filepath.Join(root, "session.jsonl")
+	// Once deliver hands the batch to the native reader, the reader is
+	// committed to the delivery and services no Add requests until the event
+	// is consumed, exactly like a Windows event arriving mid-registration.
+	native.deliver <- []fsnotify.Event{{Name: file, Op: fsnotify.Write}}
+
+	registered := make(chan RecursiveWatchResult, 1)
+	go func() { registered <- backend.AddRecursive(root, 8) }()
+	select {
+	case result := <-registered:
+		require.NoError(t, result.Err)
+		require.Equal(t, 2, result.Watched)
+	case <-time.After(2 * time.Second):
+		t.Fatal("AddRecursive blocked on a native event delivered before Start")
+	}
+
+	require.NoError(t, backend.Start())
+	event := requireReceiveWithin(t, backend.Events(), 2*time.Second)
+	assert.Equal(t, file, event.Path)
+	assert.Equal(t, backendOpWrite, event.Op)
+}
+
+// Overflow drops raw native events before their watch-maintenance side
+// effects run, so missed creates can leave recursive subtrees without native
+// watches. A full sync recovers the data but not the watches, so the
+// backend must hand recursive roots to polling.
+func TestFSNotifyBackendOverflowTransfersRecursiveRootsToPolling(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	errorInput := make(chan error, 1)
+	backend.errorInput = errorInput
+	root := t.TempDir()
+	require.NoError(t, backend.AddRecursive(root, 8).Err)
+	obligations := make(chan PollingObligation, 1)
+	backend.bindPollingOwnership(func(obligation PollingObligation) error {
+		obligations <- obligation
+		return nil
+	}, func(string) error { return nil })
+	require.NoError(t, backend.Start())
+
+	errorInput <- fsnotify.ErrEventOverflow
+
+	batch := requireReceiveWithin(t, backend.Events(), 2*time.Second)
+	assert.Equal(t, backendOpFullSync, batch.Op)
+	obligation := requireReceiveWithin(t, obligations, 2*time.Second)
+	assert.Equal(t, "fsnotify-runtime:"+root, obligation.Key)
+}
+
 func TestNativeEventQueueOverflowSurfacesLostEventsOnce(t *testing.T) {
 	queue := newNativeEventQueue()
 	stop := make(chan struct{})

--- a/internal/sync/watch_backend_fsnotify_test.go
+++ b/internal/sync/watch_backend_fsnotify_test.go
@@ -762,6 +762,79 @@ func TestFSNotifyBackendOverflowTransfersRecursiveRootsToPolling(t *testing.T) {
 	assert.Equal(t, "fsnotify-runtime:"+root, obligation.Key)
 }
 
+type scriptedWatchOps struct {
+	mu    sync.Mutex
+	fail  map[string]error
+	added []string
+}
+
+func (o *scriptedWatchOps) Add(path string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if err := o.fail[path]; err != nil {
+		return err
+	}
+	o.added = append(o.added, path)
+	return nil
+}
+
+func (o *scriptedWatchOps) Remove(string) error { return nil }
+
+func (o *scriptedWatchOps) setFail(path string, err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.fail[path] = err
+}
+
+func (o *scriptedWatchOps) addCount(path string) int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	count := 0
+	for _, added := range o.added {
+		if added == path {
+			count++
+		}
+	}
+	return count
+}
+
+// A dropped shallow-root removal loses the native watch even though the
+// one-time full sync recovers the data, so overflow must revalidate shallow
+// coverage: re-add every shallow watch and hand roots that cannot be
+// re-added to polling, exactly as an observed removal would.
+func TestFSNotifyBackendOverflowReinstallsShallowWatches(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	errorInput := make(chan error, 1)
+	backend.errorInput = errorInput
+	ops := &scriptedWatchOps{fail: map[string]error{}}
+	backend.watchOps = ops
+	kept := filepath.Join(t.TempDir(), "kept")
+	lost := filepath.Join(t.TempDir(), "lost")
+	require.NoError(t, backend.AddShallow(kept))
+	require.NoError(t, backend.AddShallow(lost))
+	ops.setFail(lost, errors.New("directory removed"))
+	obligations := make(chan PollingObligation, 2)
+	backend.bindPollingOwnership(func(obligation PollingObligation) error {
+		obligations <- obligation
+		return nil
+	}, func(string) error { return nil })
+	require.NoError(t, backend.Start())
+
+	errorInput <- fsnotify.ErrEventOverflow
+
+	event := requireReceiveWithin(t, backend.Events(), 2*time.Second)
+	assert.Equal(t, backendOpFullSync, event.Op)
+	obligation := requireReceiveWithin(t, obligations, 2*time.Second)
+	assert.Equal(t, "fsnotify-runtime:"+lost, obligation.Key)
+	assert.Equal(t, 2, ops.addCount(kept),
+		"a reachable shallow root must have its native watch re-added")
+	select {
+	case extra := <-obligations:
+		t.Fatalf("re-addable shallow root was degraded to polling: %+v", extra)
+	default:
+	}
+}
+
 func TestNativeEventQueueOverflowSurfacesLostEventsOnce(t *testing.T) {
 	queue := newNativeEventQueue()
 	stop := make(chan struct{})

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/fsevents"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -558,6 +559,23 @@ func TestDarwinWatcherExcludesRecursiveEvents(t *testing.T) {
 			return false
 		}
 	}, 400*time.Millisecond, 10*time.Millisecond)
+}
+
+// TestDarwinWatcherKqueueLostEventsReachConsumer covers the kqueue backend's
+// lost-events full sync. That event carries no path, and the wrapper drops
+// kqueue events it cannot attribute to a root, so the full sync must bypass
+// root matching or the events it stands in for are never reconciled.
+func TestDarwinWatcherKqueueLostEventsReachConsumer(t *testing.T) {
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	errorInput := make(chan error, 1)
+	backend.kqueue.errorInput = errorInput
+	watcher, batches := newDarwinTestWatcherWithBackend(t, backend)
+	watcher.Start()
+
+	errorInput <- fsnotify.ErrEventOverflow
+
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
 }
 
 func TestDarwinWatcherExcludedDirectoryRenameIsFiltered(t *testing.T) {

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -624,6 +624,39 @@ func TestDarwinWatcherKqueueLostEventsInvalidateShallowRoots(t *testing.T) {
 		"kqueue overflow must move the shallow root through loss recovery")
 }
 
+// A kqueue overflow marker arriving while FSEvents fallback is collecting or
+// reconciling is buffered for replay, and replayed events bypass
+// handleKqueueEvent. The loss marking for kqueue-backed roots must therefore
+// happen before fallback collection or a dropped root removal permanently
+// loses coverage once fallback ends.
+func TestDarwinHandleKqueueFullSyncDuringFallbackMarksShallowRootsLost(t *testing.T) {
+	for _, phase := range []darwinFallbackPhase{
+		darwinFallbackCollecting, darwinFallbackReconciling,
+	} {
+		backend := &darwinWatchBackend{
+			fallbackEvents: make(map[backendEvent]struct{}),
+		}
+		state := &darwinLogicalRoot{}
+		root := t.TempDir()
+		backend.roots.Store(&darwinRootSnapshot{roots: []darwinWatchRoot{{
+			logicalPath: root,
+			nativePath:  canonicalWatchRoot(root),
+			state:       state,
+		}}})
+		backend.fallbackPhase.Store(uint32(phase))
+
+		marker := backendEvent{Op: backendOpFullSync}
+		_, dispatch := backend.handleKqueueEvent(marker)
+
+		assert.False(t, dispatch,
+			"phase %d: the marker must be buffered for fallback replay", phase)
+		assert.Contains(t, backend.fallbackEvents, marker,
+			"phase %d: the marker must replay with the reconciliation", phase)
+		assert.NotZero(t, state.signal.Load()&darwinRootSignalLoss,
+			"phase %d: shallow roots must be marked lost before collection", phase)
+	}
+}
+
 func TestDarwinWatcherExcludedDirectoryRenameIsFiltered(t *testing.T) {
 	root := t.TempDir()
 	backend, err := newDarwinWatchBackend([]string{".git"}, 50*time.Millisecond)

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -578,6 +578,52 @@ func TestDarwinWatcherKqueueLostEventsReachConsumer(t *testing.T) {
 	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
 }
 
+// TestDarwinWatcherKqueueLostEventsInvalidateShallowRoots covers shallow-root
+// recovery after kqueue overflow. A dropped event can be the shallow root's
+// own removal, which normally signals loss through handleKqueueEvent; the
+// full-sync marker must therefore mark every active kqueue-backed root lost
+// so lifecycle recovery revalidates its watch or hands it to polling.
+func TestDarwinWatcherKqueueLostEventsInvalidateShallowRoots(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = 5 * time.Millisecond
+	backend.retryMax = 10 * time.Millisecond
+	errorInput := make(chan error, 1)
+	backend.kqueue.errorInput = errorInput
+
+	polling := make(chan PollingObligation, 4)
+	batches := make(chan WatchBatch, 8)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{
+			OnPollingRequired: func(obligation PollingObligation) error {
+				polling <- obligation
+				return nil
+			},
+			OnPollingReleased: func(string) error { return nil },
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: root}},
+	}}, 10)
+	require.Equal(t, []RecursiveWatchResult{{Watched: 1}}, results)
+	require.NoError(t, watcher.Start())
+
+	errorInput <- fsnotify.ErrEventOverflow
+
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
+	obligation := requireReceiveWithin(t, polling, 5*time.Second)
+	assert.Equal(t, root, obligation.Key,
+		"kqueue overflow must move the shallow root through loss recovery")
+}
+
 func TestDarwinWatcherExcludedDirectoryRenameIsFiltered(t *testing.T) {
 	root := t.TempDir()
 	backend, err := newDarwinWatchBackend([]string{".git"}, 50*time.Millisecond)


### PR DESCRIPTION
Fixes a Windows-only deadlock that hung `internal/sync` CI runs until the
20-minute timeout (for example
[this run](https://github.com/kenn-io/agentsview/actions/runs/32181050198/job/95870822954)),
and closes the event-loss recovery gaps found while fixing it.

## Cause

fsnotify's Windows backend services `Add` and `Remove` on the same goroutine
that delivers events over an unbuffered channel, and only between deliveries.
Our event loop was the sole consumer and called `Add`/`Remove` inline, so a
native batch with more than one event deadlocked the loop against the watcher,
and `Close` could abandon the pending request, hanging `Stop`. inotify and
kqueue use direct syscalls, so only Windows was affected.

## Changes

- Split the loop into a pump that drains the native channels into a bounded
  queue (16384 items, inotify's default) and a loop that translates and calls
  `Add`/`Remove`, so the event consumer never waits on the native watcher. The
  pump starts with the first native `Add`, because registration runs before
  `Start`, and `Stop` lets the loop leave any in-flight request before the
  native watcher closes.
- Queue overflow becomes a lost-events full sync, matching kernel overflow.
- Overflow can drop events whose side effects maintain watch coverage, so
  recovery goes beyond the one-time full sync: recursive roots move to
  polling, shallow watches are re-added (with polling on failure), and the
  macOS wrapper marks kqueue-backed roots lost in every fallback phase so
  lifecycle recovery revalidates them. The wrapper also forwards the pathless
  full-sync marker it previously dropped for lacking an owning root.
- The ssh resolve-script tests retry when MSYS bash on Windows runners dies
  during process startup, a transient runner failure unrelated to the script.

## Where to look

- `internal/sync/watch_backend_fsnotify.go`: `nativeEventQueue`, `pump`,
  `loop`, `forwardNativeError`, `Stop`.
- `internal/sync/watch_backend_factory_darwin.go`: `handleKqueueEvent`.
- `TestFSNotifyBackendRemoveDuringBatchDoesNotDeadlockEventLoop` reproduces
  the Windows hang deterministically on any OS and fails on `main`; the other
  new tests each pin one recovery path.
