### PR TITLE
feat(frontend): use the standard kit-ui splitter and make the analysis panel resizable

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1320,6 +1320,7 @@
   "session_vitals_title": "Analysis",
   "session_vitals_subtitle": "Session vital signs",
   "session_vitals_close": "Close session analysis",
+  "session_vitals_resize": "Resize session analysis panel",
   "session_vitals_session": "Session",
   "session_vitals_repository": "Repository",
   "session_vitals_worktree": "Worktree",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1320,6 +1320,7 @@
   "session_vitals_title": "Analyse",
   "session_vitals_subtitle": "Signes vitaux de la session",
   "session_vitals_close": "Fermer l'analyse de la session",
+  "session_vitals_resize": "Redimensionner le panneau d'analyse de la session",
   "session_vitals_session": "Session",
   "session_vitals_repository": "Dépôt",
   "session_vitals_worktree": "Arbre de travail",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1485,6 +1485,7 @@
   "session_vitals_title": "分析",
   "session_vitals_subtitle": "セッションのバイタルサイン",
   "session_vitals_close": "セッション分析を閉じる",
+  "session_vitals_resize": "セッション分析パネルのサイズを変更する",
   "session_vitals_session": "セッション",
   "session_vitals_repository": "リポジトリ",
   "session_vitals_worktree": "ワークツリー",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -1263,6 +1263,7 @@
   "session_vitals_title": "분석",
   "session_vitals_subtitle": "세션 바이탈 사인",
   "session_vitals_close": "세션 분석 닫기",
+  "session_vitals_resize": "세션 분석 패널 크기 조정",
   "session_vitals_session": "세션",
   "session_vitals_repository": "저장소",
   "session_vitals_worktree": "작업 트리",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1261,6 +1261,7 @@
   "session_vitals_title": "分析",
   "session_vitals_subtitle": "会话指标",
   "session_vitals_close": "关闭会话分析",
+  "session_vitals_resize": "调整会话分析面板大小",
   "session_vitals_session": "会话",
   "session_vitals_repository": "存储库",
   "session_vitals_worktree": "工作树",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -1261,6 +1261,7 @@
   "session_vitals_title": "分析",
   "session_vitals_subtitle": "對話指標",
   "session_vitals_close": "關閉對話分析",
+  "session_vitals_resize": "調整對話分析面板大小",
   "session_vitals_session": "對話",
   "session_vitals_repository": "儲存庫",
   "session_vitals_worktree": "工作樹",

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
@@ -10,7 +10,11 @@
     SIDEBAR_WIDTH_DEFAULT,
     SIDEBAR_WIDTH_MIN,
     SIDEBAR_WIDTH_STORAGE_MAX,
+    VITALS_WIDTH_DEFAULT,
+    VITALS_WIDTH_MIN,
+    VITALS_WIDTH_STORAGE_MAX,
     clampSidebarWidthForLayout,
+    clampVitalsWidthForLayout,
     isDesktopSidebarLayout,
   } from "./sidebar-width.js";
   import { ui } from "../../stores/ui.svelte.js";
@@ -49,6 +53,7 @@
       : window.innerWidth,
   );
   let resizeStartWidth = 0;
+  let vitalsResizeStartWidth = 0;
 
   const isDesktop = $derived(
     isDesktopSidebarLayout(viewportWidth),
@@ -74,6 +79,33 @@
         )
       : SIDEBAR_WIDTH_DEFAULT,
   );
+  const vitalsAvailableWidth = $derived(
+    vitalsLayoutWidth(currentLayoutWidth),
+  );
+  const vitalsWidth = $derived(
+    isDesktop
+      ? clampVitalsWidthForLayout(
+          ui.vitalsWidth,
+          vitalsAvailableWidth,
+        )
+      : VITALS_WIDTH_DEFAULT,
+  );
+
+  // Width left for the content column and vitals panel once the sidebar,
+  // its handle, and the pane borders are spoken for.
+  function vitalsLayoutWidth(layoutWidthNow: number): number {
+    const sidebarTotalWidth = ui.sidebarOpen
+      ? sidebarWidth + RESIZE_HANDLE_WIDTH + SIDEBAR_BORDER_WIDTH
+      : 0;
+
+    return Math.max(
+      0,
+      layoutWidthNow -
+        sidebarTotalWidth -
+        RESIZE_HANDLE_WIDTH -
+        SIDEBAR_BORDER_WIDTH,
+    );
+  }
   function handleBackdropClick() {
     ui.closeSidebar();
   }
@@ -117,6 +149,22 @@
     // stored preference survives drags inside the same clamp.
     if (clampedWidth === sidebarWidth) return;
     ui.setSidebarWidth(clampedWidth);
