### PR TITLE
recall: add [recall.extract] candidate_findings = "allow" to gate extraction on definite findings only (#1404)

### DIFF
--- a/cmd/agentsview/recall_extract.go
+++ b/cmd/agentsview/recall_extract.go
@@ -146,6 +146,8 @@ func setupRecallExtraction(
 	cfg config.Config, database *db.DB, idle *server.IdleTracker,
 ) (*extractScheduler, error) {
 	if !cfg.Recall.Extract.Enabled {
+		database.SetExtractCandidateFindingsAllowed(
+			cfg.Recall.Extract.AllowCandidateFindings())
 		return setupExtractReconcileOnly(database, idle)
 	}
 	dist, err := resolveExtractDistillation(cfg.Recall.Extract)

--- a/cmd/agentsview/recall_extract.go
+++ b/cmd/agentsview/recall_extract.go
@@ -134,6 +134,8 @@ func buildExtractManager(
 		Identity:       dist.Identity,
 		QuietPeriod:    dist.Quiet,
 		FailureBackoff: dist.Backoff,
+
+		AllowCandidateFindings: cfg.AllowCandidateFindings(),
 	})
 }
 
@@ -530,6 +532,11 @@ func newRecallExtractDoctorCommand() *cobra.Command {
 			fmt.Fprintf(out, "Profile: %s\n", dist.Profile)
 			fmt.Fprintf(out, "Segmenter: %s (max_window_chars=%d)\n",
 				dist.Segmenter.Name(), dist.Segmenter.MaxWindowChars)
+			candidateGate := config.RecallCandidateFindingsBlock
+			if cfg.Recall.Extract.AllowCandidateFindings() {
+				candidateGate = config.RecallCandidateFindingsAllow
+			}
+			fmt.Fprintf(out, "Candidate findings: %s\n", candidateGate)
 			fmt.Fprintf(out, "Fingerprint: %s\n", fingerprint)
 
 			ctx, cancel := context.WithTimeout(cmd.Context(),

--- a/cmd/agentsview/recall_extract_test.go
+++ b/cmd/agentsview/recall_extract_test.go
@@ -191,6 +191,46 @@ func TestSetupExtractReconcileOnlyWhenDisabled(t *testing.T) {
 		cancel()
 		sched.Stop()
 	})
+
+	t.Run("keeps candidate-only entries when configured", func(t *testing.T) {
+		d, err := db.Open(filepath.Join(t.TempDir(), "sessions.db"))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = d.Close() })
+		_, err = d.EnsureExtractGeneration(ctx, db.ExtractGeneration{
+			Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+		})
+		require.NoError(t, err)
+		require.NoError(t, d.UpsertSession(db.Session{
+			ID: "sess-candidate", Project: "p", Machine: "m", Agent: "claude",
+		}))
+		_, err = d.InsertExtractedRecallEntries(ctx, []db.RecallEntry{{
+			ID: "e-candidate", Type: "fact", ReviewState: "unreviewed_auto",
+			Status: "accepted", Title: "t", Body: "b",
+			SourceSessionID: "sess-candidate", SourceRunID: "fp-a",
+			ProvenanceOK: true,
+		}})
+		require.NoError(t, err)
+		require.NoError(t, d.ReplaceSessionSecretFindings(
+			"sess-candidate", []db.SecretFinding{{
+				SessionID: "sess-candidate", RuleName: "high-entropy-assignment",
+				Confidence: "candidate", LocationKind: "message",
+			}}, 0, "rules-v1"))
+
+		cfg := config.Config{}
+		cfg.Recall.Extract.CandidateFindings =
+			config.RecallCandidateFindingsAllow
+		sched, err := setupRecallExtraction(cfg, d, nil)
+		require.NoError(t, err)
+		require.NotNil(t, sched)
+		started, _, err := sched.mgr.TryPass(ctx, extract.PassOptions{})
+		require.NoError(t, err)
+		require.True(t, started)
+
+		entry, err := d.GetRecallEntry(ctx, "e-candidate")
+		require.NoError(t, err)
+		assert.NotNil(t, entry,
+			"candidate-only session keeps serving when configured allow")
+	})
 }
 
 func TestRecallExtractRunRefusesWhenDisabled(t *testing.T) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ description: Release history for AgentsView
 
 **New features**
 
