### PR TITLE
fix(activity): show complete compact timeline metrics

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -158,7 +158,9 @@ add an archived or maintained mirror without replacing the original identity.
   its frozen first-seen, token-only semantics. Reverified 2026-08-06 that
   DuckDB records a web-search-only flat fee as computed pricing provenance, so
   combining it with a provider-reported cost is labeled `mixed` like the
-  SQLite archive.
+  SQLite archive. Reverified 2026-08-22 that activity buckets carry the
+  selected Claude input-token snapshots identically across SQLite, PostgreSQL,
+  and DuckDB.
 - **Agentsview:** `internal/parser/claude.go` and
   `internal/parser/claude_provider.go`; local observations and fixtures are
   the implementation evidence for fields not documented upstream. Reverified

--- a/frontend/src/lib/api/generated/models/ActivityBucket.ts
+++ b/frontend/src/lib/api/generated/models/ActivityBucket.ts
@@ -8,9 +8,9 @@ export type ActivityBucket = {
   automated_at_peak: number;
   cost: MoneyMoney;
   end: string;
+  input_tokens?: number;
   interactive_at_peak: number;
   max_agents: number;
   output_tokens: number;
   start: string;
 };
-

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -37,7 +37,7 @@
     (report.buckets ?? []) as ActivityBucket[],
   );
 
-  let tooltip = $state<{ x: number; y: number; text: string } | null>(null);
+  let tooltip = $state<{ x: number; y: number; bucket: ActivityBucket } | null>(null);
   let keyboardAnchorIndex = $state<number | null>(null);
 
   // Format bucket boundaries in the report's own timezone. Bucket start/end are
@@ -101,21 +101,10 @@
   // agent was running at the peak.
   function showSlotTip(e: MouseEvent, b: ActivityBucket) {
     const rect = (e.currentTarget as Element).getBoundingClientRect();
-    const peakSplit =
-      b.automated_at_peak > 0
-        ? ` (${m.activity_int_auto_short({ int: b.interactive_at_peak, auto: b.automated_at_peak })})`
-        : "";
     tooltip = {
       x: rect.left + rect.width / 2,
       y: rect.top - 4,
-      text:
-        `${fmtBucketRange(b)} · ${m.activity_peak_label({ count: b.max_agents })}${peakSplit} · ` +
-        `${m.activity_agent_min_value({ value: b.agent_minutes.toFixed(1) })} · ` +
-        `${m.activity_output_tokens_value({
-          count: b.output_tokens,
-          countLabel: b.output_tokens.toLocaleString(getLocale()),
-        })} · ` +
-        formatMoney(b.cost),
+      bucket: b,
     };
   }
 
@@ -270,6 +259,22 @@
     if (abs >= 1_000) return `${trimDecimal(v / 1_000, 1)}k`;
     if (Number.isInteger(v)) return String(v);
     return trimDecimal(v, 1);
