### PR TITLE
fix(remotesync): curate editor remote targets

### DIFF
--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -231,6 +231,39 @@ each sync while the rest of the host remains eligible for delta transfer. The
 Windsurf content in the mirror is the sanitized export, not a byte-for-byte copy
 of the remote state database.
 
+### Curated Provider Exports
+
+Most providers export their configured directories as-is. Providers whose
+configured root is a broad application-data directory export a curated file
+list instead, so caches, extension state, and credential files stored near the
+sessions never enter the manifest, the archive, or the mirror:
+
+- **Cursor** exports only the transcript files its parser discovers under each
+  project's `agent-transcripts/` directory.
+- **VS Code Copilot** exports only chat session files under
+  `workspaceStorage/<hash>/chatSessions/` and
+  `globalStorage/{emptyWindowChatSessions,transferredChatSessions}/`, plus each
+  exporting workspace's `workspace.json` for project attribution.
+- **Zed** exports `threads/threads.db` as a consistent SQLite snapshot taken
+  with the online backup API, so committed write-ahead-log data arrives as one
+  standalone database without `-wal` or `-shm` sidecars. Hermes state databases
+  use the same snapshot mechanism.
+- **RooCode** and **Kilo Legacy** export only their discovered per-task session
+  files, **Poolside** narrows its root to `trajectories/`, and **Windsurf**
+  exports the sanitized copy described above.
+
+Budget mirror disk for the curated session files only, not for the full
+application-data directories those editors keep around them. When the last
+session under a curated Cursor or VS Code Copilot root disappears, the root
+stays advertised with an empty file list so the next sync empties the mirror
+instead of failing.
+
+An unreadable snapshot database is treated as missing: the sync continues, the
+mirror drops its cached copy, and the file transfers again once the remote
+application repairs it. Sessions already imported into the AgentsView database
+remain available throughout. Any other read failure during target resolution
+fails that host's sync without touching the mirror.
+
 ### When AgentsView Downloads A Full Archive
 
 A full HTTP transfer occurs in these cases:

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -329,11 +329,16 @@ func (s cursorSourceSet) streamingSourceRefWithCache(
 ) (SourceRef, bool, error) {
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
-	info, err := os.Stat(path)
+	// A transcript listed by the walk can vanish before this stat — a
+	// routine deletion race, not a discovery failure; the next
+	// enumeration simply no longer lists it. Genuine read errors and
+	// dangling symlinks still propagate, matching
+	// cursorFindSourceFileInProjectStrict.
+	regular, err := streamingRegularFileCandidate(path)
 	if err != nil {
 		return SourceRef{}, false, fmt.Errorf("stat cursor transcript %s: %w", path, err)
 	}
-	if !info.Mode().IsRegular() {
+	if !regular {
 		return SourceRef{}, false, nil
 	}
 	rawID, ok := cursorRawSessionIDFromPath(root, path)

--- a/internal/parser/cursor_provider_test.go
+++ b/internal/parser/cursor_provider_test.go
@@ -254,6 +254,47 @@ func TestCursorStreamingDiscoveryPropagatesAuthoritativeResolutionErrors(t *test
 	})
 }
 
