### PR TITLE
feat(parser): add Cursor IDE (GUI) session provider

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -838,15 +838,68 @@ add an archived or maintained mirror without replacing the original identity.
   confirms local chat persistence and the separate SQLite history index.
   Cursor support on the official forum documents the
   [`~/.cursor/projects/<project>/agent-transcripts` layout](https://forum.cursor.com/t/chat-history-gone-after-pc-restart-agent-transcripts-files-emptied-how-to-recover/158251/5)
-  and identifies `state.vscdb` as metadata. Cursor's public GitHub
-  organization was also searched 2026-07-19; no transcript schema or producer
-  source was found.
+  and identifies `state.vscdb` as metadata **for this CLI producer**. That
+  characterization does not extend to Cursor IDE (the GUI editor, see below):
+  for the GUI, `state.vscdb` is the only transcript store, not metadata beside
+  one. Cursor's public GitHub organization was also searched 2026-07-19; no
+  transcript schema or producer source was found.
 - **Usage and cost:** The consumed text/JSONL transcripts have no reliable
   per-message token, cache, reasoning, credit, or monetary-cost fields.
 - **Agentsview:** `internal/parser/cursor.go`,
   `internal/parser/cursor_paths.go`, and `internal/parser/cursor_provider.go`;
   workspace identity uses a filesystem-backed unique-match resolver, while
   role and attribution boundaries are reconstructed from Markdown.
+
+## Cursor IDE (`cursor-ide`)
+
+- **Format:** A shared VS Code-style global-state SQLite database
+  (`state.vscdb`), whose `cursorDiskKV` key-value table holds one JSON blob
+  per key: `composerData:<uuid>` is one chat session, and
+  `bubbleId:<composerId>:<bubbleUuid>` is one turn of that session. This is a
+  distinct product and store from Cursor Agent (the CLI, above): the GUI
+  writes no `agent-transcripts` files at all.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Cursor's public GitHub organization and first-party docs were
+  searched 2026-08-25; no `cursorDiskKV`, `composerData`, or `bubbleId` schema
+  was found. This is consistent with two independent local-history tools
+  hitting the same wall (see agentsview issue #1515): a VS Code local-history
+  extension states it does not decode Cursor's DB-only chat blobs, and `ctx`
+  (`https://github.com/ctxrs/ctx`, checked at `8c6d670`) reads only
+  `agent-transcripts` and contains none of those three strings. Evidence here
+  is instead direct inspection of a live local `state.vscdb` (macOS, 86MB,
+  `PRAGMA quick_check` = `ok`): `composerData` documents observed at `_v: 16`
+  and bubble documents at `_v: 3`. `composerData.createdAt` and
+  `.lastUpdatedAt` are epoch milliseconds; bubble `.createdAt` is a separate
+  ISO-8601 string encoding. `composerData.fullConversationHeadersOnly` is the
+  session's turn order (`bubbleId` + `type`: `1` user, `2` assistant); the
+  sibling `conversationMap` field, structurally an alternative inline-message
+  store, was observed empty (`{}`) on every real conversation inspected,
+  including multi-hundred-KB ones, so it is not a usable source at this schema
+  version. An assistant bubble's tool call is inline on that bubble's
+  `toolFormerData` (name, `rawArgs`, `result`), unlike Claude's separate
+  call/result blocks. `workspaceIdentifier.uri.fsPath` and
+  `trackedGitRepos[].{repoPath,branches[].branchName}` give cwd and git
+  branch. The issue's reporter additionally documents that a Cursor version
+  update (3.16.29) has shrunk or wiped some users' `cursorDiskKV` rows, so the
+  parser tolerates a `fullConversationHeadersOnly` entry whose `bubbleId` row
+  is missing rather than failing the whole session.
+- **Usage and cost:** No per-message or per-session token, cache, reasoning,
+  credit, or monetary-cost fields were observed in `composerData` or bubble
+  documents. Agentsview emits no usage events for this agent; cost is
+  unpriced.
+- **Agentsview:** `internal/parser/cursor_ide.go` and
+  `internal/parser/cursor_ide_provider.go`, built on the shared
+  `multiSessionContainerSourceSet` framework (see Zed, below). Fingerprinting
+  never hashes the full database (86MB+ locally, 500MB+ reported in the wild):
+  a container-level fingerprint uses whole-file size, composite mtime, and a
+  SQLite transaction-state hash over just the database and WAL headers, so a
+  rewrite that leaves size and mtime unchanged still misses the skip cache; a
+  member-level fingerprint digests every parse input of that one composer (the
+  raw `composerData` document plus its bubble rows' keys and values), so an
+  equal-length bubble rewrite, a header reorder, or a rename that leaves
+  `lastUpdatedAt` untouched still reads as changed. A chat deleted inside
+  Cursor IDE is retired through stored-source-hint tombstones on `state.vscdb`
+  change events and through complete-container ownership reconciliation.
 
 ## Amp (`amp`)
 

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -24,6 +24,7 @@ describe("KNOWN_AGENTS", () => {
       "kilo-legacy",
       "openhands",
       "cursor",
+      "cursor-ide",
       "amp",
       "zencoder",
       "zed",

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -18,6 +18,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "kilo-legacy", color: "var(--accent-purple)", label: "Kilo (legacy)" },
   { name: "openhands", color: "var(--accent-teal)", label: "OpenHands" },
   { name: "cursor", color: "var(--accent-black)" },
+  { name: "cursor-ide", color: "var(--accent-black)", label: "Cursor IDE" },
   { name: "amp", color: "var(--accent-coral)", label: "Amp" },
   { name: "zencoder", color: "var(--accent-red)", label: "Zencoder" },
   { name: "zed", color: "var(--accent-green)", label: "Zed" },

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -369,6 +369,33 @@ func (db *DB) GetAllMessages(
 	return msgs, nil
 }
 
+// ListMessageSourceUUIDs returns the non-empty source_uuid values of a
+// session's messages, in ordinal order. The sync engine uses it to verify
+// that a truncated shared-container reparse still contains every archived
+// message before letting it replace the stored transcript.
+func (db *DB) ListMessageSourceUUIDs(
+	ctx context.Context, sessionID string,
+) ([]string, error) {
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT source_uuid
+		FROM messages
+		WHERE session_id = ? AND source_uuid != ''
+		ORDER BY ordinal ASC`, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("querying message source uuids: %w", err)
+	}
+	defer rows.Close()
+	var uuids []string
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			return nil, fmt.Errorf("scanning message source uuid: %w", err)
+		}
+		uuids = append(uuids, uuid)
+	}
+	return uuids, rows.Err()
+}
+
 func (db *DB) GetResumeModelCounts(
 	ctx context.Context, sessionID string,
 ) ([]ModelCount, error) {

--- a/internal/parser/capabilities_sync_test.go
+++ b/internal/parser/capabilities_sync_test.go
@@ -53,6 +53,11 @@ func TestProviderSyncSemanticsDeclarations(t *testing.T) {
 		AgentZed: {
 			UnchangedResults: UnchangedResultMTime,
 		},
+		AgentCursorIDE: {
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+			UnchangedResults:                    UnchangedResultMTimeAndHash,
+		},
 		AgentKiro: {
 			UnchangedResults:                    UnchangedResultMTimeAndHash,
 			FingerprintHashRequiredForFreshness: true,

--- a/internal/parser/cursor_ide.go
+++ b/internal/parser/cursor_ide.go
@@ -60,6 +60,31 @@ func openCursorIDEDB(dbPath string) (*sql.DB, error) {
 	return db, nil
 }
 
+// cursorIDEQuerier is the shared read surface of *sql.DB and *sql.Tx: the
+// composer readers accept it so one snapshot transaction can serve the
+// composer document, its bubbles, and the content digest together.
+type cursorIDEQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// beginCursorIDESnapshot opens one deferred read transaction on the
+// read-only connection. Cursor keeps writing to state.vscdb while agentsview
+// reads it; without a transaction every query sees its own implicit
+// snapshot, so the digest could hash newer bubble bytes than the messages
+// just parsed, and the freshness gates would then trust a digest that does
+// not describe the stored transcript.
+func beginCursorIDESnapshot(
+	ctx context.Context, conn *sql.DB, composerID string,
+) (*sql.Tx, error) {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"beginning cursor IDE snapshot for %s: %w", composerID, err)
+	}
+	return tx, nil
+}
+
 // CursorIDEComposerExists reports whether a composerData row with the given
 // composer ID exists in state.vscdb.
 func CursorIDEComposerExists(dbPath, composerID string) bool {
@@ -135,11 +160,11 @@ type cursorIDEComposerMeta struct {
 // cursorDiskKV key index and only ever reads the one composer's rows, never
 // the whole multi-hundred-MB database.
 func cursorIDEComposerDigest(
-	ctx context.Context, conn *sql.DB, composerID string, rawComposer []byte,
+	ctx context.Context, q cursorIDEQuerier, composerID string, rawComposer []byte,
 ) (string, error) {
 	h := fnv.New64a()
 	_, _ = h.Write(rawComposer)
-	rows, err := conn.QueryContext(ctx,
+	rows, err := q.QueryContext(ctx,
 		`SELECT key, value FROM cursorDiskKV WHERE key >= ? AND key < ? ORDER BY key`,
 		cursorIDEBubbleKeyPrefix+composerID+":",
 		cursorIDEBubbleKeyPrefix+composerID+";",
@@ -171,8 +196,13 @@ func cursorIDEComposerDigest(
 func loadCursorIDEComposerMeta(
 	ctx context.Context, conn *sql.DB, composerID string,
 ) (cursorIDEComposerMeta, bool, error) {
+	tx, err := beginCursorIDESnapshot(ctx, conn, composerID)
+	if err != nil {
+		return cursorIDEComposerMeta{}, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
 	var raw []byte
-	err := conn.QueryRowContext(ctx,
+	err = tx.QueryRowContext(ctx,
 		`SELECT value FROM cursorDiskKV WHERE key = ?`,
 		cursorIDEComposerKeyPrefix+composerID,
 	).Scan(&raw)
@@ -192,7 +222,7 @@ func loadCursorIDEComposerMeta(
 		return cursorIDEComposerMeta{}, false, fmt.Errorf(
 			"decoding cursor IDE composer %s: %w", composerID, err)
 	}
-	digest, err := cursorIDEComposerDigest(ctx, conn, composerID, raw)
+	digest, err := cursorIDEComposerDigest(ctx, tx, composerID, raw)
 	if err != nil {
 		return cursorIDEComposerMeta{}, false, err
 	}
@@ -245,10 +275,10 @@ type cursorIDEBubble struct {
 }
 
 func loadCursorIDEBubble(
-	ctx context.Context, conn *sql.DB, composerID, bubbleID string,
+	ctx context.Context, q cursorIDEQuerier, composerID, bubbleID string,
 ) (*cursorIDEBubble, error) {
 	var raw []byte
-	err := conn.QueryRowContext(ctx,
+	err := q.QueryRowContext(ctx,
 		`SELECT value FROM cursorDiskKV WHERE key = ?`,
 		cursorIDEBubbleKeyPrefix+composerID+":"+bubbleID,
 	).Scan(&raw)
@@ -368,8 +398,13 @@ func parseCursorIDEComposer(
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	tx, err := beginCursorIDESnapshot(ctx, conn, composerID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
 	var raw []byte
-	err := conn.QueryRowContext(ctx,
+	err = tx.QueryRowContext(ctx,
 		`SELECT value FROM cursorDiskKV WHERE key = ?`,
 		cursorIDEComposerKeyPrefix+composerID,
 	).Scan(&raw)
@@ -396,7 +431,7 @@ func parseCursorIDEComposer(
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		bubble, err := loadCursorIDEBubble(ctx, conn, composerID, header.BubbleID)
+		bubble, err := loadCursorIDEBubble(ctx, tx, composerID, header.BubbleID)
 		if err != nil {
 			return nil, err
 		}
@@ -450,7 +485,7 @@ func parseCursorIDEComposer(
 		endedAt = startedAt
 	}
 
-	digest, err := cursorIDEComposerDigest(ctx, conn, composerID, raw)
+	digest, err := cursorIDEComposerDigest(ctx, tx, composerID, raw)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/parser/cursor_ide.go
+++ b/internal/parser/cursor_ide.go
@@ -455,6 +455,10 @@ func parseCursorIDEComposer(
 		if !ok {
 			continue
 		}
+		// The bubble UUID is each message's stable identity; the engine's
+		// truncation guard compares it against the archived messages so a
+		// gap transcript can never drop archived content unnoticed.
+		msg.SourceUUID = header.BubbleID
 		messages = append(messages, msg)
 	}
 	if len(messages) == 0 {

--- a/internal/parser/cursor_ide.go
+++ b/internal/parser/cursor_ide.go
@@ -1,0 +1,491 @@
+package parser
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json/v2"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Cursor IDE (the GUI editor) is a completely different session store from
+// Cursor Agent (the CLI, see cursor.go): it is a VS Code-style global-state
+// SQLite database, state.vscdb, whose cursorDiskKV table holds one JSON blob
+// per key. A "composerData:<uuid>" key is one chat session; its
+// fullConversationHeadersOnly array lists that session's turns in order, each
+// pointing at a sibling "bubbleId:<composerId>:<bubbleUuid>" row holding the
+// turn's text. conversationMap, the alternative inline-message field, was
+// observed empty on every real (including large) conversation, so it is not a
+// usable source in this schema version (_v: 16 composerData / _v: 3 bubbles).
+const (
+	cursorIDEIDPrefix = "cursor-ide:"
+	// CursorIDEDBRelPath is the container's path relative to the provider
+	// root: Cursor IDE's default dirs point straight at globalStorage, and
+	// state.vscdb lives directly inside it (no subdirectory).
+	CursorIDEDBRelPath         = "state.vscdb"
+	cursorIDEComposerKeyPrefix = "composerData:"
+	cursorIDEBubbleKeyPrefix   = "bubbleId:"
+
+	// cursorIDEBubbleTypeUser and cursorIDEBubbleTypeAssistant are the
+	// cursorDiskKV bubble "type" values.
+	cursorIDEBubbleTypeUser      = 1
+	cursorIDEBubbleTypeAssistant = 2
+)
+
+// cursorIDEDefaultDirs returns platform-specific default directories holding
+// state.vscdb.
+func cursorIDEDefaultDirs() []string {
+	return []string{
+		// macOS
+		"Library/Application Support/Cursor/User/globalStorage",
+		// Linux
+		".config/Cursor/User/globalStorage",
+		// Windows
+		"AppData/Roaming/Cursor/User/globalStorage",
+	}
+}
+
+func openCursorIDEDB(dbPath string) (*sql.DB, error) {
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&_busy_timeout=3000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening cursor IDE db %s: %w", dbPath, err)
+	}
+	return db, nil
+}
+
+// CursorIDEComposerExists reports whether a composerData row with the given
+// composer ID exists in state.vscdb.
+func CursorIDEComposerExists(dbPath, composerID string) bool {
+	if dbPath == "" || composerID == "" || !IsValidSessionID(composerID) {
+		return false
+	}
+	conn, err := openCursorIDEDB(dbPath)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+	var one int
+	err = conn.QueryRow(
+		`SELECT 1 FROM cursorDiskKV WHERE key = ? LIMIT 1`,
+		cursorIDEComposerKeyPrefix+composerID,
+	).Scan(&one)
+	return err == nil
+}
+
+// cursorIDEComposerHeader is one entry of fullConversationHeadersOnly: the
+// bubble to look up and its rendered role, in transcript order.
+type cursorIDEComposerHeader struct {
+	BubbleID string `json:"bubbleId"`
+	Type     int    `json:"type"`
+}
+
+type cursorIDEGitBranch struct {
+	BranchName        string `json:"branchName"`
+	LastInteractionAt int64  `json:"lastInteractionAt"`
+}
+
+type cursorIDEGitRepo struct {
+	RepoPath string               `json:"repoPath"`
+	Branches []cursorIDEGitBranch `json:"branches"`
+}
+
+type cursorIDEWorkspaceIdentifier struct {
+	URI struct {
+		FSPath string `json:"fsPath"`
+	} `json:"uri"`
+}
+
+// cursorIDEComposerDoc is the composerData:<uuid> document. Only the fields
+// the parser needs are modeled; the rest of the blob (rich editor state,
+// capability flags, encryption keys for Cursor's own cloud sync, ...) is
+// ignored.
+type cursorIDEComposerDoc struct {
+	Headers             []cursorIDEComposerHeader    `json:"fullConversationHeadersOnly"`
+	Name                string                       `json:"name"`
+	CreatedAt           int64                        `json:"createdAt"`
+	LastUpdatedAt       int64                        `json:"lastUpdatedAt"`
+	WorkspaceIdentifier cursorIDEWorkspaceIdentifier `json:"workspaceIdentifier"`
+	TrackedGitRepos     []cursorIDEGitRepo           `json:"trackedGitRepos"`
+}
+
+// cursorIDEComposerMeta is a per-composer descriptor for the engine's
+// freshness check: the composer's lastUpdatedAt plus a content digest over
+// every byte the parser reads for that composer.
+type cursorIDEComposerMeta struct {
+	rawID         string
+	lastUpdatedAt int64
+	digest        string
+}
+
+// cursorIDEComposerDigest hashes every parse input of one composer: the raw
+// composerData document (covering name, cwd, git branch, timestamps, and the
+// header order) and the key plus value bytes of every stored bubble row in
+// the composer's key range. Any committed edit to the composer -- including
+// an equal-length in-place bubble rewrite, a header reorder, or a
+// metadata-only change that leaves lastUpdatedAt untouched -- changes the
+// digest, so the engine's unchanged-result filter and freshness gates cannot
+// discard it. The range scan (":" to its successor ";") stays on the
+// cursorDiskKV key index and only ever reads the one composer's rows, never
+// the whole multi-hundred-MB database.
+func cursorIDEComposerDigest(
+	ctx context.Context, conn *sql.DB, composerID string, rawComposer []byte,
+) (string, error) {
+	h := fnv.New64a()
+	_, _ = h.Write(rawComposer)
+	rows, err := conn.QueryContext(ctx,
+		`SELECT key, value FROM cursorDiskKV WHERE key >= ? AND key < ? ORDER BY key`,
+		cursorIDEBubbleKeyPrefix+composerID+":",
+		cursorIDEBubbleKeyPrefix+composerID+";",
+	)
+	if err != nil {
+		return "", fmt.Errorf(
+			"digesting cursor IDE bubbles for %s: %w", composerID, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var key string
+		var value []byte
+		if err := rows.Scan(&key, &value); err != nil {
+			return "", fmt.Errorf(
+				"scanning cursor IDE bubble for digest %s: %w", composerID, err)
+		}
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(key))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write(value)
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf(
+			"digesting cursor IDE bubbles for %s: %w", composerID, err)
+	}
+	return strconv.FormatUint(h.Sum64(), 16), nil
+}
+
+func loadCursorIDEComposerMeta(
+	ctx context.Context, conn *sql.DB, composerID string,
+) (cursorIDEComposerMeta, bool, error) {
+	var raw []byte
+	err := conn.QueryRowContext(ctx,
+		`SELECT value FROM cursorDiskKV WHERE key = ?`,
+		cursorIDEComposerKeyPrefix+composerID,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return cursorIDEComposerMeta{}, false, nil
+	}
+	if err != nil {
+		return cursorIDEComposerMeta{}, false, fmt.Errorf(
+			"loading cursor IDE composer meta %s: %w", composerID, err)
+	}
+	var doc cursorIDEComposerDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		// Malformed is not missing: a row that exists but no longer decodes
+		// must fail loudly instead of fingerprinting as a vanished composer,
+		// which would let a complete container parse replace the archived
+		// session.
+		return cursorIDEComposerMeta{}, false, fmt.Errorf(
+			"decoding cursor IDE composer %s: %w", composerID, err)
+	}
+	digest, err := cursorIDEComposerDigest(ctx, conn, composerID, raw)
+	if err != nil {
+		return cursorIDEComposerMeta{}, false, err
+	}
+	return cursorIDEComposerMeta{
+		rawID:         composerID,
+		lastUpdatedAt: doc.LastUpdatedAt,
+		digest:        digest,
+	}, true, nil
+}
+
+// listCursorIDEComposerIDs returns every composer ID in state.vscdb.
+func listCursorIDEComposerIDs(ctx context.Context, conn *sql.DB) ([]string, error) {
+	rows, err := conn.QueryContext(ctx,
+		`SELECT key FROM cursorDiskKV WHERE key LIKE ? ORDER BY key`,
+		cursorIDEComposerKeyPrefix+"%",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing cursor IDE composers: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("scanning cursor IDE composer key: %w", err)
+		}
+		id := strings.TrimPrefix(key, cursorIDEComposerKeyPrefix)
+		if IsValidSessionID(id) {
+			ids = append(ids, id)
+		}
+	}
+	return ids, rows.Err()
+}
+
+// cursorIDEToolFormerData is a bubble's embedded tool call: unlike Claude's
+// separate call/result blocks, Cursor stores one tool invocation (input,
+// status, and output) inline on the assistant bubble that issued it.
+type cursorIDEToolFormerData struct {
+	ToolCallID string `json:"toolCallId"`
+	Name       string `json:"name"`
+	RawArgs    string `json:"rawArgs"`
+	Result     string `json:"result"`
+}
+
+type cursorIDEBubble struct {
+	Type           int                      `json:"type"`
+	Text           string                   `json:"text"`
+	CreatedAt      string                   `json:"createdAt"`
+	ToolFormerData *cursorIDEToolFormerData `json:"toolFormerData"`
+}
+
+func loadCursorIDEBubble(
+	ctx context.Context, conn *sql.DB, composerID, bubbleID string,
+) (*cursorIDEBubble, error) {
+	var raw []byte
+	err := conn.QueryRowContext(ctx,
+		`SELECT value FROM cursorDiskKV WHERE key = ?`,
+		cursorIDEBubbleKeyPrefix+composerID+":"+bubbleID,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		// Cursor version updates have been observed to shrink or wipe rows
+		// out of cursorDiskKV; a missing bubble is a gap in the transcript,
+		// not a fatal error.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf(
+			"loading cursor IDE bubble %s:%s: %w", composerID, bubbleID, err)
+	}
+	var bubble cursorIDEBubble
+	if err := json.Unmarshal(raw, &bubble); err != nil {
+		// Malformed is not missing: silently skipping a stored bubble that
+		// no longer decodes would emit a truncated transcript that
+		// force-replaces the archived full one.
+		return nil, fmt.Errorf(
+			"decoding cursor IDE bubble %s:%s: %w", composerID, bubbleID, err)
+	}
+	return &bubble, nil
+}
+
+// cursorIDEMessageFromBubble converts one decoded bubble into a
+// ParsedMessage. Returns ok=false for a bubble with no visible content (pure
+// bookkeeping bubbles such as in-flight generation placeholders).
+func cursorIDEMessageFromBubble(ordinal int, bubble cursorIDEBubble) (ParsedMessage, bool) {
+	content := strings.TrimSpace(bubble.Text)
+	msg := ParsedMessage{
+		Ordinal:       ordinal,
+		ContentLength: len(content),
+		Timestamp:     parseTimestamp(bubble.CreatedAt),
+	}
+
+	switch bubble.Type {
+	case cursorIDEBubbleTypeUser:
+		if content == "" {
+			return ParsedMessage{}, false
+		}
+		msg.Role = RoleUser
+		msg.Content = content
+		return msg, true
+
+	case cursorIDEBubbleTypeAssistant:
+		msg.Role = RoleAssistant
+		msg.Content = content
+		if bubble.ToolFormerData == nil {
+			if content == "" {
+				return ParsedMessage{}, false
+			}
+			return msg, true
+		}
+		tfd := bubble.ToolFormerData
+		msg.HasToolUse = true
+		msg.ToolCalls = []ParsedToolCall{{
+			ToolUseID: tfd.ToolCallID,
+			ToolName:  tfd.Name,
+			Category:  NormalizeToolCategory(tfd.Name),
+			InputJSON: tfd.RawArgs,
+		}}
+		if tfd.Result != "" {
+			quoted, err := json.Marshal(tfd.Result)
+			if err == nil {
+				msg.ToolResults = []ParsedToolResult{{
+					ToolUseID:     tfd.ToolCallID,
+					ContentLength: len(tfd.Result),
+					ContentRaw:    string(quoted),
+				}}
+			}
+		}
+		return msg, true
+
+	default:
+		return ParsedMessage{}, false
+	}
+}
+
+// cursorIDELatestBranch picks the branch with the most recent
+// lastInteractionAt across every tracked git repo, matching the workspace
+// picker Cursor itself shows.
+func cursorIDELatestBranch(repos []cursorIDEGitRepo) string {
+	var branch string
+	var latest int64
+	for _, repo := range repos {
+		for _, b := range repo.Branches {
+			if b.BranchName == "" {
+				continue
+			}
+			if branch == "" || b.LastInteractionAt > latest {
+				branch = b.BranchName
+				latest = b.LastInteractionAt
+			}
+		}
+	}
+	return branch
+}
+
+func cursorIDECwd(doc cursorIDEComposerDoc) string {
+	if fsPath := doc.WorkspaceIdentifier.URI.FSPath; fsPath != "" {
+		return fsPath
+	}
+	if len(doc.TrackedGitRepos) > 0 {
+		return doc.TrackedGitRepos[0].RepoPath
+	}
+	return ""
+}
+
+// parseCursorIDEComposer decodes one composer into a ParseResult using an
+// already-open connection. Returns (nil, nil) for a composer with zero
+// renderable messages (an empty draft, or one whose bubbles were all wiped by
+// a Cursor version update).
+func parseCursorIDEComposer(
+	ctx context.Context, conn *sql.DB, dbPath, composerID, machine string,
+	dbInfo os.FileInfo,
+) (*ParseResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var raw []byte
+	err := conn.QueryRowContext(ctx,
+		`SELECT value FROM cursorDiskKV WHERE key = ?`,
+		cursorIDEComposerKeyPrefix+composerID,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf(
+			"loading cursor IDE composer %s: %w", composerID, err)
+	}
+	var doc cursorIDEComposerDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		// Malformed is not missing: a nil result would read as a clean
+		// no-session and retire the archived transcript.
+		return nil, fmt.Errorf(
+			"decoding cursor IDE composer %s: %w", composerID, err)
+	}
+	if len(doc.Headers) == 0 {
+		return nil, nil
+	}
+
+	var messages []ParsedMessage
+	for _, header := range doc.Headers {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		bubble, err := loadCursorIDEBubble(ctx, conn, composerID, header.BubbleID)
+		if err != nil {
+			return nil, err
+		}
+		if bubble == nil {
+			continue
+		}
+		if bubble.Type == 0 {
+			// A shrunk or partially-written bubble row can lose its type
+			// field while the header still records the turn's role; fall
+			// back so the turn is not silently dropped. A bubble that
+			// carries its own type stays authoritative.
+			bubble.Type = header.Type
+		}
+		msg, ok := cursorIDEMessageFromBubble(len(messages), *bubble)
+		if !ok {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	if len(messages) == 0 {
+		return nil, nil
+	}
+
+	var firstMessage string
+	userCount := 0
+	for _, m := range messages {
+		if m.Role == RoleUser {
+			userCount++
+			if firstMessage == "" && m.Content != "" {
+				firstMessage = truncate(
+					strings.ReplaceAll(m.Content, "\n", " "), 300,
+				)
+			}
+		}
+	}
+
+	startedAt := cursorIDETime(doc.CreatedAt)
+	if startedAt.IsZero() && len(messages) > 0 {
+		startedAt = messages[0].Timestamp
+	}
+	// lastUpdatedAt has been observed lagging behind the bubbles' own
+	// timestamps, so the session ends at the later of the two: a stale
+	// composer stamp must not place EndedAt before the final message.
+	endedAt := cursorIDETime(doc.LastUpdatedAt)
+	for _, m := range messages {
+		if m.Timestamp.After(endedAt) {
+			endedAt = m.Timestamp
+		}
+	}
+	if endedAt.IsZero() {
+		endedAt = startedAt
+	}
+
+	digest, err := cursorIDEComposerDigest(ctx, conn, composerID, raw)
+	if err != nil {
+		return nil, err
+	}
+	cwd := cursorIDECwd(doc)
+	sess := ParsedSession{
+		ID:               cursorIDEIDPrefix + composerID,
+		Agent:            AgentCursorIDE,
+		Machine:          machine,
+		Project:          ExtractProjectFromCwd(cwd),
+		Cwd:              cwd,
+		GitBranch:        cursorIDELatestBranch(doc.TrackedGitRepos),
+		SessionName:      doc.Name,
+		FirstMessage:     firstMessage,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(messages),
+		UserMessageCount: userCount,
+		File: FileInfo{
+			Path:  VirtualSourcePath(dbPath, composerID),
+			Size:  dbInfo.Size(),
+			Mtime: endedAt.UnixNano(),
+			Hash:  digest,
+		},
+	}
+
+	return &ParseResult{Session: sess, Messages: messages}, nil
+}
+
+// cursorIDETime converts an epoch-milliseconds stamp (composerData
+// createdAt/lastUpdatedAt) to UTC. Zero stays zero. Bubble timestamps use a
+// different encoding (ISO-8601 strings) and go through parseTimestamp
+// instead.
+func cursorIDETime(epochMS int64) time.Time {
+	if epochMS == 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(epochMS).UTC()
+}

--- a/internal/parser/cursor_ide.go
+++ b/internal/parser/cursor_ide.go
@@ -453,6 +453,17 @@ func parseCursorIDEComposer(
 		}
 		msg, ok := cursorIDEMessageFromBubble(len(messages), *bubble)
 		if !ok {
+			if bubble.Type == cursorIDEBubbleTypeUser ||
+				bubble.Type == cursorIDEBubbleTypeAssistant {
+				// A conversational bubble that exists but renders nothing is
+				// indistinguishable from a row emptied in place (e.g. "{}"),
+				// so it takes the same truncation flag as a missing row and
+				// the engine verifies against the archive before the
+				// transcript can lose an archived turn. In-flight generation
+				// placeholders flag transiently and clear on the next parse;
+				// non-conversational bookkeeping bubble types stay unflagged.
+				truncated = true
+			}
 			continue
 		}
 		// The bubble UUID is each message's stable identity; the engine's

--- a/internal/parser/cursor_ide.go
+++ b/internal/parser/cursor_ide.go
@@ -427,6 +427,7 @@ func parseCursorIDEComposer(
 	}
 
 	var messages []ParsedMessage
+	truncated := false
 	for _, header := range doc.Headers {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -436,6 +437,11 @@ func parseCursorIDEComposer(
 			return nil, err
 		}
 		if bubble == nil {
+			// The transcript has a gap: a header references a bubble row
+			// that was never written or was wiped. Surface the remaining
+			// content, flagged truncated so the engine will not let it
+			// shrink an already archived fuller transcript.
+			truncated = true
 			continue
 		}
 		if bubble.Type == 0 {
@@ -503,6 +509,7 @@ func parseCursorIDEComposer(
 		EndedAt:          endedAt,
 		MessageCount:     len(messages),
 		UserMessageCount: userCount,
+		IsTruncated:      truncated,
 		File: FileInfo{
 			Path:  VirtualSourcePath(dbPath, composerID),
 			Size:  dbInfo.Size(),

--- a/internal/parser/cursor_ide_provider.go
+++ b/internal/parser/cursor_ide_provider.go
@@ -1,0 +1,356 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// Cursor IDE stores every chat session in one shared SQLite database
+// (state.vscdb). It is a multi-session container provider: discovery
+// surfaces the database as a single source and Parse fans it out into one
+// session per composer, addressed by "<db>#<composerID>" virtual paths. All
+// behavior is wired into the shared multi-session-container base via
+// options, mirroring the Zed provider.
+func newCursorIDEProviderFactory(def AgentDef) ProviderFactory {
+	return NewMultiSessionProviderFactory(
+		def,
+		cursorIDEProviderCapabilities(),
+		func(cfg ProviderConfig) multiSessionContainerSourceSet {
+			return NewMultiSessionContainerSourceSet(
+				AgentCursorIDE,
+				cfg.Roots,
+				WithContainerDiscovery(cursorIDEDiscoverContainers),
+				WithWatchRoots(cursorIDEWatchRoots),
+				WithChangedPathClassifier(cursorIDEClassifyPath),
+				WithMemberLookup(cursorIDEFindMember),
+				WithContextFingerprint(cursorIDEFingerprintSource),
+				WithContextContainerParse(cursorIDEParseContainer),
+				WithContextMemberParse(cursorIDEParseMember),
+				WithMemberPresence(cursorIDEMemberPresent),
+				WithBatchMemberPresence(cursorIDEBatchMemberPresent),
+			)
+		},
+	)
+}
+
+func cursorIDEDiscoverContainers(root string) []string {
+	if root == "" {
+		return nil
+	}
+	path := filepath.Join(root, CursorIDEDBRelPath)
+	if !IsRegularFile(path) {
+		return nil
+	}
+	return []string{path}
+}
+
+// cursorIDEWatchRoots watches the provider root directly: state.vscdb sits
+// straight inside it, with no subdirectory like Zed's threads/threads.db.
+func cursorIDEWatchRoots(roots []string) []WatchRoot {
+	out := make([]WatchRoot, 0, len(roots))
+	for _, root := range roots {
+		out = append(out, WatchRoot{
+			Path:         root,
+			Recursive:    false,
+			IncludeGlobs: []string{CursorIDEDBRelPath, CursorIDEDBRelPath + "-*"},
+			DebounceKey:  string(AgentCursorIDE) + ":state:" + root,
+		})
+	}
+	return out
+}
+
+// cursorIDEClassifyPath maps a stored or changed path to its database
+// container and composer. allowMissing relaxes the regular-file check so a
+// database delete (or its WAL/SHM sibling) still classifies for tombstones.
+func cursorIDEClassifyPath(
+	root, path string, allowMissing bool,
+) (multiSessionMatch, bool) {
+	return classifySQLiteContainerPath(
+		root, path, CursorIDEDBRelPath, allowMissing, true,
+		parseCursorIDEVirtualPath,
+	)
+}
+
+func cursorIDEFindMember(root, rawID string) (multiSessionMatch, bool) {
+	if root == "" || !IsValidSessionID(rawID) {
+		return multiSessionMatch{}, false
+	}
+	dbPath := filepath.Join(root, CursorIDEDBRelPath)
+	if !CursorIDEComposerExists(dbPath, rawID) {
+		return multiSessionMatch{}, false
+	}
+	return multiSessionMatch{
+		Path:      VirtualSourcePath(dbPath, rawID),
+		Container: dbPath,
+		MemberID:  rawID,
+	}, true
+}
+
+// cursorIDEFingerprintSource returns the composite whole-database mtime plus
+// a SQLite transaction-state hash for a container source, and a per-composer
+// content digest for a member source. Neither hashes the database's full
+// contents: state.vscdb is 86MB+ locally and 500MB+ has been reported in the
+// wild, and Cursor keeps the file open and mutating, so a full-file hash on
+// every fingerprint pass is both slow and would defeat mtime-based freshness
+// by always looking "changed". The container hash instead reads only the
+// database and WAL headers, and the member digest reads only that composer's
+// rows.
+func cursorIDEFingerprintSource(
+	ctx context.Context, src multiSessionSource,
+) (SourceFingerprint, error) {
+	info, err := os.Stat(src.Container)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return SourceFingerprint{}, nil
+		}
+		return SourceFingerprint{}, err
+	}
+	if src.MemberID == "" {
+		mtime := info.ModTime().UnixNano()
+		if composite, err := sqliteDBCompositeMtime(
+			src.Container, cursorIDEDBMtimeSuffixes,
+		); err == nil {
+			mtime = composite
+		}
+		stateHash, err := cursorIDESQLiteStateHash(src.Container)
+		if err != nil {
+			return SourceFingerprint{}, err
+		}
+		return SourceFingerprint{
+			Size:    info.Size(),
+			MTimeNS: mtime,
+			Hash:    stateHash,
+		}, nil
+	}
+
+	conn, err := openCursorIDEDB(src.Container)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	defer conn.Close()
+	meta, ok, err := loadCursorIDEComposerMeta(ctx, conn, src.MemberID)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	if !ok {
+		// Composer row is gone but the DB file remains: a keyed-empty
+		// fingerprint without error so the engine proceeds to Parse, which
+		// force-replaces the deleted composer out of the archive.
+		return SourceFingerprint{}, nil
+	}
+	return SourceFingerprint{
+		Size:    info.Size(),
+		MTimeNS: cursorIDETime(meta.lastUpdatedAt).UnixNano(),
+		Hash:    meta.digest,
+	}, nil
+}
+
+// cursorIDEDBMtimeSuffixes omits "-shm": Cursor IDE keeps its own read/write
+// connection open against state.vscdb, which continually touches the
+// shared-memory file, so including it would make every scan trigger the next
+// one (the same reasoning as omnigentDBMtimeSuffixes).
+var cursorIDEDBMtimeSuffixes = []string{"", "-wal"}
+
+// cursorIDESQLiteStateHash digests the parts of a SQLite database's on-disk
+// state that change with every committed transaction, without reading any
+// data pages: the 100-byte main header (whose change counter, schema cookie,
+// and version-valid-for fields move on rollback-journal commits) and the WAL
+// sibling's size plus 32-byte header (which grows per WAL-mode commit and
+// whose salts are re-randomized on every WAL reset). The skip cache keys on
+// it (FingerprintHashInCacheKey), so a rewrite that leaves the database's
+// size and mtime unchanged still misses the cache and reparses, without the
+// full-file hashing this provider deliberately avoids.
+func cursorIDESQLiteStateHash(dbPath string) (string, error) {
+	h := fnv.New64a()
+	f, err := os.Open(dbPath)
+	if err != nil {
+		return "", fmt.Errorf("reading cursor IDE db header %s: %w", dbPath, err)
+	}
+	defer f.Close()
+	header := make([]byte, 100)
+	n, err := io.ReadFull(f, header)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return "", fmt.Errorf("reading cursor IDE db header %s: %w", dbPath, err)
+	}
+	_, _ = h.Write(header[:n])
+	walPath := dbPath + "-wal"
+	if info, err := os.Stat(walPath); err == nil {
+		_, _ = fmt.Fprintf(h, "|wal:%d|", info.Size())
+		if wal, err := os.Open(walPath); err == nil {
+			walHeader := make([]byte, 32)
+			wn, _ := io.ReadFull(wal, walHeader)
+			_, _ = h.Write(walHeader[:wn])
+			_ = wal.Close()
+		}
+	}
+	return strconv.FormatUint(h.Sum64(), 16), nil
+}
+
+// IsCursorIDEContainerSource reports whether source addresses a whole
+// state.vscdb container rather than one "<db>#<composerID>" virtual member.
+// The sync engine's skip-cache freshness gate exempts whole containers from
+// the stored-row hash check: the archive holds only virtual member rows for
+// them, and the cache identity already carries the container state hash.
+func IsCursorIDEContainerSource(source SourceRef) bool {
+	if source.Provider != AgentCursorIDE {
+		return false
+	}
+	path := providerSourcePath(source)
+	if path == "" {
+		return false
+	}
+	_, _, virtual := parseCursorIDEVirtualPath(path)
+	return !virtual
+}
+
+func cursorIDEMemberPresent(src multiSessionSource) bool {
+	if src.MemberID == "" {
+		return IsRegularFile(src.Container)
+	}
+	return CursorIDEComposerExists(src.Container, src.MemberID)
+}
+
+// cursorIDEBatchMemberPresent reports current composer membership for the
+// stored members of one changed container over a single read connection,
+// instead of one CursorIDEComposerExists database open per member. On any
+// failure it reports every member present, so a transiently unreadable
+// database never tombstones archived sessions.
+func cursorIDEBatchMemberPresent(
+	container multiSessionSource, members []multiSessionSource,
+) map[string]bool {
+	present := make(map[string]bool, len(members))
+	existing := make(map[string]struct{})
+	conn, err := openCursorIDEDB(container.Container)
+	if err == nil {
+		defer conn.Close()
+		ids, listErr := listCursorIDEComposerIDs(context.Background(), conn)
+		err = listErr
+		for _, id := range ids {
+			existing[id] = struct{}{}
+		}
+	}
+	for _, member := range members {
+		if err != nil {
+			present[member.Path] = true
+			continue
+		}
+		_, ok := existing[member.MemberID]
+		present[member.Path] = ok
+	}
+	return present
+}
+
+func cursorIDEParseMember(
+	ctx context.Context, src multiSessionSource, req ParseRequest,
+) (*ParseResult, error) {
+	dbInfo, err := os.Stat(src.Container)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !IsValidSessionID(src.MemberID) {
+		return nil, nil
+	}
+	conn, err := openCursorIDEDB(src.Container)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	return parseCursorIDEComposer(
+		ctx, conn, src.Container, src.MemberID, req.Machine, dbInfo,
+	)
+}
+
+func cursorIDEParseContainer(
+	ctx context.Context, src multiSessionSource, req ParseRequest,
+) ([]ParseResult, error) {
+	dbInfo, err := os.Stat(src.Container)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	conn, err := openCursorIDEDB(src.Container)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	ids, err := listCursorIDEComposerIDs(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]ParseResult, 0, len(ids))
+	for _, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		result, err := parseCursorIDEComposer(
+			ctx, conn, src.Container, id, req.Machine, dbInfo,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			continue
+		}
+		results = append(results, *result)
+	}
+	return results, nil
+}
+
+// parseCursorIDEVirtualPath splits a Cursor IDE virtual source path into its
+// physical state.vscdb path and raw composer ID.
+func parseCursorIDEVirtualPath(path string) (string, string, bool) {
+	dbPath, composerID, ok := ParseVirtualSourcePathForBase(path, CursorIDEDBRelPath)
+	if !ok || !IsValidSessionID(composerID) {
+		return "", "", false
+	}
+	return dbPath, composerID, true
+}
+
+func cursorIDEProviderCapabilities() Capabilities {
+	// Stored-source hints feed the base's changed-path tombstones: a
+	// state.vscdb change event checks the archived members of that container
+	// and force-replaces the ones whose composerData row is gone, so a chat
+	// deleted in Cursor IDE is retired without waiting for an archive audit.
+	source := multiSessionContainerSourceCapabilities(
+		CapabilitySupported,
+		CapabilitySupported,
+	)
+	source.PersistentArchive = CapabilitySupported
+	return Capabilities{
+		Source: source,
+		Content: ContentCapabilities{
+			FirstMessage: CapabilitySupported,
+			SessionName:  CapabilitySupported,
+			Cwd:          CapabilitySupported,
+			GitBranch:    CapabilitySupported,
+			ToolCalls:    CapabilitySupported,
+			ToolResults:  CapabilitySupported,
+		},
+		Sync: ProviderSyncSemantics{
+			// The fingerprint hash participates in the skip-cache key and in
+			// stored-row freshness (Omnigent precedent): a database rewrite
+			// that leaves size and mtime unchanged still changes the
+			// container's transaction-state hash and so misses the cache,
+			// and a member whose lastUpdatedAt is stale is still reparsed
+			// when its content digest moved.
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+			// Compare the per-composer digest, not just the
+			// lastUpdatedAt-derived mtime, when dropping unchanged fan-out
+			// results: an edit that leaves lastUpdatedAt untouched must
+			// still rewrite the session (Zed cannot do this because it has
+			// no per-member digest).
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
+	}
+}

--- a/internal/parser/cursor_ide_provider.go
+++ b/internal/parser/cursor_ide_provider.go
@@ -172,14 +172,13 @@ func cursorIDESQLiteStateHash(dbPath string) (string, error) {
 		return "", fmt.Errorf("reading cursor IDE db header %s: %w", dbPath, err)
 	}
 	defer f.Close()
-	if info, err := f.Stat(); err == nil {
-		// Fold the file identity in so an atomic replacement of state.vscdb
-		// with a different database (a restore or profile switch renamed
-		// into place) always changes the cache identity, even when size,
-		// mtime, and the headers happen to coincide.
-		inode, device := sourceFileIdentity(info)
-		_, _ = fmt.Fprintf(h, "%d|%d|", inode, device)
-	}
+	// Fold the file identity in so an atomic replacement of state.vscdb
+	// with a different database (a restore or profile switch renamed into
+	// place) always changes the cache identity, even when size, mtime, and
+	// the headers happen to coincide. On Unix this is inode and device; on
+	// Windows the NTFS file index and volume serial read from the handle.
+	id, volume := sourceFileHandleIdentity(f)
+	_, _ = fmt.Fprintf(h, "%d|%d|", id, volume)
 	header := make([]byte, 100)
 	n, err := io.ReadFull(f, header)
 	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {

--- a/internal/parser/cursor_ide_provider.go
+++ b/internal/parser/cursor_ide_provider.go
@@ -172,6 +172,14 @@ func cursorIDESQLiteStateHash(dbPath string) (string, error) {
 		return "", fmt.Errorf("reading cursor IDE db header %s: %w", dbPath, err)
 	}
 	defer f.Close()
+	if info, err := f.Stat(); err == nil {
+		// Fold the file identity in so an atomic replacement of state.vscdb
+		// with a different database (a restore or profile switch renamed
+		// into place) always changes the cache identity, even when size,
+		// mtime, and the headers happen to coincide.
+		inode, device := sourceFileIdentity(info)
+		_, _ = fmt.Fprintf(h, "%d|%d|", inode, device)
+	}
 	header := make([]byte, 100)
 	n, err := io.ReadFull(f, header)
 	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {

--- a/internal/parser/cursor_ide_test.go
+++ b/internal/parser/cursor_ide_test.go
@@ -1,0 +1,478 @@
+// ABOUTME: Tests for the Cursor IDE (GUI) parser: cursorDiskKV composer/bubble
+// ABOUTME: decoding, message ordering, tool calls, and provider source methods.
+package parser
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cursorIDETestBubble is one synthetic cursorDiskKV bubble row.
+type cursorIDETestBubble struct {
+	id         string
+	bubbleType int
+	text       string
+	createdAt  string
+	tool       *cursorIDEToolFormerData
+}
+
+// cursorIDETestComposer is one synthetic composerData document plus its
+// bubbles, keyed under the same composer ID.
+type cursorIDETestComposer struct {
+	id        string
+	name      string
+	createdAt int64
+	updatedAt int64
+	cwd       string
+	repoPath  string
+	branch    string
+	bubbles   []cursorIDETestBubble
+	// omitBubbleIDs skips writing these bubble IDs to cursorDiskKV even
+	// though they are still listed in fullConversationHeadersOnly, so the
+	// parser must tolerate a header pointing at a row Cursor never wrote or
+	// later wiped.
+	omitBubbleIDs map[string]bool
+}
+
+func createCursorIDEDB(t *testing.T, composers []cursorIDETestComposer) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), CursorIDEDBRelPath)
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec(
+		`CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+	)
+	require.NoError(t, err)
+
+	for _, c := range composers {
+		headers := make([]cursorIDEComposerHeader, 0, len(c.bubbles))
+		for _, b := range c.bubbles {
+			headers = append(headers, cursorIDEComposerHeader{
+				BubbleID: b.id, Type: b.bubbleType,
+			})
+		}
+		doc := cursorIDEComposerDoc{
+			Headers:       headers,
+			Name:          c.name,
+			CreatedAt:     c.createdAt,
+			LastUpdatedAt: c.updatedAt,
+		}
+		doc.WorkspaceIdentifier.URI.FSPath = c.cwd
+		if c.repoPath != "" {
+			doc.TrackedGitRepos = []cursorIDEGitRepo{{
+				RepoPath: c.repoPath,
+				Branches: []cursorIDEGitBranch{{
+					BranchName: c.branch, LastInteractionAt: c.updatedAt,
+				}},
+			}}
+		}
+		raw, err := json.Marshal(doc)
+		require.NoError(t, err)
+		_, err = db.Exec(
+			`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`,
+			cursorIDEComposerKeyPrefix+c.id, raw,
+		)
+		require.NoError(t, err)
+
+		for _, b := range c.bubbles {
+			if c.omitBubbleIDs[b.id] {
+				continue
+			}
+			bubble := cursorIDEBubble{
+				Type: b.bubbleType, Text: b.text, CreatedAt: b.createdAt,
+				ToolFormerData: b.tool,
+			}
+			raw, err := json.Marshal(bubble)
+			require.NoError(t, err)
+			_, err = db.Exec(
+				`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`,
+				cursorIDEBubbleKeyPrefix+c.id+":"+b.id, raw,
+			)
+			require.NoError(t, err)
+		}
+	}
+	return dbPath
+}
+
+func TestCursorIDEProviderCapabilities(t *testing.T) {
+	factory, ok := ProviderFactoryByType(AgentCursorIDE)
+	require.True(t, ok)
+	caps := factory.Capabilities()
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolCalls)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolResults)
+
+	provider, ok := NewProvider(AgentCursorIDE, ProviderConfig{
+		Roots: []string{t.TempDir()}, Machine: "devbox",
+	})
+	require.True(t, ok)
+	require.NotNil(t, provider)
+}
+
+func TestCursorIDEProviderDiscoverAndParse(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{
+		{
+			id:        "0cd7922b-f080-4672-b26f-2d521feee055",
+			name:      "Factory course status",
+			createdAt: 1782026756842, // 2026-06-21T07:25:56.842Z
+			updatedAt: 1782026791522, // 2026-06-21T07:26:31.522Z
+			cwd:       "/Users/alice/dev/dark-factory",
+			repoPath:  "/Users/alice/dev/dark-factory",
+			branch:    "dev",
+			bubbles: []cursorIDETestBubble{
+				{
+					id: "8572a71d-1e3b-4602-bcbb-b76830401b89", bubbleType: cursorIDEBubbleTypeUser,
+					text:      "give me an overview on the development status",
+					createdAt: "2026-06-21T07:27:29.606Z",
+				},
+				{
+					id: "7337a4cc-dd16-42d3-961e-18c15afba4ca", bubbleType: cursorIDEBubbleTypeAssistant,
+					text:      "I'll inspect the factory-course package structure.",
+					createdAt: "2026-06-21T07:27:31.522Z",
+				},
+				{
+					id: "25b40601-e097-42e9-b695-d55aa242e920", bubbleType: cursorIDEBubbleTypeAssistant,
+					createdAt: "2026-06-21T07:27:32.000Z",
+					tool: &cursorIDEToolFormerData{
+						ToolCallID: "tool_d4d61399",
+						Name:       "glob_file_search",
+						RawArgs:    `{"targetDirectory":"/Users/alice/dev/dark-factory","globPattern":"**/*"}`,
+						Result:     `{"directories":[{"absPath":"/Users/alice/dev/dark-factory","files":[]}]}`,
+					},
+				},
+			},
+		},
+		{
+			// An empty draft composer: no headers, so it must not surface as
+			// a session at all.
+			id:        "empty-draft-0000-0000-0000-000000000000",
+			name:      "",
+			createdAt: 1782026756000,
+			updatedAt: 1782026756000,
+		},
+	})
+	root := filepath.Dir(dbPath)
+
+	provider, ok := NewProvider(AgentCursorIDE, ProviderConfig{
+		Roots: []string{root}, Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, root, plan.Roots[0].Path)
+	assert.False(t, plan.Roots[0].Recursive)
+	assert.Equal(t, []string{"state.vscdb", "state.vscdb-*"}, plan.Roots[0].IncludeGlobs)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, AgentCursorIDE, discovered[0].Provider)
+	assert.Equal(t, dbPath, discovered[0].DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+	require.NotZero(t, fingerprint.MTimeNS)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: discovered[0], Machine: "devbox", Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1, "the empty draft composer must not surface as a session")
+
+	sess := outcome.Results[0].Result.Session
+	messages := outcome.Results[0].Result.Messages
+	assert.Equal(t, "cursor-ide:0cd7922b-f080-4672-b26f-2d521feee055", sess.ID)
+	assert.Equal(t, AgentCursorIDE, sess.Agent)
+	assert.Equal(t, "Factory course status", sess.SessionName)
+	assert.Equal(t, "/Users/alice/dev/dark-factory", sess.Cwd)
+	assert.Equal(t, "dark_factory", sess.Project)
+	assert.Equal(t, "dev", sess.GitBranch)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, "give me an overview on the development status", sess.FirstMessage)
+
+	// composerData createdAt/lastUpdatedAt are epoch milliseconds; the parser
+	// must not confuse them with the bubbles' ISO-8601 createdAt encoding.
+	// This fixture's lastUpdatedAt (07:26:31.522Z) lags the final bubble, so
+	// EndedAt comes from the latest message timestamp instead.
+	assert.Equal(t, time.UnixMilli(1782026756842).UTC(), sess.StartedAt)
+	assert.Equal(t,
+		time.Date(2026, 6, 21, 7, 27, 32, 0, time.UTC), sess.EndedAt)
+	// Both encodings describe the same real conversation, so they must land
+	// within the same window rather than merely both parsing without error.
+	assert.WithinDuration(t, sess.StartedAt, sess.EndedAt, 2*time.Minute)
+
+	require.Len(t, messages, 3)
+	assert.Equal(t, RoleUser, messages[0].Role)
+	assert.Equal(t, "give me an overview on the development status", messages[0].Content)
+	assert.Equal(t, RoleAssistant, messages[1].Role)
+	assert.Equal(t, "I'll inspect the factory-course package structure.", messages[1].Content)
+	assert.Equal(t, RoleAssistant, messages[2].Role)
+	assert.True(t, messages[2].HasToolUse)
+	require.Len(t, messages[2].ToolCalls, 1)
+	assert.Equal(t, "glob_file_search", messages[2].ToolCalls[0].ToolName)
+	assert.Contains(t, messages[2].ToolCalls[0].InputJSON, "globPattern")
+	require.Len(t, messages[2].ToolResults, 1)
+	assert.Contains(t, messages[2].ToolResults[0].ContentRaw, "absPath")
+
+	// Ordering must come from fullConversationHeadersOnly, not from a
+	// lexicographic bubble-key scan.
+	for i, m := range messages {
+		assert.Equal(t, i, m.Ordinal)
+	}
+}
+
+func TestCursorIDEFindSourceAndFingerprint(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id:        "142856b4-34d8-4950-ba25-b45fe1c47941",
+		name:      "Thread",
+		createdAt: 1782026756842,
+		updatedAt: 1782026791522,
+		bubbles: []cursorIDETestBubble{{
+			id: "b1", bubbleType: cursorIDEBubbleTypeUser,
+			text: "hi", createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	root := filepath.Dir(dbPath)
+	composerID := "142856b4-34d8-4950-ba25-b45fe1c47941"
+	virtualPath := VirtualSourcePath(dbPath, composerID)
+
+	provider, ok := NewProvider(AgentCursorIDE, ProviderConfig{
+		Roots: []string{root}, Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		FullSessionID: "devbox~cursor-ide:" + composerID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, found.DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), found)
+	require.NoError(t, err)
+	assert.Equal(t, virtualPath, fingerprint.Key)
+	assert.Positive(t, fingerprint.Size)
+	assert.NotZero(t, fingerprint.MTimeNS)
+	assert.NotEmpty(t, fingerprint.Hash)
+
+	// A vanished composer (row deleted, DB file still present) fingerprints
+	// as keyed-empty rather than erroring, so Parse runs and force-replaces
+	// the deleted session out of the archive.
+	ghost := found
+	if src, ok := ghost.Opaque.(multiSessionSource); ok {
+		src.MemberID = "does-not-exist"
+		src.Path = VirtualSourcePath(dbPath, "does-not-exist")
+		ghost.Opaque = src
+	}
+	ghostFingerprint, err := provider.Fingerprint(context.Background(), ghost)
+	require.NoError(t, err)
+	assert.Empty(t, ghostFingerprint.Hash)
+}
+
+func TestParseCursorIDEComposer_ToleratesMissingBubbleRow(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id:        "gap-0000-0000-0000-000000000000",
+		name:      "Gappy thread",
+		createdAt: 1782026756842,
+		updatedAt: 1782026791522,
+		bubbles: []cursorIDETestBubble{
+			{id: "missing", bubbleType: cursorIDEBubbleTypeUser, text: "never written"},
+			{id: "b2", bubbleType: cursorIDEBubbleTypeUser, text: "hello", createdAt: "2026-06-21T07:27:29.606Z"},
+		},
+		omitBubbleIDs: map[string]bool{"missing": true},
+	}})
+
+	conn, err := openCursorIDEDB(dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	result, err := parseCursorIDEComposer(
+		context.Background(), conn, dbPath,
+		"gap-0000-0000-0000-000000000000", "devbox", info,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, "hello", result.Messages[0].Content)
+}
+
+func TestParseCursorIDEComposer_EmptyComposerSkipped(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id: "empty-0000-0000-0000-000000000000",
+	}})
+	conn, err := openCursorIDEDB(dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	result, err := parseCursorIDEComposer(
+		context.Background(), conn, dbPath,
+		"empty-0000-0000-0000-000000000000", "devbox", info,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestParseCursorIDEComposer_MalformedBubbleFailsInsteadOfTruncating(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id:        "corrupt-bubble-0000-0000-000000000000",
+		name:      "Corrupt bubble",
+		createdAt: 1782026756842,
+		updatedAt: 1782026791522,
+		bubbles: []cursorIDETestBubble{
+			{id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "kept", createdAt: "2026-06-21T07:27:29.606Z"},
+			{id: "b2", bubbleType: cursorIDEBubbleTypeAssistant, text: "reply", createdAt: "2026-06-21T07:27:31.522Z"},
+		},
+	}})
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		[]byte(`{"type": "not-an-int"`),
+		"bubbleId:corrupt-bubble-0000-0000-000000000000:b2",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	conn, err := openCursorIDEDB(dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	result, err := parseCursorIDEComposer(
+		context.Background(), conn, dbPath,
+		"corrupt-bubble-0000-0000-000000000000", "devbox", info,
+	)
+	require.Error(t, err,
+		"a stored bubble that no longer decodes must fail, not truncate the transcript")
+	assert.Nil(t, result)
+}
+
+func TestParseCursorIDEComposer_MalformedComposerFailsInsteadOfRetiring(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id:        "corrupt-doc-0000-0000-000000000000",
+		name:      "Corrupt doc",
+		createdAt: 1782026756842,
+		updatedAt: 1782026791522,
+		bubbles: []cursorIDETestBubble{{
+			id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "hi",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		[]byte(`{"fullConversationHeadersOnly": [truncated`),
+		"composerData:corrupt-doc-0000-0000-000000000000",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	conn, err := openCursorIDEDB(dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	result, err := parseCursorIDEComposer(
+		context.Background(), conn, dbPath,
+		"corrupt-doc-0000-0000-000000000000", "devbox", info,
+	)
+	require.Error(t, err,
+		"a composer row that no longer decodes must fail, not read as a clean no-session")
+	assert.Nil(t, result)
+
+	_, _, err = loadCursorIDEComposerMeta(
+		context.Background(), conn, "corrupt-doc-0000-0000-000000000000",
+	)
+	require.Error(t, err,
+		"the freshness meta load must not fingerprint a malformed composer as vanished")
+}
+
+func TestParseCursorIDEComposer_EndedAtNotBeforeLastMessage(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id:        "stale-stamp-0000-0000-000000000000",
+		name:      "Stale stamp",
+		createdAt: 1782026756842, // 2026-06-21T07:25:56.842Z
+		updatedAt: 1782026791522, // 2026-06-21T07:26:31.522Z, before the bubbles
+		bubbles: []cursorIDETestBubble{
+			{id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "hi", createdAt: "2026-06-21T07:27:29.606Z"},
+			{id: "b2", bubbleType: cursorIDEBubbleTypeAssistant, text: "reply", createdAt: "2026-06-21T07:28:05.000Z"},
+		},
+	}})
+	conn, err := openCursorIDEDB(dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	result, err := parseCursorIDEComposer(
+		context.Background(), conn, dbPath,
+		"stale-stamp-0000-0000-000000000000", "devbox", info,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t,
+		time.Date(2026, 6, 21, 7, 28, 5, 0, time.UTC), result.Session.EndedAt,
+		"a stale lastUpdatedAt must not place EndedAt before the final message")
+	assert.False(t, result.Session.EndedAt.Before(result.Session.StartedAt))
+}
+
+func TestParseCursorIDEComposer_TypelessBubbleFallsBackToHeaderType(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id:        "typeless-0000-0000-0000-000000000000",
+		name:      "Typeless bubble",
+		createdAt: 1782026756842,
+		updatedAt: 1782026791522,
+		bubbles: []cursorIDETestBubble{
+			{id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "ask", createdAt: "2026-06-21T07:27:29.606Z"},
+			{id: "b2", bubbleType: cursorIDEBubbleTypeAssistant, text: "answer", createdAt: "2026-06-21T07:27:31.522Z"},
+		},
+	}})
+	// Strip the type field from the assistant bubble's row, as a shrunk or
+	// partially-written row would: the header still records the turn's role.
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		[]byte(`{"text": "answer", "createdAt": "2026-06-21T07:27:31.522Z"}`),
+		"bubbleId:typeless-0000-0000-0000-000000000000:b2",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	conn, err := openCursorIDEDB(dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	result, err := parseCursorIDEComposer(
+		context.Background(), conn, dbPath,
+		"typeless-0000-0000-0000-000000000000", "devbox", info,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Messages, 2,
+		"a bubble missing its type field must fall back to the header's role")
+	assert.Equal(t, RoleUser, result.Messages[0].Role)
+	assert.Equal(t, RoleAssistant, result.Messages[1].Role)
+	assert.Equal(t, "answer", result.Messages[1].Content)
+}

