### PR TITLE
fix(parser): preserve Antigravity CLI effort metadata

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ description: Release history for AgentsView
 
 ## Unreleased
 
+**Bug fixes**
+
+- Preserve Antigravity CLI 1.1.5 generation usage and Low/Medium/High model
+  effort from SQLite executor metadata.
+
 ---
 
 ## 0.41.1

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -444,10 +444,12 @@ add an archived or maintained mirror without replacing the original identity.
 
 ## Grok Build (`grok`)
 
-- **Format:** Workspace-scoped session directories containing `summary.json`,
-  a derived `chat_history.jsonl` model-message cache, and an authoritative
+- **Format:** Workspace-scoped session directories containing `summary.json`, a
+  derived `chat_history.jsonl` model-message cache, and an authoritative
   `updates.jsonl` stream of timestamped ACP and xAI session notifications.
+
 - **Evidence:** `source`.
+
 - **Upstream:** Clone `https://github.com/xai-org/grok-build.git` at
   `d71f6e0c1f5acc5469e503e192fe14824e6f8c90`. The
   [session guide](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-pager/docs/user-guide/17-sessions.md)
@@ -461,31 +463,36 @@ add an archived or maintained mirror without replacing the original identity.
   Agentsview maps timestamped `tool_call` and terminal `tool_call_update`
   records to the existing tool-result event model, so Activity can use tool
   completion time without adding derived transcript messages.
+
 - **Usage and cost:** Durable `turn_completed` updates may carry per-model
