### PR TITLE
feat(search): add optional Chinese FTS tokenizer

### DIFF
--- a/.github/workflows/chinese-fts.yml
+++ b/.github/workflows/chinese-fts.yml
@@ -1,0 +1,54 @@
+name: Chinese FTS
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/chinese-fts.yml"
+      - "Makefile"
+      - "internal/db/**"
+      - "internal/service/**"
+      - "internal/mcp/**"
+      - "scripts/build-simple-fts.sh"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/chinese-fts.yml"
+      - "Makefile"
+      - "internal/db/**"
+      - "internal/service/**"
+      - "internal/mcp/**"
+      - "scripts/build-simple-fts.sh"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-chinese-fts:
+    name: Go Test (Chinese FTS sidecar)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
+
+      - name: Build pinned simple and cppjieba sidecar
+        run: bash scripts/build-simple-fts.sh dist/agentsview-simple
+
+      - name: Run database, service, and MCP tests with Chinese FTS enabled
+        env:
+          AGENTSVIEW_SIMPLE_DIR: ${{ github.workspace }}/dist/agentsview-simple
+          CGO_ENABLED: "1"
+        run: go test -tags "fts5" ./internal/db ./internal/service ./internal/mcp -count=1 -timeout=20m

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
 	elif [ -x "$(GOPATH_FIRST)/bin/air" ]; then printf "%s" "$(GOPATH_FIRST)/bin/air"; \
 	fi)
 
-.PHONY: build build-release install frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy test test-short test-evalingest bench-backends bench-gate bench-gate-config bench-pg-usage test-postgres test-postgres-ci test-s3 postgres-up postgres-down test-ssh test-ssh-ci ssh-up ssh-down e2e e2e-duckdb vet lint lint-ci lint-golangci lint-golangci-ci nilaway nilaway-golangci-build lint-tools tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir pricing-snapshot sqlite-vec-header dev-snapshot help
+.PHONY: build build-release install install-chinese-fts simple-fts frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy test test-short test-evalingest bench-backends bench-gate bench-gate-config bench-pg-usage test-postgres test-postgres-ci test-s3 postgres-up postgres-down test-ssh test-ssh-ci ssh-up ssh-down e2e e2e-duckdb vet lint lint-ci lint-golangci lint-golangci-ci nilaway nilaway-golangci-build lint-tools tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir pricing-snapshot sqlite-vec-header dev-snapshot help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -95,6 +95,39 @@ install: build-release
 	trap - EXIT HUP INT TERM; \
 	cleanup; \
 	exit $$status
+
+# Build the optional simple/cppjieba SQLite tokenizer sidecar from pinned
+# upstream commits. It remains separate from the Go binary so SQLite can load
+# the native extension on every supported platform.
+simple-fts:
+	bash scripts/build-simple-fts.sh dist/agentsview-simple
+
+# Install the binary and its Chinese-search sidecar in sibling bin/lib trees.
+install-chinese-fts: install simple-fts
+	@if [ -d "$(HOME)/.local/bin" ]; then \
+		INSTALL_DIR="$(HOME)/.local/bin"; \
+	else \
+		INSTALL_DIR="$${GOBIN:-$$(go env GOBIN)}"; \
+		if [ -z "$$INSTALL_DIR" ]; then \
+			GOPATH_FIRST="$$(go env GOPATH | cut -d: -f1)"; \
+			INSTALL_DIR="$$GOPATH_FIRST/bin"; \
+		fi; \
+	fi; \
+	SIMPLE_DIR="$$(cd "$$INSTALL_DIR/.." && pwd)/lib/agentsview/simple"; \
+	mkdir -p "$$SIMPLE_DIR/dict" "$$SIMPLE_DIR/licenses"; \
+	for name in libsimple.so libsimple.dylib simple.dll; do \
+		if [ -f "dist/agentsview-simple/$$name" ]; then \
+			install -m 0755 "dist/agentsview-simple/$$name" "$$SIMPLE_DIR/$$name"; \
+		fi; \
+	done; \
+	install -m 0644 dist/agentsview-simple/VERSIONS "$$SIMPLE_DIR/VERSIONS"; \
+	for name in hmm_model.utf8 idf.utf8 jieba.dict.utf8 stop_words.utf8 user.dict.utf8; do \
+		install -m 0644 "dist/agentsview-simple/dict/$$name" "$$SIMPLE_DIR/dict/$$name"; \
+	done; \
+	for name in simple-LICENSE cppjieba-LICENSE; do \
+		install -m 0644 "dist/agentsview-simple/licenses/$$name" "$$SIMPLE_DIR/licenses/$$name"; \
+	done; \
+	echo "Installed Chinese FTS sidecar to $$SIMPLE_DIR"
 
 # Build frontend SPA and copy into embed directory
 frontend:
@@ -617,6 +650,8 @@ help:
 	@echo "  build-release  - Release build (optimized, stripped)"
 	@echo "  pricing-snapshot - Restore LiteLLM snapshot from artifact branch"
 	@echo "  install        - Build and install to ~/.local/bin or GOPATH"
+	@echo "  install-chinese-fts - Install agentsview with the optional Chinese FTS sidecar"
+	@echo "  simple-fts     - Build the pinned simple/cppjieba SQLite extension"
 	@echo ""
 	@echo "  dev            - Run Go server with live reload via air (use with frontend-dev)"
 	@echo "  dev-snapshot   - Run agentsview against a fresh snapshot of prod sessions.db"