+  }
+
+  function fmtCompactValue(v: number): string {
+    return new Intl.NumberFormat(getLocale(), {
+      notation: "compact",
+      compactDisplay: "short",
+      maximumFractionDigits: 1,
+    }).format(v);
+  }
+
+  function peakValue(b: ActivityBucket): string {
+    if (b.automated_at_peak === 0) return String(b.max_agents);
+    return `${b.max_agents} (${m.activity_int_auto_short({
+      int: b.interactive_at_peak,
+      auto: b.automated_at_peak,
+    })})`;
   }
 
   function fmtOverlayTick(v: number): string {
@@ -734,7 +739,29 @@
 
     {#if tooltip}
       <div class="tooltip" style="left: {tooltip.x}px; top: {tooltip.y}px;">
-        {tooltip.text}
+        <div class="tooltip-date">{fmtBucketRange(tooltip.bucket)}</div>
+        <dl class="tooltip-metrics">
+          <div>
+            <dt>{m.activity_peak_concurrency()}</dt>
+            <dd>{peakValue(tooltip.bucket)}</dd>
+          </div>
+          <div>
+            <dt>{m.activity_agent_min()}</dt>
+            <dd>{fmtCompactValue(tooltip.bucket.agent_minutes)}</dd>
+          </div>
+          <div>
+            <dt>{m.usage_input_tokens()}</dt>
+            <dd>{fmtCompactValue(tooltip.bucket.input_tokens ?? 0)}</dd>
+          </div>
+          <div>
+            <dt>{m.usage_output_tokens()}</dt>
+            <dd>{fmtCompactValue(tooltip.bucket.output_tokens)}</dd>
+          </div>
+          <div>
+            <dt>{m.activity_cost()}</dt>
+            <dd>{formatMoney(tooltip.bucket.cost)}</dd>
+          </div>
+        </dl>
       </div>
     {/if}
   </div>
@@ -930,13 +957,44 @@
   .tooltip {
     position: fixed;
     transform: translateX(-50%) translateY(-100%);
-    padding: 4px 8px;
+    min-width: 168px;
+    padding: 8px 10px;
     background: var(--text-primary);
     color: var(--bg-primary);
-    font-size: 10px;
+    font-size: 11px;
     border-radius: var(--radius-sm);
     white-space: nowrap;
     pointer-events: none;
     z-index: var(--z-tooltip);
+  }
+
+  .tooltip-date {
+    padding-bottom: 6px;
+    border-bottom: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+    font-weight: 600;
+  }
+
+  .tooltip-metrics {
+    display: grid;
+    gap: 4px;
+    margin: 6px 0 0;
+  }
+
+  .tooltip-metrics > div {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 16px;
+    align-items: baseline;
+  }
+
+  .tooltip-metrics dt {
+    opacity: 0.7;
+  }
+
+  .tooltip-metrics dd {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-weight: 600;
+    text-align: right;
   }
 </style>

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
@@ -41,6 +41,7 @@ function makeReport(overrides: Partial<Report> = {}): Report {
       end: "2026-06-16T09:00:00Z",
       max_agents: 3,
       agent_minutes: 30,
+      input_tokens: 120000,
       output_tokens: 9000,
       cost: testMoney(0.9),
       interactive_at_peak: 2,
@@ -352,7 +353,7 @@ describe("ConcurrencyTimeline", () => {
     await tick();
     const tip = target.querySelector(".tooltip");
     expect(tip).toBeTruthy();
-    expect(tip!.textContent).toContain("peak 3");
+    expect(tip!.querySelector(".tooltip-metrics > div")?.textContent).toContain("Peak Concurrency");
     hit.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
     await tick();
     expect(target.querySelector(".tooltip")).toBeNull();
@@ -360,20 +361,26 @@ describe("ConcurrencyTimeline", () => {
     target.remove();
   });
 
-  it("labels the token count as output and surfaces cost in the tooltip", async () => {
+  it("shows structured compact metrics with cost in the tooltip", async () => {
     const target = document.createElement("div");
     document.body.appendChild(target);
-    const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
+    const report = makeReport();
+    report.buckets![2]!.agent_minutes = 7500;
+    const c = mount(ConcurrencyTimeline, { target, props: { report } });
     await tick();
-    const hit = target.querySelectorAll(".slot-hit")[2] as SVGRectElement; // 9000 tokens, $0.90
+    const hit = target.querySelectorAll(".slot-hit")[2] as SVGRectElement;
     hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
     await tick();
     const tip = target.querySelector(".tooltip");
     expect(tip).toBeTruthy();
-    // Disambiguates input vs output tokens and shows the overlay's cost value.
-    expect(tip!.textContent).toContain("output tokens");
-    expect(tip!.textContent).toContain("9,000");
-    expect(tip!.textContent).toContain("$0.90");
+    const rows = Array.from(tip!.querySelectorAll(".tooltip-metrics > div"));
+    expect(rows.map((row) => row.textContent?.replace(/\s+/g, " ").trim())).toEqual([
+      "Peak Concurrency 3 (2 int / 1 auto)",
+      "Agent-min 7.5K",
+      "Input Tokens 120K",
+      "Output Tokens 9K",
+      "Cost $0.90",
+    ]);
     unmount(c);
     target.remove();
   });
@@ -387,9 +394,12 @@ describe("ConcurrencyTimeline", () => {
     hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
     await tick();
     const tip = target.querySelector(".tooltip");
-    expect(tip!.textContent).toContain("peak 3 (2 int / 1 auto)");
+    const rows = tip!.querySelectorAll(".tooltip-metrics > div");
+    expect(rows[0]!.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      "Peak Concurrency 3 (2 int / 1 auto)",
+    );
     // agent-minutes stays a single combined figure, not split by automation.
-    expect(tip!.textContent).toContain("30.0 agent-min");
+    expect(rows[1]!.textContent?.replace(/\s+/g, " ").trim()).toBe("Agent-min 30");
     unmount(c);
     target.remove();
   });
@@ -403,8 +413,8 @@ describe("ConcurrencyTimeline", () => {
     hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
     await tick();
     const tip = target.querySelector(".tooltip");
-    expect(tip!.textContent).toContain("peak 1");
-    expect(tip!.textContent).not.toContain("int /");
+    const peakRow = tip!.querySelector(".tooltip-metrics > div");
+    expect(peakRow?.textContent?.replace(/\s+/g, " ").trim()).toBe("Peak Concurrency 1");
     unmount(c);
     target.remove();
   });

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -274,6 +274,7 @@ type Bucket struct {
 	End          string      `json:"end"`
 	MaxAgents    int         `json:"max_agents"`
 	AgentMinutes float64     `json:"agent_minutes"`
+	InputTokens  int         `json:"input_tokens,omitempty"`
 	OutputTokens int         `json:"output_tokens"`
 	Cost         money.Money `json:"cost"`
 	// Automated/interactive split of the concurrency peak: the live automated
@@ -887,8 +888,8 @@ func dedupUsage(start, end, effEnd time.Time, usage []UsageRow) []UsageRow {
 	return out
 }
 
-// applyUsage dedups usage rows to the range, then accumulates output tokens
-// and cost into r.Totals and the window whose [Start, End) contains each row's
+// applyUsage dedups usage rows to the range, then accumulates tokens and cost
+// into r.Totals and the window whose [Start, End) contains each row's
 // timestamp.
 func applyUsage(r *Report, p Params, windows []BucketWindow, start, end time.Time,
 	usage []UsageRow, automatedBy map[string]bool) error {
@@ -926,6 +927,7 @@ func applyUsageRows(
 		}
 		t, _ := parseTS(u.Timestamp)
 		if b := windowIndex(windows, t); b >= 0 && b < len(r.Buckets) {
+			r.Buckets[b].InputTokens += u.InputTokens
 			r.Buckets[b].OutputTokens += u.OutputTokens
 			r.Buckets[b].Cost, err = money.Add(
 				r.Buckets[b].Cost, allocated[i].Cost,

--- a/internal/activity/usage_test.go
+++ b/internal/activity/usage_test.go
@@ -25,11 +25,11 @@ func TestApplyUsage_DedupAndDayFilter(t *testing.T) {
 	// the range is dropped without claiming a key.
 	usage := []UsageRow{
 		{SessionID: "a", Model: "m1", Timestamp: "2026-06-16T10:00:00Z",
-			OutputTokens: 100, Cost: money.MustParseDollars("1.0"), ClaudeMessageID: "x", ClaudeRequestID: "r"},
+			InputTokens: 1000, OutputTokens: 100, Cost: money.MustParseDollars("1.0"), ClaudeMessageID: "x", ClaudeRequestID: "r"},
 		{SessionID: "a", Model: "m1", Timestamp: "2026-06-16T10:00:00Z",
-			OutputTokens: 100, Cost: money.MustParseDollars("1.0"), ClaudeMessageID: "x", ClaudeRequestID: "r"},
+			InputTokens: 1000, OutputTokens: 100, Cost: money.MustParseDollars("1.0"), ClaudeMessageID: "x", ClaudeRequestID: "r"},
 		{SessionID: "a", Model: "m1", Timestamp: "2026-06-15T23:00:00Z",
-			OutputTokens: 999, Cost: money.MustParseDollars("9.0"), UsageDedupKey: "k-out"},
+			InputTokens: 9999, OutputTokens: 999, Cost: money.MustParseDollars("9.0"), UsageDedupKey: "k-out"},
 	}
 	start := mustStart(t, "2026-06-16T00:00:00Z")
 	end := mustStart(t, "2026-06-17T00:00:00Z")
@@ -43,6 +43,7 @@ func TestApplyUsage_DedupAndDayFilter(t *testing.T) {
 	assert.Equal(t, money.MustParseDollars("1.0"), r.Totals.InteractiveCost)
 	assert.Equal(t, money.MustParseDollars("0.0"), r.Totals.AutomatedCost)
 	// 10:00 UTC -> bucket 120 (10*12).
+	assert.Equal(t, 1000, r.Buckets[120].InputTokens)
 	assert.Equal(t, 100, r.Buckets[120].OutputTokens)
 	assert.Equal(t, money.MustParseDollars("1.0"), r.Buckets[120].Cost)
 }

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -40,6 +40,10 @@ type RunOptions struct {
 	AgentsViewVersion string
 }
 
+type captureHooks struct {
+	afterPersistedSources func()
+}
+
 type ReportOptions struct {
 	CaptureDir        string
 	ResultPath        string
@@ -159,6 +163,14 @@ func resolveWorkDir(dir string) (string, error) {
 }
 
 func Run(ctx context.Context, opts RunOptions) (RunOutcome, error) {
+	return runWithHooks(ctx, opts, nil)
+}
+
+func runWithHooks(
+	ctx context.Context,
+	opts RunOptions,
+	hooks *captureHooks,
+) (RunOutcome, error) {
 	prepared, err := prepareRun(opts)
 	if err != nil {
 		return RunOutcome{}, err
@@ -193,6 +205,9 @@ func Run(ctx context.Context, opts RunOptions) (RunOutcome, error) {
 	})
 	if err != nil {
 		return RunOutcome{}, err
+	}
+	if hooks != nil {
+		state.afterPersistedSources = hooks.afterPersistedSources
 	}
 	defer state.close()
 	if err := invalidateResult(prepared.resultPath); err != nil {
@@ -565,6 +580,11 @@ func finalize(
 				continue
 			}
 			return captureFailure(state, err, agentsViewVersion)
+		}
+		if state.afterPersistedSources != nil {
+			afterPersistedSources := state.afterPersistedSources
+			state.afterPersistedSources = nil
+			afterPersistedSources()
 		}
 		ingested, err := ingest(
 			finalCtx, state, persisted.Paths, persisted.Snapshots,

--- a/internal/capture/capture_integration_test.go
+++ b/internal/capture/capture_integration_test.go
@@ -1928,8 +1928,10 @@ func TestClaudeCaptureRetryDropsRemovedSubagentUsage(t *testing.T) {
 		err     error
 	}
 	done := make(chan runResponse, 1)
+	persisted := make(chan struct{})
+	release := make(chan struct{}, 1)
 	go func() {
-		outcome, runErr := Run(context.Background(), RunOptions{
+		outcome, runErr := runWithHooks(context.Background(), RunOptions{
 			Provider: ProviderClaude, OccurrenceID: "subagent-removed",
 			CaptureDir: captureDir, ResultPath: resultPath,
 			ProviderRoot: root, WorkDir: workDir,
@@ -1937,24 +1939,35 @@ func TestClaudeCaptureRetryDropsRemovedSubagentUsage(t *testing.T) {
 			Environment: helperEnvironment(root, "claude-subagent", 0),
 			Streams:     Streams{Stdout: io.Discard, Stderr: io.Discard},
 			Limits:      testLimits(), CustomPricing: testPricing(),
+		}, &captureHooks{
+			afterPersistedSources: func() {
+				close(persisted)
+				<-release
+			},
 		})
 		done <- runResponse{outcome: outcome, err: runErr}
 	}()
+	t.Cleanup(func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	})
 
-	var sessionID string
-	require.Eventually(t, func() bool {
-		data, readErr := os.ReadFile(filepath.Join(captureDir, manifestFileName))
-		if readErr != nil {
-			return false
-		}
-		var captured manifest
-		if json.Unmarshal(data, &captured) != nil || captured.SourcesComplete ||
-			len(captured.Sources) == 0 {
-			return false
-		}
-		sessionID = captured.ProviderSessionID
-		return sessionID != ""
-	}, 20*time.Second, time.Millisecond)
+	select {
+	case <-persisted:
+	case response := <-done:
+		require.NoError(t, response.err)
+		require.Fail(t, "capture completed before persisting its source set")
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "capture did not persist its source set")
+	}
+	data, err := os.ReadFile(filepath.Join(captureDir, manifestFileName))
+	require.NoError(t, err)
+	var captured manifest
+	require.NoError(t, json.Unmarshal(data, &captured))
+	sessionID := captured.ProviderSessionID
+	require.NotEmpty(t, sessionID)
 
 	rootPath := filepath.Join(root, encodeClaudeWorkDir(physicalWorkDir), sessionID+".jsonl")
 	rootData := []byte(strings.Join(
@@ -1962,21 +1975,13 @@ func TestClaudeCaptureRetryDropsRemovedSubagentUsage(t *testing.T) {
 	require.NoError(t, os.WriteFile(rootPath, rootData, 0o600))
 	childPath := filepath.Join(
 		strings.TrimSuffix(rootPath, ".jsonl"), "subagents", "agent-abc123.jsonl")
-	require.Eventually(t, func() bool {
-		data, readErr := os.ReadFile(filepath.Join(captureDir, manifestFileName))
-		if readErr != nil {
-			return false
-		}
-		var captured manifest
-		return json.Unmarshal(data, &captured) == nil &&
-			!captured.SourcesComplete && len(captured.Sources) == 2
-	}, 20*time.Second, time.Millisecond)
 	require.NoError(t, os.Rename(childPath, filepath.Join(t.TempDir(), "removed.jsonl")))
+	release <- struct{}{}
 
 	response := <-done
 	require.NoError(t, response.err)
 	assert.Zero(t, response.outcome.ExitCode)
-	data, err := os.ReadFile(resultPath)
+	data, err = os.ReadFile(resultPath)
 	require.NoError(t, err)
 	result, err := DecodeResult(bytes.NewReader(data))
 	require.NoError(t, err)

--- a/internal/capture/state.go
+++ b/internal/capture/state.go
@@ -93,11 +93,12 @@ type manifest struct {
 }
 
 type captureState struct {
-	dir                  string
-	lock                 *flock.Flock
-	createdInfo          os.FileInfo
-	manifest             manifest
-	finalizationDeadline time.Time
+	dir                   string
+	lock                  *flock.Flock
+	createdInfo           os.FileInfo
+	manifest              manifest
+	finalizationDeadline  time.Time
+	afterPersistedSources func()
 }
 
 func createState(dir string, m manifest) (*captureState, error) {

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -882,6 +882,7 @@ func (s *Store) activityReportUsage(
 				SessionID:         r.sessionID,
 				Model:             r.model,
 				Timestamp:         tsStr,
+				InputTokens:       r.inputTok,
 				OutputTokens:      r.outputTok,
 				WebSearchRequests: r.webSearchRequests,
 				Agent:             r.agent,

--- a/internal/duckdb/activityreport_test.go
+++ b/internal/duckdb/activityreport_test.go
@@ -332,6 +332,8 @@ func TestDuckGetActivityReportUsageCostAndTokens(t *testing.T) {
 		duckDayQuery(t, "2026-06-14", "UTC"))
 	require.NoError(t, err)
 	assert.Equal(t, 1, r.Totals.Sessions)
+	require.Len(t, r.Buckets, 288)
+	assert.Equal(t, 1000, r.Buckets[126].InputTokens)
 	assert.Equal(t, 500, r.Totals.OutputTokens)
 	// Cost = (1000*3 + 500*15) / 1e6 = 0.0105
 	assert.Equal(t, money.MustParseDollars("0.0105"), r.Totals.Cost)

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -881,7 +881,7 @@ func (s *Store) activityReportUsage(
 	baseRows := make([]activity.UsageRow, len(rowsAcc))
 	for i, o := range rowsAcc {
 		row := o.row
-		_, row.OutputTokens, _, _, _ = pgDailyUsageRowTokens(o.scan)
+		row.InputTokens, row.OutputTokens, _, _, _ = pgDailyUsageRowTokens(o.scan)
 		row.WebSearchRequests = pgUsageRowWebSearchRequests(
 			o.scan.usageSource, o.scan.tokenJSON)
 		baseRows[i] = row
@@ -895,7 +895,7 @@ func (s *Store) activityReportUsage(
 		if !mask[i] {
 			continue
 		}
-		_, outputTok, _, _, _ := pgDailyUsageRowTokens(o.scan)
+		inputTok, outputTok, _, _, _ := pgDailyUsageRowTokens(o.scan)
 		costRow := o.scan
 		var sessionCost *money.Money
 		if o.scan.costSource == db.CopilotReportedCostSource && o.scan.cost.Valid {
@@ -916,6 +916,7 @@ func (s *Store) activityReportUsage(
 		}
 		row := o.row
 		row.SessionID = attribution[i]
+		row.InputTokens = inputTok
 		row.OutputTokens = outputTok
 		row.WebSearchRequests = webSearchRequests[i]
 		row.Cost = cost

--- a/internal/postgres/activityreport_pgtest_test.go
+++ b/internal/postgres/activityreport_pgtest_test.go
@@ -147,7 +147,7 @@ func TestPGGetActivityReportOpenSessionWithInRangeMessageIncluded(t *testing.T) 
 
 // TestPGGetActivityReportUsageCostAndTokens exercises the PG usage
 // union + cost path: a single priced assistant message must surface
-// its output tokens and computed cost in the day totals, matching
+// its input and output tokens and computed cost in the day totals, matching
 // the SQLite reference behavior.
 func TestPGGetActivityReportUsageCostAndTokens(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_daily_report_usage_test")
@@ -186,6 +186,8 @@ func TestPGGetActivityReportUsageCostAndTokens(t *testing.T) {
 		pgDayQuery(t, "2026-06-16", "UTC"))
 	require.NoError(t, err)
 	assert.Equal(t, 1, r.Totals.Sessions)
+	require.Len(t, r.Buckets, 288)
+	assert.Equal(t, 1000, r.Buckets[126].InputTokens)
 	assert.Equal(t, 500, r.Totals.OutputTokens)
 	// Cost = (1000*3 + 500*15) / 1e6 = 0.0105
 	assert.Equal(t, money.MustParseDollars("0.0105"), r.Totals.Cost)

--- a/testdata/golden/activity_report_v6.json
+++ b/testdata/golden/activity_report_v6.json
@@ -109,6 +109,7 @@
       "end": "2026-07-03T11:00:00Z",
       "max_agents": 1,
       "agent_minutes": 3,
+      "input_tokens": 1200,
       "output_tokens": 240,
       "cost": {
         "microdollars": 4760
@@ -121,6 +122,7 @@
       "end": "2026-07-03T12:00:00Z",
       "max_agents": 1,
       "agent_minutes": 3,
+      "input_tokens": 300,
       "output_tokens": 60,
       "cost": {
         "microdollars": 12500
@@ -133,6 +135,7 @@
       "end": "2026-07-03T13:00:00Z",
       "max_agents": 0,
       "agent_minutes": 0,
+      "input_tokens": 0,
       "output_tokens": 0,
       "cost": {
         "microdollars": 0


### PR DESCRIPTION
The Activity concurrency tooltip now shows input and output token usage in aligned label/value rows. Large token and agent-minute values use locale-aware compact notation, so buckets remain easy to scan while peak concurrency and cost keep their natural precision.

Input tokens now flow through the activity aggregation into each timeline bucket on SQLite, PostgreSQL, and DuckDB. The token overlay remains output-token based.

Capture retry coverage now pauses at the persisted-source boundary instead of polling a transient manifest state, so slow Windows scheduling cannot miss the state that the test needs to exercise.

![Activity concurrency tooltip with aligned compact metrics](https://github.com/user-attachments/assets/23877773-f50f-43f8-ae3e-cf1b71f83a77)