### PR TITLE
feat(parser): collect IcodeMate terminal CLI session transcripts

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1650,18 +1650,50 @@ add an archived or maintained mirror without replacing the original identity.
 
 ## ICodeMate (`icodemate`)
 
-- **Format:** OpenCode-compatible SQLite or legacy session/message/part storage.
+- **Format:** Two storage families under one agent, matched by on-disk layout:
+  the VSCode-extension OpenCode-compatible SQLite or legacy
+  session/message/part storage, and the terminal CLI Claude-format projects
+  JSONL (`<projectsRoot>/<project>/<session>.jsonl`).
 - **Evidence:** `no-public-source`.
 - **Upstream:** ICodeMate's first-party product pages, documentation, and public
   GitHub repository search were checked 2026-07-19 without finding producer
   source or an authoritative disk schema. The OpenCode source pinned in the
-  `opencode` entry is compatible-family evidence only.
+  `opencode` entry is compatible-family evidence for the VSCode path only; the
+  terminal CLI path's Claude-format transcript schema (type/user/assistant
+  records carrying uuid, parentUuid, sessionId, cwd, gitBranch, timestamp, and
+  message.usage token fields) is compatible-family evidence from the `claude`
+  entry.
 - **Usage and cost:** Compatible messages can persist input, output, cache-read,
   cache-write, and model identity. Agentsview catalog-prices these values and
   consumes no product-reported USD total.
 - **Agentsview:** `internal/parser/icodemate.go` delegates to
-  `internal/parser/opencode.go`; product-specific divergence is a known
-  limitation.
+  `internal/parser/opencode.go` for the VSCode OpenCode path;
+  `internal/parser/icodemate_cli.go` parses the Claude-format CLI projects
+  transcripts, and `internal/parser/icodemate_provider.go` fans the configured
+  roots out to whichever layout each root owns. Product-specific divergence is
+  a known limitation. Reverified 2026-08-22 with controlled compatible-format
+  fixtures: the CLI parser uses the Claude UUID/parent UUID graph, coalesces
+  repeated assistant message snapshots by message ID, and resolves local and
+  S3-materialized persisted tool-result sidecars before extracting content.
+  Local sidecar writes map back to their owning transcript and participate in
+  its content-based, extraction-root-independent freshness fingerprint. Remote
+  imports resolve persisted paths against their extracted sidecars before
+  parsing. CLI project attribution uses transcript cwd and branch metadata to
+  resolve repository subdirectories and managed worktrees. Transcript identity
+  is the filename session ID across configured roots, so duplicate or moved
+  copies reconcile as one `icodemate:` session. Branch reconciliation follows
+  that identity across prior and current source paths and archive rebuilds. S3
+  subagent refreshes retain archived parent provider and machine metadata
+  instead of importing ICodeMate children as Claude. S3 discovery also
+  preserves transcript-only size and mtime separately from composite sidecar
+  freshness. A trailing partial local or S3 JSONL record stays incomplete and
+  retryable without replacing archived branch content. Polling includes local
+  and S3 sidecar mtimes, shortened CLI transcripts replace archived messages,
+  and duplicate ranking uses transcript metadata rather than sidecar volume.
+  Complete CLI parses reconcile the transcript's current branch membership,
+  and source freshness is recorded only after every emitted branch commits;
+  unchanged S3 transcripts use that persisted all-branch state to skip object
+  downloads.
 
 ## WorkBuddy (`workbuddy`)
 

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -124,6 +124,16 @@ func (db *DB) FileBackedSessionCountForRebuildOwner(
 			continue
 		}
 		seenAgents[agent] = struct{}{}
+		if agent == string(parser.AgentIcodemate) {
+			// ICodeMate shares one agent label across OpenCode containers and
+			// ordinary CLI JSONL transcripts. Keep the CLI rows protected by
+			// empty-discovery safety while excluding the self-preserving
+			// container layouts.
+			conditions = append(conditions,
+				`(agent <> ? OR lower(file_path) LIKE '%.jsonl')`)
+			args = append(args, agent)
+			continue
+		}
 		conditions = append(conditions, `agent <> ?`)
 		args = append(args, agent)
 	}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -79,6 +79,17 @@ func (db *DB) FileBackedSessionCountForSource(
 	return db.fileBackedSessionCount(ctx, machine, idPrefix, true)
 }
 
+// RebuildAgentExclusion names an agent whose sessions leave the protected
+// rebuild count. KeepJSONLRows spares the agent's Claude-layout .jsonl
+// transcript rows: ICodeMate shares one agent label across self-preserving
+// OpenCode containers and ordinary CLI transcripts, and the coordinator
+// decides per resync whether the transcript rows stay protected (provider
+// enabled) or leave with the rest (provider disabled, nothing discovered).
+type RebuildAgentExclusion struct {
+	Agent         string
+	KeepJSONLRows bool
+}
+
 // FileBackedSessionCountForRebuildOwner returns the protected root-session
 // count owned by the local rebuild phase. Current, empty, and legacy local
 // machine values cover archives created before source baselines; exact