--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ agentsview stats --include-git-outcomes
 | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | ![Search](https://agentsview.io/assets/generated/screenshots/search-results.png) | ![Heatmap](https://agentsview.io/assets/generated/screenshots/heatmap.png) |
 
-- **Full-text search** across all message content (FTS5)
+- **Full-text search** across all message content (FTS5), with optional
+  `simple`/cppjieba tokenization for Chinese queries
 - **Semantic search** (opt-in) -- index session content with any
   OpenAI-compatible embeddings endpoint and search by meaning with
   `agentsview session search --semantic` or `--hybrid`; every content-search

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,10 @@ description: Release history for AgentsView
   files are gone remain in the archive. (#1677)
 - Browse and search Open Code Review sessions, including review comments,
   tools, thinking, recorded token usage, and resumed reviews. (#1660)
+- Search Chinese words and individual characters in SQLite message content
+  with an optional tokenizer sidecar. HTTP, CLI, and MCP search use word
+  segmentation; ASCII-only searches keep English stemming. Install with
+  `make install-chinese-fts`. (#1491)
 - Browse and search Tau sessions, including the active conversation branch,
   thinking, tools, session names, and recorded token usage. (#1661)
 - Configure session directories and alternate homes in `[agents.<id>]` tables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1252,7 +1252,45 @@ pulled in from PostgreSQL sync or copied from other archives.
 ## Database
 
 The SQLite database uses WAL mode for concurrent reads and includes FTS5
-full-text search indexes on message content.
+full-text search indexes on message content. To add Chinese word, phrase, and
+single-character matching, build and install the pinned `simple`/cppjieba
+sidecar with `make install-chinese-fts`. Building it requires Git, CMake
+3.19 or newer, and a C++14 compiler. AgentsView discovers it next to the binary
+or under the sibling `lib/agentsview/simple` directory. A custom path can be
+selected with `AGENTSVIEW_SIMPLE_DIR`.
+
+The sidecar adds a parallel `messages_chinese_fts` index and routes only CJK
+queries through it. ASCII-only searches continue to use the existing Porter
+index, so searches such as `run` retain English stemming. The Chinese index is
+derived data: if the sidecar is removed, AgentsView drops that optional index
+and continues with the standard FTS5 path; reinstalling the sidecar backfills
+it on the next writable open. AgentsView fingerprints the native library and
+all cppjieba dictionaries, atomically rebuilding the index when that fingerprint
+changes. Writers running with another fingerprint leave a freshness marker
+instead of mixing incompatible token streams. Pinyin expansion is disabled in
+the derived index because ASCII-only queries continue to use the Porter index.
+
+Chinese word segmentation is specific to SQLite message search, including the
+HTTP, CLI, and MCP search paths. PostgreSQL/CockroachDB and DuckDB do not load
+this SQLite extension and keep their existing search behavior. Substring and
+regular-expression searches are unchanged. Session search result snippets
+highlight the segmented matches; highlighting inside an opened transcript uses
+the original query and may miss separated Chinese words.
+
+The first backfill, a changed fingerprint, or any pending session requires a
+full index rebuild before startup completes. AgentsView logs this wait. The
+freshness ledger stores session IDs rather than old message IDs and token
+content, so it cannot remove stale entries for individual replaced or deleted
+messages. Removing the sidecar drops the Chinese index but retains the
+`messages_chinese_fts_pending_sessions` ledger and three persistent session
+triggers. The ledger holds at most one row per touched session ID until the
+next successful Chinese index rebuild clears it.
+
+Index maintenance uses TEMP triggers on the writer connection. Writes made
+without these triggers or with another sidecar fingerprint leave the index
+stale. Chinese search then falls back to standard FTS5 and logs a warning once
+per database handle. Reopening the archive with the sidecar restores the index
+and its triggers.
 
 **Schema tables:**
 
@@ -1268,6 +1306,7 @@ full-text search indexes on message content.
 | `stats`              | Aggregate counts (session_count, message_count)                              |
 | `skipped_files`      | Cache of non-interactive session files                                       |
 | `messages_fts`       | FTS5 virtual table for full-text search                                      |
+| `messages_chinese_fts` | Optional FTS5 index using the `simple` Chinese tokenizer                   |
 
 The database is automatically migrated on startup when the schema changes. When
 the stored data version is stale, AgentsView preserves the existing database and

--- a/internal/db/chinese_fts_runtime.go
+++ b/internal/db/chinese_fts_runtime.go
@@ -1,0 +1,387 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const simpleFTSDirEnv = "AGENTSVIEW_SIMPLE_DIR"
+
+const (
+	chineseFTSFingerprintStatsKey = "messages_chinese_fts_fingerprint_v1"
+	chineseFTSSchemaVersion       = "messages-chinese-fts-v3"
+)
+
+var (
+	simpleFTSRuntimeConfig, simpleFTSRuntimeErr = discoverSimpleFTSRuntime()
+)
+
+const schemaChineseFTSPendingSessions = `
+CREATE TABLE IF NOT EXISTS messages_chinese_fts_pending_sessions (
+    session_id TEXT PRIMARY KEY,
+    generation INTEGER NOT NULL CHECK (generation > 0)
+);
+
+DROP TRIGGER IF EXISTS sessions_chinese_pending_bi;
+DROP TRIGGER IF EXISTS sessions_chinese_pending_bu;
+DROP TRIGGER IF EXISTS sessions_chinese_pending_bd;
+
+CREATE TRIGGER sessions_chinese_pending_bi
+BEFORE INSERT ON sessions
+WHEN NOT EXISTS (SELECT 1 FROM sessions WHERE id = new.id) BEGIN
+    INSERT INTO messages_chinese_fts_pending_sessions(session_id, generation)
+        VALUES(new.id, 1)
+    ON CONFLICT(session_id) DO UPDATE SET
+        generation = messages_chinese_fts_pending_sessions.generation + 1;
+END;
+
+CREATE TRIGGER sessions_chinese_pending_bu
+BEFORE UPDATE OF transcript_revision ON sessions
+WHEN old.transcript_revision IS NOT new.transcript_revision BEGIN
+    INSERT INTO messages_chinese_fts_pending_sessions(session_id, generation)
+        VALUES(new.id, 1)
+    ON CONFLICT(session_id) DO UPDATE SET
+        generation = messages_chinese_fts_pending_sessions.generation + 1;
+END;
+
+CREATE TRIGGER sessions_chinese_pending_bd
+BEFORE DELETE ON sessions BEGIN
+    INSERT INTO messages_chinese_fts_pending_sessions(session_id, generation)
+        VALUES(old.id, 1)
+    ON CONFLICT(session_id) DO UPDATE SET
+        generation = messages_chinese_fts_pending_sessions.generation + 1;
+END;
+`
+
+type simpleFTSRuntime struct {
+	libraryPath    string
+	dictionaryPath string
+	fingerprint    string
+}
+
+func (c simpleFTSRuntime) available() bool {
+	return c.libraryPath != "" && c.dictionaryPath != "" && c.fingerprint != ""
+}
+
+func checkSimpleFTSRuntimeConfig() error {
+	return simpleFTSRuntimeErr
+}
+
+func discoverSimpleFTSRuntime() (simpleFTSRuntime, error) {
+	executablePath, err := os.Executable()
+	if err != nil {
+		executablePath = ""
+	}
+	return discoverSimpleFTSRuntimeFrom(executablePath, os.Getenv(simpleFTSDirEnv), runtime.GOOS)
+}
+
+func discoverSimpleFTSRuntimeFrom(
+	executablePath, explicitDir, goos string,
+) (simpleFTSRuntime, error) {
+	libraryName, err := simpleFTSLibraryName(goos)
+	if err != nil {
+		if explicitDir != "" {
+			return simpleFTSRuntime{}, err
+		}
+		// The sidecar is optional. Unsupported platforms retain the standard
+		// FTS path unless the user explicitly requested a sidecar directory.
+		return simpleFTSRuntime{}, nil
+	}
+
+	if explicitDir != "" {
+		config, err := validateSimpleFTSRuntime(explicitDir, libraryName)
+		if err != nil {
+			return simpleFTSRuntime{}, fmt.Errorf(
+				"invalid %s: %w", simpleFTSDirEnv, err,
+			)
+		}
+		return config, nil
+	}
+
+	var candidates []string
+	if executablePath != "" {
+		executableDir := filepath.Dir(executablePath)
+		candidates = append(candidates,
+			filepath.Join(executableDir, "agentsview-simple"),
+			filepath.Clean(filepath.Join(
+				executableDir, "..", "lib", "agentsview", "simple",
+			)),
+		)
+	}
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return simpleFTSRuntime{}, fmt.Errorf(
+				"checking bundled simple FTS directory %s: %w", candidate, err,
+			)
+		}
+		if !info.IsDir() {
+			return simpleFTSRuntime{}, fmt.Errorf(
+				"bundled simple FTS path is not a directory: %s", candidate,
+			)
+		}
+		config, err := validateSimpleFTSRuntime(candidate, libraryName)
+		if err != nil {
+			return simpleFTSRuntime{}, fmt.Errorf(
+				"invalid bundled simple FTS directory %s: %w", candidate, err,
+			)
+		}
+		return config, nil
+	}
+	return simpleFTSRuntime{}, nil
+}
+
+func validateSimpleFTSRuntime(
+	dir, libraryName string,
+) (simpleFTSRuntime, error) {
+	libraryPath := filepath.Join(dir, libraryName)
+	if err := requireRegularFile(libraryPath); err != nil {
+		return simpleFTSRuntime{}, fmt.Errorf("simple extension: %w", err)
+	}
+	dictionaryPath := filepath.Join(dir, "dict")
+	for _, name := range simpleFTSDictionaryFiles {
+		if err := requireRegularFile(filepath.Join(dictionaryPath, name)); err != nil {
+			return simpleFTSRuntime{}, fmt.Errorf("cppjieba dictionary: %w", err)
+		}
+	}
+	fingerprint, err := fingerprintSimpleFTSRuntime(libraryPath, dictionaryPath)
+	if err != nil {
+		return simpleFTSRuntime{}, err
+	}
+	return simpleFTSRuntime{
+		libraryPath:    libraryPath,
+		dictionaryPath: dictionaryPath,
+		fingerprint:    fingerprint,
+	}, nil
+}
+
+var simpleFTSDictionaryFiles = []string{
+	"hmm_model.utf8",
+	"idf.utf8",
+	"jieba.dict.utf8",
+	"stop_words.utf8",
+	"user.dict.utf8",
+}
+
+func fingerprintSimpleFTSRuntime(
+	libraryPath, dictionaryPath string,
+) (string, error) {
+	h := sha256.New()
+	_, _ = io.WriteString(h, chineseFTSSchemaVersion+"\n")
+
+	type fingerprintFile struct {
+		name string
+		path string
+	}
+	files := []fingerprintFile{{
+		name: filepath.Base(libraryPath),
+		path: libraryPath,
+	}}
+	for _, name := range simpleFTSDictionaryFiles {
+		files = append(files, fingerprintFile{
+			name: name,
+			path: filepath.Join(dictionaryPath, name),
+		})
+	}
+	for _, item := range files {
+		_, _ = io.WriteString(h, item.name+"\x00")
+		file, err := os.Open(item.path)
+		if err != nil {
+			return "", fmt.Errorf(
+				"opening simple FTS fingerprint input %s: %w", item.path, err,
+			)
+		}
+		_, copyErr := io.Copy(h, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return "", fmt.Errorf(
+				"hashing simple FTS fingerprint input %s: %w", item.path, copyErr,
+			)
+		}
+		if closeErr != nil {
+			return "", fmt.Errorf(
+				"closing simple FTS fingerprint input %s: %w", item.path, closeErr,
+			)
+		}
+		_, _ = io.WriteString(h, "\x00")
+	}
+	return fmt.Sprintf("%s:%x", chineseFTSSchemaVersion, h.Sum(nil)), nil
+}
+
+func simpleFTSLibraryName(goos string) (string, error) {
+	switch goos {
+	case "linux":
+		return "libsimple.so", nil
+	case "darwin":
+		return "libsimple.dylib", nil
+	case "windows":
+		return "simple.dll", nil
+	default:
+		return "", fmt.Errorf("simple FTS is unsupported on %s", goos)
+	}
+}
+
+func requireRegularFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", path)
+	}
+	return nil
+}
+
+type chineseFTSTransactor interface {
+	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
+}
+
+// ensureChineseFTS atomically reconciles the derived Chinese index with the
+// loaded extension and dictionaries. The table, complete backfill, fingerprint,
+// and connection-local maintenance triggers become visible together.
+func ensureChineseFTS(
+	ctx context.Context, conn chineseFTSTransactor, forceRebuild bool,
+) error {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning Chinese FTS transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, trigger := range []string{
+		"messages_chinese_ai",
+		"messages_chinese_ad",
+		"messages_chinese_au",
+		"sessions_chinese_pending_ai",
+		"sessions_chinese_pending_au",
+		"sessions_chinese_pending_ad",
+	} {
+		if _, err := tx.ExecContext(ctx, "DROP TRIGGER IF EXISTS "+trigger); err != nil {
+			return fmt.Errorf("dropping Chinese FTS trigger %s: %w", trigger, err)
+		}
+	}
+
+	var tableExists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM sqlite_master
+			WHERE type = 'table' AND name = 'messages_chinese_fts'
+		)`).Scan(&tableExists); err != nil {
+		return fmt.Errorf("checking Chinese FTS table: %w", err)
+	}
+
+	var pendingTableExists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM sqlite_master
+			WHERE type = 'table'
+			  AND name = 'messages_chinese_fts_pending_sessions'
+		)`).Scan(&pendingTableExists); err != nil {
+		return fmt.Errorf("checking Chinese FTS freshness ledger table: %w", err)
+	}
+
+	trackFreshness := simpleFTSRuntimeConfig.available() ||
+		tableExists || pendingTableExists
+	if !trackFreshness {
+		if _, err := tx.ExecContext(
+			ctx, "DELETE FROM stats WHERE key = ?", chineseFTSFingerprintStatsKey,
+		); err != nil {
+			return fmt.Errorf("clearing orphaned Chinese FTS fingerprint: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("committing disabled Chinese FTS state: %w", err)
+		}
+		return nil
+	}
+
+	if _, err := tx.ExecContext(ctx, schemaChineseFTSPendingSessions); err != nil {
+		return fmt.Errorf("installing Chinese FTS freshness ledger: %w", err)
+	}
+	var pendingSessions int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT count(*) FROM messages_chinese_fts_pending_sessions",
+	).Scan(&pendingSessions); err != nil {
+		return fmt.Errorf("checking Chinese FTS freshness ledger: %w", err)
+	}
+
+	if !simpleFTSRuntimeConfig.available() {
+		if tableExists {
+			if _, err := tx.ExecContext(ctx, "DROP TABLE messages_chinese_fts"); err != nil {
+				return fmt.Errorf("dropping unavailable Chinese FTS: %w", err)
+			}
+		}
+		if _, err := tx.ExecContext(
+			ctx, "DELETE FROM stats WHERE key = ?", chineseFTSFingerprintStatsKey,
+		); err != nil {
+			return fmt.Errorf("clearing Chinese FTS fingerprint: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("committing Chinese FTS removal: %w", err)
+		}
+		return nil
+	}
+
+	var storedFingerprint string
+	fingerprintErr := tx.QueryRowContext(ctx,
+		"SELECT CAST(value AS TEXT) FROM stats WHERE key = ?",
+		chineseFTSFingerprintStatsKey,
+	).Scan(&storedFingerprint)
+	if fingerprintErr != nil && !errors.Is(fingerprintErr, sql.ErrNoRows) {
+		return fmt.Errorf("reading Chinese FTS fingerprint: %w", fingerprintErr)
+	}
+	current := tableExists && fingerprintErr == nil && pendingSessions == 0 &&
+		storedFingerprint == simpleFTSRuntimeConfig.fingerprint
+
+	if forceRebuild || !current {
+		log.Print("rebuilding Chinese FTS index; startup waits for the full message scan to finish")
+		if tableExists {
+			if _, err := tx.ExecContext(ctx, "DROP TABLE messages_chinese_fts"); err != nil {
+				return fmt.Errorf("dropping stale Chinese FTS: %w", err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, schemaChineseFTS); err != nil {
+			return fmt.Errorf("creating Chinese FTS: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO messages_chinese_fts(messages_chinese_fts) VALUES('rebuild')",
+		); err != nil {
+			return fmt.Errorf("backfilling Chinese FTS: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO stats (key, value) VALUES (?, ?)
+			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+			chineseFTSFingerprintStatsKey,
+			simpleFTSRuntimeConfig.fingerprint,
+		); err != nil {
+			return fmt.Errorf("storing Chinese FTS fingerprint: %w", err)
+		}
+		if _, err := tx.ExecContext(
+			ctx, "DELETE FROM messages_chinese_fts_pending_sessions",
+		); err != nil {
+			return fmt.Errorf("clearing Chinese FTS freshness ledger: %w", err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, schemaChineseFTSTriggers); err != nil {
+		return fmt.Errorf("installing Chinese FTS triggers: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing Chinese FTS transaction: %w", err)
+	}
+	return nil
+}
+
+func installChineseFTSTriggers(conn *sql.DB) error {
+	return ensureChineseFTS(context.Background(), conn, false)
+}

--- a/internal/db/chinese_fts_search.go
+++ b/internal/db/chinese_fts_search.go
@@ -1,0 +1,88 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type messageFTSQuery struct {
+	table       string
+	match       string
+	plain       string
+	snippetTerm string
+}
+
+func (db *DB) prepareMessageFTSQuery(
+	ctx context.Context, raw string,
+) (messageFTSQuery, error) {
+	trimmed := strings.TrimSpace(raw)
+	prepared := PrepareFTSQuery(trimmed)
+	query := messageFTSQuery{
+		table: "messages_fts",
+		match: prepared,
+		plain: StripFTSQuotes(prepared),
+	}
+	if prepared == "" || !containsCJK(trimmed) || !db.HasChineseFTS() {
+		return query, nil
+	}
+
+	query.table = "messages_chinese_fts"
+	if strings.HasPrefix(trimmed, `"`) {
+		// A leading quote is the established opt-in for an explicit FTS5
+		// expression. Preserve phrases, operators, and grouping verbatim.
+		query.match = prepared
+		return query, nil
+	}
+
+	conn, err := db.getReader().Conn(ctx)
+	if err != nil {
+		return messageFTSQuery{}, fmt.Errorf(
+			"acquiring Chinese FTS query connection: %w", err,
+		)
+	}
+	defer conn.Close()
+
+	simpleFTSJiebaMu.Lock()
+	err = conn.QueryRowContext(
+		ctx, "SELECT jieba_query(?, 0)", trimmed,
+	).Scan(&query.match)
+	simpleFTSJiebaMu.Unlock()
+	if err != nil {
+		return messageFTSQuery{}, fmt.Errorf(
+			"preparing Chinese FTS query: %w", err,
+		)
+	}
+	if strings.TrimSpace(query.match) == "" {
+		return messageFTSQuery{}, &SearchInputError{
+			Msg: "search: Chinese FTS query is empty after tokenization",
+		}
+	}
+	// jieba_query joins terms with AND and may add an unquoted prefix '*'.
+	// Keep the first literal term to locate snippets when the raw query splits.
+	firstTerm, _, _ := strings.Cut(query.match, " AND ")
+	query.snippetTerm = StripFTSQuotes(strings.TrimSuffix(firstTerm, "*"))
+	return query, nil
+}
+
+func containsCJK(text string) bool {
+	for len(text) > 0 {
+		r, size := utf8.DecodeRuneInString(text)
+		if r == utf8.RuneError && size == 1 {
+			text = text[1:]
+			continue
+		}
+		if unicode.In(r,
+			unicode.Han,
+			unicode.Hangul,
+			unicode.Hiragana,
+			unicode.Katakana,
+		) {
+			return true
+		}
+		text = text[size:]
+	}
+	return false
+}

--- a/internal/db/chinese_fts_test.go
+++ b/internal/db/chinese_fts_test.go
@@ -1,0 +1,601 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainsCJK(t *testing.T) {
+	t.Parallel()
+	assert.True(t, containsCJK("SQLite 中文搜索"))
+	assert.True(t, containsCJK("日本語"))
+	assert.True(t, containsCJK("한국어"))
+	assert.False(t, containsCJK("get_views error-401"))
+}
+
+func TestDiscoverSimpleFTSRuntimeFrom(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "libsimple.so"), []byte("library"), 0o600,
+	))
+	dictDir := filepath.Join(dir, "dict")
+	require.NoError(t, os.Mkdir(dictDir, 0o700))
+	for _, name := range []string{
+		"hmm_model.utf8",
+		"idf.utf8",
+		"jieba.dict.utf8",
+		"stop_words.utf8",
+		"user.dict.utf8",
+	} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dictDir, name), []byte(name), 0o600,
+		))
+	}
+
+	got, err := discoverSimpleFTSRuntimeFrom(
+		filepath.Join(t.TempDir(), "agentsview"), dir, "linux",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "libsimple.so"), got.libraryPath)
+	assert.Equal(t, dictDir, got.dictionaryPath)
+	assert.NotEmpty(t, got.fingerprint)
+
+	originalFingerprint := got.fingerprint
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dictDir, "user.dict.utf8"), []byte("changed"), 0o600,
+	))
+	changed, err := discoverSimpleFTSRuntimeFrom(
+		filepath.Join(t.TempDir(), "agentsview"), dir, "linux",
+	)
+	require.NoError(t, err)
+	assert.NotEqual(t, originalFingerprint, changed.fingerprint)
+}
+
+func TestDiscoverSimpleFTSRuntimeUnsupportedPlatformIsOptional(t *testing.T) {
+	got, err := discoverSimpleFTSRuntimeFrom(
+		filepath.Join(t.TempDir(), "agentsview"), "", "freebsd",
+	)
+	require.NoError(t, err)
+	assert.False(t, got.available())
+
+	_, err = discoverSimpleFTSRuntimeFrom(
+		filepath.Join(t.TempDir(), "agentsview"), t.TempDir(), "freebsd",
+	)
+	require.Error(t, err)
+}
+
+func TestDiscoverSimpleFTSRuntimeExplicitDirIsValidated(t *testing.T) {
+	_, err := discoverSimpleFTSRuntimeFrom(
+		filepath.Join(t.TempDir(), "agentsview"), t.TempDir(), "linux",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), simpleFTSDirEnv)
+}
+
+func TestChineseFTSSearch(t *testing.T) {
+	if !simpleFTSRuntimeConfig.available() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	d := testDB(t)
+	seedSearchSession(t, d, "chinese", "proj", [][2]string{
+		{"user", "请验证这段长句中的中文搜索功能，并检查 SQLite 集成。"},
+		{"assistant", "发现一个错误，随后修复。"},
+	})
+	seedSearchSession(t, d, "france", "proj", [][2]string{
+		{"user", "法国的首都是巴黎。"},
+	})
+	seedSearchSession(t, d, "reverse", "proj", [][2]string{
+		{"user", "这份材料讨论国法体系。"},
+	})
+	seedSearchSession(t, d, "english", "proj", [][2]string{
+		{"user", "The runner is running get_views after error-401."},
+	})
+
+	var pending int
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT count(*) FROM messages_chinese_fts_pending_sessions",
+	).Scan(&pending))
+	assert.Zero(t, pending)
+
+	var pinyinMatch string
+	simpleFTSJiebaMu.Lock()
+	err := d.getReader().QueryRow(
+		"SELECT jieba_query(?, 0)", "zhong",
+	).Scan(&pinyinMatch)
+	simpleFTSJiebaMu.Unlock()
+	require.NoError(t, err)
+	var pinyinHits int
+	require.NoError(t, d.getReader().QueryRow(
+		`SELECT count(*) FROM messages_chinese_fts
+		 WHERE messages_chinese_fts MATCH ?`, pinyinMatch,
+	).Scan(&pinyinHits))
+	assert.Zero(t, pinyinHits)
+
+	for _, query := range []string{"中文搜索", "搜索", "错", "SQLite 中文搜索"} {
+		page, err := d.SearchContent(context.Background(), ContentSearchFilter{
+			Pattern: query,
+			Mode:    "fts",
+			Sources: []string{"messages"},
+			Limit:   20,
+		})
+		require.NoError(t, err, "query %q", query)
+		require.NotEmpty(t, page.Matches, "query %q", query)
+		assert.Equal(t, "chinese", page.Matches[0].SessionID, "query %q", query)
+	}
+
+	seedSearchSession(t, d, "separated", "proj", [][2]string{
+		{"user", "中文和搜索之间插入了额外内容。"},
+	})
+
+	andQuery, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "中文 搜索",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	andIDs := make(map[string]bool)
+	for _, match := range andQuery.Matches {
+		andIDs[match.SessionID] = true
+	}
+	assert.True(t, andIDs["chinese"])
+	assert.True(t, andIDs["separated"])
+
+	phrase, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: `"中文 搜索"`,
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.Len(t, phrase.Matches, 1)
+	assert.Equal(t, "chinese", phrase.Matches[0].SessionID)
+
+	expression, err := d.prepareMessageFTSQuery(
+		context.Background(), `"中文" OR "国法"`,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, `"中文" OR "国法"`, expression.match)
+
+	orQuery, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: `"中文" OR "国法"`,
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	orIDs := make(map[string]bool)
+	for _, match := range orQuery.Matches {
+		orIDs[match.SessionID] = true
+	}
+	assert.True(t, orIDs["chinese"])
+	assert.True(t, orIDs["reverse"])
+
+	ordered, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "法国",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.Len(t, ordered.Matches, 1)
+	assert.Equal(t, "france", ordered.Matches[0].SessionID)
+
+	grouped, err := d.Search(context.Background(), SearchFilter{
+		Query: "中文搜索",
+		Limit: 20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, grouped.Results)
+	assert.Equal(t, "chinese", grouped.Results[0].SessionID)
+
+	// ASCII-only queries continue through the existing Porter-tokenized index.
+	english, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "run",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, english.Matches)
+	assert.Equal(t, "english", english.Matches[0].SessionID)
+
+	var storedFingerprint string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT CAST(value AS TEXT) FROM stats WHERE key = ?",
+		chineseFTSFingerprintStatsKey,
+	).Scan(&storedFingerprint))
+	assert.Equal(t, simpleFTSRuntimeConfig.fingerprint, storedFingerprint)
+
+	// Simulate a pre-fix partial build: the table exists without the atomic
+	// completion fingerprint. Reopen must replace and backfill it.
+	_, err = d.getWriter().Exec(`
+		DROP TRIGGER IF EXISTS messages_chinese_ai;
+		DROP TRIGGER IF EXISTS messages_chinese_ad;
+		DROP TRIGGER IF EXISTS messages_chinese_au;
+		DROP TABLE messages_chinese_fts;
+		CREATE VIRTUAL TABLE messages_chinese_fts USING fts5(
+			content,
+			content='messages',
+			content_rowid='id',
+			tokenize='simple'
+		);
+		DELETE FROM stats WHERE key = '` + chineseFTSFingerprintStatsKey + `'`)
+	require.NoError(t, err)
+	require.NoError(t, d.Reopen())
+	repaired, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "中文搜索",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, repaired.Matches)
+	assert.Equal(t, "chinese", repaired.Matches[0].SessionID)
+
+	_, err = d.getWriter().Exec(
+		"UPDATE stats SET value = 'stale' WHERE key = ?",
+		chineseFTSFingerprintStatsKey,
+	)
+	require.NoError(t, err)
+	assert.False(t, d.HasChineseFTS())
+	require.NoError(t, d.Reopen())
+	assert.True(t, d.HasChineseFTS())
+
+	require.NoError(t, d.CloseWriter())
+	require.NoError(t, d.ReopenWriter())
+	seedSearchSession(t, d, "reopened", "proj", [][2]string{
+		{"user", "重新打开写连接以后仍然可以搜索新增中文。"},
+	})
+	reopened, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "新增中文",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, reopened.Matches)
+	assert.Equal(t, "reopened", reopened.Matches[0].SessionID)
+
+	require.NoError(t, d.Reopen())
+	seedSearchSession(t, d, "swapped", "proj", [][2]string{
+		{"user", "完整重开数据库以后继续索引中文消息。"},
+	})
+	swapped, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "索引中文",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, swapped.Matches)
+	assert.Equal(t, "swapped", swapped.Matches[0].SessionID)
+}
+
+func TestChineseFTSContentSnippetCentersOnMatch(t *testing.T) {
+	if !simpleFTSRuntimeConfig.available() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	for _, tc := range []struct {
+		name, query, opening, match string
+	}{
+		{"separated words", "全文搜索", "", "全文的搜索"},
+		{"mixed language", "SQLite全文搜索", "", "SQLite 的全文的搜索"},
+		{"contiguous phrase preferred", "全文搜索", "先讨论全文。", "全文搜索"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := testDB(t)
+			body := tc.opening + strings.Repeat("开场说明。", 100) + tc.match + "实现说明。"
+			seedSearchSession(t, d, "long-chinese", "proj", [][2]string{{"user", body}})
+
+			page, err := d.SearchContent(context.Background(), ContentSearchFilter{
+				Pattern: tc.query,
+				Mode:    "fts",
+				Sources: []string{"messages"},
+				Limit:   20,
+			})
+			require.NoError(t, err)
+			require.Len(t, page.Matches, 1)
+			assert.Contains(t, page.Matches[0].Snippet, tc.match)
+		})
+	}
+}
+
+func TestChineseFTSTableCanBeDroppedWithoutExtension(t *testing.T) {
+	if !simpleFTSRuntimeConfig.available() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	path := filepath.Join(t.TempDir(), "drop-without-extension.db")
+	d, err := Open(path)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	raw, err := sql.Open("sqlite3", makeDSN(path, false))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec("DROP TABLE messages_chinese_fts")
+	require.NoError(t, err)
+}
+
+func TestChineseFTSRebuildsAfterLegacyWriter(t *testing.T) {
+	if !simpleFTSRuntimeConfig.available() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	path := filepath.Join(t.TempDir(), "legacy-writer.db")
+	d, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, d.Close()) })
+	seedSearchSession(t, d, "legacy", "proj", [][2]string{
+		{"user", "原始中文内容。"},
+	})
+
+	raw, err := sql.Open("sqlite3", makeDSN(path, false))
+	require.NoError(t, err)
+	tx, err := raw.Begin()
+	require.NoError(t, err)
+	_, err = tx.Exec(
+		"UPDATE messages SET content = ? WHERE session_id = ?",
+		"旧版本写入的新内容可以在重开后检索。", "legacy",
+	)
+	require.NoError(t, err)
+	_, err = tx.Exec(`
+		UPDATE sessions
+		SET transcript_revision = COALESCE(transcript_revision, 0) + 1
+		WHERE id = ?`, "legacy")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	var pending int
+	require.NoError(t, raw.QueryRow(
+		"SELECT count(*) FROM messages_chinese_fts_pending_sessions",
+	).Scan(&pending))
+	assert.Equal(t, 1, pending)
+	require.NoError(t, raw.Close())
+	require.False(t, d.HasChineseFTS())
+
+	// A local metadata update does not repair the other writer's message index.
+	name := "Renamed session"
+	require.NoError(t, d.RenameSession("legacy", &name))
+	require.False(t, d.HasChineseFTS(), "renaming must preserve the stale marker")
+	insertSession(t, d, "legacy", "proj", func(s *Session) {
+		s.UserMessageCount = 2
+	})
+	require.False(t, d.HasChineseFTS(), "upserts must preserve the stale marker")
+	require.NoError(t, d.InsertMessages([]Message{{
+		SessionID: "legacy", Ordinal: 1, Role: "assistant",
+		Content: "本地追加的消息。",
+	}}))
+	require.False(t, d.HasChineseFTS(), "appends do not repair earlier stale content")
+
+	var output bytes.Buffer
+	previousWriter := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(previousWriter) })
+	require.NoError(t, d.Reopen())
+	assert.Contains(t, output.String(), "rebuilding Chinese FTS index; startup waits")
+	page, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "旧版本写入",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, page.Matches)
+	assert.Equal(t, "legacy", page.Matches[0].SessionID)
+
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT count(*) FROM messages_chinese_fts_pending_sessions",
+	).Scan(&pending))
+	assert.Zero(t, pending)
+}
+
+func TestChineseFTSForeignFingerprintDefersMaintenance(t *testing.T) {
+	if !simpleFTSRuntimeConfig.available() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	d := testDB(t)
+	var output bytes.Buffer
+	previousWriter := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(previousWriter) })
+	seedSearchSession(t, d, "foreign-runtime", "proj", [][2]string{
+		{"user", "原始中文内容。"},
+	})
+
+	_, err := d.getWriter().Exec(
+		"UPDATE stats SET value = 'foreign-runtime' WHERE key = ?",
+		chineseFTSFingerprintStatsKey,
+	)
+	require.NoError(t, err)
+	assert.False(t, d.HasChineseFTS())
+	assert.False(t, d.HasChineseFTS())
+	assert.Equal(t, 1, strings.Count(output.String(), "Chinese FTS unavailable or stale"))
+
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(
+			"UPDATE messages SET content = ? WHERE session_id = ?",
+			"跨版本写入的新中文内容。", "foreign-runtime",
+		); err != nil {
+			return err
+		}
+		_, err := tx.Exec(`
+			UPDATE sessions
+			SET transcript_revision = CAST(
+				CAST(transcript_revision AS INTEGER) + 1 AS TEXT
+			)
+			WHERE id = ?`, "foreign-runtime")
+		return err
+	}))
+
+	var pending int
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT count(*) FROM messages_chinese_fts_pending_sessions",
+	).Scan(&pending))
+	assert.Equal(t, 1, pending)
+
+	var match string
+	simpleFTSJiebaMu.Lock()
+	err = d.getReader().QueryRow(
+		"SELECT jieba_query(?, 0)", "跨版本写入",
+	).Scan(&match)
+	simpleFTSJiebaMu.Unlock()
+	require.NoError(t, err)
+
+	var staleMatches int
+	require.NoError(t, d.getReader().QueryRow(
+		`SELECT count(*) FROM messages_chinese_fts
+		 WHERE messages_chinese_fts MATCH ?`, match,
+	).Scan(&staleMatches))
+	assert.Zero(t, staleMatches)
+
+	require.NoError(t, d.Reopen())
+	assert.True(t, d.HasChineseFTS())
+	page, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "跨版本写入",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, page.Matches)
+	assert.Equal(t, "foreign-runtime", page.Matches[0].SessionID)
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT count(*) FROM messages_chinese_fts_pending_sessions",
+	).Scan(&pending))
+	assert.Zero(t, pending)
+}
+
+func TestChineseFTSJiebaConfigurationSerializesWithQueries(t *testing.T) {
+	if !simpleFTSRuntimeConfig.available() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	path := filepath.Join(t.TempDir(), "jieba-concurrency.db")
+	d, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, d.Close()) })
+	seedSearchSession(t, d, "concurrent", "proj", [][2]string{
+		{"user", "并发中文搜索。"},
+	})
+
+	const workers = 8
+	const iterations = 4
+	errs := make(chan error, workers*iterations)
+	var wg sync.WaitGroup
+	for worker := range workers {
+		wg.Add(1)
+		go func(openConnections bool) {
+			defer wg.Done()
+			for range iterations {
+				if openConnections {
+					conn, err := sql.Open(
+						sqliteArchiveDriverName, makeDSN(path, true),
+					)
+					if err == nil {
+						err = conn.Ping()
+					}
+					if conn != nil {
+						if closeErr := conn.Close(); err == nil {
+							err = closeErr
+						}
+					}
+					if err != nil {
+						errs <- err
+					}
+					continue
+				}
+				if _, err := d.prepareMessageFTSQuery(
+					context.Background(), "并发中文搜索",
+				); err != nil {
+					errs <- err
+				}
+			}
+		}(worker%2 == 0)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+// Session upserts and no-op recall inserts must leave a healthy index usable.
+func TestChineseFTSSurvivesSessionResyncUpsert(t *testing.T) {
+	if !simpleFTSRuntimeConfig.available() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	d := testDB(t)
+	seedSearchSession(t, d, "resync", "proj", [][2]string{
+		{"user", "中文搜索必须在重新同步之后仍然可用。"},
+	})
+	require.True(t, d.HasChineseFTS(), "Chinese FTS live after the first write")
+
+	// Re-upsert the same session id, leaving transcript_revision alone. This
+	// is the shape of every ordinary resync of an unchanged session.
+	insertSession(t, d, "resync", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.UserMessageCount = 2
+	})
+	// Recall imports use this insert even when the session already exists.
+	require.NoError(t, d.insertSessionIfAbsent(context.Background(), Session{
+		ID: "resync", Project: "proj", Machine: "recall-import", Agent: "claude",
+	}))
+
+	var pending int
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT count(*) FROM messages_chinese_fts_pending_sessions",
+	).Scan(&pending))
+	assert.Zero(t, pending, "resync upsert must not strand a pending row")
+	assert.True(t, d.HasChineseFTS(), "Chinese FTS stays live across a resync")
+
+	page, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "重新同步",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, page.Matches, "Chinese search still returns after resync")
+	assert.Equal(t, "resync", page.Matches[0].SessionID)
+}
+
+// TestChineseFTSSurvivesCompaction pins that staged archive compaction keeps
+// the optional Chinese index queryable. Compaction rebuilds the archive into a
+// candidate file through maintenance connections that do not load the
+// tokenizer sidecar, and then swaps that candidate in, so the index surviving
+// the round trip is worth holding still.
+func TestChineseFTSSurvivesCompaction(t *testing.T) {
+	if !simpleFTSRuntimeConfig.available() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	d := testDB(t)
+	seedSearchSession(t, d, "compact-cn", "proj", [][2]string{
+		{"user", "压缩之后中文索引必须继续可用。"},
+	})
+	require.True(t, d.HasChineseFTS(), "Chinese FTS live before compaction")
+
+	_, err := d.Compact(context.Background(), CompactOptions{
+		StagingDir: t.TempDir(),
+	})
+	require.NoError(t, err, "compaction must not fail on an archive with a Chinese index")
+
+	assert.True(t, d.HasChineseFTS(), "Chinese FTS still live after compaction")
+	page, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "中文索引",
+		Mode:    "fts",
+		Sources: []string{"messages"},
+		Limit:   20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, page.Matches, "Chinese search still returns after compaction")
+	assert.Equal(t, "compact-cn", page.Matches[0].SessionID)
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -556,6 +556,21 @@ CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
 END;
 `
 
+const chineseFTSRuntimeMatchesSQL = `EXISTS (
+    SELECT 1 FROM main.stats
+    WHERE key = '` + chineseFTSFingerprintStatsKey + `'
+      AND CAST(value AS TEXT) = agentsview_chinese_fts_fingerprint()
+)`
+
+const messagesChineseADTriggerDDL = `
+CREATE TEMP TRIGGER IF NOT EXISTS messages_chinese_ad
+AFTER DELETE ON main.messages
+WHEN ` + chineseFTSRuntimeMatchesSQL + ` BEGIN
+    INSERT INTO messages_chinese_fts(messages_chinese_fts, rowid, content)
+        VALUES('delete', old.id, old.content);
+END;
+`
+
 const schemaFTS = `
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
     content,
