### PR TITLE
fix(command-palette): dismiss only when a drag starts and ends on the overlay

### DIFF
--- a/frontend/src/lib/components/command-palette/CommandPalette.svelte
+++ b/frontend/src/lib/components/command-palette/CommandPalette.svelte
@@ -187,8 +187,23 @@
     ui.activeModal = null;
   }
 
-  function handleOverlayClick(e: MouseEvent) {
-    if ((e.target as HTMLElement).classList.contains("palette-overlay")) {
+  // A click event targets the common ancestor of its mousedown and mouseup, so a
+  // drag crossing the palette edge (selecting the query text, say) targets the
+  // overlay. Dismiss only when press and release both land on the overlay.
+  let pressedOverlay = false;
+
+  function isOverlay(e: MouseEvent) {
+    return (e.target as HTMLElement).classList.contains("palette-overlay");
+  }
+
+  function handleOverlayMousedown(e: MouseEvent) {
+    pressedOverlay = isOverlay(e);
+  }
+
+  function handleOverlayMouseup(e: MouseEvent) {
+    const pressed = pressedOverlay;
+    pressedOverlay = false;
+    if (pressed && isOverlay(e)) {
       close();
     }
   }
@@ -216,7 +231,8 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="palette-overlay"
-  onclick={handleOverlayClick}
+  onmousedown={handleOverlayMousedown}
+  onmouseup={handleOverlayMouseup}
   onkeydown={handleKeydown}
 >
   <div class="palette">

--- a/frontend/src/lib/components/command-palette/CommandPalette.test.ts
+++ b/frontend/src/lib/components/command-palette/CommandPalette.test.ts
@@ -219,6 +219,47 @@ describe("CommandPalette", () => {
     unmount(component);
   });
 
+  it("dismisses on an overlay press released on the overlay", async () => {
+    const component = mount(CommandPalette, { target: document.body });
+    await tick();
+
+    const overlay = document.querySelector<HTMLElement>(".palette-overlay")!;
+    overlay.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    overlay.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    expect(mockUi.activeModal).toBeNull();
+
+    unmount(component);
+  });
+
+  it("stays open when a drag starts in the palette and ends on the overlay", async () => {
+    const component = mount(CommandPalette, { target: document.body });
+    await tick();
+
+    const input = document.querySelector<HTMLInputElement>(".palette-input")!;
+    const overlay = document.querySelector<HTMLElement>(".palette-overlay")!;
+    input.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    overlay.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    expect(mockUi.activeModal).toBe("commandPalette");
+
+    unmount(component);
+  });
+
+  it("stays open when a drag starts on the overlay and ends in the palette", async () => {
+    const component = mount(CommandPalette, { target: document.body });
+    await tick();
+
+    const input = document.querySelector<HTMLInputElement>(".palette-input")!;
+    const overlay = document.querySelector<HTMLElement>(".palette-overlay")!;
+    overlay.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    input.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    expect(mockUi.activeModal).toBe("commandPalette");
+
+    unmount(component);
+  });
+
   it("calls clear() and resetSort() on unmount via onDestroy", async () => {
     const component = mount(CommandPalette, {
       target: document.body,


### PR DESCRIPTION
This fixes the undesirable behavior where the search overlay closes early, which happens whenever a drag starts inside the search input and is released outside it. This PR changes that behavior to match established conventions in OS and app dialogs, so that releasing the mouse button does not cancel the search or close the overlay.

The palette dismisses early due to the `click` handler on `.palette-overlay` firing on click events that target the common ancestor of its mousedown and mouseup elements. A drag that starts inside the palette and releases past its edge therefore reports `.palette-overlay` as the click target, so the palette closes even though the press began inside it. The search input sits flush with the palette border, so selecting the current query to replace it puts the release outside the input on most attempts and the palette disappears mid-gesture.

This replaces the overlay click handler with paired `mousedown` and `mouseup` handlers that dismiss only when both ends of the gesture land on the overlay itself. A press inside the palette released on the overlay leaves the palette open, and so does the mirror case of a press on the overlay released inside the palette, which would otherwise close the palette out from under a cursor that is back over the results. A plain click on the backdrop still dismisses.