+- Add `[recall.extract] candidate_findings = "allow"` to let recall extraction
+  gate sessions on definite-confidence secret findings only. Candidate-tier
+  matches (high-entropy assignments, JWT-shaped tokens, basic-auth URLs) stay
+  recorded for `secrets list --confidence candidate` but no longer exclude a
+  session from discovery, the pre-send transcript check, commit guards, or
+  reconciliation. The default `"block"` keeps the previous behavior; `recall
+  extract doctor` prints the active policy. (#1404)
+
 - Add automation-only one-shot capture for exact `claude -p` and
   `codex exec --json` executions, with isolated accounting, recoverable retries,
   exclusively created and protected local evidence, preserved child streams

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -56,12 +56,12 @@ links use `/recall?tab=generated&insight=<id>`.
 Generated insights use the configured OpenAI-compatible endpoint when
 `[insights]` has both an `endpoint` and `model`; when `[insights]` is absent,
 they use the selected agent CLI on your machine. Partial endpoint configuration
-is rejected during configuration validation. Endpoint mode sends one non-streaming
-`POST /chat/completions` request with the generated prompt as a user message.
-It accepts the first choice's `assistant` message with string `message.content`
-and optional response `model`. It does not support streaming, `/responses`, legacy completions,
-tool calls, or content-part arrays. An endpoint failure returns an error and
-does not retry through a CLI.
+is rejected during configuration validation. Endpoint mode sends one
+non-streaming `POST /chat/completions` request with the generated prompt as a
+user message. It accepts the first choice's `assistant` message with string
+`message.content` and optional response `model`. It does not support streaming,
+`/responses`, legacy completions, tool calls, or content-part arrays. An
+endpoint failure returns an error and does not retry through a CLI.
 
 ```toml
 [insights]
@@ -71,14 +71,14 @@ api_key_env = "OPENAI_API_KEY" # optional; the value is read at runtime
 # allow_http = true            # required for non-loopback HTTP endpoints
 ```
 
-Loopback HTTP endpoints are allowed for local models. Remote endpoints must
-use HTTPS unless `allow_http = true` explicitly opts into plaintext transport.
-The endpoint receives transcript-derived content, so review the provider's
-privacy and retention behavior. API keys stay in the environment and are sent
-only as a bearer header; they are not stored in the AgentsView configuration.
-Canned insight cache keys include the effective backend, model, and a safe
-endpoint identity, so changing `[insights]` after restarting the server selects
-a separate cached report. Changes to credentials or transport opt-ins do not
+Loopback HTTP endpoints are allowed for local models. Remote endpoints must use
+HTTPS unless `allow_http = true` explicitly opts into plaintext transport. The
+endpoint receives transcript-derived content, so review the provider's privacy
+and retention behavior. API keys stay in the environment and are sent only as a
+bearer header; they are not stored in the AgentsView configuration. Canned
+insight cache keys include the effective backend, model, and a safe endpoint
+identity, so changing `[insights]` after restarting the server selects a
+separate cached report. Changes to credentials or transport opt-ins do not
 change that identity; use force refresh when those changes should regenerate a
 report under the same endpoint and model.
 
@@ -199,10 +199,11 @@ names, and even a same-origin allowance can be steered elsewhere by re-resolving
 the hostname. Configure the endpoint with its final URL.
 
 Sessions are only ever extracted when they are not automated, not trashed, and
-have a clean, current **full** secret scan — a session with secret findings of
-any confidence, one never scanned, or one covered only by the fast inline sync
-scan never reaches the model. Run `agentsview secrets scan --backfill` to make
-sessions eligible. Session content is sent only to the endpoints you configure.
+have a clean, current **full** secret scan. By default, a session with secret
+findings of any confidence, one never scanned, or one covered only by the fast
+inline sync scan never reaches the model. Run
+`agentsview secrets scan --backfill` to make sessions eligible. Session content
+is sent only to the endpoints you configure.
 
 One knob narrows that boundary deliberately: `candidate_findings = "allow"`
 under `[recall.extract]`. Candidate-confidence findings — the false-positive-
@@ -212,8 +213,8 @@ longer exclude a session; only definite findings do, in discovery, in the
 pre-send transcript check, at commit, and in reconciliation. The default,
 `"block"`, keeps every recorded finding blocking. Consider `"allow"` when the
 endpoint is a machine you own and the archive is full of paths and identifiers
-that trip the entropy heuristic; keep the default for any endpoint you would
-not send a suspected secret to.
+that trip the entropy heuristic; keep the default for any endpoint you would not
+send a suspected secret to.
 
 Each distillation configuration (model, prompts, segmentation, request shape) is
 fingerprinted as a *generation*; changing the configuration builds a new corpus

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -185,7 +185,8 @@ Optional keys: `deployment` (labels which serving instance produced the corpus),
 `server` (selects among multiple named servers), `quiet_period` (default `"30m"`
 — how long a session must have been ended before extraction),
 `backstop_interval` (default `"1h"`), `failure_backoff` (default `"1h"`),
-`max_window_chars` (default 50000), `max_tokens`, per-server `api_key_env`, a
+`max_window_chars` (default 50000), `max_tokens`, `candidate_findings`
+(`"block"` default, or `"allow"` — see below), per-server `api_key_env`, a
 `[recall.extract.prompts]` table (`profile`, `dir`), and a
 `[recall.extract.request]` table (`temperature`, `extra_body`).
 
@@ -201,8 +202,18 @@ Sessions are only ever extracted when they are not automated, not trashed, and
 have a clean, current **full** secret scan — a session with secret findings of
 any confidence, one never scanned, or one covered only by the fast inline sync
 scan never reaches the model. Run `agentsview secrets scan --backfill` to make
-sessions eligible. These filters are not configurable. Session content is sent
-only to the endpoints you configure.
+sessions eligible. Session content is sent only to the endpoints you configure.
+
+One knob narrows that boundary deliberately: `candidate_findings = "allow"`
+under `[recall.extract]`. Candidate-confidence findings — the false-positive-
+prone heuristics (`high-entropy-assignment`, JWT-shaped tokens, basic-auth URLs)
+that `secrets list` hides unless asked — then stay recorded for review but no
+longer exclude a session; only definite findings do, in discovery, in the
+pre-send transcript check, at commit, and in reconciliation. The default,
+`"block"`, keeps every recorded finding blocking. Consider `"allow"` when the
+endpoint is a machine you own and the archive is full of paths and identifiers
+that trip the entropy heuristic; keep the default for any endpoint you would
+not send a suspected secret to.
 
 Each distillation configuration (model, prompts, segmentation, request shape) is
 fingerprinted as a *generation*; changing the configuration builds a new corpus

--- a/internal/config/config_recall_test.go
+++ b/internal/config/config_recall_test.go
@@ -198,6 +198,25 @@ func TestRecallExtractConfigValidate(t *testing.T) {
 				c.Servers["local"] = s
 			},
 		},
+		{
+			name: "candidate_findings allow",
+			mutate: func(c *RecallExtractConfig) {
+				c.CandidateFindings = RecallCandidateFindingsAllow
+			},
+		},
+		{
+			name: "candidate_findings block",
+			mutate: func(c *RecallExtractConfig) {
+				c.CandidateFindings = RecallCandidateFindingsBlock
+			},
+		},
+		{
+			name: "candidate_findings unknown value",
+			mutate: func(c *RecallExtractConfig) {
+				c.CandidateFindings = "maybe"
+			},
+			wantErr: "candidate_findings must be",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -446,4 +465,13 @@ func TestRecallExtractConfigTOMLLoadInvalid(t *testing.T) {
 		},
 	})
 	require.Error(t, err, "enabled without servers must fail at load")
