### PR TITLE
fix(ci): reduce transient main failures

### DIFF
--- a/.github/actions/build-desktop-artifact/action.yml
+++ b/.github/actions/build-desktop-artifact/action.yml
@@ -81,26 +81,11 @@ runs:
         fi
         build_cmd+=(--config '{"bundle":{"createUpdaterArtifacts":false}}')
 
-        build_log=$(mktemp)
-        trap 'rm -f -- "$build_log"' EXIT
-        for attempt in 1 2; do
-          set +e
-          "${build_cmd[@]}" 2>&1 | tee "$build_log"
-          build_status=${PIPESTATUS[0]}
-          set -e
-
-          if [ "$build_status" -eq 0 ]; then
-            break
-          fi
-          if [ "$attempt" -eq 2 ] ||
-            ! grep -Eq 'http status: (408|429|5[0-9]{2})' "$build_log"; then
-            exit "$build_status"
-          fi
-
-          echo "::warning::Tauri bundler download failed; retrying once"
+        if ! "${build_cmd[@]}"; then
+          echo "::warning::Desktop bundle failed; retrying once"
           sleep 10
-          : > "$build_log"
-        done
+          "${build_cmd[@]}"
+        fi
         if [ "$BUNDLE" = "appimage" ]; then
           bash scripts/repair-appimage-diricon.sh \
             "../${ARTIFACT_DIR}"/*.AppImage

--- a/.github/actions/build-desktop-artifact/action.yml
+++ b/.github/actions/build-desktop-artifact/action.yml
@@ -80,7 +80,27 @@ runs:
           build_cmd+=(--target "$AGENTSVIEW_TARGET_TRIPLE")
         fi
         build_cmd+=(--config '{"bundle":{"createUpdaterArtifacts":false}}')
-        "${build_cmd[@]}"
+
+        build_log=$(mktemp)
+        trap 'rm -f -- "$build_log"' EXIT
+        for attempt in 1 2; do
+          set +e
+          "${build_cmd[@]}" 2>&1 | tee "$build_log"
+          build_status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$build_status" -eq 0 ]; then
+            break
+          fi
+          if [ "$attempt" -eq 2 ] ||
+            ! grep -Eq 'http status: (408|429|5[0-9]{2})' "$build_log"; then
+            exit "$build_status"
+          fi
+
+          echo "::warning::Tauri bundler download failed; retrying once"
+          sleep 10
+          : > "$build_log"
+        done
         if [ "$BUNDLE" = "appimage" ]; then
           bash scripts/repair-appimage-diricon.sh \
             "../${ARTIFACT_DIR}"/*.AppImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,47 +430,10 @@ jobs:
 
       # internal/duckdb is excluded from -race (CGo-heavy, race-insensitive,
       # and 7+ minutes on its own); it is still covered without -race by the
-      # main test job's ./... run. Capture and sync run in isolated race jobs
-      # below so their timing-sensitive integration tests do not compete with
-      # other race-instrumented packages.
-      # Match the Makefile's package fan-out limit. The race detector makes
-      # highly parallel package runs slow enough to exhaust test deadlines.
+      # main test job's ./... run. Limit package fan-out because the race
+      # detector makes highly parallel runs slow enough to exhaust deadlines.
       - name: Run Go tests (race detector)
-        run: |
-          mapfile -t packages < <(
-            go list ./... | grep -Ev '/internal/(capture|duckdb|sync)$'
-          )
-          go test -p 4 -tags "fts5" -race "${packages[@]}" -count=1 -timeout=20m
-        env:
-          CGO_ENABLED: "1"
-
-  test-race-isolated:
-    name: Go Test (race detector, ${{ matrix.name }})
-    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Capture
-            package: ./internal/capture
-          - name: Sync
-            package: ./internal/sync
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ github.repository == 'kenn-io/agentsview' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
-
-      - name: Restore pricing snapshot
-        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
-
-      - name: Run ${{ matrix.name }} tests (race detector)
-        run: go test -tags "fts5" -race ${{ matrix.package }} -count=1 -timeout=20m
+        run: go list ./... | grep -v '/internal/duckdb$' | xargs go test -p 4 -tags "fts5" -race -count=1 -timeout=20m
         env:
           CGO_ENABLED: "1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,9 +430,47 @@ jobs:
 
       # internal/duckdb is excluded from -race (CGo-heavy, race-insensitive,
       # and 7+ minutes on its own); it is still covered without -race by the
-      # main test job's ./... run.
+      # main test job's ./... run. Capture and sync run in isolated race jobs
+      # below so their timing-sensitive integration tests do not compete with
+      # other race-instrumented packages.
+      # Match the Makefile's package fan-out limit. The race detector makes
+      # highly parallel package runs slow enough to exhaust test deadlines.
       - name: Run Go tests (race detector)
-        run: go test -tags "fts5" -race $(go list ./... | grep -v '/internal/duckdb$') -count=1 -timeout=20m
+        run: |
+          mapfile -t packages < <(
+            go list ./... | grep -Ev '/internal/(capture|duckdb|sync)$'
+          )
+          go test -p 4 -tags "fts5" -race "${packages[@]}" -count=1 -timeout=20m
+        env:
+          CGO_ENABLED: "1"
+
+  test-race-isolated:
+    name: Go Test (race detector, ${{ matrix.name }})
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Capture
+            package: ./internal/capture
+          - name: Sync
+            package: ./internal/sync
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: ${{ github.repository == 'kenn-io/agentsview' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
+
+      - name: Run ${{ matrix.name }} tests (race detector)
+        run: go test -tags "fts5" -race ${{ matrix.package }} -count=1 -timeout=20m
         env:
           CGO_ENABLED: "1"
 

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -648,6 +648,10 @@ func awaitQuiescentSources(
 		}
 		roots, err := locateRoot(ctx, state.manifest)
 		if err != nil {
+			if errors.Is(err, context.Canceled) ||
+				errors.Is(err, context.DeadlineExceeded) {
+				return nil, finalizationError(foundRoot, missingRoot, err)
+			}
 			return nil, err
 		}
 		if len(roots) > 1 {

--- a/internal/capture/finalization_test.go
+++ b/internal/capture/finalization_test.go
@@ -14,6 +14,55 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
+type deadlineOnSecondErrContext struct {
+	context.Context
+	checks int
+}
+
+func (c *deadlineOnSecondErrContext) Err() error {
+	c.checks++
+	if c.checks >= 2 {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+func TestAwaitQuiescentSourcesClassifiesDeadlineDuringLookup(t *testing.T) {
+	tests := []struct {
+		name           string
+		sourceObserved bool
+		wantReason     ReasonCode
+	}{
+		{name: "no source", wantReason: ReasonNoSession},
+		{
+			name: "source observed", sourceObserved: true,
+			wantReason: ReasonFinalizationTimeout,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := &captureState{manifest: manifest{
+				Provider:          string(ProviderClaude),
+				ProviderRoot:      t.TempDir(),
+				ProviderWorkDir:   t.TempDir(),
+				ProviderSessionID: "11111111-1111-4111-8111-111111111111",
+				SourceObserved:    test.sourceObserved,
+				Limits:            testLimits(),
+			}}
+			ctx := &deadlineOnSecondErrContext{Context: context.Background()}
+
+			_, err := awaitQuiescentSources(
+				ctx, state, time.Now().Add(time.Minute))
+
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			assert.Equal(
+				t, test.wantReason,
+				reasonForError(err, ReasonFinalizationTimeout),
+			)
+		})
+	}
+}
+
 func TestOversizedResultWritesBoundedFailureAndKeepsPriorFailure(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Main CI hit two unrelated failures: GitHub returned 504 while Tauri downloaded
a bundler tool, and capture lost its `no_session` classification when its
context expired during source lookup.

Desktop bundling now retries the build once. The race job keeps capture and
sync in the shared suite but caps package fan-out at four; that shared suite
completes under the existing timeout. Capture now preserves finalization state
when source lookup returns a cancellation or deadline error, so scheduler timing
does not change the reported reason.

The download retry is deliberately broad and limited to one extra attempt. This
keeps the action small and avoids parsing dependency output for HTTP status
codes.