@@ -89,7 +100,7 @@ func (db *DB) FileBackedSessionCountForRebuildOwner(
 	ctx context.Context,
 	localMachine string,
 	excludedIDPrefixes []string,
-	excludedAgents []string,
+	excludedAgents []RebuildAgentExclusion,
 ) (int, error) {
 	conditions := []string{`(
 		machine = ? OR machine = '' OR machine = 'local' OR EXISTS (
@@ -116,26 +127,22 @@ func (db *DB) FileBackedSessionCountForRebuildOwner(
 		args = append(args, prefix, prefix)
 	}
 	seenAgents := make(map[string]struct{}, len(excludedAgents))
-	for _, agent := range excludedAgents {
-		if agent == "" {
+	for _, exclusion := range excludedAgents {
+		if exclusion.Agent == "" {
 			continue
 		}
-		if _, seen := seenAgents[agent]; seen {
+		if _, seen := seenAgents[exclusion.Agent]; seen {
 			continue
 		}
-		seenAgents[agent] = struct{}{}
-		if agent == string(parser.AgentIcodemate) {
-			// ICodeMate shares one agent label across OpenCode containers and
-			// ordinary CLI JSONL transcripts. Keep the CLI rows protected by
-			// empty-discovery safety while excluding the self-preserving
-			// container layouts.
+		seenAgents[exclusion.Agent] = struct{}{}
+		if exclusion.KeepJSONLRows {
 			conditions = append(conditions,
 				`(agent <> ? OR lower(file_path) LIKE '%.jsonl')`)
-			args = append(args, agent)
+			args = append(args, exclusion.Agent)
 			continue
 		}
 		conditions = append(conditions, `agent <> ?`)
-		args = append(args, agent)
+		args = append(args, exclusion.Agent)
 	}
 
 	var count int

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -35,3 +35,52 @@ func TestFileBackedSessionCount_ExcludesNonDevinNonFileBackedAgents(
 	assert.Equal(t, 2, count,
 		"FileBackedSessionCount should include claude plus devin, but exclude other non-file-backed agents")
 }
+
+func TestFileBackedSessionCountForRebuildOwner_IcodemateExclusions(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	containerPath := "/home/user/.local/share/icodemate/icodemate.db"
+	cliPath := "/home/user/.icodemate/cli/projects/proj/abc.jsonl"
+	insertSession(t, d, "icodemate:container-1", "proj",
+		func(s *Session) {
+			s.Agent = "icodemate"
+			s.FilePath = &containerPath
+		})
+	insertSession(t, d, "icodemate:cli-1", "proj",
+		func(s *Session) {
+			s.Agent = "icodemate"
+			s.FilePath = &cliPath
+		})
+	insertSession(t, d, "claude-1", "proj")
+
+	tests := []struct {
+		name          string
+		keepJSONLRows bool
+		want          int
+	}{
+		{
+			name:          "enabled provider keeps CLI transcript rows protected",
+			keepJSONLRows: true,
+			want:          2,
+		},
+		{
+			name:          "disabled provider excludes every icodemate row",
+			keepJSONLRows: false,
+			want:          1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := d.FileBackedSessionCountForRebuildOwner(
+				ctx, defaultMachine, nil, []RebuildAgentExclusion{
+					{Agent: "icodemate", KeepJSONLRows: tt.keepJSONLRows},
+				},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, count)
+		})
+	}
+}

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -115,32 +115,35 @@ func claudeParseFile(
 
 	// First pass: collect all valid lines with metadata.
 	var (
-		entries         = make([]dagEntry, 0)
-		queuedCommands  []claudeQueuedCommand
-		hasAnyUUID      bool
-		allHaveUUID     bool
-		parentSessionID string
-		sourceSessionID string
-		sourceVersion   string
-		cwd             string
-		gitBranch       string
-		displayName     string
-		agentLabel      string
-		entrypoint      string
-		sessionKind     string
-		foundParentSID  bool
-		uploadSessionID string
-		uploadRoot      bool
-		uploadSidechain bool
-		uploadEvidence  = true
-		lineIndex       int
-		uuidLineOrdinal int
-		malformedLines  int
-		lastLineHasData bool
-		lastLineValid   bool
-		subagentMap     = map[string]string{}
-		globalStart     time.Time
-		globalEnd       time.Time
+		entries          = make([]dagEntry, 0)
+		queuedCommands   []claudeQueuedCommand
+		hasAnyUUID       bool
+		allHaveUUID      bool
+		parentSessionID  string
+		sourceSessionID  string
+		sourceVersion    string
+		cwd              string
+		gitBranch        string
+		displayName      string
+		compatibleName   string
+		compatibleAI     string
+		compatibleCustom string
+		agentLabel       string
+		entrypoint       string
+		sessionKind      string
+		foundParentSID   bool
+		uploadSessionID  string
+		uploadRoot       bool
+		uploadSidechain  bool
+		uploadEvidence   = true
+		lineIndex        int
+		uuidLineOrdinal  int
+		malformedLines   int
+		lastLineHasData  bool
+		lastLineValid    bool
+		subagentMap      = map[string]string{}
+		globalStart      time.Time
+		globalEnd        time.Time
 	)
 	allHaveUUID = true
 	if !opts.uploadIdentity {
@@ -183,6 +186,27 @@ func claudeParseFile(
 		}
 
 		entryType := gjson.GetBytes(lineBytes, "type").Str
+		if opts.compatibleTitleEvents {
+			if compatibleName == "" {
+				compatibleName = strings.Clone(strings.TrimSpace(
+					gjson.GetBytes(lineBytes, "sessionName").Str,
+				))
+			}
+			switch entryType {
+			case "custom-title":
+				if value := strings.TrimSpace(
+					gjson.GetBytes(lineBytes, "customTitle").Str,
+				); value != "" {
+					compatibleCustom = strings.Clone(value)
+				}
+			case "ai-title":
+				if value := strings.TrimSpace(
+					gjson.GetBytes(lineBytes, "aiTitle").Str,
+				); value != "" {
+					compatibleAI = strings.Clone(value)
+				}
+			}
+		}
 		if agentLabel == "" {
 			if value := gjson.GetBytes(lineBytes, "agentSetting").Str; strings.TrimSpace(value) != "" {
 				agentLabel = strings.Clone(value)
@@ -298,6 +322,7 @@ func claudeParseFile(
 		}
 		line, err := resolveClaudePersistedToolResultsContext(
 			ctx, path, compactClaudeEntry(lineBytes),
+			opts.persistedOutputPathResolver,
 		)
 		if err != nil {
 			return nil, nil, err
@@ -390,6 +415,11 @@ func claudeParseFile(
 		Path:  path,
 		Size:  info.Size(),
 		Mtime: info.ModTime().UnixNano(),
+	}
+	if opts.compatibleTitleEvents {
+		displayName = firstNonEmptyJSONLString(
+			compatibleCustom, compatibleAI, compatibleName, displayName,
+		)
 	}
 
 	meta := claudeSessionMeta{
@@ -2200,13 +2230,14 @@ func splitCleanPath(path string) []string {
 
 func resolveClaudePersistedToolResults(sessionPath, line string) string {
 	resolved, _ := resolveClaudePersistedToolResultsContext(
-		context.Background(), sessionPath, line,
+		context.Background(), sessionPath, line, nil,
 	)
 	return resolved
 }
 
 func resolveClaudePersistedToolResultsContext(
 	ctx context.Context, sessionPath, line string,
+	pathResolver func(string) (string, bool),
 ) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
@@ -2259,6 +2290,11 @@ func resolveClaudePersistedToolResultsContext(
 		}
 		if path == "" {
 			continue
+		}
+		if pathResolver != nil {
+			if resolved, ok := pathResolver(path); ok {
+				path = resolved
+			}
 		}
 		output, ok, err := readClaudePersistedToolResultContext(
 			ctx, sessionPath, path,

--- a/internal/parser/claude_lineage.go
+++ b/internal/parser/claude_lineage.go
@@ -73,16 +73,19 @@ var (
 	claudeSniffCache = map[string]claudeSniffCacheEntry{}
 )
 
-// claudeParseOptions gates opt-in parse behaviors that only the local
-// Claude provider enables. Uploads, Cowork, and Qoder reuse the Claude
-// parse body and must keep every option off.
+// claudeParseOptions gates opt-in parse behaviors for providers that reuse the
+// Claude transcript pipeline.
 type claudeParseOptions struct {
-	ctx context.Context
+	ctx                         context.Context
+	persistedOutputPathResolver func(string) (string, bool)
 	// siblingLineage enables background-fork lineage resolution
 	// against sibling transcripts in the same directory.
 	siblingLineage bool
 	// uploadIdentity enables adoption of explicit rooted transcript IDs.
 	uploadIdentity bool
+	// compatibleTitleEvents enables the sessionName, custom-title, and
+	// ai-title fields written by compatible transcript producers.
+	compatibleTitleEvents bool
 }
 
 // claudeLineagePlan describes an established fork lineage: the leading

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -265,12 +265,52 @@ func claudeSourceIsProjectLevel(source SourceRef, path string) bool {
 		!strings.HasPrefix(parts[1], "agent-")
 }
 
+// claudeLayoutSpec parameterizes claudeSourceSet over the agents that store
+// transcripts in Claude Code's projects layout
+// (<root>/<project>/<session>.jsonl with optional subagents/ trees and
+// per-session tool-results/ companion directories). Discovery, watch,
+// changed-path classification, find, and fingerprint plumbing are identical
+// across these agents; only the labels and the sidecar-freshness contract
+// differ. Parse semantics stay on each provider: Claude keeps incremental
+// appends and sibling lineage, while ICodeMate CLI relabels the shared DAG
+// parse onto its own agent and ID prefix.
+type claudeLayoutSpec struct {
+	agent         AgentType
+	dirLabel      string
+	debounceScope string
+	watchGlobs    []string
+	listFiles     func(string) []DiscoveredFile
+	// sidecarSources includes persisted tool-result companions in watch
+	// coverage, changed-path mapping, and source fingerprints. The Claude
+	// provider keeps this off: its stored fingerprints hash only the
+	// transcript, and switching to composite hashes would invalidate every
+	// archived Claude fingerprint and force a full reparse.
+	sidecarSources bool
+}
+
+func claudeLayoutSpecClaude() claudeLayoutSpec {
+	return claudeLayoutSpec{
+		agent:         AgentClaude,
+		dirLabel:      "Claude project directory",
+		debounceScope: "projects",
+		watchGlobs:    []string{"*.jsonl"},
+		listFiles:     ClaudeProjectSessionFiles,
+	}
+}
+
 type claudeSourceSet struct {
+	spec  claudeLayoutSpec
 	roots []string
 }
 
 func newClaudeSourceSet(roots []string) claudeSourceSet {
-	return claudeSourceSet{roots: cleanJSONLRoots(roots)}
+	return newClaudeLayoutSourceSet(claudeLayoutSpecClaude(), roots)
+}
+
+func newClaudeLayoutSourceSet(
+	spec claudeLayoutSpec, roots []string,
+) claudeSourceSet {
+	return claudeSourceSet{spec: spec, roots: cleanJSONLRoots(roots)}
 }
 
 func (s claudeSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
@@ -280,7 +320,7 @@ func (s claudeSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		for _, file := range ClaudeProjectSessionFiles(root) {
+		for _, file := range s.spec.listFiles(root) {
 			source, ok := s.discoveredSourceRef(root, file)
 			if !ok {
 				continue
@@ -300,7 +340,7 @@ func (s claudeSourceSet) DiscoverEach(
 			return err
 		}
 		if strings.HasPrefix(root, "s3://") {
-			for _, file := range ClaudeProjectSessionFiles(root) {
+			for _, file := range s.spec.listFiles(root) {
 				source, ok := s.discoveredSourceRef(root, file)
 				if ok {
 					if err := yield(source); err != nil {
@@ -324,7 +364,7 @@ func (s claudeSourceSet) streamLocalRoot(
 	var incomplete error
 	err := streamDirectoryEntries(ctx, root, func(project os.DirEntry) error {
 		isProjectDir, dirErr := streamingDirCandidateOrIncomplete(
-			AgentClaude, "Claude project directory", project, root,
+			s.spec.agent, s.spec.dirLabel, project, root,
 		)
 		if dirErr != nil {
 			incomplete = errors.Join(incomplete, dirErr)
@@ -364,10 +404,10 @@ func (s claudeSourceSet) streamLocalRoot(
 	return errors.Join(incomplete, err)
 }
 
-// discoveredSourceRef builds the SourceRef for one enumerated Claude session
-// file. Local files resolve through the regular file-backed source ref; s3://
-// objects (which ClaudeProjectSessionFiles enumerates via claudeS3Scanner)
-// carry their durable object metadata in the Opaque payload, because the
+// discoveredSourceRef builds the SourceRef for one enumerated session file.
+// Local files resolve through the regular file-backed source ref; s3://
+// objects (which spec.listFiles enumerates via the agent's S3 scanner) carry
+// their durable object metadata in the Opaque payload, because the
 // IsRegularFile gate that sourceRef applies to a local path would otherwise drop
 // every remote object.
 func (s claudeSourceSet) discoveredSourceRef(
@@ -388,8 +428,9 @@ func (s claudeSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 		roots = append(roots, WatchRoot{
 			Path:         root,
 			Recursive:    true,
-			IncludeGlobs: []string{"*.jsonl"},
-			DebounceKey:  string(AgentClaude) + ":projects:" + root,
+			IncludeGlobs: s.spec.watchGlobs,
+			DebounceKey: string(s.spec.agent) + ":" +
+				s.spec.debounceScope + ":" + root,
 		})
 	}
 	return WatchPlan{Roots: roots}, nil
@@ -416,6 +457,11 @@ func (s claudeSourceSet) SourcesForChangedPath(
 		if !s.hasRoot(root) {
 			return nil, nil
 		}
+		if s.spec.sidecarSources {
+			if sources, err := s.sourcesForToolResultPath(root, req.Path); err != nil || len(sources) > 0 {
+				return sources, err
+			}
+		}
 		source, ok := s.sourceForChangedPath(root, req.Path, allowMissing)
 		if !ok {
 			return nil, nil
@@ -423,6 +469,11 @@ func (s claudeSourceSet) SourcesForChangedPath(
 		return []SourceRef{source}, nil
 	}
 	for _, root := range s.roots {
+		if s.spec.sidecarSources {
+			if sources, err := s.sourcesForToolResultPath(root, req.Path); err != nil || len(sources) > 0 {
+				return sources, err
+			}
+		}
 		source, ok := s.sourceForChangedPath(root, req.Path, allowMissing)
 		if ok {
 			return []SourceRef{source}, nil
@@ -472,7 +523,9 @@ func (s claudeSourceSet) Fingerprint(
 	}
 	path, ok := s.pathFromSource(source)
 	if !ok {
-		return SourceFingerprint{}, fmt.Errorf("claude source path unavailable")
+		return SourceFingerprint{}, fmt.Errorf(
+			"%s source path unavailable", s.spec.agent,
+		)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -481,15 +534,21 @@ func (s claudeSourceSet) Fingerprint(
 	if info.IsDir() {
 		return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", path)
 	}
-	hash, err := hashJSONLSourceFileContext(ctx, path)
+	size, mtime := info.Size(), info.ModTime().UnixNano()
+	var hash string
+	if s.spec.sidecarSources {
+		hash, size, mtime, err = claudeLayoutCompositeFingerprint(ctx, path, info)
+	} else {
+		hash, err = hashJSONLSourceFileContext(ctx, path)
+	}
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
 	inode, device := sourceFileIdentity(info)
 	return SourceFingerprint{
 		Key:     firstNonEmptyJSONLString(source.FingerprintKey, source.Key, path),
-		Size:    info.Size(),
-		MTimeNS: info.ModTime().UnixNano(),
+		Size:    size,
+		MTimeNS: mtime,
 		Inode:   inode,
 		Device:  device,
 		Hash:    hash,
@@ -556,7 +615,7 @@ func (s claudeSourceSet) sourceRefFromPath(root, path string) (SourceRef, bool) 
 		return SourceRef{}, false
 	}
 	return SourceRef{
-		Provider:       AgentClaude,
+		Provider:       s.spec.agent,
 		Key:            path,
 		DisplayPath:    path,
 		FingerprintKey: path,

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -57,6 +57,10 @@ type DiscoveredFile struct {
 	Machine     string    // source machine override; empty = engine default
 	SourceSize  int64     // source object size for s3:// sources
 	SourceMtime int64     // source object mtime for s3:// sources, UnixNano
+	// TranscriptSize and TranscriptMtime retain the primary JSONL object's
+	// metadata when SourceSize and SourceMtime include persisted-result sidecars.
+	TranscriptSize  int64
+	TranscriptMtime int64
 	// SourceFingerprint is a durable object fingerprint for s3:// sources.
 	SourceFingerprint string
 	ForceParse        bool // caller requires freshness bypass
@@ -427,8 +431,31 @@ func ResolveCodexShallowWatchRoots(root string) []string {
 // expansion. The name carries no legacy entrypoint verb so the
 // provider can call it without shimming a Discover* free function.
 func ClaudeProjectSessionFiles(projectsDir string) []DiscoveredFile {
+	return projectJSONLSessionFiles(projectsDir, AgentClaude, claudeS3Scanner)
+}
+
+// IcodemateCLIProjectSessionFiles enumerates a terminal CLI projects root in
+// the same Claude-layout terms as ClaudeProjectSessionFiles, labeling every
+// discovered transcript with AgentIcodemate and scanning s3:// roots against
+// the icodemate provider segment (.../raw/icodemate) so machine metadata and
+// source labeling match the owning agent instead of Claude's.
+func IcodemateCLIProjectSessionFiles(projectsDir string) []DiscoveredFile {
+	return projectJSONLSessionFiles(projectsDir, AgentIcodemate, icodemateCLIS3Scanner)
+}
+
+// projectJSONLSessionFiles walks one Claude-layout projects root
+// (<root>/<project>/*.jsonl plus nested subagents trees) labeling each
+// DiscoveredFile with the owning agent, and routes s3:// roots through the
+// agent's own S3 scanner so the provider segment and agent metadata match.
+// Transient read errors on individual projects are skipped: a project
+// directory echoed by a concurrent watch may disappear mid-walk.
+func projectJSONLSessionFiles(
+	projectsDir string,
+	agent AgentType,
+	scanner func() S3SessionScanner,
+) []DiscoveredFile {
 	if strings.HasPrefix(projectsDir, "s3://") {
-		return s3PrefixScan(projectsDir, claudeS3Scanner())
+		return s3PrefixScan(projectsDir, scanner())
 	}
 	entries, err := os.ReadDir(projectsDir)
 	if err != nil {
@@ -462,7 +489,7 @@ func ClaudeProjectSessionFiles(projectsDir string) []DiscoveredFile {
 			files = append(files, DiscoveredFile{
 				Path:    filepath.Join(projDir, name),
 				Project: entry.Name(),
-				Agent:   AgentClaude,
+				Agent:   agent,
 			})
 		}
 
@@ -492,7 +519,7 @@ func ClaudeProjectSessionFiles(projectsDir string) []DiscoveredFile {
 					files = append(files, DiscoveredFile{
 						Path:    path,
 						Project: entry.Name(),
-						Agent:   AgentClaude,
+						Agent:   agent,
 					})
 					return nil
 				},

--- a/internal/parser/icodemate_cli.go
+++ b/internal/parser/icodemate_cli.go
@@ -1,0 +1,388 @@
+package parser
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Icodemate exposes two storage families under the single icodemate agent:
+// the VSCode-extension plugin path (OpenCode storage on
+// ~/.local/share/icodemate, owned by the OpenCode-format source set) and the
+// terminal CLI path (~/.icodemate/cli/projects), whose per-session JSONL
+// transcripts match Claude Code's project layout
+// (<root>/<project>/<session>.jsonl). The CLI source set is the shared
+// claudeSourceSet instantiated with Icodemate's layout spec; only Parse is
+// owned here, relabeling every parsed session onto Icodemate's agent and
+// icodemate: ID prefix.
+
+var _ SourceSet = (*icodemateCLISourceSet)(nil)
+
+type icodemateCLISourceSet struct {
+	claudeSourceSet
+}
+
+func newIcodemateCLISourceSet(roots []string) *icodemateCLISourceSet {
+	return &icodemateCLISourceSet{
+		claudeSourceSet: newClaudeLayoutSourceSet(
+			claudeLayoutSpecIcodemateCLI(), roots,
+		),
+	}
+}
+
+// claudeLayoutSpecIcodemateCLI adapts the shared Claude projects layout to
+// the ICodeMate terminal CLI. Watch coverage carries no *.jsonl glob and
+// sidecarSources is on because persisted tool-result companions participate
+// in freshness: a sidecar-only change must invalidate the owning transcript.
+func claudeLayoutSpecIcodemateCLI() claudeLayoutSpec {
+	return claudeLayoutSpec{
+		agent:          AgentIcodemate,
+		dirLabel:       "IcodeMate CLI project directory",
+		debounceScope:  "cli-projects",
+		listFiles:      IcodemateCLIProjectSessionFiles,
+		sidecarSources: true,
+	}
+}
+
+func (s *icodemateCLISourceSet) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	if err := ctx.Err(); err != nil {
+		return ParseOutcome{}, err
+	}
+	path, ok := s.pathFromSource(req.Source)
+	if !ok {
+		return ParseOutcome{}, fmt.Errorf("icodemate cli source path unavailable")
+	}
+	machine := firstNonEmptyJSONLString(req.Machine)
+	project := claudeProviderProject(ctx, firstNonEmptyJSONLString(
+		req.Source.ProjectHint,
+		filepath.Base(filepath.Dir(path)),
+	), path)
+	var persistedOutputPathResolver func(string) (string, bool)
+	if req.StoredPathResolver != nil {
+		persistedOutputPathResolver = func(path string) (string, bool) {
+			if local, ok := req.StoredPathResolver(path); ok {
+				return local, true
+			}
+			return req.StoredPathResolver(machine + ":" + path)
+		}
+	}
+	results, excludedIDs, err := parseIcodemateCLISession(
+		ctx, path, project, machine, persistedOutputPathResolver,
+	)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if slices.ContainsFunc(results, func(result ParseResult) bool {
+		return result.Session.IsTruncated
+	}) {
+		return ParseOutcome{ResultSetComplete: false}, nil
+	}
+	for i := range results {
+		if req.Fingerprint.Size != 0 {
+			results[i].Session.File.Size = req.Fingerprint.Size
+		}
+		if req.Fingerprint.MTimeNS != 0 {
+			results[i].Session.File.Mtime = req.Fingerprint.MTimeNS
+		}
+		if req.Fingerprint.Hash != "" {
+			results[i].Session.File.Hash = req.Fingerprint.Hash
+		}
+	}
+	out := make([]ParseResultOutcome, 0, len(results))
+	for _, result := range results {
+		out = append(out, ParseResultOutcome{
+			Result:      result,
+			DataVersion: DataVersionCurrent,
+		})
+	}
+	return ParseOutcome{
+		Results:            out,
+		ExcludedSessionIDs: excludedIDs,
+		ResultSetComplete:  true,
+		ForceReplace:       true,
+	}, nil
+}
+
+// sourcesForToolResultPath maps a changed path under a per-session
+// tool-results directory back to the transcripts whose parses read it: the
+// owning session plus, for a root session's results, every subagent
+// transcript beneath it. It is consulted only for specs with sidecarSources.
+func (s claudeSourceSet) sourcesForToolResultPath(
+	root, changedPath string,
+) ([]SourceRef, error) {
+	root = filepath.Clean(root)
+	changedPath = filepath.Clean(changedPath)
+	rel, err := filepath.Rel(root, changedPath)
+	if err != nil || rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, nil
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	toolResultsAt := slices.Index(parts, "tool-results")
+	if toolResultsAt < 2 {
+		return nil, nil
+	}
+	toolDir := filepath.Join(append([]string{root}, parts[:toolResultsAt+1]...)...)
+	ownerBase := filepath.Dir(toolDir)
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	add := func(path string) {
+		source, ok := s.sourceRef(root, path)
+		if !ok {
+			return
+		}
+		if _, ok := seen[source.Key]; ok {
+			return
+		}
+		seen[source.Key] = struct{}{}
+		sources = append(sources, source)
+	}
+	add(ownerBase + ".jsonl")
+	if slices.Contains(parts[:toolResultsAt], "subagents") {
+		return sources, nil
+	}
+
+	subagentsRoot := filepath.Join(ownerBase, "subagents")
+	err = filepath.WalkDir(subagentsRoot, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "agent-") ||
+			!strings.HasSuffix(entry.Name(), ".jsonl") {
+			return nil
+		}
+		add(path)
+		return nil
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		err = nil
+	}
+	return sources, err
+}
+
+func claudeLayoutCompositeFingerprint(
+	ctx context.Context, path string, transcriptInfo os.FileInfo,
+) (hash string, size, mtime int64, err error) {
+	transcriptHash, err := hashJSONLSourceFileContext(ctx, path)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	h := sha256.New()
+	_, _ = fmt.Fprintf(h, "transcript\x00%s\x00", transcriptHash)
+	sidecars, size, mtime, err := claudeLayoutCompositeFileInfo(
+		ctx, path, transcriptInfo,
+	)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	transcriptDir := filepath.Dir(path)
+	for _, sidecar := range sidecars {
+		if err := ctx.Err(); err != nil {
+			return "", 0, 0, err
+		}
+		relativePath, relErr := filepath.Rel(transcriptDir, sidecar)
+		if relErr != nil {
+			return "", 0, 0, fmt.Errorf(
+				"resolve sidecar %s relative to %s: %w",
+				sidecar, path, relErr,
+			)
+		}
+		sidecarHash, hashErr := hashJSONLSourceFileContext(ctx, sidecar)
+		if hashErr != nil {
+			return "", 0, 0, hashErr
+		}
+		_, _ = fmt.Fprintf(
+			h, "sidecar\x00%s\x00%s\x00",
+			filepath.ToSlash(relativePath), sidecarHash,
+		)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), size, mtime, nil
+}
+
+// ClaudeLayoutCompositeFileInfo reports the same aggregate size and mtime used
+// by sidecar-composite source fingerprints. The sync duplicate resolver uses
+// it to compare a candidate against the committed source without ignoring
+// tool-result sidecars.
+func ClaudeLayoutCompositeFileInfo(path string) (size, mtime int64, err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	_, size, mtime, err = claudeLayoutCompositeFileInfo(
+		context.Background(), path, info,
+	)
+	return size, mtime, err
+}
+
+// ClaudeLayoutCompositeMtime reports the stat-only cutoff signal for a
+// transcript and its persisted tool results. Directory mtimes participate so
+// deleting a sidecar remains visible after its own file mtime disappears.
+func ClaudeLayoutCompositeMtime(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	mtime := info.ModTime().UnixNano()
+	for _, dir := range claudeToolResultDirs(path) {
+		// The session directory remains after tool-results is removed, and its
+		// mtime records that deletion. Do not fall back to the shared project
+		// directory when the session directory itself is absent: sibling session
+		// changes must not make this transcript look fresh.
+		parentInfo, parentErr := os.Stat(filepath.Dir(dir))
+		if parentErr == nil {
+			mtime = max(mtime, parentInfo.ModTime().UnixNano())
+		} else if !errors.Is(parentErr, os.ErrNotExist) {
+			return 0, parentErr
+		}
+		err := filepath.WalkDir(dir, func(
+			_ string, entry fs.DirEntry, walkErr error,
+		) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			info, infoErr := entry.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			mtime = max(mtime, info.ModTime().UnixNano())
+			return nil
+		})
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return 0, err
+		}
+	}
+	return mtime, nil
+}
+
+func claudeLayoutCompositeFileInfo(
+	ctx context.Context, path string, transcriptInfo os.FileInfo,
+) (sidecars []string, size, mtime int64, err error) {
+	sidecars, err = claudeLayoutSidecarFiles(ctx, path)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	size = transcriptInfo.Size()
+	mtime = transcriptInfo.ModTime().UnixNano()
+	for _, sidecar := range sidecars {
+		if err := ctx.Err(); err != nil {
+			return nil, 0, 0, err
+		}
+		info, statErr := os.Stat(sidecar)
+		if statErr != nil {
+			return nil, 0, 0, statErr
+		}
+		size += info.Size()
+		mtime = max(mtime, info.ModTime().UnixNano())
+	}
+	return sidecars, size, mtime, nil
+}
+
+func claudeLayoutSidecarFiles(
+	ctx context.Context, sessionPath string,
+) ([]string, error) {
+	seenDirs := make(map[string]struct{})
+	var files []string
+	for _, dir := range claudeToolResultDirs(sessionPath) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		dir = filepath.Clean(dir)
+		if _, ok := seenDirs[dir]; ok {
+			continue
+		}
+		seenDirs[dir] = struct{}{}
+		err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			if err != nil {
+				return err
+			}
+			if !entry.IsDir() {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	slices.Sort(files)
+	return slices.Compact(files), nil
+}
+
+// parseIcodemateCLISession parses one ICodeMate CLI JSONL transcript through
+// the shared Claude graph parser, then moves every result into ICodeMate's
+// namespace. Reusing the graph parser is required for fork selection,
+// streaming assistant snapshots, and persisted tool-result sidecars to keep
+// the same semantics as the compatible Claude transcript format.
+func parseIcodemateCLISession(
+	ctx context.Context, path, project, machine string,
+	persistedOutputPathResolver func(string) (string, bool),
+) ([]ParseResult, []string, error) {
+	results, excluded, err := claudeParseFile(
+		path, project, machine,
+		claudeParseOptions{
+			ctx: ctx, compatibleTitleEvents: true,
+			persistedOutputPathResolver: persistedOutputPathResolver,
+		},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("icodemate cli parse %s: %w", path, err)
+	}
+
+	InferRelationshipTypes(results)
+	applyIcodemateCLIIdentity(results)
+	for i := range excluded {
+		excluded[i] = icodemateCLISessionID(excluded[i])
+	}
+	return results, excluded, nil
+}
+
+func icodemateCLISessionID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" || strings.HasPrefix(id, "icodemate:") {
+		return id
+	}
+	return "icodemate:" + id
+}
+
+func applyIcodemateCLIIdentity(results []ParseResult) {
+	for i := range results {
+		result := &results[i]
+		result.Session.Agent = AgentIcodemate
+		result.Session.ID = icodemateCLISessionID(result.Session.ID)
+		result.Session.ParentSessionID = icodemateCLISessionID(
+			result.Session.ParentSessionID,
+		)
+		result.Session.SourceSessionID = icodemateCLISessionID(
+			result.Session.SourceSessionID,
+		)
+		for j := range result.Messages {
+			for k := range result.Messages[j].ToolCalls {
+				call := &result.Messages[j].ToolCalls[k]
+				call.SubagentSessionID = icodemateCLISessionID(
+					call.SubagentSessionID,
+				)
+				for n := range call.ResultEvents {
+					call.ResultEvents[n].SubagentSessionID =
+						icodemateCLISessionID(
+							call.ResultEvents[n].SubagentSessionID,
+						)
+				}
+			}
+		}
+	}
+}

--- a/internal/parser/icodemate_cli_test.go
+++ b/internal/parser/icodemate_cli_test.go
@@ -1,0 +1,617 @@
+package parser
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIcodemateCLIDefaultDirs asserts the terminal CLI projects root is a
+// default alongside the VSCode-extension OpenCode storage root, so both
+// families are collected out of the box.
+func TestIcodemateCLIDefaultDirs(t *testing.T) {
+	def, ok := AgentByType(AgentIcodemate)
+	require.True(t, ok, "AgentIcodemate missing from Registry")
+	assert.Contains(t, def.DefaultDirs, ".local/share/icodemate")
+	assert.Contains(t, def.DefaultDirs, ".icodemate/cli/projects")
+}
+
+// TestIcodemateCLIDiscoverParseAndFindSource builds a Claude-format projects
+// transcript under an IcodeMate CLI root and asserts the CLI source set
+// discovers it, parses it onto the icodemate agent with the icodemate: ID
+// prefix, and resolves it back through FindSource.
+func TestIcodemateCLIDiscoverParseAndFindSource(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "my-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	repo := filepath.Join(t.TempDir(), "canonical-project")
+	cwd := filepath.Join(repo, "internal", "parser")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	require.NoError(t, os.MkdirAll(cwd, 0o755))
+
+	path := filepath.Join(projectDir, "session-cli.jsonl")
+	content := strings.Join([]string{
+		buildMetadataLine(map[string]any{
+			"type": "user", "timestamp": tsEarly, "uuid": "u1", "parentUuid": "",
+			"cwd": cwd, "gitBranch": "main",
+			"message": map[string]any{"role": "user", "content": "hello cli"},
+		}),
+		buildMetadataLine(map[string]any{
+			"type": "assistant", "timestamp": tsEarlyS1, "uuid": "u2", "parentUuid": "u1",
+			"message": map[string]any{
+				"role": "assistant", "stop_reason": "end_turn",
+				"usage": map[string]any{
+					"input_tokens":                12,
+					"cache_creation_input_tokens": 3,
+					"cache_read_input_tokens":     2,
+					"output_tokens":               7,
+				},
+				"content": []map[string]any{{"type": "text", "text": "cli reply"}},
+			},
+		}),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	provider, ok := NewProvider(AgentIcodemate, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, path, discovered[0].Key)
+	assert.Equal(t, "my-project", discovered[0].ProjectHint)
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		FullSessionID: "icodemate:session-cli",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, path, found.Key)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      discovered[0],
+		Fingerprint: SourceFingerprint{Hash: "hash-cli"},
+	})
+	require.NoError(t, err)
+	require.True(t, outcome.ResultSetComplete)
+	require.True(t, outcome.ForceReplace)
+	require.Len(t, outcome.Results, 1)
+
+	sess := outcome.Results[0].Result.Session
+	msgs := outcome.Results[0].Result.Messages
+	assert.Equal(t, AgentIcodemate, sess.Agent)
+	assert.Equal(t, "icodemate:session-cli", sess.ID)
+	assert.Equal(t, "devbox", sess.Machine)
+	assert.Equal(t, "canonical_project", sess.Project)
+	assert.Equal(t, cwd, sess.Cwd)
+	assert.Equal(t, "main", sess.GitBranch)
+	assert.Equal(t, "hello cli", sess.FirstMessage)
+	assert.Equal(t, "hash-cli", sess.File.Hash)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, 7, msgs[1].OutputTokens)
+	assert.Equal(t, 17, msgs[1].ContextTokens)
+}
+
+func TestParseIcodemateCLIStreamingSnapshots(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "streaming.jsonl")
+	content := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_stream","content":[{"type":"text","text":"Work"}],"usage":{"input_tokens":1,"output_tokens":1}}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_stream","content":[{"type":"text","text":"Working"}],"usage":{"input_tokens":1,"output_tokens":2}}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:03Z","uuid":"a3","parentUuid":"a2","message":{"id":"msg_stream","content":[{"type":"text","text":"Working"}],"usage":{"input_tokens":1,"output_tokens":3}}}`,
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	results, excluded, err := parseIcodemateCLISession(
+		t.Context(), path, "project", "devbox", nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, excluded)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Messages, 2)
+	assert.Equal(t, "Working", results[0].Messages[1].Content)
+	assert.Equal(t, 3, results[0].Messages[1].OutputTokens)
+	assert.Equal(t, 3, results[0].Session.TotalOutputTokens)
+}
+
+func TestParseIcodemateCLISplitsDivergentBranches(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fork-session.jsonl")
+	content := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"root","message":{"content":"start"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"root","message":{"content":[{"type":"text","text":"main reply 1"}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":"main prompt 2"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"u3","parentUuid":"u2","message":{"content":"main prompt 3"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:04Z","uuid":"u4","parentUuid":"u3","message":{"content":"main prompt 4"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u5","parentUuid":"u4","message":{"content":"main prompt 5"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:06Z","uuid":"fork","parentUuid":"root","message":{"content":[{"type":"text","text":"fork reply"}]}}`,
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	results, excluded, err := parseIcodemateCLISession(
+		t.Context(), path, "project", "devbox", nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, excluded)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "icodemate:fork-session", results[0].Session.ID)
+	assert.Equal(t, AgentIcodemate, results[0].Session.Agent)
+	for _, message := range results[0].Messages {
+		assert.NotEqual(t, "fork reply", message.Content)
+	}
+
+	assert.Equal(t, "icodemate:fork-session-fork", results[1].Session.ID)
+	assert.Equal(t, "icodemate:fork-session", results[1].Session.ParentSessionID)
+	assert.Equal(t, RelFork, results[1].Session.RelationshipType)
+	require.Len(t, results[1].Messages, 1)
+	assert.Equal(t, "fork reply", results[1].Messages[0].Content)
+}
+
+func TestParseIcodemateCLIResolvesPersistedToolResult(t *testing.T) {
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "project", "parent-session")
+	resultPath := filepath.Join(sessionDir, "tool-results", "output.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(resultPath), 0o755))
+	fullOutput := "full output line 1\nfull output line 2\n"
+	require.NoError(t, os.WriteFile(resultPath, []byte(fullOutput), 0o644))
+
+	resultPathJSON, err := json.Marshal(resultPath)
+	require.NoError(t, err)
+	persistedContent, err := json.Marshal(
+		"<persisted-output>\nOutput too large. Full output saved to: " +
+			resultPath + "\n\nPreview:\npreview only\n</persisted-output>",
+	)
+	require.NoError(t, err)
+	content := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make logs"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + string(persistedContent) + `}]},"toolUseResult":{"persistedOutputPath":` + string(resultPathJSON) + `}}`,
+	}, "\n") + "\n"
+	sessionPath := filepath.Join(dir, "project", "parent-session.jsonl")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
+
+	results, excluded, err := parseIcodemateCLISession(
+		t.Context(), sessionPath, "project", "devbox", nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, excluded)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Messages, 3)
+	require.Len(t, results[0].Messages[2].ToolResults, 1)
+	assert.Equal(
+		t,
+		fullOutput,
+		DecodeContent(results[0].Messages[2].ToolResults[0].ContentRaw),
+	)
+}
+
+// TestIcodemateProviderMergesOpenCodeAndCLIRoots exercises the hybrid
+// provider over a single configured Roots list containing one OpenCode-format
+// root (VSCode extension) and one Claude-format CLI root. Each family's
+// session must be discovered and parsed through its own layout without
+// cross-contamination, both relabeled onto the icodemate agent.
+func TestIcodemateProviderMergesOpenCodeAndCLIRoots(t *testing.T) {
+	opencodeRoot := t.TempDir()
+	sessionPath := filepath.Join(
+		opencodeRoot, "storage", "session_diff", "global", "ses_vscode.json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id":        "ses_vscode",
+		"parentID":  "",
+		"directory": "/home/user/code/vscodeapp",
+		"title":     "VSCode Session",
+		"time":      map[string]any{"created": 1700000000000, "updated": 1700000060000},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		opencodeRoot, "storage", "message", "ses_vscode", "msg_1.json",
+	), map[string]any{
+		"id": "msg_1", "sessionID": "ses_vscode", "role": "user",
+		"time": map[string]any{"created": 1700000000000},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		opencodeRoot, "storage", "part", "msg_1", "prt_1.json",
+	), map[string]any{
+		"id": "prt_1", "sessionID": "ses_vscode", "messageID": "msg_1",
+		"type": "text", "text": "Hello from vscode",
+		"time": map[string]any{"created": 1700000000000},
+	})
+
+	cliRoot := t.TempDir()
+	projectDir := filepath.Join(cliRoot, "my-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	cliPath := filepath.Join(projectDir, "session-cli.jsonl")
+	cliContent := strings.Join([]string{
+		buildMetadataLine(map[string]any{
+			"type": "user", "timestamp": tsEarly, "uuid": "cu1", "parentUuid": "",
+			"message": map[string]any{"role": "user", "content": "hello cli"},
+		}),
+		buildMetadataLine(map[string]any{
+			"type": "assistant", "timestamp": tsEarlyS1, "uuid": "cu2", "parentUuid": "cu1",
+			"message": map[string]any{
+				"role": "assistant", "stop_reason": "end_turn",
+				"content": []map[string]any{{"type": "text", "text": "cli reply"}},
+			},
+		}),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(cliPath, []byte(cliContent), 0o644))
+
+	provider, ok := NewProvider(AgentIcodemate, ProviderConfig{
+		Roots:   []string{opencodeRoot, cliRoot},
+		Machine: "testmachine",
+	})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 2)
+
+	sourcesByKey := make(map[string]SourceRef, len(discovered))
+	for _, src := range discovered {
+		sourcesByKey[src.Key] = src
+	}
+	require.Contains(t, sourcesByKey, sessionPath)
+	require.Contains(t, sourcesByKey, cliPath)
+
+	for key, src := range sourcesByKey {
+		outcome, err := provider.Parse(context.Background(), ParseRequest{
+			Source: src, Machine: "testmachine",
+		})
+		require.NoError(t, err)
+		require.Len(t, outcome.Results, 1)
+		parsed := outcome.Results[0].Result.Session
+		assert.Equal(t, AgentIcodemate, parsed.Agent)
+		switch key {
+		case sessionPath:
+			assert.Equal(t, "icodemate:ses_vscode", parsed.ID)
+			assert.Equal(t, "Hello from vscode", outcome.Results[0].Result.Messages[0].Content)
+		case cliPath:
+			assert.Equal(t, "icodemate:session-cli", parsed.ID)
+			assert.Equal(t, "hello cli", parsed.FirstMessage)
+		}
+	}
+}
+
+// TestIcodemateCLIProviderDiscoversS3Sessions verifies the CLI source set
+// scans s3:// projects roots with the icodemate provider segment and agent
+// label: discovered sources carry Provider=AgentIcodemate, machine metadata
+// derived from the .../<machine>/raw/icodemate layout, and the folded
+// tool-result sidecar freshness identity -- never Claude's session or machine
+// namespace.
+func TestIcodemateCLIProviderDiscoversS3Sessions(t *testing.T) {
+	oldList := listS3Objects
+	t.Cleanup(func() { listS3Objects = oldList })
+
+	root := "s3://bucket/laptop/raw/icodemate"
+	sessionURI := root + "/proj/session.jsonl"
+	sessionMtime := time.Unix(100, 0)
+	sidecarMtime := time.Unix(200, 0)
+	listS3Objects = func(got string) ([]S3Object, error) {
+		require.Equal(t, root, got)
+		return []S3Object{
+			{
+				URI:          sessionURI,
+				Size:         11,
+				LastModified: sessionMtime,
+				Fingerprint:  "s3-meta:session",
+			},
+			{
+				URI:          root + "/proj/session/tool-results/out.txt",
+				Size:         22,
+				LastModified: sidecarMtime,
+				Fingerprint:  "s3-meta:sidecar",
+			},
+		}, nil
+	}
+
+	provider, ok := NewProvider(AgentIcodemate, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	src := sources[0]
+	assert.Equal(t, AgentIcodemate, src.Provider)
+	assert.Equal(t, sessionURI, src.DisplayPath)
+	assert.Equal(t, sessionURI, src.FingerprintKey)
+	assert.Equal(t, "proj", src.ProjectHint)
+
+	s3, ok := src.Opaque.(S3DiscoveredSource)
+	require.True(t, ok, "s3 source carries S3DiscoveredSource opaque")
+	assert.Equal(t, sessionURI, s3.URI)
+	assert.Equal(t, "laptop", s3.Machine)
+	assert.Equal(t, "proj", s3.Project)
+	assert.Equal(t, int64(33), s3.Size)
+	assert.Equal(t, sidecarMtime.UnixNano(), s3.MtimeNS)
+	assert.Equal(t, int64(11), s3.TranscriptSize)
+	assert.Equal(t, sessionMtime.UnixNano(), s3.TranscriptMtimeNS)
+	assert.Contains(t, s3.Fingerprint, "session")
+	assert.Contains(t, s3.Fingerprint, "sidecar")
+}
+
+// TestIcodemateCLIProviderParsesMaterializedSource covers the engine's S3
+// materialization path: an s3:// session fetched to a local temp file is
+// re-parsed through the hybrid provider with a MaterializedFileSource opaque.
+// The CLI source set must accept it so a materialized transcript parses onto
+// the icodemate agent and fingerprints through the same path.
+func TestIcodemateCLIProviderParsesMaterializedSource(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "my-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	path := filepath.Join(projectDir, "session-mat.jsonl")
+	writeSourceFile(t, path, claudeProviderFixture("hello materialized"))
+
+	provider, ok := NewProvider(AgentIcodemate, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	materialized := SourceRef{
+		Provider:       AgentIcodemate,
+		Key:            "s3://bucket/laptop/raw/icodemate/proj/session-mat.jsonl",
+		DisplayPath:    "s3://bucket/laptop/raw/icodemate/proj/session-mat.jsonl",
+		FingerprintKey: "s3://bucket/laptop/raw/icodemate/proj/session-mat.jsonl",
+		ProjectHint:    "my-project",
+		Opaque:         MaterializedFileSource{Path: path},
+	}
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: materialized, Machine: "devbox",
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	sess := outcome.Results[0].Result.Session
+	assert.Equal(t, AgentIcodemate, sess.Agent)
+	assert.Equal(t, "icodemate:session-mat", sess.ID)
+	assert.Equal(t, "hello materialized", sess.FirstMessage)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), materialized)
+	require.NoError(t, err)
+	// Key is the canonical metadata identity, not the materialized read path.
+	assert.Equal(t, materialized.Key, fingerprint.Key)
+	assert.Positive(t, fingerprint.Size)
+	assert.NotEmpty(t, fingerprint.Hash)
+}
+
+// TestIcodemateCLISourceMethods exercises the watch, fingerprint, and
+// changed-path surfaces of the terminal CLI projects source set directly.
+// A pure-CLI provider (no OpenCode root) must plan a recursive *.jsonl watch
+// over the projects root, discover the Claude-format transcript, resolve it
+// back through FindSource, fingerprint it, and map a watched path change back
+// to exactly the owning source — while ignoring files outside the root.
+func TestIcodemateCLISourceMethods(t *testing.T) {
+	root := t.TempDir()
+	projectDir := "-Users-dev-code-demo"
+	sessionID := "cli-main"
+	sourcePath := filepath.Join(root, projectDir, sessionID+".jsonl")
+	wrongRoot := t.TempDir()
+	outsidePath := filepath.Join(wrongRoot, "other-project", "outside.jsonl")
+	writeSourceFile(t, sourcePath, claudeProviderFixture("hello cli source methods"))
+	writeSourceFile(t, outsidePath, claudeProviderFixture("outside"))
+
+	provider, ok := NewProvider(AgentIcodemate, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, root, plan.Roots[0].Path)
+	assert.True(t, plan.Roots[0].Recursive)
+	assert.Empty(t, plan.Roots[0].IncludeGlobs,
+		"the recursive watcher must admit persisted tool-result sidecars")
+	assert.Equal(t, "icodemate:cli-projects:"+root, plan.Roots[0].DebounceKey)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, sourcePath, discovered[0].Key)
+	assert.Equal(t, projectDir, discovered[0].ProjectHint)
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: sessionID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, sourcePath, found.DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), found)
+	require.NoError(t, err)
+	assert.Equal(t, sourcePath, fingerprint.Key)
+	assert.Positive(t, fingerprint.Size)
+	assert.Positive(t, fingerprint.MTimeNS)
+	assert.NotEmpty(t, fingerprint.Hash)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: sourcePath, EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, sourcePath, changed[0].DisplayPath)
+
+	require.NoError(t, os.Remove(sourcePath))
+	changed, err = provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: sourcePath, EventKind: "remove", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, sourcePath, changed[0].DisplayPath)
+
+	ignored, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: outsidePath, EventKind: "write", WatchRoot: wrongRoot},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, ignored)
+}
+
+func TestIcodemateCLIProviderHonorsContextDuringWork(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "cancel.jsonl")
+	writeSourceFile(t, path, claudeProviderFixture("cancel work"))
+	writeSourceFile(t, filepath.Join(
+		root, "project", "cancel", "tool-results", "output.txt",
+	), "persisted output\n")
+
+	provider, ok := NewProvider(AgentIcodemate, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(t.Context(), FindSourceRequest{
+		RawSessionID: "cancel",
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	t.Run("parse", func(t *testing.T) {
+		_, err := provider.Parse(
+			newCancelOnErrCheckContext(t, 2), ParseRequest{Source: source},
+		)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("fingerprint", func(t *testing.T) {
+		_, err := provider.Fingerprint(newCancelOnErrCheckContext(t, 2), source)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("sidecar traversal", func(t *testing.T) {
+		_, err := claudeLayoutSidecarFiles(
+			newCancelOnErrCheckContext(t, 2), path,
+		)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestIcodemateCLISidecarChangeInvalidatesAndMapsOwningSource(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project")
+	sessionPath := filepath.Join(projectDir, "sidecar-session.jsonl")
+	resultPath := filepath.Join(
+		projectDir, "sidecar-session", "tool-results", "output.txt",
+	)
+	writeSourceFile(t, resultPath, "first persisted output\n")
+
+	resultPathJSON, err := json.Marshal(resultPath)
+	require.NoError(t, err)
+	persistedContent, err := json.Marshal(
+		"<persisted-output>\nOutput too large. Full output saved to: " +
+			resultPath + "\n</persisted-output>",
+	)
+	require.NoError(t, err)
+	writeSourceFile(t, sessionPath, strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make logs"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + string(persistedContent) + `}]},"toolUseResult":{"persistedOutputPath":` + string(resultPathJSON) + `}}`,
+	}, "\n")+"\n")
+
+	provider, ok := NewProvider(AgentIcodemate, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(t.Context(), FindSourceRequest{
+		RawSessionID: "sidecar-session",
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	before, err := provider.Fingerprint(t.Context(), source)
+	require.NoError(t, err)
+
+	writeSourceFile(t, resultPath, "later persisted output\n")
+	after, err := provider.Fingerprint(t.Context(), source)
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Hash, after.Hash,
+		"a sidecar-only write must invalidate the owning transcript")
+
+	changed, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path: resultPath, EventKind: "write", WatchRoot: root,
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, sessionPath, changed[0].DisplayPath)
+
+	parsed, err := provider.Parse(t.Context(), ParseRequest{
+		Source: changed[0], Fingerprint: after,
+	})
+	require.NoError(t, err)
+	require.Len(t, parsed.Results, 1)
+	messages := parsed.Results[0].Result.Messages
+	require.Len(t, messages, 3)
+	require.Len(t, messages[2].ToolResults, 1)
+	assert.Equal(t, "later persisted output\n",
+		DecodeContent(messages[2].ToolResults[0].ContentRaw))
+}
+
+func TestIcodemateCLICompositeFingerprintStableAcrossRoots(t *testing.T) {
+	transcript := claudeProviderFixture("same transcript")
+	fingerprints := make([]SourceFingerprint, 0, 2)
+	for range 2 {
+		root := t.TempDir()
+		projectDir := filepath.Join(root, "project")
+		sessionPath := filepath.Join(projectDir, "session.jsonl")
+		resultPath := filepath.Join(
+			projectDir, "session", "tool-results", "output.txt",
+		)
+		writeSourceFile(t, sessionPath, transcript)
+		writeSourceFile(t, resultPath, "same persisted output\n")
+
+		provider, ok := NewProvider(
+			AgentIcodemate, ProviderConfig{Roots: []string{root}},
+		)
+		require.True(t, ok)
+		source, found, err := provider.FindSource(
+			t.Context(), FindSourceRequest{RawSessionID: "session"},
+		)
+		require.NoError(t, err)
+		require.True(t, found)
+		fingerprint, err := provider.Fingerprint(t.Context(), source)
+		require.NoError(t, err)
+		fingerprints = append(fingerprints, fingerprint)
+	}
+
+	require.Len(t, fingerprints, 2)
+	assert.Equal(t, fingerprints[0].Hash, fingerprints[1].Hash,
+		"materialization roots must not affect source identity")
+}
+
+func TestIcodemateCLIParentToolResultDirectoryChangeMapsSubagentSources(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project")
+	parentPath := filepath.Join(projectDir, "parent.jsonl")
+	childPath := filepath.Join(
+		projectDir, "parent", "subagents", "agent-child.jsonl",
+	)
+	resultPath := filepath.Join(
+		projectDir, "parent", "tool-results", "output.txt",
+	)
+	writeSourceFile(t, parentPath, claudeProviderFixture("parent"))
+	writeSourceFile(t, childPath, claudeProviderFixture("child"))
+	writeSourceFile(t, resultPath, "persisted output\n")
+
+	provider, ok := NewProvider(AgentIcodemate, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	changed, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path: filepath.Dir(resultPath), EventKind: "remove", WatchRoot: root,
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 2)
+	assert.ElementsMatch(t, []string{parentPath, childPath}, []string{
+		changed[0].DisplayPath, changed[1].DisplayPath,
+	})
+}

--- a/internal/parser/icodemate_provider.go
+++ b/internal/parser/icodemate_provider.go
@@ -1,0 +1,284 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+)
+
+// Icodemate hosts two storage families under one provider and one agent ID:
+// the VSCode-extension OpenCode storage (see icodemate.go) and the terminal
+// CLI Claude-format projects root (see icodemate_cli.go). IcodemateProvider
+// splits the configured roots by on-disk layout and delegates the family each
+// root owns: OpenCode-layout roots go to the shared openCodeFormatSourceSet
+// (SQLite and storage/session_diff), and Claude-format projects roots go to
+// the icodemateCLISourceSet. Both families label their parsed sessions onto
+// AgentIcodemate with the icodemate: ID prefix, so one source sees one agent.
+//
+// The two layouts never overlap on disk, so every SourceSet method is either a
+// per-source route (Parse, Fingerprint) or a merged fan-out (Discover, watch,
+// find). Reconciliation semantics are preserved per family: OpenCode's shared
+// icodemate.db container keeps its atomic container scopes, while CLI projects
+// roots fall through to the generic directory plan.
+
+var (
+	_ Provider                     = (*icodemateProvider)(nil)
+	_ StreamingDiscoverer          = (*icodemateProvider)(nil)
+	_ ChangedPathRelevanceProvider = (*icodemateProvider)(nil)
+)
+
+type icodemateProviderFactory struct {
+	def AgentDef
+}
+
+func newIcodemateProviderFactory(def AgentDef) ProviderFactory {
+	return icodemateProviderFactory{def: cloneAgentDef(def)}
+}
+
+func (f icodemateProviderFactory) Definition() AgentDef {
+	return cloneAgentDef(f.def)
+}
+
+func (f icodemateProviderFactory) Capabilities() Capabilities {
+	return icodemateProviderCapabilities()
+}
+
+func (f icodemateProviderFactory) NewProvider(cfg ProviderConfig) Provider {
+	cfg = cfg.Clone()
+	opencodeRoots, cliRoots := splitIcodemateRoots(cfg.Roots)
+	opencodeCfg := cfg
+	opencodeCfg.Roots = opencodeRoots
+	provider := &icodemateProvider{
+		opencode: &openCodeFormatProvider{
+			sources: newOpenCodeFormatSourceSet(
+				opencodeRoots,
+				openCodeProviderSpecForAgent(AgentIcodemate),
+				cfg.SQLiteContainerUnchangedSinceTrust,
+			),
+		},
+		cli:      newIcodemateCLISourceSet(cliRoots),
+		allRoots: cfg.Roots,
+		// allSources classifies changed paths and maps reconciliation scopes
+		// across every configured icodemate root, not just the OpenCode-format
+		// subset the inner opencode source set is built over. A root whose
+		// OpenCode layout has not materialized yet (still-empty directory)
+		// must keep icodemate.db container semantics, and CLI jsonl paths
+		// under any root stay unclassified.
+		allSources: newOpenCodeFormatSourceSet(
+			cfg.Roots,
+			openCodeProviderSpecForAgent(AgentIcodemate),
+			cfg.SQLiteContainerUnchangedSinceTrust,
+		),
+	}
+	provider.ProviderBase = ProviderBase{
+		Def:    cloneAgentDef(f.def),
+		Caps:   icodemateProviderCapabilities(),
+		Config: cfg,
+	}
+	provider.opencode.ProviderBase = ProviderBase{
+		Def:    cloneAgentDef(f.def),
+		Caps:   openCodeFormatProviderCapabilities(),
+		Config: opencodeCfg,
+	}
+	return provider
+}
+
+// icodemateProviderCapabilities combines the OpenCode container mechanics of
+// the VS Code extension with the Claude-compatible multi-session semantics of
+// terminal CLI transcripts.
+func icodemateProviderCapabilities() Capabilities {
+	caps := openCodeFormatProviderCapabilities()
+	caps.Source.MultiSessionSource = CapabilitySupported
+	caps.Source.ExcludedSessions = CapabilitySupported
+	caps.Source.ForceReplaceOnParse = CapabilitySupported
+	caps.Source.S3Discovery = CapabilitySupported
+	caps.Content.SessionName = CapabilitySupported
+	caps.Content.GitBranch = CapabilitySupported
+	caps.Content.Subagents = CapabilitySupported
+	caps.Content.ToolResults = CapabilitySupported
+	caps.Content.TerminationStatus = CapabilitySupported
+	caps.Content.MalformedLineCount = CapabilitySupported
+	caps.Content.TruncationStatus = CapabilitySupported
+	caps.Content.StopReason = CapabilitySupported
+	return caps
+}
+
+// splitIcodemateRoots partitions configured roots by on-disk layout. A root
+// with an OpenCode storage directory or icodemate.db is owned by the
+// OpenCode-format source set; anything else (the terminal CLI's
+// projects/<project>/*.jsonl layout) is owned by the CLI source set.
+func splitIcodemateRoots(roots []string) (opencodeRoots, cliRoots []string) {
+	for _, root := range roots {
+		if resolveOpenCodeFormatSource(icodemateFmt, root).Mode != "" {
+			opencodeRoots = append(opencodeRoots, root)
+		} else {
+			cliRoots = append(cliRoots, root)
+		}
+	}
+	return opencodeRoots, cliRoots
+}
+
+type icodemateProvider struct {
+	ProviderBase
+	opencode *openCodeFormatProvider
+	cli      *icodemateCLISourceSet
+	// allRoots carries every configured root so reconciliation validates and
+	// walks the full configured scope, not just the OpenCode subset the inner
+	// opencode provider is built over.
+	allRoots []string
+	// allSources is the OpenCode-format source set built over every
+	// configured root for classification and reconciliation only. Discovery
+	// and parsing stay family-split so each layout is owned where it exists;
+	// allSources exists so icodemate.db container semantics hold for roots
+	// whose OpenCode layout has not materialized yet and so CLI jsonl paths
+	// classify as unclassified (the Claude-style fallback) under any root.
+	allSources openCodeFormatSourceSet
+}
+
+func (p *icodemateProvider) Discover(ctx context.Context) ([]SourceRef, error) {
+	opencodeSources, err := p.opencode.Discover(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cliSources, err := p.cli.Discover(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return append(opencodeSources, cliSources...), nil
+}
+
+func (p *icodemateProvider) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	if err := p.opencode.DiscoverEach(ctx, yield); err != nil {
+		return err
+	}
+	return p.cli.DiscoverEach(ctx, yield)
+}
+
+func (p *icodemateProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
+	opencodePlan, err := p.opencode.WatchPlan(ctx)
+	if err != nil {
+		return WatchPlan{}, err
+	}
+	cliPlan, err := p.cli.WatchPlan(ctx)
+	if err != nil {
+		return WatchPlan{}, err
+	}
+	merged := make([]WatchRoot, 0, len(opencodePlan.Roots)+len(cliPlan.Roots))
+	merged = append(merged, opencodePlan.Roots...)
+	merged = append(merged, cliPlan.Roots...)
+	return WatchPlan{Roots: merged}, nil
+}
+
+func (p *icodemateProvider) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	opencodeSources, err := p.opencode.SourcesForChangedPath(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	cliSources, err := p.cli.SourcesForChangedPath(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(cliSources) == 0 {
+		return opencodeSources, nil
+	}
+	if len(opencodeSources) == 0 {
+		return cliSources, nil
+	}
+	seen := make(map[string]struct{}, len(opencodeSources)+len(cliSources))
+	merged := make([]SourceRef, 0, len(opencodeSources)+len(cliSources))
+	for _, src := range append(opencodeSources, cliSources...) {
+		if _, ok := seen[src.Key]; ok {
+			continue
+		}
+		seen[src.Key] = struct{}{}
+		merged = append(merged, src)
+	}
+	return merged, nil
+}
+
+func (p *icodemateProvider) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	if src, ok, err := p.opencode.FindSource(ctx, req); ok || err != nil {
+		return src, ok, err
+	}
+	req = ProviderFindRequestWithRawSessionID(p.Def, req)
+	return p.cli.FindSource(ctx, req)
+}
+
+func (p *icodemateProvider) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	switch source.Opaque.(type) {
+	case openCodeFormatSource, *openCodeFormatSource:
+		return p.opencode.Fingerprint(ctx, source)
+	case claudeSource, *claudeSource, MaterializedFileSource:
+		return p.cli.Fingerprint(ctx, source)
+	default:
+		return SourceFingerprint{}, fmt.Errorf("icodemate source path unavailable")
+	}
+}
+
+func (p *icodemateProvider) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	switch req.Source.Opaque.(type) {
+	case openCodeFormatSource, *openCodeFormatSource:
+		return p.opencode.Parse(ctx, req)
+	case claudeSource, *claudeSource, MaterializedFileSource:
+		req.Machine = firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
+		return p.cli.Parse(ctx, req)
+	default:
+		return ParseOutcome{}, fmt.Errorf("icodemate source path unavailable")
+	}
+}
+
+// ChangedPathRelevance classifies paths under any configured icodemate root
+// with OpenCode-format SQLite sidecar semantics via allSources, so a root
+// whose OpenCode layout has not materialized yet (still-empty directory)
+// keeps its icodemate.db container rules. CLI project jsonl paths classify as
+// unclassified (the same fallback Claude-style sources use), so watch
+// adapters never misfile a CLI change under OpenCode layout rules.
+func (p *icodemateProvider) ChangedPathRelevance(
+	ctx context.Context,
+	req ChangedPathRequest,
+) (ChangedPathRelevance, error) {
+	return p.allSources.ChangedPathRelevance(ctx, req)
+}
+
+// SourceForReconciliation delegates to the all-roots OpenCode source set,
+// which is the only family with a shared container (icodemate.db) whose
+// virtual members must be rehydrated exactly during reconciliation streaming.
+// CLI project transcripts are plain single-file sources and are rehydrated
+// through the generic source resolver path instead.
+func (p *icodemateProvider) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	return p.allSources.SourceForReconciliation(ctx, path, project)
+}
+
+// ResolveReconciliationScopes preserves the OpenCode container topology for
+// the shared icodemate.db under every configured icodemate root (allSources)
+// while letting CLI projects roots fall through to the generic directory
+// plan. The inner opencode source set's reconciliation container only
+// recognizes the OpenCode subset, so every other requested root is scoped as
+// a plain directory.
+func (p *icodemateProvider) ResolveReconciliationScopes(
+	_ context.Context, req ReconciliationScopeRequest,
+) (ReconciliationScopePlan, error) {
+	if err := ValidateReconciliationScopeRoots(
+		p.Def.Type, p.allRoots, req.Roots,
+	); err != nil {
+		return ReconciliationScopePlan{}, err
+	}
+	return containerAwareReconciliationScopePlan(
+		p.allRoots, req.Roots, p.allSources.reconciliationContainer,
+	), nil
+}

--- a/internal/parser/icodemate_s3.go
+++ b/internal/parser/icodemate_s3.go
@@ -1,0 +1,46 @@
+package parser
+
+import (
+	"path"
+	"strings"
+)
+
+// ICodeMate's terminal CLI stores Claude-layout transcripts, so its S3
+// surface reuses Claude's scanner, sidecar-aware stat, and temp-path rules
+// under the icodemate provider segment (.../<machine>/raw/icodemate/...) and
+// the icodemate: session namespace. The OpenCode-storage family never ingests
+// from S3; only CLI transcripts are kept.
+
+var _ S3Provider = (*icodemateProvider)(nil)
+
+func icodemateCLIS3Scanner() S3SessionScanner {
+	scanner := claudeS3Scanner()
+	scanner.Agent = AgentIcodemate
+	return scanner
+}
+
+func (p *icodemateProvider) S3Scanner() S3SessionScanner {
+	return icodemateCLIS3Scanner()
+}
+
+func (p *icodemateProvider) S3SessionID(uri string) string {
+	id, ok := strings.CutSuffix(path.Base(uri), ".jsonl")
+	if !ok || id == "" {
+		return ""
+	}
+	return "icodemate:" + id
+}
+
+func (p *icodemateProvider) S3TempRelPath(objectPath string) (string, error) {
+	return s3TempRelPathAfterRawAgent(objectPath, string(AgentIcodemate), nil)
+}
+
+func (p *icodemateProvider) S3StatSession(uri string) (S3Object, error) {
+	return StatClaudeS3Session(uri)
+}
+
+func (p *icodemateProvider) S3PostFetchHydrate(
+	tempDir, tempPath, configuredRoot, objectURI string,
+) error {
+	return nil
+}

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -54,14 +54,6 @@ func newMiMoCodeProviderFactory(def AgentDef) ProviderFactory {
 	}
 }
 
-func newIcodemateProviderFactory(def AgentDef) ProviderFactory {
-	return openCodeFormatProviderFactory{
-		def:   cloneAgentDef(def),
-		spec:  openCodeProviderSpecForAgent(AgentIcodemate),
-		index: newOpenCodeFormatSourceIndex(),
-	}
-}
-
 func (f openCodeFormatProviderFactory) Definition() AgentDef {
 	return cloneAgentDef(f.def)
 }

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -929,6 +929,9 @@ type ParseRequest struct {
 	Fingerprint SourceFingerprint
 	Machine     string
 	ForceParse  bool
+	// StoredPathResolver maps a canonical remote companion path back to the
+	// materialized file used by this parse.
+	StoredPathResolver func(string) (string, bool)
 }
 
 // ParseOutcome is the full-parse provider output. It is meaningful only when

--- a/internal/parser/provider_capabilities_test.go
+++ b/internal/parser/provider_capabilities_test.go
@@ -31,9 +31,10 @@ func TestProviderCapabilitiesS3DiscoveryMatchConsumers(t *testing.T) {
 		"new providers must opt in explicitly")
 
 	supported := map[AgentType]bool{
-		AgentClaude: true,
-		AgentCodex:  true,
-		AgentCursor: true,
+		AgentClaude:    true,
+		AgentCodex:     true,
+		AgentCursor:    true,
+		AgentIcodemate: true,
 	}
 	for _, factory := range ProviderFactories() {
 		agent := factory.Definition().Type

--- a/internal/parser/s3source.go
+++ b/internal/parser/s3source.go
@@ -298,12 +298,14 @@ func combineS3Fingerprints(values ...string) string {
 // MaterializedFileSource. The metadata threaded here is what lets the
 // incremental cutoff and skip checks run without performing that fetch.
 type S3DiscoveredSource struct {
-	URI         string
-	Project     string
-	Machine     string
-	Size        int64
-	MtimeNS     int64
-	Fingerprint string
+	URI               string
+	Project           string
+	Machine           string
+	Size              int64
+	MtimeNS           int64
+	Fingerprint       string
+	TranscriptSize    int64
+	TranscriptMtimeNS int64
 }
 
 // s3SourceRefFromDiscoveredFile builds the SourceRef for an s3:// session object
@@ -319,12 +321,14 @@ func s3SourceRefFromDiscoveredFile(root string, file DiscoveredFile) SourceRef {
 		FingerprintKey: file.Path,
 		ProjectHint:    file.Project,
 		Opaque: S3DiscoveredSource{
-			URI:         file.Path,
-			Project:     file.Project,
-			Machine:     file.Machine,
-			Size:        file.SourceSize,
-			MtimeNS:     file.SourceMtime,
-			Fingerprint: file.SourceFingerprint,
+			URI:               file.Path,
+			Project:           file.Project,
+			Machine:           file.Machine,
+			Size:              file.SourceSize,
+			MtimeNS:           file.SourceMtime,
+			Fingerprint:       file.SourceFingerprint,
+			TranscriptSize:    file.TranscriptSize,
+			TranscriptMtimeNS: file.TranscriptMtime,
 		},
 	}
 }
@@ -382,6 +386,8 @@ func s3PrefixScan(root string, scan S3SessionScanner) []DiscoveredFile {
 			SourceSize:        source.Size,
 			SourceMtime:       source.LastModified.UnixNano(),
 			SourceFingerprint: source.Fingerprint,
+			TranscriptSize:    obj.Size,
+			TranscriptMtime:   obj.LastModified.UnixNano(),
 		})
 	}
 	return out

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -875,7 +875,7 @@ var Registry = []AgentDef{
 		DisplayName:    "IcodeMate",
 		EnvVar:         "ICODEMATE_DIR",
 		ConfigKey:      "icodemate_dirs",
-		DefaultDirs:    []string{".local/share/icodemate"},
+		DefaultDirs:    []string{".local/share/icodemate", ".icodemate/cli/projects"},
 		IDPrefix:       "icodemate:",
 		WatchSubdirs:   []string{"storage/session_diff"},
 		FileBased:      true,

--- a/internal/remotesync/import_test.go
+++ b/internal/remotesync/import_test.go
@@ -279,6 +279,50 @@ func TestImporterImportsExtractedRemoteFiles(t *testing.T) {
 	assert.Contains(t, *full.FilePath, "devbox:/home/wes/.claude/projects/test-project/session.jsonl")
 }
 
+func TestImporterHydratesIcodematePersistedToolResult(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	extracted := t.TempDir()
+	remoteRoot := "/remote/icodemate/projects"
+	remoteSession := remoteRoot + "/project/sidecar.jsonl"
+	remoteResult := remoteRoot + "/project/sidecar/tool-results/output.txt"
+	localSession := remappedRemotePath(extracted, remoteSession)
+	localResult := remappedRemotePath(extracted, remoteResult)
+	require.NoError(t, os.MkdirAll(filepath.Dir(localResult), 0o755))
+	require.NoError(t, os.WriteFile(localResult, []byte("remote persisted output\n"), 0o644))
+
+	persistedPath, err := json.Marshal(remoteResult)
+	require.NoError(t, err)
+	placeholder := "<persisted-output>\nOutput too large. Full output saved to: " +
+		remoteResult + "\n</persisted-output>"
+	placeholderJSON, err := json.Marshal(placeholder)
+	require.NoError(t, err)
+	transcript := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make logs"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + string(placeholderJSON) + `}]},"toolUseResult":{"persistedOutputPath":` + string(persistedPath) + `}}`,
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(localSession, []byte(transcript), 0o644))
+
+	stats, err := Importer{Host: "devbox", DB: database}.ImportExtracted(
+		t.Context(), TargetSet{Dirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {remoteRoot},
+		}}, extracted,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.SessionsSynced)
+	messages, err := database.GetMessages(
+		t.Context(), "devbox~icodemate:sidecar", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	require.Len(t, messages[1].ToolCalls, 1)
+	assert.Equal(t, "remote persisted output\n",
+		messages[1].ToolCalls[0].ResultContent)
+}
+
 func TestImporterReturnsPartialStatsWhenOneSourceFails(t *testing.T) {
 	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
 	require.NoError(t, err)

--- a/internal/sync/changed_path_plan.go
+++ b/internal/sync/changed_path_plan.go
@@ -231,7 +231,7 @@ func (e *Engine) resolveClaudeDuplicateAttribution(
 	preferredFiles := e.dedupeClaudeDiscoveredFiles(expanded)
 	preferredBySession := make(map[string]parser.DiscoveredFile)
 	for _, file := range preferredFiles {
-		if file.Agent != parser.AgentClaude {
+		if !isClaudeFormatTranscriptFile(file) {
 			continue
 		}
 		sessionID := claudeSessionIDFromPath(file.Path)
@@ -245,7 +245,7 @@ func (e *Engine) resolveClaudeDuplicateAttribution(
 	}
 	for path, attribution := range plan.attribution {
 		for i, file := range attribution.files {
-			if file.Agent != parser.AgentClaude {
+			if !isClaudeFormatTranscriptFile(file) {
 				continue
 			}
 			sessionID := claudeSessionIDFromPath(file.Path)
@@ -263,23 +263,29 @@ func (e *Engine) resolveClaudeDuplicateAttribution(
 }
 
 // expandAffectedClaudeDuplicateCandidates resolves the archive's stored source
-// for each exact Claude session in the plan. The changed source and stored
+// for each exact Claude-compatible session in the plan. The changed source and stored
 // source are sufficient for DB-aware preference without invoking corpus-wide
 // project or nested-subagent discovery.
 func (e *Engine) expandAffectedClaudeDuplicateCandidates(
 	ctx context.Context,
 	files []parser.DiscoveredFile,
 ) ([]parser.DiscoveredFile, error) {
-	factory := e.providerFactories[parser.AgentClaude]
-	roots := e.agentDirs[parser.AgentClaude]
-	if factory == nil || len(roots) == 0 {
+	providers := make(map[parser.AgentType]parser.Provider)
+	for _, agent := range []parser.AgentType{parser.AgentClaude, parser.AgentIcodemate} {
+		factory := e.providerFactories[agent]
+		roots := e.agentDirs[agent]
+		if factory == nil || len(roots) == 0 {
+			continue
+		}
+		providers[agent] = factory.NewProvider(parser.ProviderConfig{
+			Roots: roots, Machine: e.machine,
+			SourceMachines: e.sourceMachines[agent],
+			PathRewriter:   e.pathRewriter,
+		})
+	}
+	if len(providers) == 0 {
 		return files, nil
 	}
-	provider := factory.NewProvider(parser.ProviderConfig{
-		Roots: roots, Machine: e.machine,
-		SourceMachines: e.sourceMachines[parser.AgentClaude],
-		PathRewriter:   e.pathRewriter,
-	})
 	out := append([]parser.DiscoveredFile(nil), files...)
 	seenSources := make(map[string]struct{}, len(files))
 	seenSessions := make(map[string]struct{})
@@ -290,7 +296,11 @@ func (e *Engine) expandAffectedClaudeDuplicateCandidates(
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		if file.Agent != parser.AgentClaude {
+		if !isClaudeFormatTranscriptFile(file) {
+			continue
+		}
+		provider := providers[file.Agent]
+		if provider == nil {
 			continue
 		}
 		sessionID := claudeSessionIDFromPath(file.Path)
@@ -301,7 +311,9 @@ func (e *Engine) expandAffectedClaudeDuplicateCandidates(
 		if isS3SourcePath(file.Path) {
 			idPrefix = s3SessionIDPrefix(file.Machine)
 		}
-		fullID := applyIDPrefixToID(idPrefix, sessionID)
+		fullID := applyIDPrefixToID(
+			idPrefix, claudeFormatArchiveSessionID(file.Agent, sessionID),
+		)
 		sessionKey := discoveredFileIDPrefix(file) + "\x00" + fullID
 		if _, seen := seenSessions[sessionKey]; seen {
 			continue

--- a/internal/sync/claude_format_test.go
+++ b/internal/sync/claude_format_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -174,4 +176,66 @@ func TestClaudeCandidateHasAppendProgress(t *testing.T) {
 	require.True(t, claudeCandidateHasAppendProgress(large, small))
 	require.False(t, claudeCandidateHasAppendProgress(equal, small))
 	require.False(t, claudeCandidateHasAppendProgress(small, large))
+}
+
+// TestProtectedFileSessionCountDisabledIcodemate pins the resync
+// empty-discovery safety accounting: with the ICodeMate provider enabled,
+// its CLI JSONL rows stay protected while container rows are excluded; with
+// the provider disabled, nothing is discovered and every ICodeMate row must
+// leave the protected count so a rebuild can complete while preserving the
+// disabled provider's sessions. The scoped variant covers contributor-backed
+// rebuild accounting.
+func TestProtectedFileSessionCountDisabledIcodemate(t *testing.T) {
+	database := openTestDB(t)
+	containerPath := "/data/icodemate/icodemate.db"
+	cliPath := "/data/icodemate/cli/projects/proj/abc.jsonl"
+	claudePath := "/data/claude/projects/proj/def.jsonl"
+	for _, sess := range []db.Session{
+		{
+			ID: "icodemate:container-1", Project: "proj", Machine: "local",
+			Agent: "icodemate", FilePath: &containerPath, MessageCount: 1,
+		},
+		{
+			ID: "icodemate:cli-1", Project: "proj", Machine: "local",
+			Agent: "icodemate", FilePath: &cliPath, MessageCount: 1,
+		},
+		{
+			ID: "claude-1", Project: "proj", Machine: "local",
+			Agent: "claude", FilePath: &claudePath, MessageCount: 1,
+		},
+	} {
+		require.NoError(t, database.UpsertSession(sess))
+	}
+
+	tests := []struct {
+		name           string
+		preserveAgents []parser.AgentType
+		scoped         bool
+		want           int
+	}{
+		{
+			name: "enabled provider protects CLI transcript rows",
+			want: 2,
+		},
+		{
+			name:           "disabled provider releases every icodemate row",
+			preserveAgents: []parser.AgentType{parser.AgentIcodemate},
+			want:           1,
+		},
+		{
+			name:           "contributor-scoped disabled provider releases icodemate rows",
+			preserveAgents: []parser.AgentType{parser.AgentIcodemate},
+			scoped:         true,
+			want:           1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := protectedFileSessionCount(
+				database, "local", "", tt.scoped, tt.preserveAgents,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, count)
+		})
+	}
 }

--- a/internal/sync/claude_format_test.go
+++ b/internal/sync/claude_format_test.go
@@ -1,0 +1,177 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestIsClaudeFormatTranscript(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent parser.AgentType
+		path  string
+		want  bool
+	}{
+		{"claude transcript", parser.AgentClaude, "/r/proj/abc.jsonl", true},
+		{"icodemate cli transcript", parser.AgentIcodemate, "/r/proj/abc.jsonl", true},
+		{"icodemate opencode container", parser.AgentIcodemate, "/r/icodemate.db", false},
+		{"icodemate storage json", parser.AgentIcodemate, "/r/storage/session_diff/x.json", false},
+		{"openclaude stays outside the set", parser.AgentOpenClaude, "/r/proj/abc.jsonl", false},
+		{"codex is not claude format", parser.AgentCodex, "/r/proj/abc.jsonl", false},
+		{"extension-less path", parser.AgentClaude, "/r/proj/abc", false},
+		{"bare .jsonl name has no session", parser.AgentClaude, "/r/proj/.jsonl", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isClaudeFormatTranscript(tt.agent, tt.path))
+		})
+	}
+}
+
+func TestClaudeFormatArchiveSessionID(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent parser.AgentType
+		raw   string
+		want  string
+	}{
+		{"claude keeps raw id", parser.AgentClaude, "abc-123", "abc-123"},
+		{"icodemate gains prefix", parser.AgentIcodemate, "abc-123", "icodemate:abc-123"},
+		{"icodemate prefix not doubled", parser.AgentIcodemate, "icodemate:abc", "icodemate:abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, claudeFormatArchiveSessionID(tt.agent, tt.raw))
+		})
+	}
+}
+
+func TestUsesCompositeSidecarFreshness(t *testing.T) {
+	require.True(t, usesCompositeSidecarFreshness(
+		parser.AgentIcodemate, "/r/proj/abc.jsonl",
+	))
+	require.False(t, usesCompositeSidecarFreshness(
+		parser.AgentClaude, "/r/proj/abc.jsonl",
+	), "Claude must keep plain-file freshness")
+	require.False(t, usesCompositeSidecarFreshness(
+		parser.AgentIcodemate, "/r/icodemate.db",
+	), "OpenCode container storage is not sidecar-composite")
+}
+
+// writeTranscriptFile creates a transcript of the given size with a fixed
+// mtime and returns a discovered-file record for it.
+func writeTranscriptFile(
+	t *testing.T, dir, name string, size int, mtime time.Time,
+	agent parser.AgentType,
+) parser.DiscoveredFile {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, make([]byte, size), 0o644))
+	require.NoError(t, os.Chtimes(path, mtime, mtime))
+	return parser.DiscoveredFile{Path: path, Agent: agent}
+}
+
+// TestPreferClaudeDiscoveredFile pins the same-session duplicate policy
+// documented on claudeFormatTranscriptPreference: Claude ranks append
+// progress (size) ahead of recency, while ICodeMate CLI transcripts are
+// rewritten in place, so recency (mtime) outranks size and a newer shortened
+// rewrite beats a larger stale copy.
+func TestPreferClaudeDiscoveredFile(t *testing.T) {
+	dir := t.TempDir()
+	older := time.Now().Add(-time.Hour).Truncate(time.Second)
+	newer := older.Add(30 * time.Minute)
+
+	tests := []struct {
+		name       string
+		agent      parser.AgentType
+		candidate  parser.DiscoveredFile
+		current    parser.DiscoveredFile
+		wantPrefer bool
+	}{
+		{
+			name:  "claude larger older copy wins",
+			agent: parser.AgentClaude,
+			candidate: writeTranscriptFile(
+				t, dir, "c1.jsonl", 2048, older, parser.AgentClaude,
+			),
+			current: writeTranscriptFile(
+				t, dir, "c2.jsonl", 1024, newer, parser.AgentClaude,
+			),
+			wantPrefer: true,
+		},
+		{
+			name:  "claude equal size falls back to mtime",
+			agent: parser.AgentClaude,
+			candidate: writeTranscriptFile(
+				t, dir, "c3.jsonl", 1024, newer, parser.AgentClaude,
+			),
+			current: writeTranscriptFile(
+				t, dir, "c4.jsonl", 1024, older, parser.AgentClaude,
+			),
+			wantPrefer: true,
+		},
+		{
+			name:  "icodemate newer shortened rewrite wins",
+			agent: parser.AgentIcodemate,
+			candidate: writeTranscriptFile(
+				t, dir, "i1.jsonl", 512, newer, parser.AgentIcodemate,
+			),
+			current: writeTranscriptFile(
+				t, dir, "i2.jsonl", 4096, older, parser.AgentIcodemate,
+			),
+			wantPrefer: true,
+		},
+		{
+			name:  "icodemate equal mtime falls back to size",
+			agent: parser.AgentIcodemate,
+			candidate: writeTranscriptFile(
+				t, dir, "i3.jsonl", 4096, older, parser.AgentIcodemate,
+			),
+			current: writeTranscriptFile(
+				t, dir, "i4.jsonl", 512, older, parser.AgentIcodemate,
+			),
+			wantPrefer: true,
+		},
+		{
+			name:  "unstatable candidate never wins",
+			agent: parser.AgentClaude,
+			candidate: parser.DiscoveredFile{
+				Path:  filepath.Join(dir, "missing.jsonl"),
+				Agent: parser.AgentClaude,
+			},
+			current: writeTranscriptFile(
+				t, dir, "c5.jsonl", 1, older, parser.AgentClaude,
+			),
+			wantPrefer: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(
+				t, tt.wantPrefer,
+				preferClaudeDiscoveredFile(tt.candidate, tt.current),
+			)
+		})
+	}
+}
+
+// TestClaudeCandidateHasAppendProgress pins the committed-copy escape hatch:
+// only strict transcript growth counts as append progress, so an equal-size
+// or shorter copy can never displace the committed source.
+func TestClaudeCandidateHasAppendProgress(t *testing.T) {
+	dir := t.TempDir()
+	at := time.Now().Truncate(time.Second)
+	small := writeTranscriptFile(t, dir, "a.jsonl", 100, at, parser.AgentIcodemate)
+	equal := writeTranscriptFile(t, dir, "b.jsonl", 100, at, parser.AgentIcodemate)
+	large := writeTranscriptFile(t, dir, "c.jsonl", 200, at, parser.AgentIcodemate)
+
+	require.True(t, claudeCandidateHasAppendProgress(large, small))
+	require.False(t, claudeCandidateHasAppendProgress(equal, small))
+	require.False(t, claudeCandidateHasAppendProgress(small, large))
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2797,14 +2797,25 @@ func (e *Engine) resyncBuildLocked(
 				)
 			}
 		}
-		excludedAgents := []string{
-			string(parser.AgentOpenCode),
-			string(parser.AgentKilo),
-			string(parser.AgentMiMoCode),
-			string(parser.AgentIcodemate),
+		disabledStorage := storageAgentsForDisabledProviders(e.preserveAgents)
+		// A disabled ICodeMate provider discovers nothing, so its CLI JSONL
+		// rows are preserved rather than rediscovered and must leave the
+		// protected count with the container rows.
+		excludedAgents := []db.RebuildAgentExclusion{
+			{Agent: string(parser.AgentOpenCode)},
+			{Agent: string(parser.AgentKilo)},
+			{Agent: string(parser.AgentMiMoCode)},
+			{
+				Agent: string(parser.AgentIcodemate),
+				KeepJSONLRows: !slices.Contains(
+					disabledStorage, parser.AgentIcodemate,
+				),
+			},
 		}
-		for _, agent := range storageAgentsForDisabledProviders(e.preserveAgents) {
-			excludedAgents = append(excludedAgents, string(agent))
+		for _, agent := range disabledStorage {
+			excludedAgents = append(
+				excludedAgents, db.RebuildAgentExclusion{Agent: string(agent)},
+			)
 		}
 		localOldFileSessions, err = origDB.FileBackedSessionCountForRebuildOwner(
 			context.Background(), e.machine, contributorPrefixes, excludedAgents,
@@ -3877,10 +3888,19 @@ func protectedFileSessionCount(
 			database, agent, machine, idPrefix, scoped,
 		)
 	}
-	count -= countIcodemateContainerRootSessions(
-		database, machine, idPrefix, scoped,
-	)
 	storageAgents := storageAgentsForDisabledProviders(preserveAgents)
+	if slices.Contains(storageAgents, parser.AgentIcodemate) {
+		// A disabled ICodeMate provider discovers nothing, so its CLI JSONL
+		// rows are preserved rather than rediscovered: subtract every
+		// ICodeMate row, not just the self-preserving container layouts.
+		count -= countRootSessionsForAgent(
+			database, parser.AgentIcodemate, machine, idPrefix, scoped,
+		)
+	} else {
+		count -= countIcodemateContainerRootSessions(
+			database, machine, idPrefix, scoped,
+		)
+	}
 	seenPreserved := make(map[parser.AgentType]struct{}, len(storageAgents))
 	for _, agent := range storageAgents {
 		if _, seen := seenPreserved[agent]; seen {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2379,46 +2379,54 @@ func (e *Engine) expandClaudeDuplicateCandidates(
 	ctx context.Context,
 	files []parser.DiscoveredFile,
 ) ([]parser.DiscoveredFile, error) {
-	sessionIDs := make(map[string]struct{})
+	sessionIDs := make(map[parser.AgentType]map[string]struct{})
 	seen := make(map[string]struct{}, len(files))
 	for _, file := range files {
 		seen[string(file.Agent)+"\x00"+file.Path] = struct{}{}
-		if file.Agent != parser.AgentClaude {
+		if !isClaudeFormatTranscriptFile(file) {
 			continue
 		}
 		sessionID := claudeSessionIDFromPath(file.Path)
 		if sessionID == "" {
 			continue
 		}
-		sessionIDs[sessionID] = struct{}{}
+		if sessionIDs[file.Agent] == nil {
+			sessionIDs[file.Agent] = make(map[string]struct{})
+		}
+		sessionIDs[file.Agent][sessionID] = struct{}{}
 	}
 	if len(sessionIDs) == 0 {
 		return files, nil
 	}
 
-	listSessionFiles := e.claudeProjectSessionFiles
-	if listSessionFiles == nil {
-		listSessionFiles = parser.ClaudeProjectSessionFiles
-	}
 	out := files
-	for _, claudeDir := range e.agentDirs[parser.AgentClaude] {
-		if err := ctx.Err(); err != nil {
-			return nil, err
+	for agent, ids := range sessionIDs {
+		listSessionFiles := parser.IcodemateCLIProjectSessionFiles
+		if agent == parser.AgentClaude {
+			listSessionFiles = e.claudeProjectSessionFiles
+			if listSessionFiles == nil {
+				listSessionFiles = parser.ClaudeProjectSessionFiles
+			}
 		}
-		for _, candidate := range listSessionFiles(claudeDir) {
+		for _, root := range e.agentDirs[agent] {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
-			sessionID := claudeSessionIDFromPath(candidate.Path)
-			if _, ok := sessionIDs[sessionID]; !ok {
-				continue
+			for _, candidate := range listSessionFiles(root) {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+				sessionID := claudeSessionIDFromPath(candidate.Path)
+				if _, ok := ids[sessionID]; !ok {
+					continue
+				}
+				key := string(candidate.Agent) + "\x00" + candidate.Path
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				out = append(out, candidate)
 			}
-			key := string(candidate.Agent) + "\x00" + candidate.Path
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			out = append(out, candidate)
 		}
 	}
 	return out, nil
@@ -3790,6 +3798,34 @@ func countRootSessionsForAgent(
 	return count
 }
 
+func countIcodemateContainerRootSessions(
+	database *db.DB, machine, idPrefix string, scoped bool,
+) int {
+	machinePredicate := ""
+	args := []any{string(parser.AgentIcodemate)}
+	if scoped {
+		machinePredicate = " AND machine = ?"
+		args = append(args, machine)
+	}
+	if idPrefix != "" {
+		machinePredicate += " AND substr(id, 1, length(?)) = ?"
+		args = append(args, idPrefix, idPrefix)
+	}
+	var count int
+	err := database.Reader().QueryRow(`
+		SELECT COUNT(*) FROM sessions
+		WHERE agent = ?
+		  AND lower(file_path) NOT LIKE '%.jsonl'
+		  AND message_count > 0
+		  AND relationship_type NOT IN ('subagent', 'fork')
+		  AND deleted_at IS NULL
+	`+machinePredicate, args...).Scan(&count)
+	if err != nil {
+		log.Printf("count root ICodeMate container sessions: %v", err)
+	}
+	return count
+}
+
 func storageAgentsForDisabledProviders(
 	disabledProviders []parser.AgentType,
 ) []parser.AgentType {
@@ -3836,12 +3872,14 @@ func protectedFileSessionCount(
 		parser.AgentOpenCode,
 		parser.AgentKilo,
 		parser.AgentMiMoCode,
-		parser.AgentIcodemate,
 	} {
 		count -= countRootSessionsForAgent(
 			database, agent, machine, idPrefix, scoped,
 		)
 	}
+	count -= countIcodemateContainerRootSessions(
+		database, machine, idPrefix, scoped,
+	)
 	storageAgents := storageAgentsForDisabledProviders(preserveAgents)
 	seenPreserved := make(map[parser.AgentType]struct{}, len(storageAgents))
 	for _, agent := range storageAgents {
@@ -5665,28 +5703,63 @@ func (e *Engine) reconciliationCandidate(
 	root := reconciliationWatchRoot(path, watchRoots, roots)
 	preference1, preference2, preference3 := int64(0), int64(0), int64(0)
 	statPath := validatedProviderSourceStatPath(path)
-	if agent == parser.AgentClaude {
-		if info, err := os.Stat(statPath); err == nil {
-			preference1 = info.Size()
-			preference2 = info.ModTime().UnixNano()
-			fullID := applyIDPrefixToID(e.idPrefix, identity)
+	claudeFormat := isClaudeFormatTranscript(agent, path)
+	if claudeFormat {
+		// This mirrors the duplicate-selection policy documented on
+		// claudeFormatTranscriptPreference. Claude ranks size, mtime, then
+		// unchanged-committed-copy; ICodeMate ranks committed-or-longer,
+		// mtime, then size, because its transcripts are rewritten in place
+		// and a larger stale copy must not outrank the committed source.
+		transcriptSize, transcriptMtime, transcriptOK := claudeTranscriptFileSourceInfo(
+			parser.DiscoveredFile{Path: statPath, Agent: agent},
+		)
+		if transcriptOK {
+			if agent == parser.AgentIcodemate {
+				preference2, preference3 = claudeFormatTranscriptPreference(
+					agent, transcriptSize, transcriptMtime,
+				)
+			} else {
+				preference1, preference2 = claudeFormatTranscriptPreference(
+					agent, transcriptSize, transcriptMtime,
+				)
+			}
+			fullID := applyIDPrefixToID(
+				e.idPrefix, claudeFormatArchiveSessionID(agent, identity),
+			)
 			storedPath := e.db.GetSessionFilePath(fullID)
-			storedSize, storedMtime, stored := e.db.GetSessionFileInfo(fullID)
-			if stored && e.effectiveSourcePath(path) == storedPath &&
-				storedSize == info.Size() && storedMtime == info.ModTime().UnixNano() &&
-				e.db.GetSessionDataVersion(fullID) >= db.CurrentDataVersion() {
-				preference3 = 1
+			if agent == parser.AgentIcodemate {
+				preferredAgainstStored := storedPath != "" &&
+					e.effectiveSourcePath(path) == storedPath
+				if !preferredAgainstStored && storedPath != "" {
+					storedTranscriptSize, _, storedTranscriptOK :=
+						claudeTranscriptFileSourceInfo(parser.DiscoveredFile{
+							Path: storedPath, Agent: agent,
+						})
+					preferredAgainstStored = storedTranscriptOK &&
+						transcriptSize > storedTranscriptSize
+				}
+				preference1 = boolPreference(preferredAgainstStored)
+			} else {
+				sourceSize, sourceMtime, sourceOK := claudeFormatFileSourceInfo(
+					parser.DiscoveredFile{Path: statPath, Agent: agent},
+				)
+				storedSize, storedMtime, stored := e.db.GetSessionFileInfo(fullID)
+				if sourceOK && stored && e.effectiveSourcePath(path) == storedPath &&
+					storedSize == sourceSize && storedMtime == sourceMtime &&
+					e.db.GetSessionDataVersion(fullID) >= db.CurrentDataVersion() {
+					preference3 = 1
+				}
 			}
 		}
 	}
 	if isCodexFormatAgent(agent) && codexLayoutForPath(path) == parser.CodexLayoutDated {
 		preference1 = 1
 	}
-	if isOpenCodeFormatAgent(agent) {
+	if isOpenCodeFormatAgent(agent) && !claudeFormat {
 		if statPath == path {
 			preference1 = 1
 		}
-	} else if agent != parser.AgentClaude && !isCodexFormatAgent(agent) {
+	} else if !claudeFormat && !isCodexFormatAgent(agent) {
 		for i, configured := range roots {
 			if samePathOrDescendant(statPath, configured) {
 				preference1 = int64(len(roots) - i)
@@ -5721,11 +5794,11 @@ func boolPreference(value bool) int64 {
 }
 
 func reconciliationSourceIdentity(agent parser.AgentType, source parser.SourceRef) string {
-	if agent == parser.AgentClaude {
-		return claudeSessionIDFromPath(providerDiscoveredPath(source))
+	path := providerDiscoveredPath(source)
+	if isClaudeFormatTranscript(agent, path) {
+		return claudeSessionIDFromPath(path)
 	}
 	if isOpenCodeFormatAgent(agent) {
-		path := providerDiscoveredPath(source)
 		if statPath := validatedProviderSourceStatPath(path); statPath != path {
 			_, sessionID, _ := parser.ParseVirtualSourcePath(path)
 			return sessionID
@@ -6013,9 +6086,13 @@ func aggregateOwnedMemberGone(
 func reconciliationReplacementIdentity(
 	agent parser.AgentType, storedPath string,
 ) string {
+	if isClaudeFormatAgent(agent) {
+		if isClaudeFormatTranscript(agent, storedPath) {
+			return claudeSessionIDFromPath(storedPath)
+		}
+		return ""
+	}
 	switch agent {
-	case parser.AgentClaude:
-		return claudeSessionIDFromPath(storedPath)
 	case parser.AgentCodex, parser.AgentTraeX:
 		uuid := parser.CodexSessionUUIDFromFilename(filepath.Base(storedPath))
 		if uuid == "" {
@@ -6680,7 +6757,7 @@ func (e *Engine) reconcileCopiedSourceMissingMembers(
 		ownerships = append(ownerships, db.SessionSourceOwnership{
 			ID:       member.sessionID,
 			Machine:  member.machine,
-			Agent:    string(parser.AgentClaude),
+			Agent:    string(member.agent),
 			FilePath: member.filePath,
 		})
 	}
@@ -6695,10 +6772,10 @@ func (e *Engine) reconcileCopiedSourceMissingMembers(
 	for i, member := range members {
 		e.clearSkipInMemory(member.filePath)
 		e.clearSkipInMemory(providerAgentSkipCacheKey(
-			member.filePath, parser.AgentClaude,
+			member.filePath, member.agent,
 		))
 		if err := target.DeleteProviderStatHash(
-			ctx, parser.AgentClaude, member.filePath,
+			ctx, member.agent, member.filePath,
 		); err != nil {
 			return tombstoned, fmt.Errorf(
 				"clear copied source freshness for %s: %w",
@@ -6706,7 +6783,7 @@ func (e *Engine) reconcileCopiedSourceMissingMembers(
 			)
 		}
 		changed, err := target.SoftDeleteSessionSourceOwnership(
-			ctx, member.machine, string(parser.AgentClaude),
+			ctx, member.machine, string(member.agent),
 			member.sessionID, member.filePath,
 		)
 		if err != nil {
@@ -6717,7 +6794,7 @@ func (e *Engine) reconcileCopiedSourceMissingMembers(
 		}
 		if changed {
 			tombstoned++
-			e.invalidateVerifiedSource(parser.AgentClaude, member.filePath)
+			e.invalidateVerifiedSource(member.agent, member.filePath)
 			continue
 		}
 		needsBaseline = append(needsBaseline, ownerships[i])
@@ -7047,7 +7124,7 @@ func (e *Engine) syncAllLocked(
 
 	nonContainerDiscovered := 0
 	for _, f := range all {
-		if !isOpenCodeFormatStorageAgent(f.Agent) {
+		if !isOpenCodeFormatContainerSource(f.Agent, f.Path) {
 			nonContainerDiscovered++
 		}
 	}
@@ -7355,6 +7432,8 @@ func (e *Engine) discoverProviderSources(
 				discovered.SourceSize = s3.Size
 				discovered.SourceMtime = s3.MtimeNS
 				discovered.SourceFingerprint = s3.Fingerprint
+				discovered.TranscriptSize = s3.TranscriptSize
+				discovered.TranscriptMtime = s3.TranscriptMtimeNS
 				discovered.ProviderProcess = false
 				if discovered.Project == "" {
 					discovered.Project = s3.Project
@@ -7693,6 +7772,19 @@ func (e *Engine) filterFilesByMtime(
 			out = append(out, f)
 			continue
 		}
+		if usesCompositeSidecarFreshness(f.Agent, f.Path) {
+			rawSessionID := claudeSessionIDFromPath(f.Path)
+			sessionID := applyIDPrefixToID(
+				e.idPrefix,
+				claudeFormatArchiveSessionID(f.Agent, rawSessionID),
+			)
+			if e.icodemateCLIDeletedCompanionMtime(
+				sessionID, f.Path, mtime,
+			) >= cutoffNs {
+				out = append(out, f)
+				continue
+			}
+		}
 		if f.Agent != parser.AgentCodex {
 			continue
 		}
@@ -7727,6 +7819,33 @@ func (e *Engine) filterFilesByMtime(
 		out = append(out, pickPreferredCodexDiscoveredFile(e.db, candidates))
 	}
 	return out
+}
+
+// icodemateCLIDeletedCompanionMtime recovers the project-directory deletion
+// signal only when the committed source metadata proves that the now-missing
+// per-session directory contributed to the last fingerprint. This avoids
+// making unrelated sibling-session changes refresh every CLI transcript.
+func (e *Engine) icodemateCLIDeletedCompanionMtime(
+	sessionID, path string, currentMtime int64,
+) int64 {
+	transcriptInfo, err := os.Stat(path)
+	if err != nil {
+		return currentMtime
+	}
+	companionDir := strings.TrimSuffix(path, filepath.Ext(path))
+	if _, err := os.Stat(companionDir); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return currentMtime
+	}
+	storedSize, storedMtime, ok := e.db.GetSessionFileInfo(sessionID)
+	if !ok || (storedSize == transcriptInfo.Size() &&
+		storedMtime == transcriptInfo.ModTime().UnixNano()) {
+		return currentMtime
+	}
+	projectInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		return currentMtime
+	}
+	return max(currentMtime, projectInfo.ModTime().UnixNano())
 }
 
 // codebuffCompositeMtime returns a composite freshness timestamp for a
@@ -7870,6 +7989,13 @@ func (e *Engine) discoveredFileEffectiveMtime(
 	// doc comment for what the composite covers.
 	if file.Agent == parser.AgentCodebuff || file.Agent == parser.AgentFreebuff {
 		return codebuffCompositeMtime(file.Path)
+	}
+	// ICodeMate CLI fingerprints hash transcript and sidecar contents. The
+	// incremental cutoff needs only their stat metadata, including sidecar
+	// directory mtimes so deletions remain visible without hashing every
+	// unchanged transcript during each polling pass.
+	if usesCompositeSidecarFreshness(file.Agent, file.Path) {
+		return parser.ClaudeLayoutCompositeMtime(file.Path)
 	}
 	// Watermark-only shared-container sources carry their session-row
 	// watermark from discovery. Consulting the provider Fingerprint instead
@@ -8056,7 +8182,7 @@ func (e *Engine) dedupeClaudeDiscoveredFiles(
 	byKey := make(map[string][]parser.DiscoveredFile)
 	sessionIDByKey := make(map[string]string)
 	for _, file := range files {
-		if file.Agent != parser.AgentClaude {
+		if !isClaudeFormatTranscriptFile(file) {
 			continue
 		}
 		sessionID := claudeSessionIDFromPath(file.Path)
@@ -8081,7 +8207,7 @@ func (e *Engine) dedupeClaudeDiscoveredFiles(
 	out := files[:0]
 	seen := make(map[string]struct{}, len(preferred))
 	for _, file := range files {
-		if file.Agent != parser.AgentClaude {
+		if !isClaudeFormatTranscriptFile(file) {
 			out = append(out, file)
 			continue
 		}
@@ -8103,7 +8229,53 @@ func (e *Engine) dedupeClaudeDiscoveredFiles(
 func claudeDiscoveredFileKey(
 	file parser.DiscoveredFile, sessionID string,
 ) string {
-	return discoveredFileIDPrefix(file) + "\x00" + sessionID
+	return string(file.Agent) + "\x00" + discoveredFileIDPrefix(file) + "\x00" + sessionID
+}
+
+// isClaudeFormatAgent reports whether an agent stores sessions as Claude
+// projects-layout JSONL transcripts parsed by the shared Claude DAG pipeline.
+// Like isCodexFormatAgent for TraeX, it gates the format-shaped branches
+// (duplicate expansion and dedup, reconciliation identity, atomic
+// multi-session DAG completion, S3 transcript stat and hydration) so the
+// ICodeMate terminal CLI gets the same handling as Claude. Branches tied to
+// Claude's legacy archive semantics (stale-fork-only cleanup) or to
+// ICodeMate's sidecar-composite freshness stay keyed to the concrete agent.
+// OpenClaude also stores this layout but parses linearly to one session per
+// file, so it stays outside this set.
+func isClaudeFormatAgent(agent parser.AgentType) bool {
+	return agent == parser.AgentClaude || agent == parser.AgentIcodemate
+}
+
+func isClaudeFormatTranscriptFile(file parser.DiscoveredFile) bool {
+	return isClaudeFormatTranscript(file.Agent, file.Path)
+}
+
+// isClaudeFormatTranscript additionally requires a session-bearing .jsonl
+// path. For ICodeMate this distinguishes CLI transcripts from the agent's
+// OpenCode-storage family, which shares the same agent label.
+func isClaudeFormatTranscript(agent parser.AgentType, path string) bool {
+	return isClaudeFormatAgent(agent) && claudeSessionIDFromPath(path) != ""
+}
+
+// claudeFormatArchiveSessionID maps a raw filename-derived session ID into
+// the owning agent's archive namespace using its registry ID prefix
+// (empty for Claude, "icodemate:" for ICodeMate).
+func claudeFormatArchiveSessionID(agent parser.AgentType, rawSessionID string) string {
+	def, ok := parser.AgentByType(agent)
+	if !ok || def.IDPrefix == "" {
+		return rawSessionID
+	}
+	return def.IDPrefix + strings.TrimPrefix(rawSessionID, def.IDPrefix)
+}
+
+// usesCompositeSidecarFreshness reports whether a source's freshness signals
+// (effective mtime, duplicate-selection stat, polling cutoff) must include
+// persisted tool-result sidecars. Only ICodeMate CLI transcripts opt in:
+// Claude keeps plain-file freshness because its stored fingerprints hash only
+// the transcript, and switching would invalidate every archived Claude
+// fingerprint.
+func usesCompositeSidecarFreshness(agent parser.AgentType, path string) bool {
+	return agent == parser.AgentIcodemate && isClaudeFormatTranscript(agent, path)
 }
 
 func claudeSessionIDFromPath(path string) string {
@@ -8126,14 +8298,22 @@ func (e *Engine) pickPreferredClaudeDiscoveredFile(
 	if isS3SourcePath(candidates[0].Path) {
 		idPrefix = s3SessionIDPrefix(candidates[0].Machine)
 	}
-	fullID := applyIDPrefixToID(idPrefix, sessionID)
+	fullID := applyIDPrefixToID(
+		idPrefix, claudeFormatArchiveSessionID(candidates[0].Agent, sessionID),
+	)
 	storedPath := e.db.GetSessionFilePath(fullID)
 	if storedPath != "" {
 		for _, candidate := range candidates {
 			if e.effectiveSourcePath(candidate.Path) != storedPath {
 				continue
 			}
-			if e.claudeSourceMatchesStored(fullID, candidate) {
+			// Per the claudeFormatTranscriptPreference policy: ICodeMate's
+			// committed copy stays preferred even when its composite sidecar
+			// metadata moved, while Claude's committed copy must still match
+			// the stored stat. Either way a competitor wins only with strict
+			// transcript append progress.
+			if candidate.Agent == parser.AgentIcodemate ||
+				e.claudeSourceMatchesStored(fullID, candidate) {
 				best := candidate
 				for _, competing := range candidates {
 					if e.effectiveSourcePath(competing.Path) == storedPath ||
@@ -8161,7 +8341,7 @@ func (e *Engine) pickPreferredClaudeDiscoveredFile(
 func (e *Engine) claudeSourceMatchesStored(
 	sessionID string, file parser.DiscoveredFile,
 ) bool {
-	size, mtime, ok := claudeDiscoveredFileSourceInfo(file)
+	size, mtime, ok := claudeFormatFileSourceInfo(file)
 	if !ok {
 		return false
 	}
@@ -8191,8 +8371,8 @@ func (e *Engine) effectiveSourcePath(path string) string {
 func claudeCandidateHasAppendProgress(
 	candidate, current parser.DiscoveredFile,
 ) bool {
-	candidateSize, _, candidateOK := claudeDiscoveredFileSourceInfo(candidate)
-	currentSize, _, currentOK := claudeDiscoveredFileSourceInfo(current)
+	candidateSize, _, candidateOK := claudeTranscriptFileSourceInfo(candidate)
+	currentSize, _, currentOK := claudeTranscriptFileSourceInfo(current)
 	if !candidateOK || !currentOK {
 		return false
 	}
@@ -8202,25 +8382,76 @@ func claudeCandidateHasAppendProgress(
 func preferClaudeDiscoveredFile(
 	candidate, current parser.DiscoveredFile,
 ) bool {
-	candidateSize, candidateMtime, candidateOK := claudeDiscoveredFileSourceInfo(candidate)
-	currentSize, currentMtime, currentOK := claudeDiscoveredFileSourceInfo(current)
+	candidateSize, candidateMtime, candidateOK := claudeTranscriptFileSourceInfo(candidate)
+	currentSize, currentMtime, currentOK := claudeTranscriptFileSourceInfo(current)
 	switch {
 	case candidateOK && !currentOK:
 		return true
 	case !candidateOK && currentOK:
 		return false
 	case candidateOK && currentOK:
-		if candidateSize != currentSize {
-			return candidateSize > currentSize
+		candidatePrimary, candidateSecondary := claudeFormatTranscriptPreference(
+			candidate.Agent, candidateSize, candidateMtime,
+		)
+		currentPrimary, currentSecondary := claudeFormatTranscriptPreference(
+			current.Agent, currentSize, currentMtime,
+		)
+		if candidatePrimary != currentPrimary {
+			return candidatePrimary > currentPrimary
 		}
-		if candidateMtime != currentMtime {
-			return candidateMtime > currentMtime
+		if candidateSecondary != currentSecondary {
+			return candidateSecondary > currentSecondary
 		}
 	}
 	return candidate.Path < current.Path
 }
 
-func claudeDiscoveredFileSourceInfo(
+// claudeFormatTranscriptPreference orders same-session duplicate transcripts
+// across configured roots. The policy per agent:
+//
+// Claude transcripts are append-only, so a larger copy is strictly newer
+// work: rank size first, mtime second. The committed stored copy wins only
+// while its stat still matches the stored metadata (an unchanged committed
+// copy); see pickPreferredClaudeDiscoveredFile.
+//
+// ICodeMate CLI transcripts are rewritten in place (ForceReplace parses), so
+// size is not progress: a legitimately shortened rewrite must beat a larger
+// stale copy. The committed stored path stays preferred unless a competing
+// copy shows strict transcript append progress (a continued session moved to
+// another root); among uncommitted copies, mtime ranks first and size breaks
+// ties. Only transcript bytes participate — sidecar composites are reserved
+// for freshness, not duplicate ranking, so bulky tool results cannot outrank
+// a newer transcript.
+func claudeFormatTranscriptPreference(
+	agent parser.AgentType, size, mtime int64,
+) (primary, secondary int64) {
+	if agent == parser.AgentIcodemate {
+		return mtime, size
+	}
+	return size, mtime
+}
+
+func claudeTranscriptFileSourceInfo(
+	file parser.DiscoveredFile,
+) (size, mtime int64, ok bool) {
+	if isS3SourcePath(file.Path) {
+		if file.TranscriptMtime != 0 {
+			return file.TranscriptSize, file.TranscriptMtime, true
+		}
+		obj, err := statS3Object(file.Path)
+		if err != nil {
+			return 0, 0, false
+		}
+		return obj.Size, obj.LastModified.UnixNano(), true
+	}
+	info, err := os.Stat(file.Path)
+	if err != nil {
+		return 0, 0, false
+	}
+	return info.Size(), info.ModTime().UnixNano(), true
+}
+
+func claudeFormatFileSourceInfo(
 	file parser.DiscoveredFile,
 ) (size, mtime int64, ok bool) {
 	if isS3SourcePath(file.Path) {
@@ -8235,6 +8466,10 @@ func claudeDiscoveredFileSourceInfo(
 			return 0, 0, false
 		}
 		return obj.Size, obj.LastModified.UnixNano(), true
+	}
+	if usesCompositeSidecarFreshness(file.Agent, file.Path) {
+		size, mtime, err := parser.ClaudeLayoutCompositeFileInfo(file.Path)
+		return size, mtime, err == nil
 	}
 	info, err := os.Stat(file.Path)
 	if err != nil {
@@ -9278,9 +9513,11 @@ func (e *Engine) collectAndBatchWithOptions(
 			r.releaseRetention()
 			continue
 		}
-		claudeDAG := r.agent == parser.AgentClaude && len(r.results) > 1
+		atomicDAG := sourceRequiresAtomicDAGCompletion(
+			r.agent, len(r.results),
+		)
 		var sourceCompletionSkipped map[string]bool
-		if claudeDAG {
+		if atomicDAG {
 			activeResultIDs, skipped :=
 				e.partitionIntentionalSourceSkips(resultIDs)
 			sourceCompletionSkipped = skipped
@@ -9289,7 +9526,7 @@ func (e *Engine) collectAndBatchWithOptions(
 				activeResultIDs, staleVersion,
 			); err != nil {
 				e.clearProviderSourceFreshness(ctx, r.providerStatHash)
-				log.Printf("stage Claude source data versions: %v", err)
+				log.Printf("stage DAG source data versions: %v", err)
 				stats.RecordFailed()
 				e.noteSQLiteContainerResult(r.path, false)
 				r.releaseRetention()
@@ -9473,7 +9710,7 @@ func (e *Engine) collectAndBatchWithOptions(
 					sess:                    pr.Session,
 					msgs:                    pr.Messages,
 					usageEvents:             pr.UsageEvents,
-					needsRetry:              sessionNeedsRetry || claudeDAG,
+					needsRetry:              sessionNeedsRetry || atomicDAG,
 					forceReplace:            r.forceReplace,
 					baselineEligible:        !sourceNeedsRetry,
 					storageTrustPath:        r.storageTrustPath,
@@ -9484,19 +9721,19 @@ func (e *Engine) collectAndBatchWithOptions(
 					sourceCwdStoredOK:       r.sourceCwdStoredOK,
 					sourceCompletionSkipped: sourceCompletionSkipped[applyIDPrefixToID(e.idPrefix, pr.Session.ID)],
 				}
-				if i == 0 &&
-					(r.agent == parser.AgentClaude || r.providerStatHash != nil) {
-					// Claude can emit several DAG branches from one transcript.
+				if i == 0 && (atomicDAG || r.providerStatHash != nil) {
+					// Claude-compatible providers can emit several DAG branches
+					// from one transcript.
 					// Carry their contiguous write count so the flush can make
 					// one source-level completion decision. Other digest-backed
 					// providers currently emit one result per source.
 					pw.sourceWriteCount = 1
-					if r.agent == parser.AgentClaude {
+					if atomicDAG {
 						pw.sourceWriteCount = len(allowed)
 					}
 					pw.providerStatHash = r.providerStatHash
 					pw.sourceCompletionEligible = !sourceNeedsRetry
-					pw.promoteSourceOnComplete = claudeDAG
+					pw.promoteSourceOnComplete = atomicDAG
 				}
 				pending = append(pending, pw)
 				if runtimeMetrics != nil {
@@ -9837,6 +10074,7 @@ type sourceMissingMember struct {
 	sessionID string
 	filePath  string
 	machine   string
+	agent     parser.AgentType
 }
 
 type processResult struct {
@@ -10619,10 +10857,11 @@ func (e *Engine) processProviderFile(
 		}
 	}
 	outcome, err := provider.Parse(ctx, parser.ParseRequest{
-		Source:      source,
-		Fingerprint: fingerprint,
-		Machine:     machine,
-		ForceParse:  e.forceParseRequested(file),
+		Source:             source,
+		Fingerprint:        fingerprint,
+		Machine:            machine,
+		ForceParse:         e.forceParseRequested(file),
+		StoredPathResolver: e.storedPathResolver,
 	})
 	if err != nil {
 		if !e.forceParse {
@@ -10755,6 +10994,23 @@ func (e *Engine) processProviderFile(
 		missingMembers, err =
 			e.providerSourceMissingSessionOwnershipsForCompleteResult(
 				ctx, provider, source, parsedResults,
+			)
+		if err != nil {
+			return processResult{
+				err:            err,
+				mtime:          fingerprint.MTimeNS,
+				cacheSkip:      cacheSkip,
+				cacheKey:       cacheKey,
+				noCacheSkip:    true,
+				retentionLease: lease,
+			}, true
+		}
+	} else if file.Agent == parser.AgentIcodemate && outcome.ForceReplace &&
+		outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 {
+		missingMembers, err =
+			e.completeMultiSessionSourceMissingMembers(
+				ctx, file.Agent, file.Path,
+				outcome.ExcludedSessionIDs, parsedResults,
 			)
 		if err != nil {
 			return processResult{
@@ -10984,6 +11240,7 @@ func (e *Engine) providerSourceSessionOwnershipsForForceReplace(
 			members = append(members, sourceMissingMember{
 				sessionID: id,
 				filePath:  sourcePath,
+				agent:     agent,
 				machine: e.machineForProviderSource(
 					agent, source, sourcePath,
 				),
@@ -11032,6 +11289,109 @@ func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResult(
 		missing = append(missing, member)
 	}
 	return missing, nil
+}
+
+// completeMultiSessionSourceMissingMembers lists active sessions under an
+// exact source path that a complete authoritative parse did not emit. This is
+// used by new multi-session providers whose current parser owns the complete
+// membership set, unlike Claude's separate legacy-only stale-fork cleanup.
+func (e *Engine) completeMultiSessionSourceMissingMembers(
+	ctx context.Context,
+	agent parser.AgentType,
+	sourcePath string,
+	excludedSessionIDs []string,
+	results []parser.ParseResult,
+) ([]sourceMissingMember, error) {
+	type membershipReader interface {
+		ListSessionWriteIdentitiesByID(
+			context.Context, []string,
+		) (map[string]db.SessionWriteIdentity, error)
+		ListSessionIDsByFilePath(string, string) ([]string, error)
+		ListSessionMachinesByID(
+			context.Context, []string,
+		) (map[string]string, error)
+	}
+	reader := membershipReader(e.db)
+	if e.archiveStore != nil {
+		archived, ok := e.archiveStore.(membershipReader)
+		if !ok {
+			return nil, fmt.Errorf(
+				"archive %T does not support %s source membership lookup",
+				e.archiveStore, agent,
+			)
+		}
+		reader = archived
+	}
+	present := make(map[string]struct{}, len(results)+len(excludedSessionIDs))
+	paths := make(map[string]struct{}, 1)
+	emittedIDs := make([]string, 0, len(results))
+	for _, result := range results {
+		if id := applyIDPrefixToID(e.idPrefix, result.Session.ID); id != "" {
+			present[id] = struct{}{}
+			emittedIDs = append(emittedIDs, id)
+		}
+		path := result.Session.File.Path
+		if path == "" {
+			continue
+		}
+		if e.pathRewriter != nil {
+			path = e.pathRewriter(path)
+		}
+		paths[path] = struct{}{}
+	}
+	if len(paths) == 0 && sourcePath != "" {
+		paths[e.effectiveSourcePath(sourcePath)] = struct{}{}
+	}
+	storedIdentities, err := reader.ListSessionWriteIdentitiesByID(ctx, emittedIDs)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list stored %s source identities: %w", agent, err,
+		)
+	}
+	for _, identity := range storedIdentities {
+		if identity.Agent == string(agent) && identity.FilePath != "" {
+			paths[identity.FilePath] = struct{}{}
+		}
+	}
+	for _, id := range e.applyIDPrefixToSessionIDs(excludedSessionIDs) {
+		present[id] = struct{}{}
+	}
+
+	var members []sourceMissingMember
+	var sessionIDs []string
+	for path := range paths {
+		storedIDs, err := reader.ListSessionIDsByFilePath(path, string(agent))
+		if err != nil {
+			return nil, fmt.Errorf(
+				"list %s sessions for complete source %s: %w",
+				agent, path, err,
+			)
+		}
+		for _, id := range storedIDs {
+			if _, ok := present[id]; ok {
+				continue
+			}
+			members = append(members, sourceMissingMember{
+				sessionID: id,
+				filePath:  path,
+				agent:     agent,
+			})
+			sessionIDs = append(sessionIDs, id)
+		}
+	}
+	if len(members) == 0 {
+		return nil, nil
+	}
+	storedMachines, err := reader.ListSessionMachinesByID(ctx, sessionIDs)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list stored %s session machines: %w", agent, err,
+		)
+	}
+	for i := range members {
+		members[i].machine = storedMachines[members[i].sessionID]
+	}
+	return members, nil
 }
 
 // claudeSourceMissingSessionOwnershipsForCompleteResult lists stored active
@@ -11095,6 +11455,7 @@ func (e *Engine) claudeSourceMissingSessionOwnershipsForCompleteResult(
 			members = append(members, sourceMissingMember{
 				sessionID: id,
 				filePath:  path,
+				agent:     parser.AgentClaude,
 			})
 			sessionIDs = append(sessionIDs, id)
 		}
@@ -11157,6 +11518,7 @@ func (index *archiveStaleClaudeForkIndex) missingMembers(
 				sessionID: ownership.ID,
 				filePath:  path,
 				machine:   ownership.Machine,
+				agent:     parser.AgentClaude,
 			})
 		}
 	}
@@ -17062,6 +17424,11 @@ func (e *Engine) shouldPreserveOpenCodeFormatArchive(
 	if !isOpenCodeFormatStorageAgent(agent) {
 		return false
 	}
+	// An ICodeMate CLI transcript is a plain rewritable file, never a
+	// self-preserving OpenCode container.
+	if isClaudeFormatTranscript(agent, path) {
+		return false
+	}
 	store := e.archiveStore
 	if store == nil {
 		store = e.db
@@ -17078,6 +17445,14 @@ func (e *Engine) shouldPreserveOpenCodeFormatArchive(
 	storedHasStorageFingerprint := hasOpenCodeFormatStorageFingerprint(
 		agent, storedHash,
 	)
+	currentIsOpenCodeStorage := isOpenCodeFormatStoragePath(agent, path) ||
+		isOpenCodeFormatSQLiteVirtualPath(agent, path)
+	storedIsOpenCodeStorage := isOpenCodeFormatStoragePath(agent, storedPath) ||
+		isOpenCodeFormatSQLiteVirtualPath(agent, storedPath) ||
+		(storedPath == "" && storedHasStorageFingerprint)
+	if !currentIsOpenCodeStorage && !storedIsOpenCodeStorage {
+		return false
+	}
 	storedIsSQLiteVirtual := isOpenCodeFormatSQLiteVirtualPath(
 		agent, storedPath,
 	)
@@ -17210,6 +17585,14 @@ func isOpenCodeFormatStoragePath(
 ) bool {
 	return strings.HasSuffix(path, ".json") &&
 		!isOpenCodeFormatSQLiteVirtualPath(agent, path)
+}
+
+func isOpenCodeFormatContainerSource(
+	agent parser.AgentType, path string,
+) bool {
+	return isOpenCodeFormatStorageAgent(agent) &&
+		(isOpenCodeFormatStoragePath(agent, path) ||
+			isOpenCodeFormatSQLiteVirtualPath(agent, path))
 }
 
 func isOpenCodeFormatSQLiteVirtualPath(
@@ -17974,6 +18357,13 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 		return obj.LastModified.UnixNano()
 	}
 
+	if usesCompositeSidecarFreshness(def.Type, path) {
+		mtime, err := parser.ClaudeLayoutCompositeMtime(path)
+		if err != nil {
+			return 0
+		}
+		return mtime
+	}
 	if isOpenCodeFormatStorageAgent(def.Type) {
 		mtime, err := openCodeFormatSourceMtime(def.Type, path)
 		if err != nil {
@@ -18490,9 +18880,11 @@ func (e *Engine) processAndWriteSessionFile(
 			"queue subagent parent repairs: %w", err,
 		)
 	}
-	claudeDAG := file.Agent == parser.AgentClaude && len(res.results) > 1
+	atomicDAG := sourceRequiresAtomicDAGCompletion(
+		file.Agent, len(res.results),
+	)
 	var sourceCompletionSkipped map[string]bool
-	if claudeDAG {
+	if atomicDAG {
 		activeResultIDs, skipped :=
 			e.partitionIntentionalSourceSkips(resultIDs)
 		sourceCompletionSkipped = skipped
@@ -18633,7 +19025,7 @@ func (e *Engine) processAndWriteSessionFile(
 			sess:                pr.Session,
 			msgs:                pr.Messages,
 			usageEvents:         pr.UsageEvents,
-			needsRetry:          sessionNeedsRetry || claudeDAG,
+			needsRetry:          sessionNeedsRetry || atomicDAG,
 			forceReplace:        res.forceReplace,
 			sourceCwdResolution: res.sourceCwdResolution,
 			sourceCwdStored:     res.sourceCwdStored,
@@ -18692,7 +19084,7 @@ func (e *Engine) processAndWriteSessionFile(
 	// A source-level digest is valid only when every active result and its
 	// hierarchy links commit without retry state or archive preservation.
 	// User-excluded and trashed members are resolved without writes; the other
-	// Claude DAG members stay stale until the source-level decision succeeds.
+	// DAG members stay stale until the source-level decision succeeds.
 	sourceComplete := resolved == len(res.results) &&
 		!preserved && !sourceNeedsRetry
 	if !sourceComplete {
@@ -18704,13 +19096,13 @@ func (e *Engine) processAndWriteSessionFile(
 			"link changed subagent sessions: %w", err,
 		)
 	}
-	if sourceComplete && claudeDAG {
+	if sourceComplete && atomicDAG {
 		if err := e.db.SetSessionDataVersions(
 			writtenIDs, db.CurrentDataVersion(),
 		); err != nil {
 			markSourceIncomplete()
 			return false, sessionsChanged, fmt.Errorf(
-				"complete Claude source data versions: %w", err,
+				"complete DAG source data versions: %w", err,
 			)
 		}
 	}
@@ -18719,6 +19111,15 @@ func (e *Engine) processAndWriteSessionFile(
 	}
 
 	return preserved, sessionsChanged, nil
+}
+
+func sourceRequiresAtomicDAGCompletion(
+	agent parser.AgentType, resultCount int,
+) bool {
+	if resultCount <= 1 {
+		return false
+	}
+	return isClaudeFormatAgent(agent)
 }
 
 func (e *Engine) applyWorktreeMappingToSingleSession(

--- a/internal/sync/icodemate_cli_integration_test.go
+++ b/internal/sync/icodemate_cli_integration_test.go
@@ -1,0 +1,650 @@
+package sync_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+func TestIcodemateCLIForkSessionsReconcileAcrossSourceReparse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	path := filepath.Join(projectDir, "fork-session.jsonl")
+	mainLines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"root","message":{"content":"start"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"root","message":{"content":[{"type":"text","text":"main reply 1"}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":"main prompt 2"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"u3","parentUuid":"u2","message":{"content":"main prompt 3"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:04Z","uuid":"u4","parentUuid":"u3","message":{"content":"main prompt 4"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u5","parentUuid":"u4","message":{"content":"main prompt 5"}}`,
+	}
+	forkLine := `{"type":"assistant","timestamp":"2024-01-01T10:00:06Z","uuid":"fork","parentUuid":"root","message":{"content":[{"type":"text","text":"fork reply"}]}}`
+	content := strings.Join(append(mainLines, forkLine), "\n") + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	first := engine.SyncAll(context.Background(), nil)
+	require.Zero(t, first.Failed)
+	require.Equal(t, 2, first.Synced)
+
+	mainSession, err := database.GetSession(
+		context.Background(), "icodemate:fork-session",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mainSession)
+	forkSession, err := database.GetSession(
+		context.Background(), "icodemate:fork-session-fork",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, forkSession)
+	require.NotNil(t, forkSession.ParentSessionID)
+	assert.Equal(t, "icodemate:fork-session", *forkSession.ParentSessionID)
+
+	updated := content + `{"type":"ai-title","aiTitle":"Updated title"}` + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(updated), 0o644))
+	second := engine.SyncAll(context.Background(), nil)
+	require.Zero(t, second.Failed)
+	require.Equal(t, 2, second.Synced)
+
+	mainSession, err = database.GetSession(
+		context.Background(), "icodemate:fork-session",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mainSession)
+	require.NotNil(t, mainSession.DisplayName)
+	assert.Equal(t, "Updated title", *mainSession.DisplayName)
+	forkSession, err = database.GetSession(
+		context.Background(), "icodemate:fork-session-fork",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, forkSession)
+	require.NotNil(t, forkSession.ParentSessionID)
+	assert.Equal(t, "icodemate:fork-session", *forkSession.ParentSessionID)
+
+	truncated := mainLines[0] + "\n" + `{"type":"assistant","uuid":"partial`
+	require.NoError(t, os.WriteFile(path, []byte(truncated), 0o644))
+	incomplete := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, incomplete.Failed)
+	assert.Zero(t, incomplete.Synced)
+	forkSession, err = database.GetSession(
+		context.Background(), "icodemate:fork-session-fork",
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, forkSession)
+	messages, err := database.GetMessages(
+		context.Background(), "icodemate:fork-session", 0, 20, true,
+	)
+	require.NoError(t, err)
+	assert.Len(t, messages, len(mainLines))
+
+	mainOnly := strings.Join(mainLines, "\n") + "\n" +
+		`{"type":"ai-title","aiTitle":"Main only"}` + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(mainOnly), 0o644))
+	third := engine.SyncAll(context.Background(), nil)
+	require.Zero(t, third.Failed)
+	require.Equal(t, 1, third.Synced)
+
+	mainSession, err = database.GetSession(
+		context.Background(), "icodemate:fork-session",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mainSession)
+	require.NotNil(t, mainSession.DisplayName)
+	assert.Equal(t, "Main only", *mainSession.DisplayName)
+	forkSession, err = database.GetSession(
+		context.Background(), "icodemate:fork-session-fork",
+	)
+	require.NoError(t, err)
+	assert.Nil(t, forkSession)
+	archivedFork, err := database.GetSessionFull(
+		context.Background(), "icodemate:fork-session-fork",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, archivedFork)
+	require.NotNil(t, archivedFork.DeletionCause)
+	assert.Equal(t, "source_missing", *archivedFork.DeletionCause)
+}
+
+func TestIcodemateCLIShortenedTranscriptReplacesArchivedMessages(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "shortened.jsonl")
+	initial := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "first prompt").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "obsolete reply").
+		String()
+	dbtest.WriteTestFile(t, path, []byte(initial))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+
+	shortened := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "replacement prompt").
+		String()
+	dbtest.WriteTestFile(t, path, []byte(shortened))
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+
+	messages, err := database.GetMessages(
+		t.Context(), "icodemate:shortened", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "replacement prompt", messages[0].Content)
+}
+
+func TestIcodemateCLISourceMtimeIncludesPersistedToolResults(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "mtime.jsonl")
+	sidecar := filepath.Join(
+		root, "project", "mtime", "tool-results", "output.txt",
+	)
+	olderSidecar := filepath.Join(filepath.Dir(sidecar), "older.txt")
+	dbtest.WriteTestFile(t, path, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "prompt").String()))
+	dbtest.WriteTestFile(t, sidecar, []byte("persisted output\n"))
+	dbtest.WriteTestFile(t, olderSidecar, []byte("older output\n"))
+	transcriptTime := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	olderSidecarTime := transcriptTime.Add(30 * time.Second)
+	sidecarTime := transcriptTime.Add(time.Minute)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
+	require.NoError(t, os.Chtimes(
+		olderSidecar, olderSidecarTime, olderSidecarTime,
+	))
+	require.NoError(t, os.Chtimes(sidecar, sidecarTime, sidecarTime))
+	require.NoError(t, os.Chtimes(
+		filepath.Dir(sidecar), transcriptTime, transcriptTime,
+	))
+	require.NoError(t, os.Chtimes(
+		filepath.Dir(filepath.Dir(sidecar)), transcriptTime, transcriptTime,
+	))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	assert.Equal(t, sidecarTime.UnixNano(),
+		engine.SourceMtime("icodemate:mtime"))
+
+	deletedAt := sidecarTime.Add(time.Minute)
+	require.NoError(t, os.Remove(olderSidecar))
+	require.NoError(t, os.Chtimes(
+		filepath.Dir(sidecar), deletedAt, deletedAt,
+	))
+	assert.Equal(t, deletedAt.UnixNano(),
+		engine.SourceMtime("icodemate:mtime"))
+}
+
+func TestIcodemateCLISyncAllSinceDetectsDeletedToolResult(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project")
+	sessionPath := filepath.Join(projectDir, "sidecar.jsonl")
+	sidecarPath := filepath.Join(
+		projectDir, "sidecar", "tool-results", "output.txt",
+	)
+	dbtest.WriteTestFile(t, sidecarPath, []byte("full persisted output\n"))
+
+	pathJSON, err := json.Marshal(sidecarPath)
+	require.NoError(t, err)
+	placeholder := "<persisted-output>\nOutput too large. Full output saved to: " +
+		sidecarPath + "\n</persisted-output>"
+	placeholderJSON, err := json.Marshal(placeholder)
+	require.NoError(t, err)
+	transcript := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make logs"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + string(placeholderJSON) + `}]},"toolUseResult":{"persistedOutputPath":` + string(pathJSON) + `}}`,
+	}, "\n") + "\n"
+	dbtest.WriteTestFile(t, sessionPath, []byte(transcript))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	initialMessages, err := database.GetMessages(
+		t.Context(), "icodemate:sidecar", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, initialMessages, 2)
+	require.Len(t, initialMessages[1].ToolCalls, 1)
+	require.Equal(t, "full persisted output\n",
+		initialMessages[1].ToolCalls[0].ResultContent)
+
+	cutoff := time.Now()
+	toolResultsDir := filepath.Dir(sidecarPath)
+	require.NoError(t, os.RemoveAll(filepath.Dir(toolResultsDir)))
+	changedAt := cutoff.Add(time.Second)
+	require.NoError(t, os.Chtimes(projectDir, changedAt, changedAt))
+
+	stats := engine.SyncAllSince(t.Context(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced)
+	messages, err := database.GetMessages(
+		t.Context(), "icodemate:sidecar", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	require.Len(t, messages[1].ToolCalls, 1)
+	assert.Equal(t, placeholder, messages[1].ToolCalls[0].ResultContent)
+}
+
+func TestIcodemateCLIResyncAllAbortsOnEmptyDiscovery(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "resync.jsonl")
+	dbtest.WriteTestFile(t, path, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "keep me").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "ok").
+		String()))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.Remove(path))
+
+	stats := engine.ResyncAll(t.Context(), nil)
+	assert.True(t, stats.Aborted)
+	messages, err := database.GetMessages(
+		t.Context(), "icodemate:resync", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	assert.Equal(t, "keep me", messages[0].Content)
+}
+
+func TestIcodemateCLIPartialForkWriteRetriesWholeSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	path := filepath.Join(projectDir, "forked.jsonl")
+	mainLines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"root","message":{"content":"start"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"root","message":{"content":[{"type":"text","text":"main reply 1"}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":"main prompt 2"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"u3","parentUuid":"u2","message":{"content":"main prompt 3"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:04Z","uuid":"u4","parentUuid":"u3","message":{"content":"main prompt 4"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u5","parentUuid":"u4","message":{"content":"main prompt 5"}}`,
+	}
+	require.NoError(t, os.WriteFile(
+		path, []byte(strings.Join(mainLines, "\n")+"\n"), 0o644,
+	))
+
+	database := dbtest.OpenTestDB(t)
+	initialEngine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(initialEngine.Close)
+	initial := initialEngine.SyncAll(t.Context(), nil)
+	require.Zero(t, initial.Failed)
+	require.Equal(t, 1, initial.Synced)
+	require.Equal(t, db.CurrentDataVersion(),
+		database.GetSessionDataVersion("icodemate:forked"))
+
+	forkLine := `{"type":"assistant","timestamp":"2024-01-01T10:00:06Z","uuid":"fork","parentUuid":"root","message":{"content":[{"type":"text","text":"fork reply"}]}}`
+	require.NoError(t, os.WriteFile(path, []byte(
+		strings.Join(append(mainLines, forkLine), "\n")+"\n",
+	), 0o644))
+
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`
+		CREATE TRIGGER fail_icodemate_fork_insert
+		BEFORE INSERT ON sessions
+		WHEN NEW.id = 'icodemate:forked-fork'
+		BEGIN
+			SELECT RAISE(FAIL, 'injected ICodeMate fork write failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	partialEngine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(partialEngine.Close)
+	failed := partialEngine.SyncAll(t.Context(), nil)
+	require.Equal(t, 1, failed.Synced)
+	require.Equal(t, 1, failed.Failed)
+	assert.Less(t,
+		database.GetSessionDataVersion("icodemate:forked"),
+		db.CurrentDataVersion(),
+		"the committed main branch must remain retryable",
+	)
+	fork, err := database.GetSession(t.Context(), "icodemate:forked-fork")
+	require.NoError(t, err)
+	assert.Nil(t, fork)
+
+	_, err = raw.Exec(`DROP TRIGGER fail_icodemate_fork_insert`)
+	require.NoError(t, err)
+	restarted := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(restarted.Close)
+	retry := restarted.SyncAll(t.Context(), nil)
+	require.Zero(t, retry.Failed)
+	require.Equal(t, 2, retry.Synced,
+		"the unchanged transcript must retry every branch")
+	fork, err = database.GetSession(t.Context(), "icodemate:forked-fork")
+	require.NoError(t, err)
+	require.NotNil(t, fork)
+	assert.Equal(t, db.CurrentDataVersion(),
+		database.GetSessionDataVersion("icodemate:forked"))
+	assert.Equal(t, db.CurrentDataVersion(),
+		database.GetSessionDataVersion("icodemate:forked-fork"))
+}
+
+func TestIcodemateCLIDeduplicatesSameSessionAcrossRoots(t *testing.T) {
+	liveRoot := t.TempDir()
+	archiveRoot := t.TempDir()
+	livePath := filepath.Join(liveRoot, "live-project", "duplicate.jsonl")
+	archivePath := filepath.Join(archiveRoot, "archive-project", "duplicate.jsonl")
+	liveContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "complete session").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "complete reply").
+		String()
+	archiveContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "stale session").
+		String()
+	dbtest.WriteTestFile(t, livePath, []byte(liveContent))
+	dbtest.WriteTestFile(t, archivePath, []byte(archiveContent))
+	liveSidecar := filepath.Join(
+		liveRoot, "live-project", "duplicate", "tool-results", "output.txt",
+	)
+	archiveSidecar := filepath.Join(
+		archiveRoot, "archive-project", "duplicate", "tool-results", "output.txt",
+	)
+	dbtest.WriteTestFile(t, liveSidecar, []byte("persisted output\n"))
+	dbtest.WriteTestFile(t, archiveSidecar, []byte(strings.Repeat("stale output\n", 100)))
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, older, older))
+	require.NoError(t, os.Chtimes(archiveSidecar, older, older))
+	require.NoError(t, os.Chtimes(livePath, newer, newer))
+	require.NoError(t, os.Chtimes(liveSidecar, newer, newer))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {liveRoot, archiveRoot},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	first := engine.SyncAll(t.Context(), nil)
+	require.Zero(t, first.Failed)
+	assert.Equal(t, 1, first.Synced)
+	assert.Equal(t, livePath,
+		database.GetSessionFilePath("icodemate:duplicate"))
+	messages, err := database.GetMessages(
+		t.Context(), "icodemate:duplicate", 0, 10, true,
+	)
+	require.NoError(t, err)
+	assert.Len(t, messages, 2)
+
+	touchedArchive := newer.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, touchedArchive, touchedArchive))
+	engine.SyncPaths([]string{archivePath})
+	assert.Zero(t, engine.LastSyncStats().Synced,
+		"a stale duplicate watcher event must not replace the committed source")
+	assert.Equal(t, livePath,
+		database.GetSessionFilePath("icodemate:duplicate"))
+
+	staleLarge := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", strings.Repeat("stale ", 50)).
+		AddClaudeAssistant("2024-01-01T00:00:05Z", strings.Repeat("reply ", 50)).
+		String()
+	shortened := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "replacement").
+		String()
+	dbtest.WriteTestFile(t, archivePath, []byte(staleLarge))
+	dbtest.WriteTestFile(t, livePath, []byte(shortened))
+	require.NoError(t, os.Chtimes(
+		archivePath, touchedArchive, touchedArchive,
+	))
+	shortenedAt := touchedArchive.Add(time.Second)
+	require.NoError(t, os.Chtimes(livePath, shortenedAt, shortenedAt))
+
+	stats := engine.SyncAll(t.Context(), nil)
+	require.Zero(t, stats.Failed)
+	require.Equal(t, 1, stats.Synced)
+	assert.Equal(t, livePath,
+		database.GetSessionFilePath("icodemate:duplicate"))
+	messages, err = database.GetMessages(
+		t.Context(), "icodemate:duplicate", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "replacement", messages[0].Content)
+
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{liveRoot, archiveRoot}, false,
+	))
+	assert.Equal(t, livePath,
+		database.GetSessionFilePath("icodemate:duplicate"))
+	messages, err = database.GetMessages(
+		t.Context(), "icodemate:duplicate", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "replacement", messages[0].Content)
+
+	staleSameSize := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "stale value").
+		String()
+	require.Len(t, staleSameSize, len(shortened))
+	dbtest.WriteTestFile(t, archivePath, []byte(staleSameSize))
+	touchedArchive = shortenedAt.Add(time.Second)
+	require.NoError(t, os.Chtimes(
+		archivePath, touchedArchive, touchedArchive,
+	))
+
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{liveRoot, archiveRoot}, false,
+	))
+	assert.Equal(t, livePath,
+		database.GetSessionFilePath("icodemate:duplicate"))
+	messages, err = database.GetMessages(
+		t.Context(), "icodemate:duplicate", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "replacement", messages[0].Content)
+
+	continued := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "replacement").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "continued elsewhere").
+		String()
+	dbtest.WriteTestFile(t, archivePath, []byte(continued))
+	continuedAt := touchedArchive.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, continuedAt, continuedAt))
+
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{liveRoot, archiveRoot}, false,
+	))
+	assert.Equal(t, archivePath,
+		database.GetSessionFilePath("icodemate:duplicate"))
+	messages, err = database.GetMessages(
+		t.Context(), "icodemate:duplicate", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	assert.Equal(t, "continued elsewhere", messages[1].Content)
+
+	dbtest.WriteTestFile(t, archiveSidecar, []byte("updated persisted output\n"))
+	dbtest.WriteTestFile(t, livePath, []byte(shortened))
+	staleAt := continuedAt.Add(time.Second)
+	require.NoError(t, os.Chtimes(livePath, staleAt, staleAt))
+
+	stats = engine.SyncAll(t.Context(), nil)
+	require.Zero(t, stats.Failed)
+	assert.Equal(t, archivePath,
+		database.GetSessionFilePath("icodemate:duplicate"))
+	messages, err = database.GetMessages(
+		t.Context(), "icodemate:duplicate", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	assert.Equal(t, "continued elsewhere", messages[1].Content)
+}
+
+func TestIcodemateCLIReconcilePreservesMovedSessionAcrossRoots(t *testing.T) {
+	oldRoot := t.TempDir()
+	newRoot := t.TempDir()
+	oldPath := filepath.Join(oldRoot, "old-project", "moved.jsonl")
+	mainLines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"root","message":{"content":"start"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"root","message":{"content":[{"type":"text","text":"main reply 1"}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":"main prompt 2"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"u3","parentUuid":"u2","message":{"content":"main prompt 3"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:04Z","uuid":"u4","parentUuid":"u3","message":{"content":"main prompt 4"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u5","parentUuid":"u4","message":{"content":"main prompt 5"}}`,
+	}
+	forkLine := `{"type":"assistant","timestamp":"2024-01-01T10:00:06Z","uuid":"fork","parentUuid":"root","message":{"content":[{"type":"text","text":"fork reply"}]}}`
+	initial := strings.Join(append(mainLines, forkLine), "\n") + "\n"
+	dbtest.WriteTestFile(t, oldPath, []byte(initial))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {oldRoot, newRoot},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+
+	require.NoError(t, os.Remove(oldPath))
+	newPath := filepath.Join(newRoot, "new-project", "moved.jsonl")
+	replacement := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "replacement").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "still active").
+		String()
+	dbtest.WriteTestFile(t, newPath, []byte(replacement))
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{oldRoot, newRoot}, false,
+	))
+
+	active, err := database.GetSession(t.Context(), "icodemate:moved")
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(t, newPath,
+		database.GetSessionFilePath("icodemate:moved"))
+	messages, err := database.GetMessages(
+		t.Context(), "icodemate:moved", 0, 10, true,
+	)
+	require.NoError(t, err)
+	assert.Len(t, messages, 2)
+
+	fork, err := database.GetSession(t.Context(), "icodemate:moved-fork")
+	require.NoError(t, err)
+	assert.Nil(t, fork)
+	archivedFork, err := database.GetSessionFull(
+		t.Context(), "icodemate:moved-fork",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, archivedFork)
+	require.NotNil(t, archivedFork.DeletionCause)
+	assert.Equal(t, "source_missing", *archivedFork.DeletionCause)
+}
+
+func TestIcodemateCLIResyncAllTombstonesRemovedFork(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "resync-fork.jsonl")
+	mainLines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"root","message":{"content":"start"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"root","message":{"content":[{"type":"text","text":"main reply 1"}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":"main prompt 2"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"u3","parentUuid":"u2","message":{"content":"main prompt 3"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:04Z","uuid":"u4","parentUuid":"u3","message":{"content":"main prompt 4"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u5","parentUuid":"u4","message":{"content":"main prompt 5"}}`,
+	}
+	forkLine := `{"type":"assistant","timestamp":"2024-01-01T10:00:06Z","uuid":"fork","parentUuid":"root","message":{"content":[{"type":"text","text":"fork reply"}]}}`
+	dbtest.WriteTestFile(t, path, []byte(
+		strings.Join(append(mainLines, forkLine), "\n")+"\n",
+	))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+
+	dbtest.WriteTestFile(t, path, []byte(strings.Join(mainLines, "\n")+"\n"))
+	rebuilt := engine.ResyncAll(t.Context(), nil)
+	require.False(t, rebuilt.Aborted)
+	require.Zero(t, rebuilt.Failed)
+
+	fork, err := database.GetSession(t.Context(), "icodemate:resync-fork-fork")
+	require.NoError(t, err)
+	assert.Nil(t, fork)
+	archivedFork, err := database.GetSessionFull(
+		t.Context(), "icodemate:resync-fork-fork",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, archivedFork)
+	require.NotNil(t, archivedFork.DeletionCause)
+	assert.Equal(t, "source_missing", *archivedFork.DeletionCause)
+}

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -268,6 +268,8 @@ func (e *Engine) parseDiffProviderSources(
 			discovered.SourceSize = s3.Size
 			discovered.SourceMtime = s3.MtimeNS
 			discovered.SourceFingerprint = s3.Fingerprint
+			discovered.TranscriptSize = s3.TranscriptSize
+			discovered.TranscriptMtime = s3.TranscriptMtimeNS
 			if discovered.Project == "" {
 				discovered.Project = s3.Project
 			}

--- a/internal/sync/parsediff_provider_test.go
+++ b/internal/sync/parsediff_provider_test.go
@@ -288,6 +288,8 @@ func TestParseDiffProviderSourcesThreadsS3Metadata(t *testing.T) {
 	assert.Equal(t, int64(4096), f.SourceSize)
 	assert.Equal(t, int64(1779012030000)*1_000_000, f.SourceMtime)
 	assert.Equal(t, "s3-fingerprint", f.SourceFingerprint)
+	assert.Equal(t, int64(2048), f.TranscriptSize)
+	assert.Equal(t, int64(1779012020000)*1_000_000, f.TranscriptMtime)
 	assert.Equal(t, "myproj", f.Project)
 }
 
@@ -345,12 +347,14 @@ func (p s3ParseDiffProvider) Discover(
 		Key:         p.uri,
 		DisplayPath: p.uri,
 		Opaque: parser.S3DiscoveredSource{
-			URI:         p.uri,
-			Project:     "myproj",
-			Machine:     "remote-box",
-			Size:        4096,
-			MtimeNS:     int64(1779012030000) * 1_000_000,
-			Fingerprint: "s3-fingerprint",
+			URI:               p.uri,
+			Project:           "myproj",
+			Machine:           "remote-box",
+			Size:              4096,
+			MtimeNS:           int64(1779012030000) * 1_000_000,
+			Fingerprint:       "s3-fingerprint",
+			TranscriptSize:    2048,
+			TranscriptMtimeNS: int64(1779012020000) * 1_000_000,
 		},
 	}}, nil
 }

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -215,6 +216,24 @@ func (e *Engine) processS3Session(
 				return processResult{skip: true}
 			}
 		}
