### PR TITLE
feat(parser): ingest Posit Assistant usage-events sidecar

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1523,7 +1523,8 @@ add an archived or maintained mirror without replacing the original identity.
 ## Posit Assistant (`posit-assistant`)
 
 - **Format:** Workspace conversation directories containing `conversation.json`,
-  `lm-messages.jsonl`, and `ui-messages.jsonl`.
+  `lm-messages.jsonl`, `ui-messages.jsonl`, and an optional
+  `usage-events.jsonl` sidecar of auxiliary per-request usage.
 - **Evidence:** `no-public-source`.
 - **Upstream:** Posit's product documentation and the
   [posit-dev GitHub organization](https://github.com/posit-dev) were searched
@@ -1543,7 +1544,13 @@ add an archived or maintained mirror without replacing the original identity.
   families do not expose a separately billed cache-write category in the
   pricing catalog. Claude records retain real cache-write semantics.
   Agentsview catalog-prices these values; no provider-reported USD total is
-  consumed.
+  consumed. Auxiliary usage that never appears in the transcript —
+  cache-keepalive pings and classifier calls — is appended to
+  `usage-events.jsonl` as
+  `{"type":"usage","kind":"keepalive"|"classifier", "timestamp":…,"anchorMessageId":…,"providerId":…,"modelId":…, "inputTokens":…,"outputTokens":…,"totalTokens":…,"cacheReadTokens":…, "cacheWriteTokens":…}`
+  lines; subagent conversations carry their own sidecar. Observed on real
+  idle sessions: repeated keepalive pings whose spend is invisible in
+  `lm-messages.jsonl`.
 - **Agentsview:** `internal/parser/posit_assistant_provider.go`; current schema
   details are based on observed files and fixtures. Reverified 2026-08-22
   against the samples reported in
@@ -1553,7 +1560,12 @@ add an archived or maintained mirror without replacing the original identity.
   identities preserve Posit Assistant's original buckets, and full context
   remains the sum of the persisted input, cache-read, and cache-write fields.
   Data version 91 reparses existing Posit Assistant archives through the
-  normal non-destructive resync path.
+  normal non-destructive resync path. `usage-events.jsonl` lines are ingested
+  as request-scoped usage events (`posit-assistant-` + kind) with the same
+  model-family token normalization; the sidecar participates in the composite
+  fingerprint and changed-path classification so keepalive appends on
+  otherwise idle sessions trigger resync. Data version 92 reparses existing
+  archives to pick up sidecar spend.
 
 ## Z Code (`zcode`)
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1566,7 +1566,8 @@ add an archived or maintained mirror without replacing the original identity.
   fingerprint and changed-path classification so keepalive appends on
   otherwise idle sessions trigger resync. Data version 92 reparses existing
   archives to pick up sidecar spend. Conversations with valid sidecar usage
-  are retained even when they have no renderable transcript messages.
+  are retained even when they have no renderable transcript messages, and
+  newer sidecar timestamps extend the session end time.
 
 ## Z Code (`zcode`)
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1565,7 +1565,8 @@ add an archived or maintained mirror without replacing the original identity.
   model-family token normalization; the sidecar participates in the composite
   fingerprint and changed-path classification so keepalive appends on
   otherwise idle sessions trigger resync. Data version 92 reparses existing
-  archives to pick up sidecar spend.
+  archives to pick up sidecar spend. Conversations with valid sidecar usage
+  are retained even when they have no renderable transcript messages.
 
 ## Z Code (`zcode`)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -432,7 +432,10 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // the raw workspace path from history.jsonl as the project; re-parsing routes
 // it through the shared cwd normalizer so sessions from different git
 // worktrees of the same repo group under one project.)
-const dataVersion = 92
+// (93: Posit Assistant usage-events sidecar ingestion. Existing sessions
+// need re-parsing so keepalive and classifier spend recorded in
+// usage-events.jsonl reaches the usage_events table.)
+const dataVersion = 93
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1036,6 +1036,11 @@ func TestCurrentDataVersionPositAssistantCacheAccounting(t *testing.T) {
 		"version 91 is the data-version boundary for Posit Assistant cache accounting")
 }
 