+  }
+
+  function handleVitalsResizeStart() {
+    vitalsResizeStartWidth = vitalsWidth;
+  }
+
+  function handleVitalsResize(event: SplitResizeEvent) {
+    // The handle sits on the panel's left edge, so moving it left (negative
+    // delta) widens the panel.
+    const clampedWidth = clampVitalsWidthForLayout(
+      vitalsResizeStartWidth - event.delta,
+      vitalsLayoutWidth(measureLayoutWidth()),
+    );
+
+    if (clampedWidth === vitalsWidth) return;
+    ui.setVitalsWidth(clampedWidth);
   }
 
   $effect(() => {
@@ -265,7 +313,16 @@
   </main>
 
   {#if vitals && isDesktop && ui.vitalsOpen && sessions.activeSessionId}
-    <aside class="vitals">
+    <SplitResizeHandle
+      ariaLabel={m.session_vitals_resize()}
+      ariaValueMin={VITALS_WIDTH_MIN}
+      ariaValueMax={VITALS_WIDTH_STORAGE_MAX}
+      ariaValueNow={vitalsWidth}
+      onResizeStart={handleVitalsResizeStart}
+      onResize={handleVitalsResize}
+      onResizeEnd={handleVitalsResize}
+    />
+    <aside class="vitals" style:width={`${vitalsWidth}px`}>
       {@render vitals()}
     </aside>
   {/if}
@@ -304,7 +361,6 @@
   }
 
   .vitals {
-    width: 320px;
     flex-shrink: 0;
     border-left: 1px solid var(--border-default);
     overflow: hidden;

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
@@ -61,23 +61,42 @@
   const currentLayoutWidth = $derived(
     layoutWidth ?? viewportWidth,
   );
-  const clampedLayoutWidth = $derived(
-    isDesktop
-      ? Math.max(
-          0,
-          currentLayoutWidth -
-            RESIZE_HANDLE_WIDTH -
-            SIDEBAR_BORDER_WIDTH,
-        )
-      : currentLayoutWidth,
+  const vitalsVisible = $derived(
+    Boolean(vitals) &&
+      isDesktop &&
+      ui.vitalsOpen &&
+      sessions.activeSessionId !== null,
   );
+  // The two panes share one width budget with the content column. When space
+  // runs out, pane minimums win, then the content minimum, then preferred
+  // widths: the sidebar clamp reserves the vitals panel's minimum footprint,
+  // and the vitals clamp yields whatever the actual sidebar leaves over.
+  function sidebarLayoutWidth(layoutWidthNow: number): number {
+    const vitalsReservedWidth = vitalsVisible
+      ? VITALS_WIDTH_MIN + RESIZE_HANDLE_WIDTH + SIDEBAR_BORDER_WIDTH
+      : 0;
+
+    return Math.max(
+      0,
+      layoutWidthNow -
+        RESIZE_HANDLE_WIDTH -
+        SIDEBAR_BORDER_WIDTH -
+        vitalsReservedWidth,
+    );
+  }
   const sidebarWidth = $derived(
     isDesktop
       ? clampSidebarWidthForLayout(
           ui.sidebarWidth,
-          clampedLayoutWidth,
+          sidebarLayoutWidth(currentLayoutWidth),
         )
       : SIDEBAR_WIDTH_DEFAULT,
+  );
+  const sidebarMaxWidth = $derived(
+    clampSidebarWidthForLayout(
+      SIDEBAR_WIDTH_STORAGE_MAX,
+      sidebarLayoutWidth(currentLayoutWidth),
+    ),
   );
   const vitalsAvailableWidth = $derived(
     vitalsLayoutWidth(currentLayoutWidth),
@@ -89,6 +108,12 @@
           vitalsAvailableWidth,
         )
       : VITALS_WIDTH_DEFAULT,
+  );
+  const vitalsMaxWidth = $derived(
+    clampVitalsWidthForLayout(
+      VITALS_WIDTH_STORAGE_MAX,
+      vitalsAvailableWidth,
+    ),
   );
 
   // Width left for the content column and vitals panel once the sidebar,
@@ -137,12 +162,7 @@
   function handleResize(event: SplitResizeEvent) {
     const clampedWidth = clampSidebarWidthForLayout(
       resizeStartWidth + event.delta,
-      Math.max(
-        0,
-        measureLayoutWidth() -
-          RESIZE_HANDLE_WIDTH -
-          SIDEBAR_BORDER_WIDTH,
-      ),
+      sidebarLayoutWidth(measureLayoutWidth()),
     );
 
     // Skip persisting when the clamp lands on the rendered width so a wider
@@ -300,7 +320,7 @@
     <SplitResizeHandle
       ariaLabel={m.nav_resize_sidebar()}
       ariaValueMin={SIDEBAR_WIDTH_MIN}
-      ariaValueMax={SIDEBAR_WIDTH_STORAGE_MAX}
+      ariaValueMax={sidebarMaxWidth}
       ariaValueNow={sidebarWidth}
       onResizeStart={handleResizeStart}
       onResize={handleResize}
@@ -312,18 +332,18 @@
     {@render content()}
   </main>
 
-  {#if vitals && isDesktop && ui.vitalsOpen && sessions.activeSessionId}
+  {#if vitalsVisible}
     <SplitResizeHandle
       ariaLabel={m.session_vitals_resize()}
       ariaValueMin={VITALS_WIDTH_MIN}
-      ariaValueMax={VITALS_WIDTH_STORAGE_MAX}
+      ariaValueMax={vitalsMaxWidth}
       ariaValueNow={vitalsWidth}
       onResizeStart={handleVitalsResizeStart}
       onResize={handleVitalsResize}
       onResizeEnd={handleVitalsResize}
     />
     <aside class="vitals" style:width={`${vitalsWidth}px`}>
-      {@render vitals()}
+      {@render vitals?.()}
     </aside>
   {/if}
 </div>

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
+  import {
+    SplitResizeHandle,
+    type SplitResizeEvent,
+  } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import {
     SIDEBAR_DESKTOP_BREAKPOINT,
@@ -32,25 +36,19 @@
     vitals?: Snippet;
   }
 
-  const RESIZE_HANDLE_WIDTH = 12;
+  // Rendered width of kit-ui's .kit-split-resize-handle.
+  const RESIZE_HANDLE_WIDTH = 4;
   const SIDEBAR_BORDER_WIDTH = 1;
 
   let { sidebar, content, vitals }: Props = $props();
   let layoutElement = $state<HTMLElement | null>(null);
-  let resizeHandleElement = $state<HTMLElement | null>(null);
   let layoutWidth = $state<number | null>(null);
   let viewportWidth = $state(
     typeof window === "undefined"
       ? SIDEBAR_DESKTOP_BREAKPOINT
       : window.innerWidth,
   );
-  let isResizing = $state(false);
-  let dragState = $state<{
-    startX: number;
-    startWidth: number;
-  } | null>(null);
-  let didDragMove = $state(false);
-  let activePointerId = $state<number | null>(null);
+  let resizeStartWidth = 0;
 
   const isDesktop = $derived(
     isDesktopSidebarLayout(viewportWidth),
@@ -100,13 +98,13 @@
     return nextLayoutWidth;
   }
 
-  function updateSidebarWidth(clientX: number) {
-    if (!dragState) return;
+  function handleResizeStart() {
+    resizeStartWidth = sidebarWidth;
+  }
 
-    const desiredWidth =
-      dragState.startWidth + (clientX - dragState.startX);
+  function handleResize(event: SplitResizeEvent) {
     const clampedWidth = clampSidebarWidthForLayout(
-      desiredWidth,
+      resizeStartWidth + event.delta,
       Math.max(
         0,
         measureLayoutWidth() -
@@ -115,122 +113,10 @@
       ),
     );
 
+    // Skip persisting when the clamp lands on the rendered width so a wider
+    // stored preference survives drags inside the same clamp.
     if (clampedWidth === sidebarWidth) return;
     ui.setSidebarWidth(clampedWidth);
-  }
-
-  function isActiveDragPointer(event: PointerEvent) {
-    return (
-      activePointerId === null ||
-      event.pointerId === activePointerId
-    );
-  }
-
-  function stopResizing() {
-    if (
-      resizeHandleElement &&
-      activePointerId !== null &&
-      typeof resizeHandleElement.releasePointerCapture ===
-        "function"
-    ) {
-      try {
-        resizeHandleElement.releasePointerCapture(
-          activePointerId,
-        );
-      } catch {
-        // Ignore release failures when capture is absent.
-      }
-    }
-
-    if (typeof window !== "undefined") {
-      window.removeEventListener(
-        "pointermove",
-        handlePointerMove,
-      );
-      window.removeEventListener(
-        "pointerup",
-        handlePointerUp,
-      );
-      window.removeEventListener(
-        "pointercancel",
-        handlePointerCancel,
-      );
-    }
-
-    isResizing = false;
-    dragState = null;
-    didDragMove = false;
-    activePointerId = null;
-  }
-
-  function handlePointerMove(event: PointerEvent) {
-    if (!dragState) return;
-    if (!isActiveDragPointer(event)) return;
-
-    if (event.buttons === 0) {
-      stopResizing();
-      return;
-    }
-
-    const hasMoved =
-      didDragMove || event.clientX !== dragState.startX;
-    if (!hasMoved) return;
-
-    event.preventDefault();
-    didDragMove = true;
-    updateSidebarWidth(event.clientX);
-  }
-
-  function handlePointerUp(event: PointerEvent) {
-    if (!dragState || !isActiveDragPointer(event)) return;
-
-    if (didDragMove) {
-      updateSidebarWidth(event.clientX);
-    }
-
-    stopResizing();
-  }
-
-  function handlePointerCancel(event: PointerEvent) {
-    if (!dragState || !isActiveDragPointer(event)) return;
-    stopResizing();
-  }
-
-  function handlePointerDown(event: PointerEvent) {
-    if (!isDesktop || !ui.sidebarOpen || dragState || event.button !== 0) {
-      return;
-    }
-
-    event.preventDefault();
-    dragState = {
-      startX: event.clientX,
-      startWidth: sidebarWidth,
-    };
-    didDragMove = false;
-    activePointerId =
-      typeof event.pointerId === "number"
-        ? event.pointerId
-        : null;
-    isResizing = true;
-
-    if (
-      resizeHandleElement &&
-      activePointerId !== null &&
-      typeof resizeHandleElement.setPointerCapture ===
-        "function"
-    ) {
-      try {
-        resizeHandleElement.setPointerCapture(
-          activePointerId,
-        );
-      } catch {
-        // Ignore capture failures and keep window listeners as fallback.
-      }
-    }
-
-    window.addEventListener("pointermove", handlePointerMove);
-    window.addEventListener("pointerup", handlePointerUp);
-    window.addEventListener("pointercancel", handlePointerCancel);
   }
 
   $effect(() => {
@@ -258,39 +144,11 @@
     };
   });
 
-  $effect(() => {
-    return () => {
-      stopResizing();
-    };
-  });
-
-  $effect(() => {
-    if ((!isDesktop || !ui.sidebarOpen) && isResizing) {
-      stopResizing();
-    }
-  });
-
-  $effect(() => {
-    if (typeof document === "undefined") return;
-
-    document.body.classList.toggle(
-      "sidebar-resizing",
-      isResizing,
-    );
-
-    return () => {
-      document.body.classList.remove("sidebar-resizing");
-    };
-  });
 </script>
 
 <svelte:window bind:innerWidth={viewportWidth} />
 
-<div
-  class="layout"
-  class:is-resizing={isResizing}
-  bind:this={layoutElement}
->
+<div class="layout" bind:this={layoutElement}>
   {#if ui.isMobileViewport && ui.sidebarOpen}
     <button
       class="sidebar-backdrop"
@@ -391,19 +249,15 @@
   </aside>
 
   {#if isDesktop && ui.sidebarOpen}
-    <div
-      class="resize-handle"
-      bind:this={resizeHandleElement}
-      data-testid="sidebar-resize-handle"
-      role="separator"
-      aria-label={m.nav_resize_sidebar()}
-      aria-orientation="vertical"
-      aria-valuemin={SIDEBAR_WIDTH_MIN}
-      aria-valuemax={SIDEBAR_WIDTH_STORAGE_MAX}
-      aria-valuenow={sidebarWidth}
-      onpointerdown={handlePointerDown}
-      style:width={`${RESIZE_HANDLE_WIDTH}px`}
-    ></div>
+    <SplitResizeHandle
+      ariaLabel={m.nav_resize_sidebar()}
+      ariaValueMin={SIDEBAR_WIDTH_MIN}
+      ariaValueMax={SIDEBAR_WIDTH_STORAGE_MAX}
+      ariaValueNow={sidebarWidth}
+      onResizeStart={handleResizeStart}
+      onResize={handleResize}
+      onResizeEnd={handleResize}
+    />
   {/if}
 
   <main class="content">
@@ -441,54 +295,6 @@
     display: none;
   }
 
-  .resize-handle {
-    position: relative;
-    flex-shrink: 0;
-    /* kit-ui-check-ignore: pointer-capture resizer with persisted width and test contract predates kit-ui SplitResizeHandle; swapping (and gaining keyboard resize) is tracked as a follow-up */
-    cursor: col-resize;
-    touch-action: none;
-    transition: background-color 120ms ease;
-  }
-
-  .resize-handle::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 50%;
-    width: 1px;
-    background: var(--border-default);
-    transform: translateX(-50%);
-  }
-
-  .resize-handle::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 3px;
-    height: 52px;
-    border-radius: 999px;
-    background: var(--text-muted);
-    opacity: 0.6;
-    transform: translate(-50%, -50%);
-    transition: opacity 120ms ease;
-  }
-
-  .resize-handle:hover,
-  .layout.is-resizing .resize-handle {
-    background: color-mix(
-      in srgb,
-      var(--accent-blue) 10%,
-      transparent
-    );
-  }
-
-  .resize-handle:hover::after,
-  .layout.is-resizing .resize-handle::after {
-    opacity: 1;
-  }
-
   .content {
     flex: 1;
     min-width: 0;
@@ -515,13 +321,6 @@
 
   .mobile-nav {
     display: none;
-  }
-
-  :global(body.sidebar-resizing) {
-    /* kit-ui-check-ignore: body-level drag cursor for the sidebar resizer above */
-    cursor: col-resize;
-    user-select: none;
-    -webkit-user-select: none;
   }
 
   @media (max-width: 760px) {

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.test.ts
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.test.ts
@@ -727,4 +727,51 @@ describe("ThreeColumnLayout", () => {
     );
     expect(ui.vitalsWidth).toBe(560);
   });
+
+  it("reserves the vitals minimum when widening the sidebar with both panes open", async () => {
+    setViewportWidth(1280);
+    ui.vitalsOpen = true;
+    sessions.activeSessionId = "session-1";
+    ui.setSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
+    ui.setVitalsWidth(320);
+
+    renderLayout(true);
+    await tick();
+
+    mockLayoutWidth(1280);
+
+    await dragHandle(
+      SIDEBAR_WIDTH_DEFAULT,
+      SIDEBAR_WIDTH_DEFAULT + 400,
+    );
+
+    // 1280 minus both 4px handles and both 1px pane borders leaves 990 for
+    // the sidebar clamp once the vitals minimum footprint (280 + 5) is
+    // reserved; the 480 content minimum caps the sidebar at 510 and the
+    // vitals panel yields to 280, keeping the content column at exactly 480.
+    expect(ui.sidebarWidth).toBe(510);
+    expect(getSidebar().style.width).toBe("510px");
+    expect(getVitalsPanel().style.width).toBe("280px");
+  });
+
+  it("keeps the content minimum when both stored pane widths are maxed", async () => {
+    setViewportWidth(1280);
+    ui.vitalsOpen = true;
+    sessions.activeSessionId = "session-1";
+    ui.setSidebarWidth(SIDEBAR_WIDTH_STORAGE_MAX);
+    ui.setVitalsWidth(560);
+
+    renderLayout(true);
+    await tick();
+
+    expect(getSidebar().style.width).toBe("510px");
+    expect(getVitalsPanel().style.width).toBe("280px");
+
+    // The separators advertise the layout-effective maxima, not the
+    // storage caps the current window cannot grant.
+    expect(getHandle()!.getAttribute("aria-valuemax")).toBe("510");
+    expect(
+      getVitalsHandle()!.getAttribute("aria-valuemax"),
+    ).toBe("280");
+  });
 });

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.test.ts
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.test.ts
@@ -15,10 +15,13 @@ import {
   SIDEBAR_WIDTH_DEFAULT,
   SIDEBAR_WIDTH_MIN,
   SIDEBAR_WIDTH_STORAGE_MAX,
+  VITALS_WIDTH_DEFAULT,
   clampSidebarWidthForLayout,
+  clampVitalsWidthForLayout,
 } from "./sidebar-width.js";
 import { ui } from "../../stores/ui.svelte.js";
 import { sync } from "../../stores/sync.svelte.js";
+import { sessions } from "../../stores/sessions.svelte.js";
 import { settings } from "../../stores/settings.svelte.js";
 
 const sidebarSnippet = createRawSnippet(() => ({
@@ -27,6 +30,10 @@ const sidebarSnippet = createRawSnippet(() => ({
 
 const contentSnippet = createRawSnippet(() => ({
   render: () => '<div data-testid="content-slot">Content</div>',
+}));
+
+const vitalsSnippet = createRawSnippet(() => ({
+  render: () => '<div data-testid="vitals-slot">Vitals</div>',
 }));
 
 // Rendered width of kit-ui's .kit-split-resize-handle.
@@ -48,12 +55,13 @@ function setViewportWidth(width: number) {
   window.dispatchEvent(new Event("resize"));
 }
 
-function renderLayout() {
+function renderLayout(withVitals = false) {
   component = mount(ThreeColumnLayout, {
     target: document.body,
     props: {
       sidebar: sidebarSnippet,
       content: contentSnippet,
+      ...(withVitals ? { vitals: vitalsSnippet } : {}),
     },
   });
   return component;
@@ -73,8 +81,20 @@ function getSidebar() {
 
 function getHandle() {
   return document.querySelector<HTMLElement>(
-    ".layout [role='separator']",
+    `[aria-label="${m.nav_resize_sidebar()}"]`,
   );
+}
+
+function getVitalsHandle() {
+  return document.querySelector<HTMLElement>(
+    `[aria-label="${m.session_vitals_resize()}"]`,
+  );
+}
+
+function getVitalsPanel() {
+  const panel = document.querySelector<HTMLElement>(".vitals");
+  expect(panel).not.toBeNull();
+  return panel!;
 }
 
 function getClampedSidebarWidthForLayout(
@@ -187,6 +207,9 @@ afterEach(() => {
   ui.sidebarOpen = true;
   ui.isMobileViewport = false;
   ui.setSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
+  ui.vitalsOpen = false;
+  ui.setVitalsWidth(VITALS_WIDTH_DEFAULT);
+  sessions.activeSessionId = null;
   sync.serverVersion = null;
   settings.loaded = false;
   settings.readOnly = false;
@@ -579,5 +602,129 @@ describe("ThreeColumnLayout", () => {
     await tick();
 
     expect(ui.sidebarWidth).toBe(SIDEBAR_WIDTH_DEFAULT);
+  });
+
+  it("renders a resizable vitals panel when open with an active session", async () => {
+    setViewportWidth(1280);
+    ui.vitalsOpen = true;
+    sessions.activeSessionId = "session-1";
+
+    renderLayout(true);
+    await tick();
+
+    expect(getVitalsHandle()).not.toBeNull();
+    expect(getVitalsPanel().style.width).toBe(
+      `${VITALS_WIDTH_DEFAULT}px`,
+    );
+  });
+
+  it("dragging the vitals handle left widens the panel and persists the width", async () => {
+    setViewportWidth(1280);
+    ui.vitalsOpen = true;
+    sessions.activeSessionId = "session-1";
+    ui.setVitalsWidth(VITALS_WIDTH_DEFAULT);
+
+    renderLayout(true);
+    await tick();
+
+    mockLayoutWidth(1280);
+
+    const handle = getVitalsHandle();
+    expect(handle).not.toBeNull();
+
+    handle!.dispatchEvent(pointerEvent("pointerdown", 900));
+    handle!.dispatchEvent(pointerEvent("pointermove", 820));
+    await tick();
+
+    expect(ui.vitalsWidth).toBe(VITALS_WIDTH_DEFAULT + 80);
+    expect(getVitalsPanel().style.width).toBe(
+      `${VITALS_WIDTH_DEFAULT + 80}px`,
+    );
+
+    handle!.dispatchEvent(pointerEvent("pointerup", 820));
+    await tick();
+
+    expect(ui.vitalsWidth).toBe(VITALS_WIDTH_DEFAULT + 80);
+  });
+
+  it("resizes the vitals panel from arrow keys, widening toward the content", async () => {
+    setViewportWidth(1280);
+    ui.vitalsOpen = true;
+    sessions.activeSessionId = "session-1";
+    ui.setVitalsWidth(VITALS_WIDTH_DEFAULT);
+
+    renderLayout(true);
+    await tick();
+
+    mockLayoutWidth(1280);
+
+    const handle = getVitalsHandle();
+    expect(handle).not.toBeNull();
+
+    handle!.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        key: "ArrowLeft",
+      }),
+    );
+    await tick();
+
+    expect(ui.vitalsWidth).toBe(
+      VITALS_WIDTH_DEFAULT + KEYBOARD_RESIZE_STEP,
+    );
+
+    handle!.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        key: "ArrowRight",
+      }),
+    );
+    await tick();
+
+    expect(ui.vitalsWidth).toBe(VITALS_WIDTH_DEFAULT);
+  });
+
+  it("clamps the vitals panel to the layout and keeps a wider stored preference", async () => {
+    const layoutWidth = 1100;
+    // Space left of the vitals panel: the sidebar, its handle, and both
+    // 1px pane borders plus the vitals handle.
+    const vitalsAvailable =
+      layoutWidth -
+      (SIDEBAR_WIDTH_DEFAULT +
+        RESIZE_HANDLE_WIDTH +
+        SIDEBAR_BORDER_WIDTH) -
+      RESIZE_HANDLE_WIDTH -
+      SIDEBAR_BORDER_WIDTH;
+    const expectedWidth = clampVitalsWidthForLayout(
+      560,
+      vitalsAvailable,
+    );
+
+    setViewportWidth(1280);
+    ui.vitalsOpen = true;
+    sessions.activeSessionId = "session-1";
+    ui.setVitalsWidth(560);
+    mockLayoutWidthOnRender(layoutWidth);
+
+    renderLayout(true);
+    await tick();
+
+    expect(getVitalsPanel().style.width).toBe(
+      `${expectedWidth}px`,
+    );
+
+    const handle = getVitalsHandle();
+    expect(handle).not.toBeNull();
+
+    handle!.dispatchEvent(pointerEvent("pointerdown", 900));
+    handle!.dispatchEvent(pointerEvent("pointermove", 780));
+    await tick();
+    handle!.dispatchEvent(pointerEvent("pointerup", 780));
+    await tick();
+
+    expect(getVitalsPanel().style.width).toBe(
+      `${expectedWidth}px`,
+    );
+    expect(ui.vitalsWidth).toBe(560);
   });
 });

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.test.ts
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.test.ts
@@ -29,8 +29,10 @@ const contentSnippet = createRawSnippet(() => ({
   render: () => '<div data-testid="content-slot">Content</div>',
 }));
 
-const RESIZE_HANDLE_WIDTH = 12;
+// Rendered width of kit-ui's .kit-split-resize-handle.
+const RESIZE_HANDLE_WIDTH = 4;
 const SIDEBAR_BORDER_WIDTH = 1;
+const KEYBOARD_RESIZE_STEP = 24;
 
 let component: ReturnType<typeof mount> | undefined;
 let restoreMeasuredLayoutWidth:
@@ -71,7 +73,7 @@ function getSidebar() {
 
 function getHandle() {
   return document.querySelector<HTMLElement>(
-    '[data-testid="sidebar-resize-handle"]',
+    ".layout [role='separator']",
   );
 }
 
@@ -151,52 +153,25 @@ function mockLayoutWidthOnRender(width: number) {
   };
 }
 
-function createPointerMouseEvent(
+function pointerEvent(
   type: string,
-  options: {
-    clientX: number;
-    buttons?: number;
-    pointerId: number;
-  },
+  clientX: number,
 ) {
-  const event = new MouseEvent(type, {
+  return new PointerEvent(type, {
     bubbles: true,
-    clientX: options.clientX,
-    buttons: options.buttons,
+    clientX,
+    pointerId: 1,
   });
-
-  Object.defineProperty(event, "pointerId", {
-    configurable: true,
-    value: options.pointerId,
-  });
-
-  return event;
 }
 
 async function dragHandle(startX: number, endX: number) {
   const handle = getHandle();
   expect(handle).not.toBeNull();
 
-  handle!.dispatchEvent(
-    new MouseEvent("pointerdown", {
-      bubbles: true,
-      clientX: startX,
-    }),
-  );
-  window.dispatchEvent(
-    new MouseEvent("pointermove", {
-      bubbles: true,
-      clientX: endX,
-      buttons: 1,
-    }),
-  );
+  handle!.dispatchEvent(pointerEvent("pointerdown", startX));
+  handle!.dispatchEvent(pointerEvent("pointermove", endX));
   await tick();
-  window.dispatchEvent(
-    new MouseEvent("pointerup", {
-      bubbles: true,
-      clientX: endX,
-    }),
-  );
+  handle!.dispatchEvent(pointerEvent("pointerup", endX));
   await tick();
 }
 
@@ -387,22 +362,14 @@ describe("ThreeColumnLayout", () => {
 
     mockLayoutWidth(1280);
 
-    const layout = getLayout();
     const handle = getHandle();
     expect(handle).not.toBeNull();
 
     handle!.dispatchEvent(
-      new MouseEvent("pointerdown", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT,
-      }),
+      pointerEvent("pointerdown", SIDEBAR_WIDTH_DEFAULT),
     );
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 80,
-        buttons: 1,
-      }),
+    handle!.dispatchEvent(
+      pointerEvent("pointermove", SIDEBAR_WIDTH_DEFAULT + 80),
     );
     await tick();
 
@@ -410,22 +377,15 @@ describe("ThreeColumnLayout", () => {
     expect(getSidebar().style.width).toBe(
       `${SIDEBAR_WIDTH_DEFAULT + 80}px`,
     );
-    expect(layout.classList.contains("is-resizing")).toBe(true);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      true,
-    );
 
-    window.dispatchEvent(
-      new MouseEvent("pointerup", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 80,
-      }),
+    handle!.dispatchEvent(
+      pointerEvent("pointerup", SIDEBAR_WIDTH_DEFAULT + 80),
     );
     await tick();
 
-    expect(layout.classList.contains("is-resizing")).toBe(false);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      false,
+    expect(ui.sidebarWidth).toBe(SIDEBAR_WIDTH_DEFAULT + 80);
+    expect(getSidebar().style.width).toBe(
+      `${SIDEBAR_WIDTH_DEFAULT + 80}px`,
     );
   });
 
@@ -481,16 +441,10 @@ describe("ThreeColumnLayout", () => {
     expect(handle).not.toBeNull();
 
     handle!.dispatchEvent(
-      new MouseEvent("pointerdown", {
-        bubbles: true,
-        clientX: expectedWidth,
-      }),
+      pointerEvent("pointerdown", expectedWidth),
     );
-    window.dispatchEvent(
-      new MouseEvent("pointerup", {
-        bubbles: true,
-        clientX: expectedWidth,
-      }),
+    handle!.dispatchEvent(
+      pointerEvent("pointerup", expectedWidth),
     );
     await tick();
 
@@ -517,30 +471,7 @@ describe("ThreeColumnLayout", () => {
     renderLayout();
     await tick();
 
-    const handle = getHandle();
-    expect(handle).not.toBeNull();
-
-    handle!.dispatchEvent(
-      new MouseEvent("pointerdown", {
-        bubbles: true,
-        clientX: expectedWidth,
-      }),
-    );
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        clientX: expectedWidth + 120,
-        buttons: 1,
-      }),
-    );
-    await tick();
-    window.dispatchEvent(
-      new MouseEvent("pointerup", {
-        bubbles: true,
-        clientX: expectedWidth + 120,
-      }),
-    );
-    await tick();
+    await dragHandle(expectedWidth, expectedWidth + 120);
 
     expect(getSidebar().style.width).toBe(
       `${expectedWidth}px`,
@@ -576,45 +507,7 @@ describe("ThreeColumnLayout", () => {
     ).toBe(480);
   });
 
-  it("ignores non-primary mouse buttons on the resize handle", async () => {
-    setViewportWidth(1280);
-    ui.setSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
-
-    renderLayout();
-    await tick();
-
-    mockLayoutWidth(1280);
-
-    const handle = getHandle();
-    const layout = getLayout();
-    expect(handle).not.toBeNull();
-
-    handle!.dispatchEvent(
-      new MouseEvent("pointerdown", {
-        bubbles: true,
-        button: 2,
-        buttons: 2,
-        clientX: SIDEBAR_WIDTH_DEFAULT,
-      }),
-    );
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        button: 2,
-        buttons: 2,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 100,
-      }),
-    );
-    await tick();
-
-    expect(ui.sidebarWidth).toBe(SIDEBAR_WIDTH_DEFAULT);
-    expect(layout.classList.contains("is-resizing")).toBe(false);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      false,
-    );
-  });
-
-  it("stops an active resize when the sidebar closes mid-drag", async () => {
+  it("removes the handle and keeps the dragged width when the sidebar closes mid-drag", async () => {
     setViewportWidth(1280);
     ui.sidebarOpen = true;
     ui.setSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
@@ -624,206 +517,33 @@ describe("ThreeColumnLayout", () => {
 
     mockLayoutWidth(1280);
 
-    const layout = getLayout();
     const handle = getHandle();
     expect(handle).not.toBeNull();
 
     handle!.dispatchEvent(
-      new MouseEvent("pointerdown", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT,
-      }),
+      pointerEvent("pointerdown", SIDEBAR_WIDTH_DEFAULT),
     );
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 60,
-        buttons: 1,
-      }),
+    handle!.dispatchEvent(
+      pointerEvent("pointermove", SIDEBAR_WIDTH_DEFAULT + 60),
     );
     await tick();
 
-    expect(layout.classList.contains("is-resizing")).toBe(true);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      true,
-    );
+    expect(ui.sidebarWidth).toBe(SIDEBAR_WIDTH_DEFAULT + 60);
 
     ui.sidebarOpen = false;
     await tick();
 
     expect(getHandle()).toBeNull();
-    expect(layout.classList.contains("is-resizing")).toBe(false);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      false,
-    );
-
-    const widthAfterClose = ui.sidebarWidth;
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 140,
-        buttons: 1,
-      }),
-    );
-    await tick();
-
-    expect(ui.sidebarWidth).toBe(widthAfterClose);
-  });
-
-  it("stops an active drag when a later pointermove reports no buttons pressed", async () => {
-    setViewportWidth(1280);
-    ui.setSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
-
-    renderLayout();
-    await tick();
-
-    mockLayoutWidth(1280);
-
-    const layout = getLayout();
-    const handle = getHandle();
-    expect(handle).not.toBeNull();
 
     handle!.dispatchEvent(
-      new MouseEvent("pointerdown", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT,
-      }),
-    );
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 60,
-        buttons: 1,
-      }),
+      pointerEvent("pointermove", SIDEBAR_WIDTH_DEFAULT + 140),
     );
     await tick();
 
-    expect(ui.sidebarWidth).toBe(
-      SIDEBAR_WIDTH_DEFAULT + 60,
-    );
-    expect(layout.classList.contains("is-resizing")).toBe(true);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      true,
-    );
-
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 120,
-        buttons: 0,
-      }),
-    );
-    await tick();
-
-    expect(ui.sidebarWidth).toBe(
-      SIDEBAR_WIDTH_DEFAULT + 60,
-    );
-    expect(layout.classList.contains("is-resizing")).toBe(false);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      false,
-    );
-
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 180,
-        buttons: 0,
-      }),
-    );
-    await tick();
-
-    expect(ui.sidebarWidth).toBe(
-      SIDEBAR_WIDTH_DEFAULT + 60,
-    );
-    expect(layout.classList.contains("is-resizing")).toBe(false);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      false,
-    );
+    expect(ui.sidebarWidth).toBe(SIDEBAR_WIDTH_DEFAULT + 60);
   });
 
