### PR TITLE
ci: adopt Windows 11 ARM VS2026 runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - windows-11-vs2026-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           - os: windows-latest
             goos: windows
             goarch: amd64
-          - os: windows-11-arm
+          - os: windows-11-vs2026-arm
             goos: windows
             goarch: arm64
 


### PR DESCRIPTION
Move the Windows ARM release build to the GA windows-11-vs2026-arm image now instead of waiting for the staged migration of windows-11-arm. The release continues to use the existing Go and pinned LLVM-MinGW toolchain; only the hosted runner image changes. The actionlint configuration lists the new label so workflow validation accepts it.
