### PR TITLE
fix(parser): group Antigravity CLI sessions across git worktrees

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -428,7 +428,11 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // (91: Posit Assistant inferred cache-write normalization. Existing
 // non-Anthropic auto-cached model rows need re-parsing so their persisted
 // uncached prompt remainder is priced as input rather than cache creation.)
-const dataVersion = 91
+// (92: Antigravity CLI workspace project normalization. Existing rows store
+// the raw workspace path from history.jsonl as the project; re-parsing routes
+// it through the shared cwd normalizer so sessions from different git
+// worktrees of the same repo group under one project.)
+const dataVersion = 92
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1032,8 +1032,8 @@ func TestCurrentDataVersionGrokMessageTimestamps(t *testing.T) {
 }
 
 func TestCurrentDataVersionPositAssistantCacheAccounting(t *testing.T) {
-	assert.Equal(t, 91, CurrentDataVersion(),
-		"Posit Assistant cache accounting requires a sequential backfill")
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 91,
+		"version 91 is the data-version boundary for Posit Assistant cache accounting")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bufio"
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json/jsontext"
@@ -80,7 +81,7 @@ type AntigravityCLIParseStatus struct {
 // package-level ParseAntigravityCLISessionWithStatus entrypoint was folded onto
 // the provider.
 func (p *antigravityCLIProvider) parseSessionWithStatus(
-	path, project, machine string,
+	ctx context.Context, path, project, machine string,
 ) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, AntigravityCLIParseStatus, error) {
 	var status AntigravityCLIParseStatus
 	info, err := os.Stat(path)
@@ -246,6 +247,15 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 			project = inferAntigravityProjectFromHistoryFallback(
 				filepath.Join(root, "history.jsonl"), messages, info.ModTime(),
 			)
+		}
+	}
+	// project is the raw workspace filesystem path recorded by history.jsonl.
+	// Run it through the shared cwd normalizer so sessions from different
+	// git worktrees of the same repo resolve to one project, matching how
+	// the Codex and Claude providers normalize their own cwd hints.
+	if project != "" {
+		if p := ExtractProjectFromCwdWithBranchContext(ctx, project, ""); p != "" {
+			project = p
 		}
 	}
 

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -252,10 +252,20 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 	// project is the raw workspace filesystem path recorded by history.jsonl.
 	// Run it through the shared cwd normalizer so sessions from different
 	// git worktrees of the same repo resolve to one project, matching how
