### PR TITLE
fix(parser): skip Gemini sessions without metadata

### DIFF
--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -6,13 +6,17 @@ import (
 	"bytes"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/tidwall/gjson"
 )
+
+var errGeminiMissingSessionID = errors.New("missing sessionId")
 
 // geminiTokens holds token usage counts from a Gemini message.
 type geminiTokens struct {
@@ -83,7 +87,8 @@ func (p *geminiProvider) parseSession(
 			)
 		}
 	}
-	if bytes.IndexByte(data, '\n') >= 0 {
+	if strings.EqualFold(filepath.Ext(path), ".jsonl") ||
+		bytes.IndexByte(data, '\n') >= 0 {
 		return parseGeminiJSONL(
 			path, project, machine, info, data,
 		)
@@ -99,7 +104,7 @@ func parseGeminiJSONObject(
 	sessionID := root.Get("sessionId").Str
 	if sessionID == "" {
 		return nil, nil, fmt.Errorf(
-			"missing sessionId in %s", path,
+			"%w in %s", errGeminiMissingSessionID, path,
 		)
 	}
 
@@ -208,7 +213,7 @@ func parseGeminiJSONL(
 	}
 	if sessionID == "" {
 		return nil, nil, fmt.Errorf(
-			"missing sessionId in %s", path,
+			"%w in %s", errGeminiMissingSessionID, path,
 		)
 	}
 

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -123,6 +123,44 @@ func TestParseGeminiSession_JSONLStream(t *testing.T) {
 	)
 }
 
+func TestGeminiProviderMissingSessionIDIsUnsupportedSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "multiple records",
+			content: strings.Join([]string{
+				`{"id":"m1","type":"user","content":[{"text":"orphaned prompt"}]}`,
+				`{"id":"m2","type":"gemini","content":"orphaned reply"}`,
+			}, "\n"),
+		},
+		{
+			name:    "single record without final newline",
+			content: `{"id":"m1","type":"user","content":[{"text":"orphaned prompt"}]}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := createTestFile(t, "session.jsonl", test.content)
+			provider := newGeminiTestProvider(t)
+
+			outcome, err := provider.Parse(t.Context(), ParseRequest{Source: SourceRef{
+				Provider:       AgentGemini,
+				DisplayPath:    path,
+				FingerprintKey: path,
+				Opaque:         geminiSource{Path: path},
+			}})
+
+			require.NoError(t, err)
+			assert.True(t, outcome.ResultSetComplete)
+			assert.Equal(t, SkipUnsupportedSource, outcome.SkipReason)
+			assert.Empty(t, outcome.Results)
+			assert.Empty(t, outcome.SourceErrors)
+		})
+	}
+}
+
 func TestParseGeminiSession_JSONLStreamLargeRecord(t *testing.T) {
 	largeContent := strings.Repeat("x", 16*1024*1024+1)
 	content := strings.Join([]string{
@@ -557,7 +595,7 @@ func TestParseGeminiSession_EdgeCases(t *testing.T) {
 		content := `{"projectHash":"abc","startTime":"2024-01-01T00:00:00Z","lastUpdated":"2024-01-01T00:00:00Z","messages":[]}`
 		path := createTestFile(t, "session.json", content)
 		_, _, err := parseGeminiTestSession(t, path, "my_project", "local")
-		assert.Error(t, err)
+		assert.ErrorIs(t, err, errGeminiMissingSessionID)
 	})
 }
 

--- a/internal/parser/gemini_provider.go
+++ b/internal/parser/gemini_provider.go
@@ -100,6 +100,16 @@ func (p *geminiProvider) Parse(
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
 	sess, msgs, err := p.parseSession(path, req.Source.ProjectHint, machine)
 	if err != nil {
+		if errors.Is(err, errGeminiMissingSessionID) {
+			// A session-shaped file without Gemini's metadata record has no
+			// stable identity to archive. Treat the durable source shape as an
+			// unsupported skip so reconciliation can advance without claiming
+			// authority to retire previously archived sessions.
+			return ParseOutcome{
+				ResultSetComplete: true,
+				SkipReason:        SkipUnsupportedSource,
+			}, nil
+		}
 		return ParseOutcome{}, err
 	}
 	if sess == nil {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5395,6 +5395,65 @@ func TestSyncPathsGeminiJSONL(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "gemini:"+sessionID, 2)
 }
 
+func TestReconcileGeminiMissingSessionIDDoesNotBlockHealthySources(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentGemini)
+	hash := "abcdef1234567890"
+	damagedPath := env.writeGeminiSession(
+		t,
+		filepath.Join(
+			"tmp", hash, "chats",
+			"session-missing-id.jsonl",
+		),
+		strings.Join([]string{
+			`{"sessionId":"reconcile-damaged","projectHash":"` + hash + `","startTime":"` + tsEarly + `","lastUpdated":"` + tsEarlyS5 + `","kind":"main"}`,
+			`{"id":"m1","timestamp":"` + tsEarly + `","type":"user","content":[{"text":"archived prompt"}]}`,
+		}, "\n"),
+	)
+	initial := env.engine.SyncAll(t.Context(), nil)
+	require.Zero(t, initial.Failed)
+	assertSessionMessageCount(t, env.db, "gemini:reconcile-damaged", 1)
+
+	require.NoError(t, os.WriteFile(
+		damagedPath,
+		[]byte(strings.Join([]string{
+			`{"id":"m1","timestamp":"` + tsEarly + `","type":"user","content":[{"text":"orphaned prompt"}]}`,
+			`{"id":"m2","timestamp":"` + tsEarlyS5 + `","type":"gemini","content":"orphaned reply"}`,
+		}, "\n")),
+		0o600,
+	))
+	validPath := env.writeGeminiSession(
+		t,
+		filepath.Join(
+			"tmp", hash, "chats",
+			"session-valid.jsonl",
+		),
+		strings.Join([]string{
+			`{"sessionId":"reconcile-valid","projectHash":"` + hash + `","startTime":"` + tsEarly + `","lastUpdated":"` + tsEarlyS5 + `","kind":"main"}`,
+			`{"id":"m1","timestamp":"` + tsEarly + `","type":"user","content":[{"text":"healthy prompt"}]}`,
+		}, "\n"),
+	)
+
+	reconcile := func() {
+		t.Helper()
+		err := env.engine.ReconcileWatchRoots(
+			t.Context(), []string{env.geminiDir}, false,
+		)
+		require.NoError(t, err)
+		result := env.engine.LastReconciliationResult()
+		assert.True(t, result.Complete)
+		assert.Zero(t, result.ProviderFailures)
+	}
+
+	reconcile()
+	assertSessionMessageCount(t, env.db, "gemini:reconcile-valid", 1)
+	assertSessionMessageCount(t, env.db, "gemini:reconcile-damaged", 1)
+
+	reconcile()
+	assertSessionMessageCount(t, env.db, "gemini:reconcile-damaged", 1)
+	assert.FileExists(t, damagedPath)
+	assert.FileExists(t, validPath)
+}
+
 func TestSyncPathsGeminiProjectMetadataEventRefreshesProject(t *testing.T) {
 	env := setupTestEnv(t)
 


### PR DESCRIPTION
## Summary

- classify Gemini files with no `sessionId` as unsupported sources instead of fatal parser failures
- recognize `.jsonl` by extension even when a message-only file contains one record and no trailing newline
- let watch-root reconciliation continue through healthy siblings while preserving any archived session for the incomplete path

Closes #1518.

## Test plan

- `go test -tags fts5 ./internal/parser -run 'TestGeminiProviderMissingSessionIDIsUnsupportedSource|TestParseGeminiSession_EdgeCases' -count=1`
- `go test -tags fts5 ./internal/sync -run TestReconcileGeminiMissingSessionIDDoesNotBlockHealthySources -count=1`
- `go test -tags fts5 ./internal/parser ./internal/sync -count=1`
- `go vet -tags fts5 ./...`
- `go test -short -tags fts5 ./...` passes for every package except the existing environment-sensitive `TestRunDaemonArtifactExchangeConnectsToIPv6LocalhostListener` failure on nv1
- `go test -short -tags fts5 ./cmd/agentsview -skip '^TestRunDaemonArtifactExchangeConnectsToIPv6LocalhostListener$' -count=1`
