### PR TITLE
ffix(parser): discover Qoder CLI CN sessions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,7 +296,7 @@ Omitting the key keeps its default directories.
 | Posit Assistant       | `~/.posit/assistant/workspaces/`                                                 | Per-conversation `conversation.json` tree plus `lm-messages.jsonl` transcript                                                   |
 | Positron Assistant    | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
 | QClaw                 | `~/.qclaw/assets/static/agents/`                                                 | JSONL per session                                                                                                               |
-| Qoder                 | Legacy export roots plus platform-specific `SharedClientCache` (see below)       | JSONL project transcripts plus sidecar metadata                                                                                 |
+| Qoder                 | Legacy export roots, Qoder CLI CN, plus platform-specific `SharedClientCache` (see below) | JSONL project transcripts plus sidecar metadata                                                                                 |
 | Qwen Code             | `~/.qwen/projects/`                                                              | JSONL per session                                                                                                               |
 | QwenPaw               | `~/.copaw/workspaces/`                                                           | JSON session files                                                                                                              |
 | Reasonix              | `~/.reasonix/` and `~/AppData/Roaming/reasonix/`                                 | JSONL sessions plus `.jsonl.meta` sidecars                                                                                      |
@@ -326,7 +326,10 @@ session store, so open the current Prime Agent once before syncing a legacy
 archive with AgentsView.
 
 **Qoder default directories** include the legacy `~/.qoder/projects/` and
-`~/.qoderwork/projects/` export roots plus the current IDE store:
+`~/.qoderwork/projects/` export roots, the Qoder CLI CN store, and the current
+IDE store:
+
+- **Qoder CLI CN:** `~/.qoder-cn/projects/`
 
 - **macOS:**
   `~/Library/Application Support/Qoder/SharedClientCache/cli/projects/`

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1848,7 +1848,12 @@ add an archived or maintained mirror without replacing the original identity.
   `c40d46d16a32295da63221629293a000b0675df2` and inspect its pinned
   [Qoder source adapter](https://github.com/chenhg5/tape/blob/c40d46d16a32295da63221629293a000b0675df2/internal/source/qoder/qoder.go),
   which documents the transcript/metadata pair and shared Qwen `ChatRecord`
-  shape.
+  shape. Agentsview issue [#1405](https://github.com/kenn-io/agentsview/issues/1405),
+  checked 2026-08-28, reports Qoder CLI CN 1.1.21 storing the same
+  project-scoped JSONL family under `~/.qoder-cn/projects/<project-slug>/`,
+  including `<session-id>.jsonl`. This is a user-reported local observation,
+  not producer-side evidence, and does not establish storage behavior for all
+  Qoder CN releases or platforms.
 - **Usage and cost:** The consumed files provide transcript and model/session
   metadata but no authoritative token, cache, reasoning, credit, or USD events
   to Agentsview.

--- a/internal/parser/qoder_paths.go
+++ b/internal/parser/qoder_paths.go
@@ -1,7 +1,7 @@
 package parser
 
 // qoderDefaultDirs returns platform-specific default directories that
-// hold Qoder IDE session transcripts. The IDE stores its data under
+// hold Qoder session transcripts. The IDE stores its data under
 // an Electron-style user-data directory per platform:
 //
 //	macOS:   ~/Library/Application Support/Qoder
@@ -10,15 +10,21 @@ package parser
 //
 // In recent versions Qoder also writes session transcripts to a
 // SharedClientCache path (used as the actual storage location on
-// Windows installs), so we list both. Paths that don't exist on a
-// given platform are skipped silently by discovery.
+// Windows installs), so we list the legacy, CN, and SharedClientCache
+// locations. Paths that don't exist on a given platform are skipped
+// silently by discovery.
 //
 //	Windows: %APPDATA%\Qoder\SharedClientCache\cli\projects
+//
+// Qoder CLI CN stores the same project-scoped layout under
+// ~/.qoder-cn/projects.
 func qoderDefaultDirs() []string {
 	return []string{
 		// Legacy export paths (kept for users who enable the in-IDE export).
 		".qoder/projects",
 		".qoderwork/projects",
+		// Qoder CLI CN
+		".qoder-cn/projects",
 		// macOS
 		"Library/Application Support/Qoder/SharedClientCache/cli/projects",
 		// Linux

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -410,6 +410,8 @@ func TestQoderDefaultDirs(t *testing.T) {
 	// Legacy export paths retained.
 	assert.Contains(t, dirs, ".qoder/projects")
 	assert.Contains(t, dirs, ".qoderwork/projects")
+	// Qoder CLI CN stores the same project-scoped layout under a separate root.
+	assert.Contains(t, dirs, ".qoder-cn/projects")
 	// SharedClientCache paths for the three target platforms.
 	assert.Contains(t, dirs,
 		"Library/Application Support/Qoder/SharedClientCache/cli/projects")


### PR DESCRIPTION
Fixes #1405

Qoder CLI CN 1.1.21 stores its project-scoped JSONL sessions under `~/.qoder-cn/projects/`, while AgentsView currently scans the existing Qoder roots only.

Add the CN projects root to the existing Qoder default directories so the current provider discovers these sessions without introducing a separate agent or parser. The existing `QODER_PROJECTS_DIR` / `qoder_project_dirs` override behavior is unchanged.

Also updates the focused default-directory regression and the Qoder configuration/provenance documentation, keeping the CN storage observation explicitly user-reported rather than treating it as producer-side evidence.
