### PR TITLE
fix(daemon): keep readiness wait alive during startup progress

### DIFF
--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -303,11 +303,9 @@ func stopTimer(t *time.Timer) {
 	}
 }
 
-// resetTimer stops and drains t before rearming it for d, the safe
-// stop-then-reset sequence for a timer whose channel may already hold an
-// unread tick.
+// resetTimer rearms t for d. Go 1.23 and later guarantee that Reset prevents a
+// subsequent receive from observing a stale value from the prior settings.
 func resetTimer(t *time.Timer, d time.Duration) {
-	stopTimer(t)
 	t.Reset(d)
 }
 

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -1037,6 +1037,10 @@ func waitForBackgroundServeReadyWithPolicy(
 			return nil, ctx.Err()
 		case <-ticker.C:
 		case <-timeoutC:
+			if rt := FindDaemonRuntime(dataDir, authToken); rt != nil &&
+				!rt.ReadOnly {
+				return rt, nil
+			}
 			var latest *startupState
 			if IsDaemonStarting(dataDir) {
 				latest = readStartupState(dataDir)

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -996,25 +996,40 @@ func waitForBackgroundServeReadyWithPolicy(
 	policy backgroundServeReadyWaitPolicy,
 ) (*DaemonRuntime, error) {
 	startedAt := time.Now()
+	var timer *time.Timer
 	var timeoutC <-chan time.Time
 	if !policy.Attached {
-		timer := time.NewTimer(timeout)
+		timer = time.NewTimer(timeout)
 		defer timer.Stop()
 		timeoutC = timer.C
 	}
 	ticker := time.NewTicker(startProbeTick())
 	defer ticker.Stop()
+	var lastStartupUpdate time.Time
 
 	for {
 		if rt := FindDaemonRuntime(dataDir, authToken); rt != nil &&
 			!rt.ReadOnly {
 			return rt, nil
 		}
-		if policy.Observe != nil {
-			var snapshot *startupState
+		var snapshot *startupState
+		if policy.Observe != nil || timer != nil {
 			if IsDaemonStarting(dataDir) {
 				snapshot = readStartupState(dataDir)
 			}
+		}
+		if timer != nil && snapshot != nil &&
+			snapshot.UpdatedAt.After(lastStartupUpdate) {
+			lastStartupUpdate = snapshot.UpdatedAt
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(timeout)
+		}
+		if policy.Observe != nil {
 			policy.Observe(snapshot, startupSnapshotElapsed(snapshot, startedAt, time.Now()))
 		}
 

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -1021,13 +1021,7 @@ func waitForBackgroundServeReadyWithPolicy(
 		if timer != nil && snapshot != nil &&
 			snapshot.UpdatedAt.After(lastStartupUpdate) {
 			lastStartupUpdate = snapshot.UpdatedAt
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			timer.Reset(timeout)
+			resetTimer(timer, timeout)
 		}
 		if policy.Observe != nil {
 			policy.Observe(snapshot, startupSnapshotElapsed(snapshot, startedAt, time.Now()))
@@ -1043,6 +1037,15 @@ func waitForBackgroundServeReadyWithPolicy(
 			return nil, ctx.Err()
 		case <-ticker.C:
 		case <-timeoutC:
+			var latest *startupState
+			if IsDaemonStarting(dataDir) {
+				latest = readStartupState(dataDir)
+			}
+			if latest != nil && latest.UpdatedAt.After(lastStartupUpdate) {
+				lastStartupUpdate = latest.UpdatedAt
+				resetTimer(timer, timeout)
+				continue
+			}
 			return nil, nil
 		}
 	}

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -1008,8 +1008,7 @@ func waitForBackgroundServeReadyWithPolicy(
 	var lastStartupUpdate time.Time
 
 	for {
-		if rt := FindDaemonRuntime(dataDir, authToken); rt != nil &&
-			!rt.ReadOnly {
+		if rt := FindWritableDaemonRuntime(dataDir, authToken); rt != nil {
 			return rt, nil
 		}
 		var snapshot *startupState
@@ -1037,8 +1036,7 @@ func waitForBackgroundServeReadyWithPolicy(
 			return nil, ctx.Err()
 		case <-ticker.C:
 		case <-timeoutC:
-			if rt := FindDaemonRuntime(dataDir, authToken); rt != nil &&
-				!rt.ReadOnly {
+			if rt := FindWritableDaemonRuntime(dataDir, authToken); rt != nil {
 				return rt, nil
 			}
 			var latest *startupState

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1183,6 +1183,52 @@ func TestWaitForBackgroundServeReadyTimesOutWithoutNewStartupProgress(t *testing
 	assert.Less(t, time.Since(startedAt), 200*time.Millisecond)
 }
 
+func TestWaitForBackgroundServeReadyReprobesRuntimeAtTimeout(t *testing.T) {
+	setStartProbeTickForTest(t, 300*time.Millisecond)
+	dir := runtimeTestDir(t)
+	observed := make(chan struct{}, 1)
+	resultCh := make(chan *DaemonRuntime, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		rt, waitErr := waitForBackgroundServeReadyWithPolicy(
+			context.Background(), dir, "", make(chan error), 500*time.Millisecond,
+			backgroundServeReadyWaitPolicy{
+				Observe: func(*startupState, time.Duration) {
+					select {
+					case observed <- struct{}{}:
+					default:
+					}
+				},
+			},
+		)
+		resultCh <- rt
+		errCh <- waitErr
+	}()
+
+	for range 2 {
+		select {
+		case <-observed:
+		case <-time.After(time.Second):
+			t.Fatal("readiness wait did not reach its final poll before timeout")
+		}
+	}
+	time.Sleep(100 * time.Millisecond)
+	host, port := testPingServer(t)
+	_, err := WriteDaemonRuntime(dir, host, port, version, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { RemoveDaemonRuntime(dir) })
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+		rt := <-resultCh
+		require.NotNil(t, rt)
+		assert.Equal(t, port, rt.Port)
+	case <-time.After(time.Second):
+		t.Fatal("readiness wait did not return runtime published before timeout")
+	}
+}
+
 func TestWaitForBackgroundServeReadyAttachedChildExitAndCancellation(t *testing.T) {
 	setStartProbeTickForTest(t, 10*time.Millisecond)
 

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1089,7 +1089,7 @@ func TestWaitForBackgroundServeReadyAttachedObservesProgressWithoutTimeout(
 }
 
 func TestWaitForBackgroundServeReadyRenewsTimeoutOnStartupProgress(t *testing.T) {
-	setStartProbeTickForTest(t, 5*time.Millisecond)
+	setStartProbeTickForTest(t, 110*time.Millisecond)
 	dir := runtimeTestDir(t)
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	updatedAt := time.Now()
@@ -1114,7 +1114,7 @@ func TestWaitForBackgroundServeReadyRenewsTimeoutOnStartupProgress(t *testing.T)
 	errCh := make(chan error, 1)
 	go func() {
 		rt, waitErr := waitForBackgroundServeReadyWithPolicy(
-			context.Background(), dir, "", make(chan error), 100*time.Millisecond,
+			context.Background(), dir, "", make(chan error), 200*time.Millisecond,
 			backgroundServeReadyWaitPolicy{
 				Observe: func(st *startupState, _ time.Duration) {
 					if st == nil {
@@ -1143,14 +1143,18 @@ func TestWaitForBackgroundServeReadyRenewsTimeoutOnStartupProgress(t *testing.T)
 	case <-time.After(time.Second):
 		t.Fatal("readiness wait did not observe initial startup state")
 	}
-	time.Sleep(60 * time.Millisecond)
+	select {
+	case <-initialObserved:
+	case <-time.After(time.Second):
+		t.Fatal("readiness wait did not reach its final poll before timeout")
+	}
 	writeState("2/2 sessions", updatedAt.Add(time.Second))
 	select {
 	case <-progressObserved:
 	case <-time.After(time.Second):
 		t.Fatal("readiness wait did not observe advancing startup state")
 	}
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	host, port := testPingServer(t)
 	_, err := WriteDaemonRuntime(dir, host, port, version, false)
 	require.NoError(t, err)

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1184,49 +1184,22 @@ func TestWaitForBackgroundServeReadyTimesOutWithoutNewStartupProgress(t *testing
 }
 
 func TestWaitForBackgroundServeReadyReprobesRuntimeAtTimeout(t *testing.T) {
-	setStartProbeTickForTest(t, 300*time.Millisecond)
+	setStartProbeTickForTest(t, time.Second)
 	dir := runtimeTestDir(t)
-	observed := make(chan struct{}, 1)
-	resultCh := make(chan *DaemonRuntime, 1)
-	errCh := make(chan error, 1)
-	go func() {
-		rt, waitErr := waitForBackgroundServeReadyWithPolicy(
-			context.Background(), dir, "", make(chan error), 500*time.Millisecond,
-			backgroundServeReadyWaitPolicy{
-				Observe: func(*startupState, time.Duration) {
-					select {
-					case observed <- struct{}{}:
-					default:
-					}
-				},
-			},
-		)
-		resultCh <- rt
-		errCh <- waitErr
-	}()
-
-	for range 2 {
-		select {
-		case <-observed:
-		case <-time.After(time.Second):
-			t.Fatal("readiness wait did not reach its final poll before timeout")
-		}
-	}
-	time.Sleep(100 * time.Millisecond)
 	host, port := testPingServer(t)
-	_, err := WriteDaemonRuntime(dir, host, port, version, false)
-	require.NoError(t, err)
+	rt, err := waitForBackgroundServeReadyWithPolicy(
+		context.Background(), dir, "", make(chan error), 20*time.Millisecond,
+		backgroundServeReadyWaitPolicy{
+			Observe: func(*startupState, time.Duration) {
+				_, writeErr := WriteDaemonRuntime(dir, host, port, version, false)
+				require.NoError(t, writeErr)
+			},
+		},
+	)
 	t.Cleanup(func() { RemoveDaemonRuntime(dir) })
-
-	select {
-	case err := <-errCh:
-		require.NoError(t, err)
-		rt := <-resultCh
-		require.NotNil(t, rt)
-		assert.Equal(t, port, rt.Port)
-	case <-time.After(time.Second):
-		t.Fatal("readiness wait did not return runtime published before timeout")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, rt)
+	assert.Equal(t, port, rt.Port)
 }
 
 func TestWaitForBackgroundServeReadyAttachedChildExitAndCancellation(t *testing.T) {

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1088,6 +1088,110 @@ func TestWaitForBackgroundServeReadyAttachedObservesProgressWithoutTimeout(
 	}
 }
 
+func TestWaitForBackgroundServeReadyRenewsTimeoutOnStartupProgress(t *testing.T) {
+	setStartProbeTickForTest(t, 5*time.Millisecond)
+	dir := runtimeTestDir(t)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	updatedAt := time.Now()
+	writeState := func(detail string, update time.Time) {
+		data, err := json.Marshal(startupState{
+			PID:       321,
+			StartedAt: updatedAt,
+			Phase:     "initial sync",
+			Detail:    detail,
+			UpdatedAt: update,
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
+	}
+	writeState("1/2 sessions", updatedAt)
+	MarkDaemonStarting(dir)
+	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+
+	initialObserved := make(chan struct{}, 1)
+	progressObserved := make(chan struct{}, 1)
+	resultCh := make(chan *DaemonRuntime, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		rt, waitErr := waitForBackgroundServeReadyWithPolicy(
+			context.Background(), dir, "", make(chan error), 100*time.Millisecond,
+			backgroundServeReadyWaitPolicy{
+				Observe: func(st *startupState, _ time.Duration) {
+					if st == nil {
+						return
+					}
+					if st.Detail == "2/2 sessions" {
+						select {
+						case progressObserved <- struct{}{}:
+						default:
+						}
+						return
+					}
+					select {
+					case initialObserved <- struct{}{}:
+					default:
+					}
+				},
+			},
+		)
+		resultCh <- rt
+		errCh <- waitErr
+	}()
+
+	select {
+	case <-initialObserved:
+	case <-time.After(time.Second):
+		t.Fatal("readiness wait did not observe initial startup state")
+	}
+	time.Sleep(60 * time.Millisecond)
+	writeState("2/2 sessions", updatedAt.Add(time.Second))
+	select {
+	case <-progressObserved:
+	case <-time.After(time.Second):
+		t.Fatal("readiness wait did not observe advancing startup state")
+	}
+	time.Sleep(60 * time.Millisecond)
+	host, port := testPingServer(t)
+	_, err := WriteDaemonRuntime(dir, host, port, version, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { RemoveDaemonRuntime(dir) })
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+		rt := <-resultCh
+		require.NotNil(t, rt)
+		assert.Equal(t, port, rt.Port)
+	case <-time.After(time.Second):
+		t.Fatal("readiness wait did not return authoritative runtime")
+	}
+}
+
+func TestWaitForBackgroundServeReadyTimesOutWithoutNewStartupProgress(t *testing.T) {
+	setStartProbeTickForTest(t, 5*time.Millisecond)
+	dir := runtimeTestDir(t)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	data, err := json.Marshal(startupState{
+		PID:       321,
+		StartedAt: time.Now(),
+		Phase:     "initial sync",
+		Detail:    "1/2 sessions",
+		UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
+	MarkDaemonStarting(dir)
+	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+
+	startedAt := time.Now()
+	rt, err := waitForBackgroundServeReady(
+		context.Background(), dir, "", make(chan error), 40*time.Millisecond,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, rt)
+	assert.Less(t, time.Since(startedAt), 200*time.Millisecond)
+}
+
 func TestWaitForBackgroundServeReadyAttachedChildExitAndCancellation(t *testing.T) {
 	setStartProbeTickForTest(t, 10*time.Millisecond)
 

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1089,7 +1089,7 @@ func TestWaitForBackgroundServeReadyAttachedObservesProgressWithoutTimeout(
 }
 
 func TestWaitForBackgroundServeReadyRenewsTimeoutOnStartupProgress(t *testing.T) {
-	setStartProbeTickForTest(t, 110*time.Millisecond)
+	setStartProbeTickForTest(t, 300*time.Millisecond)
 	dir := runtimeTestDir(t)
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	updatedAt := time.Now()
@@ -1109,22 +1109,14 @@ func TestWaitForBackgroundServeReadyRenewsTimeoutOnStartupProgress(t *testing.T)
 	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
 
 	initialObserved := make(chan struct{}, 1)
-	progressObserved := make(chan struct{}, 1)
 	resultCh := make(chan *DaemonRuntime, 1)
 	errCh := make(chan error, 1)
 	go func() {
 		rt, waitErr := waitForBackgroundServeReadyWithPolicy(
-			context.Background(), dir, "", make(chan error), 200*time.Millisecond,
+			context.Background(), dir, "", make(chan error), 500*time.Millisecond,
 			backgroundServeReadyWaitPolicy{
 				Observe: func(st *startupState, _ time.Duration) {
 					if st == nil {
-						return
-					}
-					if st.Detail == "2/2 sessions" {
-						select {
-						case progressObserved <- struct{}{}:
-						default:
-						}
 						return
 					}
 					select {
@@ -1149,12 +1141,7 @@ func TestWaitForBackgroundServeReadyRenewsTimeoutOnStartupProgress(t *testing.T)
 		t.Fatal("readiness wait did not reach its final poll before timeout")
 	}
 	writeState("2/2 sessions", updatedAt.Add(time.Second))
-	select {
-	case <-progressObserved:
-	case <-time.After(time.Second):
-		t.Fatal("readiness wait did not observe advancing startup state")
-	}
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 	host, port := testPingServer(t)
 	_, err := WriteDaemonRuntime(dir, host, port, version, false)
 	require.NoError(t, err)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -147,8 +147,10 @@ agentsview serve restart
 agentsview serve stop
 ```
 
-The parent command starts a detached `agentsview serve` process, waits briefly
-for it to publish its runtime record, and prints the URL, PID, and log path.
+The parent command starts a detached `agentsview serve` process and waits for it
+to publish its runtime record. The five-second readiness window measures startup
+inactivity, so continuing startup progress can keep the parent waiting longer.
+It then prints the URL, PID, and log path.
 Background server output is written to `~/.agentsview/serve.log`. `serve status`
 reports the preferred managed process, URL, version, uptime, and read-only mode
 when available. `serve stop` retains its broad lifecycle scope: it gracefully


### PR DESCRIPTION
A detached serve can spend longer than five seconds on a healthy initial sync while continuously publishing structured startup progress. The parent currently treats that fixed wall-clock limit as failure, reports that the server did not become ready, and can leave users with a running daemon that the command declared unavailable.

This changes the five-second readiness limit into an inactivity window: each newer startup snapshot renews it, while a daemon whose progress stalls still times out normally. The timeout boundary also rechecks both the canonical writable runtime and the latest progress snapshot so publication in the final polling interval is not discarded.

The tradeoff is that the parent may remain attached beyond five seconds while startup is demonstrably advancing. The CLI reference documents that behavior. The readiness loop and advancing, stalled, and timeout-boundary regressions are in cmd/agentsview/serve_background.go and cmd/agentsview/serve_background_test.go.