### PR TITLE
fix(sync): skip offline configured HTTP hosts

### DIFF
--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -299,7 +299,8 @@ func (p *remoteProgressPrinter) Print(progress sync.Progress) {
 	if label == "" {
 		return
 	}
-	if strings.HasPrefix(label, "Synced ") {
+	if strings.HasPrefix(label, "Synced ") ||
+		strings.HasPrefix(label, "Skipped ") {
 		p.finishCurrent()
 		fmt.Fprintf(p.w, "  %s\n", label)
 		return
@@ -378,7 +379,7 @@ func syncLocalAndRemotes(
 ) ([]remoteHostFailure, error) {
 	didResync := localSync()
 	full := cfgFull || didResync
-	return runRemoteHosts(hosts, full, remoteSync)
+	return runRemoteHosts(hosts, full, nil, remoteSync)
 }
 
 func runRemoteSync(
@@ -459,14 +460,14 @@ var httpRemoteCleanupRegistry = new(remotesync.CleanupRegistry)
 var errUnifiedRebuildAborted = sync.ErrUnifiedRebuildAborted
 
 type preparedHTTPRebuildCLI interface {
-	BorrowRebuildContributors() ([]sync.RebuildContributor, func(), error)
+	BorrowRebuildOptions() (sync.RebuildOptions, func(), error)
 	Close() error
 }
 
 var prepareHTTPRebuildCLI = func(
 	ctx context.Context, syncs []remotesync.HTTPSync,
 ) (preparedHTTPRebuildCLI, error) {
-	return remotesync.PrepareHTTPSyncs(ctx, syncs)
+	return remotesync.PrepareAvailableHTTPSyncs(ctx, syncs)
 }
 
 var runLocalSyncWithRebuildCLI = runLocalSyncWithRebuild
@@ -564,10 +565,11 @@ type remoteHostFailure struct {
 // runRemoteHosts syncs each configured host in declared order via syncFn and
 // continues past host-attributable failures. A pending cleanup from an earlier
 // host stops iteration and is returned separately because the callback for the
-// current host never ran. The helper performs no logging so callers own all
-// output.
+// current host never ran. Unavailable configured HTTP hosts are omitted from
+// the returned failures.
 func runRemoteHosts(
 	hosts []config.RemoteHost, full bool,
+	progress sync.ProgressFunc,
 	syncFn func(config.RemoteHost, bool) error,
 ) ([]remoteHostFailure, error) {
 	var failures []remoteHostFailure
@@ -575,6 +577,15 @@ func runRemoteHosts(
 		if err := syncFn(rh, full); err != nil {
 			if pending, ok := errors.AsType[*remotesync.PendingCleanupError](err); ok {
 				return failures, pending
+			}
+			if rh.Transport == config.RemoteTransportHTTP &&
+				remotesync.IsHostUnavailable(err) {
+				if progress != nil {
+					progress(sync.Progress{
+						Detail: "Skipped offline remote host " + rh.Host,
+					})
+				}
+				continue
 			}
 			failures = append(failures, remoteHostFailure{
 				Host: rh,
@@ -644,7 +655,7 @@ func runConfiguredLocalAndRemotes(
 				func(forceFull bool) error {
 					var blocked error
 					failures, blocked = runRemoteHosts(
-						hosts, forceFull,
+						hosts, forceFull, progress,
 						func(rh config.RemoteHost, remoteFull bool) error {
 							_, err := runRemoteSyncTransport(
 								ctx, appCfg, database, rh, remoteFull,
@@ -669,11 +680,11 @@ func runConfiguredLocalAndRemotes(
 				if prepared == nil {
 					return sync.RebuildOptions{}, nil, nil
 				}
-				contributors, release, err := prepared.BorrowRebuildContributors()
+				options, release, err := prepared.BorrowRebuildOptions()
 				if err != nil {
 					return sync.RebuildOptions{}, prepared, err
 				}
-				return sync.RebuildOptions{Contributors: contributors},
+				return options,
 					&preparedHTTPRebuildLeaseCLI{
 						prepared: prepared,
 						release:  release,
@@ -686,7 +697,7 @@ func runConfiguredLocalAndRemotes(
 				}
 				var blocked error
 				failures, blocked = runRemoteHosts(
-					remoteHosts, forceFull,
+					remoteHosts, forceFull, progress,
 					func(rh config.RemoteHost, remoteFull bool) error {
 						_, err := runRemoteSyncTransport(
 							ctx, appCfg, database, rh, remoteFull,

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	stdsync "sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -35,7 +36,7 @@ import (
 )
 
 type fakeCLIPreparedHTTPRebuild struct {
-	contributors  []agentsync.RebuildContributor
+	options       agentsync.RebuildOptions
 	closed        int
 	released      bool
 	closeReleased bool
@@ -47,10 +48,10 @@ type cliLifecycleError struct{ err error }
 func (e *cliLifecycleError) Error() string { return "lifecycle: " + e.err.Error() }
 func (e *cliLifecycleError) Unwrap() error { return e.err }
 
-func (p *fakeCLIPreparedHTTPRebuild) BorrowRebuildContributors() (
-	[]agentsync.RebuildContributor, func(), error,
+func (p *fakeCLIPreparedHTTPRebuild) BorrowRebuildOptions() (
+	agentsync.RebuildOptions, func(), error,
 ) {
-	return p.contributors, func() { p.released = true }, nil
+	return p.options, func() { p.released = true }, nil
 }
 
 func (p *fakeCLIPreparedHTTPRebuild) Close() error {
@@ -148,13 +149,15 @@ func TestDoSyncConfiguredFullUsesUnifiedHTTPContributorBeforeSSH(t *testing.T) {
 	}
 	sshHost := config.RemoteHost{Host: "ssh-box"}
 	var order []string
-	prepared := &fakeCLIPreparedHTTPRebuild{contributors: []agentsync.RebuildContributor{{
-		Name: "http-box",
-		AfterSync: func(*agentsync.Engine, *db.DB) error {
-			order = append(order, "http contributor")
-			return nil
-		},
-	}}}
+	prepared := &fakeCLIPreparedHTTPRebuild{options: agentsync.RebuildOptions{
+		Contributors: []agentsync.RebuildContributor{{
+			Name: "http-box",
+			AfterSync: func(*agentsync.Engine, *db.DB) error {
+				order = append(order, "http contributor")
+				return nil
+			},
+		}},
+	}}
 	originalPrepare := prepareHTTPRebuildCLI
 	prepareHTTPRebuildCLI = func(
 		_ context.Context, syncs []remotesync.HTTPSync,
@@ -204,13 +207,15 @@ func TestDoSyncConfiguredFullIgnoresSSHHistoryDuringUnifiedSafetyCheck(t *testin
 		Agent: "claude", FilePath: &missingPath, MessageCount: 1,
 	}))
 	httpRoot := t.TempDir()
-	prepared := &fakeCLIPreparedHTTPRebuild{contributors: []agentsync.RebuildContributor{{
-		Name: "http-box",
-		Config: agentsync.EngineConfig{
-			AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {httpRoot}},
-			Machine:   "http-box", IDPrefix: "http-box~", Ephemeral: true,
-		},
-	}}}
+	prepared := &fakeCLIPreparedHTTPRebuild{options: agentsync.RebuildOptions{
+		Contributors: []agentsync.RebuildContributor{{
+			Name: "http-box",
+			Config: agentsync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {httpRoot}},
+				Machine:   "http-box", IDPrefix: "http-box~", Ephemeral: true,
+			},
+		}},
+	}}
 	originalPrepare := prepareHTTPRebuildCLI
 	prepareHTTPRebuildCLI = func(
 		context.Context, []remotesync.HTTPSync,
@@ -387,10 +392,12 @@ func TestDoSyncContributorFailureMapsRemotePreservesCauseAndSkipsSSH(t *testing.
 		ID: "preserved", Project: "archive", Machine: "local", Agent: "codex",
 	}))
 	cause := errors.New("cache snapshot failed")
-	prepared := &fakeCLIPreparedHTTPRebuild{contributors: []agentsync.RebuildContributor{{
-		Name:      "http-box",
-		AfterSync: func(*agentsync.Engine, *db.DB) error { return cause },
-	}}}
+	prepared := &fakeCLIPreparedHTTPRebuild{options: agentsync.RebuildOptions{
+		Contributors: []agentsync.RebuildContributor{{
+			Name:      "http-box",
+			AfterSync: func(*agentsync.Engine, *db.DB) error { return cause },
+		}},
+	}}
 	originalPrepare := prepareHTTPRebuildCLI
 	prepareHTTPRebuildCLI = func(
 		context.Context, []remotesync.HTTPSync,
@@ -777,6 +784,33 @@ func TestDoSyncIncrementalKeepsOrdinaryRemotePath(t *testing.T) {
 	assert.Equal(t, 1, activeCalls)
 }
 
+func TestDoSyncIncrementalReportsSkippedOfflineHTTPHost(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	host := config.RemoteHost{
+		Host: "offline", Transport: config.RemoteTransportHTTP,
+		URL: "http://offline.invalid", Token: "token",
+	}
+	restore := stubHTTPRemoteSyncForTest(t, func(
+		context.Context, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		return remotesync.SyncStats{}, syscall.ETIMEDOUT
+	})
+	t.Cleanup(restore)
+	var output bytes.Buffer
+	printer := newRemoteProgressPrinter(&output, time.Now)
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database, []config.RemoteHost{host}, false,
+		printer.Print,
+	)
+	printer.Finish()
+
+	require.NoError(t, err)
+	assert.False(t, didResync)
+	assert.Empty(t, failures)
+	assert.Contains(t, output.String(), "Skipped offline remote host offline")
+}
+
 func TestDoSyncPreparationFailureReturnsRemoteFailureOutcome(t *testing.T) {
 	env := newSyncCLIEnv(t)
 	t.Setenv("AGENTSVIEW_NO_DAEMON", "1")
@@ -820,10 +854,12 @@ token = "remote-token"
 		0o600,
 	))
 	cause := errors.New("persist remote cache")
-	prepared := &fakeCLIPreparedHTTPRebuild{contributors: []agentsync.RebuildContributor{{
-		Name:      "http-box",
-		AfterSync: func(*agentsync.Engine, *db.DB) error { return cause },
-	}}}
+	prepared := &fakeCLIPreparedHTTPRebuild{options: agentsync.RebuildOptions{
+		Contributors: []agentsync.RebuildContributor{{
+			Name:      "http-box",
+			AfterSync: func(*agentsync.Engine, *db.DB) error { return cause },
+		}},
+	}}
 	originalPrepare := prepareHTTPRebuildCLI
 	prepareHTTPRebuildCLI = func(
 		context.Context, []remotesync.HTTPSync,
@@ -931,7 +967,7 @@ func TestRunRemoteHosts_AttemptsAllAndCollectsFailures(t *testing.T) {
 	failBeta := errors.New("ssh down")
 
 	var attempted []config.RemoteHost
-	failures, blocked := runRemoteHosts(hosts, true, func(rh config.RemoteHost, full bool) error {
+	failures, blocked := runRemoteHosts(hosts, true, nil, func(rh config.RemoteHost, full bool) error {
 		attempted = append(attempted, rh)
 		assert.True(t, full, "full flag should propagate to syncFn")
 		if rh.Host == "beta" {
@@ -951,11 +987,47 @@ func TestRunRemoteHosts_AttemptsAllAndCollectsFailures(t *testing.T) {
 
 func TestRunRemoteHosts_AllSucceedReturnsEmpty(t *testing.T) {
 	hosts := []config.RemoteHost{{Host: "alpha"}, {Host: "beta"}}
-	failures, blocked := runRemoteHosts(hosts, false, func(config.RemoteHost, bool) error {
+	failures, blocked := runRemoteHosts(hosts, false, nil, func(config.RemoteHost, bool) error {
 		return nil
 	})
 	require.NoError(t, blocked)
 	assert.Empty(t, failures)
+}
+
+func TestRunRemoteHostsSkipsOfflineConfiguredHTTPHost(t *testing.T) {
+	hosts := []config.RemoteHost{
+		{Host: "offline", Transport: config.RemoteTransportHTTP},
+		{Host: "broken", Transport: config.RemoteTransportHTTP},
+		{Host: "reachable", Transport: config.RemoteTransportHTTP},
+	}
+	broken := errors.New("remote import failed")
+	var attempted []string
+
+	var progress []agentsync.Progress
+	failures, blocked := runRemoteHosts(hosts, false, func(p agentsync.Progress) {
+		progress = append(progress, p)
+	}, func(
+		rh config.RemoteHost, _ bool,
+	) error {
+		attempted = append(attempted, rh.Host)
+		switch rh.Host {
+		case "offline":
+			return syscall.ETIMEDOUT
+		case "broken":
+			return broken
+		default:
+			return nil
+		}
+	})
+
+	require.NoError(t, blocked)
+	assert.Equal(t, []string{"offline", "broken", "reachable"}, attempted)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "broken", failures[0].Host.Host)
+	assert.ErrorIs(t, failures[0].Err, broken)
+	assert.Contains(t, progress, agentsync.Progress{
+		Detail: "Skipped offline remote host offline",
+	})
 }
 
 func TestRunRemoteSyncOnceDispatchesHTTP(t *testing.T) {
@@ -1102,7 +1174,7 @@ func TestRunRemoteHostsStopsOnPendingHTTPCleanupWithoutMisattribution(t *testing
 
 	failures, blocked := runRemoteHosts([]config.RemoteHost{
 		httpHost("alpha"), httpHost("beta"), httpHost("gamma"),
-	}, false, run)
+	}, false, nil, run)
 	require.Len(t, failures, 1)
 	assert.Equal(t, "alpha", failures[0].Host.Host)
 	assert.Same(t, owner, failures[0].Err)
@@ -1114,7 +1186,7 @@ func TestRunRemoteHostsStopsOnPendingHTTPCleanupWithoutMisattribution(t *testing
 	assert.Equal(t, 2, owner.retries)
 
 	failures, blocked = runRemoteHosts(
-		[]config.RemoteHost{httpHost("delta")}, false, run,
+		[]config.RemoteHost{httpHost("delta")}, false, nil, run,
 	)
 	assert.Empty(t, failures)
 	require.ErrorAs(t, blocked, &pending)
@@ -1122,7 +1194,7 @@ func TestRunRemoteHostsStopsOnPendingHTTPCleanupWithoutMisattribution(t *testing
 	assert.Equal(t, 3, owner.retries)
 
 	failures, blocked = runRemoteHosts(
-		[]config.RemoteHost{httpHost("epsilon")}, false, run,
+		[]config.RemoteHost{httpHost("epsilon")}, false, nil, run,
 	)
 	assert.Empty(t, failures)
 	require.NoError(t, blocked)
@@ -1398,6 +1470,9 @@ func TestRemoteProgressPrinterWritesTimedStepLines(t *testing.T) {
 	printer.Print(agentsync.Progress{
 		Detail: "Synced 10 sessions from devbox (1 unchanged)",
 	})
+	printer.Print(agentsync.Progress{
+		Detail: "Skipped offline remote host laptop",
+	})
 	printer.Finish()
 
 	got := out.String()
@@ -1408,6 +1483,8 @@ func TestRemoteProgressPrinterWritesTimedStepLines(t *testing.T) {
 	assert.Contains(t, got, "\r  Processing sessions from devbox: 10/10 sessions (100%) · 100 messages\x1b[K")
 	assert.Contains(t, got, "\n  Processing sessions from devbox completed in 3.35s\n")
 	assert.Contains(t, got, "  Synced 10 sessions from devbox (1 unchanged)\n")
+	assert.Contains(t, got, "  Skipped offline remote host laptop\n")
+	assert.NotContains(t, got, "Skipped offline remote host laptop completed")
 	assert.True(t, strings.HasSuffix(got, "\n"), "remote progress should finish on a newline")
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,8 @@ description: Release history for AgentsView
 
 - Preserve Antigravity CLI 1.1.5 generation usage and Low/Medium/High model
   effort from SQLite executor metadata.
+- Let `agentsview sync` skip offline configured HTTP hosts while local and
+  reachable remote sources continue to sync.
 
 **Improvements**
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -283,11 +283,13 @@ force unchanged manifest-capable files to transfer again. Directory-scoped and
 verbatim curated content still use delta transfer. Windsurf's sanitized curated
 export remains a separate full-archive transfer on every sync. HTTP collectors
 and spokes must use the same remote-sync protocol version; incompatible peers
-fail before exchanging targets or archive data. An HTTP preparation or
-contributor failure aborts the combined rebuild without replacing the active
-archive or running SSH. Ordinary incremental and post-swap SSH failures retain
-per-host reporting, and the command exits non-zero if any host failed. See
-[Incremental Sync](/remote-access/#incremental-sync).
+fail before exchanging targets or archive data. A configured HTTP host that is
+offline, unreachable, or times out is skipped; reachable HTTP hosts still join
+the combined rebuild. Other HTTP preparation or contributor failures abort the
+combined rebuild without replacing the active archive or running SSH. Ordinary
+incremental and post-swap SSH failures retain per-host reporting, and the
+command exits non-zero for any failure other than an unavailable configured
+HTTP host. See [Incremental Sync](/remote-access/#incremental-sync).
 
 `agentsview sync --host X` syncs one host, not the whole configured list. When
 the local daemon knows a configured host with that identity, it uses the stored

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -129,6 +129,12 @@ connection refusal usually means the daemon is not running, is still bound to
 loopback, or the URL port is wrong; DNS and timeout messages point back to the
 configured `url`.
 
+A bare `agentsview sync` treats offline, unreachable, and timed-out configured
+HTTP hosts as absent fleet members. It prints a skipped-host progress line,
+continues with local and reachable remote sources, and exits successfully unless
+another error occurs. `agentsview sync --host X` remains strict and reports an
+unavailable explicitly selected host as an error.
+
 For always-available fleet nodes launched with `agentsview daemon start`, set:
 
 ```toml

--- a/internal/remotesync/failure.go
+++ b/internal/remotesync/failure.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"syscall"
 )
@@ -82,6 +84,51 @@ func FailureSummary(err error) string {
 	}
 
 	return generic
+}
+
+// IsHostUnavailable reports transport failures that mean the configured
+// remote cannot currently be reached. Callers use this to treat optional fleet
+// members as absent while preserving authentication, protocol, response, and
+// import failures as actionable errors.
+func IsHostUnavailable(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if _, ok := errors.AsType[*PendingCleanupError](err); ok {
+		return false
+	}
+	var cleanup cleanupRetrier
+	if errors.As(err, &cleanup) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ETIMEDOUT) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) {
+		return true
+	}
+	if errors.Is(err, io.EOF) {
+		if _, ok := errors.AsType[*url.Error](err); ok {
+			return true
+		}
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		if _, ok := errors.AsType[*url.Error](err); ok {
+			return true
+		}
+		if _, ok := errors.AsType[*httpBodyReadError](err); ok {
+			return true
+		}
+	}
+	var netErr net.Error
+	if !errors.As(err, &netErr) || netErr == nil {
+		return false
+	}
+	return netErr.Timeout()
 }
 
 // statusLabel renders an HTTP status for user-facing messages using

--- a/internal/remotesync/failure_test.go
+++ b/internal/remotesync/failure_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type fakeTimeoutError struct{}
@@ -179,4 +182,210 @@ func TestFailureSummary(t *testing.T) {
 				"summaries must not leak raw error text")
 		})
 	}
+}
+
+func TestIsHostUnavailable(t *testing.T) {
+	wrappedNetworkError := func(op string, err error) error {
+		return fmt.Errorf("fetch manifest: %w", &net.OpError{
+			Op:  op,
+			Net: "tcp",
+			Err: &os.SyscallError{Syscall: op, Err: err},
+		})
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "timeout", err: fakeTimeoutError{}, want: true},
+		{name: "connection refused", err: syscall.ECONNREFUSED, want: true},
+		{
+			name: "wrapped connection reset",
+			err:  wrappedNetworkError("read", syscall.ECONNRESET),
+			want: true,
+		},
+		{
+			name: "wrapped connection aborted",
+			err:  wrappedNetworkError("read", syscall.ECONNABORTED),
+			want: true,
+		},
+		{
+			name: "wrapped broken pipe",
+			err:  wrappedNetworkError("write", syscall.EPIPE),
+			want: true,
+		},
+		{name: "host unreachable", err: syscall.EHOSTUNREACH, want: true},
+		{name: "network unreachable", err: syscall.ENETUNREACH, want: true},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: true},
+		{name: "request canceled", err: context.Canceled, want: false},
+		{
+			name: "protocol decode EOF",
+			err:  fmt.Errorf("decode remote manifest: %w", io.EOF),
+			want: false,
+		},
+		{
+			name: "protocol decode unexpected EOF",
+			err:  fmt.Errorf("decode remote manifest: %w", io.ErrUnexpectedEOF),
+			want: false,
+		},
+		{name: "timeout with retained cleanup", err: &cleanupRetryTestError{
+			cause: syscall.ETIMEDOUT,
+		}, want: false},
+		{name: "bad token", err: &StatusError{Code: 401}, want: false},
+		{name: "bad host name", err: &net.DNSError{Err: "no such host"}, want: false},
+		{name: "import failure", err: errors.New("persist mirror"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsHostUnavailable(tt.err))
+		})
+	}
+}
+
+func TestIsHostUnavailableWhenHTTPServerClosesBeforeHeaders(t *testing.T) {
+	serverResult := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter, _ *http.Request,
+	) {
+		hijacker, ok := writer.(http.Hijacker)
+		if !ok {
+			serverResult <- errors.New("response writer cannot hijack")
+			return
+		}
+		conn, _, err := hijacker.Hijack()
+		if err != nil {
+			serverResult <- err
+			return
+		}
+		serverResult <- conn.Close()
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := (HTTPSync{URL: server.URL}).fetchTargets(
+		context.Background(), server.Client(),
+	)
+	require.NoError(t, <-serverResult)
+	require.Error(t, err)
+	assert.True(t, IsHostUnavailable(err))
+}
+
+func TestIsHostUnavailableWhenHTTPHeadersAreTruncated(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+
+	serverResult := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverResult <- acceptErr
+			return
+		}
+		_, writeErr := io.WriteString(
+			conn, "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n",
+		)
+		serverResult <- errors.Join(writeErr, conn.Close())
+	}()
+
+	_, err = (HTTPSync{URL: "http://" + listener.Addr().String()}).fetchTargets(
+		t.Context(), http.DefaultClient,
+	)
+	require.NoError(t, <-serverResult)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.True(t, IsHostUnavailable(err))
+}
+
+func TestIsHostUnavailableWhenHTTPArchiveBodyIsTruncated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter, _ *http.Request,
+	) {
+		SetProtocolHeader(writer.Header())
+		writer.Header().Set("Content-Length", "20")
+		_, _ = writer.Write([]byte("short"))
+	}))
+	t.Cleanup(server.Close)
+
+	root, err := (HTTPSync{URL: server.URL}).downloadAndExtract(
+		t.Context(), server.Client(), TargetSet{},
+	)
+	assert.Empty(t, root)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.True(t, IsHostUnavailable(err))
+}
+
+func TestIsHostUnavailableWhenHTTPJSONBodyIsTruncated(t *testing.T) {
+	tests := []struct {
+		name  string
+		fetch func(context.Context, HTTPSync, *http.Client) error
+	}{
+		{
+			name: "targets",
+			fetch: func(ctx context.Context, hs HTTPSync, client *http.Client) error {
+				_, err := hs.fetchTargets(ctx, client)
+				return err
+			},
+		},
+		{
+			name: "manifest",
+			fetch: func(ctx context.Context, hs HTTPSync, client *http.Client) error {
+				_, _, err := hs.fetchManifest(ctx, client, TargetSet{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(
+				writer http.ResponseWriter, _ *http.Request,
+			) {
+				SetProtocolHeader(writer.Header())
+				writer.Header().Set("Content-Length", "20")
+				_, _ = writer.Write([]byte(`{"dirs":`))
+			}))
+			t.Cleanup(server.Close)
+
+			err := tt.fetch(
+				t.Context(), HTTPSync{URL: server.URL}, server.Client(),
+			)
+			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+			assert.True(t, IsHostUnavailable(err))
+		})
+	}
+}
+
+func TestIsHostUnavailableKeepsCompleteMalformedJSONActionable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter, _ *http.Request,
+	) {
+		SetProtocolHeader(writer.Header())
+		_, _ = writer.Write([]byte(`{"dirs":`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := (HTTPSync{URL: server.URL}).fetchTargets(
+		t.Context(), server.Client(),
+	)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.False(t, IsHostUnavailable(err))
+}
+
+func TestIsHostUnavailableWhenHTTPManifestGzipHeaderIsTruncated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter, _ *http.Request,
+	) {
+		SetProtocolHeader(writer.Header())
+		writer.Header().Set("Content-Encoding", "gzip")
+		writer.Header().Set("Content-Length", "20")
+		_, _ = writer.Write([]byte{0x1f, 0x8b})
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := (HTTPSync{URL: server.URL}).fetchManifest(
+		t.Context(), server.Client(), TargetSet{},
+	)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.True(t, IsHostUnavailable(err))
 }

--- a/internal/remotesync/http.go
+++ b/internal/remotesync/http.go
@@ -175,10 +175,14 @@ func (hs HTTPSync) fetchManifest(
 	if err := ValidateProtocolHeader(resp.Header); err != nil {
 		return Manifest{}, false, err
 	}
-	reader := io.Reader(resp.Body)
+	bodyReader := &httpBodyReader{r: resp.Body}
+	reader := io.Reader(bodyReader)
 	if resp.Header.Get("Content-Encoding") == "gzip" {
-		gz, err := gzip.NewReader(resp.Body)
+		gz, err := gzip.NewReader(bodyReader)
 		if err != nil {
+			if bodyReader.err != nil {
+				err = bodyReader.err
+			}
 			return Manifest{}, false, fmt.Errorf("decode manifest gzip: %w", err)
 		}
 		defer gz.Close()
@@ -186,6 +190,9 @@ func (hs HTTPSync) fetchManifest(
 	}
 	var manifest Manifest
 	if err := json.UnmarshalRead(reader, &manifest); err != nil {
+		if bodyReader.err != nil {
+			err = bodyReader.err
+		}
 		return Manifest{}, false, fmt.Errorf("decode remote manifest: %w", err)
 	}
 	return manifest, true, nil
@@ -299,7 +306,11 @@ func (hs HTTPSync) fetchTargets(
 		return TargetSet{}, err
 	}
 	var targets TargetSet
-	if err := json.UnmarshalRead(resp.Body, &targets); err != nil {
+	bodyReader := &httpBodyReader{r: resp.Body}
+	if err := json.UnmarshalRead(bodyReader, &targets); err != nil {
+		if bodyReader.err != nil {
+			err = bodyReader.err
+		}
 		return TargetSet{}, fmt.Errorf("decode remote targets: %w", err)
 	}
 	return targets, nil

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -50,10 +50,11 @@ func (e *HostError) Unwrap() error { return e.Err }
 // Source ownership stays internal so locks and temporary roots can only be
 // released as a group.
 type PreparedHTTPSyncs struct {
-	mu      sync.Mutex
-	sources []*PreparedHTTP
-	closing bool
-	borrows int
+	mu                    sync.Mutex
+	sources               []*PreparedHTTP
+	unavailableIDPrefixes []string
+	closing               bool
+	borrows               int
 }
 
 // PrepareHTTPSyncs prepares HTTP hosts in deterministic order, using canonical
@@ -64,11 +65,26 @@ type PreparedHTTPSyncs struct {
 func PrepareHTTPSyncs(
 	ctx context.Context, syncs []HTTPSync,
 ) (*PreparedHTTPSyncs, error) {
-	return prepareHTTPSyncs(ctx, syncs, func(
+	prepared, _, err := prepareHTTPSyncsWithUnavailable(ctx, syncs, false, func(
 		ctx context.Context, hs HTTPSync,
 	) (*PreparedHTTP, error) {
 		return hs.Prepare(ctx)
 	})
+	return prepared, err
+}
+
+// PrepareAvailableHTTPSyncs prepares every reachable HTTP host. Unavailable
+// hosts are omitted; other failures retain the all-or-nothing cleanup behavior
+// of PrepareHTTPSyncs.
+func PrepareAvailableHTTPSyncs(
+	ctx context.Context, syncs []HTTPSync,
+) (*PreparedHTTPSyncs, error) {
+	prepared, _, err := prepareHTTPSyncsWithUnavailable(ctx, syncs, true, func(
+		ctx context.Context, hs HTTPSync,
+	) (*PreparedHTTP, error) {
+		return hs.Prepare(ctx)
+	})
+	return prepared, err
 }
 
 func prepareHTTPSyncs(
@@ -76,6 +92,18 @@ func prepareHTTPSyncs(
 	syncs []HTTPSync,
 	prepare func(context.Context, HTTPSync) (*PreparedHTTP, error),
 ) (*PreparedHTTPSyncs, error) {
+	prepared, _, err := prepareHTTPSyncsWithUnavailable(
+		ctx, syncs, false, prepare,
+	)
+	return prepared, err
+}
+
+func prepareHTTPSyncsWithUnavailable(
+	ctx context.Context,
+	syncs []HTTPSync,
+	skipUnavailable bool,
+	prepare func(context.Context, HTTPSync) (*PreparedHTTP, error),
+) (*PreparedHTTPSyncs, []*HostError, error) {
 	type orderedSync struct {
 		sync    HTTPSync
 		sortKey string
@@ -94,7 +122,7 @@ func prepareHTTPSyncs(
 		}
 		lockPath, err := canonicalMirrorLockPath(MirrorDir(hs.DataDir, hs.Host))
 		if err != nil {
-			return nil, &HostError{
+			return nil, nil, &HostError{
 				Host: hs.Host, Operation: "resolve mirror lock", Err: err,
 			}
 		}
@@ -103,7 +131,7 @@ func prepareHTTPSyncs(
 				"%w: hosts %q and %q use %q",
 				ErrDuplicateMirrorLock, previous.Host, hs.Host, lockPath,
 			)
-			return nil, &HostError{
+			return nil, nil, &HostError{
 				Host: hs.Host, Operation: "resolve mirror lock", Err: cause,
 			}
 		}
@@ -119,6 +147,7 @@ func prepareHTTPSyncs(
 	prepared := &PreparedHTTPSyncs{
 		sources: make([]*PreparedHTTP, 0, len(ordered)),
 	}
+	var unavailable []*HostError
 	for _, input := range ordered {
 		hs := input.sync
 		if hs.Lifecycle != nil && hs.Lifecycle.PrepareStarted != nil {
@@ -129,50 +158,66 @@ func prepareHTTPSyncs(
 			hs.Lifecycle.PrepareFinished(err)
 		}
 		if err != nil {
+			primary := &HostError{Host: hs.Host, Operation: "prepare", Err: err}
+			if skipUnavailable && source == nil && ctx.Err() == nil &&
+				IsHostUnavailable(err) {
+				unavailable = append(unavailable, primary)
+				prepared.unavailableIDPrefixes = append(
+					prepared.unavailableIDPrefixes, rebuildIDPrefix(hs.Host),
+				)
+				hs.reportProgressDetail(
+					"Skipped offline remote host " + hs.Host,
+				)
+				continue
+			}
 			if source != nil {
 				prepared.sources = append(prepared.sources, source)
 			}
-			primary := &HostError{Host: hs.Host, Operation: "prepare", Err: err}
 			cleanupErr := prepared.Close()
 			if cleanupErr != nil {
-				return prepared, errors.Join(primary, cleanupErr)
+				return prepared, unavailable, errors.Join(primary, cleanupErr)
 			}
-			return nil, primary
+			return nil, unavailable, primary
 		}
 		prepared.sources = append(prepared.sources, source)
 	}
-	return prepared, nil
+	return prepared, unavailable, nil
 }
 
-// BorrowRebuildContributors borrows rebuild descriptions while the prepared
-// set retains cleanup ownership. Callers must invoke the idempotent release
-// function after the rebuild stops using every contributor. Close refuses to
-// release any source while a borrow remains active.
-func (p *PreparedHTTPSyncs) BorrowRebuildContributors() (
-	contributors []syncpkg.RebuildContributor,
+// BorrowRebuildOptions borrows rebuild descriptions and unavailable host
+// namespaces while the prepared set retains cleanup ownership. Callers must
+// invoke the idempotent release function after the rebuild stops using the
+// options. Close refuses to release any source while a borrow remains active.
+func (p *PreparedHTTPSyncs) BorrowRebuildOptions() (
+	options syncpkg.RebuildOptions,
 	release func(),
 	err error,
 ) {
 	if p == nil {
-		return nil, nil, ErrPreparedClosed
+		return syncpkg.RebuildOptions{}, nil, ErrPreparedClosed
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.closing {
-		return nil, nil, ErrPreparedClosed
+		return syncpkg.RebuildOptions{}, nil, ErrPreparedClosed
 	}
-	contributors = make([]syncpkg.RebuildContributor, 0, len(p.sources))
+	options.Contributors = make(
+		[]syncpkg.RebuildContributor, 0, len(p.sources),
+	)
+	options.UnavailableContributorIDPrefixes = slices.Clone(
+		p.unavailableIDPrefixes,
+	)
 	for _, source := range p.sources {
 		if source == nil {
 			continue
 		}
 		contributor, err := source.RebuildContributor()
 		if err != nil {
-			return nil, nil, &HostError{
+			return syncpkg.RebuildOptions{}, nil, &HostError{
 				Host: source.sync.Host, Operation: "build rebuild contributor", Err: err,
 			}
 		}
-		contributors = append(contributors, contributor)
+		options.Contributors = append(options.Contributors, contributor)
 	}
 	p.borrows++
 	var once sync.Once
@@ -183,7 +228,7 @@ func (p *PreparedHTTPSyncs) BorrowRebuildContributors() (
 			p.mu.Unlock()
 		})
 	}
-	return contributors, release, nil
+	return options, release, nil
 }
 
 // Close releases prepared sources in reverse order. Successfully closed

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -3151,6 +3151,42 @@ func TestPrepareHTTPSyncsSortsHostsAndUnwindsOnFailure(t *testing.T) {
 	assert.Empty(t, roots, "unwind removes the successful legacy root and spools")
 }
 
+func TestPrepareAvailableHTTPSyncsOmitsOfflineHost(t *testing.T) {
+	var progress []string
+	syncs := []HTTPSync{
+		{Host: "reachable", Progress: func(p syncpkg.Progress) {
+			progress = append(progress, p.Detail)
+		}},
+		{Host: "offline", Progress: func(p syncpkg.Progress) {
+			progress = append(progress, p.Detail)
+		}},
+	}
+	prepared, unavailable, err := prepareHTTPSyncsWithUnavailable(
+		context.Background(), syncs, true,
+		func(_ context.Context, hs HTTPSync) (*PreparedHTTP, error) {
+			if hs.Host == "offline" {
+				return nil, fakeTimeoutError{}
+			}
+			return &PreparedHTTP{sync: hs}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+	require.Len(t, unavailable, 1)
+	assert.Equal(t, "offline", unavailable[0].Host)
+	require.Len(t, prepared.sources, 1)
+	assert.Equal(t, "reachable", prepared.sources[0].sync.Host)
+	options, release, err := prepared.BorrowRebuildOptions()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"offline~"},
+		options.UnavailableContributorIDPrefixes)
+	require.Len(t, options.Contributors, 1)
+	release()
+	assert.Contains(t, progress, "Skipped offline remote host offline")
+	require.NoError(t, prepared.Close())
+}
+
 func TestPrepareHTTPSyncsLegacySourcesDoNotCreateWorkingDirectoryLocks(t *testing.T) {
 	remoteA := newMirrorTestRemote(t)
 	remoteA.writeSession(t, "a.jsonl",
@@ -3433,14 +3469,14 @@ func TestPreparedHTTPSyncsHoldAllLocksUntilClose(t *testing.T) {
 		context.Background(), []HTTPSync{syncB, syncA},
 	)
 	require.NoError(t, err)
-	contributors, release, err := prepared.BorrowRebuildContributors()
+	options, release, err := prepared.BorrowRebuildOptions()
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		release()
 		require.NoError(t, prepared.Close())
 	})
 	assert.Equal(t, []string{"host-a", "host-b"}, []string{
-		contributors[0].Name, contributors[1].Name,
+		options.Contributors[0].Name, options.Contributors[1].Name,
 	})
 
 	for _, host := range []string{"host-a", "host-b"} {
@@ -3468,7 +3504,7 @@ func TestPreparedHTTPSyncsHoldAllLocksUntilClose(t *testing.T) {
 		require.NotNil(t, competing, host)
 		require.NoError(t, competing.Close())
 	}
-	_, _, err = prepared.BorrowRebuildContributors()
+	_, _, err = prepared.BorrowRebuildOptions()
 	assert.ErrorIs(t, err, ErrPreparedClosed,
 		"closed aggregate cannot expose contributors")
 }
@@ -3481,17 +3517,17 @@ func TestPreparedHTTPSyncsBorrowBlocksCloseUntilRelease(t *testing.T) {
 	_, hs := newMirrorSync(t, remote, dataDir)
 	prepared, err := PrepareHTTPSyncs(context.Background(), []HTTPSync{hs})
 	require.NoError(t, err)
-	contributors, release, err := prepared.BorrowRebuildContributors()
+	options, release, err := prepared.BorrowRebuildOptions()
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		release()
 		require.NoError(t, prepared.Close())
 	})
-	require.Len(t, contributors, 1)
-	assert.Equal(t, hs.Host, contributors[0].Name)
+	require.Len(t, options.Contributors, 1)
+	assert.Equal(t, hs.Host, options.Contributors[0].Name)
 
 	assert.ErrorIs(t, prepared.Close(), ErrPreparedInUse)
-	_, _, err = prepared.BorrowRebuildContributors()
+	_, _, err = prepared.BorrowRebuildOptions()
 	assert.ErrorIs(t, err, ErrPreparedClosed,
 		"a Close attempt ends new borrowing while retained ownership remains retryable")
 	lockCtx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
@@ -3511,7 +3547,7 @@ func TestPreparedHTTPSyncsBorrowBlocksCloseUntilRelease(t *testing.T) {
 	require.NoError(t, lockErr)
 	require.NotNil(t, competing)
 	require.NoError(t, competing.Close())
-	_, _, err = prepared.BorrowRebuildContributors()
+	_, _, err = prepared.BorrowRebuildOptions()
 	assert.ErrorIs(t, err, ErrPreparedClosed)
 }
 
@@ -3521,7 +3557,7 @@ func TestPreparedHTTPSyncsBorrowAndCloseAreRaceSafe(t *testing.T) {
 		lock:        &MirrorLockHandle{},
 		releaseLock: func(*MirrorLockHandle) error { return nil },
 	}}}
-	_, initialRelease, err := prepared.BorrowRebuildContributors()
+	_, initialRelease, err := prepared.BorrowRebuildOptions()
 	require.NoError(t, err)
 	start := make(chan struct{})
 	borrowResults := make(chan error, 8)
@@ -3529,7 +3565,7 @@ func TestPreparedHTTPSyncsBorrowAndCloseAreRaceSafe(t *testing.T) {
 	for range 8 {
 		go func() {
 			<-start
-			_, release, borrowErr := prepared.BorrowRebuildContributors()
+			_, release, borrowErr := prepared.BorrowRebuildOptions()
 			if borrowErr == nil {
 				release()
 				release()

--- a/internal/remotesync/http_transfer.go
+++ b/internal/remotesync/http_transfer.go
@@ -26,6 +26,24 @@ type downloadedArchive struct {
 	remove     func(string) error
 }
 
+type httpBodyReadError struct{ err error }
+
+func (e *httpBodyReadError) Error() string { return e.err.Error() }
+func (e *httpBodyReadError) Unwrap() error { return e.err }
+
+type httpBodyReader struct {
+	r   io.Reader
+	err error
+}
+
+func (r *httpBodyReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		r.err = &httpBodyReadError{err: err}
+	}
+	return n, err
+}
+
 // downloadedArchiveCleanupError retains a spool whose removal failed so the
 // process-level cleanup registry can retry it before another HTTP sync starts.
 type downloadedArchiveCleanupError struct {
@@ -131,7 +149,10 @@ func (hs HTTPSync) downloadArchive(
 	closeErr := spool.Close()
 	if copyErr != nil {
 		return nil, errors.Join(
-			fmt.Errorf("download archive: %w", copyErr), closeErr,
+			&httpBodyReadError{
+				err: fmt.Errorf("download archive: %w", copyErr),
+			},
+			closeErr,
 		)
 	}
 	if closeErr != nil {

--- a/internal/remotesync/import.go
+++ b/internal/remotesync/import.go
@@ -177,13 +177,15 @@ func importEngineConfig(
 	return syncpkg.EngineConfig{
 		AgentDirs:               layout.engineDirs,
 		Machine:                 host,
-		IDPrefix:                host + "~",
+		IDPrefix:                rebuildIDPrefix(host),
 		PathRewriter:            layout.paths.pathRewriter(),
 		StoredPathResolver:      layout.paths.storedPathResolver(),
 		Ephemeral:               true,
 		BlockedResultCategories: blockedResultCategories,
 	}
 }
+
+func rebuildIDPrefix(host string) string { return host + "~" }
 
 func loadImportSkipCache(
 	database *db.DB,

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -101,7 +101,7 @@ var runHTTPRemoteSync = func(
 }
 
 type preparedHTTPRebuild interface {
-	BorrowRebuildContributors() ([]syncpkg.RebuildContributor, func(), error)
+	BorrowRebuildOptions() (syncpkg.RebuildOptions, func(), error)
 	Close() error
 }
 
@@ -109,7 +109,7 @@ var prepareHTTPRebuild = func(
 	ctx context.Context,
 	syncs []remotesync.HTTPSync,
 ) (preparedHTTPRebuild, error) {
-	return remotesync.PrepareHTTPSyncs(ctx, syncs)
+	return remotesync.PrepareAvailableHTTPSyncs(ctx, syncs)
 }
 
 type preparedHTTPRebuildLease struct {
@@ -514,7 +514,7 @@ func (s *Server) runRemoteSyncRequest(
 				stats, err := engine.SyncThenRun(
 					ctx, req.Full, progress, func(forceFull bool) error {
 						failures, remoteStats, blocked = s.runRemoteSyncHostsOwned(
-							ctx, local, req.Hosts, forceFull, progress, true,
+							ctx, local, req.Hosts, forceFull, progress, true, true,
 						)
 						return blocked
 					},
@@ -543,11 +543,11 @@ func (s *Server) runRemoteSyncRequest(
 					if prepared == nil {
 						return syncpkg.RebuildOptions{}, nil, nil
 					}
-					contributors, release, err := prepared.BorrowRebuildContributors()
+					options, release, err := prepared.BorrowRebuildOptions()
 					if err != nil {
 						return syncpkg.RebuildOptions{}, prepared, err
 					}
-					return syncpkg.RebuildOptions{Contributors: contributors},
+					return options,
 						&preparedHTTPRebuildLease{
 							prepared: prepared,
 							release:  release,
@@ -567,6 +567,7 @@ func (s *Server) runRemoteSyncRequest(
 					}
 					failures, remoteStats, blocked = s.runRemoteSyncHostsOwned(
 						ctx, local, hosts, forceFull, progress, !outerOwnsHTTP,
+						true,
 					)
 					return blocked
 				},
@@ -605,6 +606,7 @@ func (s *Server) runRemoteSyncRequest(
 			err := engine.RunExclusive(func() error {
 				failures, remoteStats, blocked = s.runRemoteSyncHostsOwned(
 					ctx, local, req.Hosts, req.Full, progress, !outerOwnsHTTP,
+					false,
 				)
 				return blocked
 			})
@@ -687,6 +689,14 @@ func newUnifiedHTTPHostLifecycle(
 		PrepareFinished: func(err error) {
 			outcome := remoteSyncLifecycleOutcome(ctx, err)
 			duration := time.Since(preparationStarted).Round(time.Millisecond)
+			if err != nil && ctx.Err() == nil &&
+				remotesync.IsHostUnavailable(err) {
+				log.Printf(
+					"remote sync HTTP host preparation finished: host=%s duration=%s outcome=skipped",
+					host.Host, duration,
+				)
+				return
+			}
 			if err != nil {
 				log.Printf(
 					"remote sync HTTP host preparation finished: host=%s duration=%s outcome=%s error=%q",
@@ -880,7 +890,7 @@ func (s *Server) runRemoteSyncHosts(
 	progress func(syncpkg.Progress),
 ) ([]remoteSyncFailure, remotesync.SyncStats, error) {
 	return s.runRemoteSyncHostsOwned(
-		ctx, local, hosts, full, progress, true,
+		ctx, local, hosts, full, progress, true, false,
 	)
 }
 
@@ -899,6 +909,7 @@ func (s *Server) runRemoteSyncHostsOwned(
 	full bool,
 	progress func(syncpkg.Progress),
 	acquireHTTPRegistry bool,
+	skipUnavailable bool,
 ) ([]remoteSyncFailure, remotesync.SyncStats, error) {
 	ingestionCfg := s.ingestionConfig()
 	failures := make([]remoteSyncFailure, 0)
@@ -942,6 +953,26 @@ func (s *Server) runRemoteSyncHostsOwned(
 		totals.SessionsTotal += stats.SessionsTotal
 		totals.Skipped += stats.Skipped
 		totals.Failed += stats.Failed
+		unavailable := err != nil && skipUnavailable &&
+			rh.Transport == config.RemoteTransportHTTP &&
+			ctx.Err() == nil && remotesync.IsHostUnavailable(err)
+		if unavailable {
+			log.Printf(
+				"remote sync host finished: host=%s transport=%s duration=%s sessions_synced=%d sessions_total=%d skipped=%d failed=%d outcome=skipped",
+				rh.Host, transport, time.Since(started).Round(time.Millisecond),
+				stats.SessionsSynced, stats.SessionsTotal, stats.Skipped,
+				stats.Failed,
+			)
+			log.Printf(
+				"remote sync %s skipped: host is offline", rh.Host,
+			)
+			if progress != nil {
+				progress(syncpkg.Progress{
+					Detail: "Skipped offline remote host " + rh.Host,
+				})
+			}
+			continue
+		}
 		outcome := remoteSyncLifecycleOutcome(ctx, err)
 		if err != nil {
 			log.Printf(

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	stdlibsync "sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -39,6 +40,14 @@ type syncRouteFixture struct {
 	db        *db.DB
 	srv       *Server
 	handler   http.Handler
+}
+
+type offlineRemoteTransport struct{}
+
+func (offlineRemoteTransport) RoundTrip(
+	*http.Request,
+) (*http.Response, error) {
+	return nil, syscall.ETIMEDOUT
 }
 
 type syncRouteFixtureConfig struct {
@@ -318,16 +327,16 @@ func stubRunHTTPRemoteSync(
 }
 
 type fakePreparedHTTPRebuild struct {
-	contributors []syncpkg.RebuildContributor
-	closed       int
-	committed    int
-	closeErrors  []error
+	options     syncpkg.RebuildOptions
+	closed      int
+	committed   int
+	closeErrors []error
 }
 
-func (p *fakePreparedHTTPRebuild) BorrowRebuildContributors() (
-	[]syncpkg.RebuildContributor, func(), error,
+func (p *fakePreparedHTTPRebuild) BorrowRebuildOptions() (
+	syncpkg.RebuildOptions, func(), error,
 ) {
-	return p.contributors, func() {}, nil
+	return p.options, func() {}, nil
 }
 
 func (p *fakePreparedHTTPRebuild) Close() error {
@@ -527,10 +536,12 @@ func TestRunRemoteSyncRequestUnifiedHTTPContributorFailureSkipsSSH(t *testing.T)
 	assertSessionCount(t, f.db, 0)
 
 	sentinel := errors.New("persist remote cache")
-	prepared := &fakePreparedHTTPRebuild{contributors: []syncpkg.RebuildContributor{{
-		Name:      "alpha",
-		AfterSync: func(*syncpkg.Engine, *db.DB) error { return sentinel },
-	}}}
+	prepared := &fakePreparedHTTPRebuild{options: syncpkg.RebuildOptions{
+		Contributors: []syncpkg.RebuildContributor{{
+			Name:      "alpha",
+			AfterSync: func(*syncpkg.Engine, *db.DB) error { return sentinel },
+		}},
+	}}
 	stubPrepareHTTPRebuild(t, func(
 		_ context.Context, syncs []remotesync.HTTPSync,
 	) (preparedHTTPRebuild, error) {
@@ -576,12 +587,12 @@ func TestRunRemoteSyncRequestContributorFailurePrecedesRetainedCleanupHost(t *te
 		Host: "beta", Operation: "cleanup", Err: cleanupCause,
 	}
 	prepared := &fakePreparedHTTPRebuild{
-		contributors: []syncpkg.RebuildContributor{{
+		options: syncpkg.RebuildOptions{Contributors: []syncpkg.RebuildContributor{{
 			Name: "alpha",
 			AfterSync: func(*syncpkg.Engine, *db.DB) error {
 				return contributorCause
 			},
-		}},
+		}}},
 		closeErrors: []error{cleanupErr, cleanupErr},
 	}
 	stubPrepareHTTPRebuild(t, func(
@@ -971,7 +982,7 @@ func TestRunRemoteSyncHostsOwnedLogsPerHostLifecycle(t *testing.T) {
 		[]config.RemoteHost{
 			{Host: "alpha", Transport: config.RemoteTransportHTTP, Token: "secret-token"},
 			{Host: "beta", Transport: config.RemoteTransportHTTP, Token: "secret-token"},
-		}, true, nil, true,
+		}, true, nil, true, false,
 	)
 
 	require.NoError(t, err)
@@ -1100,13 +1111,15 @@ func TestRunRemoteSyncRequestMixedRunsSSHFullAfterUnifiedSwap(t *testing.T) {
 	f := newSyncRouteFixture(t)
 	f.writeClaudeSession(t, "proj/local.jsonl", "local swapped before ssh")
 	order := make([]string, 0, 3)
-	prepared := &fakePreparedHTTPRebuild{contributors: []syncpkg.RebuildContributor{{
-		Name: "alpha",
-		AfterSync: func(_ *syncpkg.Engine, database *db.DB) error {
-			order = append(order, "http")
-			return nil
-		},
-	}}}
+	prepared := &fakePreparedHTTPRebuild{options: syncpkg.RebuildOptions{
+		Contributors: []syncpkg.RebuildContributor{{
+			Name: "alpha",
+			AfterSync: func(_ *syncpkg.Engine, database *db.DB) error {
+				order = append(order, "http")
+				return nil
+			},
+		}},
+	}}
 	stubPrepareHTTPRebuild(t, func(
 		context.Context, []remotesync.HTTPSync,
 	) (preparedHTTPRebuild, error) {
@@ -1208,6 +1221,35 @@ func TestRunRemoteSyncRequestRemoteOnlyKeepsActiveHTTPPath(t *testing.T) {
 	assert.Equal(t, 1, activeCalls)
 }
 
+func TestPrepareHTTPRebuildOmitsOfflineHost(t *testing.T) {
+	var progress []syncpkg.Progress
+	prepared, err := prepareHTTPRebuild(
+		context.Background(), []remotesync.HTTPSync{{
+			Host: "offline",
+			URL:  "http://offline.invalid",
+			Client: &http.Client{
+				Transport: offlineRemoteTransport{},
+			},
+			Progress: func(p syncpkg.Progress) {
+				progress = append(progress, p)
+			},
+		}},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+	options, release, err := prepared.BorrowRebuildOptions()
+	require.NoError(t, err)
+	assert.Empty(t, options.Contributors)
+	assert.Equal(t, []string{"offline~"},
+		options.UnavailableContributorIDPrefixes)
+	release()
+	require.NoError(t, prepared.Close())
+	assert.Contains(t, progress, syncpkg.Progress{
+		Detail: "Skipped offline remote host offline",
+	})
+}
+
 func TestRunRemoteSyncRequestIncrementalKeepsActiveHTTPPath(t *testing.T) {
 	f := newSyncRouteFixture(t)
 	prepareCalls := 0
@@ -1236,6 +1278,62 @@ func TestRunRemoteSyncRequestIncrementalKeepsActiveHTTPPath(t *testing.T) {
 	assert.Empty(t, response.Failures)
 	assert.Zero(t, prepareCalls)
 	assert.Equal(t, 1, activeCalls)
+}
+
+func TestRunRemoteSyncRequestConfiguredSkipsOfflineHTTPHost(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	var calls []string
+	stubRunHTTPRemoteSync(t, func(
+		_ context.Context, rh config.RemoteHost, _ bool,
+	) (remotesync.SyncStats, error) {
+		calls = append(calls, rh.Host)
+		if rh.Host == "offline" {
+			return remotesync.SyncStats{}, syscall.ETIMEDOUT
+		}
+		return remotesync.SyncStats{SessionsSynced: 1}, nil
+	})
+	var progress []syncpkg.Progress
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			IncludeLocal: true,
+			Hosts: []config.RemoteHost{
+				{Host: "offline", Transport: config.RemoteTransportHTTP},
+				{Host: "reachable", Transport: config.RemoteTransportHTTP},
+			},
+		},
+		func(p syncpkg.Progress) { progress = append(progress, p) },
+	)
+
+	require.NotNil(t, response.LocalStats)
+	assert.Empty(t, response.Error)
+	assert.Empty(t, response.Failures)
+	assert.Equal(t, []string{"offline", "reachable"}, calls)
+	assert.Contains(t, progress, syncpkg.Progress{
+		Detail: "Skipped offline remote host offline",
+	})
+}
+
+func TestRunRemoteSyncRequestExplicitHostKeepsOfflineFailure(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	stubRunHTTPRemoteSync(t, func(
+		context.Context, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		return remotesync.SyncStats{}, syscall.ETIMEDOUT
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{Hosts: []config.RemoteHost{{
+			Host: "offline", Transport: config.RemoteTransportHTTP,
+		}}}, nil,
+	)
+
+	assert.Empty(t, response.Error)
+	require.Len(t, response.Failures, 1)
+	assert.Equal(t, "offline", response.Failures[0].Host.Host)
+	assert.Contains(t, response.Failures[0].Err, "connection timed out")
 }
 
 func TestRunRemoteSyncRequestAttributesOuterOwnedHTTPCleanup(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2774,8 +2774,14 @@ func (e *Engine) resyncBuildLocked(
 	localOldFileSessions := oldFileSessions
 	rebuildOldFileSessions := oldFileSessions
 	contributorOldFileSessions := make([]int, len(opts.Contributors))
-	if len(opts.Contributors) > 0 {
-		contributorPrefixes := make([]string, 0, len(opts.Contributors))
+	if len(opts.Contributors) > 0 ||
+		len(opts.UnavailableContributorIDPrefixes) > 0 {
+		contributorPrefixes := slices.Clone(
+			opts.UnavailableContributorIDPrefixes,
+		)
+		contributorPrefixes = slices.Grow(
+			contributorPrefixes, len(opts.Contributors),
+		)
 		for _, contributor := range opts.Contributors {
 			if contributor.Config.IDPrefix != "" {
 				contributorPrefixes = append(
@@ -3143,7 +3149,8 @@ func (e *Engine) resyncBuildLocked(
 	}
 
 	localSafetyAbort := false
-	if len(opts.Contributors) > 0 {
+	if len(opts.Contributors) > 0 ||
+		len(opts.UnavailableContributorIDPrefixes) > 0 {
 		// Evaluate local safety after contributors so a contributor's own
 		// cancellation or failure remains the reported abort reason. Trash
 		// copied from the old archive cannot make an empty local pass safe.

--- a/internal/sync/rebuild_contributor.go
+++ b/internal/sync/rebuild_contributor.go
@@ -44,6 +44,10 @@ type RebuildContributor struct {
 // RebuildOptions configures optional sources for an atomic full rebuild.
 type RebuildOptions struct {
 	Contributors []RebuildContributor
+	// UnavailableContributorIDPrefixes identifies configured contributor
+	// namespaces that could not be prepared. Their history is excluded from
+	// rebuild safety expectations and survives through orphan copying.
+	UnavailableContributorIDPrefixes []string
 	// includePhaseDiagnostics is enabled only by the options entrypoint. The
 	// legacy ResyncAll wrapper keeps both returned and in-flight stats free of
 	// options-only diagnostics.

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -209,6 +209,36 @@ func TestResyncAbortsWhenContributorLosesHistoricalSource(t *testing.T) {
 	assert.NotNil(t, remote, "aborted rebuild must preserve the active archive")
 }
 
+func TestResyncPreservesAllOfflineRemoteHistoryAsOrphans(t *testing.T) {
+	localRoot := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	missingPath := filepath.Join(t.TempDir(), "offline-session.jsonl")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "offline~session", Project: "archive", Machine: "offline",
+		Agent: "claude", FilePath: &missingPath, MessageCount: 1,
+	}))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {localRoot}},
+		Machine:   "collector",
+	})
+	t.Cleanup(engine.Close)
+
+	stats, err := engine.ResyncAllWithOptions(
+		context.Background(), nil, RebuildOptions{
+			UnavailableContributorIDPrefixes: []string{"offline~"},
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted, "offline contributor history is not local safety loss")
+	assert.Equal(t, 1, stats.OrphanedCopied)
+	preserved, err := database.GetSession(context.Background(), "offline~session")
+	require.NoError(t, err)
+	assert.NotNil(t, preserved, "offline remote history must survive as an orphan")
+}
+
 func TestResyncAbortsWhenLabeledLocalSourceDisappearsAlongsideHealthyContributor(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Configured HTTP fleet members that cannot be reached—or that reset or abort an
established connection—no longer make a bare `agentsview sync` fail. The
collector reports each host as skipped and continues with local and reachable
remote sources.

Full and automatic rebuilds retain skipped host namespaces in safety
accounting, so an all-offline remote-only archive completes and preserves its
remote sessions as orphans. Direct incremental syncs emit the same skipped-host
progress message instead of succeeding silently.

Explicit `agentsview sync --host X` remains strict. Authentication, protocol,
response, cleanup, and import errors also remain failures, so only transport
unavailability receives the optional-host behavior.