@@ -572,6 +587,57 @@ CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
     INSERT INTO messages_fts(messages_fts, rowid, content)
         VALUES('delete', old.id, old.content);
     INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
+END;
+`
+
+const schemaChineseFTS = `
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_chinese_fts USING fts5(
+    content,
+    content='messages',
+    content_rowid='id',
+    tokenize='simple 0'
+);
+`
+
+const schemaChineseFTSTriggers = `
+CREATE TEMP TRIGGER IF NOT EXISTS messages_chinese_ai
+AFTER INSERT ON main.messages
+WHEN ` + chineseFTSRuntimeMatchesSQL + ` BEGIN
+    INSERT INTO messages_chinese_fts(rowid, content) VALUES (new.id, new.content);
+END;
+` + messagesChineseADTriggerDDL + `
+CREATE TEMP TRIGGER IF NOT EXISTS messages_chinese_au
+AFTER UPDATE ON main.messages
+WHEN ` + chineseFTSRuntimeMatchesSQL + ` BEGIN
+    INSERT INTO messages_chinese_fts(messages_chinese_fts, rowid, content)
+        VALUES('delete', old.id, old.content);
+    INSERT INTO messages_chinese_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+-- The persistent BEFORE triggers mark a session pending without consulting
+-- the extension, because a build without the sidecar cannot evaluate the
+-- fingerprint function. Match those events exactly and clear only generation
+-- 1, which was created by this write. Higher generations include an earlier
+-- unmaintained write and must survive until the index is rebuilt. The BEFORE
+-- INSERT trigger ignores existing sessions, so an upsert marks at most once.
+CREATE TEMP TRIGGER IF NOT EXISTS sessions_chinese_pending_ai
+AFTER INSERT ON main.sessions
+WHEN ` + chineseFTSRuntimeMatchesSQL + ` BEGIN
+    DELETE FROM messages_chinese_fts_pending_sessions
+    WHERE session_id = new.id AND generation = 1;
+END;
+CREATE TEMP TRIGGER IF NOT EXISTS sessions_chinese_pending_au
+AFTER UPDATE OF transcript_revision ON main.sessions
+WHEN old.transcript_revision IS NOT new.transcript_revision
+ AND ` + chineseFTSRuntimeMatchesSQL + ` BEGIN
+    DELETE FROM messages_chinese_fts_pending_sessions
+    WHERE session_id = new.id AND generation = 1;
+END;
+CREATE TEMP TRIGGER IF NOT EXISTS sessions_chinese_pending_ad
+AFTER DELETE ON main.sessions
+WHEN ` + chineseFTSRuntimeMatchesSQL + ` BEGIN
+    DELETE FROM messages_chinese_fts_pending_sessions
+    WHERE session_id = old.id AND generation = 1;
 END;
 `
 
@@ -730,6 +796,8 @@ type DB struct {
 	// the incremental signal path: a maintained delta must not load
 	// session history.
 	messagesLoadCount atomic.Int64
+
+	chineseFTSUnavailableLog sync.Once
 }
 
 // MessagesLoadCount returns the total number of GetAllMessages calls the
@@ -1139,6 +1207,9 @@ func open(
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	if err := checkSimpleFTSRuntimeConfig(); err != nil {
+		return nil, err
+	}
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
@@ -1503,7 +1574,7 @@ func UpgradeExportSchemaInPlace(path string, cause error) (retErr error) {
 		return fmt.Errorf("upgrading database schema: %s is empty", path)
 	}
 
-	writer, err := sql.Open("sqlite3", makeDSN(path, false))
+	writer, err := sql.Open(sqliteArchiveDriverName, makeDSN(path, false))
 	if err != nil {
 		return fmt.Errorf("opening schema upgrade writer: %w", err)
 	}
@@ -1599,6 +1670,9 @@ func initializeSchemaUpgradeMetadata(tx *sql.Tx) error {
 // any writable initialization. It is intended for cold CLI reads and recovery
 // cases where another process may own writable access to the archive.
 func OpenReadOnly(path string) (*DB, error) {
+	if err := checkSimpleFTSRuntimeConfig(); err != nil {
+		return nil, err
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1616,7 +1690,7 @@ func OpenReadOnly(path string) (*DB, error) {
 		)
 	}
 
-	reader, err := sql.Open(sqliteUsageDriverName, makeDSN(path, true))
+	reader, err := sql.Open(sqliteArchiveDriverName, makeDSN(path, true))
 	if err != nil {
 		return nil, fmt.Errorf("opening read-only reader: %w", err)
 	}
@@ -1710,7 +1784,7 @@ var (
 
 func readOnlyRequiredSchema() (map[string][]string, error) {
 	readOnlyRequiredSchemaOnce.Do(func() {
-		conn, err := sql.Open("sqlite3", ":memory:")
+		conn, err := sql.Open(sqliteArchiveDriverName, ":memory:")
 		if err != nil {
 			readOnlyRequiredSchemaErr = fmt.Errorf(
 				"opening schema probe: %w", err,
@@ -1887,7 +1961,7 @@ func probeDatabase(
 			"checking database file: %w", err,
 		)
 	}
-	conn, err := sql.Open("sqlite3", makeDSN(path, true))
+	conn, err := sql.Open(sqliteArchiveDriverName, makeDSN(path, true))
 	if err != nil {
 		return false, false, fmt.Errorf(
 			"probing schema: %w", err,
@@ -4165,7 +4239,7 @@ func openAndInit(
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	writer, err := sql.Open("sqlite3", makeDSN(path, false))
+	writer, err := sql.Open(sqliteArchiveDriverName, makeDSN(path, false))
 	if err != nil {
 		return nil, fmt.Errorf("opening writer: %w", err)
 	}
@@ -4175,7 +4249,7 @@ func openAndInit(
 		return nil, fmt.Errorf("configuring wal: %w", err)
 	}
 
-	reader, err := sql.Open(sqliteUsageDriverName, makeDSN(path, true))
+	reader, err := sql.Open(sqliteArchiveDriverName, makeDSN(path, true))
 	if err != nil {
 		writer.Close()
 		return nil, fmt.Errorf("opening reader: %w", err)
@@ -4358,6 +4432,13 @@ func (db *DB) DropFTS() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	stmts := []string{
+		"DROP TRIGGER IF EXISTS messages_chinese_ai",
+		"DROP TRIGGER IF EXISTS messages_chinese_ad",
+		"DROP TRIGGER IF EXISTS messages_chinese_au",
+		"DROP TRIGGER IF EXISTS sessions_chinese_pending_ai",
+		"DROP TRIGGER IF EXISTS sessions_chinese_pending_au",
+		"DROP TRIGGER IF EXISTS sessions_chinese_pending_ad",
+		"DROP TABLE IF EXISTS messages_chinese_fts",
 		"DROP TRIGGER IF EXISTS messages_ai",
 		"DROP TRIGGER IF EXISTS messages_ad",
 		"DROP TRIGGER IF EXISTS messages_au",
@@ -4368,6 +4449,11 @@ func (db *DB) DropFTS() error {
 		if _, err := w.Exec(s); err != nil {
 			return fmt.Errorf("drop fts (%s): %w", s, err)
 		}
+	}
+	if _, err := w.Exec(
+		"DELETE FROM stats WHERE key = ?", chineseFTSFingerprintStatsKey,
+	); err != nil {
+		return fmt.Errorf("clearing Chinese fts fingerprint: %w", err)
 	}
 	return nil
 }
@@ -4387,6 +4473,9 @@ func (db *DB) RebuildFTS() error {
 	)
 	if err != nil {
 		return fmt.Errorf("rebuild fts index: %w", err)
+	}
+	if err := ensureChineseFTS(context.Background(), w, true); err != nil {
+		return fmt.Errorf("rebuild Chinese fts index: %w", err)
 	}
 	return nil
 }
@@ -4444,6 +4533,41 @@ func (db *DB) HasFTS() bool {
 	// in the current runtime.
 	_, err := db.getReader().Exec(
 		"SELECT 1 FROM messages_fts LIMIT 1",
+	)
+	return err == nil
+}
+
+// HasChineseFTS reports whether the optional simple-tokenized message index is
+// loaded and queryable on this database connection.
+func (db *DB) HasChineseFTS() (available bool) {
+	if !simpleFTSRuntimeConfig.available() {
+		return false
+	}
+	defer func() {
+		if !available {
+			db.chineseFTSUnavailableLog.Do(func() {
+				log.Print("Chinese FTS unavailable or stale; using standard FTS5 until the archive is reopened")
+			})
+		}
+	}()
+	var storedFingerprint string
+	if err := db.getReader().QueryRow(
+		"SELECT CAST(value AS TEXT) FROM stats WHERE key = ?",
+		chineseFTSFingerprintStatsKey,
+	).Scan(&storedFingerprint); err != nil ||
+		storedFingerprint != simpleFTSRuntimeConfig.fingerprint {
+		return false
+	}
+	var hasPendingSessions bool
+	if err := db.getReader().QueryRow(`
+		SELECT EXISTS(
+			SELECT 1 FROM messages_chinese_fts_pending_sessions LIMIT 1
+		)`,
+	).Scan(&hasPendingSessions); err != nil || hasPendingSessions {
+		return false
+	}
+	_, err := db.getReader().Exec(
+		"SELECT 1 FROM messages_chinese_fts LIMIT 1",
 	)
 	return err == nil
 }
@@ -4528,6 +4652,10 @@ func (db *DB) init(ctx context.Context) error {
 		); err != nil {
 			return fmt.Errorf("backfilling FTS: %w", err)
 		}
+	}
+
+	if err := ensureChineseFTS(ctx, w, false); err != nil {
+		return fmt.Errorf("initializing Chinese FTS: %w", err)
 	}
 
 	var recallFTSCount int
@@ -4804,7 +4932,7 @@ func checkpointWALWithoutWriter(path string) error {
 		}
 		return fmt.Errorf("stat wal before final checkpoint: %w", err)
 	}
-	conn, err := sql.Open("sqlite3", makeDSN(path, false))
+	conn, err := sql.Open(sqliteArchiveDriverName, makeDSN(path, false))
 	if err != nil {
 		return fmt.Errorf("opening final checkpoint connection: %w", err)
 	}
@@ -4893,7 +5021,7 @@ func (db *DB) reopenLocked() error {
 // other caller clears the barrier.
 func (db *DB) reopenLockedWithBarrier(keepWriterBarrier bool) error {
 	writer, err := sql.Open(
-		"sqlite3", makeDSN(db.path, false),
+		sqliteArchiveDriverName, makeDSN(db.path, false),
 	)
 	if err != nil {
 		return fmt.Errorf("reopening writer: %w", err)
@@ -4903,9 +5031,13 @@ func (db *DB) reopenLockedWithBarrier(keepWriterBarrier bool) error {
 		writer.Close()
 		return fmt.Errorf("configuring reopened wal: %w", err)
 	}
+	if err := installChineseFTSTriggers(writer); err != nil {
+		writer.Close()
+		return fmt.Errorf("configuring reopened writer: %w", err)
+	}
 
 	reader, err := sql.Open(
-		sqliteUsageDriverName, makeDSN(db.path, true),
+		sqliteArchiveDriverName, makeDSN(db.path, true),
 	)
 	if err != nil {
 		writer.Close()
@@ -5025,7 +5157,7 @@ func (db *DB) ReopenWriter() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	writer, err := sql.Open("sqlite3", makeDSN(db.path, false))
+	writer, err := sql.Open(sqliteArchiveDriverName, makeDSN(db.path, false))
 	if err != nil {
 		return fmt.Errorf("reopening writer: %w", err)
 	}
@@ -5033,6 +5165,10 @@ func (db *DB) ReopenWriter() error {
 	if err := configureWAL(writer); err != nil {
 		writer.Close()
 		return fmt.Errorf("configuring reopened wal: %w", err)
+	}
+	if err := installChineseFTSTriggers(writer); err != nil {
+		writer.Close()
+		return fmt.Errorf("configuring reopened writer: %w", err)
 	}
 
 	db.connMu.Lock()

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2054,40 +2054,82 @@ func bumpTranscriptRevision(
 	return nil
 }
 
-func sessionHasFTSTx(tx transactionQueries) (bool, error) {
+func sessionHasFTSTableTx(tx transactionQueries, table string) (bool, error) {
 	var ftsCount int
 	if err := tx.QueryRow(
 		`SELECT count(*) FROM sqlite_master