+func TestCurrentDataVersionPositAssistantUsageEventsSidecar(t *testing.T) {
+	assert.Equal(t, 93, CurrentDataVersion(),
+		"Posit Assistant usage-events sidecar ingestion requires a sequential backfill")
+}
+
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "s-events", "proj")

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -1673,10 +1673,10 @@ func usageRowIsRequestScoped(
 
 // UsageSourceIsRequestScoped reports whether a usage source represents one
 // provider request even when the provider cannot attach it to a message.
+// The policy lives in usagefacts so fact construction and row scanning
+// cannot drift apart.
 func UsageSourceIsRequestScoped(source string) bool {
-	return source == "message" ||
-		source == "goose-request" ||
-		source == "deepseek-harness"
+	return usagefacts.SourceIsRequestScoped(source)
 }
 
 func recordComputedUsagePricing(

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	// Version 4 adds cache_creation_1h_tokens to version 3's historical-rate
-	// facts and prices the 1h-TTL cache-write subset at the catalog's 1h rate.
-	usageCacheFormatVersion = 4
+	// Version 5 rebuilds version 4 facts and rollups so Posit Assistant
+	// sidecar events use request-scoped pricing semantics.
+	usageCacheFormatVersion = 5
 	usageCacheApplicationID = 0x41565543
 	usageCacheKind          = "agentsview-usage-facts"
 

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -27,7 +27,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cache.temporary)
 	assert.Equal(t, filepath.Join(filepath.Dir(archivePath),
-		"usage-cache-v4-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
+		"usage-cache-v5-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
 
 	info, err := os.Stat(cache.path)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 
 	metadata := readUsageCacheMetadata(t, cache.db)
 	assert.Equal(t, "agentsview-usage-facts", metadata[usageCacheMetadataKind])
-	assert.Equal(t, "4", metadata[usageCacheMetadataFormatVersion])
+	assert.Equal(t, "5", metadata[usageCacheMetadataFormatVersion])
 	assert.Equal(t, "database-id-one", metadata[usageCacheMetadataSourceDatabaseID])
 	assert.Equal(t, "1", metadata[usageCacheMetadataNextInstallRevision])
 	assert.Equal(t, "1", metadata[usageCacheMetadataNextRollupRevision])
@@ -240,13 +240,15 @@ func TestUsageCacheGenerationPreservesRecognizedIncompleteCache(t *testing.T) {
 func TestUsageCacheGenerationChangesWithFormatAndDatabaseID(t *testing.T) {
 	dir := t.TempDir()
 	archivePath := filepath.Join(dir, "sessions.db")
-	oldPath := usageCacheGenerationPath(archivePath, 6, "database-id-one")
-	seedRecognizedUsageCache(t, oldPath, 6, "database-id-one")
+	oldPath := usageCacheGenerationPath(archivePath, 4, "database-id-one")
+	seedRecognizedUsageCache(t, oldPath, 4, "database-id-one")
 
 	manager := newUsageCacheManager(archivePath)
 	t.Cleanup(func() { require.NoError(t, manager.Close()) })
 	first, err := manager.Generation(context.Background(), "database-id-one")
 	require.NoError(t, err)
+	require.False(t, first.temporary,
+		"format bump must create a persistent generation")
 	assert.NotEqual(t, oldPath, first.path, "format bump must open a new generation")
 	_, err = os.Stat(oldPath)
 	require.NoError(t, err, "format bump must preserve the old generation")

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -71,6 +71,17 @@ func TestDailyUsageAmountsPricingBandRequestScope(t *testing.T) {
 			},
 		},
 		{
+			name:        "Posit Assistant sidecar event uses band without message ordinal",
+			usageSource: "posit-assistant-keepalive",
+			wantCost:    600_000,
+			wantApplication: export.PricingApplication{
+				Bands: []export.AppliedPricingBand{{
+					AboveInputTokens: 200_000,
+					RequestCount:     1,
+				}},
+			},
+		},
+		{
 			name:        "DeepSeek Harness compaction uses band without message ordinal",
 			usageSource: "deepseek-harness",
 			wantCost:    600_000,

--- a/internal/parser/posit_assistant_provider.go
+++ b/internal/parser/posit_assistant_provider.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,9 +26,15 @@ const (
 	positAssistantConversationFile = "conversation.json"
 	positAssistantLMMessagesFile   = "lm-messages.jsonl"
 	positAssistantUIMessagesFile   = "ui-messages.jsonl"
+	positAssistantUsageEventsFile  = "usage-events.jsonl"
 	positAssistantWorkspaceFile    = "workspace.json"
 	positAssistantSubagentsDir     = "subagents"
 	positAssistantIDPrefix         = "posit-assistant:"
+	// positAssistantUsageSourcePrefix prefixes the usage-event Source with
+	// the sidecar line's kind (keepalive, classifier). Every sidecar line
+	// records one provider request, so db.UsageSourceIsRequestScoped
+	// matches this prefix.
+	positAssistantUsageSourcePrefix = "posit-assistant-"
 )
 
 // positAssistantSummaryTagRe strips the assistant's inline bookkeeping tags
@@ -119,7 +126,7 @@ func (p *positAssistantProvider) Parse(
 		src.Project = req.Source.ProjectHint
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
-	sess, msgs, err := parsePositAssistantConversation(src, machine)
+	sess, msgs, events, err := parsePositAssistantConversation(src, machine)
 	if err != nil {
 		return ParseOutcome{}, err
 	}
@@ -141,8 +148,9 @@ func (p *positAssistantProvider) Parse(
 	return ParseOutcome{
 		Results: []ParseResultOutcome{{
 			Result: ParseResult{
-				Session:  *sess,
-				Messages: msgs,
+				Session:     *sess,
+				Messages:    msgs,
+				UsageEvents: events,
 			},
 			DataVersion: DataVersionCurrent,
 		}},
@@ -449,6 +457,13 @@ func (s positAssistantSourceSet) Fingerprint(
 			fingerprint.MTimeNS = mtime
 		}
 	}
+	uePath := filepath.Join(filepath.Dir(src.Path), positAssistantUsageEventsFile)
+	if ueInfo, err := os.Stat(uePath); err == nil {
+		fingerprint.Size += ueInfo.Size()
+		if mtime := ueInfo.ModTime().UnixNano(); mtime > fingerprint.MTimeNS {
+			fingerprint.MTimeNS = mtime
+		}
+	}
 	wsPath := s.workspaceManifestForSource(src)
 	if wsPath != "" {
 		if wsInfo, err := os.Stat(wsPath); err == nil {
@@ -458,7 +473,7 @@ func (s positAssistantSourceSet) Fingerprint(
 			}
 		}
 	}
-	fingerprint.Hash, err = positAssistantSourceHash(src.Path, lmPath, wsPath)
+	fingerprint.Hash, err = positAssistantSourceHash(src.Path, lmPath, uePath, wsPath)
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
@@ -485,11 +500,13 @@ func (s positAssistantSourceSet) workspaceManifestForSource(
 	return manifest
 }
 
-// positAssistantSourceHash combines the conversation tree, transcript, and
-// workspace manifest hashes. The manifest is included because it supplies the
-// session's project and cwd, so editing or creating it must invalidate the
-// skip cache and freshness checks, not just re-emit sources.
-func positAssistantSourceHash(convPath, lmPath, wsPath string) (string, error) {
+// positAssistantSourceHash combines the conversation tree, transcript,
+// usage-event sidecar, and workspace manifest hashes. The manifest is
+// included because it supplies the session's project and cwd, so editing or
+// creating it must invalidate the skip cache and freshness checks, not just
+// re-emit sources. The sidecar is included because idle sessions receive
+// keepalive appends with no transcript change.
+func positAssistantSourceHash(convPath, lmPath, uePath, wsPath string) (string, error) {
 	hash, err := hashJSONLSourceFile(convPath)
 	if err != nil {
 		return "", err
@@ -502,6 +519,14 @@ func positAssistantSourceHash(convPath, lmPath, wsPath string) (string, error) {
 			return "", err
 		}
 		combined += "\x00lm\x00" + lmHash
+		composite = true
+	}
+	if IsRegularFile(uePath) {
+		ueHash, err := hashJSONLSourceFile(uePath)
+		if err != nil {
+			return "", err
+		}
+		combined += "\x00usage\x00" + ueHash
 		composite = true
 	}
 	if wsPath != "" && IsRegularFile(wsPath) {
@@ -561,7 +586,8 @@ func (s positAssistantSourceSet) sourceRefForChangedPath(
 ) (SourceRef, bool) {
 	switch filepath.Base(filepath.Clean(path)) {
 	case positAssistantConversationFile,
-		positAssistantLMMessagesFile:
+		positAssistantLMMessagesFile,
+		positAssistantUsageEventsFile:
 	default:
 		return SourceRef{}, false
 	}
@@ -719,24 +745,24 @@ type positAssistantTreeNode struct {
 func parsePositAssistantConversation(
 	src positAssistantSource,
 	machine string,
-) (*ParsedSession, []ParsedMessage, error) {
+) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
 	info, err := os.Stat(src.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil, nil
+			return nil, nil, nil, nil
 		}
-		return nil, nil, fmt.Errorf("stat %s: %w", src.Path, err)
+		return nil, nil, nil, fmt.Errorf("stat %s: %w", src.Path, err)
 	}
 	data, err := os.ReadFile(src.Path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read %s: %w", src.Path, err)
+		return nil, nil, nil, fmt.Errorf("read %s: %w", src.Path, err)
 	}
 	if len(data) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	var conv positAssistantConversation
 	if err := json.Unmarshal(data, &conv); err != nil {
-		return nil, nil, fmt.Errorf("unmarshal %s: %w", src.Path, err)
+		return nil, nil, nil, fmt.Errorf("unmarshal %s: %w", src.Path, err)
 	}
 
 	convDir := filepath.Dir(src.Path)
@@ -744,11 +770,12 @@ func parsePositAssistantConversation(
 		filepath.Join(convDir, positAssistantLMMessagesFile),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var messages []ParsedMessage
 	firstMessage := ""
+	nodeOrdinals := make(map[string]int)
 	for _, node := range conv.Messages {
 		if !node.IsActive {
 			continue
@@ -769,11 +796,14 @@ func parsePositAssistantConversation(
 					strings.ReplaceAll(msg.Content, "\n", " "), 300,
 				)
 			}
+			if _, ok := nodeOrdinals[node.ID]; !ok {
+				nodeOrdinals[node.ID] = msg.Ordinal
+			}
 			messages = append(messages, msg)
 		}
 	}
 	if len(messages) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	if firstMessage == "" {
@@ -800,9 +830,18 @@ func parsePositAssistantConversation(
 		}
 	}
 
-	sessionID := filepath.Base(convDir)
+	sessionID := positAssistantIDPrefix + filepath.Base(convDir)
+	events, eventMalformed, err := readPositAssistantUsageEvents(
+		filepath.Join(convDir, positAssistantUsageEventsFile),
+		sessionID, nodeOrdinals, endedAt,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	malformed += eventMalformed
+
 	sess := &ParsedSession{
-		ID:               positAssistantIDPrefix + sessionID,
+		ID:               sessionID,
 		Project:          src.Project,
 		Machine:          machine,
 		Agent:            AgentPositAssistant,
@@ -825,8 +864,11 @@ func parsePositAssistantConversation(
 		sess.ParentSessionID = positAssistantIDPrefix + conv.Root.Metadata.ParentTreeID
 		sess.RelationshipType = RelSubagent
 	}
+	// Sidecar events are supplementary to per-message usage, so session
+	// token totals stay message-derived; the events reach cost accounting
+	// through the usage_events table.
 	accumulateMessageTokenUsage(sess, messages)
-	return sess, messages, nil
+	return sess, messages, events, nil
 }
 
 // readPositAssistantLMMessages loads lm-messages.jsonl into a map keyed by
@@ -870,6 +912,109 @@ func readPositAssistantLMMessages(
 		return nil, 0, fmt.Errorf("read %s: %w", path, err)
 	}
 	return lines, malformed, nil
+}
+
+// readPositAssistantUsageEvents loads the usage-events.jsonl sidecar, where
+// Posit Assistant records auxiliary per-request usage — cache-keepalive pings
+// and classifier calls — that never appears in the lm-messages transcript.
+// The sidecar is supplementary to the per-message usage, so events are
+// emitted only from sidecar lines (never derived from message aggregates),
+// keeping the additive messages-plus-usage-events cost queries free of
+// double counting. A missing sidecar yields no events.
+func readPositAssistantUsageEvents(
+	path, sessionID string,
+	nodeOrdinals map[string]int,
+	fallbackTime time.Time,
+) ([]ParsedUsageEvent, int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var events []ParsedUsageEvent
+	malformed := 0
+	lineNo := 0
+	lr := newLineReader(f, maxLineSize)
+	defer releaseLineReader(lr)
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		lineNo++
+		if !gjson.Valid(line) {
+			malformed++
+			continue
+		}
+		parsed := gjson.Parse(line)
+		kind := parsed.Get("kind").Str
+		if parsed.Get("type").Str != "usage" || kind == "" {
+			malformed++
+			continue
+		}
+		events = append(events, positAssistantUsageEvent(
+			parsed, kind, sessionID, lineNo, nodeOrdinals, fallbackTime,
+		))
+	}
+	if err := lr.Err(); err != nil {
+		return nil, 0, fmt.Errorf("read %s: %w", path, err)
+	}
+	return events, malformed, nil
+}
+
+// positAssistantUsageEvent converts one sidecar line into a request-scoped
+// usage event. Token buckets get the same family normalization as message
+// usage. Sidecar lines carry no identifiers, and the file is re-read whole on
+// each parse, so the dedup key is synthesized from the session, the line's
+// position in the append-only file, and its billing fields.
+func positAssistantUsageEvent(
+	parsed gjson.Result,
+	kind, sessionID string,
+	lineNo int,
+	nodeOrdinals map[string]int,
+	fallbackTime time.Time,
+) ParsedUsageEvent {
+	model := parsed.Get("modelId").Str
+	input := int(parsed.Get("inputTokens").Int())
+	output := int(parsed.Get("outputTokens").Int())
+	cacheRead := int(parsed.Get("cacheReadTokens").Int())
+	cacheWrite := int(parsed.Get("cacheWriteTokens").Int())
+	if positAssistantFoldsCacheWriteIntoInput(model) {
+		input += cacheWrite
+		cacheWrite = 0
+	}
+	timestamp := parsed.Get("timestamp").Int()
+	event := ParsedUsageEvent{
+		SessionID:                sessionID,
+		Source:                   positAssistantUsageSourcePrefix + kind,
+		Model:                    model,
+		InputTokens:              input,
+		OutputTokens:             output,
+		CacheCreationInputTokens: cacheWrite,
+		CacheReadInputTokens:     cacheRead,
+		OccurredAt: timeString(
+			positAssistantTime(timestamp), fallbackTime,
+		),
+		DedupKey: strings.Join([]string{
+			"session:" + sessionID,
+			"line=" + strconv.Itoa(lineNo),
+			"kind=" + kind,
+			"timestamp=" + strconv.FormatInt(timestamp, 10),
+			"model=" + model,
+			"input_tokens=" + strconv.Itoa(input),
+			"output_tokens=" + strconv.Itoa(output),
+			"cache_read_tokens=" + strconv.Itoa(cacheRead),
+			"cache_write_tokens=" + strconv.Itoa(cacheWrite),
+		}, "|"),
+	}
+	if ordinal, ok := nodeOrdinals[parsed.Get("anchorMessageId").Str]; ok {
+		event.MessageOrdinal = &ordinal
+	}
+	return event
 }
 
 // positAssistantMessageFromLM converts one Vercel AI SDK ModelMessage into a
@@ -1112,6 +1257,7 @@ func positAssistantProviderCapabilities() Capabilities {
 			ToolCalls:            CapabilitySupported,
 			ToolResults:          CapabilitySupported,
 			PerMessageTokenUsage: CapabilitySupported,
+			AggregateUsageEvents: CapabilitySupported,
 			MalformedLineCount:   CapabilitySupported,
 			Model:                CapabilitySupported,
 		},

--- a/internal/parser/posit_assistant_provider.go
+++ b/internal/parser/posit_assistant_provider.go
@@ -838,6 +838,12 @@ func parsePositAssistantConversation(
 	if len(messages) == 0 && len(events) == 0 {
 		return nil, nil, nil, nil
 	}
+	for _, event := range events {
+		eventTime, err := time.Parse(time.RFC3339Nano, event.OccurredAt)
+		if err == nil && eventTime.After(endedAt) {
+			endedAt = eventTime
+		}
+	}
 
 	sess := &ParsedSession{
 		ID:               sessionID,

--- a/internal/parser/posit_assistant_provider.go
+++ b/internal/parser/posit_assistant_provider.go
@@ -802,10 +802,6 @@ func parsePositAssistantConversation(
 			messages = append(messages, msg)
 		}
 	}
-	if len(messages) == 0 {
-		return nil, nil, nil, nil
-	}
-
 	if firstMessage == "" {
 		firstMessage = truncate(strings.ReplaceAll(
 			firstNonEmptyJSONLString(
@@ -839,6 +835,9 @@ func parsePositAssistantConversation(
 		return nil, nil, nil, err
 	}
 	malformed += eventMalformed
+	if len(messages) == 0 && len(events) == 0 {
+		return nil, nil, nil, nil
+	}
 
 	sess := &ParsedSession{
 		ID:               sessionID,

--- a/internal/parser/posit_assistant_provider_test.go
+++ b/internal/parser/posit_assistant_provider_test.go
@@ -149,6 +149,11 @@ func TestPositAssistantProviderClassifiesChangedPaths(t *testing.T) {
 			wantPaths: []string{mainConvPath},
 		},
 		{
+			name:      "usage-events append maps to its conversation",
+			path:      filepath.Join(mainConvDir, "usage-events.jsonl"),
+			wantPaths: []string{mainConvPath},
+		},
+		{
 			name:      "ui-messages write does not affect stored session data",
 			path:      filepath.Join(mainConvDir, "ui-messages.jsonl"),
 			wantPaths: nil,
@@ -709,4 +714,149 @@ func TestPositAssistantProviderFingerprintTracksWorkspaceManifest(t *testing.T) 
 	require.NoError(t, err)
 	assert.NotEqual(t, created.Hash, edited.Hash,
 		"editing workspace.json must change the composite fingerprint")
+}
+
+func TestPositAssistantProviderParseUsageEventsSidecar(t *testing.T) {
+	root := t.TempDir()
+	convDir := filepath.Join(root, "ws1", "99999999-9999-4999-8999-999999999999")
+	writeSourceFile(t, filepath.Join(convDir, "conversation.json"), `{
+		"schemaVersion": "3",
+		"root": {"id": "99999999-9999-4999-8999-999999999999",
+			"timestamp": 1735689600000, "metadata": {"kind": "main"}},
+		"messages": [
+			{"id": "n1", "parentId": "root", "isActive": true,
+				"lmMessageIds": [0, 1], "timestamp": 1735689600000}
+		],
+		"files": []
+	}`)
+	writeSourceFile(t, filepath.Join(convDir, "lm-messages.jsonl"),
+		`{"id":0,"message":{"role":"user","content":"hi"}}`+"\n"+
+			`{"id":1,"message":{"role":"assistant","content":[{"type":"text","text":"hello"}],"providerOptions":{"providerMetadata":{"positai":{"timestamp":1735689601000,"modelId":"claude-sonnet-4-5","usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":0,"cacheWriteTokens":100}}}}}}`+"\n")
+	writeSourceFile(t, filepath.Join(convDir, "usage-events.jsonl"),
+		`{"type":"usage","kind":"keepalive","timestamp":1735689900000,"anchorMessageId":"n1","providerId":"anthropic","modelId":"claude-sonnet-4-5","inputTokens":3,"outputTokens":2,"totalTokens":24655,"cacheReadTokens":24600,"cacheWriteTokens":50,"cacheWrite5mTokens":50}`+"\n"+
+			`{"type":"usage","kind":"classifier","timestamp":1735689910000,"anchorMessageId":"missing-node","providerId":"positai","modelId":"claude-haiku-4-5","inputTokens":400,"outputTokens":10,"totalTokens":410,"cacheReadTokens":0,"cacheWriteTokens":0}`+"\n"+
+			`{"type":"usage","kind":"keepalive","timestamp":1735689920000,"anchorMessageId":"n1","providerId":"positai","modelId":"zai-org/GLM-4.7","inputTokens":0,"outputTokens":1,"totalTokens":901,"cacheReadTokens":600,"cacheWriteTokens":300}`+"\n"+
+			`{"type":"usage","kind":"classifier","timestamp":0,"anchorMessageId":"n1","providerId":"anthropic","modelId":"claude-haiku-4-5","inputTokens":7,"outputTokens":1,"totalTokens":8,"cacheReadTokens":0,"cacheWriteTokens":0}`+"\n"+
+			"not json\n")
+
+	provider, ok := NewProvider(AgentPositAssistant, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	assert.Equal(t, CapabilitySupported,
+		provider.Capabilities().Content.AggregateUsageEvents)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: discovered[0],
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0].Result
+
+	events := result.UsageEvents
+	require.Len(t, events, 4)
+
+	keepalive := events[0]
+	assert.Equal(t,
+		"posit-assistant:99999999-9999-4999-8999-999999999999",
+		keepalive.SessionID)
+	assert.Equal(t, "posit-assistant-keepalive", keepalive.Source)
+	assert.Equal(t, "claude-sonnet-4-5", keepalive.Model)
+	assert.Equal(t, 3, keepalive.InputTokens)
+	assert.Equal(t, 2, keepalive.OutputTokens)
+	assert.Equal(t, 50, keepalive.CacheCreationInputTokens)
+	assert.Equal(t, 24600, keepalive.CacheReadInputTokens)
+	require.NotNil(t, keepalive.MessageOrdinal)
+	assert.Equal(t, 0, *keepalive.MessageOrdinal,
+		"anchorMessageId must map to the anchor node's first message ordinal")
+	assert.Equal(t, "2025-01-01T00:05:00Z", keepalive.OccurredAt)
+	assert.Nil(t, keepalive.Cost, "cost is catalog-priced downstream")
+
+	classifier := events[1]
+	assert.Equal(t, "posit-assistant-classifier", classifier.Source)
+	assert.Equal(t, "claude-haiku-4-5", classifier.Model)
+	assert.Nil(t, classifier.MessageOrdinal,
+		"unknown anchor nodes must not fabricate an ordinal")
+
+	glm := events[2]
+	assert.Equal(t, 300, glm.InputTokens,
+		"auto-cache families fold the cache-write remainder into input")
+	assert.Zero(t, glm.CacheCreationInputTokens)
+	assert.Equal(t, 600, glm.CacheReadInputTokens)
+
+	assert.Equal(t, "2025-01-01T00:00:01Z", events[3].OccurredAt,
+		"missing event timestamps fall back to the session end")
+
+	seen := make(map[string]struct{}, len(events))
+	for _, event := range events {
+		require.NotEmpty(t, event.DedupKey)
+		_, dup := seen[event.DedupKey]
+		require.False(t, dup, "dedup keys must be unique per sidecar line")
+		seen[event.DedupKey] = struct{}{}
+	}
+
+	sess := result.Session
+	assert.Equal(t, 1, sess.MalformedLines,
+		"unparseable sidecar lines must be counted")
+	assert.Equal(t, 5, sess.TotalOutputTokens,
+		"sidecar events are supplementary; session totals stay message-derived")
+	assert.Equal(t, 110, sess.PeakContextTokens)
+}
+
+func TestPositAssistantProviderFingerprintTracksUsageEventsSidecar(t *testing.T) {
+	root := t.TempDir()
+	convDir := filepath.Join(root, "ws1", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+	uePath := filepath.Join(convDir, "usage-events.jsonl")
+	writeSourceFile(t, filepath.Join(convDir, "conversation.json"),
+		`{"schemaVersion":"3","root":{},"messages":[]}`)
+	writeSourceFile(t, filepath.Join(convDir, "lm-messages.jsonl"),
+		`{"id":0,"message":{"role":"user","content":"hi"}}`+"\n")
+
+	provider, ok := NewProvider(AgentPositAssistant, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+
+	// Creating the sidecar after the fact must invalidate freshness: idle
+	// sessions receive keepalive appends without any transcript change.
+	before, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+	writeSourceFile(t, uePath,
+		`{"type":"usage","kind":"keepalive","timestamp":1735689900000,"anchorMessageId":"n1","providerId":"anthropic","modelId":"claude-sonnet-4-5","inputTokens":3,"outputTokens":2,"totalTokens":5,"cacheReadTokens":0,"cacheWriteTokens":0}`+"\n")
+	created, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Hash, created.Hash,
+		"creating usage-events.jsonl must change the composite fingerprint")
+	assert.Greater(t, created.Size, before.Size)
+
+	f, err := os.OpenFile(uePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(
+		`{"type":"usage","kind":"keepalive","timestamp":1735689960000,"anchorMessageId":"n1","providerId":"anthropic","modelId":"claude-sonnet-4-5","inputTokens":3,"outputTokens":2,"totalTokens":5,"cacheReadTokens":0,"cacheWriteTokens":0}` + "\n",
+	)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	appended, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+	assert.NotEqual(t, created.Hash, appended.Hash,
+		"appending to usage-events.jsonl must change the composite fingerprint")
+	assert.Greater(t, appended.Size, created.Size)
+
+	// The engine's incremental-sync cutoff reads MTimeNS, so the sidecar's
+	// mtime must drive the composite even when no other file changes —
+	// otherwise fallback polling would never resync a sidecar-only append.
+	future := time.Now().Add(2 * time.Hour)
+	require.NoError(t, os.Chtimes(uePath, future, future))
+	touched, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+	assert.Equal(t, future.UnixNano(), touched.MTimeNS,
+		"sidecar mtime must drive the composite fingerprint MTimeNS")
 }

--- a/internal/parser/posit_assistant_provider_test.go
+++ b/internal/parser/posit_assistant_provider_test.go
@@ -847,6 +847,8 @@ func TestPositAssistantProviderPreservesUsageOnlySession(t *testing.T) {
 	assert.Equal(t, 400, result.UsageEvents[0].InputTokens)
 	assert.Equal(t, 10, result.UsageEvents[0].OutputTokens)
 	assert.Equal(t, "2025-01-01T00:05:00Z", result.UsageEvents[0].OccurredAt)
+	assert.Equal(t, "2025-01-01T00:05:00Z",
+		result.Session.EndedAt.Format(time.RFC3339Nano))
 }
 
 func TestPositAssistantProviderFingerprintTracksUsageEventsSidecar(t *testing.T) {

--- a/internal/parser/posit_assistant_provider_test.go
+++ b/internal/parser/posit_assistant_provider_test.go
@@ -807,6 +807,48 @@ func TestPositAssistantProviderParseUsageEventsSidecar(t *testing.T) {
 	assert.Equal(t, 110, sess.PeakContextTokens)
 }
 
+func TestPositAssistantProviderPreservesUsageOnlySession(t *testing.T) {
+	root := t.TempDir()
+	conversationID := "88888888-8888-4888-8888-888888888888"
+	convDir := filepath.Join(root, "ws1", conversationID)
+	writeSourceFile(t, filepath.Join(convDir, "conversation.json"), `{
+		"schemaVersion": "3",
+		"root": {
+			"id": "88888888-8888-4888-8888-888888888888",
+			"timestamp": 1735689600000,
+			"metadata": {"kind": "main"}
+		},
+		"messages": []
+	}`)
+	writeSourceFile(t, filepath.Join(convDir, "usage-events.jsonl"),
+		`{"type":"usage","kind":"classifier","timestamp":1735689900000,"providerId":"positai","modelId":"claude-haiku-4-5","inputTokens":400,"outputTokens":10,"totalTokens":410,"cacheReadTokens":0,"cacheWriteTokens":0}`+"\n")
+
+	provider, ok := NewProvider(AgentPositAssistant, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: discovered[0],
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0].Result
+
+	assert.Equal(t, positAssistantIDPrefix+conversationID, result.Session.ID)
+	assert.Zero(t, result.Session.MessageCount)
+	assert.Empty(t, result.Messages)
+	require.Len(t, result.UsageEvents, 1)
+	assert.Equal(t, "posit-assistant-classifier", result.UsageEvents[0].Source)
+	assert.Equal(t, "claude-haiku-4-5", result.UsageEvents[0].Model)
+	assert.Equal(t, 400, result.UsageEvents[0].InputTokens)
+	assert.Equal(t, 10, result.UsageEvents[0].OutputTokens)
+	assert.Equal(t, "2025-01-01T00:05:00Z", result.UsageEvents[0].OccurredAt)
+}
+
 func TestPositAssistantProviderFingerprintTracksUsageEventsSidecar(t *testing.T) {
 	root := t.TempDir()
 	convDir := filepath.Join(root, "ws1", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")

--- a/internal/sessionwatch/watcher_test.go
+++ b/internal/sessionwatch/watcher_test.go
@@ -113,3 +113,87 @@ func TestCheckDBForChanges_FileHashChange(t *testing.T) {
 	assert.True(t, changed,
 		"file_hash-only rewrites must refresh session watchers")
 }
+
+func TestCheckDBForChangesPositAssistantSidecarAppendFallsBackToSync(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	const conversationID = "11111111-1111-4111-8111-111111111111"
+	conversationDir := filepath.Join(root, "workspace-1", conversationID)
+	workspacePath := filepath.Join(root, "workspace-1", "workspace.json")
+	conversationPath := filepath.Join(conversationDir, "conversation.json")
+	lmMessagesPath := filepath.Join(conversationDir, "lm-messages.jsonl")
+	usageEventsPath := filepath.Join(conversationDir, "usage-events.jsonl")
+
+	dbtest.WriteTestFile(t, workspacePath, []byte(`{"path":"/work/example"}`))
+	dbtest.WriteTestFile(t, conversationPath, []byte(`{
+		"schemaVersion":"3",
+		"root":{"id":"`+conversationID+`","timestamp":1735689600000,"metadata":{"kind":"main"}},
+		"messages":[{"id":"node-1","parentId":"`+conversationID+`","isActive":true,"lmMessageIds":[0,1],"timestamp":1735689600000}],
+		"files":[]
+	}`))
+	dbtest.WriteTestFile(t, lmMessagesPath, []byte(
+		`{"id":0,"message":{"role":"user","content":"Inspect the project."}}`+"\n"+
+			`{"id":1,"message":{"role":"assistant","content":[{"type":"text","text":"Looking."}],"providerOptions":{"providerMetadata":{"positai":{"timestamp":1735689601000,"modelId":"claude-sonnet-4-6","providerId":"anthropic","usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":0,"cacheWriteTokens":100}}}}}}`+"\n",
+	))
+	baseTime := time.Date(2026, time.August, 28, 10, 0, 0, 0, time.UTC)
+	for _, path := range []string{workspacePath, conversationPath, lmMessagesPath} {
+		require.NoError(t, os.Chtimes(path, baseTime, baseTime))
+	}
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentPositAssistant: {root},
+		},
+		Machine: "test",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+
+	const sessionID = "posit-assistant:" + conversationID
+	lastCount, lastDBVersion, ok := database.GetSessionVersion(sessionID)
+	require.True(t, ok)
+	sourcePath := engine.FindSourceFile(sessionID)
+	require.Equal(t, conversationPath, sourcePath)
+	lastFileMtime := engine.SourceMtime(sessionID)
+	require.Equal(t, baseTime.UnixNano(), lastFileMtime)
+
+	dbtest.WriteTestFile(t, usageEventsPath, []byte(
+		`{"type":"usage","kind":"keepalive","timestamp":1735693200000,"anchorMessageId":"node-1","providerId":"anthropic","modelId":"claude-sonnet-4-6","inputTokens":2,"outputTokens":1,"totalTokens":24642,"cacheReadTokens":24639,"cacheWriteTokens":0}`+"\n",
+	))
+	sidecarTime := baseTime.Add(time.Minute)
+	require.NoError(t, os.Chtimes(usageEventsPath, sidecarTime, sidecarTime))
+
+	watcher := New(database, engine)
+	var fileMtimeChangedAt time.Time
+	changed := watcher.checkDBForChanges(
+		sessionID,
+		&lastCount,
+		&lastDBVersion,
+		&sourcePath,
+		&lastFileMtime,
+		&fileMtimeChangedAt,
+	)
+	assert.False(t, changed, "the fallback delay must elapse before direct sync")
+	require.False(t, fileMtimeChangedAt.IsZero(),
+		"the sidecar mtime must start the fallback timer")
+	assert.Equal(t, sidecarTime.UnixNano(), lastFileMtime)
+
+	fileMtimeChangedAt = time.Now().Add(-SyncFallbackDelay)
+	changed = watcher.checkDBForChanges(
+		sessionID,
+		&lastCount,
+		&lastDBVersion,
+		&sourcePath,
+		&lastFileMtime,
+		&fileMtimeChangedAt,
+	)
+	require.True(t, changed, "the elapsed fallback must sync the sidecar")
+
+	usageEvents, err := database.GetUsageEvents(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, usageEvents, 1)
+	assert.Equal(t, "posit-assistant-keepalive", usageEvents[0].Source)
+	assert.Equal(t, 24639, usageEvents[0].CacheReadInputTokens)
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -18544,8 +18544,8 @@ func providerSourcePathNeedsFingerprint(path string) bool {
 
 func providerSourceMtimeNeedsFingerprint(agent parser.AgentType) bool {
 	switch agent {
-	case parser.AgentQoder:
-		// Qoder stores a sidecar whose mtime the plain path stat misses.
+	case parser.AgentPositAssistant, parser.AgentQoder:
+		// These providers store sidecars whose mtimes the plain path stat misses.
 		return true
 	default:
 		// RooCode is deliberately absent: its fingerprint content-hashes

--- a/internal/sync/posit_assistant_integration_test.go
+++ b/internal/sync/posit_assistant_integration_test.go
@@ -1,0 +1,79 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func writeSyncPositAssistantFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// TestSyncPositAssistantSidecarAppendResyncsWithoutWatchEvents proves the
+// non-watcher sync path picks up a usage-events.jsonl append when nothing
+// else about the conversation changed. Every other source file is aged well
+// past the first sync, so the session only resyncs if the sidecar drives the
+// provider fingerprint — both its mtime (the incremental cutoff signal) and
+// its content hash (the skip gate).
+func TestSyncPositAssistantSidecarAppendResyncsWithoutWatchEvents(t *testing.T) {
+	root := t.TempDir()
+	convID := "11111111-1111-4111-8111-111111111111"
+	convDir := filepath.Join(root, "ws1", convID)
+	wsPath := filepath.Join(root, "ws1", "workspace.json")
+	convPath := filepath.Join(convDir, "conversation.json")
+	lmPath := filepath.Join(convDir, "lm-messages.jsonl")
+
+	writeSyncPositAssistantFile(t, wsPath, `{"path":"/work/acme-app"}`)
+	writeSyncPositAssistantFile(t, convPath, `{
+		"schemaVersion": "3",
+		"root": {"id": "`+convID+`",
+			"timestamp": 1735689600000, "metadata": {"kind": "main"}},
+		"messages": [
+			{"id": "n1", "parentId": "`+convID+`", "isActive": true,
+				"lmMessageIds": [0, 1], "timestamp": 1735689600000}
+		],
+		"files": []
+	}`)
+	writeSyncPositAssistantFile(t, lmPath,
+		`{"id":0,"message":{"role":"user","content":"Inspect the auth flow."}}`+"\n"+
+			`{"id":1,"message":{"role":"assistant","content":[{"type":"text","text":"Looking."}],"providerOptions":{"providerMetadata":{"positai":{"timestamp":1735689601000,"modelId":"claude-sonnet-4-6","providerId":"anthropic","usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":0,"cacheWriteTokens":100}}}}}}`+"\n")
+
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentPositAssistant: {root},
+		},
+		Machine: "devbox",
+	})
+	t.Cleanup(engine.Close)
+
+	runSyncAndAssert(t, engine, SyncStats{TotalSessions: 1, Synced: 1})
+	sessionID := "posit-assistant:" + convID
+	usage, err := database.GetUsageEvents(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Empty(t, usage, "no sidecar yet, no usage events")
+
+	// Sidecar-only change: no other file is touched, so the session resyncs
+	// only if the sidecar participates in the provider fingerprint.
+	writeSyncPositAssistantFile(t,
+		filepath.Join(convDir, "usage-events.jsonl"),
+		`{"type":"usage","kind":"keepalive","timestamp":1735693200000,"anchorMessageId":"n1","providerId":"anthropic","modelId":"claude-sonnet-4-6","inputTokens":2,"outputTokens":1,"totalTokens":24642,"cacheReadTokens":24639,"cacheWriteTokens":0}`+"\n")
+
+	runSyncAndAssert(t, engine, SyncStats{TotalSessions: 1, Synced: 1})
+	usage, err = database.GetUsageEvents(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, usage, 1,
+		"a sidecar-only append must resync the session without a watch event")
+	assert.Equal(t, "posit-assistant-keepalive", usage[0].Source)
+	assert.Equal(t, 24639, usage[0].CacheReadInputTokens)
+	assert.Equal(t, 2, usage[0].InputTokens)
+}

--- a/internal/usagefacts/fact.go
+++ b/internal/usagefacts/fact.go
@@ -129,7 +129,7 @@ func FromEvent(in EventInput) (Fact, bool) {
 		CacheReadTokens:          clamp(in.CacheReadTokens),
 		ReportedCostMicrodollars: in.ReportedCostMicrodollars,
 		CostSource:               in.CostSource,
-		RequestScoped:            in.MessageOrdinal != nil || sourceIsRequestScoped(in.Source),
+		RequestScoped:            in.MessageOrdinal != nil || SourceIsRequestScoped(in.Source),
 		UsageDedupKey:            in.DedupKey,
 		TokenEligible:            eligible, ActivityEligible: eligible,
 	}, true
@@ -284,9 +284,15 @@ func floorTokens(value int64) int64 {
 	return value
 }
 
-func sourceIsRequestScoped(source string) bool {
+// SourceIsRequestScoped reports whether a usage source represents one
+// provider request even when the provider cannot attach it to a message.
+// Posit Assistant sidecar events ("posit-assistant-" + kind, e.g.
+// posit-assistant-keepalive, posit-assistant-classifier) each record one
+// provider request, so the whole prefix is request-scoped.
+func SourceIsRequestScoped(source string) bool {
 	return source == "message" || source == "goose-request" ||
-		source == "deepseek-harness"
+		source == "deepseek-harness" ||
+		strings.HasPrefix(source, "posit-assistant-")
 }
 
 func isTokenCounterKey(key string) bool {


### PR DESCRIPTION
**tl;dr:** Posit Assistant tracks its cache warming mechanism in `usage-events.jsonl`. This PR ingests that file so warm-cache spend is part of cost calculation. I also quickly checked again some existing PA sessions I have on disk with cache warm events.

Posit Assistant records auxiliary per-request usage that never appears in the `lm-messages.jsonl` transcript — cache-keepalive pings and classifier calls — in an append-only `usage-events.jsonl` sidecar next to each conversation (subagents carry their own). That spend was previously invisible: idle sessions receive repeated keepalive pings that never reached the usage tables.

Each sidecar line becomes a request-scoped usage event with `Source` = `"posit-assistant-" + kind`, the same model-family cache-write normalization as message usage, a `MessageOrdinal` when its anchor node resolves, and a synthesized dedup key. The sidecar is supplementary to per-message usage — events are emitted only from sidecar lines and session token totals stay message-derived — so the additive messages-plus-usage-events cost queries never double count. Posit Assistant may add new kinds (e.g. `posit-assistant-greeting`) so `strings.HasPrefix` is used.

The sidecar also joins the composite source fingerprint and changed-path classification, so a keepalive append on an otherwise idle session triggers resync.

The request-scoped source policy previously lived in two hand-synced copies (`db.UsageSourceIsRequestScoped` and `usagefacts.sourceIsRequestScoped`); it is now consolidated in `usagefacts.SourceIsRequestScoped` with `db` delegating. The new sources are registered there by prefix (`posit-assistant-`) rather than as exact literals: one-request-per-line is a property of the sidecar format, not of specific kinds, so a future PA event kind stays correctly request-scoped (and gets per-request pricing, including long-context bands) without a second list to maintain.

Because existing archives predate sidecar events, the data version moves 91 → 92 so those sessions re-parse through the normal non-destructive resync path.