### PR TITLE
test(ci): stop invoking retired release health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,6 @@ jobs:
           bash scripts/install_test.sh
           bash scripts/retry_test.sh
           bash scripts/e2e-server_test.sh
-          bash scripts/check_desktop_release_health_test.sh
-          bash scripts/check_desktop_release_health_from_event_test.sh
           bash desktop/scripts/test-repair-appimage-diricon.sh
 
   test:


### PR DESCRIPTION
Stop the scripts CI job from invoking two desktop release health tests that are
being retired with the repository-owned release automation. This lets the
release cleanup remove those scripts without leaving CI pointed at missing
files.