-  it("ignores non-owning pointer events while resizing", async () => {
-    setViewportWidth(1280);
-    ui.setSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
-
-    renderLayout();
-    await tick();
-
-    mockLayoutWidth(1280);
-
-    const layout = getLayout();
-    const handle = getHandle();
-    expect(handle).not.toBeNull();
-
-    handle!.dispatchEvent(
-      createPointerMouseEvent("pointerdown", {
-        clientX: SIDEBAR_WIDTH_DEFAULT,
-        pointerId: 1,
-      }),
-    );
-    window.dispatchEvent(
-      createPointerMouseEvent("pointermove", {
-        clientX: SIDEBAR_WIDTH_DEFAULT + 60,
-        buttons: 1,
-        pointerId: 1,
-      }),
-    );
-    await tick();
-
-    expect(ui.sidebarWidth).toBe(
-      SIDEBAR_WIDTH_DEFAULT + 60,
-    );
-    expect(layout.classList.contains("is-resizing")).toBe(true);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      true,
-    );
-
-    window.dispatchEvent(
-      createPointerMouseEvent("pointermove", {
-        clientX: SIDEBAR_WIDTH_DEFAULT + 180,
-        buttons: 1,
-        pointerId: 2,
-      }),
-    );
-    window.dispatchEvent(
-      createPointerMouseEvent("pointerup", {
-        clientX: SIDEBAR_WIDTH_DEFAULT + 180,
-        pointerId: 2,
-      }),
-    );
-    window.dispatchEvent(
-      createPointerMouseEvent("pointercancel", {
-        clientX: SIDEBAR_WIDTH_DEFAULT + 180,
-        pointerId: 2,
-      }),
-    );
-    await tick();
-
-    expect(ui.sidebarWidth).toBe(
-      SIDEBAR_WIDTH_DEFAULT + 60,
-    );
-    expect(layout.classList.contains("is-resizing")).toBe(true);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      true,
-    );
-
-    window.dispatchEvent(
-      createPointerMouseEvent("pointerup", {
-        clientX: SIDEBAR_WIDTH_DEFAULT + 60,
-        pointerId: 1,
-      }),
-    );
-    await tick();
-
-    expect(layout.classList.contains("is-resizing")).toBe(false);
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      false,
-    );
-    expect(ui.sidebarWidth).toBe(
-      SIDEBAR_WIDTH_DEFAULT + 60,
-    );
-  });
-
-  it("cleans up active drag listeners and body state on unmount", async () => {
+  it("resizes and persists the width from arrow keys on the handle", async () => {
     setViewportWidth(1280);
     ui.setSidebarWidth(SIDEBAR_WIDTH_DEFAULT);
 
@@ -836,44 +556,28 @@ describe("ThreeColumnLayout", () => {
     expect(handle).not.toBeNull();
 
     handle!.dispatchEvent(
-      new MouseEvent("pointerdown", {
+      new KeyboardEvent("keydown", {
         bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT,
-      }),
-    );
-    await tick();
-
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      true,
-    );
-
-    unmount(component!);
-    component = undefined;
-    await tick();
-
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      false,
-    );
-
-    window.dispatchEvent(
-      new MouseEvent("pointermove", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 120,
-      }),
-    );
-    window.dispatchEvent(
-      new MouseEvent("pointerup", {
-        bubbles: true,
-        clientX: SIDEBAR_WIDTH_DEFAULT + 120,
+        key: "ArrowRight",
       }),
     );
     await tick();
 
     expect(ui.sidebarWidth).toBe(
-      SIDEBAR_WIDTH_DEFAULT,
+      SIDEBAR_WIDTH_DEFAULT + KEYBOARD_RESIZE_STEP,
     );
-    expect(document.body.classList.contains("sidebar-resizing")).toBe(
-      false,
+    expect(getSidebar().style.width).toBe(
+      `${SIDEBAR_WIDTH_DEFAULT + KEYBOARD_RESIZE_STEP}px`,
     );
+
+    handle!.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        key: "ArrowLeft",
+      }),
+    );
+    await tick();
+
+    expect(ui.sidebarWidth).toBe(SIDEBAR_WIDTH_DEFAULT);
   });
 });

