### PR TITLE
docs: make platform install commands separately copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ accounts, everything local.
 
 ## Install
 
+### macOs/ Linux
 ```bash
-# macOS / Linux
 curl -fsSL https://agentsview.io/install.sh | bash
+```
 
-# Windows
+### Windows
+```bash
 powershell -ExecutionPolicy ByPass -c "irm https://agentsview.io/install.ps1 | iex"
 ```
 


### PR DESCRIPTION
Separates the macOS/Linux and Windows installer commands into their own code blocks, so GitHub’s copy button copies only the selected platform command.