### PR TITLE
fix(vector): keep embedding builds alive through rate limits

### DIFF
--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -722,8 +722,11 @@ func setupVectorServing(
 		RecallScheduler:      recallScheduler,
 		RecallMutationNotify: recallMutationNotify,
 		Close: func() error {
-			mgr.Wait()
-			recallMgr.Wait()
+			// Shutdown, not Wait: a detached API build may be waiting out
+			// provider rate limits indefinitely and must be canceled for
+			// daemon shutdown to complete.
+			mgr.Shutdown()
+			recallMgr.Shutdown()
 			ixErr := ix.Close()
 			recallErr := recallIX.Close()
 			lockErr := lock.Close()

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -1449,7 +1449,12 @@ func TestEmbeddingsDaemonClientBuildSucceedsThroughRealMiddleware(t *testing.T) 
 		"a POST build must succeed once the client sets Origin to satisfy the CSRF guard")
 }
 
-func TestVectorServingCloseWaitsForAPIStartedRecallBuild(t *testing.T) {
+// TestVectorServingCloseCancelsAPIStartedRecallBuild pins the shutdown
+// contract for detached API builds: Close cancels an in-flight build rather
+// than waiting for it, because a document build may be waiting out provider
+// rate limits indefinitely (EncoderConfig.RetryRateLimits) and progress is
+// durable across restarts anyway.
+func TestVectorServingCloseCancelsAPIStartedRecallBuild(t *testing.T) {
 	dataDir := t.TempDir()
 	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
 	dbtest.SeedSession(t, database, "s1", "agentsview")
@@ -1479,7 +1484,9 @@ func TestVectorServingCloseWaitsForAPIStartedRecallBuild(t *testing.T) {
 			}
 		}
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.MarshalWrite(w, map[string]any{"data": data}))
+		// Best-effort: once Close cancels the build, the client has already
+		// aborted this request and the write fails with a dead connection.
+		_ = json.MarshalWrite(w, map[string]any{"data": data})
 	}))
 	t.Cleanup(stub.Close)
 
@@ -1512,20 +1519,15 @@ func TestVectorServingCloseWaitsForAPIStartedRecallBuild(t *testing.T) {
 		require.Fail(t, "manual Recall build never reached the encoder")
 	}
 
+	// The encoder is never released before Close: Close itself must cancel
+	// the detached build to return.
 	closeDone := make(chan error, 1)
 	go func() { closeDone <- closeVectorServing() }()
 	select {
 	case closeErr := <-closeDone:
 		require.NoError(t, closeErr)
-		require.Fail(t, "vector serving closed while the API build was active")
-	case <-time.After(100 * time.Millisecond):
-	}
-	releaseEncode()
-	select {
-	case closeErr := <-closeDone:
-		require.NoError(t, closeErr)
 	case <-time.After(10 * time.Second):
-		require.Fail(t, "vector serving did not close after the API build completed")
+		require.Fail(t, "vector serving did not cancel the in-flight API build on Close")
 	}
 }
 

