### PR TITLE
test(capture): synchronize source removal after persistence

### DIFF
--- a/internal/capture/capture_integration_test.go
+++ b/internal/capture/capture_integration_test.go
@@ -2100,8 +2100,10 @@ func TestCaptureDistinguishesAnObservedSourceThatDisappears(t *testing.T) {
 		err     error
 	}
 	done := make(chan runResponse, 1)
+	persisted := make(chan struct{})
+	release := make(chan struct{}, 1)
 	go func() {
-		outcome, runErr := Run(context.Background(), RunOptions{
+		outcome, runErr := runWithHooks(context.Background(), RunOptions{
 			Provider: ProviderClaude, OccurrenceID: "source-disappeared",
 			CaptureDir: captureDir, ResultPath: resultPath,
 			ProviderRoot: root, WorkDir: workDir,
@@ -2109,19 +2111,31 @@ func TestCaptureDistinguishesAnObservedSourceThatDisappears(t *testing.T) {
 			Environment: helperEnvironment(root, "claude-final", 0),
 			Streams:     Streams{Stdout: io.Discard, Stderr: io.Discard},
 			Limits:      limits, CustomPricing: testPricing(),
+		}, &captureHooks{
+			afterPersistedSources: func() {
+				close(persisted)
+				<-release
+			},
 		})
 		done <- runResponse{outcome: outcome, err: runErr}
 	}()
-
-	require.Eventually(t, func() bool {
-		data, err := os.ReadFile(filepath.Join(captureDir, manifestFileName))
-		if err != nil {
-			return false
+	t.Cleanup(func() {
+		select {
+		case release <- struct{}{}:
+		default:
 		}
-		var captured manifest
-		return json.Unmarshal(data, &captured) == nil && captured.SourceObserved
-	}, 20*time.Second, 10*time.Millisecond)
+	})
+
+	select {
+	case <-persisted:
+	case response := <-done:
+		require.Failf(t, "capture completed before persisting its source set",
+			"exit=%d err=%v", response.outcome.ExitCode, response.err)
+	case <-time.After(20 * time.Second):
+		require.Fail(t, "capture did not persist its source set")
+	}
 	require.NoError(t, os.Rename(root, root+"-gone"))
+	release <- struct{}{}
 	response := <-done
 	require.Error(t, response.err)
 	assert.Equal(t, ReportFailureExitCode, response.outcome.ExitCode)
@@ -2129,7 +2143,8 @@ func TestCaptureDistinguishesAnObservedSourceThatDisappears(t *testing.T) {
 	require.NoError(t, err)
 	result, err := DecodeResult(bytes.NewReader(data))
 	require.NoError(t, err)
-	assert.Equal(t, ReasonSourceUnavailable, result.Reporting.Reason)
+	assert.Equal(t, ReasonSourceUnavailable, result.Reporting.Reason,
+		"run error: %v", response.err)
 }
 
 func TestCaptureLeavesNormalRuntimeStateUntouched(t *testing.T) {


### PR DESCRIPTION
The Windows Go job failed because the source-disappearance integration test
renamed the provider root as soon as `SourceObserved` reached the manifest.
Capture records that marker before it finishes enumerating, snapshotting, and
copying the live source, so the test could remove the directory during those
operations instead of during final live-source verification.

The test now pauses at the existing post-persistence hook, removes the live
provider root after its copy is durable, and resumes finalization. This keeps
the test focused on the `source_unavailable` contract and includes the
underlying capture error if the classification fails again. Production capture
behavior is unchanged.