-	// the Codex and Claude providers normalize their own cwd hints.
+	// the Codex and Claude providers normalize their own cwd hints. A
+	// path-rewritten parse (remote sync) describes another machine's
+	// filesystem, so it keeps the lexical rules but skips local git-root
+	// discovery: the remote workspace path could name an unrelated
+	// repository that happens to exist on the importing host.
 	if project != "" {
-		if p := ExtractProjectFromCwdWithBranchContext(ctx, project, ""); p != "" {
-			project = p
+		projectCtx := ctx
+		if p.Config.PathRewriter != nil {
+			projectCtx = WithoutFilesystemProjectDiscovery(projectCtx)
+		}
+		if normalized := ExtractProjectFromCwdWithBranchContext(
+			projectCtx, project, "",
+		); normalized != "" {
+			project = normalized
 		}
 	}
 

--- a/internal/parser/antigravity_cli_provider.go
+++ b/internal/parser/antigravity_cli_provider.go
@@ -100,6 +100,7 @@ func (p *antigravityCLIProvider) Parse(
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
 	sess, msgs, usageEvents, status, err := p.parseSessionWithStatus(
+		ctx,
 		src.Path,
 		req.Source.ProjectHint,
 		machine,

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -470,8 +470,8 @@ func TestAntigravityCLIParse_GroupsGitWorktreesUnderOneProject(t *testing.T) {
 	createAntigravityTestDB(t, filepath.Join(cliRoot, "conversations", mainID+".db"))
 	createAntigravityTestDB(t, filepath.Join(cliRoot, "conversations", worktreeID+".db"))
 	mustWrite(t, filepath.Join(cliRoot, "history.jsonl"), []byte(
-		`{"conversationId":"`+mainID+`","workspace":"`+mainRepo+`"}`+"\n"+
-			`{"conversationId":"`+worktreeID+`","workspace":"`+worktree+`"}`+"\n",
+		antigravityCLIHistoryLine(t, mainID, mainRepo)+
+			antigravityCLIHistoryLine(t, worktreeID, worktree),
 	))
 
 	files := discoverAntigravityCLITestSessions(t, cliRoot)
@@ -518,7 +518,7 @@ func TestAntigravityCLIParse_RemoteParseSkipsLocalGitDiscovery(t *testing.T) {
 	id := "11111111-2222-3333-4444-555555555555"
 	createAntigravityTestDB(t, filepath.Join(cliRoot, "conversations", id+".db"))
 	mustWrite(t, filepath.Join(cliRoot, "history.jsonl"), []byte(
-		`{"conversationId":"`+id+`","workspace":"`+worktree+`"}`+"\n",
+		antigravityCLIHistoryLine(t, id, worktree),
 	))
 
 	provider, ok := NewProvider(AgentAntigravityCLI, ProviderConfig{
@@ -1290,6 +1290,20 @@ func TestBuildAntigravityProjectMapRobust(t *testing.T) {
 func mustMkdir(t *testing.T, p string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(p, 0o755), "mkdir %s", p)
+}
+
+// antigravityCLIHistoryLine renders one history.jsonl row with real JSON
+// encoding. Workspace paths must go through json.Marshal because Windows
+// paths contain backslashes, which are escape characters inside a JSON
+// string literal.
+func antigravityCLIHistoryLine(t *testing.T, conversationID, workspace string) string {
+	t.Helper()
+	line, err := json.Marshal(map[string]string{
+		"conversationId": conversationID,
+		"workspace":      workspace,
+	})
+	require.NoError(t, err, "marshal history line")
+	return string(line) + "\n"
 }
 
 func mustWrite(t *testing.T, p string, b []byte) {

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -492,6 +492,54 @@ func TestAntigravityCLIParse_GroupsGitWorktreesUnderOneProject(t *testing.T) {
 		"sessions from different worktrees of the same repo must group under one project")
 }
 
+// TestAntigravityCLIParse_RemoteParseSkipsLocalGitDiscovery guards the remote
+// (path-rewritten) parse path: history.jsonl's workspace names a path on the
+// remote machine, so project attribution must not run git-root discovery on
+// the importing host, where a same-named local checkout would misattribute
+// the session to the local repository. Lexical normalization still applies.
+func TestAntigravityCLIParse_RemoteParseSkipsLocalGitDiscovery(t *testing.T) {
+	skipIfNoGit(t)
+
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "agentsview")
+	mustMkdirAll(t, mainRepo)
+	gitRun(t, mainRepo, "init", "-q", "-b", "main")
+	gitRun(t, mainRepo,
+		"-c", "user.email=test@example.com",
+		"-c", "user.name=Test User",
+		"-c", "commit.gpgsign=false",
+		"commit", "--allow-empty", "-q", "-m", "seed",
+	)
+	worktree := filepath.Join(root, "agentsview-feature")
+	gitRun(t, mainRepo, "worktree", "add", "-q", "-b", "feature", worktree)
+
+	cliRoot := t.TempDir()
+	mustMkdir(t, filepath.Join(cliRoot, "conversations"))
+	id := "11111111-2222-3333-4444-555555555555"
+	createAntigravityTestDB(t, filepath.Join(cliRoot, "conversations", id+".db"))
+	mustWrite(t, filepath.Join(cliRoot, "history.jsonl"), []byte(
+		`{"conversationId":"`+id+`","workspace":"`+worktree+`"}`+"\n",
+	))
+
+	provider, ok := NewProvider(AgentAntigravityCLI, ProviderConfig{
+		Roots:        []string{cliRoot},
+		PathRewriter: func(path string) string { return "remote-host:" + path },
+	})
+	require.True(t, ok)
+	cp, ok := provider.(*antigravityCLIProvider)
+	require.True(t, ok)
+
+	sess, _, _, _, err := cp.parseSessionWithStatus(
+		t.Context(),
+		filepath.Join(cliRoot, "conversations", id+".db"),
+		worktree, "remote-host",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "agentsview_feature", sess.Project,
+		"remote parse must not resolve the workspace against the local checkout")
+}
+
 func TestAntigravityCLIProjectFallbackStrictWindow(t *testing.T) {
 	root := t.TempDir()
 	id := "e0e0e0e0-e1e1-e2e2-e3e3-e4e4e4e4e4e4"

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -92,7 +92,9 @@ func parseAntigravityCLITestSessionWithStatus(
 	t *testing.T, path, project, machine string,
 ) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, AntigravityCLIParseStatus, error) {
 	t.Helper()
-	return newAntigravityCLITestProvider(t).parseSessionWithStatus(path, project, machine)
+	return newAntigravityCLITestProvider(t).parseSessionWithStatus(
+		t.Context(), path, project, machine,
+	)
 }
 
 // parseAntigravityCLITestSession is the no-status convenience wrapper the tests
@@ -406,7 +408,7 @@ func TestAntigravityCLIDiscoverAndParseDB(t *testing.T) {
 	assert.Equal(t, "antigravity-cli:"+id, sess.ID)
 	assert.Equal(t, AgentAntigravityCLI, sess.Agent)
 	assert.Equal(t, dbPath, sess.File.Path)
-	assert.Equal(t, "/tmp/db-proj", sess.Project)
+	assert.Equal(t, "db_proj", sess.Project)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, RoleUser, msgs[0].Role)
 	assert.Equal(t, "db prompt fallback", msgs[0].Content)
@@ -434,7 +436,60 @@ func TestAntigravityCLIProjectFallbackPromptAndProximity(t *testing.T) {
 	sess, msgs, err := parseAntigravityCLITestSession(t, dbPath, "", "m")
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
-	assert.Equal(t, "/tmp/fallback-proj", sess.Project, "should successfully fallback infer project")
+	assert.Equal(t, "fallback_proj", sess.Project, "should successfully fallback infer project")
+}
+
+// TestAntigravityCLIParse_GroupsGitWorktreesUnderOneProject reproduces
+// GitHub issue #1484: two Antigravity CLI sessions recorded from different
+// git worktrees of the same repo must resolve to the same project, matching
+// how the Codex provider already normalizes cwd through
+// ExtractProjectFromCwdWithBranchContext (see
+// TestParseCodexSession_WorktreeBranchFallback).
+func TestAntigravityCLIParse_GroupsGitWorktreesUnderOneProject(t *testing.T) {
+	skipIfNoGit(t)
+
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "agentsview")
+	mustMkdirAll(t, mainRepo)
+	gitRun(t, mainRepo, "init", "-q", "-b", "main")
+	gitRun(t, mainRepo,
+		"-c", "user.email=test@example.com",
+		"-c", "user.name=Test User",
+		"-c", "commit.gpgsign=false",
+		"commit", "--allow-empty", "-q", "-m", "seed",
+	)
+	worktree := filepath.Join(root, "agentsview-feature")
+	gitRun(t, mainRepo, "worktree", "add", "-q", "-b", "feature", worktree)
+
+	cliRoot := t.TempDir()
+	mustMkdir(t, filepath.Join(cliRoot, "conversations"))
+	mainID := "11111111-2222-3333-4444-555555555555"
+	worktreeID := "66666666-7777-8888-9999-000000000000"
+	mustMkdir(t, filepath.Join(cliRoot, "brain", mainID))
+	mustMkdir(t, filepath.Join(cliRoot, "brain", worktreeID))
+	createAntigravityTestDB(t, filepath.Join(cliRoot, "conversations", mainID+".db"))
+	createAntigravityTestDB(t, filepath.Join(cliRoot, "conversations", worktreeID+".db"))
+	mustWrite(t, filepath.Join(cliRoot, "history.jsonl"), []byte(
+		`{"conversationId":"`+mainID+`","workspace":"`+mainRepo+`"}`+"\n"+
+			`{"conversationId":"`+worktreeID+`","workspace":"`+worktree+`"}`+"\n",
+	))
+
+	files := discoverAntigravityCLITestSessions(t, cliRoot)
+	require.Len(t, files, 2, "discover")
+
+	projects := make(map[string]string, 2)
+	for _, f := range files {
+		sess, _, err := parseAntigravityCLITestSession(t, f.Path, f.Project, "test-machine")
+		require.NoError(t, err, "parse %s", f.Path)
+		projects[f.Path] = sess.Project
+	}
+
+	mainSess := projects[filepath.Join(cliRoot, "conversations", mainID+".db")]
+	worktreeSess := projects[filepath.Join(cliRoot, "conversations", worktreeID+".db")]
+	assert.Equal(t, "agentsview", mainSess, "main checkout project")
+	assert.Equal(t, "agentsview", worktreeSess, "worktree project")
+	assert.Equal(t, mainSess, worktreeSess,
+		"sessions from different worktrees of the same repo must group under one project")
 }
 
 func TestAntigravityCLIProjectFallbackStrictWindow(t *testing.T) {

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -3,8 +3,10 @@ package sync_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json/v2"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
 )
@@ -174,6 +177,72 @@ func TestSyncEngineAntigravityCLI_StaleDataVersionRenormalizesProject(t *testing
 	assertSessionProject(t, env.db, sessionID, "my_cli_project")
 	assert.Equal(t, db.CurrentDataVersion(), env.db.GetSessionDataVersion(sessionID),
 		"reparse must restamp the session at the current data version")
+}
+
+// TestSyncEngineAntigravityCLI_DisabledProjectDiscoveryHonoredBySyncAll pins
+// the DisableFilesystemProjectDiscovery contract on the full-sync path:
+// every sync entry point, not just SyncPaths, must put the policy on the
+// context that reaches provider parsing. The fixture workspace is a real git
+// worktree whose repository name differs from the worktree's directory
+// basename, so a full sync that probes the filesystem stores the repository
+// name instead of the lexical basename and fails this test.
+func TestSyncEngineAntigravityCLI_DisabledProjectDiscoveryHonoredBySyncAll(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available in PATH")
+	}
+	gitRun := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	gitRoot := t.TempDir()
+	mainRepo := filepath.Join(gitRoot, "grouping-repo")
+	require.NoError(t, os.MkdirAll(mainRepo, 0o755))
+	gitRun(mainRepo, "init", "-q", "-b", "main")
+	gitRun(mainRepo,
+		"-c", "user.email=test@example.com",
+		"-c", "user.name=Test User",
+		"-c", "commit.gpgsign=false",
+		"commit", "--allow-empty", "-q", "-m", "seed",
+	)
+	worktree := filepath.Join(gitRoot, "feature-checkout")
+	gitRun(mainRepo, "worktree", "add", "-q", "-b", "feature", worktree)
+
+	cliDir := t.TempDir()
+	convDir := filepath.Join(cliDir, "conversations")
+	require.NoError(t, os.MkdirAll(convDir, 0o755))
+	uuid := "bbbbbbbb-2222-4333-8444-cccccccccccc"
+	historyLine, err := json.Marshal(map[string]string{
+		"conversationId": uuid,
+		"workspace":      worktree,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cliDir, "history.jsonl"),
+		append(historyLine, '\n'), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(convDir, uuid+".pb"), []byte("pb-stub"), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(convDir, uuid+".trajectory.json"),
+		[]byte(antigravityCLISingleUserTrajectory(uuid, "hello")), 0o644,
+	))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentAntigravityCLI: {cliDir},
+		},
+		Machine:                           "local",
+		DisableFilesystemProjectDiscovery: true,
+	})
+	defer engine.Close()
+
+	require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
+	assertSessionProject(t, database, "antigravity-cli:"+uuid, "feature_checkout")
 }
 
 func TestSyncEngineAntigravityCLI_ParentLinkArrivalOrder(t *testing.T) {

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -108,8 +108,10 @@ func TestSyncEngineAntigravityCLI_HappyPath(t *testing.T) {
 	})
 	assert.Equal(t, 1, stats.Synced)
 
