### PR TITLE
feat(rawsync): add raw upload transport client and checkpoint state

### DIFF
--- a/internal/postgres/raw_client_e2e_pgtest_test.go
+++ b/internal/postgres/raw_client_e2e_pgtest_test.go
@@ -1,0 +1,527 @@
+//go:build pgtest
+
+// Package postgres_test carries the raw-client end-to-end proof as an
+// external test package: internal/server imports internal/postgres, so an
+// internal test file cannot import the server package without an import
+// cycle. Everything the exercise needs from the store layer is exported;
+// only the tiny pgtest conveniences (schema wipe, digest helper, table
+// counts, spool paths) are restated here.
+package postgres_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/artifact"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/rawclient"
+	"go.kenn.io/agentsview/internal/rawsync"
+	"go.kenn.io/agentsview/internal/server"
+)
+
+// pgE2ESchema mirrors the internal pgtest tests' shared schema. The test
+// must stay serial with them: each wipes this schema on entry and exit.
+const pgE2ESchema = "agentsview_schema_test"
+
+// pgE2ESpoolDirectory and pgE2EStageName mirror the RawUploadStore's private
+// spool layout below the data directory.
+const (
+	pgE2ESpoolDirectory = "raw-upload-spool"
+	pgE2EStageSuffix    = ".part"
+)
+
+func pgE2EStageName(uploadID string) string {
+	return uploadID + pgE2EStageSuffix
+}
+
+// newPGE2ETestDatabase opens the shared test schema wiped clean, with every
+// raw-sync table provisioned, and returns a throwaway data directory.
+func newPGE2ETestDatabase(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	pgURL := os.Getenv("TEST_PG_URL")
+	if pgURL == "" {
+		t.Skip("TEST_PG_URL not set; skipping PG tests")
+	}
+	pgE2ECleanSchema(t, pgURL)
+	t.Cleanup(func() { pgE2ECleanSchema(t, pgURL) })
+	pg, err := postgres.Open(pgURL, pgE2ESchema, true)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pg.Close()) })
+	require.NoError(t, postgres.EnsureSchema(t.Context(), pg, pgE2ESchema))
+	return pg, t.TempDir()
+}
+
+func pgE2ECleanSchema(t *testing.T, pgURL string) {
+	t.Helper()
+	pg, err := sql.Open("pgx", pgURL)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+	_, err = pg.Exec("DROP SCHEMA IF EXISTS " + pgE2ESchema + " CASCADE")
+	require.NoError(t, err, "dropping test schema")
+}
+
+// TestRawClientPostgresEndToEnd drives the full rawclient cycle — enrollment,
+// token exchange, missing-object negotiation, resumable multi-chunk uploads,
+// manifest commits, interrupted-upload resume, and stale-parent head
+// conflicts — against the real huma routes with every rawsync persistence
+// seam durable in PostgreSQL: upload sessions and offsets in
+// raw_upload_sessions plus the staging spool, custody metadata in the raw
+// ingest tables, and device identities and tokens in raw_devices and
+// raw_device_tokens. Only the artifact repository uses a throwaway directory.
+func TestRawClientPostgresEndToEnd(t *testing.T) {
+	pg, dataDir := newPGE2ETestDatabase(t)
+	ctx := t.Context()
+
+	repository, err := artifact.OpenRepository(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, repository.Close()) })
+	objects, err := rawsync.NewArtifactObjectStore(repository.Content())
+	require.NoError(t, err)
+
+	ingest, err := postgres.NewRawIngestStore(pg)
+	require.NoError(t, err)
+	authStore, err := postgres.NewRawDeviceAuthStore(pg)
+	require.NoError(t, err)
+	sessions, err := postgres.NewRawUploadStore(pg, dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sessions.Close()) })
+
+	custody, err := rawsync.NewService(
+		objects, ingest, rawsync.DefaultManifestLimits(), "parser-data-17",
+	)
+	require.NoError(t, err)
+	auth, err := rawsync.NewDeviceAuthService(authStore, 15*time.Minute)
+	require.NoError(t, err)
+	uploads, err := rawsync.NewUploadService(
+		sessions, custody, rawsync.DefaultUploadSessionTTL,
+	)
+	require.NoError(t, err)
+
+	srv := server.New(config.Config{
+		Host: "127.0.0.1", Port: 0, WriteTimeout: 30 * time.Second,
+	}, nil, nil,
+		server.WithRawSyncServices(auth, custody),
+		server.WithRawSyncUploads(uploads),
+	)
+	httpServer := httptest.NewServer(srv.Handler())
+	t.Cleanup(httpServer.Close)
+
+	wire := newPGE2EPatchTransport(http.DefaultTransport)
+	httpClient := &http.Client{Transport: wire}
+
+	// Server-side enrollment has no HTTP route by design; the issued
+	// credential is exactly what a laptop would be provisioned with, and it
+	// lands durably in raw_devices.
+	enrollment, err := auth.EnrollDevice(ctx, "tenant-pg-e2e", "laptop-pg-e2e")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-pg-e2e", enrollment.Identity.TenantID)
+	assert.NotEmpty(t, enrollment.Identity.DeviceID)
+	assert.NotEmpty(t, enrollment.Credential)
+
+	var enrolledDevices int
+	require.NoError(t, pg.QueryRowContext(ctx, `
+		SELECT count(*) FROM raw_devices
+		WHERE tenant_id = $1 AND device_id = $2`,
+		enrollment.Identity.TenantID, enrollment.Identity.DeviceID,
+	).Scan(&enrolledDevices))
+	assert.Equal(t, 1, enrolledDevices, "enrollment persisted in PostgreSQL")
+
+	// A small ChunkBytes forces every object through multiple PATCHes.
+	newLaptop := func() *rawclient.Client {
+		client, err := rawclient.NewClient(rawclient.Config{
+			BaseURL:     httpServer.URL,
+			DeviceID:    enrollment.Identity.DeviceID,
+			Credential:  enrollment.Credential,
+			HTTPClient:  httpClient,
+			ChunkBytes:  8,
+			TokenMargin: time.Minute,
+		})
+		require.NoError(t, err)
+		return client
+	}
+	client := newLaptop()
+
+	// Step 1: negotiate missing objects, then upload both through the
+	// resumable data plane backed by the PostgreSQL session store.
+	firstBody := []byte("first source object body, chunked")
+	secondBody := []byte("second source object body")
+	first := pgE2EObjectFor(t, firstBody)
+	second := pgE2EObjectFor(t, secondBody)
+	require.Greater(t, first.Length, int64(16))
+	require.Greater(t, second.Length, int64(16))
+
+	objs := []rawsync.ObjectRef{first, second}
+	missing, err := client.MissingObjects(ctx, parser.AgentClaude, objs)
+	require.NoError(t, err)
+	require.Len(t, missing, 2)
+	assert.Equal(t, objs, missing, "both objects missing in request order")
+
+	bodies := map[string][]byte{first.SHA256: firstBody, second.SHA256: secondBody}
+	for _, object := range missing {
+		require.NoError(t, client.UploadObject(
+			ctx, parser.AgentClaude, object, bytes.NewReader(bodies[object.SHA256]),
+		))
+	}
+
+	// Multi-chunk transfers actually happened over the wire: every resumable
+	// session needed more than one PATCH at the 8-byte chunk size.
+	patches, _ := wire.snapshot()
+	require.Len(t, patches, 2, "one resumable session per object")
+	for uploadID, count := range patches {
+		assert.GreaterOrEqual(t, count, int64(2),
+			"upload %s used multiple chunks", uploadID)
+	}
+
+	// After custody the durable ledger holds both objects; renegotiation
+	// against the PostgreSQL metadata store is empty.
+	missing, err = client.MissingObjects(ctx, parser.AgentClaude, objs)
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+	assert.Equal(t, 2, pgE2ETableCount(t, pg, "raw_objects"))
+
+	var issuedTokens int
+	require.NoError(t, pg.QueryRowContext(ctx,
+		`SELECT count(*) FROM raw_device_tokens`,
+	).Scan(&issuedTokens))
+	assert.GreaterOrEqual(t, issuedTokens, 1,
+		"the token exchange persisted digest-only tokens")
+
+	// Step 2: commit the first generation with an empty expected parent
+	// receipt, replay it idempotently, then chain a second generation.
+	const (
+		rootID    = "root-pg-e2e"
+		sourceKey = "projects/demo/session.jsonl"
+	)
+	capturedAt := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	entries := []rawsync.Entry{
+		{
+			Path: "session.jsonl", Type: "file",
+			Length: first.Length, Objects: []rawsync.ObjectRef{first},
+		},
+		{
+			Path: "meta/sidecar.json", Type: "file",
+			Length: second.Length, Objects: []rawsync.ObjectRef{second},
+		},
+	}
+	manifestFor := func(captureID string, captured time.Time, parent string) rawsync.Manifest {
+		return rawsync.Manifest{
+			SchemaVersion:         rawsync.ManifestSchemaVersion,
+			Provider:              parser.AgentClaude,
+			ConfiguredRootID:      rootID,
+			SourceKey:             sourceKey,
+			ExpectedParentReceipt: parent,
+			CaptureID:             captureID,
+			CapturedAt:            captured,
+			Kind:                  rawsync.ManifestSnapshot,
+			Entries:               entries,
+		}
+	}
+
+	firstCommit, err := client.CommitManifest(ctx, manifestFor(
+		"capture-pg-e2e-1", capturedAt, "",
+	))
+	require.NoError(t, err)
+	assert.NotEmpty(t, firstCommit.ManifestID)
+	assert.NotEmpty(t, firstCommit.Receipt)
+	assert.Equal(t, int64(1), firstCommit.Generation)
+	assert.True(t, firstCommit.Created)
+	assert.Equal(t, pgE2EIngestCounts{
+		Manifests: 1, Entries: 2, Objects: 2, Heads: 1, Jobs: 1,
+	}, pgE2EReadIngestCounts(t, pg), "first generation is durable in PostgreSQL")
+
+	// The same capture_id replays idempotently: same receipt and
+	// generation, never a second generation or a third metadata row set.
+	replayed, err := client.CommitManifest(ctx, manifestFor(
+		"capture-pg-e2e-1", capturedAt, "",
+	))
+	require.NoError(t, err)
+	assert.Equal(t, firstCommit.Receipt, replayed.Receipt)
+	assert.Equal(t, firstCommit.Generation, replayed.Generation)
+	assert.False(t, replayed.Created)
+	assert.Equal(t, pgE2EIngestCounts{
+		Manifests: 1, Entries: 2, Objects: 2, Heads: 1, Jobs: 1,
+	}, pgE2EReadIngestCounts(t, pg), "replay wrote nothing new")
+
+	secondCommit, err := client.CommitManifest(ctx, manifestFor(
+		"capture-pg-e2e-2", capturedAt.Add(time.Minute), firstCommit.Receipt,
+	))
+	require.NoError(t, err)
+	assert.NotEqual(t, firstCommit.Receipt, secondCommit.Receipt)
+	assert.Equal(t, int64(2), secondCommit.Generation)
+	assert.True(t, secondCommit.Created)
+
+	durableHead := func() (manifestID, receipt string, generation int64) {
+		require.NoError(t, pg.QueryRowContext(ctx, `
+			SELECT manifest_id, receipt, generation FROM raw_source_heads`,
+		).Scan(&manifestID, &receipt, &generation))
+		return manifestID, receipt, generation
+	}
+	headManifest, headReceipt, headGeneration := durableHead()
+	assert.Equal(t, secondCommit.ManifestID, headManifest)
+	assert.Equal(t, secondCommit.Receipt, headReceipt)
+	assert.Equal(t, int64(2), headGeneration)
+	assert.Equal(t, pgE2EIngestCounts{
+		Manifests: 2, Entries: 4, Objects: 4, Heads: 1, Jobs: 2,
+	}, pgE2EReadIngestCounts(t, pg), "second generation is durable in PostgreSQL")
+
+	// Step 3: simulate an interrupted upload. The laptop dies after two
+	// 8-byte chunks; the durable session and its spooled bytes survive in
+	// PostgreSQL and below dataDir while the object stays incomplete.
+	resumeBody := bytes.Repeat([]byte("raw-pg-e2e"), 4) // 40 bytes, 5 chunks
+	resumeObject := pgE2EObjectFor(t, resumeBody)
+
+	crashed := &pgE2ECrashReader{data: resumeBody, failAt: 16}
+	err = client.UploadObject(ctx, parser.AgentClaude, resumeObject, crashed)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "simulated laptop crash")
+
+	var durableOffset int64
+	var openUploadID string
+	require.NoError(t, pg.QueryRowContext(ctx, `
+		SELECT upload_id, offset_bytes FROM raw_upload_sessions
+		WHERE state = 'open' AND sha256 = $1 AND size_bytes = $2`,
+		resumeObject.SHA256, resumeObject.Length,
+	).Scan(&openUploadID, &durableOffset))
+	assert.Equal(t, int64(16), durableOffset,
+		"the two durable chunks survived the crash in PostgreSQL")
+	require.Greater(t, durableOffset, int64(0))
+	require.Less(t, durableOffset, resumeObject.Length)
+
+	staged, err := os.Stat(filepath.Join(
+		dataDir, pgE2ESpoolDirectory, pgE2EStageName(openUploadID),
+	))
+	require.NoError(t, err)
+	assert.Equal(t, durableOffset, staged.Size(),
+		"the spool holds exactly the durable prefix")
+
+	// A fresh client — new token cache, no in-memory session state —
+	// re-uploads the same object. It must resume the durable PostgreSQL
+	// session, not restart it: the start-response offset it acts on equals
+	// the durable offset, it reads only the missing tail, and only that
+	// tail travels over the wire.
+	beforePatches, beforeSent := wire.snapshot()
+	resumeClient := newLaptop()
+	resumed := &pgE2ERecordingReader{data: resumeBody}
+	require.NoError(t, resumeClient.UploadObject(
+		ctx, parser.AgentClaude, resumeObject, resumed,
+	))
+	assert.Equal(t, durableOffset, resumed.firstOffset,
+		"the fresh client's first read sat at the server's resumed offset")
+	assert.Equal(t, resumeObject.Length-durableOffset, resumed.bytesRead,
+		"the fresh client read only the missing tail")
+
+	afterPatches, afterSent := wire.snapshot()
+	var resumeUploadID string
+	var resumeWireBytes, resumePatchCount int64
+	for uploadID, sent := range afterSent {
+		delta := sent - beforeSent[uploadID]
+		if delta == 0 {
+			continue
+		}
+		require.Empty(t, resumeUploadID,
+			"only the resumed upload transferred new bytes")
+		resumeUploadID = uploadID
+		resumeWireBytes = delta
+		resumePatchCount = afterPatches[uploadID] - beforePatches[uploadID]
+	}
+	require.NotEmpty(t, resumeUploadID)
+	assert.Equal(t, openUploadID, resumeUploadID,
+		"the fresh client reused the interrupted session's upload ID")
+	assert.Equal(t, resumeObject.Length-durableOffset, resumeWireBytes,
+		"the resume re-sent only the missing bytes")
+	assert.GreaterOrEqual(t, resumePatchCount, int64(3),
+		"the resumed tail itself is multi-chunk")
+
+	// Completion is durable: custody recorded the third object, the open
+	// session is gone, and the spooled stage file was cleaned up.
+	missing, err = resumeClient.MissingObjects(
+		ctx, parser.AgentClaude, []rawsync.ObjectRef{resumeObject},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+	assert.Equal(t, 3, pgE2ETableCount(t, pg, "raw_objects"))
+
+	var openSessions int
+	require.NoError(t, pg.QueryRowContext(ctx,
+		`SELECT count(*) FROM raw_upload_sessions WHERE state = 'open'`,
+	).Scan(&openSessions))
+	assert.Zero(t, openSessions)
+
+	_, err = os.Stat(filepath.Join(
+		dataDir, pgE2ESpoolDirectory, pgE2EStageName(openUploadID),
+	))
+	assert.True(t, os.IsNotExist(err), "the completed session's spool was removed")
+
+	// Step 4: a stale parent receipt is rejected as a typed head conflict
+	// carrying the current durable head, and the conflict advances nothing.
+	_, err = client.CommitManifest(ctx, manifestFor(
+		"capture-pg-e2e-3", capturedAt.Add(2*time.Minute), firstCommit.Receipt,
+	))
+	require.Error(t, err)
+	var apiErr rawclient.APIError
+	require.True(t, rawclient.AsAPIError(err, &apiErr))
+	assert.Equal(t, http.StatusConflict, apiErr.Status)
+	assert.Equal(t, rawclient.CodeHeadConflict, apiErr.Code)
+	assert.Equal(t, secondCommit.ManifestID, apiErr.CurrentManifestID)
+	assert.Equal(t, secondCommit.Receipt, apiErr.CurrentReceipt)
+	assert.Equal(t, int64(2), apiErr.CurrentGeneration)
+
+	headManifest, headReceipt, headGeneration = durableHead()
+	assert.Equal(t, secondCommit.ManifestID, headManifest)
+	assert.Equal(t, secondCommit.Receipt, headReceipt)
+	assert.Equal(t, int64(2), headGeneration)
+	assert.Equal(t, pgE2EIngestCounts{
+		Manifests: 2, Entries: 4, Objects: 4, Heads: 1, Jobs: 2,
+	}, pgE2EReadIngestCounts(t, pg), "the rejected stale commit wrote no metadata")
+}
+
+// pgE2EObjectFor builds a validated ObjectRef carrying body's real digest.
+func pgE2EObjectFor(t *testing.T, body []byte) rawsync.ObjectRef {
+	t.Helper()
+	digest := sha256.Sum256(body)
+	object, err := rawsync.NewObjectRef(hex.EncodeToString(digest[:]), int64(len(body)))
+	require.NoError(t, err)
+	return object
+}
+
+type pgE2EIngestCounts struct {
+	Manifests int
+	Entries   int
+	Objects   int
+	Heads     int
+	Jobs      int
+}
+
+// pgE2EReadIngestCounts reads the raw ingest metadata row counts.
+func pgE2EReadIngestCounts(t *testing.T, pg *sql.DB) pgE2EIngestCounts {
+	t.Helper()
+	var counts pgE2EIngestCounts
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT
+			(SELECT count(*) FROM raw_manifests),
+			(SELECT count(*) FROM raw_manifest_entries),
+			(SELECT count(*) FROM raw_manifest_objects),
+			(SELECT count(*) FROM raw_source_heads),
+			(SELECT count(*) FROM raw_ingest_jobs)`,
+	).Scan(&counts.Manifests, &counts.Entries, &counts.Objects,
+		&counts.Heads, &counts.Jobs))
+	return counts
+}
+
+// pgE2ETableCount counts rows in one raw-sync table.
+func pgE2ETableCount(t *testing.T, pg *sql.DB, table string) int {
+	t.Helper()
+	var count int
+	require.NoError(t, pg.QueryRowContext(t.Context(),
+		"SELECT count(*) FROM "+table,
+	).Scan(&count))
+	return count
+}
+
+const pgE2EUploadsPathPrefix = "/api/v1/raw-sync/uploads/"
+
+// pgE2EPatchTransport counts resumable-upload PATCHes per upload ID and the
+// body bytes each carried, so the test can observe multi-chunk transfers and
+// prove a resumed session never re-sends bytes the server already holds.
+type pgE2EPatchTransport struct {
+	mu      sync.Mutex
+	base    http.RoundTripper
+	patches map[string]int64
+	sent    map[string]int64
+}
+
+func newPGE2EPatchTransport(base http.RoundTripper) *pgE2EPatchTransport {
+	return &pgE2EPatchTransport{
+		base:    base,
+		patches: make(map[string]int64),
+		sent:    make(map[string]int64),
+	}
+}
+
+func (t *pgE2EPatchTransport) RoundTrip(
+	req *http.Request,
+) (*http.Response, error) {
+	if req.Method == http.MethodPatch &&
+		strings.HasPrefix(req.URL.Path, pgE2EUploadsPathPrefix) {
+		uploadID := path.Base(req.URL.Path)
+		t.mu.Lock()
+		t.patches[uploadID]++
+		t.sent[uploadID] += req.ContentLength
+		t.mu.Unlock()
+	}
+	return t.base.RoundTrip(req)
+}
+
+func (t *pgE2EPatchTransport) snapshot() (patches, sent map[string]int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	patches = make(map[string]int64, len(t.patches))
+	sent = make(map[string]int64, len(t.sent))
+	for uploadID, count := range t.patches {
+		patches[uploadID] = count
+	}
+	for uploadID, sentBytes := range t.sent {
+		sent[uploadID] = sentBytes
+	}
+	return patches, sent
+}
+
+// pgE2ECrashReader stands in for a laptop that died mid-transfer: reads at or
+// beyond failAt fail, exactly as if the process vanished before it could
+// hand the client the next chunk.
+type pgE2ECrashReader struct {
+	data   []byte
+	failAt int64
+}
+
+func (r *pgE2ECrashReader) ReadAt(p []byte, off int64) (int, error) {
+	if off >= r.failAt {
+		return 0, fmt.Errorf("pg e2e: simulated laptop crash before offset %d", off)
+	}
+	n := copy(p, r.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// pgE2ERecordingReader records the first offset the client asked to read and
+// the total bytes it read — the client-side view of the server's
+// start-response offset for a resumed session.
+type pgE2ERecordingReader struct {
+	data        []byte
+	firstOffset int64
+	started     bool
+	bytesRead   int64
+}
+
+func (r *pgE2ERecordingReader) ReadAt(p []byte, off int64) (int, error) {
+	if !r.started {
+		r.started = true
+		r.firstOffset = off
+	}
+	n := copy(p, r.data[off:])
+	r.bytesRead += int64(n)
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}

--- a/internal/rawcheckpoint/driver_cgo.go
+++ b/internal/rawcheckpoint/driver_cgo.go
@@ -1,0 +1,45 @@
+//go:build !windows && cgo
+
+package rawcheckpoint
+
+import (
+	"net/url"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// checkpointDriverName selects the database/sql driver the checkpoint
+// database opens with. On Unix with cgo it is mattn/go-sqlite3 — the same
+// driver as the main archive. On Windows the cgo bindings do not build, so
+// driver_modernc.go substitutes the pure-Go modernc driver instead.
+const checkpointDriverName = "sqlite3"
+
+// checkpointDSN builds the sqlite3 DSN for the checkpoint database. The rw
+// path mirrors internal/db.Open's pragmas (WAL, busy timeout, NORMAL
+// synchronous); the ro path opens with mode=ro and no immutable hint, since
+// the checkpoint database can be concurrently rewritten by another
+// agentsview process, and carries its own busy timeout so a reader waits out
+// a concurrent writer's lock instead of failing immediately with SQLITE_BUSY.
+//
+// Both branches emit a file: URI. mattn/go-sqlite3 forwards the `_`-prefixed
+// pragma params either way, but it only honors mode=ro when the DSN carries
+// the file: scheme — a bare path silently opens read-write, so the ro
+// contract depends on the prefix.
+//
+// The path component is percent-encoded (slashes kept intact): SQLite
+// percent-decodes URI paths and splits params at `?`, so a raw path
+// containing `%`, `?`, or `#` would be misparsed — e.g. a literal "%41" in a
+// directory name would silently open a different file.
+func checkpointDSN(path string, readOnly bool) string {
+	params := url.Values{}
+	if readOnly {
+		params.Set("mode", "ro")
+		params.Set("_busy_timeout", "5000")
+	} else {
+		params.Set("_journal_mode", "WAL")
+		params.Set("_busy_timeout", "5000")
+		params.Set("_synchronous", "NORMAL")
+	}
+	escaped := (&url.URL{Path: path}).EscapedPath()
+	return "file:" + escaped + "?" + params.Encode()
+}

--- a/internal/rawcheckpoint/driver_modernc.go
+++ b/internal/rawcheckpoint/driver_modernc.go
@@ -1,0 +1,40 @@
+//go:build windows || !cgo
+
+package rawcheckpoint
+
+import (
+	"net/url"
+
+	_ "modernc.org/sqlite"
+)
+
+// checkpointDriverName selects the database/sql driver the checkpoint
+// database opens with. The cgo bindings do not build on Windows, so the
+// checkpoint database opens with modernc's pure-Go "sqlite" driver there.
+// The main archive keeps its own driver — only the checkpoint database
+// switches.
+const checkpointDriverName = "sqlite"
+
+// checkpointDSN builds the modernc "sqlite" DSN for the checkpoint database,
+// matching the pragmas driver_cgo.go sets through mattn's `_`-prefixed
+// params: WAL, busy timeout, and NORMAL synchronous on the rw path; mode=ro
+// plus a busy timeout on the ro path so a reader waits out a concurrent
+// writer's lock instead of failing immediately with SQLITE_BUSY. modernc
+// expresses connection pragmas as repeated `_pragma=name(value)` params on a
+// file: URI.
+//
+// The path component is percent-encoded (slashes kept intact) for the same
+// reason as driver_cgo.go: SQLite percent-decodes URI paths and splits
+// params at `?`, so a raw `%`, `?`, or `#` in the path would be misparsed.
+func checkpointDSN(path string, readOnly bool) string {
+	params := url.Values{}
+	params.Add("_pragma", "busy_timeout(5000)")
+	if readOnly {
+		params.Set("mode", "ro")
+	} else {
+		params.Add("_pragma", "journal_mode(WAL)")
+		params.Add("_pragma", "synchronous(NORMAL)")
+	}
+	escaped := (&url.URL{Path: path}).EscapedPath()
+	return "file:" + escaped + "?" + params.Encode()
+}

--- a/internal/rawcheckpoint/store.go
+++ b/internal/rawcheckpoint/store.go
@@ -232,6 +232,9 @@ func (s *Store) AdvanceHead(
 	if commit.Receipt == "" || commit.ManifestID == "" {
 		return ErrMissingReceipt
 	}
+	if err := rawsync.ValidateCommitResult(commit); err != nil {
+		return fmt.Errorf("rawcheckpoint: invalid commit result: %w", err)
+	}
 	return s.withImmediateWrite(ctx, "advance head", func(conn *sql.Conn) error {
 		var configured string
 		err := conn.QueryRowContext(ctx,

--- a/internal/rawcheckpoint/store.go
+++ b/internal/rawcheckpoint/store.go
@@ -30,6 +30,35 @@ type Store struct {
 	db *sql.DB
 }
 
+func (s *Store) withImmediateWrite(
+	ctx context.Context,
+	operation string,
+	fn func(*sql.Conn) error,
+) error {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: %s: %w", operation, err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return fmt.Errorf("rawcheckpoint: %s: %w", operation, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+	if err := fn(conn); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return fmt.Errorf("rawcheckpoint: %s: %w", operation, err)
+	}
+	committed = true
+	return nil
+}
+
 var ErrMissingReceipt = errors.New(
 	"rawcheckpoint: head advancement requires a durable receipt")
 
@@ -113,37 +142,33 @@ func (s *Store) SetDevice(ctx context.Context, deviceID string) error {
 	if deviceID == "" {
 		return fmt.Errorf("rawcheckpoint: device ID is required")
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("rawcheckpoint: set device: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	var current string
-	err = tx.QueryRowContext(ctx,
-		`SELECT device_id FROM device_config WHERE id = 1`).Scan(&current)
-	switch {
-	case errors.Is(err, sql.ErrNoRows):
-		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO device_config (id, device_id, created_at) VALUES (1, ?, ?)`,
-			deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+	return s.withImmediateWrite(ctx, "set device", func(conn *sql.Conn) error {
+		var current string
+		err := conn.QueryRowContext(ctx,
+			`SELECT device_id FROM device_config WHERE id = 1`).Scan(&current)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			if _, err := conn.ExecContext(ctx,
+				`INSERT INTO device_config (id, device_id, created_at) VALUES (1, ?, ?)`,
+				deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+				return fmt.Errorf("rawcheckpoint: set device: %w", err)
+			}
+		case err != nil:
 			return fmt.Errorf("rawcheckpoint: set device: %w", err)
+		case current == deviceID:
+			return nil
+		default:
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE device_config SET device_id = ?, created_at = ? WHERE id = 1`,
+				deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+				return fmt.Errorf("rawcheckpoint: set device: %w", err)
+			}
+			if _, err := conn.ExecContext(ctx, `DELETE FROM raw_sources`); err != nil {
+				return fmt.Errorf("rawcheckpoint: set device: %w", err)
+			}
 		}
-	case err != nil:
-		return fmt.Errorf("rawcheckpoint: set device: %w", err)
-	case current == deviceID:
 		return nil
-	default:
-		if _, err := tx.ExecContext(ctx,
-			`UPDATE device_config SET device_id = ?, created_at = ? WHERE id = 1`,
-			deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
-			return fmt.Errorf("rawcheckpoint: set device: %w", err)
-		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM raw_sources`); err != nil {
-			return fmt.Errorf("rawcheckpoint: set device: %w", err)
-		}
-	}
-	return tx.Commit()
+	})
 }
 
 // Device returns the recorded device identity and whether one has been set.
@@ -207,54 +232,71 @@ func (s *Store) AdvanceHead(
 	if commit.Receipt == "" || commit.ManifestID == "" {
 		return ErrMissingReceipt
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("rawcheckpoint: advance head: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withImmediateWrite(ctx, "advance head", func(conn *sql.Conn) error {
+		var configured string
+		err := conn.QueryRowContext(ctx,
+			`SELECT device_id FROM device_config WHERE id = 1`).Scan(&configured)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return ErrDeviceNotConfigured
+		case err != nil:
+			return fmt.Errorf("rawcheckpoint: advance head: read device: %w", err)
+		case configured != deviceID:
+			return ErrDeviceMismatch
+		}
 
-	var configured string
-	err = tx.QueryRowContext(ctx,
-		`SELECT device_id FROM device_config WHERE id = 1`).Scan(&configured)
-	switch {
-	case errors.Is(err, sql.ErrNoRows):
-		return ErrDeviceNotConfigured
-	case err != nil:
-		return fmt.Errorf("rawcheckpoint: advance head: read device: %w", err)
-	case configured != deviceID:
-		return ErrDeviceMismatch
-	}
+		var current SourceHead
+		err = conn.QueryRowContext(ctx,
+			`SELECT head_manifest_id, head_receipt, head_generation
+			 FROM raw_sources
+			 WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+			string(provider), configuredRootID, sourceKey,
+		).Scan(&current.ManifestID, &current.Receipt, &current.Generation)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			if expectedParentReceipt != "" {
+				return ErrHeadConflict
+			}
+			_, err = conn.ExecContext(ctx, `INSERT INTO raw_sources
+				(provider, configured_root_id, source_key,
+				 head_manifest_id, head_receipt, head_generation, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				string(provider), configuredRootID, sourceKey,
+				commit.ManifestID, commit.Receipt, commit.Generation,
+				time.Now().UTC().Format(time.RFC3339Nano))
+			if err != nil {
+				return fmt.Errorf("rawcheckpoint: advance head: %w", err)
+			}
+			return nil
+		case err != nil:
+			return fmt.Errorf("rawcheckpoint: advance head: read head: %w", err)
+		}
 
-	result, err := tx.ExecContext(ctx, `INSERT INTO raw_sources
-		(provider, configured_root_id, source_key,
-		 head_manifest_id, head_receipt, head_generation, updated_at)
-		SELECT ?, ?, ?, ?, ?, ?, ?
-		WHERE ?8 = ''
-		   OR ?8 = (SELECT head_receipt FROM raw_sources
-		            WHERE provider = ?1 AND configured_root_id = ?2 AND source_key = ?3)
-		ON CONFLICT(provider, configured_root_id, source_key) DO UPDATE SET
-			head_manifest_id = excluded.head_manifest_id,
-			head_receipt = excluded.head_receipt,
-			head_generation = excluded.head_generation,
-			updated_at = excluded.updated_at
-		WHERE raw_sources.head_receipt = ?8`,
-		string(provider), configuredRootID, sourceKey,
-		commit.ManifestID, commit.Receipt, commit.Generation,
-		time.Now().UTC().Format(time.RFC3339Nano),
-		expectedParentReceipt)
-	if err != nil {
-		return fmt.Errorf("rawcheckpoint: advance head: %w", err)
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("rawcheckpoint: advance head: %w", err)
-	}
-	if rows == 0 {
-		// Either the insert was gated on a nonempty expected parent
-		// receipt for an absent row, or the stored head (never empty
-		// once set) does not match the expected parent receipt: an
-		// older or racing writer lost.
-		return ErrHeadConflict
-	}
-	return tx.Commit()
+		if current.ManifestID == commit.ManifestID &&
+			current.Receipt == commit.Receipt &&
+			current.Generation == commit.Generation {
+			return nil
+		}
+		if commit.Generation <= current.Generation ||
+			current.Receipt != expectedParentReceipt {
+			return ErrHeadConflict
+		}
+		result, err := conn.ExecContext(ctx, `UPDATE raw_sources SET
+			head_manifest_id = ?, head_receipt = ?, head_generation = ?, updated_at = ?
+			WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+			commit.ManifestID, commit.Receipt, commit.Generation,
+			time.Now().UTC().Format(time.RFC3339Nano),
+			string(provider), configuredRootID, sourceKey)
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: advance head: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: advance head: %w", err)
+		}
+		if rows != 1 {
+			return ErrHeadConflict
+		}
+		return nil
+	})
 }

--- a/internal/rawcheckpoint/store.go
+++ b/internal/rawcheckpoint/store.go
@@ -1,0 +1,260 @@
+// Package rawcheckpoint owns the laptop's small local SQLite transport-state
+// database for hosted raw sync. It records device identity and per-source
+// acknowledged head receipts and generations. It is not a chat archive;
+// deleting it forces full source reconciliation and deletes no server data.
+package rawcheckpoint
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+const schemaVersion = 1
+
+// SourceHead is the last server-acknowledged head of one logical source.
+type SourceHead struct {
+	ManifestID string
+	Receipt    string
+	Generation int64
+	UpdatedAt  time.Time
+}
+
+// Store is the durable checkpoint database.
+type Store struct {
+	db *sql.DB
+}
+
+var ErrMissingReceipt = errors.New(
+	"rawcheckpoint: head advancement requires a durable receipt")
+
+var ErrHeadConflict = errors.New(
+	"rawcheckpoint: source head already advanced past the expected parent receipt")
+
+var ErrDeviceNotConfigured = errors.New(
+	"rawcheckpoint: head advancement requires a configured device")
+
+var ErrDeviceMismatch = errors.New(
+	"rawcheckpoint: head advancement is fenced to the configured device")
+
+// Open opens (creating if needed) the checkpoint database at path.
+func Open(ctx context.Context, path string) (*Store, error) {
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: open: %w", err)
+	}
+	store := &Store{db: db}
+	if err := store.init(ctx); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *Store) init(ctx context.Context) error {
+	var version int
+	if err := s.db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&version); err != nil {
+		return fmt.Errorf("rawcheckpoint: read schema version: %w", err)
+	}
+	if version > schemaVersion {
+		return fmt.Errorf("rawcheckpoint: database schema %d is newer than supported %d",
+			version, schemaVersion)
+	}
+	if version == schemaVersion {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: begin schema: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, statement := range []string{
+		`CREATE TABLE IF NOT EXISTS device_config (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			device_id TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS raw_sources (
+			provider TEXT NOT NULL,
+			configured_root_id TEXT NOT NULL,
+			source_key TEXT NOT NULL,
+			head_manifest_id TEXT NOT NULL DEFAULT '',
+			head_receipt TEXT NOT NULL DEFAULT '',
+			head_generation INTEGER NOT NULL DEFAULT 0,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (provider, configured_root_id, source_key)
+		)`,
+	} {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("rawcheckpoint: create schema: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx,
+		fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
+		return fmt.Errorf("rawcheckpoint: set schema version: %w", err)
+	}
+	return tx.Commit()
+}
+
+// Close releases the database handle.
+func (s *Store) Close() error { return s.db.Close() }
+
+// SetDevice records this laptop's device identity, replacing any previously
+// recorded value so re-provisioning overwrites instead of failing. Changing
+// the device identity clears all per-source heads in the same transaction,
+// because the server chains heads per device and a re-provisioned device
+// starts from an empty chain; recording the same device again is a no-op.
+func (s *Store) SetDevice(ctx context.Context, deviceID string) error {
+	if deviceID == "" {
+		return fmt.Errorf("rawcheckpoint: device ID is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: set device: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var current string
+	err = tx.QueryRowContext(ctx,
+		`SELECT device_id FROM device_config WHERE id = 1`).Scan(&current)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO device_config (id, device_id, created_at) VALUES (1, ?, ?)`,
+			deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+			return fmt.Errorf("rawcheckpoint: set device: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("rawcheckpoint: set device: %w", err)
+	case current == deviceID:
+		return nil
+	default:
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE device_config SET device_id = ?, created_at = ? WHERE id = 1`,
+			deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+			return fmt.Errorf("rawcheckpoint: set device: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM raw_sources`); err != nil {
+			return fmt.Errorf("rawcheckpoint: set device: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// Device returns the recorded device identity and whether one has been set.
+func (s *Store) Device(ctx context.Context) (string, bool, error) {
+	var deviceID string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT device_id FROM device_config WHERE id = 1`).Scan(&deviceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("rawcheckpoint: read device: %w", err)
+	}
+	return deviceID, true, nil
+}
+
+// SourceHead returns the acknowledged head for one logical source.
+func (s *Store) SourceHead(
+	ctx context.Context,
+	provider parser.AgentType,
+	configuredRootID, sourceKey string,
+) (SourceHead, bool, error) {
+	var head SourceHead
+	var updated string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT head_manifest_id, head_receipt, head_generation, updated_at
+		FROM raw_sources
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+		string(provider), configuredRootID, sourceKey,
+	).Scan(&head.ManifestID, &head.Receipt, &head.Generation, &updated)
+	if errors.Is(err, sql.ErrNoRows) {
+		return SourceHead{}, false, nil
+	}
+	if err != nil {
+		return SourceHead{}, false, fmt.Errorf("rawcheckpoint: read head: %w", err)
+	}
+	head.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updated)
+	return head, true, nil
+}
+
+// AdvanceHead records a newly acknowledged head using the server's own
+// commit semantics: expectedParentReceipt must equal the stored head receipt
+// — empty only while no head exists yet, and then required to be empty, so a
+// delayed older commit result can never overwrite a newer acknowledged head
+// nor manufacture a head out of thin air. Replaying the acknowledged head's
+// own commit is idempotent. Advancement is fenced to the configured device
+// and validated atomically: the caller's deviceID must match the recorded
+// device_config identity in the same transaction that performs the
+// compare-and-swap, so a stale in-flight ack from a re-provisioned device
+// can never repopulate heads that SetDevice cleared. Callers must pass the
+// server's durable CommitResult; an empty receipt is refused so no unsafe
+// checkpoint can advance.
+func (s *Store) AdvanceHead(
+	ctx context.Context,
+	deviceID string,
+	provider parser.AgentType,
+	configuredRootID, sourceKey string,
+	expectedParentReceipt string,
+	commit rawsync.CommitResult,
+) error {
+	if commit.Receipt == "" || commit.ManifestID == "" {
+		return ErrMissingReceipt
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: advance head: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var configured string
+	err = tx.QueryRowContext(ctx,
+		`SELECT device_id FROM device_config WHERE id = 1`).Scan(&configured)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return ErrDeviceNotConfigured
+	case err != nil:
+		return fmt.Errorf("rawcheckpoint: advance head: read device: %w", err)
+	case configured != deviceID:
+		return ErrDeviceMismatch
+	}
+
+	result, err := tx.ExecContext(ctx, `INSERT INTO raw_sources
+		(provider, configured_root_id, source_key,
+		 head_manifest_id, head_receipt, head_generation, updated_at)
+		SELECT ?, ?, ?, ?, ?, ?, ?
+		WHERE ?8 = ''
+		   OR ?8 = (SELECT head_receipt FROM raw_sources
+		            WHERE provider = ?1 AND configured_root_id = ?2 AND source_key = ?3)
+		ON CONFLICT(provider, configured_root_id, source_key) DO UPDATE SET
+			head_manifest_id = excluded.head_manifest_id,
+			head_receipt = excluded.head_receipt,
+			head_generation = excluded.head_generation,
+			updated_at = excluded.updated_at
+		WHERE raw_sources.head_receipt = ?8`,
+		string(provider), configuredRootID, sourceKey,
+		commit.ManifestID, commit.Receipt, commit.Generation,
+		time.Now().UTC().Format(time.RFC3339Nano),
+		expectedParentReceipt)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: advance head: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: advance head: %w", err)
+	}
+	if rows == 0 {
+		// Either the insert was gated on a nonempty expected parent
+		// receipt for an absent row, or the stored head (never empty
+		// once set) does not match the expected parent receipt: an
+		// older or racing writer lost.
+		return ErrHeadConflict
+	}
+	return tx.Commit()
+}

--- a/internal/rawcheckpoint/store.go
+++ b/internal/rawcheckpoint/store.go
@@ -221,6 +221,8 @@ func (s *Store) SourceHead(
 // can never repopulate heads that SetDevice cleared. Callers must pass the
 // server's durable CommitResult; an empty receipt is refused so no unsafe
 // checkpoint can advance.
+// A new source must begin at generation one, and each non-replay advancement
+// must be exactly the next generation; acknowledgements cannot skip state.
 func (s *Store) AdvanceHead(
 	ctx context.Context,
 	deviceID string,
@@ -257,7 +259,7 @@ func (s *Store) AdvanceHead(
 		).Scan(&current.ManifestID, &current.Receipt, &current.Generation)
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			if expectedParentReceipt != "" {
+			if expectedParentReceipt != "" || commit.Generation != 1 {
 				return ErrHeadConflict
 			}
 			_, err = conn.ExecContext(ctx, `INSERT INTO raw_sources
@@ -280,7 +282,7 @@ func (s *Store) AdvanceHead(
 			current.Generation == commit.Generation {
 			return nil
 		}
-		if commit.Generation <= current.Generation ||
+		if commit.Generation-current.Generation != 1 ||
 			current.Receipt != expectedParentReceipt {
 			return ErrHeadConflict
 		}

--- a/internal/rawcheckpoint/store_test.go
+++ b/internal/rawcheckpoint/store_test.go
@@ -20,6 +20,14 @@ func openTestStore(t *testing.T) *Store {
 	return store
 }
 
+func testCommitResult(sequence int, generation int64) rawsync.CommitResult {
+	return rawsync.CommitResult{
+		ManifestID: fmt.Sprintf("%064x", sequence*2),
+		Receipt:    fmt.Sprintf("%064x", sequence*2+1),
+		Generation: generation,
+	}
+}
+
 func TestStoreDeviceRoundTrip(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
@@ -36,9 +44,56 @@ func TestStoreDeviceRoundTrip(t *testing.T) {
 func TestStoreAdvanceHeadRequiresReceipt(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
+	commit := testCommitResult(1, 1)
+	commit.Receipt = ""
 	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1",
-		"src-1", "", rawsync.CommitResult{ManifestID: "rm_1"})
+		"src-1", "", commit)
 	require.ErrorIs(t, err, ErrMissingReceipt)
+}
+
+func TestStoreAdvanceHeadRejectsInvalidCommitResult(t *testing.T) {
+	t.Parallel()
+	valid := testCommitResult(1, 1)
+	tests := []struct {
+		name   string
+		commit rawsync.CommitResult
+	}{
+		{
+			name: "noncanonical manifest ID",
+			commit: rawsync.CommitResult{
+				ManifestID: "rm_1", Receipt: valid.Receipt, Generation: 1,
+			},
+		},
+		{
+			name: "uppercase receipt",
+			commit: rawsync.CommitResult{
+				ManifestID: valid.ManifestID,
+				Receipt:    "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+				Generation: 1,
+			},
+		},
+		{
+			name: "zero generation",
+			commit: rawsync.CommitResult{
+				ManifestID: valid.ManifestID, Receipt: valid.Receipt, Generation: 0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			store := openTestStore(t)
+			require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+
+			err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
+				"root-1", "src-1", "", tt.commit)
+			require.ErrorIs(t, err, rawsync.ErrInvalid)
+			_, ok, readErr := store.SourceHead(t.Context(), parser.AgentClaude,
+				"root-1", "src-1")
+			require.NoError(t, readErr)
+			assert.False(t, ok, "invalid commit result must not persist a source head")
+		})
+	}
 }
 
 func TestStoreHeadLifecycle(t *testing.T) {
@@ -49,21 +104,21 @@ func TestStoreHeadLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 
-	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 4}
+	first := testCommitResult(1, 4)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, "rr_1", head.Receipt)
+	assert.Equal(t, first.Receipt, head.Receipt)
 	assert.Equal(t, int64(4), head.Generation)
-	assert.Equal(t, "rm_1", head.ManifestID)
+	assert.Equal(t, first.ManifestID, head.ManifestID)
 
-	second := rawsync.CommitResult{ManifestID: "rm_2", Receipt: "rr_2", Generation: 5}
-	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "rr_1", second))
+	second := testCommitResult(2, 5)
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", first.Receipt, second))
 	head, ok, err = store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, "rr_2", head.Receipt)
+	assert.Equal(t, second.Receipt, head.Receipt)
 }
 
 func TestStorePersistsAcrossReopen(t *testing.T) {
@@ -72,8 +127,8 @@ func TestStorePersistsAcrossReopen(t *testing.T) {
 	store, err := Open(t.Context(), path)
 	require.NoError(t, err)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_persist"))
-	require.NoError(t, store.AdvanceHead(t.Context(), "dev_persist", parser.AgentClaude, "r", "s", "",
-		rawsync.CommitResult{ManifestID: "rm", Receipt: "rr", Generation: 1}))
+	commit := testCommitResult(1, 1)
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_persist", parser.AgentClaude, "r", "s", "", commit))
 	require.NoError(t, store.Close())
 
 	reopened, err := Open(t.Context(), path)
@@ -82,27 +137,27 @@ func TestStorePersistsAcrossReopen(t *testing.T) {
 	head, ok, err := reopened.SourceHead(t.Context(), parser.AgentClaude, "r", "s")
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, "rr", head.Receipt)
+	assert.Equal(t, commit.Receipt, head.Receipt)
 }
 
 func TestStoreAdvanceHeadRejectsStaleParent(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 4}
+	first := testCommitResult(1, 4)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 
 	// A delayed second-generation result carrying the stale parent receipt
 	// must never overwrite the newer acknowledged head.
-	stale := rawsync.CommitResult{ManifestID: "rm_2", Receipt: "rr_2", Generation: 5}
+	stale := testCommitResult(2, 5)
 	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", stale)
 	require.ErrorIs(t, err, ErrHeadConflict)
 
 	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, "rr_1", head.Receipt)
-	assert.Equal(t, "rm_1", head.ManifestID)
+	assert.Equal(t, first.Receipt, head.Receipt)
+	assert.Equal(t, first.ManifestID, head.ManifestID)
 	assert.Equal(t, int64(4), head.Generation)
 }
 
@@ -110,7 +165,7 @@ func TestStoreAdvanceHeadIdempotentReplay(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 4}
+	first := testCommitResult(1, 4)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 
 	// A retried manifest carries the same parent it used for the original
@@ -120,8 +175,8 @@ func TestStoreAdvanceHeadIdempotentReplay(t *testing.T) {
 	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, "rr_1", head.Receipt)
-	assert.Equal(t, "rm_1", head.ManifestID)
+	assert.Equal(t, first.Receipt, head.Receipt)
+	assert.Equal(t, first.ManifestID, head.ManifestID)
 	assert.Equal(t, int64(4), head.Generation)
 }
 
@@ -129,13 +184,13 @@ func TestStoreAdvanceHeadRejectsLowerGeneration(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	current := rawsync.CommitResult{ManifestID: "rm_5", Receipt: "rr_5", Generation: 5}
+	current := testCommitResult(5, 5)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
 		"root-1", "src-1", "", current))
 
