### PR TITLE
feat(rawsync): add resumable object uploads

### DIFF
--- a/cmd/agentsview/pg_raw_sync.go
+++ b/cmd/agentsview/pg_raw_sync.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"sync"
 	"time"
@@ -57,8 +58,17 @@ func preparePGRawSyncServices(
 		limits:   rawsync.DefaultManifestLimits(),
 		version:  fmt.Sprintf("parser-data-%d", db.CurrentDataVersion()),
 	}
-
-	return server.WithRawSyncServices(auth, custody), custody.Close, nil
+	uploadOption, closeUploads, err := preparePGRawSyncUploads(
+		dataDir, database, custody,
+	)
+	if err != nil {
+		return nil, nil, errors.Join(err, custody.Close())
+	}
+	return combinePGRawSyncOptions(
+			server.WithRawSyncServices(auth, custody), uploadOption,
+		), func() error {
+			return errors.Join(closeUploads(), custody.Close())
+		}, nil
 }
 
 // pgRawSyncCustody keeps ordinary pg serve startup independent from the local
@@ -88,6 +98,20 @@ func (c *pgRawSyncCustody) MissingObjects(
 		return nil, err
 	}
 	return service.MissingObjects(ctx, identity, provider, objects)
+}
+
+func (c *pgRawSyncCustody) FinalizeObject(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	provider parser.AgentType,
+	object rawsync.ObjectRef,
+	body io.Reader,
+) (rawsync.PutResult, error) {
+	service, err := c.openService(ctx)
+	if err != nil {
+		return rawsync.PutResult{}, err
+	}
+	return service.FinalizeObject(ctx, identity, provider, object, body)
 }
 
 func (c *pgRawSyncCustody) CommitManifest(
@@ -143,4 +167,33 @@ func (c *pgRawSyncCustody) Close() error {
 		return nil
 	}
 	return c.repository.Close()
+}
+
+func preparePGRawSyncUploads(
+	dataDir string,
+	database *sql.DB,
+	custody rawsync.UploadCustody,
+) (server.Option, func() error, error) {
+	uploadStore, err := postgres.NewRawUploadStore(database, dataDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("preparing raw upload session store: %w", err)
+	}
+	uploads, err := rawsync.NewUploadService(
+		uploadStore, custody, rawsync.DefaultUploadSessionTTL,
+	)
+	if err != nil {
+		return nil, nil, errors.Join(
+			fmt.Errorf("preparing raw upload service: %w", err),
+			uploadStore.Close(),
+		)
+	}
+	return server.WithRawSyncUploads(uploads), uploadStore.Close, nil
+}
+
+func combinePGRawSyncOptions(options ...server.Option) server.Option {
+	return func(target *server.Server) {
+		for _, option := range options {
+			option(target)
+		}
+	}
 }

--- a/cmd/agentsview/pg_raw_sync_test.go
+++ b/cmd/agentsview/pg_raw_sync_test.go
@@ -1,49 +1,36 @@
 package main
 
 import (
+	"context"
 	"database/sql"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
+	"database/sql/driver"
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/server"
 )
 
 func TestPreparePGRawSyncServicesRegistersHostedRoutes(t *testing.T) {
 	t.Parallel()
 
-	option, cleanup, err := preparePGRawSyncServices(
-		t.Context(), t.TempDir(), new(sql.DB),
-	)
+	database := newEmptyRawUploadTestDB(t)
+	option, cleanup, err := preparePGRawSyncServices(t.Context(), t.TempDir(), database)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, cleanup()) })
 
-	srv := server.New(config.Config{
-		Host:         "127.0.0.1",
-		Port:         8080,
-		WriteTimeout: time.Second,
-	}, nil, nil, option)
-	req := httptest.NewRequest(http.MethodGet, "/api/openapi.json", nil)
-	req.Host = "127.0.0.1:8080"
-	recorder := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(recorder, req)
-	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
-	var spec struct {
-		Paths map[string]json.RawMessage `json:"paths"`
-	}
-	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &spec))
+	spec := server.OpenAPISpec(server.VersionInfo{}, option)
 	for _, path := range []string{
 		"/api/v1/raw-sync/tokens",
 		"/api/v1/raw-sync/objects/missing",
 		"/api/v1/raw-sync/manifests",
+		"/api/v1/raw-sync/uploads",
+		"/api/v1/raw-sync/uploads/{upload_id}",
 	} {
 		assert.Contains(t, spec.Paths, path)
 	}
@@ -69,7 +56,7 @@ func TestPreparePGRawSyncServicesDoesNotOpenArtifactSyncRepository(t *testing.T)
 	require.NoError(t, os.WriteFile(repositoryPath, []byte("occupied"), 0o600))
 
 	_, cleanup, err := preparePGRawSyncServices(
-		t.Context(), dataDir, new(sql.DB),
+		t.Context(), dataDir, newEmptyRawUploadTestDB(t),
 	)
 	require.NoError(t, err)
 	require.NoError(t, cleanup())
@@ -83,8 +70,55 @@ func TestPreparePGRawSyncServicesDefersRawRepositoryOpen(t *testing.T) {
 	require.NoError(t, os.WriteFile(repositoryParent, []byte("occupied"), 0o600))
 
 	_, cleanup, err := preparePGRawSyncServices(
-		t.Context(), dataDir, new(sql.DB),
+		t.Context(), dataDir, newEmptyRawUploadTestDB(t),
 	)
 	require.NoError(t, err)
 	require.NoError(t, cleanup())
 }
