### PR TITLE
fix(parser): support current Kiro CLI session layout

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1265,6 +1265,18 @@ add an archived or maintained mirror without replacing the original identity.
 - **Format:** Legacy JSONL plus companion metadata JSON, and newer SQLite
   session databases.
 
+  The issue-reported current layout uses
+  `~/.kiro/sessions/<workspace>/sess_<id>/messages.jsonl` or the direct
+  `sess_<id>/messages.jsonl` form, with optional `session.json`. Agentsview
+  admits only these exact producer-relative shapes: one workspace segment,
+  no `.history` or `snapshots` workspace, a valid `sess_<id>` directory, and
+  no nested session directory. It preserves the literal `sess_<id>` identity
+  and maps user, assistant, tool-call, and tool-result envelope fields;
+  unknown and malformed records are ignored. This observed layout has no
+  pinned producer schema source. For duplicate IDs, SQLite outranks current
+  JSONL, current outranks legacy JSONL, configured root order breaks ties
+  within a class, and recency then canonical path provide deterministic ties.
+
 - **Evidence:** `documentation`.
 
 - **Upstream:** Kiro's first-party [license page](https://kiro.dev/license/) and
@@ -1293,12 +1305,6 @@ add an archived or maintained mirror without replacing the original identity.
   found input/output counters present but zero and no cache split. Agentsview
   currently consumes none of those sidecar usage fields, so it emits no Kiro
   usage or cost metrics.
-
-  Current CLI sessions use `~/.kiro/sessions/<workspace>/sess_<id>/messages.jsonl`
-  or the direct `sess_<id>/messages.jsonl` form, with optional `session.json`.
-  Agentsview admits only these exact producer-relative shapes, preserves the
-  literal `sess_<id>` identity, and maps documented user, assistant, tool-call,
-  and tool-result envelope fields. Unknown and malformed records are ignored.
 
 - **Agentsview:** `internal/parser/kiro.go`, `internal/parser/kiro_sqlite.go`,
   and `internal/parser/kiro_provider.go`; both generations must remain

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1294,6 +1294,12 @@ add an archived or maintained mirror without replacing the original identity.
   currently consumes none of those sidecar usage fields, so it emits no Kiro
   usage or cost metrics.
 
+  Current CLI sessions use `~/.kiro/sessions/<workspace>/sess_<id>/messages.jsonl`
+  or the direct `sess_<id>/messages.jsonl` form, with optional `session.json`.
+  Agentsview admits only these exact producer-relative shapes, preserves the
+  literal `sess_<id>` identity, and maps documented user, assistant, tool-call,
+  and tool-result envelope fields. Unknown and malformed records are ignored.
+
 - **Agentsview:** `internal/parser/kiro.go`, `internal/parser/kiro_sqlite.go`,
   and `internal/parser/kiro_provider.go`; both generations must remain
   discoverable.

--- a/internal/parser/capabilities_sync_test.go
+++ b/internal/parser/capabilities_sync_test.go
@@ -54,7 +54,8 @@ func TestProviderSyncSemanticsDeclarations(t *testing.T) {
 			UnchangedResults: UnchangedResultMTime,
 		},
 		AgentKiro: {
-			UnchangedResults: UnchangedResultMTime,
+			UnchangedResults:                    UnchangedResultMTimeAndHash,
+			FingerprintHashRequiredForFreshness: true,
 		},
 		AgentTrae: {
 			UnchangedResults: UnchangedResultMTimeAndHash,

--- a/internal/parser/kiro.go
+++ b/internal/parser/kiro.go
@@ -31,25 +31,38 @@ type kiroMeta struct {
 // discoverLegacyJSONL finds all .jsonl session files under a Kiro
 // CLI sessions directory. Layout:
 // <sessionsDir>/<uuid>.jsonl  (with companion <uuid>.json)
-func (s kiroSourceSet) discoverLegacyJSONL(sessionsDir string) []DiscoveredFile {
+func (s kiroSourceSet) discoverLegacyJSONL(sessionsDir string) ([]DiscoveredFile, error) {
 	var files []DiscoveredFile
 	for _, dir := range []string{sessionsDir, filepath.Join(sessionsDir, "cli")} {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, fmt.Errorf("read Kiro legacy directory %s: %w", dir, err)
+			}
 			continue
 		}
 		for _, e := range entries {
 			if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
 				continue
 			}
-			files = append(files, DiscoveredFile{Path: filepath.Join(dir, e.Name()), Agent: AgentKiro})
+			path := filepath.Join(dir, e.Name())
+			if _, err := loadKiroMetaStrict(path); err != nil {
+				return nil, err
+			}
+			regular, err := kiroRegularFileUnderRootChecked(sessionsDir, path)
+			if err != nil {
+				return nil, fmt.Errorf("probe Kiro legacy transcript %s: %w", path, err)
+			}
+			if regular {
+				files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
+			}
 		}
 	}
 
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].Path < files[j].Path
 	})
-	return files
+	return files, nil
 }
 
 // legacySourceFile locates a legacy Kiro JSONL session file by its raw
@@ -81,16 +94,24 @@ func KiroSessionIDFromPath(jsonlPath string) string {
 // loadKiroMeta reads the companion .json metadata file for a
 // session JSONL file.
 func loadKiroMeta(jsonlPath string) *kiroMeta {
+	meta, _ := loadKiroMetaStrict(jsonlPath)
+	return meta
+}
+
+func loadKiroMetaStrict(jsonlPath string) (*kiroMeta, error) {
 	jsonPath := strings.TrimSuffix(jsonlPath, ".jsonl") + ".json"
 	data, err := os.ReadFile(jsonPath)
 	if err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read Kiro legacy metadata %s: %w", jsonPath, err)
 	}
 	var m kiroMeta
 	if err := json.Unmarshal(data, &m); err != nil {
-		return nil
+		return nil, fmt.Errorf("decode Kiro legacy metadata %s: %w", jsonPath, err)
 	}
-	return &m
+	return &m, nil
 }
 
 // parseLegacySession parses a Kiro CLI session from its JSONL file.
@@ -204,7 +225,10 @@ func (p *kiroProvider) parseLegacySession(
 	}
 
 	// Extract metadata from companion .json file.
-	meta := loadKiroMeta(path)
+	meta, err := loadKiroMetaStrict(path)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	sessionID := strings.TrimSuffix(
 		filepath.Base(path), ".jsonl",

--- a/internal/parser/kiro.go
+++ b/internal/parser/kiro.go
@@ -339,8 +339,10 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 		return nil, nil, nil
 	}
 	meta := kiroCurrentMeta{}
-	if data, err := os.ReadFile(filepath.Join(filepath.Dir(path), "session.json")); err == nil {
-		_ = json.Unmarshal(data, &meta)
+	if sidecar, ok := kiroCurrentSidecarPath(p.sources.roots, path); ok {
+		if data, err := os.ReadFile(sidecar); err == nil {
+			_ = json.Unmarshal(data, &meta)
+		}
 	}
 	cwd := ""
 	if len(meta.WorkspacePaths) > 0 {

--- a/internal/parser/kiro.go
+++ b/internal/parser/kiro.go
@@ -287,6 +287,7 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 	var messages []ParsedMessage
 	firstMessage := ""
 	ordinal := 0
+	var earliestMessage, latestMessage time.Time
 	for {
 		line, ok := lr.next()
 		if !ok {
@@ -297,6 +298,14 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 		}
 		payload := gjson.Get(line, "payload")
 		timestamp := kiroCurrentMessageTimestamp(gjson.Get(line, "timestamp"))
+		if !timestamp.IsZero() {
+			if earliestMessage.IsZero() || timestamp.Before(earliestMessage) {
+				earliestMessage = timestamp
+			}
+			if latestMessage.IsZero() || timestamp.After(latestMessage) {
+				latestMessage = timestamp
+			}
+		}
 		typ := payload.Get("type").Str
 		content := strings.TrimSpace(payload.Get("content").Str)
 		switch typ {
@@ -354,10 +363,16 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 	}
 	startedAt, endedAt := parseTimestamp(meta.CreatedAt), parseTimestamp(meta.LastModifiedAt)
 	if startedAt.IsZero() {
-		startedAt = info.ModTime()
+		startedAt = earliestMessage
+		if startedAt.IsZero() {
+			startedAt = info.ModTime()
+		}
 	}
 	if endedAt.IsZero() {
-		endedAt = info.ModTime()
+		endedAt = latestMessage
+		if endedAt.IsZero() {
+			endedAt = info.ModTime()
+		}
 	}
 	userCount := 0
 	for _, msg := range messages {

--- a/internal/parser/kiro.go
+++ b/internal/parser/kiro.go
@@ -296,6 +296,7 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 			continue
 		}
 		payload := gjson.Get(line, "payload")
+		timestamp := kiroCurrentMessageTimestamp(gjson.Get(line, "timestamp"))
 		typ := payload.Get("type").Str
 		content := strings.TrimSpace(payload.Get("content").Str)
 		switch typ {
@@ -310,7 +311,7 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 			if role == RoleUser && firstMessage == "" {
 				firstMessage = truncate(strings.ReplaceAll(content, "\n", " "), 300)
 			}
-			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: role, Content: content, ContentLength: len(content), Model: payload.Get("reasoningModelId").Str})
+			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: role, Content: content, Timestamp: timestamp, ContentLength: len(content), Model: payload.Get("reasoningModelId").Str})
 			ordinal++
 		case "tool_call":
 			name, id := payload.Get("toolName").Str, payload.Get("toolCallId").Str
@@ -319,7 +320,7 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 			}
 			call := ParsedToolCall{ToolUseID: id, ToolName: name, Category: NormalizeToolCategory(name), InputJSON: payload.Get("args").Raw}
 			display := kiroFormatToolCalls([]ParsedToolCall{call})
-			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: RoleAssistant, Content: display, ContentLength: len(display), HasToolUse: true, ToolCalls: []ParsedToolCall{call}})
+			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: RoleAssistant, Content: display, Timestamp: timestamp, ContentLength: len(display), HasToolUse: true, ToolCalls: []ParsedToolCall{call}})
 			ordinal++
 		case "tool_result":
 			id := payload.Get("toolCallId").Str
@@ -327,7 +328,7 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 				continue
 			}
 			raw := payload.Get("content").Raw
-			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: RoleUser, ToolResults: []ParsedToolResult{{ToolUseID: id, ContentRaw: raw, ContentLength: len(raw)}}})
+			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: RoleUser, Timestamp: timestamp, ToolResults: []ParsedToolResult{{ToolUseID: id, ContentRaw: raw, ContentLength: len(raw)}}})
 			ordinal++
 		}
 	}
@@ -363,6 +364,19 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 		}
 	}
 	return &ParsedSession{ID: "kiro:" + sessionID, Project: project, Machine: machine, Agent: AgentKiro, Cwd: cwd, FirstMessage: firstMessage, StartedAt: startedAt, EndedAt: endedAt, MessageCount: len(messages), UserMessageCount: userCount, SessionName: meta.Title, File: FileInfo{Path: path, Size: info.Size(), Mtime: info.ModTime().UnixNano()}}, messages, nil
+}
+
+func kiroCurrentMessageTimestamp(value gjson.Result) time.Time {
+	if ts := parseTimestamp(value.Str); !ts.IsZero() {
+		return ts
+	}
+	if value.Type == gjson.Number {
+		millis := value.Int()
+		if millis != 0 {
+			return time.UnixMilli(millis).UTC()
+		}
+	}
+	return time.Time{}
 }
 
 // kiroExtractText extracts concatenated text from a Kiro message's

--- a/internal/parser/kiro.go
+++ b/internal/parser/kiro.go
@@ -298,16 +298,9 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 		}
 		payload := gjson.Get(line, "payload")
 		timestamp := kiroCurrentMessageTimestamp(gjson.Get(line, "timestamp"))
-		if !timestamp.IsZero() {
-			if earliestMessage.IsZero() || timestamp.Before(earliestMessage) {
-				earliestMessage = timestamp
-			}
-			if latestMessage.IsZero() || timestamp.After(latestMessage) {
-				latestMessage = timestamp
-			}
-		}
 		typ := payload.Get("type").Str
 		content := strings.TrimSpace(payload.Get("content").Str)
+		accepted := false
 		switch typ {
 		case "user", "assistant":
 			if content == "" {
@@ -321,6 +314,7 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 				firstMessage = truncate(strings.ReplaceAll(content, "\n", " "), 300)
 			}
 			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: role, Content: content, Timestamp: timestamp, ContentLength: len(content), Model: payload.Get("reasoningModelId").Str})
+			accepted = true
 			ordinal++
 		case "tool_call":
 			name, id := payload.Get("toolName").Str, payload.Get("toolCallId").Str
@@ -330,6 +324,7 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 			call := ParsedToolCall{ToolUseID: id, ToolName: name, Category: NormalizeToolCategory(name), InputJSON: payload.Get("args").Raw}
 			display := kiroFormatToolCalls([]ParsedToolCall{call})
 			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: RoleAssistant, Content: display, Timestamp: timestamp, ContentLength: len(display), HasToolUse: true, ToolCalls: []ParsedToolCall{call}})
+			accepted = true
 			ordinal++
 		case "tool_result":
 			id := payload.Get("toolCallId").Str
@@ -338,7 +333,16 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 			}
 			raw := payload.Get("content").Raw
 			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: RoleUser, Timestamp: timestamp, ToolResults: []ParsedToolResult{{ToolUseID: id, ContentRaw: raw, ContentLength: len(raw)}}})
+			accepted = true
 			ordinal++
+		}
+		if accepted && !timestamp.IsZero() {
+			if earliestMessage.IsZero() || timestamp.Before(earliestMessage) {
+				earliestMessage = timestamp
+			}
+			if latestMessage.IsZero() || timestamp.After(latestMessage) {
+				latestMessage = timestamp
+			}
 		}
 	}
 	if err := lr.Err(); err != nil {

--- a/internal/parser/kiro.go
+++ b/internal/parser/kiro.go
@@ -32,24 +32,18 @@ type kiroMeta struct {
 // CLI sessions directory. Layout:
 // <sessionsDir>/<uuid>.jsonl  (with companion <uuid>.json)
 func (s kiroSourceSet) discoverLegacyJSONL(sessionsDir string) []DiscoveredFile {
-	entries, err := os.ReadDir(sessionsDir)
-	if err != nil {
-		return nil
-	}
-
 	var files []DiscoveredFile
-	for _, e := range entries {
-		if e.IsDir() {
+	for _, dir := range []string{sessionsDir, filepath.Join(sessionsDir, "cli")} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
 			continue
 		}
-		name := e.Name()
-		if !strings.HasSuffix(name, ".jsonl") {
-			continue
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+				continue
+			}
+			files = append(files, DiscoveredFile{Path: filepath.Join(dir, e.Name()), Agent: AgentKiro})
 		}
-		files = append(files, DiscoveredFile{
-			Path:  filepath.Join(sessionsDir, name),
-			Agent: AgentKiro,
-		})
 	}
 
 	sort.Slice(files, func(i, j int) bool {
@@ -64,14 +58,13 @@ func (s kiroSourceSet) legacySourceFile(sessionsDir, rawID string) string {
 	if sessionsDir == "" || !IsValidSessionID(rawID) {
 		return ""
 	}
-	candidate := filepath.Join(sessionsDir, rawID+".jsonl")
-	if abs, err := filepath.Abs(candidate); err != nil || !strings.HasPrefix(abs, filepath.Clean(sessionsDir)) {
-		return ""
+	for _, dir := range []string{sessionsDir, filepath.Join(sessionsDir, "cli")} {
+		candidate := filepath.Join(dir, rawID+".jsonl")
+		if _, err := os.Stat(candidate); err == nil && kiroRegularFileUnderRoot(sessionsDir, candidate) {
+			return candidate
+		}
 	}
-	if _, err := os.Stat(candidate); err != nil {
-		return ""
-	}
-	return candidate
+	return ""
 }
 
 // KiroSessionIDFromPath returns the logical raw session ID for a
@@ -267,6 +260,109 @@ func (p *kiroProvider) parseLegacySession(
 	}
 
 	return sess, messages, nil
+}
+
+type kiroCurrentMeta struct {
+	Title          string   `json:"title"`
+	CreatedAt      string   `json:"createdAt"`
+	LastModifiedAt string   `json:"lastModifiedAt"`
+	WorkspacePaths []string `json:"workspacePaths"`
+}
+
+func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*ParsedSession, []ParsedMessage, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	lr := newLineReader(f, maxLineSize)
+	defer releaseLineReader(lr)
+	var messages []ParsedMessage
+	firstMessage := ""
+	ordinal := 0
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if !gjson.Valid(line) {
+			continue
+		}
+		payload := gjson.Get(line, "payload")
+		typ := payload.Get("type").Str
+		content := strings.TrimSpace(payload.Get("content").Str)
+		switch typ {
+		case "user", "assistant":
+			if content == "" {
+				continue
+			}
+			role := RoleUser
+			if typ == "assistant" {
+				role = RoleAssistant
+			}
+			if role == RoleUser && firstMessage == "" {
+				firstMessage = truncate(strings.ReplaceAll(content, "\n", " "), 300)
+			}
+			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: role, Content: content, ContentLength: len(content), Model: payload.Get("reasoningModelId").Str})
+			ordinal++
+		case "tool_call":
+			name, id := payload.Get("toolName").Str, payload.Get("toolCallId").Str
+			if name == "" || id == "" {
+				continue
+			}
+			call := ParsedToolCall{ToolUseID: id, ToolName: name, Category: NormalizeToolCategory(name), InputJSON: payload.Get("args").Raw}
+			display := kiroFormatToolCalls([]ParsedToolCall{call})
+			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: RoleAssistant, Content: display, ContentLength: len(display), HasToolUse: true, ToolCalls: []ParsedToolCall{call}})
+			ordinal++
+		case "tool_result":
+			id := payload.Get("toolCallId").Str
+			if id == "" {
+				continue
+			}
+			raw := payload.Get("content").Raw
+			messages = append(messages, ParsedMessage{Ordinal: ordinal, Role: RoleUser, ToolResults: []ParsedToolResult{{ToolUseID: id, ContentRaw: raw, ContentLength: len(raw)}}})
+			ordinal++
+		}
+	}
+	if err := lr.Err(); err != nil {
+		return nil, nil, fmt.Errorf("reading kiro %s: %w", path, err)
+	}
+	if len(messages) == 0 {
+		return nil, nil, nil
+	}
+	meta := kiroCurrentMeta{}
+	if data, err := os.ReadFile(filepath.Join(filepath.Dir(path), "session.json")); err == nil {
+		_ = json.Unmarshal(data, &meta)
+	}
+	cwd := ""
+	if len(meta.WorkspacePaths) > 0 {
+		cwd = meta.WorkspacePaths[0]
+	}
+	project := ExtractProjectFromCwd(cwd)
+	if project == "" {
+		project = "unknown"
+	}
+	startedAt, endedAt := parseTimestamp(meta.CreatedAt), parseTimestamp(meta.LastModifiedAt)
+	if startedAt.IsZero() {
+		startedAt = info.ModTime()
+	}
+	if endedAt.IsZero() {
+		endedAt = info.ModTime()
+	}
+	userCount := 0
+	for _, msg := range messages {
+		if msg.Role == RoleUser && msg.Content != "" {
+			userCount++
+		}
+	}
+	return &ParsedSession{ID: "kiro:" + sessionID, Project: project, Machine: machine, Agent: AgentKiro, Cwd: cwd, FirstMessage: firstMessage, StartedAt: startedAt, EndedAt: endedAt, MessageCount: len(messages), UserMessageCount: userCount, SessionName: meta.Title, File: FileInfo{Path: path, Size: info.Size(), Mtime: info.ModTime().UnixNano()}}, messages, nil
 }
 
 // kiroExtractText extracts concatenated text from a Kiro message's

