### PR TITLE
fix(activity): classify Grok non-interactive sessions

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -72,6 +72,25 @@ Grok is temporarily excluded at the user's request because a separate
 format-alignment change owns that provider. Once that alignment lands, add a
 Grok section and remove the explicit registry exception in the coverage test.
 
+The narrow Grok automation-provenance claim is independently verified against
+`xai-org/grok-build` at `d92c5b0b8582fda358de1f97446aa74af44a464f`, checked
+2026-08-18. The first-party
+[headless guide](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-pager/docs/user-guide/14-headless-mode.md)
+defines prompt flags as non-interactive invocation. The producer propagates
+that startup mode into
+[`PromptContext.is_non_interactive`](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L936-L944),
+whose schema identifies headless, SDK, stdio, and generic ACP execution and
+defaults false for interactive or older contexts
+([schema](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L145-L150),
+[default](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L177-L199)).
+The producer then writes that context to the same session directory as
+`prompt_context.json`
+([persistence](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session.rs#L1384-L1404),
+[spawn call](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L1049-L1055)).
+Agentsview treats only an explicit true value in a valid, session-associated
+file as durable automation evidence; file presence, a missing field, or a
+missing file does not classify a session as automated.
+
 ## Claude Code (`claude`)
 
 - **Format:** Project-scoped JSONL transcripts, including subagent JSONL, with

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 	"sync"
+
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // automatedPrefixes are first_message prefixes that identify
@@ -63,6 +65,13 @@ const userPatternMaxLen = 1024
 // AutomationEvidencePrefixBytes is the bounded prefix size used by backend
 // integrity audits. It is large enough to hold every accepted user pattern.
 const AutomationEvidencePrefixBytes = userPatternMaxLen
+
+// IsAutomatedSessionMetadata classifies durable provider-owned session
+// metadata that explicitly identifies an automated invocation.
+func IsAutomatedSessionMetadata(agent, sessionKind string) bool {
+	return agent == string(parser.AgentGrok) &&
+		sessionKind == parser.SessionKindNonInteractive
+}
 
 var (
 	userPatternsMu   sync.RWMutex

--- a/internal/db/automated_audit.go
+++ b/internal/db/automated_audit.go
@@ -27,6 +27,8 @@ func auditAutomatedFull(
 	rows, err := w.Query(
 		`SELECT
 			s.id,
+			s.agent,
+			s.session_kind,
 			s.first_message,
 			s.user_message_count,
 			s.is_automated,
@@ -62,6 +64,8 @@ func auditAutomatedMatchingHash(
 	rows, err := w.Query(
 		`SELECT
 			s.id,
+			s.agent,
+			s.session_kind,
 			s.user_message_count,
 			s.is_automated,
 			substr(CAST(first_user.content AS BLOB), 1, ?)
@@ -102,6 +106,8 @@ func auditAutomatedMatchingHash(
 	for rows.Next() {
 		var (
 			id               string
+			agent            string
+			sessionKind      string
 			userMessageCount int
 			rowAutomated     bool
 			firstUser        boundedAutomationText
@@ -109,6 +115,8 @@ func auditAutomatedMatchingHash(
 		)
 		if err := rows.Scan(
 			&id,
+			&agent,
+			&sessionKind,
 			&userMessageCount,
 			&rowAutomated,
 			&firstUser.prefix,
@@ -120,6 +128,12 @@ func auditAutomatedMatchingHash(
 			return nil, nil, fmt.Errorf(
 				"scanning bounded automated audit candidate: %w", err,
 			)
+		}
+		if IsAutomatedSessionMetadata(agent, sessionKind) {
+			setIDs, clearIDs = appendAutomationFlagChange(
+				setIDs, clearIDs, id, rowAutomated, true,
+			)
+			continue
 		}
 
 		want, conclusive := patterns.verdictFromEvidence(
@@ -146,6 +160,8 @@ func auditAutomatedMatchingHash(
 		fullRows, err := w.Query(
 			`SELECT
 				s.id,
+				s.agent,
+				s.session_kind,
 				s.first_message,
 				s.user_message_count,
 				s.is_automated,
@@ -194,21 +210,25 @@ func scanFullAutomationCandidates(
 	for rows.Next() {
 		var (
 			id           string
+			agent        string
+			sessionKind  string
 			firstMessage sql.NullString
 			firstUser    sql.NullString
 			userCount    int
 			rowAutomated bool
 		)
 		if err := rows.Scan(
-			&id, &firstMessage, &userCount, &rowAutomated, &firstUser,
+			&id, &agent, &sessionKind,
+			&firstMessage, &userCount, &rowAutomated, &firstUser,
 		); err != nil {
 			return nil, nil, fmt.Errorf(
 				"scanning automated audit candidate: %w", err,
 			)
 		}
-		want := patterns.matchesTextCandidates(
-			userCount, firstUser, firstMessage,
-		)
+		want := IsAutomatedSessionMetadata(agent, sessionKind) ||
+			patterns.matchesTextCandidates(
+				userCount, firstUser, firstMessage,
+			)
 		setIDs, clearIDs = appendAutomationFlagChange(
 			setIDs, clearIDs, id, rowAutomated, want,
 		)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1431,6 +1431,7 @@ const upsertSessionSQL = upsertSessionBaseSQL + `,
 
 func sessionIsAutomated(s Session) bool {
 	return s.IsAutomated ||
+		IsAutomatedSessionMetadata(s.Agent, s.SessionKind) ||
 		(s.UserMessageCount <= 1 &&
 			s.FirstMessage != nil &&
 			IsAutomatedSession(*s.FirstMessage))

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -39,6 +39,10 @@ type grokSignalMetrics struct {
 	HasUserMessages   bool
 }
 
+type grokPromptContext struct {
+	IsNonInteractive bool `json:"is_non_interactive"`
+}
+
 func ParseGrokSummary(
 	path, projectHint, machine string,
 ) (ParseResult, error) {
@@ -63,6 +67,16 @@ func ParseGrokSummary(
 	signals, err := parseGrokSignals(filepath.Join(sessionDir, "signals.json"))
 	if err != nil {
 		return ParseResult{}, err
+	}
+	promptContext, err := parseGrokPromptContext(
+		filepath.Join(sessionDir, "prompt_context.json"),
+	)
+	if err != nil {
+		return ParseResult{}, err
+	}
+	sessionKind := ""
+	if promptContext.IsNonInteractive {
+		sessionKind = SessionKindNonInteractive
 	}
 
 	project, cwd := grokProjectAndCwd(summary, projectHint)
@@ -141,6 +155,7 @@ func ParseGrokSummary(
 			Project:            project,
 			Machine:            machine,
 			Agent:              AgentGrok,
+			SessionKind:        sessionKind,
 			ParentSessionID:    parentSessionID,
 			RelationshipType:   relationshipType,
 			Cwd:                cwd,
@@ -191,6 +206,21 @@ func ParseGrokSummary(
 		result.Session.HasTotalOutputTokens ||
 			result.Session.HasPeakContextTokens
 	return result, nil
+}
+
+func parseGrokPromptContext(path string) (grokPromptContext, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return grokPromptContext{}, nil
+	}
+	if err != nil {
+		return grokPromptContext{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var context grokPromptContext
+	if err := json.Unmarshal(data, &context); err != nil {
+		return grokPromptContext{}, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return context, nil
 }
 
 // Grok Build writes one usage payload per completed turn, and those

--- a/internal/parser/grok_provider.go
+++ b/internal/parser/grok_provider.go
@@ -70,10 +70,16 @@ func grokWatchRoots(roots []string) []WatchRoot {
 	out := make([]WatchRoot, 0, len(roots))
 	for _, root := range roots {
 		out = append(out, WatchRoot{
-			Path:         root,
-			Recursive:    true,
-			IncludeGlobs: []string{"summary.json", "signals.json", "chat_history.jsonl", "updates.jsonl"},
-			DebounceKey:  string(AgentGrok) + ":sessions:" + root,
+			Path:      root,
+			Recursive: true,
+			IncludeGlobs: []string{
+				"summary.json",
+				"signals.json",
+				"chat_history.jsonl",
+				"updates.jsonl",
+				"prompt_context.json",
+			},
+			DebounceKey: string(AgentGrok) + ":sessions:" + root,
 		})
 	}
 	return out
@@ -147,7 +153,8 @@ func grokStrictMatch(root, path string) (singleFileMatch, bool) {
 
 func grokTrackedFileName(name string) bool {
 	switch name {
-	case "summary.json", "signals.json", "chat_history.jsonl", "updates.jsonl":
+	case "summary.json", "signals.json", "chat_history.jsonl", "updates.jsonl",
+		"prompt_context.json":
 		return true
 	default:
 		return false
@@ -207,9 +214,10 @@ func grokFingerprintSource(src singleFileSource) (SourceFingerprint, error) {
 func grokCompanionFiles(summaryPath string) map[string]string {
 	dir := filepath.Dir(summaryPath)
 	return map[string]string{
-		"signals":      filepath.Join(dir, "signals.json"),
-		"chat_history": filepath.Join(dir, "chat_history.jsonl"),
-		"updates":      filepath.Join(dir, "updates.jsonl"),
+		"signals":        filepath.Join(dir, "signals.json"),
+		"chat_history":   filepath.Join(dir, "chat_history.jsonl"),
+		"updates":        filepath.Join(dir, "updates.jsonl"),
+		"prompt_context": filepath.Join(dir, "prompt_context.json"),
 	}
 }
 

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -960,17 +960,44 @@ func TestGrokProviderFirstPromptKeepsSessionVisibleWithoutNumMessages(t *testing
 	assert.Equal(t, "Locate the Grok source", outcome.Results[0].Result.Messages[0].Content)
 }
 
+func TestGrokProviderPromptContextClassifiesNonInteractive(t *testing.T) {
+	root := t.TempDir()
+	summary := grokSummaryPath(root, "cwd-key", "sess-1")
+	writeGrokFixtureFile(t, summary, `{
+		"summary":"Inspect a function",
+		"firstPrompt":"Explain this function",
+		"createdAt":"2026-07-08T10:00:00Z"
+	}`)
+	writeGrokFixtureFile(
+		t,
+		filepath.Join(root, "cwd-key", "sess-1", "prompt_context.json"),
+		`{"is_non_interactive":true}`,
+	)
+
+	provider := newGrokTestProvider(t, root)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(t.Context(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+
+	assert.Equal(t, "non-interactive", outcome.Results[0].Result.Session.SessionKind)
+}
+
 func TestGrokProviderFingerprintTracksParsedFiles(t *testing.T) {
 	root := t.TempDir()
 	summary := grokSummaryPath(root, "cwd-key", "sess-1")
 	signals := filepath.Join(root, "cwd-key", "sess-1", "signals.json")
 	updates := filepath.Join(root, "cwd-key", "sess-1", "updates.jsonl")
 	chat := filepath.Join(root, "cwd-key", "sess-1", "chat_history.jsonl")
+	promptContext := filepath.Join(root, "cwd-key", "sess-1", "prompt_context.json")
 	unrelated := filepath.Join(root, "cwd-key", "sess-1", "notes.txt")
 	writeGrokFixtureFile(t, summary, `{"summary":"Fingerprint","firstPrompt":"hello","createdAt":"2026-07-08T10:00:00Z"}`)
 	writeGrokFixtureFile(t, signals, `{"tokenUsage":{"totalOutputTokens":1}}`)
 	writeGrokFixtureFile(t, updates, "{}\n")
 	writeGrokFixtureFile(t, chat, "{}\n")
+	writeGrokFixtureFile(t, promptContext, `{"is_non_interactive":false}`)
 	writeGrokFixtureFile(t, unrelated, "ignored")
 
 	provider := newGrokTestProvider(t, root)
@@ -1003,10 +1030,15 @@ func TestGrokProviderFingerprintTracksParsedFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, afterChat.Hash, afterUpdates.Hash)
 
+	writeGrokFixtureFile(t, promptContext, `{"is_non_interactive":true}`)
+	afterPromptContext, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	assert.NotEqual(t, afterUpdates.Hash, afterPromptContext.Hash)
+
 	writeGrokFixtureFile(t, unrelated, "still ignored")
 	afterUnrelated, err := provider.Fingerprint(context.Background(), source)
 	require.NoError(t, err)
-	assert.Equal(t, afterUpdates.Hash, afterUnrelated.Hash)
+	assert.Equal(t, afterPromptContext.Hash, afterUnrelated.Hash)
 }
 
 func TestGrokProviderChangedPathTracksParsedFiles(t *testing.T) {
@@ -1015,7 +1047,12 @@ func TestGrokProviderChangedPathTracksParsedFiles(t *testing.T) {
 	writeGrokFixtureFile(t, summary, `{"summary":"Changed path","firstPrompt":"hello","createdAt":"2026-07-08T10:00:00Z"}`)
 	provider := newGrokTestProvider(t, root)
 
-	for _, name := range []string{"summary.json", "signals.json", "chat_history.jsonl"} {
+	for _, name := range []string{
+		"summary.json",
+		"signals.json",
+		"chat_history.jsonl",
+		"prompt_context.json",
+	} {
 		changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
 			Path: filepath.Join(root, "cwd-key", "sess-1", name),
 		})
@@ -1032,7 +1069,7 @@ func TestGrokProviderChangedPathTracksParsedFiles(t *testing.T) {
 	assert.Equal(t, filepath.Clean(summary), filepath.Clean(changed[0].FingerprintKey))
 }
 
-func TestGrokProviderWatchPlanIncludesUpdates(t *testing.T) {
+func TestGrokProviderWatchPlanIncludesParsedCompanions(t *testing.T) {
 	root := t.TempDir()
 	provider := newGrokTestProvider(t, root)
 
@@ -1040,7 +1077,13 @@ func TestGrokProviderWatchPlanIncludesUpdates(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, plan.Roots, 1)
 	assert.ElementsMatch(t,
-		[]string{"summary.json", "signals.json", "chat_history.jsonl", "updates.jsonl"},
+		[]string{
+			"summary.json",
+			"signals.json",
+			"chat_history.jsonl",
+			"updates.jsonl",
+			"prompt_context.json",
+		},
 		plan.Roots[0].IncludeGlobs,
 	)
 }

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -1130,6 +1130,10 @@ const (
 	TranscriptFidelitySummary = "summary"
 )
 
+// SessionKindNonInteractive marks a provider session whose durable metadata
+// identifies a non-interactive invocation.
+const SessionKindNonInteractive = "non-interactive"
+
 // FileInfo holds file system metadata for a session source file.
 type FileInfo struct {
 	Path   string
@@ -1148,9 +1152,9 @@ type ParsedSession struct {
 	Agent      AgentType
 	AgentLabel string
 	Entrypoint string
-	// SessionKind is the top-level Claude Code session-kind marker
-	// (e.g. "bg" for background/headless sessions); empty for
-	// interactive sessions and for agents that do not emit it.
+	// SessionKind is a provider-owned top-level session classification marker
+	// (for example, Claude Code "bg" or Grok "non-interactive"); empty for
+	// interactive sessions and for agents that do not emit one.
 	SessionKind      string
 	ParentSessionID  string
 	RelationshipType RelationshipType

--- a/internal/postgres/automated_audit.go
+++ b/internal/postgres/automated_audit.go
@@ -18,6 +18,8 @@ type automatedAuditPGProgress struct {
 
 const fullAutomationCandidatesPG = `SELECT
 	s.id,
+	s.agent,
+	s.session_kind,
 	s.first_message,
 	s.user_message_count,
 	s.is_automated,
@@ -126,6 +128,8 @@ func auditAutomatedMatchingHashPG(
 	rows, err := pg.QueryContext(ctx,
 		`SELECT
 			s.id,
+			s.agent,
+			s.session_kind,
 			s.user_message_count,
 			s.is_automated,
 			CASE WHEN s.user_message_count <= 1
@@ -171,6 +175,8 @@ func auditAutomatedMatchingHashPG(
 	for rows.Next() {
 		var (
 			id                 string
+			agent              string
+			sessionKind        string
 			userMessageCount   int
 			rowAutomated       bool
 			firstUserPrefix    []byte
@@ -180,6 +186,8 @@ func auditAutomatedMatchingHashPG(
 		)
 		if err := rows.Scan(
 			&id,
+			&agent,
+			&sessionKind,
 			&userMessageCount,
 			&rowAutomated,
 			&firstUserPrefix,
@@ -193,6 +201,12 @@ func auditAutomatedMatchingHashPG(
 			)
 		}
 		progress.RowsPrefetched++
+		if db.IsAutomatedSessionMetadata(agent, sessionKind) {
+			setIDs, clearIDs = appendAutomationFlagChangePG(
+				setIDs, clearIDs, id, rowAutomated, true,
+			)
+			continue
+		}
 
 		want, conclusive := classifier.VerdictFromEvidence(
 			userMessageCount,
@@ -257,22 +271,26 @@ func scanFullAutomationCandidatesPG(
 	for rows.Next() {
 		var (
 			id           string
+			agent        string
+			sessionKind  string
 			firstMessage sql.NullString
 			firstUser    sql.NullString
 			userCount    int
 			rowAutomated bool
 		)
 		if err := rows.Scan(
-			&id, &firstMessage, &userCount, &rowAutomated, &firstUser,
+			&id, &agent, &sessionKind,
+			&firstMessage, &userCount, &rowAutomated, &firstUser,
 		); err != nil {
 			return nil, nil, count, fmt.Errorf(
 				"scanning PG automated audit candidate: %w", err,
 			)
 		}
 		count++
-		want := classifier.IsAutomatedFromTextCandidates(
-			userCount, firstUser, firstMessage,
-		)
+		want := db.IsAutomatedSessionMetadata(agent, sessionKind) ||
+			classifier.IsAutomatedFromTextCandidates(
+				userCount, firstUser, firstMessage,
+			)
 		setIDs, clearIDs = appendAutomationFlagChangePG(
 			setIDs, clearIDs, id, rowAutomated, want,
 		)

--- a/internal/postgres/automated_pgtest_test.go
+++ b/internal/postgres/automated_pgtest_test.go
@@ -104,6 +104,43 @@ func TestBackfillIsAutomatedPGMatchingHashUsesBoundedEvidence(t *testing.T) {
 	}
 }
 
+func TestBackfillIsAutomatedPGPreservesDurableClassification(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanPGSchema(t, pgURL)
+	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
+
+	local := testDB(t)
+	ps, err := New(
+		pgURL, "agentsview", local,
+		"automation-metadata-machine", true,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "creating sync")
+	defer ps.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
+
+	_, err = ps.DB().ExecContext(ctx,
+		`INSERT INTO sessions (
+			id, machine, project, agent, session_kind, first_message,
+			user_message_count, is_automated
+		 ) VALUES ($1, 'host', 'proj', 'grok', 'non-interactive', $2, 2, true)`,
+		"grok-headless", "Explain this function",
+	)
+	require.NoError(t, err, "insert durably classified session")
+
+	require.NoError(t, backfillIsAutomatedPG(ctx, ps.DB()), "backfill automation")
+
+	var got bool
+	require.NoError(t, ps.DB().QueryRowContext(ctx,
+		`SELECT is_automated FROM sessions WHERE id = $1`,
+		"grok-headless",
+	).Scan(&got), "query automation classification")
+	assert.True(t, got)
+}
+
 // TestPushSessionTrustsLocalIsAutomated verifies that
 // pushSession copies sess.IsAutomated verbatim instead of
 // re-running db.IsAutomatedSession on the first_message.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -14446,9 +14446,10 @@ func applySessionMessageDerivedFields(
 	if !countsAuthoritative {
 		s.MessageCount, s.UserMessageCount = postFilterCounts(msgs)
 	}
-	s.IsAutomated = db.IsAutomatedTranscript(
-		s.UserMessageCount, msgs, s.FirstMessage,
-	)
+	s.IsAutomated = db.IsAutomatedSessionMetadata(s.Agent, s.SessionKind) ||
+		db.IsAutomatedTranscript(
+			s.UserMessageCount, msgs, s.FirstMessage,
+		)
 }
 
 // messageTokenTotals computes the message-derived session token

--- a/internal/sync/grok_automation_integration_test.go
+++ b/internal/sync/grok_automation_integration_test.go
@@ -1,0 +1,67 @@
+package sync_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+func TestGrokPromptContextAutomationSurvivesResyncAndAudit(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "cwd-key", "sess-1")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "summary.json"),
+		[]byte(`{
+			"summary":"Inspect a function",
+			"firstPrompt":"Explain this function",
+			"createdAt":"2026-07-08T10:00:00Z"
+		}`),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "prompt_context.json"),
+		[]byte(`{"is_non_interactive":false}`),
+		0o644,
+	))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentGrok: {root}},
+		Machine:   "local",
+	})
+
+	stats := engine.SyncAll(t.Context(), nil)
+	require.Equal(t, 1, stats.Synced)
+	before, err := database.GetSession(t.Context(), "grok:sess-1")
+	require.NoError(t, err)
+	require.NotNil(t, before)
+	require.False(t, before.IsAutomated)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "prompt_context.json"),
+		[]byte(`{"is_non_interactive":true}`),
+		0o644,
+	))
+	stats = engine.SyncAll(t.Context(), nil)
+	require.Equal(t, 1, stats.Synced)
+
+	after, err := database.GetSession(t.Context(), "grok:sess-1")
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, "non-interactive", after.SessionKind)
+	require.True(t, after.IsAutomated)
+
+	require.NoError(t, database.ForceBackfillIsAutomated())
+	afterAudit, err := database.GetSession(t.Context(), "grok:sess-1")
+	require.NoError(t, err)
+	require.NotNil(t, afterAudit)
+	assert.True(t, afterAudit.IsAutomated)
+}


### PR DESCRIPTION
## Summary

Grok sessions now treat an explicit `prompt_context.json` `is_non_interactive` value as durable automation provenance. The provider watches and fingerprints the sidecar so sessions are reparsed when it appears or changes, while missing or false values remain subject to the existing transcript classifier.

SQLite and PostgreSQL automation audits preserve this provider classification, so Activity filtering and automated/interactive aggregation consume the corrected stored flag. The format inventory records commit-pinned first-party evidence for this narrow claim.

This change is limited to automated-session detection. It does not include Grok usage, timestamp, role, or agent-minute changes.
