### PR TITLE
feat(pricing): add OrcaRouter as an online pricing source

### DIFF
--- a/docs/internal/pricing-source-survey-2026-08-25.md
+++ b/docs/internal/pricing-source-survey-2026-08-25.md
@@ -229,6 +229,18 @@ without a redistribution decision. Neither the API reference nor the official
 to the catalog. That is not proof that redistribution is forbidden; it means
 this survey found no affirmative open license comparable with MIT or CC BY 4.0.
 
+## OrcaRouter
+
+The unauthenticated live
+[`GET /v1/models`](https://api.orcarouter.ai/v1/models) returned 204 models on
+2026-08-28. It uses the same envelope and price fields as OpenRouter
+(`{"data": [...]}` with per-token `prompt`/`completion` strings), so the
+existing OpenRouter parser handles it unchanged. Prices describe OrcaRouter
+routes, not necessarily first-party list prices. It omits `architecture`
+modality, which the parser treats as text output. The catalog is a live API
+without an attached open-data license, so like OpenRouter it is unsuitable as
+an embedded snapshot without a redistribution decision.
+
 ## Helicone
 
 At audited `main` commit

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -328,13 +328,15 @@ The default window is the last 30 days; pass `--all` to scan the full history.
 Model rates come from the
 [LiteLLM model pricing catalog](https://github.com/BerriAI/litellm), with the
 [OpenRouter model catalog](https://openrouter.ai/docs/api/api-reference/models/get-models)
-layered underneath for models LiteLLM does not list. Both are fetched together
-(hourly at most on `usage` invocations, daily by the server) and merged into the
-`model_pricing` table; when both catalogs list a model, LiteLLM's rate wins, and
-an OpenRouter row is dropped once LiteLLM picks the model up. If the LiteLLM
-fetch fails, AgentsView keeps the last stored rates; if only the OpenRouter
-fetch fails, the fresh LiteLLM rates are still stored and the stored OpenRouter
-rates are kept. Fresh databases are seeded from
+and the [OrcaRouter model catalog](https://api.orcarouter.ai/v1/models)
+layered underneath for models LiteLLM does not list. All three are fetched
+together (hourly at most on `usage` invocations, daily by the server) and merged
+into the `model_pricing` table; when more than one catalog lists a model,
+LiteLLM's rate wins, then OpenRouter's, and an OrcaRouter row is dropped once
+either higher-priority source picks the model up. If the LiteLLM fetch fails,
+AgentsView keeps the last stored rates; if only the OpenRouter or OrcaRouter
+fetch fails, the fresh LiteLLM rates are still stored and the stored
+OpenRouter/OrcaRouter rates are kept. Fresh databases are seeded from
 an embedded LiteLLM snapshot so offline use works before any refresh completes.
 Pass `--offline` to skip the fetch entirely and always use the embedded
 fallback.
@@ -401,10 +403,11 @@ output_microdollars_per_mtok = 800_000
 
 The table key is the model name as it appears in your session data (match the
 string the agent itself writes, dots and all — quote the key if it contains
-special characters). Custom rates take precedence over LiteLLM, OpenRouter, and
-the embedded fallback, and apply to the Usage dashboard, the `agentsview usage`
-CLI, and `pg serve` alike. A custom entry replaces the full rate row for that
-model, so omitted fields are treated as zero rather than falling through to
+special characters). Custom rates take precedence over LiteLLM, OpenRouter,
+OrcaRouter, and the embedded fallback, and apply to the Usage dashboard, the
+`agentsview usage` CLI, and `pg serve` alike. A custom entry replaces the full
+rate row for that model, so omitted fields are treated as zero rather than
+falling through to
 another catalog. A custom row is flat and suppresses any fetched request bands
 for that model. Models without a custom entry continue to resolve through the
 stored catalog.
@@ -1036,7 +1039,8 @@ Usage reports read from the same local SQLite database that powers the
 stored on each message row in the `messages` table; pricing is cached in a small
 `model_pricing` table that's refreshed on each `usage` invocation.
 
-Session data stays on your machine. The only outbound requests are the LiteLLM
-and OpenRouter pricing fetches, which you can disable with `--offline`. See
+Session data stays on your machine. The only outbound requests are the LiteLLM,
+OpenRouter, and OrcaRouter pricing fetches, which you can disable with
+`--offline`. See
 [Privacy and Telemetry](/configuration/#privacy-and-telemetry) for the full
 picture.

--- a/internal/export/pricing.go
+++ b/internal/export/pricing.go
@@ -246,8 +246,8 @@ func (r *PricingResolver) Resolve(
 
 // ResolveAt applies custom pricing matched from the reported or canonical
 // model, then the timestamp-aware GenAI Prices document, then the existing
-// LiteLLM/OpenRouter rows. An exact custom rate for the reported model still
-// takes precedence over caller-supplied canonicalization.
+// LiteLLM/OpenRouter/OrcaRouter rows. An exact custom rate for the reported
+// model still takes precedence over caller-supplied canonicalization.
 func (r *PricingResolver) ResolveAt(
 	reportedModel, canonicalModel string, timestamp time.Time,
 ) (string, PricingLookup) {

--- a/internal/pricing/catalog/openrouter.go
+++ b/internal/pricing/catalog/openrouter.go
@@ -28,24 +28,33 @@ func FetchOpenRouterPricingContext(
 func fetchOpenRouterPricing(
 	ctx context.Context, client *http.Client, url string,
 ) ([]ModelPricing, error) {
+	return fetchPricingCatalog(ctx, client, url)
+}
+
+// fetchPricingCatalog downloads an OpenRouter-shaped model catalog at url and
+// parses it into ModelPricing entries. OpenRouter and OrcaRouter publish the
+// same envelope and price fields, so the two sources share this fetch path.
+func fetchPricingCatalog(
+	ctx context.Context, client *http.Client, url string,
+) ([]ModelPricing, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating openrouter pricing request: %w", err)
+		return nil, fmt.Errorf("creating catalog pricing request: %w", err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetching openrouter pricing: %w", err)
+		return nil, fmt.Errorf("fetching model catalog pricing: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
-			"fetching openrouter pricing: status %d", resp.StatusCode,
+			"fetching model catalog pricing: status %d", resp.StatusCode,
 		)
 	}
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading openrouter response: %w", err)
+		return nil, fmt.Errorf("reading model catalog response: %w", err)
 	}
 	return ParseOpenRouterPricing(data)
 }

--- a/internal/pricing/catalog/orcarouter.go
+++ b/internal/pricing/catalog/orcarouter.go
@@ -1,0 +1,21 @@
+package catalog
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// orcarouterURL is OrcaRouter's public model list. Like OpenRouter's catalog
+// it needs no auth and returns every proxied model with its per-token
+// prompt/completion price in the same envelope.
+const orcarouterURL = "https://api.orcarouter.ai/v1/models"
+
+// FetchOrcaRouterPricingContext downloads the OrcaRouter model catalog and
+// binds the request lifetime to ctx.
+func FetchOrcaRouterPricingContext(
+	ctx context.Context,
+) ([]ModelPricing, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	return fetchPricingCatalog(ctx, client, orcarouterURL)
+}

--- a/internal/pricing/catalog/orcarouter_test.go
+++ b/internal/pricing/catalog/orcarouter_test.go
@@ -1,0 +1,95 @@
+package catalog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+func TestParseOrcaRouterPricing(t *testing.T) {
+	data := []byte(`{
+		"data": [
+			{
+				"id": "orcarouter/fusion",
+				"pricing": {
+					"prompt": "0.000010",
+					"completion": "0.000050",
+					"prompt_per_million": "10.000000",
+					"completion_per_million": "50.000000"
+				}
+			},
+			{
+				"id": "anthropic/claude-fable-5",
+				"pricing": {"prompt": "0.000005", "completion": "0.000025"}
+			},
+			{
+				"id": "orcarouter/free",
+				"pricing": {"prompt": "0", "completion": "0"}
+			},
+			{
+				"id": "orcarouter/unpriced",
+				"pricing": {"prompt": "", "completion": ""}
+			}
+		]
+	}`)
+
+	prices, err := ParseOpenRouterPricing(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, []ModelPricing{
+		{
+			ModelPattern:  "orcarouter/fusion",
+			InputPerMTok:  money.Money{Microdollars: 10_000_000},
+			OutputPerMTok: money.Money{Microdollars: 50_000_000},
+		},
+		{
+			ModelPattern:  "anthropic/claude-fable-5",
+			InputPerMTok:  money.Money{Microdollars: 5_000_000},
+			OutputPerMTok: money.Money{Microdollars: 25_000_000},
+		},
+		{ModelPattern: "orcarouter/free"},
+	}, prices, "priced entries kept, unpriced entries skipped; "+
+		"prompt_per_million fields are ignored")
+}
+
+func TestFetchOrcaRouterPricing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, r *http.Request,
+	) {
+		assert.Equal(t, "GET", r.Method)
+		_, _ = w.Write([]byte(`{"data": [{
+			"id": "orcarouter/fusion",
+			"pricing": {"prompt": "0.000010", "completion": "0.000050"}
+		}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	// FetchOrcaRouterPricingContext hits the live endpoint; exercise the
+	// shared fetch path (which it delegates to) against the fixture.
+	prices, err := fetchPricingCatalog(
+		context.Background(), server.Client(), server.URL,
+	)
+	require.NoError(t, err)
+	require.Len(t, prices, 1)
+	assert.Equal(t, "orcarouter/fusion", prices[0].ModelPattern)
+}
+
+func TestFetchOrcaRouterPricingRejectsErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := fetchPricingCatalog(
+		context.Background(), server.Client(), server.URL,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 503")
+}

--- a/internal/pricing/openrouter.go
+++ b/internal/pricing/openrouter.go
@@ -11,9 +11,12 @@ import (
 )
 
 // OpenRouterModelsMetaKey names the model_pricing sentinel row whose
-// updated_at holds the JSON list of patterns OpenRouter contributed to the
-// stored catalog. Refreshes use it to retire those rows once LiteLLM lists
-// the same model, and push targets use it to mirror that retirement.
+// updated_at holds the JSON list of patterns the online marketplace sources
+// (OpenRouter and OrcaRouter) contributed to the stored catalog. Refreshes use
+// it to retire those rows once LiteLLM lists the same model, and push targets
+// use it to mirror that retirement. The key keeps its historical name even
+// though it now tracks OrcaRouter-owned rows alongside OpenRouter-owned rows,
+// so databases written before OrcaRouter was added keep their sentinel.
 const OpenRouterModelsMetaKey = "_openrouter_models"
 
 // FetchOpenRouterPricingContext downloads the OpenRouter model catalog and
@@ -30,16 +33,34 @@ func ParseOpenRouterPricing(data []byte) ([]ModelPricing, error) {
 	return catalog.ParseOpenRouterPricing(data)
 }
 
-// Catalog is one refresh result from the GenAI Prices, LiteLLM, and OpenRouter
-// upstream sources. Reconcile merges the flat fallback rows over storage.
+// FetchOrcaRouterPricingContext downloads the OrcaRouter model catalog and
+// binds the request lifetime to ctx.
+func FetchOrcaRouterPricingContext(
+	ctx context.Context,
+) ([]ModelPricing, error) {
+	return catalog.FetchOrcaRouterPricingContext(ctx)
+}
+
+// ParseOrcaRouterPricing parses the OrcaRouter /models JSON into
+// ModelPricing entries. OrcaRouter publishes the same envelope and price
+// fields as OpenRouter, so parsing is shared with that source.
+func ParseOrcaRouterPricing(data []byte) ([]ModelPricing, error) {
+	return catalog.ParseOpenRouterPricing(data)
+}
+
+// Catalog is one refresh result from the GenAI Prices, LiteLLM, OpenRouter,
+// and OrcaRouter upstream sources. Reconcile merges the flat fallback rows
+// over storage.
 type Catalog struct {
 	GenAI      *GenAIDocument
 	LiteLLM    []ModelPricing
 	OpenRouter []ModelPricing
+	OrcaRouter []ModelPricing
 }
 
-// FetchCatalog fetches GenAI Prices first, followed by LiteLLM and OpenRouter.
-// Successful earlier sources remain available when a later source fails.
+// FetchCatalog fetches GenAI Prices first, followed by LiteLLM, OpenRouter,
+// and OrcaRouter. Successful earlier sources remain available when a later
+// source fails.
 func FetchCatalog() (Catalog, error) {
 	return FetchCatalogContext(context.Background())
 }
@@ -51,13 +72,15 @@ func FetchCatalogContext(ctx context.Context) (Catalog, error) {
 		FetchGenAIPricesContext,
 		FetchLiteLLMPricingContext,
 		FetchOpenRouterPricingContext,
+		FetchOrcaRouterPricingContext,
 	)
 }
 
 func fetchCatalog(
 	ctx context.Context,
 	fetchGenAI func(context.Context) (*GenAIPrices, error),
-	fetchLiteLLM, fetchOpenRouter func(context.Context) ([]ModelPricing, error),
+	fetchLiteLLM, fetchOpenRouter,
+	fetchOrcaRouter func(context.Context) ([]ModelPricing, error),
 ) (Catalog, error) {
 	var result Catalog
 	var warnings []error
@@ -93,30 +116,43 @@ func fetchCatalog(
 	} else {
 		result.OpenRouter = openrouter
 	}
+	orcarouter, orcaRouterErr := fetchOrcaRouter(ctx)
+	if orcaRouterErr != nil {
+		warnings = append(warnings, fmt.Errorf(
+			"fetching orcarouter catalog (storing litellm rates only): %w",
+			orcaRouterErr,
+		))
+	} else {
+		result.OrcaRouter = orcarouter
+	}
 	return result, errors.Join(warnings...)
 }
 
 // Reconcile merges the catalog over a stored table and returns the rows to
-// store, the OpenRouter ownership list to record, and the stored patterns
-// to delete. stored lists every stored model pattern; previous lists the
-// patterns an earlier refresh took from OpenRouter.
+// store, the online-marketplace ownership list to record, and the stored
+// patterns to delete. stored lists every stored model pattern; previous lists
+// the patterns an earlier refresh took from the online marketplace sources.
 //
-// An OpenRouter row is dropped when the LiteLLM catalog or a stored row
-// from another source (LiteLLM, embedded, supplemental) already lists a
-// model with the same canonical name under any spelling or provider
-// prefix, so adding OpenRouter never changes a lookup that already
-// resolved: two provider-qualified spellings of one model (LiteLLM's
-// openrouter/openai/gpt-x against OpenRouter's openai/gpt-x) would
-// otherwise tie in the resolver and leave a bare session model name
-// unpriced. The cost is that a session naming the OpenRouter id exactly
-// stays unpriced in that case, as it did before. Rows are copied whole; a
-// zero rate is a valid price for free models, so fields are never
-// backfilled across sources.
+// An online-marketplace row (OpenRouter or OrcaRouter) is dropped when the
+// LiteLLM catalog or a stored row from another source (LiteLLM, embedded,
+// supplemental) already lists a model with the same canonical name under any
+// spelling or provider prefix, so adding a marketplace source never changes a
+// lookup that already resolved: two provider-qualified spellings of one model
+// (LiteLLM's openrouter/openai/gpt-x against OpenRouter's openai/gpt-x) would
+// otherwise tie in the resolver and leave a bare session model name unpriced.
+// The cost is that a session naming the marketplace id exactly stays unpriced
+// in that case, as it did before. Rows are copied whole; a zero rate is a valid
+// price for free models, so fields are never backfilled across sources.
 //
-// Of the previously stored OpenRouter rows, those the merged catalog or a
-// stored row from another source now covers under a different spelling
-// are retired (they would tie with the replacement), those the catalog
-// lists exactly follow the catalog's ownership, and rows OpenRouter merely
+// OrcaRouter is reconciled after OpenRouter and outranks nothing: an OrcaRouter
+// row is dropped when OpenRouter already lists the same canonical model, so the
+// two marketplace sources never store duplicate spellings of one model. Both
+// sources feed the same ownership list.
+//
+// Of the previously stored marketplace rows, those the merged catalog or a
+// stored row from another source now covers under a different spelling are
+// retired (they would tie with the replacement), those the catalog lists
+// exactly follow the catalog's ownership, and rows the marketplace merely
 // delisted stay stored and tracked so past sessions keep their price.
 func (c Catalog) Reconcile(
 	stored, previous []string,
@@ -130,19 +166,10 @@ func (c Catalog) Reconcile(
 			covering = append(covering, pattern)
 		}
 	}
-	candidates := make([]string, len(c.OpenRouter))
-	for i, p := range c.OpenRouter {
-		candidates[i] = p.ModelPattern
-	}
-	dropped := CoveredPatterns(covering, candidates)
 	prices = c.LiteLLM
-	for _, p := range c.OpenRouter {
-		if slices.Contains(dropped, p.ModelPattern) {
-			continue
-		}
-		prices = append(prices, p)
-		owned = append(owned, p.ModelPattern)
-	}
+	coveringWithOpenRouter := append(slices.Clone(covering),
+		reconcileMarketplace(c.OpenRouter, covering, &prices, &owned)...)
+	reconcileMarketplace(c.OrcaRouter, coveringWithOpenRouter, &prices, &owned)
 
 	listed := make([]string, 0, len(prices))
 	for _, p := range prices {
@@ -157,6 +184,32 @@ func (c Catalog) Reconcile(
 	}
 	slices.Sort(owned)
 	return prices, slices.Compact(owned), retired
+}
+
+// reconcileMarketplace appends the source rows that no covering pattern
+// shadows to prices and owned, and returns the patterns it kept so a later
+// marketplace source can be outranked by them.
+func reconcileMarketplace(
+	rows []ModelPricing,
+	covering []string,
+	prices *[]ModelPricing,
+	owned *[]string,
+) []string {
+	candidates := make([]string, len(rows))
+	for i, p := range rows {
+		candidates[i] = p.ModelPattern
+	}
+	dropped := CoveredPatterns(covering, candidates)
+	var kept []string
+	for _, p := range rows {
+		if slices.Contains(dropped, p.ModelPattern) {
+			continue
+		}
+		*prices = append(*prices, p)
+		*owned = append(*owned, p.ModelPattern)
+		kept = append(kept, p.ModelPattern)
+	}
+	return kept
 }
 
 // CoveredPatterns returns the candidates whose canonical model name some

--- a/internal/pricing/openrouter_test.go
+++ b/internal/pricing/openrouter_test.go
@@ -29,9 +29,13 @@ func TestFetchCatalogDegradesWhenOpenRouterFails(t *testing.T) {
 	fetchOpenRouter := func(context.Context) ([]ModelPricing, error) {
 		return nil, openrouterErr
 	}
+	fetchOrcaRouter := func(context.Context) ([]ModelPricing, error) {
+		return nil, nil
+	}
 
 	catalog, err := fetchCatalog(
 		context.Background(), noGenAIPricing, fetchLiteLLM, fetchOpenRouter,
+		fetchOrcaRouter,
 	)
 
 	assert.ErrorIs(t, err, openrouterErr)
@@ -48,13 +52,46 @@ func TestFetchCatalogFailsWhenLiteLLMFails(t *testing.T) {
 		t.Fatal("openrouter must not be fetched after a litellm failure")
 		return nil, nil
 	}
+	fetchOrcaRouter := func(context.Context) ([]ModelPricing, error) {
+		t.Fatal("orcarouter must not be fetched after a litellm failure")
+		return nil, nil
+	}
 
 	catalog, err := fetchCatalog(
 		context.Background(), noGenAIPricing, fetchLiteLLM, fetchOpenRouter,
+		fetchOrcaRouter,
 	)
 
 	assert.ErrorIs(t, err, litellmErr)
 	assert.Equal(t, Catalog{}, catalog)
+}
+
+func TestFetchCatalogDegradesWhenOrcaRouterFails(t *testing.T) {
+	litellm := []ModelPricing{
+		{ModelPattern: "acme/model", InputPerMTok: rate("1")},
+	}
+	openrouter := []ModelPricing{
+		{ModelPattern: "openai/gpt-x", InputPerMTok: rate("4")},
+	}
+	fetchLiteLLM := func(context.Context) ([]ModelPricing, error) {
+		return litellm, nil
+	}
+	fetchOpenRouter := func(context.Context) ([]ModelPricing, error) {
+		return openrouter, nil
+	}
+	orcaRouterErr := errors.New("orcarouter down")
+	fetchOrcaRouter := func(context.Context) ([]ModelPricing, error) {
+		return nil, orcaRouterErr
+	}
+
+	catalog, err := fetchCatalog(
+		context.Background(), noGenAIPricing, fetchLiteLLM, fetchOpenRouter,
+		fetchOrcaRouter,
+	)
+
+	assert.ErrorIs(t, err, orcaRouterErr)
+	assert.Equal(t, Catalog{LiteLLM: litellm, OpenRouter: openrouter}, catalog,
+		"LiteLLM and OpenRouter rows survive an OrcaRouter outage")
 }
 
 func TestCatalogReconcile(t *testing.T) {
@@ -100,6 +137,35 @@ func TestCatalogReconcile(t *testing.T) {
 	price, ok = Resolve(byPattern, "only-openrouter")
 	require.True(t, ok, "OpenRouter-only model resolves by bare name")
 	assert.Equal(t, rate("7"), price.InputPerMTok)
+}
+
+func TestCatalogReconcileOrcaRouterOutrankedByOpenRouter(t *testing.T) {
+	c := Catalog{
+		OpenRouter: []ModelPricing{
+			{ModelPattern: "openai/gpt-x", InputPerMTok: rate("4")},
+			{ModelPattern: "acme/only-openrouter", InputPerMTok: rate("7")},
+		},
+		OrcaRouter: []ModelPricing{
+			// Same canonical model as an OpenRouter row: OpenRouter wins.
+			{ModelPattern: "openai/gpt-x", InputPerMTok: rate("9")},
+			// Same canonical model under a provider prefix: covered.
+			{ModelPattern: "openai/GPT-X", InputPerMTok: rate("8")},
+			// Only OrcaRouter lists this model: it is stored and owned.
+			{ModelPattern: "orcarouter/fusion", InputPerMTok: rate("3")},
+		},
+	}
+
+	prices, owned, retired := c.Reconcile(nil, nil)
+
+	assert.Equal(t, []ModelPricing{
+		{ModelPattern: "openai/gpt-x", InputPerMTok: rate("4")},
+		{ModelPattern: "acme/only-openrouter", InputPerMTok: rate("7")},
+		{ModelPattern: "orcarouter/fusion", InputPerMTok: rate("3")},
+	}, prices)
+	assert.Equal(t, []string{
+		"acme/only-openrouter", "openai/gpt-x", "orcarouter/fusion",
+	}, owned)
+	assert.Empty(t, retired)
 }
 
 func TestCatalogReconcileRetiresShadowedPrevious(t *testing.T) {

--- a/internal/pricingrefresh/refresh.go
+++ b/internal/pricingrefresh/refresh.go
@@ -278,7 +278,7 @@ func runCurrent(
 
 // storeCatalog reconciles a fetched catalog with the stored table (see
 // pricing.Catalog.Reconcile) and writes rows, retirements, and the
-// OpenRouter ownership sentinel in one transaction, so a crash or a
+// online-marketplace ownership sentinel in one transaction, so a crash or a
 // concurrent push never sees rows without the metadata that retires them.
 //
 // The sentinel and stored patterns are read before that transaction, and
@@ -300,7 +300,9 @@ func storeCatalog(database *db.DB, catalog pricing.Catalog) error {
 			return err
 		}
 	}
-	if len(catalog.LiteLLM) == 0 && len(catalog.OpenRouter) == 0 {
+	if len(catalog.LiteLLM) == 0 &&
+		len(catalog.OpenRouter) == 0 &&
+		len(catalog.OrcaRouter) == 0 {
 		return nil
 	}
 	value, err := database.GetPricingMeta(pricing.OpenRouterModelsMetaKey)


### PR DESCRIPTION
Add OrcaRouter's model catalog as a first-class pricing source, mirroring the existing OpenRouter integration. AgentsView already merges LiteLLM, OpenRouter, and the embedded fallback into the `model_pricing` table; OrcaRouter joins that set so sessions that route through OrcaRouter get accurate per-token costs. OrcaRouter publishes the same OpenRouter-shaped catalog envelope, so the fetch and parse paths are shared, and its rows are reconciled into the same marketplace ownership sentinel to keep the resolver free of duplicate spellings.

Like OpenRouter, OrcaRouter is an OpenAI-compatible AI gateway exposing a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance on the same endpoint, plus gateway-level zero-trust security that screens every prompt/response and governs tool calls on a default-deny basis with no application changes. [OrcaRouter](https://www.orcarouter.ai)

Verified: `go test ./internal/pricing/... ./internal/pricingrefresh/... ./internal/db/... ./internal/export/...` all pass, and a live fetch of `https://api.orcarouter.ai/v1/models` returns 167 priced models through the shared parser.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.