-	// Verify database ingestion
-	assertSessionProject(t, env.db, "antigravity-cli:"+uuid, "/home/user/my-cli-project")
+	// Verify database ingestion. The stored project is normalized through
+	// the shared cwd/worktree resolver, so the raw workspace path collapses
+	// to its basename with dashes folded to underscores.
+	assertSessionProject(t, env.db, "antigravity-cli:"+uuid, "my_cli_project")
 	// Expected messages:
 	// 1. User: "Check workspace status"
 	// 2. Assistant: "listing files now" (with tool calls and thoughts)
@@ -551,7 +553,7 @@ func TestSyncEngineAntigravityCLI_InferredProjectWithoutConversationID(t *testin
 		{
 			name:        "normalized match within window infers project",
 			rowTime:     base.Add(10 * time.Second),
-			wantProject: workspace,
+			wantProject: "inferred_project",
 		},
 		{
 			name:        "match outside 60s window leaves project empty",
@@ -600,7 +602,7 @@ func TestSyncSingleSessionAntigravityCLI_InferredProjectWithoutConversationID(t 
 	// The file-watcher path must persist the inferred project too.
 	require.NoError(t, env.engine.SyncSingleSession(sessionID))
 
-	assertSessionProject(t, env.db, sessionID, "/home/user/inferred-project-single")
+	assertSessionProject(t, env.db, sessionID, "inferred_project_single")
 	assertSessionMessageCount(t, env.db, sessionID, 1)
 }
 
@@ -635,7 +637,7 @@ func TestSyncPathsAntigravityCLIHistoryOnlyUpdateRefreshesProject(t *testing.T) 
 
 	env.engine.SyncPaths([]string{historyPath})
 
-	assertSessionProject(t, env.db, sessionID, "/home/user/history-arrived")
+	assertSessionProject(t, env.db, sessionID, "history_arrived")
 	assertSessionMessageCount(t, env.db, sessionID, 1)
 }
 
@@ -674,8 +676,8 @@ func TestSyncPathsAntigravityCLIHistoryRetagClearsRemovedProject(t *testing.T) {
 		Skipped:       0,
 		Anomalies:     agyCLIUnknownSchemaAnomaly(2),
 	})
