### PR TITLE
fix(parser): recover Antigravity CLI cwd

### DIFF
--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1281,7 +1281,7 @@ func TestCollectWatchRootsUsesGeminiProviderMetadataRoot(t *testing.T) {
 
 func TestCollectWatchRootsUsesAntigravityCLIHistoryRoot(t *testing.T) {
 	root := t.TempDir()
-	for _, subdir := range []string{"brain", "conversations", "implicit"} {
+	for _, subdir := range []string{"brain", "cache", "conversations", "implicit"} {
 		require.NoError(t, os.Mkdir(filepath.Join(root, subdir), 0o755))
 	}
 	cfg := config.Config{
@@ -1296,6 +1296,9 @@ func TestCollectWatchRootsUsesAntigravityCLIHistoryRoot(t *testing.T) {
 	historyRoot, ok := findCollectedWatchRoot(roots, root)
 	require.True(t, ok, "antigravity cli history.jsonl root not collected")
 	assert.False(t, historyRoot.recursive)
+	cache, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cache"))
+	require.True(t, ok, "antigravity cli workspace cache root not collected")
+	assert.False(t, cache.recursive)
 	conversations, ok := findCollectedWatchRoot(
 		roots, filepath.Join(root, "conversations"),
 	)

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1798,7 +1798,15 @@ add an archived or maintained mirror without replacing the original identity.
   provider USD cost is consumed.
 - **Agentsview:** `internal/parser/antigravity_cli.go`,
   `internal/parser/antigravity_crypto.go`, and
-  `internal/parser/antigravity_cli_provider.go`.
+  `internal/parser/antigravity_cli_provider.go`. The CLI `history.jsonl`
+  `workspace` value and the current CLI's `cache/last_conversations.json`
+  workspace-to-conversation mapping are authoritative session CWD sources when
+  the workspace is an absolute path. Agentsview prefers the first valid
+  current-cache folder for an exact conversation ID, retains the strict
+  prompt/time fallback for older untagged history rows, and leaves CWD empty
+  when the value is missing or relative. The exact absolute workspace remains
+  the CWD. The project label is derived from the path text without probing the
+  recorded folder when filesystem discovery is disabled.
 
 ## iFlow CLI (`iflow`)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -446,7 +446,11 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // the correction.)
 // (95: Posit Assistant provider identity. Existing messages and usage events
 // need re-parsing so managed Posit AI and BYO provider rows price separately.)
-const dataVersion = 95
+// (96: Antigravity CLI sessions recover CWD from history and the exact
+// cache/last_conversations.json workspace mapping. Existing rows need
+// re-parsing to receive the exact approved workspace and prefer linked Git
+// identity when normalizing worktree project labels.)
+const dataVersion = 96
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1047,8 +1047,13 @@ func TestCurrentDataVersionDevinMessageNodeTokenUsage(t *testing.T) {
 }
 
 func TestCurrentDataVersionPositAssistantProviderIdentity(t *testing.T) {
-	assert.Equal(t, 95, CurrentDataVersion(),
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 95,
 		"Posit Assistant provider identity requires re-parsing usage rows")
+}
+
+func TestCurrentDataVersionAntigravityCLICwdAndWorktreeProject(t *testing.T) {
+	assert.Equal(t, 96, CurrentDataVersion(),
+		"Antigravity CLI cwd and worktree project recovery require a sequential backfill")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -81,7 +82,7 @@ type AntigravityCLIParseStatus struct {
 // package-level ParseAntigravityCLISessionWithStatus entrypoint was folded onto
 // the provider.
 func (p *antigravityCLIProvider) parseSessionWithStatus(
-	ctx context.Context, path, project, machine string,
+	ctx context.Context, path, project, cwd, machine string,
 ) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, AntigravityCLIParseStatus, error) {
 	var status AntigravityCLIParseStatus
 	info, err := os.Stat(path)
@@ -239,18 +240,25 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 		messages[i].Ordinal = i
 	}
 
-	if project == "" {
-		project = inferAntigravityProject(
-			filepath.Join(root, "history.jsonl"), id,
-		)
-		if project == "" {
-			project = inferAntigravityProjectFromHistoryFallback(
-				filepath.Join(root, "history.jsonl"), messages, info.ModTime(),
+	historyPath := filepath.Join(root, "history.jsonl")
+	if cwd == "" {
+		workspace := buildAntigravityCLIProjectMap(root)[id]
+		if workspace == "" {
+			workspace = inferAntigravityProjectFromHistoryFallback(
+				historyPath, messages, info.ModTime(),
 			)
 		}
+		cwd = normalizeAntigravityCLIWorkspace(workspace)
+		if project == "" {
+			project = workspace
+		}
+	}
+	if project == "" {
+		project = cwd
 	}
 	// project is the raw workspace filesystem path recorded by history.jsonl.
-	// Run it through the shared cwd normalizer so sessions from different
+	// Keep an absolute workspace unchanged as Cwd, but run the project through
+	// the shared cwd normalizer so sessions from different
 	// git worktrees of the same repo resolve to one project, matching how
 	// the Codex and Claude providers normalize their own cwd hints. A
 	// path-rewritten parse (remote sync) describes another machine's
@@ -312,6 +320,7 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 	sess := &ParsedSession{
 		ID:                 antigravityCLIIDPrefix + storageID,
 		Project:            project,
+		Cwd:                cwd,
 		Machine:            machine,
 		Agent:              AgentAntigravityCLI,
 		FirstMessage:       firstMessage,
@@ -347,6 +356,24 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 		return sess, nil, usageEvents, status, nil
 	}
 	return sess, messages, usageEvents, status, nil
+}
+
+func normalizeAntigravityCLIWorkspace(workspace string) string {
+	workspace = strings.TrimSpace(workspace)
+	if workspace == "" {
+		return ""
+	}
+	if strings.HasPrefix(workspace, "/") || strings.HasPrefix(workspace, `\\`) {
+		return workspace
+	}
+	if len(workspace) >= 3 && workspace[1] == ':' &&
+		(workspace[2] == '/' || workspace[2] == '\\') {
+		letter := workspace[0]
+		if letter >= 'A' && letter <= 'Z' || letter >= 'a' && letter <= 'z' {
+			return workspace
+		}
+	}
+	return ""
 }
 
 func loadAntigravityCLIDBSteps(
@@ -478,6 +505,41 @@ func hasDisplayableAntigravityCLITrajectoryMessage(
 // often it runs.
 var buildAntigravityProjectMap = antigravityProjectMapFromHistory
 
+func buildAntigravityCLIProjectMap(root string) map[string]string {
+	out := buildAntigravityProjectMap(filepath.Join(root, "history.jsonl"))
+	// The current cache is newer than history and wins for matching IDs.
+	maps.Copy(out, antigravityProjectMapFromLastConversations(
+		filepath.Join(root, "cache", "last_conversations.json"),
+	))
+	return out
+}
+
+// antigravityProjectMapFromLastConversations reverses the current CLI cache's
+// workspace -> conversationId object into the provider's
+// conversationId -> workspace lookup shape.
+func antigravityProjectMapFromLastConversations(path string) map[string]string {
+	out := make(map[string]string)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	root := gjson.ParseBytes(raw)
+	if !root.IsObject() {
+		return out
+	}
+	root.ForEach(func(workspace, conversationID gjson.Result) bool {
+		id := strings.TrimSpace(conversationID.String())
+		path := strings.TrimSpace(workspace.String())
+		if id != "" && path != "" {
+			if _, exists := out[id]; !exists {
+				out[id] = path
+			}
+		}
+		return true
+	})
+	return out
+}
+
 // antigravityProjectMapFromHistory reads history.jsonl and returns a
 // map of conversationId -> workspace path.
 func antigravityProjectMapFromHistory(path string) map[string]string {
@@ -501,11 +563,6 @@ func antigravityProjectMapFromHistory(path string) map[string]string {
 		}
 	}
 	return out
-}
-
-func inferAntigravityProject(path, id string) string {
-	m := buildAntigravityProjectMap(path)
-	return m[id]
 }
 
 func inferAntigravityProjectFromHistoryFallback(
@@ -740,17 +797,23 @@ func decryptAntigravityCLITranscript(
 // AntigravityCLIFileInfo returns a fake os.FileInfo whose size and
 // mtime combine the session file with everything else the parser
 // renders: SQLite WAL/SHM siblings, the .trajectory.json sidecar,
-// history.jsonl, and the brain/<id> artifacts. History stays here while
-// legacy sync skip checks use this effective file info; provider hashes
-// additionally scope tagged history rows by conversation ID.
+// history.jsonl, cache/last_conversations.json, and the brain/<id> artifacts.
+// History and the workspace cache stay here while legacy sync skip checks use
+// this effective file info; provider hashes additionally scope tagged history
+// rows and workspace values by conversation ID.
 func AntigravityCLIFileInfo(path string) (os.FileInfo, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
 	}
+	root := filepath.Dir(filepath.Dir(path))
+	companions := append(
+		antigravityCLICompanionPaths(path),
+		filepath.Join(root, "cache", "last_conversations.json"),
+	)
 	return antigravityCLICombinedFileInfo(
 		info,
-		antigravityCLICompanionPaths(path)...,
+		companions...,
 	), nil
 }
 
@@ -878,16 +941,29 @@ func antigravityCompositeHashWithExtra(
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-func antigravityCLICompositeHash(path, id string) (string, error) {
+func antigravityCLICompositeHash(path, id, workspace string) (string, error) {
 	return antigravityCompositeHashWithExtra(
 		path,
 		antigravityCLIProviderCompanionPaths(path),
 		func(h interface{ Write([]byte) (int, error) }) error {
-			return addAntigravityCLIHistoryFingerprintPart(
+			if err := addAntigravityCLIHistoryFingerprintPart(
 				h,
 				filepath.Join(filepath.Dir(filepath.Dir(path)), "history.jsonl"),
 				strings.TrimPrefix(id, antigravityImplicitTag),
-			)
+			); err != nil {
+				return err
+			}
+			if workspace == "" {
+				return nil
+			}
+			if _, err := fmt.Fprintf(h, "workspace\x00%d\x00", len(workspace)); err != nil {
+				return err
+			}
+			if _, err := h.Write([]byte(workspace)); err != nil {
+				return err
+			}
+			_, err := h.Write([]byte{0})
+			return err
 		},
 	)
 }

--- a/internal/parser/antigravity_cli_provider.go
+++ b/internal/parser/antigravity_cli_provider.go
@@ -34,7 +34,7 @@ func (f antigravityCLIProviderFactory) NewProvider(cfg ProviderConfig) Provider 
 		Def:     cloneAgentDef(f.def),
 		Caps:    antigravityCLIProviderCapabilities(),
 		Config:  cfg,
-		sources: newAntigravityCLISourceSet(cfg.Roots),
+		sources: newAntigravityCLISourceSet(cfg),
 	}
 }
 
@@ -151,14 +151,23 @@ type antigravityCLISource struct {
 }
 
 type antigravityCLISourceSet struct {
-	roots []string
+	roots       []string
+	remote      bool
+	remoteRoots map[string]bool
 }
 
-func newAntigravityCLISourceSet(roots []string) antigravityCLISourceSet {
-	roots = cleanJSONLRoots(roots)
-	return antigravityCLISourceSet{
-		roots: roots,
+func newAntigravityCLISourceSet(cfg ProviderConfig) antigravityCLISourceSet {
+	s := antigravityCLISourceSet{
+		roots:       cleanJSONLRoots(cfg.Roots),
+		remote:      cfg.PathRewriter != nil,
+		remoteRoots: make(map[string]bool),
 	}
+	for root, machine := range cfg.SourceMachines {
+		if machine != "" && machine != cfg.Machine {
+			s.remoteRoots[filepath.Clean(root)] = true
+		}
+	}
+	return s
 }
 
 func (s antigravityCLISourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
@@ -614,7 +623,9 @@ func (s antigravityCLISourceSet) newSourceRef(
 ) SourceRef {
 	cwd := normalizeAntigravityCLIWorkspace(workspace)
 	resolution := SourceCwdResolution{}
-	if workspace != "" && cwd == "" {
+	if s.remote || s.remoteRoot(root) {
+		resolution.State = SourceCwdRemote
+	} else if workspace != "" && cwd == "" {
 		resolution.State = SourceCwdAmbiguous
 	} else if cwd != "" {
 		resolution = SourceCwdResolution{State: SourceCwdResolved, Path: cwd}
@@ -634,6 +645,19 @@ func (s antigravityCLISourceSet) newSourceRef(
 			Workspace: workspace,
 		},
 	}
+}
+
+func (s antigravityCLISourceSet) remoteRoot(root string) bool {
+	clean := filepath.Clean(root)
+	if s.remoteRoots[clean] {
+		return true
+	}
+	for configured := range s.remoteRoots {
+		if samePath(configured, clean) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s antigravityCLISourceSet) projectForID(root, id string) string {

--- a/internal/parser/antigravity_cli_provider.go
+++ b/internal/parser/antigravity_cli_provider.go
@@ -99,10 +99,15 @@ func (p *antigravityCLIProvider) Parse(
 		return ParseOutcome{}, fmt.Errorf("stat %s: %w", src.Path, err)
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
+	cwd := ""
+	if req.Source.CwdResolution.State == SourceCwdResolved {
+		cwd = req.Source.CwdResolution.Path
+	}
 	sess, msgs, usageEvents, status, err := p.parseSessionWithStatus(
 		ctx,
 		src.Path,
 		req.Source.ProjectHint,
+		cwd,
 		machine,
 	)
 	if err != nil {
@@ -138,10 +143,11 @@ func (p *antigravityCLIProvider) Parse(
 }
 
 type antigravityCLISource struct {
-	Root    string
-	Path    string
-	ID      string
-	Project string
+	Root      string
+	Path      string
+	ID        string
+	Project   string
+	Workspace string
 }
 
 type antigravityCLISourceSet struct {
@@ -192,6 +198,13 @@ func (s antigravityCLISourceSet) DiscoverEach(ctx context.Context, yield func(So
 		); err != nil {
 			return errors.Join(err, projects.close())
 		}
+		for id, workspace := range antigravityProjectMapFromLastConversations(
+			filepath.Join(root, "cache", "last_conversations.json"),
+		) {
+			if err := projects.put(ctx, id, workspace, true); err != nil {
+				return errors.Join(err, projects.close())
+			}
+		}
 		for _, subdir := range []string{"conversations", "implicit"} {
 			dir := filepath.Join(root, subdir)
 			err := streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
@@ -211,7 +224,7 @@ func (s antigravityCLISourceSet) DiscoverEach(ctx context.Context, yield func(So
 				if err != nil {
 					return err
 				}
-				return yield(s.newSourceRef(root, path, rawID, project))
+				return yield(s.newSourceRef(root, path, rawID, project, project))
 			})
 			if err != nil {
 				return errors.Join(err, projects.close())
@@ -236,18 +249,15 @@ func (s antigravityCLISourceSet) discoverSessions(root string) []DiscoveredFile 
 }
 
 // discoverSessionsAndProjects enumerates sessions and also returns the project
-// map it built from history.jsonl, so callers can thread the same map into
-// per-source resolution instead of rebuilding it (the map is a full read and
-// per-line parse of history.jsonl).
+// map it built from the current cache plus legacy history, so callers can
+// thread the same map into per-source resolution instead of rebuilding it.
 func (s antigravityCLISourceSet) discoverSessionsAndProjects(
 	root string,
 ) ([]DiscoveredFile, map[string]string) {
 	if root == "" {
 		return nil, nil
 	}
-	projects := buildAntigravityProjectMap(
-		filepath.Join(root, "history.jsonl"),
-	)
+	projects := buildAntigravityCLIProjectMap(root)
 	var files []DiscoveredFile
 	for _, sub := range []string{"conversations", "implicit"} {
 		dir := filepath.Join(root, sub)
@@ -319,7 +329,7 @@ func (s antigravityCLISourceSet) findSourceFile(root, id string) string {
 }
 
 func (s antigravityCLISourceSet) WatchPlan(context.Context) (WatchPlan, error) {
-	roots := make([]WatchRoot, 0, len(s.roots)*4)
+	roots := make([]WatchRoot, 0, len(s.roots)*5)
 	for _, root := range s.roots {
 		roots = append(roots,
 			WatchRoot{
@@ -339,6 +349,12 @@ func (s antigravityCLISourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 				Recursive:    false,
 				IncludeGlobs: []string{"history.jsonl"},
 				DebounceKey:  string(AgentAntigravityCLI) + ":history:" + root,
+			},
+			WatchRoot{
+				Path:         filepath.Join(root, "cache"),
+				Recursive:    false,
+				IncludeGlobs: []string{"last_conversations.json"},
+				DebounceKey:  string(AgentAntigravityCLI) + ":workspace-cache:" + root,
 			},
 			WatchRoot{
 				Path:         filepath.Join(root, "implicit"),
@@ -405,9 +421,7 @@ func (s antigravityCLISourceSet) FindSource(
 		project := ""
 		id := strings.TrimPrefix(req.RawSessionID, antigravityImplicitTag)
 		if projects[root] == nil {
-			projects[root] = buildAntigravityProjectMap(
-				filepath.Join(root, "history.jsonl"),
-			)
+			projects[root] = buildAntigravityCLIProjectMap(root)
 		}
 		project = projects[root][id]
 		if source, ok := s.sourceRef(root, path, project, false); ok {
@@ -436,7 +450,7 @@ func (s antigravityCLISourceSet) Fingerprint(
 		}
 		return SourceFingerprint{}, err
 	}
-	hash, err := antigravityCLICompositeHash(src.Path, src.ID)
+	hash, err := antigravityCLICompositeHash(src.Path, src.ID, src.Workspace)
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
@@ -477,6 +491,9 @@ func (s antigravityCLISourceSet) sourcesForChangedPath(
 	root = filepath.Clean(root)
 	path := filepath.Clean(req.Path)
 	if samePath(path, filepath.Join(root, "history.jsonl")) {
+		return s.sourcesForHistoryChange(root, req)
+	}
+	if samePath(path, filepath.Join(root, "cache", "last_conversations.json")) {
 		return s.sourcesForHistoryChange(root, req)
 	}
 	if sourcePath, id, ok := antigravityCLISourcePathForEvent(root, path); ok {
@@ -561,10 +578,11 @@ func (s antigravityCLISourceSet) sourceRef(
 	if !allowMissing && !IsRegularFile(path) {
 		return SourceRef{}, false
 	}
+	workspace := s.projectForID(root, strings.TrimPrefix(id, antigravityImplicitTag))
 	if project == "" {
-		project = s.projectForID(root, strings.TrimPrefix(id, antigravityImplicitTag))
+		project = workspace
 	}
-	return s.newSourceRef(root, path, id, project), true
+	return s.newSourceRef(root, path, id, project, workspace), true
 }
 
 // sourceRefWithProjects is sourceRef but resolves a missing project from a
@@ -584,32 +602,42 @@ func (s antigravityCLISourceSet) sourceRefWithProjects(
 	if !allowMissing && !IsRegularFile(path) {
 		return SourceRef{}, false
 	}
+	workspace := projects[strings.TrimPrefix(id, antigravityImplicitTag)]
 	if project == "" {
-		project = projects[strings.TrimPrefix(id, antigravityImplicitTag)]
+		project = workspace
 	}
-	return s.newSourceRef(root, path, id, project), true
+	return s.newSourceRef(root, path, id, project, workspace), true
 }
 
 func (s antigravityCLISourceSet) newSourceRef(
-	root, path, id, project string,
+	root, path, id, project, workspace string,
 ) SourceRef {
+	cwd := normalizeAntigravityCLIWorkspace(workspace)
+	resolution := SourceCwdResolution{}
+	if workspace != "" && cwd == "" {
+		resolution.State = SourceCwdAmbiguous
+	} else if cwd != "" {
+		resolution = SourceCwdResolution{State: SourceCwdResolved, Path: cwd}
+	}
 	return SourceRef{
 		Provider:       AgentAntigravityCLI,
 		Key:            id,
 		DisplayPath:    path,
 		FingerprintKey: path,
 		ProjectHint:    project,
+		CwdResolution:  resolution,
 		Opaque: antigravityCLISource{
-			Root:    root,
-			Path:    path,
-			ID:      id,
-			Project: project,
+			Root:      root,
+			Path:      path,
+			ID:        id,
+			Project:   project,
+			Workspace: workspace,
 		},
 	}
 }
 
 func (s antigravityCLISourceSet) projectForID(root, id string) string {
-	return buildAntigravityProjectMap(filepath.Join(root, "history.jsonl"))[id]
+	return buildAntigravityCLIProjectMap(root)[id]
 }
 
 func antigravityCLISourcePathForEvent(root, path string) (string, string, bool) {
@@ -704,7 +732,7 @@ func antigravityCLISessionIDForPath(root, path string) (string, bool) {
 
 func antigravityCLIWatchRootMatches(root, watchRoot string) bool {
 	watchRoot = filepath.Clean(watchRoot)
-	for _, subdir := range []string{"brain", "conversations", "implicit"} {
+	for _, subdir := range []string{"brain", "cache", "conversations", "implicit"} {
 		if samePath(watchRoot, filepath.Join(root, subdir)) {
 			return true
 		}
@@ -720,6 +748,7 @@ func antigravityCLIProviderCapabilities() Capabilities {
 		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
+			Cwd:                  CapabilitySupported,
 			Thinking:             CapabilitySupported,
 			ToolCalls:            CapabilitySupported,
 			ToolResults:          CapabilitySupported,

--- a/internal/parser/antigravity_cli_provider.go
+++ b/internal/parser/antigravity_cli_provider.go
@@ -103,6 +103,9 @@ func (p *antigravityCLIProvider) Parse(
 	if req.Source.CwdResolution.State == SourceCwdResolved {
 		cwd = req.Source.CwdResolution.Path
 	}
+	if req.Source.CwdResolution.State == SourceCwdRemote {
+		ctx = WithoutFilesystemProjectDiscovery(ctx)
+	}
 	sess, msgs, usageEvents, status, err := p.parseSessionWithStatus(
 		ctx,
 		src.Path,

--- a/internal/parser/antigravity_provider_test.go
+++ b/internal/parser/antigravity_provider_test.go
@@ -327,6 +327,46 @@ func TestAntigravityCLIProviderUsesLastConversationsWorkspace(t *testing.T) {
 	assert.NotEqual(t, before.Hash, after.Hash)
 }
 
+func TestAntigravityCLIProviderMarksRemoteCwd(t *testing.T) {
+	tests := map[string]func(string) ProviderConfig{
+		"path rewriter": func(root string) ProviderConfig {
+			return ProviderConfig{
+				Roots:        []string{root},
+				Machine:      "localbox",
+				PathRewriter: func(path string) string { return "remote:" + path },
+			}
+		},
+		"foreign source machine": func(root string) ProviderConfig {
+			return ProviderConfig{
+				Roots:   []string{root},
+				Machine: "localbox",
+				SourceMachines: map[string]string{
+					root: "archivebox",
+				},
+			}
+		},
+	}
+
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			id := "44444444-5555-6666-7777-888888888888"
+			writeAntigravityCLIProviderFixture(t, root, id)
+
+			provider, ok := NewProvider(AgentAntigravityCLI, config(root))
+			require.True(t, ok)
+			source, ok, err := provider.FindSource(t.Context(), FindSourceRequest{
+				RawSessionID: id,
+			})
+			require.NoError(t, err)
+			require.True(t, ok)
+			assert.Equal(t, SourceCwdRemote, source.CwdResolution.State)
+			assert.Empty(t, source.CwdResolution.Path)
+			assert.Equal(t, "/tmp/db-proj", source.ProjectHint)
+		})
+	}
+}
+
 func TestAntigravityCLIProviderParseCanSkipRecordedWorkspaceDiscovery(t *testing.T) {
 	root := t.TempDir()
 	id := "44444444-5555-6666-7777-888888888888"

--- a/internal/parser/antigravity_provider_test.go
+++ b/internal/parser/antigravity_provider_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -194,7 +195,7 @@ func TestAntigravityCLIProviderSourceMethods(t *testing.T) {
 
 	plan, err := provider.WatchPlan(context.Background())
 	require.NoError(t, err)
-	require.Len(t, plan.Roots, 4)
+	require.Len(t, plan.Roots, 5)
 	assert.Equal(t, filepath.Join(root, "brain"), plan.Roots[0].Path)
 	assert.True(t, plan.Roots[0].Recursive)
 	assert.Equal(t, filepath.Join(root, "conversations"), plan.Roots[1].Path)
@@ -202,8 +203,11 @@ func TestAntigravityCLIProviderSourceMethods(t *testing.T) {
 	assert.Equal(t, root, plan.Roots[2].Path)
 	assert.False(t, plan.Roots[2].Recursive)
 	assert.Equal(t, []string{"history.jsonl"}, plan.Roots[2].IncludeGlobs)
-	assert.Equal(t, filepath.Join(root, "implicit"), plan.Roots[3].Path)
+	assert.Equal(t, filepath.Join(root, "cache"), plan.Roots[3].Path)
 	assert.False(t, plan.Roots[3].Recursive)
+	assert.Equal(t, []string{"last_conversations.json"}, plan.Roots[3].IncludeGlobs)
+	assert.Equal(t, filepath.Join(root, "implicit"), plan.Roots[4].Path)
+	assert.False(t, plan.Roots[4].Recursive)
 
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
@@ -275,6 +279,94 @@ func TestAntigravityCLIProviderSourceMethods(t *testing.T) {
 		filepath.Join(root, "conversations", otherID+".db"),
 		implicitPath,
 	)
+}
+
+func TestAntigravityCLIProviderUsesLastConversationsWorkspace(t *testing.T) {
+	root := t.TempDir()
+	id := "44444444-5555-6666-7777-888888888888"
+	writeAntigravityCLIProviderFixture(t, root, id)
+	cachePath := filepath.Join(root, "cache", "last_conversations.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cachePath), 0o755))
+	mustWrite(t, cachePath, []byte(`{"/tmp/cache-proj":"`+id+`"}`))
+
+	provider, ok := NewProvider(AgentAntigravityCLI, ProviderConfig{
+		Roots: []string{root}, Machine: "devbox",
+	})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 2)
+	conversation := discovered[0]
+	assert.Equal(t, "/tmp/cache-proj", conversation.ProjectHint)
+	assert.Equal(t, SourceCwdResolved, conversation.CwdResolution.State)
+	assert.Equal(t, "/tmp/cache-proj", conversation.CwdResolution.Path)
+	parsed, err := provider.Parse(context.Background(), ParseRequest{
+		Source: conversation, Machine: "devbox",
+	})
+	require.NoError(t, err)
+	require.Len(t, parsed.Results, 1)
+	assert.Equal(t, "cache_proj", parsed.Results[0].Result.Session.Project)
+	assert.Equal(t, "/tmp/cache-proj", parsed.Results[0].Result.Session.Cwd)
+	before, err := provider.Fingerprint(context.Background(), conversation)
+	require.NoError(t, err)
+
+	mustWrite(t, cachePath, []byte(`{"/tmp/cache-proj-2":"`+id+`"}`))
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(), ChangedPathRequest{
+			Path:      cachePath,
+			EventKind: "write",
+			WatchRoot: filepath.Join(root, "cache"),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 2)
+	conversation = changed[0]
+	assert.Equal(t, "/tmp/cache-proj-2", conversation.CwdResolution.Path)
+	after, err := provider.Fingerprint(context.Background(), conversation)
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Hash, after.Hash)
+}
+
+func TestAntigravityCLIProviderParseCanSkipRecordedWorkspaceDiscovery(t *testing.T) {
+	root := t.TempDir()
+	id := "44444444-5555-6666-7777-888888888888"
+	writeAntigravityCLIProviderFixture(t, root, id)
+
+	workspaceRoot := t.TempDir()
+	repository := filepath.Join(workspaceRoot, "outer-repository")
+	workspace := filepath.Join(repository, "recorded-project")
+	mustMkdir(t, filepath.Join(repository, ".git"))
+	mustMkdir(t, workspace)
+
+	cachePath := filepath.Join(root, "cache", "last_conversations.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cachePath), 0o755))
+	mustWrite(t, cachePath, []byte(fmt.Sprintf(`{%q:%q}`, workspace, id)))
+
+	provider, ok := NewProvider(AgentAntigravityCLI, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, ok, err := provider.FindSource(t.Context(), FindSourceRequest{RawSessionID: id})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ctx := WithoutFilesystemProjectDiscovery(t.Context())
+	parsed, err := provider.Parse(ctx, ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, parsed.Results, 1)
+	assert.Equal(t, "recorded_project", parsed.Results[0].Result.Session.Project)
+	assert.Equal(t, workspace, parsed.Results[0].Result.Session.Cwd)
+}
+
+func TestAntigravityCLIProviderDiscoverEachReportsHistoryReadError(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, "history.jsonl"))
+
+	provider, ok := NewProvider(AgentAntigravityCLI, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+
+	err := discoverer.DiscoverEach(t.Context(), func(SourceRef) error { return nil })
+	require.Error(t, err)
 }
 
 func TestAntigravityCLIProviderHistoryRemovalInvalidatesAllSources(t *testing.T) {

--- a/internal/parser/antigravity_provider_test.go
+++ b/internal/parser/antigravity_provider_test.go
@@ -367,6 +367,39 @@ func TestAntigravityCLIProviderMarksRemoteCwd(t *testing.T) {
 	}
 }
 
+func TestAntigravityCLIProviderForeignMachineSkipsLocalProjectDiscovery(t *testing.T) {
+	root := t.TempDir()
+	id := "44444444-5555-6666-7777-888888888888"
+	writeAntigravityCLIProviderFixture(t, root, id)
+
+	workspaceRoot := t.TempDir()
+	localRepo := filepath.Join(workspaceRoot, "conflicting-local-repo")
+	workspace := filepath.Join(localRepo, "recorded-project")
+	mustMkdir(t, filepath.Join(localRepo, ".git"))
+	mustMkdir(t, workspace)
+	cachePath := filepath.Join(root, "cache", "last_conversations.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cachePath), 0o755))
+	mustWrite(t, cachePath, []byte(fmt.Sprintf(`{%q:%q}`, workspace, id)))
+
+	provider, ok := NewProvider(AgentAntigravityCLI, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "localbox",
+		SourceMachines: map[string]string{
+			root: "archivebox",
+		},
+	})
+	require.True(t, ok)
+	source, ok, err := provider.FindSource(t.Context(), FindSourceRequest{
+		RawSessionID: id,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	parsed, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, parsed.Results, 1)
+	assert.Equal(t, "recorded_project", parsed.Results[0].Result.Session.Project)
+}
+
 func TestAntigravityCLIProviderParseCanSkipRecordedWorkspaceDiscovery(t *testing.T) {
 	root := t.TempDir()
 	id := "44444444-5555-6666-7777-888888888888"

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"database/sql"
@@ -93,7 +94,7 @@ func parseAntigravityCLITestSessionWithStatus(
 ) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, AntigravityCLIParseStatus, error) {
 	t.Helper()
 	return newAntigravityCLITestProvider(t).parseSessionWithStatus(
-		t.Context(), path, project, machine,
+		t.Context(), path, project, "", machine,
 	)
 }
 
@@ -358,6 +359,14 @@ func TestAntigravityCLIDiscoverAndParse(t *testing.T) {
 	require.Len(t, files, 1, "discover")
 	assert.Equal(t, "/tmp/proj", files[0].Project, "project")
 
+	provider := newAntigravityCLITestProvider(t, root)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, SourceCwdResolved, sources[0].CwdResolution.State)
+	assert.Equal(t, "/tmp/proj", sources[0].CwdResolution.Path)
+	assert.Equal(t, CapabilitySupported, provider.Capabilities().Content.Cwd)
+
 	// Find by id should locate the same .pb.
 	assert.Equal(t, files[0].Path, findAntigravityCLITestSourceFile(t, root, id), "find")
 
@@ -366,6 +375,7 @@ func TestAntigravityCLIDiscoverAndParse(t *testing.T) {
 	)
 	require.NoError(t, err, "parse")
 	assert.Equal(t, "antigravity-cli:"+id, sess.ID)
+	assert.Equal(t, "/tmp/proj", sess.Cwd)
 	// One user message from history + one assistant from brain.
 	require.Len(t, msgs, 2)
 	assert.Equal(t, RoleUser, msgs[0].Role)
@@ -409,6 +419,7 @@ func TestAntigravityCLIDiscoverAndParseDB(t *testing.T) {
 	assert.Equal(t, AgentAntigravityCLI, sess.Agent)
 	assert.Equal(t, dbPath, sess.File.Path)
 	assert.Equal(t, "db_proj", sess.Project)
+	assert.Equal(t, "/tmp/db-proj", sess.Cwd)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, RoleUser, msgs[0].Role)
 	assert.Equal(t, "db prompt fallback", msgs[0].Content)
@@ -433,10 +444,22 @@ func TestAntigravityCLIProjectFallbackPromptAndProximity(t *testing.T) {
 	mustWrite(t, filepath.Join(root, "history.jsonl"),
 		[]byte(`{"display":"  user prompt text goes here  ","timestamp":1779000010000,"workspace":"/tmp/fallback-proj"}`))
 
-	sess, msgs, err := parseAntigravityCLITestSession(t, dbPath, "", "m")
+	provider := newAntigravityCLITestProvider(t, root)
+	sources, err := provider.Discover(context.Background())
 	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, SourceCwdUnspecified, sources[0].CwdResolution.State)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:  sources[0],
+		Machine: "m",
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	sess := &outcome.Results[0].Result.Session
+	msgs := outcome.Results[0].Result.Messages
 	require.Len(t, msgs, 2)
-	assert.Equal(t, "fallback_proj", sess.Project, "should successfully fallback infer project")
+	assert.Equal(t, "fallback_proj", sess.Project, "should normalize the inferred project label")
+	assert.Equal(t, "/tmp/fallback-proj", sess.Cwd, "should successfully fallback infer cwd")
 }
 
 // TestAntigravityCLIParse_GroupsGitWorktreesUnderOneProject reproduces
@@ -532,7 +555,7 @@ func TestAntigravityCLIParse_RemoteParseSkipsLocalGitDiscovery(t *testing.T) {
 	sess, _, _, _, err := cp.parseSessionWithStatus(
 		t.Context(),
 		filepath.Join(cliRoot, "conversations", id+".db"),
-		worktree, "remote-host",
+		worktree, "", "remote-host",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, sess)
@@ -557,6 +580,7 @@ func TestAntigravityCLIProjectFallbackStrictWindow(t *testing.T) {
 	sess, _, err := parseAntigravityCLITestSession(t, dbPath, "", "m")
 	require.NoError(t, err)
 	assert.Empty(t, sess.Project, "should reject match outside 1-minute window")
+	assert.Empty(t, sess.Cwd, "should reject cwd outside 1-minute window")
 }
 
 func TestAntigravityCLIProjectFallbackAmbiguous(t *testing.T) {
@@ -577,6 +601,7 @@ func TestAntigravityCLIProjectFallbackAmbiguous(t *testing.T) {
 	sess, _, err := parseAntigravityCLITestSession(t, dbPath, "", "m")
 	require.NoError(t, err)
 	assert.Empty(t, sess.Project, "should reject ambiguous match with different workspaces at same time closeness")
+	assert.Empty(t, sess.Cwd, "should reject ambiguous cwd match")
 }
 
 func TestAntigravityCLIProjectFallbackShortPrompt(t *testing.T) {
@@ -596,6 +621,31 @@ func TestAntigravityCLIProjectFallbackShortPrompt(t *testing.T) {
 	sess, _, err := parseAntigravityCLITestSession(t, dbPath, "", "m")
 	require.NoError(t, err)
 	assert.Empty(t, sess.Project, "should reject matching short prompts")
+	assert.Empty(t, sess.Cwd, "should reject cwd from matching short prompts")
+}
+
+func TestAntigravityCLIRejectsRelativeWorkspaceAsCwd(t *testing.T) {
+	root := t.TempDir()
+	id := "b0b0b0b0-b1b1-b2b2-b3b3-b4b4b4b4b4b4"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustWrite(t, filepath.Join(root, "conversations", id+".pb"),
+		[]byte("encrypted-placeholder"))
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"relative workspace","timestamp":1779000000000,`+
+			`"workspace":"relative/project","conversationId":"`+id+`"}`))
+
+	provider := newAntigravityCLITestProvider(t, root)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, SourceCwdAmbiguous, sources[0].CwdResolution.State)
+	assert.Empty(t, sources[0].CwdResolution.Path)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Empty(t, outcome.Results[0].Result.Session.Cwd)
 }
 
 func createAntigravityOvershortPromptDB(t *testing.T, path string) {
@@ -683,6 +733,26 @@ func TestAntigravityCLIFileInfoIncludesHistoryForLegacySync(t *testing.T) {
 		assert.Equal(t, int64(len("pb")+len(history)), info.Size())
 		assert.Equal(t, late.UnixNano(), info.ModTime().UnixNano())
 	})
+}
+
+func TestAntigravityCLIFileInfoIncludesWorkspaceCacheMtime(t *testing.T) {
+	root := t.TempDir()
+	id := "14141414-2525-3636-4747-585858585858"
+	sourcePath := filepath.Join(root, "conversations", id+".pb")
+	cachePath := filepath.Join(root, "cache", "last_conversations.json")
+	mustMkdir(t, filepath.Dir(sourcePath))
+	mustMkdir(t, filepath.Dir(cachePath))
+	mustWrite(t, sourcePath, []byte("pb"))
+	mustWrite(t, cachePath, []byte(`{"/tmp/proj":"`+id+`"}`))
+
+	early := time.Unix(1779000000, 0)
+	late := time.Unix(1779000300, 0)
+	require.NoError(t, os.Chtimes(sourcePath, early, early))
+	require.NoError(t, os.Chtimes(cachePath, late, late))
+
+	info, err := AntigravityCLIFileInfo(sourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, late.UnixNano(), info.ModTime().UnixNano())
 }
 
 // TestAntigravityCLIFileInfoIncludesBrainArtifacts pins brain
@@ -1283,6 +1353,36 @@ func TestBuildAntigravityProjectMapRobust(t *testing.T) {
 	assert.Equal(t, "/tmp/c", m["id-3"])
 	_, ok := m["id-2"]
 	assert.False(t, ok, "id-2 had no workspace, should be absent")
+}
+
+func TestAntigravityProjectMapFromLastConversations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "last_conversations.json")
+	assert.Empty(t, antigravityProjectMapFromLastConversations(path))
+	mustWrite(t, path, []byte(
+		`{"/tmp/a":"id-1","/tmp/b":"id-1",`+
+			`"relative/project":"id-2","/tmp/empty":""}`,
+	))
+	m := antigravityProjectMapFromLastConversations(path)
+	require.Len(t, m, 2)
+	assert.Equal(t, "/tmp/a", m["id-1"])
+	assert.Equal(t, "relative/project", m["id-2"])
+}
+
+func TestNormalizeAntigravityCLIWorkspaceAcceptsForeignAbsolutePaths(t *testing.T) {
+	tests := []struct {
+		workspace string
+		want      string
+	}{
+		{workspace: "/home/user/project", want: "/home/user/project"},
+		{workspace: `C:\Users\dev\project`, want: `C:\Users\dev\project`},
+		{workspace: `\\server\share\project`, want: `\\server\share\project`},
+		{workspace: "relative/project"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.workspace, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeAntigravityCLIWorkspace(tt.workspace))
+		})
+	}
 }
 
 // ---- helpers --------------------------------------------------

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -268,13 +268,7 @@ func extractProjectFromCwdWithBranchPolicy(
 		norm = strings.ReplaceAll(cwd, "\\", "/")
 	}
 	cleaned := filepath.Clean(norm)
-
-	// Recognize tool-anchored worktree manager layouts before walking git
-	// roots. These layouts encode the owning project in the path even when
-	// the git root basename is a branch or generated worktree id.
-	if p := projectFromAnchoredWorktreeLayout(cleaned); p != "" {
-		return NormalizeName(p)
-	}
+	anchoredProject := projectFromAnchoredWorktreeLayout(cleaned)
 
 	// Skip the git-root walk when the cwd cannot resolve to a
 	// real local filesystem location. On macOS a bulk walk under
@@ -284,13 +278,21 @@ func extractProjectFromCwdWithBranchPolicy(
 	if discoverFilesystem && filepath.IsAbs(cleaned) &&
 		!isForeignOSPath(cwd, cleaned, winPath) &&
 		probeGitRootForCwd(cleaned) {
-		if root := findGitRepoRoot(cleaned); root != "" {
+		if root, canonicalLinked := findGitRepoRoot(cleaned); root != "" &&
+			(canonicalLinked || anchoredProject == "") {
 			name := filepath.Base(root)
 			if isInvalidPathBase(name) {
 				return ""
 			}
 			return NormalizeName(name)
 		}
+	}
+
+	// Tool-anchored layouts own standalone repositories created inside their
+	// branch directories. Only validated linked-worktree metadata may override
+	// the lexical project with the canonical main checkout name.
+	if anchoredProject != "" {
+		return NormalizeName(anchoredProject)
 	}
 
 	// Generic hosting layouts are intentionally a fallback after live Git
@@ -647,9 +649,9 @@ func isInvalidPathBase(name string) bool {
 // and linked worktrees/submodules (.git file). When cwd no longer
 // exists on disk, sibling directories are checked for worktree
 // .git files that can reveal the true repo root.
-func findGitRepoRoot(cwd string) string {
+func findGitRepoRoot(cwd string) (string, bool) {
 	if cwd == "" {
-		return ""
+		return "", false
 	}
 
 	dir := cwd
@@ -661,7 +663,7 @@ func findGitRepoRoot(cwd string) string {
 	} else {
 		// Avoid treating non-path strings as cwd.
 		if !strings.ContainsRune(dir, filepath.Separator) {
-			return ""
+			return "", false
 		}
 		cwdMissing = true
 		dir = filepath.Dir(dir)
@@ -685,48 +687,50 @@ func findGitRepoRoot(cwd string) string {
 			sibDir = parent
 		}
 		if root := repoRootFromSiblings(sibDir, cwd); root != "" {
-			return root
+			return root, true
 		}
 	}
 
-	root, _ := findGitRepoRootLocal(dir)
-	return root
+	root, _, canonicalLinked := findGitRepoRootLocal(dir)
+	return root, canonicalLinked
 }
 
-func findGitRepoRootLocal(dir string) (root string, conservative bool) {
+func findGitRepoRootLocal(
+	dir string,
+) (root string, conservative, canonicalLinked bool) {
 	for {
 		gitPath := filepath.Join(dir, ".git")
 		info, err := statGitEntry(gitPath)
 		if errors.Is(err, errRefusedGitEntry) {
 			// A .git symlink into a refused location marks a repo
 			// boundary we must not look through.
-			return dir, false
+			return dir, false, false
 		}
 		if err == nil {
 			if info.IsDir() {
-				return dir, false
+				return dir, false, false
 			}
 			if info.Mode().IsRegular() {
 				if !gitFileTargetsProbeable(dir, gitPath) {
 					// The gitfile targets a directory the protected-path
 					// policy refuses. Stop at the worktree itself.
-					return dir, false
+					return dir, false, false
 				}
 				if root := repoRootFromGitFile(dir, gitPath); root != "" {
 					if root == dir {
-						return root, true
+						return root, true, false
 					}
-					return root, false
+					return root, false, true
 				}
 				// Keep conservative fallback for gitfile repos
 				// when metadata cannot be parsed.
-				return dir, true
+				return dir, true, false
 			}
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", false
+			return "", false, false
 		}
 		dir = parent
 	}

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -278,8 +278,8 @@ func extractProjectFromCwdWithBranchPolicy(
 	if discoverFilesystem && filepath.IsAbs(cleaned) &&
 		!isForeignOSPath(cwd, cleaned, winPath) &&
 		probeGitRootForCwd(cleaned) {
-		if root, canonicalLinked := findGitRepoRoot(cleaned); root != "" &&
-			(canonicalLinked || anchoredProject == "") {
+		if root, linkedToRecordedPath := findGitRepoRoot(cleaned); root != "" &&
+			(linkedToRecordedPath || anchoredProject == "") {
 			name := filepath.Base(root)
 			if isInvalidPathBase(name) {
 				return ""
@@ -687,7 +687,7 @@ func findGitRepoRoot(cwd string) (string, bool) {
 			sibDir = parent
 		}
 		if root := repoRootFromSiblings(sibDir, cwd); root != "" {
-			return root, true
+			return root, deletedChildIsWorktree(sibDir, cwd, root)
 		}
 	}
 

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -117,6 +117,68 @@ func TestExtractProjectFromCwd_Git(t *testing.T) {
 	}
 }
 
+func TestExtractProjectFromCwd_MissingAnchoredPathRequiresAssociatedWorktree(
+	t *testing.T,
+) {
+	tests := []struct {
+		name               string
+		containerParts     []string
+		missingParts       []string
+		associatedWorktree string
+		want               string
+	}{
+		{
+			name:           "Superset",
+			containerParts: []string{".superset", "worktrees", "sample-service"},
+			missingParts:   []string{"missing-branch", "internal"},
+			want:           "sample_service",
+		},
+		{
+			name:           "Codex",
+			containerParts: []string{".codex", "worktrees", "worktree-id"},
+			missingParts:   []string{"sample-service", "internal"},
+			want:           "sample_service",
+		},
+		{
+			name:               "SupersetAssociated",
+			containerParts:     []string{".superset", "worktrees", "sample-service"},
+			missingParts:       []string{"missing-branch", "internal"},
+			associatedWorktree: "missing-branch",
+			want:               "canonical_repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			canonicalRepo := filepath.Join(root, "canonical-repo")
+			worktreeGitDir := filepath.Join(
+				canonicalRepo, ".git", "worktrees", "existing",
+			)
+			container := filepath.Join(
+				append([]string{root}, tt.containerParts...)...,
+			)
+			sibling := filepath.Join(container, "existing")
+			mustMkdirAll(t, sibling)
+			mustMkdirAll(t, worktreeGitDir)
+			mustWriteFile(t, filepath.Join(sibling, ".git"),
+				"gitdir: "+worktreeGitDir+"\n")
+			mustWriteFile(t, filepath.Join(worktreeGitDir, "commondir"), "../..\n")
+			if tt.associatedWorktree != "" {
+				mustMkdirAll(t, filepath.Join(
+					canonicalRepo, ".git", "worktrees", tt.associatedWorktree,
+				))
+			}
+
+			cwd := filepath.Join(
+				append([]string{container}, tt.missingParts...)...,
+			)
+			assert.Equal(t, tt.want, ExtractProjectFromCwd(cwd),
+				"a sibling may override the anchor only when Git records the missing worktree")
+		})
+	}
+}
+
 func TestExtractProjectFromCwdWithBranchContext_GitWorktreeMainRoot(t *testing.T) {
 	skipIfNoGit(t)
 

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -32,6 +32,20 @@ func TestExtractProjectFromCwd_Git(t *testing.T) {
 			want: "my_app",
 		},
 		{
+			name: "SupersetStandaloneBranchRepoUsesAnchoredProject",
+			setup: func(t *testing.T, root string) string {
+				branchRepo := filepath.Join(
+					root, ".superset", "worktrees",
+					"sample-service", "feature-branch",
+				)
+				subdir := filepath.Join(branchRepo, "internal", "parser")
+				mustMkdirAll(t, filepath.Join(branchRepo, ".git"))
+				mustMkdirAll(t, subdir)
+				return subdir
+			},
+			want: "sample_service",
+		},
+		{
 			name: "GitWorktree",
 			setup: func(t *testing.T, root string) string {
 				mainRepo := filepath.Join(root, "agentsview")
@@ -68,6 +82,29 @@ func TestExtractProjectFromCwd_Git(t *testing.T) {
 				return worktree
 			},
 			want: "my_repo",
+		},
+		{
+			name: "CodexCustomNamedWorktreeUsesLinkedGitIdentity",
+			setup: func(t *testing.T, root string) string {
+				mainRepo := filepath.Join(root, "sample-service")
+				worktree := filepath.Join(
+					root, ".codex", "worktrees",
+					"sample-service-graph-retry-20260820",
+				)
+				worktreeGitDir := filepath.Join(
+					mainRepo, ".git", "worktrees", "graph-retry",
+				)
+
+				mustMkdirAll(t, filepath.Join(mainRepo, ".git"))
+				mustMkdirAll(t, worktreeGitDir)
+				mustMkdirAll(t, filepath.Join(worktree, "docs", "reviews", "run"))
+				mustWriteFile(t, filepath.Join(worktree, ".git"),
+					"gitdir: "+worktreeGitDir+"\n")
+				mustWriteFile(t, filepath.Join(worktreeGitDir, "commondir"), "../..\n")
+
+				return filepath.Join(worktree, "docs", "reviews", "run")
+			},
+			want: "sample_service",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -114,7 +114,10 @@ func TestSyncEngineAntigravityCLI_HappyPath(t *testing.T) {
 	// Verify database ingestion. The stored project is normalized through
 	// the shared cwd/worktree resolver, so the raw workspace path collapses
 	// to its basename with dashes folded to underscores.
-	assertSessionProject(t, env.db, "antigravity-cli:"+uuid, "my_cli_project")
+	assertSessionProjectAndCwd(
+		t, env.db, "antigravity-cli:"+uuid,
+		"my_cli_project", "/home/user/my-cli-project",
+	)
 	// Expected messages:
 	// 1. User: "Check workspace status"
 	// 2. Assistant: "listing files now" (with tool calls and thoughts)
@@ -666,11 +669,13 @@ func TestSyncEngineAntigravityCLI_InferredProjectWithoutConversationID(t *testin
 		name        string
 		rowTime     time.Time
 		wantProject string
+		wantCwd     string
 	}{
 		{
 			name:        "normalized match within window infers project",
 			rowTime:     base.Add(10 * time.Second),
 			wantProject: "inferred_project",
+			wantCwd:     workspace,
 		},
 		{
 			name:        "match outside 60s window leaves project empty",
@@ -695,7 +700,9 @@ func TestSyncEngineAntigravityCLI_InferredProjectWithoutConversationID(t *testin
 				Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 			})
 
-			assertSessionProject(t, env.db, sessionID, tt.wantProject)
+			assertSessionProjectAndCwd(
+				t, env.db, sessionID, tt.wantProject, tt.wantCwd,
+			)
 			assertSessionMessageCount(t, env.db, sessionID, 1)
 			msgs := fetchMessages(t, env.db, sessionID)
 			require.Len(t, msgs, 1)
@@ -719,7 +726,10 @@ func TestSyncSingleSessionAntigravityCLI_InferredProjectWithoutConversationID(t 
 	// The file-watcher path must persist the inferred project too.
 	require.NoError(t, env.engine.SyncSingleSession(sessionID))
 
-	assertSessionProject(t, env.db, sessionID, "inferred_project_single")
+	assertSessionProjectAndCwd(
+		t, env.db, sessionID,
+		"inferred_project_single", "/home/user/inferred-project-single",
+	)
 	assertSessionMessageCount(t, env.db, sessionID, 1)
 }
 
@@ -754,7 +764,9 @@ func TestSyncPathsAntigravityCLIHistoryOnlyUpdateRefreshesProject(t *testing.T) 
 
 	env.engine.SyncPaths([]string{historyPath})
 
-	assertSessionProject(t, env.db, sessionID, "history_arrived")
+	assertSessionProjectAndCwd(
+		t, env.db, sessionID, "history_arrived", "/home/user/history-arrived",
+	)
 	assertSessionMessageCount(t, env.db, sessionID, 1)
 }
 
@@ -793,8 +805,12 @@ func TestSyncPathsAntigravityCLIHistoryRetagClearsRemovedProject(t *testing.T) {
 		Skipped:       0,
 		Anomalies:     agyCLIUnknownSchemaAnomaly(2),
 	})
-	assertSessionProject(t, env.db, removedSessionID, "removed")
-	assertSessionProject(t, env.db, retaggedSessionID, "retagged")
+	assertSessionProjectAndCwd(
+		t, env.db, removedSessionID, "removed", "/home/user/removed",
+	)
+	assertSessionProjectAndCwd(
+		t, env.db, retaggedSessionID, "retagged", "/home/user/retagged",
+	)
 
 	updated := base.Add(time.Minute)
 	retaggedHistory := fmt.Sprintf(
@@ -806,8 +822,10 @@ func TestSyncPathsAntigravityCLIHistoryRetagClearsRemovedProject(t *testing.T) {
 
 	env.engine.SyncPaths([]string{historyPath})
 
-	assertSessionProject(t, env.db, removedSessionID, "")
-	assertSessionProject(t, env.db, retaggedSessionID, "retagged_now")
+	assertSessionProjectAndCwd(t, env.db, removedSessionID, "", "")
+	assertSessionProjectAndCwd(
+		t, env.db, retaggedSessionID, "retagged_now", "/home/user/retagged-now",
+	)
 	assertSessionMessageCount(t, env.db, removedSessionID, 1)
 	assertSessionMessageCount(t, env.db, retaggedSessionID, 1)
 }

--- a/internal/sync/test_helpers_test.go
+++ b/internal/sync/test_helpers_test.go
@@ -57,6 +57,16 @@ func assertSessionProject(t *testing.T, database *db.DB, sessionID string, want 
 	})
 }
 
+func assertSessionProjectAndCwd(
+	t *testing.T, database *db.DB, sessionID, wantProject, wantCwd string,
+) {
+	t.Helper()
+	assertSessionState(t, database, sessionID, func(sess *db.Session) {
+		assert.Equal(t, wantProject, sess.Project, "session %q project", sessionID)
+		assert.Equal(t, wantCwd, sess.Cwd, "session %q cwd", sessionID)
+	})
+}
+
 func runSyncAndAssert(t *testing.T, engine *sync.Engine, want sync.SyncStats) sync.SyncStats {
 	t.Helper()
 	stats := engine.SyncAll(context.Background(), nil)


### PR DESCRIPTION
Populate Antigravity CLI session CWD from the current `cache/last_conversations.json` workspace mapping, with `history.jsonl` retained for older installations and untagged-session fallback. Exact conversation matches are preferred; missing, relative, or ambiguous workspace values leave CWD empty.

The absolute workspace remains the CWD for local sources. Project labels preserve recognized anchored worktree layouts for standalone or missing branch repositories, while linked-worktree metadata explicitly tied to the recorded path can supply the canonical repository identity. Remote and foreign-machine sources retain workspace-derived project grouping but are marked remote, so archive reconciliation clears their CWD instead of treating another machine's path as local. Their project labels stay lexical instead of probing recorded paths on the importing host. Workspace mappings participate in discovery and fingerprints, and the archive data version advances so existing sessions are reparsed non-destructively.

The cache path participates in the watch plan and changed-path routing, and its modification time contributes to effective source freshness so cache-only workspace updates remain eligible during incremental sync when file watching is unavailable.
