### PR TITLE
feat(sync): generalize S3 session sources beyond Claude and Codex

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, s3-generic-provider-support]
     tags:
       - 'v*'
     paths:
@@ -73,6 +73,8 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=sha
           labels: |
             org.opencontainers.image.title=agentsview
             org.opencontainers.image.description=Local web viewer for AI agent sessions

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ description: Release history for AgentsView
 
 ## Unreleased
 
+**New features**
+
+- Ingest Cursor sessions from S3 roots through a shared single-file S3 provider
+  interface, so additional JSONL agents can opt in without repeating per-agent
+  sync switches.
+
 ---
 
 ## 0.41.1

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -217,12 +217,13 @@ directories on the remote machine, transfers the source session data locally,
 and indexes it into your local archive. SSH remote sync is deprecated and
 receives only critical fixes; use configured HTTP remote sync for new setups.
 
-Local sync can also read configured Claude and Codex roots from S3-compatible
-object storage. Add `s3://` entries to `claude_project_dirs` or
-`codex_sessions_dirs` in `~/.agentsview/config.toml`, then run `agentsview sync`
-normally. This is not SSH remote sync: object storage is treated as a read-only
-session source, using object size and `LastModified` metadata to skip unchanged
-sessions and downloading only objects that need parsing. See
+Local sync can also read configured Claude, Codex, and Cursor roots from
+S3-compatible object storage. Add `s3://` entries to `claude_project_dirs`,
+`codex_sessions_dirs`, or `cursor_project_dirs` in `~/.agentsview/config.toml`,
+then run `agentsview sync` normally. This is not SSH remote sync: object
+storage is treated as a read-only session source, using object size and
+`LastModified` metadata to skip unchanged sessions and downloading only objects
+that need parsing. See
 [Configuration — S3-Compatible Session Sources](/configuration/#s3-compatible-session-sources).
 
 #### Configured Remote Hosts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -803,9 +803,10 @@ PostgreSQL.
 
 ### S3-Compatible Session Sources
 
-Claude and Codex session roots can also be `s3://` URIs. This is useful when
-several machines push their raw session files to object storage and one central
-AgentsView instance reads them without SSH access to those machines.
+Claude, Codex, and Cursor session roots can also be `s3://` URIs. This is
+useful when several machines push their raw session files to object storage
+and one central AgentsView instance reads them without SSH access to those
+machines.
 
 ```toml
 claude_project_dirs = [
@@ -817,11 +818,16 @@ codex_sessions_dirs = [
   "~/.codex/sessions",
   "s3://agent-archive/laptop/raw/codex",
 ]
+
+cursor_project_dirs = [
+  "~/.cursor/projects",
+  "s3://agent-archive/laptop/raw/cursor",
+]
 ```
 
 S3 sources are read-only inputs to the normal local sync. AgentsView lists
 matching objects, fetches each changed object to a temporary file, parses it
-with the existing Claude/Codex parser, records the original `s3://` URI as
+with the existing per-agent parser, records the original `s3://` URI as
 `file_path`, and removes the temporary file. No persistent local mirror is
 created.
 
@@ -848,6 +854,7 @@ Expected object layouts:
 s3://bucket/.../<machine>/raw/claude/<project>/<uuid>.jsonl
 s3://bucket/.../<machine>/raw/claude/<project>/subagents/.../agent-*.jsonl
 s3://bucket/.../<machine>/raw/codex/2026/06/24/rollout-*.jsonl
+s3://bucket/.../<machine>/raw/cursor/<project>/<uuid>.jsonl
 ```
 
 The machine name is derived from the path segment immediately before `raw`. If
@@ -1022,7 +1029,7 @@ autonomous run whose last persisted prompt is outside either bound, that rollout
 uses native-watcher freshness until another persisted prompt makes it hot
 again.
 
-For `s3://` Claude and Codex roots, change detection uses object size,
+For `s3://` Claude, Codex, and Cursor roots, change detection uses object size,
 `LastModified`, and available object fingerprints such as ETag, version ID, and
 checksums from listing or stat calls. Object content is downloaded only after
 that metadata shows a parse may be needed.

--- a/docs/filesystem-sync.md
+++ b/docs/filesystem-sync.md
@@ -62,7 +62,7 @@ per-agent array, default, or environment variable, the structured entry
 supplies the machine label.
 
 `session_sources` accepts filesystem roots only. Keep using the existing
-Claude/Codex per-agent arrays for `s3://` roots; S3 ingestion has established
+per-agent arrays for `s3://` roots; S3 ingestion has established
 machine-derived ID-prefix behavior that differs from filesystem labeling. Native
 SQLite-backed agent stores are supported when `dir` points at their filesystem
 root.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -287,11 +287,12 @@ export ZENCODER_DIR=~/custom/zencoder/sessions
 agentsview serve
 ```
 
-For Claude and Codex, custom roots may also be `s3://` URIs:
+For Claude, Codex, and Cursor, custom roots may also be `s3://` URIs:
 
 ```toml
 claude_project_dirs = ["s3://agent-archive/laptop/raw/claude"]
 codex_sessions_dirs = ["s3://agent-archive/laptop/raw/codex"]
+cursor_project_dirs = ["s3://agent-archive/laptop/raw/cursor"]
 ```
 
 Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and optionally

--- a/internal/parser/capabilities.go
+++ b/internal/parser/capabilities.go
@@ -84,6 +84,12 @@ type SourceCapabilities struct {
 	// in providerStatHashers to avoid short-circuiting every
 	// SourceSet-wrapped agent on a 0==0 digest match.
 	MultiFileStatHash CapabilitySupport
+	// S3Discovery means the provider can enumerate and ingest sessions
+	// from an s3:// root under .../<machine>/raw/<agent>/ and implements
+	// S3Provider. Providers leave this at CapabilityUnsupported unless
+	// they opt in; the sync engine uses the flag instead of a hardcoded
+	// Claude/Codex whitelist.
+	S3Discovery CapabilitySupport
 }
 
 // ContentCapabilities declares optional normalized content fields a provider

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -10,6 +10,7 @@ import (
 )
 
 var _ Provider = (*claudeProvider)(nil)
+var _ S3Provider = (*claudeProvider)(nil)
 
 type claudeProviderFactory struct {
 	def AgentDef
@@ -661,6 +662,33 @@ func claudeProviderTokenTotals(
 	return totalOut, peakCtx, hasTotalOut, hasPeakCtx
 }
 
+func (p *claudeProvider) S3Scanner() S3SessionScanner {
+	return claudeS3Scanner()
+}
+
+func (p *claudeProvider) S3SessionID(uri string) string {
+	name := pathBase(uri)
+	id, ok := strings.CutSuffix(name, ".jsonl")
+	if !ok {
+		return ""
+	}
+	return id
+}
+
+func (p *claudeProvider) S3TempRelPath(objectPath string) (string, error) {
+	return s3TempRelPathAfterRawAgent(objectPath, string(AgentClaude), nil)
+}
+
+func (p *claudeProvider) S3StatSession(uri string) (S3Object, error) {
+	return StatClaudeS3Session(uri)
+}
+
+func (p *claudeProvider) S3PostFetchHydrate(
+	tempDir, tempPath, configuredRoot, objectURI string,
+) error {
+	return nil
+}
+
 func claudeProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
@@ -677,6 +705,7 @@ func claudeProviderCapabilities() Capabilities {
 			ForceReplaceOnParse:  CapabilitySupported,
 			VerifiedLocalStat:    CapabilitySupported,
 			MultiFileStatHash:    CapabilitySupported,
+			S3Discovery:          CapabilitySupported,
 		},
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -13,6 +13,7 @@ import (
 
 var _ Provider = (*codexProvider)(nil)
 var _ ActivityHintProvider = (*codexProvider)(nil)
+var _ S3Provider = (*codexProvider)(nil)
 
 // codexProviderSpec parameterizes the one shared Codex-format provider
 // implementation for Codex and its TraeX fork. Both reuse the same
@@ -73,7 +74,11 @@ func (f *codexProviderFactory) Definition() AgentDef {
 }
 
 func (f *codexProviderFactory) Capabilities() Capabilities {
-	return codexProviderCapabilities()
+	caps := codexProviderCapabilities()
+	if f.spec.agent == AgentCodex {
+		caps.Source.S3Discovery = CapabilitySupported
+	}
+	return caps
 }
 
 func (f *codexProviderFactory) NewProvider(cfg ProviderConfig) Provider {
@@ -81,7 +86,7 @@ func (f *codexProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	return &codexProvider{
 		ProviderBase: ProviderBase{
 			Def:    cloneAgentDef(f.def),
-			Caps:   codexProviderCapabilities(),
+			Caps:   f.Capabilities(),
 			Config: cfg,
 		},
 		spec:            f.spec,
@@ -109,6 +114,41 @@ func (p *codexProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) 
 
 func (p *codexProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
+}
+
+func (p *codexProvider) S3Scanner() S3SessionScanner {
+	if p.spec.agent != AgentCodex {
+		return S3SessionScanner{Agent: p.spec.agent}
+	}
+	return codexS3Scanner()
+}
+
+func (p *codexProvider) S3SessionID(uri string) string {
+	if p.spec.agent != AgentCodex {
+		return ""
+	}
+	uuid := CodexSessionUUIDFromFilename(pathBase(uri))
+	if uuid == "" {
+		return ""
+	}
+	return "codex:" + uuid
+}
+
+func (p *codexProvider) S3TempRelPath(objectPath string) (string, error) {
+	if p.spec.agent != AgentCodex {
+		return "", fmt.Errorf("unsafe s3 object name: %q", objectPath)
+	}
+	return s3TempRelPathAfterRawAgent(objectPath, "codex", codexS3TempRelParts)
+}
+
+func (p *codexProvider) S3StatSession(uri string) (S3Object, error) {
+	return StatCodexS3Session(uri)
+}
+
+func (p *codexProvider) S3PostFetchHydrate(
+	tempDir, tempPath, configuredRoot, objectURI string,
+) error {
+	return nil
 }
 
 func (p *codexProvider) ActivityHintSources(

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -10,6 +10,7 @@ import (
 )
 
 var _ Provider = (*cursorProvider)(nil)
+var _ S3Provider = (*cursorProvider)(nil)
 
 type cursorProviderFactory struct {
 	def AgentDef
@@ -35,12 +36,14 @@ func (f cursorProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 			Caps:   cursorProviderCapabilities(),
 			Config: cfg,
 		},
-		sources: newCursorSourceSet(cfg.Roots),
+		DefaultS3Provider: cursorDefaultS3Provider(),
+		sources:           newCursorSourceSet(cfg.Roots),
 	}
 }
 
 type cursorProvider struct {
 	ProviderBase
+	DefaultS3Provider
 	sources cursorSourceSet
 }
 
@@ -128,12 +131,26 @@ func newCursorSourceSet(roots []string) cursorSourceSet {
 	return cursorSourceSet{roots: cleanJSONLRoots(roots)}
 }
 
+func cursorDefaultS3Provider() DefaultS3Provider {
+	return DefaultS3Provider{
+		Agent:      AgentCursor,
+		IDPrefix:   "cursor:",
+		Extensions: []string{".jsonl", ".txt"},
+	}
+}
+
 func (s cursorSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	var sources []SourceRef
 	seen := make(map[string]struct{})
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
 			return nil, err
+		}
+		if isS3URI(root) {
+			for _, file := range s3PrefixScan(root, cursorDefaultS3Provider().S3Scanner()) {
+				addJSONLSource(s3SourceRefFromDiscoveredFile(root, file), &sources, seen)
+			}
+			continue
 		}
 		for _, path := range s.discoverTranscriptPaths(root) {
 			source, ok := s.sourceRef(root, path)
@@ -151,6 +168,14 @@ func (s cursorSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef)
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+		if isS3URI(root) {
+			for _, file := range s3PrefixScan(root, cursorDefaultS3Provider().S3Scanner()) {
+				if err := yield(s3SourceRefFromDiscoveredFile(root, file)); err != nil {
+					return err
+				}
+			}
+			continue
 		}
 		resolvedRoot, err := filepath.EvalSymlinks(root)
 		if err != nil {
@@ -423,6 +448,9 @@ func cursorAddSeen(seen map[string]string, name, fullPath string) {
 func (s cursorSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 	roots := make([]WatchRoot, 0, len(s.roots))
 	for _, root := range s.roots {
+		if isS3URI(root) {
+			continue
+		}
 		roots = append(roots, WatchRoot{
 			Path:         root,
 			Recursive:    true,
@@ -588,6 +616,8 @@ func (s cursorSourceSet) pathFromSource(source SourceRef) (string, bool) {
 		if src != nil && src.Path != "" {
 			return src.Path, true
 		}
+	case MaterializedFileSource:
+		return src.Path, src.Path != ""
 	}
 	for _, candidate := range []string{
 		source.DisplayPath,
@@ -751,6 +781,7 @@ func cursorProviderCapabilities() Capabilities {
 			PerSessionErrors:     CapabilityNotApplicable,
 			ExcludedSessions:     CapabilityNotApplicable,
 			ForceReplaceOnParse:  CapabilityNotApplicable,
+			S3Discovery:          CapabilitySupported,
 		},
 		Content: ContentCapabilities{
 			FirstMessage: CapabilitySupported,

--- a/internal/parser/cursor_provider_test.go
+++ b/internal/parser/cursor_provider_test.go
@@ -301,6 +301,17 @@ func TestCursorProviderFingerprintSkipsOversizedTranscriptHash(t *testing.T) {
 	assert.Contains(t, err.Error(), "file too large")
 }
 
+func TestCursorPathFromSourceMaterializedFile(t *testing.T) {
+	s := newCursorSourceSet([]string{t.TempDir()})
+	path := filepath.Join(t.TempDir(), "abc.jsonl")
+	got, ok := s.pathFromSource(SourceRef{
+		Provider: AgentCursor,
+		Opaque:   MaterializedFileSource{Path: path},
+	})
+	require.True(t, ok)
+	assert.Equal(t, path, got)
+}
+
 func cursorProviderWriteTranscript(
 	t *testing.T,
 	dir string,

--- a/internal/parser/provider_capabilities_test.go
+++ b/internal/parser/provider_capabilities_test.go
@@ -22,6 +22,35 @@ func TestProviderCapabilitiesPersistentArchiveDefaultUnsupported(t *testing.T) {
 	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).PersistentArchive)
 }
 
+func TestProviderCapabilitiesS3DiscoveryDefaultUnsupported(t *testing.T) {
+	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).S3Discovery)
+}
+
+func TestProviderCapabilitiesS3DiscoveryMatchConsumers(t *testing.T) {
+	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).S3Discovery,
+		"new providers must opt in explicitly")
+
+	supported := map[AgentType]bool{
+		AgentClaude: true,
+		AgentCodex:  true,
+		AgentCursor: true,
+	}
+	for _, factory := range ProviderFactories() {
+		agent := factory.Definition().Type
+		got := factory.Capabilities().Source.S3Discovery
+		if supported[agent] {
+			assert.Equal(t, CapabilitySupported, got)
+			provider := factory.NewProvider(ProviderConfig{
+				Roots: []string{t.TempDir()},
+			})
+			assert.Implements(t, (*S3Provider)(nil), provider)
+			continue
+		}
+		assert.Equalf(t, CapabilityUnsupported, got,
+			"%s must not opt into S3 discovery", agent)
+	}
+}
+
 func TestProviderCapabilitiesActivityHintsMatchConsumers(t *testing.T) {
 	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).ActivityHints,
 		"new providers must opt in explicitly")
@@ -164,6 +193,27 @@ func TestProviderMigrationRejectsStreamingCapabilityWithoutInterface(t *testing.
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "StreamingDiscoverer")
+}
+
+func TestProviderMigrationRejectsS3DiscoveryWithoutInterface(t *testing.T) {
+	factory := testProviderFactory{
+		def: AgentDef{Type: "invalid-s3-provider"},
+		caps: Capabilities{Source: SourceCapabilities{
+			DiscoverSources: CapabilitySupported,
+			FindSource:      CapabilitySupported,
+			S3Discovery:     CapabilitySupported,
+		}},
+	}
+
+	err := ValidateProviderMigrationModes(
+		[]ProviderFactory{factory},
+		map[AgentType]ProviderMigrationMode{
+			"invalid-s3-provider": ProviderMigrationProviderAuthoritative,
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "S3Provider")
 }
 
 func TestProviderMigrationRejectsSharedContainerWithoutExactRehydration(t *testing.T) {

--- a/internal/parser/provider_migration.go
+++ b/internal/parser/provider_migration.go
@@ -169,6 +169,15 @@ func validateProviderMigrationMode(
 				}
 			}
 		}
+		if caps.S3Discovery == CapabilitySupported {
+			provider := factory.NewProvider(ProviderConfig{})
+			if _, ok := provider.(S3Provider); !ok {
+				return fmt.Errorf(
+					"%s: S3 discovery capability requires S3Provider",
+					def.Type,
+				)
+			}
+		}
 	case ProviderMigrationImportOnly:
 		if !isImportOnlyAgentType(def.Type) {
 			return fmt.Errorf(

--- a/internal/parser/s3_discovery_test.go
+++ b/internal/parser/s3_discovery_test.go
@@ -146,3 +146,90 @@ func TestCodexSourceSetDiscoversS3Sessions(t *testing.T) {
 	assert.Equal(t, mtime.UnixNano(), s3.MtimeNS)
 	assert.Contains(t, s3.Fingerprint, "rollout")
 }
+
+func TestCursorSourceSetDiscoversS3Sessions(t *testing.T) {
+	oldList := listS3Objects
+	t.Cleanup(func() { listS3Objects = oldList })
+
+	root := "s3://bucket/laptop/raw/cursor"
+	jsonlURI := root + "/demo-proj/11111111-1111-4111-8111-111111111111.jsonl"
+	txtURI := root + "/demo-proj/22222222-2222-4222-8222-222222222222.txt"
+	ignored := root + "/demo-proj/notes.md"
+	mtime := time.Unix(100, 0)
+	listS3Objects = func(got string) ([]S3Object, error) {
+		require.Equal(t, root, got)
+		return []S3Object{
+			{
+				URI: jsonlURI, Size: 11, LastModified: mtime,
+				Fingerprint: "s3-meta:jsonl",
+			},
+			{
+				URI: txtURI, Size: 7, LastModified: mtime,
+				Fingerprint: "s3-meta:txt",
+			},
+			{
+				URI: ignored, Size: 3, LastModified: mtime,
+				Fingerprint: "s3-meta:md",
+			},
+		}, nil
+	}
+
+	sources, err := newCursorSourceSet([]string{root}).Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 2)
+
+	byPath := make(map[string]SourceRef, len(sources))
+	for _, src := range sources {
+		byPath[src.DisplayPath] = src
+		assert.Equal(t, AgentCursor, src.Provider)
+		assert.Equal(t, "demo-proj", src.ProjectHint)
+		s3, ok := src.Opaque.(S3DiscoveredSource)
+		require.True(t, ok)
+		assert.Equal(t, "laptop", s3.Machine)
+		assert.Equal(t, "demo-proj", s3.Project)
+	}
+	require.Contains(t, byPath, jsonlURI)
+	require.Contains(t, byPath, txtURI)
+	assert.Equal(t, int64(11), byPath[jsonlURI].Opaque.(S3DiscoveredSource).Size)
+	assert.Equal(t, int64(7), byPath[txtURI].Opaque.(S3DiscoveredSource).Size)
+}
+
+func TestCursorSourceSetDiscoverEachYieldsS3Sessions(t *testing.T) {
+	oldList := listS3Objects
+	t.Cleanup(func() { listS3Objects = oldList })
+
+	root := "s3://bucket/laptop/raw/cursor"
+	sessionURI := root + "/demo-proj/11111111-1111-4111-8111-111111111111.jsonl"
+	listS3Objects = func(string) ([]S3Object, error) {
+		return []S3Object{{
+			URI:          sessionURI,
+			Size:         11,
+			LastModified: time.Unix(100, 0),
+			Fingerprint:  "s3-meta:jsonl",
+		}}, nil
+	}
+
+	var got []SourceRef
+	err := newCursorSourceSet([]string{root}).DiscoverEach(
+		context.Background(),
+		func(src SourceRef) error {
+			got = append(got, src)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, sessionURI, got[0].DisplayPath)
+	assert.Equal(t, AgentCursor, got[0].Provider)
+}
+
+func TestCursorWatchPlanSkipsS3Roots(t *testing.T) {
+	local := t.TempDir()
+	plan, err := newCursorSourceSet([]string{
+		local,
+		"s3://bucket/laptop/raw/cursor",
+	}).WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, local, plan.Roots[0].Path)
+}

--- a/internal/parser/s3_provider.go
+++ b/internal/parser/s3_provider.go
@@ -1,0 +1,141 @@
+package parser
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// S3Provider is the opt-in surface that lets a single-file provider ingest
+// sessions from an s3:// root laid out as .../<machine>/raw/<agent>/...
+// Claude and Codex implement it with extra sidecar, fork, and index behavior.
+// Simple JSONL providers embed DefaultS3Provider.
+type S3Provider interface {
+	S3Scanner() S3SessionScanner
+	S3SessionID(uri string) string
+	S3TempRelPath(objectPath string) (string, error)
+	S3StatSession(uri string) (S3Object, error)
+	S3PostFetchHydrate(tempDir, tempPath, configuredRoot, objectURI string) error
+}
+
+// DefaultS3Provider covers the common single-file S3 layout: keep objects whose
+// names match Extensions, derive project from the first path segment, identify
+// the session as IDPrefix plus the filename stem, strip raw/<agent> for the
+// temp materialization path, and skip sidecar folding and post-fetch hydrate.
+type DefaultS3Provider struct {
+	Agent      AgentType
+	IDPrefix   string
+	Extensions []string
+}
+
+// S3ProviderFor returns the S3Provider implementation for a registered agent,
+// if that agent's provider implements the interface.
+func S3ProviderFor(agent AgentType) (S3Provider, bool) {
+	p, ok := NewProvider(agent, ProviderConfig{})
+	if !ok {
+		return nil, false
+	}
+	sp, ok := p.(S3Provider)
+	return sp, ok
+}
+
+// AgentSupportsS3Discovery reports whether the agent's factory declares
+// Source.S3Discovery. Scheduling and S3 root-segment detection should trust
+// this flag rather than a hardcoded agent whitelist.
+func AgentSupportsS3Discovery(agent AgentType) bool {
+	factory, ok := ProviderFactoryByType(agent)
+	if !ok {
+		return false
+	}
+	return factory.Capabilities().Source.S3Discovery == CapabilitySupported
+}
+
+func (p DefaultS3Provider) S3Scanner() S3SessionScanner {
+	exts := append([]string(nil), p.Extensions...)
+	return S3SessionScanner{
+		Agent: p.Agent,
+		Keep: func(_ string, segs []string) bool {
+			if len(segs) < 2 {
+				return false
+			}
+			base := segs[len(segs)-1]
+			for _, ext := range exts {
+				if ext != "" && strings.HasSuffix(strings.ToLower(base), strings.ToLower(ext)) {
+					return true
+				}
+			}
+			return false
+		},
+		Project: func(_ string, segs []string) string {
+			if len(segs) == 0 {
+				return ""
+			}
+			return segs[0]
+		},
+	}
+}
+
+func (p DefaultS3Provider) S3SessionID(uri string) string {
+	base := path.Base(uri)
+	ext := path.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	if stem == "" || stem == base && ext == "" {
+		return ""
+	}
+	return p.IDPrefix + stem
+}
+
+func (p DefaultS3Provider) S3TempRelPath(objectPath string) (string, error) {
+	return s3TempRelPathAfterRawAgent(objectPath, string(p.Agent), nil)
+}
+
+func (p DefaultS3Provider) S3StatSession(uri string) (S3Object, error) {
+	return statS3Object(uri)
+}
+
+func (p DefaultS3Provider) S3PostFetchHydrate(
+	tempDir, tempPath, configuredRoot, objectURI string,
+) error {
+	return nil
+}
+
+func s3TempRelPathAfterRawAgent(
+	objectPath, agentSeg string, rewrite func([]string) []string,
+) (string, error) {
+	trimmed := strings.TrimPrefix(objectPath, "s3://")
+	parts := strings.Split(trimmed, "/")
+	relParts := parts
+	if len(parts) > 1 {
+		relParts = parts[1:]
+	}
+	if agentSeg != "" {
+		for i := 0; i+1 < len(parts); i++ {
+			if parts[i] == "raw" && parts[i+1] == agentSeg {
+				relParts = parts[i+2:]
+				break
+			}
+		}
+	}
+	if rewrite != nil {
+		relParts = rewrite(relParts)
+	}
+	return sanitizeS3TempRelParts(objectPath, relParts)
+}
+
+func sanitizeS3TempRelParts(objectPath string, relParts []string) (string, error) {
+	if len(relParts) == 0 {
+		return "", fmt.Errorf("unsafe s3 object name: %q", objectPath)
+	}
+	for _, part := range relParts {
+		if part == "" || part == "." || part == ".." ||
+			strings.ContainsAny(part, `\/`) {
+			return "", fmt.Errorf("unsafe s3 object name: %q", objectPath)
+		}
+	}
+	return filepath.Join(relParts...), nil
+}
+
+func isS3URI(root string) bool {
+	return strings.HasPrefix(root, "s3://")
+}

--- a/internal/parser/s3_provider_test.go
+++ b/internal/parser/s3_provider_test.go
@@ -1,0 +1,76 @@
+package parser
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultS3ProviderSessionIDAndTempPath(t *testing.T) {
+	p := DefaultS3Provider{
+		Agent:      AgentCursor,
+		IDPrefix:   "cursor:",
+		Extensions: []string{".jsonl", ".txt"},
+	}
+
+	assert.Equal(t, "cursor:abc", p.S3SessionID(
+		"s3://bucket/laptop/raw/cursor/demo-proj/abc.jsonl",
+	))
+	assert.Equal(t, "cursor:abc", p.S3SessionID(
+		"s3://bucket/laptop/raw/cursor/demo-proj/abc.txt",
+	))
+	assert.Empty(t, p.S3SessionID("s3://bucket/laptop/raw/cursor/demo-proj/"))
+
+	got, err := p.S3TempRelPath(
+		"s3://bucket/laptop/raw/cursor/demo-proj/abc.jsonl",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("demo-proj", "abc.jsonl"), got)
+
+	_, err = p.S3TempRelPath(
+		"s3://bucket/laptop/raw/cursor/demo-proj/../abc.jsonl",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe s3 object name")
+}
+
+func TestDefaultS3ProviderScannerKeepAndProject(t *testing.T) {
+	scan := DefaultS3Provider{
+		Agent:      AgentCursor,
+		Extensions: []string{".jsonl", ".txt"},
+	}.S3Scanner()
+
+	assert.Equal(t, AgentCursor, scan.Agent)
+	assert.True(t, scan.Keep("demo-proj/abc.jsonl", []string{"demo-proj", "abc.jsonl"}))
+	assert.True(t, scan.Keep("demo-proj/abc.txt", []string{"demo-proj", "abc.txt"}))
+	assert.False(t, scan.Keep("demo-proj/notes.md", []string{"demo-proj", "notes.md"}))
+	assert.False(t, scan.Keep("abc.jsonl", []string{"abc.jsonl"}))
+	assert.Equal(t, "demo-proj", scan.Project("demo-proj/abc.jsonl", []string{"demo-proj", "abc.jsonl"}))
+	assert.Nil(t, scan.Sidecars)
+}
+
+func TestDefaultS3ProviderStatSessionUsesPlainObjectStat(t *testing.T) {
+	const uri = "s3://bucket/laptop/raw/cursor/demo-proj/abc.jsonl"
+	oldStat := statS3Object
+	t.Cleanup(func() { statS3Object = oldStat })
+	statS3Object = func(got string) (S3Object, error) {
+		require.Equal(t, uri, got)
+		return S3Object{URI: uri, Size: 42}, nil
+	}
+
+	got, err := DefaultS3Provider{Agent: AgentCursor}.S3StatSession(uri)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), got.Size)
+	assert.Equal(t, uri, got.URI)
+}
+
+func TestAgentSupportsS3Discovery(t *testing.T) {
+	assert.True(t, AgentSupportsS3Discovery(AgentClaude))
+	assert.True(t, AgentSupportsS3Discovery(AgentCodex))
+	assert.True(t, AgentSupportsS3Discovery(AgentCursor))
+	assert.False(t, AgentSupportsS3Discovery(AgentTraeX))
+	assert.False(t, AgentSupportsS3Discovery(AgentGrok))
+	assert.False(t, AgentSupportsS3Discovery(AgentType("not-an-agent")))
+}

--- a/internal/parser/s3source.go
+++ b/internal/parser/s3source.go
@@ -1,4 +1,4 @@
-// ABOUTME: Reads Claude/Codex session JSONL directly from an S3-compatible
+// ABOUTME: Reads session JSONL directly from an S3-compatible
 // ABOUTME: object store (AWS S3, MinIO, Aliyun OSS, R2, ...) — pure Go, no cgo.
 package parser
 
@@ -376,7 +376,7 @@ func s3SourceRefFromDiscoveredFile(root string, file DiscoveredFile) SourceRef {
 	}
 }
 
-// s3SessionScanner configures the shared S3 discovery scan over a session root
+// S3SessionScanner configures the shared S3 discovery scan over a session root
 // laid out as .../<machine>/raw/<provider>. The scan lists every object under
 // the root, derives the source machine from that layout, and emits a
 // DiscoveredFile for each object Keep accepts. Keep and Project receive both the
@@ -386,7 +386,7 @@ func s3SourceRefFromDiscoveredFile(root string, file DiscoveredFile) SourceRef {
 // freshness identity (Claude tool-results); providers without sidecars leave it
 // nil, and providers that derive the project from session content leave Project
 // nil.
-type s3SessionScanner struct {
+type S3SessionScanner struct {
 	Agent    AgentType
 	Keep     func(rel string, segs []string) bool
 	Project  func(rel string, segs []string) string
@@ -397,7 +397,7 @@ type s3SessionScanner struct {
 // .../<machine>/raw/<provider> layout. discoverClaudeS3 and discoverCodexS3 are
 // thin configurations of it, and any JSONL provider whose sessions land under
 // the same layout can reuse it by supplying its own Keep/Project predicates.
-func s3PrefixScan(root string, scan s3SessionScanner) []DiscoveredFile {
+func s3PrefixScan(root string, scan S3SessionScanner) []DiscoveredFile {
 	objects, err := listS3Objects(root)
 	if err != nil {
 		return nil
@@ -442,13 +442,17 @@ func s3PrefixScan(root string, scan s3SessionScanner) []DiscoveredFile {
 //   - subagents .../subagents/.../agent-*.jsonl
 //
 // Project is the first path segment under the root (e.g. "-home-user-proj").
-func discoverClaudeS3(root string) []DiscoveredFile {
-	return s3PrefixScan(root, s3SessionScanner{
+func claudeS3Scanner() S3SessionScanner {
+	return S3SessionScanner{
 		Agent:    AgentClaude,
 		Keep:     keepClaudeS3Session,
 		Project:  func(_ string, segs []string) string { return segs[0] },
 		Sidecars: claudeS3SidecarObjects,
-	})
+	}
+}
+
+func discoverClaudeS3(root string) []DiscoveredFile {
+	return s3PrefixScan(root, claudeS3Scanner())
 }
 
 // claudeS3SubagentTranscriptPaths lists candidate subagent transcript objects,
@@ -528,13 +532,17 @@ func claudeS3SidecarObjects(uri string, all []S3Object) []S3Object {
 // discoverCodexS3 lists Codex rollout-*.jsonl under an s3:// sessions root
 // (any depth — Codex nests under 2026/MM/DD/). Project is derived from
 // session content, so it is left empty here, as in the local path.
-func discoverCodexS3(root string) []DiscoveredFile {
-	return s3PrefixScan(root, s3SessionScanner{
+func codexS3Scanner() S3SessionScanner {
+	return S3SessionScanner{
 		Agent: AgentCodex,
 		Keep: func(_ string, segs []string) bool {
 			return isCodexSessionFilename(segs[len(segs)-1])
 		},
-	})
+	}
+}
+
+func discoverCodexS3(root string) []DiscoveredFile {
+	return s3PrefixScan(root, codexS3Scanner())
 }
 
 // FindCodexS3ParentSessionURI locates one explicitly named parent rollout
@@ -667,4 +675,16 @@ func s3URIWithLast(parts []string, last string) string {
 	out = append(out, parts...)
 	out = append(out, last)
 	return "s3://" + strings.Join(out, "/")
+}
+
+func codexS3TempRelParts(parts []string) []string {
+	for i, part := range parts {
+		if part == "sessions" || part == "archived_sessions" {
+			return parts[i:]
+		}
+	}
+	if len(parts) == 0 {
+		return parts
+	}
+	return append([]string{"sessions"}, parts...)
 }

--- a/internal/parser/s3source_test.go
+++ b/internal/parser/s3source_test.go
@@ -110,7 +110,7 @@ func TestS3PrefixScanGeneralizesByScanner(t *testing.T) {
 		}, nil
 	}
 
-	got := s3PrefixScan(root, s3SessionScanner{
+	got := s3PrefixScan(root, S3SessionScanner{
 		Agent: AgentQwen,
 		Keep: func(rel string, _ []string) bool {
 			return strings.HasSuffix(rel, ".jsonl")

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -9558,12 +9558,18 @@ func (e *Engine) processFile(
 
 	// Every registered agent is provider-authoritative, so processProviderFile
 	// owns all local-file processing. The only sources that fall through are
-	// s3:// Claude/Codex objects, which bypass the provider (its source sets
-	// read local files) and use the legacy S3 sync path. Anything else is an
-	// unrecognized agent type.
+	// s3:// objects for providers that declare S3Discovery, which bypass the
+	// provider (its source sets read local files) and use the dedicated S3
+	// sync path. Anything else is an unrecognized agent type.
 	if !strings.HasPrefix(file.Path, "s3://") {
 		return processResult{
 			err: fmt.Errorf("unknown agent type: %s", file.Agent),
+		}
+	}
+
+	if !parser.AgentSupportsS3Discovery(file.Agent) {
+		return processResult{
+			err: fmt.Errorf("unsupported s3 agent type: %s", file.Agent),
 		}
 	}
 
@@ -9609,14 +9615,7 @@ func (e *Engine) processFile(
 	}
 
 	var res processResult
-	switch file.Agent {
-	case parser.AgentClaude, parser.AgentCodex:
-		res = e.processS3Session(ctx, file, info)
-	default:
-		res = processResult{
-			err: fmt.Errorf("unsupported s3 agent type: %s", file.Agent),
-		}
-	}
+	res = e.processS3Session(ctx, file, info)
 	res.cacheSkip = cacheSkip
 	res.mtime = mtime
 	res.sourceFingerprint = sourceFingerprint
@@ -9696,7 +9695,7 @@ func (e *Engine) processProviderFile(
 		return processResult{}, false
 	}
 	// S3 sources are not provider-owned: the provider source sets read local
-	// files, so s3:// paths use the legacy S3 sync path (processS3Session),
+	// files, so s3:// paths use the dedicated S3 sync path (processS3Session),
 	// which handles object fetch, fingerprinting, and per-agent skip logic.
 	if strings.HasPrefix(file.Path, "s3://") {
 		return processResult{}, false

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -69,51 +69,11 @@ func applyIDPrefixToParsedResult(
 }
 
 func safeS3TempRelPath(file parser.DiscoveredFile) (string, error) {
-	trimmed := strings.TrimPrefix(file.Path, "s3://")
-	parts := strings.Split(trimmed, "/")
-	relParts := parts
-	if len(parts) > 1 {
-		relParts = parts[1:]
-	}
-	if file.Agent == parser.AgentClaude {
-		for i := 0; i+1 < len(parts); i++ {
-			if parts[i] == "raw" && parts[i+1] == "claude" {
-				relParts = parts[i+2:]
-				break
-			}
-		}
-	}
-	if file.Agent == parser.AgentCodex {
-		for i := 0; i+1 < len(parts); i++ {
-			if parts[i] == "raw" && parts[i+1] == "codex" {
-				relParts = parts[i+2:]
-				break
-			}
-		}
-		relParts = codexS3TempRelParts(relParts)
-	}
-	if len(relParts) == 0 {
+	p, ok := s3ProviderFor(file.Agent)
+	if !ok {
 		return "", fmt.Errorf("unsafe s3 object name: %q", file.Path)
 	}
-	for _, part := range relParts {
-		if part == "" || part == "." || part == ".." ||
-			strings.ContainsAny(part, `\/`) {
-			return "", fmt.Errorf("unsafe s3 object name: %q", file.Path)
-		}
-	}
-	return filepath.Join(relParts...), nil
-}
-
-func codexS3TempRelParts(parts []string) []string {
-	for i, part := range parts {
-		if part == "sessions" || part == "archived_sessions" {
-			return parts[i:]
-		}
-	}
-	if len(parts) == 0 {
-		return parts
-	}
-	return append([]string{"sessions"}, parts...)
+	return p.S3TempRelPath(file.Path)
 }
 
 func hydrateS3CodexSessionIndex(sessionPath, sessionURI string) (string, error) {
@@ -214,7 +174,7 @@ func hydrateS3CodexParent(
 	return true
 }
 
-// processS3Session reads a Claude/Codex session JSONL directly from object
+// processS3Session reads a session JSONL directly from object
 // storage (in-process, no persistent local mirror): download the object's
 // bytes, buffer them to a transient temp file so the existing path-based
 // parsers (incremental offsets, subagent layout) work unchanged, run the
@@ -288,6 +248,26 @@ func (e *Engine) processS3Session(
 				}
 			}
 		}
+	default:
+		rawID := ""
+		if p, ok := s3ProviderFor(file.Agent); ok {
+			rawID = p.S3SessionID(file.Path)
+		}
+		if rawID != "" {
+			fullID := applyIDPrefixToID(idPrefix, rawID)
+			if !sourceChanged &&
+				e.shouldSkipFileWithPrefix(
+					idPrefix, rawID, sourceInfo, sourceFingerprint,
+				) &&
+				e.db.GetSessionFilePath(fullID) == file.Path {
+				sess, _ := e.db.GetSession(ctx, fullID)
+				if sess != nil &&
+					sess.Project != "" &&
+					!parser.NeedsProjectReparse(sess.Project) {
+					return processResult{skip: true}
+				}
+			}
+		}
 	}
 
 	relPath, err := safeS3TempRelPath(file)
@@ -351,6 +331,16 @@ func (e *Engine) processS3Session(
 		}
 		if indexPath != "" {
 			defer parser.EvictCodexSessionIndex(indexPath)
+		}
+	default:
+		configuredRoot := ""
+		if file.ProviderSource != nil {
+			configuredRoot = file.ProviderSource.ConfiguredRoot
+		}
+		if p, ok := s3ProviderFor(file.Agent); ok {
+			if err := p.S3PostFetchHydrate(dir, tmp, configuredRoot, file.Path); err != nil {
+				return processResult{err: err, noCacheSkip: true, retentionLease: lease}
+			}
 		}
 	}
 	res, err := e.parseMaterializedS3Source(ctx, file, dir, tmp)

--- a/internal/sync/s3_source.go
+++ b/internal/sync/s3_source.go
@@ -17,7 +17,12 @@ var (
 	statS3Object        = parser.StatS3Object
 	statClaudeS3Session = parser.StatClaudeS3Session
 	statCodexS3Session  = parser.StatCodexS3Session
+	lookupS3Provider    = parser.S3ProviderFor
 )
+
+func s3ProviderFor(agent parser.AgentType) (parser.S3Provider, bool) {
+	return lookupS3Provider(agent)
+}
 
 func s3SourceFileInfo(file parser.DiscoveredFile) (os.FileInfo, error) {
 	size := file.SourceSize
@@ -52,35 +57,31 @@ func s3SourceFingerprint(file parser.DiscoveredFile) string {
 }
 
 func statS3SourceObject(file parser.DiscoveredFile) (parser.S3Object, error) {
-	stat := statS3Object
+	// Keep Claude/Codex package-level hooks so existing tests can stub
+	// sidecar-aware stats without replacing the provider.
 	switch file.Agent {
 	case parser.AgentClaude:
-		stat = statClaudeS3Session
+		return statClaudeS3Session(file.Path)
 	case parser.AgentCodex:
-		stat = statCodexS3Session
+		return statCodexS3Session(file.Path)
 	}
-	return stat(file.Path)
+	p, ok := s3ProviderFor(file.Agent)
+	if !ok {
+		return parser.S3Object{}, fmt.Errorf("unsupported s3 agent type: %s", file.Agent)
+	}
+	return p.S3StatSession(file.Path)
 }
 
 func s3DiscoveredSessionID(file parser.DiscoveredFile) string {
-	switch file.Agent {
-	case parser.AgentClaude:
-		id := claudeSessionIDFromPath(file.Path)
-		if id == "" {
-			return ""
-		}
-		return applyIDPrefixToID(s3SessionIDPrefix(file.Machine), id)
-	case parser.AgentCodex:
-		uuid := parser.CodexSessionUUIDFromFilename(path.Base(file.Path))
-		if uuid == "" {
-			return ""
-		}
-		return applyIDPrefixToID(
-			s3SessionIDPrefix(file.Machine), "codex:"+uuid,
-		)
-	default:
+	p, ok := s3ProviderFor(file.Agent)
+	if !ok {
 		return ""
 	}
+	id := p.S3SessionID(file.Path)
+	if id == "" {
+		return ""
+	}
+	return applyIDPrefixToID(s3SessionIDPrefix(file.Machine), id)
 }
 
 func (e *Engine) s3SourceMetadataChanged(file parser.DiscoveredFile) bool {
@@ -320,7 +321,7 @@ func s3MachineFromRoot(root string) string {
 }
 
 func isS3AgentRootSegment(seg string) bool {
-	return seg == "claude" || seg == "codex"
+	return parser.AgentSupportsS3Discovery(parser.AgentType(seg))
 }
 
 func s3RelFromRoot(root, uri string) (string, bool) {
@@ -354,9 +355,13 @@ func (e *Engine) hydrateS3DiscoveredFile(
 		if file.Machine == "" {
 			file.Machine = s3MachineFromRoot(root)
 		}
-		if file.Project == "" && file.Agent == parser.AgentClaude {
-			if first, _, ok := strings.Cut(rel, "/"); ok {
-				file.Project = first
+		if file.Project == "" {
+			if p, ok := s3ProviderFor(file.Agent); ok {
+				scan := p.S3Scanner()
+				if scan.Project != nil && strings.Contains(rel, "/") {
+					segs := strings.Split(rel, "/")
+					file.Project = scan.Project(rel, segs)
+				}
 			}
 		}
 		break
@@ -367,14 +372,8 @@ func (e *Engine) hydrateS3DiscoveredFile(
 		}
 	}
 	if file.SourceMtime == 0 {
-		stat := statS3Object
-		switch file.Agent {
-		case parser.AgentClaude:
-			stat = statClaudeS3Session
-		case parser.AgentCodex:
-			stat = statCodexS3Session
-		}
-		if obj, err := stat(file.Path); err == nil {
+		obj, err := statS3SourceObject(*file)
+		if err == nil {
 			file.SourceSize = obj.Size
 			file.SourceMtime = obj.LastModified.UnixNano()
 			file.SourceFingerprint = obj.Fingerprint

--- a/internal/sync/s3_source_test.go
+++ b/internal/sync/s3_source_test.go
@@ -1169,6 +1169,95 @@ func TestSyncS3MachineFromRootUsesRawAgentLayout(t *testing.T) {
 		"laptop",
 		s3MachineFromRoot("s3://bucket/archive/raw/laptop/raw/claude"),
 	)
+	assert.Equal(
+		t,
+		"laptop",
+		s3MachineFromRoot("s3://bucket/archive/raw/laptop/raw/cursor"),
+	)
+	assert.Empty(t, s3MachineFromRoot("s3://bucket/archive/raw/laptop/raw/qwen"))
+}
+
+func TestS3DiscoveredSessionIDUsesProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		file parser.DiscoveredFile
+		want string
+	}{
+		{
+			name: "claude",
+			file: parser.DiscoveredFile{
+				Agent:   parser.AgentClaude,
+				Path:    "s3://bucket/laptop/raw/claude/proj/sess.jsonl",
+				Machine: "laptop",
+			},
+			want: "laptop~sess",
+		},
+		{
+			name: "codex",
+			file: parser.DiscoveredFile{
+				Agent: parser.AgentCodex,
+				Path: "s3://bucket/laptop/raw/codex/2026/06/24/" +
+					"rollout-2026-06-24T00-00-00-11111111-1111-4111-8111-111111111111.jsonl",
+				Machine: "laptop",
+			},
+			want: "laptop~codex:11111111-1111-4111-8111-111111111111",
+		},
+		{
+			name: "cursor",
+			file: parser.DiscoveredFile{
+				Agent:   parser.AgentCursor,
+				Path:    "s3://bucket/laptop/raw/cursor/proj/abc.jsonl",
+				Machine: "laptop",
+			},
+			want: "laptop~cursor:abc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, s3DiscoveredSessionID(tt.file))
+		})
+	}
+}
+
+func TestSafeS3TempRelPathUsesProvider(t *testing.T) {
+	got, err := safeS3TempRelPath(parser.DiscoveredFile{
+		Agent: parser.AgentCursor,
+		Path:  "s3://bucket/laptop/raw/cursor/demo-proj/abc.jsonl",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("demo-proj", "abc.jsonl"), got)
+
+	got, err = safeS3TempRelPath(parser.DiscoveredFile{
+		Agent: parser.AgentClaude,
+		Path:  "s3://bucket/laptop/raw/claude/demo-proj/sess.jsonl",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("demo-proj", "sess.jsonl"), got)
+}
+
+func TestIsS3AgentRootSegmentUsesCapability(t *testing.T) {
+	assert.True(t, isS3AgentRootSegment("claude"))
+	assert.True(t, isS3AgentRootSegment("codex"))
+	assert.True(t, isS3AgentRootSegment("cursor"))
+	assert.False(t, isS3AgentRootSegment("qwen"))
+	assert.False(t, isS3AgentRootSegment("traex"))
+}
+
+func TestHydrateS3DiscoveredFileDerivesCursorProject(t *testing.T) {
+	e := &Engine{
+		db: openTestDB(t),
+		agentDirs: map[parser.AgentType][]string{
+			parser.AgentCursor: {"s3://bucket/laptop/raw/cursor"},
+		},
+	}
+	file := parser.DiscoveredFile{
+		Agent:       parser.AgentCursor,
+		Path:        "s3://bucket/laptop/raw/cursor/demo-proj/abc.jsonl",
+		SourceMtime: 1,
+	}
+	e.hydrateS3DiscoveredFile(context.Background(), "laptop~cursor:abc", &file)
+	assert.Equal(t, "laptop", file.Machine)
+	assert.Equal(t, "demo-proj", file.Project)
 }
 
 func TestSyncSingleSessionS3PreservesStoredMachine(t *testing.T) {

--- a/internal/sync/s3_test.go
+++ b/internal/sync/s3_test.go
@@ -106,6 +106,61 @@ func TestProcessS3CodexNamespacesIDsBySourceMachine(t *testing.T) {
 	assert.Nil(t, raw)
 }
 
+func TestProcessS3CursorNamespacesIDsBySourceMachine(t *testing.T) {
+	database := openTestDB(t)
+	path := "s3://bucket/laptop/raw/cursor/demo-proj/shared-id.jsonl"
+	content := "user:\nHello from Cursor\nassistant:\nHi there.\n"
+
+	oldFetch := fetchS3Object
+	t.Cleanup(func() { fetchS3Object = oldFetch })
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		if got != path {
+			return nil, missingS3ObjectError()
+		}
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+
+	e := &Engine{db: database, machine: "central"}
+	res := e.processFile(context.Background(), parser.DiscoveredFile{
+		Agent:       parser.AgentCursor,
+		Path:        path,
+		Project:     "demo-proj",
+		Machine:     "laptop",
+		SourceSize:  int64(len(content)),
+		SourceMtime: time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC).UnixNano(),
+	})
+	require.NoError(t, res.err)
+	require.Len(t, res.results, 1)
+
+	written, _, failed, _ := e.writeBatch([]pendingWrite{{
+		sess: res.results[0].Session,
+		msgs: res.results[0].Messages,
+	}}, syncWriteDefault, false)
+	require.Equal(t, 1, written)
+	require.Equal(t, 0, failed)
+
+	sess, err := database.GetSessionFull(context.Background(), "laptop~cursor:shared-id")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "laptop", sess.Machine)
+	assert.Equal(t, "cursor", sess.Agent)
+	assert.Equal(t, path, derefString(sess.FilePath))
+	raw, err := database.GetSessionFull(context.Background(), "cursor:shared-id")
+	require.NoError(t, err)
+	assert.Nil(t, raw)
+}
+
+func TestProcessFileS3UnsupportedAgent(t *testing.T) {
+	e := &Engine{db: openTestDB(t), machine: "central"}
+	res := e.processFile(context.Background(), parser.DiscoveredFile{
+		Agent:       parser.AgentGrok,
+		Path:        "s3://bucket/laptop/raw/grok/proj/sess.jsonl",
+		SourceMtime: 1,
+	})
+	require.Error(t, res.err)
+	assert.Contains(t, res.err.Error(), "unsupported s3 agent type")
+}
+
 func TestProcessS3CodexForkRetriesUntilParentAvailable(t *testing.T) {
 	database := openTestDB(t)
 	const root = "s3://bucket/laptop/raw/codex"


### PR DESCRIPTION
## Summary

- Adds an `S3Provider` interface (with `DefaultS3Provider` for single-file agents) so S3 session roots are no longer hardcoded to Claude and Codex.
- Enables Cursor S3 discovery for `s3://.../<machine>/raw/cursor/<project>/<uuid>.jsonl`, which is what a central archive already stores.
- Claude and Codex keep their sidecar, fork, and session-index behavior. Skip-cache gates that depend on engine internals stay special-cased.
- Docker publishes branch and SHA tags so this fork can ship a GHCR image (`ghcr.io/durandom/agentsview`) before a version tag.

Reviewers should start at `internal/parser/s3_provider.go`, then the Cursor discover/watch changes and the remaining switch points in `internal/sync/s3.go` and `internal/sync/s3_source.go`.

Made with [Cursor](https://cursor.com)