-		 WHERE type='table' AND name='messages_fts'`,
+		 WHERE type='table' AND name=?`, table,
 	).Scan(&ftsCount); err != nil {
-		return false, fmt.Errorf("probing fts table: %w", err)
+		return false, fmt.Errorf("probing fts table %s: %w", table, err)
 	}
 	return ftsCount > 0, nil
+}
+
+func sessionHasCurrentChineseFTSTx(
+	tx transactionQueries,
+) (bool, error) {
+	exists, err := sessionHasFTSTableTx(tx, "messages_chinese_fts")
+	if err != nil || !exists || !simpleFTSRuntimeConfig.available() {
+		return false, err
+	}
+	var storedFingerprint string
+	err = tx.QueryRow(
+		"SELECT CAST(value AS TEXT) FROM stats WHERE key = ?",
+		chineseFTSFingerprintStatsKey,
+	).Scan(&storedFingerprint)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf(
+			"reading Chinese fts fingerprint: %w", err,
+		)
+	}
+	return storedFingerprint == simpleFTSRuntimeConfig.fingerprint, nil
 }
 
 func deleteSessionMessageRowsTx(
 	tx transactionQueries, sessionID string,
 ) error {
-	hasFTS, err := sessionHasFTSTx(tx)
-	if err != nil {
-		return err
+	tables := []struct {
+		name       string
+		deleteName string
+		deleteDDL  string
+	}{
+		{"messages_fts", "messages_ad", messagesADTriggerDDL},
+		{"messages_chinese_fts", "messages_chinese_ad", messagesChineseADTriggerDDL},
+	}
+	active := tables[:0]
+	for _, table := range tables {
+		var exists bool
+		var err error
+		if table.name == "messages_chinese_fts" {
+			exists, err = sessionHasCurrentChineseFTSTx(tx)
+		} else {
+			exists, err = sessionHasFTSTableTx(tx, table.name)
+		}
+		if err != nil {
+			return err
+		}
+		if exists {
+			active = append(active, table)
+		}
 	}
 
-	if hasFTS {
+	for _, table := range active {
 		// Bulk-delete the FTS entries first so the later row delete
-		// does not re-tokenize large message blobs through messages_ad.
+		// does not re-tokenize large message blobs through delete triggers.
 		if _, err := tx.Exec(
-			`INSERT INTO messages_fts(messages_fts, rowid, content)
-			 SELECT 'delete', id, content
-			 FROM messages WHERE session_id = ?`,
+			`INSERT INTO `+table.name+`(`+table.name+`, rowid, content)
+			 SELECT 'delete', id, content FROM messages WHERE session_id = ?`,
 			sessionID,
 		); err != nil {
-			return fmt.Errorf("bulk-deleting fts entries: %w", err)
+			return fmt.Errorf("bulk-deleting %s entries: %w", table.name, err)
 		}
 		if _, err := tx.Exec(
-			"DROP TRIGGER IF EXISTS messages_ad",
+			"DROP TRIGGER IF EXISTS " + table.deleteName,
 		); err != nil {
-			return fmt.Errorf("dropping messages_ad trigger: %w", err)
+			return fmt.Errorf("dropping %s trigger: %w", table.deleteName, err)
 		}
 	}
 	if _, err := tx.Exec(
@@ -2095,9 +2137,9 @@ func deleteSessionMessageRowsTx(
 	); err != nil {
 		return fmt.Errorf("deleting old messages: %w", err)
 	}
-	if hasFTS {
-		if _, err := tx.Exec(messagesADTriggerDDL); err != nil {
-			return fmt.Errorf("restoring messages_ad trigger: %w", err)
+	for _, table := range active {
+		if _, err := tx.Exec(table.deleteDDL); err != nil {
+			return fmt.Errorf("restoring %s trigger: %w", table.deleteName, err)
 		}
 	}
 	return nil

--- a/internal/db/prepared_testdb_test.go
+++ b/internal/db/prepared_testdb_test.go
@@ -10,7 +10,7 @@ import (
 // initialized with the current schema and data version. It is intentionally
 // test-only so production code cannot bypass the normal open/migration path.
 func OpenPreparedTestDB(path string) (*DB, error) {
-	writer, err := sql.Open("sqlite3", makeDSN(path, false))
+	writer, err := sql.Open(sqliteArchiveDriverName, makeDSN(path, false))
 	if err != nil {
 		return nil, fmt.Errorf("opening prepared test writer: %w", err)
 	}
@@ -19,8 +19,12 @@ func OpenPreparedTestDB(path string) (*DB, error) {
 		writer.Close()
 		return nil, fmt.Errorf("configuring prepared test wal: %w", err)
 	}
+	if err := installChineseFTSTriggers(writer); err != nil {
+		writer.Close()
+		return nil, fmt.Errorf("configuring prepared test Chinese FTS: %w", err)
+	}
 
-	reader, err := sql.Open(sqliteUsageDriverName, makeDSN(path, true))
+	reader, err := sql.Open(sqliteArchiveDriverName, makeDSN(path, true))
 	if err != nil {
 		writer.Close()
 		return nil, fmt.Errorf("opening prepared test reader: %w", err)

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -347,7 +347,11 @@ func (db *DB) Search(
 	if f.Limit <= 0 || f.Limit > MaxSearchLimit {
 		f.Limit = DefaultSearchLimit
 	}
-	f.Query = PrepareFTSQuery(f.Query)
+	ftsQuery, err := db.prepareMessageFTSQuery(ctx, f.Query)
+	if err != nil {
+		return SearchPage{}, err
+	}
+	f.Query = ftsQuery.match
 
 	// ORDER BY for the outer query. FTS5 ranks are negative (lower = better),
 	// so rank ASC places message matches (negative rank) before name-only rows
@@ -395,7 +399,7 @@ func (db *DB) Search(
 	// each term in double quotes for FTS (e.g. "fix bug" → `"fix" "bug"`).
 	// LIKE and instr() must use the plain text form so name/content substring
 	// searches work correctly.
-	plainQuery := StripFTSQuotes(f.Query)
+	plainQuery := ftsQuery.plain
 	if plainQuery == "" {
 		return SearchPage{}, nil
 	}
@@ -512,6 +516,7 @@ func (db *DB) Search(
 		innerWhereSQL,     // NOT IN subquery WHERE (%s)
 		orderBy,           // ORDER BY (%s)
 	)
+	query = strings.ReplaceAll(query, "messages_fts", ftsQuery.table)
 
 	// Replace the ROW_NUMBER inner subquery's ? for best_query with args
 	// re-ordered: the first innerWhere param (f.Query) was already included in

--- a/internal/db/search_content.go
+++ b/internal/db/search_content.go
@@ -692,6 +692,10 @@ func (db *DB) searchContentFTS(
 	if !db.HasFTS() {
 		return ContentSearchPage{}, errFTSUnavailable
 	}
+	ftsQuery, err := db.prepareMessageFTSQuery(ctx, f.Pattern)
+	if err != nil {
+		return ContentSearchPage{}, err
+	}
 	scope, scopeArgs := sessionScopeSubquery(f)
 	sysPred := "1=1"
 	if f.ExcludeSystem {
@@ -708,10 +712,13 @@ func (db *DB) searchContentFTS(
 		WHERE messages_fts MATCH ? AND %s AND m.%s
 		ORDER BY rank ASC, m.ordinal ASC, m.id ASC
 		LIMIT ? OFFSET ?`, sysPred, scope)
-	args := []any{PrepareFTSQuery(f.Pattern)}
+	query = strings.ReplaceAll(query, "messages_fts", ftsQuery.table)
+	args := []any{ftsQuery.match}
 	args = append(args, scopeArgs...)
 	args = append(args, f.Limit+1, f.Cursor)
-	page, err := db.scanContentMatches(ctx, query, args, f.Limit, f.Cursor, f.ftsSnippet)
+	page, err := db.scanContentMatches(ctx, query, args, f.Limit, f.Cursor, func(body string) string {
+		return f.ftsSnippet(body, ftsQuery.snippetTerm)
+	})
 	if err != nil {
 		return ContentSearchPage{}, classifyFTSError(err)
 	}
@@ -721,12 +728,15 @@ func (db *DB) searchContentFTS(
 // ftsSnippet builds the snippet for an FTS match. FTS matching is tokenized, so
 // there is no exact byte offset; it centers on the first case-insensitive
 // occurrence of the de-quoted query phrase, falling back to the query's first
-// token, then to the start. Trying the whole phrase first keeps a phrase query
-// ("foo bar") centered on the phrase rather than on a stray earlier "foo". The
-// approximation only affects snippet centering, not redaction, which scans the
-// full body.
-func (f ContentSearchFilter) ftsSnippet(body string) string {
+// token, then a segmented term if supplied, then to the start. Trying the whole
+// phrase first keeps a phrase query ("foo bar") centered on the phrase rather
+// than on a stray earlier "foo". The approximation only affects snippet
+// centering, not redaction, which scans the full body.
+func (f ContentSearchFilter) ftsSnippet(body, segmentedTerm string) string {
 	start, end := FTSSnippetRange(f.Pattern, body)
+	if start == end && segmentedTerm != "" {
+		start, end, _ = CaseInsensitiveSpan(body, segmentedTerm)
+	}
 	return f.buildSnippet(body, start, end)
 }
 
@@ -1171,6 +1181,10 @@ func (db *DB) hybridFTSLeg(
 func (db *DB) fetchHybridFTSBatch(
 	ctx context.Context, f ContentSearchFilter, k, offset int,
 ) ([]hybridDisplay, error) {
+	ftsQuery, err := db.prepareMessageFTSQuery(ctx, f.Pattern)
+	if err != nil {
+		return nil, err
+	}
 	scope, scopeArgs := semanticSessionScopeSubquery(f)
 	query := fmt.Sprintf(`
 		SELECT m.session_id, m.ordinal,
@@ -1181,8 +1195,9 @@ func (db *DB) fetchHybridFTSBatch(
 		  AND m.%s
 		ORDER BY f.rank, m.id LIMIT ? OFFSET ?`,
 		SystemPrefixSQL("m.content", "m.role"), scope)
+	query = strings.ReplaceAll(query, "messages_fts", ftsQuery.table)
 
-	args := []any{PrepareFTSQuery(f.Pattern)}
+	args := []any{ftsQuery.match}
 	args = append(args, scopeArgs...)
 	args = append(args, k, offset)
 

--- a/internal/db/search_content_test.go
+++ b/internal/db/search_content_test.go
@@ -653,14 +653,14 @@ func TestFTSSnippetCentersOnPhrase(t *testing.T) {
 
 	t.Run("phrase present centers on phrase", func(t *testing.T) {
 		f := ContentSearchFilter{Pattern: `"error handler"`, Mode: "fts"}
-		assert.Contains(t, f.ftsSnippet(body), "error handler",
+		assert.Contains(t, f.ftsSnippet(body, ""), "error handler",
 			"snippet did not center on the phrase")
 	})
 	t.Run("phrase absent falls back to first token", func(t *testing.T) {
 		// No contiguous "error handler" substring, so centering falls back to
 		// the first token "error", windowing its early occurrence.
 		f := ContentSearchFilter{Pattern: `"error nonexistent"`, Mode: "fts"}
-		assert.Contains(t, f.ftsSnippet(body), "error in the early",
+		assert.Contains(t, f.ftsSnippet(body, ""), "error in the early",
 			"fallback snippet not centered on first token")
 	})
 }

--- a/internal/db/sqlite_driver.go
+++ b/internal/db/sqlite_driver.go
@@ -2,36 +2,88 @@ package db
 
 import (
 	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"sync"
 
 	"github.com/mattn/go-sqlite3"
 )
 
-const sqliteUsageDriverName = "agentsview_sqlite3"
+const (
+	sqliteUsageDriverName   = "agentsview_sqlite3"
+	sqliteArchiveDriverName = "agentsview_archive_sqlite3"
+)
+
+// simpleFTSJiebaMu serializes the two upstream entry points that share
+// cppjieba's module-global dictionary state: jieba_dict and jieba_query.
+// The simple FTS tokenizer used by MATCH, trigger maintenance, and rebuilds
+// does not read that state; it tokenizes documents directly by code point.
+var simpleFTSJiebaMu sync.Mutex
 
 func init() {
 	sql.Register(sqliteUsageDriverName, &sqlite3.SQLiteDriver{
-		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-			if err := conn.RegisterFunc(
-				"agentsview_timestamp_unix_micro",
-				sqliteTimestampUnixMicro,
-				true,
-			); err != nil {
-				return err
-			}
-			if err := conn.RegisterFunc(
-				"agentsview_usage_output_tokens",
-				sqliteUsageOutputTokens,
-				true,
-			); err != nil {
-				return err
-			}
-			return conn.RegisterFunc(
-				"agentsview_usage_web_search_requests",
-				parseUsageWebSearchRequests,
-				true,
-			)
-		},
+		ConnectHook: configureSQLiteConnection,
 	})
+	drv := &sqlite3.SQLiteDriver{ConnectHook: configureArchiveSQLiteConnection}
+	if simpleFTSRuntimeConfig.available() {
+		drv.Extensions = []string{simpleFTSRuntimeConfig.libraryPath}
+	}
+	sql.Register(sqliteArchiveDriverName, drv)
+}
+
+func configureSQLiteConnection(conn *sqlite3.SQLiteConn) error {
+	if err := conn.RegisterFunc(
+		"agentsview_timestamp_unix_micro",
+		sqliteTimestampUnixMicro,
+		true,
+	); err != nil {
+		return err
+	}
+	if err := conn.RegisterFunc(
+		"agentsview_usage_output_tokens",
+		sqliteUsageOutputTokens,
+		true,
+	); err != nil {
+		return err
+	}
+	if err := conn.RegisterFunc(
+		"agentsview_usage_web_search_requests",
+		parseUsageWebSearchRequests,
+		true,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func configureArchiveSQLiteConnection(conn *sqlite3.SQLiteConn) error {
+	if err := configureSQLiteConnection(conn); err != nil {
+		return err
+	}
+	if err := conn.RegisterFunc(
+		"agentsview_chinese_fts_fingerprint",
+		func() string { return simpleFTSRuntimeConfig.fingerprint },
+		true,
+	); err != nil {
+		return fmt.Errorf("registering Chinese FTS fingerprint: %w", err)
+	}
+	if !simpleFTSRuntimeConfig.available() {
+		return nil
+	}
+
+	// Upstream reads jieba_dict_path only while constructing/using
+	// jieba_query's process-global cppjieba instance. Serialize the setter
+	// with every internal jieba_query call. MATCH and index maintenance use
+	// SimpleTokenizer::tokenize and do not consult this path.
+	simpleFTSJiebaMu.Lock()
+	defer simpleFTSJiebaMu.Unlock()
+	if _, err := conn.Exec(
+		"SELECT jieba_dict(?)",
+		[]driver.Value{simpleFTSRuntimeConfig.dictionaryPath},
+	); err != nil {
+		return fmt.Errorf("configuring simple FTS5 dictionaries: %w", err)
+	}
+	return nil
 }
 
 func sqliteTimestampUnixMicro(raw string) any {

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -909,6 +909,7 @@ func (s *Store) Search(ctx context.Context, f db.SearchFilter) (db.SearchPage, e
 	// identically across backends. An explicit exact phrase (user-supplied
 	// leading quote) collapses to a single term, preserving the exact-phrase
 	// opt-in.
+	f.Query = db.PrepareFTSQuery(f.Query)
 	plainTerm := db.StripFTSQuotes(f.Query)
 	terms := db.FTSTerms(f.Query)
 	if plainTerm == "" || len(terms) == 0 {

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -781,8 +781,8 @@ func TestSearchGroupsMessagesAndIncludesNameMatches(t *testing.T) {
 
 // TestSearchOperatorTokenNoError mirrors the SQLite FTS 500 regression on the
 // DuckDB/ILIKE backend: a single token containing operator characters (hyphen,
-// colon), prepared the way the HTTP handler does, must match content and not
-// error. ILIKE has no FTS-operator hazard, but this pins backend parity.
+// colon, embedded quote), whether raw or explicitly quoted, must match content
+// and not error. ILIKE has no FTS-operator hazard, but this pins backend parity.
 func TestSearchOperatorTokenNoError(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)
@@ -790,7 +790,7 @@ func TestSearchOperatorTokenNoError(t *testing.T) {
 	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
 		Session: syncSession(sessionID, "alpha", "first msg text", "2026-03-20T10:00:00.000Z", 2),
 		Messages: []db.Message{
-			syncMessage(sessionID, 0, "user", "hit error-401 from the api", "2026-03-20T10:00:00.000Z"),
+			syncMessage(sessionID, 0, "user", `hit error-401 from the api and say"hi`, "2026-03-20T10:00:00.000Z"),
 			syncMessage(sessionID, 1, "assistant", "returned status:500 to client", "2026-03-20T10:00:01.000Z"),
 		},
 		DataVersion:     1,
@@ -804,9 +804,9 @@ func TestSearchOperatorTokenNoError(t *testing.T) {
 	require.NoError(t, err)
 	store := NewStoreFromDB(syncer.DB())
 
-	for _, raw := range []string{"error-401", "status:500"} {
+	for _, raw := range []string{"error-401", "status:500", `say"hi`, `"say""hi"`} {
 		page, err := store.Search(ctx, db.SearchFilter{
-			Query: db.PrepareFTSQuery(raw), Limit: 10,
+			Query: raw, Limit: 10,
 		})
 		require.NoError(t, err, "Search(%q)", raw)
 		require.Len(t, page.Results, 1, "results for %q", raw)

--- a/internal/mcp/shape.go
+++ b/internal/mcp/shape.go
@@ -1,11 +1,10 @@
 // ABOUTME: Response-shaping helpers shared by the MCP tools: limit
-// ABOUTME: clamping, rune-safe truncation, FTS query building, the
+// ABOUTME: clamping, rune-safe truncation, the
 // ABOUTME: self-reference exclusion window, and the role filter.
 package mcp
 
 import (
 	"slices"
-	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -64,41 +63,6 @@ func clampLimit(requested, def, max int) int {
 		return def
 	}
 	return requested
-}
-
-// buildSearchQuery turns a user's search input into an FTS5 expression
-// that is safe and useful to hand to the agentsview search layer. Two
-// sharp edges bite a naive caller: bare punctuation in a token (the
-// hyphen in "agentsview-mcp", a colon in "foo:bar", a stray paren) is
-// parsed as query syntax and raises an error, and an unquoted multi-word
-// query is matched as a single exact phrase, so natural-language input
-// quietly returns nothing.
-//
-// We quote each whitespace-separated term, escaping any embedded quote by
-// doubling it. Quoting makes punctuation literal inside the term, and
-// space-separated quoted phrases combine under FTS5's implicit AND - so
-// every term must appear without demanding an exact phrase. The leading
-// quote also makes db.PrepareFTSQuery pass the query through unchanged
-// instead of re-wrapping it as a phrase.
-//
-// A query the caller already opened with a double quote is treated as a
-// deliberate FTS expression (including an explicit "exact phrase") and is
-// passed through untouched.
-func buildSearchQuery(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" || strings.HasPrefix(raw, `"`) {
-		return raw
-	}
-	var b strings.Builder
-	for i, term := range strings.Fields(raw) {
-		if i > 0 {
-			b.WriteByte(' ')
-		}
-		b.WriteByte('"')
-		b.WriteString(strings.ReplaceAll(term, `"`, `""`))
-		b.WriteByte('"')
-	}
-	return b.String()
 }
 
 // isActiveSince reports whether an RFC3339 timestamp falls within the

--- a/internal/mcp/shape_test.go
+++ b/internal/mcp/shape_test.go
@@ -1,34 +1,11 @@
 package mcp
 
 import (
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestBuildSearchQuery(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name, raw, want string
-	}{
-		{"single word quoted", "login", `"login"`},
-		{"multi-word AND", "fix bug", `"fix" "bug"`},
-		{"hyphen token literal", "agentsview-mcp", `"agentsview-mcp"`},
-		{"colon token literal", "status:500", `"status:500"`},
-		{"embedded quote doubled", `say"hi`, `"say""hi"`},
-		{"leading quote passthrough", `"fix bug"`, `"fix bug"`},
-		{"empty", "", ""},
-		{"whitespace only", "   ", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, buildSearchQuery(tc.raw))
-		})
-	}
-}
 
 func TestTruncate(t *testing.T) {
 	t.Parallel()
@@ -82,13 +59,4 @@ func TestStrval(t *testing.T) {
 	assert.Equal(t, "", strval(nil))
 	v := "x"
 	assert.Equal(t, "x", strval(&v))
-}
-
-// Guard against accidental whitespace regressions in the multi-term query
-// builder.
-func TestBuildSearchQuery_NoTrailingSpace(t *testing.T) {
-	t.Parallel()
-	got := buildSearchQuery("a b c")
-	assert.False(t, strings.HasSuffix(got, " "))
-	assert.Equal(t, `"a" "b" "c"`, got)
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -112,7 +112,7 @@ func (t *toolset) searchSessions(
 	res, err := t.svc.Search(ctx, service.SearchRequest{
 		DateFrom: in.DateFrom,
 		DateTo:   in.DateTo,
-		Query:    buildSearchQuery(in.Query),
+		Query:    in.Query,
 		Project:  in.Project,
 		Sort:     in.Sort,
 		Cursor:   in.Cursor,

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -81,6 +81,46 @@ func TestSearchSessions_ReturnsHitsWithOrdinal(t *testing.T) {
 	assert.Zero(t, out.ExcludedActive)
 }
 
+func TestSearchSessions_ChineseSegmentation(t *testing.T) {
+	ts, d := newTestToolset(t)
+	if !d.HasChineseFTS() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	seedFTSSession(t, d, "chinese", "proj",
+		"这是全文的搜索实现说明。", "2024-06-15T10:00:00Z")
+
+	out := mustSearch(t, ts, searchSessionsIn{Query: "全文搜索"})
+	require.Len(t, out.Results, 1)
+	assert.Equal(t, "chinese", out.Results[0].SessionID)
+	assert.Contains(t, out.Results[0].Snippet, "<mark>全文</mark>")
+	assert.Contains(t, out.Results[0].Snippet, "<mark>搜索</mark>")
+
+	phrase := mustSearch(t, ts, searchSessionsIn{Query: `"全文搜索"`})
+	assert.Empty(t, phrase.Results, "explicit phrases must retain word adjacency")
+}
+
+func TestSearchSessions_QuerySyntax(t *testing.T) {
+	ts, d := newTestToolset(t)
+	seedFTSSession(t, d, "terms", "proj",
+		`fix the bug with status:500 and say"hi`, "2024-06-15T10:00:00Z")
+	for _, tc := range []struct {
+		query string
+		hits  int
+	}{
+		{"fix bug", 1},
+		{"status:500", 1},
+		{`say"hi`, 1},
+		{`"say""hi"`, 1},
+		{`"fix bug"`, 0},
+		{`"fix" OR "missing"`, 1},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			out := mustSearch(t, ts, searchSessionsIn{Query: tc.query})
+			assert.Len(t, out.Results, tc.hits)
+		})
+	}
+}
+
 func TestSearchSessions_ExcludesRecentlyActive(t *testing.T) {
 	ts, d := newTestToolset(t)
 	if !d.HasFTS() {

--- a/internal/postgres/messages.go
+++ b/internal/postgres/messages.go
@@ -345,6 +345,7 @@ func (s *Store) Search(
 	// user query behaves identically across backends. An explicit exact phrase
 	// (user-supplied leading quote) collapses to a single term, preserving the
 	// exact-phrase opt-in.
+	f.Query = db.PrepareFTSQuery(f.Query)
 	plainTerm := db.StripFTSQuotes(f.Query)
 	terms := db.FTSTerms(f.Query)
 	if plainTerm == "" || len(terms) == 0 {

--- a/internal/postgres/messages_pgtest_test.go
+++ b/internal/postgres/messages_pgtest_test.go
@@ -815,8 +815,8 @@ func TestGetMessagesIDPopulated(t *testing.T) {
 
 // TestPGSearchOperatorTokenNoError mirrors the SQLite FTS 500 regression on the
 // PostgreSQL/ILIKE backend: a single token containing operator characters
-// (hyphen, colon), prepared the way the HTTP handler does, must match content
-// and not error. ILIKE has no FTS-operator hazard, but this pins parity.
+// (hyphen, colon, embedded quote), whether raw or explicitly quoted, must match
+// content and not error. ILIKE has no FTS-operator hazard, but this pins parity.
 func TestPGSearchOperatorTokenNoError(t *testing.T) {
 	pgURL := testPGURL(t)
 	ensureStoreSchema(t, pgURL)
@@ -839,8 +839,8 @@ func TestPGSearchOperatorTokenNoError(t *testing.T) {
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp, content_length)
 		VALUES
-			('optok-001', 0, 'user', 'hit error-401 from the api',
-			 '2026-03-20T10:00:00Z'::timestamptz, 26),
+			('optok-001', 0, 'user', 'hit error-401 from the api and say"hi',
+			 '2026-03-20T10:00:00Z'::timestamptz, 35),
 			('optok-001', 1, 'assistant', 'returned status:500 to client',
 			 '2026-03-20T10:00:01Z'::timestamptz, 30)
 		ON CONFLICT DO NOTHING`)
@@ -850,9 +850,9 @@ func TestPGSearchOperatorTokenNoError(t *testing.T) {
 	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
-	for _, raw := range []string{"error-401", "status:500"} {
+	for _, raw := range []string{"error-401", "status:500", `say"hi`, `"say""hi"`} {
 		page, err := store.Search(context.Background(), db.SearchFilter{
-			Query: db.PrepareFTSQuery(raw), Limit: 10,
+			Query: raw, Limit: 10,
 		})
 		require.NoError(t, err, "Search(%q)", raw)
 		require.Len(t, page.Results, 1, "results for %q", raw)

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -680,11 +680,14 @@ func (b *directBackend) Search(
 	page, err := b.db.Search(ctx, db.SearchFilter{
 		DateFrom: req.DateFrom,
 		DateTo:   req.DateTo,
-		Query:    db.PrepareFTSQuery(query),
-		Project:  req.Project,
-		Sort:     req.Sort,
-		Cursor:   req.Cursor,
-		Limit:    limit,
+		// Pass the query through untouched. db.Search prepares it itself,
+		// and pre-quoting here made every Chinese query look like an
+		// explicit FTS5 expression, which skipped word segmentation.
+		Query:   query,
+		Project: req.Project,
+		Sort:    req.Sort,
+		Cursor:  req.Cursor,
+		Limit:   limit,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/search_chinese_test.go
+++ b/internal/service/search_chinese_test.go
@@ -1,0 +1,43 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/service"
+)
+
+// TestDirectSearchSegmentsChineseQuery pins that the service search path hands
+// the user's query to the store untouched. Pre-applying db.PrepareFTSQuery
+// here quoted every Chinese query, the store read that leading quote as the
+// opt-in for an explicit FTS5 expression, and word segmentation was skipped:
+// a query then only matched its characters run together verbatim.
+func TestDirectSearchSegmentsChineseQuery(t *testing.T) {
+	t.Parallel()
+	d := dbtest.OpenTestDB(t)
+	id := "cn1"
+	dbtest.SeedSessionWithMessages(t, d, id, "proj", []db.Message{
+		dbtest.UserMsg(id, 0, "这是全文的搜索实现说明。"),
+		dbtest.AsstMsg(id, 1, "understood"),
+	}, dbtest.WithMessageCounts(3, 2))
+	if !d.HasChineseFTS() {
+		t.Skip("simple FTS5 runtime is not installed for this test process")
+	}
+	be := service.NewDirectBackend(d, nil)
+
+	// jieba segments 全文搜索 into 全文 AND 搜索, both of which the message
+	// contains. As the literal phrase it never matches, because the message
+	// separates the two words.
+	res, err := be.Search(context.Background(), service.SearchRequest{
+		Query: "全文搜索",
+		Limit: 20,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Results, "segmented Chinese query should match")
+	assert.Equal(t, id, res.Results[0].SessionID)
+}

--- a/scripts/build-simple-fts.sh
+++ b/scripts/build-simple-fts.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+simple_repo="https://github.com/wangfenjin/simple.git"
+simple_commit="4ed008934495fc55ff4bf6620bba58311988b23e"
+cppjieba_commit="194c144d8b5ed1baf3190d07c5226e804454ab47"
+output_dir="${1:-dist/agentsview-simple}"
+temp_parent="${TMPDIR:-${XDG_CACHE_HOME:-$HOME/.cache}}"
+
+mkdir -p "$temp_parent"
+build_root=$(mktemp -d "$temp_parent/agentsview-simple-build.XXXXXX")
+cleanup() {
+    rm -rf -- "$build_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+git clone --quiet --filter=blob:none --no-checkout "$simple_repo" "$build_root/source"
+git -C "$build_root/source" checkout --quiet --detach "$simple_commit"
+actual_commit=$(git -C "$build_root/source" rev-parse HEAD)
+if [ "$actual_commit" != "$simple_commit" ]; then
+    echo "simple checkout mismatch: expected $simple_commit, got $actual_commit" >&2
+    exit 1
+fi
+
+linker_flags=""
+case "$(uname -s)" in
+    Linux) linker_flags="-static-libstdc++ -static-libgcc" ;;
+    Darwin) ;;
+    # The Windows sidecar is installed as a bare simple.dll, so anything it
+    # links dynamically has to already be on the loading process's PATH.
+    # MinGW would otherwise pull in libstdc++-6, libgcc_s and libwinpthread,
+    # and loading the extension fails on machines without them.
+    MINGW*|MSYS*|CYGWIN*) linker_flags="-static" ;;
+    *) echo "unsupported platform: $(uname -s)" >&2; exit 1 ;;
+esac
+
+cmake -S "$build_root/source" -B "$build_root/build" \
+    -DBUILD_SQLITE3=OFF \
+    -DBUILD_TEST_EXAMPLE=OFF \
+    -DSIMPLE_WITH_JIEBA=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_SHARED_LINKER_FLAGS="$linker_flags"
+cmake --build "$build_root/build" --config Release --parallel
+
+cppjieba_dir="$build_root/build/cppjieba/src/cppjieba"
+actual_cppjieba=$(git -C "$cppjieba_dir" rev-parse HEAD)
+if [ "$actual_cppjieba" != "$cppjieba_commit" ]; then
+    echo "cppjieba checkout mismatch: expected $cppjieba_commit, got $actual_cppjieba" >&2
+    exit 1
+fi
+
+case "$(uname -s)" in
+    Linux)
+        built_library="$build_root/build/src/libsimple.so"
+        installed_library="libsimple.so"
+        ;;
+    Darwin)
+        built_library="$build_root/build/src/libsimple.dylib"
+        installed_library="libsimple.dylib"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        built_library="$build_root/build/src/Release/simple.dll"
+        if [ ! -f "$built_library" ]; then
+            built_library="$build_root/build/src/libsimple.dll"
+        fi
+        installed_library="simple.dll"
+        ;;
+esac
+
+if [ ! -f "$built_library" ]; then
+    echo "built simple library not found at $built_library" >&2
+    exit 1
+fi
+
+rm -rf -- "$output_dir"
+mkdir -p "$output_dir/dict" "$output_dir/licenses"
+install -m 0755 "$built_library" "$output_dir/$installed_library"
+for name in hmm_model.utf8 idf.utf8 jieba.dict.utf8 stop_words.utf8 user.dict.utf8; do
+    install -m 0644 "$cppjieba_dir/dict/$name" "$output_dir/dict/$name"
+done
+install -m 0644 "$build_root/source/LICENSE" "$output_dir/licenses/simple-LICENSE"
+install -m 0644 "$cppjieba_dir/LICENSE" "$output_dir/licenses/cppjieba-LICENSE"
+printf '%s\n' \
+    "simple $simple_commit" \
+    "cppjieba $cppjieba_commit" \
+    > "$output_dir/VERSIONS"
+
+echo "Built $output_dir"


### PR DESCRIPTION
Adds optional Chinese word and single-character search to SQLite through the pinned simple/cppjieba sidecar. HTTP, CLI, and MCP message searches segment CJK queries, preserve explicit quoted expressions, and retain English stemming for ASCII-only queries. PostgreSQL/CockroachDB and DuckDB retain their existing matching behavior and now prepare raw queries at the store boundary to preserve literal embedded quotes.

The parallel Chinese index is derived data. Its first backfill, a changed library or dictionary fingerprint, or pending writes requires a full rebuild before writable startup completes; the session-only freshness ledger cannot repair old token entries individually. Startup waits and stale-index fallback now emit logs. TEMP writer triggers maintain the index without requiring older writers to load the extension.

Removing the sidecar drops the optional index while retaining the small freshness ledger and persistent session triggers; reinstalling rebuilds the index and clears pending rows. Session-result snippets highlight segmented matches, while highlighting inside an opened transcript still uses the original query. Configuration documentation describes these limits, and the sidecar workflow covers database, service, and MCP tests.