--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -294,7 +294,7 @@ func recallVectorGeneration(
 // named server ("" means the default), combining the global model identity
 // and caller-selected role prefix with that server's transport settings.
 func newVectorEncoder(
-	c config.VectorEmbeddingsConfig, serverName, inputPrefix string,
+	c config.VectorEmbeddingsConfig, serverName, inputPrefix string, retryRateLimits bool,
 ) (kitvec.EncodeFunc, error) {
 	name, server, err := c.Server(serverName)
 	if err != nil {
@@ -314,25 +314,29 @@ func newVectorEncoder(
 		RequestDimensions: c.RequestDimensions,
 		Timeout:           timeout,
 		MaxRetries:        server.MaxRetries,
+		RetryRateLimits:   retryRateLimits,
 		InputPrefix:       inputPrefix,
 		InputSuffix:       c.InputSuffix,
 	}), nil
 }
 
 // newVectorQueryEncoder builds the default or named server encoder used only
-// for search queries.
+// for search queries. Queries are latency-sensitive, so a 429 fails fast
+// through the normal MaxRetries budget rather than retrying indefinitely.
 func newVectorQueryEncoder(
 	c config.VectorEmbeddingsConfig, serverName string,
 ) (kitvec.EncodeFunc, error) {
-	return newVectorEncoder(c, serverName, c.QueryPrefix)
+	return newVectorEncoder(c, serverName, c.QueryPrefix, false)
 }
 
 // newVectorDocumentEncoder builds the default or named server encoder used
-// only for document builds and repairs.
+// only for document builds and repairs. Document builds are long-running and
+// durable (progress survives a restart), so a 429 is retried until it clears
+// rather than aborting the whole build.
 func newVectorDocumentEncoder(
 	c config.VectorEmbeddingsConfig, serverName string,
 ) (kitvec.EncodeFunc, error) {
-	return newVectorEncoder(c, serverName, c.DocumentPrefix)
+	return newVectorEncoder(c, serverName, c.DocumentPrefix, true)
 }
 
 // vectorDocumentEncoderSet builds one document encoder per configured

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -229,7 +229,7 @@ func TestNewVectorEncoderWiresOllamaCPUFallback(t *testing.T) {
 				OllamaCPUFallback: true,
 			},
 		},
-	}, "local", "")
+	}, "local", "", false)
 	require.NoError(t, err)
 
 	out, err := enc(context.Background(), []string{"alpha"})

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -48,8 +48,9 @@ batch_size = 32                   # inputs per HTTP call (default 32)
 concurrency = 4                   # documents embedded in parallel during a build (default 4)
 timeout = "30s"                   # per-HTTP-call timeout (default "30s")
 max_retries = 3                   # attempts on 5xx/network errors; 4xx fails fast (default 3)
-                                   # document builds retry a 429 until it clears instead of
-                                   # spending this budget on it; query encoders still count it here
+                                   # document builds retry a 429 until it clears (or the daemon
+                                   # shuts down) instead of spending this budget on it; query
+                                   # encoders still count it here
 # ollama_cpu_fallback = true      # Ollama only: retry invalid Metal vectors once on CPU
 
 [vector.embed]

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -47,7 +47,9 @@ api_key_env = "OPENAI_API_KEY"    # name of an env var holding the key; omit for
 batch_size = 32                   # inputs per HTTP call (default 32)
 concurrency = 4                   # documents embedded in parallel during a build (default 4)
 timeout = "30s"                   # per-HTTP-call timeout (default "30s")
-max_retries = 3                   # attempts on 429/5xx/network errors; 4xx fails fast (default 3)
+max_retries = 3                   # attempts on 5xx/network errors; 4xx fails fast (default 3)
+                                   # document builds retry a 429 until it clears instead of
+                                   # spending this budget on it; query encoders still count it here
 # ollama_cpu_fallback = true      # Ollama only: retry invalid Metal vectors once on CPU
 
 [vector.embed]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,8 +223,11 @@ type VectorEmbeddingsServerConfig struct {
 	// Timeout is a parseable duration string applied to each HTTP
 	// call. Default "30s".
 	Timeout string `toml:"timeout" json:"timeout"`
-	// MaxRetries is the maximum total attempts on 429/5xx/network errors
-	// (4xx fails fast); 0 means one attempt. Default 3.
+	// MaxRetries is the maximum total attempts on retryable errors other than
+	// document-build 429 rate limits, which retry until success or
+	// cancellation instead of consuming this budget (see
+	// vector.EncoderConfig.RetryRateLimits). Other 4xx responses fail fast;
+	// 0 means one attempt. Default 3.
 	MaxRetries int `toml:"max_retries" json:"max_retries"`
 }
 

