### PR TITLE
feat(api): opt in to session source paths

### DIFF
--- a/frontend/src/lib/api/generated/services/SessionsService.ts
+++ b/frontend/src/lib/api/generated/services/SessionsService.ts
@@ -113,6 +113,7 @@ export class SessionsService {
     includeOneShot,
     includeAutomated,
     includeChildren,
+    includeSource,
     outcome,
     healthGrade,
     cursor,
@@ -189,6 +190,10 @@ export class SessionsService {
      */
     includeChildren?: boolean,
     /**
+     * Include source file paths
+     */
+    includeSource?: boolean,
+    /**
      * Filter by detected outcome
      */
     outcome?: string,
@@ -249,6 +254,7 @@ export class SessionsService {
         'include_one_shot': includeOneShot,
         'include_automated': includeAutomated,
         'include_children': includeChildren,
+        'include_source': includeSource,
         'outcome': outcome,
         'health_grade': healthGrade,
         'cursor': cursor,
@@ -327,6 +333,7 @@ export class SessionsService {
     includeOneShot,
     includeAutomated,
     includeChildren,
+    includeSource,
     outcome,
     healthGrade,
     cursor,
@@ -403,6 +410,10 @@ export class SessionsService {
      */
     includeChildren?: boolean,
     /**
+     * Include source file paths
+     */
+    includeSource?: boolean,
+    /**
      * Filter by detected outcome
      */
     outcome?: string,
@@ -463,6 +474,7 @@ export class SessionsService {
         'include_one_shot': includeOneShot,
         'include_automated': includeAutomated,
         'include_children': includeChildren,
+        'include_source': includeSource,
         'outcome': outcome,
         'health_grade': healthGrade,
         'cursor': cursor,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -152,8 +152,14 @@ type rowScanner interface {
 
 // scanSessionRow scans sessionBaseCols into a Session.
 func scanSessionRow(rs rowScanner) (Session, error) {
+	return scanSessionRowWithSource(rs, false)
+}
+
+// scanSessionRowWithSource scans sessionBaseCols and an optional trailing
+// file_path into a Session.
+func scanSessionRowWithSource(rs rowScanner, includeSource bool) (Session, error) {
 	var s Session
-	err := rs.Scan(
+	targets := []any{
 		&s.ID, &s.Project, &s.Machine, &s.Agent,
 		&s.AgentLabel, &s.Entrypoint, &s.SessionKind,
 		&s.FirstMessage, &s.DisplayName, &s.StartedAt, &s.EndedAt,
@@ -184,7 +190,11 @@ func scanSessionRow(rs rowScanner) (Session, error) {
 		&s.ParserMalformedLines, &s.IsTruncated,
 		&s.DeletedAt, &s.TerminationStatus,
 		&s.TranscriptRevision, &s.CreatedAt,
-	)
+	}
+	if includeSource {
+		targets = append(targets, &s.FilePath)
+	}
+	err := rs.Scan(targets...)
 	return s, err
 }
 
@@ -520,6 +530,7 @@ type SessionFilter struct {
 	AutomatedScope     string   // "", "human", "all", or "automated"
 	IncludeChildren    bool     // include subagent sessions (for sidebar grouping)
 	IncludeOrphans     bool     // promote orphan child rows to sidebar roots
+	IncludeSource      bool     // include the session source file path in list rows
 	Outcome            []string // filter by outcome values
 	HealthGrade        []string // filter by health grade values
 	MinToolFailures    *int     // minimum tool_failure_signal_count
@@ -706,7 +717,11 @@ func (db *DB) ListSessions(
 		)
 	}
 
-	query := "SELECT " + sessionBaseCols +
+	columns := sessionBaseCols
+	if f.IncludeSource {
+		columns += ", file_path"
+	}
+	query := "SELECT " + columns +
 		" FROM sessions WHERE " + cursorWhere + " " +
 		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
@@ -719,7 +734,7 @@ func (db *DB) ListSessions(
 	}
 	defer rows.Close()
 
-	sessions, err := scanSessionRows(rows)
+	sessions, err := scanSessionRowsWithSource(rows, f.IncludeSource)
 	if err != nil {
 		return SessionPage{}, err
 	}
@@ -5165,9 +5180,13 @@ func (db *DB) GetBranches(
 // scanSessionRows iterates rows and scans each using
 // scanSessionRow.
 func scanSessionRows(rows *sql.Rows) ([]Session, error) {
+	return scanSessionRowsWithSource(rows, false)
+}
+
+func scanSessionRowsWithSource(rows *sql.Rows, includeSource bool) ([]Session, error) {
 	sessions := []Session{}
 	for rows.Next() {
-		s, err := scanSessionRow(rows)
+		s, err := scanSessionRowWithSource(rows, includeSource)
 		if err != nil {
 			return nil, fmt.Errorf("scanning session: %w", err)
 		}

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -303,10 +303,16 @@ const duckSessionCols = `id, project, machine, agent,
 	deleted_at, deletion_cause, termination_status, transcript_revision`
 
 func scanSession(rs interface{ Scan(...any) error }) (db.Session, error) {
+	return scanSessionWithSource(rs, false)
+}
+
+func scanSessionWithSource(
+	rs interface{ Scan(...any) error }, includeSource bool,
+) (db.Session, error) {
 	var s db.Session
 	var createdAt any
 	var startedAt, endedAt, deletedAt any
-	err := rs.Scan(
+	targets := []any{
 		&s.ID, &s.Project, &s.Machine, &s.Agent,
 		&s.AgentLabel, &s.Entrypoint, &s.SessionKind,
 		&s.FirstMessage, &s.DisplayName,
@@ -335,7 +341,11 @@ func scanSession(rs interface{ Scan(...any) error }) (db.Session, error) {
 		&s.ParserMalformedLines, &s.IsTruncated,
 		&s.SecretLeakCount, &s.SecretsRulesVersion,
 		&deletedAt, &s.DeletionCause, &s.TerminationStatus, &s.TranscriptRevision,
-	)
+	}
+	if includeSource {
+		targets = append(targets, &s.FilePath)
+	}
+	err := rs.Scan(targets...)
 	if err != nil {
 		return s, err
 	}
@@ -353,9 +363,15 @@ func scanSession(rs interface{ Scan(...any) error }) (db.Session, error) {
 }
 
 func scanSessionRows(rows *sql.Rows) ([]db.Session, error) {
+	return scanSessionRowsWithSource(rows, false)
+}
+
+func scanSessionRowsWithSource(
+	rows *sql.Rows, includeSource bool,
+) ([]db.Session, error) {
 	sessions := []db.Session{}
 	for rows.Next() {
-		s, err := scanSession(rows)
+		s, err := scanSessionWithSource(rows, includeSource)
 		if err != nil {
 			return nil, fmt.Errorf("scanning duckdb session: %w", err)
 		}
@@ -499,7 +515,11 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		}
 		cursorWhere += " AND " + pageBuilder.CursorPredicate(rs, f, vals, cur.ID)
 	}
-	query := "SELECT " + duckSessionCols +
+	columns := duckSessionCols
+	if f.IncludeSource {
+		columns += ", file_path"
+	}
+	query := "SELECT " + columns +
 		" FROM sessions WHERE " + cursorWhere + " " +
 		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
@@ -509,7 +529,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		return db.SessionPage{}, fmt.Errorf("querying duckdb sessions: %w", err)
 	}
 	defer rows.Close()
-	sessions, err := scanSessionRows(rows)
+	sessions, err := scanSessionRowsWithSource(rows, f.IncludeSource)
 	if err != nil {
 		return db.SessionPage{}, err
 	}

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -316,6 +316,15 @@ func duckContractSessionsCursorsAndMetadata(
 	require.Len(t, page.Sessions, 1)
 	require.Equal(t, fixture.betaID, page.Sessions[0].ID)
 	require.NotEmpty(t, page.NextCursor)
+	assert.Nil(t, page.Sessions[0].FilePath)
+
+	withSource, err := store.ListSessions(ctx, db.SessionFilter{
+		Project: "alpha", IncludeSource: true, Limit: 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, withSource.Sessions, 1)
+	require.NotNil(t, withSource.Sessions[0].FilePath)
+	assert.Equal(t, fixture.alphaPath, *withSource.Sessions[0].FilePath)
 
 	cur, err := store.DecodeCursor(page.NextCursor)
 	require.NoError(t, err)

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -2227,8 +2227,9 @@ func TestReadStatusFromConfigCountsAllSourceMachines(t *testing.T) {
 }
 
 type syncFixture struct {
-	alphaID string
-	betaID  string
+	alphaID   string
+	alphaPath string
+	betaID    string
 }
 
 func newLocalDB(t *testing.T) *db.DB {
@@ -2490,11 +2491,14 @@ func seedDuckDBSyncFixture(t *testing.T, local *db.DB) syncFixture {
 	}}))
 	alphaID := "duck-sync-alpha"
 	betaID := "duck-sync-beta"
+	alphaPath := filepath.Join(t.TempDir(), "alpha.jsonl")
 	alphaSecret := "secret token sk-duckdb"
 	callIndex := 0
+	alphaSession := syncSession(alphaID, "alpha", "alpha first", "2026-01-10T00:00:00.000Z", 2)
+	alphaSession.FilePath = &alphaPath
 	writes := []db.SessionBatchWrite{
 		{
-			Session: syncSession(alphaID, "alpha", "alpha first", "2026-01-10T00:00:00.000Z", 2),
+			Session: alphaSession,
 			Messages: []db.Message{
 				syncMessage(alphaID, 0, "user", "alpha first", "2026-01-10T00:00:00.000Z"),
 				syncMessage(alphaID, 1, "assistant", alphaSecret, "2026-01-10T00:01:00.000Z",
@@ -2557,7 +2561,7 @@ func seedDuckDBSyncFixture(t *testing.T, local *db.DB) syncFixture {
 	note := "pin alpha"
 	_, err = local.PinMessage(alphaID, msgs[0].ID, &note)
 	require.NoError(t, err)
-	return syncFixture{alphaID: alphaID, betaID: betaID}
+	return syncFixture{alphaID: alphaID, alphaPath: alphaPath, betaID: betaID}
 }
 
 func syncSession(id, project, first, ts string, messageCount int) db.Session {

--- a/internal/postgres/session_identity_pgtest_test.go
+++ b/internal/postgres/session_identity_pgtest_test.go
@@ -92,6 +92,7 @@ func TestPGClaudeProvenanceVisibleInReadPaths(t *testing.T) {
 
 	page, err := store.ListSessions(ctx, db.SessionFilter{
 		IncludeChildren: true,
+		IncludeSource:   true,
 	})
 	require.NoError(t, err, "ListSessions")
 	require.Len(t, page.Sessions, 1, "expected one listed session")

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -42,10 +42,9 @@ type Store struct {
 	semanticUnavailableReason string
 }
 
-// pgSessionCols is the column list for standard PG session queries.
-// PostgreSQL retains the source file path used by read-side session
-// functionality while omitting volatile local fingerprint metadata.
-const pgSessionCols = `id, project, machine, agent,
+// pgSessionBaseCols is the column list for PG session queries that do not
+// expose source paths.
+const pgSessionBaseCols = `id, project, machine, agent,
 	agent_label, entrypoint, session_kind,
 	first_message, COALESCE(display_name, session_name) AS display_name, created_at, started_at,
 	ended_at, message_count, user_message_count,
@@ -71,7 +70,12 @@ const pgSessionCols = `id, project, machine, agent,
 	cwd, git_branch, source_session_id, source_version,
 	transcript_fidelity, parser_malformed_lines, is_truncated,
 	secret_leak_count, secrets_rules_version,
-	deleted_at, deletion_cause, termination_status, transcript_revision,
+	deleted_at, deletion_cause, termination_status, transcript_revision`
+
+// pgSessionCols is the column list for full PG session queries.
+// PostgreSQL retains the source file path used by read-side session
+// functionality while omitting volatile local fingerprint metadata.
+const pgSessionCols = pgSessionBaseCols + `,
 	file_path`
 
 // paramBuilder generates numbered PostgreSQL placeholders.
@@ -200,10 +204,16 @@ func pgTerminationPred(status string, pb *paramBuilder) string {
 func scanPGSession(
 	rs interface{ Scan(...any) error },
 ) (db.Session, error) {
+	return scanPGSessionWithSource(rs, true)
+}
+
+func scanPGSessionWithSource(
+	rs interface{ Scan(...any) error }, includeSource bool,
+) (db.Session, error) {
 	var s db.Session
 	var createdAt *time.Time
 	var startedAt, endedAt, deletedAt *time.Time
-	err := rs.Scan(
+	targets := []any{
 		&s.ID, &s.Project, &s.Machine, &s.Agent,
 		&s.AgentLabel, &s.Entrypoint, &s.SessionKind,
 		&s.FirstMessage, &s.DisplayName,
@@ -233,8 +243,11 @@ func scanPGSession(
 		&s.TranscriptFidelity, &s.ParserMalformedLines, &s.IsTruncated,
 		&s.SecretLeakCount, &s.SecretsRulesVersion,
 		&deletedAt, &s.DeletionCause, &s.TerminationStatus, &s.TranscriptRevision,
-		&s.FilePath,
-	)
+	}
+	if includeSource {
+		targets = append(targets, &s.FilePath)
+	}
+	err := rs.Scan(targets...)
 	if err != nil {
 		return s, err
 	}
@@ -294,9 +307,15 @@ func (s *Store) FindSessionIDsByPartial(
 func scanPGSessionRows(
 	rows *sql.Rows,
 ) ([]db.Session, error) {
+	return scanPGSessionRowsWithSource(rows, true)
+}
+
+func scanPGSessionRowsWithSource(
+	rows *sql.Rows, includeSource bool,
+) ([]db.Session, error) {
 	sessions := []db.Session{}
 	for rows.Next() {
-		s, err := scanPGSession(rows)
+		s, err := scanPGSessionWithSource(rows, includeSource)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"scanning session: %w", err,
@@ -462,7 +481,11 @@ func (s *Store) ListSessions(
 		)
 	}
 
-	query := "SELECT " + pgSessionCols +
+	columns := pgSessionBaseCols
+	if f.IncludeSource {
+		columns = pgSessionCols
+	}
+	query := "SELECT " + columns +
 		" FROM sessions WHERE " + cursorWhere + " " +
 		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
@@ -477,7 +500,7 @@ func (s *Store) ListSessions(
 	}
 	defer rows.Close()
 
-	sessions, err := scanPGSessionRows(rows)
+	sessions, err := scanPGSessionRowsWithSource(rows, f.IncludeSource)
 	if err != nil {
 		return db.SessionPage{}, err
 	}

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -34,14 +34,14 @@ func ensureStoreSchema(t *testing.T, pgURL string) {
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, ended_at, message_count,
-			 user_message_count)
+			 user_message_count, file_path)
 		VALUES
 			('store-test-001', 'test-machine',
 			 'test-project', 'claude-code',
 			 'hello world',
 			 '2026-03-12T10:00:00Z'::timestamptz,
 			 '2026-03-12T10:30:00Z'::timestamptz,
-			 2, 1)
+			 2, 1, '/fixtures/store-test-001.jsonl')
 	`)
 	require.NoError(t, err, "inserting test session")
 	_, err = pg.Exec(`
@@ -176,8 +176,16 @@ func TestStoreListSessions(t *testing.T) {
 	)
 	require.NoError(t, err, "ListSessions")
 	assert.NotZero(t, page.Total, "expected at least 1 session")
-	t.Logf("sessions: %d, total: %d",
-		len(page.Sessions), page.Total)
+	require.Len(t, page.Sessions, 1)
+	assert.Nil(t, page.Sessions[0].FilePath)
+
+	withSource, err := store.ListSessions(
+		ctx, db.SessionFilter{IncludeSource: true, Limit: 10},
+	)
+	require.NoError(t, err, "ListSessions with source")
+	require.Len(t, withSource.Sessions, 1)
+	require.NotNil(t, withSource.Sessions[0].FilePath)
+	assert.Equal(t, "/fixtures/store-test-001.jsonl", *withSource.Sessions[0].FilePath)
 }
 
 func TestStoreListSessions_MachineMultiSelect(t *testing.T) {

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -76,6 +76,7 @@ type sessionFilterInput struct {
 	IncludeOneShot   bool              `query:"include_one_shot" doc:"Include one-shot sessions"`
 	IncludeAutomated bool              `query:"include_automated" doc:"Include automated sessions"`
 	IncludeChildren  bool              `query:"include_children" doc:"Include child sessions"`
+	IncludeSource    bool              `query:"include_source" doc:"Include source file paths"`
 	Outcome          string            `query:"outcome" doc:"Filter by detected outcome"`
 	HealthGrade      string            `query:"health_grade" doc:"Filter by health grade"`
 	Cursor           string            `query:"cursor" doc:"Opaque pagination cursor"`
@@ -142,6 +143,7 @@ func (in *sessionFilterInput) listFilter() (service.ListFilter, error) {
 		IncludeOneShot:   in.IncludeOneShot,
 		IncludeAutomated: in.IncludeAutomated,
 		IncludeChildren:  in.IncludeChildren,
+		IncludeSource:    in.IncludeSource,
 		Outcome:          in.Outcome,
 		HealthGrade:      in.HealthGrade,
 		Cursor:           in.Cursor,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1532,6 +1532,35 @@ func TestListSessions_WithData(t *testing.T) {
 	}
 }
 
+func TestListSessions_IncludesSourcePathOnlyWhenRequested(t *testing.T) {
+	te := setup(t)
+	sourcePath := filepath.Join(t.TempDir(), "session.jsonl")
+	te.seedSession(t, "s1", "my-app", 5, func(s *db.Session) {
+		s.FilePath = &sourcePath
+	})
+
+	decodeSession := func(t *testing.T, path string) map[string]jsontext.Value {
+		t.Helper()
+		w := te.get(t, path)
+		assertStatus(t, w, http.StatusOK)
+		var raw struct {
+			Sessions []map[string]jsontext.Value `json:"sessions"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+		require.Len(t, raw.Sessions, 1)
+		return raw.Sessions[0]
+	}
+
+	withoutSource := decodeSession(t, "/api/v1/sessions")
+	assert.NotContains(t, withoutSource, "file_path")
+
+	withSource := decodeSession(t, "/api/v1/sessions?include_source=true")
+	require.Contains(t, withSource, "file_path")
+	var gotPath string
+	require.NoError(t, json.Unmarshal(withSource["file_path"], &gotPath))
+	assert.Equal(t, sourcePath, gotPath)
+}
+
 func TestListSessions_ProjectFilter(t *testing.T) {
 	te := setup(t)
 	te.seedSession(t, "s1", "my-app", 5)

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -193,6 +193,7 @@ func listFilterToDB(f ListFilter) db.SessionFilter {
 		ExcludeOneShot:       !f.IncludeOneShot,
 		ExcludeAutomated:     !f.IncludeAutomated,
 		IncludeChildren:      f.IncludeChildren,
+		IncludeSource:        f.IncludeSource,
 		Cursor:               f.Cursor,
 		Limit:                f.Limit,
 		MinToolFailures:      f.MinToolFailures,

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -229,6 +229,9 @@ func filterToQuery(f ListFilter) url.Values {
 	if f.IncludeChildren {
 		q.Set("include_children", "true")
 	}
+	if f.IncludeSource {
+		q.Set("include_source", "true")
+	}
 	setIfNotEmpty("outcome", f.Outcome)
 	setIfNotEmpty("health_grade", f.HealthGrade)
 	setIfNotEmpty("termination", f.Termination)

--- a/internal/service/http_internal_test.go
+++ b/internal/service/http_internal_test.go
@@ -41,15 +41,17 @@ func TestHTTPBackendRecallCapabilityRespectsReadOnlyMode(t *testing.T) {
 	}
 }
 
-func TestFilterToQueryKeepsTimezoneWithCursor(t *testing.T) {
+func TestFilterToQueryKeepsListOptions(t *testing.T) {
 	t.Parallel()
 	query := filterToQuery(ListFilter{
-		Timezone: "America/New_York",
-		Cursor:   "next-page",
+		Timezone:      "America/New_York",
+		Cursor:        "next-page",
+		IncludeSource: true,
 	})
 
 	assert.Equal(t, "America/New_York", query.Get("timezone"))
 	assert.Equal(t, "next-page", query.Get("cursor"))
+	assert.Equal(t, "true", query.Get("include_source"))
 }
 
 func TestSearchContentUsesLongRunningClient(t *testing.T) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -387,6 +387,7 @@ type ListFilter struct {
 	IncludeOneShot   bool   `json:"include_one_shot,omitempty"`
 	IncludeAutomated bool   `json:"include_automated,omitempty"`
 	IncludeChildren  bool   `json:"include_children,omitempty"`
+	IncludeSource    bool   `json:"include_source,omitempty"`
 	Outcome          string `json:"outcome,omitempty"`      // comma-separated
 	HealthGrade      string `json:"health_grade,omitempty"` // comma-separated
 	Termination      string `json:"termination,omitempty"`  // comma-separated


### PR DESCRIPTION
Session-list consumers that validate transcript lineage cannot recover source paths consistently across storage backends. This adds an opt-in `include_source=true` query parameter and carries it through direct and HTTP service backends so SQLite, DuckDB, and PostgreSQL return `file_path` only when requested.

Default list responses stay path-free on every backend. The option changes only list projections; pagination, filtering, and stored session data are unchanged.