+}
+
+func TestRecallExtractConfigAllowCandidateFindings(t *testing.T) {
+	cfg := validRecallExtractConfig()
+	assert.False(t, cfg.AllowCandidateFindings(), "default blocks every recorded finding")
+	cfg.CandidateFindings = RecallCandidateFindingsBlock
+	assert.False(t, cfg.AllowCandidateFindings())
+	cfg.CandidateFindings = RecallCandidateFindingsAllow
+	assert.True(t, cfg.AllowCandidateFindings())
 }

--- a/internal/config/config_recall_test.go
+++ b/internal/config/config_recall_test.go
@@ -43,6 +43,13 @@ func TestRecallExtractConfigValidate(t *testing.T) {
 			mutate: func(c *RecallExtractConfig) { *c = RecallExtractConfig{} },
 		},
 		{
+			name: "disabled rejects unknown candidate_findings",
+			mutate: func(c *RecallExtractConfig) {
+				*c = RecallExtractConfig{CandidateFindings: "maybe"}
+			},
+			wantErr: "candidate_findings must be",
+		},
+		{
 			name:    "enabled missing model",
 			mutate:  func(c *RecallExtractConfig) { c.Model = "" },
 			wantErr: "model is required",

--- a/internal/config/recall.go
+++ b/internal/config/recall.go
@@ -135,8 +135,6 @@ func (c RecallExtractConfig) ResolvedServer() (string, RecallExtractServerConfig
 	return name, s, nil
 }
 
-// Validate checks the extraction config for internal consistency. It is a
-// no-op when the section is disabled.
 // Values for RecallExtractConfig.CandidateFindings.
 const (
 	RecallCandidateFindingsBlock = "block"
@@ -150,7 +148,18 @@ func (c RecallExtractConfig) AllowCandidateFindings() bool {
 	return c.CandidateFindings == RecallCandidateFindingsAllow
 }
 
+// Validate checks the extraction config for internal consistency. When the
+// section is disabled, it validates only CandidateFindings because the
+// reconcile-only daemon path still applies that policy to a serving corpus.
 func (c RecallExtractConfig) Validate() error {
+	switch c.CandidateFindings {
+	case "", RecallCandidateFindingsBlock, RecallCandidateFindingsAllow:
+	default:
+		return fmt.Errorf(
+			"[recall.extract] candidate_findings must be %q or %q, got %q",
+			RecallCandidateFindingsBlock, RecallCandidateFindingsAllow,
+			c.CandidateFindings)
+	}
 	if !c.Enabled {
 		return nil
 	}
@@ -181,14 +190,6 @@ func (c RecallExtractConfig) Validate() error {
 		if err := c.Servers[name].validate(name); err != nil {
 			return err
 		}
-	}
-	switch c.CandidateFindings {
-	case "", RecallCandidateFindingsBlock, RecallCandidateFindingsAllow:
-	default:
-		return fmt.Errorf(
-			"[recall.extract] candidate_findings must be %q or %q, got %q",
-			RecallCandidateFindingsBlock, RecallCandidateFindingsAllow,
-			c.CandidateFindings)
 	}
 	if c.MaxWindowChars <= 0 {
 		return fmt.Errorf(

--- a/internal/config/recall.go
+++ b/internal/config/recall.go
@@ -54,9 +54,16 @@ type RecallExtractConfig struct {
 	BackstopInterval string `toml:"backstop_interval" json:"backstop_interval"`
 	// FailureBackoff is how long a failed session waits before being
 	// retried. Default "1h".
-	FailureBackoff string                     `toml:"failure_backoff" json:"failure_backoff"`
-	Prompts        RecallExtractPromptsConfig `toml:"prompts" json:"prompts"`
-	Request        RecallExtractRequestConfig `toml:"request" json:"request"`
+	FailureBackoff string `toml:"failure_backoff" json:"failure_backoff"`
+	// CandidateFindings selects how candidate-confidence secret findings
+	// (high-entropy assignments, JWT-shaped tokens, basic-auth URLs — the
+	// heuristics `secrets list` hides by default) gate extraction: "block"
+	// (default) excludes a session on any recorded finding; "allow" lets
+	// definite findings alone decide, so candidate matches are recorded for
+	// review without keeping the session out of the corpus.
+	CandidateFindings string                     `toml:"candidate_findings" json:"candidate_findings,omitempty"`
+	Prompts           RecallExtractPromptsConfig `toml:"prompts" json:"prompts"`
+	Request           RecallExtractRequestConfig `toml:"request" json:"request"`
 }
 
 // RecallExtractServerConfig is one named extraction endpoint: transport
@@ -130,6 +137,19 @@ func (c RecallExtractConfig) ResolvedServer() (string, RecallExtractServerConfig
 
 // Validate checks the extraction config for internal consistency. It is a
 // no-op when the section is disabled.
+// Values for RecallExtractConfig.CandidateFindings.
+const (
+	RecallCandidateFindingsBlock = "block"
+	RecallCandidateFindingsAllow = "allow"
+)
+
+// AllowCandidateFindings reports whether candidate-confidence secret
+// findings are excluded from the extraction gate (candidate_findings =
+// "allow"). The default keeps every recorded finding blocking.
+func (c RecallExtractConfig) AllowCandidateFindings() bool {
+	return c.CandidateFindings == RecallCandidateFindingsAllow
+}
+
 func (c RecallExtractConfig) Validate() error {
 	if !c.Enabled {
 		return nil
@@ -161,6 +181,14 @@ func (c RecallExtractConfig) Validate() error {
 		if err := c.Servers[name].validate(name); err != nil {
 			return err
 		}
+	}
+	switch c.CandidateFindings {
+	case "", RecallCandidateFindingsBlock, RecallCandidateFindingsAllow:
+	default:
+		return fmt.Errorf(
+			"[recall.extract] candidate_findings must be %q or %q, got %q",
+			RecallCandidateFindingsBlock, RecallCandidateFindingsAllow,
+			c.CandidateFindings)
 	}
 	if c.MaxWindowChars <= 0 {
 		return fmt.Errorf(
@@ -410,6 +438,9 @@ func (c *Config) mergeRecallExtractTOML(file RecallConfig, meta toml.MetaData) {
 	}
 	if file.Extract.FailureBackoff != "" {
 		extract.FailureBackoff = file.Extract.FailureBackoff
+	}
+	if file.Extract.CandidateFindings != "" {
+		extract.CandidateFindings = file.Extract.CandidateFindings
 	}
 	if file.Extract.Prompts.Profile != "" {
 		extract.Prompts.Profile = file.Extract.Prompts.Profile

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -663,6 +663,12 @@ type DB struct {
 	// ErrWriterClosed instead of the generic read-only error.
 	writerClosed atomic.Bool
 	dataStale    atomic.Bool // set by Open when user_version < dataVersion
+	// extractAllowCandidateFindings narrows the recall-extraction secret
+	// gate to definite-confidence findings. Set by the extraction manager
+	// from [recall.extract] candidate_findings; false (every recorded
+	// finding blocks) until then, so read-only tools and archives without
+	// extraction keep the strict boundary.
+	extractAllowCandidateFindings atomic.Bool
 
 	cursorMu     sync.RWMutex
 	cursorSecret []byte
@@ -5012,4 +5018,19 @@ func (db *DB) GetOrCreateSyncState(key, defaultValue string) (string, error) {
 		"SELECT value FROM pg_sync_state WHERE key = ?", key,
 	).Scan(&value)
 	return value, err
+}
+
+// SetExtractCandidateFindingsAllowed selects the secret-findings tier that
+// gates recall extraction on this archive: false (default) excludes a session
+// on any recorded finding, true on definite-confidence findings only. The
+// extraction manager sets it from configuration; the eligibility, guard,
+// activation and reconciliation queries all read it.
+func (db *DB) SetExtractCandidateFindingsAllowed(allow bool) {
+	db.extractAllowCandidateFindings.Store(allow)
+}
+
+// ExtractCandidateFindingsAllowed reports the current policy; see
+// SetExtractCandidateFindingsAllowed.
+func (db *DB) ExtractCandidateFindingsAllowed() bool {
+	return db.extractAllowCandidateFindings.Load()
 }

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -223,6 +223,7 @@ func (db *DB) ActivateExtractGeneration(
 
 	if err := verifyExtractActivationCoverageTx(
 		ctx, tx, fingerprint, scanVersions, quietCutoff,
+		db.ExtractCandidateFindingsAllowed(),
 	); err != nil {
 		return err
 	}
@@ -286,7 +287,8 @@ func (db *DB) ActivateExtractGeneration(
 		return `NOT EXISTS (SELECT 1 FROM sessions s
 			WHERE s.id = ` + idColumn + `
 			  AND ` +
-			fmt.Sprintf(extractEligibleSessionSQL, versionMarks) + `)`
+			fmt.Sprintf(extractEligibleSessionSQL, versionMarks,
+				extractFindingsGateSQL(db.ExtractCandidateFindingsAllowed())) + `)`
 	}
 	staleArgs := make([]any, 0, len(scanVersions)+2)
 	staleArgs = append(staleArgs, fingerprint)
@@ -370,8 +372,9 @@ func (db *DB) ActivateExtractGeneration(
 // pass removes them.
 func verifyExtractActivationCoverageTx(
 	ctx context.Context, tx *sql.Tx, fingerprint string,
-	scanVersions []string, quietCutoff time.Time,
+	scanVersions []string, quietCutoff time.Time, allowCandidates bool,
 ) error {
+	gate := extractFindingsGateSQL(allowCandidates)
 	versionMarks := strings.TrimSuffix(
 		strings.Repeat("?,", len(scanVersions)), ",")
 	// Full eligibility, not merely "not hard-ineligible": a pending or
@@ -395,7 +398,7 @@ func verifyExtractActivationCoverageTx(
 		SELECT COUNT(*) FROM recall_extract_progress p
 		JOIN sessions s ON s.id = p.session_id
 		WHERE p.generation_fingerprint = ? AND p.state IN (?, ?)
-		  AND `+fmt.Sprintf(extractEligibleSessionSQL, versionMarks),
+		  AND `+fmt.Sprintf(extractEligibleSessionSQL, versionMarks, gate),
 		buildingArgs...,
 	).Scan(&building); err != nil {
 		return fmt.Errorf("counting unfinished coverage: %w", err)
@@ -421,7 +424,7 @@ func verifyExtractActivationCoverageTx(
 		SELECT COUNT(*) FROM recall_extract_progress p
 		JOIN sessions s ON s.id = p.session_id
 		WHERE p.generation_fingerprint = ? AND p.state = ?
-		  AND NOT (`+extractSessionIneligibleSQL+`)
+		  AND NOT (`+extractSessionIneligibleSQL(allowCandidates)+`)
 		  AND (
 			((s.local_modified_at IS NULL AND p.content_stamped_at = '')
 				OR s.local_modified_at >= p.content_stamped_at)
@@ -456,7 +459,7 @@ func verifyExtractActivationCoverageTx(
 		SELECT COUNT(*) FROM recall_extract_progress p
 		JOIN sessions s ON s.id = p.session_id
 		WHERE p.generation_fingerprint = ? AND p.state = ?
-		  AND `+fmt.Sprintf(extractEligibleSessionSQL, versionMarks)+`
+		  AND `+fmt.Sprintf(extractEligibleSessionSQL, versionMarks, gate)+`
 		  AND ((s.local_modified_at IS NULL AND p.content_stamped_at = '')
 			OR s.local_modified_at >= p.content_stamped_at)
 		  AND EXISTS (
@@ -485,7 +488,7 @@ func verifyExtractActivationCoverageTx(
 	if err := tx.QueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1 FROM sessions s
-			WHERE `+fmt.Sprintf(extractEligibleSessionSQL, versionMarks)+`
+			WHERE `+fmt.Sprintf(extractEligibleSessionSQL, versionMarks, gate)+`
 			  AND NOT EXISTS (
 				SELECT 1 FROM recall_extract_progress p
 				WHERE p.session_id = s.id
@@ -1171,18 +1174,35 @@ type ExtractCandidateQuery struct {
 	// revisit unrestricted; ignored unless IncludeDone is set.
 	DoneChangedSince time.Time
 	Limit            int
+	// allowCandidateFindings mirrors DB.ExtractCandidateFindingsAllowed at
+	// query time; ExtractCandidates sets it, tests may leave it zero.
+	allowCandidateFindings bool
+}
+
+// extractFindingsGateSQL is the secret_findings predicate shared by every
+// extraction boundary (aliases: sessions s, secret_findings sf). By default
+// any recorded finding excludes the session; when candidate findings are
+// allowed (see DB.SetExtractCandidateFindingsAllowed) only definite-tier
+// findings do, and the candidate tier stays recorded for review.
+func extractFindingsGateSQL(allowCandidates bool) string {
+	if allowCandidates {
+		return "sf.session_id = s.id AND sf.confidence = 'definite'"
+	}
+	return "sf.session_id = s.id"
 }
 
 // extractEligibleSessionSQL is the extraction privacy boundary over one
 // sessions row aliased s. Every arm of the candidates query applies it, so
 // the discovery and progress paths can never disagree about eligibility. It
-// consumes len(ScanVersions)+1 args: the versions, then the quiet cutoff.
+// takes two format arguments — the scan-version placeholders and the
+// findings gate from extractFindingsGateSQL — and consumes
+// len(ScanVersions)+1 query args: the versions, then the quiet cutoff.
 const extractEligibleSessionSQL = `s.deleted_at IS NULL
 	AND s.is_automated = 0
 	AND s.secret_leak_count = 0
 	AND s.secrets_rules_version IN (%s)
 	AND NOT EXISTS (
-		SELECT 1 FROM secret_findings sf WHERE sf.session_id = s.id
+		SELECT 1 FROM secret_findings sf WHERE %s
 	)
 	AND s.message_count > 0
 	AND s.ended_at IS NOT NULL
@@ -1214,7 +1234,8 @@ func extractCandidateSQL(q ExtractCandidateQuery) (string, []any, error) {
 	}
 	versionMarks := strings.Repeat("?,", len(q.ScanVersions))
 	versionMarks = versionMarks[:len(versionMarks)-1]
-	eligible := fmt.Sprintf(extractEligibleSessionSQL, versionMarks)
+	eligible := fmt.Sprintf(extractEligibleSessionSQL, versionMarks,
+		extractFindingsGateSQL(q.allowCandidateFindings))
 	eligibleArgs := make([]any, 0, len(q.ScanVersions)+1)
 	for _, version := range q.ScanVersions {
 		eligibleArgs = append(eligibleArgs, version)
@@ -1323,6 +1344,7 @@ func (db *DB) ExtractCandidates(
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	q.allowCandidateFindings = db.ExtractCandidateFindingsAllowed()
 	query, args, err := extractCandidateSQL(q)
 	if err != nil {
 		return nil, err
@@ -1453,12 +1475,13 @@ func (db *DB) CommitExtractedUnit(
 	}
 	defer func() { _ = tx.Rollback() }()
 	if err := verifyExtractSessionGuardTx(ctx, tx, ExtractSessionGuard{
-		SessionID:          u.SessionID,
-		ScanVersions:       u.ScanVersions,
-		MessageCount:       u.MessageCount,
-		TranscriptRevision: u.TranscriptRevision,
-		LocalModifiedAt:    u.LocalModifiedAt,
-		EndedAt:            u.EndedAt,
+		AllowCandidateFindings: db.ExtractCandidateFindingsAllowed(),
+		SessionID:              u.SessionID,
+		ScanVersions:           u.ScanVersions,
+		MessageCount:           u.MessageCount,
+		TranscriptRevision:     u.TranscriptRevision,
+		LocalModifiedAt:        u.LocalModifiedAt,
+		EndedAt:                u.EndedAt,
 	}); err != nil {
 		return 0, err
 	}
@@ -1512,12 +1535,15 @@ func (db *DB) CommitExtractedUnit(
 // derived from; verification refuses the write when the stored row has
 // moved or the session is no longer eligible.
 type ExtractSessionGuard struct {
-	SessionID          string
-	ScanVersions       []string
-	MessageCount       int
-	TranscriptRevision *string
-	LocalModifiedAt    *string
-	EndedAt            *string
+	// AllowCandidateFindings narrows the commit-time findings check to
+	// definite-confidence findings (see DB.SetExtractCandidateFindingsAllowed).
+	AllowCandidateFindings bool
+	SessionID              string
+	ScanVersions           []string
+	MessageCount           int
+	TranscriptRevision     *string
+	LocalModifiedAt        *string
+	EndedAt                *string
 }
 
 func verifyExtractSessionGuardTx(
@@ -1575,10 +1601,11 @@ func verifyExtractSessionGuardTx(
 			u.SessionID)
 	}
 	var findings int
-	if err := tx.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM secret_findings WHERE session_id = ?",
-		u.SessionID,
-	).Scan(&findings); err != nil {
+	findingsSQL := "SELECT COUNT(*) FROM secret_findings WHERE session_id = ?"
+	if u.AllowCandidateFindings {
+		findingsSQL += " AND confidence = 'definite'"
+	}
+	if err := tx.QueryRowContext(ctx, findingsSQL, u.SessionID).Scan(&findings); err != nil {
 		return fmt.Errorf(
 			"counting findings for session %s: %w", u.SessionID, err)
 	}
@@ -1657,10 +1684,15 @@ func bindExtractedEvidenceTx(
 // qualify — they are transient (every transcript write clears the stamp
 // until rescan) and retracting on them would rebuild the corpus on every
 // sync.
-const extractSessionIneligibleSQL = `s.deleted_at IS NOT NULL
+func extractSessionIneligibleSQL(allowCandidates bool) string {
+	return `s.deleted_at IS NOT NULL
 	OR s.is_automated != 0
 	OR s.secret_leak_count > 0
-	OR EXISTS (SELECT 1 FROM secret_findings sf WHERE sf.session_id = s.id)`
+	OR EXISTS (
+		SELECT 1 FROM secret_findings sf WHERE ` +
+		extractFindingsGateSQL(allowCandidates) + `
+	)`
+}
 
 // ReconcileIneligibleExtractSessions removes the generated corpus of
 // sessions that lost extraction eligibility after extraction. It is
@@ -1694,7 +1726,7 @@ func (db *DB) ReconcileIneligibleExtractSessions(
 	defer func() { _ = tx.Rollback() }()
 	ineligible := `
 		SELECT s.id FROM sessions s
-		WHERE (` + extractSessionIneligibleSQL + `)`
+		WHERE (` + extractSessionIneligibleSQL(db.ExtractCandidateFindingsAllowed()) + `)`
 	var bound []any
 	if !changedSince.IsZero() {
 		ineligible += `
@@ -1999,12 +2031,13 @@ func (db *DB) RefreshExtractedSessionCoverage(
 	}
 	defer func() { _ = tx.Rollback() }()
 	if err := verifyExtractSessionGuardTx(ctx, tx, ExtractSessionGuard{
-		SessionID:          u.Session.ID,
-		ScanVersions:       u.ScanVersions,
-		MessageCount:       u.Session.MessageCount,
-		TranscriptRevision: u.Session.TranscriptRevision,
-		LocalModifiedAt:    u.Session.LocalModifiedAt,
-		EndedAt:            u.Session.EndedAt,
+		AllowCandidateFindings: db.ExtractCandidateFindingsAllowed(),
+		SessionID:              u.Session.ID,
+		ScanVersions:           u.ScanVersions,
+		MessageCount:           u.Session.MessageCount,
+		TranscriptRevision:     u.Session.TranscriptRevision,
+		LocalModifiedAt:        u.Session.LocalModifiedAt,
+		EndedAt:                u.Session.EndedAt,
 	}); err != nil {
 		return zero, err
 	}

--- a/internal/db/recall_extract_test.go
+++ b/internal/db/recall_extract_test.go
@@ -3167,3 +3167,109 @@ func TestRefreshExtractedSessionCoverageRestoresProvenance(t *testing.T) {
 	assert.Equal(t, "sess-1-uuid-0", evidence.MessageStartSourceUUID)
 	assert.Equal(t, "sess-1-uuid-1", evidence.MessageEndSourceUUID)
 }
+
+func TestExtractCandidatesAllowCandidateFindingsPolicy(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	d.SetExtractCandidateFindingsAllowed(true)
+
+	seedExtractCandidate(t, d, "sess-clean", 2*time.Hour, nil)
+	seedExtractCandidate(t, d, "sess-candidate", 2*time.Hour, nil)
+	seedExtractCandidate(t, d, "sess-definite", 2*time.Hour, nil)
+	require.NoError(t, d.ReplaceSessionSecretFindings(
+		"sess-candidate",
+		[]SecretFinding{{
+			SessionID:    "sess-candidate",
+			RuleName:     "high-entropy-assignment",
+			Confidence:   "candidate",
+			LocationKind: "message",
+		}},
+		0, "rules-v1",
+	))
+	require.NoError(t, d.ReplaceSessionSecretFindings(
+		"sess-definite",
+		[]SecretFinding{{
+			SessionID:    "sess-definite",
+			RuleName:     "aws-access-key-id",
+			Confidence:   "definite",
+			LocationKind: "message",
+		}},
+		1, "rules-v1",
+	))
+
+	ids, err := d.ExtractCandidates(ctx, ExtractCandidateQuery{
+		Fingerprint:  "fp-a",
+		QuietCutoff:  time.Now().Add(-30 * time.Minute),
+		ScanVersions: []string{"rules-v1"},
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"sess-clean", "sess-candidate"}, ids,
+		"with candidate findings allowed only definite findings exclude a session")
+
+	// Switching the policy back restores the strict boundary on the same rows.
+	d.SetExtractCandidateFindingsAllowed(false)
+	ids, err = d.ExtractCandidates(ctx, ExtractCandidateQuery{
+		Fingerprint:  "fp-a",
+		QuietCutoff:  time.Now().Add(-30 * time.Minute),
+		ScanVersions: []string{"rules-v1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sess-clean"}, ids)
+}
+
+func TestReconcileIneligibleKeepsCandidateOnlySessionsWhenAllowed(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	d.SetExtractCandidateFindingsAllowed(true)
+	fp := "fp-a"
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: fp, Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	entry := func(id, sessionID, fp string) RecallEntry {
+		return RecallEntry{
+			ID: id, Type: "fact", Scope: "project", Status: "accepted",
+			ReviewState: "unreviewed_auto", Title: "t", Body: "b",
+			SourceSessionID: sessionID, SourceRunID: fp,
+			Evidence: []RecallEvidence{{
+				SessionID: sessionID, MessageEndOrdinal: 1,
+			}},
+		}
+	}
+	for _, id := range []string{"sess-candidate", "sess-definite"} {
+		seedExtractCandidate(t, d, id, 2*time.Hour, nil)
+		_, err = d.UpsertExtractProgress(ctx, ExtractProgressUpsert{
+			SessionID: id, Fingerprint: fp,
+			ContentDigest: "dg", UnitsTotal: 2, StampedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		_, err = d.InsertExtractedRecallEntries(ctx, []RecallEntry{
+			entry("e-"+id, id, fp),
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, d.ReplaceSessionSecretFindings(
+		"sess-candidate", []SecretFinding{{
+			SessionID: "sess-candidate", RuleName: "high-entropy-assignment",
+			Confidence: "candidate", LocationKind: "message",
+			RedactedMatch: "…AHm", RulesVersion: "rules-v1",
+		}}, 0, "rules-v1"))
+	require.NoError(t, d.ReplaceSessionSecretFindings(
+		"sess-definite", []SecretFinding{{
+			SessionID: "sess-definite", RuleName: "aws-access-key-id",
+			Confidence: "definite", LocationKind: "message",
+			RedactedMatch: "AKIA…", RulesVersion: "rules-v1",
+		}}, 1, "rules-v1"))
+
+	rowsRemoved, entriesDeleted, err := d.ReconcileIneligibleExtractSessions(
+		ctx, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, rowsRemoved, "only the definite-finding session is retracted")
+	assert.Equal(t, 1, entriesDeleted)
+	kept, err := d.GetRecallEntry(ctx, "e-sess-candidate")
+	require.NoError(t, err)
+	assert.NotNil(t, kept, "candidate-only session keeps its entries")
+	gone, err := d.GetRecallEntry(ctx, "e-sess-definite")
+	require.NoError(t, err)
+	assert.Nil(t, gone)
+}

--- a/internal/recall/extract/manager.go
+++ b/internal/recall/extract/manager.go
@@ -51,6 +51,14 @@ type ManagerConfig struct {
 	FailureBackoff time.Duration
 	// MaxAttempts bounds transient retries per model call. Defaults to 3.
 	MaxAttempts int
+	// AllowCandidateFindings narrows the secret gate to definite-confidence
+	// findings: candidate-tier matches (high-entropy assignments, JWT-shaped
+	// tokens, basic-auth URLs) stay recorded for review but no longer keep a
+	// session out of extraction, in discovery, the pre-send transcript
+	// re-scan, commit-time drift checks, and ineligibility reconciliation.
+	// Off by default: every recorded finding blocks. NewManager applies the
+	// same policy to the archive so the SQL boundaries agree with it.
+	AllowCandidateFindings bool
 }
 
 // Manager drives extraction for one generation: it scans for eligible
@@ -156,6 +164,7 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	if cfg.FailureBackoff <= 0 {
 		cfg.FailureBackoff = defaultFailureBackoff
 	}
+	cfg.DB.SetExtractCandidateFindingsAllowed(cfg.AllowCandidateFindings)
 	if cfg.MaxAttempts <= 0 {
 		cfg.MaxAttempts = defaultMaxAttempts
 	}
@@ -404,13 +413,29 @@ func (m *Manager) refuseSecretFindings(
 	if err != nil {
 		return err
 	}
-	if len(findings) > 0 {
+	if n := m.blockingFindings(findings); n > 0 {
 		return &ineligibleSessionError{err: fmt.Errorf(
 			"session %s has %d recorded secret findings and is excluded "+
-				"from extraction", sessionID, len(findings),
+				"from extraction", sessionID, n,
 		)}
 	}
 	return nil
+}
+
+// blockingFindings counts the recorded findings that exclude a session:
+// all of them by default, definite-confidence ones only when candidate
+// findings are allowed.
+func (m *Manager) blockingFindings(findings []db.SecretFinding) int {
+	if !m.cfg.AllowCandidateFindings {
+		return len(findings)
+	}
+	n := 0
+	for _, f := range findings {
+		if f.Confidence == secrets.ConfidenceDefinite {
+			n++
+		}
+	}
+	return n
 }
 
 // settledPastQuietPeriod refuses a session whose ended_at falls inside
@@ -591,7 +616,7 @@ func (m *Manager) extractSession(
 	// incremental append whose deferred rescan crashed before it landed).
 	// Re-scanning the content this function is about to send makes the
 	// boundary independent of that history.
-	secretMatches := transcriptSecretMatches(rows)
+	secretMatches := transcriptSecretMatches(rows, m.cfg.AllowCandidateFindings)
 	messages := make([]Message, 0, len(rows))
 	for _, row := range rows {
 		messages = append(messages, Message{
@@ -610,7 +635,7 @@ func (m *Manager) extractSession(
 	// token in the scan that the endpoint still receives contiguously. Raw
 	// contents, not formatted unit texts, so interposed formatting cannot
 	// push a straddling key under the scanner's payload-purity gate.
-	secretMatches += aggregateModelSecretMatches(messages)
+	secretMatches += aggregateModelSecretMatches(messages, m.cfg.AllowCandidateFindings)
 	units := m.cfg.Segmenter.Units(messages)
 	digest := unitsDigest(units)
 	// A digest change means previously extracted units may have different
@@ -914,7 +939,7 @@ func (m *Manager) recheckExtraction(
 	if err != nil {
 		return false, false, err
 	}
-	if len(findings) > 0 {
+	if m.blockingFindings(findings) > 0 {
 		return false, false, nil
 	}
 	return true, !sessionSnapshotChanged(before, recheck), nil
@@ -984,17 +1009,29 @@ func (m *Manager) discardSessionOutput(
 // single-token credential split mid-token across messages, which the newline
 // would otherwise break so a regex needing contiguous characters could not
 // match. Either matching means the material is present.
-func aggregateModelSecretMatches(messages []Message) int {
+func aggregateModelSecretMatches(messages []Message, allowCandidates bool) int {
 	texts := VisibleContents(messages)
-	matches := len(secrets.Scan(strings.Join(texts, "\n")))
-	matches += len(secrets.Scan(strings.Join(texts, "")))
+	scan := gateScanner(allowCandidates)
+	matches := len(scan(strings.Join(texts, "\n")))
+	matches += len(scan(strings.Join(texts, "")))
 	return matches
 }
 
-func transcriptSecretMatches(rows []db.Message) int {
+// gateScanner picks the ruleset the pre-send re-scan applies: the full
+// ruleset by default, definite rules only when candidate findings are
+// allowed — the same tier split the archive's eligibility SQL uses.
+func gateScanner(allowCandidates bool) func(string) []secrets.Match {
+	if allowCandidates {
+		return secrets.ScanDefinite
+	}
+	return secrets.Scan
+}
+
+func transcriptSecretMatches(rows []db.Message, allowCandidates bool) int {
+	scan := gateScanner(allowCandidates)
 	matches := 0
 	for _, row := range rows {
-		matches += len(secrets.Scan(row.Content))
+		matches += len(scan(row.Content))
 	}
 	return matches
 }

--- a/internal/recall/extract/manager_test.go
+++ b/internal/recall/extract/manager_test.go
@@ -2882,3 +2882,112 @@ func TestManagerRunPassDiscardsEntriesWhenRevisitFindsSecrets(t *testing.T) {
 	assert.Equal(t, db.ExtractProgressFailed, progress.State)
 	assert.Contains(t, progress.LastError, "secrets scan --backfill")
 }
+
+func TestManagerAllowCandidateFindingsExtractsCandidateOnlySessions(t *testing.T) {
+	d := newTestArchive(t)
+	ctx := context.Background()
+	server, log := modelServer(t, alwaysEntries(t, "x"))
+	// A full scan recorded only a candidate-confidence match (a high-entropy
+	// path, a JWT-shaped identifier): leak count zero. With
+	// candidate_findings = "allow" that must not keep the session out.
+	seedSession(t, d, "sess-candidate", turnMessages("a", "b"), nil)
+	if err := d.ReplaceSessionSecretFindings(
+		"sess-candidate",
+		[]db.SecretFinding{{
+			SessionID:     "sess-candidate",
+			RuleName:      "high-entropy-assignment",
+			Confidence:    "candidate",
+			LocationKind:  "message",
+			RedactedMatch: "…AHm",
+		}},
+		0, secrets.RulesVersion(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	m := newManager(t, d, server.URL, func(c *ManagerConfig) {
+		c.AllowCandidateFindings = true
+	})
+
+	result, err := m.RunPass(ctx, PassOptions{})
+	if err != nil {
+		t.Fatalf("RunPass: %v", err)
+	}
+	if result.Sessions != 1 || result.Failed != 0 || log.count() == 0 {
+		t.Fatalf("candidate-only session must be extracted when candidate "+
+			"findings are allowed: %+v, %d calls", result, log.count())
+	}
+	if _, err := m.RunPass(ctx, PassOptions{SessionID: "sess-candidate"}); err != nil {
+		t.Fatalf("explicit run on a candidate-only session must be accepted: %v", err)
+	}
+}
+
+func TestManagerAllowCandidateFindingsStillRefusesDefinite(t *testing.T) {
+	d := newTestArchive(t)
+	ctx := context.Background()
+	server, log := modelServer(t, alwaysEntries(t, "x"))
+	// The relaxed policy narrows the gate to definite findings; it must not
+	// open it. A definite finding (leak count 1) keeps the session out.
+	seedSession(t, d, "sess-definite", turnMessages("a", "b"), nil)
+	if err := d.ReplaceSessionSecretFindings(
+		"sess-definite",
+		[]db.SecretFinding{{
+			SessionID:     "sess-definite",
+			RuleName:      "aws-access-key-id",
+			Confidence:    "definite",
+			LocationKind:  "message",
+			RedactedMatch: "AKIA…",
+		}},
+		1, secrets.RulesVersion(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	m := newManager(t, d, server.URL, func(c *ManagerConfig) {
+		c.AllowCandidateFindings = true
+	})
+
+	result, err := m.RunPass(ctx, PassOptions{})
+	if err != nil {
+		t.Fatalf("RunPass: %v", err)
+	}
+	if result.Sessions != 0 || log.count() != 0 {
+		t.Fatalf("definite finding must still exclude the session: %+v, "+
+			"%d calls", result, log.count())
+	}
+	if _, err := m.RunPass(ctx, PassOptions{SessionID: "sess-definite"}); err == nil {
+		t.Fatal("explicit run on a session with a definite finding must be refused")
+	}
+	if log.count() != 0 {
+		t.Fatal("refusal must happen before any model call")
+	}
+}
+
+func TestManagerAllowCandidateFindingsPreSendScanIgnoresCandidateText(t *testing.T) {
+	d := newTestArchive(t)
+	ctx := context.Background()
+	server, log := modelServer(t, alwaysEntries(t, "x"))
+	// The transcript itself contains candidate-tier material (a high-entropy
+	// assignment) that the pre-send re-scan would normally reject "despite a
+	// current scan stamp". Under the relaxed policy the re-scan applies
+	// definite rules only, so the unit reaches the model.
+	seedSession(t, d, "sess-entropy", turnMessages(
+		"set GDRIVE_FOLDER=1a4UzQ9x7LmP3nR8vT2wY5bC6dE0fG1hJ4kL7mNAHm and sync",
+		"done",
+	), nil)
+	if err := d.ReplaceSessionSecretFindings(
+		"sess-entropy", nil, 0, secrets.RulesVersion(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	m := newManager(t, d, server.URL, func(c *ManagerConfig) {
+		c.AllowCandidateFindings = true
+	})
+
+	result, err := m.RunPass(ctx, PassOptions{})
+	if err != nil {
+		t.Fatalf("RunPass: %v", err)
+	}
+	if result.Failed != 0 || result.Sessions != 1 || log.count() == 0 {
+		t.Fatalf("candidate-tier text must not fail the pre-send scan when "+
+			"candidate findings are allowed: %+v, %d calls", result, log.count())
+	}
+}


### PR DESCRIPTION
Adds an opt-in for Recall extraction to ignore candidate-confidence secret
findings while continuing to block definite findings:

```toml
[recall.extract]
candidate_findings = "allow" # default: "block"
```

Candidate findings are false-positive-prone heuristics that remain recorded for
review. With `"allow"`, they no longer exclude a session during discovery,
pre-send scanning, commit and activation guards, or corpus reconciliation. The
same policy applies when extraction is disabled but an existing corpus remains
served.

The default remains `"block"`, so existing configurations keep treating every
recorded finding as an extraction boundary. `recall extract doctor` reports the
active policy. This change does not alter the database schema.

Addresses #1404.