--- a/frontend/src/lib/components/layout/sidebar-width.test.ts
+++ b/frontend/src/lib/components/layout/sidebar-width.test.ts
@@ -6,8 +6,14 @@ import {
   SIDEBAR_WIDTH_KEY,
   SIDEBAR_WIDTH_MIN,
   SIDEBAR_WIDTH_STORAGE_MAX,
+  VITALS_WIDTH_DEFAULT,
+  VITALS_WIDTH_KEY,
+  VITALS_WIDTH_MIN,
+  VITALS_WIDTH_STORAGE_MAX,
   clampSidebarWidthForLayout,
   clampStoredSidebarWidth,
+  clampStoredVitalsWidth,
+  clampVitalsWidthForLayout,
   isDesktopSidebarLayout,
 } from "./sidebar-width.js";
 
@@ -60,5 +66,28 @@ describe("sidebar width helpers", () => {
   it("limits sidebar width by the available layout width", () => {
     expect(clampSidebarWidthForLayout(520, 700)).toBe(220);
     expect(clampSidebarWidthForLayout(520, 900)).toBe(420);
+  });
+
+  it("exports the expected vitals width constants", () => {
+    expect(VITALS_WIDTH_KEY).toBe("agentsview-vitals-width");
+    expect(VITALS_WIDTH_DEFAULT).toBe(320);
+    expect(VITALS_WIDTH_MIN).toBe(280);
+    expect(VITALS_WIDTH_STORAGE_MAX).toBe(560);
+  });
+
+  it("clamps stored vitals widths and falls back on invalid values", () => {
+    expect(clampStoredVitalsWidth(undefined)).toBe(VITALS_WIDTH_DEFAULT);
+    expect(clampStoredVitalsWidth("not-a-number")).toBe(
+      VITALS_WIDTH_DEFAULT,
+    );
+    expect(clampStoredVitalsWidth(100)).toBe(VITALS_WIDTH_MIN);
+    expect(clampStoredVitalsWidth("400")).toBe(400);
+    expect(clampStoredVitalsWidth(999)).toBe(VITALS_WIDTH_STORAGE_MAX);
+  });
+
+  it("limits vitals width by the available layout width", () => {
+    expect(clampVitalsWidthForLayout(560, 700)).toBe(280);
+    expect(clampVitalsWidthForLayout(560, 900)).toBe(420);
+    expect(clampVitalsWidthForLayout(320, 1200)).toBe(320);
   });
 });