--- a/internal/vector/encoder.go
+++ b/internal/vector/encoder.go
@@ -49,9 +49,14 @@ type EncoderConfig struct {
 	RequestDimensions bool
 	// Timeout bounds each individual HTTP request.
 	Timeout time.Duration
-	// MaxRetries is the maximum total attempts on 429/5xx/network errors
-	// (4xx fails fast); values <= 0 mean one attempt.
+	// MaxRetries is the maximum total attempts on retryable errors; values
+	// <= 0 mean one attempt. A 429 does not consume this budget when
+	// RetryRateLimits is enabled.
 	MaxRetries int
+	// RetryRateLimits keeps retrying HTTP 429 responses until the request
+	// succeeds or ctx is canceled. Long-running document builds enable this;
+	// latency-sensitive query encoders leave it disabled and use MaxRetries.
+	RetryRateLimits bool
 	// InputPrefix is prepended verbatim to every input text before it is
 	// sent. Callers use distinct encoder instances when query and document
 	// inputs require different task instructions. Empty means no prefix.
@@ -448,13 +453,15 @@ func (ec *encoderClient) encode(ctx context.Context, texts []string) ([][]float3
 		return nil, err
 	}
 
-	attempts := ec.cfg.MaxRetries
-	if attempts <= 0 {
-		attempts = 1
+	maxAttempts := ec.cfg.MaxRetries
+	if maxAttempts <= 0 {
+		maxAttempts = 1
 	}
 
 	var lastErr error
-	for attempt := 1; attempt <= attempts; attempt++ {
+	nonRateLimitAttempts := 0
+	rateLimitAttempts := 0
+	for {
 		vectors, retryable, err := ec.attemptEncode(ctx, reqBody, texts)
 		if err == nil {
 			return vectors, nil
@@ -479,7 +486,20 @@ func (ec *encoderClient) encode(ctx context.Context, texts []string) ([][]float3
 				ec.cfg.Model, err)
 		}
 		lastErr = err
-		if attempt == attempts && ec.cfg.OllamaCPUFallback {
+		if ec.cfg.RetryRateLimits && isRateLimitError(err) {
+			// A 429 is the one error class the provider tells us exactly how
+			// to handle: it clears with time and doesn't indicate the request
+			// itself is broken. Retry it forever (until ctx is canceled)
+			// rather than spending the limited MaxRetries budget on it, so a
+			// large build doesn't abort permanently on a transient quota.
+			rateLimitAttempts++
+			if err := sleepBackoff(ctx, rateLimitAttempts, err); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		nonRateLimitAttempts++
+		if nonRateLimitAttempts == maxAttempts && ec.cfg.OllamaCPUFallback {
 			if _, ok := errors.AsType[*InvalidEmbeddingError](err); ok {
 				merged, fallbackErr := ec.ollamaCPUFallback(ctx, texts, vectors)
 				if fallbackErr == nil {
@@ -491,14 +511,22 @@ func (ec *encoderClient) encode(ctx context.Context, texts []string) ([][]float3
 				)
 			}
 		}
-		if !retryable || attempt == attempts {
+		if !retryable || nonRateLimitAttempts == maxAttempts {
 			return nil, lastErr
 		}
-		if err := sleepBackoff(ctx, attempt, err); err != nil {
+		if err := sleepBackoff(ctx, nonRateLimitAttempts, err); err != nil {
 			return nil, err
 		}
 	}
-	return nil, lastErr
+}
+
+// isRateLimitError reports whether err is an HTTP 429 (Too Many Requests)
+// response from the embeddings endpoint.
+func isRateLimitError(err error) bool {
+	if statusErr, ok := errors.AsType[*HTTPStatusError](err); ok {
+		return statusErr.Status == http.StatusTooManyRequests
+	}
+	return false
 }
 
 func (ec *encoderClient) ollamaCPUFallback(

--- a/internal/vector/encoder_test.go
+++ b/internal/vector/encoder_test.go
@@ -1251,6 +1251,72 @@ func TestEncoderRetries429ThenSucceeds(t *testing.T) {
 	assert.Equal(t, int32(2), attempts.Load())
 }
 
+func TestEncoderRetryRateLimitsSurvivesMoreRateLimitsThanMaxRetries(t *testing.T) {
+	// Reproduces #1353: embeddings build must not abort permanently on a
+	// 429 that clears with time. 5 consecutive 429s exceed MaxRetries: 1,
+	// so without RetryRateLimits this would fail on the second attempt.
+	var attempts atomic.Int32
+	const rateLimitedResponses = 5
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n <= rateLimitedResponses {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("rate limited"))
+			return
+		}
+		writeJSON(t, w, http.StatusOK, embeddingsResponse{
+			Data: []embeddingDatum{{Index: 0, Embedding: []float32{1, 2, 3}}},
+		})
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:        srv.URL + "/v1",
+		Model:           "test-model",
+		Dimension:       3,
+		Timeout:         5 * time.Second,
+		MaxRetries:      1,
+		RetryRateLimits: true,
+	})
+
+	out, err := enc(context.Background(), []string{"hello"})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	// Not an exact count: Go's transport can silently retry a request once at
+	// the connection level after a backoff-induced idle period, so the raw
+	// request count the server observes isn't 1:1 with encode()'s own retry
+	// counter. What actually matters is that MORE than MaxRetries rate-limited
+	// responses didn't abort the call.
+	assert.GreaterOrEqual(t, attempts.Load(), int32(rateLimitedResponses+1))
+}
+
+func TestEncoderRetryRateLimitsDisabledFailsFastOn429PastMaxRetries(t *testing.T) {
+	// Without RetryRateLimits, a 429 is just another retryable error and
+	// still respects MaxRetries -- this is the pre-existing behavior for
+	// latency-sensitive query encoders (see newVectorQueryEncoder).
+	var attempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("rate limited"))
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:   srv.URL + "/v1",
+		Model:      "test-model",
+		Dimension:  3,
+		Timeout:    5 * time.Second,
+		MaxRetries: 2,
+	})
+
+	_, err := enc(context.Background(), []string{"hello"})
+	require.Error(t, err)
+	assert.Equal(t, int32(2), attempts.Load())
+}
+
 func TestEncoder500ExhaustsRetries(t *testing.T) {
 	var attempts atomic.Int32
 

--- a/internal/vector/manager.go
+++ b/internal/vector/manager.go
@@ -88,6 +88,13 @@ type Manager struct {
 	// non-blocking while a build is in flight.
 	opMu sync.Mutex
 
+	// detachedCtx is the lifecycle context for StartBuild's detached build
+	// goroutines: it outlives the HTTP request that triggered a build but is
+	// canceled by Shutdown, so a build stuck waiting out rate limits cannot
+	// block daemon shutdown forever. cancelDetached cancels it.
+	detachedCtx    context.Context
+	cancelDetached context.CancelFunc
+
 	// mu guards running and status; held only for short field updates so
 	// Status() stays responsive during a build.
 	mu        sync.Mutex
@@ -219,9 +226,11 @@ func NewResolvingManager(
 		me.Encode = recoveringEncoder(me.Encode)
 		wrapped.ByName[name] = me
 	}
+	detachedCtx, cancelDetached := context.WithCancel(context.Background())
 	return &Manager{
 		ix: ix, encoders: wrapped, gen: displayGen,
 		resolveTarget: resolveTarget, now: time.Now,
+		detachedCtx: detachedCtx, cancelDetached: cancelDetached,
 	}
 }
 
@@ -259,8 +268,8 @@ func recoveringEncoder(enc kitvec.EncodeFunc) kitvec.EncodeFunc {
 
 // StartBuild launches a Build in a background goroutine, returning
 // ErrBuildRunning if one is already in flight rather than queuing behind it.
-// The goroutine runs against context.Background() so it outlives the HTTP
-// request that triggered it.
+// The goroutine runs against the manager's detached lifecycle context so it
+// outlives the HTTP request that triggered it but still stops on Shutdown.
 func (m *Manager) StartBuild(req BuildRequest) error {
 	if err := validateBuildRequest(req); err != nil {
 		return err
@@ -273,7 +282,7 @@ func (m *Manager) StartBuild(req BuildRequest) error {
 		return err
 	}
 	go func() {
-		result, err := m.runBuild(context.Background(), req, me)
+		result, err := m.runBuild(m.detachedCtx, req, me)
 		m.finish(result, err)
 	}()
 	return nil
@@ -326,6 +335,17 @@ func (m *Manager) Wait() {
 		}
 		<-done
 	}
+}
+
+// Shutdown cancels any detached StartBuild in flight and blocks until no
+// build is running. Owners call it instead of Wait when closing down: a
+// detached build's encoder may be waiting out provider rate limits
+// indefinitely (EncoderConfig.RetryRateLimits), so without cancellation
+// Wait could never return. Build progress is durable, so a canceled build
+// resumes incrementally on the next start.
+func (m *Manager) Shutdown() {
+	m.cancelDetached()
+	m.Wait()
 }
 
 // Generations delegates to the underlying Index, listing every generation

--- a/internal/vector/manager_test.go
+++ b/internal/vector/manager_test.go
@@ -231,6 +231,37 @@ func TestManagerWaitBlocksUntilAsyncBuildCompletes(t *testing.T) {
 	}
 }
 
+func TestManagerShutdownCancelsDetachedStartBuild(t *testing.T) {
+	// Models a document build stuck retrying HTTP 429 responses forever
+	// (EncoderConfig.RetryRateLimits): the encoder returns only once its
+	// context is canceled. Shutdown must cancel the detached build so daemon
+	// shutdown does not hang on Wait.
+	ix := openTestIndex(t)
+	stuckEncoder := func(ctx context.Context, _ []string) ([][]float32, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	m := NewManager(
+		ix, twoDocSource(), soloEncoders(stuckEncoder), fakeGeneration("fake-model"),
+	)
+	require.NoError(t, m.StartBuild(BuildRequest{}))
+	waitFor(t, func() bool { return m.Status().Running }, "build never reported running")
+
+	done := make(chan struct{})
+	go func() {
+		m.Shutdown()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Shutdown did not cancel the detached build")
+	}
+	status := m.Status()
+	assert.False(t, status.Running)
+	assert.Contains(t, status.LastError, context.Canceled.Error())
+}
+
 func TestManagerTryBuildReturnsFalseWhileRunning(t *testing.T) {
 	ix := openTestIndex(t)
 	src := twoDocSource()


### PR DESCRIPTION
## Summary

- Document embeddings builds now retry an HTTP 429 (honoring `Retry-After` when present, capped exponential backoff otherwise) until it succeeds or the build is canceled, instead of spending the normal `max_retries` budget on it.
- Query encoders are unchanged: latency-sensitive, so a 429 still counts against `max_retries` and fails fast, same as before.
- Daemon shutdown now cancels a detached API-started build instead of waiting for it to finish. With unbounded 429 retries, waiting could block shutdown forever when a provider's quota never recovers. Build progress is durable, so a canceled build resumes incrementally on the next start; scheduler-driven builds already stopped with the daemon context, and API-started builds now behave the same way.

## Root cause

`embeddings build` treated a 429 as just another retryable error under the shared `max_retries` budget. A 429 is the one error class a provider tells you exactly how to handle (it clears with time, the request itself isn't broken) -- treating it like a permanent failure meant a large first build died partway through and needed an external retry loop wrapped around the command by hand (repro in the issue: 28,085 of 142,161 documents embedded, then a 429 aborted the whole run).

## Scope

`internal/vector/encoder.go`'s retry loop, a `RetryRateLimits` field threaded through the existing document-vs-query encoder constructors in `cmd/agentsview/embeddings.go` (only document builds enable it), and `internal/vector/manager.go`, where detached builds now run on a manager-owned cancellable context with a `Shutdown` method that `vectorServing.Close` calls before waiting. Reviewers should look at the reworked retry loop in `encode` and at the `Shutdown`/`Wait` ordering in `Manager` and `vectorServing.Close`.

**Note:** #1356's fix (separate PR, already up) touches the same `embeddings.go`/`config.go`/`docs/semantic-search.md` files for an unrelated reason (per-batch token-cap). Whichever of the two merges second will need a small conflict resolution against the other -- I hit that conflict myself while preparing this PR and reconciled it manually rather than force-resolving; happy to help resolve it again here once one lands.
