### PR TITLE
test(capture): surface the run error when source observation flakes

### DIFF
--- a/internal/capture/capture_integration_test.go
+++ b/internal/capture/capture_integration_test.go
@@ -2126,6 +2126,36 @@ func TestCaptureDistinguishesAnObservedSourceThatDisappears(t *testing.T) {
 		}
 	})
 
+	// Wait for the manifest to record an observed source, but fail
+	// immediately with the run's actual error if the capture finishes
+	// first: an opaque Eventually timeout here has flaked on Windows CI
+	// and hides whether the run aborted early or is still in flight.
+	observeDeadline := time.NewTimer(20 * time.Second)
+	defer observeDeadline.Stop()
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+	for observed := false; !observed; {
+		select {
+		case response := <-done:
+			t.Fatalf(
+				"capture run finished before the source was observed: exit=%d err=%v",
+				response.outcome.ExitCode, response.err,
+			)
+		case <-observeDeadline.C:
+			t.Fatal(
+				"timed out waiting for an observed source; capture run still in flight",
+			)
+		case <-poll.C:
+			data, err := os.ReadFile(filepath.Join(captureDir, manifestFileName))
+			if err != nil {
+				continue
+			}
+			var captured manifest
+			observed = json.Unmarshal(data, &captured) == nil &&
+				captured.SourceObserved
+		}
+	}
+
 	select {
 	case <-persisted:
 	case response := <-done:


### PR DESCRIPTION
`TestCaptureDistinguishesAnObservedSourceThatDisappears` failed once on Windows CI (PR #1549's first run) with nothing but `Condition never satisfied` after its 20-second `Eventually`. The test only read the capture run's result channel after the manifest recorded an observed source, so any run that aborted early — transient ACL setup failure, manifest rename contention with the test's 10ms reads, helper spawn error — burned the whole timeout and discarded its actual error.

The `Eventually` is now a select loop with the same manifest polling and the same assertions afterward, but it fails immediately with the run's exit code and error when the capture finishes before the source is observed, and reports "run still in flight" when the timeout fires with the run still going. The next flake will name its cause on sight instead of reproducing an opaque timeout; the two failure shapes also discriminate between an early abort and a stalled run (for example a virus scanner stalling the freshly copied helper binary).

No production code changes; the test's contract is unchanged. Stacked on #1549 only to keep CI history linear — the change is independent and can be retargeted to main if the base merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
