### PR TITLE
fix(docker): fail over between Debian mirrors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,13 @@ RUN npm run build
 
 FROM golang:1.27.0-bookworm AS build
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential ca-certificates \
+COPY docker/debian-*.list /etc/apt/mirrors/
+RUN sed -i \
+      -e 's#URIs: http://deb.debian.org/debian$#URIs: mirror+file:/etc/apt/mirrors/debian-mirrors.list#' \
+      -e 's#URIs: http://deb.debian.org/debian-security$#URIs: mirror+file:/etc/apt/mirrors/debian-security-mirrors.list#' \
+      /etc/apt/sources.list.d/debian.sources \
+    && timeout 90s apt-get -o Acquire::http::Timeout=10 update \
+    && timeout 90s apt-get -o Acquire::http::Timeout=10 install -y --no-install-recommends build-essential ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
@@ -55,8 +60,13 @@ RUN /out/agentsview --version
 
 FROM debian:bookworm-slim
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+COPY docker/debian-*.list /etc/apt/mirrors/
+RUN sed -i \
+      -e 's#URIs: http://deb.debian.org/debian$#URIs: mirror+file:/etc/apt/mirrors/debian-mirrors.list#' \
+      -e 's#URIs: http://deb.debian.org/debian-security$#URIs: mirror+file:/etc/apt/mirrors/debian-security-mirrors.list#' \
+      /etc/apt/sources.list.d/debian.sources \
+    && timeout 90s apt-get -o Acquire::http::Timeout=10 update \
+    && timeout 90s apt-get -o Acquire::http::Timeout=10 install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /data /agents
 

--- a/docker/debian-mirrors.list
+++ b/docker/debian-mirrors.list
@@ -1,0 +1,8 @@
+http://debian-archive.trafficmanager.net/debian/	priority:1
+http://deb.debian.org/debian/	priority:2
+http://ftp.us.debian.org/debian/	priority:3
+http://debian.csail.mit.edu/debian/	priority:3
+http://mirror.us.oneandone.net/debian/	priority:3
+http://mirrors.ocf.berkeley.edu/debian/	priority:3
+http://mirrors.accretive-networks.net/debian/	priority:3
+http://repo.ialab.dsu.edu/debian/	priority:3

--- a/docker/debian-security-mirrors.list
+++ b/docker/debian-security-mirrors.list
@@ -1,0 +1,7 @@
+http://debian-archive.trafficmanager.net/debian-security/	priority:1
+http://security.debian.org/debian-security/	priority:2
+http://debian.csail.mit.edu/debian-security/	priority:3
+http://mirror.us.oneandone.net/debian-security/	priority:3
+http://mirrors.ocf.berkeley.edu/debian-security/	priority:3
+http://mirrors.accretive-networks.net/debian-security/	priority:3
+http://repo.ialab.dsu.edu/debian-security/	priority:3


### PR DESCRIPTION
AgentsView OCI builds depended on one Debian CDN. When that endpoint stopped responding, `apt-get` could stall the build for several minutes.

This keeps the existing Debian Bookworm build and runtime images, but gives Apt an ordered mirror list. GitHub-hosted runners prefer Microsoft's Azure-hosted Debian mirror, then Debian's official endpoints, then independent US mirrors. A stalled HTTP request fails over after 10 seconds, and each Apt command has a 90-second final deadline.

A cold ARM64 Bake build completed with the new mirror setup, and kenn-dist accepted the resulting OCI archive.