--- a/internal/parser/kiro.go
+++ b/internal/parser/kiro.go
@@ -353,8 +353,12 @@ func (p *kiroProvider) parseCurrentSession(path, sessionID, machine string) (*Pa
 	}
 	meta := kiroCurrentMeta{}
 	if sidecar, ok := kiroCurrentSidecarPath(p.sources.roots, path); ok {
-		if data, err := os.ReadFile(sidecar); err == nil {
-			_ = json.Unmarshal(data, &meta)
+		data, readErr := os.ReadFile(sidecar)
+		if readErr != nil {
+			return nil, nil, fmt.Errorf("read Kiro current metadata %s: %w", sidecar, readErr)
+		}
+		if unmarshalErr := json.Unmarshal(data, &meta); unmarshalErr != nil {
+			return nil, nil, fmt.Errorf("decode Kiro current metadata %s: %w", sidecar, unmarshalErr)
 		}
 	}
 	cwd := ""

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -928,6 +928,21 @@ func kiroDBUnderRoot(root, dbPath string, requireRegular bool) bool {
 	if !ok || filepath.ToSlash(rel) != kiroSQLiteDBName {
 		return false
 	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false
+	}
+	resolvedDB, err := filepath.EvalSymlinks(dbPath)
+	if err != nil {
+		if requireRegular {
+			return false
+		}
+		_, rootErr := os.Stat(root)
+		return rootErr == nil
+	}
+	if _, ok := relUnder(resolvedRoot, resolvedDB); !ok {
+		return false
+	}
 	return !requireRegular || IsRegularFile(dbPath)
 }
 
@@ -979,7 +994,6 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 		}
 		if isKiroCurrentSessionDir(entry.Name()) {
 			add("", entry.Name())
-			continue
 		}
 		if !isKiroCurrentWorkspaceDir(entry.Name()) {
 			continue
@@ -1028,7 +1042,6 @@ func (s kiroSourceSet) discoverCurrentJSONLEach(ctx context.Context, root string
 			if source, ok := s.sourceRef(root, path, false); ok {
 				return yield(source)
 			}
-			return nil
 		}
 		if !isKiroCurrentWorkspaceDir(entry.Name()) {
 			return nil

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -83,6 +83,31 @@ func (p *kiroProvider) Fingerprint(
 	return p.sources.Fingerprint(ctx, source)
 }
 
+func (p *kiroProvider) ReconciliationSourceRank(
+	source SourceRef,
+) ReconciliationSourceRank {
+	src, ok := p.sources.sourceFromRef(source)
+	if !ok {
+		return ReconciliationSourceRank{}
+	}
+	class := int64(0)
+	switch src.Kind {
+	case kiroSourceLegacyJSONL:
+		class = 1
+	case kiroSourceCurrentJSONL:
+		class = 2
+	case kiroSourceSQLiteSession:
+		class = 3
+	}
+	recency := source.DiscoveryMTimeNS
+	if recency == 0 && src.Path != "" {
+		if info, err := os.Stat(src.Path); err == nil {
+			recency = info.ModTime().UnixNano()
+		}
+	}
+	return ReconciliationSourceRank{Class: class, Recency: recency}
+}
+
 func (p *kiroProvider) PersistentArchiveSource(
 	path string, fullSessionID string,
 ) (string, bool) {
@@ -516,20 +541,6 @@ func (s kiroSourceSet) FindSource(
 	if err := ctx.Err(); err != nil {
 		return SourceRef{}, false, err
 	}
-	if req.RawSessionID != "" {
-		for _, root := range s.roots {
-			dbPath := kiroSQLiteDBPath(root)
-			if dbPath != "" && KiroSQLiteSessionExists(dbPath, req.RawSessionID) {
-				return s.newSourceRef(
-					root,
-					KiroSQLiteVirtualPath(dbPath, req.RawSessionID),
-					dbPath,
-					req.RawSessionID,
-					kiroSourceSQLiteSession,
-				), true, nil
-			}
-		}
-	}
 	for _, path := range []string{req.StoredFilePath, req.FingerprintKey} {
 		if path == "" {
 			continue
@@ -539,7 +550,9 @@ func (s kiroSourceSet) FindSource(
 				if req.RequireFreshSource && !kiroSourceExists(source) {
 					continue
 				}
-				return source, true, nil
+				if req.RawSessionID == "" {
+					return source, true, nil
+				}
 			}
 		}
 	}
@@ -547,25 +560,32 @@ func (s kiroSourceSet) FindSource(
 		return SourceRef{}, false, nil
 	}
 	for _, root := range s.roots {
-		path := s.legacySourceFile(root, req.RawSessionID)
-		if path != "" {
-			if source, ok := s.sourceRef(root, path, false); ok {
-				return source, true, nil
-			}
+		var candidates []SourceRef
+		if dbPath := kiroSQLiteDBPath(root); dbPath != "" &&
+			KiroSQLiteSessionExists(dbPath, req.RawSessionID) {
+			candidates = append(candidates, s.newSourceRef(
+				root, KiroSQLiteVirtualPath(dbPath, req.RawSessionID), dbPath,
+				req.RawSessionID, kiroSourceSQLiteSession,
+			))
 		}
-	}
-	for _, root := range s.roots {
 		if source, ok := s.findCurrentJSONL(root, req.RawSessionID); ok {
-			return source, true, nil
+			candidates = append(candidates, source)
 		}
-	}
-	for _, root := range s.roots {
-		for _, file := range s.discoverLegacyJSONL(root) {
-			if KiroSessionIDFromPath(file.Path) == req.RawSessionID {
-				if source, ok := s.sourceRef(root, file.Path, false); ok {
-					return source, true, nil
-				}
+		if path := s.legacySourceFile(root, req.RawSessionID); path != "" {
+			if source, ok := s.sourceRef(root, path, false); ok {
+				candidates = append(candidates, source)
 			}
+		}
+		for _, file := range s.discoverLegacyJSONL(root) {
+			if KiroSessionIDFromPath(file.Path) != req.RawSessionID {
+				continue
+			}
+			if source, ok := s.sourceRef(root, file.Path, false); ok {
+				candidates = append(candidates, source)
+			}
+		}
+		if source, ok := s.bestSource(candidates); ok {
+			return source, true, nil
 		}
 	}
 	return SourceRef{}, false, nil
@@ -689,12 +709,16 @@ func (s kiroSourceSet) sourceRef(
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
 	if currentPath, sessionID, ok := kiroCurrentPathUnderRoot(root, path); ok {
-		if !allowMissing && !kiroRegularFileUnderRoot(root, currentPath) {
+		if _, err := os.Lstat(currentPath); err == nil {
+			if !kiroRegularFileUnderRoot(root, currentPath) {
+				return SourceRef{}, false
+			}
+		} else if !allowMissing || !kiroEventPathUnderRoot(root, currentPath) {
 			return SourceRef{}, false
 		}
 		return s.newSourceRef(root, currentPath, "", sessionID, kiroSourceCurrentJSONL), true
 	}
-	if kiroLegacyPathUnderRoot(root, path) && IsRegularFile(path) {
+	if kiroLegacyPathUnderRoot(root, path) && kiroRegularFileUnderRoot(root, path) {
 		return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
 	}
 	if dbPath, sessionID, ok := kiroSQLiteVirtualPathParts(path); ok {
@@ -709,7 +733,7 @@ func (s kiroSourceSet) sourceRef(
 	if !kiroLegacyPathUnderRoot(root, path) {
 		return SourceRef{}, false
 	}
-	if !allowMissing && !IsRegularFile(path) {
+	if !allowMissing && !kiroRegularFileUnderRoot(root, path) {
 		return SourceRef{}, false
 	}
 	return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
@@ -722,9 +746,12 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
 	if currentPath, sessionID, ok := kiroCurrentPathForEvent(root, path); ok {
+		if !kiroEventPathUnderRoot(root, currentPath) {
+			return SourceRef{}, false
+		}
 		return s.newSourceRef(root, currentPath, "", sessionID, kiroSourceCurrentJSONL), true
 	}
-	if kiroLegacyPathUnderRoot(root, path) {
+	if kiroLegacyPathUnderRoot(root, path) && kiroEventPathUnderRoot(root, path) {
 		return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
 	}
 	if dbPath, sessionID, ok := kiroSQLiteVirtualPathParts(path); ok {
@@ -764,6 +791,11 @@ func (s kiroSourceSet) legacyPathShadowed(path string) bool {
 		if dbPath != "" && KiroSQLiteSessionExists(dbPath, legacyID) {
 			return true
 		}
+		for _, file := range s.discoverCurrentJSONL(root) {
+			if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok && id == legacyID {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -772,9 +804,15 @@ func (s kiroSourceSet) newSourceRef(
 	root, path, dbPath, sessionID string,
 	kind kiroSourceKind,
 ) SourceRef {
+	key := path
+	if kind == kiroSourceSQLiteSession || kind == kiroSourceCurrentJSONL {
+		key = sessionID
+	} else if kind == kiroSourceLegacyJSONL {
+		key = KiroSessionIDFromPath(path)
+	}
 	return SourceRef{
 		Provider:       AgentKiro,
-		Key:            path,
+		Key:            key,
 		DisplayPath:    path,
 		FingerprintKey: path,
 		Opaque: kiroSource{
@@ -785,6 +823,45 @@ func (s kiroSourceSet) newSourceRef(
 			Kind:      kind,
 		},
 	}
+}
+
+func (s kiroSourceSet) bestSource(sources []SourceRef) (SourceRef, bool) {
+	if len(sources) == 0 {
+		return SourceRef{}, false
+	}
+	best := sources[0]
+	bestRank := s.sourceRank(best)
+	for _, source := range sources[1:] {
+		rank := s.sourceRank(source)
+		if rank.Class > bestRank.Class ||
+			(rank.Class == bestRank.Class && rank.Recency > bestRank.Recency) {
+			best, bestRank = source, rank
+		}
+	}
+	return best, true
+}
+
+func (s kiroSourceSet) sourceRank(source SourceRef) ReconciliationSourceRank {
+	src, ok := s.sourceFromRef(source)
+	if !ok {
+		return ReconciliationSourceRank{}
+	}
+	class := int64(0)
+	switch src.Kind {
+	case kiroSourceLegacyJSONL:
+		class = 1
+	case kiroSourceCurrentJSONL:
+		class = 2
+	case kiroSourceSQLiteSession:
+		class = 3
+	}
+	recency := source.DiscoveryMTimeNS
+	if recency == 0 {
+		if info, err := os.Stat(src.Path); err == nil {
+			recency = info.ModTime().UnixNano()
+		}
+	}
+	return ReconciliationSourceRank{Class: class, Recency: recency}
 }
 
 func kiroDBUnderRoot(root, dbPath string, requireRegular bool) bool {
@@ -990,6 +1067,30 @@ func kiroRegularFileUnderRoot(root, path string) bool {
 	}
 	_, ok := relUnder(resolvedRoot, resolvedPath)
 	return ok
+}
+
+// kiroEventPathUnderRoot validates an event path even when the changed file
+// has already been removed; existing ancestors must resolve inside the root.
+func kiroEventPathUnderRoot(root, path string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	if _, ok := relUnder(root, path); !ok {
+		return false
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false
+	}
+	for candidate := path; ; candidate = filepath.Dir(candidate) {
+		if resolved, err := filepath.EvalSymlinks(candidate); err == nil {
+			_, ok := relUnder(resolvedRoot, resolved)
+			return ok
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			return false
+		}
+	}
 }
 
 func kiroProviderCapabilities() Capabilities {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -1082,7 +1082,9 @@ func (s kiroSourceSet) Fingerprint(
 		}
 		return fingerprint, nil
 	}
-	if src.Kind == kiroSourceCurrentJSONL {
+	sidecar := ""
+	switch src.Kind {
+	case kiroSourceCurrentJSONL:
 		if sidecar, ok := kiroCurrentSidecarPath(s.roots, src.Path); ok {
 			if sideInfo, err := os.Stat(sidecar); err == nil {
 				fingerprint.Size += sideInfo.Size()
@@ -1091,9 +1093,7 @@ func (s kiroSourceSet) Fingerprint(
 				}
 			}
 		}
-	}
-	sidecar := ""
-	if src.Kind == kiroSourceLegacyJSONL {
+	case kiroSourceLegacyJSONL:
 		candidate, found, sidecarErr := kiroLegacySidecarPath(s.roots, src.Path)
 		if sidecarErr != nil {
 			return SourceFingerprint{}, sidecarErr
@@ -1111,15 +1111,16 @@ func (s kiroSourceSet) Fingerprint(
 		}
 	}
 	hash := ""
-	if src.Kind == kiroSourceCurrentJSONL {
+	switch src.Kind {
+	case kiroSourceCurrentJSONL:
 		sidecar = ""
 		if candidate, ok := kiroCurrentSidecarPath(s.roots, src.Path); ok {
 			sidecar = candidate
 		}
 		hash, err = hashKiroJSONLSource(src.Path, sidecar)
-	} else if src.Kind == kiroSourceLegacyJSONL {
+	case kiroSourceLegacyJSONL:
 		hash, err = hashKiroJSONLSource(src.Path, sidecar)
-	} else {
+	default:
 		hash, err = hashJSONLSourceFile(src.Path)
 	}
 	if err != nil {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -347,6 +347,7 @@ type kiroSource struct {
 type kiroSourceSet struct {
 	roots     []string
 	planCache *kiroChangedPlanCache
+	readDir   func(string) ([]os.DirEntry, error)
 }
 
 type kiroChangedPlanCache struct {
@@ -360,6 +361,7 @@ func newKiroSourceSet(roots []string) kiroSourceSet {
 	return kiroSourceSet{
 		roots:     cleanJSONLRoots(roots),
 		planCache: &kiroChangedPlanCache{},
+		readDir:   os.ReadDir,
 	}
 }
 
@@ -417,7 +419,11 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 			}
 			databases = append(databases, dbSource)
 		}
-		for _, file := range s.discoverCurrentJSONL(root) {
+		currentFiles, err := s.discoverCurrentJSONL(root)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, file := range currentFiles {
 			if source, ok := s.sourceRef(root, file.Path, false); ok {
 				if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok {
 					s.setSourceMTime(&source)
@@ -589,7 +595,7 @@ func (s kiroSourceSet) SourcesForChangedPath(
 		if !ok {
 			continue
 		}
-		winners, databases, err := s.sourcePlanForChangedPath(ctx, req)
+		winners, databases, err := s.sourcePlanForChangedPath(ctx, req, source)
 		if err != nil {
 			return nil, err
 		}
@@ -623,8 +629,26 @@ func (s kiroSourceSet) SourcesForChangedPath(
 }
 
 func (s kiroSourceSet) sourcePlanForChangedPath(
-	ctx context.Context, req ChangedPathRequest,
+	ctx context.Context, req ChangedPathRequest, changed SourceRef,
 ) (map[string]SourceRef, []SourceRef, error) {
+	changedSrc, ok := s.sourceFromRef(changed)
+	if !ok {
+		return nil, nil, nil
+	}
+	if changedSrc.Kind != kiroSourceSQLiteDB {
+		id := changedSrc.SessionID
+		if id == "" {
+			id = KiroSessionIDFromPath(changedSrc.Path)
+		}
+		winner, found, err := s.sourceForSession(ctx, id, changed)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !found {
+			return map[string]SourceRef{}, nil, nil
+		}
+		return map[string]SourceRef{id: winner}, nil, nil
+	}
 	if s.planCache == nil {
 		return s.sourcePlan(ctx)
 	}
@@ -647,6 +671,69 @@ func (s kiroSourceSet) sourcePlanForChangedPath(
 	s.planCache.databases = databases
 	s.planCache.mu.Unlock()
 	return winners, databases, nil
+}
+
+func (s kiroSourceSet) sourceForSession(
+	ctx context.Context, sessionID string, changed SourceRef,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	if sessionID == "" {
+		return SourceRef{}, false, nil
+	}
+	var candidates []SourceRef
+	if changedSrc, ok := s.sourceFromRef(changed); ok &&
+		changedSrc.Kind != kiroSourceSQLiteDB && kiroSourceExists(changed) {
+		s.setSourceMTime(&changed)
+		candidates = append(candidates, changed)
+	}
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return SourceRef{}, false, err
+		}
+		dbPath, err := kiroSQLiteDBPathChecked(root)
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		if dbPath != "" {
+			meta, found, err := KiroSQLiteSessionMetaForID(dbPath, sessionID)
+			if err != nil {
+				return SourceRef{}, false, fmt.Errorf(
+					"find Kiro SQLite session %s: %w", sessionID, err,
+				)
+			}
+			if found {
+				source := s.newSourceRef(
+					root, meta.VirtualPath, dbPath, sessionID,
+					kiroSourceSQLiteSession,
+				)
+				source.DiscoveryMTimeNS = meta.FileMtime
+				candidates = append(candidates, source)
+			}
+		}
+		currentFiles, err := s.discoverCurrentJSONLForSession(root, sessionID)
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		for _, file := range currentFiles {
+			if source, ok := s.sourceRef(root, file.Path, false); ok {
+				s.setSourceMTime(&source)
+				candidates = append(candidates, source)
+			}
+		}
+		if filepath.Base(sessionID) == sessionID && sessionID != "." && sessionID != ".." {
+			for _, dir := range []string{root, filepath.Join(root, "cli")} {
+				path := filepath.Join(dir, sessionID+".jsonl")
+				if source, ok := s.sourceRef(root, path, false); ok {
+					s.setSourceMTime(&source)
+					candidates = append(candidates, source)
+				}
+			}
+		}
+	}
+	winner, found := s.bestSource(candidates)
+	return winner, found, nil
 }
 
 func kiroChangedPlanCacheKey(req ChangedPathRequest) string {
@@ -796,7 +883,11 @@ func (s kiroSourceSet) FindSource(
 				))
 			}
 		}
-		for _, file := range s.discoverCurrentJSONL(root) {
+		currentFiles, err := s.discoverCurrentJSONL(root)
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		for _, file := range currentFiles {
 			if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok &&
 				id == req.RawSessionID {
 				if source, ok := s.sourceRef(root, file.Path, false); ok {
@@ -1185,7 +1276,7 @@ func kiroLegacyPathUnderRoot(root, path string) bool {
 	return strings.HasSuffix(rel, ".jsonl")
 }
 
-func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
+func (s kiroSourceSet) discoverCurrentJSONL(root string) ([]DiscoveredFile, error) {
 	var files []DiscoveredFile
 	add := func(workspace, session string) {
 		path := filepath.Join(root, workspace, session, "messages.jsonl")
@@ -1193,9 +1284,12 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
 		}
 	}
-	entries, err := os.ReadDir(root)
+	entries, err := s.readDir(root)
 	if err != nil {
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -1208,9 +1302,12 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 			continue
 		}
 		workspace := filepath.Join(root, entry.Name())
-		children, err := os.ReadDir(workspace)
+		children, err := s.readDir(workspace)
 		if err != nil {
-			continue
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
 		}
 		for _, child := range children {
 			if child.IsDir() && isKiroCurrentSessionDir(child.Name()) {
@@ -1218,7 +1315,38 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 			}
 		}
 	}
-	return files
+	return files, nil
+}
+
+func (s kiroSourceSet) discoverCurrentJSONLForSession(
+	root, sessionID string,
+) ([]DiscoveredFile, error) {
+	if !isKiroCurrentSessionDir(sessionID) {
+		return nil, nil
+	}
+	var files []DiscoveredFile
+	add := func(workspace string) {
+		path := filepath.Join(root, workspace, sessionID, "messages.jsonl")
+		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok &&
+			kiroRegularFileUnderRoot(root, path) {
+			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
+		}
+	}
+	add("")
+	entries, err := s.readDir(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return files, nil
+		}
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !isKiroCurrentWorkspaceDir(entry.Name()) {
+			continue
+		}
+		add(entry.Name())
+	}
+	return files, nil
 }
 
 func (s kiroSourceSet) discoverCurrentJSONLEach(ctx context.Context, root string, yield func(SourceRef) error) error {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -1618,7 +1618,8 @@ func kiroProviderCapabilities() Capabilities {
 			ToolResults:  CapabilitySupported,
 		},
 		Sync: ProviderSyncSemantics{
-			UnchangedResults: UnchangedResultMTime,
+			UnchangedResults:                    UnchangedResultMTimeAndHash,
+			FingerprintHashRequiredForFreshness: true,
 		},
 	}
 }

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -1073,12 +1074,41 @@ func (s kiroSourceSet) Fingerprint(
 			}
 		}
 	}
-	hash, err := hashJSONLSourceFile(src.Path)
+	hash := ""
+	if src.Kind == kiroSourceCurrentJSONL {
+		sidecar := ""
+		if candidate, ok := kiroCurrentSidecarPath(s.roots, src.Path); ok {
+			sidecar = candidate
+		}
+		hash, err = hashKiroCurrentSource(src.Path, sidecar)
+	} else {
+		hash, err = hashJSONLSourceFile(src.Path)
+	}
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
 	fingerprint.Hash = hash
 	return fingerprint, nil
+}
+
+func hashKiroCurrentSource(transcript, sidecar string) (string, error) {
+	transcriptHash, err := hashJSONLSourceFile(transcript)
+	if err != nil {
+		return "", err
+	}
+	sidecarHash := "missing"
+	if sidecar != "" {
+		if _, err := os.Stat(sidecar); err == nil {
+			sidecarHash, err = hashJSONLSourceFile(sidecar)
+			if err != nil {
+				return "", err
+			}
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat %s: %w", sidecar, err)
+		}
+	}
+	digest := sha256.Sum256([]byte("kiro-current\x00" + transcriptHash + "\x00" + sidecarHash))
+	return fmt.Sprintf("%x", digest[:]), nil
 }
 
 func (s kiroSourceSet) sourceFromRef(source SourceRef) (kiroSource, bool) {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -219,7 +219,7 @@ func (p *kiroProvider) parseSQLiteDB(
 	if len(results) == 0 && len(sourceErrs) == 0 {
 		return ParseOutcome{
 			ResultSetComplete: true,
-			ForceReplace:      true,
+			ForceReplace:      !src.SessionIDsSet && !src.SessionIDsZeroWinner,
 			SkipReason:        SkipNoSession,
 		}, nil
 	}
@@ -227,7 +227,7 @@ func (p *kiroProvider) parseSQLiteDB(
 		Results:           results,
 		SourceErrors:      sourceErrs,
 		ResultSetComplete: true,
-		ForceReplace:      true,
+		ForceReplace:      !src.SessionIDsSet && !src.SessionIDsZeroWinner,
 	}, nil
 }
 
@@ -324,13 +324,15 @@ const (
 )
 
 type kiroSource struct {
-	Root          string
-	Path          string
-	DBPath        string
-	SessionID     string
-	Kind          kiroSourceKind
-	SessionIDs    map[string]struct{}
-	SessionIDsSet bool
+	Root                 string
+	Path                 string
+	DBPath               string
+	SessionID            string
+	Kind                 kiroSourceKind
+	SessionIDs           map[string]struct{}
+	SessionIDsSet        bool
+	SessionIDsTotal      int
+	SessionIDsZeroWinner bool
 }
 
 type kiroSourceSet struct {
@@ -373,12 +375,19 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
 			dbSource := s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB)
 			metas, err := ListKiroSQLiteSessionMeta(dbPath)
-			if err == nil {
-				for _, meta := range metas {
-					member := s.newSourceRef(root, meta.VirtualPath, dbPath, meta.SessionID, kiroSourceSQLiteSession)
-					member.DiscoveryMTimeNS = meta.FileMtime
-					candidates[meta.SessionID] = append(candidates[meta.SessionID], member)
-				}
+			if err != nil {
+				return nil, nil, fmt.Errorf("list Kiro SQLite sessions in %s: %w", dbPath, err)
+			}
+			dbSourceSrc, ok := s.sourceFromRef(dbSource)
+			if !ok {
+				return nil, nil, fmt.Errorf("Kiro SQLite source unavailable: %s", dbPath)
+			}
+			dbSourceSrc.SessionIDsTotal = len(metas)
+			dbSource.Opaque = dbSourceSrc
+			for _, meta := range metas {
+				member := s.newSourceRef(root, meta.VirtualPath, dbPath, meta.SessionID, kiroSourceSQLiteSession)
+				member.DiscoveryMTimeNS = meta.FileMtime
+				candidates[meta.SessionID] = append(candidates[meta.SessionID], member)
 			}
 			databases = append(databases, dbSource)
 		}
@@ -410,12 +419,19 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 	for i := range databases {
 		src, _ := s.sourceFromRef(databases[i])
 		src.SessionIDs = make(map[string]struct{})
-		src.SessionIDsSet = true
 		for id, winner := range winners {
 			winnerSrc, ok := s.sourceFromRef(winner)
 			if ok && winnerSrc.Kind == kiroSourceSQLiteSession && samePath(winnerSrc.DBPath, src.DBPath) {
 				src.SessionIDs[id] = struct{}{}
 			}
+		}
+		if src.SessionIDsTotal > 0 && len(src.SessionIDs) < src.SessionIDsTotal {
+			src.SessionIDsSet = true
+			src.SessionIDsZeroWinner = len(src.SessionIDs) == 0
+		} else {
+			src.SessionIDs = nil
+			src.SessionIDsSet = false
+			src.SessionIDsZeroWinner = false
 		}
 		databases[i].Opaque = src
 	}

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -440,7 +440,10 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 				}
 			}
 		}
-		legacyFiles := s.discoverLegacyJSONL(root)
+		legacyFiles, err := s.discoverLegacyJSONL(root)
+		if err != nil {
+			return nil, nil, err
+		}
 		s.indexLegacyFiles(root, legacyFiles)
 		for _, file := range legacyFiles {
 			id := KiroSessionIDFromPath(file.Path)
@@ -585,7 +588,7 @@ func (s kiroSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 		roots = append(roots, WatchRoot{
 			Path:         root,
 			Recursive:    true,
-			IncludeGlobs: []string{"*.jsonl", "messages.jsonl", "session.json", kiroSQLiteDBName, kiroSQLiteDBName + "-*"},
+			IncludeGlobs: []string{"*.jsonl", "*.json", "messages.jsonl", "session.json", kiroSQLiteDBName, kiroSQLiteDBName + "-*"},
 			DebounceKey:  string(AgentKiro) + ":root:" + root,
 		})
 	}
@@ -734,7 +737,11 @@ func (s kiroSourceSet) sourceForSession(
 				candidates = append(candidates, source)
 			}
 		}
-		for _, source := range s.legacySourcesForSession(root, sessionID, changed) {
+		legacySources, err := s.legacySourcesForSession(root, sessionID, changed)
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		for _, source := range legacySources {
 			s.setSourceMTime(&source)
 			candidates = append(candidates, source)
 		}
@@ -767,22 +774,29 @@ func (s kiroSourceSet) indexLegacyFiles(root string, files []DiscoveredFile) {
 	kiroLegacyIdentityIndex.indexed[root] = true
 }
 
-func (s kiroSourceSet) ensureLegacyIdentityIndex(root string) {
+func (s kiroSourceSet) ensureLegacyIdentityIndex(root string) error {
 	root = filepath.Clean(root)
 	kiroLegacyIdentityIndex.RLock()
 	indexed := kiroLegacyIdentityIndex.indexed[root]
 	kiroLegacyIdentityIndex.RUnlock()
 	if indexed {
-		return
+		return nil
 	}
-	s.indexLegacyFiles(root, s.discoverLegacyJSONL(root))
+	files, err := s.discoverLegacyJSONL(root)
+	if err != nil {
+		return err
+	}
+	s.indexLegacyFiles(root, files)
+	return nil
 }
 
 func (s kiroSourceSet) legacySourcesForSession(
 	root, sessionID string, changed SourceRef,
-) []SourceRef {
+) ([]SourceRef, error) {
 	root = filepath.Clean(root)
-	s.ensureLegacyIdentityIndex(root)
+	if err := s.ensureLegacyIdentityIndex(root); err != nil {
+		return nil, err
+	}
 	paths := make(map[string]struct{})
 	if changedSrc, ok := s.sourceFromRef(changed); ok &&
 		changedSrc.Kind == kiroSourceLegacyJSONL &&
@@ -808,7 +822,7 @@ func (s kiroSourceSet) legacySourcesForSession(
 			sources = append(sources, source)
 		}
 	}
-	return sources
+	return sources, nil
 }
 
 func kiroChangedPlanCacheKey(req ChangedPathRequest) string {
@@ -975,7 +989,11 @@ func (s kiroSourceSet) FindSource(
 				candidates = append(candidates, source)
 			}
 		}
-		for _, file := range s.discoverLegacyJSONL(root) {
+		legacyFiles, err := s.discoverLegacyJSONL(root)
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		for _, file := range legacyFiles {
 			if KiroSessionIDFromPath(file.Path) != req.RawSessionID {
 				continue
 			}
@@ -1074,13 +1092,33 @@ func (s kiroSourceSet) Fingerprint(
 			}
 		}
 	}
+	sidecar := ""
+	if src.Kind == kiroSourceLegacyJSONL {
+		candidate, found, sidecarErr := kiroLegacySidecarPath(s.roots, src.Path)
+		if sidecarErr != nil {
+			return SourceFingerprint{}, sidecarErr
+		}
+		if found {
+			sidecar = candidate
+			sideInfo, statErr := os.Stat(sidecar)
+			if statErr != nil {
+				return SourceFingerprint{}, fmt.Errorf("stat %s: %w", sidecar, statErr)
+			}
+			fingerprint.Size += sideInfo.Size()
+			if sideInfo.ModTime().UnixNano() > fingerprint.MTimeNS {
+				fingerprint.MTimeNS = sideInfo.ModTime().UnixNano()
+			}
+		}
+	}
 	hash := ""
 	if src.Kind == kiroSourceCurrentJSONL {
-		sidecar := ""
+		sidecar = ""
 		if candidate, ok := kiroCurrentSidecarPath(s.roots, src.Path); ok {
 			sidecar = candidate
 		}
-		hash, err = hashKiroCurrentSource(src.Path, sidecar)
+		hash, err = hashKiroJSONLSource(src.Path, sidecar)
+	} else if src.Kind == kiroSourceLegacyJSONL {
+		hash, err = hashKiroJSONLSource(src.Path, sidecar)
 	} else {
 		hash, err = hashJSONLSourceFile(src.Path)
 	}
@@ -1091,7 +1129,7 @@ func (s kiroSourceSet) Fingerprint(
 	return fingerprint, nil
 }
 
-func hashKiroCurrentSource(transcript, sidecar string) (string, error) {
+func hashKiroJSONLSource(transcript, sidecar string) (string, error) {
 	transcriptHash, err := hashJSONLSourceFile(transcript)
 	if err != nil {
 		return "", err
@@ -1199,6 +1237,12 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 		}
 		return s.newSourceRef(root, currentPath, "", sessionID, kiroSourceCurrentJSONL), true
 	}
+	if legacyPath, ok := kiroLegacyMetaPathForEvent(root, path); ok {
+		if !kiroEventPathUnderRoot(root, legacyPath) {
+			return SourceRef{}, false
+		}
+		return s.newSourceRef(root, legacyPath, "", "", kiroSourceLegacyJSONL), true
+	}
 	if kiroLegacyPathUnderRoot(root, path) && kiroEventPathUnderRoot(root, path) {
 		return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
 	}
@@ -1215,6 +1259,14 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 		return s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB), true
 	}
 	return SourceRef{}, false
+}
+
+func kiroLegacyMetaPathForEvent(root, path string) (string, bool) {
+	if filepath.Ext(path) != ".json" {
+		return "", false
+	}
+	legacyPath := strings.TrimSuffix(filepath.Clean(path), ".json") + ".jsonl"
+	return legacyPath, kiroLegacyPathUnderRoot(root, legacyPath)
 }
 
 func (s kiroSourceSet) newSourceRef(
@@ -1396,11 +1448,19 @@ func kiroLegacyPathUnderRoot(root, path string) bool {
 
 func (s kiroSourceSet) discoverCurrentJSONL(root string) ([]DiscoveredFile, error) {
 	var files []DiscoveredFile
-	add := func(workspace, session string) {
+	add := func(workspace, session string) error {
 		path := filepath.Join(root, workspace, session, "messages.jsonl")
-		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
+		if _, _, ok := kiroCurrentPathUnderRoot(root, path); !ok {
+			return nil
+		}
+		regular, err := kiroRegularFileUnderRootChecked(root, path)
+		if err != nil {
+			return fmt.Errorf("probe Kiro current transcript %s: %w", path, err)
+		}
+		if regular {
 			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
 		}
+		return nil
 	}
 	entries, err := s.readDir(root)
 	if err != nil {
@@ -1414,7 +1474,9 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) ([]DiscoveredFile, erro
 			continue
 		}
 		if isKiroCurrentSessionDir(entry.Name()) {
-			add("", entry.Name())
+			if err := add("", entry.Name()); err != nil {
+				return nil, err
+			}
 		}
 		if !isKiroCurrentWorkspaceDir(entry.Name()) {
 			continue
@@ -1429,7 +1491,9 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) ([]DiscoveredFile, erro
 		}
 		for _, child := range children {
 			if child.IsDir() && isKiroCurrentSessionDir(child.Name()) {
-				add(entry.Name(), child.Name())
+				if err := add(entry.Name(), child.Name()); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -1443,14 +1507,23 @@ func (s kiroSourceSet) discoverCurrentJSONLForSession(
 		return nil, nil
 	}
 	var files []DiscoveredFile
-	add := func(workspace string) {
+	add := func(workspace string) error {
 		path := filepath.Join(root, workspace, sessionID, "messages.jsonl")
-		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok &&
-			kiroRegularFileUnderRoot(root, path) {
+		if _, _, ok := kiroCurrentPathUnderRoot(root, path); !ok {
+			return nil
+		}
+		regular, err := kiroRegularFileUnderRootChecked(root, path)
+		if err != nil {
+			return fmt.Errorf("probe Kiro current transcript %s: %w", path, err)
+		}
+		if regular {
 			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
 		}
+		return nil
 	}
-	add("")
+	if err := add(""); err != nil {
+		return nil, err
+	}
 	entries, err := s.readDir(root)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -1462,7 +1535,9 @@ func (s kiroSourceSet) discoverCurrentJSONLForSession(
 		if !entry.IsDir() || !isKiroCurrentWorkspaceDir(entry.Name()) {
 			continue
 		}
-		add(entry.Name())
+		if err := add(entry.Name()); err != nil {
+			return nil, err
+		}
 	}
 	return files, nil
 }
@@ -1474,6 +1549,13 @@ func (s kiroSourceSet) discoverCurrentJSONLEach(ctx context.Context, root string
 		}
 		if isKiroCurrentSessionDir(entry.Name()) {
 			path := filepath.Join(root, entry.Name(), "messages.jsonl")
+			regular, err := kiroRegularFileUnderRootChecked(root, path)
+			if err != nil {
+				return fmt.Errorf("probe Kiro current transcript %s: %w", path, err)
+			}
+			if !regular {
+				return nil
+			}
 			if source, ok := s.sourceRef(root, path, false); ok {
 				return yield(source)
 			}
@@ -1487,6 +1569,13 @@ func (s kiroSourceSet) discoverCurrentJSONLEach(ctx context.Context, root string
 				return nil
 			}
 			path := filepath.Join(workspace, child.Name(), "messages.jsonl")
+			regular, err := kiroRegularFileUnderRootChecked(root, path)
+			if err != nil {
+				return fmt.Errorf("probe Kiro current transcript %s: %w", path, err)
+			}
+			if !regular {
+				return nil
+			}
 			if source, ok := s.sourceRef(root, path, false); ok {
 				return yield(source)
 			}
@@ -1502,6 +1591,16 @@ func (s kiroSourceSet) discoverLegacyJSONLEach(ctx context.Context, root string,
 				return nil
 			}
 			path := filepath.Join(dir, entry.Name())
+			regular, err := kiroRegularFileUnderRootChecked(root, path)
+			if err != nil {
+				return fmt.Errorf("probe Kiro legacy transcript %s: %w", path, err)
+			}
+			if !regular {
+				return nil
+			}
+			if _, err := loadKiroMetaStrict(path); err != nil {
+				return err
+			}
 			if source, ok := s.sourceRef(root, path, false); ok {
 				return yield(source)
 			}
@@ -1576,19 +1675,59 @@ func kiroCurrentSidecarPath(roots []string, transcript string) (string, bool) {
 }
 
 func kiroRegularFileUnderRoot(root, path string) bool {
-	if !IsRegularFile(path) {
-		return false
+	regular, _ := kiroRegularFileUnderRootChecked(root, path)
+	return regular
+}
+
+func kiroRegularFileUnderRootChecked(root, path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, nil
 	}
 	resolvedRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		return false
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
 	}
 	resolvedPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return false
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
 	}
 	_, ok := relUnder(resolvedRoot, resolvedPath)
-	return ok
+	return ok, nil
+}
+
+func kiroLegacySidecarPath(
+	roots []string, transcript string,
+) (string, bool, error) {
+	for _, root := range roots {
+		if !kiroLegacyPathUnderRoot(root, transcript) {
+			continue
+		}
+		sidecar := strings.TrimSuffix(transcript, ".jsonl") + ".json"
+		if _, err := os.Lstat(sidecar); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", false, fmt.Errorf("stat %s: %w", sidecar, err)
+		}
+		if !kiroEventPathUnderRoot(root, sidecar) {
+			continue
+		}
+		return sidecar, true, nil
+	}
+	return "", false, nil
 }
 
 // kiroEventPathUnderRoot validates an event path even when the changed file

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -454,6 +454,16 @@ func (s kiroSourceSet) SourcesForChangedPath(
 			continue
 		}
 		sources := []SourceRef{source}
+		if current, ok := s.sourceFromRef(source); ok &&
+			current.Kind == kiroSourceCurrentJSONL {
+			if dbPath := kiroSQLiteDBPath(root); dbPath != "" &&
+				KiroSQLiteSessionExists(dbPath, current.SessionID) {
+				sources = append(sources, s.newSourceRef(
+					root, KiroSQLiteVirtualPath(dbPath, current.SessionID), dbPath,
+					current.SessionID, kiroSourceSQLiteSession,
+				))
+			}
+		}
 		sources = append(
 			sources,
 			s.changedPathTombstones(root, source, req.StoredSourcePaths)...,
@@ -541,6 +551,7 @@ func (s kiroSourceSet) FindSource(
 	if err := ctx.Err(); err != nil {
 		return SourceRef{}, false, err
 	}
+	var hinted []SourceRef
 	for _, path := range []string{req.StoredFilePath, req.FingerprintKey} {
 		if path == "" {
 			continue
@@ -553,14 +564,21 @@ func (s kiroSourceSet) FindSource(
 				if req.RawSessionID == "" {
 					return source, true, nil
 				}
+				if sourceMatchesKiroSession(source, req.RawSessionID) {
+					if req.PreferStoredSource {
+						return source, true, nil
+					}
+					hinted = append(hinted, source)
+				}
 			}
 		}
 	}
 	if req.RawSessionID == "" {
 		return SourceRef{}, false, nil
 	}
+	var candidates []SourceRef
+	candidates = append(candidates, hinted...)
 	for _, root := range s.roots {
-		var candidates []SourceRef
 		if dbPath := kiroSQLiteDBPath(root); dbPath != "" &&
 			KiroSQLiteSessionExists(dbPath, req.RawSessionID) {
 			candidates = append(candidates, s.newSourceRef(
@@ -568,8 +586,13 @@ func (s kiroSourceSet) FindSource(
 				req.RawSessionID, kiroSourceSQLiteSession,
 			))
 		}
-		if source, ok := s.findCurrentJSONL(root, req.RawSessionID); ok {
-			candidates = append(candidates, source)
+		for _, file := range s.discoverCurrentJSONL(root) {
+			if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok &&
+				id == req.RawSessionID {
+				if source, ok := s.sourceRef(root, file.Path, false); ok {
+					candidates = append(candidates, source)
+				}
+			}
 		}
 		if path := s.legacySourceFile(root, req.RawSessionID); path != "" {
 			if source, ok := s.sourceRef(root, path, false); ok {
@@ -584,9 +607,9 @@ func (s kiroSourceSet) FindSource(
 				candidates = append(candidates, source)
 			}
 		}
-		if source, ok := s.bestSource(candidates); ok {
-			return source, true, nil
-		}
+	}
+	if source, ok := s.bestSource(candidates); ok {
+		return source, true, nil
 	}
 	return SourceRef{}, false, nil
 }
@@ -666,11 +689,12 @@ func (s kiroSourceSet) Fingerprint(
 		return fingerprint, nil
 	}
 	if src.Kind == kiroSourceCurrentJSONL {
-		sidecar := filepath.Join(filepath.Dir(src.Path), "session.json")
-		if sideInfo, err := os.Stat(sidecar); err == nil && !sideInfo.IsDir() {
-			fingerprint.Size += sideInfo.Size()
-			if sideInfo.ModTime().UnixNano() > fingerprint.MTimeNS {
-				fingerprint.MTimeNS = sideInfo.ModTime().UnixNano()
+		if sidecar, ok := kiroCurrentSidecarPath(s.roots, src.Path); ok {
+			if sideInfo, err := os.Stat(sidecar); err == nil {
+				fingerprint.Size += sideInfo.Size()
+				if sideInfo.ModTime().UnixNano() > fingerprint.MTimeNS {
+					fingerprint.MTimeNS = sideInfo.ModTime().UnixNano()
+				}
 			}
 		}
 	}
@@ -746,6 +770,11 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
 	if currentPath, sessionID, ok := kiroCurrentPathForEvent(root, path); ok {
+		if filepath.Base(path) == "session.json" {
+			if _, err := os.Lstat(path); err == nil && !kiroRegularFileUnderRoot(root, path) {
+				return SourceRef{}, false
+			}
+		}
 		if !kiroEventPathUnderRoot(root, currentPath) {
 			return SourceRef{}, false
 		}
@@ -812,6 +841,7 @@ func (s kiroSourceSet) newSourceRef(
 	}
 	return SourceRef{
 		Provider:       AgentKiro,
+		ConfiguredRoot: root,
 		Key:            key,
 		DisplayPath:    path,
 		FingerprintKey: path,
@@ -825,6 +855,22 @@ func (s kiroSourceSet) newSourceRef(
 	}
 }
 
+func sourceMatchesKiroSession(source SourceRef, rawID string) bool {
+	src, ok := source.Opaque.(kiroSource)
+	if !ok {
+		if ptr, ptrOK := source.Opaque.(*kiroSource); ptrOK && ptr != nil {
+			src, ok = *ptr, true
+		}
+	}
+	if !ok {
+		return false
+	}
+	if src.SessionID != "" {
+		return src.SessionID == rawID
+	}
+	return KiroSessionIDFromPath(src.Path) == rawID
+}
+
 func (s kiroSourceSet) bestSource(sources []SourceRef) (SourceRef, bool) {
 	if len(sources) == 0 {
 		return SourceRef{}, false
@@ -833,12 +879,23 @@ func (s kiroSourceSet) bestSource(sources []SourceRef) (SourceRef, bool) {
 	bestRank := s.sourceRank(best)
 	for _, source := range sources[1:] {
 		rank := s.sourceRank(source)
-		if rank.Class > bestRank.Class ||
-			(rank.Class == bestRank.Class && rank.Recency > bestRank.Recency) {
+		bestRoot, sourceRoot := s.rootIndex(best.ConfiguredRoot), s.rootIndex(source.ConfiguredRoot)
+		if sourceRoot < bestRoot ||
+			(sourceRoot == bestRoot && (rank.Class > bestRank.Class ||
+				(rank.Class == bestRank.Class && rank.Recency > bestRank.Recency))) {
 			best, bestRank = source, rank
 		}
 	}
 	return best, true
+}
+
+func (s kiroSourceSet) rootIndex(root string) int {
+	for i, configured := range s.roots {
+		if samePath(configured, root) {
+			return i
+		}
+	}
+	return len(s.roots)
 }
 
 func (s kiroSourceSet) sourceRank(source SourceRef) ReconciliationSourceRank {
@@ -1051,6 +1108,20 @@ func kiroCurrentPathForEvent(root, path string) (string, string, bool) {
 		return "", "", false
 	}
 	return filepath.Join(filepath.Dir(path), "messages.jsonl"), session, true
+}
+
+func kiroCurrentSidecarPath(roots []string, transcript string) (string, bool) {
+	for _, root := range roots {
+		current, _, ok := kiroCurrentPathUnderRoot(root, transcript)
+		if !ok || !samePath(current, transcript) {
+			continue
+		}
+		sidecar := filepath.Join(filepath.Dir(transcript), "session.json")
+		if kiroRegularFileUnderRoot(root, sidecar) {
+			return sidecar, true
+		}
+	}
+	return "", false
 }
 
 func kiroRegularFileUnderRoot(root, path string) bool {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -393,7 +393,11 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
+		dbPath, dbPathErr := kiroSQLiteDBPathChecked(root)
+		if dbPathErr != nil {
+			return nil, nil, dbPathErr
+		}
+		if dbPath != "" {
 			dbSource := s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB)
 			metas, err := ListKiroSQLiteSessionMeta(dbPath)
 			if err != nil {
@@ -476,12 +480,42 @@ func (s kiroSourceSet) setSourceMTime(source *SourceRef) {
 }
 
 func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		dbPath, err := kiroSQLiteDBPathChecked(root)
+		if err != nil {
+			return err
+		}
+		if dbPath == "" {
+			continue
+		}
+		store, err := OpenKiroSQLiteStore(dbPath)
+		if err != nil {
+			return err
+		}
+		listErr := store.ForEachSessionMeta(ctx, func(KiroSQLiteSessionMeta) error {
+			return nil
+		})
+		closeErr := store.Close()
+		if listErr != nil {
+			return listErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+	}
 	var firstErr error
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
+		dbPath, dbPathErr := kiroSQLiteDBPathChecked(root)
+		if dbPathErr != nil {
+			return dbPathErr
+		}
+		if dbPath != "" {
 			store, err := OpenKiroSQLiteStore(dbPath)
 			if err != nil {
 				if firstErr == nil {
@@ -512,10 +546,16 @@ func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) e
 			}
 		}
 		if err := s.discoverLegacyJSONLEach(ctx, root, yield); err != nil {
-			return err
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
 		}
 		if err := s.discoverCurrentJSONLEach(ctx, root, yield); err != nil {
-			return err
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
 		}
 	}
 	return firstErr
@@ -738,7 +778,11 @@ func (s kiroSourceSet) FindSource(
 	var candidates []SourceRef
 	candidates = append(candidates, hinted...)
 	for _, root := range s.roots {
-		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
+		dbPath, dbPathErr := kiroSQLiteDBPathChecked(root)
+		if dbPathErr != nil {
+			return SourceRef{}, false, dbPathErr
+		}
+		if dbPath != "" {
 			exists, err := KiroSQLiteSessionExistsWithError(dbPath, req.RawSessionID)
 			if err != nil {
 				return SourceRef{}, false, fmt.Errorf(

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -963,8 +963,14 @@ func kiroLegacyPathUnderRoot(root, path string) bool {
 
 func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 	var files []DiscoveredFile
-	add := func(workspace, session string) {
-		path := filepath.Join(root, workspace, session, "messages.jsonl")
+	add := func(session string) {
+		path := filepath.Join(root, session, "messages.jsonl")
+		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
+			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
+		}
+	}
+	addWorkspace := func(session string) {
+		path := filepath.Join(root, kiroCurrentWorkspaceDir, session, "messages.jsonl")
 		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
 			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
 		}
@@ -978,16 +984,15 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 			continue
 		}
 		if isKiroCurrentSessionDir(entry.Name()) {
-			add("", entry.Name())
-			continue
+			add(entry.Name())
 		}
-		children, err := os.ReadDir(filepath.Join(root, entry.Name()))
-		if err != nil {
-			continue
-		}
+	}
+	workspace := filepath.Join(root, kiroCurrentWorkspaceDir)
+	children, err := os.ReadDir(workspace)
+	if err == nil {
 		for _, child := range children {
 			if child.IsDir() && isKiroCurrentSessionDir(child.Name()) {
-				add(entry.Name(), child.Name())
+				addWorkspace(child.Name())
 			}
 		}
 	}
@@ -998,26 +1003,12 @@ func (s kiroSourceSet) findCurrentJSONL(root, sessionID string) (SourceRef, bool
 	if !isKiroCurrentSessionDir(sessionID) {
 		return SourceRef{}, false
 	}
-	for _, workspace := range []string{"", "*"} {
-		if workspace == "" {
-			path := filepath.Join(root, sessionID, "messages.jsonl")
-			if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
-				return s.newSourceRef(root, path, "", sessionID, kiroSourceCurrentJSONL), true
-			}
-			continue
-		}
-		entries, err := os.ReadDir(root)
-		if err != nil {
-			return SourceRef{}, false
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			path := filepath.Join(root, entry.Name(), sessionID, "messages.jsonl")
-			if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
-				return s.newSourceRef(root, path, "", sessionID, kiroSourceCurrentJSONL), true
-			}
+	for _, path := range []string{
+		filepath.Join(root, sessionID, "messages.jsonl"),
+		filepath.Join(root, kiroCurrentWorkspaceDir, sessionID, "messages.jsonl"),
+	} {
+		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
+			return s.newSourceRef(root, path, "", sessionID, kiroSourceCurrentJSONL), true
 		}
 	}
 	return SourceRef{}, false
@@ -1035,7 +1026,10 @@ func (s kiroSourceSet) discoverCurrentJSONLEach(ctx context.Context, root string
 			}
 			return nil
 		}
-		workspace := filepath.Join(root, entry.Name())
+		if entry.Name() != kiroCurrentWorkspaceDir {
+			return nil
+		}
+		workspace := filepath.Join(root, kiroCurrentWorkspaceDir)
 		return streamDirectoryEntries(ctx, workspace, func(child os.DirEntry) error {
 			if !child.IsDir() || !isKiroCurrentSessionDir(child.Name()) {
 				return nil
@@ -1075,6 +1069,8 @@ func isKiroCurrentSessionDir(name string) bool {
 	return strings.HasPrefix(name, "sess_") && IsValidSessionID(id)
 }
 
+const kiroCurrentWorkspaceDir = "workspace"
+
 func kiroCurrentPathUnderRoot(root, path string) (string, string, bool) {
 	rel, ok := relUnder(filepath.Clean(root), filepath.Clean(path))
 	if !ok {
@@ -1082,6 +1078,9 @@ func kiroCurrentPathUnderRoot(root, path string) (string, string, bool) {
 	}
 	parts := strings.Split(filepath.ToSlash(rel), "/")
 	if (len(parts) != 2 && len(parts) != 3) || parts[len(parts)-1] != "messages.jsonl" {
+		return "", "", false
+	}
+	if len(parts) == 3 && parts[0] != kiroCurrentWorkspaceDir {
 		return "", "", false
 	}
 	session := parts[len(parts)-2]

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -357,6 +358,15 @@ type kiroChangedPlanCache struct {
 	databases []SourceRef
 }
 
+var kiroLegacyIdentityIndex = struct {
+	sync.RWMutex
+	roots   map[string]map[string]map[string]struct{}
+	indexed map[string]bool
+}{
+	roots:   make(map[string]map[string]map[string]struct{}),
+	indexed: make(map[string]bool),
+}
+
 func newKiroSourceSet(roots []string) kiroSourceSet {
 	return kiroSourceSet{
 		roots:     cleanJSONLRoots(roots),
@@ -390,7 +400,6 @@ func (s kiroSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []SourceRef, error) {
 	candidates := make(map[string][]SourceRef)
 	databases := make([]SourceRef, 0)
-	databaseMetas := make(map[string][]KiroSQLiteSessionMeta)
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
@@ -411,7 +420,6 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 			}
 			dbSourceSrc.SessionIDsTotal = len(metas)
 			dbSource.Opaque = dbSourceSrc
-			databaseMetas[dbPath] = metas
 			for _, meta := range metas {
 				member := s.newSourceRef(root, meta.VirtualPath, dbPath, meta.SessionID, kiroSourceSQLiteSession)
 				member.DiscoveryMTimeNS = meta.FileMtime
@@ -431,7 +439,9 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 				}
 			}
 		}
-		for _, file := range s.discoverLegacyJSONL(root) {
+		legacyFiles := s.discoverLegacyJSONL(root)
+		s.indexLegacyFiles(root, legacyFiles)
+		for _, file := range legacyFiles {
 			id := KiroSessionIDFromPath(file.Path)
 			if id == "" {
 				continue
@@ -451,23 +461,24 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 	for i := range databases {
 		src, _ := s.sourceFromRef(databases[i])
 		src.SessionIDs = make(map[string]struct{})
+		src.PreservedIDs = nil
 		for id, winner := range winners {
 			winnerSrc, ok := s.sourceFromRef(winner)
-			if ok && winnerSrc.Kind == kiroSourceSQLiteSession && samePath(winnerSrc.DBPath, src.DBPath) {
-				src.SessionIDs[id] = struct{}{}
+			if !ok {
+				continue
 			}
+			if winnerSrc.Kind == kiroSourceSQLiteSession && samePath(winnerSrc.DBPath, src.DBPath) {
+				src.SessionIDs[id] = struct{}{}
+				continue
+			}
+			src.PreservedIDs = append(src.PreservedIDs, "kiro:"+id)
 		}
+		sort.Strings(src.PreservedIDs)
 		if src.SessionIDsTotal > 0 && len(src.SessionIDs) < src.SessionIDsTotal {
 			src.SessionIDsSet = true
-			for _, meta := range databaseMetas[src.DBPath] {
-				if _, ok := src.SessionIDs[meta.SessionID]; !ok {
-					src.PreservedIDs = append(src.PreservedIDs, "kiro:"+meta.SessionID)
-				}
-			}
 		} else {
 			src.SessionIDs = nil
 			src.SessionIDsSet = false
-			src.PreservedIDs = nil
 		}
 		databases[i].Opaque = src
 	}
@@ -722,18 +733,81 @@ func (s kiroSourceSet) sourceForSession(
 				candidates = append(candidates, source)
 			}
 		}
-		if filepath.Base(sessionID) == sessionID && sessionID != "." && sessionID != ".." {
-			for _, dir := range []string{root, filepath.Join(root, "cli")} {
-				path := filepath.Join(dir, sessionID+".jsonl")
-				if source, ok := s.sourceRef(root, path, false); ok {
-					s.setSourceMTime(&source)
-					candidates = append(candidates, source)
-				}
-			}
+		for _, source := range s.legacySourcesForSession(root, sessionID, changed) {
+			s.setSourceMTime(&source)
+			candidates = append(candidates, source)
 		}
 	}
 	winner, found := s.bestSource(candidates)
 	return winner, found, nil
+}
+
+func (s kiroSourceSet) indexLegacyFiles(root string, files []DiscoveredFile) {
+	root = filepath.Clean(root)
+	kiroLegacyIdentityIndex.Lock()
+	defer kiroLegacyIdentityIndex.Unlock()
+	bySession := kiroLegacyIdentityIndex.roots[root]
+	if bySession == nil {
+		bySession = make(map[string]map[string]struct{})
+		kiroLegacyIdentityIndex.roots[root] = bySession
+	}
+	for _, file := range files {
+		id := KiroSessionIDFromPath(file.Path)
+		if id == "" {
+			continue
+		}
+		paths := bySession[id]
+		if paths == nil {
+			paths = make(map[string]struct{})
+			bySession[id] = paths
+		}
+		paths[filepath.Clean(file.Path)] = struct{}{}
+	}
+	kiroLegacyIdentityIndex.indexed[root] = true
+}
+
+func (s kiroSourceSet) ensureLegacyIdentityIndex(root string) {
+	root = filepath.Clean(root)
+	kiroLegacyIdentityIndex.RLock()
+	indexed := kiroLegacyIdentityIndex.indexed[root]
+	kiroLegacyIdentityIndex.RUnlock()
+	if indexed {
+		return
+	}
+	s.indexLegacyFiles(root, s.discoverLegacyJSONL(root))
+}
+
+func (s kiroSourceSet) legacySourcesForSession(
+	root, sessionID string, changed SourceRef,
+) []SourceRef {
+	root = filepath.Clean(root)
+	s.ensureLegacyIdentityIndex(root)
+	paths := make(map[string]struct{})
+	if changedSrc, ok := s.sourceFromRef(changed); ok &&
+		changedSrc.Kind == kiroSourceLegacyJSONL &&
+		samePath(changedSrc.Root, root) &&
+		kiroSourceExists(changed) &&
+		KiroSessionIDFromPath(changedSrc.Path) == sessionID {
+		paths[filepath.Clean(changedSrc.Path)] = struct{}{}
+		s.indexLegacyFiles(root, []DiscoveredFile{{
+			Path: changedSrc.Path, Agent: AgentKiro,
+		}})
+	}
+	kiroLegacyIdentityIndex.RLock()
+	for path := range kiroLegacyIdentityIndex.roots[root][sessionID] {
+		paths[path] = struct{}{}
+	}
+	kiroLegacyIdentityIndex.RUnlock()
+	sources := make([]SourceRef, 0, len(paths))
+	for path := range paths {
+		if KiroSessionIDFromPath(path) != sessionID {
+			continue
+		}
+		if source, ok := s.sourceRef(root, path, false); ok {
+			sources = append(sources, source)
+		}
+	}
+	return sources
 }
 
 func kiroChangedPlanCacheKey(req ChangedPathRequest) string {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -397,8 +397,7 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 			dbSource := s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB)
 			metas, err := ListKiroSQLiteSessionMeta(dbPath)
 			if err != nil {
-				databases = append(databases, dbSource)
-				continue
+				return nil, nil, fmt.Errorf("list Kiro SQLite sessions in %s: %w", dbPath, err)
 			}
 			dbSourceSrc, ok := s.sourceFromRef(dbSource)
 			if !ok {
@@ -477,6 +476,7 @@ func (s kiroSourceSet) setSourceMTime(source *SourceRef) {
 }
 
 func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	var firstErr error
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -484,7 +484,10 @@ func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) e
 		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
 			store, err := OpenKiroSQLiteStore(dbPath)
 			if err != nil {
-				return err
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
 			}
 			err = store.ForEachSessionMeta(ctx, func(meta KiroSQLiteSessionMeta) error {
 				source := s.newSourceRef(
@@ -496,10 +499,16 @@ func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) e
 			})
 			closeErr := store.Close()
 			if err != nil {
-				return err
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
 			}
 			if closeErr != nil {
-				return closeErr
+				if firstErr == nil {
+					firstErr = closeErr
+				}
+				continue
 			}
 		}
 		if err := s.discoverLegacyJSONLEach(ctx, root, yield); err != nil {
@@ -509,7 +518,7 @@ func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) e
 			return err
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func (s kiroSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
@@ -563,7 +572,11 @@ func (s kiroSourceSet) SourcesForChangedPath(
 				sources = append(sources, winner)
 			}
 		}
-		sources = append(sources, s.changedPathTombstones(root, source, req.StoredSourcePaths, winners)...)
+		tombstones, err := s.changedPathTombstones(root, source, req.StoredSourcePaths, winners)
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, tombstones...)
 		return sources, nil
 	}
 	return nil, nil
@@ -648,10 +661,10 @@ func (s kiroSourceSet) changedPathTombstones(
 	changed SourceRef,
 	storedPaths []string,
 	winners map[string]SourceRef,
-) []SourceRef {
+) ([]SourceRef, error) {
 	src, ok := s.sourceFromRef(changed)
 	if !ok || src.Kind != kiroSourceSQLiteDB || !IsRegularFile(src.DBPath) {
-		return nil
+		return nil, nil
 	}
 	var tombstones []SourceRef
 	seen := make(map[string]struct{})
@@ -667,7 +680,11 @@ func (s kiroSourceSet) changedPathTombstones(
 		if !samePath(member.DBPath, src.DBPath) {
 			continue
 		}
-		if KiroSQLiteSessionExists(member.DBPath, member.SessionID) {
+		exists, err := KiroSQLiteSessionExistsWithError(member.DBPath, member.SessionID)
+		if err != nil {
+			return nil, fmt.Errorf("check Kiro SQLite session %s: %w", member.SessionID, err)
+		}
+		if exists {
 			continue
 		}
 		if winner, ok := winners[member.SessionID]; ok {
@@ -683,7 +700,7 @@ func (s kiroSourceSet) changedPathTombstones(
 		seen[member.Path] = struct{}{}
 		tombstones = append(tombstones, ref)
 	}
-	return tombstones
+	return tombstones, nil
 }
 
 func (s kiroSourceSet) FindSource(
@@ -721,12 +738,19 @@ func (s kiroSourceSet) FindSource(
 	var candidates []SourceRef
 	candidates = append(candidates, hinted...)
 	for _, root := range s.roots {
-		if dbPath := kiroSQLiteDBPath(root); dbPath != "" &&
-			KiroSQLiteSessionExists(dbPath, req.RawSessionID) {
-			candidates = append(candidates, s.newSourceRef(
-				root, KiroSQLiteVirtualPath(dbPath, req.RawSessionID), dbPath,
-				req.RawSessionID, kiroSourceSQLiteSession,
-			))
+		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
+			exists, err := KiroSQLiteSessionExistsWithError(dbPath, req.RawSessionID)
+			if err != nil {
+				return SourceRef{}, false, fmt.Errorf(
+					"find Kiro SQLite session %s: %w", req.RawSessionID, err,
+				)
+			}
+			if exists {
+				candidates = append(candidates, s.newSourceRef(
+					root, KiroSQLiteVirtualPath(dbPath, req.RawSessionID), dbPath,
+					req.RawSessionID, kiroSourceSQLiteSession,
+				))
+			}
 		}
 		for _, file := range s.discoverCurrentJSONL(root) {
 			if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok &&

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -790,6 +790,9 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 		return s.newSourceRef(root, path, dbPath, sessionID, kiroSourceSQLiteSession), true
 	}
 	if dbPath, ok := kiroDBPathForEvent(root, path); ok {
+		if !kiroDBUnderRoot(root, dbPath, false) {
+			return SourceRef{}, false
+		}
 		return s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB), true
 	}
 	return SourceRef{}, false
@@ -880,9 +883,9 @@ func (s kiroSourceSet) bestSource(sources []SourceRef) (SourceRef, bool) {
 	for _, source := range sources[1:] {
 		rank := s.sourceRank(source)
 		bestRoot, sourceRoot := s.rootIndex(best.ConfiguredRoot), s.rootIndex(source.ConfiguredRoot)
-		if sourceRoot < bestRoot ||
-			(sourceRoot == bestRoot && (rank.Class > bestRank.Class ||
-				(rank.Class == bestRank.Class && rank.Recency > bestRank.Recency))) {
+		if rank.Class > bestRank.Class ||
+			(rank.Class == bestRank.Class && (sourceRoot < bestRoot ||
+				(sourceRoot == bestRoot && rank.Recency > bestRank.Recency))) {
 			best, bestRank = source, rank
 		}
 	}

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -118,9 +118,36 @@ func (p *kiroProvider) Parse(
 		return p.parseSQLiteDB(ctx, src, machine)
 	case kiroSourceSQLiteSession:
 		return p.parseSQLiteSession(src, machine, req.Fingerprint)
+	case kiroSourceCurrentJSONL:
+		return p.parseCurrentJSONL(src, machine, req.Fingerprint)
 	default:
 		return p.parseLegacyJSONL(src, machine, req.Fingerprint)
 	}
+}
+
+func (p *kiroProvider) parseCurrentJSONL(
+	src kiroSource, machine string, fingerprint SourceFingerprint,
+) (ParseOutcome, error) {
+	sess, msgs, err := p.parseCurrentSession(src.Path, src.SessionID, machine)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if sess == nil {
+		return ParseOutcome{ResultSetComplete: true, SkipReason: SkipNoSession}, nil
+	}
+	if fingerprint.Size > 0 {
+		sess.File.Size = fingerprint.Size
+	}
+	if fingerprint.MTimeNS > 0 {
+		sess.File.Mtime = fingerprint.MTimeNS
+	}
+	if fingerprint.Hash != "" {
+		sess.File.Hash = fingerprint.Hash
+	}
+	return ParseOutcome{Results: []ParseResultOutcome{{
+		Result:      ParseResult{Session: *sess, Messages: msgs},
+		DataVersion: DataVersionCurrent,
+	}}, ResultSetComplete: true}, nil
 }
 
 func (p *kiroProvider) parseSQLiteDB(
@@ -288,6 +315,7 @@ const (
 	kiroSourceLegacyJSONL kiroSourceKind = iota
 	kiroSourceSQLiteDB
 	kiroSourceSQLiteSession
+	kiroSourceCurrentJSONL
 )
 
 type kiroSource struct {
@@ -326,6 +354,11 @@ func (s kiroSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 				addJSONLSource(source, &sources, seen)
 			}
 		}
+		for _, file := range s.discoverCurrentJSONL(root) {
+			if source, ok := s.sourceRef(root, file.Path, false); ok {
+				addJSONLSource(source, &sources, seen)
+			}
+		}
 	}
 	sortJSONLSources(sources)
 	return sources, nil
@@ -357,19 +390,10 @@ func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) e
 				return closeErr
 			}
 		}
-		if err := streamDirectoryEntries(ctx, root, func(entry os.DirEntry) error {
-			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
-				return nil
-			}
-			path := filepath.Join(root, entry.Name())
-			if s.legacyPathShadowed(path) {
-				return nil
-			}
-			if source, ok := s.sourceRef(root, path, false); ok {
-				return yield(source)
-			}
-			return nil
-		}); err != nil {
+		if err := s.discoverLegacyJSONLEach(ctx, root, yield); err != nil {
+			return err
+		}
+		if err := s.discoverCurrentJSONLEach(ctx, root, yield); err != nil {
 			return err
 		}
 	}
@@ -381,8 +405,8 @@ func (s kiroSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 	for _, root := range s.roots {
 		roots = append(roots, WatchRoot{
 			Path:         root,
-			Recursive:    false,
-			IncludeGlobs: []string{"*.jsonl", kiroSQLiteDBName, kiroSQLiteDBName + "-*"},
+			Recursive:    true,
+			IncludeGlobs: []string{"*.jsonl", "messages.jsonl", "session.json", kiroSQLiteDBName, kiroSQLiteDBName + "-*"},
 			DebounceKey:  string(AgentKiro) + ":root:" + root,
 		})
 	}
@@ -435,6 +459,8 @@ func (s kiroSourceSet) StoredSourceHintScopes(
 				Path: src.DBPath, IncludeVirtualMembers: true,
 			}}
 		case kiroSourceSQLiteSession, kiroSourceLegacyJSONL:
+			return []StoredSourceHintScope{{Path: src.Path}}
+		case kiroSourceCurrentJSONL:
 			return []StoredSourceHintScope{{Path: src.Path}}
 		}
 		return nil
@@ -528,15 +554,18 @@ func (s kiroSourceSet) FindSource(
 			}
 		}
 	}
-	sources, err := s.Discover(ctx)
-	if err != nil {
-		return SourceRef{}, false, err
-	}
-	for _, source := range sources {
-		src := source.Opaque.(kiroSource)
-		if src.Kind == kiroSourceLegacyJSONL &&
-			KiroSessionIDFromPath(src.Path) == req.RawSessionID {
+	for _, root := range s.roots {
+		if source, ok := s.findCurrentJSONL(root, req.RawSessionID); ok {
 			return source, true, nil
+		}
+	}
+	for _, root := range s.roots {
+		for _, file := range s.discoverLegacyJSONL(root) {
+			if KiroSessionIDFromPath(file.Path) == req.RawSessionID {
+				if source, ok := s.sourceRef(root, file.Path, false); ok {
+					return source, true, nil
+				}
+			}
 		}
 	}
 	return SourceRef{}, false, nil
@@ -616,6 +645,15 @@ func (s kiroSourceSet) Fingerprint(
 		}
 		return fingerprint, nil
 	}
+	if src.Kind == kiroSourceCurrentJSONL {
+		sidecar := filepath.Join(filepath.Dir(src.Path), "session.json")
+		if sideInfo, err := os.Stat(sidecar); err == nil && !sideInfo.IsDir() {
+			fingerprint.Size += sideInfo.Size()
+			if sideInfo.ModTime().UnixNano() > fingerprint.MTimeNS {
+				fingerprint.MTimeNS = sideInfo.ModTime().UnixNano()
+			}
+		}
+	}
 	hash, err := hashJSONLSourceFile(src.Path)
 	if err != nil {
 		return SourceFingerprint{}, err
@@ -650,6 +688,12 @@ func (s kiroSourceSet) sourceRef(
 ) (SourceRef, bool) {
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
+	if currentPath, sessionID, ok := kiroCurrentPathUnderRoot(root, path); ok {
+		if !allowMissing && !kiroRegularFileUnderRoot(root, currentPath) {
+			return SourceRef{}, false
+		}
+		return s.newSourceRef(root, currentPath, "", sessionID, kiroSourceCurrentJSONL), true
+	}
 	if kiroLegacyPathUnderRoot(root, path) && IsRegularFile(path) {
 		return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
 	}
@@ -677,6 +721,9 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 	}
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
+	if currentPath, sessionID, ok := kiroCurrentPathForEvent(root, path); ok {
+		return s.newSourceRef(root, currentPath, "", sessionID, kiroSourceCurrentJSONL), true
+	}
 	if kiroLegacyPathUnderRoot(root, path) {
 		return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
 	}
@@ -697,6 +744,11 @@ func (s kiroSourceSet) currentSessionIDs() map[string]struct{} {
 	for _, root := range s.roots {
 		for id := range KiroSQLiteSessionIDs(root) {
 			ids[id] = struct{}{}
+		}
+		for _, file := range s.discoverCurrentJSONL(root) {
+			if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok {
+				ids[id] = struct{}{}
+			}
 		}
 	}
 	return ids
@@ -765,10 +817,179 @@ func kiroLegacyPathUnderRoot(root, path string) bool {
 	if !ok {
 		return false
 	}
-	if strings.Contains(rel, string(filepath.Separator)) {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) == 2 && parts[0] != "cli" {
+		return false
+	}
+	if len(parts) > 2 {
 		return false
 	}
 	return strings.HasSuffix(rel, ".jsonl")
+}
+
+func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
+	var files []DiscoveredFile
+	add := func(workspace, session string) {
+		path := filepath.Join(root, workspace, session, "messages.jsonl")
+		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
+			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
+		}
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if isKiroCurrentSessionDir(entry.Name()) {
+			add("", entry.Name())
+			continue
+		}
+		children, err := os.ReadDir(filepath.Join(root, entry.Name()))
+		if err != nil {
+			continue
+		}
+		for _, child := range children {
+			if child.IsDir() && isKiroCurrentSessionDir(child.Name()) {
+				add(entry.Name(), child.Name())
+			}
+		}
+	}
+	return files
+}
+
+func (s kiroSourceSet) findCurrentJSONL(root, sessionID string) (SourceRef, bool) {
+	if !isKiroCurrentSessionDir(sessionID) {
+		return SourceRef{}, false
+	}
+	for _, workspace := range []string{"", "*"} {
+		if workspace == "" {
+			path := filepath.Join(root, sessionID, "messages.jsonl")
+			if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
+				return s.newSourceRef(root, path, "", sessionID, kiroSourceCurrentJSONL), true
+			}
+			continue
+		}
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			return SourceRef{}, false
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			path := filepath.Join(root, entry.Name(), sessionID, "messages.jsonl")
+			if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
+				return s.newSourceRef(root, path, "", sessionID, kiroSourceCurrentJSONL), true
+			}
+		}
+	}
+	return SourceRef{}, false
+}
+
+func (s kiroSourceSet) discoverCurrentJSONLEach(ctx context.Context, root string, yield func(SourceRef) error) error {
+	return streamDirectoryEntries(ctx, root, func(entry os.DirEntry) error {
+		if !entry.IsDir() {
+			return nil
+		}
+		if isKiroCurrentSessionDir(entry.Name()) {
+			path := filepath.Join(root, entry.Name(), "messages.jsonl")
+			if source, ok := s.sourceRef(root, path, false); ok {
+				return yield(source)
+			}
+			return nil
+		}
+		workspace := filepath.Join(root, entry.Name())
+		return streamDirectoryEntries(ctx, workspace, func(child os.DirEntry) error {
+			if !child.IsDir() || !isKiroCurrentSessionDir(child.Name()) {
+				return nil
+			}
+			path := filepath.Join(workspace, child.Name(), "messages.jsonl")
+			if source, ok := s.sourceRef(root, path, false); ok {
+				return yield(source)
+			}
+			return nil
+		})
+	})
+}
+
+func (s kiroSourceSet) discoverLegacyJSONLEach(ctx context.Context, root string, yield func(SourceRef) error) error {
+	for _, dir := range []string{root, filepath.Join(root, "cli")} {
+		if err := streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+				return nil
+			}
+			path := filepath.Join(dir, entry.Name())
+			if s.legacyPathShadowed(path) {
+				return nil
+			}
+			if source, ok := s.sourceRef(root, path, false); ok {
+				return yield(source)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isKiroCurrentSessionDir(name string) bool {
+	id := strings.TrimPrefix(name, "sess_")
+	return strings.HasPrefix(name, "sess_") && IsValidSessionID(id)
+}
+
+func kiroCurrentPathUnderRoot(root, path string) (string, string, bool) {
+	rel, ok := relUnder(filepath.Clean(root), filepath.Clean(path))
+	if !ok {
+		return "", "", false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if (len(parts) != 2 && len(parts) != 3) || parts[len(parts)-1] != "messages.jsonl" {
+		return "", "", false
+	}
+	session := parts[len(parts)-2]
+	if !isKiroCurrentSessionDir(session) {
+		return "", "", false
+	}
+	return filepath.Clean(path), session, true
+}
+
+func kiroCurrentPathForEvent(root, path string) (string, string, bool) {
+	if current, id, ok := kiroCurrentPathUnderRoot(root, path); ok {
+		return current, id, true
+	}
+	rel, ok := relUnder(filepath.Clean(root), filepath.Clean(path))
+	if !ok {
+		return "", "", false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if (len(parts) != 2 && len(parts) != 3) || parts[len(parts)-1] != "session.json" {
+		return "", "", false
+	}
+	session := parts[len(parts)-2]
+	if !isKiroCurrentSessionDir(session) {
+		return "", "", false
+	}
+	return filepath.Join(filepath.Dir(path), "messages.jsonl"), session, true
+}
+
+func kiroRegularFileUnderRoot(root, path string) bool {
+	if !IsRegularFile(path) {
+		return false
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	_, ok := relUnder(resolvedRoot, resolvedPath)
+	return ok
 }
 
 func kiroProviderCapabilities() Capabilities {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -1131,6 +1131,20 @@ func (s kiroSourceSet) sourceFromRef(source SourceRef) (kiroSource, bool) {
 	return kiroSource{}, false
 }
 
+// IsKiroSQLiteSource reports whether a Kiro source is backed by the current
+// SQLite store rather than one of the JSONL layouts.
+func IsKiroSQLiteSource(source SourceRef) bool {
+	src, ok := (kiroSourceSet{}).sourceFromRef(source)
+	return ok && (src.Kind == kiroSourceSQLiteDB || src.Kind == kiroSourceSQLiteSession)
+}
+
+// KiroSQLiteSourcePresent reports whether the SQLite container for a Kiro
+// source still exists at parse time.
+func KiroSQLiteSourcePresent(source SourceRef) bool {
+	src, ok := (kiroSourceSet{}).sourceFromRef(source)
+	return ok && IsRegularFile(src.DBPath)
+}
+
 func (s kiroSourceSet) sourceRef(
 	root, path string,
 	allowMissing bool,

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -359,15 +359,6 @@ type kiroChangedPlanCache struct {
 	databases []SourceRef
 }
 
-var kiroLegacyIdentityIndex = struct {
-	sync.RWMutex
-	roots   map[string]map[string]map[string]struct{}
-	indexed map[string]bool
-}{
-	roots:   make(map[string]map[string]map[string]struct{}),
-	indexed: make(map[string]bool),
-}
-
 func newKiroSourceSet(roots []string) kiroSourceSet {
 	return kiroSourceSet{
 		roots:     cleanJSONLRoots(roots),
@@ -444,7 +435,6 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 		if err != nil {
 			return nil, nil, err
 		}
-		s.indexLegacyFiles(root, legacyFiles)
 		for _, file := range legacyFiles {
 			id := KiroSessionIDFromPath(file.Path)
 			if id == "" {
@@ -501,32 +491,6 @@ func (s kiroSourceSet) setSourceMTime(source *SourceRef) {
 }
 
 func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
-	for _, root := range s.roots {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		dbPath, err := kiroSQLiteDBPathChecked(root)
-		if err != nil {
-			return err
-		}
-		if dbPath == "" {
-			continue
-		}
-		store, err := OpenKiroSQLiteStore(dbPath)
-		if err != nil {
-			return err
-		}
-		listErr := store.ForEachSessionMeta(ctx, func(KiroSQLiteSessionMeta) error {
-			return nil
-		})
-		closeErr := store.Close()
-		if listErr != nil {
-			return listErr
-		}
-		if closeErr != nil {
-			return closeErr
-		}
-	}
 	var firstErr error
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
@@ -750,53 +714,13 @@ func (s kiroSourceSet) sourceForSession(
 	return winner, found, nil
 }
 
-func (s kiroSourceSet) indexLegacyFiles(root string, files []DiscoveredFile) {
-	root = filepath.Clean(root)
-	kiroLegacyIdentityIndex.Lock()
-	defer kiroLegacyIdentityIndex.Unlock()
-	bySession := kiroLegacyIdentityIndex.roots[root]
-	if bySession == nil {
-		bySession = make(map[string]map[string]struct{})
-		kiroLegacyIdentityIndex.roots[root] = bySession
-	}
-	for _, file := range files {
-		id := KiroSessionIDFromPath(file.Path)
-		if id == "" {
-			continue
-		}
-		paths := bySession[id]
-		if paths == nil {
-			paths = make(map[string]struct{})
-			bySession[id] = paths
-		}
-		paths[filepath.Clean(file.Path)] = struct{}{}
-	}
-	kiroLegacyIdentityIndex.indexed[root] = true
-}
-
-func (s kiroSourceSet) ensureLegacyIdentityIndex(root string) error {
-	root = filepath.Clean(root)
-	kiroLegacyIdentityIndex.RLock()
-	indexed := kiroLegacyIdentityIndex.indexed[root]
-	kiroLegacyIdentityIndex.RUnlock()
-	if indexed {
-		return nil
-	}
-	files, err := s.discoverLegacyJSONL(root)
-	if err != nil {
-		return err
-	}
-	s.indexLegacyFiles(root, files)
-	return nil
-}
-
+// legacySourcesForSession resolves the legacy transcripts that can carry
+// sessionID with bounded exact-path probes: legacy identity is derived from
+// the file name, so only <root>/<id>.jsonl and <root>/cli/<id>.jsonl qualify.
 func (s kiroSourceSet) legacySourcesForSession(
 	root, sessionID string, changed SourceRef,
 ) ([]SourceRef, error) {
 	root = filepath.Clean(root)
-	if err := s.ensureLegacyIdentityIndex(root); err != nil {
-		return nil, err
-	}
 	paths := make(map[string]struct{})
 	if changedSrc, ok := s.sourceFromRef(changed); ok &&
 		changedSrc.Kind == kiroSourceLegacyJSONL &&
@@ -804,20 +728,23 @@ func (s kiroSourceSet) legacySourcesForSession(
 		kiroSourceExists(changed) &&
 		KiroSessionIDFromPath(changedSrc.Path) == sessionID {
 		paths[filepath.Clean(changedSrc.Path)] = struct{}{}
-		s.indexLegacyFiles(root, []DiscoveredFile{{
-			Path: changedSrc.Path, Agent: AgentKiro,
-		}})
 	}
-	kiroLegacyIdentityIndex.RLock()
-	for path := range kiroLegacyIdentityIndex.roots[root][sessionID] {
-		paths[path] = struct{}{}
+	if IsValidSessionID(sessionID) {
+		for _, dir := range []string{root, filepath.Join(root, "cli")} {
+			candidate := filepath.Join(dir, sessionID+".jsonl")
+			regular, err := kiroRegularFileUnderRootChecked(root, candidate)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"probe Kiro legacy transcript %s: %w", candidate, err,
+				)
+			}
+			if regular {
+				paths[candidate] = struct{}{}
+			}
+		}
 	}
-	kiroLegacyIdentityIndex.RUnlock()
 	sources := make([]SourceRef, 0, len(paths))
 	for path := range paths {
-		if KiroSessionIDFromPath(path) != sessionID {
-			continue
-		}
 		if source, ok := s.sourceRef(root, path, false); ok {
 			sources = append(sources, source)
 		}

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 var _ Provider = (*kiroProvider)(nil)
@@ -87,6 +88,14 @@ func (p *kiroProvider) ReconciliationSourceRank(
 	source SourceRef,
 ) ReconciliationSourceRank {
 	return p.sources.sourceRank(source)
+}
+
+func (p *kiroProvider) PreservedSessionIDs(source SourceRef) []string {
+	src, ok := p.sources.sourceFromRef(source)
+	if !ok || len(src.PreservedIDs) == 0 {
+		return nil
+	}
+	return append([]string(nil), src.PreservedIDs...)
 }
 
 func (p *kiroProvider) PersistentArchiveSource(
@@ -219,7 +228,7 @@ func (p *kiroProvider) parseSQLiteDB(
 	if len(results) == 0 && len(sourceErrs) == 0 {
 		return ParseOutcome{
 			ResultSetComplete: true,
-			ForceReplace:      !src.SessionIDsSet && !src.SessionIDsZeroWinner,
+			ForceReplace:      !src.SessionIDsSet,
 			SkipReason:        SkipNoSession,
 		}, nil
 	}
@@ -227,7 +236,7 @@ func (p *kiroProvider) parseSQLiteDB(
 		Results:           results,
 		SourceErrors:      sourceErrs,
 		ResultSetComplete: true,
-		ForceReplace:      !src.SessionIDsSet && !src.SessionIDsZeroWinner,
+		ForceReplace:      !src.SessionIDsSet,
 	}, nil
 }
 
@@ -324,23 +333,34 @@ const (
 )
 
 type kiroSource struct {
-	Root                 string
-	Path                 string
-	DBPath               string
-	SessionID            string
-	Kind                 kiroSourceKind
-	SessionIDs           map[string]struct{}
-	SessionIDsSet        bool
-	SessionIDsTotal      int
-	SessionIDsZeroWinner bool
+	Root            string
+	Path            string
+	DBPath          string
+	SessionID       string
+	Kind            kiroSourceKind
+	SessionIDs      map[string]struct{}
+	SessionIDsSet   bool
+	SessionIDsTotal int
+	PreservedIDs    []string
 }
 
 type kiroSourceSet struct {
-	roots []string
+	roots     []string
+	planCache *kiroChangedPlanCache
+}
+
+type kiroChangedPlanCache struct {
+	mu        sync.Mutex
+	key       string
+	winners   map[string]SourceRef
+	databases []SourceRef
 }
 
 func newKiroSourceSet(roots []string) kiroSourceSet {
-	return kiroSourceSet{roots: cleanJSONLRoots(roots)}
+	return kiroSourceSet{
+		roots:     cleanJSONLRoots(roots),
+		planCache: &kiroChangedPlanCache{},
+	}
 }
 
 func (s kiroSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
@@ -368,6 +388,7 @@ func (s kiroSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []SourceRef, error) {
 	candidates := make(map[string][]SourceRef)
 	databases := make([]SourceRef, 0)
+	databaseMetas := make(map[string][]KiroSQLiteSessionMeta)
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
@@ -376,7 +397,8 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 			dbSource := s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB)
 			metas, err := ListKiroSQLiteSessionMeta(dbPath)
 			if err != nil {
-				return nil, nil, fmt.Errorf("list Kiro SQLite sessions in %s: %w", dbPath, err)
+				databases = append(databases, dbSource)
+				continue
 			}
 			dbSourceSrc, ok := s.sourceFromRef(dbSource)
 			if !ok {
@@ -384,6 +406,7 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 			}
 			dbSourceSrc.SessionIDsTotal = len(metas)
 			dbSource.Opaque = dbSourceSrc
+			databaseMetas[dbPath] = metas
 			for _, meta := range metas {
 				member := s.newSourceRef(root, meta.VirtualPath, dbPath, meta.SessionID, kiroSourceSQLiteSession)
 				member.DiscoveryMTimeNS = meta.FileMtime
@@ -427,11 +450,15 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 		}
 		if src.SessionIDsTotal > 0 && len(src.SessionIDs) < src.SessionIDsTotal {
 			src.SessionIDsSet = true
-			src.SessionIDsZeroWinner = len(src.SessionIDs) == 0
+			for _, meta := range databaseMetas[src.DBPath] {
+				if _, ok := src.SessionIDs[meta.SessionID]; !ok {
+					src.PreservedIDs = append(src.PreservedIDs, "kiro:"+meta.SessionID)
+				}
+			}
 		} else {
 			src.SessionIDs = nil
 			src.SessionIDsSet = false
-			src.SessionIDsZeroWinner = false
+			src.PreservedIDs = nil
 		}
 		databases[i].Opaque = src
 	}
@@ -513,7 +540,7 @@ func (s kiroSourceSet) SourcesForChangedPath(
 		if !ok {
 			continue
 		}
-		winners, databases, err := s.sourcePlan(ctx)
+		winners, databases, err := s.sourcePlanForChangedPath(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -540,6 +567,44 @@ func (s kiroSourceSet) SourcesForChangedPath(
 		return sources, nil
 	}
 	return nil, nil
+}
+
+func (s kiroSourceSet) sourcePlanForChangedPath(
+	ctx context.Context, req ChangedPathRequest,
+) (map[string]SourceRef, []SourceRef, error) {
+	if s.planCache == nil {
+		return s.sourcePlan(ctx)
+	}
+	key := kiroChangedPlanCacheKey(req)
+	s.planCache.mu.Lock()
+	if s.planCache.key == key {
+		winners, databases := s.planCache.winners, s.planCache.databases
+		s.planCache.mu.Unlock()
+		return winners, databases, nil
+	}
+	s.planCache.mu.Unlock()
+
+	winners, databases, err := s.sourcePlan(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	s.planCache.mu.Lock()
+	s.planCache.key = key
+	s.planCache.winners = winners
+	s.planCache.databases = databases
+	s.planCache.mu.Unlock()
+	return winners, databases, nil
+}
+
+func kiroChangedPlanCacheKey(req ChangedPathRequest) string {
+	info, err := os.Stat(req.Path)
+	if err != nil {
+		return fmt.Sprintf("%s\x00%s\x00%s\x00missing", req.WatchRoot, req.Path, req.EventKind)
+	}
+	return fmt.Sprintf(
+		"%s\x00%s\x00%s\x00%d\x00%d",
+		req.WatchRoot, req.Path, req.EventKind, info.Size(), info.ModTime().UnixNano(),
+	)
 }
 
 func (s kiroSourceSet) StoredSourceHintScopes(
@@ -927,9 +992,9 @@ func (s kiroSourceSet) bestSource(sources []SourceRef) (SourceRef, bool) {
 	for _, source := range sources[1:] {
 		rank := s.sourceRank(source)
 		bestRoot, sourceRoot := s.rootIndex(best.ConfiguredRoot), s.rootIndex(source.ConfiguredRoot)
-		if sourceRoot < bestRoot ||
-			(sourceRoot == bestRoot && (rank.Class > bestRank.Class ||
-				(rank.Class == bestRank.Class && (rank.Recency > bestRank.Recency ||
+		if rank.Class > bestRank.Class ||
+			(rank.Class == bestRank.Class && (sourceRoot < bestRoot ||
+				(sourceRoot == bestRoot && (rank.Recency > bestRank.Recency ||
 					(rank.Recency == bestRank.Recency && s.sourcePath(source) < s.sourcePath(best)))))) {
 			best, bestRank = source, rank
 		}
@@ -1140,7 +1205,8 @@ func isKiroCurrentSessionDir(name string) bool {
 }
 
 func isKiroCurrentWorkspaceDir(name string) bool {
-	return name != "" && name != ".history" && name != "snapshots"
+	return name != "" && name != ".history" && name != "snapshots" &&
+		!isKiroCurrentSessionDir(name)
 }
 
 func kiroCurrentPathUnderRoot(root, path string) (string, string, bool) {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -963,14 +963,8 @@ func kiroLegacyPathUnderRoot(root, path string) bool {
 
 func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 	var files []DiscoveredFile
-	add := func(session string) {
-		path := filepath.Join(root, session, "messages.jsonl")
-		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
-			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
-		}
-	}
-	addWorkspace := func(session string) {
-		path := filepath.Join(root, kiroCurrentWorkspaceDir, session, "messages.jsonl")
+	add := func(workspace, session string) {
+		path := filepath.Join(root, workspace, session, "messages.jsonl")
 		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
 			files = append(files, DiscoveredFile{Path: path, Agent: AgentKiro})
 		}
@@ -984,15 +978,20 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 			continue
 		}
 		if isKiroCurrentSessionDir(entry.Name()) {
-			add(entry.Name())
+			add("", entry.Name())
+			continue
 		}
-	}
-	workspace := filepath.Join(root, kiroCurrentWorkspaceDir)
-	children, err := os.ReadDir(workspace)
-	if err == nil {
+		if !isKiroCurrentWorkspaceDir(entry.Name()) {
+			continue
+		}
+		workspace := filepath.Join(root, entry.Name())
+		children, err := os.ReadDir(workspace)
+		if err != nil {
+			continue
+		}
 		for _, child := range children {
 			if child.IsDir() && isKiroCurrentSessionDir(child.Name()) {
-				addWorkspace(child.Name())
+				add(entry.Name(), child.Name())
 			}
 		}
 	}
@@ -1003,10 +1002,15 @@ func (s kiroSourceSet) findCurrentJSONL(root, sessionID string) (SourceRef, bool
 	if !isKiroCurrentSessionDir(sessionID) {
 		return SourceRef{}, false
 	}
-	for _, path := range []string{
-		filepath.Join(root, sessionID, "messages.jsonl"),
-		filepath.Join(root, kiroCurrentWorkspaceDir, sessionID, "messages.jsonl"),
-	} {
+	paths := []string{filepath.Join(root, sessionID, "messages.jsonl")}
+	if entries, err := os.ReadDir(root); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() && isKiroCurrentWorkspaceDir(entry.Name()) {
+				paths = append(paths, filepath.Join(root, entry.Name(), sessionID, "messages.jsonl"))
+			}
+		}
+	}
+	for _, path := range paths {
 		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
 			return s.newSourceRef(root, path, "", sessionID, kiroSourceCurrentJSONL), true
 		}
@@ -1026,10 +1030,10 @@ func (s kiroSourceSet) discoverCurrentJSONLEach(ctx context.Context, root string
 			}
 			return nil
 		}
-		if entry.Name() != kiroCurrentWorkspaceDir {
+		if !isKiroCurrentWorkspaceDir(entry.Name()) {
 			return nil
 		}
-		workspace := filepath.Join(root, kiroCurrentWorkspaceDir)
+		workspace := filepath.Join(root, entry.Name())
 		return streamDirectoryEntries(ctx, workspace, func(child os.DirEntry) error {
 			if !child.IsDir() || !isKiroCurrentSessionDir(child.Name()) {
 				return nil
@@ -1069,7 +1073,9 @@ func isKiroCurrentSessionDir(name string) bool {
 	return strings.HasPrefix(name, "sess_") && IsValidSessionID(id)
 }
 
-const kiroCurrentWorkspaceDir = "workspace"
+func isKiroCurrentWorkspaceDir(name string) bool {
+	return name != "" && name != ".history" && name != "snapshots"
+}
 
 func kiroCurrentPathUnderRoot(root, path string) (string, string, bool) {
 	rel, ok := relUnder(filepath.Clean(root), filepath.Clean(path))
@@ -1080,7 +1086,7 @@ func kiroCurrentPathUnderRoot(root, path string) (string, string, bool) {
 	if (len(parts) != 2 && len(parts) != 3) || parts[len(parts)-1] != "messages.jsonl" {
 		return "", "", false
 	}
-	if len(parts) == 3 && parts[0] != kiroCurrentWorkspaceDir {
+	if len(parts) == 3 && !isKiroCurrentWorkspaceDir(parts[0]) {
 		return "", "", false
 	}
 	session := parts[len(parts)-2]
@@ -1102,11 +1108,11 @@ func kiroCurrentPathForEvent(root, path string) (string, string, bool) {
 	if (len(parts) != 2 && len(parts) != 3) || parts[len(parts)-1] != "session.json" {
 		return "", "", false
 	}
-	session := parts[len(parts)-2]
-	if !isKiroCurrentSessionDir(session) {
+	current, session, ok := kiroCurrentPathUnderRoot(root, filepath.Join(filepath.Dir(path), "messages.jsonl"))
+	if !ok {
 		return "", "", false
 	}
-	return filepath.Join(filepath.Dir(path), "messages.jsonl"), session, true
+	return current, session, true
 }
 
 func kiroCurrentSidecarPath(roots []string, transcript string) (string, bool) {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -837,9 +837,10 @@ func (s kiroSourceSet) newSourceRef(
 	kind kiroSourceKind,
 ) SourceRef {
 	key := path
-	if kind == kiroSourceSQLiteSession || kind == kiroSourceCurrentJSONL {
+	switch kind {
+	case kiroSourceSQLiteSession, kiroSourceCurrentJSONL:
 		key = sessionID
-	} else if kind == kiroSourceLegacyJSONL {
+	case kiroSourceLegacyJSONL:
 		key = KiroSessionIDFromPath(path)
 	}
 	return SourceRef{
@@ -1013,26 +1014,6 @@ func (s kiroSourceSet) discoverCurrentJSONL(root string) []DiscoveredFile {
 		}
 	}
 	return files
-}
-
-func (s kiroSourceSet) findCurrentJSONL(root, sessionID string) (SourceRef, bool) {
-	if !isKiroCurrentSessionDir(sessionID) {
-		return SourceRef{}, false
-	}
-	paths := []string{filepath.Join(root, sessionID, "messages.jsonl")}
-	if entries, err := os.ReadDir(root); err == nil {
-		for _, entry := range entries {
-			if entry.IsDir() && isKiroCurrentWorkspaceDir(entry.Name()) {
-				paths = append(paths, filepath.Join(root, entry.Name(), sessionID, "messages.jsonl"))
-			}
-		}
-	}
-	for _, path := range paths {
-		if _, _, ok := kiroCurrentPathUnderRoot(root, path); ok && kiroRegularFileUnderRoot(root, path) {
-			return s.newSourceRef(root, path, "", sessionID, kiroSourceCurrentJSONL), true
-		}
-	}
-	return SourceRef{}, false
 }
 
 func (s kiroSourceSet) discoverCurrentJSONLEach(ctx context.Context, root string, yield func(SourceRef) error) error {

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -86,26 +86,7 @@ func (p *kiroProvider) Fingerprint(
 func (p *kiroProvider) ReconciliationSourceRank(
 	source SourceRef,
 ) ReconciliationSourceRank {
-	src, ok := p.sources.sourceFromRef(source)
-	if !ok {
-		return ReconciliationSourceRank{}
-	}
-	class := int64(0)
-	switch src.Kind {
-	case kiroSourceLegacyJSONL:
-		class = 1
-	case kiroSourceCurrentJSONL:
-		class = 2
-	case kiroSourceSQLiteSession:
-		class = 3
-	}
-	recency := source.DiscoveryMTimeNS
-	if recency == 0 && src.Path != "" {
-		if info, err := os.Stat(src.Path); err == nil {
-			recency = info.ModTime().UnixNano()
-		}
-	}
-	return ReconciliationSourceRank{Class: class, Recency: recency}
+	return p.sources.sourceRank(source)
 }
 
 func (p *kiroProvider) PersistentArchiveSource(
@@ -205,6 +186,11 @@ func (p *kiroProvider) parseSQLiteDB(
 	results := make([]ParseResultOutcome, 0, len(metas))
 	var sourceErrs []SourceError
 	for _, meta := range metas {
+		if src.SessionIDsSet {
+			if _, ok := src.SessionIDs[meta.SessionID]; !ok {
+				continue
+			}
+		}
 		if err := ctx.Err(); err != nil {
 			return ParseOutcome{}, err
 		}
@@ -303,12 +289,6 @@ func (p *kiroProvider) parseLegacyJSONL(
 	machine string,
 	fingerprint SourceFingerprint,
 ) (ParseOutcome, error) {
-	if p.sources.legacyPathShadowed(src.Path) {
-		return ParseOutcome{
-			ResultSetComplete: true,
-			SkipReason:        SkipNoSession,
-		}, nil
-	}
 	sess, msgs, err := p.parseLegacySession(src.Path, machine)
 	if err != nil {
 		return ParseOutcome{}, err
@@ -344,11 +324,13 @@ const (
 )
 
 type kiroSource struct {
-	Root      string
-	Path      string
-	DBPath    string
-	SessionID string
-	Kind      kiroSourceKind
+	Root          string
+	Path          string
+	DBPath        string
+	SessionID     string
+	Kind          kiroSourceKind
+	SessionIDs    map[string]struct{}
+	SessionIDsSet bool
 }
 
 type kiroSourceSet struct {
@@ -360,33 +342,95 @@ func newKiroSourceSet(roots []string) kiroSourceSet {
 }
 
 func (s kiroSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
-	var sources []SourceRef
+	winners, databases, err := s.sourcePlan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sources := make([]SourceRef, 0, len(winners)+len(databases))
 	seen := make(map[string]struct{})
-	currentIDs := s.currentSessionIDs()
-	for _, root := range s.roots {
-		if err := ctx.Err(); err != nil {
-			return nil, err
+	for _, source := range databases {
+		addJSONLSource(source, &sources, seen)
+	}
+	for _, source := range winners {
+		if src, ok := s.sourceFromRef(source); ok && src.Kind == kiroSourceSQLiteSession {
+			continue
 		}
-		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
-			addJSONLSource(s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB), &sources, seen)
-		}
-		for _, file := range s.discoverLegacyJSONL(root) {
-			if _, shadowed := currentIDs[KiroSessionIDFromPath(file.Path)]; shadowed {
-				continue
-			}
-			source, ok := s.sourceRef(root, file.Path, false)
-			if ok {
-				addJSONLSource(source, &sources, seen)
-			}
-		}
-		for _, file := range s.discoverCurrentJSONL(root) {
-			if source, ok := s.sourceRef(root, file.Path, false); ok {
-				addJSONLSource(source, &sources, seen)
-			}
-		}
+		addJSONLSource(source, &sources, seen)
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+// sourcePlan is the single Kiro authority used before normal workers are
+// started. Physical SQLite sources carry the member allowlist selected here.
+func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []SourceRef, error) {
+	candidates := make(map[string][]SourceRef)
+	databases := make([]SourceRef, 0)
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
+			dbSource := s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB)
+			metas, err := ListKiroSQLiteSessionMeta(dbPath)
+			if err == nil {
+				for _, meta := range metas {
+					member := s.newSourceRef(root, meta.VirtualPath, dbPath, meta.SessionID, kiroSourceSQLiteSession)
+					member.DiscoveryMTimeNS = meta.FileMtime
+					candidates[meta.SessionID] = append(candidates[meta.SessionID], member)
+				}
+			}
+			databases = append(databases, dbSource)
+		}
+		for _, file := range s.discoverCurrentJSONL(root) {
+			if source, ok := s.sourceRef(root, file.Path, false); ok {
+				if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok {
+					s.setSourceMTime(&source)
+					candidates[id] = append(candidates[id], source)
+				}
+			}
+		}
+		for _, file := range s.discoverLegacyJSONL(root) {
+			id := KiroSessionIDFromPath(file.Path)
+			if id == "" {
+				continue
+			}
+			if source, ok := s.sourceRef(root, file.Path, false); ok {
+				s.setSourceMTime(&source)
+				candidates[id] = append(candidates[id], source)
+			}
+		}
+	}
+	winners := make(map[string]SourceRef, len(candidates))
+	for id, list := range candidates {
+		if winner, ok := s.bestSource(list); ok {
+			winners[id] = winner
+		}
+	}
+	for i := range databases {
+		src, _ := s.sourceFromRef(databases[i])
+		src.SessionIDs = make(map[string]struct{})
+		src.SessionIDsSet = true
+		for id, winner := range winners {
+			winnerSrc, ok := s.sourceFromRef(winner)
+			if ok && winnerSrc.Kind == kiroSourceSQLiteSession && samePath(winnerSrc.DBPath, src.DBPath) {
+				src.SessionIDs[id] = struct{}{}
+			}
+		}
+		databases[i].Opaque = src
+	}
+	return winners, databases, nil
+}
+
+func (s kiroSourceSet) setSourceMTime(source *SourceRef) {
+	if source.DiscoveryMTimeNS != 0 {
+		return
+	}
+	if src, ok := s.sourceFromRef(*source); ok {
+		if info, err := os.Stat(src.Path); err == nil {
+			source.DiscoveryMTimeNS = info.ModTime().UnixNano()
+		}
+	}
 }
 
 func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
@@ -453,21 +497,30 @@ func (s kiroSourceSet) SourcesForChangedPath(
 		if !ok {
 			continue
 		}
-		sources := []SourceRef{source}
-		if current, ok := s.sourceFromRef(source); ok &&
-			current.Kind == kiroSourceCurrentJSONL {
-			if dbPath := kiroSQLiteDBPath(root); dbPath != "" &&
-				KiroSQLiteSessionExists(dbPath, current.SessionID) {
-				sources = append(sources, s.newSourceRef(
-					root, KiroSQLiteVirtualPath(dbPath, current.SessionID), dbPath,
-					current.SessionID, kiroSourceSQLiteSession,
-				))
+		winners, databases, err := s.sourcePlan(ctx)
+		if err != nil {
+			return nil, err
+		}
+		current, _ := s.sourceFromRef(source)
+		sources := make([]SourceRef, 0, 2)
+		if current.Kind == kiroSourceSQLiteDB {
+			for _, database := range databases {
+				db, ok := s.sourceFromRef(database)
+				if ok && samePath(db.DBPath, current.DBPath) {
+					sources = append(sources, database)
+					break
+				}
+			}
+		} else {
+			id := current.SessionID
+			if id == "" {
+				id = KiroSessionIDFromPath(current.Path)
+			}
+			if winner, ok := winners[id]; ok {
+				sources = append(sources, winner)
 			}
 		}
-		sources = append(
-			sources,
-			s.changedPathTombstones(root, source, req.StoredSourcePaths)...,
-		)
+		sources = append(sources, s.changedPathTombstones(root, source, req.StoredSourcePaths, winners)...)
 		return sources, nil
 	}
 	return nil, nil
@@ -513,6 +566,7 @@ func (s kiroSourceSet) changedPathTombstones(
 	root string,
 	changed SourceRef,
 	storedPaths []string,
+	winners map[string]SourceRef,
 ) []SourceRef {
 	src, ok := s.sourceFromRef(changed)
 	if !ok || src.Kind != kiroSourceSQLiteDB || !IsRegularFile(src.DBPath) {
@@ -533,6 +587,13 @@ func (s kiroSourceSet) changedPathTombstones(
 			continue
 		}
 		if KiroSQLiteSessionExists(member.DBPath, member.SessionID) {
+			continue
+		}
+		if winner, ok := winners[member.SessionID]; ok {
+			if winnerSrc, winnerOK := s.sourceFromRef(winner); winnerOK &&
+				!(winnerSrc.Kind == kiroSourceSQLiteSession && samePath(winnerSrc.DBPath, member.DBPath)) {
+				tombstones = append(tombstones, winner)
+			}
 			continue
 		}
 		if _, dup := seen[member.Path]; dup {
@@ -798,40 +859,6 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 	return SourceRef{}, false
 }
 
-func (s kiroSourceSet) currentSessionIDs() map[string]struct{} {
-	ids := make(map[string]struct{})
-	for _, root := range s.roots {
-		for id := range KiroSQLiteSessionIDs(root) {
-			ids[id] = struct{}{}
-		}
-		for _, file := range s.discoverCurrentJSONL(root) {
-			if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok {
-				ids[id] = struct{}{}
-			}
-		}
-	}
-	return ids
-}
-
-func (s kiroSourceSet) legacyPathShadowed(path string) bool {
-	legacyID := KiroSessionIDFromPath(path)
-	if legacyID == "" {
-		return false
-	}
-	for _, root := range s.roots {
-		dbPath := kiroSQLiteDBPath(root)
-		if dbPath != "" && KiroSQLiteSessionExists(dbPath, legacyID) {
-			return true
-		}
-		for _, file := range s.discoverCurrentJSONL(root) {
-			if _, id, ok := kiroCurrentPathUnderRoot(root, file.Path); ok && id == legacyID {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func (s kiroSourceSet) newSourceRef(
 	root, path, dbPath, sessionID string,
 	kind kiroSourceKind,
@@ -884,9 +911,10 @@ func (s kiroSourceSet) bestSource(sources []SourceRef) (SourceRef, bool) {
 	for _, source := range sources[1:] {
 		rank := s.sourceRank(source)
 		bestRoot, sourceRoot := s.rootIndex(best.ConfiguredRoot), s.rootIndex(source.ConfiguredRoot)
-		if rank.Class > bestRank.Class ||
-			(rank.Class == bestRank.Class && (sourceRoot < bestRoot ||
-				(sourceRoot == bestRoot && rank.Recency > bestRank.Recency))) {
+		if sourceRoot < bestRoot ||
+			(sourceRoot == bestRoot && (rank.Class > bestRank.Class ||
+				(rank.Class == bestRank.Class && (rank.Recency > bestRank.Recency ||
+					(rank.Recency == bestRank.Recency && s.sourcePath(source) < s.sourcePath(best)))))) {
 			best, bestRank = source, rank
 		}
 	}
@@ -907,15 +935,7 @@ func (s kiroSourceSet) sourceRank(source SourceRef) ReconciliationSourceRank {
 	if !ok {
 		return ReconciliationSourceRank{}
 	}
-	class := int64(0)
-	switch src.Kind {
-	case kiroSourceLegacyJSONL:
-		class = 1
-	case kiroSourceCurrentJSONL:
-		class = 2
-	case kiroSourceSQLiteSession:
-		class = 3
-	}
+	class := kiroSourceClass(src.Kind)
 	recency := source.DiscoveryMTimeNS
 	if recency == 0 {
 		if info, err := os.Stat(src.Path); err == nil {
@@ -923,6 +943,42 @@ func (s kiroSourceSet) sourceRank(source SourceRef) ReconciliationSourceRank {
 		}
 	}
 	return ReconciliationSourceRank{Class: class, Recency: recency}
+}
+
+func kiroSourceClass(kind kiroSourceKind) int64 {
+	switch kind {
+	case kiroSourceLegacyJSONL:
+		return 1
+	case kiroSourceCurrentJSONL:
+		return 2
+	case kiroSourceSQLiteSession:
+		return 3
+	default:
+		return 0
+	}
+}
+
+func (s kiroSourceSet) sourcePath(source SourceRef) string {
+	if src, ok := s.sourceFromRef(source); ok {
+		path := src.Path
+		if path == "" {
+			path = src.DBPath
+		}
+		if canonical, err := filepath.EvalSymlinks(path); err == nil {
+			path = canonical
+		}
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(providerSourcePathForRank(source))
+}
+
+func providerSourcePathForRank(source SourceRef) string {
+	for _, path := range []string{source.DisplayPath, source.FingerprintKey, source.Key} {
+		if path != "" {
+			return path
+		}
+	}
+	return ""
 }
 
 func kiroDBUnderRoot(root, dbPath string, requireRegular bool) bool {
@@ -1051,9 +1107,6 @@ func (s kiroSourceSet) discoverLegacyJSONLEach(ctx context.Context, root string,
 				return nil
 			}
 			path := filepath.Join(dir, entry.Name())
-			if s.legacyPathShadowed(path) {
-				return nil
-			}
 			if source, ok := s.sourceRef(root, path, false); ok {
 				return yield(source)
 			}

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -405,7 +405,7 @@ func (s kiroSourceSet) sourcePlan(ctx context.Context) (map[string]SourceRef, []
 			}
 			dbSourceSrc, ok := s.sourceFromRef(dbSource)
 			if !ok {
-				return nil, nil, fmt.Errorf("Kiro SQLite source unavailable: %s", dbPath)
+				return nil, nil, fmt.Errorf("kiro SQLite source unavailable: %s", dbPath)
 			}
 			dbSourceSrc.SessionIDsTotal = len(metas)
 			dbSource.Opaque = dbSourceSrc
@@ -729,7 +729,7 @@ func (s kiroSourceSet) changedPathTombstones(
 		}
 		if winner, ok := winners[member.SessionID]; ok {
 			if winnerSrc, winnerOK := s.sourceFromRef(winner); winnerOK &&
-				!(winnerSrc.Kind == kiroSourceSQLiteSession && samePath(winnerSrc.DBPath, member.DBPath)) {
+				(winnerSrc.Kind != kiroSourceSQLiteSession || !samePath(winnerSrc.DBPath, member.DBPath)) {
 				tombstones = append(tombstones, winner)
 			}
 			continue

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -840,6 +840,25 @@ func TestKiroProviderChangedCurrentEventScansOnlyAffectedSession(t *testing.T) {
 		"a non-database event should inspect only the root directory")
 }
 
+func TestKiroProviderChangedCurrentEventIgnoresUnrelatedLegacyDamage(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	current := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	writeSourceFile(t, current, `{"payload":{"type":"user","content":"current"}}`+"\n")
+	writeSourceFile(t, filepath.Join(root, "broken.jsonl"), "{}\n")
+	writeSourceFile(t, filepath.Join(root, "broken.json"), "{")
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: current, WatchRoot: root, EventKind: "write",
+	})
+	require.NoError(t, err,
+		"an unrelated malformed legacy sidecar must not fail a current-session event")
+	require.Len(t, changed, 1)
+	assert.Equal(t, current, changed[0].DisplayPath)
+}
+
 func TestKiroProviderChangedLegacyEventPreservesMetadataIdentity(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "storage-name.jsonl")

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -486,7 +486,7 @@ func TestKiroProviderCurrentLayoutRejectsLookalikesAndEscapes(t *testing.T) {
 	root := t.TempDir()
 	valid := filepath.Join(root, "project-a", "sess_0123456789abcdef", "messages.jsonl")
 	writeSourceFile(t, valid, `{"payload":{"type":"user","content":"ok"}}`+"\n")
-	secondValid := filepath.Join(root, "workspace", "sess_fedcba9876543210", "messages.jsonl")
+	secondValid := filepath.Join(root, "sess_fedcba9876543210", "sess_aaaaaaaaaaaaaaaa", "messages.jsonl")
 	writeSourceFile(t, secondValid, `{"payload":{"type":"user","content":"ok"}}`+"\n")
 	for _, path := range []string{
 		filepath.Join(root, ".history", "sess_0123456789abcdef", "messages.jsonl"),
@@ -507,7 +507,7 @@ func TestKiroProviderCurrentLayoutRejectsLookalikesAndEscapes(t *testing.T) {
 	assert.ElementsMatch(t, []string{valid, secondValid}, []string{sources[0].DisplayPath, sources[1].DisplayPath})
 	for _, tc := range []struct{ id, path string }{
 		{"sess_0123456789abcdef", valid},
-		{"sess_fedcba9876543210", secondValid},
+		{"sess_aaaaaaaaaaaaaaaa", secondValid},
 	} {
 		found, foundOK, findErr := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: tc.id})
 		require.NoError(t, findErr)
@@ -689,6 +689,34 @@ func TestKiroProviderCurrentSidecarRequiresRegularContainedFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, outcome.Results, 1)
 	assert.Empty(t, outcome.Results[0].Result.Session.SessionName)
+}
+
+func TestKiroProviderRejectsSQLiteSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	outsideDB := filepath.Join(outside, kiroSQLiteDBName)
+	_, db := newKiroProviderSQLiteDBAt(t, outside)
+	require.NoError(t, db.Close())
+	dbPath := filepath.Join(root, kiroSQLiteDBName)
+	if err := os.Symlink(outsideDB, dbPath); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, sources)
+
+	virtual := KiroSQLiteVirtualPath(dbPath, "sqlite-session")
+	_, ok, err = provider.FindSource(context.Background(), FindSourceRequest{
+		StoredFilePath: virtual,
+		RawSessionID:   "sqlite-session",
+	})
+	require.NoError(t, err)
+	assert.False(t, ok)
+	_, err = OpenKiroSQLiteStore(dbPath)
+	assert.Error(t, err, "a symlinked database must not be opened")
 }
 
 func TestKiroIDEProviderSourceMethods(t *testing.T) {

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -162,6 +162,7 @@ func TestKiroProviderSkipsShadowedLegacySource(t *testing.T) {
 	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
 	require.True(t, ok)
 	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID:   "shadowed-session",
 		StoredFilePath: shadowedPath,
 	})
 	require.NoError(t, err)
@@ -207,6 +208,7 @@ func TestKiroProviderShadowsLegacyAcrossAllRoots(t *testing.T) {
 	assert.Equal(t, dbPath, discovered[0].DisplayPath)
 
 	legacySource, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID:   "shared-session",
 		StoredFilePath: legacyPath,
 	})
 	require.NoError(t, err)
@@ -218,6 +220,45 @@ func TestKiroProviderShadowsLegacyAcrossAllRoots(t *testing.T) {
 	assert.True(t, outcome.ResultSetComplete)
 	assert.Len(t, outcome.Results, 1)
 	assert.Equal(t, "kiro:shared-session", outcome.Results[0].Result.Session.ID)
+}
+
+func TestKiroProviderZeroWinnerSQLitePreservesArchive(t *testing.T) {
+	currentRoot := t.TempDir()
+	sqliteRoot := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	dbPath, db := newKiroProviderSQLiteDBAt(t, sqliteRoot)
+	seedKiroSQLiteSession(
+		t, db, "/home/user/code/current", rawID,
+		readKiroFixture(t, "standard_payload.json"),
+		1779012000000, 1779012030000,
+	)
+	currentPath := filepath.Join(currentRoot, "workspace", rawID, "messages.jsonl")
+	writeSourceFile(t, currentPath, `{"payload":{"type":"user","content":"current"}}`+"\n")
+
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{
+		Roots: []string{currentRoot, sqliteRoot},
+	})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	var database SourceRef
+	var foundCurrent bool
+	for _, source := range discovered {
+		if source.DisplayPath == dbPath {
+			database = source
+		}
+		if source.DisplayPath == currentPath {
+			foundCurrent = true
+		}
+	}
+	require.True(t, foundCurrent)
+	require.Equal(t, dbPath, database.DisplayPath)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: database})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	assert.False(t, outcome.ForceReplace)
+	assert.Equal(t, SkipNoSession, outcome.SkipReason)
 }
 
 func TestKiroProviderFingerprintsSQLiteAndLegacySources(t *testing.T) {
@@ -548,6 +589,59 @@ func TestKiroProviderCurrentLayoutLifecycleAndExactLookup(t *testing.T) {
 	fingerprint, err := provider.Fingerprint(context.Background(), found)
 	require.NoError(t, err)
 	assert.Greater(t, fingerprint.Size, int64(len(`{"payload":{"type":"user","content":"hello"}}`)+1))
+}
+
+func TestKiroProviderCurrentBoundsUseAcceptedMessageTimestamps(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	path := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	writeSourceFile(t, path, strings.Join([]string{
+		`{"timestamp":"2099-01-01T00:00:00Z","payload":{"type":"session_metadata"}}`,
+		`{"timestamp":"2026-08-24T12:30:00Z","payload":{"type":"assistant","content":"latest"}}`,
+		`{"timestamp":"2026-08-24T12:00:00Z","payload":{"type":"user","content":"earliest"}}`,
+	}, "\n")+"\n")
+
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: rawID})
+	require.NoError(t, err)
+	require.True(t, found)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	session := outcome.Results[0].Result.Session
+	assert.Equal(t, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC), session.StartedAt)
+	assert.Equal(t, time.Date(2026, 8, 24, 12, 30, 0, 0, time.UTC), session.EndedAt)
+}
+
+func TestKiroProviderStablePathTieBreak(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	direct := filepath.Join(root, rawID, "messages.jsonl")
+	workspace := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	fixture := `{"timestamp":"2026-08-24T12:00:00Z","payload":{"type":"user","content":"same"}}` + "\n"
+	writeSourceFile(t, direct, fixture)
+	writeSourceFile(t, workspace, fixture)
+	tie := time.Unix(1700000000, 0)
+	require.NoError(t, os.Chtimes(direct, tie, tie))
+	require.NoError(t, os.Chtimes(workspace, tie, tie))
+
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	found, foundOK, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: rawID})
+	require.NoError(t, err)
+	require.True(t, foundOK)
+	assert.Equal(t, direct, found.DisplayPath)
+}
+
+func TestKiroProviderDiscoveryFailsOnSQLiteMetadataError(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, kiroSQLiteDBName)
+	writeSourceFile(t, dbPath, "not a sqlite database")
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	_, err := provider.Discover(context.Background())
+	assert.Error(t, err)
 }
 
 func TestKiroProviderLogicalIdentityAndRankUnifyLegacyAndCurrent(t *testing.T) {

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -857,6 +857,50 @@ func TestKiroProviderChangedLegacyEventPreservesMetadataIdentity(t *testing.T) {
 	assert.Equal(t, path, changed[0].DisplayPath)
 }
 
+func TestKiroProviderLegacySidecarEventAndFingerprint(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "storage-name.jsonl")
+	sidecar := filepath.Join(root, "storage-name.json")
+	writeSourceFile(t, path, kiroProviderJSONLFixture("legacy"))
+	writeSourceFile(t, sidecar, kiroProviderMetaFixture("mapped-session", "/home/user/code/legacy"))
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: sidecar, WatchRoot: root, EventKind: "write",
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, path, changed[0].DisplayPath)
+	before, err := provider.Fingerprint(context.Background(), changed[0])
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(sidecar, []byte(
+		strings.Replace(
+			kiroProviderMetaFixture("mapped-session", "/home/user/code/legacy"),
+			`"title":"mapped-session"`, `"title":"mapped-sessioX"`, 1,
+		),
+	), 0o644))
+	transcriptInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	earlier := transcriptInfo.ModTime().Add(-time.Minute)
+	require.NoError(t, os.Chtimes(sidecar, earlier, earlier))
+	after, err := provider.Fingerprint(context.Background(), changed[0])
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Hash, after.Hash)
+}
+
+func TestKiroProviderLegacyMetadataDecodeFailureIsRetryable(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "storage-name.jsonl")
+	writeSourceFile(t, path, kiroProviderJSONLFixture("legacy"))
+	writeSourceFile(t, filepath.Join(root, "storage-name.json"), "{")
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	_, err := provider.Discover(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode Kiro legacy metadata")
+}
+
 func TestKiroProviderChangedCurrentEventRanksMetadataMappedLegacy(t *testing.T) {
 	currentRoot := t.TempDir()
 	legacyRoot := t.TempDir()

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -487,6 +487,9 @@ func TestKiroProviderCurrentLayoutRejectsLookalikesAndEscapes(t *testing.T) {
 	valid := filepath.Join(root, "workspace", "sess_0123456789abcdef", "messages.jsonl")
 	writeSourceFile(t, valid, `{"payload":{"type":"user","content":"ok"}}`+"\n")
 	for _, path := range []string{
+		filepath.Join(root, ".history", "sess_0123456789abcdef", "messages.jsonl"),
+		filepath.Join(root, "snapshots", "sess_0123456789abcdef", "messages.jsonl"),
+		filepath.Join(root, "arbitrary", "sess_0123456789abcdef", "messages.jsonl"),
 		filepath.Join(root, "workspace", ".history", "sess_0123456789abcdef", "messages.jsonl"),
 		filepath.Join(root, "workspace", "sess_0123456789abcdef", "snapshots", "messages.jsonl"),
 		filepath.Join(root, "workspace", "nested", "sess_0123456789abcdef", "messages.jsonl"),

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -814,6 +814,29 @@ func TestKiroProviderChangedLegacyEventPreservesMetadataIdentity(t *testing.T) {
 	assert.Equal(t, path, changed[0].DisplayPath)
 }
 
+func TestKiroProviderChangedCurrentEventRanksMetadataMappedLegacy(t *testing.T) {
+	currentRoot := t.TempDir()
+	legacyRoot := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	current := filepath.Join(currentRoot, "workspace", rawID, "messages.jsonl")
+	writeSourceFile(t, current, `{"payload":{"type":"user","content":"current"}}`+"\n")
+	legacy := filepath.Join(legacyRoot, "storage-name.jsonl")
+	writeSourceFile(t, legacy, kiroProviderJSONLFixture("legacy"))
+	writeSourceFile(t, filepath.Join(legacyRoot, "storage-name.json"),
+		kiroProviderMetaFixture(rawID, "/home/user/code/legacy"))
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{
+		Roots: []string{currentRoot, legacyRoot},
+	})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: current, WatchRoot: currentRoot, EventKind: "write",
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, current, changed[0].DisplayPath)
+}
+
 func TestKiroProviderDiscoveryFailsOnCurrentRootReadError(t *testing.T) {
 	root := t.TempDir()
 	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -765,6 +766,79 @@ func TestKiroProviderChangedCurrentEventIncludesSQLiteDuplicate(t *testing.T) {
 	assert.Equal(t, []string{KiroSQLiteVirtualPath(dbPath, rawID)}, got)
 	assert.Equal(t, int64(3), provider.(ReconciliationSourceRanker).
 		ReconciliationSourceRank(changed[0]).Class)
+}
+
+func TestKiroProviderChangedCurrentEventScansOnlyAffectedSession(t *testing.T) {
+	root := t.TempDir()
+	targetID := "sess_0123456789abcdef"
+	target := filepath.Join(root, "workspace", targetID, "messages.jsonl")
+	writeSourceFile(t, target, `{"payload":{"type":"user","content":"target"}}`+"\n")
+	for i := 0; i < 128; i++ {
+		id := fmt.Sprintf("sess_%016x", i)
+		path := filepath.Join(root, "workspace", id, "messages.jsonl")
+		writeSourceFile(t, path, `{"payload":{"type":"user","content":"decoy"}}`+"\n")
+	}
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	kiro := provider.(*kiroProvider)
+	var readDirs []string
+	kiro.sources.readDir = func(path string) ([]os.DirEntry, error) {
+		readDirs = append(readDirs, path)
+		return os.ReadDir(path)
+	}
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: target, WatchRoot: root, EventKind: "write",
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, target, changed[0].DisplayPath)
+	assert.Equal(t, []string{root}, readDirs,
+		"a non-database event should inspect only the root directory")
+}
+
+func TestKiroProviderChangedLegacyEventPreservesMetadataIdentity(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "storage-name.jsonl")
+	writeSourceFile(t, path, kiroProviderJSONLFixture("legacy"))
+	writeSourceFile(t, filepath.Join(root, "storage-name.json"),
+		kiroProviderMetaFixture("mapped-session", "/home/user/code/legacy"))
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: path, WatchRoot: root, EventKind: "write",
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, path, changed[0].DisplayPath)
+}
+
+func TestKiroProviderDiscoveryFailsOnCurrentRootReadError(t *testing.T) {
+	root := t.TempDir()
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	provider.(*kiroProvider).sources.readDir = func(string) ([]os.DirEntry, error) {
+		return nil, fmt.Errorf("current root is unreadable")
+	}
+	_, err := provider.Discover(context.Background())
+	assert.Error(t, err)
+}
+
+func TestKiroProviderDiscoveryFailsOnCurrentWorkspaceReadError(t *testing.T) {
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	require.NoError(t, os.Mkdir(workspace, 0o755))
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	provider.(*kiroProvider).sources.readDir = func(path string) ([]os.DirEntry, error) {
+		if samePath(path, root) {
+			return os.ReadDir(path)
+		}
+		return nil, fmt.Errorf("current workspace is unreadable")
+	}
+	_, err := provider.Discover(context.Background())
+	assert.Error(t, err)
 }
 
 func TestKiroProviderCurrentSidecarRequiresRegularContainedFile(t *testing.T) {

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -597,6 +597,49 @@ func TestKiroProviderCurrentLayoutLifecycleAndExactLookup(t *testing.T) {
 	assert.Greater(t, fingerprint.Size, int64(len(`{"payload":{"type":"user","content":"hello"}}`)+1))
 }
 
+func TestKiroProviderCurrentFingerprintIncludesSidecarContent(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	path := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	sidecar := filepath.Join(filepath.Dir(path), "session.json")
+	writeSourceFile(t, path, `{"payload":{"type":"user","content":"hello"}}`+"\n")
+	writeSourceFile(t, sidecar, `{"title":"A"}`)
+
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: rawID})
+	require.NoError(t, err)
+	require.True(t, found)
+	before, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(sidecar, []byte(`{"title":"B"}`), 0o644))
+	transcriptInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	earlier := transcriptInfo.ModTime().Add(-time.Minute)
+	require.NoError(t, os.Chtimes(sidecar, earlier, earlier))
+	after, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Hash, after.Hash)
+}
+
+func TestKiroProviderCurrentMetadataDecodeFailureIsRetryable(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	path := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	sidecar := filepath.Join(filepath.Dir(path), "session.json")
+	writeSourceFile(t, path, `{"payload":{"type":"user","content":"hello"}}`+"\n")
+	writeSourceFile(t, sidecar, "{")
+
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: rawID})
+	require.NoError(t, err)
+	require.True(t, found)
+	_, err = provider.Parse(context.Background(), ParseRequest{Source: source})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode Kiro current metadata")
+}
+
 func TestKiroProviderCurrentBoundsUseAcceptedMessageTimestamps(t *testing.T) {
 	root := t.TempDir()
 	rawID := "sess_0123456789abcdef"

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -773,7 +773,7 @@ func TestKiroProviderChangedCurrentEventScansOnlyAffectedSession(t *testing.T) {
 	targetID := "sess_0123456789abcdef"
 	target := filepath.Join(root, "workspace", targetID, "messages.jsonl")
 	writeSourceFile(t, target, `{"payload":{"type":"user","content":"target"}}`+"\n")
-	for i := 0; i < 128; i++ {
+	for i := range 128 {
 		id := fmt.Sprintf("sess_%016x", i)
 		path := filepath.Join(root, "workspace", id, "messages.jsonl")
 		writeSourceFile(t, path, `{"payload":{"type":"user","content":"decoy"}}`+"\n")

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -645,12 +645,8 @@ func TestKiroProviderDiscoveryFailsOnSQLiteMetadataError(t *testing.T) {
 	writeSourceFile(t, dbPath, "not a sqlite database")
 	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
 	require.True(t, ok)
-	discovered, err := provider.Discover(context.Background())
-	require.NoError(t, err)
-	require.Len(t, discovered, 1)
-	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: discovered[0]})
+	_, err := provider.Discover(context.Background())
 	assert.Error(t, err)
-	assert.Empty(t, outcome.Results)
 }
 
 func TestKiroProviderLogicalIdentityAndRankUnifyLegacyAndCurrent(t *testing.T) {

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -226,15 +226,18 @@ func TestKiroProviderZeroWinnerSQLitePreservesArchive(t *testing.T) {
 	currentRoot := t.TempDir()
 	sqliteRoot := t.TempDir()
 	rawID := "sess_0123456789abcdef"
+	winnerDBPath, winnerDB := newKiroProviderSQLiteDBAt(t, currentRoot)
+	seedKiroSQLiteSession(
+		t, winnerDB, "/home/user/code/current", rawID,
+		readKiroFixture(t, "standard_payload.json"),
+		1779012000000, 1779012030000,
+	)
 	dbPath, db := newKiroProviderSQLiteDBAt(t, sqliteRoot)
 	seedKiroSQLiteSession(
 		t, db, "/home/user/code/current", rawID,
 		readKiroFixture(t, "standard_payload.json"),
 		1779012000000, 1779012030000,
 	)
-	currentPath := filepath.Join(currentRoot, "workspace", rawID, "messages.jsonl")
-	writeSourceFile(t, currentPath, `{"payload":{"type":"user","content":"current"}}`+"\n")
-
 	provider, ok := NewProvider(AgentKiro, ProviderConfig{
 		Roots: []string{currentRoot, sqliteRoot},
 	})
@@ -242,22 +245,25 @@ func TestKiroProviderZeroWinnerSQLitePreservesArchive(t *testing.T) {
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
 	var database SourceRef
-	var foundCurrent bool
+	var foundWinner bool
 	for _, source := range discovered {
 		if source.DisplayPath == dbPath {
 			database = source
 		}
-		if source.DisplayPath == currentPath {
-			foundCurrent = true
+		if source.DisplayPath == winnerDBPath {
+			foundWinner = true
 		}
 	}
-	require.True(t, foundCurrent)
+	require.True(t, foundWinner)
 	require.Equal(t, dbPath, database.DisplayPath)
 
 	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: database})
 	require.NoError(t, err)
 	assert.Empty(t, outcome.Results)
 	assert.False(t, outcome.ForceReplace)
+	assert.Equal(t, []string{"kiro:" + rawID}, provider.(interface {
+		PreservedSessionIDs(SourceRef) []string
+	}).PreservedSessionIDs(database))
 	assert.Equal(t, SkipNoSession, outcome.SkipReason)
 }
 
@@ -527,8 +533,8 @@ func TestKiroProviderCurrentLayoutRejectsLookalikesAndEscapes(t *testing.T) {
 	root := t.TempDir()
 	valid := filepath.Join(root, "project-a", "sess_0123456789abcdef", "messages.jsonl")
 	writeSourceFile(t, valid, `{"payload":{"type":"user","content":"ok"}}`+"\n")
-	secondValid := filepath.Join(root, "sess_fedcba9876543210", "sess_aaaaaaaaaaaaaaaa", "messages.jsonl")
-	writeSourceFile(t, secondValid, `{"payload":{"type":"user","content":"ok"}}`+"\n")
+	nestedSession := filepath.Join(root, "sess_fedcba9876543210", "sess_aaaaaaaaaaaaaaaa", "messages.jsonl")
+	writeSourceFile(t, nestedSession, `{"payload":{"type":"user","content":"bad"}}`+"\n")
 	for _, path := range []string{
 		filepath.Join(root, ".history", "sess_0123456789abcdef", "messages.jsonl"),
 		filepath.Join(root, "snapshots", "sess_0123456789abcdef", "messages.jsonl"),
@@ -544,11 +550,10 @@ func TestKiroProviderCurrentLayoutRejectsLookalikesAndEscapes(t *testing.T) {
 	require.True(t, ok)
 	sources, err := provider.Discover(context.Background())
 	require.NoError(t, err)
-	require.Len(t, sources, 2)
-	assert.ElementsMatch(t, []string{valid, secondValid}, []string{sources[0].DisplayPath, sources[1].DisplayPath})
+	require.Len(t, sources, 1)
+	assert.Equal(t, valid, sources[0].DisplayPath)
 	for _, tc := range []struct{ id, path string }{
 		{"sess_0123456789abcdef", valid},
-		{"sess_aaaaaaaaaaaaaaaa", secondValid},
 	} {
 		found, foundOK, findErr := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: tc.id})
 		require.NoError(t, findErr)
@@ -640,8 +645,12 @@ func TestKiroProviderDiscoveryFailsOnSQLiteMetadataError(t *testing.T) {
 	writeSourceFile(t, dbPath, "not a sqlite database")
 	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
 	require.True(t, ok)
-	_, err := provider.Discover(context.Background())
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: discovered[0]})
 	assert.Error(t, err)
+	assert.Empty(t, outcome.Results)
 }
 
 func TestKiroProviderLogicalIdentityAndRankUnifyLegacyAndCurrent(t *testing.T) {

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,7 +45,7 @@ func TestKiroProviderSourceMethods(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, plan.Roots, 1)
 	assert.Equal(t, root, plan.Roots[0].Path)
-	assert.False(t, plan.Roots[0].Recursive)
+	assert.True(t, plan.Roots[0].Recursive)
 	assert.Contains(t, plan.Roots[0].IncludeGlobs, "*.jsonl")
 	assert.Contains(t, plan.Roots[0].IncludeGlobs, kiroSQLiteDBName)
 	assert.Contains(t, plan.Roots[0].IncludeGlobs, kiroSQLiteDBName+"-*")
@@ -456,6 +457,73 @@ func TestKiroProviderRejectsInvalidStoredSQLitePaths(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, ok, "stored path %q", path)
 	}
+}
+
+// Synthetic reproduction: the reporter supplied no loadable transcript.
+func TestKiroProviderCurrentLayoutParsesMessages(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "workspace", "sess_0123456789abcdef", "messages.jsonl")
+	writeSourceFile(t, path, strings.Join([]string{
+		`{"payload":{"type":"user","content":"hello"}}`,
+		`{"payload":{"type":"assistant","content":"hi"}}`,
+		`{"payload":{"type":"tool_call","toolName":"read","toolCallId":"call-1","args":{"path":"a.go"}}}`,
+		`{"payload":{"type":"tool_result","toolCallId":"call-1","content":"ok"}}`,
+		`{"payload":{"type":"informational","content":"skip"}}`,
+	}, "\n")+"\n")
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, "kiro:sess_0123456789abcdef", outcome.Results[0].Result.Session.ID)
+	assert.Len(t, outcome.Results[0].Result.Messages, 4)
+}
+
+func TestKiroProviderCurrentLayoutRejectsLookalikesAndEscapes(t *testing.T) {
+	root := t.TempDir()
+	valid := filepath.Join(root, "workspace", "sess_0123456789abcdef", "messages.jsonl")
+	writeSourceFile(t, valid, `{"payload":{"type":"user","content":"ok"}}`+"\n")
+	for _, path := range []string{
+		filepath.Join(root, "workspace", ".history", "sess_0123456789abcdef", "messages.jsonl"),
+		filepath.Join(root, "workspace", "sess_0123456789abcdef", "snapshots", "messages.jsonl"),
+		filepath.Join(root, "workspace", "nested", "sess_0123456789abcdef", "messages.jsonl"),
+		filepath.Join(root, "workspace", "session_0123456789abcdef", "messages.jsonl"),
+	} {
+		writeSourceFile(t, path, `{"payload":{"type":"user","content":"bad"}}`+"\n")
+	}
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, valid, sources[0].DisplayPath)
+	_, ok, err = provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: "sess_../escape"})
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestKiroProviderCurrentLayoutLifecycleAndExactLookup(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "sess_0123456789abcdef", "messages.jsonl")
+	writeSourceFile(t, path, `{"payload":{"type":"user","content":"hello"}}`+"\n")
+	sidecar := filepath.Join(filepath.Dir(path), "session.json")
+	writeSourceFile(t, sidecar, `{"title":"Synthetic","workspacePaths":["/home/user/project"]}`)
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{Path: sidecar, WatchRoot: root, EventKind: "write"})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, path, changed[0].DisplayPath)
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: "sess_0123456789abcdef"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, path, found.DisplayPath)
+	fingerprint, err := provider.Fingerprint(context.Background(), found)
+	require.NoError(t, err)
+	assert.Greater(t, fingerprint.Size, int64(len(`{"payload":{"type":"user","content":"hello"}}`)+1))
 }
 
 func TestKiroIDEProviderSourceMethods(t *testing.T) {

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -596,6 +596,77 @@ func TestKiroProviderRejectsCurrentSymlinkEscapeOnLookupAndChange(t *testing.T) 
 	assert.Empty(t, changed)
 }
 
+func TestKiroProviderFindSourceRanksAllRepresentationsAndRoots(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	legacy := filepath.Join(root, rawID+".jsonl")
+	current := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	writeSourceFile(t, legacy, kiroProviderJSONLFixture("legacy"))
+	writeSourceFile(t, current, `{"payload":{"type":"user","content":"current"}}`+"\n")
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: rawID, StoredFilePath: legacy,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, current, found.DisplayPath,
+		"a non-pinned stored hint must use the same representation ranking as discovery")
+	pinned, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: rawID, StoredFilePath: legacy, PreferStoredSource: true,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, legacy, pinned.DisplayPath)
+}
+
+func TestKiroProviderChangedCurrentEventIncludesSQLiteDuplicate(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	current := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	writeSourceFile(t, current, `{"payload":{"type":"user","content":"current"}}`+"\n")
+	dbPath, db := newKiroProviderSQLiteDBAt(t, root)
+	seedKiroSQLiteSession(t, db, "/home/user/code/kiro-app", rawID,
+		readKiroFixture(t, "standard_payload.json"), 1779012000000, 1779012030000)
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: current, WatchRoot: root, EventKind: "write",
+	})
+	require.NoError(t, err)
+	got := make([]string, len(changed))
+	for i, source := range changed {
+		got[i] = source.DisplayPath
+	}
+	assert.ElementsMatch(t, []string{current, KiroSQLiteVirtualPath(dbPath, rawID)}, got)
+	assert.Equal(t, int64(3), provider.(ReconciliationSourceRanker).
+		ReconciliationSourceRank(changed[1]).Class,
+		"SQLite remains the higher-ranked duplicate when a current transcript changes")
+}
+
+func TestKiroProviderCurrentSidecarRequiresRegularContainedFile(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	current := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	writeSourceFile(t, current, `{"payload":{"type":"user","content":"hello"}}`+"\n")
+	sidecar := filepath.Join(filepath.Dir(current), "session.json")
+	require.NoError(t, os.Mkdir(sidecar, 0o755))
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: sidecar, WatchRoot: root, EventKind: "write",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, changed, "a directory named session.json is not metadata")
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Empty(t, outcome.Results[0].Result.Session.SessionName)
+}
+
 func TestKiroIDEProviderSourceMethods(t *testing.T) {
 	root := t.TempDir()
 	oldWSHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -170,8 +170,8 @@ func TestKiroProviderSkipsShadowedLegacySource(t *testing.T) {
 	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
 	require.NoError(t, err)
 	assert.True(t, outcome.ResultSetComplete)
-	assert.Equal(t, SkipNoSession, outcome.SkipReason)
-	assert.Empty(t, outcome.Results)
+	assert.Len(t, outcome.Results, 1)
+	assert.Equal(t, "kiro:shadowed-session", outcome.Results[0].Result.Session.ID)
 
 	source, ok, err = provider.FindSource(context.Background(), FindSourceRequest{
 		FullSessionID:  "host~kiro:shadowed-session",
@@ -216,8 +216,8 @@ func TestKiroProviderShadowsLegacyAcrossAllRoots(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, outcome.ResultSetComplete)
-	assert.Equal(t, SkipNoSession, outcome.SkipReason)
-	assert.Empty(t, outcome.Results)
+	assert.Len(t, outcome.Results, 1)
+	assert.Equal(t, "kiro:shared-session", outcome.Results[0].Result.Session.ID)
 }
 
 func TestKiroProviderFingerprintsSQLiteAndLegacySources(t *testing.T) {
@@ -574,10 +574,11 @@ func TestKiroProviderLogicalIdentityAndRankUnifyLegacyAndCurrent(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	require.Len(t, streamed, 1)
+	require.Len(t, streamed, 2)
 	assert.Equal(t, rawID, streamed[0].Key)
 	ranker := provider.(ReconciliationSourceRanker)
-	assert.Equal(t, int64(2), ranker.ReconciliationSourceRank(streamed[0]).Class)
+	assert.Equal(t, int64(1), ranker.ReconciliationSourceRank(streamed[0]).Class)
+	assert.Equal(t, int64(2), ranker.ReconciliationSourceRank(streamed[1]).Class)
 	legacySource, ok, err := provider.FindSource(context.Background(), FindSourceRequest{StoredFilePath: legacy})
 	require.NoError(t, err)
 	require.True(t, ok)
@@ -662,10 +663,9 @@ func TestKiroProviderChangedCurrentEventIncludesSQLiteDuplicate(t *testing.T) {
 	for i, source := range changed {
 		got[i] = source.DisplayPath
 	}
-	assert.ElementsMatch(t, []string{current, KiroSQLiteVirtualPath(dbPath, rawID)}, got)
+	assert.Equal(t, []string{KiroSQLiteVirtualPath(dbPath, rawID)}, got)
 	assert.Equal(t, int64(3), provider.(ReconciliationSourceRanker).
-		ReconciliationSourceRank(changed[1]).Class,
-		"SQLite remains the higher-ranked duplicate when a current transcript changes")
+		ReconciliationSourceRank(changed[0]).Class)
 }
 
 func TestKiroProviderCurrentSidecarRequiresRegularContainedFile(t *testing.T) {

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -526,6 +526,76 @@ func TestKiroProviderCurrentLayoutLifecycleAndExactLookup(t *testing.T) {
 	assert.Greater(t, fingerprint.Size, int64(len(`{"payload":{"type":"user","content":"hello"}}`)+1))
 }
 
+func TestKiroProviderLogicalIdentityAndRankUnifyLegacyAndCurrent(t *testing.T) {
+	root := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	legacy := filepath.Join(root, rawID+".jsonl")
+	current := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	writeSourceFile(t, legacy, kiroProviderJSONLFixture("legacy"))
+	writeSourceFile(t, current, `{"timestamp":"2026-08-24T12:34:56Z","payload":{"type":"user","content":"current"}}`+"\n")
+
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, current, discovered[0].DisplayPath)
+	assert.Equal(t, rawID, discovered[0].Key)
+
+	var streamed []SourceRef
+	err = provider.(interface {
+		DiscoverEach(context.Context, func(SourceRef) error) error
+	}).DiscoverEach(context.Background(), func(source SourceRef) error {
+		streamed = append(streamed, source)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, streamed, 1)
+	assert.Equal(t, rawID, streamed[0].Key)
+	ranker := provider.(ReconciliationSourceRanker)
+	assert.Equal(t, int64(2), ranker.ReconciliationSourceRank(streamed[0]).Class)
+	legacySource, ok, err := provider.FindSource(context.Background(), FindSourceRequest{StoredFilePath: legacy})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawID, legacySource.Key)
+	assert.Equal(t, int64(1), ranker.ReconciliationSourceRank(legacySource).Class)
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: rawID})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, current, found.DisplayPath)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: found})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	require.Len(t, outcome.Results[0].Result.Messages, 1)
+	assert.Equal(t, time.Date(2026, 8, 24, 12, 34, 56, 0, time.UTC),
+		outcome.Results[0].Result.Messages[0].Timestamp)
+}
+
+func TestKiroProviderRejectsCurrentSymlinkEscapeOnLookupAndChange(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	rawID := "sess_0123456789abcdef"
+	outsidePath := filepath.Join(outside, "messages.jsonl")
+	writeSourceFile(t, outsidePath, `{"payload":{"type":"user","content":"outside"}}`+"\n")
+	path := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsidePath, path); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	_, ok, err := provider.FindSource(context.Background(), FindSourceRequest{StoredFilePath: path})
+	require.NoError(t, err)
+	assert.False(t, ok)
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{Path: path, WatchRoot: root, EventKind: "write"})
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+}
+
 func TestKiroIDEProviderSourceMethods(t *testing.T) {
 	root := t.TempDir()
 	oldWSHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -484,16 +484,18 @@ func TestKiroProviderCurrentLayoutParsesMessages(t *testing.T) {
 
 func TestKiroProviderCurrentLayoutRejectsLookalikesAndEscapes(t *testing.T) {
 	root := t.TempDir()
-	valid := filepath.Join(root, "workspace", "sess_0123456789abcdef", "messages.jsonl")
+	valid := filepath.Join(root, "project-a", "sess_0123456789abcdef", "messages.jsonl")
 	writeSourceFile(t, valid, `{"payload":{"type":"user","content":"ok"}}`+"\n")
+	secondValid := filepath.Join(root, "workspace", "sess_fedcba9876543210", "messages.jsonl")
+	writeSourceFile(t, secondValid, `{"payload":{"type":"user","content":"ok"}}`+"\n")
 	for _, path := range []string{
 		filepath.Join(root, ".history", "sess_0123456789abcdef", "messages.jsonl"),
 		filepath.Join(root, "snapshots", "sess_0123456789abcdef", "messages.jsonl"),
-		filepath.Join(root, "arbitrary", "sess_0123456789abcdef", "messages.jsonl"),
 		filepath.Join(root, "workspace", ".history", "sess_0123456789abcdef", "messages.jsonl"),
 		filepath.Join(root, "workspace", "sess_0123456789abcdef", "snapshots", "messages.jsonl"),
 		filepath.Join(root, "workspace", "nested", "sess_0123456789abcdef", "messages.jsonl"),
 		filepath.Join(root, "workspace", "session_0123456789abcdef", "messages.jsonl"),
+		filepath.Join(root, "project-a", "sess_bad.id", "messages.jsonl"),
 	} {
 		writeSourceFile(t, path, `{"payload":{"type":"user","content":"bad"}}`+"\n")
 	}
@@ -501,8 +503,27 @@ func TestKiroProviderCurrentLayoutRejectsLookalikesAndEscapes(t *testing.T) {
 	require.True(t, ok)
 	sources, err := provider.Discover(context.Background())
 	require.NoError(t, err)
-	require.Len(t, sources, 1)
-	assert.Equal(t, valid, sources[0].DisplayPath)
+	require.Len(t, sources, 2)
+	assert.ElementsMatch(t, []string{valid, secondValid}, []string{sources[0].DisplayPath, sources[1].DisplayPath})
+	for _, tc := range []struct{ id, path string }{
+		{"sess_0123456789abcdef", valid},
+		{"sess_fedcba9876543210", secondValid},
+	} {
+		found, foundOK, findErr := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: tc.id})
+		require.NoError(t, findErr)
+		require.True(t, foundOK)
+		assert.Equal(t, tc.path, found.DisplayPath)
+	}
+	sidecar := filepath.Join(filepath.Dir(valid), "session.json")
+	writeSourceFile(t, sidecar, `{"title":"Synthetic"}`)
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{Path: sidecar, WatchRoot: root, EventKind: "write"})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, valid, changed[0].DisplayPath)
+	changed, err = provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{Path: valid, WatchRoot: root, EventKind: "write"})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, valid, changed[0].DisplayPath)
 	_, ok, err = provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: "sess_../escape"})
 	require.NoError(t, err)
 	assert.False(t, ok)

--- a/internal/parser/kiro_sqlite.go
+++ b/internal/parser/kiro_sqlite.go
@@ -133,11 +133,56 @@ func KiroSQLiteSessionExistsWithError(dbPath, sessionID string) (bool, error) {
 	return store.sessionExists(sessionID)
 }
 
+// KiroSQLiteSessionMetaForID returns metadata for one logical conversation
+// without enumerating the rest of the database.
+func KiroSQLiteSessionMetaForID(
+	dbPath, sessionID string,
+) (KiroSQLiteSessionMeta, bool, error) {
+	if dbPath == "" || sessionID == "" {
+		return KiroSQLiteSessionMeta{}, false, nil
+	}
+	store, err := OpenKiroSQLiteStore(dbPath)
+	if err != nil {
+		return KiroSQLiteSessionMeta{}, false, err
+	}
+	defer store.Close()
+	return store.sessionMetaForID(sessionID)
+}
+
 // SessionExists reports whether the current Kiro DB has at least one
 // row for sessionID.
 func (s *KiroSQLiteStore) SessionExists(sessionID string) bool {
 	exists, _ := s.sessionExists(sessionID)
 	return exists
+}
+
+func (s *KiroSQLiteStore) sessionMetaForID(
+	sessionID string,
+) (KiroSQLiteSessionMeta, bool, error) {
+	if s == nil || s.db == nil {
+		return KiroSQLiteSessionMeta{}, false, fmt.Errorf("kiro sqlite store is closed")
+	}
+	var id string
+	var updatedAt int64
+	err := s.db.QueryRow(`
+		SELECT conversation_id, MAX(updated_at)
+		  FROM conversations_v2
+		 WHERE conversation_id = ?
+		 GROUP BY conversation_id
+	`, sessionID).Scan(&id, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return KiroSQLiteSessionMeta{}, false, nil
+	}
+	if err != nil {
+		return KiroSQLiteSessionMeta{}, false, fmt.Errorf(
+			"finding kiro sqlite session meta: %w", err,
+		)
+	}
+	return KiroSQLiteSessionMeta{
+		SessionID:   id,
+		VirtualPath: KiroSQLiteVirtualPath(s.dbPath, id),
+		FileMtime:   updatedAt * 1_000_000,
+	}, true, nil
 }
 
 func (s *KiroSQLiteStore) sessionExists(sessionID string) (bool, error) {

--- a/internal/parser/kiro_sqlite.go
+++ b/internal/parser/kiro_sqlite.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -68,26 +69,37 @@ func (s *KiroSQLiteStore) Close() error {
 // kiroSQLiteDBPath returns the current-store Kiro SQLite DB when the
 // configured root contains one.
 func kiroSQLiteDBPath(dir string) string {
+	path, _ := kiroSQLiteDBPathChecked(dir)
+	return path
+}
+
+func kiroSQLiteDBPathChecked(dir string) (string, error) {
 	if dir == "" {
-		return ""
+		return "", nil
 	}
 	path := filepath.Join(dir, kiroSQLiteDBName)
 	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return ""
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("stat Kiro SQLite DB %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return "", nil
 	}
 	resolvedDir, err := filepath.EvalSymlinks(dir)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	resolvedPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	if _, ok := relUnder(resolvedDir, resolvedPath); !ok {
-		return ""
+		return "", nil
 	}
-	return path
+	return path, nil
 }
 
 // KiroSQLiteVirtualPath gives each conversation inside the shared
@@ -118,14 +130,19 @@ func KiroSQLiteSessionExistsWithError(dbPath, sessionID string) (bool, error) {
 		return false, err
 	}
 	defer store.Close()
-	return store.SessionExists(sessionID), nil
+	return store.sessionExists(sessionID)
 }
 
 // SessionExists reports whether the current Kiro DB has at least one
 // row for sessionID.
 func (s *KiroSQLiteStore) SessionExists(sessionID string) bool {
+	exists, _ := s.sessionExists(sessionID)
+	return exists
+}
+
+func (s *KiroSQLiteStore) sessionExists(sessionID string) (bool, error) {
 	if s == nil || s.db == nil || sessionID == "" {
-		return false
+		return false, nil
 	}
 	var found int
 	err := s.db.QueryRow(
@@ -135,7 +152,10 @@ func (s *KiroSQLiteStore) SessionExists(sessionID string) bool {
 		  LIMIT 1`,
 		sessionID,
 	).Scan(&found)
-	return err == nil
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
 }
 
 // ListKiroSQLiteSessionMeta returns one metadata row per logical

--- a/internal/parser/kiro_sqlite.go
+++ b/internal/parser/kiro_sqlite.go
@@ -105,15 +105,20 @@ func kiroSQLiteVirtualPathParts(path string) (string, string, bool) {
 // KiroSQLiteSessionExists reports whether the current Kiro DB has
 // at least one row for sessionID.
 func KiroSQLiteSessionExists(dbPath, sessionID string) bool {
+	exists, _ := KiroSQLiteSessionExistsWithError(dbPath, sessionID)
+	return exists
+}
+
+func KiroSQLiteSessionExistsWithError(dbPath, sessionID string) (bool, error) {
 	if dbPath == "" || sessionID == "" {
-		return false
+		return false, nil
 	}
 	store, err := OpenKiroSQLiteStore(dbPath)
 	if err != nil {
-		return false
+		return false, err
 	}
 	defer store.Close()
-	return store.SessionExists(sessionID)
+	return store.SessionExists(sessionID), nil
 }
 
 // SessionExists reports whether the current Kiro DB has at least one

--- a/internal/parser/kiro_sqlite.go
+++ b/internal/parser/kiro_sqlite.go
@@ -40,8 +40,15 @@ type KiroSQLiteStore struct {
 
 // OpenKiroSQLiteStore opens a read-only current-store Kiro SQLite DB.
 func OpenKiroSQLiteStore(dbPath string) (*KiroSQLiteStore, error) {
-	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+	info, err := os.Lstat(dbPath)
+	if os.IsNotExist(err) {
 		return nil, fmt.Errorf("kiro sqlite db not found: %s", dbPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("stat kiro sqlite db %s: %w", dbPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing symlinked kiro sqlite db: %s", dbPath)
 	}
 	db, err := openKiroSQLiteDB(dbPath)
 	if err != nil {
@@ -67,6 +74,17 @@ func kiroSQLiteDBPath(dir string) string {
 	path := filepath.Join(dir, kiroSQLiteDBName)
 	info, err := os.Stat(path)
 	if err != nil || info.IsDir() {
+		return ""
+	}
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return ""
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return ""
+	}
+	if _, ok := relUnder(resolvedDir, resolvedPath); !ok {
 		return ""
 	}
 	return path

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -595,7 +595,7 @@ var Registry = []AgentDef{
 		EnvVar:      "KIRO_SESSIONS_DIR",
 		ConfigKey:   "kiro_dirs",
 		DefaultDirs: []string{
-			".kiro/sessions/cli",
+			".kiro/sessions",
 			".local/share/kiro-cli",
 		},
 		IDPrefix:  "kiro:",

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5876,7 +5876,7 @@ func (e *Engine) reconciliationCandidate(
 		rank := ranker.ReconciliationSourceRank(source)
 		if agent == parser.AgentKiro {
 			preference1 = rank.Class
-			preference2 = configuredRootPreference(statPath, roots)
+			preference2 = configuredRootPreferenceForSource(source, statPath, roots)
 			preference3 = rank.Recency
 		} else {
 			preference2 = rank.Class
@@ -5904,6 +5904,20 @@ func configuredRootPreference(path string, roots []string) int64 {
 		}
 	}
 	return 0
+}
+
+func configuredRootPreferenceForSource(
+	source parser.SourceRef, path string, roots []string,
+) int64 {
+	if source.ConfiguredRoot != "" {
+		for i, configured := range roots {
+			if samePathOrDescendant(configured, source.ConfiguredRoot) &&
+				samePathOrDescendant(source.ConfiguredRoot, configured) {
+				return int64(len(roots) - i)
+			}
+		}
+	}
+	return configuredRootPreference(path, roots)
 }
 
 func boolPreference(value bool) int64 {
@@ -11145,7 +11159,9 @@ func (e *Engine) processProviderFile(
 			}
 		}
 		skipRes := processResult{
-			skip:                 !outcome.ForceReplace,
+			// A complete Kiro source can report no current rows while still
+			// owning stored members that need source-missing reconciliation.
+			skip:                 !outcome.ForceReplace && len(missingMembers) == 0,
 			excludedSessionIDs:   excludedSessionIDs,
 			preservedSessionIDs:  preservedSessionIDs,
 			sourceMissingMembers: missingMembers,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7660,7 +7660,12 @@ func filterProviderSourcesToScope(
 ) []parser.SourceRef {
 	filtered := sources[:0]
 	for _, source := range sources {
-		if scope.includes(source.ConfiguredRoot) {
+		// Overlapping roots can attribute a winner to an out-of-scope
+		// ancestor; a physically in-scope source stays admitted.
+		if scope.includes(source.ConfiguredRoot) ||
+			scope.includes(validatedProviderSourceStatPath(
+				providerDiscoveredPath(source),
+			)) {
 			filtered = append(filtered, source)
 		}
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5600,10 +5600,15 @@ func (e *Engine) streamReconciliationCandidates(
 			for i, scope := range group.scopes {
 				groupProofs[i] = storedSourceDBHintScopes(scope.PhysicalProofScopes)
 			}
+			rankingRoots := traversalRoots
+			if agent == parser.AgentKiro {
+				// Kiro precedence uses configured roots for reordered scoped requests.
+				rankingRoots = e.agentDirs[agent]
+			}
 			var spoolErr error
 			err = discoverer.DiscoverEach(ctx, func(source parser.SourceRef) error {
 				candidate, ok := e.reconciliationCandidate(
-					provider, source, traversalRoots, watchRoots,
+					provider, source, rankingRoots, watchRoots,
 				)
 				if !ok {
 					return nil
@@ -5858,12 +5863,7 @@ func (e *Engine) reconciliationCandidate(
 			preference1 = 1
 		}
 	} else if !claudeFormat && !isCodexFormatAgent(agent) {
-		for i, configured := range roots {
-			if samePathOrDescendant(statPath, configured) {
-				preference1 = int64(len(roots) - i)
-				break
-			}
-		}
+		preference1 = configuredRootPreference(statPath, roots)
 	}
 	if ranker, ok := provider.(parser.ReconciliationSourceRanker); ok {
 		rank := ranker.ReconciliationSourceRank(source)
@@ -5882,6 +5882,15 @@ func (e *Engine) reconciliationCandidate(
 		Project: source.ProjectHint, Preference1: preference1,
 		Preference2: preference2, Preference3: preference3,
 	}, true
+}
+
+func configuredRootPreference(path string, roots []string) int64 {
+	for i, configured := range roots {
+		if samePathOrDescendant(path, configured) {
+			return int64(len(roots) - i)
+		}
+	}
+	return 0
 }
 
 func boolPreference(value bool) int64 {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5695,13 +5695,6 @@ func (e *Engine) streamReconciliationCandidates(
 					return providers, completedScopes,
 						failedRoots, failures, discoveryErr, ctx.Err()
 				}
-				if agent == parser.AgentKiro {
-					kiroErr := fmt.Errorf(
-						"%s provider streaming discovery: %w", agent, err,
-					)
-					return providers, completedScopes, failedRoots, failures,
-						errors.Join(discoveryErr, kiroErr), kiroErr
-				}
 				log.Printf("%s provider streaming discovery: %v", agent, err)
 				failures++
 				failedRoots = append(failedRoots, groupRetryRoots...)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -17279,6 +17279,9 @@ func shouldReplaceFullParseMessages(
 ) bool {
 	return forceReplace || pw.forceReplace || pw.needsRetry || stale ||
 		revivingSourceMissing ||
+		// Kiro full parses rebuild the complete accepted message projection;
+		// append semantics would retain rows removed or rewritten by the source.
+		pw.sess.Agent == parser.AgentKiro ||
 		pw.sess.Agent == parser.AgentCowork ||
 		// Copilot execution start/completion records arrive after the
 		// assistant tool-call message and attach result events to it. An

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11167,8 +11167,12 @@ func (e *Engine) processProviderFile(
 		excludedSessionIDs := append([]string(nil), outcome.ExcludedSessionIDs...)
 		preservedSessionIDs := providerPreservedSessionIDs(provider, source)
 		var missingMembers []sourceMissingMember
-		if file.Agent == parser.AgentKiro && outcome.ResultSetComplete &&
-			len(outcome.SourceErrors) == 0 {
+		if file.Agent == parser.AgentKiro &&
+			parser.KiroSQLiteSourcePresent(source) &&
+			outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 {
+			// Only a present SQLite container owns a complete membership set.
+			// Current and legacy JSONL sources can legitimately parse to no
+			// accepted records during a partial rewrite and must preserve archive rows.
 			missingMembers, err = e.providerSourceMissingSessionOwnershipsForCompleteResultWithPreserved(
 				ctx, provider, source, preservedSessionIDs, nil,
 			)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7194,7 +7194,6 @@ func (e *Engine) syncAllLocked(
 		all = dedupeDiscoveredFiles(all)
 	}
 	all = e.dedupeClaudeDiscoveredFiles(all)
-	all = e.filterShadowedLegacyKiroFiles(all)
 	if forceDiscoveredFiles {
 		for i := range all {
 			all[i].ForceParse = true
@@ -7461,8 +7460,14 @@ func (e *Engine) discoverProviderSources(
 		if !ok || factory == nil {
 			continue
 		}
+		providerRoots := filteredRoots
+		if agentType == parser.AgentKiro {
+			// Kiro must arbitrate against out-of-scope roots before scoped
+			// admission, otherwise a lower-ranked in-scope copy is imported.
+			providerRoots = roots
+		}
 		provider := factory.NewProvider(parser.ProviderConfig{
-			Roots:                              filteredRoots,
+			Roots:                              providerRoots,
 			Machine:                            e.machine,
 			SourceMachines:                     e.sourceMachines[agentType],
 			PathRewriter:                       e.pathRewriter,
@@ -7489,6 +7494,9 @@ func (e *Engine) discoverProviderSources(
 			log.Printf("%s provider discovery: %v", agentType, err)
 			failures++
 			continue
+		}
+		if agentType == parser.AgentKiro {
+			sources = filterProviderSourcesToScope(sources, scope)
 		}
 		forceParseSource := func(string) bool { return false }
 		if agentType == parser.AgentVSCopilot {
@@ -7556,6 +7564,19 @@ func (e *Engine) discoverProviderSources(
 		}
 	}
 	return files, failures
+}
+
+func filterProviderSourcesToScope(
+	sources []parser.SourceRef,
+	scope *rootSyncScope,
+) []parser.SourceRef {
+	filtered := sources[:0]
+	for _, source := range sources {
+		if scope.includes(source.ConfiguredRoot) {
+			filtered = append(filtered, source)
+		}
+	}
+	return filtered
 }
 
 func providerSourcePathSet(sources []parser.SourceRef) map[string]struct{} {
@@ -18183,21 +18204,6 @@ func (e *Engine) FindSourceFile(sessionID string) string {
 		}
 		return ""
 	}
-	if def.Type == parser.AgentKiro {
-		for _, dir := range e.agentDirs[parser.AgentKiro] {
-			dbPath := kiroSQLiteDBPath(dir)
-			if dbPath == "" ||
-				!parser.KiroSQLiteSessionExists(
-					dbPath, rawSessionID,
-				) {
-				continue
-			}
-			return parser.KiroSQLiteVirtualPath(
-				dbPath, rawSessionID,
-			)
-		}
-	}
-
 	bareID := strings.TrimPrefix(rawID, def.IDPrefix)
 	storedPath := e.db.GetSessionFilePath(sessionID)
 
@@ -19299,58 +19305,6 @@ func (e *Engine) applyWorktreeMappingToSingleSession(
 		)
 	}
 	return mapped.Project, nil
-}
-
-// filterShadowedLegacyKiroFiles drops discovered legacy Kiro JSONL sources
-// whose logical session ID already exists in a current-store SQLite database
-// under any configured Kiro root. The Kiro provider performs the same
-// shadowing during its own Discover, but only across the roots it is
-// configured with; a scoped sync (e.g. SyncRootsSince over a single root)
-// configures the provider with that scope only, so the engine reapplies the
-// cross-root shadow here using every configured Kiro root. This keeps a legacy
-// file from being imported when its session lives in the SQLite store of a
-// different, out-of-scope root.
-func (e *Engine) filterShadowedLegacyKiroFiles(
-	files []parser.DiscoveredFile,
-) []parser.DiscoveredFile {
-	if !hasLegacyKiroCandidates(files) {
-		return files
-	}
-
-	currentIDs := make(map[string]struct{})
-	for _, dir := range e.agentDirs[parser.AgentKiro] {
-		for id := range parser.KiroSQLiteSessionIDs(dir) {
-			currentIDs[id] = struct{}{}
-		}
-	}
-	if len(currentIDs) == 0 {
-		return files
-	}
-
-	out := files[:0]
-	for _, file := range files {
-		if file.Agent != parser.AgentKiro ||
-			filepath.Base(file.Path) == kiroSQLiteDBName {
-			out = append(out, file)
-			continue
-		}
-		legacyID := parser.KiroSessionIDFromPath(file.Path)
-		if _, shadowed := currentIDs[legacyID]; shadowed {
-			continue
-		}
-		out = append(out, file)
-	}
-	return out
-}
-
-func hasLegacyKiroCandidates(files []parser.DiscoveredFile) bool {
-	for _, file := range files {
-		if file.Agent == parser.AgentKiro &&
-			filepath.Base(file.Path) != kiroSQLiteDBName {
-			return true
-		}
-	}
-	return false
 }
 
 // kiroSQLiteDBName is the filename of the current-store Kiro SQLite DB.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5558,6 +5558,9 @@ func (e *Engine) streamReconciliationCandidates(
 			}
 			planRetryRoots = append(planRetryRoots, scope.RetryRoots...)
 		}
+		if agent == parser.AgentKiro {
+			traversalRoots = append([]string(nil), e.agentDirs[agent]...)
+		}
 		provider := factory.NewProvider(parser.ProviderConfig{
 			Roots: traversalRoots, Machine: e.machine, PathRewriter: e.pathRewriter,
 			SourceMachines:                     e.sourceMachines[agent],
@@ -5584,8 +5587,15 @@ func (e *Engine) streamReconciliationCandidates(
 			for _, scope := range group.scopes {
 				groupRetryRoots = append(groupRetryRoots, scope.RetryRoots...)
 			}
+			discoveryRoots := group.roots
+			if agent == parser.AgentKiro {
+				// Kiro source arbitration spans every configured root even when
+				// the proof scope is partial; only the winning candidate inside
+				// that proof is admitted to processing below.
+				discoveryRoots = e.agentDirs[agent]
+			}
 			scopeProvider := factory.NewProvider(parser.ProviderConfig{
-				Roots: group.roots, Machine: e.machine,
+				Roots: discoveryRoots, Machine: e.machine,
 				SourceMachines:                     e.sourceMachines[agent],
 				PathRewriter:                       e.pathRewriter,
 				SQLiteContainerUnchangedSinceTrust: containerTrusted,
@@ -5605,12 +5615,23 @@ func (e *Engine) streamReconciliationCandidates(
 				// Kiro precedence uses configured roots for reordered scoped requests.
 				rankingRoots = e.agentDirs[agent]
 			}
+			var kiroWinners map[string]reconciliationCandidate
+			if agent == parser.AgentKiro {
+				kiroWinners = make(map[string]reconciliationCandidate)
+			}
 			var spoolErr error
 			err = discoverer.DiscoverEach(ctx, func(source parser.SourceRef) error {
 				candidate, ok := e.reconciliationCandidate(
 					provider, source, rankingRoots, watchRoots,
 				)
 				if !ok {
+					return nil
+				}
+				if agent == parser.AgentKiro {
+					current, exists := kiroWinners[candidate.Identity]
+					if !exists || reconciliationCandidatePreferred(candidate, current) {
+						kiroWinners[candidate.Identity] = candidate
+					}
 					return nil
 				}
 				admitted := false
@@ -5642,6 +5663,29 @@ func (e *Engine) streamReconciliationCandidates(
 				spoolErr = spool.Add(ctx, candidate)
 				return spoolErr
 			})
+			if err == nil && agent == parser.AgentKiro {
+				for _, identity := range slices.Sorted(maps.Keys(kiroWinners)) {
+					candidate := kiroWinners[identity]
+					admitted := false
+					for _, proofScopes := range groupProofs {
+						if db.StoredSourcePathHintScopesContain(candidate.Path, proofScopes) {
+							admitted = true
+							break
+						}
+					}
+					if !admitted {
+						continue
+					}
+					spoolErr = spool.Add(ctx, candidate)
+					if spoolErr != nil {
+						break
+					}
+				}
+				if spoolErr != nil {
+					return providers, completedScopes,
+						failedRoots, failures, discoveryErr, spoolErr
+				}
+			}
 			if err != nil {
 				if spoolErr != nil {
 					return providers, completedScopes,
@@ -5895,6 +5939,21 @@ func (e *Engine) reconciliationCandidate(
 		Project: source.ProjectHint, Preference1: preference1,
 		Preference2: preference2, Preference3: preference3,
 	}, true
+}
+
+func reconciliationCandidatePreferred(
+	candidate, current reconciliationCandidate,
+) bool {
+	if candidate.Preference1 != current.Preference1 {
+		return candidate.Preference1 > current.Preference1
+	}
+	if candidate.Preference2 != current.Preference2 {
+		return candidate.Preference2 > current.Preference2
+	}
+	if candidate.Preference3 != current.Preference3 {
+		return candidate.Preference3 > current.Preference3
+	}
+	return candidate.Path < current.Path
 }
 
 func configuredRootPreference(path string, roots []string) int64 {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5867,8 +5867,14 @@ func (e *Engine) reconciliationCandidate(
 	}
 	if ranker, ok := provider.(parser.ReconciliationSourceRanker); ok {
 		rank := ranker.ReconciliationSourceRank(source)
-		preference2 = rank.Class
-		preference3 = rank.Recency
+		if agent == parser.AgentKiro {
+			preference1 = rank.Class
+			preference2 = configuredRootPreference(statPath, roots)
+			preference3 = rank.Recency
+		} else {
+			preference2 = rank.Class
+			preference3 = rank.Recency
+		}
 	}
 	if agent == parser.AgentAntigravityCLI {
 		preference2 = boolPreference(strings.HasSuffix(path, ".db"))
@@ -10233,6 +10239,9 @@ type sourceMissingMember struct {
 type processResult struct {
 	results            []parser.ParseResult
 	excludedSessionIDs []string
+	// preservedSessionIDs are higher-ranked members omitted by a shared source;
+	// they remain present while lower-ranked source ownership is reconciled.
+	preservedSessionIDs []string
 	// sourceMissingMembers carries stored sessions whose virtual member
 	// source no longer exists inside a still-present shared container
 	// (e.g. a Windsurf conversation deleted from state.vscdb). They must
@@ -11076,8 +11085,24 @@ func (e *Engine) processProviderFile(
 			e.anomalies.recordUnsupportedSourceLayout(string(file.Agent), file.Path)
 		}
 		excludedSessionIDs := append([]string(nil), outcome.ExcludedSessionIDs...)
+		preservedSessionIDs := providerPreservedSessionIDs(provider, source)
 		var missingMembers []sourceMissingMember
-		if outcome.ForceReplace && outcome.ResultSetComplete {
+		if file.Agent == parser.AgentKiro && outcome.ResultSetComplete &&
+			len(outcome.SourceErrors) == 0 {
+			missingMembers, err = e.providerSourceMissingSessionOwnershipsForCompleteResultWithPreserved(
+				ctx, provider, source, preservedSessionIDs, nil,
+			)
+			if err != nil {
+				return processResult{
+					err:            err,
+					mtime:          fingerprint.MTimeNS,
+					cacheSkip:      cacheSkip,
+					cacheKey:       cacheKey,
+					noCacheSkip:    true,
+					retentionLease: lease,
+				}, true
+			}
+		} else if outcome.ForceReplace && outcome.ResultSetComplete {
 			owned, ownershipErr :=
 				e.providerSourceSessionOwnershipsForForceReplace(
 					ctx, provider, source,
@@ -11115,6 +11140,7 @@ func (e *Engine) processProviderFile(
 		skipRes := processResult{
 			skip:                 !outcome.ForceReplace,
 			excludedSessionIDs:   excludedSessionIDs,
+			preservedSessionIDs:  preservedSessionIDs,
 			sourceMissingMembers: missingMembers,
 			mtime:                fingerprint.MTimeNS,
 			cacheSkip:            cacheSkip,
@@ -11143,17 +11169,18 @@ func (e *Engine) processProviderFile(
 	parsedResults := parseOutcomeResults(outcome.Results)
 	parsedCount := len(parsedResults)
 	excludedSessionIDs := append([]string(nil), outcome.ExcludedSessionIDs...)
+	preservedSessionIDs := providerPreservedSessionIDs(provider, source)
 	var missingMembers []sourceMissingMember
 	// Parse-diff intentionally reports a removed Trae member through its
 	// presence sweep. It never filters unchanged results or writes tombstones,
 	// so ownership reconciliation is needed only by real sync engines.
-	if ((file.Agent == parser.AgentOmnigent && outcome.ForceReplace) ||
+	if (file.Agent == parser.AgentKiro ||
+		(file.Agent == parser.AgentOmnigent && outcome.ForceReplace) ||
 		(file.Agent == parser.AgentTrae && !e.forceParse)) &&
 		outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 {
-		missingMembers, err =
-			e.providerSourceMissingSessionOwnershipsForCompleteResult(
-				ctx, provider, source, parsedResults,
-			)
+		missingMembers, err = e.providerSourceMissingSessionOwnershipsForCompleteResultWithPreserved(
+			ctx, provider, source, preservedSessionIDs, parsedResults,
+		)
 		if err != nil {
 			return processResult{
 				err:            err,
@@ -11204,6 +11231,7 @@ func (e *Engine) processProviderFile(
 	res := processResult{
 		results:              filteredResults,
 		excludedSessionIDs:   excludedSessionIDs,
+		preservedSessionIDs:  preservedSessionIDs,
 		sourceMissingMembers: missingMembers,
 		mtime:                fingerprint.MTimeNS,
 		cacheSkip:            cacheSkip,
@@ -11345,6 +11373,20 @@ func (e *Engine) providerSourceSessionIDsForForceReplace(
 	return ids, nil
 }
 
+type preservedSessionIDProvider interface {
+	PreservedSessionIDs(parser.SourceRef) []string
+}
+
+func providerPreservedSessionIDs(
+	provider parser.Provider, source parser.SourceRef,
+) []string {
+	preserved, ok := provider.(preservedSessionIDProvider)
+	if !ok {
+		return nil
+	}
+	return preserved.PreservedSessionIDs(source)
+}
+
 // providerSourceSessionOwnershipsForForceReplace lists the stored active
 // sessions owned by a force-replaced source, paired with the exact stored
 // file path each row is tracked under, so callers can either hard-delete
@@ -11431,10 +11473,27 @@ func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResult(
 	source parser.SourceRef,
 	results []parser.ParseResult,
 ) ([]sourceMissingMember, error) {
+	return e.providerSourceMissingSessionOwnershipsForCompleteResultWithPreserved(
+		ctx, provider, source, nil, results,
+	)
+}
+
+func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResultWithPreserved(
+	ctx context.Context,
+	provider parser.Provider,
+	source parser.SourceRef,
+	preservedSessionIDs []string,
+	results []parser.ParseResult,
+) ([]sourceMissingMember, error) {
 	emitted := make(map[string]struct{}, len(results))
 	for _, result := range results {
 		id := applyIDPrefixToID(e.idPrefix, result.Session.ID)
 		if id != "" {
+			emitted[id] = struct{}{}
+		}
+	}
+	for _, id := range preservedSessionIDs {
+		if id := applyIDPrefixToID(e.idPrefix, id); id != "" {
 			emitted[id] = struct{}{}
 		}
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11474,17 +11474,6 @@ func (e *Engine) providerSourceSessionOwnershipsForForceReplace(
 	return members, nil
 }
 
-func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResult(
-	ctx context.Context,
-	provider parser.Provider,
-	source parser.SourceRef,
-	results []parser.ParseResult,
-) ([]sourceMissingMember, error) {
-	return e.providerSourceMissingSessionOwnershipsForCompleteResultWithPreserved(
-		ctx, provider, source, nil, results,
-	)
-}
-
 func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResultWithPreserved(
 	ctx context.Context,
 	provider parser.Provider,
@@ -19384,20 +19373,6 @@ func (e *Engine) applyWorktreeMappingToSingleSession(
 
 // kiroSQLiteDBName is the filename of the current-store Kiro SQLite DB.
 const kiroSQLiteDBName = "data.sqlite3"
-
-// kiroSQLiteDBPath returns the current-store Kiro SQLite DB path when the
-// configured root contains one, or "" otherwise.
-func kiroSQLiteDBPath(dir string) string {
-	if dir == "" {
-		return ""
-	}
-	path := filepath.Join(dir, kiroSQLiteDBName)
-	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return ""
-	}
-	return path
-}
 
 // parseKiroSQLiteVirtualPath splits a virtual Kiro SQLite source path back
 // into its database path and raw session ID using the provider-neutral

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5651,6 +5651,13 @@ func (e *Engine) streamReconciliationCandidates(
 					return providers, completedScopes,
 						failedRoots, failures, discoveryErr, ctx.Err()
 				}
+				if agent == parser.AgentKiro {
+					kiroErr := fmt.Errorf(
+						"%s provider streaming discovery: %w", agent, err,
+					)
+					return providers, completedScopes, failedRoots, failures,
+						errors.Join(discoveryErr, kiroErr), kiroErr
+				}
 				log.Printf("%s provider streaming discovery: %v", agent, err)
 				failures++
 				failedRoots = append(failedRoots, groupRetryRoots...)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1772,6 +1772,49 @@ func TestSyncEngineKiroPartialSQLitePreservesShadowedAndTombstonesRemoved(
 	assert.NotNil(t, activeShadowed)
 }
 
+func TestSyncRootsSinceKiroPreservesOutOfScopeWinnerAfterSQLiteRemoval(
+	t *testing.T,
+) {
+	winnerRoot := t.TempDir()
+	partialRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(
+		t, parser.AgentKiro, []string{winnerRoot, partialRoot},
+	)
+	rawID := "sess_0123456789abcdef"
+	partial := createKiroSQLiteDB(t, partialRoot)
+	partial.addSession(
+		t, "/home/user/code/partial", rawID,
+		readKiroSQLiteFixture(t, "overlap_payload.json"),
+		1779015600000, 1779015610000,
+	)
+	current := filepath.Join(winnerRoot, "workspace", rawID, "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(current), 0o755))
+	require.NoError(t, os.WriteFile(
+		current,
+		[]byte(`{"payload":{"type":"user","content":"current"}}`+"\n"),
+		0o644,
+	))
+
+	initial := env.engine.SyncAll(context.Background(), nil)
+	require.Zero(t, initial.Failed)
+	active, err := env.db.GetSession(context.Background(), "kiro:"+rawID)
+	require.NoError(t, err)
+	require.NotNil(t, active)
+
+	_, err = partial.db.Exec(
+		`DELETE FROM conversations_v2 WHERE conversation_id = ?`, rawID,
+	)
+	require.NoError(t, err)
+	env.engine.SyncRootsSince(
+		context.Background(), []string{partialRoot}, time.Time{}, nil,
+	)
+
+	active, err = env.db.GetSession(context.Background(), "kiro:"+rawID)
+	require.NoError(t, err)
+	assert.NotNil(t, active,
+		"an out-of-scope current winner must preserve a removed DB member")
+}
+
 func TestSyncEngineKiroLegacyOnlySyncPath(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentKiro)
 	writeLegacyKiroSession(

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1707,7 +1707,7 @@ func TestSyncRootsSinceKiroLegacyShadowedBySQLiteOutsideScope(t *testing.T) {
 	legacyRoot := t.TempDir()
 	sqliteRoot := t.TempDir()
 	env := setupSingleAgentTestEnvWithDirs(
-		t, parser.AgentKiro, []string{sqliteRoot, legacyRoot},
+		t, parser.AgentKiro, []string{legacyRoot, sqliteRoot},
 	)
 
 	ks := createKiroSQLiteDB(t, sqliteRoot)
@@ -1725,6 +1725,51 @@ func TestSyncRootsSinceKiroLegacyShadowedBySQLiteOutsideScope(t *testing.T) {
 		context.Background(), []string{legacyRoot}, time.Time{}, nil,
 	)
 	assert.Equal(t, 0, stats.TotalSessions, "total sessions")
+}
+
+func TestSyncEngineKiroPartialSQLitePreservesShadowedAndTombstonesRemoved(
+	t *testing.T,
+) {
+	winnerRoot := t.TempDir()
+	partialRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(
+		t, parser.AgentKiro, []string{winnerRoot, partialRoot},
+	)
+	winner := createKiroSQLiteDB(t, winnerRoot)
+	partial := createKiroSQLiteDB(t, partialRoot)
+	fixture := readKiroSQLiteFixture(t, "overlap_payload.json")
+	winner.addSession(t, "/home/user/code/winner", "shadowed", fixture, 1779015600000, 1779015610000)
+	partial.addSession(t, "/home/user/code/partial", "shadowed", fixture, 1779015600000, 1779015610000)
+	partial.addSession(t, "/home/user/code/partial", "removed", fixture, 1779015600000, 1779015610000)
+
+	initial := env.engine.SyncAll(context.Background(), nil)
+	require.Zero(t, initial.Failed)
+	activeShadowed, err := env.db.GetSession(context.Background(), "kiro:shadowed")
+	require.NoError(t, err)
+	require.NotNil(t, activeShadowed)
+	activeRemoved, err := env.db.GetSession(context.Background(), "kiro:removed")
+	require.NoError(t, err)
+	require.NotNil(t, activeRemoved)
+
+	_, err = partial.db.Exec(
+		`DELETE FROM conversations_v2 WHERE conversation_id = ?`, "removed",
+	)
+	require.NoError(t, err)
+	env.engine.SyncPaths([]string{partial.path})
+
+	activeRemoved, err = env.db.GetSession(context.Background(), "kiro:removed")
+	require.NoError(t, err)
+	assert.Nil(t, activeRemoved)
+	archivedRemoved, err := env.db.GetSessionFull(
+		context.Background(), "kiro:removed",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, archivedRemoved)
+	require.NotNil(t, archivedRemoved.DeletionCause)
+	assert.Equal(t, "source_missing", *archivedRemoved.DeletionCause)
+	activeShadowed, err = env.db.GetSession(context.Background(), "kiro:shadowed")
+	require.NoError(t, err)
+	assert.NotNil(t, activeShadowed)
 }
 
 func TestSyncEngineKiroLegacyOnlySyncPath(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1703,6 +1703,26 @@ func TestSyncEngineKiroSQLiteCurrentStoreShadowsLegacy(t *testing.T) {
 	require.Contains(t, *sess.FilePath, "data.sqlite3#overlap-session", "legacy event replaced sqlite-backed session: %+v", sess)
 }
 
+func TestSyncEngineKiroFullParseReplacesMessages(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentKiro)
+	rawID := "sess_0123456789abcdef"
+	path := filepath.Join(env.kiroDir, "workspace", rawID, "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(strings.Join([]string{
+		`{"payload":{"type":"user","content":"first"}}`,
+		`{"payload":{"type":"assistant","content":"second"}}`,
+	}, "\n")+"\n"), 0o644))
+	env.engine.SyncPaths([]string{path})
+	assertSessionMessageCount(t, env.db, "kiro:"+rawID, 2)
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"payload":{"type":"user","content":"rewritten"}}`+"\n",
+	), 0o644))
+	future := time.Now().Add(time.Minute)
+	require.NoError(t, os.Chtimes(path, future, future))
+	env.engine.SyncPaths([]string{path})
+	assertSessionMessageCount(t, env.db, "kiro:"+rawID, 1)
+}
+
 func TestSyncRootsSinceKiroLegacyShadowedBySQLiteOutsideScope(t *testing.T) {
 	legacyRoot := t.TempDir()
 	sqliteRoot := t.TempDir()

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1815,6 +1815,49 @@ func TestSyncRootsSinceKiroPreservesOutOfScopeWinnerAfterSQLiteRemoval(
 		"an out-of-scope current winner must preserve a removed DB member")
 }
 
+func TestSyncRootsSinceKiroTombstonesRemovedAllShadowedMember(
+	t *testing.T,
+) {
+	winnerRoot := t.TempDir()
+	partialRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(
+		t, parser.AgentKiro, []string{winnerRoot, partialRoot},
+	)
+	winner := createKiroSQLiteDB(t, winnerRoot)
+	partial := createKiroSQLiteDB(t, partialRoot)
+	fixture := readKiroSQLiteFixture(t, "overlap_payload.json")
+	winner.addSession(t, "/home/user/code/winner", "shadowed", fixture, 1779015600000, 1779015610000)
+	partial.addSession(t, "/home/user/code/partial", "shadowed", fixture, 1779015600000, 1779015610000)
+	partial.addSession(t, "/home/user/code/partial", "removed", fixture, 1779015600000, 1779015610000)
+
+	initial := env.engine.SyncAll(context.Background(), nil)
+	require.Zero(t, initial.Failed)
+	removed, err := env.db.GetSession(context.Background(), "kiro:removed")
+	require.NoError(t, err)
+	require.NotNil(t, removed)
+
+	_, err = partial.db.Exec(
+		`DELETE FROM conversations_v2 WHERE conversation_id = ?`, "removed",
+	)
+	require.NoError(t, err)
+	stats := env.engine.SyncRootsSince(
+		context.Background(), []string{partialRoot}, time.Time{}, nil,
+	)
+	require.False(t, stats.Aborted)
+
+	active, err := env.db.GetSession(context.Background(), "kiro:removed")
+	require.NoError(t, err)
+	assert.Nil(t, active,
+		"a removed member must be tombstoned even when all remaining DB rows are shadowed")
+	archived, err := env.db.GetSessionFull(
+		context.Background(), "kiro:removed",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+}
+
 func TestSyncEngineKiroLegacyOnlySyncPath(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentKiro)
 	writeLegacyKiroSession(

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1707,7 +1707,7 @@ func TestSyncRootsSinceKiroLegacyShadowedBySQLiteOutsideScope(t *testing.T) {
 	legacyRoot := t.TempDir()
 	sqliteRoot := t.TempDir()
 	env := setupSingleAgentTestEnvWithDirs(
-		t, parser.AgentKiro, []string{legacyRoot, sqliteRoot},
+		t, parser.AgentKiro, []string{sqliteRoot, legacyRoot},
 	)
 
 	ks := createKiroSQLiteDB(t, sqliteRoot)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1723,6 +1723,39 @@ func TestSyncEngineKiroFullParseReplacesMessages(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "kiro:"+rawID, 1)
 }
 
+func TestSyncEngineKiroSameStatMetadataRewriteIsDetected(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentKiro)
+	rawID := "sess_0123456789abcdef"
+	path := filepath.Join(env.kiroDir, "workspace", rawID, "messages.jsonl")
+	sidecar := filepath.Join(filepath.Dir(path), "session.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"payload":{"type":"user","content":"hello"}}`+"\n",
+	), 0o644))
+	require.NoError(t, os.WriteFile(sidecar, []byte(`{"title":"A"}`), 0o644))
+	stamp := time.Unix(1_700_000_000, 0)
+	require.NoError(t, os.Chtimes(path, stamp, stamp))
+	require.NoError(t, os.Chtimes(sidecar, stamp, stamp))
+
+	initial := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, initial.Aborted)
+	before, err := env.db.GetSessionFull(context.Background(), "kiro:"+rawID)
+	require.NoError(t, err)
+	require.NotNil(t, before)
+	require.NotNil(t, before.SessionName)
+	assert.Equal(t, "A", *before.SessionName)
+
+	require.NoError(t, os.WriteFile(sidecar, []byte(`{"title":"B"}`), 0o644))
+	require.NoError(t, os.Chtimes(sidecar, stamp, stamp))
+	updated := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, updated.Aborted)
+	after, err := env.db.GetSessionFull(context.Background(), "kiro:"+rawID)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	require.NotNil(t, after.SessionName)
+	assert.Equal(t, "B", *after.SessionName)
+}
+
 func TestSyncRootsSinceKiroLegacyShadowedBySQLiteOutsideScope(t *testing.T) {
 	legacyRoot := t.TempDir()
 	sqliteRoot := t.TempDir()
@@ -1833,6 +1866,37 @@ func TestSyncRootsSinceKiroPreservesOutOfScopeWinnerAfterSQLiteRemoval(
 	require.NoError(t, err)
 	assert.NotNil(t, active,
 		"an out-of-scope current winner must preserve a removed DB member")
+}
+
+func TestSyncRootsSinceKiroArbitratesAcrossConfiguredRootsBeforeProcessing(
+	t *testing.T,
+) {
+	winnerRoot := t.TempDir()
+	partialRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(
+		t, parser.AgentKiro, []string{winnerRoot, partialRoot},
+	)
+	rawID := "sess_0123456789abcdef"
+	for root, content := range map[string]string{
+		winnerRoot:  "configured winner",
+		partialRoot: "scoped loser",
+	} {
+		path := filepath.Join(root, "workspace", rawID, "messages.jsonl")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(
+			fmt.Sprintf(`{"payload":{"type":"user","content":%q}}`, content)+"\n",
+		), 0o644))
+	}
+
+	initial := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, initial.Aborted)
+	assertMessageContent(t, env.db, "kiro:"+rawID, "configured winner")
+
+	stats := env.engine.SyncRootsSince(
+		context.Background(), []string{partialRoot}, time.Time{}, nil,
+	)
+	require.False(t, stats.Aborted)
+	assertMessageContent(t, env.db, "kiro:"+rawID, "configured winner")
 }
 
 func TestSyncRootsSinceKiroTombstonesRemovedAllShadowedMember(

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1756,6 +1756,29 @@ func TestSyncEngineKiroSameStatMetadataRewriteIsDetected(t *testing.T) {
 	assert.Equal(t, "B", *after.SessionName)
 }
 
+func TestSyncEngineKiroEmptyCurrentRewritePreservesArchive(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentKiro)
+	rawID := "sess_0123456789abcdef"
+	path := filepath.Join(env.kiroDir, "workspace", rawID, "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"payload":{"type":"user","content":"keep this"}}`+"\n",
+	), 0o644))
+	env.engine.SyncPaths([]string{path})
+
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"payload":{"type":"session_metadata","content":"not a message"}}`+"\n",
+	), 0o644))
+	future := time.Now().Add(time.Minute)
+	require.NoError(t, os.Chtimes(path, future, future))
+	env.engine.SyncPaths([]string{path})
+
+	active, err := env.db.GetSession(context.Background(), "kiro:"+rawID)
+	require.NoError(t, err)
+	assert.NotNil(t, active, "an empty current rewrite must preserve the archive")
+	assertMessageContent(t, env.db, "kiro:"+rawID, "keep this")
+}
+
 func TestSyncRootsSinceKiroLegacyShadowedBySQLiteOutsideScope(t *testing.T) {
 	legacyRoot := t.TempDir()
 	sqliteRoot := t.TempDir()

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1965,6 +1965,31 @@ func TestSyncRootsSinceKiroTombstonesRemovedAllShadowedMember(
 	assert.Equal(t, "source_missing", *archived.DeletionCause)
 }
 
+func TestSyncRootsSinceKiroOverlappingRootsKeepInScopeWinner(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "nest")
+	require.NoError(t, os.MkdirAll(child, 0o755))
+	env := setupSingleAgentTestEnvWithDirs(
+		t, parser.AgentKiro, []string{parent, child},
+	)
+	rawID := "sess_0123456789abcdef"
+	path := filepath.Join(child, rawID, "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"payload":{"type":"user","content":"scoped"}}`+"\n",
+	), 0o644))
+
+	stats := env.engine.SyncRootsSince(
+		context.Background(), []string{child}, time.Time{}, nil,
+	)
+	require.False(t, stats.Aborted)
+
+	active, err := env.db.GetSession(context.Background(), "kiro:"+rawID)
+	require.NoError(t, err)
+	assert.NotNil(t, active,
+		"a physically in-scope winner attributed to an overlapping ancestor root must stay admitted")
+}
+
 func TestReconcileWatchRootsKiroDiscoveryFailureDoesNotAbortOtherAgents(
 	t *testing.T,
 ) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1965,6 +1965,52 @@ func TestSyncRootsSinceKiroTombstonesRemovedAllShadowedMember(
 	assert.Equal(t, "source_missing", *archived.DeletionCause)
 }
 
+func TestReconcileWatchRootsKiroDiscoveryFailureDoesNotAbortOtherAgents(
+	t *testing.T,
+) {
+	env := setupFocusedTestEnv(t, parser.AgentKiro, parser.AgentClaude)
+	rawID := "sess_0123456789abcdef"
+	kiroPath := filepath.Join(env.kiroDir, "workspace", rawID, "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(kiroPath), 0o755))
+	require.NoError(t, os.WriteFile(kiroPath, []byte(
+		`{"payload":{"type":"user","content":"keep"}}`+"\n",
+	), 0o644))
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "Hello").
+		String()
+	claudePath := env.writeClaudeSession(
+		t, "claude-project", "claude-session.jsonl", content,
+	)
+	initial := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, initial.Failed)
+	kiroBefore, err := env.db.GetSession(t.Context(), "kiro:"+rawID)
+	require.NoError(t, err)
+	require.NotNil(t, kiroBefore)
+	claudeBefore, err := env.db.GetSession(t.Context(), "claude-session")
+	require.NoError(t, err)
+	require.NotNil(t, claudeBefore)
+
+	require.NoError(t, os.Remove(claudePath))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(env.kiroDir, "broken.jsonl"), []byte("{}\n"), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(env.kiroDir, "broken.json"), []byte("{"), 0o644,
+	))
+
+	err = env.engine.ReconcileWatchRoots(t.Context(), nil, true)
+	require.Error(t, err, "the failed Kiro scope must stay queued for retry")
+
+	claudeGone, err := env.db.GetSession(t.Context(), "claude-session")
+	require.NoError(t, err)
+	assert.Nil(t, claudeGone,
+		"a Kiro discovery failure must not abort other agents' reconciliation")
+	kiroKept, err := env.db.GetSession(t.Context(), "kiro:"+rawID)
+	require.NoError(t, err)
+	assert.NotNil(t, kiroKept,
+		"Kiro sessions must be preserved when Kiro discovery fails")
+}
+
 func TestSyncEngineKiroLegacyOnlySyncPath(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentKiro)
 	writeLegacyKiroSession(

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -4177,6 +4177,20 @@ func TestKiroReconciliationRootPreferenceUsesConfiguredOrder(t *testing.T) {
 	))
 }
 
+func TestKiroReconciliationRootPreferenceUsesSourceAttribution(t *testing.T) {
+	ancestor := filepath.Join(t.TempDir(), "ancestor")
+	descendant := filepath.Join(ancestor, "descendant")
+	path := filepath.Join(descendant, "session.jsonl")
+	source := parser.SourceRef{ConfiguredRoot: descendant}
+
+	assert.Equal(t, int64(1), configuredRootPreferenceForSource(
+		source, path, []string{ancestor, descendant},
+	), "the provider root must outrank an overlapping ancestor")
+	assert.Equal(t, int64(2), configuredRootPreferenceForSource(
+		parser.SourceRef{}, path, []string{ancestor, descendant},
+	), "unknown attribution must retain the path fallback")
+}
+
 func TestFilterEmptyMessages(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -4157,6 +4157,26 @@ func (f fakeFileInfo) ModTime() time.Time {
 func (f fakeFileInfo) IsDir() bool { return false }
 func (f fakeFileInfo) Sys() any    { return nil }
 
+func TestKiroReconciliationRootPreferenceUsesConfiguredOrder(t *testing.T) {
+	first := filepath.Join(t.TempDir(), "first")
+	second := filepath.Join(t.TempDir(), "second")
+	firstPath := filepath.Join(first, "sess.jsonl")
+	secondPath := filepath.Join(second, "sess.jsonl")
+
+	assert.Equal(t, int64(2), configuredRootPreference(
+		firstPath, []string{first, second},
+	))
+	assert.Equal(t, int64(1), configuredRootPreference(
+		secondPath, []string{first, second},
+	))
+	assert.Equal(t, int64(1), configuredRootPreference(
+		firstPath, []string{second, first},
+	))
+	assert.Equal(t, int64(2), configuredRootPreference(
+		secondPath, []string{second, first},
+	))
+}
+
 func TestFilterEmptyMessages(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -4157,46 +4157,6 @@ func (f fakeFileInfo) ModTime() time.Time {
 func (f fakeFileInfo) IsDir() bool { return false }
 func (f fakeFileInfo) Sys() any    { return nil }
 
-func TestHasLegacyKiroCandidates(t *testing.T) {
-	tests := []struct {
-		name  string
-		files []parser.DiscoveredFile
-		want  bool
-	}{
-		{
-			name: "empty",
-			want: false,
-		},
-		{
-			name: "non-kiro files",
-			files: []parser.DiscoveredFile{
-				{Agent: parser.AgentClaude, Path: "/tmp/claude/session.jsonl"},
-			},
-			want: false,
-		},
-		{
-			name: "kiro sqlite database source",
-			files: []parser.DiscoveredFile{
-				{Agent: parser.AgentKiro, Path: "/tmp/kiro/data.sqlite3"},
-			},
-			want: false,
-		},
-		{
-			name: "legacy kiro jsonl",
-			files: []parser.DiscoveredFile{
-				{Agent: parser.AgentKiro, Path: "/tmp/kiro/session.jsonl"},
-			},
-			want: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, hasLegacyKiroCandidates(tt.files))
-		})
-	}
-}
-
 func TestFilterEmptyMessages(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sync/kiro_issue1499_repro_test.go
+++ b/internal/sync/kiro_issue1499_repro_test.go
@@ -1,0 +1,32 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// Synthetic reproduction: issue #1499 shipped no loadable transcript artifact.
+// This preserves the reported provider-relative path and documented envelope
+// shape, then proves the existing Kiro provider emits the session.
+func TestKiroIssue1499CurrentLayoutReproduction(t *testing.T) {
+	root := t.TempDir()
+	transcript := filepath.Join(root, "workspace", "sess_0123456789abcdef", "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcript), 0o755))
+	require.NoError(t, os.WriteFile(transcript,
+		[]byte(`{"payload":{"type":"user","content":"synthetic prompt"}}`+"\n"), 0o644))
+
+	provider, ok := parser.NewProvider(parser.AgentKiro, parser.ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	result, err := provider.Parse(context.Background(), parser.ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, result.Results, 1)
+	require.Equal(t, "kiro:sess_0123456789abcdef", result.Results[0].Result.Session.ID)
+}

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -84,7 +84,6 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 		files = append(files, providerFiles...)
 	}
 	files = dedupeDiscoveredFiles(files)
-	files = e.filterShadowedLegacyKiroFiles(files)
 
 	// Newest first by source mtime (composite stats for virtual
 	// paths), tie-broken by path so the --limit sample is stable.

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -71,8 +71,8 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 	}
 
 	// Discovery mirrors syncAllLocked's file phase: provider discovery over
-	// the configured dirs per agent, then dedupe and the legacy-Kiro shadow
-	// filter. Provider discovery already enumerates shared-SQLite sources
+	// the configured dirs per agent, then dedupe. Provider discovery already
+	// arbitrates Kiro shared-SQLite sources intrinsically and enumerates
 	// (Kiro's data.sqlite3, db-mode OpenCode's opencode.db) per session, so
 	// no separate db-source synthesis is needed.
 	var files []parser.DiscoveredFile


### PR DESCRIPTION
Kiro CLI workspace sessions stored outside the legacy cli directory are now recognized, including direct and one-workspace sess_<id>/messages.jsonl layouts. The provider parses the documented fields and preserves literal producer identity across lookup, watcher, SQLite, and reconciliation paths.

SQLite outranks current JSONL, current JSONL outranks legacy JSONL, and configured root order breaks same-class ties before recency and canonical path. The same winner drives normal discovery, changed-path handling, scoped sync, persistence, lookup, and reconciliation. Missing sidecar bounds use parsed message timestamps before transcript mtime. History, snapshot, traversal, invalid-ID, and symlink escapes remain rejected; incomplete SQLite reads fail closed without replacing archived authority, while clean empty databases remain authoritative. Existing archive preservation and row-removal behavior remain unchanged.

Closes #1499.