--- a/internal/parser/cursor_ide_test.go
+++ b/internal/parser/cursor_ide_test.go
@@ -308,6 +308,8 @@ func TestParseCursorIDEComposer_ToleratesMissingBubbleRow(t *testing.T) {
 	require.NotNil(t, result)
 	require.Len(t, result.Messages, 1)
 	assert.Equal(t, "hello", result.Messages[0].Content)
+	assert.True(t, result.Session.IsTruncated,
+		"a transcript with a missing bubble row must be flagged truncated")
 }
 
 func TestParseCursorIDEComposer_EmptyComposerSkipped(t *testing.T) {

--- a/internal/parser/file_identity_unix.go
+++ b/internal/parser/file_identity_unix.go
@@ -13,3 +13,13 @@ func sourceFileIdentity(info os.FileInfo) (inode, device uint64) {
 	}
 	return 0, 0
 }
+
+// sourceFileHandleIdentity returns the stable filesystem identity of an open
+// file: inode and device on Unix. Zeros mean the identity is unavailable.
+func sourceFileHandleIdentity(f *os.File) (id, volume uint64) {
+	info, err := f.Stat()
+	if err != nil {
+		return 0, 0
+	}
+	return sourceFileIdentity(info)
+}

--- a/internal/parser/file_identity_windows.go
+++ b/internal/parser/file_identity_windows.go
@@ -2,8 +2,25 @@
 
 package parser
 
