### PR TITLE
fix(docs): bypass instant navigation on logo link to marketing homepage

### DIFF
--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -7,7 +7,7 @@
 {% endif %}
 <header class="{{ class }}" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
-    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo agentsview-logo-link" aria-label="{{ config.site_name }}" data-md-component="logo">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo agentsview-logo-link" aria-label="{{ config.site_name }}" data-md-component="logo" data-preview="">
       <span class="agentsview-logo-mark" aria-hidden="true">AV</span>
     </a>
     <label class="md-header__button md-icon" for="__drawer" aria-label="{{ lang.t('nav') }}">


### PR DESCRIPTION
Adds `data-preview=""` to the logo anchor to opt it out of Zensical's `navigation.instant`, which otherwise intercepts the logo link and fetches the marketing homepage via XHR, producing a mangled page when the home icon is clicked from the docs.

Fixes #1571