-	older := rawsync.CommitResult{ManifestID: "rm_4", Receipt: "rr_4", Generation: 4}
+	older := testCommitResult(4, 4)
 	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
-		"root-1", "src-1", "rr_5", older)
+		"root-1", "src-1", current.Receipt, older)
 	require.ErrorIs(t, err, ErrHeadConflict)
 	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
@@ -153,11 +208,7 @@ func TestStoreConcurrentAdvanceHeadReturnsCASResults(t *testing.T) {
 	start := make(chan struct{})
 	results := make(chan error, writers)
 	for i := range writers {
-		commit := rawsync.CommitResult{
-			ManifestID: fmt.Sprintf("rm_%d", i),
-			Receipt:    fmt.Sprintf("rr_%d", i),
-			Generation: 1,
-		}
+		commit := testCommitResult(i, 1)
 		go func() {
 			<-start
 			results <- store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
@@ -186,8 +237,8 @@ func TestStoreSetDeviceChangeClearsHeads(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "",
-		rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 1}))
+	first := testCommitResult(1, 1)
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 
 	// Re-provisioning under a different device identity clears per-source
 	// heads: the server chains heads per device, so the new device starts
@@ -203,7 +254,7 @@ func TestStoreSetDeviceChangeClearsHeads(t *testing.T) {
 
 	// The new chain advances from empty, and recording the same device
 	// again is a no-op that keeps both the head and the provisioning time.
-	fresh := rawsync.CommitResult{ManifestID: "rm_2", Receipt: "rr_2", Generation: 1}
+	fresh := testCommitResult(2, 1)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_2", parser.AgentClaude, "root-1", "src-1", "", fresh))
 	var createdAt string
 	require.NoError(t, store.db.QueryRowContext(t.Context(),
@@ -212,7 +263,7 @@ func TestStoreSetDeviceChangeClearsHeads(t *testing.T) {
 	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, "rr_2", head.Receipt)
+	assert.Equal(t, fresh.Receipt, head.Receipt)
 	var createdAtAfter string
 	require.NoError(t, store.db.QueryRowContext(t.Context(),
 		`SELECT created_at FROM device_config WHERE id = 1`).Scan(&createdAtAfter))
@@ -224,8 +275,9 @@ func TestStoreSetDeviceChangeClearsHeads(t *testing.T) {
 func TestStoreAdvanceHeadRequiresConfiguredDevice(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
+	commit := testCommitResult(1, 1)
 	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "",
-		rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 1})
+		commit)
 	require.ErrorIs(t, err, ErrDeviceNotConfigured)
 }
 
@@ -236,18 +288,18 @@ func TestStoreAdvanceHeadRejectsForeignDevice(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 1}
+	first := testCommitResult(1, 1)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 
 	// A different device may not advance dev_1's chain even with the
 	// correct expected parent receipt.
-	second := rawsync.CommitResult{ManifestID: "rm_2", Receipt: "rr_2", Generation: 2}
-	err := store.AdvanceHead(t.Context(), "dev_2", parser.AgentClaude, "root-1", "src-1", "rr_1", second)
+	second := testCommitResult(2, 2)
+	err := store.AdvanceHead(t.Context(), "dev_2", parser.AgentClaude, "root-1", "src-1", first.Receipt, second)
 	require.ErrorIs(t, err, ErrDeviceMismatch)
 	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, "rr_1", head.Receipt)
+	assert.Equal(t, first.Receipt, head.Receipt)
 
 	// Re-provisioning clears heads; a delayed first-generation ack from
 	// dev_1 (empty expected parent) must not repopulate dev_2's chain.
@@ -266,8 +318,9 @@ func TestStoreAdvanceHeadAbsentSourceRequiresEmptyParent(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	commit := rawsync.CommitResult{ManifestID: "rm_ghost", Receipt: "rr_ghost_child", Generation: 1}
-	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "rr_ghost", commit)
+	commit := testCommitResult(1, 1)
+	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1",
+		testCommitResult(2, 1).Receipt, commit)
 	require.ErrorIs(t, err, ErrHeadConflict)
 	_, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)

