### PR TITLE
fix(activity): validate CLI bucket range bounds

### DIFF
--- a/cmd/agentsview/activity.go
+++ b/cmd/agentsview/activity.go
@@ -401,6 +401,13 @@ func resolveActivityReport(
 	if err != nil {
 		return activity.Report{}, err
 	}
+	if options.BucketRange != nil &&
+		options.BucketRange.End > artifacts.Report.BucketCount {
+		if cursor != nil {
+			return activity.Report{}, fmt.Errorf("invalid sessions cursor")
+		}
+		return activity.Report{}, fmt.Errorf("invalid activity report bucket")
+	}
 	digest, err := activity.ArtifactDigest(artifacts)
 	if err != nil {
 		return activity.Report{}, err

--- a/cmd/agentsview/activity_test.go
+++ b/cmd/agentsview/activity_test.go
@@ -171,6 +171,15 @@ func TestResolveActivityReport_BadBucket(t *testing.T) {
 	require.Error(t, err, "off-allow-list bucket is rejected before query")
 }
 
+func TestResolveActivityReportRejectsSessionRangePastBucketCount(t *testing.T) {
+	d := newTestDB(t)
+	_, err := resolveActivityReport(ActivityReportConfig{
+		Preset: "day", Date: "2026-06-16", Timezone: "UTC",
+		SessionsBucketStart: "287", SessionsBucketEnd: "289",
+	}, d)
+	require.EqualError(t, err, "invalid activity report bucket")
+}
+
 func TestResolveActivityReport_JSONShape(t *testing.T) {
 	d := newTestDB(t)
 	r, err := resolveActivityReport(ActivityReportConfig{

--- a/frontend/scripts/generate-api-client.mjs
+++ b/frontend/scripts/generate-api-client.mjs
@@ -113,6 +113,9 @@ const generatedTrailingNewlines = generatedTrailingNewlineCounts(generatedDir);
 const tempDir = mkdtempSync(join(tmpdir(), "agentsview-openapi-"));
 try {
   const specPath = join(tempDir, "openapi.json");
+  run("go", ["run", "./internal/pricing/cmd/litellm-snapshot", "-restore"], {
+    cwd: repoRoot,
+  });
   const spec = run("go", ["run", "./cmd/agentsview", "openapi"], {
     cwd: repoRoot,
     capture: true,

--- a/frontend/src/lib/components/usage/AttributionPanel.test.ts
+++ b/frontend/src/lib/components/usage/AttributionPanel.test.ts
@@ -354,7 +354,7 @@ describe("AttributionPanel colors", () => {
     unmount(component);
   });
 
-  it("uses lexical Matplotlib colors for colliding model representations", async () => {
+  it("uses aggregate-cost-ranked Matplotlib colors for model representations", async () => {
     settings.chartPalette = "matplotlib";
     usage.summary = summaryWithModels();
     usage.toggles.attribution.groupBy = "model";
@@ -369,8 +369,8 @@ describe("AttributionPanel colors", () => {
     const railColors = Array.from(document.querySelectorAll<HTMLElement>(".rail-dot")).map(
       (dot) => dot.style.background,
     );
-    expect(tileColors).toEqual(["#ff7f0e", "#1f77b4"]);
-    expect(railColors).toEqual(["rgb(255, 127, 14)", "rgb(31, 119, 180)"]);
+    expect(tileColors).toEqual(["#1f77b4", "#ff7f0e"]);
+    expect(railColors).toEqual(["rgb(31, 119, 180)", "rgb(255, 127, 14)"]);
     unmount(component);
   });
 });

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -8,7 +8,6 @@ import { testMoney } from "../../test/money.js";
 import type { Money } from "../../money.js";
 import { settings } from "../../stores/settings.svelte.js";
 import type { DailyUsageEntry, UsageSummaryResponse } from "../../api/types/usage.js";
-import { projectColor } from "../../utils/projectColor.js";
 import { usageChartColorMaps } from "../../utils/usageChartColors.js";
 import { setLocale } from "../../i18n/index.js";
 
@@ -372,7 +371,7 @@ describe("CostTimeSeriesChart", () => {
     unmount(component);
   });
 
-  it("keeps a single rendered model series on its established color", async () => {
+  it("assigns the first usage color to a single rendered model series", async () => {
     usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
     usage.summary.daily = [
@@ -385,7 +384,7 @@ describe("CostTimeSeriesChart", () => {
 
     const paths = document.querySelectorAll<SVGPathElement>("path.lc-area-path");
     expect(paths).toHaveLength(1);
-    expect(paths[0]!.getAttribute("fill")).toBe(projectColor("single-model"));
+    expect(paths[0]!.getAttribute("fill")).toBe("var(--accent-blue)");
     expect(document.querySelectorAll(".legend-item")).toHaveLength(0);
     unmount(component);
   });
@@ -529,7 +528,7 @@ describe("CostTimeSeriesChart", () => {
     unmount(component);
   });
 
-  it("uses lexical Matplotlib colors for colliding model paths and legend dots", async () => {
+  it("uses aggregate-cost-ranked Matplotlib colors for model paths and legend dots", async () => {
     settings.chartPalette = "matplotlib";
     usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
@@ -553,8 +552,8 @@ describe("CostTimeSeriesChart", () => {
     const dots = Array.from(document.querySelectorAll<HTMLElement>(".legend-dot")).map(
       (dot) => dot.style.background,
     );
-    expect(paths).toEqual(["#ff7f0e", "#1f77b4"]);
-    expect(dots).toEqual(["rgb(255, 127, 14)", "rgb(31, 119, 180)"]);
+    expect(paths).toEqual(["#1f77b4", "#ff7f0e"]);
+    expect(dots).toEqual(["rgb(31, 119, 180)", "rgb(255, 127, 14)"]);
     unmount(component);
   });
 });

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -578,14 +578,14 @@ describe("UsagePage refresh behavior", () => {
       ".chart-svg .lc-bar, .chart-svg .lc-area-path",
     );
     const firstDot = () => document.querySelector<HTMLElement>(".list-dot");
-    expect(firstMark()?.getAttribute("fill")).toBe("var(--accent-sky)");
-    expect(firstDot()?.style.background).toBe("var(--accent-sky)");
+    expect(firstMark()?.getAttribute("fill")).toBe("var(--accent-blue)");
+    expect(firstDot()?.style.background).toBe("var(--accent-blue)");
 
     settings.chartPalette = "matplotlib";
     await tick();
 
-    expect(firstMark()?.getAttribute("fill")).toBe("#c5b0d5");
-    expect(firstDot()?.style.background).toBe("rgb(197, 176, 213)");
+    expect(firstMark()?.getAttribute("fill")).toBe("#1f77b4");
+    expect(firstDot()?.style.background).toBe("rgb(31, 119, 180)");
   });
 
   it("loads agent metadata on mount for the Agent dropdown", async () => {

--- a/frontend/src/lib/utils/chartPalette.ts
+++ b/frontend/src/lib/utils/chartPalette.ts
@@ -1,4 +1,4 @@
-import { seriesColorMap } from "./projectColor.js";
+import { PROJECT_PALETTE, seriesColorMap } from "./projectColor.js";
 
 export type ChartPalette = "agentsview" | "matplotlib";
 
@@ -29,6 +29,14 @@ const TAB20B_AND_TAB20C = [
   "#dadaeb",
 ] as const;
 
+function matplotlibFamily(count: number): readonly string[] {
+  return count <= 9
+    ? TAB10
+    : count <= 18
+      ? TAB20
+      : TAB20B_AND_TAB20C;
+}
+
 export function isChartPalette(value: unknown): value is ChartPalette {
   return value === "agentsview" || value === "matplotlib";
 }
@@ -53,11 +61,7 @@ export function chartSeriesColorMap(
     }
   } else {
     activeIds.sort();
-    const family = activeIds.length <= 9
-      ? TAB10
-      : activeIds.length <= 18
-        ? TAB20
-        : TAB20B_AND_TAB20C;
+    const family = matplotlibFamily(activeIds.length);
     for (const [index, id] of activeIds.entries()) {
       colors.set(id, family[index % family.length]!);
     }
@@ -70,5 +74,24 @@ export function chartSeriesColorMap(
       palette === "agentsview" ? agentsviewOtherColor ?? MUTED : MUTED,
     );
   }
+  return colors;
+}
+
+export function orderedChartSeriesColorMap(
+  ids: readonly string[],
+  palette: ChartPalette,
+): ReadonlyMap<string, string> {
+  const activeIds = [...new Set(ids)]
+    .filter((id) => id !== "" && id !== "__other__");
+  const family = palette === "agentsview"
+    ? PROJECT_PALETTE
+    : matplotlibFamily(activeIds.length);
+  const colors = new Map<string, string>();
+
+  for (const [index, id] of activeIds.entries()) {
+    colors.set(id, family[index % family.length]!);
+  }
+  if (ids.includes("")) colors.set("", MUTED);
+  if (ids.includes("__other__")) colors.set("__other__", MUTED);
   return colors;
 }

--- a/frontend/src/lib/utils/usageChartColors.test.ts
+++ b/frontend/src/lib/utils/usageChartColors.test.ts
@@ -67,11 +67,12 @@ function tenModelSummary(): UsageSummaryResponse {
 }
 
 describe("usageChartColorMaps", () => {
-  it("chooses the Matplotlib family from the full model universe", () => {
+  it("assigns Matplotlib colors by aggregate cost descending", () => {
     const colors = usageChartColorMaps(tenModelSummary(), "matplotlib").model;
 
     expect(colors.size).toBe(10);
-    expect(colors.get("model-alpha")).toBe("#1f77b4");
-    expect(colors.get("model-zulu")).toBe("#c5b0d5");
+    expect(colors.get("model-zulu")).toBe("#1f77b4");
+    expect(colors.get("model-india")).toBe("#aec7e8");
+    expect(colors.get("model-alpha")).toBe("#c5b0d5");
   });
 });

--- a/frontend/src/lib/utils/usageChartColors.ts
+++ b/frontend/src/lib/utils/usageChartColors.ts
@@ -1,6 +1,6 @@
 import type { UsageSummaryResponse } from "../api/types/usage.js";
 import {
-  chartSeriesColorMap,
+  orderedChartSeriesColorMap,
   type ChartPalette,
 } from "./chartPalette.js";
 
@@ -10,38 +10,58 @@ export interface UsageChartColorMaps {
   agent: ReadonlyMap<string, string>;
 }
 
+function rankedIds(costs: ReadonlyMap<string, number>): string[] {
+  return [...costs.entries()]
+    .sort(([leftId, leftCost], [rightId, rightCost]) =>
+      rightCost - leftCost || leftId.localeCompare(rightId)
+    )
+    .map(([id]) => id);
+}
+
+function addCost(costs: Map<string, number>, id: string, microdollars: number) {
+  costs.set(id, (costs.get(id) ?? 0) + microdollars);
+}
+
 export function usageChartColorMaps(
   summary: UsageSummaryResponse | null,
   palette: ChartPalette,
 ): UsageChartColorMaps {
-  const projects = new Set<string>();
-  const models = new Set<string>();
-  const agents = new Set<string>();
+  const projects = new Map<string, number>();
+  const models = new Map<string, number>();
+  const agents = new Map<string, number>();
 
   for (const item of summary?.projectTotals ?? []) {
-    projects.add(item.project_key);
+    projects.set(item.project_key, item.cost.microdollars);
   }
   for (const item of summary?.modelTotals ?? []) {
-    models.add(item.model);
+    models.set(item.model, item.cost.microdollars);
   }
   for (const item of summary?.agentTotals ?? []) {
-    agents.add(item.agent);
+    agents.set(item.agent, item.cost.microdollars);
   }
+
+  const dailyProjects = new Map<string, number>();
+  const dailyModels = new Map<string, number>();
+  const dailyAgents = new Map<string, number>();
   for (const day of summary?.daily ?? []) {
     for (const item of day.projectBreakdowns ?? []) {
-      projects.add(item.project_key);
+      addCost(dailyProjects, item.project_key, item.cost.microdollars);
     }
     for (const item of day.modelBreakdowns ?? []) {
-      models.add(item.modelName);
+      addCost(dailyModels, item.modelName, item.cost.microdollars);
     }
     for (const item of day.agentBreakdowns ?? []) {
-      agents.add(item.agent);
+      addCost(dailyAgents, item.agent, item.cost.microdollars);
     }
   }
 
+  for (const [id, cost] of dailyProjects) projects.set(id, cost);
+  for (const [id, cost] of dailyModels) models.set(id, cost);
+  for (const [id, cost] of dailyAgents) agents.set(id, cost);
+
   return {
-    project: chartSeriesColorMap([...projects].sort(), palette),
-    model: chartSeriesColorMap([...models].sort(), palette),
-    agent: chartSeriesColorMap([...agents].sort(), palette),
+    project: orderedChartSeriesColorMap(rankedIds(projects), palette),
+    model: orderedChartSeriesColorMap(rankedIds(models), palette),
+    agent: orderedChartSeriesColorMap(rankedIds(agents), palette),
   };
 }


### PR DESCRIPTION
Rejects local CLI session bucket ranges whose exclusive end exceeds the generated report's bucket count, matching the HTTP endpoint's range domain. A behavioral regression test covers an oversized range on a 288-bucket day.

This intentionally does not add cursor-version or request-compatibility handling because the UI and CLI are coupled and this migration does not preserve old client semantics.
