### PR TITLE
feat(rawsync): add device authentication core

### DIFF
--- a/docs/hosted-raw-sync.md
+++ b/docs/hosted-raw-sync.md
@@ -1,0 +1,123 @@
+---
+title: Hosted Raw Sync
+description: Architecture, security boundaries, and delivery status for raw-first hosted sync
+---
+
+Hosted raw sync is the planned, in-development path for sending original agent
+source artifacts to a hosted AgentsView service. The server will keep the
+authoritative raw generation, then derive PostgreSQL sessions and embeddings
+from it.
+
+```mermaid
+flowchart LR
+    Watcher["Laptop watcher"] -->|"authenticated raw upload"| Custody["Immutable raw custody"]
+    Custody --> Parser["Server parsing"]
+    Parser --> PostgreSQL["PostgreSQL projection"]
+    PostgreSQL --> Embeddings["Server embeddings"]
+```
+
+This moves long-running parsing and embedding work off laptops and gives the
+server enough source material to reparse after parser fixes or rebuild derived
+data after loss.
+
+!!! warning "Not available for use yet"
+
+    AgentsView has internal raw-custody and device-authentication foundations, but
+    it does not yet expose enrollment or upload endpoints, a laptop uploader,
+    server-side parsing workers, or server-owned embeddings. There is no command or
+    configuration setting to enable hosted raw sync.
+
+    The existing [`agentsview pg push`](/pg-sync/) workflow remains supported and
+    unchanged. It parses sessions locally and can build embeddings locally before
+    pushing derived rows and vectors to PostgreSQL.
+
+The tracked delivery sequence and production acceptance criteria live in
+[GitHub issue #1352](https://github.com/kenn-io/agentsview/issues/1352).
+
+## Delivery status
+
+| Layer                  | Status                                                                             | Current boundary                                                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Raw custody            | Foundation implemented in [#1396](https://github.com/kenn-io/agentsview/pull/1396) | Validated objects, canonical manifests, durable receipts, source-head fencing, and parse-job creation                       |
+| Device authentication  | Foundation implemented in [#1459](https://github.com/kenn-io/agentsview/pull/1459) | One-time device credentials, scoped short-lived tokens, server-derived identity, and revocation                             |
+| HTTP raw transport     | Not implemented                                                                    | Enrollment, token, negotiation, resumable upload, commit, and status routes remain to be added                              |
+| Laptop capture         | Not implemented                                                                    | Provider watching, append fast paths, SQLite snapshots, spooling, checkpoints, and reconciliation remain future client work |
+| Server derivation      | Not implemented                                                                    | Manifest materialization, parsing, transactional PostgreSQL projection, and embeddings are not running                      |
+| Operations and cutover | Not implemented                                                                    | Retention, garbage collection, disaster rebuilds, rollout controls, and migration from `pg push` remain future work         |
+
+Because #1459 implements authentication but not HTTP handlers, the broader
+“device enrollment and authenticated raw transport” delivery item in #1352
+remains incomplete.
+
+## Raw custody contract
+
+The custody foundation accepts a complete logical generation of one provider
+source. A generation is represented by a canonical manifest containing:
+
+- the provider, configured source-root identity, and logical source key;
+- a capture identity and capture time;
+- either a snapshot with ordered file-object references or a tombstone; and
+- the expected receipt for the preceding accepted generation.
+
+The custody API accepts authenticated tenant and immutable device identity
+separately from the manifest. Future HTTP handlers must derive that identity
+through device authentication. Canonicalization binds it into the manifest
+envelope rather than trusting client-supplied manifest fields. The canonical
+JSON digest becomes the manifest ID.
+
+Raw objects are identified by exact SHA-256 and byte length. Custody is
+tenant-scoped, verifies content before registering it, treats an identical retry
+as a no-op, and rejects conflicting content. Providers that AgentsView does not
+recognize or excludes from remote sync are rejected before their bytes enter
+custody.
+
+A manifest can commit only after every referenced object exists and verifies.
+The PostgreSQL acceptance transaction then:
+
+1. checks the expected parent receipt against the current source head;
+1. records the manifest, file entries, and ordered object references;
+1. assigns a monotonically increasing generation and durable receipt;
+1. creates the corresponding parse job; and
+1. advances the source head.
+
+Repeating the same capture returns its existing receipt. Reusing a capture
+identity for different content or committing against a stale parent fails
+closed. Accepted manifest metadata is append-only. PostgreSQL holds custody
+metadata and processing state; the object store holds the authoritative raw
+bytes and canonical manifests.
+
+## Device authentication contract
+
+Enrollment creates an immutable device ID and a random credential. The clear
+credential is returned once; PostgreSQL retains only its SHA-256 digest.
+
+An active device exchanges that credential for an opaque, short-lived token.
+Tokens can be restricted to one or more fixed operations:
+
+- missing-object negotiation;
+- object upload;
+- manifest commit; and
+- status reads.
+
+Token authentication derives the tenant and device from server-side records and
+checks the required scope and expiry. PostgreSQL stores only the token digest.
+Revoking a device prevents new token issuance and immediately makes its
+outstanding tokens unusable. A human-readable device name is display metadata,
+not authorization identity.
+
+## Security and deployment boundary
+
+Raw provider files can contain prompts, responses, tool activity, paths, and
+other sensitive data. Hosted raw sync is not end-to-end encrypted: the server
+must be able to read retained source files to parse them.
+
+The implemented foundations isolate object and metadata identities by tenant and
+do not deduplicate across tenants. A production deployment must also provide TLS
+in transit, encryption at rest for object storage, PostgreSQL, backups, and
+worker scratch space, plus access controls around device enrollment and
+revocation. PostgreSQL row-level security remains a planned defense-in-depth
+layer; the current foundation does not configure it.
+
+Do not build integrations against the internal Go packages or raw PostgreSQL
+tables yet. The public HTTP protocol, operator controls, compatibility policy,
+and recovery tooling will be documented when those entry points exist.

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -14,6 +14,14 @@ pushes its own sessions; `pg serve` reads from the shared database.
 The resulting UI includes the session browser, analytics dashboard,
 search, and, as of 0.23.0, the Usage dashboard as well.
 
+!!! note "Separate hosted raw-sync work"
+
+    [Hosted Raw Sync](/hosted-raw-sync/) is a separate, in-development path in
+    which a hosted server retains original provider artifacts and performs
+    parsing and embedding. Its internal custody and device-authentication
+    foundations do not change the `pg push`, `pg push --watch`, or `pg serve`
+    behavior documented on this page.
+
 ## Quick Start
 
 ### 1. Configure PostgreSQL

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -37,6 +37,7 @@ nav = [
   {"Artifact Folder Sync" = "artifact-sync.md"},
   {"Filesystem Session Sync" = "filesystem-sync.md"},
   {"PostgreSQL Sync" = "pg-sync.md"},
+  {"Hosted Raw Sync (In Development)" = "hosted-raw-sync.md"},
   {"DuckDB Mirror" = "duckdb.md"},
 ]
 

--- a/internal/postgres/raw_device_auth_store.go
+++ b/internal/postgres/raw_device_auth_store.go
@@ -1,0 +1,229 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// RawDeviceAuthStore persists raw-transport devices and short-lived tokens.
+type RawDeviceAuthStore struct {
+	db *sql.DB
+}
+
+// NewRawDeviceAuthStore constructs a PostgreSQL raw device auth store.
+func NewRawDeviceAuthStore(db *sql.DB) (*RawDeviceAuthStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("%w: PostgreSQL connection is required", rawsync.ErrInvalid)
+	}
+	return &RawDeviceAuthStore{db: db}, nil
+}
+
+// EnrollDevice records only the device credential digest.
+func (s *RawDeviceAuthStore) EnrollDevice(
+	ctx context.Context,
+	record rawsync.DeviceEnrollmentRecord,
+) error {
+	if err := validateRawDeviceEnrollment(record); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO raw_devices (
+			device_id, tenant_id, display_name, credential_sha256, created_at
+		) VALUES ($1, $2, $3, $4, $5)`,
+		record.Identity.DeviceID,
+		record.Identity.TenantID,
+		record.DisplayName,
+		record.CredentialDigest[:],
+		record.CreatedAt,
+	)
+	if err != nil {
+		if rawDeviceAuthUniqueViolation(err) {
+			return fmt.Errorf("enrolling raw sync device: %w", rawsync.ErrConflict)
+		}
+		return fmt.Errorf("enrolling raw sync device: %w", err)
+	}
+	return nil
+}
+
+// IssueToken atomically verifies one active device credential and records the token.
+func (s *RawDeviceAuthStore) IssueToken(
+	ctx context.Context,
+	deviceID string,
+	credential rawsync.CredentialDigest,
+	token rawsync.DeviceTokenRecord,
+) (rawsync.AuthIdentity, error) {
+	if err := validateRawDeviceLookupID(deviceID); err != nil {
+		return rawsync.AuthIdentity{}, err
+	}
+	if err := validateRawDeviceTokenRecord(token); err != nil {
+		return rawsync.AuthIdentity{}, err
+	}
+	var identity rawsync.AuthIdentity
+	err := s.db.QueryRowContext(ctx, `
+		WITH active_device AS (
+			SELECT tenant_id, device_id
+			FROM raw_devices
+			WHERE device_id = $1
+				AND credential_sha256 = $2
+				AND revoked_at IS NULL
+		)
+		INSERT INTO raw_device_tokens (
+			token_sha256, tenant_id, device_id, scope_bits, issued_at, expires_at
+		)
+		SELECT $3, tenant_id, device_id, $4, $5, $6
+		FROM active_device
+		RETURNING tenant_id, device_id`,
+		deviceID,
+		credential[:],
+		token.Digest[:],
+		int16(token.Scopes),
+		token.IssuedAt,
+		token.ExpiresAt,
+	).Scan(&identity.TenantID, &identity.DeviceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return rawsync.AuthIdentity{}, rawsync.ErrUnauthorized
+	}
+	if err != nil {
+		if rawDeviceAuthUniqueViolation(err) {
+			return rawsync.AuthIdentity{}, fmt.Errorf(
+				"issuing raw sync token: %w", rawsync.ErrConflict,
+			)
+		}
+		return rawsync.AuthIdentity{}, fmt.Errorf("issuing raw sync token: %w", err)
+	}
+	return identity, nil
+}
+
+// AuthenticateToken derives identity only from an active, unexpired scoped token.
+func (s *RawDeviceAuthStore) AuthenticateToken(
+	ctx context.Context,
+	digest rawsync.TokenDigest,
+	required rawsync.DeviceTokenScope,
+	now time.Time,
+) (rawsync.AuthIdentity, error) {
+	if !rawDeviceAuthSingleScope(required) || now.IsZero() {
+		return rawsync.AuthIdentity{}, fmt.Errorf(
+			"%w: invalid raw sync token authentication request", rawsync.ErrInvalid,
+		)
+	}
+	var identity rawsync.AuthIdentity
+	err := s.db.QueryRowContext(ctx, `
+		SELECT devices.tenant_id, devices.device_id
+		FROM raw_device_tokens AS tokens
+		JOIN raw_devices AS devices
+			ON devices.tenant_id = tokens.tenant_id
+			AND devices.device_id = tokens.device_id
+		WHERE tokens.token_sha256 = $1
+			AND tokens.expires_at > $2
+			AND devices.revoked_at IS NULL
+			AND (tokens.scope_bits & $3) = $3`,
+		digest[:], now.UTC(), int16(required),
+	).Scan(&identity.TenantID, &identity.DeviceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return rawsync.AuthIdentity{}, rawsync.ErrUnauthorized
+	}
+	if err != nil {
+		return rawsync.AuthIdentity{}, fmt.Errorf("authenticating raw sync token: %w", err)
+	}
+	return identity, nil
+}
+
+// RevokeDevice invalidates the device once; token rows remain as audit history.
+func (s *RawDeviceAuthStore) RevokeDevice(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	revokedAt time.Time,
+) (bool, error) {
+	if err := validateRawDeviceAuthIdentity(identity); err != nil {
+		return false, err
+	}
+	if revokedAt.IsZero() {
+		return false, fmt.Errorf("%w: revocation time is required", rawsync.ErrInvalid)
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE raw_devices
+		SET revoked_at = $3
+		WHERE tenant_id = $1 AND device_id = $2 AND revoked_at IS NULL`,
+		identity.TenantID, identity.DeviceID, revokedAt.UTC(),
+	)
+	if err != nil {
+		return false, fmt.Errorf("revoking raw sync device: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("checking raw sync device revocation: %w", err)
+	}
+	return updated == 1, nil
+}
+
+func validateRawDeviceEnrollment(record rawsync.DeviceEnrollmentRecord) error {
+	if err := validateRawDeviceAuthIdentity(record.Identity); err != nil {
+		return err
+	}
+	if record.DisplayName == "" || len(record.DisplayName) > 256 ||
+		!utf8.ValidString(record.DisplayName) ||
+		strings.TrimSpace(record.DisplayName) != record.DisplayName {
+		return fmt.Errorf("%w: device display name is not canonical", rawsync.ErrInvalid)
+	}
+	for _, r := range record.DisplayName {
+		if unicode.IsControl(r) {
+			return fmt.Errorf(
+				"%w: device display name contains a control character", rawsync.ErrInvalid,
+			)
+		}
+	}
+	if record.CreatedAt.IsZero() || record.CreatedAt != record.CreatedAt.UTC() ||
+		record.RevokedAt != nil {
+		return fmt.Errorf("%w: device enrollment time is not canonical", rawsync.ErrInvalid)
+	}
+	return nil
+}
+
+func validateRawDeviceTokenRecord(token rawsync.DeviceTokenRecord) error {
+	if !token.Scopes.Allows(token.Scopes) || token.Identity != (rawsync.AuthIdentity{}) ||
+		token.IssuedAt.IsZero() || token.IssuedAt != token.IssuedAt.UTC() ||
+		token.ExpiresAt != token.ExpiresAt.UTC() ||
+		!token.ExpiresAt.After(token.IssuedAt) {
+		return fmt.Errorf("%w: raw sync token record is not canonical", rawsync.ErrInvalid)
+	}
+	return nil
+}
+
+func validateRawDeviceLookupID(deviceID string) error {
+	_, err := rawsync.NewAuthIdentity("auth-lookup", deviceID)
+	return err
+}
+
+func validateRawDeviceAuthIdentity(identity rawsync.AuthIdentity) error {
+	validated, err := rawsync.NewAuthIdentity(identity.TenantID, identity.DeviceID)
+	if err != nil || validated != identity {
+		return fmt.Errorf("%w: authenticated identity is not canonical", rawsync.ErrInvalid)
+	}
+	return nil
+}
+
+func rawDeviceAuthSingleScope(scope rawsync.DeviceTokenScope) bool {
+	switch scope {
+	case rawsync.ScopeNegotiate, rawsync.ScopeUpload,
+		rawsync.ScopeCommit, rawsync.ScopeStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+func rawDeviceAuthUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr != nil && pgErr.Code == "23505"
+}
+
+var _ rawsync.DeviceAuthStore = (*RawDeviceAuthStore)(nil)

--- a/internal/postgres/raw_device_auth_store_pgtest_test.go
+++ b/internal/postgres/raw_device_auth_store_pgtest_test.go
@@ -1,0 +1,114 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestRawDeviceAuthStoreLifecycleAndTenantIsolation(t *testing.T) {
+	pg, store := newRawDeviceAuthTestStore(t)
+	service, err := rawsync.NewDeviceAuthService(store, time.Hour)
+	require.NoError(t, err)
+
+	first, err := service.EnrollDevice(t.Context(), "tenant-a", "work laptop")
+	require.NoError(t, err)
+	second, err := service.EnrollDevice(t.Context(), "tenant-b", "build host")
+	require.NoError(t, err)
+
+	var storedTenant, storedName, storedDigest string
+	err = pg.QueryRowContext(t.Context(), `
+		SELECT tenant_id, display_name, encode(credential_sha256, 'hex')
+		FROM raw_devices
+		WHERE device_id = $1`, first.Identity.DeviceID).Scan(
+		&storedTenant, &storedName, &storedDigest,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", storedTenant)
+	assert.Equal(t, "work laptop", storedName)
+	wantCredentialDigest := sha256.Sum256([]byte(first.Credential))
+	assert.Equal(t, hex.EncodeToString(wantCredentialDigest[:]), storedDigest)
+	assert.NotContains(t, storedDigest, first.Credential)
+
+	_, err = service.IssueToken(
+		t.Context(), first.Identity.DeviceID, second.Credential, rawsync.ScopeAll,
+	)
+	assert.ErrorIs(t, err, rawsync.ErrUnauthorized)
+	assert.NotContains(t, err.Error(), second.Credential)
+
+	firstToken, err := service.IssueToken(
+		t.Context(), first.Identity.DeviceID, first.Credential, rawsync.ScopeAll,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, first.Identity, firstToken.Identity)
+	for _, scope := range []rawsync.DeviceTokenScope{
+		rawsync.ScopeNegotiate,
+		rawsync.ScopeUpload,
+		rawsync.ScopeCommit,
+		rawsync.ScopeStatus,
+	} {
+		identity, authErr := service.AuthenticateToken(t.Context(), firstToken.Token, scope)
+		require.NoError(t, authErr)
+		assert.Equal(t, first.Identity, identity)
+	}
+
+	tokenHash := sha256.Sum256([]byte(firstToken.Token))
+	_, err = store.AuthenticateToken(
+		t.Context(), rawsync.TokenDigest(tokenHash), rawsync.ScopeStatus,
+		firstToken.ExpiresAt,
+	)
+	assert.ErrorIs(t, err, rawsync.ErrUnauthorized)
+
+	revoked, err := service.RevokeDevice(t.Context(), first.Identity)
+	require.NoError(t, err)
+	assert.True(t, revoked)
+	revoked, err = service.RevokeDevice(t.Context(), first.Identity)
+	require.NoError(t, err)
+	assert.False(t, revoked)
+
+	_, err = service.AuthenticateToken(t.Context(), firstToken.Token, rawsync.ScopeUpload)
+	assert.ErrorIs(t, err, rawsync.ErrUnauthorized)
+	_, err = service.IssueToken(
+		t.Context(), first.Identity.DeviceID, first.Credential, rawsync.ScopeUpload,
+	)
+	assert.ErrorIs(t, err, rawsync.ErrUnauthorized)
+
+	secondToken, err := service.IssueToken(
+		t.Context(), second.Identity.DeviceID, second.Credential, rawsync.ScopeStatus,
+	)
+	require.NoError(t, err)
+	identity, err := service.AuthenticateToken(
+		t.Context(), secondToken.Token, rawsync.ScopeStatus,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, second.Identity, identity)
+
+	var tokenCount int
+	require.NoError(t, pg.QueryRowContext(
+		t.Context(), `SELECT count(*) FROM raw_device_tokens`,
+	).Scan(&tokenCount))
+	assert.Equal(t, 2, tokenCount,
+		"revocation keeps token audit rows while invalidating them through the device")
+}
+
+func newRawDeviceAuthTestStore(t *testing.T) (*sql.DB, *RawDeviceAuthStore) {
+	t.Helper()
+	pgURL := testPGURL(t)
+	cleanSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanSchemaTestPG(t, pgURL) })
+	pg, err := Open(pgURL, schemaTestSchema, true)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pg.Close()) })
+	require.NoError(t, EnsureSchema(t.Context(), pg, schemaTestSchema))
+	store, err := NewRawDeviceAuthStore(pg)
+	require.NoError(t, err)
+	return pg, store
+}