-import "os"
+import (
+	"os"
+	"syscall"
+)
 
 func sourceFileIdentity(info os.FileInfo) (inode, device uint64) {
 	return 0, 0
+}
+
+// sourceFileHandleIdentity returns the stable filesystem identity of an open
+// file: the NTFS file index and volume serial number, the Windows analog of
+// inode and device. os.FileInfo.Sys() does not carry these, so they must be
+// read through the open handle. Zeros mean the identity is unavailable.
+func sourceFileHandleIdentity(f *os.File) (id, volume uint64) {
+	var info syscall.ByHandleFileInformation
+	err := syscall.GetFileInformationByHandle(syscall.Handle(f.Fd()), &info)
+	if err != nil {
+		return 0, 0
+	}
+	return uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow),
+		uint64(info.VolumeSerialNumber)
 }

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -51,9 +51,9 @@ type multiSessionMatch struct {
 // path into its physical container path and raw member ID. allowMissing
 // relaxes the regular-file requirement so a database delete (or its WAL/SHM
 // sibling) still classifies for tombstones. rejectShmSiblingEvents refuses to
-// resolve a bare "-shm" sibling event to the container; only Omnigent sets
-// it, because opening its own read connections updates that file's mtime and
-// would otherwise make every scan trigger the next one.
+// resolve a bare "-shm" sibling event to the container; Omnigent and Cursor
+// IDE set it, because opening their own read connections updates that file's
+// mtime and would otherwise make every scan trigger the next one.
 func classifySQLiteContainerPath(
 	root, path, dbRelPath string,
 	allowMissing, rejectShmSiblingEvents bool,

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -1110,6 +1110,8 @@ func providerFactoryForDef(def AgentDef) ProviderFactory {
 		return newCortexProviderFactory(def)
 	case AgentCursor:
 		return newCursorProviderFactory(def)
+	case AgentCursorIDE:
+		return newCursorIDEProviderFactory(def)
 	case AgentChatGPT:
 		return newImportOnlyProviderFactory(def)
 	case AgentDeepSeekTUI:

--- a/internal/parser/provider_migration.go
+++ b/internal/parser/provider_migration.go
@@ -25,6 +25,7 @@ var providerMigrationModes = map[AgentType]ProviderMigrationMode{
 	AgentGeminiApps:     ProviderMigrationImportOnly,
 	AgentOpenHands:      ProviderMigrationProviderAuthoritative,
 	AgentCursor:         ProviderMigrationProviderAuthoritative,
+	AgentCursorIDE:      ProviderMigrationProviderAuthoritative,
 	AgentMiMoCode:       ProviderMigrationProviderAuthoritative,
 	AgentOpenCode:       ProviderMigrationProviderAuthoritative,
 	AgentKilo:           ProviderMigrationProviderAuthoritative,

--- a/internal/parser/provider_test.go
+++ b/internal/parser/provider_test.go
@@ -150,6 +150,7 @@ func TestProviderRegistryMirrorsAgentRegistry(t *testing.T) {
 
 func TestStoredSourceHintCapabilitiesMatchConsumers(t *testing.T) {
 	wantSupported := map[AgentType]bool{
+		AgentCursorIDE: true,
 		AgentDevin:     true,
 		AgentForge:     true,
 		AgentKiro:      true,

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -28,6 +28,7 @@ const (
 	AgentKiloLegacy     AgentType = "kilo-legacy"
 	AgentOpenHands      AgentType = "openhands"
 	AgentCursor         AgentType = "cursor"
+	AgentCursorIDE      AgentType = "cursor-ide"
 	AgentIflow          AgentType = "iflow"
 	AgentAmp            AgentType = "amp"
 	AgentZencoder       AgentType = "zencoder"
@@ -313,6 +314,28 @@ var Registry = []AgentDef{
 		DefaultDirs: []string{".cursor/projects"},
 		IDPrefix:    "cursor:",
 		FileBased:   true,
+	},
+	{
+		// Cursor IDE (the GUI editor) is a distinct product from Cursor Agent
+		// (the CLI, see AgentCursor above): it stores every chat session in
+		// one shared VS Code-style global-state SQLite database
+		// (state.vscdb), fanned out into one session per composer addressed
+		// by a "<db>#<composerID>" virtual path.
+		Type:        AgentCursorIDE,
+		DisplayName: "Cursor IDE",
+		EnvVar:      "CURSOR_IDE_DIR",
+		ConfigKey:   "cursor_ide_dirs",
+		DefaultDirs: cursorIDEDefaultDirs(),
+		IDPrefix:    "cursor-ide:",
+		FileBased:   true,
+		// state.vscdb is VS Code's shared global-state database: besides
+		// Cursor's own chat data, its ItemTable co-locates Cursor's live
+		// auth tokens (observed keys cursorAuth/accessToken and
+		// cursorAuth/refreshToken) plus whatever other installed extensions
+		// have stored there, and composerData blobs carry per-composer sync
+		// encryption keys. Remote sync stays disabled until there is an
+		// allowlisted export schema, matching Omnigent's chat.db precedent.
+		RemoteSyncExcluded: true,
 	},
 	{
 		Type:        AgentAmp,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -450,6 +450,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentKiloLegacy,
 		AgentOpenHands,
 		AgentCursor,
+		AgentCursorIDE,
 		AgentAmp,
 		AgentVSCodeCopilot,
 		AgentWindsurf,

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -451,3 +451,42 @@ func TestSyncAllCursorIDESameSizeSameMtimeRewriteReparses(t *testing.T) {
 	assert.Equal(t, "howdy", *sess.FirstMessage,
 		"a same-size, same-mtime rewrite must miss the skip cache and reparse")
 }
+
+func TestSyncAllCursorIDEWipedBubblesMarkSourceMissingAndPreserveTranscript(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "wiped-composer", name: "Wiped chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	before, err := database.GetSessionFull(t.Context(), "cursor-ide:wiped-composer")
+	require.NoError(t, err)
+	require.NotNil(t, before)
+
+	// A Cursor update wiping bubble rows while the composer document and its
+	// headers survive: the transcript's source material is locally gone, but
+	// the archived session must stay browsable and intact.
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`DELETE FROM cursorDiskKV WHERE key = ?`, "bubbleId:wiped-composer:b1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	archived, err := database.GetSessionFull(t.Context(), "cursor-ide:wiped-composer")
+	require.NoError(t, err)
+	assertSourceMissingState(t, archived)
+	assert.Equal(t, before.MessageCount, archived.MessageCount,
+		"wiped bubble rows must not truncate the archived transcript")
+}

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -490,3 +490,104 @@ func TestSyncAllCursorIDEWipedBubblesMarkSourceMissingAndPreserveTranscript(
 	assert.Equal(t, before.MessageCount, archived.MessageCount,
 		"wiped bubble rows must not truncate the archived transcript")
 }
+
+func TestSyncAllCursorIDEPartialBubbleWipeKeepsArchivedTranscript(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "partial-composer", name: "Partially wiped chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{
+			{id: "b1", bubbleType: 1, text: "ask", createdAt: "2026-06-21T07:27:29.606Z"},
+			{id: "b2", bubbleType: 2, text: "answer", createdAt: "2026-06-21T07:27:31.522Z"},
+		},
+	}})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	sess, err := database.GetSession(t.Context(), "cursor-ide:partial-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 2, sess.MessageCount)
+
+	// A partial wipe: one bubble row vanishes while the composer document
+	// still references it. The truncated remainder must not replace the
+	// archived fuller transcript.
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`DELETE FROM cursorDiskKV WHERE key = ?`, "bubbleId:partial-composer:b2",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err = database.GetSession(t.Context(), "cursor-ide:partial-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess, "the preserved session must stay active")
+	assert.Equal(t, 2, sess.MessageCount,
+		"a partial bubble wipe must not shrink the archived transcript")
+}
+
+func TestSyncAllCursorIDEGappedComposerSurfacesAndKeepsGrowing(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	composer := cursorIDESyncComposer{
+		id: "gappy-composer", name: "Gappy chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{
+			{id: "missing", bubbleType: 1, text: "never written"},
+			{id: "b1", bubbleType: 1, text: "hello", createdAt: "2026-06-21T07:27:29.606Z"},
+		},
+	}
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{composer})
+	// Remove the first bubble's row so the composer starts out gapped, as a
+	// database wiped before agentsview ever saw it would be.
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`DELETE FROM cursorDiskKV WHERE key = ?`, "bubbleId:gappy-composer:missing",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced,
+		"a gapped composer never seen before must still surface its remaining content")
+	sess, err := database.GetSession(t.Context(), "cursor-ide:gappy-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 1, sess.MessageCount)
+	assert.True(t, sess.IsTruncated)
+
+	// The user keeps chatting in the gapped conversation: growth must not be
+	// frozen by the shrink guard.
+	composer.bubbles = append(composer.bubbles, cursorIDESyncBubble{
+		id: "b2", bubbleType: 2, text: "reply", createdAt: "2026-06-21T07:27:31.522Z",
+	})
+	writer, err = sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		cursorIDEComposerJSON(t, composer), "composerData:gappy-composer",
+	)
+	require.NoError(t, err)
+	raw, err := json.Marshal(map[string]any{
+		"type": 2, "text": "reply", "createdAt": "2026-06-21T07:27:31.522Z",
+	})
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`,
+		"bubbleId:gappy-composer:b2", raw,
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err = database.GetSession(t.Context(), "cursor-ide:gappy-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, 2, sess.MessageCount,
+		"new turns in a gapped conversation must keep syncing")
+}

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -789,6 +790,9 @@ func TestSyncAllCursorIDEEmptiedBubbleKeepsArchivedTranscript(t *testing.T) {
 }
 
 func TestSyncAllCursorIDEReplacedDatabaseFileReparses(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the replacement is detectable only by inode/device identity, which sourceFileIdentity does not provide on Windows")
+	}
 	root := t.TempDir()
 	dbPath := filepath.Join(root, "state.vscdb")
 	composer := func(text string) cursorIDESyncComposer {

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -652,4 +653,27 @@ func TestSyncAllCursorIDEEarlierBubbleWipeWithGrowthKeepsArchive(t *testing.T) {
 	require.NotNil(t, sess.FirstMessage)
 	assert.Equal(t, "first ask", *sess.FirstMessage,
 		"the archived first turn must survive the masked wipe")
+}
+
+func TestSourceMtimeCursorIDEResolvesVirtualMemberPath(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "watched-composer", name: "Watched chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	engine, _ := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+
+	// The session watcher polls SourceMtime; a "state.vscdb#<composer>"
+	// virtual path cannot be stat'ed, so it must resolve through the member
+	// fingerprint instead of returning zero and disabling change detection.
+	mtime := engine.SourceMtime("cursor-ide:watched-composer")
+	assert.Equal(t,
+		time.UnixMilli(1782026791522).UTC().UnixNano(), mtime,
+		"the watcher token must be the composer's lastUpdatedAt-derived mtime")
 }

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -669,11 +668,84 @@ func TestSourceMtimeCursorIDEResolvesVirtualMemberPath(t *testing.T) {
 	engine, _ := newCursorIDESyncEngine(t, root)
 	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
 
-	// The session watcher polls SourceMtime; a "state.vscdb#<composer>"
-	// virtual path cannot be stat'ed, so it must resolve through the member
-	// fingerprint instead of returning zero and disabling change detection.
-	mtime := engine.SourceMtime("cursor-ide:watched-composer")
-	assert.Equal(t,
-		time.UnixMilli(1782026791522).UTC().UnixNano(), mtime,
-		"the watcher token must be the composer's lastUpdatedAt-derived mtime")
+	// The session watcher polls SourceMtime as an equality-only change
+	// token; a "state.vscdb#<composer>" virtual path cannot be stat'ed, so
+	// it must resolve through the member fingerprint instead of returning
+	// zero and disabling change detection.
+	token := engine.SourceMtime("cursor-ide:watched-composer")
+	require.NotZero(t, token,
+		"the watcher token must resolve through the member fingerprint")
+
+	// An in-place bubble rewrite leaves lastUpdatedAt untouched; the token
+	// must still move so the polling fallback sees the edit.
+	raw, err := json.Marshal(map[string]any{
+		"type": 1, "text": "hello, edited in place",
+		"createdAt": "2026-06-21T07:27:29.606Z",
+	})
+	require.NoError(t, err)
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		raw, "bubbleId:watched-composer:b1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	edited := engine.SourceMtime("cursor-ide:watched-composer")
+	require.NotZero(t, edited)
+	assert.NotEqual(t, token, edited,
+		"an edit that leaves lastUpdatedAt untouched must still move the token")
+}
+
+func TestResyncAllCursorIDEKeepsArchivedTranscriptOverGapResult(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{
+		{
+			id: "resync-composer", name: "Resynced chat",
+			createdAt: 1782026756842, updatedAt: 1782026791522,
+			bubbles: []cursorIDESyncBubble{
+				{id: "b1", bubbleType: 1, text: "ask", createdAt: "2026-06-21T07:27:29.606Z"},
+				{id: "b2", bubbleType: 2, text: "answer", createdAt: "2026-06-21T07:27:31.522Z"},
+			},
+		},
+		{
+			id: "healthy-composer", name: "Healthy chat",
+			createdAt: 1782026756842, updatedAt: 1782026801522,
+			bubbles: []cursorIDESyncBubble{{
+				id: "b1", bubbleType: 1, text: "fine",
+				createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+	})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+	sess, err := database.GetSession(t.Context(), "cursor-ide:resync-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 2, sess.MessageCount)
+
+	// Wipe one bubble, then rebuild the archive. During the rebuild e.db is
+	// the fresh database, so the truncation guard must verify against the
+	// original archive (archiveStore); admitting the gap transcript there
+	// would put the session into the rebuild and the orphan copy would
+	// never rescue the fuller original.
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`DELETE FROM cursorDiskKV WHERE key = ?`, "bubbleId:resync-composer:b2",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	stats := engine.ResyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+
+	sess, err = database.GetSession(t.Context(), "cursor-ide:resync-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess,
+		"the archived session must survive the rebuild")
+	assert.Equal(t, 2, sess.MessageCount,
+		"a full resync must not replace the archive with a gap transcript")
 }

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -591,3 +591,65 @@ func TestSyncAllCursorIDEGappedComposerSurfacesAndKeepsGrowing(t *testing.T) {
 	assert.Equal(t, 2, sess.MessageCount,
 		"new turns in a gapped conversation must keep syncing")
 }
+
+func TestSyncAllCursorIDEEarlierBubbleWipeWithGrowthKeepsArchive(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	composer := cursorIDESyncComposer{
+		id: "masked-composer", name: "Masked wipe chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{
+			{id: "b1", bubbleType: 1, text: "first ask", createdAt: "2026-06-21T07:27:29.606Z"},
+			{id: "b2", bubbleType: 2, text: "first answer", createdAt: "2026-06-21T07:27:31.522Z"},
+		},
+	}
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{composer})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	sess, err := database.GetSession(t.Context(), "cursor-ide:masked-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 2, sess.MessageCount)
+
+	// Wipe the first bubble while the conversation keeps growing: the new
+	// transcript has as many messages as the archive, but no longer contains
+	// the archived first turn. A message-count guard alone would admit it.
+	composer.bubbles = append(composer.bubbles,
+		cursorIDESyncBubble{id: "b3", bubbleType: 1, text: "second ask", createdAt: "2026-06-21T07:28:01.000Z"},
+		cursorIDESyncBubble{id: "b4", bubbleType: 2, text: "second answer", createdAt: "2026-06-21T07:28:05.000Z"},
+	)
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		cursorIDEComposerJSON(t, composer), "composerData:masked-composer",
+	)
+	require.NoError(t, err)
+	for _, b := range composer.bubbles[2:] {
+		raw, err := json.Marshal(map[string]any{
+			"type": b.bubbleType, "text": b.text, "createdAt": b.createdAt,
+		})
+		require.NoError(t, err)
+		_, err = writer.Exec(
+			`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`,
+			"bubbleId:masked-composer:"+b.id, raw,
+		)
+		require.NoError(t, err)
+	}
+	_, err = writer.Exec(
+		`DELETE FROM cursorDiskKV WHERE key = ?`, "bubbleId:masked-composer:b1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err = database.GetSession(t.Context(), "cursor-ide:masked-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, 2, sess.MessageCount,
+		"a wiped earlier bubble masked by new turns must not replace the archive")
+	require.NotNil(t, sess.FirstMessage)
+	assert.Equal(t, "first ask", *sess.FirstMessage,
+		"the archived first turn must survive the masked wipe")
+}

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -1,0 +1,453 @@
+package sync_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// cursorIDESyncBubble is one synthetic cursorDiskKV bubble row.
+type cursorIDESyncBubble struct {
+	id         string
+	bubbleType int
+	text       string
+	createdAt  string
+}
+
+// cursorIDESyncComposer is one synthetic composerData document plus its
+// bubbles.
+type cursorIDESyncComposer struct {
+	id        string
+	name      string
+	createdAt int64
+	updatedAt int64
+	bubbles   []cursorIDESyncBubble
+}
+
+func cursorIDEComposerJSON(t *testing.T, c cursorIDESyncComposer) []byte {
+	t.Helper()
+	headers := make([]map[string]any, 0, len(c.bubbles))
+	for _, b := range c.bubbles {
+		headers = append(headers, map[string]any{
+			"bubbleId": b.id, "type": b.bubbleType,
+		})
+	}
+	raw, err := json.Marshal(map[string]any{
+		"fullConversationHeadersOnly": headers,
+		"name":                        c.name,
+		"createdAt":                   c.createdAt,
+		"lastUpdatedAt":               c.updatedAt,
+		"workspaceIdentifier": map[string]any{
+			"uri": map[string]any{"fsPath": "/work/project"},
+		},
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+func createCursorIDEStateDB(
+	t *testing.T, dbPath string, composers []cursorIDESyncComposer,
+) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec(
+		`CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)`,
+	)
+	require.NoError(t, err)
+	for _, c := range composers {
+		_, err = db.Exec(
+			`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`,
+			"composerData:"+c.id, cursorIDEComposerJSON(t, c),
+		)
+		require.NoError(t, err)
+		for _, b := range c.bubbles {
+			raw, err := json.Marshal(map[string]any{
+				"type": b.bubbleType, "text": b.text, "createdAt": b.createdAt,
+			})
+			require.NoError(t, err)
+			_, err = db.Exec(
+				`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`,
+				"bubbleId:"+c.id+":"+b.id, raw,
+			)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func newCursorIDESyncEngine(
+	t *testing.T, root string,
+) (*sync.Engine, *db.DB) {
+	t.Helper()
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCursorIDE: {root},
+		},
+		Machine: "local",
+	})
+	return engine, database
+}
+
+func TestSyncPathsCursorIDEDeletedComposerTombstonesSession(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{
+		{
+			id: "deleted-composer", name: "Deleted chat",
+			createdAt: 1782026756842, updatedAt: 1782026791522,
+			bubbles: []cursorIDESyncBubble{{
+				id: "b1", bubbleType: 1, text: "gone",
+				createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+		{
+			id: "surviving-composer", name: "Surviving chat",
+			createdAt: 1782026756842, updatedAt: 1782026801522,
+			bubbles: []cursorIDESyncBubble{{
+				id: "b1", bubbleType: 1, text: "kept",
+				createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+	})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+	beforeDelete, err := database.GetSessionFull(
+		t.Context(), "cursor-ide:deleted-composer",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, beforeDelete)
+
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	for _, key := range []string{
+		"composerData:deleted-composer", "bubbleId:deleted-composer:b1",
+	} {
+		_, err = writer.Exec(`DELETE FROM cursorDiskKV WHERE key = ?`, key)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+
+	engine.SyncPaths([]string{dbPath})
+
+	archived, err := database.GetSessionFull(
+		t.Context(), "cursor-ide:deleted-composer",
+	)
+	require.NoError(t, err)
+	assertSourceMissingState(t, archived)
+	assert.Equal(t, beforeDelete.MessageCount, archived.MessageCount,
+		"source loss must retain the archived transcript")
+	surviving, err := database.GetSessionFull(
+		t.Context(), "cursor-ide:surviving-composer",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, surviving)
+	assert.Nil(t, surviving.SourceMissingAt)
+}
+
+func TestSyncPathsCursorIDEDeletedPhysicalDBPreservesSessions(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "archived-composer", name: "Archived chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.Remove(dbPath))
+
+	engine.SyncPaths([]string{dbPath})
+
+	sess, err := database.GetSession(t.Context(), "cursor-ide:archived-composer")
+	require.NoError(t, err)
+	assert.NotNil(t, sess,
+		"removing state.vscdb must not delete already-synced sessions")
+}
+
+func TestReconcileWatchRootsCursorIDEDeletedMemberTombstonesSession(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{
+		{
+			id: "deleted-composer", name: "Deleted chat",
+			createdAt: 1782026756842, updatedAt: 1782026791522,
+			bubbles: []cursorIDESyncBubble{{
+				id: "b1", bubbleType: 1, text: "gone",
+				createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+		{
+			id: "surviving-composer", name: "Surviving chat",
+			createdAt: 1782026756842, updatedAt: 1782026801522,
+			bubbles: []cursorIDESyncBubble{{
+				id: "b1", bubbleType: 1, text: "kept",
+				createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+	})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	for _, key := range []string{
+		"composerData:deleted-composer", "bubbleId:deleted-composer:b1",
+	} {
+		_, err = writer.Exec(`DELETE FROM cursorDiskKV WHERE key = ?`, key)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{root}, false,
+	))
+
+	archived, err := database.GetSessionFull(
+		t.Context(), "cursor-ide:deleted-composer",
+	)
+	require.NoError(t, err)
+	assertSourceMissingState(t, archived)
+	surviving, err := database.GetSessionFull(
+		t.Context(), "cursor-ide:surviving-composer",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, surviving)
+	assert.Nil(t, surviving.SourceMissingAt)
+}
+
+func TestSyncAllCursorIDEAddedBubbleWithUnchangedTimestampReparses(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	composer := cursorIDESyncComposer{
+		id: "edited-composer", name: "Edited chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{composer})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	sess, err := database.GetSession(t.Context(), "cursor-ide:edited-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 1, sess.MessageCount)
+
+	// A new turn whose write leaves lastUpdatedAt untouched: the composer
+	// document changes only in its header list.
+	composer.bubbles = append(composer.bubbles, cursorIDESyncBubble{
+		id: "b2", bubbleType: 2, text: "world",
+		createdAt: "2026-06-21T07:27:31.522Z",
+	})
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		cursorIDEComposerJSON(t, composer), "composerData:edited-composer",
+	)
+	require.NoError(t, err)
+	raw, err := json.Marshal(map[string]any{
+		"type": 2, "text": "world", "createdAt": "2026-06-21T07:27:31.522Z",
+	})
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`,
+		"bubbleId:edited-composer:b2", raw,
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err = database.GetSession(t.Context(), "cursor-ide:edited-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, 2, sess.MessageCount,
+		"an added turn must not be dropped as unchanged when lastUpdatedAt is stale")
+}
+
+func TestSyncAllCursorIDEBubbleContentEditWithUnchangedComposerDocReparses(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "edited-composer", name: "Edited chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	sess, err := database.GetSession(t.Context(), "cursor-ide:edited-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.FirstMessage)
+	require.Equal(t, "hello", *sess.FirstMessage)
+
+	// Rewrite the bubble in place without touching composerData at all:
+	// lastUpdatedAt and the header list stay identical, so only the stored
+	// bubble bytes reveal the edit.
+	raw, err := json.Marshal(map[string]any{
+		"type": 1, "text": "hello, but rewritten in place",
+		"createdAt": "2026-06-21T07:27:29.606Z",
+	})
+	require.NoError(t, err)
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		raw, "bubbleId:edited-composer:b1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err = database.GetSession(t.Context(), "cursor-ide:edited-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.FirstMessage)
+	assert.Equal(t, "hello, but rewritten in place", *sess.FirstMessage,
+		"an in-place bubble rewrite must not be dropped as unchanged")
+}
+
+func TestSyncAllCursorIDEEmptiedContainerRetiresAllMembers(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "only-composer", name: "Only chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(`DELETE FROM cursorDiskKV`)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	archived, err := database.GetSessionFull(t.Context(), "cursor-ide:only-composer")
+	require.NoError(t, err)
+	assertSourceMissingState(t, archived)
+}
+
+func TestSyncAllCursorIDERenamedComposerWithUnchangedTimestampReparses(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	composer := cursorIDESyncComposer{
+		id: "renamed-composer", name: "Old name",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{composer})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+
+	// Rename the chat without touching lastUpdatedAt or any bubble: only the
+	// composer document's name field changes.
+	composer.name = "New name"
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		cursorIDEComposerJSON(t, composer), "composerData:renamed-composer",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err := database.GetSession(t.Context(), "cursor-ide:renamed-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.DisplayName)
+	assert.Equal(t, "New name", *sess.DisplayName,
+		"a rename that leaves lastUpdatedAt untouched must not be dropped as unchanged")
+}
+
+func TestSyncAllCursorIDESameSizeSameMtimeRewriteReparses(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "rewritten-composer", name: "Rewritten chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	// A second unchanged pass lets the engine record the container's
+	// skip-cache entry, so the rewrite below must actually defeat the cached
+	// skip rather than just the unchanged-result filter.
+	engine.SyncAll(t.Context(), nil)
+	before, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	// Rewrite the bubble to an equal-length value and restore the database
+	// file's mtime, so size, mtime, and the composer document are all
+	// byte-identical to the synced state. Only the SQLite change counter and
+	// the bubble's content differ.
+	raw, err := json.Marshal(map[string]any{
+		"type": 1, "text": "howdy", "createdAt": "2026-06-21T07:27:29.606Z",
+	})
+	require.NoError(t, err)
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		raw, "bubbleId:rewritten-composer:b1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	after, err := os.Stat(dbPath)
+	require.NoError(t, err)
+	require.Equal(t, before.Size(), after.Size(),
+		"fixture must reproduce a same-size rewrite")
+	require.NoError(t, os.Chtimes(dbPath, before.ModTime(), before.ModTime()))
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err := database.GetSession(
+		t.Context(), "cursor-ide:rewritten-composer",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.FirstMessage)
+	assert.Equal(t, "howdy", *sess.FirstMessage,
+		"a same-size, same-mtime rewrite must miss the skip cache and reparse")
+}

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -749,3 +749,85 @@ func TestResyncAllCursorIDEKeepsArchivedTranscriptOverGapResult(t *testing.T) {
 	assert.Equal(t, 2, sess.MessageCount,
 		"a full resync must not replace the archive with a gap transcript")
 }
+
+func TestSyncAllCursorIDEEmptiedBubbleKeepsArchivedTranscript(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "emptied-composer", name: "Emptied chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{
+			{id: "b1", bubbleType: 1, text: "ask", createdAt: "2026-06-21T07:27:29.606Z"},
+			{id: "b2", bubbleType: 2, text: "answer", createdAt: "2026-06-21T07:27:31.522Z"},
+		},
+	}})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	sess, err := database.GetSession(t.Context(), "cursor-ide:emptied-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 2, sess.MessageCount)
+
+	// The bubble row survives but its content is wiped in place: the header
+	// still references it, so the transcript is incomplete, not edited.
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+		[]byte(`{}`), "bubbleId:emptied-composer:b2",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err = database.GetSession(t.Context(), "cursor-ide:emptied-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, 2, sess.MessageCount,
+		"a bubble emptied in place must not erase the archived turn")
+}
+
+func TestSyncAllCursorIDEReplacedDatabaseFileReparses(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	composer := func(text string) cursorIDESyncComposer {
+		return cursorIDESyncComposer{
+			id: "replaced-composer", name: "Replaced chat",
+			createdAt: 1782026756842, updatedAt: 1782026791522,
+			bubbles: []cursorIDESyncBubble{{
+				id: "b1", bubbleType: 1, text: text,
+				createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		}
+	}
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{composer("hello")})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	// A second unchanged pass records the container's skip-cache entry.
+	engine.SyncAll(t.Context(), nil)
+	before, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	// Rename a different database over state.vscdb, built by an identical
+	// statement sequence so its size and 100-byte header match, and restore
+	// the mtime -- the shape of a backup restore or profile switch. Only the
+	// file identity distinguishes it.
+	otherPath := filepath.Join(t.TempDir(), "state.vscdb")
+	createCursorIDEStateDB(t, otherPath, []cursorIDESyncComposer{composer("howdy")})
+	require.NoError(t, os.Rename(otherPath, dbPath))
+	after, err := os.Stat(dbPath)
+	require.NoError(t, err)
+	require.Equal(t, before.Size(), after.Size(),
+		"fixture must reproduce a same-size replacement")
+	require.NoError(t, os.Chtimes(dbPath, before.ModTime(), before.ModTime()))
+
+	engine.SyncAll(t.Context(), nil)
+
+	sess, err := database.GetSession(t.Context(), "cursor-ide:replaced-composer")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.FirstMessage)
+	assert.Equal(t, "howdy", *sess.FirstMessage,
+		"a replaced database file must miss the skip cache and reparse")
+}

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -790,9 +789,6 @@ func TestSyncAllCursorIDEEmptiedBubbleKeepsArchivedTranscript(t *testing.T) {
 }
 
 func TestSyncAllCursorIDEReplacedDatabaseFileReparses(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("the replacement is detectable only by inode/device identity, which sourceFileIdentity does not provide on Windows")
-	}
 	root := t.TempDir()
 	dbPath := filepath.Join(root, "state.vscdb")
 	composer := func(text string) cursorIDESyncComposer {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11344,6 +11344,9 @@ func (e *Engine) processProviderFile(
 	filteredResults := e.dropUnchangedSharedSQLiteResults(
 		file, parsedResults, providerSemantics.UnchangedResults,
 	)
+	filteredResults = e.dropShrinkingTruncatedCursorIDEResults(
+		file, filteredResults,
+	)
 	res := processResult{
 		results:              filteredResults,
 		excludedSessionIDs:   excludedSessionIDs,
@@ -11468,6 +11471,39 @@ func (e *Engine) dropUnchangedSharedSQLiteResults(
 			continue
 		}
 		// Unchanged: drop so the write batch neither rewrites nor recounts it.
+	}
+	return kept
+}
+
+// dropShrinkingTruncatedCursorIDEResults keeps a Cursor IDE composer whose
+// parse saw headers referencing missing bubble rows (a partial cursorDiskKV
+// wipe, flagged IsTruncated by the parser) from force-replacing an archived
+// session with fewer messages than it already has. First-time discovery and
+// a gapped conversation that keeps growing still write, so a wiped database
+// continues to surface its remaining content; only the shrinking overwrite
+// is refused, preserving the fuller archived transcript. The emitted result
+// still counts as present for ownership reconciliation, so the preserved
+// session stays active rather than being marked source-missing.
+func (e *Engine) dropShrinkingTruncatedCursorIDEResults(
+	file parser.DiscoveredFile,
+	results []parser.ParseResult,
+) []parser.ParseResult {
+	if file.Agent != parser.AgentCursorIDE || len(results) == 0 ||
+		e.forceParseRequested(file) {
+		return results
+	}
+	kept := results[:0]
+	for _, r := range results {
+		if !r.Session.IsTruncated {
+			kept = append(kept, r)
+			continue
+		}
+		id := applyIDPrefixToID(e.idPrefix, r.Session.ID)
+		stored, ok := e.db.GetSessionMessageCount(id)
+		if ok && r.Session.MessageCount < stored {
+			continue
+		}
+		kept = append(kept, r)
 	}
 	return kept
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11345,7 +11345,7 @@ func (e *Engine) processProviderFile(
 		file, parsedResults, providerSemantics.UnchangedResults,
 	)
 	filteredResults = e.dropShrinkingTruncatedCursorIDEResults(
-		file, filteredResults,
+		ctx, file, filteredResults,
 	)
 	res := processResult{
 		results:              filteredResults,
@@ -11478,13 +11478,17 @@ func (e *Engine) dropUnchangedSharedSQLiteResults(
 // dropShrinkingTruncatedCursorIDEResults keeps a Cursor IDE composer whose
 // parse saw headers referencing missing bubble rows (a partial cursorDiskKV
 // wipe, flagged IsTruncated by the parser) from force-replacing an archived
-// session with fewer messages than it already has. First-time discovery and
-// a gapped conversation that keeps growing still write, so a wiped database
-// continues to surface its remaining content; only the shrinking overwrite
-// is refused, preserving the fuller archived transcript. The emitted result
-// still counts as present for ownership reconciliation, so the preserved
-// session stays active rather than being marked source-missing.
+// session that has messages the truncated transcript no longer carries.
+// Every message's source_uuid is its bubble UUID, so the guard admits a
+// truncated result only when it still contains every archived bubble: a
+// message count alone would admit a wipe of an earlier bubble masked by
+// newly added turns. First-time discovery and a gapped conversation that
+// keeps growing still write, so a wiped database continues to surface its
+// remaining content. The emitted result still counts as present for
+// ownership reconciliation, so a preserved session stays active rather than
+// being marked source-missing.
 func (e *Engine) dropShrinkingTruncatedCursorIDEResults(
+	ctx context.Context,
 	file parser.DiscoveredFile,
 	results []parser.ParseResult,
 ) []parser.ParseResult {
@@ -11499,8 +11503,26 @@ func (e *Engine) dropShrinkingTruncatedCursorIDEResults(
 			continue
 		}
 		id := applyIDPrefixToID(e.idPrefix, r.Session.ID)
-		stored, ok := e.db.GetSessionMessageCount(id)
-		if ok && r.Session.MessageCount < stored {
+		archived, err := e.db.ListMessageSourceUUIDs(ctx, id)
+		if err != nil {
+			// The archive cannot be verified; refusing the overwrite is the
+			// recoverable direction.
+			continue
+		}
+		incoming := make(map[string]struct{}, len(r.Messages))
+		for _, msg := range r.Messages {
+			if msg.SourceUUID != "" {
+				incoming[msg.SourceUUID] = struct{}{}
+			}
+		}
+		containsArchive := true
+		for _, uuid := range archived {
+			if _, ok := incoming[uuid]; !ok {
+				containsArchive = false
+				break
+			}
+		}
+		if !containsArchive {
 			continue
 		}
 		kept = append(kept, r)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11373,8 +11373,11 @@ func (e *Engine) processProviderFile(
 		fingerprint.Hash != "" {
 		// A whole-container parse may only be skip-cached after its member
 		// writes commit (cache-after-write); virtual member parses keep the
-		// immediate cache path.
-		res.cacheAfterWrite = providerPersistentSharedContainerSource(source)
+		// immediate cache path. A truncation-verification failure must not
+		// be promoted either: caching that pass as clean would freeze the
+		// refused result behind a cached skip instead of retrying it.
+		res.cacheAfterWrite = providerPersistentSharedContainerSource(source) &&
+			!truncationVerifyFailed
 	}
 	// Incremental-append providers (Claude and Codex) need the stored file
 	// identity so a later sync can detect an atomic file replacement

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11498,6 +11498,32 @@ func (e *Engine) dropShrinkingTruncatedCursorIDEResults(
 		e.forceParseRequested(file) {
 		return results, false
 	}
+	type messageSourceUUIDReader interface {
+		ListMessageSourceUUIDs(context.Context, string) ([]string, error)
+	}
+	reader := messageSourceUUIDReader(e.db)
+	if e.archiveStore != nil {
+		// A rebuild writes into a fresh database while the original archive
+		// remains readable as archiveStore. Verifying against the empty
+		// rebuild target would admit every truncated transcript, and once
+		// written there the orphan copy would never rescue the fuller
+		// original. A refused write instead leaves the session out of the
+		// rebuild, and the orphan copy carries the archived full transcript
+		// across.
+		archived, ok := e.archiveStore.(messageSourceUUIDReader)
+		if !ok {
+			kept = results[:0]
+			for _, r := range results {
+				if r.Session.IsTruncated {
+					verifyFailed = true
+					continue
+				}
+				kept = append(kept, r)
+			}
+			return kept, verifyFailed
+		}
+		reader = archived
+	}
 	kept = results[:0]
 	for _, r := range results {
 		if !r.Session.IsTruncated {
@@ -11505,7 +11531,7 @@ func (e *Engine) dropShrinkingTruncatedCursorIDEResults(
 			continue
 		}
 		id := applyIDPrefixToID(e.idPrefix, r.Session.ID)
-		archived, err := e.db.ListMessageSourceUUIDs(ctx, id)
+		archived, err := reader.ListMessageSourceUUIDs(ctx, id)
 		if err != nil {
 			// The archive cannot be verified; refusing the overwrite is the
 			// recoverable direction.
@@ -18604,6 +18630,14 @@ func (e *Engine) providerSessionSourceMtime(
 		if err != nil || !providerOutcomeContainsSession(outcome, sessionID) {
 			return 0
 		}
+	}
+	if def.Type == parser.AgentCursorIDE && fingerprint.Hash != "" {
+		// SourceMtime is an equality-only change token (see the Codebuff
+		// branch): folding the member content digest in lets the watcher's
+		// polling fallback see an edit that leaves lastUpdatedAt untouched.
+		h := fnv.New64a()
+		_, _ = fmt.Fprintf(h, "%d|%s", fingerprint.MTimeNS, fingerprint.Hash)
+		return int64(h.Sum64())
 	}
 	return fingerprint.MTimeNS
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11344,9 +11344,8 @@ func (e *Engine) processProviderFile(
 	filteredResults := e.dropUnchangedSharedSQLiteResults(
 		file, parsedResults, providerSemantics.UnchangedResults,
 	)
-	filteredResults = e.dropShrinkingTruncatedCursorIDEResults(
-		ctx, file, filteredResults,
-	)
+	filteredResults, truncationVerifyFailed :=
+		e.dropShrinkingTruncatedCursorIDEResults(ctx, file, filteredResults)
 	res := processResult{
 		results:              filteredResults,
 		excludedSessionIDs:   excludedSessionIDs,
@@ -11355,7 +11354,7 @@ func (e *Engine) processProviderFile(
 		mtime:                fingerprint.MTimeNS,
 		cacheSkip:            cacheSkip,
 		cacheKey:             cacheKey,
-		noCacheSkip:          !cleanCache,
+		noCacheSkip:          !cleanCache || truncationVerifyFailed,
 		forceReplace:         outcome.ForceReplace || incForceReplace,
 		suppressPresenceSweep: outcome.SkipReason == parser.SkipUnsupportedSource ||
 			!outcome.ResultSetComplete,
@@ -11487,16 +11486,19 @@ func (e *Engine) dropUnchangedSharedSQLiteResults(
 // remaining content. The emitted result still counts as present for
 // ownership reconciliation, so a preserved session stays active rather than
 // being marked source-missing.
+// The returned verifyFailed reports that an archive read failed during
+// verification: the caller must not skip-cache the pass as clean, so the
+// dropped result is re-attempted instead of frozen behind a cached skip.
 func (e *Engine) dropShrinkingTruncatedCursorIDEResults(
 	ctx context.Context,
 	file parser.DiscoveredFile,
 	results []parser.ParseResult,
-) []parser.ParseResult {
+) (kept []parser.ParseResult, verifyFailed bool) {
 	if file.Agent != parser.AgentCursorIDE || len(results) == 0 ||
 		e.forceParseRequested(file) {
-		return results
+		return results, false
 	}
-	kept := results[:0]
+	kept = results[:0]
 	for _, r := range results {
 		if !r.Session.IsTruncated {
 			kept = append(kept, r)
@@ -11507,6 +11509,7 @@ func (e *Engine) dropShrinkingTruncatedCursorIDEResults(
 		if err != nil {
 			// The archive cannot be verified; refusing the overwrite is the
 			// recoverable direction.
+			verifyFailed = true
 			continue
 		}
 		incoming := make(map[string]struct{}, len(r.Messages))
@@ -11527,7 +11530,7 @@ func (e *Engine) dropShrinkingTruncatedCursorIDEResults(
 		}
 		kept = append(kept, r)
 	}
-	return kept
+	return kept, verifyFailed
 }
 
 func (e *Engine) providerSourceSessionIDsForForceReplace(
@@ -18619,6 +18622,13 @@ func providerSourceMtimeNeedsFingerprint(agent parser.AgentType) bool {
 	switch agent {
 	case parser.AgentQoder:
 		// Qoder stores a sidecar whose mtime the plain path stat misses.
+		return true
+	case parser.AgentCursorIDE:
+		// A "state.vscdb#<composer>" virtual path cannot be stat'ed. The
+		// path-shape check already routes it through the member fingerprint
+		// because Windsurf's database shares the state.vscdb name; this
+		// entry makes cursor-ide's session-watcher token independent of
+		// that coincidence.
 		return true
 	default:
 		// RooCode is deliberately absent: its fingerprint content-hashes

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2304,6 +2304,17 @@ func providerVirtualSourceContainerExists(path string) bool {
 	return container != path && parser.IsRegularFile(container)
 }
 
+// providerPersistentSharedContainerSource reports whether source addresses a
+// whole shared-database container whose archive rows are all virtual members:
+// Omnigent's chat.db or Cursor IDE's state.vscdb. Such containers have no
+// stored row under their own physical path, so skip-cache identity carries
+// the container hash and parser data version instead of a stored-row check,
+// and container parses are cached only after their member writes commit.
+func providerPersistentSharedContainerSource(source parser.SourceRef) bool {
+	return parser.IsOmnigentContainerSource(source) ||
+		parser.IsCursorIDEContainerSource(source)
+}
+
 func providerDeletedPhysicalSQLiteSource(
 	agent parser.AgentType, path string,
 ) bool {
@@ -11214,7 +11225,8 @@ func (e *Engine) processProviderFile(
 			omnigentContainerExists :=
 				parser.IsOmnigentContainerSource(source) &&
 					parser.IsRegularFile(providerDiscoveredPath(source))
-			traeContainerExists := file.Agent == parser.AgentTrae &&
+			sharedContainerExists := (file.Agent == parser.AgentTrae ||
+				file.Agent == parser.AgentCursorIDE) &&
 				parser.IsRegularFile(providerDiscoveredPath(source))
 			sourceFileMissing := false
 			if statPath := validatedProviderSourceStatPath(file.Path); statPath != "" {
@@ -11223,14 +11235,14 @@ func (e *Engine) processProviderFile(
 			}
 			if e.pathRewriter != nil ||
 				(providerVirtualSourceContainerExists(file.Path) ||
-					omnigentContainerExists || traeContainerExists ||
+					omnigentContainerExists || sharedContainerExists ||
 					sourceFileMissing) {
 				// The provider re-resolved this exact virtual member against a
 				// still-present shared container, or authoritatively parsed an
-				// empty Omnigent or Trae container, or the backing source itself
-				// is gone. Carry the stored ownership to the recoverable
-				// source-missing seam instead of treating absence as a parser
-				// exclusion.
+				// empty Omnigent, Trae, or Cursor IDE container, or the backing
+				// source itself is gone. Carry the stored ownership to the
+				// recoverable source-missing seam instead of treating absence
+				// as a parser exclusion.
 				missingMembers = owned
 			} else {
 				for _, member := range owned {
@@ -11279,6 +11291,7 @@ func (e *Engine) processProviderFile(
 	// so ownership reconciliation is needed only by real sync engines.
 	if (file.Agent == parser.AgentKiro ||
 		(file.Agent == parser.AgentOmnigent && outcome.ForceReplace) ||
+		(file.Agent == parser.AgentCursorIDE && outcome.ForceReplace) ||
 		(file.Agent == parser.AgentTrae && !e.forceParse)) &&
 		outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 {
 		missingMembers, err = e.providerSourceMissingSessionOwnershipsForCompleteResultWithPreserved(
@@ -11351,14 +11364,15 @@ func (e *Engine) processProviderFile(
 		sourceCwdStored:          cwdDecision.storedCwd,
 		sourceCwdStoredOK:        cwdDecision.storedOK,
 	}
-	if file.Agent == parser.AgentOmnigent && cacheSkip && cleanCache &&
+	if (file.Agent == parser.AgentOmnigent ||
+		file.Agent == parser.AgentCursorIDE) && cacheSkip && cleanCache &&
 		!e.forceParseRequested(file) &&
 		outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 &&
 		fingerprint.Hash != "" {
-		// A whole-container omnigent parse may only be skip-cached after its
-		// member writes commit (cache-after-write); virtual member parses keep
-		// the immediate cache path.
-		res.cacheAfterWrite = parser.IsOmnigentContainerSource(source)
+		// A whole-container parse may only be skip-cached after its member
+		// writes commit (cache-after-write); virtual member parses keep the
+		// immediate cache path.
+		res.cacheAfterWrite = providerPersistentSharedContainerSource(source)
 	}
 	// Incremental-append providers (Claude and Codex) need the stored file
 	// identity so a later sync can detect an atomic file replacement
@@ -12552,10 +12566,10 @@ func providerProcessCacheKey(
 	key = providerProcessCacheKeyWithHash(
 		key, fingerprint, providerSemantics,
 	)
-	// A whole-container omnigent cache identity includes the parser data
-	// version: the container has no stored row of its own, so a restart must
-	// not accept an entry recorded by an older parser version.
-	if parser.IsOmnigentContainerSource(source) {
+	// A whole-container cache identity includes the parser data version: the
+	// container has no stored row of its own, so a restart must not accept
+	// an entry recorded by an older parser version.
+	if providerPersistentSharedContainerSource(source) {
 		separator := "?"
 		if strings.Contains(key, "?") {
 			separator = "&"
@@ -12639,11 +12653,12 @@ func (e *Engine) providerSkipCacheEntryFreshInDB(
 		!providerSemantics.FingerprintHashRequiredForFreshness {
 		return true, false
 	}
-	if parser.IsOmnigentContainerSource(source) {
-		// A whole-container omnigent source has only virtual member rows in
-		// the archive, so its entry is fresh without ever finding a row for
-		// the physical container path: the cache identity already carries the
-		// container hash and parser data version. This is distinct from
+	if providerPersistentSharedContainerSource(source) {
+		// A whole-container source (Omnigent chat.db, Cursor IDE state.vscdb)
+		// has only virtual member rows in the archive, so its entry is fresh
+		// without ever finding a row for the physical container path: the
+		// cache identity already carries the container hash and parser data
+		// version. This is distinct from
 		// ProviderSyncSemantics.SkipCacheFreshWithoutStoredRow below, which
 		// trusts an entry only while NO row exists yet and resumes stored-row
 		// hash validation once the provider persists one.


### PR DESCRIPTION
Cursor IDE, the GUI editor, stores chats in a VS Code-style global-state SQLite database (`state.vscdb`, table `cursorDiskKV`) rather than the `agent-transcripts` files the existing `cursor` (Cursor Agent CLI) provider reads, so GUI sessions were never discovered. This adds a distinct `cursor-ide` provider on the shared `multiSessionContainerSourceSet` framework (the same shape as Zed and Omnigent): `composerData:<uuid>` rows decode into sessions, and each session's `fullConversationHeadersOnly` array orders lookups into sibling `bubbleId:<composerId>:<bubbleUuid>` rows for message content, tool calls, and timestamps. The existing `cursor` provider is untouched.

Freshness and deletion semantics, where reviewers should look:

- Fingerprinting never hashes the full database (86MB+ observed locally, 500MB+ reported in the wild). The container fingerprint uses size, composite mtime, and a SQLite transaction-state hash over just the database and WAL headers (change counter, schema cookie, WAL size and salts), declared with `FingerprintHashInCacheKey` and `FingerprintHashRequiredForFreshness`, so a rewrite that lands on the same size and mtime still misses the skip cache. The per-composer fingerprint digests every parse input — the raw `composerData` document plus that composer's bubble rows — so an equal-length bubble rewrite, a header reorder, or a rename that leaves `lastUpdatedAt` untouched still reparses under `UnchangedResultMTimeAndHash`.
- A chat deleted inside Cursor IDE is marked source-missing and stays browsable, never hard-deleted. Stored-source hints fan a `state.vscdb` change event out into per-member tombstones using a batched single-connection membership check, and `internal/sync/engine.go` includes cursor-ide in complete-container ownership reconciliation, in the emptied-container source-missing seam, and in the whole-container skip-cache exemptions generalized from Omnigent (no stored row of its own, parser data version in the cache key, cache-after-write). Removing `state.vscdb` itself preserves every archived session.
- `state.vscdb` co-locates Cursor's live auth tokens (`ItemTable`) and per-composer sync encryption keys, so the provider is `RemoteSyncExcluded`, matching the Omnigent `chat.db` precedent.

Deletion, reconciliation, emptied-container, stale-edit, and same-size/same-mtime rewrite behavior is pinned by `internal/sync/cursor_ide_integration_test.go`; parsing and fingerprinting by `internal/parser/cursor_ide_test.go`. The `docs/internal/session-format-sources.md` entry records the schema evidence per the provenance convention.