--- a/internal/rawcheckpoint/store_test.go
+++ b/internal/rawcheckpoint/store_test.go
@@ -96,6 +96,41 @@ func TestStoreAdvanceHeadRejectsInvalidCommitResult(t *testing.T) {
 	}
 }
 
+func TestStoreAdvanceHeadRequiresFirstGeneration(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+
+	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
+		"root-1", "src-1", "", testCommitResult(1, 2))
+	require.ErrorIs(t, err, ErrHeadConflict)
+	_, ok, readErr := store.SourceHead(t.Context(), parser.AgentClaude,
+		"root-1", "src-1")
+	require.NoError(t, readErr)
+	assert.False(t, ok, "a source chain may not begin after generation one")
+}
+
+func TestStoreAdvanceHeadRejectsGenerationGap(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	first := testCommitResult(1, 1)
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
+		"root-1", "src-1", "", first))
+
+	gap := testCommitResult(3, 3)
+	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
+		"root-1", "src-1", first.Receipt, gap)
+	require.ErrorIs(t, err, ErrHeadConflict)
+	head, ok, readErr := store.SourceHead(t.Context(), parser.AgentClaude,
+		"root-1", "src-1")
+	require.NoError(t, readErr)
+	require.True(t, ok)
+	assert.Equal(t, first.ManifestID, head.ManifestID)
+	assert.Equal(t, first.Receipt, head.Receipt)
+	assert.Equal(t, first.Generation, head.Generation)
+}
+
 func TestStoreHeadLifecycle(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
@@ -104,16 +139,16 @@ func TestStoreHeadLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 
-	first := testCommitResult(1, 4)
+	first := testCommitResult(1, 1)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, first.Receipt, head.Receipt)
-	assert.Equal(t, int64(4), head.Generation)
+	assert.Equal(t, int64(1), head.Generation)
 	assert.Equal(t, first.ManifestID, head.ManifestID)
 
-	second := testCommitResult(2, 5)
+	second := testCommitResult(2, 2)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", first.Receipt, second))
 	head, ok, err = store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
@@ -144,12 +179,12 @@ func TestStoreAdvanceHeadRejectsStaleParent(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	first := testCommitResult(1, 4)
+	first := testCommitResult(1, 1)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 
 	// A delayed second-generation result carrying the stale parent receipt
 	// must never overwrite the newer acknowledged head.
-	stale := testCommitResult(2, 5)
+	stale := testCommitResult(2, 2)
 	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", stale)
 	require.ErrorIs(t, err, ErrHeadConflict)
 
@@ -158,14 +193,14 @@ func TestStoreAdvanceHeadRejectsStaleParent(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, first.Receipt, head.Receipt)
 	assert.Equal(t, first.ManifestID, head.ManifestID)
-	assert.Equal(t, int64(4), head.Generation)
+	assert.Equal(t, int64(1), head.Generation)
 }
 
 func TestStoreAdvanceHeadIdempotentReplay(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	first := testCommitResult(1, 4)
+	first := testCommitResult(1, 1)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 
 	// A retried manifest carries the same parent it used for the original
@@ -177,18 +212,21 @@ func TestStoreAdvanceHeadIdempotentReplay(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, first.Receipt, head.Receipt)
 	assert.Equal(t, first.ManifestID, head.ManifestID)
-	assert.Equal(t, int64(4), head.Generation)
+	assert.Equal(t, int64(1), head.Generation)
 }
 
 func TestStoreAdvanceHeadRejectsLowerGeneration(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t)
 	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
-	current := testCommitResult(5, 5)
+	first := testCommitResult(1, 1)
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
-		"root-1", "src-1", "", current))
+		"root-1", "src-1", "", first))
+	current := testCommitResult(2, 2)
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
+		"root-1", "src-1", first.Receipt, current))
 
-	older := testCommitResult(4, 4)
+	older := testCommitResult(3, 1)
 	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
 		"root-1", "src-1", current.Receipt, older)
 	require.ErrorIs(t, err, ErrHeadConflict)

--- a/internal/rawcheckpoint/store_test.go
+++ b/internal/rawcheckpoint/store_test.go
@@ -1,0 +1,215 @@
+package rawcheckpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(t.Context(), t.TempDir()+"/rawcheckpoint.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store
+}
+
+func TestStoreDeviceRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	_, ok, err := store.Device(t.Context())
+	require.NoError(t, err)
+	assert.False(t, ok)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	device, ok, err := store.Device(t.Context())
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "dev_1", device)
+}
+
+func TestStoreAdvanceHeadRequiresReceipt(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1",
+		"src-1", "", rawsync.CommitResult{ManifestID: "rm_1"})
+	require.ErrorIs(t, err, ErrMissingReceipt)
+}
+
+func TestStoreHeadLifecycle(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	_, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 4}
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
+	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "rr_1", head.Receipt)
+	assert.Equal(t, int64(4), head.Generation)
+	assert.Equal(t, "rm_1", head.ManifestID)
+
+	second := rawsync.CommitResult{ManifestID: "rm_2", Receipt: "rr_2", Generation: 5}
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "rr_1", second))
+	head, ok, err = store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "rr_2", head.Receipt)
+}
+
+func TestStorePersistsAcrossReopen(t *testing.T) {
+	t.Parallel()
+	path := t.TempDir() + "/rawcheckpoint.db"
+	store, err := Open(t.Context(), path)
+	require.NoError(t, err)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_persist"))
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_persist", parser.AgentClaude, "r", "s", "",
+		rawsync.CommitResult{ManifestID: "rm", Receipt: "rr", Generation: 1}))
+	require.NoError(t, store.Close())
+
+	reopened, err := Open(t.Context(), path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+	head, ok, err := reopened.SourceHead(t.Context(), parser.AgentClaude, "r", "s")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "rr", head.Receipt)
+}
+
+func TestStoreAdvanceHeadRejectsStaleParent(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 4}
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
+
+	// A delayed second-generation result carrying the stale parent receipt
+	// must never overwrite the newer acknowledged head.
+	stale := rawsync.CommitResult{ManifestID: "rm_2", Receipt: "rr_2", Generation: 5}
+	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", stale)
+	require.ErrorIs(t, err, ErrHeadConflict)
+
+	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "rr_1", head.Receipt)
+	assert.Equal(t, "rm_1", head.ManifestID)
+	assert.Equal(t, int64(4), head.Generation)
+}
+
+func TestStoreAdvanceHeadIdempotentReplay(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 4}
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
+
+	// Re-acknowledging the stored head with its own receipt passes the
+	// compare-and-swap and rewrites identical values.
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "rr_1", first))
+	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "rr_1", head.Receipt)
+	assert.Equal(t, "rm_1", head.ManifestID)
+	assert.Equal(t, int64(4), head.Generation)
+}
+
+func TestStoreSetDeviceChangeClearsHeads(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "",
+		rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 1}))
+
+	// Re-provisioning under a different device identity clears per-source
+	// heads: the server chains heads per device, so the new device starts
+	// from an empty chain.
+	require.NoError(t, store.SetDevice(t.Context(), "dev_2"))
+	device, ok, err := store.Device(t.Context())
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "dev_2", device)
+	_, ok, err = store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// The new chain advances from empty, and recording the same device
+	// again is a no-op that keeps both the head and the provisioning time.
+	fresh := rawsync.CommitResult{ManifestID: "rm_2", Receipt: "rr_2", Generation: 1}
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_2", parser.AgentClaude, "root-1", "src-1", "", fresh))
+	var createdAt string
+	require.NoError(t, store.db.QueryRowContext(t.Context(),
+		`SELECT created_at FROM device_config WHERE id = 1`).Scan(&createdAt))
+	require.NoError(t, store.SetDevice(t.Context(), "dev_2"))
+	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "rr_2", head.Receipt)
+	var createdAtAfter string
+	require.NoError(t, store.db.QueryRowContext(t.Context(),
+		`SELECT created_at FROM device_config WHERE id = 1`).Scan(&createdAtAfter))
+	assert.Equal(t, createdAt, createdAtAfter)
+}
+
+// TestStoreAdvanceHeadRequiresConfiguredDevice: advancement before any
+// device identity is recorded is refused, not defaulted.
+func TestStoreAdvanceHeadRequiresConfiguredDevice(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "",
+		rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 1})
+	require.ErrorIs(t, err, ErrDeviceNotConfigured)
+}
+
+// TestStoreAdvanceHeadRejectsForeignDevice: only the configured device may
+// advance heads — including after re-provisioning cleared them, when a
+// stale in-flight ack from the previous device must not repopulate heads.
+func TestStoreAdvanceHeadRejectsForeignDevice(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 1}
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
+
+	// A different device may not advance dev_1's chain even with the
+	// correct expected parent receipt.
+	second := rawsync.CommitResult{ManifestID: "rm_2", Receipt: "rr_2", Generation: 2}
+	err := store.AdvanceHead(t.Context(), "dev_2", parser.AgentClaude, "root-1", "src-1", "rr_1", second)
+	require.ErrorIs(t, err, ErrDeviceMismatch)
+	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "rr_1", head.Receipt)
+
+	// Re-provisioning clears heads; a delayed first-generation ack from
+	// dev_1 (empty expected parent) must not repopulate dev_2's chain.
+	require.NoError(t, store.SetDevice(t.Context(), "dev_2"))
+	err = store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first)
+	require.ErrorIs(t, err, ErrDeviceMismatch)
+	_, ok, err = store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// TestStoreAdvanceHeadAbsentSourceRequiresEmptyParent: the absent-row insert
+// is gated on an empty expected parent receipt, exactly like the
+// conflict-update path.
+func TestStoreAdvanceHeadAbsentSourceRequiresEmptyParent(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	commit := rawsync.CommitResult{ManifestID: "rm_ghost", Receipt: "rr_ghost_child", Generation: 1}
+	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "rr_ghost", commit)
+	require.ErrorIs(t, err, ErrHeadConflict)
+	_, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	assert.False(t, ok, "no row may be created for a nonempty expected parent")
+}