--- a/internal/postgres/raw_device_auth_store_test.go
+++ b/internal/postgres/raw_device_auth_store_test.go
@@ -1,0 +1,18 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRawDeviceAuthUniqueViolationRejectsTypedNil(t *testing.T) {
+	t.Parallel()
+
+	var pgErr *pgconn.PgError
+	var err error = pgErr
+	assert.NotPanics(t, func() {
+		assert.False(t, rawDeviceAuthUniqueViolation(err))
+	})
+}

--- a/internal/postgres/raw_ingest_schema.go
+++ b/internal/postgres/raw_ingest_schema.go
@@ -16,6 +16,32 @@ import (
 // combined with the other key columns. Composite keys therefore use fixed-size
 // SHA-256 digests of those values; the full text is stored beside them.
 const rawIngestDDL = `
+CREATE TABLE IF NOT EXISTS raw_devices (
+    device_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    display_name TEXT NOT NULL
+        CHECK (octet_length(display_name) BETWEEN 1 AND 256),
+    credential_sha256 BYTEA NOT NULL UNIQUE
+        CHECK (octet_length(credential_sha256) = 32),
+    created_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    UNIQUE (tenant_id, device_id),
+    CHECK (revoked_at IS NULL OR revoked_at >= created_at)
+);
+
+CREATE TABLE IF NOT EXISTS raw_device_tokens (
+    token_sha256 BYTEA PRIMARY KEY
+        CHECK (octet_length(token_sha256) = 32),
+    tenant_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    scope_bits SMALLINT NOT NULL CHECK (scope_bits BETWEEN 1 AND 15),
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    CHECK (expires_at > issued_at),
+    FOREIGN KEY (tenant_id, device_id)
+        REFERENCES raw_devices (tenant_id, device_id) ON DELETE RESTRICT
+);
+
 CREATE TABLE IF NOT EXISTS raw_objects (
     tenant_id TEXT NOT NULL,
     sha256 TEXT NOT NULL CHECK (sha256 ~ '^[0-9a-f]{64}$'),
@@ -138,6 +164,8 @@ CREATE INDEX IF NOT EXISTS idx_raw_ingest_jobs_ready
 CREATE INDEX IF NOT EXISTS idx_raw_ingest_jobs_lease
     ON raw_ingest_jobs (lease_expires_at, id)
     WHERE state = 'leased';
+CREATE INDEX IF NOT EXISTS idx_raw_device_tokens_expiry
+    ON raw_device_tokens (expires_at, tenant_id, device_id);
 `
 
 const rawIngestAppendOnlyDDL = `

--- a/internal/postgres/raw_ingest_schema_pgtest_test.go
+++ b/internal/postgres/raw_ingest_schema_pgtest_test.go
@@ -25,6 +25,8 @@ func TestEnsureSchemaCreatesRawIngestCustodyTables(t *testing.T) {
 	require.NoError(t, EnsureSchema(t.Context(), pg, schemaTestSchema))
 
 	for _, table := range []string{
+		"raw_devices",
+		"raw_device_tokens",
 		"raw_objects",
 		"raw_manifests",
 		"raw_manifest_entries",
@@ -43,6 +45,7 @@ func TestEnsureSchemaCreatesRawIngestCustodyTables(t *testing.T) {
 	}
 
 	for _, index := range []string{
+		"idx_raw_device_tokens_expiry",
 		"idx_raw_ingest_jobs_ready",
 		"idx_raw_ingest_jobs_lease",
 	} {
@@ -67,6 +70,14 @@ func TestRawIngestSchemaUsesTenantScopedKeys(t *testing.T) {
 	require.NoError(t, EnsureSchema(t.Context(), pg, schemaTestSchema))
 
 	wantDefinitions := map[string][]string{
+		"raw_devices": {
+			"PRIMARY KEY (device_id)",
+			"UNIQUE (tenant_id, device_id)",
+		},
+		"raw_device_tokens": {
+			"PRIMARY KEY (token_sha256)",
+			"FOREIGN KEY (tenant_id, device_id)",
+		},
 		"raw_objects": {
 			"PRIMARY KEY (tenant_id, sha256)",
 		},

--- a/internal/rawsync/device_auth.go
+++ b/internal/rawsync/device_auth.go
@@ -1,0 +1,289 @@
+package rawsync
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+var ErrUnauthorized = errors.New("raw sync authentication failed")
+
+const (
+	deviceIDPrefix     = "dev_"
+	credentialPrefix   = "avdc_"
+	tokenPrefix        = "avdt_"
+	deviceIDRandomSize = 16
+	secretRandomSize   = 32
+	secretEncodedSize  = 43
+	maxDeviceNameBytes = 256
+	maxDeviceTokenTTL  = 24 * time.Hour
+)
+
+// DeviceTokenScope is the fixed authorization surface for raw transport.
+type DeviceTokenScope uint8
+
+const (
+	ScopeNegotiate DeviceTokenScope = 1 << iota
+	ScopeUpload
+	ScopeCommit
+	ScopeStatus
+
+	ScopeAll = ScopeNegotiate | ScopeUpload | ScopeCommit | ScopeStatus
+)
+
+// Allows reports whether the set contains every required scope.
+func (s DeviceTokenScope) Allows(required DeviceTokenScope) bool {
+	return s.valid() && required.valid() && s&required == required
+}
+
+func (s DeviceTokenScope) valid() bool {
+	return s != 0 && s&^ScopeAll == 0
+}
+
+func (s DeviceTokenScope) single() bool {
+	return s.valid() && s&(s-1) == 0
+}
+
+// CredentialDigest is the only persisted form of a device credential.
+type CredentialDigest [sha256.Size]byte
+
+// TokenDigest is the only persisted form of an upload access token.
+type TokenDigest [sha256.Size]byte
+
+// DeviceEnrollmentRecord is the durable server-side device record.
+type DeviceEnrollmentRecord struct {
+	Identity         AuthIdentity
+	DisplayName      string
+	CredentialDigest CredentialDigest
+	CreatedAt        time.Time
+	RevokedAt        *time.Time
+}
+
+// DeviceTokenRecord is the durable server-side token record.
+type DeviceTokenRecord struct {
+	Digest    TokenDigest
+	Identity  AuthIdentity
+	Scopes    DeviceTokenScope
+	IssuedAt  time.Time
+	ExpiresAt time.Time
+}
+
+// DeviceEnrollment returns the credential exactly once to its caller.
+type DeviceEnrollment struct {
+	Identity    AuthIdentity
+	DisplayName string
+	Credential  string
+	CreatedAt   time.Time
+}
+
+// IssuedDeviceToken is a short-lived scoped raw-transport credential.
+type IssuedDeviceToken struct {
+	Token     string
+	Identity  AuthIdentity
+	Scopes    DeviceTokenScope
+	ExpiresAt time.Time
+}
+
+// DeviceAuthStore owns durable enrollment, token exchange, and revocation.
+type DeviceAuthStore interface {
+	EnrollDevice(context.Context, DeviceEnrollmentRecord) error
+	IssueToken(
+		context.Context, string, CredentialDigest, DeviceTokenRecord,
+	) (AuthIdentity, error)
+	AuthenticateToken(
+		context.Context, TokenDigest, DeviceTokenScope, time.Time,
+	) (AuthIdentity, error)
+	RevokeDevice(context.Context, AuthIdentity, time.Time) (bool, error)
+}
+
+// DeviceAuthService creates digest-only credentials and scoped access tokens.
+type DeviceAuthService struct {
+	store  DeviceAuthStore
+	ttl    time.Duration
+	random io.Reader
+	now    func() time.Time
+}
+
+// NewDeviceAuthService constructs the device authentication boundary.
+func NewDeviceAuthService(
+	store DeviceAuthStore,
+	tokenTTL time.Duration,
+) (*DeviceAuthService, error) {
+	if isNilServiceDependency(store) {
+		return nil, fmt.Errorf("%w: device auth store is required", ErrInvalid)
+	}
+	if tokenTTL <= 0 || tokenTTL > maxDeviceTokenTTL {
+		return nil, fmt.Errorf(
+			"%w: device token lifetime must be greater than zero and at most %s", ErrInvalid,
+			maxDeviceTokenTTL,
+		)
+	}
+	return &DeviceAuthService{
+		store: store, ttl: tokenTTL, random: rand.Reader, now: time.Now,
+	}, nil
+}
+
+// EnrollDevice creates an immutable device identity and one-time credential.
+func (s *DeviceAuthService) EnrollDevice(
+	ctx context.Context,
+	tenantID string,
+	displayName string,
+) (DeviceEnrollment, error) {
+	if err := validateOpaqueID("tenant", tenantID); err != nil {
+		return DeviceEnrollment{}, err
+	}
+	if err := validateDeviceDisplayName(displayName); err != nil {
+		return DeviceEnrollment{}, err
+	}
+	deviceID, err := s.randomValue(deviceIDPrefix, deviceIDRandomSize)
+	if err != nil {
+		return DeviceEnrollment{}, fmt.Errorf("generating raw sync device identity: %w", err)
+	}
+	identity, err := NewAuthIdentity(tenantID, deviceID)
+	if err != nil {
+		return DeviceEnrollment{}, err
+	}
+	credential, err := s.randomValue(credentialPrefix, secretRandomSize)
+	if err != nil {
+		return DeviceEnrollment{}, fmt.Errorf("generating raw sync device credential: %w", err)
+	}
+	createdAt := s.now().UTC()
+	record := DeviceEnrollmentRecord{
+		Identity:         identity,
+		DisplayName:      displayName,
+		CredentialDigest: CredentialDigest(sha256.Sum256([]byte(credential))),
+		CreatedAt:        createdAt,
+	}
+	if err := s.store.EnrollDevice(ctx, record); err != nil {
+		return DeviceEnrollment{}, fmt.Errorf("enrolling raw sync device: %w", err)
+	}
+	return DeviceEnrollment{
+		Identity: identity, DisplayName: displayName,
+		Credential: credential, CreatedAt: createdAt,
+	}, nil
+}
+
+// IssueToken exchanges an active device credential for a scoped access token.
+func (s *DeviceAuthService) IssueToken(
+	ctx context.Context,
+	deviceID string,
+	credential string,
+	scopes DeviceTokenScope,
+) (IssuedDeviceToken, error) {
+	if !scopes.valid() {
+		return IssuedDeviceToken{}, fmt.Errorf("%w: invalid device token scopes", ErrInvalid)
+	}
+	if err := validateOpaqueID("device", deviceID); err != nil {
+		return IssuedDeviceToken{}, err
+	}
+	credentialDigest, err := digestDeviceSecret(credential, credentialPrefix)
+	if err != nil {
+		return IssuedDeviceToken{}, err
+	}
+	token, err := s.randomValue(tokenPrefix, secretRandomSize)
+	if err != nil {
+		return IssuedDeviceToken{}, fmt.Errorf("generating raw sync access token: %w", err)
+	}
+	now := s.now().UTC()
+	record := DeviceTokenRecord{
+		Digest:    TokenDigest(sha256.Sum256([]byte(token))),
+		Scopes:    scopes,
+		IssuedAt:  now,
+		ExpiresAt: now.Add(s.ttl),
+	}
+	identity, err := s.store.IssueToken(
+		ctx, deviceID, CredentialDigest(credentialDigest), record,
+	)
+	if err != nil {
+		return IssuedDeviceToken{}, fmt.Errorf("issuing raw sync access token: %w", err)
+	}
+	if err := validateServiceIdentity(identity); err != nil {
+		return IssuedDeviceToken{}, fmt.Errorf("validating raw sync token identity: %w", err)
+	}
+	return IssuedDeviceToken{
+		Token: token, Identity: identity, Scopes: scopes, ExpiresAt: record.ExpiresAt,
+	}, nil
+}
+
+// AuthenticateToken derives tenant and device identity from one scoped token.
+func (s *DeviceAuthService) AuthenticateToken(
+	ctx context.Context,
+	token string,
+	required DeviceTokenScope,
+) (AuthIdentity, error) {
+	if !required.single() {
+		return AuthIdentity{}, fmt.Errorf("%w: exactly one required scope is required", ErrInvalid)
+	}
+	digest, err := digestDeviceSecret(token, tokenPrefix)
+	if err != nil {
+		return AuthIdentity{}, err
+	}
+	identity, err := s.store.AuthenticateToken(
+		ctx, TokenDigest(digest), required, s.now().UTC(),
+	)
+	if err != nil {
+		return AuthIdentity{}, fmt.Errorf("authenticating raw sync access token: %w", err)
+	}
+	if err := validateServiceIdentity(identity); err != nil {
+		return AuthIdentity{}, fmt.Errorf("validating raw sync token identity: %w", err)
+	}
+	return identity, nil
+}
+
+// RevokeDevice invalidates a device and all of its outstanding tokens.
+func (s *DeviceAuthService) RevokeDevice(
+	ctx context.Context,
+	identity AuthIdentity,
+) (bool, error) {
+	if err := validateServiceIdentity(identity); err != nil {
+		return false, err
+	}
+	revoked, err := s.store.RevokeDevice(ctx, identity, s.now().UTC())
+	if err != nil {
+		return false, fmt.Errorf("revoking raw sync device: %w", err)
+	}
+	return revoked, nil
+}
+
+func (s *DeviceAuthService) randomValue(prefix string, size int) (string, error) {
+	buffer := make([]byte, size)
+	if _, err := io.ReadFull(s.random, buffer); err != nil {
+		return "", err
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func digestDeviceSecret(value, prefix string) ([sha256.Size]byte, error) {
+	var zero [sha256.Size]byte
+	encoded, ok := strings.CutPrefix(value, prefix)
+	if !ok || len(encoded) != secretEncodedSize {
+		return zero, ErrUnauthorized
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil || len(decoded) != secretRandomSize ||
+		base64.RawURLEncoding.EncodeToString(decoded) != encoded {
+		return zero, ErrUnauthorized
+	}
+	return sha256.Sum256([]byte(value)), nil
+}
+
+func validateDeviceDisplayName(value string) error {
+	if value == "" || len(value) > maxDeviceNameBytes || !utf8.ValidString(value) ||
+		strings.TrimSpace(value) != value {
+		return fmt.Errorf("%w: device display name is not canonical", ErrInvalid)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%w: device display name contains a control character", ErrInvalid)
+		}
+	}
+	return nil
+}

--- a/internal/rawsync/device_auth_test.go
+++ b/internal/rawsync/device_auth_test.go
@@ -1,0 +1,217 @@
+package rawsync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceAuthServiceEnrollmentTokenAndRevocation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 7, 30, 0, 0, time.UTC)
+	store := newMemoryDeviceAuthStore()
+	service, err := NewDeviceAuthService(store, time.Hour)
+	require.NoError(t, err)
+	service.random = bytes.NewReader(append(
+		append(bytes.Repeat([]byte{0}, 16), bytes.Repeat([]byte{1}, 32)...),
+		bytes.Repeat([]byte{2}, 32)...,
+	))
+	service.now = func() time.Time { return now }
+
+	enrollment, err := service.EnrollDevice(t.Context(), "tenant-a", "work laptop")
+	require.NoError(t, err)
+	assert.Equal(t, AuthIdentity{
+		TenantID: "tenant-a",
+		DeviceID: "dev_AAAAAAAAAAAAAAAAAAAAAA",
+	}, enrollment.Identity)
+	assert.Equal(t, "avdc_AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE", enrollment.Credential)
+	assert.Equal(t, "work laptop", enrollment.DisplayName)
+	assert.Equal(t, now, enrollment.CreatedAt)
+
+	stored := store.devices[enrollment.Identity.DeviceID]
+	assert.Equal(t,
+		CredentialDigest(sha256.Sum256([]byte(enrollment.Credential))),
+		stored.CredentialDigest,
+	)
+	assert.NotContains(t, string(stored.CredentialDigest[:]), enrollment.Credential)
+
+	issued, err := service.IssueToken(
+		t.Context(), enrollment.Identity.DeviceID, enrollment.Credential,
+		ScopeNegotiate|ScopeUpload,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "avdt_AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI", issued.Token)
+	assert.Equal(t, enrollment.Identity, issued.Identity)
+	assert.Equal(t, ScopeNegotiate|ScopeUpload, issued.Scopes)
+	assert.Equal(t, now.Add(time.Hour), issued.ExpiresAt)
+
+	identity, err := service.AuthenticateToken(t.Context(), issued.Token, ScopeUpload)
+	require.NoError(t, err)
+	assert.Equal(t, enrollment.Identity, identity)
+
+	_, err = service.AuthenticateToken(t.Context(), issued.Token, ScopeCommit)
+	assert.ErrorIs(t, err, ErrUnauthorized)
+	assert.NotContains(t, err.Error(), issued.Token)
+
+	revoked, err := service.RevokeDevice(t.Context(), enrollment.Identity)
+	require.NoError(t, err)
+	assert.True(t, revoked)
+
+	_, err = service.AuthenticateToken(t.Context(), issued.Token, ScopeUpload)
+	assert.ErrorIs(t, err, ErrUnauthorized)
+	assert.NotContains(t, err.Error(), issued.Token)
+}
+
+func TestDeviceAuthServiceCredentialAndExpiryFailuresStayOpaque(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 8, 0, 0, 0, time.UTC)
+	store := newMemoryDeviceAuthStore()
+	service, err := NewDeviceAuthService(store, 15*time.Minute)
+	require.NoError(t, err)
+	service.random = bytes.NewReader(append(
+		append(
+			append(bytes.Repeat([]byte{3}, 16), bytes.Repeat([]byte{4}, 32)...),
+			bytes.Repeat([]byte{5}, 32)...,
+		),
+		bytes.Repeat([]byte{6}, 32)...,
+	))
+	service.now = func() time.Time { return now }
+
+	enrollment, err := service.EnrollDevice(t.Context(), "tenant-b", "build host")
+	require.NoError(t, err)
+
+	_, err = service.IssueToken(
+		t.Context(), enrollment.Identity.DeviceID,
+		"avdc_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", ScopeStatus,
+	)
+	assert.ErrorIs(t, err, ErrUnauthorized)
+	assert.NotContains(t, err.Error(), enrollment.Credential)
+
+	issued, err := service.IssueToken(
+		t.Context(), enrollment.Identity.DeviceID, enrollment.Credential, ScopeStatus,
+	)
+	require.NoError(t, err)
+
+	now = issued.ExpiresAt
+	_, err = service.AuthenticateToken(t.Context(), issued.Token, ScopeStatus)
+	assert.ErrorIs(t, err, ErrUnauthorized)
+	assert.NotContains(t, err.Error(), issued.Token)
+}
+
+func TestDeviceAuthServiceRejectsInvalidScopeRequestsBeforeStoreAccess(t *testing.T) {
+	t.Parallel()
+
+	store := newMemoryDeviceAuthStore()
+	service, err := NewDeviceAuthService(store, time.Hour)
+	require.NoError(t, err)
+
+	_, err = service.IssueToken(
+		t.Context(), "device-a", "avdc_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 0,
+	)
+	assert.ErrorIs(t, err, ErrInvalid)
+	assert.Zero(t, store.issueCalls)
+
+	_, err = service.AuthenticateToken(
+		t.Context(), "avdt_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		ScopeNegotiate|ScopeUpload,
+	)
+	assert.ErrorIs(t, err, ErrInvalid)
+	assert.Zero(t, store.authenticateCalls)
+}
+
+func TestDigestDeviceSecretRejectsOversizedInputWithoutProportionalAllocation(t *testing.T) {
+	t.Parallel()
+
+	oversized := credentialPrefix + strings.Repeat("A", 8*1024)
+	result := testing.Benchmark(func(b *testing.B) {
+		for b.Loop() {
+			_, _ = digestDeviceSecret(oversized, credentialPrefix)
+		}
+	})
+
+	assert.Less(t, result.AllocedBytesPerOp(), int64(1024),
+		"invalid unauthenticated secrets must be rejected before proportional decoding")
+}
+
+type memoryDeviceAuthStore struct {
+	devices           map[string]DeviceEnrollmentRecord
+	tokens            map[TokenDigest]DeviceTokenRecord
+	issueCalls        int
+	authenticateCalls int
+}
+
+func newMemoryDeviceAuthStore() *memoryDeviceAuthStore {
+	return &memoryDeviceAuthStore{
+		devices: make(map[string]DeviceEnrollmentRecord),
+		tokens:  make(map[TokenDigest]DeviceTokenRecord),
+	}
+}
+
+func (s *memoryDeviceAuthStore) EnrollDevice(
+	_ context.Context,
+	record DeviceEnrollmentRecord,
+) error {
+	if _, exists := s.devices[record.Identity.DeviceID]; exists {
+		return ErrConflict
+	}
+	s.devices[record.Identity.DeviceID] = record
+	return nil
+}
+
+func (s *memoryDeviceAuthStore) IssueToken(
+	_ context.Context,
+	deviceID string,
+	credential CredentialDigest,
+	token DeviceTokenRecord,
+) (AuthIdentity, error) {
+	s.issueCalls++
+	device, exists := s.devices[deviceID]
+	if !exists || device.RevokedAt != nil || device.CredentialDigest != credential {
+		return AuthIdentity{}, ErrUnauthorized
+	}
+	token.Identity = device.Identity
+	s.tokens[token.Digest] = token
+	return device.Identity, nil
+}
+
+func (s *memoryDeviceAuthStore) AuthenticateToken(
+	_ context.Context,
+	digest TokenDigest,
+	required DeviceTokenScope,
+	now time.Time,
+) (AuthIdentity, error) {
+	s.authenticateCalls++
+	token, exists := s.tokens[digest]
+	if !exists || !now.Before(token.ExpiresAt) || !token.Scopes.Allows(required) {
+		return AuthIdentity{}, ErrUnauthorized
+	}
+	device, exists := s.devices[token.Identity.DeviceID]
+	if !exists || device.RevokedAt != nil {
+		return AuthIdentity{}, ErrUnauthorized
+	}
+	return token.Identity, nil
+}
+
+func (s *memoryDeviceAuthStore) RevokeDevice(
+	_ context.Context,
+	identity AuthIdentity,
+	revokedAt time.Time,
+) (bool, error) {
+	device, exists := s.devices[identity.DeviceID]
+	if !exists || device.Identity != identity || device.RevokedAt != nil {
+		return false, nil
+	}
+	device.RevokedAt = new(revokedAt)
+	s.devices[identity.DeviceID] = device
+	return true, nil
+}
+
+var _ DeviceAuthStore = (*memoryDeviceAuthStore)(nil)


### PR DESCRIPTION
Adds the server-side device authentication boundary for hosted raw custody.

Devices enroll once and keep a random credential; PostgreSQL stores only its
SHA-256 digest. Active devices exchange that credential for short-lived opaque
tokens scoped to negotiation, upload, commit, and status. Authentication derives
tenant and device identity from server-side records, and revocation invalidates
outstanding tokens.

This remains an internal foundation. #1459 does not add HTTP enrollment or
upload routes, the laptop uploader, server parsing, or server embeddings, so the
authenticated raw transport item in #1352 remains incomplete.

The Zensical guide now documents the completed raw custody foundation from
#1396, this authentication boundary, their security guarantees, the current
delivery status, and the unchanged `pg push` workflow.
