### PR TITLE
fix(frontend): keep concurrency tooltip on screen and ignore future buckets

### DIFF
--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -38,7 +38,29 @@
   );
 
   let tooltip = $state<{ x: number; y: number; bucket: ActivityBucket } | null>(null);
+  let tooltipEl = $state<HTMLDivElement>();
+  let tooltipPos = $state<{ left: number; top: number } | null>(null);
   let keyboardAnchorIndex = $state<number | null>(null);
+
+  const TIP_PAD = 8;
+
+  // Clamp the measured tooltip box inside the viewport so it stays fully
+  // visible when the hovered bucket sits near a chart or window edge. The
+  // tooltip renders hidden for one frame while this measures it.
+  $effect(() => {
+    if (!tooltip || !tooltipEl) {
+      tooltipPos = null;
+      return;
+    }
+    const w = tooltipEl.offsetWidth;
+    const h = tooltipEl.offsetHeight;
+    const left = Math.min(
+      Math.max(tooltip.x - w / 2, TIP_PAD),
+      Math.max(window.innerWidth - w - TIP_PAD, TIP_PAD),
+    );
+    const top = Math.max(tooltip.y - h, TIP_PAD);
+    tooltipPos = { left, top };
+  });
 
   // Format bucket boundaries in the report's own timezone. Bucket start/end are
   // UTC instants of local calendar boundaries, so rendering them in the report
@@ -160,7 +182,7 @@
     const next = Math.max(
       0,
       Math.min(
-        buckets.length - 1,
+        liveBars.length - 1,
         idx + (e.key === "ArrowRight" ? 1 : -1),
       ),
     );
@@ -205,19 +227,19 @@
   }
 
   function moveRangeDrag(event: PointerEvent) {
-    if (dragStart === null || !containerEl || bars.length === 0) return;
+    if (dragStart === null || !containerEl || liveBars.length === 0) return;
     const x = event.clientX - containerEl.getBoundingClientRect().left;
-    const first = bars[0]!;
-    const last = bars.at(-1)!;
+    const first = liveBars[0]!;
+    const last = liveBars.at(-1)!;
     if (x <= first.cellX) {
       dragEnd = 0;
       return;
     }
     if (x >= last.cellX + last.cellW) {
-      dragEnd = bars.length - 1;
+      dragEnd = liveBars.length - 1;
       return;
     }
-    const idx = bars.findIndex((bar) => x < bar.cellX + bar.cellW);
+    const idx = liveBars.findIndex((bar) => x < bar.cellX + bar.cellW);
     if (idx >= 0) dragEnd = idx;
   }
 
@@ -523,6 +545,14 @@
     Math.max(((rangeEndMs - futureStartMs) / rangeSpanMs) * plotWidth, 0),
   );
 
+  // Buckets that start at or after the effective end are entirely in the
+  // future. They get no hit target, so they cannot be hovered, focused,
+  // tooltipped, or selected. Buckets are chronological, so this is a prefix
+  // of bars and slot indexes stay aligned.
+  const liveBars = $derived(
+    bars.filter((bar) => Date.parse(buckets[bar.idx]!.start) < futureStartMs),
+  );
+
   const svgH = $derived(CHART_H + STRIP_GAP + STRIP_H + X_LABEL_H);
   const stripY = $derived(CHART_H + STRIP_GAP);
 
@@ -713,7 +743,7 @@
           />
         {/if}
 