-	assertSessionProject(t, env.db, removedSessionID, "/home/user/removed")
-	assertSessionProject(t, env.db, retaggedSessionID, "/home/user/retagged")
+	assertSessionProject(t, env.db, removedSessionID, "removed")
+	assertSessionProject(t, env.db, retaggedSessionID, "retagged")
 
 	updated := base.Add(time.Minute)
 	retaggedHistory := fmt.Sprintf(
@@ -688,7 +690,7 @@ func TestSyncPathsAntigravityCLIHistoryRetagClearsRemovedProject(t *testing.T) {
 	env.engine.SyncPaths([]string{historyPath})
 
 	assertSessionProject(t, env.db, removedSessionID, "")
-	assertSessionProject(t, env.db, retaggedSessionID, "/home/user/retagged-now")
+	assertSessionProject(t, env.db, retaggedSessionID, "retagged_now")
 	assertSessionMessageCount(t, env.db, removedSessionID, 1)
 	assertSessionMessageCount(t, env.db, retaggedSessionID, 1)
 }

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -128,6 +128,54 @@ func TestSyncEngineAntigravityCLI_HappyPath(t *testing.T) {
 	assert.Equal(t, "listing files now", msgs[1].Content)
 }
 
+// TestSyncEngineAntigravityCLI_StaleDataVersionRenormalizesProject covers
+// archives written before data version 92: their rows store the raw
+// workspace path as the project, and the source files are unchanged, so no
+// fingerprint movement can trigger a reparse. The stale per-session data
+// version alone must defeat the unchanged-source skip so an ordinary
+// incremental sync replaces the raw path with the normalized project name.
+func TestSyncEngineAntigravityCLI_StaleDataVersionRenormalizesProject(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentAntigravityCLI)
+	uuid := "aaaaaaaa-1111-4222-8333-bbbbbbbbbbbb"
+	sessionID := "antigravity-cli:" + uuid
+
+	convDir := filepath.Join(env.antigravityCLIDir, "conversations")
+	require.NoError(t, os.MkdirAll(convDir, 0o755))
+	historyLine := `{"conversationId": "` + uuid +
+		`", "workspace": "/home/user/my-cli-project"}` + "\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(env.antigravityCLIDir, "history.jsonl"),
+		[]byte(historyLine), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(convDir, uuid+".pb"), []byte("pb-stub"), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(convDir, uuid+".trajectory.json"),
+		[]byte(antigravityCLISingleUserTrajectory(uuid, "hello")), 0o644,
+	))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1, Synced: 1})
+	assertSessionProject(t, env.db, sessionID, "my_cli_project")
+
+	// Simulate the archive an older binary left behind: the raw workspace
+	// path stored as the project, stamped with data version 91 -- the last
+	// version whose parser stored workspace paths unnormalized. The current
+	// version must stay above 91 for these rows to reparse.
+	require.NoError(t, env.db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"UPDATE sessions SET project = ?, data_version = 91 WHERE id = ?",
+			"/home/user/my-cli-project", sessionID,
+		)
+		return err
+	}))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1, Synced: 1})
+	assertSessionProject(t, env.db, sessionID, "my_cli_project")
+	assert.Equal(t, db.CurrentDataVersion(), env.db.GetSessionDataVersion(sessionID),
+		"reparse must restamp the session at the current data version")
+}
+
 func TestSyncEngineAntigravityCLI_ParentLinkArrivalOrder(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1687,14 +1687,25 @@ func (e *Engine) applyChangedPathSyncLocked(
 }
 
 // SyncPathsContext is SyncPaths with caller-controlled cancellation. The
+// parsePolicyContext applies engine-level parse policies to ctx. A
+// discovery-disabled engine must carry the policy on every context that
+// reaches provider parsing -- full syncs, streamed reconciliation, changed
+// paths, single-session refreshes, source lookups, and parse diffs -- so a
+// working directory recorded in a transcript is never probed on the local
+// host regardless of which entry point triggered the parse.
+func (e *Engine) parsePolicyContext(ctx context.Context) context.Context {
+	if e.disableProjectDiscovery {
+		return parser.WithoutFilesystemProjectDiscovery(ctx)
+	}
+	return ctx
+}
+
 // file watcher threads the serve shutdown context through here.
 func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) error {
 	if e.refuseWriteInForceParse("SyncPaths") {
 		return nil
 	}
-	if e.disableProjectDiscovery {
-		ctx = parser.WithoutFilesystemProjectDiscovery(ctx)
-	}
+	ctx = e.parsePolicyContext(ctx)
 	stats, tombstoned, err := func() (SyncStats, int, error) {
 		e.syncMu.Lock()
 		defer e.syncMu.Unlock()
@@ -4905,6 +4916,7 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 	if err := ctx.Err(); err != nil {
 		return SyncStats{Aborted: true}, metrics, 0, eligibility, err
 	}
+	ctx = e.parsePolicyContext(ctx)
 	if force {
 		e.clearWatcherOverflowCaches()
 	}
@@ -7108,6 +7120,7 @@ func (e *Engine) syncAllLocked(
 	if ctx.Err() != nil {
 		return SyncStats{Aborted: true}
 	}
+	ctx = e.parsePolicyContext(ctx)
 
 	if recordSyncState {
 		e.recordSyncStarted()
@@ -18255,6 +18268,7 @@ func (e *Engine) findProviderSourceFile(
 	rawSessionID string,
 	storedPath string,
 ) string {
+	ctx = e.parsePolicyContext(ctx)
 	mode := e.providerMigrationModes[def.Type]
 	if mode != parser.ProviderMigrationProviderAuthoritative {
 		return ""
@@ -18314,6 +18328,7 @@ func (e *Engine) providerSessionSourceMtime(
 	rawSessionID string,
 	storedPath string,
 ) int64 {
+	ctx = e.parsePolicyContext(ctx)
 	factory, ok := e.providerFactories[def.Type]
 	if !ok || factory == nil {
 		return 0
@@ -18710,6 +18725,7 @@ func (e *Engine) SyncSingleSessionContext(
 			sessionID,
 		)
 	}
+	ctx = e.parsePolicyContext(ctx)
 	e.syncMu.Lock()
 	preserved := false
 	sessionsChanged := false

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -47,6 +47,7 @@ func NewDiffEngine(database *db.DB, cfg EngineConfig) *Engine {
 // no skip cache, no sync state. It holds the engine's sync mutex for
 // the duration.
 func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDiffReport, error) {
+	ctx = e.parsePolicyContext(ctx)
 	e.syncMu.Lock()
 	defer e.syncMu.Unlock()
 	defer e.retentionBudget().scavengeIfNeeded()


### PR DESCRIPTION
Antigravity CLI sessions from different git worktrees of the same repo now group under one project in the Sessions sidebar, matching how Codex and Claude sessions already behave. Previously the raw workspace filesystem path from `history.jsonl` was stored as `ParsedSession.Project` with no normalization, so each worktree showed up as its own project group (#1484).

The fix threads `context.Context` through `parseSessionWithStatus` and routes the workspace path through the shared `ExtractProjectFromCwdWithBranchContext` normalizer, which resolves a worktree path back to its parent repository name. Because of this, stored Antigravity project names change shape: raw paths like `/home/user/my-cli-project` become `my_cli_project`. The parser data version is bumped to 92 so archives written before the change reparse: their sources are byte-identical, so nothing fingerprint-side could otherwise trigger the renormalization, and the same repo would stay split between a path-named group and the normalized one. A sync integration test pins that boundary by stamping a raw-path row with version 91 and asserting an ordinary incremental sync renormalizes it.

Remote (SSH-imported) parses keep the lexical normalization but skip local git-root discovery, gated on `Config.PathRewriter` — the same remote signal the Cursor provider uses. Without the gate, a remote workspace path that also exists on the importing host would be attributed to the importer's local repository.

The engine's `DisableFilesystemProjectDiscovery` option now holds on every entry point: previously only `SyncPaths` put the policy on the parse context, so a discovery-disabled engine running a full sync, streamed reconciliation, single-session refresh, source lookup, or parse diff would still walk the local filesystem for git roots. A `parsePolicyContext` helper is applied at each funnel, and an integration test drives a git-worktree workspace through `SyncAll` on a discovery-disabled engine to prove the stored project stays lexical.

Review focus: the normalizer call and remote gate in `internal/parser/antigravity_cli.go`, the data-version bump in `internal/db/db.go`, and the `parsePolicyContext` call sites in `internal/sync/engine.go`; the rest is context plumbing and test fixtures (history.jsonl lines are built with `json.Marshal` so Windows workspace paths with backslashes survive JSON decoding).