--- a/frontend/src/lib/components/layout/sidebar-width.ts
+++ b/frontend/src/lib/components/layout/sidebar-width.ts
@@ -5,23 +5,47 @@ export const SIDEBAR_WIDTH_DEFAULT = 260;
 export const SIDEBAR_WIDTH_MIN = 220;
 export const SIDEBAR_WIDTH_STORAGE_MAX = 520;
 export const SIDEBAR_CONTENT_MIN = 480;
+export const VITALS_WIDTH_KEY = "agentsview-vitals-width";
+export const VITALS_WIDTH_DEFAULT = 320;
+export const VITALS_WIDTH_MIN = 280;
+export const VITALS_WIDTH_STORAGE_MAX = 560;
 // Desktop starts one pixel past kit-ui's medium breakpoint so JS layout
 // logic agrees with the (max-width: 760px) CSS rules and ui.isMobileViewport.
 export const SIDEBAR_DESKTOP_BREAKPOINT = BREAKPOINTS.medium + 1;
 
-export function clampStoredSidebarWidth(value: unknown): number {
+function clampStoredPaneWidth(
+  value: unknown,
+  fallback: number,
+  minWidth: number,
+  maxWidth: number,
+): number {
   const numericValue =
     typeof value === "string" && value.trim() !== ""
       ? Number(value)
       : value;
 
   if (typeof numericValue !== "number" || !Number.isFinite(numericValue)) {
-    return SIDEBAR_WIDTH_DEFAULT;
+    return fallback;
   }
 
-  return Math.min(
+  return Math.min(maxWidth, Math.max(minWidth, numericValue));
+}
+
+export function clampStoredSidebarWidth(value: unknown): number {
+  return clampStoredPaneWidth(
+    value,
+    SIDEBAR_WIDTH_DEFAULT,
+    SIDEBAR_WIDTH_MIN,
     SIDEBAR_WIDTH_STORAGE_MAX,
-    Math.max(SIDEBAR_WIDTH_MIN, numericValue),
+  );
+}
+
+export function clampStoredVitalsWidth(value: unknown): number {
+  return clampStoredPaneWidth(
+    value,
+    VITALS_WIDTH_DEFAULT,
+    VITALS_WIDTH_MIN,
+    VITALS_WIDTH_STORAGE_MAX,
   );
 }
 
@@ -29,14 +53,40 @@ export function isDesktopSidebarLayout(viewportWidth: number): boolean {
   return viewportWidth >= SIDEBAR_DESKTOP_BREAKPOINT;
 }
 
+function clampPaneWidthForLayout(
+  desiredWidth: number,
+  layoutWidth: number,
+  minWidth: number,
+  maxWidth: number,
+): number {
+  const layoutMaxWidth = Math.max(
+    minWidth,
+    Math.min(maxWidth, layoutWidth - SIDEBAR_CONTENT_MIN),
+  );
+
+  return Math.min(layoutMaxWidth, Math.max(minWidth, desiredWidth));
+}
+
 export function clampSidebarWidthForLayout(
   desiredWidth: number,
   layoutWidth: number,
 ): number {
-  const layoutMaxWidth = Math.max(
+  return clampPaneWidthForLayout(
+    desiredWidth,
+    layoutWidth,
     SIDEBAR_WIDTH_MIN,
-    Math.min(SIDEBAR_WIDTH_STORAGE_MAX, layoutWidth - SIDEBAR_CONTENT_MIN),
+    SIDEBAR_WIDTH_STORAGE_MAX,
   );
+}
 
-  return Math.min(layoutMaxWidth, Math.max(SIDEBAR_WIDTH_MIN, desiredWidth));
+export function clampVitalsWidthForLayout(
+  desiredWidth: number,
+  layoutWidth: number,
+): number {
+  return clampPaneWidthForLayout(
+    desiredWidth,
+    layoutWidth,
+    VITALS_WIDTH_MIN,
+    VITALS_WIDTH_STORAGE_MAX,
+  );
 }

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -9,7 +9,10 @@ import {
 import {
   SIDEBAR_WIDTH_DEFAULT,
   SIDEBAR_WIDTH_KEY,
+  VITALS_WIDTH_DEFAULT,
+  VITALS_WIDTH_KEY,
   clampStoredSidebarWidth,
+  clampStoredVitalsWidth,
 } from "../components/layout/sidebar-width.js";
 
 type Theme = "light" | "dark";
@@ -232,6 +235,16 @@ function readStoredSidebarWidth(): number {
   }
 }
 
+function readStoredVitalsWidth(): number {
+  try {
+    return clampStoredVitalsWidth(
+      localStorage?.getItem(VITALS_WIDTH_KEY),
+    );
+  } catch {
+    return VITALS_WIDTH_DEFAULT;
+  }
+}
+
 function readStoredBool(key: string, fallback: boolean): boolean {
   try {
     const raw = localStorage?.getItem(key);
@@ -267,6 +280,7 @@ class UIStore {
     readStoredTranscriptMode(),
   );
   sidebarWidth: number = $state(readStoredSidebarWidth());
+  vitalsWidth: number = $state(readStoredVitalsWidth());
   activeModal: ModalType = $state(null);
   /** Whether the next gist publish should be secret instead of public. */
   publishSecret: boolean = $state(false);
@@ -328,6 +342,17 @@ class UIStore {
           localStorage?.setItem(
             SIDEBAR_WIDTH_KEY,
             String(this.sidebarWidth),
+          );
+        } catch {
+          // ignore
+        }
+      });
+
+      $effect(() => {
+        try {
+          localStorage?.setItem(
+            VITALS_WIDTH_KEY,
+            String(this.vitalsWidth),
           );
         } catch {
           // ignore
@@ -530,6 +555,10 @@ class UIStore {
 
   setSidebarWidth(width: number) {
     this.sidebarWidth = clampStoredSidebarWidth(width);
+  }
+
+  setVitalsWidth(width: number) {
+    this.vitalsWidth = clampStoredVitalsWidth(width);
   }
 
   setPublishTarget(target: Exclude<PublishTarget, null>) {

--- a/frontend/src/vitest-setup.ts
+++ b/frontend/src/vitest-setup.ts
@@ -77,6 +77,23 @@ export function installFallbackResizeObserver(): void {
   });
 }
 
+/** jsdom has no pointer capture; kit-ui's SplitResizeHandle captures the
+ * pointer on drag start. Inert stubs keep drags dispatchable in tests —
+ * events are delivered by plain dispatch on the handle, so capture-based
+ * retargeting is not needed. */
+export function installFallbackPointerCapture(): void {
+  const proto = globalThis.Element?.prototype;
+  if (!proto || typeof proto.setPointerCapture === "function") return;
+
+  Object.assign(proto, {
+    setPointerCapture(): void {},
+    releasePointerCapture(): void {},
+    hasPointerCapture(): boolean {
+      return false;
+    },
+  });
+}
+
 /** Svelte motion reads prefers-reduced-motion during module initialization.
  * jsdom does not implement matchMedia, so provide the inert browser shape. */
 export function installFallbackMatchMedia(): void {
@@ -100,5 +117,6 @@ export function installFallbackMatchMedia(): void {
 
 installFallbackStorage("localStorage");
 installFallbackResizeObserver();
+installFallbackPointerCapture();
 installFallbackMatchMedia();
 initI18n();


### PR DESCRIPTION
The session list splitter was a bespoke pointer-capture resizer that predated kit-ui's `SplitResizeHandle` and looked different from the standard divider used across kenn apps — the code even carried a `kit-ui-check-ignore` comment marking the swap as a tracked follow-up. The sidebar now uses the shared 4px handle, which also brings keyboard resizing via arrow keys; both ignore markers are gone and `kit-ui-check` reports zero findings.

The right-hand session analysis (vitals) panel was fixed at 320px, so charts and long repository paths could not get more room. It now gets the same handle on its left edge: drag deltas are inverted (moving the divider left widens the panel), and the width persists per browser (`agentsview-vitals-width`) the same way the sidebar width does. The resize handle's accessible label is new copy, added to all six locales.

Both panes clamp against one shared width budget with the content column. The sidebar clamp reserves the analysis panel's minimum footprint while the panel is visible, and the panel yields whatever the actual sidebar leaves over, so the 480px content minimum holds at any layout of 990px or wider. Precedence when space runs out: pane minimums, then the content minimum, then preferred widths — below 990px the pane floors bound the squeeze rather than a responsive collapse, which stays out of scope. Each separator advertises the layout-effective maximum in `aria-valuemax` rather than a storage cap the window cannot grant. (Before this PR the fixed 320px panel could squeeze the content column to 161px; the independent clamps in an earlier revision allowed 195px — review 12657 flagged that, and the shared budget resolves it.)

Sidebar behavior carried over unchanged: localStorage persistence and the guard that keeps a wider stored preference intact when a drag stays inside the clamp. Pointer mechanics (capture, pointer-id filtering, cancel handling) now live in kit-ui, so the tests that policed the bespoke plumbing were removed; jsdom lacks pointer capture, so the vitest setup stubs it alongside the existing ResizeObserver stub.

Reviewers should look at the budget arithmetic and the inverted delta in `ThreeColumnLayout.svelte`, and the cross-pane tests asserting the 510/280/480 split at a 1280px layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
