### PR TITLE
test(postgres): add usage performance benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ postgres-up:
 	docker compose -f docker-compose.test.yml up -d --wait
 
 # Run opt-in PostgreSQL usage benchmarks against the pinned PG16 service.
-bench-pg-usage:
+bench-pg-usage: pricing-snapshot
 	docker compose -f docker-compose.test.yml up -d --wait postgres
 	TEST_PG_URL="postgres://agentsview_test:agentsview_test_password@localhost:5433/agentsview_test?sslmode=disable" \
 	CGO_ENABLED=1 go test -tags "fts5,pgtest,kit_posthog_disabled" ./internal/postgres \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
 	elif [ -x "$(GOPATH_FIRST)/bin/air" ]; then printf "%s" "$(GOPATH_FIRST)/bin/air"; \
 	fi)
 
-.PHONY: build build-release install frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy test test-short test-evalingest bench-backends bench-gate bench-gate-config test-postgres test-postgres-ci test-s3 postgres-up postgres-down test-ssh test-ssh-ci ssh-up ssh-down e2e e2e-duckdb vet lint lint-ci lint-golangci lint-golangci-ci nilaway nilaway-golangci-build lint-tools tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir pricing-snapshot sqlite-vec-header dev-snapshot help
+.PHONY: build build-release install frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy test test-short test-evalingest bench-backends bench-gate bench-gate-config bench-pg-usage test-postgres test-postgres-ci test-s3 postgres-up postgres-down test-ssh test-ssh-ci ssh-up ssh-down e2e e2e-duckdb vet lint lint-ci lint-golangci lint-golangci-ci nilaway nilaway-golangci-build lint-tools tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir pricing-snapshot sqlite-vec-header dev-snapshot help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -358,6 +358,13 @@ bench-gate-config:
 postgres-up:
 	docker compose -f docker-compose.test.yml up -d --wait
 
+# Run opt-in PostgreSQL usage benchmarks against the pinned PG16 service.
+bench-pg-usage:
+	docker compose -f docker-compose.test.yml up -d --wait postgres
+	TEST_PG_URL="postgres://agentsview_test:agentsview_test_password@localhost:5433/agentsview_test?sslmode=disable" \
+	CGO_ENABLED=1 go test -tags "fts5,pgtest,kit_posthog_disabled" ./internal/postgres \
+		-run '^$$' -bench 'BenchmarkPGUsage(Read|Refresh)' -benchmem -count=5
+
 # Stop test PostgreSQL container
 postgres-down:
 	docker compose -f docker-compose.test.yml down
@@ -622,6 +629,7 @@ help:
 	@echo "  test           - Run all tests"
 	@echo "  test-short     - Run fast tests only"
 	@echo "  bench-backends - Benchmark SQLite, DuckDB, and PostgreSQL stores"
+	@echo "  bench-pg-usage - Run opt-in PostgreSQL usage benchmarks against PG16"
 	@echo "  bench-gate     - Run the hot-path benchmarks CI gates PRs on"
 	@echo "  test-postgres  - Run PostgreSQL integration tests"
 	@echo "  test-s3        - Run S3 discovery integration tests (Docker)"

--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ postgres-up:
 bench-pg-usage: pricing-snapshot
 	docker compose -f docker-compose.test.yml up -d --wait postgres
 	TEST_PG_URL="postgres://agentsview_test:agentsview_test_password@localhost:5433/agentsview_test?sslmode=disable" \
-	CGO_ENABLED=1 go test -tags "fts5,pgtest,kit_posthog_disabled" ./internal/postgres \
+	CGO_ENABLED=1 go test -tags "fts5,pgtest" ./internal/postgres \
 		-run '^$$' -bench 'BenchmarkPGUsage(Read|Refresh)' -benchmem -count=5
 
 # Stop test PostgreSQL container

--- a/docs/internal/pg-usage-native-optimization.md
+++ b/docs/internal/pg-usage-native-optimization.md
@@ -1,0 +1,23 @@
+# PostgreSQL usage benchmark decision
+
+PostgreSQL usage currently uses the live query methods in
+`internal/postgres/usage.go`. This benchmark-first slice records the evidence
+needed before changing that query shape. It measures the five public usage
+methods, their supported windows and breakdown modes, and the cold push, delta
+push, and catalog maintenance paths against the pinned PostgreSQL 16 compose
+service.
+
+The benchmark reuses the SQLite/PostgreSQL parity fixture, including survivor,
+reported-cost, rounding, timestamp, and activity-only cases. Exact non-empty
+results are asserted before timing. `rows_scanned` and `bytes_token_usage` are
+reported as fixture workload metrics, while `ns/op`, `B/op`, and `allocs/op`
+come from the Go benchmark runner.
+
+This is evidence only. It does not choose a facts table, aggregate, trigger,
+refresh schedule, or materialized view. Go-owned pricing, per-survivor
+microdollar rounding, Cockroach-compatible SQL, SQLite parity, and read-only
+PostgreSQL serving remain the authority. Run the opt-in target with:
+
+```text
+make bench-pg-usage
+```

--- a/docs/internal/pg-usage-native-optimization.md
+++ b/docs/internal/pg-usage-native-optimization.md
@@ -15,6 +15,11 @@ usage-event inputs outside timing, not PostgreSQL execution-plan rows, while
 `bytes_token_usage` measures token-usage bytes from those inputs. `ns/op`,
 `B/op`, and `allocs/op` come from the Go benchmark runner.
 
+The read workload is configured as 48 sessions with four messages per session,
+six projects, four agents, four priced models, and four date buckets. The
+correctness and refresh benchmarks retain the smaller parity fixture so their
+exact push and result assertions stay deterministic.
+
 This is evidence only. It does not choose a facts table, aggregate, trigger,
 refresh schedule, or materialized view. Go-owned pricing, per-survivor
 microdollar rounding, Cockroach-compatible SQL, SQLite parity, and read-only

--- a/docs/internal/pg-usage-native-optimization.md
+++ b/docs/internal/pg-usage-native-optimization.md
@@ -8,10 +8,12 @@ push, and catalog probe paths against the pinned PostgreSQL 16 compose
 service.
 
 The benchmark reuses the SQLite/PostgreSQL parity fixture, including survivor,
-reported-cost, rounding, timestamp, and activity-only cases. Exact non-empty
-results are asserted before timing. `rows_scanned` and `bytes_token_usage` are
-measured from the fixture rows selected by each window, while `ns/op`, `B/op`, and `allocs/op`
-come from the Go benchmark runner.
+reported-cost, rounding, timestamp, and activity-only cases. Each read case
+compares complete SQLite and PostgreSQL results for all five usage methods
+before timing. `eligible_usage_input_rows` counts eligible fixture message and
+usage-event inputs outside timing, not PostgreSQL execution-plan rows, while
+`bytes_token_usage` measures token-usage bytes from those inputs. `ns/op`,
+`B/op`, and `allocs/op` come from the Go benchmark runner.
 
 This is evidence only. It does not choose a facts table, aggregate, trigger,
 refresh schedule, or materialized view. Go-owned pricing, per-survivor

--- a/docs/internal/pg-usage-native-optimization.md
+++ b/docs/internal/pg-usage-native-optimization.md
@@ -4,13 +4,13 @@ PostgreSQL usage currently uses the live query methods in
 `internal/postgres/usage.go`. This benchmark-first slice records the evidence
 needed before changing that query shape. It measures the five public usage
 methods, their supported windows and breakdown modes, and the cold push, delta
-push, and catalog maintenance paths against the pinned PostgreSQL 16 compose
+push, and catalog probe paths against the pinned PostgreSQL 16 compose
 service.
 
 The benchmark reuses the SQLite/PostgreSQL parity fixture, including survivor,
 reported-cost, rounding, timestamp, and activity-only cases. Exact non-empty
 results are asserted before timing. `rows_scanned` and `bytes_token_usage` are
-reported as fixture workload metrics, while `ns/op`, `B/op`, and `allocs/op`
+measured from the fixture rows selected by each window, while `ns/op`, `B/op`, and `allocs/op`
 come from the Go benchmark runner.
 
 This is evidence only. It does not choose a facts table, aggregate, trigger,

--- a/docs/internal/pg-usage-native-optimization.md
+++ b/docs/internal/pg-usage-native-optimization.md
@@ -15,10 +15,13 @@ usage-event inputs outside timing, not PostgreSQL execution-plan rows, while
 `bytes_token_usage` measures token-usage bytes from those inputs. `ns/op`,
 `B/op`, and `allocs/op` come from the Go benchmark runner.
 
-The read workload is configured as 48 sessions with four messages per session,
-six projects, four agents, four priced models, and four date buckets. The
-correctness and refresh benchmarks retain the smaller parity fixture so their
-exact push and result assertions stay deterministic.
+The read workload is configured as 500 sessions with 200 messages per session,
+ten projects, three agents, four priced models, and four date buckets, for
+100,000 bulk messages. The correctness and standard refresh benchmarks retain
+the smaller parity fixture so their exact push and result assertions stay
+deterministic. `BenchmarkPGUsageRefreshLarge` deliberately loads the
+repository-scale corpus to measure cold-load and multi-message delta behavior
+separately.
 
 This is evidence only. It does not choose a facts table, aggregate, trigger,
 refresh schedule, or materialized view. Go-owned pricing, per-survivor

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -10,7 +10,7 @@ auto-push watcher or OS service, then serve a read-only web UI from
 it — useful for team dashboards or multi-machine setups.
 
 The PostgreSQL usage optimization baseline and its architecture boundary are