+	case parser.AgentIcodemate:
+		sessionID := claudeFormatArchiveSessionID(
+			file.Agent, strings.TrimSuffix(sourceInfo.Name(), ".jsonl"),
+		)
+		fullID := applyIDPrefixToID(idPrefix, sessionID)
+		if e.shouldSkipFileWithPrefix(
+			idPrefix, sessionID, sourceInfo, sourceFingerprint,
+		) &&
+			e.db.GetSessionFilePathNotSourceMissing(fullID) == file.Path &&
+			e.db.GetDataVersionByAgentPath(
+				file.Path, string(parser.AgentIcodemate),
+			) >= db.CurrentDataVersion() {
+			sess, _ := e.db.GetSession(ctx, fullID)
+			if sess != nil && sess.Project != "" &&
+				!parser.NeedsProjectReparse(sess.Project) {
+				return processResult{skip: true}
+			}
+		}
 	case parser.AgentCodex:
 		if uuid := parser.CodexSessionUUIDFromFilename(
 			path.Base(file.Path),
@@ -308,15 +327,15 @@ func (e *Engine) processS3Session(
 	}
 	hydratedToolResults := false
 	sawPersistedToolResults := false
-	switch file.Agent {
-	case parser.AgentClaude:
+	switch {
+	case isClaudeFormatAgent(file.Agent):
 		rewrote, sawPersisted, err := hydrateS3ClaudeToolResults(tmp, file.Path)
 		if err != nil {
 			return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 		}
 		hydratedToolResults = rewrote
 		sawPersistedToolResults = sawPersisted
-	case parser.AgentCodex:
+	case file.Agent == parser.AgentCodex:
 		configuredRoot := ""
 		if file.ProviderSource != nil {
 			configuredRoot = file.ProviderSource.ConfiguredRoot
@@ -374,7 +393,8 @@ func (e *Engine) processS3Session(
 	res.excludedSessionIDs = applyIDPrefixToIDs(
 		idPrefix, res.excludedSessionIDs,
 	)
-	if file.Agent == parser.AgentClaude {
+	switch file.Agent {
+	case parser.AgentClaude:
 		missing, err := e.claudeSourceMissingSessionOwnershipsForCompleteResult(
 			ctx,
 			file.Path,
@@ -395,6 +415,25 @@ func (e *Engine) processS3Session(
 			res.claudeRowlessFreshnessKey =
 				e.claudeRowlessFreshnessCacheKey(file.Path, sourceFingerprint)
 		}
+	case parser.AgentIcodemate:
+		if res.suppressPresenceSweep || res.providerWideFailureCount > 0 {
+			break
+		}
+		missing, err := e.completeMultiSessionSourceMissingMembers(
+			ctx,
+			file.Agent,
+			file.Path,
+			res.excludedSessionIDs,
+			res.results,
+		)
+		if err != nil {
+			return processResult{
+				err:            err,
+				noCacheSkip:    true,
+				retentionLease: lease,
+			}
+		}
+		res.sourceMissingMembers = missing
 	}
 	res.retentionLease = lease
 	return res
@@ -443,10 +482,16 @@ func (e *Engine) parseMaterializedS3Source(
 	if err != nil {
 		return processResult{}, err
 	}
+	providerWideFailureCount := len(outcome.SourceErrors)
+	if !outcome.ResultSetComplete {
+		providerWideFailureCount++
+	}
+	providerFailureCount := providerWideFailureCount
 	retrySessionIDs := make(map[string]bool)
 	for _, result := range outcome.Results {
 		if result.DataVersion == parser.DataVersionNeedsRetry {
 			retrySessionIDs[result.Result.Session.ID] = true
+			providerFailureCount++
 		}
 	}
 	if len(retrySessionIDs) == 0 {
@@ -457,9 +502,13 @@ func (e *Engine) parseMaterializedS3Source(
 	// session but excludes its ID), and the caller needs those IDs to drop the
 	// previously-archived row on resync. ForceReplace must survive too.
 	return processResult{
-		results:            parseOutcomeResults(outcome.Results),
-		excludedSessionIDs: append([]string(nil), outcome.ExcludedSessionIDs...),
-		forceReplace:       outcome.ForceReplace,
-		retrySessionIDs:    retrySessionIDs,
+		results:                  parseOutcomeResults(outcome.Results),
+		excludedSessionIDs:       append([]string(nil), outcome.ExcludedSessionIDs...),
+		forceReplace:             outcome.ForceReplace,
+		retrySessionIDs:          retrySessionIDs,
+		suppressPresenceSweep:    !outcome.ResultSetComplete,
+		providerFailureCount:     providerFailureCount,
+		providerWideFailureCount: providerWideFailureCount,
+		noCacheSkip:              !providerOutcomeAllowsCleanSkipCache(outcome),
 	}, nil
 }

--- a/internal/sync/s3_provider_discovery_test.go
+++ b/internal/sync/s3_provider_discovery_test.go
@@ -85,3 +85,28 @@ func TestProcessFileS3ProviderDiscoveredRoutesToS3Path(t *testing.T) {
 	assert.Equal(t, "laptop", sess.Machine)
 	assert.Equal(t, path, derefString(sess.FilePath))
 }
+
+func TestDiscoverProviderSourcesThreadsS3TranscriptMetadata(t *testing.T) {
+	const root = "s3://bucket/remote-box/raw/claude"
+	const uri = root + "/proj/session.jsonl"
+	e := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine: "central",
+		ProviderFactories: []parser.ProviderFactory{
+			s3ParseDiffProviderFactory{uri: uri},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentClaude: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(e.Close)
+
+	files, failures := e.discoverProviderSources(t.Context(), nil, nil)
+	require.Zero(t, failures)
+	require.Len(t, files, 1)
+	assert.Equal(t, int64(2048), files[0].TranscriptSize)
+	assert.Equal(t,
+		int64(1779012020000)*1_000_000, files[0].TranscriptMtime)
+}

--- a/internal/sync/s3_sidecars_test.go
+++ b/internal/sync/s3_sidecars_test.go
@@ -103,6 +103,67 @@ func TestProcessS3ClaudeFetchesPersistedToolResultSidecar(t *testing.T) {
 	assert.Equal(t, 1, fetched[sidecarPath])
 }
 
+func TestProcessS3IcodemateFetchesPersistedToolResultSidecar(t *testing.T) {
+	database := openTestDB(t)
+	path := "s3://bucket/laptop/raw/icodemate/test-proj/parent-session.jsonl"
+	sidecarPath := "s3://bucket/laptop/raw/icodemate/test-proj/" +
+		"parent-session/tool-results/output.txt"
+	localResultPath := "/tmp/icodemate/cli/projects/test-proj/" +
+		"parent-session/tool-results/output.txt"
+	fullOutput := "full ICodeMate output\n"
+	persistedContentJSON := mustSyncJSONString(t,
+		"<persisted-output>\n"+
+			"Output too large. Full output saved to: "+localResultPath+
+			"\n\nPreview:\npreview only\n</persisted-output>")
+	resultPathJSON := mustSyncJSONString(t, localResultPath)
+	content := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make logs"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + persistedContentJSON + `}]},"toolUseResult":{"persistedOutputPath":` + resultPathJSON + `}}`,
+	}, "\n")
+
+	oldFetch := fetchS3Object
+	t.Cleanup(func() { fetchS3Object = oldFetch })
+	fetched := make(map[string]int)
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		fetched[got]++
+		switch got {
+		case path:
+			return io.NopCloser(strings.NewReader(content)), nil
+		case sidecarPath:
+			return io.NopCloser(strings.NewReader(fullOutput)), nil
+		default:
+			return nil, errors.New("unexpected s3 fetch: " + got)
+		}
+	}
+
+	e := &Engine{db: database, machine: "central"}
+	res := e.processFile(context.Background(), parser.DiscoveredFile{
+		Agent:       parser.AgentIcodemate,
+		Path:        path,
+		Project:     "test-proj",
+		Machine:     "laptop",
+		SourceSize:  int64(len(content)),
+		SourceMtime: time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC).UnixNano(),
+	})
+
+	require.NoError(t, res.err)
+	require.Len(t, res.results, 1)
+	assert.Equal(t, parser.AgentIcodemate, res.results[0].Session.Agent)
+	assert.Equal(t, "laptop~icodemate:parent-session", res.results[0].Session.ID)
+	require.Len(t, res.results[0].Messages, 3)
+	require.Len(t, res.results[0].Messages[2].ToolResults, 1)
+	assert.Equal(
+		t,
+		fullOutput,
+		parser.DecodeContent(
+			res.results[0].Messages[2].ToolResults[0].ContentRaw,
+		),
+	)
+	assert.Equal(t, 1, fetched[path])
+	assert.Equal(t, 1, fetched[sidecarPath])
+}
+
 func TestProcessS3ClaudeMissingSidecarKeepsPersistedPreview(t *testing.T) {
 	database := openTestDB(t)
 	path := "s3://bucket/laptop/raw/claude/test-proj/parent-session.jsonl"

--- a/internal/sync/s3_source.go
+++ b/internal/sync/s3_source.go
@@ -67,12 +67,13 @@ func statS3SourceObject(file parser.DiscoveredFile) (parser.S3Object, error) {
 func statS3SourceObjectWithProvider(
 	file parser.DiscoveredFile, p parser.S3Provider,
 ) (parser.S3Object, error) {
-	// Keep Claude/Codex package-level hooks so existing tests can stub
-	// sidecar-aware stats without replacing the provider.
-	switch file.Agent {
-	case parser.AgentClaude:
+	// Keep Claude-format/Codex package-level hooks so existing tests can stub
+	// sidecar-aware stats without replacing the provider. ICodeMate CLI
+	// transcripts share Claude's sidecar-aware stat and its seam.
+	switch {
+	case isClaudeFormatAgent(file.Agent):
 		return statClaudeS3Session(file.Path)
-	case parser.AgentCodex:
+	case file.Agent == parser.AgentCodex:
 		return statCodexS3Session(file.Path)
 	}
 	return p.S3StatSession(file.Path)
@@ -398,7 +399,7 @@ func (e *Engine) hydrateS3DiscoveredFile(
 	}
 }
 
-// SyncClaudeS3SubagentTranscriptsContext ingests the given s3:// Claude
+// SyncS3SubagentTranscriptsContext ingests the given s3:// Claude-compatible
 // subagent transcript objects. The changed-path pipeline
 // (SyncPathsContext) classifies by statting local files, so it cannot
 // route s3:// objects; the on-demand subagent refresh behind `session
@@ -409,11 +410,15 @@ func (e *Engine) hydrateS3DiscoveredFile(
 // remaining objects still sync. parentSessionID preserves the stored
 // parent's machine namespace when its original S3 root is no longer
 // configured.
-func (e *Engine) SyncClaudeS3SubagentTranscriptsContext(
-	ctx context.Context, parentSessionID string, paths []string,
+func (e *Engine) SyncS3SubagentTranscriptsContext(
+	ctx context.Context, parentSessionID string, parentAgent parser.AgentType,
+	paths []string,
 ) error {
-	if e.refuseWriteInForceParse("SyncClaudeS3SubagentTranscripts") {
+	if e.refuseWriteInForceParse("SyncS3SubagentTranscripts") {
 		return nil
+	}
+	if !isClaudeFormatAgent(parentAgent) {
+		return fmt.Errorf("sync s3 subagent transcripts: unsupported parent agent %q", parentAgent)
 	}
 	e.syncMu.Lock()
 	synced := false
@@ -446,11 +451,12 @@ func (e *Engine) SyncClaudeS3SubagentTranscriptsContext(
 			continue
 		}
 		file := parser.DiscoveredFile{
-			Path: p, Agent: parser.AgentClaude, Machine: parentMachine,
+			Path: p, Agent: parentAgent, Machine: parentMachine,
 		}
-		sessionID := strings.TrimSuffix(path.Base(p), ".jsonl")
-		childID := applyIDPrefixToID(
-			s3SessionIDPrefix(parentMachine), sessionID)
+		childID := s3DiscoveredSessionID(file)
+		if childID == "" {
+			continue
+		}
 		e.hydrateS3DiscoveredFile(ctx, childID, &file)
 		if file.Project == "" {
 			file.Project = parentProject

--- a/internal/sync/s3_source_test.go
+++ b/internal/sync/s3_source_test.go
@@ -69,6 +69,130 @@ func TestProcessFileS3UsesObjectMetadataToSkipBeforeFetch(t *testing.T) {
 	assert.False(t, fetched, "unchanged S3 object should not be fetched")
 }
 
+func TestProcessS3IcodemateReconcilesRemovedForkThenSkipsUnchanged(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	const uri = "s3://bucket/laptop/raw/icodemate/project/fork-session.jsonl"
+	mainLines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"root","message":{"content":"start"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"root","message":{"content":[{"type":"text","text":"main reply 1"}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":"main prompt 2"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"u3","parentUuid":"u2","message":{"content":"main prompt 3"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:04Z","uuid":"u4","parentUuid":"u3","message":{"content":"main prompt 4"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u5","parentUuid":"u4","message":{"content":"main prompt 5"}}`,
+	}
+	forkLine := `{"type":"assistant","timestamp":"2024-01-01T10:00:06Z","uuid":"fork","parentUuid":"root","message":{"content":[{"type":"text","text":"fork reply"}]}}`
+	content := strings.Join(append(mainLines, forkLine), "\n") + "\n"
+	mtime := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC).UnixNano()
+	fingerprint := "s3:fingerprint:icodemate-forked"
+
+	oldFetch := fetchS3Object
+	t.Cleanup(func() { fetchS3Object = oldFetch })
+	var fetches int
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, uri, got)
+		fetches++
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+
+	engine := NewEngine(database, EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+	file := parser.DiscoveredFile{
+		Agent:             parser.AgentIcodemate,
+		Path:              uri,
+		Project:           "project",
+		Machine:           "laptop",
+		SourceSize:        int64(len(content)),
+		SourceMtime:       mtime,
+		SourceFingerprint: fingerprint,
+	}
+	first := engine.processFile(t.Context(), file)
+	require.NoError(t, first.err)
+	require.Len(t, first.results, 2)
+	jobs := make(chan syncJob, 1)
+	jobs <- syncJob{
+		path: file.Path, agent: file.Agent, machine: file.Machine,
+		processResult: first,
+	}
+	close(jobs)
+	firstStats := engine.collectAndBatch(
+		t.Context(), jobs, 1, 1, nil, syncWriteDefault,
+	)
+	require.Zero(t, firstStats.Failed)
+	require.Equal(t, 2, firstStats.Synced)
+	require.Equal(t, 1, fetches)
+
+	content = mainLines[0] + "\n{"
+	mtime += int64(time.Second)
+	fingerprint = "s3:fingerprint:icodemate-truncated"
+	file.SourceSize = int64(len(content))
+	file.SourceMtime = mtime
+	file.SourceFingerprint = fingerprint
+	truncated := engine.processFile(t.Context(), file)
+	require.NoError(t, truncated.err)
+	jobs = make(chan syncJob, 1)
+	jobs <- syncJob{
+		path: file.Path, agent: file.Agent, machine: file.Machine,
+		processResult: truncated,
+	}
+	close(jobs)
+	truncatedStats := engine.collectAndBatch(
+		t.Context(), jobs, 1, 1, nil, syncWriteDefault,
+	)
+	require.Equal(t, 1, truncatedStats.Failed)
+	require.Zero(t, truncatedStats.Synced)
+	require.Zero(t, truncatedStats.Tombstoned)
+	require.Equal(t, 2, fetches)
+
+	const forkID = "laptop~icodemate:fork-session-fork"
+	fork, err := database.GetSession(t.Context(), forkID)
+	require.NoError(t, err)
+	require.NotNil(t, fork,
+		"an incomplete source must preserve its archived branches")
+
+	content = strings.Join(mainLines, "\n") + "\n"
+	mtime += int64(time.Second)
+	fingerprint = "s3:fingerprint:icodemate-main-only"
+	file.SourceSize = int64(len(content))
+	file.SourceMtime = mtime
+	file.SourceFingerprint = fingerprint
+	second := engine.processFile(t.Context(), file)
+	require.NoError(t, second.err)
+	require.Len(t, second.results, 1)
+	jobs = make(chan syncJob, 1)
+	jobs <- syncJob{
+		path: file.Path, agent: file.Agent, machine: file.Machine,
+		processResult: second,
+	}
+	close(jobs)
+	secondStats := engine.collectAndBatch(
+		t.Context(), jobs, 1, 1, nil, syncWriteDefault,
+	)
+	require.Zero(t, secondStats.Failed)
+	require.Equal(t, 1, secondStats.Synced)
+	require.Equal(t, 1, secondStats.Tombstoned)
+	require.Equal(t, 3, fetches)
+
+	fork, err = database.GetSession(t.Context(), forkID)
+	require.NoError(t, err)
+	assert.Nil(t, fork)
+	archivedFork, err := database.GetSessionFull(t.Context(), forkID)
+	require.NoError(t, err)
+	require.NotNil(t, archivedFork)
+	require.NotNil(t, archivedFork.DeletionCause)
+	assert.Equal(t, "source_missing", *archivedFork.DeletionCause)
+
+	engine.Close()
+	freshEngine := NewEngine(database, EngineConfig{Machine: "local"})
+	t.Cleanup(freshEngine.Close)
+	third := freshEngine.processFile(t.Context(), file)
+	require.NoError(t, third.err)
+	assert.True(t, third.skip)
+	assert.Equal(t, 3, fetches,
+		"a fresh engine must not fetch an unchanged complete source")
+}
+
 func TestProcessS3ClaudeForceParseBypassesPrimarylessFreshness(t *testing.T) {
 	database := openTestDB(t)
 	const uri = "s3://bucket/root/claude/project/force-replay.jsonl"
@@ -1525,21 +1649,75 @@ func TestSourceMtimeS3HostPrefixedClaudeUsesSidecarMetadata(t *testing.T) {
 	)
 }
 
+func TestSourceMtimeS3IcodemateUsesSidecarMetadata(t *testing.T) {
+	database := openTestDB(t)
+	path := "s3://bucket/laptop/raw/icodemate/test-proj/manual-id.jsonl"
+	transcriptMtime := time.Date(2026, 6, 24, 13, 5, 0, 0, time.UTC)
+	sidecarMtime := transcriptMtime.Add(time.Minute)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:        "laptop~icodemate:manual-id",
+		Project:   "test-proj",
+		Machine:   "laptop",
+		Agent:     "icodemate",
+		FilePath:  strPtr(path),
+		FileSize:  int64Ptr(128),
+		FileMtime: int64Ptr(transcriptMtime.UnixNano()),
+	}))
+
+	oldStat := statS3Object
+	oldStatClaude := statClaudeS3Session
+	t.Cleanup(func() {
+		statS3Object = oldStat
+		statClaudeS3Session = oldStatClaude
+	})
+	statS3Object = func(got string) (parser.S3Object, error) {
+		require.Equal(t, path, got)
+		return parser.S3Object{
+			URI:          path,
+			Size:         128,
+			LastModified: transcriptMtime,
+		}, nil
+	}
+	statClaudeS3Session = func(got string) (parser.S3Object, error) {
+		require.Equal(t, path, got)
+		return parser.S3Object{
+			URI:          path,
+			Size:         256,
+			LastModified: sidecarMtime,
+		}, nil
+	}
+
+	e := &Engine{
+		db:      database,
+		machine: "central",
+		agentDirs: map[parser.AgentType][]string{
+			parser.AgentIcodemate: {"s3://bucket/laptop/raw/icodemate"},
+		},
+	}
+
+	assert.Equal(t, sidecarMtime.UnixNano(),
+		e.SourceMtime("laptop~icodemate:manual-id"))
+}
+
 func TestPickPreferredClaudeDiscoveredFileUsesS3Metadata(t *testing.T) {
 	database := openTestDB(t)
 	oldFile := parser.DiscoveredFile{
-		Agent:       parser.AgentClaude,
-		Path:        "s3://bucket/a/test-proj/session.jsonl",
-		Project:     "test-proj",
-		SourceSize:  100,
-		SourceMtime: time.Date(2026, 6, 24, 13, 3, 0, 0, time.UTC).UnixNano(),
+		Agent:           parser.AgentClaude,
+		Path:            "s3://bucket/a/test-proj/session.jsonl",
+		Project:         "test-proj",
+		SourceSize:      1000,
+		SourceMtime:     time.Date(2026, 6, 24, 13, 5, 0, 0, time.UTC).UnixNano(),
+		TranscriptSize:  100,
+		TranscriptMtime: time.Date(2026, 6, 24, 13, 3, 0, 0, time.UTC).UnixNano(),
 	}
 	newFile := parser.DiscoveredFile{
-		Agent:       parser.AgentClaude,
-		Path:        "s3://bucket/z/test-proj/session.jsonl",
-		Project:     "test-proj",
-		SourceSize:  200,
-		SourceMtime: time.Date(2026, 6, 24, 13, 4, 0, 0, time.UTC).UnixNano(),
+		Agent:           parser.AgentClaude,
+		Path:            "s3://bucket/z/test-proj/session.jsonl",
+		Project:         "test-proj",
+		SourceSize:      200,
+		SourceMtime:     time.Date(2026, 6, 24, 13, 4, 0, 0, time.UTC).UnixNano(),
+		TranscriptSize:  200,
+		TranscriptMtime: time.Date(2026, 6, 24, 13, 4, 0, 0, time.UTC).UnixNano(),
 	}
 	e := &Engine{db: database, machine: "central"}
 

--- a/internal/sync/s3_test.go
+++ b/internal/sync/s3_test.go
@@ -799,8 +799,9 @@ func TestSyncClaudeS3SubagentTranscriptsContextPreservesStoredParentNamespace(
 		Machine:   "central",
 		Ephemeral: true,
 	})
-	require.NoError(t, engine.SyncClaudeS3SubagentTranscriptsContext(
-		context.Background(), "laptop~parent-uuid", []string{childPath}))
+	require.NoError(t, engine.SyncS3SubagentTranscriptsContext(
+		context.Background(), "laptop~parent-uuid", parser.AgentClaude,
+		[]string{childPath}))
 
 	child, err := database.GetSessionFull(
 		context.Background(), "laptop~agent-worker1")
@@ -817,6 +818,87 @@ func TestSyncClaudeS3SubagentTranscriptsContextPreservesStoredParentNamespace(
 		context.Background(), "agent-worker1")
 	require.NoError(t, err)
 	assert.Nil(t, rawChild, "the child must not collide with a local session")
+}
+
+func TestSyncArchivedS3IcodemateParentPreservesChildAgentAndIDNamespace(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	const root = "s3://bucket/laptop/raw/icodemate"
+	const parentPath = root + "/project/parent-uuid.jsonl"
+	const childPath = root +
+		"/project/parent-uuid/subagents/agent-worker1.jsonl"
+	const parentID = "laptop~icodemate:parent-uuid"
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithSessionID(
+			"2026-05-20T10:01:00Z", "do the subtask", "parent-uuid").
+		AddClaudeAssistant("2026-05-20T10:01:30Z", "subtask done").
+		String()
+
+	oldPaths := subagentTranscriptPaths
+	oldFetch := fetchS3Object
+	oldStat := statClaudeS3Session
+	t.Cleanup(func() {
+		subagentTranscriptPaths = oldPaths
+		fetchS3Object = oldFetch
+		statClaudeS3Session = oldStat
+	})
+	subagentTranscriptPaths = func(got string) []string {
+		require.Equal(t, parentPath, got)
+		return []string{childPath}
+	}
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		if got == parentPath {
+			return nil, missingS3ObjectError()
+		}
+		require.Equal(t, childPath, got)
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+	statClaudeS3Session = func(got string) (parser.S3Object, error) {
+		if got == parentPath {
+			return parser.S3Object{}, missingS3ObjectError()
+		}
+		require.Equal(t, childPath, got)
+		return parser.S3Object{
+			URI:          childPath,
+			Size:         int64(len(content)),
+			LastModified: time.Date(2026, 5, 20, 10, 2, 0, 0, time.UTC),
+			Fingerprint:  "s3-meta:icodemate-worker1",
+		}, nil
+	}
+
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:       parentID,
+		Project:  "project",
+		Machine:  "laptop",
+		Agent:    "icodemate",
+		FilePath: strPtr(parentPath),
+	}))
+	require.NoError(t, database.BaselineActiveSessionSourceOwnerships(
+		t.Context(), []db.SessionSourceOwnership{{
+			ID: parentID, Machine: "laptop", Agent: "icodemate", FilePath: parentPath,
+		}},
+	))
+	tombstoned, err := database.SoftDeleteSessionSourceOwnership(
+		t.Context(), "laptop", "icodemate", parentID, parentPath,
+	)
+	require.NoError(t, err)
+	require.True(t, tombstoned)
+	engine := NewEngine(database, EngineConfig{Machine: "central", Ephemeral: true})
+	t.Cleanup(engine.Close)
+	assert.Error(t, engine.SyncSessionWithSubagentsContext(t.Context(), parentID))
+
+	child, err := database.GetSessionFull(
+		t.Context(), "laptop~icodemate:agent-worker1")
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	assert.Equal(t, "icodemate", child.Agent)
+	require.NotNil(t, child.ParentSessionID)
+	assert.Equal(t, parentID, *child.ParentSessionID)
+	claudeChild, err := database.GetSessionFull(
+		t.Context(), "laptop~agent-worker1")
+	require.NoError(t, err)
+	assert.Nil(t, claudeChild)
 }
 
 func TestSyncClaudeS3SubagentTranscriptsEmitsSessionsForForkTombstone(
@@ -887,8 +969,8 @@ func TestSyncClaudeS3SubagentTranscriptsEmitsSessionsForForkTombstone(
 		Emitter: emitter,
 	})
 	t.Cleanup(engine.Close)
-	require.NoError(t, engine.SyncClaudeS3SubagentTranscriptsContext(
-		t.Context(), "laptop~parent-uuid", []string{childPath},
+	require.NoError(t, engine.SyncS3SubagentTranscriptsContext(
+		t.Context(), "laptop~parent-uuid", parser.AgentClaude, []string{childPath},
 	))
 
 	assert.Equal(t, []string{"messages", "sessions"}, emitter.got(),
@@ -953,8 +1035,9 @@ func TestSyncClaudeS3SubagentTranscriptsContextUsesPrefixedChildProject(
 		Ephemeral: true,
 	})
 
-	require.NoError(t, engine.SyncClaudeS3SubagentTranscriptsContext(
-		context.Background(), "laptop~parent-uuid", []string{childPath}))
+	require.NoError(t, engine.SyncS3SubagentTranscriptsContext(
+		context.Background(), "laptop~parent-uuid", parser.AgentClaude,
+		[]string{childPath}))
 
 	remoteChild, err := database.GetSessionFull(
 		context.Background(), "laptop~agent-worker1")

--- a/internal/sync/session_subagents.go
+++ b/internal/sync/session_subagents.go
@@ -8,6 +8,8 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 )
 
+var subagentTranscriptPaths = parser.ClaudeSubagentTranscriptPaths
+
 // SyncSessionWithSubagentsContext refreshes one session and the candidate
 // Claude subagent transcripts in its root tree. Child discovery still runs
 // when the requested-session refresh fails so callers can retain archived data
@@ -18,19 +20,26 @@ func (e *Engine) SyncSessionWithSubagentsContext(
 ) error {
 	parentErr := e.SyncSingleSessionContext(ctx, sessionID)
 
+	// The archive session ID carries its agent prefix (host prefixes are
+	// stripped first), so the parent agent resolves without a row lookup and
+	// stays correct even when the parent is soft-deleted.
+	parentAgent := parser.AgentClaude
+	if def, ok := parser.AgentByPrefix(sessionID); ok {
+		parentAgent = def.Type
+	}
 	sourcePath := e.db.GetSessionFilePath(sessionID)
 	if sourcePath == "" {
 		sourcePath = e.FindSourceFile(sessionID)
 	}
-	paths := parser.ClaudeSubagentTranscriptPaths(sourcePath)
+	paths := subagentTranscriptPaths(sourcePath)
 	if len(paths) == 0 {
 		return parentErr
 	}
 
 	var subagentErr error
 	if strings.HasPrefix(sourcePath, "s3://") {
-		subagentErr = e.SyncClaudeS3SubagentTranscriptsContext(
-			ctx, sessionID, paths)
+		subagentErr = e.SyncS3SubagentTranscriptsContext(
+			ctx, sessionID, parentAgent, paths)
 	} else {
 		subagentErr = e.SyncPathsContext(ctx, paths)
 	}


### PR DESCRIPTION
Icodemate stores sessions in two families under one agent, matched by on-disk layout: the VS Code extension's OpenCode-compatible storage and the terminal CLI's Claude Code-format projects store. Only the first was collected, so terminal CLI sessions never reached the archive.

This change adds the terminal CLI projects layout to the icodemate default directories. CLI-owned roots reuse the shared Claude source set through a small layout spec (`claudeLayoutSpec`): discovery, watch, changed-path, find, and fingerprint plumbing are the Claude implementation, with the icodemate agent label, sidecar-composite freshness, and an icodemate-owned `Parse` that relabels sessions onto the `icodemate:` id prefix. The combined provider splits configured roots by on-disk layout so each family keeps its own watch, find, fingerprint, and reconciliation semantics; both families surface as a single icodemate agent in the UI.

In the sync engine, Claude-format handling dispatches through one documented predicate family (`isClaudeFormatAgent`, `isClaudeFormatTranscript`, `claudeFormatArchiveSessionID`, `usesCompositeSidecarFreshness`), following the existing `isCodexFormatAgent` pattern, instead of per-site agent pairs and prefix literals. The same-session duplicate policy is documented on `claudeFormatTranscriptPreference` and pinned by table-driven tests: Claude ranks append progress first because its transcripts are append-only; ICodeMate ranks recency first because its transcripts are rewritten in place, and the committed copy is displaced only by strict transcript growth. Claude keeps plain-file fingerprints; composite hashes would invalidate every archived Claude fingerprint.

The session-format source inventory now records the CLI family. Reviewers: the new surfaces are `internal/parser/icodemate_cli.go` (spec, parse relabeling, sidecar-composite helpers), the spec plumbing in `internal/parser/claude_provider.go`, and the predicate family in `internal/sync/engine.go`; Claude and other-agent behavior is unchanged, and existing suites pass unmodified.
