### PR TITLE
fix: normalize Posit Assistant inferred cache writes

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1478,10 +1478,23 @@ add an archived or maintained mirror without replacing the original identity.
   were also public, but no matching producer or authoritative
   persisted-session schema was found.
 - **Usage and cost:** Language-model messages can persist input, output,
-  cache-read, and cache-write tokens with model identity. Agentsview
-  catalog-prices these values; no provider-reported USD total is consumed.
+  cache-read, and cache-write tokens with model identity. Observed GLM, Gemma,
+  and Kimi records use the Anthropic-shaped `cacheWriteTokens` field for the
+  uncached prompt remainder while leaving `inputTokens` at zero; these model
+  families do not expose a separately billed cache-write category in the
+  pricing catalog. Claude records retain real cache-write semantics.
+  Agentsview catalog-prices these values; no provider-reported USD total is
+  consumed.
 - **Agentsview:** `internal/parser/posit_assistant_provider.go`; current schema
-  details are based on observed files and fixtures.
+  details are based on observed files and fixtures. Reverified 2026-08-22
+  against the samples reported in
+  [#1466](https://github.com/kenn-io/agentsview/issues/1466): the parser folds
+  the persisted cache-write remainder into uncached input only for recognized
+  GLM, Gemma, and Kimi model families. Missing and unrecognized model identities
+  preserve Posit Assistant's original buckets, and full context remains the
+  sum of the persisted input, cache-read, and cache-write fields. Data version
+  91 reparses existing Posit Assistant archives through the normal
+  non-destructive resync path.
 
 ## Z Code (`zcode`)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -425,7 +425,10 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // (90: Grok message timestamp backfill. Grok chat-history rows do not carry
 // timestamps; re-parsing enriches them from the authoritative timestamped
 // updates stream so existing sessions participate in activity aggregation.)
-const dataVersion = 90
+// (91: Posit Assistant inferred cache-write normalization. Existing
+// non-Anthropic auto-cached model rows need re-parsing so their persisted
+// uncached prompt remainder is priced as input rather than cache creation.)
+const dataVersion = 91
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1027,8 +1027,13 @@ func TestCurrentDataVersionIncludesOpenCodeProjectMetadataChange(t *testing.T) {
 }
 
 func TestCurrentDataVersionGrokMessageTimestamps(t *testing.T) {
-	assert.Equal(t, 90, CurrentDataVersion(),
-		"Grok message timestamps require a sequential backfill")
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 90,
+		"version 90 is the data-version boundary for Grok message timestamps")
+}
+
+func TestCurrentDataVersionPositAssistantCacheAccounting(t *testing.T) {
+	assert.Equal(t, 91, CurrentDataVersion(),
+		"Posit Assistant cache accounting requires a sequential backfill")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/posit_assistant_provider.go
+++ b/internal/parser/posit_assistant_provider.go
@@ -1009,11 +1009,27 @@ func positAssistantToolResults(content gjson.Result) []ParsedToolResult {
 	return results
 }
 
+// positAssistantFoldsCacheWriteIntoInput reports whether Posit Assistant's
+// cacheWriteTokens bucket is the inferred uncached prompt remainder for the
+// model family, rather than a separately billed cache creation. Missing and
+// unrecognized model identities fail closed and preserve the producer's
+// original bucket labels.
+func positAssistantFoldsCacheWriteIntoInput(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if slash := strings.LastIndexByte(model, '/'); slash >= 0 {
+		model = model[slash+1:]
+	}
+	return strings.HasPrefix(model, "glm-") ||
+		strings.HasPrefix(model, "gemma-") ||
+		strings.HasPrefix(model, "kimi-")
+}
+
 // positAssistantFillTokenUsage maps positai usage metadata onto the message.
-// ContextTokens counts the full billed context (fresh input plus cache reads
-// and writes), matching the Claude parser's attribution. TokenUsage is
-// re-emitted with Claude-style snake_case keys so downstream token-presence
-// and cost consumers read it uniformly.
+// ContextTokens counts the full prompt context (fresh input plus cache reads
+// and persisted cache writes), matching the Claude parser's attribution. For
+// known auto-cached non-Anthropic families, the persisted cache-write bucket
+// is folded into uncached input before TokenUsage is re-emitted with
+// Claude-style snake_case keys for downstream presence and cost consumers.
 func positAssistantFillTokenUsage(msg *ParsedMessage, usage gjson.Result) {
 	if !usage.Exists() {
 		return
@@ -1039,7 +1055,11 @@ func positAssistantFillTokenUsage(msg *ParsedMessage, usage gjson.Result) {
 	cacheWriteField := usage.Get("cacheWriteTokens")
 	if cacheWriteField.Exists() {
 		cacheWrite = int(cacheWriteField.Int())
-		tokenUsage["cache_creation_input_tokens"] = cacheWrite
+		if positAssistantFoldsCacheWriteIntoInput(msg.Model) {
+			tokenUsage["input_tokens"] = input + cacheWrite
+		} else {
+			tokenUsage["cache_creation_input_tokens"] = cacheWrite
+		}
 	}
 	if len(tokenUsage) == 0 {
 		return

--- a/internal/parser/posit_assistant_provider_test.go
+++ b/internal/parser/posit_assistant_provider_test.go
@@ -501,6 +501,110 @@ func TestPositAssistantProviderParseSparseTokenUsage(t *testing.T) {
 	assert.False(t, empty.HasContextTokens)
 }
 
+func TestPositAssistantProviderNormalizesInferredCacheWrites(t *testing.T) {
+	tests := []struct {
+		name        string
+		positai     string
+		wantModel   string
+		wantUsage   string
+		wantContext int
+		wantOutput  int
+	}{
+		{
+			name:        "GLM inferred cache write",
+			positai:     `"modelId":"glm-4.7","usage":{"inputTokens":0,"outputTokens":7,"cacheReadTokens":20,"cacheWriteTokens":80}`,
+			wantModel:   "glm-4.7",
+			wantUsage:   `{"input_tokens":80,"output_tokens":7,"cache_read_input_tokens":20}`,
+			wantContext: 100,
+			wantOutput:  7,
+		},
+		{
+			name:        "provider-qualified Gemma inferred cache write",
+			positai:     `"modelId":"google/gemma-3-27b-it","usage":{"inputTokens":5,"outputTokens":7,"cacheReadTokens":20,"cacheWriteTokens":80}`,
+			wantModel:   "google/gemma-3-27b-it",
+			wantUsage:   `{"input_tokens":85,"output_tokens":7,"cache_read_input_tokens":20}`,
+			wantContext: 105,
+			wantOutput:  7,
+		},
+		{
+			name:        "provider-qualified Kimi inferred cache write",
+			positai:     `"modelId":"moonshotai/kimi-k2.5","usage":{"inputTokens":0,"outputTokens":7,"cacheReadTokens":20,"cacheWriteTokens":80}`,
+			wantModel:   "moonshotai/kimi-k2.5",
+			wantUsage:   `{"input_tokens":80,"output_tokens":7,"cache_read_input_tokens":20}`,
+			wantContext: 100,
+			wantOutput:  7,
+		},
+		{
+			name:        "Claude real cache write",
+			positai:     `"modelId":"claude-sonnet-4-6","usage":{"inputTokens":5,"outputTokens":7,"cacheReadTokens":20,"cacheWriteTokens":80}`,
+			wantModel:   "claude-sonnet-4-6",
+			wantUsage:   `{"input_tokens":5,"output_tokens":7,"cache_read_input_tokens":20,"cache_creation_input_tokens":80}`,
+			wantContext: 105,
+			wantOutput:  7,
+		},
+		{
+			name:        "missing model preserves producer buckets",
+			positai:     `"usage":{"inputTokens":5,"outputTokens":7,"cacheReadTokens":20,"cacheWriteTokens":80}`,
+			wantUsage:   `{"input_tokens":5,"output_tokens":7,"cache_read_input_tokens":20,"cache_creation_input_tokens":80}`,
+			wantContext: 105,
+			wantOutput:  7,
+		},
+		{
+			name:        "unrecognized model preserves producer buckets",
+			positai:     `"modelId":"custom-auto-model","usage":{"inputTokens":5,"outputTokens":7,"cacheReadTokens":20,"cacheWriteTokens":80}`,
+			wantModel:   "custom-auto-model",
+			wantUsage:   `{"input_tokens":5,"output_tokens":7,"cache_read_input_tokens":20,"cache_creation_input_tokens":80}`,
+			wantContext: 105,
+			wantOutput:  7,
+		},
+		{
+			name:        "fully cached zero-valued prompt split",
+			positai:     `"modelId":"glm-4.7","usage":{"inputTokens":0,"outputTokens":0,"cacheReadTokens":100,"cacheWriteTokens":0}`,
+			wantModel:   "glm-4.7",
+			wantUsage:   `{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":100}`,
+			wantContext: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			convDir := filepath.Join(root, "ws1", "99999999-9999-4999-8999-999999999999")
+			writeSourceFile(t, filepath.Join(convDir, "conversation.json"), `{
+				"schemaVersion":"3",
+				"root":{"id":"99999999-9999-4999-8999-999999999999","timestamp":1735689600000,"metadata":{"kind":"main"}},
+				"messages":[{"id":"n1","parentId":"99999999-9999-4999-8999-999999999999","isActive":true,"lmMessageIds":[0,1],"timestamp":1735689600000}]
+			}`)
+			writeSourceFile(t, filepath.Join(convDir, "lm-messages.jsonl"),
+				`{"id":0,"message":{"role":"user","content":"hi"}}`+"\n"+
+					`{"id":1,"message":{"role":"assistant","content":[{"type":"text","text":"done"}],"providerOptions":{"providerMetadata":{"positai":{`+tt.positai+`}}}}}`+"\n")
+
+			provider, ok := NewProvider(AgentPositAssistant, ProviderConfig{
+				Roots: []string{root},
+			})
+			require.True(t, ok)
+			discovered, err := provider.Discover(context.Background())
+			require.NoError(t, err)
+			require.Len(t, discovered, 1)
+			outcome, err := provider.Parse(context.Background(), ParseRequest{
+				Source: discovered[0],
+			})
+			require.NoError(t, err)
+			require.Len(t, outcome.Results, 1)
+			messages := outcome.Results[0].Result.Messages
+			require.Len(t, messages, 2)
+			assistant := messages[1]
+
+			assert.Equal(t, tt.wantModel, assistant.Model)
+			assert.JSONEq(t, tt.wantUsage, string(assistant.TokenUsage))
+			assert.Equal(t, tt.wantContext, assistant.ContextTokens)
+			assert.True(t, assistant.HasContextTokens)
+			assert.Equal(t, tt.wantOutput, assistant.OutputTokens)
+			assert.True(t, assistant.HasOutputTokens)
+		})
+	}
+}
+
 func TestPositAssistantProviderClassifiesDeletedPaths(t *testing.T) {
 	root := t.TempDir()
 	convDir := filepath.Join(root, "ws1", "55555555-5555-4555-8555-555555555555")


### PR DESCRIPTION
Posit Assistant persists all model usage in an Anthropic-shaped set of token
buckets, including a `cacheWriteTokens` field. For GLM, Gemma, and Kimi
records, the observed files put the uncached prompt remainder in
`cacheWriteTokens` while leaving `inputTokens` at zero. Those model families
have no separately billed cache-write category in the pricing catalog, so
Agentsview priced that remainder as cache creation instead of ordinary input.

This extends the Posit Assistant token-normalization path to classify the
persisted buckets by model family before emitting Agentsview's snake-case
token fields. For recognized GLM, Gemma, and Kimi identities, the persisted
cache-write remainder is folded into uncached input. Claude records keep real
cache-write semantics, and missing or unrecognized model identities preserve
Posit Assistant's original buckets unchanged. Full context remains the sum of
the persisted input, cache-read, and cache-write fields in every case.

Because existing archives were already stored with the old accounting, the data
version moves 90 → 91 so those rows are re-parsed through the normal
non-destructive resync path.

**Tests**

- Table-driven parser tests over representative GLM, Gemma, and Kimi model IDs
  assert the inferred cache-write remainder is added to uncached input, and
  that Claude and unrecognized identities are left untouched.
- A data-version test pins 91 for the Posit Assistant cache accounting; the
  previous exact-equality assertion on 90 is relaxed to a boundary check so it
  no longer breaks on every subsequent bump.
- `docs/internal/session-format-sources.md` records the reverification against
  the samples in #1466.

Closes #1466

AI was used for assistance.