-        {#each bars as bar (bar.idx)}
+        {#each liveBars as bar (bar.idx)}
           {@const b = buckets[bar.idx]}
           <Rect
             class="slot-hit"
@@ -738,7 +768,13 @@
     </Chart>
 
     {#if tooltip}
-      <div class="tooltip" style="left: {tooltip.x}px; top: {tooltip.y}px;">
+      <div
+        bind:this={tooltipEl}
+        class="tooltip"
+        style={tooltipPos
+          ? `left: ${tooltipPos.left}px; top: ${tooltipPos.top}px;`
+          : "visibility: hidden;"}
+      >
         <div class="tooltip-date">{fmtBucketRange(tooltip.bucket)}</div>
         <dl class="tooltip-metrics">
           <div>
@@ -957,7 +993,6 @@
 
   .tooltip {
     position: fixed;
-    transform: translateX(-50%) translateY(-100%);
     min-width: 168px;
     padding: 8px 10px;
     background: var(--text-primary);

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
@@ -341,6 +341,105 @@ describe("ConcurrencyTimeline", () => {
     unmount(c);
   });
 
+  it("renders no hit target for future buckets and clamps keyboard nav to live ones", async () => {
+    // The last of the three minute buckets starts at the effective end, so it
+    // is entirely in the future: it must not be hoverable, tooltippable, or
+    // reachable, while its bar geometry still renders.
+    const report = minuteReport({
+      elapsed_bucket_count: 2,
+      partial: true,
+      as_of: "2026-06-16T00:10:00Z",
+      effective_end: "2026-06-16T00:10:00Z",
+    });
+    report.buckets![2] = {
+      ...report.buckets![2]!,
+      max_agents: 0,
+      agent_minutes: 0,
+      output_tokens: 0,
+    };
+    const onSelectRange = vi.fn();
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, {
+      target,
+      props: { report, onSelectRange },
+    });
+    await tick();
+
+    const hits = target.querySelectorAll(".slot-hit");
+    expect(hits.length).toBe(2);
+    expect(target.querySelector('[data-concurrency-bucket-index="2"]')).toBeNull();
+    // The future bucket keeps its (zero-height) bar segments.
+    expect(target.querySelectorAll(".concurrency-seg.interactive").length).toBe(3);
+
+    // Shift+ArrowRight from the last live slot clamps to the live range
+    // instead of extending the selection into the future bucket.
+    hits[1]!.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "ArrowRight",
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    await tick();
+    expect(onSelectRange).toHaveBeenCalledWith(expect.objectContaining({ start: 1, end: 2 }));
+
+    unmount(c);
+    target.remove();
+  });
+
+  it("clamps the hover tooltip inside the viewport at the top-left edge", async () => {
+    // jsdom reports zero-size boxes, so mock the tooltip's measured size. The
+    // hovered slot's rect is all zeros, anchoring the tooltip at x=0, y=-4.
+    // Hand-computed from viewport geometry (innerWidth 1024, pad 8): the
+    // unclamped box would sit at left -100, top -104; both clamp to 8.
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(200);
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(100);
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
+    await tick();
+    const hit = target.querySelectorAll(".slot-hit")[2] as SVGRectElement;
+    hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector<HTMLDivElement>(".tooltip");
+    expect(tip).toBeTruthy();
+    expect(tip!.style.left).toBe("8px");
+    expect(tip!.style.top).toBe("8px");
+    unmount(c);
+    target.remove();
+  });
+
+  it("centers the tooltip above an anchor away from viewport edges", async () => {
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(200);
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(100);
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
+    await tick();
+    const hit = target.querySelectorAll(".slot-hit")[2] as SVGRectElement;
+    vi.spyOn(hit, "getBoundingClientRect").mockReturnValue({
+      left: 400,
+      top: 300,
+      width: 40,
+      height: 180,
+      right: 440,
+      bottom: 480,
+      x: 400,
+      y: 300,
+      toJSON: () => ({}),
+    } as DOMRect);
+    hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector<HTMLDivElement>(".tooltip");
+    // Anchor center x = 420, anchor y = 300 - 4 = 296; a 200x100 box centered
+    // above lands at left 320, top 196 with no clamping needed.
+    expect(tip!.style.left).toBe("320px");
+    expect(tip!.style.top).toBe("196px");
+    unmount(c);
+    target.remove();
+  });
+
   it("shows a tooltip on slot hover and clears it on leave", async () => {
     const target = document.createElement("div");
     document.body.appendChild(target);


### PR DESCRIPTION
## TL;DR

Hovering a concurrency bucket near a window edge cut off part of the tooltip, and hovering the not-yet-elapsed part of the range highlighted it and popped an all-zero tooltip that reads as "nothing happened" instead of "has not happened yet". The tooltip now clamps itself inside the viewport, and buckets that start at or after the report's effective end get no hover target.

## How

The tooltip drops its fixed CSS transform. An effect measures the rendered box and clamps its left and top to the viewport with an 8px pad, keeping the centered-above placement when there is room.

The API returns buckets for the whole requested range, including ones that have not started. A `liveBars` prefix now feeds the hover hit targets, so future buckets cannot be hovered, focused, or selected, and keyboard navigation and drag selection clamp to the last live bucket. Their bar geometry and the shaded future region still render.

Review from `ConcurrencyTimeline.svelte`; the new tests pin the clamped tooltip positions and the live hit-target count.


<img width="242" height="563" alt="image" src="https://github.com/user-attachments/assets/0869f824-8c76-43aa-ba5e-c484961fe115" />