--- a/internal/rawcheckpoint/store_test.go
+++ b/internal/rawcheckpoint/store_test.go
@@ -1,6 +1,8 @@
 package rawcheckpoint
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,15 +113,73 @@ func TestStoreAdvanceHeadIdempotentReplay(t *testing.T) {
 	first := rawsync.CommitResult{ManifestID: "rm_1", Receipt: "rr_1", Generation: 4}
 	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 
-	// Re-acknowledging the stored head with its own receipt passes the
-	// compare-and-swap and rewrites identical values.
-	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "rr_1", first))
+	// A retried manifest carries the same parent it used for the original
+	// commit. Recognize the identical committed result without requiring the
+	// now-current receipt as a fabricated parent.
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first))
 	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "rr_1", head.Receipt)
 	assert.Equal(t, "rm_1", head.ManifestID)
 	assert.Equal(t, int64(4), head.Generation)
+}
+
+func TestStoreAdvanceHeadRejectsLowerGeneration(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	current := rawsync.CommitResult{ManifestID: "rm_5", Receipt: "rr_5", Generation: 5}
+	require.NoError(t, store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
+		"root-1", "src-1", "", current))
+
+	older := rawsync.CommitResult{ManifestID: "rm_4", Receipt: "rr_4", Generation: 4}
+	err := store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
+		"root-1", "src-1", "rr_5", older)
+	require.ErrorIs(t, err, ErrHeadConflict)
+	head, ok, err := store.SourceHead(t.Context(), parser.AgentClaude, "root-1", "src-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, current.ManifestID, head.ManifestID)
+	assert.Equal(t, current.Receipt, head.Receipt)
+	assert.Equal(t, current.Generation, head.Generation)
+}
+
+func TestStoreConcurrentAdvanceHeadReturnsCASResults(t *testing.T) {
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+
+	const writers = 16
+	start := make(chan struct{})
+	results := make(chan error, writers)
+	for i := range writers {
+		commit := rawsync.CommitResult{
+			ManifestID: fmt.Sprintf("rm_%d", i),
+			Receipt:    fmt.Sprintf("rr_%d", i),
+			Generation: 1,
+		}
+		go func() {
+			<-start
+			results <- store.AdvanceHead(t.Context(), "dev_1", parser.AgentClaude,
+				"root-1", "src-1", "", commit)
+		}()
+	}
+	close(start)
+
+	var successes, conflicts int
+	for range writers {
+		err := <-results
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrHeadConflict):
+			conflicts++
+		default:
+			assert.NoError(t, err, "concurrent writers must return a CAS result")
+		}
+	}
+	assert.Equal(t, 1, successes)
+	assert.Equal(t, writers-1, conflicts)
 }
 
 func TestStoreSetDeviceChangeClearsHeads(t *testing.T) {

--- a/internal/rawclient/client.go
+++ b/internal/rawclient/client.go
@@ -1,0 +1,264 @@
+// Package rawclient is the laptop-side HTTP client for the authenticated
+// raw-ingest transport: scoped-token exchange, missing-object negotiation,
+// resumable object uploads, and manifest-last commits.
+package rawclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// octetBody marks a raw pre-encoded request body. doOnce sends it verbatim
+// instead of JSON-encoding it, so octet-stream uploads reuse the same
+// authenticated retry path as JSON requests.
+type octetBody struct {
+	data []byte
+}
+
+// Error codes produced by the raw-sync HTTP surface.
+const (
+	CodeUnauthorized     = "unauthorized"
+	CodeInvalidRequest   = "invalid_request"
+	CodeNotFound         = "not_found"
+	CodeConflict         = "conflict"
+	CodeMissingObject    = "missing_object"
+	CodeHeadConflict     = "head_conflict"
+	CodeUploadOffset     = "upload_offset_conflict"
+	CodeChecksumMismatch = "checksum_mismatch"
+	// Gateway timeouts must be matched on HTTP Status 504, not this code field.
+	CodeGatewayTimeout = "gateway_timeout"
+	CodeInternal       = "internal_error"
+)
+
+const (
+	defaultChunkBytes  = int64(4 << 20) // matches rawsync.DefaultUploadChunkBytes
+	defaultTokenMargin = time.Minute
+)
+
+// maxErrorBodyBytes caps how much of an error response body is read before
+// decoding it; larger bodies are truncated, never buffered whole.
+const maxErrorBodyBytes = 64 << 10
+
+// APIError is a decoded raw-sync API error response.
+type APIError struct {
+	Status              int    `json:"-"`
+	Code                string `json:"code,omitempty"`
+	Message             string `json:"error"`
+	CurrentManifestID   string `json:"current_manifest_id,omitempty"`
+	CurrentReceipt      string `json:"current_receipt,omitempty"`
+	CurrentGeneration   int64  `json:"current_generation,omitzero"`
+	CurrentUploadOffset *int64 `json:"upload_offset,omitempty"`
+}
+
+func (e *APIError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("raw sync api error %d %s: %s", e.Status, e.Code, e.Message)
+	}
+	return fmt.Sprintf("raw sync api error %d: %s", e.Status, e.Message)
+}
+
+// AsAPIError reports whether err carries a decoded API error, copying it into
+// out when it does.
+func AsAPIError(err error, out *APIError) bool {
+	if apiErr, ok := errors.AsType[*APIError](err); ok {
+		*out = *apiErr
+		return true
+	}
+	return false
+}
+
+// wireError mirrors the server's error response shape. The server always
+// sets "error", so an empty message means the body was not an API error.
+type wireError struct {
+	Code                string `json:"code,omitempty"`
+	Message             string `json:"error"`
+	CurrentManifestID   string `json:"current_manifest_id,omitempty"`
+	CurrentReceipt      string `json:"current_receipt,omitempty"`
+	CurrentGeneration   int64  `json:"current_generation,omitzero"`
+	CurrentUploadOffset *int64 `json:"upload_offset,omitempty"`
+}
+
+// decodeAPIError converts a non-2xx response body into an *APIError. Bodies
+// that do not decode as a wire error still report the status under
+// CodeInternal, so transport failures never vanish.
+func decodeAPIError(status int, body []byte) error {
+	apiErr := &APIError{Status: status}
+	var wire wireError
+	if err := json.Unmarshal(body, &wire); err == nil && wire.Message != "" {
+		apiErr.Code = wire.Code
+		apiErr.Message = wire.Message
+		apiErr.CurrentManifestID = wire.CurrentManifestID
+		apiErr.CurrentReceipt = wire.CurrentReceipt
+		apiErr.CurrentGeneration = wire.CurrentGeneration
+		apiErr.CurrentUploadOffset = wire.CurrentUploadOffset
+	} else {
+		apiErr.Code = CodeInternal
+		apiErr.Message = "raw sync request failed"
+	}
+	return apiErr
+}
+
+// Config constructs a Client. Credential holds the injected avdc_ device
+// credential; the client never persists or logs it.
+type Config struct {
+	BaseURL     string
+	DeviceID    string
+	Credential  string
+	HTTPClient  *http.Client
+	ChunkBytes  int64
+	TokenMargin time.Duration
+}
+
+// Client talks to one agentsview server's raw-sync surface for one device.
+type Client struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+	tokens     *tokenProvider
+	chunkBytes int64
+}
+
+// NewClient validates configuration and returns a Client that authenticates
+// each do request with scoped avdt_ bearer tokens, exchanged on demand for
+// the device credential. A zero TokenMargin falls back to defaultTokenMargin.
+func NewClient(cfg Config) (*Client, error) {
+	base, err := url.Parse(strings.TrimRight(cfg.BaseURL, "/"))
+	if err != nil || base.Scheme == "" || base.Host == "" {
+		return nil, fmt.Errorf("rawclient: invalid base URL %q", cfg.BaseURL)
+	}
+	if cfg.DeviceID == "" || cfg.Credential == "" {
+		return nil, fmt.Errorf("rawclient: device ID and credential are required")
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Minute}
+	}
+	chunkBytes := cfg.ChunkBytes
+	if chunkBytes <= 0 {
+		chunkBytes = defaultChunkBytes
+	}
+	if chunkBytes > rawsync.DefaultUploadChunkBytes {
+		chunkBytes = rawsync.DefaultUploadChunkBytes
+	}
+	client := &Client{
+		baseURL:    base,
+		httpClient: httpClient,
+		chunkBytes: chunkBytes,
+	}
+	margin := cfg.TokenMargin
+	if margin <= 0 {
+		margin = defaultTokenMargin
+	}
+	client.tokens = newTokenProvider(client, cfg.DeviceID, cfg.Credential, margin)
+	return client, nil
+}
+
+// do performs one authenticated JSON request, retrying exactly once with a
+// refreshed token after an unauthorized response. The request body, when
+// non-nil, is encoded with encoding/json/v2 semantics.
+func (c *Client) do(
+	ctx context.Context,
+	method string,
+	path string,
+	header http.Header,
+	body any,
+) (*http.Response, error) {
+	for attempt := 0; ; attempt++ {
+		token, err := c.tokens.token(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.doOnce(ctx, method, path, header, body, token)
+		if err == nil {
+			return resp, nil
+		}
+		var apiErr APIError
+		if attempt >= 1 ||
+			!AsAPIError(err, &apiErr) || apiErr.Status != http.StatusUnauthorized {
+			return nil, err
+		}
+		c.tokens.invalidate()
+	}
+}
+
+// doOnce sends a single request with the given bearer token. It returns the
+// response for 2xx statuses; any other status becomes an *APIError decoded
+// from at most maxErrorBodyBytes of the body.
+func (c *Client) doOnce(
+	ctx context.Context,
+	method string,
+	path string,
+	header http.Header,
+	body any,
+	token string,
+) (*http.Response, error) {
+	var payload io.Reader
+	if body != nil {
+		// octetBody bypasses JSON encoding: the caller already serialized
+		// the payload and set its Content-Type header.
+		if raw, ok := body.(octetBody); ok {
+			payload = bytes.NewReader(raw.data)
+		} else {
+			data, err := json.Marshal(body)
+			if err != nil {
+				return nil, fmt.Errorf("rawclient: encoding request body: %w", err)
+			}
+			payload = bytes.NewReader(data)
+		}
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, method, c.baseURL.String()+path, payload,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for key, values := range header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	if body != nil && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		_ = resp.Body.Close()
+		return nil, decodeAPIError(resp.StatusCode, errBody)
+	}
+	return resp, nil
+}
+
+// rawRequest sends one JSON request without client-managed authentication:
+// the caller supplies its own Authorization header. The device-credential
+// token exchange uses this path so it never recurses through do's
+// scoped-token handling.
+func (c *Client) rawRequest(
+	ctx context.Context,
+	method string,
+	path string,
+	header http.Header,
+	body any,
+) (*http.Response, error) {
+	return c.doOnce(ctx, method, path, header, body, "")
+}
+
+// jsonDecode decodes a JSON response body into dst with encoding/json/v2.
+func jsonDecode(body io.Reader, dst any) error {
+	return json.UnmarshalRead(body, dst)
+}

--- a/internal/rawclient/client.go
+++ b/internal/rawclient/client.go
@@ -140,7 +140,14 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Minute}
+		httpClient = &http.Client{
+			Timeout:       10 * time.Minute,
+			CheckRedirect: refuseRedirects,
+		}
+	} else if httpClient.CheckRedirect == nil {
+		enforced := *httpClient
+		enforced.CheckRedirect = refuseRedirects
+		httpClient = &enforced
 	}
 	chunkBytes := cfg.ChunkBytes
 	if chunkBytes <= 0 {
@@ -160,6 +167,10 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 	client.tokens = newTokenProvider(client, cfg.DeviceID, cfg.Credential, margin)
 	return client, nil
+}
+
+func refuseRedirects(*http.Request, []*http.Request) error {
+	return http.ErrUseLastResponse
 }
 
 // do performs one authenticated JSON request, retrying exactly once with a

--- a/internal/rawclient/client.go
+++ b/internal/rawclient/client.go
@@ -144,7 +144,9 @@ func NewClient(cfg Config) (*Client, error) {
 			Timeout:       10 * time.Minute,
 			CheckRedirect: refuseRedirects,
 		}
-	} else if httpClient.CheckRedirect == nil {
+	} else {
+		// Always replace the caller's policy: 307 and 308 responses can
+		// replay the token-exchange body containing the device credential.
 		enforced := *httpClient
 		enforced.CheckRedirect = refuseRedirects
 		httpClient = &enforced

--- a/internal/rawclient/client_test.go
+++ b/internal/rawclient/client_test.go
@@ -1,0 +1,113 @@
+package rawclient
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeAPIError(t *testing.T) {
+	t.Parallel()
+	offset := int64(5)
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   APIError
+		wantOK bool
+	}{
+		{
+			name:   "offset conflict carries authoritative offset",
+			status: http.StatusConflict,
+			body: `{"code":"upload_offset_conflict","error":"raw upload offset changed",` +
+				`"upload_offset":5}`,
+			want: APIError{
+				Status:              http.StatusConflict,
+				Code:                "upload_offset_conflict",
+				Message:             "raw upload offset changed",
+				CurrentUploadOffset: &offset,
+			},
+			wantOK: true,
+		},
+		{
+			name:   "head conflict carries current head",
+			status: http.StatusConflict,
+			body: `{"code":"head_conflict","error":"raw source head changed",` +
+				`"current_manifest_id":"rm_1","current_receipt":"rr_1","current_generation":3}`,
+			want: APIError{
+				Status:            http.StatusConflict,
+				Code:              "head_conflict",
+				Message:           "raw source head changed",
+				CurrentManifestID: "rm_1",
+				CurrentReceipt:    "rr_1",
+				CurrentGeneration: 3,
+			},
+			wantOK: true,
+		},
+		{
+			name:   "missing object conflict",
+			status: http.StatusConflict,
+			body:   `{"code":"missing_object","error":"raw manifest references a missing object"}`,
+			want: APIError{
+				Status:  http.StatusConflict,
+				Code:    "missing_object",
+				Message: "raw manifest references a missing object",
+			},
+			wantOK: true,
+		},
+		{
+			name:   "unauthorized",
+			status: http.StatusUnauthorized,
+			body:   `{"code":"unauthorized","error":"Unauthorized"}`,
+			want: APIError{
+				Status:  http.StatusUnauthorized,
+				Code:    "unauthorized",
+				Message: "Unauthorized",
+			},
+			wantOK: true,
+		},
+		{
+			name:   "non-json body still reports status and code",
+			status: http.StatusInternalServerError,
+			body:   `upstream broke`,
+			want: APIError{
+				Status:  http.StatusInternalServerError,
+				Code:    CodeInternal,
+				Message: "raw sync request failed",
+			},
+			wantOK: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var got APIError
+			err := decodeAPIError(tt.status, json.RawMessage(tt.body))
+			require.Error(t, err)
+			ok := AsAPIError(err, &got)
+			require.Equal(t, tt.wantOK, ok)
+			if tt.want.CurrentUploadOffset == nil {
+				assert.Nil(t, got.CurrentUploadOffset)
+			} else {
+				require.NotNil(t, got.CurrentUploadOffset)
+				assert.Equal(t, *tt.want.CurrentUploadOffset, *got.CurrentUploadOffset)
+			}
+			assert.Equal(t, tt.want.Status, got.Status)
+			assert.Equal(t, tt.want.Code, got.Code)
+			assert.Equal(t, tt.want.Message, got.Message)
+			assert.Equal(t, tt.want.CurrentManifestID, got.CurrentManifestID)
+			assert.Equal(t, tt.want.CurrentReceipt, got.CurrentReceipt)
+			assert.Equal(t, tt.want.CurrentGeneration, got.CurrentGeneration)
+		})
+	}
+}
+
+func TestAsAPIErrorRejectsForeignErrors(t *testing.T) {
+	t.Parallel()
+	var got APIError
+	assert.False(t, AsAPIError(errors.New("boom"), &got))
+}

--- a/internal/rawclient/client_test.go
+++ b/internal/rawclient/client_test.go
@@ -129,13 +129,24 @@ func TestClientRefusesCredentialRedirects(t *testing.T) {
 				return &http.Client{Timeout: time.Second}
 			},
 		},