+
+var registerEmptyRawUploadDriver sync.Once
+
+func newEmptyRawUploadTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	registerEmptyRawUploadDriver.Do(func() {
+		sql.Register("empty-raw-upload-cleanup", emptyRawUploadDriver{})
+	})
+	database, err := sql.Open("empty-raw-upload-cleanup", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	return database
+}
+
+type emptyRawUploadDriver struct{}
+
+func (emptyRawUploadDriver) Open(string) (driver.Conn, error) {
+	return emptyRawUploadConnection{}, nil
+}
+
+type emptyRawUploadConnection struct{}
+
+func (emptyRawUploadConnection) Prepare(string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (emptyRawUploadConnection) Close() error { return nil }
+
+func (emptyRawUploadConnection) Begin() (driver.Tx, error) { return nil, driver.ErrSkip }
+
+func (emptyRawUploadConnection) QueryContext(
+	context.Context,
+	string,
+	[]driver.NamedValue,
+) (driver.Rows, error) {
+	return emptyRawUploadRows{}, nil
+}
+
+type emptyRawUploadRows struct{}
+
+func (emptyRawUploadRows) Columns() []string { return []string{"upload_id"} }
+
+func (emptyRawUploadRows) Close() error { return nil }
+
+func (emptyRawUploadRows) Next([]driver.Value) error { return io.EOF }
+
+var _ driver.QueryerContext = emptyRawUploadConnection{}

--- a/frontend/scripts/generate-api-client.mjs
+++ b/frontend/scripts/generate-api-client.mjs
@@ -57,6 +57,164 @@ function preserveExplicitAuthorizationHeaders() {
   writeFileSync(requestPath, source.replace(generatedAuth, explicitHeaderFirst));
 }
 
+function preserveStructuredResponseHeaders() {
+  const optionsPath = join(frontendDir, "src/lib/api/generated/core/ApiRequestOptions.ts");
+  const optionsSource = readFileSync(optionsPath, "utf8");
+  const generatedOption = "  readonly responseHeader?: string;\n";
+  const structuredOption = `  readonly responseHeader?: string;
+  readonly responseHeaders?: Record<string, {
+    readonly name: string;
+    readonly type: 'string' | 'number' | 'boolean';
+  }>;
+`;
+  if (!optionsSource.includes(generatedOption)) {
+    throw new Error("generated request options no longer match the response-header patch");
+  }
+  writeFileSync(optionsPath, optionsSource.replace(generatedOption, structuredOption));
+
+  const requestPath = join(frontendDir, "src/lib/api/generated/core/request.ts");
+  let requestSource = readFileSync(requestPath, "utf8");
+  const generatedHeaderReader = `export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
+  if (responseHeader) {
+    const content = response.headers.get(responseHeader);
+    if (isString(content)) {
+      return content;
+    }
+  }
+  return undefined;
+};
+`;
+  const structuredHeaderReader = `${generatedHeaderReader}
+export const getResponseHeaders = (
+  response: Response,
+  responseHeaders?: ApiRequestOptions['responseHeaders'],
+): Record<string, string | number | boolean> | undefined => {
+  if (!responseHeaders) return undefined;
+  return Object.fromEntries(Object.entries(responseHeaders).map(([property, option]) => {
+    const content = response.headers.get(option.name);
+    if (content === null) throw new Error(\`Response header \${option.name} is missing\`);
+    switch (option.type) {
+      case 'number': {
+        const value = Number(content);
+        if (!Number.isFinite(value)) {
+          throw new Error(\`Response header \${option.name} is not a number\`);
+        }
+        return [property, value];
+      }
+      case 'boolean':
+        if (content === 'true') return [property, true];
+        if (content === 'false') return [property, false];
+        throw new Error(\`Response header \${option.name} is not a boolean\`);
+      default:
+        return [property, content];
+    }
+  }));
+};
+`;
+  if (!requestSource.includes(generatedHeaderReader)) {
+    throw new Error("generated request helper no longer matches the response-header patch");
+  }
+  requestSource = requestSource.replace(generatedHeaderReader, structuredHeaderReader);
+  const generatedResponseRead = `        const responseBody = await getResponseBody(response);
+        const responseHeader = getResponseHeader(response, options.responseHeader);
+
+        const result: ApiResult = {
+          url,
+          ok: response.ok,
+          status: response.status,
+          statusText: response.statusText,
+          body: responseHeader ?? responseBody,
+        };
+`;
+  const structuredResponseRead = `        const responseBody = await getResponseBody(response);
+        const responseHeader = getResponseHeader(response, options.responseHeader);
+        const responseHeaders = response.ok
+          ? getResponseHeaders(response, options.responseHeaders)
+          : undefined;
+
+        const result: ApiResult = {
+          url,
+          ok: response.ok,
+          status: response.status,
+          statusText: response.statusText,
+          body: responseHeaders ?? responseHeader ?? responseBody,
+        };
+`;
+  if (!requestSource.includes(generatedResponseRead)) {
+    throw new Error("generated request flow no longer matches the response-header patch");
+  }
+  writeFileSync(requestPath, requestSource.replace(generatedResponseRead, structuredResponseRead));
+}
+
+function preserveRawSyncUploadStatusResponse() {
+  const modelName = "RawSyncUploadStatusResponse";
+  const modelPath = join(frontendDir, `src/lib/api/generated/models/${modelName}.ts`);
+  writeFileSync(modelPath, `/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ${modelName} = {
+  offset: number;
+  length: number;
+  complete: boolean;
+};
+`);
+
+  const indexPath = join(frontendDir, "src/lib/api/generated/index.ts");
+  const indexSource = readFileSync(indexPath, "utf8");
+  const responseExport = "export type { RawSyncUploadResponse } from './models/RawSyncUploadResponse';\n";
+  if (!indexSource.includes(responseExport)) {
+    throw new Error("generated API index no longer matches the raw upload status patch");
+  }
+  writeFileSync(
+    indexPath,
+    indexSource.replace(
+      responseExport,
+      `${responseExport}export type { ${modelName} } from './models/${modelName}';\n`,
+    ),
+  );
+
+  const servicePath = join(frontendDir, "src/lib/api/generated/services/RawSyncService.ts");
+  let serviceSource = readFileSync(servicePath, "utf8");
+  const responseImport =
+    "import type { RawSyncUploadResponse } from '../models/RawSyncUploadResponse';\n";
+  if (!serviceSource.includes(responseImport)) {
+    throw new Error("generated raw sync imports no longer match the upload status patch");
+  }
+  serviceSource = serviceSource.replace(
+    responseImport,
+    `${responseImport}import type { ${modelName} } from '../models/${modelName}';\n`,
+  );
+  const statusStart = serviceSource.indexOf("   * Read a raw upload offset");
+  const statusEnd = serviceSource.indexOf("  /**", statusStart + 1);
+  if (statusStart < 0 || statusEnd < 0) {
+    throw new Error("generated raw upload status method was not found");
+  }
+  let statusMethod = serviceSource.slice(statusStart, statusEnd);
+  const generatedDocumentation = "   * @returns string OK";
+  const generatedReturn = "  }): CancelablePromise<string> {";
+  const generatedHeader = "      responseHeader: 'Upload-Complete',";
+  if (
+    !statusMethod.includes(generatedDocumentation) ||
+    !statusMethod.includes(generatedReturn) ||
+    !statusMethod.includes(generatedHeader)
+  ) {
+    throw new Error("generated raw upload status method no longer matches the header patch");
+  }
+  statusMethod = statusMethod
+    .replace(generatedDocumentation, `   * @returns ${modelName} OK`)
+    .replace(generatedReturn, `  }): CancelablePromise<${modelName}> {`)
+    .replace(generatedHeader, `      responseHeaders: {
+        offset: { name: 'Upload-Offset', type: 'number' },
+        length: { name: 'Upload-Length', type: 'number' },
+        complete: { name: 'Upload-Complete', type: 'boolean' },
+      },`);
+  writeFileSync(
+    servicePath,
+    serviceSource.slice(0, statusStart) + statusMethod + serviceSource.slice(statusEnd),
+  );
+}
+
 function generatedTrailingNewlineCounts(dir, base = dir, counts = new Map()) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const path = join(dir, entry.name);
@@ -196,6 +354,8 @@ try {
   }
   suppressExpectedAbortLogging();
   preserveExplicitAuthorizationHeaders();
+  preserveStructuredResponseHeaders();
+  preserveRawSyncUploadStatusResponse();
   normalizeGeneratedTrailingNewlines(generatedDir, generatedTrailingNewlines);
 } finally {
   rmSync(tempDir, { recursive: true, force: true });

--- a/frontend/src/lib/api/RawSyncService.generated-client.test.ts
+++ b/frontend/src/lib/api/RawSyncService.generated-client.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { OpenAPI } from "./generated/core/OpenAPI";
 import { RawSyncService } from "./generated/services/RawSyncService";
 
-describe("RawSyncService authentication", () => {
+describe("RawSyncService generated client", () => {
   afterEach(() => {
     OpenAPI.TOKEN = undefined;
     vi.unstubAllGlobals();
@@ -22,5 +22,25 @@ describe("RawSyncService authentication", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(new Headers(request.headers).get("Authorization")).toBe("Bearer device-credential");
+  });
+
+  it("returns every authoritative raw upload status header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, {
+      status: 200,
+      headers: {
+        "Upload-Offset": "7",
+        "Upload-Length": "11",
+        "Upload-Complete": "false",
+      },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const status = await RawSyncService.headApiV1RawSyncUploadsUploadId({
+      uploadId: "upl_AQEBAQEBAQEBAQEBAQEBAQ",
+      authorization: "Bearer upload-token",
+    });
+
+    expect(status).toEqual({ offset: 7, length: 11, complete: false });
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/lib/api/generated/core/ApiRequestOptions.ts
+++ b/frontend/src/lib/api/generated/core/ApiRequestOptions.ts
@@ -13,5 +13,9 @@ export type ApiRequestOptions = {
   readonly body?: any;
   readonly mediaType?: string;
   readonly responseHeader?: string;
+  readonly responseHeaders?: Record<string, {
+    readonly name: string;
+    readonly type: 'string' | 'number' | 'boolean';
+  }>;
   readonly errors?: Record<number, string>;
 };

--- a/frontend/src/lib/api/generated/core/request.ts
+++ b/frontend/src/lib/api/generated/core/request.ts
@@ -233,6 +233,32 @@ export const getResponseHeader = (response: Response, responseHeader?: string): 
   return undefined;
 };
 
+export const getResponseHeaders = (
+  response: Response,
+  responseHeaders?: ApiRequestOptions['responseHeaders'],
+): Record<string, string | number | boolean> | undefined => {
+  if (!responseHeaders) return undefined;
+  return Object.fromEntries(Object.entries(responseHeaders).map(([property, option]) => {
+    const content = response.headers.get(option.name);
+    if (content === null) throw new Error(`Response header ${option.name} is missing`);
+    switch (option.type) {
+      case 'number': {
+        const value = Number(content);
+        if (!Number.isFinite(value)) {
+          throw new Error(`Response header ${option.name} is not a number`);
+        }
+        return [property, value];
+      }
+      case 'boolean':
+        if (content === 'true') return [property, true];
+        if (content === 'false') return [property, false];
+        throw new Error(`Response header ${option.name} is not a boolean`);
+      default:
+        return [property, content];
+    }
+  }));
+};
+
 export const getResponseBody = async (response: Response): Promise<any> => {
   if (response.status !== 204) {
     try {
@@ -308,13 +334,16 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
         const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
         const responseBody = await getResponseBody(response);
         const responseHeader = getResponseHeader(response, options.responseHeader);
+        const responseHeaders = response.ok
+          ? getResponseHeaders(response, options.responseHeaders)
+          : undefined;
 
         const result: ApiResult = {
           url,
           ok: response.ok,
           status: response.status,
           statusText: response.statusText,
-          body: responseHeader ?? responseBody,
+          body: responseHeaders ?? responseHeader ?? responseBody,
         };
 
         catchErrorCodes(options, result);

--- a/frontend/src/lib/api/generated/index.ts
+++ b/frontend/src/lib/api/generated/index.ts
@@ -184,6 +184,9 @@ export type { RawSyncMissingObjectsResponse } from './models/RawSyncMissingObjec
 export type { RawsyncObjectRef } from './models/RawsyncObjectRef';
 export type { RawSyncTokenInputBody } from './models/RawSyncTokenInputBody';
 export type { RawSyncTokenResponse } from './models/RawSyncTokenResponse';
+export type { RawSyncUploadResponse } from './models/RawSyncUploadResponse';
+export type { RawSyncUploadStatusResponse } from './models/RawSyncUploadStatusResponse';
+export type { RawSyncUploadStartInputBody } from './models/RawSyncUploadStartInputBody';
 export type { RemoteSyncRequest } from './models/RemoteSyncRequest';
 export type { RemotesyncTargetSet } from './models/RemotesyncTargetSet';
 export type { RenameRequest } from './models/RenameRequest';

--- a/frontend/src/lib/api/generated/models/ApiErrorResponse.ts
+++ b/frontend/src/lib/api/generated/models/ApiErrorResponse.ts
@@ -8,5 +8,6 @@ export type ApiErrorResponse = {
   current_manifest_id?: string;
   current_receipt?: string;
   error: string;
+  upload_offset?: number;
 };
 

--- a/frontend/src/lib/api/generated/models/RawSyncUploadResponse.ts
+++ b/frontend/src/lib/api/generated/models/RawSyncUploadResponse.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { RawsyncObjectRef } from './RawsyncObjectRef';
+export type RawSyncUploadResponse = {
+  complete: boolean;
+  created: boolean;
+  expires_at?: string;
+  object: RawsyncObjectRef;
+  offset: number;
+  upload_id?: string;
+};

--- a/frontend/src/lib/api/generated/models/RawSyncUploadStartInputBody.ts
+++ b/frontend/src/lib/api/generated/models/RawSyncUploadStartInputBody.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { RawsyncObjectRef } from './RawsyncObjectRef';
+export type RawSyncUploadStartInputBody = {
+  object: RawsyncObjectRef;
+  provider: string;
+};

--- a/frontend/src/lib/api/generated/models/RawSyncUploadStatusResponse.ts
+++ b/frontend/src/lib/api/generated/models/RawSyncUploadStatusResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type RawSyncUploadStatusResponse = {
+  offset: number;
+  length: number;
+  complete: boolean;
+};

--- a/frontend/src/lib/api/generated/services/RawSyncService.ts
+++ b/frontend/src/lib/api/generated/services/RawSyncService.ts
@@ -8,6 +8,9 @@ import type { RawSyncMissingObjectsInputBody } from '../models/RawSyncMissingObj
 import type { RawSyncMissingObjectsResponse } from '../models/RawSyncMissingObjectsResponse';
 import type { RawSyncTokenInputBody } from '../models/RawSyncTokenInputBody';
 import type { RawSyncTokenResponse } from '../models/RawSyncTokenResponse';
+import type { RawSyncUploadResponse } from '../models/RawSyncUploadResponse';
+import type { RawSyncUploadStatusResponse } from '../models/RawSyncUploadStatusResponse';
+import type { RawSyncUploadStartInputBody } from '../models/RawSyncUploadStartInputBody';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -105,6 +108,125 @@ export class RawSyncService {
       },
       body: requestBody,
       mediaType: 'application/json',
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
+  /**
+   * Create or resume a raw object upload
+   * @returns RawSyncUploadResponse OK
+   * @throws ApiError
+   */
+  public static postApiV1RawSyncUploads({
+    requestBody,
+    authorization,
+  }: {
+    requestBody: RawSyncUploadStartInputBody,
+    authorization?: string,
+  }): CancelablePromise<RawSyncUploadResponse> {
+    return __request(OpenAPI, {
+      method: 'POST',
+      url: '/api/v1/raw-sync/uploads',
+      headers: {
+        'Authorization': authorization,
+      },
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
+  /**
+   * Read a raw upload offset
+   * @returns RawSyncUploadStatusResponse OK
+   * @throws ApiError
+   */
+  public static headApiV1RawSyncUploadsUploadId({
+    uploadId,
+    authorization,
+  }: {
+    uploadId: string,
+    authorization?: string,
+  }): CancelablePromise<RawSyncUploadStatusResponse> {
+    return __request(OpenAPI, {
+      method: 'HEAD',
+      url: '/api/v1/raw-sync/uploads/{upload_id}',
+      path: {
+        'upload_id': uploadId,
+      },
+      headers: {
+        'Authorization': authorization,
+      },
+      responseHeaders: {
+        offset: { name: 'Upload-Offset', type: 'number' },
+        length: { name: 'Upload-Length', type: 'number' },
+        complete: { name: 'Upload-Complete', type: 'boolean' },
+      },
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
+  /**
+   * Append a raw upload chunk
+   * @returns RawSyncUploadResponse OK
+   * @throws ApiError
+   */
+  public static patchApiV1RawSyncUploadsUploadId({
+    uploadId,
+    uploadOffset,
+    requestBody,
+    authorization,
+  }: {
+    uploadId: string,
+    uploadOffset: number,
+    requestBody: Blob,
+    authorization?: string,
+  }): CancelablePromise<RawSyncUploadResponse> {
+    return __request(OpenAPI, {
+      method: 'PATCH',
+      url: '/api/v1/raw-sync/uploads/{upload_id}',
+      path: {
+        'upload_id': uploadId,
+      },
+      headers: {
+        'Authorization': authorization,
+        'Upload-Offset': uploadOffset,
+      },
+      body: requestBody,
+      mediaType: 'application/octet-stream',
       errors: {
         400: `Bad Request`,
         401: `Unauthorized`,

--- a/internal/postgres/raw_ingest_schema.go
+++ b/internal/postgres/raw_ingest_schema.go
@@ -42,6 +42,31 @@ CREATE TABLE IF NOT EXISTS raw_device_tokens (
         REFERENCES raw_devices (tenant_id, device_id) ON DELETE RESTRICT
 );
 
+CREATE TABLE IF NOT EXISTS raw_upload_sessions (
+    upload_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    sha256 TEXT NOT NULL CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+    size_bytes BIGINT NOT NULL CHECK (size_bytes >= 0),
+    offset_bytes BIGINT NOT NULL DEFAULT 0
+        CHECK (offset_bytes >= 0 AND offset_bytes <= size_bytes),
+    generation BIGINT NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    state TEXT NOT NULL DEFAULT 'open'
+        CHECK (state IN ('open', 'complete', 'expired')),
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ,
+    CHECK (expires_at > created_at),
+    CHECK (
+        (state = 'complete' AND completed_at IS NOT NULL AND offset_bytes = size_bytes)
+        OR (state <> 'complete' AND completed_at IS NULL)
+    ),
+    FOREIGN KEY (tenant_id, device_id)
+        REFERENCES raw_devices (tenant_id, device_id) ON DELETE RESTRICT
+);
+
 CREATE TABLE IF NOT EXISTS raw_objects (
     tenant_id TEXT NOT NULL,
     sha256 TEXT NOT NULL CHECK (sha256 ~ '^[0-9a-f]{64}$'),
@@ -166,6 +191,14 @@ CREATE INDEX IF NOT EXISTS idx_raw_ingest_jobs_lease
     WHERE state = 'leased';
 CREATE INDEX IF NOT EXISTS idx_raw_device_tokens_expiry
     ON raw_device_tokens (expires_at, tenant_id, device_id);
+CREATE INDEX IF NOT EXISTS idx_raw_upload_sessions_expiry
+    ON raw_upload_sessions (expires_at, upload_id)
+    WHERE state = 'open';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_raw_upload_sessions_open_object
+    ON raw_upload_sessions (
+        tenant_id, device_id, provider, sha256, size_bytes
+    )
+    WHERE state = 'open';
 `
 
 const rawIngestAppendOnlyDDL = `
@@ -218,6 +251,10 @@ WITH required_table_privileges(table_name, privilege) AS (
         ('raw_devices', 'SELECT'),
         ('raw_device_tokens', 'SELECT'),
         ('raw_device_tokens', 'INSERT'),
+        ('raw_upload_sessions', 'SELECT'),
+        ('raw_upload_sessions', 'INSERT'),
+        ('raw_upload_sessions', 'UPDATE'),
+        ('raw_upload_sessions', 'DELETE'),
         ('raw_objects', 'SELECT'),
         ('raw_objects', 'INSERT'),
         ('raw_objects', 'UPDATE'),

--- a/internal/postgres/raw_ingest_schema_pgtest_test.go
+++ b/internal/postgres/raw_ingest_schema_pgtest_test.go
@@ -28,6 +28,7 @@ func TestEnsureSchemaCreatesRawIngestCustodyTables(t *testing.T) {
 	for _, table := range []string{
 		"raw_devices",
 		"raw_device_tokens",
+		"raw_upload_sessions",
 		"raw_objects",
 		"raw_manifests",
 		"raw_manifest_entries",
@@ -47,6 +48,8 @@ func TestEnsureSchemaCreatesRawIngestCustodyTables(t *testing.T) {
 
 	for _, index := range []string{
 		"idx_raw_device_tokens_expiry",
+		"idx_raw_upload_sessions_expiry",
+		"idx_raw_upload_sessions_open_object",
 		"idx_raw_ingest_jobs_ready",
 		"idx_raw_ingest_jobs_lease",
 	} {
@@ -77,6 +80,10 @@ func TestRawIngestSchemaUsesTenantScopedKeys(t *testing.T) {
 		},
 		"raw_device_tokens": {
 			"PRIMARY KEY (token_sha256)",
+			"FOREIGN KEY (tenant_id, device_id)",
+		},
+		"raw_upload_sessions": {
+			"PRIMARY KEY (upload_id)",
 			"FOREIGN KEY (tenant_id, device_id)",
 		},
 		"raw_objects": {
@@ -315,6 +322,7 @@ func TestCanWriteRawSyncSchemaRequiresExactRuntimePrivileges(t *testing.T) {
 		`GRANT USAGE ON SCHEMA ` + schema + ` TO ` + role,
 		`GRANT SELECT ON ` + schema + `.raw_devices TO ` + role,
 		`GRANT SELECT, INSERT ON ` + schema + `.raw_device_tokens TO ` + role,
+		`GRANT SELECT, INSERT, UPDATE, DELETE ON ` + schema + `.raw_upload_sessions TO ` + role,
 		`GRANT SELECT, INSERT, UPDATE ON ` + schema + `.raw_objects TO ` + role,
 		`GRANT SELECT, INSERT ON ` + schema + `.raw_manifests TO ` + role,
 		`GRANT INSERT ON ` + schema + `.raw_manifest_entries TO ` + role,
@@ -345,6 +353,10 @@ func TestCanWriteRawSyncSchemaRequiresExactRuntimePrivileges(t *testing.T) {
 		{"raw_devices", "SELECT"},
 		{"raw_device_tokens", "SELECT"},
 		{"raw_device_tokens", "INSERT"},
+		{"raw_upload_sessions", "SELECT"},
+		{"raw_upload_sessions", "INSERT"},
+		{"raw_upload_sessions", "UPDATE"},
+		{"raw_upload_sessions", "DELETE"},
 		{"raw_objects", "SELECT"},
 		{"raw_objects", "INSERT"},
 		{"raw_objects", "UPDATE"},

--- a/internal/postgres/raw_upload_custody_pgtest_test.go
+++ b/internal/postgres/raw_upload_custody_pgtest_test.go
@@ -1,0 +1,88 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/artifact"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestRawResumableUploadEndToEnd(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	repository, err := artifact.OpenRepository(t.Context(), dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, repository.Close()) })
+	objects, err := rawsync.NewArtifactObjectStore(repository.Content())
+	require.NoError(t, err)
+	metadata, err := NewRawIngestStore(pg)
+	require.NoError(t, err)
+	custody, err := rawsync.NewService(
+		objects, metadata, rawsync.DefaultManifestLimits(), "parser-data-17",
+	)
+	require.NoError(t, err)
+	sessions, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sessions.Close()) })
+	uploads, err := rawsync.NewUploadService(
+		sessions, custody, rawsync.DefaultUploadSessionTTL,
+	)
+	require.NoError(t, err)
+
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	body := []byte("durable resumable raw object")
+	object := rawCustodyObjectRef(t, body)
+	session, created, err := uploads.Start(
+		t.Context(), identity, parser.AgentCodex, object,
+	)
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	partial, err := uploads.Append(
+		t.Context(), identity, session.ID, 0, body[:8],
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), partial.Offset)
+	completed, err := uploads.Append(
+		t.Context(), identity, session.ID, partial.Offset, body[8:],
+	)
+	require.NoError(t, err)
+	assert.True(t, completed.Complete)
+	assert.Equal(t, object.Length, completed.Offset)
+
+	missing, err := custody.MissingObjects(
+		t.Context(), identity, parser.AgentCodex, []rawsync.ObjectRef{object},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+	_, reader, err := objects.OpenObject(t.Context(), identity.TenantID, object)
+	require.NoError(t, err)
+	stored, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Verify())
+	require.NoError(t, reader.Close())
+	assert.Equal(t, body, stored)
+
+	var state string
+	var offset int64
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT state, offset_bytes
+		FROM raw_upload_sessions
+		WHERE upload_id = $1`, session.ID).Scan(&state, &offset))
+	assert.Equal(t, "complete", state)
+	assert.Equal(t, object.Length, offset)
+	assert.Equal(t, 1, rawIngestTableCount(t, pg, "raw_objects"))
+
+	status, err := uploads.Status(
+		t.Context(), identity, session.ID,
+	)
+	require.NoError(t, err)
+	assert.True(t, status.Complete)
+	assert.Equal(t, rawsync.DefaultUploadSessionTTL, status.ExpiresAt.Sub(status.CreatedAt))
+}

--- a/internal/postgres/raw_upload_store.go
+++ b/internal/postgres/raw_upload_store.go
@@ -1,0 +1,845 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+const rawUploadSpoolDirectory = "raw-upload-spool"
+
+const (
+	rawUploadCleanupBatch    = 128
+	rawUploadCleanupInterval = 15 * time.Minute
+	rawUploadCleanupTimeout  = 30 * time.Second
+)
+
+const rawUploadSessionColumns = `
+    upload_id, tenant_id, device_id, provider, sha256, size_bytes,
+    offset_bytes, generation, state, created_at, expires_at`
+
+// RawUploadStore combines PostgreSQL offset fencing with a restart-safe spool.
+type RawUploadStore struct {
+	db            *sql.DB
+	root          *os.Root
+	closeOnce     sync.Once
+	closeErr      error
+	syncDirectory func() error
+	cleanupCancel context.CancelFunc
+	cleanupWG     sync.WaitGroup
+	scanMu        sync.Mutex
+	scanDirectory *os.File
+}
+
+// NewRawUploadStore opens the private spool below one agentsview data directory.
+func NewRawUploadStore(database *sql.DB, dataDir string) (*RawUploadStore, error) {
+	if database == nil {
+		return nil, fmt.Errorf("%w: PostgreSQL connection is required", rawsync.ErrInvalid)
+	}
+	if strings.TrimSpace(dataDir) == "" {
+		return nil, fmt.Errorf("%w: raw upload data directory is required", rawsync.ErrInvalid)
+	}
+	root, err := openRawUploadSpool(dataDir, syncRawUploadDirectory)
+	if err != nil {
+		return nil, err
+	}
+	store := &RawUploadStore{db: database, root: root}
+	store.syncDirectory = store.syncSpoolDirectory
+	startupCtx, cancelStartup := context.WithTimeout(
+		context.Background(), rawUploadCleanupTimeout,
+	)
+	err = store.cleanupExpiredAndOrphaned(startupCtx, time.Now().UTC())
+	cancelStartup()
+	if err != nil {
+		_ = root.Close()
+		return nil, fmt.Errorf("cleaning raw upload spool at startup: %w", err)
+	}
+	cleanupCtx, cancelCleanup := context.WithCancel(context.Background())
+	store.cleanupCancel = cancelCleanup
+	store.cleanupWG.Go(func() {
+		ticker := time.NewTicker(rawUploadCleanupInterval)
+		defer ticker.Stop()
+		store.runCleanupLoop(cleanupCtx, ticker.C)
+	})
+	return store, nil
+}
+
+func openRawUploadSpool(
+	dataDir string,
+	syncParent func(string) error,
+) (*os.Root, error) {
+	spoolPath, err := filepath.Abs(filepath.Join(dataDir, rawUploadSpoolDirectory))
+	if err != nil {
+		return nil, fmt.Errorf("resolving raw upload spool: %w", err)
+	}
+	if err := os.MkdirAll(spoolPath, 0o700); err != nil {
+		return nil, fmt.Errorf("creating raw upload spool: %w", err)
+	}
+	if err := os.Chmod(spoolPath, 0o700); err != nil {
+		return nil, fmt.Errorf("restricting raw upload spool: %w", err)
+	}
+	if err := syncParent(filepath.Dir(spoolPath)); err != nil {
+		return nil, fmt.Errorf("syncing raw upload spool parent: %w", err)
+	}
+	root, err := os.OpenRoot(spoolPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening raw upload spool: %w", err)
+	}
+	return root, nil
+}
+
+func syncRawUploadDirectory(path string) (returnErr error) {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { returnErr = errors.Join(returnErr, directory.Close()) }()
+	if err := directory.Sync(); err != nil &&
+		!isRawUploadDirectorySyncUnsupported(err) {
+		return err
+	}
+	return nil
+}
+
+// Close releases the retained spool root. It is safe to call more than once.
+func (s *RawUploadStore) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.closeOnce.Do(func() {
+		if s.cleanupCancel != nil {
+			s.cleanupCancel()
+		}
+		s.cleanupWG.Wait()
+		s.scanMu.Lock()
+		if s.scanDirectory != nil {
+			s.closeErr = s.scanDirectory.Close()
+			s.scanDirectory = nil
+		}
+		s.scanMu.Unlock()
+		s.closeErr = errors.Join(s.closeErr, s.root.Close())
+	})
+	return s.closeErr
+}
+
+func (s *RawUploadStore) Create(
+	ctx context.Context,
+	record rawsync.UploadSession,
+) (rawsync.UploadSession, bool, error) {
+	if err := rawsync.ValidateUploadSession(record); err != nil ||
+		record.Offset != 0 || record.Complete {
+		return rawsync.UploadSession{}, false, fmt.Errorf(
+			"%w: invalid raw upload session record", rawsync.ErrInvalid,
+		)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return rawsync.UploadSession{}, false, fmt.Errorf("beginning raw upload create: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var expiredID string
+	err = tx.QueryRowContext(ctx, `
+		UPDATE raw_upload_sessions
+		SET state = 'expired', updated_at = $1
+		WHERE tenant_id = $2 AND device_id = $3 AND provider = $4
+			AND sha256 = $5 AND size_bytes = $6
+			AND state = 'open' AND expires_at <= $1
+		RETURNING upload_id`,
+		record.CreatedAt, record.Identity.TenantID, record.Identity.DeviceID,
+		record.Provider, record.Object.SHA256, record.Object.Length,
+	).Scan(&expiredID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return rawsync.UploadSession{}, false, fmt.Errorf("expiring prior raw upload: %w", err)
+	}
+
+	row := tx.QueryRowContext(ctx, `
+		INSERT INTO raw_upload_sessions (
+			upload_id, tenant_id, device_id, provider, sha256, size_bytes,
+			offset_bytes, state, created_at, updated_at, expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6, 0, 'open', $7, $7, $8)
+		ON CONFLICT (
+			tenant_id, device_id, provider, sha256, size_bytes
+		) WHERE state = 'open'
+		DO UPDATE SET updated_at = raw_upload_sessions.updated_at
+		RETURNING `+rawUploadSessionColumns+`, upload_id = $1`,
+		record.ID, record.Identity.TenantID, record.Identity.DeviceID,
+		record.Provider, record.Object.SHA256, record.Object.Length,
+		record.CreatedAt, record.ExpiresAt,
+	)
+	session, state, created, err := scanRawUploadSession(row, true)
+	if err != nil {
+		return rawsync.UploadSession{}, false, fmt.Errorf("storing raw upload session: %w", err)
+	}
+	if state != rawUploadStateOpen {
+		return rawsync.UploadSession{}, false, fmt.Errorf(
+			"raw upload create returned a non-open session: %w", rawsync.ErrConflict,
+		)
+	}
+	if err := tx.Commit(); err != nil {
+		return rawsync.UploadSession{}, false, fmt.Errorf("committing raw upload create: %w", err)
+	}
+	if expiredID != "" {
+		_ = s.removeRawUploadStage(expiredID)
+	}
+	return session, created, nil
+}
+
+func (s *RawUploadStore) Status(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	now time.Time,
+) (rawsync.UploadSession, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("beginning raw upload status: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	session, state, err := loadRawUploadSessionLocked(ctx, tx, identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	retired, err := retireExpiredRawUploadSession(
+		ctx, tx, session, state, uploadID, now,
+	)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	if retired {
+		if err := tx.Commit(); err != nil {
+			return rawsync.UploadSession{}, fmt.Errorf("committing raw upload expiry: %w", err)
+		}
+		_ = s.removeRawUploadStage(uploadID)
+		return rawsync.UploadSession{}, rawsync.ErrNotFound
+	}
+	if state == rawUploadStateExpired {
+		return rawsync.UploadSession{}, rawsync.ErrNotFound
+	}
+	if err := tx.Commit(); err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("committing raw upload status: %w", err)
+	}
+	return session, nil
+}
+
+func (s *RawUploadStore) Append(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	expectedOffset int64,
+	chunk []byte,
+	now time.Time,
+) (rawsync.UploadSession, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("beginning raw upload append: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	session, state, err := loadRawUploadSessionLocked(ctx, tx, identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	retired, err := retireExpiredRawUploadSession(
+		ctx, tx, session, state, uploadID, now,
+	)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	if retired {
+		if err := tx.Commit(); err != nil {
+			return rawsync.UploadSession{}, fmt.Errorf("committing raw upload expiry: %w", err)
+		}
+		_ = s.removeRawUploadStage(uploadID)
+		return rawsync.UploadSession{}, rawsync.ErrNotFound
+	}
+	if state == rawUploadStateComplete {
+		if err := tx.Commit(); err != nil {
+			return rawsync.UploadSession{}, fmt.Errorf("committing completed upload retry: %w", err)
+		}
+		return session, nil
+	}
+	if state != rawUploadStateOpen {
+		return rawsync.UploadSession{}, rawsync.ErrNotFound
+	}
+	if session.Offset != expectedOffset {
+		return rawsync.UploadSession{}, &rawsync.UploadOffsetConflictError{
+			CurrentOffset: session.Offset,
+		}
+	}
+	if int64(len(chunk)) > session.Object.Length-session.Offset {
+		return rawsync.UploadSession{}, fmt.Errorf(
+			"%w: raw upload chunk exceeds declared object length", rawsync.ErrInvalid,
+		)
+	}
+	if err := s.writeRawUploadChunk(session, chunk); err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	newOffset := session.Offset + int64(len(chunk))
+	result, err := tx.ExecContext(ctx, `
+		UPDATE raw_upload_sessions
+		SET offset_bytes = $1, updated_at = $2
+		WHERE upload_id = $3 AND state = 'open' AND offset_bytes = $4`,
+		newOffset, now, uploadID, session.Offset,
+	)
+	if err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("advancing raw upload offset: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("checking raw upload offset: %w", err)
+	}
+	if updated != 1 {
+		return rawsync.UploadSession{}, fmt.Errorf(
+			"raw upload offset changed while appending: %w", rawsync.ErrConflict,
+		)
+	}
+	if err := tx.Commit(); err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("committing raw upload append: %w", err)
+	}
+	session.Offset = newOffset
+	return session, nil
+}
+
+func (s *RawUploadStore) Open(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	now time.Time,
+) (rawsync.UploadSession, io.ReadCloser, error) {
+	session, err := s.Status(ctx, identity, uploadID, now)
+	if err != nil {
+		return rawsync.UploadSession{}, nil, err
+	}
+	if session.Complete {
+		return rawsync.UploadSession{}, nil, rawsync.ErrNotFound
+	}
+	file, err := s.root.Open(rawUploadStageName(uploadID))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return rawsync.UploadSession{}, nil, rawsync.ErrNotFound
+		}
+		return rawsync.UploadSession{}, nil, fmt.Errorf("opening raw upload spool file: %w", err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return rawsync.UploadSession{}, nil, fmt.Errorf("stating raw upload spool file: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() != session.Offset {
+		_ = file.Close()
+		return rawsync.UploadSession{}, nil, fmt.Errorf(
+			"raw upload spool does not match durable offset: %w", rawsync.ErrConflict,
+		)
+	}
+	return session, file, nil
+}
+
+func (s *RawUploadStore) Reset(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	expectedGeneration int64,
+	now time.Time,
+) (rawsync.UploadSession, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("beginning raw upload reset: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	session, state, err := loadRawUploadSessionLocked(ctx, tx, identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	retired, err := retireExpiredRawUploadSession(
+		ctx, tx, session, state, uploadID, now,
+	)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	if retired {
+		if err := tx.Commit(); err != nil {
+			return rawsync.UploadSession{}, fmt.Errorf("committing raw upload expiry: %w", err)
+		}
+		_ = s.removeRawUploadStage(uploadID)
+		return rawsync.UploadSession{}, rawsync.ErrNotFound
+	}
+	if state != rawUploadStateOpen {
+		return rawsync.UploadSession{}, rawsync.ErrNotFound
+	}
+	if session.Generation != expectedGeneration {
+		return rawsync.UploadSession{}, fmt.Errorf(
+			"raw upload generation changed while resetting: %w", rawsync.ErrConflict,
+		)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE raw_upload_sessions
+		SET offset_bytes = 0, generation = generation + 1, updated_at = $1
+		WHERE upload_id = $2 AND state = 'open'`, now, uploadID,
+	); err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("resetting raw upload offset: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("committing raw upload reset: %w", err)
+	}
+	session.Offset = 0
+	session.Generation++
+	return session, nil
+}
+
+func (s *RawUploadStore) Complete(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	now time.Time,
+) (rawsync.UploadSession, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("beginning raw upload completion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	session, state, err := loadRawUploadSessionLocked(ctx, tx, identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	retired, err := retireExpiredRawUploadSession(
+		ctx, tx, session, state, uploadID, now,
+	)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	if retired {
+		if err := tx.Commit(); err != nil {
+			return rawsync.UploadSession{}, fmt.Errorf("committing raw upload expiry: %w", err)
+		}
+		_ = s.removeRawUploadStage(uploadID)
+		return rawsync.UploadSession{}, rawsync.ErrNotFound
+	}
+	if state == rawUploadStateComplete {
+		if err := tx.Commit(); err != nil {
+			return rawsync.UploadSession{}, fmt.Errorf("committing completed upload retry: %w", err)
+		}
+		return session, nil
+	}
+	if state != rawUploadStateOpen {
+		return rawsync.UploadSession{}, rawsync.ErrNotFound
+	}
+	if session.Offset != session.Object.Length {
+		return rawsync.UploadSession{}, fmt.Errorf(
+			"%w: raw upload is incomplete", rawsync.ErrConflict,
+		)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE raw_upload_sessions
+		SET state = 'complete', completed_at = $1, updated_at = $1
+		WHERE upload_id = $2 AND state = 'open'`, now, uploadID,
+	); err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("completing raw upload: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return rawsync.UploadSession{}, fmt.Errorf("committing raw upload completion: %w", err)
+	}
+	session.Complete = true
+	_ = s.removeRawUploadStage(uploadID)
+	return session, nil
+}
+
+func (s *RawUploadStore) runCleanupLoop(
+	ctx context.Context,
+	ticks <-chan time.Time,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now, ok := <-ticks:
+			if !ok {
+				return
+			}
+			cleanupCtx, cancel := context.WithTimeout(ctx, rawUploadCleanupTimeout)
+			err := s.cleanupExpiredAndOrphaned(cleanupCtx, now.UTC())
+			cancel()
+			if err != nil && !errors.Is(err, context.Canceled) {
+				log.Printf("raw upload cleanup failed: %v", err)
+			}
+		}
+	}
+}
+
+func (s *RawUploadStore) cleanupExpiredAndOrphaned(
+	ctx context.Context,
+	now time.Time,
+) error {
+	rows, err := s.db.QueryContext(ctx, `
+		WITH expired AS (
+			SELECT upload_id
+			FROM raw_upload_sessions
+			WHERE state = 'open' AND expires_at <= $1
+			ORDER BY expires_at, upload_id
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE raw_upload_sessions AS sessions
+		SET state = 'expired', updated_at = $1
+		FROM expired
+		WHERE sessions.upload_id = expired.upload_id
+		RETURNING sessions.upload_id`, now, rawUploadCleanupBatch)
+	if err != nil {
+		return fmt.Errorf("expiring abandoned raw uploads: %w", err)
+	}
+	expiredIDs := make([]string, 0, rawUploadCleanupBatch)
+	for rows.Next() {
+		var uploadID string
+		if err := rows.Scan(&uploadID); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("reading expired raw upload: %w", err)
+		}
+		expiredIDs = append(expiredIDs, uploadID)
+	}
+	if err := errors.Join(rows.Err(), rows.Close()); err != nil {
+		return fmt.Errorf("finishing expired raw upload query: %w", err)
+	}
+	rows, err = s.db.QueryContext(ctx, `
+		WITH terminal AS (
+			SELECT upload_id
+			FROM raw_upload_sessions
+			WHERE state IN ('complete', 'expired') AND expires_at <= $1
+			ORDER BY expires_at, upload_id
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)
+		DELETE FROM raw_upload_sessions AS sessions
+		USING terminal
+		WHERE sessions.upload_id = terminal.upload_id
+		RETURNING sessions.upload_id`, now, rawUploadCleanupBatch)
+	if err != nil {
+		return fmt.Errorf("deleting terminal raw uploads: %w", err)
+	}
+	terminalIDs := make([]string, 0, rawUploadCleanupBatch)
+	for rows.Next() {
+		var uploadID string
+		if err := rows.Scan(&uploadID); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("reading deleted raw upload: %w", err)
+		}
+		terminalIDs = append(terminalIDs, uploadID)
+	}
+	if err := errors.Join(rows.Err(), rows.Close()); err != nil {
+		return fmt.Errorf("finishing terminal raw upload query: %w", err)
+	}
+	var cleanupErr error
+	for _, uploadID := range append(expiredIDs, terminalIDs...) {
+		cleanupErr = errors.Join(cleanupErr, s.removeRawUploadStage(uploadID))
+	}
+
+	stageNames, err := s.nextRawUploadStageNames(rawUploadCleanupBatch)
+	if err != nil {
+		return errors.Join(cleanupErr, fmt.Errorf("scanning raw upload spool: %w", err))
+	}
+	for _, stageName := range stageNames {
+		cleanupErr = errors.Join(
+			cleanupErr, s.reconcileRawUploadStage(ctx, stageName, now),
+		)
+	}
+	return cleanupErr
+}
+
+func (s *RawUploadStore) nextRawUploadStageNames(limit int) ([]string, error) {
+	s.scanMu.Lock()
+	defer s.scanMu.Unlock()
+	if s.scanDirectory == nil {
+		directory, err := s.root.Open(".")
+		if err != nil {
+			return nil, err
+		}
+		s.scanDirectory = directory
+	}
+	entries, err := s.scanDirectory.ReadDir(limit)
+	if errors.Is(err, io.EOF) {
+		err = nil
+		closeErr := s.scanDirectory.Close()
+		s.scanDirectory = nil
+		if closeErr != nil {
+			return nil, closeErr
+		}
+	}
+	if err != nil {
+		closeErr := s.scanDirectory.Close()
+		s.scanDirectory = nil
+		return nil, errors.Join(err, closeErr)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".part") {
+			names = append(names, entry.Name())
+		}
+	}
+	return names, nil
+}
+
+func (s *RawUploadStore) reconcileRawUploadStage(
+	ctx context.Context,
+	stageName string,
+	now time.Time,
+) error {
+	uploadID, ok := strings.CutSuffix(stageName, ".part")
+	if !ok {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning raw upload spool reconciliation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var state string
+	var expiresAt time.Time
+	err = tx.QueryRowContext(ctx, `
+		SELECT state, expires_at
+		FROM raw_upload_sessions
+		WHERE upload_id = $1
+		FOR UPDATE`, uploadID).Scan(&state, &expiresAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		if err := tx.Rollback(); err != nil {
+			return fmt.Errorf("releasing orphaned raw upload lookup: %w", err)
+		}
+		return s.removeRawUploadStageName(stageName)
+	}
+	if err != nil {
+		return fmt.Errorf("loading raw upload spool owner: %w", err)
+	}
+	remove := state != rawUploadStateOpen
+	if state == rawUploadStateOpen && !now.Before(expiresAt) {
+		if err := expireRawUploadSession(ctx, tx, uploadID, now); err != nil {
+			return err
+		}
+		remove = true
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing raw upload spool reconciliation: %w", err)
+	}
+	if remove {
+		return s.removeRawUploadStageName(stageName)
+	}
+	return nil
+}
+
+func (s *RawUploadStore) removeRawUploadStage(uploadID string) error {
+	return s.removeRawUploadStageName(rawUploadStageName(uploadID))
+}
+
+func (s *RawUploadStore) removeRawUploadStageName(stageName string) error {
+	err := s.root.Remove(stageName)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return s.syncDirectory()
+}
+
+func (s *RawUploadStore) writeRawUploadChunk(
+	session rawsync.UploadSession,
+	chunk []byte,
+) (returnErr error) {
+	file, created, err := s.openRawUploadStage(rawUploadStageName(session.ID))
+	if err != nil {
+		return fmt.Errorf("opening raw upload spool for append: %w", err)
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, file.Close())
+		if returnErr != nil && created {
+			returnErr = errors.Join(returnErr, s.removeRawUploadStage(session.ID))
+		}
+	}()
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stating raw upload spool for append: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() < session.Offset {
+		return fmt.Errorf(
+			"raw upload spool is behind durable offset: %w", rawsync.ErrConflict,
+		)
+	}
+	if info.Size() > session.Offset {
+		if err := file.Truncate(session.Offset); err != nil {
+			return fmt.Errorf("discarding uncommitted raw upload tail: %w", err)
+		}
+	}
+	if len(chunk) != 0 {
+		written, err := file.WriteAt(chunk, session.Offset)
+		if err != nil {
+			return fmt.Errorf("writing raw upload chunk: %w", err)
+		}
+		if written != len(chunk) {
+			return fmt.Errorf("writing raw upload chunk: %w", io.ErrShortWrite)
+		}
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("syncing raw upload chunk: %w", err)
+	}
+	if created {
+		if err := s.syncDirectory(); err != nil {
+			return fmt.Errorf("syncing raw upload spool directory: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *RawUploadStore) openRawUploadStage(name string) (*os.File, bool, error) {
+	file, err := s.root.OpenFile(name, os.O_RDWR, 0o600)
+	if err == nil {
+		return file, false, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, false, err
+	}
+	file, err = s.root.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if errors.Is(err, os.ErrExist) {
+		file, err = s.root.OpenFile(name, os.O_RDWR, 0o600)
+		return file, false, err
+	}
+	return file, err == nil, err
+}
+
+func (s *RawUploadStore) syncSpoolDirectory() (returnErr error) {
+	directory, err := s.root.Open(".")
+	if err != nil {
+		return err
+	}
+	defer func() { returnErr = errors.Join(returnErr, directory.Close()) }()
+	if err := directory.Sync(); err != nil &&
+		!isRawUploadDirectorySyncUnsupported(err) {
+		return err
+	}
+	return nil
+}
+
+const (
+	rawUploadStateOpen     = "open"
+	rawUploadStateComplete = "complete"
+	rawUploadStateExpired  = "expired"
+)
+
+type rawUploadRow interface {
+	Scan(...any) error
+}
+
+func scanRawUploadSession(
+	row rawUploadRow,
+	withCreated bool,
+) (rawsync.UploadSession, string, bool, error) {
+	var session rawsync.UploadSession
+	var provider string
+	var state string
+	created := false
+	destinations := []any{
+		&session.ID,
+		&session.Identity.TenantID,
+		&session.Identity.DeviceID,
+		&provider,
+		&session.Object.SHA256,
+		&session.Object.Length,
+		&session.Offset,
+		&session.Generation,
+		&state,
+		&session.CreatedAt,
+		&session.ExpiresAt,
+	}
+	if withCreated {
+		destinations = append(destinations, &created)
+	}
+	if err := row.Scan(destinations...); err != nil {
+		return rawsync.UploadSession{}, "", false, err
+	}
+	session.Provider = parser.AgentType(provider)
+	session.CreatedAt = session.CreatedAt.UTC()
+	session.ExpiresAt = session.ExpiresAt.UTC()
+	session.Complete = state == rawUploadStateComplete
+	if err := rawsync.ValidateUploadSession(session); err != nil {
+		return rawsync.UploadSession{}, "", false, fmt.Errorf(
+			"validating stored raw upload session: %w", err,
+		)
+	}
+	return session, state, created, nil
+}
+
+func loadRawUploadSessionLocked(
+	ctx context.Context,
+	tx *sql.Tx,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+) (rawsync.UploadSession, string, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT `+rawUploadSessionColumns+`
+		FROM raw_upload_sessions
+		WHERE upload_id = $1 AND tenant_id = $2 AND device_id = $3
+		FOR UPDATE`, uploadID, identity.TenantID, identity.DeviceID)
+	session, state, _, err := scanRawUploadSession(row, false)
+	if errors.Is(err, sql.ErrNoRows) {
+		return rawsync.UploadSession{}, "", rawsync.ErrNotFound
+	}
+	if err != nil {
+		return rawsync.UploadSession{}, "", fmt.Errorf("loading raw upload session: %w", err)
+	}
+	return session, state, nil
+}
+
+func expireRawUploadSession(
+	ctx context.Context,
+	tx *sql.Tx,
+	uploadID string,
+	now time.Time,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE raw_upload_sessions
+		SET state = 'expired', updated_at = $1
+		WHERE upload_id = $2 AND state = 'open'`, now, uploadID,
+	); err != nil {
+		return fmt.Errorf("expiring raw upload session: %w", err)
+	}
+	return nil
+}
+
+func retireExpiredRawUploadSession(
+	ctx context.Context,
+	tx *sql.Tx,
+	session rawsync.UploadSession,
+	state string,
+	uploadID string,
+	now time.Time,
+) (bool, error) {
+	if now.Before(session.ExpiresAt) {
+		return false, nil
+	}
+	if state == rawUploadStateOpen {
+		if err := expireRawUploadSession(ctx, tx, uploadID, now); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM raw_upload_sessions
+		WHERE upload_id = $1 AND state IN ('complete', 'expired')`,
+		uploadID,
+	); err != nil {
+		return false, fmt.Errorf("deleting expired raw upload: %w", err)
+	}
+	return true, nil
+}
+
+func rawUploadStageName(uploadID string) string {
+	return uploadID + ".part"
+}
+
+var _ rawsync.UploadSessionStore = (*RawUploadStore)(nil)

--- a/internal/postgres/raw_upload_store_pgtest_test.go
+++ b/internal/postgres/raw_upload_store_pgtest_test.go
@@ -1,0 +1,417 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestRawUploadStoreResumesAfterRestartAndRepairsCrashTail(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	first, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	record := rawUploadRecord(t, identity, "upl_AQEBAQEBAQEBAQEBAQEBAQ", now)
+	created, wasCreated, err := first.Create(t.Context(), record)
+	require.NoError(t, err)
+	assert.True(t, wasCreated)
+	assert.Equal(t, record, created)
+
+	resumed, wasCreated, err := first.Create(t.Context(), rawUploadRecord(
+		t, identity, "upl_AgICAgICAgICAgICAgICAg", now,
+	))
+	require.NoError(t, err)
+	assert.False(t, wasCreated)
+	assert.Equal(t, record.ID, resumed.ID)
+
+	appended, err := first.Append(
+		t.Context(), identity, record.ID, 0, []byte("hello"), now,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), appended.Offset)
+	require.NoError(t, first.Close())
+
+	stagePath := filepath.Join(dataDir, rawUploadSpoolDirectory, record.ID+".part")
+	file, err := os.OpenFile(stagePath, os.O_WRONLY|os.O_APPEND, 0)
+	require.NoError(t, err)
+	_, err = file.Write([]byte("uncommitted-tail"))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	restarted, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restarted.Close()) })
+	status, err := restarted.Status(t.Context(), identity, record.ID, now)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), status.Offset)
+
+	_, err = restarted.Append(
+		t.Context(), identity, record.ID, 0, []byte("wrong offset"), now,
+	)
+	var conflict *rawsync.UploadOffsetConflictError
+	require.ErrorAs(t, err, &conflict)
+	assert.Equal(t, int64(5), conflict.CurrentOffset)
+
+	appended, err = restarted.Append(
+		t.Context(), identity, record.ID, 5, []byte(" world"), now,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, record.Object.Length, appended.Offset)
+	opened, reader, err := restarted.Open(t.Context(), identity, record.ID, now)
+	require.NoError(t, err)
+	assert.Equal(t, appended, opened)
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, []byte("hello world"), data,
+		"the uncommitted tail must be truncated before the resumed append")
+}
+
+func TestRawUploadStoreFencesTenantDeviceExpiryAndCompletion(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	store, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	otherIdentity := rawUploadIdentity(t, pg, "tenant-b", "device-b")
+	record := rawUploadRecord(t, identity, "upl_AQEBAQEBAQEBAQEBAQEBAQ", now)
+	_, _, err = store.Create(t.Context(), record)
+	require.NoError(t, err)
+
+	_, err = store.Status(t.Context(), otherIdentity, record.ID, now)
+	assert.ErrorIs(t, err, rawsync.ErrNotFound)
+	_, err = store.Append(
+		t.Context(), otherIdentity, record.ID, 0, []byte("hello world"), now,
+	)
+	assert.ErrorIs(t, err, rawsync.ErrNotFound)
+
+	full, err := store.Append(
+		t.Context(), identity, record.ID, 0, []byte("hello world"), now,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, record.Object.Length, full.Offset)
+	completed, err := store.Complete(t.Context(), identity, record.ID, now)
+	require.NoError(t, err)
+	assert.True(t, completed.Complete)
+	assert.NoFileExists(t,
+		filepath.Join(dataDir, rawUploadSpoolDirectory, record.ID+".part"))
+	retried, err := store.Append(
+		t.Context(), identity, record.ID, record.Object.Length, nil, now,
+	)
+	require.NoError(t, err)
+	assert.True(t, retried.Complete)
+	_, err = store.Status(t.Context(), identity, record.ID, record.ExpiresAt)
+	assert.ErrorIs(t, err, rawsync.ErrNotFound)
+	var retained int
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT count(*) FROM raw_upload_sessions WHERE upload_id = $1`,
+		record.ID,
+	).Scan(&retained))
+	assert.Zero(t, retained)
+
+	expiring := rawUploadRecord(
+		t, identity, "upl_AgICAgICAgICAgICAgICAg", now,
+	)
+	_, _, err = store.Create(t.Context(), expiring)
+	require.NoError(t, err)
+	_, err = store.Status(t.Context(), identity, expiring.ID, expiring.ExpiresAt)
+	assert.ErrorIs(t, err, rawsync.ErrNotFound)
+}
+
+func TestRawUploadStoreResetLeavesTruncationToNextLockedAppend(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	store, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	record := rawUploadRecord(t, identity, "upl_AQEBAQEBAQEBAQEBAQEBAQ", now)
+	_, _, err = store.Create(t.Context(), record)
+	require.NoError(t, err)
+	_, err = store.Append(
+		t.Context(), identity, record.ID, 0, []byte("hello world"), now,
+	)
+	require.NoError(t, err)
+
+	reset, err := store.Reset(t.Context(), identity, record.ID, 0, now)
+	require.NoError(t, err)
+	assert.Zero(t, reset.Offset)
+	stagePath := filepath.Join(dataDir, rawUploadSpoolDirectory, record.ID+".part")
+	info, err := os.Stat(stagePath)
+	require.NoError(t, err)
+	assert.Equal(t, record.Object.Length, info.Size(),
+		"reset must not truncate after releasing the row lock")
+	appended, err := store.Append(
+		t.Context(), identity, record.ID, 0, []byte("replacement"), now,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, record.Object.Length, appended.Offset)
+	_, reader, err := store.Open(t.Context(), identity, record.ID, now)
+	require.NoError(t, err)
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, []byte("replacement"), data)
+}
+
+func TestRawUploadStoreResetFencesVerifiedGeneration(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	store, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	record := rawUploadRecord(t, identity, "upl_AQEBAQEBAQEBAQEBAQEBAQ", now)
+	_, _, err = store.Create(t.Context(), record)
+	require.NoError(t, err)
+	_, err = store.Append(
+		t.Context(), identity, record.ID, 0, []byte("hello earth"), now,
+	)
+	require.NoError(t, err)
+
+	verified, reader, err := store.Open(t.Context(), identity, record.ID, now)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	reset, err := store.Reset(
+		t.Context(), identity, record.ID, verified.Generation, now,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), reset.Generation)
+	_, err = store.Append(
+		t.Context(), identity, record.ID, 0, []byte("hello world"), now,
+	)
+	require.NoError(t, err)
+
+	_, err = store.Reset(
+		t.Context(), identity, record.ID, verified.Generation, now,
+	)
+	assert.ErrorIs(t, err, rawsync.ErrConflict)
+	status, err := store.Status(t.Context(), identity, record.ID, now)
+	require.NoError(t, err)
+	assert.Equal(t, record.Object.Length, status.Offset)
+	assert.Equal(t, int64(1), status.Generation)
+	_, reader, err = store.Open(t.Context(), identity, record.ID, now)
+	require.NoError(t, err)
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, []byte("hello world"), data)
+}
+
+func TestRawUploadStoreRetriesFailedStageDirectorySync(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	store, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	syncCalls := 0
+	store.syncDirectory = func() error {
+		syncCalls++
+		if syncCalls == 1 {
+			return errors.New("sync failed")
+		}
+		return nil
+	}
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	record := rawUploadRecord(t, identity, "upl_AQEBAQEBAQEBAQEBAQEBAQ", now)
+	_, _, err = store.Create(t.Context(), record)
+	require.NoError(t, err)
+	_, err = store.Append(t.Context(), identity, record.ID, 0, []byte("hello"), now)
+	require.ErrorContains(t, err, "sync failed")
+	stagePath := filepath.Join(dataDir, rawUploadSpoolDirectory, record.ID+".part")
+	_, err = os.Stat(stagePath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	status, err := store.Status(t.Context(), identity, record.ID, now)
+	require.NoError(t, err)
+	assert.Zero(t, status.Offset)
+
+	_, err = store.Append(t.Context(), identity, record.ID, 0, []byte("hello"), now)
+	require.NoError(t, err)
+	_, err = store.Append(t.Context(), identity, record.ID, 5, []byte(" world"), now)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, syncCalls)
+}
+
+func TestRawUploadStoreStartupCleansExpiredCompletedAndOrphanedSpools(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	store, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	past := now.Add(-2 * time.Hour)
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	records := []rawsync.UploadSession{
+		rawUploadRecord(t, identity, "upl_AQEBAQEBAQEBAQEBAQEBAQ", past),
+		rawUploadRecord(t, identity, "upl_AgICAgICAgICAgICAgICAg", past),
+		rawUploadRecord(t, identity, "upl_AwMDAwMDAwMDAwMDAwMDAw", now),
+	}
+	bodies := [][]byte{[]byte("hello world"), []byte("hello earth"), []byte("hello mars!")}
+	for index := range records {
+		records[index].Object = rawCustodyObjectRef(t, bodies[index])
+		record := records[index]
+		_, _, err = store.Create(t.Context(), record)
+		require.NoError(t, err)
+		_, err = store.Append(
+			t.Context(), identity, record.ID, 0, bodies[index][:5], record.CreatedAt,
+		)
+		require.NoError(t, err)
+	}
+	_, err = pg.ExecContext(t.Context(), `
+		UPDATE raw_upload_sessions
+		SET state = 'complete', offset_bytes = size_bytes, completed_at = $1,
+			updated_at = $1
+		WHERE upload_id = $2`, now, records[1].ID,
+	)
+	require.NoError(t, err)
+	orphanID := "upl_BAQEBAQEBAQEBAQEBAQEBA"
+	spoolDir := filepath.Join(dataDir, rawUploadSpoolDirectory)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(spoolDir, orphanID+".part"), []byte("orphan"), 0o600,
+	))
+	require.NoError(t, store.Close())
+
+	restarted, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restarted.Close()) })
+
+	var terminalRows int
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT count(*) FROM raw_upload_sessions
+		WHERE upload_id IN ($1, $2)`,
+		records[0].ID, records[1].ID,
+	).Scan(&terminalRows))
+	assert.Zero(t, terminalRows)
+	for _, uploadID := range []string{records[0].ID, records[1].ID, orphanID} {
+		assert.NoFileExists(t, filepath.Join(spoolDir, uploadID+".part"))
+	}
+	assert.FileExists(t, filepath.Join(spoolDir, records[2].ID+".part"))
+}
+
+func TestRawUploadStorePeriodicCleanupRunsOnTick(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	store, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	record := rawUploadRecord(t, identity, "upl_AQEBAQEBAQEBAQEBAQEBAQ", now)
+	_, _, err = store.Create(t.Context(), record)
+	require.NoError(t, err)
+	_, err = store.Append(t.Context(), identity, record.ID, 0, []byte("hello"), now)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ticks := make(chan time.Time, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		store.runCleanupLoop(ctx, ticks)
+	}()
+	ticks <- record.ExpiresAt
+	stagePath := filepath.Join(dataDir, rawUploadSpoolDirectory, record.ID+".part")
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(stagePath)
+		return errors.Is(statErr, os.ErrNotExist)
+	}, time.Second, 10*time.Millisecond)
+	cancel()
+	<-done
+}
+
+func TestRawUploadStoreCleanupBoundsEachPass(t *testing.T) {
+	pg, dataDir := newRawUploadTestDatabase(t)
+	store, err := NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	now := time.Now().UTC()
+	identity := rawUploadIdentity(t, pg, "tenant-a", "device-a")
+	for index := range rawUploadCleanupBatch + 1 {
+		_, err = pg.ExecContext(t.Context(), `
+			INSERT INTO raw_upload_sessions (
+				upload_id, tenant_id, device_id, provider, sha256, size_bytes,
+				offset_bytes, state, created_at, updated_at, expires_at
+			) VALUES ($1, $2, $3, $4, $5, 1, 0, 'open', $6, $6, $7)`,
+			fmt.Sprintf("bounded-cleanup-%03d", index),
+			identity.TenantID, identity.DeviceID, parser.AgentCodex,
+			fmt.Sprintf("%064x", index+1), now.Add(-2*time.Hour), now.Add(-time.Hour),
+		)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, store.cleanupExpiredAndOrphaned(t.Context(), now))
+
+	var open int
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT count(*) FILTER (WHERE state = 'open')
+		FROM raw_upload_sessions`).Scan(&open))
+	assert.Equal(t, 1, open)
+}
+
+func newRawUploadTestDatabase(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	pgURL := testPGURL(t)
+	cleanSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanSchemaTestPG(t, pgURL) })
+	pg, err := Open(pgURL, schemaTestSchema, true)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pg.Close()) })
+	require.NoError(t, EnsureSchema(t.Context(), pg, schemaTestSchema))
+	return pg, t.TempDir()
+}
+
+func rawUploadIdentity(
+	t *testing.T,
+	pg *sql.DB,
+	tenantID string,
+	deviceID string,
+) rawsync.AuthIdentity {
+	t.Helper()
+	digest := sha256.Sum256([]byte(tenantID + "/" + deviceID))
+	_, err := pg.ExecContext(t.Context(), `
+		INSERT INTO raw_devices (
+			device_id, tenant_id, display_name, credential_sha256, created_at
+		) VALUES ($1, $2, $1, $3, $4)`,
+		deviceID, tenantID, digest[:],
+		time.Date(2026, time.August, 19, 11, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	identity, err := rawsync.NewAuthIdentity(tenantID, deviceID)
+	require.NoError(t, err)
+	return identity
+}
+
+func rawUploadRecord(
+	t *testing.T,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	now time.Time,
+) rawsync.UploadSession {
+	t.Helper()
+	object := rawCustodyObjectRef(t, []byte("hello world"))
+	return rawsync.UploadSession{
+		ID: uploadID, Identity: identity, Provider: parser.AgentCodex,
+		Object: object, CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}
+}

--- a/internal/postgres/raw_upload_store_test.go
+++ b/internal/postgres/raw_upload_store_test.go
@@ -1,0 +1,24 @@
+package postgres
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenRawUploadSpoolSyncsParentDirectory(t *testing.T) {
+	dataDir := t.TempDir()
+	var syncedPath string
+
+	root, err := openRawUploadSpool(dataDir, func(path string) error {
+		syncedPath = path
+		return nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, root.Close()) })
+
+	assert.Equal(t, dataDir, syncedPath)
+	assert.DirExists(t, filepath.Join(dataDir, rawUploadSpoolDirectory))
+}

--- a/internal/postgres/raw_upload_sync_unix.go
+++ b/internal/postgres/raw_upload_sync_unix.go
@@ -1,0 +1,14 @@
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package postgres
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isRawUploadDirectorySyncUnsupported(err error) bool {
+	return errors.Is(err, syscall.EINVAL) ||
+		errors.Is(err, syscall.ENOSYS) ||
+		errors.Is(err, syscall.ENOTSUP)
+}

--- a/internal/postgres/raw_upload_sync_unix_test.go
+++ b/internal/postgres/raw_upload_sync_unix_test.go
@@ -1,0 +1,20 @@
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package postgres
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRawUploadDirectorySyncUnsupportedErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{syscall.EINVAL, syscall.ENOSYS, syscall.ENOTSUP} {
+		assert.True(t, isRawUploadDirectorySyncUnsupported(err))
+	}
+	assert.False(t, isRawUploadDirectorySyncUnsupported(errors.New("disk failure")))
+}

--- a/internal/postgres/raw_upload_sync_windows.go
+++ b/internal/postgres/raw_upload_sync_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package postgres
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isRawUploadDirectorySyncUnsupported(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_INVALID_FUNCTION) ||
+		errors.Is(err, windows.ERROR_INVALID_HANDLE) ||
+		errors.Is(err, windows.ERROR_NOT_SUPPORTED)
+}

--- a/internal/postgres/raw_upload_sync_windows_test.go
+++ b/internal/postgres/raw_upload_sync_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package postgres
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+func TestRawUploadDirectorySyncUnsupportedErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{
+		windows.ERROR_ACCESS_DENIED,
+		windows.ERROR_INVALID_FUNCTION,
+		windows.ERROR_INVALID_HANDLE,
+		windows.ERROR_NOT_SUPPORTED,
+	} {
+		assert.True(t, isRawUploadDirectorySyncUnsupported(err))
+	}
+	assert.False(t, isRawUploadDirectorySyncUnsupported(errors.New("disk failure")))
+}

--- a/internal/rawsync/upload.go
+++ b/internal/rawsync/upload.go
@@ -1,0 +1,445 @@
+package rawsync
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+const (
+	DefaultUploadChunkBytes = int64(4 << 20)
+	DefaultUploadSessionTTL = 24 * time.Hour
+
+	uploadIDPrefix      = "upl_"
+	uploadIDRandomSize  = 16
+	uploadIDEncodedSize = 22
+	maxUploadSessionTTL = 7 * 24 * time.Hour
+	uploadFinalizeLocks = 64
+)
+
+// UploadOffsetConflictError reports the authoritative resumable offset.
+type UploadOffsetConflictError struct {
+	CurrentOffset int64
+}
+
+func (e *UploadOffsetConflictError) Error() string {
+	return "raw upload offset changed"
+}
+
+func (e *UploadOffsetConflictError) Unwrap() error { return ErrConflict }
+
+// UploadChecksumMismatchError reports that staged bytes were discarded.
+type UploadChecksumMismatchError struct {
+	CurrentOffset int64
+}
+
+func (e *UploadChecksumMismatchError) Error() string {
+	return "raw upload checksum did not match"
+}
+
+func (e *UploadChecksumMismatchError) Unwrap() error { return ErrConflict }
+
+// UploadSession is one durable, device-bound object transfer.
+type UploadSession struct {
+	ID         string
+	Identity   AuthIdentity
+	Provider   parser.AgentType
+	Object     ObjectRef
+	Offset     int64
+	Generation int64
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	Complete   bool
+}
+
+// UploadSessionStore owns durable session metadata and restart-safe staged bytes.
+type UploadSessionStore interface {
+	Create(context.Context, UploadSession) (UploadSession, bool, error)
+	Status(context.Context, AuthIdentity, string, time.Time) (UploadSession, error)
+	Append(
+		context.Context, AuthIdentity, string, int64, []byte, time.Time,
+	) (UploadSession, error)
+	Open(
+		context.Context, AuthIdentity, string, time.Time,
+	) (UploadSession, io.ReadCloser, error)
+	Reset(
+		context.Context, AuthIdentity, string, int64, time.Time,
+	) (UploadSession, error)
+	Complete(context.Context, AuthIdentity, string, time.Time) (UploadSession, error)
+}
+
+// UploadCustody is the existing verified raw-object boundary used at finalization.
+type UploadCustody interface {
+	MissingObjects(
+		context.Context, AuthIdentity, parser.AgentType, []ObjectRef,
+	) ([]ObjectRef, error)
+	FinalizeObject(
+		context.Context, AuthIdentity, parser.AgentType, ObjectRef, io.Reader,
+	) (PutResult, error)
+}
+
+// UploadService coordinates exact-offset staging with independently verified custody.
+type UploadService struct {
+	store   UploadSessionStore
+	custody UploadCustody
+	ttl     time.Duration
+	random  io.Reader
+	now     func() time.Time
+	locks   [uploadFinalizeLocks]chan struct{}
+}
+
+// NewUploadService constructs the resumable raw-object transfer boundary.
+func NewUploadService(
+	store UploadSessionStore,
+	custody UploadCustody,
+	ttl time.Duration,
+) (*UploadService, error) {
+	if isNilServiceDependency(store) {
+		return nil, fmt.Errorf("%w: upload session store is required", ErrInvalid)
+	}
+	if isNilServiceDependency(custody) {
+		return nil, fmt.Errorf("%w: upload custody service is required", ErrInvalid)
+	}
+	if ttl <= 0 || ttl > maxUploadSessionTTL {
+		return nil, fmt.Errorf(
+			"%w: upload session lifetime must be greater than zero and at most %s",
+			ErrInvalid, maxUploadSessionTTL,
+		)
+	}
+	service := &UploadService{
+		store: store, custody: custody, ttl: ttl, random: rand.Reader, now: time.Now,
+	}
+	for index := range service.locks {
+		service.locks[index] = make(chan struct{}, 1)
+		service.locks[index] <- struct{}{}
+	}
+	return service, nil
+}
+
+// Start creates or resumes one upload, or reports already-verified custody.
+func (s *UploadService) Start(
+	ctx context.Context,
+	identity AuthIdentity,
+	provider parser.AgentType,
+	object ObjectRef,
+) (UploadSession, bool, error) {
+	if err := validateServiceIdentity(identity); err != nil {
+		return UploadSession{}, false, err
+	}
+	if err := validateProvider(provider); err != nil {
+		return UploadSession{}, false, err
+	}
+	canonical, err := NewObjectRef(object.SHA256, object.Length)
+	if err != nil || canonical != object {
+		return UploadSession{}, false, fmt.Errorf("%w: invalid upload object", ErrInvalid)
+	}
+	missing, err := s.custody.MissingObjects(ctx, identity, provider, []ObjectRef{object})
+	if err != nil {
+		return UploadSession{}, false, fmt.Errorf("checking upload object custody: %w", err)
+	}
+	if len(missing) == 0 {
+		return UploadSession{
+			Identity: identity, Provider: provider, Object: object,
+			Offset: object.Length, Complete: true,
+		}, false, nil
+	}
+	if len(missing) != 1 || missing[0] != object {
+		return UploadSession{}, false, fmt.Errorf(
+			"upload custody returned a different missing object: %w", ErrConflict,
+		)
+	}
+	uploadID, err := s.newUploadID()
+	if err != nil {
+		return UploadSession{}, false, fmt.Errorf("generating raw upload identity: %w", err)
+	}
+	now := s.now().UTC()
+	record := UploadSession{
+		ID: uploadID, Identity: identity, Provider: provider, Object: object,
+		CreatedAt: now, ExpiresAt: now.Add(s.ttl),
+	}
+	session, created, err := s.store.Create(ctx, record)
+	if err != nil {
+		return UploadSession{}, false, fmt.Errorf("creating raw upload session: %w", err)
+	}
+	if err := validateStoredUploadSession(session, identity, session.ID); err != nil ||
+		session.Provider != provider || session.Object != object || session.Complete {
+		return UploadSession{}, false, fmt.Errorf(
+			"upload session store returned a different transfer: %w", ErrConflict,
+		)
+	}
+	return session, created, nil
+}
+
+// Status returns the authoritative offset for one device-bound upload.
+func (s *UploadService) Status(
+	ctx context.Context,
+	identity AuthIdentity,
+	uploadID string,
+) (UploadSession, error) {
+	if err := validateServiceIdentity(identity); err != nil {
+		return UploadSession{}, err
+	}
+	if err := validateUploadID(uploadID); err != nil {
+		return UploadSession{}, err
+	}
+	session, err := s.store.Status(ctx, identity, uploadID, s.now().UTC())
+	if err != nil {
+		return UploadSession{}, fmt.Errorf("loading raw upload session: %w", err)
+	}
+	if err := validateStoredUploadSession(session, identity, uploadID); err != nil {
+		return UploadSession{}, fmt.Errorf("validating raw upload session: %w", err)
+	}
+	return session, nil
+}
+
+// Append writes one exact-offset chunk and finalizes full objects idempotently.
+func (s *UploadService) Append(
+	ctx context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	expectedOffset int64,
+	chunk []byte,
+) (UploadSession, error) {
+	if err := validateServiceIdentity(identity); err != nil {
+		return UploadSession{}, err
+	}
+	if err := validateUploadID(uploadID); err != nil {
+		return UploadSession{}, err
+	}
+	if expectedOffset < 0 || int64(len(chunk)) > DefaultUploadChunkBytes {
+		return UploadSession{}, fmt.Errorf("%w: invalid raw upload chunk", ErrInvalid)
+	}
+	now := s.now().UTC()
+	session, err := s.store.Append(ctx, identity, uploadID, expectedOffset, chunk, now)
+	if err != nil {
+		return UploadSession{}, fmt.Errorf("appending raw upload chunk: %w", err)
+	}
+	if err := validateStoredUploadSession(session, identity, uploadID); err != nil {
+		return UploadSession{}, fmt.Errorf("validating appended raw upload session: %w", err)
+	}
+	if session.Complete {
+		return session, nil
+	}
+	expectedAfter := expectedOffset + int64(len(chunk))
+	if session.Offset != expectedAfter {
+		return UploadSession{}, fmt.Errorf(
+			"upload session store advanced to a different offset: %w", ErrConflict,
+		)
+	}
+	if session.Offset < session.Object.Length {
+		if len(chunk) == 0 {
+			return UploadSession{}, fmt.Errorf("%w: empty upload chunk made no progress", ErrInvalid)
+		}
+		return session, nil
+	}
+	return s.finalizeSerialized(ctx, identity, uploadID, session, now)
+}
+
+func (s *UploadService) finalizeSerialized(
+	ctx context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	session UploadSession,
+	now time.Time,
+) (UploadSession, error) {
+	digest := sha256.Sum256([]byte(uploadID))
+	lock := s.locks[int(digest[0])%len(s.locks)]
+	select {
+	case <-ctx.Done():
+		return UploadSession{}, ctx.Err()
+	case <-lock:
+	}
+	defer func() { lock <- struct{}{} }()
+
+	current, err := s.store.Status(ctx, identity, uploadID, now)
+	if err != nil {
+		return UploadSession{}, fmt.Errorf("rechecking raw upload before finalization: %w", err)
+	}
+	if err := validateStoredUploadSession(current, identity, uploadID); err != nil ||
+		current.Provider != session.Provider || current.Object != session.Object {
+		return UploadSession{}, fmt.Errorf("raw upload changed before finalization: %w", ErrConflict)
+	}
+	if current.Complete {
+		return current, nil
+	}
+	if current.Offset != current.Object.Length || current.Offset != session.Offset {
+		return UploadSession{}, fmt.Errorf("raw upload offset changed before finalization: %w", ErrConflict)
+	}
+	return s.finalize(ctx, identity, uploadID, current, now)
+}
+
+func (s *UploadService) finalize(
+	ctx context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	session UploadSession,
+	now time.Time,
+) (UploadSession, error) {
+	opened, reader, err := s.store.Open(ctx, identity, uploadID, now)
+	if err != nil {
+		if completed, ok := s.completedAfterFinalizeRace(
+			ctx, identity, uploadID, session, now,
+		); ok {
+			return completed, nil
+		}
+		return UploadSession{}, fmt.Errorf("opening staged raw upload: %w", err)
+	}
+	if err := validateStoredUploadSession(opened, identity, uploadID); err != nil ||
+		opened.Object != session.Object || opened.Offset != session.Offset {
+		_ = reader.Close()
+		return UploadSession{}, fmt.Errorf("staged raw upload changed: %w", ErrConflict)
+	}
+	hash := sha256.New()
+	readBytes, readErr := io.Copy(hash, &uploadContextReader{ctx: ctx, reader: reader})
+	readErr = errors.Join(readErr, reader.Close())
+	if readErr != nil {
+		return UploadSession{}, fmt.Errorf("hashing staged raw upload: %w", readErr)
+	}
+	digest := hex.EncodeToString(hash.Sum(nil))
+	if readBytes != session.Object.Length || digest != session.Object.SHA256 {
+		reset, resetErr := s.store.Reset(
+			ctx, identity, uploadID, opened.Generation, now,
+		)
+		if resetErr != nil {
+			return UploadSession{}, fmt.Errorf("resetting mismatched raw upload: %w", resetErr)
+		}
+		mismatch := &UploadChecksumMismatchError{CurrentOffset: 0}
+		if err := validateStoredUploadSession(reset, identity, uploadID); err != nil ||
+			reset.Offset != 0 || reset.Complete {
+			return UploadSession{}, errors.Join(
+				mismatch, fmt.Errorf("upload store returned an invalid reset: %w", ErrConflict),
+			)
+		}
+		return reset, mismatch
+	}
+
+	opened, reader, err = s.store.Open(ctx, identity, uploadID, now)
+	if err != nil {
+		if completed, ok := s.completedAfterFinalizeRace(
+			ctx, identity, uploadID, session, now,
+		); ok {
+			return completed, nil
+		}
+		return UploadSession{}, fmt.Errorf("reopening verified raw upload: %w", err)
+	}
+	if err := validateStoredUploadSession(opened, identity, uploadID); err != nil ||
+		opened.Object != session.Object || opened.Offset != session.Offset {
+		_ = reader.Close()
+		return UploadSession{}, fmt.Errorf("verified raw upload changed: %w", ErrConflict)
+	}
+	result, finalizeErr := s.custody.FinalizeObject(
+		ctx, identity, session.Provider, session.Object,
+		&uploadContextReader{ctx: ctx, reader: reader},
+	)
+	finalizeErr = errors.Join(finalizeErr, reader.Close())
+	if finalizeErr != nil {
+		return UploadSession{}, fmt.Errorf("finalizing staged raw upload: %w", finalizeErr)
+	}
+	if result.Info.Ref != session.Object {
+		return UploadSession{}, fmt.Errorf("raw upload custody changed identity: %w", ErrConflict)
+	}
+	completed, err := s.store.Complete(ctx, identity, uploadID, now)
+	if err != nil {
+		return UploadSession{}, fmt.Errorf("completing raw upload session: %w", err)
+	}
+	if err := validateStoredUploadSession(completed, identity, uploadID); err != nil ||
+		!completed.Complete || completed.Offset != completed.Object.Length {
+		return UploadSession{}, fmt.Errorf("upload store returned invalid completion: %w", ErrConflict)
+	}
+	return completed, nil
+}
+
+func (s *UploadService) completedAfterFinalizeRace(
+	ctx context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	expected UploadSession,
+	now time.Time,
+) (UploadSession, bool) {
+	current, err := s.store.Status(ctx, identity, uploadID, now)
+	if err != nil || validateStoredUploadSession(current, identity, uploadID) != nil ||
+		current.Provider != expected.Provider || current.Object != expected.Object ||
+		!current.Complete {
+		return UploadSession{}, false
+	}
+	return current, true
+}
+
+type uploadContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *uploadContextReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(buffer)
+}
+
+func (s *UploadService) newUploadID() (string, error) {
+	buffer := make([]byte, uploadIDRandomSize)
+	if _, err := io.ReadFull(s.random, buffer); err != nil {
+		return "", err
+	}
+	return uploadIDPrefix + base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func validateUploadID(value string) error {
+	encoded, ok := strings.CutPrefix(value, uploadIDPrefix)
+	if !ok || len(encoded) != uploadIDEncodedSize {
+		return fmt.Errorf("%w: invalid raw upload identity", ErrInvalid)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil || len(decoded) != uploadIDRandomSize ||
+		base64.RawURLEncoding.EncodeToString(decoded) != encoded {
+		return fmt.Errorf("%w: invalid raw upload identity", ErrInvalid)
+	}
+	return nil
+}
+
+// ValidateUploadSession rejects noncanonical durable session records.
+func ValidateUploadSession(session UploadSession) error {
+	if err := validateUploadID(session.ID); err != nil {
+		return err
+	}
+	if err := validateServiceIdentity(session.Identity); err != nil {
+		return err
+	}
+	if err := validateProvider(session.Provider); err != nil {
+		return err
+	}
+	canonical, err := NewObjectRef(session.Object.SHA256, session.Object.Length)
+	if err != nil || canonical != session.Object ||
+		session.Offset < 0 || session.Offset > session.Object.Length ||
+		session.Generation < 0 ||
+		session.CreatedAt.IsZero() || session.ExpiresAt.IsZero() ||
+		!session.ExpiresAt.After(session.CreatedAt) ||
+		(session.Complete && session.Offset != session.Object.Length) {
+		return fmt.Errorf("%w: invalid raw upload session", ErrInvalid)
+	}
+	return nil
+}
+
+func validateStoredUploadSession(
+	session UploadSession,
+	identity AuthIdentity,
+	uploadID string,
+) error {
+	if session.ID != uploadID || session.Identity != identity ||
+		ValidateUploadSession(session) != nil {
+		return ErrConflict
+	}
+	return nil
+}
+
+var _ UploadCustody = (*Service)(nil)

--- a/internal/rawsync/upload_test.go
+++ b/internal/rawsync/upload_test.go
@@ -1,0 +1,544 @@
+package rawsync
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestUploadServiceStartsDurableDeviceBoundSession(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	custody := newMemoryUploadCustody()
+	service := newUploadServiceForTest(t, store, custody, now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	object := objectRefForBytes(t, []byte("hello"))
+
+	session, created, err := service.Start(
+		t.Context(), identity, parser.AgentCodex, object,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, created)
+	assert.Equal(t, "upl_AQEBAQEBAQEBAQEBAQEBAQ", session.ID)
+	assert.Equal(t, identity, session.Identity)
+	assert.Equal(t, parser.AgentCodex, session.Provider)
+	assert.Equal(t, object, session.Object)
+	assert.Zero(t, session.Offset)
+	assert.Equal(t, now, session.CreatedAt)
+	assert.Equal(t, now.Add(DefaultUploadSessionTTL), session.ExpiresAt)
+	assert.False(t, session.Complete)
+	assert.Equal(t, 1, store.createCalls)
+}
+
+func TestUploadServiceSkipsSessionWhenObjectAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	custody := newMemoryUploadCustody()
+	custody.objectPresent = true
+	service := newUploadServiceForTest(t, store, custody, now)
+	object := objectRefForBytes(t, []byte("already present"))
+
+	session, created, err := service.Start(
+		t.Context(), AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"},
+		parser.AgentCodex, object,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, created)
+	assert.Empty(t, session.ID)
+	assert.Equal(t, object.Length, session.Offset)
+	assert.True(t, session.Complete)
+	assert.Zero(t, store.createCalls)
+}
+
+func TestUploadServiceAppendsAndIndependentlyFinalizesExactObject(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	events := make([]string, 0)
+	store := newMemoryUploadSessionStore()
+	store.events = &events
+	custody := newMemoryUploadCustody()
+	custody.events = &events
+	service := newUploadServiceForTest(t, store, custody, now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	body := []byte("complete object")
+	object := objectRefForBytes(t, body)
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+
+	partial, err := service.Append(
+		t.Context(), identity, session.ID, 0, body[:5],
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), partial.Offset)
+	assert.False(t, partial.Complete)
+	assert.Zero(t, custody.finalizeCalls)
+
+	completed, err := service.Append(
+		t.Context(), identity, session.ID, 5, body[5:],
+	)
+
+	require.NoError(t, err)
+	assert.True(t, completed.Complete)
+	assert.Equal(t, object.Length, completed.Offset)
+	assert.Equal(t, body, custody.finalizedBody)
+	assert.Equal(t, 1, custody.finalizeCalls)
+	assert.Equal(t, []string{
+		"append", "append", "open", "open", "finalize", "complete",
+	}, events)
+}
+
+func TestUploadServiceReturnsCurrentOffsetWithoutWritingOnConflict(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	custody := newMemoryUploadCustody()
+	service := newUploadServiceForTest(t, store, custody, now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	object := objectRefForBytes(t, []byte("offset"))
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+
+	_, err = service.Append(t.Context(), identity, session.ID, 3, []byte("bad"))
+
+	var conflict *UploadOffsetConflictError
+	require.ErrorAs(t, err, &conflict)
+	assert.Zero(t, conflict.CurrentOffset)
+	assert.Empty(t, store.data)
+	assert.Zero(t, custody.finalizeCalls)
+}
+
+func TestUploadServiceChecksumMismatchResetsSession(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	custody := newMemoryUploadCustody()
+	service := newUploadServiceForTest(t, store, custody, now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	object := objectRefForBytes(t, []byte("expected"))
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+
+	_, err = service.Append(
+		t.Context(), identity, session.ID, 0, []byte("corrupt!"),
+	)
+
+	var mismatch *UploadChecksumMismatchError
+	require.ErrorAs(t, err, &mismatch)
+	assert.Zero(t, mismatch.CurrentOffset)
+	assert.Zero(t, store.session.Offset)
+	assert.Empty(t, store.data)
+	assert.Equal(t, 1, store.resetCalls)
+	assert.Zero(t, custody.finalizeCalls)
+}
+
+func TestUploadServiceDoesNotReportResetOffsetWhenResetFails(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	store.resetErr = errors.New("database unavailable")
+	service := newUploadServiceForTest(t, store, newMemoryUploadCustody(), now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	object := objectRefForBytes(t, []byte("expected"))
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+
+	_, err = service.Append(t.Context(), identity, session.ID, 0, []byte("corrupt!"))
+
+	var mismatch *UploadChecksumMismatchError
+	assert.NotErrorAs(t, err, &mismatch)
+	assert.ErrorContains(t, err, "database unavailable")
+	assert.Equal(t, object.Length, store.session.Offset)
+}
+
+func TestUploadServiceStopsHashingWhenRequestIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	service := newUploadServiceForTest(t, store, newMemoryUploadCustody(), now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	body := bytes.Repeat([]byte("cancel"), 1024)
+	object := objectRefForBytes(t, body)
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	store.openReader = func(data []byte) io.ReadCloser {
+		return io.NopCloser(&cancelAfterFirstRead{reader: bytes.NewReader(data), cancel: cancel})
+	}
+
+	_, err = service.Append(ctx, identity, session.ID, 0, body)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.False(t, store.session.Complete)
+}
+
+func TestUploadServiceSerializesDuplicateFinalization(t *testing.T) {
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	custody := newMemoryUploadCustody()
+	custody.finalizeStarted = make(chan struct{}, 2)
+	custody.finalizeRelease = make(chan struct{})
+	service := newUploadServiceForTest(t, store, custody, now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	body := []byte("duplicate final patch")
+	object := objectRefForBytes(t, body)
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+	store.session.Offset = object.Length
+	store.data = append([]byte(nil), body...)
+
+	results := make(chan error, 2)
+	go func() {
+		_, appendErr := service.Append(t.Context(), identity, session.ID, object.Length, nil)
+		results <- appendErr
+	}()
+	select {
+	case <-custody.finalizeStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "first finalization did not start")
+	}
+	go func() {
+		_, appendErr := service.Append(t.Context(), identity, session.ID, object.Length, nil)
+		results <- appendErr
+	}()
+	select {
+	case <-custody.finalizeStarted:
+		require.FailNow(t, "duplicate finalization reached custody concurrently")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(custody.finalizeRelease)
+
+	require.NoError(t, <-results)
+	require.NoError(t, <-results)
+	assert.Equal(t, 1, custody.finalizeCalls)
+	assert.True(t, store.session.Complete)
+}
+
+func TestUploadServiceAcceptsCompletionByAnotherProcess(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	custody := newMemoryUploadCustody()
+	service := newUploadServiceForTest(t, store, custody, now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	body := []byte("completed elsewhere")
+	object := objectRefForBytes(t, body)
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+	store.session.Offset = object.Length
+	store.data = append([]byte(nil), body...)
+	store.completeOnOpen = true
+
+	completed, err := service.Append(
+		t.Context(), identity, session.ID, object.Length, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, completed.Complete)
+	assert.Equal(t, object.Length, completed.Offset)
+	assert.Zero(t, custody.finalizeCalls)
+}
+
+func TestUploadServiceRetriesFinalizationWithoutAnotherChunk(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	custody := newMemoryUploadCustody()
+	custody.finalizeErr = errors.New("custody unavailable")
+	service := newUploadServiceForTest(t, store, custody, now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	body := []byte("retry")
+	object := objectRefForBytes(t, body)
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+
+	_, err = service.Append(t.Context(), identity, session.ID, 0, body)
+	require.ErrorContains(t, err, "custody unavailable")
+	assert.Equal(t, object.Length, store.session.Offset)
+	assert.False(t, store.session.Complete)
+
+	custody.finalizeErr = nil
+	completed, err := service.Append(
+		t.Context(), identity, session.ID, object.Length, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, completed.Complete)
+	assert.Equal(t, 2, custody.finalizeCalls)
+}
+
+func TestUploadServiceRejectsOversizedChunkBeforeStore(t *testing.T) {
+	t.Parallel()
+
+	service := newUploadServiceForTest(
+		t, newMemoryUploadSessionStore(), newMemoryUploadCustody(), time.Now().UTC(),
+	)
+
+	_, err := service.Append(
+		t.Context(),
+		AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"},
+		"upl_AQEBAQEBAQEBAQEBAQEBAQ",
+		0,
+		make([]byte, DefaultUploadChunkBytes+1),
+	)
+
+	assert.ErrorIs(t, err, ErrInvalid)
+}
+
+func newUploadServiceForTest(
+	t *testing.T,
+	store UploadSessionStore,
+	custody UploadCustody,
+	now time.Time,
+) *UploadService {
+	t.Helper()
+	service, err := NewUploadService(store, custody, DefaultUploadSessionTTL)
+	require.NoError(t, err)
+	service.random = bytes.NewReader(bytes.Repeat([]byte{1}, uploadIDRandomSize))
+	service.now = func() time.Time { return now }
+	return service
+}
+
+type memoryUploadSessionStore struct {
+	mu             sync.Mutex
+	session        UploadSession
+	data           []byte
+	events         *[]string
+	openReader     func([]byte) io.ReadCloser
+	completeOnOpen bool
+	resetErr       error
+	createCalls    int
+	resetCalls     int
+	completeCalls  int
+}
+
+func newMemoryUploadSessionStore() *memoryUploadSessionStore {
+	return new(memoryUploadSessionStore)
+}
+
+func (s *memoryUploadSessionStore) Create(
+	_ context.Context,
+	record UploadSession,
+) (UploadSession, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.createCalls++
+	if s.session.ID != "" {
+		return s.session, false, nil
+	}
+	s.session = record
+	return record, true, nil
+}
+
+func (s *memoryUploadSessionStore) Status(
+	_ context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	_ time.Time,
+) (UploadSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.session.ID != uploadID || s.session.Identity != identity {
+		return UploadSession{}, ErrNotFound
+	}
+	return s.session, nil
+}
+
+func (s *memoryUploadSessionStore) Append(
+	_ context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	expectedOffset int64,
+	chunk []byte,
+	_ time.Time,
+) (UploadSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.events != nil {
+		*s.events = append(*s.events, "append")
+	}
+	if s.session.ID != uploadID || s.session.Identity != identity {
+		return UploadSession{}, ErrNotFound
+	}
+	if s.session.Offset != expectedOffset {
+		return UploadSession{}, &UploadOffsetConflictError{
+			CurrentOffset: s.session.Offset,
+		}
+	}
+	if int64(len(chunk)) > s.session.Object.Length-s.session.Offset {
+		return UploadSession{}, ErrInvalid
+	}
+	s.data = append(s.data, chunk...)
+	s.session.Offset += int64(len(chunk))
+	return s.session, nil
+}
+
+func (s *memoryUploadSessionStore) Open(
+	_ context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	_ time.Time,
+) (UploadSession, io.ReadCloser, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.events != nil {
+		*s.events = append(*s.events, "open")
+	}
+	if s.session.ID != uploadID || s.session.Identity != identity {
+		return UploadSession{}, nil, ErrNotFound
+	}
+	if s.completeOnOpen {
+		s.completeOnOpen = false
+		s.session.Complete = true
+		return UploadSession{}, nil, ErrNotFound
+	}
+	data := append([]byte(nil), s.data...)
+	if s.openReader != nil {
+		return s.session, s.openReader(data), nil
+	}
+	return s.session, io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *memoryUploadSessionStore) Reset(
+	_ context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	expectedGeneration int64,
+	_ time.Time,
+) (UploadSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.session.ID != uploadID || s.session.Identity != identity {
+		return UploadSession{}, ErrNotFound
+	}
+	if s.session.Generation != expectedGeneration {
+		return UploadSession{}, ErrConflict
+	}
+	s.resetCalls++
+	if s.resetErr != nil {
+		return UploadSession{}, s.resetErr
+	}
+	s.data = nil
+	s.session.Offset = 0
+	s.session.Generation++
+	return s.session, nil
+}
+
+func (s *memoryUploadSessionStore) Complete(
+	_ context.Context,
+	identity AuthIdentity,
+	uploadID string,
+	_ time.Time,
+) (UploadSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.events != nil {
+		*s.events = append(*s.events, "complete")
+	}
+	if s.session.ID != uploadID || s.session.Identity != identity {
+		return UploadSession{}, ErrNotFound
+	}
+	s.completeCalls++
+	s.session.Complete = true
+	return s.session, nil
+}
+
+type memoryUploadCustody struct {
+	mu              sync.Mutex
+	objectPresent   bool
+	finalizeErr     error
+	finalizedBody   []byte
+	finalizeCalls   int
+	events          *[]string
+	finalizeStarted chan struct{}
+	finalizeRelease chan struct{}
+}
+
+func newMemoryUploadCustody() *memoryUploadCustody {
+	return new(memoryUploadCustody)
+}
+
+func (s *memoryUploadCustody) MissingObjects(
+	_ context.Context,
+	_ AuthIdentity,
+	_ parser.AgentType,
+	objects []ObjectRef,
+) ([]ObjectRef, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.objectPresent {
+		return nil, nil
+	}
+	return objects, nil
+}
+
+func (s *memoryUploadCustody) FinalizeObject(
+	_ context.Context,
+	_ AuthIdentity,
+	_ parser.AgentType,
+	object ObjectRef,
+	body io.Reader,
+) (PutResult, error) {
+	s.mu.Lock()
+	if s.events != nil {
+		*s.events = append(*s.events, "finalize")
+	}
+	s.finalizeCalls++
+	started := s.finalizeStarted
+	release := s.finalizeRelease
+	finalizeErr := s.finalizeErr
+	s.mu.Unlock()
+	if started != nil {
+		started <- struct{}{}
+	}
+	if release != nil {
+		<-release
+	}
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return PutResult{}, err
+	}
+	s.mu.Lock()
+	s.finalizedBody = data
+	s.mu.Unlock()
+	if finalizeErr != nil {
+		return PutResult{}, finalizeErr
+	}
+	return PutResult{Info: ObjectInfo{Ref: object}, Created: true}, nil
+}
+
+type cancelAfterFirstRead struct {
+	reader io.Reader
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (r *cancelAfterFirstRead) Read(buffer []byte) (int, error) {
+	read, err := r.reader.Read(buffer)
+	r.once.Do(r.cancel)
+	return read, err
+}
+
+var _ UploadSessionStore = (*memoryUploadSessionStore)(nil)
+var _ UploadCustody = (*memoryUploadCustody)(nil)

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -111,14 +111,14 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		// and scoped tokens before Host and CORS middleware relax remote
 		// restrictions. They never compare against the legacy shared bearer.
 		if s.isRawSyncOwnAuthPath(r.URL.Path) {
-			requestCtx := r.Context()
+			baseCtx := r.Context()
+			authCtx := baseCtx
 			cancel := func() {}
 			if writeTimeout > 0 {
-				requestCtx, cancel = context.WithTimeout(requestCtx, writeTimeout)
+				authCtx, cancel = context.WithTimeout(authCtx, writeTimeout)
 			}
 			defer cancel()
-			r = r.WithContext(requestCtx)
-			identity, err := s.authenticateRawSyncRequest(r)
+			identity, err := s.authenticateRawSyncRequest(r.WithContext(authCtx))
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					http.Error(w, "raw sync authentication timed out", http.StatusGatewayTimeout)
@@ -133,7 +133,15 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 				http.Error(w, "raw sync authentication failed", http.StatusInternalServerError)
 				return
 			}
-			ctx := context.WithValue(requestCtx, ctxKeyRawSyncIdentity, identity)
+			handlerCtx := authCtx
+			if r.Method == http.MethodPatch && isRawSyncUploadPath(r.URL.Path) {
+				// Upload authentication stays bounded by WriteTimeout, but body
+				// transfer and checksum finalization use the client's request
+				// lifetime plus the route's extended transport read deadline.
+				cancel()
+				handlerCtx = baseCtx
+			}
+			ctx := context.WithValue(handlerCtx, ctxKeyRawSyncIdentity, identity)
 			ctx = context.WithValue(ctx, ctxKeyRemoteAuth, true)
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
@@ -220,8 +228,11 @@ func (s *Server) isRawSyncOwnAuthPath(path string) bool {
 	if s.rawSyncCustody == nil {
 		return false
 	}
-	return path == "/api/v1/raw-sync/objects/missing" ||
-		path == "/api/v1/raw-sync/manifests"
+	if path == "/api/v1/raw-sync/objects/missing" ||
+		path == "/api/v1/raw-sync/manifests" {
+		return true
+	}
+	return s.rawSyncUploads != nil && isRawSyncUploadPath(path)
 }
 
 func (s *Server) authenticateRawSyncRequest(
@@ -245,8 +256,21 @@ func (s *Server) authenticateRawSyncRequest(
 			r.Context(), secret, rawsync.ScopeCommit,
 		)
 	default:
+		if s.rawSyncUploads != nil && isRawSyncUploadPath(r.URL.Path) {
+			return s.rawSyncDeviceAuth.AuthenticateToken(
+				r.Context(), secret, rawsync.ScopeUpload,
+			)
+		}
 		return rawsync.AuthIdentity{}, rawsync.ErrUnauthorized
 	}
+}
+
+func isRawSyncUploadPath(path string) bool {
+	if path == "/api/v1/raw-sync/uploads" {
+		return true
+	}
+	remainder, ok := strings.CutPrefix(path, "/api/v1/raw-sync/uploads/")
+	return ok && remainder != "" && !strings.Contains(remainder, "/")
 }
 
 // setCORSOnAuthError adds CORS headers to 401 responses so

--- a/internal/server/compress.go
+++ b/internal/server/compress.go
@@ -58,6 +58,10 @@ type gzipResponseWriter struct {
 	plain       bool
 }
 
+func (w *gzipResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 func (w *gzipResponseWriter) Header() http.Header {
 	return w.ResponseWriter.Header()
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -45,12 +45,13 @@ type bytesOutput struct {
 }
 
 type apiErrorResponse struct {
-	Status            int    `json:"-"`
-	Code              string `json:"code,omitempty"`
-	Message           string `json:"error"`
-	CurrentManifestID string `json:"current_manifest_id,omitempty"`
-	CurrentReceipt    string `json:"current_receipt,omitempty"`
-	CurrentGeneration int64  `json:"current_generation,omitzero"`
+	Status              int    `json:"-"`
+	Code                string `json:"code,omitempty"`
+	Message             string `json:"error"`
+	CurrentManifestID   string `json:"current_manifest_id,omitempty"`
+	CurrentReceipt      string `json:"current_receipt,omitempty"`
+	CurrentGeneration   int64  `json:"current_generation,omitzero"`
+	CurrentUploadOffset *int64 `json:"upload_offset,omitempty"`
 }
 
 func (e *apiErrorResponse) Error() string {
@@ -423,6 +424,26 @@ func (s *Server) humaTimeout() func(*huma.Operation) {
 				triggerStatus:  http.StatusServiceUnavailable,
 			}
 			timeoutHandler.ServeHTTP(tw, req.WithContext(ctx.Context()))
+		})
+	}
+}
+
+func (s *Server) humaReadDeadline(timeout time.Duration) func(*huma.Operation) {
+	return func(op *huma.Operation) {
+		op.Middlewares = append(op.Middlewares, func(ctx huma.Context, next func(huma.Context)) {
+			_, writer := humago.Unwrap(ctx)
+			err := http.NewResponseController(writer).SetReadDeadline(
+				time.Now().Add(timeout),
+			)
+			if err != nil && !errors.Is(err, http.ErrNotSupported) {
+				log.Printf("extending request read deadline: %v", err)
+				_ = huma.WriteErr(
+					s.api, ctx, http.StatusInternalServerError,
+					"Unable to prepare request upload",
+				)
+				return
+			}
+			next(ctx)
 		})
 	}
 }

--- a/internal/server/huma_routes_raw_sync.go
+++ b/internal/server/huma_routes_raw_sync.go
@@ -39,6 +39,9 @@ func (s *Server) registerRawSyncRoutes() {
 		http.MethodPost, "/manifests", "Commit a raw manifest",
 		s.humaRawSyncManifest, s.humaTimeout(), maxBodyBytes(rawSyncControlMaxBodyBytes),
 	)
+	if s.rawSyncUploads != nil || s.rawSyncSchemaOnly {
+		s.registerRawUploadRoutes(group)
+	}
 }
 
 type rawSyncTokenInput struct {
@@ -177,11 +180,25 @@ func rawSyncHTTPError(err error) error {
 		return nil
 	}
 	var headConflict *rawsync.HeadConflictError
+	var offsetConflict *rawsync.UploadOffsetConflictError
+	var checksumMismatch *rawsync.UploadChecksumMismatchError
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		return apiError(http.StatusGatewayTimeout, "gateway timeout")
 	case errors.Is(err, rawsync.ErrUnauthorized):
 		return apiErrorWithCode(http.StatusUnauthorized, "unauthorized", "Unauthorized")
+	case errors.As(err, &offsetConflict) && offsetConflict != nil:
+		offset := offsetConflict.CurrentOffset
+		return &apiErrorResponse{
+			Status: http.StatusConflict, Code: "upload_offset_conflict",
+			Message: "raw upload offset changed", CurrentUploadOffset: &offset,
+		}
+	case errors.As(err, &checksumMismatch) && checksumMismatch != nil:
+		offset := checksumMismatch.CurrentOffset
+		return &apiErrorResponse{
+			Status: http.StatusConflict, Code: "checksum_mismatch",
+			Message: "raw upload checksum did not match", CurrentUploadOffset: &offset,
+		}
 	case errors.As(err, &headConflict) && headConflict != nil:
 		return &apiErrorResponse{
 			Status:            http.StatusConflict,

--- a/internal/server/huma_routes_raw_sync_test.go
+++ b/internal/server/huma_routes_raw_sync_test.go
@@ -513,6 +513,8 @@ func TestRawSyncCanonicalOpenAPISpecIncludesRoutes(t *testing.T) {
 		"/api/v1/raw-sync/tokens",
 		"/api/v1/raw-sync/objects/missing",
 		"/api/v1/raw-sync/manifests",
+		"/api/v1/raw-sync/uploads",
+		"/api/v1/raw-sync/uploads/{upload_id}",
 	} {
 		assert.Contains(t, paths, path)
 	}

--- a/internal/server/huma_routes_raw_upload.go
+++ b/internal/server/huma_routes_raw_upload.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+const (
+	rawSyncUploadOffsetHeader   = "Upload-Offset"
+	rawSyncUploadLengthHeader   = "Upload-Length"
+	rawSyncUploadCompleteHeader = "Upload-Complete"
+	rawSyncUploadStartMaxBytes  = 4 << 10
+	// Upload PATCH authentication runs before this route-specific extension.
+	rawSyncUploadReadTimeout = 15 * time.Minute
+	// Huma treats a body exactly equal to MaxBodyBytes as oversized, so the
+	// transport read ceiling is one byte above the service's accepted chunk.
+	rawSyncUploadReadMaxBytes = rawsync.DefaultUploadChunkBytes + 1
+)
+
+func (s *Server) registerRawUploadRoutes(group routeGroup) {
+	group.register(
+		http.MethodPost, "/uploads", "Create or resume a raw object upload",
+		s.humaRawSyncUploadStart, s.humaTimeout(), maxBodyBytes(rawSyncUploadStartMaxBytes),
+	)
+	group.register(
+		http.MethodHead, "/uploads/{upload_id}", "Read a raw upload offset",
+		s.humaRawSyncUploadStatus, s.humaTimeout(),
+	)
+	group.register(
+		http.MethodPatch, "/uploads/{upload_id}", "Append a raw upload chunk",
+		s.humaRawSyncUploadAppend, s.humaReadDeadline(rawSyncUploadReadTimeout),
+		maxBodyBytes(rawSyncUploadReadMaxBytes),
+	)
+}
+
+type rawSyncUploadStartInput struct {
+	Authorization string `header:"Authorization"`
+	Body          struct {
+		Provider parser.AgentType  `json:"provider"`
+		Object   rawsync.ObjectRef `json:"object"`
+	}
+}
+
+type rawSyncUploadResponse struct {
+	UploadID  string            `json:"upload_id,omitempty"`
+	Object    rawsync.ObjectRef `json:"object"`
+	Offset    int64             `json:"offset"`
+	Complete  bool              `json:"complete"`
+	Created   bool              `json:"created"`
+	ExpiresAt *time.Time        `json:"expires_at,omitempty"`
+}
+
+type rawSyncUploadStartOutput struct {
+	Location string `header:"Location"`
+	Body     rawSyncUploadResponse
+}
+
+func (s *Server) humaRawSyncUploadStart(
+	ctx context.Context,
+	in *rawSyncUploadStartInput,
+) (*rawSyncUploadStartOutput, error) {
+	identity, err := rawSyncIdentityFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	session, created, err := s.rawSyncUploads.Start(
+		ctx, identity, in.Body.Provider, in.Body.Object,
+	)
+	if err != nil {
+		return nil, rawSyncHTTPError(err)
+	}
+	location := ""
+	if session.ID != "" {
+		location = s.basePath + "/api/v1/raw-sync/uploads/" + session.ID
+	}
+	return &rawSyncUploadStartOutput{
+		Location: location,
+		Body:     rawSyncUploadResponseFromSession(session, created),
+	}, nil
+}
+
+type rawSyncUploadStatusInput struct {
+	Authorization string `header:"Authorization"`
+	UploadID      string `path:"upload_id"`
+}
+
+type rawSyncUploadHeaders struct {
+	UploadOffset   int64 `header:"Upload-Offset"`
+	UploadLength   int64 `header:"Upload-Length"`
+	UploadComplete bool  `header:"Upload-Complete"`
+}
+
+func (s *Server) humaRawSyncUploadStatus(
+	ctx context.Context,
+	in *rawSyncUploadStatusInput,
+) (*rawSyncUploadHeaders, error) {
+	identity, err := rawSyncIdentityFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	session, err := s.rawSyncUploads.Status(ctx, identity, in.UploadID)
+	if err != nil {
+		return nil, rawSyncHTTPError(err)
+	}
+	headers := rawSyncUploadHeadersFromSession(session)
+	return &headers, nil
+}
+
+type rawSyncUploadAppendInput struct {
+	Authorization string `header:"Authorization"`
+	UploadID      string `path:"upload_id"`
+	UploadOffset  int64  `header:"Upload-Offset" required:"true"`
+	RawBody       []byte `contentType:"application/octet-stream"`
+}
+
+type rawSyncUploadAppendOutput struct {
+	UploadOffset   int64 `header:"Upload-Offset"`
+	UploadLength   int64 `header:"Upload-Length"`
+	UploadComplete bool  `header:"Upload-Complete"`
+	Body           rawSyncUploadResponse
+}
+
+func (s *Server) humaRawSyncUploadAppend(
+	ctx context.Context,
+	in *rawSyncUploadAppendInput,
+) (*rawSyncUploadAppendOutput, error) {
+	identity, err := rawSyncIdentityFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	session, err := s.rawSyncUploads.Append(
+		ctx, identity, in.UploadID, in.UploadOffset, in.RawBody,
+	)
+	if err != nil {
+		return nil, rawSyncHTTPError(err)
+	}
+	return &rawSyncUploadAppendOutput{
+		UploadOffset: session.Offset, UploadLength: session.Object.Length,
+		UploadComplete: session.Complete,
+		Body:           rawSyncUploadResponseFromSession(session, false),
+	}, nil
+}
+
+func rawSyncUploadHeadersFromSession(session rawsync.UploadSession) rawSyncUploadHeaders {
+	return rawSyncUploadHeaders{
+		UploadOffset:   session.Offset,
+		UploadLength:   session.Object.Length,
+		UploadComplete: session.Complete,
+	}
+}
+
+func rawSyncUploadResponseFromSession(
+	session rawsync.UploadSession,
+	created bool,
+) rawSyncUploadResponse {
+	var expiresAt *time.Time
+	if !session.ExpiresAt.IsZero() {
+		value := session.ExpiresAt
+		expiresAt = &value
+	}
+	return rawSyncUploadResponse{
+		UploadID: session.ID, Object: session.Object, Offset: session.Offset,
+		Complete: session.Complete, Created: created, ExpiresAt: expiresAt,
+	}
+}

--- a/internal/server/huma_routes_raw_upload_test.go
+++ b/internal/server/huma_routes_raw_upload_test.go
@@ -1,0 +1,595 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestRawUploadStartUsesScopedIdentityAndReturnsResumeState(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	object := rawHTTPUploadObject(t, []byte("hello world"))
+	auth := rawUploadAuthStub(t, identity)
+	uploads := &rawSyncUploadsStub{
+		start: func(
+			_ context.Context,
+			gotIdentity rawsync.AuthIdentity,
+			provider parser.AgentType,
+			gotObject rawsync.ObjectRef,
+		) (rawsync.UploadSession, bool, error) {
+			assert.Equal(t, identity, gotIdentity)
+			assert.Equal(t, parser.AgentCodex, provider)
+			assert.Equal(t, object, gotObject)
+			return rawsync.UploadSession{
+				ID: "upl_AQEBAQEBAQEBAQEBAQEBAQ", Identity: identity,
+				Provider: provider, Object: object, Offset: 5,
+				CreatedAt: time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC),
+				ExpiresAt: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+			}, false, nil
+		},
+	}
+	srv := newRawUploadHTTPTestServer(t, auth, uploads)
+	body, err := json.Marshal(map[string]any{
+		"provider": parser.AgentCodex,
+		"object":   object,
+	})
+	require.NoError(t, err)
+
+	recorder := serveRawSyncJSON(
+		t, srv, http.MethodPost, "/api/v1/raw-sync/uploads",
+		string(body), "avdt_upload", "",
+	)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	var response rawSyncUploadResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "upl_AQEBAQEBAQEBAQEBAQEBAQ", response.UploadID)
+	assert.Equal(t, object, response.Object)
+	assert.Equal(t, int64(5), response.Offset)
+	assert.False(t, response.Complete)
+	assert.False(t, response.Created)
+	assert.Equal(t, 1, uploads.startCalls)
+}
+
+func TestRawUploadStartLocationIncludesBasePath(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploadID := "upl_AQEBAQEBAQEBAQEBAQEBAQ"
+	object := rawHTTPUploadObject(t, []byte("hello world"))
+	uploads := &rawSyncUploadsStub{
+		start: func(
+			context.Context,
+			rawsync.AuthIdentity,
+			parser.AgentType,
+			rawsync.ObjectRef,
+		) (rawsync.UploadSession, bool, error) {
+			return rawsync.UploadSession{
+				ID: uploadID, Identity: identity, Provider: parser.AgentCodex,
+				Object:    object,
+				CreatedAt: time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC),
+				ExpiresAt: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+			}, true, nil
+		},
+	}
+	srv := newRawUploadHTTPTestServer(
+		t, rawUploadAuthStub(t, identity), uploads, WithBasePath("/viewer"),
+	)
+	body, err := json.Marshal(map[string]any{
+		"provider": parser.AgentCodex,
+		"object":   object,
+	})
+	require.NoError(t, err)
+
+	recorder := serveRawSyncJSON(
+		t, srv, http.MethodPost, "/viewer/api/v1/raw-sync/uploads",
+		string(body), "avdt_upload", "",
+	)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	assert.Equal(t, "/viewer/api/v1/raw-sync/uploads/"+uploadID,
+		recorder.Header().Get("Location"))
+}
+
+func TestRawUploadHeadReportsAuthoritativeOffset(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploadID := "upl_AQEBAQEBAQEBAQEBAQEBAQ"
+	object := rawHTTPUploadObject(t, []byte("hello world"))
+	uploads := &rawSyncUploadsStub{
+		status: func(
+			_ context.Context,
+			gotIdentity rawsync.AuthIdentity,
+			gotUploadID string,
+		) (rawsync.UploadSession, error) {
+			assert.Equal(t, identity, gotIdentity)
+			assert.Equal(t, uploadID, gotUploadID)
+			return rawsync.UploadSession{
+				ID: uploadID, Identity: identity, Provider: parser.AgentCodex,
+				Object: object, Offset: 5,
+				CreatedAt: time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC),
+				ExpiresAt: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+	srv := newRawUploadHTTPTestServer(t, rawUploadAuthStub(t, identity), uploads)
+
+	recorder := serveRawUploadChunk(
+		t, srv, http.MethodHead, "/api/v1/raw-sync/uploads/"+uploadID,
+		"avdt_upload", 0, nil,
+	)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	assert.Empty(t, recorder.Body.String())
+	assert.Equal(t, "5", recorder.Header().Get(rawSyncUploadOffsetHeader))
+	assert.Equal(t, strconv.FormatInt(object.Length, 10),
+		recorder.Header().Get(rawSyncUploadLengthHeader))
+	assert.Equal(t, "false", recorder.Header().Get(rawSyncUploadCompleteHeader))
+	assert.Equal(t, 1, uploads.statusCalls)
+}
+
+func TestRawUploadPatchAppendsOpaqueChunkAndReturnsCompletion(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploadID := "upl_AQEBAQEBAQEBAQEBAQEBAQ"
+	chunk := []byte{0, 1, 2, 3}
+	object := rawHTTPUploadObject(t, chunk)
+	uploads := &rawSyncUploadsStub{
+		appendChunk: func(
+			_ context.Context,
+			gotIdentity rawsync.AuthIdentity,
+			gotUploadID string,
+			offset int64,
+			gotChunk []byte,
+		) (rawsync.UploadSession, error) {
+			assert.Equal(t, identity, gotIdentity)
+			assert.Equal(t, uploadID, gotUploadID)
+			assert.Zero(t, offset)
+			assert.Equal(t, chunk, gotChunk)
+			return rawsync.UploadSession{
+				ID: uploadID, Identity: identity, Provider: parser.AgentCodex,
+				Object: object, Offset: object.Length, Complete: true,
+				CreatedAt: time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC),
+				ExpiresAt: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+	srv := newRawUploadHTTPTestServer(t, rawUploadAuthStub(t, identity), uploads)
+
+	recorder := serveRawUploadChunk(
+		t, srv, http.MethodPatch, "/api/v1/raw-sync/uploads/"+uploadID,
+		"avdt_upload", 0, chunk,
+	)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	assert.Equal(t, strconv.FormatInt(object.Length, 10),
+		recorder.Header().Get(rawSyncUploadOffsetHeader))
+	assert.Equal(t, "true", recorder.Header().Get(rawSyncUploadCompleteHeader))
+	var response rawSyncUploadResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.True(t, response.Complete)
+	assert.Equal(t, object.Length, response.Offset)
+	assert.Equal(t, 1, uploads.appendCalls)
+}
+
+func TestRawUploadPatchIsNotWrappedByShortWriteTimeout(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploadID := "upl_AQEBAQEBAQEBAQEBAQEBAQ"
+	object := rawHTTPUploadObject(t, []byte("chunk"))
+	uploads := &rawSyncUploadsStub{
+		appendChunk: func(
+			ctx context.Context,
+			_ rawsync.AuthIdentity,
+			_ string,
+			_ int64,
+			_ []byte,
+		) (rawsync.UploadSession, error) {
+			time.Sleep(50 * time.Millisecond)
+			_, hasDeadline := ctx.Deadline()
+			assert.False(t, hasDeadline)
+			assert.NoError(t, ctx.Err())
+			return rawsync.UploadSession{
+				ID: uploadID, Identity: identity, Provider: parser.AgentCodex,
+				Object: object, Offset: object.Length, Complete: true,
+				CreatedAt: time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC),
+				ExpiresAt: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+	srv := New(config.Config{
+		Host: "127.0.0.1", Port: 8080, AuthToken: "legacy-shared-token",
+		RequireAuth: true, WriteTimeout: 10 * time.Millisecond,
+	}, nil, nil,
+		WithRawSyncServices(rawUploadAuthStub(t, identity), new(rawSyncCustodyStub)),
+		WithRawSyncUploads(uploads),
+	)
+
+	recorder := serveRawUploadChunk(
+		t, srv, http.MethodPatch, "/api/v1/raw-sync/uploads/"+uploadID,
+		"avdt_upload", 0, []byte("chunk"),
+	)
+
+	assert.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+}
+
+func TestRawUploadPatchExtendsRealServerReadDeadline(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploadID := "upl_AQEBAQEBAQEBAQEBAQEBAQ"
+	chunk := []byte("chunk")
+	object := rawHTTPUploadObject(t, chunk)
+	uploads := &rawSyncUploadsStub{
+		appendChunk: func(
+			_ context.Context,
+			_ rawsync.AuthIdentity,
+			_ string,
+			_ int64,
+			gotChunk []byte,
+		) (rawsync.UploadSession, error) {
+			assert.Equal(t, chunk, gotChunk)
+			return rawsync.UploadSession{
+				ID: uploadID, Identity: identity, Provider: parser.AgentCodex,
+				Object: object, Offset: object.Length, Complete: true,
+				CreatedAt: time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC),
+				ExpiresAt: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+	srv := newRawUploadHTTPTestServer(t, rawUploadAuthStub(t, identity), uploads)
+	srv.httpReadTimeout = 50 * time.Millisecond
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(listener) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, srv.Shutdown(ctx))
+		err := <-serveErr
+		require.True(t, errors.Is(err, http.ErrServerClosed), "Serve returned %v", err)
+	})
+
+	reader, writer := io.Pipe()
+	request, err := http.NewRequest(
+		http.MethodPatch,
+		"http://"+listener.Addr().String()+"/api/v1/raw-sync/uploads/"+uploadID,
+		reader,
+	)
+	require.NoError(t, err)
+	request.ContentLength = int64(len(chunk))
+	request.Header.Set("Authorization", "Bearer avdt_upload")
+	request.Header.Set("Content-Type", "application/octet-stream")
+	request.Header.Set(rawSyncUploadOffsetHeader, "0")
+	response := make(chan *http.Response, 1)
+	requestErr := make(chan error, 1)
+	go func() {
+		result, err := http.DefaultClient.Do(request)
+		if err != nil {
+			requestErr <- err
+			return
+		}
+		response <- result
+	}()
+	require.NoError(t, writeSlowUploadBody(writer, chunk, 150*time.Millisecond))
+
+	select {
+	case err := <-requestErr:
+		t.Fatalf("slow upload request failed: %v", err)
+	case result := <-response:
+		defer result.Body.Close()
+		assert.Equal(t, http.StatusOK, result.StatusCode)
+	case <-time.After(3 * time.Second):
+		t.Fatal("slow upload request did not finish")
+	}
+}
+
+func writeSlowUploadBody(writer *io.PipeWriter, body []byte, delay time.Duration) error {
+	if _, err := writer.Write(body[:1]); err != nil {
+		return err
+	}
+	time.Sleep(delay)
+	if _, err := writer.Write(body[1:]); err != nil {
+		return err
+	}
+	return writer.Close()
+}
+
+func TestRawUploadOffsetConflictReturnsResumeOffset(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploads := &rawSyncUploadsStub{
+		appendChunk: func(
+			context.Context,
+			rawsync.AuthIdentity,
+			string,
+			int64,
+			[]byte,
+		) (rawsync.UploadSession, error) {
+			return rawsync.UploadSession{}, &rawsync.UploadOffsetConflictError{
+				CurrentOffset: 5,
+			}
+		},
+	}
+	srv := newRawUploadHTTPTestServer(t, rawUploadAuthStub(t, identity), uploads)
+
+	recorder := serveRawUploadChunk(
+		t, srv, http.MethodPatch,
+		"/api/v1/raw-sync/uploads/upl_AQEBAQEBAQEBAQEBAQEBAQ",
+		"avdt_upload", 0, []byte("chunk"),
+	)
+
+	require.Equal(t, http.StatusConflict, recorder.Code, recorder.Body.String())
+	var response apiErrorResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "upload_offset_conflict", response.Code)
+	require.NotNil(t, response.CurrentUploadOffset)
+	assert.Equal(t, int64(5), *response.CurrentUploadOffset)
+}
+
+func TestRawUploadChecksumMismatchReturnsResetOffset(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploads := &rawSyncUploadsStub{
+		appendChunk: func(
+			context.Context,
+			rawsync.AuthIdentity,
+			string,
+			int64,
+			[]byte,
+		) (rawsync.UploadSession, error) {
+			return rawsync.UploadSession{}, &rawsync.UploadChecksumMismatchError{
+				CurrentOffset: 0,
+			}
+		},
+	}
+	srv := newRawUploadHTTPTestServer(t, rawUploadAuthStub(t, identity), uploads)
+
+	recorder := serveRawUploadChunk(
+		t, srv, http.MethodPatch,
+		"/api/v1/raw-sync/uploads/upl_AQEBAQEBAQEBAQEBAQEBAQ",
+		"avdt_upload", 0, []byte("chunk"),
+	)
+
+	require.Equal(t, http.StatusConflict, recorder.Code, recorder.Body.String())
+	var response apiErrorResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "checksum_mismatch", response.Code)
+	require.NotNil(t, response.CurrentUploadOffset)
+	assert.Zero(t, *response.CurrentUploadOffset)
+}
+
+func TestRawUploadBoundsChunkBeforeService(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploads := &rawSyncUploadsStub{
+		appendChunk: func(
+			context.Context,
+			rawsync.AuthIdentity,
+			string,
+			int64,
+			[]byte,
+		) (rawsync.UploadSession, error) {
+			require.FailNow(t, "oversized chunk must not reach upload service")
+			return rawsync.UploadSession{}, nil
+		},
+	}
+	srv := newRawUploadHTTPTestServer(t, rawUploadAuthStub(t, identity), uploads)
+
+	recorder := serveRawUploadChunk(
+		t, srv, http.MethodPatch,
+		"/api/v1/raw-sync/uploads/upl_AQEBAQEBAQEBAQEBAQEBAQ",
+		"avdt_upload", 0, bytes.Repeat([]byte{1}, int(rawsync.DefaultUploadChunkBytes+1)),
+	)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code, recorder.Body.String())
+	assert.Zero(t, uploads.appendCalls)
+}
+
+func TestRawUploadCORSAllowsAndExposesResumeHeaders(t *testing.T) {
+	t.Parallel()
+
+	identity := rawsync.AuthIdentity{TenantID: "tenant-auth", DeviceID: "device-auth"}
+	uploadID := "upl_AQEBAQEBAQEBAQEBAQEBAQ"
+	object := rawHTTPUploadObject(t, []byte("hello world"))
+	uploads := &rawSyncUploadsStub{
+		status: func(
+			context.Context,
+			rawsync.AuthIdentity,
+			string,
+		) (rawsync.UploadSession, error) {
+			return rawsync.UploadSession{
+				ID: uploadID, Identity: identity, Provider: parser.AgentCodex,
+				Object:    object,
+				CreatedAt: time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC),
+				ExpiresAt: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+	srv := newRawUploadHTTPTestServer(t, rawUploadAuthStub(t, identity), uploads)
+	preflight := httptest.NewRequest(
+		http.MethodOptions, "/api/v1/raw-sync/uploads/"+uploadID, nil,
+	)
+	preflight.Host = "127.0.0.1:8080"
+	preflight.RemoteAddr = "192.0.2.10:54321"
+	preflight.Header.Set("Origin", "https://client.example")
+	preflight.Header.Set("Access-Control-Request-Method", http.MethodPatch)
+	preflight.Header.Set(
+		"Access-Control-Request-Headers", "authorization, content-type, upload-offset",
+	)
+	preflightRecorder := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(preflightRecorder, preflight)
+
+	require.Equal(t, http.StatusNoContent, preflightRecorder.Code)
+	assert.Contains(t,
+		preflightRecorder.Header().Get("Access-Control-Allow-Headers"),
+		rawSyncUploadOffsetHeader,
+	)
+
+	req := httptest.NewRequest(http.MethodHead, "/api/v1/raw-sync/uploads/"+uploadID, nil)
+	req.Host = "127.0.0.1:8080"
+	req.RemoteAddr = "192.0.2.10:54321"
+	req.Header.Set("Origin", "https://client.example")
+	req.Header.Set("Authorization", "Bearer avdt_upload")
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	assert.Contains(t,
+		recorder.Header().Get("Access-Control-Expose-Headers"),
+		rawSyncUploadOffsetHeader,
+	)
+}
+
+func rawUploadAuthStub(
+	t *testing.T,
+	identity rawsync.AuthIdentity,
+) *rawSyncAuthStub {
+	t.Helper()
+	return &rawSyncAuthStub{
+		authenticateToken: func(
+			_ context.Context,
+			token string,
+			required rawsync.DeviceTokenScope,
+		) (rawsync.AuthIdentity, error) {
+			assert.Equal(t, "avdt_upload", token)
+			assert.Equal(t, rawsync.ScopeUpload, required)
+			return identity, nil
+		},
+	}
+}
+
+func newRawUploadHTTPTestServer(
+	t *testing.T,
+	auth RawSyncDeviceAuth,
+	uploads RawSyncUploads,
+	options ...Option,
+) *Server {
+	t.Helper()
+	options = append([]Option{
+		WithRawSyncServices(auth, new(rawSyncCustodyStub)),
+		WithRawSyncUploads(uploads),
+	}, options...)
+	return New(config.Config{
+		Host: "127.0.0.1", Port: 8080,
+		AuthToken: "legacy-shared-token", RequireAuth: true,
+		WriteTimeout: 30 * time.Second,
+	}, nil, nil, options...)
+}
+
+func serveRawUploadChunk(
+	t *testing.T,
+	srv *Server,
+	method string,
+	path string,
+	bearer string,
+	offset int64,
+	body []byte,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Host = "127.0.0.1:8080"
+	req.RemoteAddr = "192.0.2.10:54321"
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	if method == http.MethodPatch {
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set(rawSyncUploadOffsetHeader, strconv.FormatInt(offset, 10))
+	}
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	return recorder
+}
+
+func rawHTTPUploadObject(t *testing.T, body []byte) rawsync.ObjectRef {
+	t.Helper()
+	manifest := rawHTTPTestManifest()
+	manifest.Entries[0].Objects[0].Length = int64(len(body))
+	manifest.Entries[0].Length = int64(len(body))
+	object := manifest.Entries[0].Objects[0]
+	digest := sha256.Sum256(body)
+	object.SHA256 = hex.EncodeToString(digest[:])
+	return object
+}
+
+type rawSyncUploadsStub struct {
+	start func(
+		context.Context,
+		rawsync.AuthIdentity,
+		parser.AgentType,
+		rawsync.ObjectRef,
+	) (rawsync.UploadSession, bool, error)
+	status func(
+		context.Context,
+		rawsync.AuthIdentity,
+		string,
+	) (rawsync.UploadSession, error)
+	appendChunk func(
+		context.Context,
+		rawsync.AuthIdentity,
+		string,
+		int64,
+		[]byte,
+	) (rawsync.UploadSession, error)
+	startCalls  int
+	statusCalls int
+	appendCalls int
+}
+
+func (s *rawSyncUploadsStub) Start(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	provider parser.AgentType,
+	object rawsync.ObjectRef,
+) (rawsync.UploadSession, bool, error) {
+	s.startCalls++
+	return s.start(ctx, identity, provider, object)
+}
+
+func (s *rawSyncUploadsStub) Status(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+) (rawsync.UploadSession, error) {
+	s.statusCalls++
+	return s.status(ctx, identity, uploadID)
+}
+
+func (s *rawSyncUploadsStub) Append(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	offset int64,
+	chunk []byte,
+) (rawsync.UploadSession, error) {
+	s.appendCalls++
+	return s.appendChunk(ctx, identity, uploadID, offset, chunk)
+}
+
+var _ RawSyncUploads = (*rawSyncUploadsStub)(nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,8 +66,12 @@ const daemonService = "agentsview"
 const (
 	defaultInsightLogDrainTimeout    = 2 * time.Second
 	defaultInsightLogStopWaitTimeout = 500 * time.Millisecond
+	defaultHTTPReadTimeout           = 10 * time.Second
 	corsAllowedRequestHeaders        = "Content-Type, Authorization, " +
-		service.SemanticSearchIntentHeader + ", " + rawSyncDeviceIDHeader
+		service.SemanticSearchIntentHeader + ", " + rawSyncDeviceIDHeader +
+		", " + rawSyncUploadOffsetHeader
+	corsExposedResponseHeaders = rawSyncUploadOffsetHeader + ", " +
+		rawSyncUploadLengthHeader + ", " + rawSyncUploadCompleteHeader + ", Location"
 )
 
 // Server is the HTTP server that serves the SPA and REST API.
@@ -102,6 +106,7 @@ type Server struct {
 
 	insightLogDrainTimeout    time.Duration
 	insightLogStopWaitTimeout time.Duration
+	httpReadTimeout           time.Duration
 
 	// handlerDelay is injected before each timeout-wrapped
 	// handler, used only by tests to guarantee handlers
@@ -172,6 +177,7 @@ type Server struct {
 	rawSyncDeviceAuth      RawSyncDeviceAuth
 	rawSyncCustody         RawSyncCustody
 	rawSyncSchemaOnly      bool
+	rawSyncUploads         RawSyncUploads
 
 	ensurePricing func(context.Context, *db.DB) error
 }
@@ -232,6 +238,7 @@ func New(
 		httpRemoteCleanupRegistry: new(remotesync.CleanupRegistry),
 		insightLogDrainTimeout:    defaultInsightLogDrainTimeout,
 		insightLogStopWaitTimeout: defaultInsightLogStopWaitTimeout,
+		httpReadTimeout:           defaultHTTPReadTimeout,
 		ensurePricing:             pricingrefresh.EnsureCurrent,
 		spaFS:                     dist,
 		spaHandler:                http.FileServerFS(dist),
@@ -310,11 +317,40 @@ type RawSyncCustody interface {
 	) (rawsync.CommitResult, error)
 }
 
+// RawSyncUploads exposes authenticated resumable raw-object transfers.
+type RawSyncUploads interface {
+	Start(
+		context.Context,
+		rawsync.AuthIdentity,
+		parser.AgentType,
+		rawsync.ObjectRef,
+	) (rawsync.UploadSession, bool, error)
+	Status(
+		context.Context,
+		rawsync.AuthIdentity,
+		string,
+	) (rawsync.UploadSession, error)
+	Append(
+		context.Context,
+		rawsync.AuthIdentity,
+		string,
+		int64,
+		[]byte,
+	) (rawsync.UploadSession, error)
+}
+
 // WithRawSyncServices enables authenticated raw-sync machine routes.
 func WithRawSyncServices(auth RawSyncDeviceAuth, custody RawSyncCustody) Option {
 	return func(s *Server) {
 		s.rawSyncDeviceAuth = auth
 		s.rawSyncCustody = custody
+	}
+}
+
+// WithRawSyncUploads enables the scoped resumable raw-object data plane.
+func WithRawSyncUploads(uploads RawSyncUploads) Option {
+	return func(s *Server) {
+		s.rawSyncUploads = uploads
 	}
 }
 
@@ -1205,7 +1241,7 @@ func (s *Server) Serve(ln net.Listener) error {
 	srv := &http.Server{
 		Addr:        addr,
 		Handler:     s.Handler(),
-		ReadTimeout: 10 * time.Second,
+		ReadTimeout: s.httpReadTimeout,
 		IdleTimeout: 120 * time.Second,
 	}
 	if s.baseCtx != nil {
@@ -1383,12 +1419,13 @@ func corsMiddleware(
 				ensureVaryHeader(w.Header(), "Origin")
 				w.Header().Set(
 					"Access-Control-Allow-Methods",
-					"GET, POST, PUT, PATCH, DELETE, OPTIONS",
+					"GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS",
 				)
 				w.Header().Set(
 					"Access-Control-Allow-Headers",
 					corsAllowedRequestHeaders,
 				)
+				w.Header().Set("Access-Control-Expose-Headers", corsExposedResponseHeaders)
 				if r.Method == http.MethodOptions {
 					w.WriteHeader(http.StatusNoContent)
 					return
@@ -1420,12 +1457,13 @@ func corsMiddleware(
 			ensureVaryHeader(w.Header(), "Origin")
 			w.Header().Set(
 				"Access-Control-Allow-Methods",
-				"GET, POST, PUT, PATCH, DELETE, OPTIONS",
+				"GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS",
 			)
 			w.Header().Set(
 				"Access-Control-Allow-Headers",
 				corsAllowedRequestHeaders,
 			)
+			w.Header().Set("Access-Control-Expose-Headers", corsExposedResponseHeaders)
 			if r.Method == http.MethodOptions {
 				if !safeForReads {
 					http.Error(


### PR DESCRIPTION
Adds authenticated resumable raw-object uploads to hosted PostgreSQL raw sync. Scoped upload tokens can start or resume an upload, read its exact offset, and append bounded chunks. Finalization independently verifies length and SHA-256 before tenant-scoped immutable custody; retries are idempotent, and offset or checksum conflicts return the authoritative resume offset.

Upload sessions are durable in PostgreSQL and staged in a private restart-safe spool with exact-offset fencing, crash-tail truncation, and bounded cleanup of expired or orphaned state. The runtime privilege probe now includes the upload table's exact DML requirements.

Raw custody remains lazily opened under its dedicated `raw-sync` repository, preserving ordinary `pg serve` startup and repository ownership behavior from #1473. Device enrollment UX, laptop watcher behavior, quotas, S3 hosting, and downstream processing remain outside this slice.

Refs #1352
