### PR TITLE
Add hosted raw watch daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -195,6 +195,12 @@ jobs:
           )
           $packages = $packages | Where-Object { $_ -notin $isolatedPackages }
           go test -tags "fts5" $packages -count=1 -timeout=20m
+        env:
+          CGO_ENABLED: "1"
+
+      - name: Run raw capture tests (macOS)
+        if: runner.os == 'macOS'
+        run: go test -tags "fts5" ./internal/rawcapture -count=1 -timeout=10m
         env:
           CGO_ENABLED: "1"
 

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -118,6 +118,7 @@ func newRootCommand() *cobra.Command {
 	root.AddCommand(newUsageCommand())
 	root.AddCommand(newActivityCommand())
 	root.AddCommand(newPGCommand())
+	root.AddCommand(newRawSyncCommand())
 	root.AddCommand(newDuckDBCommand())
 	root.AddCommand(newEmbeddingsCommand())
 	root.AddCommand(newSessionCommand())

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -115,6 +115,27 @@ func TestPGStatusHelpShowsProjectFlags(t *testing.T) {
 	}
 }
 
+func TestRawSyncCommandsKeepCredentialOutOfArguments(t *testing.T) {
+	help, err := executeCommand(newRootCommand(), "raw-sync", "watch", "--help")
+	require.NoError(t, err)
+	for _, want := range []string{
+		"--server", "--device-id", "--allow-insecure-http", "--debounce", "--interval",
+		"AGENTSVIEW_RAW_SYNC_CREDENTIAL",
+	} {
+		assert.Contains(t, help, want)
+	}
+	assert.NotContains(t, help, "--credential")
+	_, err = executeCommand(
+		newRootCommand(), "raw-sync", "watch", "--credential=private-value",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown flag: --credential")
+	assert.NotContains(t, err.Error(), "private-value")
+	status, err := executeCommand(newRootCommand(), "raw-sync", "status", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, status, "Show durable laptop raw-sync status")
+}
+
 func TestDuckDBQuackServeHelpShowsSafetyFlags(t *testing.T) {
 	help, err := executeCommand(newRootCommand(), "duckdb", "quack", "serve", "--help")
 	require.NoError(t, err, "Execute")

--- a/cmd/agentsview/raw_sync.go
+++ b/cmd/agentsview/raw_sync.go
@@ -1,0 +1,487 @@
+package main
+
+import (
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcapture"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawclient"
+	"go.kenn.io/agentsview/internal/rawupload"
+	"go.kenn.io/agentsview/internal/rawwatch"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+)
+
+const (
+	defaultRawSyncDebounce   = 2 * time.Second
+	defaultRawSyncAudit      = 15 * time.Minute
+	defaultRawSyncRetry      = time.Minute
+	defaultRawSyncAuditLimit = 128
+)
+
+type rawSyncWatchConfig struct {
+	Server            string
+	DeviceID          string
+	AllowInsecureHTTP bool
+	Debounce          time.Duration
+	Interval          time.Duration
+	AuditLimit        int
+}
+
+type rawSyncRootRegistrar interface {
+	RegisterRoots([]syncpkg.WatchRoot, int) []syncpkg.RecursiveWatchResult
+}
+
+type rawSyncLoopWorker interface {
+	AuditAll(context.Context) error
+	Drain(context.Context) error
+}
+
+func newRawSyncCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "raw-sync",
+		Short:        "Capture and upload provider-owned raw session sources",
+		GroupID:      groupData,
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newRawSyncWatchCommand())
+	cmd.AddCommand(newRawSyncStatusCommand())
+	return cmd
+}
+
+func newRawSyncWatchCommand() *cobra.Command {
+	cfg := rawSyncWatchConfig{}
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Continuously capture and upload raw session sources",
+		Long: "Continuously capture and upload raw session sources.\n\n" +
+			"The device credential is read only from " +
+			"AGENTSVIEW_RAW_SYNC_CREDENTIAL; it cannot be passed as an argument.",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, stop := signal.NotifyContext(
+				cmd.Context(), os.Interrupt, syscall.SIGTERM,
+			)
+			defer stop()
+			if err := runRawSyncWatch(ctx, cfg); err != nil {
+				return fmt.Errorf("raw-sync watch: %w", err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cfg.Server, "server", "", "Raw-sync server URL (or AGENTSVIEW_RAW_SYNC_URL)")
+	cmd.Flags().StringVar(&cfg.DeviceID, "device-id", "", "Provisioned device ID (or AGENTSVIEW_RAW_SYNC_DEVICE_ID)")
+	cmd.Flags().BoolVar(&cfg.AllowInsecureHTTP, "allow-insecure-http", false, "Allow HTTP only for a loopback raw-sync server")
+	cmd.Flags().DurationVar(&cfg.Debounce, "debounce", defaultRawSyncDebounce, "Coalesce window for filesystem changes")
+	cmd.Flags().DurationVar(&cfg.Interval, "interval", defaultRawSyncAudit, "Bounded full-source audit interval")
+	cmd.Flags().IntVar(&cfg.AuditLimit, "audit-limit", defaultRawSyncAuditLimit, "Maximum source work per provider audit")
+	return cmd
+}
+
+func newRawSyncStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "status",
+		Short:        "Show durable laptop raw-sync status",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := runRawSyncStatus(cmd.Context(), cmd.OutOrStdout()); err != nil {
+				return fmt.Errorf("raw-sync status: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+func runRawSyncWatch(ctx context.Context, watchCfg rawSyncWatchConfig) error {
+	watchCfg.Server = firstNonempty(watchCfg.Server, os.Getenv("AGENTSVIEW_RAW_SYNC_URL"))
+	watchCfg.DeviceID = firstNonempty(
+		watchCfg.DeviceID, os.Getenv("AGENTSVIEW_RAW_SYNC_DEVICE_ID"),
+	)
+	credential := os.Getenv("AGENTSVIEW_RAW_SYNC_CREDENTIAL")
+	if err := validateRawSyncWatchConfig(watchCfg, credential); err != nil {
+		return err
+	}
+	appCfg, err := config.LoadReadOnly()
+	if err != nil {
+		return err
+	}
+	providers, roots, err := rawSyncProvidersAndRoots(ctx, appCfg)
+	if err != nil {
+		return err
+	}
+	if len(providers) == 0 {
+		return errors.New("no configured provider supports raw capture")
+	}
+	checkpointPath := rawSyncCheckpointPath(appCfg.DataDir)
+	store, err := rawcheckpoint.Open(ctx, checkpointPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	if err := store.EnsureDevice(ctx, watchCfg.DeviceID); err != nil {
+		return err
+	}
+	client, err := rawclient.NewClient(rawclient.Config{
+		BaseURL: watchCfg.Server, DeviceID: watchCfg.DeviceID, Credential: credential,
+	})
+	if err != nil {
+		return err
+	}
+	capturer := rawcapture.New(store)
+	worker := rawwatch.NewWorker(
+		providers,
+		capturer,
+		rawwatch.NewAuditor(store, capturer, watchCfg.AuditLimit),
+		rawupload.New(store, client, watchCfg.DeviceID),
+	)
+	watcher, err := syncpkg.NewWatcherWithCallback(
+		watchCfg.Debounce,
+		watchCfg.Debounce,
+		rawSyncWatchCallback(worker.HandleBatch),
+		appCfg.WatchExcludePatterns,
+		syncpkg.WatcherOptions{},
+	)
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+	pendingRoots, uncovered := registerRawSyncRoots(watcher, roots)
+	if uncovered != 0 {
+		log.Printf("warning: raw-sync watcher has %d uncovered roots; registration retry and periodic audit remain active", uncovered)
+	}
+	if err := watcher.StartCollecting(); err != nil {
+		return err
+	}
+	if err := worker.AuditAll(ctx); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		log.Printf("warning: initial raw-sync audit failed; periodic repair remains active")
+	}
+	watcher.OpenDispatch()
+	refreshRoots := func() error {
+		var err error
+		pendingRoots, err = refreshRawSyncRoots(watcher, pendingRoots)
+		return err
+	}
+	return runRawSyncLoop(
+		ctx, worker, watchCfg.Interval, defaultRawSyncRetry, refreshRoots,
+	)
+}
+
+func runRawSyncLoop(
+	ctx context.Context,
+	worker rawSyncLoopWorker,
+	auditInterval time.Duration,
+	retryInterval time.Duration,
+	refreshRoots func() error,
+) error {
+	audit := time.NewTicker(auditInterval)
+	retry := time.NewTicker(retryInterval)
+	defer audit.Stop()
+	defer retry.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-audit.C:
+			if err := worker.AuditAll(ctx); err != nil && ctx.Err() == nil {
+				log.Printf("warning: raw-sync audit failed")
+			}
+		case <-retry.C:
+			if refreshRoots != nil {
+				if err := refreshRoots(); err != nil && ctx.Err() == nil {
+					log.Printf("warning: raw-sync watcher registration retry failed")
+				}
+			}
+			if err := worker.Drain(ctx); err != nil && ctx.Err() == nil {
+				log.Printf("warning: raw-sync upload retry failed")
+			}
+		}
+	}
+}
+
+func registerRawSyncRoots(
+	registrar rawSyncRootRegistrar,
+	roots []syncpkg.WatchRoot,
+) ([]syncpkg.WatchRoot, int) {
+	pending := make([]syncpkg.WatchRoot, 0, len(roots))
+	results := registrar.RegisterRoots(roots, recursiveWatchBudget)
+	for i, root := range roots {
+		if i >= len(results) ||
+			(!results[i].MissingRootLifecycleOwned &&
+				(!root.Exists || rawSyncRootUncovered(results[i]))) {
+			pending = append(pending, root)
+		}
+	}
+	return pending, len(pending)
+}
+
+func rawSyncRootUncovered(result syncpkg.RecursiveWatchResult) bool {
+	return result.Err != nil || result.Unwatched != 0 ||
+		result.BudgetExhausted || result.ResourceExhausted || result.Watched == 0
+}
+
+func refreshRawSyncRoots(
+	registrar rawSyncRootRegistrar,
+	pending []syncpkg.WatchRoot,
+) ([]syncpkg.WatchRoot, error) {
+	var ready []syncpkg.WatchRoot
+	remaining := make([]syncpkg.WatchRoot, 0, len(pending))
+	var errs []error
+	for _, root := range pending {
+		info, err := os.Stat(root.Path)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			remaining = append(remaining, root)
+		case err != nil:
+			remaining = append(remaining, root)
+			errs = append(errs, fmt.Errorf("inspect pending watch root: %w", err))
+		case !info.IsDir():
+			remaining = append(remaining, root)
+		default:
+			root.Exists = true
+			ready = append(ready, root)
+		}
+	}
+	failed, _ := registerRawSyncRoots(registrar, ready)
+	remaining = append(remaining, failed...)
+	return remaining, errors.Join(errs...)
+}
+
+func validateRawSyncWatchConfig(cfg rawSyncWatchConfig, credential string) error {
+	if strings.TrimSpace(cfg.Server) == "" {
+		return errors.New("--server or AGENTSVIEW_RAW_SYNC_URL is required")
+	}
+	parsed, err := url.Parse(cfg.Server)
+	if err != nil || parsed.Host == "" ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return errors.New("raw-sync server URL is invalid")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("raw-sync server URL must not contain credentials")
+	}
+	if parsed.Scheme == "http" {
+		if !cfg.AllowInsecureHTTP {
+			return errors.New("raw-sync server URL must use HTTPS")
+		}
+		if !rawSyncLoopbackHost(parsed.Hostname()) {
+			return errors.New("insecure raw-sync HTTP is limited to loopback")
+		}
+	}
+	if strings.TrimSpace(cfg.DeviceID) == "" {
+		return errors.New("--device-id or AGENTSVIEW_RAW_SYNC_DEVICE_ID is required")
+	}
+	if credential == "" {
+		return errors.New("AGENTSVIEW_RAW_SYNC_CREDENTIAL is required")
+	}
+	if cfg.Debounce <= 0 || cfg.Interval <= 0 || cfg.AuditLimit <= 0 {
+		return errors.New("debounce, interval, and audit-limit must be positive")
+	}
+	return nil
+}
+
+func rawSyncLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+type rawSyncWatchError struct {
+	retry syncpkg.WatchBatch
+}
+
+func (*rawSyncWatchError) Error() string {
+	return "raw-sync watcher work failed"
+}
+
+func (e *rawSyncWatchError) WatchRetryBatch() syncpkg.WatchBatch {
+	retry := e.retry
+	retry.Paths = append([]string(nil), retry.Paths...)
+	retry.ReconcileRoots = append([]string(nil), retry.ReconcileRoots...)
+	return retry
+}
+
+func rawSyncWatchRetryBatch(batch syncpkg.WatchBatch) syncpkg.WatchBatch {
+	if batch.FullSync || len(batch.Renames) != 0 {
+		return syncpkg.WatchBatch{FullSync: true, LostEvents: batch.LostEvents}
+	}
+	return syncpkg.WatchBatch{
+		Paths:          append([]string(nil), batch.Paths...),
+		ReconcileRoots: append([]string(nil), batch.ReconcileRoots...),
+		LostEvents:     batch.LostEvents,
+	}
+}
+
+func rawSyncWatchCallback(
+	handle func(context.Context, syncpkg.WatchBatch) error,
+) func(context.Context, syncpkg.WatchBatch) error {
+	return func(ctx context.Context, batch syncpkg.WatchBatch) error {
+		if err := handle(ctx, batch); err != nil {
+			return &rawSyncWatchError{retry: rawSyncWatchRetryBatch(batch)}
+		}
+		return nil
+	}
+}
+
+func rawSyncProvidersAndRoots(
+	ctx context.Context,
+	cfg config.Config,
+) ([]parser.Provider, []syncpkg.WatchRoot, error) {
+	var providers []parser.Provider
+	rootIndex := make(map[string]int)
+	var roots []syncpkg.WatchRoot
+	for _, factory := range cfg.LocalProviderFactories() {
+		if factory.Capabilities().RawCapture.Support != parser.CapabilitySupported {
+			continue
+		}
+		def := factory.Definition()
+		configuredRoots := rawSyncFilesystemRoots(cfg.ResolveDirs(def.Type))
+		for index, root := range configuredRoots {
+			absoluteRoot, err := filepath.Abs(root)
+			if err != nil {
+				return nil, nil, fmt.Errorf(
+					"raw-sync resolve configured root for %s: %w", def.Type, err,
+				)
+			}
+			configuredRoots[index] = absoluteRoot
+		}
+		if len(configuredRoots) == 0 {
+			continue
+		}
+		provider := factory.NewProvider(parser.ProviderConfig{
+			Roots: configuredRoots, Machine: cfg.LocalMachineName,
+			SourceMachines: cfg.SourceMachines[def.Type],
+		})
+		watchRoots, err := parser.ResolveWatchRoots(ctx, provider)
+		if err != nil {
+			return nil, nil, fmt.Errorf("raw-sync watch roots for %s: %w", def.Type, err)
+		}
+		providers = append(providers, provider)
+		for _, planned := range watchRoots {
+			path := filepath.Clean(planned.Path)
+			info, statErr := os.Stat(path)
+			exists := statErr == nil && info != nil && info.IsDir()
+			if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+				return nil, nil, fmt.Errorf("raw-sync inspect watch root: %w", statErr)
+			}
+			scope := syncpkg.WatchScope{
+				Agent:   string(def.Type),
+				SyncDir: rawSyncConfiguredRootForPath(configuredRoots, path),
+			}
+			if index, found := rootIndex[path]; found {
+				if index < 0 || index >= len(roots) {
+					return nil, nil, fmt.Errorf("raw-sync watch root index is invalid")
+				}
+				root := &roots[index]
+				root.Recursive = root.Recursive || planned.Recursive
+				root.Exists = root.Exists || exists
+				if !slices.Contains(root.Scopes, scope) {
+					root.Scopes = append(root.Scopes, scope)
+				}
+				continue
+			}
+			rootIndex[path] = len(roots)
+			roots = append(roots, syncpkg.WatchRoot{
+				Path: path, Recursive: planned.Recursive, Exists: exists,
+				Scopes: []syncpkg.WatchScope{scope},
+			})
+		}
+	}
+	return providers, roots, nil
+}
+
+func rawSyncFilesystemRoots(roots []string) []string {
+	return slices.DeleteFunc(append([]string(nil), roots...), func(root string) bool {
+		return root == "" || strings.HasPrefix(strings.ToLower(root), "s3://")
+	})
+}
+
+func rawSyncConfiguredRootForPath(configuredRoots []string, watchPath string) string {
+	best := ""
+	for _, candidate := range configuredRoots {
+		candidate = filepath.Clean(candidate)
+		relative, err := filepath.Rel(candidate, watchPath)
+		if err != nil || relative == ".." || strings.HasPrefix(
+			relative, ".."+string(filepath.Separator),
+		) {
+			continue
+		}
+		if len(candidate) > len(best) {
+			best = candidate
+		}
+	}
+	if best != "" {
+		return best
+	}
+	return watchPath
+}
+
+func runRawSyncStatus(ctx context.Context, out io.Writer) error {
+	cfg, err := config.LoadReadOnly()
+	if err != nil {
+		return err
+	}
+	path := rawSyncCheckpointPath(cfg.DataDir)
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return writeRawSyncStatus(out, rawcheckpoint.ClientStatus{})
+	} else if err != nil {
+		return err
+	}
+	store, err := rawcheckpoint.OpenReadOnly(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	status, err := store.ClientStatus(ctx)
+	if err != nil {
+		return err
+	}
+	return writeRawSyncStatus(out, status)
+}
+
+func writeRawSyncStatus(out io.Writer, status rawcheckpoint.ClientStatus) error {
+	payload, err := json.Marshal(status)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, string(payload))
+	return err
+}
+
+func rawSyncCheckpointPath(dataDir string) string {
+	return filepath.Join(dataDir, "raw-sync", "checkpoint.db")
+}
+
+func firstNonempty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/cmd/agentsview/raw_sync_test.go
+++ b/cmd/agentsview/raw_sync_test.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+)
+
+type recordingRawSyncRootRegistrar struct {
+	roots []syncpkg.WatchRoot
+}
+
+type recordingRawSyncLoopWorker struct {
+	audits int
+	drains int
+}
+
+func (w *recordingRawSyncLoopWorker) AuditAll(context.Context) error {
+	w.audits++
+	return nil
+}
+
+func (w *recordingRawSyncLoopWorker) Drain(context.Context) error {
+	w.drains++
+	return nil
+}
+
+func (r *recordingRawSyncRootRegistrar) RegisterRoots(
+	roots []syncpkg.WatchRoot,
+	_ int,
+) []syncpkg.RecursiveWatchResult {
+	r.roots = append(r.roots, roots...)
+	results := make([]syncpkg.RecursiveWatchResult, len(roots))
+	for i, root := range roots {
+		if root.Exists {
+			results[i].Watched = 1
+		}
+	}
+	return results
+}
+
+func TestValidateRawSyncWatchConfigRejectsUnsafeServerURLs(t *testing.T) {
+	base := rawSyncWatchConfig{
+		Server: "https://sync.example.test", DeviceID: "device-a",
+		Debounce: time.Second, Interval: time.Minute, AuditLimit: 1,
+	}
+	for _, server := range []string{
+		"http://sync.example.test",
+		"ftp://sync.example.test",
+		"https://user:private-value@sync.example.test",
+		"https://sync.example.test?private=value",
+		"https://sync.example.test/#private-value",
+	} {
+		cfg := base
+		cfg.Server = server
+
+		err := validateRawSyncWatchConfig(cfg, "credential-value")
+
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "private-value")
+		assert.NotContains(t, err.Error(), "credential-value")
+	}
+}
+
+func TestValidateRawSyncWatchConfigAllowsExplicitLoopbackHTTP(t *testing.T) {
+	for _, server := range []string{
+		"http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080",
+	} {
+		cfg := rawSyncWatchConfig{
+			Server: server, DeviceID: "device-a", AllowInsecureHTTP: true,
+			Debounce: time.Second, Interval: time.Minute, AuditLimit: 1,
+		}
+
+		require.NoError(t, validateRawSyncWatchConfig(cfg, "credential-value"))
+	}
+}
+
+func TestValidateRawSyncWatchConfigRejectsNonLoopbackHTTPOverride(t *testing.T) {
+	cfg := rawSyncWatchConfig{
+		Server: "http://sync.example.test", DeviceID: "device-a",
+		AllowInsecureHTTP: true,
+		Debounce:          time.Second, Interval: time.Minute, AuditLimit: 1,
+	}
+
+	err := validateRawSyncWatchConfig(cfg, "credential-value")
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), cfg.Server)
+}
+
+func TestRawSyncWatchCallbackRedactsOperationalErrors(t *testing.T) {
+	const sensitivePath = "/private/session/path"
+	callback := rawSyncWatchCallback(func(
+		context.Context, syncpkg.WatchBatch,
+	) error {
+		return errors.New("open " + sensitivePath)
+	})
+
+	err := callback(t.Context(), syncpkg.WatchBatch{})
+
+	require.EqualError(t, err, "raw-sync watcher work failed")
+	assert.NotContains(t, err.Error(), sensitivePath)
+}
+
+func TestRawSyncWatchCallbackRetainsRetryScope(t *testing.T) {
+	const sensitivePath = "/private/session/path"
+	tests := []struct {
+		name  string
+		batch syncpkg.WatchBatch
+		want  syncpkg.WatchBatch
+	}{
+		{
+			name: "paths",
+			batch: syncpkg.WatchBatch{
+				Paths: []string{sensitivePath}, LostEvents: true,
+			},
+			want: syncpkg.WatchBatch{
+				Paths: []string{sensitivePath}, LostEvents: true,
+			},
+		},
+		{
+			name:  "reconciliation roots",
+			batch: syncpkg.WatchBatch{ReconcileRoots: []string{sensitivePath}},
+			want:  syncpkg.WatchBatch{ReconcileRoots: []string{sensitivePath}},
+		},
+		{
+			name:  "full sync",
+			batch: syncpkg.WatchBatch{FullSync: true, LostEvents: true},
+			want:  syncpkg.WatchBatch{FullSync: true, LostEvents: true},
+		},
+		{
+			name: "file rename",
+			batch: syncpkg.WatchBatch{Renames: []syncpkg.WatchRename{{
+				Path: sensitivePath, ItemType: syncpkg.ItemIsFile,
+			}}},
+			want: syncpkg.WatchBatch{FullSync: true},
+		},
+		{
+			name: "ambiguous rename",
+			batch: syncpkg.WatchBatch{Renames: []syncpkg.WatchRename{{
+				Path: sensitivePath, ItemType: syncpkg.ItemIsUnknown,
+			}}, LostEvents: true},
+			want: syncpkg.WatchBatch{FullSync: true, LostEvents: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callback := rawSyncWatchCallback(func(
+				context.Context, syncpkg.WatchBatch,
+			) error {
+				return errors.New("open " + sensitivePath)
+			})
+
+			err := callback(t.Context(), tt.batch)
+
+			require.EqualError(t, err, "raw-sync watcher work failed")
+			assert.NotContains(t, err.Error(), sensitivePath)
+			var retryErr syncpkg.WatchRetryError
+			require.ErrorAs(t, err, &retryErr)
+			assert.Equal(t, tt.want, retryErr.WatchRetryBatch())
+		})
+	}
+}
+
+func TestRunRawSyncLoopAuditsRetriesAndStopsOnCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		worker := &recordingRawSyncLoopWorker{}
+		done := make(chan error, 1)
+		go func() {
+			done <- runRawSyncLoop(ctx, worker, time.Hour, time.Hour, nil)
+		}()
+
+		time.Sleep(time.Hour)
+		synctest.Wait()
+		assert.Equal(t, 1, worker.audits)
+		assert.Equal(t, 1, worker.drains)
+		cancel()
+		synctest.Wait()
+		require.NoError(t, <-done)
+	})
+}
+
+func TestRawSyncStatusWithoutCheckpointDoesNotCreateState(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+
+	output, err := executeCommand(newRootCommand(), "raw-sync", "status")
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"device_id":"",
+		"pending_generations":0,
+		"pending_objects":0,
+		"pending_object_bytes":0,
+		"outbox":{"used_bytes":0,"reserved_bytes":0,"limit_bytes":0},
+		"permanent_failures":0
+	}`, output)
+	_, err = os.Stat(filepath.Join(dataDir, "raw-sync"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRawSyncMissingRootIsCountedAndRegisteredAfterCreation(t *testing.T) {
+	rootPath := filepath.Join(t.TempDir(), "later")
+	roots := []syncpkg.WatchRoot{{Path: rootPath, Recursive: true, Exists: false}}
+	registrar := &recordingRawSyncRootRegistrar{}
+
+	pending, uncovered := registerRawSyncRoots(registrar, roots)
+
+	assert.Equal(t, 1, uncovered)
+	require.Len(t, pending, 1)
+	require.Len(t, registrar.roots, 1)
+	assert.False(t, registrar.roots[0].Exists)
+	require.NoError(t, os.Mkdir(rootPath, 0o700))
+	pending, err := refreshRawSyncRoots(registrar, pending)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	require.Len(t, registrar.roots, 2)
+	assert.True(t, registrar.roots[1].Exists)
+}
+
+func TestRefreshRawSyncRootsKeepsStillMissingRoot(t *testing.T) {
+	rootPath := filepath.Join(t.TempDir(), "still-missing")
+	registrar := &recordingRawSyncRootRegistrar{}
+
+	pending, err := refreshRawSyncRoots(registrar, []syncpkg.WatchRoot{{
+		Path: rootPath, Recursive: true,
+	}})
+
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Empty(t, registrar.roots)
+	_, statErr := os.Stat(rootPath)
+	assert.True(t, errors.Is(statErr, os.ErrNotExist))
+}
+
+func TestRawSyncProvidersExcludeS3Roots(t *testing.T) {
+	localRoot := t.TempDir()
+	assert.Equal(t, []string{localRoot}, rawSyncFilesystemRoots([]string{
+		"", localRoot, "s3://example-bucket/raw/claude",
+	}))
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentClaude: {localRoot, "s3://example-bucket/raw/claude"},
+	}}
+
+	providers, roots, err := rawSyncProvidersAndRoots(t.Context(), cfg)
+
+	require.NoError(t, err)
+	require.Len(t, providers, 1)
+	require.Len(t, roots, 1)
+	assert.Equal(t, localRoot, roots[0].Path)
+}
+
+func TestRawSyncProvidersNormalizeRelativeRootsForCapture(t *testing.T) {
+	base := t.TempDir()
+	t.Chdir(base)
+	absoluteRoot := filepath.Join(base, "sessions")
+	sessionPath := filepath.Join(absoluteRoot, "project", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o700))
+	require.NoError(t, os.WriteFile(sessionPath, []byte("{}\n"), 0o600))
+	relativeRoot := "sessions"
+	require.False(t, filepath.IsAbs(relativeRoot))
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentClaude: {relativeRoot},
+	}}
+
+	providers, roots, err := rawSyncProvidersAndRoots(t.Context(), cfg)
+	require.NoError(t, err)
+	require.Len(t, providers, 1)
+	require.Len(t, roots, 1)
+	assert.True(t, filepath.IsAbs(roots[0].Path))
+	discovery, err := parser.DiscoverRawCaptureSources(t.Context(), providers[0])
+	require.NoError(t, err)
+	require.True(t, discovery.Complete)
+	require.Len(t, discovery.Sources, 1)
+	plan, supported, err := parser.ResolveRawCapturePlan(
+		t.Context(), providers[0], discovery.Sources[0],
+	)
+	require.NoError(t, err)
+	require.True(t, supported)
+	assert.True(t, filepath.IsAbs(plan.ConfiguredRoot))
+	watchedRoot, err := os.Stat(roots[0].Path)
+	require.NoError(t, err)
+	plannedRoot, err := os.Stat(plan.ConfiguredRoot)
+	require.NoError(t, err)
+	assert.True(t, os.SameFile(watchedRoot, plannedRoot),
+		"capture plan must retain the normalized watched root")
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -32,6 +32,42 @@ behavior, failure codes, and a complete GitHub Actions job.
 
 ______________________________________________________________________
 
+### `agentsview raw-sync`
+
+Capture supported local provider sources and upload their raw generations to
+hosted custody:
+
+```bash
+export AGENTSVIEW_RAW_SYNC_URL=https://agents.example.com
+export AGENTSVIEW_RAW_SYNC_DEVICE_ID=device-id
+export AGENTSVIEW_RAW_SYNC_CREDENTIAL=device-credential
+agentsview raw-sync watch
+agentsview raw-sync status
+```
+
+`raw-sync watch` runs an initial bounded audit, watches for filesystem changes,
+and retries interrupted uploads from its durable local checkpoint. The device
+credential is accepted only through `AGENTSVIEW_RAW_SYNC_CREDENTIAL`, never as a
+command-line flag. `--server` and `--device-id` override their corresponding
+environment variables.
+
+| Flag                    | Default      | Description                                      |
+| ----------------------- | ------------ | ------------------------------------------------ |
+| `--server`              | environment  | Raw-sync server URL                              |
+| `--device-id`           | environment  | Provisioned device ID                            |
+| `--allow-insecure-http` | `false`      | Allow HTTP for a loopback server only            |
+| `--debounce`            | `2s`         | Coalescing window for filesystem changes         |
+| `--interval`            | `15m`        | Interval between bounded provider audits         |
+| `--audit-limit`         | `128`        | Maximum source work in each provider audit       |
+
+`raw-sync status` reads the checkpoint without creating one and prints
+path-free JSON containing capture, queue, retry, failure, and coverage state.
+S3 roots are not captured. This remains an in-development raw-custody path:
+device enrollment and server-side session derivation are not yet available.
+See [Hosted Raw Sync](/hosted-raw-sync/) for the current boundary.
+
+______________________________________________________________________
+
 ### `agentsview daemon`
 
 Manage the detached writable SQLite server:

--- a/docs/hosted-raw-sync.md
+++ b/docs/hosted-raw-sync.md
@@ -22,11 +22,10 @@ data after loss.
 
 !!! warning "Not available for use yet"
 
-    AgentsView now exposes part of the authenticated raw-sync control plane from
-    `agentsview pg serve`, but it does not yet expose device enrollment, object
-    upload, or status endpoints. There is also no laptop uploader, server-side
-    parsing worker, or server-owned embedding pipeline. No supported command or
-    configuration setting enables hosted raw sync end to end.
+    AgentsView now has a laptop capture-and-upload daemon and the matching raw
+    custody transport. It still does not expose device enrollment, server-side
+    parsing, or server-owned embeddings. An operator-provisioned device can test raw
+    custody, but no supported command enables hosted raw sync end to end.
 
     The existing [`agentsview pg push`](/pg-sync/) workflow remains supported and
     unchanged. It parses sessions locally and can build embeddings locally before
@@ -37,18 +36,44 @@ The tracked delivery sequence and production acceptance criteria live in
 
 ## Delivery status
 
-| Layer                  | Status                                                                                       | Current boundary                                                                                                            |
-| ---------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Raw custody            | Foundation implemented in [#1396](https://github.com/kenn-io/agentsview/pull/1396)           | Validated objects, canonical manifests, durable receipts, source-head fencing, and parse-job creation                       |
-| Device authentication  | Foundation implemented in [#1459](https://github.com/kenn-io/agentsview/pull/1459)           | One-time device credentials, scoped short-lived tokens, server-derived identity, and revocation                             |
-| HTTP raw transport     | Control plane partly implemented in [#1473](https://github.com/kenn-io/agentsview/pull/1473) | Credential exchange, missing-object negotiation, and manifest commit; enrollment, object upload, and status remain          |
-| Laptop capture         | Not implemented                                                                              | Provider watching, append fast paths, SQLite snapshots, spooling, checkpoints, and reconciliation remain future client work |
-| Server derivation      | Not implemented                                                                              | Manifest materialization, parsing, transactional PostgreSQL projection, and embeddings are not running                      |
-| Operations and cutover | Not implemented                                                                              | Retention, garbage collection, disaster rebuilds, rollout controls, and migration from `pg push` remain future work         |
+| Layer                  | Status                                                                             | Current boundary                                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Raw custody            | Foundation implemented in [#1396](https://github.com/kenn-io/agentsview/pull/1396) | Validated objects, canonical manifests, durable receipts, source-head fencing, and parse-job creation               |
+| Device authentication  | Foundation implemented in [#1459](https://github.com/kenn-io/agentsview/pull/1459) | Credential exchange, scoped short-lived tokens, server-derived identity, and revocation; no enrollment command yet  |
+| HTTP raw transport     | Implemented through resumable object upload                                        | Credential exchange, negotiation, upload, and manifest commit; no remote status endpoint                            |
+| Laptop capture         | Implemented for supported local provider sources                                   | Watching, bounded audits, SQLite snapshots, durable spooling, checkpoints, retries, and local status                |
+| Server derivation      | Not implemented                                                                    | Manifest materialization, parsing, transactional PostgreSQL projection, and embeddings are not running              |
+| Operations and cutover | Not implemented                                                                    | Retention, garbage collection, disaster rebuilds, rollout controls, and migration from `pg push` remain future work |
 
 The broader “device enrollment and authenticated raw transport” delivery item in
-#1352 remains incomplete because there is no supported way to enroll a device or
-upload the objects that a manifest references.
+#1352 remains incomplete because there is no supported way to enroll a device,
+and accepted raw generations are not yet turned into hosted sessions.
+
+## Laptop raw watch daemon
+
+`agentsview raw-sync watch` watches supported local provider roots, captures
+their original files, and uploads durable generations. It does not parse
+sessions or write the local SQLite archive. S3 roots are excluded.
+
+The server URL and device ID may be flags or environment variables. The device
+credential is environment-only so it does not appear in process arguments:
+
+```bash
+export AGENTSVIEW_RAW_SYNC_URL=https://agents.example.com
+export AGENTSVIEW_RAW_SYNC_DEVICE_ID=device-id
+export AGENTSVIEW_RAW_SYNC_CREDENTIAL=device-credential
+agentsview raw-sync watch
+```
+
+The command performs an initial bounded audit, watches for changes, repeats the
+audit every 15 minutes by default, and retries uploads every minute. Captures
+and upload state are kept under `raw-sync/` in the configured AgentsView data
+directory. `agentsview raw-sync status` prints path-free JSON describing the
+local checkpoint, pending work, retry time, failures, and coverage.
+
+The normal writable `agentsview serve` daemon has its own parser watcher. Run
+both only when local parsed sessions and hosted raw custody are both required;
+doing so intentionally creates two watchers over the same provider roots.
 
 ## HTTP control plane
 
@@ -63,19 +88,21 @@ The implemented routes are:
 | --------------------------------------- | --------------------------------------- | --------------------------------------- |
 | `POST /api/v1/raw-sync/tokens`          | Device credential and device ID         | Issue a 15-minute scoped access token   |
 | `POST /api/v1/raw-sync/objects/missing` | Access token with the `negotiate` scope | Return object references not in custody |
+| `POST /api/v1/raw-sync/uploads`         | Access token with the `upload` scope    | Start or resume an object upload        |
+| `HEAD /api/v1/raw-sync/uploads/{id}`    | Access token with the `upload` scope    | Read the accepted upload offset         |
+| `PATCH /api/v1/raw-sync/uploads/{id}`   | Access token with the `upload` scope    | Append and finalize object bytes        |
 | `POST /api/v1/raw-sync/manifests`       | Access token with the `commit` scope    | Validate and commit one raw generation  |
 
 These machine routes use their own device credentials and scoped tokens. They do
 not accept the shared bearer token that can protect the rest of a remote
 AgentsView server. The token endpoint accepts the fixed `negotiate`, `upload`,
-`commit`, and `status` scope names, although this branch exposes handlers only
-for negotiation and commit.
+`commit`, and `status` scope names. There is not yet a remote status handler;
+the current status command reads the laptop checkpoint.
 
 PostgreSQL stores device, token, manifest, receipt, source-head, and parse-job
 metadata. The raw object repository is opened lazily under `raw-sync/` in the
-configured AgentsView data directory. Because the HTTP surface cannot yet upload
-missing objects, it is a server foundation for the future laptop client, not a
-complete protocol for integrations.
+configured AgentsView data directory. The HTTP surface is still an internal
+protocol for the AgentsView laptop client, not a supported integration API.
 
 ## Raw custody contract
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -430,7 +430,10 @@ add an archived or maintained mirror without replacing the original identity.
   includes an unterminated invalid final record after `task_complete`;
   ordinary live parsing still defers that tail while its writer can complete
   it. This bounded lookup is deliberately separate from the provider's general
-  full-archive UUID discovery.
+  full-archive UUID discovery. Hosted raw discovery and event-driven capture
+  preserve each physical transcript under its configured root; duplicate
+  ranking remains limited to normalized discovery. Reverified 2026-08-29 with
+  live and archived copies sharing one UUID.
 
 ## TraeX (`traex`)
 

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -12,6 +12,8 @@ import (
 var _ Provider = (*claudeProvider)(nil)
 var _ S3Provider = (*claudeProvider)(nil)
 var _ RawCaptureProvider = (*claudeProvider)(nil)
+var _ RawCaptureSourceProvider = (*claudeProvider)(nil)
+var _ StreamingRawCaptureSourceProvider = (*claudeProvider)(nil)
 
 type claudeProviderFactory struct {
 	def AgentDef
@@ -50,6 +52,52 @@ func (p *claudeProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 
 func (p *claudeProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
 	return p.sources.DiscoverEach(ctx, yield)
+}
+
+func (p *claudeProvider) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	yield func(SourceRef) error,
+) (bool, error) {
+	ctx = withRawCaptureStreamingTraversal(ctx)
+	var incomplete error
+	for rootIndex, root := range p.sources.roots {
+		if err := ReportRawCaptureDiscoveryProgress(ctx); err != nil {
+			return false, err
+		}
+		if isS3URI(root) {
+			continue
+		}
+		err := p.sources.discoverEachRoot(ctx, root, func(source SourceRef) error {
+			for _, earlierRoot := range p.sources.roots[:rootIndex] {
+				earlier, ok := p.sources.sourceRefFromPath(
+					earlierRoot, source.DisplayPath,
+				)
+				if ok && earlier.Key == source.Key {
+					return nil
+				}
+			}
+			return yield(source)
+		})
+		if err == nil {
+			continue
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		rootErr, ok := rawCaptureIncompleteRootError(p.Def.Type, root, err)
+		if !ok {
+			return false, err
+		}
+		incomplete = errors.Join(incomplete, rootErr)
+	}
+	return incomplete == nil, incomplete
+}
+
+func (p *claudeProvider) RawCaptureSourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	return p.SourcesForChangedPath(ctx, req)
 }
 
 func (p *claudeProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
@@ -388,23 +436,30 @@ func (s claudeSourceSet) DiscoverEach(
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if strings.HasPrefix(root, "s3://") {
-			for _, file := range s.spec.listFiles(root) {
-				source, ok := s.discoveredSourceRef(root, file)
-				if ok {
-					if err := yield(source); err != nil {
-						return err
-					}
-				}
-			}
-			continue
-		}
-		err := s.streamLocalRoot(ctx, root, yield)
-		if err != nil {
+		if err := s.discoverEachRoot(ctx, root, yield); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (s claudeSourceSet) discoverEachRoot(
+	ctx context.Context,
+	root string,
+	yield func(SourceRef) error,
+) error {
+	if strings.HasPrefix(root, "s3://") {
+		for _, file := range s.spec.listFiles(root) {
+			source, ok := s.discoveredSourceRef(root, file)
+			if ok {
+				if err := yield(source); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	return s.streamLocalRoot(ctx, root, yield)
 }
 
 func (s claudeSourceSet) streamLocalRoot(

--- a/internal/parser/claude_provider_test.go
+++ b/internal/parser/claude_provider_test.go
@@ -271,6 +271,49 @@ func TestClaudeProviderStreamingDiscoveryPropagatesProjectSymlinkErrors(t *testi
 	})
 }
 
+func TestClaudeRawCaptureRootReplacementIsIncomplete(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "sessions")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "ignored.txt"), nil, 0o600,
+	))
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	paused := make(chan struct{})
+	resume := make(chan struct{})
+	progressCalls := 0
+	ctx := WithRawCaptureDiscoveryProgress(t.Context(), func() error {
+		progressCalls++
+		if progressCalls == 2 {
+			close(paused)
+			<-resume
+		}
+		return nil
+	})
+	type discoveryResult struct {
+		discovery RawCaptureDiscovery
+		err       error
+	}
+	resultCh := make(chan discoveryResult, 1)
+	go func() {
+		discovery, err := DiscoverRawCaptureSources(ctx, provider)
+		resultCh <- discoveryResult{discovery: discovery, err: err}
+	}()
+
+	<-paused
+	require.NoError(t, os.Rename(root, root+"-old"))
+	require.NoError(t, os.Mkdir(root, 0o700))
+	close(resume)
+	result := <-resultCh
+
+	require.Error(t, result.err)
+	assert.ErrorIs(t, result.err, errStreamingDirectoryChanged)
+	var incomplete DiscoveryIncompleteError
+	assert.ErrorAs(t, result.err, &incomplete)
+	assert.False(t, result.discovery.Complete)
+}
+
 func TestClaudeProviderStreamingDiscoveryStopsAfterYieldError(t *testing.T) {
 	root := t.TempDir()
 	for _, project := range []string{"-Users-dev-code-one", "-Users-dev-code-two"} {

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -16,6 +16,8 @@ var _ Provider = (*codexProvider)(nil)
 var _ ActivityHintProvider = (*codexProvider)(nil)
 var _ S3Provider = (*codexProvider)(nil)
 var _ RawCaptureProvider = (*codexProvider)(nil)
+var _ RawCaptureSourceProvider = (*codexProvider)(nil)
+var _ StreamingRawCaptureSourceProvider = (*codexProvider)(nil)
 
 // codexProviderSpec parameterizes the one shared Codex-format provider
 // implementation for Codex and its TraeX fork. Both reuse the same
@@ -112,6 +114,67 @@ func (p *codexProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 
 func (p *codexProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
 	return p.sources.DiscoverEach(ctx, yield)
+}
+
+func (p *codexProvider) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	yield func(SourceRef) error,
+) (bool, error) {
+	ctx = withRawCaptureStreamingTraversal(ctx)
+	var incomplete error
+	for _, root := range p.sources.roots {
+		if err := ReportRawCaptureDiscoveryProgress(ctx); err != nil {
+			return false, err
+		}
+		if isS3URI(root) {
+			continue
+		}
+		err := p.sources.discoverEachRoot(ctx, root, yield)
+		if err == nil {
+			continue
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		rootErr, ok := rawCaptureIncompleteRootError(p.Def.Type, root, err)
+		if !ok {
+			return false, err
+		}
+		incomplete = errors.Join(incomplete, rootErr)
+	}
+	return incomplete == nil, incomplete
+}
+
+func (p *codexProvider) RawCaptureSourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p.sources.ownsCodexSidecars() &&
+		filepath.Base(req.Path) == CodexSessionIndexFilename {
+		return nil, nil
+	}
+	roots := p.sources.roots
+	if req.WatchRoot != "" {
+		roots = nil
+		for _, root := range p.sources.roots {
+			if samePath(root, req.WatchRoot) {
+				roots = append(roots, root)
+			}
+		}
+	}
+	for _, root := range roots {
+		source, ok := p.sources.sourceRef(root, req.Path, true)
+		if !ok {
+			source, ok = p.sources.directPathSource(root, req.Path, true)
+		}
+		if ok {
+			return []SourceRef{source}, nil
+		}
+	}
+	return nil, nil
 }
 
 func (p *codexProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
@@ -524,40 +587,47 @@ func (s codexSourceSet) DiscoverEach(
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if strings.HasPrefix(root, "s3://") {
-			if !s.ownsCodexSidecars() {
-				continue
-			}
-			for _, file := range s3PrefixScan(root, codexS3Scanner()) {
-				if err := yield(s3SourceRefFromDiscoveredFile(root, file)); err != nil {
-					return err
-				}
-			}
-			continue
-		}
-		err := streamDirectoryTree(ctx, root, func(path string, entry os.DirEntry) error {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			if !isCodexSessionFilename(entry.Name()) {
-				return nil
-			}
-			source, ok := s.sourceRef(root, path, true)
-			if !ok {
-				if _, _, supported := CodexSessionPathInfo(root, path); supported {
-					source, ok = s.directPathSource(root, path, true)
-				}
-			}
-			if !ok {
-				return nil
-			}
-			return yield(source)
-		})
-		if err != nil {
+		if err := s.discoverEachRoot(ctx, root, yield); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (s codexSourceSet) discoverEachRoot(
+	ctx context.Context,
+	root string,
+	yield func(SourceRef) error,
+) error {
+	if strings.HasPrefix(root, "s3://") {
+		if !s.ownsCodexSidecars() {
+			return nil
+		}
+		for _, file := range s3PrefixScan(root, codexS3Scanner()) {
+			if err := yield(s3SourceRefFromDiscoveredFile(root, file)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return streamDirectoryTree(ctx, root, func(path string, entry os.DirEntry) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !isCodexSessionFilename(entry.Name()) {
+			return nil
+		}
+		source, ok := s.sourceRef(root, path, true)
+		if !ok {
+			if _, _, supported := CodexSessionPathInfo(root, path); supported {
+				source, ok = s.directPathSource(root, path, true)
+			}
+		}
+		if !ok {
+			return nil
+		}
+		return yield(source)
+	})
 }
 
 func (s codexSourceSet) discover(
@@ -960,7 +1030,8 @@ func (s codexSourceSet) canonicalSource(
 	if !ok || src.UUID == "" {
 		return source, true, nil
 	}
-	best := source
+	var best SourceRef
+	foundExisting := false
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
 			return SourceRef{}, false, err
@@ -973,9 +1044,13 @@ func (s codexSourceSet) canonicalSource(
 		if !ok {
 			continue
 		}
-		if preferCodexSource(candidate, best) {
+		if !foundExisting || preferCodexSource(candidate, best) {
 			best = candidate
+			foundExisting = true
 		}
+	}
+	if !foundExisting {
+		return source, true, nil
 	}
 	return best, true, nil
 }

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -1622,7 +1622,7 @@ func TestCodexProviderParseIncrementalHonorsContext(t *testing.T) {
 	assert.Equal(t, IncrementalUnsupported, status)
 }
 
-func TestCodexProviderDiscoverDedupesLiveAndArchivedByUUID(t *testing.T) {
+func TestCodexProviderRawDiscoveryKeepsLiveAndArchivedPhysicalSources(t *testing.T) {
 	base := t.TempDir()
 	liveRoot := filepath.Join(base, "sessions")
 	archivedRoot := filepath.Join(base, "archived_sessions")
@@ -1631,6 +1631,16 @@ func TestCodexProviderDiscoverDedupesLiveAndArchivedByUUID(t *testing.T) {
 	archivedPath := writeCodexProviderArchivedSession(
 		t, archivedRoot, uuid, "archived",
 	)
+	sharedMeta := testjsonl.CodexSessionMetaJSON(
+		uuid, "/home/user/code/api", "codex_cli_rs", "2026-06-11T12:44:06Z",
+	) + "\n"
+	require.NoError(t, os.WriteFile(livePath, []byte(sharedMeta), 0o644))
+	require.NoError(t, os.WriteFile(archivedPath, []byte(sharedMeta), 0o644))
+	renamedArchivedPath := filepath.Join(
+		archivedRoot, "rollout-2026-06-12T08-00-00-"+uuid+".jsonl",
+	)
+	require.NoError(t, os.Rename(archivedPath, renamedArchivedPath))
+	archivedPath = renamedArchivedPath
 
 	provider, ok := NewProvider(AgentCodex, ProviderConfig{
 		Roots: []string{archivedRoot, liveRoot},
@@ -1641,6 +1651,13 @@ func TestCodexProviderDiscoverDedupesLiveAndArchivedByUUID(t *testing.T) {
 	require.Len(t, discovered, 1)
 	assert.Equal(t, livePath, discovered[0].DisplayPath)
 	assert.NotEqual(t, archivedPath, discovered[0].DisplayPath)
+
+	rawDiscovery, err := DiscoverRawCaptureSources(t.Context(), provider)
+	require.NoError(t, err)
+	require.True(t, rawDiscovery.Complete)
+	require.Len(t, rawDiscovery.Sources, 2)
+	assert.ElementsMatch(t, []string{archivedPath, livePath},
+		sourceDisplayPaths(rawDiscovery.Sources))
 }
 
 func TestCodexProviderDiscoverEachYieldsDuplicateCandidates(t *testing.T) {
@@ -1664,6 +1681,35 @@ func TestCodexProviderDiscoverEachYieldsDuplicateCandidates(t *testing.T) {
 	}))
 
 	assert.ElementsMatch(t, []string{archivedPath, livePath}, paths)
+}
+
+func TestCodexRawCaptureDiscoveryContinuesAfterIncompleteRoot(t *testing.T) {
+	unreadableRoot := t.TempDir()
+	healthyRoot := t.TempDir()
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e5"
+	healthyPath := writeCodexProviderSession(t, healthyRoot, uuid, "healthy")
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{
+		Roots: []string{unreadableRoot, healthyRoot},
+	})
+	require.True(t, ok)
+	ctx := withStreamingDirectoryReader(t.Context(), func(
+		ctx context.Context,
+		dir string,
+		yield func(os.DirEntry) error,
+	) error {
+		if dir == unreadableRoot {
+			return os.ErrPermission
+		}
+		return streamDirectoryEntriesDirect(ctx, dir, yield)
+	})
+
+	discovery, err := DiscoverRawCaptureSources(ctx, provider)
+	require.Error(t, err)
+	_, incomplete := errors.AsType[DiscoveryIncompleteError](err)
+	require.True(t, incomplete)
+	assert.False(t, discovery.Complete)
+	require.Len(t, discovery.Sources, 1)
+	assert.Equal(t, healthyPath, discovery.Sources[0].DisplayPath)
 }
 
 func TestCodexProviderDiscoverEachIncludesNoncanonicalRollout(t *testing.T) {
@@ -1901,6 +1947,14 @@ func TestCodexProviderChangedPathPinsArchivedDuplicate(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, changed, 1)
 	assert.Equal(t, archivedPath, changed[0].DisplayPath)
+
+	rawChanged, err := RawCaptureSourcesForChangedPath(
+		t.Context(), provider,
+		ChangedPathRequest{Path: archivedPath, EventKind: "write"},
+	)
+	require.NoError(t, err)
+	require.Len(t, rawChanged, 1)
+	assert.Equal(t, archivedPath, rawChanged[0].DisplayPath)
 }
 
 func TestCodexProviderChangedPathClassifiesRemovedTranscript(t *testing.T) {
@@ -1941,6 +1995,30 @@ func TestCodexProviderIndexPathClassifiesAllSiblingSources(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, []string{firstPath, secondPath}, sourceDisplayPaths(changed))
+}
+
+func TestCodexProviderRawIndexPathDefersToBoundedAudit(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "sessions")
+	writeCodexProviderSession(
+		t, root, "019eb791-cf7d-75c1-8439-9ed74c1229e9", "first",
+	)
+	writeCodexProviderSession(
+		t, root, "019eb791-cf7d-75c1-8439-9ed74c1229ea", "second",
+	)
+	indexPath := filepath.Join(base, CodexSessionIndexFilename)
+	require.NoError(t, os.WriteFile(indexPath, []byte("{}\n"), 0o644))
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	changed, err := RawCaptureSourcesForChangedPath(
+		t.Context(), provider, ChangedPathRequest{
+			Path: indexPath, EventKind: "write", WatchRoot: base,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, changed)
 }
 
 func writeCodexProviderSession(

--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -37,14 +37,14 @@ func (f dbBackedProviderFactory) Definition() AgentDef {
 }
 
 func (f dbBackedProviderFactory) Capabilities() Capabilities {
-	return f.spec.caps
+	return withDBBackedRawCapture(f.spec.caps)
 }
 
 func (f dbBackedProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	cfg = cfg.Clone()
 	return &dbBackedProvider{
 		Def:     cloneAgentDef(f.def),
-		Caps:    f.spec.caps,
+		Caps:    withDBBackedRawCapture(f.spec.caps),
 		Config:  cfg,
 		spec:    f.spec,
 		sources: newDBBackedSourceSet(f.spec, cfg.Roots),
@@ -55,6 +55,133 @@ type dbBackedProvider struct {
 	ProviderBase
 	spec    dbBackedProviderSpec
 	sources dbBackedSourceSet
+}
+
+var _ StreamingRawCaptureSourceProvider = (*dbBackedProvider)(nil)
+
+type dbBackedRawSource struct {
+	Root   string
+	DBPath string
+}
+
+func withDBBackedRawCapture(capabilities Capabilities) Capabilities {
+	capabilities.RawCapture = RawCaptureCapabilities{
+		Support:  CapabilitySupported,
+		Shape:    RawCaptureShapeSQLite,
+		Append:   RawCaptureAppendReplaceOnly,
+		Snapshot: RawCaptureSnapshotOnlineBackup,
+	}
+	return capabilities
+}
+
+func (p *dbBackedProvider) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	yield func(SourceRef) error,
+) (bool, error) {
+	complete := true
+	for _, root := range p.sources.roots {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		if err := ReportRawCaptureDiscoveryProgress(ctx); err != nil {
+			return false, err
+		}
+		dbPath := p.spec.findDB(root)
+		if dbPath == "" {
+			complete = complete && rawCaptureDBRootComplete(root, p.spec.dbName)
+			continue
+		}
+		if !rawCaptureDBPathRegular(dbPath) {
+			complete = false
+			continue
+		}
+		if err := yield(p.newRawCaptureSource(root, dbPath)); err != nil {
+			return false, err
+		}
+	}
+	return complete, nil
+}
+
+func rawCaptureDBPathRegular(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}
+
+func rawCaptureDBRootComplete(root, dbName string) bool {
+	info, err := os.Stat(root)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	dbInfo, err := os.Lstat(filepath.Join(root, dbName))
+	if err == nil {
+		return dbInfo.Mode().IsRegular()
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
+}
+
+func (p *dbBackedProvider) RawCaptureSourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for _, root := range p.sources.roots {
+		if req.WatchRoot != "" && !samePath(req.WatchRoot, root) {
+			continue
+		}
+		dbPath, ok := p.sources.dbPathForEvent(root, req.Path)
+		if !ok || !IsRegularFile(dbPath) {
+			continue
+		}
+		return []SourceRef{p.newRawCaptureSource(root, dbPath)}, nil
+	}
+	return nil, nil
+}
+
+func (p *dbBackedProvider) PlanRawCapture(
+	ctx context.Context,
+	source SourceRef,
+) (RawCapturePlan, error) {
+	if err := ctx.Err(); err != nil {
+		return RawCapturePlan{}, err
+	}
+	raw, ok := source.Opaque.(dbBackedRawSource)
+	if !ok || raw.Root == "" || raw.DBPath == "" {
+		return RawCapturePlan{}, invalidRawCapturePlan("database source path unavailable")
+	}
+	if source.Provider != p.spec.agent || source.Key != p.spec.dbName ||
+		!samePath(raw.DBPath, filepath.Join(raw.Root, p.spec.dbName)) ||
+		!IsRegularFile(raw.DBPath) {
+		return RawCapturePlan{}, invalidRawCapturePlan("database source does not match provider root")
+	}
+	return RawCapturePlan{
+		ConfiguredRoot: raw.Root,
+		CaptureRoot:    raw.Root,
+		SourceKey:      source.Key,
+		Entries: []RawCaptureEntry{{
+			Path:      p.spec.dbName,
+			LocalPath: raw.DBPath,
+		}},
+	}, nil
+}
+
+func (p *dbBackedProvider) newRawCaptureSource(root, dbPath string) SourceRef {
+	return SourceRef{
+		Provider:       p.spec.agent,
+		Key:            p.spec.dbName,
+		DisplayPath:    dbPath,
+		FingerprintKey: dbPath,
+		Opaque: dbBackedRawSource{
+			Root: root, DBPath: dbPath,
+		},
+	}
 }
 
 func (p *dbBackedProvider) Discover(ctx context.Context) ([]SourceRef, error) {

--- a/internal/parser/db_backed_provider_test.go
+++ b/internal/parser/db_backed_provider_test.go
@@ -98,6 +98,154 @@ func TestForgeProviderSourceMethodsAndParse(t *testing.T) {
 	assert.Len(t, result.Result.Messages, 4)
 }
 
+type rawCaptureSourceDiscoverer interface {
+	RawCaptureSourcesForChangedPath(
+		context.Context, ChangedPathRequest,
+	) ([]SourceRef, error)
+}
+
+func TestDBBackedProviderRawCaptureUsesOnePhysicalDatabaseSource(t *testing.T) {
+	dbPath, seeder, db := newForgeTestDB(t)
+	defer db.Close()
+	seedForgeConversation(t, seeder)
+	seeder.AddConversation(
+		"conv-002", "Second", 123,
+		`{"conversation_id":"conv-002","messages":[]}`,
+		"2026-05-03 09:58:15.000000000",
+		"2026-05-03 10:00:16.000000000", "",
+	)
+	root := filepath.Dir(dbPath)
+	provider, ok := NewProvider(AgentForge, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discoverer, ok := provider.(rawCaptureSourceDiscoverer)
+	require.True(t, ok, "db-backed providers must expose physical raw sources")
+	discovery, err := DiscoverRawCaptureSources(t.Context(), provider)
+	require.NoError(t, err)
+	require.True(t, discovery.Complete)
+	sources := discovery.Sources
+	require.Len(t, sources, 1)
+	assert.Equal(t, ForgeDBFilename, sources[0].Key)
+	assert.Equal(t, dbPath, sources[0].DisplayPath)
+
+	changed, err := discoverer.RawCaptureSourcesForChangedPath(
+		t.Context(), ChangedPathRequest{
+			Path:      dbPath + "-wal",
+			EventKind: "write",
+			WatchRoot: root,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, sources, changed)
+
+	capabilities := provider.Capabilities().RawCapture
+	assert.Equal(t, RawCaptureCapabilities{
+		Support:  CapabilitySupported,
+		Shape:    RawCaptureShapeSQLite,
+		Append:   RawCaptureAppendReplaceOnly,
+		Snapshot: RawCaptureSnapshotOnlineBackup,
+	}, capabilities)
+	planner, ok := provider.(RawCaptureProvider)
+	require.True(t, ok)
+	plan, err := planner.PlanRawCapture(t.Context(), sources[0])
+	require.NoError(t, err)
+	assert.Equal(t, root, plan.ConfiguredRoot)
+	assert.Equal(t, root, plan.CaptureRoot)
+	assert.Equal(t, ForgeDBFilename, plan.SourceKey)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, RawCaptureEntry{
+		Path: ForgeDBFilename, LocalPath: dbPath,
+	}, plan.Entries[0])
+}
+
+func TestDBBackedProviderRawCaptureReportsDiscoveryCompleteness(t *testing.T) {
+	dbPath, _, db := newForgeTestDB(t)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	healthyRoot := filepath.Dir(dbPath)
+	nonRegularRoot := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(nonRegularRoot, ForgeDBFilename), 0o755))
+
+	tests := []struct {
+		name       string
+		secondRoot string
+		complete   bool
+	}{
+		{
+			name:       "configured root unavailable",
+			secondRoot: filepath.Join(t.TempDir(), "missing"),
+			complete:   false,
+		},
+		{
+			name:       "database absent from accessible root",
+			secondRoot: t.TempDir(),
+			complete:   true,
+		},
+		{
+			name:       "database path is not a regular file",
+			secondRoot: nonRegularRoot,
+			complete:   false,
+		},
+	}
+	danglingRoot := t.TempDir()
+	if err := os.Symlink(
+		filepath.Join(danglingRoot, "missing.db"),
+		filepath.Join(danglingRoot, ForgeDBFilename),
+	); err == nil {
+		tests = append(tests, struct {
+			name       string
+			secondRoot string
+			complete   bool
+		}{
+			name:       "database path is a dangling symlink",
+			secondRoot: danglingRoot,
+			complete:   false,
+		})
+	} else {
+		t.Logf("dangling symlink coverage unavailable: %v", err)
+	}
+	linkedDatabaseRoot := t.TempDir()
+	if err := os.Symlink(
+		dbPath, filepath.Join(linkedDatabaseRoot, ForgeDBFilename),
+	); err == nil {
+		tests = append(tests, struct {
+			name       string
+			secondRoot string
+			complete   bool
+		}{
+			name:       "database path is a symlink to a regular file",
+			secondRoot: linkedDatabaseRoot,
+			complete:   false,
+		})
+	} else {
+		t.Logf("regular symlink coverage unavailable: %v", err)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, ok := NewProvider(AgentForge, ProviderConfig{
+				Roots: []string{healthyRoot, tt.secondRoot},
+			})
+			require.True(t, ok)
+			discovery, err := DiscoverRawCaptureSources(t.Context(), provider)
+			require.NoError(t, err)
+			assert.Equal(t, tt.complete, discovery.Complete)
+			require.Len(t, discovery.Sources, 1)
+			assert.Equal(t, dbPath, discovery.Sources[0].DisplayPath)
+
+			var streamed []SourceRef
+			complete, err := StreamRawCaptureSources(
+				t.Context(), provider, func(source SourceRef) error {
+					streamed = append(streamed, source)
+					return nil
+				},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.complete, complete)
+			require.Len(t, streamed, 1)
+			assert.Equal(t, dbPath, streamed[0].DisplayPath)
+		})
+	}
+}
+
 func TestPiebaldProviderSourceMethodsAndParse(t *testing.T) {
 	dbPath := newPiebaldTestDB(t)
 	seedPiebaldProviderBasicChat(t, dbPath)

--- a/internal/parser/goose_provider.go
+++ b/internal/parser/goose_provider.go
@@ -32,7 +32,7 @@ func (f *gooseProviderFactory) Definition() AgentDef {
 }
 
 func (f *gooseProviderFactory) Capabilities() Capabilities {
-	return gooseProviderCapabilities()
+	return withDBBackedRawCapture(gooseProviderCapabilities())
 }
 
 func (f *gooseProviderFactory) NewProvider(cfg ProviderConfig) Provider {
@@ -41,7 +41,7 @@ func (f *gooseProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	spec := gooseProviderSpec()
 	base := &dbBackedProvider{
 		Def:     cloneAgentDef(f.def),
-		Caps:    spec.caps,
+		Caps:    withDBBackedRawCapture(spec.caps),
 		Config:  cfg,
 		spec:    spec,
 		sources: newDBBackedSourceSet(spec, cfg.Roots),

--- a/internal/parser/raw_capture.go
+++ b/internal/parser/raw_capture.go
@@ -69,9 +69,147 @@ type RawCapturePlan struct {
 	Entries        []RawCaptureEntry
 }
 
+// RawCaptureDiscovery reports physical sources and whether every configured
+// root was enumerated successfully. Incomplete results may still be captured,
+// but callers must not infer deletions from omitted sources.
+type RawCaptureDiscovery struct {
+	Sources  []SourceRef
+	Complete bool
+}
+
 // RawCaptureProvider is the optional provider-owned physical source contract.
 type RawCaptureProvider interface {
 	PlanRawCapture(context.Context, SourceRef) (RawCapturePlan, error)
+}
+
+// RawCaptureSourceProvider optionally exposes physical raw sources separately
+// from the provider's normalized per-session discovery surface.
+type RawCaptureSourceProvider interface {
+	RawCaptureSourcesForChangedPath(
+		context.Context, ChangedPathRequest,
+	) ([]SourceRef, error)
+}
+
+// StreamingRawCaptureSourceProvider emits physical raw sources without
+// retaining the provider's complete discovery result in memory.
+type StreamingRawCaptureSourceProvider interface {
+	DiscoverRawCaptureSourcesEach(
+		context.Context, func(SourceRef) error,
+	) (complete bool, err error)
+}
+
+type rawCaptureDiscoveryProgressContextKey struct{}
+
+// WithRawCaptureDiscoveryProgress installs the periodic auditor's bounded
+// traversal handshake. Raw-capture providers report each filesystem entry or
+// configured root before examining it so the auditor can suspend the scan.
+func WithRawCaptureDiscoveryProgress(
+	ctx context.Context,
+	progress func() error,
+) context.Context {
+	return context.WithValue(ctx, rawCaptureDiscoveryProgressContextKey{}, progress)
+}
+
+// ReportRawCaptureDiscoveryProgress reports one physical discovery step when
+// a bounded traversal handshake is installed. Other discovery callers pay no
+// callback cost beyond the context lookup.
+func ReportRawCaptureDiscoveryProgress(ctx context.Context) error {
+	progress, _ := ctx.Value(rawCaptureDiscoveryProgressContextKey{}).(func() error)
+	if progress == nil {
+		return nil
+	}
+	return progress()
+}
+
+// StreamRawCaptureSources discovers physical raw sources through the bounded
+// callback surface required by raw-capture providers.
+func StreamRawCaptureSources(
+	ctx context.Context,
+	provider Provider,
+	yield func(SourceRef) error,
+) (bool, error) {
+	if streaming, ok := provider.(StreamingRawCaptureSourceProvider); ok {
+		return streaming.DiscoverRawCaptureSourcesEach(ctx, yield)
+	}
+	return false, UnsupportedProviderFeatureError{
+		Provider: provider.Definition().Type,
+		Feature:  ProviderFeatureRawCapture,
+	}
+}
+
+// DiscoverRawCaptureSources discovers physical raw sources without parsing.
+func DiscoverRawCaptureSources(
+	ctx context.Context,
+	provider Provider,
+) (RawCaptureDiscovery, error) {
+	if _, ok := provider.(StreamingRawCaptureSourceProvider); ok {
+		var sources []SourceRef
+		complete, err := StreamRawCaptureSources(ctx, provider, func(source SourceRef) error {
+			sources = append(sources, source)
+			return nil
+		})
+		sortJSONLSources(sources)
+		return RawCaptureDiscovery{Sources: sources, Complete: complete}, err
+	}
+	if provider.Capabilities().RawCapture.Support == CapabilitySupported {
+		return RawCaptureDiscovery{}, UnsupportedProviderFeatureError{
+			Provider: provider.Definition().Type,
+			Feature:  ProviderFeatureRawCapture,
+		}
+	}
+	if streaming, ok := provider.(StreamingDiscoverer); ok {
+		return collectRawCaptureDiscovery(ctx, streaming.DiscoverEach)
+	}
+	sources, err := provider.Discover(ctx)
+	return RawCaptureDiscovery{Sources: sources, Complete: err == nil}, err
+}
+
+func collectRawCaptureDiscovery(
+	ctx context.Context,
+	discover func(context.Context, func(SourceRef) error) error,
+) (RawCaptureDiscovery, error) {
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	err := discover(ctx, func(source SourceRef) error {
+		addJSONLSource(source, &sources, seen)
+		return nil
+	})
+	sortJSONLSources(sources)
+	return RawCaptureDiscovery{Sources: sources, Complete: err == nil}, err
+}
+
+func rawCaptureIncompleteRootError(
+	provider AgentType,
+	root string,
+	err error,
+) (error, bool) {
+	if _, ok := errors.AsType[DiscoveryIncompleteError](err); ok {
+		return err, true
+	}
+	if errors.Is(err, errStreamingDirectoryChanged) {
+		return incompleteDiscoveryError(
+			provider, "discover raw capture root "+root, err,
+		), true
+	}
+	if _, ok := errors.AsType[*os.PathError](err); ok {
+		return incompleteDiscoveryError(
+			provider, "discover raw capture root "+root, err,
+		), true
+	}
+	return err, false
+}
+
+// RawCaptureSourcesForChangedPath maps a watcher event to physical raw
+// sources without routing database events through per-session discovery.
+func RawCaptureSourcesForChangedPath(
+	ctx context.Context,
+	provider Provider,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if physical, ok := provider.(RawCaptureSourceProvider); ok {
+		return physical.RawCaptureSourcesForChangedPath(ctx, req)
+	}
+	return provider.SourcesForChangedPath(ctx, req)
 }
 
 // ResolveRawCapturePlan returns and validates a provider-owned raw source plan.
@@ -113,8 +251,13 @@ func validateRawCapturePlan(
 	source SourceRef,
 	plan RawCapturePlan,
 ) (RawCapturePlan, error) {
-	if capabilities.Shape != RawCaptureShapeFiles ||
-		capabilities.Snapshot != RawCaptureSnapshotNone {
+	switch {
+	case capabilities.Shape == RawCaptureShapeFiles &&
+		capabilities.Snapshot == RawCaptureSnapshotNone:
+	case capabilities.Shape == RawCaptureShapeSQLite &&
+		capabilities.Snapshot == RawCaptureSnapshotOnlineBackup &&
+		capabilities.Append == RawCaptureAppendReplaceOnly:
+	default:
 		return RawCapturePlan{}, invalidRawCapturePlan("unsupported source shape or snapshot requirement")
 	}
 	if plan.SourceKey == "" || plan.SourceKey != source.Key {
@@ -184,6 +327,9 @@ func validateRawCapturePlan(
 		}
 	default:
 		return RawCapturePlan{}, invalidRawCapturePlan("unknown append policy %d", capabilities.Append)
+	}
+	if capabilities.Shape == RawCaptureShapeSQLite && len(entries) != 1 {
+		return RawCapturePlan{}, invalidRawCapturePlan("SQLite source must have exactly one entry")
 	}
 	slices.SortFunc(entries, func(a, b RawCaptureEntry) int {
 		return strings.Compare(a.Path, b.Path)

--- a/internal/parser/raw_capture_test.go
+++ b/internal/parser/raw_capture_test.go
@@ -38,6 +38,33 @@ type rawCaptureUndeclaredProvider struct {
 	ProviderBase
 }
 
+type streamingRawCaptureTestProvider struct {
+	rawCaptureTestProvider
+	sources     []SourceRef
+	complete    bool
+	streamCalls int
+}
+
+func (p *streamingRawCaptureTestProvider) DiscoverRawCaptureSourcesEach(
+	_ context.Context,
+	yield func(SourceRef) error,
+) (bool, error) {
+	p.streamCalls++
+	for _, source := range p.sources {
+		if err := yield(source); err != nil {
+			return false, err
+		}
+	}
+	return p.complete, nil
+}
+
+func (p *streamingRawCaptureTestProvider) RawCaptureSourcesForChangedPath(
+	context.Context,
+	ChangedPathRequest,
+) ([]SourceRef, error) {
+	return nil, nil
+}
+
 func (p *rawCaptureUndeclaredProvider) Parse(
 	context.Context,
 	ParseRequest,
@@ -52,6 +79,53 @@ func rawCaptureTestCapabilities() Capabilities {
 		Append:   RawCaptureAppendOne,
 		Snapshot: RawCaptureSnapshotNone,
 	}}
+}
+
+func TestStreamRawCaptureSourcesUsesProviderStreamWithoutCollecting(t *testing.T) {
+	provider := &streamingRawCaptureTestProvider{
+		sources: []SourceRef{
+			{Provider: AgentClaude, Key: "a"},
+			{Provider: AgentClaude, Key: "b"},
+		},
+		complete: true,
+	}
+	provider.Def = AgentDef{Type: AgentClaude}
+	provider.Caps = rawCaptureTestCapabilities()
+	var got []string
+
+	complete, err := StreamRawCaptureSources(
+		t.Context(), provider, func(source SourceRef) error {
+			got = append(got, source.Key)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, complete)
+	assert.Equal(t, []string{"a", "b"}, got)
+	assert.Equal(t, 1, provider.streamCalls)
+}
+
+func TestDiscoverRawCaptureSourcesCollectsProviderStream(t *testing.T) {
+	provider := &streamingRawCaptureTestProvider{
+		sources: []SourceRef{
+			{Provider: AgentClaude, Key: "a"},
+			{Provider: AgentClaude, Key: "b"},
+		},
+		complete: true,
+	}
+	provider.Def = AgentDef{Type: AgentClaude}
+	provider.Caps = rawCaptureTestCapabilities()
+
+	discovery, err := DiscoverRawCaptureSources(t.Context(), provider)
+
+	require.NoError(t, err)
+	assert.True(t, discovery.Complete)
+	assert.Equal(t, []SourceRef{
+		{Provider: AgentClaude, Key: "a"},
+		{Provider: AgentClaude, Key: "b"},
+	}, discovery.Sources)
+	assert.Equal(t, 1, provider.streamCalls)
 }
 
 func canonicalRawCaptureTestPath(t *testing.T, path string) string {

--- a/internal/parser/streaming_discovery.go
+++ b/internal/parser/streaming_discovery.go
@@ -11,6 +11,7 @@ import (
 const streamingDirectoryBatchSize = 64
 
 var errStopStreamingDiscovery = errors.New("stop streaming discovery")
+var errStreamingDirectoryChanged = errors.New("streaming directory changed during discovery")
 
 // DiscoveryIncompleteError reports a bounded traversal that stopped before it
 // could authoritatively enumerate its configured scope. Callers must retain the
@@ -252,11 +253,27 @@ func streamDirectoryEntries(
 func streamDirectoryEntriesDirect(
 	ctx context.Context, dir string, yield func(os.DirEntry) error,
 ) error {
-	file, err := os.Open(dir)
+	root, err := os.OpenRoot(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
+		return err
+	}
+	file, err := root.Open(".")
+	if err != nil {
+		_ = root.Close()
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	// Root.Open on Windows establishes the directory file with delete sharing,
+	// while OpenRoot's traversal handle itself does not. Once the directory
+	// file is open, retaining the root handle adds no confinement and would
+	// prevent a paused bounded audit from allowing that directory to be renamed.
+	if err := root.Close(); err != nil {
+		_ = file.Close()
 		return err
 	}
 	defer file.Close()
@@ -283,6 +300,42 @@ func streamDirectoryEntriesDirect(
 			return readErr
 		}
 	}
+}
+
+func withRawCaptureStreamingTraversal(ctx context.Context) context.Context {
+	reader := streamingDirectoryReader(streamDirectoryEntriesDirect)
+	if configured, ok := ctx.Value(
+		streamingDirectoryReaderContextKey{},
+	).(streamingDirectoryReader); ok {
+		reader = configured
+	}
+	return withStreamingDirectoryReader(ctx, func(
+		readerCtx context.Context,
+		dir string,
+		yield func(os.DirEntry) error,
+	) error {
+		openedInfo, err := os.Stat(dir)
+		if err != nil {
+			return err
+		}
+		err = reader(readerCtx, dir, func(entry os.DirEntry) error {
+			if err := ReportRawCaptureDiscoveryProgress(readerCtx); err != nil {
+				return err
+			}
+			return yield(entry)
+		})
+		if err != nil {
+			return err
+		}
+		currentInfo, err := os.Stat(dir)
+		if err != nil {
+			return errors.Join(errStreamingDirectoryChanged, err)
+		}
+		if !os.SameFile(openedInfo, currentInfo) {
+			return errStreamingDirectoryChanged
+		}
+		return nil
+	})
 }
 
 // streamDirectoryTree walks a directory without filepath.WalkDir's

--- a/internal/parser/streaming_discovery.go
+++ b/internal/parser/streaming_discovery.go
@@ -318,6 +318,9 @@ func withRawCaptureStreamingTraversal(ctx context.Context) context.Context {
 		if err != nil {
 			return err
 		}
+		// Windows resolves Stat identity lazily from the path. Prime it before
+		// traversal so a replacement cannot make openedInfo adopt the new ID.
+		_ = os.SameFile(openedInfo, openedInfo)
 		err = reader(readerCtx, dir, func(entry os.DirEntry) error {
 			if err := ReportRawCaptureDiscoveryProgress(readerCtx); err != nil {
 				return err

--- a/internal/parser/streaming_discovery_test.go
+++ b/internal/parser/streaming_discovery_test.go
@@ -114,3 +114,38 @@ func TestStreamDirectoryEntriesStopsAfterMidTraversalCancellation(t *testing.T) 
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, streamingDirectoryBatchSize+1, count)
 }
+
+func TestStreamDirectoryEntriesRejectsReplacementWhilePaused(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "sessions")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	for _, name := range []string{"a.jsonl", "b.jsonl"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+	}
+	paused := make(chan struct{})
+	resume := make(chan struct{})
+	first := true
+	ctx := WithRawCaptureDiscoveryProgress(t.Context(), func() error {
+		if first {
+			first = false
+			close(paused)
+			<-resume
+		}
+		return nil
+	})
+	ctx = withRawCaptureStreamingTraversal(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- streamDirectoryEntries(ctx, dir, func(os.DirEntry) error {
+			return nil
+		})
+	}()
+
+	<-paused
+	moved := dir + "-moved"
+	require.NoError(t, os.Rename(dir, moved))
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "replacement.jsonl"), nil, 0o600))
+	close(resume)
+
+	assert.ErrorIs(t, <-errCh, errStreamingDirectoryChanged)
+}

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -30,7 +30,7 @@ func (f zcodeProviderFactory) Definition() AgentDef {
 }
 
 func (f zcodeProviderFactory) Capabilities() Capabilities {
-	return zcodeProviderCapabilities()
+	return withDBBackedRawCapture(zcodeProviderCapabilities())
 }
 
 func (f zcodeProviderFactory) NewProvider(cfg ProviderConfig) Provider {
@@ -39,7 +39,7 @@ func (f zcodeProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	spec := zcodeProviderSpec()
 	return &dbBackedProvider{
 		Def:     cloneAgentDef(f.def),
-		Caps:    spec.caps,
+		Caps:    withDBBackedRawCapture(spec.caps),
 		Config:  cfg,
 		spec:    spec,
 		sources: newDBBackedSourceSet(spec, cfg.Roots),

--- a/internal/rawcapture/capturer.go
+++ b/internal/rawcapture/capturer.go
@@ -5,6 +5,7 @@ package rawcapture
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -41,12 +42,13 @@ const (
 )
 
 type observedCaptureEntry struct {
-	planned  parser.RawCaptureEntry
-	root     *os.Root
-	relative string
-	file     *os.File
-	info     os.FileInfo
-	identity string
+	planned            parser.RawCaptureEntry
+	root               *os.Root
+	relative           string
+	file               *os.File
+	info               os.FileInfo
+	identity           string
+	checkpointIdentity string
 }
 
 type capturedFileState struct {
@@ -83,6 +85,7 @@ type Capturer struct {
 	store          *rawcheckpoint.Store
 	files          fileOperations
 	manifestLimits rawsync.ManifestLimits
+	sqliteBackup   func(context.Context, *sql.Conn, string, int64) error
 	capturePhase   func(capturePhase, string)
 	discardObjects func(context.Context, []rawsync.ObjectRef) error
 }
@@ -92,6 +95,7 @@ func New(store *rawcheckpoint.Store) *Capturer {
 	return &Capturer{
 		store: store, files: defaultFileOperations(),
 		manifestLimits: rawsync.DefaultManifestLimits(),
+		sqliteBackup:   sqliteOnlineBackup,
 		discardObjects: store.DiscardUnreferencedObjects,
 	}
 }
@@ -106,10 +110,6 @@ func (c *Capturer) Capture(
 		return Result{}, err
 	}
 	capabilities := provider.Capabilities().RawCapture
-	if capabilities.Snapshot != parser.RawCaptureSnapshotNone ||
-		capabilities.Shape == parser.RawCaptureShapeSQLite {
-		return Result{}, ErrUnsupportedSnapshot
-	}
 	plan, supported, err := parser.ResolveRawCapturePlan(ctx, provider, source)
 	if err != nil {
 		return Result{}, err
@@ -117,17 +117,8 @@ func (c *Capturer) Capture(
 	if !supported {
 		return Result{}, ErrUnsupportedProvider
 	}
-	scope, err := openCapturePlanScope(plan)
-	if err != nil {
-		return Result{}, err
-	}
-	defer func() {
-		resultErr = errors.Join(resultErr, scope.Close())
-		if resultErr != nil {
-			result = Result{}
-		}
-	}()
-	root, err := c.store.ResolveConfiguredRoot(ctx, source.Provider, plan.ConfiguredRoot)
+	originalPlan := plan
+	root, err := c.store.ResolveConfiguredRoot(ctx, source.Provider, originalPlan.ConfiguredRoot)
 	if err != nil {
 		return Result{}, err
 	}
@@ -136,24 +127,7 @@ func (c *Capturer) Capture(
 		ConfiguredRootID: root.ID,
 		SourceKey:        plan.SourceKey,
 	}
-	base, hasBase, err := c.store.CaptureBase(ctx, identity)
-	if err != nil {
-		return Result{}, err
-	}
-	observed, sourceBytes, err := c.observePlan(scope)
-	if err != nil {
-		return Result{}, err
-	}
-	defer closeObservedEntries(observed)
-	provisional := c.provisionalAssessment(observed, sourceBytes, base, hasBase)
-	reservationBytes := captureReservationBytes(provisional)
-	reservation, err := c.store.ReserveSourceCapture(ctx, identity, reservationBytes)
-	if errors.Is(err, rawcheckpoint.ErrOutboxFull) {
-		return Result{Status: StatusDegraded, Source: identity}, nil
-	}
-	if err != nil {
-		return Result{}, err
-	}
+	var reservation rawcheckpoint.Reservation
 	committed := false
 	cleanupIncomplete := false
 	var installed []rawsync.ObjectRef
@@ -169,16 +143,148 @@ func (c *Capturer) Capture(
 				)
 			}
 			resultErr = errors.Join(resultErr, cleanupErr)
+			if resultErr != nil {
+				result = Result{}
+			}
 		}
 		finishPublication()
 	}()
+	snapshot := false
+	observationRecorded := false
+	var removeSnapshot func() error
+	switch {
+	case capabilities.Shape == parser.RawCaptureShapeFiles &&
+		capabilities.Snapshot == parser.RawCaptureSnapshotNone:
+	case capabilities.Shape == parser.RawCaptureShapeSQLite &&
+		capabilities.Snapshot == parser.RawCaptureSnapshotOnlineBackup:
+		sourcePath := plan.Entries[0].LocalPath
+		if c.capturePhase != nil {
+			c.capturePhase(capturePhaseBeforeRead, sourcePath)
+		}
+		sourceScope, scopeErr := openCapturePlanScope(plan)
+		if scopeErr != nil {
+			return Result{}, scopeErr
+		}
+		defer func() {
+			resultErr = errors.Join(resultErr, sourceScope.Close())
+			if resultErr != nil {
+				result = Result{}
+			}
+		}()
+		sourceObserved, _, observeErr := c.observePlan(sourceScope)
+		if observeErr != nil {
+			return Result{}, observeErr
+		}
+		defer closeObservedEntries(sourceObserved)
+		if len(sourceObserved) != 1 {
+			return Result{}, ErrSourceChanged
+		}
+		sqliteSource, openErr := openSQLiteSnapshotSource(
+			ctx, sourcePath, sourceObserved[0].info,
+		)
+		if openErr != nil {
+			return Result{}, openErr
+		}
+		defer func() {
+			resultErr = errors.Join(resultErr, sqliteSource.Close())
+			if resultErr != nil {
+				result = Result{}
+			}
+		}()
+		snapshotBytes, sizeErr := sqliteOnlineBackupSize(ctx, sqliteSource.connection)
+		if sizeErr != nil {
+			return Result{}, sizeErr
+		}
+		if err := c.store.RecordSourceObservation(ctx, identity); err != nil {
+			return Result{}, err
+		}
+		observationRecorded = true
+		reservationBytes := sqliteSnapshotReservationBytes(snapshotBytes)
+		reservation, err = c.store.ReserveSourceCapture(ctx, identity, reservationBytes)
+		if errors.Is(err, rawcheckpoint.ErrOutboxFull) {
+			return Result{Status: StatusDegraded, Source: identity}, nil
+		}
+		if err != nil {
+			return Result{}, err
+		}
+		plan, removeSnapshot, err = c.snapshotSQLitePlan(
+			ctx, plan, sqliteSource.connection, snapshotBytes,
+		)
+		if errors.Is(err, rawcheckpoint.ErrOutboxFull) {
+			return Result{Status: StatusDegraded, Source: identity}, nil
+		}
+		if err != nil {
+			return Result{}, err
+		}
+		defer func() {
+			cleanupErr := removeSnapshot()
+			if committed {
+				return
+			}
+			resultErr = errors.Join(resultErr, cleanupErr)
+			if resultErr != nil {
+				result = Result{}
+			}
+		}()
+		if err := sqliteSource.verifyCurrent(); err != nil {
+			return Result{}, err
+		}
+		snapshot = true
+	default:
+		return Result{}, ErrUnsupportedSnapshot
+	}
+	scope, err := openCapturePlanScope(plan)
+	if err != nil {
+		return Result{}, err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, scope.Close())
+		if resultErr != nil {
+			result = Result{}
+		}
+	}()
+	observed, sourceBytes, err := c.observePlan(scope)
+	if err != nil {
+		return Result{}, err
+	}
+	defer closeObservedEntries(observed)
+	if !observationRecorded {
+		if err := c.store.RecordSourceObservation(ctx, identity); err != nil {
+			return Result{}, err
+		}
+	}
+	base, hasBase, err := c.store.CaptureBase(ctx, identity)
+	if err != nil {
+		return Result{}, err
+	}
+	if snapshot {
+		for i := range observed {
+			observed[i].checkpointIdentity = "sqlite-online-backup:" + observed[i].planned.Path
+		}
+	}
+	provisional := c.provisionalAssessment(observed, sourceBytes, base, hasBase)
+	if base.PermanentlyRejected {
+		provisional = c.fullAssessment(observed, sourceBytes)
+	}
+	reservationBytes := captureReservationBytes(provisional)
+	if reservation.ID == "" {
+		reservation, err = c.store.ReserveSourceCapture(ctx, identity, reservationBytes)
+		if errors.Is(err, rawcheckpoint.ErrOutboxFull) {
+			return Result{Status: StatusDegraded, Source: identity}, nil
+		}
+		if err != nil {
+			return Result{}, err
+		}
+	}
 	assessment, err := c.assessCapture(ctx, observed, sourceBytes, base, hasBase)
 	if err != nil {
 		return Result{}, err
 	}
-	if assessment.unchanged {
-		if err := validateCapturePlanStillCurrent(ctx, provider, source, plan, scope); err != nil {
-			return Result{}, err
+	if assessment.unchanged && !base.PermanentlyRejected {
+		if !snapshot {
+			if err := validateCapturePlanStillCurrent(ctx, provider, source, originalPlan, scope); err != nil {
+				return Result{}, err
+			}
 		}
 		for i := range observed {
 			if err := c.verifyCapturedFile(ctx, observed[i], capturedFileState{
@@ -190,11 +296,16 @@ func (c *Capturer) Capture(
 				return Result{}, err
 			}
 		}
-		if err := c.store.CompleteUnchangedCapture(ctx, reservation.ID, identity); err != nil {
+		if err := c.store.CompleteUnchangedCapture(
+			ctx, reservation.ID, identity, base.CaptureID, base.ObservationRevision,
+		); err != nil {
 			return Result{}, err
 		}
 		committed = true
 		return Result{Status: StatusUnchanged, Source: identity}, nil
+	}
+	if base.PermanentlyRejected {
+		assessment = c.fullAssessment(observed, sourceBytes)
 	}
 	captureID, err := newCaptureID()
 	if err != nil {
@@ -251,11 +362,13 @@ func (c *Capturer) Capture(
 			cleanupIncomplete = errors.Is(err, errCleanupIncomplete)
 			return Result{}, err
 		}
+		capturedIdentity := entry.FileIdentity
+		entry.FileIdentity = observed[i].checkpointIdentity
 		entries = append(entries, entry)
 		capturedFiles = append(capturedFiles, capturedFileState{
 			length:       entry.Length,
 			modTimeNS:    entry.ModTimeNS,
-			fileIdentity: entry.FileIdentity,
+			fileIdentity: capturedIdentity,
 			prefixSHA256: entry.PrefixSHA256,
 		})
 	}
@@ -264,8 +377,10 @@ func (c *Capturer) Capture(
 			return Result{}, err
 		}
 	}
-	if err := validateCapturePlanStillCurrent(ctx, provider, source, plan, scope); err != nil {
-		return Result{}, err
+	if !snapshot {
+		if err := validateCapturePlanStillCurrent(ctx, provider, source, originalPlan, scope); err != nil {
+			return Result{}, err
+		}
 	}
 	if err := c.validateForUpload(identity, captureID, capturedAt, entries); err != nil {
 		return Result{}, err
@@ -286,6 +401,13 @@ func (c *Capturer) Capture(
 		return Result{}, err
 	}
 	committed = true
+	finishPublication()
+	finishPublication = func() {}
+	if base.PermanentlyRejected {
+		if _, err := c.store.CollectGarbage(ctx); err != nil {
+			return Result{}, err
+		}
+	}
 	return Result{
 		Status: StatusCaptured, CaptureID: captureID, Source: identity,
 	}, nil
@@ -310,7 +432,7 @@ func (c *Capturer) provisionalAssessment(
 	for _, current := range observed {
 		previous, ok := byPath[current.planned.Path]
 		if !ok || previous.Appendable != current.planned.Appendable ||
-			previous.FileIdentity != current.identity {
+			previous.FileIdentity != captureCheckpointIdentity(current) {
 			return full
 		}
 		entry := cloneCapturedEntry(previous)
@@ -383,6 +505,11 @@ func (c *Capturer) observePlan(
 				"rawcapture: stat %q: %w", entry.planned.Path, sanitizeFilesystemError(err),
 			)
 		}
+		rootedInfo, err := entry.root.Lstat(entry.relative)
+		if err != nil || !rootedInfo.Mode().IsRegular() {
+			closeObservedEntries(observed)
+			return nil, 0, ErrSourceChanged
+		}
 		file, err := entry.root.Open(entry.relative)
 		if err != nil {
 			closeObservedEntries(observed)
@@ -401,7 +528,10 @@ func (c *Capturer) observePlan(
 				"rawcapture: stat %q: %w", entry.planned.Path, sanitizeFilesystemError(err),
 			)
 		}
+		currentInfo, err := entry.root.Lstat(entry.relative)
 		if !info.Mode().IsRegular() || info.Size() < 0 ||
+			err != nil || !currentInfo.Mode().IsRegular() ||
+			!os.SameFile(rootedInfo, info) || !os.SameFile(currentInfo, info) ||
 			!pathInfo.Mode().IsRegular() || !os.SameFile(pathInfo, info) ||
 			sourceBytes > int64(^uint64(0)>>1)-info.Size() {
 			file.Close()
@@ -417,7 +547,7 @@ func (c *Capturer) observePlan(
 		sourceBytes += info.Size()
 		observed = append(observed, observedCaptureEntry{
 			planned: entry.planned, root: entry.root, relative: entry.relative,
-			file: file, info: info, identity: identity,
+			file: file, info: info, identity: identity, checkpointIdentity: identity,
 		})
 	}
 	return observed, sourceBytes, nil
@@ -449,7 +579,7 @@ func (c *Capturer) assessCapture(
 	for _, current := range observed {
 		previous, ok := byPath[current.planned.Path]
 		if !ok || previous.Appendable != current.planned.Appendable ||
-			previous.FileIdentity != current.identity {
+			previous.FileIdentity != captureCheckpointIdentity(current) {
 			return full, nil
 		}
 		appendBases = append(appendBases, cloneCapturedEntry(previous))
@@ -511,13 +641,20 @@ func (c *Capturer) fullAssessment(
 			Path:         current.planned.Path,
 			Length:       current.info.Size(),
 			ModTimeNS:    current.info.ModTime().UnixNano(),
-			FileIdentity: current.identity,
+			FileIdentity: captureCheckpointIdentity(current),
 			PrefixSHA256: placeholderObjectRef(i, current.info.Size()).SHA256,
 			Appendable:   current.planned.Appendable,
 			Objects:      []rawsync.ObjectRef{placeholderObjectRef(i, current.info.Size())},
 		})
 	}
 	return captureAssessment{mode: captureFull, objectBytes: sourceBytes, entries: entries}
+}
+
+func captureCheckpointIdentity(entry observedCaptureEntry) string {
+	if entry.checkpointIdentity != "" {
+		return entry.checkpointIdentity
+	}
+	return entry.identity
 }
 
 func placeholderObjectRef(index int, length int64) rawsync.ObjectRef {

--- a/internal/rawcapture/capturer_test.go
+++ b/internal/rawcapture/capturer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -223,6 +224,92 @@ func TestCapturerReturnsUnchangedWithoutAnotherGeneration(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, first.CaptureID, base.CaptureID)
+}
+
+func TestCapturerReplacesPermanentFailureWhenSourceIsUnchanged(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.NoError(t, appendFile(sourcePath, "two\n"))
+	second, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	_, found, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", first.CaptureID,
+		rawcheckpoint.GenerationFailurePermanent, time.Time{},
+	))
+
+	base, ok, err := store.CaptureBase(t.Context(), second.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, second.CaptureID, base.CaptureID,
+		"replacement must compare the newest rejected suffix content")
+	assert.True(t, base.PermanentlyRejected)
+	var rejectedRefs []rawsync.ObjectRef
+	for _, entry := range base.Entries {
+		rejectedRefs = append(rejectedRefs, entry.Objects...)
+	}
+
+	replacement, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, replacement.Status)
+	assert.NotEqual(t, second.CaptureID, replacement.CaptureID)
+	manifest, found, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, replacement.CaptureID, manifest.CaptureID)
+	require.Len(t, manifest.Entries, 1)
+	assert.Len(t, manifest.Entries[0].Objects, 1,
+		"a source revision must replace the rejected generation with a full snapshot")
+	replacementRef := manifest.Entries[0].Objects[0]
+	for _, ref := range rejectedRefs {
+		if ref != replacementRef {
+			assert.NoFileExists(t, store.ObjectPath(ref))
+		}
+	}
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t,
+		replacementRef.Length+rawcheckpoint.CaptureMetadataCharge(1, 1),
+		usage.UsedBytes,
+	)
+	status, err := store.ClientStatus(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, status.PermanentFailures)
+}
+
+func TestCapturerReplacesPermanentFailureWithinOneGenerationCapacity(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 2000)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	provider, source, sourcePath := captureFileProvider(t, "one\n")
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	_, found, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", first.CaptureID,
+		rawcheckpoint.GenerationFailurePermanent, time.Time{},
+	))
+	require.NoError(t, appendFile(sourcePath, "two\n"))
+
+	replacement, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, replacement.Status)
+	manifest, found, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, replacement.CaptureID, manifest.CaptureID)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.LessOrEqual(t, usage.UsedBytes, int64(2000))
 }
 
 func TestCapturerRejectsSameSizeMutationBeforeUnchangedDecision(t *testing.T) {
@@ -569,15 +656,218 @@ func TestCapturerHonorsCancellation(t *testing.T) {
 	assert.Zero(t, usage.ReservedBytes)
 }
 
-func TestCapturerRejectsSQLiteSnapshotRequirement(t *testing.T) {
+func TestCapturerSnapshotsSQLiteWithOnlineBackup(t *testing.T) {
 	store, _ := openCapturerTestStore(t, 1<<20)
-	provider, source, _ := captureFileProvider(t, "one\n")
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "live.db")
+	db, err := sql.Open(sqliteSnapshotDriverName, dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	db.SetMaxOpenConns(2)
+	_, err = db.Exec(`PRAGMA journal_mode=WAL`)
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA wal_autocheckpoint=0`)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE items (value TEXT NOT NULL)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO items (value) VALUES ('committed')`)
+	require.NoError(t, err)
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	_, err = tx.Exec(`INSERT INTO items (value) VALUES ('uncommitted')`)
+	require.NoError(t, err)
+
+	provider := &captureTestProvider{
+		Def: parser.AgentDef{Type: parser.AgentForge},
+		Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+			Support:  parser.CapabilitySupported,
+			Shape:    parser.RawCaptureShapeSQLite,
+			Append:   parser.RawCaptureAppendReplaceOnly,
+			Snapshot: parser.RawCaptureSnapshotOnlineBackup,
+		}},
+		plan: parser.RawCapturePlan{
+			ConfiguredRoot: root,
+			CaptureRoot:    root,
+			SourceKey:      "live.db",
+			Entries: []parser.RawCaptureEntry{{
+				Path: "live.db", LocalPath: dbPath,
+			}},
+		},
+	}
+	source := parser.SourceRef{Provider: parser.AgentForge, Key: "live.db"}
 	provider.Caps.RawCapture.Shape = parser.RawCaptureShapeSQLite
 	provider.Caps.RawCapture.Snapshot = parser.RawCaptureSnapshotOnlineBackup
 
-	_, err := New(store).Capture(t.Context(), provider, source)
+	result, err := New(store).Capture(t.Context(), provider, source)
 
-	require.ErrorIs(t, err, ErrUnsupportedSnapshot)
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, result.Status)
+	generation, ok, err := store.NextGeneration(t.Context())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, generation.Entries, 1)
+	assert.Equal(t, "live.db", generation.Entries[0].Path)
+	require.Len(t, generation.Entries[0].Objects, 1)
+	snapshot, err := sql.Open(
+		sqliteSnapshotDriverName, store.ObjectPath(generation.Entries[0].Objects[0]),
+	)
+	require.NoError(t, err)
+	defer snapshot.Close()
+	var values string
+	err = snapshot.QueryRow(`SELECT group_concat(value, ',') FROM items`).Scan(&values)
+	require.NoError(t, err)
+	assert.Equal(t, "committed", values)
+	temporary, err := os.ReadDir(store.CaptureTempDir())
+	require.NoError(t, err)
+	assert.Empty(t, temporary)
+
+	unchanged, err := New(store).Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	assert.Equal(t, StatusUnchanged, unchanged.Status)
+	require.NoError(t, tx.Rollback())
+	_, err = db.Exec(`INSERT INTO items (value) VALUES ('later')`)
+	require.NoError(t, err)
+	changed, err := New(store).Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, changed.Status)
+	assert.NotEqual(t, result.CaptureID, changed.CaptureID)
+	base, ok, err := store.CaptureBase(t.Context(), changed.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, changed.CaptureID, base.CaptureID)
+}
+
+func TestCapturerRejectsSQLiteSymlinkSwapAfterPlanValidation(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "live.db")
+	writeSQLiteCaptureTestDB(t, dbPath, "validated")
+	outOfRootPath := filepath.Join(t.TempDir(), "outside.db")
+	writeSQLiteCaptureTestDB(t, outOfRootPath, "outside")
+	provider := &captureTestProvider{
+		Def: parser.AgentDef{Type: parser.AgentForge},
+		Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+			Support: parser.CapabilitySupported, Shape: parser.RawCaptureShapeSQLite,
+			Append:   parser.RawCaptureAppendReplaceOnly,
+			Snapshot: parser.RawCaptureSnapshotOnlineBackup,
+		}},
+		plan: parser.RawCapturePlan{
+			ConfiguredRoot: root, CaptureRoot: root, SourceKey: "live.db",
+			Entries: []parser.RawCaptureEntry{{Path: "live.db", LocalPath: dbPath}},
+		},
+	}
+	source := parser.SourceRef{Provider: parser.AgentForge, Key: "live.db"}
+	capturer := New(store)
+	swapped := false
+	capturer.capturePhase = func(phase capturePhase, path string) {
+		if swapped || phase != capturePhaseBeforeRead || path == "" {
+			return
+		}
+		swapped = true
+		relocated := path + ".validated"
+		require.NoError(t, os.Rename(path, relocated))
+		if err := os.Symlink(outOfRootPath, path); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+	}
+
+	_, err := capturer.Capture(t.Context(), provider, source)
+
+	require.True(t, swapped)
+	require.ErrorIs(t, err, ErrSourceChanged)
+	_, ok, readErr := store.NextGeneration(t.Context())
+	require.NoError(t, readErr)
+	assert.False(t, ok)
+	usage, readErr := store.OutboxUsage(t.Context())
+	require.NoError(t, readErr)
+	assert.Zero(t, usage.UsedBytes)
+	assert.Zero(t, usage.ReservedBytes)
+}
+
+func TestCapturerReservesSQLiteSnapshotCapacityBeforeBackup(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 2048)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "live.db")
+	db, err := sql.Open(sqliteSnapshotDriverName, dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE items (value BLOB NOT NULL)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO items (value) VALUES (zeroblob(16384))`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	provider := &captureTestProvider{
+		Def: parser.AgentDef{Type: parser.AgentForge},
+		Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+			Support: parser.CapabilitySupported, Shape: parser.RawCaptureShapeSQLite,
+			Append:   parser.RawCaptureAppendReplaceOnly,
+			Snapshot: parser.RawCaptureSnapshotOnlineBackup,
+		}},
+		plan: parser.RawCapturePlan{
+			ConfiguredRoot: root, CaptureRoot: root, SourceKey: "live.db",
+			Entries: []parser.RawCaptureEntry{{Path: "live.db", LocalPath: dbPath}},
+		},
+	}
+	source := parser.SourceRef{Provider: parser.AgentForge, Key: "live.db"}
+	capturer := New(store)
+	backupStarted := false
+	capturer.sqliteBackup = func(context.Context, *sql.Conn, string, int64) error {
+		backupStarted = true
+		return errors.New("backup must not start")
+	}
+
+	result, err := capturer.Capture(t.Context(), provider, source)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusDegraded, result.Status)
+	assert.False(t, backupStarted)
+	temporary, err := os.ReadDir(store.CaptureTempDir())
+	require.NoError(t, err)
+	assert.Empty(t, temporary)
+}
+
+func TestCapturerKeepsCommittedSQLiteCaptureWhenSnapshotCleanupFails(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "live.db")
+	writeSQLiteCaptureTestDB(t, dbPath, "captured")
+	provider := &captureTestProvider{
+		Def: parser.AgentDef{Type: parser.AgentForge},
+		Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+			Support: parser.CapabilitySupported, Shape: parser.RawCaptureShapeSQLite,
+			Append:   parser.RawCaptureAppendReplaceOnly,
+			Snapshot: parser.RawCaptureSnapshotOnlineBackup,
+		}},
+		plan: parser.RawCapturePlan{
+			ConfiguredRoot: root, CaptureRoot: root, SourceKey: "live.db",
+			Entries: []parser.RawCaptureEntry{{Path: "live.db", LocalPath: dbPath}},
+		},
+	}
+	capturer := New(store)
+	capturer.files.removeAll = func(string) error { return errors.New("cleanup failed") }
+
+	result, err := capturer.Capture(
+		t.Context(), provider,
+		parser.SourceRef{Provider: parser.AgentForge, Key: "live.db"},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, result.Status)
+	generation, ok, err := store.NextGeneration(t.Context())
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, result.CaptureID, generation.CaptureID)
+}
+
+func writeSQLiteCaptureTestDB(t *testing.T, path, value string) {
+	t.Helper()
+	database, err := sql.Open(sqliteSnapshotDriverName, path)
+	require.NoError(t, err)
+	_, err = database.Exec(`CREATE TABLE items (value TEXT NOT NULL)`)
+	require.NoError(t, err)
+	_, err = database.Exec(`INSERT INTO items (value) VALUES (?)`, value)
+	require.NoError(t, err)
+	require.NoError(t, database.Close())
 }
 
 func TestCapturerStoresOnlySuffixObjectForVerifiedAppend(t *testing.T) {
@@ -657,8 +947,8 @@ func TestCapturerAppendsFromAcknowledgedBaseAfterLocalObjectGC(t *testing.T) {
 		Generation: 1,
 		Created:    true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", first.CaptureID, commit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", first.CaptureID, commit,
 	))
 	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", first.CaptureID, commit)
 	require.NoError(t, err)
@@ -940,8 +1230,8 @@ func TestCapturerReservesOnlyVerifiedSuffixForAcknowledgedLargeSource(t *testing
 		ManifestID: strings.Repeat("a", 64), Receipt: strings.Repeat("b", 64),
 		Generation: 1, Created: true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", manifest.CaptureID, commit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", manifest.CaptureID, commit,
 	))
 	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", manifest.CaptureID, commit)
 	require.NoError(t, err)

--- a/internal/rawcapture/files.go
+++ b/internal/rawcapture/files.go
@@ -18,10 +18,11 @@ import (
 )
 
 type fileOperations struct {
-	stat    func(string) (os.FileInfo, error)
-	rename  func(string, string) error
-	remove  func(string) error
-	syncDir func(string) error
+	stat      func(string) (os.FileInfo, error)
+	rename    func(string, string) error
+	remove    func(string) error
+	removeAll func(string) error
+	syncDir   func(string) error
 }
 
 type scopedCaptureEntry struct {
@@ -114,7 +115,8 @@ func (s *capturePlanScope) MatchesRoots(plan parser.RawCapturePlan) bool {
 
 func defaultFileOperations() fileOperations {
 	return fileOperations{
-		stat: os.Stat, rename: os.Rename, remove: os.Remove, syncDir: syncDirectory,
+		stat: os.Stat, rename: os.Rename, remove: os.Remove,
+		removeAll: os.RemoveAll, syncDir: syncDirectory,
 	}
 }
 

--- a/internal/rawcapture/sqlite_snapshot.go
+++ b/internal/rawcapture/sqlite_snapshot.go
@@ -1,0 +1,287 @@
+package rawcapture
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+)
+
+const (
+	sqliteBackupTimeout    = 5 * time.Minute
+	sqliteBackupRetryDelay = 25 * time.Millisecond
+)
+
+func (c *Capturer) snapshotSQLitePlan(
+	ctx context.Context,
+	plan parser.RawCapturePlan,
+	source *sql.Conn,
+	maxBytes int64,
+) (parser.RawCapturePlan, func() error, error) {
+	if len(plan.Entries) != 1 {
+		return parser.RawCapturePlan{}, nil, ErrUnsupportedSnapshot
+	}
+	temporary, err := os.MkdirTemp(c.store.CaptureTempDir(), "sqlite-")
+	if err != nil {
+		return parser.RawCapturePlan{}, nil, fmt.Errorf("rawcapture: create SQLite snapshot directory: %w", err)
+	}
+	cleanup := func() error {
+		if err := c.files.removeAll(temporary); err != nil {
+			return fmt.Errorf("rawcapture: remove SQLite snapshot: %w", err)
+		}
+		return nil
+	}
+	destination := filepath.Join(temporary, "snapshot.db")
+	backupCtx, cancel := context.WithTimeout(ctx, sqliteBackupTimeout)
+	defer cancel()
+	if err := c.sqliteBackup(
+		backupCtx, source, destination, maxBytes,
+	); err != nil {
+		return parser.RawCapturePlan{}, nil, errors.Join(err, cleanup())
+	}
+	return parser.RawCapturePlan{
+		ConfiguredRoot: temporary,
+		CaptureRoot:    temporary,
+		SourceKey:      plan.SourceKey,
+		Entries: []parser.RawCaptureEntry{{
+			Path: plan.Entries[0].Path, LocalPath: destination,
+		}},
+	}, cleanup, nil
+}
+
+type sqliteSnapshotSource struct {
+	database         *sql.DB
+	connection       *sql.Conn
+	pathPin          *os.File
+	path             string
+	expectedInfo     os.FileInfo
+	expectedIdentity string
+}
+
+func openSQLiteSnapshotSource(
+	ctx context.Context,
+	sourcePath string,
+	expected os.FileInfo,
+) (*sqliteSnapshotSource, error) {
+	pathPin, err := pinSQLiteSnapshotPath(sourcePath, expected)
+	if err != nil {
+		if errors.Is(err, ErrSourceChanged) || errors.Is(err, os.ErrNotExist) {
+			return nil, ErrSourceChanged
+		}
+		return nil, fmt.Errorf("rawcapture: pin SQLite source: %w", err)
+	}
+	pinInfo, err := pathPin.Stat()
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("rawcapture: inspect pinned SQLite source: %w", err),
+			pathPin.Close(),
+		)
+	}
+	expectedIdentity := stableFileIdentity(pathPin, pinInfo)
+	if expectedIdentity == "" {
+		return nil, errors.Join(ErrSourceChanged, pathPin.Close())
+	}
+	pathInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, errors.Join(ErrSourceChanged, pathPin.Close())
+		}
+		return nil, errors.Join(
+			fmt.Errorf("rawcapture: inspect SQLite source: %w", err),
+			pathPin.Close(),
+		)
+	}
+	if expected == nil || !pathInfo.Mode().IsRegular() ||
+		!os.SameFile(expected, pathInfo) {
+		return nil, errors.Join(ErrSourceChanged, pathPin.Close())
+	}
+	database, err := sql.Open(
+		sqliteSnapshotDriverName, sqliteSnapshotDSN(sourcePath, true),
+	)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("rawcapture: open SQLite source: %w", err), pathPin.Close(),
+		)
+	}
+	connection, err := database.Conn(ctx)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("rawcapture: connect SQLite source: %w", err),
+			database.Close(), pathPin.Close(),
+		)
+	}
+	source := &sqliteSnapshotSource{
+		database: database, connection: connection, pathPin: pathPin,
+		path: sourcePath, expectedInfo: expected, expectedIdentity: expectedIdentity,
+	}
+	actualPath, err := sqliteSnapshotMainPath(ctx, connection)
+	if err != nil {
+		return nil, errors.Join(err, source.Close())
+	}
+	if !sameSQLiteSnapshotPath(actualPath, sourcePath) {
+		return nil, errors.Join(ErrSourceChanged, source.Close())
+	}
+	if err := source.verifyCurrent(); err != nil {
+		return nil, errors.Join(err, source.Close())
+	}
+	return source, nil
+}
+
+func (s *sqliteSnapshotSource) verifyCurrent() error {
+	pathInfo, err := os.Stat(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrSourceChanged
+		}
+		return fmt.Errorf("rawcapture: inspect SQLite source: %w", err)
+	}
+	if !pathInfo.Mode().IsRegular() ||
+		!os.SameFile(s.expectedInfo, pathInfo) {
+		return ErrSourceChanged
+	}
+	identity, err := sqliteSnapshotConnectionIdentity(s.connection)
+	if err != nil {
+		return err
+	}
+	if identity == "" || identity != s.expectedIdentity {
+		return ErrSourceChanged
+	}
+	return nil
+}
+
+func (s *sqliteSnapshotSource) Close() error {
+	if s == nil {
+		return nil
+	}
+	return errors.Join(s.connection.Close(), s.database.Close(), s.pathPin.Close())
+}
+
+func pinSQLiteSnapshotPath(path string, expected os.FileInfo) (*os.File, error) {
+	// Keep an independently opened path handle until the SQLite connection
+	// closes. In particular, Windows opens this handle without delete sharing,
+	// so the name cannot be replaced in the interval before SQLite opens it.
+	pin, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := pin.Stat()
+	if err != nil {
+		return nil, errors.Join(err, pin.Close())
+	}
+	if expected == nil || !info.Mode().IsRegular() ||
+		!os.SameFile(expected, info) {
+		return nil, errors.Join(ErrSourceChanged, pin.Close())
+	}
+	return pin, nil
+}
+
+func sqliteSnapshotMainPath(ctx context.Context, connection *sql.Conn) (string, error) {
+	rows, err := connection.QueryContext(ctx, `PRAGMA database_list`)
+	if err != nil {
+		return "", fmt.Errorf("rawcapture: inspect SQLite source path: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sequence int
+		var name, path string
+		if err := rows.Scan(&sequence, &name, &path); err != nil {
+			return "", fmt.Errorf("rawcapture: inspect SQLite source path: %w", err)
+		}
+		if name == "main" && path != "" {
+			return path, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("rawcapture: inspect SQLite source path: %w", err)
+	}
+	return "", ErrSourceChanged
+}
+
+func sameSQLiteSnapshotPath(actual, expected string) bool {
+	actual, err := filepath.EvalSymlinks(actual)
+	if err != nil {
+		return false
+	}
+	expected, err = filepath.EvalSymlinks(expected)
+	if err != nil {
+		return false
+	}
+	relative, err := filepath.Rel(filepath.Clean(expected), filepath.Clean(actual))
+	return err == nil && relative == "."
+}
+
+func sqliteOnlineBackupSize(ctx context.Context, source *sql.Conn) (int64, error) {
+	var pages, pageBytes int64
+	if err := source.QueryRowContext(ctx, `PRAGMA page_count`).Scan(&pages); err != nil {
+		return 0, fmt.Errorf("rawcapture: read SQLite page count: %w", err)
+	}
+	if err := source.QueryRowContext(ctx, `PRAGMA page_size`).Scan(&pageBytes); err != nil {
+		return 0, fmt.Errorf("rawcapture: read SQLite page size: %w", err)
+	}
+	if pages < 0 || pageBytes < 0 || (pages != 0 && pageBytes > math.MaxInt64/pages) {
+		return math.MaxInt64, nil
+	}
+	return pages * pageBytes, nil
+}
+
+func runSQLiteBackup(
+	ctx context.Context,
+	pageBytes int64,
+	maxBytes int64,
+	step func() (bool, error),
+	remaining func() int,
+	pageCount func() int,
+) error {
+	previousRemaining := -1
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		done, err := step()
+		if err != nil {
+			return err
+		}
+		if err := sqliteBackupSizeError(int64(pageCount()), pageBytes, maxBytes); err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+		currentRemaining := remaining()
+		if currentRemaining == previousRemaining {
+			timer := time.NewTimer(sqliteBackupRetryDelay)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+		previousRemaining = currentRemaining
+	}
+}
+
+func sqliteBackupSizeError(pages, pageBytes, maxBytes int64) error {
+	if pages < 0 || pageBytes < 0 || pages != 0 && pageBytes > math.MaxInt64/pages ||
+		pages*pageBytes > maxBytes {
+		return rawcheckpoint.ErrOutboxFull
+	}
+	return nil
+}
+
+func sqliteSnapshotReservationBytes(snapshotBytes int64) int64 {
+	metadata := rawcheckpoint.CaptureMetadataCharge(1, 1)
+	if snapshotBytes > math.MaxInt64-metadata {
+		return math.MaxInt64
+	}
+	return snapshotBytes + metadata
+}

--- a/internal/rawcapture/sqlite_snapshot_cgo.go
+++ b/internal/rawcapture/sqlite_snapshot_cgo.go
@@ -1,0 +1,162 @@
+//go:build !windows && cgo
+
+package rawcapture
+
+/*
+typedef struct sqlite3 sqlite3;
+typedef struct sqlite3_file sqlite3_file;
+int sqlite3_file_control(sqlite3*, const char*, int, void*);
+const char *sqlite3_sourceid(void);
+void sqlite3_free(void*);
+
+#include <sys/stat.h>
+#include <string.h>
+
+#define RAWCAPTURE_SQLITE_FCNTL_FILE_POINTER 7
+#define RAWCAPTURE_SQLITE_FCNTL_VFSNAME 12
+#define RAWCAPTURE_SQLITE_SOURCE_ID \
+	"2026-07-24 19:02:57 bf7c7f30031888f4e796e429ab3978879485813aaca6f641c7b33e4e09459bcc"
+
+typedef struct rawcaptureUnixFile {
+	const void *methods;
+	void *vfs;
+	void *inode;
+	int fd;
+} rawcaptureUnixFile;
+
+static int rawcaptureSQLiteIdentity(
+	void *db, unsigned long long *device, unsigned long long *inode
+) {
+	// The unixFile layout is private SQLite ABI. Fail closed unless both the
+	// bundled amalgamation and one of its Unix VFS implementations are active.
+	if (strcmp(sqlite3_sourceid(), RAWCAPTURE_SQLITE_SOURCE_ID) != 0) return -2;
+	char *vfsName = 0;
+	int result = sqlite3_file_control(
+		(sqlite3*)db, "main", RAWCAPTURE_SQLITE_FCNTL_VFSNAME, &vfsName
+	);
+	if (result != 0 || vfsName == 0) return result == 0 ? -3 : result;
+	int supportedVFS = strncmp(vfsName, "unix", 4) == 0
+		&& (vfsName[4] == '\0' || vfsName[4] == '-');
+	sqlite3_free(vfsName);
+	if (!supportedVFS) return -4;
+
+	sqlite3_file *file = 0;
+	result = sqlite3_file_control(
+		(sqlite3*)db, "main", RAWCAPTURE_SQLITE_FCNTL_FILE_POINTER, &file
+	);
+	if (result != 0 || file == 0) return result == 0 ? -1 : result;
+	struct stat info;
+	if (fstat(((rawcaptureUnixFile*)file)->fd, &info) != 0) return -1;
+	*device = (unsigned long long)info.st_dev;
+	*inode = (unsigned long long)info.st_ino;
+	return 0;
+}
+*/
+import "C"
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"unsafe"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+const sqliteSnapshotDriverName = "sqlite3"
+
+func sqliteSnapshotConnectionIdentity(connection *sql.Conn) (string, error) {
+	var device, inode C.ulonglong
+	err := connection.Raw(func(driverConnection any) error {
+		sqliteConnection, ok := driverConnection.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("unexpected SQLite source driver %T", driverConnection)
+		}
+		field, ok := reflect.TypeOf(sqliteConnection).Elem().FieldByName("db")
+		if !ok {
+			return errors.New("rawcapture: SQLite source driver has no database handle")
+		}
+		if field.Type.Kind() != reflect.Pointer && field.Type.Kind() != reflect.UnsafePointer {
+			return errors.New("rawcapture: SQLite source driver database handle changed type")
+		}
+		database := *(*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(sqliteConnection), field.Offset))
+		if database == nil {
+			return errors.New("rawcapture: SQLite source driver has no open database")
+		}
+		if result := C.rawcaptureSQLiteIdentity(database, &device, &inode); result != 0 {
+			return fmt.Errorf("rawcapture: inspect SQLite source identity: result %d", result)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d:%d", uint64(device), uint64(inode)), nil
+}
+
+func sqliteOnlineBackup(
+	ctx context.Context, sourceConn *sql.Conn, destinationPath string, maxBytes int64,
+) error {
+	destination, err := sql.Open("sqlite3", sqliteSnapshotDSN(destinationPath, false))
+	if err != nil {
+		return fmt.Errorf("rawcapture: open SQLite snapshot: %w", err)
+	}
+	defer destination.Close()
+	destinationConn, err := destination.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("rawcapture: connect SQLite snapshot: %w", err)
+	}
+	defer destinationConn.Close()
+	var pages, pageBytes int64
+	if err := sourceConn.QueryRowContext(ctx, `PRAGMA page_count`).Scan(&pages); err != nil {
+		return fmt.Errorf("rawcapture: read SQLite page count: %w", err)
+	}
+	if err := sourceConn.QueryRowContext(ctx, `PRAGMA page_size`).Scan(&pageBytes); err != nil {
+		return fmt.Errorf("rawcapture: read SQLite page size: %w", err)
+	}
+	if err := sqliteBackupSizeError(pages, pageBytes, maxBytes); err != nil {
+		return err
+	}
+
+	err = sourceConn.Raw(func(sourceDriver any) error {
+		sourceSQLite, ok := sourceDriver.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("unexpected SQLite source driver %T", sourceDriver)
+		}
+		return destinationConn.Raw(func(destinationDriver any) (resultErr error) {
+			destinationSQLite, ok := destinationDriver.(*sqlite3.SQLiteConn)
+			if !ok {
+				return fmt.Errorf("unexpected SQLite snapshot driver %T", destinationDriver)
+			}
+			backup, err := destinationSQLite.Backup("main", sourceSQLite, "main")
+			if err != nil {
+				return err
+			}
+			defer func() { resultErr = errors.Join(resultErr, backup.Finish()) }()
+			return runSQLiteBackup(
+				ctx, pageBytes, maxBytes,
+				func() (bool, error) { return backup.Step(128) },
+				backup.Remaining,
+				backup.PageCount,
+			)
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("rawcapture: back up SQLite source: %w", err)
+	}
+	return nil
+}
+
+func sqliteSnapshotDSN(path string, readOnly bool) string {
+	values := url.Values{}
+	values.Set("_busy_timeout", "5000")
+	if readOnly {
+		values.Set("mode", "ro")
+	} else {
+		values.Set("mode", "rwc")
+	}
+	return "file:" + (&url.URL{Path: path}).EscapedPath() + "?" + values.Encode()
+}

--- a/internal/rawcapture/sqlite_snapshot_modernc.go
+++ b/internal/rawcapture/sqlite_snapshot_modernc.go
@@ -1,0 +1,120 @@
+//go:build windows
+
+package rawcapture
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"unsafe"
+
+	"modernc.org/libc"
+	"modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+const sqliteSnapshotDriverName = "sqlite"
+
+func sqliteSnapshotConnectionIdentity(connection *sql.Conn) (string, error) {
+	var identity string
+	err := connection.Raw(func(driverConnection any) error {
+		value := reflect.ValueOf(driverConnection)
+		if value.Kind() != reflect.Pointer || value.IsNil() ||
+			value.Elem().Type().PkgPath() != "modernc.org/sqlite" ||
+			value.Elem().Type().Name() != "conn" {
+			return fmt.Errorf("unexpected SQLite source driver %T", driverConnection)
+		}
+		connectionType := value.Elem().Type()
+		databaseField, databaseOK := connectionType.FieldByName("db")
+		tlsField, tlsOK := connectionType.FieldByName("tls")
+		if !databaseOK || databaseField.Type.Kind() != reflect.Uintptr ||
+			!tlsOK || tlsField.Type != reflect.TypeFor[*libc.TLS]() {
+			return errors.New("rawcapture: SQLite source driver layout changed")
+		}
+		base := unsafe.Pointer(value.Pointer())
+		database := *(*uintptr)(unsafe.Add(base, databaseField.Offset))
+		tls := *(**libc.TLS)(unsafe.Add(base, tlsField.Offset))
+		if database == 0 || tls == nil {
+			return errors.New("rawcapture: SQLite source driver has no open database")
+		}
+		name := tls.Alloc(5)
+		defer tls.Free(5)
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(name)), 5), "main\x00")
+		var identityErr error
+		identity, identityErr = sqliteSnapshotModerncConnectionIdentity(
+			tls, database, name,
+		)
+		if identityErr != nil {
+			return identityErr
+		}
+		return nil
+	})
+	return identity, err
+}
+
+func sqliteOnlineBackup(
+	ctx context.Context, connection *sql.Conn, destinationPath string, maxBytes int64,
+) error {
+	var pages, pageBytes int64
+	if err := connection.QueryRowContext(ctx, `PRAGMA page_count`).Scan(&pages); err != nil {
+		return fmt.Errorf("rawcapture: read SQLite page count: %w", err)
+	}
+	if err := connection.QueryRowContext(ctx, `PRAGMA page_size`).Scan(&pageBytes); err != nil {
+		return fmt.Errorf("rawcapture: read SQLite page size: %w", err)
+	}
+	if err := sqliteBackupSizeError(pages, pageBytes, maxBytes); err != nil {
+		return err
+	}
+	err := connection.Raw(func(driverConnection any) (resultErr error) {
+		backuper, ok := driverConnection.(interface {
+			NewBackup(string) (*sqlite.Backup, error)
+		})
+		if !ok {
+			return fmt.Errorf("unexpected SQLite source driver %T", driverConnection)
+		}
+		backup, err := backuper.NewBackup(sqliteSnapshotDSN(destinationPath, false))
+		if err != nil {
+			return err
+		}
+		defer func() { resultErr = errors.Join(resultErr, backup.Finish()) }()
+		return runSQLiteBackup(
+			ctx, pageBytes, maxBytes,
+			func() (bool, error) {
+				more, err := backup.Step(128)
+				if sqliteModerncBackupBusy(err) {
+					return false, nil
+				}
+				return !more, err
+			},
+			backup.Remaining,
+			backup.PageCount,
+		)
+	})
+	if err != nil {
+		return fmt.Errorf("rawcapture: back up SQLite source: %w", err)
+	}
+	return nil
+}
+
+func sqliteModerncBackupBusy(err error) bool {
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	code := sqliteErr.Code() & 0xff
+	return code == sqlite3.SQLITE_BUSY || code == sqlite3.SQLITE_LOCKED
+}
+
+func sqliteSnapshotDSN(path string, readOnly bool) string {
+	values := url.Values{}
+	values.Add("_pragma", "busy_timeout(5000)")
+	if readOnly {
+		values.Set("mode", "ro")
+	} else {
+		values.Set("mode", "rwc")
+	}
+	return "file:" + (&url.URL{Path: path}).EscapedPath() + "?" + values.Encode()
+}

--- a/internal/rawcapture/sqlite_snapshot_modernc_windows.go
+++ b/internal/rawcapture/sqlite_snapshot_modernc_windows.go
@@ -1,0 +1,36 @@
+package rawcapture
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"modernc.org/libc"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+func sqliteSnapshotModerncConnectionIdentity(
+	tls *libc.TLS, database, name uintptr,
+) (string, error) {
+	argumentSize := int(unsafe.Sizeof(uintptr(0)))
+	argument := tls.Alloc(argumentSize)
+	defer tls.Free(argumentSize)
+	*(*uintptr)(unsafe.Pointer(argument)) = 0
+	result := sqlite3.Xsqlite3_file_control(
+		tls, database, name,
+		int32(sqlite3.SQLITE_FCNTL_WIN32_GET_HANDLE), argument,
+	)
+	if result != sqlite3.SQLITE_OK {
+		return "", fmt.Errorf("rawcapture: inspect SQLite source identity: result %d", result)
+	}
+	file := windows.Handle(*(*uintptr)(unsafe.Pointer(argument)))
+	if file == 0 || file == windows.InvalidHandle {
+		return "", fmt.Errorf("rawcapture: SQLite source has no open file")
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(file, &info); err != nil {
+		return "", fmt.Errorf("rawcapture: inspect SQLite source identity: %w", err)
+	}
+	fileIndex := uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow)
+	return fmt.Sprintf("%d:%d", uint64(info.VolumeSerialNumber), fileIndex), nil
+}

--- a/internal/rawcapture/sqlite_snapshot_test.go
+++ b/internal/rawcapture/sqlite_snapshot_test.go
@@ -1,0 +1,58 @@
+package rawcapture
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+)
+
+func TestRunSQLiteBackupRejectsGrowthPastLimit(t *testing.T) {
+	pageCount := 1
+	steps := 0
+
+	err := runSQLiteBackup(
+		t.Context(), 4096, 4096,
+		func() (bool, error) {
+			steps++
+			pageCount = 2
+			return false, nil
+		},
+		func() int { return 1 },
+		func() int { return pageCount },
+	)
+
+	require.ErrorIs(t, err, rawcheckpoint.ErrOutboxFull)
+	assert.Equal(t, 1, steps)
+}
+
+func TestSnapshotSQLitePlanAddsBackupDeadline(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	capturer := New(store)
+	backupErr := errors.New("stop after checking deadline")
+	capturer.sqliteBackup = func(
+		ctx context.Context, _ *sql.Conn, _ string, _ int64,
+	) error {
+		_, bounded := ctx.Deadline()
+		assert.True(t, bounded)
+		return backupErr
+	}
+
+	_, _, err := capturer.snapshotSQLitePlan(
+		t.Context(),
+		parser.RawCapturePlan{
+			SourceKey: "source.db",
+			Entries:   []parser.RawCaptureEntry{{Path: "source.db"}},
+		},
+		nil,
+		4096,
+	)
+
+	require.ErrorIs(t, err, backupErr)
+}

--- a/internal/rawcapture/sqlite_snapshot_unix_test.go
+++ b/internal/rawcapture/sqlite_snapshot_unix_test.go
@@ -1,0 +1,116 @@
+//go:build unix
+
+package rawcapture
+
+import (
+	"context"
+	"database/sql"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestSQLiteSnapshotConnectionIdentityIsIndependentOfPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "source.db")
+	writeSQLiteCaptureTestDB(t, path, "connected")
+	expected, err := os.Stat(path)
+	require.NoError(t, err)
+	source, err := openSQLiteSnapshotSource(context.Background(), path, expected)
+	require.NoError(t, err)
+	defer source.Close()
+	replacement := filepath.Join(dir, "replacement.db")
+	writeSQLiteCaptureTestDB(t, replacement, "replacement")
+	replacementFile, err := os.Open(replacement)
+	require.NoError(t, err)
+	replacementInfo, err := replacementFile.Stat()
+	require.NoError(t, err)
+	replacementIdentity := stableFileIdentity(replacementFile, replacementInfo)
+	require.NoError(t, replacementFile.Close())
+	require.NotEqual(t, source.expectedIdentity, replacementIdentity)
+
+	source.expectedIdentity = replacementIdentity
+
+	require.ErrorIs(t, source.verifyCurrent(), ErrSourceChanged)
+}
+
+func TestOpenSQLiteSnapshotSourceAcceptsSymlinkedAncestor(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	require.NoError(t, os.Mkdir(realDir, 0o700))
+	linkedDir := filepath.Join(root, "linked")
+	if err := os.Symlink(realDir, linkedDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	path := filepath.Join(linkedDir, "source.db")
+	writeSQLiteCaptureTestDB(t, path, "connected")
+	expected, err := os.Stat(path)
+	require.NoError(t, err)
+
+	source, err := openSQLiteSnapshotSource(t.Context(), path, expected)
+	require.NoError(t, err)
+	require.NoError(t, source.Close())
+}
+
+func TestOpenSQLiteSnapshotSourcePreservesPermissionError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "source.db")
+	writeSQLiteCaptureTestDB(t, path, "connected")
+	expected, err := os.Stat(path)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(path, 0))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(path, 0o600)) })
+
+	source, err := openSQLiteSnapshotSource(t.Context(), path, expected)
+	if err == nil {
+		require.NoError(t, source.Close())
+		t.Skip("filesystem permissions are not enforced for this process")
+	}
+	require.ErrorIs(t, err, fs.ErrPermission)
+	require.NotErrorIs(t, err, ErrSourceChanged)
+}
+
+func TestCapturerCleansSQLiteSnapshotWhenSourceChangesAfterBackup(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	root := t.TempDir()
+	path := filepath.Join(root, "source.db")
+	writeSQLiteCaptureTestDB(t, path, "original")
+	provider := &captureTestProvider{
+		Def: parser.AgentDef{Type: parser.AgentForge},
+		Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+			Support: parser.CapabilitySupported, Shape: parser.RawCaptureShapeSQLite,
+			Append:   parser.RawCaptureAppendReplaceOnly,
+			Snapshot: parser.RawCaptureSnapshotOnlineBackup,
+		}},
+		plan: parser.RawCapturePlan{
+			ConfiguredRoot: root, CaptureRoot: root, SourceKey: "source.db",
+			Entries: []parser.RawCaptureEntry{{Path: "source.db", LocalPath: path}},
+		},
+	}
+	capturer := New(store)
+	capturer.sqliteBackup = func(
+		ctx context.Context, connection *sql.Conn, destination string, maxBytes int64,
+	) error {
+		if err := sqliteOnlineBackup(ctx, connection, destination, maxBytes); err != nil {
+			return err
+		}
+		relocated := path + ".original"
+		require.NoError(t, os.Rename(path, relocated))
+		writeSQLiteCaptureTestDB(t, path, "replacement")
+		return nil
+	}
+
+	_, err := capturer.Capture(
+		t.Context(), provider, parser.SourceRef{Provider: parser.AgentForge, Key: "source.db"},
+	)
+
+	require.ErrorIs(t, err, ErrSourceChanged)
+	temporary, err := os.ReadDir(store.CaptureTempDir())
+	require.NoError(t, err)
+	require.Empty(t, temporary)
+}

--- a/internal/rawcapture/sqlite_snapshot_windows_test.go
+++ b/internal/rawcapture/sqlite_snapshot_windows_test.go
@@ -1,0 +1,23 @@
+package rawcapture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPinSQLiteSnapshotPathPreventsReplacement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "source.db")
+	writeSQLiteCaptureTestDB(t, path, "original")
+	expected, err := os.Stat(path)
+	require.NoError(t, err)
+	pin, err := pinSQLiteSnapshotPath(path, expected)
+	require.NoError(t, err)
+
+	moved := path + ".moved"
+	require.Error(t, os.Rename(path, moved))
+	require.NoError(t, pin.Close())
+	require.NoError(t, os.Rename(path, moved))
+}

--- a/internal/rawcheckpoint/ack.go
+++ b/internal/rawcheckpoint/ack.go
@@ -23,6 +23,7 @@ type GenerationFailureClass string
 const (
 	GenerationFailureTransient             GenerationFailureClass = "transient"
 	GenerationFailureParentReceiptConflict GenerationFailureClass = "parent_receipt_conflict"
+	GenerationFailurePermanent             GenerationFailureClass = "permanent"
 )
 
 // AcknowledgeResult reports whether an acknowledgement was replayed and what
@@ -32,45 +33,55 @@ type AcknowledgeResult struct {
 	Garbage  GarbageCollectionReport
 }
 
-// BindFinalizedManifestID durably associates the canonical manifest ID
-// returned for a specific finalized upload with its local capture. This
-// separate fence prevents a later acknowledgement from applying a result that
-// belongs to another manifest at the same server generation.
-func (s *Store) BindFinalizedManifestID(
+// BindFinalizedCommit durably records the full server result for a finalized
+// generation before the local acknowledgement advances its source head. A
+// later drain can then finish acknowledgement without committing the manifest
+// again.
+func (s *Store) BindFinalizedCommit(
 	ctx context.Context,
-	deviceID, captureID, manifestID string,
+	deviceID, captureID string,
+	commit rawsync.CommitResult,
 ) error {
 	if captureID == "" {
 		return ErrAcknowledgeConflict
 	}
-	if _, err := rawsync.NewObjectRef(manifestID, 0); err != nil {
-		return fmt.Errorf("rawcheckpoint: invalid finalized manifest ID: %w", err)
+	if err := rawsync.ValidateCommitResult(commit); err != nil {
+		return fmt.Errorf("rawcheckpoint: invalid finalized commit: %w", err)
 	}
-	return s.withImmediateWrite(ctx, "bind finalized manifest ID", func(conn *sql.Conn) error {
+	return s.withImmediateWrite(ctx, "bind finalized commit", func(conn *sql.Conn) error {
 		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
 			return err
 		}
-		var state, stored string
-		err := conn.QueryRowContext(ctx, `SELECT state, manifest_id
-			FROM outbox_generations WHERE capture_id = ?`, captureID).Scan(&state, &stored)
+		var state, manifestID, receipt string
+		var generation int64
+		err := conn.QueryRowContext(ctx, `SELECT state, manifest_id, ack_receipt, ack_generation
+			FROM outbox_generations WHERE capture_id = ?`, captureID,
+		).Scan(&state, &manifestID, &receipt, &generation)
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrAcknowledgeConflict
 		}
 		if err != nil {
-			return fmt.Errorf("rawcheckpoint: bind finalized manifest ID: %w", err)
+			return fmt.Errorf("rawcheckpoint: bind finalized commit: %w", err)
 		}
-		if state != "finalized" || (stored != "" && stored != manifestID) {
+		if state != "finalized" {
 			return ErrAcknowledgeConflict
 		}
-		if stored == manifestID {
+		if manifestID == commit.ManifestID && receipt == commit.Receipt &&
+			generation == commit.Generation {
 			return nil
 		}
+		if manifestID != "" || receipt != "" || generation != 0 {
+			return ErrAcknowledgeConflict
+		}
 		result, err := conn.ExecContext(ctx, `UPDATE outbox_generations
-			SET manifest_id = ?, updated_at = ?
-			WHERE capture_id = ? AND state = 'finalized' AND manifest_id = ''`,
-			manifestID, s.now().UTC().Format(time.RFC3339Nano), captureID)
+			SET manifest_id = ?, ack_receipt = ?, ack_generation = ?, updated_at = ?
+			WHERE capture_id = ? AND state = 'finalized'
+				AND manifest_id = '' AND ack_receipt = '' AND ack_generation = 0`,
+			commit.ManifestID, commit.Receipt, commit.Generation,
+			s.now().UTC().Format(time.RFC3339Nano), captureID,
+		)
 		if err != nil {
-			return fmt.Errorf("rawcheckpoint: bind finalized manifest ID: %w", err)
+			return fmt.Errorf("rawcheckpoint: bind finalized commit: %w", err)
 		}
 		changed, err := result.RowsAffected()
 		if err != nil || changed != 1 {
@@ -78,6 +89,49 @@ func (s *Store) BindFinalizedManifestID(
 		}
 		return nil
 	})
+}
+
+// FinalizedCommit returns a server result durably recorded for a finalized
+// generation. The bool is false when the generation still needs committing.
+func (s *Store) FinalizedCommit(
+	ctx context.Context,
+	deviceID, captureID string,
+) (rawsync.CommitResult, bool, error) {
+	if captureID == "" {
+		return rawsync.CommitResult{}, false, ErrAcknowledgeConflict
+	}
+	var commit rawsync.CommitResult
+	found := false
+	err := s.withImmediateWrite(ctx, "read finalized commit", func(conn *sql.Conn) error {
+		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
+			return err
+		}
+		var state string
+		err := conn.QueryRowContext(ctx, `SELECT state, manifest_id, ack_receipt, ack_generation
+			FROM outbox_generations WHERE capture_id = ?`, captureID,
+		).Scan(&state, &commit.ManifestID, &commit.Receipt, &commit.Generation)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrAcknowledgeConflict
+		}
+		if err != nil {
+			return fmt.Errorf("rawcheckpoint: read finalized commit: %w", err)
+		}
+		if state != "finalized" {
+			return ErrAcknowledgeConflict
+		}
+		if commit.ManifestID == "" && commit.Receipt == "" && commit.Generation == 0 {
+			return nil
+		}
+		if err := rawsync.ValidateCommitResult(commit); err != nil {
+			return fmt.Errorf("rawcheckpoint: invalid stored finalized commit: %w", err)
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return rawsync.CommitResult{}, false, err
+	}
+	return commit, found, nil
 }
 
 // FinalizeNextManifest returns the oldest uploadable generation and durably
@@ -156,6 +210,7 @@ func (s *Store) RecordGenerationFailure(
 	retryAt time.Time,
 ) error {
 	blocked := 0
+	attemptIncrement := 0
 	retryStamp := ""
 	switch class {
 	case GenerationFailureTransient:
@@ -163,7 +218,13 @@ func (s *Store) RecordGenerationFailure(
 			return ErrGenerationFailureConflict
 		}
 		retryStamp = checkpointTimestamp(retryAt)
+		attemptIncrement = 1
 	case GenerationFailureParentReceiptConflict:
+		if !retryAt.IsZero() {
+			return ErrGenerationFailureConflict
+		}
+		blocked = 1
+	case GenerationFailurePermanent:
 		if !retryAt.IsZero() {
 			return ErrGenerationFailureConflict
 		}
@@ -176,10 +237,11 @@ func (s *Store) RecordGenerationFailure(
 			return err
 		}
 		result, err := conn.ExecContext(ctx, `UPDATE outbox_generations SET
-			retry_at = ?, error_class = ?, blocked = ?, updated_at = ?
+			retry_at = ?, error_class = ?, blocked = ?,
+			attempt_count = attempt_count + ?, updated_at = ?
 			WHERE capture_id = ? AND state = 'finalized'
 				AND (blocked = 0 OR ? = 1)`, retryStamp, string(class),
-			blocked, checkpointTimestamp(s.now()), captureID, blocked)
+			blocked, attemptIncrement, checkpointTimestamp(s.now()), captureID, blocked)
 		if err != nil {
 			return fmt.Errorf("rawcheckpoint: record generation failure: %w", err)
 		}
@@ -191,8 +253,121 @@ func (s *Store) RecordGenerationFailure(
 	})
 }
 
-// ResumeGeneration reconciles a parent-receipt conflict to the reported
-// server head and requeues the local generation to freeze that new parent.
+// GenerationAttempts returns the durable transient failure count for one
+// finalized generation, fenced to the configured device.
+func (s *Store) GenerationAttempts(
+	ctx context.Context,
+	deviceID, captureID string,
+) (int, error) {
+	var attempts int
+	err := s.withImmediateWrite(ctx, "read generation attempts", func(conn *sql.Conn) error {
+		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
+			return err
+		}
+		if err := conn.QueryRowContext(ctx, `SELECT attempt_count
+			FROM outbox_generations WHERE capture_id = ? AND state = 'finalized'`,
+			captureID,
+		).Scan(&attempts); errors.Is(err, sql.ErrNoRows) {
+			return ErrGenerationFailureConflict
+		} else if err != nil {
+			return fmt.Errorf("rawcheckpoint: read generation attempts: %w", err)
+		}
+		return nil
+	})
+	return attempts, err
+}
+
+// DiscardRejectedGeneration removes a permanently rejected generation and
+// every unacknowledged descendant, then resets the source to its last durable
+// server head so a later audit can create a fresh replacement generation.
+func (s *Store) DiscardRejectedGeneration(
+	ctx context.Context,
+	deviceID, captureID string,
+) (GarbageCollectionReport, error) {
+	if captureID == "" {
+		return GarbageCollectionReport{}, ErrGenerationFailureConflict
+	}
+	err := s.withImmediateWrite(ctx, "discard rejected generation", func(conn *sql.Conn) error {
+		if err := requireConfiguredDeviceConn(ctx, conn, deviceID); err != nil {
+			return err
+		}
+		return discardRejectedGenerationConn(ctx, conn, captureID, s)
+	})
+	if err != nil {
+		return GarbageCollectionReport{}, err
+	}
+	return s.CollectGarbage(ctx)
+}
+
+func discardRejectedGenerationConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	captureID string,
+	store *Store,
+) error {
+	rows, err := conn.QueryContext(ctx, `WITH RECURSIVE suffix(capture_id) AS (
+			SELECT capture_id FROM outbox_generations
+			WHERE capture_id = ? AND state = 'finalized'
+			UNION ALL
+			SELECT generation.capture_id FROM outbox_generations AS generation
+			JOIN suffix ON generation.predecessor_capture_id = suffix.capture_id
+			WHERE generation.state != 'acknowledged'
+		)
+		SELECT capture_id FROM suffix`, captureID)
+	if err != nil {
+		return fmt.Errorf("rawcheckpoint: discard rejected generation: %w", err)
+	}
+	var discarded []string
+	for rows.Next() {
+		var current string
+		if err := rows.Scan(&current); err != nil {
+			rows.Close()
+			return fmt.Errorf("rawcheckpoint: discard rejected generation: %w", err)
+		}
+		discarded = append(discarded, current)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("rawcheckpoint: discard rejected generation: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("rawcheckpoint: discard rejected generation: %w", err)
+	}
+	if len(discarded) == 0 {
+		return ErrGenerationFailureConflict
+	}
+	for _, current := range discarded {
+		if err := releaseGenerationObjectsConn(ctx, conn, current); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM outbox_entries WHERE capture_id = ?`, current); err != nil {
+			return fmt.Errorf("rawcheckpoint: discard rejected entries: %w", err)
+		}
+	}
+	if err := resetInvalidSourcesConn(
+		ctx, conn, discarded, store, "server_rejected",
+	); err != nil {
+		return err
+	}
+	for _, current := range discarded {
+		if _, err := conn.ExecContext(ctx,
+			`DELETE FROM outbox_generations WHERE capture_id = ?`, current); err != nil {
+			return fmt.Errorf("rawcheckpoint: discard rejected generation: %w", err)
+		}
+	}
+	if _, err := conn.ExecContext(ctx, `UPDATE outbox_objects
+			SET state = 'garbage_pending'
+			WHERE ref_count = 0 AND state != 'remote'`); err != nil {
+		return fmt.Errorf("rawcheckpoint: discard rejected objects: %w", err)
+	}
+	return nil
+}
+
+// ResumeGeneration atomically reconciles a parent-receipt conflict to the
+// reported server head and requeues the local generation to freeze that new
+// parent. It accepts an untouched finalized generation, a transiently failed
+// generation without a durable commit result, or an older blocked conflict.
 func (s *Store) ResumeGeneration(
 	ctx context.Context,
 	deviceID, captureID string,
@@ -206,21 +381,27 @@ func (s *Store) ResumeGeneration(
 			return err
 		}
 		var source SourceIdentity
-		var state, failureClass string
+		var state, failureClass, manifestID, receipt string
+		var generation int64
 		var blocked int
 		err := conn.QueryRowContext(ctx, `SELECT provider, configured_root_id,
-			source_key, state, error_class, blocked FROM outbox_generations
+			source_key, state, error_class, blocked, manifest_id, ack_receipt,
+			ack_generation FROM outbox_generations
 			WHERE capture_id = ?`, captureID,
 		).Scan(&source.Provider, &source.ConfiguredRootID, &source.SourceKey,
-			&state, &failureClass, &blocked)
+			&state, &failureClass, &blocked, &manifestID, &receipt, &generation)
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrGenerationFailureConflict
 		}
 		if err != nil {
 			return fmt.Errorf("rawcheckpoint: resume generation: read state: %w", err)
 		}
-		if state != "finalized" ||
-			failureClass != string(GenerationFailureParentReceiptConflict) || blocked != 1 {
+		cleanFinalized := failureClass == "" && blocked == 0
+		transientFailure := failureClass == string(GenerationFailureTransient) &&
+			blocked == 0 && manifestID == "" && receipt == "" && generation == 0
+		blockedConflict := failureClass == string(GenerationFailureParentReceiptConflict) &&
+			blocked == 1
+		if state != "finalized" || (!cleanFinalized && !transientFailure && !blockedConflict) {
 			return ErrGenerationFailureConflict
 		}
 		now := s.now().UTC().Format(time.RFC3339Nano)
@@ -239,9 +420,15 @@ func (s *Store) ResumeGeneration(
 		}
 		result, err := conn.ExecContext(ctx, `UPDATE outbox_generations SET
 			state = 'queued', expected_parent_receipt = '', manifest_id = '',
-			retry_at = '', error_class = '', blocked = 0, updated_at = ?
+			ack_receipt = '', ack_generation = 0,
+			retry_at = '', error_class = '', blocked = 0, attempt_count = 0,
+			updated_at = ?
 			WHERE capture_id = ? AND state = 'finalized'
-			AND error_class = ? AND blocked = 1`, now, captureID,
+			AND ((error_class = '' AND blocked = 0)
+				OR (error_class = ? AND blocked = 0
+					AND manifest_id = '' AND ack_receipt = '' AND ack_generation = 0)
+				OR (error_class = ? AND blocked = 1))`, now, captureID,
+			string(GenerationFailureTransient),
 			string(GenerationFailureParentReceiptConflict))
 		if err != nil {
 			return fmt.Errorf("rawcheckpoint: resume generation: %w", err)
@@ -326,7 +513,10 @@ func (s *Store) AcknowledgeGeneration(
 			return ErrAcknowledgeConflict
 		}
 		if state != "finalized" || storedManifestID == "" ||
-			storedManifestID != commit.ManifestID || expectedParent != current.Receipt ||
+			storedManifestID != commit.ManifestID ||
+			((storedReceipt != "" || storedGeneration != 0) &&
+				(storedReceipt != commit.Receipt || storedGeneration != commit.Generation)) ||
+			expectedParent != current.Receipt ||
 			commit.Generation != current.Generation+1 {
 			return ErrAcknowledgeConflict
 		}

--- a/internal/rawcheckpoint/ack_test.go
+++ b/internal/rawcheckpoint/ack_test.go
@@ -2,6 +2,7 @@ package rawcheckpoint
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,8 +47,8 @@ func TestFinalizeAndAcknowledgeOfflineChainInOrder(t *testing.T) {
 		Generation: 1,
 		Created:    true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generations[0].CaptureID, firstCommit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generations[0].CaptureID, firstCommit,
 	))
 	ack, err := store.AcknowledgeGeneration(
 		t.Context(), "device-a", generations[0].CaptureID, firstCommit,
@@ -68,8 +69,8 @@ func TestFinalizeAndAcknowledgeOfflineChainInOrder(t *testing.T) {
 		Generation: 2,
 		Created:    true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generations[1].CaptureID, secondCommit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generations[1].CaptureID, secondCommit,
 	))
 	_, err = store.AcknowledgeGeneration(
 		t.Context(), "device-a", generations[1].CaptureID, secondCommit,
@@ -88,6 +89,187 @@ func TestFinalizeAndAcknowledgeOfflineChainInOrder(t *testing.T) {
 	assert.True(t, replayed.Replayed)
 }
 
+func TestFinalizeNextManifestOrdersExactSecondBeforeLaterFraction(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	baseTime := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	for sequence, capturedAt := range []time.Time{
+		baseTime,
+		baseTime.Add(100 * time.Millisecond),
+	} {
+		ref := rawsync.ObjectRef{
+			SHA256: validCheckpointDigest(byte(sequence + 10)), Length: 1,
+		}
+		installOutboxTestObject(t, store, ref, []byte{byte(sequence)})
+		generation := testCapturedGeneration(sequence+1, root, "", ref)
+		generation.Source.SourceKey = fmt.Sprintf("source-%d", sequence)
+		generation.CapturedAt = capturedAt
+		reservation, err := store.ReserveSourceCapture(
+			t.Context(), generation.Source, 1793,
+		)
+		require.NoError(t, err)
+		require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	}
+
+	manifest, found, err := store.FinalizeNextManifest(t.Context(), "device-a")
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, fmt.Sprintf("%032x", 1), manifest.CaptureID)
+}
+
+func TestBindFinalizedCommitPersistsResultForRetry(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(10), Length: 1}
+	installOutboxTestObject(t, store, ref, []byte{1})
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	commit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1),
+		Receipt:    validCheckpointDigest(2),
+		Generation: 1,
+		Created:    true,
+	}
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generation.CaptureID, commit,
+	))
+	stored, found, err := store.FinalizedCommit(t.Context(), "device-a", generation.CaptureID)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, commit.ManifestID, stored.ManifestID)
+	assert.Equal(t, commit.Receipt, stored.Receipt)
+	assert.Equal(t, commit.Generation, stored.Generation)
+}
+
+func TestQueueTombstoneWaitsForSnapshotAndIsIdempotent(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	snapshot := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, snapshot))
+
+	tombstoneID, queued, err := store.QueueTombstone(t.Context(), snapshot.Source)
+	require.NoError(t, err)
+	require.True(t, queued)
+	assert.NotEmpty(t, tombstoneID)
+	_, queued, err = store.QueueTombstone(t.Context(), snapshot.Source)
+	require.NoError(t, err)
+	assert.False(t, queued)
+
+	first, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, snapshot.CaptureID, first.CaptureID)
+	retry, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, snapshot.CaptureID, retry.CaptureID,
+		"tombstone must wait for the snapshot receipt")
+
+	firstCommit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1),
+		Receipt:    validCheckpointDigest(2),
+		Generation: 1,
+		Created:    true,
+	}
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", snapshot.CaptureID, firstCommit,
+	))
+	_, err = store.AcknowledgeGeneration(
+		t.Context(), "device-a", snapshot.CaptureID, firstCommit,
+	)
+	require.NoError(t, err)
+
+	deleted, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, tombstoneID, deleted.CaptureID)
+	assert.Equal(t, rawsync.ManifestTombstone, deleted.Kind)
+	assert.Equal(t, firstCommit.Receipt, deleted.ExpectedParentReceipt)
+	assert.Empty(t, deleted.Entries)
+
+	base, ok, err := store.CaptureBase(t.Context(), snapshot.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, tombstoneID, base.CaptureID)
+	assert.Equal(t, rawsync.ManifestTombstone, base.Kind)
+	assert.Empty(t, base.Entries)
+}
+
+func TestQueueTombstoneReplacesPermanentlyRejectedTombstone(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	snapshot := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, snapshot))
+	manifest, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	snapshotCommit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(1),
+		Receipt:    validCheckpointDigest(2),
+		Generation: 1,
+		Created:    true,
+	}
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", manifest.CaptureID, snapshotCommit,
+	))
+	_, err = store.AcknowledgeGeneration(
+		t.Context(), "device-a", manifest.CaptureID, snapshotCommit,
+	)
+	require.NoError(t, err)
+	rejectedID, queued, err := store.QueueTombstone(t.Context(), snapshot.Source)
+	require.NoError(t, err)
+	require.True(t, queued)
+	rejected, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rejectedID, rejected.CaptureID)
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", rejectedID,
+		GenerationFailurePermanent, time.Time{},
+	))
+	status, err := store.ClientStatus(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, status.PermanentFailures)
+
+	replacementID, queued, err := store.QueueTombstone(t.Context(), snapshot.Source)
+
+	require.NoError(t, err)
+	require.True(t, queued)
+	assert.NotEqual(t, rejectedID, replacementID)
+	replacement, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, replacementID, replacement.CaptureID)
+	assert.Equal(t, rawsync.ManifestTombstone, replacement.Kind)
+	assert.Equal(t, snapshotCommit.Receipt, replacement.ExpectedParentReceipt)
+	var rejectedRows int
+	require.NoError(t, store.db.QueryRow(
+		`SELECT count(*) FROM outbox_generations WHERE capture_id = ?`, rejectedID,
+	).Scan(&rejectedRows))
+	assert.Zero(t, rejectedRows)
+	status, err = store.ClientStatus(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, status.PermanentFailures)
+	_, queued, err = store.QueueTombstone(t.Context(), snapshot.Source)
+	require.NoError(t, err)
+	assert.False(t, queued, "the healthy replacement remains idempotent")
+}
+
 func TestAcknowledgeGenerationRejectsStaleInputsWithoutAdvancing(t *testing.T) {
 	store, root := openOutboxTestStore(t, 1<<20)
 	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
@@ -104,11 +286,14 @@ func TestAcknowledgeGenerationRejectsStaleInputsWithoutAdvancing(t *testing.T) {
 		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
 		Generation: 1, Created: true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generation.CaptureID, valid.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generation.CaptureID, valid,
 	))
-	require.ErrorIs(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generation.CaptureID, validCheckpointDigest(9),
+	require.ErrorIs(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generation.CaptureID, rawsync.CommitResult{
+			ManifestID: validCheckpointDigest(9), Receipt: valid.Receipt,
+			Generation: valid.Generation,
+		},
 	), ErrAcknowledgeConflict)
 
 	for _, tc := range []struct {
@@ -157,8 +342,8 @@ func TestAcknowledgedCaptureBaseRetainsObjectReferencesAfterLocalGC(t *testing.T
 		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
 		Generation: 1, Created: true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generation.CaptureID, commit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generation.CaptureID, commit,
 	))
 	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", generation.CaptureID, commit)
 	require.NoError(t, err)
@@ -189,8 +374,8 @@ func TestCaptureBaseSnapshotRemainsCoherentDuringAcknowledgement(t *testing.T) {
 		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
 		Generation: 1, Created: true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generation.CaptureID, commit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generation.CaptureID, commit,
 	))
 
 	tx, err := store.db.BeginTx(t.Context(), &sql.TxOptions{ReadOnly: true})
@@ -234,8 +419,8 @@ func TestAcknowledgedGenerationCompactsToBoundedHeadReplayState(t *testing.T) {
 		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
 		Generation: 1, Created: true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generation.CaptureID, commit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generation.CaptureID, commit,
 	))
 	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", generation.CaptureID, commit)
 	require.NoError(t, err)
@@ -276,8 +461,8 @@ func TestAcknowledgementReplayFinishesPendingGarbageCollection(t *testing.T) {
 		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
 		Generation: 1, Created: true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generation.CaptureID, commit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generation.CaptureID, commit,
 	))
 	objectPath := store.ObjectPath(ref)
 	require.NoError(t, os.Remove(objectPath))
@@ -340,6 +525,63 @@ func TestParentConflictBlocksOnlyItsSourceChain(t *testing.T) {
 	).Scan(&errorClass, &blocked))
 	assert.Equal(t, string(GenerationFailureParentReceiptConflict), errorClass)
 	assert.Equal(t, 1, blocked)
+}
+
+func TestPermanentReplacementRecyclesCapacityAndCollectsRejectedObjects(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1793)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	rejectedRef := rawsync.ObjectRef{SHA256: validCheckpointDigest(20), Length: 1}
+	installOutboxTestObject(t, store, rejectedRef, []byte{1})
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	rejected := testCapturedGeneration(1, root, "", rejectedRef)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, rejected))
+	_, found, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", rejected.CaptureID,
+		GenerationFailurePermanent, time.Time{},
+	))
+
+	replacementRef := rawsync.ObjectRef{SHA256: validCheckpointDigest(21), Length: 1}
+	installOutboxTestObject(t, store, replacementRef, []byte{2})
+	replacementReservation, err := store.ReserveSourceCapture(
+		t.Context(), rejected.Source, 1793,
+	)
+	require.NoError(t, err)
+	_, err = store.ReserveSourceCapture(t.Context(), rejected.Source, 1)
+	require.ErrorIs(t, err, ErrOutboxFull,
+		"recyclable capacity must be credited to only one active reservation")
+	replacement := testCapturedGeneration(2, root, rejected.CaptureID, replacementRef)
+	require.NoError(t, store.CommitCapture(
+		t.Context(), replacementReservation.ID, replacement,
+	))
+	_, err = store.CollectGarbage(t.Context())
+	require.NoError(t, err)
+
+	var rejectedRows int
+	require.NoError(t, store.db.QueryRow(`SELECT count(*) FROM outbox_objects
+		WHERE sha256 = ? AND length = ?`, rejectedRef.SHA256, rejectedRef.Length,
+	).Scan(&rejectedRows))
+	assert.Zero(t, rejectedRows)
+	assert.NoFileExists(t, store.ObjectPath(rejectedRef))
+	var replacementRefs int
+	var replacementState string
+	require.NoError(t, store.db.QueryRow(`SELECT ref_count, state FROM outbox_objects
+		WHERE sha256 = ? AND length = ?`, replacementRef.SHA256, replacementRef.Length,
+	).Scan(&replacementRefs, &replacementState))
+	assert.Equal(t, 1, replacementRefs)
+	assert.Equal(t, "live", replacementState)
+	assert.FileExists(t, store.ObjectPath(replacementRef))
+	var generations int
+	require.NoError(t, store.db.QueryRow(
+		`SELECT count(*) FROM outbox_generations`,
+	).Scan(&generations))
+	assert.Equal(t, 1, generations)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1793), usage.UsedBytes)
 }
 
 func TestTransientFailureIsNotFinalizableBeforeRetryTime(t *testing.T) {
@@ -414,9 +656,6 @@ func TestResumeGenerationRequeuesAgainstReconciledServerHead(t *testing.T) {
 	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generation.CaptureID, validCheckpointDigest(3),
-	))
 	require.NoError(t, store.RecordGenerationFailure(
 		t.Context(), "device-a", generation.CaptureID,
 		GenerationFailureParentReceiptConflict, time.Time{},
@@ -444,6 +683,40 @@ func TestResumeGenerationRequeuesAgainstReconciledServerHead(t *testing.T) {
 	assert.Empty(t, manifestID)
 }
 
+func TestResumeGenerationAtomicallyReconcilesUnblockedConflict(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(10), Length: 1}
+	installOutboxTestObject(t, store, ref, []byte{1})
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1793)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	reconciled := SourceHead{
+		ManifestID: validCheckpointDigest(4), Receipt: validCheckpointDigest(5),
+		Generation: 1,
+	}
+
+	require.NoError(t, store.ResumeGeneration(
+		t.Context(), "device-a", generation.CaptureID, reconciled,
+	))
+	retried, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, reconciled.Receipt, retried.ExpectedParentReceipt)
+	var failureClass string
+	var blocked int
+	require.NoError(t, store.db.QueryRow(`SELECT error_class, blocked
+		FROM outbox_generations WHERE capture_id = ?`, generation.CaptureID,
+	).Scan(&failureClass, &blocked))
+	assert.Empty(t, failureClass)
+	assert.Zero(t, blocked)
+}
+
 func TestResumeGenerationRequeuesAgainstEmptyServerHead(t *testing.T) {
 	store, root := openOutboxTestStore(t, 1<<20)
 	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
@@ -456,9 +729,6 @@ func TestResumeGenerationRequeuesAgainstEmptyServerHead(t *testing.T) {
 	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", generation.CaptureID, validCheckpointDigest(3),
-	))
 	require.NoError(t, store.RecordGenerationFailure(
 		t.Context(), "device-a", generation.CaptureID,
 		GenerationFailureParentReceiptConflict, time.Time{},
@@ -502,8 +772,8 @@ func TestRepeatedAcknowledgementsReuseBoundedOutboxCapacity(t *testing.T) {
 			Generation: int64(sequence),
 			Created:    true,
 		}
-		require.NoError(t, store.BindFinalizedManifestID(
-			t.Context(), "device-a", manifest.CaptureID, commit.ManifestID,
+		require.NoError(t, store.BindFinalizedCommit(
+			t.Context(), "device-a", manifest.CaptureID, commit,
 		))
 		_, err = store.AcknowledgeGeneration(
 			t.Context(), "device-a", manifest.CaptureID, commit,

--- a/internal/rawcheckpoint/outbox.go
+++ b/internal/rawcheckpoint/outbox.go
@@ -41,13 +41,13 @@ const (
 
 // CoverageState records a persistent gap interval for one configured root.
 type CoverageState struct {
-	Provider         parser.AgentType
-	ConfiguredRootID string
-	State            CoverageStatus
-	Reason           string
-	DegradedAt       *time.Time
-	RecoveredAt      *time.Time
-	UpdatedAt        time.Time
+	Provider         parser.AgentType `json:"provider"`
+	ConfiguredRootID string           `json:"configured_root_id"`
+	State            CoverageStatus   `json:"state"`
+	Reason           string           `json:"reason,omitempty"`
+	DegradedAt       *time.Time       `json:"degraded_at,omitempty"`
+	RecoveredAt      *time.Time       `json:"recovered_at,omitempty"`
+	UpdatedAt        time.Time        `json:"updated_at"`
 }
 
 // Reservation fences outbox capacity while a capturer writes temporary files.
@@ -65,6 +65,14 @@ type SourceIdentity struct {
 	SourceKey        string
 }
 
+// SourceCheckpoint fences reconciliation work to the source generation that
+// was current when the source page was read.
+type SourceCheckpoint struct {
+	Source              SourceIdentity
+	CaptureID           string
+	ObservationRevision int64
+}
+
 // CapturedEntry is one complete logical file in a captured generation.
 type CapturedEntry struct {
 	Path         string
@@ -78,26 +86,30 @@ type CapturedEntry struct {
 
 // CapturedGeneration is an immutable local source generation.
 type CapturedGeneration struct {
-	CaptureID            string
-	Source               SourceIdentity
-	PredecessorCaptureID string
-	CapturedAt           time.Time
-	Kind                 rawsync.ManifestKind
-	Entries              []CapturedEntry
+	CaptureID                   string
+	Source                      SourceIdentity
+	PredecessorCaptureID        string
+	CapturedAt                  time.Time
+	Kind                        rawsync.ManifestKind
+	Entries                     []CapturedEntry
+	ExpectedObservationRevision *int64
 }
 
 // CaptureBaseState is the newest acknowledged or locally queued generation.
 type CaptureBaseState struct {
-	CaptureID string
-	Head      SourceHead
-	Entries   []CapturedEntry
+	CaptureID           string
+	ObservationRevision int64
+	Kind                rawsync.ManifestKind
+	Head                SourceHead
+	Entries             []CapturedEntry
+	PermanentlyRejected bool
 }
 
 // OutboxUsage reports charged and reserved bytes against the configured bound.
 type OutboxUsage struct {
-	UsedBytes     int64
-	ReservedBytes int64
-	LimitBytes    int64
+	UsedBytes     int64 `json:"used_bytes"`
+	ReservedBytes int64 `json:"reserved_bytes"`
+	LimitBytes    int64 `json:"limit_bytes"`
 }
 
 // GarbageCollectionReport describes normal-operation spool reclamation.
@@ -196,13 +208,15 @@ func OpenWithOptions(ctx context.Context, path string, options Options) (*Store,
 func (s *Store) bindSpool(ctx context.Context) error {
 	return s.withImmediateWrite(ctx, "bind object spool", func(conn *sql.Conn) error {
 		var bound string
+		var boundLimit int64
 		err := conn.QueryRowContext(ctx,
-			`SELECT spool_path FROM outbox_config WHERE id = 1`).Scan(&bound)
+			`SELECT spool_path, max_outbox_bytes FROM outbox_config WHERE id = 1`,
+		).Scan(&bound, &boundLimit)
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 			if _, err := conn.ExecContext(ctx,
-				`INSERT INTO outbox_config (id, spool_path) VALUES (1, ?)`,
-				s.spoolDir); err != nil {
+				`INSERT INTO outbox_config (id, spool_path, max_outbox_bytes)
+				VALUES (1, ?, ?)`, s.spoolDir, s.maxOutboxBytes); err != nil {
 				return fmt.Errorf("rawcheckpoint: bind object spool: %w", err)
 			}
 			return nil
@@ -211,6 +225,13 @@ func (s *Store) bindSpool(ctx context.Context) error {
 		case bound != s.spoolDir:
 			return ErrSpoolMismatch
 		default:
+			if boundLimit == s.maxOutboxBytes {
+				return nil
+			}
+			if _, err := conn.ExecContext(ctx, `UPDATE outbox_config
+				SET max_outbox_bytes = ? WHERE id = 1`, s.maxOutboxBytes); err != nil {
+				return fmt.Errorf("rawcheckpoint: update outbox limit: %w", err)
+			}
 			return nil
 		}
 	})
@@ -297,7 +318,9 @@ func (s *Store) ReserveCapture(
 	configuredRootID string,
 	bytes int64,
 ) (Reservation, error) {
-	return s.reserveCapture(ctx, SourceIdentity{ConfiguredRootID: configuredRootID}, bytes)
+	return s.reserveCapture(
+		ctx, SourceIdentity{ConfiguredRootID: configuredRootID}, bytes,
+	)
 }
 
 // ReserveSourceCapture atomically reserves the caller's worst-case object and
@@ -338,7 +361,15 @@ func (s *Store) reserveCapture(
 		if err != nil {
 			return err
 		}
-		if bytes > s.maxOutboxBytes-usage.UsedBytes-usage.ReservedBytes {
+		recyclable, err := recyclablePermanentFailureBytesConn(ctx, conn, source)
+		if err != nil {
+			return err
+		}
+		effectiveUsed := usage.UsedBytes - recyclable
+		if effectiveUsed < 0 {
+			return fmt.Errorf("rawcheckpoint: recyclable outbox capacity exceeds usage")
+		}
+		if bytes > s.maxOutboxBytes-effectiveUsed-usage.ReservedBytes {
 			now := s.now().UTC()
 			if err := setSourceCoverageDegradedConn(
 				ctx, conn, source, "outbox_full", now,
@@ -372,6 +403,93 @@ func (s *Store) reserveCapture(
 	return reservation, err
 }
 
+// RecordSourceObservation durably invalidates older absence scans after the
+// caller has positively opened a tracked source.
+func (s *Store) RecordSourceObservation(
+	ctx context.Context,
+	source SourceIdentity,
+) error {
+	return s.withImmediateWrite(ctx, "record source observation", func(conn *sql.Conn) error {
+		return recordSourceObservationConn(ctx, conn, source)
+	})
+}
+
+func recordSourceObservationConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	source SourceIdentity,
+) error {
+	if _, err := conn.ExecContext(ctx, `UPDATE raw_sources
+		SET observation_revision = observation_revision + 1
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+		string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
+		return fmt.Errorf("rawcheckpoint: record source observation: %w", err)
+	}
+	return nil
+}
+
+func recyclablePermanentFailureBytesConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	source SourceIdentity,
+) (int64, error) {
+	if source.Provider == "" || source.SourceKey == "" {
+		return 0, nil
+	}
+	var reserved int
+	if err := conn.QueryRowContext(ctx, `SELECT EXISTS(
+		SELECT 1 FROM outbox_reservations
+		WHERE provider = ? AND configured_root_id = ? AND source_key = ?
+	)`, string(source.Provider), source.ConfiguredRootID, source.SourceKey).Scan(&reserved); err != nil {
+		return 0, fmt.Errorf("rawcheckpoint: inspect recyclable reservation: %w", err)
+	}
+	if reserved != 0 {
+		return 0, nil
+	}
+	latest, found, err := latestCaptureIDConn(ctx, conn, source)
+	if err != nil || !found || latest == "" {
+		return 0, err
+	}
+	permanentRoot, err := permanentFailureAncestorConn(ctx, conn, latest)
+	if err != nil || permanentRoot == "" {
+		return 0, err
+	}
+	var generationBytes, objectBytes int64
+	if err := conn.QueryRowContext(ctx, `WITH RECURSIVE suffix(capture_id) AS (
+		SELECT capture_id FROM outbox_generations WHERE capture_id = ?
+		UNION ALL
+		SELECT generation.capture_id FROM outbox_generations AS generation
+		JOIN suffix ON generation.predecessor_capture_id = suffix.capture_id
+	)
+	SELECT coalesce(sum(generation.metadata_bytes), 0)
+	FROM outbox_generations AS generation
+	JOIN suffix ON suffix.capture_id = generation.capture_id`, permanentRoot,
+	).Scan(&generationBytes); err != nil {
+		return 0, fmt.Errorf("rawcheckpoint: read recyclable generation capacity: %w", err)
+	}
+	if err := conn.QueryRowContext(ctx, `WITH RECURSIVE suffix(capture_id) AS (
+		SELECT capture_id FROM outbox_generations WHERE capture_id = ?
+		UNION ALL
+		SELECT generation.capture_id FROM outbox_generations AS generation
+		JOIN suffix ON generation.predecessor_capture_id = suffix.capture_id
+	), suffix_refs(sha256, length, references_in_suffix) AS (
+		SELECT entry_object.sha256, entry_object.length, count(*)
+		FROM outbox_entry_objects AS entry_object
+		JOIN suffix ON suffix.capture_id = entry_object.capture_id
+		GROUP BY entry_object.sha256, entry_object.length
+	)
+	SELECT coalesce(sum(object.length), 0)
+	FROM outbox_objects AS object
+	JOIN suffix_refs AS suffix_ref
+		ON suffix_ref.sha256 = object.sha256 AND suffix_ref.length = object.length
+	WHERE object.state != 'remote'
+		AND object.ref_count = suffix_ref.references_in_suffix`, permanentRoot,
+	).Scan(&objectBytes); err != nil {
+		return 0, fmt.Errorf("rawcheckpoint: read recyclable object capacity: %w", err)
+	}
+	return generationBytes + objectBytes, nil
+}
+
 // ReleaseReservation idempotently releases unused reserved capacity.
 func (s *Store) ReleaseReservation(ctx context.Context, reservationID string) error {
 	if reservationID == "" {
@@ -392,6 +510,8 @@ func (s *Store) CompleteUnchangedCapture(
 	ctx context.Context,
 	reservationID string,
 	source SourceIdentity,
+	expectedCaptureID string,
+	expectedObservationRevision int64,
 ) error {
 	if reservationID == "" || source.Provider == "" ||
 		source.ConfiguredRootID == "" || source.SourceKey == "" {
@@ -413,6 +533,24 @@ func (s *Store) CompleteUnchangedCapture(
 			reservationProvider, reservationRoot, reservationSourceKey, source,
 		) {
 			return ErrCaptureConflict
+		}
+		if expectedCaptureID != "" {
+			result, err := conn.ExecContext(ctx, `UPDATE raw_sources
+				SET observation_revision = observation_revision + 1
+				WHERE provider = ? AND configured_root_id = ? AND source_key = ?
+					AND latest_capture_id = ? AND observation_revision = ?`,
+				string(source.Provider), source.ConfiguredRootID, source.SourceKey,
+				expectedCaptureID, expectedObservationRevision)
+			if err != nil {
+				return fmt.Errorf("rawcheckpoint: complete unchanged capture: record observation: %w", err)
+			}
+			updated, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("rawcheckpoint: complete unchanged capture: record observation: %w", err)
+			}
+			if updated != 1 {
+				return ErrCaptureConflict
+			}
 		}
 		if _, err := conn.ExecContext(ctx,
 			`DELETE FROM outbox_reservations WHERE id = ?`, reservationID); err != nil {
@@ -464,6 +602,12 @@ func (s *Store) OutboxUsage(ctx context.Context) (OutboxUsage, error) {
 		return OutboxUsage{}, fmt.Errorf("rawcheckpoint: read outbox usage: %w", err)
 	}
 	usage.LimitBytes = s.maxOutboxBytes
+	if usage.LimitBytes == 0 {
+		if err := s.db.QueryRowContext(ctx, `SELECT max_outbox_bytes
+			FROM outbox_config WHERE id = 1`).Scan(&usage.LimitBytes); err != nil {
+			return OutboxUsage{}, fmt.Errorf("rawcheckpoint: read outbox limit: %w", err)
+		}
+	}
 	return usage, nil
 }
 
@@ -546,6 +690,26 @@ func (s *Store) CommitCapture(
 		if latest != validated.PredecessorCaptureID {
 			return ErrCaptureConflict
 		}
+		if validated.ExpectedObservationRevision != nil {
+			var observationRevision int64
+			err := conn.QueryRowContext(ctx, `SELECT observation_revision
+				FROM raw_sources
+				WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
+				string(validated.Source.Provider), validated.Source.ConfiguredRootID,
+				validated.Source.SourceKey,
+			).Scan(&observationRevision)
+			if errors.Is(err, sql.ErrNoRows) ||
+				err == nil && observationRevision != *validated.ExpectedObservationRevision {
+				return ErrCaptureConflict
+			}
+			if err != nil {
+				return fmt.Errorf("rawcheckpoint: commit capture: read source observation: %w", err)
+			}
+		}
+		permanentRoot, err := permanentFailureAncestorConn(ctx, conn, latest)
+		if err != nil {
+			return err
+		}
 		newObjectBytes, err := missingObjectBytesConn(ctx, conn, uniqueObjects)
 		if err != nil {
 			return err
@@ -555,20 +719,27 @@ func (s *Store) CommitCapture(
 		}
 
 		now := s.now().UTC().Format(time.RFC3339Nano)
-		var predecessor any
-		if validated.PredecessorCaptureID != "" {
-			var headCaptureID string
-			if found {
-				if err := conn.QueryRowContext(ctx, `SELECT head_capture_id FROM raw_sources
+		var headCaptureID string
+		if found {
+			if err := conn.QueryRowContext(ctx, `SELECT head_capture_id FROM raw_sources
 					WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
-					string(validated.Source.Provider), validated.Source.ConfiguredRootID,
-					validated.Source.SourceKey).Scan(&headCaptureID); err != nil {
-					return fmt.Errorf("rawcheckpoint: commit capture: read source head: %w", err)
-				}
+				string(validated.Source.Provider), validated.Source.ConfiguredRootID,
+				validated.Source.SourceKey).Scan(&headCaptureID); err != nil {
+				return fmt.Errorf("rawcheckpoint: commit capture: read source head: %w", err)
 			}
-			if validated.PredecessorCaptureID != headCaptureID {
-				predecessor = validated.PredecessorCaptureID
+		}
+		predecessorCaptureID := validated.PredecessorCaptureID
+		if permanentRoot != "" {
+			if err := discardRejectedGenerationConn(
+				ctx, conn, permanentRoot, s,
+			); err != nil {
+				return err
 			}
+			predecessorCaptureID = headCaptureID
+		}
+		var predecessor any
+		if predecessorCaptureID != "" && predecessorCaptureID != headCaptureID {
+			predecessor = predecessorCaptureID
 		}
 		if _, err := conn.ExecContext(ctx, `INSERT INTO outbox_generations
 			(capture_id, provider, configured_root_id, source_key,
@@ -577,7 +748,7 @@ func (s *Store) CommitCapture(
 			VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?)`,
 			validated.CaptureID, string(validated.Source.Provider),
 			validated.Source.ConfiguredRootID, validated.Source.SourceKey,
-			predecessor, validated.CapturedAt.Format(time.RFC3339Nano),
+			predecessor, checkpointTimestamp(validated.CapturedAt),
 			string(validated.Kind), metadataBytes, now, now); err != nil {
 			return fmt.Errorf("rawcheckpoint: commit capture: insert generation: %w", err)
 		}
@@ -589,7 +760,8 @@ func (s *Store) CommitCapture(
 		}
 		if found {
 			if _, err := conn.ExecContext(ctx, `UPDATE raw_sources SET
-				latest_capture_id = ?, updated_at = ?
+				latest_capture_id = ?, observation_revision = observation_revision + 1,
+				updated_at = ?
 				WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
 				validated.CaptureID, now, string(validated.Source.Provider),
 				validated.Source.ConfiguredRootID, validated.Source.SourceKey); err != nil {
@@ -597,8 +769,9 @@ func (s *Store) CommitCapture(
 			}
 		} else {
 			if _, err := conn.ExecContext(ctx, `INSERT INTO raw_sources
-				(provider, configured_root_id, source_key, updated_at, latest_capture_id)
-				VALUES (?, ?, ?, ?, ?)`, string(validated.Source.Provider),
+				(provider, configured_root_id, source_key, updated_at, latest_capture_id,
+				 observation_revision)
+				VALUES (?, ?, ?, ?, ?, 1)`, string(validated.Source.Provider),
 				validated.Source.ConfiguredRootID, validated.Source.SourceKey,
 				now, validated.CaptureID); err != nil {
 				return fmt.Errorf("rawcheckpoint: commit capture: insert source: %w", err)
@@ -615,6 +788,90 @@ func (s *Store) CommitCapture(
 		}
 		return nil
 	})
+}
+
+// QueueTombstone durably appends one deletion after the newest local source
+// generation. Repeated deletion observations are idempotent unless the newest
+// tombstone was permanently rejected and must be replaced.
+func (s *Store) QueueTombstone(
+	ctx context.Context,
+	source SourceIdentity,
+) (string, bool, error) {
+	return s.queueTombstone(ctx, source, "", 0, false)
+}
+
+// QueueTombstoneIfLatest queues a deletion only while expectedCaptureID is
+// still the source's newest local generation. A concurrent capture makes the
+// stale absence observation a no-op.
+func (s *Store) QueueTombstoneIfLatest(
+	ctx context.Context,
+	source SourceIdentity,
+	expectedCaptureID string,
+	expectedObservationRevision int64,
+) (string, bool, error) {
+	return s.queueTombstone(
+		ctx, source, expectedCaptureID, expectedObservationRevision, true,
+	)
+}
+
+func (s *Store) queueTombstone(
+	ctx context.Context,
+	source SourceIdentity,
+	expectedCaptureID string,
+	expectedObservationRevision int64,
+	fenced bool,
+) (string, bool, error) {
+	base, found, err := s.CaptureBase(ctx, source)
+	if err != nil || !found {
+		return "", false, err
+	}
+	if fenced && base.CaptureID != expectedCaptureID {
+		return "", false, nil
+	}
+	if base.Kind == rawsync.ManifestTombstone && !base.PermanentlyRejected {
+		return "", false, nil
+	}
+	reservation, err := s.ReserveSourceCapture(
+		ctx, source, CaptureMetadataCharge(0, 0),
+	)
+	if err != nil {
+		return "", false, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = s.ReleaseReservation(context.Background(), reservation.ID)
+		}
+	}()
+	captureID, err := randomCheckpointID()
+	if err != nil {
+		return "", false, err
+	}
+	var expectedRevision *int64
+	if fenced {
+		expectedRevision = &expectedObservationRevision
+	}
+	err = s.CommitCapture(ctx, reservation.ID, CapturedGeneration{
+		CaptureID:                   captureID,
+		Source:                      source,
+		PredecessorCaptureID:        base.CaptureID,
+		CapturedAt:                  s.now().UTC(),
+		Kind:                        rawsync.ManifestTombstone,
+		ExpectedObservationRevision: expectedRevision,
+	})
+	if fenced && errors.Is(err, ErrCaptureConflict) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	committed = true
+	if base.PermanentlyRejected {
+		if _, err := s.CollectGarbage(ctx); err != nil {
+			return "", false, err
+		}
+	}
+	return captureID, true, nil
 }
 
 func reservationMatchesSource(
@@ -652,6 +909,102 @@ func (s *Store) CaptureBase(
 	return base, found, nil
 }
 
+// ConfiguredRootSources lists source chains already known beneath one local
+// configured root. It contains identity only, never source content.
+func (s *Store) ConfiguredRootSources(
+	ctx context.Context,
+	provider parser.AgentType,
+	configuredRootID string,
+) ([]SourceIdentity, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT source_key FROM raw_sources
+		WHERE provider = ? AND configured_root_id = ? ORDER BY source_key`,
+		string(provider), configuredRootID)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: list configured-root sources: %w", err)
+	}
+	defer rows.Close()
+	var sources []SourceIdentity
+	for rows.Next() {
+		var source SourceIdentity
+		source.Provider = provider
+		source.ConfiguredRootID = configuredRootID
+		if err := rows.Scan(&source.SourceKey); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: list configured-root sources: %w", err)
+		}
+		sources = append(sources, source)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: list configured-root sources: %w", err)
+	}
+	return sources, nil
+}
+
+// ConfiguredRootSourcesPage returns at most limit source checkpoints after
+// afterKey, wrapping to the beginning so repeated bounded calls rotate through
+// a root.
+func (s *Store) ConfiguredRootSourcesPage(
+	ctx context.Context,
+	provider parser.AgentType,
+	configuredRootID string,
+	afterKey string,
+	limit int,
+) ([]SourceCheckpoint, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	sources, err := s.configuredRootSourcesRange(
+		ctx, provider, configuredRootID, afterKey, ">", limit,
+	)
+	if err != nil || len(sources) == limit || afterKey == "" {
+		return sources, err
+	}
+	wrapped, err := s.configuredRootSourcesRange(
+		ctx, provider, configuredRootID, afterKey, "<=", limit-len(sources),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return append(sources, wrapped...), nil
+}
+
+func (s *Store) configuredRootSourcesRange(
+	ctx context.Context,
+	provider parser.AgentType,
+	configuredRootID string,
+	afterKey string,
+	comparison string,
+	limit int,
+) ([]SourceCheckpoint, error) {
+	query := `SELECT source_key, latest_capture_id, observation_revision FROM raw_sources
+		WHERE provider = ? AND configured_root_id = ? AND source_key ` + comparison + ` ?
+		ORDER BY source_key LIMIT ?`
+	rows, err := s.db.QueryContext(
+		ctx, query, string(provider), configuredRootID, afterKey, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: page configured-root sources: %w", err)
+	}
+	defer rows.Close()
+	sources := make([]SourceCheckpoint, 0, limit)
+	for rows.Next() {
+		source := SourceCheckpoint{
+			Source: SourceIdentity{
+				Provider: provider, ConfiguredRootID: configuredRootID,
+			},
+		}
+		if err := rows.Scan(
+			&source.Source.SourceKey, &source.CaptureID, &source.ObservationRevision,
+		); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: page configured-root sources: %w", err)
+		}
+		sources = append(sources, source)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: page configured-root sources: %w", err)
+	}
+	return sources, nil
+}
+
 type checkpointQueryer interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...any) *sql.Row
@@ -665,13 +1018,14 @@ func captureBaseSnapshot(
 	var captureID string
 	var headCaptureID string
 	var head SourceHead
+	var observationRevision int64
 	var updatedAt string
 	err := queryer.QueryRowContext(ctx, `SELECT latest_capture_id, head_capture_id, head_manifest_id,
-		head_receipt, head_generation, updated_at FROM raw_sources
+		head_receipt, head_generation, observation_revision, updated_at FROM raw_sources
 		WHERE provider = ? AND configured_root_id = ? AND source_key = ?`,
 		string(source.Provider), source.ConfiguredRootID, source.SourceKey,
 	).Scan(&captureID, &headCaptureID, &head.ManifestID, &head.Receipt,
-		&head.Generation, &updatedAt)
+		&head.Generation, &observationRevision, &updatedAt)
 	if errors.Is(err, sql.ErrNoRows) || captureID == "" {
 		return CaptureBaseState{}, false, nil
 	}
@@ -684,20 +1038,70 @@ func captureBaseSnapshot(
 		if err != nil {
 			return CaptureBaseState{}, false, err
 		}
-		if len(generation.Entries) != 0 {
-			return CaptureBaseState{
-				CaptureID: captureID, Head: head, Entries: generation.Entries,
-			}, true, nil
+		permanentRoot, err := permanentFailureAncestor(ctx, queryer, captureID)
+		if err != nil {
+			return CaptureBaseState{}, false, err
 		}
+		return CaptureBaseState{
+			CaptureID: captureID, ObservationRevision: observationRevision,
+			Kind: generation.Kind,
+			Head: head, Entries: generation.Entries,
+			PermanentlyRejected: permanentRoot != "",
+		}, true, nil
 	}
 	entries, err := loadAcknowledgedBase(ctx, queryer, source)
 	if err != nil {
 		return CaptureBaseState{}, false, err
 	}
+	kind := rawsync.ManifestSnapshot
 	if len(entries) == 0 {
-		return CaptureBaseState{}, false, nil
+		kind = rawsync.ManifestTombstone
 	}
-	return CaptureBaseState{CaptureID: captureID, Head: head, Entries: entries}, true, nil
+	return CaptureBaseState{
+		CaptureID: captureID, ObservationRevision: observationRevision,
+		Kind: kind, Head: head, Entries: entries,
+	}, true, nil
+}
+
+func permanentFailureAncestor(
+	ctx context.Context,
+	queryer checkpointQueryer,
+	captureID string,
+) (string, error) {
+	var permanentCaptureID string
+	err := queryer.QueryRowContext(ctx, `WITH RECURSIVE ancestors(
+		capture_id, predecessor_capture_id, error_class, blocked
+	) AS (
+		SELECT capture_id, predecessor_capture_id, error_class, blocked
+		FROM outbox_generations WHERE capture_id = ?
+		UNION ALL
+		SELECT generation.capture_id, generation.predecessor_capture_id,
+			generation.error_class, generation.blocked
+		FROM outbox_generations AS generation
+		JOIN ancestors ON generation.capture_id = ancestors.predecessor_capture_id
+	)
+	SELECT capture_id FROM ancestors
+	WHERE blocked = 1 AND error_class = ? LIMIT 1`,
+		captureID, string(GenerationFailurePermanent),
+	).Scan(&permanentCaptureID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("rawcheckpoint: read permanent failure ancestor: %w", err)
+	}
+	return permanentCaptureID, nil
+}
+
+func permanentFailureAncestorConn(
+	ctx context.Context,
+	conn *sql.Conn,
+	captureID string,
+) (string, error) {
+	if captureID == "" {
+		return "", nil
+	}
+	return permanentFailureAncestor(ctx, conn, captureID)
 }
 
 func loadAcknowledgedBase(
@@ -974,8 +1378,19 @@ func validateCapturedGeneration(
 ) (CapturedGeneration, int64, map[string]rawsync.ObjectRef, error) {
 	if generation.CaptureID == "" || generation.Source.Provider == "" ||
 		generation.Source.ConfiguredRootID == "" || generation.Source.SourceKey == "" ||
-		generation.CapturedAt.IsZero() || generation.Kind != rawsync.ManifestSnapshot ||
-		len(generation.Entries) == 0 {
+		generation.CapturedAt.IsZero() {
+		return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured generation")
+	}
+	switch generation.Kind {
+	case rawsync.ManifestSnapshot:
+		if len(generation.Entries) == 0 {
+			return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured generation")
+		}
+	case rawsync.ManifestTombstone:
+		if len(generation.Entries) != 0 {
+			return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured generation")
+		}
+	default:
 		return CapturedGeneration{}, 0, nil, fmt.Errorf("rawcheckpoint: invalid captured generation")
 	}
 	validated := generation

--- a/internal/rawcheckpoint/outbox_test.go
+++ b/internal/rawcheckpoint/outbox_test.go
@@ -90,7 +90,7 @@ func TestOpenWithOptionsMigratesVersionOneAndEnforcesForeignKeys(t *testing.T) {
 	var version, foreignKeys int
 	require.NoError(t, store.db.QueryRow("PRAGMA user_version").Scan(&version))
 	require.NoError(t, store.db.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys))
-	assert.Equal(t, 5, version)
+	assert.Equal(t, schemaVersion, version)
 	assert.Equal(t, 1, foreignKeys)
 
 	_, err = store.db.Exec(`INSERT INTO outbox_entries
@@ -98,6 +98,75 @@ func TestOpenWithOptionsMigratesVersionOneAndEnforcesForeignKeys(t *testing.T) {
 		 file_identity, prefix_sha256, appendable)
 		VALUES ('missing-capture', 0, 'session.jsonl', 1, 0, '', '', 1)`)
 	require.Error(t, err, "foreign keys must reject an orphaned outbox entry")
+}
+
+func TestOpenWithOptionsRequeuesManifestOnlyFinalizedGeneration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	for _, statements := range [][]string{
+		versionOneSchemaStatements,
+		versionTwoMigrationStatements,
+		versionThreeMigrationStatements,
+		versionFourMigrationStatements,
+		versionFiveMigrationStatements,
+	} {
+		for _, statement := range statements {
+			_, err = db.Exec(statement)
+			require.NoError(t, err)
+		}
+	}
+	const (
+		captureID = "00000000000000000000000000000001"
+		timestamp = "2026-08-25T00:00:00Z"
+	)
+	manifestID := validCheckpointDigest(1)
+	_, err = db.Exec(`INSERT INTO device_config (id, device_id, created_at)
+		VALUES (1, 'device-a', ?)`, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO configured_roots
+		(id, provider, local_root, created_at, updated_at)
+		VALUES ('root-a', 'claude', '/capture', ?, ?)`, timestamp, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO raw_sources
+		(provider, configured_root_id, source_key, head_manifest_id,
+		 head_receipt, head_generation, latest_capture_id, updated_at)
+		VALUES ('claude', 'root-a', 'source-a', '', '', 0, ?, ?)`,
+		captureID, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO outbox_generations
+		(capture_id, provider, configured_root_id, source_key, captured_at,
+		 kind, state, manifest_id, metadata_bytes, created_at, updated_at)
+		VALUES (?, 'claude', 'root-a', 'source-a', ?, 'snapshot', 'finalized',
+		 ?, 1024, ?, ?)`, captureID, timestamp, manifestID, timestamp, timestamp)
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA user_version = 5`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store, err := OpenWithOptions(t.Context(), path, Options{
+		SpoolDir: filepath.Join(t.TempDir(), "spool"), MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	stored, found, err := store.FinalizedCommit(t.Context(), "device-a", captureID)
+
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Empty(t, stored.ManifestID)
+	commit := rawsync.CommitResult{
+		ManifestID: manifestID, Receipt: validCheckpointDigest(2), Generation: 1,
+	}
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", captureID, commit,
+	))
+	stored, found, err = store.FinalizedCommit(t.Context(), "device-a", captureID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, commit.ManifestID, stored.ManifestID)
+	assert.Equal(t, commit.Receipt, stored.Receipt)
+	assert.Equal(t, commit.Generation, stored.Generation)
 }
 
 func TestOpenWithOptionsCompactsVersionThreeTerminalGenerations(t *testing.T) {
@@ -506,6 +575,55 @@ func TestResolveConfiguredRootPersistsCanonicalProviderIdentity(t *testing.T) {
 	assert.Equal(t, first, persisted)
 }
 
+func TestConfiguredRootSourcesPageReturnsBoundedCircularPages(t *testing.T) {
+	base := t.TempDir()
+	store, err := OpenWithOptions(t.Context(), filepath.Join(base, "checkpoint.db"), Options{
+		SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	rootPath := filepath.Join(base, "sessions")
+	require.NoError(t, os.Mkdir(rootPath, 0o700))
+	root, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, rootPath,
+	)
+	require.NoError(t, err)
+	for _, key := range []string{"a", "b", "c", "d", "e"} {
+		_, err := store.db.ExecContext(t.Context(), `INSERT INTO raw_sources
+			(provider, configured_root_id, source_key, updated_at)
+			VALUES (?, ?, ?, ?)`, parser.AgentClaude, root.ID, key,
+			checkpointTimestamp(time.Now()))
+		require.NoError(t, err)
+	}
+
+	first, err := store.ConfiguredRootSourcesPage(
+		t.Context(), parser.AgentClaude, root.ID, "", 2,
+	)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	assert.Equal(t, []string{"a", "b"}, []string{
+		first[0].Source.SourceKey, first[1].Source.SourceKey,
+	})
+
+	second, err := store.ConfiguredRootSourcesPage(
+		t.Context(), parser.AgentClaude, root.ID, first[1].Source.SourceKey, 2,
+	)
+	require.NoError(t, err)
+	require.Len(t, second, 2)
+	assert.Equal(t, []string{"c", "d"}, []string{
+		second[0].Source.SourceKey, second[1].Source.SourceKey,
+	})
+
+	wrapped, err := store.ConfiguredRootSourcesPage(
+		t.Context(), parser.AgentClaude, root.ID, second[1].Source.SourceKey, 2,
+	)
+	require.NoError(t, err)
+	require.Len(t, wrapped, 2)
+	assert.Equal(t, []string{"e", "a"}, []string{
+		wrapped[0].Source.SourceKey, wrapped[1].Source.SourceKey,
+	})
+}
+
 func TestResolveConfiguredRootDoesNotExposeLocalPathInFilesystemError(t *testing.T) {
 	store, _ := openOutboxTestStore(t, 1<<20)
 	privateRoot := filepath.Join(t.TempDir(), "private", "missing")
@@ -754,7 +872,7 @@ func TestCompleteUnchangedCaptureRejectsReservationForAnotherSource(t *testing.T
 	reservation, err := store.ReserveSourceCapture(t.Context(), sourceA, 128)
 	require.NoError(t, err)
 
-	err = store.CompleteUnchangedCapture(t.Context(), reservation.ID, sourceB)
+	err = store.CompleteUnchangedCapture(t.Context(), reservation.ID, sourceB, "", 0)
 
 	assert.ErrorIs(t, err, ErrCaptureConflict)
 	usage, readErr := store.OutboxUsage(t.Context())
@@ -775,7 +893,7 @@ func TestCompleteUnchangedCaptureAcceptsRootScopedReservation(t *testing.T) {
 		Provider: root.Provider, ConfiguredRootID: root.ID, SourceKey: "source-a",
 	}
 
-	err = store.CompleteUnchangedCapture(t.Context(), reservation.ID, source)
+	err = store.CompleteUnchangedCapture(t.Context(), reservation.ID, source, "", 0)
 
 	require.NoError(t, err)
 	usage, err := store.OutboxUsage(t.Context())

--- a/internal/rawcheckpoint/recovery.go
+++ b/internal/rawcheckpoint/recovery.go
@@ -168,7 +168,9 @@ func (s *Store) recoverObjectSpool(ctx context.Context) (RecoveryReport, error) 
 				}
 			}
 			report.InvalidGenerations = len(invalid)
-			if err := resetInvalidSourcesConn(ctx, conn, invalid, s); err != nil {
+			if err := resetInvalidSourcesConn(
+				ctx, conn, invalid, s, "missing_object",
+			); err != nil {
 				return err
 			}
 			for _, captureID := range invalid {
@@ -266,6 +268,7 @@ func resetInvalidSourcesConn(
 	conn *sql.Conn,
 	invalid []string,
 	store *Store,
+	reason string,
 ) error {
 	seen := make(map[SourceIdentity]struct{})
 	for _, captureID := range invalid {
@@ -295,8 +298,9 @@ func resetInvalidSourcesConn(
 			string(source.Provider), source.ConfiguredRootID, source.SourceKey); err != nil {
 			return fmt.Errorf("rawcheckpoint: recover: reset capture base: %w", err)
 		}
-		if err := setSourceCoverageDegradedConn(ctx, conn, source,
-			"missing_object", store.now().UTC()); err != nil {
+		if err := setSourceCoverageDegradedConn(
+			ctx, conn, source, reason, store.now().UTC(),
+		); err != nil {
 			return err
 		}
 	}

--- a/internal/rawcheckpoint/recovery_test.go
+++ b/internal/rawcheckpoint/recovery_test.go
@@ -29,8 +29,8 @@ func TestRecoverInvalidatesBrokenOfflineSuffixAndResetsAcknowledgedBase(t *testi
 		ManifestID: validCheckpointDigest(1), Receipt: validCheckpointDigest(2),
 		Generation: 1, Created: true,
 	}
-	require.NoError(t, store.BindFinalizedManifestID(
-		t.Context(), "device-a", first.CaptureID, commit.ManifestID,
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", first.CaptureID, commit,
 	))
 	_, err = store.AcknowledgeGeneration(t.Context(), "device-a", first.CaptureID, commit)
 	require.NoError(t, err)

--- a/internal/rawcheckpoint/schema.go
+++ b/internal/rawcheckpoint/schema.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const schemaVersion = 5
+const schemaVersion = 8
 
 func (s *Store) init(ctx context.Context) error {
 	var version int
@@ -55,6 +55,27 @@ func (s *Store) init(ctx context.Context) error {
 		for _, statement := range versionFiveMigrationStatements {
 			if _, err := tx.ExecContext(ctx, statement); err != nil {
 				return fmt.Errorf("rawcheckpoint: migrate schema to version 5: %w", err)
+			}
+		}
+	}
+	if version < 6 {
+		for _, statement := range versionSixMigrationStatements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("rawcheckpoint: migrate schema to version 6: %w", err)
+			}
+		}
+	}
+	if version < 7 {
+		for _, statement := range versionSevenMigrationStatements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("rawcheckpoint: migrate schema to version 7: %w", err)
+			}
+		}
+	}
+	if version < 8 {
+		for _, statement := range versionEightMigrationStatements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("rawcheckpoint: migrate schema to version 8: %w", err)
 			}
 		}
 	}
@@ -289,4 +310,25 @@ var versionFiveMigrationStatements = []string{
 		SELECT provider, configured_root_id, '', reason,
 			COALESCE(degraded_at, updated_at), updated_at
 		FROM raw_coverage WHERE state = 'degraded'`,
+}
+
+var versionSixMigrationStatements = []string{
+	`ALTER TABLE outbox_config
+		ADD COLUMN max_outbox_bytes INTEGER NOT NULL DEFAULT 1073741824
+		CHECK (max_outbox_bytes > 0)`,
+}
+
+var versionSevenMigrationStatements = []string{
+	`ALTER TABLE outbox_generations
+		ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0
+		CHECK (attempt_count >= 0)`,
+}
+
+var versionEightMigrationStatements = []string{
+	`ALTER TABLE raw_sources
+		ADD COLUMN observation_revision INTEGER NOT NULL DEFAULT 0
+		CHECK (observation_revision >= 0)`,
+	`UPDATE outbox_generations SET manifest_id = ''
+		WHERE state = 'finalized' AND manifest_id != ''
+			AND ack_receipt = '' AND ack_generation = 0`,
 }

--- a/internal/rawcheckpoint/status.go
+++ b/internal/rawcheckpoint/status.go
@@ -1,0 +1,281 @@
+package rawcheckpoint
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// ClientSourceStatus is one path-free source-chain checkpoint.
+type ClientSourceStatus struct {
+	Provider         parser.AgentType `json:"provider"`
+	ConfiguredRootID string           `json:"configured_root_id"`
+	SourceID         string           `json:"source_id"`
+	LatestCaptureID  string           `json:"latest_capture_id"`
+	Head             SourceHead       `json:"head"`
+	UpdatedAt        time.Time        `json:"updated_at"`
+}
+
+// ClientStatus is the local, content-free operational state of raw sync.
+type ClientStatus struct {
+	DeviceID           string               `json:"device_id"`
+	LastCaptureAt      *time.Time           `json:"last_capture_at,omitempty"`
+	PendingGenerations int                  `json:"pending_generations"`
+	PendingObjects     int                  `json:"pending_objects"`
+	PendingObjectBytes int64                `json:"pending_object_bytes"`
+	Outbox             OutboxUsage          `json:"outbox"`
+	RetryAt            *time.Time           `json:"retry_at,omitempty"`
+	PermanentFailures  int                  `json:"permanent_failures"`
+	Sources            []ClientSourceStatus `json:"sources,omitempty"`
+	Coverage           []CoverageState      `json:"coverage,omitempty"`
+}
+
+// ClientStatus reads a consistent operational snapshot without exposing local
+// source paths, credentials, or captured bytes.
+func (s *Store) ClientStatus(ctx context.Context) (ClientStatus, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return ClientStatus{}, fmt.Errorf("rawcheckpoint: begin status snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var schema int
+	if err := tx.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&schema); err != nil {
+		return ClientStatus{}, fmt.Errorf("rawcheckpoint: read status schema: %w", err)
+	}
+	var status ClientStatus
+	err = tx.QueryRowContext(ctx,
+		`SELECT device_id FROM device_config WHERE id = 1`,
+	).Scan(&status.DeviceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		status.DeviceID = ""
+	} else if err != nil {
+		return ClientStatus{}, err
+	}
+	if schema == 1 {
+		status.Outbox.LimitBytes = s.maxOutboxBytes
+		if status.Outbox.LimitBytes == 0 {
+			status.Outbox.LimitBytes = defaultMaxOutboxBytes
+		}
+		status.Sources, err = clientVersionOneSourceStatuses(ctx, tx)
+		if err != nil {
+			return ClientStatus{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return ClientStatus{}, fmt.Errorf("rawcheckpoint: commit status snapshot: %w", err)
+		}
+		return status, nil
+	}
+	status.Outbox, err = clientStatusOutboxUsage(ctx, tx, s.maxOutboxBytes)
+	if err != nil {
+		return ClientStatus{}, err
+	}
+	var retryAt sql.NullString
+	if schema == 2 {
+		err = tx.QueryRowContext(ctx, `SELECT count(*) FROM outbox_generations
+			WHERE state IN ('queued', 'finalized')`,
+		).Scan(&status.PendingGenerations)
+	} else {
+		err = tx.QueryRowContext(ctx, `SELECT count(*), min(NULLIF(retry_at, ''))
+			FROM outbox_generations
+			WHERE state IN ('queued', 'finalized')`,
+		).Scan(&status.PendingGenerations, &retryAt)
+	}
+	if err != nil {
+		return ClientStatus{}, fmt.Errorf("rawcheckpoint: read generation status: %w", err)
+	}
+	var lastCapture sql.NullString
+	if err := tx.QueryRowContext(ctx, `SELECT max(updated_at) FROM raw_sources
+		WHERE latest_capture_id != ''`).Scan(&lastCapture); err != nil {
+		return ClientStatus{}, fmt.Errorf("rawcheckpoint: read last capture: %w", err)
+	}
+	status.LastCaptureAt = parseOptionalTime(lastCapture)
+	status.RetryAt = parseOptionalTime(retryAt)
+	err = tx.QueryRowContext(ctx, `SELECT count(*), coalesce(sum(length), 0)
+		FROM outbox_objects WHERE state = 'live' AND ref_count > 0`,
+	).Scan(&status.PendingObjects, &status.PendingObjectBytes)
+	if err != nil {
+		return ClientStatus{}, fmt.Errorf("rawcheckpoint: read object status: %w", err)
+	}
+	if schema >= 3 {
+		err = tx.QueryRowContext(ctx, `SELECT count(*) FROM outbox_generations
+			WHERE blocked = 1 AND error_class = ?`, string(GenerationFailurePermanent),
+		).Scan(&status.PermanentFailures)
+		if err != nil {
+			return ClientStatus{}, fmt.Errorf("rawcheckpoint: read permanent failures: %w", err)
+		}
+	}
+	status.Sources, err = clientSourceStatuses(ctx, tx)
+	if err != nil {
+		return ClientStatus{}, err
+	}
+	status.Coverage, err = clientCoverageStatuses(ctx, tx)
+	if err != nil {
+		return ClientStatus{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ClientStatus{}, fmt.Errorf("rawcheckpoint: commit status snapshot: %w", err)
+	}
+	return status, nil
+}
+
+type statusQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func clientStatusOutboxUsage(
+	ctx context.Context,
+	query statusQueryer,
+	configuredLimit int64,
+) (OutboxUsage, error) {
+	usage := OutboxUsage{LimitBytes: configuredLimit}
+	err := query.QueryRowContext(ctx, `SELECT
+		COALESCE((SELECT sum(length) FROM outbox_objects WHERE state != 'remote'), 0) +
+		COALESCE((SELECT sum(metadata_bytes) FROM outbox_generations), 0),
+		COALESCE((SELECT sum(reserved_bytes) FROM outbox_reservations), 0)`,
+	).Scan(&usage.UsedBytes, &usage.ReservedBytes)
+	if err != nil {
+		return OutboxUsage{}, fmt.Errorf("rawcheckpoint: read outbox usage: %w", err)
+	}
+	if usage.LimitBytes == 0 {
+		var hasLimitColumn int
+		if err := query.QueryRowContext(ctx, `SELECT count(*)
+			FROM pragma_table_info('outbox_config')
+			WHERE name = 'max_outbox_bytes'`).Scan(&hasLimitColumn); err != nil {
+			return OutboxUsage{}, fmt.Errorf("rawcheckpoint: inspect outbox limit: %w", err)
+		}
+		if hasLimitColumn == 0 {
+			usage.LimitBytes = defaultMaxOutboxBytes
+		} else if err := query.QueryRowContext(ctx, `SELECT max_outbox_bytes
+			FROM outbox_config WHERE id = 1`).Scan(&usage.LimitBytes); err != nil {
+			return OutboxUsage{}, fmt.Errorf("rawcheckpoint: read outbox limit: %w", err)
+		}
+	}
+	return usage, nil
+}
+
+func clientSourceStatuses(
+	ctx context.Context,
+	query statusQueryer,
+) ([]ClientSourceStatus, error) {
+	rows, err := query.QueryContext(ctx, `SELECT provider, configured_root_id,
+		source_key, latest_capture_id, head_manifest_id, head_receipt,
+		head_generation, updated_at FROM raw_sources
+		ORDER BY provider, configured_root_id, source_key`)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: read source status: %w", err)
+	}
+	defer rows.Close()
+	var statuses []ClientSourceStatus
+	for rows.Next() {
+		var item ClientSourceStatus
+		var sourceKey string
+		var updatedAt string
+		if err := rows.Scan(
+			&item.Provider, &item.ConfiguredRootID,
+			&sourceKey, &item.LatestCaptureID,
+			&item.Head.ManifestID, &item.Head.Receipt, &item.Head.Generation,
+			&updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: read source status: %w", err)
+		}
+		item.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+		item.Head.UpdatedAt = item.UpdatedAt
+		item.SourceID = opaqueSourceStatusID(
+			item.Provider, item.ConfiguredRootID, sourceKey,
+		)
+		statuses = append(statuses, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: read source status: %w", err)
+	}
+	return statuses, nil
+}
+
+func clientVersionOneSourceStatuses(
+	ctx context.Context,
+	query statusQueryer,
+) ([]ClientSourceStatus, error) {
+	rows, err := query.QueryContext(ctx, `SELECT provider, configured_root_id,
+		source_key, head_manifest_id, head_receipt, head_generation, updated_at
+		FROM raw_sources ORDER BY provider, configured_root_id, source_key`)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: read version-one source status: %w", err)
+	}
+	defer rows.Close()
+	var statuses []ClientSourceStatus
+	for rows.Next() {
+		var item ClientSourceStatus
+		var sourceKey string
+		var updatedAt string
+		if err := rows.Scan(
+			&item.Provider, &item.ConfiguredRootID, &sourceKey,
+			&item.Head.ManifestID, &item.Head.Receipt, &item.Head.Generation,
+			&updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: read version-one source status: %w", err)
+		}
+		item.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+		item.Head.UpdatedAt = item.UpdatedAt
+		item.SourceID = opaqueSourceStatusID(
+			item.Provider, item.ConfiguredRootID, sourceKey,
+		)
+		statuses = append(statuses, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: read version-one source status: %w", err)
+	}
+	return statuses, nil
+}
+
+func opaqueSourceStatusID(
+	provider parser.AgentType,
+	configuredRootID string,
+	sourceKey string,
+) string {
+	digest := sha256.Sum256([]byte(
+		string(provider) + "\x00" + configuredRootID + "\x00" + sourceKey,
+	))
+	return fmt.Sprintf("%x", digest[:16])
+}
+
+func clientCoverageStatuses(
+	ctx context.Context,
+	query statusQueryer,
+) ([]CoverageState, error) {
+	rows, err := query.QueryContext(ctx, `SELECT provider, configured_root_id,
+		state, reason, degraded_at, recovered_at, updated_at FROM raw_coverage
+		ORDER BY provider, configured_root_id`)
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: read coverage status: %w", err)
+	}
+	defer rows.Close()
+	var statuses []CoverageState
+	for rows.Next() {
+		var item CoverageState
+		var provider string
+		var degradedAt, recoveredAt, updatedAt sql.NullString
+		if err := rows.Scan(
+			&provider, &item.ConfiguredRootID, &item.State, &item.Reason,
+			&degradedAt, &recoveredAt, &updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("rawcheckpoint: read coverage status: %w", err)
+		}
+		item.Provider = parser.AgentType(provider)
+		item.DegradedAt = parseOptionalTime(degradedAt)
+		item.RecoveredAt = parseOptionalTime(recoveredAt)
+		if parsed := parseOptionalTime(updatedAt); parsed != nil {
+			item.UpdatedAt = *parsed
+		}
+		statuses = append(statuses, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: read coverage status: %w", err)
+	}
+	return statuses, nil
+}

--- a/internal/rawcheckpoint/status_test.go
+++ b/internal/rawcheckpoint/status_test.go
@@ -1,0 +1,253 @@
+package rawcheckpoint
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestClientStatusReportsPendingRetryAndSourceHeadWithoutPaths(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	base := t.TempDir()
+	store, err := OpenWithOptions(t.Context(), filepath.Join(base, "checkpoint.db"), Options{
+		SpoolDir:       filepath.Join(base, "spool"),
+		MaxOutboxBytes: 1 << 20, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	root, err := store.ResolveConfiguredRoot(t.Context(), "claude", t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	_, ok, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	retryAt := now.Add(5 * time.Minute)
+	require.NoError(t, store.RecordGenerationFailure(
+		t.Context(), "device-a", generation.CaptureID,
+		GenerationFailureTransient, retryAt,
+	))
+
+	status, err := store.ClientStatus(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "device-a", status.DeviceID)
+	assert.Equal(t, 1, status.PendingGenerations)
+	assert.Equal(t, 1, status.PendingObjects)
+	assert.Equal(t, int64(3), status.PendingObjectBytes)
+	assert.Equal(t, int64(1795), status.Outbox.UsedBytes)
+	require.NotNil(t, status.RetryAt)
+	assert.Equal(t, retryAt, *status.RetryAt)
+	require.Len(t, status.Sources, 1)
+	assert.Equal(t, generation.Source.Provider, status.Sources[0].Provider)
+	assert.Equal(t, generation.Source.ConfiguredRootID,
+		status.Sources[0].ConfiguredRootID)
+	assert.NotEmpty(t, status.Sources[0].SourceID)
+	assert.NotContains(t, status.Sources[0].SourceID, generation.Source.SourceKey)
+	assert.Equal(t, generation.CaptureID, status.Sources[0].LatestCaptureID)
+	assert.Empty(t, status.Sources[0].Head.Receipt)
+	require.Len(t, status.Coverage, 1)
+	assert.Equal(t, CoverageComplete, status.Coverage[0].State)
+	assert.Zero(t, status.PermanentFailures)
+}
+
+func TestClientStatusKeepsLastCaptureAfterAcknowledgement(t *testing.T) {
+	now := time.Date(2026, 8, 27, 13, 0, 0, 0, time.UTC)
+	base := t.TempDir()
+	path := filepath.Join(base, "checkpoint.db")
+	store, err := OpenWithOptions(t.Context(), path, Options{
+		SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	root, err := store.ResolveConfiguredRoot(t.Context(), "claude", t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: abcObjectSHA256, Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	generation := testCapturedGeneration(1, root, "", ref)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	manifest, found, err := store.FinalizeNextManifest(t.Context(), "device-a")
+	require.NoError(t, err)
+	require.True(t, found)
+	commit := rawsync.CommitResult{
+		ManifestID: validCheckpointDigest(90), Receipt: validCheckpointDigest(91),
+		Generation: 1, Created: true,
+	}
+	assert.Equal(t, generation.CaptureID, manifest.CaptureID)
+	require.NoError(t, store.BindFinalizedCommit(
+		t.Context(), "device-a", generation.CaptureID, commit,
+	))
+	_, err = store.AcknowledgeGeneration(
+		t.Context(), "device-a", generation.CaptureID, commit,
+	)
+	require.NoError(t, err)
+
+	status, err := store.ClientStatus(t.Context())
+
+	require.NoError(t, err)
+	assert.Zero(t, status.PendingGenerations)
+	require.NotNil(t, status.LastCaptureAt)
+	assert.Equal(t, now, *status.LastCaptureAt)
+}
+
+func TestOpenReadOnlyReadsWhileWriterOwnsCheckpoint(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, "checkpoint.db")
+	writer, err := OpenWithOptions(t.Context(), path, Options{
+		SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
+	require.NoError(t, writer.SetDevice(t.Context(), "device-a"))
+
+	reader, err := OpenReadOnly(t.Context(), path)
+
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	status, err := reader.ClientStatus(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "device-a", status.DeviceID)
+	assert.Equal(t, int64(1<<20), status.Outbox.LimitBytes)
+}
+
+func TestOpenReadOnlyStatusSupportsVersionOneCheckpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	for _, statement := range versionOneSchemaStatements {
+		_, err = db.Exec(statement)
+		require.NoError(t, err)
+	}
+	updatedAt := time.Date(2026, 8, 1, 12, 30, 0, 0, time.UTC)
+	_, err = db.Exec(`INSERT INTO device_config (id, device_id, created_at)
+		VALUES (1, ?, ?)`, "legacy-device", checkpointTimestamp(updatedAt))
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO raw_sources (
+		provider, configured_root_id, source_key, head_manifest_id,
+		head_receipt, head_generation, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?)`, "claude", "legacy-root", "private-source-key",
+		validCheckpointDigest(1), validCheckpointDigest(2), 7,
+		checkpointTimestamp(updatedAt))
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA user_version = 1`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	reader, err := OpenReadOnly(t.Context(), path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	status, err := reader.ClientStatus(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-device", status.DeviceID)
+	assert.Nil(t, status.LastCaptureAt)
+	assert.Zero(t, status.PendingGenerations)
+	assert.Zero(t, status.PendingObjects)
+	assert.Zero(t, status.PendingObjectBytes)
+	assert.Zero(t, status.Outbox.UsedBytes)
+	assert.Zero(t, status.Outbox.ReservedBytes)
+	assert.Equal(t, defaultMaxOutboxBytes, status.Outbox.LimitBytes)
+	assert.Nil(t, status.RetryAt)
+	assert.Zero(t, status.PermanentFailures)
+	require.Len(t, status.Sources, 1)
+	assert.Equal(t, "claude", string(status.Sources[0].Provider))
+	assert.Equal(t, "legacy-root", status.Sources[0].ConfiguredRootID)
+	assert.NotEmpty(t, status.Sources[0].SourceID)
+	assert.NotContains(t, status.Sources[0].SourceID, "private-source-key")
+	assert.Empty(t, status.Sources[0].LatestCaptureID)
+	assert.Equal(t, validCheckpointDigest(1), status.Sources[0].Head.ManifestID)
+	assert.Equal(t, validCheckpointDigest(2), status.Sources[0].Head.Receipt)
+	assert.Equal(t, int64(7), status.Sources[0].Head.Generation)
+	assert.Equal(t, updatedAt, status.Sources[0].UpdatedAt)
+	assert.Equal(t, updatedAt, status.Sources[0].Head.UpdatedAt)
+	assert.Empty(t, status.Coverage)
+	inspection, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inspection.Close()) })
+	var version int
+	require.NoError(t, inspection.QueryRow(`PRAGMA user_version`).Scan(&version))
+	assert.Equal(t, 1, version, "read-only status must not migrate the checkpoint")
+}
+
+func TestOpenReadOnlyStatusSupportsVersionTwoCheckpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	for _, statements := range [][]string{
+		versionOneSchemaStatements,
+		versionTwoMigrationStatements,
+	} {
+		for _, statement := range statements {
+			_, err = db.Exec(statement)
+			require.NoError(t, err)
+		}
+	}
+	_, err = db.Exec(`INSERT INTO outbox_config (id, spool_path) VALUES (1, 'spool')`)
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA user_version = 2`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	reader, err := OpenReadOnly(t.Context(), path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	status, err := reader.ClientStatus(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, defaultMaxOutboxBytes, status.Outbox.LimitBytes)
+	assert.Zero(t, status.PendingGenerations)
+	assert.Nil(t, status.RetryAt)
+	assert.Zero(t, status.PermanentFailures)
+	inspection, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inspection.Close()) })
+	var version int
+	require.NoError(t, inspection.QueryRow(`PRAGMA user_version`).Scan(&version))
+	assert.Equal(t, 2, version, "read-only status must not migrate the checkpoint")
+}
+
+func TestOpenReadOnlyStatusSupportsVersionFiveCheckpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, false))
+	require.NoError(t, err)
+	for _, statements := range [][]string{
+		versionOneSchemaStatements,
+		versionTwoMigrationStatements,
+		versionThreeMigrationStatements,
+		versionFourMigrationStatements,
+		versionFiveMigrationStatements,
+	} {
+		for _, statement := range statements {
+			_, err = db.Exec(statement)
+			require.NoError(t, err)
+		}
+	}
+	_, err = db.Exec(`INSERT INTO outbox_config (id, spool_path) VALUES (1, 'spool')`)
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA user_version = 5`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	reader, err := OpenReadOnly(t.Context(), path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	status, err := reader.ClientStatus(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, defaultMaxOutboxBytes, status.Outbox.LimitBytes)
+}

--- a/internal/rawcheckpoint/store.go
+++ b/internal/rawcheckpoint/store.go
@@ -20,10 +20,10 @@ import (
 
 // SourceHead is the last server-acknowledged head of one logical source.
 type SourceHead struct {
-	ManifestID string
-	Receipt    string
-	Generation int64
-	UpdatedAt  time.Time
+	ManifestID string    `json:"manifest_id"`
+	Receipt    string    `json:"receipt"`
+	Generation int64     `json:"generation"`
+	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 // Store is the durable checkpoint database.
@@ -104,6 +104,22 @@ func openCheckpointDB(path string) (*sql.DB, error) {
 	return db, nil
 }
 
+// OpenReadOnly opens an existing checkpoint for concurrent status reads. It
+// neither acquires the writer/spool process locks nor runs schema migrations
+// or recovery, so a status command can inspect a live watcher without taking
+// ownership of its durable state.
+func OpenReadOnly(ctx context.Context, path string) (*Store, error) {
+	db, err := sql.Open(checkpointDriverName, checkpointDSN(path, true))
+	if err != nil {
+		return nil, fmt.Errorf("rawcheckpoint: open read-only: %w", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("rawcheckpoint: open read-only: %w", err)
+	}
+	return &Store{db: db}, nil
+}
+
 // Close releases the database handle.
 func (s *Store) Close() error {
 	dbErr := s.db.Close()
@@ -172,6 +188,35 @@ func (s *Store) SetDevice(ctx context.Context, deviceID string) error {
 	}
 	_, err = s.CollectGarbage(ctx)
 	return err
+}
+
+// EnsureDevice initializes an empty checkpoint for deviceID or verifies that
+// an existing checkpoint belongs to that same immutable device. It never
+// reprovisions or clears durable transport state on a mismatch.
+func (s *Store) EnsureDevice(ctx context.Context, deviceID string) error {
+	if deviceID == "" {
+		return fmt.Errorf("rawcheckpoint: device ID is required")
+	}
+	return s.withImmediateWrite(ctx, "ensure device", func(conn *sql.Conn) error {
+		var current string
+		err := conn.QueryRowContext(ctx,
+			`SELECT device_id FROM device_config WHERE id = 1`).Scan(&current)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			if _, err := conn.ExecContext(ctx,
+				`INSERT INTO device_config (id, device_id, created_at) VALUES (1, ?, ?)`,
+				deviceID, checkpointTimestamp(s.now())); err != nil {
+				return fmt.Errorf("rawcheckpoint: ensure device: %w", err)
+			}
+			return nil
+		case err != nil:
+			return fmt.Errorf("rawcheckpoint: ensure device: %w", err)
+		case current != deviceID:
+			return ErrDeviceMismatch
+		default:
+			return nil
+		}
+	})
 }
 
 // Device returns the recorded device identity and whether one has been set.

--- a/internal/rawcheckpoint/store_test.go
+++ b/internal/rawcheckpoint/store_test.go
@@ -308,6 +308,30 @@ func TestStoreSetDeviceChangeClearsHeads(t *testing.T) {
 	assert.Equal(t, createdAt, createdAtAfter)
 }
 
+func TestStoreEnsureDeviceRejectsReprovisioningWithoutMutatingState(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t)
+	require.NoError(t, store.SetDevice(t.Context(), "dev_1"))
+	first := testCommitResult(1, 1)
+	require.NoError(t, store.AdvanceHead(
+		t.Context(), "dev_1", parser.AgentClaude, "root-1", "src-1", "", first,
+	))
+
+	err := store.EnsureDevice(t.Context(), "dev_2")
+
+	require.ErrorIs(t, err, ErrDeviceMismatch)
+	device, ok, readErr := store.Device(t.Context())
+	require.NoError(t, readErr)
+	require.True(t, ok)
+	assert.Equal(t, "dev_1", device)
+	head, ok, readErr := store.SourceHead(
+		t.Context(), parser.AgentClaude, "root-1", "src-1",
+	)
+	require.NoError(t, readErr)
+	require.True(t, ok)
+	assert.Equal(t, first.Receipt, head.Receipt)
+}
+
 // TestStoreAdvanceHeadRequiresConfiguredDevice: advancement before any
 // device identity is recorded is refused, not defaulted.
 func TestStoreAdvanceHeadRequiresConfiguredDevice(t *testing.T) {

--- a/internal/rawupload/uploader.go
+++ b/internal/rawupload/uploader.go
@@ -1,0 +1,230 @@
+// Package rawupload drains the durable laptop outbox through the raw-ingest
+// client and advances checkpoints only after a server receipt is durable.
+package rawupload
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawclient"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// missingObjectBatchSize keeps negotiation requests comfortably below the
+// one-MiB control-plane limit even at maximum canonical object-ref size.
+const missingObjectBatchSize = 2048
+
+const (
+	transientRetryDelay = time.Minute
+	maximumRetryDelay   = time.Hour
+)
+
+// Transport is the rawclient surface required by the outbox uploader.
+type Transport interface {
+	MissingObjects(
+		context.Context, parser.AgentType, []rawsync.ObjectRef,
+	) ([]rawsync.ObjectRef, error)
+	UploadObject(
+		context.Context, parser.AgentType, rawsync.ObjectRef, io.ReaderAt,
+	) error
+	CommitManifest(context.Context, rawsync.Manifest) (rawsync.CommitResult, error)
+}
+
+// Result summarizes one acknowledged generation without retaining source
+// content or credentials.
+type Result struct {
+	CaptureID     string
+	ManifestID    string
+	Receipt       string
+	Generation    int64
+	Uploaded      int
+	UploadedBytes int64
+}
+
+// Uploader drains generations from one durable checkpoint store.
+type Uploader struct {
+	store     *rawcheckpoint.Store
+	transport Transport
+	deviceID  string
+	now       func() time.Time
+}
+
+// New constructs an uploader for one already-configured device.
+func New(
+	store *rawcheckpoint.Store,
+	transport Transport,
+	deviceID string,
+) *Uploader {
+	return &Uploader{
+		store: store, transport: transport, deviceID: deviceID, now: time.Now,
+	}
+}
+
+// UploadNext uploads and acknowledges the oldest ready generation. The bool
+// is false when no generation is currently ready.
+func (u *Uploader) UploadNext(
+	ctx context.Context,
+) (Result, bool, error) {
+	manifest, found, err := u.store.FinalizeNextManifest(ctx, u.deviceID)
+	if err != nil || !found {
+		return Result{}, false, err
+	}
+	result := Result{CaptureID: manifest.CaptureID}
+	commit, committed, err := u.store.FinalizedCommit(ctx, u.deviceID, manifest.CaptureID)
+	if err != nil {
+		return Result{}, true, u.recordFailure(ctx, manifest.CaptureID, err)
+	}
+	if !committed {
+		objects := manifestObjects(manifest)
+		missing, err := missingObjects(ctx, u.transport, manifest.Provider, objects)
+		if err != nil {
+			return Result{}, true, u.recordFailure(ctx, manifest.CaptureID, err)
+		}
+		for _, object := range missing {
+			file, err := os.Open(u.store.ObjectPath(object))
+			if err != nil {
+				cause := fmt.Errorf("rawupload: open queued object: %w", err)
+				return Result{}, true, u.recordFailure(ctx, manifest.CaptureID, cause)
+			}
+			uploadErr := u.transport.UploadObject(ctx, manifest.Provider, object, file)
+			closeErr := file.Close()
+			if uploadErr != nil {
+				return Result{}, true, u.recordFailure(ctx, manifest.CaptureID, uploadErr)
+			}
+			if closeErr != nil {
+				cause := fmt.Errorf("rawupload: close queued object: %w", closeErr)
+				return Result{}, true, u.recordFailure(ctx, manifest.CaptureID, cause)
+			}
+			result.Uploaded++
+			result.UploadedBytes += object.Length
+		}
+		commit, err = u.transport.CommitManifest(ctx, manifest)
+		if err != nil {
+			return Result{}, true, u.recordFailure(ctx, manifest.CaptureID, err)
+		}
+		if err := u.store.BindFinalizedCommit(
+			ctx, u.deviceID, manifest.CaptureID, commit,
+		); err != nil {
+			return Result{}, true, u.recordFailure(ctx, manifest.CaptureID, err)
+		}
+	}
+	if _, err := u.store.AcknowledgeGeneration(
+		ctx, u.deviceID, manifest.CaptureID, commit,
+	); err != nil {
+		return Result{}, true, u.recordFailure(ctx, manifest.CaptureID, err)
+	}
+	result.ManifestID = commit.ManifestID
+	result.Receipt = commit.Receipt
+	result.Generation = commit.Generation
+	return result, true, nil
+}
+
+func (u *Uploader) recordFailure(
+	ctx context.Context,
+	captureID string,
+	cause error,
+) error {
+	class := rawcheckpoint.GenerationFailureTransient
+	retryAt := time.Time{}
+	var apiError rawclient.APIError
+	if rawclient.AsAPIError(cause, &apiError) {
+		switch {
+		case apiError.Code == rawclient.CodeHeadConflict:
+			class = rawcheckpoint.GenerationFailureParentReceiptConflict
+			retryAt = time.Time{}
+		case apiError.Status == http.StatusRequestTimeout,
+			apiError.Status == http.StatusTooManyRequests,
+			apiError.Status >= http.StatusInternalServerError,
+			apiError.Code == rawclient.CodeMissingObject:
+		case apiError.Code == rawclient.CodeInvalidRequest,
+			apiError.Code == rawclient.CodeChecksumMismatch:
+			class = rawcheckpoint.GenerationFailurePermanent
+			retryAt = time.Time{}
+		}
+	}
+	if class == rawcheckpoint.GenerationFailureParentReceiptConflict {
+		reconciled := rawcheckpoint.SourceHead{
+			ManifestID: apiError.CurrentManifestID,
+			Receipt:    apiError.CurrentReceipt,
+			Generation: apiError.CurrentGeneration,
+		}
+		if err := u.store.ResumeGeneration(
+			ctx, u.deviceID, captureID, reconciled,
+		); err != nil {
+			return errors.Join(cause, err)
+		}
+		return cause
+	}
+	if class == rawcheckpoint.GenerationFailureTransient {
+		attempts, err := u.store.GenerationAttempts(ctx, u.deviceID, captureID)
+		if err != nil {
+			return errors.Join(cause, err)
+		}
+		retryAt = u.now().UTC().Add(transientBackoff(attempts))
+	}
+	if class == rawcheckpoint.GenerationFailurePermanent {
+		if err := u.store.RecordGenerationFailure(
+			ctx, u.deviceID, captureID, class, time.Time{},
+		); err != nil {
+			return errors.Join(cause, err)
+		}
+		return cause
+	}
+	if err := u.store.RecordGenerationFailure(
+		ctx, u.deviceID, captureID, class, retryAt,
+	); err != nil {
+		return errors.Join(cause, err)
+	}
+	return cause
+}
+
+func transientBackoff(previousAttempts int) time.Duration {
+	delay := transientRetryDelay
+	for range max(previousAttempts, 0) {
+		if delay >= maximumRetryDelay/2 {
+			return maximumRetryDelay
+		}
+		delay *= 2
+	}
+	return delay
+}
+
+func manifestObjects(manifest rawsync.Manifest) []rawsync.ObjectRef {
+	seen := make(map[rawsync.ObjectRef]struct{})
+	var objects []rawsync.ObjectRef
+	for _, entry := range manifest.Entries {
+		for _, object := range entry.Objects {
+			if _, exists := seen[object]; exists {
+				continue
+			}
+			seen[object] = struct{}{}
+			objects = append(objects, object)
+		}
+	}
+	return objects
+}
+
+func missingObjects(
+	ctx context.Context,
+	transport Transport,
+	provider parser.AgentType,
+	objects []rawsync.ObjectRef,
+) ([]rawsync.ObjectRef, error) {
+	var missing []rawsync.ObjectRef
+	for start := 0; start < len(objects); start += missingObjectBatchSize {
+		end := min(start+missingObjectBatchSize, len(objects))
+		batch, err := transport.MissingObjects(ctx, provider, objects[start:end])
+		if err != nil {
+			return nil, err
+		}
+		missing = append(missing, batch...)
+	}
+	return missing, nil
+}

--- a/internal/rawupload/uploader.go
+++ b/internal/rawupload/uploader.go
@@ -26,6 +26,9 @@ const (
 	maximumRetryDelay   = time.Hour
 )
 
+// ErrPermanentFailure marks an upload rejection that was durably blocked.
+var ErrPermanentFailure = errors.New("rawupload: permanent upload failure")
+
 // Transport is the rawclient surface required by the outbox uploader.
 type Transport interface {
 	MissingObjects(
@@ -175,7 +178,7 @@ func (u *Uploader) recordFailure(
 		); err != nil {
 			return errors.Join(cause, err)
 		}
-		return cause
+		return errors.Join(ErrPermanentFailure, cause)
 	}
 	if err := u.store.RecordGenerationFailure(
 		ctx, u.deviceID, captureID, class, retryAt,

--- a/internal/rawupload/uploader_test.go
+++ b/internal/rawupload/uploader_test.go
@@ -286,6 +286,7 @@ func TestUploaderPersistsPermanentRejectionAndSuppressesRetry(t *testing.T) {
 	_, found, err := New(store, transport, "device-a").UploadNext(t.Context())
 
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPermanentFailure)
 	require.True(t, found)
 	require.NoError(t, store.Close())
 	store, err = rawcheckpoint.OpenWithOptions(

--- a/internal/rawupload/uploader_test.go
+++ b/internal/rawupload/uploader_test.go
@@ -1,0 +1,465 @@
+package rawupload
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawclient"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+type uploadTransportStub struct {
+	missingBatches [][]rawsync.ObjectRef
+	uploaded       map[rawsync.ObjectRef]string
+	commit         rawsync.CommitResult
+	commitErr      error
+	commitFunc     func(rawsync.Manifest) (rawsync.CommitResult, error)
+	commitCalls    int
+}
+
+func (s *uploadTransportStub) MissingObjects(
+	_ context.Context,
+	_ parser.AgentType,
+	objects []rawsync.ObjectRef,
+) ([]rawsync.ObjectRef, error) {
+	s.missingBatches = append(s.missingBatches, append([]rawsync.ObjectRef(nil), objects...))
+	return append([]rawsync.ObjectRef(nil), objects...), nil
+}
+
+func (s *uploadTransportStub) UploadObject(
+	_ context.Context,
+	_ parser.AgentType,
+	object rawsync.ObjectRef,
+	content io.ReaderAt,
+) error {
+	data := make([]byte, object.Length)
+	_, err := content.ReadAt(data, 0)
+	if err != nil && err != io.EOF {
+		return err
+	}
+	s.uploaded[object] = string(data)
+	return nil
+}
+
+func (s *uploadTransportStub) CommitManifest(
+	_ context.Context,
+	manifest rawsync.Manifest,
+) (rawsync.CommitResult, error) {
+	s.commitCalls++
+	if s.commitFunc != nil {
+		return s.commitFunc(manifest)
+	}
+	return s.commit, s.commitErr
+}
+
+func TestUploaderRetriesPostCommitAcknowledgementWithoutRecommitting(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	base := t.TempDir()
+	store, generation := queuedUploadTestGenerationAt(t, base, func() time.Time { return now })
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	commit := rawsync.CommitResult{
+		ManifestID: strings.Repeat("a", 64),
+		Receipt:    strings.Repeat("b", 64),
+		Generation: 1,
+		Created:    true,
+	}
+	checkpoint, err := sql.Open("sqlite3", filepath.Join(base, "checkpoint.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, checkpoint.Close()) })
+	_, err = checkpoint.Exec(`CREATE TRIGGER fail_acknowledgement
+		BEFORE UPDATE OF head_capture_id ON raw_sources
+		BEGIN SELECT RAISE(FAIL, 'forced acknowledgement failure'); END`)
+	require.NoError(t, err)
+
+	transport := &uploadTransportStub{uploaded: make(map[rawsync.ObjectRef]string), commit: commit}
+	uploader := New(store, transport, "device-a")
+	uploader.now = func() time.Time { return now }
+	_, uploaded, err := uploader.UploadNext(t.Context())
+	require.Error(t, err)
+	require.True(t, uploaded)
+	assert.Equal(t, 1, transport.commitCalls)
+
+	_, uploaded, err = uploader.UploadNext(t.Context())
+	require.NoError(t, err)
+	assert.False(t, uploaded, "post-commit acknowledgement failures must honor backoff")
+	assert.Equal(t, 1, transport.commitCalls)
+	_, err = checkpoint.Exec(`DROP TRIGGER fail_acknowledgement`)
+	require.NoError(t, err)
+
+	now = now.Add(transientRetryDelay)
+	result, uploaded, err := uploader.UploadNext(t.Context())
+
+	require.NoError(t, err)
+	require.True(t, uploaded)
+	assert.Equal(t, 1, transport.commitCalls, "retry must use the durable commit result")
+	assert.Equal(t, generation.CaptureID, result.CaptureID)
+	assert.Equal(t, commit.ManifestID, result.ManifestID)
+	assert.Equal(t, commit.Receipt, result.Receipt)
+	assert.Equal(t, commit.Generation, result.Generation)
+	head, ok, err := store.SourceHead(
+		t.Context(), generation.Source.Provider, generation.Source.ConfiguredRootID,
+		generation.Source.SourceKey,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, commit.ManifestID, head.ManifestID)
+	assert.Equal(t, commit.Receipt, head.Receipt)
+	assert.Equal(t, commit.Generation, head.Generation)
+}
+
+func TestUploaderClassifiesGatewayTimeoutByHTTPStatus(t *testing.T) {
+	store, generation := queuedUploadTestGeneration(t)
+	transport := &uploadTransportStub{
+		uploaded: make(map[rawsync.ObjectRef]string),
+		commitErr: &rawclient.APIError{
+			Status:  http.StatusGatewayTimeout,
+			Code:    rawclient.CodeInternal,
+			Message: "request timed out",
+		},
+	}
+	uploader := New(store, transport, "device-a")
+
+	result, found, err := uploader.UploadNext(t.Context())
+
+	require.Error(t, err)
+	require.True(t, found)
+	assert.Zero(t, result)
+	_, found, retryErr := uploader.UploadNext(t.Context())
+	require.NoError(t, retryErr)
+	assert.False(t, found, "durable retry time must delay the finalized generation")
+	base, ok, readErr := store.CaptureBase(t.Context(), generation.Source)
+	require.NoError(t, readErr)
+	require.True(t, ok)
+	assert.Equal(t, generation.CaptureID, base.CaptureID)
+}
+
+func TestUploaderRetriesRecoverableClientErrors(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	store, _ := queuedUploadTestGenerationWithNow(t, func() time.Time { return now })
+	transport := &uploadTransportStub{
+		uploaded: make(map[rawsync.ObjectRef]string),
+		commitErr: &rawclient.APIError{
+			Status:  http.StatusUnauthorized,
+			Code:    rawclient.CodeUnauthorized,
+			Message: "credential expired",
+		},
+	}
+	uploader := New(store, transport, "device-a")
+	uploader.now = func() time.Time { return now }
+
+	_, found, err := uploader.UploadNext(t.Context())
+	require.Error(t, err)
+	require.True(t, found)
+	now = now.Add(2 * transientRetryDelay)
+	transport.commitErr = nil
+	transport.commit = rawsync.CommitResult{
+		ManifestID: strings.Repeat("c", 64), Receipt: strings.Repeat("d", 64),
+		Generation: 1, Created: true,
+	}
+	_, found, err = uploader.UploadNext(t.Context())
+	require.NoError(t, err)
+	assert.True(t, found, "corrected credentials must resume the source chain")
+}
+
+func TestUploaderExponentiallyBacksOffRepeatedTransientFailures(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	store, _ := queuedUploadTestGenerationWithNow(t, func() time.Time { return now })
+	transport := &uploadTransportStub{
+		uploaded: make(map[rawsync.ObjectRef]string),
+		commitErr: &rawclient.APIError{
+			Status: http.StatusServiceUnavailable, Code: rawclient.CodeInternal,
+		},
+	}
+	uploader := New(store, transport, "device-a")
+	uploader.now = func() time.Time { return now }
+
+	_, found, err := uploader.UploadNext(t.Context())
+	require.Error(t, err)
+	require.True(t, found)
+	now = now.Add(transientRetryDelay)
+	_, found, err = uploader.UploadNext(t.Context())
+	require.Error(t, err)
+	require.True(t, found)
+	transport.commitErr = nil
+	transport.commit = rawsync.CommitResult{
+		ManifestID: strings.Repeat("c", 64), Receipt: strings.Repeat("d", 64),
+		Generation: 1, Created: true,
+	}
+	now = now.Add(transientRetryDelay)
+	_, found, err = uploader.UploadNext(t.Context())
+	require.NoError(t, err)
+	assert.False(t, found, "second transient failure must wait longer than the first")
+	now = now.Add(transientRetryDelay)
+	_, found, err = uploader.UploadNext(t.Context())
+	require.NoError(t, err)
+	assert.True(t, found)
+}
+
+func TestUploaderRecoversHeadConflictAfterTransientFailure(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	store, generation := queuedUploadTestGenerationWithNow(t, func() time.Time { return now })
+	reconciled := rawsync.CommitResult{
+		ManifestID: strings.Repeat("a", 64), Receipt: strings.Repeat("b", 64),
+		Generation: 1,
+	}
+	committed := rawsync.CommitResult{
+		ManifestID: strings.Repeat("c", 64), Receipt: strings.Repeat("d", 64),
+		Generation: 2, Created: true,
+	}
+	transport := &uploadTransportStub{uploaded: make(map[rawsync.ObjectRef]string)}
+	transport.commitFunc = func(manifest rawsync.Manifest) (rawsync.CommitResult, error) {
+		switch transport.commitCalls {
+		case 1:
+			return rawsync.CommitResult{}, &rawclient.APIError{
+				Status: http.StatusServiceUnavailable, Code: rawclient.CodeInternal,
+			}
+		case 2:
+			return rawsync.CommitResult{}, &rawclient.APIError{
+				Status: http.StatusConflict, Code: rawclient.CodeHeadConflict,
+				CurrentManifestID: reconciled.ManifestID,
+				CurrentReceipt:    reconciled.Receipt,
+				CurrentGeneration: reconciled.Generation,
+			}
+		default:
+			assert.Equal(t, reconciled.Receipt, manifest.ExpectedParentReceipt)
+			return committed, nil
+		}
+	}
+	uploader := New(store, transport, "device-a")
+	uploader.now = func() time.Time { return now }
+
+	_, found, err := uploader.UploadNext(t.Context())
+	require.Error(t, err)
+	require.True(t, found)
+	now = now.Add(transientRetryDelay)
+	_, found, err = uploader.UploadNext(t.Context())
+	require.Error(t, err)
+	require.True(t, found)
+
+	result, found, err := uploader.UploadNext(t.Context())
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, generation.CaptureID, result.CaptureID)
+	assert.Equal(t, committed.Receipt, result.Receipt)
+	assert.Equal(t, 3, transport.commitCalls)
+}
+
+func TestUploaderBacksOffMissingLocalSpoolObject(t *testing.T) {
+	store, generation := queuedUploadTestGeneration(t)
+	ref := generation.Entries[0].Objects[0]
+	require.NoError(t, os.Remove(store.ObjectPath(ref)))
+	uploader := New(store, &uploadTransportStub{}, "device-a")
+
+	_, found, err := uploader.UploadNext(t.Context())
+	require.Error(t, err)
+	require.True(t, found)
+	_, found, err = uploader.UploadNext(t.Context())
+	require.NoError(t, err)
+	assert.False(t, found, "persistent local failures must not hot-loop")
+}
+
+func TestUploaderPersistsPermanentRejectionAndSuppressesRetry(t *testing.T) {
+	baseDir := t.TempDir()
+	store, generation := queuedUploadTestGenerationAt(t, baseDir, nil)
+	transport := &uploadTransportStub{
+		uploaded: make(map[rawsync.ObjectRef]string),
+		commitErr: &rawclient.APIError{
+			Status: http.StatusBadRequest, Code: rawclient.CodeInvalidRequest,
+		},
+	}
+
+	_, found, err := New(store, transport, "device-a").UploadNext(t.Context())
+
+	require.Error(t, err)
+	require.True(t, found)
+	require.NoError(t, store.Close())
+	store, err = rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(baseDir, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(baseDir, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	base, ok, err := store.CaptureBase(t.Context(), generation.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, generation.CaptureID, base.CaptureID)
+	_, found, err = New(store, transport, "device-a").UploadNext(t.Context())
+	require.NoError(t, err)
+	assert.False(t, found)
+	status, err := store.ClientStatus(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, status.PermanentFailures)
+}
+
+func TestUploaderUploadsMissingObjectsBeforeAcknowledgingManifest(t *testing.T) {
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	rootPath := t.TempDir()
+	root, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, rootPath)
+	require.NoError(t, err)
+	contents := []string{"first", "second"}
+	refs := make([]rawsync.ObjectRef, 0, len(contents))
+	for _, content := range contents {
+		ref := objectRefFor(content)
+		path := store.ObjectPath(ref)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		refs = append(refs, ref)
+	}
+	source := rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: root.ID, SourceKey: "source-1",
+	}
+	reservation, err := store.ReserveSourceCapture(
+		t.Context(), source, int64(len(contents[0])+len(contents[1]))+
+			rawcheckpoint.CaptureMetadataCharge(1, len(refs)),
+	)
+	require.NoError(t, err)
+	generation := rawcheckpoint.CapturedGeneration{
+		CaptureID: strings.Repeat("1", 32), Source: source,
+		CapturedAt: time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC),
+		Kind:       rawsync.ManifestSnapshot,
+		Entries: []rawcheckpoint.CapturedEntry{{
+			Path: "session.jsonl", Length: int64(len(contents[0]) + len(contents[1])),
+			FileIdentity: "device:1:inode:2", PrefixSHA256: refs[1].SHA256,
+			Appendable: true, Objects: refs,
+		}},
+	}
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	transport := &uploadTransportStub{
+		uploaded: make(map[rawsync.ObjectRef]string),
+		commit: rawsync.CommitResult{
+			ManifestID: strings.Repeat("a", 64),
+			Receipt:    strings.Repeat("b", 64),
+			Generation: 1,
+			Created:    true,
+		},
+	}
+
+	result, uploaded, err := New(store, transport, "device-a").UploadNext(t.Context())
+
+	require.NoError(t, err)
+	require.True(t, uploaded)
+	assert.Equal(t, generation.CaptureID, result.CaptureID)
+	assert.Equal(t, int64(len(contents[0])+len(contents[1])), result.UploadedBytes)
+	assert.Equal(t, contents[0], transport.uploaded[refs[0]])
+	assert.Equal(t, contents[1], transport.uploaded[refs[1]])
+	head, ok, err := store.SourceHead(
+		t.Context(), source.Provider, source.ConfiguredRootID, source.SourceKey,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, transport.commit.Receipt, head.Receipt)
+	assert.NoFileExists(t, store.ObjectPath(refs[0]))
+	assert.NoFileExists(t, store.ObjectPath(refs[1]))
+}
+
+func TestMissingObjectNegotiationUsesBoundedBatches(t *testing.T) {
+	transport := &uploadTransportStub{}
+	objects := make([]rawsync.ObjectRef, 5000)
+	for i := range objects {
+		objects[i] = rawsync.ObjectRef{SHA256: fmt.Sprintf("%064x", i+1), Length: int64(i)}
+	}
+
+	missing, err := missingObjects(
+		t.Context(), transport, parser.AgentClaude, objects,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, objects, missing)
+	require.Greater(t, len(transport.missingBatches), 1)
+	for _, batch := range transport.missingBatches {
+		assert.LessOrEqual(t, len(batch), missingObjectBatchSize)
+	}
+}
+
+func objectRefFor(content string) rawsync.ObjectRef {
+	digest := sha256.Sum256([]byte(content))
+	ref, err := rawsync.NewObjectRef(fmt.Sprintf("%x", digest), int64(len(content)))
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}
+
+func queuedUploadTestGeneration(
+	t *testing.T,
+) (*rawcheckpoint.Store, rawcheckpoint.CapturedGeneration) {
+	return queuedUploadTestGenerationWithNow(t, nil)
+}
+
+func queuedUploadTestGenerationWithNow(
+	t *testing.T,
+	now func() time.Time,
+) (*rawcheckpoint.Store, rawcheckpoint.CapturedGeneration) {
+	t.Helper()
+	base := t.TempDir()
+	store, generation := queuedUploadTestGenerationAt(t, base, now)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store, generation
+}
+
+func queuedUploadTestGenerationAt(
+	t *testing.T,
+	base string,
+	now func() time.Time,
+) (*rawcheckpoint.Store, rawcheckpoint.CapturedGeneration) {
+	t.Helper()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20, Now: now,
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	root, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, t.TempDir())
+	require.NoError(t, err)
+	ref := objectRefFor("first")
+	path := store.ObjectPath(ref)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte("first"), 0o600))
+	source := rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: root.ID, SourceKey: "source-1",
+	}
+	reservation, err := store.ReserveSourceCapture(
+		t.Context(), source, ref.Length+rawcheckpoint.CaptureMetadataCharge(1, 1),
+	)
+	require.NoError(t, err)
+	generation := rawcheckpoint.CapturedGeneration{
+		CaptureID: strings.Repeat("2", 32), Source: source,
+		CapturedAt: time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC),
+		Kind:       rawsync.ManifestSnapshot,
+		Entries: []rawcheckpoint.CapturedEntry{{
+			Path: "session.jsonl", Length: ref.Length,
+			FileIdentity: "device:1:inode:2", PrefixSHA256: ref.SHA256,
+			Appendable: true, Objects: []rawsync.ObjectRef{ref},
+		}},
+	}
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+	return store, generation
+}

--- a/internal/rawwatch/auditor.go
+++ b/internal/rawwatch/auditor.go
@@ -1,0 +1,536 @@
+// Package rawwatch captures provider watcher events and repairs missed events
+// with bounded periodic audits, without invoking normalized parsing.
+package rawwatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcapture"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+)
+
+// AuditResult summarizes bounded work for one provider pass.
+type AuditResult struct {
+	Visited    int
+	Captured   int
+	Unchanged  int
+	Tombstoned int
+	Degraded   int
+	Complete   bool
+}
+
+// Auditor rotates capture work and repairs sources missed by watcher events.
+type Auditor struct {
+	store         *rawcheckpoint.Store
+	capturer      *rawcapture.Capturer
+	maxWork       int
+	scans         map[parser.AgentType]*auditDiscoveryScan
+	nextKnownRoot map[parser.AgentType]int
+	knownAfter    map[string]string
+}
+
+// NewAuditor constructs a bounded auditor. maxWork must be positive.
+func NewAuditor(
+	store *rawcheckpoint.Store,
+	capturer *rawcapture.Capturer,
+	maxWork int,
+) *Auditor {
+	if maxWork <= 0 {
+		maxWork = 1
+	}
+	return &Auditor{
+		store: store, capturer: capturer, maxWork: maxWork,
+		scans:         make(map[parser.AgentType]*auditDiscoveryScan),
+		nextKnownRoot: make(map[parser.AgentType]int),
+		knownAfter:    make(map[string]string),
+	}
+}
+
+// AuditProvider reconciles at most maxWork source captures or tombstones.
+func (a *Auditor) AuditProvider(
+	ctx context.Context,
+	provider parser.Provider,
+) (AuditResult, error) {
+	return a.auditProviderBounded(ctx, provider)
+}
+
+// AuditProviderFull reconciles every currently discovered or absent source.
+// It is reserved for explicit full-sync markers; periodic audits stay bounded.
+func (a *Auditor) AuditProviderFull(
+	ctx context.Context,
+	provider parser.Provider,
+) (AuditResult, error) {
+	a.stopDiscoveryScan(provider.Definition().Type)
+	return a.auditProviderFull(ctx, provider)
+}
+
+type auditDiscoveryEvent struct {
+	source   parser.SourceRef
+	complete bool
+	err      error
+	terminal bool
+	progress bool
+	resume   chan struct{}
+}
+
+type auditDiscoveryScan struct {
+	events       <-chan auditDiscoveryEvent
+	cancel       context.CancelFunc
+	resume       chan struct{}
+	terminal     *auditDiscoveryEvent
+	known        []rawcheckpoint.SourceCheckpoint
+	presentKnown map[string]bool
+	knownRoot    *parser.WatchRoot
+}
+
+func (a *Auditor) auditProviderBounded(
+	ctx context.Context,
+	provider parser.Provider,
+) (AuditResult, error) {
+	result := AuditResult{}
+	providerType := provider.Definition().Type
+	traversalRemaining := a.maxWork
+	scan, err := a.discoveryScan(ctx, provider, &traversalRemaining)
+	if err != nil {
+		return result, err
+	}
+	if scan.events == nil {
+		return result, nil
+	}
+	if scan.resume != nil {
+		close(scan.resume)
+		scan.resume = nil
+		traversalRemaining--
+		if traversalRemaining == 0 {
+			return result, nil
+		}
+	}
+
+	remaining := a.maxWork
+	seenPhysical := make(map[string]struct{}, a.maxWork)
+	if scan.terminal != nil {
+		event := *scan.terminal
+		scan.terminal = nil
+		return a.finishDiscoveryScan(
+			ctx, providerType, scan, event, result, remaining, &traversalRemaining,
+		)
+	}
+	for {
+		if traversalRemaining == 0 {
+			return result, nil
+		}
+		var event auditDiscoveryEvent
+		var ok bool
+		select {
+		case <-ctx.Done():
+			a.stopDiscoveryScan(providerType)
+			return result, ctx.Err()
+		case event, ok = <-scan.events:
+		}
+		if !ok {
+			a.stopDiscoveryScan(providerType)
+			return result, nil
+		}
+		if event.terminal {
+			return a.finishDiscoveryScan(
+				ctx, providerType, scan, event, result, remaining, &traversalRemaining,
+			)
+		}
+		if event.progress {
+			traversalRemaining--
+			if traversalRemaining == 0 {
+				scan.resume = event.resume
+				return result, nil
+			}
+			close(event.resume)
+			continue
+		}
+		identity, supported, err := a.rawCaptureSourceIdentity(ctx, provider, event.source)
+		if err != nil {
+			a.stopDiscoveryScan(providerType)
+			return result, err
+		}
+		if !supported {
+			continue
+		}
+		key := auditSourceIdentityKey(identity)
+		if _, tracked := scan.presentKnown[key]; tracked {
+			scan.presentKnown[key] = true
+		}
+		physicalKey := rawWatchSourceDedupKey(event.source)
+		if _, duplicate := seenPhysical[physicalKey]; duplicate {
+			continue
+		}
+		seenPhysical[physicalKey] = struct{}{}
+		capture, err := a.capturer.Capture(ctx, provider, event.source)
+		if err != nil {
+			a.stopDiscoveryScan(providerType)
+			return result, err
+		}
+		remaining--
+		result.Visited++
+		switch capture.Status {
+		case rawcapture.StatusCaptured:
+			result.Captured++
+		case rawcapture.StatusUnchanged:
+			result.Unchanged++
+		case rawcapture.StatusDegraded:
+			result.Degraded++
+		}
+		if remaining == 0 {
+			return result, nil
+		}
+	}
+}
+
+func (a *Auditor) discoveryScan(
+	ctx context.Context,
+	provider parser.Provider,
+	traversalRemaining *int,
+) (*auditDiscoveryScan, error) {
+	providerType := provider.Definition().Type
+	if scan := a.scans[providerType]; scan != nil {
+		if scan.events == nil && *traversalRemaining > 0 {
+			a.startDiscoveryScan(ctx, provider, scan)
+		}
+		return scan, nil
+	}
+	watchPlan, err := provider.WatchPlan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	known, knownRoot, err := a.nextKnownSourcePage(
+		ctx, providerType, watchPlan.Roots, traversalRemaining,
+	)
+	if err != nil {
+		return nil, err
+	}
+	presentKnown := make(map[string]bool, len(known))
+	for _, source := range known {
+		presentKnown[auditSourceIdentityKey(source.Source)] = false
+	}
+
+	scan := &auditDiscoveryScan{
+		known: known, presentKnown: presentKnown,
+		knownRoot: knownRoot,
+	}
+	a.scans[providerType] = scan
+	if *traversalRemaining > 0 {
+		a.startDiscoveryScan(ctx, provider, scan)
+	}
+	return scan, nil
+}
+
+func (a *Auditor) startDiscoveryScan(
+	ctx context.Context,
+	provider parser.Provider,
+	scan *auditDiscoveryScan,
+) {
+	scanCtx, cancel := context.WithCancel(ctx)
+	events := make(chan auditDiscoveryEvent)
+	scan.events = events
+	scan.cancel = cancel
+	go func() {
+		defer close(events)
+		progressCtx := parser.WithRawCaptureDiscoveryProgress(scanCtx, func() error {
+			resume := make(chan struct{})
+			select {
+			case events <- auditDiscoveryEvent{progress: true, resume: resume}:
+			case <-scanCtx.Done():
+				return scanCtx.Err()
+			}
+			select {
+			case <-resume:
+				return nil
+			case <-scanCtx.Done():
+				return scanCtx.Err()
+			}
+		})
+		complete, discoveryErr := parser.StreamRawCaptureSources(
+			progressCtx, provider, func(source parser.SourceRef) error {
+				select {
+				case events <- auditDiscoveryEvent{source: source}:
+				case <-scanCtx.Done():
+					return scanCtx.Err()
+				}
+				return nil
+			},
+		)
+		select {
+		case events <- auditDiscoveryEvent{
+			complete: complete, err: discoveryErr, terminal: true,
+		}:
+		case <-scanCtx.Done():
+		}
+	}()
+}
+
+func (a *Auditor) finishDiscoveryScan(
+	ctx context.Context,
+	providerType parser.AgentType,
+	scan *auditDiscoveryScan,
+	event auditDiscoveryEvent,
+	result AuditResult,
+	remaining int,
+	traversalRemaining *int,
+) (AuditResult, error) {
+	discoveryComplete := event.complete
+	if _, ok := errors.AsType[parser.DiscoveryIncompleteError](event.err); ok {
+		discoveryComplete = false
+	} else if errors.Is(event.err, os.ErrNotExist) {
+		discoveryComplete = false
+	} else if event.err != nil {
+		a.stopDiscoveryScan(providerType)
+		return result, event.err
+	}
+	if discoveryComplete && len(scan.known) != 0 {
+		if *traversalRemaining == 0 {
+			scan.terminal = &event
+			return result, nil
+		}
+		*traversalRemaining--
+		if !rawAuditRootsComplete(ctx, []parser.WatchRoot{*scan.knownRoot}) {
+			discoveryComplete = false
+		}
+	}
+	result.Complete = discoveryComplete
+	if result.Complete {
+		for _, checkpoint := range scan.known {
+			if remaining == 0 {
+				break
+			}
+			if scan.presentKnown[auditSourceIdentityKey(checkpoint.Source)] {
+				continue
+			}
+			remaining--
+			_, queued, err := a.store.QueueTombstoneIfLatest(
+				ctx, checkpoint.Source, checkpoint.CaptureID,
+				checkpoint.ObservationRevision,
+			)
+			if errors.Is(err, rawcheckpoint.ErrOutboxFull) {
+				result.Degraded++
+				continue
+			}
+			if err != nil {
+				a.stopDiscoveryScan(providerType)
+				return result, fmt.Errorf("rawwatch: queue tombstone: %w", err)
+			}
+			if queued {
+				result.Tombstoned++
+			}
+		}
+	}
+	a.stopDiscoveryScan(providerType)
+	return result, nil
+}
+
+func (a *Auditor) stopDiscoveryScan(provider parser.AgentType) {
+	if scan := a.scans[provider]; scan != nil {
+		if scan.cancel != nil {
+			scan.cancel()
+		}
+		delete(a.scans, provider)
+	}
+}
+
+func (a *Auditor) rawCaptureSourceIdentity(
+	ctx context.Context,
+	provider parser.Provider,
+	source parser.SourceRef,
+) (rawcheckpoint.SourceIdentity, bool, error) {
+	plan, supported, err := parser.ResolveRawCapturePlan(ctx, provider, source)
+	if err != nil || !supported {
+		return rawcheckpoint.SourceIdentity{}, supported, err
+	}
+	root, err := a.store.ResolveConfiguredRoot(
+		ctx, source.Provider, plan.ConfiguredRoot,
+	)
+	if err != nil {
+		return rawcheckpoint.SourceIdentity{}, false, err
+	}
+	return rawcheckpoint.SourceIdentity{
+		Provider: source.Provider, ConfiguredRootID: root.ID,
+		SourceKey: plan.SourceKey,
+	}, true, nil
+}
+
+func (a *Auditor) nextKnownSourcePage(
+	ctx context.Context,
+	provider parser.AgentType,
+	roots []parser.WatchRoot,
+	traversalRemaining *int,
+) ([]rawcheckpoint.SourceCheckpoint, *parser.WatchRoot, error) {
+	if len(roots) == 0 {
+		return nil, nil, nil
+	}
+	start := a.nextKnownRoot[provider] % len(roots)
+	for offset := 0; offset < len(roots) && *traversalRemaining > 0; offset++ {
+		rootIndex := (start + offset) % len(roots)
+		a.nextKnownRoot[provider] = (rootIndex + 1) % len(roots)
+		*traversalRemaining--
+		if !rawAuditRootsComplete(ctx, []parser.WatchRoot{roots[rootIndex]}) {
+			continue
+		}
+		root, err := a.store.ResolveConfiguredRoot(
+			ctx, provider, roots[rootIndex].Path,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		after := a.knownAfter[root.ID]
+		sources, err := a.store.ConfiguredRootSourcesPage(
+			ctx, root.Provider, root.ID, after, a.maxWork,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(sources) == 0 {
+			continue
+		}
+		a.knownAfter[root.ID] = sources[len(sources)-1].Source.SourceKey
+		selectedRoot := roots[rootIndex]
+		return sources, &selectedRoot, nil
+	}
+	return nil, nil, nil
+}
+
+func auditSourceIdentityKey(source rawcheckpoint.SourceIdentity) string {
+	return string(source.Provider) + "\x00" + source.ConfiguredRootID + "\x00" + source.SourceKey
+}
+
+func (a *Auditor) auditProviderFull(
+	ctx context.Context,
+	provider parser.Provider,
+) (AuditResult, error) {
+	result := AuditResult{}
+	discovery, err := parser.DiscoverRawCaptureSources(ctx, provider)
+	if _, ok := errors.AsType[parser.DiscoveryIncompleteError](err); ok {
+		discovery.Complete = false
+	} else if errors.Is(err, os.ErrNotExist) {
+		discovery.Complete = false
+	} else if err != nil {
+		return result, err
+	}
+	sources := discovery.Sources
+	type discoveredSource struct {
+		source parser.SourceRef
+		rootID string
+	}
+	discovered := make([]discoveredSource, 0, len(sources))
+	present := make(map[string]map[string]struct{})
+	for _, source := range sources {
+		plan, supported, err := parser.ResolveRawCapturePlan(ctx, provider, source)
+		if err != nil {
+			return AuditResult{}, err
+		}
+		if !supported {
+			continue
+		}
+		root, err := a.store.ResolveConfiguredRoot(ctx, source.Provider, plan.ConfiguredRoot)
+		if err != nil {
+			return AuditResult{}, err
+		}
+		if present[root.ID] == nil {
+			present[root.ID] = make(map[string]struct{})
+		}
+		present[root.ID][plan.SourceKey] = struct{}{}
+		discovered = append(discovered, discoveredSource{source: source, rootID: root.ID})
+	}
+
+	watchPlan, err := provider.WatchPlan(ctx)
+	if err != nil {
+		return result, err
+	}
+	discovery.Complete = discovery.Complete && rawAuditRootsComplete(ctx, watchPlan.Roots)
+	result.Complete = discovery.Complete
+	var absent []rawcheckpoint.SourceIdentity
+	reconciledRootIDs := make(map[string]struct{}, len(watchPlan.Roots))
+	degradedRootIDs := make(map[string]struct{})
+	if discovery.Complete {
+		for _, watchRoot := range watchPlan.Roots {
+			root, err := a.store.ResolveConfiguredRoot(
+				ctx, provider.Definition().Type, watchRoot.Path,
+			)
+			if err != nil {
+				return result, err
+			}
+			reconciledRootIDs[root.ID] = struct{}{}
+			known, err := a.store.ConfiguredRootSources(ctx, root.Provider, root.ID)
+			if err != nil {
+				return result, err
+			}
+			for _, source := range known {
+				if _, exists := present[root.ID][source.SourceKey]; exists {
+					continue
+				}
+				absent = append(absent, source)
+			}
+		}
+	}
+	for _, source := range absent {
+		_, queued, err := a.store.QueueTombstone(ctx, source)
+		if errors.Is(err, rawcheckpoint.ErrOutboxFull) {
+			result.Degraded++
+			degradedRootIDs[source.ConfiguredRootID] = struct{}{}
+			continue
+		}
+		if err != nil {
+			return result, fmt.Errorf("rawwatch: queue tombstone: %w", err)
+		}
+		if queued {
+			result.Tombstoned++
+		}
+	}
+	for _, item := range discovered {
+		capture, err := a.capturer.Capture(ctx, provider, item.source)
+		if err != nil {
+			return result, err
+		}
+		result.Visited++
+		switch capture.Status {
+		case rawcapture.StatusCaptured:
+			result.Captured++
+		case rawcapture.StatusUnchanged:
+			result.Unchanged++
+		case rawcapture.StatusDegraded:
+			result.Degraded++
+			degradedRootIDs[item.rootID] = struct{}{}
+		}
+	}
+	for rootID := range reconciledRootIDs {
+		if _, degraded := degradedRootIDs[rootID]; degraded {
+			continue
+		}
+		if err := a.store.CompleteRootReconciliation(ctx, rootID); err != nil {
+			return result, fmt.Errorf(
+				"rawwatch: complete root reconciliation: %w", err,
+			)
+		}
+	}
+	return result, nil
+}
+
+func rawAuditRootsComplete(ctx context.Context, roots []parser.WatchRoot) bool {
+	for _, root := range roots {
+		if ctx.Err() != nil {
+			return false
+		}
+		dir, err := os.Open(root.Path)
+		if err != nil {
+			return false
+		}
+		info, statErr := dir.Stat()
+		_, readErr := dir.Readdirnames(1)
+		closeErr := dir.Close()
+		if statErr != nil || !info.IsDir() || closeErr != nil ||
+			(readErr != nil && !errors.Is(readErr, io.EOF)) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rawwatch/auditor_test.go
+++ b/internal/rawwatch/auditor_test.go
@@ -1,0 +1,1217 @@
+package rawwatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcapture"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+type auditProvider struct {
+	parser.ProviderBase
+	root                string
+	missingPathFallback bool
+	streamCalls         int
+	streamedSources     int
+	examinedEntries     int
+	planCalls           int
+	planErrorAt         int
+}
+
+type partialAuditProvider struct {
+	*auditProvider
+	roots           []string
+	unavailableRoot string
+	openedRoots     int
+}
+
+type staleAuditProvider struct {
+	*auditProvider
+}
+
+type duplicateAuditProvider struct {
+	*auditProvider
+	sources []parser.SourceRef
+}
+
+func (p *staleAuditProvider) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	_ func(parser.SourceRef) error,
+) (bool, error) {
+	if err := parser.ReportRawCaptureDiscoveryProgress(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (p *duplicateAuditProvider) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	yield func(parser.SourceRef) error,
+) (bool, error) {
+	for _, source := range p.sources {
+		if err := parser.ReportRawCaptureDiscoveryProgress(ctx); err != nil {
+			return false, err
+		}
+		if err := yield(source); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (p *duplicateAuditProvider) PlanRawCapture(
+	_ context.Context,
+	source parser.SourceRef,
+) (parser.RawCapturePlan, error) {
+	return parser.RawCapturePlan{
+		ConfiguredRoot: p.root,
+		CaptureRoot:    p.root,
+		SourceKey:      source.Key,
+		Entries: []parser.RawCaptureEntry{{
+			Path:      filepath.Base(source.DisplayPath),
+			LocalPath: source.DisplayPath,
+		}},
+	}, nil
+}
+
+func newAuditProvider(root string) *auditProvider {
+	return &auditProvider{
+		Def: parser.AgentDef{Type: parser.AgentClaude},
+		Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+			Support:  parser.CapabilitySupported,
+			Shape:    parser.RawCaptureShapeFiles,
+			Append:   parser.RawCaptureAppendReplaceOnly,
+			Snapshot: parser.RawCaptureSnapshotNone,
+		}},
+		root: root,
+	}
+}
+
+func (p *auditProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	panic("raw audit must not parse")
+}
+
+func (p *auditProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	entries, err := os.ReadDir(p.root)
+	if err != nil {
+		return nil, err
+	}
+	var sources []parser.SourceRef
+	for _, entry := range entries {
+		if entry.Type().IsRegular() {
+			sources = append(sources, parser.SourceRef{
+				Provider: parser.AgentClaude,
+				Key:      entry.Name(), DisplayPath: filepath.Join(p.root, entry.Name()),
+			})
+		}
+	}
+	sort.Slice(sources, func(i, j int) bool { return sources[i].Key < sources[j].Key })
+	return sources, nil
+}
+
+func (p *auditProvider) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	yield func(parser.SourceRef) error,
+) (bool, error) {
+	p.streamCalls++
+	dir, err := os.Open(p.root)
+	if err != nil {
+		return false, err
+	}
+	defer dir.Close()
+	for {
+		entries, err := dir.ReadDir(1)
+		if errors.Is(err, io.EOF) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		entry := entries[0]
+		p.examinedEntries++
+		if err := parser.ReportRawCaptureDiscoveryProgress(ctx); err != nil {
+			return false, err
+		}
+		if !entry.Type().IsRegular() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".jsonl" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(p.root, entry.Name())); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return false, err
+		}
+		p.streamedSources++
+		if err := yield(parser.SourceRef{
+			Provider: parser.AgentClaude,
+			Key:      entry.Name(), DisplayPath: filepath.Join(p.root, entry.Name()),
+		}); err != nil {
+			return false, err
+		}
+	}
+}
+
+func (p *auditProvider) WatchPlan(context.Context) (parser.WatchPlan, error) {
+	return parser.WatchPlan{Roots: []parser.WatchRoot{{Path: p.root}}}, nil
+}
+
+func (p *auditProvider) PlanRawCapture(
+	_ context.Context, source parser.SourceRef,
+) (parser.RawCapturePlan, error) {
+	p.planCalls++
+	if p.planErrorAt == p.planCalls {
+		return parser.RawCapturePlan{}, errors.New("injected plan failure")
+	}
+	return parser.RawCapturePlan{
+		ConfiguredRoot: p.root, CaptureRoot: p.root, SourceKey: source.Key,
+		Entries: []parser.RawCaptureEntry{{
+			Path: source.Key, LocalPath: filepath.Join(p.root, source.Key),
+		}},
+	}, nil
+}
+
+func newPartialAuditProvider(roots ...string) *partialAuditProvider {
+	return &partialAuditProvider{
+		auditProvider: newAuditProvider(roots[0]),
+		roots:         roots,
+	}
+}
+
+func (p *partialAuditProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	var sources []parser.SourceRef
+	for _, root := range p.roots {
+		if root == p.unavailableRoot {
+			continue
+		}
+		entries, err := os.ReadDir(root)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.Type().IsRegular() {
+				sources = append(sources, parser.SourceRef{
+					Provider: parser.AgentClaude,
+					Key:      entry.Name(), DisplayPath: filepath.Join(root, entry.Name()),
+				})
+			}
+		}
+	}
+	sort.Slice(sources, func(i, j int) bool { return sources[i].Key < sources[j].Key })
+	return sources, nil
+}
+
+func (p *partialAuditProvider) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	yield func(parser.SourceRef) error,
+) (bool, error) {
+	p.streamCalls++
+	for _, root := range p.roots {
+		if err := parser.ReportRawCaptureDiscoveryProgress(ctx); err != nil {
+			return false, err
+		}
+		p.openedRoots++
+		if root == p.unavailableRoot {
+			continue
+		}
+		entries, err := os.ReadDir(root)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		for _, entry := range entries {
+			if err := parser.ReportRawCaptureDiscoveryProgress(ctx); err != nil {
+				return false, err
+			}
+			if !entry.Type().IsRegular() {
+				continue
+			}
+			if err := yield(parser.SourceRef{
+				Provider: parser.AgentClaude,
+				Key:      entry.Name(), DisplayPath: filepath.Join(root, entry.Name()),
+			}); err != nil {
+				return false, err
+			}
+		}
+	}
+	return p.unavailableRoot == "", nil
+}
+
+func (p *partialAuditProvider) RawCaptureSourcesForChangedPath(
+	context.Context, parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	return nil, nil
+}
+
+func (p *partialAuditProvider) WatchPlan(context.Context) (parser.WatchPlan, error) {
+	roots := make([]parser.WatchRoot, 0, len(p.roots))
+	for _, root := range p.roots {
+		roots = append(roots, parser.WatchRoot{Path: root})
+	}
+	return parser.WatchPlan{Roots: roots}, nil
+}
+
+func (p *partialAuditProvider) PlanRawCapture(
+	_ context.Context, source parser.SourceRef,
+) (parser.RawCapturePlan, error) {
+	root := filepath.Dir(source.DisplayPath)
+	return parser.RawCapturePlan{
+		ConfiguredRoot: root, CaptureRoot: root, SourceKey: source.Key,
+		Entries: []parser.RawCaptureEntry{{
+			Path: source.Key, LocalPath: source.DisplayPath,
+		}},
+	}, nil
+}
+
+func newRootCoverageFailure(
+	t *testing.T, maxOutboxBytes int64,
+) (string, *rawcheckpoint.Store, string) {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "session.jsonl"), []byte("session"), 0o600,
+	))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: maxOutboxBytes,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+	_, err = store.ReserveCapture(
+		t.Context(), configured.ID, maxOutboxBytes+1,
+	)
+	require.ErrorIs(t, err, rawcheckpoint.ErrOutboxFull)
+
+	coverage, ok, err := store.Coverage(
+		t.Context(), parser.AgentClaude, configured.ID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, rawcheckpoint.CoverageDegraded, coverage.State)
+	return root, store, configured.ID
+}
+
+func TestAuditorFullReconciliationClearsRootCoverageFailure(t *testing.T) {
+	const maxOutboxBytes int64 = 1 << 20
+	root, store, rootID := newRootCoverageFailure(t, maxOutboxBytes)
+
+	provider := newAuditProvider(root)
+	result, err := NewAuditor(store, rawcapture.New(store), 1).
+		AuditProviderFull(t.Context(), provider)
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Zero(t, result.Degraded)
+
+	coverage, ok, err := store.Coverage(
+		t.Context(), parser.AgentClaude, rootID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageComplete, coverage.State)
+}
+
+func TestAuditorFullReconciliationPreservesIncompleteRootCoverageFailure(t *testing.T) {
+	const maxOutboxBytes int64 = 1 << 20
+	root, store, rootID := newRootCoverageFailure(t, maxOutboxBytes)
+	provider := newPartialAuditProvider(root)
+	provider.unavailableRoot = root
+
+	result, err := NewAuditor(store, rawcapture.New(store), 1).
+		AuditProviderFull(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, result.Complete)
+
+	coverage, ok, err := store.Coverage(
+		t.Context(), parser.AgentClaude, rootID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageDegraded, coverage.State)
+}
+
+func TestAuditorFullReconciliationPreservesDegradedRootCoverageFailure(t *testing.T) {
+	const maxOutboxBytes int64 = 1 << 20
+	root, store, rootID := newRootCoverageFailure(t, maxOutboxBytes)
+	blocker, err := store.ReserveCapture(t.Context(), rootID, maxOutboxBytes)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.ReleaseReservation(context.Background(), blocker.ID))
+	})
+
+	result, err := NewAuditor(store, rawcapture.New(store), 1).
+		AuditProviderFull(t.Context(), newAuditProvider(root))
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Equal(t, 1, result.Degraded)
+
+	coverage, ok, err := store.Coverage(
+		t.Context(), parser.AgentClaude, rootID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageDegraded, coverage.State)
+}
+
+func TestAuditorFullReconciliationIsolatesTombstoneBackpressureByRoot(t *testing.T) {
+	const maxOutboxBytes int64 = 1 << 20
+	completeRoot := t.TempDir()
+	degradedRoot := t.TempDir()
+	stalePath := filepath.Join(degradedRoot, "stale.jsonl")
+	require.NoError(t, os.WriteFile(stalePath, []byte("stale"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: maxOutboxBytes,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newPartialAuditProvider(completeRoot, degradedRoot)
+	capturer := rawcapture.New(store)
+	captured, err := capturer.Capture(t.Context(), provider, parser.SourceRef{
+		Provider:    parser.AgentClaude,
+		Key:         "stale.jsonl",
+		DisplayPath: stalePath,
+	})
+	require.NoError(t, err)
+	require.Equal(t, rawcapture.StatusCaptured, captured.Status)
+	require.NoError(t, os.Remove(stalePath))
+
+	completeConfigured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, completeRoot,
+	)
+	require.NoError(t, err)
+	degradedConfigured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, degradedRoot,
+	)
+	require.NoError(t, err)
+	for _, rootID := range []string{completeConfigured.ID, degradedConfigured.ID} {
+		_, err = store.ReserveCapture(t.Context(), rootID, maxOutboxBytes+1)
+		require.ErrorIs(t, err, rawcheckpoint.ErrOutboxFull)
+	}
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	remaining := maxOutboxBytes - usage.UsedBytes - usage.ReservedBytes
+	require.Positive(t, remaining)
+	blocker, err := store.ReserveCapture(
+		t.Context(), degradedConfigured.ID, remaining,
+	)
+	require.NoError(t, err)
+
+	result, err := NewAuditor(store, capturer, 1).
+		AuditProviderFull(t.Context(), provider)
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Equal(t, 1, result.Degraded)
+	require.Zero(t, result.Tombstoned)
+
+	coverage, ok, err := store.Coverage(
+		t.Context(), parser.AgentClaude, completeConfigured.ID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageComplete, coverage.State)
+	coverage, ok, err = store.Coverage(
+		t.Context(), parser.AgentClaude, degradedConfigured.ID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageDegraded, coverage.State)
+
+	require.NoError(t, store.ReleaseReservation(t.Context(), blocker.ID))
+	require.NoError(t, os.WriteFile(stalePath, []byte("stale"), 0o600))
+	recaptured, err := capturer.Capture(t.Context(), provider, parser.SourceRef{
+		Provider:    parser.AgentClaude,
+		Key:         "stale.jsonl",
+		DisplayPath: stalePath,
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, rawcapture.StatusDegraded, recaptured.Status)
+	coverage, ok, err = store.Coverage(
+		t.Context(), parser.AgentClaude, degradedConfigured.ID,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawcheckpoint.CoverageDegraded, coverage.State,
+		"clearing the source failure must expose the preserved root failure")
+}
+
+func TestAuditorRotatesBoundedCapturesAndRepairsDeletion(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"a.jsonl", "b.jsonl", "c.jsonl"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(name), 0o600))
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newAuditProvider(root)
+	auditor := NewAuditor(store, rawcapture.New(store), 2)
+
+	initialCaptured := 0
+	initialComplete := false
+	for range 8 {
+		result, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, result.Visited+result.Tombstoned, 2)
+		initialCaptured += result.Captured
+		if result.Complete {
+			initialComplete = true
+			break
+		}
+	}
+	require.True(t, initialComplete)
+	require.Equal(t, 3, initialCaptured)
+	configured, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, root)
+	require.NoError(t, err)
+	for _, key := range []string{"a.jsonl", "b.jsonl", "c.jsonl"} {
+		base, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+			Provider: parser.AgentClaude, ConfiguredRootID: configured.ID, SourceKey: key,
+		})
+		require.NoError(t, err)
+		require.True(t, ok, key)
+		assert.Equal(t, rawsync.ManifestSnapshot, base.Kind)
+	}
+
+	require.NoError(t, os.Remove(filepath.Join(root, "b.jsonl")))
+	tombstoned := 0
+	for range 8 {
+		result, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, result.Visited+result.Tombstoned, 2)
+		if !result.Complete {
+			assert.Zero(t, result.Tombstoned,
+				"absence is unproven before discovery EOF")
+		}
+		tombstoned += result.Tombstoned
+		if tombstoned != 0 {
+			break
+		}
+	}
+	assert.Equal(t, 1, tombstoned)
+	baseState, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: configured.ID, SourceKey: "b.jsonl",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawsync.ManifestTombstone, baseState.Kind)
+}
+
+func TestAuditorDoesNotTombstoneSourceRecapturedDuringResumedScan(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "target.jsonl")
+	require.NoError(t, os.WriteFile(targetPath, []byte("first"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newAuditProvider(root)
+	capturer := rawcapture.New(store)
+	target := parser.SourceRef{
+		Provider: parser.AgentClaude,
+		Key:      "target.jsonl", DisplayPath: targetPath,
+	}
+	_, err = capturer.Capture(t.Context(), provider, target)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(targetPath))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ignored.txt"), nil, 0o600))
+	auditor := NewAuditor(store, capturer, 1)
+
+	paused, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, paused.Complete)
+	require.Zero(t, paused.Tombstoned)
+	require.NoError(t, os.WriteFile(targetPath, []byte("second"), 0o600))
+	_, err = capturer.Capture(t.Context(), provider, target)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(targetPath))
+
+	tombstoned := 0
+	for range 4 {
+		result, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		tombstoned += result.Tombstoned
+		if result.Complete {
+			break
+		}
+	}
+	assert.Zero(t, tombstoned)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+	latest, found, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: configured.ID,
+		SourceKey:        target.Key,
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, rawsync.ManifestSnapshot, latest.Kind)
+}
+
+func TestAuditorDoesNotTombstoneSourceObservedUnchangedDuringResumedScan(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "target.jsonl")
+	require.NoError(t, os.WriteFile(targetPath, []byte("first"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := &staleAuditProvider{auditProvider: newAuditProvider(root)}
+	capturer := rawcapture.New(store)
+	target := parser.SourceRef{
+		Provider: parser.AgentClaude,
+		Key:      "target.jsonl", DisplayPath: targetPath,
+	}
+	_, err = capturer.Capture(t.Context(), provider, target)
+	require.NoError(t, err)
+	parkedPath := targetPath + ".parked"
+	require.NoError(t, os.Rename(targetPath, parkedPath))
+	auditor := NewAuditor(store, capturer, 1)
+
+	selected, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, selected.Complete)
+	paused, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, paused.Complete)
+	require.NoError(t, os.Rename(parkedPath, targetPath))
+	observed, err := capturer.Capture(t.Context(), provider, target)
+	require.NoError(t, err)
+	require.Equal(t, rawcapture.StatusUnchanged, observed.Status)
+
+	tombstoned := 0
+	complete := false
+	for range 3 {
+		result, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		tombstoned += result.Tombstoned
+		complete = result.Complete
+		if complete {
+			break
+		}
+	}
+	assert.True(t, complete)
+	assert.Zero(t, tombstoned)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+	latest, found, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: configured.ID,
+		SourceKey:        target.Key,
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, rawsync.ManifestSnapshot, latest.Kind)
+}
+
+func TestAuditorDoesNotTombstoneSourceObservedDegradedDuringResumedScan(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "target.jsonl")
+	require.NoError(t, os.WriteFile(targetPath, []byte("first"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := &staleAuditProvider{auditProvider: newAuditProvider(root)}
+	capturer := rawcapture.New(store)
+	target := parser.SourceRef{
+		Provider: parser.AgentClaude,
+		Key:      "target.jsonl", DisplayPath: targetPath,
+	}
+	_, err = capturer.Capture(t.Context(), provider, target)
+	require.NoError(t, err)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+	usage, err := store.OutboxUsage(t.Context())
+	require.NoError(t, err)
+	const tombstoneOnlyCapacity int64 = 1200
+	blocker, err := store.ReserveCapture(
+		t.Context(), configured.ID,
+		usage.LimitBytes-usage.UsedBytes-usage.ReservedBytes-tombstoneOnlyCapacity,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, blocker.ID)
+	auditor := NewAuditor(store, capturer, 1)
+
+	selected, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, selected.Complete)
+	paused, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, paused.Complete)
+	observed, err := capturer.Capture(t.Context(), provider, target)
+	require.NoError(t, err)
+	require.Equal(t, rawcapture.StatusDegraded, observed.Status)
+
+	tombstoned := 0
+	complete := false
+	for range 3 {
+		result, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		tombstoned += result.Tombstoned
+		complete = result.Complete
+		if complete {
+			break
+		}
+	}
+	assert.True(t, complete)
+	assert.Zero(t, tombstoned)
+	latest, found, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: configured.ID,
+		SourceKey:        target.Key,
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, rawsync.ManifestSnapshot, latest.Kind)
+}
+
+func TestAuditorDoesNotTombstoneSourceObservedBeforeCaptureFailure(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "target.jsonl")
+	require.NoError(t, os.WriteFile(targetPath, []byte("first"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := &staleAuditProvider{auditProvider: newAuditProvider(root)}
+	capturer := rawcapture.New(store)
+	target := parser.SourceRef{
+		Provider: parser.AgentClaude,
+		Key:      "target.jsonl", DisplayPath: targetPath,
+	}
+	_, err = capturer.Capture(t.Context(), provider, target)
+	require.NoError(t, err)
+	auditor := NewAuditor(store, capturer, 1)
+
+	selected, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, selected.Complete)
+	paused, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, paused.Complete)
+	provider.planErrorAt = provider.planCalls + 2
+	_, err = capturer.Capture(t.Context(), provider, target)
+	require.ErrorContains(t, err, "injected plan failure")
+
+	tombstoned := 0
+	complete := false
+	for range 3 {
+		result, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		tombstoned += result.Tombstoned
+		complete = result.Complete
+		if complete {
+			break
+		}
+	}
+	assert.True(t, complete)
+	assert.Zero(t, tombstoned)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+	latest, found, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: configured.ID,
+		SourceKey:        target.Key,
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, rawsync.ManifestSnapshot, latest.Kind)
+}
+
+func TestAuditorChargesResumedRootWorkToCurrentTraversalBudget(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "target.jsonl")
+	require.NoError(t, os.WriteFile(targetPath, []byte("first"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newPartialAuditProvider(root)
+	capturer := rawcapture.New(store)
+	target := parser.SourceRef{
+		Provider: parser.AgentClaude,
+		Key:      "target.jsonl", DisplayPath: targetPath,
+	}
+	_, err = capturer.Capture(t.Context(), provider, target)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(targetPath))
+	auditor := NewAuditor(store, capturer, 1)
+
+	first, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, first.Complete)
+	second, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.False(t, second.Complete)
+	resumed, err := auditor.AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+
+	assert.False(t, resumed.Complete,
+		"resumed root work must leave terminal validation for a later call")
+	assert.Zero(t, resumed.Tombstoned)
+}
+
+func TestAuditorPeriodicPassStreamsLargeDiscoveryWithBoundedCaptureWork(t *testing.T) {
+	root := t.TempDir()
+	for index := range 257 {
+		name := fmt.Sprintf("session-%03d.jsonl", index)
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(name), 0o600))
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newAuditProvider(root)
+	auditor := NewAuditor(store, rawcapture.New(store), 3)
+
+	result, err := auditor.AuditProvider(t.Context(), provider)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Visited)
+	assert.False(t, result.Complete)
+	assert.Equal(t, 1, provider.streamCalls)
+	assert.Equal(t, 1, provider.streamedSources)
+	assert.Equal(t, 2, provider.examinedEntries)
+}
+
+func TestAuditorPeriodicPassBoundsSparseDirectoryTraversal(t *testing.T) {
+	root := t.TempDir()
+	for index := range 257 {
+		name := fmt.Sprintf("ignored-%03d.txt", index)
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(name), 0o600))
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider, ok := parser.NewProvider(parser.AgentClaude, parser.ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	auditor := NewAuditor(store, rawcapture.New(store), 3)
+
+	result, err := auditor.AuditProvider(t.Context(), provider)
+
+	require.NoError(t, err)
+	assert.Zero(t, result.Visited)
+	assert.False(t, result.Complete)
+}
+
+func TestAuditorPeriodicPassBoundsManyEmptyRoots(t *testing.T) {
+	roots := make([]string, 0, 257)
+	for range 257 {
+		roots = append(roots, t.TempDir())
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newPartialAuditProvider(roots...)
+
+	result, err := NewAuditor(store, rawcapture.New(store), 3).
+		AuditProvider(t.Context(), provider)
+
+	require.NoError(t, err)
+	assert.Zero(t, result.Visited)
+	assert.False(t, result.Complete)
+	assert.Zero(t, provider.openedRoots,
+		"known-root probes must consume the same traversal budget")
+}
+
+func TestAuditorDoesNotTombstoneWhenDiscoverySkipsUnavailableRoot(t *testing.T) {
+	unavailableRoot := t.TempDir()
+	healthyRoot := t.TempDir()
+	unavailableSource := filepath.Join(unavailableRoot, "unavailable.jsonl")
+	healthySource := filepath.Join(healthyRoot, "healthy.jsonl")
+	require.NoError(t, os.WriteFile(unavailableSource, []byte("first"), 0o600))
+	require.NoError(t, os.WriteFile(healthySource, []byte("first"), 0o600))
+
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newPartialAuditProvider(unavailableRoot, healthyRoot)
+	auditor := NewAuditor(store, rawcapture.New(store), 4)
+
+	initialCaptured := 0
+	initialComplete := false
+	for range 4 {
+		first, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		initialCaptured += first.Captured
+		if first.Complete {
+			initialComplete = true
+			break
+		}
+	}
+	require.True(t, initialComplete)
+	require.Equal(t, 2, initialCaptured)
+	unavailableConfigured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, unavailableRoot,
+	)
+	require.NoError(t, err)
+
+	provider.unavailableRoot = unavailableRoot
+	require.NoError(t, os.WriteFile(healthySource, []byte("second"), 0o600))
+	secondCaptured := 0
+	for range 4 {
+		second, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		assert.Zero(t, second.Tombstoned)
+		secondCaptured += second.Captured
+		if second.Complete || secondCaptured != 0 {
+			break
+		}
+	}
+	assert.Equal(t, 1, secondCaptured)
+
+	provider.unavailableRoot = ""
+	require.NoError(t, os.RemoveAll(unavailableRoot))
+	require.NoError(t, os.WriteFile(healthySource, []byte("third"), 0o600))
+	thirdCaptured := 0
+	for range 4 {
+		third, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		assert.Zero(t, third.Tombstoned)
+		thirdCaptured += third.Captured
+		if thirdCaptured != 0 {
+			break
+		}
+	}
+	assert.Equal(t, 1, thirdCaptured)
+
+	baseState, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: unavailableConfigured.ID,
+		SourceKey:        filepath.Base(unavailableSource),
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawsync.ManifestSnapshot, baseState.Kind)
+}
+
+func TestAuditorClaudePartialDiscoveryDoesNotTombstone(t *testing.T) {
+	root := t.TempDir()
+	healthyRoot := t.TempDir()
+	unavailableProject := filepath.Join(root, "unavailable-project")
+	healthyProject := filepath.Join(healthyRoot, "healthy-project")
+	unavailableSource := filepath.Join(unavailableProject, "unavailable.jsonl")
+	healthySource := filepath.Join(healthyProject, "healthy.jsonl")
+	require.NoError(t, os.MkdirAll(unavailableProject, 0o755))
+	require.NoError(t, os.MkdirAll(healthyProject, 0o755))
+	require.NoError(t, os.WriteFile(unavailableSource, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(healthySource, []byte("{}\n"), 0o600))
+
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider, ok := parser.NewProvider(parser.AgentClaude, parser.ProviderConfig{
+		Roots: []string{root, healthyRoot},
+	})
+	require.True(t, ok)
+	discovery, err := parser.DiscoverRawCaptureSources(t.Context(), provider)
+	require.NoError(t, err)
+	var unavailableKey string
+	for _, source := range discovery.Sources {
+		if source.DisplayPath == unavailableSource {
+			unavailableKey = source.Key
+		}
+	}
+	require.NotEmpty(t, unavailableKey)
+	auditor := NewAuditor(store, rawcapture.New(store), 4)
+
+	initialCaptured := 0
+	initialComplete := false
+	for range 4 {
+		first, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		initialCaptured += first.Captured
+		if first.Complete {
+			initialComplete = true
+			break
+		}
+	}
+	require.True(t, initialComplete)
+	require.Equal(t, 2, initialCaptured)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+
+	parkedProject := filepath.Join(t.TempDir(), "unavailable-project")
+	require.NoError(t, os.Rename(unavailableProject, parkedProject))
+	danglingTarget := filepath.Join(t.TempDir(), "missing-project")
+	if err := os.Symlink(danglingTarget, unavailableProject); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	require.NoError(t, os.WriteFile(healthySource, []byte("{\"changed\":true}\n"), 0o600))
+	partialCaptured := 0
+	for range 2 {
+		partial, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		assert.Zero(t, partial.Tombstoned)
+		partialCaptured += partial.Captured
+	}
+	assert.Equal(t, 1, partialCaptured)
+
+	baseState, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: configured.ID,
+		SourceKey:        unavailableKey,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawsync.ManifestSnapshot, baseState.Kind)
+
+	require.NoError(t, os.Remove(unavailableProject))
+	tombstoned := 0
+	for range 8 {
+		deleted, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		tombstoned += deleted.Tombstoned
+		if tombstoned != 0 {
+			break
+		}
+	}
+	assert.Equal(t, 1, tombstoned)
+}
+
+func TestAuditorDoesNotLetOldTombstonesStarveNewSources(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"a.jsonl", "b.jsonl", "c.jsonl"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(name), 0o600))
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newAuditProvider(root)
+	auditor := NewAuditor(store, rawcapture.New(store), 2)
+	for range 8 {
+		result, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+		if result.Complete {
+			break
+		}
+	}
+	for _, name := range []string{"a.jsonl", "b.jsonl", "c.jsonl"} {
+		require.NoError(t, os.Remove(filepath.Join(root, name)))
+	}
+	for range 8 {
+		_, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "d.jsonl"), []byte("new"), 0o600))
+	for range 8 {
+		_, err := auditor.AuditProvider(t.Context(), provider)
+		require.NoError(t, err)
+	}
+	configured, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, root)
+	require.NoError(t, err)
+	captured, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: configured.ID, SourceKey: "d.jsonl",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawsync.ManifestSnapshot, captured.Kind)
+}
+
+func TestAuditorBoundedCapturesPhysicalDuplicates(t *testing.T) {
+	root := t.TempDir()
+	stalePath := filepath.Join(root, "stale.jsonl")
+	preferredPath := filepath.Join(root, "preferred.jsonl")
+	require.NoError(t, os.WriteFile(stalePath, []byte("stale"), 0o600))
+	require.NoError(t, os.WriteFile(preferredPath, []byte("preferred"), 0o600))
+	stale := parser.SourceRef{
+		Provider: parser.AgentClaude, Key: "duplicate", DisplayPath: stalePath,
+	}
+	preferred := parser.SourceRef{
+		Provider: parser.AgentClaude, Key: "duplicate", DisplayPath: preferredPath,
+	}
+	provider := &duplicateAuditProvider{
+		auditProvider: newAuditProvider(root),
+		sources:       []parser.SourceRef{stale, preferred},
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	result, err := NewAuditor(store, rawcapture.New(store), 8).
+		AuditProvider(t.Context(), provider)
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Equal(t, 2, result.Visited)
+	require.Equal(t, 2, result.Captured)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+	latest, found, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: configured.ID,
+		SourceKey:        "duplicate",
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, latest.Entries, 1)
+	assert.Equal(t, filepath.Base(preferredPath), latest.Entries[0].Path)
+}
+
+func TestAuditorFullCapturesPhysicalCodexDuplicatesWithinRoot(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "sessions")
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e5"
+	metadata := `{"timestamp":"2026-06-11T12:44:06Z","type":"session_meta","payload":{"id":"` +
+		uuid + `"}}` + "\n"
+	archivedPath := filepath.Join(
+		root, "rollout-2026-06-12T08-00-00-"+uuid+".jsonl",
+	)
+	livePath := filepath.Join(
+		root, "2026", "06", "11",
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(livePath), 0o755))
+	require.NoError(t, os.WriteFile(
+		archivedPath, []byte(metadata+`{"copy":"archived"}`+"\n"), 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		livePath, []byte(metadata+`{"copy":"live"}`+"\n"), 0o600,
+	))
+	provider, ok := parser.NewProvider(parser.AgentCodex, parser.ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	checkpointDir := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(checkpointDir, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(checkpointDir, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	result, err := NewAuditor(store, rawcapture.New(store), 8).
+		AuditProviderFull(t.Context(), provider)
+	require.NoError(t, err)
+	require.True(t, result.Complete)
+	require.Equal(t, 2, result.Visited)
+	require.Equal(t, 2, result.Captured)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentCodex, root,
+	)
+	require.NoError(t, err)
+	latest, found, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider:         parser.AgentCodex,
+		ConfiguredRootID: configured.ID,
+		SourceKey:        parser.CodexSourceKey(parser.AgentCodex, uuid),
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, latest.Entries, 1)
+	assert.NotEmpty(t, latest.Entries[0].Path)
+}

--- a/internal/rawwatch/auditor_windows_test.go
+++ b/internal/rawwatch/auditor_windows_test.go
@@ -1,0 +1,50 @@
+package rawwatch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcapture"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+)
+
+func TestAuditorPausedDirectoryAllowsRenameAndRemoval(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	project := filepath.Join(root, "project")
+	require.NoError(t, os.Mkdir(project, 0o700))
+	for _, name := range []string{"a.jsonl", "b.jsonl"} {
+		require.NoError(t, os.WriteFile(filepath.Join(project, name), []byte(name), 0o600))
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider, ok := parser.NewProvider(parser.AgentClaude, parser.ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	auditor := NewAuditor(store, rawcapture.New(store), 3)
+	ctx, cancel := context.WithCancel(t.Context())
+
+	result, err := auditor.AuditProvider(ctx, provider)
+
+	require.NoError(t, err)
+	assert.False(t, result.Complete)
+	assert.Zero(t, result.Visited)
+	moved := root + "-moved"
+	require.NoError(t, os.Rename(root, moved))
+	require.NoError(t, os.RemoveAll(moved))
+	cancel()
+}

--- a/internal/rawwatch/worker.go
+++ b/internal/rawwatch/worker.go
@@ -1,0 +1,223 @@
+package rawwatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcapture"
+	"go.kenn.io/agentsview/internal/rawupload"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+)
+
+// ErrFullSyncIncomplete keeps a full-sync marker retryable when outbox
+// backpressure prevents the current pass from reconciling every source.
+var ErrFullSyncIncomplete = errors.New("rawwatch: full audit incomplete")
+
+type generationUploader interface {
+	UploadNext(context.Context) (rawupload.Result, bool, error)
+}
+
+// Worker serializes watcher capture, audit, and upload work so hosted raw mode
+// has one bounded laptop-side work stream.
+type Worker struct {
+	mu        sync.Mutex
+	providers []parser.Provider
+	capturer  *rawcapture.Capturer
+	auditor   *Auditor
+	uploader  generationUploader
+}
+
+type fullAuditStatus struct {
+	degraded int
+	complete bool
+}
+
+// NewWorker constructs one serialized raw-capture worker.
+func NewWorker(
+	providers []parser.Provider,
+	capturer *rawcapture.Capturer,
+	auditor *Auditor,
+	uploader generationUploader,
+) *Worker {
+	return &Worker{
+		providers: append([]parser.Provider(nil), providers...),
+		capturer:  capturer, auditor: auditor, uploader: uploader,
+	}
+}
+
+// HandleBatch captures physical sources named by one watcher batch, promotes
+// uncertain or removal-shaped batches to bounded audit, then drains uploads.
+func (w *Worker) HandleBatch(
+	ctx context.Context,
+	batch syncpkg.WatchBatch,
+) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if batch.FullSync {
+		status, err := w.auditAllFullLocked(ctx)
+		if err != nil {
+			return err
+		}
+		if err := w.drainLocked(ctx); err != nil {
+			return err
+		}
+		if status.degraded != 0 || !status.complete {
+			return fmt.Errorf(
+				"%w: degraded=%d discovery_complete=%t",
+				ErrFullSyncIncomplete, status.degraded, status.complete,
+			)
+		}
+		return nil
+	}
+	if len(batch.ReconcileRoots) != 0 || len(batch.Renames) != 0 {
+		if err := w.auditAllLocked(ctx); err != nil {
+			return err
+		}
+		return w.drainLocked(ctx)
+	}
+	for _, provider := range w.providers {
+		if provider.Capabilities().RawCapture.Support != parser.CapabilitySupported {
+			continue
+		}
+		plan, err := provider.WatchPlan(ctx)
+		if err != nil {
+			return err
+		}
+		needsAudit := false
+		seen := make(map[string]struct{})
+		for _, path := range batch.Paths {
+			for _, root := range plan.Roots {
+				if !rawWatchPathWithin(root.Path, path) {
+					continue
+				}
+				if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+					needsAudit = true
+					break
+				} else if err != nil {
+					return fmt.Errorf("rawwatch: inspect changed source: %w", err)
+				}
+				sources, err := parser.RawCaptureSourcesForChangedPath(
+					ctx, provider, parser.ChangedPathRequest{
+						Path: path, EventKind: "change", WatchRoot: root.Path,
+					},
+				)
+				if err != nil {
+					return err
+				}
+				if len(sources) == 0 {
+					needsAudit = true
+				}
+				for _, source := range sources {
+					key := rawWatchSourceDedupKey(source)
+					if _, exists := seen[key]; exists {
+						continue
+					}
+					seen[key] = struct{}{}
+					if _, err := w.capturer.Capture(ctx, provider, source); err != nil {
+						if errors.Is(err, rawcapture.ErrSourceChanged) ||
+							rawWatchPathMissing(path) {
+							needsAudit = true
+							continue
+						}
+						return fmt.Errorf("rawwatch: capture changed source: %w", err)
+					}
+				}
+			}
+		}
+		if needsAudit {
+			if _, err := w.auditor.AuditProvider(ctx, provider); err != nil {
+				return err
+			}
+		}
+	}
+	return w.drainLocked(ctx)
+}
+
+func rawWatchSourceDedupKey(source parser.SourceRef) string {
+	physical := source.FingerprintKey
+	if physical == "" {
+		physical = source.DisplayPath
+	}
+	return string(source.Provider) + "\x00" + source.Key + "\x00" + physical
+}
+
+func rawWatchPathMissing(path string) bool {
+	_, err := os.Lstat(path)
+	return errors.Is(err, os.ErrNotExist)
+}
+
+// AuditAll runs one bounded repair pass per supported provider and drains any
+// newly ready generations.
+func (w *Worker) AuditAll(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := w.auditAllLocked(ctx); err != nil {
+		return err
+	}
+	return w.drainLocked(ctx)
+}
+
+// Drain uploads all currently ready generations until the durable retry fence
+// or an empty outbox stops work.
+func (w *Worker) Drain(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.drainLocked(ctx)
+}
+
+func (w *Worker) auditAllLocked(ctx context.Context) error {
+	for _, provider := range w.providers {
+		if provider.Capabilities().RawCapture.Support != parser.CapabilitySupported {
+			continue
+		}
+		if _, err := w.auditor.AuditProvider(ctx, provider); err != nil {
+			return fmt.Errorf("rawwatch: audit %s: %w", provider.Definition().Type, err)
+		}
+	}
+	return nil
+}
+
+func (w *Worker) auditAllFullLocked(ctx context.Context) (fullAuditStatus, error) {
+	status := fullAuditStatus{complete: true}
+	for _, provider := range w.providers {
+		if provider.Capabilities().RawCapture.Support != parser.CapabilitySupported {
+			continue
+		}
+		result, err := w.auditor.AuditProviderFull(ctx, provider)
+		if err != nil {
+			return status, fmt.Errorf(
+				"rawwatch: full audit %s: %w", provider.Definition().Type, err,
+			)
+		}
+		status.degraded += result.Degraded
+		status.complete = status.complete && result.Complete
+	}
+	return status, nil
+}
+
+func (w *Worker) drainLocked(ctx context.Context) error {
+	if w.uploader == nil {
+		return nil
+	}
+	for {
+		_, found, err := w.uploader.UploadNext(ctx)
+		if err != nil {
+			return fmt.Errorf("rawwatch: upload generation: %w", err)
+		}
+		if !found {
+			return nil
+		}
+	}
+}
+
+func rawWatchPathWithin(root, path string) bool {
+	relative, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	return err == nil && relative != ".." &&
+		!strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}

--- a/internal/rawwatch/worker.go
+++ b/internal/rawwatch/worker.go
@@ -208,6 +208,9 @@ func (w *Worker) drainLocked(ctx context.Context) error {
 	for {
 		_, found, err := w.uploader.UploadNext(ctx)
 		if err != nil {
+			if errors.Is(err, rawupload.ErrPermanentFailure) {
+				continue
+			}
 			return fmt.Errorf("rawwatch: upload generation: %w", err)
 		}
 		if !found {

--- a/internal/rawwatch/worker_test.go
+++ b/internal/rawwatch/worker_test.go
@@ -1,0 +1,467 @@
+package rawwatch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcapture"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawsync"
+	"go.kenn.io/agentsview/internal/rawupload"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+)
+
+type recordingRawUploadTransport struct {
+	commits int
+}
+
+func (t *recordingRawUploadTransport) MissingObjects(
+	context.Context,
+	parser.AgentType,
+	[]rawsync.ObjectRef,
+) ([]rawsync.ObjectRef, error) {
+	return nil, nil
+}
+
+func (t *recordingRawUploadTransport) UploadObject(
+	context.Context,
+	parser.AgentType,
+	rawsync.ObjectRef,
+	io.ReaderAt,
+) error {
+	return nil
+}
+
+func (t *recordingRawUploadTransport) CommitManifest(
+	_ context.Context,
+	_ rawsync.Manifest,
+) (rawsync.CommitResult, error) {
+	t.commits++
+	return rawsync.CommitResult{
+		ManifestID: fmt.Sprintf("%064x", t.commits),
+		Receipt:    fmt.Sprintf("%064x", t.commits+100),
+		Generation: 1,
+		Created:    true,
+	}, nil
+}
+
+func (p *auditProvider) SourcesForChangedPath(
+	_ context.Context,
+	req parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	if _, err := os.Stat(req.Path); err != nil {
+		if os.IsNotExist(err) {
+			if !p.missingPathFallback {
+				return nil, nil
+			}
+			return []parser.SourceRef{{
+				Provider: parser.AgentClaude,
+				Key:      filepath.Base(req.Path), DisplayPath: req.Path,
+			}}, nil
+		}
+		return nil, err
+	}
+	return []parser.SourceRef{{
+		Provider: parser.AgentClaude,
+		Key:      filepath.Base(req.Path), DisplayPath: req.Path,
+	}}, nil
+}
+
+type collidingRootProvider struct {
+	parser.ProviderBase
+	roots []string
+}
+
+func newCollidingRootProvider(roots ...string) *collidingRootProvider {
+	return &collidingRootProvider{
+		Def: parser.AgentDef{Type: parser.AgentForge},
+		Caps: parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+			Support: parser.CapabilitySupported, Shape: parser.RawCaptureShapeFiles,
+			Append:   parser.RawCaptureAppendReplaceOnly,
+			Snapshot: parser.RawCaptureSnapshotNone,
+		}},
+		roots: roots,
+	}
+}
+
+func (p *collidingRootProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	panic("raw watch must not parse")
+}
+
+func (p *collidingRootProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	return nil, nil
+}
+
+func (p *collidingRootProvider) WatchPlan(context.Context) (parser.WatchPlan, error) {
+	plan := parser.WatchPlan{}
+	for _, root := range p.roots {
+		plan.Roots = append(plan.Roots, parser.WatchRoot{Path: root})
+	}
+	return plan, nil
+}
+
+func (p *collidingRootProvider) SourcesForChangedPath(
+	_ context.Context, req parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	return []parser.SourceRef{{
+		Provider: parser.AgentForge, Key: "state.db", DisplayPath: req.Path,
+		FingerprintKey: req.Path,
+	}}, nil
+}
+
+func (p *collidingRootProvider) PlanRawCapture(
+	_ context.Context, source parser.SourceRef,
+) (parser.RawCapturePlan, error) {
+	root := filepath.Dir(source.DisplayPath)
+	return parser.RawCapturePlan{
+		ConfiguredRoot: root, CaptureRoot: root, SourceKey: source.Key,
+		Entries: []parser.RawCaptureEntry{{
+			Path: "state.db", LocalPath: source.DisplayPath,
+		}},
+	}, nil
+}
+
+func TestWorkerCapturesCollidingSourceKeysFromSeparateRoots(t *testing.T) {
+	firstRoot := t.TempDir()
+	secondRoot := t.TempDir()
+	firstPath := filepath.Join(firstRoot, "state.db")
+	secondPath := filepath.Join(secondRoot, "state.db")
+	require.NoError(t, os.WriteFile(firstPath, []byte("first"), 0o600))
+	require.NoError(t, os.WriteFile(secondPath, []byte("second"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newCollidingRootProvider(firstRoot, secondRoot)
+	capturer := rawcapture.New(store)
+	worker := NewWorker(
+		[]parser.Provider{provider}, capturer,
+		NewAuditor(store, capturer, 16), nil,
+	)
+
+	err = worker.HandleBatch(t.Context(), syncpkg.WatchBatch{
+		Paths: []string{firstPath, secondPath},
+	})
+
+	require.NoError(t, err)
+	for _, rootPath := range []string{firstRoot, secondRoot} {
+		root, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentForge, rootPath)
+		require.NoError(t, err)
+		_, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+			Provider: parser.AgentForge, ConfiguredRootID: root.ID, SourceKey: "state.db",
+		})
+		require.NoError(t, err)
+		assert.True(t, ok, rootPath)
+	}
+}
+
+func TestWorkerFullSyncAuditsBeyondBoundedLimit(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"first.jsonl", "second.jsonl", "third.jsonl"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(name), 0o600))
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newAuditProvider(root)
+	capturer := rawcapture.New(store)
+	worker := NewWorker(
+		[]parser.Provider{provider}, capturer,
+		NewAuditor(store, capturer, 1), nil,
+	)
+
+	err = worker.HandleBatch(t.Context(), syncpkg.WatchBatch{FullSync: true})
+	require.NoError(t, err)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+	for _, name := range []string{"first.jsonl", "second.jsonl", "third.jsonl"} {
+		baseState, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+			Provider: parser.AgentClaude, ConfiguredRootID: configured.ID, SourceKey: name,
+		})
+		require.NoError(t, err)
+		require.True(t, ok, name)
+		assert.Equal(t, rawsync.ManifestSnapshot, baseState.Kind)
+	}
+}
+
+func TestWorkerPromotesUncertainWatchBatchesToAudit(t *testing.T) {
+	tests := map[string]syncpkg.WatchBatch{
+		"reconcile root": {ReconcileRoots: []string{"lost-event-root"}},
+		"rename":         {Renames: []syncpkg.WatchRename{{Path: "renamed-source"}}},
+	}
+	for name, batch := range tests {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "session.jsonl")
+			require.NoError(t, os.WriteFile(path, []byte("session\n"), 0o600))
+			base := t.TempDir()
+			store, err := rawcheckpoint.OpenWithOptions(
+				t.Context(), filepath.Join(base, "checkpoint.db"),
+				rawcheckpoint.Options{
+					SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+				},
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			provider := newAuditProvider(root)
+			capturer := rawcapture.New(store)
+			worker := NewWorker(
+				[]parser.Provider{provider}, capturer,
+				NewAuditor(store, capturer, 16), nil,
+			)
+
+			require.NoError(t, worker.HandleBatch(t.Context(), batch))
+
+			configured, err := store.ResolveConfiguredRoot(
+				t.Context(), parser.AgentClaude, root,
+			)
+			require.NoError(t, err)
+			_, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+				Provider: parser.AgentClaude, ConfiguredRootID: configured.ID,
+				SourceKey: "session.jsonl",
+			})
+			require.NoError(t, err)
+			assert.True(t, ok, "the audit must capture sources absent from batch.Paths")
+		})
+	}
+}
+
+func TestWorkerFullSyncReportsOutboxBackpressure(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"first.jsonl", "second.jsonl"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(name), 0o600))
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 2000,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	provider := newAuditProvider(root)
+	capturer := rawcapture.New(store)
+	transport := &recordingRawUploadTransport{}
+	worker := NewWorker(
+		[]parser.Provider{provider}, capturer,
+		NewAuditor(store, capturer, 1), rawupload.New(store, transport, "device-a"),
+	)
+
+	err = worker.HandleBatch(t.Context(), syncpkg.WatchBatch{FullSync: true})
+
+	require.ErrorIs(t, err, ErrFullSyncIncomplete)
+	assert.Equal(t, 1, transport.commits, "queued work must drain before the retry")
+	require.NoError(t, worker.HandleBatch(t.Context(), syncpkg.WatchBatch{FullSync: true}))
+	assert.Equal(t, 2, transport.commits, "the retry must capture and drain deferred work")
+	configured, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, root)
+	require.NoError(t, err)
+	for _, name := range []string{"first.jsonl", "second.jsonl"} {
+		_, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+			Provider: parser.AgentClaude, ConfiguredRootID: configured.ID, SourceKey: name,
+		})
+		require.NoError(t, err)
+		assert.True(t, ok, name)
+	}
+}
+
+func TestWorkerFullSyncReportsIncompleteDiscovery(t *testing.T) {
+	healthyRoot := t.TempDir()
+	healthyPath := filepath.Join(healthyRoot, "session.jsonl")
+	require.NoError(t, os.WriteFile(healthyPath, []byte("healthy"), 0o600))
+	unavailableRoot := filepath.Join(t.TempDir(), "unavailable")
+	provider := newPartialAuditProvider(healthyRoot, unavailableRoot)
+	provider.unavailableRoot = unavailableRoot
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	capturer := rawcapture.New(store)
+	worker := NewWorker(
+		[]parser.Provider{provider}, capturer,
+		NewAuditor(store, capturer, 16), nil,
+	)
+
+	err = worker.HandleBatch(t.Context(), syncpkg.WatchBatch{FullSync: true})
+
+	require.ErrorIs(t, err, ErrFullSyncIncomplete)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, healthyRoot,
+	)
+	require.NoError(t, err)
+	_, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: configured.ID,
+		SourceKey: "session.jsonl",
+	})
+	require.NoError(t, err)
+	assert.True(t, ok, "healthy sources must still be captured")
+}
+
+func TestWorkerAuditsMissingFallbackAndContinuesBatch(t *testing.T) {
+	root := t.TempDir()
+	deletedPath := filepath.Join(root, "deleted.jsonl")
+	changedPath := filepath.Join(root, "changed.jsonl")
+	require.NoError(t, os.WriteFile(deletedPath, []byte("old\n"), 0o600))
+	require.NoError(t, os.WriteFile(changedPath, []byte("one\n"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newAuditProvider(root)
+	provider.missingPathFallback = true
+	capturer := rawcapture.New(store)
+	worker := NewWorker(
+		[]parser.Provider{provider}, capturer,
+		NewAuditor(store, capturer, 16), nil,
+	)
+	require.NoError(t, worker.AuditAll(t.Context()))
+	require.NoError(t, os.Remove(deletedPath))
+	require.NoError(t, os.WriteFile(changedPath, []byte("two\n"), 0o600))
+
+	err = worker.HandleBatch(t.Context(), syncpkg.WatchBatch{
+		Paths: []string{deletedPath, changedPath},
+	})
+
+	require.NoError(t, err)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, root,
+	)
+	require.NoError(t, err)
+	deleted, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: configured.ID,
+		SourceKey: "deleted.jsonl",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawsync.ManifestTombstone, deleted.Kind)
+	changed, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: configured.ID,
+		SourceKey: "changed.jsonl",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawsync.ManifestSnapshot, changed.Kind)
+	assert.Equal(t, int64(4), changed.Entries[0].Length)
+}
+
+func TestWorkerCapturesChangedPathAndAuditsDeletionWithoutParsing(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "session.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("one\n"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newAuditProvider(root)
+	capturer := rawcapture.New(store)
+	worker := NewWorker(
+		[]parser.Provider{provider}, capturer,
+		NewAuditor(store, capturer, 16), nil,
+	)
+
+	err = worker.HandleBatch(t.Context(), syncpkg.WatchBatch{Paths: []string{path}})
+	require.NoError(t, err)
+	configured, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, root)
+	require.NoError(t, err)
+	identity := rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: configured.ID,
+		SourceKey: "session.jsonl",
+	}
+	first, ok, err := store.CaptureBase(t.Context(), identity)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawsync.ManifestSnapshot, first.Kind)
+
+	require.NoError(t, os.WriteFile(path, []byte("two\n"), 0o600))
+	require.NoError(t, worker.HandleBatch(
+		t.Context(), syncpkg.WatchBatch{Paths: []string{path}},
+	))
+	second, ok, err := store.CaptureBase(t.Context(), identity)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.NotEqual(t, first.CaptureID, second.CaptureID)
+
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, worker.HandleBatch(
+		t.Context(), syncpkg.WatchBatch{Paths: []string{path}},
+	))
+	deleted, ok, err := store.CaptureBase(t.Context(), identity)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, rawsync.ManifestTombstone, deleted.Kind)
+}
+
+func TestWorkerAuditSkipsMissingProviderRootAndContinues(t *testing.T) {
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	healthyRoot := t.TempDir()
+	healthyPath := filepath.Join(healthyRoot, "session.jsonl")
+	require.NoError(t, os.WriteFile(healthyPath, []byte("healthy\n"), 0o600))
+	missing := newAuditProvider(filepath.Join(t.TempDir(), "missing"))
+	healthy := newAuditProvider(healthyRoot)
+	capturer := rawcapture.New(store)
+	worker := NewWorker(
+		[]parser.Provider{missing, healthy}, capturer,
+		NewAuditor(store, capturer, 16), nil,
+	)
+
+	err = worker.AuditAll(t.Context())
+
+	require.NoError(t, err)
+	configured, err := store.ResolveConfiguredRoot(
+		t.Context(), parser.AgentClaude, healthyRoot,
+	)
+	require.NoError(t, err)
+	_, ok, err := store.CaptureBase(t.Context(), rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: configured.ID,
+		SourceKey: "session.jsonl",
+	})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/internal/rawwatch/worker_test.go
+++ b/internal/rawwatch/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,13 +15,15 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/rawcapture"
 	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawclient"
 	"go.kenn.io/agentsview/internal/rawsync"
 	"go.kenn.io/agentsview/internal/rawupload"
 	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
 
 type recordingRawUploadTransport struct {
-	commits int
+	commits    int
+	commitErrs []error
 }
 
 func (t *recordingRawUploadTransport) MissingObjects(
@@ -45,12 +48,52 @@ func (t *recordingRawUploadTransport) CommitManifest(
 	_ rawsync.Manifest,
 ) (rawsync.CommitResult, error) {
 	t.commits++
+	if t.commits <= len(t.commitErrs) && t.commitErrs[t.commits-1] != nil {
+		return rawsync.CommitResult{}, t.commitErrs[t.commits-1]
+	}
 	return rawsync.CommitResult{
 		ManifestID: fmt.Sprintf("%064x", t.commits),
 		Receipt:    fmt.Sprintf("%064x", t.commits+100),
 		Generation: 1,
 		Created:    true,
 	}, nil
+}
+
+func TestWorkerDrainSkipsPermanentlyRejectedGeneration(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"first.jsonl", "second.jsonl"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(name), 0o600))
+	}
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	provider := newAuditProvider(root)
+	capturer := rawcapture.New(store)
+	transport := &recordingRawUploadTransport{commitErrs: []error{
+		&rawclient.APIError{
+			Status: http.StatusBadRequest, Code: rawclient.CodeInvalidRequest,
+		},
+	}}
+	worker := NewWorker(
+		[]parser.Provider{provider}, capturer,
+		NewAuditor(store, capturer, 16), rawupload.New(store, transport, "device-a"),
+	)
+
+	err = worker.HandleBatch(t.Context(), syncpkg.WatchBatch{FullSync: true})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, transport.commits,
+		"a rejected source must not prevent another source from uploading")
+	status, err := store.ClientStatus(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, status.PermanentFailures)
 }
 
 func (p *auditProvider) SourcesForChangedPath(

--- a/internal/sync/verified_source_gate_integration_test.go
+++ b/internal/sync/verified_source_gate_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -370,8 +371,23 @@ func TestVerifiedSourceGateRechecksAfterStatAndWatcherInvalidation(t *testing.T)
 
 	info, err := os.Stat(file.Path)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(file.Path, []byte("changed\n"), 0o600))
-	require.NoError(t, os.Chtimes(file.Path, info.ModTime(), info.ModTime()))
+	baselineChangeTime, ok := fileChangeTime(file.Path, info)
+	require.True(t, ok, "native change time unavailable")
+	changeTime := baselineChangeTime
+	deadline := time.Now().Add(2 * time.Second)
+	for changeTime == baselineChangeTime && time.Now().Before(deadline) {
+		require.NoError(t, os.WriteFile(file.Path, []byte("changed\n"), 0o600))
+		require.NoError(t, os.Chtimes(file.Path, info.ModTime(), info.ModTime()))
+		changedInfo, statErr := os.Stat(file.Path)
+		require.NoError(t, statErr)
+		changeTime, ok = fileChangeTime(file.Path, changedInfo)
+		require.True(t, ok, "native change time unavailable after rewrite")
+		if changeTime == baselineChangeTime {
+			time.Sleep(time.Millisecond)
+		}
+	}
+	require.NotEqual(t, baselineChangeTime, changeTime,
+		"fixture must cross a native change-time tick")
 	runVerifiedSourcePass(t, engine, files)
 	assert.Equal(t, 2, provider.fingerprintCalls,
 		"same-size rewrite with restored mtime must deep-verify")


### PR DESCRIPTION
## What changed

- Adds `raw-sync watch` and `raw-sync status` for continuous laptop-side raw
  capture and upload.
- Captures SQLite-backed providers through bounded online backups and file
  providers through ordered snapshots, append generations, and tombstones.
- Persists device-fenced checkpoints, durable retries, receipts, coverage
  state, and bounded outbox usage without storing parsed chat data.
- Reconciles missed watcher events with rotating audits while keeping upload
  and capture work serialized.

## Why

This advances the laptop watcher and uploader stage in #1352. Hosted raw mode
now has a durable local daemon path that can survive offline periods, watcher
gaps, source replacement, transport conflicts, and process restarts without
advancing an unsafe checkpoint.

## Limits

Remote transport requires HTTPS. Loopback HTTP is available only through the
explicit development flag. S3 roots stay out of this laptop filesystem watcher
and continue through their existing ingestion path.