+		{
+			name: "supplied client with permissive redirect policy",
+			httpClient: func() *http.Client {
+				return &http.Client{
+					Timeout: time.Second,
+					CheckRedirect: func(*http.Request, []*http.Request) error {
+						return nil
+					},
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			var redirected int32
+			var redirected atomic.Int32
 			target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				atomic.AddInt32(&redirected, 1)
+				redirected.Add(1)
 				w.Header().Set("Content-Type", "application/json")
 				fmt.Fprintf(w, `{"token":"avdt_redirected","device_id":"dev_test",`+
 					`"scopes":["negotiate","upload","commit"],"expires_at":%q}`,
@@ -158,7 +169,7 @@ func TestClientRefusesCredentialRedirects(t *testing.T) {
 			require.NoError(t, err)
 			_, err = client.tokens.token(t.Context())
 			assert.Error(t, err)
-			assert.EqualValues(t, 0, atomic.LoadInt32(&redirected),
+			assert.EqualValues(t, 0, redirected.Load(),
 				"redirect target must not receive the device credential")
 		})
 	}

--- a/internal/rawclient/client_test.go
+++ b/internal/rawclient/client_test.go
@@ -3,8 +3,12 @@ package rawclient
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -110,4 +114,52 @@ func TestAsAPIErrorRejectsForeignErrors(t *testing.T) {
 	t.Parallel()
 	var got APIError
 	assert.False(t, AsAPIError(errors.New("boom"), &got))
+}
+
+func TestClientRefusesCredentialRedirects(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		httpClient func() *http.Client
+	}{
+		{name: "default client"},
+		{
+			name: "supplied client without redirect policy",
+			httpClient: func() *http.Client {
+				return &http.Client{Timeout: time.Second}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var redirected int32
+			target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				atomic.AddInt32(&redirected, 1)
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"token":"avdt_redirected","device_id":"dev_test",`+
+					`"scopes":["negotiate","upload","commit"],"expires_at":%q}`,
+					time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano))
+			}))
+			t.Cleanup(target.Close)
+			endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+			}))
+			t.Cleanup(endpoint.Close)
+
+			var supplied *http.Client
+			if tt.httpClient != nil {
+				supplied = tt.httpClient()
+			}
+			client, err := NewClient(Config{
+				BaseURL: endpoint.URL, DeviceID: "dev_test",
+				Credential: "avdc_test", HTTPClient: supplied,
+			})
+			require.NoError(t, err)
+			_, err = client.tokens.token(t.Context())
+			assert.Error(t, err)
+			assert.EqualValues(t, 0, atomic.LoadInt32(&redirected),
+				"redirect target must not receive the device credential")
+		})
+	}
 }

--- a/internal/rawclient/commit.go
+++ b/internal/rawclient/commit.go
@@ -1,0 +1,47 @@
+package rawclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// commitResultWire mirrors the manifest-commit response body. rawsync's
+// CommitResult is the custody-domain type and carries no JSON tags, so the
+// four wire fields decode here and convert.
+type commitResultWire struct {
+	ManifestID string `json:"manifest_id"`
+	Receipt    string `json:"receipt"`
+	Generation int64  `json:"generation"`
+	Created    bool   `json:"created"`
+}
+
+// CommitManifest submits one complete manifest and returns its durable
+// receipt. Only this response authorizes checkpoint advancement. Head
+// conflicts and missing objects surface as typed APIError values so callers
+// can distinguish re-capture from retry.
+func (c *Client) CommitManifest(
+	ctx context.Context,
+	manifest rawsync.Manifest,
+) (rawsync.CommitResult, error) {
+	resp, err := c.do(ctx, http.MethodPost, "/api/v1/raw-sync/manifests", nil, manifest)
+	if err != nil {
+		return rawsync.CommitResult{}, err
+	}
+	defer resp.Body.Close()
+	var wire commitResultWire
+	if err := jsonDecode(resp.Body, &wire); err != nil {
+		return rawsync.CommitResult{}, fmt.Errorf("rawclient: decode commit result: %w", err)
+	}
+	if wire.Receipt == "" {
+		return rawsync.CommitResult{}, fmt.Errorf("rawclient: commit response missing receipt")
+	}
+	return rawsync.CommitResult{
+		ManifestID: wire.ManifestID,
+		Receipt:    wire.Receipt,
+		Generation: wire.Generation,
+		Created:    wire.Created,
+	}, nil
+}

--- a/internal/rawclient/commit.go
+++ b/internal/rawclient/commit.go
@@ -38,10 +38,14 @@ func (c *Client) CommitManifest(
 	if wire.Receipt == "" {
 		return rawsync.CommitResult{}, fmt.Errorf("rawclient: commit response missing receipt")
 	}
-	return rawsync.CommitResult{
+	result := rawsync.CommitResult{
 		ManifestID: wire.ManifestID,
 		Receipt:    wire.Receipt,
 		Generation: wire.Generation,
 		Created:    wire.Created,
-	}, nil
+	}
+	if err := rawsync.ValidateCommitResult(result); err != nil {
+		return rawsync.CommitResult{}, fmt.Errorf("rawclient: invalid commit response: %w", err)
+	}
+	return result, nil
 }

--- a/internal/rawclient/commit_test.go
+++ b/internal/rawclient/commit_test.go
@@ -3,9 +3,11 @@ package rawclient
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,6 +48,8 @@ func rawHTTPTestManifest() rawsync.Manifest {
 func TestCommitManifestDecodesReceipt(t *testing.T) {
 	t.Parallel()
 	manifest := rawHTTPTestManifest()
+	manifestID := strings.Repeat("a", 64)
+	receipt := strings.Repeat("b", 64)
 	server := httptest.NewServer(withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Handler goroutines use assert, never require/FailNow.
 		assert.Equal(t, http.MethodPost, r.Method)
@@ -55,17 +59,71 @@ func TestCommitManifestDecodesReceipt(t *testing.T) {
 			assert.Equal(t, manifest, sent)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, `{"manifest_id":"rm_1","receipt":"rr_1","generation":2,"created":true}`)
+		fmt.Fprintf(w, `{"manifest_id":%q,"receipt":%q,"generation":2,"created":true}`,
+			manifestID, receipt)
 	})))
 	t.Cleanup(server.Close)
 	client := newTestClient(t, server.URL, time.Minute)
 
 	result, err := client.CommitManifest(t.Context(), manifest)
 	require.NoError(t, err)
-	assert.Equal(t, "rm_1", result.ManifestID)
-	assert.Equal(t, "rr_1", result.Receipt)
+	assert.Equal(t, manifestID, result.ManifestID)
+	assert.Equal(t, receipt, result.Receipt)
 	assert.Equal(t, int64(2), result.Generation)
 	assert.True(t, result.Created)
+}
+
+func TestCommitManifestRejectsInvalidResult(t *testing.T) {
+	t.Parallel()
+	validManifestID := strings.Repeat("a", 64)
+	validReceipt := strings.Repeat("b", 64)
+	tests := []struct {
+		name       string
+		manifestID string
+		receipt    string
+		generation int64
+		want       string
+	}{
+		{
+			name:       "noncanonical manifest ID",
+			manifestID: "rm_1",
+			receipt:    validReceipt,
+			generation: 1,
+			want:       "manifest ID",
+		},
+		{
+			name:       "uppercase receipt",
+			manifestID: validManifestID,
+			receipt:    strings.Repeat("B", 64),
+			generation: 1,
+			want:       "receipt",
+		},
+		{
+			name:       "zero generation",
+			manifestID: validManifestID,
+			receipt:    validReceipt,
+			generation: 0,
+			want:       "generation",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w,
+					`{"manifest_id":%q,"receipt":%q,"generation":%d,"created":true}`,
+					tt.manifestID, tt.receipt, tt.generation)
+			})))
+			t.Cleanup(server.Close)
+			client := newTestClient(t, server.URL, time.Minute)
+
+			result, err := client.CommitManifest(t.Context(), rawHTTPTestManifest())
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+			assert.Equal(t, rawsync.CommitResult{}, result)
+		})
+	}
 }
 
 func TestCommitManifestSurfacesHeadConflict(t *testing.T) {
@@ -113,10 +171,12 @@ func TestCommitManifestPassesMissingObjectThrough(t *testing.T) {
 
 func TestCommitManifestRejectsMissingReceipt(t *testing.T) {
 	t.Parallel()
+	manifestID := strings.Repeat("a", 64)
 	server := httptest.NewServer(withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Handler goroutines use assert, never require/FailNow.
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, `{"manifest_id":"rm_2","receipt":"","generation":3,"created":true}`)
+		fmt.Fprintf(w, `{"manifest_id":%q,"receipt":"","generation":3,"created":true}`,
+			manifestID)
 	})))
 	t.Cleanup(server.Close)
 	client := newTestClient(t, server.URL, time.Minute)

--- a/internal/rawclient/commit_test.go
+++ b/internal/rawclient/commit_test.go
@@ -1,0 +1,128 @@
+package rawclient
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// rawHTTPTestManifest builds one valid snapshot manifest with a unique
+// capture ID per call, so parallel scripted commits never collide.
+func rawHTTPTestManifest() rawsync.Manifest {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		panic("rawclient: reading capture nonce: " + err.Error())
+	}
+	return rawsync.Manifest{
+		SchemaVersion:    rawsync.ManifestSchemaVersion,
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: "av_root_test",
+		SourceKey:        "~/.claude/projects",
+		CaptureID:        hex.EncodeToString(nonce[:]),
+		CapturedAt:       time.Now().UTC().Round(0),
+		Kind:             rawsync.ManifestSnapshot,
+		Entries: []rawsync.Entry{{
+			Path:   "session-01.jsonl",
+			Type:   "file",
+			Length: 3,
+			Objects: []rawsync.ObjectRef{{
+				SHA256: "aa00000000000000000000000000000000000000000000000000000000000000",
+				Length: 3,
+			}},
+		}},
+	}
+}
+
+func TestCommitManifestDecodesReceipt(t *testing.T) {
+	t.Parallel()
+	manifest := rawHTTPTestManifest()
+	server := httptest.NewServer(withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handler goroutines use assert, never require/FailNow.
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/raw-sync/manifests", r.URL.Path)
+		var sent rawsync.Manifest
+		if assert.NoError(t, jsonDecode(r.Body, &sent)) {
+			assert.Equal(t, manifest, sent)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"manifest_id":"rm_1","receipt":"rr_1","generation":2,"created":true}`)
+	})))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	result, err := client.CommitManifest(t.Context(), manifest)
+	require.NoError(t, err)
+	assert.Equal(t, "rm_1", result.ManifestID)
+	assert.Equal(t, "rr_1", result.Receipt)
+	assert.Equal(t, int64(2), result.Generation)
+	assert.True(t, result.Created)
+}
+
+func TestCommitManifestSurfacesHeadConflict(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handler goroutines use assert, never require/FailNow.
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/raw-sync/manifests", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		io.WriteString(w, `{"code":"head_conflict","error":"raw source head changed",`+
+			`"current_manifest_id":"rm_9","current_receipt":"rr_9","current_generation":7}`)
+	})))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	_, err := client.CommitManifest(t.Context(), rawHTTPTestManifest())
+	require.Error(t, err)
+	var apiErr APIError
+	require.True(t, AsAPIError(err, &apiErr))
+	assert.Equal(t, http.StatusConflict, apiErr.Status)
+	assert.Equal(t, CodeHeadConflict, apiErr.Code)
+	assert.Equal(t, "rm_9", apiErr.CurrentManifestID)
+	assert.Equal(t, "rr_9", apiErr.CurrentReceipt)
+	assert.Equal(t, int64(7), apiErr.CurrentGeneration)
+}
+
+func TestCommitManifestPassesMissingObjectThrough(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handler goroutines use assert, never require/FailNow.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		io.WriteString(w, `{"code":"missing_object","error":"manifest references missing object"}`)
+	})))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	_, err := client.CommitManifest(t.Context(), rawHTTPTestManifest())
+	require.Error(t, err)
+	var apiErr APIError
+	require.True(t, AsAPIError(err, &apiErr))
+	assert.Equal(t, CodeMissingObject, apiErr.Code)
+}
+
+func TestCommitManifestRejectsMissingReceipt(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handler goroutines use assert, never require/FailNow.
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"manifest_id":"rm_2","receipt":"","generation":3,"created":true}`)
+	})))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	result, err := client.CommitManifest(t.Context(), rawHTTPTestManifest())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "missing receipt")
+	assert.Equal(t, rawsync.CommitResult{}, result)
+}

--- a/internal/rawclient/e2e_test.go
+++ b/internal/rawclient/e2e_test.go
@@ -1,0 +1,675 @@
+package rawclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/artifact"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawsync"
+	"go.kenn.io/agentsview/internal/server"
+)
+
+// TestRawClientEndToEnd drives the full client cycle — enrollment, token
+// exchange, missing-object negotiation, resumable multi-chunk uploads, and
+// manifest commits — against the real huma routes mounted with real
+// rawsync services. Only the persistence seams are in-memory fakes defined
+// in this file; every HTTP hop, validation layer, and custody boundary is
+// production code.
+func TestRawClientEndToEnd(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	uploads := newE2EUploadSessionStore()
+	httpServer, auth := newE2ERawSyncServer(t, uploads)
+
+	// Step 1: enroll a device through the real DeviceAuthService.
+	// Server-side enrollment has no HTTP route by design; the issued
+	// credential is exactly what a laptop would be provisioned with.
+	enrollment, err := auth.EnrollDevice(ctx, "tenant-e2e", "laptop-e2e")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-e2e", enrollment.Identity.TenantID)
+	assert.NotEmpty(t, enrollment.Identity.DeviceID)
+	assert.NotEmpty(t, enrollment.Credential)
+
+	// The laptop's checkpoint store records its device identity once.
+	checkpointPath := t.TempDir() + "/rawcheckpoint.db"
+	checkpoint, err := rawcheckpoint.Open(ctx, checkpointPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, checkpoint.Close()) })
+	require.NoError(t, checkpoint.SetDevice(ctx, enrollment.Identity.DeviceID))
+	storedDevice, ok, err := checkpoint.Device(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, enrollment.Identity.DeviceID, storedDevice)
+
+	// A small ChunkBytes forces every object through multiple PATCHes.
+	client, err := NewClient(Config{
+		BaseURL:     httpServer.URL,
+		DeviceID:    enrollment.Identity.DeviceID,
+		Credential:  enrollment.Credential,
+		HTTPClient:  httpServer.Client(),
+		ChunkBytes:  8,
+		TokenMargin: time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Step 2: build a two-object generation from fixture bytes with real
+	// SHA-256 digests. Both bodies exceed two chunks at 8 bytes each.
+	firstBody := []byte("first source object body, chunked")
+	secondBody := []byte("second source object body")
+	first := e2EObjectFor(t, firstBody)
+	second := e2EObjectFor(t, secondBody)
+	require.Greater(t, first.Length, int64(16))
+	require.Greater(t, second.Length, int64(16))
+
+	const (
+		rootID    = "root-e2e"
+		sourceKey = "projects/demo/session.jsonl"
+	)
+	capturedAt := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	entries := []rawsync.Entry{
+		{
+			Path: "session.jsonl", Type: "file",
+			Length: first.Length, Objects: []rawsync.ObjectRef{first},
+		},
+		{
+			Path: "meta/sidecar.json", Type: "file",
+			Length: second.Length, Objects: []rawsync.ObjectRef{second},
+		},
+	}
+	manifestFor := func(captureID string, captured time.Time, parent string) rawsync.Manifest {
+		return rawsync.Manifest{
+			SchemaVersion:         rawsync.ManifestSchemaVersion,
+			Provider:              parser.AgentClaude,
+			ConfiguredRootID:      rootID,
+			SourceKey:             sourceKey,
+			ExpectedParentReceipt: parent,
+			CaptureID:             captureID,
+			CapturedAt:            captured,
+			Kind:                  rawsync.ManifestSnapshot,
+			Entries:               entries,
+		}
+	}
+
+	// Step 3: negotiate missing objects, then upload both through the
+	// resumable data plane.
+	objects := []rawsync.ObjectRef{first, second}
+	missing, err := client.MissingObjects(ctx, parser.AgentClaude, objects)
+	require.NoError(t, err)
+	require.Len(t, missing, 2)
+	assert.Equal(t, objects, missing, "both objects missing in request order")
+
+	bodies := map[string][]byte{first.SHA256: firstBody, second.SHA256: secondBody}
+	for _, object := range missing {
+		require.NoError(t, client.UploadObject(
+			ctx, parser.AgentClaude, object, bytes.NewReader(bodies[object.SHA256]),
+		))
+	}
+	// Multi-chunk transfers actually happened: every session needed more
+	// than one PATCH at the 8-byte chunk size.
+	for uploadID, appends := range uploads.appendCounts() {
+		assert.GreaterOrEqual(t, appends, 2, "upload %s used multiple chunks", uploadID)
+	}
+
+	// After custody the server holds both objects; renegotiation is empty.
+	missing, err = client.MissingObjects(ctx, parser.AgentClaude, objects)
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+
+	// Step 4: commit the first generation with an empty expected parent
+	// receipt, then advance the laptop's checkpoint from the durable result.
+	firstCommit, err := client.CommitManifest(ctx, manifestFor(
+		"capture-e2e-1", capturedAt, "",
+	))
+	require.NoError(t, err)
+	assert.NotEmpty(t, firstCommit.ManifestID)
+	assert.NotEmpty(t, firstCommit.Receipt)
+	assert.Equal(t, int64(1), firstCommit.Generation)
+	assert.True(t, firstCommit.Created)
+	require.NoError(t, checkpoint.AdvanceHead(
+		ctx, enrollment.Identity.DeviceID, parser.AgentClaude,
+		rootID, sourceKey, "", firstCommit,
+	))
+	head, ok, err := checkpoint.SourceHead(ctx, parser.AgentClaude, rootID, sourceKey)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, firstCommit.Receipt, head.Receipt)
+	assert.Equal(t, firstCommit.ManifestID, head.ManifestID)
+	assert.Equal(t, int64(1), head.Generation)
+
+	// The same capture_id replays idempotently: same receipt and
+	// generation, never a second generation.
+	replayed, err := client.CommitManifest(ctx, manifestFor(
+		"capture-e2e-1", capturedAt, "",
+	))
+	require.NoError(t, err)
+	assert.Equal(t, firstCommit.Receipt, replayed.Receipt)
+	assert.Equal(t, firstCommit.Generation, replayed.Generation)
+	assert.False(t, replayed.Created)
+
+	// Step 5: a second generation chained onto the first receipt advances
+	// the server head to generation 2.
+	secondCommit, err := client.CommitManifest(ctx, manifestFor(
+		"capture-e2e-2", capturedAt.Add(time.Minute), firstCommit.Receipt,
+	))
+	require.NoError(t, err)
+	assert.NotEqual(t, firstCommit.Receipt, secondCommit.Receipt)
+	assert.Equal(t, int64(2), secondCommit.Generation)
+	assert.True(t, secondCommit.Created)
+	require.NoError(t, checkpoint.AdvanceHead(
+		ctx, enrollment.Identity.DeviceID, parser.AgentClaude,
+		rootID, sourceKey, firstCommit.Receipt, secondCommit,
+	))
+
+	// Step 6: a stale parent receipt is rejected as a typed head conflict
+	// carrying the current head, not a generic failure.
+	_, err = client.CommitManifest(ctx, manifestFor(
+		"capture-e2e-3", capturedAt.Add(2*time.Minute), firstCommit.Receipt,
+	))
+	require.Error(t, err)
+	var apiErr APIError
+	require.True(t, AsAPIError(err, &apiErr))
+	assert.Equal(t, http.StatusConflict, apiErr.Status)
+	assert.Equal(t, CodeHeadConflict, apiErr.Code)
+	assert.Equal(t, secondCommit.ManifestID, apiErr.CurrentManifestID)
+	assert.Equal(t, secondCommit.Receipt, apiErr.CurrentReceipt)
+	assert.Equal(t, int64(2), apiErr.CurrentGeneration)
+
+	// Step 7: the checkpoint reflects only the last acknowledged head —
+	// generation 2 — and the rejected stale commit advanced nothing.
+	head, ok, err = checkpoint.SourceHead(ctx, parser.AgentClaude, rootID, sourceKey)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, secondCommit.Receipt, head.Receipt)
+	assert.Equal(t, secondCommit.ManifestID, head.ManifestID)
+	assert.Equal(t, int64(2), head.Generation)
+}
+
+// e2EObjectFor builds a validated ObjectRef carrying body's real digest.
+func e2EObjectFor(t *testing.T, body []byte) rawsync.ObjectRef {
+	t.Helper()
+	digest := sha256.Sum256(body)
+	object, err := rawsync.NewObjectRef(hex.EncodeToString(digest[:]), int64(len(body)))
+	require.NoError(t, err)
+	return object
+}
+
+// newE2ERawSyncServer mounts the real huma server with real rawsync
+// services: device authentication, custody, resumable uploads, and the
+// verified artifact ledger backed by a throwaway repository.
+func newE2ERawSyncServer(
+	t *testing.T,
+	uploads *e2EUploadSessionStore,
+) (*httptest.Server, *rawsync.DeviceAuthService) {
+	t.Helper()
+	repository, err := artifact.OpenRepository(t.Context(), t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, repository.Close()) })
+	objects, err := rawsync.NewArtifactObjectStore(repository.Content())
+	require.NoError(t, err)
+
+	metadata := newE2EMetadataStore()
+	custody, err := rawsync.NewService(
+		objects, metadata, rawsync.DefaultManifestLimits(), "parser-data-17",
+	)
+	require.NoError(t, err)
+
+	uploadService, err := rawsync.NewUploadService(
+		uploads, custody, rawsync.DefaultUploadSessionTTL,
+	)
+	require.NoError(t, err)
+
+	auth, err := rawsync.NewDeviceAuthService(
+		newE2EDeviceAuthStore(), time.Hour,
+	)
+	require.NoError(t, err)
+
+	srv := server.New(config.Config{
+		Host: "127.0.0.1", Port: 8080,
+		AuthToken: "legacy-shared-token", RequireAuth: true,
+		WriteTimeout: 30 * time.Second,
+	}, nil, nil,
+		server.WithRawSyncServices(auth, custody),
+		server.WithRawSyncUploads(uploadService),
+	)
+	httpServer := httptest.NewServer(srv.Handler())
+	t.Cleanup(httpServer.Close)
+	return httpServer, auth
+}
+
+// e2EDeviceAuthStore is an in-memory DeviceAuthStore backed by maps. It
+// mirrors the PostgreSQL store's semantics: enrollments persist once,
+// credentials authenticate only active devices, tokens are digest-only and
+// scope-checked, and revocation invalidates the device and its tokens.
+type e2EDeviceAuthStore struct {
+	mu      sync.Mutex
+	devices map[string]rawsync.DeviceEnrollmentRecord
+	tokens  map[rawsync.TokenDigest]rawsync.DeviceTokenRecord
+}
+
+func newE2EDeviceAuthStore() *e2EDeviceAuthStore {
+	return &e2EDeviceAuthStore{
+		devices: make(map[string]rawsync.DeviceEnrollmentRecord),
+		tokens:  make(map[rawsync.TokenDigest]rawsync.DeviceTokenRecord),
+	}
+}
+
+func (s *e2EDeviceAuthStore) EnrollDevice(
+	_ context.Context,
+	record rawsync.DeviceEnrollmentRecord,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.devices[record.Identity.DeviceID]; exists {
+		return fmt.Errorf("enrolling raw sync device: %w", rawsync.ErrConflict)
+	}
+	s.devices[record.Identity.DeviceID] = record
+	return nil
+}
+
+func (s *e2EDeviceAuthStore) activeIdentity(
+	deviceID string,
+	credential rawsync.CredentialDigest,
+) (rawsync.AuthIdentity, bool) {
+	record, exists := s.devices[deviceID]
+	if !exists || record.CredentialDigest != credential || record.RevokedAt != nil {
+		return rawsync.AuthIdentity{}, false
+	}
+	return record.Identity, true
+}
+
+func (s *e2EDeviceAuthStore) AuthenticateCredential(
+	_ context.Context,
+	deviceID string,
+	credential rawsync.CredentialDigest,
+) (rawsync.AuthIdentity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	identity, ok := s.activeIdentity(deviceID, credential)
+	if !ok {
+		return rawsync.AuthIdentity{}, rawsync.ErrUnauthorized
+	}
+	return identity, nil
+}
+
+func (s *e2EDeviceAuthStore) IssueToken(
+	_ context.Context,
+	deviceID string,
+	credential rawsync.CredentialDigest,
+	token rawsync.DeviceTokenRecord,
+) (rawsync.AuthIdentity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	identity, ok := s.activeIdentity(deviceID, credential)
+	if !ok {
+		return rawsync.AuthIdentity{}, rawsync.ErrUnauthorized
+	}
+	token.Identity = identity
+	s.tokens[token.Digest] = token
+	return identity, nil
+}
+
+func (s *e2EDeviceAuthStore) AuthenticateToken(
+	_ context.Context,
+	digest rawsync.TokenDigest,
+	required rawsync.DeviceTokenScope,
+	now time.Time,
+) (rawsync.AuthIdentity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token, exists := s.tokens[digest]
+	if !exists || !token.ExpiresAt.After(now) || !token.Scopes.Allows(required) {
+		return rawsync.AuthIdentity{}, rawsync.ErrUnauthorized
+	}
+	device, exists := s.devices[token.Identity.DeviceID]
+	if !exists || device.RevokedAt != nil || device.Identity != token.Identity {
+		return rawsync.AuthIdentity{}, rawsync.ErrUnauthorized
+	}
+	return token.Identity, nil
+}
+
+func (s *e2EDeviceAuthStore) RevokeDevice(
+	_ context.Context,
+	identity rawsync.AuthIdentity,
+	revokedAt time.Time,
+) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, exists := s.devices[identity.DeviceID]
+	if !exists || record.Identity != identity || record.RevokedAt != nil {
+		return false, nil
+	}
+	record.RevokedAt = &revokedAt
+	s.devices[identity.DeviceID] = record
+	return true, nil
+}
+
+// e2EHeadKey identifies one source head exactly as the PostgreSQL store
+// keys it: tenant, device, provider, root, and source key.
+type e2EHeadKey struct {
+	tenant   string
+	device   string
+	provider parser.AgentType
+	root     string
+	source   string
+}
+
+// e2ECaptureKey pairs one head with a capture_id for replay detection.
+type e2ECaptureKey struct {
+	head      e2EHeadKey
+	captureID string
+}
+
+// e2EMetadataStore is an in-memory MetadataStore with the real head
+// compare-and-swap semantics: manifests are accepted only when the expected
+// parent receipt matches the current head, the first head carries an empty
+// receipt at generation 0, commits increment the generation, and the same
+// capture_id replays its original result idempotently.
+type e2EMetadataStore struct {
+	mu       sync.Mutex
+	verified map[string]map[rawsync.ObjectRef]bool
+	heads    map[e2EHeadKey]*e2ESourceHead
+	captures map[e2ECaptureKey]rawsync.CommitResult
+}
+
+type e2ESourceHead struct {
+	manifestID string
+	receipt    string
+	generation int64
+}
+
+func newE2EMetadataStore() *e2EMetadataStore {
+	return &e2EMetadataStore{
+		verified: make(map[string]map[rawsync.ObjectRef]bool),
+		heads:    make(map[e2EHeadKey]*e2ESourceHead),
+		captures: make(map[e2ECaptureKey]rawsync.CommitResult),
+	}
+}
+
+func (s *e2EMetadataStore) RecordVerifiedObject(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	object rawsync.ObjectRef,
+) error {
+	return s.RecordVerifiedObjects(ctx, identity, []rawsync.ObjectRef{object})
+}
+
+func (s *e2EMetadataStore) RecordVerifiedObjects(
+	_ context.Context,
+	identity rawsync.AuthIdentity,
+	objects []rawsync.ObjectRef,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	verified := s.verified[identity.TenantID]
+	if verified == nil {
+		verified = make(map[rawsync.ObjectRef]bool)
+		s.verified[identity.TenantID] = verified
+	}
+	for _, object := range objects {
+		verified[object] = true
+	}
+	return nil
+}
+
+func (s *e2EMetadataStore) MissingObjects(
+	_ context.Context,
+	identity rawsync.AuthIdentity,
+	objects []rawsync.ObjectRef,
+) ([]rawsync.ObjectRef, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	missing := make([]rawsync.ObjectRef, 0, len(objects))
+	for _, object := range objects {
+		if !s.verified[identity.TenantID][object] {
+			missing = append(missing, object)
+		}
+	}
+	return missing, nil
+}
+
+func (s *e2EMetadataStore) CommitManifest(
+	_ context.Context,
+	manifest rawsync.CanonicalManifest,
+	_ string,
+) (rawsync.CommitResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	head := e2EHeadKey{
+		tenant:   manifest.Identity.TenantID,
+		device:   manifest.Identity.DeviceID,
+		provider: manifest.Manifest.Provider,
+		root:     manifest.Manifest.ConfiguredRootID,
+		source:   manifest.Manifest.SourceKey,
+	}
+	capture := e2ECaptureKey{head: head, captureID: manifest.Manifest.CaptureID}
+	if prior, exists := s.captures[capture]; exists {
+		if prior.ManifestID != manifest.ManifestID {
+			return rawsync.CommitResult{}, fmt.Errorf(
+				"raw capture identifier reused: %w", rawsync.ErrConflict)
+		}
+		prior.Created = false
+		return prior, nil
+	}
+	current := s.heads[head]
+	if current == nil {
+		current = &e2ESourceHead{}
+		s.heads[head] = current
+	}
+	if manifest.Manifest.ExpectedParentReceipt != current.receipt {
+		return rawsync.CommitResult{}, &rawsync.HeadConflictError{
+			CurrentManifestID: current.manifestID,
+			CurrentReceipt:    current.receipt,
+			CurrentGeneration: current.generation,
+		}
+	}
+	for _, object := range manifest.Objects {
+		if !s.verified[manifest.Identity.TenantID][object] {
+			return rawsync.CommitResult{}, fmt.Errorf(
+				"%w: %s", rawsync.ErrMissingObject, object.SHA256)
+		}
+	}
+	receipt, err := e2EReceipt()
+	if err != nil {
+		return rawsync.CommitResult{}, err
+	}
+	current.manifestID = manifest.ManifestID
+	current.receipt = receipt
+	current.generation++
+	result := rawsync.CommitResult{
+		ManifestID: manifest.ManifestID,
+		Receipt:    receipt,
+		Generation: current.generation,
+		Created:    true,
+	}
+	s.captures[capture] = result
+	return result, nil
+}
+
+// e2EReceipt mints a lowercase-hex receipt matching the parent-receipt
+// format the manifest validator accepts.
+func e2EReceipt() (string, error) {
+	var value [32]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generating e2e receipt: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+// e2EUploadRecord is one staged transfer: its durable session metadata and
+// the bytes appended so far.
+type e2EUploadRecord struct {
+	session rawsync.UploadSession
+	data    []byte
+}
+
+// e2EUploadSessionStore is an in-memory multi-session UploadSessionStore
+// staging bytes per upload ID at exact offsets. It mirrors
+// internal/rawsync/upload_test.go's memoryUploadSessionStore semantics —
+// offset conflicts report the authoritative offset, resets bump the session
+// generation — but keeps every concurrent session alive, keyed by upload ID.
+type e2EUploadSessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]*e2EUploadRecord
+	appends  map[string]int
+}
+
+func newE2EUploadSessionStore() *e2EUploadSessionStore {
+	return &e2EUploadSessionStore{
+		sessions: make(map[string]*e2EUploadRecord),
+		appends:  make(map[string]int),
+	}
+}
+
+// appendCounts reports how many PATCHes each upload received.
+func (s *e2EUploadSessionStore) appendCounts() map[string]int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	counts := make(map[string]int, len(s.appends))
+	maps.Copy(counts, s.appends)
+	return counts
+}
+
+func (s *e2EUploadSessionStore) lookup(
+	identity rawsync.AuthIdentity,
+	uploadID string,
+) (*e2EUploadRecord, error) {
+	record, exists := s.sessions[uploadID]
+	if !exists || record.session.Identity != identity {
+		return nil, rawsync.ErrNotFound
+	}
+	return record, nil
+}
+
+func (s *e2EUploadSessionStore) Create(
+	_ context.Context,
+	record rawsync.UploadSession,
+) (rawsync.UploadSession, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, exists := s.sessions[record.ID]; exists {
+		return existing.session, false, nil
+	}
+	s.sessions[record.ID] = &e2EUploadRecord{session: record}
+	return record, true, nil
+}
+
+func (s *e2EUploadSessionStore) Status(
+	_ context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	_ time.Time,
+) (rawsync.UploadSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, err := s.lookup(identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	return record.session, nil
+}
+
+func (s *e2EUploadSessionStore) Append(
+	_ context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	expectedOffset int64,
+	chunk []byte,
+	_ time.Time,
+) (rawsync.UploadSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, err := s.lookup(identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	s.appends[uploadID]++
+	if record.session.Offset != expectedOffset {
+		return rawsync.UploadSession{}, &rawsync.UploadOffsetConflictError{
+			CurrentOffset: record.session.Offset,
+		}
+	}
+	if int64(len(chunk)) > record.session.Object.Length-record.session.Offset {
+		return rawsync.UploadSession{}, rawsync.ErrInvalid
+	}
+	record.data = append(record.data, chunk...)
+	record.session.Offset += int64(len(chunk))
+	return record.session, nil
+}
+
+func (s *e2EUploadSessionStore) Open(
+	_ context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	_ time.Time,
+) (rawsync.UploadSession, io.ReadCloser, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, err := s.lookup(identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, nil, err
+	}
+	data := append([]byte(nil), record.data...)
+	return record.session, io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *e2EUploadSessionStore) Reset(
+	_ context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	expectedGeneration int64,
+	_ time.Time,
+) (rawsync.UploadSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, err := s.lookup(identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	if record.session.Generation != expectedGeneration {
+		return rawsync.UploadSession{}, rawsync.ErrConflict
+	}
+	record.data = nil
+	record.session.Offset = 0
+	record.session.Generation++
+	return record.session, nil
+}
+
+func (s *e2EUploadSessionStore) Complete(
+	_ context.Context,
+	identity rawsync.AuthIdentity,
+	uploadID string,
+	_ time.Time,
+) (rawsync.UploadSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, err := s.lookup(identity, uploadID)
+	if err != nil {
+		return rawsync.UploadSession{}, err
+	}
+	record.session.Complete = true
+	return record.session, nil
+}
+
+var (
+	_ rawsync.DeviceAuthStore    = (*e2EDeviceAuthStore)(nil)
+	_ rawsync.MetadataStore      = (*e2EMetadataStore)(nil)
+	_ rawsync.UploadSessionStore = (*e2EUploadSessionStore)(nil)
+)

--- a/internal/rawclient/tokens.go
+++ b/internal/rawclient/tokens.go
@@ -1,0 +1,117 @@
+package rawclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// tokenScopes is the exact scope set the transport needs; the status scope
+// has no server route yet and is not requested.
+var tokenScopes = []string{"negotiate", "upload", "commit"}
+
+type tokenResponse struct {
+	Token     string    `json:"token"`
+	DeviceID  string    `json:"device_id"`
+	Scopes    []string  `json:"scopes"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// tokenProvider caches one live device token and refreshes it with
+// single-flight semantics before the server-side expiry margin.
+type tokenProvider struct {
+	client     *Client
+	deviceID   string
+	credential string
+	margin     time.Duration
+
+	mu      sync.Mutex
+	current string
+	expires time.Time
+	refresh chan struct{}
+}
+
+func newTokenProvider(
+	client *Client,
+	deviceID, credential string,
+	margin time.Duration,
+) *tokenProvider {
+	return &tokenProvider{
+		client: client, deviceID: deviceID, credential: credential,
+		margin: margin, refresh: make(chan struct{}, 1),
+	}
+}
+
+// token returns a bearer token valid beyond the configured margin. Concurrent
+// callers share one in-flight exchange.
+func (p *tokenProvider) token(ctx context.Context) (string, error) {
+	token, ok := p.cached()
+	if ok {
+		return token, nil
+	}
+
+	select {
+	case p.refresh <- struct{}{}:
+		defer func() { <-p.refresh }()
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+
+	// Re-check after winning the refresh slot: another caller may have
+	// completed the exchange while this one waited.
+	token, ok = p.cached()
+	if ok {
+		return token, nil
+	}
+	return p.exchange(ctx)
+}
+
+// invalidate drops the cached token after an unauthorized response.
+func (p *tokenProvider) invalidate() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.current = ""
+	p.expires = time.Time{}
+}
+
+// cached returns the current token when it is still valid beyond the margin.
+func (p *tokenProvider) cached() (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.current == "" || !time.Now().Add(p.margin).Before(p.expires) {
+		return "", false
+	}
+	return p.current, true
+}
+
+// exchange trades the device credential for a fresh scoped token and caches
+// it. It goes through rawRequest, never do: do prefetches an avdt token and
+// would recurse into this provider.
+func (p *tokenProvider) exchange(ctx context.Context) (string, error) {
+	body := struct {
+		Scopes []string `json:"scopes"`
+	}{Scopes: tokenScopes}
+	resp, err := p.client.rawRequest(ctx, http.MethodPost, "/api/v1/raw-sync/tokens",
+		http.Header{
+			"Authorization":          []string{"Bearer " + p.credential},
+			"X-AgentsView-Device-ID": []string{p.deviceID},
+		}, body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var issued tokenResponse
+	if err := jsonDecode(resp.Body, &issued); err != nil {
+		return "", fmt.Errorf("rawclient: decode token response: %w", err)
+	}
+	if issued.Token == "" || issued.DeviceID != p.deviceID {
+		return "", fmt.Errorf("rawclient: token response identity mismatch")
+	}
+	p.mu.Lock()
+	p.current = issued.Token
+	p.expires = issued.ExpiresAt
+	p.mu.Unlock()
+	return issued.Token, nil
+}

--- a/internal/rawclient/tokens_test.go
+++ b/internal/rawclient/tokens_test.go
@@ -1,0 +1,148 @@
+package rawclient
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClient(t *testing.T, baseURL string, margin time.Duration) *Client {
+	t.Helper()
+	client, err := NewClient(Config{
+		BaseURL: baseURL, DeviceID: "dev_test",
+		Credential: "avdc_test", TokenMargin: margin,
+	})
+	require.NoError(t, err)
+	return client
+}
+
+// newTokenTestServer mounts only the token-exchange route. It counts
+// exchanges and issues tokens with the given TTL.
+func newTokenTestServer(t *testing.T, exchanges *int32, ttl time.Duration) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handler goroutines use assert, never require/FailNow; the
+		// response is always written so a mismatch fails fast, not hangs.
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/raw-sync/tokens", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"scopes":["negotiate","upload","commit"]}`, string(body))
+		assert.Equal(t, "Bearer avdc_test", r.Header.Get("Authorization"))
+		assert.Equal(t, "dev_test", r.Header.Get("X-AgentsView-Device-ID"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"token":"avdt_%d","device_id":"dev_test",`+
+			`"scopes":["negotiate","upload","commit"],`+
+			`"expires_at":%q}`, atomic.AddInt32(exchanges, 1),
+			time.Now().Add(ttl).UTC().Format(time.RFC3339Nano))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestTokenProviderCachesUntilExpiryMargin(t *testing.T) {
+	t.Parallel()
+	var exchanges int32
+	server := newTokenTestServer(t, &exchanges, 10*time.Minute)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	first, err := client.tokens.token(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "avdt_1", first)
+
+	second, err := client.tokens.token(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "avdt_1", second)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&exchanges))
+}
+
+func TestTokenProviderRefreshesPastMargin(t *testing.T) {
+	t.Parallel()
+	var exchanges int32
+	// TTL below the margin, so the issued token is already stale for this
+	// client the moment it is cached and the second call must re-exchange.
+	server := newTokenTestServer(t, &exchanges, time.Minute)
+	client := newTestClient(t, server.URL, 90*time.Second)
+
+	_, err := client.tokens.token(t.Context())
+	require.NoError(t, err)
+	second, err := client.tokens.token(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "avdt_2", second)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&exchanges))
+}
+
+func TestTokenProviderSingleFlight(t *testing.T) {
+	t.Parallel()
+	var exchanges int32
+	server := newTokenTestServer(t, &exchanges, 10*time.Minute)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	const callers = 8
+	results := make(chan string, callers)
+	for range callers {
+		go func() {
+			// assert, not require: the send must be unconditional so the
+			// result loop below always drains.
+			token, err := client.tokens.token(context.Background())
+			assert.NoError(t, err)
+			results <- token
+		}()
+	}
+	for range callers {
+		assert.NotEmpty(t, <-results)
+	}
+	assert.EqualValues(t, 1, atomic.LoadInt32(&exchanges))
+}
+
+// TestDoRetriesWithRefreshedTokenAfterUnauthorized covers do's forced-refresh
+// path: a 401 on a data route invalidates the cached token, triggers one
+// re-exchange, and the retried call succeeds with the new token.
+func TestDoRetriesWithRefreshedTokenAfterUnauthorized(t *testing.T) {
+	t.Parallel()
+	var exchanges, objectCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// assert (not require): this handler runs on a server goroutine.
+		switch r.URL.Path {
+		case "/api/v1/raw-sync/tokens":
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "Bearer avdc_test", r.Header.Get("Authorization"))
+			assert.Equal(t, "dev_test", r.Header.Get("X-AgentsView-Device-ID"))
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"token":"avdt_%d","device_id":"dev_test",`+
+				`"scopes":["negotiate","upload","commit"],`+
+				`"expires_at":%q}`, atomic.AddInt32(&exchanges, 1),
+				time.Now().Add(10*time.Minute).UTC().Format(time.RFC3339Nano))
+		case "/api/v1/raw-sync/objects/missing":
+			assert.Equal(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			if atomic.AddInt32(&objectCalls, 1) == 1 {
+				assert.Equal(t, "Bearer avdt_1", r.Header.Get("Authorization"))
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprint(w, `{"code":"unauthorized","error":"Unauthorized"}`)
+				return
+			}
+			assert.Equal(t, "Bearer avdt_2", r.Header.Get("Authorization"))
+			fmt.Fprint(w, `{"stored":true}`)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	resp, err := client.do(t.Context(), http.MethodGet, "/api/v1/raw-sync/objects/missing", nil, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&exchanges))
+	assert.EqualValues(t, 2, atomic.LoadInt32(&objectCalls))
+}

