### PR TITLE
fix(frontend): route arrows by focused or clicked pane (#1481)

### DIFF
--- a/frontend/e2e/message-loading.spec.ts
+++ b/frontend/e2e/message-loading.spec.ts
@@ -203,6 +203,11 @@ test.describe("Message loading", () => {
     await sp.goto();
     await sp.selectFirstSession();
 
+    await sp.scroller.dispatchEvent("pointerdown", {
+      bubbles: true,
+      pointerType: "mouse",
+    });
+
     const follow = page.getByLabel("Follow latest messages");
     await follow.click();
     await expect(follow).toHaveAttribute("aria-pressed", "true");

--- a/frontend/e2e/session-list.spec.ts
+++ b/frontend/e2e/session-list.spec.ts
@@ -62,18 +62,33 @@ test.describe("Session list", () => {
   test("plain arrows over the sessions list navigate sessions", async ({
     page,
   }) => {
-    const sessionId = await sp.sessionItems.first().getAttribute(
-      "data-session-id",
-    );
+    const sessionWithMessages = sp.sessionItems
+      .filter({
+        has: page.locator(".session-count", { hasText: /[1-9]/ }),
+      })
+      .first();
+    const sessionId = await sessionWithMessages.getAttribute("data-session-id");
     expect(sessionId).toBeTruthy();
     await page.goto(`/sessions/${encodeURIComponent(sessionId!)}`);
-    await expect(sp.messageRows.first()).toBeVisible();
-    await expect(sp.sessionItems.first()).toHaveClass(/active/);
+    const hasMessages = await expect(sp.messageRows.first())
+      .toBeVisible({ timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+    expect(hasMessages || process.env.AGENTSVIEW_E2E_BACKEND === "duckdb").toBe(
+      true,
+    );
+    await expect(sessionWithMessages).toHaveClass(/active/);
 
     await page.mouse.move(0, 0);
     await sp.sessionListScroll.hover();
+    const activeSessionBefore =
+      await sessionWithMessages.getAttribute("data-session-id");
     await page.keyboard.press("ArrowDown");
-    await expect(sp.sessionItems.nth(1)).toHaveClass(/active/);
+    await expect(
+      page.locator('.session-item[aria-current="page"]'),
+    ).not.toHaveAttribute("data-session-id", activeSessionBefore!);
+
+    if (!hasMessages) return;
 
     await sp.scroller.hover();
     await sp.messageRows.first().click();

--- a/frontend/e2e/session-list.spec.ts
+++ b/frontend/e2e/session-list.spec.ts
@@ -59,6 +59,20 @@ test.describe("Session list", () => {
     await expect(sp.sessionItems.first()).toHaveClass(/active/);
   });
 
+  test("plain arrows over the sessions list navigate sessions", async () => {
+    await sp.selectSession(0);
+    await expect(sp.sessionItems.first()).toHaveClass(/active/);
+
+    await sp.sessionListScroll.hover();
+    await page.keyboard.press("ArrowDown");
+    await expect(sp.sessionItems.nth(1)).toHaveClass(/active/);
+
+    await sp.scroller.hover();
+    await sp.messageRows.first().click();
+    await page.keyboard.press("ArrowDown");
+    await expect(sp.messageRows.nth(1)).toHaveClass(/selected/);
+  });
+
   const filterCases = [
     { project: "project-alpha", expectedCount: ALPHA_SESSIONS },
     { project: "project-beta", expectedCount: BETA_SESSIONS },

--- a/frontend/e2e/session-list.spec.ts
+++ b/frontend/e2e/session-list.spec.ts
@@ -59,7 +59,7 @@ test.describe("Session list", () => {
     await expect(sp.sessionItems.first()).toHaveClass(/active/);
   });
 
-  test("plain arrows over the sessions list navigate sessions", async ({
+  test("plain arrows follow the last session or message interaction", async ({
     page,
   }) => {
     const sessionWithMessages = sp.sessionItems
@@ -79,8 +79,7 @@ test.describe("Session list", () => {
     );
     await expect(sessionWithMessages).toHaveClass(/active/);
 
-    await page.mouse.move(0, 0);
-    await sp.sessionListScroll.hover();
+    await sessionWithMessages.focus();
     const activeSessionBefore =
       await sessionWithMessages.getAttribute("data-session-id");
     await page.keyboard.press("ArrowDown");
@@ -90,7 +89,6 @@ test.describe("Session list", () => {
 
     if (!hasMessages) return;
 
-    await sp.scroller.hover();
     await sp.messageRows.first().click();
     await page.keyboard.press("ArrowDown");
     await expect(sp.messageRows.nth(1)).toHaveClass(/selected/);

--- a/frontend/e2e/session-list.spec.ts
+++ b/frontend/e2e/session-list.spec.ts
@@ -62,9 +62,15 @@ test.describe("Session list", () => {
   test("plain arrows over the sessions list navigate sessions", async ({
     page,
   }) => {
-    await sp.selectSession(0);
+    const sessionId = await sp.sessionItems.first().getAttribute(
+      "data-session-id",
+    );
+    expect(sessionId).toBeTruthy();
+    await page.goto(`/sessions/${encodeURIComponent(sessionId!)}`);
+    await expect(sp.messageRows.first()).toBeVisible();
     await expect(sp.sessionItems.first()).toHaveClass(/active/);
 
+    await page.mouse.move(0, 0);
     await sp.sessionListScroll.hover();
     await page.keyboard.press("ArrowDown");
     await expect(sp.sessionItems.nth(1)).toHaveClass(/active/);

--- a/frontend/e2e/session-list.spec.ts
+++ b/frontend/e2e/session-list.spec.ts
@@ -59,7 +59,9 @@ test.describe("Session list", () => {
     await expect(sp.sessionItems.first()).toHaveClass(/active/);
   });
 
-  test("plain arrows over the sessions list navigate sessions", async () => {
+  test("plain arrows over the sessions list navigate sessions", async ({
+    page,
+  }) => {
     await sp.selectSession(0);
     await expect(sp.sessionItems.first()).toHaveClass(/active/);
 

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -17,6 +17,7 @@
   import { TrashIcon, CheckIcon } from "../../icons.js";
   import { formatNumber } from "../../utils/format.js";
   import { agentColor } from "../../utils/agents.js";
+  import { registerSessionList } from "../../utils/arrow-target.js";
   import {
     type DisplayItem,
     type GroupMode,
@@ -51,6 +52,9 @@
 
   onMount(() => {
     detachSidebar = sessions.attachSidebar();
+    const element = containerRef;
+    if (!element) return;
+    return registerSessionList(element);
   });
 
   $effect(() => {

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -25,6 +25,7 @@
     OVERSCAN,
     STORAGE_KEY_GROUP,
     getInitialGroupMode,
+    adjacentVisibleSessionId,
     buildGroupSections,
     buildDisplayItems,
     computeTotalSize,
@@ -50,11 +51,20 @@
   let expandedGroups: Set<string> = $state(new Set());
   let detachSidebar: (() => void) | null = null;
 
+  function navigateVisibleSession(delta: number) {
+    const id = adjacentVisibleSessionId(
+      renderDisplayItems,
+      sessions.activeSessionId,
+      delta,
+    );
+    if (id) sessions.selectSession(id);
+  }
+
   onMount(() => {
     detachSidebar = sessions.attachSidebar();
     const element = containerRef;
     if (!element) return;
-    return registerSessionList(element);
+    return registerSessionList(element, navigateVisibleSession);
   });
 
   $effect(() => {

--- a/frontend/src/lib/components/sidebar/session-list-utils.test.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.test.ts
@@ -5,6 +5,7 @@ import {
   ITEM_HEIGHT,
   HEADER_HEIGHT,
   STORAGE_KEY,
+  adjacentVisibleSessionId,
   buildGroupSections,
   buildDisplayItems,
   computeTotalSize,
@@ -341,6 +342,99 @@ describe("buildDisplayItems (grouped)", () => {
       expect(parts[0]).toBe("session");
       expect(parts[1]).toBe(s.label);
     }
+  });
+});
+
+describe("adjacentVisibleSessionId", () => {
+  it("follows grouped display order instead of source order", () => {
+    const groups = [
+      makeGroup("gpt", 1, "g1"),
+      makeGroup("claude", 1, "c1"),
+      makeGroup("claude", 1, "c2"),
+    ];
+    const sections = buildGroupSections(groups, "agent");
+    const items = buildDisplayItems(
+      groups,
+      sections,
+      "agent",
+      new Set(),
+      new Set(),
+    );
+
+    expect(
+      adjacentVisibleSessionId(
+        items,
+        groups[2]!.primarySessionId,
+        1,
+      ),
+    ).toBe(groups[0]!.primarySessionId);
+  });
+
+  it("maps a hidden child to its collapsed lineage row", () => {
+    const root = makeSession({ id: "root" });
+    const child = makeSession({
+      id: "child",
+      parent_session_id: "root",
+    });
+    const lineage: SessionGroup = {
+      key: root.id,
+      project: root.project,
+      sessions: [root, child],
+      primarySessionId: root.id,
+      totalMessages: root.message_count + child.message_count,
+      firstMessage: root.first_message,
+      startedAt: root.started_at,
+      endedAt: child.ended_at,
+    };
+    const next = makeGroup("gpt", 1, "next");
+    const items = buildDisplayItems(
+      [lineage, next],
+      [],
+      "none",
+      new Set(),
+      new Set(),
+    );
+
+    expect(adjacentVisibleSessionId(items, child.id, 1)).toBe(
+      next.primarySessionId,
+    );
+  });
+
+  it("moves from a collapsed section to the next visible session", () => {
+    const claude = makeGroup("claude", 1, "collapsed");
+    const gpt = makeGroup("gpt", 1, "visible");
+    const groups = [claude, gpt];
+    const sections = buildGroupSections(groups, "agent");
+    const items = buildDisplayItems(
+      groups,
+      sections,
+      "agent",
+      new Set(["claude"]),
+      new Set(),
+    );
+
+    expect(
+      adjacentVisibleSessionId(items, claude.primarySessionId, 1),
+    ).toBe(gpt.primarySessionId);
+  });
+
+  it("uses the visible edge when the active session is filtered out", () => {
+    const first = makeGroup("claude", 1, "first");
+    const last = makeGroup("gpt", 1, "last");
+    const items = buildDisplayItems(
+      [first, last],
+      [],
+      "none",
+      new Set(),
+      new Set(),
+    );
+
+    expect(adjacentVisibleSessionId(items, "filtered", 1)).toBe(
+      first.primarySessionId,
+    );
+    expect(adjacentVisibleSessionId(items, "filtered", -1)).toBe(
+      last.primarySessionId,
+    );
   });
 });
 

--- a/frontend/src/lib/components/sidebar/session-list-utils.test.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.test.ts
@@ -400,6 +400,57 @@ describe("adjacentVisibleSessionId", () => {
     );
   });
 
+  it.each([
+    {
+      name: "subagent",
+      child: {
+        relationship_type: "subagent" as const,
+      },
+    },
+    {
+      name: "teammate",
+      child: {
+        first_message: "<teammate-message>hi</teammate-message>",
+      },
+    },
+  ])("skips a collapsed $name group in both directions", ({ child }) => {
+    const root = makeSession({ id: "root" });
+    const continuation = makeSession({
+      id: "continuation",
+      parent_session_id: root.id,
+    });
+    const hidden = makeSession({
+      id: "hidden",
+      parent_session_id: root.id,
+      ...child,
+    });
+    const lineage: SessionGroup = {
+      key: root.id,
+      project: root.project,
+      sessions: [root, continuation, hidden],
+      primarySessionId: root.id,
+      totalMessages: 30,
+      firstMessage: root.first_message,
+      startedAt: root.started_at,
+      endedAt: hidden.ended_at,
+    };
+    const next = makeGroup("gpt", 1, "next");
+    const items = buildDisplayItems(
+      [lineage, next],
+      [],
+      "none",
+      new Set(),
+      new Set([lineage.key]),
+    );
+
+    expect(adjacentVisibleSessionId(items, hidden.id, -1)).toBe(
+      continuation.id,
+    );
+    expect(adjacentVisibleSessionId(items, hidden.id, 1)).toBe(
+      next.primarySessionId,
+    );
+  });
+
   it("moves from a collapsed section to the next visible session", () => {
     const claude = makeGroup("claude", 1, "collapsed");
     const gpt = makeGroup("gpt", 1, "visible");

--- a/frontend/src/lib/components/sidebar/session-list-utils.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.ts
@@ -29,6 +29,8 @@ export interface DisplayItem {
   group?: SessionGroup;
   /** Session groups represented by a collapsible section header. */
   sectionGroups?: SessionGroup[];
+  /** Sessions represented by a collapsible child-group header. */
+  memberSessionIds?: string[];
   /** For child items within an expanded continuation chain. */
   session?: SessionGroupInput;
   /** True when this is a child session inside an expanded group. */
@@ -291,6 +293,7 @@ function emitGroupItems(
       label: "Subagents",
       count: subagents.length,
       group: g,
+      memberSessionIds: subagents.map((session) => session.id),
       depth: 1,
       isLastChild: depth1Idx === depth1Count - 1,
       height: TEAM_HEADER_HEIGHT,
@@ -331,6 +334,7 @@ function emitGroupItems(
       label: "Team",
       count: teammates.length,
       group: g,
+      memberSessionIds: teammates.map((session) => session.id),
       depth: 1,
       isLastChild: depth1Idx === depth1Count - 1,
       height: TEAM_HEADER_HEIGHT,
@@ -427,6 +431,11 @@ export function adjacentVisibleSessionId(
   let current = displayItems.findIndex(
     (item) => displaySessionId(item) === activeSessionId,
   );
+  if (current < 0) {
+    current = displayItems.findIndex(
+      (item) => item.memberSessionIds?.includes(activeSessionId),
+    );
+  }
   if (current < 0) {
     current = displayItems.findIndex(
       (item) =>

--- a/frontend/src/lib/components/sidebar/session-list-utils.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.ts
@@ -27,6 +27,8 @@ export interface DisplayItem {
   label: string;
   count: number;
   group?: SessionGroup;
+  /** Session groups represented by a collapsible section header. */
+  sectionGroups?: SessionGroup[];
   /** For child items within an expanded continuation chain. */
   session?: SessionGroupInput;
   /** True when this is a child session inside an expanded group. */
@@ -389,6 +391,7 @@ export function buildDisplayItems(
       type: "header",
       label: section.label,
       count: section.groups.length,
+      sectionGroups: section.groups,
       height: HEADER_HEIGHT,
       top: y.value,
     });
@@ -401,6 +404,67 @@ export function buildDisplayItems(
     }
   }
   return items;
+}
+
+function displaySessionId(item: DisplayItem): string | null {
+  if (item.type !== "session") return null;
+  if (item.isChild) return item.session?.id ?? null;
+  return item.group?.primarySessionId ?? null;
+}
+
+/**
+ * Find the next rendered session row. When a collapsed lineage or section
+ * hides the active session, treat its visible representative as the current
+ * position.
+ */
+export function adjacentVisibleSessionId(
+  displayItems: DisplayItem[],
+  activeSessionId: string | null,
+  delta: number,
+): string | null {
+  if (!activeSessionId) return null;
+
+  let current = displayItems.findIndex(
+    (item) => displaySessionId(item) === activeSessionId,
+  );
+  if (current < 0) {
+    current = displayItems.findIndex(
+      (item) =>
+        item.type === "session" &&
+        item.group?.sessions.some(
+          (session) => session.id === activeSessionId,
+        ),
+    );
+  }
+  if (current < 0) {
+    current = displayItems.findIndex(
+      (item) =>
+        item.type === "header" &&
+        item.sectionGroups?.some((group) =>
+          group.sessions.some(
+            (session) => session.id === activeSessionId,
+          ),
+        ),
+    );
+  }
+
+  if (current < 0) {
+    const rows = displayItems.filter(
+      (item) => item.type === "session",
+    );
+    const edge = delta > 0 ? rows[0] : rows[rows.length - 1];
+    return edge ? displaySessionId(edge) : null;
+  }
+
+  for (
+    let next = current + delta;
+    next >= 0 && next < displayItems.length;
+    next += delta
+  ) {
+    const id = displaySessionId(displayItems[next]!);
+    if (id) return id;
+  }
+  return null;
 }
 
 /**

--- a/frontend/src/lib/utils/arrow-target.test.ts
+++ b/frontend/src/lib/utils/arrow-target.test.ts
@@ -83,4 +83,30 @@ describe("resolveArrowTarget", () => {
     expect(resolveArrowTarget(document.body, null, "sessionList")).toBe("message");
     list.remove();
   });
+
+  it("rejects a registered list only while its sidebar is hidden", () => {
+    const sidebar = document.createElement("aside");
+    const list = document.createElement("div");
+    sidebar.appendChild(list);
+    document.body.appendChild(sidebar);
+    const navigate = vi.fn();
+    const detach = registerSessionList(list, navigate);
+
+    sidebar.style.display = "none";
+    expect(resolveArrowTarget(document.body, list, "sessionList")).toBe(
+      "message",
+    );
+    expect(navigateRegisteredSessionList(1)).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+
+    sidebar.style.display = "flex";
+    expect(resolveArrowTarget(document.body, list, "sessionList")).toBe(
+      "sessionList",
+    );
+    expect(navigateRegisteredSessionList(1)).toBe(true);
+    expect(navigate).toHaveBeenCalledWith(1);
+
+    detach();
+    sidebar.remove();
+  });
 });

--- a/frontend/src/lib/utils/arrow-target.test.ts
+++ b/frontend/src/lib/utils/arrow-target.test.ts
@@ -31,6 +31,30 @@ describe("resolveArrowTarget", () => {
     list.remove();
   });
 
+  it("lets document hover override stale row focus", () => {
+    const list = makeList();
+    const row = document.createElement("button");
+    list.appendChild(row);
+    const documentHover = vi
+      .spyOn(document.documentElement, "matches")
+      .mockImplementation((selector) => selector === ":hover");
+    vi.spyOn(list, "matches").mockReturnValue(false);
+
+    expect(resolveArrowTarget(row, list, true)).toBe("message");
+
+    documentHover.mockRestore();
+    list.remove();
+  });
+
+  it("keeps focused list keyboard routing without pointer hover", () => {
+    const list = makeList();
+    const row = document.createElement("button");
+    list.appendChild(row);
+
+    expect(resolveArrowTarget(row, list, true)).toBe("sessionList");
+    list.remove();
+  });
+
   it("vetoes native editing and modal focus", () => {
     const list = makeList();
     const input = document.createElement("input");
@@ -50,6 +74,36 @@ describe("resolveArrowTarget", () => {
     const list = makeList();
     list.remove();
     expect(resolveArrowTarget(document.body, list, true)).toBe("message");
+  });
+
+  it("keeps native and dialog vetoes when the ref is disconnected", () => {
+    const list = makeList();
+    const input = document.createElement("input");
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    const button = document.createElement("button");
+    dialog.appendChild(button);
+    list.remove();
+
+    expect(resolveArrowTarget(input, list, true)).toBe("none");
+    expect(resolveArrowTarget(button, list, true)).toBe("none");
+  });
+
+  it("treats missing matchMedia as a coarse-pointer fallback", () => {
+    const list = makeList();
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(resolveArrowTarget(document.body, list)).toBe("message");
+
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+    list.remove();
   });
 
   it("uses registration as the sole source of the session-list element", () => {

--- a/frontend/src/lib/utils/arrow-target.test.ts
+++ b/frontend/src/lib/utils/arrow-target.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   getSessionListElement,
+  navigateRegisteredSessionList,
   registerSessionList,
   resolveArrowTarget,
 } from "./arrow-target.js";
@@ -13,45 +14,24 @@ function makeList() {
 }
 
 describe("resolveArrowTarget", () => {
-  it("uses focused containment before hover", () => {
+  it("uses focused containment before any recorded interaction", () => {
     const list = makeList();
     const row = document.createElement("button");
     list.appendChild(row);
 
-    expect(resolveArrowTarget(row, list, false)).toBe("sessionList");
+    expect(resolveArrowTarget(row, list)).toBe("sessionList");
     list.remove();
   });
 
-  it("uses live hover only for fine pointers", () => {
-    const list = makeList();
-    vi.spyOn(list, "matches").mockImplementation((selector) => selector === ":hover");
-
-    expect(resolveArrowTarget(document.body, list, true)).toBe("sessionList");
-    expect(resolveArrowTarget(document.body, list, false)).toBe("message");
-    list.remove();
-  });
-
-  it("lets document hover override stale row focus", () => {
-    const list = makeList();
-    const row = document.createElement("button");
-    list.appendChild(row);
-    const documentHover = vi
-      .spyOn(document.documentElement, "matches")
-      .mockImplementation((selector) => selector === ":hover");
-    vi.spyOn(list, "matches").mockReturnValue(false);
-
-    expect(resolveArrowTarget(row, list, true)).toBe("message");
-
-    documentHover.mockRestore();
-    list.remove();
-  });
-
-  it("keeps focused list keyboard routing without pointer hover", () => {
+  it("uses the last deliberate interaction instead of passive pointer position", () => {
     const list = makeList();
     const row = document.createElement("button");
     list.appendChild(row);
 
-    expect(resolveArrowTarget(row, list, true)).toBe("sessionList");
+    expect(resolveArrowTarget(row, list, "message")).toBe("message");
+    expect(resolveArrowTarget(document.body, list, "sessionList")).toBe(
+      "sessionList",
+    );
     list.remove();
   });
 
@@ -59,21 +39,21 @@ describe("resolveArrowTarget", () => {
     const list = makeList();
     const input = document.createElement("input");
     list.appendChild(input);
-    expect(resolveArrowTarget(input, list, true)).toBe("none");
+    expect(resolveArrowTarget(input, list, "sessionList")).toBe("none");
 
     const dialog = document.createElement("div");
     dialog.setAttribute("role", "dialog");
     const button = document.createElement("button");
     dialog.appendChild(button);
     list.appendChild(dialog);
-    expect(resolveArrowTarget(button, list, true)).toBe("none");
+    expect(resolveArrowTarget(button, list, "sessionList")).toBe("none");
     list.remove();
   });
 
   it("falls back after the live ref disconnects", () => {
     const list = makeList();
     list.remove();
-    expect(resolveArrowTarget(document.body, list, true)).toBe("message");
+    expect(resolveArrowTarget(document.body, list, "sessionList")).toBe("message");
   });
 
   it("keeps native and dialog vetoes when the ref is disconnected", () => {
@@ -85,35 +65,22 @@ describe("resolveArrowTarget", () => {
     dialog.appendChild(button);
     list.remove();
 
-    expect(resolveArrowTarget(input, list, true)).toBe("none");
-    expect(resolveArrowTarget(button, list, true)).toBe("none");
-  });
-
-  it("treats missing matchMedia as a coarse-pointer fallback", () => {
-    const list = makeList();
-    const originalMatchMedia = window.matchMedia;
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      value: undefined,
-    });
-
-    expect(resolveArrowTarget(document.body, list)).toBe("message");
-
-    Object.defineProperty(window, "matchMedia", {
-      configurable: true,
-      value: originalMatchMedia,
-    });
-    list.remove();
+    expect(resolveArrowTarget(input, list, "sessionList")).toBe("none");
+    expect(resolveArrowTarget(button, list, "sessionList")).toBe("none");
   });
 
   it("uses registration as the sole source of the session-list element", () => {
     const list = makeList();
-    const detach = registerSessionList(list);
+    const navigate = vi.fn();
+    const detach = registerSessionList(list, navigate);
 
     expect(getSessionListElement()).toBe(list);
+    expect(navigateRegisteredSessionList(1)).toBe(true);
+    expect(navigate).toHaveBeenCalledWith(1);
     detach();
     expect(getSessionListElement()).toBeNull();
-    expect(resolveArrowTarget(document.body, null, true)).toBe("message");
+    expect(navigateRegisteredSessionList(1)).toBe(false);
+    expect(resolveArrowTarget(document.body, null, "sessionList")).toBe("message");
     list.remove();
   });
 });

--- a/frontend/src/lib/utils/arrow-target.test.ts
+++ b/frontend/src/lib/utils/arrow-target.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { resolveArrowTarget } from "./arrow-target.js";
+import {
+  getSessionListElement,
+  registerSessionList,
+  resolveArrowTarget,
+} from "./arrow-target.js";
 
 function makeList() {
   const list = document.createElement("div");
@@ -46,5 +50,16 @@ describe("resolveArrowTarget", () => {
     const list = makeList();
     list.remove();
     expect(resolveArrowTarget(document.body, list, true)).toBe("message");
+  });
+
+  it("uses registration as the sole source of the session-list element", () => {
+    const list = makeList();
+    const detach = registerSessionList(list);
+
+    expect(getSessionListElement()).toBe(list);
+    detach();
+    expect(getSessionListElement()).toBeNull();
+    expect(resolveArrowTarget(document.body, null, true)).toBe("message");
+    list.remove();
   });
 });

--- a/frontend/src/lib/utils/arrow-target.test.ts
+++ b/frontend/src/lib/utils/arrow-target.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { resolveArrowTarget } from "./arrow-target.js";
+
+function makeList() {
+  const list = document.createElement("div");
+  list.className = "session-list-scroll";
+  document.body.appendChild(list);
+  return list;
+}
+
+describe("resolveArrowTarget", () => {
+  it("uses focused containment before hover", () => {
+    const list = makeList();
+    const row = document.createElement("button");
+    list.appendChild(row);
+
+    expect(resolveArrowTarget(row, list, false)).toBe("sessionList");
+    list.remove();
+  });
+
+  it("uses live hover only for fine pointers", () => {
+    const list = makeList();
+    vi.spyOn(list, "matches").mockImplementation((selector) => selector === ":hover");
+
+    expect(resolveArrowTarget(document.body, list, true)).toBe("sessionList");
+    expect(resolveArrowTarget(document.body, list, false)).toBe("message");
+    list.remove();
+  });
+
+  it("vetoes native editing and modal focus", () => {
+    const list = makeList();
+    const input = document.createElement("input");
+    list.appendChild(input);
+    expect(resolveArrowTarget(input, list, true)).toBe("none");
+
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    const button = document.createElement("button");
+    dialog.appendChild(button);
+    list.appendChild(dialog);
+    expect(resolveArrowTarget(button, list, true)).toBe("none");
+    list.remove();
+  });
+
+  it("falls back after the live ref disconnects", () => {
+    const list = makeList();
+    list.remove();
+    expect(resolveArrowTarget(document.body, list, true)).toBe("message");
+  });
+});

--- a/frontend/src/lib/utils/arrow-target.ts
+++ b/frontend/src/lib/utils/arrow-target.ts
@@ -1,5 +1,3 @@
-const SESSION_LIST_QUERY = ".session-list-scroll";
-
 export type ArrowTarget = "sessionList" | "message" | "none";
 
 let sessionListElement: HTMLElement | null = null;
@@ -34,8 +32,5 @@ export function resolveArrowTarget(
 }
 
 export function getSessionListElement(): HTMLElement | null {
-  return sessionListElement ??
-    (typeof document === "undefined"
-      ? null
-      : document.querySelector<HTMLElement>(SESSION_LIST_QUERY));
+  return sessionListElement;
 }

--- a/frontend/src/lib/utils/arrow-target.ts
+++ b/frontend/src/lib/utils/arrow-target.ts
@@ -1,21 +1,33 @@
 export type ArrowTarget = "sessionList" | "message" | "none";
+export type ArrowInteractionTarget = Exclude<ArrowTarget, "none">;
 
 let sessionListElement: HTMLElement | null = null;
+let sessionListNavigate: ((delta: number) => void) | null = null;
 
-export function registerSessionList(element: HTMLElement): () => void {
+export function registerSessionList(
+  element: HTMLElement,
+  navigate: (delta: number) => void,
+): () => void {
   sessionListElement = element;
+  sessionListNavigate = navigate;
   return () => {
-    if (sessionListElement === element) sessionListElement = null;
+    if (sessionListElement === element) {
+      sessionListElement = null;
+      sessionListNavigate = null;
+    }
   };
+}
+
+export function navigateRegisteredSessionList(delta: number): boolean {
+  if (!sessionListElement?.isConnected || !sessionListNavigate) return false;
+  sessionListNavigate(delta);
+  return true;
 }
 
 export function resolveArrowTarget(
   activeElement: Element | null = typeof document === "undefined" ? null : document.activeElement,
   sessionList: HTMLElement | null = sessionListElement,
-  finePointer =
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(hover: hover) and (pointer: fine)").matches,
+  lastInteraction: ArrowInteractionTarget | null = null,
 ): ArrowTarget {
   const active = activeElement as HTMLElement | null;
   if (
@@ -26,19 +38,8 @@ export function resolveArrowTarget(
   }
 
   if (!sessionList?.isConnected) return "message";
-
-  // A fine-pointer hover inside the document is fresher than focus left on a
-  // row, so moving into the message pane restores message navigation.
-  const pointerIsInsideDocument =
-    finePointer &&
-    typeof document !== "undefined" &&
-    document.documentElement.matches(":hover");
-  if (pointerIsInsideDocument) {
-    return sessionList.matches(":hover") ? "sessionList" : "message";
-  }
-
+  if (lastInteraction) return lastInteraction;
   if (sessionList.contains(active)) return "sessionList";
-  if (finePointer && sessionList.matches(":hover")) return "sessionList";
   return "message";
 }
 

--- a/frontend/src/lib/utils/arrow-target.ts
+++ b/frontend/src/lib/utils/arrow-target.ts
@@ -4,6 +4,28 @@ export type ArrowInteractionTarget = Exclude<ArrowTarget, "none">;
 let sessionListElement: HTMLElement | null = null;
 let sessionListNavigate: ((delta: number) => void) | null = null;
 
+function isRendered(element: HTMLElement | null): element is HTMLElement {
+  if (!element?.isConnected) return false;
+
+  const view = element.ownerDocument.defaultView;
+  for (
+    let current: HTMLElement | null = element;
+    current;
+    current = current.parentElement
+  ) {
+    const style = view?.getComputedStyle(current);
+    if (
+      current.hidden ||
+      style?.display === "none" ||
+      style?.visibility === "hidden" ||
+      style?.visibility === "collapse"
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function registerSessionList(
   element: HTMLElement,
   navigate: (delta: number) => void,
@@ -19,7 +41,7 @@ export function registerSessionList(
 }
 
 export function navigateRegisteredSessionList(delta: number): boolean {
-  if (!sessionListElement?.isConnected || !sessionListNavigate) return false;
+  if (!isRendered(sessionListElement) || !sessionListNavigate) return false;
   sessionListNavigate(delta);
   return true;
 }
@@ -37,7 +59,7 @@ export function resolveArrowTarget(
     return "none";
   }
 
-  if (!sessionList?.isConnected) return "message";
+  if (!isRendered(sessionList)) return "message";
   if (lastInteraction) return lastInteraction;
   if (sessionList.contains(active)) return "sessionList";
   return "message";

--- a/frontend/src/lib/utils/arrow-target.ts
+++ b/frontend/src/lib/utils/arrow-target.ts
@@ -1,0 +1,41 @@
+const SESSION_LIST_QUERY = ".session-list-scroll";
+
+export type ArrowTarget = "sessionList" | "message" | "none";
+
+let sessionListElement: HTMLElement | null = null;
+
+export function registerSessionList(element: HTMLElement): () => void {
+  sessionListElement = element;
+  return () => {
+    if (sessionListElement === element) sessionListElement = null;
+  };
+}
+
+export function resolveArrowTarget(
+  activeElement: Element | null = typeof document === "undefined" ? null : document.activeElement,
+  sessionList: HTMLElement | null = sessionListElement,
+  finePointer =
+    typeof window !== "undefined" &&
+    window.matchMedia("(hover: hover) and (pointer: fine)").matches,
+): ArrowTarget {
+  if (!sessionList?.isConnected) return "message";
+
+  const active = activeElement as HTMLElement | null;
+  if (
+    active?.matches("input, textarea, select, [contenteditable='true']") ||
+    active?.closest("[role='dialog']")
+  ) {
+    return "none";
+  }
+
+  if (sessionList.contains(active)) return "sessionList";
+  if (finePointer && sessionList.matches(":hover")) return "sessionList";
+  return "message";
+}
+
+export function getSessionListElement(): HTMLElement | null {
+  return sessionListElement ??
+    (typeof document === "undefined"
+      ? null
+      : document.querySelector<HTMLElement>(SESSION_LIST_QUERY));
+}

--- a/frontend/src/lib/utils/arrow-target.ts
+++ b/frontend/src/lib/utils/arrow-target.ts
@@ -14,16 +14,27 @@ export function resolveArrowTarget(
   sessionList: HTMLElement | null = sessionListElement,
   finePointer =
     typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
     window.matchMedia("(hover: hover) and (pointer: fine)").matches,
 ): ArrowTarget {
-  if (!sessionList?.isConnected) return "message";
-
   const active = activeElement as HTMLElement | null;
   if (
     active?.matches("input, textarea, select, [contenteditable='true']") ||
     active?.closest("[role='dialog']")
   ) {
     return "none";
+  }
+
+  if (!sessionList?.isConnected) return "message";
+
+  // A fine-pointer hover inside the document is fresher than focus left on a
+  // row, so moving into the message pane restores message navigation.
+  const pointerIsInsideDocument =
+    finePointer &&
+    typeof document !== "undefined" &&
+    document.documentElement.matches(":hover");
+  if (pointerIsInsideDocument) {
+    return sessionList.matches(":hover") ? "sessionList" : "message";
   }
 
   if (sessionList.contains(active)) return "sessionList";

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -149,11 +149,19 @@ describe("registerShortcuts", () => {
   });
 
   describe("arrow target", () => {
-    function mountSessionList() {
+    function mountSessionList(
+      navigate = (delta: number) =>
+        sessions.navigateSession(
+          delta,
+          starred.filterOnly
+            ? (session) => starred.isStarred(session.id)
+            : undefined,
+        ),
+    ) {
       const list = document.createElement("div");
       list.className = "session-list-scroll";
       document.body.appendChild(list);
-      detachSessionList = registerSessionList(list);
+      detachSessionList = registerSessionList(list, navigate);
       return list;
     }
 
@@ -172,6 +180,31 @@ describe("registerShortcuts", () => {
       fireKey("ArrowUp");
       expect(sessions.activeSessionId).toBe("s1");
       expect(navigateMessage).not.toHaveBeenCalled();
+    });
+
+    it("switches panes after deliberate pointer interaction, not hover", () => {
+      const navigateSessions = vi.fn();
+      const list = mountSessionList(navigateSessions);
+      const row = document.createElement("button");
+      list.appendChild(row);
+      row.focus();
+
+      fireKey("ArrowDown");
+      expect(navigateSessions).toHaveBeenCalledWith(1);
+
+      const message = document.createElement("div");
+      document.body.appendChild(message);
+      message.dispatchEvent(new Event("pointermove", { bubbles: true }));
+      fireKey("ArrowDown");
+      expect(navigateSessions).toHaveBeenCalledTimes(2);
+      expect(navigateMessage).not.toHaveBeenCalled();
+
+      message.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      expect(document.activeElement).toBe(row);
+
+      fireKey("ArrowDown");
+      expect(navigateSessions).toHaveBeenCalledTimes(2);
+      expect(navigateMessage).toHaveBeenCalledWith(1);
     });
 
     it("keeps arrow navigation within the starred-only list", () => {

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -193,6 +193,7 @@ describe("registerShortcuts", () => {
       expect(navigateSessions).toHaveBeenCalledWith(1);
 
       const message = document.createElement("div");
+      message.className = "message-list-scroll";
       document.body.appendChild(message);
       message.dispatchEvent(new Event("pointermove", { bubbles: true }));
       fireKey("ArrowDown");
@@ -205,6 +206,36 @@ describe("registerShortcuts", () => {
       fireKey("ArrowDown");
       expect(navigateSessions).toHaveBeenCalledTimes(2);
       expect(navigateMessage).toHaveBeenCalledWith(1);
+
+      const unrelated = document.createElement("button");
+      document.body.appendChild(unrelated);
+      row.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      unrelated.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      fireKey("ArrowDown");
+      expect(navigateSessions).toHaveBeenCalledTimes(3);
+      expect(navigateMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses session navigation after a sidebar control interaction", () => {
+      const navigateSessions = vi.fn();
+      const sidebar = document.createElement("aside");
+      sidebar.id = "session-sidebar";
+      const filter = document.createElement("button");
+      sidebar.appendChild(filter);
+      document.body.appendChild(sidebar);
+      const list = mountSessionList(navigateSessions);
+      sidebar.appendChild(list);
+
+      const messagePane = document.createElement("div");
+      messagePane.className = "message-list-scroll";
+      document.body.appendChild(messagePane);
+      messagePane.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      filter.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+
+      fireKey("ArrowDown");
+
+      expect(navigateSessions).toHaveBeenCalledWith(1);
+      expect(navigateMessage).not.toHaveBeenCalled();
     });
 
     it("keeps arrow navigation within the starred-only list", () => {

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -289,6 +289,21 @@ describe("registerShortcuts", () => {
       expect(navigateMessage).toHaveBeenCalledWith(1);
     });
 
+    it("routes arrows to messages after mobile auto-close hides the sidebar", () => {
+      const navigateSessions = vi.fn();
+      const sidebar = document.createElement("aside");
+      document.body.appendChild(sidebar);
+      const list = mountSessionList(navigateSessions);
+      sidebar.appendChild(list);
+      list.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+
+      sidebar.style.display = "none";
+      fireKey("ArrowDown");
+
+      expect(navigateSessions).not.toHaveBeenCalled();
+      expect(navigateMessage).toHaveBeenCalledWith(1);
+    });
+
     it("clears the list route when registration is unregistered", () => {
       const list = mountSessionList();
       detachSessionList?.();

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -195,6 +195,31 @@ describe("registerShortcuts", () => {
       expect(navigateMessage).not.toHaveBeenCalled();
     });
 
+    it.each([
+      ["direct/root", {}],
+      ["subagent", { relationship_type: "subagent" }],
+      ["forked child", { parent_session_id: "root", relationship_type: "fork" }],
+      ["continuation", { parent_session_id: "root", relationship_type: "continuation" }],
+      ["imported", { agent: "imported-agent" }],
+      ["soft-deleted", { deleted_at: "2026-08-01T00:00:00Z" }],
+      ["tombstoned", { tombstoned: true }],
+    ])("preserves arrow routing for the %s Session lineage variant", (_name, variant) => {
+      const list = mountSessionList();
+      sessions.sessions = [
+        { id: "root" } as any,
+        { id: "variant", ...variant } as any,
+      ];
+      sessions.activeSessionId = "root";
+      const row = document.createElement("button");
+      list.appendChild(row);
+      row.focus();
+
+      fireKey("ArrowDown");
+
+      expect(sessions.activeSessionId).toBe("variant");
+      expect(navigateMessage).not.toHaveBeenCalled();
+    });
+
     it("keeps message fallback and native vetoes", () => {
       const list = mountSessionList();
       list.appendChild(document.createElement("button"));

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -157,7 +157,7 @@ describe("registerShortcuts", () => {
       return list;
     }
 
-    it("navigates sessions from focused or hovered list context", () => {
+    it("navigates sessions up and down in the registered list", () => {
       const list = mountSessionList();
       sessions.sessions = [
         { id: "s1" } as any,
@@ -169,6 +169,29 @@ describe("registerShortcuts", () => {
       row.focus();
       fireKey("ArrowDown");
       expect(sessions.activeSessionId).toBe("s2");
+      fireKey("ArrowUp");
+      expect(sessions.activeSessionId).toBe("s1");
+      expect(navigateMessage).not.toHaveBeenCalled();
+    });
+
+    it("keeps arrow navigation within the starred-only list", () => {
+      const list = mountSessionList();
+      sessions.sessions = [
+        { id: "s1" } as any,
+        { id: "s2" } as any,
+        { id: "s3" } as any,
+      ];
+      sessions.activeSessionId = "s1";
+      starred.filterOnly = true;
+      starred.ids = new Set(["s1", "s3"]);
+      const row = document.createElement("button");
+      list.appendChild(row);
+      row.focus();
+
+      fireKey("ArrowDown");
+      expect(sessions.activeSessionId).toBe("s3");
+      fireKey("ArrowUp");
+      expect(sessions.activeSessionId).toBe("s1");
       expect(navigateMessage).not.toHaveBeenCalled();
     });
 
@@ -186,11 +209,36 @@ describe("registerShortcuts", () => {
       expect(sessions.activeSessionId).toBeNull();
     });
 
+    it("does not route arrows from a dialog through the message fallback", () => {
+      const list = mountSessionList();
+      const dialog = document.createElement("div");
+      dialog.setAttribute("role", "dialog");
+      const button = document.createElement("button");
+      dialog.appendChild(button);
+      list.appendChild(dialog);
+      button.focus();
+
+      fireKey("ArrowDown");
+
+      expect(navigateMessage).not.toHaveBeenCalled();
+      expect(sessions.activeSessionId).toBeNull();
+    });
+
     it("clears the list route when the component disconnects", () => {
       const list = mountSessionList();
       list.remove();
       fireKey("ArrowDown");
       expect(navigateMessage).toHaveBeenCalledWith(1);
+    });
+
+    it("clears the list route when registration is unregistered", () => {
+      const list = mountSessionList();
+      detachSessionList?.();
+      detachSessionList = undefined;
+      list.appendChild(document.createElement("button"));
+      fireKey("ArrowDown");
+      expect(navigateMessage).toHaveBeenCalledWith(1);
+      expect(sessions.activeSessionId).toBeNull();
     });
   });
 

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -10,6 +10,7 @@ import { copyToClipboard } from "../utils/clipboard.js";
 import AppHeader from "../components/layout/AppHeader.svelte";
 import SidebarToggleButton from "../components/layout/SidebarToggleButton.svelte";
 import { registerShortcuts } from "./keyboard.js";
+import { registerSessionList } from "./arrow-target.js";
 
 vi.mock("../utils/clipboard.js", () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
@@ -28,6 +29,7 @@ describe("registerShortcuts", () => {
   let cleanup: () => void;
   let navigateMessage: (delta: number) => void;
   let navigateUserPrompt: (delta: number) => void;
+  let detachSessionList: (() => void) | undefined;
 
   beforeEach(() => {
     ui.activeModal = null;
@@ -41,10 +43,13 @@ describe("registerShortcuts", () => {
     navigateMessage = vi.fn();
     navigateUserPrompt = vi.fn();
     cleanup = registerShortcuts({ navigateMessage, navigateUserPrompt });
+    detachSessionList = undefined;
   });
 
   afterEach(() => {
     cleanup();
+    detachSessionList?.();
+    document.body.innerHTML = "";
   });
 
   describe("Cmd+K modal toggle", () => {
@@ -140,6 +145,52 @@ describe("registerShortcuts", () => {
       ui.activeModal = "commandPalette";
       fireKey("J", { shiftKey: true });
       expect(navigateUserPrompt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("arrow target", () => {
+    function mountSessionList() {
+      const list = document.createElement("div");
+      list.className = "session-list-scroll";
+      document.body.appendChild(list);
+      detachSessionList = registerSessionList(list);
+      return list;
+    }
+
+    it("navigates sessions from focused or hovered list context", () => {
+      const list = mountSessionList();
+      sessions.sessions = [
+        { id: "s1" } as any,
+        { id: "s2" } as any,
+      ];
+      sessions.activeSessionId = "s1";
+      const row = document.createElement("button");
+      list.appendChild(row);
+      row.focus();
+      fireKey("ArrowDown");
+      expect(sessions.activeSessionId).toBe("s2");
+      expect(navigateMessage).not.toHaveBeenCalled();
+    });
+
+    it("keeps message fallback and native vetoes", () => {
+      const list = mountSessionList();
+      list.appendChild(document.createElement("button"));
+      fireKey("ArrowDown");
+      expect(navigateMessage).toHaveBeenCalledWith(1);
+
+      const input = document.createElement("input");
+      list.appendChild(input);
+      input.focus();
+      fireKey("ArrowDown");
+      expect(navigateMessage).toHaveBeenCalledTimes(1);
+      expect(sessions.activeSessionId).toBeNull();
+    });
+
+    it("clears the list route when the component disconnects", () => {
+      const list = mountSessionList();
+      list.remove();
+      fireKey("ArrowDown");
+      expect(navigateMessage).toHaveBeenCalledWith(1);
     });
   });
 

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -11,7 +11,12 @@ import { configureGeneratedClient } from "../api/runtime.js";
 import { supportsResume, buildResumeCommand, formatResumeResponseCommand } from "./resume.js";
 import { copyToClipboard } from "./clipboard.js";
 import { toggleSidebarWithFocus } from "./sidebar-toggle.js";
-import { getSessionListElement, resolveArrowTarget } from "./arrow-target.js";
+import {
+  getSessionListElement,
+  navigateRegisteredSessionList,
+  resolveArrowTarget,
+  type ArrowInteractionTarget,
+} from "./arrow-target.js";
 
 function starredSessionFilter(): ((s: { id: string }) => boolean) | undefined {
   return starred.filterOnly
@@ -64,6 +69,16 @@ function activeResumeModel(sessionId: string): string {
  * Returns a cleanup function to remove the listener.
  */
 export function registerShortcuts(opts: ShortcutOptions): () => void {
+  let lastArrowInteraction: ArrowInteractionTarget | null = null;
+
+  function rememberArrowInteraction(e: PointerEvent | FocusEvent) {
+    if (!(e.target instanceof Node)) return;
+    const sessionList = getSessionListElement();
+    lastArrowInteraction = sessionList?.contains(e.target)
+      ? "sessionList"
+      : "message";
+  }
+
   function handler(e: KeyboardEvent) {
     const meta = e.metaKey || e.ctrlKey;
 
@@ -155,9 +170,10 @@ export function registerShortcuts(opts: ShortcutOptions): () => void {
         const target = resolveArrowTarget(
           document.activeElement,
           getSessionListElement(),
+          lastArrowInteraction,
         );
         if (target === "sessionList") {
-          sessions.navigateSession(1, starredSessionFilter());
+          navigateRegisteredSessionList(1);
         } else if (target === "message") {
           opts.navigateMessage(1);
         }
@@ -167,9 +183,10 @@ export function registerShortcuts(opts: ShortcutOptions): () => void {
         const target = resolveArrowTarget(
           document.activeElement,
           getSessionListElement(),
+          lastArrowInteraction,
         );
         if (target === "sessionList") {
-          sessions.navigateSession(-1, starredSessionFilter());
+          navigateRegisteredSessionList(-1);
         } else if (target === "message") {
           opts.navigateMessage(-1);
         }
@@ -266,6 +283,12 @@ export function registerShortcuts(opts: ShortcutOptions): () => void {
     }
   }
 
+  document.addEventListener("pointerdown", rememberArrowInteraction, true);
+  document.addEventListener("focusin", rememberArrowInteraction, true);
   document.addEventListener("keydown", handler);
-  return () => document.removeEventListener("keydown", handler);
+  return () => {
+    document.removeEventListener("pointerdown", rememberArrowInteraction, true);
+    document.removeEventListener("focusin", rememberArrowInteraction, true);
+    document.removeEventListener("keydown", handler);
+  };
 }

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -13,6 +13,12 @@ import { copyToClipboard } from "./clipboard.js";
 import { toggleSidebarWithFocus } from "./sidebar-toggle.js";
 import { getSessionListElement, resolveArrowTarget } from "./arrow-target.js";
 
+function starredSessionFilter(): ((s: { id: string }) => boolean) | undefined {
+  return starred.filterOnly
+    ? (s: { id: string }) => starred.isStarred(s.id)
+    : undefined;
+}
+
 function isInputFocused(): boolean {
   const el = document.activeElement;
   if (!el) return false;
@@ -146,31 +152,33 @@ export function registerShortcuts(opts: ShortcutOptions): () => void {
     const keyActions: Record<string, () => void> = {
       j: () => opts.navigateMessage(1),
       ArrowDown: () => {
-        if (resolveArrowTarget(document.activeElement, getSessionListElement()) === "sessionList") {
-          sessions.navigateSession(1);
-        } else {
+        const target = resolveArrowTarget(
+          document.activeElement,
+          getSessionListElement(),
+        );
+        if (target === "sessionList") {
+          sessions.navigateSession(1, starredSessionFilter());
+        } else if (target === "message") {
           opts.navigateMessage(1);
         }
       },
       k: () => opts.navigateMessage(-1),
       ArrowUp: () => {
-        if (resolveArrowTarget(document.activeElement, getSessionListElement()) === "sessionList") {
-          sessions.navigateSession(-1);
-        } else {
+        const target = resolveArrowTarget(
+          document.activeElement,
+          getSessionListElement(),
+        );
+        if (target === "sessionList") {
+          sessions.navigateSession(-1, starredSessionFilter());
+        } else if (target === "message") {
           opts.navigateMessage(-1);
         }
       },
       "]": () => {
-        const filter = starred.filterOnly
-          ? (s: { id: string }) => starred.isStarred(s.id)
-          : undefined;
-        sessions.navigateSession(1, filter);
+        sessions.navigateSession(1, starredSessionFilter());
       },
       "[": () => {
-        const filter = starred.filterOnly
-          ? (s: { id: string }) => starred.isStarred(s.id)
-          : undefined;
-        sessions.navigateSession(-1, filter);
+        sessions.navigateSession(-1, starredSessionFilter());
       },
       o: () => ui.toggleSort(),
       l: () => ui.cycleLayout(),

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -72,11 +72,17 @@ export function registerShortcuts(opts: ShortcutOptions): () => void {
   let lastArrowInteraction: ArrowInteractionTarget | null = null;
 
   function rememberArrowInteraction(e: PointerEvent | FocusEvent) {
-    if (!(e.target instanceof Node)) return;
+    if (!(e.target instanceof Element)) return;
     const sessionList = getSessionListElement();
-    lastArrowInteraction = sessionList?.contains(e.target)
-      ? "sessionList"
-      : "message";
+    const sessionSidebar = sessionList?.closest("#session-sidebar");
+    if (
+      sessionList?.contains(e.target) ||
+      sessionSidebar?.contains(e.target)
+    ) {
+      lastArrowInteraction = "sessionList";
+    } else if (e.target.closest(".message-list-scroll")) {
+      lastArrowInteraction = "message";
+    }
   }
 
   function handler(e: KeyboardEvent) {

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -11,6 +11,7 @@ import { configureGeneratedClient } from "../api/runtime.js";
 import { supportsResume, buildResumeCommand, formatResumeResponseCommand } from "./resume.js";
 import { copyToClipboard } from "./clipboard.js";
 import { toggleSidebarWithFocus } from "./sidebar-toggle.js";
+import { getSessionListElement, resolveArrowTarget } from "./arrow-target.js";
 
 function isInputFocused(): boolean {
   const el = document.activeElement;
@@ -144,9 +145,21 @@ export function registerShortcuts(opts: ShortcutOptions): () => void {
 
     const keyActions: Record<string, () => void> = {
       j: () => opts.navigateMessage(1),
-      ArrowDown: () => opts.navigateMessage(1),
+      ArrowDown: () => {
+        if (resolveArrowTarget(document.activeElement, getSessionListElement()) === "sessionList") {
+          sessions.navigateSession(1);
+        } else {
+          opts.navigateMessage(1);
+        }
+      },
       k: () => opts.navigateMessage(-1),
-      ArrowUp: () => opts.navigateMessage(-1),
+      ArrowUp: () => {
+        if (resolveArrowTarget(document.activeElement, getSessionListElement()) === "sessionList") {
+          sessions.navigateSession(-1);
+        } else {
+          opts.navigateMessage(-1);
+        }
+      },
       "]": () => {
         const filter = starred.filterOnly
           ? (s: { id: string }) => starred.isStarred(s.id)


### PR DESCRIPTION
Plain ArrowUp and ArrowDown now follow the sessions list after keyboard focus
or a deliberate click there. Clicking the message pane routes them back to
message navigation. Passive pointer movement no longer changes the target.

Session arrows follow the sidebar's rendered order, including grouping,
collapsed sections and lineages, expanded children, and starred filtering.
Inputs, dialogs, disconnected lists, and existing bracket shortcuts keep their
previous behavior.

Closes #1481
