### PR TITLE
fix(docker): distribute Apt requests across mirrors

### DIFF
--- a/docker/debian-mirrors.list
+++ b/docker/debian-mirrors.list
@@ -1,8 +1,8 @@
-http://debian-archive.trafficmanager.net/debian/	priority:1
-http://deb.debian.org/debian/	priority:2
-http://ftp.us.debian.org/debian/	priority:3
-http://debian.csail.mit.edu/debian/	priority:3
-http://mirror.us.oneandone.net/debian/	priority:3
-http://mirrors.ocf.berkeley.edu/debian/	priority:3
-http://mirrors.accretive-networks.net/debian/	priority:3
-http://repo.ialab.dsu.edu/debian/	priority:3
+http://debian-archive.trafficmanager.net/debian/
+http://deb.debian.org/debian/
+http://ftp.us.debian.org/debian/
+http://debian.csail.mit.edu/debian/
+http://mirror.us.oneandone.net/debian/
+http://mirrors.ocf.berkeley.edu/debian/
+http://mirrors.accretive-networks.net/debian/
+http://repo.ialab.dsu.edu/debian/

--- a/docker/debian-security-mirrors.list
+++ b/docker/debian-security-mirrors.list
@@ -1,7 +1,7 @@
-http://debian-archive.trafficmanager.net/debian-security/	priority:1
-http://security.debian.org/debian-security/	priority:2
-http://debian.csail.mit.edu/debian-security/	priority:3
-http://mirror.us.oneandone.net/debian-security/	priority:3
-http://mirrors.ocf.berkeley.edu/debian-security/	priority:3
-http://mirrors.accretive-networks.net/debian-security/	priority:3
-http://repo.ialab.dsu.edu/debian-security/	priority:3
+http://debian-archive.trafficmanager.net/debian-security/
+http://security.debian.org/debian-security/
+http://debian.csail.mit.edu/debian-security/
+http://mirror.us.oneandone.net/debian-security/
+http://mirrors.ocf.berkeley.edu/debian-security/
+http://mirrors.accretive-networks.net/debian-security/
+http://repo.ialab.dsu.edu/debian-security/


### PR DESCRIPTION
Apt kept using the highest-priority Debian mirror when it responded partially, so a slow mirror could consume the entire command timeout without reaching the remaining entries. This gives the existing Bookworm mirrors equal priority, allowing each file request to select a working mirror while preserving the existing request and command deadlines.
