### PR TITLE
feat(rawcapture): add durable capture outbox

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,3 +1,7 @@
+review_agent = "codex"
+review_model = "gpt-5.6-terra"
+review_reasoning = "high"
+
 review_guidelines = """
 agentsview is a single-user developer tool. Default mode binds to
 127.0.0.1. Optional managed Caddy proxy mode allows LAN access while

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,7 +1,3 @@
-review_agent = "codex"
-review_model = "gpt-5.6-terra"
-review_reasoning = "high"
-
 review_guidelines = """
 agentsview is a single-user developer tool. Default mode binds to
 127.0.0.1. Optional managed Caddy proxy mode allows LAN access while

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -244,9 +244,9 @@ add an archived or maintained mirror without replacing the original identity.
   unfinished included session withholds computed or mixed cost;
   provider-reported cost remains authoritative. Reverified 2026-08-27 that
   raw-capture membership mirrors persisted tool output resolution: it includes
-  direct regular files in the session's `tool-results/` directory and, for
-  subagents, the enclosing parent session's `tool-results/` directory. These
-  immutable companions are captured with the appendable transcript so a
+  regular files at any depth in the session's `tool-results/` directory and,
+  for subagents, the enclosing parent session's `tool-results/` directory.
+  These immutable companions are captured with the appendable transcript so a
   reconstructed tree preserves the parser's physical inputs.
 
 ## OpenClaude (`openclaude`)

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -242,7 +242,12 @@ add an archived or maintained mirror without replacing the original identity.
   cannot hide missing delegated input or cache usage. Reverified 2026-08-22
   that an incomplete category breakdown, malformed included transcript, or
   unfinished included session withholds computed or mixed cost;
-  provider-reported cost remains authoritative.
+  provider-reported cost remains authoritative. Reverified 2026-08-27 that
+  raw-capture membership mirrors persisted tool output resolution: it includes
+  direct regular files in the session's `tool-results/` directory and, for
+  subagents, the enclosing parent session's `tool-results/` directory. These
+  immutable companions are captured with the appendable transcript so a
+  reconstructed tree preserves the parser's physical inputs.
 
 ## OpenClaude (`openclaude`)
 
@@ -1490,11 +1495,11 @@ add an archived or maintained mirror without replacing the original identity.
   against the samples reported in
   [#1466](https://github.com/kenn-io/agentsview/issues/1466): the parser folds
   the persisted cache-write remainder into uncached input only for recognized
-  GLM, Gemma, and Kimi model families. Missing and unrecognized model identities
-  preserve Posit Assistant's original buckets, and full context remains the
-  sum of the persisted input, cache-read, and cache-write fields. Data version
-  91 reparses existing Posit Assistant archives through the normal
-  non-destructive resync path.
+  GLM, Gemma, and Kimi model families. Missing and unrecognized model
+  identities preserve Posit Assistant's original buckets, and full context
+  remains the sum of the persisted input, cache-read, and cache-write fields.
+  Data version 91 reparses existing Posit Assistant archives through the
+  normal non-destructive resync path.
 
 ## Z Code (`zcode`)
 

--- a/internal/capture/capture_integration_test.go
+++ b/internal/capture/capture_integration_test.go
@@ -1451,7 +1451,6 @@ func TestRunCodexFindsChildInSpawnDayShard(t *testing.T) {
 	resultPath := filepath.Join(t.TempDir(), "result.json")
 	producer := copyCaptureHelper(t, "codex")
 	limits := testLimits()
-	limits.FinalizationWait = 5 * time.Second
 	_, err := Run(context.Background(), RunOptions{
 		Provider: ProviderCodex, OccurrenceID: "codex-late-child",
 		CaptureDir: filepath.Join(t.TempDir(), "capture"), ResultPath: resultPath,

--- a/internal/parser/capabilities.go
+++ b/internal/parser/capabilities.go
@@ -19,9 +19,10 @@ const (
 // unsupported results, but scheduling and validation should trust this
 // declaration once a provider has migrated off the legacy adapter.
 type Capabilities struct {
-	Source  SourceCapabilities
-	Content ContentCapabilities
-	Sync    ProviderSyncSemantics
+	Source     SourceCapabilities
+	Content    ContentCapabilities
+	Sync       ProviderSyncSemantics
+	RawCapture RawCaptureCapabilities
 }
 
 // UnchangedResultPolicy controls how the engine compares parsed members from a

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -95,20 +95,54 @@ func (p *claudeProvider) PlanRawCapture(
 			"resolve claude source path: %s", rawCaptureFilesystemError(err),
 		)
 	}
+	entries := []RawCaptureEntry{{
+		Path:       filepath.ToSlash(rel),
+		LocalPath:  src.Path,
+		Appendable: true,
+	}}
+	for _, dir := range claudeToolResultDirs(src.Path) {
+		children, err := os.ReadDir(dir)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return RawCapturePlan{}, invalidRawCapturePlan(
+				"read Claude tool results: %s", rawCaptureFilesystemError(err),
+			)
+		}
+		for _, child := range children {
+			path := filepath.Join(dir, child.Name())
+			info, err := os.Stat(path)
+			if err != nil {
+				return RawCapturePlan{}, invalidRawCapturePlan(
+					"stat Claude tool result: %s", rawCaptureFilesystemError(err),
+				)
+			}
+			if !info.Mode().IsRegular() {
+				continue
+			}
+			rel, err := filepath.Rel(src.Root, path)
+			if err != nil {
+				return RawCapturePlan{}, invalidRawCapturePlan(
+					"resolve Claude tool result: %s", rawCaptureFilesystemError(err),
+				)
+			}
+			entries = append(entries, RawCaptureEntry{
+				Path: filepath.ToSlash(rel), LocalPath: path,
+			})
+		}
+	}
 	return RawCapturePlan{
 		ConfiguredRoot: src.Root,
 		CaptureRoot:    src.Root,
 		SourceKey:      source.Key,
-		Entries: []RawCaptureEntry{{
-			Path:       filepath.ToSlash(rel),
-			LocalPath:  src.Path,
-			Appendable: true,
-		}},
+		Entries:        entries,
 	}, nil
 }
 
 // ComputeMultiFileStatHash implements parser.MultiFileStatHasher for the
-// single-file Claude transcript. Claude has no sibling companions; the
+// Claude transcript. Tool-result companions are immutable and do not affect
+// the transcript freshness gate; raw capture enumerates them separately.
 // digest exists so stat-verified freshness persists in provider_freshness
 // across process restarts, sparing a fresh engine (daemon restart or a
 // one-shot CLI sync) the full-content hash that Fingerprint performs for

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -100,37 +100,22 @@ func (p *claudeProvider) PlanRawCapture(
 		LocalPath:  src.Path,
 		Appendable: true,
 	}}
-	for _, dir := range claudeToolResultDirs(src.Path) {
-		children, err := os.ReadDir(dir)
-		if errors.Is(err, os.ErrNotExist) {
-			continue
-		}
+	sidecars, err := claudeLayoutSidecarFiles(ctx, src.Path)
+	if err != nil {
+		return RawCapturePlan{}, invalidRawCapturePlan(
+			"read Claude tool results: %s", rawCaptureFilesystemError(err),
+		)
+	}
+	for _, path := range sidecars {
+		rel, err := filepath.Rel(src.Root, path)
 		if err != nil {
 			return RawCapturePlan{}, invalidRawCapturePlan(
-				"read Claude tool results: %s", rawCaptureFilesystemError(err),
+				"resolve Claude tool result: %s", rawCaptureFilesystemError(err),
 			)
 		}
-		for _, child := range children {
-			path := filepath.Join(dir, child.Name())
-			info, err := os.Stat(path)
-			if err != nil {
-				return RawCapturePlan{}, invalidRawCapturePlan(
-					"stat Claude tool result: %s", rawCaptureFilesystemError(err),
-				)
-			}
-			if !info.Mode().IsRegular() {
-				continue
-			}
-			rel, err := filepath.Rel(src.Root, path)
-			if err != nil {
-				return RawCapturePlan{}, invalidRawCapturePlan(
-					"resolve Claude tool result: %s", rawCaptureFilesystemError(err),
-				)
-			}
-			entries = append(entries, RawCaptureEntry{
-				Path: filepath.ToSlash(rel), LocalPath: path,
-			})
-		}
+		entries = append(entries, RawCaptureEntry{
+			Path: filepath.ToSlash(rel), LocalPath: path,
+		})
 	}
 	return RawCapturePlan{
 		ConfiguredRoot: src.Root,

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -11,6 +11,7 @@ import (
 
 var _ Provider = (*claudeProvider)(nil)
 var _ S3Provider = (*claudeProvider)(nil)
+var _ RawCaptureProvider = (*claudeProvider)(nil)
 
 type claudeProviderFactory struct {
 	def AgentDef
@@ -75,6 +76,35 @@ func (p *claudeProvider) Fingerprint(
 	source SourceRef,
 ) (SourceFingerprint, error) {
 	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *claudeProvider) PlanRawCapture(
+	ctx context.Context,
+	source SourceRef,
+) (RawCapturePlan, error) {
+	if err := ctx.Err(); err != nil {
+		return RawCapturePlan{}, err
+	}
+	src, ok := source.Opaque.(claudeSource)
+	if !ok || src.Root == "" || src.Path == "" || isS3URI(src.Root) {
+		return RawCapturePlan{}, invalidRawCapturePlan("claude source is not a local discovered transcript")
+	}
+	rel, err := filepath.Rel(src.Root, src.Path)
+	if err != nil {
+		return RawCapturePlan{}, invalidRawCapturePlan(
+			"resolve claude source path: %s", rawCaptureFilesystemError(err),
+		)
+	}
+	return RawCapturePlan{
+		ConfiguredRoot: src.Root,
+		CaptureRoot:    src.Root,
+		SourceKey:      source.Key,
+		Entries: []RawCaptureEntry{{
+			Path:       filepath.ToSlash(rel),
+			LocalPath:  src.Path,
+			Appendable: true,
+		}},
+	}, nil
 }
 
 // ComputeMultiFileStatHash implements parser.MultiFileStatHasher for the
@@ -763,6 +793,12 @@ func claudeProviderCapabilities() Capabilities {
 			FingerprintHashInCacheKey:           true,
 			FingerprintHashRequiredForFreshness: true,
 			SkipCacheFreshWithoutStoredRow:      true,
+		},
+		RawCapture: RawCaptureCapabilities{
+			Support:  CapabilitySupported,
+			Shape:    RawCaptureShapeFiles,
+			Append:   RawCaptureAppendOne,
+			Snapshot: RawCaptureSnapshotNone,
 		},
 	}
 }

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 var _ Provider = (*codexProvider)(nil)
 var _ ActivityHintProvider = (*codexProvider)(nil)
 var _ S3Provider = (*codexProvider)(nil)
+var _ RawCaptureProvider = (*codexProvider)(nil)
 
 // codexProviderSpec parameterizes the one shared Codex-format provider
 // implementation for Codex and its TraeX fork. Both reuse the same
@@ -77,6 +79,8 @@ func (f *codexProviderFactory) Capabilities() Capabilities {
 	caps := codexProviderCapabilities()
 	if f.spec.agent == AgentCodex {
 		caps.Source.S3Discovery = CapabilitySupported
+	} else {
+		caps.RawCapture = RawCaptureCapabilities{}
 	}
 	return caps
 }
@@ -241,6 +245,61 @@ func (p *codexProvider) Fingerprint(
 	source SourceRef,
 ) (SourceFingerprint, error) {
 	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *codexProvider) PlanRawCapture(
+	ctx context.Context,
+	source SourceRef,
+) (RawCapturePlan, error) {
+	if err := ctx.Err(); err != nil {
+		return RawCapturePlan{}, err
+	}
+	if p.spec.agent != AgentCodex {
+		return RawCapturePlan{}, invalidRawCapturePlan("provider does not own Codex raw companions")
+	}
+	src, ok := source.Opaque.(codexSource)
+	if !ok || src.Root == "" || src.Path == "" || isS3URI(src.Root) {
+		return RawCapturePlan{}, invalidRawCapturePlan("codex source is not a local discovered transcript")
+	}
+	captureRoot := filepath.Clean(src.Root)
+	indexPath := codexSessionIndexPath(src.Path)
+	if indexPath != "" {
+		captureRoot = filepath.Dir(indexPath)
+	}
+	rel, err := filepath.Rel(captureRoot, src.Path)
+	if err != nil {
+		return RawCapturePlan{}, invalidRawCapturePlan(
+			"resolve Codex source path: %s", rawCaptureFilesystemError(err),
+		)
+	}
+	entries := []RawCaptureEntry{{
+		Path:       filepath.ToSlash(rel),
+		LocalPath:  src.Path,
+		Appendable: true,
+	}}
+	if indexPath != "" {
+		info, err := os.Stat(indexPath)
+		switch {
+		case err == nil && info.Mode().IsRegular():
+			entries = append(entries, RawCaptureEntry{
+				Path:      CodexSessionIndexFilename,
+				LocalPath: indexPath,
+			})
+		case errors.Is(err, os.ErrNotExist):
+		case err != nil:
+			return RawCapturePlan{}, invalidRawCapturePlan(
+				"stat Codex session index: %s", rawCaptureFilesystemError(err),
+			)
+		default:
+			return RawCapturePlan{}, invalidRawCapturePlan("Codex session index is not a regular file")
+		}
+	}
+	return RawCapturePlan{
+		ConfiguredRoot: src.Root,
+		CaptureRoot:    captureRoot,
+		SourceKey:      source.Key,
+		Entries:        entries,
+	}, nil
 }
 
 // ComputeMultiFileStatHash implements parser.MultiFileStatHasher over the
@@ -1016,6 +1075,12 @@ func codexProviderCapabilities() Capabilities {
 			FingerprintHashInCacheKey:           true,
 			FingerprintHashRequiredForFreshness: true,
 			SkipCacheFreshWithoutStoredRow:      true,
+		},
+		RawCapture: RawCaptureCapabilities{
+			Support:  CapabilitySupported,
+			Shape:    RawCaptureShapeFiles,
+			Append:   RawCaptureAppendOne,
+			Snapshot: RawCaptureSnapshotNone,
 		},
 	}
 }

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -264,6 +264,8 @@ func (p *codexProvider) PlanRawCapture(
 	captureRoot := filepath.Clean(src.Root)
 	indexPath := codexSessionIndexPath(src.Path)
 	if indexPath != "" {
+		// The provider reads this named sibling as session metadata, so raw
+		// capture widens only far enough to preserve the same parse inputs.
 		captureRoot = filepath.Dir(indexPath)
 	}
 	rel, err := filepath.Rel(captureRoot, src.Path)

--- a/internal/parser/icodemate_cli.go
+++ b/internal/parser/icodemate_cli.go
@@ -307,7 +307,14 @@ func claudeLayoutSidecarFiles(
 			if err != nil {
 				return err
 			}
-			if !entry.IsDir() {
+			if entry.IsDir() {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if info.Mode().IsRegular() {
 				files = append(files, path)
 			}
 			return nil

--- a/internal/parser/raw_capture.go
+++ b/internal/parser/raw_capture.go
@@ -1,0 +1,242 @@
+package parser
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/rawpath"
+)
+
+const ProviderFeatureRawCapture = "raw capture"
+
+var ErrInvalidRawCapturePlan = errors.New("invalid raw capture plan")
+
+// RawCaptureShape describes the physical shape a provider exposes for raw
+// capture. The zero value is unsupported.
+type RawCaptureShape uint8
+
+const (
+	RawCaptureShapeUnsupported RawCaptureShape = iota
+	RawCaptureShapeFiles
+	RawCaptureShapeSQLite
+)
+
+// RawCaptureAppendPolicy declares whether a provider can safely extend one
+// entry while retaining the prior generation's ordered object references.
+type RawCaptureAppendPolicy uint8
+
+const (
+	RawCaptureAppendReplaceOnly RawCaptureAppendPolicy = iota
+	RawCaptureAppendOne
+)
+
+// RawCaptureSnapshotRequirement declares how capture obtains a consistent
+// source view. The zero value requires no provider-specific snapshot.
+type RawCaptureSnapshotRequirement uint8
+
+const (
+	RawCaptureSnapshotNone RawCaptureSnapshotRequirement = iota
+	RawCaptureSnapshotOnlineBackup
+)
+
+// RawCaptureCapabilities declares a provider's raw source shape. Providers
+// default to unsupported and must implement RawCaptureProvider when enabled.
+type RawCaptureCapabilities struct {
+	Support  CapabilitySupport
+	Shape    RawCaptureShape
+	Append   RawCaptureAppendPolicy
+	Snapshot RawCaptureSnapshotRequirement
+}
+
+// RawCaptureEntry maps one provider-owned local file to its logical manifest
+// path. Path always uses slash separators and is relative to CaptureRoot.
+type RawCaptureEntry struct {
+	Path       string
+	LocalPath  string
+	Appendable bool
+}
+
+// RawCapturePlan is the complete physical membership of one logical source.
+type RawCapturePlan struct {
+	ConfiguredRoot string
+	CaptureRoot    string
+	SourceKey      string
+	Entries        []RawCaptureEntry
+}
+
+// RawCaptureProvider is the optional provider-owned physical source contract.
+type RawCaptureProvider interface {
+	PlanRawCapture(context.Context, SourceRef) (RawCapturePlan, error)
+}
+
+// ResolveRawCapturePlan returns and validates a provider-owned raw source plan.
+// Generic callers never inspect SourceRef.Opaque.
+func ResolveRawCapturePlan(
+	ctx context.Context,
+	provider Provider,
+	source SourceRef,
+) (RawCapturePlan, bool, error) {
+	if provider.Capabilities().RawCapture.Support != CapabilitySupported {
+		return RawCapturePlan{}, false, nil
+	}
+	providerType := provider.Definition().Type
+	if source.Provider != providerType {
+		return RawCapturePlan{}, false, invalidRawCapturePlan(
+			"source provider %q does not match %q", source.Provider, providerType,
+		)
+	}
+	planner, ok := provider.(RawCaptureProvider)
+	if !ok {
+		return RawCapturePlan{}, false, UnsupportedProviderFeatureError{
+			Provider: providerType,
+			Feature:  ProviderFeatureRawCapture,
+		}
+	}
+	plan, err := planner.PlanRawCapture(ctx, source)
+	if err != nil {
+		return RawCapturePlan{}, false, err
+	}
+	validated, err := validateRawCapturePlan(provider.Capabilities().RawCapture, source, plan)
+	if err != nil {
+		return RawCapturePlan{}, false, err
+	}
+	return validated, true, nil
+}
+
+func validateRawCapturePlan(
+	capabilities RawCaptureCapabilities,
+	source SourceRef,
+	plan RawCapturePlan,
+) (RawCapturePlan, error) {
+	if capabilities.Shape != RawCaptureShapeFiles ||
+		capabilities.Snapshot != RawCaptureSnapshotNone {
+		return RawCapturePlan{}, invalidRawCapturePlan("unsupported source shape or snapshot requirement")
+	}
+	if plan.SourceKey == "" || plan.SourceKey != source.Key {
+		return RawCapturePlan{}, invalidRawCapturePlan("source key does not match provider source")
+	}
+	configuredRoot, err := validateRawCaptureRoot("configured", plan.ConfiguredRoot)
+	if err != nil {
+		return RawCapturePlan{}, err
+	}
+	captureRoot, err := validateRawCaptureRoot("capture", plan.CaptureRoot)
+	if err != nil {
+		return RawCapturePlan{}, err
+	}
+	if len(plan.Entries) == 0 {
+		return RawCapturePlan{}, invalidRawCapturePlan("source has no entries")
+	}
+
+	entries := append([]RawCaptureEntry(nil), plan.Entries...)
+	seen := make(map[string]struct{}, len(entries))
+	appendable := 0
+	for i := range entries {
+		logical := entries[i].Path
+		if err := rawpath.Validate(logical, rawpath.DefaultMaxBytes); err != nil {
+			return RawCapturePlan{}, invalidRawCapturePlan("entry path %q is not a safe relative path", logical)
+		}
+		if _, exists := seen[logical]; exists {
+			return RawCapturePlan{}, invalidRawCapturePlan("entry path %q is duplicated", logical)
+		}
+		seen[logical] = struct{}{}
+
+		localPath := filepath.Clean(entries[i].LocalPath)
+		if !filepath.IsAbs(localPath) {
+			return RawCapturePlan{}, invalidRawCapturePlan("entry %q path must be absolute", logical)
+		}
+		resolvedPath, err := filepath.EvalSymlinks(localPath)
+		if err != nil {
+			return RawCapturePlan{}, invalidRawCapturePlan(
+				"resolve entry %q: %s", logical, rawCaptureFilesystemError(err),
+			)
+		}
+		if !rawCapturePathWithin(captureRoot, resolvedPath) &&
+			!rawCapturePathWithin(configuredRoot, resolvedPath) {
+			return RawCapturePlan{}, invalidRawCapturePlan("entry %q escapes provider roots", logical)
+		}
+		info, err := os.Stat(resolvedPath)
+		if err != nil {
+			return RawCapturePlan{}, invalidRawCapturePlan(
+				"stat entry %q: %s", logical, rawCaptureFilesystemError(err),
+			)
+		}
+		if !info.Mode().IsRegular() {
+			return RawCapturePlan{}, invalidRawCapturePlan("entry %q is not a regular file", logical)
+		}
+		entries[i].LocalPath = filepath.Clean(resolvedPath)
+		if entries[i].Appendable {
+			appendable++
+		}
+	}
+	switch capabilities.Append {
+	case RawCaptureAppendReplaceOnly:
+		if appendable != 0 {
+			return RawCapturePlan{}, invalidRawCapturePlan("replace-only source has an appendable entry")
+		}
+	case RawCaptureAppendOne:
+		if appendable != 1 {
+			return RawCapturePlan{}, invalidRawCapturePlan("source must have exactly one appendable entry")
+		}
+	default:
+		return RawCapturePlan{}, invalidRawCapturePlan("unknown append policy %d", capabilities.Append)
+	}
+	slices.SortFunc(entries, func(a, b RawCaptureEntry) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	return RawCapturePlan{
+		ConfiguredRoot: configuredRoot,
+		CaptureRoot:    captureRoot,
+		SourceKey:      plan.SourceKey,
+		Entries:        entries,
+	}, nil
+}
+
+func validateRawCaptureRoot(kind, root string) (string, error) {
+	root = filepath.Clean(root)
+	if !filepath.IsAbs(root) {
+		return "", invalidRawCapturePlan("%s root must be absolute", kind)
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", invalidRawCapturePlan(
+			"resolve %s root: %s", kind, rawCaptureFilesystemError(err),
+		)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", invalidRawCapturePlan(
+			"stat %s root: %s", kind, rawCaptureFilesystemError(err),
+		)
+	}
+	if !info.IsDir() {
+		return "", invalidRawCapturePlan("%s root is not a directory", kind)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func rawCapturePathWithin(root, candidate string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(candidate))
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func invalidRawCapturePlan(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidRawCapturePlan, fmt.Sprintf(format, args...))
+}
+
+func rawCaptureFilesystemError(err error) string {
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return "not found"
+	case errors.Is(err, os.ErrPermission):
+		return "permission denied"
+	case errors.Is(err, os.ErrInvalid):
+		return "invalid path"
+	default:
+		return "filesystem error"
+	}
+}

--- a/internal/parser/raw_capture_test.go
+++ b/internal/parser/raw_capture_test.go
@@ -1,0 +1,478 @@
+package parser
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type rawCaptureTestProvider struct {
+	ProviderBase
+	plan   RawCapturePlan
+	err    error
+	called bool
+}
+
+func (p *rawCaptureTestProvider) Parse(
+	context.Context,
+	ParseRequest,
+) (ParseOutcome, error) {
+	return ParseOutcome{}, nil
+}
+
+func (p *rawCaptureTestProvider) PlanRawCapture(
+	_ context.Context,
+	_ SourceRef,
+) (RawCapturePlan, error) {
+	p.called = true
+	return p.plan, p.err
+}
+
+type rawCaptureUndeclaredProvider struct {
+	ProviderBase
+}
+
+func (p *rawCaptureUndeclaredProvider) Parse(
+	context.Context,
+	ParseRequest,
+) (ParseOutcome, error) {
+	return ParseOutcome{}, nil
+}
+
+func rawCaptureTestCapabilities() Capabilities {
+	return Capabilities{RawCapture: RawCaptureCapabilities{
+		Support:  CapabilitySupported,
+		Shape:    RawCaptureShapeFiles,
+		Append:   RawCaptureAppendOne,
+		Snapshot: RawCaptureSnapshotNone,
+	}}
+}
+
+func canonicalRawCaptureTestPath(t *testing.T, path string) string {
+	t.Helper()
+	canonical, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return canonical
+}
+
+func TestResolveRawCapturePlanLeavesUnsupportedProviderUntouched(t *testing.T) {
+	provider := &rawCaptureTestProvider{
+		Def: AgentDef{Type: AgentClaude}}
+
+	plan, ok, err := ResolveRawCapturePlan(t.Context(), provider, SourceRef{
+		Provider: AgentClaude,
+		Key:      "source-1",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, plan)
+	assert.False(t, provider.called, "unsupported capability must not invoke the planner")
+}
+
+func TestResolveRawCapturePlanRequiresDeclaredInterface(t *testing.T) {
+	provider := &rawCaptureUndeclaredProvider{
+		Def:  AgentDef{Type: AgentClaude},
+		Caps: rawCaptureTestCapabilities()}
+
+	_, ok, err := ResolveRawCapturePlan(t.Context(), provider, SourceRef{
+		Provider: AgentClaude,
+		Key:      "source-1",
+	})
+
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.ErrorIs(t, err, ErrUnsupportedProviderFeature)
+}
+
+func TestResolveRawCapturePlanValidatesProviderOwnedPlan(t *testing.T) {
+	captureRoot := t.TempDir()
+	localPath := filepath.Join(captureRoot, "project", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(localPath), 0o755))
+	require.NoError(t, os.WriteFile(localPath, []byte("one\n"), 0o600))
+
+	valid := RawCapturePlan{
+		ConfiguredRoot: captureRoot,
+		CaptureRoot:    captureRoot,
+		SourceKey:      "source-1",
+		Entries: []RawCaptureEntry{{
+			Path:       "project/session.jsonl",
+			LocalPath:  localPath,
+			Appendable: true,
+		}},
+	}
+
+	tests := []struct {
+		name       string
+		source     SourceRef
+		mutatePlan func(*RawCapturePlan)
+	}{
+		{
+			name:   "provider mismatch",
+			source: SourceRef{Provider: AgentCodex, Key: "source-1"},
+		},
+		{
+			name:   "absolute logical path",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				plan.Entries[0].Path = "/session.jsonl"
+			},
+		},
+		{
+			name:   "parent traversal",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				plan.Entries[0].Path = "../session.jsonl"
+			},
+		},
+		{
+			name:   "control character",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				plan.Entries[0].Path = "project/session\x01.jsonl"
+			},
+		},
+		{
+			name:   "alternate data stream",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				plan.Entries[0].Path = "project/session.jsonl:secret"
+			},
+		},
+		{
+			name:   "Windows reserved component",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				plan.Entries[0].Path = "project/CON.txt"
+			},
+		},
+		{
+			name:   "Windows trailing dot",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				plan.Entries[0].Path = "project/session."
+			},
+		},
+		{
+			name:   "duplicate logical path",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				plan.Entries = append(plan.Entries, plan.Entries[0])
+			},
+		},
+		{
+			name:   "outside capture root",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				outside := filepath.Join(t.TempDir(), "session.jsonl")
+				require.NoError(t, os.WriteFile(outside, []byte("two\n"), 0o600))
+				plan.Entries[0].LocalPath = outside
+			},
+		},
+		{
+			name:   "two appendable entries",
+			source: SourceRef{Provider: AgentClaude, Key: "source-1"},
+			mutatePlan: func(plan *RawCapturePlan) {
+				other := filepath.Join(captureRoot, "project", "other.jsonl")
+				require.NoError(t, os.WriteFile(other, []byte("two\n"), 0o600))
+				plan.Entries = append(plan.Entries, RawCaptureEntry{
+					Path:       "project/other.jsonl",
+					LocalPath:  other,
+					Appendable: true,
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := valid
+			plan.Entries = append([]RawCaptureEntry(nil), valid.Entries...)
+			if tt.mutatePlan != nil {
+				tt.mutatePlan(&plan)
+			}
+			provider := &rawCaptureTestProvider{
+				Def:  AgentDef{Type: AgentClaude},
+				Caps: rawCaptureTestCapabilities(),
+				plan: plan,
+			}
+
+			_, ok, err := ResolveRawCapturePlan(t.Context(), provider, tt.source)
+
+			require.Error(t, err)
+			assert.False(t, ok)
+			assert.ErrorIs(t, err, ErrInvalidRawCapturePlan)
+		})
+	}
+}
+
+func TestResolveRawCapturePlanReturnsIndependentValidatedCopy(t *testing.T) {
+	captureRoot := t.TempDir()
+	localPath := filepath.Join(captureRoot, "session.jsonl")
+	require.NoError(t, os.WriteFile(localPath, []byte("one\n"), 0o600))
+	provider := &rawCaptureTestProvider{
+		Def:  AgentDef{Type: AgentClaude},
+		Caps: rawCaptureTestCapabilities(),
+		plan: RawCapturePlan{
+			ConfiguredRoot: captureRoot,
+			CaptureRoot:    captureRoot,
+			SourceKey:      "source-1",
+			Entries: []RawCaptureEntry{{
+				Path:       "session.jsonl",
+				LocalPath:  localPath,
+				Appendable: true,
+			}},
+		},
+	}
+
+	plan, ok, err := ResolveRawCapturePlan(t.Context(), provider, SourceRef{
+		Provider: AgentClaude,
+		Key:      "source-1",
+	})
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, "session.jsonl", plan.Entries[0].Path)
+	provider.plan.Entries[0].Path = "mutated.jsonl"
+	assert.Equal(t, "session.jsonl", plan.Entries[0].Path)
+}
+
+func TestResolveRawCapturePlanRejectsUnknownAppendPolicy(t *testing.T) {
+	captureRoot := t.TempDir()
+	localPath := filepath.Join(captureRoot, "session.jsonl")
+	require.NoError(t, os.WriteFile(localPath, []byte("one\n"), 0o600))
+	capabilities := rawCaptureTestCapabilities()
+	capabilities.RawCapture.Append = RawCaptureAppendPolicy(99)
+	provider := &rawCaptureTestProvider{
+		Def:  AgentDef{Type: AgentClaude},
+		Caps: capabilities,
+		plan: RawCapturePlan{
+			ConfiguredRoot: captureRoot,
+			CaptureRoot:    captureRoot,
+			SourceKey:      "source-1",
+			Entries: []RawCaptureEntry{{
+				Path:       "session.jsonl",
+				LocalPath:  localPath,
+				Appendable: true,
+			}},
+		},
+	}
+
+	_, supported, err := ResolveRawCapturePlan(t.Context(), provider, SourceRef{
+		Provider: AgentClaude,
+		Key:      "source-1",
+	})
+
+	require.Error(t, err)
+	assert.False(t, supported)
+	assert.ErrorIs(t, err, ErrInvalidRawCapturePlan)
+}
+
+func TestClaudeProviderPlansSingleAppendableTranscript(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "project", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sourcePath), 0o755))
+	require.NoError(t, os.WriteFile(sourcePath, []byte("{}\n"), 0o600))
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	plan, supported, err := ResolveRawCapturePlan(t.Context(), provider, sources[0])
+
+	require.NoError(t, err)
+	require.True(t, supported)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, root), plan.ConfiguredRoot)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, root), plan.CaptureRoot)
+	assert.Equal(t, sources[0].Key, plan.SourceKey)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, "project/session.jsonl", plan.Entries[0].Path)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, sourcePath), plan.Entries[0].LocalPath)
+	assert.True(t, plan.Entries[0].Appendable)
+}
+
+func TestCodexProviderPlansTranscriptWithOptionalIndex(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "sessions")
+	sourcePath := filepath.Join(
+		root,
+		"2026", "08", "25",
+		"rollout-2026-08-25T10-00-00-11111111-1111-4111-8111-111111111111.jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sourcePath), 0o755))
+	require.NoError(t, os.WriteFile(sourcePath, []byte("{}\n"), 0o600))
+	indexPath := filepath.Join(base, CodexSessionIndexFilename)
+	require.NoError(t, os.WriteFile(indexPath, []byte("{}\n"), 0o600))
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	plan, supported, err := ResolveRawCapturePlan(t.Context(), provider, sources[0])
+
+	require.NoError(t, err)
+	require.True(t, supported)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, root), plan.ConfiguredRoot)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, base), plan.CaptureRoot)
+	assert.Equal(t, sources[0].Key, plan.SourceKey)
+	require.Len(t, plan.Entries, 2)
+	assert.Equal(t, "session_index.jsonl", plan.Entries[0].Path)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, indexPath), plan.Entries[0].LocalPath)
+	assert.False(t, plan.Entries[0].Appendable)
+	assert.Equal(t, "sessions/2026/08/25/"+filepath.Base(sourcePath), plan.Entries[1].Path)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, sourcePath), plan.Entries[1].LocalPath)
+	assert.True(t, plan.Entries[1].Appendable)
+
+	require.NoError(t, os.Remove(indexPath))
+	plan, supported, err = ResolveRawCapturePlan(t.Context(), provider, sources[0])
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, "sessions/2026/08/25/"+filepath.Base(sourcePath), plan.Entries[0].Path)
+	assert.True(t, plan.Entries[0].Appendable)
+}
+
+func TestClaudeProviderPlansThroughSymlinkedRoot(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real-projects")
+	linkedRoot := filepath.Join(base, "linked-projects")
+	sourcePath := filepath.Join(realRoot, "project", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sourcePath), 0o755))
+	require.NoError(t, os.WriteFile(sourcePath, []byte("{}\n"), 0o600))
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{linkedRoot}})
+	require.True(t, ok)
+	linkedSource := filepath.Join(linkedRoot, "project", "session.jsonl")
+	sources, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path:      linkedSource,
+		WatchRoot: linkedRoot,
+		EventKind: "write",
+	})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	plan, supported, err := ResolveRawCapturePlan(t.Context(), provider, sources[0])
+
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, realRoot), plan.ConfiguredRoot)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, sourcePath), plan.Entries[0].LocalPath)
+}
+
+func TestCodexProviderPlansThroughSymlinkedRoot(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "rollouts")
+	linkedRoot := filepath.Join(base, "sessions")
+	realSource := filepath.Join(
+		realRoot,
+		"2026", "08", "25",
+		"rollout-2026-08-25T10-00-00-11111111-1111-4111-8111-111111111111.jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(realSource), 0o755))
+	require.NoError(t, os.WriteFile(realSource, []byte("{}\n"), 0o600))
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	indexPath := filepath.Join(base, CodexSessionIndexFilename)
+	require.NoError(t, os.WriteFile(indexPath, []byte("{}\n"), 0o600))
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{linkedRoot}})
+	require.True(t, ok)
+	linkedSource := filepath.Join(
+		linkedRoot,
+		"2026", "08", "25",
+		filepath.Base(realSource),
+	)
+	sources, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path:      linkedSource,
+		WatchRoot: linkedRoot,
+		EventKind: "write",
+	})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	plan, supported, err := ResolveRawCapturePlan(t.Context(), provider, sources[0])
+
+	require.NoError(t, err)
+	require.True(t, supported)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, realRoot), plan.ConfiguredRoot)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, base), plan.CaptureRoot)
+	require.Len(t, plan.Entries, 2)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, indexPath), plan.Entries[0].LocalPath)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, realSource), plan.Entries[1].LocalPath)
+}
+
+func TestTraeXProviderDoesNotOptIntoRawCapture(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(
+		root,
+		"2026", "08", "25",
+		"rollout-2026-08-25T10-00-00-11111111-1111-4111-8111-111111111111.jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sourcePath), 0o755))
+	require.NoError(t, os.WriteFile(sourcePath, []byte("{}\n"), 0o600))
+	provider, ok := NewProvider(AgentTraeX, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	plan, supported, err := ResolveRawCapturePlan(t.Context(), provider, sources[0])
+
+	require.NoError(t, err)
+	assert.False(t, supported)
+	assert.Empty(t, plan)
+}
+
+func TestResolveRawCapturePlanPropagatesProviderError(t *testing.T) {
+	want := errors.New("capture plan failed")
+	provider := &rawCaptureTestProvider{
+		Def:  AgentDef{Type: AgentClaude},
+		Caps: rawCaptureTestCapabilities(),
+		err:  want,
+	}
+
+	_, supported, err := ResolveRawCapturePlan(t.Context(), provider, SourceRef{
+		Provider: AgentClaude,
+		Key:      "source-1",
+	})
+
+	assert.False(t, supported)
+	assert.ErrorIs(t, err, want)
+}
+
+func TestResolveRawCapturePlanDoesNotExposeLocalPathInFilesystemError(t *testing.T) {
+	root := t.TempDir()
+	missing := filepath.Join(root, "private", "missing.jsonl")
+	provider := &rawCaptureTestProvider{
+		Def:  AgentDef{Type: AgentClaude},
+		Caps: rawCaptureTestCapabilities(),
+		plan: RawCapturePlan{
+			ConfiguredRoot: root,
+			CaptureRoot:    root,
+			SourceKey:      "source-1",
+			Entries: []RawCaptureEntry{{
+				Path: "project/session.jsonl", LocalPath: missing, Appendable: true,
+			}},
+		},
+	}
+
+	_, _, err := ResolveRawCapturePlan(t.Context(), provider, SourceRef{
+		Provider: AgentClaude,
+		Key:      "source-1",
+	})
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), root)
+	assert.ErrorIs(t, err, ErrInvalidRawCapturePlan)
+}

--- a/internal/parser/raw_capture_test.go
+++ b/internal/parser/raw_capture_test.go
@@ -274,11 +274,14 @@ func TestResolveRawCapturePlanRejectsUnknownAppendPolicy(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidRawCapturePlan)
 }
 
-func TestClaudeProviderPlansSingleAppendableTranscript(t *testing.T) {
+func TestClaudeProviderPlansTranscriptWithToolResults(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "project", "session.jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(sourcePath), 0o755))
 	require.NoError(t, os.WriteFile(sourcePath, []byte("{}\n"), 0o600))
+	toolResultPath := filepath.Join(root, "project", "session", "tool-results", "result.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(toolResultPath), 0o755))
+	require.NoError(t, os.WriteFile(toolResultPath, []byte("result\n"), 0o600))
 	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{root}})
 	require.True(t, ok)
 	sources, err := provider.Discover(t.Context())
@@ -292,10 +295,13 @@ func TestClaudeProviderPlansSingleAppendableTranscript(t *testing.T) {
 	assert.Equal(t, canonicalRawCaptureTestPath(t, root), plan.ConfiguredRoot)
 	assert.Equal(t, canonicalRawCaptureTestPath(t, root), plan.CaptureRoot)
 	assert.Equal(t, sources[0].Key, plan.SourceKey)
-	require.Len(t, plan.Entries, 1)
+	require.Len(t, plan.Entries, 2)
 	assert.Equal(t, "project/session.jsonl", plan.Entries[0].Path)
 	assert.Equal(t, canonicalRawCaptureTestPath(t, sourcePath), plan.Entries[0].LocalPath)
 	assert.True(t, plan.Entries[0].Appendable)
+	assert.Equal(t, "project/session/tool-results/result.txt", plan.Entries[1].Path)
+	assert.Equal(t, canonicalRawCaptureTestPath(t, toolResultPath), plan.Entries[1].LocalPath)
+	assert.False(t, plan.Entries[1].Appendable)
 }
 
 func TestCodexProviderPlansTranscriptWithOptionalIndex(t *testing.T) {

--- a/internal/parser/raw_capture_test.go
+++ b/internal/parser/raw_capture_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -274,14 +275,27 @@ func TestResolveRawCapturePlanRejectsUnknownAppendPolicy(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidRawCapturePlan)
 }
 
-func TestClaudeProviderPlansTranscriptWithToolResults(t *testing.T) {
+func TestClaudeProviderPlansAndParsesNestedToolResults(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "project", "session.jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(sourcePath), 0o755))
-	require.NoError(t, os.WriteFile(sourcePath, []byte("{}\n"), 0o600))
-	toolResultPath := filepath.Join(root, "project", "session", "tool-results", "result.txt")
+	toolResultPath := filepath.Join(
+		root, "project", "session", "tool-results", "batches", "result.txt",
+	)
 	require.NoError(t, os.MkdirAll(filepath.Dir(toolResultPath), 0o755))
-	require.NoError(t, os.WriteFile(toolResultPath, []byte("result\n"), 0o600))
+	fullOutput := "full nested output\n"
+	require.NoError(t, os.WriteFile(toolResultPath, []byte(fullOutput), 0o600))
+	resultPathJSON := mustJSONString(t, toolResultPath)
+	persistedContentJSON := mustJSONString(t,
+		"<persisted-output>\n"+
+			"Output too large. Full output saved to: "+toolResultPath+
+			"\n\nPreview (first 2KB):\npreview only\n</persisted-output>")
+	content := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"},"cwd":"/tmp/project"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make logs"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + persistedContentJSON + `,"is_error":false}]},"toolUseResult":{"persistedOutputPath":` + resultPathJSON + `,"persistedOutputSize":19}}`,
+	}, "\n")
+	require.NoError(t, os.WriteFile(sourcePath, []byte(content), 0o600))
 	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{root}})
 	require.True(t, ok)
 	sources, err := provider.Discover(t.Context())
@@ -299,9 +313,17 @@ func TestClaudeProviderPlansTranscriptWithToolResults(t *testing.T) {
 	assert.Equal(t, "project/session.jsonl", plan.Entries[0].Path)
 	assert.Equal(t, canonicalRawCaptureTestPath(t, sourcePath), plan.Entries[0].LocalPath)
 	assert.True(t, plan.Entries[0].Appendable)
-	assert.Equal(t, "project/session/tool-results/result.txt", plan.Entries[1].Path)
+	assert.Equal(t, "project/session/tool-results/batches/result.txt", plan.Entries[1].Path)
 	assert.Equal(t, canonicalRawCaptureTestPath(t, toolResultPath), plan.Entries[1].LocalPath)
 	assert.False(t, plan.Entries[1].Appendable)
+
+	parsed, err := provider.Parse(t.Context(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, parsed.Results, 1)
+	messages := parsed.Results[0].Result.Messages
+	require.Len(t, messages, 3)
+	require.Len(t, messages[2].ToolResults, 1)
+	assert.Equal(t, fullOutput, DecodeContent(messages[2].ToolResults[0].ContentRaw))
 }
 
 func TestCodexProviderPlansTranscriptWithOptionalIndex(t *testing.T) {

--- a/internal/rawcapture/capacity_linux_test.go
+++ b/internal/rawcapture/capacity_linux_test.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+package rawcapture
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestCapturerChecksCapacityBeforeReadingUnchangedCompanion(t *testing.T) {
+	const maxBytes = int64(1 << 20)
+	store, _ := openCapturerTestStore(t, maxBytes)
+	provider, source, transcript := captureFileProvider(t, "one\n")
+	companionPath := filepath.Join(filepath.Dir(transcript), "companion.json")
+	require.NoError(t, os.WriteFile(companionPath, []byte("companion\n"), 0o600))
+	provider.plan.Entries = append(provider.plan.Entries, parser.RawCaptureEntry{
+		Path: "project/companion.json", LocalPath: companionPath,
+	})
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	_, err = store.ReserveCapture(
+		t.Context(), first.Source.ConfiguredRootID, maxBytes-usage.UsedBytes,
+	)
+	require.NoError(t, err)
+	require.NoError(t, appendFile(transcript, "two\n"))
+	info, err := os.Stat(companionPath)
+	require.NoError(t, err)
+	wantAtime := time.Unix(1, 0)
+	require.NoError(t, os.Chtimes(companionPath, wantAtime, info.ModTime()))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusDegraded, result.Status)
+	var stat syscall.Stat_t
+	require.NoError(t, syscall.Stat(companionPath, &stat))
+	assert.Equal(t, wantAtime.UnixNano(), stat.Atim.Sec*int64(time.Second)+stat.Atim.Nsec)
+}

--- a/internal/rawcapture/capturer.go
+++ b/internal/rawcapture/capturer.go
@@ -123,6 +123,9 @@ func (c *Capturer) Capture(
 	}
 	defer func() {
 		resultErr = errors.Join(resultErr, scope.Close())
+		if resultErr != nil {
+			result = Result{}
+		}
 	}()
 	root, err := c.store.ResolveConfiguredRoot(ctx, source.Provider, plan.ConfiguredRoot)
 	if err != nil {
@@ -373,18 +376,30 @@ func (c *Capturer) observePlan(
 		pathInfo, err := c.files.stat(entry.planned.LocalPath)
 		if err != nil {
 			closeObservedEntries(observed)
-			return nil, 0, ErrSourceChanged
+			if sourcePathChangedError(err) {
+				return nil, 0, ErrSourceChanged
+			}
+			return nil, 0, fmt.Errorf(
+				"rawcapture: stat %q: %w", entry.planned.Path, sanitizeFilesystemError(err),
+			)
 		}
 		file, err := entry.root.Open(entry.relative)
 		if err != nil {
 			closeObservedEntries(observed)
-			return nil, 0, ErrSourceChanged
+			if sourcePathChangedError(err) {
+				return nil, 0, ErrSourceChanged
+			}
+			return nil, 0, fmt.Errorf(
+				"rawcapture: open %q: %w", entry.planned.Path, sanitizeFilesystemError(err),
+			)
 		}
 		info, err := file.Stat()
 		if err != nil {
 			file.Close()
 			closeObservedEntries(observed)
-			return nil, 0, fmt.Errorf("rawcapture: stat %q: filesystem error", entry.planned.Path)
+			return nil, 0, fmt.Errorf(
+				"rawcapture: stat %q: %w", entry.planned.Path, sanitizeFilesystemError(err),
+			)
 		}
 		if !info.Mode().IsRegular() || info.Size() < 0 ||
 			!pathInfo.Mode().IsRegular() || !os.SameFile(pathInfo, info) ||
@@ -406,6 +421,11 @@ func (c *Capturer) observePlan(
 		})
 	}
 	return observed, sourceBytes, nil
+}
+
+func sourcePathChangedError(err error) bool {
+	return errors.Is(err, os.ErrNotExist) ||
+		sanitizeFilesystemError(err).Error() == "path escapes from parent"
 }
 
 func (c *Capturer) assessCapture(
@@ -441,7 +461,10 @@ func (c *Capturer) assessCapture(
 				ctx, current.file, previous.Length,
 			)
 			if err != nil {
-				return captureAssessment{}, err
+				return captureAssessment{}, fmt.Errorf(
+					"rawcapture: hash %q: %w", current.planned.Path,
+					sanitizeFilesystemError(err),
+				)
 			}
 			if length != previous.Length || digest != previous.PrefixSHA256 {
 				return full, nil
@@ -459,7 +482,10 @@ func (c *Capturer) assessCapture(
 		}
 		digest, length, err := hashOpenFileContext(ctx, current.file)
 		if err != nil {
-			return captureAssessment{}, err
+			return captureAssessment{}, fmt.Errorf(
+				"rawcapture: hash %q: %w", current.planned.Path,
+				sanitizeFilesystemError(err),
+			)
 		}
 		if length != previous.Length || digest != previous.PrefixSHA256 {
 			return full, nil

--- a/internal/rawcapture/capturer.go
+++ b/internal/rawcapture/capturer.go
@@ -177,6 +177,20 @@ func (c *Capturer) Capture(
 		if err := validateCapturePlanStillCurrent(ctx, provider, source, plan, scope); err != nil {
 			return Result{}, err
 		}
+		for i := range observed {
+			if err := c.verifyCapturedFile(ctx, observed[i], capturedFileState{
+				length:       observed[i].info.Size(),
+				modTimeNS:    observed[i].info.ModTime().UnixNano(),
+				fileIdentity: observed[i].identity,
+				prefixSHA256: assessment.entries[i].PrefixSHA256,
+			}); err != nil {
+				return Result{}, err
+			}
+		}
+		if err := c.store.CompleteUnchangedCapture(ctx, reservation.ID, identity); err != nil {
+			return Result{}, err
+		}
+		committed = true
 		return Result{Status: StatusUnchanged, Source: identity}, nil
 	}
 	captureID, err := newCaptureID()
@@ -454,7 +468,7 @@ func (c *Capturer) assessCapture(
 		prospective = append(prospective, cloneCapturedEntry(previous))
 	}
 	if suffixBytes == 0 {
-		return captureAssessment{unchanged: true}, nil
+		return captureAssessment{entries: prospective, unchanged: true}, nil
 	}
 	return captureAssessment{
 		mode: captureAppend, objectBytes: suffixBytes, entries: prospective,

--- a/internal/rawcapture/capturer.go
+++ b/internal/rawcapture/capturer.go
@@ -1,0 +1,547 @@
+// Package rawcapture captures provider-owned source files into the durable raw
+// upload outbox without parsing their content.
+package rawcapture
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+var (
+	ErrSourceChanged       = errors.New("rawcapture: source changed during capture")
+	ErrUnsupportedSnapshot = errors.New("rawcapture: provider snapshot requirement is not implemented")
+	ErrUnsupportedProvider = errors.New("rawcapture: provider does not support raw capture")
+	errCleanupIncomplete   = errors.New("rawcapture: cleanup incomplete")
+)
+
+// Status is the observable outcome of one capture request.
+type Status string
+
+const (
+	StatusCaptured  Status = "captured"
+	StatusUnchanged Status = "unchanged"
+	StatusDegraded  Status = "degraded"
+)
+
+type captureMode uint8
+
+const (
+	captureFull captureMode = iota
+	captureAppend
+)
+
+type observedCaptureEntry struct {
+	planned  parser.RawCaptureEntry
+	root     *os.Root
+	relative string
+	file     *os.File
+	info     os.FileInfo
+	identity string
+}
+
+type capturedFileState struct {
+	length       int64
+	modTimeNS    int64
+	fileIdentity string
+	prefixSHA256 string
+}
+
+type captureAssessment struct {
+	mode        captureMode
+	objectBytes int64
+	entries     []rawcheckpoint.CapturedEntry
+	appendBases []rawcheckpoint.CapturedEntry
+	unchanged   bool
+}
+
+// Result identifies the durable source generation created by Capture.
+type Result struct {
+	Status    Status
+	CaptureID string
+	Source    rawcheckpoint.SourceIdentity
+}
+
+type capturePhase uint8
+
+const (
+	capturePhaseBeforeRead capturePhase = iota + 1
+	capturePhaseAfterRead
+)
+
+// Capturer turns one provider source into a stable durable generation.
+type Capturer struct {
+	store          *rawcheckpoint.Store
+	files          fileOperations
+	manifestLimits rawsync.ManifestLimits
+	capturePhase   func(capturePhase, string)
+	discardObjects func(context.Context, []rawsync.ObjectRef) error
+}
+
+// New constructs a capturer over one durable checkpoint store.
+func New(store *rawcheckpoint.Store) *Capturer {
+	return &Capturer{
+		store: store, files: defaultFileOperations(),
+		manifestLimits: rawsync.DefaultManifestLimits(),
+		discardObjects: store.DiscardUnreferencedObjects,
+	}
+}
+
+// Capture captures one complete provider source without invoking its parser.
+func (c *Capturer) Capture(
+	ctx context.Context,
+	provider parser.Provider,
+	source parser.SourceRef,
+) (result Result, resultErr error) {
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	capabilities := provider.Capabilities().RawCapture
+	if capabilities.Snapshot != parser.RawCaptureSnapshotNone ||
+		capabilities.Shape == parser.RawCaptureShapeSQLite {
+		return Result{}, ErrUnsupportedSnapshot
+	}
+	plan, supported, err := parser.ResolveRawCapturePlan(ctx, provider, source)
+	if err != nil {
+		return Result{}, err
+	}
+	if !supported {
+		return Result{}, ErrUnsupportedProvider
+	}
+	scope, err := openCapturePlanScope(plan)
+	if err != nil {
+		return Result{}, err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, scope.Close())
+	}()
+	root, err := c.store.ResolveConfiguredRoot(ctx, source.Provider, plan.ConfiguredRoot)
+	if err != nil {
+		return Result{}, err
+	}
+	identity := rawcheckpoint.SourceIdentity{
+		Provider:         source.Provider,
+		ConfiguredRootID: root.ID,
+		SourceKey:        plan.SourceKey,
+	}
+	base, hasBase, err := c.store.CaptureBase(ctx, identity)
+	if err != nil {
+		return Result{}, err
+	}
+	observed, sourceBytes, err := c.observePlan(scope)
+	if err != nil {
+		return Result{}, err
+	}
+	defer closeObservedEntries(observed)
+	provisional := c.provisionalAssessment(observed, sourceBytes, base, hasBase)
+	reservationBytes := captureReservationBytes(provisional)
+	reservation, err := c.store.ReserveSourceCapture(ctx, identity, reservationBytes)
+	if errors.Is(err, rawcheckpoint.ErrOutboxFull) {
+		return Result{Status: StatusDegraded, Source: identity}, nil
+	}
+	if err != nil {
+		return Result{}, err
+	}
+	committed := false
+	cleanupIncomplete := false
+	var installed []rawsync.ObjectRef
+	finishPublication := func() {}
+	defer func() {
+		if !committed {
+			cleanupErr := c.discardObjects(
+				context.Background(), installed,
+			)
+			if cleanupErr == nil && !cleanupIncomplete {
+				cleanupErr = c.store.ReleaseReservation(
+					context.Background(), reservation.ID,
+				)
+			}
+			resultErr = errors.Join(resultErr, cleanupErr)
+		}
+		finishPublication()
+	}()
+	assessment, err := c.assessCapture(ctx, observed, sourceBytes, base, hasBase)
+	if err != nil {
+		return Result{}, err
+	}
+	if assessment.unchanged {
+		if err := validateCapturePlanStillCurrent(ctx, provider, source, plan, scope); err != nil {
+			return Result{}, err
+		}
+		return Result{Status: StatusUnchanged, Source: identity}, nil
+	}
+	captureID, err := newCaptureID()
+	if err != nil {
+		return Result{}, err
+	}
+	capturedAt := c.storeNow()
+	if err := c.validateForUpload(identity, captureID, capturedAt, assessment.entries); err != nil {
+		if assessment.mode != captureAppend {
+			return Result{}, err
+		}
+		assessment = c.fullAssessment(observed, sourceBytes)
+		if err := c.validateForUpload(identity, captureID, capturedAt, assessment.entries); err != nil {
+			return Result{}, err
+		}
+	}
+	requiredBytes := captureReservationBytes(assessment)
+	if requiredBytes > reservation.ReservedBytes {
+		if err := c.store.ReleaseReservation(ctx, reservation.ID); err != nil {
+			return Result{}, err
+		}
+		reservation = rawcheckpoint.Reservation{}
+		reservation, err = c.store.ReserveSourceCapture(ctx, identity, requiredBytes)
+		if errors.Is(err, rawcheckpoint.ErrOutboxFull) {
+			return Result{Status: StatusDegraded, Source: identity}, nil
+		}
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	finishPublication = c.store.BeginObjectPublication()
+	if c.capturePhase != nil {
+		c.capturePhase(capturePhaseBeforeRead, "")
+	}
+
+	entries := make([]rawcheckpoint.CapturedEntry, 0, len(plan.Entries))
+	capturedFiles := make([]capturedFileState, 0, len(plan.Entries))
+	for i := range observed {
+		planned := observed[i].planned
+		var entry rawcheckpoint.CapturedEntry
+		var newlyInstalled bool
+		if assessment.mode == captureAppend && planned.Appendable {
+			entry, newlyInstalled, err = c.captureAppendFile(
+				ctx, observed[i], assessment.appendBases[i],
+			)
+		} else if assessment.mode == captureAppend {
+			err = c.verifyReusedFile(ctx, observed[i], assessment.appendBases[i])
+			entry = cloneCapturedEntry(assessment.appendBases[i])
+		} else {
+			entry, newlyInstalled, err = c.captureFile(ctx, observed[i])
+		}
+		if newlyInstalled && len(entry.Objects) != 0 {
+			installed = append(installed, entry.Objects[len(entry.Objects)-1])
+		}
+		if err != nil {
+			cleanupIncomplete = errors.Is(err, errCleanupIncomplete)
+			return Result{}, err
+		}
+		entries = append(entries, entry)
+		capturedFiles = append(capturedFiles, capturedFileState{
+			length:       entry.Length,
+			modTimeNS:    entry.ModTimeNS,
+			fileIdentity: entry.FileIdentity,
+			prefixSHA256: entry.PrefixSHA256,
+		})
+	}
+	for i := range observed {
+		if err := c.verifyCapturedFile(ctx, observed[i], capturedFiles[i]); err != nil {
+			return Result{}, err
+		}
+	}
+	if err := validateCapturePlanStillCurrent(ctx, provider, source, plan, scope); err != nil {
+		return Result{}, err
+	}
+	if err := c.validateForUpload(identity, captureID, capturedAt, entries); err != nil {
+		return Result{}, err
+	}
+	predecessor := ""
+	if hasBase {
+		predecessor = base.CaptureID
+	}
+	generation := rawcheckpoint.CapturedGeneration{
+		CaptureID:            captureID,
+		Source:               identity,
+		PredecessorCaptureID: predecessor,
+		CapturedAt:           capturedAt,
+		Kind:                 rawsync.ManifestSnapshot,
+		Entries:              entries,
+	}
+	if err := c.store.CommitCapture(ctx, reservation.ID, generation); err != nil {
+		return Result{}, err
+	}
+	committed = true
+	return Result{
+		Status: StatusCaptured, CaptureID: captureID, Source: identity,
+	}, nil
+}
+
+func (c *Capturer) provisionalAssessment(
+	observed []observedCaptureEntry,
+	sourceBytes int64,
+	base rawcheckpoint.CaptureBaseState,
+	hasBase bool,
+) captureAssessment {
+	full := c.fullAssessment(observed, sourceBytes)
+	if !hasBase || len(observed) != len(base.Entries) {
+		return full
+	}
+	byPath := make(map[string]rawcheckpoint.CapturedEntry, len(base.Entries))
+	for _, entry := range base.Entries {
+		byPath[entry.Path] = entry
+	}
+	prospective := make([]rawcheckpoint.CapturedEntry, 0, len(observed))
+	var suffixBytes int64
+	for _, current := range observed {
+		previous, ok := byPath[current.planned.Path]
+		if !ok || previous.Appendable != current.planned.Appendable ||
+			previous.FileIdentity != current.identity {
+			return full
+		}
+		entry := cloneCapturedEntry(previous)
+		if current.planned.Appendable {
+			if current.info.Size() < previous.Length {
+				return full
+			}
+			entry.Length = current.info.Size()
+			entry.ModTimeNS = current.info.ModTime().UnixNano()
+			if current.info.Size() > previous.Length {
+				growth := current.info.Size() - previous.Length
+				suffixBytes += growth
+				entry.Objects = append(entry.Objects,
+					placeholderObjectRef(len(entry.Objects), growth))
+			}
+		} else if current.info.Size() != previous.Length {
+			return full
+		}
+		prospective = append(prospective, entry)
+	}
+	return captureAssessment{
+		mode: captureAppend, objectBytes: suffixBytes, entries: prospective,
+	}
+}
+
+func captureReservationBytes(assessment captureAssessment) int64 {
+	objectReferences := 0
+	for _, entry := range assessment.entries {
+		objectReferences += len(entry.Objects)
+	}
+	metadataBytes := rawcheckpoint.CaptureMetadataCharge(
+		len(assessment.entries), objectReferences,
+	)
+	if assessment.objectBytes > math.MaxInt64-metadataBytes {
+		return math.MaxInt64
+	}
+	return assessment.objectBytes + metadataBytes
+}
+
+func validateCapturePlanStillCurrent(
+	ctx context.Context,
+	provider parser.Provider,
+	source parser.SourceRef,
+	initial parser.RawCapturePlan,
+	scope *capturePlanScope,
+) error {
+	current, supported, err := parser.ResolveRawCapturePlan(ctx, provider, source)
+	if err != nil {
+		return err
+	}
+	if !supported || !sameCapturePlan(initial, current) || !scope.MatchesRoots(current) {
+		return ErrSourceChanged
+	}
+	return nil
+}
+
+func (c *Capturer) observePlan(
+	scope *capturePlanScope,
+) ([]observedCaptureEntry, int64, error) {
+	observed := make([]observedCaptureEntry, 0, len(scope.entries))
+	var sourceBytes int64
+	for _, entry := range scope.entries {
+		pathInfo, err := c.files.stat(entry.planned.LocalPath)
+		if err != nil {
+			closeObservedEntries(observed)
+			return nil, 0, ErrSourceChanged
+		}
+		file, err := entry.root.Open(entry.relative)
+		if err != nil {
+			closeObservedEntries(observed)
+			return nil, 0, ErrSourceChanged
+		}
+		info, err := file.Stat()
+		if err != nil {
+			file.Close()
+			closeObservedEntries(observed)
+			return nil, 0, fmt.Errorf("rawcapture: stat %q: filesystem error", entry.planned.Path)
+		}
+		if !info.Mode().IsRegular() || info.Size() < 0 ||
+			!pathInfo.Mode().IsRegular() || !os.SameFile(pathInfo, info) ||
+			sourceBytes > int64(^uint64(0)>>1)-info.Size() {
+			file.Close()
+			closeObservedEntries(observed)
+			return nil, 0, ErrSourceChanged
+		}
+		identity := stableFileIdentity(file, info)
+		if identity == "" {
+			file.Close()
+			closeObservedEntries(observed)
+			return nil, 0, ErrSourceChanged
+		}
+		sourceBytes += info.Size()
+		observed = append(observed, observedCaptureEntry{
+			planned: entry.planned, root: entry.root, relative: entry.relative,
+			file: file, info: info, identity: identity,
+		})
+	}
+	return observed, sourceBytes, nil
+}
+
+func (c *Capturer) assessCapture(
+	ctx context.Context,
+	observed []observedCaptureEntry,
+	sourceBytes int64,
+	base rawcheckpoint.CaptureBaseState,
+	hasBase bool,
+) (captureAssessment, error) {
+	full := c.fullAssessment(observed, sourceBytes)
+	if !hasBase || len(observed) != len(base.Entries) {
+		return full, nil
+	}
+	byPath := make(map[string]rawcheckpoint.CapturedEntry, len(base.Entries))
+	for _, entry := range base.Entries {
+		byPath[entry.Path] = entry
+	}
+	prospective := make([]rawcheckpoint.CapturedEntry, 0, len(observed))
+	appendBases := make([]rawcheckpoint.CapturedEntry, 0, len(observed))
+	var suffixBytes int64
+	for _, current := range observed {
+		previous, ok := byPath[current.planned.Path]
+		if !ok || previous.Appendable != current.planned.Appendable ||
+			previous.FileIdentity != current.identity {
+			return full, nil
+		}
+		appendBases = append(appendBases, cloneCapturedEntry(previous))
+		if current.planned.Appendable {
+			if current.info.Size() < previous.Length {
+				return full, nil
+			}
+			digest, length, err := hashOpenFilePrefixContext(
+				ctx, current.file, previous.Length,
+			)
+			if err != nil {
+				return captureAssessment{}, err
+			}
+			if length != previous.Length || digest != previous.PrefixSHA256 {
+				return full, nil
+			}
+			entry := cloneCapturedEntry(previous)
+			entry.Length = current.info.Size()
+			entry.ModTimeNS = current.info.ModTime().UnixNano()
+			if current.info.Size() > previous.Length {
+				growth := current.info.Size() - previous.Length
+				suffixBytes += growth
+				entry.Objects = append(entry.Objects, placeholderObjectRef(len(entry.Objects), growth))
+			}
+			prospective = append(prospective, entry)
+			continue
+		}
+		digest, length, err := hashOpenFileContext(ctx, current.file)
+		if err != nil {
+			return captureAssessment{}, err
+		}
+		if length != previous.Length || digest != previous.PrefixSHA256 {
+			return full, nil
+		}
+		prospective = append(prospective, cloneCapturedEntry(previous))
+	}
+	if suffixBytes == 0 {
+		return captureAssessment{unchanged: true}, nil
+	}
+	return captureAssessment{
+		mode: captureAppend, objectBytes: suffixBytes, entries: prospective,
+		appendBases: appendBases,
+	}, nil
+}
+
+func (c *Capturer) fullAssessment(
+	observed []observedCaptureEntry,
+	sourceBytes int64,
+) captureAssessment {
+	entries := make([]rawcheckpoint.CapturedEntry, 0, len(observed))
+	for i, current := range observed {
+		entries = append(entries, rawcheckpoint.CapturedEntry{
+			Path:         current.planned.Path,
+			Length:       current.info.Size(),
+			ModTimeNS:    current.info.ModTime().UnixNano(),
+			FileIdentity: current.identity,
+			PrefixSHA256: placeholderObjectRef(i, current.info.Size()).SHA256,
+			Appendable:   current.planned.Appendable,
+			Objects:      []rawsync.ObjectRef{placeholderObjectRef(i, current.info.Size())},
+		})
+	}
+	return captureAssessment{mode: captureFull, objectBytes: sourceBytes, entries: entries}
+}
+
+func placeholderObjectRef(index int, length int64) rawsync.ObjectRef {
+	return rawsync.ObjectRef{SHA256: fmt.Sprintf("%064x", index+1), Length: length}
+}
+
+func (c *Capturer) validateForUpload(
+	identity rawcheckpoint.SourceIdentity,
+	captureID string,
+	capturedAt time.Time,
+	entries []rawcheckpoint.CapturedEntry,
+) error {
+	manifestEntries := make([]rawsync.Entry, 0, len(entries))
+	for _, entry := range entries {
+		manifestEntries = append(manifestEntries, rawsync.Entry{
+			Path: entry.Path, Type: "file", Length: entry.Length,
+			Objects: append([]rawsync.ObjectRef(nil), entry.Objects...),
+		})
+	}
+	return rawsync.ValidateManifestForUpload(rawsync.Manifest{
+		SchemaVersion:    rawsync.ManifestSchemaVersion,
+		Provider:         identity.Provider,
+		ConfiguredRootID: identity.ConfiguredRootID,
+		SourceKey:        identity.SourceKey,
+		CaptureID:        captureID,
+		CapturedAt:       capturedAt,
+		Kind:             rawsync.ManifestSnapshot,
+		Entries:          manifestEntries,
+	}, c.manifestLimits)
+}
+
+func (c *Capturer) storeNow() time.Time {
+	return time.Now().UTC()
+}
+
+func newCaptureID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("rawcapture: generate capture ID: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+func cloneCapturedEntry(entry rawcheckpoint.CapturedEntry) rawcheckpoint.CapturedEntry {
+	entry.Objects = append([]rawsync.ObjectRef(nil), entry.Objects...)
+	return entry
+}
+
+func sameCapturePlan(a, b parser.RawCapturePlan) bool {
+	if a.ConfiguredRoot != b.ConfiguredRoot || a.CaptureRoot != b.CaptureRoot ||
+		a.SourceKey != b.SourceKey || len(a.Entries) != len(b.Entries) {
+		return false
+	}
+	for i := range a.Entries {
+		if a.Entries[i] != b.Entries[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func closeObservedEntries(entries []observedCaptureEntry) {
+	for i := range entries {
+		_ = entries[i].file.Close()
+	}
+}

--- a/internal/rawcapture/capturer.go
+++ b/internal/rawcapture/capturer.go
@@ -237,8 +237,7 @@ func (c *Capturer) Capture(
 				ctx, observed[i], assessment.appendBases[i],
 			)
 		} else if assessment.mode == captureAppend {
-			err = c.verifyReusedFile(ctx, observed[i], assessment.appendBases[i])
-			entry = cloneCapturedEntry(assessment.appendBases[i])
+			entry, err = c.captureReusedFile(ctx, observed[i], assessment.appendBases[i])
 		} else {
 			entry, newlyInstalled, err = c.captureFile(ctx, observed[i])
 		}

--- a/internal/rawcapture/capturer_test.go
+++ b/internal/rawcapture/capturer_test.go
@@ -1,0 +1,1030 @@
+package rawcapture
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+type captureTestProvider struct {
+	parser.ProviderBase
+	plan      parser.RawCapturePlan
+	planCalls atomic.Int32
+	planHook  func(int32)
+}
+
+func (p *captureTestProvider) Parse(
+	context.Context,
+	parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	panic("raw capture must not invoke Parse")
+}
+
+func (p *captureTestProvider) PlanRawCapture(
+	context.Context,
+	parser.SourceRef,
+) (parser.RawCapturePlan, error) {
+	call := p.planCalls.Add(1)
+	if p.planHook != nil {
+		p.planHook(call)
+	}
+	return p.plan, nil
+}
+
+func openCapturerTestStore(
+	t *testing.T,
+	maxBytes int64,
+) (*rawcheckpoint.Store, string) {
+	t.Helper()
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(),
+		filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir:       filepath.Join(base, "spool"),
+			MaxOutboxBytes: maxBytes,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store, base
+}
+
+func captureFileProvider(
+	t *testing.T,
+	content string,
+) (*captureTestProvider, parser.SourceRef, string) {
+	t.Helper()
+	root := t.TempDir()
+	path := filepath.Join(root, "project", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	var err error
+	root, err = filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	path, err = filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	provider := &captureTestProvider{
+		Def: parser.AgentDef{Type: parser.AgentClaude},
+		Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+			Support:  parser.CapabilitySupported,
+			Shape:    parser.RawCaptureShapeFiles,
+			Append:   parser.RawCaptureAppendOne,
+			Snapshot: parser.RawCaptureSnapshotNone,
+		}},
+		plan: parser.RawCapturePlan{
+			ConfiguredRoot: root,
+			CaptureRoot:    root,
+			SourceKey:      "source-1",
+			Entries: []parser.RawCaptureEntry{{
+				Path:       "project/session.jsonl",
+				LocalPath:  path,
+				Appendable: true,
+			}},
+		},
+	}
+	return provider, parser.SourceRef{
+		Provider: parser.AgentClaude,
+		Key:      "source-1",
+	}, path
+}
+
+func TestCapturerPersistsStableGenerationWithoutParsing(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	capturer := New(store)
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, result.Status)
+	assert.NotEmpty(t, result.CaptureID)
+	queued, ok, err := store.NextGeneration(t.Context())
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, result.CaptureID, queued.CaptureID)
+	assert.Equal(t, source.Key, queued.Source.SourceKey)
+	require.Len(t, queued.Entries, 1)
+	entry := queued.Entries[0]
+	assert.Equal(t, "project/session.jsonl", entry.Path)
+	assert.Equal(t, int64(4), entry.Length)
+	assert.NotEmpty(t, entry.FileIdentity)
+	assert.Equal(t, "2c8b08da5ce60398e1f19af0e5dccc744df274b826abe585eaba68c525434806", entry.PrefixSHA256)
+	require.Len(t, entry.Objects, 1)
+	assert.Equal(t, entry.PrefixSHA256, entry.Objects[0].SHA256)
+	assert.Equal(t, int64(4), entry.Objects[0].Length)
+	content, err := os.ReadFile(store.ObjectPath(entry.Objects[0]))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("one\n"), content)
+}
+
+func TestConcurrentCapturesDoNotDiscardAnotherCaptureSharedObject(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	providerA, sourceA, _ := captureFileProvider(t, "shared\n")
+	providerB, sourceB, _ := captureFileProvider(t, "shared\n")
+	providerB.plan.SourceKey = "source-2"
+	sourceB.Key = "source-2"
+	digest := sha256.Sum256([]byte("shared\n"))
+	ref := rawsync.ObjectRef{SHA256: fmt.Sprintf("%x", digest), Length: 7}
+	objectDir := filepath.Dir(store.ObjectPath(ref))
+	installedA := make(chan struct{})
+	releaseA := make(chan struct{})
+	capturerA := New(store)
+	capturerA.files.syncDir = func(path string) error {
+		if filepath.Clean(path) == filepath.Clean(objectDir) {
+			close(installedA)
+			<-releaseA
+			return errors.New("forced directory sync failure")
+		}
+		return syncDirectory(path)
+	}
+	startedB := make(chan struct{})
+	beforeCommitB := make(chan struct{})
+	releaseB := make(chan struct{})
+	providerB.planHook = func(call int32) {
+		switch call {
+		case 1:
+			close(startedB)
+		case 2:
+			close(beforeCommitB)
+			<-releaseB
+		}
+	}
+	type captureOutcome struct {
+		result Result
+		err    error
+	}
+	outcomeA := make(chan captureOutcome, 1)
+	outcomeB := make(chan captureOutcome, 1)
+	go func() {
+		result, err := capturerA.Capture(t.Context(), providerA, sourceA)
+		outcomeA <- captureOutcome{result: result, err: err}
+	}()
+	<-installedA
+	go func() {
+		result, err := New(store).Capture(t.Context(), providerB, sourceB)
+		outcomeB <- captureOutcome{result: result, err: err}
+	}()
+	<-startedB
+	select {
+	case <-beforeCommitB:
+		close(releaseA)
+		first := <-outcomeA
+		require.Error(t, first.err)
+		close(releaseB)
+	case <-time.After(500 * time.Millisecond):
+		close(releaseA)
+		first := <-outcomeA
+		require.Error(t, first.err)
+		<-beforeCommitB
+		close(releaseB)
+	}
+
+	second := <-outcomeB
+
+	require.NoError(t, second.err)
+	assert.Equal(t, StatusCaptured, second.result.Status)
+	assert.FileExists(t, store.ObjectPath(ref))
+}
+
+func TestCapturerReturnsUnchangedWithoutAnotherGeneration(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+
+	second, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusUnchanged, second.Status)
+	assert.Empty(t, second.CaptureID)
+	base, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         source.Provider,
+		ConfiguredRootID: first.Source.ConfiguredRootID,
+		SourceKey:        source.Key,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, first.CaptureID, base.CaptureID)
+}
+
+func TestCapturerRejectsMutationWithoutPublishingGeneration(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	capturer.capturePhase = func(phase capturePhase, _ string) {
+		if phase == capturePhaseAfterRead {
+			require.NoError(t, os.WriteFile(sourcePath, []byte("changed\n"), 0o600))
+		}
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerRejectsGrowthAfterCapacityReservation(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	capturer.capturePhase = func(phase capturePhase, _ string) {
+		if phase == capturePhaseBeforeRead {
+			require.NoError(t, appendFile(sourcePath, "two\n"))
+		}
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerReleasesReservationWhenObjectInstallFails(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	want := errors.New("rename failed")
+	capturer.files.rename = func(string, string) error { return want }
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, want)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+}
+
+func TestCapturerRemovesEarlierObjectsWhenLaterInstallFails(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, transcript := captureFileProvider(t, "one\n")
+	companionPath := filepath.Join(filepath.Dir(transcript), "companion.json")
+	require.NoError(t, os.WriteFile(companionPath, []byte("companion\n"), 0o600))
+	provider.plan.Entries = append(provider.plan.Entries, parser.RawCaptureEntry{
+		Path: "project/companion.json", LocalPath: companionPath,
+	})
+	capturer := New(store)
+	renames := 0
+	capturer.files.rename = func(source, destination string) error {
+		renames++
+		if renames == 2 {
+			return errors.New("second rename failed")
+		}
+		return os.Rename(source, destination)
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorContains(t, err, "second rename failed")
+	firstRef := rawsync.ObjectRef{
+		SHA256: "2c8b08da5ce60398e1f19af0e5dccc744df274b826abe585eaba68c525434806",
+		Length: 4,
+	}
+	assert.NoFileExists(t, store.ObjectPath(firstRef))
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerRejectsEarlierEntryMutationDuringLaterCapture(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, transcript := captureFileProvider(t, "one\n")
+	provider.plan.Entries[0].Path = "a-transcript.jsonl"
+	companionPath := filepath.Join(filepath.Dir(transcript), "b-companion.json")
+	require.NoError(t, os.WriteFile(companionPath, []byte("companion\n"), 0o600))
+	provider.plan.Entries = append(provider.plan.Entries, parser.RawCaptureEntry{
+		Path: "b-companion.json", LocalPath: companionPath,
+	})
+	capturer := New(store)
+	capturer.capturePhase = func(phase capturePhase, path string) {
+		if phase == capturePhaseAfterRead && path == companionPath {
+			require.NoError(t, os.WriteFile(transcript, []byte("changed\n"), 0o600))
+		}
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerRejectsEntryThatEscapesRootAfterPlanValidation(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "safe\n")
+	projectDir := filepath.Dir(sourcePath)
+	originalDir := projectDir + "-original"
+	outsideDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outsideDir, filepath.Base(sourcePath)), []byte("leak\n"), 0o600,
+	))
+	capturer := New(store)
+	originalStat := capturer.files.stat
+	swapped := false
+	capturer.files.stat = func(path string) (os.FileInfo, error) {
+		if path == sourcePath && !swapped {
+			swapped = true
+			require.NoError(t, os.Rename(projectDir, originalDir))
+			if err := os.Symlink(outsideDir, projectDir); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+		}
+		return originalStat(path)
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+}
+
+func TestCapturerRejectsCompanionAddedDuringCapture(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	companionPath := filepath.Join(filepath.Dir(sourcePath), "session_index.jsonl")
+	capturer := New(store)
+	capturer.capturePhase = func(phase capturePhase, _ string) {
+		if phase != capturePhaseAfterRead || len(provider.plan.Entries) != 1 {
+			return
+		}
+		require.NoError(t, os.WriteFile(companionPath, []byte("index\n"), 0o600))
+		provider.plan.Entries = append(provider.plan.Entries, parser.RawCaptureEntry{
+			Path: "project/session_index.jsonl", LocalPath: companionPath,
+		})
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+}
+
+func TestCapturerRejectsCompanionAddedBeforeUnchangedDecision(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	companionPath := filepath.Join(filepath.Dir(sourcePath), "session_index.jsonl")
+	originalStat := capturer.files.stat
+	added := false
+	capturer.files.stat = func(path string) (os.FileInfo, error) {
+		if path == sourcePath && !added {
+			added = true
+			require.NoError(t, os.WriteFile(companionPath, []byte("index\n"), 0o600))
+			provider.plan.Entries = append(provider.plan.Entries, parser.RawCaptureEntry{
+				Path: "project/session_index.jsonl", LocalPath: companionPath,
+			})
+		}
+		return originalStat(path)
+	}
+
+	_, err = capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+	base, ok, readErr := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, readErr)
+	require.True(t, ok)
+	assert.Equal(t, first.CaptureID, base.CaptureID)
+}
+
+func TestCapturerRetainsReservationWhenFailedObjectCleanupFails(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, transcript := captureFileProvider(t, "one\n")
+	companionPath := filepath.Join(filepath.Dir(transcript), "companion.json")
+	require.NoError(t, os.WriteFile(companionPath, []byte("companion\n"), 0o600))
+	provider.plan.Entries = append(provider.plan.Entries, parser.RawCaptureEntry{
+		Path: "project/companion.json", LocalPath: companionPath,
+	})
+	capturer := New(store)
+	renames := 0
+	capturer.files.rename = func(source, destination string) error {
+		renames++
+		if renames == 2 {
+			return errors.New("second rename failed")
+		}
+		return os.Rename(source, destination)
+	}
+	wantCleanup := errors.New("cleanup failed")
+	capturer.discardObjects = func(context.Context, []rawsync.ObjectRef) error {
+		return wantCleanup
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, wantCleanup)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Positive(t, usage.ReservedBytes)
+}
+
+func TestCapturerDiscardsRenamedObjectWhenDirectorySyncFails(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	objectDir := filepath.Dir(store.ObjectPath(rawsync.ObjectRef{
+		SHA256: "2c8b08da5ce60398e1f19af0e5dccc744df274b826abe585eaba68c525434806",
+		Length: 4,
+	}))
+	capturer.files.syncDir = func(path string) error {
+		if filepath.Clean(path) == filepath.Clean(objectDir) {
+			return errors.New("sync failed")
+		}
+		return syncDirectory(path)
+	}
+	var discarded []rawsync.ObjectRef
+	capturer.discardObjects = func(_ context.Context, refs []rawsync.ObjectRef) error {
+		discarded = append(discarded, refs...)
+		for _, ref := range refs {
+			require.NoError(t, os.Remove(store.ObjectPath(ref)))
+		}
+		return nil
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorContains(t, err, "sync object directory")
+	require.Len(t, discarded, 1)
+	assert.NoFileExists(t, store.ObjectPath(discarded[0]))
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerSyncsEveryObjectDirectoryEntryBeforeCommit(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	var synced []string
+	capturer.files.syncDir = func(path string) error {
+		synced = append(synced, filepath.Clean(path))
+		return syncDirectory(path)
+	}
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	base, ok, err := store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	objectDir := filepath.Dir(store.ObjectPath(base.Entries[0].Objects[0]))
+	shaDir := filepath.Dir(objectDir)
+	objectsDir := filepath.Dir(shaDir)
+	spoolDir := filepath.Dir(objectsDir)
+	assert.Subset(t, synced, []string{
+		filepath.Dir(spoolDir), spoolDir, objectsDir, shaDir, objectDir,
+	})
+}
+
+func TestCapturerRetainsReservationWhenTemporaryCleanupFails(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	capturer.files.rename = func(string, string) error { return errors.New("rename failed") }
+	wantCleanup := errors.New("temporary cleanup failed")
+	capturer.files.remove = func(string) error { return wantCleanup }
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, wantCleanup)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Positive(t, usage.ReservedBytes)
+}
+
+func TestCapturerHonorsCancellation(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := New(store).Capture(ctx, provider, source)
+
+	require.ErrorIs(t, err, context.Canceled)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerRejectsSQLiteSnapshotRequirement(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	provider.Caps.RawCapture.Shape = parser.RawCaptureShapeSQLite
+	provider.Caps.RawCapture.Snapshot = parser.RawCaptureSnapshotOnlineBackup
+
+	_, err := New(store).Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrUnsupportedSnapshot)
+}
+
+func TestCapturerStoresOnlySuffixObjectForVerifiedAppend(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, appendFile(sourcePath, "two\n"))
+
+	second, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, second.Status)
+	assert.NotEqual(t, first.CaptureID, second.CaptureID)
+	base, ok, err := store.CaptureBase(t.Context(), second.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	entry := base.Entries[0]
+	assert.Equal(t, int64(8), entry.Length)
+	assert.Equal(t, "c3f9c8c283a2b1f2f1896f27a01cbe3cddc0c9d93f752e4639035a0f5b36f6e8", entry.PrefixSHA256)
+	require.Len(t, entry.Objects, 2)
+	assert.Equal(t, "2c8b08da5ce60398e1f19af0e5dccc744df274b826abe585eaba68c525434806", entry.Objects[0].SHA256)
+	assert.Equal(t, int64(4), entry.Objects[0].Length)
+	assert.Equal(t, "27dd8ed44a83ff94d557f9fd0412ed5a8cbca69ea04922d88c01184a07300a5a", entry.Objects[1].SHA256)
+	assert.Equal(t, int64(4), entry.Objects[1].Length)
+	suffix, err := os.ReadFile(store.ObjectPath(entry.Objects[1]))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("two\n"), suffix)
+}
+
+func TestCapturerAppendsFromAcknowledgedBaseAfterLocalObjectGC(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	commit := rawsync.CommitResult{
+		ManifestID: strings.Repeat("a", 64),
+		Receipt:    strings.Repeat("b", 64),
+		Generation: 1,
+		Created:    true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", first.CaptureID, commit.ManifestID,
+	))
+	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", first.CaptureID, commit)
+	require.NoError(t, err)
+	firstRef := rawsync.ObjectRef{
+		SHA256: "2c8b08da5ce60398e1f19af0e5dccc744df274b826abe585eaba68c525434806",
+		Length: 4,
+	}
+	assert.NoFileExists(t, store.ObjectPath(firstRef))
+	require.NoError(t, appendFile(sourcePath, "two\n"))
+
+	second, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, second.Status)
+	base, ok, err := store.CaptureBase(t.Context(), second.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	assert.Equal(t, []rawsync.ObjectRef{
+		firstRef,
+		{SHA256: "27dd8ed44a83ff94d557f9fd0412ed5a8cbca69ea04922d88c01184a07300a5a", Length: 4},
+	}, base.Entries[0].Objects)
+}
+
+func TestCapturerFallsBackToFullObjectAfterTruncation(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\ntwo\n")
+	capturer := New(store)
+	_, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(sourcePath, []byte("x\n"), 0o600))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	base, ok, err := store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	require.Len(t, base.Entries[0].Objects, 1)
+	assert.Equal(t, "73cb3858a687a8494ca3323053016282f3dad39d42cf62ca4e79dda2aac7d9ac", base.Entries[0].Objects[0].SHA256)
+	assert.Equal(t, int64(2), base.Entries[0].Objects[0].Length)
+}
+
+func TestCapturerFallsBackToFullObjectAfterSameSizeRewrite(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	_, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(sourcePath, []byte("two\n"), 0o600))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	base, ok, err := store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	require.Len(t, base.Entries[0].Objects, 1)
+	assert.Equal(t, "27dd8ed44a83ff94d557f9fd0412ed5a8cbca69ea04922d88c01184a07300a5a", base.Entries[0].Objects[0].SHA256)
+}
+
+func TestCapturerFallsBackWhenEarlyPrefixWasRewrittenBeforeAppend(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 2<<20)
+	initial := bytes.Repeat([]byte("a"), 128<<10)
+	provider, source, sourcePath := captureFileProvider(t, string(initial))
+	capturer := New(store)
+	_, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	file, err := os.OpenFile(sourcePath, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	_, err = file.WriteAt([]byte("b"), 0)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	require.NoError(t, appendFile(sourcePath, "tail\n"))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	base, ok, err := store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	assert.Len(t, base.Entries[0].Objects, 1,
+		"a prefix rewrite outside the old 64 KiB boundary must force replacement")
+	assert.Equal(t, int64(len(initial)+5), base.Entries[0].Objects[0].Length)
+}
+
+func TestCapturerFallsBackWhenSamePathWasReplacedBeforeAppend(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	_, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, os.Rename(sourcePath, sourcePath+".old"))
+	require.NoError(t, os.WriteFile(sourcePath, []byte("one\ntwo\n"), 0o600))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	base, ok, err := store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	assert.Len(t, base.Entries[0].Objects, 1)
+	assert.Equal(t, int64(8), base.Entries[0].Objects[0].Length)
+}
+
+func TestCapturerReplacesWholeSourceWhenCompanionChanges(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, transcript := captureFileProvider(t, "one\n")
+	indexPath := filepath.Join(filepath.Dir(filepath.Dir(transcript)), "index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, []byte("index\n"), 0o600))
+	provider.plan.Entries = append(provider.plan.Entries, parser.RawCaptureEntry{
+		Path:      "index.jsonl",
+		LocalPath: indexPath,
+	})
+	capturer := New(store)
+	_, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(indexPath, []byte("index two\n"), 0o600))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	base, ok, err := store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 2)
+	for _, entry := range base.Entries {
+		assert.Len(t, entry.Objects, 1)
+	}
+}
+
+func TestCapturerDegradesBeforeInstallingSuffixWhenMetadataDoesNotFit(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 3847)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, appendFile(sourcePath, "two\n"))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusDegraded, result.Status)
+	base, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, first.CaptureID, base.CaptureID)
+	suffixRef := rawsync.ObjectRef{
+		SHA256: "27dd8ed44a83ff94d557f9fd0412ed5a8cbca69ea04922d88c01184a07300a5a",
+		Length: 4,
+	}
+	assert.NoFileExists(t, store.ObjectPath(suffixRef))
+}
+
+func TestSuccessfulSourceDoesNotClearAnotherSourceCoverageGap(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 2000)
+	root := t.TempDir()
+	largePath := filepath.Join(root, "large.jsonl")
+	smallPath := filepath.Join(root, "small.jsonl")
+	require.NoError(t, os.WriteFile(largePath, bytes.Repeat([]byte("x"), 1000), 0o600))
+	require.NoError(t, os.WriteFile(smallPath, []byte("x"), 0o600))
+	newProvider := func(sourceKey, path string) *captureTestProvider {
+		return &captureTestProvider{
+			Def: parser.AgentDef{Type: parser.AgentClaude},
+			Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+				Support: parser.CapabilitySupported, Shape: parser.RawCaptureShapeFiles,
+				Append: parser.RawCaptureAppendOne, Snapshot: parser.RawCaptureSnapshotNone,
+			}},
+			plan: parser.RawCapturePlan{
+				ConfiguredRoot: root, CaptureRoot: root, SourceKey: sourceKey,
+				Entries: []parser.RawCaptureEntry{{
+					Path: filepath.Base(path), LocalPath: path, Appendable: true,
+				}},
+			},
+		}
+	}
+	largeSource := parser.SourceRef{Provider: parser.AgentClaude, Key: "large"}
+	smallSource := parser.SourceRef{Provider: parser.AgentClaude, Key: "small"}
+
+	degraded, err := New(store).Capture(
+		t.Context(), newProvider("large", largePath), largeSource,
+	)
+	require.NoError(t, err)
+	require.Equal(t, StatusDegraded, degraded.Status)
+	captured, err := New(store).Capture(
+		t.Context(), newProvider("small", smallPath), smallSource,
+	)
+	require.NoError(t, err)
+	require.Equal(t, StatusCaptured, captured.Status)
+
+	coverage, ok, err := store.Coverage(
+		t.Context(), parser.AgentClaude, degraded.Source.ConfiguredRootID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageDegraded, coverage.State)
+	assert.Equal(t, "outbox_full", coverage.Reason)
+}
+
+func TestCapturerReservesOnlyVerifiedSuffixForAcknowledgedLargeSource(t *testing.T) {
+	baseDir := t.TempDir()
+	checkpointPath := filepath.Join(baseDir, "checkpoint.db")
+	spoolDir := filepath.Join(baseDir, "spool")
+	store, err := rawcheckpoint.OpenWithOptions(t.Context(), checkpointPath,
+		rawcheckpoint.Options{SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider, source, sourcePath := captureFileProvider(t, strings.Repeat("x", 4096))
+	first, err := New(store).Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	manifest, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	commit := rawsync.CommitResult{
+		ManifestID: strings.Repeat("a", 64), Receipt: strings.Repeat("b", 64),
+		Generation: 1, Created: true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", manifest.CaptureID, commit.ManifestID,
+	))
+	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", manifest.CaptureID, commit)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+	store, err = rawcheckpoint.OpenWithOptions(t.Context(), checkpointPath,
+		rawcheckpoint.Options{SpoolDir: spoolDir, MaxOutboxBytes: 2049})
+	require.NoError(t, err)
+	require.NoError(t, appendFile(sourcePath, "y"))
+
+	result, err := New(store).Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, result.Status)
+	assert.NotEqual(t, first.CaptureID, result.CaptureID)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2049), usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerRequiresFullReservationAfterAppendVerificationFallsBack(t *testing.T) {
+	const maxBytes = int64(1 << 20)
+	store, _ := openCapturerTestStore(t, maxBytes)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	const provisionalBytes = int64(1792)
+	_, err = store.ReserveCapture(
+		t.Context(), first.Source.ConfiguredRootID,
+		maxBytes-usage.UsedBytes-provisionalBytes,
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(sourcePath, []byte("two\n"), 0o600))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusDegraded, result.Status)
+	base, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, first.CaptureID, base.CaptureID)
+}
+
+func TestCapturerRejectsMutationDuringSuffixRead(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, appendFile(sourcePath, "two\n"))
+	capturer.capturePhase = func(phase capturePhase, _ string) {
+		if phase == capturePhaseAfterRead {
+			require.NoError(t, appendFile(sourcePath, "three\n"))
+		}
+	}
+
+	_, err = capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+	base, ok, readErr := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, readErr)
+	require.True(t, ok)
+	assert.Equal(t, first.CaptureID, base.CaptureID)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerRollsOverBeforeProspectiveObjectLimit(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	capturer.manifestLimits = rawsync.DefaultManifestLimits()
+	capturer.manifestLimits.MaxObjects = 2
+	_, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, appendFile(sourcePath, "two\n"))
+	second, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	secondBase, ok, err := store.CaptureBase(t.Context(), second.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, secondBase.Entries, 1)
+	assert.Len(t, secondBase.Entries[0].Objects, 2)
+	require.NoError(t, appendFile(sourcePath, "three\n"))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	base, ok, err := store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	assert.Len(t, base.Entries[0].Objects, 1)
+	assert.Equal(t, int64(14), base.Entries[0].Objects[0].Length)
+}
+
+func TestCapturerRollsOverBeforeProspectiveCanonicalLimit(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	base, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	fullEntry := cloneCapturedEntry(base.Entries[0])
+	fullEntry.Length = 8
+	fullEntry.Objects = []rawsync.ObjectRef{placeholderObjectRef(0, 8)}
+	appendEntry := cloneCapturedEntry(fullEntry)
+	appendEntry.Objects = []rawsync.ObjectRef{
+		base.Entries[0].Objects[0], placeholderObjectRef(1, 4),
+	}
+	limits := rawsync.DefaultManifestLimits()
+	limits.MaxCanonicalBytes = uploadCanonicalBytes(
+		t, first.Source, []rawcheckpoint.CapturedEntry{fullEntry},
+	) + len(".999999999")
+	require.Greater(t,
+		uploadCanonicalBytes(t, first.Source, []rawcheckpoint.CapturedEntry{appendEntry}),
+		limits.MaxCanonicalBytes,
+	)
+	capturer.manifestLimits = limits
+	require.NoError(t, appendFile(sourcePath, "two\n"))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	base, ok, err = store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 1)
+	assert.Len(t, base.Entries[0].Objects, 1)
+	assert.Equal(t, int64(8), base.Entries[0].Objects[0].Length)
+}
+
+func TestCapturerRejectsFullReplacementOutsideManifestLimits(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, _ := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	capturer.manifestLimits = rawsync.DefaultManifestLimits()
+	capturer.manifestLimits.MaxFileBytes = 3
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, rawsync.ErrInvalid)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+}
+
+func uploadCanonicalBytes(
+	t *testing.T,
+	source rawcheckpoint.SourceIdentity,
+	entries []rawcheckpoint.CapturedEntry,
+) int {
+	t.Helper()
+	manifestEntries := make([]rawsync.Entry, 0, len(entries))
+	for _, entry := range entries {
+		manifestEntries = append(manifestEntries, rawsync.Entry{
+			Path: entry.Path, Type: "file", Length: entry.Length,
+			Objects: append([]rawsync.ObjectRef(nil), entry.Objects...),
+		})
+	}
+	identity, err := rawsync.NewAuthIdentity(strings.Repeat(`"`, 128), strings.Repeat(`"`, 128))
+	require.NoError(t, err)
+	canonical, err := rawsync.ValidateAndCanonicalize(identity, rawsync.Manifest{
+		SchemaVersion:         rawsync.ManifestSchemaVersion,
+		Provider:              source.Provider,
+		ConfiguredRootID:      source.ConfiguredRootID,
+		SourceKey:             source.SourceKey,
+		ExpectedParentReceipt: strings.Repeat("0", 64),
+		CaptureID:             strings.Repeat("c", 32),
+		CapturedAt:            time.Date(2026, 8, 25, 12, 0, 0, 999999999, time.UTC),
+		Kind:                  rawsync.ManifestSnapshot,
+		Entries:               manifestEntries,
+	}, rawsync.DefaultManifestLimits())
+	require.NoError(t, err)
+	return len(canonical.CanonicalJSON)
+}
+
+func appendFile(path, content string) error {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	if _, err := file.WriteString(content); err != nil {
+		file.Close()
+		return err
+	}
+	return file.Close()
+}

--- a/internal/rawcapture/capturer_test.go
+++ b/internal/rawcapture/capturer_test.go
@@ -609,6 +609,37 @@ func TestCapturerStoresOnlySuffixObjectForVerifiedAppend(t *testing.T) {
 	assert.Equal(t, []byte("two\n"), suffix)
 }
 
+func TestCapturerRefreshesReusedCompanionMetadataForAppend(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, transcriptPath := captureFileProvider(t, "one\n")
+	companionPath := filepath.Join(filepath.Dir(transcriptPath), "session_index.jsonl")
+	require.NoError(t, os.WriteFile(companionPath, []byte("index\n"), 0o600))
+	provider.plan.Entries = append(provider.plan.Entries, parser.RawCaptureEntry{
+		Path: "project/session_index.jsonl", LocalPath: companionPath,
+	})
+	capturer := New(store)
+	_, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	initialInfo, err := os.Stat(companionPath)
+	require.NoError(t, err)
+	touchedAt := initialInfo.ModTime().Add(time.Hour)
+	require.NoError(t, os.Chtimes(companionPath, touchedAt, touchedAt))
+	currentInfo, err := os.Stat(companionPath)
+	require.NoError(t, err)
+	require.NotEqual(t, initialInfo.ModTime(), currentInfo.ModTime())
+	require.NoError(t, appendFile(transcriptPath, "two\n"))
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, result.Status)
+	base, ok, err := store.CaptureBase(t.Context(), result.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, base.Entries, 2)
+	assert.Equal(t, currentInfo.ModTime().UnixNano(), base.Entries[1].ModTimeNS)
+}
+
 func TestCapturerAppendsFromAcknowledgedBaseAfterLocalObjectGC(t *testing.T) {
 	store, _ := openCapturerTestStore(t, 1<<20)
 	require.NoError(t, store.SetDevice(t.Context(), "device-a"))

--- a/internal/rawcapture/capturer_test.go
+++ b/internal/rawcapture/capturer_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -986,6 +987,78 @@ func TestCapturerRequiresFullReservationAfterAppendVerificationFallsBack(t *test
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, first.CaptureID, base.CaptureID)
+}
+
+func TestCapturerDoesNotReturnDegradedStatusWithCleanupError(t *testing.T) {
+	const maxBytes = int64(1 << 20)
+	store, _ := openCapturerTestStore(t, maxBytes)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	const provisionalBytes = int64(1792)
+	_, err = store.ReserveCapture(
+		t.Context(), first.Source.ConfiguredRootID,
+		maxBytes-usage.UsedBytes-provisionalBytes,
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(sourcePath, []byte("two\n"), 0o600))
+	cleanupErr := errors.New("injected cleanup failure")
+	capturer.discardObjects = func(context.Context, []rawsync.ObjectRef) error {
+		return cleanupErr
+	}
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, cleanupErr)
+	assert.Empty(t, result)
+}
+
+func TestCapturerPreservesAndSanitizesObservationIOErrors(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	capturer.files.stat = func(path string) (os.FileInfo, error) {
+		if path == sourcePath {
+			return nil, &os.PathError{Op: "stat", Path: path, Err: syscall.EIO}
+		}
+		return os.Stat(path)
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, syscall.EIO)
+	assert.NotErrorIs(t, err, ErrSourceChanged)
+	assert.NotContains(t, err.Error(), sourcePath)
+	assert.Contains(t, err.Error(), `project/session.jsonl`)
+}
+
+func TestAssessCaptureSanitizesOpenFileErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("one\n"), 0o600))
+	file, err := os.Open(path)
+	require.NoError(t, err)
+	info, err := file.Stat()
+	require.NoError(t, err)
+	identity := stableFileIdentity(file, info)
+	require.NotEmpty(t, identity)
+	require.NoError(t, file.Close())
+	observed := []observedCaptureEntry{{
+		planned: parser.RawCaptureEntry{Path: "session.jsonl", Appendable: true},
+		file:    file, info: info, identity: identity,
+	}}
+	base := rawcheckpoint.CaptureBaseState{Entries: []rawcheckpoint.CapturedEntry{{
+		Path: "session.jsonl", Length: info.Size(), FileIdentity: identity,
+		PrefixSHA256: strings.Repeat("a", 64), Appendable: true,
+	}}}
+
+	_, err = (&Capturer{}).assessCapture(t.Context(), observed, info.Size(), base, true)
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), path)
+	assert.Contains(t, err.Error(), `session.jsonl`)
 }
 
 func TestCapturerRejectsMutationDuringSuffixRead(t *testing.T) {

--- a/internal/rawcapture/capturer_test.go
+++ b/internal/rawcapture/capturer_test.go
@@ -224,6 +224,24 @@ func TestCapturerReturnsUnchangedWithoutAnotherGeneration(t *testing.T) {
 	assert.Equal(t, first.CaptureID, base.CaptureID)
 }
 
+func TestCapturerRejectsSameSizeMutationBeforeUnchangedDecision(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	_, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	initialPlanCalls := provider.planCalls.Load()
+	provider.planHook = func(call int32) {
+		if call == initialPlanCalls+2 {
+			require.NoError(t, os.WriteFile(sourcePath, []byte("two\n"), 0o600))
+		}
+	}
+
+	_, err = capturer.Capture(t.Context(), provider, source)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+}
+
 func TestCapturerRejectsMutationWithoutPublishingGeneration(t *testing.T) {
 	store, _ := openCapturerTestStore(t, 1<<20)
 	provider, source, sourcePath := captureFileProvider(t, "one\n")
@@ -810,6 +828,65 @@ func TestSuccessfulSourceDoesNotClearAnotherSourceCoverageGap(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, rawcheckpoint.CoverageDegraded, coverage.State)
 	assert.Equal(t, "outbox_full", coverage.Reason)
+}
+
+func TestUnchangedSourcesClearOnlyTheirOwnCoverageFailures(t *testing.T) {
+	const maxBytes = int64(1 << 20)
+	store, _ := openCapturerTestStore(t, maxBytes)
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "first.jsonl")
+	secondPath := filepath.Join(root, "second.jsonl")
+	require.NoError(t, os.WriteFile(firstPath, []byte("first\n"), 0o600))
+	require.NoError(t, os.WriteFile(secondPath, []byte("second\n"), 0o600))
+	newProvider := func(sourceKey, path string) *captureTestProvider {
+		return &captureTestProvider{
+			Def: parser.AgentDef{Type: parser.AgentClaude},
+			Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+				Support: parser.CapabilitySupported, Shape: parser.RawCaptureShapeFiles,
+				Append: parser.RawCaptureAppendOne, Snapshot: parser.RawCaptureSnapshotNone,
+			}},
+			plan: parser.RawCapturePlan{
+				ConfiguredRoot: root, CaptureRoot: root, SourceKey: sourceKey,
+				Entries: []parser.RawCaptureEntry{{
+					Path: filepath.Base(path), LocalPath: path, Appendable: true,
+				}},
+			},
+		}
+	}
+	firstProvider := newProvider("first", firstPath)
+	secondProvider := newProvider("second", secondPath)
+	firstSource := parser.SourceRef{Provider: parser.AgentClaude, Key: "first"}
+	secondSource := parser.SourceRef{Provider: parser.AgentClaude, Key: "second"}
+	first, err := New(store).Capture(t.Context(), firstProvider, firstSource)
+	require.NoError(t, err)
+	second, err := New(store).Capture(t.Context(), secondProvider, secondSource)
+	require.NoError(t, err)
+	_, err = store.ReserveSourceCapture(t.Context(), first.Source, maxBytes)
+	require.ErrorIs(t, err, rawcheckpoint.ErrOutboxFull)
+	_, err = store.ReserveSourceCapture(t.Context(), second.Source, maxBytes)
+	require.ErrorIs(t, err, rawcheckpoint.ErrOutboxFull)
+
+	firstRetry, err := New(store).Capture(t.Context(), firstProvider, firstSource)
+
+	require.NoError(t, err)
+	require.Equal(t, StatusUnchanged, firstRetry.Status)
+	coverage, ok, err := store.Coverage(
+		t.Context(), parser.AgentClaude, first.Source.ConfiguredRootID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageDegraded, coverage.State)
+
+	secondRetry, err := New(store).Capture(t.Context(), secondProvider, secondSource)
+
+	require.NoError(t, err)
+	require.Equal(t, StatusUnchanged, secondRetry.Status)
+	coverage, ok, err = store.Coverage(
+		t.Context(), parser.AgentClaude, second.Source.ConfiguredRootID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageComplete, coverage.State)
 }
 
 func TestCapturerReservesOnlyVerifiedSuffixForAcknowledgedLargeSource(t *testing.T) {

--- a/internal/rawcapture/files.go
+++ b/internal/rawcapture/files.go
@@ -330,37 +330,43 @@ func (c *Capturer) captureAppendFile(
 	return entry, installed, err
 }
 
-func (c *Capturer) verifyReusedFile(
+func (c *Capturer) captureReusedFile(
 	ctx context.Context,
 	observed observedCaptureEntry,
 	base rawcheckpoint.CapturedEntry,
-) error {
+) (rawcheckpoint.CapturedEntry, error) {
 	planned := observed.planned
 	file := observed.file
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("rawcapture: seek %q: filesystem error", planned.Path)
+		return rawcheckpoint.CapturedEntry{}, fmt.Errorf(
+			"rawcapture: seek %q: filesystem error", planned.Path,
+		)
 	}
 	before, err := file.Stat()
 	if err != nil {
-		return ErrSourceChanged
+		return rawcheckpoint.CapturedEntry{}, ErrSourceChanged
 	}
 	identity := stableFileIdentity(file, before)
 	if !before.Mode().IsRegular() || before.Size() != base.Length ||
 		identity == "" || identity != observed.identity || identity != base.FileIdentity {
-		return ErrSourceChanged
+		return rawcheckpoint.CapturedEntry{}, ErrSourceChanged
 	}
 	hash := sha256.New()
 	length, err := copyContext(ctx, hash, file)
 	if err != nil {
-		return fmt.Errorf("rawcapture: read %q: %w", planned.Path, sanitizeFilesystemError(err))
+		return rawcheckpoint.CapturedEntry{}, fmt.Errorf(
+			"rawcapture: read %q: %w", planned.Path, sanitizeFilesystemError(err),
+		)
 	}
 	afterHandle, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("rawcapture: restat %q: filesystem error", planned.Path)
+		return rawcheckpoint.CapturedEntry{}, fmt.Errorf(
+			"rawcapture: restat %q: filesystem error", planned.Path,
+		)
 	}
 	afterFile, err := observed.root.Open(observed.relative)
 	if err != nil {
-		return ErrSourceChanged
+		return rawcheckpoint.CapturedEntry{}, ErrSourceChanged
 	}
 	afterPath, pathErr := afterFile.Stat()
 	afterIdentity := ""
@@ -371,9 +377,12 @@ func (c *Capturer) verifyReusedFile(
 	if pathErr != nil || !os.SameFile(before, afterPath) || !stableFileInfo(before, afterHandle) ||
 		afterIdentity != identity ||
 		length != base.Length || hex.EncodeToString(hash.Sum(nil)) != base.PrefixSHA256 {
-		return ErrSourceChanged
+		return rawcheckpoint.CapturedEntry{}, ErrSourceChanged
 	}
-	return nil
+	entry := cloneCapturedEntry(base)
+	entry.ModTimeNS = before.ModTime().UnixNano()
+	entry.FileIdentity = identity
+	return entry, nil
 }
 
 func (c *Capturer) verifyCapturedFile(

--- a/internal/rawcapture/files.go
+++ b/internal/rawcapture/files.go
@@ -1,0 +1,593 @@
+package rawcapture
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+type fileOperations struct {
+	stat    func(string) (os.FileInfo, error)
+	rename  func(string, string) error
+	remove  func(string) error
+	syncDir func(string) error
+}
+
+type scopedCaptureEntry struct {
+	planned  parser.RawCaptureEntry
+	root     *os.Root
+	relative string
+}
+
+type capturePlanScope struct {
+	entries        []scopedCaptureEntry
+	roots          []*os.Root
+	captureInfo    os.FileInfo
+	configuredInfo os.FileInfo
+}
+
+func openCapturePlanScope(plan parser.RawCapturePlan) (*capturePlanScope, error) {
+	captureRoot, err := os.OpenRoot(plan.CaptureRoot)
+	if err != nil {
+		return nil, fmt.Errorf("rawcapture: open capture root: filesystem error")
+	}
+	captureInfo, err := captureRoot.Stat(".")
+	if err != nil {
+		_ = captureRoot.Close()
+		return nil, fmt.Errorf("rawcapture: stat capture root: filesystem error")
+	}
+	scope := &capturePlanScope{
+		roots: []*os.Root{captureRoot}, captureInfo: captureInfo,
+		configuredInfo: captureInfo,
+	}
+	configuredRoot := captureRoot
+	if plan.ConfiguredRoot != plan.CaptureRoot {
+		configuredRoot, err = os.OpenRoot(plan.ConfiguredRoot)
+		if err != nil {
+			_ = captureRoot.Close()
+			return nil, fmt.Errorf("rawcapture: open configured root: filesystem error")
+		}
+		scope.roots = append(scope.roots, configuredRoot)
+		scope.configuredInfo, err = configuredRoot.Stat(".")
+		if err != nil {
+			_ = scope.Close()
+			return nil, fmt.Errorf("rawcapture: stat configured root: filesystem error")
+		}
+	}
+	for _, planned := range plan.Entries {
+		root := captureRoot
+		relative, ok := relativeWithinRoot(plan.CaptureRoot, planned.LocalPath)
+		if !ok {
+			root = configuredRoot
+			relative, ok = relativeWithinRoot(plan.ConfiguredRoot, planned.LocalPath)
+		}
+		if !ok {
+			_ = scope.Close()
+			return nil, ErrSourceChanged
+		}
+		scope.entries = append(scope.entries, scopedCaptureEntry{
+			planned: planned, root: root, relative: relative,
+		})
+	}
+	return scope, nil
+}
+
+func relativeWithinRoot(root, path string) (string, bool) {
+	relative, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil || relative == ".." ||
+		strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.Clean(relative), true
+}
+
+func (s *capturePlanScope) Close() error {
+	var closeErr error
+	for _, root := range s.roots {
+		if err := root.Close(); err != nil {
+			closeErr = errors.Join(closeErr, sanitizeFilesystemError(err))
+		}
+	}
+	s.roots = nil
+	return closeErr
+}
+
+func (s *capturePlanScope) MatchesRoots(plan parser.RawCapturePlan) bool {
+	captureInfo, err := os.Stat(plan.CaptureRoot)
+	if err != nil || !os.SameFile(s.captureInfo, captureInfo) {
+		return false
+	}
+	configuredInfo, err := os.Stat(plan.ConfiguredRoot)
+	return err == nil && os.SameFile(s.configuredInfo, configuredInfo)
+}
+
+func defaultFileOperations() fileOperations {
+	return fileOperations{
+		stat: os.Stat, rename: os.Rename, remove: os.Remove, syncDir: syncDirectory,
+	}
+}
+
+func (c *Capturer) captureFile(
+	ctx context.Context,
+	observed observedCaptureEntry,
+) (entry rawcheckpoint.CapturedEntry, installed bool, resultErr error) {
+	if err := ctx.Err(); err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, err
+	}
+	planned := observed.planned
+	source := observed.file
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf("rawcapture: seek %q: filesystem error", planned.Path)
+	}
+	before, err := source.Stat()
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf("rawcapture: stat %q: filesystem error", planned.Path)
+	}
+	beforeIdentity := stableFileIdentity(source, before)
+	if !before.Mode().IsRegular() || !stableFileInfo(observed.info, before) ||
+		beforeIdentity == "" || beforeIdentity != observed.identity {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	temporary, err := os.CreateTemp(c.store.CaptureTempDir(), "capture-*")
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf(
+			"rawcapture: create temporary object: %w", sanitizeFilesystemError(err),
+		)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if err := c.files.remove(temporaryPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			resultErr = errors.Join(resultErr, fmt.Errorf(
+				"%w: remove temporary object: %w",
+				errCleanupIncomplete, sanitizeFilesystemError(err),
+			))
+		}
+	}()
+
+	hash := sha256.New()
+	written, err := copyContext(ctx, io.MultiWriter(temporary, hash), source)
+	if err != nil {
+		temporary.Close()
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf(
+			"rawcapture: read %q: %w", planned.Path, sanitizeFilesystemError(err),
+		)
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf(
+			"rawcapture: sync temporary object: %w", sanitizeFilesystemError(err),
+		)
+	}
+	if err := temporary.Close(); err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf(
+			"rawcapture: close temporary object: %w", sanitizeFilesystemError(err),
+		)
+	}
+	if c.capturePhase != nil {
+		c.capturePhase(capturePhaseAfterRead, planned.LocalPath)
+	}
+	digest := hex.EncodeToString(hash.Sum(nil))
+	afterHandle, err := source.Stat()
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf("rawcapture: restat %q: filesystem error", planned.Path)
+	}
+	afterFile, err := observed.root.Open(observed.relative)
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	afterPath, pathErr := afterFile.Stat()
+	afterIdentity := ""
+	if pathErr == nil {
+		afterIdentity = stableFileIdentity(afterFile, afterPath)
+	}
+	_ = afterFile.Close()
+	if pathErr != nil || !os.SameFile(before, afterPath) || !stableFileInfo(before, afterHandle) ||
+		afterIdentity != beforeIdentity ||
+		written != before.Size() {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	verifiedDigest, verifiedBytes, err := hashScopedFileContext(
+		ctx, observed.root, observed.relative,
+	)
+	if err != nil || verifiedBytes != written || verifiedDigest != digest {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+
+	ref, err := rawsync.NewObjectRef(digest, written)
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, err
+	}
+	entry = rawcheckpoint.CapturedEntry{
+		Path:         planned.Path,
+		Length:       written,
+		ModTimeNS:    before.ModTime().UnixNano(),
+		FileIdentity: beforeIdentity,
+		PrefixSHA256: digest,
+		Appendable:   planned.Appendable,
+		Objects:      []rawsync.ObjectRef{ref},
+	}
+	installed, err = c.installObject(ctx, temporaryPath, ref)
+	return entry, installed, err
+}
+
+func (c *Capturer) captureAppendFile(
+	ctx context.Context,
+	observed observedCaptureEntry,
+	base rawcheckpoint.CapturedEntry,
+) (entry rawcheckpoint.CapturedEntry, installed bool, resultErr error) {
+	if err := ctx.Err(); err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, err
+	}
+	planned := observed.planned
+	source := observed.file
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf("rawcapture: seek %q: filesystem error", planned.Path)
+	}
+	before, err := source.Stat()
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	beforeIdentity := stableFileIdentity(source, before)
+	if !before.Mode().IsRegular() || !stableFileInfo(observed.info, before) ||
+		before.Size() <= base.Length ||
+		beforeIdentity == "" || beforeIdentity != observed.identity ||
+		beforeIdentity != base.FileIdentity {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	temporary, err := os.CreateTemp(c.store.CaptureTempDir(), "capture-append-*")
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf(
+			"rawcapture: create temporary object: %w", sanitizeFilesystemError(err),
+		)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if err := c.files.remove(temporaryPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			resultErr = errors.Join(resultErr, fmt.Errorf(
+				"%w: remove temporary object: %w",
+				errCleanupIncomplete, sanitizeFilesystemError(err),
+			))
+		}
+	}()
+
+	prefixHash := sha256.New()
+	fullHash := sha256.New()
+	prefixBytes, err := copyContext(
+		ctx, io.MultiWriter(prefixHash, fullHash), io.LimitReader(source, base.Length),
+	)
+	if err != nil || prefixBytes != base.Length ||
+		hex.EncodeToString(prefixHash.Sum(nil)) != base.PrefixSHA256 {
+		temporary.Close()
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	suffixHash := sha256.New()
+	suffixBytes, err := copyContext(ctx, io.MultiWriter(temporary, suffixHash, fullHash), source)
+	if err != nil || suffixBytes != before.Size()-base.Length {
+		temporary.Close()
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf(
+			"rawcapture: sync temporary object: %w", sanitizeFilesystemError(err),
+		)
+	}
+	if err := temporary.Close(); err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf(
+			"rawcapture: close temporary object: %w", sanitizeFilesystemError(err),
+		)
+	}
+	if c.capturePhase != nil {
+		c.capturePhase(capturePhaseAfterRead, planned.LocalPath)
+	}
+	afterHandle, err := source.Stat()
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, fmt.Errorf("rawcapture: restat %q: filesystem error", planned.Path)
+	}
+	afterFile, err := observed.root.Open(observed.relative)
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	afterPath, pathErr := afterFile.Stat()
+	afterIdentity := ""
+	if pathErr == nil {
+		afterIdentity = stableFileIdentity(afterFile, afterPath)
+	}
+	_ = afterFile.Close()
+	if pathErr != nil || !os.SameFile(before, afterPath) || !stableFileInfo(before, afterHandle) ||
+		afterIdentity != beforeIdentity {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	fullDigest := hex.EncodeToString(fullHash.Sum(nil))
+	verifiedDigest, verifiedBytes, err := hashScopedFileContext(
+		ctx, observed.root, observed.relative,
+	)
+	if err != nil || verifiedBytes != before.Size() || verifiedDigest != fullDigest {
+		return rawcheckpoint.CapturedEntry{}, false, ErrSourceChanged
+	}
+	ref, err := rawsync.NewObjectRef(hex.EncodeToString(suffixHash.Sum(nil)), suffixBytes)
+	if err != nil {
+		return rawcheckpoint.CapturedEntry{}, false, err
+	}
+	entry = cloneCapturedEntry(base)
+	entry.Length = before.Size()
+	entry.ModTimeNS = before.ModTime().UnixNano()
+	entry.FileIdentity = beforeIdentity
+	entry.PrefixSHA256 = fullDigest
+	entry.Objects = append(entry.Objects, ref)
+	installed, err = c.installObject(ctx, temporaryPath, ref)
+	return entry, installed, err
+}
+
+func (c *Capturer) verifyReusedFile(
+	ctx context.Context,
+	observed observedCaptureEntry,
+	base rawcheckpoint.CapturedEntry,
+) error {
+	planned := observed.planned
+	file := observed.file
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rawcapture: seek %q: filesystem error", planned.Path)
+	}
+	before, err := file.Stat()
+	if err != nil {
+		return ErrSourceChanged
+	}
+	identity := stableFileIdentity(file, before)
+	if !before.Mode().IsRegular() || before.Size() != base.Length ||
+		identity == "" || identity != observed.identity || identity != base.FileIdentity {
+		return ErrSourceChanged
+	}
+	hash := sha256.New()
+	length, err := copyContext(ctx, hash, file)
+	if err != nil {
+		return fmt.Errorf("rawcapture: read %q: %w", planned.Path, sanitizeFilesystemError(err))
+	}
+	afterHandle, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("rawcapture: restat %q: filesystem error", planned.Path)
+	}
+	afterFile, err := observed.root.Open(observed.relative)
+	if err != nil {
+		return ErrSourceChanged
+	}
+	afterPath, pathErr := afterFile.Stat()
+	afterIdentity := ""
+	if pathErr == nil {
+		afterIdentity = stableFileIdentity(afterFile, afterPath)
+	}
+	_ = afterFile.Close()
+	if pathErr != nil || !os.SameFile(before, afterPath) || !stableFileInfo(before, afterHandle) ||
+		afterIdentity != identity ||
+		length != base.Length || hex.EncodeToString(hash.Sum(nil)) != base.PrefixSHA256 {
+		return ErrSourceChanged
+	}
+	return nil
+}
+
+func (c *Capturer) verifyCapturedFile(
+	ctx context.Context,
+	observed observedCaptureEntry,
+	captured capturedFileState,
+) error {
+	planned := observed.planned
+	file, err := observed.root.Open(observed.relative)
+	if err != nil {
+		return ErrSourceChanged
+	}
+	defer file.Close()
+	before, err := file.Stat()
+	if err != nil {
+		return ErrSourceChanged
+	}
+	identity := stableFileIdentity(file, before)
+	if !before.Mode().IsRegular() || !stableFileInfo(observed.info, before) ||
+		before.Size() != captured.length || before.ModTime().UnixNano() != captured.modTimeNS ||
+		identity == "" || identity != observed.identity || identity != captured.fileIdentity {
+		return ErrSourceChanged
+	}
+	hash := sha256.New()
+	length, err := copyContext(ctx, hash, file)
+	if err != nil {
+		return fmt.Errorf("rawcapture: validate %q: %w", planned.Path, sanitizeFilesystemError(err))
+	}
+	afterHandle, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("rawcapture: restat %q after final validation: filesystem error", planned.Path)
+	}
+	afterFile, err := observed.root.Open(observed.relative)
+	if err != nil {
+		return ErrSourceChanged
+	}
+	afterPath, pathErr := afterFile.Stat()
+	afterIdentity := ""
+	if pathErr == nil {
+		afterIdentity = stableFileIdentity(afterFile, afterPath)
+	}
+	_ = afterFile.Close()
+	if pathErr != nil || !os.SameFile(before, afterPath) || !stableFileInfo(before, afterHandle) ||
+		afterIdentity != identity ||
+		length != captured.length || hex.EncodeToString(hash.Sum(nil)) != captured.prefixSHA256 {
+		return ErrSourceChanged
+	}
+	return nil
+}
+
+func (c *Capturer) installObject(
+	ctx context.Context,
+	temporaryPath string,
+	ref rawsync.ObjectRef,
+) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	destination := c.store.ObjectPath(ref)
+	if info, err := c.files.stat(destination); err == nil {
+		if !info.Mode().IsRegular() || info.Size() != ref.Length {
+			return false, fmt.Errorf("rawcapture: existing object has conflicting size")
+		}
+		digest, length, err := hashFileContext(ctx, destination)
+		if err != nil || digest != ref.SHA256 || length != ref.Length {
+			return false, fmt.Errorf("rawcapture: existing object failed verification")
+		}
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf(
+			"rawcapture: stat object destination: %w", sanitizeFilesystemError(err),
+		)
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return false, fmt.Errorf(
+			"rawcapture: create object directory: %w", sanitizeFilesystemError(err),
+		)
+	}
+	if err := c.syncObjectDirectoryHierarchy(); err != nil {
+		return false, err
+	}
+	if err := c.files.rename(temporaryPath, destination); err != nil {
+		return false, fmt.Errorf(
+			"rawcapture: install object: %w", sanitizeFilesystemError(err),
+		)
+	}
+	if err := c.files.syncDir(filepath.Dir(destination)); err != nil {
+		return true, fmt.Errorf("rawcapture: sync object directory: filesystem error")
+	}
+	return true, nil
+}
+
+func (c *Capturer) syncObjectDirectoryHierarchy() error {
+	spoolDir := filepath.Dir(c.store.CaptureTempDir())
+	for _, directory := range []string{
+		filepath.Dir(spoolDir),
+		spoolDir,
+		filepath.Join(spoolDir, "objects"),
+		filepath.Join(spoolDir, "objects", "sha256"),
+	} {
+		if err := c.files.syncDir(directory); err != nil {
+			return fmt.Errorf("rawcapture: sync object directory hierarchy: filesystem error")
+		}
+	}
+	return nil
+}
+
+func stableFileInfo(a, b os.FileInfo) bool {
+	return a.Mode() == b.Mode() && a.Size() == b.Size() &&
+		a.ModTime().Equal(b.ModTime()) && os.SameFile(a, b)
+}
+
+func copyContext(ctx context.Context, destination io.Writer, source io.Reader) (int64, error) {
+	buffer := make([]byte, 64<<10)
+	var total int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		read, readErr := source.Read(buffer)
+		if read > 0 {
+			written, writeErr := destination.Write(buffer[:read])
+			total += int64(written)
+			if writeErr != nil {
+				return total, writeErr
+			}
+			if written != read {
+				return total, io.ErrShortWrite
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return total, nil
+			}
+			return total, readErr
+		}
+	}
+}
+
+func hashFileContext(ctx context.Context, path string) (string, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	length, err := copyContext(ctx, hash, file)
+	if err != nil {
+		return "", length, err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), length, nil
+}
+
+func hashScopedFileContext(
+	ctx context.Context,
+	root *os.Root,
+	relative string,
+) (string, int64, error) {
+	file, err := root.Open(relative)
+	if err != nil {
+		return "", 0, ErrSourceChanged
+	}
+	defer file.Close()
+	return hashOpenFileContext(ctx, file)
+}
+
+func hashOpenFileContext(ctx context.Context, file *os.File) (string, int64, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", 0, err
+	}
+	hash := sha256.New()
+	length, err := copyContext(ctx, hash, file)
+	if err != nil {
+		return "", length, err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), length, nil
+}
+
+func hashOpenFilePrefixContext(
+	ctx context.Context,
+	file *os.File,
+	limit int64,
+) (string, int64, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", 0, err
+	}
+	hash := sha256.New()
+	length, err := copyContext(ctx, hash, io.LimitReader(file, limit))
+	if err != nil {
+		return "", length, err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), length, nil
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil && runtime.GOOS != "windows" {
+		// Windows does not support syncing directory handles. The atomic rename
+		// remains the durability boundary available there.
+		return err
+	}
+	return nil
+}
+
+func sanitizeFilesystemError(err error) error {
+	if pathErr, ok := errors.AsType[*os.PathError](err); ok {
+		return pathErr.Err
+	}
+	if linkErr, ok := errors.AsType[*os.LinkError](err); ok {
+		return linkErr.Err
+	}
+	return err
+}

--- a/internal/rawcapture/identity_unix.go
+++ b/internal/rawcapture/identity_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package rawcapture
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func stableFileIdentity(_ *os.File, info os.FileInfo) string {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%d:%d", uint64(stat.Dev), uint64(stat.Ino))
+}

--- a/internal/rawcapture/identity_windows.go
+++ b/internal/rawcapture/identity_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package rawcapture
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func stableFileIdentity(file *os.File, _ os.FileInfo) string {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(
+		windows.Handle(file.Fd()), &info,
+	); err != nil {
+		return ""
+	}
+	fileIndex := uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow)
+	return fmt.Sprintf("%d:%d", uint64(info.VolumeSerialNumber), fileIndex)
+}

--- a/internal/rawcapture/identity_windows_test.go
+++ b/internal/rawcapture/identity_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package rawcapture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestStableFileIdentityDistinguishesFilesWithEqualCreationTimes(t *testing.T) {
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "first.jsonl")
+	secondPath := filepath.Join(root, "second.jsonl")
+	require.NoError(t, os.WriteFile(firstPath, []byte("same\n"), 0o600))
+	require.NoError(t, os.WriteFile(secondPath, []byte("same\n"), 0o600))
+	first, err := os.OpenFile(firstPath, os.O_RDWR, 0)
+	require.NoError(t, err)
+	defer first.Close()
+	second, err := os.OpenFile(secondPath, os.O_RDWR, 0)
+	require.NoError(t, err)
+	defer second.Close()
+	created := windows.NsecToFiletime(
+		time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC).UnixNano(),
+	)
+	require.NoError(t, windows.SetFileTime(
+		windows.Handle(first.Fd()), &created, nil, nil,
+	))
+	require.NoError(t, windows.SetFileTime(
+		windows.Handle(second.Fd()), &created, nil, nil,
+	))
+	firstInfo, err := first.Stat()
+	require.NoError(t, err)
+	secondInfo, err := second.Stat()
+	require.NoError(t, err)
+
+	firstIdentity := stableFileIdentity(first, firstInfo)
+	secondIdentity := stableFileIdentity(second, secondInfo)
+
+	assert.NotEmpty(t, firstIdentity)
+	assert.NotEmpty(t, secondIdentity)
+	assert.NotEqual(t, firstIdentity, secondIdentity)
+}

--- a/internal/rawcheckpoint/ack.go
+++ b/internal/rawcheckpoint/ack.go
@@ -521,6 +521,10 @@ func releaseGenerationObjectsConn(ctx context.Context, conn *sql.Conn, captureID
 		}
 		refs = append(refs, item)
 	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("rawcheckpoint: release generation objects: %w", err)
+	}
 	if err := rows.Close(); err != nil {
 		return fmt.Errorf("rawcheckpoint: release generation objects: %w", err)
 	}

--- a/internal/rawcheckpoint/ack.go
+++ b/internal/rawcheckpoint/ack.go
@@ -1,0 +1,541 @@
+package rawcheckpoint
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+var ErrAcknowledgeConflict = errors.New("rawcheckpoint: generation acknowledgement conflict")
+
+var ErrGenerationFailureConflict = errors.New(
+	"rawcheckpoint: generation failure state conflict")
+
+// GenerationFailureClass records the transport outcome needed by the later
+// uploader without embedding provider responses or raw content in the outbox.
+type GenerationFailureClass string
+
+const (
+	GenerationFailureTransient             GenerationFailureClass = "transient"
+	GenerationFailureParentReceiptConflict GenerationFailureClass = "parent_receipt_conflict"
+)
+
+// AcknowledgeResult reports whether an acknowledgement was replayed and what
+// physical capacity its normal-operation garbage collection reclaimed.
+type AcknowledgeResult struct {
+	Replayed bool
+	Garbage  GarbageCollectionReport
+}
+
+// BindFinalizedManifestID durably associates the canonical manifest ID
+// returned for a specific finalized upload with its local capture. This
+// separate fence prevents a later acknowledgement from applying a result that
+// belongs to another manifest at the same server generation.
+func (s *Store) BindFinalizedManifestID(
+	ctx context.Context,
+	deviceID, captureID, manifestID string,
+) error {
+	if captureID == "" {
+		return ErrAcknowledgeConflict
+	}
+	if _, err := rawsync.NewObjectRef(manifestID, 0); err != nil {
+		return fmt.Errorf("rawcheckpoint: invalid finalized manifest ID: %w", err)
+	}
+	return s.withImmediateWrite(ctx, "bind finalized manifest ID", func(conn *sql.Conn) error {
+		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
+			return err
+		}
+		var state, stored string
+		err := conn.QueryRowContext(ctx, `SELECT state, manifest_id
+			FROM outbox_generations WHERE capture_id = ?`, captureID).Scan(&state, &stored)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrAcknowledgeConflict
+		}
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: bind finalized manifest ID: %w", err)
+		}
+		if state != "finalized" || (stored != "" && stored != manifestID) {
+			return ErrAcknowledgeConflict
+		}
+		if stored == manifestID {
+			return nil
+		}
+		result, err := conn.ExecContext(ctx, `UPDATE outbox_generations
+			SET manifest_id = ?, updated_at = ?
+			WHERE capture_id = ? AND state = 'finalized' AND manifest_id = ''`,
+			manifestID, s.now().UTC().Format(time.RFC3339Nano), captureID)
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: bind finalized manifest ID: %w", err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed != 1 {
+			return ErrAcknowledgeConflict
+		}
+		return nil
+	})
+}
+
+// FinalizeNextManifest returns the oldest uploadable generation and durably
+// freezes the acknowledged parent receipt used by all retries.
+func (s *Store) FinalizeNextManifest(
+	ctx context.Context,
+	deviceID string,
+) (rawsync.Manifest, bool, error) {
+	var manifest rawsync.Manifest
+	found := false
+	err := s.withImmediateWrite(ctx, "finalize next manifest", func(conn *sql.Conn) error {
+		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
+			return err
+		}
+		var provider, capturedAt, kind, state, expectedParent string
+		err := conn.QueryRowContext(ctx, `SELECT generation.capture_id,
+			generation.provider, generation.configured_root_id,
+			generation.source_key, generation.captured_at, generation.kind,
+			generation.state, generation.expected_parent_receipt
+			FROM outbox_generations AS generation
+			LEFT JOIN outbox_generations AS predecessor
+				ON predecessor.capture_id = generation.predecessor_capture_id
+			WHERE generation.state IN ('queued', 'finalized')
+			AND generation.blocked = 0
+			AND (generation.retry_at = '' OR generation.retry_at <= ?)
+			AND (generation.predecessor_capture_id IS NULL
+				OR predecessor.state = 'acknowledged')
+			ORDER BY generation.captured_at, generation.capture_id LIMIT 1`,
+			s.now().UTC().Format(time.RFC3339Nano),
+		).Scan(&manifest.CaptureID, &provider, &manifest.ConfiguredRootID,
+			&manifest.SourceKey, &capturedAt, &kind, &state, &expectedParent)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: finalize manifest: select generation: %w", err)
+		}
+		manifest.SchemaVersion = rawsync.ManifestSchemaVersion
+		manifest.Provider = parser.AgentType(provider)
+		manifest.CapturedAt, _ = time.Parse(time.RFC3339Nano, capturedAt)
+		manifest.Kind = rawsync.ManifestKind(kind)
+		if state == "queued" {
+			if err := conn.QueryRowContext(ctx, `SELECT head_receipt FROM raw_sources
+				WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+				provider, manifest.ConfiguredRootID, manifest.SourceKey,
+			).Scan(&expectedParent); err != nil {
+				return fmt.Errorf("rawcheckpoint: finalize manifest: read source head: %w", err)
+			}
+			now := s.now().UTC().Format(time.RFC3339Nano)
+			if _, err := conn.ExecContext(ctx, `UPDATE outbox_generations SET
+				state = 'finalized', expected_parent_receipt = ?, updated_at = ?
+				WHERE capture_id = ? AND state = 'queued'`,
+				expectedParent, now, manifest.CaptureID); err != nil {
+				return fmt.Errorf("rawcheckpoint: finalize manifest: persist parent: %w", err)
+			}
+		}
+		manifest.ExpectedParentReceipt = expectedParent
+		entries, err := loadManifestEntriesConn(ctx, conn, manifest.CaptureID)
+		if err != nil {
+			return err
+		}
+		manifest.Entries = entries
+		found = true
+		return nil
+	})
+	return manifest, found && err == nil, err
+}
+
+// RecordGenerationFailure durably delays a transient retry or blocks one
+// source chain after a parent-receipt conflict. Other source chains remain
+// independently uploadable.
+func (s *Store) RecordGenerationFailure(
+	ctx context.Context,
+	deviceID, captureID string,
+	class GenerationFailureClass,
+	retryAt time.Time,
+) error {
+	blocked := 0
+	retryStamp := ""
+	switch class {
+	case GenerationFailureTransient:
+		if retryAt.IsZero() {
+			return ErrGenerationFailureConflict
+		}
+		retryStamp = retryAt.UTC().Format(time.RFC3339Nano)
+	case GenerationFailureParentReceiptConflict:
+		if !retryAt.IsZero() {
+			return ErrGenerationFailureConflict
+		}
+		blocked = 1
+	default:
+		return ErrGenerationFailureConflict
+	}
+	return s.withImmediateWrite(ctx, "record generation failure", func(conn *sql.Conn) error {
+		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
+			return err
+		}
+		result, err := conn.ExecContext(ctx, `UPDATE outbox_generations SET
+			retry_at = ?, error_class = ?, blocked = ?, updated_at = ?
+			WHERE capture_id = ? AND state = 'finalized'`, retryStamp, string(class),
+			blocked, s.now().UTC().Format(time.RFC3339Nano), captureID)
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: record generation failure: %w", err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed != 1 {
+			return ErrGenerationFailureConflict
+		}
+		return nil
+	})
+}
+
+// ResumeGeneration reconciles a parent-receipt conflict to the reported
+// server head and requeues the local generation to freeze that new parent.
+func (s *Store) ResumeGeneration(
+	ctx context.Context,
+	deviceID, captureID string,
+	reconciled SourceHead,
+) error {
+	if err := validateReconciledSourceHead(reconciled); err != nil {
+		return fmt.Errorf("rawcheckpoint: invalid reconciled head: %w", err)
+	}
+	return s.withImmediateWrite(ctx, "resume generation", func(conn *sql.Conn) error {
+		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
+			return err
+		}
+		var source SourceIdentity
+		var state, failureClass string
+		var blocked int
+		err := conn.QueryRowContext(ctx, `SELECT provider, configured_root_id,
+			source_key, state, error_class, blocked FROM outbox_generations
+			WHERE capture_id = ?`, captureID,
+		).Scan(&source.Provider, &source.ConfiguredRootID, &source.SourceKey,
+			&state, &failureClass, &blocked)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrGenerationFailureConflict
+		}
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: resume generation: read state: %w", err)
+		}
+		if state != "finalized" ||
+			failureClass != string(GenerationFailureParentReceiptConflict) || blocked != 1 {
+			return ErrGenerationFailureConflict
+		}
+		now := s.now().UTC().Format(time.RFC3339Nano)
+		if _, err := conn.ExecContext(ctx, `UPDATE raw_sources SET
+			head_capture_id = '', head_manifest_id = ?, head_receipt = ?,
+			head_generation = ?, updated_at = ?
+			WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+			reconciled.ManifestID, reconciled.Receipt, reconciled.Generation, now,
+			string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
+			return fmt.Errorf("rawcheckpoint: resume generation: reconcile source head: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM raw_source_base_entries
+			WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+			string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
+			return fmt.Errorf("rawcheckpoint: resume generation: clear stale append base: %w", err)
+		}
+		result, err := conn.ExecContext(ctx, `UPDATE outbox_generations SET
+			state = 'queued', expected_parent_receipt = '', manifest_id = '',
+			retry_at = '', error_class = '', blocked = 0, updated_at = ?
+			WHERE capture_id = ? AND state = 'finalized'
+			AND error_class = ? AND blocked = 1`, now, captureID,
+			string(GenerationFailureParentReceiptConflict))
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: resume generation: %w", err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed != 1 {
+			return ErrGenerationFailureConflict
+		}
+		return nil
+	})
+}
+
+func validateReconciledSourceHead(head SourceHead) error {
+	if head.ManifestID == "" && head.Receipt == "" && head.Generation == 0 {
+		return nil
+	}
+	return rawsync.ValidateCommitResult(rawsync.CommitResult{
+		ManifestID: head.ManifestID,
+		Receipt:    head.Receipt,
+		Generation: head.Generation,
+	})
+}
+
+// AcknowledgeGeneration atomically fences a durable server result to the
+// finalized local generation, advances its source head, and releases local
+// object references while retaining the acknowledged append base metadata.
+func (s *Store) AcknowledgeGeneration(
+	ctx context.Context,
+	deviceID, captureID string,
+	commit rawsync.CommitResult,
+) (AcknowledgeResult, error) {
+	if captureID == "" {
+		return AcknowledgeResult{}, ErrAcknowledgeConflict
+	}
+	if err := rawsync.ValidateCommitResult(commit); err != nil {
+		return AcknowledgeResult{}, fmt.Errorf("rawcheckpoint: invalid commit result: %w", err)
+	}
+	var result AcknowledgeResult
+	err := s.withImmediateWrite(ctx, "acknowledge generation", func(conn *sql.Conn) error {
+		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
+			return err
+		}
+		var source SourceIdentity
+		var state, expectedParent, storedManifestID, storedReceipt string
+		var storedGeneration int64
+		var current SourceHead
+		err := conn.QueryRowContext(ctx, `SELECT generation.provider,
+			generation.configured_root_id, generation.source_key, generation.state,
+			generation.expected_parent_receipt, generation.manifest_id,
+			generation.ack_receipt, generation.ack_generation,
+			source.head_manifest_id, source.head_receipt, source.head_generation
+			FROM outbox_generations AS generation
+			JOIN raw_sources AS source
+				ON source.provider = generation.provider
+				AND source.configured_root_id = generation.configured_root_id
+				AND source.source_key = generation.source_key
+			WHERE generation.capture_id = ?`, captureID,
+		).Scan(&source.Provider, &source.ConfiguredRootID, &source.SourceKey,
+			&state, &expectedParent, &storedManifestID, &storedReceipt, &storedGeneration,
+			&current.ManifestID, &current.Receipt, &current.Generation)
+		if errors.Is(err, sql.ErrNoRows) {
+			var replay SourceHead
+			err = conn.QueryRowContext(ctx, `SELECT head_manifest_id, head_receipt,
+				head_generation FROM raw_sources WHERE head_capture_id = ?`, captureID,
+			).Scan(&replay.ManifestID, &replay.Receipt, &replay.Generation)
+			if err == nil && replay.ManifestID == commit.ManifestID &&
+				replay.Receipt == commit.Receipt && replay.Generation == commit.Generation {
+				result.Replayed = true
+				return nil
+			}
+			return ErrAcknowledgeConflict
+		}
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: acknowledge generation: read state: %w", err)
+		}
+		if state == "acknowledged" {
+			if storedManifestID == commit.ManifestID && storedReceipt == commit.Receipt &&
+				storedGeneration == commit.Generation {
+				result.Replayed = true
+				return nil
+			}
+			return ErrAcknowledgeConflict
+		}
+		if state != "finalized" || storedManifestID == "" ||
+			storedManifestID != commit.ManifestID || expectedParent != current.Receipt ||
+			commit.Generation != current.Generation+1 {
+			return ErrAcknowledgeConflict
+		}
+		entries, err := loadCapturedEntriesConn(ctx, conn, captureID)
+		if err != nil {
+			return err
+		}
+		if err := replaceAcknowledgedBaseConn(ctx, conn, source, entries); err != nil {
+			return err
+		}
+		if err := releaseGenerationObjectsConn(ctx, conn, captureID); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM outbox_objects
+			WHERE state = 'remote' AND ref_count = 0 AND NOT EXISTS (
+				SELECT 1 FROM raw_source_base_objects AS base
+				WHERE base.sha256 = outbox_objects.sha256
+				AND base.length = outbox_objects.length
+			)`); err != nil {
+			return fmt.Errorf("rawcheckpoint: acknowledge generation: prune remote objects: %w", err)
+		}
+		now := s.now().UTC().Format(time.RFC3339Nano)
+		if _, err := conn.ExecContext(ctx, `DELETE FROM outbox_entries WHERE capture_id = ?`,
+			captureID); err != nil {
+			return fmt.Errorf("rawcheckpoint: acknowledge generation: release entries: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE raw_sources SET
+			head_capture_id = ?, head_manifest_id = ?, head_receipt = ?,
+			head_generation = ?, updated_at = ?
+			WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+			captureID, commit.ManifestID, commit.Receipt, commit.Generation, now,
+			string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
+			return fmt.Errorf("rawcheckpoint: acknowledge generation: advance head: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE outbox_generations
+			SET predecessor_capture_id = NULL, updated_at = ?
+			WHERE predecessor_capture_id = ?`, now, captureID); err != nil {
+			return fmt.Errorf("rawcheckpoint: acknowledge generation: detach successor: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM outbox_generations WHERE capture_id = ?`, captureID); err != nil {
+			return fmt.Errorf("rawcheckpoint: acknowledge generation: compact generation: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE outbox_objects
+			SET state = 'garbage_pending'
+			WHERE ref_count = 0 AND state != 'remote'`); err != nil {
+			return fmt.Errorf("rawcheckpoint: acknowledge generation: mark garbage: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return result, err
+	}
+	result.Garbage, err = s.CollectGarbage(ctx)
+	return result, err
+}
+
+func requireConfiguredDeviceConn(ctx context.Context, conn *sql.Conn, deviceID string) error {
+	var configured string
+	err := conn.QueryRowContext(ctx,
+		`SELECT device_id FROM device_config WHERE id = 1`).Scan(&configured)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return ErrDeviceNotConfigured
+	case err != nil:
+		return fmt.Errorf("rawcheckpoint: read configured device: %w", err)
+	case configured != deviceID:
+		return ErrDeviceMismatch
+	default:
+		return nil
+	}
+}
+
+func loadManifestEntriesConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	captureID string,
+) ([]rawsync.Entry, error) {
+	captured, err := loadCapturedEntriesConn(ctx, conn, captureID)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]rawsync.Entry, 0, len(captured))
+	for _, entry := range captured {
+		entries = append(entries, rawsync.Entry{
+			Path: entry.Path, Type: "file", Length: entry.Length,
+			Objects: append([]rawsync.ObjectRef(nil), entry.Objects...),
+		})
+	}
+	return entries, nil
+}
+
+func loadCapturedEntriesConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	captureID string,
+) ([]CapturedEntry, error) {
+	rows, err := conn.QueryContext(ctx, `SELECT entry_ordinal, path, length,
+		mod_time_ns, file_identity, prefix_sha256, appendable
+		FROM outbox_entries WHERE capture_id = ? ORDER BY entry_ordinal`, captureID)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: load captured entries: %w", err)
+	}
+	defer rows.Close()
+	entries := make([]CapturedEntry, 0)
+	ordinals := make([]int, 0)
+	for rows.Next() {
+		var entry CapturedEntry
+		var ordinal int
+		if err := rows.Scan(&ordinal, &entry.Path, &entry.Length, &entry.ModTimeNS,
+			&entry.FileIdentity, &entry.PrefixSHA256, &entry.Appendable); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load captured entries: %w", err)
+		}
+		entries = append(entries, entry)
+		ordinals = append(ordinals, ordinal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: load captured entries: %w", err)
+	}
+	rows.Close()
+	for i, ordinal := range ordinals {
+		objectRows, err := conn.QueryContext(ctx, `SELECT sha256, length
+			FROM outbox_entry_objects WHERE capture_id = ? AND entry_ordinal = ?
+			ORDER BY object_ordinal`, captureID, ordinal)
+		if err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load captured objects: %w", err)
+		}
+		for objectRows.Next() {
+			var ref rawsync.ObjectRef
+			if err := objectRows.Scan(&ref.SHA256, &ref.Length); err != nil {
+				objectRows.Close()
+				return nil, fmt.Errorf("rawcheckpoint: load captured objects: %w", err)
+			}
+			entries[i].Objects = append(entries[i].Objects, ref)
+		}
+		if err := objectRows.Close(); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load captured objects: %w", err)
+		}
+	}
+	return entries, nil
+}
+
+func replaceAcknowledgedBaseConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	source SourceIdentity,
+	entries []CapturedEntry,
+) error {
+	if _, err := conn.ExecContext(ctx, `DELETE FROM raw_source_base_entries
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+		string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
+		return fmt.Errorf("rawcheckpoint: replace acknowledged base: %w", err)
+	}
+	for entryOrdinal, entry := range entries {
+		if _, err := conn.ExecContext(ctx, `INSERT INTO raw_source_base_entries
+			(provider, configured_root_id, source_key, entry_ordinal, path, length,
+			 mod_time_ns, file_identity, prefix_sha256, appendable)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, string(source.Provider),
+			source.ConfiguredRootID, source.SourceKey, entryOrdinal, entry.Path,
+			entry.Length, entry.ModTimeNS, entry.FileIdentity, entry.PrefixSHA256,
+			entry.Appendable); err != nil {
+			return fmt.Errorf("rawcheckpoint: replace acknowledged base entry: %w", err)
+		}
+		for objectOrdinal, ref := range entry.Objects {
+			if _, err := conn.ExecContext(ctx, `INSERT INTO raw_source_base_objects
+				(provider, configured_root_id, source_key, entry_ordinal,
+				 object_ordinal, sha256, length) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				string(source.Provider), source.ConfiguredRootID, source.SourceKey,
+				entryOrdinal, objectOrdinal, ref.SHA256, ref.Length); err != nil {
+				return fmt.Errorf("rawcheckpoint: replace acknowledged base object: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func releaseGenerationObjectsConn(ctx context.Context, conn *sql.Conn, captureID string) error {
+	rows, err := conn.QueryContext(ctx, `SELECT sha256, length, count(*)
+		FROM outbox_entry_objects WHERE capture_id = ? GROUP BY sha256, length`, captureID)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: release generation objects: %w", err)
+	}
+	type referenced struct {
+		ref   rawsync.ObjectRef
+		count int64
+	}
+	var refs []referenced
+	for rows.Next() {
+		var item referenced
+		if err := rows.Scan(&item.ref.SHA256, &item.ref.Length, &item.count); err != nil {
+			rows.Close()
+			return fmt.Errorf("rawcheckpoint: release generation objects: %w", err)
+		}
+		refs = append(refs, item)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("rawcheckpoint: release generation objects: %w", err)
+	}
+	for _, item := range refs {
+		result, err := conn.ExecContext(ctx, `UPDATE outbox_objects
+			SET ref_count = ref_count - ?
+			WHERE sha256 = ? AND length = ? AND ref_count >= ?`,
+			item.count, item.ref.SHA256, item.ref.Length, item.count)
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: release generation object: %w", err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil || changed != 1 {
+			return fmt.Errorf("rawcheckpoint: release generation object reference mismatch")
+		}
+	}
+	return nil
+}

--- a/internal/rawcheckpoint/ack.go
+++ b/internal/rawcheckpoint/ack.go
@@ -106,7 +106,7 @@ func (s *Store) FinalizeNextManifest(
 			AND (generation.predecessor_capture_id IS NULL
 				OR predecessor.state = 'acknowledged')
 			ORDER BY generation.captured_at, generation.capture_id LIMIT 1`,
-			s.now().UTC().Format(time.RFC3339Nano),
+			checkpointTimestamp(s.now()),
 		).Scan(&manifest.CaptureID, &provider, &manifest.ConfiguredRootID,
 			&manifest.SourceKey, &capturedAt, &kind, &state, &expectedParent)
 		if errors.Is(err, sql.ErrNoRows) {
@@ -126,7 +126,7 @@ func (s *Store) FinalizeNextManifest(
 			).Scan(&expectedParent); err != nil {
 				return fmt.Errorf("rawcheckpoint: finalize manifest: read source head: %w", err)
 			}
-			now := s.now().UTC().Format(time.RFC3339Nano)
+			now := checkpointTimestamp(s.now())
 			if _, err := conn.ExecContext(ctx, `UPDATE outbox_generations SET
 				state = 'finalized', expected_parent_receipt = ?, updated_at = ?
 				WHERE capture_id = ? AND state = 'queued'`,
@@ -162,7 +162,7 @@ func (s *Store) RecordGenerationFailure(
 		if retryAt.IsZero() {
 			return ErrGenerationFailureConflict
 		}
-		retryStamp = retryAt.UTC().Format(time.RFC3339Nano)
+		retryStamp = checkpointTimestamp(retryAt)
 	case GenerationFailureParentReceiptConflict:
 		if !retryAt.IsZero() {
 			return ErrGenerationFailureConflict
@@ -177,8 +177,9 @@ func (s *Store) RecordGenerationFailure(
 		}
 		result, err := conn.ExecContext(ctx, `UPDATE outbox_generations SET
 			retry_at = ?, error_class = ?, blocked = ?, updated_at = ?
-			WHERE capture_id = ? AND state = 'finalized'`, retryStamp, string(class),
-			blocked, s.now().UTC().Format(time.RFC3339Nano), captureID)
+			WHERE capture_id = ? AND state = 'finalized'
+				AND (blocked = 0 OR ? = 1)`, retryStamp, string(class),
+			blocked, checkpointTimestamp(s.now()), captureID, blocked)
 		if err != nil {
 			return fmt.Errorf("rawcheckpoint: record generation failure: %w", err)
 		}
@@ -460,6 +461,10 @@ func loadCapturedEntriesConn(
 				return nil, fmt.Errorf("rawcheckpoint: load captured objects: %w", err)
 			}
 			entries[i].Objects = append(entries[i].Objects, ref)
+		}
+		if err := objectRows.Err(); err != nil {
+			objectRows.Close()
+			return nil, fmt.Errorf("rawcheckpoint: load captured objects: %w", err)
 		}
 		if err := objectRows.Close(); err != nil {
 			return nil, fmt.Errorf("rawcheckpoint: load captured objects: %w", err)

--- a/internal/rawcheckpoint/ack_test.go
+++ b/internal/rawcheckpoint/ack_test.go
@@ -363,11 +363,43 @@ func TestTransientFailureIsNotFinalizableBeforeRetryTime(t *testing.T) {
 	_, ok, err = store.FinalizeNextManifest(t.Context(), "device-a")
 	require.NoError(t, err)
 	assert.False(t, ok)
-	store.now = func() time.Time { return retryAt.Add(time.Second) }
+	store.now = func() time.Time { return retryAt.Add(500 * time.Millisecond) }
 	retried, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, generation.CaptureID, retried.CaptureID)
+}
+
+func TestParentConflictCannotBeClearedByLateTransientFailure(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(10), Length: 1}
+	installOutboxTestObject(t, store, ref, []byte{1})
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", generation.CaptureID,
+		GenerationFailureParentReceiptConflict, time.Time{},
+	))
+
+	err = store.RecordGenerationFailure(
+		t.Context(), "device-a", generation.CaptureID,
+		GenerationFailureTransient, time.Now().Add(time.Minute),
+	)
+
+	require.ErrorIs(t, err, ErrGenerationFailureConflict)
+	var class string
+	var blocked int
+	require.NoError(t, store.db.QueryRow(`SELECT error_class, blocked
+		FROM outbox_generations WHERE capture_id = ?`, generation.CaptureID,
+	).Scan(&class, &blocked))
+	assert.Equal(t, string(GenerationFailureParentReceiptConflict), class)
+	assert.Equal(t, 1, blocked)
 }
 
 func TestResumeGenerationRequeuesAgainstReconciledServerHead(t *testing.T) {

--- a/internal/rawcheckpoint/ack_test.go
+++ b/internal/rawcheckpoint/ack_test.go
@@ -1,6 +1,7 @@
 package rawcheckpoint
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
@@ -170,6 +171,51 @@ func TestAcknowledgedCaptureBaseRetainsObjectReferencesAfterLocalGC(t *testing.T
 	assert.Equal(t, commit.Receipt, base.Head.Receipt)
 	assert.Equal(t, generation.Entries, base.Entries)
 	assert.NoFileExists(t, store.ObjectPath(ref))
+}
+
+func TestCaptureBaseSnapshotRemainsCoherentDuringAcknowledgement(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	commit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
+		Generation: 1, Created: true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generation.CaptureID, commit.ManifestID,
+	))
+
+	tx, err := store.db.BeginTx(t.Context(), &sql.TxOptions{ReadOnly: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	var captureID string
+	require.NoError(t, tx.QueryRowContext(t.Context(), `SELECT latest_capture_id
+		FROM raw_sources WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+		string(generation.Source.Provider), generation.Source.ConfiguredRootID,
+		generation.Source.SourceKey,
+	).Scan(&captureID))
+	require.Equal(t, generation.CaptureID, captureID)
+
+	_, err = store.AcknowledgeGeneration(
+		t.Context(), "device-a", generation.CaptureID, commit,
+	)
+	require.NoError(t, err)
+	base, ok, err := captureBaseSnapshot(t.Context(), tx, generation.Source)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generation.CaptureID, base.CaptureID)
+	assert.Empty(t, base.Head.Receipt)
+	assert.Zero(t, base.Head.Generation)
+	assert.Equal(t, generation.Entries, base.Entries)
 }
 
 func TestAcknowledgedGenerationCompactsToBoundedHeadReplayState(t *testing.T) {

--- a/internal/rawcheckpoint/ack_test.go
+++ b/internal/rawcheckpoint/ack_test.go
@@ -1,0 +1,439 @@
+package rawcheckpoint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestFinalizeAndAcknowledgeOfflineChainInOrder(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	refs := []rawsync.ObjectRef{
+		{SHA256: validCheckpointDigest(10), Length: 1},
+		{SHA256: validCheckpointDigest(11), Length: 1},
+		{SHA256: validCheckpointDigest(12), Length: 1},
+	}
+	predecessor := ""
+	var generations []CapturedGeneration
+	for i, ref := range refs {
+		installOutboxTestObject(t, store, ref, []byte{byte(i)})
+		reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+		require.NoError(t, err)
+		generation := testCapturedGeneration(i+1, root, predecessor, ref)
+		require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+		generations = append(generations, generation)
+		predecessor = generation.CaptureID
+	}
+
+	first, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generations[0].CaptureID, first.CaptureID)
+	assert.Empty(t, first.ExpectedParentReceipt)
+	assert.Equal(t, generations[0].Entries[0].Objects, first.Entries[0].Objects)
+
+	firstCommit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1),
+		Receipt:    validCheckpointDigest(2),
+		Generation: 1,
+		Created:    true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generations[0].CaptureID, firstCommit.ManifestID,
+	))
+	ack, err := store.AcknowledgeGeneration(
+		t.Context(), "device-a", generations[0].CaptureID, firstCommit,
+	)
+	require.NoError(t, err)
+	assert.False(t, ack.Replayed)
+	assert.Equal(t, 1, ack.Garbage.Objects)
+	assert.NoFileExists(t, store.ObjectPath(refs[0]))
+
+	second, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generations[1].CaptureID, second.CaptureID)
+	assert.Equal(t, firstCommit.Receipt, second.ExpectedParentReceipt)
+	secondCommit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(3),
+		Receipt:    validCheckpointDigest(4),
+		Generation: 2,
+		Created:    true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generations[1].CaptureID, secondCommit.ManifestID,
+	))
+	_, err = store.AcknowledgeGeneration(
+		t.Context(), "device-a", generations[1].CaptureID, secondCommit,
+	)
+	require.NoError(t, err)
+	third, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generations[2].CaptureID, third.CaptureID)
+	assert.Equal(t, secondCommit.Receipt, third.ExpectedParentReceipt)
+
+	replayed, err := store.AcknowledgeGeneration(
+		t.Context(), "device-a", generations[1].CaptureID, secondCommit,
+	)
+	require.NoError(t, err)
+	assert.True(t, replayed.Replayed)
+}
+
+func TestAcknowledgeGenerationRejectsStaleInputsWithoutAdvancing(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	valid := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
+		Generation: 1, Created: true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generation.CaptureID, valid.ManifestID,
+	))
+	require.ErrorIs(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generation.CaptureID, validCheckpointDigest(9),
+	), ErrAcknowledgeConflict)
+
+	for _, tc := range []struct {
+		name      string
+		deviceID  string
+		captureID string
+		commit    rawsync.CommitResult
+	}{
+		{name: "foreign device", deviceID: "device-b", captureID: generation.CaptureID, commit: valid},
+		{name: "foreign capture", deviceID: "device-a", captureID: "missing", commit: valid},
+		{name: "wrong generation", deviceID: "device-a", captureID: generation.CaptureID,
+			commit: rawsync.CommitResult{ManifestID: valid.ManifestID, Receipt: valid.Receipt, Generation: 2}},
+		{name: "wrong manifest", deviceID: "device-a", captureID: generation.CaptureID,
+			commit: rawsync.CommitResult{ManifestID: validCheckpointDigest(9), Receipt: valid.Receipt, Generation: 1}},
+		{name: "invalid receipt", deviceID: "device-a", captureID: generation.CaptureID,
+			commit: rawsync.CommitResult{ManifestID: valid.ManifestID, Receipt: "bad", Generation: 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := store.AcknowledgeGeneration(
+				t.Context(), tc.deviceID, tc.captureID, tc.commit,
+			)
+			require.Error(t, err)
+			head, ok, readErr := store.SourceHead(
+				t.Context(), root.Provider, root.ID, generation.Source.SourceKey,
+			)
+			require.NoError(t, readErr)
+			require.True(t, ok)
+			assert.Zero(t, head.Generation)
+		})
+	}
+}
+
+func TestAcknowledgedCaptureBaseRetainsObjectReferencesAfterLocalGC(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	commit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
+		Generation: 1, Created: true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generation.CaptureID, commit.ManifestID,
+	))
+	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", generation.CaptureID, commit)
+	require.NoError(t, err)
+
+	base, ok, err := store.CaptureBase(t.Context(), generation.Source)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generation.CaptureID, base.CaptureID)
+	assert.Equal(t, commit.Receipt, base.Head.Receipt)
+	assert.Equal(t, generation.Entries, base.Entries)
+	assert.NoFileExists(t, store.ObjectPath(ref))
+}
+
+func TestAcknowledgedGenerationCompactsToBoundedHeadReplayState(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	commit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
+		Generation: 1, Created: true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generation.CaptureID, commit.ManifestID,
+	))
+	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", generation.CaptureID, commit)
+	require.NoError(t, err)
+
+	usage, err := store.OutboxUsage(t.Context())
+
+	require.NoError(t, err)
+	assert.Zero(t, usage.UsedBytes)
+	var generations int
+	require.NoError(t, store.db.QueryRow(
+		`SELECT count(*) FROM outbox_generations`,
+	).Scan(&generations))
+	assert.Zero(t, generations)
+	base, ok, err := store.CaptureBase(t.Context(), generation.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generation.CaptureID, base.CaptureID)
+	replayed, err := store.AcknowledgeGeneration(
+		t.Context(), "device-a", generation.CaptureID, commit,
+	)
+	require.NoError(t, err)
+	assert.True(t, replayed.Replayed)
+}
+
+func TestAcknowledgementReplayFinishesPendingGarbageCollection(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	commit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
+		Generation: 1, Created: true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generation.CaptureID, commit.ManifestID,
+	))
+	objectPath := store.ObjectPath(ref)
+	require.NoError(t, os.Remove(objectPath))
+	require.NoError(t, os.MkdirAll(objectPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(objectPath, "busy"), []byte("x"), 0o600))
+
+	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", generation.CaptureID, commit)
+	require.Error(t, err)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Equal(t, ref.Length, usage.UsedBytes)
+	require.NoError(t, os.RemoveAll(objectPath))
+
+	replayed, err := store.AcknowledgeGeneration(
+		t.Context(), "device-a", generation.CaptureID, commit,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, replayed.Replayed)
+	assert.Equal(t, 1, replayed.Garbage.Objects)
+	usage, err = store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, usage.UsedBytes)
+}
+
+func TestParentConflictBlocksOnlyItsSourceChain(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	firstRef := rawsync.ObjectRef{SHA256: validCheckpointDigest(10), Length: 1}
+	secondRef := rawsync.ObjectRef{SHA256: validCheckpointDigest(11), Length: 1}
+	installOutboxTestObject(t, store, firstRef, []byte{1})
+	installOutboxTestObject(t, store, secondRef, []byte{2})
+	firstReservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	first := testCapturedGeneration(1, root, "", firstRef)
+	require.NoError(t, store.CommitCapture(t.Context(), firstReservation.ID, first))
+	secondReservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	second := testCapturedGeneration(2, root, "", secondRef)
+	second.Source.SourceKey = "source-2"
+	require.NoError(t, store.CommitCapture(t.Context(), secondReservation.ID, second))
+	manifest, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, first.CaptureID, manifest.CaptureID)
+
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", first.CaptureID,
+		GenerationFailureParentReceiptConflict, time.Time{},
+	))
+	next, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, second.CaptureID, next.CaptureID)
+	var errorClass string
+	var blocked int
+	require.NoError(t, store.db.QueryRow(`SELECT error_class, blocked
+		FROM outbox_generations WHERE capture_id = ?`, first.CaptureID,
+	).Scan(&errorClass, &blocked))
+	assert.Equal(t, string(GenerationFailureParentReceiptConflict), errorClass)
+	assert.Equal(t, 1, blocked)
+}
+
+func TestTransientFailureIsNotFinalizableBeforeRetryTime(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(10), Length: 1}
+	installOutboxTestObject(t, store, ref, []byte{1})
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	retryAt := time.Date(2026, 8, 25, 13, 0, 0, 0, time.UTC)
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", generation.CaptureID,
+		GenerationFailureTransient, retryAt,
+	))
+
+	_, ok, err = store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	store.now = func() time.Time { return retryAt.Add(time.Second) }
+	retried, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generation.CaptureID, retried.CaptureID)
+}
+
+func TestResumeGenerationRequeuesAgainstReconciledServerHead(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(10), Length: 1}
+	installOutboxTestObject(t, store, ref, []byte{1})
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generation.CaptureID, validCheckpointDigest(3),
+	))
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", generation.CaptureID,
+		GenerationFailureParentReceiptConflict, time.Time{},
+	))
+	reconciled := SourceHead{
+		ManifestID: validCheckpointDigest(4), Receipt: validCheckpointDigest(5),
+		Generation: 1,
+	}
+
+	require.NoError(t, store.ResumeGeneration(
+		t.Context(), "device-a", generation.CaptureID, reconciled,
+	))
+	retried, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generation.CaptureID, retried.CaptureID)
+	assert.Equal(t, reconciled.Receipt, retried.ExpectedParentReceipt)
+	var state, expectedParent, manifestID string
+	require.NoError(t, store.db.QueryRow(`SELECT state, expected_parent_receipt,
+		manifest_id FROM outbox_generations WHERE capture_id = ?`, generation.CaptureID,
+	).Scan(&state, &expectedParent, &manifestID))
+	assert.Equal(t, "finalized", state)
+	assert.Equal(t, reconciled.Receipt, expectedParent)
+	assert.Empty(t, manifestID)
+}
+
+func TestResumeGenerationRequeuesAgainstEmptyServerHead(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(10), Length: 1}
+	installOutboxTestObject(t, store, ref, []byte{1})
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", generation.CaptureID, validCheckpointDigest(3),
+	))
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", generation.CaptureID,
+		GenerationFailureParentReceiptConflict, time.Time{},
+	))
+
+	require.NoError(t, store.ResumeGeneration(
+		t.Context(), "device-a", generation.CaptureID, SourceHead{},
+	))
+	retried, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Empty(t, retried.ExpectedParentReceipt)
+	head, ok, err := store.SourceHead(
+		t.Context(), root.Provider, root.ID, generation.Source.SourceKey,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Empty(t, head.ManifestID)
+	assert.Empty(t, head.Receipt)
+	assert.Zero(t, head.Generation)
+}
+
+func TestRepeatedAcknowledgementsReuseBoundedOutboxCapacity(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1793)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	predecessor := ""
+	for sequence := 1; sequence <= 3; sequence++ {
+		ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(byte(9 + sequence)), Length: 1}
+		installOutboxTestObject(t, store, ref, []byte{byte(sequence)})
+		reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+		require.NoError(t, err)
+		generation := testCapturedGeneration(sequence, root, predecessor, ref)
+		require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+		manifest, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+		require.NoError(t, err)
+		require.True(t, ok)
+		commit := rawsync.CommitResult{
+			ManifestID: validCheckpointDigest(byte(sequence)),
+			Receipt:    validCheckpointDigest(byte(sequence + 3)),
+			Generation: int64(sequence),
+			Created:    true,
+		}
+		require.NoError(t, store.BindFinalizedManifestID(
+			t.Context(), "device-a", manifest.CaptureID, commit.ManifestID,
+		))
+		_, err = store.AcknowledgeGeneration(
+			t.Context(), "device-a", manifest.CaptureID, commit,
+		)
+		require.NoError(t, err)
+		usage, err := store.OutboxUsage(t.Context())
+		require.NoError(t, err)
+		assert.Zero(t, usage.UsedBytes)
+		predecessor = generation.CaptureID
+	}
+}

--- a/internal/rawcheckpoint/driver_cgo.go
+++ b/internal/rawcheckpoint/driver_cgo.go
@@ -32,6 +32,7 @@ const checkpointDriverName = "sqlite3"
 // directory name would silently open a different file.
 func checkpointDSN(path string, readOnly bool) string {
 	params := url.Values{}
+	params.Set("_foreign_keys", "on")
 	if readOnly {
 		params.Set("mode", "ro")
 		params.Set("_busy_timeout", "5000")

--- a/internal/rawcheckpoint/driver_modernc.go
+++ b/internal/rawcheckpoint/driver_modernc.go
@@ -29,6 +29,7 @@ const checkpointDriverName = "sqlite"
 func checkpointDSN(path string, readOnly bool) string {
 	params := url.Values{}
 	params.Add("_pragma", "busy_timeout(5000)")
+	params.Add("_pragma", "foreign_keys(1)")
 	if readOnly {
 		params.Set("mode", "ro")
 	} else {

--- a/internal/rawcheckpoint/lock.go
+++ b/internal/rawcheckpoint/lock.go
@@ -1,0 +1,90 @@
+package rawcheckpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/gofrs/flock"
+)
+
+var ErrStoreLocked = errors.New("rawcheckpoint: checkpoint or spool is already in use")
+
+func acquireStoreLocks(
+	ctx context.Context,
+	checkpointPath, spoolDir string,
+) ([]*flock.Flock, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	checkpointTarget, err := canonicalLockTarget(checkpointPath)
+	if err != nil {
+		return nil, err
+	}
+	spoolTarget, err := filepath.EvalSymlinks(spoolDir)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: resolve spool lock target: %s",
+			checkpointFilesystemError(err))
+	}
+	paths := []string{
+		checkpointTarget + ".rawcheckpoint.lock",
+		filepath.Join(spoolTarget, ".rawcheckpoint.lock"),
+	}
+	slices.Sort(paths)
+	paths = slices.Compact(paths)
+	locks := make([]*flock.Flock, 0, len(paths))
+	for _, path := range paths {
+		lock := flock.New(path)
+		locked, err := lock.TryLock()
+		if err != nil {
+			return nil, errors.Join(
+				fmt.Errorf("rawcheckpoint: acquire process lock: %s",
+					checkpointFilesystemError(err)),
+				releaseStoreLocks(locks),
+			)
+		}
+		if !locked {
+			return nil, errors.Join(ErrStoreLocked, releaseStoreLocks(locks))
+		}
+		locks = append(locks, lock)
+		if err := os.Chmod(path, 0o600); err != nil {
+			return nil, errors.Join(
+				fmt.Errorf("rawcheckpoint: secure process lock: %s",
+					checkpointFilesystemError(err)),
+				releaseStoreLocks(locks),
+			)
+		}
+	}
+	return locks, nil
+}
+
+func canonicalLockTarget(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("rawcheckpoint: resolve checkpoint lock target: %s",
+			checkpointFilesystemError(err))
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		return resolved, nil
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(absolute))
+	if err != nil {
+		return "", fmt.Errorf("rawcheckpoint: resolve checkpoint lock parent: %s",
+			checkpointFilesystemError(err))
+	}
+	return filepath.Join(parent, filepath.Base(absolute)), nil
+}
+
+func releaseStoreLocks(locks []*flock.Flock) error {
+	var errs []error
+	for _, lock := range slices.Backward(locks) {
+		if err := lock.Unlock(); err != nil {
+			errs = append(errs, fmt.Errorf("rawcheckpoint: release process lock: %s",
+				checkpointFilesystemError(err)))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -741,9 +741,12 @@ func (s *Store) loadGenerationEntries(ctx context.Context, captureID string) ([]
 	return entries, nil
 }
 
-// CollectGarbage removes unreferenced spool objects and only then releases
-// their charged rows. Missing files are an idempotent success.
+// CollectGarbage waits for active object publication, removes unreferenced
+// spool objects, and only then releases their charged rows. Missing files are
+// an idempotent success.
 func (s *Store) CollectGarbage(ctx context.Context) (GarbageCollectionReport, error) {
+	s.publicationMu.Lock()
+	defer s.publicationMu.Unlock()
 	s.objectMu.Lock()
 	defer s.objectMu.Unlock()
 	var report GarbageCollectionReport

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -362,17 +362,20 @@ func (s *Store) CompleteUnchangedCapture(
 		return fmt.Errorf("rawcheckpoint: invalid unchanged capture")
 	}
 	return s.withImmediateWrite(ctx, "complete unchanged capture", func(conn *sql.Conn) error {
-		var reservationRoot string
+		var reservationProvider, reservationRoot, reservationSourceKey string
 		err := conn.QueryRowContext(ctx,
-			`SELECT configured_root_id FROM outbox_reservations WHERE id = ?`, reservationID,
-		).Scan(&reservationRoot)
+			`SELECT provider, configured_root_id, source_key
+			FROM outbox_reservations WHERE id = ?`, reservationID,
+		).Scan(&reservationProvider, &reservationRoot, &reservationSourceKey)
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrReservationMissing
 		}
 		if err != nil {
 			return fmt.Errorf("rawcheckpoint: complete unchanged capture: read reservation: %w", err)
 		}
-		if reservationRoot != source.ConfiguredRootID {
+		if !reservationMatchesSource(
+			reservationProvider, reservationRoot, reservationSourceKey, source,
+		) {
 			return ErrCaptureConflict
 		}
 		if _, err := conn.ExecContext(ctx,
@@ -482,22 +485,21 @@ func (s *Store) CommitCapture(
 		return err
 	}
 	return s.withImmediateWrite(ctx, "commit capture", func(conn *sql.Conn) error {
-		var reservationRoot, reservationProvider string
+		var reservationProvider, reservationRoot, reservationSourceKey string
 		var reservedBytes int64
-		err := conn.QueryRowContext(ctx, `SELECT reservation.configured_root_id,
-			reservation.reserved_bytes, root.provider
-			FROM outbox_reservations AS reservation
-			JOIN configured_roots AS root ON root.id = reservation.configured_root_id
-			WHERE reservation.id = ?`, reservationID,
-		).Scan(&reservationRoot, &reservedBytes, &reservationProvider)
+		err := conn.QueryRowContext(ctx, `SELECT provider, configured_root_id,
+			source_key, reserved_bytes
+			FROM outbox_reservations WHERE id = ?`, reservationID,
+		).Scan(&reservationProvider, &reservationRoot, &reservationSourceKey, &reservedBytes)
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrReservationMissing
 		}
 		if err != nil {
 			return fmt.Errorf("rawcheckpoint: commit capture: read reservation: %w", err)
 		}
-		if reservationRoot != validated.Source.ConfiguredRootID ||
-			reservationProvider != string(validated.Source.Provider) {
+		if !reservationMatchesSource(
+			reservationProvider, reservationRoot, reservationSourceKey, validated.Source,
+		) {
 			return ErrCaptureConflict
 		}
 
@@ -577,6 +579,17 @@ func (s *Store) CommitCapture(
 		}
 		return nil
 	})
+}
+
+func reservationMatchesSource(
+	provider string,
+	configuredRootID string,
+	sourceKey string,
+	source SourceIdentity,
+) bool {
+	return provider == string(source.Provider) &&
+		configuredRootID == source.ConfiguredRootID &&
+		(sourceKey == "" || sourceKey == source.SourceKey)
 }
 
 // CaptureBase returns the newest queued generation for append planning.

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -1,0 +1,1128 @@
+package rawcheckpoint
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawpath"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+const (
+	defaultMaxOutboxBytes        int64 = 1 << 30
+	generationMetadataBytes      int64 = 1024
+	entryMetadataBytes           int64 = 512
+	objectReferenceMetadataBytes int64 = 256
+)
+
+var (
+	ErrOutboxFull          = errors.New("rawcheckpoint: outbox capacity exhausted")
+	ErrCaptureConflict     = errors.New("rawcheckpoint: capture predecessor conflict")
+	ErrReservationMissing  = errors.New("rawcheckpoint: capture reservation not found")
+	ErrReservationTooSmall = errors.New("rawcheckpoint: capture reservation is too small")
+)
+
+// CoverageStatus is the capture completeness state for one configured root.
+type CoverageStatus string
+
+const (
+	CoverageComplete CoverageStatus = "complete"
+	CoverageDegraded CoverageStatus = "degraded"
+)
+
+// CoverageState records a persistent gap interval for one configured root.
+type CoverageState struct {
+	Provider         parser.AgentType
+	ConfiguredRootID string
+	State            CoverageStatus
+	Reason           string
+	DegradedAt       *time.Time
+	RecoveredAt      *time.Time
+	UpdatedAt        time.Time
+}
+
+// Reservation fences outbox capacity while a capturer writes temporary files.
+type Reservation struct {
+	ID               string
+	ConfiguredRootID string
+	ReservedBytes    int64
+	CreatedAt        time.Time
+}
+
+// SourceIdentity is one device-local raw source chain.
+type SourceIdentity struct {
+	Provider         parser.AgentType
+	ConfiguredRootID string
+	SourceKey        string
+}
+
+// CapturedEntry is one complete logical file in a captured generation.
+type CapturedEntry struct {
+	Path         string
+	Length       int64
+	ModTimeNS    int64
+	FileIdentity string
+	PrefixSHA256 string
+	Appendable   bool
+	Objects      []rawsync.ObjectRef
+}
+
+// CapturedGeneration is an immutable local source generation.
+type CapturedGeneration struct {
+	CaptureID            string
+	Source               SourceIdentity
+	PredecessorCaptureID string
+	CapturedAt           time.Time
+	Kind                 rawsync.ManifestKind
+	Entries              []CapturedEntry
+}
+
+// CaptureBaseState is the newest acknowledged or locally queued generation.
+type CaptureBaseState struct {
+	CaptureID string
+	Head      SourceHead
+	Entries   []CapturedEntry
+}
+
+// OutboxUsage reports charged and reserved bytes against the configured bound.
+type OutboxUsage struct {
+	UsedBytes     int64
+	ReservedBytes int64
+	LimitBytes    int64
+}
+
+// GarbageCollectionReport describes normal-operation spool reclamation.
+type GarbageCollectionReport struct {
+	Objects int
+	Bytes   int64
+}
+
+// Options configures durable outbox storage. Zero values select bounded local
+// defaults so the existing Open API remains compatible.
+type Options struct {
+	SpoolDir       string
+	MaxOutboxBytes int64
+	Now            func() time.Time
+}
+
+// ConfiguredRoot is the stable local mapping used in remote source identity.
+type ConfiguredRoot struct {
+	ID        string
+	Provider  parser.AgentType
+	LocalPath string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// OpenWithOptions opens the checkpoint and configures its durable object spool.
+func OpenWithOptions(ctx context.Context, path string, options Options) (*Store, error) {
+	if options.SpoolDir == "" {
+		options.SpoolDir = path + ".objects"
+	}
+	if options.MaxOutboxBytes == 0 {
+		options.MaxOutboxBytes = defaultMaxOutboxBytes
+	}
+	if options.MaxOutboxBytes < 0 {
+		return nil, fmt.Errorf("rawcheckpoint: maximum outbox bytes must be positive")
+	}
+	if options.Now == nil {
+		options.Now = time.Now
+	}
+	spoolDir, err := filepath.Abs(options.SpoolDir)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: resolve spool directory: %s",
+			checkpointFilesystemError(err))
+	}
+	if err := os.MkdirAll(filepath.Join(spoolDir, "objects", "sha256"), 0o700); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: create object spool: %s",
+			checkpointFilesystemError(err))
+	}
+	if err := os.MkdirAll(filepath.Join(spoolDir, ".tmp"), 0o700); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: create temporary spool: %s",
+			checkpointFilesystemError(err))
+	}
+	processLocks, err := acquireStoreLocks(ctx, path, spoolDir)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := openCheckpointDB(path)
+	if err != nil {
+		_ = releaseStoreLocks(processLocks)
+		return nil, err
+	}
+	store := &Store{
+		db:             db,
+		spoolDir:       spoolDir,
+		maxOutboxBytes: options.MaxOutboxBytes,
+		now:            options.Now,
+		processLocks:   processLocks,
+	}
+	if err := store.init(ctx); err != nil {
+		db.Close()
+		_ = releaseStoreLocks(processLocks)
+		return nil, err
+	}
+	if _, err := store.Recover(ctx); err != nil {
+		db.Close()
+		_ = releaseStoreLocks(processLocks)
+		return nil, err
+	}
+	return store, nil
+}
+
+// ResolveConfiguredRoot returns the persistent opaque identity for a provider
+// root after canonicalizing symlinks.
+func (s *Store) ResolveConfiguredRoot(
+	ctx context.Context,
+	provider parser.AgentType,
+	localRoot string,
+) (ConfiguredRoot, error) {
+	canonical, err := canonicalConfiguredRoot(localRoot)
+	if err != nil {
+		return ConfiguredRoot{}, err
+	}
+	var resolved ConfiguredRoot
+	err = s.withImmediateWrite(ctx, "resolve configured root", func(conn *sql.Conn) error {
+		var createdAt, updatedAt string
+		err := conn.QueryRowContext(ctx, `SELECT id, created_at, updated_at
+			FROM configured_roots WHERE provider = ? AND local_root = ?`,
+			string(provider), canonical,
+		).Scan(&resolved.ID, &createdAt, &updatedAt)
+		if err == nil {
+			resolved.Provider = provider
+			resolved.LocalPath = canonical
+			resolved.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+			resolved.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+			return nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("rawcheckpoint: resolve configured root: %w", err)
+		}
+		id, err := randomCheckpointID()
+		if err != nil {
+			return err
+		}
+		now := s.now().UTC()
+		stamp := now.Format(time.RFC3339Nano)
+		if _, err := conn.ExecContext(ctx, `INSERT INTO configured_roots
+			(id, provider, local_root, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?)`, id, string(provider), canonical, stamp, stamp); err != nil {
+			return fmt.Errorf("rawcheckpoint: resolve configured root: %w", err)
+		}
+		resolved = ConfiguredRoot{
+			ID: id, Provider: provider, LocalPath: canonical,
+			CreatedAt: now, UpdatedAt: now,
+		}
+		return nil
+	})
+	return resolved, err
+}
+
+// ObjectPath returns the content-addressed local spool path for an object.
+func (s *Store) ObjectPath(ref rawsync.ObjectRef) string {
+	prefix := "invalid"
+	if len(ref.SHA256) >= 2 {
+		prefix = ref.SHA256[:2]
+	}
+	return filepath.Join(s.spoolDir, "objects", "sha256", prefix, ref.SHA256)
+}
+
+// CaptureTempDir is the private same-filesystem staging directory used before
+// content-addressed object installation.
+func (s *Store) CaptureTempDir() string {
+	return filepath.Join(s.spoolDir, ".tmp")
+}
+
+// CaptureMetadataCharge returns the conservative durable metadata charge for
+// one generation.
+func CaptureMetadataCharge(entries, objectReferences int) int64 {
+	if entries < 0 || objectReferences < 0 {
+		return 0
+	}
+	return generationMetadataBytes + int64(entries)*entryMetadataBytes +
+		int64(objectReferences)*objectReferenceMetadataBytes
+}
+
+// ReserveCapture atomically reserves root-scoped capacity. A root-scoped
+// failure remains degraded until a later full-root reconciliation.
+func (s *Store) ReserveCapture(
+	ctx context.Context,
+	configuredRootID string,
+	bytes int64,
+) (Reservation, error) {
+	return s.reserveCapture(ctx, SourceIdentity{ConfiguredRootID: configuredRootID}, bytes)
+}
+
+// ReserveSourceCapture atomically reserves the caller's worst-case object and
+// metadata bytes and attributes capacity failure to one logical source.
+func (s *Store) ReserveSourceCapture(
+	ctx context.Context,
+	source SourceIdentity,
+	bytes int64,
+) (Reservation, error) {
+	if source.Provider == "" || source.SourceKey == "" {
+		return Reservation{}, fmt.Errorf("rawcheckpoint: invalid source capture reservation")
+	}
+	return s.reserveCapture(ctx, source, bytes)
+}
+
+func (s *Store) reserveCapture(
+	ctx context.Context,
+	source SourceIdentity,
+	bytes int64,
+) (Reservation, error) {
+	if source.ConfiguredRootID == "" || bytes < 0 {
+		return Reservation{}, fmt.Errorf("rawcheckpoint: invalid capture reservation")
+	}
+	var reservation Reservation
+	full := false
+	err := s.withImmediateWrite(ctx, "reserve capture", func(conn *sql.Conn) error {
+		var provider string
+		if err := conn.QueryRowContext(ctx,
+			`SELECT provider FROM configured_roots WHERE id = ?`, source.ConfiguredRootID,
+		).Scan(&provider); err != nil {
+			return fmt.Errorf("rawcheckpoint: reserve capture: read configured root: %w", err)
+		}
+		if source.Provider != "" && string(source.Provider) != provider {
+			return fmt.Errorf("rawcheckpoint: reserve capture: provider mismatch")
+		}
+		source.Provider = parser.AgentType(provider)
+		usage, err := outboxUsageConn(ctx, conn)
+		if err != nil {
+			return err
+		}
+		if bytes > s.maxOutboxBytes-usage.UsedBytes-usage.ReservedBytes {
+			now := s.now().UTC()
+			if err := setSourceCoverageDegradedConn(
+				ctx, conn, source, "outbox_full", now,
+			); err != nil {
+				return err
+			}
+			full = true
+			return nil
+		}
+		id, err := randomCheckpointID()
+		if err != nil {
+			return err
+		}
+		now := s.now().UTC()
+		if _, err := conn.ExecContext(ctx, `INSERT INTO outbox_reservations
+			(id, configured_root_id, reserved_bytes, created_at)
+			VALUES (?, ?, ?, ?)`, id, source.ConfiguredRootID, bytes,
+			now.Format(time.RFC3339Nano)); err != nil {
+			return fmt.Errorf("rawcheckpoint: reserve capture: %w", err)
+		}
+		reservation = Reservation{
+			ID: id, ConfiguredRootID: source.ConfiguredRootID,
+			ReservedBytes: bytes, CreatedAt: now,
+		}
+		return nil
+	})
+	if err == nil && full {
+		return Reservation{}, ErrOutboxFull
+	}
+	return reservation, err
+}
+
+// ReleaseReservation idempotently releases unused reserved capacity.
+func (s *Store) ReleaseReservation(ctx context.Context, reservationID string) error {
+	if reservationID == "" {
+		return nil
+	}
+	return s.withImmediateWrite(ctx, "release capture reservation", func(conn *sql.Conn) error {
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM outbox_reservations WHERE id = ?`, reservationID); err != nil {
+			return fmt.Errorf("rawcheckpoint: release capture reservation: %w", err)
+		}
+		return nil
+	})
+}
+
+// OutboxUsage returns exact charged object and metadata bytes plus active
+// worst-case reservations.
+func (s *Store) OutboxUsage(ctx context.Context) (OutboxUsage, error) {
+	var usage OutboxUsage
+	err := s.db.QueryRowContext(ctx, `SELECT
+		COALESCE((SELECT sum(length) FROM outbox_objects WHERE state != 'remote'), 0) +
+		COALESCE((SELECT sum(metadata_bytes) FROM outbox_generations), 0),
+		COALESCE((SELECT sum(reserved_bytes) FROM outbox_reservations), 0)`,
+	).Scan(&usage.UsedBytes, &usage.ReservedBytes)
+	if err != nil {
+		return OutboxUsage{}, fmt.Errorf("rawcheckpoint: read outbox usage: %w", err)
+	}
+	usage.LimitBytes = s.maxOutboxBytes
+	return usage, nil
+}
+
+func outboxUsageConn(ctx context.Context, conn *sql.Conn) (OutboxUsage, error) {
+	var usage OutboxUsage
+	err := conn.QueryRowContext(ctx, `SELECT
+		COALESCE((SELECT sum(length) FROM outbox_objects WHERE state != 'remote'), 0) +
+		COALESCE((SELECT sum(metadata_bytes) FROM outbox_generations), 0),
+		COALESCE((SELECT sum(reserved_bytes) FROM outbox_reservations), 0)`,
+	).Scan(&usage.UsedBytes, &usage.ReservedBytes)
+	if err != nil {
+		return OutboxUsage{}, fmt.Errorf("rawcheckpoint: read outbox usage: %w", err)
+	}
+	return usage, nil
+}
+
+// Coverage returns the current completeness state for one configured root.
+func (s *Store) Coverage(
+	ctx context.Context,
+	provider parser.AgentType,
+	configuredRootID string,
+) (CoverageState, bool, error) {
+	var coverage CoverageState
+	var state, degradedAt, recoveredAt, updatedAt sql.NullString
+	err := s.db.QueryRowContext(ctx, `SELECT state, reason, degraded_at,
+		recovered_at, updated_at FROM raw_coverage
+		WHERE provider = ? AND configured_root_id = ?`,
+		string(provider), configuredRootID,
+	).Scan(&state, &coverage.Reason, &degradedAt, &recoveredAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CoverageState{}, false, nil
+	}
+	if err != nil {
+		return CoverageState{}, false, fmt.Errorf("rawcheckpoint: read coverage: %w", err)
+	}
+	coverage.Provider = provider
+	coverage.ConfiguredRootID = configuredRootID
+	coverage.State = CoverageStatus(state.String)
+	coverage.DegradedAt = parseOptionalTime(degradedAt)
+	coverage.RecoveredAt = parseOptionalTime(recoveredAt)
+	coverage.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt.String)
+	return coverage, true, nil
+}
+
+// CommitCapture atomically publishes one completely installed local generation.
+func (s *Store) CommitCapture(
+	ctx context.Context,
+	reservationID string,
+	generation CapturedGeneration,
+) error {
+	s.objectMu.Lock()
+	defer s.objectMu.Unlock()
+	validated, metadataBytes, uniqueObjects, err := validateCapturedGeneration(s, generation)
+	if err != nil {
+		return err
+	}
+	return s.withImmediateWrite(ctx, "commit capture", func(conn *sql.Conn) error {
+		var reservationRoot, reservationProvider string
+		var reservedBytes int64
+		err := conn.QueryRowContext(ctx, `SELECT reservation.configured_root_id,
+			reservation.reserved_bytes, root.provider
+			FROM outbox_reservations AS reservation
+			JOIN configured_roots AS root ON root.id = reservation.configured_root_id
+			WHERE reservation.id = ?`, reservationID,
+		).Scan(&reservationRoot, &reservedBytes, &reservationProvider)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrReservationMissing
+		}
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: commit capture: read reservation: %w", err)
+		}
+		if reservationRoot != validated.Source.ConfiguredRootID ||
+			reservationProvider != string(validated.Source.Provider) {
+			return ErrCaptureConflict
+		}
+
+		latest, found, err := latestCaptureIDConn(ctx, conn, validated.Source)
+		if err != nil {
+			return err
+		}
+		if latest != validated.PredecessorCaptureID {
+			return ErrCaptureConflict
+		}
+		newObjectBytes, err := missingObjectBytesConn(ctx, conn, uniqueObjects)
+		if err != nil {
+			return err
+		}
+		if metadataBytes > reservedBytes-newObjectBytes {
+			return ErrReservationTooSmall
+		}
+
+		now := s.now().UTC().Format(time.RFC3339Nano)
+		var predecessor any
+		if validated.PredecessorCaptureID != "" {
+			var headCaptureID string
+			if found {
+				if err := conn.QueryRowContext(ctx, `SELECT head_capture_id FROM raw_sources
+					WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+					string(validated.Source.Provider), validated.Source.ConfiguredRootID,
+					validated.Source.SourceKey).Scan(&headCaptureID); err != nil {
+					return fmt.Errorf("rawcheckpoint: commit capture: read source head: %w", err)
+				}
+			}
+			if validated.PredecessorCaptureID != headCaptureID {
+				predecessor = validated.PredecessorCaptureID
+			}
+		}
+		if _, err := conn.ExecContext(ctx, `INSERT INTO outbox_generations
+			(capture_id, provider, configured_root_id, source_key,
+			 predecessor_capture_id, captured_at, kind, state, metadata_bytes,
+			 created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?)`,
+			validated.CaptureID, string(validated.Source.Provider),
+			validated.Source.ConfiguredRootID, validated.Source.SourceKey,
+			predecessor, validated.CapturedAt.Format(time.RFC3339Nano),
+			string(validated.Kind), metadataBytes, now, now); err != nil {
+			return fmt.Errorf("rawcheckpoint: commit capture: insert generation: %w", err)
+		}
+		if err := insertCapturedObjectsConn(ctx, conn, s, uniqueObjects, now); err != nil {
+			return err
+		}
+		if err := insertCapturedEntriesConn(ctx, conn, validated); err != nil {
+			return err
+		}
+		if found {
+			if _, err := conn.ExecContext(ctx, `UPDATE raw_sources SET
+				latest_capture_id = ?, updated_at = ?
+				WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+				validated.CaptureID, now, string(validated.Source.Provider),
+				validated.Source.ConfiguredRootID, validated.Source.SourceKey); err != nil {
+				return fmt.Errorf("rawcheckpoint: commit capture: update source: %w", err)
+			}
+		} else {
+			if _, err := conn.ExecContext(ctx, `INSERT INTO raw_sources
+				(provider, configured_root_id, source_key, updated_at, latest_capture_id)
+				VALUES (?, ?, ?, ?, ?)`, string(validated.Source.Provider),
+				validated.Source.ConfiguredRootID, validated.Source.SourceKey,
+				now, validated.CaptureID); err != nil {
+				return fmt.Errorf("rawcheckpoint: commit capture: insert source: %w", err)
+			}
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM outbox_reservations WHERE id = ?`, reservationID); err != nil {
+			return fmt.Errorf("rawcheckpoint: commit capture: release reservation: %w", err)
+		}
+		if err := clearSourceCoverageFailureConn(
+			ctx, conn, validated.Source, s.now().UTC(),
+		); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// CaptureBase returns the newest queued generation for append planning.
+func (s *Store) CaptureBase(
+	ctx context.Context,
+	source SourceIdentity,
+) (CaptureBaseState, bool, error) {
+	var captureID string
+	var headCaptureID string
+	var head SourceHead
+	var updatedAt string
+	err := s.db.QueryRowContext(ctx, `SELECT latest_capture_id, head_capture_id, head_manifest_id,
+		head_receipt, head_generation, updated_at FROM raw_sources
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+		string(source.Provider), source.ConfiguredRootID, source.SourceKey,
+	).Scan(&captureID, &headCaptureID, &head.ManifestID, &head.Receipt,
+		&head.Generation, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) || captureID == "" {
+		return CaptureBaseState{}, false, nil
+	}
+	if err != nil {
+		return CaptureBaseState{}, false, fmt.Errorf("rawcheckpoint: read capture base: %w", err)
+	}
+	head.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+	if captureID != headCaptureID {
+		generation, err := s.loadGeneration(ctx, captureID)
+		if err != nil {
+			return CaptureBaseState{}, false, err
+		}
+		if len(generation.Entries) != 0 {
+			return CaptureBaseState{
+				CaptureID: captureID, Head: head, Entries: generation.Entries,
+			}, true, nil
+		}
+	}
+	entries, err := s.loadAcknowledgedBase(ctx, source)
+	if err != nil {
+		return CaptureBaseState{}, false, err
+	}
+	if len(entries) == 0 {
+		return CaptureBaseState{}, false, nil
+	}
+	return CaptureBaseState{CaptureID: captureID, Head: head, Entries: entries}, true, nil
+}
+
+func (s *Store) loadAcknowledgedBase(
+	ctx context.Context,
+	source SourceIdentity,
+) ([]CapturedEntry, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT entry_ordinal, path, length,
+		mod_time_ns, file_identity, prefix_sha256, appendable
+		FROM raw_source_base_entries
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?
+		ORDER BY entry_ordinal`, string(source.Provider), source.ConfiguredRootID, source.SourceKey)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: load acknowledged base: %w", err)
+	}
+	defer rows.Close()
+	entries := make([]CapturedEntry, 0)
+	ordinals := make([]int, 0)
+	for rows.Next() {
+		var entry CapturedEntry
+		var ordinal int
+		if err := rows.Scan(&ordinal, &entry.Path, &entry.Length, &entry.ModTimeNS,
+			&entry.FileIdentity, &entry.PrefixSHA256, &entry.Appendable); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load acknowledged base: %w", err)
+		}
+		entries = append(entries, entry)
+		ordinals = append(ordinals, ordinal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: load acknowledged base: %w", err)
+	}
+	rows.Close()
+	for i, ordinal := range ordinals {
+		objectRows, err := s.db.QueryContext(ctx, `SELECT sha256, length
+			FROM raw_source_base_objects
+			WHERE provider = ? AND configured_root_id = ? AND source_key = ?
+			AND entry_ordinal = ? ORDER BY object_ordinal`, string(source.Provider),
+			source.ConfiguredRootID, source.SourceKey, ordinal)
+		if err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load acknowledged base objects: %w", err)
+		}
+		for objectRows.Next() {
+			var ref rawsync.ObjectRef
+			if err := objectRows.Scan(&ref.SHA256, &ref.Length); err != nil {
+				objectRows.Close()
+				return nil, fmt.Errorf("rawcheckpoint: load acknowledged base objects: %w", err)
+			}
+			entries[i].Objects = append(entries[i].Objects, ref)
+		}
+		if err := objectRows.Close(); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load acknowledged base objects: %w", err)
+		}
+	}
+	return entries, nil
+}
+
+// NextGeneration returns the oldest queued generation whose predecessor is
+// absent or acknowledged.
+func (s *Store) NextGeneration(
+	ctx context.Context,
+) (CapturedGeneration, bool, error) {
+	var captureID string
+	err := s.db.QueryRowContext(ctx, `SELECT generation.capture_id
+		FROM outbox_generations AS generation
+		LEFT JOIN outbox_generations AS predecessor
+			ON predecessor.capture_id = generation.predecessor_capture_id
+		WHERE generation.state = 'queued'
+		AND generation.blocked = 0
+		AND (generation.retry_at = '' OR generation.retry_at <= ?)
+		AND (generation.predecessor_capture_id IS NULL OR predecessor.state = 'acknowledged')
+		ORDER BY generation.captured_at, generation.capture_id LIMIT 1`,
+		s.now().UTC().Format(time.RFC3339Nano),
+	).Scan(&captureID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CapturedGeneration{}, false, nil
+	}
+	if err != nil {
+		return CapturedGeneration{}, false, fmt.Errorf("rawcheckpoint: read next generation: %w", err)
+	}
+	generation, err := s.loadGeneration(ctx, captureID)
+	return generation, err == nil, err
+}
+
+func (s *Store) loadGeneration(ctx context.Context, captureID string) (CapturedGeneration, error) {
+	var generation CapturedGeneration
+	var provider, capturedAt, kind string
+	var predecessor sql.NullString
+	err := s.db.QueryRowContext(ctx, `SELECT provider, configured_root_id,
+		source_key, predecessor_capture_id, captured_at, kind
+		FROM outbox_generations WHERE capture_id = ?`, captureID,
+	).Scan(&provider, &generation.Source.ConfiguredRootID,
+		&generation.Source.SourceKey, &predecessor, &capturedAt, &kind)
+	if err != nil {
+		return CapturedGeneration{}, fmt.Errorf("rawcheckpoint: load generation: %w", err)
+	}
+	generation.CaptureID = captureID
+	generation.Source.Provider = parser.AgentType(provider)
+	generation.PredecessorCaptureID = predecessor.String
+	generation.CapturedAt, _ = time.Parse(time.RFC3339Nano, capturedAt)
+	generation.Kind = rawsync.ManifestKind(kind)
+	entries, err := s.loadGenerationEntries(ctx, captureID)
+	if err != nil {
+		return CapturedGeneration{}, err
+	}
+	generation.Entries = entries
+	return generation, nil
+}
+
+func (s *Store) loadGenerationEntries(ctx context.Context, captureID string) ([]CapturedEntry, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT entry_ordinal, path, length,
+		mod_time_ns, file_identity, prefix_sha256, appendable
+		FROM outbox_entries WHERE capture_id = ? ORDER BY entry_ordinal`, captureID)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: load generation entries: %w", err)
+	}
+	defer rows.Close()
+	entries := make([]CapturedEntry, 0)
+	ordinals := make([]int, 0)
+	for rows.Next() {
+		var entry CapturedEntry
+		var ordinal int
+		if err := rows.Scan(&ordinal, &entry.Path, &entry.Length, &entry.ModTimeNS,
+			&entry.FileIdentity, &entry.PrefixSHA256, &entry.Appendable); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load generation entries: %w", err)
+		}
+		entries = append(entries, entry)
+		ordinals = append(ordinals, ordinal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: load generation entries: %w", err)
+	}
+	for i, ordinal := range ordinals {
+		objectRows, err := s.db.QueryContext(ctx, `SELECT sha256, length
+			FROM outbox_entry_objects WHERE capture_id = ? AND entry_ordinal = ?
+			ORDER BY object_ordinal`, captureID, ordinal)
+		if err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load generation objects: %w", err)
+		}
+		for objectRows.Next() {
+			var ref rawsync.ObjectRef
+			if err := objectRows.Scan(&ref.SHA256, &ref.Length); err != nil {
+				objectRows.Close()
+				return nil, fmt.Errorf("rawcheckpoint: load generation objects: %w", err)
+			}
+			entries[i].Objects = append(entries[i].Objects, ref)
+		}
+		if err := objectRows.Close(); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: load generation objects: %w", err)
+		}
+	}
+	return entries, nil
+}
+
+// CollectGarbage removes unreferenced spool objects and only then releases
+// their charged rows. Missing files are an idempotent success.
+func (s *Store) CollectGarbage(ctx context.Context) (GarbageCollectionReport, error) {
+	s.objectMu.Lock()
+	defer s.objectMu.Unlock()
+	var report GarbageCollectionReport
+	err := s.withImmediateWrite(ctx, "collect object garbage", func(conn *sql.Conn) error {
+		rows, err := conn.QueryContext(ctx, `SELECT sha256, length FROM outbox_objects
+			WHERE state = 'garbage_pending' AND ref_count = 0 ORDER BY sha256, length`)
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: list garbage: %w", err)
+		}
+		var refs []rawsync.ObjectRef
+		for rows.Next() {
+			var ref rawsync.ObjectRef
+			if err := rows.Scan(&ref.SHA256, &ref.Length); err != nil {
+				rows.Close()
+				return fmt.Errorf("rawcheckpoint: list garbage: %w", err)
+			}
+			refs = append(refs, ref)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("rawcheckpoint: list garbage: %w", err)
+		}
+		for _, ref := range refs {
+			if err := os.Remove(s.ObjectPath(ref)); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("rawcheckpoint: remove garbage object: %s",
+					checkpointFilesystemError(err))
+			}
+			var retained int
+			err := conn.QueryRowContext(ctx, `SELECT EXISTS(
+				SELECT 1 FROM raw_source_base_objects
+				WHERE sha256 = ? AND length = ?
+			)`, ref.SHA256, ref.Length).Scan(&retained)
+			if err != nil {
+				return fmt.Errorf("rawcheckpoint: inspect acknowledged object base: %w", err)
+			}
+			var result sql.Result
+			if retained != 0 {
+				result, err = conn.ExecContext(ctx, `UPDATE outbox_objects SET state = 'remote'
+					WHERE sha256 = ? AND length = ? AND state = 'garbage_pending'
+					AND ref_count = 0`, ref.SHA256, ref.Length)
+			} else {
+				result, err = conn.ExecContext(ctx, `DELETE FROM outbox_objects
+					WHERE sha256 = ? AND length = ? AND state = 'garbage_pending'
+					AND ref_count = 0`, ref.SHA256, ref.Length)
+			}
+			if err != nil {
+				return fmt.Errorf("rawcheckpoint: finish object garbage collection: %w", err)
+			}
+			rows, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("rawcheckpoint: finish object garbage collection: %w", err)
+			}
+			if rows == 1 {
+				report.Objects++
+				report.Bytes += ref.Length
+			}
+		}
+		return nil
+	})
+	return report, err
+}
+
+// DiscardUnreferencedObjects removes objects installed by a failed capture if
+// no committed generation adopted them. It is safe to call repeatedly.
+func (s *Store) DiscardUnreferencedObjects(
+	ctx context.Context,
+	refs []rawsync.ObjectRef,
+) error {
+	s.objectMu.Lock()
+	defer s.objectMu.Unlock()
+	return s.withImmediateWrite(ctx, "discard unreferenced capture objects", func(conn *sql.Conn) error {
+		for _, ref := range refs {
+			var state string
+			err := conn.QueryRowContext(ctx, `SELECT state FROM outbox_objects
+				WHERE sha256 = ? AND length = ?`, ref.SHA256, ref.Length).Scan(&state)
+			switch {
+			case err == nil && state != "remote":
+				continue
+			case !errors.Is(err, sql.ErrNoRows):
+				if err != nil {
+					return fmt.Errorf("rawcheckpoint: inspect failed capture object: %w", err)
+				}
+			}
+			if err := os.Remove(s.ObjectPath(ref)); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("rawcheckpoint: discard failed capture object: %s",
+					checkpointFilesystemError(err))
+			}
+		}
+		return nil
+	})
+}
+
+func validateCapturedGeneration(
+	store *Store,
+	generation CapturedGeneration,
+) (CapturedGeneration, int64, map[string]rawsync.ObjectRef, error) {
+	if generation.CaptureID == "" || generation.Source.Provider == "" ||
+		generation.Source.ConfiguredRootID == "" || generation.Source.SourceKey == "" ||
+		generation.CapturedAt.IsZero() || generation.Kind != rawsync.ManifestSnapshot ||
+		len(generation.Entries) == 0 {
+		return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured generation")
+	}
+	validated := generation
+	validated.CapturedAt = generation.CapturedAt.UTC()
+	validated.Entries = make([]CapturedEntry, len(generation.Entries))
+	uniqueObjects := make(map[string]rawsync.ObjectRef)
+	byDigest := make(map[string]rawsync.ObjectRef)
+	metadataBytes := generationMetadataBytes + int64(len(generation.Entries))*entryMetadataBytes
+	seenPaths := make(map[string]struct{}, len(generation.Entries))
+	for i, entry := range generation.Entries {
+		if err := rawpath.Validate(entry.Path, rawpath.DefaultMaxBytes); err != nil {
+			return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured entry path: %w", err)
+		}
+		if _, ok := seenPaths[entry.Path]; ok || entry.Length < 0 || len(entry.Objects) == 0 {
+			return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured entry")
+		}
+		seenPaths[entry.Path] = struct{}{}
+		if _, err := rawsync.NewObjectRef(entry.PrefixSHA256, 0); err != nil {
+			return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured prefix digest")
+		}
+		validated.Entries[i] = entry
+		validated.Entries[i].Objects = append([]rawsync.ObjectRef(nil), entry.Objects...)
+		var total int64
+		for _, ref := range entry.Objects {
+			canonical, err := rawsync.NewObjectRef(ref.SHA256, ref.Length)
+			if err != nil || canonical != ref || ref.Length > entry.Length-total {
+				return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured object reference")
+			}
+			total += ref.Length
+			key := ref.SHA256 + fmt.Sprintf(":%d", ref.Length)
+			if prior, ok := byDigest[ref.SHA256]; ok && prior.Length != ref.Length {
+				return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: conflicting object lengths")
+			}
+			byDigest[ref.SHA256] = ref
+			uniqueObjects[key] = ref
+			metadataBytes += objectReferenceMetadataBytes
+		}
+		if total != entry.Length {
+			return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: captured object lengths do not match entry")
+		}
+	}
+	for _, ref := range uniqueObjects {
+		var state string
+		dbErr := store.db.QueryRow(`SELECT state FROM outbox_objects
+			WHERE sha256 = ? AND length = ?`, ref.SHA256, ref.Length).Scan(&state)
+		info, err := os.Stat(store.ObjectPath(ref))
+		if dbErr == nil && state == "remote" {
+			switch {
+			case errors.Is(err, os.ErrNotExist):
+				continue
+			case err != nil || !info.Mode().IsRegular() || info.Size() != ref.Length:
+				return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: acknowledged object has conflicting local state")
+			default:
+				if err := os.Remove(store.ObjectPath(ref)); err != nil {
+					return CapturedGeneration{}, 0, nil, fmt.Errorf(
+						"rawcheckpoint: discard redundant acknowledged object: %s",
+						checkpointFilesystemError(err),
+					)
+				}
+				continue
+			}
+		}
+		if err == nil && info.Mode().IsRegular() && info.Size() == ref.Length {
+			continue
+		}
+		if err == nil || !errors.Is(err, os.ErrNotExist) {
+			return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: captured object has conflicting local state")
+		}
+		return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: captured object is not durably installed")
+	}
+	return validated, metadataBytes, uniqueObjects, nil
+}
+
+func latestCaptureIDConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	source SourceIdentity,
+) (string, bool, error) {
+	var latest string
+	err := conn.QueryRowContext(ctx, `SELECT latest_capture_id FROM raw_sources
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+		string(source.Provider), source.ConfiguredRootID, source.SourceKey,
+	).Scan(&latest)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("rawcheckpoint: read latest capture: %w", err)
+	}
+	return latest, true, nil
+}
+
+func missingObjectBytesConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	objects map[string]rawsync.ObjectRef,
+) (int64, error) {
+	var bytes int64
+	for _, ref := range objects {
+		var length int64
+		err := conn.QueryRowContext(ctx,
+			`SELECT length FROM outbox_objects WHERE sha256 = ?`, ref.SHA256).Scan(&length)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			bytes += ref.Length
+		case err != nil:
+			return 0, fmt.Errorf("rawcheckpoint: inspect captured object: %w", err)
+		case length != ref.Length:
+			return 0, fmt.Errorf("rawcheckpoint: object digest has conflicting length")
+		}
+	}
+	return bytes, nil
+}
+
+func insertCapturedObjectsConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	store *Store,
+	objects map[string]rawsync.ObjectRef,
+	now string,
+) error {
+	for _, ref := range objects {
+		spoolName, err := filepath.Rel(store.spoolDir, store.ObjectPath(ref))
+		if err != nil || strings.HasPrefix(spoolName, "..") {
+			return fmt.Errorf("rawcheckpoint: derive object spool name")
+		}
+		state := "live"
+		if info, statErr := os.Stat(store.ObjectPath(ref)); statErr != nil ||
+			!info.Mode().IsRegular() || info.Size() != ref.Length {
+			state = "remote"
+		}
+		if _, err := conn.ExecContext(ctx, `INSERT INTO outbox_objects
+			(sha256, length, spool_name, ref_count, state, created_at)
+			VALUES (?, ?, ?, 0, ?, ?)
+			ON CONFLICT(sha256, length) DO UPDATE SET
+				spool_name = excluded.spool_name,
+				state = CASE WHEN excluded.state = 'live' THEN 'live'
+					ELSE outbox_objects.state END`,
+			ref.SHA256, ref.Length, filepath.ToSlash(spoolName), state, now); err != nil {
+			return fmt.Errorf("rawcheckpoint: insert captured object: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertCapturedEntriesConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	generation CapturedGeneration,
+) error {
+	for entryOrdinal, entry := range generation.Entries {
+		if _, err := conn.ExecContext(ctx, `INSERT INTO outbox_entries
+			(capture_id, entry_ordinal, path, length, mod_time_ns,
+			 file_identity, prefix_sha256, appendable)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, generation.CaptureID, entryOrdinal,
+			entry.Path, entry.Length, entry.ModTimeNS, entry.FileIdentity,
+			entry.PrefixSHA256, entry.Appendable); err != nil {
+			return fmt.Errorf("rawcheckpoint: insert captured entry: %w", err)
+		}
+		for objectOrdinal, ref := range entry.Objects {
+			if _, err := conn.ExecContext(ctx, `INSERT INTO outbox_entry_objects
+				(capture_id, entry_ordinal, object_ordinal, sha256, length)
+				VALUES (?, ?, ?, ?, ?)`, generation.CaptureID, entryOrdinal,
+				objectOrdinal, ref.SHA256, ref.Length); err != nil {
+				return fmt.Errorf("rawcheckpoint: insert captured entry object: %w", err)
+			}
+			if _, err := conn.ExecContext(ctx, `UPDATE outbox_objects
+				SET ref_count = ref_count + 1
+				WHERE sha256 = ? AND length = ?`, ref.SHA256, ref.Length); err != nil {
+				return fmt.Errorf("rawcheckpoint: reference captured object: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func setCoverageConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	provider parser.AgentType,
+	configuredRootID string,
+	state CoverageStatus,
+	reason string,
+	now time.Time,
+) error {
+	stamp := now.UTC().Format(time.RFC3339Nano)
+	if state == CoverageDegraded {
+		_, err := conn.ExecContext(ctx, `INSERT INTO raw_coverage
+			(provider, configured_root_id, state, reason, degraded_at, updated_at)
+			VALUES (?, ?, 'degraded', ?, ?, ?)
+			ON CONFLICT(provider, configured_root_id) DO UPDATE SET
+			state = 'degraded', reason = excluded.reason,
+			degraded_at = COALESCE(raw_coverage.degraded_at, excluded.degraded_at),
+			recovered_at = NULL, updated_at = excluded.updated_at`,
+			string(provider), configuredRootID, reason, stamp, stamp)
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: mark coverage degraded: %w", err)
+		}
+		return nil
+	}
+	_, err := conn.ExecContext(ctx, `INSERT INTO raw_coverage
+		(provider, configured_root_id, state, reason, recovered_at, updated_at)
+		VALUES (?, ?, 'complete', '', ?, ?)
+		ON CONFLICT(provider, configured_root_id) DO UPDATE SET
+		state = 'complete', reason = '',
+		recovered_at = CASE WHEN raw_coverage.state = 'degraded'
+			THEN excluded.recovered_at ELSE raw_coverage.recovered_at END,
+		updated_at = excluded.updated_at`, string(provider), configuredRootID, stamp, stamp)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: mark coverage complete: %w", err)
+	}
+	return nil
+}
+
+func setSourceCoverageDegradedConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	source SourceIdentity,
+	reason string,
+	now time.Time,
+) error {
+	stamp := now.UTC().Format(time.RFC3339Nano)
+	_, err := conn.ExecContext(ctx, `INSERT INTO raw_coverage_failures
+		(provider, configured_root_id, source_key, reason, degraded_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(provider, configured_root_id, source_key) DO UPDATE SET
+			reason = excluded.reason, updated_at = excluded.updated_at`,
+		string(source.Provider), source.ConfiguredRootID, source.SourceKey,
+		reason, stamp, stamp)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: record source coverage failure: %w", err)
+	}
+	return setCoverageConn(ctx, conn, source.Provider, source.ConfiguredRootID,
+		CoverageDegraded, reason, now)
+}
+
+func clearSourceCoverageFailureConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	source SourceIdentity,
+	now time.Time,
+) error {
+	if _, err := conn.ExecContext(ctx, `DELETE FROM raw_coverage_failures
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+		string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
+		return fmt.Errorf("rawcheckpoint: clear source coverage failure: %w", err)
+	}
+	var reason string
+	err := conn.QueryRowContext(ctx, `SELECT reason FROM raw_coverage_failures
+		WHERE provider = ? AND configured_root_id = ?
+		ORDER BY degraded_at, source_key LIMIT 1`,
+		string(source.Provider), source.ConfiguredRootID).Scan(&reason)
+	if errors.Is(err, sql.ErrNoRows) {
+		return setCoverageConn(ctx, conn, source.Provider, source.ConfiguredRootID,
+			CoverageComplete, "", now)
+	}
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: inspect remaining coverage failures: %w", err)
+	}
+	return setCoverageConn(ctx, conn, source.Provider, source.ConfiguredRootID,
+		CoverageDegraded, reason, now)
+}
+
+func parseOptionalTime(value sql.NullString) *time.Time {
+	if !value.Valid || value.String == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value.String)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func canonicalConfiguredRoot(root string) (string, error) {
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("rawcheckpoint: resolve configured root: %s",
+			checkpointFilesystemError(err))
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("rawcheckpoint: resolve configured root: %s",
+			checkpointFilesystemError(err))
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return "", fmt.Errorf("rawcheckpoint: stat configured root: %s",
+			checkpointFilesystemError(err))
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("rawcheckpoint: configured root is not a directory")
+	}
+	return filepath.Clean(canonical), nil
+}
+
+func checkpointFilesystemError(err error) string {
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return "not found"
+	case errors.Is(err, os.ErrPermission):
+		return "permission denied"
+	case errors.Is(err, os.ErrInvalid):
+		return "invalid path"
+	default:
+		return "filesystem error"
+	}
+}
+
+func randomCheckpointID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("rawcheckpoint: generate identity: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -254,7 +254,8 @@ func CaptureMetadataCharge(entries, objectReferences int) int64 {
 }
 
 // ReserveCapture atomically reserves root-scoped capacity. A root-scoped
-// failure remains degraded until a later full-root reconciliation.
+// failure remains degraded until CompleteRootReconciliation records a
+// successful full-root pass.
 func (s *Store) ReserveCapture(
 	ctx context.Context,
 	configuredRootID string,
@@ -379,6 +380,35 @@ func (s *Store) CompleteUnchangedCapture(
 			return fmt.Errorf("rawcheckpoint: complete unchanged capture: release reservation: %w", err)
 		}
 		return clearSourceCoverageFailureConn(ctx, conn, source, s.now().UTC())
+	})
+}
+
+// CompleteRootReconciliation clears a root-wide coverage failure after a full
+// source reconciliation.
+func (s *Store) CompleteRootReconciliation(
+	ctx context.Context,
+	configuredRootID string,
+) error {
+	if configuredRootID == "" {
+		return fmt.Errorf("rawcheckpoint: invalid root reconciliation")
+	}
+	return s.withImmediateWrite(ctx, "complete root reconciliation", func(conn *sql.Conn) error {
+		var provider string
+		if err := conn.QueryRowContext(ctx,
+			`SELECT provider FROM configured_roots WHERE id = ?`, configuredRootID,
+		).Scan(&provider); err != nil {
+			return fmt.Errorf(
+				"rawcheckpoint: complete root reconciliation: read configured root: %w", err,
+			)
+		}
+		if _, err := conn.ExecContext(ctx, `DELETE FROM raw_coverage_failures
+			WHERE provider = ? AND configured_root_id = ? AND source_key = ''`,
+			provider, configuredRootID); err != nil {
+			return fmt.Errorf("rawcheckpoint: clear root coverage failure: %w", err)
+		}
+		return refreshCoverageFromFailuresConn(
+			ctx, conn, parser.AgentType(provider), configuredRootID, s.now().UTC(),
+		)
 	})
 }
 
@@ -1132,19 +1162,31 @@ func clearSourceCoverageFailureConn(
 		string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
 		return fmt.Errorf("rawcheckpoint: clear source coverage failure: %w", err)
 	}
+	return refreshCoverageFromFailuresConn(
+		ctx, conn, source.Provider, source.ConfiguredRootID, now,
+	)
+}
+
+func refreshCoverageFromFailuresConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	provider parser.AgentType,
+	configuredRootID string,
+	now time.Time,
+) error {
 	var reason string
 	err := conn.QueryRowContext(ctx, `SELECT reason FROM raw_coverage_failures
 		WHERE provider = ? AND configured_root_id = ?
 		ORDER BY degraded_at, source_key LIMIT 1`,
-		string(source.Provider), source.ConfiguredRootID).Scan(&reason)
+		string(provider), configuredRootID).Scan(&reason)
 	if errors.Is(err, sql.ErrNoRows) {
-		return setCoverageConn(ctx, conn, source.Provider, source.ConfiguredRootID,
+		return setCoverageConn(ctx, conn, provider, configuredRootID,
 			CoverageComplete, "", now)
 	}
 	if err != nil {
 		return fmt.Errorf("rawcheckpoint: inspect remaining coverage failures: %w", err)
 	}
-	return setCoverageConn(ctx, conn, source.Provider, source.ConfiguredRootID,
+	return setCoverageConn(ctx, conn, provider, configuredRootID,
 		CoverageDegraded, reason, now)
 }
 

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -711,6 +711,10 @@ func loadAcknowledgedBase(
 			}
 			entries[i].Objects = append(entries[i].Objects, ref)
 		}
+		if err := objectRows.Err(); err != nil {
+			objectRows.Close()
+			return nil, fmt.Errorf("rawcheckpoint: load acknowledged base objects: %w", err)
+		}
 		if err := objectRows.Close(); err != nil {
 			return nil, fmt.Errorf("rawcheckpoint: load acknowledged base objects: %w", err)
 		}
@@ -733,7 +737,7 @@ func (s *Store) NextGeneration(
 		AND (generation.retry_at = '' OR generation.retry_at <= ?)
 		AND (generation.predecessor_capture_id IS NULL OR predecessor.state = 'acknowledged')
 		ORDER BY generation.captured_at, generation.capture_id LIMIT 1`,
-		s.now().UTC().Format(time.RFC3339Nano),
+		checkpointTimestamp(s.now()),
 	).Scan(&captureID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return CapturedGeneration{}, false, nil
@@ -816,6 +820,10 @@ func loadGenerationEntries(
 			}
 			entries[i].Objects = append(entries[i].Objects, ref)
 		}
+		if err := objectRows.Err(); err != nil {
+			objectRows.Close()
+			return nil, fmt.Errorf("rawcheckpoint: load generation objects: %w", err)
+		}
 		if err := objectRows.Close(); err != nil {
 			return nil, fmt.Errorf("rawcheckpoint: load generation objects: %w", err)
 		}
@@ -846,6 +854,10 @@ func (s *Store) CollectGarbage(ctx context.Context) (GarbageCollectionReport, er
 				return fmt.Errorf("rawcheckpoint: list garbage: %w", err)
 			}
 			refs = append(refs, ref)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("rawcheckpoint: list garbage: %w", err)
 		}
 		if err := rows.Close(); err != nil {
 			return fmt.Errorf("rawcheckpoint: list garbage: %w", err)

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -553,11 +553,40 @@ func (s *Store) CaptureBase(
 	ctx context.Context,
 	source SourceIdentity,
 ) (CaptureBaseState, bool, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return CaptureBaseState{}, false, fmt.Errorf(
+			"rawcheckpoint: begin capture base snapshot: %w", err,
+		)
+	}
+	defer func() { _ = tx.Rollback() }()
+	base, found, err := captureBaseSnapshot(ctx, tx, source)
+	if err != nil {
+		return CaptureBaseState{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return CaptureBaseState{}, false, fmt.Errorf(
+			"rawcheckpoint: commit capture base snapshot: %w", err,
+		)
+	}
+	return base, found, nil
+}
+
+type checkpointQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func captureBaseSnapshot(
+	ctx context.Context,
+	queryer checkpointQueryer,
+	source SourceIdentity,
+) (CaptureBaseState, bool, error) {
 	var captureID string
 	var headCaptureID string
 	var head SourceHead
 	var updatedAt string
-	err := s.db.QueryRowContext(ctx, `SELECT latest_capture_id, head_capture_id, head_manifest_id,
+	err := queryer.QueryRowContext(ctx, `SELECT latest_capture_id, head_capture_id, head_manifest_id,
 		head_receipt, head_generation, updated_at FROM raw_sources
 		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
 		string(source.Provider), source.ConfiguredRootID, source.SourceKey,
@@ -571,7 +600,7 @@ func (s *Store) CaptureBase(
 	}
 	head.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
 	if captureID != headCaptureID {
-		generation, err := s.loadGeneration(ctx, captureID)
+		generation, err := loadGeneration(ctx, queryer, captureID)
 		if err != nil {
 			return CaptureBaseState{}, false, err
 		}
@@ -581,7 +610,7 @@ func (s *Store) CaptureBase(
 			}, true, nil
 		}
 	}
-	entries, err := s.loadAcknowledgedBase(ctx, source)
+	entries, err := loadAcknowledgedBase(ctx, queryer, source)
 	if err != nil {
 		return CaptureBaseState{}, false, err
 	}
@@ -591,11 +620,12 @@ func (s *Store) CaptureBase(
 	return CaptureBaseState{CaptureID: captureID, Head: head, Entries: entries}, true, nil
 }
 
-func (s *Store) loadAcknowledgedBase(
+func loadAcknowledgedBase(
 	ctx context.Context,
+	queryer checkpointQueryer,
 	source SourceIdentity,
 ) ([]CapturedEntry, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT entry_ordinal, path, length,
+	rows, err := queryer.QueryContext(ctx, `SELECT entry_ordinal, path, length,
 		mod_time_ns, file_identity, prefix_sha256, appendable
 		FROM raw_source_base_entries
 		WHERE provider = ? AND configured_root_id = ? AND source_key = ?
@@ -621,7 +651,7 @@ func (s *Store) loadAcknowledgedBase(
 	}
 	rows.Close()
 	for i, ordinal := range ordinals {
-		objectRows, err := s.db.QueryContext(ctx, `SELECT sha256, length
+		objectRows, err := queryer.QueryContext(ctx, `SELECT sha256, length
 			FROM raw_source_base_objects
 			WHERE provider = ? AND configured_root_id = ? AND source_key = ?
 			AND entry_ordinal = ? ORDER BY object_ordinal`, string(source.Provider),
@@ -667,15 +697,19 @@ func (s *Store) NextGeneration(
 	if err != nil {
 		return CapturedGeneration{}, false, fmt.Errorf("rawcheckpoint: read next generation: %w", err)
 	}
-	generation, err := s.loadGeneration(ctx, captureID)
+	generation, err := loadGeneration(ctx, s.db, captureID)
 	return generation, err == nil, err
 }
 
-func (s *Store) loadGeneration(ctx context.Context, captureID string) (CapturedGeneration, error) {
+func loadGeneration(
+	ctx context.Context,
+	queryer checkpointQueryer,
+	captureID string,
+) (CapturedGeneration, error) {
 	var generation CapturedGeneration
 	var provider, capturedAt, kind string
 	var predecessor sql.NullString
-	err := s.db.QueryRowContext(ctx, `SELECT provider, configured_root_id,
+	err := queryer.QueryRowContext(ctx, `SELECT provider, configured_root_id,
 		source_key, predecessor_capture_id, captured_at, kind
 		FROM outbox_generations WHERE capture_id = ?`, captureID,
 	).Scan(&provider, &generation.Source.ConfiguredRootID,
@@ -688,7 +722,7 @@ func (s *Store) loadGeneration(ctx context.Context, captureID string) (CapturedG
 	generation.PredecessorCaptureID = predecessor.String
 	generation.CapturedAt, _ = time.Parse(time.RFC3339Nano, capturedAt)
 	generation.Kind = rawsync.ManifestKind(kind)
-	entries, err := s.loadGenerationEntries(ctx, captureID)
+	entries, err := loadGenerationEntries(ctx, queryer, captureID)
 	if err != nil {
 		return CapturedGeneration{}, err
 	}
@@ -696,8 +730,12 @@ func (s *Store) loadGeneration(ctx context.Context, captureID string) (CapturedG
 	return generation, nil
 }
 
-func (s *Store) loadGenerationEntries(ctx context.Context, captureID string) ([]CapturedEntry, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT entry_ordinal, path, length,
+func loadGenerationEntries(
+	ctx context.Context,
+	queryer checkpointQueryer,
+	captureID string,
+) ([]CapturedEntry, error) {
+	rows, err := queryer.QueryContext(ctx, `SELECT entry_ordinal, path, length,
 		mod_time_ns, file_identity, prefix_sha256, appendable
 		FROM outbox_entries WHERE capture_id = ? ORDER BY entry_ordinal`, captureID)
 	if err != nil {
@@ -720,7 +758,7 @@ func (s *Store) loadGenerationEntries(ctx context.Context, captureID string) ([]
 		return nil, fmt.Errorf("rawcheckpoint: load generation entries: %w", err)
 	}
 	for i, ordinal := range ordinals {
-		objectRows, err := s.db.QueryContext(ctx, `SELECT sha256, length
+		objectRows, err := queryer.QueryContext(ctx, `SELECT sha256, length
 			FROM outbox_entry_objects WHERE capture_id = ? AND entry_ordinal = ?
 			ORDER BY object_ordinal`, captureID, ordinal)
 		if err != nil {

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -348,6 +348,39 @@ func (s *Store) ReleaseReservation(ctx context.Context, reservationID string) er
 	})
 }
 
+// CompleteUnchangedCapture atomically releases a verified unchanged capture's
+// reservation and clears only that source's coverage failure.
+func (s *Store) CompleteUnchangedCapture(
+	ctx context.Context,
+	reservationID string,
+	source SourceIdentity,
+) error {
+	if reservationID == "" || source.Provider == "" ||
+		source.ConfiguredRootID == "" || source.SourceKey == "" {
+		return fmt.Errorf("rawcheckpoint: invalid unchanged capture")
+	}
+	return s.withImmediateWrite(ctx, "complete unchanged capture", func(conn *sql.Conn) error {
+		var reservationRoot string
+		err := conn.QueryRowContext(ctx,
+			`SELECT configured_root_id FROM outbox_reservations WHERE id = ?`, reservationID,
+		).Scan(&reservationRoot)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrReservationMissing
+		}
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: complete unchanged capture: read reservation: %w", err)
+		}
+		if reservationRoot != source.ConfiguredRootID {
+			return ErrCaptureConflict
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM outbox_reservations WHERE id = ?`, reservationID); err != nil {
+			return fmt.Errorf("rawcheckpoint: complete unchanged capture: release reservation: %w", err)
+		}
+		return clearSourceCoverageFailureConn(ctx, conn, source, s.now().UTC())
+	})
+}
+
 // OutboxUsage returns exact charged object and metadata bytes plus active
 // worst-case reservations.
 func (s *Store) OutboxUsage(ctx context.Context) (OutboxUsage, error) {

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -317,8 +317,9 @@ func (s *Store) reserveCapture(
 		}
 		now := s.now().UTC()
 		if _, err := conn.ExecContext(ctx, `INSERT INTO outbox_reservations
-			(id, configured_root_id, reserved_bytes, created_at)
-			VALUES (?, ?, ?, ?)`, id, source.ConfiguredRootID, bytes,
+			(id, provider, configured_root_id, source_key, reserved_bytes, created_at)
+			VALUES (?, ?, ?, ?, ?, ?)`, id, string(source.Provider),
+			source.ConfiguredRootID, source.SourceKey, bytes,
 			now.Format(time.RFC3339Nano)); err != nil {
 			return fmt.Errorf("rawcheckpoint: reserve capture: %w", err)
 		}

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -114,6 +114,9 @@ type Options struct {
 	Now            func() time.Time
 }
 
+var ErrSpoolMismatch = errors.New(
+	"rawcheckpoint: checkpoint is bound to a different object spool")
+
 // ConfiguredRoot is the stable local mapping used in remote source identity.
 type ConfiguredRoot struct {
 	ID        string
@@ -150,6 +153,11 @@ func OpenWithOptions(ctx context.Context, path string, options Options) (*Store,
 		return nil, fmt.Errorf("rawcheckpoint: create temporary spool: %s",
 			checkpointFilesystemError(err))
 	}
+	spoolDir, err = filepath.EvalSymlinks(spoolDir)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: resolve object spool: %s",
+			checkpointFilesystemError(err))
+	}
 	processLocks, err := acquireStoreLocks(ctx, path, spoolDir)
 	if err != nil {
 		return nil, err
@@ -172,12 +180,40 @@ func OpenWithOptions(ctx context.Context, path string, options Options) (*Store,
 		_ = releaseStoreLocks(processLocks)
 		return nil, err
 	}
+	if err := store.bindSpool(ctx); err != nil {
+		db.Close()
+		_ = releaseStoreLocks(processLocks)
+		return nil, err
+	}
 	if _, err := store.Recover(ctx); err != nil {
 		db.Close()
 		_ = releaseStoreLocks(processLocks)
 		return nil, err
 	}
 	return store, nil
+}
+
+func (s *Store) bindSpool(ctx context.Context) error {
+	return s.withImmediateWrite(ctx, "bind object spool", func(conn *sql.Conn) error {
+		var bound string
+		err := conn.QueryRowContext(ctx,
+			`SELECT spool_path FROM outbox_config WHERE id = 1`).Scan(&bound)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			if _, err := conn.ExecContext(ctx,
+				`INSERT INTO outbox_config (id, spool_path) VALUES (1, ?)`,
+				s.spoolDir); err != nil {
+				return fmt.Errorf("rawcheckpoint: bind object spool: %w", err)
+			}
+			return nil
+		case err != nil:
+			return fmt.Errorf("rawcheckpoint: read object spool binding: %w", err)
+		case bound != s.spoolDir:
+			return ErrSpoolMismatch
+		default:
+			return nil
+		}
+	})
 }
 
 // ResolveConfiguredRoot returns the persistent opaque identity for a provider

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -701,6 +701,48 @@ func TestSuccessfulCaptureClearsItsOwnSourceCoverageFailure(t *testing.T) {
 	assert.NotNil(t, coverage.RecoveredAt)
 }
 
+func TestCompleteUnchangedCaptureRejectsReservationForAnotherSource(t *testing.T) {
+	store, root := openOutboxTestStore(t, 2000)
+	sourceA := SourceIdentity{
+		Provider: root.Provider, ConfiguredRootID: root.ID, SourceKey: "source-a",
+	}
+	sourceB := SourceIdentity{
+		Provider: root.Provider, ConfiguredRootID: root.ID, SourceKey: "source-b",
+	}
+	_, err := store.ReserveSourceCapture(t.Context(), sourceB, 2001)
+	require.ErrorIs(t, err, ErrOutboxFull)
+	reservation, err := store.ReserveSourceCapture(t.Context(), sourceA, 128)
+	require.NoError(t, err)
+
+	err = store.CompleteUnchangedCapture(t.Context(), reservation.ID, sourceB)
+
+	assert.ErrorIs(t, err, ErrCaptureConflict)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Equal(t, int64(128), usage.ReservedBytes)
+	coverage, ok, readErr := store.Coverage(t.Context(), root.Provider, root.ID)
+	require.NoError(t, readErr)
+	require.True(t, ok)
+	assert.Equal(t, CoverageDegraded, coverage.State)
+	assert.Equal(t, "outbox_full", coverage.Reason)
+}
+
+func TestCompleteUnchangedCaptureAcceptsRootScopedReservation(t *testing.T) {
+	store, root := openOutboxTestStore(t, 2000)
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 128)
+	require.NoError(t, err)
+	source := SourceIdentity{
+		Provider: root.Provider, ConfiguredRootID: root.ID, SourceKey: "source-a",
+	}
+
+	err = store.CompleteUnchangedCapture(t.Context(), reservation.ID, source)
+
+	require.NoError(t, err)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
 func TestCommitCaptureQueuesOfflineGenerationsAndChargesDuplicateObjectOnce(t *testing.T) {
 	store, root := openOutboxTestStore(t, 1<<20)
 	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
@@ -753,6 +795,29 @@ func TestCommitCaptureRejectsProviderThatDoesNotOwnReservedRoot(t *testing.T) {
 	err = store.CommitCapture(t.Context(), reservation.ID, generation)
 
 	require.ErrorIs(t, err, ErrCaptureConflict)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+}
+
+func TestCommitCaptureRejectsReservationForAnotherSource(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservationSource := SourceIdentity{
+		Provider: root.Provider, ConfiguredRootID: root.ID, SourceKey: "source-a",
+	}
+	reservation, err := store.ReserveSourceCapture(t.Context(), reservationSource, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	generation.Source.SourceKey = "source-b"
+
+	err = store.CommitCapture(t.Context(), reservation.ID, generation)
+
+	assert.ErrorIs(t, err, ErrCaptureConflict)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Equal(t, int64(1795), usage.ReservedBytes)
 	_, ok, readErr := store.NextGeneration(t.Context())
 	require.NoError(t, readErr)
 	assert.False(t, ok)

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -142,14 +142,25 @@ func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
 	invalidOnly := validCheckpointDigest(3)
 	acknowledgedOnly := validCheckpointDigest(4)
 	shared := validCheckpointDigest(5)
+	invalidDescendant := validCheckpointDigest(6)
 	_, err = db.Exec(`INSERT INTO outbox_objects
 		(sha256, length, spool_name, ref_count, state, created_at)
 		VALUES (?, 5, ?, 1, 'live', ?),
 		       (?, 7, ?, 1, 'live', ?),
-		       (?, 11, ?, 2, 'live', ?)`,
+		       (?, 11, ?, 2, 'live', ?),
+		       (?, 13, ?, 1, 'live', ?)`,
 		invalidOnly, invalidOnly, timestamp,
 		acknowledgedOnly, acknowledgedOnly, timestamp,
-		shared, shared, timestamp)
+		shared, shared, timestamp,
+		invalidDescendant, invalidDescendant, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO outbox_generations
+		(capture_id, provider, configured_root_id, source_key,
+		 predecessor_capture_id, captured_at, kind, state, metadata_bytes,
+		 created_at, updated_at)
+		VALUES ('capture-invalid-descendant', 'claude', 'root-a', 'source-a',
+		 'capture-invalid', ?, 'snapshot', 'queued', 400, ?, ?)`,
+		timestamp, timestamp, timestamp)
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO outbox_entries
 		(capture_id, entry_ordinal, path, length, mod_time_ns,
@@ -157,16 +168,19 @@ func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
 		VALUES ('capture-invalid', 0, 'invalid.jsonl', 16, 0, 'invalid', ?, 1),
 		       ('capture-acknowledged', 0, 'acknowledged.jsonl', 7, 0,
 		        'acknowledged', ?, 1),
-		       ('capture-queued', 0, 'queued.jsonl', 11, 0, 'queued', ?, 1)`,
-		invalidOnly, acknowledgedOnly, shared)
+		       ('capture-queued', 0, 'queued.jsonl', 11, 0, 'queued', ?, 1),
+		       ('capture-invalid-descendant', 0, 'descendant.jsonl', 13, 0,
+		        'descendant', ?, 1)`,
+		invalidOnly, acknowledgedOnly, shared, invalidDescendant)
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO outbox_entry_objects
 		(capture_id, entry_ordinal, object_ordinal, sha256, length)
 		VALUES ('capture-invalid', 0, 0, ?, 5),
 		       ('capture-invalid', 0, 1, ?, 11),
 		       ('capture-acknowledged', 0, 0, ?, 7),
-		       ('capture-queued', 0, 0, ?, 11)`,
-		invalidOnly, shared, acknowledgedOnly, shared)
+		       ('capture-queued', 0, 0, ?, 11),
+		       ('capture-invalid-descendant', 0, 0, ?, 13)`,
+		invalidOnly, shared, acknowledgedOnly, shared, invalidDescendant)
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO raw_source_base_entries
 		(provider, configured_root_id, source_key, entry_ordinal, path, length,
@@ -189,6 +203,7 @@ func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
 		{digest: invalidOnly, data: "12345"},
 		{digest: acknowledgedOnly, data: "1234567"},
 		{digest: shared, data: "12345678901"},
+		{digest: invalidDescendant, data: "1234567890123"},
 	} {
 		objectDir := filepath.Join(spoolDir, "objects", "sha256", object.digest[:2])
 		require.NoError(t, os.MkdirAll(objectDir, 0o700))
@@ -230,6 +245,16 @@ func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
 	).Scan(&invalidObjects))
 	assert.Zero(t, invalidObjects)
 	_, err = os.Stat(store.ObjectPath(rawsync.ObjectRef{SHA256: invalidOnly, Length: 5}))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	var descendantObjects int
+	require.NoError(t, store.db.QueryRow(
+		`SELECT count(*) FROM outbox_objects WHERE sha256 = ? AND length = 13`,
+		invalidDescendant,
+	).Scan(&descendantObjects))
+	assert.Zero(t, descendantObjects)
+	_, err = os.Stat(store.ObjectPath(rawsync.ObjectRef{
+		SHA256: invalidDescendant, Length: 13,
+	}))
 	assert.ErrorIs(t, err, os.ErrNotExist)
 
 	var acknowledgedReferences int

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -100,8 +100,9 @@ func TestOpenWithOptionsMigratesVersionOneAndEnforcesForeignKeys(t *testing.T) {
 	require.Error(t, err, "foreign keys must reject an orphaned outbox entry")
 }
 
-func TestOpenWithOptionsCompactsVersionThreeInvalidGenerations(t *testing.T) {
+func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "checkpoint.db")
+	spoolDir := filepath.Join(t.TempDir(), "spool")
 	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
 	require.NoError(t, err)
 	for _, statements := range [][]string{
@@ -120,33 +121,127 @@ func TestOpenWithOptionsCompactsVersionThreeInvalidGenerations(t *testing.T) {
 		VALUES ('root-a', 'claude', '/capture', ?, ?)`, timestamp, timestamp)
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO raw_sources
-		(provider, configured_root_id, source_key, latest_capture_id, updated_at)
-		VALUES ('claude', 'root-a', 'source-a', '', ?)`, timestamp)
+		(provider, configured_root_id, source_key, head_manifest_id,
+		 head_receipt, head_generation, latest_capture_id, updated_at)
+		VALUES ('claude', 'root-a', 'source-a', ?, ?, 1, 'capture-queued', ?)`,
+		validCheckpointDigest(1), validCheckpointDigest(2), timestamp)
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO outbox_generations
 		(capture_id, provider, configured_root_id, source_key, captured_at,
-		 kind, state, metadata_bytes, created_at, updated_at)
+		 kind, state, manifest_id, metadata_bytes, created_at, updated_at)
 		VALUES ('capture-invalid', 'claude', 'root-a', 'source-a', ?,
-		 'snapshot', 'invalid', 1792, ?, ?)`, timestamp, timestamp, timestamp)
+		 'snapshot', 'invalid', '', 100, ?, ?),
+		('capture-acknowledged', 'claude', 'root-a', 'source-a', ?,
+		 'snapshot', 'acknowledged', ?, 200, ?, ?),
+		('capture-queued', 'claude', 'root-a', 'source-a', ?,
+		 'snapshot', 'queued', '', 300, ?, ?)`,
+		timestamp, timestamp, timestamp,
+		timestamp, validCheckpointDigest(1), timestamp, timestamp,
+		timestamp, timestamp, timestamp)
+	require.NoError(t, err)
+	invalidOnly := validCheckpointDigest(3)
+	acknowledgedOnly := validCheckpointDigest(4)
+	shared := validCheckpointDigest(5)
+	_, err = db.Exec(`INSERT INTO outbox_objects
+		(sha256, length, spool_name, ref_count, state, created_at)
+		VALUES (?, 5, ?, 1, 'live', ?),
+		       (?, 7, ?, 1, 'live', ?),
+		       (?, 11, ?, 2, 'live', ?)`,
+		invalidOnly, invalidOnly, timestamp,
+		acknowledgedOnly, acknowledgedOnly, timestamp,
+		shared, shared, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO outbox_entries
+		(capture_id, entry_ordinal, path, length, mod_time_ns,
+		 file_identity, prefix_sha256, appendable)
+		VALUES ('capture-invalid', 0, 'invalid.jsonl', 16, 0, 'invalid', ?, 1),
+		       ('capture-acknowledged', 0, 'acknowledged.jsonl', 7, 0,
+		        'acknowledged', ?, 1),
+		       ('capture-queued', 0, 'queued.jsonl', 11, 0, 'queued', ?, 1)`,
+		invalidOnly, acknowledgedOnly, shared)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO outbox_entry_objects
+		(capture_id, entry_ordinal, object_ordinal, sha256, length)
+		VALUES ('capture-invalid', 0, 0, ?, 5),
+		       ('capture-invalid', 0, 1, ?, 11),
+		       ('capture-acknowledged', 0, 0, ?, 7),
+		       ('capture-queued', 0, 0, ?, 11)`,
+		invalidOnly, shared, acknowledgedOnly, shared)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO raw_source_base_entries
+		(provider, configured_root_id, source_key, entry_ordinal, path, length,
+		 mod_time_ns, file_identity, prefix_sha256, appendable)
+		VALUES ('claude', 'root-a', 'source-a', 0, 'acknowledged.jsonl', 7,
+		        0, 'acknowledged', ?, 1)`, acknowledgedOnly)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO raw_source_base_objects
+		(provider, configured_root_id, source_key, entry_ordinal,
+		 object_ordinal, sha256, length)
+		VALUES ('claude', 'root-a', 'source-a', 0, 0, ?, 7)`, acknowledgedOnly)
 	require.NoError(t, err)
 	_, err = db.Exec(`PRAGMA user_version = 3`)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
+	for _, object := range []struct {
+		digest string
+		data   string
+	}{
+		{digest: invalidOnly, data: "12345"},
+		{digest: acknowledgedOnly, data: "1234567"},
+		{digest: shared, data: "12345678901"},
+	} {
+		objectDir := filepath.Join(spoolDir, "objects", "sha256", object.digest[:2])
+		require.NoError(t, os.MkdirAll(objectDir, 0o700))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(objectDir, object.digest), []byte(object.data), 0o600,
+		))
+	}
 
 	store, err := OpenWithOptions(t.Context(), path, Options{
-		SpoolDir: filepath.Join(t.TempDir(), "spool"), MaxOutboxBytes: 1 << 20,
+		SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, store.Close()) })
 
 	usage, err := store.OutboxUsage(t.Context())
 	require.NoError(t, err)
-	assert.Zero(t, usage.UsedBytes)
+	assert.Equal(t, int64(311), usage.UsedBytes)
 	var generations int
 	require.NoError(t, store.db.QueryRow(
 		`SELECT count(*) FROM outbox_generations`,
 	).Scan(&generations))
-	assert.Zero(t, generations)
+	assert.Equal(t, 1, generations)
+
+	var sharedReferences int
+	var sharedState string
+	require.NoError(t, store.db.QueryRow(
+		`SELECT ref_count, state FROM outbox_objects WHERE sha256 = ? AND length = 11`,
+		shared,
+	).Scan(&sharedReferences, &sharedState))
+	assert.Equal(t, 1, sharedReferences)
+	assert.Equal(t, "live", sharedState)
+	_, err = os.Stat(store.ObjectPath(rawsync.ObjectRef{SHA256: shared, Length: 11}))
+	assert.NoError(t, err)
+
+	var invalidObjects int
+	require.NoError(t, store.db.QueryRow(
+		`SELECT count(*) FROM outbox_objects WHERE sha256 = ? AND length = 5`,
+		invalidOnly,
+	).Scan(&invalidObjects))
+	assert.Zero(t, invalidObjects)
+	_, err = os.Stat(store.ObjectPath(rawsync.ObjectRef{SHA256: invalidOnly, Length: 5}))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	var acknowledgedReferences int
+	var acknowledgedState string
+	require.NoError(t, store.db.QueryRow(
+		`SELECT ref_count, state FROM outbox_objects WHERE sha256 = ? AND length = 7`,
+		acknowledgedOnly,
+	).Scan(&acknowledgedReferences, &acknowledgedState))
+	assert.Zero(t, acknowledgedReferences)
+	assert.Equal(t, "remote", acknowledgedState)
+	_, err = os.Stat(store.ObjectPath(rawsync.ObjectRef{SHA256: acknowledgedOnly, Length: 7}))
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestOpenWithOptionsPreservesVersionFourRootCoverageGap(t *testing.T) {

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -370,6 +370,46 @@ func TestOpenWithOptionsHoldsCheckpointAndSpoolProcessLocksUntilClose(t *testing
 	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
 }
 
+func TestOpenWithOptionsRejectsChangedSpoolBeforeRecovery(t *testing.T) {
+	base := t.TempDir()
+	checkpointPath := filepath.Join(base, "checkpoint.db")
+	spoolDir := filepath.Join(base, "spool")
+	store, err := OpenWithOptions(t.Context(), checkpointPath, Options{
+		SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	sourceRoot := filepath.Join(base, "sources")
+	require.NoError(t, os.MkdirAll(sourceRoot, 0o755))
+	root, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, sourceRoot)
+	require.NoError(t, err)
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	require.NoError(t, store.Close())
+
+	mismatched, err := OpenWithOptions(t.Context(), checkpointPath, Options{
+		SpoolDir: filepath.Join(base, "other-spool"), MaxOutboxBytes: 1 << 20,
+	})
+	if mismatched != nil {
+		require.NoError(t, mismatched.Close())
+	}
+	require.ErrorIs(t, err, ErrSpoolMismatch)
+
+	reopened, err := OpenWithOptions(t.Context(), checkpointPath, Options{
+		SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+	queued, ok, err := reopened.NextGeneration(t.Context())
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generation.CaptureID, queued.CaptureID)
+	assert.FileExists(t, reopened.ObjectPath(ref))
+}
+
 func TestOpenWithOptionsRejectsCheckpointAndSpoolContentionAcrossProcesses(t *testing.T) {
 	if os.Getenv("AGENTSVIEW_RAWCHECKPOINT_LOCK_HELPER") == "1" {
 		_, err := OpenWithOptions(t.Context(), os.Getenv("AGENTSVIEW_RAWCHECKPOINT_PATH"), Options{

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -485,6 +485,45 @@ func TestInsertCapturedObjectsPromotesRemoteRowWhenLocalBytesArePresent(t *testi
 	assert.Equal(t, ref.Length, usage.UsedBytes)
 }
 
+func TestCollectGarbageWaitsForObjectPublication(t *testing.T) {
+	store, _ := openOutboxTestStore(t, 1<<20)
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	_, err := store.db.Exec(`INSERT INTO outbox_objects
+		(sha256, length, spool_name, ref_count, state, created_at)
+		VALUES (?, ?, 'objects/pending', 0, 'garbage_pending', '2026-08-25T00:00:00Z')`,
+		ref.SHA256, ref.Length)
+	require.NoError(t, err)
+	finishPublication := store.BeginObjectPublication()
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	type collectionOutcome struct {
+		report GarbageCollectionReport
+		err    error
+	}
+	started := make(chan struct{})
+	completed := make(chan collectionOutcome, 1)
+	go func() {
+		close(started)
+		report, err := store.CollectGarbage(t.Context())
+		completed <- collectionOutcome{report: report, err: err}
+	}()
+	<-started
+
+	select {
+	case outcome := <-completed:
+		finishPublication()
+		require.FailNow(t, "garbage collection completed during publication",
+			"report=%+v error=%v", outcome.report, outcome.err)
+	case <-time.After(100 * time.Millisecond):
+		assert.FileExists(t, store.ObjectPath(ref))
+	}
+
+	finishPublication()
+	outcome := <-completed
+	require.NoError(t, outcome.err)
+	assert.Equal(t, GarbageCollectionReport{Objects: 1, Bytes: 3}, outcome.report)
+	assert.NoFileExists(t, store.ObjectPath(ref))
+}
+
 func testCapturedGeneration(
 	sequence int,
 	root ConfiguredRoot,

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -123,7 +123,8 @@ func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
 	_, err = db.Exec(`INSERT INTO raw_sources
 		(provider, configured_root_id, source_key, head_manifest_id,
 		 head_receipt, head_generation, latest_capture_id, updated_at)
-		VALUES ('claude', 'root-a', 'source-a', ?, ?, 1, 'capture-queued', ?)`,
+		VALUES ('claude', 'root-a', 'source-a', ?, ?, 1,
+			'capture-invalid-descendant', ?)`,
 		validCheckpointDigest(1), validCheckpointDigest(2), timestamp)
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO outbox_generations
@@ -217,6 +218,14 @@ func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	base, ok, err := store.CaptureBase(t.Context(), SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: "root-a", SourceKey: "source-a",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "capture-acknowledged", base.CaptureID)
+	require.Len(t, base.Entries, 1)
+	assert.Equal(t, "acknowledged.jsonl", base.Entries[0].Path)
 
 	usage, err := store.OutboxUsage(t.Context())
 	require.NoError(t, err)

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -1,0 +1,625 @@
+package rawcheckpoint
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func createVersionOneCheckpoint(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec(`CREATE TABLE device_config (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		device_id TEXT NOT NULL,
+		created_at TEXT NOT NULL
+	)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE raw_sources (
+		provider TEXT NOT NULL,
+		configured_root_id TEXT NOT NULL,
+		source_key TEXT NOT NULL,
+		head_manifest_id TEXT NOT NULL DEFAULT '',
+		head_receipt TEXT NOT NULL DEFAULT '',
+		head_generation INTEGER NOT NULL DEFAULT 0,
+		updated_at TEXT NOT NULL,
+		PRIMARY KEY (provider, configured_root_id, source_key)
+	)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO device_config (id, device_id, created_at)
+		VALUES (1, 'dev_existing', '2026-08-25T00:00:00Z')`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO raw_sources
+		(provider, configured_root_id, source_key, head_manifest_id,
+		 head_receipt, head_generation, updated_at)
+		VALUES ('claude', 'root-existing', 'source-existing',
+		 ?, ?, 1, '2026-08-25T00:00:00Z')`,
+		validCheckpointDigest(2), validCheckpointDigest(3))
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA user_version = 1`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func validCheckpointDigest(value byte) string {
+	const hex = "0123456789abcdef"
+	result := make([]byte, 64)
+	for i := range result {
+		result[i] = hex[value%16]
+	}
+	return string(result)
+}
+
+func TestOpenWithOptionsMigratesVersionOneAndEnforcesForeignKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.db")
+	createVersionOneCheckpoint(t, path)
+	store, err := OpenWithOptions(t.Context(), path, Options{
+		SpoolDir:       filepath.Join(t.TempDir(), "spool"),
+		MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	deviceID, ok, err := store.Device(t.Context())
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "dev_existing", deviceID)
+	head, ok, err := store.SourceHead(
+		t.Context(), parser.AgentClaude, "root-existing", "source-existing",
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, int64(1), head.Generation)
+	assert.Equal(t, validCheckpointDigest(2), head.ManifestID)
+	assert.Equal(t, validCheckpointDigest(3), head.Receipt)
+
+	var version, foreignKeys int
+	require.NoError(t, store.db.QueryRow("PRAGMA user_version").Scan(&version))
+	require.NoError(t, store.db.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys))
+	assert.Equal(t, 5, version)
+	assert.Equal(t, 1, foreignKeys)
+
+	_, err = store.db.Exec(`INSERT INTO outbox_entries
+		(capture_id, entry_ordinal, path, length, mod_time_ns,
+		 file_identity, prefix_sha256, appendable)
+		VALUES ('missing-capture', 0, 'session.jsonl', 1, 0, '', '', 1)`)
+	require.Error(t, err, "foreign keys must reject an orphaned outbox entry")
+}
+
+func TestOpenWithOptionsCompactsVersionThreeInvalidGenerations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	for _, statements := range [][]string{
+		versionOneSchemaStatements,
+		versionTwoMigrationStatements,
+		versionThreeMigrationStatements,
+	} {
+		for _, statement := range statements {
+			_, err = db.Exec(statement)
+			require.NoError(t, err)
+		}
+	}
+	const timestamp = "2026-08-25T00:00:00Z"
+	_, err = db.Exec(`INSERT INTO configured_roots
+		(id, provider, local_root, created_at, updated_at)
+		VALUES ('root-a', 'claude', '/capture', ?, ?)`, timestamp, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO raw_sources
+		(provider, configured_root_id, source_key, latest_capture_id, updated_at)
+		VALUES ('claude', 'root-a', 'source-a', '', ?)`, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO outbox_generations
+		(capture_id, provider, configured_root_id, source_key, captured_at,
+		 kind, state, metadata_bytes, created_at, updated_at)
+		VALUES ('capture-invalid', 'claude', 'root-a', 'source-a', ?,
+		 'snapshot', 'invalid', 1792, ?, ?)`, timestamp, timestamp, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA user_version = 3`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store, err := OpenWithOptions(t.Context(), path, Options{
+		SpoolDir: filepath.Join(t.TempDir(), "spool"), MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, usage.UsedBytes)
+	var generations int
+	require.NoError(t, store.db.QueryRow(
+		`SELECT count(*) FROM outbox_generations`,
+	).Scan(&generations))
+	assert.Zero(t, generations)
+}
+
+func TestOpenWithOptionsPreservesVersionFourRootCoverageGap(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	for _, statements := range [][]string{
+		versionOneSchemaStatements,
+		versionTwoMigrationStatements,
+		versionThreeMigrationStatements,
+		versionFourMigrationStatements,
+	} {
+		for _, statement := range statements {
+			_, err = db.Exec(statement)
+			require.NoError(t, err)
+		}
+	}
+	const timestamp = "2026-08-25T00:00:00Z"
+	_, err = db.Exec(`INSERT INTO configured_roots
+		(id, provider, local_root, created_at, updated_at)
+		VALUES ('root-a', 'claude', '/capture', ?, ?)`, timestamp, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO raw_coverage
+		(provider, configured_root_id, state, reason, degraded_at, updated_at)
+		VALUES ('claude', 'root-a', 'degraded', 'outbox_full', ?, ?)`,
+		timestamp, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA user_version = 4`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store, err := OpenWithOptions(t.Context(), path, Options{
+		SpoolDir: filepath.Join(t.TempDir(), "spool"), MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	var failures int
+	require.NoError(t, store.db.QueryRow(
+		`SELECT count(*) FROM raw_coverage_failures WHERE source_key = ''`,
+	).Scan(&failures))
+	assert.Equal(t, 1, failures)
+	coverage, ok, err := store.Coverage(
+		t.Context(), parser.AgentClaude, "root-a",
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, CoverageDegraded, coverage.State)
+}
+
+func TestOpenWithOptionsHoldsCheckpointAndSpoolProcessLocksUntilClose(t *testing.T) {
+	base := t.TempDir()
+	checkpointPath := filepath.Join(base, "checkpoint.db")
+	spoolDir := filepath.Join(base, "spool")
+	first, err := OpenWithOptions(t.Context(), checkpointPath, Options{
+		SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+
+	_, err = OpenWithOptions(t.Context(), checkpointPath, Options{
+		SpoolDir: filepath.Join(base, "other-spool"), MaxOutboxBytes: 1 << 20,
+	})
+	require.ErrorIs(t, err, ErrStoreLocked)
+	_, err = OpenWithOptions(t.Context(), filepath.Join(base, "other.db"), Options{
+		SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20,
+	})
+	require.ErrorIs(t, err, ErrStoreLocked)
+	require.NoError(t, first.Close())
+
+	reopened, err := OpenWithOptions(t.Context(), checkpointPath, Options{
+		SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+}
+
+func TestOpenWithOptionsRejectsCheckpointAndSpoolContentionAcrossProcesses(t *testing.T) {
+	if os.Getenv("AGENTSVIEW_RAWCHECKPOINT_LOCK_HELPER") == "1" {
+		_, err := OpenWithOptions(t.Context(), os.Getenv("AGENTSVIEW_RAWCHECKPOINT_PATH"), Options{
+			SpoolDir: os.Getenv("AGENTSVIEW_RAWCHECKPOINT_SPOOL"), MaxOutboxBytes: 1 << 20,
+		})
+		if !errors.Is(err, ErrStoreLocked) {
+			_, _ = fmt.Fprintf(os.Stderr, "expected store lock, got %v", err)
+			os.Exit(2)
+		}
+		os.Exit(0)
+	}
+	base := t.TempDir()
+	checkpointPath := filepath.Join(base, "checkpoint.db")
+	spoolDir := filepath.Join(base, "spool")
+	store, err := OpenWithOptions(t.Context(), checkpointPath, Options{
+		SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	for _, tc := range []struct {
+		name       string
+		checkpoint string
+		spool      string
+	}{
+		{name: "checkpoint", checkpoint: checkpointPath, spool: filepath.Join(base, "other-spool")},
+		{name: "spool", checkpoint: filepath.Join(base, "other.db"), spool: spoolDir},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			command := exec.Command(os.Args[0],
+				"-test.run=^TestOpenWithOptionsRejectsCheckpointAndSpoolContentionAcrossProcesses$",
+			)
+			command.Env = append(os.Environ(),
+				"AGENTSVIEW_RAWCHECKPOINT_LOCK_HELPER=1",
+				"AGENTSVIEW_RAWCHECKPOINT_PATH="+tc.checkpoint,
+				"AGENTSVIEW_RAWCHECKPOINT_SPOOL="+tc.spool,
+			)
+			output, err := command.CombinedOutput()
+			require.NoError(t, err, string(output))
+		})
+	}
+}
+
+func TestResolveConfiguredRootPersistsCanonicalProviderIdentity(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	linkedRoot := filepath.Join(base, "linked")
+	otherRoot := filepath.Join(base, "other")
+	require.NoError(t, os.MkdirAll(realRoot, 0o755))
+	require.NoError(t, os.MkdirAll(otherRoot, 0o755))
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	canonicalRealRoot, err := filepath.EvalSymlinks(realRoot)
+	require.NoError(t, err)
+	dbPath := filepath.Join(base, "checkpoint.db")
+	spoolDir := filepath.Join(base, "spool")
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	store, err := OpenWithOptions(t.Context(), dbPath, Options{
+		SpoolDir:       spoolDir,
+		MaxOutboxBytes: 1 << 20,
+		Now:            func() time.Time { return now },
+	})
+	require.NoError(t, err)
+
+	first, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, linkedRoot)
+	require.NoError(t, err)
+	viaRealPath, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, realRoot)
+	require.NoError(t, err)
+	other, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, otherRoot)
+	require.NoError(t, err)
+	otherProvider, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentCodex, realRoot)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ID, viaRealPath.ID)
+	assert.Equal(t, canonicalRealRoot, first.LocalPath)
+	assert.Equal(t, parser.AgentClaude, first.Provider)
+	assert.Equal(t, now, first.CreatedAt)
+	assert.Equal(t, now, first.UpdatedAt)
+	assert.NotEqual(t, first.ID, other.ID)
+	assert.NotEqual(t, first.ID, otherProvider.ID)
+	assert.Regexp(t, `^[0-9a-f]{32}$`, first.ID)
+	require.NoError(t, store.Close())
+
+	reopened, err := OpenWithOptions(t.Context(), dbPath, Options{
+		SpoolDir:       spoolDir,
+		MaxOutboxBytes: 1 << 20,
+		Now:            func() time.Time { return now.Add(time.Hour) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+	persisted, err := reopened.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, realRoot)
+	require.NoError(t, err)
+	assert.Equal(t, first, persisted)
+}
+
+func TestResolveConfiguredRootDoesNotExposeLocalPathInFilesystemError(t *testing.T) {
+	store, _ := openOutboxTestStore(t, 1<<20)
+	privateRoot := filepath.Join(t.TempDir(), "private", "missing")
+
+	_, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, privateRoot)
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), filepath.Dir(filepath.Dir(privateRoot)))
+}
+
+const (
+	emptyObjectSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	abcObjectSHA256   = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+)
+
+func openOutboxTestStore(t *testing.T, maxBytes int64) (*Store, ConfiguredRoot) {
+	t.Helper()
+	base := t.TempDir()
+	rootPath := filepath.Join(base, "sources")
+	require.NoError(t, os.MkdirAll(rootPath, 0o755))
+	store, err := OpenWithOptions(t.Context(), filepath.Join(base, "checkpoint.db"), Options{
+		SpoolDir:       filepath.Join(base, "spool"),
+		MaxOutboxBytes: maxBytes,
+		Now: func() time.Time {
+			return time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	root, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, rootPath)
+	require.NoError(t, err)
+	return store, root
+}
+
+func installOutboxTestObject(
+	t *testing.T,
+	store *Store,
+	ref rawsync.ObjectRef,
+	content []byte,
+) {
+	t.Helper()
+	path := store.ObjectPath(ref)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+}
+
+func TestInsertCapturedObjectsPromotesRemoteRowWhenLocalBytesArePresent(t *testing.T) {
+	store, _ := openOutboxTestStore(t, 1<<20)
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	_, err := store.db.Exec(`INSERT INTO outbox_objects
+		(sha256, length, spool_name, ref_count, state, created_at)
+		VALUES (?, ?, 'objects/remote', 0, 'remote', '2026-08-25T00:00:00Z')`,
+		ref.SHA256, ref.Length)
+	require.NoError(t, err)
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+
+	err = store.withImmediateWrite(t.Context(), "test promote remote object", func(conn *sql.Conn) error {
+		return insertCapturedObjectsConn(t.Context(), conn, store,
+			map[string]rawsync.ObjectRef{ref.SHA256: ref}, "2026-08-25T00:00:01Z")
+	})
+
+	require.NoError(t, err)
+	var state string
+	require.NoError(t, store.db.QueryRow(`SELECT state FROM outbox_objects
+		WHERE sha256 = ? AND length = ?`, ref.SHA256, ref.Length).Scan(&state))
+	assert.Equal(t, "live", state)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, ref.Length, usage.UsedBytes)
+}
+
+func testCapturedGeneration(
+	sequence int,
+	root ConfiguredRoot,
+	predecessor string,
+	ref rawsync.ObjectRef,
+) CapturedGeneration {
+	captureID := fmt.Sprintf("%032x", sequence)
+	return CapturedGeneration{
+		CaptureID: captureID,
+		Source: SourceIdentity{
+			Provider:         root.Provider,
+			ConfiguredRootID: root.ID,
+			SourceKey:        "source-1",
+		},
+		PredecessorCaptureID: predecessor,
+		CapturedAt:           time.Date(2026, 8, 25, 12, 0, sequence, 0, time.UTC),
+		Kind:                 rawsync.ManifestSnapshot,
+		Entries: []CapturedEntry{{
+			Path:         "project/session.jsonl",
+			Length:       ref.Length,
+			ModTimeNS:    int64(sequence),
+			FileIdentity: "device:1:inode:2",
+			PrefixSHA256: ref.SHA256,
+			Appendable:   true,
+			Objects:      []rawsync.ObjectRef{ref},
+		}},
+	}
+}
+
+func TestReserveCaptureIsAtomicAndMarksOnlyItsRootDegraded(t *testing.T) {
+	store, root := openOutboxTestStore(t, 2048)
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var reservationsMu sync.Mutex
+	var reservations []Reservation
+	for range 2 {
+		go func() {
+			<-start
+			reservation, err := store.ReserveCapture(t.Context(), root.ID, 1536)
+			if err == nil {
+				reservationsMu.Lock()
+				reservations = append(reservations, reservation)
+				reservationsMu.Unlock()
+			}
+			results <- err
+		}()
+	}
+	close(start)
+
+	var successes, full int
+	for range 2 {
+		err := <-results
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrOutboxFull):
+			full++
+		default:
+			require.NoError(t, err)
+		}
+	}
+	assert.Equal(t, 1, successes)
+	assert.Equal(t, 1, full)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), usage.UsedBytes)
+	assert.Equal(t, int64(1536), usage.ReservedBytes)
+	assert.Equal(t, int64(2048), usage.LimitBytes)
+	coverage, ok, err := store.Coverage(t.Context(), root.Provider, root.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, CoverageDegraded, coverage.State)
+	assert.Equal(t, "outbox_full", coverage.Reason)
+
+	require.Len(t, reservations, 1)
+	require.NoError(t, store.ReleaseReservation(t.Context(), reservations[0].ID))
+	usage, err = store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestReserveCaptureRejectsMetadataOnlyOverflowWithoutObjects(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1791)
+
+	_, err := store.ReserveCapture(t.Context(), root.ID, 1792)
+
+	require.ErrorIs(t, err, ErrOutboxFull)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+	var generations, objects int
+	require.NoError(t, store.db.QueryRow(`SELECT count(*) FROM outbox_generations`).Scan(&generations))
+	require.NoError(t, store.db.QueryRow(`SELECT count(*) FROM outbox_objects`).Scan(&objects))
+	assert.Zero(t, generations)
+	assert.Zero(t, objects)
+}
+
+func TestSuccessfulCaptureClearsItsOwnSourceCoverageFailure(t *testing.T) {
+	store, root := openOutboxTestStore(t, 2000)
+	source := SourceIdentity{
+		Provider: root.Provider, ConfiguredRootID: root.ID, SourceKey: "source-1",
+	}
+	_, err := store.ReserveSourceCapture(t.Context(), source, 2001)
+	require.ErrorIs(t, err, ErrOutboxFull)
+	coverage, ok, err := store.Coverage(t.Context(), root.Provider, root.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, CoverageDegraded, coverage.State)
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(10), Length: 1}
+	installOutboxTestObject(t, store, ref, []byte{1})
+	reservation, err := store.ReserveSourceCapture(t.Context(), source, 1793)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+
+	coverage, ok, err = store.Coverage(t.Context(), root.Provider, root.ID)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, CoverageComplete, coverage.State)
+	assert.NotNil(t, coverage.RecoveredAt)
+}
+
+func TestCommitCaptureQueuesOfflineGenerationsAndChargesDuplicateObjectOnce(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+
+	firstReservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	first := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), firstReservation.ID, first))
+
+	secondReservation, err := store.ReserveCapture(t.Context(), root.ID, 1792)
+	require.NoError(t, err)
+	second := testCapturedGeneration(2, root, first.CaptureID, ref)
+	require.NoError(t, store.CommitCapture(t.Context(), secondReservation.ID, second))
+
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(3587), usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+	var objectRows, refCount int
+	require.NoError(t, store.db.QueryRow(`SELECT count(*), sum(ref_count)
+		FROM outbox_objects`).Scan(&objectRows, &refCount))
+	assert.Equal(t, 1, objectRows)
+	assert.Equal(t, 2, refCount)
+
+	base, ok, err := store.CaptureBase(t.Context(), second.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, second.CaptureID, base.CaptureID)
+	require.Len(t, base.Entries, 1)
+	assert.Equal(t, second.Entries[0], base.Entries[0])
+
+	next, ok, err := store.NextGeneration(t.Context())
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, first.CaptureID, next.CaptureID)
+	assert.Empty(t, next.PredecessorCaptureID)
+	assert.Equal(t, first.Entries, next.Entries)
+}
+
+func TestCommitCaptureRejectsProviderThatDoesNotOwnReservedRoot(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	generation.Source.Provider = parser.AgentCodex
+
+	err = store.CommitCapture(t.Context(), reservation.ID, generation)
+
+	require.ErrorIs(t, err, ErrCaptureConflict)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+}
+
+func TestZeroByteGenerationsConsumeMetadataCapacity(t *testing.T) {
+	store, root := openOutboxTestStore(t, 3584)
+	ref := rawsync.ObjectRef{SHA256: emptyObjectSHA256, Length: 0}
+	installOutboxTestObject(t, store, ref, nil)
+
+	predecessor := ""
+	for sequence := 1; sequence <= 2; sequence++ {
+		reservation, err := store.ReserveCapture(t.Context(), root.ID, 1792)
+		require.NoError(t, err)
+		generation := testCapturedGeneration(sequence, root, predecessor, ref)
+		require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+		predecessor = generation.CaptureID
+	}
+
+	_, err := store.ReserveCapture(t.Context(), root.ID, 1792)
+	require.ErrorIs(t, err, ErrOutboxFull)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(3584), usage.UsedBytes)
+	var generations int
+	require.NoError(t, store.db.QueryRow(`SELECT count(*) FROM outbox_generations`).Scan(&generations))
+	assert.Equal(t, 2, generations)
+}
+
+func TestSetDeviceReclaimsQueuedObjectsAndPreservesConfiguredRoots(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+
+	require.NoError(t, store.SetDevice(t.Context(), "dev_2"))
+
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, usage.UsedBytes)
+	assert.NoFileExists(t, store.ObjectPath(ref))
+	var generations, objects, roots int
+	require.NoError(t, store.db.QueryRow(`SELECT count(*) FROM outbox_generations`).Scan(&generations))
+	require.NoError(t, store.db.QueryRow(`SELECT count(*) FROM outbox_objects`).Scan(&objects))
+	require.NoError(t, store.db.QueryRow(`SELECT count(*) FROM configured_roots`).Scan(&roots))
+	assert.Zero(t, generations)
+	assert.Zero(t, objects)
+	assert.Equal(t, 1, roots)
+	persisted, err := store.ResolveConfiguredRoot(t.Context(), root.Provider, root.LocalPath)
+	require.NoError(t, err)
+	assert.Equal(t, root.ID, persisted.ID)
+}

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -278,7 +278,7 @@ func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
-func TestOpenWithOptionsPreservesVersionFourRootCoverageGap(t *testing.T) {
+func TestOpenWithOptionsReconcilesVersionFourRootCoverageGap(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "checkpoint.db")
 	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
 	require.NoError(t, err)
@@ -324,6 +324,24 @@ func TestOpenWithOptionsPreservesVersionFourRootCoverageGap(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, CoverageDegraded, coverage.State)
+
+	require.NoError(t, store.CompleteRootReconciliation(t.Context(), "root-a"))
+	coverage, ok, err = store.Coverage(t.Context(), parser.AgentClaude, "root-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, CoverageComplete, coverage.State)
+
+	source := SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: "root-a", SourceKey: "source-a",
+	}
+	_, err = store.ReserveSourceCapture(t.Context(), source, 1<<20+1)
+	require.ErrorIs(t, err, ErrOutboxFull)
+	require.NoError(t, store.CompleteRootReconciliation(t.Context(), "root-a"))
+	coverage, ok, err = store.Coverage(t.Context(), parser.AgentClaude, "root-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, CoverageDegraded, coverage.State)
+	assert.Equal(t, "outbox_full", coverage.Reason)
 }
 
 func TestOpenWithOptionsHoldsCheckpointAndSpoolProcessLocksUntilClose(t *testing.T) {

--- a/internal/rawcheckpoint/recovery.go
+++ b/internal/rawcheckpoint/recovery.go
@@ -98,6 +98,32 @@ func (s *Store) Recover(ctx context.Context) (RecoveryReport, error) {
 			checkpointFilesystemError(err))
 	}
 	err = s.withImmediateWrite(ctx, "recover object spool state", func(conn *sql.Conn) error {
+		rows, err := conn.QueryContext(ctx, `SELECT provider, configured_root_id, source_key
+			FROM outbox_reservations`)
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: recover: list stale reservations: %w", err)
+		}
+		var interrupted []SourceIdentity
+		for rows.Next() {
+			var source SourceIdentity
+			if err := rows.Scan(
+				&source.Provider, &source.ConfiguredRootID, &source.SourceKey,
+			); err != nil {
+				rows.Close()
+				return fmt.Errorf("rawcheckpoint: recover: list stale reservations: %w", err)
+			}
+			interrupted = append(interrupted, source)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("rawcheckpoint: recover: list stale reservations: %w", err)
+		}
+		for _, source := range interrupted {
+			if err := setSourceCoverageDegradedConn(
+				ctx, conn, source, "capture_interrupted", s.now().UTC(),
+			); err != nil {
+				return err
+			}
+		}
 		result, err := conn.ExecContext(ctx, `DELETE FROM outbox_reservations`)
 		if err != nil {
 			return fmt.Errorf("rawcheckpoint: recover: clear stale reservations: %w", err)

--- a/internal/rawcheckpoint/recovery.go
+++ b/internal/rawcheckpoint/recovery.go
@@ -1,0 +1,285 @@
+package rawcheckpoint
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// RecoveryReport describes bounded startup repair of the private object spool.
+type RecoveryReport struct {
+	TemporaryFiles     int
+	UnreferencedFiles  int
+	Reservations       int
+	InvalidGenerations int
+	Garbage            GarbageCollectionReport
+}
+
+// Recover removes incomplete files and invalidates the complete local suffix
+// behind any missing or wrong-sized referenced object. Acknowledged heads and
+// their retained append metadata never advance during recovery.
+func (s *Store) Recover(ctx context.Context) (RecoveryReport, error) {
+	s.objectMu.Lock()
+	var report RecoveryReport
+	entries, err := os.ReadDir(s.CaptureTempDir())
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		s.objectMu.Unlock()
+		return report, fmt.Errorf("rawcheckpoint: read temporary spool: %s",
+			checkpointFilesystemError(err))
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(s.CaptureTempDir(), entry.Name())); err != nil {
+			s.objectMu.Unlock()
+			return report, fmt.Errorf("rawcheckpoint: remove temporary spool entry: %s",
+				checkpointFilesystemError(err))
+		}
+		report.TemporaryFiles++
+	}
+
+	known := make(map[string]rawsync.ObjectRef)
+	rows, err := s.db.QueryContext(ctx, `SELECT sha256, length, state FROM outbox_objects`)
+	if err != nil {
+		s.objectMu.Unlock()
+		return report, fmt.Errorf("rawcheckpoint: list recovery objects: %w", err)
+	}
+	var broken []rawsync.ObjectRef
+	for rows.Next() {
+		var ref rawsync.ObjectRef
+		var state string
+		if err := rows.Scan(&ref.SHA256, &ref.Length, &state); err != nil {
+			rows.Close()
+			s.objectMu.Unlock()
+			return report, fmt.Errorf("rawcheckpoint: list recovery objects: %w", err)
+		}
+		path := filepath.Clean(s.ObjectPath(ref))
+		if state == "remote" {
+			continue
+		}
+		known[path] = ref
+		info, statErr := os.Stat(path)
+		if statErr != nil || !info.Mode().IsRegular() || info.Size() != ref.Length {
+			broken = append(broken, ref)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		s.objectMu.Unlock()
+		return report, fmt.Errorf("rawcheckpoint: list recovery objects: %w", err)
+	}
+	objectsRoot := filepath.Join(s.spoolDir, "objects", "sha256")
+	err = filepath.WalkDir(objectsRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if _, ok := known[filepath.Clean(path)]; ok {
+			return nil
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		report.UnreferencedFiles++
+		return nil
+	})
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		s.objectMu.Unlock()
+		return report, fmt.Errorf("rawcheckpoint: sweep unreferenced objects: %s",
+			checkpointFilesystemError(err))
+	}
+	err = s.withImmediateWrite(ctx, "recover object spool state", func(conn *sql.Conn) error {
+		result, err := conn.ExecContext(ctx, `DELETE FROM outbox_reservations`)
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: recover: clear stale reservations: %w", err)
+		}
+		cleared, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: recover: count stale reservations: %w", err)
+		}
+		report.Reservations = int(cleared)
+		if len(broken) != 0 {
+			invalid, err := invalidGenerationSuffixConn(ctx, conn, broken)
+			if err != nil {
+				return err
+			}
+			for _, captureID := range invalid {
+				if err := releaseGenerationObjectsConn(ctx, conn, captureID); err != nil {
+					return err
+				}
+				if _, err := conn.ExecContext(ctx,
+					`DELETE FROM outbox_entries WHERE capture_id = ?`, captureID); err != nil {
+					return fmt.Errorf("rawcheckpoint: recover: release invalid entries: %w", err)
+				}
+			}
+			report.InvalidGenerations = len(invalid)
+			if err := resetInvalidSourcesConn(ctx, conn, invalid, s); err != nil {
+				return err
+			}
+			for _, captureID := range invalid {
+				if _, err := conn.ExecContext(ctx,
+					`DELETE FROM outbox_generations WHERE capture_id = ?`, captureID); err != nil {
+					return fmt.Errorf("rawcheckpoint: recover: compact invalid generation: %w", err)
+				}
+			}
+			if _, err := conn.ExecContext(ctx, `UPDATE outbox_objects
+				SET state = 'garbage_pending'
+				WHERE ref_count = 0 AND state != 'remote'`); err != nil {
+				return fmt.Errorf("rawcheckpoint: recover: mark garbage: %w", err)
+			}
+		}
+		return nil
+	})
+	s.objectMu.Unlock()
+	if err != nil {
+		return report, err
+	}
+	report.Garbage, err = s.CollectGarbage(ctx)
+	return report, err
+}
+
+// VerifyObject performs explicit full-digest verification for one retained
+// local object without making startup scan every object byte.
+func (s *Store) VerifyObject(ctx context.Context, ref rawsync.ObjectRef) error {
+	if _, err := rawsync.NewObjectRef(ref.SHA256, ref.Length); err != nil {
+		return err
+	}
+	s.objectMu.Lock()
+	defer s.objectMu.Unlock()
+	var present int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM outbox_objects
+		WHERE sha256 = ? AND length = ?`, ref.SHA256, ref.Length).Scan(&present); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return rawsync.ErrNotFound
+		}
+		return fmt.Errorf("rawcheckpoint: verify object: %w", err)
+	}
+	digest, length, err := hashCheckpointObject(ctx, s.ObjectPath(ref))
+	if err != nil || digest != ref.SHA256 || length != ref.Length {
+		return fmt.Errorf("rawcheckpoint: verify object: %w", rawsync.ErrInvalid)
+	}
+	return nil
+}
+
+func invalidGenerationSuffixConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	broken []rawsync.ObjectRef,
+) ([]string, error) {
+	invalid := make(map[string]struct{})
+	for _, ref := range broken {
+		rows, err := conn.QueryContext(ctx, `WITH RECURSIVE suffix(capture_id) AS (
+			SELECT entry_object.capture_id FROM outbox_entry_objects AS entry_object
+			JOIN outbox_generations AS generation
+				ON generation.capture_id = entry_object.capture_id
+			WHERE entry_object.sha256 = ? AND entry_object.length = ?
+				AND generation.state != 'acknowledged'
+			UNION
+			SELECT generation.capture_id FROM outbox_generations AS generation
+			JOIN suffix ON generation.predecessor_capture_id = suffix.capture_id
+			WHERE generation.state != 'acknowledged'
+		)
+		SELECT capture_id FROM suffix`, ref.SHA256, ref.Length)
+		if err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: find broken generation suffix: %w", err)
+		}
+		for rows.Next() {
+			var captureID string
+			if err := rows.Scan(&captureID); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("rawcheckpoint: find broken generation suffix: %w", err)
+			}
+			invalid[captureID] = struct{}{}
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: find broken generation suffix: %w", err)
+		}
+	}
+	result := make([]string, 0, len(invalid))
+	for captureID := range invalid {
+		result = append(result, captureID)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func resetInvalidSourcesConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	invalid []string,
+	store *Store,
+) error {
+	seen := make(map[SourceIdentity]struct{})
+	for _, captureID := range invalid {
+		var source SourceIdentity
+		if err := conn.QueryRowContext(ctx, `SELECT provider, configured_root_id,
+			source_key FROM outbox_generations WHERE capture_id = ?`, captureID,
+		).Scan(&source.Provider, &source.ConfiguredRootID, &source.SourceKey); err != nil {
+			return fmt.Errorf("rawcheckpoint: recover: read invalid source: %w", err)
+		}
+		seen[source] = struct{}{}
+	}
+	for source := range seen {
+		var headManifestID, headCaptureID string
+		if err := conn.QueryRowContext(ctx, `SELECT head_manifest_id, head_capture_id FROM raw_sources
+			WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+			string(source.Provider), source.ConfiguredRootID, source.SourceKey,
+		).Scan(&headManifestID, &headCaptureID); err != nil {
+			return fmt.Errorf("rawcheckpoint: recover: read acknowledged head: %w", err)
+		}
+		latest := ""
+		if headManifestID != "" {
+			latest = headCaptureID
+		}
+		if _, err := conn.ExecContext(ctx, `UPDATE raw_sources SET latest_capture_id = ?,
+			updated_at = ? WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+			latest, store.now().UTC().Format(time.RFC3339Nano),
+			string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
+			return fmt.Errorf("rawcheckpoint: recover: reset capture base: %w", err)
+		}
+		if err := setSourceCoverageDegradedConn(ctx, conn, source,
+			"missing_object", store.now().UTC()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hashCheckpointObject(ctx context.Context, path string) (string, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	buffer := make([]byte, 64<<10)
+	var length int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", length, err
+		}
+		read, readErr := file.Read(buffer)
+		if read > 0 {
+			written, writeErr := hash.Write(buffer[:read])
+			length += int64(written)
+			if writeErr != nil {
+				return "", length, writeErr
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return hex.EncodeToString(hash.Sum(nil)), length, nil
+			}
+			return "", length, readErr
+		}
+	}
+}

--- a/internal/rawcheckpoint/recovery.go
+++ b/internal/rawcheckpoint/recovery.go
@@ -71,6 +71,11 @@ func (s *Store) Recover(ctx context.Context) (RecoveryReport, error) {
 			broken = append(broken, ref)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		s.objectMu.Unlock()
+		return report, fmt.Errorf("rawcheckpoint: list recovery objects: %w", err)
+	}
 	if err := rows.Close(); err != nil {
 		s.objectMu.Unlock()
 		return report, fmt.Errorf("rawcheckpoint: list recovery objects: %w", err)
@@ -113,6 +118,10 @@ func (s *Store) Recover(ctx context.Context) (RecoveryReport, error) {
 				return fmt.Errorf("rawcheckpoint: recover: list stale reservations: %w", err)
 			}
 			interrupted = append(interrupted, source)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("rawcheckpoint: recover: list stale reservations: %w", err)
 		}
 		if err := rows.Close(); err != nil {
 			return fmt.Errorf("rawcheckpoint: recover: list stale reservations: %w", err)
@@ -225,6 +234,10 @@ func invalidGenerationSuffixConn(
 				return nil, fmt.Errorf("rawcheckpoint: find broken generation suffix: %w", err)
 			}
 			invalid[captureID] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("rawcheckpoint: find broken generation suffix: %w", err)
 		}
 		if err := rows.Close(); err != nil {
 			return nil, fmt.Errorf("rawcheckpoint: find broken generation suffix: %w", err)

--- a/internal/rawcheckpoint/recovery.go
+++ b/internal/rawcheckpoint/recovery.go
@@ -29,6 +29,17 @@ type RecoveryReport struct {
 // behind any missing or wrong-sized referenced object. Acknowledged heads and
 // their retained append metadata never advance during recovery.
 func (s *Store) Recover(ctx context.Context) (RecoveryReport, error) {
+	s.publicationMu.Lock()
+	report, err := s.recoverObjectSpool(ctx)
+	s.publicationMu.Unlock()
+	if err != nil {
+		return report, err
+	}
+	report.Garbage, err = s.CollectGarbage(ctx)
+	return report, err
+}
+
+func (s *Store) recoverObjectSpool(ctx context.Context) (RecoveryReport, error) {
 	s.objectMu.Lock()
 	var report RecoveryReport
 	entries, err := os.ReadDir(s.CaptureTempDir())
@@ -178,8 +189,7 @@ func (s *Store) Recover(ctx context.Context) (RecoveryReport, error) {
 	if err != nil {
 		return report, err
 	}
-	report.Garbage, err = s.CollectGarbage(ctx)
-	return report, err
+	return report, nil
 }
 
 // VerifyObject performs explicit full-digest verification for one retained

--- a/internal/rawcheckpoint/recovery_test.go
+++ b/internal/rawcheckpoint/recovery_test.go
@@ -157,3 +157,22 @@ func TestVerifyObjectPerformsExplicitFullDigestCheck(t *testing.T) {
 
 	require.ErrorIs(t, err, rawsync.ErrInvalid)
 }
+
+func TestRecoverWaitsForActiveObjectPublication(t *testing.T) {
+	store, _ := openOutboxTestStore(t, 1<<20)
+	finishPublication := store.BeginObjectPublication()
+	result := make(chan error, 1)
+	go func() {
+		_, err := store.Recover(t.Context())
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		require.Failf(t, "recovery returned during publication", "error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	finishPublication()
+
+	require.NoError(t, <-result)
+}

--- a/internal/rawcheckpoint/recovery_test.go
+++ b/internal/rawcheckpoint/recovery_test.go
@@ -1,0 +1,116 @@
+package rawcheckpoint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestRecoverInvalidatesBrokenOfflineSuffixAndResetsAcknowledgedBase(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	firstRef := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, firstRef, []byte("abc"))
+	firstReservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	first := testCapturedGeneration(1, root, "", firstRef)
+	require.NoError(t, store.CommitCapture(t.Context(), firstReservation.ID, first))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	commit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
+		Generation: 1, Created: true,
+	}
+	require.NoError(t, store.BindFinalizedManifestID(
+		t.Context(), "device-a", first.CaptureID, commit.ManifestID,
+	))
+	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", first.CaptureID, commit)
+	require.NoError(t, err)
+
+	secondRef := rawsync.ObjectRef{SHA256: validCheckpointDigest(12), Length: 3}
+	thirdRef := rawsync.ObjectRef{SHA256: validCheckpointDigest(13), Length: 3}
+	installOutboxTestObject(t, store, secondRef, []byte("def"))
+	secondReservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	second := testCapturedGeneration(2, root, first.CaptureID, secondRef)
+	require.NoError(t, store.CommitCapture(t.Context(), secondReservation.ID, second))
+	installOutboxTestObject(t, store, thirdRef, []byte("ghi"))
+	thirdReservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	third := testCapturedGeneration(3, root, second.CaptureID, thirdRef)
+	require.NoError(t, store.CommitCapture(t.Context(), thirdReservation.ID, third))
+
+	require.NoError(t, os.WriteFile(store.ObjectPath(secondRef), []byte("broken"), 0o600))
+	temporary := filepath.Join(store.CaptureTempDir(), "stale.tmp")
+	require.NoError(t, os.WriteFile(temporary, []byte("stale"), 0o600))
+	orphan := filepath.Join(store.spoolDir, "objects", "sha256", "ff", validCheckpointDigest(15))
+	require.NoError(t, os.MkdirAll(filepath.Dir(orphan), 0o700))
+	require.NoError(t, os.WriteFile(orphan, []byte("orphan"), 0o600))
+	_, err = store.ReserveCapture(t.Context(), root.ID, 128)
+	require.NoError(t, err)
+
+	report, err := store.Recover(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.TemporaryFiles)
+	assert.Equal(t, 1, report.UnreferencedFiles)
+	assert.Equal(t, 1, report.Reservations)
+	assert.Equal(t, 2, report.InvalidGenerations)
+	assert.Equal(t, 2, report.Garbage.Objects)
+	assert.NoFileExists(t, temporary)
+	assert.NoFileExists(t, orphan)
+	assert.NoFileExists(t, store.ObjectPath(secondRef))
+	assert.NoFileExists(t, store.ObjectPath(thirdRef))
+
+	base, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, first.CaptureID, base.CaptureID)
+	assert.Equal(t, first.Entries, base.Entries)
+	assert.Equal(t, commit.Receipt, base.Head.Receipt)
+	_, ok, err = store.NextGeneration(t.Context())
+	require.NoError(t, err)
+	assert.False(t, ok)
+	head, ok, err := store.SourceHead(
+		t.Context(), first.Source.Provider, first.Source.ConfiguredRootID, first.Source.SourceKey,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, commit.Receipt, head.Receipt)
+	coverage, ok, err := store.Coverage(t.Context(), root.Provider, root.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, CoverageDegraded, coverage.State)
+	assert.Equal(t, "missing_object", coverage.Reason)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+	var generations int
+	require.NoError(t, store.db.QueryRow(`SELECT count(*) FROM outbox_generations`).Scan(
+		&generations,
+	))
+	assert.Zero(t, generations)
+}
+
+func TestVerifyObjectPerformsExplicitFullDigestCheck(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	require.NoError(t, store.VerifyObject(t.Context(), ref))
+	require.NoError(t, os.WriteFile(store.ObjectPath(ref), []byte("xyz"), 0o600))
+
+	err = store.VerifyObject(t.Context(), ref)
+
+	require.ErrorIs(t, err, rawsync.ErrInvalid)
+}

--- a/internal/rawcheckpoint/recovery_test.go
+++ b/internal/rawcheckpoint/recovery_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/rawsync"
 )
 
@@ -97,6 +99,47 @@ func TestRecoverInvalidatesBrokenOfflineSuffixAndResetsAcknowledgedBase(t *testi
 		&generations,
 	))
 	assert.Zero(t, generations)
+}
+
+func TestOpenRecoversInterruptedSourceReservationAsCoverageGap(t *testing.T) {
+	base := t.TempDir()
+	checkpointPath := filepath.Join(base, "checkpoint.db")
+	spoolDir := filepath.Join(base, "spool")
+	sourceRoot := filepath.Join(base, "sources")
+	require.NoError(t, os.MkdirAll(sourceRoot, 0o755))
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	options := Options{
+		SpoolDir: spoolDir, MaxOutboxBytes: 1 << 20,
+		Now: func() time.Time { return now },
+	}
+	store, err := OpenWithOptions(t.Context(), checkpointPath, options)
+	require.NoError(t, err)
+	root, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, sourceRoot)
+	require.NoError(t, err)
+	source := SourceIdentity{
+		Provider: root.Provider, ConfiguredRootID: root.ID, SourceKey: "source-a",
+	}
+	_, err = store.ReserveSourceCapture(t.Context(), source, 128)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	reopened, err := OpenWithOptions(t.Context(), checkpointPath, options)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+	usage, err := reopened.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, usage.ReservedBytes)
+	coverage, ok, err := reopened.Coverage(t.Context(), root.Provider, root.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, CoverageDegraded, coverage.State)
+	assert.Equal(t, "capture_interrupted", coverage.Reason)
+	var failureReason string
+	require.NoError(t, reopened.db.QueryRow(`SELECT reason FROM raw_coverage_failures
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+		string(source.Provider), source.ConfiguredRootID, source.SourceKey,
+	).Scan(&failureReason))
+	assert.Equal(t, "capture_interrupted", failureReason)
 }
 
 func TestVerifyObjectPerformsExplicitFullDigestCheck(t *testing.T) {

--- a/internal/rawcheckpoint/rows_error_test.go
+++ b/internal/rawcheckpoint/rows_error_test.go
@@ -100,6 +100,13 @@ func (c *rowErrorConn) QueryContext(
 			err:     errInjectedRowIteration,
 		}, nil
 	case strings.Contains(query, "state = 'garbage_pending'"):
+		if c.scenario.mode == "garbage_objects" {
+			return &rowErrorRows{
+				columns: []string{"sha256", "length"},
+				values:  [][]driver.Value{{validCheckpointDigest(1), int64(1)}},
+				err:     errInjectedRowIteration,
+			}, nil
+		}
 		return &rowErrorRows{columns: []string{"sha256", "length"}}, nil
 	default:
 		return nil, fmt.Errorf("unexpected query for %s: %s", c.scenario.mode, query)
@@ -215,4 +222,18 @@ func TestReleaseGenerationObjectsStopsBeforeUpdatesOnIterationError(t *testing.T
 
 	assert.ErrorIs(t, err, errInjectedRowIteration)
 	assert.Zero(t, scenario.objectUpdates.Load())
+}
+
+func TestCollectGarbageStopsBeforeFileRemovalOnIterationError(t *testing.T) {
+	db, _ := openRowErrorDB(t, "garbage_objects")
+	store := &Store{db: db, spoolDir: t.TempDir()}
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(1), Length: 1}
+	path := store.ObjectPath(ref)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte{1}, 0o600))
+
+	_, err := store.CollectGarbage(t.Context())
+
+	assert.ErrorIs(t, err, errInjectedRowIteration)
+	assert.FileExists(t, path)
 }

--- a/internal/rawcheckpoint/rows_error_test.go
+++ b/internal/rawcheckpoint/rows_error_test.go
@@ -1,0 +1,218 @@
+package rawcheckpoint
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+var errInjectedRowIteration = errors.New("injected row iteration failure")
+
+const rowErrorDriverName = "rawcheckpoint_row_error"
+
+var (
+	rowErrorDriverOnce sync.Once
+	rowErrorSequence   atomic.Int64
+	rowErrorScenarios  sync.Map
+)
+
+type rowErrorScenario struct {
+	mode               string
+	reservationDeletes atomic.Int64
+	objectUpdates      atomic.Int64
+}
+
+type rowErrorDriver struct{}
+
+func (rowErrorDriver) Open(name string) (driver.Conn, error) {
+	value, ok := rowErrorScenarios.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("unknown row error scenario %q", name)
+	}
+	return &rowErrorConn{scenario: value.(*rowErrorScenario)}, nil
+}
+
+type rowErrorConn struct {
+	scenario *rowErrorScenario
+}
+
+func (*rowErrorConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare is not supported")
+}
+
+func (*rowErrorConn) Close() error { return nil }
+
+func (*rowErrorConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("driver transactions are not supported")
+}
+
+func (c *rowErrorConn) QueryContext(
+	_ context.Context,
+	query string,
+	_ []driver.NamedValue,
+) (driver.Rows, error) {
+	switch {
+	case strings.Contains(query, "SELECT sha256, length, state FROM outbox_objects"):
+		if c.scenario.mode == "recovery_objects" {
+			return &rowErrorRows{
+				columns: []string{"sha256", "length", "state"},
+				values:  [][]driver.Value{{validCheckpointDigest(1), int64(1), "live"}},
+				err:     errInjectedRowIteration,
+			}, nil
+		}
+		return &rowErrorRows{columns: []string{"sha256", "length", "state"}}, nil
+	case strings.Contains(query, "FROM outbox_reservations"):
+		if c.scenario.mode == "recovery_reservations" {
+			return &rowErrorRows{
+				columns: []string{"provider", "configured_root_id", "source_key"},
+				values:  [][]driver.Value{{"claude", "root-a", "source-a"}},
+				err:     errInjectedRowIteration,
+			}, nil
+		}
+		return &rowErrorRows{
+			columns: []string{"provider", "configured_root_id", "source_key"},
+		}, nil
+	case strings.Contains(query, "WITH RECURSIVE suffix"):
+		return &rowErrorRows{
+			columns: []string{"capture_id"},
+			values:  [][]driver.Value{{"capture-a"}},
+			err:     errInjectedRowIteration,
+		}, nil
+	case strings.Contains(query, "FROM outbox_entry_objects"):
+		return &rowErrorRows{
+			columns: []string{"sha256", "length", "count"},
+			values:  [][]driver.Value{{validCheckpointDigest(1), int64(1), int64(1)}},
+			err:     errInjectedRowIteration,
+		}, nil
+	case strings.Contains(query, "state = 'garbage_pending'"):
+		return &rowErrorRows{columns: []string{"sha256", "length"}}, nil
+	default:
+		return nil, fmt.Errorf("unexpected query for %s: %s", c.scenario.mode, query)
+	}
+}
+
+func (c *rowErrorConn) ExecContext(
+	_ context.Context,
+	query string,
+	_ []driver.NamedValue,
+) (driver.Result, error) {
+	switch {
+	case query == "BEGIN IMMEDIATE", query == "COMMIT", query == "ROLLBACK":
+	case strings.Contains(query, "INSERT INTO raw_coverage_failures"):
+	case strings.Contains(query, "INSERT INTO raw_coverage"):
+	case strings.Contains(query, "DELETE FROM outbox_reservations"):
+		c.scenario.reservationDeletes.Add(1)
+	case strings.Contains(query, "UPDATE outbox_objects"):
+		c.scenario.objectUpdates.Add(1)
+	default:
+		return nil, fmt.Errorf("unexpected exec for %s: %s", c.scenario.mode, query)
+	}
+	return driver.RowsAffected(1), nil
+}
+
+type rowErrorRows struct {
+	columns []string
+	values  [][]driver.Value
+	err     error
+	index   int
+}
+
+func (r *rowErrorRows) Columns() []string { return r.columns }
+
+func (*rowErrorRows) Close() error { return nil }
+
+func (r *rowErrorRows) Next(dest []driver.Value) error {
+	if r.index < len(r.values) {
+		copy(dest, r.values[r.index])
+		r.index++
+		return nil
+	}
+	if r.err != nil {
+		return r.err
+	}
+	return io.EOF
+}
+
+func openRowErrorDB(t *testing.T, mode string) (*sql.DB, *rowErrorScenario) {
+	t.Helper()
+	rowErrorDriverOnce.Do(func() { sql.Register(rowErrorDriverName, rowErrorDriver{}) })
+	scenario := &rowErrorScenario{mode: mode}
+	name := fmt.Sprintf("%s-%d", mode, rowErrorSequence.Add(1))
+	rowErrorScenarios.Store(name, scenario)
+	t.Cleanup(func() { rowErrorScenarios.Delete(name) })
+	db, err := sql.Open(rowErrorDriverName, name)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	return db, scenario
+}
+
+func TestRecoverStopsBeforeSpoolSweepOnObjectIterationError(t *testing.T) {
+	db, _ := openRowErrorDB(t, "recovery_objects")
+	store := &Store{
+		db: db, spoolDir: t.TempDir(), now: func() time.Time { return time.Unix(0, 0) },
+	}
+	known := rawsync.ObjectRef{SHA256: validCheckpointDigest(1), Length: 1}
+	omitted := rawsync.ObjectRef{SHA256: validCheckpointDigest(2), Length: 1}
+	for _, ref := range []rawsync.ObjectRef{known, omitted} {
+		path := store.ObjectPath(ref)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte{1}, 0o600))
+	}
+
+	_, err := store.Recover(t.Context())
+
+	assert.ErrorIs(t, err, errInjectedRowIteration)
+	assert.FileExists(t, store.ObjectPath(omitted))
+}
+
+func TestRecoverPreservesReservationsOnIterationError(t *testing.T) {
+	db, scenario := openRowErrorDB(t, "recovery_reservations")
+	store := &Store{
+		db: db, spoolDir: t.TempDir(), now: func() time.Time { return time.Unix(0, 0) },
+	}
+
+	_, err := store.Recover(t.Context())
+
+	assert.ErrorIs(t, err, errInjectedRowIteration)
+	assert.Zero(t, scenario.reservationDeletes.Load())
+}
+
+func TestInvalidGenerationSuffixRejectsIterationError(t *testing.T) {
+	db, _ := openRowErrorDB(t, "invalid_suffix")
+	conn, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	_, err = invalidGenerationSuffixConn(t.Context(), conn, []rawsync.ObjectRef{{
+		SHA256: validCheckpointDigest(1), Length: 1,
+	}})
+
+	assert.ErrorIs(t, err, errInjectedRowIteration)
+}
+
+func TestReleaseGenerationObjectsStopsBeforeUpdatesOnIterationError(t *testing.T) {
+	db, scenario := openRowErrorDB(t, "release_objects")
+	conn, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	err = releaseGenerationObjectsConn(t.Context(), conn, "capture-a")
+
+	assert.ErrorIs(t, err, errInjectedRowIteration)
+	assert.Zero(t, scenario.objectUpdates.Load())
+}

--- a/internal/rawcheckpoint/schema.go
+++ b/internal/rawcheckpoint/schema.go
@@ -229,6 +229,24 @@ var versionFourMigrationStatements = []string{
 			AND generation.manifest_id = raw_sources.head_manifest_id
 		LIMIT 1
 	), '')`,
+	`UPDATE outbox_objects SET ref_count = ref_count - (
+		SELECT count(*) FROM outbox_entry_objects AS entry_object
+		JOIN outbox_generations AS generation
+			ON generation.capture_id = entry_object.capture_id
+		WHERE generation.state IN ('invalid', 'acknowledged')
+			AND entry_object.sha256 = outbox_objects.sha256
+			AND entry_object.length = outbox_objects.length
+	)
+	WHERE EXISTS (
+		SELECT 1 FROM outbox_entry_objects AS entry_object
+		JOIN outbox_generations AS generation
+			ON generation.capture_id = entry_object.capture_id
+		WHERE generation.state IN ('invalid', 'acknowledged')
+			AND entry_object.sha256 = outbox_objects.sha256
+			AND entry_object.length = outbox_objects.length
+	)`,
+	`UPDATE outbox_objects SET state = 'garbage_pending'
+		WHERE ref_count = 0 AND state != 'remote'`,
 	`DELETE FROM outbox_generations WHERE state = 'invalid'`,
 	`UPDATE outbox_generations SET predecessor_capture_id = NULL
 		WHERE predecessor_capture_id IN (

--- a/internal/rawcheckpoint/schema.go
+++ b/internal/rawcheckpoint/schema.go
@@ -262,6 +262,11 @@ var versionFourMigrationStatements = []string{
 			SELECT capture_id FROM outbox_generations WHERE state = 'acknowledged'
 		)`,
 	`DELETE FROM outbox_generations WHERE state = 'acknowledged'`,
+	`UPDATE raw_sources SET latest_capture_id = head_capture_id
+		WHERE latest_capture_id != '' AND NOT EXISTS (
+			SELECT 1 FROM outbox_generations AS generation
+			WHERE generation.capture_id = raw_sources.latest_capture_id
+		)`,
 }
 
 var versionFiveMigrationStatements = []string{

--- a/internal/rawcheckpoint/schema.go
+++ b/internal/rawcheckpoint/schema.go
@@ -1,0 +1,256 @@
+package rawcheckpoint
+
+import (
+	"context"
+	"fmt"
+)
+
+const schemaVersion = 5
+
+func (s *Store) init(ctx context.Context) error {
+	var version int
+	if err := s.db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&version); err != nil {
+		return fmt.Errorf("rawcheckpoint: read schema version: %w", err)
+	}
+	if version > schemaVersion {
+		return fmt.Errorf("rawcheckpoint: database schema %d is newer than supported %d",
+			version, schemaVersion)
+	}
+	if version == schemaVersion {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: begin schema: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, statement := range versionOneSchemaStatements {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("rawcheckpoint: create base schema: %w", err)
+		}
+	}
+	if version < 2 {
+		for _, statement := range versionTwoMigrationStatements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("rawcheckpoint: migrate schema to version 2: %w", err)
+			}
+		}
+	}
+	if version < 3 {
+		for _, statement := range versionThreeMigrationStatements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("rawcheckpoint: migrate schema to version 3: %w", err)
+			}
+		}
+	}
+	if version < 4 {
+		for _, statement := range versionFourMigrationStatements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("rawcheckpoint: migrate schema to version 4: %w", err)
+			}
+		}
+	}
+	if version < 5 {
+		for _, statement := range versionFiveMigrationStatements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("rawcheckpoint: migrate schema to version 5: %w", err)
+			}
+		}
+	}
+	if _, err := tx.ExecContext(ctx,
+		fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
+		return fmt.Errorf("rawcheckpoint: set schema version: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("rawcheckpoint: commit schema: %w", err)
+	}
+	return nil
+}
+
+var versionOneSchemaStatements = []string{
+	`CREATE TABLE IF NOT EXISTS device_config (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		device_id TEXT NOT NULL,
+		created_at TEXT NOT NULL
+	)`,
+	`CREATE TABLE IF NOT EXISTS raw_sources (
+		provider TEXT NOT NULL,
+		configured_root_id TEXT NOT NULL,
+		source_key TEXT NOT NULL,
+		head_manifest_id TEXT NOT NULL DEFAULT '',
+		head_receipt TEXT NOT NULL DEFAULT '',
+		head_generation INTEGER NOT NULL DEFAULT 0,
+		updated_at TEXT NOT NULL,
+		PRIMARY KEY (provider, configured_root_id, source_key)
+	)`,
+}
+
+var versionTwoMigrationStatements = []string{
+	`ALTER TABLE raw_sources ADD COLUMN latest_capture_id TEXT NOT NULL DEFAULT ''`,
+	`CREATE TABLE configured_roots (
+		id TEXT PRIMARY KEY,
+		provider TEXT NOT NULL,
+		local_root TEXT NOT NULL,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		UNIQUE (provider, local_root)
+	)`,
+	`CREATE TABLE outbox_reservations (
+		id TEXT PRIMARY KEY,
+		configured_root_id TEXT NOT NULL,
+		reserved_bytes INTEGER NOT NULL CHECK (reserved_bytes >= 0),
+		created_at TEXT NOT NULL,
+		FOREIGN KEY (configured_root_id) REFERENCES configured_roots(id) ON DELETE CASCADE
+	)`,
+	`CREATE TABLE outbox_objects (
+		sha256 TEXT NOT NULL,
+		length INTEGER NOT NULL CHECK (length >= 0),
+		spool_name TEXT NOT NULL,
+		ref_count INTEGER NOT NULL CHECK (ref_count >= 0),
+		state TEXT NOT NULL CHECK (state IN ('live', 'garbage_pending', 'remote')),
+		created_at TEXT NOT NULL,
+		PRIMARY KEY (sha256, length)
+	)`,
+	`CREATE TABLE outbox_generations (
+		capture_id TEXT PRIMARY KEY,
+		provider TEXT NOT NULL,
+		configured_root_id TEXT NOT NULL,
+		source_key TEXT NOT NULL,
+		predecessor_capture_id TEXT,
+		captured_at TEXT NOT NULL,
+		kind TEXT NOT NULL CHECK (kind IN ('snapshot', 'tombstone')),
+		state TEXT NOT NULL CHECK (state IN ('queued', 'finalized', 'acknowledged', 'invalid')),
+		expected_parent_receipt TEXT NOT NULL DEFAULT '',
+		manifest_id TEXT NOT NULL DEFAULT '',
+		ack_receipt TEXT NOT NULL DEFAULT '',
+		ack_generation INTEGER NOT NULL DEFAULT 0,
+		metadata_bytes INTEGER NOT NULL CHECK (metadata_bytes >= 0),
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		FOREIGN KEY (configured_root_id) REFERENCES configured_roots(id),
+		FOREIGN KEY (predecessor_capture_id) REFERENCES outbox_generations(capture_id) ON DELETE CASCADE,
+		UNIQUE (provider, configured_root_id, source_key, capture_id)
+	)`,
+	`CREATE TABLE outbox_entries (
+		capture_id TEXT NOT NULL,
+		entry_ordinal INTEGER NOT NULL CHECK (entry_ordinal >= 0),
+		path TEXT NOT NULL,
+		length INTEGER NOT NULL CHECK (length >= 0),
+		mod_time_ns INTEGER NOT NULL,
+		file_identity TEXT NOT NULL,
+		prefix_sha256 TEXT NOT NULL,
+		appendable INTEGER NOT NULL CHECK (appendable IN (0, 1)),
+		PRIMARY KEY (capture_id, entry_ordinal),
+		UNIQUE (capture_id, path),
+		FOREIGN KEY (capture_id) REFERENCES outbox_generations(capture_id) ON DELETE CASCADE
+	)`,
+	`CREATE TABLE outbox_entry_objects (
+		capture_id TEXT NOT NULL,
+		entry_ordinal INTEGER NOT NULL,
+		object_ordinal INTEGER NOT NULL CHECK (object_ordinal >= 0),
+		sha256 TEXT NOT NULL,
+		length INTEGER NOT NULL CHECK (length >= 0),
+		PRIMARY KEY (capture_id, entry_ordinal, object_ordinal),
+		FOREIGN KEY (capture_id, entry_ordinal)
+			REFERENCES outbox_entries(capture_id, entry_ordinal) ON DELETE CASCADE,
+		FOREIGN KEY (sha256, length)
+			REFERENCES outbox_objects(sha256, length)
+	)`,
+	`CREATE TABLE raw_source_base_entries (
+		provider TEXT NOT NULL,
+		configured_root_id TEXT NOT NULL,
+		source_key TEXT NOT NULL,
+		entry_ordinal INTEGER NOT NULL CHECK (entry_ordinal >= 0),
+		path TEXT NOT NULL,
+		length INTEGER NOT NULL CHECK (length >= 0),
+		mod_time_ns INTEGER NOT NULL,
+		file_identity TEXT NOT NULL,
+		prefix_sha256 TEXT NOT NULL,
+		appendable INTEGER NOT NULL CHECK (appendable IN (0, 1)),
+		PRIMARY KEY (provider, configured_root_id, source_key, entry_ordinal),
+		UNIQUE (provider, configured_root_id, source_key, path),
+		FOREIGN KEY (configured_root_id) REFERENCES configured_roots(id)
+	)`,
+	`CREATE TABLE raw_source_base_objects (
+		provider TEXT NOT NULL,
+		configured_root_id TEXT NOT NULL,
+		source_key TEXT NOT NULL,
+		entry_ordinal INTEGER NOT NULL,
+		object_ordinal INTEGER NOT NULL CHECK (object_ordinal >= 0),
+		sha256 TEXT NOT NULL,
+		length INTEGER NOT NULL CHECK (length >= 0),
+		PRIMARY KEY (
+			provider, configured_root_id, source_key, entry_ordinal, object_ordinal
+		),
+		FOREIGN KEY (provider, configured_root_id, source_key, entry_ordinal)
+			REFERENCES raw_source_base_entries(
+				provider, configured_root_id, source_key, entry_ordinal
+			) ON DELETE CASCADE
+	)`,
+	`CREATE TABLE raw_coverage (
+		provider TEXT NOT NULL,
+		configured_root_id TEXT NOT NULL,
+		state TEXT NOT NULL CHECK (state IN ('complete', 'degraded')),
+		reason TEXT NOT NULL DEFAULT '',
+		degraded_at TEXT,
+		recovered_at TEXT,
+		updated_at TEXT NOT NULL,
+		PRIMARY KEY (provider, configured_root_id),
+		FOREIGN KEY (configured_root_id) REFERENCES configured_roots(id)
+	)`,
+	`CREATE INDEX outbox_generations_ready_idx
+		ON outbox_generations(state, captured_at, capture_id)`,
+	`CREATE INDEX outbox_generations_source_idx
+		ON outbox_generations(provider, configured_root_id, source_key, captured_at)`,
+	`CREATE INDEX outbox_objects_state_idx ON outbox_objects(state)`,
+}
+
+var versionThreeMigrationStatements = []string{
+	`ALTER TABLE outbox_generations
+		ADD COLUMN retry_at TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE outbox_generations
+		ADD COLUMN error_class TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE outbox_generations
+		ADD COLUMN blocked INTEGER NOT NULL DEFAULT 0 CHECK (blocked IN (0, 1))`,
+	`CREATE INDEX outbox_generations_due_idx
+		ON outbox_generations(blocked, retry_at, state, captured_at, capture_id)`,
+}
+
+var versionFourMigrationStatements = []string{
+	`ALTER TABLE raw_sources
+		ADD COLUMN head_capture_id TEXT NOT NULL DEFAULT ''`,
+	`UPDATE raw_sources SET head_capture_id = COALESCE((
+		SELECT generation.capture_id FROM outbox_generations AS generation
+		WHERE generation.provider = raw_sources.provider
+			AND generation.configured_root_id = raw_sources.configured_root_id
+			AND generation.source_key = raw_sources.source_key
+			AND generation.state = 'acknowledged'
+			AND generation.manifest_id = raw_sources.head_manifest_id
+		LIMIT 1
+	), '')`,
+	`DELETE FROM outbox_generations WHERE state = 'invalid'`,
+	`UPDATE outbox_generations SET predecessor_capture_id = NULL
+		WHERE predecessor_capture_id IN (
+			SELECT capture_id FROM outbox_generations WHERE state = 'acknowledged'
+		)`,
+	`DELETE FROM outbox_generations WHERE state = 'acknowledged'`,
+}
+
+var versionFiveMigrationStatements = []string{
+	`CREATE TABLE raw_coverage_failures (
+		provider TEXT NOT NULL,
+		configured_root_id TEXT NOT NULL,
+		source_key TEXT NOT NULL,
+		reason TEXT NOT NULL,
+		degraded_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		PRIMARY KEY (provider, configured_root_id, source_key),
+		FOREIGN KEY (configured_root_id) REFERENCES configured_roots(id) ON DELETE CASCADE
+	)`,
+	`INSERT INTO raw_coverage_failures
+		(provider, configured_root_id, source_key, reason, degraded_at, updated_at)
+		SELECT provider, configured_root_id, '', reason,
+			COALESCE(degraded_at, updated_at), updated_at
+		FROM raw_coverage WHERE state = 'degraded'`,
+}

--- a/internal/rawcheckpoint/schema.go
+++ b/internal/rawcheckpoint/schema.go
@@ -88,6 +88,10 @@ var versionOneSchemaStatements = []string{
 
 var versionTwoMigrationStatements = []string{
 	`ALTER TABLE raw_sources ADD COLUMN latest_capture_id TEXT NOT NULL DEFAULT ''`,
+	`CREATE TABLE outbox_config (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		spool_path TEXT NOT NULL
+	)`,
 	`CREATE TABLE configured_roots (
 		id TEXT PRIMARY KEY,
 		provider TEXT NOT NULL,

--- a/internal/rawcheckpoint/schema.go
+++ b/internal/rawcheckpoint/schema.go
@@ -98,7 +98,9 @@ var versionTwoMigrationStatements = []string{
 	)`,
 	`CREATE TABLE outbox_reservations (
 		id TEXT PRIMARY KEY,
+		provider TEXT NOT NULL,
 		configured_root_id TEXT NOT NULL,
+		source_key TEXT NOT NULL,
 		reserved_bytes INTEGER NOT NULL CHECK (reserved_bytes >= 0),
 		created_at TEXT NOT NULL,
 		FOREIGN KEY (configured_root_id) REFERENCES configured_roots(id) ON DELETE CASCADE
@@ -229,20 +231,27 @@ var versionFourMigrationStatements = []string{
 			AND generation.manifest_id = raw_sources.head_manifest_id
 		LIMIT 1
 	), '')`,
-	`UPDATE outbox_objects SET ref_count = ref_count - (
+	`WITH RECURSIVE invalid_suffix(capture_id) AS (
+		SELECT capture_id FROM outbox_generations WHERE state = 'invalid'
+		UNION
+		SELECT generation.capture_id FROM outbox_generations AS generation
+		JOIN invalid_suffix
+			ON generation.predecessor_capture_id = invalid_suffix.capture_id
+	), discarded(capture_id) AS (
+		SELECT capture_id FROM invalid_suffix
+		UNION
+		SELECT capture_id FROM outbox_generations WHERE state = 'acknowledged'
+	)
+	UPDATE outbox_objects SET ref_count = ref_count - (
 		SELECT count(*) FROM outbox_entry_objects AS entry_object
-		JOIN outbox_generations AS generation
-			ON generation.capture_id = entry_object.capture_id
-		WHERE generation.state IN ('invalid', 'acknowledged')
-			AND entry_object.sha256 = outbox_objects.sha256
+		JOIN discarded ON discarded.capture_id = entry_object.capture_id
+		WHERE entry_object.sha256 = outbox_objects.sha256
 			AND entry_object.length = outbox_objects.length
 	)
 	WHERE EXISTS (
 		SELECT 1 FROM outbox_entry_objects AS entry_object
-		JOIN outbox_generations AS generation
-			ON generation.capture_id = entry_object.capture_id
-		WHERE generation.state IN ('invalid', 'acknowledged')
-			AND entry_object.sha256 = outbox_objects.sha256
+		JOIN discarded ON discarded.capture_id = entry_object.capture_id
+		WHERE entry_object.sha256 = outbox_objects.sha256
 			AND entry_object.length = outbox_objects.length
 	)`,
 	`UPDATE outbox_objects SET state = 'garbage_pending'

--- a/internal/rawcheckpoint/store.go
+++ b/internal/rawcheckpoint/store.go
@@ -37,6 +37,12 @@ type Store struct {
 	processLocks   []*flock.Flock
 }
 
+const checkpointTimeLayout = "2006-01-02T15:04:05.000000000Z"
+
+func checkpointTimestamp(value time.Time) string {
+	return value.UTC().Format(checkpointTimeLayout)
+}
+
 // BeginObjectPublication serializes the interval in which a capturer can
 // install unpublished objects and either commit or discard them.
 func (s *Store) BeginObjectPublication() func() {
@@ -124,7 +130,7 @@ func (s *Store) SetDevice(ctx context.Context, deviceID string) error {
 		case errors.Is(err, sql.ErrNoRows):
 			if _, err := conn.ExecContext(ctx,
 				`INSERT INTO device_config (id, device_id, created_at) VALUES (1, ?, ?)`,
-				deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+				deviceID, checkpointTimestamp(s.now())); err != nil {
 				return fmt.Errorf("rawcheckpoint: set device: %w", err)
 			}
 		case err != nil:
@@ -135,7 +141,7 @@ func (s *Store) SetDevice(ctx context.Context, deviceID string) error {
 			reset = true
 			if _, err := conn.ExecContext(ctx,
 				`UPDATE device_config SET device_id = ?, created_at = ? WHERE id = 1`,
-				deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+				deviceID, checkpointTimestamp(s.now())); err != nil {
 				return fmt.Errorf("rawcheckpoint: set device: %w", err)
 			}
 			if _, err := conn.ExecContext(ctx,
@@ -265,7 +271,7 @@ func (s *Store) AdvanceHead(
 				VALUES (?, ?, ?, ?, ?, ?, ?)`,
 				string(provider), configuredRootID, sourceKey,
 				commit.ManifestID, commit.Receipt, commit.Generation,
-				time.Now().UTC().Format(time.RFC3339Nano))
+				checkpointTimestamp(s.now()))
 			if err != nil {
 				return fmt.Errorf("rawcheckpoint: advance head: %w", err)
 			}
@@ -287,7 +293,7 @@ func (s *Store) AdvanceHead(
 			head_manifest_id = ?, head_receipt = ?, head_generation = ?, updated_at = ?
 			WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
 			commit.ManifestID, commit.Receipt, commit.Generation,
-			time.Now().UTC().Format(time.RFC3339Nano),
+			checkpointTimestamp(s.now()),
 			string(provider), configuredRootID, sourceKey)
 		if err != nil {
 			return fmt.Errorf("rawcheckpoint: advance head: %w", err)

--- a/internal/rawcheckpoint/store.go
+++ b/internal/rawcheckpoint/store.go
@@ -9,13 +9,14 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
+
+	"github.com/gofrs/flock"
 
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/rawsync"
 )
-
-const schemaVersion = 1
 
 // SourceHead is the last server-acknowledged head of one logical source.
 type SourceHead struct {
@@ -27,7 +28,20 @@ type SourceHead struct {
 
 // Store is the durable checkpoint database.
 type Store struct {
-	db *sql.DB
+	db             *sql.DB
+	spoolDir       string
+	maxOutboxBytes int64
+	now            func() time.Time
+	objectMu       sync.Mutex
+	publicationMu  sync.Mutex
+	processLocks   []*flock.Flock
+}
+
+// BeginObjectPublication serializes the interval in which a capturer can
+// install unpublished objects and either commit or discard them.
+func (s *Store) BeginObjectPublication() func() {
+	s.publicationMu.Lock()
+	return s.publicationMu.Unlock
 }
 
 func (s *Store) withImmediateWrite(
@@ -73,65 +87,24 @@ var ErrDeviceMismatch = errors.New(
 
 // Open opens (creating if needed) the checkpoint database at path.
 func Open(ctx context.Context, path string) (*Store, error) {
+	return OpenWithOptions(ctx, path, Options{})
+}
+
+func openCheckpointDB(path string) (*sql.DB, error) {
 	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
 	if err != nil {
 		return nil, fmt.Errorf("rawcheckpoint: open: %w", err)
 	}
-	store := &Store{db: db}
-	if err := store.init(ctx); err != nil {
-		db.Close()
-		return nil, err
-	}
-	return store, nil
-}
-
-func (s *Store) init(ctx context.Context) error {
-	var version int
-	if err := s.db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&version); err != nil {
-		return fmt.Errorf("rawcheckpoint: read schema version: %w", err)
-	}
-	if version > schemaVersion {
-		return fmt.Errorf("rawcheckpoint: database schema %d is newer than supported %d",
-			version, schemaVersion)
-	}
-	if version == schemaVersion {
-		return nil
-	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("rawcheckpoint: begin schema: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	for _, statement := range []string{
-		`CREATE TABLE IF NOT EXISTS device_config (
-			id INTEGER PRIMARY KEY CHECK (id = 1),
-			device_id TEXT NOT NULL,
-			created_at TEXT NOT NULL
-		)`,
-		`CREATE TABLE IF NOT EXISTS raw_sources (
-			provider TEXT NOT NULL,
-			configured_root_id TEXT NOT NULL,
-			source_key TEXT NOT NULL,
-			head_manifest_id TEXT NOT NULL DEFAULT '',
-			head_receipt TEXT NOT NULL DEFAULT '',
-			head_generation INTEGER NOT NULL DEFAULT 0,
-			updated_at TEXT NOT NULL,
-			PRIMARY KEY (provider, configured_root_id, source_key)
-		)`,
-	} {
-		if _, err := tx.ExecContext(ctx, statement); err != nil {
-			return fmt.Errorf("rawcheckpoint: create schema: %w", err)
-		}
-	}
-	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
-		return fmt.Errorf("rawcheckpoint: set schema version: %w", err)
-	}
-	return tx.Commit()
+	return db, nil
 }
 
 // Close releases the database handle.
-func (s *Store) Close() error { return s.db.Close() }
+func (s *Store) Close() error {
+	dbErr := s.db.Close()
+	lockErr := releaseStoreLocks(s.processLocks)
+	s.processLocks = nil
+	return errors.Join(dbErr, lockErr)
+}
 
 // SetDevice records this laptop's device identity, replacing any previously
 // recorded value so re-provisioning overwrites instead of failing. Changing
@@ -142,7 +115,8 @@ func (s *Store) SetDevice(ctx context.Context, deviceID string) error {
 	if deviceID == "" {
 		return fmt.Errorf("rawcheckpoint: device ID is required")
 	}
-	return s.withImmediateWrite(ctx, "set device", func(conn *sql.Conn) error {
+	reset := false
+	err := s.withImmediateWrite(ctx, "set device", func(conn *sql.Conn) error {
 		var current string
 		err := conn.QueryRowContext(ctx,
 			`SELECT device_id FROM device_config WHERE id = 1`).Scan(&current)
@@ -158,17 +132,40 @@ func (s *Store) SetDevice(ctx context.Context, deviceID string) error {
 		case current == deviceID:
 			return nil
 		default:
+			reset = true
 			if _, err := conn.ExecContext(ctx,
 				`UPDATE device_config SET device_id = ?, created_at = ? WHERE id = 1`,
 				deviceID, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
 				return fmt.Errorf("rawcheckpoint: set device: %w", err)
 			}
-			if _, err := conn.ExecContext(ctx, `DELETE FROM raw_sources`); err != nil {
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE outbox_objects SET ref_count = 0, state = 'garbage_pending'`); err != nil {
+				return fmt.Errorf("rawcheckpoint: set device: %w", err)
+			}
+			for _, statement := range []string{
+				`DELETE FROM outbox_generations`,
+				`DELETE FROM outbox_reservations`,
+				`DELETE FROM raw_source_base_entries`,
+				`DELETE FROM raw_coverage_failures`,
+				`DELETE FROM raw_coverage`,
+				`DELETE FROM raw_sources`,
+			} {
+				if _, err := conn.ExecContext(ctx, statement); err != nil {
+					return fmt.Errorf("rawcheckpoint: set device: %w", err)
+				}
+			}
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE outbox_objects SET state = 'garbage_pending' WHERE ref_count = 0`); err != nil {
 				return fmt.Errorf("rawcheckpoint: set device: %w", err)
 			}
 		}
 		return nil
 	})
+	if err != nil || !reset {
+		return err
+	}
+	_, err = s.CollectGarbage(ctx)
+	return err
 }
 
 // Device returns the recorded device identity and whether one has been set.

--- a/internal/rawclient/upload.go
+++ b/internal/rawclient/upload.go
@@ -36,20 +36,22 @@ func (c *Client) MissingObjects(
 	objects []rawsync.ObjectRef,
 ) ([]rawsync.ObjectRef, error) {
 	positions := make(map[rawsync.ObjectRef]int, len(objects))
-	for i, object := range objects {
+	unique := make([]rawsync.ObjectRef, 0, len(objects))
+	for _, object := range objects {
 		canonical, err := rawsync.NewObjectRef(object.SHA256, object.Length)
 		if err != nil || canonical != object {
 			return nil, fmt.Errorf("rawclient: invalid missing object request")
 		}
 		if _, duplicate := positions[object]; duplicate {
-			return nil, fmt.Errorf("rawclient: invalid missing object request: duplicate object")
+			continue
 		}
-		positions[object] = i
+		positions[object] = len(unique)
+		unique = append(unique, object)
 	}
 	body := struct {
 		Provider parser.AgentType    `json:"provider"`
 		Objects  []rawsync.ObjectRef `json:"objects"`
-	}{Provider: provider, Objects: objects}
+	}{Provider: provider, Objects: unique}
 	resp, err := c.do(ctx, http.MethodPost, "/api/v1/raw-sync/objects/missing", nil, body)
 	if err != nil {
 		return nil, err

--- a/internal/rawclient/upload.go
+++ b/internal/rawclient/upload.go
@@ -35,6 +35,17 @@ func (c *Client) MissingObjects(
 	provider parser.AgentType,
 	objects []rawsync.ObjectRef,
 ) ([]rawsync.ObjectRef, error) {
+	positions := make(map[rawsync.ObjectRef]int, len(objects))
+	for i, object := range objects {
+		canonical, err := rawsync.NewObjectRef(object.SHA256, object.Length)
+		if err != nil || canonical != object {
+			return nil, fmt.Errorf("rawclient: invalid missing object request")
+		}
+		if _, duplicate := positions[object]; duplicate {
+			return nil, fmt.Errorf("rawclient: invalid missing object request: duplicate object")
+		}
+		positions[object] = i
+	}
 	body := struct {
 		Provider parser.AgentType    `json:"provider"`
 		Objects  []rawsync.ObjectRef `json:"objects"`
@@ -49,6 +60,15 @@ func (c *Client) MissingObjects(
 	}
 	if err := jsonDecode(resp.Body, &out); err != nil {
 		return nil, fmt.Errorf("rawclient: decode missing objects: %w", err)
+	}
+	lastPosition := -1
+	for _, object := range out.Missing {
+		canonical, err := rawsync.NewObjectRef(object.SHA256, object.Length)
+		position, requested := positions[object]
+		if err != nil || canonical != object || !requested || position <= lastPosition {
+			return nil, fmt.Errorf("rawclient: invalid missing objects response")
+		}
+		lastPosition = position
 	}
 	return out.Missing, nil
 }

--- a/internal/rawclient/upload_test.go
+++ b/internal/rawclient/upload_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json/v2"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -62,6 +64,43 @@ func TestMissingObjectsRoundTrip(t *testing.T) {
 	require.Len(t, missing, 1)
 	assert.Equal(t, digest, missing[0].SHA256)
 	assert.Equal(t, int64(3), missing[0].Length)
+}
+
+func TestMissingObjectsRejectsResponseOutsideRequestedOrderedSubset(t *testing.T) {
+	t.Parallel()
+	first := rawsync.ObjectRef{SHA256: strings.Repeat("a", 64), Length: 1}
+	second := rawsync.ObjectRef{SHA256: strings.Repeat("b", 64), Length: 2}
+	unrelated := rawsync.ObjectRef{SHA256: strings.Repeat("c", 64), Length: 3}
+	for _, tc := range []struct {
+		name     string
+		response []rawsync.ObjectRef
+	}{
+		{name: "unrelated", response: []rawsync.ObjectRef{unrelated}},
+		{name: "duplicate", response: []rawsync.ObjectRef{first, first}},
+		{name: "reordered", response: []rawsync.ObjectRef{second, first}},
+		{name: "noncanonical", response: []rawsync.ObjectRef{{SHA256: "bad", Length: 1}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mux := withTokenRoute(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				payload, err := json.Marshal(struct {
+					Missing []rawsync.ObjectRef `json:"missing"`
+				}{Missing: tc.response})
+				assert.NoError(t, err)
+				_, _ = w.Write(payload)
+			}))
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+			client := newTestClient(t, server.URL, time.Minute)
+
+			_, err := client.MissingObjects(
+				t.Context(), parser.AgentClaude, []rawsync.ObjectRef{first, second},
+			)
+
+			require.ErrorContains(t, err, "invalid missing objects response")
+		})
+	}
 }
 
 // uploadScript is a scripted resumable-upload backend. startOffset is what

--- a/internal/rawclient/upload_test.go
+++ b/internal/rawclient/upload_test.go
@@ -58,8 +58,9 @@ func TestMissingObjectsRoundTrip(t *testing.T) {
 	t.Cleanup(server.Close)
 	client := newTestClient(t, server.URL, time.Minute)
 
+	object := rawsync.ObjectRef{SHA256: digest, Length: 3}
 	missing, err := client.MissingObjects(t.Context(), parser.AgentClaude,
-		[]rawsync.ObjectRef{{SHA256: digest, Length: 3}})
+		[]rawsync.ObjectRef{object, object})
 	require.NoError(t, err)
 	require.Len(t, missing, 1)
 	assert.Equal(t, digest, missing[0].SHA256)

--- a/internal/rawpath/path.go
+++ b/internal/rawpath/path.go
@@ -1,0 +1,54 @@
+// Package rawpath validates logical paths transported by hosted raw sync.
+package rawpath
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const DefaultMaxBytes = 4096
+
+var ErrInvalid = errors.New("invalid raw logical path")
+
+// Validate enforces the cross-platform relative-path contract used by capture
+// plans and raw manifests.
+func Validate(value string, maxBytes int) error {
+	if value == "" || len(value) > maxBytes || !utf8.ValidString(value) ||
+		path.IsAbs(value) || path.Clean(value) != value || value == "." ||
+		value == ".." || strings.HasPrefix(value, "../") ||
+		strings.ContainsRune(value, '\\') || platformUnsafe(value) {
+		return fmt.Errorf("%w: path is not canonical and relative", ErrInvalid)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%w: path contains a control character", ErrInvalid)
+		}
+	}
+	return nil
+}
+
+func platformUnsafe(value string) bool {
+	if strings.ContainsRune(value, ':') {
+		return true
+	}
+	for component := range strings.SplitSeq(value, "/") {
+		if strings.HasSuffix(component, ".") || strings.HasSuffix(component, " ") {
+			return true
+		}
+		base, _, _ := strings.Cut(component, ".")
+		upper := strings.ToUpper(base)
+		switch upper {
+		case "CON", "PRN", "AUX", "NUL", "CLOCK$", "CONIN$", "CONOUT$":
+			return true
+		}
+		if len(upper) == 4 && upper[3] >= '1' && upper[3] <= '9' &&
+			(upper[:3] == "COM" || upper[:3] == "LPT") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rawsync/manifest.go
+++ b/internal/rawsync/manifest.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json/v2"
 	"errors"
 	"fmt"
-	"path"
 	"slices"
 	"strings"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"unicode/utf8"
 
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawpath"
 )
 
 var (
@@ -202,6 +202,25 @@ func ValidateAndCanonicalize(
 	}, nil
 }
 
+// ValidateManifestForUpload applies server upload policy before local capture
+// commits bytes. It reserves the largest valid authentication envelope and a
+// future parent receipt so a queued manifest cannot become oversized later.
+func ValidateManifestForUpload(manifest Manifest, limits ManifestLimits) error {
+	prospective := manifest
+	if prospective.ExpectedParentReceipt == "" {
+		prospective.ExpectedParentReceipt = strings.Repeat("0", 64)
+	}
+	identity, err := NewAuthIdentity(
+		strings.Repeat(`"`, maxOpaqueIDBytes),
+		strings.Repeat(`"`, maxOpaqueIDBytes),
+	)
+	if err != nil {
+		return err
+	}
+	_, err = ValidateAndCanonicalize(identity, prospective, limits)
+	return err
+}
+
 // ValidateCanonicalManifest verifies canonical integrity without imposing a
 // deployment's policy limits a second time.
 func ValidateCanonicalManifest(manifest CanonicalManifest) error {
@@ -385,40 +404,10 @@ func validateEntries(manifest Manifest, limits ManifestLimits) ([]ObjectRef, err
 }
 
 func validateEntryPath(value string, maxBytes int) error {
-	if value == "" || len(value) > maxBytes || !utf8.ValidString(value) ||
-		path.IsAbs(value) || path.Clean(value) != value || value == "." ||
-		value == ".." || strings.HasPrefix(value, "../") ||
-		strings.ContainsRune(value, '\\') || isPlatformUnsafeEntryPath(value) {
-		return fmt.Errorf("%w: entry path is not a canonical relative path", ErrInvalid)
-	}
-	for _, r := range value {
-		if unicode.IsControl(r) {
-			return fmt.Errorf("%w: entry path contains a control character", ErrInvalid)
-		}
+	if err := rawpath.Validate(value, maxBytes); err != nil {
+		return fmt.Errorf("%w: entry path: %v", ErrInvalid, err)
 	}
 	return nil
-}
-
-func isPlatformUnsafeEntryPath(value string) bool {
-	if strings.ContainsRune(value, ':') {
-		return true
-	}
-	for component := range strings.SplitSeq(value, "/") {
-		if strings.HasSuffix(component, ".") || strings.HasSuffix(component, " ") {
-			return true
-		}
-		base, _, _ := strings.Cut(component, ".")
-		upper := strings.ToUpper(base)
-		switch upper {
-		case "CON", "PRN", "AUX", "NUL", "CLOCK$", "CONIN$", "CONOUT$":
-			return true
-		}
-		if len(upper) == 4 && upper[3] >= '1' && upper[3] <= '9' &&
-			(upper[:3] == "COM" || upper[:3] == "LPT") {
-			return true
-		}
-	}
-	return false
 }
 
 // validateProvider fails closed for providers the server cannot classify and

--- a/internal/rawsync/manifest_test.go
+++ b/internal/rawsync/manifest_test.go
@@ -209,6 +209,58 @@ func TestValidateAndCanonicalizeAcceptsEmptyTombstone(t *testing.T) {
 	assert.Empty(t, got.Manifest.Entries)
 }
 
+func TestValidateManifestForUploadAllowsProvisionalParentReceipt(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest()
+	manifest.ExpectedParentReceipt = ""
+
+	require.NoError(t, ValidateManifestForUpload(manifest, DefaultManifestLimits()))
+}
+
+func TestValidateManifestForUploadEnforcesProspectiveObjectLimit(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest()
+	limits := DefaultManifestLimits()
+	limits.MaxObjects = 2
+
+	err := ValidateManifestForUpload(manifest, limits)
+
+	require.ErrorIs(t, err, ErrInvalid)
+}
+
+func TestValidateManifestForUploadReservesWorstCaseEscapedAuthenticationIDs(t *testing.T) {
+	t.Parallel()
+
+	manifest := validManifest()
+	manifest.ExpectedParentReceipt = ""
+	prospective := cloneManifest(manifest)
+	prospective.ExpectedParentReceipt = strings.Repeat("0", 64)
+	asciiIdentity, err := NewAuthIdentity(
+		strings.Repeat("t", maxOpaqueIDBytes),
+		strings.Repeat("d", maxOpaqueIDBytes),
+	)
+	require.NoError(t, err)
+	ascii, err := ValidateAndCanonicalize(
+		asciiIdentity, prospective, DefaultManifestLimits(),
+	)
+	require.NoError(t, err)
+	limits := DefaultManifestLimits()
+	limits.MaxCanonicalBytes = len(ascii.CanonicalJSON)
+	escapedIdentity, err := NewAuthIdentity(
+		strings.Repeat(`"`, maxOpaqueIDBytes),
+		strings.Repeat(`"`, maxOpaqueIDBytes),
+	)
+	require.NoError(t, err)
+	_, err = ValidateAndCanonicalize(escapedIdentity, prospective, limits)
+	require.ErrorIs(t, err, ErrInvalid, "test limit must reject valid escaped IDs")
+
+	err = ValidateManifestForUpload(manifest, limits)
+
+	require.ErrorIs(t, err, ErrInvalid)
+}
+
 func validManifest() Manifest {
 	return Manifest{
 		SchemaVersion:    ManifestSchemaVersion,


### PR DESCRIPTION
## What changed

- Add provider-owned raw capture plans for Claude and Codex sources.
- Capture stable full snapshots and verified append suffixes without parsing raw content.
- Add a bounded, crash-safe outbox with ordered delivery, fenced acknowledgements, recovery, and compact terminal state.

## Why

This delivers the durable local capture layer needed before hosted raw sync can run continuously. Provider code remains responsible for physical source membership, while generic capture and checkpoint code enforce containment, stability, capacity, and server-chain ordering.

## Usage

There is no new runtime command in this slice. The new package APIs are ready for the uploader and scheduling work in the next stacked change.

Refs #1352

Stacked on #1498.