+func TestCursorStreamingDiscoverySkipsTranscriptVanishedBeforeStat(t *testing.T) {
+	root := t.TempDir()
+	transcriptsDir := filepath.Join(root, "Users-demo", "agent-transcripts")
+	healthy := cursorProviderWriteJSONLTranscript(
+		t, transcriptsDir, "healthy.jsonl", "still on disk",
+	)
+	ctx := withStreamingDirectoryReader(t.Context(), func(
+		_ context.Context, dir string, yield func(os.DirEntry) error,
+	) error {
+		if samePath(dir, transcriptsDir) {
+			if err := yield(failingInfoDirEntry{
+				name: "a-vanished.jsonl", err: os.ErrNotExist,
+			}); err != nil {
+				return err
+			}
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := yield(entry); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	provider, ok := NewProvider(AgentCursor, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	var streamed []string
+	err := provider.(StreamingDiscoverer).DiscoverEach(ctx, func(source SourceRef) error {
+		streamed = append(streamed, source.DisplayPath)
+		return nil
+	})
+
+	require.NoError(t, err,
+		"a transcript deleted between enumeration and stat must not fail discovery")
+	assert.Equal(t, []string{healthy}, streamed)
+}
+
 func TestCursorProviderResolvesDuplicateStemsWithinProject(t *testing.T) {
 	root := t.TempDir()
 	firstProject := "Users-fiona-Documents-first"

--- a/internal/parser/kilo_legacy_provider.go
+++ b/internal/parser/kilo_legacy_provider.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,9 +23,7 @@ func newKiloLegacyProviderFactory(def AgentDef) ProviderFactory {
 			return NewSingleFileSourceSet(
 				def.Type,
 				cfg.Roots,
-				WithFileDiscovery(func(root string) []singleFileMatch {
-					return kiloLegacyDiscoverFiles(root)
-				}),
+				WithStreamingFileDiscovery(kiloLegacyDiscoverEach),
 				WithFileWatchRoots(func(roots []string) []WatchRoot {
 					return kiloLegacyWatchRoots(roots)
 				}),
@@ -50,44 +50,47 @@ func newKiloLegacyProviderFactory(def AgentDef) ProviderFactory {
 	)
 }
 
-// kiloLegacyDiscoverFiles finds all Kilo (legacy) session directories
+// kiloLegacyDiscoverEach streams the Kilo (legacy) session sources
 // under a root. root is the globalStorage directory (e.g.
 // ~/Library/.../kilocode.kilo-code). Sessions live under
 // <root>/tasks/<taskId>/, identified by the presence of
-// task_metadata.json.
-func kiloLegacyDiscoverFiles(root string) []singleFileMatch {
+// task_metadata.json. A missing tasks directory is a legitimately
+// empty scope, but any other traversal failure propagates so an
+// unreadable directory cannot present an authoritative empty
+// enumeration.
+func kiloLegacyDiscoverEach(
+	ctx context.Context, root string, yield func(singleFileMatch) error,
+) error {
 	tasksDir := filepath.Join(root, "tasks")
-	entries, err := os.ReadDir(tasksDir)
-	if err != nil {
-		return nil
-	}
-	var matches []singleFileMatch
-	for _, entry := range entries {
+	return streamDirectoryEntries(ctx, tasksDir, func(entry os.DirEntry) error {
 		if !entry.IsDir() {
-			continue
+			return nil
 		}
 		// Reject symlinked task directories. Symlinks can
 		// resolve outside the configured root, so remote sync
 		// must not archive files from an unexpected location.
 		if entry.Type()&os.ModeSymlink != 0 {
-			continue
+			return nil
 		}
 		// Skip _index.json and other underscore-prefixed
 		// metadata files. Sessions are timestamped UUIDs.
 		if strings.HasPrefix(entry.Name(), "_") ||
 			strings.HasPrefix(entry.Name(), ".") {
-			continue
+			return nil
 		}
-		taskDir := filepath.Join(tasksDir, entry.Name())
-		metadataPath := filepath.Join(taskDir, "task_metadata.json")
-		if !IsRegularFile(metadataPath) {
-			continue
+		metadataPath := filepath.Join(tasksDir, entry.Name(), "task_metadata.json")
+		info, err := os.Lstat(metadataPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("stat kilo legacy session %s: %w", metadataPath, err)
 		}
-		matches = append(matches, singleFileMatch{
-			Path: metadataPath,
-		})
-	}
-	return matches
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		return yield(singleFileMatch{Path: metadataPath})
+	})
 }
 
 // kiloLegacyWatchRoots returns the watch plan for the configured

--- a/internal/parser/kilo_legacy_test.go
+++ b/internal/parser/kilo_legacy_test.go
@@ -18,6 +18,69 @@ import (
 	"go.kenn.io/agentsview/internal/money"
 )
 
+func kiloLegacyDiscoverMatchesForTest(t *testing.T, root string) []singleFileMatch {
+	t.Helper()
+	var matches []singleFileMatch
+	require.NoError(t, kiloLegacyDiscoverEach(t.Context(), root,
+		func(match singleFileMatch) error {
+			matches = append(matches, match)
+			return nil
+		}))
+	return matches
+}
+
+// TestKiloLegacyDiscoveryUnreadableDirsFail guards the same contract
+// as TestRooCodeDiscoveryUnreadableTasksDirFails: a traversal failure
+// must propagate instead of presenting an authoritative empty
+// enumeration, which would tombstone baselined sessions locally and
+// let remote sync evict valid mirror data.
+func TestKiloLegacyDiscoveryUnreadableDirsFail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory-permission read failures are not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	root := t.TempDir()
+	taskDir := filepath.Join(root, "tasks", "task-1")
+	require.NoError(t, os.MkdirAll(taskDir, 0o755))
+	metadataPath := filepath.Join(taskDir, "task_metadata.json")
+	require.NoError(t, os.WriteFile(metadataPath, []byte(`{}`), 0o644))
+	provider, ok := NewProvider(AgentKiloLegacy, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	matches := kiloLegacyDiscoverMatchesForTest(t, root)
+	require.Len(t, matches, 1)
+	require.Equal(t, metadataPath, matches[0].Path)
+
+	t.Run("unreadable task dir", func(t *testing.T) {
+		require.NoError(t, os.Chmod(taskDir, 0o000))
+		t.Cleanup(func() { require.NoError(t, os.Chmod(taskDir, 0o755)) })
+		err := kiloLegacyDiscoverEach(t.Context(), root,
+			func(singleFileMatch) error { return nil })
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		_, err = provider.Discover(t.Context())
+		require.Error(t, err,
+			"an unreadable task directory must not collect an authoritative empty discovery")
+	})
+
+	t.Run("unreadable tasks root", func(t *testing.T) {
+		tasksDir := filepath.Join(root, "tasks")
+		require.NoError(t, os.Chmod(tasksDir, 0o000))
+		t.Cleanup(func() { require.NoError(t, os.Chmod(tasksDir, 0o755)) })
+		err := kiloLegacyDiscoverEach(t.Context(), root,
+			func(singleFileMatch) error { return nil })
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		_, err = provider.Discover(t.Context())
+		require.Error(t, err,
+			"an unreadable tasks directory must not collect an authoritative empty discovery")
+	})
+}
+
 // writeKiloLegacyFixture creates a minimal Kilo (legacy) task directory
 // containing the three JSON files. Callers may overwrite
 // individual files by writing to the returned paths.
@@ -839,7 +902,7 @@ func TestKiloLegacyDiscoverAndClassifyPath(t *testing.T) {
 		filepath.Join(tasksDir, "_index"), 0o755,
 	))
 
-	matches := kiloLegacyDiscoverFiles(root)
+	matches := kiloLegacyDiscoverMatchesForTest(t, root)
 	require.Len(t, matches, 1)
 	assert.True(t,
 		filepath.IsAbs(matches[0].Path),
@@ -923,7 +986,7 @@ func TestKiloLegacyParseFileReturnsUsageFromUI(t *testing.T) {
 	}
 	mustWriteJSON(t, filepath.Join(taskDir, "ui_messages.json"), msgs)
 
-	matches := kiloLegacyDiscoverFiles(root)
+	matches := kiloLegacyDiscoverMatchesForTest(t, root)
 	require.Len(t, matches, 1)
 	results, _, err := kiloLegacyParseFile(
 		singleFileSource{Root: root, Path: matches[0].Path},
@@ -1339,7 +1402,7 @@ func TestKiloLegacyDiscoverRejectsSymlinkedTaskDir(t *testing.T) {
 	symlinkTask := filepath.Join(tasksDir, "symlink-task")
 	require.NoError(t, os.Symlink(outsideDir, symlinkTask))
 
-	matches := kiloLegacyDiscoverFiles(root)
+	matches := kiloLegacyDiscoverMatchesForTest(t, root)
 	require.Len(t, matches, 1,
 		"only the real task should be discovered; symlink should be rejected")
 	assert.Contains(t, matches[0].Path, "real-task",

--- a/internal/parser/roocode_provider.go
+++ b/internal/parser/roocode_provider.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +57,14 @@ func rooCodeDiscoverEach(
 			return nil
 		}
 		historyPath := filepath.Join(tasksDir, entry.Name(), "history_item.json")
-		if !IsRegularFile(historyPath) {
+		info, err := os.Lstat(historyPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("stat roocode session %s: %w", historyPath, err)
+		}
+		if !info.Mode().IsRegular() {
 			return nil
 		}
 		return yield(singleFileMatch{Path: historyPath})

--- a/internal/parser/roocode_provider_test.go
+++ b/internal/parser/roocode_provider_test.go
@@ -10,6 +10,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The per-file stat inside the task walk follows the same contract as
+// the tasks-directory enumeration: an unreadable task directory must
+// propagate, not be silently skipped as if its session were deleted.
+func TestRooCodeDiscoveryUnreadableTaskDirFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory-permission read failures are not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	root := t.TempDir()
+	historyPath := writeRooCodeDiscoveryTask(t, root, "task-1")
+	taskDir := filepath.Dir(historyPath)
+	provider, ok := NewProvider(AgentRooCode, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	paths, err := rooCodeDiscoverPaths(t, provider)
+	require.NoError(t, err)
+	require.Equal(t, []string{historyPath}, paths)
+
+	require.NoError(t, os.Chmod(taskDir, 0o000))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(taskDir, 0o755)) })
+	paths, err = rooCodeDiscoverPaths(t, provider)
+	require.Error(t, err,
+		"an unreadable task directory must not be skipped as a deleted session")
+	assert.ErrorIs(t, err, os.ErrPermission)
+	assert.Empty(t, paths)
+}
+
 func writeRooCodeDiscoveryTask(t *testing.T, root, taskID string) string {
 	t.Helper()
 	taskDir := filepath.Join(root, "tasks", taskID)

--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -16,7 +16,8 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 	tw := tar.NewWriter(w)
 	forbidden := newForbiddenRootMatcher(targets.ForbiddenRoots)
 	hermesSQLite := make(map[string]string)
-	for stateDB := range sqliteSnapshotTargets(targets) {
+	snapshotAgents := sqliteSnapshotTargets(targets)
+	for stateDB := range snapshotAgents {
 		for _, path := range hermesSQLitePaths(stateDB) {
 			hermesSQLite[path] = stateDB
 		}
@@ -32,7 +33,7 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 				return nil
 			}
 			writtenHermesState[stateDB] = struct{}{}
-			return writeSQLiteStateDBSnapshot(tw, stateDB)
+			return writeSQLiteStateDBSnapshot(tw, stateDB, snapshotAgents[stateDB])
 		}
 		if optional {
 			return writeOptionalArchiveFile(tw, path)
@@ -83,8 +84,13 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 	return nil
 }
 
-func writeSQLiteStateDBSnapshot(tw *tar.Writer, stateDB string) error {
-	_, modTime, exists := hermesSQLiteSnapshotIdentity(stateDB)
+func writeSQLiteStateDBSnapshot(
+	tw *tar.Writer, stateDB string, agent parser.AgentType,
+) error {
+	_, modTime, exists, err := sqliteSnapshotIdentityForAgent(stateDB, agent)
+	if err != nil {
+		return fmt.Errorf("identify sqlite snapshot %q: %w", stateDB, err)
+	}
 	if !exists {
 		return nil
 	}
@@ -95,7 +101,11 @@ func writeSQLiteStateDBSnapshot(tw *tar.Writer, stateDB string) error {
 	defer os.RemoveAll(tmpDir)
 	snapshotPath := filepath.Join(tmpDir, "state.db")
 	if err := writeHermesSnapshotFile(snapshotPath, stateDB); err != nil {
-		return fmt.Errorf("snapshot hermes database %q: %w", stateDB, err)
+		label := "sqlite"
+		if agent == parser.AgentHermes {
+			label = "hermes"
+		}
+		return fmt.Errorf("snapshot %s database %q: %w", label, stateDB, err)
 	}
 	if err := os.Chtimes(snapshotPath, modTime, modTime); err != nil {
 		return fmt.Errorf("stamp hermes database snapshot: %w", err)
@@ -365,10 +375,7 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 	tw := tar.NewWriter(w)
 	forbidden := newForbiddenRootMatcher(allowed.ForbiddenRoots)
 	allowedRoots := allowed.DeltaAllowedRoots()
-	hermesStateDBs := make(map[string]struct{})
-	for stateDB := range sqliteSnapshotTargets(allowed) {
-		hermesStateDBs[filepath.Clean(stateDB)] = struct{}{}
-	}
+	snapshotAgents := sqliteSnapshotTargets(allowed)
 	writtenHermesState := make(map[string]struct{})
 	for _, path := range files {
 		local, ok := resolveDeltaFilePath(allowedRoots, forbidden, path)
@@ -377,10 +384,10 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 		}
 		if stateDB, isHermesSQLite := sqliteSnapshotForArchivePath(local); isHermesSQLite {
 			stateDB = filepath.Clean(stateDB)
-			if _, allowed := hermesStateDBs[stateDB]; allowed {
+			if agent, allowed := snapshotAgents[stateDB]; allowed {
 				if _, written := writtenHermesState[stateDB]; !written {
 					writtenHermesState[stateDB] = struct{}{}
-					if err := writeSQLiteStateDBSnapshot(tw, stateDB); err != nil {
+					if err := writeSQLiteStateDBSnapshot(tw, stateDB, agent); err != nil {
 						return err
 					}
 				}

--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -95,6 +95,15 @@ func writeSQLiteStateDBSnapshot(tw *tar.Writer, stateDB string) error {
 	defer os.RemoveAll(tmpDir)
 	snapshotPath := filepath.Join(tmpDir, "state.db")
 	if err := writeSQLiteSnapshotFile(snapshotPath, stateDB); err != nil {
+		// The source can vanish or turn unreadable between the identity
+		// probe above and the online backup. Re-probe it: an unusable
+		// source is an omitted archive entry, exactly as if the probe
+		// had failed first, so the next manifest evicts the mirror's
+		// stale copy. A still-usable source means the failure was local
+		// (temp dir, destination write) and must propagate.
+		if _, _, stillUsable := sqliteSnapshotIdentity(stateDB); !stillUsable {
+			return nil
+		}
 		return fmt.Errorf("snapshot sqlite database %q: %w", stateDB, err)
 	}
 	if err := os.Chtimes(snapshotPath, modTime, modTime); err != nil {

--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -15,25 +15,24 @@ import (
 func WriteArchive(w io.Writer, targets TargetSet) error {
 	tw := tar.NewWriter(w)
 	forbidden := newForbiddenRootMatcher(targets.ForbiddenRoots)
-	hermesSQLite := make(map[string]string)
-	snapshotAgents := sqliteSnapshotTargets(targets)
-	for stateDB := range snapshotAgents {
-		for _, path := range hermesSQLitePaths(stateDB) {
-			hermesSQLite[path] = stateDB
+	snapshotSQLite := make(map[string]string)
+	for stateDB := range sqliteSnapshotTargets(targets) {
+		for _, path := range sqliteSnapshotPaths(stateDB) {
+			snapshotSQLite[path] = stateDB
 		}
 	}
-	writtenHermesState := make(map[string]struct{})
+	writtenSnapshots := make(map[string]struct{})
 	writePath := func(path string, optional bool) error {
 		if forbidden.within(path) {
 			return nil
 		}
 		clean := filepath.Clean(path)
-		if stateDB, ok := hermesSQLite[clean]; ok {
-			if _, written := writtenHermesState[stateDB]; written {
+		if stateDB, ok := snapshotSQLite[clean]; ok {
+			if _, written := writtenSnapshots[stateDB]; written {
 				return nil
 			}
-			writtenHermesState[stateDB] = struct{}{}
-			return writeSQLiteStateDBSnapshot(tw, stateDB, snapshotAgents[stateDB])
+			writtenSnapshots[stateDB] = struct{}{}
+			return writeSQLiteStateDBSnapshot(tw, stateDB)
 		}
 		if optional {
 			return writeOptionalArchiveFile(tw, path)
@@ -84,40 +83,31 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 	return nil
 }
 
-func writeSQLiteStateDBSnapshot(
-	tw *tar.Writer, stateDB string, agent parser.AgentType,
-) error {
-	_, modTime, exists, err := sqliteSnapshotIdentityForAgent(stateDB, agent)
-	if err != nil {
-		return fmt.Errorf("identify sqlite snapshot %q: %w", stateDB, err)
-	}
+func writeSQLiteStateDBSnapshot(tw *tar.Writer, stateDB string) error {
+	_, modTime, exists := sqliteSnapshotIdentity(stateDB)
 	if !exists {
 		return nil
 	}
-	tmpDir, err := os.MkdirTemp("", "agentsview-hermes-snapshot-*")
+	tmpDir, err := os.MkdirTemp("", "agentsview-sqlite-snapshot-*")
 	if err != nil {
 		return fmt.Errorf("create sqlite snapshot dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 	snapshotPath := filepath.Join(tmpDir, "state.db")
-	if err := writeHermesSnapshotFile(snapshotPath, stateDB); err != nil {
-		label := "sqlite"
-		if agent == parser.AgentHermes {
-			label = "hermes"
-		}
-		return fmt.Errorf("snapshot %s database %q: %w", label, stateDB, err)
+	if err := writeSQLiteSnapshotFile(snapshotPath, stateDB); err != nil {
+		return fmt.Errorf("snapshot sqlite database %q: %w", stateDB, err)
 	}
 	if err := os.Chtimes(snapshotPath, modTime, modTime); err != nil {
-		return fmt.Errorf("stamp hermes database snapshot: %w", err)
+		return fmt.Errorf("stamp sqlite database snapshot: %w", err)
 	}
 	info, err := os.Stat(snapshotPath)
 	if err != nil {
-		return fmt.Errorf("stat hermes database snapshot: %w", err)
+		return fmt.Errorf("stat sqlite database snapshot: %w", err)
 	}
 	return writeArchiveFileAs(tw, stateDB, snapshotPath, info)
 }
 
-var writeHermesSnapshotFile = writeSQLiteSnapshot
+var writeSQLiteSnapshotFile = writeSQLiteSnapshot
 
 func writeWindsurfArchiveFiles(
 	tw *tar.Writer, files []string, forbidden forbiddenRootMatcher,
@@ -375,19 +365,19 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 	tw := tar.NewWriter(w)
 	forbidden := newForbiddenRootMatcher(allowed.ForbiddenRoots)
 	allowedRoots := allowed.DeltaAllowedRoots()
-	snapshotAgents := sqliteSnapshotTargets(allowed)
-	writtenHermesState := make(map[string]struct{})
+	snapshotDBs := sqliteSnapshotTargets(allowed)
+	writtenSnapshots := make(map[string]struct{})
 	for _, path := range files {
 		local, ok := resolveDeltaFilePath(allowedRoots, forbidden, path)
 		if !ok {
 			continue
 		}
-		if stateDB, isHermesSQLite := sqliteSnapshotForArchivePath(local); isHermesSQLite {
+		if stateDB, isSnapshotSQLite := sqliteSnapshotForArchivePath(local); isSnapshotSQLite {
 			stateDB = filepath.Clean(stateDB)
-			if agent, allowed := snapshotAgents[stateDB]; allowed {
-				if _, written := writtenHermesState[stateDB]; !written {
-					writtenHermesState[stateDB] = struct{}{}
-					if err := writeSQLiteStateDBSnapshot(tw, stateDB, agent); err != nil {
+			if _, allowed := snapshotDBs[stateDB]; allowed {
+				if _, written := writtenSnapshots[stateDB]; !written {
+					writtenSnapshots[stateDB] = struct{}{}
+					if err := writeSQLiteStateDBSnapshot(tw, stateDB); err != nil {
 						return err
 					}
 				}

--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -43,7 +43,7 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 		if parser.RemoteSyncExcludedAgent(agent) {
 			continue
 		}
-		if _, fileScoped := targets.Files[agent]; fileScoped {
+		if targets.isFileScoped(agent) {
 			continue
 		}
 		for _, root := range dirs {

--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -16,7 +16,7 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 	tw := tar.NewWriter(w)
 	forbidden := newForbiddenRootMatcher(targets.ForbiddenRoots)
 	hermesSQLite := make(map[string]string)
-	for _, stateDB := range hermesStateDBTargets(targets) {
+	for stateDB := range sqliteSnapshotTargets(targets) {
 		for _, path := range hermesSQLitePaths(stateDB) {
 			hermesSQLite[path] = stateDB
 		}
@@ -32,7 +32,7 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 				return nil
 			}
 			writtenHermesState[stateDB] = struct{}{}
-			return writeHermesStateDBSnapshot(tw, stateDB)
+			return writeSQLiteStateDBSnapshot(tw, stateDB)
 		}
 		if optional {
 			return writeOptionalArchiveFile(tw, path)
@@ -84,13 +84,17 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 }
 
 func writeHermesStateDBSnapshot(tw *tar.Writer, stateDB string) error {
+	return writeSQLiteStateDBSnapshot(tw, stateDB)
+}
+
+func writeSQLiteStateDBSnapshot(tw *tar.Writer, stateDB string) error {
 	_, modTime, exists := hermesSQLiteSnapshotIdentity(stateDB)
 	if !exists {
 		return nil
 	}
 	tmpDir, err := os.MkdirTemp("", "agentsview-hermes-snapshot-*")
 	if err != nil {
-		return fmt.Errorf("create hermes snapshot dir: %w", err)
+		return fmt.Errorf("create sqlite snapshot dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 	snapshotPath := filepath.Join(tmpDir, "state.db")
@@ -366,7 +370,7 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 	forbidden := newForbiddenRootMatcher(allowed.ForbiddenRoots)
 	allowedRoots := allowed.DeltaAllowedRoots()
 	hermesStateDBs := make(map[string]struct{})
-	for _, stateDB := range hermesStateDBTargets(allowed) {
+	for stateDB := range sqliteSnapshotTargets(allowed) {
 		hermesStateDBs[filepath.Clean(stateDB)] = struct{}{}
 	}
 	writtenHermesState := make(map[string]struct{})
@@ -375,12 +379,12 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 		if !ok {
 			continue
 		}
-		if stateDB, isHermesSQLite := hermesStateDBForArchivePath(local); isHermesSQLite {
+		if stateDB, isHermesSQLite := sqliteSnapshotForArchivePath(local); isHermesSQLite {
 			stateDB = filepath.Clean(stateDB)
 			if _, allowed := hermesStateDBs[stateDB]; allowed {
 				if _, written := writtenHermesState[stateDB]; !written {
 					writtenHermesState[stateDB] = struct{}{}
-					if err := writeHermesStateDBSnapshot(tw, stateDB); err != nil {
+					if err := writeSQLiteStateDBSnapshot(tw, stateDB); err != nil {
 						return err
 					}
 				}

--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -83,10 +83,6 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 	return nil
 }
 
-func writeHermesStateDBSnapshot(tw *tar.Writer, stateDB string) error {
-	return writeSQLiteStateDBSnapshot(tw, stateDB)
-}
-
 func writeSQLiteStateDBSnapshot(tw *tar.Writer, stateDB string) error {
 	_, modTime, exists := hermesSQLiteSnapshotIdentity(stateDB)
 	if !exists {

--- a/internal/remotesync/archive_test.go
+++ b/internal/remotesync/archive_test.go
@@ -341,13 +341,13 @@ func TestWriteArchivePropagatesAdvertisedHermesSnapshotFailure(t *testing.T) {
 	writeHermesImportStateDB(t, stateDB)
 
 	wantErr := errors.New("forced sqlite backup failure")
-	originalSnapshot := writeHermesSnapshotFile
-	writeHermesSnapshotFile = func(dstPath, srcPath string) error {
+	originalSnapshot := writeSQLiteSnapshotFile
+	writeSQLiteSnapshotFile = func(dstPath, srcPath string) error {
 		assert.NotEmpty(t, dstPath)
 		assert.Equal(t, stateDB, srcPath)
 		return wantErr
 	}
-	t.Cleanup(func() { writeHermesSnapshotFile = originalSnapshot })
+	t.Cleanup(func() { writeSQLiteSnapshotFile = originalSnapshot })
 
 	var archive bytes.Buffer
 	err := WriteArchive(&archive, TargetSet{
@@ -355,7 +355,7 @@ func TestWriteArchivePropagatesAdvertisedHermesSnapshotFailure(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, wantErr)
-	assert.Contains(t, err.Error(), "snapshot hermes database")
+	assert.Contains(t, err.Error(), "snapshot sqlite database")
 }
 
 func hermesTestSidecars(stateDB string) []string {

--- a/internal/remotesync/archive_test.go
+++ b/internal/remotesync/archive_test.go
@@ -358,6 +358,30 @@ func TestWriteArchivePropagatesAdvertisedHermesSnapshotFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "snapshot sqlite database")
 }
 
+// A database that passes the identity probe but vanishes before the
+// online backup is a deletion race, not an archive failure: the entry
+// is omitted so the next manifest evicts the mirror's stale copy. The
+// propagation test above pins the complementary branch — a backup
+// failure with a still-usable source stays fatal.
+func TestWriteArchiveOmitsSnapshotWhenSourceVanishesMidBackup(t *testing.T) {
+	stateDB := filepath.Join(t.TempDir(), "profile", "state.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+	writeHermesImportStateDB(t, stateDB)
+
+	originalSnapshot := writeSQLiteSnapshotFile
+	writeSQLiteSnapshotFile = func(dstPath, srcPath string) error {
+		require.NoError(t, os.Remove(srcPath))
+		return errors.New("open sqlite snapshot source: no such file")
+	}
+	t.Cleanup(func() { writeSQLiteSnapshotFile = originalSnapshot })
+
+	var archive bytes.Buffer
+	require.NoError(t, WriteArchive(&archive, TargetSet{
+		Dirs: map[parser.AgentType][]string{parser.AgentHermes: {stateDB}},
+	}))
+	assert.Empty(t, archiveEntries(t, archive.Bytes()))
+}
+
 func hermesTestSidecars(stateDB string) []string {
 	return []string{
 		stateDB + "-wal",

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -1013,7 +1013,7 @@ func (r *mirrorTestRemote) addWindsurfFileScopedAgent(t *testing.T) string {
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	resolved := ResolveTargets(config.Config{
+	resolved := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentWindsurf: {userRoot},
 		},
@@ -2544,7 +2544,7 @@ func (r *mirrorTestRemote) addRooCodeAgent(
 	mcpSettings := filepath.Join(settingsDir, "mcp_settings.json")
 	require.NoError(t, os.WriteFile(mcpSettings,
 		[]byte(`{"mcpServers":{"s":{"env":{"API_KEY":"sk-secret"}}}}`), 0o644))
-	resolved := ResolveTargets(config.Config{
+	resolved := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentRooCode: {rooRoot},
 		},

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -506,6 +506,25 @@ func TestIssue1492VanishedZedDatabaseRemainsEvictable(t *testing.T) {
 	assert.Equal(t, []string{mirrorPath}, diff.Deletions)
 }
 
+func TestIssue1492ZedSnapshotErrorsPropagate(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	require.NoError(t, os.WriteFile(dbPath, []byte("corrupt sqlite database"), 0o644))
+	targets := TargetSet{
+		Dirs:  map[parser.AgentType][]string{parser.AgentZed: {root}},
+		Files: map[parser.AgentType][]string{parser.AgentZed: {dbPath}},
+	}
+	_, err := BuildManifest(targets)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identify sqlite snapshot")
+
+	var archive bytes.Buffer
+	err = WriteArchive(&archive, targets)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identify sqlite snapshot")
+}
+
 func TestIssue1492ZedSnapshotDeltaUsesOnlineBackup(t *testing.T) {
 	root := t.TempDir()
 	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json/v2"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -345,6 +346,34 @@ func TestIssue1492EmptyEditorRootsRetainEmptyFileTargets(t *testing.T) {
 	assert.False(t, marker)
 }
 
+func TestIssue1492CuratedEditorRootsAccumulateFiles(t *testing.T) {
+	root := t.TempDir()
+	cursorRoots := []string{filepath.Join(root, "cursor-a"), filepath.Join(root, "cursor-b")}
+	vscodeRoots := []string{filepath.Join(root, "vscode-a"), filepath.Join(root, "vscode-b")}
+	for i, cursorRoot := range cursorRoots {
+		path := filepath.Join(cursorRoot, "project", "agent-transcripts",
+			fmt.Sprintf("01234567-89ab-cdef-0123-456789abcde%d.jsonl", i))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("cursor"), 0o644))
+	}
+	for i, vscodeRoot := range vscodeRoots {
+		workspaceDir := filepath.Join(vscodeRoot, "workspaceStorage", fmt.Sprintf("hash-%d", i))
+		chat := filepath.Join(workspaceDir, "chatSessions", "01234567-89ab-cdef-0123-456789abcdef.json")
+		require.NoError(t, os.MkdirAll(filepath.Dir(chat), 0o755))
+		require.NoError(t, os.WriteFile(chat, []byte(`{"id":"chat"}`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(workspaceDir, "workspace.json"), []byte(`{"folder":"/repo"}`), 0o644))
+	}
+	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentCursor:        cursorRoots,
+		parser.AgentVSCodeCopilot: vscodeRoots,
+	}})
+
+	assert.ElementsMatch(t, cursorRoots, targets.Dirs[parser.AgentCursor])
+	assert.Len(t, targets.Files[parser.AgentCursor], len(cursorRoots))
+	assert.ElementsMatch(t, vscodeRoots, targets.Dirs[parser.AgentVSCodeCopilot])
+	assert.Len(t, targets.Files[parser.AgentVSCodeCopilot], len(vscodeRoots)*2)
+}
+
 func TestArchiveRequestPreservesEmptyFiles(t *testing.T) {
 	request := ArchiveRequest{
 		TargetSet: TargetSet{
@@ -385,6 +414,20 @@ func TestSelectAllowedTargetsRootOnlyCuratedRequestIsEmptyAndNoFilesystemAccess(
 	_, ok := SelectAllowedTargets(allowed, requested)
 	assert.False(t, ok)
 	assert.Empty(t, touched)
+
+	forbiddenAllowed := TargetSet{
+		Dirs:           map[parser.AgentType][]string{parser.AgentCursor: {root}},
+		Files:          map[parser.AgentType][]string{parser.AgentCursor: {}},
+		ForbiddenRoots: []string{root},
+	}
+	stale := TargetSet{
+		Dirs: map[parser.AgentType][]string{parser.AgentCursor: {root}},
+		Files: map[parser.AgentType][]string{parser.AgentCursor: {
+			filepath.Join(root, "project", "agent-transcripts", "01234567-89ab-cdef-0123-456789abcdef.jsonl"),
+		}},
+	}
+	_, ok = SelectAllowedTargets(forbiddenAllowed, stale)
+	assert.False(t, ok, "stale curated files under forbidden roots must stay rejected")
 
 	selected, ok := SelectAllowedTargets(allowed, TargetSet{
 		Dirs: map[parser.AgentType][]string{parser.AgentCursor: {root}},

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -93,6 +93,7 @@ func TestIssue1492ZedActiveWALIsOneStableStandaloneDatabase(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
 	writer, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 	defer writer.Close()
 	_, err = writer.Exec(`PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE threads (id TEXT PRIMARY KEY); INSERT INTO threads VALUES ('wal-thread');`)
 	require.NoError(t, err)
@@ -158,6 +159,85 @@ func TestIssue1492VanishedCuratedFileIsOmittedAndDeltaIsConfined(t *testing.T) {
 
 	_, ok := SelectAllowedFiles(targets, []string{filepath.Join(root, "project", "mcp_auth.json")})
 	assert.False(t, ok)
+}
+
+func TestIssue1492VanishedCursorAndVSCodeFilesRemainAuthorized(t *testing.T) {
+	id := "01234567-89ab-cdef-0123-456789abcdef"
+	tests := []struct {
+		name  string
+		agent parser.AgentType
+		path  func(string) string
+	}{
+		{
+			name:  "cursor",
+			agent: parser.AgentCursor,
+			path: func(root string) string {
+				return filepath.Join(root, "project", "agent-transcripts", id+".jsonl")
+			},
+		},
+		{
+			name:  "vscode",
+			agent: parser.AgentVSCodeCopilot,
+			path: func(root string) string {
+				return filepath.Join(root, "workspaceStorage", "hash", "chatSessions", id+".json")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			path := tt.path(root)
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+			require.NoError(t, os.WriteFile(path, []byte("session"), 0o644))
+			cfg := config.Config{AgentDirs: map[parser.AgentType][]string{tt.agent: {root}}}
+			stale := ResolveTargets(cfg)
+			require.Contains(t, stale.Files[tt.agent], path)
+			require.NoError(t, os.Remove(path))
+
+			fresh := ResolveTargets(cfg)
+			require.Contains(t, fresh.Dirs[tt.agent], root)
+			files, ok := SelectAllowedFiles(fresh, []string{path})
+			require.True(t, ok, "vanished %s file must remain authorized", tt.name)
+			var delta bytes.Buffer
+			require.NoError(t, WriteArchiveFiles(&delta, fresh, files))
+			assert.Empty(t, archiveEntries(t, delta.Bytes()))
+		})
+	}
+}
+
+func TestIssue1492ZedSnapshotDeltaUsesOnlineBackup(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
+	_, err = writer.Exec(`PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE threads (id TEXT PRIMARY KEY); INSERT INTO threads VALUES ('delta-thread')`)
+	require.NoError(t, err)
+	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentZed: {root},
+	}})
+	files, ok := SelectAllowedFiles(targets, []string{dbPath})
+	require.True(t, ok, "Zed snapshot must be authorized as a delta file")
+	var delta bytes.Buffer
+	require.NoError(t, WriteArchiveFiles(&delta, targets, files))
+	entries := archiveEntries(t, delta.Bytes())
+	require.Len(t, entries, 1)
+	var snapshot []byte
+	for name, body := range entries {
+		if strings.HasSuffix(name, "/threads/threads.db") {
+			snapshot = body
+		}
+	}
+	require.NotEmpty(t, snapshot)
+	snapshotPath := filepath.Join(t.TempDir(), "threads.db")
+	require.NoError(t, os.WriteFile(snapshotPath, snapshot, 0o600))
+	reader, err := sql.Open("sqlite3", snapshotPath)
+	require.NoError(t, err)
+	var id string
+	require.NoError(t, reader.QueryRow("SELECT id FROM threads").Scan(&id))
+	assert.Equal(t, "delta-thread", id)
+	require.NoError(t, reader.Close())
 }
 
 func keys(values map[string][]byte) []string {

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -375,11 +375,12 @@ func TestIssue1492CuratedEditorRootsAccumulateFiles(t *testing.T) {
 }
 
 func TestArchiveRequestPreservesEmptyFiles(t *testing.T) {
+	targetSet := TargetSet{
+		Dirs:  map[parser.AgentType][]string{parser.AgentCursor: {"/root"}},
+		Files: map[parser.AgentType][]string{parser.AgentCursor: {}},
+	}
 	request := ArchiveRequest{
-		TargetSet: TargetSet{
-			Dirs:  map[parser.AgentType][]string{parser.AgentCursor: {"/root"}},
-			Files: map[parser.AgentType][]string{parser.AgentCursor: {}},
-		},
+		TargetSet:  targetSet,
 		DeltaFiles: []string{},
 	}
 	data, err := json.Marshal(request)

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -1,0 +1,170 @@
+package remotesync
+
+import (
+	"archive/tar"
+	"bytes"
+	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func archiveEntries(t *testing.T, data []byte) map[string][]byte {
+	t.Helper()
+	entries := make(map[string][]byte)
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return entries
+		}
+		require.NoError(t, err)
+		body, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		entries[hdr.Name] = body
+	}
+}
+
+func manifestPaths(m Manifest) []string {
+	paths := make([]string, 0, len(m.Files))
+	for _, file := range m.Files {
+		paths = append(paths, file.Path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func TestIssue1492CuratesCursorAndVSCodeTargets(t *testing.T) {
+	root := t.TempDir()
+	id := "01234567-89ab-cdef-0123-456789abcdef"
+	cursor := filepath.Join(root, "cursor", "project", "agent-transcripts", id+".jsonl")
+	cursorDecoy := filepath.Join(root, "cursor", "project", "mcp_auth.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cursor), 0o755))
+	require.NoError(t, os.WriteFile(cursor, []byte("cursor"), 0o644))
+	require.NoError(t, os.WriteFile(cursorDecoy, []byte("secret"), 0o644))
+
+	vscodeRoot := filepath.Join(root, "vscode")
+	workspaceDir := filepath.Join(vscodeRoot, "workspaceStorage", "workspace-hash")
+	workspaceChat := filepath.Join(workspaceDir, "chatSessions", id+".json")
+	workspaceManifest := filepath.Join(workspaceDir, "workspace.json")
+	globalChat := filepath.Join(vscodeRoot, "globalStorage", "emptyWindowChatSessions", id+".jsonl")
+	vscodeDecoy := filepath.Join(vscodeRoot, "globalStorage", "mcp_auth.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(workspaceChat), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(globalChat), 0o755))
+	require.NoError(t, os.WriteFile(workspaceChat, []byte("workspace chat"), 0o644))
+	require.NoError(t, os.WriteFile(workspaceManifest, []byte(`{"folder":"/repo"}`), 0o644))
+	require.NoError(t, os.WriteFile(globalChat, []byte("global chat"), 0o644))
+	require.NoError(t, os.WriteFile(vscodeDecoy, []byte("secret"), 0o644))
+
+	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentCursor:        {filepath.Join(root, "cursor")},
+		parser.AgentVSCodeCopilot: {vscodeRoot},
+	}})
+	require.Len(t, targets.Files[parser.AgentCursor], 1)
+	require.Len(t, targets.Files[parser.AgentVSCodeCopilot], 3)
+	assert.Contains(t, targets.Files[parser.AgentVSCodeCopilot], workspaceManifest)
+	assert.NotContains(t, strings.Join(targets.Files[parser.AgentCursor], "\n"), "mcp_auth")
+
+	manifest, err := BuildManifest(targets)
+	require.NoError(t, err)
+	var archive bytes.Buffer
+	require.NoError(t, WriteArchive(&archive, targets))
+	paths := strings.Join(manifestPaths(manifest), "\n")
+	entries := archiveEntries(t, archive.Bytes())
+	assert.NotContains(t, paths, "mcp_auth.json")
+	for name := range entries {
+		assert.NotContains(t, name, "mcp_auth.json")
+	}
+	assert.Contains(t, paths, "workspace.json")
+}
+
+func TestIssue1492ZedActiveWALIsOneStableStandaloneDatabase(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer writer.Close()
+	_, err = writer.Exec(`PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE threads (id TEXT PRIMARY KEY); INSERT INTO threads VALUES ('wal-thread');`)
+	require.NoError(t, err)
+	walInfo, err := os.Stat(dbPath + "-wal")
+	require.NoError(t, err)
+	assert.Greater(t, walInfo.Size(), int64(32))
+
+	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentZed: {root},
+	}})
+	require.Equal(t, []string{dbPath}, targets.Files[parser.AgentZed])
+	manifest, err := BuildManifest(targets)
+	require.NoError(t, err)
+	require.Len(t, manifest.Files, 1)
+	manifestEntry := manifest.Files[0]
+	var archive bytes.Buffer
+	require.NoError(t, WriteArchive(&archive, targets))
+	entries := archiveEntries(t, archive.Bytes())
+	require.Len(t, entries, 1)
+	archiveBody, ok := entries[filepath.ToSlash(dbPath)]
+	if !ok {
+		for name, body := range entries {
+			if strings.HasSuffix(name, "/threads/threads.db") {
+				archiveBody, ok = body, true
+			}
+		}
+	}
+	require.True(t, ok)
+	assert.NotContains(t, strings.Join(keys(entries), "\n"), "-wal")
+
+	snapshot := filepath.Join(t.TempDir(), "threads.db")
+	require.NoError(t, os.WriteFile(snapshot, archiveBody, 0o600))
+	reader, err := sql.Open("sqlite3", snapshot)
+	require.NoError(t, err)
+	var id string
+	require.NoError(t, reader.QueryRow("SELECT id FROM threads").Scan(&id))
+	assert.Equal(t, "wal-thread", id)
+	require.NoError(t, reader.Close())
+	require.NoError(t, writer.Close())
+
+	for _, entry := range manifest.Files {
+		assert.Equal(t, manifestEntry.Size, entry.Size)
+		assert.Equal(t, manifestEntry.MtimeNS, entry.MtimeNS)
+	}
+}
+
+func TestIssue1492VanishedCuratedFileIsOmittedAndDeltaIsConfined(t *testing.T) {
+	root := t.TempDir()
+	id := "01234567-89ab-cdef-0123-456789abcdef"
+	selected := filepath.Join(root, "project", "agent-transcripts", id+".jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(selected), 0o755))
+	require.NoError(t, os.WriteFile(selected, []byte("session"), 0o644))
+	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentCursor: {root},
+	}})
+	require.NoError(t, os.Remove(selected))
+	manifest, err := BuildManifest(targets)
+	require.NoError(t, err)
+	assert.Empty(t, manifest.Files)
+	var archive bytes.Buffer
+	require.NoError(t, WriteArchive(&archive, targets))
+	assert.Empty(t, archiveEntries(t, archive.Bytes()))
+
+	_, ok := SelectAllowedFiles(targets, []string{filepath.Join(root, "project", "mcp_auth.json")})
+	assert.False(t, ok)
+}
+
+func keys(values map[string][]byte) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -470,6 +470,14 @@ func TestSelectAllowedTargetsDirectoryOnlyRequestRequiresCurrentCuratedFiles(t *
 		}
 		_, ok := SelectAllowedTargets(allowed, requested)
 		assert.False(t, ok, "%s directory-only request must not discard current curated files", tc.agent)
+
+		requestedEmpty := TargetSet{
+			Dirs:  map[parser.AgentType][]string{tc.agent: {root}},
+			Files: map[parser.AgentType][]string{tc.agent: {}},
+		}
+		_, ok = SelectAllowedTargets(allowed, requestedEmpty)
+		assert.False(t, ok,
+			"%s explicitly empty file request must not discard current curated files", tc.agent)
 	}
 }
 
@@ -569,6 +577,27 @@ func TestIssue1492UnreadableCuratedRootFailsResolution(t *testing.T) {
 		_, err := ResolveTargets(cfg)
 		require.Error(t, err,
 			"an unreadable editor root must not resolve to an empty target set")
+		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+
+	t.Run("roocode root stat error", func(t *testing.T) {
+		parent := t.TempDir()
+		root := filepath.Join(parent, "roo")
+		task := filepath.Join(root, "tasks", "task-1")
+		require.NoError(t, os.MkdirAll(task, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(task, "history_item.json"), []byte("{}"), 0o644))
+		cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+			parser.AgentRooCode: {root},
+		}}
+		targets := resolveTargetsForTest(t, cfg)
+		require.NotEmpty(t, targets.Files[parser.AgentRooCode])
+
+		require.NoError(t, os.Chmod(parent, 0o000))
+		t.Cleanup(func() { require.NoError(t, os.Chmod(parent, 0o755)) })
+		_, err := ResolveTargets(cfg)
+		require.Error(t, err,
+			"an unreadable RooCode root must not resolve to an empty target set")
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})
 

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -34,6 +35,13 @@ func archiveEntries(t *testing.T, data []byte) map[string][]byte {
 		require.NoError(t, err)
 		entries[hdr.Name] = body
 	}
+}
+
+func resolveTargetsForTest(t *testing.T, cfg config.Config) TargetSet {
+	t.Helper()
+	targets, err := ResolveTargets(cfg)
+	require.NoError(t, err)
+	return targets
 }
 
 func manifestPaths(m Manifest) []string {
@@ -67,7 +75,7 @@ func TestIssue1492CuratesCursorAndVSCodeTargets(t *testing.T) {
 	require.NoError(t, os.WriteFile(globalChat, []byte("global chat"), 0o644))
 	require.NoError(t, os.WriteFile(vscodeDecoy, []byte("secret"), 0o644))
 
-	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentCursor:        {filepath.Join(root, "cursor")},
 		parser.AgentVSCodeCopilot: {vscodeRoot},
 	}})
@@ -103,7 +111,7 @@ func TestIssue1492ZedActiveWALIsOneStableStandaloneDatabase(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, walInfo.Size(), int64(32))
 
-	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentZed: {root},
 	}})
 	require.Equal(t, []string{dbPath}, targets.Files[parser.AgentZed])
@@ -148,7 +156,7 @@ func TestIssue1492VanishedCuratedFileIsOmittedAndDeltaIsConfined(t *testing.T) {
 	selected := filepath.Join(root, "project", "agent-transcripts", id+".jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(selected), 0o755))
 	require.NoError(t, os.WriteFile(selected, []byte("session"), 0o644))
-	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentCursor: {root},
 	}})
 	require.NoError(t, os.Remove(selected))
@@ -192,11 +200,11 @@ func TestIssue1492VanishedCursorAndVSCodeFilesRemainAuthorized(t *testing.T) {
 			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 			require.NoError(t, os.WriteFile(path, []byte("session"), 0o644))
 			cfg := config.Config{AgentDirs: map[parser.AgentType][]string{tt.agent: {root}}}
-			stale := ResolveTargets(cfg)
+			stale := resolveTargetsForTest(t, cfg)
 			require.Contains(t, stale.Files[tt.agent], path)
 			require.NoError(t, os.Remove(path))
 
-			fresh := ResolveTargets(cfg)
+			fresh := resolveTargetsForTest(t, cfg)
 			require.Contains(t, fresh.Dirs[tt.agent], root)
 			files, ok := SelectAllowedFiles(fresh, []string{path})
 			require.True(t, ok, "vanished %s file must remain authorized", tt.name)
@@ -224,9 +232,9 @@ func TestIssue1492AllCuratedEditorFilesVanishedRemainAuthorized(t *testing.T) {
 			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 			require.NoError(t, os.WriteFile(path, []byte("session"), 0o644))
 			cfg := config.Config{AgentDirs: map[parser.AgentType][]string{tt.agent: {root}}}
-			stale := ResolveTargets(cfg)
+			stale := resolveTargetsForTest(t, cfg)
 			require.NoError(t, os.Remove(path))
-			fresh := ResolveTargets(cfg)
+			fresh := resolveTargetsForTest(t, cfg)
 			selected, ok := SelectAllowedTargets(fresh, stale)
 			require.True(t, ok, "vanished %s target must remain authorized", tt.name)
 			manifest, err := BuildManifest(selected)
@@ -252,7 +260,7 @@ func TestIssue1492VanishedVSCodeWorkspaceIsEvictedFromMirror(t *testing.T) {
 	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentVSCodeCopilot: {root},
 	}}
-	initial := ResolveTargets(cfg)
+	initial := resolveTargetsForTest(t, cfg)
 	require.Contains(t, initial.Files[parser.AgentVSCodeCopilot], workspace)
 
 	mirror := t.TempDir()
@@ -261,7 +269,7 @@ func TestIssue1492VanishedVSCodeWorkspaceIsEvictedFromMirror(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(mirrorWorkspace), 0o755))
 	require.NoError(t, os.WriteFile(mirrorWorkspace, []byte("stale"), 0o644))
 	require.NoError(t, os.Remove(workspace))
-	fresh := ResolveTargets(cfg)
+	fresh := resolveTargetsForTest(t, cfg)
 	selected, ok := SelectAllowedFiles(fresh, []string{workspace})
 	require.True(t, ok, "vanished workspace.json must remain authorized")
 	var delta bytes.Buffer
@@ -284,7 +292,7 @@ func TestIssue1492VSCodeWorkspaceMetadataRequiresSelectedChat(t *testing.T) {
 	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentVSCodeCopilot: {root},
 	}}
-	allowed := ResolveTargets(cfg)
+	allowed := resolveTargetsForTest(t, cfg)
 	unauthorized := filepath.Join(root, "workspaceStorage", "other", "workspace.json")
 	_, ok := SelectAllowedFiles(allowed, []string{unauthorized})
 	assert.False(t, ok)
@@ -302,7 +310,7 @@ func TestIssue1492EmptyEditorRootsRetainEmptyFileTargets(t *testing.T) {
 	for _, dir := range []string{filepath.Join(root, "cursor"), filepath.Join(root, "vscode")} {
 		require.NoError(t, os.MkdirAll(dir, 0o755))
 	}
-	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentCursor:        {filepath.Join(root, "cursor")},
 		parser.AgentVSCodeCopilot: {filepath.Join(root, "vscode")},
 	}})
@@ -363,7 +371,7 @@ func TestIssue1492CuratedEditorRootsAccumulateFiles(t *testing.T) {
 		require.NoError(t, os.WriteFile(chat, []byte(`{"id":"chat"}`), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(workspaceDir, "workspace.json"), []byte(`{"folder":"/repo"}`), 0o644))
 	}
-	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentCursor:        cursorRoots,
 		parser.AgentVSCodeCopilot: vscodeRoots,
 	}})
@@ -476,7 +484,7 @@ func TestIssue1492EmptyCuratedRootsProduceEmptyArchives(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 		require.NoError(t, os.WriteFile(path, []byte("credential decoy"), 0o600))
 	}
-	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentCursor:        {cursorRoot},
 		parser.AgentVSCodeCopilot: {vscodeRoot},
 	}})
@@ -504,11 +512,11 @@ func TestIssue1492VanishedZedDatabaseRemainsEvictable(t *testing.T) {
 	configured := config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentZed: {root},
 	}}
-	initial := ResolveTargets(configured)
+	initial := resolveTargetsForTest(t, configured)
 	require.Equal(t, []string{dbPath}, initial.Files[parser.AgentZed])
 	require.NoError(t, os.Remove(dbPath))
 
-	fresh := ResolveTargets(configured)
+	fresh := resolveTargetsForTest(t, configured)
 	assert.Equal(t, []string{root}, fresh.Dirs[parser.AgentZed])
 	assert.Equal(t, []string{dbPath}, fresh.Files[parser.AgentZed])
 	manifest, err := BuildManifest(fresh)
@@ -531,23 +539,91 @@ func TestIssue1492VanishedZedDatabaseRemainsEvictable(t *testing.T) {
 	assert.Equal(t, []string{mirrorPath}, diff.Deletions)
 }
 
-func TestIssue1492ZedSnapshotErrorsPropagate(t *testing.T) {
+// A resolution error must fail the whole resolution instead of
+// silently dropping the agent: an agent absent from the advertised
+// targets is indistinguishable from an uninstalled one, so the client
+// would evict its entire mirror subtree over a transient read error.
+func TestIssue1492UnreadableCuratedRootFailsResolution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory-permission read failures are not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	id := "01234567-89ab-cdef-0123-456789abcdef"
+
+	t.Run("vscode discovery error", func(t *testing.T) {
+		root := t.TempDir()
+		chat := filepath.Join(root, "workspaceStorage", "hash", "chatSessions", id+".json")
+		require.NoError(t, os.MkdirAll(filepath.Dir(chat), 0o755))
+		require.NoError(t, os.WriteFile(chat, []byte(`{"id":"chat"}`), 0o644))
+		cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVSCodeCopilot: {root},
+		}}
+		targets := resolveTargetsForTest(t, cfg)
+		require.Contains(t, targets.Files[parser.AgentVSCodeCopilot], chat)
+
+		storage := filepath.Join(root, "workspaceStorage")
+		require.NoError(t, os.Chmod(storage, 0o000))
+		t.Cleanup(func() { require.NoError(t, os.Chmod(storage, 0o755)) })
+		_, err := ResolveTargets(cfg)
+		require.Error(t, err,
+			"an unreadable editor root must not resolve to an empty target set")
+		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+
+	t.Run("zed root stat error", func(t *testing.T) {
+		parent := t.TempDir()
+		root := filepath.Join(parent, "zed")
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "threads"), 0o755))
+		cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+			parser.AgentZed: {root},
+		}}
+		targets := resolveTargetsForTest(t, cfg)
+		require.Contains(t, targets.Dirs[parser.AgentZed], root)
+
+		require.NoError(t, os.Chmod(parent, 0o000))
+		t.Cleanup(func() { require.NoError(t, os.Chmod(parent, 0o755)) })
+		_, err := ResolveTargets(cfg)
+		require.Error(t, err,
+			"an unreadable Zed root must not resolve to an empty target set")
+		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+}
+
+// A corrupt Zed database must not block the whole sync: the archive
+// database preserves already-imported sessions, so the unreadable file
+// degrades to a missing manifest entry (the mirror evicts its cached
+// copy) while every other agent keeps syncing.
+func TestIssue1492CorruptZedDatabaseDoesNotBlockOtherAgents(t *testing.T) {
 	root := t.TempDir()
 	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)
 	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
 	require.NoError(t, os.WriteFile(dbPath, []byte("corrupt sqlite database"), 0o644))
+	cursorRoot := filepath.Join(root, "cursor")
+	cursorFile := filepath.Join(cursorRoot, "project", "agent-transcripts",
+		"01234567-89ab-cdef-0123-456789abcdef.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cursorFile), 0o755))
+	require.NoError(t, os.WriteFile(cursorFile, []byte("cursor transcript"), 0o644))
 	targets := TargetSet{
-		Dirs:  map[parser.AgentType][]string{parser.AgentZed: {root}},
-		Files: map[parser.AgentType][]string{parser.AgentZed: {dbPath}},
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentZed:    {root},
+			parser.AgentCursor: {cursorRoot},
+		},
+		Files: map[parser.AgentType][]string{
+			parser.AgentZed:    {dbPath},
+			parser.AgentCursor: {cursorFile},
+		},
 	}
-	_, err := BuildManifest(targets)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "identify sqlite snapshot")
+	manifest, err := BuildManifest(targets)
+	require.NoError(t, err)
+	assert.Equal(t, []string{cursorFile}, manifestPaths(manifest))
 
 	var archive bytes.Buffer
-	err = WriteArchive(&archive, targets)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "identify sqlite snapshot")
+	require.NoError(t, WriteArchive(&archive, targets))
+	entries := archiveEntries(t, archive.Bytes())
+	require.Len(t, entries, 1)
+	assert.NotContains(t, strings.Join(keys(entries), "\n"), "threads.db")
 }
 
 func TestIssue1492ZedSnapshotDeltaUsesOnlineBackup(t *testing.T) {
@@ -559,7 +635,7 @@ func TestIssue1492ZedSnapshotDeltaUsesOnlineBackup(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 	_, err = writer.Exec(`PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE threads (id TEXT PRIMARY KEY); INSERT INTO threads VALUES ('delta-thread')`)
 	require.NoError(t, err)
-	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentZed: {root},
 	}})
 	files, ok := SelectAllowedFiles(targets, []string{dbPath})

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -205,6 +205,40 @@ func TestIssue1492VanishedCursorAndVSCodeFilesRemainAuthorized(t *testing.T) {
 	}
 }
 
+func TestIssue1492VanishedVSCodeWorkspaceIsEvictedFromMirror(t *testing.T) {
+	root := t.TempDir()
+	workspaceDir := filepath.Join(root, "workspaceStorage", "hash")
+	workspace := filepath.Join(workspaceDir, "workspace.json")
+	chat := filepath.Join(workspaceDir, "chatSessions", "01234567-89ab-cdef-0123-456789abcdef.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(chat), 0o755))
+	require.NoError(t, os.WriteFile(workspace, []byte(`{"folder":"/repo"}`), 0o644))
+	require.NoError(t, os.WriteFile(chat, []byte(`{"id":"chat"}`), 0o644))
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentVSCodeCopilot: {root},
+	}}
+	initial := ResolveTargets(cfg)
+	require.Contains(t, initial.Files[parser.AgentVSCodeCopilot], workspace)
+
+	mirror := t.TempDir()
+	mirrorWorkspace, err := safeRemappedRemotePath(mirror, workspace)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(mirrorWorkspace), 0o755))
+	require.NoError(t, os.WriteFile(mirrorWorkspace, []byte("stale"), 0o644))
+	require.NoError(t, os.Remove(workspace))
+	fresh := ResolveTargets(cfg)
+	selected, ok := SelectAllowedFiles(fresh, []string{workspace})
+	require.True(t, ok, "vanished workspace.json must remain authorized")
+	var delta bytes.Buffer
+	require.NoError(t, WriteArchiveFiles(&delta, fresh, selected))
+	assert.Empty(t, archiveEntries(t, delta.Bytes()))
+
+	manifest, err := BuildManifest(fresh)
+	require.NoError(t, err)
+	diff, err := MirrorDiff(mirror, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, []string{mirrorWorkspace}, diff.Deletions)
+}
+
 func TestIssue1492EmptyEditorRootsRemainWithoutEmptyFileTargets(t *testing.T) {
 	root := t.TempDir()
 	for _, dir := range []string{filepath.Join(root, "cursor"), filepath.Join(root, "vscode")} {

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -205,6 +205,57 @@ func TestIssue1492VanishedCursorAndVSCodeFilesRemainAuthorized(t *testing.T) {
 	}
 }
 
+func TestIssue1492EmptyEditorRootsRemainWithoutEmptyFileTargets(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{filepath.Join(root, "cursor"), filepath.Join(root, "vscode")} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentCursor:        {filepath.Join(root, "cursor")},
+		parser.AgentVSCodeCopilot: {filepath.Join(root, "vscode")},
+	}})
+
+	assert.Contains(t, targets.Dirs[parser.AgentCursor], filepath.Join(root, "cursor"))
+	assert.Contains(t, targets.Dirs[parser.AgentVSCodeCopilot], filepath.Join(root, "vscode"))
+	assert.NotContains(t, targets.Files, parser.AgentCursor)
+	assert.NotContains(t, targets.Files, parser.AgentVSCodeCopilot)
+}
+
+func TestIssue1492VanishedZedDatabaseRemainsEvictable(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	require.NoError(t, os.WriteFile(dbPath, []byte("selected"), 0o644))
+	configured := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentZed: {root},
+	}}
+	initial := ResolveTargets(configured)
+	require.Equal(t, []string{dbPath}, initial.Files[parser.AgentZed])
+	require.NoError(t, os.Remove(dbPath))
+
+	fresh := ResolveTargets(configured)
+	assert.Equal(t, []string{root}, fresh.Dirs[parser.AgentZed])
+	assert.Equal(t, []string{dbPath}, fresh.Files[parser.AgentZed])
+	manifest, err := BuildManifest(fresh)
+	require.NoError(t, err)
+	assert.Empty(t, manifest.Files)
+
+	selected, ok := SelectAllowedFiles(fresh, []string{dbPath})
+	require.True(t, ok)
+	var delta bytes.Buffer
+	require.NoError(t, WriteArchiveFiles(&delta, fresh, selected))
+	assert.Empty(t, archiveEntries(t, delta.Bytes()))
+
+	mirror := t.TempDir()
+	mirrorPath, err := safeRemappedRemotePath(mirror, dbPath)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(mirrorPath), 0o755))
+	require.NoError(t, os.WriteFile(mirrorPath, []byte("stale"), 0o644))
+	diff, err := MirrorDiff(mirror, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, []string{mirrorPath}, diff.Deletions)
+}
+
 func TestIssue1492ZedSnapshotDeltaUsesOnlineBackup(t *testing.T) {
 	root := t.TempDir()
 	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -620,6 +620,32 @@ func TestIssue1492UnreadableCuratedRootFailsResolution(t *testing.T) {
 	})
 }
 
+// A curated file whose stat fails for any reason other than absence
+// must fail resolution instead of being silently omitted, or the next
+// manifest would evict the client's cached copy.
+func TestIssue1492UnreadableCuratedFilePropagatesStatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory-permission read failures are not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	path := filepath.Join(sub, "session.json")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{}"), 0o644))
+	regular, err := regularCuratedFile(root, path)
+	require.NoError(t, err)
+	assert.True(t, regular)
+
+	require.NoError(t, os.Chmod(sub, 0o000))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(sub, 0o755)) })
+	_, err = regularCuratedFile(root, path)
+	require.Error(t, err, "an unreadable curated file must not be silently omitted")
+	assert.ErrorIs(t, err, os.ErrPermission)
+}
+
 // A corrupt Zed database must not block the whole sync: the archive
 // database preserves already-imported sessions, so the unreadable file
 // degrades to a missing manifest entry (the mirror evicts its cached

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -205,6 +205,40 @@ func TestIssue1492VanishedCursorAndVSCodeFilesRemainAuthorized(t *testing.T) {
 	}
 }
 
+func TestIssue1492AllCuratedEditorFilesVanishedRemainAuthorized(t *testing.T) {
+	id := "01234567-89ab-cdef-0123-456789abcdef"
+	tests := []struct {
+		name  string
+		agent parser.AgentType
+		path  string
+	}{
+		{"cursor", parser.AgentCursor, filepath.Join("project", "agent-transcripts", id+".jsonl")},
+		{"vscode", parser.AgentVSCodeCopilot, filepath.Join("workspaceStorage", "hash", "chatSessions", id+".json")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, tt.path)
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+			require.NoError(t, os.WriteFile(path, []byte("session"), 0o644))
+			cfg := config.Config{AgentDirs: map[parser.AgentType][]string{tt.agent: {root}}}
+			stale := ResolveTargets(cfg)
+			require.NoError(t, os.Remove(path))
+			fresh := ResolveTargets(cfg)
+			selected, ok := SelectAllowedTargets(fresh, stale)
+			require.True(t, ok, "vanished %s target must remain authorized", tt.name)
+			manifest, err := BuildManifest(selected)
+			require.NoError(t, err)
+			assert.Empty(t, manifest.Files)
+			files, ok := SelectAllowedFiles(fresh, []string{path})
+			require.True(t, ok, "vanished %s delta must remain authorized", tt.name)
+			var delta bytes.Buffer
+			require.NoError(t, WriteArchiveFiles(&delta, fresh, files))
+			assert.Empty(t, archiveEntries(t, delta.Bytes()))
+		})
+	}
+}
+
 func TestIssue1492VanishedVSCodeWorkspaceIsEvictedFromMirror(t *testing.T) {
 	root := t.TempDir()
 	workspaceDir := filepath.Join(root, "workspaceStorage", "hash")

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -428,6 +428,8 @@ func TestSelectAllowedTargetsRootOnlyCuratedRequestIsEmptyAndNoFilesystemAccess(
 	}
 	_, ok = SelectAllowedTargets(forbiddenAllowed, stale)
 	assert.False(t, ok, "stale curated files under forbidden roots must stay rejected")
+	_, ok = SelectAllowedFiles(forbiddenAllowed, stale.Files[parser.AgentCursor])
+	assert.False(t, ok, "stale delta files under forbidden roots must stay rejected")
 
 	selected, ok := SelectAllowedTargets(allowed, TargetSet{
 		Dirs: map[parser.AgentType][]string{parser.AgentCursor: {root}},

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -440,6 +440,30 @@ func TestSelectAllowedTargetsRootOnlyCuratedRequestIsEmptyAndNoFilesystemAccess(
 	assert.Empty(t, selected.Files[parser.AgentCursor])
 }
 
+func TestSelectAllowedTargetsDirectoryOnlyRequestRequiresCurrentCuratedFiles(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		agent parser.AgentType
+		file  string
+	}{
+		{agent: parser.AgentCursor, file: filepath.Join(root, "cursor", "chat.jsonl")},
+		{agent: parser.AgentVSCodeCopilot, file: filepath.Join(root, "vscode", "chat.json")},
+		{agent: parser.AgentRooCode, file: filepath.Join(root, "roo", "session.json")},
+		{agent: parser.AgentZed, file: filepath.Join(root, parser.ZedThreadsDBRelPath)},
+	}
+	for _, tc := range cases {
+		allowed := TargetSet{
+			Dirs:  map[parser.AgentType][]string{tc.agent: {root}},
+			Files: map[parser.AgentType][]string{tc.agent: {tc.file}},
+		}
+		requested := TargetSet{
+			Dirs: map[parser.AgentType][]string{tc.agent: {root}},
+		}
+		_, ok := SelectAllowedTargets(allowed, requested)
+		assert.False(t, ok, "%s directory-only request must not discard current curated files", tc.agent)
+	}
+}
+
 func TestIssue1492EmptyCuratedRootsProduceEmptyArchives(t *testing.T) {
 	root := t.TempDir()
 	cursorRoot := filepath.Join(root, "cursor")

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -239,6 +239,28 @@ func TestIssue1492VanishedVSCodeWorkspaceIsEvictedFromMirror(t *testing.T) {
 	assert.Equal(t, []string{mirrorWorkspace}, diff.Deletions)
 }
 
+func TestIssue1492VSCodeWorkspaceMetadataRequiresSelectedChat(t *testing.T) {
+	root := t.TempDir()
+	workspaceDir := filepath.Join(root, "workspaceStorage", "allowed")
+	chat := filepath.Join(workspaceDir, "chatSessions", "01234567-89ab-cdef-0123-456789abcdef.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(chat), 0o755))
+	require.NoError(t, os.WriteFile(chat, []byte(`{"id":"chat"}`), 0o644))
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentVSCodeCopilot: {root},
+	}}
+	allowed := ResolveTargets(cfg)
+	unauthorized := filepath.Join(root, "workspaceStorage", "other", "workspace.json")
+	_, ok := SelectAllowedFiles(allowed, []string{unauthorized})
+	assert.False(t, ok)
+
+	requested := TargetSet{
+		Dirs:  map[parser.AgentType][]string{parser.AgentVSCodeCopilot: {root}},
+		Files: map[parser.AgentType][]string{parser.AgentVSCodeCopilot: {chat, unauthorized}},
+	}
+	_, ok = SelectAllowedTargets(allowed, requested)
+	assert.False(t, ok)
+}
+
 func TestIssue1492EmptyEditorRootsRemainWithoutEmptyFileTargets(t *testing.T) {
 	root := t.TempDir()
 	for _, dir := range []string{filepath.Join(root, "cursor"), filepath.Join(root, "vscode")} {

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -601,6 +601,27 @@ func TestIssue1492UnreadableCuratedRootFailsResolution(t *testing.T) {
 		assert.ErrorIs(t, err, os.ErrPermission)
 	})
 
+	t.Run("kilo legacy discovery error", func(t *testing.T) {
+		root := t.TempDir()
+		task := filepath.Join(root, "tasks", "task-1")
+		require.NoError(t, os.MkdirAll(task, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(task, "task_metadata.json"), []byte("{}"), 0o644))
+		cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+			parser.AgentKiloLegacy: {root},
+		}}
+		targets := resolveTargetsForTest(t, cfg)
+		require.NotEmpty(t, targets.Files[parser.AgentKiloLegacy])
+
+		tasksDir := filepath.Join(root, "tasks")
+		require.NoError(t, os.Chmod(tasksDir, 0o000))
+		t.Cleanup(func() { require.NoError(t, os.Chmod(tasksDir, 0o755)) })
+		_, err := ResolveTargets(cfg)
+		require.Error(t, err,
+			"an unreadable Kilo Legacy tasks directory must not resolve to an empty target set")
+		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+
 	t.Run("zed root stat error", func(t *testing.T) {
 		parent := t.TempDir()
 		root := filepath.Join(parent, "zed")

--- a/internal/remotesync/issue1492_repro_test.go
+++ b/internal/remotesync/issue1492_repro_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"database/sql"
+	"encoding/json/v2"
 	"io"
 	"os"
 	"path/filepath"
@@ -295,7 +296,7 @@ func TestIssue1492VSCodeWorkspaceMetadataRequiresSelectedChat(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestIssue1492EmptyEditorRootsRemainWithoutEmptyFileTargets(t *testing.T) {
+func TestIssue1492EmptyEditorRootsRetainEmptyFileTargets(t *testing.T) {
 	root := t.TempDir()
 	for _, dir := range []string{filepath.Join(root, "cursor"), filepath.Join(root, "vscode")} {
 		require.NoError(t, os.MkdirAll(dir, 0o755))
@@ -307,8 +308,122 @@ func TestIssue1492EmptyEditorRootsRemainWithoutEmptyFileTargets(t *testing.T) {
 
 	assert.Contains(t, targets.Dirs[parser.AgentCursor], filepath.Join(root, "cursor"))
 	assert.Contains(t, targets.Dirs[parser.AgentVSCodeCopilot], filepath.Join(root, "vscode"))
-	assert.NotContains(t, targets.Files, parser.AgentCursor)
-	assert.NotContains(t, targets.Files, parser.AgentVSCodeCopilot)
+	assert.Empty(t, targets.Files[parser.AgentCursor])
+	assert.Empty(t, targets.Files[parser.AgentVSCodeCopilot])
+	_, cursorMarker := targets.Files[parser.AgentCursor]
+	_, vscodeMarker := targets.Files[parser.AgentVSCodeCopilot]
+	assert.True(t, cursorMarker)
+	assert.True(t, vscodeMarker)
+
+	data, err := json.Marshal(targets)
+	require.NoError(t, err)
+	var roundTrip TargetSet
+	require.NoError(t, json.Unmarshal(data, &roundTrip))
+	_, cursorMarker = roundTrip.Files[parser.AgentCursor]
+	_, vscodeMarker = roundTrip.Files[parser.AgentVSCodeCopilot]
+	assert.True(t, cursorMarker)
+	assert.True(t, vscodeMarker)
+
+	allowedSibling := filepath.Join(root, "allowed")
+	filtered := filterForbiddenTargets(TargetSet{
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentCursor: {allowedSibling, filepath.Join(root, "forbidden")},
+		},
+		Files:          map[parser.AgentType][]string{parser.AgentCursor: {}},
+		ForbiddenRoots: []string{filepath.Join(root, "forbidden")},
+	})
+	_, marker := filtered.Files[parser.AgentCursor]
+	assert.True(t, marker)
+	filtered = filterForbiddenTargets(TargetSet{
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentCursor: {filepath.Join(root, "forbidden")},
+		},
+		Files:          map[parser.AgentType][]string{parser.AgentCursor: {}},
+		ForbiddenRoots: []string{filepath.Join(root, "forbidden")},
+	})
+	_, marker = filtered.Files[parser.AgentCursor]
+	assert.False(t, marker)
+}
+
+func TestArchiveRequestPreservesEmptyFiles(t *testing.T) {
+	request := ArchiveRequest{
+		TargetSet: TargetSet{
+			Dirs:  map[parser.AgentType][]string{parser.AgentCursor: {"/root"}},
+			Files: map[parser.AgentType][]string{parser.AgentCursor: {}},
+		},
+		DeltaFiles: []string{},
+	}
+	data, err := json.Marshal(request)
+	require.NoError(t, err)
+	var decoded ArchiveRequest
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	files, ok := decoded.Files[parser.AgentCursor]
+	require.True(t, ok)
+	assert.Empty(t, files)
+	assert.NotNil(t, decoded.DeltaFiles)
+}
+
+func TestSelectAllowedTargetsRootOnlyCuratedRequestIsEmptyAndNoFilesystemAccess(t *testing.T) {
+	root := t.TempDir()
+	allowed := TargetSet{
+		Dirs:  map[parser.AgentType][]string{parser.AgentCursor: {root}},
+		Files: map[parser.AgentType][]string{parser.AgentCursor: {}},
+	}
+	requested := TargetSet{
+		Dirs:  map[parser.AgentType][]string{parser.AgentCursor: {root}},
+		Files: map[parser.AgentType][]string{parser.AgentCursor: {`/attacker/evil`}},
+	}
+	var touched []string
+	orig := evalSymlinksFn
+	evalSymlinksFn = func(path string) (string, error) {
+		if strings.Contains(path, "attacker") {
+			touched = append(touched, path)
+		}
+		return orig(path)
+	}
+	t.Cleanup(func() { evalSymlinksFn = orig })
+	_, ok := SelectAllowedTargets(allowed, requested)
+	assert.False(t, ok)
+	assert.Empty(t, touched)
+
+	selected, ok := SelectAllowedTargets(allowed, TargetSet{
+		Dirs: map[parser.AgentType][]string{parser.AgentCursor: {root}},
+	})
+	require.True(t, ok)
+	_, marker := selected.Files[parser.AgentCursor]
+	assert.True(t, marker)
+	assert.Empty(t, selected.Files[parser.AgentCursor])
+}
+
+func TestIssue1492EmptyCuratedRootsProduceEmptyArchives(t *testing.T) {
+	root := t.TempDir()
+	cursorRoot := filepath.Join(root, "cursor")
+	vscodeRoot := filepath.Join(root, "vscode")
+	for _, path := range []string{
+		filepath.Join(cursorRoot, "mcp_auth.json"),
+		filepath.Join(vscodeRoot, "User", "settings.json"),
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("credential decoy"), 0o600))
+	}
+	targets := ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentCursor:        {cursorRoot},
+		parser.AgentVSCodeCopilot: {vscodeRoot},
+	}})
+
+	for _, agent := range []parser.AgentType{
+		parser.AgentCursor, parser.AgentVSCodeCopilot,
+	} {
+		files, ok := targets.Files[agent]
+		require.True(t, ok, "%s must retain its file-scope marker", agent)
+		assert.Empty(t, files)
+	}
+	manifest, err := BuildManifest(targets)
+	require.NoError(t, err)
+	assert.Empty(t, manifest.Files)
+	var archive bytes.Buffer
+	require.NoError(t, WriteArchive(&archive, targets))
+	assert.Empty(t, archiveEntries(t, archive.Bytes()))
 }
 
 func TestIssue1492VanishedZedDatabaseRemainsEvictable(t *testing.T) {

--- a/internal/remotesync/manifest.go
+++ b/internal/remotesync/manifest.go
@@ -44,11 +44,11 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 	}
 	m := Manifest{Files: []ManifestEntry{}}
 	forbidden := newForbiddenRootMatcher(targets.ForbiddenRoots)
-	hermesStateDBs := hermesStateDBTargets(targets)
-	hermesSQLite := make(map[string]struct{}, len(hermesStateDBs)*4)
-	for _, stateDB := range hermesStateDBs {
-		for _, path := range hermesSQLitePaths(stateDB) {
-			hermesSQLite[path] = struct{}{}
+	snapshotTargets := sqliteSnapshotTargets(targets)
+	snapshotPaths := make(map[string]struct{}, len(snapshotTargets)*4)
+	for stateDB := range snapshotTargets {
+		for _, path := range sqliteSnapshotPaths(stateDB) {
+			snapshotPaths[path] = struct{}{}
 		}
 	}
 	add := func(path string, info os.FileInfo) {
@@ -82,7 +82,7 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			continue
 		}
 		for _, root := range dirs {
-			if _, ok := hermesSQLite[filepath.Clean(root)]; ok {
+			if _, ok := snapshotPaths[filepath.Clean(root)]; ok {
 				continue
 			}
 			if err := manifestWalk(root, forbidden, add); err != nil {
@@ -95,7 +95,7 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			continue
 		}
 		for _, path := range files {
-			if _, ok := hermesSQLite[filepath.Clean(path)]; ok {
+			if _, ok := snapshotPaths[filepath.Clean(path)]; ok {
 				continue
 			}
 			if err := addLstat(path); err != nil {
@@ -104,14 +104,14 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 		}
 	}
 	for _, path := range targets.AllExtraFiles() {
-		if _, ok := hermesSQLite[filepath.Clean(path)]; ok {
+		if _, ok := snapshotPaths[filepath.Clean(path)]; ok {
 			continue
 		}
 		if err := addLstat(path); err != nil {
 			return Manifest{}, err
 		}
 	}
-	for _, stateDB := range hermesStateDBs {
+	for stateDB := range snapshotTargets {
 		if forbidden.within(stateDB) {
 			continue
 		}

--- a/internal/remotesync/manifest.go
+++ b/internal/remotesync/manifest.go
@@ -78,7 +78,7 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 		if parser.RemoteSyncExcludedAgent(agent) {
 			continue
 		}
-		if _, fileScoped := targets.Files[agent]; fileScoped {
+		if targets.isFileScoped(agent) {
 			continue
 		}
 		for _, root := range dirs {

--- a/internal/remotesync/manifest.go
+++ b/internal/remotesync/manifest.go
@@ -111,14 +111,11 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			return Manifest{}, err
 		}
 	}
-	for stateDB, agent := range snapshotTargets {
+	for stateDB := range snapshotTargets {
 		if forbidden.within(stateDB) {
 			continue
 		}
-		size, modTime, exists, err := sqliteSnapshotIdentityForAgent(stateDB, agent)
-		if err != nil {
-			return Manifest{}, fmt.Errorf("identify sqlite snapshot %q: %w", stateDB, err)
-		}
+		size, modTime, exists := sqliteSnapshotIdentity(stateDB)
 		if exists {
 			m.Files = append(m.Files, ManifestEntry{
 				Path: stateDB, Size: size, MtimeNS: modTime.UnixNano(),

--- a/internal/remotesync/manifest.go
+++ b/internal/remotesync/manifest.go
@@ -111,11 +111,14 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			return Manifest{}, err
 		}
 	}
-	for stateDB := range snapshotTargets {
+	for stateDB, agent := range snapshotTargets {
 		if forbidden.within(stateDB) {
 			continue
 		}
-		size, modTime, exists := hermesSQLiteSnapshotIdentity(stateDB)
+		size, modTime, exists, err := sqliteSnapshotIdentityForAgent(stateDB, agent)
+		if err != nil {
+			return Manifest{}, fmt.Errorf("identify sqlite snapshot %q: %w", stateDB, err)
+		}
 		if exists {
 			m.Files = append(m.Files, ManifestEntry{
 				Path: stateDB, Size: size, MtimeNS: modTime.UnixNano(),

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -476,8 +476,9 @@ func resolveWindsurfTarget(root string) (string, []string) {
 // ui_messages.json siblings are exported.
 func resolveRooCodeTarget(root string) (string, []string, error) {
 	targetRoot := filepath.Clean(root)
-	if info, err := os.Stat(targetRoot); err != nil || !info.IsDir() {
-		return "", nil, nil
+	ok, err := statCuratedDir(targetRoot)
+	if err != nil || !ok {
+		return "", nil, err
 	}
 	provider, ok := parser.NewProvider(parser.AgentRooCode, parser.ProviderConfig{
 		Roots: []string{targetRoot},
@@ -515,8 +516,9 @@ func resolveRooCodeTarget(root string) (string, []string, error) {
 // API credentials, caches, and other unrelated data.
 func resolveKiloLegacyTarget(root string) (string, []string, error) {
 	targetRoot := filepath.Clean(root)
-	if info, err := os.Stat(targetRoot); err != nil || !info.IsDir() {
-		return "", nil, nil
+	ok, err := statCuratedDir(targetRoot)
+	if err != nil || !ok {
+		return "", nil, err
 	}
 	provider, ok := parser.NewProvider(parser.AgentKiloLegacy, parser.ProviderConfig{
 		Roots: []string{targetRoot},
@@ -566,6 +568,20 @@ func curatedRoot(root string) (bool, error) {
 		return false, fmt.Errorf("stat remote sync root %q: %w", root, err)
 	}
 	return info.IsDir() && info.Mode()&os.ModeSymlink == 0, nil
+}
+
+// statCuratedDir is curatedRoot for resolvers that historically follow
+// symlinked roots (RooCode, Kilo Legacy): same error contract, but the
+// symlink target's type decides.
+func statCuratedDir(root string) (bool, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat remote sync root %q: %w", root, err)
+	}
+	return info.IsDir(), nil
 }
 
 func regularCuratedFile(root, path string) bool {
@@ -706,7 +722,11 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 		allowedDirs := allowed.Dirs[agent]
 		fileScoped := allowed.isFileScoped(agent)
 		if fileScoped {
-			if _, hasRequestedFiles := requested.Files[agent]; !hasRequestedFiles {
+			// A request that names the directory without any curated
+			// files would select an empty manifest and evict the
+			// client's mirror even while sessions exist. Accept it
+			// only when the fresh curated scope is itself empty.
+			if requestedFiles, ok := requested.Files[agent]; !ok || len(requestedFiles) == 0 {
 				emptyScope := emptyFileScopeAgent(agent) &&
 					len(allowed.Files[agent]) == 0
 				if !emptyScope {

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -92,7 +92,10 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				root, targetFiles := resolveEditorTarget(def.Type, dir)
 				if root != "" {
 					dirs[def.Type] = append(dirs[def.Type], root)
-					files[def.Type] = append([]string{}, targetFiles...)
+					if _, exists := files[def.Type]; !exists {
+						files[def.Type] = []string{}
+					}
+					files[def.Type] = append(files[def.Type], targetFiles...)
 				}
 				continue
 			}
@@ -198,10 +201,6 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 		return t
 	}
 	forbidden := newForbiddenRootMatcher(t.ForbiddenRoots)
-	fileScoped := make(map[parser.AgentType]bool, len(t.Files))
-	for agent := range t.Files {
-		fileScoped[agent] = true
-	}
 	for agent, dirs := range t.Dirs {
 		kept := withoutForbidden(dirs, forbidden)
 		if len(kept) == 0 {
@@ -225,10 +224,11 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 	// A file-scoped agent's root is only safe to advertise alongside its
 	// curated file list; if filtering removed either half, drop both so the
 	// agent cannot degrade to a raw directory target.
-	for agent := range fileScoped {
-		_, hasDirs := t.Dirs[agent]
-		_, hasFiles := t.Files[agent]
-		if hasDirs != hasFiles {
+	for agent := range t.Files {
+		if !t.isFileScoped(agent) {
+			continue
+		}
+		if _, hasDirs := t.Dirs[agent]; !hasDirs {
 			delete(t.Dirs, agent)
 			delete(t.Files, agent)
 		}
@@ -667,7 +667,9 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 			selectedFile, ok := selectAllowedString(allowedFiles, file)
 			include := true
 			if !ok {
-				selectedFile, include, ok = classifyCuratedFile(allowed, agent, file, files)
+				selectedFile, include, ok = classifyCuratedFile(
+					allowed, forbidden, agent, file, files,
+				)
 				if !ok {
 					return TargetSet{}, false
 				}
@@ -774,7 +776,7 @@ func kiloLegacySessionFileShape(rel string) bool {
 // (settings/mcp_settings.json, checkpoints, caches) unreachable, and
 // the symlink walk rejects components that would escape the root.
 func classifyCuratedFile(
-	allowed TargetSet, agent parser.AgentType, file string,
+	allowed TargetSet, forbidden forbiddenRootMatcher, agent parser.AgentType, file string,
 	candidateFiles ...[]string,
 ) (string, bool, bool) {
 	if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
@@ -787,6 +789,9 @@ func classifyCuratedFile(
 		return "", false, false
 	}
 	for _, dir := range allowed.Dirs[agent] {
+		if forbidden.within(dir) {
+			continue
+		}
 		if remotePathDialect(file) != remotePathDialect(dir) {
 			continue
 		}
@@ -804,6 +809,9 @@ func classifyCuratedFile(
 			continue
 		}
 		if symlinkEscapesRoot(dir, file) {
+			return "", false, false
+		}
+		if forbidden.within(file) {
 			return "", false, false
 		}
 		info, err := os.Lstat(file)
@@ -1022,7 +1030,9 @@ func selectAllowedFile(
 		if canonical, ok := selectAllowedString(files, file); ok {
 			return canonical, true, !forbidden.within(canonical)
 		}
-		canonical, include, ok := classifyCuratedFile(allowed, agent, file, files)
+		canonical, include, ok := classifyCuratedFile(
+			allowed, forbidden, agent, file, files,
+		)
 		if ok {
 			return canonical, include, !forbidden.within(file)
 		}
@@ -1039,7 +1049,7 @@ func selectAllowedFile(
 			continue
 		}
 		canonical, include, ok := classifyCuratedFile(
-			allowed, agent, file, candidateFiles,
+			allowed, forbidden, agent, file, candidateFiles,
 		)
 		if ok {
 			return canonical, include, !forbidden.within(file)

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -665,12 +665,17 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 		}
 	}
 	for agent, files := range requested.Files {
-		allowedFiles, ok := allowed.Files[agent]
-		if !ok {
-			return TargetSet{}, false
-		}
+		allowedFiles, hasAllowedFiles := allowed.Files[agent]
 		for _, file := range files {
 			selectedFile, ok := selectAllowedString(allowedFiles, file)
+			if !ok && (!hasAllowedFiles || len(allowedFiles) == 0) {
+				ok = verbatimSessionFileUnderAllowedRoot(
+					allowed, agent, file, files,
+				)
+				if ok {
+					selectedFile = file
+				}
+			}
 			if !ok {
 				// Targets are re-resolved for every request, so a
 				// session file deleted between the client's target
@@ -679,7 +684,7 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 				// the sync over a routine deletion race; the archive
 				// writers tolerate missing files, so authorize
 				// session-shaped paths under a still-allowed root.
-				if !verbatimSessionFileUnderAllowedRoot(allowed, agent, file) {
+				if !verbatimSessionFileUnderAllowedRoot(allowed, agent, file, files) {
 					return TargetSet{}, false
 				}
 				selectedFile = file
@@ -784,6 +789,7 @@ func kiloLegacySessionFileShape(rel string) bool {
 // the symlink walk rejects components that would escape the root.
 func verbatimSessionFileUnderAllowedRoot(
 	allowed TargetSet, agent parser.AgentType, file string,
+	candidateFiles ...[]string,
 ) bool {
 	if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 		return false
@@ -803,7 +809,9 @@ func verbatimSessionFileUnderAllowedRoot(
 			continue
 		}
 		if agent == parser.AgentVSCodeCopilot && isVSCodeWorkspaceMetadata(rel) {
-			if !vscodeWorkspaceMetadataTiedToAllowedSession(allowed, dir, file) {
+			if !vscodeWorkspaceMetadataTiedToAllowedSession(
+				allowed, dir, file, candidateFiles...,
+			) {
 				continue
 			}
 		} else if !sessionFileShape(agent, rel) {
@@ -847,7 +855,7 @@ func sessionFileShape(agent parser.AgentType, rel string) bool {
 }
 
 func vscodeWorkspaceMetadataTiedToAllowedSession(
-	allowed TargetSet, root, file string,
+	allowed TargetSet, root, file string, candidateFiles ...[]string,
 ) bool {
 	rel, ok := remoteArchiveRel(root, file)
 	if !ok {
@@ -857,7 +865,11 @@ func vscodeWorkspaceMetadataTiedToAllowedSession(
 	if !isVSCodeWorkspaceMetadata(rel) {
 		return false
 	}
-	for _, selected := range allowed.Files[parser.AgentVSCodeCopilot] {
+	selectedFiles := allowed.Files[parser.AgentVSCodeCopilot]
+	for _, files := range candidateFiles {
+		selectedFiles = append(selectedFiles, files...)
+	}
+	for _, selected := range selectedFiles {
 		selectedRel, ok := remoteArchiveRel(root, selected)
 		if !ok {
 			continue
@@ -912,7 +924,7 @@ func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
 	forbidden := newForbiddenRootMatcher(allowed.ForbiddenRoots)
 	selected := make([]string, 0, len(files))
 	for _, file := range files {
-		canonical, ok := selectAllowedFile(allowed, forbidden, file)
+		canonical, ok := selectAllowedFile(allowed, forbidden, file, files)
 		if !ok {
 			return nil, false
 		}
@@ -930,6 +942,7 @@ func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
 // under a trusted allowed root before the matcher sees it.
 func selectAllowedFile(
 	allowed TargetSet, forbidden forbiddenRootMatcher, file string,
+	candidateFiles []string,
 ) (string, bool) {
 	if canonical, ok := selectAllowedString(allowed.AllExtraFiles(), file); ok {
 		return canonical, !forbidden.within(canonical)
@@ -948,7 +961,24 @@ func selectAllowedFile(
 		if canonical, ok := selectAllowedString(files, file); ok {
 			return canonical, !forbidden.within(canonical)
 		}
-		if verbatimSessionFileUnderAllowedRoot(allowed, agent, file) {
+		if verbatimSessionFileUnderAllowedRoot(allowed, agent, file, files) {
+			return file, !forbidden.within(file)
+		}
+	}
+	// A fresh editor resolution can retain the authorized root while all
+	// curated leaves have vanished. The request still carries the prior
+	// exact file set, so validate its strict shape against that root before
+	// considering any directory-scoped agents.
+	for _, agent := range []parser.AgentType{
+		parser.AgentCursor, parser.AgentVSCodeCopilot, parser.AgentZed,
+		parser.AgentRooCode, parser.AgentKiloLegacy,
+	} {
+		if _, ok := allowed.Dirs[agent]; !ok {
+			continue
+		}
+		if verbatimSessionFileUnderAllowedRoot(
+			allowed, agent, file, candidateFiles,
+		) {
 			return file, !forbidden.within(file)
 		}
 	}
@@ -959,7 +989,8 @@ func selectAllowedFile(
 		return "", false
 	}
 	for agent, dirs := range allowed.Dirs {
-		if _, fileScoped := allowed.Files[agent]; fileScoped {
+		if _, fileScoped := allowed.Files[agent]; fileScoped ||
+			verbatimFileScopedAgent(agent) || snapshotFileScopedAgent(agent) {
 			// File-scoped agents export a curated file list, not a raw
 			// directory walk. Accepting a delta request by directory
 			// prefix would stream a raw file (an unsanitized

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -775,7 +775,7 @@ func kiloLegacySessionFileShape(rel string) bool {
 	return false
 }
 
-// verbatimSessionFileUnderAllowedRoot authorizes a session-shaped file
+// verbatimSessionFileUnderAllowedRoot authorizes a curated file
 // under a verbatim file-scoped agent's still-allowed root when the
 // file itself is absent from the fresh per-request resolution — the
 // deletion race between a client's target fetch and its next request.
@@ -824,6 +824,10 @@ func sessionFileShape(agent parser.AgentType, rel string) bool {
 		return ok
 	case parser.AgentVSCodeCopilot:
 		parts := strings.Split(rel, "/")
+		if len(parts) == 3 && parts[0] == "workspaceStorage" &&
+			parts[1] != "" && parts[2] == "workspace.json" {
+			return true
+		}
 		if len(parts) == 4 && parts[0] == "workspaceStorage" &&
 			parts[2] == "chatSessions" {
 			return parser.IsValidSessionID(strings.TrimSuffix(parts[3], filepath.Ext(parts[3]))) &&

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -492,26 +492,6 @@ func resolveKiloLegacyTarget(root string) (string, []string) {
 	return targetRoot, files
 }
 
-func resolveProviderFiles(agent parser.AgentType, root string, keep func(string) bool) (string, []string) {
-	provider, ok := parser.NewProvider(agent, parser.ProviderConfig{Roots: []string{root}})
-	if !ok {
-		return "", nil
-	}
-	sources, err := provider.Discover(context.Background())
-	if err != nil {
-		return "", nil
-	}
-	var files []string
-	for _, source := range sources {
-		path := providerDiscoveredPath(source)
-		if keep(path) && regularCuratedFile(root, path) {
-			files = append(files, filepath.Clean(path))
-		}
-	}
-	slices.Sort(files)
-	return root, slices.Compact(files)
-}
-
 func curatedRoot(root string) bool {
 	info, err := os.Lstat(root)
 	return err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -2,6 +2,7 @@ package remotesync
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -12,7 +13,15 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 )
 
-func ResolveTargets(cfg config.Config) TargetSet {
+// ResolveTargets resolves the advertised target set for every
+// configured agent. A resolution error (an unreadable root, a failed
+// provider discovery) fails the whole resolution rather than silently
+// narrowing the target set: an agent that vanishes from the response
+// looks identical to an uninstalled agent, so the client would evict
+// its entire mirror subtree and re-transfer everything once the error
+// clears. Failing closed matches how manifest walks already treat
+// read errors under dir-scoped roots.
+func ResolveTargets(cfg config.Config) (TargetSet, error) {
 	dirs := make(map[parser.AgentType][]string)
 	files := make(map[parser.AgentType][]string)
 	providerExtraFiles := make(map[parser.AgentType][]string)
@@ -50,7 +59,10 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				continue
 			}
 			if def.Type == parser.AgentAider {
-				targets := resolveAiderTargets(dir)
+				targets, err := resolveAiderTargets(dir)
+				if err != nil {
+					return TargetSet{}, err
+				}
 				if len(targets) > 0 {
 					dirs[def.Type] = append(dirs[def.Type], targets...)
 				}
@@ -65,7 +77,10 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				continue
 			}
 			if def.Type == parser.AgentRooCode {
-				root, targetFiles := resolveRooCodeTarget(dir)
+				root, targetFiles, err := resolveRooCodeTarget(dir)
+				if err != nil {
+					return TargetSet{}, err
+				}
 				if root != "" && len(targetFiles) > 0 {
 					dirs[def.Type] = append(dirs[def.Type], root)
 					files[def.Type] = append(files[def.Type], targetFiles...)
@@ -73,7 +88,10 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				continue
 			}
 			if def.Type == parser.AgentKiloLegacy {
-				root, targetFiles := resolveKiloLegacyTarget(dir)
+				root, targetFiles, err := resolveKiloLegacyTarget(dir)
+				if err != nil {
+					return TargetSet{}, err
+				}
 				if root != "" && len(targetFiles) > 0 {
 					dirs[def.Type] = append(dirs[def.Type], root)
 					files[def.Type] = append(files[def.Type], targetFiles...)
@@ -87,9 +105,11 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				}
 				continue
 			}
-			if def.Type == parser.AgentCursor ||
-				def.Type == parser.AgentVSCodeCopilot {
-				root, targetFiles := resolveEditorTarget(def.Type, dir)
+			if emptyFileScopeAgent(def.Type) {
+				root, targetFiles, err := resolveEditorTarget(def.Type, dir)
+				if err != nil {
+					return TargetSet{}, err
+				}
 				if root != "" {
 					dirs[def.Type] = append(dirs[def.Type], root)
 					if _, exists := files[def.Type]; !exists {
@@ -100,7 +120,10 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				continue
 			}
 			if def.Type == parser.AgentZed {
-				root, targetFiles := resolveZedTarget(dir)
+				root, targetFiles, err := resolveZedTarget(dir)
+				if err != nil {
+					return TargetSet{}, err
+				}
 				if root != "" {
 					dirs[def.Type] = append(dirs[def.Type], root)
 					files[def.Type] = append(files[def.Type], targetFiles...)
@@ -126,24 +149,26 @@ func ResolveTargets(cfg config.Config) TargetSet {
 	return filterForbiddenTargets(TargetSet{
 		Dirs: dirs, Files: files, ProviderExtraFiles: providerExtraFiles,
 		ForbiddenRoots: forbiddenRoots,
-	})
+	}), nil
 }
 
 // resolveEditorTarget asks the parser for the exact session files it would
 // consume, then adds only the workspace manifest needed to preserve project
 // attribution. The configured editor root remains the authorization boundary.
-func resolveEditorTarget(agent parser.AgentType, root string) (string, []string) {
+func resolveEditorTarget(agent parser.AgentType, root string) (string, []string, error) {
 	root = filepath.Clean(root)
-	if !curatedRoot(root) {
-		return "", nil
+	ok, err := curatedRoot(root)
+	if err != nil || !ok {
+		return "", nil, err
 	}
 	provider, ok := parser.NewProvider(agent, parser.ProviderConfig{Roots: []string{root}})
 	if !ok {
-		return "", nil
+		return "", nil, nil
 	}
-	sources, err := provider.Discover(context.Background())
+	sources, err := discoverProviderSources(provider)
 	if err != nil {
-		return "", nil
+		return "", nil, fmt.Errorf("discover %s remote sync targets under %q: %w",
+			agent, root, err)
 	}
 	seen := make(map[string]struct{})
 	var files []string
@@ -177,7 +202,28 @@ func resolveEditorTarget(agent parser.AgentType, root string) (string, []string)
 		}
 	}
 	sort.Strings(files)
-	return root, files
+	return root, files, nil
+}
+
+// discoverProviderSources prefers the streaming discovery path the
+// sync engine uses. Unlike some batch Discover implementations, which
+// convert traversal failures into an authoritative empty enumeration,
+// DiscoverEach propagates them, so an unreadable root cannot resolve
+// to an empty curated target and evict the client's mirror.
+func discoverProviderSources(provider parser.Provider) ([]parser.SourceRef, error) {
+	streamer, ok := provider.(parser.StreamingDiscoverer)
+	if !ok {
+		return provider.Discover(context.Background())
+	}
+	var sources []parser.SourceRef
+	err := streamer.DiscoverEach(context.Background(), func(source parser.SourceRef) error {
+		sources = append(sources, source)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return sources, nil
 }
 
 func isLocalRemoteSyncSource(
@@ -216,8 +262,7 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 	for agent, files := range t.Files {
 		kept := withoutForbidden(files, forbidden)
 		if len(kept) == 0 {
-			if _, hasDirs := t.Dirs[agent]; hasDirs &&
-				(agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot) {
+			if _, hasDirs := t.Dirs[agent]; hasDirs && emptyFileScopeAgent(agent) {
 				t.Files[agent] = []string{}
 			} else {
 				delete(t.Files, agent)
@@ -381,19 +426,23 @@ func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
 	}
 }
 
-func resolveAiderTargets(root string) []string {
+func resolveAiderTargets(root string) ([]string, error) {
 	if isAiderUnsafeRoot(root) {
-		return nil
+		return nil, nil
 	}
 	provider, ok := parser.NewProvider(parser.AgentAider, parser.ProviderConfig{
 		Roots: []string{root},
 	})
 	if !ok {
-		return nil
+		return nil, nil
 	}
+	// Aider stays on batch Discover: its streaming enumeration yields
+	// different source references than the batch path this resolver's
+	// history-file filter matches.
 	sources, err := provider.Discover(context.Background())
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("discover aider remote sync targets under %q: %w",
+			root, err)
 	}
 	out := make([]string, 0, len(sources))
 	for _, source := range sources {
@@ -402,7 +451,7 @@ func resolveAiderTargets(root string) []string {
 			out = append(out, path)
 		}
 	}
-	return out
+	return out, nil
 }
 
 func resolveWindsurfTarget(root string) (string, []string) {
@@ -425,20 +474,21 @@ func resolveWindsurfTarget(root string) (string, []string) {
 // caches, and checkpoints — none of which may be archived. Only the
 // discovered tasks/<id>/history_item.json files and their
 // ui_messages.json siblings are exported.
-func resolveRooCodeTarget(root string) (string, []string) {
+func resolveRooCodeTarget(root string) (string, []string, error) {
 	targetRoot := filepath.Clean(root)
 	if info, err := os.Stat(targetRoot); err != nil || !info.IsDir() {
-		return "", nil
+		return "", nil, nil
 	}
 	provider, ok := parser.NewProvider(parser.AgentRooCode, parser.ProviderConfig{
 		Roots: []string{targetRoot},
 	})
 	if !ok {
-		return "", nil
+		return "", nil, nil
 	}
-	sources, err := provider.Discover(context.Background())
+	sources, err := discoverProviderSources(provider)
 	if err != nil {
-		return "", nil
+		return "", nil, fmt.Errorf("discover roocode remote sync targets under %q: %w",
+			targetRoot, err)
 	}
 	var files []string
 	for _, source := range sources {
@@ -453,9 +503,9 @@ func resolveRooCodeTarget(root string) (string, []string) {
 		}
 	}
 	if len(files) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
-	return targetRoot, files
+	return targetRoot, files, nil
 }
 
 // resolveKiloLegacyTarget resolves a Kilo Legacy globalStorage root to
@@ -463,20 +513,21 @@ func resolveRooCodeTarget(root string) (string, []string) {
 // api_conversation_history.json). This avoids recursively transferring
 // the entire globalStorage directory, which can contain MCP settings,
 // API credentials, caches, and other unrelated data.
-func resolveKiloLegacyTarget(root string) (string, []string) {
+func resolveKiloLegacyTarget(root string) (string, []string, error) {
 	targetRoot := filepath.Clean(root)
 	if info, err := os.Stat(targetRoot); err != nil || !info.IsDir() {
-		return "", nil
+		return "", nil, nil
 	}
 	provider, ok := parser.NewProvider(parser.AgentKiloLegacy, parser.ProviderConfig{
 		Roots: []string{targetRoot},
 	})
 	if !ok {
-		return "", nil
+		return "", nil, nil
 	}
-	sources, err := provider.Discover(context.Background())
+	sources, err := discoverProviderSources(provider)
 	if err != nil {
-		return "", nil
+		return "", nil, fmt.Errorf("discover kilo legacy remote sync targets under %q: %w",
+			targetRoot, err)
 	}
 	var files []string
 	for _, source := range sources {
@@ -497,17 +548,24 @@ func resolveKiloLegacyTarget(root string) (string, []string) {
 		}
 	}
 	if len(files) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
-	return targetRoot, files
+	return targetRoot, files, nil
 }
 
-func curatedRoot(root string) bool {
+// curatedRoot reports whether root is a plain directory that may
+// anchor a curated target. A missing or non-directory root is a
+// legitimately absent target; any other stat failure propagates so an
+// unreadable root cannot masquerade as an uninstalled agent.
+func curatedRoot(root string) (bool, error) {
 	info, err := os.Lstat(root)
-	if err != nil || info == nil {
-		return false
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat remote sync root %q: %w", root, err)
 	}
-	return info.IsDir() && info.Mode()&os.ModeSymlink == 0
+	return info.IsDir() && info.Mode()&os.ModeSymlink == 0, nil
 }
 
 func regularCuratedFile(root, path string) bool {
@@ -519,34 +577,37 @@ func regularCuratedFile(root, path string) bool {
 	return regularRemoteSyncFile(path)
 }
 
-func resolveZedTarget(root string) (string, []string) {
+func resolveZedTarget(root string) (string, []string, error) {
 	root = filepath.Clean(root)
-	if !curatedRoot(root) {
-		return "", nil
+	ok, err := curatedRoot(root)
+	if err != nil || !ok {
+		return "", nil, err
 	}
 	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)
-	if !curatedFileOrMissing(root, dbPath) {
-		return "", nil
+	ok, err = curatedFileOrMissing(root, dbPath)
+	if err != nil || !ok {
+		return "", nil, err
 	}
-	return root, []string{dbPath}
+	return root, []string{dbPath}, nil
 }
 
 // curatedFileOrMissing retains a selected leaf through a deletion race so the
-// manifest can omit it and the mirror can evict its stale copy.
-func curatedFileOrMissing(root, path string) bool {
+// manifest can omit it and the mirror can evict its stale copy. A stat
+// failure other than absence propagates like curatedRoot's.
+func curatedFileOrMissing(root, path string) (bool, error) {
 	path = filepath.Clean(path)
 	rel, err := filepath.Rel(root, path)
 	if err != nil || !filepath.IsLocal(rel) || symlinkEscapesRoot(root, path) {
-		return false
+		return false, nil
 	}
 	info, err := os.Lstat(path)
 	if os.IsNotExist(err) {
-		return true
+		return true, nil
 	}
-	if err != nil || info == nil {
-		return false
+	if err != nil {
+		return false, fmt.Errorf("stat remote sync target %q: %w", path, err)
 	}
-	return info.Mode().IsRegular()
+	return info.Mode().IsRegular(), nil
 }
 
 // resolvePoolsideTarget narrows a Poolside application-data root to
@@ -646,10 +707,9 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 		fileScoped := allowed.isFileScoped(agent)
 		if fileScoped {
 			if _, hasRequestedFiles := requested.Files[agent]; !hasRequestedFiles {
-				emptyEditorScope :=
-					(agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot) &&
-						len(allowed.Files[agent]) == 0
-				if !emptyEditorScope {
+				emptyScope := emptyFileScopeAgent(agent) &&
+					len(allowed.Files[agent]) == 0
+				if !emptyScope {
 					return TargetSet{}, false
 				}
 			}
@@ -677,16 +737,13 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 		allowedFiles := allowed.Files[agent]
 		for _, file := range files {
 			selectedFile, ok := selectAllowedString(allowedFiles, file)
-			include := true
 			if !ok {
-				include, ok = classifyCuratedFile(
-					allowed, forbidden, agent, file, files,
-				)
-				if !ok {
+				if !authorizedStaleCuratedFile(allowed, forbidden, agent, file, files) {
 					return TargetSet{}, false
 				}
-			}
-			if !include {
+				// A stale curated reference is authorized but omitted, so
+				// the manifest built from the selection agrees the file is
+				// gone and the client mirror evicts its copy.
 				continue
 			}
 			if selected.Files == nil {
@@ -780,25 +837,28 @@ func kiloLegacySessionFileShape(rel string) bool {
 	return false
 }
 
-// classifyCuratedFile validates a stale curated file request
-// under a verbatim file-scoped agent's still-allowed root when the
-// file itself is absent from the fresh per-request resolution — the
-// deletion race between a client's target fetch and its next request.
-// The strict shape keeps everything else under the root
-// (settings/mcp_settings.json, checkpoints, caches) unreachable, and
-// the symlink walk rejects components that would escape the root.
-func classifyCuratedFile(
-	allowed TargetSet, forbidden forbiddenRootMatcher, agent parser.AgentType, file string,
-	candidateFiles ...[]string,
-) (bool, bool) {
+// authorizedStaleCuratedFile reports whether a curated file request
+// that missed the fresh per-request resolution is still authorized
+// under a verbatim or snapshot file-scoped agent's allowed root — the
+// deletion race between a client's target fetch and its next request,
+// or a discovery preference flip (Cursor and VS Code prefer one
+// transcript extension over its sibling). An authorized stale file is
+// always omitted from the selection, never streamed: the strict shape
+// keeps everything else under the root (settings/mcp_settings.json,
+// checkpoints, caches) unreachable, and the symlink walk rejects
+// components that would escape the root.
+func authorizedStaleCuratedFile(
+	allowed TargetSet, forbidden forbiddenRootMatcher, agent parser.AgentType,
+	file string, requestedFiles []string,
+) bool {
 	if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
-		return false, false
+		return false
 	}
 	if !isAbsRemotePath(file) {
-		return false, false
+		return false
 	}
 	if _, err := safeRemotePathArchiveName(file); err != nil {
-		return false, false
+		return false
 	}
 	for _, dir := range allowed.Dirs[agent] {
 		if forbidden.within(dir) {
@@ -813,7 +873,7 @@ func classifyCuratedFile(
 		}
 		if agent == parser.AgentVSCodeCopilot && isVSCodeWorkspaceMetadata(rel) {
 			if !vscodeWorkspaceMetadataTiedToAllowedSession(
-				allowed, dir, file, candidateFiles...,
+				allowed, dir, file, requestedFiles,
 			) {
 				continue
 			}
@@ -821,28 +881,25 @@ func classifyCuratedFile(
 			continue
 		}
 		if symlinkEscapesRoot(dir, file) {
-			return false, false
+			return false
 		}
 		if forbidden.within(file) {
-			return false, false
+			return false
 		}
 		info, err := os.Lstat(file)
 		if os.IsNotExist(err) {
-			return false, true
+			return true
 		}
 		if err != nil || !info.Mode().IsRegular() {
-			return false, false
+			return false
 		}
 		if agent == parser.AgentVSCodeCopilot && isVSCodeWorkspaceMetadata(rel) &&
-			vscodeWorkspaceChatVanished(allowed, forbidden, dir, rel, candidateFiles...) {
-			return false, true
+			vscodeWorkspaceChatVanished(allowed, forbidden, dir, rel, requestedFiles) {
+			return true
 		}
-		if hasPreferredCuratedSibling(dir, allowed.Files[agent], rel) {
-			return false, true
-		}
-		return false, false
+		return hasPreferredCuratedSibling(dir, allowed.Files[agent], rel)
 	}
-	return false, false
+	return false
 }
 
 func hasPreferredCuratedSibling(root string, allowedFiles []string, rel string) bool {
@@ -868,39 +925,37 @@ func hasPreferredCuratedSibling(root string, allowedFiles []string, rel string) 
 
 func vscodeWorkspaceChatVanished(
 	allowed TargetSet, forbidden forbiddenRootMatcher, root, rel string,
-	candidateFiles ...[]string,
+	requestedFiles []string,
 ) bool {
 	parts := strings.Split(rel, "/")
-	for _, files := range candidateFiles {
-		for _, file := range files {
-			chatRel, ok := remoteArchiveRel(root, file)
-			if !ok {
-				continue
-			}
-			chatParts := strings.Split(chatRel, "/")
-			if len(chatParts) != 4 || chatParts[0] != "workspaceStorage" ||
-				chatParts[1] != parts[1] || chatParts[2] != "chatSessions" ||
-				!vscodeChatSessionFileShape(chatParts[3]) {
-				continue
-			}
-			if !isAbsRemotePath(file) || remotePathDialect(file) != remotePathDialect(root) {
-				continue
-			}
-			if _, err := safeRemotePathArchiveName(file); err != nil ||
-				symlinkEscapesRoot(root, file) || forbidden.within(file) {
-				continue
-			}
-			if _, err := os.Lstat(file); !os.IsNotExist(err) {
-				continue
-			}
-			for _, allowedFile := range allowed.Files[parser.AgentVSCodeCopilot] {
-				allowedRel, ok := remoteArchiveRel(root, allowedFile)
-				if ok && strings.HasPrefix(allowedRel, "workspaceStorage/"+parts[1]+"/chatSessions/") {
-					return false
-				}
-			}
-			return true
+	for _, file := range requestedFiles {
+		chatRel, ok := remoteArchiveRel(root, file)
+		if !ok {
+			continue
 		}
+		chatParts := strings.Split(chatRel, "/")
+		if len(chatParts) != 4 || chatParts[0] != "workspaceStorage" ||
+			chatParts[1] != parts[1] || chatParts[2] != "chatSessions" ||
+			!vscodeChatSessionFileShape(chatParts[3]) {
+			continue
+		}
+		if !isAbsRemotePath(file) || remotePathDialect(file) != remotePathDialect(root) {
+			continue
+		}
+		if _, err := safeRemotePathArchiveName(file); err != nil ||
+			symlinkEscapesRoot(root, file) || forbidden.within(file) {
+			continue
+		}
+		if _, err := os.Lstat(file); !os.IsNotExist(err) {
+			continue
+		}
+		for _, allowedFile := range allowed.Files[parser.AgentVSCodeCopilot] {
+			allowedRel, ok := remoteArchiveRel(root, allowedFile)
+			if ok && strings.HasPrefix(allowedRel, "workspaceStorage/"+parts[1]+"/chatSessions/") {
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }
@@ -935,7 +990,7 @@ func sessionFileShape(agent parser.AgentType, rel string) bool {
 }
 
 func vscodeWorkspaceMetadataTiedToAllowedSession(
-	allowed TargetSet, root, file string, candidateFiles ...[]string,
+	allowed TargetSet, root, file string, requestedFiles []string,
 ) bool {
 	rel, ok := remoteArchiveRel(root, file)
 	if !ok {
@@ -945,10 +1000,9 @@ func vscodeWorkspaceMetadataTiedToAllowedSession(
 	if !isVSCodeWorkspaceMetadata(rel) {
 		return false
 	}
-	selectedFiles := allowed.Files[parser.AgentVSCodeCopilot]
-	for _, files := range candidateFiles {
-		selectedFiles = append(selectedFiles, files...)
-	}
+	selectedFiles := slices.Concat(
+		allowed.Files[parser.AgentVSCodeCopilot], requestedFiles,
+	)
 	for _, selected := range selectedFiles {
 		selectedRel, ok := remoteArchiveRel(root, selected)
 		if !ok {
@@ -1004,11 +1058,11 @@ func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
 	forbidden := newForbiddenRootMatcher(allowed.ForbiddenRoots)
 	selected := make([]string, 0, len(files))
 	for _, file := range files {
-		canonical, include, ok := selectAllowedFile(allowed, forbidden, file, files)
+		canonical, ok := selectAllowedFile(allowed, forbidden, file, files)
 		if !ok {
 			return nil, false
 		}
-		if include {
+		if canonical != "" {
 			selected = append(selected, canonical)
 		}
 	}
@@ -1021,13 +1075,15 @@ func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
 // on an unmatched client-supplied path: on Windows a raw request naming
 // \\attacker\share would otherwise force an outbound SMB connection.
 // Every accept path below is either a server-derived string or anchored
-// under a trusted allowed root before the matcher sees it.
+// under a trusted allowed root before the matcher sees it. An empty
+// canonical result with ok=true means the request is authorized but the
+// file is omitted from the delta (a stale curated reference).
 func selectAllowedFile(
 	allowed TargetSet, forbidden forbiddenRootMatcher, file string,
-	candidateFiles []string,
-) (string, bool, bool) {
+	requestedFiles []string,
+) (string, bool) {
 	if canonical, ok := selectAllowedString(allowed.AllExtraFiles(), file); ok {
-		return canonical, true, !forbidden.within(canonical)
+		return canonical, !forbidden.within(canonical)
 	}
 	for agent, files := range allowed.Files {
 		if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
@@ -1037,24 +1093,20 @@ func selectAllowedFile(
 		// their curated files; the exact-match requirement keeps
 		// settings and caches under their directory unreachable. A
 		// session-shaped file missing from the fresh resolution is
-		// still authorized (deletion race); WriteArchiveFiles then
-		// skips it because its delta roots come from the same fresh
-		// resolution.
+		// still authorized (deletion race) but omitted, so the delta
+		// archive and manifest agree that the file no longer exists.
 		if canonical, ok := selectAllowedString(files, file); ok {
-			return canonical, true, !forbidden.within(canonical)
+			return canonical, !forbidden.within(canonical)
 		}
-		include, ok := classifyCuratedFile(
-			allowed, forbidden, agent, file, files,
-		)
-		if ok {
-			return file, include, !forbidden.within(file)
+		if authorizedStaleCuratedFile(allowed, forbidden, agent, file, requestedFiles) {
+			return "", true
 		}
 	}
 	if !isAbsRemotePath(file) {
-		return "", false, false
+		return "", false
 	}
 	if _, err := safeRemotePathArchiveName(file); err != nil {
-		return "", false, false
+		return "", false
 	}
 	for agent, dirs := range allowed.Dirs {
 		if allowed.isFileScoped(agent) ||
@@ -1080,7 +1132,7 @@ func selectAllowedFile(
 			}
 			if _, ok := remoteArchiveRel(dir, file); ok {
 				if symlinkEscapesRoot(dir, file) {
-					return "", false, false
+					return "", false
 				}
 				// Exact root matches are allowed: file roots (Aider
 				// history files) must stream, and a directory root
@@ -1088,11 +1140,11 @@ func selectAllowedFile(
 				// non-regular entries. The file is anchored under the
 				// trusted dir at this point, so the forbidden check may
 				// canonicalize it.
-				return file, true, !forbidden.within(file)
+				return file, !forbidden.within(file)
 			}
 		}
 	}
-	return "", false, false
+	return "", false
 }
 
 type pathDialect int

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -201,6 +201,10 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 		return t
 	}
 	forbidden := newForbiddenRootMatcher(t.ForbiddenRoots)
+	fileScopedAgents := make(map[parser.AgentType]struct{}, len(t.Files))
+	for agent := range t.Files {
+		fileScopedAgents[agent] = struct{}{}
+	}
 	for agent, dirs := range t.Dirs {
 		kept := withoutForbidden(dirs, forbidden)
 		if len(kept) == 0 {
@@ -212,7 +216,8 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 	for agent, files := range t.Files {
 		kept := withoutForbidden(files, forbidden)
 		if len(kept) == 0 {
-			if _, hasDirs := t.Dirs[agent]; hasDirs {
+			if _, hasDirs := t.Dirs[agent]; hasDirs &&
+				(agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot) {
 				t.Files[agent] = []string{}
 			} else {
 				delete(t.Files, agent)
@@ -224,8 +229,11 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 	// A file-scoped agent's root is only safe to advertise alongside its
 	// curated file list; if filtering removed either half, drop both so the
 	// agent cannot degrade to a raw directory target.
-	for agent := range t.Files {
-		if !t.isFileScoped(agent) {
+	for agent := range fileScopedAgents {
+		_, hasFiles := t.Files[agent]
+		if !hasFiles || !t.isFileScoped(agent) {
+			delete(t.Dirs, agent)
+			delete(t.Files, agent)
 			continue
 		}
 		if _, hasDirs := t.Dirs[agent]; !hasDirs {
@@ -667,7 +675,7 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 			selectedFile, ok := selectAllowedString(allowedFiles, file)
 			include := true
 			if !ok {
-				selectedFile, include, ok = classifyCuratedFile(
+				include, ok = classifyCuratedFile(
 					allowed, forbidden, agent, file, files,
 				)
 				if !ok {
@@ -778,15 +786,15 @@ func kiloLegacySessionFileShape(rel string) bool {
 func classifyCuratedFile(
 	allowed TargetSet, forbidden forbiddenRootMatcher, agent parser.AgentType, file string,
 	candidateFiles ...[]string,
-) (string, bool, bool) {
+) (bool, bool) {
 	if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
-		return "", false, false
+		return false, false
 	}
 	if !isAbsRemotePath(file) {
-		return "", false, false
+		return false, false
 	}
 	if _, err := safeRemotePathArchiveName(file); err != nil {
-		return "", false, false
+		return false, false
 	}
 	for _, dir := range allowed.Dirs[agent] {
 		if forbidden.within(dir) {
@@ -809,28 +817,28 @@ func classifyCuratedFile(
 			continue
 		}
 		if symlinkEscapesRoot(dir, file) {
-			return "", false, false
+			return false, false
 		}
 		if forbidden.within(file) {
-			return "", false, false
+			return false, false
 		}
 		info, err := os.Lstat(file)
 		if os.IsNotExist(err) {
-			return "", false, true
+			return false, true
 		}
 		if err != nil || !info.Mode().IsRegular() {
-			return "", false, false
+			return false, false
 		}
 		if agent == parser.AgentVSCodeCopilot && isVSCodeWorkspaceMetadata(rel) &&
-			vscodeWorkspaceChatVanished(allowed, dir, rel, candidateFiles...) {
-			return "", false, true
+			vscodeWorkspaceChatVanished(allowed, forbidden, dir, rel, candidateFiles...) {
+			return false, true
 		}
 		if hasPreferredCuratedSibling(dir, allowed.Files[agent], rel) {
-			return "", false, true
+			return false, true
 		}
-		return "", false, false
+		return false, false
 	}
-	return "", false, false
+	return false, false
 }
 
 func hasPreferredCuratedSibling(root string, allowedFiles []string, rel string) bool {
@@ -855,7 +863,8 @@ func hasPreferredCuratedSibling(root string, allowedFiles []string, rel string) 
 }
 
 func vscodeWorkspaceChatVanished(
-	allowed TargetSet, root, rel string, candidateFiles ...[]string,
+	allowed TargetSet, forbidden forbiddenRootMatcher, root, rel string,
+	candidateFiles ...[]string,
 ) bool {
 	parts := strings.Split(rel, "/")
 	for _, files := range candidateFiles {
@@ -874,7 +883,7 @@ func vscodeWorkspaceChatVanished(
 				continue
 			}
 			if _, err := safeRemotePathArchiveName(file); err != nil ||
-				symlinkEscapesRoot(root, file) {
+				symlinkEscapesRoot(root, file) || forbidden.within(file) {
 				continue
 			}
 			if _, err := os.Lstat(file); !os.IsNotExist(err) {
@@ -1030,29 +1039,11 @@ func selectAllowedFile(
 		if canonical, ok := selectAllowedString(files, file); ok {
 			return canonical, true, !forbidden.within(canonical)
 		}
-		canonical, include, ok := classifyCuratedFile(
+		include, ok := classifyCuratedFile(
 			allowed, forbidden, agent, file, files,
 		)
 		if ok {
-			return canonical, include, !forbidden.within(file)
-		}
-	}
-	// A fresh editor resolution can retain the authorized root while all
-	// curated leaves have vanished. The request still carries the prior
-	// exact file set, so validate its strict shape against that root before
-	// considering any directory-scoped agents.
-	for _, agent := range []parser.AgentType{
-		parser.AgentCursor, parser.AgentVSCodeCopilot, parser.AgentZed,
-		parser.AgentRooCode, parser.AgentKiloLegacy,
-	} {
-		if _, ok := allowed.Dirs[agent]; !ok {
-			continue
-		}
-		canonical, include, ok := classifyCuratedFile(
-			allowed, forbidden, agent, file, candidateFiles,
-		)
-		if ok {
-			return canonical, include, !forbidden.within(file)
+			return file, include, !forbidden.within(file)
 		}
 	}
 	if !isAbsRemotePath(file) {

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -92,7 +92,9 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				root, targetFiles := resolveEditorTarget(def.Type, dir)
 				if root != "" {
 					dirs[def.Type] = append(dirs[def.Type], root)
-					files[def.Type] = append(files[def.Type], targetFiles...)
+					if len(targetFiles) > 0 {
+						files[def.Type] = append(files[def.Type], targetFiles...)
+					}
 				}
 				continue
 			}
@@ -530,10 +532,25 @@ func resolveZedTarget(root string) (string, []string) {
 		return "", nil
 	}
 	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)
-	if !regularCuratedFile(root, dbPath) {
+	if !curatedFileOrMissing(root, dbPath) {
 		return "", nil
 	}
 	return root, []string{dbPath}
+}
+
+// curatedFileOrMissing retains a selected leaf through a deletion race so the
+// manifest can omit it and the mirror can evict its stale copy.
+func curatedFileOrMissing(root, path string) bool {
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil || !filepath.IsLocal(rel) || symlinkEscapesRoot(root, path) {
+		return false
+	}
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return true
+	}
+	return err == nil && info.Mode().IsRegular()
 }
 
 // resolvePoolsideTarget narrows a Poolside application-data root to

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -645,9 +645,13 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 		allowedDirs := allowed.Dirs[agent]
 		fileScoped := allowed.isFileScoped(agent)
 		if fileScoped {
-			if _, hasRequestedFiles := requested.Files[agent]; !hasRequestedFiles &&
-				!verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
-				return TargetSet{}, false
+			if _, hasRequestedFiles := requested.Files[agent]; !hasRequestedFiles {
+				emptyEditorScope :=
+					(agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot) &&
+						len(allowed.Files[agent]) == 0
+				if !emptyEditorScope {
+					return TargetSet{}, false
+				}
 			}
 		}
 		for _, dir := range dirs {

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -87,6 +87,23 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				}
 				continue
 			}
+			if def.Type == parser.AgentCursor ||
+				def.Type == parser.AgentVSCodeCopilot {
+				root, targetFiles := resolveEditorTarget(def.Type, dir)
+				if root != "" && len(targetFiles) > 0 {
+					dirs[def.Type] = append(dirs[def.Type], root)
+					files[def.Type] = append(files[def.Type], targetFiles...)
+				}
+				continue
+			}
+			if def.Type == parser.AgentZed {
+				root, targetFiles := resolveZedTarget(dir)
+				if root != "" && len(targetFiles) > 0 {
+					dirs[def.Type] = append(dirs[def.Type], root)
+					files[def.Type] = append(files[def.Type], targetFiles...)
+				}
+				continue
+			}
 			if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 				continue
 			}
@@ -107,6 +124,57 @@ func ResolveTargets(cfg config.Config) TargetSet {
 		Dirs: dirs, Files: files, ProviderExtraFiles: providerExtraFiles,
 		ForbiddenRoots: forbiddenRoots,
 	})
+}
+
+// resolveEditorTarget asks the parser for the exact session files it would
+// consume, then adds only the workspace manifest needed to preserve project
+// attribution. The configured editor root remains the authorization boundary.
+func resolveEditorTarget(agent parser.AgentType, root string) (string, []string) {
+	root = filepath.Clean(root)
+	if !curatedRoot(root) {
+		return "", nil
+	}
+	provider, ok := parser.NewProvider(agent, parser.ProviderConfig{Roots: []string{root}})
+	if !ok {
+		return "", nil
+	}
+	sources, err := provider.Discover(context.Background())
+	if err != nil {
+		return "", nil
+	}
+	seen := make(map[string]struct{})
+	var files []string
+	for _, source := range sources {
+		path := providerDiscoveredPath(source)
+		if path == "" || !regularCuratedFile(root, path) {
+			continue
+		}
+		if _, exists := seen[path]; !exists {
+			seen[path] = struct{}{}
+			files = append(files, path)
+		}
+		if agent != parser.AgentVSCodeCopilot {
+			continue
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil || filepath.IsAbs(rel) {
+			continue
+		}
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+		if len(parts) != 4 || parts[0] != "workspaceStorage" ||
+			parts[2] != "chatSessions" {
+			continue
+		}
+		workspace := filepath.Join(root, "workspaceStorage", parts[1], "workspace.json")
+		if regularCuratedFile(root, workspace) {
+			if _, exists := seen[workspace]; !exists {
+				seen[workspace] = struct{}{}
+				files = append(files, workspace)
+			}
+		}
+	}
+	sort.Strings(files)
+	return root, files
 }
 
 func isLocalRemoteSyncSource(
@@ -420,6 +488,52 @@ func resolveKiloLegacyTarget(root string) (string, []string) {
 		return "", nil
 	}
 	return targetRoot, files
+}
+
+func resolveProviderFiles(agent parser.AgentType, root string, keep func(string) bool) (string, []string) {
+	provider, ok := parser.NewProvider(agent, parser.ProviderConfig{Roots: []string{root}})
+	if !ok {
+		return "", nil
+	}
+	sources, err := provider.Discover(context.Background())
+	if err != nil {
+		return "", nil
+	}
+	var files []string
+	for _, source := range sources {
+		path := providerDiscoveredPath(source)
+		if keep(path) && regularCuratedFile(root, path) {
+			files = append(files, filepath.Clean(path))
+		}
+	}
+	slices.Sort(files)
+	return root, slices.Compact(files)
+}
+
+func curatedRoot(root string) bool {
+	info, err := os.Lstat(root)
+	return err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0
+}
+
+func regularCuratedFile(root, path string) bool {
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil || !filepath.IsLocal(rel) || symlinkEscapesRoot(root, path) {
+		return false
+	}
+	return regularRemoteSyncFile(path)
+}
+
+func resolveZedTarget(root string) (string, []string) {
+	root = filepath.Clean(root)
+	if !curatedRoot(root) {
+		return "", nil
+	}
+	dbPath := filepath.Join(root, parser.ZedThreadsDBRelPath)
+	if !regularCuratedFile(root, dbPath) {
+		return "", nil
+	}
+	return root, []string{dbPath}
 }
 
 // resolvePoolsideTarget narrows a Poolside application-data root to

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -802,7 +802,11 @@ func verbatimSessionFileUnderAllowedRoot(
 		if !ok || rel == "" {
 			continue
 		}
-		if !sessionFileShape(agent, rel) {
+		if agent == parser.AgentVSCodeCopilot && isVSCodeWorkspaceMetadata(rel) {
+			if !vscodeWorkspaceMetadataTiedToAllowedSession(allowed, dir, file) {
+				continue
+			}
+		} else if !sessionFileShape(agent, rel) {
 			continue
 		}
 		if symlinkEscapesRoot(dir, file) {
@@ -824,10 +828,6 @@ func sessionFileShape(agent parser.AgentType, rel string) bool {
 		return ok
 	case parser.AgentVSCodeCopilot:
 		parts := strings.Split(rel, "/")
-		if len(parts) == 3 && parts[0] == "workspaceStorage" &&
-			parts[1] != "" && parts[2] == "workspace.json" {
-			return true
-		}
 		if len(parts) == 4 && parts[0] == "workspaceStorage" &&
 			parts[2] == "chatSessions" {
 			return parser.IsValidSessionID(strings.TrimSuffix(parts[3], filepath.Ext(parts[3]))) &&
@@ -844,6 +844,46 @@ func sessionFileShape(agent parser.AgentType, rel string) bool {
 	default:
 		return rooCodeSessionFileShape(rel)
 	}
+}
+
+func vscodeWorkspaceMetadataTiedToAllowedSession(
+	allowed TargetSet, root, file string,
+) bool {
+	rel, ok := remoteArchiveRel(root, file)
+	if !ok {
+		return false
+	}
+	parts := strings.Split(rel, "/")
+	if !isVSCodeWorkspaceMetadata(rel) {
+		return false
+	}
+	for _, selected := range allowed.Files[parser.AgentVSCodeCopilot] {
+		selectedRel, ok := remoteArchiveRel(root, selected)
+		if !ok {
+			continue
+		}
+		selectedParts := strings.Split(selectedRel, "/")
+		if len(selectedParts) != 4 || selectedParts[0] != "workspaceStorage" ||
+			selectedParts[1] != parts[1] || selectedParts[2] != "chatSessions" {
+			continue
+		}
+		if vscodeChatSessionFileShape(selectedParts[3]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isVSCodeWorkspaceMetadata(rel string) bool {
+	parts := strings.Split(rel, "/")
+	return len(parts) == 3 && parts[0] == "workspaceStorage" &&
+		parts[1] != "" && parts[2] == "workspace.json"
+}
+
+func vscodeChatSessionFileShape(name string) bool {
+	ext := filepath.Ext(name)
+	return (ext == ".json" || ext == ".jsonl") &&
+		parser.IsValidSessionID(strings.TrimSuffix(name, ext))
 }
 
 func isAiderUnsafeRoot(dir string) bool {

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -494,7 +494,10 @@ func resolveKiloLegacyTarget(root string) (string, []string) {
 
 func curatedRoot(root string) bool {
 	info, err := os.Lstat(root)
-	return err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0
+	if err != nil || info == nil {
+		return false
+	}
+	return info.IsDir() && info.Mode()&os.ModeSymlink == 0
 }
 
 func regularCuratedFile(root, path string) bool {
@@ -530,7 +533,10 @@ func curatedFileOrMissing(root, path string) bool {
 	if os.IsNotExist(err) {
 		return true
 	}
-	return err == nil && info.Mode().IsRegular()
+	if err != nil || info == nil {
+		return false
+	}
+	return info.Mode().IsRegular()
 }
 
 // resolvePoolsideTarget narrows a Poolside application-data root to

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -92,9 +92,7 @@ func ResolveTargets(cfg config.Config) TargetSet {
 				root, targetFiles := resolveEditorTarget(def.Type, dir)
 				if root != "" {
 					dirs[def.Type] = append(dirs[def.Type], root)
-					if len(targetFiles) > 0 {
-						files[def.Type] = append(files[def.Type], targetFiles...)
-					}
+					files[def.Type] = append([]string{}, targetFiles...)
 				}
 				continue
 			}
@@ -215,7 +213,11 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 	for agent, files := range t.Files {
 		kept := withoutForbidden(files, forbidden)
 		if len(kept) == 0 {
-			delete(t.Files, agent)
+			if _, hasDirs := t.Dirs[agent]; hasDirs {
+				t.Files[agent] = []string{}
+			} else {
+				delete(t.Files, agent)
+			}
 			continue
 		}
 		t.Files[agent] = kept
@@ -633,9 +635,10 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 	forbidden := newForbiddenRootMatcher(selected.ForbiddenRoots)
 	for agent, dirs := range requested.Dirs {
 		allowedDirs := allowed.Dirs[agent]
-		if _, fileScoped := allowed.Files[agent]; fileScoped {
-			requestedFiles, ok := requested.Files[agent]
-			if !ok || len(requestedFiles) == 0 {
+		fileScoped := allowed.isFileScoped(agent)
+		if fileScoped {
+			if _, hasRequestedFiles := requested.Files[agent]; !hasRequestedFiles &&
+				!verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 				return TargetSet{}, false
 			}
 		}
@@ -649,31 +652,28 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 			}
 			selected.Dirs[agent] = append(selected.Dirs[agent], selectedDir)
 		}
+		if fileScoped {
+			if selected.Files == nil {
+				selected.Files = make(map[parser.AgentType][]string)
+			}
+			if _, ok := selected.Files[agent]; !ok {
+				selected.Files[agent] = []string{}
+			}
+		}
 	}
 	for agent, files := range requested.Files {
-		allowedFiles, hasAllowedFiles := allowed.Files[agent]
+		allowedFiles := allowed.Files[agent]
 		for _, file := range files {
 			selectedFile, ok := selectAllowedString(allowedFiles, file)
-			if !ok && (!hasAllowedFiles || len(allowedFiles) == 0) {
-				ok = verbatimSessionFileUnderAllowedRoot(
-					allowed, agent, file, files,
-				)
-				if ok {
-					selectedFile = file
-				}
-			}
+			include := true
 			if !ok {
-				// Targets are re-resolved for every request, so a
-				// session file deleted between the client's target
-				// fetch and this request is no longer in the fresh
-				// resolution. Failing the whole request would abort
-				// the sync over a routine deletion race; the archive
-				// writers tolerate missing files, so authorize
-				// session-shaped paths under a still-allowed root.
-				if !verbatimSessionFileUnderAllowedRoot(allowed, agent, file, files) {
+				selectedFile, include, ok = classifyCuratedFile(allowed, agent, file, files)
+				if !ok {
 					return TargetSet{}, false
 				}
-				selectedFile = file
+			}
+			if !include {
+				continue
 			}
 			if selected.Files == nil {
 				selected.Files = make(map[parser.AgentType][]string)
@@ -766,28 +766,25 @@ func kiloLegacySessionFileShape(rel string) bool {
 	return false
 }
 
-// verbatimSessionFileUnderAllowedRoot authorizes a curated file
+// classifyCuratedFile validates a stale curated file request
 // under a verbatim file-scoped agent's still-allowed root when the
 // file itself is absent from the fresh per-request resolution — the
 // deletion race between a client's target fetch and its next request.
 // The strict shape keeps everything else under the root
 // (settings/mcp_settings.json, checkpoints, caches) unreachable, and
 // the symlink walk rejects components that would escape the root.
-func verbatimSessionFileUnderAllowedRoot(
+func classifyCuratedFile(
 	allowed TargetSet, agent parser.AgentType, file string,
 	candidateFiles ...[]string,
-) bool {
+) (string, bool, bool) {
 	if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
-		return false
+		return "", false, false
 	}
 	if !isAbsRemotePath(file) {
-		return false
-	}
-	if _, err := os.Lstat(file); err == nil || !os.IsNotExist(err) {
-		return false
+		return "", false, false
 	}
 	if _, err := safeRemotePathArchiveName(file); err != nil {
-		return false
+		return "", false, false
 	}
 	for _, dir := range allowed.Dirs[agent] {
 		if remotePathDialect(file) != remotePathDialect(dir) {
@@ -807,9 +804,82 @@ func verbatimSessionFileUnderAllowedRoot(
 			continue
 		}
 		if symlinkEscapesRoot(dir, file) {
-			return false
+			return "", false, false
 		}
-		return true
+		info, err := os.Lstat(file)
+		if os.IsNotExist(err) {
+			return "", false, true
+		}
+		if err != nil || !info.Mode().IsRegular() {
+			return "", false, false
+		}
+		if agent == parser.AgentVSCodeCopilot && isVSCodeWorkspaceMetadata(rel) &&
+			vscodeWorkspaceChatVanished(allowed, dir, rel, candidateFiles...) {
+			return "", false, true
+		}
+		if hasPreferredCuratedSibling(dir, allowed.Files[agent], rel) {
+			return "", false, true
+		}
+		return "", false, false
+	}
+	return "", false, false
+}
+
+func hasPreferredCuratedSibling(root string, allowedFiles []string, rel string) bool {
+	separator := strings.LastIndexByte(rel, '/')
+	dir, name := rel[:separator+1], rel[separator+1:]
+	stem := strings.TrimSuffix(name, filepath.Ext(name))
+	for _, file := range allowedFiles {
+		candidate, ok := remoteArchiveRel(root, file)
+		if !ok {
+			continue
+		}
+		candidateSeparator := strings.LastIndexByte(candidate, '/')
+		candidateDir := candidate[:candidateSeparator+1]
+		candidateName := candidate[candidateSeparator+1:]
+		if candidateDir == dir &&
+			strings.TrimSuffix(candidateName, filepath.Ext(candidateName)) == stem &&
+			filepath.Ext(candidateName) != filepath.Ext(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func vscodeWorkspaceChatVanished(
+	allowed TargetSet, root, rel string, candidateFiles ...[]string,
+) bool {
+	parts := strings.Split(rel, "/")
+	for _, files := range candidateFiles {
+		for _, file := range files {
+			chatRel, ok := remoteArchiveRel(root, file)
+			if !ok {
+				continue
+			}
+			chatParts := strings.Split(chatRel, "/")
+			if len(chatParts) != 4 || chatParts[0] != "workspaceStorage" ||
+				chatParts[1] != parts[1] || chatParts[2] != "chatSessions" ||
+				!vscodeChatSessionFileShape(chatParts[3]) {
+				continue
+			}
+			if !isAbsRemotePath(file) || remotePathDialect(file) != remotePathDialect(root) {
+				continue
+			}
+			if _, err := safeRemotePathArchiveName(file); err != nil ||
+				symlinkEscapesRoot(root, file) {
+				continue
+			}
+			if _, err := os.Lstat(file); !os.IsNotExist(err) {
+				continue
+			}
+			for _, allowedFile := range allowed.Files[parser.AgentVSCodeCopilot] {
+				allowedRel, ok := remoteArchiveRel(root, allowedFile)
+				if ok && strings.HasPrefix(allowedRel, "workspaceStorage/"+parts[1]+"/chatSessions/") {
+					return false
+				}
+			}
+			return true
+		}
 	}
 	return false
 }
@@ -913,11 +983,13 @@ func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
 	forbidden := newForbiddenRootMatcher(allowed.ForbiddenRoots)
 	selected := make([]string, 0, len(files))
 	for _, file := range files {
-		canonical, ok := selectAllowedFile(allowed, forbidden, file, files)
+		canonical, include, ok := selectAllowedFile(allowed, forbidden, file, files)
 		if !ok {
 			return nil, false
 		}
-		selected = append(selected, canonical)
+		if include {
+			selected = append(selected, canonical)
+		}
 	}
 	return selected, true
 }
@@ -932,9 +1004,9 @@ func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
 func selectAllowedFile(
 	allowed TargetSet, forbidden forbiddenRootMatcher, file string,
 	candidateFiles []string,
-) (string, bool) {
+) (string, bool, bool) {
 	if canonical, ok := selectAllowedString(allowed.AllExtraFiles(), file); ok {
-		return canonical, !forbidden.within(canonical)
+		return canonical, true, !forbidden.within(canonical)
 	}
 	for agent, files := range allowed.Files {
 		if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
@@ -948,10 +1020,11 @@ func selectAllowedFile(
 		// skips it because its delta roots come from the same fresh
 		// resolution.
 		if canonical, ok := selectAllowedString(files, file); ok {
-			return canonical, !forbidden.within(canonical)
+			return canonical, true, !forbidden.within(canonical)
 		}
-		if verbatimSessionFileUnderAllowedRoot(allowed, agent, file, files) {
-			return file, !forbidden.within(file)
+		canonical, include, ok := classifyCuratedFile(allowed, agent, file, files)
+		if ok {
+			return canonical, include, !forbidden.within(file)
 		}
 	}
 	// A fresh editor resolution can retain the authorized root while all
@@ -965,20 +1038,21 @@ func selectAllowedFile(
 		if _, ok := allowed.Dirs[agent]; !ok {
 			continue
 		}
-		if verbatimSessionFileUnderAllowedRoot(
+		canonical, include, ok := classifyCuratedFile(
 			allowed, agent, file, candidateFiles,
-		) {
-			return file, !forbidden.within(file)
+		)
+		if ok {
+			return canonical, include, !forbidden.within(file)
 		}
 	}
 	if !isAbsRemotePath(file) {
-		return "", false
+		return "", false, false
 	}
 	if _, err := safeRemotePathArchiveName(file); err != nil {
-		return "", false
+		return "", false, false
 	}
 	for agent, dirs := range allowed.Dirs {
-		if _, fileScoped := allowed.Files[agent]; fileScoped ||
+		if allowed.isFileScoped(agent) ||
 			verbatimFileScopedAgent(agent) || snapshotFileScopedAgent(agent) {
 			// File-scoped agents export a curated file list, not a raw
 			// directory walk. Accepting a delta request by directory
@@ -1001,7 +1075,7 @@ func selectAllowedFile(
 			}
 			if _, ok := remoteArchiveRel(dir, file); ok {
 				if symlinkEscapesRoot(dir, file) {
-					return "", false
+					return "", false, false
 				}
 				// Exact root matches are allowed: file roots (Aider
 				// history files) must stream, and a directory root
@@ -1009,11 +1083,11 @@ func selectAllowedFile(
 				// non-regular entries. The file is anchored under the
 				// trusted dir at this point, so the forbidden check may
 				// canonicalize it.
-				return file, !forbidden.within(file)
+				return file, true, !forbidden.within(file)
 			}
 		}
 	}
-	return "", false
+	return "", false, false
 }
 
 type pathDialect int

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -797,6 +797,9 @@ func verbatimSessionFileUnderAllowedRoot(
 	if !isAbsRemotePath(file) {
 		return false
 	}
+	if _, err := os.Lstat(file); err == nil || !os.IsNotExist(err) {
+		return false
+	}
 	if _, err := safeRemotePathArchiveName(file); err != nil {
 		return false
 	}

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -174,7 +174,14 @@ func resolveEditorTarget(agent parser.AgentType, root string) (string, []string,
 	var files []string
 	for _, source := range sources {
 		path := providerDiscoveredPath(source)
-		if path == "" || !regularCuratedFile(root, path) {
+		if path == "" {
+			continue
+		}
+		regular, err := regularCuratedFile(root, path)
+		if err != nil {
+			return "", nil, err
+		}
+		if !regular {
 			continue
 		}
 		if _, exists := seen[path]; !exists {
@@ -194,7 +201,11 @@ func resolveEditorTarget(agent parser.AgentType, root string) (string, []string,
 			continue
 		}
 		workspace := filepath.Join(root, "workspaceStorage", parts[1], "workspace.json")
-		if regularCuratedFile(root, workspace) {
+		regular, err = regularCuratedFile(root, workspace)
+		if err != nil {
+			return "", nil, err
+		}
+		if regular {
 			if _, exists := seen[workspace]; !exists {
 				seen[workspace] = struct{}{}
 				files = append(files, workspace)
@@ -494,12 +505,23 @@ func resolveRooCodeTarget(root string) (string, []string, error) {
 	var files []string
 	for _, source := range sources {
 		historyPath := providerDiscoveredPath(source)
-		if historyPath == "" || !regularRemoteSyncFile(historyPath) {
+		if historyPath == "" {
+			continue
+		}
+		regular, err := statRegularRemoteSyncFile(historyPath)
+		if err != nil {
+			return "", nil, err
+		}
+		if !regular {
 			continue
 		}
 		files = append(files, historyPath)
 		msgPath := filepath.Join(filepath.Dir(historyPath), "ui_messages.json")
-		if regularRemoteSyncFile(msgPath) {
+		regular, err = statRegularRemoteSyncFile(msgPath)
+		if err != nil {
+			return "", nil, err
+		}
+		if regular {
 			files = append(files, msgPath)
 		}
 	}
@@ -534,7 +556,14 @@ func resolveKiloLegacyTarget(root string) (string, []string, error) {
 	var files []string
 	for _, source := range sources {
 		metadataPath := providerDiscoveredPath(source)
-		if metadataPath == "" || !regularRemoteSyncFile(metadataPath) {
+		if metadataPath == "" {
+			continue
+		}
+		regular, err := statRegularRemoteSyncFile(metadataPath)
+		if err != nil {
+			return "", nil, err
+		}
+		if !regular {
 			continue
 		}
 		files = append(files, metadataPath)
@@ -544,7 +573,11 @@ func resolveKiloLegacyTarget(root string) (string, []string, error) {
 			"api_conversation_history.json",
 		} {
 			sibPath := filepath.Join(taskDir, name)
-			if regularRemoteSyncFile(sibPath) {
+			regular, err := statRegularRemoteSyncFile(sibPath)
+			if err != nil {
+				return "", nil, err
+			}
+			if regular {
 				files = append(files, sibPath)
 			}
 		}
@@ -584,13 +617,28 @@ func statCuratedDir(root string) (bool, error) {
 	return info.IsDir(), nil
 }
 
-func regularCuratedFile(root, path string) bool {
+func regularCuratedFile(root, path string) (bool, error) {
 	path = filepath.Clean(path)
 	rel, err := filepath.Rel(root, path)
 	if err != nil || !filepath.IsLocal(rel) || symlinkEscapesRoot(root, path) {
-		return false
+		return false, nil
 	}
-	return regularRemoteSyncFile(path)
+	return statRegularRemoteSyncFile(path)
+}
+
+// statRegularRemoteSyncFile applies the curated-resolver error
+// contract to one selected file: a missing file is an omitted target,
+// while any other stat failure propagates so it cannot silently
+// shrink the curated set and evict the client's mirror copies.
+func statRegularRemoteSyncFile(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat remote sync target %q: %w", path, err)
+	}
+	return info.Mode().IsRegular(), nil
 }
 
 func resolveZedTarget(root string) (string, []string, error) {

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -90,7 +90,7 @@ func ResolveTargets(cfg config.Config) TargetSet {
 			if def.Type == parser.AgentCursor ||
 				def.Type == parser.AgentVSCodeCopilot {
 				root, targetFiles := resolveEditorTarget(def.Type, dir)
-				if root != "" && len(targetFiles) > 0 {
+				if root != "" {
 					dirs[def.Type] = append(dirs[def.Type], root)
 					files[def.Type] = append(files[def.Type], targetFiles...)
 				}
@@ -98,7 +98,7 @@ func ResolveTargets(cfg config.Config) TargetSet {
 			}
 			if def.Type == parser.AgentZed {
 				root, targetFiles := resolveZedTarget(dir)
-				if root != "" && len(targetFiles) > 0 {
+				if root != "" {
 					dirs[def.Type] = append(dirs[def.Type], root)
 					files[def.Type] = append(files[def.Type], targetFiles...)
 				}
@@ -768,7 +768,7 @@ func kiloLegacySessionFileShape(rel string) bool {
 func verbatimSessionFileUnderAllowedRoot(
 	allowed TargetSet, agent parser.AgentType, file string,
 ) bool {
-	if !verbatimFileScopedAgent(agent) {
+	if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 		return false
 	}
 	if !isAbsRemotePath(file) {
@@ -802,6 +802,24 @@ func sessionFileShape(agent parser.AgentType, rel string) bool {
 	switch agent {
 	case parser.AgentKiloLegacy:
 		return kiloLegacySessionFileShape(rel)
+	case parser.AgentCursor:
+		_, ok := parser.ParseCursorTranscriptRelPath(rel)
+		return ok
+	case parser.AgentVSCodeCopilot:
+		parts := strings.Split(rel, "/")
+		if len(parts) == 4 && parts[0] == "workspaceStorage" &&
+			parts[2] == "chatSessions" {
+			return parser.IsValidSessionID(strings.TrimSuffix(parts[3], filepath.Ext(parts[3]))) &&
+				(filepath.Ext(parts[3]) == ".json" || filepath.Ext(parts[3]) == ".jsonl")
+		}
+		if len(parts) == 3 && parts[0] == "globalStorage" &&
+			(parts[1] == "emptyWindowChatSessions" || parts[1] == "transferredChatSessions") {
+			return parser.IsValidSessionID(strings.TrimSuffix(parts[2], filepath.Ext(parts[2]))) &&
+				(filepath.Ext(parts[2]) == ".json" || filepath.Ext(parts[2]) == ".jsonl")
+		}
+		return false
+	case parser.AgentZed:
+		return filepath.ToSlash(filepath.Clean(rel)) == parser.ZedThreadsDBRelPath
 	default:
 		return rooCodeSessionFileShape(rel)
 	}
@@ -856,10 +874,10 @@ func selectAllowedFile(
 		return canonical, !forbidden.within(canonical)
 	}
 	for agent, files := range allowed.Files {
-		if !verbatimFileScopedAgent(agent) {
+		if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 			continue
 		}
-		// Verbatim file-scoped agents (RooCode) delta-stream exactly
+		// Verbatim and snapshot file-scoped agents delta-stream exactly
 		// their curated files; the exact-match requirement keeps
 		// settings and caches under their directory unreachable. A
 		// session-shaped file missing from the fresh resolution is

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -20,6 +20,13 @@ import (
 	"go.kenn.io/agentsview/internal/ssh"
 )
 
+func resolveTargetsForTest(t *testing.T, cfg config.Config) remotesync.TargetSet {
+	t.Helper()
+	targets, err := remotesync.ResolveTargets(cfg)
+	require.NoError(t, err)
+	return targets
+}
+
 func TestResolveTargetsExcludesNonLocalStructuredSessionSources(t *testing.T) {
 	localMachine, err := os.Hostname()
 	require.NoError(t, err)
@@ -65,7 +72,7 @@ machine = %q
 	cfg, err := config.LoadMinimal()
 	require.NoError(t, err)
 	require.Equal(t, localMachine, cfg.LocalMachineName)
-	targets := remotesync.ResolveTargets(cfg)
+	targets := resolveTargetsForTest(t, cfg)
 
 	assert.ElementsMatch(t, []string{localRoot, localStructuredRoot},
 		targets.Dirs[parser.AgentCopilot])
@@ -115,7 +122,7 @@ func TestResolveTargetsFiltersAndIncludesSpecialFiles(t *testing.T) {
 	codexIndex := filepath.Join(root, ".codex", parser.CodexSessionIndexFilename)
 	require.NoError(t, os.WriteFile(codexIndex, []byte("{}\n"), 0o644))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude: {claudeDir, missingDir},
 			parser.AgentCodex:  {codexDir},
@@ -162,7 +169,7 @@ func TestResolveTargetsExcludesRemoteSyncExcludedAgentState(t *testing.T) {
 		filepath.Join(root, "credentials.json"), []byte("secret"), 0o600,
 	))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentTrae: {root},
 		},
@@ -181,7 +188,7 @@ func TestResolveTargetsExcludesTraeProfile(t *testing.T) {
 	require.NoError(t, os.MkdirAll(traeRoot, 0o755))
 	require.NoError(t, os.MkdirAll(claudeRoot, 0o755))
 
-	targets := remotesync.ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentTrae:   {traeRoot},
 		parser.AgentClaude: {claudeRoot},
 	}})
@@ -203,7 +210,7 @@ func TestResolveTargetsOmitsAllowedTargetsInsideForbiddenRoots(t *testing.T) {
 	require.NoError(t, os.MkdirAll(nestedClaude, 0o755))
 	require.NoError(t, os.MkdirAll(outsideClaude, 0o755))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentTrae:   {traeRoot},
 			parser.AgentClaude: {nestedClaude, outsideClaude},
@@ -239,7 +246,7 @@ func TestResolveTargetsDropsFileScopedAgentWhenSessionFilesForbidden(
 		[]byte(`{"id":"task-1","ts":1,"task":"t"}`), 0o644,
 	))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentTrae:    {tasksDir},
 			parser.AgentRooCode: {rooRoot},
@@ -263,7 +270,7 @@ func TestResolveTargetsPoolsideNarrowsToTrajectories(t *testing.T) {
 	require.NoError(t, os.MkdirAll(trajectoriesDir, 0o755))
 	require.NoError(t, os.WriteFile(settingsFile, []byte(`{"api_key":"sk-secret"}`), 0o644))
 
-	targets := remotesync.ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentPoolside: {root},
 	}})
 
@@ -281,7 +288,7 @@ func TestResolveTargetsPoolsideNarrowsToTrajectories(t *testing.T) {
 func TestResolveTargetsPoolsideSkipsMissingTrajectories(t *testing.T) {
 	root := t.TempDir()
 
-	targets := remotesync.ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentPoolside: {root},
 	}})
 
@@ -296,7 +303,7 @@ func TestResolveTargetsPoolsideTrajectoriesRoot(t *testing.T) {
 	trajectoriesDir := filepath.Join(t.TempDir(), "trajectories")
 	require.NoError(t, os.MkdirAll(trajectoriesDir, 0o755))
 
-	targets := remotesync.ResolveTargets(config.Config{AgentDirs: map[parser.AgentType][]string{
+	targets := resolveTargetsForTest(t, config.Config{AgentDirs: map[parser.AgentType][]string{
 		parser.AgentPoolside: {trajectoriesDir},
 	}})
 
@@ -321,7 +328,7 @@ func TestResolveTargetsExpandsHermesProfilesWithDatabaseFiles(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("sqlite"), 0o644))
 	}
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentHermes: {profilesRoot},
 		},
@@ -349,7 +356,7 @@ func TestResolveTargetsIncludesFlatCustomHermesRoot(t *testing.T) {
 		filepath.Join(root, "child.jsonl"), []byte("{}\n"), 0o644,
 	))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentHermes: {root},
 		},
@@ -372,7 +379,7 @@ func TestResolveTargetsSkipsSessionlessHermesProfileCredentials(t *testing.T) {
 		filepath.Join(profileRoot, "debug.jsonl"), []byte("not a session\n"), 0o600,
 	))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentHermes: {profileRoot},
 		},
@@ -392,7 +399,7 @@ func TestResolveTargetsSkipsAiderHomeRoot(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(aiderHistory), 0o755))
 	require.NoError(t, os.WriteFile(aiderHistory, []byte("# aider\n"), 0o644))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentAider: {home + string(filepath.Separator)},
 		},
@@ -546,7 +553,7 @@ func TestResolveTargetsMatchesSSHResolverForRepresentativeHome(t *testing.T) {
 	require.NoError(t, err, "ssh resolver output: %s", out)
 	sshDirs, sshFiles, sshExtra, _ := ssh.ParseResolvedTargetsWithFilesForTest(string(out))
 
-	goTargets := remotesync.ResolveTargets(config.Config{
+	goTargets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude:   {claudeDir},
 			parser.AgentCodex:    {codexDir},
@@ -752,7 +759,7 @@ func TestRooCodeRemoteSyncExportsOnlySessionFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(checkpointBlob, []byte("checkpoint"), 0o644))
 	require.NoError(t, os.WriteFile(cacheBlob, []byte("cache"), 0o644))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentRooCode: {rooRoot},
 		},
@@ -865,13 +872,13 @@ func TestRooCodeRemoteSyncToleratesVanishedSessionFile(t *testing.T) {
 			parser.AgentRooCode: {rooRoot},
 		},
 	}
-	staleClientTargets := remotesync.ResolveTargets(cfg)
+	staleClientTargets := resolveTargetsForTest(t, cfg)
 	require.Contains(t, staleClientTargets.Files[parser.AgentRooCode],
 		task1Messages)
 
 	// The whole task vanishes on the remote before the next request.
 	require.NoError(t, os.RemoveAll(task1))
-	freshServerTargets := remotesync.ResolveTargets(cfg)
+	freshServerTargets := resolveTargetsForTest(t, cfg)
 	assert.NotContains(t, freshServerTargets.Files[parser.AgentRooCode],
 		task1Messages)
 
@@ -947,7 +954,7 @@ func TestRooCodeRemoteSyncSkipsRootWithoutSessions(t *testing.T) {
 		filepath.Join(settingsDir, "mcp_settings.json"),
 		[]byte(`{"mcpServers":{}}`), 0o644))
 
-	targets := remotesync.ResolveTargets(config.Config{
+	targets := resolveTargetsForTest(t, config.Config{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentRooCode: {rooRoot},
 		},

--- a/internal/remotesync/sqlite_snapshot.go
+++ b/internal/remotesync/sqlite_snapshot.go
@@ -175,7 +175,43 @@ func hermesStateDBTargets(targets TargetSet) []string {
 	return paths
 }
 
+func sqliteSnapshotPathsForTargets(targets TargetSet) []string {
+	paths := hermesStateDBTargets(targets)
+	seen := make(map[string]struct{}, len(paths)+len(targets.Files[parser.AgentZed]))
+	for _, path := range paths {
+		seen[path] = struct{}{}
+	}
+	for _, path := range targets.Files[parser.AgentZed] {
+		if filepath.Base(filepath.Clean(path)) == "threads.db" {
+			seen[filepath.Clean(path)] = struct{}{}
+		}
+	}
+	paths = paths[:0]
+	for path := range seen {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func sqliteSnapshotTargets(targets TargetSet) map[string]parser.AgentType {
+	out := make(map[string]parser.AgentType)
+	for _, path := range sqliteSnapshotPathsForTargets(targets) {
+		out[path] = parser.AgentHermes
+	}
+	for _, path := range targets.Files[parser.AgentZed] {
+		if filepath.Base(filepath.Clean(path)) == "threads.db" {
+			out[filepath.Clean(path)] = parser.AgentZed
+		}
+	}
+	return out
+}
+
 func hermesSQLitePaths(stateDB string) []string {
+	return sqliteSnapshotPaths(stateDB)
+}
+
+func sqliteSnapshotPaths(stateDB string) []string {
 	return []string{
 		filepath.Clean(stateDB),
 		filepath.Clean(stateDB + "-wal"),
@@ -185,15 +221,19 @@ func hermesSQLitePaths(stateDB string) []string {
 }
 
 func hermesStateDBForArchivePath(path string) (string, bool) {
+	return sqliteSnapshotForArchivePath(path)
+}
+
+func sqliteSnapshotForArchivePath(path string) (string, bool) {
 	path = filepath.Clean(path)
 	switch filepath.Base(path) {
-	case "state.db":
+	case "state.db", "threads.db":
 		return path, true
-	case "state.db-wal":
+	case "state.db-wal", "threads.db-wal":
 		return strings.TrimSuffix(path, "-wal"), true
-	case "state.db-shm":
+	case "state.db-shm", "threads.db-shm":
 		return strings.TrimSuffix(path, "-shm"), true
-	case "state.db-journal":
+	case "state.db-journal", "threads.db-journal":
 		return strings.TrimSuffix(path, "-journal"), true
 	default:
 		return "", false

--- a/internal/remotesync/sqlite_snapshot.go
+++ b/internal/remotesync/sqlite_snapshot.go
@@ -89,52 +89,31 @@ func writeSQLiteSnapshot(dstPath, srcPath string) (err error) {
 	return nil
 }
 
-func sqliteSnapshotIdentity(path string) (int64, time.Time, bool, error) {
+// sqliteSnapshotIdentity treats an unusable database as an optional
+// missing archive component. The SQLite archive preserves imported
+// sessions even when their source files disappear, so omitting an
+// unreadable database from the manifest costs only the mirror's cached
+// copy, and a later sync retries after the writer repairs or replaces
+// it. Failing the manifest instead would block every other agent's
+// sync behind one bad file.
+func sqliteSnapshotIdentity(path string) (int64, time.Time, bool) {
 	info, err := os.Lstat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, time.Time{}, false, nil
-		}
-		return 0, time.Time{}, false, fmt.Errorf("stat sqlite database %q: %w", path, err)
-	}
-	if !info.Mode().IsRegular() {
-		return 0, time.Time{}, false, nil
+	if err != nil || !info.Mode().IsRegular() {
+		return 0, time.Time{}, false
 	}
 	conn, err := sql.Open("sqlite3", sqliteReadOnlyDSN(path))
 	if err != nil {
-		return 0, time.Time{}, false, fmt.Errorf("open sqlite database %q: %w", path, err)
+		return 0, time.Time{}, false
 	}
 	defer conn.Close()
 	var pageSize, pageCount int64
 	if err := conn.QueryRow(`PRAGMA page_size`).Scan(&pageSize); err != nil {
-		return 0, time.Time{}, false, fmt.Errorf("read sqlite page size %q: %w", path, err)
-	}
-	if err := conn.QueryRow(`PRAGMA page_count`).Scan(&pageCount); err != nil {
-		return 0, time.Time{}, false, fmt.Errorf("read sqlite page count %q: %w", path, err)
-	}
-	return pageSize * pageCount, sqliteSnapshotModTime(path, info.ModTime()), true, nil
-}
-
-// hermesSQLiteSnapshotIdentity treats an unusable state database as an
-// optional missing archive component. Hermes transcripts remain independently
-// useful, and a later sync can retry the database after the writer repairs or
-// replaces it.
-func hermesSQLiteSnapshotIdentity(path string) (int64, time.Time, bool) {
-	size, modTime, exists, err := sqliteSnapshotIdentity(path)
-	if err != nil {
 		return 0, time.Time{}, false
 	}
-	return size, modTime, exists
-}
-
-func sqliteSnapshotIdentityForAgent(
-	path string, agent parser.AgentType,
-) (int64, time.Time, bool, error) {
-	if agent == parser.AgentZed {
-		return sqliteSnapshotIdentity(path)
+	if err := conn.QueryRow(`PRAGMA page_count`).Scan(&pageCount); err != nil {
+		return 0, time.Time{}, false
 	}
-	size, modTime, exists := hermesSQLiteSnapshotIdentity(path)
-	return size, modTime, exists, nil
+	return pageSize * pageCount, sqliteSnapshotModTime(path, info.ModTime()), true
 }
 
 func sqliteSnapshotModTime(stateDB string, modTime time.Time) time.Time {
@@ -185,40 +164,20 @@ func hermesStateDBTargets(targets TargetSet) []string {
 	return paths
 }
 
-func sqliteSnapshotPathsForTargets(targets TargetSet) []string {
-	paths := hermesStateDBTargets(targets)
-	seen := make(map[string]struct{}, len(paths)+len(targets.Files[parser.AgentZed]))
-	for _, path := range paths {
-		seen[path] = struct{}{}
+// sqliteSnapshotTargets returns the set of databases (Hermes state.db,
+// Zed threads.db) whose manifest and archive entries are consistent
+// snapshots rather than raw file copies.
+func sqliteSnapshotTargets(targets TargetSet) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, path := range hermesStateDBTargets(targets) {
+		out[path] = struct{}{}
 	}
 	for _, path := range targets.Files[parser.AgentZed] {
 		if filepath.Base(filepath.Clean(path)) == "threads.db" {
-			seen[filepath.Clean(path)] = struct{}{}
-		}
-	}
-	paths = paths[:0]
-	for path := range seen {
-		paths = append(paths, path)
-	}
-	sort.Strings(paths)
-	return paths
-}
-
-func sqliteSnapshotTargets(targets TargetSet) map[string]parser.AgentType {
-	out := make(map[string]parser.AgentType)
-	for _, path := range sqliteSnapshotPathsForTargets(targets) {
-		out[path] = parser.AgentHermes
-	}
-	for _, path := range targets.Files[parser.AgentZed] {
-		if filepath.Base(filepath.Clean(path)) == "threads.db" {
-			out[filepath.Clean(path)] = parser.AgentZed
+			out[filepath.Clean(path)] = struct{}{}
 		}
 	}
 	return out
-}
-
-func hermesSQLitePaths(stateDB string) []string {
-	return sqliteSnapshotPaths(stateDB)
 }
 
 func sqliteSnapshotPaths(stateDB string) []string {

--- a/internal/remotesync/sqlite_snapshot.go
+++ b/internal/remotesync/sqlite_snapshot.go
@@ -127,6 +127,16 @@ func hermesSQLiteSnapshotIdentity(path string) (int64, time.Time, bool) {
 	return size, modTime, exists
 }
 
+func sqliteSnapshotIdentityForAgent(
+	path string, agent parser.AgentType,
+) (int64, time.Time, bool, error) {
+	if agent == parser.AgentZed {
+		return sqliteSnapshotIdentity(path)
+	}
+	size, modTime, exists := hermesSQLiteSnapshotIdentity(path)
+	return size, modTime, exists, nil
+}
+
 func sqliteSnapshotModTime(stateDB string, modTime time.Time) time.Time {
 	for _, suffix := range []string{"-wal", "-journal"} {
 		info, err := os.Lstat(stateDB + suffix)
@@ -194,14 +204,14 @@ func sqliteSnapshotPathsForTargets(targets TargetSet) []string {
 	return paths
 }
 
-func sqliteSnapshotTargets(targets TargetSet) map[string]struct{} {
-	out := make(map[string]struct{})
+func sqliteSnapshotTargets(targets TargetSet) map[string]parser.AgentType {
+	out := make(map[string]parser.AgentType)
 	for _, path := range sqliteSnapshotPathsForTargets(targets) {
-		out[path] = struct{}{}
+		out[path] = parser.AgentHermes
 	}
 	for _, path := range targets.Files[parser.AgentZed] {
 		if filepath.Base(filepath.Clean(path)) == "threads.db" {
-			out[filepath.Clean(path)] = struct{}{}
+			out[filepath.Clean(path)] = parser.AgentZed
 		}
 	}
 	return out

--- a/internal/remotesync/sqlite_snapshot.go
+++ b/internal/remotesync/sqlite_snapshot.go
@@ -220,10 +220,6 @@ func sqliteSnapshotPaths(stateDB string) []string {
 	}
 }
 
-func hermesStateDBForArchivePath(path string) (string, bool) {
-	return sqliteSnapshotForArchivePath(path)
-}
-
 func sqliteSnapshotForArchivePath(path string) (string, bool) {
 	path = filepath.Clean(path)
 	switch filepath.Base(path) {

--- a/internal/remotesync/sqlite_snapshot.go
+++ b/internal/remotesync/sqlite_snapshot.go
@@ -194,14 +194,14 @@ func sqliteSnapshotPathsForTargets(targets TargetSet) []string {
 	return paths
 }
 
-func sqliteSnapshotTargets(targets TargetSet) map[string]parser.AgentType {
-	out := make(map[string]parser.AgentType)
+func sqliteSnapshotTargets(targets TargetSet) map[string]struct{} {
+	out := make(map[string]struct{})
 	for _, path := range sqliteSnapshotPathsForTargets(targets) {
-		out[path] = parser.AgentHermes
+		out[path] = struct{}{}
 	}
 	for _, path := range targets.Files[parser.AgentZed] {
 		if filepath.Base(filepath.Clean(path)) == "threads.db" {
-			out[filepath.Clean(path)] = parser.AgentZed
+			out[filepath.Clean(path)] = struct{}{}
 		}
 	}
 	return out

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -151,6 +151,9 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 	dirScoped.ForbiddenRoots = append([]string(nil), t.ForbiddenRoots...)
 	fileScoped.ForbiddenRoots = append([]string(nil), t.ForbiddenRoots...)
 	for agent, dirs := range t.Dirs {
+		if emptyCuratedFileScopedAgent(agent, t.Files[agent]) {
+			continue
+		}
 		if _, ok := t.Files[agent]; ok &&
 			!verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 			if fileScoped.Dirs == nil {
@@ -165,6 +168,9 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 		dirScoped.Dirs[agent] = dirs
 	}
 	for agent, files := range t.Files {
+		if emptyCuratedFileScopedAgent(agent, files) {
+			continue
+		}
 		target := &fileScoped
 		if verbatimFileScopedAgent(agent) || snapshotFileScopedAgent(agent) {
 			target = &dirScoped
@@ -187,6 +193,11 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 		target.ProviderExtraFiles[agent] = files
 	}
 	return dirScoped, fileScoped
+}
+
+func emptyCuratedFileScopedAgent(agent parser.AgentType, files []string) bool {
+	return len(files) == 0 &&
+		(agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot)
 }
 
 // DeltaAllowedRoots returns the trusted base paths a delta-archive file

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -106,6 +106,11 @@ func (t TargetSet) HasFileScopedAgents() bool {
 	return len(t.Files) > 0
 }
 
+func (t TargetSet) isFileScoped(agent parser.AgentType) bool {
+	_, ok := t.Files[agent]
+	return ok
+}
+
 // verbatimFileScopedAgent reports whether a file-scoped agent's
 // curated files are exported byte-for-byte by WriteArchive. Verbatim
 // agents (RooCode) can ride the manifest/delta path: the manifest
@@ -151,10 +156,7 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 	dirScoped.ForbiddenRoots = append([]string(nil), t.ForbiddenRoots...)
 	fileScoped.ForbiddenRoots = append([]string(nil), t.ForbiddenRoots...)
 	for agent, dirs := range t.Dirs {
-		if emptyCuratedFileScopedAgent(agent, t.Files[agent]) {
-			continue
-		}
-		if _, ok := t.Files[agent]; ok &&
+		if t.isFileScoped(agent) &&
 			!verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 			if fileScoped.Dirs == nil {
 				fileScoped.Dirs = make(map[parser.AgentType][]string)
@@ -168,9 +170,6 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 		dirScoped.Dirs[agent] = dirs
 	}
 	for agent, files := range t.Files {
-		if emptyCuratedFileScopedAgent(agent, files) {
-			continue
-		}
 		target := &fileScoped
 		if verbatimFileScopedAgent(agent) || snapshotFileScopedAgent(agent) {
 			target = &dirScoped
@@ -195,11 +194,6 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 	return dirScoped, fileScoped
 }
 
-func emptyCuratedFileScopedAgent(agent parser.AgentType, files []string) bool {
-	return len(files) == 0 &&
-		(agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot)
-}
-
 // DeltaAllowedRoots returns the trusted base paths a delta-archive file
 // may resolve under: every non-file-scoped agent directory, the
 // verbatim file-scoped agents' curated files (exact matches only —
@@ -215,7 +209,7 @@ func (t TargetSet) DeltaAllowedRoots() []string {
 		if parser.RemoteSyncExcludedAgent(agent) {
 			continue
 		}
-		if _, fileScoped := t.Files[agent]; fileScoped {
+		if t.isFileScoped(agent) {
 			continue
 		}
 		for _, dir := range dirs {
@@ -229,14 +223,6 @@ func (t TargetSet) DeltaAllowedRoots() []string {
 			continue
 		}
 		if verbatimFileScopedAgent(agent) || snapshotFileScopedAgent(agent) {
-			if len(files) == 0 {
-				for _, dir := range t.Dirs[agent] {
-					if !forbidden.within(dir) {
-						roots = append(roots, dir)
-					}
-				}
-				continue
-			}
 			for _, file := range files {
 				if !forbidden.within(file) {
 					roots = append(roots, file)

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -113,18 +113,35 @@ func (t TargetSet) isFileScoped(agent parser.AgentType) bool {
 
 // verbatimFileScopedAgent reports whether a file-scoped agent's
 // curated files are exported byte-for-byte by WriteArchive. Verbatim
-// agents (RooCode) can ride the manifest/delta path: the manifest
-// advertises exactly the files the archive streams, so one changed
-// transcript transfers alone. Sanitizing agents (Windsurf rewrites
-// its state DB) must stay on the full-archive flow, and new
-// file-scoped agents default to sanitized until added here.
+// agents (RooCode, Kilo Legacy, Cursor, VS Code Copilot) can ride the
+// manifest/delta path: the manifest advertises exactly the files the
+// archive streams, so one changed transcript transfers alone.
+// Sanitizing agents (Windsurf rewrites its state DB) must stay on the
+// full-archive flow, and new file-scoped agents default to sanitized
+// until added here.
 func verbatimFileScopedAgent(agent parser.AgentType) bool {
 	return agent == parser.AgentRooCode || agent == parser.AgentKiloLegacy ||
 		agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot
 }
 
+// snapshotFileScopedAgent reports whether a file-scoped agent's
+// curated files are exported as consistent SQLite snapshots rather
+// than raw bytes. Snapshot agents ride the manifest/delta path like
+// verbatim agents; the manifest advertises the snapshot's logical
+// identity instead of the raw file's.
 func snapshotFileScopedAgent(agent parser.AgentType) bool {
 	return agent == parser.AgentZed
+}
+
+// emptyFileScopeAgent reports whether an agent's root stays
+// advertised with an explicitly empty curated file list when
+// discovery finds no sessions. Retaining the empty scope keeps a
+// stale client request authorized after the last session is deleted,
+// so the manifest can go empty and the client mirror evicts the
+// remaining copies instead of failing the sync. Agents without this
+// trait drop the root entirely when nothing is discovered.
+func emptyFileScopeAgent(agent parser.AgentType) bool {
+	return agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot
 }
 
 // HasSanitizedFileScopedAgents reports whether any agent's export is

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -182,7 +182,7 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 	dirScoped.ExtraFiles = t.ExtraFiles
 	for agent, files := range t.ProviderExtraFiles {
 		target := &dirScoped
-		if _, fileScopedAgent := t.Files[agent]; fileScopedAgent &&
+		if t.isFileScoped(agent) &&
 			!verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 			target = &fileScoped
 		}

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -218,6 +218,14 @@ func (t TargetSet) DeltaAllowedRoots() []string {
 			continue
 		}
 		if verbatimFileScopedAgent(agent) || snapshotFileScopedAgent(agent) {
+			if len(files) == 0 {
+				for _, dir := range t.Dirs[agent] {
+					if !forbidden.within(dir) {
+						roots = append(roots, dir)
+					}
+				}
+				continue
+			}
 			for _, file := range files {
 				if !forbidden.within(file) {
 					roots = append(roots, file)

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -114,7 +114,12 @@ func (t TargetSet) HasFileScopedAgents() bool {
 // its state DB) must stay on the full-archive flow, and new
 // file-scoped agents default to sanitized until added here.
 func verbatimFileScopedAgent(agent parser.AgentType) bool {
-	return agent == parser.AgentRooCode || agent == parser.AgentKiloLegacy
+	return agent == parser.AgentRooCode || agent == parser.AgentKiloLegacy ||
+		agent == parser.AgentCursor || agent == parser.AgentVSCodeCopilot
+}
+
+func snapshotFileScopedAgent(agent parser.AgentType) bool {
+	return agent == parser.AgentZed
 }
 
 // HasSanitizedFileScopedAgents reports whether any agent's export is
@@ -122,7 +127,7 @@ func verbatimFileScopedAgent(agent parser.AgentType) bool {
 // manifest/delta path cannot model.
 func (t TargetSet) HasSanitizedFileScopedAgents() bool {
 	for agent := range t.Files {
-		if !verbatimFileScopedAgent(agent) {
+		if !verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 			return true
 		}
 	}
@@ -146,7 +151,8 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 	dirScoped.ForbiddenRoots = append([]string(nil), t.ForbiddenRoots...)
 	fileScoped.ForbiddenRoots = append([]string(nil), t.ForbiddenRoots...)
 	for agent, dirs := range t.Dirs {
-		if _, ok := t.Files[agent]; ok && !verbatimFileScopedAgent(agent) {
+		if _, ok := t.Files[agent]; ok &&
+			!verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 			if fileScoped.Dirs == nil {
 				fileScoped.Dirs = make(map[parser.AgentType][]string)
 			}
@@ -160,7 +166,7 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 	}
 	for agent, files := range t.Files {
 		target := &fileScoped
-		if verbatimFileScopedAgent(agent) {
+		if verbatimFileScopedAgent(agent) || snapshotFileScopedAgent(agent) {
 			target = &dirScoped
 		}
 		if target.Files == nil {
@@ -172,7 +178,7 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 	for agent, files := range t.ProviderExtraFiles {
 		target := &dirScoped
 		if _, fileScopedAgent := t.Files[agent]; fileScopedAgent &&
-			!verbatimFileScopedAgent(agent) {
+			!verbatimFileScopedAgent(agent) && !snapshotFileScopedAgent(agent) {
 			target = &fileScoped
 		}
 		if target.ProviderExtraFiles == nil {
@@ -211,7 +217,7 @@ func (t TargetSet) DeltaAllowedRoots() []string {
 		if parser.RemoteSyncExcludedAgent(agent) {
 			continue
 		}
-		if verbatimFileScopedAgent(agent) {
+		if verbatimFileScopedAgent(agent) || snapshotFileScopedAgent(agent) {
 			for _, file := range files {
 				if !forbidden.within(file) {
 					roots = append(roots, file)

--- a/internal/server/huma_routes_remote_sync.go
+++ b/internal/server/huma_routes_remote_sync.go
@@ -43,9 +43,13 @@ func (s *Server) humaRemoteSyncTargets(
 	if _, ok := s.db.(*db.DB); !ok {
 		return nil, apiError(http.StatusNotImplemented, "not available in remote mode")
 	}
+	targets, err := remotesync.ResolveTargets(s.ingestionConfig())
+	if err != nil {
+		return nil, apiError(http.StatusInternalServerError, err.Error())
+	}
 	return &remoteSyncTargetsOutput{
 		ProtocolVersion: strconv.Itoa(remotesync.ProtocolVersion),
-		Body:            remotesync.ResolveTargets(s.ingestionConfig()),
+		Body:            targets,
 	}, nil
 }
 
@@ -75,7 +79,11 @@ func (s *Server) remoteSyncManifestHTTP(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "invalid manifest request", http.StatusBadRequest)
 		return
 	}
-	allowed := remotesync.ResolveTargets(s.ingestionConfig())
+	allowed, err := remotesync.ResolveTargets(s.ingestionConfig())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	manifestTargets, ok := remotesync.SelectAllowedTargets(allowed, req)
 	if !ok {
 		http.Error(w, "remote sync target is not allowed", http.StatusForbidden)
@@ -130,7 +138,11 @@ func (s *Server) remoteSyncArchiveHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid archive request", http.StatusBadRequest)
 		return
 	}
-	allowed := remotesync.ResolveTargets(s.ingestionConfig())
+	allowed, err := remotesync.ResolveTargets(s.ingestionConfig())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	archiveTargets, ok := remotesync.SelectAllowedTargets(allowed, req.TargetSet)
 	if !ok {
 		http.Error(w, "remote sync target is not allowed", http.StatusForbidden)
@@ -156,7 +168,6 @@ func (s *Server) remoteSyncArchiveHTTP(w http.ResponseWriter, r *http.Request) {
 		gz = gzip.NewWriter(archiveWriter)
 		out = gz
 	}
-	var err error
 	if deltaMode {
 		err = remotesync.WriteArchiveFiles(out, allowed, files)
 	} else {

--- a/internal/server/huma_routes_remote_sync_internal_test.go
+++ b/internal/server/huma_routes_remote_sync_internal_test.go
@@ -575,6 +575,54 @@ func TestRemoteSyncArchiveRejectsDeltaForFileScopedAgent(t *testing.T) {
 	assert.NotContains(t, archiveW.Body.String(), "extension secret value")
 }
 
+func TestRemoteSyncArchiveRejectsUnauthorizedVSCodeWorkspaceInFullArchive(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	vscodeRoot := filepath.Join(dir, "Code", "User")
+	workspaceDir := filepath.Join(vscodeRoot, "workspaceStorage", "allowed")
+	chatPath := filepath.Join(workspaceDir, "chatSessions", "01234567-89ab-cdef-0123-456789abcdef.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(chatPath), 0o755))
+	require.NoError(t, os.WriteFile(chatPath, []byte(`{"id":"chat"}`), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workspaceDir, "workspace.json"), []byte(`{"folder":"/repo"}`), 0o644,
+	))
+	srv := New(config.Config{
+		Host:        "127.0.0.1",
+		Port:        8080,
+		DataDir:     dir,
+		DBPath:      dbPath,
+		AuthToken:   "remote-token",
+		RequireAuth: false,
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVSCodeCopilot: {vscodeRoot},
+		},
+	}, database, nil)
+	handler := currentRemoteSyncHandler(srv.Handler())
+	targetReq := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)
+	targetReq.Header.Set("Authorization", "Bearer remote-token")
+	targetW := httptest.NewRecorder()
+	handler.ServeHTTP(targetW, targetReq)
+	require.Equal(t, http.StatusOK, targetW.Code, targetW.Body.String())
+	var targets remotesync.TargetSet
+	require.NoError(t, json.Unmarshal(targetW.Body.Bytes(), &targets))
+	unauthorized := filepath.Join(vscodeRoot, "workspaceStorage", "other", "workspace.json")
+	targets.Files[parser.AgentVSCodeCopilot] = append(
+		targets.Files[parser.AgentVSCodeCopilot], unauthorized,
+	)
+	payload, err := json.Marshal(remotesync.ArchiveRequest{TargetSet: targets})
+	require.NoError(t, err)
+	archiveReq := httptest.NewRequest(
+		http.MethodPost, "/api/v1/remote-sync/archive", bytes.NewReader(payload),
+	)
+	archiveReq.Header.Set("Authorization", "Bearer remote-token")
+	archiveReq.Header.Set("Content-Type", "application/json")
+	archiveW := httptest.NewRecorder()
+	handler.ServeHTTP(archiveW, archiveReq)
+
+	assert.Equal(t, http.StatusForbidden, archiveW.Code, archiveW.Body.String())
+}
+
 func TestRemoteSyncArchiveWindsurfStreamsSanitizedStateDB(t *testing.T) {
 	handler, targets, _ := newWindsurfRemoteSyncServer(t)
 	payload, err := json.Marshal(targets)

--- a/internal/server/huma_routes_remote_sync_internal_test.go
+++ b/internal/server/huma_routes_remote_sync_internal_test.go
@@ -218,6 +218,46 @@ func TestIssue1492AuthenticatedVSCodeWorkspacePresentChatMissingEvictsMirror(t *
 	archiveW := post("/api/v1/remote-sync/archive", remotesync.ArchiveRequest{TargetSet: stale})
 	require.Equal(t, http.StatusOK, archiveW.Code, archiveW.Body.String())
 	assert.Empty(t, tarEntries(t, archiveW.Body.Bytes()))
+	require.NoError(t, os.WriteFile(chat, []byte(`{"id":"chat"}`), 0o644))
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	dataDir := t.TempDir()
+	clientDB, err := db.Open(filepath.Join(dataDir, "client.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clientDB.Close()) })
+	sync := func() {
+		_, err := (remotesync.HTTPSync{
+			Host: "vscode-host", URL: ts.URL, Token: "remote-token",
+			DataDir: dataDir, DB: clientDB,
+		}).Run(t.Context())
+		require.NoError(t, err)
+	}
+	sync()
+	mirrorRoot := remotesync.MirrorDir(dataDir, "vscode-host")
+	mirrorContains := func(name string) bool {
+		found := false
+		err := filepath.Walk(mirrorRoot, func(path string, info os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if !info.IsDir() && filepath.Base(path) == name {
+				found = true
+			}
+			return nil
+		})
+		if err != nil && !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+		return found
+	}
+	assert.True(t, mirrorContains(filepath.Base(chat)))
+	assert.True(t, mirrorContains(filepath.Base(workspace)))
+
+	require.NoError(t, os.Remove(chat))
+	sync()
+	assert.False(t, mirrorContains(filepath.Base(chat)))
+	assert.False(t, mirrorContains(filepath.Base(workspace)))
 }
 
 func TestIssue1492AuthenticatedEmptyCuratedCredentialDecoys(t *testing.T) {

--- a/internal/server/huma_routes_remote_sync_internal_test.go
+++ b/internal/server/huma_routes_remote_sync_internal_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/remotesync"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 func newRemoteSyncServer(t *testing.T) (*Server, http.Handler, string) {
@@ -60,6 +62,68 @@ func currentRemoteSyncHandler(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func TestIssue1492AuthenticatedHTTPMirrorImportUsesCuratedTargets(t *testing.T) {
+	dir := t.TempDir()
+	serverDBPath := filepath.Join(dir, "server.db")
+	serverDB := dbtest.OpenTestDBAt(t, serverDBPath)
+	claudeRoot := filepath.Join(dir, "claude")
+	cursorRoot := filepath.Join(dir, "cursor")
+	transcript := filepath.Join(claudeRoot, "session.jsonl")
+	cursorFile := filepath.Join(cursorRoot, "project", "agent-transcripts", "session.jsonl")
+	decoy := filepath.Join(cursorRoot, "project", "mcp_auth.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcript), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(cursorFile), 0o755))
+	require.NoError(t, os.WriteFile(transcript, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-08-24T12:00:00Z", "authenticated mirror").String()), 0o644))
+	require.NoError(t, os.WriteFile(cursorFile, []byte("cursor transcript"), 0o644))
+	require.NoError(t, os.WriteFile(decoy, []byte("secret"), 0o600))
+
+	srv := New(config.Config{
+		Host: "127.0.0.1", Port: 8080, DataDir: dir, DBPath: serverDBPath,
+		AuthToken: "remote-token", RequireAuth: true,
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeRoot}, parser.AgentCursor: {cursorRoot},
+		},
+	}, serverDB, nil)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	for _, token := range []string{"", "wrong-token"} {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/remote-sync/targets", nil)
+		require.NoError(t, err)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		req.Header.Set(remotesync.ProtocolHeader, strconv.Itoa(remotesync.ProtocolVersion))
+		resp, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	dataDir := t.TempDir()
+	clientDB, err := db.Open(filepath.Join(dataDir, "client.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clientDB.Close()) })
+	stats, err := (remotesync.HTTPSync{
+		Host: "authenticated-host", URL: ts.URL, Token: "remote-token",
+		DataDir: dataDir, DB: clientDB,
+	}).Run(t.Context())
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, stats.SessionsTotal, 1)
+
+	var mirrorFiles []string
+	require.NoError(t, filepath.Walk(remotesync.MirrorDir(dataDir, "authenticated-host"),
+		func(path string, info os.FileInfo, walkErr error) error {
+			if walkErr != nil || info.IsDir() {
+				return walkErr
+			}
+			mirrorFiles = append(mirrorFiles, filepath.Base(path))
+			return nil
+		}))
+	assert.NotContains(t, mirrorFiles, "mcp_auth.json")
 }
 
 func TestRemoteSyncTargetsRequiresBearerAndBypassesHostCheck(t *testing.T) {

--- a/internal/server/huma_routes_remote_sync_internal_test.go
+++ b/internal/server/huma_routes_remote_sync_internal_test.go
@@ -166,6 +166,137 @@ func TestIssue1492AuthenticatedAllCuratedFilesVanishedLifecycle(t *testing.T) {
 	assert.Empty(t, tarEntries(t, archiveW.Body.Bytes()))
 }
 
+func TestIssue1492AuthenticatedVSCodeWorkspacePresentChatMissingEvictsMirror(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "server.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	root := filepath.Join(dir, "vscode")
+	workspaceDir := filepath.Join(root, "workspaceStorage", "hash")
+	workspace := filepath.Join(workspaceDir, "workspace.json")
+	chat := filepath.Join(workspaceDir, "chatSessions", "01234567-89ab-cdef-0123-456789abcdef.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(chat), 0o755))
+	require.NoError(t, os.WriteFile(workspace, []byte(`{"folder":"/repo"}`), 0o644))
+	require.NoError(t, os.WriteFile(chat, []byte(`{"id":"chat"}`), 0o644))
+	srv := New(config.Config{
+		Host: "127.0.0.1", Port: 8080, DataDir: dir, DBPath: dbPath,
+		AuthToken: "remote-token", RequireAuth: true,
+		AgentDirs: map[parser.AgentType][]string{parser.AgentVSCodeCopilot: {root}},
+	}, database, nil)
+	handler := currentRemoteSyncHandler(srv.Handler())
+
+	get := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)
+	get.Header.Set("Authorization", "Bearer remote-token")
+	getW := httptest.NewRecorder()
+	handler.ServeHTTP(getW, get)
+	require.Equal(t, http.StatusOK, getW.Code, getW.Body.String())
+	var stale remotesync.TargetSet
+	require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &stale))
+	require.Contains(t, stale.Files[parser.AgentVSCodeCopilot], chat)
+	require.Contains(t, stale.Files[parser.AgentVSCodeCopilot], workspace)
+	require.NoError(t, os.Remove(chat))
+
+	post := func(path string, body any) *httptest.ResponseRecorder {
+		payload, err := json.Marshal(body)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer remote-token")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w
+	}
+	manifestW := post("/api/v1/remote-sync/manifest", stale)
+	require.Equal(t, http.StatusOK, manifestW.Code, manifestW.Body.String())
+	manifestReader, err := gzip.NewReader(bytes.NewReader(manifestW.Body.Bytes()))
+	require.NoError(t, err)
+	manifestBody, err := io.ReadAll(manifestReader)
+	require.NoError(t, err)
+	require.NoError(t, manifestReader.Close())
+	var manifest remotesync.Manifest
+	require.NoError(t, json.Unmarshal(manifestBody, &manifest))
+	assert.Empty(t, manifest.Files)
+	archiveW := post("/api/v1/remote-sync/archive", remotesync.ArchiveRequest{TargetSet: stale})
+	require.Equal(t, http.StatusOK, archiveW.Code, archiveW.Body.String())
+	assert.Empty(t, tarEntries(t, archiveW.Body.Bytes()))
+}
+
+func TestIssue1492AuthenticatedEmptyCuratedCredentialDecoys(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "server.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	cursorRoot := filepath.Join(dir, "cursor")
+	vscodeRoot := filepath.Join(dir, "vscode")
+	cursorDecoy := filepath.Join(cursorRoot, "mcp_auth.json")
+	vscodeDecoy := filepath.Join(vscodeRoot, "User", "settings.json")
+	for _, path := range []string{cursorDecoy, vscodeDecoy} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("credential decoy"), 0o600))
+	}
+	srv := New(config.Config{
+		Host: "127.0.0.1", Port: 8080, DataDir: dir, DBPath: dbPath,
+		AuthToken: "remote-token", RequireAuth: true,
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCursor: {cursorRoot}, parser.AgentVSCodeCopilot: {vscodeRoot},
+		},
+	}, database, nil)
+	handler := currentRemoteSyncHandler(srv.Handler())
+	get := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)
+	get.Header.Set("Authorization", "Bearer remote-token")
+	getW := httptest.NewRecorder()
+	handler.ServeHTTP(getW, get)
+	require.Equal(t, http.StatusOK, getW.Code, getW.Body.String())
+	var targets remotesync.TargetSet
+	require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &targets))
+	for _, agent := range []parser.AgentType{parser.AgentCursor, parser.AgentVSCodeCopilot} {
+		_, ok := targets.Files[agent]
+		assert.True(t, ok)
+		assert.Empty(t, targets.Files[agent])
+	}
+
+	post := func(path string, body any) *httptest.ResponseRecorder {
+		payload, err := json.Marshal(body)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer remote-token")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w
+	}
+	manifestW := post("/api/v1/remote-sync/manifest", targets)
+	require.Equal(t, http.StatusOK, manifestW.Code, manifestW.Body.String())
+	manifestReader, err := gzip.NewReader(bytes.NewReader(manifestW.Body.Bytes()))
+	require.NoError(t, err)
+	manifestBody, err := io.ReadAll(manifestReader)
+	require.NoError(t, err)
+	require.NoError(t, manifestReader.Close())
+	var manifest remotesync.Manifest
+	require.NoError(t, json.Unmarshal(manifestBody, &manifest))
+	assert.Empty(t, manifest.Files)
+	archiveW := post("/api/v1/remote-sync/archive", remotesync.ArchiveRequest{TargetSet: targets})
+	require.Equal(t, http.StatusOK, archiveW.Code, archiveW.Body.String())
+	assert.Empty(t, tarEntries(t, archiveW.Body.Bytes()))
+	deltaW := post("/api/v1/remote-sync/archive", remotesync.ArchiveRequest{
+		TargetSet: targets, DeltaFiles: []string{cursorDecoy, vscodeDecoy},
+	})
+	assert.Equal(t, http.StatusForbidden, deltaW.Code)
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	dataDir := t.TempDir()
+	clientDB, err := db.Open(filepath.Join(dataDir, "client.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clientDB.Close()) })
+	stats, err := (remotesync.HTTPSync{
+		Host: "empty-host", URL: ts.URL, Token: "remote-token",
+		DataDir: dataDir, DB: clientDB,
+	}).Run(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.SessionsTotal)
+	_, mirrorErr := os.Stat(remotesync.MirrorDir(dataDir, "empty-host"))
+	assert.True(t, os.IsNotExist(mirrorErr), "empty target sync must not create a decoy mirror")
+}
+
 func TestRemoteSyncTargetsRequiresBearerAndBypassesHostCheck(t *testing.T) {
 	_, handler, _ := newRemoteSyncServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)

--- a/internal/server/huma_routes_remote_sync_internal_test.go
+++ b/internal/server/huma_routes_remote_sync_internal_test.go
@@ -126,6 +126,46 @@ func TestIssue1492AuthenticatedHTTPMirrorImportUsesCuratedTargets(t *testing.T) 
 	assert.NotContains(t, mirrorFiles, "mcp_auth.json")
 }
 
+func TestIssue1492AuthenticatedAllCuratedFilesVanishedLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "server.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	root := filepath.Join(dir, "cursor")
+	file := filepath.Join(root, "project", "agent-transcripts", "01234567-89ab-cdef-0123-456789abcdef.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(file), 0o755))
+	require.NoError(t, os.WriteFile(file, []byte("cursor transcript"), 0o644))
+	srv := New(config.Config{
+		Host: "127.0.0.1", Port: 8080, DataDir: dir, DBPath: dbPath,
+		AuthToken: "remote-token", RequireAuth: true,
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCursor: {root}},
+	}, database, nil)
+	handler := currentRemoteSyncHandler(srv.Handler())
+	get := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)
+	get.Header.Set("Authorization", "Bearer remote-token")
+	getW := httptest.NewRecorder()
+	handler.ServeHTTP(getW, get)
+	require.Equal(t, http.StatusOK, getW.Code, getW.Body.String())
+	var stale remotesync.TargetSet
+	require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &stale))
+	require.NoError(t, os.Remove(file))
+
+	post := func(path string, body any) *httptest.ResponseRecorder {
+		payload, err := json.Marshal(body)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer remote-token")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w
+	}
+	manifestW := post("/api/v1/remote-sync/manifest", stale)
+	require.Equal(t, http.StatusOK, manifestW.Code, manifestW.Body.String())
+	archiveW := post("/api/v1/remote-sync/archive", remotesync.ArchiveRequest{TargetSet: stale})
+	require.Equal(t, http.StatusOK, archiveW.Code, archiveW.Body.String())
+	assert.Empty(t, tarEntries(t, archiveW.Body.Bytes()))
+}
+
 func TestRemoteSyncTargetsRequiresBearerAndBypassesHostCheck(t *testing.T) {
 	_, handler, _ := newRemoteSyncServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)


### PR DESCRIPTION
Remote sync currently recurses through broad Cursor, VS Code Copilot, and Zed roots, copying unrelated editor data into persistent mirrors. This bounds those providers to parser-required Cursor transcripts, VS Code chat sessions plus workspace metadata, and standalone Zed `threads.db` snapshots through the existing `TargetSet.Files`, manifest, delta, mirror, and import paths.

Empty Cursor and VS Code roots remain explicitly file-scoped when no sessions are discovered, so credential, settings, cache, and extension files cannot fall back to recursive export. When the last VS Code chat disappears, its workspace metadata is omitted with the stale chat and the persistent mirror evicts both entries.

Zed exports use SQLite online backup so committed WAL data becomes one consistent database without transferring WAL or SHM sidecars. Authenticated target selection preserves root and symlink confinement, unchanged mirrors produce no repeat fetch, and deletion races evict stale files without widening the selected set.

Closes #1492.
