### PR TITLE
fix(frontend): stop 1Password prompt in project picker

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "agentsview-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#c17ec002b99af750d1572388622bb8bf1db51667",
+        "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#b4227114b3f6cc5edaa9a7ebf6cab7dbec2f527e",
         "@lucide/svelte": "1.26.0",
         "@tanstack/virtual-core": "3.17.6",
         "dompurify": "3.4.13",
@@ -495,7 +495,7 @@
     },
     "node_modules/@kenn-io/kit-ui": {
       "version": "0.0.1",
-      "resolved": "git+https://github.com/kenn-io/kit-ui.git#c17ec002b99af750d1572388622bb8bf1db51667",
+      "resolved": "git+https://github.com/kenn-io/kit-ui.git#b4227114b3f6cc5edaa9a7ebf6cab7dbec2f527e",
       "integrity": "sha512-PO/q7UxzmgnlTnpKp7QIlxZFuf5IoIK/yFeq9d3Wb86PyQt1LVmHfumxPXjpJg0s22GlLINJOsFhe6pNEtsFRQ==",
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "agentsview-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#97be355ef25a02ce96de6da4f3627ed5b922c4c3",
+        "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#c17ec002b99af750d1572388622bb8bf1db51667",
         "@lucide/svelte": "1.26.0",
         "@tanstack/virtual-core": "3.17.6",
         "dompurify": "3.4.13",
@@ -495,8 +495,8 @@
     },
     "node_modules/@kenn-io/kit-ui": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/kenn-io/kit-ui.git#97be355ef25a02ce96de6da4f3627ed5b922c4c3",
-      "integrity": "sha512-CuJXIErLmTJBiHO8hbIm8vJ3WAgwk/H1lKtVcXYsxI2u8KlmPl+dqhLD1HyhuvELlvEPYQRIJhglcaIJk4g1Eg==",
+      "resolved": "git+https://github.com/kenn-io/kit-ui.git#c17ec002b99af750d1572388622bb8bf1db51667",
+      "integrity": "sha512-PO/q7UxzmgnlTnpKp7QIlxZFuf5IoIK/yFeq9d3Wb86PyQt1LVmHfumxPXjpJg0s22GlLINJOsFhe6pNEtsFRQ==",
       "license": "Apache-2.0",
       "bin": {
         "kit-ui-check": "bin/kit-ui-check.mjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "e2e": "playwright test"
   },
   "dependencies": {
-    "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#97be355ef25a02ce96de6da4f3627ed5b922c4c3",
+    "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#c17ec002b99af750d1572388622bb8bf1db51667",
     "@lucide/svelte": "1.26.0",
     "@tanstack/virtual-core": "3.17.6",
     "dompurify": "3.4.13",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "e2e": "playwright test"
   },
   "dependencies": {
-    "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#c17ec002b99af750d1572388622bb8bf1db51667",
+    "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#b4227114b3f6cc5edaa9a7ebf6cab7dbec2f527e",
     "@lucide/svelte": "1.26.0",
     "@tanstack/virtual-core": "3.17.6",
     "dompurify": "3.4.13",

--- a/frontend/src/lib/components/layout/ProjectTypeahead.svelte
+++ b/frontend/src/lib/components/layout/ProjectTypeahead.svelte
@@ -63,6 +63,7 @@
   {value}
   fallbackLabel={displayValue}
   {placeholder}
+  inputAttributes={{ "data-1p-ignore": "true" }}
   {title}
   {emptyLabel}
   {allowCustom}

--- a/frontend/src/lib/components/layout/ProjectTypeahead.test.ts
+++ b/frontend/src/lib/components/layout/ProjectTypeahead.test.ts
@@ -62,6 +62,17 @@ describe("ProjectTypeahead", () => {
     ).toBe("false");
   });
 
+  it("marks the project query for 1Password exclusion", async () => {
+    component = mount(ProjectTypeahead, {
+      target: document.body,
+      props: { projects, value: "", onselect: vi.fn() },
+    });
+
+    await fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByRole("combobox").getAttribute("data-1p-ignore")).toBe("true");
+  });
+
   it("can omit the all-projects option for a required selection", async () => {
     component = mount(ProjectTypeahead, {
       target: document.body,


### PR DESCRIPTION
Opening the All Projects picker could trigger 1Password's credential menu
because kit-ui's transient search input could not receive field-specific
browser integration attributes.

This pins the merged kit-ui Typeahead API and applies `data-1p-ignore` only to
project queries. Password and token fields elsewhere remain available to
password managers. The component regression opens the picker and checks the
rendered combobox marker.
