### PR TITLE
feat(cli): query retained soft-deleted sessions (#1471)

### DIFF
--- a/cmd/agentsview/session_list.go
+++ b/cmd/agentsview/session_list.go
@@ -27,6 +27,7 @@ func newSessionListCommand() *cobra.Command {
 		minUserMessages                         int
 		includeOneShot                          bool
 		includeAutomated, includeChildren       bool
+		includeDeleted                          bool
 		outcome, healthGrade                    string
 		minToolFailures                         int
 		hasSecret                               bool
@@ -69,6 +70,7 @@ func newSessionListCommand() *cobra.Command {
 				IncludeOneShot:   includeOneShot,
 				IncludeAutomated: includeAutomated,
 				IncludeChildren:  includeChildren,
+				IncludeDeleted:   includeDeleted,
 				Outcome:          outcome,
 				HealthGrade:      healthGrade,
 				HasSecret:        hasSecret,
@@ -166,6 +168,8 @@ func newSessionListCommand() *cobra.Command {
 		"Include automated sessions (excluded by default)")
 	flags.BoolVar(&includeChildren, "include-children", false,
 		"Include subagent/child sessions")
+	flags.BoolVar(&includeDeleted, "include-deleted", false,
+		"Include retained soft-deleted sessions")
 	flags.StringVar(&outcome, "outcome", "",
 		"Filter by outcome (comma-separated: success,failure,...)")
 	flags.StringVar(&healthGrade, "health-grade", "",

--- a/cmd/agentsview/session_list_test.go
+++ b/cmd/agentsview/session_list_test.go
@@ -4,9 +4,12 @@ package main
 
 import (
 	"bytes"
+	"database/sql"
+	"path/filepath"
 	"testing"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
@@ -25,11 +28,27 @@ func TestSessionListSinceMutuallyExclusiveWithActiveSince(t *testing.T) {
 }
 
 func TestSessionListIncludeDeletedFlag(t *testing.T) {
-	cmd := newSessionListCommand()
-	cmd.SetArgs([]string{"--help"})
-	err := cmd.Execute()
+	dataDir := newAgentDataDir(t)
+	seedSessionsWithOpts(t, dataDir,
+		sessionSeed{id: "list-active", project: "proj"},
+		sessionSeed{id: "list-deleted", project: "proj"},
+	)
+	conn, err := sql.Open("sqlite3", filepath.Join(dataDir, "sessions.db"))
 	require.NoError(t, err)
-	assert.Contains(t, cmd.Flag("include-deleted").Usage, "soft-deleted")
+	_, err = conn.Exec("UPDATE sessions SET deleted_at = ? WHERE id = ?",
+		"2026-05-21T00:00:00Z", "list-deleted")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	defaultOut, err := executeCommand(newRootCommand(),
+		"session", "list", "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"list-active"}, sessionListIDs(t, defaultOut))
+	withDeletedOut, err := executeCommand(newRootCommand(),
+		"session", "list", "--include-deleted", "--format", "json")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"list-active", "list-deleted"},
+		sessionListIDs(t, withDeletedOut))
 }
 
 func TestSessionListSinceRejectsInvalidFormat(t *testing.T) {

--- a/cmd/agentsview/session_list_test.go
+++ b/cmd/agentsview/session_list_test.go
@@ -24,6 +24,14 @@ func TestSessionListSinceMutuallyExclusiveWithActiveSince(t *testing.T) {
 		"--since and --active-since are mutually exclusive")
 }
 
+func TestSessionListIncludeDeletedFlag(t *testing.T) {
+	cmd := newSessionListCommand()
+	cmd.SetArgs([]string{"--help"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, cmd.Flag("include-deleted").Usage, "soft-deleted")
+}
+
 func TestSessionListSinceRejectsInvalidFormat(t *testing.T) {
 	_, err := executeCommand(newRootCommand(),
 		"session", "list", "--since", "3x")

--- a/cmd/agentsview/session_search.go
+++ b/cmd/agentsview/session_search.go
@@ -28,6 +28,7 @@ func newSessionSearchCommand() *cobra.Command {
 		activeSince, since                       string
 		includeChildren, includeAutomated        bool
 		includeOneShot                           bool
+		includeDeleted                           bool
 		limit, cursor, contextN                  int
 	)
 	cmd := &cobra.Command{
@@ -77,6 +78,7 @@ func newSessionSearchCommand() *cobra.Command {
 				IncludeChildren:  includeChildren,
 				IncludeAutomated: includeAutomated,
 				IncludeOneShot:   includeOneShot,
+				IncludeDeleted:   includeDeleted,
 				Scope:            scope,
 				Limit:            limit,
 				Cursor:           cursor,
@@ -123,6 +125,8 @@ func newSessionSearchCommand() *cobra.Command {
 	flags.BoolVar(&includeChildren, "include-children", false, "Include subagent sessions")
 	flags.BoolVar(&includeAutomated, "include-automated", false, "Include automated sessions")
 	flags.BoolVar(&includeOneShot, "include-one-shot", false, "Include one-shot sessions")
+	flags.BoolVar(&includeDeleted, "include-deleted", false,
+		"Include retained soft-deleted sessions")
 	flags.IntVar(&limit, "limit", 0, "Max results (default 50, max 500)")
 	flags.IntVar(&cursor, "cursor", 0, "Pagination cursor from a previous response")
 	flags.IntVar(&contextN, "context", 0,

--- a/cmd/agentsview/session_search_test.go
+++ b/cmd/agentsview/session_search_test.go
@@ -37,6 +37,14 @@ func TestSessionSearchSinceMutuallyExclusiveWithActiveSince(t *testing.T) {
 		"--since and --active-since are mutually exclusive")
 }
 
+func TestSessionSearchIncludeDeletedFlag(t *testing.T) {
+	cmd := newSessionSearchCommand()
+	cmd.SetArgs([]string{"--help"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, cmd.Flag("include-deleted").Usage, "soft-deleted")
+}
+
 func TestSessionSearchSinceRejectsInvalidFormat(t *testing.T) {
 	cmd := newSessionSearchCommand()
 	cmd.SetArgs([]string{"needle", "--since", "3x"})

--- a/cmd/agentsview/session_search_test.go
+++ b/cmd/agentsview/session_search_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json/v2"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mattn/go-runewidth"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
@@ -38,11 +40,38 @@ func TestSessionSearchSinceMutuallyExclusiveWithActiveSince(t *testing.T) {
 }
 
 func TestSessionSearchIncludeDeletedFlag(t *testing.T) {
-	cmd := newSessionSearchCommand()
-	cmd.SetArgs([]string{"--help"})
-	err := cmd.Execute()
+	dataDir := newAgentDataDir(t)
+	seedSessionsWithOpts(t, dataDir,
+		sessionSeed{id: "search-active", project: "proj"},
+		sessionSeed{id: "search-deleted", project: "proj"},
+	)
+	seedSearchMessage(t, dataDir, "search-active", "needle active")
+	seedSearchMessage(t, dataDir, "search-deleted", "needle deleted")
+	conn, err := sql.Open("sqlite3", filepath.Join(dataDir, "sessions.db"))
 	require.NoError(t, err)
-	assert.Contains(t, cmd.Flag("include-deleted").Usage, "soft-deleted")
+	_, err = conn.Exec("UPDATE sessions SET deleted_at = ? WHERE id = ?",
+		"2026-05-21T00:00:00Z", "search-deleted")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	defaultOut, err := executeCommand(newRootCommand(),
+		"session", "search", "needle", "--format", "json")
+	require.NoError(t, err)
+	defaultResult := decodeCLIJSON[service.ContentSearchResult](t, defaultOut)
+	assert.Equal(t, []string{"search-active"}, searchMatchIDs(defaultResult.Matches))
+	withDeletedOut, err := executeCommand(newRootCommand(),
+		"session", "search", "needle", "--include-deleted", "--format", "json")
+	require.NoError(t, err)
+	withDeletedResult := decodeCLIJSON[service.ContentSearchResult](t, withDeletedOut)
+	assert.ElementsMatch(t, []string{"search-active", "search-deleted"},
+		searchMatchIDs(withDeletedResult.Matches))
+}
+
+func searchMatchIDs(matches []db.ContentMatch) []string {
+	ids := make([]string, len(matches))
+	for i := range matches {
+		ids[i] = matches[i].SessionID
+	}
+	return ids
 }
 
 func TestSessionSearchSinceRejectsInvalidFormat(t *testing.T) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1080,7 +1080,10 @@ requires auth, or `--pg` to read from configured PostgreSQL.
 When that hides matching sessions on the first page, it reports the counts and
 the corresponding `--include-one-shot` or `--include-automated` flags on stderr.
 Use `--include-deleted` to include retained soft-deleted sessions; permanently
-excluded sessions remain hidden.
+excluded sessions remain hidden. Semantic and hybrid searches reuse only
+vectors created before deletion. Agentsview does not send an already deleted
+transcript to the configured embedding server, so those modes omit a deleted
+session when it has no compatible existing vector.
 Stdout, including `--format json`, keeps its existing shape for pipelines.
 
 `AGENTSVIEW_PG_URL`, a legacy `[pg].url`, or the effective default target from

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1079,6 +1079,8 @@ requires auth, or `--pg` to read from configured PostgreSQL.
 `agentsview session list` excludes one-shot and automated sessions by default.
 When that hides matching sessions on the first page, it reports the counts and
 the corresponding `--include-one-shot` or `--include-automated` flags on stderr.
+Use `--include-deleted` to include retained soft-deleted sessions; permanently
+excluded sessions remain hidden.
 Stdout, including `--format json`, keeps its existing shape for pipelines.
 
 `AGENTSVIEW_PG_URL`, a legacy `[pg].url`, or the effective default target from

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -273,6 +273,7 @@ therefore appear on both dates.
 | `--include-one-shot`  | `include_one_shot`  | bool                              |
 | `--include-automated` | `include_automated` | bool                              |
 | `--include-children`  | `include_children`  | bool                              |
+| `--include-deleted`   | `include_deleted`   | bool; include retained soft-deleted sessions |
 | `--outcome`           | `outcome`           | comma-separated                   |
 | `--health-grade`      | `health_grade`      | comma-separated                   |
 | `--min-tool-failures` | `min_tool_failures` | int; `0` is a meaningful filter   |
@@ -586,7 +587,8 @@ agentsview session search <pattern> [flags]
 
 One-shot, automated, and subagent sessions are excluded by
 default; opt back in with `--include-one-shot`,
-`--include-automated`, or `--include-children`.
+`--include-automated`, or `--include-children`. Retained soft-deleted
+sessions are excluded by default and require `--include-deleted`.
 
 | Flag                  | HTTP param          | Notes                                                  |
 |-----------------------|---------------------|--------------------------------------------------------|
@@ -612,6 +614,7 @@ default; opt back in with `--include-one-shot`,
 | `--include-children`  | `include_children`  | bool                                                   |
 | `--include-automated` | `include_automated` | bool                                                   |
 | `--include-one-shot`  | `include_one_shot`  | bool                                                   |
+| `--include-deleted`   | `include_deleted`   | bool; include retained soft-deleted sessions          |
 | `--limit`             | `limit`             | int; default 50, max 500                               |
 | `--cursor`            | `cursor`            | int — pagination cursor from a previous response       |
 

--- a/frontend/src/lib/api/generated/services/SearchService.ts
+++ b/frontend/src/lib/api/generated/services/SearchService.ts
@@ -92,6 +92,7 @@ export class SearchService {
     includeChildren,
     includeAutomated,
     includeOneShot,
+    includeDeleted,
     limit,
     cursor,
     context,
@@ -177,6 +178,10 @@ export class SearchService {
      */
     includeOneShot?: boolean,
     /**
+     * Include retained soft-deleted sessions
+     */
+    includeDeleted?: boolean,
+    /**
      * Maximum number of results
      */
     limit?: number,
@@ -215,6 +220,7 @@ export class SearchService {
         'include_children': includeChildren,
         'include_automated': includeAutomated,
         'include_one_shot': includeOneShot,
+        'include_deleted': includeDeleted,
         'limit': limit,
         'cursor': cursor,
         'context': context,

--- a/frontend/src/lib/api/generated/services/SessionsService.ts
+++ b/frontend/src/lib/api/generated/services/SessionsService.ts
@@ -114,6 +114,7 @@ export class SessionsService {
     includeAutomated,
     includeChildren,
     includeSource,
+    includeDeleted,
     outcome,
     healthGrade,
     cursor,
@@ -194,6 +195,10 @@ export class SessionsService {
      */
     includeSource?: boolean,
     /**
+     * Include retained soft-deleted sessions
+     */
+    includeDeleted?: boolean,
+    /**
      * Filter by detected outcome
      */
     outcome?: string,
@@ -255,6 +260,7 @@ export class SessionsService {
         'include_automated': includeAutomated,
         'include_children': includeChildren,
         'include_source': includeSource,
+        'include_deleted': includeDeleted,
         'outcome': outcome,
         'health_grade': healthGrade,
         'cursor': cursor,
@@ -334,6 +340,7 @@ export class SessionsService {
     includeAutomated,
     includeChildren,
     includeSource,
+    includeDeleted,
     outcome,
     healthGrade,
     cursor,
@@ -414,6 +421,10 @@ export class SessionsService {
      */
     includeSource?: boolean,
     /**
+     * Include retained soft-deleted sessions
+     */
+    includeDeleted?: boolean,
+    /**
      * Filter by detected outcome
      */
     outcome?: string,
@@ -475,6 +486,7 @@ export class SessionsService {
         'include_automated': includeAutomated,
         'include_children': includeChildren,
         'include_source': includeSource,
+        'include_deleted': includeDeleted,
         'outcome': outcome,
         'health_grade': healthGrade,
         'cursor': cursor,

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -426,7 +426,7 @@ type UnitOffset struct {
 
 // ScanEmbeddableUnits streams the embeddable universe — user/assistant
 // messages that are not is_system and not system-prefixed (per
-// SystemPrefixSQL), from non-trashed sessions — reducing contiguous runs of
+// SystemPrefixSQL) — reducing contiguous runs of
 // embeddable assistant messages between embeddable user messages into single
 // EmbeddableUnit "run" documents; each embeddable user message is emitted as
 // its own "user" unit. Units are emitted in (session_id, ordinal) order of
@@ -443,6 +443,9 @@ type UnitOffset struct {
 // sessionFilterPredicates' ExcludeAutomated scope applies
 // (automatedScopePredicate("human", ...)), so the embedding index's default
 // scope matches session search's default exclusion of automated sessions.
+// Soft-deleted sessions remain in the scan because semantic and hybrid search
+// apply the session deletion filter after vector lookup. Hard-deleted sessions
+// have no session row and therefore leave the scan for full refresh to prune.
 // maxEnded returns the maximum sessions.ended_at seen across the scanned
 // rows (as its original raw string), or "" when the scan produced no rows.
 //
@@ -465,7 +468,6 @@ func (db *DB) ScanEmbeddableUnits(
 	preds := []string{
 		"m.role IN ('user', 'assistant')",
 		"m.is_system = 0",
-		"s.deleted_at IS NULL",
 		SystemPrefixSQL("m.content", "m.role"),
 	}
 	if !includeAutomated {

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -424,6 +424,44 @@ type UnitOffset struct {
 	ByteStart int `json:"b"`
 }
 
+// SoftDeletedSessionIDs returns the subset of ids whose retained session row
+// is soft-deleted. Hard-deleted sessions have no row and are not returned.
+func (db *DB) SoftDeletedSessionIDs(
+	ctx context.Context, ids []string,
+) (map[string]struct{}, error) {
+	deleted := make(map[string]struct{})
+	err := queryChunked(ids, func(chunk []string) error {
+		placeholders, args := inPlaceholders(chunk)
+		rows, err := db.getReader().QueryContext(ctx,
+			"SELECT id FROM sessions WHERE deleted_at IS NOT NULL AND id IN "+placeholders,
+			args...,
+		)
+		if err != nil {
+			return fmt.Errorf("querying soft-deleted sessions: %w", err)
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return fmt.Errorf("scanning soft-deleted session id: %w", err)
+			}
+			deleted[id] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("iterating soft-deleted session ids: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("closing soft-deleted session ids: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return deleted, nil
+}
+
 // ScanEmbeddableUnits streams the embeddable universe — user/assistant
 // messages that are not is_system and not system-prefixed (per
 // SystemPrefixSQL) — reducing contiguous runs of

--- a/internal/db/messages_units_test.go
+++ b/internal/db/messages_units_test.go
@@ -635,10 +635,10 @@ func TestScanEmbeddableUnitsOrdersBySessionThenOrdinal(t *testing.T) {
 	assert.Equal(t, 0, got[2].Ordinal)
 }
 
-// TestScanEmbeddableUnitsExcludesTrashedSessions asserts that units
-// belonging to a soft-deleted (trashed) session never stream, since a
-// trashed session's content should not be indexed for semantic search.
-func TestScanEmbeddableUnitsExcludesTrashedSessions(t *testing.T) {
+// TestScanEmbeddableUnitsIncludesTrashedSessions asserts that units belonging
+// to a soft-deleted session still stream so include-deleted semantic search
+// remains available after a full vector refresh.
+func TestScanEmbeddableUnitsIncludesTrashedSessions(t *testing.T) {
 	d := testDB(t)
 
 	insertSession(t, d, "trashed-sess", "proj", func(s *Session) {
@@ -662,8 +662,11 @@ func TestScanEmbeddableUnitsExcludesTrashedSessions(t *testing.T) {
 
 	got, _ := scanUnits(t, d, "", true)
 
-	require.Len(t, got, 1)
-	assert.Equal(t, "live-sess", got[0].SessionID)
+	require.Len(t, got, 2)
+	assert.ElementsMatch(t, []string{"live-sess", "trashed-sess"}, []string{
+		got[0].SessionID,
+		got[1].SessionID,
+	})
 }
 
 // TestScanEmbeddableUnitsSessionChangeClosesOpenRun asserts that a run left

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -430,8 +430,8 @@ func BuildSessionBaseFilterSQL(
 ) (string, []any) {
 	b := NewQueryBuilder(dialect, 0)
 	preds := []string{"message_count > 0"}
-	preds = append(preds, sessionDeletionPredicates(f, b,
-		func(col string) string { return col })...)
+	preds = append(preds, sessionDeletionPredicates(f,
+		func(col string) string { return col }, "")...)
 	filterPreds, oneShotPred := sessionFilterPredicates(f, b, func(col string) string { return col })
 	preds = append(preds, filterPreds...)
 	if oneShotPred != "" {
@@ -489,7 +489,7 @@ func buildSessionFilterWithBuilder(
 	}
 
 	basePreds := []string{q("message_count") + " > 0"}
-	basePreds = append(basePreds, sessionDeletionPredicates(f, b, q)...)
+	basePreds = append(basePreds, sessionDeletionPredicates(f, q, qualifier)...)
 	if !f.IncludeChildren {
 		basePreds = append(basePreds,
 			q("relationship_type")+" NOT IN ("+b.dialect.SidebarChildRelationshipsSQL()+")")
@@ -513,9 +513,9 @@ func buildSessionFilterWithBuilder(
 		rootMatchParts = append(rootMatchParts, oneShotPred)
 	}
 	rootMatchParts = append(rootMatchParts,
-		sessionDeletionPredicates(f, b, func(col string) string {
+		sessionDeletionPredicates(f, func(col string) string {
 			return "root_session." + col
-		})...)
+		}, "root_session")...)
 	rootMatchParts = append(rootMatchParts,
 		BuildCanonicalRootWhere(b.dialect, "root_session", f.IncludeOrphans))
 	rootMatch := strings.Join(rootMatchParts, " AND ")
@@ -533,9 +533,9 @@ func buildSessionFilterWithBuilder(
 		"SELECT s.id FROM sessions s" +
 		" JOIN tree t ON s.parent_session_id = t.id" +
 		" WHERE s.message_count > 0 AND " +
-		strings.Join(sessionDeletionPredicates(f, b, func(col string) string {
+		strings.Join(sessionDeletionPredicates(f, func(col string) string {
 			return "s." + col
-		}), " AND ") +
+		}, "s"), " AND ") +
 		childAutomationWhere +
 		") SELECT id FROM tree"
 
@@ -543,13 +543,13 @@ func buildSessionFilterWithBuilder(
 }
 
 func sessionDeletionPredicates(
-	f SessionFilter, b *QueryBuilder, q func(string) string,
+	f SessionFilter, q func(string) string, qualifier string,
 ) []string {
 	if !f.IncludeDeleted {
 		return []string{q("deleted_at") + " IS NULL"}
 	}
-	id := q("id")
-	if id == "id" {
+	id := qualifier + ".id"
+	if qualifier == "" {
 		id = "sessions.id"
 	}
 	return []string{"NOT EXISTS (SELECT 1 FROM excluded_sessions es WHERE es.id = " + id + ")"}

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -429,10 +429,9 @@ func BuildSessionBaseFilterSQL(
 	f SessionFilter, dialect QueryDialect,
 ) (string, []any) {
 	b := NewQueryBuilder(dialect, 0)
-	preds := []string{
-		"message_count > 0",
-		"deleted_at IS NULL",
-	}
+	preds := []string{"message_count > 0"}
+	preds = append(preds, sessionDeletionPredicates(f, b,
+		func(col string) string { return col })...)
 	filterPreds, oneShotPred := sessionFilterPredicates(f, b, func(col string) string { return col })
 	preds = append(preds, filterPreds...)
 	if oneShotPred != "" {
@@ -489,10 +488,8 @@ func buildSessionFilterWithBuilder(
 		return qualifier + "." + col
 	}
 
-	basePreds := []string{
-		q("message_count") + " > 0",
-		q("deleted_at") + " IS NULL",
-	}
+	basePreds := []string{q("message_count") + " > 0"}
+	basePreds = append(basePreds, sessionDeletionPredicates(f, b, q)...)
 	if !f.IncludeChildren {
 		basePreds = append(basePreds,
 			q("relationship_type")+" NOT IN ("+b.dialect.SidebarChildRelationshipsSQL()+")")
@@ -516,6 +513,10 @@ func buildSessionFilterWithBuilder(
 		rootMatchParts = append(rootMatchParts, oneShotPred)
 	}
 	rootMatchParts = append(rootMatchParts,
+		sessionDeletionPredicates(f, b, func(col string) string {
+			return "root_session." + col
+		})...)
+	rootMatchParts = append(rootMatchParts,
 		BuildCanonicalRootWhere(b.dialect, "root_session", f.IncludeOrphans))
 	rootMatch := strings.Join(rootMatchParts, " AND ")
 	childAutomationPred := automationScopePredicate(f, b.dialect, "s")
@@ -526,17 +527,32 @@ func buildSessionFilterWithBuilder(
 
 	cte := "WITH RECURSIVE tree(id) AS (" +
 		"SELECT root_session.id FROM sessions root_session" +
-		" WHERE root_session.message_count > 0" +
-		" AND root_session.deleted_at IS NULL AND " +
+		" WHERE root_session.message_count > 0 AND " +
 		rootMatch +
 		" UNION " +
 		"SELECT s.id FROM sessions s" +
 		" JOIN tree t ON s.parent_session_id = t.id" +
-		" WHERE s.message_count > 0 AND s.deleted_at IS NULL" +
+		" WHERE s.message_count > 0 AND " +
+		strings.Join(sessionDeletionPredicates(f, b, func(col string) string {
+			return "s." + col
+		}), " AND ") +
 		childAutomationWhere +
 		") SELECT id FROM tree"
 
 	return baseWhere + " AND " + q("id") + " IN (" + cte + ")"
+}
+
+func sessionDeletionPredicates(
+	f SessionFilter, b *QueryBuilder, q func(string) string,
+) []string {
+	if !f.IncludeDeleted {
+		return []string{q("deleted_at") + " IS NULL"}
+	}
+	id := q("id")
+	if id == "id" {
+		id = "sessions.id"
+	}
+	return []string{"NOT EXISTS (SELECT 1 FROM excluded_sessions es WHERE es.id = " + id + ")"}
 }
 
 func automationScopePredicate(

--- a/internal/db/query_dialect_test.go
+++ b/internal/db/query_dialect_test.go
@@ -184,6 +184,20 @@ func TestBuildSessionFilterSQLResolvesDSTDateBounds(t *testing.T) {
 	}
 }
 
+func TestBuildSessionFilterSQLIncludeDeletedKeepsPermanentExclusions(t *testing.T) {
+	defaultSQL, _ := BuildSessionFilterSQL(SessionFilter{}, SQLiteQueryDialect())
+	assert.Contains(t, normalizeSQL(defaultSQL), "deleted_at IS NULL")
+
+	includeSQL, _ := BuildSessionFilterSQL(SessionFilter{
+		IncludeDeleted: true, IncludeChildren: true,
+	}, SQLiteQueryDialect())
+	normalized := normalizeSQL(includeSQL)
+	assert.NotContains(t, normalized, "deleted_at IS NULL")
+	assert.Contains(t, normalized, "NOT EXISTS (SELECT 1 FROM excluded_sessions")
+	assert.Contains(t, normalized, "root_session.id")
+	assert.Contains(t, normalized, "s.id")
+}
+
 func TestBuildSessionFilterSQLRendersIncludeChildrenCTE(t *testing.T) {
 	filter := SessionFilter{
 		IncludeChildren:  true,

--- a/internal/db/search_content.go
+++ b/internal/db/search_content.go
@@ -35,6 +35,7 @@ type ContentSearchFilter struct {
 	Project, ExcludeProject, Machine, Agent           string
 	Date, DateFrom, DateTo, Timezone, ActiveSince     string
 	IncludeChildren, IncludeAutomated, IncludeOneShot bool
+	IncludeDeleted                                    bool // include retained soft-deleted sessions
 	// GitBranch is a branchListSep-joined list of opaque (project, branch) tokens (EncodeBranchFilterToken).
 	GitBranch string
 
@@ -130,6 +131,7 @@ func contentSessionFilter(f ContentSearchFilter) SessionFilter {
 		ExcludeOneShot:   !f.IncludeOneShot,
 		ExcludeAutomated: !f.IncludeAutomated,
 		IncludeChildren:  f.IncludeChildren,
+		IncludeDeleted:   f.IncludeDeleted,
 	}
 }
 

--- a/internal/db/search_content_semantic_vector_test.go
+++ b/internal/db/search_content_semantic_vector_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: end-to-end semantic search tests wiring a real internal/vector
-// ABOUTME: index into db.SearchContent, pinning anchor-local snippet centering.
+// ABOUTME: End-to-end semantic and hybrid search tests using a real vector index.
+// ABOUTME: Covers snippet centering and retained soft-deleted session vectors.
 package db_test
 
 import (
@@ -115,4 +115,61 @@ func TestSearchContentSemanticCrossMemberChunkCentersOnAnchorMessage(t *testing.
 		"snippet must center on the anchor message's matched content")
 	assert.NotContains(t, m.Snippet, memberA,
 		"snippet must not carry text from a different run member")
+}
+
+func TestSearchContentSemanticAndHybridRetainSoftDeletedVectors(t *testing.T) {
+	ctx := context.Background()
+	d := dbtest.OpenTestDB(t)
+	dbtest.SeedSessionWithMessages(t, d, "deleted-session", "proj", []db.Message{
+		dbtest.UserMsg("deleted-session", 0, "archived vector content"),
+	}, dbtest.WithMessageCounts(2, 2))
+
+	enc := func(_ context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range texts {
+			out[i] = []float32{1, 0, 0}
+		}
+		return out, nil
+	}
+
+	ix, err := vector.Open(ctx, filepath.Join(t.TempDir(), "vectors.db"), false, 4000)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ix.Close()) }()
+	gen := kitvec.Generation{Model: "fake-model", Dimensions: 3}
+	_, err = ix.Build(ctx, d, enc, gen, vector.BuildOptions{})
+	require.NoError(t, err)
+
+	d.SetVectorSearcher(vectorIndexSearcher{ix: ix, enc: enc})
+	active, err := d.SearchContent(ctx, db.ContentSearchFilter{
+		Pattern: "unrelated query", Mode: "semantic", Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, active.Matches, 1)
+	assert.Equal(t, "deleted-session", active.Matches[0].SessionID)
+
+	require.NoError(t, d.SoftDeleteSession("deleted-session"))
+	_, err = ix.Build(ctx, d, enc, gen, vector.BuildOptions{Backstop: true})
+	require.NoError(t, err)
+
+	for _, mode := range []string{"semantic", "hybrid"} {
+		t.Run(mode, func(t *testing.T) {
+			if mode == "hybrid" && !d.HasFTS() {
+				t.Skip("FTS5 is unavailable")
+			}
+
+			withoutDeleted, err := d.SearchContent(ctx, db.ContentSearchFilter{
+				Pattern: "unrelated query", Mode: mode, Limit: 10,
+			})
+			require.NoError(t, err)
+			assert.Empty(t, withoutDeleted.Matches)
+
+			withDeleted, err := d.SearchContent(ctx, db.ContentSearchFilter{
+				Pattern: "unrelated query", Mode: mode,
+				IncludeDeleted: true, Limit: 10,
+			})
+			require.NoError(t, err)
+			require.Len(t, withDeleted.Matches, 1)
+			assert.Equal(t, "deleted-session", withDeleted.Matches[0].SessionID)
+		})
+	}
 }

--- a/internal/db/search_content_semantic_vector_test.go
+++ b/internal/db/search_content_semantic_vector_test.go
@@ -124,7 +124,9 @@ func TestSearchContentSemanticAndHybridRetainSoftDeletedVectors(t *testing.T) {
 		dbtest.UserMsg("deleted-session", 0, "archived vector content"),
 	}, dbtest.WithMessageCounts(2, 2))
 
+	var encoded []string
 	enc := func(_ context.Context, texts []string) ([][]float32, error) {
+		encoded = append(encoded, texts...)
 		out := make([][]float32, len(texts))
 		for i := range texts {
 			out[i] = []float32{1, 0, 0}
@@ -148,8 +150,10 @@ func TestSearchContentSemanticAndHybridRetainSoftDeletedVectors(t *testing.T) {
 	assert.Equal(t, "deleted-session", active.Matches[0].SessionID)
 
 	require.NoError(t, d.SoftDeleteSession("deleted-session"))
+	encoded = nil
 	_, err = ix.Build(ctx, d, enc, gen, vector.BuildOptions{Backstop: true})
 	require.NoError(t, err)
+	assert.Empty(t, encoded, "a backstop must reuse the existing deleted-session vector")
 
 	for _, mode := range []string{"semantic", "hybrid"} {
 		t.Run(mode, func(t *testing.T) {
@@ -172,4 +176,60 @@ func TestSearchContentSemanticAndHybridRetainSoftDeletedVectors(t *testing.T) {
 			assert.Equal(t, "deleted-session", withDeleted.Matches[0].SessionID)
 		})
 	}
+
+	dbtest.SeedSessionWithMessages(t, d, "active-session", "proj", []db.Message{
+		dbtest.UserMsg("active-session", 0, "new active vector content"),
+	}, dbtest.WithMessageCounts(2, 2))
+	encoded = nil
+	nextGen := kitvec.Generation{Model: "next-fake-model", Dimensions: 3}
+	result, err := ix.Build(ctx, d, enc, nextGen, vector.BuildOptions{Backstop: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"new active vector content"}, encoded,
+		"a new generation must not re-embed deleted transcript content")
+	assert.Equal(t, 1, result.Fill.Documents)
+}
+
+func TestVectorBuildDoesNotEncodeAlreadyDeletedSessions(t *testing.T) {
+	ctx := context.Background()
+	d := dbtest.OpenTestDB(t)
+	for _, session := range []struct {
+		id, content string
+	}{
+		{id: "active-session", content: "active vector content"},
+		{id: "deleted-session", content: "deleted vector content"},
+	} {
+		dbtest.SeedSessionWithMessages(t, d, session.id, "proj", []db.Message{
+			dbtest.UserMsg(session.id, 0, session.content),
+		}, dbtest.WithMessageCounts(2, 2))
+	}
+	require.NoError(t, d.SoftDeleteSession("deleted-session"))
+
+	var encoded []string
+	enc := func(_ context.Context, texts []string) ([][]float32, error) {
+		encoded = append(encoded, texts...)
+		out := make([][]float32, len(texts))
+		for i := range texts {
+			out[i] = []float32{1, 0, 0}
+		}
+		return out, nil
+	}
+
+	ix, err := vector.Open(ctx, filepath.Join(t.TempDir(), "vectors.db"), false, 4000)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ix.Close()) }()
+	gen := kitvec.Generation{Model: "fake-model", Dimensions: 3}
+	result, err := ix.Build(ctx, d, enc, gen, vector.BuildOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"active vector content"}, encoded,
+		"the encoder must receive active content and never deleted content")
+	assert.Equal(t, 1, result.Fill.Documents)
+
+	d.SetVectorSearcher(vectorIndexSearcher{ix: ix, enc: enc})
+	page, err := d.SearchContent(ctx, db.ContentSearchFilter{
+		Pattern: "unrelated query", Mode: "semantic",
+		IncludeDeleted: true, Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Matches, 1)
+	assert.Equal(t, "active-session", page.Matches[0].SessionID)
 }

--- a/internal/db/search_content_test.go
+++ b/internal/db/search_content_test.go
@@ -52,6 +52,59 @@ func TestSearchContentSubstringMessages(t *testing.T) {
 	assert.Contains(t, m.Snippet, "DATABASE_URL", "snippet")
 }
 
+func TestIncludeDeletedListAndContentSearchPreservesExclusions(t *testing.T) {
+	d := testDB(t)
+	for _, id := range []string{"active", "source-missing", "user-trash", "permanent"} {
+		seedSearchSession(t, d, id, "proj", [][2]string{{"user", "deleted NEEDLE " + id}})
+	}
+	_, err := d.getWriter().Exec(
+		"UPDATE sessions SET deleted_at = ? WHERE id != ?",
+		"2026-05-21T00:00:00Z", "active",
+	)
+	require.NoError(t, err, "soft-delete retained sessions")
+	_, err = d.getWriter().Exec(
+		"INSERT INTO excluded_sessions (id) VALUES (?)", "permanent",
+	)
+	require.NoError(t, err, "exclude permanent session")
+
+	defaultList, err := d.ListSessions(context.Background(), SessionFilter{
+		ExcludeOneShot: true, ExcludeAutomated: true, Limit: 50,
+	})
+	require.NoError(t, err, "default list")
+	assert.Equal(t, []string{"active"}, collectIDs(defaultList.Sessions))
+
+	withDeleted, err := d.ListSessions(context.Background(), SessionFilter{
+		ExcludeOneShot: true, ExcludeAutomated: true,
+		IncludeDeleted: true, Limit: 50,
+	})
+	require.NoError(t, err, "include-deleted list")
+	assert.ElementsMatch(t, []string{"active", "source-missing", "user-trash"},
+		collectIDs(withDeleted.Sessions))
+
+	defaultSearch, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"},
+		IncludeOneShot: true, Limit: 50,
+	})
+	require.NoError(t, err, "default search")
+	assert.Equal(t, []string{"active"}, contentMatchIDs(defaultSearch.Matches))
+
+	withDeletedSearch, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"},
+		IncludeOneShot: true, IncludeDeleted: true, Limit: 50,
+	})
+	require.NoError(t, err, "include-deleted search")
+	assert.ElementsMatch(t, []string{"active", "source-missing", "user-trash"},
+		contentMatchIDs(withDeletedSearch.Matches))
+}
+
+func contentMatchIDs(matches []ContentMatch) []string {
+	ids := make([]string, len(matches))
+	for i, match := range matches {
+		ids[i] = match.SessionID
+	}
+	return ids
+}
+
 // TestSearchContentRedactsStraddlingSecret pins the default (non-reveal)
 // content-search guarantee: a secret adjacent to the match that extends past
 // the snippet window must not leak. A snippet-only redaction would cut the PEM

--- a/internal/db/search_content_test.go
+++ b/internal/db/search_content_test.go
@@ -97,6 +97,42 @@ func TestIncludeDeletedListAndContentSearchPreservesExclusions(t *testing.T) {
 		contentMatchIDs(withDeletedSearch.Matches))
 }
 
+func TestIncludeDeletedChildrenExecutesRootAndChildPredicates(t *testing.T) {
+	d := testDB(t)
+	seedSearchSession(t, d, "deleted-root", "proj", [][2]string{{"user", "NEEDLE root"}})
+	seedSearchSession(t, d, "deleted-child", "proj", [][2]string{{"user", "NEEDLE child"}})
+	_, err := d.getWriter().Exec(`
+		UPDATE sessions SET deleted_at = ? WHERE id IN (?, ?);
+		UPDATE sessions SET relationship_type = 'subagent', parent_session_id = ?
+		WHERE id = ?`,
+		"2026-05-21T00:00:00Z", "deleted-root", "deleted-child",
+		"deleted-root", "deleted-child")
+	require.NoError(t, err, "soft-delete root and child")
+
+	defaultList, err := d.ListSessions(context.Background(), SessionFilter{
+		IncludeChildren: true, Limit: 50,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, collectIDs(defaultList.Sessions))
+
+	withDeleted, err := d.ListSessions(context.Background(), SessionFilter{
+		IncludeChildren: true,
+		IncludeDeleted:  true, Limit: 50,
+	})
+	require.NoError(t, err, "include-deleted child list")
+	assert.ElementsMatch(t, []string{"deleted-root", "deleted-child"},
+		collectIDs(withDeleted.Sessions))
+
+	withDeletedSearch, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"},
+		IncludeChildren: true, IncludeOneShot: true, IncludeDeleted: true,
+		Limit: 50,
+	})
+	require.NoError(t, err, "include-deleted child search")
+	assert.ElementsMatch(t, []string{"deleted-root", "deleted-child"},
+		contentMatchIDs(withDeletedSearch.Matches))
+}
+
 func contentMatchIDs(matches []ContentMatch) []string {
 	ids := make([]string, len(matches))
 	for i, match := range matches {

--- a/internal/db/search_content_test.go
+++ b/internal/db/search_content_test.go
@@ -58,7 +58,11 @@ func TestIncludeDeletedListAndContentSearchPreservesExclusions(t *testing.T) {
 		seedSearchSession(t, d, id, "proj", [][2]string{{"user", "deleted NEEDLE " + id}})
 	}
 	_, err := d.getWriter().Exec(
-		"UPDATE sessions SET deleted_at = ? WHERE id != ?",
+		`UPDATE sessions SET deleted_at = ?, deletion_cause = CASE id
+			WHEN 'source-missing' THEN 'source_missing'
+			WHEN 'user-trash' THEN 'user_deleted'
+			WHEN 'permanent' THEN 'user_deleted'
+		END WHERE id != ?`,
 		"2026-05-21T00:00:00Z", "active",
 	)
 	require.NoError(t, err, "soft-delete retained sessions")
@@ -95,18 +99,52 @@ func TestIncludeDeletedListAndContentSearchPreservesExclusions(t *testing.T) {
 	require.NoError(t, err, "include-deleted search")
 	assert.ElementsMatch(t, []string{"active", "source-missing", "user-trash"},
 		contentMatchIDs(withDeletedSearch.Matches))
+	var causes map[string]string
+	rows, err := d.getReader().Query(
+		"SELECT id, deletion_cause FROM sessions WHERE id IN (?, ?, ?)",
+		"source-missing", "user-trash", "permanent",
+	)
+	require.NoError(t, err)
+	causes = map[string]string{}
+	defer rows.Close()
+	for rows.Next() {
+		var id, cause string
+		require.NoError(t, rows.Scan(&id, &cause))
+		causes[id] = cause
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, map[string]string{
+		"source-missing": "source_missing",
+		"user-trash":     "user_deleted",
+		"permanent":      "user_deleted",
+	}, causes)
 }
 
 func TestIncludeDeletedChildrenExecutesRootAndChildPredicates(t *testing.T) {
 	d := testDB(t)
-	seedSearchSession(t, d, "deleted-root", "proj", [][2]string{{"user", "NEEDLE root"}})
-	seedSearchSession(t, d, "deleted-child", "proj", [][2]string{{"user", "NEEDLE child"}})
+	for _, id := range []string{"deleted-root", "subagent-child", "fork-child", "continuation-child"} {
+		seedSearchSession(t, d, id, "proj", [][2]string{{"user", "NEEDLE " + id}})
+	}
 	_, err := d.getWriter().Exec(`
-		UPDATE sessions SET deleted_at = ? WHERE id IN (?, ?);
-		UPDATE sessions SET relationship_type = 'subagent', parent_session_id = ?
-		WHERE id = ?`,
-		"2026-05-21T00:00:00Z", "deleted-root", "deleted-child",
-		"deleted-root", "deleted-child")
+		UPDATE sessions SET deleted_at = ? WHERE id IN (?, ?, ?, ?);
+		UPDATE sessions SET deletion_cause = CASE id
+			WHEN 'deleted-root' THEN 'source_missing'
+			ELSE 'user_deleted'
+		END WHERE id IN (?, ?, ?, ?);
+		UPDATE sessions SET relationship_type = CASE id
+			WHEN 'subagent-child' THEN 'subagent'
+			WHEN 'fork-child' THEN 'fork'
+			WHEN 'continuation-child' THEN 'continuation'
+		END, parent_session_id = ? WHERE id IN (?, ?, ?);
+		UPDATE sessions SET source_version = CASE id
+			WHEN 'subagent-child' THEN 'v-subagent'
+			WHEN 'fork-child' THEN 'v-fork'
+			WHEN 'continuation-child' THEN 'v-continuation'
+		END WHERE id IN (?, ?, ?)`,
+		"2026-05-21T00:00:00Z", "deleted-root", "subagent-child", "fork-child", "continuation-child",
+		"deleted-root", "subagent-child", "fork-child", "continuation-child",
+		"deleted-root", "subagent-child", "fork-child", "continuation-child",
+		"subagent-child", "fork-child", "continuation-child")
 	require.NoError(t, err, "soft-delete root and child")
 
 	defaultList, err := d.ListSessions(context.Background(), SessionFilter{
@@ -120,7 +158,7 @@ func TestIncludeDeletedChildrenExecutesRootAndChildPredicates(t *testing.T) {
 		IncludeDeleted:  true, Limit: 50,
 	})
 	require.NoError(t, err, "include-deleted child list")
-	assert.ElementsMatch(t, []string{"deleted-root", "deleted-child"},
+	assert.ElementsMatch(t, []string{"deleted-root", "subagent-child", "fork-child", "continuation-child"},
 		collectIDs(withDeleted.Sessions))
 
 	withDeletedSearch, err := d.SearchContent(context.Background(), ContentSearchFilter{
@@ -129,8 +167,43 @@ func TestIncludeDeletedChildrenExecutesRootAndChildPredicates(t *testing.T) {
 		Limit: 50,
 	})
 	require.NoError(t, err, "include-deleted child search")
-	assert.ElementsMatch(t, []string{"deleted-root", "deleted-child"},
+	assert.ElementsMatch(t, []string{"deleted-root", "subagent-child", "fork-child", "continuation-child"},
 		contentMatchIDs(withDeletedSearch.Matches))
+
+	page, err := d.ListSessions(context.Background(), SessionFilter{
+		IncludeChildren: true, IncludeDeleted: true, Limit: 1,
+	})
+	require.NoError(t, err, "include-deleted paginated child list")
+	ids := collectIDs(page.Sessions)
+	for page.NextCursor != "" {
+		page, err = d.ListSessions(context.Background(), SessionFilter{
+			IncludeChildren: true, IncludeDeleted: true,
+			Cursor: page.NextCursor, Limit: 1,
+		})
+		require.NoError(t, err, "include-deleted next child page")
+		ids = append(ids, collectIDs(page.Sessions)...)
+	}
+	assert.ElementsMatch(t, []string{
+		"deleted-root", "subagent-child", "fork-child", "continuation-child",
+	}, ids)
+}
+
+func TestIncludeDeletedDoesNotAffectSidebarIndex(t *testing.T) {
+	d := testDB(t)
+	seedSearchSession(t, d, "sidebar-root", "proj", [][2]string{{"user", "root"}})
+	seedSearchSession(t, d, "sidebar-child", "proj", [][2]string{{"user", "child"}})
+	_, err := d.getWriter().Exec(`
+		UPDATE sessions SET deleted_at = ?, deletion_cause = 'user_deleted'
+		WHERE id IN (?, ?);
+		UPDATE sessions SET relationship_type = 'subagent', parent_session_id = ?
+		WHERE id = ?`, "2026-05-21T00:00:00Z", "sidebar-root", "sidebar-child",
+		"sidebar-root", "sidebar-child")
+	require.NoError(t, err)
+	index, err := d.GetSidebarSessionIndex(context.Background(), SessionFilter{
+		IncludeDeleted: true, Limit: 1,
+	})
+	require.NoError(t, err, "sidebar index with include-deleted")
+	assert.Empty(t, index.Sessions)
 }
 
 func contentMatchIDs(matches []ContentMatch) []string {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -528,6 +528,7 @@ type SessionFilter struct {
 	// (session list, substring/regex/fts search) leaves this false.
 	ChildExemptOneShot bool
 	ExcludeAutomated   bool     // exclude sessions where is_automated = 1
+	IncludeDeleted     bool     // include retained soft-deleted sessions
 	AutomatedScope     string   // "", "human", "all", or "automated"
 	IncludeChildren    bool     // include subagent sessions (for sidebar grouping)
 	IncludeOrphans     bool     // promote orphan child rows to sidebar roots

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -759,6 +759,9 @@ func (db *DB) ListSessions(
 func (db *DB) GetSidebarSessionIndex(
 	ctx context.Context, f SessionFilter,
 ) (SidebarSessionIndex, error) {
+	// IncludeDeleted is scoped to list and content-search queries; sidebar
+	// indexes retain their existing active-session policy.
+	f.IncludeDeleted = false
 	f.IncludeChildren = true
 	f.IncludeOrphans = true
 

--- a/internal/duckdb/include_deleted_test.go
+++ b/internal/duckdb/include_deleted_test.go
@@ -1,0 +1,74 @@
+//go:build !(windows && arm64)
+
+package duckdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestIncludeDeletedListAndSearchUsesDuckDBExclusionTable(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	writes := []db.SessionBatchWrite{}
+	for _, id := range []string{"duck-active", "duck-deleted", "duck-permanent"} {
+		writes = append(writes, db.SessionBatchWrite{
+			Session: syncSession(id, "proj", "needle "+id,
+				"2026-05-01T10:00:00.000Z", 1),
+			Messages: []db.Message{syncMessage(id, 0, "user", "needle "+id,
+				"2026-05-01T10:00:00.000Z")},
+			DataVersion: 1, ReplaceMessages: true,
+		})
+	}
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, createSchema(ctx, syncer.DB()))
+	_, err = syncer.pushEverything(ctx, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	_, err = syncer.DB().ExecContext(ctx, `
+		UPDATE sessions SET deleted_at = TIMESTAMP '2026-05-02 00:00:00'
+		WHERE id IN ('duck-deleted', 'duck-permanent')`)
+	require.NoError(t, err)
+	_, err = syncer.DB().ExecContext(ctx,
+		`INSERT INTO excluded_sessions (id) VALUES ('duck-permanent')`)
+	require.NoError(t, err)
+
+	page, err := store.ListSessions(ctx, db.SessionFilter{
+		IncludeDeleted: true, Limit: 50,
+	})
+	require.NoError(t, err, "DuckDB include-deleted list")
+	assert.ElementsMatch(t, []string{"duck-active", "duck-deleted"},
+		includeDeletedDuckSessionIDs(page.Sessions))
+
+	search, err := store.SearchContent(ctx, db.ContentSearchFilter{
+		Pattern: "needle", Mode: "substring", Sources: []string{"messages"},
+		IncludeOneShot: true, IncludeDeleted: true, Limit: 50,
+	})
+	require.NoError(t, err, "DuckDB include-deleted search")
+	assert.ElementsMatch(t, []string{"duck-active", "duck-deleted"},
+		includeDeletedDuckMatchIDs(search.Matches))
+}
+
+func includeDeletedDuckSessionIDs(sessions []db.Session) []string {
+	ids := make([]string, len(sessions))
+	for i := range sessions {
+		ids[i] = sessions[i].ID
+	}
+	return ids
+}
+
+func includeDeletedDuckMatchIDs(matches []db.ContentMatch) []string {
+	ids := make([]string, len(matches))
+	for i := range matches {
+		ids[i] = matches[i].SessionID
+	}
+	return ids
+}

--- a/internal/duckdb/schema.go
+++ b/internal/duckdb/schema.go
@@ -13,9 +13,10 @@ import (
 // SchemaVersion is the version of the DuckDB mirror schema created by
 // createSchema. The mirror schema is create-only: there are no in-place
 // migrations between versions. A version mismatch means the mirror file
-// must be rebuilt with 'agentsview duckdb push --full'. v11 adds the raw GenAI
-// pricing document on top of v10's usage-accounting rebuild boundary.
-const SchemaVersion = 11
+// must be rebuilt with 'agentsview duckdb push --full'. v12 adds the
+// permanently-excluded session catalog needed by opt-in deleted-session
+// queries on top of v11's raw GenAI pricing document.
+const SchemaVersion = 12
 
 const schemaVersionMetadataKey = "agentsview_schema_version"
 
@@ -708,6 +709,17 @@ var mirrorTables = []tableSpec{
 		indexes: []string{
 			"CREATE INDEX IF NOT EXISTS idx_secret_findings_session ON secret_findings(session_id)",
 			"CREATE INDEX IF NOT EXISTS idx_secret_findings_rule ON secret_findings(rule_name)",
+		},
+	},
+	{
+		name: "excluded_sessions",
+		create: `CREATE TABLE IF NOT EXISTS excluded_sessions (
+			id TEXT PRIMARY KEY,
+			created_at TIMESTAMP
+		)`,
+		columns: []columnSpec{
+			{"id", "id TEXT"},
+			{"created_at", "created_at TIMESTAMP"},
 		},
 	},
 	{

--- a/internal/duckdb/schema_test.go
+++ b/internal/duckdb/schema_test.go
@@ -52,6 +52,7 @@ func TestEnsureSchemaCreatesRequiredMirrorTables(t *testing.T) {
 		"tool_calls",
 		"tool_result_events",
 		"secret_findings",
+		"excluded_sessions",
 		"starred_sessions",
 		"pinned_messages",
 	} {

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -1413,6 +1413,7 @@ func contentSessionFilter(f db.ContentSearchFilter) db.SessionFilter {
 		ExcludeOneShot:   !f.IncludeOneShot,
 		ExcludeAutomated: !f.IncludeAutomated,
 		IncludeChildren:  f.IncludeChildren,
+		IncludeDeleted:   f.IncludeDeleted,
 	}
 }
 

--- a/internal/postgres/search_content.go
+++ b/internal/postgres/search_content.go
@@ -93,6 +93,7 @@ func pgSessionFilter(f db.ContentSearchFilter) db.SessionFilter {
 		ExcludeOneShot:   !f.IncludeOneShot,
 		ExcludeAutomated: !f.IncludeAutomated,
 		IncludeChildren:  f.IncludeChildren,
+		IncludeDeleted:   f.IncludeDeleted,
 	}
 }
 

--- a/internal/server/huma_routes_include_deleted_test.go
+++ b/internal/server/huma_routes_include_deleted_test.go
@@ -1,0 +1,50 @@
+package server_test
+
+import (
+	"database/sql"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestHumaIncludeDeletedQueryMappingForListAndContentSearch(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "huma-active", "proj", 2)
+	te.seedSession(t, "huma-deleted", "proj", 2)
+	te.seedMessages(t, "huma-active", 1, func(_ int, m *db.Message) {
+		m.Content = "needle active"
+	})
+	te.seedMessages(t, "huma-deleted", 1, func(_ int, m *db.Message) {
+		m.Content = "needle deleted"
+	})
+	conn, err := sql.Open("sqlite3", filepath.Join(te.dataDir, "test.db"))
+	require.NoError(t, err)
+	_, err = conn.Exec("UPDATE sessions SET deleted_at = ? WHERE id = ?",
+		"2026-05-21T00:00:00Z", "huma-deleted")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	defaultList := te.get(t, "/api/v1/sessions?limit=50")
+	assert.Equal(t, http.StatusOK, defaultList.Code)
+	assert.Contains(t, defaultList.Body.String(), "huma-active")
+	assert.NotContains(t, defaultList.Body.String(), "huma-deleted")
+	withDeletedList := te.get(t,
+		"/api/v1/sessions?limit=50&include_deleted=true")
+	assert.Equal(t, http.StatusOK, withDeletedList.Code)
+	assert.Contains(t, withDeletedList.Body.String(), "huma-deleted")
+
+	defaultSearch := te.get(t,
+		"/api/v1/search/content?pattern=needle&in=messages&limit=50")
+	assert.Equal(t, http.StatusOK, defaultSearch.Code)
+	assert.Contains(t, defaultSearch.Body.String(), "huma-active")
+	assert.NotContains(t, defaultSearch.Body.String(), "huma-deleted")
+	withDeletedSearch := te.get(t,
+		"/api/v1/search/content?pattern=needle&in=messages&limit=50&include_deleted=true")
+	assert.Equal(t, http.StatusOK, withDeletedSearch.Code)
+	assert.Contains(t, withDeletedSearch.Body.String(), "huma-deleted")
+}

--- a/internal/server/huma_routes_include_deleted_test.go
+++ b/internal/server/huma_routes_include_deleted_test.go
@@ -47,4 +47,9 @@ func TestHumaIncludeDeletedQueryMappingForListAndContentSearch(t *testing.T) {
 		"/api/v1/search/content?pattern=needle&in=messages&limit=50&include_deleted=true")
 	assert.Equal(t, http.StatusOK, withDeletedSearch.Code)
 	assert.Contains(t, withDeletedSearch.Body.String(), "huma-deleted")
+
+	withDeletedSidebar := te.get(t,
+		"/api/v1/sessions/sidebar-index?limit=50&include_deleted=true")
+	assert.Equal(t, http.StatusOK, withDeletedSidebar.Code)
+	assert.NotContains(t, withDeletedSidebar.Body.String(), "huma-deleted")
 }

--- a/internal/server/huma_routes_search.go
+++ b/internal/server/huma_routes_search.go
@@ -52,6 +52,7 @@ type contentSearchInput struct {
 	IncludeChildren  bool               `query:"include_children" doc:"Include child sessions"`
 	IncludeAutomated bool               `query:"include_automated" doc:"Include automated sessions"`
 	IncludeOneShot   bool               `query:"include_one_shot" doc:"Include one-shot sessions"`
+	IncludeDeleted   bool               `query:"include_deleted" doc:"Include retained soft-deleted sessions"`
 	Limit            int                `query:"limit" minimum:"0" doc:"Maximum number of results"`
 	Cursor           int                `query:"cursor" minimum:"0" doc:"Pagination cursor"`
 	Context          int                `query:"context" doc:"Include N messages of context before and after each match (max 10)"`
@@ -137,6 +138,7 @@ func (s *Server) humaSearchContent(
 		IncludeChildren:  in.IncludeChildren,
 		IncludeAutomated: in.IncludeAutomated,
 		IncludeOneShot:   in.IncludeOneShot,
+		IncludeDeleted:   in.IncludeDeleted,
 		Scope:            string(in.Scope),
 		Limit:            in.Limit,
 		Cursor:           in.Cursor,

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -77,6 +77,7 @@ type sessionFilterInput struct {
 	IncludeAutomated bool              `query:"include_automated" doc:"Include automated sessions"`
 	IncludeChildren  bool              `query:"include_children" doc:"Include child sessions"`
 	IncludeSource    bool              `query:"include_source" doc:"Include source file paths"`
+	IncludeDeleted   bool              `query:"include_deleted" doc:"Include retained soft-deleted sessions"`
 	Outcome          string            `query:"outcome" doc:"Filter by detected outcome"`
 	HealthGrade      string            `query:"health_grade" doc:"Filter by health grade"`
 	Cursor           string            `query:"cursor" doc:"Opaque pagination cursor"`
@@ -144,6 +145,7 @@ func (in *sessionFilterInput) listFilter() (service.ListFilter, error) {
 		IncludeAutomated: in.IncludeAutomated,
 		IncludeChildren:  in.IncludeChildren,
 		IncludeSource:    in.IncludeSource,
+		IncludeDeleted:   in.IncludeDeleted,
 		Outcome:          in.Outcome,
 		HealthGrade:      in.HealthGrade,
 		Cursor:           in.Cursor,

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -194,6 +194,7 @@ func listFilterToDB(f ListFilter) db.SessionFilter {
 		ExcludeAutomated:     !f.IncludeAutomated,
 		IncludeChildren:      f.IncludeChildren,
 		IncludeSource:        f.IncludeSource,
+		IncludeDeleted:       f.IncludeDeleted,
 		Cursor:               f.Cursor,
 		Limit:                f.Limit,
 		MinToolFailures:      f.MinToolFailures,
@@ -823,6 +824,7 @@ func (b *directBackend) SearchContent(
 		IncludeChildren:  req.IncludeChildren,
 		IncludeAutomated: req.IncludeAutomated,
 		IncludeOneShot:   req.IncludeOneShot,
+		IncludeDeleted:   req.IncludeDeleted,
 		Scope:            req.Scope,
 		// The store builds snippets from the full source field and redacts
 		// secrets (including ones straddling the snippet window) unless reveal

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -649,7 +649,6 @@ func TestDirectBackend_IncludeDeletedReachesListAndSearch(t *testing.T) {
 	dbtest.EnsureTestDBAt(t, path)
 	d := dbtest.OpenTestDBAt(t, path)
 	env := &directTestEnv{db: d}
-	svc := service.NewDirectBackend(d, nil)
 	for _, id := range []string{"direct-active", "direct-deleted"} {
 		dbtest.SeedSession(t, env.db, id, "proj", func(s *db.Session) {
 			s.MessageCount = 2
@@ -674,7 +673,7 @@ func TestDirectBackend_IncludeDeletedReachesListAndSearch(t *testing.T) {
 	require.NoError(t, conn.Close())
 	d = dbtest.OpenTestDBAt(t, path)
 	env.db = d
-	svc = service.NewDirectBackend(d, nil)
+	svc := service.NewDirectBackend(d, nil)
 	defaultList, err := svc.List(context.Background(), service.ListFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"direct-active"}, directSessionIDs(defaultList.Sessions))

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -643,6 +643,78 @@ func TestDirectBackend_List_TimezoneValidationAndUTCDefault(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid timezone: Fake/Zone")
 }
 
+func TestDirectBackend_IncludeDeletedReachesListAndSearch(t *testing.T) {
+	dir := dbtest.MkdirTempWithCleanup(t, "agentsview-direct-include-deleted-")
+	path := filepath.Join(dir, "sessions.db")
+	dbtest.EnsureTestDBAt(t, path)
+	d := dbtest.OpenTestDBAt(t, path)
+	env := &directTestEnv{db: d}
+	svc := service.NewDirectBackend(d, nil)
+	for _, id := range []string{"direct-active", "direct-deleted"} {
+		dbtest.SeedSession(t, env.db, id, "proj", func(s *db.Session) {
+			s.MessageCount = 2
+			s.UserMessageCount = 2
+			if id == "direct-deleted" {
+				s.DeletedAt = dbtest.Ptr("2026-05-21T00:00:00Z")
+			}
+		})
+		require.NoError(t, env.db.ReplaceSessionMessages(id, []db.Message{
+			{SessionID: id, Ordinal: 0, Role: "user", Content: "needle " + id,
+				Timestamp: "2026-05-20T12:00:00Z"},
+			{SessionID: id, Ordinal: 1, Role: "assistant", Content: "reply",
+				Timestamp: "2026-05-20T12:00:01Z"},
+		}))
+	}
+	require.NoError(t, d.Close())
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	_, err = conn.Exec("UPDATE sessions SET deleted_at = ? WHERE id = ?",
+		"2026-05-21T00:00:00Z", "direct-deleted")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	d = dbtest.OpenTestDBAt(t, path)
+	env.db = d
+	svc = service.NewDirectBackend(d, nil)
+	defaultList, err := svc.List(context.Background(), service.ListFilter{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"direct-active"}, directSessionIDs(defaultList.Sessions))
+	withDeleted, err := svc.List(context.Background(), service.ListFilter{
+		IncludeDeleted: true, Limit: 50,
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"direct-active", "direct-deleted"},
+		directSessionIDs(withDeleted.Sessions))
+
+	defaultSearch, err := svc.SearchContent(context.Background(), service.ContentSearchRequest{
+		Pattern: "needle", Mode: "substring", Sources: []string{"messages"}, Limit: 50,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"direct-active"}, directMatchIDs(defaultSearch.Matches))
+	withDeletedSearch, err := svc.SearchContent(context.Background(), service.ContentSearchRequest{
+		Pattern: "needle", Mode: "substring", Sources: []string{"messages"},
+		IncludeDeleted: true, Limit: 50,
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"direct-active", "direct-deleted"},
+		directMatchIDs(withDeletedSearch.Matches))
+}
+
+func directSessionIDs(sessions []db.Session) []string {
+	ids := make([]string, len(sessions))
+	for i := range sessions {
+		ids[i] = sessions[i].ID
+	}
+	return ids
+}
+
+func directMatchIDs(matches []db.ContentMatch) []string {
+	ids := make([]string, len(matches))
+	for i := range matches {
+		ids[i] = matches[i].SessionID
+	}
+	return ids
+}
+
 func TestDirectSearchContentRejectsInvalidTimezone(t *testing.T) {
 	t.Parallel()
 	svc, _ := newDirectTestSvc(t)

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -232,6 +232,9 @@ func filterToQuery(f ListFilter) url.Values {
 	if f.IncludeSource {
 		q.Set("include_source", "true")
 	}
+	if f.IncludeDeleted {
+		q.Set("include_deleted", "true")
+	}
 	setIfNotEmpty("outcome", f.Outcome)
 	setIfNotEmpty("health_grade", f.HealthGrade)
 	setIfNotEmpty("termination", f.Termination)
@@ -525,6 +528,9 @@ func (b *httpBackend) SearchContent(
 	}
 	if req.IncludeOneShot {
 		q.Set("include_one_shot", "true")
+	}
+	if req.IncludeDeleted {
+		q.Set("include_deleted", "true")
 	}
 	if req.Limit > 0 {
 		q.Set("limit", strconv.Itoa(req.Limit))

--- a/internal/service/http_internal_test.go
+++ b/internal/service/http_internal_test.go
@@ -44,14 +44,16 @@ func TestHTTPBackendRecallCapabilityRespectsReadOnlyMode(t *testing.T) {
 func TestFilterToQueryKeepsListOptions(t *testing.T) {
 	t.Parallel()
 	query := filterToQuery(ListFilter{
-		Timezone:      "America/New_York",
-		Cursor:        "next-page",
-		IncludeSource: true,
+		Timezone:       "America/New_York",
+		Cursor:         "next-page",
+		IncludeSource:  true,
+		IncludeDeleted: true,
 	})
 
 	assert.Equal(t, "America/New_York", query.Get("timezone"))
 	assert.Equal(t, "next-page", query.Get("cursor"))
 	assert.Equal(t, "true", query.Get("include_source"))
+	assert.Equal(t, "true", query.Get("include_deleted"))
 }
 
 func TestSearchContentUsesLongRunningClient(t *testing.T) {

--- a/internal/service/http_test.go
+++ b/internal/service/http_test.go
@@ -959,13 +959,16 @@ func TestHTTPSearchContent(t *testing.T) {
 			if r.URL.Query().Get("timezone") != "America/New_York" {
 				t.Errorf("timezone = %s", r.URL.Query().Get("timezone"))
 			}
+			if r.URL.Query().Get("include_deleted") != "true" {
+				t.Errorf("include_deleted = %s", r.URL.Query().Get("include_deleted"))
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"matches":[{"session_id":"s1","location":"message"}],"next_cursor":0}`))
 		}))
 	defer srv.Close()
 	be := service.NewHTTPBackend(srv.URL, "", true)
 	res, err := be.SearchContent(context.Background(), service.ContentSearchRequest{
-		Pattern: "needle", Timezone: "America/New_York", Limit: 50,
+		Pattern: "needle", Timezone: "America/New_York", IncludeDeleted: true, Limit: 50,
 	})
 	require.NoError(t, err)
 	require.Len(t, res.Matches, 1)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -168,6 +168,7 @@ type ContentSearchRequest struct {
 	Project, ExcludeProject, Machine, Agent           string
 	Date, DateFrom, DateTo, Timezone, ActiveSince     string
 	IncludeChildren, IncludeAutomated, IncludeOneShot bool
+	IncludeDeleted                                    bool `json:"include_deleted,omitempty"`
 	// GitBranch is a branchListSep-joined list of opaque (project, branch) tokens (EncodeBranchFilterToken).
 	GitBranch string
 
@@ -388,6 +389,7 @@ type ListFilter struct {
 	IncludeAutomated bool   `json:"include_automated,omitempty"`
 	IncludeChildren  bool   `json:"include_children,omitempty"`
 	IncludeSource    bool   `json:"include_source,omitempty"`
+	IncludeDeleted   bool   `json:"include_deleted,omitempty"`
 	Outcome          string `json:"outcome,omitempty"`      // comma-separated
 	HealthGrade      string `json:"health_grade,omitempty"` // comma-separated
 	Termination      string `json:"termination,omitempty"`  // comma-separated

--- a/internal/vector/build.go
+++ b/internal/vector/build.go
@@ -94,6 +94,145 @@ type BuildResult struct {
 	Fill        kitvec.FillStats
 }
 
+type softDeletedSessionSource interface {
+	SoftDeletedSessionIDs(
+		ctx context.Context, sessionIDs []string,
+	) (map[string]struct{}, error)
+}
+
+// softDeletedPendingStore keeps soft-deleted transcript content out of the
+// encoder. It omits deleted documents from each pending page without stamping
+// them, then Build prunes those mirror rows after active documents finish.
+// Already-covered documents never enter PendingForGeneration and therefore
+// keep their existing vectors during ordinary and backstop builds.
+type softDeletedPendingStore struct {
+	kitvec.Store[string, string]
+	ix      *Index
+	source  softDeletedSessionSource
+	skipped map[string]string // doc key -> session id
+}
+
+func (s *softDeletedPendingStore) PendingForGeneration(
+	ctx context.Context, gen string, limit int,
+) ([]kitvec.Pending[string], error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	pending, err := s.Store.PendingForGeneration(ctx, gen, limit+len(s.skipped))
+	if err != nil || len(pending) == 0 {
+		return pending, err
+	}
+
+	docSessions, sessionIDs, err := s.sessionsForPending(ctx, pending)
+	if err != nil {
+		return nil, err
+	}
+	deleted, err := s.source.SoftDeletedSessionIDs(ctx, sessionIDs)
+	if err != nil {
+		return nil, fmt.Errorf("classifying pending soft-deleted sessions: %w", err)
+	}
+
+	eligible := make([]kitvec.Pending[string], 0, min(limit, len(pending)))
+	for _, p := range pending {
+		sessionID := docSessions[p.Doc]
+		if _, ok := deleted[sessionID]; ok {
+			s.skipped[p.Doc] = sessionID
+			continue
+		}
+		delete(s.skipped, p.Doc)
+		eligible = append(eligible, p)
+		if len(eligible) == limit {
+			break
+		}
+	}
+	return eligible, nil
+}
+
+func (s *softDeletedPendingStore) sessionsForPending(
+	ctx context.Context, pending []kitvec.Pending[string],
+) (map[string]string, []string, error) {
+	keys := make([]string, len(pending))
+	for i, p := range pending {
+		keys[i] = p.Doc
+	}
+	docSessions := make(map[string]string, len(keys))
+	if err := chunkKeys(keys, func(chunk []string) error {
+		placeholders, args := inPlaceholders(chunk)
+		rows, err := s.ix.db.QueryContext(ctx,
+			`SELECT doc_key, session_id FROM `+s.ix.spec.DocsTable+
+				` WHERE doc_key IN `+placeholders,
+			args...,
+		)
+		if err != nil {
+			return fmt.Errorf("querying pending document sessions: %w", err)
+		}
+		for rows.Next() {
+			var key, sessionID string
+			if err := rows.Scan(&key, &sessionID); err != nil {
+				rows.Close()
+				return fmt.Errorf("scanning pending document session: %w", err)
+			}
+			docSessions[key] = sessionID
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("iterating pending document sessions: %w", err)
+		}
+		return rows.Close()
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	seen := make(map[string]struct{}, len(docSessions))
+	sessionIDs := make([]string, 0, len(docSessions))
+	for _, p := range pending {
+		sessionID, ok := docSessions[p.Doc]
+		if !ok {
+			return nil, nil, fmt.Errorf("pending document %s has no mirror session", p.Doc)
+		}
+		if _, ok := seen[sessionID]; ok {
+			continue
+		}
+		seen[sessionID] = struct{}{}
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	return docSessions, sessionIDs, nil
+}
+
+func (s *softDeletedPendingStore) pruneSkipped(ctx context.Context) (int, error) {
+	if len(s.skipped) == 0 {
+		return 0, nil
+	}
+	sessionIDs := make([]string, 0, len(s.skipped))
+	seen := make(map[string]struct{}, len(s.skipped))
+	for _, sessionID := range s.skipped {
+		if _, ok := seen[sessionID]; ok {
+			continue
+		}
+		seen[sessionID] = struct{}{}
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	deleted, err := s.source.SoftDeletedSessionIDs(ctx, sessionIDs)
+	if err != nil {
+		return 0, fmt.Errorf("rechecking skipped soft-deleted sessions: %w", err)
+	}
+
+	var pruned int
+	for key, sessionID := range s.skipped {
+		if _, ok := deleted[sessionID]; !ok {
+			continue
+		}
+		removed, err := s.ix.deleteMirrorDocument(ctx, key)
+		if err != nil {
+			return pruned, fmt.Errorf("pruning unembedded soft-deleted document %s: %w", key, err)
+		}
+		if removed {
+			pruned++
+		}
+	}
+	return pruned, nil
+}
+
 // Build runs one embedding pass against gen (the desired vector space, from
 // config: Model, Dimensions, and the fingerprinted Params — max_input_chars,
 // doc_unit_scheme, and chunk_overlap_chars; see vectorGeneration in
@@ -186,10 +325,18 @@ func (ix *Index) Build(
 	}
 
 	wrapped, finish := ix.wrapProgress(validatingEncoder(enc), total, o.Progress)
-	fillStore := &repairQueueCompletingStore{
+	var fillStore kitvec.Store[string, string] = &repairQueueCompletingStore{
 		Store: ix.store,
 		db:    ix.db,
 		spec:  ix.spec,
+	}
+	var deletedStore *softDeletedPendingStore
+	if source, ok := src.(softDeletedSessionSource); ok {
+		deletedStore = &softDeletedPendingStore{
+			Store: fillStore, ix: ix, source: source,
+			skipped: make(map[string]string),
+		}
+		fillStore = deletedStore
 	}
 	fillStats, fillErr := kitvec.Fill[string, string](ctx, fillStore, target, wrapped,
 		kitvec.WithFillSplit[string](ix.split),
@@ -209,6 +356,13 @@ func (ix *Index) Build(
 	result.Fill = fillStats
 	if fillErr != nil {
 		return result, fillErr
+	}
+	if deletedStore != nil {
+		pruned, err := deletedStore.pruneSkipped(ctx)
+		if err != nil {
+			return result, err
+		}
+		result.Refresh.Deleted += pruned
 	}
 
 	activated, err := ix.maybeActivate(ctx, target, wasBuilding)

--- a/internal/vector/build.go
+++ b/internal/vector/build.go
@@ -118,34 +118,39 @@ func (s *softDeletedPendingStore) PendingForGeneration(
 	if limit <= 0 {
 		return nil, nil
 	}
-	pending, err := s.Store.PendingForGeneration(ctx, gen, limit+len(s.skipped))
-	if err != nil || len(pending) == 0 {
-		return pending, err
-	}
-
-	docSessions, sessionIDs, err := s.sessionsForPending(ctx, pending)
-	if err != nil {
-		return nil, err
-	}
-	deleted, err := s.source.SoftDeletedSessionIDs(ctx, sessionIDs)
-	if err != nil {
-		return nil, fmt.Errorf("classifying pending soft-deleted sessions: %w", err)
-	}
-
-	eligible := make([]kitvec.Pending[string], 0, min(limit, len(pending)))
-	for _, p := range pending {
-		sessionID := docSessions[p.Doc]
-		if _, ok := deleted[sessionID]; ok {
-			s.skipped[p.Doc] = sessionID
-			continue
+	for {
+		pendingLimit := limit + len(s.skipped)
+		pending, err := s.Store.PendingForGeneration(ctx, gen, pendingLimit)
+		if err != nil || len(pending) == 0 {
+			return pending, err
 		}
-		delete(s.skipped, p.Doc)
-		eligible = append(eligible, p)
-		if len(eligible) == limit {
-			break
+
+		docSessions, sessionIDs, err := s.sessionsForPending(ctx, pending)
+		if err != nil {
+			return nil, err
+		}
+		deleted, err := s.source.SoftDeletedSessionIDs(ctx, sessionIDs)
+		if err != nil {
+			return nil, fmt.Errorf("classifying pending soft-deleted sessions: %w", err)
+		}
+
+		eligible := make([]kitvec.Pending[string], 0, min(limit, len(pending)))
+		for _, p := range pending {
+			sessionID := docSessions[p.Doc]
+			if _, ok := deleted[sessionID]; ok {
+				s.skipped[p.Doc] = sessionID
+				continue
+			}
+			delete(s.skipped, p.Doc)
+			eligible = append(eligible, p)
+			if len(eligible) == limit {
+				break
+			}
+		}
+		if len(eligible) > 0 || len(pending) < pendingLimit {
+			return eligible, nil
 		}
 	}
-	return eligible, nil
 }
 
 func (s *softDeletedPendingStore) sessionsForPending(

--- a/internal/vector/build_test.go
+++ b/internal/vector/build_test.go
@@ -83,6 +83,35 @@ func TestBuildFirstBuildEmbedsAllAndActivates(t *testing.T) {
 	assert.Equal(t, gen.Fingerprint(), active)
 }
 
+func TestBuildContinuesPastDeletedOnlyPendingPage(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{deletedSessions: make(map[string]struct{})}
+	for i := range 128 {
+		sessionID := fmt.Sprintf("deleted-%03d", i)
+		src.rows = append(src.rows, fakeUnit{
+			unit:    userDoc(sessionID, "message", 0, "deleted content"),
+			endedAt: "2024-01-01T00:00:00Z",
+		})
+		src.deletedSessions[sessionID] = struct{}{}
+	}
+	src.rows = append(src.rows, fakeUnit{
+		unit:    userDoc("z-active", "message", 0, "active content"),
+		endedAt: "2024-01-01T00:00:00Z",
+	})
+
+	var encoded []string
+	enc := func(_ context.Context, texts []string) ([][]float32, error) {
+		encoded = append(encoded, texts...)
+		return fakeBuildEncoder()(ctx, texts)
+	}
+	result, err := ix.Build(ctx, src, enc, fakeGeneration("fake-model"), BuildOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"active content"}, encoded)
+	assert.Equal(t, 1, result.Fill.Documents)
+	assert.True(t, result.Activated)
+}
+
 func TestBuildSecondBuildNoChangesFillsZero(t *testing.T) {
 	ix := openTestIndex(t)
 	ctx := context.Background()

--- a/internal/vector/mirror_test.go
+++ b/internal/vector/mirror_test.go
@@ -21,6 +21,7 @@ type fakeUnitSource struct {
 	rows                []fakeUnit
 	gotSince            string
 	gotIncludeAutomated bool
+	deletedSessions     map[string]struct{}
 }
 
 // fakeUnit pairs an EmbeddableUnit with the ended_at of its session, so the
@@ -55,6 +56,18 @@ func (f *fakeUnitSource) ScanEmbeddableUnits(
 		}
 	}
 	return maxEnded, nil
+}
+
+func (f *fakeUnitSource) SoftDeletedSessionIDs(
+	_ context.Context, sessionIDs []string,
+) (map[string]struct{}, error) {
+	deleted := make(map[string]struct{})
+	for _, sessionID := range sessionIDs {
+		if _, ok := f.deletedSessions[sessionID]; ok {
+			deleted[sessionID] = struct{}{}
+		}
+	}
+	return deleted, nil
 }
 
 // userDoc builds the single-message "user" unit shape most mirror and build


### PR DESCRIPTION
Agentsview's CLI list and content-search commands now accept an explicit
`--include-deleted` option for retained soft-deleted sessions. The option works
through direct and daemon-backed requests and includes both root and child
sessions.

Semantic and hybrid search reuse compatible vectors created before a session
was soft-deleted. Vector builds filter already-deleted transcripts before any
encoding call, so deletion never causes a new embedding request. If a
compatible vector does not already exist, semantic and hybrid search omit that
deleted session even when `--include-deleted` is set.

Default queries still hide soft-deleted sessions. Permanently excluded sessions
remain hidden, hard deletion still removes vectors, and unrelated sidebar,
usage, analytics, and synchronization paths keep their existing policy.

This change adds no table, corpus version, vector recreation, or migration.

Closes #1471
