### PR TITLE
fix(frontend): keep virtual rows aligned after sort toggle

### DIFF
--- a/frontend/e2e/virtualizer.spec.ts
+++ b/frontend/e2e/virtualizer.spec.ts
@@ -17,6 +17,7 @@ const SESSIONS = {
   ALPHA_5: { project: "project-alpha", count: 3, displayRows: 5 },
   ALPHA_2: { project: "project-alpha", count: 2, displayRows: 2 },
   BETA_6: { project: "project-beta", count: 3, displayRows: 5 },
+  DELTA_5500: { project: "project-delta", count: 2750 },
 };
 
 function getSessionItem(
@@ -102,6 +103,10 @@ async function waitForLayoutSettle(page: Page, itemCount: number) {
  * virtual rows by checking translateY positions against heights.
  */
 async function verifyNoVerticalGaps(rows: Locator) {
+  expect(await maxVerticalGap(rows)).toBeLessThanOrEqual(1);
+}
+
+async function maxVerticalGap(rows: Locator) {
   const positions = await rows.evaluateAll((els) =>
     els.map((el) => {
       const style = el.style.transform;
@@ -115,13 +120,17 @@ async function verifyNoVerticalGaps(rows: Locator) {
     }),
   );
 
+  let maxGap = 0;
   for (let i = 0; i < positions.length - 1; i++) {
     const current = positions[i]!;
     const next = positions[i + 1]!;
     const expectedNextStart = current.translateY + current.height;
-    expect(Math.abs(expectedNextStart - next.translateY))
-      .toBeLessThanOrEqual(1);
+    maxGap = Math.max(
+      maxGap,
+      Math.abs(expectedNextStart - next.translateY),
+    );
   }
+  return maxGap;
 }
 
 test.beforeEach(async ({ page }) => {
@@ -242,20 +251,43 @@ test.describe("Virtualizer measurement", () => {
     expect(heightA).not.toBe(heightB);
   });
 
-  test("message virtualizer stays populated across sort toggles", async ({
+  test("message rows stay adjacent across deep sort toggles", async ({
     page,
   }) => {
-    const { project, count, displayRows } = SESSIONS.ALPHA_5;
+    const { project, count } = SESSIONS.DELTA_5500;
     const sid = await selectSession(page, project, count);
-    await expectSessionLoaded(page, sid, displayRows);
+    await expectSessionLoaded(page, sid);
 
     const rows = page.locator(LOC.row);
+    const scroller = page.locator(LOC.listScroll);
     const sortButton = page.getByLabel("Toggle sort order");
-    await sortButton.click();
-    await expect(rows.first()).toBeVisible({ timeout: 5_000 });
+    await page.addStyleTag({
+      content: `
+        .message.is-user { height: 320px; overflow: hidden; }
+        .message:not(.is-user) { height: 80px; overflow: hidden; }
+      `,
+    });
+    await scroller.evaluate((element) => {
+      element.scrollTop = element.scrollHeight * 0.65;
+    });
+    await expect
+      .poll(() => scroller.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+    await expect
+      .poll(() => maxVerticalGap(rows))
+      .toBeLessThanOrEqual(1);
 
     await sortButton.click();
     await expect(rows.first()).toBeVisible({ timeout: 5_000 });
+    await expect
+      .poll(() => maxVerticalGap(rows))
+      .toBeLessThanOrEqual(1);
+
+    await sortButton.click();
+    await expect(rows.first()).toBeVisible({ timeout: 5_000 });
+    await expect
+      .poll(() => maxVerticalGap(rows))
+      .toBeLessThanOrEqual(1);
   });
 
   test("session switch without explicit row count wait", async ({

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -108,8 +108,8 @@
     displayedOrdinals.join(","),
   );
 
-  function itemAt(index: number) {
-    if (ui.sortNewestFirst) {
+  function itemAt(index: number, newestFirst = ui.sortNewestFirst) {
+    if (newestFirst) {
       const mapped = displayItemsAsc.length - 1 - index;
       return displayItemsAsc[mapped];
     }
@@ -120,6 +120,7 @@
     const count = displayItemsAsc.length;
     const el = containerRef ?? null;
     const sid = sessions.activeSessionId ?? "";
+    const newestFirst = ui.sortNewestFirst;
     return {
       count,
       getScrollElement: () => el,
@@ -128,7 +129,7 @@
       useAnimationFrameWithResizeObserver: true,
       measureCacheKey: sid,
       getItemKey: (index: number) => {
-        const item = itemAt(index);
+        const item = itemAt(index, newestFirst);
         if (!item) return `${sid}-${index}`;
         if (item.kind === "tool-group") {
           return `${sid}-tg-${item.ordinals[0]}`;


### PR DESCRIPTION
Transcript rows now remain adjacent when users toggle between oldest-first and newest-first order, including after deep scrolling through mixed-height messages.

The sort direction is now a reactive input to the message virtualizer, so item keys and cached measurements stay aligned with the rendered order instead of leaving gaps or overlaps. The focused browser regression uses uneven row heights and repeated deep-scroll toggles. The key review point is the virtualizer options closure in `MessageList.svelte`.