### PR TITLE
fix(quality): show refresh progress for filter changes

### DIFF
--- a/frontend/src/lib/components/quality/QualityPage.svelte
+++ b/frontend/src/lib/components/quality/QualityPage.svelte
@@ -613,7 +613,7 @@
     </div>
 
     <RefreshControl
-      lastUpdatedAt={analytics.lastUpdatedAt}
+      lastUpdatedAt={analytics.qualityLastUpdatedAt}
       busy={querying}
       onRefresh={handleRefresh}
       label={m.quality_page_refresh()}

--- a/frontend/src/lib/components/quality/QualityPage.svelte
+++ b/frontend/src/lib/components/quality/QualityPage.svelte
@@ -27,9 +27,10 @@
     SignalCalibration,
     SignalSessionExample,
   } from "../../api/types.js";
-  import { Card, IconButton, Typeahead } from "@kenn-io/kit-ui";
+  import { Card, Typeahead } from "@kenn-io/kit-ui";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
   import RangePicker from "../shared/RangePicker.svelte";
+  import RefreshControl from "../shared/RefreshControl.svelte";
   import {
     resolveRange,
     selectionFromWindow,
@@ -43,7 +44,6 @@
     type QualityPatternView,
   } from "./qualityPatterns.js";
 
-  const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
   const QUALITY_WINDOW_PARAM = "window_days";
   const QUALITY_DATE_PARAM_KEYS = [
     QUALITY_WINDOW_PARAM,
@@ -54,7 +54,6 @@
     typeof AnalyticsService.getApiV1AnalyticsSignals
   >[0];
 
-  let refreshTimer: ReturnType<typeof setInterval> | undefined;
   let unsubEvents: (() => void) | undefined;
   let selectedSignalId: string | null = $state(null);
   let signalExamples: SignalSessionExample[] = $state([]);
@@ -74,6 +73,7 @@
     buildRuleBasedRecommendations(patterns),
   );
   const loading = $derived(analytics.loading.signals);
+  const querying = $derived(analytics.querying.signals);
   const error = $derived(analytics.errors.signals);
   const earliestSession = $derived(sync.stats?.earliest_session ?? null);
   const rangeSelection = $derived(
@@ -493,10 +493,6 @@
     sessions.loadProjects();
     sessions.loadAgents();
     fetchQualitySignals();
-    refreshTimer = setInterval(
-      () => fetchQualitySignals(),
-      REFRESH_INTERVAL_MS,
-    );
     unsubEvents = events.subscribeDebounced(() => {
       fetchQualitySignals();
     });
@@ -560,7 +556,6 @@
         qualityDateIntentEstablished,
       );
     }
-    if (refreshTimer !== undefined) clearInterval(refreshTimer);
     unsubEvents?.();
   });
 
@@ -581,7 +576,7 @@
   <header class="toolbar">
     <RangePicker
       selection={rangeSelection}
-      busy={loading}
+      busy={querying}
       {earliestSession}
       onSelect={applyRange}
     />
@@ -617,19 +612,20 @@
       </label>
     </div>
 
-    <IconButton
-      class="toolbar-refresh"
-      onclick={handleRefresh}
+    <RefreshControl
+      lastUpdatedAt={analytics.lastUpdatedAt}
+      busy={querying}
+      onRefresh={handleRefresh}
+      label={m.quality_page_refresh()}
       title={m.quality_page_refresh()}
-      ariaLabel={m.quality_page_refresh()}
-    >
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-        <path d="M8 3a5 5 0 00-4.546 2.914.5.5 0 01-.908-.418A6 6 0 0114 8a.5.5 0 01-1 0 5 5 0 00-5-5zm4.546 7.086a.5.5 0 01.908.418A6 6 0 012 8a.5.5 0 011 0 5 5 0 005 5 5 5 0 004.546-2.914z"/>
-      </svg>
-    </IconButton>
+    />
   </header>
 
-  <main class="content">
+  <main class="content" class:querying aria-busy={querying}>
+    {#if querying}
+      <div class="query-progress" aria-hidden="true"></div>
+    {/if}
+
     <section class="section-block" aria-labelledby="actions-title">
       <div class="section-heading compact">
         <div>
@@ -1003,10 +999,6 @@
     width: 128px;
   }
 
-  :global(.toolbar-refresh.kit-icon-button) {
-    margin-left: auto;
-  }
-
   .content {
     flex: 1;
     min-height: 0;
@@ -1015,6 +1007,41 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-6);
+    position: relative;
+    transition: opacity 0.12s;
+  }
+
+  .content.querying {
+    opacity: 0.88;
+  }
+
+  .query-progress {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 4;
+    height: 2px;
+    overflow: hidden;
+    background: color-mix(
+      in srgb,
+      var(--accent-blue) 16%,
+      transparent
+    );
+  }
+
+  .query-progress::before {
+    content: "";
+    display: block;
+    width: 38%;
+    height: 100%;
+    background: var(--accent-blue);
+    border-radius: 999px;
+    animation: query-progress 1s ease-in-out infinite;
+  }
+
+  .toolbar :global(.kit-refresh-control) {
+    margin-left: auto;
   }
 
   .section-block {
@@ -1657,6 +1684,15 @@
     }
   }
 