-recorded in [the usage benchmark decision](/internal/pg-usage-native-optimization/).
+recorded in [the maintainer usage benchmark decision](https://github.com/kenn-io/agentsview/blob/main/docs/internal/pg-usage-native-optimization.md).
 
 The sync direction is one-way: SQLite to PostgreSQL. Each machine
 pushes its own sessions; `pg serve` reads from the shared database.

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -9,6 +9,9 @@ PostgreSQL database, keep that database current with an optional
 auto-push watcher or OS service, then serve a read-only web UI from
 it — useful for team dashboards or multi-machine setups.
 
+The PostgreSQL usage optimization baseline and its architecture boundary are
+recorded in [the usage benchmark decision](/internal/pg-usage-native-optimization/).
+
 The sync direction is one-way: SQLite to PostgreSQL. Each machine
 pushes its own sessions; `pg serve` reads from the shared database.
 The resulting UI includes the session browser, analytics dashboard,

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -10,7 +10,7 @@ auto-push watcher or OS service, then serve a read-only web UI from
 it — useful for team dashboards or multi-machine setups.
 
 The PostgreSQL usage optimization baseline and its architecture boundary are
-recorded in [the maintainer usage benchmark decision](https://github.com/kenn-io/agentsview/blob/main/docs/internal/pg-usage-native-optimization.md).
+recorded in `docs/internal/pg-usage-native-optimization.md`.
 
 The sync direction is one-way: SQLite to PostgreSQL. Each machine
 pushes its own sessions; `pg serve` reads from the shared database.

--- a/internal/postgres/helpers_pgtest_test.go
+++ b/internal/postgres/helpers_pgtest_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func testPGURL(t *testing.T) string {
+func testPGURL(t testing.TB) string {
 	t.Helper()
 	url := os.Getenv("TEST_PG_URL")
 	if url == "" {

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -27,7 +27,7 @@ func cleanPGSchema(t *testing.T, pgURL string) {
 	)
 }
 
-func cleanNamedPGSchema(t *testing.T, pgURL, schema string) {
+func cleanNamedPGSchema(t testing.TB, pgURL, schema string) {
 	t.Helper()
 	pg, err := sql.Open("pgx", pgURL)
 	require.NoError(t, err, "connecting to pg")

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -191,6 +191,11 @@ func validatePGUsageBenchmarkRead(
 	require.NotZero(b, counts.Total)
 	require.NotZero(b, matching)
 	require.NotNil(b, session)
+	if breakdowns {
+		require.NotEmpty(b, session.Breakdown)
+	} else {
+		require.Empty(b, session.Breakdown)
+	}
 }
 
 func measurePGUsageFixture(

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -153,6 +153,9 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 	cleanNamedPGSchema(t, pgURL, schema)
 	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
 	fixture := openPGUsageBenchmarkFixture(t)
+	sessions, messages := pgUsageRemoteCardinality(t, fixture.remote)
+	require.Zero(t, sessions)
+	require.Zero(t, messages)
 	fixture.prime(t)
 	rowsScanned, tokenUsageBytes := measurePGUsageFixture(t, fixture.remote, db.UsageFilter{
 		From: "2026-08-12", To: "2026-08-12", Timezone: "UTC",
@@ -360,7 +363,7 @@ func BenchmarkPGUsageRefresh(b *testing.B) {
 			b.StopTimer()
 			payload := `{"input_tokens":20,"output_tokens":10}`
 			if iterations%2 == 1 {
-				payload = `{"input_tokens":21,"output_tokens":9}`
+				payload = `{"input_tokens":21,"output_tokens":10}`
 			}
 			fixture.replaceDeltaMessage(b, payload)
 			b.StartTimer()

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -21,17 +22,17 @@ import (
 const pgUsageBenchmarkSchemaPrefix = "agentsview_pg_usage_bench"
 
 const (
-	pgUsageBenchmarkBulkSessions           = 48
-	pgUsageBenchmarkBulkMessagesPerSession = 4
+	pgUsageBenchmarkBulkSessions           = 500
+	pgUsageBenchmarkBulkMessagesPerSession = 200
 	pgUsageBenchmarkBulkDateBuckets        = 4
 )
 
 var (
 	pgUsageBenchmarkBulkProjects = []string{
-		"bulk-project-a", "bulk-project-b", "bulk-project-c",
-		"bulk-project-d", "bulk-project-e", "bulk-project-f",
+		"agentsview", "quokka", "arrow-rs", "side-quests", "infrastructure",
+		"blog", "experiments", "docs", "dotfiles", "playground",
 	}
-	pgUsageBenchmarkBulkAgents = []string{"claude", "codex", "cursor", "hermes"}
+	pgUsageBenchmarkBulkAgents = []string{"claude", "codex", "openhands"}
 	pgUsageBenchmarkBulkModels = []string{
 		"model-priced", "model-reported", "model-bulk-cheap", "model-bulk-premium",
 	}
@@ -46,14 +47,14 @@ type pgUsageBenchmarkCase struct {
 
 func pgUsageBenchmarkCases() []pgUsageBenchmarkCase {
 	return []pgUsageBenchmarkCase{
-		{name: "one-day/no-breakdowns", from: "2026-08-12", to: "2026-08-12", expectedEligibleInputRows: 52},
-		{name: "one-day/breakdowns", from: "2026-08-12", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 52},
-		{name: "seven-day/no-breakdowns", from: "2026-08-06", to: "2026-08-12", expectedEligibleInputRows: 100},
-		{name: "seven-day/breakdowns", from: "2026-08-06", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 100},
-		{name: "thirty-day/no-breakdowns", from: "2026-07-14", to: "2026-08-12", expectedEligibleInputRows: 149},
-		{name: "thirty-day/breakdowns", from: "2026-07-14", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 149},
-		{name: "all-history/no-breakdowns", expectedEligibleInputRows: 197},
-		{name: "all-history/breakdowns", breakdowns: true, expectedEligibleInputRows: 197},
+		{name: "one-day/no-breakdowns", from: "2026-08-12", to: "2026-08-12", expectedEligibleInputRows: 25_004},
+		{name: "one-day/breakdowns", from: "2026-08-12", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 25_004},
+		{name: "seven-day/no-breakdowns", from: "2026-08-06", to: "2026-08-12", expectedEligibleInputRows: 50_004},
+		{name: "seven-day/breakdowns", from: "2026-08-06", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 50_004},
+		{name: "thirty-day/no-breakdowns", from: "2026-07-14", to: "2026-08-12", expectedEligibleInputRows: 75_005},
+		{name: "thirty-day/breakdowns", from: "2026-07-14", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 75_005},
+		{name: "all-history/no-breakdowns", expectedEligibleInputRows: 100_005},
+		{name: "all-history/breakdowns", breakdowns: true, expectedEligibleInputRows: 100_005},
 	}
 }
 
@@ -155,6 +156,8 @@ func seedPGUsageBenchmarkBulkFixture(t testing.TB, local *db.DB, count int) {
 		}
 		sessionID := "benchmark-bulk-" + strconv.Itoa(i)
 		startedAt := day + "T09:00:00Z"
+		startTime, err := time.Parse(time.RFC3339, startedAt)
+		require.NoError(t, err)
 		sessions = append(sessions, db.Session{
 			ID: sessionID, Project: pgUsageBenchmarkBulkProjects[i%len(pgUsageBenchmarkBulkProjects)],
 			Machine: "bench-machine", Agent: pgUsageBenchmarkBulkAgents[i%len(pgUsageBenchmarkBulkAgents)],
@@ -162,14 +165,15 @@ func seedPGUsageBenchmarkBulkFixture(t testing.TB, local *db.DB, count int) {
 			UserMessageCount: 2,
 		})
 		for ordinal := 0; ordinal < pgUsageBenchmarkBulkMessagesPerSession; ordinal++ {
-			inputTokens := 10 + (i % 7) + ordinal
-			outputTokens := 5 + (i % 5) + ordinal
+			inputTokens := 1200 + (i % 17) + ordinal
+			outputTokens := 480 + (i % 13) + (ordinal % 11)
 			messages = append(messages, db.Message{
 				SessionID: sessionID, Ordinal: ordinal, Role: "assistant",
-				Timestamp: day + "T09:0" + strconv.Itoa(ordinal+1) + ":00Z",
+				Timestamp: startTime.Add(time.Duration(ordinal) * time.Minute).Format(time.RFC3339),
 				Model:     pgUsageBenchmarkBulkModels[(i+ordinal)%len(pgUsageBenchmarkBulkModels)],
 				TokenUsage: json.RawMessage(`{"input_tokens":` + strconv.Itoa(inputTokens) +
-					`,"output_tokens":` + strconv.Itoa(outputTokens) + `}`),
+					`,"output_tokens":` + strconv.Itoa(outputTokens) +
+					`,"cache_creation_input_tokens":300,"cache_read_input_tokens":2400}`),
 				ClaudeMessageID: "benchmark-bulk-message-" + strconv.Itoa(i) + "-" + strconv.Itoa(ordinal),
 				ClaudeRequestID: "benchmark-bulk-request-" + strconv.Itoa(i) + "-" + strconv.Itoa(ordinal),
 			})
@@ -216,16 +220,26 @@ func (f *pgUsageBenchmarkFixture) requireFixedCardinality(t testing.TB) {
 }
 
 func (f *pgUsageBenchmarkFixture) replaceDeltaMessage(t testing.TB, payload string) {
+	f.replaceDeltaSessionMessage(t, "snapshot-winner", payload, 1)
+}
+
+func (f *pgUsageBenchmarkFixture) replaceDeltaBulkMessage(t testing.TB, payload string) {
+	f.replaceDeltaSessionMessage(t, "benchmark-bulk-0", payload, pgUsageBenchmarkBulkMessagesPerSession)
+}
+
+func (f *pgUsageBenchmarkFixture) replaceDeltaSessionMessage(
+	t testing.TB, sessionID, payload string, expectedCount int,
+) {
 	t.Helper()
 	f.requireFixedCardinality(t)
-	messages, err := f.local.GetMessages(t.Context(), "snapshot-winner", 0, 1, true)
+	messages, err := f.local.GetMessages(t.Context(), sessionID, 0, expectedCount, true)
 	require.NoError(t, err)
-	require.Len(t, messages, 1)
+	require.Len(t, messages, expectedCount)
 	messages[0].TokenUsage = []byte(payload)
-	require.NoError(t, f.local.ReplaceSessionMessages("snapshot-winner", messages))
-	messageCount, err := f.local.MessageCount("snapshot-winner")
+	require.NoError(t, f.local.ReplaceSessionMessages(sessionID, messages))
+	messageCount, err := f.local.MessageCount(sessionID)
 	require.NoError(t, err)
-	require.Equal(t, 1, messageCount)
+	require.Equal(t, expectedCount, messageCount)
 }
 
 func TestPGUsageBenchmarkFixture(t *testing.T) {
@@ -364,16 +378,20 @@ func BenchmarkPGUsageRead(b *testing.B) {
 	fixture := openPGUsageBenchmarkFixture(b)
 	fixture.addBulk(b, pgUsageBenchmarkBulkSessions)
 	fixture.prime(b)
+	loadedSessions, loadedMessages := pgUsageRemoteCardinality(b, fixture.remote)
+	require.Equal(b, 6+pgUsageBenchmarkBulkSessions, loadedSessions)
+	require.Equal(b, 5+pgUsageBenchmarkBulkSessions*pgUsageBenchmarkBulkMessagesPerSession, loadedMessages)
 	ctx := context.Background()
 	for _, tc := range pgUsageBenchmarkCases() {
 		b.Run(tc.name, func(b *testing.B) {
 			filter := pgUsageBenchmarkFilter(tc)
-			b.Logf("fixture_scale=bulk_sessions=%d bulk_messages=%d messages_per_session=%d projects=%d agents=%d models=%d dates=%d",
+			b.Logf("fixture_scale=bulk_sessions=%d bulk_messages=%d messages_per_session=%d projects=%d agents=%d models=%d dates=%d loaded_table_rows=sessions:%d messages:%d",
 				pgUsageBenchmarkBulkSessions,
 				pgUsageBenchmarkBulkSessions*pgUsageBenchmarkBulkMessagesPerSession,
 				pgUsageBenchmarkBulkMessagesPerSession,
 				len(pgUsageBenchmarkBulkProjects), len(pgUsageBenchmarkBulkAgents),
-				len(pgUsageBenchmarkBulkModels), pgUsageBenchmarkBulkDateBuckets)
+				len(pgUsageBenchmarkBulkModels), pgUsageBenchmarkBulkDateBuckets,
+				loadedSessions, loadedMessages)
 			eligibleUsageInputRows, tokenUsageBytes := measurePGUsageFixture(b, fixture.remote, filter)
 			require.Equal(b, tc.expectedEligibleInputRows, eligibleUsageInputRows)
 			requireCompleteUsageParity(b, fixture.local, fixture.remote, filter)
@@ -396,7 +414,7 @@ func BenchmarkPGUsageRead(b *testing.B) {
 					b.Fatal(err)
 				}
 				session, err := fixture.remote.GetSessionUsage(
-					ctx, "snapshot-winner", tc.breakdowns)
+					ctx, "benchmark-bulk-0", tc.breakdowns)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -557,5 +575,73 @@ func BenchmarkPGUsageRefresh(b *testing.B) {
 		}
 		require.NotZero(b, tables)
 		b.ReportMetric(float64(tables), "catalog_rows")
+	})
+}
+
+func BenchmarkPGUsageRefreshLarge(b *testing.B) {
+	ctx := context.Background()
+	b.Run("ColdPush", func(b *testing.B) {
+		fixture := openPGUsageBenchmarkFixture(b)
+		fixture.addBulk(b, pgUsageBenchmarkBulkSessions)
+		b.Logf("fixture_scale=bulk_sessions=%d bulk_messages=%d messages_per_session=%d configured_table_rows=sessions:%d messages:%d",
+			pgUsageBenchmarkBulkSessions,
+			pgUsageBenchmarkBulkSessions*pgUsageBenchmarkBulkMessagesPerSession,
+			pgUsageBenchmarkBulkMessagesPerSession,
+			fixture.expectedSessions,
+			fixture.expectedMessages)
+		for b.Loop() {
+			b.StopTimer()
+			fixture.resetRemoteEmpty(b)
+			b.StartTimer()
+			result, err := fixture.sync.Push(ctx, true, nil)
+			b.StopTimer()
+			require.NoError(b, err)
+			require.Equal(b, fixture.expectedSessions, result.SessionsPushed)
+			require.Equal(b, fixture.expectedMessages, result.MessagesPushed)
+			sessions, messages := pgUsageRemoteCardinality(b, fixture.remote)
+			require.Equal(b, fixture.expectedSessions, sessions)
+			require.Equal(b, fixture.expectedMessages, messages)
+			b.Logf("loaded_table_rows=sessions:%d messages:%d", sessions, messages)
+			requireCompleteUsageParity(b, fixture.local, fixture.remote,
+				pgUsageBenchmarkValidationFilter())
+			b.StartTimer()
+		}
+		b.ReportMetric(float64(fixture.expectedSessions), "sessions_pushed")
+		b.ReportMetric(float64(fixture.expectedMessages), "messages_pushed")
+	})
+
+	b.Run("DeltaPush", func(b *testing.B) {
+		fixture := openPGUsageBenchmarkFixture(b)
+		fixture.addBulk(b, pgUsageBenchmarkBulkSessions)
+		fixture.prime(b)
+		loadedSessions, loadedMessages := pgUsageRemoteCardinality(b, fixture.remote)
+		b.Logf("fixture_scale=bulk_sessions=%d bulk_messages=%d messages_per_session=%d loaded_table_rows=sessions:%d messages:%d",
+			pgUsageBenchmarkBulkSessions,
+			pgUsageBenchmarkBulkSessions*pgUsageBenchmarkBulkMessagesPerSession,
+			pgUsageBenchmarkBulkMessagesPerSession,
+			loadedSessions,
+			loadedMessages)
+		iterations := 0
+		for b.Loop() {
+			b.StopTimer()
+			payload := `{"input_tokens":2000,"output_tokens":800}`
+			if iterations%2 == 1 {
+				payload = `{"input_tokens":2001,"output_tokens":801}`
+			}
+			fixture.replaceDeltaBulkMessage(b, payload)
+			b.StartTimer()
+			result, err := fixture.sync.Push(ctx, false, nil)
+			b.StopTimer()
+			require.NoError(b, err)
+			require.Equal(b, 1, result.SessionsPushed)
+			require.Equal(b, pgUsageBenchmarkBulkMessagesPerSession, result.MessagesPushed)
+			fixture.requireFixedCardinality(b)
+			requireCompleteUsageParity(b, fixture.local, fixture.remote,
+				pgUsageBenchmarkValidationFilter())
+			iterations++
+			b.StartTimer()
+		}
+		b.ReportMetric(1, "sessions_pushed")
+		b.ReportMetric(pgUsageBenchmarkBulkMessagesPerSession, "messages_pushed")
 	})
 }

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -15,11 +15,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/money"
 )
 
 const pgUsageBenchmarkSchemaPrefix = "agentsview_pg_usage_bench"
 
-const pgUsageBenchmarkBulkRows = 24
+const (
+	pgUsageBenchmarkBulkSessions           = 48
+	pgUsageBenchmarkBulkMessagesPerSession = 4
+	pgUsageBenchmarkBulkDateBuckets        = 4
+)
+
+var (
+	pgUsageBenchmarkBulkProjects = []string{
+		"bulk-project-a", "bulk-project-b", "bulk-project-c",
+		"bulk-project-d", "bulk-project-e", "bulk-project-f",
+	}
+	pgUsageBenchmarkBulkAgents = []string{"claude", "codex", "cursor", "hermes"}
+	pgUsageBenchmarkBulkModels = []string{
+		"model-priced", "model-reported", "model-bulk-cheap", "model-bulk-premium",
+	}
+)
 
 type pgUsageBenchmarkCase struct {
 	name                      string
@@ -30,14 +46,14 @@ type pgUsageBenchmarkCase struct {
 
 func pgUsageBenchmarkCases() []pgUsageBenchmarkCase {
 	return []pgUsageBenchmarkCase{
-		{name: "one-day/no-breakdowns", from: "2026-08-12", to: "2026-08-12", expectedEligibleInputRows: 8},
-		{name: "one-day/breakdowns", from: "2026-08-12", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 8},
-		{name: "seven-day/no-breakdowns", from: "2026-08-06", to: "2026-08-12", expectedEligibleInputRows: 16},
-		{name: "seven-day/breakdowns", from: "2026-08-06", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 16},
-		{name: "thirty-day/no-breakdowns", from: "2026-07-14", to: "2026-08-12", expectedEligibleInputRows: 17},
-		{name: "thirty-day/breakdowns", from: "2026-07-14", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 17},
-		{name: "all-history/no-breakdowns", expectedEligibleInputRows: 29},
-		{name: "all-history/breakdowns", breakdowns: true, expectedEligibleInputRows: 29},
+		{name: "one-day/no-breakdowns", from: "2026-08-12", to: "2026-08-12", expectedEligibleInputRows: 52},
+		{name: "one-day/breakdowns", from: "2026-08-12", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 52},
+		{name: "seven-day/no-breakdowns", from: "2026-08-06", to: "2026-08-12", expectedEligibleInputRows: 100},
+		{name: "seven-day/breakdowns", from: "2026-08-06", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 100},
+		{name: "thirty-day/no-breakdowns", from: "2026-07-14", to: "2026-08-12", expectedEligibleInputRows: 149},
+		{name: "thirty-day/breakdowns", from: "2026-07-14", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 149},
+		{name: "all-history/no-breakdowns", expectedEligibleInputRows: 197},
+		{name: "all-history/breakdowns", breakdowns: true, expectedEligibleInputRows: 197},
 	}
 }
 
@@ -117,35 +133,52 @@ func (f *pgUsageBenchmarkFixture) addBulk(t testing.TB, count int) {
 	t.Helper()
 	seedPGUsageBenchmarkBulkFixture(t, f.local, count)
 	f.expectedSessions += count
-	f.expectedMessages += count
+	f.expectedMessages += count * pgUsageBenchmarkBulkMessagesPerSession
 }
 
 func seedPGUsageBenchmarkBulkFixture(t testing.TB, local *db.DB, count int) {
 	t.Helper()
+	require.Greater(t, count, 0)
+	require.Zero(t, count%pgUsageBenchmarkBulkDateBuckets, "bulk sessions must divide evenly across date buckets")
+	sessionsPerDate := count / pgUsageBenchmarkBulkDateBuckets
 	sessions := make([]db.Session, 0, count)
-	messages := make([]db.Message, 0, count)
+	messages := make([]db.Message, 0, count*pgUsageBenchmarkBulkMessagesPerSession)
 	for i := 0; i < count; i++ {
 		day := "2026-06-20"
-		if i < 4 {
+		switch i / sessionsPerDate {
+		case 0:
 			day = "2026-08-12"
-		} else if i < 12 {
+		case 1:
 			day = "2026-08-08"
+		case 2:
+			day = "2026-07-20"
 		}
 		sessionID := "benchmark-bulk-" + strconv.Itoa(i)
 		startedAt := day + "T09:00:00Z"
 		sessions = append(sessions, db.Session{
-			ID: sessionID, Project: "bulk-project", Machine: "bench-machine",
-			Agent: "bulk", StartedAt: &startedAt, MessageCount: 1,
-			UserMessageCount: 1,
+			ID: sessionID, Project: pgUsageBenchmarkBulkProjects[i%len(pgUsageBenchmarkBulkProjects)],
+			Machine: "bench-machine", Agent: pgUsageBenchmarkBulkAgents[i%len(pgUsageBenchmarkBulkAgents)],
+			StartedAt: &startedAt, MessageCount: pgUsageBenchmarkBulkMessagesPerSession,
+			UserMessageCount: 2,
 		})
-		messages = append(messages, db.Message{
-			SessionID: sessionID, Ordinal: 0, Role: "assistant",
-			Timestamp: day + "T09:01:00Z", Model: "model-priced",
-			TokenUsage:      json.RawMessage(`{"input_tokens":1,"output_tokens":0}`),
-			ClaudeMessageID: "benchmark-bulk-message-" + strconv.Itoa(i),
-			ClaudeRequestID: "benchmark-bulk-request-" + strconv.Itoa(i),
-		})
+		for ordinal := 0; ordinal < pgUsageBenchmarkBulkMessagesPerSession; ordinal++ {
+			inputTokens := 10 + (i % 7) + ordinal
+			outputTokens := 5 + (i % 5) + ordinal
+			messages = append(messages, db.Message{
+				SessionID: sessionID, Ordinal: ordinal, Role: "assistant",
+				Timestamp: day + "T09:0" + strconv.Itoa(ordinal+1) + ":00Z",
+				Model:     pgUsageBenchmarkBulkModels[(i+ordinal)%len(pgUsageBenchmarkBulkModels)],
+				TokenUsage: json.RawMessage(`{"input_tokens":` + strconv.Itoa(inputTokens) +
+					`,"output_tokens":` + strconv.Itoa(outputTokens) + `}`),
+				ClaudeMessageID: "benchmark-bulk-message-" + strconv.Itoa(i) + "-" + strconv.Itoa(ordinal),
+				ClaudeRequestID: "benchmark-bulk-request-" + strconv.Itoa(i) + "-" + strconv.Itoa(ordinal),
+			})
+		}
 	}
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{
+		{ModelPattern: "model-bulk-cheap", InputPerMTok: money.Money{Microdollars: 500_000}, OutputPerMTok: money.Money{Microdollars: 1_000_000}},
+		{ModelPattern: "model-bulk-premium", InputPerMTok: money.Money{Microdollars: 2_000_000}, OutputPerMTok: money.Money{Microdollars: 3_000_000}},
+	}))
 	for i := range sessions {
 		require.NoError(t, local.UpsertSession(sessions[i]))
 	}
@@ -329,12 +362,18 @@ func (s *pgUsageMethodRecorder) GetSessionUsage(
 
 func BenchmarkPGUsageRead(b *testing.B) {
 	fixture := openPGUsageBenchmarkFixture(b)
-	fixture.addBulk(b, pgUsageBenchmarkBulkRows)
+	fixture.addBulk(b, pgUsageBenchmarkBulkSessions)
 	fixture.prime(b)
 	ctx := context.Background()
 	for _, tc := range pgUsageBenchmarkCases() {
 		b.Run(tc.name, func(b *testing.B) {
 			filter := pgUsageBenchmarkFilter(tc)
+			b.Logf("fixture_scale=bulk_sessions=%d bulk_messages=%d messages_per_session=%d projects=%d agents=%d models=%d dates=%d",
+				pgUsageBenchmarkBulkSessions,
+				pgUsageBenchmarkBulkSessions*pgUsageBenchmarkBulkMessagesPerSession,
+				pgUsageBenchmarkBulkMessagesPerSession,
+				len(pgUsageBenchmarkBulkProjects), len(pgUsageBenchmarkBulkAgents),
+				len(pgUsageBenchmarkBulkModels), pgUsageBenchmarkBulkDateBuckets)
 			eligibleUsageInputRows, tokenUsageBytes := measurePGUsageFixture(b, fixture.remote, filter)
 			require.Equal(b, tc.expectedEligibleInputRows, eligibleUsageInputRows)
 			requireCompleteUsageParity(b, fixture.local, fixture.remote, filter)

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -95,7 +95,7 @@ func openPGUsageBenchmarkFixture(t testing.TB) *pgUsageBenchmarkFixture {
 
 	var version string
 	req.NoError(remote.DB().QueryRowContext(t.Context(), "SHOW server_version").Scan(&version))
-	t.Logf("pg_version=%s fixture_sessions=%d fixture_messages=%d fixture_usage_events=%d", version, 5, 4, 1)
+	t.Logf("pg_version=%s fixture_sessions=%d fixture_messages=%d fixture_usage_events=%d", version, 6, 5, 1)
 	return &pgUsageBenchmarkFixture{
 		pgURL: pgURL, schema: schema,
 		local: local, remote: remote, sync: syncer,
@@ -106,11 +106,11 @@ func (f *pgUsageBenchmarkFixture) prime(t testing.TB) {
 	t.Helper()
 	result, err := f.sync.Push(t.Context(), true, nil)
 	require.NoError(t, err)
-	require.Equal(t, 5, result.SessionsPushed)
-	require.Equal(t, 4, result.MessagesPushed)
+	require.Equal(t, 6, result.SessionsPushed)
+	require.Equal(t, 5, result.MessagesPushed)
 	sessions, messages := pgUsageRemoteCardinality(t, f.remote)
-	require.Equal(t, 5, sessions)
-	require.Equal(t, 4, messages)
+	require.Equal(t, 6, sessions)
+	require.Equal(t, 5, messages)
 }
 
 func (f *pgUsageBenchmarkFixture) resetRemoteEmpty(t testing.TB) {
@@ -128,8 +128,8 @@ func (f *pgUsageBenchmarkFixture) requireFixedCardinality(t testing.TB) {
 	require.NoError(t, err)
 	require.Equal(t, 1, messageCount)
 	sessions, messages := pgUsageRemoteCardinality(t, f.remote)
-	require.Equal(t, 5, sessions)
-	require.Equal(t, 4, messages)
+	require.Equal(t, 6, sessions)
+	require.Equal(t, 5, messages)
 }
 
 func (f *pgUsageBenchmarkFixture) replaceDeltaMessage(t testing.TB, payload string) {
@@ -179,6 +179,30 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 			} else {
 				require.Zero(t, len(usage.Breakdown))
 			}
+		})
+	}
+}
+
+func TestPGUsageBenchmarkActivityOnlySessionCoverage(t *testing.T) {
+	fixture := openPGUsageBenchmarkFixture(t)
+	fixture.prime(t)
+	filter := db.UsageFilter{Timezone: "UTC"}
+	for _, backend := range []struct {
+		name  string
+		store db.Store
+	}{
+		{name: "sqlite", store: fixture.local},
+		{name: "postgres", store: fixture.remote},
+	} {
+		t.Run(backend.name, func(t *testing.T) {
+			counts, err := backend.store.GetUsageSessionCounts(t.Context(), filter)
+			require.NoError(t, err)
+			matching, err := backend.store.GetUsageMatchingSessionCount(t.Context(), filter)
+			require.NoError(t, err)
+			require.NotContains(t, counts.ByProject, "project-e")
+			require.Equal(t, 4, counts.Total)
+			require.Equal(t, 6, matching,
+				"tokenless activity-only session matches without normal usage rows")
 		})
 	}
 }
@@ -376,21 +400,21 @@ func BenchmarkPGUsageRefresh(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			require.Equal(b, 5, result.SessionsPushed)
-			require.Equal(b, 4, result.MessagesPushed)
+			require.Equal(b, 6, result.SessionsPushed)
+			require.Equal(b, 5, result.MessagesPushed)
 			sessions, messages := pgUsageRemoteCardinality(b, fixture.remote)
-			require.Equal(b, 5, sessions)
-			require.Equal(b, 4, messages)
+			require.Equal(b, 6, sessions)
+			require.Equal(b, 5, messages)
 			sessionsPushed += result.SessionsPushed
 			messagesPushed += result.MessagesPushed
 			iterations++
 			b.StartTimer()
 		}
 		b.StopTimer()
-		require.Equal(b, 5*iterations, sessionsPushed)
-		require.Equal(b, 4*iterations, messagesPushed)
-		b.ReportMetric(5, "sessions_pushed")
-		b.ReportMetric(4, "messages_pushed")
+		require.Equal(b, 6*iterations, sessionsPushed)
+		require.Equal(b, 5*iterations, messagesPushed)
+		b.ReportMetric(6, "sessions_pushed")
+		b.ReportMetric(5, "messages_pushed")
 	})
 	b.Run("DeltaPush", func(b *testing.B) {
 		fixture := openPGUsageBenchmarkFixture(b)

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -151,10 +151,10 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 	require.Zero(t, sessions)
 	require.Zero(t, messages)
 	fixture.prime(t)
-	rowsScanned, tokenUsageBytes := measurePGUsageFixture(t, fixture.remote, db.UsageFilter{
+	eligibleUsageInputRows, tokenUsageBytes := measurePGUsageFixture(t, fixture.remote, db.UsageFilter{
 		From: "2026-08-12", To: "2026-08-12", Timezone: "UTC",
 	})
-	require.Equal(t, 4, rowsScanned,
+	require.Equal(t, 4, eligibleUsageInputRows,
 		"daily usage metrics include the blank-timestamp message via session start")
 	require.Equal(t, int64(len(`{"input_tokens":10,"output_tokens":5}`))+
 		int64(len(`{"input_tokens":20,"output_tokens":10,"server_tool_use":{"web_search_requests":1}}`))+
@@ -183,6 +183,76 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 	}
 }
 
+type pgUsageCountsOverride struct {
+	db.Store
+	counts db.UsageSessionCounts
+}
+
+func (s pgUsageCountsOverride) GetUsageSessionCounts(
+	context.Context, db.UsageFilter,
+) (db.UsageSessionCounts, error) {
+	return s.counts, nil
+}
+
+func TestPGUsageBenchmarkReadPreflightRejectsMismatchedCompleteResult(t *testing.T) {
+	fixture := openPGUsageBenchmarkFixture(t)
+	fixture.prime(t)
+	filter := pgUsageBenchmarkFilter(pgUsageBenchmarkCases()[0])
+	counts, err := fixture.remote.GetUsageSessionCounts(t.Context(), filter)
+	require.NoError(t, err)
+	counts.Total++
+	remote := pgUsageCountsOverride{Store: fixture.remote, counts: counts}
+	require.Error(t, completeUsageParity(t.Context(), fixture.local, remote, filter),
+		"complete preflight must reject a non-empty PostgreSQL count mismatch")
+
+	recorded := &pgUsageMethodRecorder{Store: fixture.remote}
+	requireCompleteUsageParity(t, fixture.local, recorded, filter)
+	require.ElementsMatch(t, []string{
+		"GetDailyUsage", "GetTopSessionsByCost", "GetUsageSessionCounts",
+		"GetUsageMatchingSessionCount", "GetSessionUsage",
+	}, recorded.calls)
+}
+
+type pgUsageMethodRecorder struct {
+	db.Store
+	calls []string
+}
+
+func (s *pgUsageMethodRecorder) GetDailyUsage(
+	ctx context.Context, filter db.UsageFilter,
+) (db.DailyUsageResult, error) {
+	s.calls = append(s.calls, "GetDailyUsage")
+	return s.Store.GetDailyUsage(ctx, filter)
+}
+
+func (s *pgUsageMethodRecorder) GetTopSessionsByCost(
+	ctx context.Context, filter db.UsageFilter, limit int,
+) ([]db.TopSessionEntry, error) {
+	s.calls = append(s.calls, "GetTopSessionsByCost")
+	return s.Store.GetTopSessionsByCost(ctx, filter, limit)
+}
+
+func (s *pgUsageMethodRecorder) GetUsageSessionCounts(
+	ctx context.Context, filter db.UsageFilter,
+) (db.UsageSessionCounts, error) {
+	s.calls = append(s.calls, "GetUsageSessionCounts")
+	return s.Store.GetUsageSessionCounts(ctx, filter)
+}
+
+func (s *pgUsageMethodRecorder) GetUsageMatchingSessionCount(
+	ctx context.Context, filter db.UsageFilter,
+) (int, error) {
+	s.calls = append(s.calls, "GetUsageMatchingSessionCount")
+	return s.Store.GetUsageMatchingSessionCount(ctx, filter)
+}
+
+func (s *pgUsageMethodRecorder) GetSessionUsage(
+	ctx context.Context, sessionID string, includeBreakdown bool,
+) (*db.SessionUsage, error) {
+	s.calls = append(s.calls, "GetSessionUsage")
+	return s.Store.GetSessionUsage(ctx, sessionID, includeBreakdown)
+}
+
 func BenchmarkPGUsageRead(b *testing.B) {
 	fixture := openPGUsageBenchmarkFixture(b)
 	fixture.prime(b)
@@ -190,8 +260,8 @@ func BenchmarkPGUsageRead(b *testing.B) {
 	for _, tc := range pgUsageBenchmarkCases() {
 		b.Run(tc.name, func(b *testing.B) {
 			filter := pgUsageBenchmarkFilter(tc)
-			rowsScanned, tokenUsageBytes := measurePGUsageFixture(b, fixture.remote, filter)
-			validatePGUsageBenchmarkRead(b, fixture.remote, ctx, filter, tc.breakdowns)
+			eligibleUsageInputRows, tokenUsageBytes := measurePGUsageFixture(b, fixture.remote, filter)
+			requireCompleteUsageParity(b, fixture.local, fixture.remote, filter)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				daily, err := fixture.remote.GetDailyUsage(ctx, filter)
@@ -219,36 +289,9 @@ func BenchmarkPGUsageRead(b *testing.B) {
 					b.Fatal("usage benchmark returned an empty result")
 				}
 			}
-			b.ReportMetric(float64(rowsScanned), "rows_scanned")
+			b.ReportMetric(float64(eligibleUsageInputRows), "eligible_usage_input_rows")
 			b.ReportMetric(float64(tokenUsageBytes), "bytes_token_usage")
 		})
-	}
-}
-
-func validatePGUsageBenchmarkRead(
-	b *testing.B, store *Store, ctx context.Context, filter db.UsageFilter,
-	breakdowns bool,
-) {
-	b.Helper()
-	daily, err := store.GetDailyUsage(ctx, filter)
-	require.NoError(b, err)
-	top, err := store.GetTopSessionsByCost(ctx, filter, 10)
-	require.NoError(b, err)
-	counts, err := store.GetUsageSessionCounts(ctx, filter)
-	require.NoError(b, err)
-	matching, err := store.GetUsageMatchingSessionCount(ctx, filter)
-	require.NoError(b, err)
-	session, err := store.GetSessionUsage(ctx, "snapshot-winner", breakdowns)
-	require.NoError(b, err)
-	require.NotEmpty(b, daily.Daily)
-	require.NotEmpty(b, top)
-	require.NotZero(b, counts.Total)
-	require.NotZero(b, matching)
-	require.NotNil(b, session)
-	if breakdowns {
-		require.NotEmpty(b, session.Breakdown)
-	} else {
-		require.Empty(b, session.Breakdown)
 	}
 }
 
@@ -256,6 +299,7 @@ func measurePGUsageFixture(
 	t testing.TB, store *Store, filter db.UsageFilter,
 ) (int, int64) {
 	t.Helper()
+	// This counts eligible fixture inputs outside timing, not PostgreSQL execution-plan rows.
 	ctx := t.Context()
 	messageWhere, args := pgUsageBenchmarkWindow(
 		"COALESCE(m.timestamp, s.started_at)", filter)

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -1,0 +1,173 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+const pgUsageBenchmarkSchema = "agentsview_pg_usage_bench"
+
+type pgUsageBenchmarkFixture struct {
+	local  *db.DB
+	remote *Store
+	sync   *Sync
+	filter db.UsageFilter
+}
+
+func openPGUsageBenchmarkFixture(b *testing.B) *pgUsageBenchmarkFixture {
+	b.Helper()
+	req := require.New(b)
+	pgURL := testPGURL(b)
+	admin, err := sql.Open("pgx", pgURL)
+	req.NoError(err)
+	_, err = admin.Exec("DROP SCHEMA IF EXISTS " + pgUsageBenchmarkSchema + " CASCADE")
+	req.NoError(err)
+	req.NoError(admin.Close())
+
+	local, err := db.Open(b.TempDir() + "/usage-bench.db")
+	req.NoError(err)
+	seedUsageParityFixture(b, local)
+	syncer, err := New(pgURL, pgUsageBenchmarkSchema, local, "bench-machine", true, SyncOptions{})
+	req.NoError(err)
+	_, err = syncer.Push(b.Context(), true, nil)
+	req.NoError(err)
+	remote, err := NewStore(pgURL, pgUsageBenchmarkSchema, true)
+	req.NoError(err)
+	b.Cleanup(func() {
+		_ = remote.Close()
+		_ = syncer.Close()
+		_ = local.Close()
+		admin, _ := sql.Open("pgx", pgURL)
+		_, _ = admin.Exec("DROP SCHEMA IF EXISTS " + pgUsageBenchmarkSchema + " CASCADE")
+		_ = admin.Close()
+	})
+
+	var version string
+	req.NoError(remote.DB().QueryRowContext(b.Context(), "SHOW server_version").Scan(&version))
+	b.Logf("pg_version=%s fixture_sessions=%d fixture_messages=%d fixture_usage_events=%d", version, 5, 4, 1)
+	return &pgUsageBenchmarkFixture{
+		local: local, remote: remote, sync: syncer,
+		filter: db.UsageFilter{From: "2026-08-12", To: "2026-08-12", Timezone: "UTC"},
+	}
+}
+
+func TestPGUsageBenchmarkFixture(t *testing.T) {
+	pgURL := testPGURL(t)
+	const schema = "agentsview_usage_benchmark_fixture_test"
+	cleanNamedPGSchema(t, pgURL, schema)
+	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
+	local := testDB(t)
+	seedUsageParityFixture(t, local)
+	syncer, err := New(pgURL, schema, local, "bench-fixture-machine", true, SyncOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, syncer.Close()) })
+	_, err = syncer.Push(t.Context(), true, nil)
+	require.NoError(t, err)
+	remote, err := NewStore(pgURL, schema, true)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, remote.Close()) })
+
+	for _, tc := range []struct {
+		name       string
+		from, to   string
+		breakdowns bool
+	}{
+		{name: "one-day", from: "2026-08-12", to: "2026-08-12"},
+		{name: "seven-day", from: "2026-08-06", to: "2026-08-12"},
+		{name: "thirty-day", from: "2026-07-14", to: "2026-08-12", breakdowns: true},
+		{name: "all-history", breakdowns: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := db.UsageFilter{From: tc.from, To: tc.to, Timezone: "UTC", Breakdowns: tc.breakdowns}
+			localResult := captureUsageParitySnapshot(t, local, filter)
+			remoteResult := captureUsageParitySnapshot(t, remote, filter)
+			require.NotEmpty(t, remoteResult.Top)
+			require.NotEmpty(t, remoteResult.Daily.Dates)
+			require.Equal(t, localResult, remoteResult)
+			require.NotZero(t, remoteResult.Counts.Total)
+			require.NotZero(t, remoteResult.MatchingSessionCount)
+		})
+	}
+}
+
+func BenchmarkPGUsageRead(b *testing.B) {
+	fixture := openPGUsageBenchmarkFixture(b)
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name       string
+		from, to   string
+		breakdowns bool
+	}{
+		{name: "one-day", from: "2026-08-12", to: "2026-08-12"},
+		{name: "seven-day", from: "2026-08-06", to: "2026-08-12"},
+		{name: "thirty-day", from: "2026-07-14", to: "2026-08-12", breakdowns: true},
+		{name: "all-history", breakdowns: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			filter := db.UsageFilter{From: tc.from, To: tc.to, Timezone: "UTC", Breakdowns: tc.breakdowns}
+			b.ReportMetric(5, "rows_scanned")
+			b.ReportMetric(178, "bytes_token_usage")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				daily, err := fixture.remote.GetDailyUsage(ctx, filter)
+				require.NoError(b, err)
+				top, err := fixture.remote.GetTopSessionsByCost(ctx, filter, 10)
+				require.NoError(b, err)
+				counts, err := fixture.remote.GetUsageSessionCounts(ctx, filter)
+				require.NoError(b, err)
+				matching, err := fixture.remote.GetUsageMatchingSessionCount(ctx, filter)
+				require.NoError(b, err)
+				session, err := fixture.remote.GetSessionUsage(ctx, "snapshot-winner", true)
+				require.NoError(b, err)
+				require.NotEmpty(b, daily.Daily)
+				require.NotEmpty(b, top)
+				require.NotZero(b, counts.Total)
+				require.NotZero(b, matching)
+				require.NotNil(b, session)
+			}
+		})
+	}
+}
+
+func BenchmarkPGUsageRefresh(b *testing.B) {
+	fixture := openPGUsageBenchmarkFixture(b)
+	ctx := context.Background()
+	b.Run("ColdPush", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result, err := fixture.sync.Push(ctx, true, nil)
+			require.NoError(b, err)
+			require.NotZero(b, result.SessionsPushed)
+			b.ReportMetric(float64(result.SessionsPushed), "sessions_pushed")
+			b.ReportMetric(float64(result.MessagesPushed), "messages_pushed")
+		}
+	})
+	b.Run("DeltaPush", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			session := usageParitySessionFixture("snapshot-winner", "project-b", "claude", "2026-08-12T10:01:00Z", 10+i+1, 20)
+			require.NoError(b, fixture.local.UpsertSession(session))
+			result, err := fixture.sync.Push(ctx, false, nil)
+			require.NoError(b, err)
+			b.ReportMetric(float64(result.SessionsPushed), "sessions_pushed")
+			b.ReportMetric(float64(result.MessagesPushed), "messages_pushed")
+		}
+	})
+	b.Run("CatalogProbe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var tables int
+			err := fixture.remote.DB().QueryRowContext(ctx, `
+				SELECT count(*) FROM pg_catalog.pg_class c
+				JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+				WHERE n.nspname = $1 AND c.relkind IN ('r', 'i')`, pgUsageBenchmarkSchema).Scan(&tables)
+			require.NoError(b, err)
+			require.NotZero(b, tables)
+			b.ReportMetric(float64(tables), "catalog_rows")
+		}
+	})
+}

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -98,6 +98,15 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 	remote, err := NewStore(pgURL, schema, true)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, remote.Close()) })
+	rowsScanned, tokenUsageBytes := measurePGUsageFixture(t, remote, db.UsageFilter{
+		From: "2026-08-12", To: "2026-08-12", Timezone: "UTC",
+	})
+	require.Equal(t, 4, rowsScanned,
+		"daily usage metrics include the blank-timestamp message via session start")
+	require.Equal(t, int64(len(`{"input_tokens":10,"output_tokens":5}`))+
+		int64(len(`{"input_tokens":20,"output_tokens":10,"server_tool_use":{"web_search_requests":1}}`))+
+		int64(len(`{"input_tokens":7,"output_tokens":3}`)), tokenUsageBytes,
+		"token bytes cover every token-eligible daily message")
 
 	for _, tc := range pgUsageBenchmarkCases() {
 		t.Run(tc.name, func(t *testing.T) {
@@ -109,6 +118,14 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 			require.Equal(t, localResult, remoteResult)
 			require.NotZero(t, remoteResult.Counts.Total)
 			require.NotZero(t, remoteResult.MatchingSessionCount)
+			usage, err := remote.GetSessionUsage(
+				t.Context(), "snapshot-winner", tc.breakdowns)
+			require.NoError(t, err)
+			if tc.breakdowns {
+				require.NotZero(t, usage.BreakdownCount)
+			} else {
+				require.Zero(t, usage.BreakdownCount)
+			}
 		})
 	}
 }
@@ -120,7 +137,7 @@ func BenchmarkPGUsageRead(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			filter := pgUsageBenchmarkFilter(tc)
 			rowsScanned, tokenUsageBytes := measurePGUsageFixture(b, fixture.remote, filter)
-			validatePGUsageBenchmarkRead(b, fixture.remote, ctx, filter)
+			validatePGUsageBenchmarkRead(b, fixture.remote, ctx, filter, tc.breakdowns)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				daily, err := fixture.remote.GetDailyUsage(ctx, filter)
@@ -139,7 +156,8 @@ func BenchmarkPGUsageRead(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				session, err := fixture.remote.GetSessionUsage(ctx, "snapshot-winner", true)
+				session, err := fixture.remote.GetSessionUsage(
+					ctx, "snapshot-winner", tc.breakdowns)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -153,7 +171,10 @@ func BenchmarkPGUsageRead(b *testing.B) {
 	}
 }
 
-func validatePGUsageBenchmarkRead(b *testing.B, store *Store, ctx context.Context, filter db.UsageFilter) {
+func validatePGUsageBenchmarkRead(
+	b *testing.B, store *Store, ctx context.Context, filter db.UsageFilter,
+	breakdowns bool,
+) {
 	b.Helper()
 	daily, err := store.GetDailyUsage(ctx, filter)
 	require.NoError(b, err)
@@ -163,7 +184,7 @@ func validatePGUsageBenchmarkRead(b *testing.B, store *Store, ctx context.Contex
 	require.NoError(b, err)
 	matching, err := store.GetUsageMatchingSessionCount(ctx, filter)
 	require.NoError(b, err)
-	session, err := store.GetSessionUsage(ctx, "snapshot-winner", true)
+	session, err := store.GetSessionUsage(ctx, "snapshot-winner", breakdowns)
 	require.NoError(b, err)
 	require.NotEmpty(b, daily.Daily)
 	require.NotEmpty(b, top)
@@ -172,24 +193,50 @@ func validatePGUsageBenchmarkRead(b *testing.B, store *Store, ctx context.Contex
 	require.NotNil(b, session)
 }
 
-func measurePGUsageFixture(b *testing.B, store *Store, filter db.UsageFilter) (int, int64) {
-	b.Helper()
-	ctx := b.Context()
-	messageWhere, args := pgUsageBenchmarkWindow("timestamp", filter)
+func measurePGUsageFixture(
+	t testing.TB, store *Store, filter db.UsageFilter,
+) (int, int64) {
+	t.Helper()
+	ctx := t.Context()
+	messageWhere, args := pgUsageBenchmarkWindow(
+		"COALESCE(m.timestamp, s.started_at)", filter)
+	messageWindow := strings.TrimPrefix(messageWhere, " WHERE ")
+	if messageWindow == "" {
+		messageWindow = "TRUE"
+	}
 	var messageRows int
 	var tokenUsageBytes int64
 	if err := store.DB().QueryRowContext(ctx,
-		"SELECT count(*), COALESCE(sum(octet_length(token_usage)), 0) FROM messages"+messageWhere,
+		`SELECT count(*), COALESCE(sum(octet_length(m.token_usage)), 0)
+		 FROM messages m
+		 JOIN sessions s ON s.id = m.session_id
+		 WHERE m.token_usage != ''
+		   AND m.model != ''
+		   AND m.model != '<synthetic>'
+		   AND s.deleted_at IS NULL
+		   AND COALESCE(m.timestamp, s.started_at) IS NOT NULL
+		   AND `+messageWindow,
 		args...,
 	).Scan(&messageRows, &tokenUsageBytes); err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
-	eventWhere, eventArgs := pgUsageBenchmarkWindow("occurred_at", filter)
+	eventWhere, eventArgs := pgUsageBenchmarkWindow(
+		"COALESCE(ue.occurred_at, s.started_at)", filter)
+	eventWindow := strings.TrimPrefix(eventWhere, " WHERE ")
+	if eventWindow == "" {
+		eventWindow = "TRUE"
+	}
 	var eventRows int
 	if err := store.DB().QueryRowContext(ctx,
-		"SELECT count(*) FROM usage_events"+eventWhere, eventArgs...,
+		`SELECT count(*)
+		 FROM usage_events ue
+		 JOIN sessions s ON s.id = ue.session_id
+		 WHERE ue.model != ''
+		   AND s.deleted_at IS NULL
+		   AND COALESCE(ue.occurred_at, s.started_at) IS NOT NULL
+		   AND `+eventWindow, eventArgs...,
 	).Scan(&eventRows); err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
 	return messageRows + eventRows, tokenUsageBytes
 }
@@ -232,8 +279,22 @@ func BenchmarkPGUsageRefresh(b *testing.B) {
 	b.Run("DeltaPush", func(b *testing.B) {
 		var sessionsPushed, messagesPushed int
 		for i := 0; i < b.N; i++ {
-			session := usageParitySessionFixture("snapshot-winner", "project-b", "claude", "2026-08-12T10:01:00Z", 10+i+1, 20)
+			session := usageParitySessionFixture(
+				"snapshot-winner", "project-b", "claude", "2026-08-12T10:01:00Z",
+				10+i+1, 20)
+			session.MessageCount = i + 2
 			if err := fixture.local.UpsertSession(session); err != nil {
+				b.Fatal(err)
+			}
+			if err := fixture.local.InsertMessages([]db.Message{{
+				SessionID:     "snapshot-winner",
+				Ordinal:       i + 1,
+				Role:          "assistant",
+				Content:       "delta-payload-" + strconv.Itoa(i),
+				ContentLength: len("delta-payload-" + strconv.Itoa(i)),
+				Timestamp:     "2026-08-12T10:01:00Z",
+				Model:         "model-priced",
+			}}); err != nil {
 				b.Fatal(err)
 			}
 			result, err := fixture.sync.Push(ctx, false, nil)

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -5,6 +5,8 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,6 +15,29 @@ import (
 )
 
 const pgUsageBenchmarkSchema = "agentsview_pg_usage_bench"
+
+type pgUsageBenchmarkCase struct {
+	name       string
+	from, to   string
+	breakdowns bool
+}
+
+func pgUsageBenchmarkCases() []pgUsageBenchmarkCase {
+	return []pgUsageBenchmarkCase{
+		{name: "one-day/no-breakdowns", from: "2026-08-12", to: "2026-08-12"},
+		{name: "one-day/breakdowns", from: "2026-08-12", to: "2026-08-12", breakdowns: true},
+		{name: "seven-day/no-breakdowns", from: "2026-08-06", to: "2026-08-12"},
+		{name: "seven-day/breakdowns", from: "2026-08-06", to: "2026-08-12", breakdowns: true},
+		{name: "thirty-day/no-breakdowns", from: "2026-07-14", to: "2026-08-12"},
+		{name: "thirty-day/breakdowns", from: "2026-07-14", to: "2026-08-12", breakdowns: true},
+		{name: "all-history/no-breakdowns"},
+		{name: "all-history/breakdowns", breakdowns: true},
+	}
+}
+
+func pgUsageBenchmarkFilter(tc pgUsageBenchmarkCase) db.UsageFilter {
+	return db.UsageFilter{From: tc.from, To: tc.to, Timezone: "UTC", Breakdowns: tc.breakdowns}
+}
 
 type pgUsageBenchmarkFixture struct {
 	local  *db.DB
@@ -74,18 +99,9 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, remote.Close()) })
 
-	for _, tc := range []struct {
-		name       string
-		from, to   string
-		breakdowns bool
-	}{
-		{name: "one-day", from: "2026-08-12", to: "2026-08-12"},
-		{name: "seven-day", from: "2026-08-06", to: "2026-08-12"},
-		{name: "thirty-day", from: "2026-07-14", to: "2026-08-12", breakdowns: true},
-		{name: "all-history", breakdowns: true},
-	} {
+	for _, tc := range pgUsageBenchmarkCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			filter := db.UsageFilter{From: tc.from, To: tc.to, Timezone: "UTC", Breakdowns: tc.breakdowns}
+			filter := pgUsageBenchmarkFilter(tc)
 			localResult := captureUsageParitySnapshot(t, local, filter)
 			remoteResult := captureUsageParitySnapshot(t, remote, filter)
 			require.NotEmpty(t, remoteResult.Top)
@@ -100,74 +116,150 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 func BenchmarkPGUsageRead(b *testing.B) {
 	fixture := openPGUsageBenchmarkFixture(b)
 	ctx := context.Background()
-	for _, tc := range []struct {
-		name       string
-		from, to   string
-		breakdowns bool
-	}{
-		{name: "one-day", from: "2026-08-12", to: "2026-08-12"},
-		{name: "seven-day", from: "2026-08-06", to: "2026-08-12"},
-		{name: "thirty-day", from: "2026-07-14", to: "2026-08-12", breakdowns: true},
-		{name: "all-history", breakdowns: true},
-	} {
+	for _, tc := range pgUsageBenchmarkCases() {
 		b.Run(tc.name, func(b *testing.B) {
-			filter := db.UsageFilter{From: tc.from, To: tc.to, Timezone: "UTC", Breakdowns: tc.breakdowns}
-			b.ReportMetric(5, "rows_scanned")
-			b.ReportMetric(178, "bytes_token_usage")
+			filter := pgUsageBenchmarkFilter(tc)
+			rowsScanned, tokenUsageBytes := measurePGUsageFixture(b, fixture.remote, filter)
+			validatePGUsageBenchmarkRead(b, fixture.remote, ctx, filter)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				daily, err := fixture.remote.GetDailyUsage(ctx, filter)
-				require.NoError(b, err)
+				if err != nil {
+					b.Fatal(err)
+				}
 				top, err := fixture.remote.GetTopSessionsByCost(ctx, filter, 10)
-				require.NoError(b, err)
+				if err != nil {
+					b.Fatal(err)
+				}
 				counts, err := fixture.remote.GetUsageSessionCounts(ctx, filter)
-				require.NoError(b, err)
+				if err != nil {
+					b.Fatal(err)
+				}
 				matching, err := fixture.remote.GetUsageMatchingSessionCount(ctx, filter)
-				require.NoError(b, err)
+				if err != nil {
+					b.Fatal(err)
+				}
 				session, err := fixture.remote.GetSessionUsage(ctx, "snapshot-winner", true)
-				require.NoError(b, err)
-				require.NotEmpty(b, daily.Daily)
-				require.NotEmpty(b, top)
-				require.NotZero(b, counts.Total)
-				require.NotZero(b, matching)
-				require.NotNil(b, session)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(daily.Daily) == 0 || len(top) == 0 || counts.Total == 0 || matching == 0 || session == nil {
+					b.Fatal("usage benchmark returned an empty result")
+				}
 			}
+			b.ReportMetric(float64(rowsScanned), "rows_scanned")
+			b.ReportMetric(float64(tokenUsageBytes), "bytes_token_usage")
 		})
 	}
+}
+
+func validatePGUsageBenchmarkRead(b *testing.B, store *Store, ctx context.Context, filter db.UsageFilter) {
+	b.Helper()
+	daily, err := store.GetDailyUsage(ctx, filter)
+	require.NoError(b, err)
+	top, err := store.GetTopSessionsByCost(ctx, filter, 10)
+	require.NoError(b, err)
+	counts, err := store.GetUsageSessionCounts(ctx, filter)
+	require.NoError(b, err)
+	matching, err := store.GetUsageMatchingSessionCount(ctx, filter)
+	require.NoError(b, err)
+	session, err := store.GetSessionUsage(ctx, "snapshot-winner", true)
+	require.NoError(b, err)
+	require.NotEmpty(b, daily.Daily)
+	require.NotEmpty(b, top)
+	require.NotZero(b, counts.Total)
+	require.NotZero(b, matching)
+	require.NotNil(b, session)
+}
+
+func measurePGUsageFixture(b *testing.B, store *Store, filter db.UsageFilter) (int, int64) {
+	b.Helper()
+	ctx := b.Context()
+	messageWhere, args := pgUsageBenchmarkWindow("timestamp", filter)
+	var messageRows int
+	var tokenUsageBytes int64
+	if err := store.DB().QueryRowContext(ctx,
+		"SELECT count(*), COALESCE(sum(octet_length(token_usage)), 0) FROM messages"+messageWhere,
+		args...,
+	).Scan(&messageRows, &tokenUsageBytes); err != nil {
+		b.Fatal(err)
+	}
+	eventWhere, eventArgs := pgUsageBenchmarkWindow("occurred_at", filter)
+	var eventRows int
+	if err := store.DB().QueryRowContext(ctx,
+		"SELECT count(*) FROM usage_events"+eventWhere, eventArgs...,
+	).Scan(&eventRows); err != nil {
+		b.Fatal(err)
+	}
+	return messageRows + eventRows, tokenUsageBytes
+}
+
+func pgUsageBenchmarkWindow(column string, filter db.UsageFilter) (string, []any) {
+	clauses := make([]string, 0, 2)
+	args := make([]any, 0, 2)
+	if filter.From != "" {
+		args = append(args, filter.From)
+		clauses = append(clauses, column+" >= $"+strconv.Itoa(len(args))+"::date")
+	}
+	if filter.To != "" {
+		args = append(args, filter.To)
+		clauses = append(clauses, column+" < ($"+strconv.Itoa(len(args))+"::date + INTERVAL '1 day')")
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return " WHERE " + strings.Join(clauses, " AND "), args
 }
 
 func BenchmarkPGUsageRefresh(b *testing.B) {
 	fixture := openPGUsageBenchmarkFixture(b)
 	ctx := context.Background()
 	b.Run("ColdPush", func(b *testing.B) {
+		var sessionsPushed, messagesPushed int
 		for i := 0; i < b.N; i++ {
 			result, err := fixture.sync.Push(ctx, true, nil)
-			require.NoError(b, err)
-			require.NotZero(b, result.SessionsPushed)
-			b.ReportMetric(float64(result.SessionsPushed), "sessions_pushed")
-			b.ReportMetric(float64(result.MessagesPushed), "messages_pushed")
+			if err != nil {
+				b.Fatal(err)
+			}
+			sessionsPushed += result.SessionsPushed
+			messagesPushed += result.MessagesPushed
 		}
+		require.NotZero(b, sessionsPushed)
+		require.NotZero(b, messagesPushed)
+		b.ReportMetric(float64(sessionsPushed)/float64(b.N), "sessions_pushed")
+		b.ReportMetric(float64(messagesPushed)/float64(b.N), "messages_pushed")
 	})
 	b.Run("DeltaPush", func(b *testing.B) {
+		var sessionsPushed, messagesPushed int
 		for i := 0; i < b.N; i++ {
 			session := usageParitySessionFixture("snapshot-winner", "project-b", "claude", "2026-08-12T10:01:00Z", 10+i+1, 20)
-			require.NoError(b, fixture.local.UpsertSession(session))
+			if err := fixture.local.UpsertSession(session); err != nil {
+				b.Fatal(err)
+			}
 			result, err := fixture.sync.Push(ctx, false, nil)
-			require.NoError(b, err)
-			b.ReportMetric(float64(result.SessionsPushed), "sessions_pushed")
-			b.ReportMetric(float64(result.MessagesPushed), "messages_pushed")
+			if err != nil {
+				b.Fatal(err)
+			}
+			sessionsPushed += result.SessionsPushed
+			messagesPushed += result.MessagesPushed
 		}
+		require.NotZero(b, sessionsPushed)
+		require.NotZero(b, messagesPushed)
+		b.ReportMetric(float64(sessionsPushed)/float64(b.N), "sessions_pushed")
+		b.ReportMetric(float64(messagesPushed)/float64(b.N), "messages_pushed")
 	})
 	b.Run("CatalogProbe", func(b *testing.B) {
+		var tables int
 		for i := 0; i < b.N; i++ {
-			var tables int
 			err := fixture.remote.DB().QueryRowContext(ctx, `
 				SELECT count(*) FROM pg_catalog.pg_class c
 				JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 				WHERE n.nspname = $1 AND c.relkind IN ('r', 'i')`, pgUsageBenchmarkSchema).Scan(&tables)
-			require.NoError(b, err)
-			require.NotZero(b, tables)
-			b.ReportMetric(float64(tables), "catalog_rows")
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
+		require.NotZero(b, tables)
+		b.ReportMetric(float64(tables), "catalog_rows")
 	})
 }

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -18,22 +19,25 @@ import (
 
 const pgUsageBenchmarkSchemaPrefix = "agentsview_pg_usage_bench"
 
+const pgUsageBenchmarkBulkRows = 24
+
 type pgUsageBenchmarkCase struct {
-	name       string
-	from, to   string
-	breakdowns bool
+	name                      string
+	from, to                  string
+	breakdowns                bool
+	expectedEligibleInputRows int
 }
 
 func pgUsageBenchmarkCases() []pgUsageBenchmarkCase {
 	return []pgUsageBenchmarkCase{
-		{name: "one-day/no-breakdowns", from: "2026-08-12", to: "2026-08-12"},
-		{name: "one-day/breakdowns", from: "2026-08-12", to: "2026-08-12", breakdowns: true},
-		{name: "seven-day/no-breakdowns", from: "2026-08-06", to: "2026-08-12"},
-		{name: "seven-day/breakdowns", from: "2026-08-06", to: "2026-08-12", breakdowns: true},
-		{name: "thirty-day/no-breakdowns", from: "2026-07-14", to: "2026-08-12"},
-		{name: "thirty-day/breakdowns", from: "2026-07-14", to: "2026-08-12", breakdowns: true},
-		{name: "all-history/no-breakdowns"},
-		{name: "all-history/breakdowns", breakdowns: true},
+		{name: "one-day/no-breakdowns", from: "2026-08-12", to: "2026-08-12", expectedEligibleInputRows: 8},
+		{name: "one-day/breakdowns", from: "2026-08-12", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 8},
+		{name: "seven-day/no-breakdowns", from: "2026-08-06", to: "2026-08-12", expectedEligibleInputRows: 16},
+		{name: "seven-day/breakdowns", from: "2026-08-06", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 16},
+		{name: "thirty-day/no-breakdowns", from: "2026-07-14", to: "2026-08-12", expectedEligibleInputRows: 17},
+		{name: "thirty-day/breakdowns", from: "2026-07-14", to: "2026-08-12", breakdowns: true, expectedEligibleInputRows: 17},
+		{name: "all-history/no-breakdowns", expectedEligibleInputRows: 29},
+		{name: "all-history/breakdowns", breakdowns: true, expectedEligibleInputRows: 29},
 	}
 }
 
@@ -41,12 +45,18 @@ func pgUsageBenchmarkFilter(tc pgUsageBenchmarkCase) db.UsageFilter {
 	return db.UsageFilter{From: tc.from, To: tc.to, Timezone: "UTC", Breakdowns: tc.breakdowns}
 }
 
+func pgUsageBenchmarkValidationFilter() db.UsageFilter {
+	return db.UsageFilter{From: "2026-08-12", To: "2026-08-12", Timezone: "UTC"}
+}
+
 type pgUsageBenchmarkFixture struct {
-	pgURL  string
-	schema string
-	local  *db.DB
-	remote *Store
-	sync   *Sync
+	pgURL            string
+	schema           string
+	local            *db.DB
+	remote           *Store
+	sync             *Sync
+	expectedSessions int
+	expectedMessages int
 }
 
 func pgUsageRemoteCardinality(t testing.TB, remote *Store) (int, int) {
@@ -95,22 +105,62 @@ func openPGUsageBenchmarkFixture(t testing.TB) *pgUsageBenchmarkFixture {
 
 	var version string
 	req.NoError(remote.DB().QueryRowContext(t.Context(), "SHOW server_version").Scan(&version))
-	t.Logf("pg_version=%s fixture_sessions=%d fixture_messages=%d fixture_usage_events=%d", version, 6, 5, 1)
+	t.Logf("pg_version=%s fixture_baseline_sessions=%d fixture_baseline_messages=%d fixture_usage_events=%d", version, 6, 5, 1)
 	return &pgUsageBenchmarkFixture{
 		pgURL: pgURL, schema: schema,
 		local: local, remote: remote, sync: syncer,
+		expectedSessions: 6, expectedMessages: 5,
 	}
+}
+
+func (f *pgUsageBenchmarkFixture) addBulk(t testing.TB, count int) {
+	t.Helper()
+	seedPGUsageBenchmarkBulkFixture(t, f.local, count)
+	f.expectedSessions += count
+	f.expectedMessages += count
+}
+
+func seedPGUsageBenchmarkBulkFixture(t testing.TB, local *db.DB, count int) {
+	t.Helper()
+	sessions := make([]db.Session, 0, count)
+	messages := make([]db.Message, 0, count)
+	for i := 0; i < count; i++ {
+		day := "2026-06-20"
+		if i < 4 {
+			day = "2026-08-12"
+		} else if i < 12 {
+			day = "2026-08-08"
+		}
+		sessionID := "benchmark-bulk-" + strconv.Itoa(i)
+		startedAt := day + "T09:00:00Z"
+		sessions = append(sessions, db.Session{
+			ID: sessionID, Project: "bulk-project", Machine: "bench-machine",
+			Agent: "bulk", StartedAt: &startedAt, MessageCount: 1,
+			UserMessageCount: 1,
+		})
+		messages = append(messages, db.Message{
+			SessionID: sessionID, Ordinal: 0, Role: "assistant",
+			Timestamp: day + "T09:01:00Z", Model: "model-priced",
+			TokenUsage:      json.RawMessage(`{"input_tokens":1,"output_tokens":0}`),
+			ClaudeMessageID: "benchmark-bulk-message-" + strconv.Itoa(i),
+			ClaudeRequestID: "benchmark-bulk-request-" + strconv.Itoa(i),
+		})
+	}
+	for i := range sessions {
+		require.NoError(t, local.UpsertSession(sessions[i]))
+	}
+	require.NoError(t, local.InsertMessages(messages))
 }
 
 func (f *pgUsageBenchmarkFixture) prime(t testing.TB) {
 	t.Helper()
 	result, err := f.sync.Push(t.Context(), true, nil)
 	require.NoError(t, err)
-	require.Equal(t, 6, result.SessionsPushed)
-	require.Equal(t, 5, result.MessagesPushed)
+	require.Equal(t, f.expectedSessions, result.SessionsPushed)
+	require.Equal(t, f.expectedMessages, result.MessagesPushed)
 	sessions, messages := pgUsageRemoteCardinality(t, f.remote)
-	require.Equal(t, 6, sessions)
-	require.Equal(t, 5, messages)
+	require.Equal(t, f.expectedSessions, sessions)
+	require.Equal(t, f.expectedMessages, messages)
 }
 
 func (f *pgUsageBenchmarkFixture) resetRemoteEmpty(t testing.TB) {
@@ -128,8 +178,8 @@ func (f *pgUsageBenchmarkFixture) requireFixedCardinality(t testing.TB) {
 	require.NoError(t, err)
 	require.Equal(t, 1, messageCount)
 	sessions, messages := pgUsageRemoteCardinality(t, f.remote)
-	require.Equal(t, 6, sessions)
-	require.Equal(t, 5, messages)
+	require.Equal(t, f.expectedSessions, sessions)
+	require.Equal(t, f.expectedMessages, messages)
 }
 
 func (f *pgUsageBenchmarkFixture) replaceDeltaMessage(t testing.TB, payload string) {
@@ -279,12 +329,14 @@ func (s *pgUsageMethodRecorder) GetSessionUsage(
 
 func BenchmarkPGUsageRead(b *testing.B) {
 	fixture := openPGUsageBenchmarkFixture(b)
+	fixture.addBulk(b, pgUsageBenchmarkBulkRows)
 	fixture.prime(b)
 	ctx := context.Background()
 	for _, tc := range pgUsageBenchmarkCases() {
 		b.Run(tc.name, func(b *testing.B) {
 			filter := pgUsageBenchmarkFilter(tc)
 			eligibleUsageInputRows, tokenUsageBytes := measurePGUsageFixture(b, fixture.remote, filter)
+			require.Equal(b, tc.expectedEligibleInputRows, eligibleUsageInputRows)
 			requireCompleteUsageParity(b, fixture.local, fixture.remote, filter)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -405,6 +457,8 @@ func BenchmarkPGUsageRefresh(b *testing.B) {
 			sessions, messages := pgUsageRemoteCardinality(b, fixture.remote)
 			require.Equal(b, 6, sessions)
 			require.Equal(b, 5, messages)
+			requireCompleteUsageParity(b, fixture.local, fixture.remote,
+				pgUsageBenchmarkValidationFilter())
 			sessionsPushed += result.SessionsPushed
 			messagesPushed += result.MessagesPushed
 			iterations++
@@ -437,6 +491,8 @@ func BenchmarkPGUsageRefresh(b *testing.B) {
 			require.Equal(b, 1, result.SessionsPushed)
 			require.Equal(b, 1, result.MessagesPushed)
 			fixture.requireFixedCardinality(b)
+			requireCompleteUsageParity(b, fixture.local, fixture.remote,
+				pgUsageBenchmarkValidationFilter())
 			sessionsPushed += result.SessionsPushed
 			messagesPushed += result.MessagesPushed
 			iterations++

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -122,9 +122,9 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 				t.Context(), "snapshot-winner", tc.breakdowns)
 			require.NoError(t, err)
 			if tc.breakdowns {
-				require.NotZero(t, usage.BreakdownCount)
+				require.NotZero(t, len(usage.Breakdown))
 			} else {
-				require.Zero(t, usage.BreakdownCount)
+				require.Zero(t, len(usage.Breakdown))
 			}
 		})
 	}

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -200,6 +200,14 @@ func (f *pgUsageBenchmarkFixture) prime(t testing.TB) {
 	require.Equal(t, f.expectedMessages, messages)
 }
 
+func (f *pgUsageBenchmarkFixture) analyzeUsageTables(t testing.TB) {
+	t.Helper()
+	_, err := f.remote.DB().ExecContext(t.Context(),
+		"ANALYZE sessions, messages, usage_events, cursor_usage_events, model_pricing, model_pricing_bands")
+	require.NoError(t, err)
+	t.Logf("analyzed_usage_tables=sessions,messages,usage_events,cursor_usage_events,model_pricing,model_pricing_bands")
+}
+
 func (f *pgUsageBenchmarkFixture) resetRemoteEmpty(t testing.TB) {
 	t.Helper()
 	cleanNamedPGSchema(t, f.pgURL, f.schema)
@@ -378,6 +386,7 @@ func BenchmarkPGUsageRead(b *testing.B) {
 	fixture := openPGUsageBenchmarkFixture(b)
 	fixture.addBulk(b, pgUsageBenchmarkBulkSessions)
 	fixture.prime(b)
+	fixture.analyzeUsageTables(b)
 	loadedSessions, loadedMessages := pgUsageRemoteCardinality(b, fixture.remote)
 	require.Equal(b, 6+pgUsageBenchmarkBulkSessions, loadedSessions)
 	require.Equal(b, 5+pgUsageBenchmarkBulkSessions*pgUsageBenchmarkBulkMessagesPerSession, loadedMessages)
@@ -614,6 +623,7 @@ func BenchmarkPGUsageRefreshLarge(b *testing.B) {
 		fixture := openPGUsageBenchmarkFixture(b)
 		fixture.addBulk(b, pgUsageBenchmarkBulkSessions)
 		fixture.prime(b)
+		fixture.analyzeUsageTables(b)
 		loadedSessions, loadedMessages := pgUsageRemoteCardinality(b, fixture.remote)
 		b.Logf("fixture_scale=bulk_sessions=%d bulk_messages=%d messages_per_session=%d loaded_table_rows=sessions:%d messages:%d",
 			pgUsageBenchmarkBulkSessions,

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -295,16 +295,21 @@ func BenchmarkPGUsageRefresh(b *testing.B) {
 	b.Run("DeltaPush", func(b *testing.B) {
 		var sessionsPushed, messagesPushed int
 		for i := 0; i < b.N; i++ {
+			messageCount, err := fixture.local.MessageCount("snapshot-winner")
+			if err != nil {
+				b.Fatal(err)
+			}
+			nextOrdinal := messageCount + 1
 			session := usageParitySessionFixture(
 				"snapshot-winner", "project-b", "claude", "2026-08-12T10:01:00Z",
 				10+i+1, 20)
-			session.MessageCount = i + 2
+			session.MessageCount = nextOrdinal
 			if err := fixture.local.UpsertSession(session); err != nil {
 				b.Fatal(err)
 			}
 			if err := fixture.local.InsertMessages([]db.Message{{
 				SessionID:     "snapshot-winner",
-				Ordinal:       i + 1,
+				Ordinal:       nextOrdinal,
 				Role:          "assistant",
 				Content:       "delta-payload-" + strconv.Itoa(i),
 				ContentLength: len("delta-payload-" + strconv.Itoa(i)),

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -4,7 +4,9 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,7 +16,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-const pgUsageBenchmarkSchema = "agentsview_pg_usage_bench"
+const pgUsageBenchmarkSchemaPrefix = "agentsview_pg_usage_bench"
 
 type pgUsageBenchmarkCase struct {
 	name       string
@@ -40,37 +42,45 @@ func pgUsageBenchmarkFilter(tc pgUsageBenchmarkCase) db.UsageFilter {
 }
 
 type pgUsageBenchmarkFixture struct {
+	schema string
 	local  *db.DB
 	remote *Store
 	sync   *Sync
 	filter db.UsageFilter
 }
 
+func pgUsageBenchmarkSchema(b *testing.B) string {
+	b.Helper()
+	hash := sha256.Sum256([]byte(b.Name() + "\x00" + b.TempDir()))
+	return pgUsageBenchmarkSchemaPrefix + "_" + hex.EncodeToString(hash[:8])
+}
+
 func openPGUsageBenchmarkFixture(b *testing.B) *pgUsageBenchmarkFixture {
 	b.Helper()
 	req := require.New(b)
 	pgURL := testPGURL(b)
+	schema := pgUsageBenchmarkSchema(b)
 	admin, err := sql.Open("pgx", pgURL)
 	req.NoError(err)
-	_, err = admin.Exec("DROP SCHEMA IF EXISTS " + pgUsageBenchmarkSchema + " CASCADE")
+	_, err = admin.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE")
 	req.NoError(err)
 	req.NoError(admin.Close())
 
 	local, err := db.Open(b.TempDir() + "/usage-bench.db")
 	req.NoError(err)
 	seedUsageParityFixture(b, local)
-	syncer, err := New(pgURL, pgUsageBenchmarkSchema, local, "bench-machine", true, SyncOptions{})
+	syncer, err := New(pgURL, schema, local, "bench-machine", true, SyncOptions{})
 	req.NoError(err)
 	_, err = syncer.Push(b.Context(), true, nil)
 	req.NoError(err)
-	remote, err := NewStore(pgURL, pgUsageBenchmarkSchema, true)
+	remote, err := NewStore(pgURL, schema, true)
 	req.NoError(err)
 	b.Cleanup(func() {
 		_ = remote.Close()
 		_ = syncer.Close()
 		_ = local.Close()
 		admin, _ := sql.Open("pgx", pgURL)
-		_, _ = admin.Exec("DROP SCHEMA IF EXISTS " + pgUsageBenchmarkSchema + " CASCADE")
+		_, _ = admin.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE")
 		_ = admin.Close()
 	})
 
@@ -78,7 +88,8 @@ func openPGUsageBenchmarkFixture(b *testing.B) *pgUsageBenchmarkFixture {
 	req.NoError(remote.DB().QueryRowContext(b.Context(), "SHOW server_version").Scan(&version))
 	b.Logf("pg_version=%s fixture_sessions=%d fixture_messages=%d fixture_usage_events=%d", version, 5, 4, 1)
 	return &pgUsageBenchmarkFixture{
-		local: local, remote: remote, sync: syncer,
+		schema: schema,
+		local:  local, remote: remote, sync: syncer,
 		filter: db.UsageFilter{From: "2026-08-12", To: "2026-08-12", Timezone: "UTC"},
 	}
 }
@@ -320,7 +331,7 @@ func BenchmarkPGUsageRefresh(b *testing.B) {
 			err := fixture.remote.DB().QueryRowContext(ctx, `
 				SELECT count(*) FROM pg_catalog.pg_class c
 				JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-				WHERE n.nspname = $1 AND c.relkind IN ('r', 'i')`, pgUsageBenchmarkSchema).Scan(&tables)
+				WHERE n.nspname = $1 AND c.relkind IN ('r', 'i')`, fixture.schema).Scan(&tables)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -42,6 +42,7 @@ func pgUsageBenchmarkFilter(tc pgUsageBenchmarkCase) db.UsageFilter {
 }
 
 type pgUsageBenchmarkFixture struct {
+	pgURL  string
 	schema string
 	local  *db.DB
 	remote *Store
@@ -49,33 +50,42 @@ type pgUsageBenchmarkFixture struct {
 	filter db.UsageFilter
 }
 
-func pgUsageBenchmarkSchema(b *testing.B) string {
-	b.Helper()
-	hash := sha256.Sum256([]byte(b.Name() + "\x00" + b.TempDir()))
+func pgUsageRemoteCardinality(t testing.TB, remote *Store) (int, int) {
+	t.Helper()
+	var sessions, messages int
+	err := remote.DB().QueryRowContext(
+		t.Context(), "SELECT (SELECT count(*) FROM sessions), (SELECT count(*) FROM messages)",
+	).Scan(&sessions, &messages)
+	require.NoError(t, err)
+	return sessions, messages
+}
+
+func pgUsageBenchmarkSchema(t testing.TB) string {
+	t.Helper()
+	hash := sha256.Sum256([]byte(t.Name() + "\x00" + t.TempDir()))
 	return pgUsageBenchmarkSchemaPrefix + "_" + hex.EncodeToString(hash[:8])
 }
 
-func openPGUsageBenchmarkFixture(b *testing.B) *pgUsageBenchmarkFixture {
-	b.Helper()
-	req := require.New(b)
-	pgURL := testPGURL(b)
-	schema := pgUsageBenchmarkSchema(b)
+func openPGUsageBenchmarkFixture(t testing.TB) *pgUsageBenchmarkFixture {
+	t.Helper()
+	req := require.New(t)
+	pgURL := testPGURL(t)
+	schema := pgUsageBenchmarkSchema(t)
 	admin, err := sql.Open("pgx", pgURL)
 	req.NoError(err)
 	_, err = admin.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE")
 	req.NoError(err)
 	req.NoError(admin.Close())
 
-	local, err := db.Open(b.TempDir() + "/usage-bench.db")
+	local, err := db.Open(t.TempDir() + "/usage-bench.db")
 	req.NoError(err)
-	seedUsageParityFixture(b, local)
+	seedUsageParityFixture(t, local)
 	syncer, err := New(pgURL, schema, local, "bench-machine", true, SyncOptions{})
 	req.NoError(err)
-	_, err = syncer.Push(b.Context(), true, nil)
-	req.NoError(err)
+	req.NoError(EnsureSchema(t.Context(), syncer.pg, schema))
 	remote, err := NewStore(pgURL, schema, true)
 	req.NoError(err)
-	b.Cleanup(func() {
+	t.Cleanup(func() {
 		_ = remote.Close()
 		_ = syncer.Close()
 		_ = local.Close()
@@ -85,13 +95,56 @@ func openPGUsageBenchmarkFixture(b *testing.B) *pgUsageBenchmarkFixture {
 	})
 
 	var version string
-	req.NoError(remote.DB().QueryRowContext(b.Context(), "SHOW server_version").Scan(&version))
-	b.Logf("pg_version=%s fixture_sessions=%d fixture_messages=%d fixture_usage_events=%d", version, 5, 4, 1)
+	req.NoError(remote.DB().QueryRowContext(t.Context(), "SHOW server_version").Scan(&version))
+	t.Logf("pg_version=%s fixture_sessions=%d fixture_messages=%d fixture_usage_events=%d", version, 5, 4, 1)
 	return &pgUsageBenchmarkFixture{
-		schema: schema,
-		local:  local, remote: remote, sync: syncer,
+		pgURL: pgURL, schema: schema,
+		local: local, remote: remote, sync: syncer,
 		filter: db.UsageFilter{From: "2026-08-12", To: "2026-08-12", Timezone: "UTC"},
 	}
+}
+
+func (f *pgUsageBenchmarkFixture) prime(t testing.TB) {
+	t.Helper()
+	result, err := f.sync.Push(t.Context(), true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 5, result.SessionsPushed)
+	require.Equal(t, 4, result.MessagesPushed)
+	sessions, messages := pgUsageRemoteCardinality(t, f.remote)
+	require.Equal(t, 5, sessions)
+	require.Equal(t, 4, messages)
+}
+
+func (f *pgUsageBenchmarkFixture) resetRemoteEmpty(t testing.TB) {
+	t.Helper()
+	cleanNamedPGSchema(t, f.pgURL, f.schema)
+	require.NoError(t, EnsureSchema(t.Context(), f.sync.pg, f.schema))
+	sessions, messages := pgUsageRemoteCardinality(t, f.remote)
+	require.Zero(t, sessions)
+	require.Zero(t, messages)
+}
+
+func (f *pgUsageBenchmarkFixture) requireFixedCardinality(t testing.TB) {
+	t.Helper()
+	messageCount, err := f.local.MessageCount("snapshot-winner")
+	require.NoError(t, err)
+	require.Equal(t, 1, messageCount)
+	sessions, messages := pgUsageRemoteCardinality(t, f.remote)
+	require.Equal(t, 5, sessions)
+	require.Equal(t, 4, messages)
+}
+
+func (f *pgUsageBenchmarkFixture) replaceDeltaMessage(t testing.TB, payload string) {
+	t.Helper()
+	f.requireFixedCardinality(t)
+	messages, err := f.local.GetMessages(t.Context(), "snapshot-winner", 0, 1, true)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	messages[0].TokenUsage = []byte(payload)
+	require.NoError(t, f.local.ReplaceSessionMessages("snapshot-winner", messages))
+	messageCount, err := f.local.MessageCount("snapshot-winner")
+	require.NoError(t, err)
+	require.Equal(t, 1, messageCount)
 }
 
 func TestPGUsageBenchmarkFixture(t *testing.T) {
@@ -99,17 +152,9 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 	const schema = "agentsview_usage_benchmark_fixture_test"
 	cleanNamedPGSchema(t, pgURL, schema)
 	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
-	local := testDB(t)
-	seedUsageParityFixture(t, local)
-	syncer, err := New(pgURL, schema, local, "bench-fixture-machine", true, SyncOptions{})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, syncer.Close()) })
-	_, err = syncer.Push(t.Context(), true, nil)
-	require.NoError(t, err)
-	remote, err := NewStore(pgURL, schema, true)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, remote.Close()) })
-	rowsScanned, tokenUsageBytes := measurePGUsageFixture(t, remote, db.UsageFilter{
+	fixture := openPGUsageBenchmarkFixture(t)
+	fixture.prime(t)
+	rowsScanned, tokenUsageBytes := measurePGUsageFixture(t, fixture.remote, db.UsageFilter{
 		From: "2026-08-12", To: "2026-08-12", Timezone: "UTC",
 	})
 	require.Equal(t, 4, rowsScanned,
@@ -122,14 +167,14 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 	for _, tc := range pgUsageBenchmarkCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			filter := pgUsageBenchmarkFilter(tc)
-			localResult := captureUsageParitySnapshot(t, local, filter)
-			remoteResult := captureUsageParitySnapshot(t, remote, filter)
+			localResult := captureUsageParitySnapshot(t, fixture.local, filter)
+			remoteResult := captureUsageParitySnapshot(t, fixture.remote, filter)
 			require.NotEmpty(t, remoteResult.Top)
 			require.NotEmpty(t, remoteResult.Daily.Dates)
 			require.Equal(t, localResult, remoteResult)
 			require.NotZero(t, remoteResult.Counts.Total)
 			require.NotZero(t, remoteResult.MatchingSessionCount)
-			usage, err := remote.GetSessionUsage(
+			usage, err := fixture.remote.GetSessionUsage(
 				t.Context(), "snapshot-winner", tc.breakdowns)
 			require.NoError(t, err)
 			if tc.breakdowns {
@@ -143,6 +188,7 @@ func TestPGUsageBenchmarkFixture(t *testing.T) {
 
 func BenchmarkPGUsageRead(b *testing.B) {
 	fixture := openPGUsageBenchmarkFixture(b)
+	fixture.prime(b)
 	ctx := context.Background()
 	for _, tc := range pgUsageBenchmarkCases() {
 		b.Run(tc.name, func(b *testing.B) {
@@ -275,64 +321,72 @@ func pgUsageBenchmarkWindow(column string, filter db.UsageFilter) (string, []any
 }
 
 func BenchmarkPGUsageRefresh(b *testing.B) {
-	fixture := openPGUsageBenchmarkFixture(b)
 	ctx := context.Background()
 	b.Run("ColdPush", func(b *testing.B) {
+		fixture := openPGUsageBenchmarkFixture(b)
 		var sessionsPushed, messagesPushed int
-		for i := 0; i < b.N; i++ {
+		iterations := 0
+		for b.Loop() {
+			b.StopTimer()
+			fixture.resetRemoteEmpty(b)
+			b.StartTimer()
 			result, err := fixture.sync.Push(ctx, true, nil)
+			b.StopTimer()
 			if err != nil {
 				b.Fatal(err)
 			}
+			require.Equal(b, 5, result.SessionsPushed)
+			require.Equal(b, 4, result.MessagesPushed)
+			sessions, messages := pgUsageRemoteCardinality(b, fixture.remote)
+			require.Equal(b, 5, sessions)
+			require.Equal(b, 4, messages)
 			sessionsPushed += result.SessionsPushed
 			messagesPushed += result.MessagesPushed
+			iterations++
+			b.StartTimer()
 		}
-		require.NotZero(b, sessionsPushed)
-		require.NotZero(b, messagesPushed)
-		b.ReportMetric(float64(sessionsPushed)/float64(b.N), "sessions_pushed")
-		b.ReportMetric(float64(messagesPushed)/float64(b.N), "messages_pushed")
+		b.StopTimer()
+		require.Equal(b, 5*iterations, sessionsPushed)
+		require.Equal(b, 4*iterations, messagesPushed)
+		b.ReportMetric(5, "sessions_pushed")
+		b.ReportMetric(4, "messages_pushed")
 	})
 	b.Run("DeltaPush", func(b *testing.B) {
+		fixture := openPGUsageBenchmarkFixture(b)
+		fixture.prime(b)
 		var sessionsPushed, messagesPushed int
-		for i := 0; i < b.N; i++ {
-			messageCount, err := fixture.local.MessageCount("snapshot-winner")
-			if err != nil {
-				b.Fatal(err)
+		iterations := 0
+		for b.Loop() {
+			b.StopTimer()
+			payload := `{"input_tokens":20,"output_tokens":10}`
+			if iterations%2 == 1 {
+				payload = `{"input_tokens":21,"output_tokens":9}`
 			}
-			nextOrdinal := messageCount + 1
-			session := usageParitySessionFixture(
-				"snapshot-winner", "project-b", "claude", "2026-08-12T10:01:00Z",
-				10+i+1, 20)
-			session.MessageCount = nextOrdinal
-			if err := fixture.local.UpsertSession(session); err != nil {
-				b.Fatal(err)
-			}
-			if err := fixture.local.InsertMessages([]db.Message{{
-				SessionID:     "snapshot-winner",
-				Ordinal:       nextOrdinal,
-				Role:          "assistant",
-				Content:       "delta-payload-" + strconv.Itoa(i),
-				ContentLength: len("delta-payload-" + strconv.Itoa(i)),
-				Timestamp:     "2026-08-12T10:01:00Z",
-				Model:         "model-priced",
-			}}); err != nil {
-				b.Fatal(err)
-			}
+			fixture.replaceDeltaMessage(b, payload)
+			b.StartTimer()
 			result, err := fixture.sync.Push(ctx, false, nil)
+			b.StopTimer()
 			if err != nil {
 				b.Fatal(err)
 			}
+			require.Equal(b, 1, result.SessionsPushed)
+			require.Equal(b, 1, result.MessagesPushed)
+			fixture.requireFixedCardinality(b)
 			sessionsPushed += result.SessionsPushed
 			messagesPushed += result.MessagesPushed
+			iterations++
+			b.StartTimer()
 		}
-		require.NotZero(b, sessionsPushed)
-		require.NotZero(b, messagesPushed)
-		b.ReportMetric(float64(sessionsPushed)/float64(b.N), "sessions_pushed")
-		b.ReportMetric(float64(messagesPushed)/float64(b.N), "messages_pushed")
+		b.StopTimer()
+		require.Equal(b, iterations, sessionsPushed)
+		require.Equal(b, iterations, messagesPushed)
+		b.ReportMetric(1, "sessions_pushed")
+		b.ReportMetric(1, "messages_pushed")
 	})
 	b.Run("CatalogProbe", func(b *testing.B) {
+		fixture := openPGUsageBenchmarkFixture(b)
 		var tables int
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := fixture.remote.DB().QueryRowContext(ctx, `
 				SELECT count(*) FROM pg_catalog.pg_class c
 				JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace

--- a/internal/postgres/usage_bench_pgtest_test.go
+++ b/internal/postgres/usage_bench_pgtest_test.go
@@ -47,7 +47,6 @@ type pgUsageBenchmarkFixture struct {
 	local  *db.DB
 	remote *Store
 	sync   *Sync
-	filter db.UsageFilter
 }
 
 func pgUsageRemoteCardinality(t testing.TB, remote *Store) (int, int) {
@@ -100,7 +99,6 @@ func openPGUsageBenchmarkFixture(t testing.TB) *pgUsageBenchmarkFixture {
 	return &pgUsageBenchmarkFixture{
 		pgURL: pgURL, schema: schema,
 		local: local, remote: remote, sync: syncer,
-		filter: db.UsageFilter{From: "2026-08-12", To: "2026-08-12", Timezone: "UTC"},
 	}
 }
 
@@ -148,10 +146,6 @@ func (f *pgUsageBenchmarkFixture) replaceDeltaMessage(t testing.TB, payload stri
 }
 
 func TestPGUsageBenchmarkFixture(t *testing.T) {
-	pgURL := testPGURL(t)
-	const schema = "agentsview_usage_benchmark_fixture_test"
-	cleanNamedPGSchema(t, pgURL, schema)
-	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
 	fixture := openPGUsageBenchmarkFixture(t)
 	sessions, messages := pgUsageRemoteCardinality(t, fixture.remote)
 	require.Zero(t, sessions)

--- a/internal/postgres/usage_facts_parity_pgtest_test.go
+++ b/internal/postgres/usage_facts_parity_pgtest_test.go
@@ -5,6 +5,8 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -170,29 +172,71 @@ func TestSQLiteFactsAndPostgresLiveUsageParity(t *testing.T) {
 }
 
 func requireCompleteUsageParity(
-	t *testing.T, local, remote db.Store, filter db.UsageFilter,
+	t testing.TB, local, remote db.Store, filter db.UsageFilter,
 ) {
 	t.Helper()
-	ctx := context.Background()
+	require.NoError(t, completeUsageParity(t.Context(), local, remote, filter))
+}
+
+func completeUsageParity(
+	ctx context.Context, local, remote db.Store, filter db.UsageFilter,
+) error {
 	localDaily, err := local.GetDailyUsage(ctx, filter)
-	require.NoError(t, err)
+	if err != nil {
+		return fmt.Errorf("local GetDailyUsage: %w", err)
+	}
 	remoteDaily, err := remote.GetDailyUsage(ctx, filter)
-	require.NoError(t, err)
-	require.Equal(t, localDaily, remoteDaily, "complete daily result")
+	if err != nil {
+		return fmt.Errorf("remote GetDailyUsage: %w", err)
+	}
+	if !reflect.DeepEqual(localDaily, remoteDaily) {
+		return fmt.Errorf("complete daily result differs")
+	}
 	localTop, err := local.GetTopSessionsByCost(ctx, filter, 10)
-	require.NoError(t, err)
+	if err != nil {
+		return fmt.Errorf("local GetTopSessionsByCost: %w", err)
+	}
 	remoteTop, err := remote.GetTopSessionsByCost(ctx, filter, 10)
-	require.NoError(t, err)
-	require.Equal(t, localTop, remoteTop, "complete top-session result")
-	localSession, err := local.GetSessionUsage(ctx, "snapshot-winner", true)
-	require.NoError(t, err)
-	remoteSession, err := remote.GetSessionUsage(ctx, "snapshot-winner", true)
-	require.NoError(t, err)
-	require.Equal(t, localSession, remoteSession, "complete session result")
-	localWithoutBreakdown := captureUsageParitySession(t, local, false)
-	remoteWithoutBreakdown := captureUsageParitySession(t, remote, false)
-	require.Equal(t, localWithoutBreakdown, remoteWithoutBreakdown,
-		"complete session result without breakdown")
+	if err != nil {
+		return fmt.Errorf("remote GetTopSessionsByCost: %w", err)
+	}
+	if !reflect.DeepEqual(localTop, remoteTop) {
+		return fmt.Errorf("complete top-session result differs")
+	}
+	localCounts, err := local.GetUsageSessionCounts(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("local GetUsageSessionCounts: %w", err)
+	}
+	remoteCounts, err := remote.GetUsageSessionCounts(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("remote GetUsageSessionCounts: %w", err)
+	}
+	if !reflect.DeepEqual(localCounts, remoteCounts) {
+		return fmt.Errorf("complete session-count result differs")
+	}
+	localMatching, err := local.GetUsageMatchingSessionCount(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("local GetUsageMatchingSessionCount: %w", err)
+	}
+	remoteMatching, err := remote.GetUsageMatchingSessionCount(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("remote GetUsageMatchingSessionCount: %w", err)
+	}
+	if localMatching != remoteMatching {
+		return fmt.Errorf("complete matching-session-count result differs")
+	}
+	localSession, err := local.GetSessionUsage(ctx, "snapshot-winner", filter.Breakdowns)
+	if err != nil {
+		return fmt.Errorf("local GetSessionUsage: %w", err)
+	}
+	remoteSession, err := remote.GetSessionUsage(ctx, "snapshot-winner", filter.Breakdowns)
+	if err != nil {
+		return fmt.Errorf("remote GetSessionUsage: %w", err)
+	}
+	if !reflect.DeepEqual(localSession, remoteSession) {
+		return fmt.Errorf("complete session result differs")
+	}
+	return nil
 }
 
 func seedUsageParityFixture(t testing.TB, local *db.DB) {

--- a/internal/postgres/usage_facts_parity_pgtest_test.go
+++ b/internal/postgres/usage_facts_parity_pgtest_test.go
@@ -123,7 +123,7 @@ func TestSQLiteFactsAndPostgresLiveUsageParity(t *testing.T) {
 			ByProject: map[string]int{"project-a": 1, "project-c": 1, "project-d": 1},
 			ByAgent:   map[string]int{"claude": 2, "hermes": 1},
 		},
-		MatchingSessionCount: 5,
+		MatchingSessionCount: 4,
 		Session: usageParitySession{
 			SessionID: "snapshot-winner", TotalOutputTokens: 10,
 			PeakContextTokens: 20, HasTokenData: true,
@@ -156,6 +156,17 @@ func TestSQLiteFactsAndPostgresLiveUsageParity(t *testing.T) {
 	require.Equal(t, localWithoutBreakdown, remoteWithoutBreakdown,
 		"cross-backend session result without breakdown")
 	requireCompleteUsageParity(t, local, remote, filter)
+
+	breakdownFilter := filter
+	breakdownFilter.Breakdowns = true
+	localWithBreakdowns := captureUsageParitySnapshot(t, local, breakdownFilter)
+	remoteWithBreakdowns := captureUsageParitySnapshot(t, remote, breakdownFilter)
+	require.NotEmpty(t, localWithBreakdowns.Daily.ProjectBreakdowns)
+	require.NotEmpty(t, localWithBreakdowns.Daily.AgentBreakdowns)
+	require.NotEmpty(t, remoteWithBreakdowns.Daily.ProjectBreakdowns)
+	require.NotEmpty(t, remoteWithBreakdowns.Daily.AgentBreakdowns)
+	require.Equal(t, localWithBreakdowns, remoteWithBreakdowns,
+		"cross-backend daily breakdown result")
 }
 
 func requireCompleteUsageParity(
@@ -204,7 +215,7 @@ func seedUsageParityFixture(t testing.TB, local *db.DB) {
 		usageParitySessionFixture("snapshot-winner", "project-b", "claude", "2026-08-12T10:01:00Z", 10, 20),
 		usageParitySessionFixture("reported", "project-c", "hermes", "2026-08-12T11:00:00Z", 5, 30),
 		usageParitySessionFixture("blank-timestamp", "project-d", "claude", "2026-08-12T12:00:00Z", 3, 7),
-		usageParitySessionFixture("activity-only", "project-e", "claude", "2026-08-12T13:00:00Z", 0, 0),
+		usageParitySessionFixture("activity-only", "project-e", "claude", "2026-07-20T13:00:00Z", 0, 0),
 	}
 	for i := range sessions {
 		require.NoError(t, local.UpsertSession(sessions[i]),
@@ -232,7 +243,8 @@ func seedUsageParityFixture(t testing.TB, local *db.DB) {
 		},
 		{
 			SessionID: "activity-only", Ordinal: 0, Role: "assistant",
-			Timestamp: "2026-08-12T13:01:00Z", Model: "model-activity",
+			Timestamp: "2026-07-20T13:01:00Z", Model: "model-activity",
+			TokenUsage: json.RawMessage(`{"input_tokens":4,"output_tokens":2}`),
 		},
 	}), "seed messages")
 

--- a/internal/postgres/usage_facts_parity_pgtest_test.go
+++ b/internal/postgres/usage_facts_parity_pgtest_test.go
@@ -154,7 +154,7 @@ func requireCompleteUsageParity(
 	require.Equal(t, localSession, remoteSession, "complete session result")
 }
 
-func seedUsageParityFixture(t *testing.T, local *db.DB) {
+func seedUsageParityFixture(t testing.TB, local *db.DB) {
 	t.Helper()
 	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{
 		{

--- a/internal/postgres/usage_facts_parity_pgtest_test.go
+++ b/internal/postgres/usage_facts_parity_pgtest_test.go
@@ -145,6 +145,16 @@ func TestSQLiteFactsAndPostgresLiveUsageParity(t *testing.T) {
 	require.Equal(t, want, localGot, "SQLite facts result")
 	require.Equal(t, want, remoteGot, "PostgreSQL live result")
 	require.Equal(t, localGot, remoteGot, "cross-backend result")
+	wantWithoutBreakdown := want.Session
+	wantWithoutBreakdown.Breakdown = nil
+	localWithoutBreakdown := captureUsageParitySession(t, local, false)
+	remoteWithoutBreakdown := captureUsageParitySession(t, remote, false)
+	require.Equal(t, wantWithoutBreakdown, localWithoutBreakdown,
+		"SQLite session result without breakdown")
+	require.Equal(t, wantWithoutBreakdown, remoteWithoutBreakdown,
+		"PostgreSQL session result without breakdown")
+	require.Equal(t, localWithoutBreakdown, remoteWithoutBreakdown,
+		"cross-backend session result without breakdown")
 	requireCompleteUsageParity(t, local, remote, filter)
 }
 
@@ -168,6 +178,10 @@ func requireCompleteUsageParity(
 	remoteSession, err := remote.GetSessionUsage(ctx, "snapshot-winner", true)
 	require.NoError(t, err)
 	require.Equal(t, localSession, remoteSession, "complete session result")
+	localWithoutBreakdown := captureUsageParitySession(t, local, false)
+	remoteWithoutBreakdown := captureUsageParitySession(t, remote, false)
+	require.Equal(t, localWithoutBreakdown, remoteWithoutBreakdown,
+		"complete session result without breakdown")
 }
 
 func seedUsageParityFixture(t testing.TB, local *db.DB) {
@@ -255,9 +269,7 @@ func captureUsageParitySnapshot(
 	require.NoError(t, err, "usage session counts")
 	matching, err := store.GetUsageMatchingSessionCount(ctx, filter)
 	require.NoError(t, err, "matching session count")
-	session, err := store.GetSessionUsage(ctx, "snapshot-winner", true)
-	require.NoError(t, err, "session usage")
-	require.NotNil(t, session, "session usage result")
+	session := captureUsageParitySession(t, store, true)
 
 	out := usageParitySnapshot{
 		Daily: usageParityDaily{
@@ -272,16 +284,7 @@ func captureUsageParitySnapshot(
 			},
 		},
 		Counts: counts, MatchingSessionCount: matching,
-		Session: usageParitySession{
-			SessionID:         session.SessionID,
-			TotalOutputTokens: session.TotalOutputTokens,
-			PeakContextTokens: session.PeakContextTokens,
-			HasTokenData:      session.HasTokenData,
-			CostMicrodollars:  session.Cost.Microdollars,
-			HasCost:           session.HasCost, Models: session.Models,
-			UnpricedModels: session.UnpricedModels,
-			BreakdownCount: session.BreakdownCount,
-		},
+		Session: session,
 	}
 	for _, day := range daily.Daily {
 		out.Daily.Dates = append(out.Daily.Dates, day.Date)
@@ -313,8 +316,31 @@ func captureUsageParitySnapshot(
 			CostMicrodollars: entry.Cost.Microdollars,
 		})
 	}
+	return out
+}
+
+func captureUsageParitySession(
+	t *testing.T, store db.Store, includeBreakdown bool,
+) usageParitySession {
+	t.Helper()
+	session, err := store.GetSessionUsage(
+		context.Background(), "snapshot-winner", includeBreakdown)
+	require.NoError(t, err, "session usage")
+	require.NotNil(t, session, "session usage result")
+
+	out := usageParitySession{
+		SessionID:         session.SessionID,
+		TotalOutputTokens: session.TotalOutputTokens,
+		PeakContextTokens: session.PeakContextTokens,
+		HasTokenData:      session.HasTokenData,
+		CostMicrodollars:  session.Cost.Microdollars,
+		HasCost:           session.HasCost,
+		Models:            session.Models,
+		UnpricedModels:    session.UnpricedModels,
+		BreakdownCount:    session.BreakdownCount,
+	}
 	for _, entry := range session.Breakdown {
-		out.Session.Breakdown = append(out.Session.Breakdown, usageParityBreakdown{
+		out.Breakdown = append(out.Breakdown, usageParityBreakdown{
 			Source: entry.Source, Timestamp: entry.Timestamp, Model: entry.Model,
 			InputTokens: entry.InputTokens, OutputTokens: entry.OutputTokens,
 			CostMicrodollars: entry.Cost.Microdollars, HasCost: entry.HasCost,

--- a/internal/postgres/usage_facts_parity_pgtest_test.go
+++ b/internal/postgres/usage_facts_parity_pgtest_test.go
@@ -171,6 +171,76 @@ func TestSQLiteFactsAndPostgresLiveUsageParity(t *testing.T) {
 		"cross-backend daily breakdown result")
 }
 
+func TestPGUsageFractionalMicrodollarRoundingParity(t *testing.T) {
+	const schema = "agentsview_usage_fractional_rounding_test"
+	pgURL := testPGURL(t)
+	cleanNamedPGSchema(t, pgURL, schema)
+	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
+
+	local := testDB(t)
+	seedUsageParityFixture(t, local)
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern: "model-fractional",
+		InputPerMTok: money.Money{Microdollars: 500_000},
+	}}))
+	startedAt := "2026-08-12T13:00:00Z"
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID: "fractional-rounding", Project: "project-rounding",
+		Machine: "parity-machine", Agent: "claude", StartedAt: &startedAt,
+		MessageCount: 2, UserMessageCount: 1,
+	}))
+	require.NoError(t, local.InsertMessages([]db.Message{
+		{
+			SessionID: "fractional-rounding", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-12T13:01:00Z", Model: "model-fractional",
+			TokenUsage:      json.RawMessage(`{"input_tokens":1,"output_tokens":0}`),
+			ClaudeMessageID: "fractional-message-0", ClaudeRequestID: "fractional-request-0",
+		},
+		{
+			SessionID: "fractional-rounding", Ordinal: 1, Role: "assistant",
+			Timestamp: "2026-08-12T13:02:00Z", Model: "model-fractional",
+			TokenUsage:      json.RawMessage(`{"input_tokens":1,"output_tokens":0}`),
+			ClaudeMessageID: "fractional-message-1", ClaudeRequestID: "fractional-request-1",
+		},
+	}))
+
+	syncer, err := New(pgURL, schema, local, "parity-machine", true, SyncOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, syncer.Close()) })
+	_, err = syncer.Push(t.Context(), false, nil)
+	require.NoError(t, err)
+	remote, err := NewStore(pgURL, schema, true)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, remote.Close()) })
+
+	filter := db.UsageFilter{From: "2026-08-12", To: "2026-08-12", Timezone: "UTC"}
+	for _, backend := range []struct {
+		name  string
+		store db.Store
+	}{
+		{name: "sqlite", store: local},
+		{name: "postgres", store: remote},
+	} {
+		t.Run(backend.name, func(t *testing.T) {
+			usage, err := backend.store.GetSessionUsage(
+				t.Context(), "fractional-rounding", true)
+			require.NoError(t, err)
+			require.NotNil(t, usage)
+			require.Equal(t, int64(2), usage.Cost.Microdollars)
+			require.True(t, usage.HasCost)
+			require.Len(t, usage.Breakdown, 2)
+			for _, row := range usage.Breakdown {
+				require.Equal(t, 1, row.InputTokens)
+				require.Equal(t, int64(1), row.Cost.Microdollars)
+			}
+			daily, err := backend.store.GetDailyUsage(t.Context(), filter)
+			require.NoError(t, err)
+			require.Equal(t, 59, daily.Totals.InputTokens)
+			require.Equal(t, int64(260_042), daily.Totals.TotalCost.Microdollars)
+		})
+	}
+}
+
 func requireCompleteUsageParity(
 	t testing.TB, local, remote db.Store, filter db.UsageFilter,
 ) {

--- a/internal/postgres/usage_facts_parity_pgtest_test.go
+++ b/internal/postgres/usage_facts_parity_pgtest_test.go
@@ -260,6 +260,7 @@ func seedUsageParityFixture(t testing.TB, local *db.DB) {
 		usageParitySessionFixture("reported", "project-c", "hermes", "2026-08-12T11:00:00Z", 5, 30),
 		usageParitySessionFixture("blank-timestamp", "project-d", "claude", "2026-08-12T12:00:00Z", 3, 7),
 		usageParitySessionFixture("activity-only", "project-e", "claude", "2026-07-20T13:00:00Z", 0, 0),
+		usageParitySessionFixture("historical-usage", "project-f", "claude", "2026-07-20T13:02:00Z", 4, 6),
 	}
 	for i := range sessions {
 		require.NoError(t, local.UpsertSession(sessions[i]),
@@ -288,7 +289,11 @@ func seedUsageParityFixture(t testing.TB, local *db.DB) {
 		{
 			SessionID: "activity-only", Ordinal: 0, Role: "assistant",
 			Timestamp: "2026-07-20T13:01:00Z", Model: "model-activity",
-			TokenUsage: json.RawMessage(`{"input_tokens":4,"output_tokens":2}`),
+		},
+		{
+			SessionID: "historical-usage", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-07-20T13:02:00Z", Model: "model-priced",
+			TokenUsage: json.RawMessage(`{"input_tokens":6,"output_tokens":4}`),
 		},
 	}), "seed messages")
 

--- a/internal/postgres/usage_facts_parity_pgtest_test.go
+++ b/internal/postgres/usage_facts_parity_pgtest_test.go
@@ -31,6 +31,8 @@ type usageParityDaily struct {
 	CostMicrodollars    int64
 	Models              []string
 	SessionCounts       db.UsageSessionCounts
+	ProjectBreakdowns   []usageParityProjectBreakdown
+	AgentBreakdowns     []usageParityAgentBreakdown
 }
 
 type usageParityTopSession struct {
@@ -62,6 +64,20 @@ type usageParityBreakdown struct {
 	OutputTokens     int
 	CostMicrodollars int64
 	HasCost          bool
+}
+
+type usageParityProjectBreakdown struct {
+	ProjectKey, Project                  string
+	InputTokens, OutputTokens            int
+	CacheCreationTokens, CacheReadTokens int
+	CostMicrodollars                     int64
+}
+
+type usageParityAgentBreakdown struct {
+	Agent                                string
+	InputTokens, OutputTokens            int
+	CacheCreationTokens, CacheReadTokens int
+	CostMicrodollars                     int64
 }
 
 func TestSQLiteFactsAndPostgresLiveUsageParity(t *testing.T) {
@@ -270,6 +286,24 @@ func captureUsageParitySnapshot(
 	for _, day := range daily.Daily {
 		out.Daily.Dates = append(out.Daily.Dates, day.Date)
 		out.Daily.Models = append(out.Daily.Models, day.ModelsUsed...)
+		for _, breakdown := range day.ProjectBreakdowns {
+			out.Daily.ProjectBreakdowns = append(out.Daily.ProjectBreakdowns, usageParityProjectBreakdown{
+				ProjectKey: breakdown.ProjectKey, Project: breakdown.Project,
+				InputTokens: breakdown.InputTokens, OutputTokens: breakdown.OutputTokens,
+				CacheCreationTokens: breakdown.CacheCreationTokens,
+				CacheReadTokens:     breakdown.CacheReadTokens,
+				CostMicrodollars:    breakdown.Cost.Microdollars,
+			})
+		}
+		for _, breakdown := range day.AgentBreakdowns {
+			out.Daily.AgentBreakdowns = append(out.Daily.AgentBreakdowns, usageParityAgentBreakdown{
+				Agent: breakdown.Agent, InputTokens: breakdown.InputTokens,
+				OutputTokens:        breakdown.OutputTokens,
+				CacheCreationTokens: breakdown.CacheCreationTokens,
+				CacheReadTokens:     breakdown.CacheReadTokens,
+				CostMicrodollars:    breakdown.Cost.Microdollars,
+			})
+		}
 	}
 	sort.Strings(out.Daily.Models)
 	for _, entry := range top {


### PR DESCRIPTION
PostgreSQL still serves usage analytics from live message and usage-event queries, while SQLite has a normalized facts path. The repository has no PostgreSQL-specific benchmark for the five public usage methods or their refresh cost, so the query-shape choice in issue #1451 lacks a reproducible baseline.

This adds an opt-in PostgreSQL 16 benchmark substrate covering varied read windows, all five usage methods, breakdowns, complete SQLite/PostgreSQL result checks before timing, an initial full push into an initialized empty schema, a fixed-cardinality one-message delta, catalog probes, eligible usage input counts, token-usage bytes, allocations, and the existing parity fixture. It records the constraints for a later optimization while leaving production queries, schemas, pricing, and public results unchanged. The benchmark remains outside the normal CI bench gate because it requires Docker.

Refs #1451