--- a/internal/rawclient/upload.go
+++ b/internal/rawclient/upload.go
@@ -153,6 +153,7 @@ func (c *Client) UploadObject(
 
 // appendChunk PATCHes one chunk at offset and returns the server-confirmed
 // next offset and completion, preferring the response headers over the body.
+// A successful response must acknowledge exactly the bytes in this request.
 func (c *Client) appendChunk(
 	ctx context.Context,
 	uploadID string,
@@ -182,6 +183,12 @@ func (c *Client) appendChunk(
 	}
 	if err := validateUploadProgress(next, complete, object.Length); err != nil {
 		return 0, false, err
+	}
+	expectedNext := offset + int64(len(chunk))
+	if next != expectedNext {
+		return 0, false, fmt.Errorf(
+			"rawclient: upload response confirmed offset %d; expected offset %d after %d-byte chunk",
+			next, expectedNext, len(chunk))
 	}
 	return next, complete, nil
 }

--- a/internal/rawclient/upload.go
+++ b/internal/rawclient/upload.go
@@ -81,13 +81,16 @@ func (c *Client) UploadObject(
 		return fmt.Errorf("rawclient: decode upload session: %w", err)
 	}
 	resp.Body.Close()
+	if err := validateUploadIdentity(session, object, ""); err != nil {
+		return err
+	}
+	if err := validateUploadProgress(session.Offset, session.Complete, object.Length); err != nil {
+		return err
+	}
 	if session.Complete {
 		return nil
 	}
 	offset := session.Offset
-	if offset < 0 || offset > object.Length {
-		return fmt.Errorf("rawclient: upload session offset %d out of range", offset)
-	}
 	buf := make([]byte, c.chunkBytes)
 	conflicts := 0
 	for offset < object.Length {
@@ -98,7 +101,9 @@ func (c *Client) UploadObject(
 		if _, err := content.ReadAt(chunk, offset); err != nil {
 			return fmt.Errorf("rawclient: read object bytes at %d: %w", offset, err)
 		}
-		next, complete, err := c.appendChunk(ctx, session.UploadID, offset, chunk)
+		next, complete, err := c.appendChunk(
+			ctx, session.UploadID, object, offset, chunk,
+		)
 		if err != nil {
 			if apiErr, ok := errors.AsType[*APIError](err); ok &&
 				apiErr.Code == CodeUploadOffset &&
@@ -121,9 +126,6 @@ func (c *Client) UploadObject(
 			return err
 		}
 		conflicts = 0
-		if next < 0 || next > object.Length {
-			return fmt.Errorf("rawclient: upload offset %d out of range", next)
-		}
 		if next <= offset && !complete {
 			return fmt.Errorf("rawclient: upload made no progress at offset %d", offset)
 		}
@@ -136,7 +138,9 @@ func (c *Client) UploadObject(
 	// the start response and the last chunk can both land here. One empty
 	// PATCH at the confirmed offset asks the server to finalize; custody is
 	// not accepted until it answers complete.
-	next, complete, err := c.appendChunk(ctx, session.UploadID, offset, nil)
+	next, complete, err := c.appendChunk(
+		ctx, session.UploadID, object, offset, nil,
+	)
 	if err != nil {
 		return err
 	}
@@ -152,6 +156,7 @@ func (c *Client) UploadObject(
 func (c *Client) appendChunk(
 	ctx context.Context,
 	uploadID string,
+	object rawsync.ObjectRef,
 	offset int64,
 	chunk []byte,
 ) (int64, bool, error) {
@@ -161,15 +166,56 @@ func (c *Client) appendChunk(
 		return 0, false, err
 	}
 	defer resp.Body.Close()
-	if next, complete, ok := uploadProgress(resp.Header); ok {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return next, complete, nil
-	}
 	var out uploadPatchResponse
 	if err := jsonDecode(resp.Body, &out); err != nil {
 		return 0, false, fmt.Errorf("rawclient: decode upload append: %w", err)
 	}
-	return out.Offset, out.Complete, nil
+	if err := validateUploadIdentity(out.uploadStartResponse, object, uploadID); err != nil {
+		return 0, false, err
+	}
+	if err := validateUploadProgress(out.Offset, out.Complete, object.Length); err != nil {
+		return 0, false, err
+	}
+	next, complete := out.Offset, out.Complete
+	if headerOffset, headerComplete, ok := uploadProgress(resp.Header); ok {
+		next, complete = headerOffset, headerComplete
+	}
+	if err := validateUploadProgress(next, complete, object.Length); err != nil {
+		return 0, false, err
+	}
+	return next, complete, nil
+}
+
+func validateUploadIdentity(
+	response uploadStartResponse,
+	object rawsync.ObjectRef,
+	uploadID string,
+) error {
+	if response.Object != object {
+		return fmt.Errorf("rawclient: upload response identifies a different object")
+	}
+	if uploadID != "" {
+		if response.UploadID != uploadID {
+			return fmt.Errorf("rawclient: upload response identifies a different upload ID")
+		}
+		return nil
+	}
+	if !response.Complete && response.UploadID == "" {
+		return fmt.Errorf("rawclient: incomplete upload response is missing upload ID")
+	}
+	return nil
+}
+
+func validateUploadProgress(offset int64, complete bool, length int64) error {
+	if offset < 0 || offset > length {
+		return fmt.Errorf("rawclient: upload response offset %d out of range", offset)
+	}
+	if complete && offset != length {
+		return fmt.Errorf(
+			"rawclient: upload response complete at offset %d, want %d", offset, length,
+		)
+	}
+	return nil
 }
 
 // uploadProgress reads the authoritative post-PATCH progress headers. It

--- a/internal/rawclient/upload.go
+++ b/internal/rawclient/upload.go
@@ -1,0 +1,214 @@
+package rawclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// maxUploadOffsetConflicts bounds consecutive offset-conflict recoveries so a
+// server that keeps rejecting cannot loop the client forever.
+const maxUploadOffsetConflicts = 8
+
+type uploadStartResponse struct {
+	UploadID string            `json:"upload_id,omitempty"`
+	Object   rawsync.ObjectRef `json:"object"`
+	Offset   int64             `json:"offset"`
+	Complete bool              `json:"complete"`
+}
+
+type uploadPatchResponse struct {
+	uploadStartResponse
+}
+
+// MissingObjects asks the server which of objects it does not already hold
+// for provider and returns that subset in request order.
+func (c *Client) MissingObjects(
+	ctx context.Context,
+	provider parser.AgentType,
+	objects []rawsync.ObjectRef,
+) ([]rawsync.ObjectRef, error) {
+	body := struct {
+		Provider parser.AgentType    `json:"provider"`
+		Objects  []rawsync.ObjectRef `json:"objects"`
+	}{Provider: provider, Objects: objects}
+	resp, err := c.do(ctx, http.MethodPost, "/api/v1/raw-sync/objects/missing", nil, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Missing []rawsync.ObjectRef `json:"missing"`
+	}
+	if err := jsonDecode(resp.Body, &out); err != nil {
+		return nil, fmt.Errorf("rawclient: decode missing objects: %w", err)
+	}
+	return out.Missing, nil
+}
+
+// UploadObject transfers one immutable object through a resumable upload
+// session. Content must supply exactly object.Length bytes; chunk boundaries
+// are storage boundaries only. Offset conflicts adopt the server's
+// authoritative offset; checksum mismatch after finalization is terminal and
+// the caller must re-capture the source. When the confirmed offset reaches
+// the full length before the server reports completion, one empty PATCH at
+// that offset triggers finalization — success is never reported before the
+// server confirms the session complete.
+func (c *Client) UploadObject(
+	ctx context.Context,
+	provider parser.AgentType,
+	object rawsync.ObjectRef,
+	content io.ReaderAt,
+) error {
+	body := struct {
+		Provider parser.AgentType  `json:"provider"`
+		Object   rawsync.ObjectRef `json:"object"`
+	}{Provider: provider, Object: object}
+	resp, err := c.do(ctx, http.MethodPost, "/api/v1/raw-sync/uploads", nil, body)
+	if err != nil {
+		return err
+	}
+	var session uploadStartResponse
+	if err := jsonDecode(resp.Body, &session); err != nil {
+		resp.Body.Close()
+		return fmt.Errorf("rawclient: decode upload session: %w", err)
+	}
+	resp.Body.Close()
+	if session.Complete {
+		return nil
+	}
+	offset := session.Offset
+	if offset < 0 || offset > object.Length {
+		return fmt.Errorf("rawclient: upload session offset %d out of range", offset)
+	}
+	buf := make([]byte, c.chunkBytes)
+	conflicts := 0
+	for offset < object.Length {
+		chunk := buf
+		if remain := object.Length - offset; remain < int64(len(chunk)) {
+			chunk = chunk[:remain]
+		}
+		if _, err := content.ReadAt(chunk, offset); err != nil {
+			return fmt.Errorf("rawclient: read object bytes at %d: %w", offset, err)
+		}
+		next, complete, err := c.appendChunk(ctx, session.UploadID, offset, chunk)
+		if err != nil {
+			if apiErr, ok := errors.AsType[*APIError](err); ok &&
+				apiErr.Code == CodeUploadOffset &&
+				apiErr.CurrentUploadOffset != nil {
+				adopted := *apiErr.CurrentUploadOffset
+				if adopted < 0 || adopted > object.Length {
+					return fmt.Errorf("rawclient: server upload offset %d out of range", adopted)
+				}
+				if adopted == offset {
+					return fmt.Errorf("rawclient: upload offset conflict repeats offset %d", offset)
+				}
+				offset = adopted
+				conflicts++
+				if conflicts > maxUploadOffsetConflicts {
+					return fmt.Errorf("rawclient: upload offset conflicted more than %d times",
+						maxUploadOffsetConflicts)
+				}
+				continue
+			}
+			return err
+		}
+		conflicts = 0
+		if next < 0 || next > object.Length {
+			return fmt.Errorf("rawclient: upload offset %d out of range", next)
+		}
+		if next <= offset && !complete {
+			return fmt.Errorf("rawclient: upload made no progress at offset %d", offset)
+		}
+		offset = next
+		if complete {
+			return nil
+		}
+	}
+	// The session holds every byte, but no response has reported completion —
+	// the start response and the last chunk can both land here. One empty
+	// PATCH at the confirmed offset asks the server to finalize; custody is
+	// not accepted until it answers complete.
+	next, complete, err := c.appendChunk(ctx, session.UploadID, offset, nil)
+	if err != nil {
+		return err
+	}
+	if next != object.Length || !complete {
+		return fmt.Errorf(
+			"rawclient: upload session not finalized at offset %d", next)
+	}
+	return nil
+}
+
+// appendChunk PATCHes one chunk at offset and returns the server-confirmed
+// next offset and completion, preferring the response headers over the body.
+func (c *Client) appendChunk(
+	ctx context.Context,
+	uploadID string,
+	offset int64,
+	chunk []byte,
+) (int64, bool, error) {
+	resp, err := c.doOctet(ctx, http.MethodPatch,
+		"/api/v1/raw-sync/uploads/"+url.PathEscape(uploadID), offset, chunk)
+	if err != nil {
+		return 0, false, err
+	}
+	defer resp.Body.Close()
+	if next, complete, ok := uploadProgress(resp.Header); ok {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return next, complete, nil
+	}
+	var out uploadPatchResponse
+	if err := jsonDecode(resp.Body, &out); err != nil {
+		return 0, false, fmt.Errorf("rawclient: decode upload append: %w", err)
+	}
+	return out.Offset, out.Complete, nil
+}
+
+// uploadProgress reads the authoritative post-PATCH progress headers. It
+// reports ok only when both headers parse; callers then prefer these values
+// over the response body.
+func uploadProgress(h http.Header) (offset int64, complete bool, ok bool) {
+	rawOffset := h.Get("Upload-Offset")
+	rawComplete := h.Get("Upload-Complete")
+	if rawOffset == "" || rawComplete == "" {
+		return 0, false, false
+	}
+	offset, err := strconv.ParseInt(rawOffset, 10, 64)
+	if err != nil {
+		return 0, false, false
+	}
+	complete, err = strconv.ParseBool(rawComplete)
+	if err != nil {
+		return 0, false, false
+	}
+	return offset, complete, true
+}
+
+// doOctet sends one authenticated octet-stream request carrying the
+// Upload-Offset header, sharing do's unauthorized-retry logic. The chunk must
+// not exceed the client's chunk size, which itself never exceeds
+// rawsync.DefaultUploadChunkBytes.
+func (c *Client) doOctet(
+	ctx context.Context,
+	method string,
+	path string,
+	offset int64,
+	chunk []byte,
+) (*http.Response, error) {
+	if int64(len(chunk)) > c.chunkBytes {
+		return nil, fmt.Errorf("rawclient: chunk of %d bytes exceeds upload chunk size %d",
+			len(chunk), c.chunkBytes)
+	}
+	header := http.Header{}
+	header.Set("Content-Type", "application/octet-stream")
+	header.Set("Upload-Offset", strconv.FormatInt(offset, 10))
+	return c.do(ctx, method, path, header, octetBody{data: chunk})
+}

--- a/internal/rawclient/upload.go
+++ b/internal/rawclient/upload.go
@@ -98,7 +98,8 @@ func (c *Client) UploadObject(
 		if remain := object.Length - offset; remain < int64(len(chunk)) {
 			chunk = chunk[:remain]
 		}
-		if _, err := content.ReadAt(chunk, offset); err != nil {
+		if n, err := content.ReadAt(chunk, offset); err != nil &&
+			!(errors.Is(err, io.EOF) && n == len(chunk)) {
 			return fmt.Errorf("rawclient: read object bytes at %d: %w", offset, err)
 		}
 		next, complete, err := c.appendChunk(

--- a/internal/rawclient/upload.go
+++ b/internal/rawclient/upload.go
@@ -99,7 +99,7 @@ func (c *Client) UploadObject(
 			chunk = chunk[:remain]
 		}
 		if n, err := content.ReadAt(chunk, offset); err != nil &&
-			!(errors.Is(err, io.EOF) && n == len(chunk)) {
+			(!errors.Is(err, io.EOF) || n != len(chunk)) {
 			return fmt.Errorf("rawclient: read object bytes at %d: %w", offset, err)
 		}
 		next, complete, err := c.appendChunk(

--- a/internal/rawclient/upload_test.go
+++ b/internal/rawclient/upload_test.go
@@ -400,6 +400,27 @@ func TestUploadObjectResumesFromServerOffset(t *testing.T) {
 	assert.Equal(t, 10, uploaded)
 }
 
+func TestUploadObjectAdoptsConcurrentDuplicateCompletion(t *testing.T) {
+	t.Parallel()
+	body := []byte("concurrent duplicate")
+	script := &uploadScript{
+		length: int64(len(body)), failFirst: "offset_conflict", postIncomplete: true,
+	}
+	// The POST is stale at offset zero. Before this client's first PATCH lands,
+	// another uploader completes the shared session at the full object length.
+	script.startOffset, script.offset = 0, int64(len(body))
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	require.NoError(t, client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body)))
+	// The stale data PATCH was rejected, then one empty PATCH confirmed the
+	// completed session; no duplicate bytes were accepted.
+	require.Len(t, script.patchBytes, 1)
+	assert.Empty(t, script.patchBytes[0])
+}
+
 func TestUploadObjectChecksumMismatchIsTerminal(t *testing.T) {
 	t.Parallel()
 	body := []byte("terminal")

--- a/internal/rawclient/upload_test.go
+++ b/internal/rawclient/upload_test.go
@@ -320,6 +320,48 @@ func TestUploadObjectRejectsMalformedPatchResponse(t *testing.T) {
 	}
 }
 
+func TestUploadObjectRejectsPatchOffsetBeyondChunk(t *testing.T) {
+	t.Parallel()
+	body := []byte("hello")
+	object := newUploadObject(t, body)
+	var patchedBytes atomic.Int64
+	handler := withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			io.WriteString(w, uploadResponseJSON("up_1", object, 0, false))
+		case http.MethodPatch:
+			chunk, err := io.ReadAll(r.Body)
+			if !assert.NoError(t, err) {
+				http.Error(w, "read chunk", http.StatusInternalServerError)
+				return
+			}
+			patchedBytes.Add(int64(len(chunk)))
+			w.Header().Set("Upload-Offset", strconv.FormatInt(object.Length, 10))
+			w.Header().Set("Upload-Length", strconv.FormatInt(object.Length, 10))
+			w.Header().Set("Upload-Complete", "true")
+			io.WriteString(w, uploadResponseJSON(
+				"up_1", object, object.Length, true))
+		default:
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := NewClient(Config{
+		BaseURL: server.URL, DeviceID: "dev_test", Credential: "avdc_test",
+		TokenMargin: time.Minute, ChunkBytes: 2,
+	})
+	require.NoError(t, err)
+
+	err = client.UploadObject(t.Context(), parser.AgentClaude,
+		object, bytes.NewReader(body))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "expected offset 2")
+	assert.EqualValues(t, 2, patchedBytes.Load(),
+		"client must reject completion after only the first chunk")
+}
+
 func TestUploadObjectSingleChunkCompletes(t *testing.T) {
 	t.Parallel()
 	body := []byte("hello")

--- a/internal/rawclient/upload_test.go
+++ b/internal/rawclient/upload_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -82,6 +83,7 @@ type uploadScript struct {
 	postIncomplete bool
 	deferComplete  bool
 	neverComplete  bool
+	object         rawsync.ObjectRef
 }
 
 func (s *uploadScript) handler(t *testing.T) http.Handler {
@@ -91,13 +93,20 @@ func (s *uploadScript) handler(t *testing.T) http.Handler {
 		// Handler goroutines use assert, never require/FailNow.
 		switch {
 		case r.URL.Path == "/api/v1/raw-sync/uploads" && r.Method == http.MethodPost:
+			var in struct {
+				Object rawsync.ObjectRef `json:"object"`
+			}
+			if !assert.NoError(t, jsonDecode(r.Body, &in)) {
+				http.Error(w, "bad upload start", http.StatusBadRequest)
+				return
+			}
+			s.object = in.Object
 			w.Header().Set("Content-Type", "application/json")
 			complete := s.offset >= s.length
 			if s.postIncomplete {
 				complete = false
 			}
-			fmt.Fprintf(w, `{"upload_id":"up_1","offset":%d,"complete":%t}`,
-				s.startOffset, complete)
+			io.WriteString(w, uploadResponseJSON("up_1", s.object, s.startOffset, complete))
 		case r.URL.Path == "/api/v1/raw-sync/uploads/up_1" && r.Method == http.MethodPatch:
 			assert.NotEmpty(t, r.Header.Get("Authorization"))
 			assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
@@ -146,11 +155,10 @@ func (s *uploadScript) handler(t *testing.T) http.Handler {
 			w.Header().Set("Upload-Complete", strconv.FormatBool(complete))
 			if s.lieInBody {
 				// Stale body: only the headers carry the truth.
-				fmt.Fprintf(w, `{"upload_id":"up_1","offset":0,"complete":false}`)
+				io.WriteString(w, uploadResponseJSON("up_1", s.object, 0, false))
 				return
 			}
-			fmt.Fprintf(w, `{"upload_id":"up_1","offset":%d,"complete":%t}`,
-				s.offset, complete)
+			io.WriteString(w, uploadResponseJSON("up_1", s.object, s.offset, complete))
 		default:
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 			http.Error(w, "unexpected", http.StatusNotFound)
@@ -165,6 +173,151 @@ func newUploadObject(t *testing.T, body []byte) rawsync.ObjectRef {
 	object, err := rawsync.NewObjectRef(hex.EncodeToString(digest[:]), int64(len(body)))
 	require.NoError(t, err)
 	return object
+}
+
+func uploadResponseJSON(
+	uploadID string,
+	object rawsync.ObjectRef,
+	offset int64,
+	complete bool,
+) string {
+	return fmt.Sprintf(
+		`{"upload_id":%q,"object":{"sha256":%q,"length":%d},`+
+			`"offset":%d,"complete":%t}`,
+		uploadID, object.SHA256, object.Length, offset, complete,
+	)
+}
+
+func TestUploadObjectRejectsMalformedStartResponse(t *testing.T) {
+	t.Parallel()
+	body := []byte("hello")
+	object := newUploadObject(t, body)
+	other := newUploadObject(t, []byte("world"))
+	tests := []struct {
+		name     string
+		response string
+		want     string
+	}{
+		{
+			name: "completed response has short offset",
+			response: uploadResponseJSON(
+				"", object, object.Length-1, true,
+			),
+			want: "complete at offset",
+		},
+		{
+			name:     "response identifies different object",
+			response: uploadResponseJSON("", other, other.Length, true),
+			want:     "different object",
+		},
+		{
+			name:     "incomplete response omits upload ID",
+			response: uploadResponseJSON("", object, 0, false),
+			want:     "missing upload ID",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var patches atomic.Int32
+			handler := withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPost:
+					w.Header().Set("Content-Type", "application/json")
+					io.WriteString(w, tt.response)
+				case http.MethodPatch:
+					patches.Add(1)
+					w.Header().Set("Upload-Offset", strconv.FormatInt(object.Length, 10))
+					w.Header().Set("Upload-Length", strconv.FormatInt(object.Length, 10))
+					w.Header().Set("Upload-Complete", "true")
+					io.WriteString(w, uploadResponseJSON("", object, object.Length, true))
+				default:
+					http.Error(w, "unexpected", http.StatusNotFound)
+				}
+			}))
+			server := httptest.NewServer(handler)
+			t.Cleanup(server.Close)
+			client := newTestClient(t, server.URL, time.Minute)
+
+			err := client.UploadObject(t.Context(), parser.AgentClaude,
+				object, bytes.NewReader(body))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+			assert.Zero(t, patches.Load(), "invalid start response must stop before PATCH")
+		})
+	}
+}
+
+func TestUploadObjectRejectsMalformedPatchResponse(t *testing.T) {
+	t.Parallel()
+	body := []byte("hello")
+	object := newUploadObject(t, body)
+	other := newUploadObject(t, []byte("world"))
+	tests := []struct {
+		name         string
+		response     string
+		headerOffset int64
+		want         string
+	}{
+		{
+			name:         "response identifies different upload",
+			response:     uploadResponseJSON("up_other", object, object.Length, true),
+			headerOffset: object.Length,
+			want:         "different upload ID",
+		},
+		{
+			name:         "response identifies different object",
+			response:     uploadResponseJSON("up_1", other, other.Length, true),
+			headerOffset: object.Length,
+			want:         "different object",
+		},
+		{
+			name:         "completed response has short offset",
+			response:     uploadResponseJSON("up_1", object, object.Length-1, true),
+			headerOffset: object.Length - 1,
+			want:         "complete at offset",
+		},
+		{
+			name:         "headers report short completion",
+			response:     uploadResponseJSON("up_1", object, object.Length, true),
+			headerOffset: object.Length - 1,
+			want:         "complete at offset",
+		},
+		{
+			name:         "headers report offset beyond object",
+			response:     uploadResponseJSON("up_1", object, object.Length, true),
+			headerOffset: object.Length + 1,
+			want:         "out of range",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler := withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPost:
+					w.Header().Set("Content-Type", "application/json")
+					io.WriteString(w, uploadResponseJSON("up_1", object, 0, false))
+				case http.MethodPatch:
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("Upload-Offset", strconv.FormatInt(tt.headerOffset, 10))
+					w.Header().Set("Upload-Length", strconv.FormatInt(object.Length, 10))
+					w.Header().Set("Upload-Complete", "true")
+					io.WriteString(w, tt.response)
+				default:
+					http.Error(w, "unexpected", http.StatusNotFound)
+				}
+			}))
+			server := httptest.NewServer(handler)
+			t.Cleanup(server.Close)
+			client := newTestClient(t, server.URL, time.Minute)
+
+			err := client.UploadObject(t.Context(), parser.AgentClaude,
+				object, bytes.NewReader(body))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
 }
 
 func TestUploadObjectSingleChunkCompletes(t *testing.T) {

--- a/internal/rawclient/upload_test.go
+++ b/internal/rawclient/upload_test.go
@@ -1,0 +1,327 @@
+package rawclient
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// withTokenRoute mounts the device-credential token exchange next to a data
+// route so newTestClient's authenticated calls succeed. The issued avdt token
+// outlives every test here.
+func withTokenRoute(next http.Handler) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/raw-sync/tokens", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"token":"avdt_up","device_id":"dev_test",`+
+			`"scopes":["negotiate","upload","commit"],`+
+			`"expires_at":%q}`,
+			time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano))
+	})
+	mux.Handle("/", next)
+	return mux
+}
+
+func TestMissingObjectsRoundTrip(t *testing.T) {
+	t.Parallel()
+	digest := "aa00000000000000000000000000000000000000000000000000000000000000"
+	mux := withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handler goroutines use assert, never require/FailNow.
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/raw-sync/objects/missing", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		if assert.NoError(t, err) {
+			assert.Equal(t, `{"provider":"claude","objects":[`+
+				`{"sha256":"`+digest+`","length":3}]}`, string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"missing":[{"sha256":"`+digest+`","length":3}]}`)
+	}))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	missing, err := client.MissingObjects(t.Context(), parser.AgentClaude,
+		[]rawsync.ObjectRef{{SHA256: digest, Length: 3}})
+	require.NoError(t, err)
+	require.Len(t, missing, 1)
+	assert.Equal(t, digest, missing[0].SHA256)
+	assert.Equal(t, int64(3), missing[0].Length)
+}
+
+// uploadScript is a scripted resumable-upload backend. startOffset is what
+// the POST reports; offset is the authoritative offset the PATCH route
+// defends — keeping them distinct lets a conflict response rewind a client
+// that raced ahead. lieInBody makes successful PATCH bodies carry stale
+// progress so header preference is observable. postIncomplete makes the
+// POST report an incomplete session even at the full offset; deferComplete
+// holds the completion report until an empty finalization PATCH arrives;
+// neverComplete makes the PATCH route refuse to ever complete.
+type uploadScript struct {
+	mu             sync.Mutex
+	startOffset    int64
+	offset         int64
+	length         int64
+	patchBytes     [][]byte
+	failFirst      string // "offset_conflict" | "checksum_mismatch"
+	lieInBody      bool
+	postIncomplete bool
+	deferComplete  bool
+	neverComplete  bool
+}
+
+func (s *uploadScript) handler(t *testing.T) http.Handler {
+	return withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		// Handler goroutines use assert, never require/FailNow.
+		switch {
+		case r.URL.Path == "/api/v1/raw-sync/uploads" && r.Method == http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			complete := s.offset >= s.length
+			if s.postIncomplete {
+				complete = false
+			}
+			fmt.Fprintf(w, `{"upload_id":"up_1","offset":%d,"complete":%t}`,
+				s.startOffset, complete)
+		case r.URL.Path == "/api/v1/raw-sync/uploads/up_1" && r.Method == http.MethodPatch:
+			assert.NotEmpty(t, r.Header.Get("Authorization"))
+			assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
+			offset, err := strconv.ParseInt(r.Header.Get("Upload-Offset"), 10, 64)
+			if !assert.NoError(t, err) {
+				http.Error(w, "bad offset header", http.StatusInternalServerError)
+				return
+			}
+			body, err := io.ReadAll(r.Body)
+			if !assert.NoError(t, err) {
+				http.Error(w, "bad body", http.StatusInternalServerError)
+				return
+			}
+			if s.failFirst == "offset_conflict" {
+				s.failFirst = ""
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				fmt.Fprintf(w, `{"code":"upload_offset_conflict",`+
+					`"error":"raw upload offset changed","upload_offset":%d}`, s.offset)
+				return
+			}
+			if s.failFirst == "checksum_mismatch" {
+				s.failFirst = ""
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				fmt.Fprintf(w, `{"code":"checksum_mismatch",`+
+					`"error":"raw upload checksum did not match","upload_offset":0}`)
+				return
+			}
+			if !assert.Equal(t, s.offset, offset,
+				"PATCH must target the server-confirmed offset") {
+				http.Error(w, "offset mismatch", http.StatusConflict)
+				return
+			}
+			s.patchBytes = append(s.patchBytes, body)
+			s.offset += int64(len(body))
+			complete := s.offset >= s.length
+			if s.deferComplete && len(body) > 0 {
+				// Finalization answers only the empty finalization PATCH.
+				complete = false
+			}
+			if s.neverComplete {
+				complete = false
+			}
+			w.Header().Set("Upload-Offset", strconv.FormatInt(s.offset, 10))
+			w.Header().Set("Upload-Complete", strconv.FormatBool(complete))
+			if s.lieInBody {
+				// Stale body: only the headers carry the truth.
+				fmt.Fprintf(w, `{"upload_id":"up_1","offset":0,"complete":false}`)
+				return
+			}
+			fmt.Fprintf(w, `{"upload_id":"up_1","offset":%d,"complete":%t}`,
+				s.offset, complete)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+}
+
+// newUploadObject builds a validated ObjectRef for body.
+func newUploadObject(t *testing.T, body []byte) rawsync.ObjectRef {
+	t.Helper()
+	digest := sha256.Sum256(body)
+	object, err := rawsync.NewObjectRef(hex.EncodeToString(digest[:]), int64(len(body)))
+	require.NoError(t, err)
+	return object
+}
+
+func TestUploadObjectSingleChunkCompletes(t *testing.T) {
+	t.Parallel()
+	body := []byte("hello")
+	script := &uploadScript{length: int64(len(body)), lieInBody: true}
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	require.NoError(t, client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body)))
+	// One PATCH carried the whole object; the stale body did not mislead the
+	// client because the response headers won.
+	require.Len(t, script.patchBytes, 1)
+	assert.Equal(t, body, script.patchBytes[0])
+}
+
+func TestUploadObjectResumesFromServerOffset(t *testing.T) {
+	t.Parallel()
+	body := []byte("0123456789abcdefghij")
+	script := &uploadScript{length: int64(len(body)), failFirst: "offset_conflict"}
+	// The POST reports offset 0 while the server's authoritative offset is
+	// 10: the first PATCH races ahead and the conflict must rewind it.
+	script.startOffset, script.offset = 0, 10
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	require.NoError(t, client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body)))
+	// Exactly the tail beyond the authoritative offset was transferred.
+	require.NotEmpty(t, script.patchBytes)
+	var uploaded int
+	for _, chunk := range script.patchBytes {
+		uploaded += len(chunk)
+	}
+	assert.Equal(t, 10, uploaded)
+}
+
+func TestUploadObjectChecksumMismatchIsTerminal(t *testing.T) {
+	t.Parallel()
+	body := []byte("terminal")
+	script := &uploadScript{length: int64(len(body)), failFirst: "checksum_mismatch"}
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	err := client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body))
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusConflict, apiErr.Status)
+	assert.Equal(t, CodeChecksumMismatch, apiErr.Code)
+	require.NotNil(t, apiErr.CurrentUploadOffset)
+	assert.EqualValues(t, 0, *apiErr.CurrentUploadOffset)
+	// No successful PATCH and no retry: the mismatch was terminal.
+	assert.Empty(t, script.patchBytes)
+}
+
+func TestUploadObjectRejectsOversizedChunk(t *testing.T) {
+	t.Parallel()
+	body := []byte("0123456789abcdefghij")
+	script := &uploadScript{length: int64(len(body))}
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client, err := NewClient(Config{
+		BaseURL: server.URL, DeviceID: "dev_test",
+		Credential: "avdc_test", TokenMargin: time.Minute, ChunkBytes: 8,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body)))
+	// 20 bytes at ChunkBytes 8 → PATCHes of 8, 8, 4 — never more than 8.
+	require.Len(t, script.patchBytes, 3)
+	var got []byte
+	for _, chunk := range script.patchBytes {
+		assert.LessOrEqual(t, len(chunk), 8)
+		got = append(got, chunk...)
+	}
+	assert.Equal(t, body, got)
+
+	// The configured ceiling never exceeds the transport's hard cap.
+	capped, err := NewClient(Config{
+		BaseURL: server.URL, DeviceID: "dev_test",
+		Credential: "avdc_test",
+		ChunkBytes: rawsync.DefaultUploadChunkBytes + 1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, rawsync.DefaultUploadChunkBytes, capped.chunkBytes)
+}
+
+func TestUploadObjectZeroLengthSkipsPatch(t *testing.T) {
+	t.Parallel()
+	script := &uploadScript{length: 0}
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	require.NoError(t, client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, nil), bytes.NewReader(nil)))
+	assert.Empty(t, script.patchBytes)
+}
+
+func TestUploadObjectFinalizesFullOffsetSession(t *testing.T) {
+	t.Parallel()
+	body := []byte("finalize")
+	script := &uploadScript{length: int64(len(body)), postIncomplete: true}
+	// Custody already holds every byte (offset == length) but the session is
+	// not finalized: one empty PATCH at the confirmed offset must complete it.
+	script.startOffset, script.offset = int64(len(body)), int64(len(body))
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	require.NoError(t, client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body)))
+	// Exactly one zero-byte PATCH finalized the full-offset session.
+	require.Len(t, script.patchBytes, 1)
+	assert.Empty(t, script.patchBytes[0])
+}
+
+func TestUploadObjectFinalizesAfterDeferredCompletion(t *testing.T) {
+	t.Parallel()
+	body := []byte("deferred")
+	script := &uploadScript{length: int64(len(body)), deferComplete: true}
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	require.NoError(t, client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body)))
+	// The data PATCH reported the full offset without completion; the empty
+	// finalization PATCH then confirmed it.
+	require.Len(t, script.patchBytes, 2)
+	assert.Equal(t, body, script.patchBytes[0])
+	assert.Empty(t, script.patchBytes[1])
+}
+
+func TestUploadObjectErrorsWhenFinalizationStaysIncomplete(t *testing.T) {
+	t.Parallel()
+	body := []byte("never")
+	script := &uploadScript{
+		length: int64(len(body)), postIncomplete: true, neverComplete: true,
+	}
+	script.startOffset, script.offset = int64(len(body)), int64(len(body))
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	err := client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not finalized")
+	// Exactly one finalization attempt: the client never spins on a session
+	// the server refuses to complete.
+	require.Len(t, script.patchBytes, 1)
+	assert.Empty(t, script.patchBytes[0])
+}

--- a/internal/rawclient/upload_test.go
+++ b/internal/rawclient/upload_test.go
@@ -86,6 +86,13 @@ type uploadScript struct {
 	object         rawsync.ObjectRef
 }
 
+type fullReadEOFReaderAt []byte
+
+func (r fullReadEOFReaderAt) ReadAt(dst []byte, offset int64) (int, error) {
+	n := copy(dst, r[offset:])
+	return n, io.EOF
+}
+
 func (s *uploadScript) handler(t *testing.T) http.Handler {
 	return withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.mu.Lock()
@@ -374,6 +381,20 @@ func TestUploadObjectSingleChunkCompletes(t *testing.T) {
 		parser.AgentClaude, newUploadObject(t, body), bytes.NewReader(body)))
 	// One PATCH carried the whole object; the stale body did not mislead the
 	// client because the response headers won.
+	require.Len(t, script.patchBytes, 1)
+	assert.Equal(t, body, script.patchBytes[0])
+}
+
+func TestUploadObjectAcceptsFullReadWithEOF(t *testing.T) {
+	t.Parallel()
+	body := []byte("hello")
+	script := &uploadScript{length: int64(len(body))}
+	server := httptest.NewServer(script.handler(t))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL, time.Minute)
+
+	require.NoError(t, client.UploadObject(t.Context(),
+		parser.AgentClaude, newUploadObject(t, body), fullReadEOFReaderAt(body)))
 	require.Len(t, script.patchBytes, 1)
 	assert.Equal(t, body, script.patchBytes[0])
 }

--- a/internal/rawsync/metadata_store.go
+++ b/internal/rawsync/metadata_store.go
@@ -13,6 +13,21 @@ type CommitResult struct {
 	Created    bool
 }
 
+// ValidateCommitResult rejects commit acknowledgements that cannot be used as
+// durable source-chain checkpoints.
+func ValidateCommitResult(result CommitResult) error {
+	if !isCanonicalSHA256(result.ManifestID) {
+		return fmt.Errorf("%w: commit manifest ID must be lowercase SHA-256", ErrInvalid)
+	}
+	if !isCanonicalSHA256(result.Receipt) {
+		return fmt.Errorf("%w: commit receipt must be lowercase SHA-256", ErrInvalid)
+	}
+	if result.Generation <= 0 {
+		return fmt.Errorf("%w: commit generation must be positive", ErrInvalid)
+	}
+	return nil
+}
+
 // HeadConflictError reports the current accepted source head.
 type HeadConflictError struct {
 	CurrentManifestID string

--- a/internal/rawsync/upload.go
+++ b/internal/rawsync/upload.go
@@ -227,6 +227,11 @@ func (s *UploadService) Append(
 		return UploadSession{}, fmt.Errorf("validating appended raw upload session: %w", err)
 	}
 	if session.Complete {
+		if session.Offset != expectedOffset {
+			return UploadSession{}, &UploadOffsetConflictError{
+				CurrentOffset: session.Offset,
+			}
+		}
 		return session, nil
 	}
 	expectedAfter := expectedOffset + int64(len(chunk))

--- a/internal/rawsync/upload_test.go
+++ b/internal/rawsync/upload_test.go
@@ -124,6 +124,28 @@ func TestUploadServiceReturnsCurrentOffsetWithoutWritingOnConflict(t *testing.T)
 	assert.Zero(t, custody.finalizeCalls)
 }
 
+func TestUploadServiceReturnsCurrentOffsetAfterConcurrentCompletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	store := newMemoryUploadSessionStore()
+	custody := newMemoryUploadCustody()
+	service := newUploadServiceForTest(t, store, custody, now)
+	identity := AuthIdentity{TenantID: "tenant-a", DeviceID: "dev-a"}
+	body := []byte("concurrent duplicate")
+	object := objectRefForBytes(t, body)
+	session, _, err := service.Start(t.Context(), identity, parser.AgentCodex, object)
+	require.NoError(t, err)
+	store.completeBeforeAppend = true
+
+	_, err = service.Append(t.Context(), identity, session.ID, 0, body[:5])
+
+	var conflict *UploadOffsetConflictError
+	require.ErrorAs(t, err, &conflict)
+	assert.Equal(t, object.Length, conflict.CurrentOffset)
+	assert.Empty(t, store.data, "the stale chunk must not be accepted")
+}
+
 func TestUploadServiceChecksumMismatchResetsSession(t *testing.T) {
 	t.Parallel()
 
@@ -321,16 +343,17 @@ func newUploadServiceForTest(
 }
 
 type memoryUploadSessionStore struct {
-	mu             sync.Mutex
-	session        UploadSession
-	data           []byte
-	events         *[]string
-	openReader     func([]byte) io.ReadCloser
-	completeOnOpen bool
-	resetErr       error
-	createCalls    int
-	resetCalls     int
-	completeCalls  int
+	mu                   sync.Mutex
+	session              UploadSession
+	data                 []byte
+	events               *[]string
+	openReader           func([]byte) io.ReadCloser
+	completeBeforeAppend bool
+	completeOnOpen       bool
+	resetErr             error
+	createCalls          int
+	resetCalls           int
+	completeCalls        int
 }
 
 func newMemoryUploadSessionStore() *memoryUploadSessionStore {
@@ -380,6 +403,12 @@ func (s *memoryUploadSessionStore) Append(
 	}
 	if s.session.ID != uploadID || s.session.Identity != identity {
 		return UploadSession{}, ErrNotFound
+	}
+	if s.completeBeforeAppend {
+		s.completeBeforeAppend = false
+		s.session.Offset = s.session.Object.Length
+		s.session.Complete = true
+		return s.session, nil
 	}
 	if s.session.Offset != expectedOffset {
 		return UploadSession{}, &UploadOffsetConflictError{


### PR DESCRIPTION
## Summary

Adds the laptop-side half of the hosted raw-ingest transport, as one feature
commit on top of the merged server surface (#1459, #1473, #1488).

`internal/rawclient` is the HTTP client for the authenticated raw-sync
surface:

- scoped-token exchange with TTL-aware caching and single-flight refresh,
  plus one forced re-exchange retry on unauthorized responses;
- missing-object negotiation (`POST /objects/missing`);
- resumable chunked uploads (`POST`/`PATCH` on `/uploads`) with
  authoritative offset recovery on `upload_offset_conflict`, terminal
  `checksum_mismatch`, and a final empty PATCH when a resumed session
  already sits at the full offset but was not finalized (server crash
  window between append commit and finalization);
- manifest-last commit returning the durable receipt, with typed
  `head_conflict` surfacing the current receipt and generation.

`internal/rawcheckpoint` is the small dedicated local SQLite database for
transport state: one-row device identity and per-source head
receipts/generations keyed by `(provider, configured_root_id, source_key)`,
using the same dual mattn/modernc driver split as `internal/vector`. Head
advancement refuses anything without a durable receipt, so the checkpoint
can only trail server acknowledgment. The device credential is injected
through `Config` and never persisted or logged.

Tenant identity is never sent by the client; it stays derived from the
authenticated server context (spec invariants 3 and 4).

Proof comes from three layers: wire-contract unit tests against scripted
handlers, a full-cycle end-to-end test against the real huma server stack
with real rawsync services and in-memory stores, and a `pgtest` end-to-end
against the durable PostgreSQL stores that also covers interrupted-upload
resume (durable offset row plus spool prefix observed before and after a
fresh client re-uploads) and the stale-parent head conflict.

Known limits, deliberately deferred to the capture-agent slice: negotiation
calls are unbatched against the server's 1 MiB control-plane cap (roughly
9-10k object refs per call against the 16384-object manifest ceiling), and
there is no status scope because no server route exists yet.

Reviewers should start at `internal/rawclient/upload.go` (offset recovery
and finalization), `internal/rawclient/tokens.go` (refresh discipline), and
`internal/rawcheckpoint/store.go` (receipt-gated advancement).
