### PR TITLE
fix(activity): keep overlay selector inside chart card

### DIFF
--- a/frontend/e2e/activity-layout.spec.ts
+++ b/frontend/e2e/activity-layout.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test("keeps the concurrency overlay selector inside its chart card", async ({ page }) => {
+  await page.setViewportSize({ width: 2048, height: 768 });
+  await page.goto("/activity");
+
+  const chartCard = page.locator(".chart-panel").first();
+  const overlaySelector = chartCard.locator(".overlay-toggle .kit-typeahead__trigger");
+  await expect(overlaySelector).toBeVisible();
+
+  const [cardBox, selectorBox] = await Promise.all([
+    chartCard.boundingBox(),
+    overlaySelector.boundingBox(),
+  ]);
+  expect(cardBox).not.toBeNull();
+  expect(selectorBox).not.toBeNull();
+  expect(selectorBox!.x + selectorBox!.width).toBeLessThanOrEqual(cardBox!.x + cardBox!.width);
+});

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -845,6 +845,7 @@
 
   .overlay-toggle :global(.kit-typeahead) {
     flex: 0 0 96px;
+    width: 96px;
   }
 
   .timeline-body {


### PR DESCRIPTION
On WebKit, the Activity concurrency chart's overlay selector could extend beyond the right edge because the Typeahead flex basis was not included in the overlay group's intrinsic width. Give the selector an explicit 96px width while retaining its fixed flex basis, and cover the card boundary with a Playwright regression that runs in Chromium and WebKit.