-  input, output, cache-read, cache-creation, and reasoning tokens plus optional
-  `costUsdTicks` (10^10 ticks per USD), as defined by the
+  input, output, cache-read, cache-creation, and reasoning tokens plus
+  optional `costUsdTicks` (10^10 ticks per USD), as defined by the
   [notification schema](https://github.com/xai-org/grok-build/blob/d71f6e0c1f5acc5469e503e192fe14824e6f8c90/crates/codegen/xai-grok-shell/src/extensions/notification.rs).
-  Agentsview emits one usage event per prompt and model, subtracts cache reads
-  from the full input count, and uses reported cost ticks when present.
+  Agentsview emits one usage event per prompt and model, subtracts cache
+  reads from the full input count, and uses reported cost ticks when present.
+
 - **Automation:** The first-party
   [headless guide](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-pager/docs/user-guide/14-headless-mode.md)
-  defines prompt flags as non-interactive invocation. The producer propagates
-  that startup mode into
+  defines prompt flags as non-interactive invocation. The producer
+  propagates that startup mode into
   [`PromptContext.is_non_interactive`](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L936-L944),
-  whose schema identifies headless, SDK, stdio, and generic ACP execution and
-  defaults false for interactive or older contexts
+  whose schema identifies headless, SDK, stdio, and generic ACP execution
+  and defaults false for interactive or older contexts
   ([schema](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L145-L150),
-  [default](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L177-L199)).
-  The producer writes that context to the same session directory as
-  `prompt_context.json`
-  ([persistence](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session.rs#L1384-L1404),
-  [spawn call](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L1049-L1055)).
-  Agentsview treats only an explicit true value in a valid, session-associated
-  file as durable automation evidence; file presence, a missing field, or a
-  missing file does not classify a session as automated.
-- **Agentsview:** `internal/parser/grok.go`,
-  `internal/parser/grok_provider.go`, colocated tests, and the sanitized
-  upstream-generated fixtures in `internal/parser/testdata/grok-build`.
+
+    [default](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-agent/src/prompt/context.rs#L177-L199)).
+    The producer writes that context to the same session directory as
+    `prompt_context.json`
+    ([persistence](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session.rs#L1384-L1404),
+
+    [spawn call](https://github.com/xai-org/grok-build/blob/d92c5b0b8582fda358de1f97446aa74af44a464f/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs#L1049-L1055)).
+    Agentsview treats only an explicit true value in a valid, session-associated
+    file as durable automation evidence; file presence, a missing field, or a
+    missing file does not classify a session as automated.
+
+- **Agentsview:** `internal/parser/grok.go`, `internal/parser/grok_provider.go`,
+  colocated tests, and the sanitized upstream-generated fixtures in
+  `internal/parser/testdata/grok-build`.
 
 ## MiMo Code (`mimocode`)
 
@@ -1539,14 +1546,26 @@ add an archived or maintained mirror without replacing the original identity.
   specification, or authoritative protobuf schema was found. The independent
   CodeBurn evidence pinned in the `antigravity` entry also covers CLI
   discovery, live RPC metadata, and the shorter capture window, but not the
-  encrypted producer format.
+  encrypted producer format. Reverified 2026-08-20 against Google's official
+  [Antigravity CLI 1.1.16 macOS ARM64 release](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.16),
+  asset SHA-256
+  `a902e8b24fdc53504e7daf658e18f7ba47ebb9cfcf058aa6c01e37c5e610d389`. Its Go
+  binary embeds `FileDescriptorProto` records for
+  `third_party/jetski/cortex_pb/cortex.proto` and
+  `third_party/jetski/codeium_common_pb/codeium_common.proto`. These compiled
+  descriptors name the fields consumed below, but the persistence writer
+  remains closed source, so the evidence class remains `no-public-source`.
 - **Usage and cost:** SQLite `gen_metadata` and trajectory sidecars can carry
   input, output, thinking-output, cache-read, and model fields; output already
-  includes thinking. In CLI 1.1.5 SQLite, generation field 2 contains packed
-  step indices, field 19 can contain only the base model slug, and the matching
-  `executor_metadata` range carries the effort-qualified model in field 28.
-  Agentsview avoids double counting and catalog-prices usage. No provider USD
-  cost is consumed.
+  includes thinking. In CLI 1.1.5 SQLite,
+  `CortexStepGeneratorMetadata.step_indices` (field 2) contains packed step
+  indices and `ChatModelMetadata.response_model` (field 19) can contain only
+  the base model slug. The matching `ExecutorMetadata.last_step_idx` range
+  carries the effort-qualified model at
+  `cascade_config.planner_config.model_name` (fields 10, 1, and 28).
+  `ChatModelMetadata.model_display_name` (field 21) remains the complete label
+  when present. Agentsview avoids double counting and catalog-prices usage. No
+  provider USD cost is consumed.
 - **Agentsview:** `internal/parser/antigravity_cli.go`,
   `internal/parser/antigravity_crypto.go`, and
   `internal/parser/antigravity_cli_provider.go`.

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1511,10 +1511,13 @@ missing file does not classify a session as automated.
   CodeBurn evidence pinned in the `antigravity` entry also covers CLI
   discovery, live RPC metadata, and the shorter capture window, but not the
   encrypted producer format.
-- **Usage and cost:** Sidecar generator metadata can carry input, output,
-  thinking-output, cache-read, and model fields; output already includes
-  thinking. Agentsview avoids double counting and catalog-prices usage. No
-  provider USD cost is consumed.
+- **Usage and cost:** SQLite `gen_metadata` and trajectory sidecars can carry
+  input, output, thinking-output, cache-read, and model fields; output already
+  includes thinking. In CLI 1.1.5 SQLite, generation field 2 contains packed
+  step indices, field 19 can contain only the base model slug, and the matching
+  `executor_metadata` range carries the effort-qualified model in field 28.
+  Agentsview avoids double counting and catalog-prices usage. No provider USD
+  cost is consumed.
 - **Agentsview:** `internal/parser/antigravity_cli.go`,
   `internal/parser/antigravity_crypto.go`, and
   `internal/parser/antigravity_cli_provider.go`.

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"database/sql"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -326,6 +327,8 @@ func roleForAntigravityStepKind(kind antigravityStepKind) RoleType {
 func loadAntigravityStepsWithRawCount(
 	db *sql.DB,
 ) (antigravityStepLoadResult, error) {
+	generations := loadAntigravityGenerationMetadata(db)
+	executors := loadAntigravityExecutorMetadata(db)
 	rows, err := db.Query(
 		`SELECT idx, step_type, step_payload FROM steps ` +
 			`ORDER BY idx`,
@@ -334,23 +337,10 @@ func loadAntigravityStepsWithRawCount(
 		return antigravityStepLoadResult{}, fmt.Errorf("query steps: %w", err)
 	}
 	defer rows.Close()
-
-	// Gracefully query gen_metadata if the table exists
-	var genMeta map[int][]byte
-	if genRows, err := db.Query("SELECT idx, data FROM gen_metadata"); err == nil {
-		defer genRows.Close()
-		genMeta = make(map[int][]byte)
-		for genRows.Next() {
-			var idx int
-			var data []byte
-			if err := genRows.Scan(&idx, &data); err == nil {
-				genMeta[idx] = data
-			}
-		}
-	}
-
+	steps := make([]antigravityLoadedStep, 0)
+	stepPositions := make(map[int]int)
 	var result antigravityStepLoadResult
-	result.hasGenMetadata = len(genMeta) > 0
+	result.hasGenMetadata = len(generations) > 0
 	for rows.Next() {
 		var (
 			idx      int
@@ -360,20 +350,236 @@ func loadAntigravityStepsWithRawCount(
 		if err := rows.Scan(&idx, &stepType, &payload); err != nil {
 			return antigravityStepLoadResult{}, fmt.Errorf("scan step: %w", err)
 		}
+		parsedStep, parsed := newAntigravityStep(idx, stepType, payload)
+		var msg ParsedMessage
+		var decoded bool
+		kind := antigravityStepKind(stepType)
+		if parsed {
+			kind = parsedStep.kind
+			msg, decoded = decodeAntigravityParsedStep(parsedStep)
+		}
+		stepPositions[idx] = len(steps)
+		steps = append(steps, antigravityLoadedStep{
+			kind: kind, msg: msg, decoded: decoded,
+		})
 		result.rawStepCount++
-		msg, decoded := decodeAntigravityStep(idx, stepType, payload)
-		if data, ok := genMeta[idx]; ok {
-			msg = result.appendGenMetadataUsage(data, msg, decoded)
-		}
-		if !decoded {
-			continue
-		}
-		result.messages = append(result.messages, msg)
 	}
 	if err := rows.Err(); err != nil {
 		return antigravityStepLoadResult{}, fmt.Errorf("iterate steps: %w", err)
 	}
+
+	for _, generation := range generations {
+		position, found := generationPlannerStep(
+			generation, steps, stepPositions,
+		)
+		executorModel := ""
+		if stepIndex, known := generation.maxStepIndex(); known {
+			executorModel = executorModelForStep(executors, stepIndex)
+		}
+		if !found {
+			result.appendGenMetadataUsage(
+				generation.data, ParsedMessage{}, false, executorModel,
+			)
+			continue
+		}
+		step := &steps[position]
+		step.msg = result.appendGenMetadataUsage(
+			generation.data, step.msg, step.decoded, executorModel,
+		)
+	}
+	for _, step := range steps {
+		if step.decoded {
+			result.messages = append(result.messages, step.msg)
+		}
+	}
 	return result, nil
+}
+
+type antigravityLoadedStep struct {
+	kind    antigravityStepKind
+	msg     ParsedMessage
+	decoded bool
+}
+
+type antigravityGenerationMetadata struct {
+	idx              int
+	data             []byte
+	stepIndices      []int
+	hasStepIndices   bool
+	stepIndicesValid bool
+}
+
+func (g antigravityGenerationMetadata) maxStepIndex() (int, bool) {
+	if !g.hasStepIndices {
+		return g.idx, true
+	}
+	if !g.stepIndicesValid || len(g.stepIndices) == 0 {
+		return 0, false
+	}
+	maxIdx := g.stepIndices[0]
+	for _, idx := range g.stepIndices[1:] {
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+	}
+	return maxIdx, true
+}
+
+type antigravityExecutorMetadata struct {
+	endStep int
+	model   string
+}
+
+func loadAntigravityGenerationMetadata(
+	db *sql.DB,
+) []antigravityGenerationMetadata {
+	rows, err := db.Query("SELECT idx, data FROM gen_metadata ORDER BY idx")
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var generations []antigravityGenerationMetadata
+	for rows.Next() {
+		var generation antigravityGenerationMetadata
+		if err := rows.Scan(&generation.idx, &generation.data); err != nil {
+			continue
+		}
+		generation.stepIndices,
+			generation.hasStepIndices,
+			generation.stepIndicesValid =
+			extractAntigravityStepIndices(generation.data)
+		generations = append(generations, generation)
+	}
+	return generations
+}
+
+func loadAntigravityExecutorMetadata(
+	db *sql.DB,
+) []antigravityExecutorMetadata {
+	rows, err := db.Query("SELECT data FROM executor_metadata ORDER BY idx")
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var executors []antigravityExecutorMetadata
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			continue
+		}
+		executor, ok := extractAntigravityExecutorMetadata(data)
+		if ok {
+			executors = append(executors, executor)
+		}
+	}
+	sort.SliceStable(executors, func(i, j int) bool {
+		return executors[i].endStep < executors[j].endStep
+	})
+	return executors
+}
+
+func extractAntigravityStepIndices(
+	data []byte,
+) (indices []int, present bool, valid bool) {
+	fields, err := agProtoParse(data)
+	if err != nil {
+		return nil, false, false
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	for _, field := range fields {
+		if field.Number != 2 {
+			continue
+		}
+		present = true
+		if field.Wire == pbWireVarint {
+			if field.Varint > maxInt {
+				return nil, true, false
+			}
+			indices = append(indices, int(field.Varint))
+			continue
+		}
+		if field.Wire != pbWireBytes {
+			return nil, true, false
+		}
+		for packed := field.Bytes; len(packed) > 0; {
+			value, size := binary.Uvarint(packed)
+			if size <= 0 || value > maxInt {
+				return nil, true, false
+			}
+			indices = append(indices, int(value))
+			packed = packed[size:]
+		}
+	}
+	return indices, present, true
+}
+
+func extractAntigravityExecutorMetadata(
+	data []byte,
+) (antigravityExecutorMetadata, bool) {
+	fields, err := agProtoParse(data)
+	if err != nil {
+		return antigravityExecutorMetadata{}, false
+	}
+	end, ok := agProtoFind(fields, 3)
+	if !ok || end.Wire != pbWireVarint {
+		return antigravityExecutorMetadata{}, false
+	}
+	executor, ok := agProtoFind(fields, 10)
+	if !ok || executor.Nested == nil {
+		return antigravityExecutorMetadata{}, false
+	}
+	association, ok := agProtoFind(executor.Nested, 1)
+	if !ok || association.Nested == nil {
+		return antigravityExecutorMetadata{}, false
+	}
+	variant, ok := agProtoFind(association.Nested, 28)
+	if !ok {
+		return antigravityExecutorMetadata{}, false
+	}
+	model, ok := agProtoString(variant)
+	if !ok || !isPlausibleModelName(model) {
+		return antigravityExecutorMetadata{}, false
+	}
+	return antigravityExecutorMetadata{
+		endStep: int(end.Varint),
+		model:   model,
+	}, true
+}
+
+func generationPlannerStep(
+	generation antigravityGenerationMetadata,
+	steps []antigravityLoadedStep,
+	positions map[int]int,
+) (int, bool) {
+	for _, idx := range generation.stepIndices {
+		position, ok := positions[idx]
+		if !ok {
+			continue
+		}
+		step := steps[position]
+		if step.kind == antigravityStepKindPlannerResponse &&
+			step.decoded {
+			return position, true
+		}
+	}
+	if generation.hasStepIndices {
+		return 0, false
+	}
+	position, ok := positions[generation.idx]
+	return position, ok
+}
+
+func executorModelForStep(
+	executors []antigravityExecutorMetadata, stepIndex int,
+) string {
+	for _, executor := range executors {
+		if executor.endStep >= stepIndex {
+			return executor.model
+		}
+	}
+	return ""
 }
 
 // appendGenMetadataUsage records a usage event from one gen_metadata
@@ -383,9 +589,12 @@ func loadAntigravityStepsWithRawCount(
 // cannot render can still be rescued by the CLI trajectory sidecar
 // transcript, and its usage must not be dropped.
 func (r *antigravityStepLoadResult) appendGenMetadataUsage(
-	data []byte, msg ParsedMessage, decoded bool,
+	data []byte,
+	msg ParsedMessage,
+	decoded bool,
+	executorModel string,
 ) ParsedMessage {
-	genModel := extractModelName(data)
+	genModel := resolveAntigravityGenerationModel(data, executorModel)
 	block, okUsage := extractTokenUsage(data)
 	if okUsage {
 		// gen_metadata field semantics (cross-validated against sidecar
@@ -549,39 +758,67 @@ func tokenBlockFrom(fs []agProtoField) (agTokenBlock, bool) {
 	return block, true
 }
 
-// extractModelName recursively walks fields to extract the model name from Field 21 or Field 19.
+// extractModelName prefers the complete display label in field 21 and falls
+// back to the base model slug in field 19.
 func extractModelName(data []byte) string {
+	model, _ := extractAntigravityGenerationModel(data)
+	return model
+}
+
+func extractAntigravityGenerationModel(data []byte) (string, bool) {
 	fields, err := agProtoParse(data)
 	if err != nil {
-		return ""
+		return "", false
 	}
-	var model string
-	var walk func([]agProtoField)
-	walk = func(fs []agProtoField) {
-		if model != "" {
-			return
-		}
-		if f21, ok := agProtoFind(fs, 21); ok {
-			if s, ok := agProtoString(f21); ok &&
-				isPlausibleModelName(s) {
-				model = s
-				return
-			}
-		}
-		if f19, ok := agProtoFind(fs, 19); ok {
-			if s, ok := agProtoString(f19); ok &&
-				isPlausibleModelName(s) {
-				model = s
-				return
-			}
-		}
-		for _, f := range fs {
-			if f.Nested != nil {
-				walk(f.Nested)
+	if model := extractModelNameFromFields(fields, 21); model != "" {
+		return model, true
+	}
+	return extractModelNameFromFields(fields, 19), false
+}
+
+func extractModelNameFromFields(
+	fields []agProtoField, fieldNumber int,
+) string {
+	for _, field := range fields {
+		if field.Number == fieldNumber {
+			if model, ok := agProtoString(field); ok &&
+				isPlausibleModelName(model) {
+				return model
 			}
 		}
 	}
-	walk(fields)
+	for _, field := range fields {
+		if field.Nested != nil {
+			if model := extractModelNameFromFields(
+				field.Nested, fieldNumber,
+			); model != "" {
+				return model
+			}
+		}
+	}
+	return ""
+}
+
+func resolveAntigravityGenerationModel(
+	data []byte, executorModel string,
+) string {
+	generationModel, hasDisplayLabel :=
+		extractAntigravityGenerationModel(data)
+	if hasDisplayLabel || executorModel == "" {
+		return generationModel
+	}
+	if antigravityBaseModel(executorModel) == generationModel {
+		return executorModel
+	}
+	return generationModel
+}
+
+func antigravityBaseModel(model string) string {
+	for _, suffix := range []string{"-low", "-medium", "-high"} {
+		if base, ok := strings.CutSuffix(model, suffix); ok {
+			return base
+		}
+	}
 	return model
 }
 
@@ -628,7 +865,12 @@ func decodeAntigravityStep(
 	if !ok {
 		return ParsedMessage{}, false
 	}
+	return decodeAntigravityParsedStep(step)
+}
 
+func decodeAntigravityParsedStep(
+	step antigravityStep,
+) (ParsedMessage, bool) {
 	// Extract tool calls for assistant steps before the content guard
 	// so that tool-only steps (no displayable text) are not silently
 	// dropped.

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -273,6 +273,30 @@ const (
 	antigravityStepKindPlannerResponse antigravityStepKind = 15
 )
 
+// These field numbers come from the FileDescriptorProto records embedded in
+// the official Antigravity CLI 1.1.16 Go binary. Keep the identifiers aligned
+// with the producer's protobuf names so the parser does not turn schema paths
+// back into anonymous numeric guesses.
+const (
+	agCortexStepGeneratorMetadataChatModelField   = 1
+	agCortexStepGeneratorMetadataStepIndicesField = 2
+
+	agChatModelMetadataUsageField            = 4
+	agChatModelMetadataResponseModelField    = 19
+	agChatModelMetadataModelDisplayNameField = 21
+
+	agModelUsageStatsModelField            = 1
+	agModelUsageStatsInputTokensField      = 2
+	agModelUsageStatsOutputTokensField     = 3
+	agModelUsageStatsCacheWriteTokensField = 4
+	agModelUsageStatsCacheReadTokensField  = 5
+
+	agExecutorMetadataLastStepIndexField = 3
+	agExecutorMetadataCascadeConfigField = 10
+	agCascadeConfigPlannerConfigField    = 1
+	agCascadePlannerConfigModelNameField = 28
+)
+
 type antigravityStep struct {
 	idx       int
 	kind      antigravityStepKind
@@ -426,8 +450,8 @@ func (g antigravityGenerationMetadata) maxStepIndex() (int, bool) {
 }
 
 type antigravityExecutorMetadata struct {
-	endStep int
-	model   string
+	lastStepIndex int
+	modelName     string
 }
 
 func loadAntigravityGenerationMetadata(
@@ -475,7 +499,7 @@ func loadAntigravityExecutorMetadata(
 		}
 	}
 	sort.SliceStable(executors, func(i, j int) bool {
-		return executors[i].endStep < executors[j].endStep
+		return executors[i].lastStepIndex < executors[j].lastStepIndex
 	})
 	return executors
 }
@@ -489,7 +513,7 @@ func extractAntigravityStepIndices(
 	}
 	maxInt := uint64(^uint(0) >> 1)
 	for _, field := range fields {
-		if field.Number != 2 {
+		if field.Number != agCortexStepGeneratorMetadataStepIndicesField {
 			continue
 		}
 		present = true
@@ -522,29 +546,37 @@ func extractAntigravityExecutorMetadata(
 	if err != nil {
 		return antigravityExecutorMetadata{}, false
 	}
-	end, ok := agProtoFind(fields, 3)
-	if !ok || end.Wire != pbWireVarint {
+	lastStep, ok := agProtoFind(
+		fields, agExecutorMetadataLastStepIndexField,
+	)
+	if !ok || lastStep.Wire != pbWireVarint {
 		return antigravityExecutorMetadata{}, false
 	}
-	executor, ok := agProtoFind(fields, 10)
-	if !ok || executor.Nested == nil {
+	cascadeConfig, ok := agProtoFind(
+		fields, agExecutorMetadataCascadeConfigField,
+	)
+	if !ok || cascadeConfig.Nested == nil {
 		return antigravityExecutorMetadata{}, false
 	}
-	association, ok := agProtoFind(executor.Nested, 1)
-	if !ok || association.Nested == nil {
+	plannerConfig, ok := agProtoFind(
+		cascadeConfig.Nested, agCascadeConfigPlannerConfigField,
+	)
+	if !ok || plannerConfig.Nested == nil {
 		return antigravityExecutorMetadata{}, false
 	}
-	variant, ok := agProtoFind(association.Nested, 28)
+	modelNameField, ok := agProtoFind(
+		plannerConfig.Nested, agCascadePlannerConfigModelNameField,
+	)
 	if !ok {
 		return antigravityExecutorMetadata{}, false
 	}
-	model, ok := agProtoString(variant)
-	if !ok || !isPlausibleModelName(model) {
+	modelName, ok := agProtoString(modelNameField)
+	if !ok || !isPlausibleModelName(modelName) {
 		return antigravityExecutorMetadata{}, false
 	}
 	return antigravityExecutorMetadata{
-		endStep: int(end.Varint),
-		model:   model,
+		lastStepIndex: int(lastStep.Varint),
+		modelName:     modelName,
 	}, true
 }
 
@@ -575,8 +607,8 @@ func executorModelForStep(
 	executors []antigravityExecutorMetadata, stepIndex int,
 ) string {
 	for _, executor := range executors {
-		if executor.endStep >= stepIndex {
-			return executor.model
+		if executor.lastStepIndex >= stepIndex {
+			return executor.modelName
 		}
 	}
 	return ""
@@ -597,14 +629,10 @@ func (r *antigravityStepLoadResult) appendGenMetadataUsage(
 	genModel := resolveAntigravityGenerationModel(data, executorModel)
 	block, okUsage := extractTokenUsage(data)
 	if okUsage {
-		// gen_metadata field semantics (cross-validated against sidecar
-		// generatorMetadata ground truth in 550/550 blocks):
-		//   f2 = uncached input (inputTokens)
-		//   f3 = total output including thinking (outputTokens)
-		//   f5 = cache-read (cacheReadTokens, absent when no cache hits)
-		//   f4 = always 0/absent, ignored
-		// No per-field reasoning breakdown is available; f3 already
-		// includes thinking tokens.
+		// ModelUsageStats.input_tokens is uncached input,
+		// output_tokens includes thinking in the observed SQLite blocks,
+		// and cache_read_tokens is absent when there are no cache hits.
+		// Those blocks do not provide a separate persisted reasoning count.
 		context := block.UncachedInput + block.CacheRead
 		eventModel := genModel
 		var occurredAt string
@@ -642,16 +670,17 @@ func (r *antigravityStepLoadResult) appendGenMetadataUsage(
 // ground truth (generatorMetadata[].chatModel.usage matches in 550/550
 // blocks):
 //
-//	UncachedInput = f2 (inputTokens, tokens not served from cache)
-//	TotalOutput   = f3 (outputTokens, includes thinking)
-//	CacheRead     = f5 (cacheReadTokens, absent/zero for cache-miss sessions)
+//	UncachedInput = ModelUsageStats.input_tokens
+//	TotalOutput   = ModelUsageStats.output_tokens, including thinking in
+//	                observed SQLite blocks
+//	CacheRead     = ModelUsageStats.cache_read_tokens
 //
 // No per-field reasoning breakdown is available in gen_metadata;
 // TotalOutput already includes thinking tokens.
 type agTokenBlock struct {
-	UncachedInput int // f2: tokens not served from cache
-	TotalOutput   int // f3: total output including thinking
-	CacheRead     int // f5: cache-read tokens (0 when absent)
+	UncachedInput int // ModelUsageStats.input_tokens
+	TotalOutput   int // ModelUsageStats.output_tokens
+	CacheRead     int // ModelUsageStats.cache_read_tokens
 }
 
 // maxPlausibleTokens caps the token values accepted by the heuristic.
@@ -667,6 +696,25 @@ func extractTokenUsage(data []byte) (agTokenBlock, bool) {
 	if err != nil {
 		return agTokenBlock{}, false
 	}
+	if chatModel, ok := extractAntigravityChatModel(fields); ok {
+		usage, ok := agProtoFind(
+			chatModel, agChatModelMetadataUsageField,
+		)
+		if !ok || usage.Nested == nil {
+			return agTokenBlock{}, false
+		}
+		return tokenBlockFrom(usage.Nested)
+	}
+	return extractLegacyAntigravityTokenUsage(fields)
+}
+
+// extractLegacyAntigravityTokenUsage preserves support for older persisted
+// records that predate CortexStepGeneratorMetadata.chat_model. Their enclosing
+// message is not represented by the current embedded descriptors, so finding
+// ModelUsageStats still requires the established bounded recursive walk.
+func extractLegacyAntigravityTokenUsage(
+	fields []agProtoField,
+) (agTokenBlock, bool) {
 	var found bool
 	var block agTokenBlock
 	var walk func([]agProtoField)
@@ -691,75 +739,83 @@ func extractTokenUsage(data []byte) (agTokenBlock, bool) {
 
 // tokenBlockFrom reports whether fs is a plausible token usage block.
 //
-// Field semantics are cross-validated against sidecar ground truth
+// The embedded ModelUsageStats descriptor names the fields below. Their usage
+// semantics are cross-validated against sidecar ground truth
 // (generatorMetadata[].chatModel.usage matches in 550/550 blocks):
 //
-//	f1 = model-kind varint in [1000, 5000)
-//	f2 = uncached input (inputTokens)
-//	f3 = total output including thinking (outputTokens)
-//	f4 = always 0/absent, ignored
-//	f5 = cache-read (cacheReadTokens, absent when no cache hits)
+//	model             = enum varint in [1000, 5000)
+//	input_tokens      = uncached input
+//	output_tokens     = total output including thinking
+//	cache_write_tokens = deprecated and ignored
+//	cache_read_tokens = cache-read input, absent when there are no cache hits
 //
 // No per-field reasoning breakdown is available in gen_metadata;
 // the reasoning return value is always 0.
 //
-// f2 and f3 are required. f5 is optional: proto3 omits zero-valued
-// fields, and a fresh session with no cache hits omits f5 entirely.
-// Requiring f5 (the previous heuristic) caused the parser to miss
-// token blocks in such sessions, which is why the single-generation
-// June-11 archives all have no extracted block under the old mapping.
+// input_tokens and output_tokens are required. cache_read_tokens is optional:
+// proto3 omits zero-valued fields, and a fresh session with no cache hits omits
+// it entirely. Requiring cache_read_tokens (the previous heuristic) caused the
+// parser to miss token blocks in such sessions.
 func tokenBlockFrom(fs []agProtoField) (agTokenBlock, bool) {
-	f1, ok1 := agProtoFind(fs, 1)
-	f2, ok2 := agProtoFind(fs, 2)
-	f3, ok3 := agProtoFind(fs, 3)
-	// f5 (cache-read) is optional: proto3 omits zero-valued fields, and
-	// cache-read is absent when a session has no cache hits.
-	f5, hasF5 := agProtoFind(fs, 5)
+	model, hasModel := agProtoFind(fs, agModelUsageStatsModelField)
+	inputTokens, hasInput := agProtoFind(
+		fs, agModelUsageStatsInputTokensField,
+	)
+	outputTokens, hasOutput := agProtoFind(
+		fs, agModelUsageStatsOutputTokensField,
+	)
+	// cache_read_tokens is optional: proto3 omits zero-valued fields.
+	cacheReadTokens, hasCacheRead := agProtoFind(
+		fs, agModelUsageStatsCacheReadTokensField,
+	)
 
-	if !ok1 || !ok2 || !ok3 ||
-		f1.Wire != pbWireVarint || f2.Wire != pbWireVarint ||
-		f3.Wire != pbWireVarint {
+	if !hasModel || !hasInput || !hasOutput ||
+		model.Wire != pbWireVarint || inputTokens.Wire != pbWireVarint ||
+		outputTokens.Wire != pbWireVarint {
 		return agTokenBlock{}, false
 	}
-	if f1.Varint < 1000 || f1.Varint >= 5000 {
+	if model.Varint < 1000 || model.Varint >= 5000 {
 		return agTokenBlock{}, false
 	}
-	if f2.Varint > maxPlausibleTokens || f3.Varint > maxPlausibleTokens {
+	if inputTokens.Varint > maxPlausibleTokens ||
+		outputTokens.Varint > maxPlausibleTokens {
 		return agTokenBlock{}, false
 	}
-	// f2 (input) and f3 (output) are independent quantities, but an
-	// implausibly large combined footprint (input + output > cap)
-	// signals a decoy block where both values individually pass the
-	// per-field cap but are collectively implausible for a single
-	// generation.
-	if f2.Varint+f3.Varint > maxPlausibleTokens {
+	// Input and output are independent quantities, but an implausibly large
+	// combined footprint signals a decoy block where both values individually
+	// pass the per-field cap.
+	if inputTokens.Varint+outputTokens.Varint > maxPlausibleTokens {
 		return agTokenBlock{}, false
 	}
-	// f4 is consistently absent/zero in real blocks and carries no
-	// semantics. Tolerate its presence but ignore the value.
-	if f4, hasF4 := agProtoFind(fs, 4); hasF4 {
-		if f4.Wire != pbWireVarint || f4.Varint > maxPlausibleTokens {
+	// cache_write_tokens is deprecated. Observed gen_metadata blocks leave it
+	// absent or zero; validate it when present but do not report another class.
+	if cacheWriteTokens, hasCacheWrite := agProtoFind(
+		fs, agModelUsageStatsCacheWriteTokensField,
+	); hasCacheWrite {
+		if cacheWriteTokens.Wire != pbWireVarint ||
+			cacheWriteTokens.Varint > maxPlausibleTokens {
 			return agTokenBlock{}, false
 		}
 	}
-	if hasF5 {
-		if f5.Wire != pbWireVarint || f5.Varint > maxPlausibleTokens {
+	if hasCacheRead {
+		if cacheReadTokens.Wire != pbWireVarint ||
+			cacheReadTokens.Varint > maxPlausibleTokens {
 			return agTokenBlock{}, false
 		}
 	}
 
 	block := agTokenBlock{
-		UncachedInput: int(f2.Varint),
-		TotalOutput:   int(f3.Varint),
+		UncachedInput: int(inputTokens.Varint),
+		TotalOutput:   int(outputTokens.Varint),
 	}
-	if hasF5 {
-		block.CacheRead = int(f5.Varint)
+	if hasCacheRead {
+		block.CacheRead = int(cacheReadTokens.Varint)
 	}
 	return block, true
 }
 
-// extractModelName prefers the complete display label in field 21 and falls
-// back to the base model slug in field 19.
+// extractModelName prefers ChatModelMetadata.model_display_name and falls back
+// to ChatModelMetadata.response_model.
 func extractModelName(data []byte) string {
 	model, _ := extractAntigravityGenerationModel(data)
 	return model
@@ -770,10 +826,78 @@ func extractAntigravityGenerationModel(data []byte) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	if model := extractModelNameFromFields(fields, 21); model != "" {
+	if chatModel, ok := extractAntigravityChatModel(fields); ok {
+		return extractAntigravityChatModelName(chatModel)
+	}
+	return extractLegacyAntigravityGenerationModel(fields)
+}
+
+func extractAntigravityChatModel(
+	fields []agProtoField,
+) ([]agProtoField, bool) {
+	chatModel, ok := agProtoFind(
+		fields, agCortexStepGeneratorMetadataChatModelField,
+	)
+	if !ok || chatModel.Nested == nil {
+		return nil, false
+	}
+	if usage, ok := agProtoFind(
+		chatModel.Nested, agChatModelMetadataUsageField,
+	); ok && usage.Nested != nil {
+		return chatModel.Nested, true
+	}
+	if extractModelNameField(
+		chatModel.Nested, agChatModelMetadataModelDisplayNameField,
+	) != "" {
+		return chatModel.Nested, true
+	}
+	if extractModelNameField(
+		chatModel.Nested, agChatModelMetadataResponseModelField,
+	) != "" {
+		return chatModel.Nested, true
+	}
+	return nil, false
+}
+
+func extractAntigravityChatModelName(
+	fields []agProtoField,
+) (string, bool) {
+	if model := extractModelNameField(
+		fields, agChatModelMetadataModelDisplayNameField,
+	); model != "" {
 		return model, true
 	}
-	return extractModelNameFromFields(fields, 19), false
+	return extractModelNameField(
+		fields, agChatModelMetadataResponseModelField,
+	), false
+}
+
+func extractModelNameField(fields []agProtoField, fieldNumber int) string {
+	field, ok := agProtoFind(fields, fieldNumber)
+	if !ok {
+		return ""
+	}
+	model, ok := agProtoString(field)
+	if !ok || !isPlausibleModelName(model) {
+		return ""
+	}
+	return model
+}
+
+// extractLegacyAntigravityGenerationModel preserves the recursive decoder for
+// older persisted records that do not contain
+// CortexStepGeneratorMetadata.chat_model.
+func extractLegacyAntigravityGenerationModel(
+	fields []agProtoField,
+) (string, bool) {
+	if model := extractModelNameFromFields(
+		fields, agChatModelMetadataModelDisplayNameField,
+	); model != "" {
+		return model, true
+	}
+	return extractModelNameFromFields(
+		fields, agChatModelMetadataResponseModelField,
+	), false
 }
 
 func extractModelNameFromFields(
@@ -823,8 +947,8 @@ func antigravityBaseModel(model string) string {
 }
 
 // isPlausibleModelName reports whether s looks like a human-readable
-// model identifier. Field 21/19 sometimes carries a nested protobuf
-// message whose low bytes (tags, varints, NULs) are valid UTF-8 --
+// model identifier. The model_display_name and response_model fields can carry
+// a nested protobuf message in older records whose low bytes are valid UTF-8.
 // agProtoString cannot tell those apart from text, and the raw bytes
 // previously leaked into messages.model (and broke `pg push`, which
 // rejects NUL bytes). Require every rune to be printable, at least

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2656,6 +2656,168 @@ func TestAntigravityTokenUsage(t *testing.T) {
 	assert.True(t, sess.HasPeakContextTokens)
 }
 
+func TestAntigravityCLIGenerationMetadataMapsToPlannerStepAndExecutorModel(t *testing.T) {
+	tests := []struct {
+		name            string
+		generationModel string
+		modelField      int
+		executorModel   string
+		wantModel       string
+	}{
+		{
+			name:            "base slug gains executor effort",
+			generationModel: "gemini-3.7-flash",
+			modelField:      19,
+			executorModel:   "gemini-3.7-flash-high",
+			wantModel:       "gemini-3.7-flash-high",
+		},
+		{
+			name:            "different executor base is ignored",
+			generationModel: "claude-sonnet-4-6",
+			modelField:      19,
+			executorModel:   "gemini-3.7-flash-high",
+			wantModel:       "claude-sonnet-4-6",
+		},
+		{
+			name:            "display label stays authoritative",
+			generationModel: "Gemini 3.7 Flash (High)",
+			modelField:      21,
+			executorModel:   "gemini-3.7-flash-medium",
+			wantModel:       "Gemini 3.7 Flash (High)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			id := "55555555-6666-7777-8888-cccccccccccc"
+			mustMkdir(t, filepath.Join(root, "conversations"))
+			dbPath := filepath.Join(root, "conversations", id+".db")
+
+			db, err := sql.Open("sqlite3", dbPath)
+			require.NoError(t, err)
+			defer db.Close()
+
+			createAntigravityStepTables(t, db)
+			mustExec(t, db, `CREATE TABLE gen_metadata (
+				idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+			mustExec(t, db, `CREATE TABLE executor_metadata (
+				idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+
+			tsEarly := encodePB([]pbField{{
+				num: 1, wire: pbWireVarint, varint: 1779000000,
+			}})
+			userPayload := encodePB([]pbField{
+				{num: 5, wire: pbWireBytes, bytes: tsEarly},
+				{
+					num:   17,
+					wire:  pbWireBytes,
+					bytes: []byte("user question text goes here and is long"),
+				},
+			})
+			tsLate := encodePB([]pbField{{
+				num: 1, wire: pbWireVarint, varint: 1779000100,
+			}})
+			plannerPayload := encodePB([]pbField{
+				{num: 1, wire: pbWireVarint, varint: 15},
+				{num: 5, wire: pbWireBytes, bytes: tsLate},
+				{
+					num:   17,
+					wire:  pbWireBytes,
+					bytes: []byte("assistant response body goes here and is long"),
+				},
+			})
+			mustExec(t, db,
+				`INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 14, ?)`,
+				userPayload)
+			mustExec(t, db,
+				`INSERT INTO steps (idx, step_type, step_payload) VALUES (3, 132, ?)`,
+				plannerPayload)
+
+			genData := createAntigravityMockGenMetadataForSteps(
+				t, 2400, 180, 0, tt.generationModel, tt.modelField, 3,
+			)
+			mustExec(t, db,
+				`INSERT INTO gen_metadata (idx, data, size) VALUES (7, ?, ?)`,
+				genData, len(genData))
+			executorData := createAntigravityMockExecutorMetadata(
+				3, tt.executorModel,
+			)
+			mustExec(t, db,
+				`INSERT INTO executor_metadata (idx, data, size) VALUES (0, ?, ?)`,
+				executorData, len(executorData))
+
+			_, msgs, usageEvents, _, err :=
+				parseAntigravityCLITestSessionWithStatus(
+					t, dbPath, "test-project", "test-machine",
+				)
+			require.NoError(t, err)
+			require.Len(t, msgs, 2)
+			assert.Equal(t, tt.wantModel, msgs[1].Model)
+			assert.Equal(t, 2400, msgs[1].ContextTokens)
+			assert.Equal(t, 180, msgs[1].OutputTokens)
+
+			require.Len(t, usageEvents, 1)
+			assert.Equal(t, tt.wantModel, usageEvents[0].Model)
+			assert.Equal(t, 2400, usageEvents[0].InputTokens)
+			assert.Equal(t, 180, usageEvents[0].OutputTokens)
+			occurredAt, err := time.Parse(
+				time.RFC3339Nano, usageEvents[0].OccurredAt,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, int64(1779000100), occurredAt.Unix())
+		})
+	}
+}
+
+func TestExtractAntigravityStepIndicesDistinguishesAbsentAndMalformed(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		wantIndices []int
+		wantPresent bool
+		wantValid   bool
+	}{
+		{
+			name: "absent uses legacy mapping",
+			data: encodePB([]pbField{{
+				num: 19, wire: pbWireBytes, bytes: []byte("gemini-3.7-flash"),
+			}}),
+			wantValid: true,
+		},
+		{
+			name: "packed indices",
+			data: encodePB([]pbField{{
+				num:  2,
+				wire: pbWireBytes,
+				bytes: append(
+					encodeVarint(148), encodeVarint(149)...,
+				),
+			}}),
+			wantIndices: []int{148, 149},
+			wantPresent: true,
+			wantValid:   true,
+		},
+		{
+			name: "malformed packed indices",
+			data: encodePB([]pbField{{
+				num: 2, wire: pbWireBytes, bytes: []byte{0x80},
+			}}),
+			wantPresent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indices, present, valid :=
+				extractAntigravityStepIndices(tt.data)
+			assert.Equal(t, tt.wantIndices, indices)
+			assert.Equal(t, tt.wantPresent, present)
+			assert.Equal(t, tt.wantValid, valid)
+		})
+	}
+}
+
 // TestAntigravityTokenUsageCachedTokens verifies the gen_metadata path
 // when cache-read tokens are present. ContextTokens is the full context
 // window (uncached input + cache-read), InputTokens carries just the
@@ -3155,40 +3317,86 @@ func createAntigravityMockGenMetadata(t *testing.T, uncachedInput, totalOutput, 
 }
 
 func createAntigravityMockGenMetadataWithField(t *testing.T, fieldNum int, uncachedInput, totalOutput, cacheRead int, model string) []byte {
+	return createAntigravityMockGenMetadataData(
+		t, fieldNum, uncachedInput, totalOutput, cacheRead, model, 21, nil,
+	)
+}
+
+func createAntigravityMockGenMetadataForSteps(
+	t *testing.T,
+	uncachedInput, totalOutput, cacheRead int,
+	model string,
+	modelField int,
+	stepIndices ...int,
+) []byte {
+	return createAntigravityMockGenMetadataData(
+		t, 1020, uncachedInput, totalOutput, cacheRead,
+		model, modelField, stepIndices,
+	)
+}
+
+func createAntigravityMockGenMetadataData(
+	t *testing.T,
+	fieldNum, uncachedInput, totalOutput, cacheRead int,
+	model string,
+	modelField int,
+	stepIndices []int,
+) []byte {
+	t.Helper()
 	// Build token usage inner block with remapped field semantics
 	// cross-validated against sidecar ground truth:
 	//   f2 = uncached input (inputTokens)
 	//   f3 = total output including thinking (outputTokens)
 	//   f4 = absent (never carries semantics)
 	//   f5 = cache-read (cacheReadTokens, present when > 0)
-	usageInner := encodePB([]pbField{
+	usageFields := []pbField{
 		{num: 1, wire: pbWireVarint, varint: uint64(fieldNum)},
 		{num: 2, wire: pbWireVarint, varint: uint64(uncachedInput)},
 		{num: 3, wire: pbWireVarint, varint: uint64(totalOutput)},
-	})
+	}
 	if cacheRead > 0 {
-		usageInner = encodePB([]pbField{
-			{num: 1, wire: pbWireVarint, varint: uint64(fieldNum)},
-			{num: 2, wire: pbWireVarint, varint: uint64(uncachedInput)},
-			{num: 3, wire: pbWireVarint, varint: uint64(totalOutput)},
-			{num: 5, wire: pbWireVarint, varint: uint64(cacheRead)},
+		usageFields = append(usageFields, pbField{
+			num: 5, wire: pbWireVarint, varint: uint64(cacheRead),
 		})
 	}
+	usageInner := encodePB(usageFields)
+	f17Inner := encodePB([]pbField{{
+		num: 2, wire: pbWireBytes, bytes: usageInner,
+	}})
 
-	// Build Field 2 (Nested message) of Field 17
-	f17Inner := encodePB([]pbField{
-		{num: 2, wire: pbWireBytes, bytes: usageInner},
-	})
-
-	// Build top-level fields: Field 17 (Nested bytes), Field 21 (String bytes)
-	topFields := []pbField{
-		{num: 17, wire: pbWireBytes, bytes: f17Inner},
+	topFields := []pbField{{
+		num: 17, wire: pbWireBytes, bytes: f17Inner,
+	}}
+	if len(stepIndices) > 0 {
+		var packed []byte
+		for _, idx := range stepIndices {
+			packed = append(packed, encodeVarint(uint64(idx))...)
+		}
+		topFields = append(topFields, pbField{
+			num: 2, wire: pbWireBytes, bytes: packed,
+		})
 	}
 	if model != "" {
-		topFields = append(topFields, pbField{num: 21, wire: pbWireBytes, bytes: []byte(model)})
+		topFields = append(topFields, pbField{
+			num: modelField, wire: pbWireBytes, bytes: []byte(model),
+		})
 	}
-
 	return encodePB(topFields)
+}
+
+func createAntigravityMockExecutorMetadata(
+	endStep int, model string,
+) []byte {
+	association := encodePB([]pbField{{
+		num: 28, wire: pbWireBytes, bytes: []byte(model),
+	}})
+	executor := encodePB([]pbField{{
+		num: 1, wire: pbWireBytes, bytes: association,
+	}})
+	return encodePB([]pbField{
+		{num: 3, wire: pbWireVarint, varint: uint64(endStep)},
+		{num: 10, wire: pbWireBytes, bytes: executor},
+	})
 }
 
 // TestExtractTokenUsageFalsePositiveGuards verifies that decoy blocks

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2667,21 +2667,21 @@ func TestAntigravityCLIGenerationMetadataMapsToPlannerStepAndExecutorModel(t *te
 		{
 			name:            "base slug gains executor effort",
 			generationModel: "gemini-3.7-flash",
-			modelField:      19,
+			modelField:      agChatModelMetadataResponseModelField,
 			executorModel:   "gemini-3.7-flash-high",
 			wantModel:       "gemini-3.7-flash-high",
 		},
 		{
 			name:            "different executor base is ignored",
 			generationModel: "claude-sonnet-4-6",
-			modelField:      19,
+			modelField:      agChatModelMetadataResponseModelField,
 			executorModel:   "gemini-3.7-flash-high",
 			wantModel:       "claude-sonnet-4-6",
 		},
 		{
 			name:            "display label stays authoritative",
 			generationModel: "Gemini 3.7 Flash (High)",
-			modelField:      21,
+			modelField:      agChatModelMetadataModelDisplayNameField,
 			executorModel:   "gemini-3.7-flash-medium",
 			wantModel:       "Gemini 3.7 Flash (High)",
 		},
@@ -2781,14 +2781,16 @@ func TestExtractAntigravityStepIndicesDistinguishesAbsentAndMalformed(t *testing
 		{
 			name: "absent uses legacy mapping",
 			data: encodePB([]pbField{{
-				num: 19, wire: pbWireBytes, bytes: []byte("gemini-3.7-flash"),
+				num:   agChatModelMetadataResponseModelField,
+				wire:  pbWireBytes,
+				bytes: []byte("gemini-3.7-flash"),
 			}}),
 			wantValid: true,
 		},
 		{
 			name: "packed indices",
 			data: encodePB([]pbField{{
-				num:  2,
+				num:  agCortexStepGeneratorMetadataStepIndicesField,
 				wire: pbWireBytes,
 				bytes: append(
 					encodeVarint(148), encodeVarint(149)...,
@@ -2801,7 +2803,9 @@ func TestExtractAntigravityStepIndicesDistinguishesAbsentAndMalformed(t *testing
 		{
 			name: "malformed packed indices",
 			data: encodePB([]pbField{{
-				num: 2, wire: pbWireBytes, bytes: []byte{0x80},
+				num:   agCortexStepGeneratorMetadataStepIndicesField,
+				wire:  pbWireBytes,
+				bytes: []byte{0x80},
 			}}),
 			wantPresent: true,
 		},
@@ -3318,7 +3322,8 @@ func createAntigravityMockGenMetadata(t *testing.T, uncachedInput, totalOutput, 
 
 func createAntigravityMockGenMetadataWithField(t *testing.T, fieldNum int, uncachedInput, totalOutput, cacheRead int, model string) []byte {
 	return createAntigravityMockGenMetadataData(
-		t, fieldNum, uncachedInput, totalOutput, cacheRead, model, 21, nil,
+		t, fieldNum, uncachedInput, totalOutput, cacheRead,
+		model, agChatModelMetadataModelDisplayNameField,
 	)
 }
 
@@ -3329,10 +3334,73 @@ func createAntigravityMockGenMetadataForSteps(
 	modelField int,
 	stepIndices ...int,
 ) []byte {
-	return createAntigravityMockGenMetadataData(
-		t, 1020, uncachedInput, totalOutput, cacheRead,
-		model, modelField, stepIndices,
-	)
+	t.Helper()
+	usageFields := []pbField{
+		{num: agModelUsageStatsModelField, wire: pbWireVarint, varint: 1020},
+		{
+			num:    agModelUsageStatsInputTokensField,
+			wire:   pbWireVarint,
+			varint: uint64(uncachedInput),
+		},
+		{
+			num:    agModelUsageStatsOutputTokensField,
+			wire:   pbWireVarint,
+			varint: uint64(totalOutput),
+		},
+	}
+	if cacheRead > 0 {
+		usageFields = append(usageFields, pbField{
+			num:    agModelUsageStatsCacheReadTokensField,
+			wire:   pbWireVarint,
+			varint: uint64(cacheRead),
+		})
+	}
+	chatModelFields := []pbField{{
+		num:   agChatModelMetadataUsageField,
+		wire:  pbWireBytes,
+		bytes: encodePB(usageFields),
+	}}
+	if model != "" {
+		chatModelFields = append(chatModelFields, pbField{
+			num: modelField, wire: pbWireBytes, bytes: []byte(model),
+		})
+	}
+
+	var packedStepIndices []byte
+	for _, idx := range stepIndices {
+		packedStepIndices = append(
+			packedStepIndices, encodeVarint(uint64(idx))...,
+		)
+	}
+	// Put plausible model and usage decoys outside chat_model and before the
+	// real metadata. The current-schema decoder must follow the descriptor path
+	// instead of accepting the first recursively matching field numbers.
+	decoyUsage := encodePB([]pbField{
+		{num: agModelUsageStatsModelField, wire: pbWireVarint, varint: 1020},
+		{num: agModelUsageStatsInputTokensField, wire: pbWireVarint, varint: 1},
+		{num: agModelUsageStatsOutputTokensField, wire: pbWireVarint, varint: 1},
+	})
+	legacyDecoyWrapper := encodePB([]pbField{{
+		num: 2, wire: pbWireBytes, bytes: decoyUsage,
+	}})
+	return encodePB([]pbField{
+		{
+			num:   agChatModelMetadataModelDisplayNameField,
+			wire:  pbWireBytes,
+			bytes: []byte("wrong top-level model"),
+		},
+		{num: 17, wire: pbWireBytes, bytes: legacyDecoyWrapper},
+		{
+			num:   agCortexStepGeneratorMetadataChatModelField,
+			wire:  pbWireBytes,
+			bytes: encodePB(chatModelFields),
+		},
+		{
+			num:   agCortexStepGeneratorMetadataStepIndicesField,
+			wire:  pbWireBytes,
+			bytes: packedStepIndices,
+		},
+	})
 }
 
 func createAntigravityMockGenMetadataData(
@@ -3340,23 +3408,31 @@ func createAntigravityMockGenMetadataData(
 	fieldNum, uncachedInput, totalOutput, cacheRead int,
 	model string,
 	modelField int,
-	stepIndices []int,
 ) []byte {
 	t.Helper()
-	// Build token usage inner block with remapped field semantics
-	// cross-validated against sidecar ground truth:
-	//   f2 = uncached input (inputTokens)
-	//   f3 = total output including thinking (outputTokens)
-	//   f4 = absent (never carries semantics)
-	//   f5 = cache-read (cacheReadTokens, present when > 0)
+	// Older records use unknown wrappers around a ModelUsageStats payload.
 	usageFields := []pbField{
-		{num: 1, wire: pbWireVarint, varint: uint64(fieldNum)},
-		{num: 2, wire: pbWireVarint, varint: uint64(uncachedInput)},
-		{num: 3, wire: pbWireVarint, varint: uint64(totalOutput)},
+		{
+			num:    agModelUsageStatsModelField,
+			wire:   pbWireVarint,
+			varint: uint64(fieldNum),
+		},
+		{
+			num:    agModelUsageStatsInputTokensField,
+			wire:   pbWireVarint,
+			varint: uint64(uncachedInput),
+		},
+		{
+			num:    agModelUsageStatsOutputTokensField,
+			wire:   pbWireVarint,
+			varint: uint64(totalOutput),
+		},
 	}
 	if cacheRead > 0 {
 		usageFields = append(usageFields, pbField{
-			num: 5, wire: pbWireVarint, varint: uint64(cacheRead),
+			num:    agModelUsageStatsCacheReadTokensField,
+			wire:   pbWireVarint,
+			varint: uint64(cacheRead),
 		})
 	}
 	usageInner := encodePB(usageFields)
@@ -3367,15 +3443,6 @@ func createAntigravityMockGenMetadataData(
 	topFields := []pbField{{
 		num: 17, wire: pbWireBytes, bytes: f17Inner,
 	}}
-	if len(stepIndices) > 0 {
-		var packed []byte
-		for _, idx := range stepIndices {
-			packed = append(packed, encodeVarint(uint64(idx))...)
-		}
-		topFields = append(topFields, pbField{
-			num: 2, wire: pbWireBytes, bytes: packed,
-		})
-	}
 	if model != "" {
 		topFields = append(topFields, pbField{
 			num: modelField, wire: pbWireBytes, bytes: []byte(model),
@@ -3385,17 +3452,29 @@ func createAntigravityMockGenMetadataData(
 }
 
 func createAntigravityMockExecutorMetadata(
-	endStep int, model string,
+	lastStepIndex int, modelName string,
 ) []byte {
-	association := encodePB([]pbField{{
-		num: 28, wire: pbWireBytes, bytes: []byte(model),
+	plannerConfig := encodePB([]pbField{{
+		num:   agCascadePlannerConfigModelNameField,
+		wire:  pbWireBytes,
+		bytes: []byte(modelName),
 	}})
-	executor := encodePB([]pbField{{
-		num: 1, wire: pbWireBytes, bytes: association,
+	cascadeConfig := encodePB([]pbField{{
+		num:   agCascadeConfigPlannerConfigField,
+		wire:  pbWireBytes,
+		bytes: plannerConfig,
 	}})
 	return encodePB([]pbField{
-		{num: 3, wire: pbWireVarint, varint: uint64(endStep)},
-		{num: 10, wire: pbWireBytes, bytes: executor},
+		{
+			num:    agExecutorMetadataLastStepIndexField,
+			wire:   pbWireVarint,
+			varint: uint64(lastStepIndex),
+		},
+		{
+			num:   agExecutorMetadataCascadeConfigField,
+			wire:  pbWireBytes,
+			bytes: cascadeConfig,
+		},
 	})
 }
 


### PR DESCRIPTION
## Problem

Antigravity CLI 1.1.5 stores generation data in a new format.

`gen_metadata.idx` identifies a generation. It does not identify a step.

Protobuf field 2 contains the step indices for the generation.

Generation field 19 contains the base model slug:

```text
gemini-3.7-flash
```

The related `executor_metadata` field 28 contains the model effort:

```text
gemini-3.7-flash-high
```

AgentsView currently uses `gen_metadata.idx` as the step index. This behavior can attach data to the wrong step.

It can also discard usage data when the two indices differ.

AgentsView does not read the model effort from the executor metadata.

As a result, the parsed model can lose its Low, Medium, or High effort.

Closes #1460.

## Change

- Read the packed step indices from generation field 2.
- Map each generation to its first decoded planner step.
- Use protobuf field 1 as the primary step kind.
- Use the SQLite `step_type` value only when field 1 is absent.
- Use the largest generation step index to select the executor range.
- Select the first executor whose `endStep` includes that index.
- Read the effort-qualified model from executor field 28.
- Apply the executor model only when both base model slugs match.
- Keep the complete field 21 display label when it is available.
- Use `gen_metadata.idx` only when generation field 2 is absent.
- Do not guess a step when field 2 is present but invalid.
- Document the observed Antigravity CLI 1.1.5 fields.

## Compatibility

The change keeps support for older session formats.

Sessions without `executor_metadata` continue to parse.

Sessions without generation field 2 continue to use the index-aligned format.

A complete field 21 label remains authoritative:

```text
Gemini 3.7 Flash (High)
```

AgentsView does not apply an executor model when the base model slugs differ.

## Verification

The regression tests cover these conditions:

- The generation index differs from the planner step index.
- Generation field 2 contains packed step indices.
- The SQLite `step_type` value differs from protobuf field 1.
- Protobuf field 1 identifies the step as a planner response.
- Executor field 28 restores the `-high` suffix.
- A different executor base model does not replace the generation model.
- A complete field 21 label remains unchanged.
- The usage event uses the planner timestamp.
- The message receives the correct token counts.
- An absent field 2 enables the legacy fallback.
- A valid field 2 enables the new mapping.
- An invalid field 2 does not enable the legacy fallback.
- Older index-aligned sessions work without an executor table.

These commands completed successfully:

```text
go test -tags fts5 ./internal/parser -count=1
make test-short
```

The Markdown source checks also passed.

The complete documentation check could not load `origin/docs-assets`. The fork does not contain that artifact branch.

Two independent reviewers found no remaining issues after the final fixes.

## Data safety

The parser only reads the existing SQLite metadata.

This change does not modify a session database.

This change does not connect to the central PostgreSQL database.

This change does not run `agentsview pg push`.

This change does not start a resync.

This change does not change the remote backup.