+  @keyframes query-progress {
+    0% {
+      transform: translateX(-105%);
+    }
+    100% {
+      transform: translateX(265%);
+    }
+  }
+
   @media (max-width: 900px) {
     .toolbar,
     .section-heading {
@@ -1664,7 +1700,7 @@
       flex-direction: column;
     }
 
-    :global(.toolbar-refresh.kit-icon-button) {
+    .toolbar :global(.kit-refresh-control) {
       margin-left: 0;
     }
 

--- a/frontend/src/lib/components/quality/QualityPage.test.ts
+++ b/frontend/src/lib/components/quality/QualityPage.test.ts
@@ -54,4 +54,17 @@ describe("QualityPage", () => {
     expect(content?.querySelector(".query-progress")).not.toBeNull();
     expect(refreshButton?.disabled).toBe(true);
   });
+
+  it("shows Quality freshness instead of dashboard freshness", async () => {
+    const now = new Date("2026-06-15T15:00:00Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    analytics.lastUpdatedAt = now - 3 * 60_000;
+    analytics.qualityLastUpdatedAt = now - 7 * 60_000;
+
+    component = mount(QualityPage, { target: document.body });
+    await tick();
+
+    expect(document.body.textContent).toContain("Updated 7m ago");
+    expect(document.body.textContent).not.toContain("Updated 3m ago");
+  });
 });

--- a/frontend/src/lib/components/quality/QualityPage.test.ts
+++ b/frontend/src/lib/components/quality/QualityPage.test.ts
@@ -37,4 +37,21 @@ describe("QualityPage", () => {
     expect(document.body.textContent).toContain("Quality Patterns");
     expect(insights.load).not.toHaveBeenCalled();
   });
+
+  it("shows refresh activity while a filtered quality query is running", async () => {
+    component = mount(QualityPage, { target: document.body });
+    await tick();
+
+    analytics.querying.signals = true;
+    await tick();
+
+    const content = document.querySelector(".content");
+    const refreshButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Refresh quality"]',
+    );
+
+    expect(content?.getAttribute("aria-busy")).toBe("true");
+    expect(content?.querySelector(".query-progress")).not.toBeNull();
+    expect(refreshButton?.disabled).toBe(true);
+  });
 });

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -90,6 +90,7 @@ class AnalyticsStore {
   signals = $state<SignalsAnalyticsResponse | null>(null);
   topMetric: TopSessionsMetric = $state("messages");
   lastUpdatedAt: number | null = $state(null);
+  qualityLastUpdatedAt: number | null = $state(null);
   hasNewData: boolean = $state(false);
 
   loading = $state({
@@ -794,7 +795,7 @@ class AnalyticsStore {
     // silently narrow the Quality signal facts.
     const result = await this.fetchSignals({ includeModel: false });
     if (result === "ok") {
-      this.markRefreshComplete();
+      this.qualityLastUpdatedAt = Date.now();
     }
   }
 

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -792,7 +792,10 @@ class AnalyticsStore {
     // The Quality page has no model control and the model filter is an
     // Analytics-only scope; omit it so a model selected on Analytics does not
     // silently narrow the Quality signal facts.
-    await this.fetchSignals({ includeModel: false });
+    const result = await this.fetchSignals({ includeModel: false });
+    if (result === "ok") {
+      this.markRefreshComplete();
+    }
   }
 
   setTopMetric(m: TopSessionsMetric) {

--- a/frontend/src/lib/stores/analytics.test.ts
+++ b/frontend/src/lib/stores/analytics.test.ts
@@ -437,6 +437,21 @@ describe("AnalyticsStore.setSkillsGranularity", () => {
 });
 
 describe("AnalyticsStore freshness state", () => {
+  it("records a successful Quality refresh time", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date("2026-06-15T15:00:00Z"));
+
+      await analytics.fetchSignalsForQuality();
+
+      expect(analytics.lastUpdatedAt).toBe(
+        new Date("2026-06-15T15:00:00Z").getTime(),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("records full refresh time and clears new-data hints", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     try {

--- a/frontend/src/lib/stores/analytics.test.ts
+++ b/frontend/src/lib/stores/analytics.test.ts
@@ -275,6 +275,7 @@ function resetStore() {
   analytics.topSessions = null;
   analytics.signals = null;
   analytics.lastUpdatedAt = null;
+  analytics.qualityLastUpdatedAt = null;
   analytics.hasNewData = false;
   analytics.querying = {
     summary: false,
@@ -437,16 +438,24 @@ describe("AnalyticsStore.setSkillsGranularity", () => {
 });
 
 describe("AnalyticsStore freshness state", () => {
-  it("records a successful Quality refresh time", async () => {
+  it("records Quality freshness without changing dashboard freshness", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     try {
+      analytics.lastUpdatedAt = new Date(
+        "2026-06-15T14:55:00Z",
+      ).getTime();
+      analytics.hasNewData = true;
       vi.setSystemTime(new Date("2026-06-15T15:00:00Z"));
 
       await analytics.fetchSignalsForQuality();
 
-      expect(analytics.lastUpdatedAt).toBe(
+      expect(analytics.qualityLastUpdatedAt).toBe(
         new Date("2026-06-15T15:00:00Z").getTime(),
       );
+      expect(analytics.lastUpdatedAt).toBe(
+        new Date("2026-06-15T14:55:00Z").getTime(),
+      );
+      expect(analytics.hasNewData).toBe(true);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
Quality now shows the same refresh feedback as the other analytics pages when filters trigger a background query. The page keeps existing results visible while the shared refresh control spins and an animated progress bar marks the content busy.

Successful Quality reads also update the refresh timestamp. The main review area is `QualityPage.svelte`, where the page now follows the shared refresh scheduler and query-state pattern.
