### PR TITLE
test(sync): use public macOS paths for Cursor fixtures

### DIFF
--- a/internal/sync/cursor_cwd_lifecycle_integration_test.go
+++ b/internal/sync/cursor_cwd_lifecycle_integration_test.go
@@ -177,7 +177,7 @@ func TestSyncEngineCursorUnavailableChangedTranscriptPreservesCwd(t *testing.T) 
 
 func TestResyncCursorUnavailablePreservesArchiveCwd(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeCursorProjectDir(workspace)
 	sessionID := "12121212-3434-4567-8899-aaaaaaaaaaaa"
@@ -216,7 +216,7 @@ func TestResyncCursorUnavailablePreservesArchiveCwd(t *testing.T) {
 
 func TestResyncCursorFilteredCwdSurvivesOrphanCopy(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	oldWorkspace := filepath.Join(workspaceRoot, "Code", "old")
 	newWorkspace := filepath.Join(workspaceRoot, "Code", "new")
 	projectDir := encodeCursorProjectDir(oldWorkspace)
@@ -263,7 +263,7 @@ func TestResyncCursorFilteredCwdSurvivesOrphanCopy(t *testing.T) {
 
 func TestParseDiffCursorCwdDoesNotWriteOnParseError(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeCursorProjectDir(workspace)
 	sessionID := "56565656-7878-4901-8222-bbbbbbbbbbbb"
@@ -321,7 +321,7 @@ func TestParseDiffCursorCwdDoesNotWriteOnParseError(t *testing.T) {
 
 func TestSyncEngineCursorResolvedFilteredCwdIsReconciled(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	oldWorkspace := filepath.Join(workspaceRoot, "Code", "old")
 	workspace := filepath.Join(workspaceRoot, "Code", "new")
 	projectDir := encodeCursorProjectDir(workspace)
@@ -365,7 +365,7 @@ func TestSyncEngineCursorResolvedFilteredCwdIsReconciled(t *testing.T) {
 
 func TestSyncEngineCursorOversizedTranscriptReconcilesWorkspace(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeCursorProjectDir(workspace)
 	sessionID := "eeeeeeee-ffff-4000-8111-222222222222"
@@ -417,7 +417,7 @@ func TestSyncEngineCursorOversizedTranscriptReconcilesWorkspace(t *testing.T) {
 
 func TestSyncEngineCursorNoneSingleSessionClearsFilteredCwd(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeCursorProjectDir(workspace)
 	sessionID := "ffffffff-0000-4111-8222-333333333333"
@@ -461,7 +461,7 @@ func TestSyncEngineCursorNoneSingleSessionClearsFilteredCwd(t *testing.T) {
 
 func TestSyncEngineCursorRemoteClearsStoredCwd(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeCursorProjectDir(workspace)
 	sessionID := "11111111-2222-4333-8444-555555555555"
@@ -505,7 +505,7 @@ func TestSyncEngineCursorRemoteClearsStoredCwd(t *testing.T) {
 
 func TestSyncEngineCursorSourceMissingRevivalPreservesCwd(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeCursorProjectDir(workspace)
 	sessionID := "22222222-3333-4444-8555-666666666666"
@@ -554,7 +554,7 @@ func TestSyncEngineCursorSourceMissingRevivalPreservesCwd(t *testing.T) {
 
 func TestSyncEngineCursorUnchangedTranscriptFollowsWorkspaceLifecycle(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeCursorProjectDir(workspace)
 	sessionID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
@@ -614,7 +614,7 @@ func TestSyncEngineCursorUnchangedTranscriptFollowsWorkspaceLifecycle(t *testing
 
 func TestSyncEngineCursorCompleteNoneAndAmbiguousClearStoredCwd(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeCursorProjectDir(workspace)
 	sessionID := "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff"

--- a/internal/sync/cwd_filter_integration_test.go
+++ b/internal/sync/cwd_filter_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +40,25 @@ func encodeCursorProjectDir(path string) string {
 		})...)
 	}
 	return strings.Join(parts, "-")
+}
+
+// cursorWorkspaceTempDir returns the public spelling of a macOS temporary
+// directory. Cursor workspace resolution normalizes /private/var to /var, so
+// fixtures must use that same user-facing path for filters and assertions.
+func cursorWorkspaceTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if runtime.GOOS != "darwin" || !strings.HasPrefix(dir, "/private/") {
+		return dir
+	}
+	publicDir := strings.TrimPrefix(dir, "/private")
+	privateInfo, err := os.Stat(dir)
+	require.NoError(t, err)
+	publicInfo, err := os.Stat(publicDir)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(privateInfo, publicInfo),
+		"macOS temporary path spellings must identify the same directory")
+	return publicDir
 }
 
 func setupClaudeEnvWithCwdPrefixes(
@@ -106,10 +126,10 @@ func TestSyncEngineCursorCwdPrefixFilterAndProjectIdentity(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	matchingWorkspace := filepath.Join(workspaceRoot, "app")
 	boundaryWorkspace := filepath.Join(workspaceRoot, "app2")
-	outsideWorkspace := filepath.Join(t.TempDir(), "other")
+	outsideWorkspace := filepath.Join(cursorWorkspaceTempDir(t), "other")
 	for _, workspace := range []string{matchingWorkspace, boundaryWorkspace, outsideWorkspace} {
 		require.NoError(t, os.MkdirAll(workspace, 0o755))
 	}
@@ -158,7 +178,7 @@ func TestSyncEngineCursorIssue1418ShapeRetainsMatchingSession(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	root := t.TempDir()
-	workspace := filepath.Join(t.TempDir(), "work-area")
+	workspace := filepath.Join(cursorWorkspaceTempDir(t), "work-area")
 	require.NoError(t, os.MkdirAll(workspace, 0o755))
 	projectDir := encodeCursorProjectDir(workspace)
 	prefix := filepath.Dir(workspace)
@@ -291,7 +311,7 @@ func TestSyncEngineCursorCwdConsumerPaths(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	cwd := filepath.Join(t.TempDir(), "cursorworkspace")
+	cwd := filepath.Join(cursorWorkspaceTempDir(t), "cursorworkspace")
 	require.NoError(t, os.MkdirAll(cwd, 0o755))
 	projectDir := encodeCursorProjectDir(cwd)
 
@@ -391,7 +411,7 @@ func TestSyncEngineCursorCwdDataVersionRefresh(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	root := t.TempDir()
-	workspace := filepath.Join(t.TempDir(), "refresh")
+	workspace := filepath.Join(cursorWorkspaceTempDir(t), "refresh")
 	require.NoError(t, os.MkdirAll(workspace, 0o755))
 	projectDir := encodeCursorProjectDir(workspace)
 	prefix := workspace
@@ -1292,7 +1312,7 @@ func TestSyncEngineCursorCwdFilterRelaxationRefreshesStaleRows(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "relaxed")
 	require.NoError(t, os.MkdirAll(workspace, 0o755))
 	otherRoot := t.TempDir()

--- a/internal/sync/issue1418_repro_test.go
+++ b/internal/sync/issue1418_repro_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestIssue1418WorkspaceAppearsWithoutTranscriptChange(t *testing.T) {
 	root := t.TempDir()
-	workspaceRoot := t.TempDir()
+	workspaceRoot := cursorWorkspaceTempDir(t)
 	workspace := filepath.Join(workspaceRoot, "Code", "app")
 	projectDir := encodeIssue1418ProjectDir(workspace)
 	sessionID := "dddddddd-eeee-4fff-8000-111111111111"


### PR DESCRIPTION
Cursor workspace integration fixtures now derive encoded paths, filters, and
expected values from macOS's public `/var/...` spelling. The resolver already
normalizes the runner's `/private/var/...` temporary paths to that spelling;
aligning the fixtures removes the macOS-only failures without changing
production path handling.
