### PR TITLE
ci(desktop): run the full desktop unit suite in the Windows lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,8 +370,8 @@ jobs:
             Start-Sleep -Seconds (10 * $attempt)
           }
 
-      - name: Run Windows desktop update tests
-        run: cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml --lib install_downloaded_update
+      - name: Run Windows desktop unit tests
+        run: cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml --lib
 
   integration:
     runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}


### PR DESCRIPTION
The Desktop Unit Tests (Windows) lane was added in #488 to cover the Windows update stop/install ordering, and its cargo test invocation filtered to `install_downloaded_update`. That filter means the rest of the desktop crate's unit tests run nowhere in CI: this is the only lane that executes desktop Rust tests, and the macOS desktop workflows only build artifacts.

This drops the filter so the lane runs the whole `--lib` suite. The full test module already compiles in this lane today (cargo's test filtering happens at runtime), so the added cost is only test execution, which is sub-second. Platform-gated tests are behind `#[cfg(unix)]` and the remaining tests use tempdirs and missing-binary spawns that behave the same on Windows.

Reviewers: the only change is the test step in `.github/workflows/ci.yml` (name + dropped filter).