### PR TITLE
fix(frontend): use stable project keys in Usage filter

### DIFF
--- a/frontend/e2e/usage.spec.ts
+++ b/frontend/e2e/usage.spec.ts
@@ -127,6 +127,9 @@ test.describe("Usage page", () => {
       .locator(".usage-toolbar .kit-filter-dropdown__btn")
       .first();
     await trigger.click();
+    await expect(
+      page.locator(".usage-toolbar .kit-filter-dropdown__item").first(),
+    ).toBeVisible();
 
     // Click "Deselect all".
     await page
@@ -231,7 +234,9 @@ test.describe("Usage page", () => {
     ).toHaveAttribute("aria-checked", "true");
   });
 
-  test("URL updates when filter changes", async ({ page }) => {
+  test("project filters use stable keys without writing them to the URL", async ({
+    page,
+  }) => {
     // Wait for data.
     await expect(
       page.locator(".summary-cards .card-value").first(),
@@ -242,15 +247,26 @@ test.describe("Usage page", () => {
       .locator(".usage-toolbar .kit-filter-dropdown__btn")
       .first();
     await trigger.click();
-    await page
+    const projectOption = page
       .locator(".usage-toolbar .kit-filter-dropdown__item")
       .filter({ hasText: "project-delta" })
-      .first()
-      .click();
+      .first();
+    await expect(projectOption).toBeVisible();
+    const filteredRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith("/api/v1/usage/summary") &&
+        !!url.searchParams.get("exclude_project_key");
+    });
+    await projectOption.click();
+    const requestUrl = new URL((await filteredRequest).url());
     await page.mouse.click(10, 10);
 
-    // URL should contain the exclude_project param.
-    await expect(page).toHaveURL(/exclude_project=/);
+    expect(requestUrl.searchParams.get("exclude_project_key")).toBeTruthy();
+    await expect(page).toHaveURL((url) =>
+      url.pathname === "/usage" &&
+      !url.searchParams.has("exclude_project") &&
+      !url.searchParams.has("exclude_project_key")
+    );
   });
 
   test("returning bare refreshes rolling bounds after midnight", async ({

--- a/frontend/src/lib/components/usage/FilterDropdown.svelte
+++ b/frontend/src/lib/components/usage/FilterDropdown.svelte
@@ -25,6 +25,8 @@
     onDeselectAll?: () => void;
     color?: (name: string) => string;
     mode?: "exclude" | "include";
+    /** Active exclusions represented outside excludedCsv. */
+    unlistedExcludedCount?: number;
   }
 
   let {
@@ -36,6 +38,7 @@
     onDeselectAll,
     color,
     mode = "exclude",
+    unlistedExcludedCount = 0,
   }: Props = $props();
 
   function itemId(item: FilterItem): string {
@@ -52,9 +55,12 @@
       0,
     ),
   );
-  const filteredCount = $derived(filterSet.size);
+  const filteredCount = $derived(
+    filterSet.size + Math.max(0, unlistedExcludedCount),
+  );
   const unlistedFilteredCount = $derived(
-    Math.max(0, filteredCount - listedFilteredCount),
+    Math.max(0, filterSet.size - listedFilteredCount) +
+      Math.max(0, unlistedExcludedCount),
   );
   const visibleCount = $derived(
     items.length - listedFilteredCount,

--- a/frontend/src/lib/components/usage/FilterDropdown.svelte
+++ b/frontend/src/lib/components/usage/FilterDropdown.svelte
@@ -24,6 +24,8 @@
     onDeselectAll?: () => void;
     color?: (name: string) => string;
     mode?: "exclude" | "include";
+    /** Exclusions that are not present in items, such as stable project keys. */
+    unlistedExcludedCount?: number;
   }
 
   let {
@@ -35,15 +37,18 @@
     onDeselectAll,
     color,
     mode = "exclude",
+    unlistedExcludedCount = 0,
   }: Props = $props();
 
   const filterSet = $derived(
     new Set(excludedCsv ? excludedCsv.split(",") : []),
   );
 
-  const filteredCount = $derived(filterSet.size);
+  const filteredCount = $derived(
+    filterSet.size + Math.max(0, unlistedExcludedCount),
+  );
   const visibleCount = $derived(
-    items.length - filteredCount,
+    items.length - filterSet.size,
   );
 
   const buttonLabel = $derived.by(() => {
@@ -55,7 +60,7 @@
         countLabel: filteredCount.toLocaleString(),
       });
     }
-    if (visibleCount === 1) {
+    if (visibleCount === 1 && unlistedExcludedCount === 0) {
       const visible = items.find(
         (i) => !filterSet.has(i.name),
       );
@@ -67,7 +72,9 @@
         return `${label}: ${visible.name}`;
       }
     }
-    if (visibleCount === 0) return m.usage_filter_none({ label });
+    if (visibleCount === 0 && unlistedExcludedCount === 0) {
+      return m.usage_filter_none({ label });
+    }
     return m.usage_filter_hidden({
       label,
       countLabel: filteredCount.toLocaleString(),

--- a/frontend/src/lib/components/usage/FilterDropdown.svelte
+++ b/frontend/src/lib/components/usage/FilterDropdown.svelte
@@ -10,6 +10,7 @@
   import { m } from "../../i18n/index.js";
 
   interface FilterItem {
+    id?: string;
     name: string;
     count?: number;
   }
@@ -17,15 +18,13 @@
   interface Props {
     label: string;
     items: FilterItem[];
-    /** Comma-separated list of EXCLUDED item names. */
+    /** Comma-separated list of excluded item IDs. */
     excludedCsv: string;
-    onToggle: (name: string) => void;
+    onToggle: (id: string) => void;
     onSelectAll?: () => void;
     onDeselectAll?: () => void;
     color?: (name: string) => string;
     mode?: "exclude" | "include";
-    /** Exclusions that are not present in items, such as stable project keys. */
-    unlistedExcludedCount?: number;
   }
 
   let {
@@ -37,18 +36,28 @@
     onDeselectAll,
     color,
     mode = "exclude",
-    unlistedExcludedCount = 0,
   }: Props = $props();
+
+  function itemId(item: FilterItem): string {
+    return item.id ?? item.name;
+  }
 
   const filterSet = $derived(
     new Set(excludedCsv ? excludedCsv.split(",") : []),
   );
 
-  const filteredCount = $derived(
-    filterSet.size + Math.max(0, unlistedExcludedCount),
+  const listedFilteredCount = $derived(
+    items.reduce(
+      (count, item) => count + (filterSet.has(itemId(item)) ? 1 : 0),
+      0,
+    ),
+  );
+  const filteredCount = $derived(filterSet.size);
+  const unlistedFilteredCount = $derived(
+    Math.max(0, filteredCount - listedFilteredCount),
   );
   const visibleCount = $derived(
-    items.length - filterSet.size,
+    items.length - listedFilteredCount,
   );
 
   const buttonLabel = $derived.by(() => {
@@ -60,9 +69,9 @@
         countLabel: filteredCount.toLocaleString(),
       });
     }
-    if (visibleCount === 1 && unlistedExcludedCount === 0) {
+    if (visibleCount === 1 && unlistedFilteredCount === 0) {
       const visible = items.find(
-        (i) => !filterSet.has(i.name),
+        (item) => !filterSet.has(itemId(item)),
       );
       if (visible) {
         const maxLen = 20;
@@ -72,7 +81,7 @@
         return `${label}: ${visible.name}`;
       }
     }
-    if (visibleCount === 0 && unlistedExcludedCount === 0) {
+    if (visibleCount === 0 && unlistedFilteredCount === 0) {
       return m.usage_filter_none({ label });
     }
     return m.usage_filter_hidden({
@@ -83,17 +92,18 @@
 
   const dropdownItems = $derived.by((): FilterDropdownItem[] => {
     const mapped = items.map((item): FilterDropdownItem => {
+      const id = itemId(item);
       const included =
         mode === "include"
-          ? filterSet.has(item.name)
-          : !filterSet.has(item.name);
+          ? filterSet.has(id)
+          : !filterSet.has(id);
       return {
-        id: item.name,
+        id,
         label: item.name,
         active: included,
         count: item.count,
         color: color?.(item.name),
-        onSelect: () => onToggle(item.name),
+        onSelect: () => onToggle(id),
       };
     });
     if (mode === "include") {

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -60,18 +60,54 @@
     usageChartColorMaps(usage.summary, settings.chartPalette),
   );
 
-  const projectItems = $derived(
-    sessions.projects.map((p) => ({
-      name: p.name,
-      count: p.session_count,
-    })),
-  );
+  interface ProjectFilterItem {
+    id: string;
+    name: string;
+    count?: number;
+  }
 
-  const excludedProjectKeyCount = $derived(
-    usage.excludedProjectKeys
-      ? usage.excludedProjectKeys.split(",").filter(Boolean).length
-      : 0,
-  );
+  // Keep projects already returned by the summary so a project remains
+  // available in the dropdown after filtering removes it from the response.
+  let knownProjects: ProjectFilterItem[] = $state([]);
+
+  function mergeIntoKnownProjects(
+    projects: Array<{ project_key: string; project: string }>,
+    counts: Record<string, number>,
+  ): void {
+    if (projects.length === 0) return;
+    const byKey = new Map(knownProjects.map((project) => [project.id, project]));
+    let changed = false;
+    for (const project of projects) {
+      if (!project.project_key || !project.project) continue;
+      const existing = byKey.get(project.project_key);
+      const count = counts[project.project_key];
+      if (
+        !existing ||
+        existing.name !== project.project ||
+        existing.count !== count
+      ) {
+        byKey.set(project.project_key, {
+          id: project.project_key,
+          name: project.project,
+          count,
+        });
+        changed = true;
+      }
+    }
+    if (changed) {
+      knownProjects = [...byKey.values()].sort(
+        (a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id),
+      );
+    }
+  }
+
+  $effect(() => {
+    const fromSummary = usage.summary?.projectTotals ?? [];
+    const counts = usage.summary?.sessionCounts.byProject ?? {};
+    untrack(() => mergeIntoKnownProjects(fromSummary, counts));
+  });
+
+  const projectItems = $derived(knownProjects);
 
   const agentItems = $derived(
     sessions.agents.map((a) => ({
@@ -489,12 +525,11 @@
       <FilterDropdown
         label={m.analytics_col_project()}
         items={projectItems}
-        excludedCsv={usage.excludedProjects}
-        unlistedExcludedCount={excludedProjectKeyCount}
-        onToggle={(name) => usage.toggleProject(name)}
+        excludedCsv={usage.excludedProjectKeys}
+        onToggle={(key) => usage.toggleProjectKey(key)}
         onSelectAll={() => usage.selectAllProjects()}
         onDeselectAll={() =>
-          usage.deselectAllProjects(projectItems.map((p) => p.name))}
+          usage.deselectAllProjectKeys(projectItems.map((p) => p.id))}
       />
 
       <FilterDropdown

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -109,6 +109,12 @@
 
   const projectItems = $derived(knownProjects);
 
+  const legacyExcludedProjectCount = $derived(
+    usage.excludedProjects
+      ? usage.excludedProjects.split(",").filter(Boolean).length
+      : 0,
+  );
+
   const agentItems = $derived(
     sessions.agents.map((a) => ({
       name: a.name,
@@ -526,6 +532,7 @@
         label={m.analytics_col_project()}
         items={projectItems}
         excludedCsv={usage.excludedProjectKeys}
+        unlistedExcludedCount={legacyExcludedProjectCount}
         onToggle={(key) => usage.toggleProjectKey(key)}
         onSelectAll={() => usage.selectAllProjects()}
         onDeselectAll={() =>

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -60,54 +60,16 @@
     usageChartColorMaps(usage.summary, settings.chartPalette),
   );
 
-  interface ProjectFilterItem {
-    id: string;
-    name: string;
-    count?: number;
-  }
-
   // Keep projects already returned by the summary so a project remains
-  // available in the dropdown after filtering removes it from the response.
-  let knownProjects: ProjectFilterItem[] = $state([]);
-
-  function mergeIntoKnownProjects(
-    projects: Array<{ project_key: string; project: string }>,
-    counts: Record<string, number>,
-  ): void {
-    if (projects.length === 0) return;
-    const byKey = new Map(knownProjects.map((project) => [project.id, project]));
-    let changed = false;
-    for (const project of projects) {
-      if (!project.project_key || !project.project) continue;
-      const existing = byKey.get(project.project_key);
-      const count = counts[project.project_key];
-      if (
-        !existing ||
-        existing.name !== project.project ||
-        existing.count !== count
-      ) {
-        byKey.set(project.project_key, {
-          id: project.project_key,
-          name: project.project,
-          count,
-        });
-        changed = true;
-      }
-    }
-    if (changed) {
-      knownProjects = [...byKey.values()].sort(
-        (a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id),
-      );
-    }
-  }
+  // available after filtering removes it or the page is remounted.
 
   $effect(() => {
     const fromSummary = usage.summary?.projectTotals ?? [];
     const counts = usage.summary?.sessionCounts.byProject ?? {};
-    untrack(() => mergeIntoKnownProjects(fromSummary, counts));
+    untrack(() => usage.mergeKnownProjects(fromSummary, counts));
   });
 
-  const projectItems = $derived(knownProjects);
+  const projectItems = $derived(usage.knownProjects);
 
   const legacyExcludedProjectCount = $derived(
     usage.excludedProjects

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -67,6 +67,12 @@
     })),
   );
 
+  const excludedProjectKeyCount = $derived(
+    usage.excludedProjectKeys
+      ? usage.excludedProjectKeys.split(",").filter(Boolean).length
+      : 0,
+  );
+
   const agentItems = $derived(
     sessions.agents.map((a) => ({
       name: a.name,
@@ -484,6 +490,7 @@
         label={m.analytics_col_project()}
         items={projectItems}
         excludedCsv={usage.excludedProjects}
+        unlistedExcludedCount={excludedProjectKeyCount}
         onToggle={(name) => usage.toggleProject(name)}
         onSelectAll={() => usage.selectAllProjects()}
         onDeselectAll={() =>

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -24,7 +24,7 @@ async function flushEffects() {
 
 let component: ReturnType<typeof mount> | undefined;
 
-function usageSummaryWithUnsupported(kind?: string) {
+function usageSummaryWithUnsupported(kind?: string): UsageSummaryResponse {
   return {
     from: "2024-06-01",
     to: "2024-06-01",
@@ -138,6 +138,7 @@ afterEach(() => {
   usage.toggles.timeSeries.groupBy = "project";
   usage.toggles.attribution.groupBy = "project";
   usage.toggles.attribution.view = "treemap";
+  usage.excludedProjects = "";
   usage.excludedProjectKeys = "";
   settings.chartPalette = "agentsview";
   sessions.projects = [];
@@ -146,7 +147,7 @@ afterEach(() => {
 });
 
 describe("UsagePage refresh behavior", () => {
-  it("shows and clears project-key exclusions from the Project filter", async () => {
+  it("uses stable project keys in the Project filter", async () => {
     vi.stubGlobal(
       "ResizeObserver",
       class {
@@ -158,19 +159,71 @@ describe("UsagePage refresh behavior", () => {
     vi.spyOn(sessions, "loadAgents").mockResolvedValue();
     router.route = "usage";
     router.params = {};
-    usage.excludedProjectKeys = "project-key-1,project-key-2";
-    sessions.projects = [{ name: "visible-project", session_count: 4 }];
+    const summary = usageSummaryWithUnsupported();
+    summary.projectTotals = [
+      {
+        project_key: "project-key-1",
+        project: "shared-label",
+        inputTokens: 80,
+        outputTokens: 40,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        cost: testMoney(8),
+      },
+      {
+        project_key: "project-key-2",
+        project: "shared-label",
+        inputTokens: 20,
+        outputTokens: 10,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        cost: testMoney(2),
+      },
+    ];
+    usage.summary = summary;
 
     component = mount(UsagePage, { target: document.body });
     await flushEffects();
 
     const projectFilter = document.querySelector<HTMLButtonElement>(
-      '.kit-filter-dropdown__btn[aria-label="Project: 2 hidden"]',
+      '.kit-filter-dropdown__btn[aria-label="Project: All"]',
     );
     expect(projectFilter).not.toBeNull();
 
     projectFilter!.click();
     await tick();
+    const projectOptions = document.querySelectorAll<HTMLButtonElement>(
+      ".kit-filter-dropdown__item",
+    );
+    expect(projectOptions).toHaveLength(2);
+    expect(projectOptions[0]?.textContent).toContain("shared-label");
+    expect(projectOptions[1]?.textContent).toContain("shared-label");
+
+    projectOptions[1]!.click();
+    expect(usage.excludedProjectKeys).toBe("project-key-2");
+    expect(usage.excludedProjects).toBe("");
+
+    usage.summary = {
+      ...summary,
+      projectTotals: [summary.projectTotals[0]!],
+    };
+    await tick();
+    expect(
+      document.querySelectorAll(".kit-filter-dropdown__item"),
+    ).toHaveLength(2);
+
+    const deselectAll = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        ".kit-filter-dropdown__bulk-btn",
+      ),
+    ).find((button) => button.textContent?.trim() === "Deselect all");
+    expect(deselectAll).not.toBeUndefined();
+
+    deselectAll!.click();
+    expect(usage.excludedProjectKeys).toBe(
+      "project-key-1,project-key-2",
+    );
+
     const selectAll = Array.from(
       document.querySelectorAll<HTMLButtonElement>(
         ".kit-filter-dropdown__bulk-btn",

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -140,6 +140,7 @@ afterEach(() => {
   usage.toggles.attribution.view = "treemap";
   usage.excludedProjects = "";
   usage.excludedProjectKeys = "";
+  usage.knownProjects = [];
   settings.chartPalette = "agentsview";
   sessions.projects = [];
   yokedDates.setEnabled(false);
@@ -207,10 +208,25 @@ describe("UsagePage refresh behavior", () => {
       ...summary,
       projectTotals: [summary.projectTotals[0]!],
     };
+    await unmount(component);
+    component = mount(UsagePage, { target: document.body });
+    await flushEffects();
+
+    const remountedProjectFilter = document.querySelector<HTMLButtonElement>(
+      ".usage-toolbar .kit-filter-dropdown__btn",
+    );
+    expect(remountedProjectFilter).not.toBeNull();
+    remountedProjectFilter!.click();
     await tick();
     expect(
       document.querySelectorAll(".kit-filter-dropdown__item"),
     ).toHaveLength(2);
+    const remountedOptions = document.querySelectorAll<HTMLButtonElement>(
+      ".kit-filter-dropdown__item",
+    );
+    remountedOptions[1]!.click();
+    expect(usage.excludedProjectKeys).toBe("");
+
     usage.excludedProjectKeys = "unlisted-project-key";
 
     const deselectAll = Array.from(

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -138,6 +138,7 @@ afterEach(() => {
   usage.toggles.timeSeries.groupBy = "project";
   usage.toggles.attribution.groupBy = "project";
   usage.toggles.attribution.view = "treemap";
+  usage.excludedProjectKeys = "";
   settings.chartPalette = "agentsview";
   sessions.projects = [];
   yokedDates.setEnabled(false);
@@ -145,6 +146,42 @@ afterEach(() => {
 });
 
 describe("UsagePage refresh behavior", () => {
+  it("shows and clears project-key exclusions from the Project filter", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    router.route = "usage";
+    router.params = {};
+    usage.excludedProjectKeys = "project-key-1,project-key-2";
+    sessions.projects = [{ name: "visible-project", session_count: 4 }];
+
+    component = mount(UsagePage, { target: document.body });
+    await flushEffects();
+
+    const projectFilter = document.querySelector<HTMLButtonElement>(
+      '.kit-filter-dropdown__btn[aria-label="Project: 2 hidden"]',
+    );
+    expect(projectFilter).not.toBeNull();
+
+    projectFilter!.click();
+    await tick();
+    const selectAll = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        ".kit-filter-dropdown__bulk-btn",
+      ),
+    ).find((button) => button.textContent?.trim() === "Select all");
+    expect(selectAll).not.toBeUndefined();
+
+    selectAll!.click();
+    expect(usage.excludedProjectKeys).toBe("");
+  });
+
   it("hydrates token mode from the canonical URL before fetching", async () => {
     vi.stubGlobal(
       "ResizeObserver",

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -211,6 +211,7 @@ describe("UsagePage refresh behavior", () => {
     expect(
       document.querySelectorAll(".kit-filter-dropdown__item"),
     ).toHaveLength(2);
+    usage.excludedProjectKeys = "unlisted-project-key";
 
     const deselectAll = Array.from(
       document.querySelectorAll<HTMLButtonElement>(
@@ -221,7 +222,7 @@ describe("UsagePage refresh behavior", () => {
 
     deselectAll!.click();
     expect(usage.excludedProjectKeys).toBe(
-      "project-key-1,project-key-2",
+      "unlisted-project-key,project-key-1,project-key-2",
     );
 
     const selectAll = Array.from(
@@ -233,6 +234,42 @@ describe("UsagePage refresh behavior", () => {
 
     selectAll!.click();
     expect(usage.excludedProjectKeys).toBe("");
+  });
+
+  it("shows legacy project-name exclusions until they are cleared", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    router.route = "usage";
+    router.params = {};
+    usage.excludedProjects = "legacy-project";
+    usage.summary = usageSummaryWithUnsupported();
+
+    component = mount(UsagePage, { target: document.body });
+    await flushEffects();
+
+    const projectFilter = document.querySelector<HTMLButtonElement>(
+      '.kit-filter-dropdown__btn[aria-label="Project: 1 hidden"]',
+    );
+    expect(projectFilter).not.toBeNull();
+
+    projectFilter!.click();
+    await tick();
+    const selectAll = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        ".kit-filter-dropdown__bulk-btn",
+      ),
+    ).find((button) => button.textContent?.trim() === "Select all");
+    expect(selectAll).not.toBeUndefined();
+
+    selectAll!.click();
+    expect(usage.excludedProjects).toBe("");
   });
 
   it("hydrates token mode from the canonical URL before fetching", async () => {

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -522,7 +522,13 @@ class UsageStore {
   }
 
   deselectAllProjectKeys(all: string[]): void {
-    this.excludedProjectKeys = all.join(",");
+    const excluded = new Set(
+      this.excludedProjectKeys
+        ? this.excludedProjectKeys.split(",").filter(Boolean)
+        : [],
+    );
+    for (const key of all) excluded.add(key);
+    this.excludedProjectKeys = [...excluded].join(",");
     this.fetchAll();
   }
 

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -41,6 +41,12 @@ export interface UsagePairwiseSelection {
   right: UsagePairwiseSideSelection;
 }
 
+export interface UsageProjectFilterItem {
+  id: string;
+  name: string;
+  count?: number;
+}
+
 export type GroupBy = "project" | "model" | "agent";
 export type TimeSeriesView = "stacked-area" | "bars" | "lines";
 export type AttributionView = "treemap" | "list" | "bars";
@@ -217,6 +223,7 @@ class UsageStore {
   excludedAgents: string = $state("");
   excludedModels: string = $state("");
   selectedModels: string = $state("");
+  knownProjects: UsageProjectFilterItem[] = $state([]);
 
   constructor() {
     const saved = loadUsageFilters();
@@ -333,6 +340,39 @@ class UsageStore {
     return this.summary?.projectTotals.find(
       (entry) => entry.project_key === key,
     )?.project ?? "";
+  }
+
+  mergeKnownProjects(
+    projects: Array<{ project_key: string; project: string }>,
+    counts: Record<string, number>,
+  ): void {
+    if (projects.length === 0) return;
+    const byKey = new Map(
+      this.knownProjects.map((project) => [project.id, project]),
+    );
+    let changed = false;
+    for (const project of projects) {
+      if (!project.project_key || !project.project) continue;
+      const existing = byKey.get(project.project_key);
+      const count = counts[project.project_key];
+      if (
+        !existing ||
+        existing.name !== project.project ||
+        existing.count !== count
+      ) {
+        byKey.set(project.project_key, {
+          id: project.project_key,
+          name: project.project,
+          count,
+        });
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.knownProjects = [...byKey.values()].sort(
+        (a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id),
+      );
+    }
   }
 
   private pairwiseOptionsFor(

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -521,8 +521,8 @@ class UsageStore {
     this.fetchAll();
   }
 
-  deselectAllProjects(all: string[]): void {
-    this.excludedProjects = all.join(",");
+  deselectAllProjectKeys(all: string[]): void {
+    this.excludedProjectKeys = all.join(",");
     this.fetchAll();
   }
 


### PR DESCRIPTION
The Usage toolbar now identifies Project filter options by stable `project_key`
values while keeping resolved project names as display labels. This prevents
duplicate display names from sharing one control identity and keeps the toolbar
aligned with the project filter applied by the Usage requests.

The singleton Usage store retains projects seen in earlier summary responses,
so an excluded project remains individually restorable after leaving and
returning to the page. Bulk Deselect all adds the listed keys to existing
exclusions, so a filtered response that omits a hidden project cannot silently
clear it. Legacy name exclusions remain visibly active until Select all clears
both forms.

The mismatch began when attribution clicks switched to stable keys but the
toolbar continued to write name exclusions. A treemap click could hide a
project through `excludedProjectKeys` while the dropdown read
`excludedProjects`.

Stable keys remain response-scoped and stay out of URLs. Existing name-based
URL filters remain supported. The main review points are the stable-key
catalogue and bulk-selection state in `usage.svelte.ts` and the ID/label split
in `FilterDropdown.svelte`.
