### PR TITLE
docs: refresh the 0.42.0 release story

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ commands. Do not copy their catalogues into this file.
   details, and absolute user paths out of code, tests, fixtures,
   documentation, commit messages, and pull request text. Run the private-data
   scrub before publishing.
+- Write changelog entries in plain language for people who do not live in the
+  codebase. Lead each entry with the outcome a user or operator will notice.
+  Put implementation details after that outcome, and include them only when
+  they help the reader act or understand a limit.
 - Keep pull request titles and descriptions in sync with the current diff.
 - Do not post pull request or issue comments unless the user asks.
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,9 @@ reverse proxy.
 
 ## Token Usage and Cost Tracking
 
-`agentsview usage` is a fast, local replacement for ccusage and similar tools.
-It tracks token consumption and compute costs across **all** your coding agents
--- not just Claude Code. Because session data is already indexed in SQLite,
-queries are over 100x faster than tools that re-parse raw session files on every
-run.
+`agentsview usage` tracks token consumption and compute costs across **all**
+your coding agents -- not just Claude Code. Reports read from the same local
+SQLite archive that powers the UI.
 
 ```bash
 # Daily cost summary (default: last 30 days)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2706,8 +2706,8 @@ ______________________________________________________________________
   commands that report token usage and estimated cost by day or for the
   current day, scoped to Claude Code and Codex sessions. Pricing is pulled
   from the LiteLLM catalog with an embedded fallback for offline use. See
-  [Token Usage & Costs](/docs/token-usage/) for the full write-up, including
-  benchmarks against `ccusage`.
+  [Token Usage & Costs](/docs/token-usage/) for the full reporting model and
+  coverage details.
 - Add [OpenHands CLI](/docs/configuration/#session-discovery) session support.
   Local OpenHands conversations under `~/.openhands/conversations` are
   discovered, synced, and rendered alongside other agents. A new shallow-watch

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,42 +3,123 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
-## Unreleased
+## 0.42.0
+
+<small>2026-09-01</small>
 
 **New features**
 
-- Add `[recall.extract] candidate_findings = "allow"` to let recall extraction
-  gate sessions on definite-confidence secret findings only. Candidate-tier
-  matches (high-entropy assignments, JWT-shaped tokens, basic-auth URLs) stay
-  recorded for `secrets list --confidence candidate` but no longer exclude a
-  session from discovery, the pre-send transcript check, commit guards, or
-  reconciliation. The default `"block"` keeps the previous behavior; `recall
-  extract doctor` prints the active policy. (#1404)
-
-- Add automation-only one-shot capture for exact `claude -p` and
-  `codex exec --json` executions, with isolated accounting, recoverable retries,
-  exclusively created and protected local evidence, preserved child streams
-  and outcomes, bounded finalization work, and a closed versioned usage result.
-  Existing Claude sources and conflicting provider identities cannot be reused
-  as a new occurrence.
-
-- Ingest Cursor sessions from S3 roots through a shared single-file S3 provider
-  interface, so additional JSONL agents can opt in without repeating per-agent
-  sync switches.
-
-**Bug fixes**
-
-- Preserve Antigravity CLI 1.1.5 generation usage and Low/Medium/High model
-  effort from SQLite executor metadata.
-- Let `agentsview sync` skip offline configured HTTP hosts while local and
-  reachable remote sources continue to sync.
+- Keep raw session history from several machines in one hosted archive. Devices
+  authenticate with operator-provisioned credentials, resume interrupted
+  uploads, keep durable checkpoints, and can run `agentsview raw-sync watch`
+  continuously.
+- Measure one automated Claude or Codex run exactly with
+  `agentsview capture run`. The command preserves the raw source files and
+  child-process outcome, then writes a versioned usage report that can be
+  recovered after interruption.
+- Browse sessions from **Cursor IDE**, **IcodeMate CLI**, and **Posit
+  Assistant**, including recorded usage events when the source provides them.
+- Read supported single-file session formats from S3-compatible storage, not
+  only Claude and Codex roots. Each provider still documents whether its
+  format can be represented as one object.
+- Use the web interface in **Japanese**.
+- Price more models through OpenRouter and use the rate that was active when a
+  historical usage event occurred.
+- Let API clients request session source paths explicitly with
+  `include_source=true`. Paths remain hidden by default.
+- Let Recall extraction continue past likely false-positive secret findings with
+  `[recall.extract] candidate_findings = "allow"`. Definite findings still
+  block extraction, and the default `"block"` policy remains unchanged.
+  (#1404)
 
 **Improvements**
 
-- Build and lint with Go 1.27 and golangci-lint 2.13.0. Source builds now
-  require Go 1.27+, and the Go code now uses `encoding/json/v2` semantics.
+- Get daily usage reports faster on large archives. SQLite now serves exact
+  results from a disposable daily rollup cache and rebuilds missing or stale
+  data before answering.
+- Keep active OpenCode archives responsive by parsing only the sessions that
+  changed inside a shared database.
+- Keep embedding builds moving through provider rate limits and cap each batch
+  by token count as well as item count.
+- Resize the analysis panel to give long reports or transcripts more room.
+- Prevent accidental data loss when an upload would replace a session with a
+  shorter copy. The client must now give explicit consent.
+- Continue local sync when a configured HTTP host is offline, and choose remote
+  sync targets more predictably.
+- Make container builds less dependent on any one Debian mirror by distributing
+  downloads and failing over automatically.
+- Build from source with Go 1.27 and use its JSON v2 behavior consistently.
 
----
+**Bug fixes**
+
+- Keep archived sessions available after their original source files disappear.
+- Finish full reconciliation even when a source must be deferred, and show
+  progress while a full resync completes its final archive work.
+- Discover OpenCode channel databases and recover project working directories
+  from older OpenCode metadata.
+- Recover Antigravity working directories, generation usage, and model effort,
+  and group sessions from multiple Git worktrees under the same project.
+- Read current Kiro CLI and Qoder CN layouts, tolerate incomplete Gemini data,
+  and stop retrying known-unsupported encrypted Trae sessions.
+- Include Devin sessions in Usage reports.
+- Correct Claude one-hour cache-write pricing and Posit Assistant cache-write
+  accounting.
+- Preserve timestamps with UTC offsets when older PostgreSQL rows are read.
+- Restore Grok agent-minute totals and automated-session classification.
+- Keep daemon startup attached while progress is still advancing instead of
+  reporting a false readiness timeout.
+- Keep transcript rows aligned after changing sort order, and send arrow-key
+  navigation to the pane that currently has focus.
+- Keep Usage project filters stable and stop password managers from treating the
+  project picker as a credential field.
+
+**Acknowledgements**
+
+- Thanks to [Rusty Shackleford](https://github.com/salmonumbrella) for hosted
+  raw custody, device authentication, resumable uploads, durable checkpoints,
+  and continuous watching.
+- Thanks to [Wes McKinney](https://github.com/wesm) for exact one-shot capture,
+  the daily usage cache, source-path opt-in, sync resilience, and release and
+  website documentation.
+- Thanks to [Rod Boev](https://github.com/rodboev) for OpenCode, Kiro, Trae, and
+  remote-sync fixes; shorter-upload consent; and focused-pane navigation.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for
+  historical pricing, Go 1.27 JSON v2 behavior, container reliability, the
+  resizable analysis panel, and frontend stability fixes.
+- Thanks to [Angel Hermon](https://github.com/anhermon) for Cursor IDE,
+  Antigravity recovery, and resilient, token-bounded embedding builds.
+- Thanks to [Takuro Onoue](https://github.com/kusanaginoturugi) for Japanese
+  localization.
+- Thanks to [Michael Chow](https://github.com/machow) for Posit Assistant usage
+  events and correct Claude one-hour cache-write pricing.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for Grok activity and
+  classification fixes and safer activity charts.
+- Thanks to [Daniel Hernik](https://github.com/danielhernik) for the Recall
+  candidate-finding policy.
+- Thanks to [Sam Odio](https://github.com/srosro) for keeping daemon readiness
+  waiting active through startup progress.
+- Thanks to [Tom](https://github.com/tomb3214) for recovering Antigravity CLI
+  working directories.
+- Thanks to [John Riviello](https://github.com/JohnRiv) for showing Devin
+  sessions in Usage.
+- Thanks to [Enoch](https://github.com/bferanmi806-sketch) for Qoder CN
+  discovery.
+- Thanks to [Jorge Pinto Sousa](https://github.com/sousajo-cc) for clearer
+  platform installation commands.
+- Thanks to [Prateek Rungta](https://github.com/prateek) for stronger Windows
+  desktop coverage.
+- Thanks to [Trent Nelson](https://github.com/tpn) for preserving PostgreSQL
+  timestamp offsets and safely skipping incomplete Gemini sessions.
+- Thanks to [Matt Van Horn](https://github.com/mvanhorn) for Posit Assistant
+  cache-write accounting.
+- Thanks to [loong](https://github.com/LeonidasLux) for IcodeMate CLI support.
+- Thanks to [Marcel Hild](https://github.com/durandom) for extending S3 session
+  discovery beyond Claude and Codex.
+- Thanks to [godlockin](https://github.com/godlockin) for OpenRouter pricing.
+- Thanks to [Jessie.H](https://github.com/jchuder) for preserving Antigravity
+  effort metadata.
+
+______________________________________________________________________
 
 ## 0.41.1
 
@@ -46,7 +127,8 @@ description: Release history for AgentsView
 
 **New features**
 
-- Add Windows system tray support with proper lifecycle behavior.
+- Keep AgentsView available from the Windows system tray after its window
+  closes, and use the tray to reopen or quit the app.
 
 **Bug fixes**
 
@@ -63,7 +145,7 @@ description: Release history for AgentsView
 - Thanks to [Wes McKinney](https://github.com/wesm) for reliable daily usage
   snapshots and release documentation.
 
----
+______________________________________________________________________
 
 ## 0.41.0
 
@@ -71,61 +153,61 @@ description: Release history for AgentsView
 
 **New features**
 
-- Add session support for **DeepSeek Harness**, **TraeX (TRAE CLI 2.0)**,
-  **Codebuff and Freebuff**, **Prime Agent**, and **Goose**. The new parsers
-  preserve the formats' available reasoning, tool activity, relationships, and
-  usage or recorded costs; Prime Agent also carries Pi-family fork lineage and
-  RLM-attributed usage.
-- Import **Gemini Apps** `Prompted` activity from English-language Google
+- Browse sessions from **DeepSeek Harness**, **TraeX (TRAE CLI 2.0)**,
+  **Codebuff and Freebuff**, **Prime Agent**, and **Goose**. AgentsView keeps
+  the reasoning, tool activity, relationships, usage, and recorded costs that
+  each format provides. Prime Agent also keeps Pi-family fork lineage and
+  recursive language model (RLM) usage attribution.
+- Bring **Gemini Apps** `Prompted` activity into AgentsView from English Google
   Takeout exports with `agentsview import --type gemini-apps`. Each activity
   record becomes a one-turn session with its exported timezone preserved.
-- Discover **Qoder IDE** sessions from the platform-specific
+- Find **Qoder IDE** sessions in the platform-specific
   `SharedClientCache/cli/projects` store in addition to the legacy export
   directories.
-- Generate insights through a configured OpenAI-compatible
-  `/chat/completions` endpoint as an alternative to local agent CLIs.
-- Let expanded tool results switch between escaped raw text and sanitized,
-  rendered Markdown.
-- Organize model-written reports under **Recall → Generated insights**, add a
-  separate deterministic **Quality** page, expose Recall extraction coverage,
-  and manage extraction generations.
-- Record Amp's model and token counts per inference so model switches retain
-  their own usage rows.
-- Attribute complete delegated-session costs to the session that spawned the
-  work in usage reports, with `--own-only` available for the root session's
-  direct cost.
-- Add versioned JSON output to `agentsview usage statusline` for shell scripts
-  and status integrations.
+- Generate insights through an OpenAI-compatible `/chat/completions` endpoint
+  when a local agent CLI is not the right runner.
+- Switch expanded tool results between escaped source text and safe rendered
+  Markdown.
+- Find model-written reports under **Recall → Generated insights**, review
+  deterministic findings on a separate **Quality** page, see extraction
+  coverage, and manage extraction generations.
+- Keep Amp usage accurate across model switches by recording model and token
+  counts for each inference.
+- See the full cost of delegated work on the session that started it. Use
+  `--own-only` when a report should include only the root session's direct
+  cost.
+- Feed shell prompts and status integrations with versioned JSON from
+  `agentsview usage statusline`.
 
 **Improvements**
 
-- Scale large activity reports with streaming aggregation, bounded pagination,
-  and fewer repeated snapshot scans.
-- Speed up daily usage reporting and duplicate-prompt analysis with narrower
+- Keep large Activity reports responsive by processing results in bounded pages
+  instead of repeatedly scanning the same snapshot.
+- Return daily usage and duplicate-prompt reports faster through narrower
   indexed queries.
-- Make HTTP sync transfer and parse only sessions whose source files changed.
-- Reduce idle polling CPU and add `disabled_agents` so unused local session
-  sources can be turned off without removing archived sessions.
-- Persist Claude and Codex freshness digests across daemon restarts to avoid
-  reparsing unchanged sessions.
-- Bound startup reconciliation and expose daemon process identity, coverage,
-  and synchronization health in runtime status.
+- Transfer and parse only changed source files during HTTP sync.
+- Use less CPU while idle. Set `disabled_agents` to stop scanning unused local
+  sources without removing their archived sessions.
+- Avoid reparsing unchanged Claude and Codex sessions after a daemon restart.
+- Reach readiness without loading unbounded reconciliation work, and show the
+  daemon identity, coverage, and sync health in status output.
 - Recover from invalid Ollama embedding responses on CPU systems by retrying
-  through the compatible native endpoint.
+  through Ollama's compatible native endpoint.
 
 **Bug fixes**
 
-- Populate working directories for Kimi sessions.
-- Support legacy Zed thread schemas and restore response items from current VS
-  Code Copilot session files.
-- Preserve Codex tool outputs during incremental parsing and associate forked
-  turns with their actual parents.
-- Exclude replayed Codex subagent usage and stop repeatedly parsing titled
+- Show the correct working directory for Kimi sessions.
+- Read older Zed thread schemas and restore response items from current VS Code
+  Copilot session files.
+- Keep Codex tool output during incremental parsing and attach forked turns to
+  their actual parents.
+- Stop double-counting replayed Codex subagent usage and stop reparsing titled
   sessions when `session_index.jsonl` is absent.
-- Remove replayed prefixes from backgrounded Claude sessions and keep
-  IDE-context envelopes out of session previews.
-- Remove stored Claude sessions that a complete current parse no longer emits.
-- Honor explicitly empty agent-directory arrays instead of restoring default
+- Remove replayed prefixes from backgrounded Claude sessions and keep editor
+  context out of session previews.
+- Remove stale Claude rows when a complete parse confirms that the source no
+  longer contains those sessions.
+- Respect explicitly empty agent-directory arrays instead of restoring default
   discovery roots.
 - Stop the macOS app from asking for access to Documents, Downloads, Desktop,
   iCloud Drive, and cloud-provider folders such as Dropbox. Discovery read Git
@@ -134,19 +216,21 @@ description: Release history for AgentsView
   Sessions in those folders now keep path-only project identity; set
   `scan_protected_paths` to opt back in to Git remote, worktree, and branch
   detail there.
-- Keep OpenCode's session container from consuming recursive watch capacity.
-- Keep root-session navigation unfiltered when returning from a child session.
-- Distinguish failed frontend actions from successful ones.
+- Keep OpenCode's shared session database from consuming recursive watcher
+  capacity.
+- Return from a child session to its root without leaving an accidental filter
+  behind.
+- Report failed interface actions as failures instead of showing success.
 - Start reliably when IPv4 and IPv6 listeners encounter port collisions.
-- Report stalled synchronization as unhealthy.
+- Mark stalled synchronization as unhealthy.
 
 **Acknowledgements**
 
 - Thanks to [Wes McKinney](https://github.com/wesm) for Recall extraction
-  progress and generation management; Generated insights and Quality; protected
-  path discovery; Codex and Claude freshness, parsing, and cleanup fixes; daemon
-  identity and health; HTTP sync, bounded startup, and activity scaling; usage
-  performance; and release documentation.
+  progress and generation management; Generated insights and Quality;
+  protected path discovery; Codex and Claude freshness, parsing, and cleanup
+  fixes; daemon identity and health; HTTP sync, bounded startup, and activity
+  scaling; usage performance; and release documentation.
 - Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for Prime
   Agent support, Ollama CPU recovery, Codex replay and fork fixes, accurate
   frontend action outcomes, bounded activity scans, lower idle CPU, and
@@ -177,7 +261,7 @@ description: Release history for AgentsView
 - Thanks to [Elliot Murphy](https://github.com/statik) for Windows-compatible
   parser fixtures.
 
----
+______________________________________________________________________
 
 ## 0.40.1
 
@@ -185,13 +269,13 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
-- Preserve Kimi Work token usage when protocol 1.4 writes a tool result before
-  the step's trailing usage record, and price the explicit `k2d6-agent` model
-  alias at K2.6 rates across SQLite, PostgreSQL, and DuckDB. Existing affected
-  sessions are repaired on resync.
-- Prevent `agentsview pg serve` from failing its startup automation audit with
-  an invalid UTF-8 error when affected PostgreSQL minor releases slice
-  compressed multibyte session text.
+- Keep Kimi Work token totals complete when protocol 1.4 writes a tool result
+  before the step's trailing usage record, and price the explicit `k2d6-agent`
+  model alias at K2.6 rates across SQLite, PostgreSQL, and DuckDB. Existing
+  affected sessions are repaired on resync.
+- Start `agentsview pg serve` reliably on affected PostgreSQL minor releases
+  instead of failing its automation audit when compressed multibyte session
+  text is split at an invalid UTF-8 boundary.
 
 **Acknowledgements**
 
@@ -200,7 +284,7 @@ description: Release history for AgentsView
 - Thanks to [Wes McKinney](https://github.com/wesm) for PostgreSQL startup
   compatibility and release documentation.
 
----
+______________________________________________________________________
 
 ## 0.40.0
 
@@ -208,40 +292,41 @@ description: Release history for AgentsView
 
 **New features**
 
-- Add a top-level **Data** workspace for inspecting the complete project
-  inventory, opening a project's observed folders, previewing full-archive
-  reclassification impact, and managing per-machine worktree mapping rules.
-- Add an experimental **Recall corpus browser** with extraction coverage,
+- Inspect every known project from the top-level **Data** workspace. Open its
+  observed folders, preview full-archive reclassification, and manage
+  per-machine worktree mappings.
+- Browse the experimental **Recall corpus** with extraction coverage,
   project/type/generation/review-state filters, expandable entries, and links
   from stored evidence to its source transcript. Recall remains local,
-  SQLite-only research functionality; see [Recall](/docs/recall/) for its trust and
-  lifecycle limits.
-- Add an early, explicit **artifact folder transport** behind
-  `agentsview sync --target`: participating archives can publish normalized,
-  immutable session revisions, track target-specific progress, and import
-  supported peer checkpoints. This is not a finished general-purpose sync
-  service: it is manual, trusted-folder-only, excludes raw provider files and
-  mutable curation, and has no continuous scheduler or hosted transport. See
+  SQLite-only research functionality; see [Recall](/docs/recall/) for its
+  trust and lifecycle limits.
+- Move normalized session revisions between trusted folders with the early
+  **artifact folder transport** behind `agentsview sync --target`:
+  participating archives can publish normalized, immutable session revisions,
+  track target-specific progress, and import supported peer checkpoints. This
+  is not a finished general-purpose sync service: it is manual,
+  trusted-folder-only, excludes raw provider files and mutable curation, and
+  has no continuous scheduler or hosted transport. See
   [Artifact Folder Sync](/docs/artifact-sync/) for the current boundaries.
-- Add versioned `agentsview export hour`, `day`, and `digest` reporting
-  contracts with canonical JSON, exact UTC-hour correction, and content digests
-  for incremental reporting workflows.
-- Add `[[session_sources]]` for filesystem roots labeled by source machine.
+- Build incremental reporting workflows on versioned `agentsview export hour`,
+  `day`, and `digest` output with canonical JSON, exact UTC-hour correction,
+  and content digests.
+- Label filesystem roots by source machine with `[[session_sources]]`.
   Attribution is captured at first ingestion, survives local resync, and is
   preserved when sessions are mirrored to PostgreSQL or DuckDB.
-- Add session support for **Omnigent** SQLite conversations and **Kimi Work**
-  desktop wire logs, including Kimi Work usage metrics when its logs provide
-  them.
-- Add server-wide **Agentsview** and **Matplotlib** chart color palettes under
+- Browse **Omnigent** SQLite conversations and **Kimi Work** desktop wire logs,
+  including Kimi Work usage metrics when its logs provide them.
+- Choose server-wide **Agentsview** and **Matplotlib** chart palettes under
   **Settings > Appearance**.
-- Capture Claude Code's top-level `sessionKind` and per-prompt `promptSource`
-  metadata and preserve it through archive and artifact round trips.
+- Keep Claude Code's top-level `sessionKind` and per-prompt `promptSource`
+  metadata through archive and artifact round trips.
 
 **Improvements**
 
 - Unify usage aggregation across reports and replace floating-point machine
-  money with exact integer microdollar values. Human-facing tables still render
-  ordinary dollar amounts; versioned JSON contracts use microdollar objects.
+  money with exact integer microdollar values. Human-facing tables still
+  render ordinary dollar amounts; versioned JSON contracts use microdollar
+  objects.
 - Show language choices by their native names and use Taiwan-specific
   terminology throughout Traditional Chinese (`zh-TW`).
 - Replace the long Settings page with compact section navigation, and move the
@@ -276,9 +361,9 @@ description: Release history for AgentsView
 **Acknowledgements**
 
 - Thanks to [Wes McKinney](https://github.com/wesm) for the Data and Recall
-  workspaces; artifact publication, peer import, and folder transport; Omnigent
-  support; nested-subagent, Codex freshness, repository attribution, and
-  remote-root fixes; and release documentation.
+  workspaces; artifact publication, peer import, and folder transport;
+  Omnigent support; nested-subagent, Codex freshness, repository attribution,
+  and remote-root fixes; and release documentation.
 - Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for exact
   microdollar accounting, chart palettes, compact Settings navigation, the
   relocated sidebar toggle, path presentation, daily pricing refresh,
@@ -309,50 +394,50 @@ description: Release history for AgentsView
 - Thanks to [Alex Kreidler](https://github.com/alexkreidler) for bounding
   persisted Claude tool-result reads.
 
----
+______________________________________________________________________
 
 ## 0.39.0
+
 <small>2026-07-26</small>
 
 **New features**
 
-- Add session support for **Poolside Agent CLI**, **RooCode**, the **Kilo
+- Browse sessions from **Poolside Agent CLI**, **RooCode**, the **Kilo
   (legacy)** VS Code extension, and **Trae**. Trae's legacy inline-message
   layout is supported; modern encrypted layouts are detected and reported
   clearly instead of being silently skipped.
-- Add experimental **Recall extraction** with opt-in, scheduled local-model
+- Turn selected sessions into searchable, evidence-linked knowledge with
+  experimental **Recall extraction**. It supports opt-in scheduled local-model
   processing, generation management, provenance checks, lexical/vector/hybrid
   retrieval, and a read-only session evidence panel. Recall remains an
-  experimental local-SQLite feature; see [Recall](/docs/recall/) for its current
-  limits.
-- Add **French localization** across the application.
-- Guide first-time **semantic search** setup directly in the command palette.
-  The palette supplies configuration and restart steps, can start an embedding
-  build, follows build progress, and retries the query when the index is ready.
-- Add per-machine breakdowns to `agentsview usage daily --json --breakdown`,
-  and roll explicit subagent costs into the parent session total shown in the
-  session header.
-- Show recorded **repository and worktree context** in Session Vital Signs, and
-  add an `AGE` column to human-readable `agentsview session search` results.
-- Introduce an experimental portable artifact envelope and local
-  DocBank-backed store as internal foundations for future workflows. This
-  release does not add an export/import user workflow for the format.
+  experimental local-SQLite feature; see [Recall](/docs/recall/) for its
+  current limits.
+- Use the application in **French**.
+- Set up **semantic search** directly from the command palette. The palette
+  supplies configuration and restart steps, can start an embedding build,
+  follows build progress, and retries the query when the index is ready.
+- Break down `agentsview usage daily --json --breakdown` by machine, and see
+  explicit subagent costs in the parent session total.
+- See recorded **repository and worktree context** in Session Vital Signs and
+  session age in human-readable `agentsview session search` results.
+- Prepare for future portable workflows with an experimental artifact envelope
+  and local store. This release does not add a user-facing import or export
+  workflow for that format.
 
 **Improvements**
 
-- Bound filesystem-event sync work by the changed batch, and bound Gemini
-  reconciliation by affected roots, so passive daemon memory and work do not
-  scale with the full archive.
-- Improve semantic search with role-aware query/document prefixes, automatic
-  detection and repair of invalid stored vectors, and incremental
+- Keep passive sync memory and work tied to the changed files and affected
+  Gemini roots instead of the full archive.
+- Get more reliable semantic results through role-aware query/document prefixes,
+  automatic detection and repair of invalid stored vectors, and incremental
   PostgreSQL vector reconciliation.
 - Start analysis **Calls** details collapsed, label inline teammate messages
   distinctly, and assign stable, visually distinct colors across active
   attribution series.
 - Preserve Claude session identity metadata and include the recorded model in
   generated resume commands.
-- Make the API write timeout configurable and include clearer timeout details
-  in server responses.
+- Make the API write timeout configurable and include clearer timeout details in
+  server responses.
 - Simplify DuckDB into a disposable, safely rebuildable local mirror. This is a
   user-visible compatibility change: **`duckdb push` now writes only the local
   mirror file** and rejects `[duckdb].url`; `duckdb status` and `duckdb serve`
@@ -389,8 +474,8 @@ description: Release history for AgentsView
   setup, the session-search age column, Poolside target deduplication, daemon
   startup reliability, Antigravity parent links, and clearer DuckDB remote
   failures.
-- Thanks to [Tyler Gibbs](https://github.com/tylergibbs1) for keeping Claude
-  IDE context out of generated session titles.
+- Thanks to [Tyler Gibbs](https://github.com/tylergibbs1) for keeping Claude IDE
+  context out of generated session titles.
 - Thanks to [ajinkyajacob](https://github.com/ajinkyajacob) for detecting
   invalid and failed OpenCode tool calls.
 - Thanks to [Stephen Cross](https://github.com/scross01) for Poolside Agent CLI,
@@ -410,10 +495,10 @@ description: Release history for AgentsView
   Grok's per-turn usage accounting.
 - Thanks to [TzeKei Lee](https://github.com/chikei) for parsing OhMyPi subagent
   transcripts as nested sessions.
-- Thanks to [Erik Krogen](https://github.com/xkrogen) for using
-  Copilot-reported billing as the authoritative session cost.
-- Thanks to [David Riordan](https://github.com/riordan) for role-aware
-  embedding prefixes.
+- Thanks to [Erik Krogen](https://github.com/xkrogen) for using Copilot-reported
+  billing as the authoritative session cost.
+- Thanks to [David Riordan](https://github.com/riordan) for role-aware embedding
+  prefixes.
 - Thanks to [serverless83](https://github.com/serverless83) for tracking Hermes
   `skill_view` usage.
 - Thanks to [kai](https://github.com/dpanbug) for French localization and the
@@ -431,9 +516,10 @@ description: Release history for AgentsView
 - Thanks to [matt wilkie](https://github.com/maphew) for collaboration on the
   portable artifact foundation.
 
----
+______________________________________________________________________
 
 ## 0.38.1
+
 <small>2026-07-13</small>
 
 **Bug fixes**
@@ -445,53 +531,54 @@ description: Release history for AgentsView
 
 **Acknowledgements**
 
-- Thanks to [Wes McKinney](https://github.com/wesm) for restoring Codex
-  subagent lineage and titles and for release documentation.
+- Thanks to [Wes McKinney](https://github.com/wesm) for restoring Codex subagent
+  lineage and titles and for release documentation.
 
----
+______________________________________________________________________
 
 ## 0.38.0
+
 <small>2026-07-13</small>
 
 **New features**
 
-- Add **desktop deep links** for opening local Codex threads in Codex Desktop
-  and local Claude workspaces in Claude Code. On macOS, closing the desktop
-  window now keeps AgentsView available from a menu-bar status item with
-  actions to show the window, open logs, check for updates, and quit.
-- Add config-driven **`agentsview daemon start|status|restart|stop`** commands
-  for the writable SQLite daemon. The commands use the effective
-  `config.toml`, leave read-only PostgreSQL and DuckDB servers alone, and
-  report startup state, URL, PID, live daemon version, and uptime.
-- Add an experimental **Recall** substrate for provenance-linked durable
-  knowledge. Recall supports lexical query and task briefs, exact
+- Open local Codex threads in Codex Desktop and Claude workspaces in Claude Code
+  through **desktop deep links**. On macOS, closing the desktop window now
+  keeps AgentsView available from a menu-bar status item with actions to show
+  the window, open logs, check for updates, and quit.
+- Manage the writable SQLite daemon with
+  **`agentsview daemon start|status|restart|stop`**. The commands use the
+  effective `config.toml`, leave read-only PostgreSQL and DuckDB servers
+  alone, and report startup state, URL, PID, live daemon version, and uptime.
+- Store and review provenance-linked durable knowledge with experimental
+  **Recall**. Recall supports lexical query and task briefs, exact
   transcript-evidence validation, host-owned review states, supersession,
   measurement events, dry-run extraction, and guarded reviewed imports.
-- Add **PostgreSQL semantic and hybrid search** through pgvector. `pg push`
-  copies changed chunks from the active local embedding generation,
-  `pg serve` and `--pg` reads search a matching generation, and
-  `pg vectors list|drop` manages stored generations.
-- Add **Semantic** and **Hybrid** modes to the web command palette alongside
-  Full text search, with remembered mode selection and actionable index or
-  configuration errors.
-- Track **transcript reading progress** in the browser, mark sessions with new
-  content, place a boundary at the first unread message, and add
-  `Shift+J`/`Shift+K` navigation between user prompts.
-- Show the active **embedding build** in Settings, including phase, model,
+- Search a shared PostgreSQL archive by meaning with pgvector-backed semantic
+  and hybrid search. `pg push` copies changed chunks from the active local
+  embedding generation, `pg serve` and `--pg` reads search a matching
+  generation, and `pg vectors list|drop` manages stored generations.
+- Choose **Semantic** and **Hybrid** modes from the web command palette
+  alongside Full text search, with remembered mode selection and actionable
+  index or configuration errors.
+- Resume reading where you left off. The browser tracks transcript progress,
+  marks sessions with new content, places a boundary at the first unread
+  message, and supports `Shift+J`/`Shift+K` navigation between user prompts.
+- Follow an active **embedding build** from Settings, including phase, model,
   dimensions, chunk progress, throughput, elapsed time, estimated completion,
   and local generations.
-- Add `request_dimensions` for embedding models and endpoints that support
+- Use `request_dimensions` with embedding models and endpoints that support
   **Matryoshka-reduced vectors**, keeping the requested dimension in the
   generation fingerprint and validating every response.
-- Add interactive **skill usage trends** to Analytics with day, week, and month
-  grouping plus per-skill series controls.
-- Import **Grok Build** sessions through a metadata-first provider, including
-  full messages, thinking, tool calls, and usage when `chat_history.jsonl` and
-  `signals.json` are available.
-- Import **ZCode** transcript messages, thinking, tool calls, tool results, and
-  usage from its local SQLite archive.
-- Add a stable v1 JSON contract for **`agentsview version --json`**.
-- Upgrade content-free **`agentsview export sessions`** JSON/NDJSON with
+- Explore **skill usage trends** in Analytics by day, week, or month, with
+  per-skill series controls.
+- Browse **Grok Build** sessions with messages, thinking, tool calls, and usage
+  when `chat_history.jsonl` and `signals.json` are available.
+- Browse **ZCode** messages, thinking, tool calls, results, and usage from its
+  local SQLite archive.
+- Read version details from the stable v1 **`agentsview version --json`**
+  contract.
+- Export richer content-free session evidence as JSON or NDJSON with
   privacy-bounded project, repository, worktree, checkout, pricing, usage,
   cursor, and archive-generation evidence without transcript text. Releases
   0.38.0 and 0.38.1 mislabeled this incompatible shape as v1; current builds
@@ -499,8 +586,8 @@ description: Release history for AgentsView
 
 **Improvements**
 
-- Speed up configured HTTP **full remote syncs** by rebuilding local and
-  remote sessions together with FTS suspended, while avoiding retransfers of
+- Speed up configured HTTP **full remote syncs** by rebuilding local and remote
+  sessions together with FTS suspended, while avoiding retransfers of
   unchanged files from manifest-capable remotes.
 - Bound **passive daemon memory and background sync work** by changed paths and
   provider capabilities instead of repeatedly materializing archive-wide
@@ -510,19 +597,19 @@ description: Release history for AgentsView
   work on active transcripts.
 - Let Analytics, Usage, Activity, Trends, and Insights date ranges be linked
   globally or controlled independently from Settings.
-- Keep **`daemon restart` startup progress** attached to the terminal until
-  the replacement daemon is ready, with periodic phase and elapsed-time
-  updates during long migrations or initial syncs.
+- Keep **`daemon restart` startup progress** attached to the terminal until the
+  replacement daemon is ready, with periodic phase and elapsed-time updates
+  during long migrations or initial syncs.
 
 **Bug fixes**
 
 - Keep Activity's calendar-relative views current when the local date changes
   without requiring a page refresh.
-- Align `agentsview stats` session totals with the default visibility rules
-  used by session lists, including one-shot, automated, child, and deleted
+- Align `agentsview stats` session totals with the default visibility rules used
+  by session lists, including one-shot, automated, child, and deleted
   sessions.
-- Report the running daemon's **actual live version** in lifecycle status
-  output instead of trusting a possibly stale runtime-record value.
+- Report the running daemon's **actual live version** in lifecycle status output
+  instead of trusting a possibly stale runtime-record value.
 - Recover safely when a writable daemon still owns the archive but its runtime
   record is missing, and surface runtime-record publication warnings in server
   logs.
@@ -530,8 +617,8 @@ description: Release history for AgentsView
   updates while the sidecar is still exiting.
 - Replay replaced JSONL segments from **VS Code Copilot** instead of treating
   same-length splices as append-only transcript growth.
-- Export only the requested **Hermes** session when one transcript file
-  contains multiple sessions.
+- Export only the requested **Hermes** session when one transcript file contains
+  multiple sessions.
 - Prevent missing hashed SPA assets from falling back to stale HTML content.
 - Recognize trusted **Windows directory owners** correctly through the updated
   filesystem trust checks.
@@ -542,7 +629,8 @@ description: Release history for AgentsView
   the macOS menu-bar status item.
 - Thanks to [Rod Boev](https://github.com/rodboev) for transcript reading
   progress, user-prompt navigation, Grok and ZCode ingestion, stats visibility
-  parity, Hermes export fixes, Claude linkage performance, and daemon recovery.
+  parity, Hermes export fixes, Claude linkage performance, and daemon
+  recovery.
 - Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the
   stable version and session-evidence contracts, embedding build status,
   reduced output dimensions, and JSONL parser workspace reuse.
@@ -553,21 +641,23 @@ description: Release history for AgentsView
 - Thanks to [Leuconoe](https://github.com/Leuconoe) for reliable desktop update
   installation while the backend exits.
 - Thanks to [Wes McKinney](https://github.com/wesm) for Recall, PostgreSQL and
-  command-palette semantic search, skill trends, daemon lifecycle and progress,
-  independent date ranges, remote-sync and background-memory improvements,
-  Codex append performance, Activity date rollover, live daemon version
-  reporting, SPA fallback and Windows owner fixes, and release documentation.
+  command-palette semantic search, skill trends, daemon lifecycle and
+  progress, independent date ranges, remote-sync and background-memory
+  improvements, Codex append performance, Activity date rollover, live daemon
+  version reporting, SPA fallback and Windows owner fixes, and release
+  documentation.
 
----
+______________________________________________________________________
 
 ## 0.37.5
+
 <small>2026-07-09</small>
 
 **New features**
 
-- Prefer richer **`agy-reader` trajectory sidecars** when parsing Antigravity
-  IDE sessions, falling back to the existing heuristic decode when a sidecar is
-  missing, malformed, or does not cover the session's database steps.
+- Show richer Antigravity IDE sessions when **`agy-reader` trajectory sidecars**
+  are available, while falling back to the existing heuristic decode when a
+  sidecar is missing, malformed, or incomplete.
 
 **Bug fixes**
 
@@ -575,8 +665,9 @@ description: Release history for AgentsView
   ambiguous `local` label, and keep full-rebuild safety independent when a
   configured remote has the same hostname as the collector.
 
-- Remove **recommended-plugin context injected into Codex sessions** from
-  parsed transcripts so it no longer appears as user-authored content.
+- Remove **recommended-plugin context injected into Codex sessions** from parsed
+  transcripts so it no longer appears as user-authored content.
+
 - Include **overnight session activity** in date-filtered results by matching
   dates against session activity windows instead of only session start dates.
 
@@ -584,28 +675,27 @@ description: Release history for AgentsView
 
 - Thanks to [Matthew Jacobs](https://github.com/mjacobs) for `agy-reader`
   trajectory sidecar support in Antigravity IDE sessions.
-- Thanks to [Wes McKinney](https://github.com/wesm) for Codex
-  recommended-plugin filtering, overnight date-filter support, and release
-  documentation.
+- Thanks to [Wes McKinney](https://github.com/wesm) for Codex recommended-plugin
+  filtering, overnight date-filter support, and release documentation.
 
----
+______________________________________________________________________
 
 ## 0.37.4
+
 <small>2026-07-09</small>
 
 **New features**
 
-- Add **incremental HTTP remote sync** backed by a persistent per-host mirror.
-  After the initial archive download, the collector compares a remote manifest
-  with its mirror and requests only changed files when fewer than half of the
-  manifest files need fetching. Deleted remote files are removed from the
-  mirror without deleting sessions already stored in the local archive.
+- Transfer only changed remote files after the first HTTP sync. The collector
+  compares a remote manifest with a persistent per-host mirror and requests
+  only changed files when fewer than half need fetching. Deleted remote files
+  leave the mirror without deleting sessions already stored in the archive.
 
 **Improvements**
 
 - Include **GPT-5.6 model pricing** for the base alias and the Sol, Terra, and
-  Luna variants in the embedded fallback catalog, so fresh installs and offline
-  usage reports can estimate their costs without a network fetch.
+  Luna variants in the embedded fallback catalog, so fresh installs and
+  offline usage reports can estimate their costs without a network fetch.
 - Explain **default `session list` exclusions** on stderr when one-shot or
   automated sessions are hidden, including the number in each category and the
   flags that include them. Structured stdout remains unchanged for scripts.
@@ -617,9 +707,10 @@ description: Release history for AgentsView
 - Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for making
   the `session list` default exclusions visible.
 
----
+______________________________________________________________________
 
 ## 0.37.3
+
 <small>2026-07-09</small>
 
 **Bug fixes**
@@ -634,9 +725,10 @@ description: Release history for AgentsView
 - Thanks to [Wes McKinney](https://github.com/wesm) for restoring optimized
   release and Docker SQLite builds.
 
----
+______________________________________________________________________
 
 ## 0.37.2
+
 <small>2026-07-08</small>
 
 **Improvements**
@@ -645,8 +737,8 @@ description: Release history for AgentsView
   Once a full pass has verified every session in a shared OpenCode-format
   SQLite database, later idle passes can skip the container before per-session
   fingerprinting by comparing SQLite write markers for the database and WAL.
-- Reduce **heap retention after large sync backfills** by periodically
-  returning memory to the operating system while archived signal and secret
+- Reduce **heap retention after large sync backfills** by periodically returning
+  memory to the operating system while archived signal and secret
   recomputations walk large message and tool-result payloads.
 
 **Bug fixes**
@@ -662,50 +754,49 @@ description: Release history for AgentsView
 
 **Acknowledgements**
 
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for
-  speeding up unchanged OpenCode-family SQLite container syncs.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for speeding
+  up unchanged OpenCode-family SQLite container syncs.
 - Thanks to [Rod Boev](https://github.com/rodboev) for OpenCode skill-name
   extraction and large-backfill memory reductions.
 - Thanks to [Wes McKinney](https://github.com/wesm) for watcher shutdown fixes,
   desktop icon spacing, and release documentation.
 
----
+______________________________________________________________________
 
 ## 0.37.1
+
 <small>2026-07-08</small>
 
 **New features**
 
-- Add **semantic and hybrid search** backed by an opt-in local embeddings
-  index. AgentsView now embeds user-message units and grouped assistant runs,
+- Find sessions by meaning with **semantic and hybrid search** backed by an
+  opt-in local embeddings index. AgentsView embeds conversation units,
   supports `agentsview embeddings build|list|activate|retire`, adds
-  `session search --semantic` and `--hybrid`, and returns conversation-unit
-  citation ranges with lineage metadata for sidechain and subagent hits.
-- Add **content-free session summary export** with a v1 JSON/NDJSON contract.
+  `session search --semantic` and `--hybrid`, and returns citation ranges with
+  lineage metadata for sidechain and subagent matches.
+- Export content-free session summaries through a v1 JSON/NDJSON contract.
   `agentsview export sessions` emits session metadata, usage totals, pricing
   provenance, project identity, stable cursors, and reset errors without
   transcript text.
-- Add **single-session insight analysis** from the session header. Session
-  analysis uses the existing insight-generation pipeline with
-  `agent_analysis` plus `session_id`, builds a prompt from that session's
-  messages, timing, and usage, and stores the result with the other insights.
-- Add **Posit Assistant, Windsurf workspace chat, Qoder, and ZCode session
-  support**. These providers cover Posit Assistant workspace conversations,
+- Analyze one session from its header and store the report with other insights.
+  The analysis uses that session's messages, timing, and usage.
+- Browse **Posit Assistant, Windsurf workspace chat, Qoder, and ZCode
+  sessions**. These providers cover Posit Assistant workspace conversations,
   Windsurf `workspaceStorage` chat state, Qoder project transcripts and
   sidecars, and ZCode's local SQLite session database.
-- Add **Korean (`ko`) localization** and register it alongside English,
-  Simplified Chinese, and Traditional Chinese.
+- Use the application in **Korean (`ko`)**, alongside English, Simplified
+  Chinese, and Traditional Chinese.
 - Render **Mermaid fenced code blocks** in markdown messages while keeping the
   source readable if the Mermaid runtime cannot load.
 - Show **session context and detailed token breakdowns** in usage views,
   including session-level output-token and peak-context details.
-- Add **copy buttons for tool blocks**, with separate affordances for tool
-  input and output content.
-- Add **worktree layout mappings** in Settings. Worktree mappings now support
-  both explicit path-prefix mappings and the `repo_dot_worktrees` layout for
-  paths like `<prefix>/<repo>.worktrees/<branch>/...`.
-- Add **`sync_include_cwd_prefixes`** to `config.toml` so local sync can ingest
-  only sessions whose working directory falls under an allowed path prefix.
+- Copy tool input and output separately with **tool-block copy buttons**.
+- Map sessions back to repositories with **worktree layout mappings** in
+  Settings. Use explicit path-prefix mappings or the `repo_dot_worktrees`
+  layout for paths like `<prefix>/<repo>.worktrees/<branch>/...`.
+- Limit local ingestion to approved working-directory prefixes with
+  **`sync_include_cwd_prefixes`** in `config.toml`, so sync can ingest only
+  sessions whose working directory falls under an allowed path prefix.
 
 **Improvements**
 
@@ -732,21 +823,21 @@ description: Release history for AgentsView
   parent-child lineage for OMP transcripts.
 - Skip **local git discovery for sessions from other machines**, avoiding
   host-local repository probes for synced foreign-machine sessions.
-- Fix **Linux release builds** by compiling the sqlite-vec cgo bindings
-  against the SQLite header bundled with `mattn/go-sqlite3`. This is why the
-  release ships as 0.37.1: the 0.37.0 tag never produced binaries.
+- Fix **Linux release builds** by compiling the sqlite-vec cgo bindings against
+  the SQLite header bundled with `mattn/go-sqlite3`. This is why the release
+  ships as 0.37.1: the 0.37.0 tag never produced binaries.
 
 **Acknowledgements**
 
-- Thanks to [Wes McKinney](https://github.com/wesm) for semantic search,
-  session summary export, activity cost fixes, foreign-machine git-discovery
+- Thanks to [Wes McKinney](https://github.com/wesm) for semantic search, session
+  summary export, activity cost fixes, foreign-machine git-discovery
   safeguards, the Linux release-build fix, and release documentation.
 - Thanks to [Rod Boev](https://github.com/rodboev) for Windsurf workspace chat,
   Qoder and ZCode support, Mermaid rendering, usage context and token
   breakdowns, worktree layout mappings, tool-block copy buttons,
   single-session insight analysis, and the Codex custom tool-call fix.
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for aligned CLI
-  session search output and OMP parent-session lineage mapping.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for aligned CLI session
+  search output and OMP parent-session lineage mapping.
 - Thanks to [Elliot Murphy](https://github.com/statik) for Posit Assistant
   session support.
 - Thanks to [Rob Schilder](https://github.com/RobSchilderr) for
@@ -754,8 +845,8 @@ description: Release history for AgentsView
 - Thanks to [Phillip Cloud](https://github.com/cpcloud) for PostgreSQL and
   DuckDB push-churn reductions, OpenCode-family sync churn fixes, and calendar
   range picker preservation.
-- Thanks to [Mr Koala](https://github.com/Mr-Koala) for applying configured
-  port settings to the active runtime config.
+- Thanks to [Mr Koala](https://github.com/Mr-Koala) for applying configured port
+  settings to the active runtime config.
 - Thanks to [Prateek Rungta](https://github.com/prateek) for consistent usage
   agent-exclusion filtering.
 - Thanks to [Leuconoe](https://github.com/Leuconoe) for the Korean (`ko`)
@@ -763,19 +854,20 @@ description: Release history for AgentsView
 - Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for
   recurring sync and database performance benchmark gates.
 
----
+______________________________________________________________________
 
 ## 0.36.1
+
 <small>2026-07-03</small>
 
 **New features**
 
-- Add **Devin CLI session support**. AgentsView now discovers Devin CLI roots,
-  reads local session data from the `cli/` subtree, parses Devin messages and
-  tool activity, includes Devin in supported-agent metadata, and documents the
-  safe root to share when filing bug reports.
-- Extend **`parse-diff` diagnostics** for sessions last written through the
-  incremental-append path. These rows are now classified as
+- Browse **Devin CLI sessions**. AgentsView discovers Devin CLI roots, reads
+  local session data from the `cli/` subtree, parses Devin messages and tool
+  activity, includes Devin in supported-agent metadata, and documents the safe
+  root to share when filing bug reports.
+- Get accurate **`parse-diff` diagnostics** for sessions last written through
+  the incremental-append path. These rows are now classified as
   `incremental_skew`, excluded from `--fail-on-change`, and accompanied by
   guidance to run a full resync for a clean parser-drift baseline.
 - Report **Antigravity `gen_metadata` without usage anomalies** in sync
@@ -785,14 +877,14 @@ description: Release history for AgentsView
 **Improvements**
 
 - Show clearer **startup and resync state** while AgentsView initializes.
-  Background startup now publishes the daemon PID, elapsed time, current phase,
-  progress detail, and log path for `agentsview serve status`, while full
-  resyncs print durable phase and completion lines.
+  Background startup now publishes the daemon PID, elapsed time, current
+  phase, progress detail, and log path for `agentsview serve status`, while
+  full resyncs print durable phase and completion lines.
 - Improve **remote sync configuration and error reporting**. HTTP remote sync
   now validates configured hosts more directly, keeps ad hoc HTTP remotes
-  unsupported, and maps common failures such as token rejection, missing remote
-  endpoints, connection refusal, DNS failures, and timeouts to actionable
-  messages.
+  unsupported, and maps common failures such as token rejection, missing
+  remote endpoints, connection refusal, DNS failures, and timeouts to
+  actionable messages.
 - Refresh **frontend controls and dialogs** by migrating the Svelte UI to the
   shared `@kenn-io/kit-ui` components, making filters, range pickers, dialogs,
   settings controls, copy buttons, refresh controls, and related interaction
@@ -813,12 +905,12 @@ description: Release history for AgentsView
 
 **Acknowledgements**
 
-- Thanks to [Aaron Florey](https://github.com/aaronflorey) for Devin CLI
-  session discovery and parsing.
+- Thanks to [Aaron Florey](https://github.com/aaronflorey) for Devin CLI session
+  discovery and parsing.
 - Thanks to [Matthew Jacobs](https://github.com/mjacobs) for `parse-diff`
   incremental-skew diagnostics, OMP leading-title discovery, Antigravity
-  `gen_metadata` anomaly reporting, and the same-size same-mtime Claude rewrite
-  fix.
+  `gen_metadata` anomaly reporting, and the same-size same-mtime Claude
+  rewrite fix.
 - Thanks to [Wes McKinney](https://github.com/wesm) for startup transparency,
   resync consistency fixes, and remote sync configuration and error reporting.
 - Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the
@@ -826,44 +918,40 @@ description: Release history for AgentsView
 - Thanks to [Rod Boev](https://github.com/rodboev) for scoping PostgreSQL
   session-alias backfill markers by target.
 
----
+______________________________________________________________________
 
 ## 0.36.0
+
 <small>2026-07-02</small>
 
 **New features**
 
-- Add **pairwise usage cost comparisons** to the Usage page and usage API. The
-  new comparison panel can compare any two project or model slices in the
-  current date/filter window and reports backend-computed cost, session count,
-  total tokens, cost per session, tokens per session, absolute deltas, and
-  percent deltas. The REST surface is
-  `GET /api/v1/usage/pairwise-comparison`.
-- Show **parser malformed-line badges** on session detail pages when a parser
-  preserved a session but skipped malformed source lines. The badge uses the
-  persisted `parser_malformed_lines` count already produced by parser/sync
-  validation, so users can spot partially recovered transcripts without opening
-  CLI sync logs.
-- Add **Traditional Chinese (`zh-TW`) localization** across the Svelte frontend
-  and register it as a supported locale alongside English and Simplified
-  Chinese.
-- Support **forking Claude sessions from a selected message**. Claude message
-  headers now expose a fork action that renders the transcript through the
-  selected ordinal into a temporary prompt and launches `claude` from the
-  session working directory, or returns a copyable command when launch is not
+- Compare the cost of any two project or model slices from the Usage page or
+  API. The comparison uses the current date and filter window, and reports
+  cost, sessions, tokens, per-session averages, and absolute and percentage
+  changes. The REST endpoint is `GET /api/v1/usage/pairwise-comparison`.
+- See a **malformed-line badge** when AgentsView recovered a session but skipped
+  malformed source lines. The persisted `parser_malformed_lines` count makes
+  partially recovered transcripts visible without opening CLI sync logs.
+- Use the application in **Traditional Chinese (`zh-TW`)**, alongside English
+  and Simplified Chinese.
+- Fork a **Claude session from any selected message**. Claude message headers
+  now expose a fork action that renders the transcript through the selected
+  ordinal into a temporary prompt and launches `claude` from the session
+  working directory, or returns a copyable command when launch is not
   available.
-- Add **branch metadata and filter support** for session queries. The new
+- Filter sessions, search, analytics, activity, and usage by Git branch. The
   `GET /api/v1/branches` endpoint returns distinct `(project, branch)` pairs
-  with opaque filter tokens, and session, search, analytics, activity, and usage
-  endpoints accept those tokens as `git_branch`. Project-scoped tokens keep
-  same-named branches in different repositories distinct and preserve empty
-  branch values.
-- Flag **Antigravity sessions decoded from unrecognized schemas**. Antigravity
-  IDE and CLI parsers now fingerprint SQLite schemas into `source_version`;
-  unknown fingerprints get an `agy-schema:<prefix>` marker, session details
-  expose `decode_confidence: "low"`, sync summaries count the affected
-  sessions, `doctor sync` reports them, and the UI shows an **Unverified
-  schema** badge.
+  with opaque filter tokens, and session, search, analytics, activity, and
+  usage endpoints accept those tokens as `git_branch`. Project-scoped tokens
+  keep same-named branches in different repositories distinct and preserve
+  empty branch values.
+- See an **Unverified schema** badge when an Antigravity session came from an
+  unrecognized schema. Antigravity IDE and CLI parsers fingerprint SQLite
+  schemas into `source_version`; unknown fingerprints get an
+  `agy-schema:<prefix>` marker, session details expose
+  `decode_confidence: "low"`, sync summaries count the affected sessions,
+  `doctor sync` reports them, and the UI shows an **Unverified schema** badge.
 
 **Improvements**
 
@@ -877,8 +965,8 @@ description: Release history for AgentsView
 - Reduce **daemon sync CPU usage while sessions are actively streaming** by
   avoiding repeated skip-check work on hot files that are still being written.
 - Improve **unsupported usage reporting** from agent capabilities. Agents now
-  advertise whether they lack per-message token data and whether their costs are
-  denominated in AI credits (surfaced as "Copilot AI Credits" for Copilot
+  advertise whether they lack per-message token data and whether their costs
+  are denominated in AI credits (surfaced as "Copilot AI Credits" for Copilot
   agents) as separate capabilities, so Copilot-family filters keep
   Copilot-specific wording while other no-token agents get generic guidance.
 - Publish a **`stable` Docker image tag** on tagged releases. `stable` always
@@ -890,10 +978,11 @@ description: Release history for AgentsView
 - Fix **DuckDB push schema setup through Quack** so remote Quack-backed pushes
   initialize and validate the DuckDB schema correctly.
 - Fix **Visual Studio 2026 Copilot session parsing** for the current trace
-  layout while preserving the existing Visual Studio Copilot agent identity and
-  discovery paths.
+  layout while preserving the existing Visual Studio Copilot agent identity
+  and discovery paths.
 - Surface **unsupported Copilot usage filters** correctly in the Usage page and
-  API instead of showing an empty report without the Copilot no-token-data note.
+  API instead of showing an empty report without the Copilot no-token-data
+  note.
 - Backfill **worktree mappings** for sessions that have empty working-directory
   rows but can be matched from sibling sessions under the same mapping.
 - Prevent **OpenCode WAL watcher feedback loops** by reading OpenCode-family
@@ -907,10 +996,10 @@ description: Release history for AgentsView
 **Acknowledgements**
 
 - Thanks to [Rod Boev](https://github.com/rodboev) for pairwise usage
-  comparisons, Cursor attribution parity, Claude message-point session forking,
-  worktree-mapping backfills, unsupported usage capability metadata, usage
-  filter fixes, Visual Studio 2026 Copilot session parsing, and the `stable`
-  Docker image tag.
+  comparisons, Cursor attribution parity, Claude message-point session
+  forking, worktree-mapping backfills, unsupported usage capability metadata,
+  usage filter fixes, Visual Studio 2026 Copilot session parsing, and the
+  `stable` Docker image tag.
 - Thanks to [Matthew Jacobs](https://github.com/mjacobs) for parser
   malformed-line badges, Antigravity schema-confidence reporting,
   provider-backed `parse-diff` coverage, the Copilot CLI wording fix, and MCP
@@ -926,9 +1015,10 @@ description: Release history for AgentsView
 - Thanks to [Wes McKinney](https://github.com/wesm) for daemon sync CPU
   reduction, Windows test-suite fixture reuse, and release documentation.
 
----
+______________________________________________________________________
 
 ## 0.35.2
+
 <small>2026-06-30</small>
 
 **Bug fixes**
@@ -941,9 +1031,10 @@ description: Release history for AgentsView
 - Thanks to [leejuhanKr](https://github.com/leejuhanKr) for fixing PostgreSQL
   push sync behavior around skipped ownership conflicts.
 
----
+______________________________________________________________________
 
 ## 0.35.1
+
 <small>2026-06-30</small>
 
 **New features**
@@ -957,8 +1048,8 @@ description: Release history for AgentsView
 **Improvements**
 
 - Reuse the configured **DuckDB mirror path** for Quack sync so `duckdb push`,
-  `duckdb status`, `duckdb serve`, and `duckdb quack serve` stay pointed at the
-  same mirror by default.
+  `duckdb status`, `duckdb serve`, and `duckdb quack serve` stay pointed at
+  the same mirror by default.
 - Improve **DuckDB and Quack sync behavior and coverage**.
 
 **Bug fixes**
@@ -982,19 +1073,20 @@ description: Release history for AgentsView
 - Thanks to [Wes McKinney](https://github.com/wesm) for desktop backend error
   surfacing, desktop updater signature validation, and release documentation.
 
----
+______________________________________________________________________
 
 ## 0.35.0
+
 <small>2026-06-29</small>
 
 **New features**
 
-- Add **HTTP daemon remote sync** so configured remote hosts can sync through the
-  local daemon instead of requiring each CLI invocation to perform the work
-  directly.
-- Add **PostgreSQL serve support for curation and insights**. `agentsview pg
-  serve` can now back starred, trashed, renamed, and insight workflows from the
-  shared PostgreSQL store.
+- Add **HTTP daemon remote sync** so configured remote hosts can sync through
+  the local daemon instead of requiring each CLI invocation to perform the
+  work directly.
+- Add **PostgreSQL serve support for curation and insights**.
+  `agentsview pg serve` can now back starred, trashed, renamed, and insight
+  workflows from the shared PostgreSQL store.
 - Add a read-only **`agentsview mcp` server** for MCP-capable assistants to
   search sessions, inspect message windows, and summarize usage from the
   AgentsView archive. See [MCP Server](/docs/mcp/).
@@ -1078,15 +1170,16 @@ description: Release history for AgentsView
 **Acknowledgements**
 
 - Thanks to [Wes McKinney](https://github.com/wesm) for HTTP daemon remote sync,
-  daemon-first CLI and desktop workflows, Recent Edits, UI text-size scaling and
-  high-contrast mode, remote sync progress fixes, daemon replacement handling,
-  raw markdown docs routes, Amp documentation deprecation, PostgreSQL push
-  watermark fixes, and installer hardening.
+  daemon-first CLI and desktop workflows, Recent Edits, UI text-size scaling
+  and high-contrast mode, remote sync progress fixes, daemon replacement
+  handling, raw markdown docs routes, Amp documentation deprecation,
+  PostgreSQL push watermark fixes, and installer hardening.
 - Thanks to [Rod Boev](https://github.com/rodboev) for PostgreSQL serve curation
-  and insight persistence, generated insight export and publishing, Cursor admin
-  usage ingestion, per-remote sync intervals, named PostgreSQL push targets,
-  offline LiteLLM pricing fallback data, Pi lineage preservation, Insights help,
-  desktop fixes, Claude import/config fixes, and usage/stat fixes.
+  and insight persistence, generated insight export and publishing, Cursor
+  admin usage ingestion, per-remote sync intervals, named PostgreSQL push
+  targets, offline LiteLLM pricing fallback data, Pi lineage preservation,
+  Insights help, desktop fixes, Claude import/config fixes, and usage/stat
+  fixes.
 - Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the MCP server,
   parser anomaly signals, Codex rename and `/goal` handling fixes, Antigravity
   summary-mode sessions, blocked PostgreSQL push error handling, and parser
@@ -1110,9 +1203,10 @@ description: Release history for AgentsView
 - Thanks to [Martin Wimpress](https://github.com/flexiondotorg) for compatible
   PostgreSQL push schema handling.
 
----
+______________________________________________________________________
 
 ## 0.34.5
+
 <small>2026-06-23</small>
 
 **Bug fixes**
@@ -1124,251 +1218,242 @@ description: Release history for AgentsView
 
 - Refresh **command and session API docs** for current behavior.
 
----
+______________________________________________________________________
 
 ## 0.34.4
+
 <small>2026-06-22</small>
 
 **New features**
 
-- Reject **exported archives from newer AgentsView versions** so
-  incompatible imports fail safely.
+- Reject **exported archives from newer AgentsView versions** so incompatible
+  imports fail safely.
 
 **Improvements**
 
-- Refresh **daily usage totals** correctly while reducing repeated
-  pricing lookup work.
-- Group **GitHub Actions Renovate updates** in CI dependency
-  automation.
+- Refresh **daily usage totals** correctly while reducing repeated pricing
+  lookup work.
+- Group **GitHub Actions Renovate updates** in CI dependency automation.
 
 **Bug fixes**
 
-- Avoid **macOS Photos permission prompts** while scanning Aider
-  sessions.
-- Avoid **macOS Music permission prompts** while scanning Aider
-  sessions.
-- Reparse **stale Roborev CI projects** so updated session data
-  appears correctly.
+- Avoid **macOS Photos permission prompts** while scanning Aider sessions.
+- Avoid **macOS Music permission prompts** while scanning Aider sessions.
+- Reparse **stale Roborev CI projects** so updated session data appears
+  correctly.
 
----
+______________________________________________________________________
 
 ## 0.34.3
+
 <small>2026-06-22</small>
 
 **Improvements**
 
-- Make **full resync rebuilds** more efficient, reducing sync cost for
-  large archives.
+- Make **full resync rebuilds** more efficient, reducing sync cost for large
+  archives.
 - Update documentation for the latest **command, usage, and session API**
   changes.
 
 **Bug fixes**
 
-- Recognize **embedded security review prompts** correctly in stored
-  messages.
+- Recognize **embedded security review prompts** correctly in stored messages.
 
----
+______________________________________________________________________
 
 ## 0.34.2
+
 <small>2026-06-22</small>
 
 **New features**
 
-- Show **detailed resync progress** while full resyncs are running,
-  so the UI can report the current phase instead of only showing a
-  generic syncing state.
-- Add a **resume-focused session table** to
-  `agentsview session list`, including `--resume` and `--active`
-  modes for quickly finding recently active sessions.
+- Show **detailed resync progress** while full resyncs are running, so the UI
+  can report the current phase instead of only showing a generic syncing
+  state.
+- Add a **resume-focused session table** to `agentsview session list`, including
+  `--resume` and `--active` modes for quickly finding recently active
+  sessions.
 
 **Improvements**
 
-- Add **native session links in the sidebar** when an agent exposes
-  a supported resume target.
-- Redesign the **supported agents docs grid** as uniform clickable
-  chips.
+- Add **native session links in the sidebar** when an agent exposes a supported
+  resume target.
+- Redesign the **supported agents docs grid** as uniform clickable chips.
 
 **Bug fixes**
 
-- Handle **search terms with operator characters** without returning
-  server errors.
+- Handle **search terms with operator characters** without returning server
+  errors.
 - Parse **native Kimi Code records** correctly.
 - Improve **incremental JSONL resume reliability**.
 - Make **large-session deletes safer** for full-text search cleanup.
-- Prevent **Ctrl+K command palette input** from reselecting text on
-  every keystroke.
-- Avoid **DuckDB tool-call attachment failures** from invalid
-  negative call indexes.
+- Prevent **Ctrl+K command palette input** from reselecting text on every
+  keystroke.
+- Avoid **DuckDB tool-call attachment failures** from invalid negative call
+  indexes.
 
 **Acknowledgements**
 
-- Thanks to [Wes McKinney](https://github.com/wesm) for detailed
-  resync progress, native Kimi Code record parsing, and the supported
-  agents docs grid redesign.
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the
-  resume-focused session table and search operator-character fix.
-- Thanks to [Rod Boev](https://github.com/rodboev) for native sidebar
-  session links, incremental JSONL resume reliability, safer
-  large-session full-text cleanup, and the Ctrl+K palette input fix.
-- Thanks to [MirzaSamadAhmedBaig](https://github.com/Mirza-Samad-Ahmed-Baig)
-  for the DuckDB negative call-index fix.
+- Thanks to [Wes McKinney](https://github.com/wesm) for detailed resync
+  progress, native Kimi Code record parsing, and the supported agents docs
+  grid redesign.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the resume-focused
+  session table and search operator-character fix.
+- Thanks to [Rod Boev](https://github.com/rodboev) for native sidebar session
+  links, incremental JSONL resume reliability, safer large-session full-text
+  cleanup, and the Ctrl+K palette input fix.
+- Thanks to [MirzaSamadAhmedBaig](https://github.com/Mirza-Samad-Ahmed-Baig) for
+  the DuckDB negative call-index fix.
 
----
+______________________________________________________________________
 
 ## 0.34.1
+
 <small>2026-06-21</small>
 
 **New features**
 
-- Add the **AgentsView documentation site**, including quickstart,
-  commands, configuration, usage, stats, token usage, API, remote
-  access, and PostgreSQL sync docs.
-- Add **documentation build and deployment support**, including
-  validation, asset hydration, screenshot handling, and Vercel
-  deployment configuration.
+- Add the **AgentsView documentation site**, including quickstart, commands,
+  configuration, usage, stats, token usage, API, remote access, and PostgreSQL
+  sync docs.
+- Add **documentation build and deployment support**, including validation,
+  asset hydration, screenshot handling, and Vercel deployment configuration.
 
 **Improvements**
 
-- Clarify **forwarded development access** instructions for public
-  origins, tunnels, WSL2, Codespaces, Coder, and reverse proxy setups.
-- Move **internal-only documentation** into an internal docs area so
-  it stays available without publishing as user documentation.
-- Add automated checks for **docs sources, built site output,
-  redirects, and docs assets**.
+- Clarify **forwarded development access** instructions for public origins,
+  tunnels, WSL2, Codespaces, Coder, and reverse proxy setups.
+- Move **internal-only documentation** into an internal docs area so it stays
+  available without publishing as user documentation.
+- Add automated checks for **docs sources, built site output, redirects, and
+  docs assets**.
 
 **Bug fixes**
 
-- Avoid scanning **protected home directories** during Aider session
-  discovery.
+- Avoid scanning **protected home directories** during Aider session discovery.
 
----
+______________________________________________________________________
 
 ## 0.34.0
+
 <small>2026-06-20</small>
 
 **New features**
 
-- Add the **Activity** reporting dashboard. The new top-level page
-  reports active time, idle time, peak concurrency, agent-minutes,
-  cost, output tokens, projects, models, machine filters,
-  automation filters, clickable concurrency buckets, session rows,
-  project/model/agent breakdowns, and range-scoped Activity
-  Insights. See [Activity](/docs/activity/).
-- Add **session quality scoring and insight patterns**. Session
-  intelligence now has a richer scoring basis for recurring quality
-  patterns, and the Activity page can generate a daily or range
-  activity insight for the currently resolved range.
-- Add a **Top Skills** analytics panel that ranks skill-backed tool
-  calls by call count, sessions, recency, agent mix, project mix,
-  and weekly trend. Skill names come from explicit tool metadata and
-  are inferred from `SKILL.md` reads for agents (such as Codex and
-  Cursor) that do not record them. See [Top Skills](/docs/usage/#top-skills).
-- Add new session sources: **OhMyPi**, **Reasonix**, **aider**,
-  **Mistral Vibe**, **Visual Studio Copilot**, **Shelley**,
-  **QwenPaw**, **MiMoCode**, **Claude Cowork** sessions from Claude
-  Desktop local-agent mode, **Kilo**, **DeepSeek TUI**, and
-  **gptme**. Each source has a matching environment variable and
-  `config.toml` directory-array key. See
+- Add the **Activity** reporting dashboard. The new top-level page reports
+  active time, idle time, peak concurrency, agent-minutes, cost, output
+  tokens, projects, models, machine filters, automation filters, clickable
+  concurrency buckets, session rows, project/model/agent breakdowns, and
+  range-scoped Activity Insights. See [Activity](/docs/activity/).
+- Add **session quality scoring and insight patterns**. Session intelligence now
+  has a richer scoring basis for recurring quality patterns, and the Activity
+  page can generate a daily or range activity insight for the currently
+  resolved range.
+- Add a **Top Skills** analytics panel that ranks skill-backed tool calls by
+  call count, sessions, recency, agent mix, project mix, and weekly trend.
+  Skill names come from explicit tool metadata and are inferred from
+  `SKILL.md` reads for agents (such as Codex and Cursor) that do not record
+  them. See [Top Skills](/docs/usage/#top-skills).
+- Add new session sources: **OhMyPi**, **Reasonix**, **aider**, **Mistral
+  Vibe**, **Visual Studio Copilot**, **Shelley**, **QwenPaw**, **MiMoCode**,
+  **Claude Cowork** sessions from Claude Desktop local-agent mode, **Kilo**,
+  **DeepSeek TUI**, and **gptme**. Each source has a matching environment
+  variable and `config.toml` directory-array key. See
   [Session Discovery](/docs/configuration/#session-discovery).
-- Add **background `serve` mode**. `agentsview serve --background`
-  starts the web UI as a managed local service, writes logs to
-  `~/.agentsview/serve.log`, and records enough runtime metadata for
-  `agentsview serve status` and `agentsview serve stop` to inspect or
-  stop the daemon later. See [CLI Reference](/docs/commands/#background-mode).
-- Route `agentsview session` **read commands through PostgreSQL**.
-  When `AGENTSVIEW_PG_URL` or `[pg].url` is configured, read-only
-  session commands use the shared PostgreSQL store by default; pass
-  `--pg` to require that path explicitly. Mutating commands continue
-  to use the local archive.
-- Target an **explicit session server** from the `agentsview session`
-  CLI with `--server <url>`, authenticated by `AGENTSVIEW_SERVER_TOKEN`
-  or `--server-token-file`; a discovered local daemon's token is never
-  sent to an explicit URL. See [Session API](/docs/session-api/).
+- Add **background `serve` mode**. `agentsview serve --background` starts the
+  web UI as a managed local service, writes logs to `~/.agentsview/serve.log`,
+  and records enough runtime metadata for `agentsview serve status` and
+  `agentsview serve stop` to inspect or stop the daemon later. See
+  [CLI Reference](/docs/commands/#background-mode).
+- Route `agentsview session` **read commands through PostgreSQL**. When
+  `AGENTSVIEW_PG_URL` or `[pg].url` is configured, read-only session commands
+  use the shared PostgreSQL store by default; pass `--pg` to require that path
+  explicitly. Mutating commands continue to use the local archive.
+- Target an **explicit session server** from the `agentsview session` CLI with
+  `--server <url>`, authenticated by `AGENTSVIEW_SERVER_TOKEN` or
+  `--server-token-file`; a discovered local daemon's token is never sent to an
+  explicit URL. See [Session API](/docs/session-api/).
 - Add **session list sorting** to CLI and HTTP surfaces with
-  `agentsview session list --sort`, `--reverse`, `order_by`,
-  `descending`, and per-key direction suffixes such as
-  `messages:desc,started:asc`. See
+  `agentsview session list --sort`, `--reverse`, `order_by`, `descending`, and
+  per-key direction suffixes such as `messages:desc,started:asc`. See
   [Session API](/docs/session-api/#agentsview-session-list).
-- Add `agentsview doctor sync`, a **sync diagnostics** report for
-  checking database readability, data-version counts, agent roots,
-  and recent sync-debug lines. See [CLI Reference](/docs/commands/#agentsview-doctor-sync).
-- Add `agentsview parse-diff`, a parser QA report that re-parses
-  source files from the current archive and reports differences from
-  the stored SQLite rows without rewriting sessions. See
+- Add `agentsview doctor sync`, a **sync diagnostics** report for checking
+  database readability, data-version counts, agent roots, and recent
+  sync-debug lines. See [CLI Reference](/docs/commands/#agentsview-doctor-sync).
+- Add `agentsview parse-diff`, a parser QA report that re-parses source files
+  from the current archive and reports differences from the stored SQLite rows
+  without rewriting sessions. See
   [CLI Reference](/docs/commands/#agentsview-parse-diff).
-- Surface **Copilot AI credits** in usage reporting when
-  Copilot-family sessions have priced usage.
-- Add **Copy source file path** to the session export menu when the
-  active session has a backing source file.
+- Surface **Copilot AI credits** in usage reporting when Copilot-family sessions
+  have priced usage.
+- Add **Copy source file path** to the session export menu when the active
+  session has a backing source file.
 
 **Improvements**
 
-- Use one shared **range picker** and keep date ranges synchronized
-  across the Analytics dashboard, Usage page, and Activity page.
-- Improve **SQLite dashboard performance** by reducing heavy analytics
-  refetches during sync, adding more deliberate freshness handling,
-  improving large sidebar index loading, adding usage-query indexes,
-  compressing API responses, and bounding WAL checkpoints.
+- Use one shared **range picker** and keep date ranges synchronized across the
+  Analytics dashboard, Usage page, and Activity page.
+- Improve **SQLite dashboard performance** by reducing heavy analytics refetches
+  during sync, adding more deliberate freshness handling, improving large
+  sidebar index loading, adding usage-query indexes, compressing API
+  responses, and bounding WAL checkpoints.
 - Batch **PostgreSQL push comparison reads** for faster sync.
-- Preserve **source machine metadata** during PostgreSQL push instead
-  of replacing it with the pushing machine.
-- Persist **Codex and OpenCode working directories** so Git worktree
-  mappings can classify more sessions by their real project root.
-- Streamline the **Analytics and Usage refresh control**: a single
-  refresh button paired with a relative "Updated…" timestamp, where a
-  manual refresh also resets the automatic refresh timer.
-- Show **agent-provided display names in the dashboard "Top sessions"**
-  list instead of the first message, matching the session sidebar.
-- Extract **token usage and cost from VS Code Copilot** sessions when
-  their persisted request metadata includes `promptTokens`,
-  `outputTokens`, and resolved model names. See
+- Preserve **source machine metadata** during PostgreSQL push instead of
+  replacing it with the pushing machine.
+- Persist **Codex and OpenCode working directories** so Git worktree mappings
+  can classify more sessions by their real project root.
+- Streamline the **Analytics and Usage refresh control**: a single refresh
+  button paired with a relative "Updated…" timestamp, where a manual refresh
+  also resets the automatic refresh timer.
+- Show **agent-provided display names in the dashboard "Top sessions"** list
+  instead of the first message, matching the session sidebar.
+- Extract **token usage and cost from VS Code Copilot** sessions when their
+  persisted request metadata includes `promptTokens`, `outputTokens`, and
+  resolved model names. See
   [VS Code Copilot Token Metrics](/docs/token-usage/#vs-code-copilot-token-metrics).
-- Improve **Antigravity** parsing: IDE role detection now recognizes
-  newer step types, model-name extraction filters noisy prose and URLs,
-  token extraction is more complete, and tool-call metadata is richer.
-- Import **Codex renamed session titles** from `session_index.jsonl`
-  and re-parse **Codex sessions when token counts arrive late**, so
-  sidebar titles and usage rows catch up without a manual workaround.
-- Promote **orphan subagent sessions** into sidebar roots instead of
-  hiding them behind missing parents.
-- Fill in **working directory metadata for Pi** sessions when the Pi
-  transcript header provides it.
+- Improve **Antigravity** parsing: IDE role detection now recognizes newer step
+  types, model-name extraction filters noisy prose and URLs, token extraction
+  is more complete, and tool-call metadata is richer.
+- Import **Codex renamed session titles** from `session_index.jsonl` and
+  re-parse **Codex sessions when token counts arrive late**, so sidebar titles
+  and usage rows catch up without a manual workaround.
+- Promote **orphan subagent sessions** into sidebar roots instead of hiding them
+  behind missing parents.
+- Fill in **working directory metadata for Pi** sessions when the Pi transcript
+  header provides it.
 - Refresh frontend glyphs with **lucide icons**.
-- Strengthen **selected session styling** in the sidebar so the active
-  row remains visible across themes and agent colors.
-- Improve **Activity refresh controls**, filter controls, selected
-  sidebar rows, and read-only UI states.
-- Advertise the WSL **`eth0` URL** when `agentsview serve --host
-  0.0.0.0` runs inside WSL and no explicit `--public-url` was supplied.
-- Migrate frontend tooling to **Vite+** while preserving the existing
-  Svelte app behavior.
+- Strengthen **selected session styling** in the sidebar so the active row
+  remains visible across themes and agent colors.
+- Improve **Activity refresh controls**, filter controls, selected sidebar rows,
+  and read-only UI states.
+- Advertise the WSL **`eth0` URL** when `agentsview serve --host 0.0.0.0` runs
+  inside WSL and no explicit `--public-url` was supplied.
+- Migrate frontend tooling to **Vite+** while preserving the existing Svelte app
+  behavior.
 
 **Bug fixes**
 
-- Prevent **PostgreSQL push collisions** for same-ID sessions from
-  different machines.
-- Deduplicate **duplicate Claude sync sources** so the same transcript
-  is not indexed from overlapping roots.
-- Support the **Claude companion session layout**, including subagent
-  parent inference from companion directories and externalized tool
-  result content.
-- Support the newer **`.kimi-code` session layout** and add
-  **`.kimi_openclaw`** to OpenClaw's default discovery paths.
-- Parse **OpenClaw and QClaw `toolCall`/`toolResult` blocks**, whose
-  camelCase names the shared content extractor previously dropped, so
-  tool calls and tool-only assistant turns no longer vanish from those
-  transcripts.
-- Render Cursor **`ApplyPatch` tool calls** as patch/diff content in
-  the message viewer and markdown/export paths.
+- Prevent **PostgreSQL push collisions** for same-ID sessions from different
+  machines.
+- Deduplicate **duplicate Claude sync sources** so the same transcript is not
+  indexed from overlapping roots.
+- Support the **Claude companion session layout**, including subagent parent
+  inference from companion directories and externalized tool result content.
+- Support the newer **`.kimi-code` session layout** and add **`.kimi_openclaw`**
+  to OpenClaw's default discovery paths.
+- Parse **OpenClaw and QClaw `toolCall`/`toolResult` blocks**, whose camelCase
+  names the shared content extractor previously dropped, so tool calls and
+  tool-only assistant turns no longer vanish from those transcripts.
+- Render Cursor **`ApplyPatch` tool calls** as patch/diff content in the message
+  viewer and markdown/export paths.
 - Fix **nested fenced code block** parsing.
 - Pin CSP resource origins to the configured **public origin**, fixing
   deployments behind a trusted public URL or proxy.
-- Classify **single-turn automation from session transcripts**, not
-  just the stored first-message preview, so automated review sessions
-  are filtered correctly even when their preview is a generated title.
+- Classify **single-turn automation from session transcripts**, not just the
+  stored first-message preview, so automated review sessions are filtered
+  correctly even when their preview is a generated title.
 - Base **skill analytics** on message timestamps.
-- Route **command palette session picks** correctly from non-session
-  pages.
+- Route **command palette session picks** correctly from non-session pages.
 - Skip **local-only frontend calls in read-only mode**, including
   PostgreSQL-backed `pg serve` deployments.
 - Tolerate **NULL message timestamps** in velocity analytics.
@@ -1379,502 +1464,500 @@ description: Release history for AgentsView
 
 **Acknowledgements**
 
-- Thanks to [Wes McKinney](https://github.com/wesm) for the Activity dashboard, SQLite dashboard performance, sync diagnostics, explicit session-server targets, Claude companion session linking, Cursor `ApplyPatch` rendering, nested fence parsing, the WSL `eth0` URL, copy-source-path support, and assorted CLI and frontend fixes.
-- Thanks to [Nitin Gupta](https://github.com/g-nitin) for background `serve` mode.
+- Thanks to [Wes McKinney](https://github.com/wesm) for the Activity dashboard,
+  SQLite dashboard performance, sync diagnostics, explicit session-server
+  targets, Claude companion session linking, Cursor `ApplyPatch` rendering,
+  nested fence parsing, the WSL `eth0` URL, copy-source-path support, and
+  assorted CLI and frontend fixes.
+- Thanks to [Nitin Gupta](https://github.com/g-nitin) for background `serve`
+  mode.
 - Thanks to [Luiz Ferraz](https://github.com/Fryuni) for OhMyPi support.
 - Thanks to [Frank Zhu](https://github.com/gkld) for QwenPaw support.
-- Thanks to [Rod Boev](https://github.com/rodboev) for Reasonix support, Codex renamed titles, PostgreSQL source-machine preservation, PostgreSQL push batching, Copilot AI credits, orphan subagent promotion, and MiMoCode support.
-- Thanks to [SyedaAnshrahGillani](https://github.com/SyedaAnshrahGillani) for Antigravity role and model extraction improvements.
-- Thanks to [Justin Cauchon](https://github.com/Cauchon) for Claude Cowork indexing.
-- Thanks to [stephan379](https://github.com/stephan379) for VS Code Copilot token and cost extraction.
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for `parse-diff` reporting, Shelley support, session sorting, the NULL timestamp velocity fix, OpenClaw/QClaw tool-call parsing, and parser registry coverage.
+- Thanks to [Rod Boev](https://github.com/rodboev) for Reasonix support, Codex
+  renamed titles, PostgreSQL source-machine preservation, PostgreSQL push
+  batching, Copilot AI credits, orphan subagent promotion, and MiMoCode
+  support.
+- Thanks to [SyedaAnshrahGillani](https://github.com/SyedaAnshrahGillani) for
+  Antigravity role and model extraction improvements.
+- Thanks to [Justin Cauchon](https://github.com/Cauchon) for Claude Cowork
+  indexing.
+- Thanks to [stephan379](https://github.com/stephan379) for VS Code Copilot
+  token and cost extraction.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for `parse-diff`
+  reporting, Shelley support, session sorting, the NULL timestamp velocity
+  fix, OpenClaw/QClaw tool-call parsing, and parser registry coverage.
 - Thanks to [matt wilkie](https://github.com/maphew) for Kilo support.
 - Thanks to [yuna](https://github.com/yunasora) for DeepSeek TUI support.
-- Thanks to [Matt Van Horn](https://github.com/mvanhorn) for PostgreSQL-backed CLI reads.
-- Thanks to [潦草学者](https://github.com/liaocaoxuezhe) for Kimi `.kimi-code` and `.kimi_openclaw` support.
-- Thanks to [Douglas Creager](https://github.com/dcreager) for Pi working-directory metadata and dashboard display names.
+- Thanks to [Matt Van Horn](https://github.com/mvanhorn) for PostgreSQL-backed
+  CLI reads.
+- Thanks to [潦草学者](https://github.com/liaocaoxuezhe) for Kimi `.kimi-code` and
+  `.kimi_openclaw` support.
+- Thanks to [Douglas Creager](https://github.com/dcreager) for Pi
+  working-directory metadata and dashboard display names.
 - Thanks to [Bob](https://github.com/TimeToBuildBob) for the gptme parser.
-- Thanks to [Trần Quốc Việt](https://github.com/charlieviettq) for the Top Skills analytics panel and `SKILL.md` skill-name inference.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for session quality scoring and insight patterns, the Vite+ migration, and the Codex late-token-count fix.
-- Thanks to [vikram bhandoh](https://github.com/vikram) for Antigravity token extraction and richer tool-call metadata.
-- Thanks to [Phillip Cloud](https://github.com/cpcloud) for synchronized date ranges, the shared range picker, lucide icon migration, transcript-based automation classification, refresh and filter polish, read-only UI fixes, and usage chart label fixes.
-- Thanks to [liyi0x0](https://github.com/liyi0x0) for the Windows background daemon window fix.
-- Thanks to [Jesse Vincent](https://github.com/obra) for duplicate Claude sync-source deduplication and unwatched-root polling improvements.
-- Thanks to [Berend de Boer](https://github.com/berenddeboer) for Codex and OpenCode working-directory persistence.
+- Thanks to [Trần Quốc Việt](https://github.com/charlieviettq) for the Top
+  Skills analytics panel and `SKILL.md` skill-name inference.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for session
+  quality scoring and insight patterns, the Vite+ migration, and the Codex
+  late-token-count fix.
+- Thanks to [vikram bhandoh](https://github.com/vikram) for Antigravity token
+  extraction and richer tool-call metadata.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for synchronized date
+  ranges, the shared range picker, lucide icon migration, transcript-based
+  automation classification, refresh and filter polish, read-only UI fixes,
+  and usage chart label fixes.
+- Thanks to [liyi0x0](https://github.com/liyi0x0) for the Windows background
+  daemon window fix.
+- Thanks to [Jesse Vincent](https://github.com/obra) for duplicate Claude
+  sync-source deduplication and unwatched-root polling improvements.
+- Thanks to [Berend de Boer](https://github.com/berenddeboer) for Codex and
+  OpenCode working-directory persistence.
 - Thanks to [KBS](https://github.com/youdie006) for aider support.
-- Thanks to [Amjad Saadeh](https://github.com/amjadsaadeh) for Mistral Vibe support.
-- Thanks to [mtucker-virtra](https://github.com/mtucker-virtra) for Visual Studio Copilot support.
+- Thanks to [Amjad Saadeh](https://github.com/amjadsaadeh) for Mistral Vibe
+  support.
+- Thanks to [mtucker-virtra](https://github.com/mtucker-virtra) for Visual
+  Studio Copilot support.
 
----
+______________________________________________________________________
 
 ## 0.33.1
+
 <small>2026-06-12</small>
 
 **New features**
 
-- Show **user-assigned Pi session names**. The Pi parser now
-  extracts names assigned with Pi's `/name` command, so those
-  sessions appear in the sidebar under their given name
-  alongside other agent-provided session names.
+- Show **user-assigned Pi session names**. The Pi parser now extracts names
+  assigned with Pi's `/name` command, so those sessions appear in the sidebar
+  under their given name alongside other agent-provided session names.
 
 **Bug fixes**
 
-- Stop **double-counting forked Codex sessions**. `codex fork`
-  copies the parent's rollout history — session metadata,
-  turns, messages, and token counts — into the top of the new
-  file, and the parser counted that replayed prefix as the
-  fork's own activity, billing the shared history in both the
-  parent and the fork; the replayed parent metadata could also
-  overwrite the fork's session ID, storing the fork under the
-  parent's identity. Forked sessions now skip the replayed
-  history and keep their own identity.
-- Render **tool call groups** reliably when message identifiers
-  repeat. Sessions read through the
-  [PostgreSQL backend](/docs/pg-sync/)'s `pg serve` leave message
-  IDs unset (its messages table keys on session and ordinal),
-  so a tool call group holding more than one message produced
-  duplicate render keys and tore down the message panel. Groups
-  now key messages by their ordinal, which is unique within a
-  session on every backend.
+- Stop **double-counting forked Codex sessions**. `codex fork` copies the
+  parent's rollout history — session metadata, turns, messages, and token
+  counts — into the top of the new file, and the parser counted that replayed
+  prefix as the fork's own activity, billing the shared history in both the
+  parent and the fork; the replayed parent metadata could also overwrite the
+  fork's session ID, storing the fork under the parent's identity. Forked
+  sessions now skip the replayed history and keep their own identity.
+- Render **tool call groups** reliably when message identifiers repeat. Sessions
+  read through the [PostgreSQL backend](/docs/pg-sync/)'s `pg serve` leave
+  message IDs unset (its messages table keys on session and ordinal), so a
+  tool call group holding more than one message produced duplicate render keys
+  and tore down the message panel. Groups now key messages by their ordinal,
+  which is unique within a session on every backend.
 
 **Acknowledgements**
 
-- Thanks to [Douglas Creager](https://github.com/dcreager) for the Pi session name extraction.
-- Thanks to [nyxst4ck](https://github.com/nyxst4ck) for the forked Codex session fix.
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the tool call group rendering fix.
+- Thanks to [Douglas Creager](https://github.com/dcreager) for the Pi session
+  name extraction.
+- Thanks to [nyxst4ck](https://github.com/nyxst4ck) for the forked Codex session
+  fix.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the tool call group
+  rendering fix.
 
----
+______________________________________________________________________
 
 ## 0.33.0
+
 <small>2026-06-12</small>
 
 **New features**
 
 - Add a **DuckDB mirror backend** with Quack remote support.
   `agentsview duckdb push` mirrors the local SQLite archive into
-  `~/.agentsview/sessions.duckdb`, `agentsview duckdb serve`
-  runs the read-only web UI from that mirror, and
-  `agentsview duckdb quack serve` exposes the mirror over
-  DuckDB's Quack remote protocol so another machine can serve
-  from it. SQLite remains the source of truth for ingestion —
-  the mirror is one-way, like [PostgreSQL sync](/docs/pg-sync/).
-  Configuration lives in a `[duckdb]` section of `config.toml`.
-  See [DuckDB Mirror](/docs/duckdb/) for the full setup, including
-  the Quack token and loopback safety defaults. The DuckDB
-  driver is linked into every binary except `windows/arm64`,
-  where the upstream bindings ship no prebuilt library —
-  `agentsview duckdb` subcommands report a clear error there
-  while everything SQLite-backed keeps working.
-- Add **Command Code** session support. Sessions are discovered
-  under `~/.commandcode/projects/` as one JSONL file per
-  session, with an optional `.meta.json` sidecar for metadata;
-  structured tool calls, tool results, and thinking blocks are
-  parsed from the message content. Configure custom paths with
-  `COMMANDCODE_PROJECTS_DIR` or `commandcode_project_dirs`. See
+  `~/.agentsview/sessions.duckdb`, `agentsview duckdb serve` runs the
+  read-only web UI from that mirror, and `agentsview duckdb quack serve`
+  exposes the mirror over DuckDB's Quack remote protocol so another machine
+  can serve from it. SQLite remains the source of truth for ingestion — the
+  mirror is one-way, like [PostgreSQL sync](/docs/pg-sync/). Configuration
+  lives in a `[duckdb]` section of `config.toml`. See
+  [DuckDB Mirror](/docs/duckdb/) for the full setup, including the Quack token
+  and loopback safety defaults. The DuckDB driver is linked into every binary
+  except `windows/arm64`, where the upstream bindings ship no prebuilt library
+  — `agentsview duckdb` subcommands report a clear error there while everything
+  SQLite-backed keeps working.
+- Add **Command Code** session support. Sessions are discovered under
+  `~/.commandcode/projects/` as one JSONL file per session, with an optional
+  `.meta.json` sidecar for metadata; structured tool calls, tool results, and
+  thinking blocks are parsed from the message content. Configure custom paths
+  with `COMMANDCODE_PROJECTS_DIR` or `commandcode_project_dirs`. See
   [Session Discovery](/docs/configuration/#session-discovery).
-- Add **Zed** AI assistant session support. AgentsView reads
-  Zed's `threads/threads.db` SQLite database from the
-  platform data directory (`~/Library/Application Support/Zed`
-  on macOS, `~/.local/share/zed` on Linux,
-  `~/AppData/Local/Zed` on Windows), extracting messages, model
-  names, and per-request token usage, so Zed sessions also
-  contribute to [usage and cost reports](/docs/token-usage/).
-  Configure custom paths with `ZED_DIR` or `zed_dirs`.
-- Allow publishing sessions as **secret GitHub gists**. The
-  publish button in the session header is now a dropdown with
-  **Publish public Gist** and **Publish secret Gist** entries,
-  backed by an optional `secret` parameter on the publish
-  endpoint. Note that secret gists are unlisted, not
-  access-controlled — anyone with the URL can read them. The
-  `p` shortcut still publishes publicly. See
-  [Publish to Gist](/docs/usage/#publish-to-gist).
-- Ship **native Windows ARM64 builds**: release archives now
-  include a native `windows_arm64` binary (built with the
-  aarch64 llvm-mingw toolchain, with full CGO/FTS5 support) and
-  PyPI gains a `win_arm64` wheel. The PowerShell installer
-  prefers the native build automatically. See
+- Add **Zed** AI assistant session support. AgentsView reads Zed's
+  `threads/threads.db` SQLite database from the platform data directory
+  (`~/Library/Application Support/Zed` on macOS, `~/.local/share/zed` on
+  Linux, `~/AppData/Local/Zed` on Windows), extracting messages, model names,
+  and per-request token usage, so Zed sessions also contribute to
+  [usage and cost reports](/docs/token-usage/). Configure custom paths with
+  `ZED_DIR` or `zed_dirs`.
+- Allow publishing sessions as **secret GitHub gists**. The publish button in
+  the session header is now a dropdown with **Publish public Gist** and
+  **Publish secret Gist** entries, backed by an optional `secret` parameter on
+  the publish endpoint. Note that secret gists are unlisted, not
+  access-controlled — anyone with the URL can read them. The `p` shortcut
+  still publishes publicly. See [Publish to Gist](/docs/usage/#publish-to-gist).
+- Ship **native Windows ARM64 builds**: release archives now include a native
+  `windows_arm64` binary (built with the aarch64 llvm-mingw toolchain, with
+  full CGO/FTS5 support) and PyPI gains a `win_arm64` wheel. The PowerShell
+  installer prefers the native build automatically. See
   [Quick Start](/docs/quickstart/#install).
 - Add **configurable remote hosts** for
-  [`agentsview sync`](/docs/commands/#agentsview-sync). Declare a
-  fleet of machines as `[[remote_hosts]]` entries in
-  `config.toml` (each with `host` and optional `user` / `port`)
-  and a bare `agentsview sync` runs the local sync, then syncs
-  every configured host over SSH in order. Failed hosts are
-  reported and skipped rather than aborting the run;
-  `sync --host X` continues to ignore the configured list.
-- Show the **session cost** in the session header. Next to the
-  token summary, the header now displays the estimated cost of
-  the open session (`<$0.01` floor, two decimals up to $100,
-  whole dollars above), computed from the same per-session
-  usage endpoint that powers `agentsview session usage`. The
-  badge is hidden when the session has no token data or its
-  models have no pricing.
-- Add **syntax highlighting** for fenced code blocks, powered
-  by Shiki. Twelve common languages are bundled (JavaScript,
-  TypeScript, Python, Bash, JSON, YAML, Markdown, HTML, CSS,
-  Rust, Go, SQL); unlabeled or unknown languages render as
-  plain text. Highlighting is skipped for blocks over 50 KB or
-  800 lines to keep large sessions fast, and the highlighter
-  loads lazily in code-split chunks so it costs nothing until
-  the first code fence renders. See
-  [Code Blocks](/docs/usage/#code-blocks).
+  [`agentsview sync`](/docs/commands/#agentsview-sync). Declare a fleet of
+  machines as `[[remote_hosts]]` entries in `config.toml` (each with `host`
+  and optional `user` / `port`) and a bare `agentsview sync` runs the local
+  sync, then syncs every configured host over SSH in order. Failed hosts are
+  reported and skipped rather than aborting the run; `sync --host X` continues
+  to ignore the configured list.
+- Show the **session cost** in the session header. Next to the token summary,
+  the header now displays the estimated cost of the open session (`<$0.01`
+  floor, two decimals up to $100, whole dollars above), computed from the same
+  per-session usage endpoint that powers `agentsview session usage`. The badge
+  is hidden when the session has no token data or its models have no pricing.
+- Add **syntax highlighting** for fenced code blocks, powered by Shiki. Twelve
+  common languages are bundled (JavaScript, TypeScript, Python, Bash, JSON,
+  YAML, Markdown, HTML, CSS, Rust, Go, SQL); unlabeled or unknown languages
+  render as plain text. Highlighting is skipped for blocks over 50 KB or 800
+  lines to keep large sessions fast, and the highlighter loads lazily in
+  code-split chunks so it costs nothing until the first code fence renders.
+  See [Code Blocks](/docs/usage/#code-blocks).
 
 **Improvements**
 
-- Show **agent-provided session names** in the sidebar. Several
-  agents record a session title (Claude Code's `/rename`,
-  Claude.ai and ChatGPT conversation names, Forge, Hermes,
-  Kiro, Piebald, Cortex Code, and Command Code's `.meta.json`
-  titles); the session list now shows these titles instead of
-  the first-message preview. Manual in-app renames always win
-  and are never overwritten by agent-provided names. The
-  release bumps the parser data version, so existing sessions
-  backfill their names on the next resync.
-- Leave **session labels** untruncated. Sidebar labels were
-  hard-truncated at 50 characters; the full label is now placed
-  in the DOM and CSS ellipsis clipping adapts to the actual
-  sidebar width instead of a fixed character count.
-- Extract **Antigravity CLI token usage**. The parser now reads
-  token counts from trajectory `gen_metadata` blobs and from
-  sidecar `generatorMetadata` arrays, with precedence rules
-  that prevent double-counting, so Antigravity CLI sessions
-  contribute to the [Usage dashboard](/docs/token-usage/#usage-dashboard)
-  and `agentsview usage` after the 0.33.0 resync.
-- Prefer **agy-reader trajectory sidecars** when they are at
-  least as complete as the raw Antigravity CLI source: for
-  SQLite sessions the richer source wins by step count, and for
-  encrypted `.pb` sessions the sidecar is used whenever
-  present.
-- Infer the **Antigravity CLI project** when `history.jsonl`
-  rows lack a conversation ID, by matching the conversation's
-  first user prompt against history entries — previously those
-  sessions grouped under `unknown`.
-- Discover **nested Claude workflow subagents**. Subagent
-  transcripts written under nested `subagents/` paths (as
-  produced by workflow orchestration) are now found by a
-  recursive walk instead of a flat directory listing, so they
+- Show **agent-provided session names** in the sidebar. Several agents record a
+  session title (Claude Code's `/rename`, Claude.ai and ChatGPT conversation
+  names, Forge, Hermes, Kiro, Piebald, Cortex Code, and Command Code's
+  `.meta.json` titles); the session list now shows these titles instead of the
+  first-message preview. Manual in-app renames always win and are never
+  overwritten by agent-provided names. The release bumps the parser data
+  version, so existing sessions backfill their names on the next resync.
+- Leave **session labels** untruncated. Sidebar labels were hard-truncated at 50
+  characters; the full label is now placed in the DOM and CSS ellipsis
+  clipping adapts to the actual sidebar width instead of a fixed character
+  count.
+- Extract **Antigravity CLI token usage**. The parser now reads token counts
+  from trajectory `gen_metadata` blobs and from sidecar `generatorMetadata`
+  arrays, with precedence rules that prevent double-counting, so Antigravity
+  CLI sessions contribute to the
+  [Usage dashboard](/docs/token-usage/#usage-dashboard) and `agentsview usage`
+  after the 0.33.0 resync.
+- Prefer **agy-reader trajectory sidecars** when they are at least as complete
+  as the raw Antigravity CLI source: for SQLite sessions the richer source
+  wins by step count, and for encrypted `.pb` sessions the sidecar is used
+  whenever present.
+- Infer the **Antigravity CLI project** when `history.jsonl` rows lack a
+  conversation ID, by matching the conversation's first user prompt against
+  history entries — previously those sessions grouped under `unknown`.
+- Discover **nested Claude workflow subagents**. Subagent transcripts written
+  under nested `subagents/` paths (as produced by workflow orchestration) are
+  now found by a recursive walk instead of a flat directory listing, so they
   appear in the [sub-agent tree](/docs/usage/#sub-agent-tree).
-- Keep the app usable when the **PostgreSQL sync backend is
-  degraded**. A 5xx from the backend no longer forces a full
-  page reload (which could loop while the database was down) —
-  the UI stays interactive with a compact status-bar warning,
-  and recovers once a real data read succeeds. True network
-  failures still use the reload-based recovery path.
-- Improve **PostgreSQL and CockroachDB analytics performance**:
-  usage-window queries push their filters down into the source
-  tables, tool-call category aggregation moved from Go into
-  SQL, and model-pricing writes are batched and skipped when
-  unchanged. Aggregation semantics are unchanged across SQLite,
+- Keep the app usable when the **PostgreSQL sync backend is degraded**. A 5xx
+  from the backend no longer forces a full page reload (which could loop while
+  the database was down) — the UI stays interactive with a compact status-bar
+  warning, and recovers once a real data read succeeds. True network failures
+  still use the reload-based recovery path.
+- Improve **PostgreSQL and CockroachDB analytics performance**: usage-window
+  queries push their filters down into the source tables, tool-call category
+  aggregation moved from Go into SQL, and model-pricing writes are batched and
+  skipped when unchanged. Aggregation semantics are unchanged across SQLite,
   PostgreSQL, and CockroachDB.
 - Ship fallback pricing for **`claude-fable-5`** ($10 input,
-  $50 output, $12.50 cache creation, $1 cache read per million
-  tokens), so Fable 5 sessions are priced before the LiteLLM
-  catalog catches up. See
+  $50 output, $12.50 cache creation, $1 cache read per million tokens), so
+  Fable 5 sessions are priced before the LiteLLM catalog catches up. See
   [Pricing Source](/docs/token-usage/#pricing-source).
-- Fall back to the **system browser on Linux** when the desktop
-  WebView cannot render. On GPU/driver/compositor combinations
-  where WebKitGTK aborts with an EGL error and leaves a blank
-  window, the desktop app now detects the dead WebView, opens
-  the UI in your default browser, and explains what happened —
+- Fall back to the **system browser on Linux** when the desktop WebView cannot
+  render. On GPU/driver/compositor combinations where WebKitGTK aborts with an
+  EGL error and leaves a blank window, the desktop app now detects the dead
+  WebView, opens the UI in your default browser, and explains what happened —
   the backend keeps running either way.
-- Add **anonymous daemon telemetry**. The server now sends a
-  daily liveness ping (version, commit, OS, architecture, and a
-  random per-machine install ID — no session data, paths,
-  hostnames, or prompts). Disable it with
+- Add **anonymous daemon telemetry**. The server now sends a daily liveness ping
+  (version, commit, OS, architecture, and a random per-machine install ID — no
+  session data, paths, hostnames, or prompts). Disable it with
   `AGENTSVIEW_TELEMETRY_ENABLED=0`. See
   [Privacy and Telemetry](/docs/configuration/#privacy-and-telemetry).
 
 **Bug fixes**
 
-- Include **non-Claude agents** in the peak context token
-  distribution. The stats bucketing was gated to Claude
-  sessions even though other parsers (Hermes, Kimi, Forge, Zed)
-  record peak context tokens; the gate now keys on whether the
-  data exists.
-- Create the PostgreSQL **content trigram index** with
-  `fastupdate = off`. With the GIN default, continuous ingest
-  buffered inserts into a pending list that only VACUUM merges,
-  bloating the index by orders of magnitude on large archives.
-  New indexes are created with `fastupdate = off` and existing
-  ones are altered on startup; run
-  `REINDEX INDEX idx_messages_content_trgm;` once to reclaim
-  space already consumed.
-- Fix the **Windows PowerShell 5.x installer**, which aborted
-  with "maximum redirection count exceeded" while resolving the
-  latest release; the installer now follows the redirect with a
-  HEAD request that works on both PowerShell 5.x and 7+. On
-  Windows ARM64 it also probes for the native `arm64` asset and
-  falls back to `amd64` under emulation only when no native
+- Include **non-Claude agents** in the peak context token distribution. The
+  stats bucketing was gated to Claude sessions even though other parsers
+  (Hermes, Kimi, Forge, Zed) record peak context tokens; the gate now keys on
+  whether the data exists.
+- Create the PostgreSQL **content trigram index** with `fastupdate = off`. With
+  the GIN default, continuous ingest buffered inserts into a pending list that
+  only VACUUM merges, bloating the index by orders of magnitude on large
+  archives. New indexes are created with `fastupdate = off` and existing ones
+  are altered on startup; run `REINDEX INDEX idx_messages_content_trgm;` once
+  to reclaim space already consumed.
+- Fix the **Windows PowerShell 5.x installer**, which aborted with "maximum
+  redirection count exceeded" while resolving the latest release; the
+  installer now follows the redirect with a HEAD request that works on both
+  PowerShell 5.x and 7+. On Windows ARM64 it also probes for the native
+  `arm64` asset and falls back to `amd64` under emulation only when no native
   build exists.
 
 **Acknowledgements**
 
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the DuckDB mirror backend, secret gist publishing, nested workflow subagent discovery, untruncated session labels, and daemon telemetry.
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the Antigravity CLI sidecar token usage, trajectory-sidecar preference, project inference, and parser fuzz hardening.
-- Thanks to [vikram bhandoh](https://github.com/vikram) for Antigravity CLI token usage extraction.
-- Thanks to [Aaron Florey](https://github.com/aaronflorey) for Command Code session support.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the
+  DuckDB mirror backend, secret gist publishing, nested workflow subagent
+  discovery, untruncated session labels, and daemon telemetry.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the Antigravity CLI
+  sidecar token usage, trajectory-sidecar preference, project inference, and
+  parser fuzz hardening.
+- Thanks to [vikram bhandoh](https://github.com/vikram) for Antigravity CLI
+  token usage extraction.
+- Thanks to [Aaron Florey](https://github.com/aaronflorey) for Command Code
+  session support.
 - Thanks to [ArBing Xie](https://github.com/arbing) for Zed session support.
 - Thanks to [Josix](https://github.com/josix) for Shiki syntax highlighting.
-- Thanks to [chrislee3408](https://github.com/chrislee3408) for the session cost display in the session header.
-- Thanks to [Gordon Woodhull](https://github.com/gordonwoodhull) for agent-provided session names in the sidebar.
-- Thanks to [Phillip Cloud](https://github.com/cpcloud) for degraded-backend resilience and the CockroachDB analytics performance work.
-- Thanks to [Martin Wimpress](https://github.com/flexiondotorg) for the trigram index fix.
-- Thanks to [matt wilkie](https://github.com/maphew) for the Linux system-browser fallback.
-- Thanks to [nyxst4ck](https://github.com/nyxst4ck) for the peak context token distribution fix.
+- Thanks to [chrislee3408](https://github.com/chrislee3408) for the session cost
+  display in the session header.
+- Thanks to [Gordon Woodhull](https://github.com/gordonwoodhull) for
+  agent-provided session names in the sidebar.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for degraded-backend
+  resilience and the CockroachDB analytics performance work.
+- Thanks to [Martin Wimpress](https://github.com/flexiondotorg) for the trigram
+  index fix.
+- Thanks to [matt wilkie](https://github.com/maphew) for the Linux
+  system-browser fallback.
+- Thanks to [nyxst4ck](https://github.com/nyxst4ck) for the peak context token
+  distribution fix.
 
----
+______________________________________________________________________
 
 ## 0.32.1
+
 <small>2026-06-05</small>
 
 **New features**
 
-- Show the **full content of tool calls** in the message
-  viewer. Long tool parameters — Bash commands and
-  heredocs, large `Write` payloads — were truncated at
-  200 characters with no way to reach the rest, even
-  though the complete text was already stored. The
-  collapsed [tool block](/docs/usage/#tool-blocks) now previews
-  the first 20 lines with a *Show more* / *Show less*
-  toggle, Bash calls render their `description` and
-  `command` fields in full, content is capped at 200 lines
-  to keep the DOM light, and a search match inside a
-  collapsed block expands it automatically.
+- Show the **full content of tool calls** in the message viewer. Long tool
+  parameters — Bash commands and heredocs, large `Write` payloads — were
+  truncated at 200 characters with no way to reach the rest, even though the
+  complete text was already stored. The collapsed
+  [tool block](/docs/usage/#tool-blocks) now previews the first 20 lines with
+  a *Show more* / *Show less* toggle, Bash calls render their `description`
+  and `command` fields in full, content is capped at 200 lines to keep the DOM
+  light, and a search match inside a collapsed block expands it automatically.
 
 **Improvements**
 
-- Skip **`/usage` probe sessions** from session lists and
-  usage reporting. Content-free probes whose only real
-  turn is the `/usage` command — such as CodexBar's
-  ClaudeProbe, which runs `claude /usage` to read usage
-  stats — are now dropped during parsing, while sessions
-  that also contain a genuine prompt are kept.
+- Skip **`/usage` probe sessions** from session lists and usage reporting.
+  Content-free probes whose only real turn is the `/usage` command — such as
+  CodexBar's ClaudeProbe, which runs `claude /usage` to read usage stats — are
+  now dropped during parsing, while sessions that also contain a genuine
+  prompt are kept.
 - Recognize **Codex code-review sessions** as
   [automated activity](/docs/configuration/#automated-session-detection).
-  Codex re-emits the initial prompt verbatim when it
-  continues a task across turns, which pushed the
-  user-message count past the single-turn gate and left
-  review sessions (`"You are a code reviewer."` and
-  `"You are a security code reviewer."`) unflagged. The
-  parser now drops a verbatim replay of the first prompt
-  until a distinct user turn appears, so these sessions
-  classify as automated and stay out of session lists and
-  analytics by default. Both this and the `/usage` skip
-  ship with a `dataVersion` bump, so existing archives
-  correct themselves on the next resync.
+  Codex re-emits the initial prompt verbatim when it continues a task across
+  turns, which pushed the user-message count past the single-turn gate and
+  left review sessions (`"You are a code reviewer."` and
+  `"You are a security code reviewer."`) unflagged. The parser now drops a
+  verbatim replay of the first prompt until a distinct user turn appears, so
+  these sessions classify as automated and stay out of session lists and
+  analytics by default. Both this and the `/usage` skip ship with a
+  `dataVersion` bump, so existing archives correct themselves on the next
+  resync.
 
 **Bug fixes**
 
-- Resolve **dotted model names** to the dashed
-  pricing-catalog keys so usage costs compute correctly.
-  Some agents report model ids with dots (such as
-  OpenCode's `claude-opus-4.7`) while the LiteLLM table
-  keys them by the dashed API string (`claude-opus-4-7`),
-  so [`agentsview usage daily`](/docs/token-usage/#agentsview-usage-daily)
-  priced those sessions at `$0.00`. Every cost lookup now
-  falls back to the dot-to-dash form.
-- Speed up **sync project resolution** by avoiding
-  unnecessary `git` subprocesses. Resolving a session's
-  project now prefers a cheap filesystem `.git` walk for
-  normal repos and linked worktrees instead of shelling
-  out to `git` per session, keeping the previous git-based
-  lookup as a fallback for rare live-repo layouts. On a
-  ~35.7k-session archive this brings cold-sync time back
-  from about 4m31s to about 1m14s.
+- Resolve **dotted model names** to the dashed pricing-catalog keys so usage
+  costs compute correctly. Some agents report model ids with dots (such as
+  OpenCode's `claude-opus-4.7`) while the LiteLLM table keys them by the
+  dashed API string (`claude-opus-4-7`), so
+  [`agentsview usage daily`](/docs/token-usage/#agentsview-usage-daily) priced
+  those sessions at `$0.00`. Every cost lookup now falls back to the
+  dot-to-dash form.
+- Speed up **sync project resolution** by avoiding unnecessary `git`
+  subprocesses. Resolving a session's project now prefers a cheap filesystem
+  `.git` walk for normal repos and linked worktrees instead of shelling out to
+  `git` per session, keeping the previous git-based lookup as a fallback for
+  rare live-repo layouts. On a ~35.7k-session archive this brings cold-sync
+  time back from about 4m31s to about 1m14s.
 
 **Acknowledgements**
 
-- Thanks to [Nat Torkington](https://github.com/njt) for showing the full content of tool calls with a show-more toggle.
-- Thanks to [Daniel Grenner](https://github.com/dgrenner) for resolving dotted model names to dashed pricing keys.
+- Thanks to [Nat Torkington](https://github.com/njt) for showing the full
+  content of tool calls with a show-more toggle.
+- Thanks to [Daniel Grenner](https://github.com/dgrenner) for resolving dotted
+  model names to dashed pricing keys.
 
----
+______________________________________________________________________
 
 ## 0.32.0
+
 <small>2026-06-03</small>
 
 **New features**
 
-- Add support for newer **Antigravity CLI SQLite sessions**
-  stored as `~/.gemini/antigravity-cli/conversations/<uuid>.db`.
-  AgentsView discovers the SQLite files directly, prefers them
-  over same-ID encrypted `.pb` files, parses the trajectory steps
-  through the shared Antigravity SQLite/protobuf path, and includes
-  `.db-wal` / `.db-shm` metadata in change detection so live
-  updates resync reliably. The existing encrypted `.pb`,
-  `agy-reader` sidecar, and plaintext summary flows remain in
-  place for older Antigravity CLI sessions. See
-  [Session Discovery](/docs/configuration/#session-discovery).
-- Add **Copilot CLI token usage tracking**. The parser now reads
-  assistant output tokens from `assistant.message` events and
-  model-level input, output, cache-read, cache-write, and
-  reasoning totals from `session.shutdown` `modelMetrics`.
-  Claude model IDs reported with dotted versions are normalized to
-  the pricing-catalog form, so Copilot CLI rows now contribute to
-  the [Usage dashboard](/docs/token-usage/#usage-dashboard),
-  `agentsview usage`, and per-session usage reports after the
-  0.32.0 resync.
-- Add `GET /api/v1/sessions/{id}/usage`, a per-session usage
-  REST endpoint that returns the same stable JSON fields as
+- Add support for newer **Antigravity CLI SQLite sessions** stored as
+  `~/.gemini/antigravity-cli/conversations/<uuid>.db`. AgentsView discovers
+  the SQLite files directly, prefers them over same-ID encrypted `.pb` files,
+  parses the trajectory steps through the shared Antigravity SQLite/protobuf
+  path, and includes `.db-wal` / `.db-shm` metadata in change detection so
+  live updates resync reliably. The existing encrypted `.pb`, `agy-reader`
+  sidecar, and plaintext summary flows remain in place for older Antigravity
+  CLI sessions. See [Session Discovery](/docs/configuration/#session-discovery).
+- Add **Copilot CLI token usage tracking**. The parser now reads assistant
+  output tokens from `assistant.message` events and model-level input, output,
+  cache-read, cache-write, and reasoning totals from `session.shutdown`
+  `modelMetrics`. Claude model IDs reported with dotted versions are
+  normalized to the pricing-catalog form, so Copilot CLI rows now contribute
+  to the [Usage dashboard](/docs/token-usage/#usage-dashboard),
+  `agentsview usage`, and per-session usage reports after the 0.32.0 resync.
+- Add `GET /api/v1/sessions/{id}/usage`, a per-session usage REST endpoint that
+  returns the same stable JSON fields as
   [`agentsview session usage --format json`](/docs/session-api/#agentsview-session-usage),
-  including cost status, model lists, and unpriced models. The
-  endpoint works under both local SQLite-backed `agentsview serve`
-  and read-only [`agentsview pg serve`](/docs/pg-sync/#agentsview-pg-serve).
-- Add an automatic PostgreSQL push daemon. Run
-  `agentsview pg push --watch` for a foreground watcher that
-  performs an initial catch-up push, coalesces file changes with
-  `--debounce`, pushes at a periodic `--interval` floor, and
+  including cost status, model lists, and unpriced models. The endpoint
+  works under both local SQLite-backed `agentsview serve` and read-only
+  [`agentsview pg serve`](/docs/pg-sync/#agentsview-pg-serve).
+- Add an automatic PostgreSQL push daemon. Run `agentsview pg push --watch` for
+  a foreground watcher that performs an initial catch-up push, coalesces file
+  changes with `--debounce`, pushes at a periodic `--interval` floor, and
   reconnects after transient PostgreSQL failures. The new
-  `agentsview pg service` command installs and manages that
-  watcher as a per-user launchd service on macOS or
-  `systemd --user` service on Linux. See
+  `agentsview pg service` command installs and manages that watcher as a
+  per-user launchd service on macOS or `systemd --user` service on Linux. See
   [PostgreSQL Sync](/docs/pg-sync/#automatic-push-watcher).
-- Ship fallback pricing for `claude-opus-4-7` at the current
-  Opus 4.6 / 4.8 tier (`$5` input, `$25` output,
-  `$6.25` cache creation, `$0.50` cache read per million tokens),
-  so offline reports and fresh installs no longer leave Opus 4.7
-  rows unpriced before the LiteLLM catalog is available locally.
+- Ship fallback pricing for `claude-opus-4-7` at the current Opus 4.6 / 4.8 tier
+  (`$5` input, `$25` output, `$6.25` cache creation, `$0.50` cache read per
+  million tokens), so offline reports and fresh installs no longer leave Opus
+  4.7 rows unpriced before the LiteLLM catalog is available locally.
 
 **Improvements**
 
-- Replace the custom daemon state-file and PID-lock code with the
-  shared `go.kenn.io/kit` daemon runtime. CLI commands now use
-  kit runtime records and start locks for daemon discovery, and
-  the server exposes a shared `/api/ping` liveness endpoint.
-- Switch git repository discovery and author lookup paths onto
-  `go.kenn.io/kit` helpers, thread caller contexts through git
-  outcome collection, and pin the Go toolchain consistently in
-  source and Docker builds.
-- Improve the PostgreSQL push/watch path so the watcher uses the
-  same `[pg]` config, project filters, classifier wiring, and
-  result-content blocking rules as one-shot `pg push` and normal
-  `serve`.
-- Replace custom frontend UI glyphs with shared lucide Svelte
-  icons for more consistent controls, with focused icon export
-  tests to guard the mappings.
-- Improve forwarded-host rejection handling. When AgentsView is
-  reached through SSH port forwarding, a reverse proxy, or a
-  remote dev environment with an untrusted `Host`, the server now
-  returns a descriptive `403` body and logs a breadcrumb; the
-  frontend Settings load surfaces the same actionable
+- Replace the custom daemon state-file and PID-lock code with the shared
+  `go.kenn.io/kit` daemon runtime. CLI commands now use kit runtime records
+  and start locks for daemon discovery, and the server exposes a shared
+  `/api/ping` liveness endpoint.
+- Switch git repository discovery and author lookup paths onto `go.kenn.io/kit`
+  helpers, thread caller contexts through git outcome collection, and pin the
+  Go toolchain consistently in source and Docker builds.
+- Improve the PostgreSQL push/watch path so the watcher uses the same `[pg]`
+  config, project filters, classifier wiring, and result-content blocking
+  rules as one-shot `pg push` and normal `serve`.
+- Replace custom frontend UI glyphs with shared lucide Svelte icons for more
+  consistent controls, with focused icon export tests to guard the mappings.
+- Improve forwarded-host rejection handling. When AgentsView is reached through
+  SSH port forwarding, a reverse proxy, or a remote dev environment with an
+  untrusted `Host`, the server now returns a descriptive `403` body and logs a
+  breadcrumb; the frontend Settings load surfaces the same actionable
   `--public-url` hint instead of a generic forbidden error. See
   [Remote Access](/docs/remote-access/#forwarded-dev-environments).
-- Update `agy-reader` install documentation to the current module
-  root command: `go install github.com/mjacobs/agy-reader@latest`.
+- Update `agy-reader` install documentation to the current module root command:
+  `go install github.com/mjacobs/agy-reader@latest`.
 
 **Bug fixes**
 
-- Stop benign `tar` warnings from aborting SSH remote sync. The
-  local extractor now uses Go's `archive/tar`, skips only known
-  self-referential hardlinks, and still fails on malformed,
-  truncated, or path-escaping archives. Remote `tar` non-zero
-  exits are tolerated only when every stderr line matches known
+- Stop benign `tar` warnings from aborting SSH remote sync. The local extractor
+  now uses Go's `archive/tar`, skips only known self-referential hardlinks,
+  and still fails on malformed, truncated, or path-escaping archives. Remote
+  `tar` non-zero exits are tolerated only when every stderr line matches known
   "file changed/removed while reading" warnings.
-- Rename the private frontend npm package from the old working
-  name to `agentsview-frontend`, matching the current project
-  identity and avoiding package-name conflicts.
+- Rename the private frontend npm package from the old working name to
+  `agentsview-frontend`, matching the current project identity and avoiding
+  package-name conflicts.
 
 **Acknowledgements**
 
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for self-explaining forwarded-host 403 responses, Antigravity CLI SQLite session support, and updated `agy-reader` install guidance.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the lucide icon migration, shared kit daemon runtime, kit git-helper migration, and Go toolchain pinning.
-- Thanks to [Max Feinberg](https://github.com/mxfeinberg) for the PostgreSQL push watcher and macOS/Linux service management.
-- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for Copilot CLI token usage tracking.
-- Thanks to [Phillip Cloud](https://github.com/cpcloud) for the per-session usage REST endpoint.
-- Thanks to [Charley Wu](https://github.com/akunzai) for catching the broken `agy-reader` install command path.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for self-explaining
+  forwarded-host 403 responses, Antigravity CLI SQLite session support, and
+  updated `agy-reader` install guidance.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the
+  lucide icon migration, shared kit daemon runtime, kit git-helper migration,
+  and Go toolchain pinning.
+- Thanks to [Max Feinberg](https://github.com/mxfeinberg) for the PostgreSQL
+  push watcher and macOS/Linux service management.
+- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for Copilot CLI
+  token usage tracking.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for the per-session
+  usage REST endpoint.
+- Thanks to [Charley Wu](https://github.com/akunzai) for catching the broken
+  `agy-reader` install command path.
 
----
+______________________________________________________________________
 
 ## 0.31.1
+
 <small>2026-05-28</small>
 
 **Bug fixes**
 
-- Add fallback pricing for **Claude Opus 4.8** so cost
-  estimates stay accurate before the model reaches the
-  LiteLLM catalog. Opus 4.8 launched at the same rates as
-  Opus 4.6 / 4.7 ($5 input / $25 output per million tokens,
-  $6.25 / $0.50 cache create / read), but with no catalog
-  entry yet the exact-match cost lookup priced its messages
-  at $0 in `agentsview usage`. AgentsView now seeds a
-  `claude-opus-4-8` fallback row at the current Opus tier;
-  the background LiteLLM refresh takes over automatically
-  once the upstream catalog adds the model.
+- Add fallback pricing for **Claude Opus 4.8** so cost estimates stay accurate
+  before the model reaches the LiteLLM catalog. Opus 4.8 launched at the same
+  rates as Opus 4.6 / 4.7 ($5 input / $25 output per million tokens,
+  $6.25 / $0.50 cache create / read), but with no catalog entry yet the
+  exact-match cost lookup priced its messages at $0 in `agentsview usage`.
+  AgentsView now seeds a `claude-opus-4-8` fallback row at the current Opus
+  tier; the background LiteLLM refresh takes over automatically once the
+  upstream catalog adds the model.
 
----
+______________________________________________________________________
 
 ## 0.31.0
+
 <small>2026-05-28</small>
 
 **New features**
 
-- Parse **decrypted Antigravity CLI trajectory sidecars**
-  for richer Antigravity session imports. When a
-  `<uuid>.trajectory.json` file sits next to the existing
-  AES-encrypted `<uuid>.pb` transcript (under
-  `~/.gemini/antigravity-cli/conversations/` or `implicit/`),
-  AgentsView uses it as the source of truth for messages,
-  tool calls, and tool results, falling back to the
-  `history.jsonl` + `brain/` artifact path when no sidecar
+- Parse **decrypted Antigravity CLI trajectory sidecars** for richer Antigravity
+  session imports. When a `<uuid>.trajectory.json` file sits next to the
+  existing AES-encrypted `<uuid>.pb` transcript (under
+  `~/.gemini/antigravity-cli/conversations/` or `implicit/`), AgentsView uses
+  it as the source of truth for messages, tool calls, and tool results,
+  falling back to the `history.jsonl` + `brain/` artifact path when no sidecar
   is present. The sidecars are produced out-of-process by
-  [agy-reader](https://github.com/mjacobs/agy-reader), which
-  performs the decryption and writes plain JSON — so this
-  path needs no `ANTIGRAVITY_KEY`. AgentsView treats the
-  sidecar as untrusted input: unknown step types are skipped
-  and reads are size-capped. The in-process `ANTIGRAVITY_KEY`
-  decrypt path is preserved as a fallback. See
+  [agy-reader](https://github.com/mjacobs/agy-reader), which performs the
+  decryption and writes plain JSON — so this path needs no `ANTIGRAVITY_KEY`.
+  AgentsView treats the sidecar as untrusted input: unknown step types are
+  skipped and reads are size-capped. The in-process `ANTIGRAVITY_KEY` decrypt
+  path is preserved as a fallback. See
   [Session Discovery](/docs/configuration/#session-discovery).
-- Expand **[secret scanning](/docs/session-api/#secret-scanning)**
-  with six more well-anchored vendor rules: OpenAI
-  (`sk-proj-`, `sk-svcacct-`, `sk-admin-`), GitLab personal
-  access tokens (`glpat-…`), npm tokens (`npm_…`), PyPI API
-  tokens (`pypi-…` macaroons), Hugging Face tokens (`hf_…`),
-  and SendGrid keys (`SG.…`). The CLI summary now splits
-  counts into definite vs. candidate findings —
-  `N findings (X definite, Y candidate)` — and points you at
+- Expand **[secret scanning](/docs/session-api/#secret-scanning)** with six more
+  well-anchored vendor rules: OpenAI (`sk-proj-`, `sk-svcacct-`, `sk-admin-`),
+  GitLab personal access tokens (`glpat-…`), npm tokens (`npm_…`), PyPI API
+  tokens (`pypi-…` macaroons), Hugging Face tokens (`hf_…`), and SendGrid keys
+  (`SG.…`). The CLI summary now splits counts into definite vs. candidate
+  findings — `N findings (X definite, Y candidate)` — and points you at
   [`agentsview secrets list --confidence all`](/docs/commands/#agentsview-secrets)
-  when candidate-tier matches exist. JSON consumers get the
-  new count fields automatically.
+  when candidate-tier matches exist. JSON consumers get the new count fields
+  automatically.
 
 **Improvements**
 
-- Give the right-column
-  [Session Vital Signs](/docs/usage/#session-vital-signs) panel a
-  sticky **Analysis** title bar with an explicit close
-  button, and make the header toggle read *Show / Hide
-  session analysis* based on the panel's current state.
-- Add hover and title hints plus accessible labels across
-  the compact title bar, session breadcrumb, sidebar group
-  headers, and modal controls, improving the experience for
-  assistive-technology users.
-- Document the project's current security posture — threat
-  model, trust boundaries, outbound channels, data-at-rest
-  sensitivity, and open questions — in a new
+- Give the right-column [Session Vital Signs](/docs/usage/#session-vital-signs)
+  panel a sticky **Analysis** title bar with an explicit close button, and
+  make the header toggle read *Show / Hide session analysis* based on the
+  panel's current state.
+- Add hover and title hints plus accessible labels across the compact title bar,
+  session breadcrumb, sidebar group headers, and modal controls, improving the
+  experience for assistive-technology users.
+- Document the project's current security posture — threat model, trust
+  boundaries, outbound channels, data-at-rest sensitivity, and open questions
+  — in a new
   [`SECURITY.md`](https://github.com/kenn-io/agentsview/blob/main/SECURITY.md).
-- Update frontend dependencies and the Docker / CI GitHub
-  Actions.
+- Update frontend dependencies and the Docker / CI GitHub Actions.
 
 **Bug fixes**
 
-- Treat only `401 Unauthorized` from a settings load as a
-  token-auth challenge. A `403 Forbidden` response now
-  surfaces as a settings error instead of triggering a
-  misleading auth-token prompt.
-- Use the GitHub release **redirect endpoint** in the
-  installers and the in-binary updater (`install.sh`,
-  `install.ps1`, and `agentsview update`), reading the
-  `releases/latest` 302 target instead of calling
-  `api.github.com`. Users behind shared NAT, VPN, or CGNAT
-  no longer exhaust the unauthenticated API's 60-request
-  hourly quota during install or update.
+- Treat only `401 Unauthorized` from a settings load as a token-auth challenge.
+  A `403 Forbidden` response now surfaces as a settings error instead of
+  triggering a misleading auth-token prompt.
+- Use the GitHub release **redirect endpoint** in the installers and the
+  in-binary updater (`install.sh`, `install.ps1`, and `agentsview update`),
+  reading the `releases/latest` 302 target instead of calling
+  `api.github.com`. Users behind shared NAT, VPN, or CGNAT no longer exhaust
+  the unauthenticated API's 60-request hourly quota during install or update.
 
 **Acknowledgements**
 
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the SECURITY.md describing the project security posture and parsing decrypted Antigravity CLI trajectory sidecars.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for header accessibility hints and labels.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the SECURITY.md
+  describing the project security posture and parsing decrypted Antigravity
+  CLI trajectory sidecars.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for header
+  accessibility hints and labels.
 
----
+______________________________________________________________________
 
 ## 0.30.1
+
 <small>2026-05-25</small>
 
 **Bug fixes**
@@ -1882,415 +1965,394 @@ description: Release history for AgentsView
 - Refresh pricing from LiteLLM when
   [`agentsview session usage`](/docs/session-api/#agentsview-session-usage)
   hits an unpriced model. The command previously reported
-  `Cost: n/a (unpriced: <model>)` for a newly released model
-  even when LiteLLM already had the rate — running
-  `agentsview serve` once was enough to fix it, because the
-  server's background refresh populated the catalog, while
-  the CLI path only seeded the embedded fallback. The CLI now
-  triggers a one-shot LiteLLM fetch when it encounters an
-  unpriced model and no daemon is running, then re-queries.
-  A one-hour cooldown keeps repeated invocations — or
-  persistent fetch failures when offline — from pinging
-  LiteLLM on every call.
+  `Cost: n/a (unpriced: <model>)` for a newly released model even when LiteLLM
+  already had the rate — running `agentsview serve` once was enough to fix it,
+  because the server's background refresh populated the catalog, while the CLI
+  path only seeded the embedded fallback. The CLI now triggers a one-shot
+  LiteLLM fetch when it encounters an unpriced model and no daemon is running,
+  then re-queries. A one-hour cooldown keeps repeated invocations — or
+  persistent fetch failures when offline — from pinging LiteLLM on every call.
 
----
+______________________________________________________________________
 
 ## 0.30.0
+
 <small>2026-05-24</small>
 
 **New features**
 
-- Add full **session content search** across stored
-  transcripts — substring, RE2 regex, or FTS5 tokenized
-  modes — over message bodies, tool inputs, and tool result
-  content. Exposed as `agentsview session search <pattern>`
-  with the standard session filters (`--project`, `--agent`,
-  `--date-from`, etc.) plus `--regex`, `--fts`, and
-  `--in messages,tool_input,tool_result`, and over HTTP at
-  `GET /api/v1/search/content`. Snippets are returned with
-  ~60 characters of context on each side, snapped to rune
-  boundaries, and any value that matches a secret-scanner
-  rule is masked unless the caller passes `--reveal` from
-  localhost.
-- Add **secret scanning** for session content. A new
-  `internal/secrets` rule pack flags definite vendor
-  formats (AWS access keys, `sk-ant-…`, `ghp_…`,
-  `github_pat_…`, `xoxb/xoxa/xoxp/xoxr/xoxs`, Stripe
-  `sk_live_…` / `rk_live_…`, Google `AIza…` keys, PEM
-  private-key blocks) plus an opt-in candidate tier
-  (basic-auth URLs, JWTs, high-entropy assignments).
-  Definite findings are scored inline during sync; the new
-  [`agentsview secrets`](/docs/commands/#agentsview-secrets)
-  command group lists them (redacted by default) and
-  re-scans the archive for the candidate tier on demand.
-  Sessions carry a `secret_leak_count` summary that surfaces
-  in [`session get`](/docs/session-api/#agentsview-session-get)
-  and a new
+- Add full **session content search** across stored transcripts — substring, RE2
+  regex, or FTS5 tokenized modes — over message bodies, tool inputs, and tool
+  result content. Exposed as `agentsview session search <pattern>` with the
+  standard session filters (`--project`, `--agent`, `--date-from`, etc.) plus
+  `--regex`, `--fts`, and `--in messages,tool_input,tool_result`, and over
+  HTTP at `GET /api/v1/search/content`. Snippets are returned with ~60
+  characters of context on each side, snapped to rune boundaries, and any
+  value that matches a secret-scanner rule is masked unless the caller passes
+  `--reveal` from localhost.
+- Add **secret scanning** for session content. A new `internal/secrets` rule
+  pack flags definite vendor formats (AWS access keys, `sk-ant-…`, `ghp_…`,
+  `github_pat_…`, `xoxb/xoxa/xoxp/xoxr/xoxs`, Stripe `sk_live_…` /
+  `rk_live_…`, Google `AIza…` keys, PEM private-key blocks) plus an opt-in
+  candidate tier (basic-auth URLs, JWTs, high-entropy assignments). Definite
+  findings are scored inline during sync; the new
+  [`agentsview secrets`](/docs/commands/#agentsview-secrets) command group
+  lists them (redacted by default) and re-scans the archive for the candidate
+  tier on demand. Sessions carry a `secret_leak_count` summary that surfaces
+  in [`session get`](/docs/session-api/#agentsview-session-get) and a new
   [`session list --has-secret`](/docs/session-api/#agentsview-session-list)
   filter; the same shape is mirrored in PostgreSQL sync.
-- Add [`agentsview session usage <id>`](/docs/session-api/#agentsview-session-usage),
-  a per-session token-and-cost report. Prints output and
-  peak-context totals plus a `~$X.XX` model-pricing
-  estimate, with `--format json` for scripting. Reuses the
-  same LiteLLM pricing table and `custom_model_pricing`
-  overrides as `agentsview usage daily`, and runs an
-  on-demand sync for the target session when no daemon is
-  running. Replaces the older `token-use` subcommand, which
-  remains as a deprecated alias.
-- Add support for **Google Antigravity** IDE and CLI
-  sessions ([Antigravity](https://antigravity.google),
-  Google's agentic IDE). The IDE parser opens per-session
-  SQLite databases under `~/.gemini/antigravity/conversations/`
-  and decodes the protobuf step payloads; the CLI parser
-  reads `~/.gemini/antigravity-cli/` and surfaces the
-  plaintext `brain/` artifacts and `history.jsonl`. Setting
-  `ANTIGRAVITY_KEY` to the base64-encoded AES key
-  additionally decrypts the `.pb` transcripts, mirroring the
-  strategy used by the upstream
+- Add
+  [`agentsview session usage <id>`](/docs/session-api/#agentsview-session-usage),
+  a per-session token-and-cost report. Prints output and peak-context totals
+  plus a `~$X.XX` model-pricing estimate, with `--format json` for scripting.
+  Reuses the same LiteLLM pricing table and `custom_model_pricing` overrides
+  as `agentsview usage daily`, and runs an on-demand sync for the target
+  session when no daemon is running. Replaces the older `token-use`
+  subcommand, which remains as a deprecated alias.
+- Add support for **Google Antigravity** IDE and CLI sessions
+  ([Antigravity](https://antigravity.google), Google's agentic IDE). The IDE
+  parser opens per-session SQLite databases under
+  `~/.gemini/antigravity/conversations/` and decodes the protobuf step
+  payloads; the CLI parser reads `~/.gemini/antigravity-cli/` and surfaces the
+  plaintext `brain/` artifacts and `history.jsonl`. Setting `ANTIGRAVITY_KEY`
+  to the base64-encoded AES key additionally decrypts the `.pb` transcripts,
+  mirroring the strategy used by the upstream
   [`antigravity_decryptor`](https://github.com/arashz/antigravity_decryptor)
-  Python tool. Override the directories with `ANTIGRAVITY_DIR`
-  / `antigravity_dirs` and `ANTIGRAVITY_CLI_DIR` /
-  `antigravity_cli_dirs`.
+  Python tool. Override the directories with `ANTIGRAVITY_DIR` /
+  `antigravity_dirs` and `ANTIGRAVITY_CLI_DIR` / `antigravity_cli_dirs`.
 - Add support for **[Qwen Code](https://github.com/QwenLM/qwen-code)**
-  (`~/.qwen/projects/`, override with `QWEN_PROJECTS_DIR`
-  or `qwen_project_dirs`), **QClaw**
-  (`~/.qclaw/assets/static/agents/`, override with `QCLAW_DIR` or
-  `qclaw_dirs`), and **WorkBuddy**
-  (`~/.workbuddy/projects/`, override with
-  `WORKBUDDY_PROJECTS_DIR` or `workbuddy_project_dirs`).
-  WorkBuddy includes inline subagent linking via
+  (`~/.qwen/projects/`, override with `QWEN_PROJECTS_DIR` or
+  `qwen_project_dirs`), **QClaw** (`~/.qclaw/assets/static/agents/`, override
+  with `QCLAW_DIR` or `qclaw_dirs`), and **WorkBuddy**
+  (`~/.workbuddy/projects/`, override with `WORKBUDDY_PROJECTS_DIR` or
+  `workbuddy_project_dirs`). WorkBuddy includes inline subagent linking via
   `<sessionId>:subagent:<subagentId>` IDs.
 - Add support for the **current Kiro CLI SQLite store** at
-  `~/.local/share/kiro-cli/data.sqlite3`. The Kiro CLI
-  parser now reads both the legacy
-  `~/.kiro/sessions/cli/` JSONL layout and the SQLite
-  `conversations_v2` table; when the same conversation
-  exists in both, the SQLite record wins.
-- Add **PostgreSQL curation metadata** to `pg push`.
-  Starred sessions and pinned messages now sync to two new
-  tables (`starred_sessions`, `pinned_messages`) so curation
-  state is shared across machines through the same push.
-  Pinned messages are reconciled by `source_uuid`, so pins
-  survive message-ordinal shifts after a re-parse.
-- Add [configurable insight agent binaries](/docs/recall/#configuring-agent-binaries).
-  Set `[agent.<name>] binary = "..."` in
-  `~/.agentsview/config.toml` to point each insight-generation
-  agent (Claude, Codex, Copilot, Gemini, Kiro) at a specific
-  executable. When unset, AgentsView falls through to the
+  `~/.local/share/kiro-cli/data.sqlite3`. The Kiro CLI parser now reads both
+  the legacy `~/.kiro/sessions/cli/` JSONL layout and the SQLite
+  `conversations_v2` table; when the same conversation exists in both, the
+  SQLite record wins.
+- Add **PostgreSQL curation metadata** to `pg push`. Starred sessions and pinned
+  messages now sync to two new tables (`starred_sessions`, `pinned_messages`)
+  so curation state is shared across machines through the same push. Pinned
+  messages are reconciled by `source_uuid`, so pins survive message-ordinal
+  shifts after a re-parse.
+- Add
+  [configurable insight agent binaries](/docs/recall/#configuring-agent-binaries).
+  Set `[agent.<name>] binary = "..."` in `~/.agentsview/config.toml` to
+  point each insight-generation agent (Claude, Codex, Copilot, Gemini, Kiro)
+  at a specific executable. When unset, AgentsView falls through to the
   default `PATH` lookup.
 
 **Improvements**
 
-- Add a [follow latest message toggle](/docs/usage/#follow-latest-message)
-  to the session header. While active, the message list
-  auto-scrolls to the newest message as updates stream in;
-  clicking a specific message or scrolling up cancels the
-  follow. The preference is persisted in localStorage.
-- Honor the [Normal and Focused transcript modes](/docs/usage/#focused-transcript-mode)
-  in the standalone HTML export. The exported file now ships
-  with a Normal / Focused radio toggle in the document
-  header, so a recipient who only wants the user-and-final
-  view can flip into Focused mode without re-running the
+- Add a [follow latest message toggle](/docs/usage/#follow-latest-message) to
+  the session header. While active, the message list auto-scrolls to the
+  newest message as updates stream in; clicking a specific message or
+  scrolling up cancels the follow. The preference is persisted in
+  localStorage.
+- Honor the
+  [Normal and Focused transcript modes](/docs/usage/#focused-transcript-mode)
+  in the standalone HTML export. The exported file now ships with a Normal /
+  Focused radio toggle in the document header, so a recipient who only wants
+  the user-and-final view can flip into Focused mode without re-running the
   export.
-- Add **copy buttons to code blocks** in session messages,
-  matching the per-message copy action. The button appears
-  on hover/focus over the code block and copies the raw
-  code (no fences).
-- Import richer **Hermes** state-database metadata —
-  parent-continuation chains, titles, per-message token
-  usage, and inline cost — and classify Hermes compaction
-  handoffs as compact-boundary system messages. Hermes now
+- Add **copy buttons to code blocks** in session messages, matching the
+  per-message copy action. The button appears on hover/focus over the code
+  block and copies the raw code (no fences).
+- Import richer **Hermes** state-database metadata — parent-continuation chains,
+  titles, per-message token usage, and inline cost — and classify Hermes
+  compaction handoffs as compact-boundary system messages. Hermes now
   contributes to `agentsview usage` totals.
-- Normalize **Gemini** per-message token usage into the
-  same `input_tokens` / `output_tokens` /
-  `cache_creation_input_tokens` / `cache_read_input_tokens`
-  shape used by Claude and Codex, with Gemini thoughts
-  counted toward output tokens and cached prefix toward
-  cache reads. Gemini sessions now produce real cost rows
-  in `agentsview usage` instead of showing up only in the
+- Normalize **Gemini** per-message token usage into the same `input_tokens` /
+  `output_tokens` / `cache_creation_input_tokens` / `cache_read_input_tokens`
+  shape used by Claude and Codex, with Gemini thoughts counted toward output
+  tokens and cached prefix toward cache reads. Gemini sessions now produce
+  real cost rows in `agentsview usage` instead of showing up only in the
   models-used list.
 - Note Homebrew Cask in the README install section:
-  `brew install --cask agentsview` is the recommended
-  desktop-app install on macOS.
+  `brew install --cask agentsview` is the recommended desktop-app install on
+  macOS.
 - Rename the upstream repository to
   [`github.com/kenn-io/agentsview`](https://github.com/kenn-io/agentsview),
-  publish the container image at
-  `ghcr.io/kenn-io/agentsview`, and adopt the
-  `go.kenn.io/agentsview` vanity Go module path. All
-  references in the docs site have been updated to match.
+  publish the container image at `ghcr.io/kenn-io/agentsview`, and adopt the
+  `go.kenn.io/agentsview` vanity Go module path. All references in the docs
+  site have been updated to match.
 
 **Bug fixes**
 
-- Load the sidebar from a new skinny session-index endpoint
-  so large refreshes no longer trip a render storm against
-  the full session payload — the index returns lightweight
-  rows and the visible rows hydrate on demand.
-- Widen the server's CSP `connect-src` to allow `http:`,
-  `https:`, `ws:`, and `wss:` origins so the desktop app's
-  **Connect to Remote Server** action can reach external
-  AgentsView instances. Other CSP directives stay pinned
-  to `'self'`.
-- Skip slash-command first messages (`/login`, `/plan`,
-  `/clear`, …) when computing the sidebar preview text,
-  instead of the previous allowlist that only covered
-  `/clear` and `/effort`. The slash-prefix heuristic
-  matches any `/<word>` followed by end-of-string or
-  whitespace, so absolute file paths in user messages
-  still surface normally.
-- Fix a Windows desktop sidecar lock during in-place
-  updates — the bundled Go server is now stopped only
-  immediately before the Tauri updater swaps the binary,
-  so the download phase no longer races against the
-  running `agentsview.exe`.
-- Harden temporary-directory cleanup in tests against
-  open SQLite handles on Windows by forcing a GC and
-  retrying `RemoveAll` with exponential backoff. CI-only
-  change.
+- Load the sidebar from a new skinny session-index endpoint so large refreshes
+  no longer trip a render storm against the full session payload — the index
+  returns lightweight rows and the visible rows hydrate on demand.
+- Widen the server's CSP `connect-src` to allow `http:`, `https:`, `ws:`, and
+  `wss:` origins so the desktop app's **Connect to Remote Server** action can
+  reach external AgentsView instances. Other CSP directives stay pinned to
+  `'self'`.
+- Skip slash-command first messages (`/login`, `/plan`, `/clear`, …) when
+  computing the sidebar preview text, instead of the previous allowlist that
+  only covered `/clear` and `/effort`. The slash-prefix heuristic matches any
+  `/<word>` followed by end-of-string or whitespace, so absolute file paths in
+  user messages still surface normally.
+- Fix a Windows desktop sidecar lock during in-place updates — the bundled Go
+  server is now stopped only immediately before the Tauri updater swaps the
+  binary, so the download phase no longer races against the running
+  `agentsview.exe`.
+- Harden temporary-directory cleanup in tests against open SQLite handles on
+  Windows by forcing a GC and retrying `RemoveAll` with exponential backoff.
+  CI-only change.
 
 **Acknowledgements**
 
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for fixing a Windows desktop update sidecar lock, supporting configured insight agent binaries, importing Hermes state-database metadata and usage, the copy action on session code blocks, and the go.kenn.io vanity module path.
-- Thanks to [Trent Nelson](https://github.com/tpn) for clarifying insight generation in read-only mode and Normal/Focused transcript modes in HTML exports.
-- Thanks to [Matej Sychra](https://github.com/suculent) for Qwen Code agent support.
-- Thanks to [Muescha](https://github.com/muescha) for the Homebrew Cask install note in the README.
-- Thanks to [Bob N](https://github.com/danxtshake) for reading the current Kiro CLI SQLite session store.
-- Thanks to [Christopher Swingley](https://github.com/cswingle) for skipping any slash command when computing the session preview.
-- Thanks to [Evgenii Terekhov](https://github.com/nergal-perm) for normalizing Gemini token usage for cost tracking.
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for supporting Google Antigravity IDE and CLI sessions.
-- Thanks to [ArBing Xie](https://github.com/arbing) for QClaw agent support and WorkBuddy agent support.
-- Thanks to [lisiyuan656](https://github.com/lisiyuan656) for PostgreSQL curation metadata sync.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for fixing a
+  Windows desktop update sidecar lock, supporting configured insight agent
+  binaries, importing Hermes state-database metadata and usage, the copy
+  action on session code blocks, and the go.kenn.io vanity module path.
+- Thanks to [Trent Nelson](https://github.com/tpn) for clarifying insight
+  generation in read-only mode and Normal/Focused transcript modes in HTML
+  exports.
+- Thanks to [Matej Sychra](https://github.com/suculent) for Qwen Code agent
+  support.
+- Thanks to [Muescha](https://github.com/muescha) for the Homebrew Cask install
+  note in the README.
+- Thanks to [Bob N](https://github.com/danxtshake) for reading the current Kiro
+  CLI SQLite session store.
+- Thanks to [Christopher Swingley](https://github.com/cswingle) for skipping any
+  slash command when computing the session preview.
+- Thanks to [Evgenii Terekhov](https://github.com/nergal-perm) for normalizing
+  Gemini token usage for cost tracking.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for supporting Google
+  Antigravity IDE and CLI sessions.
+- Thanks to [ArBing Xie](https://github.com/arbing) for QClaw agent support and
+  WorkBuddy agent support.
+- Thanks to [lisiyuan656](https://github.com/lisiyuan656) for PostgreSQL
+  curation metadata sync.
 
----
+______________________________________________________________________
 
 ## 0.29.0
+
 <small>2026-05-10</small>
 
 **New features**
 
-- Add session support for [Piebald](https://piebald.ai), a
-  database-backed coding agent. AgentsView discovers Piebald's
-  `app.db` SQLite file under `~/.local/share/piebald/` (override
-  with `PIEBALD_DIR` or `piebald_dirs`), opens it read-only, and
-  parses each chat on demand into the standard
+- Add session support for [Piebald](https://piebald.ai), a database-backed
+  coding agent. AgentsView discovers Piebald's `app.db` SQLite file under
+  `~/.local/share/piebald/` (override with `PIEBALD_DIR` or `piebald_dirs`),
+  opens it read-only, and parses each chat on demand into the standard
   user/assistant/tool model. Reasoning parts are surfaced as
-  `[Thinking]…[/Thinking]` blocks, tool calls are mapped onto
-  AgentsView's taxonomy, and Piebald's `sub_agent_chat_id`
-  links parent tool calls to the spawned child chat so subagent
-  expansion works inline. Per-chat incremental sync only
-  re-parses rows whose `updated_at` changed.
+  `[Thinking]…[/Thinking]` blocks, tool calls are mapped onto AgentsView's
+  taxonomy, and Piebald's `sub_agent_chat_id` links parent tool calls to the
+  spawned child chat so subagent expansion works inline. Per-chat incremental
+  sync only re-parses rows whose `updated_at` changed.
 - Add user-configurable
   [worktree project mappings](/docs/configuration/#worktree-project-mappings).
-  AgentsView normally infers a session's project from its `cwd`,
-  which doesn't recognize custom worktree layouts like
-  `~/code/{project}.worktrees/feat/<branch>/` — those sessions
-  end up grouped under the branch name instead of the parent
-  repo. The new **Worktree Project Mappings** section in
-  Settings lets you register a path-prefix → project mapping
-  per machine, applied to new sessions as they sync and, via an
-  **Apply** button, retroactively to already-imported sessions.
-  Mappings live in a `worktree_project_mappings` SQLite table
-  scoped to the host machine, so mappings created on one machine
-  never leak into another's view of synced sessions.
+  AgentsView normally infers a session's project from its `cwd`, which doesn't
+  recognize custom worktree layouts like
+  `~/code/{project}.worktrees/feat/<branch>/` — those sessions end up grouped
+  under the branch name instead of the parent repo. The new **Worktree Project
+  Mappings** section in Settings lets you register a path-prefix → project
+  mapping per machine, applied to new sessions as they sync and, via an
+  **Apply** button, retroactively to already-imported sessions. Mappings live
+  in a `worktree_project_mappings` SQLite table scoped to the host machine, so
+  mappings created on one machine never leak into another's view of synced
+  sessions.
 
 **Improvements**
 
 - Add Piebald to the
   [supported-agents reference table](/docs/configuration/#session-discovery)
   in the README and to the docs.
-- Fix sync progress accounting for database-backed agents
-  (Piebald, OpenCode, Warp, Forge): the terminal `PhaseDone`
-  callback was overwriting the cumulative `MessagesIndexed`
-  count with the file-only total, so the post-sync log line
-  under-reported indexed messages.
-- Validate Piebald fork session IDs (`piebald:<chat>-<row>`).
-  Stale or typoed fork IDs that resolved to a real base chat
-  but not a real fork row previously returned mtimes and
-  succeeded silently; they now require an exact `Session.ID`
-  match in the parsed results.
-- Drop the hard-coded agent list from `agentsview --help`. The
-  list went stale every time a new agent was added; the
-  README's supported-agents table and the per-agent env vars
-  below it stay authoritative.
+- Fix sync progress accounting for database-backed agents (Piebald, OpenCode,
+  Warp, Forge): the terminal `PhaseDone` callback was overwriting the
+  cumulative `MessagesIndexed` count with the file-only total, so the
+  post-sync log line under-reported indexed messages.
+- Validate Piebald fork session IDs (`piebald:<chat>-<row>`). Stale or typoed
+  fork IDs that resolved to a real base chat but not a real fork row
+  previously returned mtimes and succeeded silently; they now require an exact
+  `Session.ID` match in the parsed results.
+- Drop the hard-coded agent list from `agentsview --help`. The list went stale
+  every time a new agent was added; the README's supported-agents table and
+  the per-agent env vars below it stay authoritative.
 - Update GitHub Actions, Go, and frontend dependencies.
 
 **Bug fixes**
 
-- Discover and import Codex sessions from
-  `~/.codex/archived_sessions/` in addition to
-  `~/.codex/sessions/`, supporting both the dated live-session
-  layout and the flat archived layout. Sessions are deduplicated
-  by canonical session ID, with live paths preferred when a
-  session exists in both locations.
-- Link Claude `Task` and `Agent` tool calls to their child
-  subagent sessions when result-side `toolUseResult.agentId` is
-  the only signal available (queue/progress mapping absent).
-  The parser also preserves sibling subagent tool calls when
-  Claude emits additive same-`message.id` assistant chunks, so
-  parallel subagents under one parent message all link inline.
-  Existing Claude archives need a full resync to pick up the
-  populated `subagent_session_id` on historical rows.
+- Discover and import Codex sessions from `~/.codex/archived_sessions/` in
+  addition to `~/.codex/sessions/`, supporting both the dated live-session
+  layout and the flat archived layout. Sessions are deduplicated by canonical
+  session ID, with live paths preferred when a session exists in both
+  locations.
+- Link Claude `Task` and `Agent` tool calls to their child subagent sessions
+  when result-side `toolUseResult.agentId` is the only signal available
+  (queue/progress mapping absent). The parser also preserves sibling subagent
+  tool calls when Claude emits additive same-`message.id` assistant chunks, so
+  parallel subagents under one parent message all link inline. Existing Claude
+  archives need a full resync to pick up the populated `subagent_session_id`
+  on historical rows.
 
 **Acknowledgements**
 
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for documenting Forge in the supported-agents table.
-- Thanks to [Kevin Roberts](https://github.com/basekevin) for adding Piebald support.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for importing archived Codex sessions and adding configurable worktree project mappings.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for documenting Forge
+  in the supported-agents table.
+- Thanks to [Kevin Roberts](https://github.com/basekevin) for adding Piebald
+  support.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for
+  importing archived Codex sessions and adding configurable worktree project
+  mappings.
 
----
+______________________________________________________________________
 
 ## 0.28.0
+
 <small>2026-05-06</small>
 
 **New features**
 
-- Add session support for [Forge](https://forgecode.dev), a
-  database-backed coding agent. AgentsView discovers
-  `.forge.db` SQLite files under `~/.forge` (override with
-  `FORGE_DIR` or `forge_dirs`), opens them read-only, and
-  parses each conversation on demand into the standard
-  user/assistant/tool model. Reasoning traces are surfaced as
-  `[Thinking]…[/Thinking]` blocks, and Forge's nine
-  agent-specific tool names (`fs_search`, `patch`,
-  `multi_patch`, `undo`, `remove`, `fetch`, `todo_write`,
-  `todo_read`, `parallel`) are mapped onto AgentsView's
-  taxonomy. Per-conversation incremental sync only re-parses
+- Add session support for [Forge](https://forgecode.dev), a database-backed
+  coding agent. AgentsView discovers `.forge.db` SQLite files under `~/.forge`
+  (override with `FORGE_DIR` or `forge_dirs`), opens them read-only, and
+  parses each conversation on demand into the standard user/assistant/tool
+  model. Reasoning traces are surfaced as `[Thinking]…[/Thinking]` blocks, and
+  Forge's nine agent-specific tool names (`fs_search`, `patch`, `multi_patch`,
+  `undo`, `remove`, `fetch`, `todo_write`, `todo_read`, `parallel`) are mapped
+  onto AgentsView's taxonomy. Per-conversation incremental sync only re-parses
   rows whose `updated_at` changed.
 
 **Improvements**
 
 - Preview common tool inputs in the collapsed
-  [tool block](/docs/usage/#tool-blocks) header so the most
-  meaningful field shows without expanding. `TodoWrite`
-  surfaces the in-progress todo (or last todo) with a `→`
-  prefix; `TaskCreate` shows the subject; `TaskUpdate` shows
-  `#<id> · <status> · <subject>`; `Skill` shows the skill
-  name; `ToolSearch` shows the first line of the query; and
-  `Task`/`Agent`/subagent calls show the description (falling
-  back to the prompt). These previews take precedence over
-  the first line of `content`, which for these tools is a
-  generic header that hides the useful information.
-- Link Codex `spawn_agent` tool calls to the spawned
-  subagent's session, so the inline subagent expander in the
-  message viewer works the same way for Codex sessions as it
-  already did for Claude `Task` calls.
-- Make git outcome metrics opt-in for
-  [`agentsview stats`](/docs/stats/). Outcome aggregation walks
-  every session's working directory and shells out to `git`,
-  which is slow on large repos and brittle when the cwd has
-  moved or the repo is unavailable. Add
-  `--include-git-outcomes` to opt into local commit, LOC, and
-  files-changed totals, and `--include-github-outcomes` to
-  additionally include GitHub PR counts via `gh` (this
-  implies `--include-git-outcomes`). The `GHToken` is only
-  resolved when GitHub outcomes are requested.
+  [tool block](/docs/usage/#tool-blocks) header so the most meaningful field
+  shows without expanding. `TodoWrite` surfaces the in-progress todo (or last
+  todo) with a `→` prefix; `TaskCreate` shows the subject; `TaskUpdate` shows
+  `#<id> · <status> · <subject>`; `Skill` shows the skill name; `ToolSearch`
+  shows the first line of the query; and `Task`/`Agent`/subagent calls show
+  the description (falling back to the prompt). These previews take precedence
+  over the first line of `content`, which for these tools is a generic header
+  that hides the useful information.
+- Link Codex `spawn_agent` tool calls to the spawned subagent's session, so the
+  inline subagent expander in the message viewer works the same way for Codex
+  sessions as it already did for Claude `Task` calls.
+- Make git outcome metrics opt-in for [`agentsview stats`](/docs/stats/).
+  Outcome aggregation walks every session's working directory and shells out
+  to `git`, which is slow on large repos and brittle when the cwd has moved or
+  the repo is unavailable. Add `--include-git-outcomes` to opt into local
+  commit, LOC, and files-changed totals, and `--include-github-outcomes` to
+  additionally include GitHub PR counts via `gh` (this implies
+  `--include-git-outcomes`). The `GHToken` is only resolved when GitHub
+  outcomes are requested.
 
 **Bug fixes**
 
-- Link Codex App subagent spawn events to the corresponding
-  child session. The Codex parser now consumes both
-  `spawn_agent` outputs and
-  `collab_agent_spawn_end.new_thread_id` events, recognizes
-  `wait_agent` calls with `targets`, and accepts subagent
-  notifications that identify children via `agent_path`
-  alongside the legacy `agent_id`. Without this, related
-  Codex App subagent sessions did not resolve in the
-  transcript or in the sidebar's child list.
+- Link Codex App subagent spawn events to the corresponding child session. The
+  Codex parser now consumes both `spawn_agent` outputs and
+  `collab_agent_spawn_end.new_thread_id` events, recognizes `wait_agent` calls
+  with `targets`, and accepts subagent notifications that identify children
+  via `agent_path` alongside the legacy `agent_id`. Without this, related
+  Codex App subagent sessions did not resolve in the transcript or in the
+  sidebar's child list.
 
 **Acknowledgements**
 
-- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for adding Forge agent support.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for linking Codex spawn calls to subagent sessions and linking Codex app subagents.
-- Thanks to [Mike Baik](https://github.com/wbaik) for linking Claude subagent tool calls.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for adding Forge agent
+  support.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for linking
+  Codex spawn calls to subagent sessions and linking Codex app subagents.
+- Thanks to [Mike Baik](https://github.com/wbaik) for linking Claude subagent
+  tool calls.
 
----
+______________________________________________________________________
 
 ## 0.27.0
+
 <small>2026-05-04</small>
 
 **New features**
 
 - Publish official Docker images. The
   [`ghcr.io/kenn-io/agentsview`](https://github.com/kenn-io/agentsview/pkgs/container/agentsview)
-  multi-arch image (linux/amd64, linux/arm64) is built on tagged
-  releases and pushes to main, and the repo ships a `Dockerfile`,
-  `docker-entrypoint.sh`, and a `docker-compose.prod.yaml` example.
-  The same image runs both `agentsview serve` (default) and
-  `agentsview pg serve` (set `PG_SERVE=1`). See the
-  [Quick Start](/docs/quickstart/#docker) for usage.
-- Add a [session status indicator](/docs/usage/#session-status-indicator)
-  that classifies each session by recency and termination state and
-  surfaces six visual states (working, waiting, idle, stale, unclean,
-  quiet) on the sidebar dot and the dashboard's Top Sessions table.
-  Backed by a new `termination_status` column on the `sessions` table
-  populated by the Claude Code and Codex parsers from per-message
-  stop reasons. Sessions can now be filtered by status from the
-  [filter dropdown](/docs/usage/#session-filters) or via the new
-  `?termination=` URL parameter.
-- Use Copilot CLI's `workspace.yaml` `name` field as the session
-  title when present, falling back to the first user message
-  otherwise. Copilot itself writes a short generated or user-set
-  name to that file, so sessions now show meaningful titles like
-  *"Fix login authentication bug"* instead of the verbatim first
-  prompt. Existing AgentsView display-name overrides still win.
+  multi-arch image (linux/amd64, linux/arm64) is built on tagged releases
+  and pushes to main, and the repo ships a `Dockerfile`,
+  `docker-entrypoint.sh`, and a `docker-compose.prod.yaml` example. The same
+  image runs both `agentsview serve` (default) and `agentsview pg serve` (set
+  `PG_SERVE=1`). See the [Quick Start](/docs/quickstart/#docker) for usage.
+- Add a [session status indicator](/docs/usage/#session-status-indicator) that
+  classifies each session by recency and termination state and surfaces six
+  visual states (working, waiting, idle, stale, unclean, quiet) on the sidebar
+  dot and the dashboard's Top Sessions table. Backed by a new
+  `termination_status` column on the `sessions` table populated by the Claude
+  Code and Codex parsers from per-message stop reasons. Sessions can now be
+  filtered by status from the [filter dropdown](/docs/usage/#session-filters)
+  or via the new `?termination=` URL parameter.
+- Use Copilot CLI's `workspace.yaml` `name` field as the session title when
+  present, falling back to the first user message otherwise. Copilot itself
+  writes a short generated or user-set name to that file, so sessions now show
+  meaningful titles like *"Fix login authentication bug"* instead of the
+  verbatim first prompt. Existing AgentsView display-name overrides still win.
 
 **Improvements**
 
-- Degrade large watch trees instead of failing server startup. When
-  the recursive file watcher hits its 8192-directory budget or the
-  OS inotify/file-descriptor limit (`EMFILE`/`ENOSPC`), the affected
-  root falls back to the existing 15-minute periodic sync plus a new
-  2-minute poll loop, and the server logs which roots are watched
-  vs. polled. The HTTP listener now binds before the watcher is
-  registered, so users hitting these limits no longer see startup
-  abort with `socket: too many open files`.
-- Sessions, Usage, and the Analytics dashboard now share a single
-  filter store: machine, agent, project, min user-message, and
-  one-shot/automated toggles applied in the sidebar carry across to
-  the Usage page header and the dashboard panels. The Usage page
-  reuses the same `SessionFilterControl` widget with searchable
-  agent and machine multi-selects (the sidebar's **Status** pills
-  are sidebar- and dashboard-only).
-- Fix the README `agentsview stats` reference (the README previously
-  showed the non-existent `agentsview session stats` form).
+- Degrade large watch trees instead of failing server startup. When the
+  recursive file watcher hits its 8192-directory budget or the OS
+  inotify/file-descriptor limit (`EMFILE`/`ENOSPC`), the affected root falls
+  back to the existing 15-minute periodic sync plus a new 2-minute poll loop,
+  and the server logs which roots are watched vs. polled. The HTTP listener
+  now binds before the watcher is registered, so users hitting these limits no
+  longer see startup abort with `socket: too many open files`.
+- Sessions, Usage, and the Analytics dashboard now share a single filter store:
+  machine, agent, project, min user-message, and one-shot/automated toggles
+  applied in the sidebar carry across to the Usage page header and the
+  dashboard panels. The Usage page reuses the same `SessionFilterControl`
+  widget with searchable agent and machine multi-selects (the sidebar's
+  **Status** pills are sidebar- and dashboard-only).
+- Fix the README `agentsview stats` reference (the README previously showed the
+  non-existent `agentsview session stats` form).
 
 **Bug fixes**
 
-- Return `409 Conflict` when uploading a session that is already
-  excluded by config or sitting in the trash, instead of silently
-  dropping the upload.
-- Allow compaction-boundary summary cards to expand in the message
-  viewer. Long or multi-line summaries get a "Show full summary"
-  toggle; short summaries stay inline.
-- Read the `model` and `usage` fields from OpenClaw assistant turns
-  so `agentsview usage daily --agent openclaw` reports actual cost
-  and token totals instead of `$0.00`.
+- Return `409 Conflict` when uploading a session that is already excluded by
+  config or sitting in the trash, instead of silently dropping the upload.
+- Allow compaction-boundary summary cards to expand in the message viewer. Long
+  or multi-line summaries get a "Show full summary" toggle; short summaries
+  stay inline.
+- Read the `model` and `usage` fields from OpenClaw assistant turns so
+  `agentsview usage daily --agent openclaw` reports actual cost and token
+  totals instead of `$0.00`.
 - Synthesize `Message.ID` from the message ordinal in
   [`pg serve`](/docs/pg-sync/) responses. PG's `messages` table has a
-  composite primary key (`session_id`, `ordinal`) and no `id`
-  column, which previously left every row with `id = 0` and broke
-  Svelte's keyed `{#each}` rendering in the message viewer.
+  composite primary key (`session_id`, `ordinal`) and no `id` column, which
+  previously left every row with `id = 0` and broke Svelte's keyed `{#each}`
+  rendering in the message viewer.
 
 **Acknowledgements**
 
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for fixing session and usage filter behavior and tests covering Codex assistant blockquotes.
-- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for using the Copilot workspace.yaml name as the session title.
-- Thanks to [zerone0x](https://github.com/zerone0x) for fixing the README stats command reference, allowing compaction-boundary summaries to expand, and returning 409 for excluded or trashed uploads.
-- Thanks to [juno02139](https://github.com/juno02139) for extracting OpenClaw per-message token usage and model.
-- Thanks to [Phillip Cloud](https://github.com/cpcloud) for adding session termination status detection and StatusDot UI.
-- Thanks to [Aaron Florey](https://github.com/aaronflorey) for the Docker deployment workflow.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for fixing
+  session and usage filter behavior and tests covering Codex assistant
+  blockquotes.
+- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for using the
+  Copilot workspace.yaml name as the session title.
+- Thanks to [zerone0x](https://github.com/zerone0x) for fixing the README stats
+  command reference, allowing compaction-boundary summaries to expand, and
+  returning 409 for excluded or trashed uploads.
+- Thanks to [juno02139](https://github.com/juno02139) for extracting OpenClaw
+  per-message token usage and model.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for adding session
+  termination status detection and StatusDot UI.
+- Thanks to [Aaron Florey](https://github.com/aaronflorey) for the Docker
+  deployment workflow.
 
----
+______________________________________________________________________
 
 ## 0.26.1
+
 <small>2026-04-30</small>
 
 **Improvements**
 
-- Refresh the filter controls and active-filter displays on the
-  Sessions, Usage, and Analytics views for clearer state and
-  more consistent behavior across the three pages.
-- Add launchd support for running the PostgreSQL helper service
-  on macOS.
+- Refresh the filter controls and active-filter displays on the Sessions, Usage,
+  and Analytics views for clearer state and more consistent behavior across
+  the three pages.
+- Add launchd support for running the PostgreSQL helper service on macOS.
 - Update frontend and Go dependencies.
 
 **Bug fixes**
@@ -2298,224 +2360,247 @@ description: Release history for AgentsView
 - Fix session filter behavior in the sidebar.
 - Fix Usage page filter behavior and the selected-filter state.
 - Keep timing API response arrays non-null.
-- Disable the WebKit DMABUF renderer on Linux desktop builds to
-  avoid rendering issues.
+- Disable the WebKit DMABUF renderer on Linux desktop builds to avoid rendering
+  issues.
 
----
+______________________________________________________________________
 
 ## 0.26.0
+
 <small>2026-04-29</small>
 
 **New features**
 
-- Add a [Trends page](/docs/usage/#trends) for ad-hoc term-frequency line
-  charts over your session history. Plot up to 12 terms — each with
-  optional pipe-separated variants like `cat|cats` — at day, week, or
-  month granularity, and optionally normalize counts by message
-  volume. Backed by both SQLite and PostgreSQL, so the page works
-  under local `agentsview serve` and shared [`pg serve`](/docs/pg-sync/)
-  deployments.
+- Add a [Trends page](/docs/usage/#trends) for ad-hoc term-frequency line charts
+  over your session history. Plot up to 12 terms — each with optional
+  pipe-separated variants like `cat|cats` — at day, week, or month
+  granularity, and optionally normalize counts by message volume. Backed by
+  both SQLite and PostgreSQL, so the page works under local `agentsview serve`
+  and shared [`pg serve`](/docs/pg-sync/) deployments.
 - Replace the right-column activity minimap with a richer
-  [Session Vital Signs](/docs/usage/#session-vital-signs) panel covering
-  total wall-clock, slowest call, per-category time spent, a
-  per-category timeline, and a chronological calls list with parallel
-  groups bracketed and sub-agents expandable inline. Each tool block
-  in the conversation now also shows a duration badge, and each
-  assistant message shows a per-turn summary line.
-- Make the default date range on the Usage and Analytics dashboards
-  *rolling* — pages left open across midnight roll the window forward
-  at the next refresh tick, sync event, or manual refresh, instead of
-  staying anchored to the day they loaded. Manual date edits or
-  `?from=…&to=…` URL parameters pin the window; preset buttons (`7d`,
-  `30d`, `90d`, `1y`) return to rolling mode.
+  [Session Vital Signs](/docs/usage/#session-vital-signs) panel covering total
+  wall-clock, slowest call, per-category time spent, a per-category timeline,
+  and a chronological calls list with parallel groups bracketed and sub-agents
+  expandable inline. Each tool block in the conversation now also shows a
+  duration badge, and each assistant message shows a per-turn summary line.
+- Make the default date range on the Usage and Analytics dashboards *rolling* —
+  pages left open across midnight roll the window forward at the next refresh
+  tick, sync event, or manual refresh, instead of staying anchored to the day
+  they loaded. Manual date edits or `?from=…&to=…` URL parameters pin the
+  window; preset buttons (`7d`, `30d`, `90d`, `1y`) return to rolling mode.
 
 **Improvements**
 
-- Scale call duration bars in the Vital Signs Calls list relative to
-  the longest call in scope rather than total session wall-clock, so
-  call-vs-call comparison stays legible in long sessions.
-- Lower the progressive-load threshold from 20,000 to 3,000 messages
-  so large sessions render the message viewer faster — older pages
-  lazy-load on scroll instead of all loading on session open.
-- Reuse the shared `DateRangeSelector` component on the Usage page
-  for consistent presets and behavior between Analytics and Usage.
-- Faster full resync: batched SQLite writes with per-session
-  savepoints, multi-row inserts for messages and tool calls, and a
-  single FTS rebuild on the temp database before the atomic swap. On
-  a 26.7k-session workload, full-resync wall-clock improved from
-  about 1m17s to about 34s.
-- Expand [Gemini ingestion](/docs/configuration/#session-discovery) to
-  discover and parse the newer streamed `session-*.jsonl` format
-  alongside the legacy `.json` Gemini session files.
+- Scale call duration bars in the Vital Signs Calls list relative to the longest
+  call in scope rather than total session wall-clock, so call-vs-call
+  comparison stays legible in long sessions.
+- Lower the progressive-load threshold from 20,000 to 3,000 messages so large
+  sessions render the message viewer faster — older pages lazy-load on scroll
+  instead of all loading on session open.
+- Reuse the shared `DateRangeSelector` component on the Usage page for
+  consistent presets and behavior between Analytics and Usage.
+- Faster full resync: batched SQLite writes with per-session savepoints,
+  multi-row inserts for messages and tool calls, and a single FTS rebuild on
+  the temp database before the atomic swap. On a 26.7k-session workload,
+  full-resync wall-clock improved from about 1m17s to about 34s.
+- Expand [Gemini ingestion](/docs/configuration/#session-discovery) to discover
+  and parse the newer streamed `session-*.jsonl` format alongside the legacy
+  `.json` Gemini session files.
 - Render Claude Code `!cmd` bash shortcut wrappers (`<bash-input>`,
-  `<bash-stdout>`, `<bash-stderr>`) as code blocks in message bodies
-  and as inline `<code>` in sidebar previews and breadcrumbs, instead
-  of leaking the literal pseudo-HTML into the UI.
+  `<bash-stdout>`, `<bash-stderr>`) as code blocks in message bodies and as
+  inline `<code>` in sidebar previews and breadcrumbs, instead of leaking the
+  literal pseudo-HTML into the UI.
 
 **Bug fixes**
 
-- Recognize managed worktree project paths — Middleman GitHub
-  worktrees and Codex App's `~/.codex/worktrees/<id>/<repo>` layout —
-  as the owning repo, so sessions land under the right project
-  instead of the worktree id.
-- Sync OpenCode SQLite sessions when `opencode.db` and the per-file
-  `storage/` layout coexist in the same root. SQLite virtual paths
-  are used as a fallback for source lookup and single-session sync
-  in those hybrid roots.
-- Surface Claude Code `queued_command` attachments — the user
-  prompts submitted while a tool call is still running — as regular
-  user messages in the transcript instead of dropping them. The
-  embedded `dataVersion` bumps from 19 to 20 so existing databases
-  re-parse on next startup and recover any previously missed
-  mid-flight messages.
+- Recognize managed worktree project paths — Middleman GitHub worktrees and
+  Codex App's `~/.codex/worktrees/<id>/<repo>` layout — as the owning repo, so
+  sessions land under the right project instead of the worktree id.
+- Sync OpenCode SQLite sessions when `opencode.db` and the per-file `storage/`
+  layout coexist in the same root. SQLite virtual paths are used as a fallback
+  for source lookup and single-session sync in those hybrid roots.
+- Surface Claude Code `queued_command` attachments — the user prompts submitted
+  while a tool call is still running — as regular user messages in the
+  transcript instead of dropping them. The embedded `dataVersion` bumps from
+  19 to 20 so existing databases re-parse on next startup and recover any
+  previously missed mid-flight messages.
 - Run remote [SSH sync](/docs/commands/#agentsview-sync) commands through
-  `sh -c` so command parsing is independent of the remote login
-  shell and embedded single quotes are escaped safely.
-- Atomically swap the binary during self-update by staging the new
-  binary at `dstPath + ".new"` (with the executable bit already set)
-  and renaming it into place, so concurrent `agentsview` invocations
-  during an update no longer hit a partially written or
-  non-executable file.
+  `sh -c` so command parsing is independent of the remote login shell and
+  embedded single quotes are escaped safely.
+- Atomically swap the binary during self-update by staging the new binary at
+  `dstPath + ".new"` (with the executable bit already set) and renaming it
+  into place, so concurrent `agentsview` invocations during an update no
+  longer hit a partially written or non-executable file.
 
 **Acknowledgements**
 
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for reusing the shared date-range selector on the Usage page and recognizing managed worktree project paths.
-- Thanks to [Phillip Cloud](https://github.com/cpcloud) for the rolling default date range for the Usage and Analytics dashboards, gating the frontend with svelte-check and vitest, the session-duration UX, and rendering Claude Code bash shortcut wrappers as code blocks.
-- Thanks to [Aaron Florey](https://github.com/aaronflorey) for syncing OpenCode SQLite sessions in hybrid roots and running remote SSH sync commands through a POSIX shell.
-- Thanks to [Christopher Swingley](https://github.com/cswingle) for the Gemini JSONL import fix.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for reusing
+  the shared date-range selector on the Usage page and recognizing managed
+  worktree project paths.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for the rolling default
+  date range for the Usage and Analytics dashboards, gating the frontend with
+  svelte-check and vitest, the session-duration UX, and rendering Claude Code
+  bash shortcut wrappers as code blocks.
+- Thanks to [Aaron Florey](https://github.com/aaronflorey) for syncing OpenCode
+  SQLite sessions in hybrid roots and running remote SSH sync commands through
+  a POSIX shell.
+- Thanks to [Christopher Swingley](https://github.com/cswingle) for the Gemini
+  JSONL import fix.
 
----
+______________________________________________________________________
 
 ## 0.25.0
+
 <small>2026-04-25</small>
 
 **Improvements**
 
 - Use `is_automated` consistently across [`agentsview stats`](/docs/stats/)
-  totals, archetypes, distributions, and agent portfolio metrics, so
-  the stats report uses the stored automation classification instead
-  of mixing in older user-message-count heuristics.
-- Rename the data directory environment variable to
-  `AGENTSVIEW_DATA_DIR`. The legacy `AGENT_VIEWER_DATA_DIR` name is
-  still accepted as a fallback when the canonical variable is unset.
-- Build and test against Go 1.26. Source builds now require Go
-  1.26+ with CGO.
+  totals, archetypes, distributions, and agent portfolio metrics, so the stats
+  report uses the stored automation classification instead of mixing in older
+  user-message-count heuristics.
+- Rename the data directory environment variable to `AGENTSVIEW_DATA_DIR`. The
+  legacy `AGENT_VIEWER_DATA_DIR` name is still accepted as a fallback when the
+  canonical variable is unset.
+- Build and test against Go 1.26. Source builds now require Go 1.26+ with CGO.
 
 **Bug fixes**
 
-- Filter synthetic Copilot skill messages from parsed conversations,
-  so injected skill context no longer affects stored transcripts,
-  first messages, or user-message counts.
+- Filter synthetic Copilot skill messages from parsed conversations, so injected
+  skill context no longer affects stored transcripts, first messages, or
+  user-message counts.
 
 **Acknowledgements**
 
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for NilAway lint checks and updating the build to Go 1.26 and fixing an arm64 desktop test flake.
-- Thanks to [Tim O'Guin](https://github.com/timoguin) for filtering synthetic Copilot skill messages.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for NilAway
+  lint checks and updating the build to Go 1.26 and fixing an arm64 desktop
+  test flake.
+- Thanks to [Tim O'Guin](https://github.com/timoguin) for filtering synthetic
+  Copilot skill messages.
 
----
+______________________________________________________________________
 
 ## 0.24.0
+
 <small>2026-04-23</small>
 
 **New features**
 
-- Add OpenCode storage-backed session support. AgentsView now
-  auto-detects when an OpenCode root uses the per-file `storage/`
-  layout (`storage/session`, `storage/message`, `storage/part`)
-  and parses the JSON files directly. The legacy `opencode.db`
-  SQLite backend is still read transparently when that's what's
-  present — see [Session Discovery](/docs/configuration/#session-discovery).
-- Add [custom model pricing](/docs/token-usage/#custom-model-pricing)
-  via `[custom_model_pricing.<model>]` tables in
-  `~/.agentsview/config.toml`, for models not in the LiteLLM
-  catalog or when you want to override the catalog's rates.
-- Add configurable [automation patterns](/docs/configuration/#automated-session-detection)
-  via `[automated] prefixes`, `substrings`, and `exact_matches` in
-  `~/.agentsview/config.toml`, so single-turn sessions with
-  first-message patterns unique to your own automation get filtered
-  from session lists and analytics alongside the built-in roborev
-  patterns.
+- Add OpenCode storage-backed session support. AgentsView now auto-detects when
+  an OpenCode root uses the per-file `storage/` layout (`storage/session`,
+  `storage/message`, `storage/part`) and parses the JSON files directly. The
+  legacy `opencode.db` SQLite backend is still read transparently when that's
+  what's present — see
+  [Session Discovery](/docs/configuration/#session-discovery).
+- Add [custom model pricing](/docs/token-usage/#custom-model-pricing) via
+  `[custom_model_pricing.<model>]` tables in `~/.agentsview/config.toml`, for
+  models not in the LiteLLM catalog or when you want to override the catalog's
+  rates.
+- Add configurable
+  [automation patterns](/docs/configuration/#automated-session-detection) via
+  `[automated] prefixes`, `substrings`, and `exact_matches` in
+  `~/.agentsview/config.toml`, so single-turn sessions with first-message
+  patterns unique to your own automation get filtered from session lists and
+  analytics alongside the built-in roborev patterns.
 
 **Improvements**
 
-- Broaden built-in automated-session detection to cover Claude
-  Code conversation-title generation, warmup pings, roborev
-  review combiner prompts, and AgentsView's own changelog
-  generator.
-- Refresh the `is_automated` classification at startup, using a
-  classifier hash that covers built-in patterns and configured
-  `[automated]` patterns, so edits to automation rules and rows
-  imported from other archives get re-labeled without a manual
-  resync.
-- Improve Claude first-message selection in the sidebar by
-  skipping leading `/clear` and `/effort` command envelopes so
-  the session preview shows the next real user message instead.
+- Broaden built-in automated-session detection to cover Claude Code
+  conversation-title generation, warmup pings, roborev review combiner
+  prompts, and AgentsView's own changelog generator.
+- Refresh the `is_automated` classification at startup, using a classifier hash
+  that covers built-in patterns and configured `[automated]` patterns, so
+  edits to automation rules and rows imported from other archives get
+  re-labeled without a manual resync.
+- Improve Claude first-message selection in the sidebar by skipping leading
+  `/clear` and `/effort` command envelopes so the session preview shows the
+  next real user message instead.
 
 **Bug fixes**
 
-- Narrow OpenCode's storage-mode file-watch root to the `storage/`
-  subtree, reducing inotify pressure and spurious watch events on
-  binaries, logs, and caches. SQLite mode continues to watch the
-  `opencode.db` parent.
-- Stop orphaned subagent/fork rows from surfacing as top-level
-  groups in the sidebar when their parent session has been
-  filtered or rotated off disk.
-- Fix Codex parser handling so `codex exec` sessions interrupted
-  mid-run (which emit a synthetic `<turn_aborted>` user message)
-  are classified and counted correctly.
+- Narrow OpenCode's storage-mode file-watch root to the `storage/` subtree,
+  reducing inotify pressure and spurious watch events on binaries, logs, and
+  caches. SQLite mode continues to watch the `opencode.db` parent.
+- Stop orphaned subagent/fork rows from surfacing as top-level groups in the
+  sidebar when their parent session has been filtered or rotated off disk.
+- Fix Codex parser handling so `codex exec` sessions interrupted mid-run (which
+  emit a synthetic `<turn_aborted>` user message) are classified and counted
+  correctly.
 
 **Acknowledgements**
 
-- Thanks to [Eran Sandler](https://github.com/erans) for adding OpenCode storage-backed session support.
-- Thanks to [Antoine](https://github.com/anth2o) for custom model pricing via config.
+- Thanks to [Eran Sandler](https://github.com/erans) for adding OpenCode
+  storage-backed session support.
+- Thanks to [Antoine](https://github.com/anth2o) for custom model pricing via
+  config.
 
----
+______________________________________________________________________
 
 ## 0.23.5
+
 <small>2026-04-20</small>
 
 **Improvements**
 
-- Coalesce rapid dashboard update events to cap refetch frequency and keep the UI smoother under heavy activity.
+- Coalesce rapid dashboard update events to cap refetch frequency and keep the
+  UI smoother under heavy activity.
 
----
+______________________________________________________________________
 
 ## 0.23.1
+
 <small>2026-04-19</small>
 
 **Bug fixes**
 
-- Usage reporting excludes cached Codex tokens from `input_tokens`, making token totals more accurate.
+- Usage reporting excludes cached Codex tokens from `input_tokens`, making token
+  totals more accurate.
 
----
+______________________________________________________________________
 
 ## 0.23.0
+
 <small>2026-04-19</small>
 
 **New features**
 
-- Add live dashboard refresh via Server-Sent Events so the Sessions and Usage views update without a full page reload when new sync data lands.
-- Add [session intelligence](/docs/session-intelligence/) with health signals, outcome classification, score/grade badges, a per-session signal panel, and aggregated dashboard health analytics.
-- Add the [`agentsview session`](/docs/session-api/) CLI as a programmatic surface for listing, inspecting, exporting, syncing, and watching session data.
-- Add markdown export for sessions via `/api/v1/sessions/{id}/md`, including optional child-session depth controls.
-- Add SSH remote sync to [`agentsview sync`](/docs/commands/#agentsview-sync) so a local archive can pull session data from a remote machine over SSH.
-- Add PostgreSQL-backed usage reporting so the Usage dashboard and related endpoints work under [`agentsview pg serve`](/docs/pg-sync/).
-- Add [`agentsview stats`](/docs/stats/), an experimental window-scoped reporter for session, git, and outcome activity across the local archive.
+- Add live dashboard refresh via Server-Sent Events so the Sessions and Usage
+  views update without a full page reload when new sync data lands.
+- Add [session intelligence](/docs/session-intelligence/) with health signals,
+  outcome classification, score/grade badges, a per-session signal panel, and
+  aggregated dashboard health analytics.
+- Add the [`agentsview session`](/docs/session-api/) CLI as a programmatic
+  surface for listing, inspecting, exporting, syncing, and watching session
+  data.
+- Add markdown export for sessions via `/api/v1/sessions/{id}/md`, including
+  optional child-session depth controls.
+- Add SSH remote sync to [`agentsview sync`](/docs/commands/#agentsview-sync) so
+  a local archive can pull session data from a remote machine over SSH.
+- Add PostgreSQL-backed usage reporting so the Usage dashboard and related
+  endpoints work under [`agentsview pg serve`](/docs/pg-sync/).
+- Add [`agentsview stats`](/docs/stats/), an experimental window-scoped reporter
+  for session, git, and outcome activity across the local archive.
 
 **Improvements**
 
-- Require the explicit `serve` subcommand to start the server; plain `agentsview` now shows help.
+- Require the explicit `serve` subcommand to start the server; plain
+  `agentsview` now shows help.
 - Show session names in the Usage page's Top Sessions by Cost table.
 - Preserve active filters when switching between the Sessions and Usage tabs.
-- Link the Usage page's `Project | Model | Agent` group-by selectors so the chart and attribution panel stay in sync.
-- Make incremental parsing more reliable by validating files with inode and device tracking in addition to size and mtime.
+- Link the Usage page's `Project | Model | Agent` group-by selectors so the
+  chart and attribution panel stay in sync.
+- Make incremental parsing more reliable by validating files with inode and
+  device tracking in addition to size and mtime.
 - Rewrite the project README as a clearer user-facing guide.
 
 **Bug fixes**
 
-- Surface the underlying login-shell probe failure reason for arm64 desktop flake cases instead of hiding the root cause.
-- Only self-heal the frontend events store on transient failures, avoiding permanent retry loops against unsupported event streams.
-- Accept raw session IDs in `agentsview token-use` in addition to canonical stored IDs.
+- Surface the underlying login-shell probe failure reason for arm64 desktop
+  flake cases instead of hiding the root cause.
+- Only self-heal the frontend events store on transient failures, avoiding
+  permanent retry loops against unsupported event streams.
+- Accept raw session IDs in `agentsview token-use` in addition to canonical
+  stored IDs.
 - Resolve ephemeral `serve` port handling correctly.
 - Parse Claude Code CLI JSON array output correctly in insight generation.
 - Recognize the `"helpful assistant"` prefix as an automated session.
@@ -2523,198 +2608,318 @@ description: Release history for AgentsView
 
 **Acknowledgements**
 
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for linking usage group-by selectors, migrating command tree to Cobra, adding markdown session export, resolving ephemeral serve port, showing session name in Top Sessions by Cost, and preserving filters when switching between the Sessions and Usage tabs.
-- Thanks to [Jesse Robbins](https://github.com/jesserobbins) for correctly parsing Claude Code CLI JSON array output in insight generation.
-- Thanks to [Trent Nelson](https://github.com/tpn) for PostgreSQL-backed usage reporting.
-- Thanks to [Phillip Cloud](https://github.com/cpcloud) for live dashboard refresh via Server-Sent Events and self-healing the frontend events store only on transient failures.
-- Thanks to [AO](https://github.com/andrewwowens) for inode/device tracking to validate incremental parses.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for linking
+  usage group-by selectors, migrating command tree to Cobra, adding markdown
+  session export, resolving ephemeral serve port, showing session name in Top
+  Sessions by Cost, and preserving filters when switching between the Sessions
+  and Usage tabs.
+- Thanks to [Jesse Robbins](https://github.com/jesserobbins) for correctly
+  parsing Claude Code CLI JSON array output in insight generation.
+- Thanks to [Trent Nelson](https://github.com/tpn) for PostgreSQL-backed usage
+  reporting.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for live dashboard
+  refresh via Server-Sent Events and self-healing the frontend events store
+  only on transient failures.
+- Thanks to [AO](https://github.com/andrewwowens) for inode/device tracking to
+  validate incremental parses.
 
----
+______________________________________________________________________
 
 ## 0.22.2
+
 <small>2026-04-13</small>
 
 **Bug fixes**
 
-- Correct fallback pricing for Claude Opus 4.6 so usage cost estimates use the proper `$5` input and `$25` output rates.
+- Correct fallback pricing for Claude Opus 4.6 so usage cost estimates use the
+  proper `$5` input and `$25` output rates.
 
----
+______________________________________________________________________
 
 ## 0.22.1
+
 <small>2026-04-13</small>
 
 **Bug fixes**
 
-- Keep Codex model detection consistent during incremental syncs so usage reporting stays accurate.
+- Keep Codex model detection consistent during incremental syncs so usage
+  reporting stays accurate.
 
----
+______________________________________________________________________
 
 ## 0.22.0
+
 <small>2026-04-13</small>
 
 **Improvements**
 
-- Extend usage cost tracking to [OpenCode and Pi](/docs/token-usage/#agent-coverage) sessions alongside Claude Code and Codex. Their token counts now flow into the [Usage dashboard](/docs/token-usage/#usage-dashboard) and `agentsview usage` CLI reports.
-- Refine the Usage dashboard summary cards and cost-over-time chart for clearer cost reporting.
+- Extend usage cost tracking to
+  [OpenCode and Pi](/docs/token-usage/#agent-coverage) sessions alongside
+  Claude Code and Codex. Their token counts now flow into the
+  [Usage dashboard](/docs/token-usage/#usage-dashboard) and `agentsview usage`
+  CLI reports.
+- Refine the Usage dashboard summary cards and cost-over-time chart for clearer
+  cost reporting.
 
 **Bug fixes**
 
-- Sync Codex `exec` sessions so execution activity appears reliably in AgentsView.
-- Fix usage accounting so total cost data stays complete across supported providers.
+- Sync Codex `exec` sessions so execution activity appears reliably in
+  AgentsView.
+- Fix usage accounting so total cost data stays complete across supported
+  providers.
 
----
+______________________________________________________________________
 
 ## 0.21.0
+
 <small>2026-04-13</small>
 
 **New features**
 
-- Add a [token usage dashboard](/docs/token-usage/#usage-dashboard) to the web UI for exploring cost and token totals across your agent sessions. The new `/usage` page shows summary cards, a cost-over-time chart, a cost attribution treemap with project/model/agent toggles, top sessions by cost, and a cache efficiency panel. Filter by project, agent, model, and date range — filter state is written back to the URL so views are shareable and bookmarkable.
-- Add backing API endpoints for the usage dashboard so scripts and external tools can fetch the same summary, time series, and attribution data the UI uses.
+- Add a [token usage dashboard](/docs/token-usage/#usage-dashboard) to the web
+  UI for exploring cost and token totals across your agent sessions. The new
+  `/usage` page shows summary cards, a cost-over-time chart, a cost
+  attribution treemap with project/model/agent toggles, top sessions by cost,
+  and a cache efficiency panel. Filter by project, agent, model, and date
+  range — filter state is written back to the URL so views are shareable and
+  bookmarkable.
+- Add backing API endpoints for the usage dashboard so scripts and external
+  tools can fetch the same summary, time series, and attribution data the UI
+  uses.
 
 **Bug fixes**
 
-- Prevent some Claude usage records from being double-counted in cost and token totals.
+- Prevent some Claude usage records from being double-counted in cost and token
+  totals.
 - Correct Opus 4.6 pricing in usage cost calculations.
 
----
+______________________________________________________________________
 
 ## 0.20.0
+
 <small>2026-04-12</small>
 
 **New features**
 
-- Add [`agentsview usage daily`](/docs/token-usage/#agentsview-usage-daily) and [`agentsview usage statusline`](/docs/token-usage/#agentsview-usage-statusline) commands that report token usage and estimated cost by day or for the current day, scoped to Claude Code and Codex sessions. Pricing is pulled from the LiteLLM catalog with an embedded fallback for offline use. See [Token Usage & Costs](/docs/token-usage/) for the full write-up, including benchmarks against `ccusage`.
-- Add [OpenHands CLI](/docs/configuration/#session-discovery) session support. Local OpenHands conversations under `~/.openhands/conversations` are discovered, synced, and rendered alongside other agents. A new shallow-watch mode is used for agents that store each conversation in its own subdirectory, so file watchers don't exhaust inotify limits.
-- Add [Positron Assistant](/docs/configuration/#session-discovery) session support. Positron is a VS Code–based IDE; chat sessions under `workspaceStorage/*/chatSessions/` are parsed using the VSCode Copilot format. Built-in discovery covers macOS only in 0.20.0 — Linux and Windows users need to set `POSITRON_DIR` or `positron_dirs`.
-- Filter pinned messages by the currently selected project. The [Pinned](/docs/usage/#pinned-messages) page only shows pins from the active project, the count badge reflects the filtered total, and a dedicated empty state is shown when the filter yields no results.
+- Add [`agentsview usage daily`](/docs/token-usage/#agentsview-usage-daily) and
+  [`agentsview usage statusline`](/docs/token-usage/#agentsview-usage-statusline)
+  commands that report token usage and estimated cost by day or for the
+  current day, scoped to Claude Code and Codex sessions. Pricing is pulled
+  from the LiteLLM catalog with an embedded fallback for offline use. See
+  [Token Usage & Costs](/docs/token-usage/) for the full write-up, including
+  benchmarks against `ccusage`.
+- Add [OpenHands CLI](/docs/configuration/#session-discovery) session support.
+  Local OpenHands conversations under `~/.openhands/conversations` are
+  discovered, synced, and rendered alongside other agents. A new shallow-watch
+  mode is used for agents that store each conversation in its own
+  subdirectory, so file watchers don't exhaust inotify limits.
+- Add [Positron Assistant](/docs/configuration/#session-discovery) session
+  support. Positron is a VS Code–based IDE; chat sessions under
+  `workspaceStorage/*/chatSessions/` are parsed using the VSCode Copilot
+  format. Built-in discovery covers macOS only in 0.20.0 — Linux and Windows
+  users need to set `POSITRON_DIR` or `positron_dirs`.
+- Filter pinned messages by the currently selected project. The
+  [Pinned](/docs/usage/#pinned-messages) page only shows pins from the active
+  project, the count badge reflects the filtered total, and a dedicated empty
+  state is shown when the filter yields no results.
 
 **Improvements**
 
-- Drop the Intel macOS desktop builds regression. Release artifacts now include `.dmg` files for both Apple Silicon (`aarch64`) and Intel (`x86_64`) Macs, a Linux `arm64` AppImage for PR artifact coverage, plus the existing Linux `x86_64` AppImage and Windows `.exe`.
-- Stop enumerating agent names in CLI help text so the `--agent` flag and one-line descriptions don't go stale every time a new agent lands.
+- Drop the Intel macOS desktop builds regression. Release artifacts now include
+  `.dmg` files for both Apple Silicon (`aarch64`) and Intel (`x86_64`) Macs, a
+  Linux `arm64` AppImage for PR artifact coverage, plus the existing Linux
+  `x86_64` AppImage and Windows `.exe`.
+- Stop enumerating agent names in CLI help text so the `--agent` flag and
+  one-line descriptions don't go stale every time a new agent lands.
 
 **Bug fixes**
 
-- Auto-recover the macOS desktop app when WKWebView's content process is killed during sleep/wake. A Rust-side focus probe detects a dead WebView and force-reloads it; a JavaScript `visibilitychange` handler pings the backend and reloads if unreachable.
-- Honor `pi_dirs`, `cursor_project_dirs`, and `amp_dirs` from `config.toml`. These arrays were previously dropped by the loader because the registry entries for Pi, Cursor, and Amp were missing `ConfigKey`.
-- Claude Code streaming messages were being recorded multiple times by the parser, inflating historical input-token totals by roughly 2×. The parser now deduplicates them. After upgrading, the first `agentsview usage` invocation triggers a full resync so historical totals are recomputed with the fix.
-- Codex sessions now capture the per-request `token_count` events embedded in `event_msg` entries, so Codex messages populate token usage (and therefore show up in [`agentsview usage daily`](/docs/token-usage/)) where they previously reported zero.
+- Auto-recover the macOS desktop app when WKWebView's content process is killed
+  during sleep/wake. A Rust-side focus probe detects a dead WebView and
+  force-reloads it; a JavaScript `visibilitychange` handler pings the backend
+  and reloads if unreachable.
+- Honor `pi_dirs`, `cursor_project_dirs`, and `amp_dirs` from `config.toml`.
+  These arrays were previously dropped by the loader because the registry
+  entries for Pi, Cursor, and Amp were missing `ConfigKey`.
+- Claude Code streaming messages were being recorded multiple times by the
+  parser, inflating historical input-token totals by roughly 2×. The parser
+  now deduplicates them. After upgrading, the first `agentsview usage`
+  invocation triggers a full resync so historical totals are recomputed with
+  the fix.
+- Codex sessions now capture the per-request `token_count` events embedded in
+  `event_msg` entries, so Codex messages populate token usage (and therefore
+  show up in [`agentsview usage daily`](/docs/token-usage/)) where they
+  previously reported zero.
 
 **Acknowledgements**
 
-- Thanks to [kinglau66](https://github.com/kinglau66) for fixing the stale synced-status label and showing the exact sync time on hover.
-- Thanks to [Srujun Thanmay Gupta](https://github.com/srujun) for adding Hermes Agent session support.
-- Thanks to [Mario Witte](https://github.com/mariow) for adding Warp agent support.
-- Thanks to [nodivbyzero](https://github.com/nodivbyzero) for adding Positron Assistant session support.
-- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for filtering pinned messages by the selected project.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for restoring the Intel macOS desktop build.
-- Thanks to [Rajiv Shah](https://github.com/rajshah4) for adding OpenHands CLI session support and shallow watch mode.
+- Thanks to [kinglau66](https://github.com/kinglau66) for fixing the stale
+  synced-status label and showing the exact sync time on hover.
+- Thanks to [Srujun Thanmay Gupta](https://github.com/srujun) for adding Hermes
+  Agent session support.
+- Thanks to [Mario Witte](https://github.com/mariow) for adding Warp agent
+  support.
+- Thanks to [nodivbyzero](https://github.com/nodivbyzero) for adding Positron
+  Assistant session support.
+- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for filtering
+  pinned messages by the selected project.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for
+  restoring the Intel macOS desktop build.
+- Thanks to [Rajiv Shah](https://github.com/rajshah4) for adding OpenHands CLI
+  session support and shallow watch mode.
 
----
+______________________________________________________________________
 
 ## 0.19.0
+
 <small>2026-04-08</small>
 
 **New features**
 
-- Add Warp agent session support, reading AI conversations from Warp's local SQLite database with tool call breakdowns and token usage.
-- Add Hermes Agent session support across CLI, Discord, webhook, and cron platforms, with per-platform project grouping and skill prefix handling.
-- Add Cortex Code session support for Snowflake's AI coding agent, parsing both embedded-history and split-file formats.
-- Add Kiro CLI and Kiro IDE session support for Amazon's AI coding assistant, including unified diff rendering for edit actions.
-- Add Cursor session history with resume (`cursor agent --resume`) and automatic workspace recovery via `--workspace`.
-- Add the ability to resume Claude sessions in Claude Desktop via the session resume menu (macOS).
+- Add Warp agent session support, reading AI conversations from Warp's local
+  SQLite database with tool call breakdowns and token usage.
+- Add Hermes Agent session support across CLI, Discord, webhook, and cron
+  platforms, with per-platform project grouping and skill prefix handling.
+- Add Cortex Code session support for Snowflake's AI coding agent, parsing both
+  embedded-history and split-file formats.
+- Add Kiro CLI and Kiro IDE session support for Amazon's AI coding assistant,
+  including unified diff rendering for edit actions.
+- Add Cursor session history with resume (`cursor agent --resume`) and automatic
+  workspace recovery via `--workspace`.
+- Add the ability to resume Claude sessions in Claude Desktop via the session
+  resume menu (macOS).
 
 **Improvements**
 
-- Add [project filtering](/docs/pg-sync/#project-filtering) to `pg push` with `--projects`, `--exclude-projects`, and `--all-projects` flags plus config file equivalents. A new [`agentsview projects`](/docs/commands/#agentsview-projects) command lists all projects with session counts.
-- Add an opt-out for the update check via `disable_update_check` in config, `AGENTSVIEW_DISABLE_UPDATE_CHECK=1` environment variable, or `--no-update-check` CLI flag.
+- Add [project filtering](/docs/pg-sync/#project-filtering) to `pg push` with
+  `--projects`, `--exclude-projects`, and `--all-projects` flags plus config
+  file equivalents. A new
+  [`agentsview projects`](/docs/commands/#agentsview-projects) command lists
+  all projects with session counts.
+- Add an opt-out for the update check via `disable_update_check` in config,
+  `AGENTSVIEW_DISABLE_UPDATE_CHECK=1` environment variable, or
+  `--no-update-check` CLI flag.
 
 **Bug fixes**
 
-- Fix the synced status label staying stale after a sync completes. The relative time now refreshes every 10 seconds, and hovering shows the exact sync timestamp.
+- Fix the synced status label staying stale after a sync completes. The relative
+  time now refreshes every 10 seconds, and hovering shows the exact sync
+  timestamp.
 
 **Acknowledgements**
 
-- Thanks to [Jacob Struzik](https://github.com/jstruzik) for resuming Claude sessions in Claude Desktop.
-- Thanks to [Christian Bush](https://github.com/cbb330) for Cursor session history with resume and workspace recovery.
-- Thanks to [AO](https://github.com/andrewwowens) for adding Cortex Code session support.
+- Thanks to [Jacob Struzik](https://github.com/jstruzik) for resuming Claude
+  sessions in Claude Desktop.
+- Thanks to [Christian Bush](https://github.com/cbb330) for Cursor session
+  history with resume and workspace recovery.
+- Thanks to [AO](https://github.com/andrewwowens) for adding Cortex Code session
+  support.
 
----
+______________________________________________________________________
 
 ## 0.18.0
+
 <small>2026-04-02</small>
 
 **New features**
 
-- Import [Claude.ai and ChatGPT conversations](/docs/chat-import/) into AgentsView. Upload the zip file export from either service via the UI or CLI to bring your full conversation history — including ChatGPT images — into your local database alongside your agent coding sessions.
-- Show token usage metrics across sessions, analytics views, and exports. Session breadcrumbs display peak context and output tokens, the analytics dashboard includes output token summary cards and heatmap metrics, and CSV exports include token totals.
+- Import [Claude.ai and ChatGPT conversations](/docs/chat-import/) into
+  AgentsView. Upload the zip file export from either service via the UI or CLI
+  to bring your full conversation history — including ChatGPT images — into
+  your local database alongside your agent coding sessions.
+- Show token usage metrics across sessions, analytics views, and exports.
+  Session breadcrumbs display peak context and output tokens, the analytics
+  dashboard includes output token summary cards and heatmap metrics, and CSV
+  exports include token totals.
 
 **Improvements**
 
-- Detect automated roborev sessions and filter them out of session lists, counts, and analytics by default. An "Include automated" toggle in the session filter dropdown opts back in.
+- Detect automated roborev sessions and filter them out of session lists,
+  counts, and analytics by default. An "Include automated" toggle in the
+  session filter dropdown opts back in.
 
 **Bug fixes**
 
-- Keep pinned messages pinned after a session resync. Previously, re-syncing a session's messages could silently remove all pins due to cascade deletes; pins are now preserved by matching on message ordinal.
-- Reduce WebView memory usage when rendering message content by rekeying content-parser caches on message ID instead of full message text and lowering cache capacity.
+- Keep pinned messages pinned after a session resync. Previously, re-syncing a
+  session's messages could silently remove all pins due to cascade deletes;
+  pins are now preserved by matching on message ordinal.
+- Reduce WebView memory usage when rendering message content by rekeying
+  content-parser caches on message ID instead of full message text and
+  lowering cache capacity.
 
 **Acknowledgements**
 
-- Thanks to [Trent Nelson](https://github.com/tpn) for token-usage metrics across sessions, analytics, and exports.
-- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for preserving pinned messages after a session resync.
+- Thanks to [Trent Nelson](https://github.com/tpn) for token-usage metrics
+  across sessions, analytics, and exports.
+- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for preserving
+  pinned messages after a session resync.
 
----
+______________________________________________________________________
 
 ## 0.17.1
+
 <small>2026-03-29</small>
 
 **Bug fixes**
 
-- `pg serve` automatically applies pending PostgreSQL schema migrations on startup, reducing upgrade friction and startup failures.
+- `pg serve` automatically applies pending PostgreSQL schema migrations on
+  startup, reducing upgrade friction and startup failures.
 
 **Acknowledgements**
 
-- Thanks to [Thomas Maloney](https://github.com/tlmaloney) for auto-migrating the PostgreSQL schema on pg serve startup.
+- Thanks to [Thomas Maloney](https://github.com/tlmaloney) for auto-migrating
+  the PostgreSQL schema on pg serve startup.
 
----
+______________________________________________________________________
 
 ## 0.17.0
+
 <small>2026-03-28</small>
 
 **New features**
 
-- Add a session activity minimap with click-to-navigate support for quickly jumping to activity hotspots within a session.
-- Add a resizable session sidebar so you can drag the divider to adjust the layout to fit your workflow.
-- Capture and display Codex subagent result events in session transcripts, with an expandable history of status updates per tool call.
+- Add a session activity minimap with click-to-navigate support for quickly
+  jumping to activity hotspots within a session.
+- Add a resizable session sidebar so you can drag the divider to adjust the
+  layout to fit your workflow.
+- Capture and display Codex subagent result events in session transcripts, with
+  an expandable history of status updates per tool call.
 
 **Improvements**
 
-- Support Cursor's nested transcript directory layout for more reliable transcript discovery.
+- Support Cursor's nested transcript directory layout for more reliable
+  transcript discovery.
 
 **Bug fixes**
 
-- Restore Copilot as an insight-generation agent alongside Claude, Codex, and Gemini.
+- Restore Copilot as an insight-generation agent alongside Claude, Codex, and
+  Gemini.
 - Fix transcript strip pill spacing in WebKit browsers.
 
 **Acknowledgements**
 
-- Thanks to [Trent Nelson](https://github.com/tpn) for a resizable session sidebar and modeling Codex subagent result events.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for fixing transcript-strip pill spacing in WebKit.
-- Thanks to [Christian Bush](https://github.com/cbb330) for supporting Cursor's nested transcript directory layout.
+- Thanks to [Trent Nelson](https://github.com/tpn) for a resizable session
+  sidebar and modeling Codex subagent result events.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for fixing
+  transcript-strip pill spacing in WebKit.
+- Thanks to [Christian Bush](https://github.com/cbb330) for supporting Cursor's
+  nested transcript directory layout.
 
----
+______________________________________________________________________
 
 ## 0.16.2
+
 <small>2026-03-25</small>
 
 **Bug fixes**
 
-- Detect Claude conversation forks across the full reply subtree so branched threads display correctly.
+- Detect Claude conversation forks across the full reply subtree so branched
+  threads display correctly.
 
----
+______________________________________________________________________
 
 ## 0.16.1
+
 <small>2026-03-25</small>
 
 **Bug fixes**
@@ -2723,118 +2928,171 @@ description: Release history for AgentsView
 
 **Acknowledgements**
 
-- Thanks to [Trent Nelson](https://github.com/tpn) for adding managed Caddy support to pg serve and adding multi-host machine filtering and labels.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for adding URL-based session linking.
+- Thanks to [Trent Nelson](https://github.com/tpn) for adding managed Caddy
+  support to pg serve and adding multi-host machine filtering and labels.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for adding
+  URL-based session linking.
 
----
+______________________________________________________________________
 
 ## 0.16.0
+
 <small>2026-03-24</small>
 
 **New features**
 
-- Add direct URL links for opening specific sessions, enabling bookmarks and sharing of session deep links.
-- Add machine labels and multi-host filtering to separate sessions by source machine in shared deployments.
-- Add focused transcript mode with a responsive header that strips intermediate tool calls and thinking blocks for easier reading.
+- Add direct URL links for opening specific sessions, enabling bookmarks and
+  sharing of session deep links.
+- Add machine labels and multi-host filtering to separate sessions by source
+  machine in shared deployments.
+- Add focused transcript mode with a responsive header that strips intermediate
+  tool calls and thinking blocks for easier reading.
 - Add `Del` as a keyboard shortcut to delete or archive the selected session.
-- Add Kimi (Moonshot AI) session support for importing and viewing Kimi conversations.
-- Add PostgreSQL push sync and a read-only server mode (`pg push`, `pg serve`) for shared multi-user deployments backed by a central PostgreSQL database.
+- Add Kimi (Moonshot AI) session support for importing and viewing Kimi
+  conversations.
+- Add PostgreSQL push sync and a read-only server mode (`pg push`, `pg serve`)
+  for shared multi-user deployments backed by a central PostgreSQL database.
 
 **Improvements**
 
-- Group command palette search results by session, add a relevance/recency sort toggle, and match against session names in addition to message content.
-- Show model information in the session UI, including Codex session models, displayed in message headers.
+- Group command palette search results by session, add a relevance/recency sort
+  toggle, and match against session names in addition to message content.
+- Show model information in the session UI, including Codex session models,
+  displayed in message headers.
 - Use OpenCode session titles as display names in the session list.
-- Improve the mobile layout for smaller screens with a responsive sidebar and viewport-aware keyboard shortcuts.
-- Add managed Caddy support to `pg serve` for simpler TLS-terminated shared deployments.
-- Publish platform-specific wheels to PyPI for easier installation via `pip install agentsview`.
+- Improve the mobile layout for smaller screens with a responsive sidebar and
+  viewport-aware keyboard shortcuts.
+- Add managed Caddy support to `pg serve` for simpler TLS-terminated shared
+  deployments.
+- Publish platform-specific wheels to PyPI for easier installation via
+  `pip install agentsview`.
 - Add standard macOS app menu actions for Hide and Hide Others.
 
 **Bug fixes**
 
-- Show user messages that begin with skill or command invocations (e.g. `[Skill: name]`) in transcripts instead of hiding them.
-- Prevent Linux desktop app freezes with improved runtime CSP handling in the Tauri configuration.
+- Show user messages that begin with skill or command invocations (e.g.
+  `[Skill: name]`) in transcripts instead of hiding them.
+- Prevent Linux desktop app freezes with improved runtime CSP handling in the
+  Tauri configuration.
 - Restore desktop copy, paste, and cut keyboard shortcuts through the Edit menu.
-- Fix pinned message navigation in very large sessions where the virtualizer could stop mid-scroll before reaching the target message.
-- Surface insight generation errors directly in the UI with error status and message display instead of silently failing.
+- Fix pinned message navigation in very large sessions where the virtualizer
+  could stop mid-scroll before reaching the target message.
+- Surface insight generation errors directly in the UI with error status and
+  message display instead of silently failing.
 
 **Acknowledgements**
 
-- Thanks to [Thomas Maloney](https://github.com/tlmaloney) for PostgreSQL push sync and read-only server mode and showing user messages that begin with skill or command invocations.
-- Thanks to [CL Kao](https://github.com/clkao) for showing which model Codex sessions use.
-- Thanks to [Adam Hjerpe](https://github.com/hjerpe) for using the OpenCode session title as the display name.
-- Thanks to [Gary Ritchie](https://github.com/gtritchie) for Hide and Hide Others actions in the macOS app menu.
-- Thanks to [0xjjjjjj](https://github.com/0xjjjjjj) for the mobile responsive layout.
-- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for repairing pinned-message navigation in large sessions.
-- Thanks to [Li Ye](https://github.com/liye71023326) for adding Kimi (Moonshot AI) agent support.
-- Thanks to [Maxim Khailo](https://github.com/mempko) for fixing a Linux desktop app freeze with layered CSP and runtime port pinning.
-- Thanks to [Trent Nelson](https://github.com/tpn) for a focused transcript mode with a responsive header.
-- Thanks to [Stan Rosenberg](https://github.com/srosenberg) for a Del-key shortcut to delete or archive sessions.
+- Thanks to [Thomas Maloney](https://github.com/tlmaloney) for PostgreSQL push
+  sync and read-only server mode and showing user messages that begin with
+  skill or command invocations.
+- Thanks to [CL Kao](https://github.com/clkao) for showing which model Codex
+  sessions use.
+- Thanks to [Adam Hjerpe](https://github.com/hjerpe) for using the OpenCode
+  session title as the display name.
+- Thanks to [Gary Ritchie](https://github.com/gtritchie) for Hide and Hide
+  Others actions in the macOS app menu.
+- Thanks to [0xjjjjjj](https://github.com/0xjjjjjj) for the mobile responsive
+  layout.
+- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for repairing
+  pinned-message navigation in large sessions.
+- Thanks to [Li Ye](https://github.com/liye71023326) for adding Kimi (Moonshot
+  AI) agent support.
+- Thanks to [Maxim Khailo](https://github.com/mempko) for fixing a Linux desktop
+  app freeze with layered CSP and runtime port pinning.
+- Thanks to [Trent Nelson](https://github.com/tpn) for a focused transcript mode
+  with a responsive header.
+- Thanks to [Stan Rosenberg](https://github.com/srosenberg) for a Del-key
+  shortcut to delete or archive sessions.
 
----
+______________________________________________________________________
 
 ## 0.15.0
+
 <small>2026-03-17</small>
 
 **New features**
 
-- Add `agentsview token-use`, a CLI command that outputs machine-readable token usage data for scripts and automation.
+- Add `agentsview token-use`, a CLI command that outputs machine-readable token
+  usage data for scripts and automation.
 
 **Improvements**
 
 - Improve cross-platform token usage reporting on macOS, Linux, and Windows.
-- Make token usage insights more consistent across application and system restarts.
+- Make token usage insights more consistent across application and system
+  restarts.
 
 **Bug fixes**
 
-- Fix cases where token usage can be attributed to the wrong process after PID reuse or restarts.
+- Fix cases where token usage can be attributed to the wrong process after PID
+  reuse or restarts.
 
----
+______________________________________________________________________
 
 ## 0.14.0
+
 <small>2026-03-15</small>
 
 **New features**
 
-- Add in-session search with `Cmd+F` / `Ctrl+F` and keyboard navigation between matches for finding text within a session's messages.
-- Display token usage for each session, showing input and output token counts in the session detail header.
-- Add Zencoder CLI session support for importing and viewing Zencoder conversations.
-- Add GitHub Copilot CLI resume support in the session dropdown, letting you reopen Copilot CLI sessions directly.
-- Ship Linux desktop builds as AppImages, adding Linux to the desktop app platform matrix alongside macOS `.dmg` and Windows `.exe`.
+- Add in-session search with `Cmd+F` / `Ctrl+F` and keyboard navigation between
+  matches for finding text within a session's messages.
+- Display token usage for each session, showing input and output token counts in
+  the session detail header.
+- Add Zencoder CLI session support for importing and viewing Zencoder
+  conversations.
+- Add GitHub Copilot CLI resume support in the session dropdown, letting you
+  reopen Copilot CLI sessions directly.
+- Ship Linux desktop builds as AppImages, adding Linux to the desktop app
+  platform matrix alongside macOS `.dmg` and Windows `.exe`.
 
 **Improvements**
 
-- Improve insight agent detection for sandboxed sessions and GitHub Copilot, producing more accurate and relevant insights.
-- Speed up session resync for larger histories, reducing the time to re-parse all session files.
+- Improve insight agent detection for sandboxed sessions and GitHub Copilot,
+  producing more accurate and relevant insights.
+- Speed up session resync for larger histories, reducing the time to re-parse
+  all session files.
 
 **Bug fixes**
 
-- Fix updater output so the verify step starts on a new line after download progress.
+- Fix updater output so the verify step starts on a new line after download
+  progress.
 
 **Acknowledgements**
 
-- Thanks to [Aleksei Sotov](https://github.com/asotov-zen) for adding Zencoder CLI agent support.
-- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for adding Copilot CLI resume support to session dropdown and in-session search with keyboard navigation, plus a resync performance fix.
-- Thanks to [CL Kao](https://github.com/clkao) for collecting and displaying per-session token usage.
+- Thanks to [Aleksei Sotov](https://github.com/asotov-zen) for adding Zencoder
+  CLI agent support.
+- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for adding
+  Copilot CLI resume support to session dropdown and in-session search with
+  keyboard navigation, plus a resync performance fix.
+- Thanks to [CL Kao](https://github.com/clkao) for collecting and displaying
+  per-session token usage.
 
----
+______________________________________________________________________
 
 ## 0.13.0
+
 <small>2026-03-12</small>
 
 **New features**
 
-- Add a Settings page for appearance, terminal, GitHub, agent directory, and remote access options — centralizing configuration that was previously spread across individual modals and config file edits.
-- Add remote access with bearer token authentication, trusted public origins, and managed Caddy reverse proxy mode for secure multi-device access.
-- Organize sub-agents and teams in a collapsible tree view in the sidebar, making complex multi-agent sessions easier to navigate.
-- Update live sessions incrementally as new activity arrives, replacing full refreshes for faster real-time updates.
+- Add a Settings page for appearance, terminal, GitHub, agent directory, and
+  remote access options — centralizing configuration that was previously
+  spread across individual modals and config file edits.
+- Add remote access with bearer token authentication, trusted public origins,
+  and managed Caddy reverse proxy mode for secure multi-device access.
+- Organize sub-agents and teams in a collapsible tree view in the sidebar,
+  making complex multi-agent sessions easier to navigate.
+- Update live sessions incrementally as new activity arrives, replacing full
+  refreshes for faster real-time updates.
 - Add desktop zoom controls for adjusting the interface scale.
 
 **Improvements**
 
-- Skip common dependency and build folders (e.g. `node_modules`, `__pycache__`, `.git`) during recursive watching to reduce noise and overhead.
+- Skip common dependency and build folders (e.g. `node_modules`, `__pycache__`,
+  `.git`) during recursive watching to reduce noise and overhead.
 - Show release information in a new About dialog accessible from the header.
-- Shut down cleanly on `Ctrl+C` and stop auto-opening the browser on startup by default.
+- Shut down cleanly on `Ctrl+C` and stop auto-opening the browser on startup by
+  default.
 
 **Bug fixes**
 
@@ -2844,131 +3102,192 @@ description: Release history for AgentsView
 
 **Acknowledgements**
 
-- Thanks to [Trent Nelson](https://github.com/tpn) for adding trusted public origins and managed Caddy mode.
-- Thanks to [Ben Sedat](https://github.com/bsedat) for excluding common dependency and build directories from the recursive watcher.
-- Thanks to [TalesOfThales](https://github.com/userFRM) for a centralized settings page with remote-access authentication and a configurable API base URL, the sub-agent and team tree view with collapsible hierarchy, and preserving project-name casing in group headers.
+- Thanks to [Trent Nelson](https://github.com/tpn) for adding trusted public
+  origins and managed Caddy mode.
+- Thanks to [Ben Sedat](https://github.com/bsedat) for excluding common
+  dependency and build directories from the recursive watcher.
+- Thanks to [TalesOfThales](https://github.com/userFRM) for a centralized
+  settings page with remote-access authentication and a configurable API base
+  URL, the sub-agent and team tree view with collapsible hierarchy, and
+  preserving project-name casing in group headers.
 
----
+______________________________________________________________________
 
 ## 0.12.0
+
 <small>2026-03-10</small>
 
 **New features**
 
-- Add iFlow agent support for importing and viewing iFlow conversations, including JSONL session parsing and tool calls.
-- Add a session resume menu with three actions: reopen a session, launch a terminal in its working directory, and open the directory in Finder/Explorer.
-- Ship packaged desktop releases (`.dmg` for macOS, `.exe` for Windows) as the recommended install path, with built-in auto-update support.
+- Add iFlow agent support for importing and viewing iFlow conversations,
+  including JSONL session parsing and tool calls.
+- Add a session resume menu with three actions: reopen a session, launch a
+  terminal in its working directory, and open the directory in
+  Finder/Explorer.
+- Ship packaged desktop releases (`.dmg` for macOS, `.exe` for Windows) as the
+  recommended install path, with built-in auto-update support.
 
 **Improvements**
 
-- Replace the single-select agent filter with a multi-select agent filter, allowing multiple agents to be selected at once.
-- Improve cross-platform path handling for more reliable session discovery on Windows and WSL.
+- Replace the single-select agent filter with a multi-select agent filter,
+  allowing multiple agents to be selected at once.
+- Improve cross-platform path handling for more reliable session discovery on
+  Windows and WSL.
 
 **Bug fixes**
 
-- Fix Amp tool output rendering so tool results display correctly in expanded tool blocks.
+- Fix Amp tool output rendering so tool results display correctly in expanded
+  tool blocks.
 
 **Acknowledgements**
 
-- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for surfacing Copilot reasoningText as thinking blocks.
-- Thanks to [CL Kao](https://github.com/clkao) for category-based tool-metadata dispatch for cross-agent consistency.
-- Thanks to [Song Li](https://github.com/boltomli) for iFlow agent support, the multi-select agent filter, and cross-platform path handling fixes.
-- Thanks to [Luis Colunga](https://github.com/sinnet3000) for fixing missing Amp tool output in the UI.
+- Thanks to [Michael Chapman](https://github.com/MCBoarder289) for surfacing
+  Copilot reasoningText as thinking blocks.
+- Thanks to [CL Kao](https://github.com/clkao) for category-based tool-metadata
+  dispatch for cross-agent consistency.
+- Thanks to [Song Li](https://github.com/boltomli) for iFlow agent support, the
+  multi-select agent filter, and cross-platform path handling fixes.
+- Thanks to [Luis Colunga](https://github.com/sinnet3000) for fixing missing Amp
+  tool output in the UI.
 
----
+______________________________________________________________________
 
 ## 0.11.0
+
 <small>2026-03-08</small>
 
 **New features**
 
-- Add Pi agent support for importing and viewing Pi conversations, including JSONL session parsing, thinking blocks, and tool calls.
-- Add an `agentsview sync` command to populate the database without starting the HTTP server. Supports a `--full` flag to force a complete resync.
-- Add session renaming (double-click or right-click context menu), soft delete with trash and undo, and pinned messages with a gallery view.
-- Persist starred sessions in SQLite so stars survive server restarts. Existing localStorage stars are automatically migrated on first load.
+- Add Pi agent support for importing and viewing Pi conversations, including
+  JSONL session parsing, thinking blocks, and tool calls.
+- Add an `agentsview sync` command to populate the database without starting the
+  HTTP server. Supports a `--full` flag to force a complete resync.
+- Add session renaming (double-click or right-click context menu), soft delete
+  with trash and undo, and pinned messages with a gallery view.
+- Persist starred sessions in SQLite so stars survive server restarts. Existing
+  localStorage stars are automatically migrated on first load.
 
 **Improvements**
 
-- Exclude single-turn sessions (one or fewer user messages) by default in session lists and analytics views to reduce noise. A new "Include single-turn" toggle in the sidebar filter dropdown opts back in.
-- Normalize tool metadata across agents so tool calls from Gemini, Pi, and other agents display with the same metadata tags as their Claude equivalents.
+- Exclude single-turn sessions (one or fewer user messages) by default in
+  session lists and analytics views to reduce noise. A new "Include
+  single-turn" toggle in the sidebar filter dropdown opts back in.
+- Normalize tool metadata across agents so tool calls from Gemini, Pi, and other
+  agents display with the same metadata tags as their Claude equivalents.
 
 **Bug fixes**
 
-- Align timestamps between message headers and grouped tool call headers so they sit at the same right edge in all layouts.
+- Align timestamps between message headers and grouped tool call headers so they
+  sit at the same right edge in all layouts.
 - Show Copilot `reasoningText` as thinking blocks instead of discarding it.
-- Extract Gemini tool results more reliably and recognize additional Gemini tool names (`replace`, `run_shell_command`, `grep_search`, `glob`, `list_directory`).
+- Extract Gemini tool results more reliably and recognize additional Gemini tool
+  names (`replace`, `run_shell_command`, `grep_search`, `glob`,
+  `list_directory`).
 
 **Acknowledgements**
 
-- Thanks to [TalesOfThales](https://github.com/userFRM) for OpenClaw agent support, removing the redundant toggle-thinking button, persisting starred sessions in SQLite, and session management with rename, trash/undo, and pinned messages.
-- Thanks to [CL Kao](https://github.com/clkao) for storing tool-result content with a category blocklist, the sync subcommand that populates data without serving, and extracting Gemini tool-result content and expanding tool-name coverage.
+- Thanks to [TalesOfThales](https://github.com/userFRM) for OpenClaw agent
+  support, removing the redundant toggle-thinking button, persisting starred
+  sessions in SQLite, and session management with rename, trash/undo, and
+  pinned messages.
+- Thanks to [CL Kao](https://github.com/clkao) for storing tool-result content
+  with a category blocklist, the sync subcommand that populates data without
+  serving, and extracting Gemini tool-result content and expanding tool-name
+  coverage.
 - Thanks to [Cesar Arze](https://github.com/carze) for adding Pi agent support.
 
----
+______________________________________________________________________
 
 ## 0.10.0
+
 <small>2026-03-04</small>
 
 **New features**
 
-- Add Amp, VS Code Copilot, and OpenClaw agent support, including session parsing, filtering, and agent-colored display.
-- Add a Tauri-based desktop app wrapper that runs the web UI in a native window (in development, not yet released).
-- Add session starring with `s` key toggle and a starred-only filter for quick access to important sessions.
-- Add switchable message layouts — Default, Compact, and Stream — cycled with the `l` key.
+- Add Amp, VS Code Copilot, and OpenClaw agent support, including session
+  parsing, filtering, and agent-colored display.
+- Add a Tauri-based desktop app wrapper that runs the web UI in a native window
+  (in development, not yet released).
+- Add session starring with `s` key toggle and a starred-only filter for quick
+  access to important sessions.
+- Add switchable message layouts — Default, Compact, and Stream — cycled with
+  the `l` key.
 - Add collapsible sidebar grouping by agent to organize sessions by tool.
-- Add block-type filtering to toggle visibility of user messages, assistant responses, thinking blocks, tool calls, and code blocks.
+- Add block-type filtering to toggle visibility of user messages, assistant
+  responses, thinking blocks, tool calls, and code blocks.
 - Add a copy button on message headers to copy message content to the clipboard.
-- Add inline subagent transcript viewing for Task and Agent tool calls, loading the full subagent conversation on demand.
+- Add inline subagent transcript viewing for Task and Agent tool calls, loading
+  the full subagent conversation on demand.
 
 **Improvements**
 
-- Enrich Codex tool call display with structured formatting for bash, write_stdin, and apply_patch calls.
-- Store tool result content alongside tool calls, with configurable category blocklists to control database size.
-- Use a non-destructive database resync flow that preserves existing session data instead of dropping the database.
-- Simplify the message viewer header by removing the dedicated toggle-thinking button (use block-type filtering instead).
+- Enrich Codex tool call display with structured formatting for bash,
+  write_stdin, and apply_patch calls.
+- Store tool result content alongside tool calls, with configurable category
+  blocklists to control database size.
+- Use a non-destructive database resync flow that preserves existing session
+  data instead of dropping the database.
+- Simplify the message viewer header by removing the dedicated toggle-thinking
+  button (use block-type filtering instead).
 
 **Bug fixes**
 
-- Return an empty array instead of `null` from the sessions API when no sessions match.
-- Fix dashboard date handling in analytics and insights views for consistent date-range filtering.
+- Return an empty array instead of `null` from the sessions API when no sessions
+  match.
+- Fix dashboard date handling in analytics and insights views for consistent
+  date-range filtering.
 
 **Acknowledgements**
 
-- Thanks to [Luis Colunga](https://github.com/sinnet3000) for Amp agent support and centralizing the agent registry.
-- Thanks to [Christoph Deil](https://github.com/cdeil) for returning an empty array instead of null from the sessions API and adding VSCode Copilot agent support.
-- Thanks to [thellert](https://github.com/thellert) for subagent transcript viewing for Task and Agent tool calls.
-- Thanks to [TalesOfThales](https://github.com/userFRM) for the per-message copy button, block-type filtering by content category, collapsible sidebar grouping by agent, switchable message layouts (default, compact, stream), and session starring with localStorage persistence.
+- Thanks to [Luis Colunga](https://github.com/sinnet3000) for Amp agent support
+  and centralizing the agent registry.
+- Thanks to [Christoph Deil](https://github.com/cdeil) for returning an empty
+  array instead of null from the sessions API and adding VSCode Copilot agent
+  support.
+- Thanks to [thellert](https://github.com/thellert) for subagent transcript
+  viewing for Task and Agent tool calls.
+- Thanks to [TalesOfThales](https://github.com/userFRM) for the per-message copy
+  button, block-type filtering by content category, collapsible sidebar
+  grouping by agent, switchable message layouts (default, compact, stream),
+  and session starring with localStorage persistence.
 
----
+______________________________________________________________________
 
 ## 0.9.0
+
 <small>2026-02-27</small>
 
 **New features**
 
-- Add Cursor agent support, including parsing Cursor sessions and filtering them in the UI.
+- Add Cursor agent support, including parsing Cursor sessions and filtering them
+  in the UI.
 
 **Improvements**
 
-- Show tool call parameters in expanded tool blocks for better execution visibility.
+- Show tool call parameters in expanded tool blocks for better execution
+  visibility.
 - Restrict CORS to `localhost` origin to improve local security defaults.
 
 **Bug fixes**
 
-- Fix `install.sh` version parsing so installs work correctly with minified release JSON.
+- Fix `install.sh` version parsing so installs work correctly with minified
+  release JSON.
 
 **Acknowledgements**
 
-- Thanks to [procrypt](https://github.com/procrypto) for restricting CORS to the localhost origin.
+- Thanks to [procrypt](https://github.com/procrypto) for restricting CORS to the
+  localhost origin.
 
----
+______________________________________________________________________
 
 ## 0.8.0
+
 <small>2026-02-26</small>
 
 **New features**
 
-- Replace the project dropdown with a filterable typeahead to find and switch projects faster.
+- Replace the project dropdown with a filterable typeahead to find and switch
+  projects faster.
 
 **Improvements**
 
@@ -2982,18 +3301,22 @@ description: Release history for AgentsView
 
 **Acknowledgements**
 
-- Thanks to [CL Kao](https://github.com/clkao) for the session DAG view with fork detection and subagent linking.
-- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for fixing text selection inside tool-call blocks and the filterable project typeahead.
+- Thanks to [CL Kao](https://github.com/clkao) for the session DAG view with
+  fork detection and subagent linking.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for fixing
+  text selection inside tool-call blocks and the filterable project typeahead.
 
----
+______________________________________________________________________
 
 ## 0.7.0
+
 <small>2026-02-25</small>
 
 **New features**
 
 - Add a session DAG view that detects forks and shows branch relationships.
-- Add inline subagent linking so parent and subagent conversations are connected in context.
+- Add inline subagent linking so parent and subagent conversations are connected
+  in context.
 - Add an `All` option to the Analytics date range picker.
 - Add a `Hide unknown` filter to reduce noise from unclassified items.
 
@@ -3007,55 +3330,72 @@ description: Release history for AgentsView
 - Fix Analytics message counting so totals match actual message data.
 - Fix agent color assignment for more consistent visual identification.
 
----
+______________________________________________________________________
 
 ## 0.6.0
+
 <small>2026-02-25</small>
 
 **New features**
 
-- Support multiple Claude project directories, including mixed Windows/WSL setups.
+- Support multiple Claude project directories, including mixed Windows/WSL
+  setups.
 - Add session filters to quickly narrow the session list and analytics views.
 - Add in-app resync so you can refresh data without restarting AgentsView.
-- Support theme control via `postMessage` when embedding AgentsView in an iframe.
+- Support theme control via `postMessage` when embedding AgentsView in an
+  iframe.
 
 **Improvements**
 
 - Condense watcher warnings to reduce noisy sync notifications.
-- Add a polling fallback for unwatchable directories to keep sync running reliably.
+- Add a polling fallback for unwatchable directories to keep sync running
+  reliably.
 
 **Bug fixes**
 
 - Fix an app freeze when search returns no results.
 - Fix Gemini project detection so sessions map to the correct project.
 
----
+______________________________________________________________________
 
 ## 0.5.0
+
 <small>2026-02-25</small>
 
 **New features**
 
-- Add Copilot CLI session support so Copilot CLI conversations appear in AgentsView.
-- Add OpenCode session history support so OpenCode conversations can be synced and viewed.
-- Show a copyable Session ID in the session detail header for quicker sharing and lookup.
+- Add Copilot CLI session support so Copilot CLI conversations appear in
+  AgentsView.
+- Add OpenCode session history support so OpenCode conversations can be synced
+  and viewed.
+- Show a copyable Session ID in the session detail header for quicker sharing
+  and lookup.
 
 **Improvements**
 
-- Improve session source classification and sync coverage for newly supported tools.
-- Follow symlinks during project discovery so linked workspaces are detected correctly.
-- Improve interrupted-run recovery so valid sync results are preserved more reliably.
+- Improve session source classification and sync coverage for newly supported
+  tools.
+- Follow symlinks during project discovery so linked workspaces are detected
+  correctly.
+- Improve interrupted-run recovery so valid sync results are preserved more
+  reliably.
 
 **Acknowledgements**
 
-- Thanks to [Shreyas Karnik](https://github.com/shreyaskarnik) for the copyable Session ID in the session detail header.
-- Thanks to [CL Kao](https://github.com/clkao) for following symlinks when discovering project directories.
-- Thanks to [thellert](https://github.com/thellert) for theme control via postMessage for iframe embedding.
-- Thanks to [Nat Torkington](https://github.com/njt) for multi-directory Claude project support (including mixed Windows/WSL), condensed watcher warnings, and a polling fallback for unwatchable directories.
+- Thanks to [Shreyas Karnik](https://github.com/shreyaskarnik) for the copyable
+  Session ID in the session detail header.
+- Thanks to [CL Kao](https://github.com/clkao) for following symlinks when
+  discovering project directories.
+- Thanks to [thellert](https://github.com/thellert) for theme control via
+  postMessage for iframe embedding.
+- Thanks to [Nat Torkington](https://github.com/njt) for multi-directory Claude
+  project support (including mixed Windows/WSL), condensed watcher warnings,
+  and a polling fallback for unwatchable directories.
 
----
+______________________________________________________________________
 
 ## 0.4.1
+
 <small>2026-02-24</small>
 
 **Improvements**
@@ -3066,11 +3406,13 @@ description: Release history for AgentsView
 **Bug fixes**
 
 - Fix insights generation/store behavior to improve stability and accuracy.
-- Restore `CLAUDE_NO_SOUND=1` for Claude subprocesses to keep background runs silent.
+- Restore `CLAUDE_NO_SOUND=1` for Claude subprocesses to keep background runs
+  silent.
 
----
+______________________________________________________________________
 
 ## 0.4.0
+
 <small>2026-02-24</small>
 
 **New features**
@@ -3081,46 +3423,56 @@ description: Release history for AgentsView
 
 **Improvements**
 
-- Normalize worktree project names so sessions stay grouped consistently across worktrees.
+- Normalize worktree project names so sessions stay grouped consistently across
+  worktrees.
 - Improve message and tool block presentation for better readability.
 
 **Bug fixes**
 
 - Fix insight generation authentication failures.
-- Skip oversized JSONL lines during ingest so one bad line no longer fails the whole session.
+- Skip oversized JSONL lines during ingest so one bad line no longer fails the
+  whole session.
 - Embed the IANA timezone database to improve timezone support on Windows.
 
----
+______________________________________________________________________
 
 ## 0.3.2
+
 <small>2026-02-23</small>
 
 **New features**
 
-- Add session continuity via `sessionId` chaining, so resumed conversations stay linked as one ongoing session across sync/import.
+- Add session continuity via `sessionId` chaining, so resumed conversations stay
+  linked as one ongoing session across sync/import.
 
 **Improvements**
 
-- Improve sidebar session list and item behavior to better represent continued sessions.
-- Make session list state updates and virtualization smoother for larger histories.
+- Improve sidebar session list and item behavior to better represent continued
+  sessions.
+- Make session list state updates and virtualization smoother for larger
+  histories.
 
 **Bug fixes**
 
-- Fix cases where continued conversation segments appear as separate sessions instead of a single chain.
+- Fix cases where continued conversation segments appear as separate sessions
+  instead of a single chain.
 - Fix Claude parsing/sync edge cases so session links persist reliably.
 
----
+______________________________________________________________________
 
 ## 0.3.1
+
 <small>2026-02-22</small>
 
 **Bug fixes**
 
-- Keep exported and gist HTML styling in sync with current app design tokens for consistent visuals.
+- Keep exported and gist HTML styling in sync with current app design tokens for
+  consistent visuals.
 
----
+______________________________________________________________________
 
 ## 0.3.0
+
 <small>2026-02-22</small>
 
 **New features**
@@ -3129,29 +3481,36 @@ description: Release history for AgentsView
 
 **Improvements**
 
-- Improve the message viewer with clearer rendering for code blocks, tool calls, and thinking content.
-- Refine the analytics experience for easier session exploration and readability.
+- Improve the message viewer with clearer rendering for code blocks, tool calls,
+  and thinking content.
+- Refine the analytics experience for easier session exploration and
+  readability.
 - Improve sync performance to load and refresh data faster.
 - Update project dependencies to improve compatibility and stability.
-- Standardize session count formatting with explicit `en-US` locale handling for consistent display.
+- Standardize session count formatting with explicit `en-US` locale handling for
+  consistent display.
 
----
+______________________________________________________________________
 
 ## 0.2.2
+
 <small>2026-02-22</small>
 
 **Improvements**
 
-- Reduce Hour-of-Week heatmap cell size by 20% for a denser, easier-to-scan analytics view.
+- Reduce Hour-of-Week heatmap cell size by 20% for a denser, easier-to-scan
+  analytics view.
 
 **Bug fixes**
 
-- Fix available-port probing to bind the correct host, improving startup reliability.
+- Fix available-port probing to bind the correct host, improving startup
+  reliability.
 - Ensure builds compile without frontend assets by providing `go:embed` stubs.
 
----
+______________________________________________________________________
 
 ## 0.2.1
+
 <small>2026-02-21</small>
 
 **Improvements**
@@ -3160,49 +3519,61 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
-- Make installer exit on `SHA256SUMS` download failures to prevent incomplete or unverified installs.
+- Make installer exit on `SHA256SUMS` download failures to prevent incomplete or
+  unverified installs.
 
----
+______________________________________________________________________
 
 ## 0.2.0
+
 <small>2026-02-21</small>
 
 **New features**
 
-- Render Codex function calls as informative tool blocks in session views and exports.
+- Render Codex function calls as informative tool blocks in session views and
+  exports.
 
 **Improvements**
 
-- Make the activity calendar full-width and centered for a cleaner analytics layout.
+- Make the activity calendar full-width and centered for a cleaner analytics
+  layout.
 - Increase heatmap cell size (about 20%) to improve readability.
 - Combine day and hour activity charts into a more streamlined analytics view.
 - Default analytics to a 1-year date range instead of 30 days.
 - Match gist/export styling with the app's visual theme for consistent output.
 - Filter out system-injected user messages from the message list display.
 
----
+______________________________________________________________________
 
 ## 0.1.0
+
 <small>2026-02-21</small>
 
 **New features**
 
 - Launch AgentsView with an integrated Go backend and Svelte frontend.
 - Add analytics as the home screen with a persistent sidebar.
-- Add rich dashboard views, including summary cards, activity timeline, project breakdown, top sessions, and session shape metrics.
-- Add hour-of-week heatmap analytics with timezone display and interactive filtering.
-- Add tool-aware analytics, including tool usage, thinking/tool counts, velocity metrics, and agent comparison.
+- Add rich dashboard views, including summary cards, activity timeline, project
+  breakdown, top sessions, and session shape metrics.
+- Add hour-of-week heatmap analytics with timezone display and interactive
+  filtering.
+- Add tool-aware analytics, including tool usage, thinking/tool counts, velocity
+  metrics, and agent comparison.
 - Add analytics permalinks, drill-down navigation, transitions, and CSV export.
 - Add Gemini CLI session ingestion.
-- Add tool-call ingestion and parsing (including Codex function calls) for deeper analytics.
+- Add tool-call ingestion and parsing (including Codex function calls) for
+  deeper analytics.
 - Add self-update support and cross-platform install scripts.
 - Add frontend/backend version tracking with mismatch detection.
 
 **Improvements**
 
-- Improve dashboard usability with centralized active filter badges, project filtering, top sessions, and layout updates.
-- Improve session pane performance and virtualized list stability for deep scrolling.
-- Load sessions and selected session messages fully by default for smoother browsing.
+- Improve dashboard usability with centralized active filter badges, project
+  filtering, top sessions, and layout updates.
+- Improve session pane performance and virtualized list stability for deep
+  scrolling.
+- Load sessions and selected session messages fully by default for smoother
+  browsing.
 - Improve search UX by scrolling to and highlighting the matched message.
 - Keep sessions newest-first while showing messages in chronological order.
 - Refresh branding with the AgentsView name, periscope logo, and favicon.
@@ -3210,7 +3581,8 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
-- Fix analytics drill-down behavior so heatmap and project clicks filter and navigate correctly.
+- Fix analytics drill-down behavior so heatmap and project clicks filter and
+  navigate correctly.
 - Fix `prune --max-messages` so it counts user messages correctly.
 - Fix Claude parsing to skip system-injected user messages.
 - Fix chart panels so they stay within dashboard grid bounds.
@@ -3218,5 +3590,6 @@ description: Release history for AgentsView
 - Fix concurrent load/search race conditions to keep results consistent.
 - Harden markdown sanitization to prevent XSS and preserve escaped content.
 - Fix theme persistence when browser `localStorage` is unavailable.
-- Fix session-loading edge cases, including short session IDs and empty Gemini directories.
+- Fix session-loading edge cases, including short session IDs and empty Gemini
+  directories.
 - Fix Darwin release builds by targeting the macOS 15 runner.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -451,7 +451,7 @@ ______________________________________________________________________
 
 Report token usage and estimated cost aggregated by local-time day, scoped to
 the last 30 days by default. See [Token Usage & Costs](/docs/token-usage/) for a
-full write-up, including benchmarks against `ccusage`.
+full write-up on reporting behavior and agent coverage.
 
 ```bash
 agentsview usage daily [flags]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,8 +7,8 @@ description: All AgentsView commands, flags, and environment variables
 
 ### `agentsview capture`
 
-Capture and export the usage of one exact non-interactive automation run
-without starting the daemon, server, web interface, or watchers:
+Capture and export the usage of one exact non-interactive automation run without
+starting the daemon, server, web interface, or watchers:
 
 ```bash
 agentsview capture run \
@@ -51,20 +51,21 @@ credential is accepted only through `AGENTSVIEW_RAW_SYNC_CREDENTIAL`, never as a
 command-line flag. `--server` and `--device-id` override their corresponding
 environment variables.
 
-| Flag                    | Default      | Description                                      |
-| ----------------------- | ------------ | ------------------------------------------------ |
-| `--server`              | environment  | Raw-sync server URL                              |
-| `--device-id`           | environment  | Provisioned device ID                            |
-| `--allow-insecure-http` | `false`      | Allow HTTP for a loopback server only            |
-| `--debounce`            | `2s`         | Coalescing window for filesystem changes         |
-| `--interval`            | `15m`        | Interval between bounded provider audits         |
-| `--audit-limit`         | `128`        | Maximum source work in each provider audit       |
+| Flag                    | Default     | Description                                |
+| ----------------------- | ----------- | ------------------------------------------ |
+| `--server`              | environment | Raw-sync server URL                        |
+| `--device-id`           | environment | Provisioned device ID                      |
+| `--allow-insecure-http` | `false`     | Allow HTTP for a loopback server only      |
+| `--debounce`            | `2s`        | Coalescing window for filesystem changes   |
+| `--interval`            | `15m`       | Interval between bounded provider audits   |
+| `--audit-limit`         | `128`       | Maximum source work in each provider audit |
 
-`raw-sync status` reads the checkpoint without creating one and prints
-path-free JSON containing capture, queue, retry, failure, and coverage state.
-S3 roots are not captured. This remains an in-development raw-custody path:
-device enrollment and server-side session derivation are not yet available.
-See [Hosted Raw Sync](/docs/hosted-raw-sync/) for the current boundary.
+`raw-sync status` reads the checkpoint without creating one and prints path-free
+JSON containing capture, queue, retry, failure, and coverage state. S3 roots are
+not captured. A deployment operator must provision the device ID and credential;
+there is no public enrollment command yet. Accepted raw generations are not yet
+parsed into hosted sessions. See [Hosted Raw Sync](/docs/hosted-raw-sync/) for
+the current boundary.
 
 ______________________________________________________________________
 
@@ -186,12 +187,12 @@ agentsview serve stop
 The parent command starts a detached `agentsview serve` process and waits for it
 to publish its runtime record. The five-second readiness window measures startup
 inactivity, so continuing startup progress can keep the parent waiting longer.
-It then prints the URL, PID, and log path.
-Background server output is written to `~/.agentsview/serve.log`. `serve status`
-reports the preferred managed process, URL, version, uptime, and read-only mode
-when available. `serve stop` retains its broad lifecycle scope: it gracefully
-terminates confirmed writable SQLite and read-only PostgreSQL or DuckDB server
-processes for the data directory and cleans up their runtime records.
+It then prints the URL, PID, and log path. Background server output is written
+to `~/.agentsview/serve.log`. `serve status` reports the preferred managed
+process, URL, version, uptime, and read-only mode when available. `serve stop`
+retains its broad lifecycle scope: it gracefully terminates confirmed writable
+SQLite and read-only PostgreSQL or DuckDB server processes for the data
+directory and cleans up their runtime records.
 
 `serve restart` is intentionally narrower and config-driven. It restarts only
 the writable SQLite daemon, leaves read-only servers alive, and starts the
@@ -285,10 +286,10 @@ receives only critical fixes; use configured HTTP remote sync for new setups.
 Local sync can also read configured Claude, Codex, and Cursor roots from
 S3-compatible object storage. Add `s3://` entries to `claude_project_dirs`,
 `codex_sessions_dirs`, or `cursor_project_dirs` in `~/.agentsview/config.toml`,
-then run `agentsview sync` normally. This is not SSH remote sync: object
-storage is treated as a read-only session source, using object size and
-`LastModified` metadata to skip unchanged sessions and downloading only objects
-that need parsing. See
+then run `agentsview sync` normally. This is not SSH remote sync: object storage
+is treated as a read-only session source, using object size and `LastModified`
+metadata to skip unchanged sessions and downloading only objects that need
+parsing. See
 [Configuration — S3-Compatible Session Sources](/docs/configuration/#s3-compatible-session-sources).
 
 #### Configured Remote Hosts
@@ -327,8 +328,8 @@ offline, unreachable, or times out is skipped; reachable HTTP hosts still join
 the combined rebuild. Other HTTP preparation or contributor failures abort the
 combined rebuild without replacing the active archive or running SSH. Ordinary
 incremental and post-swap SSH failures retain per-host reporting, and the
-command exits non-zero for any failure other than an unavailable configured
-HTTP host. See [Incremental Sync](/docs/remote-access/#incremental-sync).
+command exits non-zero for any failure other than an unavailable configured HTTP
+host. See [Incremental Sync](/docs/remote-access/#incremental-sync).
 
 `agentsview sync --host X` syncs one host, not the whole configured list. When
 the local daemon knows a configured host with that identity, it uses the stored
@@ -437,7 +438,7 @@ The JSON contract uses these fields:
 | `name`           | string  | Canonical tool name, always `agentsview`     |
 | `version`        | string  | Build version                                |
 | `commit`         | string  | Source commit recorded at build time         |
-| `build_date`     | string  | UTC build timestamp, or an empty string       |
+| `build_date`     | string  | UTC build timestamp, or an empty string      |
 
 Consumers should require the expected `schema_version` and ignore unknown
 fields. Adding an optional field does not require a schema bump; removing or
@@ -449,8 +450,8 @@ ______________________________________________________________________
 ### `agentsview usage daily`
 
 Report token usage and estimated cost aggregated by local-time day, scoped to
-the last 30 days by default. See [Token Usage & Costs](/docs/token-usage/) for a full
-write-up, including benchmarks against `ccusage`.
+the last 30 days by default. See [Token Usage & Costs](/docs/token-usage/) for a
+full write-up, including benchmarks against `ccusage`.
 
 ```bash
 agentsview usage daily [flags]
@@ -546,8 +547,8 @@ agentsview usage cursor --since 2026-05-01 --until 2026-05-31
 agentsview usage cursor --all --email you@example.com
 ```
 
-See [Cursor Admin Usage Events](/docs/token-usage/#cursor-admin-usage-events) for
-setup and reporting behavior.
+See [Cursor Admin Usage Events](/docs/token-usage/#cursor-admin-usage-events)
+for setup and reporting behavior.
 
 ______________________________________________________________________
 
@@ -647,19 +648,19 @@ agentsview token-use 550e8400-e29b-41d4-a716-446655440000
 }
 ```
 
-`cost_usd` is a deprecated compatibility alias for `cost.microdollars / 1e6`
-and will be removed in a future release; new consumers should read
+`cost_usd` is a deprecated compatibility alias for `cost.microdollars / 1e6` and
+will be removed in a future release; new consumers should read
 `cost.microdollars` directly.
 
-See [`agentsview session usage`](/docs/session-api/#agentsview-session-usage) for the
-full field reference and exit-code contract.
+See [`agentsview session usage`](/docs/session-api/#agentsview-session-usage)
+for the full field reference and exit-code contract.
 
 ______________________________________________________________________
 
 ### `agentsview pg push`
 
-Sync sessions from local SQLite to PostgreSQL. See [PostgreSQL Sync](/docs/pg-sync/)
-for full documentation.
+Sync sessions from local SQLite to PostgreSQL. See
+[PostgreSQL Sync](/docs/pg-sync/) for full documentation.
 
 ```bash
 agentsview pg push [target] [flags]
@@ -702,9 +703,9 @@ ______________________________________________________________________
 ### `agentsview pg serve`
 
 Start a read-only session web UI backed by PostgreSQL. On a writable PostgreSQL
-schema, the same server also registers the partial [hosted raw-sync control
-plane](/docs/hosted-raw-sync/#http-control-plane). See [PostgreSQL Sync](/docs/pg-sync/)
-for full server documentation.
+schema, the same server also registers the
+[hosted raw-sync control plane](/docs/hosted-raw-sync/#http-control-plane). See
+[PostgreSQL Sync](/docs/pg-sync/) for full server documentation.
 
 ```bash
 agentsview pg serve [flags]
@@ -723,8 +724,8 @@ ______________________________________________________________________
 Install and manage the PostgreSQL auto-push service, which runs
 `agentsview pg push --watch` in the background. Supported service managers are
 launchd on macOS and `systemd --user` on Linux. See
-[PostgreSQL Sync — `agentsview pg service`](/docs/pg-sync/#agentsview-pg-service) for
-setup notes.
+[PostgreSQL Sync — `agentsview pg service`](/docs/pg-sync/#agentsview-pg-service)
+for setup notes.
 
 ```bash
 agentsview pg service install
@@ -748,8 +749,8 @@ ______________________________________________________________________
 
 ### `agentsview pg vectors`
 
-Inspect and drop semantic-search embedding generations stored in PostgreSQL.
-See [Semantic Search — Maintenance](/docs/semantic-search/#maintenance) for details.
+Inspect and drop semantic-search embedding generations stored in PostgreSQL. See
+[Semantic Search — Maintenance](/docs/semantic-search/#maintenance) for details.
 
 ```bash
 agentsview pg vectors list [flags]
@@ -761,17 +762,18 @@ agentsview pg vectors drop <id> [flags]
 | `list`      | List generations with model, dimension, document/chunk counts, and contributing machines |
 | `drop <id>` | Drop a generation and all of its embeddings (prompts for confirmation)                   |
 
-| Flag       | Default | Description                                          |
-| ---------- | ------- | ---------------------------------------------------- |
+| Flag       | Default | Description                                             |
+| ---------- | ------- | ------------------------------------------------------- |
 | `--target` |         | PG target name (default: the default configured target) |
-| `--yes`    | `false` | Skip the confirmation prompt (`drop` only)           |
+| `--yes`    | `false` | Skip the confirmation prompt (`drop` only)              |
 
 ______________________________________________________________________
 
 ### `agentsview duckdb`
 
 Mirror the local SQLite archive into DuckDB and serve from it, locally or over
-the Quack remote protocol. See [DuckDB Mirror](/docs/duckdb/) for full documentation.
+the Quack remote protocol. See [DuckDB Mirror](/docs/duckdb/) for full
+documentation.
 
 ```bash
 agentsview duckdb push          # mirror SQLite into sessions.duckdb
@@ -783,16 +785,16 @@ agentsview duckdb quack serve   # expose the mirror over Quack
 `duckdb push` accepts the same `--full` / `--projects` / `--exclude-projects` /
 `--all-projects` / `--watch` / `--debounce` / `--interval` flags as `pg push`.
 `duckdb push` always writes the local mirror file at `[duckdb].path`; it never
-targets a remote Quack endpoint. If `[duckdb].url` or `AGENTSVIEW_DUCKDB_URL`
-is configured, push fails immediately with an error to unset it and serve the
+targets a remote Quack endpoint. If `[duckdb].url` or `AGENTSVIEW_DUCKDB_URL` is
+configured, push fails immediately with an error to unset it and serve the
 mirror remotely with `duckdb quack serve` instead. `duckdb status` and
 `duckdb serve` do target the remote Quack endpoint when `[duckdb].url` or
 `AGENTSVIEW_DUCKDB_URL` is set, and the local mirror file otherwise. When
-`[duckdb].path` or `AGENTSVIEW_DUCKDB_PATH` is set, `duckdb quack serve`
-exposes that same mirror by default unless `--path` overrides it.
-`duckdb serve` accepts the same serve flags as `pg serve`. The DuckDB backend
-is unavailable on Windows ARM64 (the upstream bindings ship no prebuilt
-library for that platform); all other commands work normally there.
+`[duckdb].path` or `AGENTSVIEW_DUCKDB_PATH` is set, `duckdb quack serve` exposes
+that same mirror by default unless `--path` overrides it. `duckdb serve` accepts
+the same serve flags as `pg serve`. The DuckDB backend is unavailable on Windows
+ARM64 (the upstream bindings ship no prebuilt library for that platform); all
+other commands work normally there.
 
 ______________________________________________________________________
 
@@ -821,7 +823,8 @@ ______________________________________________________________________
 ### `agentsview health`
 
 Inspect session intelligence in a human-friendly CLI view. See
-[Session Intelligence](/docs/session-intelligence/) for the scoring and signal model.
+[Session Intelligence](/docs/session-intelligence/) for the scoring and signal
+model.
 
 ```bash
 agentsview health [session-id] [flags]
@@ -904,7 +907,7 @@ The report includes:
 - configured/default agent roots and whether each exists
 - recent debug lines mentioning sync, data versions, warnings, or failures
 - Antigravity CLI summary-mode counts and Antigravity sessions decoded from
-    unrecognized `agy-schema:` fingerprints
+  unrecognized `agy-schema:` fingerprints
 - a likely-cause summary when startup sync behavior looks abnormal
 
 ______________________________________________________________________
@@ -946,13 +949,13 @@ covered alongside normal file-backed agents.
 The report distinguishes parser drift from comparison-basis skew:
 
 - `raced` means the source changed while `parse-diff` was running. It is
-    reported for review but does not fail `--fail-on-change`.
+  reported for review but does not fail `--fail-on-change`.
 - `incremental_skew` means the stored row was last written by an
-    incremental-append sync, so a fresh full re-parse can legitimately differ on
-    append-path metadata. It is also reported but excluded from
-    `--fail-on-change`.
+  incremental-append sync, so a fresh full re-parse can legitimately differ on
+  append-path metadata. It is also reported but excluded from
+  `--fail-on-change`.
 - `pending_resync` means the stored data version is behind the running binary;
-    the next data-version resync rewrites those rows.
+  the next data-version resync rewrites those rows.
 
 If the report includes `incremental_skew`, run a full resync before treating the
 archive as a clean parser-drift baseline. A full resync rewrites those rows
@@ -962,15 +965,15 @@ ______________________________________________________________________
 
 ### `agentsview import`
 
-Import Claude.ai, ChatGPT, or Gemini Apps conversations into the local database. See
-[Chat Import](/docs/chat-import/) for full documentation.
+Import Claude.ai, ChatGPT, or Gemini Apps conversations into the local database.
+See [Chat Import](/docs/chat-import/) for full documentation.
 
 ```bash
 agentsview import --type <type> <path>
 ```
 
-| Flag     | Default | Description                                      |
-| -------- | ------- | ------------------------------------------------ |
+| Flag     | Default | Description                                                      |
+| -------- | ------- | ---------------------------------------------------------------- |
 | `--type` |         | Import type: `claude-ai`, `chatgpt`, or `gemini-apps` (required) |
 
 The path can be a `.zip` file, a `conversations.json` file (Claude.ai only), a
@@ -991,8 +994,8 @@ ______________________________________________________________________
 ### `agentsview export sessions`
 
 Export content-free session summaries from the local archive. See
-[Session Export](/docs/session-export/) for the full JSON/NDJSON contract, cursor
-semantics, pricing provenance, and project identity rules.
+[Session Export](/docs/session-export/) for the full JSON/NDJSON contract,
+cursor semantics, pricing provenance, and project identity rules.
 
 ```bash
 agentsview export sessions [flags]
@@ -1039,9 +1042,9 @@ agentsview export sessions --all --format ndjson --project agentsview
 The JSON top level has `schema_version`, `database_id`, `cursor`, `pricing`,
 `projects`, and `sessions`. NDJSON writes the same metadata as the first line,
 then one session row per following line. Current builds emit
-`schema_version: 6`; see [Session Export](/docs/session-export/#versioning) for the
-v1 and transitional 0.38 release history. The default and maximum page size is
-`db.MaxSessionLimit`, currently 500.
+`schema_version: 6`; see [Session Export](/docs/session-export/#versioning) for
+the v1 and transitional 0.38 release history. The default and maximum page size
+is `db.MaxSessionLimit`, currently 500.
 
 When `--cursor` is present, only `--format`, `--json`, and `--limit` may be
 combined with it. Cursor reset errors write structured JSON to stderr, leave
@@ -1068,17 +1071,17 @@ agentsview export digest --from 2026-06-28 --to 2026-07-27
 
 Hour and date keys must be exact, zero-padded UTC values. Open and future hours
 are rejected. The current UTC date contains only closed hours and has no day
-digest. Digest ranges are inclusive and limited to 31 dates. Integrations
-should validate the emitted `schema_version: 2` and content digest before
-accepting a document.
+digest. Digest ranges are inclusive and limited to 31 dates. Integrations should
+validate the emitted `schema_version: 2` and content digest before accepting a
+document.
 
 ______________________________________________________________________
 
 ### `agentsview session`
 
 Programmatic access to session data for scripts, automation agents, and CI jobs.
-See [Session API](/docs/session-api/) for full documentation, including stability
-guarantees, transport auto-detection, and every subcommand.
+See [Session API](/docs/session-api/) for full documentation, including
+stability guarantees, transport auto-detection, and every subcommand.
 
 ```bash
 agentsview session get <id>              # metadata + signals
@@ -1102,8 +1105,8 @@ cost. `--own-only` restores the older own-session output.
 and `--hybrid` modes. Semantic and hybrid results can be scoped with
 `--scope top|all|subordinate` (default `all`) to include or exclude sidechain
 and subagent content — see
-[Semantic Search](/docs/semantic-search/#scoping-results-scope).
-The human-readable table includes an `AGE` column derived from each match's
+[Semantic Search](/docs/semantic-search/#scoping-results-scope). The
+human-readable table includes an `AGE` column derived from each match's
 timestamp, so recent evidence is visible without opening the session. Matches
 without a usable timestamp show `—`.
 
@@ -1155,10 +1158,10 @@ ______________________________________________________________________
 
 ### `agentsview recall`
 
-Inspect the experimental durable-knowledge layer over the local session
-archive. Recall is active research and its corpus may require rebuilding as the
-schema, scoring, and trust policy evolve. See
-[Recall (Experimental)](/docs/recall/) for its current guarantees and limitations.
+Inspect the experimental durable-knowledge layer over the local session archive.
+Recall is active research and its corpus may require rebuilding as the schema,
+scoring, and trust policy evolve. See [Recall (Experimental)](/docs/recall/) for
+its current guarantees and limitations.
 
 ```bash
 agentsview recall list
@@ -1175,22 +1178,23 @@ agentsview recall extract preview --session <id>
 agentsview recall import <accepted-recall.jsonl> --dry-run
 ```
 
-Model-backed extraction requires an enabled `[recall.extract]` config section
-— see [Recall](/docs/recall/#automatic-extraction). `preview` replaces the earlier
+Model-backed extraction requires an enabled `[recall.extract]` config section —
+see [Recall](/docs/recall/#automatic-extraction). `preview` replaces the earlier
 `extract --session <id> --dry-run` form, which still works as a fallback. The
-extraction subcommands operate on the local archive only and refuse
-`--server`; while a daemon owns the archive, it runs extraction passes itself
-and manual `run`/`activate`/`retire` are refused.
+extraction subcommands operate on the local archive only and refuse `--server`;
+while a daemon owns the archive, it runs extraction passes itself and manual
+`run`/`activate`/`retire` are refused.
 
 Use an isolated `AGENTSVIEW_DATA_DIR` for Recall population experiments. Import
-with `--dry-run` first; a write requires `--yes`, and a remote write also requires
-`--allow-remote-import`. Import against the default production directory is
-refused unless `--allow-production-import` is supplied explicitly. These flags
-do not bypass Recall's trust or evidence checks.
+with `--dry-run` first; a write requires `--yes`, and a remote write also
+requires `--allow-remote-import`. Import against the default production
+directory is refused unless `--allow-production-import` is supplied explicitly.
+These flags do not bypass Recall's trust or evidence checks.
 
-When `--server <url>` targets an explicit daemon, provide remote credentials with
-`AGENTSVIEW_SERVER_TOKEN` or `--server-token-file <path>`. Recall never sends the
-local daemon token from `config.toml` to an explicitly supplied server.
+When `--server <url>` targets an explicit daemon, provide remote credentials
+with `AGENTSVIEW_SERVER_TOKEN` or `--server-token-file <path>`. Recall never
+sends the local daemon token from `config.toml` to an explicitly supplied
+server.
 
 ______________________________________________________________________
 
@@ -1199,8 +1203,8 @@ ______________________________________________________________________
 Run a read-only Model Context Protocol server for assistant clients that can
 call MCP tools. The server exposes session search, listing, overview, message
 retrieval, content search, and usage-summary tools over the same service layer
-used by the CLI and HTTP API. See [MCP Server](/docs/mcp/) for setup examples and
-operational guidance.
+used by the CLI and HTTP API. See [MCP Server](/docs/mcp/) for setup examples
+and operational guidance.
 
 ```bash
 agentsview mcp
@@ -1222,8 +1226,8 @@ opening the local SQLite archive directly.
 Use `--server <url>` to point at an explicit running daemon. When the daemon
 requires auth, provide `AGENTSVIEW_SERVER_TOKEN` or
 `--server-token-file <path>`. Use `--pg` to read from configured PostgreSQL
-directly, or run [`agentsview pg serve`](/docs/pg-sync/#agentsview-pg-serve) and pass
-its URL with `--server`.
+directly, or run [`agentsview pg serve`](/docs/pg-sync/#agentsview-pg-serve) and
+pass its URL with `--server`.
 
 | Flag                         | Default | Description                                         |
 | ---------------------------- | ------- | --------------------------------------------------- |
@@ -1238,8 +1242,8 @@ ______________________________________________________________________
 ### `agentsview secrets`
 
 Scan for and list detected secret leaks across sessions, with matches redacted
-by default. See [Secret Scanning](/docs/session-api/#secret-scanning) for the full
-detector set, storage shape, and HTTP API.
+by default. See [Secret Scanning](/docs/session-api/#secret-scanning) for the
+full detector set, storage shape, and HTTP API.
 
 ```bash
 agentsview secrets scan [flags]   # scan sessions for leaks
@@ -1278,8 +1282,8 @@ ______________________________________________________________________
 
 Install or list the bundled skill files that teach coding-agent harnesses
 (Claude Code, Codex, and other `.agents/skills` readers) to search AgentsView
-history. See [Semantic Search](/docs/semantic-search/#skills-for-coding-agents) for
-what the skill does and when to re-run it.
+history. See [Semantic Search](/docs/semantic-search/#skills-for-coding-agents)
+for what the skill does and when to re-run it.
 
 ```bash
 agentsview skills install [--harness claude|agents] [--project] [--force]
@@ -1353,7 +1357,7 @@ agentsview help
 | `POSIT_ASSISTANT_DIR`             | `~/.posit/assistant/workspaces`                      | Posit Assistant workspaces directory                                                                |
 | `POSITRON_DIR`                    | (platform-specific)                                  | Positron Assistant user directory                                                                   |
 | `QCLAW_DIR`                       | `~/.qclaw/agents`                                    | QClaw agents directory                                                                              |
-| `QODER_PROJECTS_DIR`              | Legacy and platform-specific roots                   | Qoder projects directory; see [Session Discovery](/docs/configuration/#session-discovery)                 |
+| `QODER_PROJECTS_DIR`              | Legacy and platform-specific roots                   | Qoder projects directory; see [Session Discovery](/docs/configuration/#session-discovery)           |
 | `QWEN_PROJECTS_DIR`               | `~/.qwen/projects`                                   | Qwen Code projects directory                                                                        |
 | `QWENPAW_DIR`                     | `~/.copaw/workspaces`                                | QwenPaw workspaces directory                                                                        |
 | `REASONIX_DIR`                    | `~/.reasonix` and `~/AppData/Roaming/reasonix`       | Reasonix data directory                                                                             |
@@ -1381,7 +1385,7 @@ agentsview help
 | `AGENTSVIEW_DISABLE_UPDATE_CHECK` |                                                      | Set to `1` to disable the update check                                                              |
 | `AGENTSVIEW_NO_DAEMON`            |                                                      | Set to `1`, `true`, `yes`, or `on` to disable CLI daemon auto-start                                 |
 | `AGENTSVIEW_DAEMON_IDLE_TIMEOUT`  | `20m`                                                | Override idle self-shutdown duration for detached background daemons                                |
-| `AGENTSVIEW_TELEMETRY_ENABLED`    |                                                      | Set to `0` to disable [anonymous daemon telemetry](/docs/configuration/#anonymous-daemon-telemetry)      |
+| `AGENTSVIEW_TELEMETRY_ENABLED`    |                                                      | Set to `0` to disable [anonymous daemon telemetry](/docs/configuration/#anonymous-daemon-telemetry) |
 
 Environment variables override the built-in defaults. Set them in your shell
 profile or pass them inline:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,8 +11,7 @@ AgentsView stores all persistent data under a single directory, defaulting to
 !!! note
 
     `AGENT_VIEWER_DATA_DIR` is still accepted as a legacy fallback when
-    `AGENTSVIEW_DATA_DIR` is unset, but new setups should use
-    `AGENTSVIEW_DATA_DIR`.
+    `AGENTSVIEW_DATA_DIR` is unset, but new setups should use `AGENTSVIEW_DATA_DIR`.
 
 ```
 ~/.agentsview/
@@ -26,10 +25,10 @@ AgentsView stores all persistent data under a single directory, defaulting to
 └── uploads/         # Uploaded session files
 ```
 
-`usage-cache-v6-<id>.db` is a derived cache of usage aggregates, not user
-data. It is safe to delete when no AgentsView process is running; the next
-usage query rebuilds it automatically. `sessions.db` remains the only file
-that needs backing up.
+`usage-cache-v6-<id>.db` is a derived cache of usage aggregates, not user data.
+It is safe to delete when no AgentsView process is running; the next usage query
+rebuilds it automatically. `sessions.db` remains the only file that needs
+backing up.
 
 The desktop app and CLI share a detached local daemon for fresh reads and
 writes. A running daemon owns local SQLite writes for this data directory and
@@ -51,9 +50,9 @@ stores persistent settings that survive restarts.
 
 !!! note
 
-    The config format changed from JSON to TOML. Existing `config.json` files
-    are automatically migrated to `config.toml` on first run (the JSON file is
-    renamed to `config.json.bak`).
+    The config format changed from JSON to TOML. Existing `config.json` files are
+    automatically migrated to `config.toml` on first run (the JSON file is renamed
+    to `config.json.bak`).
 
 ```toml
 cursor_secret = "base64-encoded-secret"
@@ -63,33 +62,33 @@ daemon_idle_timeout = "20m"
 chart_palette = "agentsview"
 ```
 
-| Field                               | Description                                                                                                                                                                                                                                          |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cursor_secret`                     | Auto-generated HMAC key for pagination cursor signing                                                                                                                                                                                                |
-| `cursor_admin_api_key`              | Cursor Admin API key used by `agentsview usage cursor`                                                                                                                                                                                               |
-| `cursor_admin_email`                | Optional default Cursor Admin usage filter by member email                                                                                                                                                                                           |
-| `cursor_admin_user_id`              | Optional default Cursor Admin usage filter by member user ID                                                                                                                                                                                         |
-| `github_token`                      | Optional saved GitHub token for Gist publishing                                                                                                                                                                                                      |
-| `result_content_blocked_categories` | Tool categories whose result content is not stored (default: `["Read", "Glob"]`)                                                                                                                                                                     |
-| `host`                              | Interface the server binds to (default `127.0.0.1`); non-loopback values require `require_auth = true`                                                                                                                                               |
-| `require_auth`                      | Require bearer-token authentication for API access                                                                                                                                                                                                   |
-| `auth_token`                        | Auto-generated 256-bit bearer token for remote access; can be overridden with `AGENTSVIEW_AUTH_TOKEN`                                                                                                                                                |
-| `public_url`                        | Public URL for hostname/proxy access and origin validation                                                                                                                                                                                           |
-| `public_origins`                    | Array of additional trusted CORS origins                                                                                                                                                                                                             |
-| `daemon_idle_timeout`               | Idle timeout for detached writable daemons; set to `"0s"` to keep them alive                                                                                                                                                                         |
-| `chart_palette`                     | Server-wide categorical chart colors: `"agentsview"` (default) or `"matplotlib"`; also configurable under **Settings > Appearance**                                                                                                                  |
-| `disabled_agents`                   | Session providers to exclude from local filesystem scanning; changes require a daemon restart — see [Disabling Session Providers](#disabling-session-providers)                                                                                     |
+| Field                               | Description                                                                                                                                                                                                                                               |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cursor_secret`                     | Auto-generated HMAC key for pagination cursor signing                                                                                                                                                                                                     |
+| `cursor_admin_api_key`              | Cursor Admin API key used by `agentsview usage cursor`                                                                                                                                                                                                    |
+| `cursor_admin_email`                | Optional default Cursor Admin usage filter by member email                                                                                                                                                                                                |
+| `cursor_admin_user_id`              | Optional default Cursor Admin usage filter by member user ID                                                                                                                                                                                              |
+| `github_token`                      | Optional saved GitHub token for Gist publishing                                                                                                                                                                                                           |
+| `result_content_blocked_categories` | Tool categories whose result content is not stored (default: `["Read", "Glob"]`)                                                                                                                                                                          |
+| `host`                              | Interface the server binds to (default `127.0.0.1`); non-loopback values require `require_auth = true`                                                                                                                                                    |
+| `require_auth`                      | Require bearer-token authentication for API access                                                                                                                                                                                                        |
+| `auth_token`                        | Auto-generated 256-bit bearer token for remote access; can be overridden with `AGENTSVIEW_AUTH_TOKEN`                                                                                                                                                     |
+| `public_url`                        | Public URL for hostname/proxy access and origin validation                                                                                                                                                                                                |
+| `public_origins`                    | Array of additional trusted CORS origins                                                                                                                                                                                                                  |
+| `daemon_idle_timeout`               | Idle timeout for detached writable daemons; set to `"0s"` to keep them alive                                                                                                                                                                              |
+| `chart_palette`                     | Server-wide categorical chart colors: `"agentsview"` (default) or `"matplotlib"`; also configurable under **Settings > Appearance**                                                                                                                       |
+| `disabled_agents`                   | Session providers to exclude from local filesystem scanning; changes require a daemon restart — see [Disabling Session Providers](#disabling-session-providers)                                                                                           |
 | `[proxy]`                           | Managed proxy configuration table — see [Remote Access](/docs/remote-access/)                                                                                                                                                                             |
-| `disable_update_check`              | Disable the automatic update check (see [Privacy](#privacy-and-telemetry))                                                                                                                                                                           |
-| `scan_protected_paths`              | Allow Git discovery inside macOS privacy-protected folders, accepting one consent prompt per folder — see [macOS Protected Folders](#macos-protected-folders)                                                                                        |
+| `disable_update_check`              | Disable the automatic update check (see [Privacy](#privacy-and-telemetry))                                                                                                                                                                                |
+| `scan_protected_paths`              | Allow Git discovery inside macOS privacy-protected folders, accepting one consent prompt per folder — see [macOS Protected Folders](#macos-protected-folders)                                                                                             |
 | `[pg]`                              | PostgreSQL sync configuration — see [PostgreSQL Sync](/docs/pg-sync/)                                                                                                                                                                                     |
 | `[duckdb]`                          | DuckDB mirror configuration — see [DuckDB Mirror](/docs/duckdb/)                                                                                                                                                                                          |
 | `[vector]`                          | Opt-in semantic-search index; model settings live in `[vector.embeddings]`, named endpoints in `[vector.embeddings.servers.<name>]`, embedding schedule in `[vector.embed]` — see [Semantic Search](/docs/semantic-search/#enabling-vector) for every key |
 | `[recall.extract]`                  | Opt-in model-backed recall extraction; named endpoints in `[recall.extract.servers.<name>]`, prompt selection in `[recall.extract.prompts]`, request overrides in `[recall.extract.request]` — see [Recall](/docs/recall/#automatic-extraction)           |
-| `[insights]`                        | Optional generated-insights endpoint and model; local loopback HTTP is allowed, remote plaintext requires `allow_http = true`, and endpoint failures do not retry through a CLI — see [Recall](/docs/recall/#current-surface) |
+| `[insights]`                        | Optional generated-insights endpoint and model; local loopback HTTP is allowed, remote plaintext requires `allow_http = true`, and endpoint failures do not retry through a CLI — see [Recall](/docs/recall/#current-surface)                             |
 | `[[remote_hosts]]`                  | Remote machines synced by a bare `agentsview sync` — see [CLI Reference](/docs/commands/#agentsview-sync)                                                                                                                                                 |
 | `[[session_sources]]`               | Additional filesystem session roots with per-root machine labels — see [Filesystem Session Sync](/docs/filesystem-sync/)                                                                                                                                  |
-| `[automated]`                       | Custom automated-session patterns — see [Automated Session Detection](#automated-session-detection)                                                                                                                                                  |
+| `[automated]`                       | Custom automated-session patterns — see [Automated Session Detection](#automated-session-detection)                                                                                                                                                       |
 | `[custom_model_pricing]`            | Per-model price overrides for usage reports — see [Custom Model Pricing](/docs/token-usage/#custom-model-pricing)                                                                                                                                         |
 
 The `cursor_secret` is generated automatically on first run. For Gist
@@ -99,7 +98,8 @@ requests, if no token is saved, it then tries `AGENTSVIEW_GITHUB_TOKEN` and then
 `gh auth login`. For remote or proxied access, save a `github_token` via the web
 UI Settings page or the API endpoint `POST /api/v1/config/github` when you want
 AgentsView to publish gists. Remote access fields can be configured via the
-Settings page or CLI flags — see [Remote Access](/docs/remote-access/) for details.
+Settings page or CLI flags — see [Remote Access](/docs/remote-access/) for
+details.
 
 `agentsview daemon start` and `agentsview daemon restart` load the normal
 effective configuration from this file and supported environment variables; they
@@ -113,8 +113,8 @@ both are set.
 
 !!! note
 
-    Older configs may still contain `remote_access = true`. AgentsView still
-    reads that legacy key for backward compatibility, but new setups should use
+    Older configs may still contain `remote_access = true`. AgentsView still reads
+    that legacy key for backward compatibility, but new setups should use
     `require_auth = true`.
 
 ## Remote Hosts
@@ -152,12 +152,12 @@ deltas when fewer than half of the manifest files need fetching; see
 [Remote Access — Incremental Sync](/docs/remote-access/#incremental-sync).
 
 When a full or automatic data-version rebuild includes local sources, configured
-HTTP hosts join the same temporary-database bulk ingest and atomic swap. `--full`
-reparses the complete local and remote corpus without retransferring unchanged
-files from manifest-capable spokes. HTTP remote sync requires the collector and
-remote daemon to use the same remote-sync protocol version. After upgrading
-either host, upgrade the other before syncing again; incompatible peers fail
-before targets or archive data are exchanged.
+HTTP hosts join the same temporary-database bulk ingest and atomic swap.
+`--full` reparses the complete local and remote corpus without retransferring
+unchanged files from manifest-capable spokes. HTTP remote sync requires the
+collector and remote daemon to use the same remote-sync protocol version. After
+upgrading either host, upgrade the other before syncing again; incompatible
+peers fail before targets or archive data are exchanged.
 
 Each `remote_hosts.host` value must be unique and stable. It namespaces imported
 session IDs, the database skip cache, and the persistent mirror; changing it for
@@ -167,9 +167,8 @@ can reuse stale state. A configured HTTP host can be selected later with
 without a matching configured host, `--host` remains an SSH remote sync. HTTP
 remote sync is the recommended transport. SSH remote sync is deprecated and
 receives only critical fixes. HTTP failures are summarized with actionable
-messages for common cases such as token
-rejection, missing remote archive endpoints, connection refusal, DNS failures,
-and timeouts.
+messages for common cases such as token rejection, missing remote archive
+endpoints, connection refusal, DNS failures, and timeouts.
 
 Set `interval` to a positive duration such as `"5m"` to have a running collector
 daemon sync that host periodically. Zero or omitted disables the per-host
@@ -244,74 +243,77 @@ server-side and leave only local stubs; historical local Amp thread JSON files
 can still be parsed.
 
 The matching environment variable and `*_dirs` configuration key override an
-agent's default directories. Environment variables take precedence when both
-are set. An explicit empty `*_dirs` array, such as `grok_dirs = []`, clears that
+agent's default directories. Environment variables take precedence when both are
+set. An explicit empty `*_dirs` array, such as `grok_dirs = []`, clears that
 agent's default local directories, so local discovery finds nothing there.
 Matching `session_sources` entries for that agent still apply. Provider-wide
-exclusion is documented under [Disabling Session Providers](#disabling-session-providers).
-Omitting the key keeps its default directories.
+exclusion is documented under
+[Disabling Session Providers](#disabling-session-providers). Omitting the key
+keeps its default directories.
 
-| Agent                 | Default Directory                                                                | File Format                                                                                                                     |
-| --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Aider                 | No default; opt in with `AIDER_DIR` or `aider_dirs`                              | `.aider.chat.history.md` Markdown history files                                                                                 |
-| Amp (deprecated)      | `~/.local/share/amp/threads/`                                                    | Historical local JSON thread files                                                                                              |
-| Antigravity (IDE)     | `~/.gemini/antigravity/`                                                         | SQLite database per session                                                                                                     |
-| Antigravity CLI       | `~/.gemini/antigravity-cli/`                                                     | SQLite `conversations/<uuid>.db`, `<uuid>.trajectory.json` sidecars, or encrypted `.pb` files plus `brain/` and `history.jsonl` |
-| Claude Code           | `~/.claude/projects/`                                                            | JSONL per session                                                                                                               |
-| OpenClaude            | `~/.openclaude/projects/`                                                        | JSONL per session                                                                                                               |
-| Claude Cowork         | (platform-specific, see below)                                                   | Claude Desktop cowork sessions                                                                                                  |
-| Codebuff / Freebuff   | `~/.config/manicode/projects/`                                                   | Per-session `chat-messages.json` + `run-state.json` with subagent transcripts                                                  |
-| Codex                 | `~/.codex/sessions/` and `~/.codex/archived_sessions/`                           | JSONL per session                                                                                                               |
-| Command Code          | `~/.commandcode/projects/`                                                       | JSONL per session, optional `.meta.json` sidecar                                                                                |
-| Copilot CLI           | `~/.copilot/`                                                                    | JSONL per session under `session-state/`                                                                                        |
-| Devin CLI             | `~/.local/share/devin/` (Linux), `~/Library/Application Support/devin/` (macOS)  | Local CLI data rooted at the directory that contains `cli/`; session data is discovered under `<root>/cli/...`                  |
-| Cortex Code           | `~/.snowflake/cortex/conversations/`                                             | JSON / JSONL per session                                                                                                        |
-| Cursor                | `~/.cursor/projects/`                                                            | JSONL or plain-text transcripts                                                                                                 |
-| DeepSeek TUI          | `~/.codewhale/sessions/` and `~/.deepseek/sessions/`                             | JSON per session                                                                                                                |
-| DeepSeek Harness      | `~/.dsh/sessions/` (or `$DSH_HOME/sessions/`)                                    | Plain or multi-frame zstd JSONL per session                                                                                     |
-| Forge                 | `~/.forge/`                                                                      | SQLite database (`.forge.db`)                                                                                                   |
-| Gemini CLI            | `~/.gemini/`                                                                     | JSONL in `tmp/` subdirectory                                                                                                    |
-| Goose                 | (platform-specific, see below)                                                   | SQLite `sessions.db` with transcripts, tool activity, relationships, usage, and recorded costs                                  |
-| gptme                 | `~/.local/share/gptme/logs/`                                                     | JSONL logs                                                                                                                      |
-| Grok                  | `~/.grok/sessions/`                                                              | `summary.json` + optional `signals.json` + `chat_history.jsonl` transcript when present                                         |
-| Hermes Agent          | `~/.hermes/sessions/`                                                            | JSONL / JSON per session                                                                                                        |
-| iFlow                 | `~/.iflow/projects/`                                                             | JSONL per session                                                                                                               |
-| Kilo                  | `~/.local/share/kilo/`                                                           | SQLite DB or `storage/` JSON files                                                                                              |
-| Kimi                  | `~/.kimi/sessions/` and `~/.kimi-code/sessions/`                                 | JSONL per session                                                                                                               |
-| Kimi Work             | (platform-specific, see below)                                                   | JSONL per session (kimi-code kernel wire logs)                                                                                  |
-| Kiro CLI              | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/`                           | JSONL per session and SQLite database                                                                                           |
-| Kiro IDE              | (platform-specific, see below)                                                   | JSON / chat files                                                                                                               |
-| Kilo (legacy)         | (platform-specific, see below)                                                   | `tasks/<uuid>/{task_metadata.json,ui_messages.json,api_conversation_history.json}`                                              |
-| MiMoCode              | `~/.local/share/mimocode/`                                                       | SQLite DB or `storage/` JSON files                                                                                              |
-| Mistral Vibe          | `~/.vibe/logs/session/`                                                          | Per-session `messages.jsonl` plus `meta.json`                                                                                   |
-| OhMyPi                | `~/.omp/agent/sessions/`                                                         | JSONL per session                                                                                                               |
-| OpenClaw              | `~/.openclaw/assets/static/agents/` and `~/.kimi_openclaw/assets/static/agents/` | JSONL per session                                                                                                               |
-| OpenCode              | `~/.local/share/opencode/`                                                       | SQLite DB or `storage/` JSON files                                                                                              |
-| OpenHands CLI         | `~/.openhands/conversations/`                                                    | Per-conversation `base_state.json` + `events/*.json`                                                                            |
-| Omnigent              | `~/.omnigent/`                                                                   | SQLite `chat.db`, one session per conversation                                                                                  |
-| Pi                    | `~/.pi/agent/sessions/`                                                          | JSONL per session                                                                                                               |
-| Prime Agent           | `~/.prime/agent/sessions/`                                                       | Flat Pi-family JSONL sessions                                                                                                   |
-| Poolside              | `~/Library/Application Support/poolside/trajectories/` (macOS), `~/.local/state/poolside/trajectories/` (Linux), `%APPDATA%\\poolside\\trajectories\\` (Windows) | NDJSON trajectory files                                                                                                         |
-| Piebald               | `~/.local/share/piebald/`                                                        | SQLite database (`app.db`)                                                                                                      |
-| Posit Assistant       | `~/.posit/assistant/workspaces/`                                                 | Per-conversation `conversation.json` tree plus `lm-messages.jsonl` transcript                                                   |
-| Positron Assistant    | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
-| QClaw                 | `~/.qclaw/assets/static/agents/`                                                 | JSONL per session                                                                                                               |
-| Qoder                 | Legacy export roots, Qoder CLI CN, plus platform-specific `SharedClientCache` (see below) | JSONL project transcripts plus sidecar metadata                                                                                 |
-| Qwen Code             | `~/.qwen/projects/`                                                              | JSONL per session                                                                                                               |
-| QwenPaw               | `~/.copaw/workspaces/`                                                           | JSON session files                                                                                                              |
-| Reasonix              | `~/.reasonix/` and `~/AppData/Roaming/reasonix/`                                 | JSONL sessions plus `.jsonl.meta` sidecars                                                                                      |
-| RooCode               | (platform-specific, see below)                                                   | `history_item.json` + `ui_messages.json` per task                                                                              |
-| Shelley               | `~/.config/shelley/`                                                             | SQLite database (`shelley.db`)                                                                                                  |
-| Visual Studio Copilot | (platform-specific, see below)                                                   | Trace JSONL files                                                                                                               |
-| VS Code Copilot       | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
-| Windsurf              | (platform-specific, see below)                                                   | SQLite `workspaceStorage/<hash>/state.vscdb` workspace chat data                                                                |
-| Trae                  | (platform-specific, see below)                                                   | Legacy inline chat data in SQLite `workspaceStorage/<hash>/state.vscdb` and `globalStorage/state.vscdb`; modern encrypted layouts are detected as unsupported |
-| TraeX (TRAE CLI)      | `~/.trae/cli/sessions/` and `~/.trae/cli/archived_sessions/`                     | Codex-compatible rollout JSONL per session                                                                                      |
-| Warp                  | (platform-specific, see below)                                                   | SQLite database                                                                                                                 |
-| WorkBuddy             | `~/.workbuddy/projects/`                                                         | JSONL per session                                                                                                               |
-| ZCode                 | `~/.zcode/cli/db/` or `~/.zcode/cli/`                                            | SQLite database (`db.sqlite`) with usage rows                                                                                   |
-| Zed                   | (platform-specific, see below)                                                   | SQLite database (`threads/threads.db`)                                                                                          |
-| Zencoder              | `~/.zencoder/sessions/`                                                          | JSONL per session                                                                                                               |
+| Agent                 | Default Directory                                                                                                                                                | File Format                                                                                                                                                   |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Aider                 | No default; opt in with `AIDER_DIR` or `aider_dirs`                                                                                                              | `.aider.chat.history.md` Markdown history files                                                                                                               |
+| Amp (deprecated)      | `~/.local/share/amp/threads/`                                                                                                                                    | Historical local JSON thread files                                                                                                                            |
+| Antigravity (IDE)     | `~/.gemini/antigravity/`                                                                                                                                         | SQLite database per session                                                                                                                                   |
+| Antigravity CLI       | `~/.gemini/antigravity-cli/`                                                                                                                                     | SQLite `conversations/<uuid>.db`, `<uuid>.trajectory.json` sidecars, or encrypted `.pb` files plus `brain/` and `history.jsonl`                               |
+| Claude Code           | `~/.claude/projects/`                                                                                                                                            | JSONL per session                                                                                                                                             |
+| OpenClaude            | `~/.openclaude/projects/`                                                                                                                                        | JSONL per session                                                                                                                                             |
+| Claude Cowork         | (platform-specific, see below)                                                                                                                                   | Claude Desktop cowork sessions                                                                                                                                |
+| Codebuff / Freebuff   | `~/.config/manicode/projects/`                                                                                                                                   | Per-session `chat-messages.json` + `run-state.json` with subagent transcripts                                                                                 |
+| Codex                 | `~/.codex/sessions/` and `~/.codex/archived_sessions/`                                                                                                           | JSONL per session                                                                                                                                             |
+| Command Code          | `~/.commandcode/projects/`                                                                                                                                       | JSONL per session, optional `.meta.json` sidecar                                                                                                              |
+| Copilot CLI           | `~/.copilot/`                                                                                                                                                    | JSONL per session under `session-state/`                                                                                                                      |
+| Devin CLI             | `~/.local/share/devin/` (Linux), `~/Library/Application Support/devin/` (macOS)                                                                                  | Local CLI data rooted at the directory that contains `cli/`; session data is discovered under `<root>/cli/...`                                                |
+| Cortex Code           | `~/.snowflake/cortex/conversations/`                                                                                                                             | JSON / JSONL per session                                                                                                                                      |
+| Cursor                | `~/.cursor/projects/`                                                                                                                                            | JSONL or plain-text transcripts                                                                                                                               |
+| Cursor IDE            | (platform-specific, see below)                                                                                                                                   | Shared VS Code-style `globalStorage/state.vscdb` database, one session per Composer                                                                           |
+| DeepSeek TUI          | `~/.codewhale/sessions/` and `~/.deepseek/sessions/`                                                                                                             | JSON per session                                                                                                                                              |
+| DeepSeek Harness      | `~/.dsh/sessions/` (or `$DSH_HOME/sessions/`)                                                                                                                    | Plain or multi-frame zstd JSONL per session                                                                                                                   |
+| Forge                 | `~/.forge/`                                                                                                                                                      | SQLite database (`.forge.db`)                                                                                                                                 |
+| Gemini CLI            | `~/.gemini/`                                                                                                                                                     | JSONL in `tmp/` subdirectory                                                                                                                                  |
+| Goose                 | (platform-specific, see below)                                                                                                                                   | SQLite `sessions.db` with transcripts, tool activity, relationships, usage, and recorded costs                                                                |
+| gptme                 | `~/.local/share/gptme/logs/`                                                                                                                                     | JSONL logs                                                                                                                                                    |
+| Grok                  | `~/.grok/sessions/`                                                                                                                                              | `summary.json` + optional `signals.json` + `chat_history.jsonl` transcript when present                                                                       |
+| Hermes Agent          | `~/.hermes/sessions/`                                                                                                                                            | JSONL / JSON per session                                                                                                                                      |
+| iFlow                 | `~/.iflow/projects/`                                                                                                                                             | JSONL per session                                                                                                                                             |
+| IcodeMate             | `~/.local/share/icodemate/` and `~/.icodemate/cli/projects/`                                                                                                     | OpenCode-family storage, including per-session usage events                                                                                                   |
+| Kilo                  | `~/.local/share/kilo/`                                                                                                                                           | SQLite DB or `storage/` JSON files                                                                                                                            |
+| Kimi                  | `~/.kimi/sessions/` and `~/.kimi-code/sessions/`                                                                                                                 | JSONL per session                                                                                                                                             |
+| Kimi Work             | (platform-specific, see below)                                                                                                                                   | JSONL per session (kimi-code kernel wire logs)                                                                                                                |
+| Kiro CLI              | `~/.kiro/sessions/cli/` and `~/.local/share/kiro-cli/`                                                                                                           | JSONL per session and SQLite database                                                                                                                         |
+| Kiro IDE              | (platform-specific, see below)                                                                                                                                   | JSON / chat files                                                                                                                                             |
+| Kilo (legacy)         | (platform-specific, see below)                                                                                                                                   | `tasks/<uuid>/{task_metadata.json,ui_messages.json,api_conversation_history.json}`                                                                            |
+| MiMoCode              | `~/.local/share/mimocode/`                                                                                                                                       | SQLite DB or `storage/` JSON files                                                                                                                            |
+| Mistral Vibe          | `~/.vibe/logs/session/`                                                                                                                                          | Per-session `messages.jsonl` plus `meta.json`                                                                                                                 |
+| OhMyPi                | `~/.omp/agent/sessions/`                                                                                                                                         | JSONL per session                                                                                                                                             |
+| OpenClaw              | `~/.openclaw/assets/static/agents/` and `~/.kimi_openclaw/assets/static/agents/`                                                                                 | JSONL per session                                                                                                                                             |
+| OpenCode              | `~/.local/share/opencode/`                                                                                                                                       | SQLite DB or `storage/` JSON files                                                                                                                            |
+| OpenHands CLI         | `~/.openhands/conversations/`                                                                                                                                    | Per-conversation `base_state.json` + `events/*.json`                                                                                                          |
+| Omnigent              | `~/.omnigent/`                                                                                                                                                   | SQLite `chat.db`, one session per conversation                                                                                                                |
+| Pi                    | `~/.pi/agent/sessions/`                                                                                                                                          | JSONL per session                                                                                                                                             |
+| Prime Agent           | `~/.prime/agent/sessions/`                                                                                                                                       | Flat Pi-family JSONL sessions                                                                                                                                 |
+| Poolside              | `~/Library/Application Support/poolside/trajectories/` (macOS), `~/.local/state/poolside/trajectories/` (Linux), `%APPDATA%\\poolside\\trajectories\\` (Windows) | NDJSON trajectory files                                                                                                                                       |
+| Piebald               | `~/.local/share/piebald/`                                                                                                                                        | SQLite database (`app.db`)                                                                                                                                    |
+| Posit Assistant       | `~/.posit/assistant/workspaces/`                                                                                                                                 | Per-conversation `conversation.json` tree plus `lm-messages.jsonl` transcript                                                                                 |
+| Positron Assistant    | (platform-specific, see below)                                                                                                                                   | JSON / JSONL per session                                                                                                                                      |
+| QClaw                 | `~/.qclaw/assets/static/agents/`                                                                                                                                 | JSONL per session                                                                                                                                             |
+| Qoder                 | Legacy export roots, Qoder CLI CN, plus platform-specific `SharedClientCache` (see below)                                                                        | JSONL project transcripts plus sidecar metadata                                                                                                               |
+| Qwen Code             | `~/.qwen/projects/`                                                                                                                                              | JSONL per session                                                                                                                                             |
+| QwenPaw               | `~/.copaw/workspaces/`                                                                                                                                           | JSON session files                                                                                                                                            |
+| Reasonix              | `~/.reasonix/` and `~/AppData/Roaming/reasonix/`                                                                                                                 | JSONL sessions plus `.jsonl.meta` sidecars                                                                                                                    |
+| RooCode               | (platform-specific, see below)                                                                                                                                   | `history_item.json` + `ui_messages.json` per task                                                                                                             |
+| Shelley               | `~/.config/shelley/`                                                                                                                                             | SQLite database (`shelley.db`)                                                                                                                                |
+| Visual Studio Copilot | (platform-specific, see below)                                                                                                                                   | Trace JSONL files                                                                                                                                             |
+| VS Code Copilot       | (platform-specific, see below)                                                                                                                                   | JSON / JSONL per session                                                                                                                                      |
+| Windsurf              | (platform-specific, see below)                                                                                                                                   | SQLite `workspaceStorage/<hash>/state.vscdb` workspace chat data                                                                                              |
+| Trae                  | (platform-specific, see below)                                                                                                                                   | Legacy inline chat data in SQLite `workspaceStorage/<hash>/state.vscdb` and `globalStorage/state.vscdb`; modern encrypted layouts are detected as unsupported |
+| TraeX (TRAE CLI)      | `~/.trae/cli/sessions/` and `~/.trae/cli/archived_sessions/`                                                                                                     | Codex-compatible rollout JSONL per session                                                                                                                    |
+| Warp                  | (platform-specific, see below)                                                                                                                                   | SQLite database                                                                                                                                               |
+| WorkBuddy             | `~/.workbuddy/projects/`                                                                                                                                         | JSONL per session                                                                                                                                             |
+| ZCode                 | `~/.zcode/cli/db/` or `~/.zcode/cli/`                                                                                                                            | SQLite database (`db.sqlite`) with usage rows                                                                                                                 |
+| Zed                   | (platform-specific, see below)                                                                                                                                   | SQLite database (`threads/threads.db`)                                                                                                                        |
+| Zencoder              | `~/.zencoder/sessions/`                                                                                                                                          | JSONL per session                                                                                                                                             |
 
 DeepSeek Harness sessions are read from its default JSONL persistence backend,
 including plain `session.jsonl` and multi-frame `session.jsonl.zstd` files.
@@ -321,9 +323,9 @@ directly at one or more session roots. The optional SQLite persistence backend
 is not supported.
 
 Prime Agent support targets the current flat session layout in v0.7.0. That
-release migrates the older per-project layout when Prime Agent opens its
-session store, so open the current Prime Agent once before syncing a legacy
-archive with AgentsView.
+release migrates the older per-project layout when Prime Agent opens its session
+store, so open the current Prime Agent once before syncing a legacy archive with
+AgentsView.
 
 **Qoder default directories** include the legacy `~/.qoder/projects/` and
 `~/.qoderwork/projects/` export roots, the Qoder CLI CN store, and the current
@@ -333,17 +335,19 @@ IDE store:
 
 - **macOS:**
   `~/Library/Application Support/Qoder/SharedClientCache/cli/projects/`
+
 - **Linux:** `~/.config/Qoder/SharedClientCache/cli/projects/`
+
 - **Windows:** `%APPDATA%\Qoder\SharedClientCache\cli\projects\`
 
 Set `QODER_PROJECTS_DIR` or `qoder_project_dirs` to replace these defaults with
 one or more explicit roots.
 
 Grok sessions are read from `summary.json` (title, timestamps, project),
-optional `signals.json` (token counters), and `chat_history.jsonl` when
-present for the full transcript (user turns, assistant replies, thinking,
-and tool calls). If `chat_history.jsonl` is missing, AgentsView falls back
-to summary-only mode. Set `GROK_DIR` or `grok_dirs` to override the default
+optional `signals.json` (token counters), and `chat_history.jsonl` when present
+for the full transcript (user turns, assistant replies, thinking, and tool
+calls). If `chat_history.jsonl` is missing, AgentsView falls back to
+summary-only mode. Set `GROK_DIR` or `grok_dirs` to override the default
 directory.
 
 **Goose default directories** are:
@@ -353,18 +357,18 @@ directory.
 
 `GOOSE_PATH_ROOT` follows Goose's own path-root convention and resolves
 `<root>/data/sessions/sessions.db`. A `goose_dirs` entry may instead point
-directly to that sessions directory, its parent data directory, or the
-database file.
+directly to that sessions directory, its parent data directory, or the database
+file.
 
 Omnigent sessions are read from `~/.omnigent/chat.db`. Set `OMNIGENT_DIR` or
 `omnigent_dirs` to override the default directory. AgentsView creates one
-session per conversation and supports the split text-ID and current
-binary-UUID schema generations; the older single-table schema is detected and
-reported as unsupported without losing sessions already synced from it.
-Remote HTTP and SSH sync stay disabled for Omnigent because `chat.db`
-co-locates transcripts with authentication secrets. A metadata-only edit made
-directly in `chat.db` can be deferred by the immediate filesystem-event sync;
-the next scheduled reconciliation pass or an explicit resync picks it up.
+session per conversation and supports the split text-ID and current binary-UUID
+schema generations; the older single-table schema is detected and reported as
+unsupported without losing sessions already synced from it. Remote HTTP and SSH
+sync stay disabled for Omnigent because `chat.db` co-locates transcripts with
+authentication secrets. A metadata-only edit made directly in `chat.db` can be
+deferred by the immediate filesystem-event sync; the next scheduled
+reconciliation pass or an explicit resync picks it up.
 
 **VS Code Copilot default directories** vary by platform:
 
@@ -395,31 +399,35 @@ Windsurf stores workspace chats in `workspaceStorage/<hash>/state.vscdb`.
 
 **Trae default directories** vary by platform:
 
-- **macOS:** `~/Library/Application Support/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
+- **macOS:** `~/Library/Application Support/Trae/User/`, `Trae CN/User/`, and
+  `TRAE SOLO CN/User/`
 - **Linux:** `~/.config/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
 - **Windows:** `%APPDATA%/Trae/User/`, `Trae CN/User/`, and `TRAE SOLO CN/User/`
 
 Trae stores chats in `workspaceStorage/<hash>/state.vscdb` and
 `globalStorage/state.vscdb`. Override these roots with `TRAE_DIR` or the
-`trae_dirs` configuration key.
-AgentsView watches `workspaceStorage` and `globalStorage`, then reads chat
-records from those SQLite stores.
+`trae_dirs` configuration key. AgentsView watches `workspaceStorage` and
+`globalStorage`, then reads chat records from those SQLite stores.
 
 Trae legacy inline-message parsing is supported. Modern encrypted transcript
 layouts are detected and reported as unsupported. Remote HTTP and SSH target
-resolution is still disabled. A Trae root is a full user profile, and AgentsView does not
-archive or ship that profile wholesale. The follow-up path is Windsurf-style
-curated file targets only: `state.vscdb`, `state.vscdb-wal`, and
+resolution is still disabled. A Trae root is a full user profile, and AgentsView
+does not archive or ship that profile wholesale. The follow-up path is
+Windsurf-style curated file targets only: `state.vscdb`, `state.vscdb-wal`, and
 `workspace.json` for each supported workspace store.
 
 **Kimi Work default directories** vary by platform. Kimi Work is the
 kimi-desktop app (the "daimon" runtime); it stores conversations as kimi-code
-kernel wire logs under `<root>/wd_<workspace>_<hash>/<session>/agents/<agent>/wire.jsonl`:
+kernel wire logs under
+`<root>/wd_<workspace>_<hash>/<session>/agents/<agent>/wire.jsonl`:
 
-- **macOS:** `~/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
-- **Linux:** `~/.config/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **macOS:**
+  `~/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **Linux:**
+  `~/.config/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
   (or `~/.local/share/...` on some installs)
-- **Windows:** `%APPDATA%/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
+- **Windows:**
+  `%APPDATA%/kimi-desktop/daimon-share/daimon/runtime/kimi-code/home/sessions/`
 
 Only `conv-*` session directories are user conversations; auxiliary internal
 sessions (`ctitle-*`, `sklsum-*`, `dvlt-*`) are excluded from discovery. Set
@@ -445,6 +453,15 @@ transcript; subagent runs nest under a `subagents/` subdirectory of their parent
 conversation. All Posit Assistant hosts (Positron/VS Code extension, standalone,
 desktop, TUI) share this location. Set `POSIT_ASSISTANT_DIR` or
 `posit_assistant_dirs` if your installation stores its workspaces elsewhere.
+
+**Cursor IDE** is the graphical editor, distinct from the Cursor command-line
+agent above. AgentsView reads Composer sessions from Cursor's shared
+`globalStorage/state.vscdb` database. The default follows Cursor's normal user
+data directory on macOS, Linux, and Windows; set `CURSOR_IDE_DIR` or
+`cursor_ide_dirs` to override it. This database also contains authentication and
+extension state, so Cursor IDE is deliberately excluded from remote source-file
+sync. Parsed sessions still stay in the local archive and can be shared through
+the normal PostgreSQL or DuckDB paths.
 
 **Claude Cowork default directories** follow Claude Desktop's Electron user-data
 location:
@@ -472,28 +489,25 @@ independently.
 
 Subagent tool calls (basher, code-searcher, file-picker, code-reviewer, etc.)
 are parsed from the AI message blocks and displayed inline in the transcript
-view. The agent template (e.g. `base2-free-deepseek`, `base2-free-mimo`) is
-read from run-state.json's `agentType` field and shown in the session
-detail header. This is the classification label used server-side to pick
-the per-step LLM; the literal LLM is not persisted by the CLI and is
-not visible in the UI.
-Project names are derived from the session's working directory via git-root
-detection.
+view. The agent template (e.g. `base2-free-deepseek`, `base2-free-mimo`) is read
+from run-state.json's `agentType` field and shown in the session detail header.
+This is the classification label used server-side to pick the per-step LLM; the
+literal LLM is not persisted by the CLI and is not visible in the UI. Project
+names are derived from the session's working directory via git-root detection.
 
-Codebuff and Freebuff sessions report cost only. The CLI's on-disk
-format does not persist per-message input/output/cache tokens, so the
-daily usage model breakdown shows the cost-attributed agent template
-(e.g. `base2-deepseek`, `base2-free-minimax-m3`) without per-message
-token figures. Reported-cost rows ride as microdollars on `money.Money`
-like every other agent, and per-model rates for `base2-*` templates are
-not in the embedded pricing tables, so cache savings for these rows
-resolve to zero by design rather than an aggregator bug.
+Codebuff and Freebuff sessions report cost only. The CLI's on-disk format does
+not persist per-message input/output/cache tokens, so the daily usage model
+breakdown shows the cost-attributed agent template (e.g. `base2-deepseek`,
+`base2-free-minimax-m3`) without per-message token figures. Reported-cost rows
+ride as microdollars on `money.Money` like every other agent, and per-model
+rates for `base2-*` templates are not in the embedded pricing tables, so cache
+savings for these rows resolve to zero by design rather than an aggregator bug.
 
 Freebuff does not have its own environment variable or config key — it shares
-the Codebuff provider for discovery and the parser auto-classifies sessions.
-Set `CODEBUFF_DIR` or `codebuff_dirs` when manicode stores its projects
-directory somewhere other than `~/.config/manicode/projects`; this covers both
-Codebuff and Freebuff sessions.
+the Codebuff provider for discovery and the parser auto-classifies sessions. Set
+`CODEBUFF_DIR` or `codebuff_dirs` when manicode stores its projects directory
+somewhere other than `~/.config/manicode/projects`; this covers both Codebuff
+and Freebuff sessions.
 
 **OpenHands CLI shallow watch:** OpenHands stores each conversation in its own
 subdirectory, which would consume one recursive file watch per session and can
@@ -572,17 +586,18 @@ names and per-request token usage.
 - **macOS:**
   `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
 - **Linux:** `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
-- **Windows:** `~/AppData/Roaming/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
+- **Windows:**
+  `~/AppData/Roaming/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
 
-RooCode (rooveterinaryinc.roo-cline) is a VSCode extension that stores
-sessions under `tasks/<taskId>/` in VSCode's globalStorage directory. Each task
-directory contains `history_item.json` (metadata including task description,
-model name, workspace path, token counts, and recorded cost) and
-`ui_messages.json` (the Cline-format transcript with user prompts, assistant
-responses, reasoning blocks, and tool calls). AgentsView parses the
-`apiConfigName` field from `history_item.json` as the session model, extracts
-project names from the workspace path via git-root detection, and emits the
-recorded `totalCost` as a usage event for cost tracking.
+RooCode (rooveterinaryinc.roo-cline) is a VSCode extension that stores sessions
+under `tasks/<taskId>/` in VSCode's globalStorage directory. Each task directory
+contains `history_item.json` (metadata including task description, model name,
+workspace path, token counts, and recorded cost) and `ui_messages.json` (the
+Cline-format transcript with user prompts, assistant responses, reasoning
+blocks, and tool calls). AgentsView parses the `apiConfigName` field from
+`history_item.json` as the session model, extracts project names from the
+workspace path via git-root detection, and emits the recorded `totalCost` as a
+usage event for cost tracking.
 
 RooCode was shut down on May 15, 2026. ZooCode (Zoo-CodeInc.zoo-cline) is the
 active community fork and will be supported separately. Set `ROOCODE_DIR` or
@@ -592,7 +607,8 @@ active community fork and will be supported separately. Set `ROOCODE_DIR` or
 canonical lowercase `kilocode.kilo-code` global storage directory that VSCode
 writes on disk:
 
-- **macOS:** `~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code/`
+- **macOS:**
+  `~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code/`
 - **Linux:** `~/.config/Code/User/globalStorage/kilocode.kilo-code/`
 - **Windows:** `%APPDATA%/Code/User/globalStorage/kilocode.kilo-code/`
 
@@ -606,16 +622,15 @@ a reparse. Sessions are parsed through RooCode-descended Cline message handling
 linking). Set `KILO_LEGACY_DIR` or `kilo_legacy_dirs` when the legacy extension
 stores its data outside the standard locations.
 
-**Kilo (legacy) vs Kilo.** These are two different agents. *Kilo* (the
-`kilo` agent) is the OpenCode-based core at `~/.local/share/kilo/`; it
-covers both the Kilo CLI and the rebuilt Kilo Code VS Code extension,
-which share that same `kilo.db`. *Kilo (legacy)* (the `kilo-legacy` agent)
-is the legacy RooCode-derived VS Code extension that wrote per-task JSON
-under `kilocode.kilo-code/tasks/` and stopped receiving new sessions after
-Kilo rebuilt the extension on OpenCode (public beta 2026-03-10, GA
-2026-04-02). The `kilo-legacy` agent is frozen at that legacy format and
-only archives older sessions; newer Kilo VS Code activity appears under
-`kilo`.
+**Kilo (legacy) vs Kilo.** These are two different agents. *Kilo* (the `kilo`
+agent) is the OpenCode-based core at `~/.local/share/kilo/`; it covers both the
+Kilo CLI and the rebuilt Kilo Code VS Code extension, which share that same
+`kilo.db`. *Kilo (legacy)* (the `kilo-legacy` agent) is the legacy
+RooCode-derived VS Code extension that wrote per-task JSON under
+`kilocode.kilo-code/tasks/` and stopped receiving new sessions after Kilo
+rebuilt the extension on OpenCode (public beta 2026-03-10, GA 2026-04-02). The
+`kilo-legacy` agent is frozen at that legacy format and only archives older
+sessions; newer Kilo VS Code activity appears under `kilo`.
 
 **Antigravity CLI transcript sources:** Antigravity CLI has used both SQLite
 databases and AES-encrypted `.pb` files. AgentsView reads whichever source is
@@ -624,21 +639,21 @@ richest, in this order:
 1. **Decrypted trajectory sidecar.** For either format, if a
    `<uuid>.trajectory.json` file sits next to the source `.db` or `.pb` file
    (under `conversations/` or `implicit/`) and covers the session, AgentsView
-   uses it as the source of truth for the full structured transcript — messages,
-   tool calls, tool results, reasoning, and diffs. This is the highest-fidelity
-   source for both formats. These sidecars are written out-of-process by
-   [agy-reader](https://github.com/mjacobs/agy-reader), which performs the
-   decryption; AgentsView reads the resulting plain JSON as untrusted input and
-   needs no `ANTIGRAVITY_KEY` in this mode.
+   uses it as the source of truth for the full structured transcript —
+   messages, tool calls, tool results, reasoning, and diffs. This is the
+   highest-fidelity source for both formats. These sidecars are written
+   out-of-process by [agy-reader](https://github.com/mjacobs/agy-reader),
+   which performs the decryption; AgentsView reads the resulting plain JSON as
+   untrusted input and needs no `ANTIGRAVITY_KEY` in this mode.
 1. **SQLite trajectory database.** Newer Antigravity CLI releases write
    `conversations/<uuid>.db`. Without a covering sidecar (above), AgentsView
-   opens the database read-only and decodes the trajectory steps directly. This
-   direct decode is heuristic: it recovers prompts and tool-call names but not
-   full structured tool results, reasoning, or diffs — a degraded **summary
-   mode** transcript. If both `conversations/<uuid>.db` and
+   opens the database read-only and decodes the trajectory steps directly.
+   This direct decode is heuristic: it recovers prompts and tool-call names
+   but not full structured tool results, reasoning, or diffs — a degraded
+   **summary mode** transcript. If both `conversations/<uuid>.db` and
    `conversations/<uuid>.pb` exist, the SQLite database wins. Change detection
-   also factors in `<uuid>.db-wal` and `<uuid>.db-shm` so active sessions resync
-   as SQLite sidecar files move.
+   also factors in `<uuid>.db-wal` and `<uuid>.db-shm` so active sessions
+   resync as SQLite sidecar files move.
 1. **In-process `.pb` decryption.** With no sidecar present, set
    `ANTIGRAVITY_KEY` (base64-encoded AES key, 16/24/32 bytes after decoding)
    before starting AgentsView and it decrypts the `.pb` payloads itself,
@@ -765,22 +780,23 @@ codex_sessions_dirs = [
 
 The corresponding fields are `aider_dirs`, `amp_dirs`, `antigravity_dirs`,
 `antigravity_cli_dirs`, `claude_project_dirs`, `openclaude_project_dirs`,
-`cowork_dirs`, `devin_dirs`, `codebuff_dirs`, `codex_sessions_dirs`, `commandcode_project_dirs`,
-`copilot_dirs`, `cortex_dirs`, `cursor_project_dirs`,
-`deepseek_harness_sessions_dirs`, `deepseek_tui_sessions_dirs`, `forge_dirs`,
-`gemini_dirs`, `goose_dirs`,
+`cowork_dirs`, `devin_dirs`, `codebuff_dirs`, `codex_sessions_dirs`,
+`commandcode_project_dirs`, `copilot_dirs`, `cortex_dirs`,
+`cursor_project_dirs`, `deepseek_harness_sessions_dirs`,
+`deepseek_tui_sessions_dirs`, `forge_dirs`, `gemini_dirs`, `goose_dirs`,
 `gptme_dirs`, `grok_dirs`, `hermes_sessions_dirs`, `iflow_dirs`, `kilo_dirs`,
 `kilo_legacy_dirs`, `kimi_dirs`, `kimi_work_dirs`, `kiro_dirs`, `kiro_ide_dirs`,
 `mimocode_dirs`, `vibe_session_dirs`, `omp_dirs`, `openclaw_dirs`,
-`opencode_dirs`, `openhands_dirs`, `pi_dirs`, `prime_agent_dirs`, `piebald_dirs`,
-`posit_assistant_dirs`, `positron_dirs`, `qclaw_dirs`, `qoder_project_dirs`,
-`qwen_project_dirs`, `qwenpaw_dirs`, `reasonix_dirs`, `roocode_dirs`,
-`shelley_dirs`, `traex_sessions_dirs`, `visualstudio_copilot_dirs`,
-`vscode_copilot_dirs`, `windsurf_dirs`, `warp_dirs`,
-`workbuddy_project_dirs`, `zcode_dirs`, `zed_dirs`, and `zencoder_dirs`. Each
-accepts an array of paths. Environment variables take precedence over these
-arrays when both are set; otherwise, a non-empty array replaces the default
-path and an explicit empty array clears the default local directory.
+`opencode_dirs`, `openhands_dirs`, `pi_dirs`, `prime_agent_dirs`,
+`piebald_dirs`, `posit_assistant_dirs`, `positron_dirs`, `qclaw_dirs`,
+`qoder_project_dirs`, `qwen_project_dirs`, `qwenpaw_dirs`, `reasonix_dirs`,
+`roocode_dirs`, `shelley_dirs`, `traex_sessions_dirs`,
+`visualstudio_copilot_dirs`, `vscode_copilot_dirs`, `windsurf_dirs`,
+`warp_dirs`, `workbuddy_project_dirs`, `zcode_dirs`, `zed_dirs`, and
+`zencoder_dirs`. Each accepts an array of paths. Environment variables take
+precedence over these arrays when both are set; otherwise, a non-empty array
+replaces the default path and an explicit empty array clears the default local
+directory.
 
 All listed directories are discovered, watched, and synced independently.
 
@@ -801,21 +817,22 @@ the per-agent arrays, defaults, and environment variables above. Equivalent
 roots are deduplicated; a structured entry supplies the machine label when it
 duplicates a shorthand root. An omitted `machine` uses the local hostname.
 
-Machine attribution is captured when each session is first ingested. Changing
-an entry's `machine` value affects newly discovered sessions but does not
-relabel existing sessions during ordinary syncs or `agentsview sync --full`.
-Changing attribution for existing sessions is not currently supported.
+Machine attribution is captured when each session is first ingested. Changing an
+entry's `machine` value affects newly discovered sessions but does not relabel
+existing sessions during ordinary syncs or `agentsview sync --full`. Changing
+attribution for existing sessions is not currently supported.
 
-See [Filesystem Session Sync](/docs/filesystem-sync/) for multi-machine examples,
-transport safety, ID deduplication, watcher behavior, and the comparison with
-PostgreSQL.
+See [Filesystem Session Sync](/docs/filesystem-sync/) for multi-machine
+examples, transport safety, ID deduplication, watcher behavior, and the
+comparison with PostgreSQL.
 
 ### S3-Compatible Session Sources
 
-Claude, Codex, and Cursor session roots can also be `s3://` URIs. This is
-useful when several machines push their raw session files to object storage
-and one central AgentsView instance reads them without SSH access to those
-machines.
+Claude, Codex, Cursor, and IcodeMate session roots can also be `s3://` URIs.
+These are the providers whose current formats can be discovered and parsed as
+individual objects; future providers opt in through the same capability. This is
+useful when several machines push their raw session files to object storage and
+one central AgentsView instance reads them without SSH access to those machines.
 
 ```toml
 claude_project_dirs = [
@@ -831,6 +848,11 @@ codex_sessions_dirs = [
 cursor_project_dirs = [
   "~/.cursor/projects",
   "s3://agent-archive/laptop/raw/cursor",
+]
+
+icodemate_dirs = [
+  "~/.local/share/icodemate",
+  "s3://agent-archive/laptop/raw/icodemate",
 ]
 ```
 
@@ -864,6 +886,7 @@ s3://bucket/.../<machine>/raw/claude/<project>/<uuid>.jsonl
 s3://bucket/.../<machine>/raw/claude/<project>/subagents/.../agent-*.jsonl
 s3://bucket/.../<machine>/raw/codex/2026/06/24/rollout-*.jsonl
 s3://bucket/.../<machine>/raw/cursor/<project>/<uuid>.jsonl
+s3://bucket/.../<machine>/raw/icodemate/<project>/<session>.jsonl
 ```
 
 The machine name is derived from the path segment immediately before `raw`. If
@@ -885,19 +908,18 @@ manual sync, and the periodic directory scan.
 The parser infers a session's project from its `cwd`. It recognizes common
 worktree manager layouts, including the generic
 `worktrees/github.com/<owner>/<repository>/<worktree>` convention, where the
-repository segment becomes the project. Layouts it does not recognize — such
-as `~/code/{project}.worktrees/feat/<branch>/` — otherwise group sessions
-under `<branch>` rather than `{project}`. For those, register manual
-**path-prefix → project** rules from the **Rules** view on the
-[Data page](/docs/data/#rules), or let the
-[mapping editor](/docs/data/#create-a-project-mapping) create one from a project's
-observed session folders:
+repository segment becomes the project. Layouts it does not recognize — such as
+`~/code/{project}.worktrees/feat/<branch>/` — otherwise group sessions under
+`<branch>` rather than `{project}`. For those, register manual **path-prefix →
+project** rules from the **Rules** view on the [Data page](/docs/data/#rules),
+or let the [mapping editor](/docs/data/#create-a-project-mapping) create one
+from a project's observed session folders:
 
 ![Worktree mapping rules on the Data page](/docs/assets/generated/screenshots/worktree-mappings.png)
 
 - Mappings are explicit; there is no auto-discovery.
-- Each rule is scoped to one machine. The machine selector manages rules for
-  the local machine and for any remotely synced machine. Rules live in the
+- Each rule is scoped to one machine. The machine selector manages rules for the
+  local machine and for any remotely synced machine. Rules live in the
   writable archive that ingests that machine's sessions, which may be the
   source machine's local SQLite archive or a separate collector archive.
 - Each rule applies whenever a session's `cwd` falls under the configured
@@ -911,8 +933,8 @@ observed session folders:
   the first path segment under the prefix when it is named `<repo>.worktrees`,
   so a path like `/code/agentsview.worktrees/feature/frontend` resolves to
   project `agentsview`.
-- Rules created from the Data mapping editor record the mislabeled
-  project they corrected, shown as the rule's **original label**. The value is
+- Rules created from the Data mapping editor record the mislabeled project they
+  corrected, shown as the rule's **original label**. The value is
   informational and set once; to manually revert a reclassification, edit the
   rule's target back to that original label and apply again.
 - Disabling or deleting a rule does not rewrite sessions by itself. Sessions
@@ -1026,17 +1048,15 @@ native watcher and periodic-sync freshness behavior. AgentsView reads only
 session identity and timestamp metadata from accepted hint records and neither
 stores nor logs submitted prompt text.
 
-For each configured local Codex session root, AgentsView probes
-`history.jsonl` in the cleaned root's parent. For example, a custom
-`/data/custom/sessions` root probes `/data/custom/history.jsonl`. It does not
-search ancestors or the rollout archive for another history file. Missing hint
-files remain cheap probes.
+For each configured local Codex session root, AgentsView probes `history.jsonl`
+in the cleaned root's parent. For example, a custom `/data/custom/sessions` root
+probes `/data/custom/history.jsonl`. It does not search ancestors or the rollout
+archive for another history file. Missing hint files remain cheap probes.
 
 The initial daemon poll bootstraps at most the newest 4 MiB of each history file
 and accepts records at most 24 hours old. If AgentsView restarts during a long
 autonomous run whose last persisted prompt is outside either bound, that rollout
-uses native-watcher freshness until another persisted prompt makes it hot
-again.
+uses native-watcher freshness until another persisted prompt makes it hot again.
 
 For `s3://` Claude, Codex, and Cursor roots, change detection uses object size,
 `LastModified`, and available object fingerprints such as ETag, version ID, and
@@ -1188,19 +1208,22 @@ curl http://127.0.0.1:8080/api/v1/sync/status
 
 ## Privacy and Telemetry
 
-By default, all session data stays on your local machine in SQLite. AgentsView
-never sends session content, project names, prompts, file paths, or hostnames
-anywhere.
+By default, all session data stays on your local machine in SQLite. Normal
+browsing, search, and reports do not send session content, project names,
+prompts, file paths, or hostnames anywhere.
 
 Optional features that send data externally when you enable them:
 
-- [PostgreSQL sync](/docs/pg-sync/) (`pg push`) sends session data to a PostgreSQL
-  database you configure.
-- The [DuckDB mirror](/docs/duckdb/) writes a local DuckDB file by default; data only
-  leaves the machine if you expose the mirror over a remote Quack endpoint.
-- [Generated insights](/docs/recall/#current-surface) sends scoped session content to
-  the configured endpoint when `[insights]` is set, or to the selected agent
-  CLI when it is absent.
+- [Hosted Raw Sync](/docs/hosted-raw-sync/) sends original provider files to a
+  hosted custody service configured by your deployment operator.
+- [PostgreSQL sync](/docs/pg-sync/) (`pg push`) sends session data to a
+  PostgreSQL database you configure.
+- The [DuckDB mirror](/docs/duckdb/) writes a local DuckDB file by default; data
+  only leaves the machine if you expose the mirror over a remote Quack
+  endpoint.
+- [Generated insights](/docs/recall/#current-surface) sends scoped session
+  content to the configured endpoint when `[insights]` is set, or to the
+  selected agent CLI when it is absent.
 - [Publish to Gist](/docs/usage/#publish-to-gist) uploads a session to GitHub.
 
 The automatic outbound requests are update checks and an anonymous daemon ping:

--- a/docs/hosted-raw-sync.md
+++ b/docs/hosted-raw-sync.md
@@ -1,59 +1,58 @@
 ---
 title: Hosted Raw Sync
-description: Architecture, security boundaries, and delivery status for raw-first hosted sync
+description: Keep original session files in hosted custody with authenticated, resumable uploads
 ---
 
-Hosted raw sync is the planned, in-development path for sending original agent
-source artifacts to a hosted AgentsView service. The server will keep the
-authoritative raw generation, then derive PostgreSQL sessions and embeddings
-from it.
+Hosted raw sync keeps original agent session files from one or more machines in
+hosted custody. Each laptop captures supported local sources, authenticates as a
+provisioned device, resumes interrupted uploads, and remembers durable progress
+across restarts. `agentsview raw-sync watch` keeps the hosted copy current.
 
 ```mermaid
 flowchart LR
     Watcher["Laptop watcher"] -->|"authenticated raw upload"| Custody["Immutable raw custody"]
-    Custody --> Parser["Server parsing"]
+    Custody -. "future" .-> Parser["Server parsing"]
     Parser --> PostgreSQL["PostgreSQL projection"]
     PostgreSQL --> Embeddings["Server embeddings"]
 ```
 
-This moves long-running parsing and embedding work off laptops and gives the
-server enough source material to reparse after parser fixes or rebuild derived
-data after loss.
+The raw archive gives an operator the source material needed to rebuild derived
+data. Version 0.42.0 ships capture and upload; it does not yet parse accepted
+generations into hosted sessions or build server-owned embeddings.
 
-!!! warning "Not available for use yet"
+!!! note "You need provisioned device credentials"
 
-    AgentsView now has a laptop capture-and-upload daemon and the matching raw
-    custody transport. It still does not expose device enrollment, server-side
-    parsing, or server-owned embeddings. An operator-provisioned device can test raw
-    custody, but no supported command enables hosted raw sync end to end.
+    The laptop command is ready to use once the hosted deployment operator gives you
+    a server URL, device ID, and device credential. Device enrollment and revocation
+    are operator-managed; AgentsView does not yet provide a public enrollment
+    command or HTTP endpoint.
 
-    The existing [`agentsview pg push`](/docs/pg-sync/) workflow remains supported
-    and unchanged. It parses sessions locally and can build embeddings locally
-    before pushing derived rows and vectors to PostgreSQL.
+    Use [`agentsview pg push`](/docs/pg-sync/) when the shared server must provide
+    browsable sessions today. It parses sessions locally and can build embeddings
+    locally before pushing derived rows and vectors to PostgreSQL.
 
 The tracked delivery sequence and production acceptance criteria live in
 [GitHub issue #1352](https://github.com/kenn-io/agentsview/issues/1352).
 
 ## Delivery status
 
-| Layer                  | Status                                                                             | Current boundary                                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Raw custody            | Foundation implemented in [#1396](https://github.com/kenn-io/agentsview/pull/1396) | Validated objects, canonical manifests, durable receipts, source-head fencing, and parse-job creation               |
-| Device authentication  | Foundation implemented in [#1459](https://github.com/kenn-io/agentsview/pull/1459) | Credential exchange, scoped short-lived tokens, server-derived identity, and revocation; no enrollment command yet  |
-| HTTP raw transport     | Implemented through resumable object upload                                        | Credential exchange, negotiation, upload, and manifest commit; no remote status endpoint                            |
-| Laptop capture         | Implemented for supported local provider sources                                   | Watching, bounded audits, SQLite snapshots, durable spooling, checkpoints, retries, and local status                |
-| Server derivation      | Not implemented                                                                    | Manifest materialization, parsing, transactional PostgreSQL projection, and embeddings are not running              |
-| Operations and cutover | Not implemented                                                                    | Retention, garbage collection, disaster rebuilds, rollout controls, and migration from `pg push` remain future work |
+| Layer                  | Status        | Current boundary                                                                                                             |
+| ---------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Raw custody            | Available     | Validated objects, canonical manifests, durable receipts, source-head fencing, and parse-job creation                        |
+| Device authentication  | Available     | Credential exchange, scoped short-lived tokens, server-derived identity, and revocation; enrollment remains operator-managed |
+| HTTP raw transport     | Available     | Missing-object negotiation, resumable upload, and manifest commit; status is local only                                      |
+| Laptop capture         | Available     | Watching, bounded audits, safe SQLite snapshots, durable spooling, checkpoints, retries, and local status                    |
+| Server derivation      | Not available | Accepted generations are not yet parsed into PostgreSQL sessions or embeddings                                               |
+| Operations and cutover | Not available | Retention, garbage collection, disaster rebuilds, and migration from `pg push` remain future work                            |
 
-The broader “device enrollment and authenticated raw transport” delivery item in
-#1352 remains incomplete because there is no supported way to enroll a device,
-and accepted raw generations are not yet turned into hosted sessions.
+The broader delivery issue remains open because public enrollment, hosted
+session derivation, and production lifecycle controls are not finished.
 
 ## Laptop raw watch daemon
 
 `agentsview raw-sync watch` watches supported local provider roots, captures
 their original files, and uploads durable generations. It does not parse
-sessions or write the local SQLite archive. S3 roots are excluded.
+sessions or write the normal local SQLite archive. S3 roots are excluded.
 
 The server URL and device ID may be flags or environment variables. The device
 credential is environment-only so it does not appear in process arguments:
@@ -173,7 +172,7 @@ worker scratch space, plus access controls around device enrollment and
 revocation. PostgreSQL row-level security remains a planned defense-in-depth
 layer; the current foundation does not configure it.
 
-Do not build integrations against the partial HTTP routes, internal Go packages,
-or raw PostgreSQL tables yet. The complete public protocol, operator controls,
-compatibility policy, and recovery tooling will be documented when those entry
-points exist.
+Treat the HTTP routes as the protocol between the bundled laptop client and a
+hosted AgentsView deployment, not as a general integration API. Public operator
+controls, compatibility policy, and recovery tooling will be documented when
+those entry points exist.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ description: Documentation map and mental model for AgentsView, the local-first 
 # AgentsView Documentation
 
 AgentsView is a local-first system of record for AI coding agent sessions. A
-background daemon syncs sessions from more than 50 agent harnesses into a
-SQLite archive on your machine, and serves them through a web UI, desktop app,
-CLI, REST API, and MCP server.
+background daemon syncs sessions from more than 60 agent formats into a SQLite
+archive on your machine, and serves them through a web UI, desktop app, CLI,
+REST API, and MCP server.
 
 New here? The [product overview](/) explains what AgentsView is for, and the
 [five-minute guide](/guide/) walks the whole loop with screenshots. This
@@ -21,38 +21,38 @@ documentation is the comprehensive, task-oriented reference.
 
 ## Start here
 
-| If you want to… | Read… |
-| --- | --- |
-| Install and see your sessions in under a minute | [Quick Start](/docs/quickstart/) |
-| Learn the web interface | [Usage Guide](/docs/usage/) |
-| See when agents ran, overlapped, and what it cost | [Activity](/docs/activity/) |
-| Get daily token and cost reports | [Token Usage & Costs](/docs/token-usage/) |
-| Search transcripts by meaning, not just words | [Semantic Search](/docs/semantic-search/) |
-| Score session health and outcomes | [Session Intelligence](/docs/session-intelligence/) |
-| Browse extracted, provenance-linked knowledge | [Recall](/docs/recall/) |
-| Give agents and scripts access to the archive | [MCP Server](/docs/mcp/) and [Session API](/docs/session-api/) |
-| Share sessions across machines or a team | [PostgreSQL Sync](/docs/pg-sync/), [DuckDB Mirror](/docs/duckdb/), [Filesystem Session Sync](/docs/filesystem-sync/) |
-| Configure discovery, paths, and settings | [Configuration](/docs/configuration/) |
-| Look up a command or flag | [CLI Reference](/docs/commands/) |
+| If you want to…                                   | Read…                                                                                                                                                           |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Install and see your sessions in under a minute   | [Quick Start](/docs/quickstart/)                                                                                                                                |
+| Learn the web interface                           | [Usage Guide](/docs/usage/)                                                                                                                                     |
+| See when agents ran, overlapped, and what it cost | [Activity](/docs/activity/)                                                                                                                                     |
+| Get daily token and cost reports                  | [Token Usage & Costs](/docs/token-usage/)                                                                                                                       |
+| Search transcripts by meaning, not just words     | [Semantic Search](/docs/semantic-search/)                                                                                                                       |
+| Score session health and outcomes                 | [Session Intelligence](/docs/session-intelligence/)                                                                                                             |
+| Browse extracted, provenance-linked knowledge     | [Recall](/docs/recall/)                                                                                                                                         |
+| Give agents and scripts access to the archive     | [MCP Server](/docs/mcp/) and [Session API](/docs/session-api/)                                                                                                  |
+| Share sessions across machines or a team          | [Hosted Raw Sync](/docs/hosted-raw-sync/), [PostgreSQL Sync](/docs/pg-sync/), [DuckDB Mirror](/docs/duckdb/), [Filesystem Session Sync](/docs/filesystem-sync/) |
+| Configure discovery, paths, and settings          | [Configuration](/docs/configuration/)                                                                                                                           |
+| Look up a command or flag                         | [CLI Reference](/docs/commands/)                                                                                                                                |
 
 ## The mental model
 
 **The daemon owns the archive.** The desktop app and freshness-sensitive CLI
 commands share one detached local daemon that holds the writable SQLite
-connection, watches your agents' session directories, and syncs new messages
-as they are written. Read-only commands attach to a warm daemon or fall back
-to a direct read-only view, so one-off scripts stay fast. See
+connection, watches your agents' session directories, and syncs new messages as
+they are written. Read-only commands attach to a warm daemon or fall back to a
+direct read-only view, so one-off scripts stay fast. See
 [`agentsview daemon`](/docs/commands/#agentsview-daemon).
 
 **SQLite is the system of record.** Every parsed session lives in
 `~/.agentsview/` with full-text indexes. Optional backends extend it:
-[PostgreSQL](/docs/pg-sync/) for a shared team view and
-[DuckDB](/docs/duckdb/) for analytical reads. Both are mirrors pushed from
-SQLite, never the source of truth.
+[PostgreSQL](/docs/pg-sync/) for a shared team view and [DuckDB](/docs/duckdb/)
+for analytical reads. Both are mirrors pushed from SQLite, never the source of
+truth.
 
-**Everything is an interface over the same archive.** The web UI, desktop
-app, CLI reports, REST endpoints, SSE streams, and MCP tools all read the same
-data, so people and agents see the same history.
+**Everything is an interface over the same archive.** The web UI, desktop app,
+CLI reports, REST endpoints, SSE streams, and MCP tools all read the same data,
+so people and agents see the same history.
 
 ## How it works
 
@@ -60,17 +60,17 @@ data, so people and agents see the same history.
 
 AgentsView watches your agent session directories for changes, parses each
 agent's format, and stores structured data in SQLite with full-text search
-indexes. The embedded web frontend provides browsing, search, and analytics
-over the REST API.
+indexes. The embedded web frontend provides browsing, search, and analytics over
+the REST API.
 
 ## Privacy
 
-Session data stays on your machine. There are no accounts and no cloud
-services; the server binds to `127.0.0.1` unless you explicitly configure
-[remote access](/docs/remote-access/). Sharing beyond the machine happens only
-through sync targets you configure and control. An anonymous, content-free
-daemon liveness ping is the only telemetry, and
-`AGENTSVIEW_TELEMETRY_ENABLED=0` disables it.
+Session data stays on your machine by default. The server binds to `127.0.0.1`
+unless you explicitly configure [remote access](/docs/remote-access/). Data
+leaves the machine only for features you choose, such as hosted raw sync, a
+PostgreSQL target, remote DuckDB access, Generated Insights, or publishing a
+session to GitHub. An anonymous, content-free daemon liveness ping is the only
+telemetry, and `AGENTSVIEW_TELEMETRY_ENABLED=0` disables it.
 
 ## Human and machine-readable pages
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -50,7 +50,7 @@ The Markdown pages are canonical for machine readers; the HTML routes drop the
 - [DuckDB Mirror](https://agentsview.io/docs/duckdb.md): Mirror the SQLite archive into DuckDB, locally or over the Quack remote protocol.
 - [Filesystem Session Sync](https://agentsview.io/docs/filesystem-sync.md): View sessions from multiple machines by transporting native session directories.
 - [Artifact Folder Sync](https://agentsview.io/docs/artifact-sync.md): Exchange normalized sessions between archives through a trusted folder.
-- [Hosted Raw Sync](https://agentsview.io/docs/hosted-raw-sync.md): Architecture, security boundaries, and delivery status for raw-first hosted sync (in development).
+- [Hosted Raw Sync](https://agentsview.io/docs/hosted-raw-sync.md): Keep original provider files from several devices in one hosted archive with authenticated, resumable uploads.
 - [Remote Access](https://agentsview.io/docs/remote-access.md): Access AgentsView from other devices on your network.
 
 ## Project

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -3,27 +3,27 @@ title: PostgreSQL Sync
 description: Share sessions across machines with PostgreSQL push sync, an auto-push service, and a read-only server
 ---
 
-AgentsView stores sessions locally in SQLite by default. PostgreSQL
-sync lets you push sessions from one or more machines into a shared
-PostgreSQL database, keep that database current with an optional
-auto-push watcher or OS service, then serve a read-only web UI from
-it — useful for team dashboards or multi-machine setups.
+AgentsView stores sessions locally in SQLite by default. PostgreSQL sync lets
+you push sessions from one or more machines into a shared PostgreSQL database,
+keep that database current with an optional auto-push watcher or OS service,
+then serve a read-only web UI from it — useful for team dashboards or
+multi-machine setups.
 
 The PostgreSQL usage optimization baseline and its architecture boundary are
 recorded in `docs/internal/pg-usage-native-optimization.md`.
 
-The sync direction is one-way: SQLite to PostgreSQL. Each machine
-pushes its own sessions; `pg serve` reads from the shared database.
-The resulting UI includes the session browser, analytics dashboard,
-search, and, as of 0.23.0, the Usage dashboard as well.
+The sync direction is one-way: SQLite to PostgreSQL. Each machine pushes its own
+sessions; `pg serve` reads from the shared database. The resulting UI includes
+the session browser, analytics dashboard, search, and, as of 0.23.0, the Usage
+dashboard as well.
 
-!!! note "Separate hosted raw-sync work"
+!!! note "Separate hosted raw sync"
 
-    [Hosted Raw Sync](/docs/hosted-raw-sync/) is a separate, in-development path in
-    which a hosted server retains original provider artifacts and performs
-    parsing and embedding. Writable `pg serve` deployments now expose part of its
-    authenticated HTTP control plane. This does not change `pg push`, `pg push
-    --watch`, or the read-only session UI and APIs documented on this page.
+    [Hosted Raw Sync](/docs/hosted-raw-sync/) is a separate path that keeps original
+    provider artifacts in hosted custody through authenticated, resumable uploads.
+    It does not yet turn accepted generations into hosted sessions or embeddings.
+    This does not change `pg push`, `pg push --watch`, or the read-only session UI
+    and APIs documented on this page.
 
 ## Quick Start
 
@@ -37,14 +37,14 @@ url = "postgres://user:pass@host:5432/dbname?sslmode=require"
 machine_name = "my-laptop"
 ```
 
-The `machine_name` identifies which machine pushed each session.
-It defaults to the system hostname if omitted. It must not be
-`"local"` (reserved for the local SQLite sentinel).
+The `machine_name` identifies which machine pushed each session. It defaults to
+the system hostname if omitted. It must not be `"local"` (reserved for the local
+SQLite sentinel).
 
 For multiple PostgreSQL destinations, use named `[pg.NAME]` blocks and
-`default_pg` instead of the legacy single `[pg]` block. Named target names
-are normalized case-insensitively, and `all`, `local`, plus the legacy `[pg]`
-field names `url`, `schema`, `machine_name`, `allow_insecure`, `projects`, and
+`default_pg` instead of the legacy single `[pg]` block. Named target names are
+normalized case-insensitively, and `all`, `local`, plus the legacy `[pg]` field
+names `url`, `schema`, `machine_name`, `allow_insecure`, `projects`, and
 `exclude_projects` are unavailable as `[pg.NAME]` names.
 
 ### 2. Push Sessions
@@ -53,9 +53,8 @@ field names `url`, `schema`, `machine_name`, `allow_insecure`, `projects`, and
 agentsview pg push
 ```
 
-This one-shot command syncs all local sessions, messages, and tool
-calls to PostgreSQL. The schema is created automatically on first
-push.
+This one-shot command syncs all local sessions, messages, and tool calls to
+PostgreSQL. The schema is created automatically on first push.
 
 To keep PostgreSQL current automatically, run the foreground watcher:
 
@@ -75,13 +74,13 @@ agentsview pg service install
 agentsview pg serve
 ```
 
-Opens the read-only web UI at `http://127.0.0.1:8080`, backed
-entirely by PostgreSQL. It does not use local SQLite or file watching, and its
-session UI and APIs do not accept session uploads. A writable deployment can
-also expose the separate, partial [hosted raw-sync control
-plane](/docs/hosted-raw-sync/#http-control-plane).
+Opens the read-only web UI at `http://127.0.0.1:8080`, backed entirely by
+PostgreSQL. It does not use local SQLite or file watching, and its session UI
+and APIs do not accept session uploads. A writable deployment can also expose
+the separate
+[hosted raw-sync control plane](/docs/hosted-raw-sync/#http-control-plane).
 
----
+______________________________________________________________________
 
 ## Commands
 
@@ -93,53 +92,49 @@ Sync sessions from the local SQLite database to PostgreSQL.
 agentsview pg push [target] [flags]
 ```
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--all` | `false` | Push every configured PG target sequentially |
-| `--full` | `false` | Force full local resync and re-push, bypassing change detection |
-| `--no-vectors` | `false` | Skip the semantic-search vector phase for this run |
-| `--projects` | | Comma-separated projects to push (inclusive) |
-| `--exclude-projects` | | Comma-separated projects to exclude |
-| `--all-projects` | `false` | Ignore configured project filters for this run |
-| `--watch` | `false` | Run continuously, pushing on change plus a periodic floor |
-| `--debounce` | `30s` | Coalesce window after a filesystem change before pushing (`--watch` only) |
-| `--interval` | `15m` | Periodic floor push interval (`--watch` only) |
+| Flag                 | Default | Description                                                               |
+| -------------------- | ------- | ------------------------------------------------------------------------- |
+| `--all`              | `false` | Push every configured PG target sequentially                              |
+| `--full`             | `false` | Force full local resync and re-push, bypassing change detection           |
+| `--no-vectors`       | `false` | Skip the semantic-search vector phase for this run                        |
+| `--projects`         |         | Comma-separated projects to push (inclusive)                              |
+| `--exclude-projects` |         | Comma-separated projects to exclude                                       |
+| `--all-projects`     | `false` | Ignore configured project filters for this run                            |
+| `--watch`            | `false` | Run continuously, pushing on change plus a periodic floor                 |
+| `--debounce`         | `30s`   | Coalesce window after a filesystem change before pushing (`--watch` only) |
+| `--interval`         | `15m`   | Periodic floor push interval (`--watch` only)                             |
 
-Without `--watch`, push is on-demand — run it whenever you want
-to sync. With `--watch`, the command stays in the foreground and
-keeps pushing until interrupted.
+Without `--watch`, push is on-demand — run it whenever you want to sync. With
+`--watch`, the command stays in the foreground and keeps pushing until
+interrupted.
 
-When no target is passed, `pg push` uses the effective default target.
-Pass one named target explicitly to push just that destination, or use
-`--all` to fan out across every configured target. `--all --watch` is
-rejected.
+When no target is passed, `pg push` uses the effective default target. Pass one
+named target explicitly to push just that destination, or use `--all` to fan out
+across every configured target. `--all --watch` is rejected.
 
 **What happens on push:**
 
 1. Runs a local sync to pick up any new or modified session files
-2. Compares local sessions against the PostgreSQL watermark to
-   find what changed since the last push
-3. Upserts sessions, messages, tool calls, and (as of 0.30.0)
+1. Compares local sessions against the PostgreSQL watermark to find what changed
+   since the last push
+1. Upserts sessions, messages, tool calls, and (as of 0.30.0)
    [curation metadata](#curation-metadata) in batches of 50
-4. Advances the watermark timestamp on success
+1. Advances the watermark timestamp on success
 
-Incremental pushes use a two-layer fingerprint to skip
-unchanged sessions: first, session metadata fields (project,
-agent, timestamps, message counts) are compared; then, per-
-session message statistics (count, content length sum/max/min,
-system message ordinals, tool call counts) are checked against
-PostgreSQL. Use `--full` to bypass both layers and re-push
-everything — for example, after a schema reset or when message
-content was rewritten in place.
+Incremental pushes use a two-layer fingerprint to skip unchanged sessions:
+first, session metadata fields (project, agent, timestamps, message counts) are
+compared; then, per- session message statistics (count, content length
+sum/max/min, system message ordinals, tool call counts) are checked against
+PostgreSQL. Use `--full` to bypass both layers and re-push everything — for
+example, after a schema reset or when message content was rewritten in place.
 
-If any sessions fail to push, the watermark is not advanced so
-they are retried on the next run. The exit code is 1 when any
-errors occur, 0 otherwise.
+If any sessions fail to push, the watermark is not advanced so they are retried
+on the next run. The exit code is 1 when any errors occur, 0 otherwise.
 
 #### Automatic Push Watcher
 
-As of 0.32.0, `agentsview pg push --watch` runs a long-lived
-auto-push daemon in the foreground:
+As of 0.32.0, `agentsview pg push --watch` runs a long-lived auto-push daemon in
+the foreground:
 
 ```bash
 agentsview pg push --watch
@@ -147,36 +142,33 @@ agentsview pg push --watch --debounce 1m
 agentsview pg push --watch --interval 5m
 ```
 
-The watcher performs one initial local sync plus PostgreSQL push,
-then pushes again after session-directory changes settle for the
-debounce window. Ordinary changes carry a bounded set of changed paths to the
-daemon, so a one-session edit does not rediscover the full local archive.
-Watcher overflow, lost events, and ambiguous renames promote to authoritative
-reconciliation of the currently available provider roots. The interval acts as
-a floor: even if filesystem events are missed or a root cannot be watched
-because of OS watch limits, the next interval push catches up.
+The watcher performs one initial local sync plus PostgreSQL push, then pushes
+again after session-directory changes settle for the debounce window. Ordinary
+changes carry a bounded set of changed paths to the daemon, so a one-session
+edit does not rediscover the full local archive. Watcher overflow, lost events,
+and ambiguous renames promote to authoritative reconciliation of the currently
+available provider roots. The interval acts as a floor: even if filesystem
+events are missed or a root cannot be watched because of OS watch limits, the
+next interval push catches up.
 
 Operational details:
 
-- Only one watcher can run per AgentsView data directory; a
-  runtime lock prevents competing pushes from racing watermarks.
-- PostgreSQL connections are opened lazily and reset after errors,
-  so a transiently unavailable database is retried on the next
-  trigger instead of crashing the watcher.
-- On shutdown (`Ctrl+C`, `SIGTERM`), the watcher attempts one
-  bounded final flush.
-- Logs are written to `pg-watch.log` under the AgentsView data
-  directory.
-- The watcher uses the selected PostgreSQL target, or the
-  `default_pg` target when no name is passed, along with the same
-  machine name, project filters, classifier settings, and
-  `result_content_blocked_categories` behavior as one-shot
-  `pg push`.
+- Only one watcher can run per AgentsView data directory; a runtime lock
+  prevents competing pushes from racing watermarks.
+- PostgreSQL connections are opened lazily and reset after errors, so a
+  transiently unavailable database is retried on the next trigger instead of
+  crashing the watcher.
+- On shutdown (`Ctrl+C`, `SIGTERM`), the watcher attempts one bounded final
+  flush.
+- Logs are written to `pg-watch.log` under the AgentsView data directory.
+- The watcher uses the selected PostgreSQL target, or the `default_pg` target
+  when no name is passed, along with the same machine name, project filters,
+  classifier settings, and `result_content_blocked_categories` behavior as
+  one-shot `pg push`.
 
 #### Project Filtering
 
-By default, `pg push` syncs all projects. Use project filters
-to push a subset:
+By default, `pg push` syncs all projects. Use project filters to push a subset:
 
 ```bash
 # Push only these projects
@@ -189,11 +181,11 @@ agentsview pg push --exclude-projects scratch
 agentsview pg push --all-projects
 ```
 
-`--projects` and `--exclude-projects` are mutually exclusive.
-`--all-projects` cannot be combined with either.
+`--projects` and `--exclude-projects` are mutually exclusive. `--all-projects`
+cannot be combined with either.
 
-Project filters can also be set in `config.toml` so you don't
-need to pass them on every run:
+Project filters can also be set in `config.toml` so you don't need to pass them
+on every run:
 
 ```toml
 [pg]
@@ -203,63 +195,54 @@ projects = ["alpha", "beta"]
 ```
 
 CLI flags override config values. Use
-[`agentsview projects`](/docs/commands/#agentsview-projects) to list
-available project names.
+[`agentsview projects`](/docs/commands/#agentsview-projects) to list available
+project names.
 
-Filtered pushes keep their own local push watermark for each
-target/filter set. For example, repeated
-`agentsview pg push --projects alpha,beta` runs use a different
-watermark from unfiltered pushes and from
-`agentsview pg push --projects gamma`. This keeps allow-list pushes
-incremental without advancing the unfiltered/global cursor.
+Filtered pushes keep their own local push watermark for each target/filter set.
+For example, repeated `agentsview pg push --projects alpha,beta` runs use a
+different watermark from unfiltered pushes and from
+`agentsview pg push --projects gamma`. This keeps allow-list pushes incremental
+without advancing the unfiltered/global cursor.
 
-After upgrading from an older version, the first filtered push for a
-given project set may still scan the matching local sessions once to
-seed that scoped watermark. Later pushes with the same filter set use
-the scoped watermark.
+After upgrading from an older version, the first filtered push for a given
+project set may still scan the matching local sessions once to seed that scoped
+watermark. Later pushes with the same filter set use the scoped watermark.
 
 #### Curation Metadata
 
-As of 0.30.0, `pg push` also synchronizes two pieces of
-per-user curation state alongside session content:
+As of 0.30.0, `pg push` also synchronizes two pieces of per-user curation state
+alongside session content:
 
-| PostgreSQL table | What it holds |
-|------------------|---------------|
-| `starred_sessions` | One row per starred session: `session_id`, `created_at` |
-| `pinned_messages` | One row per pin: `id`, `session_id`, `message_id`, `ordinal`, `source_uuid`, `note`, `created_at` |
+| PostgreSQL table   | What it holds                                                                                     |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| `starred_sessions` | One row per starred session: `session_id`, `created_at`                                           |
+| `pinned_messages`  | One row per pin: `id`, `session_id`, `message_id`, `ordinal`, `source_uuid`, `note`, `created_at` |
 
-Stars are keyed by session ID and overwrite cleanly across
-machines. Pins are reconciled by `source_uuid` — a stable
-identifier derived from the underlying message — so a pin
-survives a re-parse that shifts message ordinals. Without
-this, pins would silently drift to the wrong message after
-any session resync.
+Stars are keyed by session ID and overwrite cleanly across machines. Pins are
+reconciled by `source_uuid` — a stable identifier derived from the underlying
+message — so a pin survives a re-parse that shifts message ordinals. Without
+this, pins would silently drift to the wrong message after any session resync.
 
-Curation tables are populated by the same `pg push` run; no
-separate command or flag is required. The
-[`agentsview secrets`](/docs/commands/#agentsview-secrets) findings
-also push through this codepath, with the same parity
-guarantees as session content (`secret_findings` table,
-per-session `secret_leak_count`, and the
-[`has-secret`](/docs/session-api/#agentsview-session-list) list
-filter).
+Curation tables are populated by the same `pg push` run; no separate command or
+flag is required. The [`agentsview secrets`](/docs/commands/#agentsview-secrets)
+findings also push through this codepath, with the same parity guarantees as
+session content (`secret_findings` table, per-session `secret_leak_count`, and
+the [`has-secret`](/docs/session-api/#agentsview-session-list) list filter).
 
 #### Vector Push
 
-When `[vector]` is enabled locally, `pg push` runs a vector phase
-after the session and message phases, copying the machine's
-active embedding generation from `vectors.db` into pgvector so a
-shared PostgreSQL deployment can answer `--semantic`/`--hybrid`.
-Only changed sessions are re-sent. Skip the phase for one run
-with `--no-vectors`, or disable it persistently with
-`push_vectors = false` under `[pg]`. Databases without pgvector
-(for example CockroachDB) skip the phase and keep syncing session
-content. See
-[semantic search: PostgreSQL](/docs/semantic-search/#postgresql) for
-the full push, serve, and maintenance workflow.
+When `[vector]` is enabled locally, `pg push` runs a vector phase after the
+session and message phases, copying the machine's active embedding generation
+from `vectors.db` into pgvector so a shared PostgreSQL deployment can answer
+`--semantic`/`--hybrid`. Only changed sessions are re-sent. Skip the phase for
+one run with `--no-vectors`, or disable it persistently with
+`push_vectors = false` under `[pg]`. Databases without pgvector (for example
+CockroachDB) skip the phase and keep syncing session content. See
+[semantic search: PostgreSQL](/docs/semantic-search/#postgresql) for the full
+push, serve, and maintenance workflow.
 
-`pg vectors list` and `pg vectors drop <id>` inspect and remove
-pushed generations.
+`pg vectors list` and `pg vectors drop <id>` inspect and remove pushed
+generations.
 
 ### `agentsview pg status`
 
@@ -271,13 +254,12 @@ agentsview pg status --all
 agentsview pg status --projects alpha,beta
 ```
 
-Without a target name, `pg status` uses the effective default target.
-Pass one named target explicitly to inspect that destination, or use
-`--all` to print every configured target sequentially.
+Without a target name, `pg status` uses the effective default target. Pass one
+named target explicitly to inspect that destination, or use `--all` to print
+every configured target sequentially.
 
-Use the same `--projects`, `--exclude-projects`, or `--all-projects`
-filter flags as `pg push` to inspect the matching filtered or
-unfiltered watermark.
+Use the same `--projects`, `--exclude-projects`, or `--all-projects` filter
+flags as `pg push` to inspect the matching filtered or unfiltered watermark.
 
 Output:
 
@@ -288,17 +270,17 @@ PG sessions: 1842
 PG messages: 47291
 ```
 
-| Field | Description |
-|-------|-------------|
-| Machine | Configured machine name or hostname |
-| Last push | Timestamp of last successful push ("never" if no push yet) |
-| PG sessions | Total session count in PostgreSQL (all machines) |
-| PG messages | Total message count in PostgreSQL (all machines) |
+| Field       | Description                                                |
+| ----------- | ---------------------------------------------------------- |
+| Machine     | Configured machine name or hostname                        |
+| Last push   | Timestamp of last successful push ("never" if no push yet) |
+| PG sessions | Total session count in PostgreSQL (all machines)           |
+| PG messages | Total message count in PostgreSQL (all machines)           |
 
 ### `agentsview pg service`
 
-Install and manage the [`pg push --watch`](#automatic-push-watcher)
-auto-push daemon as a per-user OS service.
+Install and manage the [`pg push --watch`](#automatic-push-watcher) auto-push
+daemon as a per-user OS service.
 
 ```bash
 agentsview pg service install
@@ -311,29 +293,27 @@ agentsview pg service uninstall
 
 Supported service managers:
 
-| Platform | Manager |
-|----------|---------|
-| macOS | launchd LaunchAgent |
-| Linux | `systemd --user` unit |
+| Platform | Manager               |
+| -------- | --------------------- |
+| macOS    | launchd LaunchAgent   |
+| Linux    | `systemd --user` unit |
 
-The generated unit runs `agentsview pg push --watch`, pins
-`AGENTSVIEW_DATA_DIR` to the data directory used at install time,
-and writes logs to `~/.agentsview/pg-watch.log` unless you changed
-the data directory.
+The generated unit runs `agentsview pg push --watch`, pins `AGENTSVIEW_DATA_DIR`
+to the data directory used at install time, and writes logs to
+`~/.agentsview/pg-watch.log` unless you changed the data directory.
 
 `install` requires a literal PostgreSQL URL in the effective default target of
 `~/.agentsview/config.toml`, either the legacy `[pg].url` or the target selected
 by `default_pg` from named `[pg.NAME]` blocks. It intentionally rejects
-`AGENTSVIEW_PG_URL` and environment-expanded URLs such as
-`${PG_PASSWORD}` because background services do not inherit your
-interactive shell environment. Other session-directory environment
-variables are not copied into the unit either; put persistent
-settings in `config.toml` before installing.
+`AGENTSVIEW_PG_URL` and environment-expanded URLs such as `${PG_PASSWORD}`
+because background services do not inherit your interactive shell environment.
+Other session-directory environment variables are not copied into the unit
+either; put persistent settings in `config.toml` before installing.
 
-On headless Linux machines, `systemd --user` services stop at
-logout and do not start at boot unless user lingering is enabled.
-If lingering is disabled, `install` prints the exact
-`loginctl enable-linger "$USER"` command and offers to run it.
+On headless Linux machines, `systemd --user` services stop at logout and do not
+start at boot unless user lingering is enabled. If lingering is disabled,
+`install` prints the exact `loginctl enable-linger "$USER"` command and offers
+to run it.
 
 ### `agentsview pg serve`
 
@@ -343,114 +323,107 @@ Start a read-only web UI backed by PostgreSQL.
 agentsview pg serve [flags]
 ```
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--host` | `127.0.0.1` | Bind address |
-| `--port` | `8080` | Port |
-| `--base-path` | | URL prefix for reverse-proxy subpath |
-| `--public-url` | | Public-facing URL for proxy access |
-| `--public-origin` | | Trusted browser origin (repeatable/comma-separated) |
-| `--public-port` | `8443` | External port for managed proxy |
-| `--proxy` | | Managed proxy mode (`caddy`) |
-| `--caddy-bin` | `caddy` | Caddy binary path |
-| `--proxy-bind-host` | `0.0.0.0` | Caddy bind address |
-| `--tls-cert` | | TLS certificate path |
-| `--tls-key` | | TLS key path |
-| `--allowed-subnet` | | CIDR allowlist (repeatable/comma-separated) |
+| Flag                | Default     | Description                                         |
+| ------------------- | ----------- | --------------------------------------------------- |
+| `--host`            | `127.0.0.1` | Bind address                                        |
+| `--port`            | `8080`      | Port                                                |
+| `--base-path`       |             | URL prefix for reverse-proxy subpath                |
+| `--public-url`      |             | Public-facing URL for proxy access                  |
+| `--public-origin`   |             | Trusted browser origin (repeatable/comma-separated) |
+| `--public-port`     | `8443`      | External port for managed proxy                     |
+| `--proxy`           |             | Managed proxy mode (`caddy`)                        |
+| `--caddy-bin`       | `caddy`     | Caddy binary path                                   |
+| `--proxy-bind-host` | `0.0.0.0`   | Caddy bind address                                  |
+| `--tls-cert`        |             | TLS certificate path                                |
+| `--tls-key`         |             | TLS key path                                        |
+| `--allowed-subnet`  |             | CIDR allowlist (repeatable/comma-separated)         |
 
 The normal session server is read-only: session uploads, file watching, and
 local sync are disabled. Sessions from all machines appear in a single unified
-view. The same deployment also serves the analytics dashboard and the Usage
-page from PostgreSQL-backed queries.
+view. The same deployment also serves the analytics dashboard and the Usage page
+from PostgreSQL-backed queries.
 
 When the PostgreSQL role can write the raw-sync tables and ingest-job sequence,
-`pg serve` also registers the partial [hosted raw-sync control
-plane](/docs/hosted-raw-sync/#http-control-plane). Those routes can write raw custody
-metadata and local raw-sync storage, but they do not make the session APIs
-writable. A PostgreSQL role without the required raw-sync write privileges omits
-the runtime routes.
+`pg serve` also registers the
+[hosted raw-sync control plane](/docs/hosted-raw-sync/#http-control-plane).
+Those routes can write raw custody metadata and local raw-sync storage, but they
+do not make the session APIs writable. A PostgreSQL role without the required
+raw-sync write privileges omits the runtime routes.
 
-On startup, `pg serve` automatically applies any pending
-schema migrations to PostgreSQL, creating new tables and
-indexes added in newer AgentsView versions. This removes
-the need to run `pg push` before starting the server after
-an upgrade. If the PostgreSQL role is read-only, the
-migration is skipped and the server falls back to the
-schema compatibility check.
+On startup, `pg serve` automatically applies any pending schema migrations to
+PostgreSQL, creating new tables and indexes added in newer AgentsView versions.
+This removes the need to run `pg push` before starting the server after an
+upgrade. If the PostgreSQL role is read-only, the migration is skipped and the
+server falls back to the schema compatibility check.
 
-When `require_auth` is enabled, a bearer token is generated if
-needed and printed on startup. Pass it via
-`Authorization: Bearer <token>` on API requests. The SSE watch
-endpoint also accepts `?token=<token>` as a query parameter since
+When `require_auth` is enabled, a bearer token is generated if needed and
+printed on startup. Pass it via `Authorization: Bearer <token>` on API requests.
+The SSE watch endpoint also accepts `?token=<token>` as a query parameter since
 the `EventSource` API cannot set custom headers.
 
 The raw-sync machine routes do not accept this shared bearer token. They use
 their own device credentials and operation-scoped tokens as described in the
 [hosted raw-sync security boundary](/docs/hosted-raw-sync/#security-and-deployment-boundary).
 
-For LAN access, combine `require_auth = true` with a non-loopback
-bind such as `agentsview pg serve --host 0.0.0.0`, or keep the
-backend on loopback and expose it through a proxy.
+For LAN access, combine `require_auth = true` with a non-loopback bind such as
+`agentsview pg serve --host 0.0.0.0`, or keep the backend on loopback and expose
+it through a proxy.
 
-`pg serve` does **not** expose the global live-refresh event stream
-used by normal `agentsview serve`, because there is no local sync
-engine attached to the server. The session browser, analytics, and
-usage views still work normally; they are just not auto-refreshed by
-the global SSE path.
+`pg serve` does **not** expose the global live-refresh event stream used by
+normal `agentsview serve`, because there is no local sync engine attached to the
+server. The session browser, analytics, and usage views still work normally;
+they are just not auto-refreshed by the global SSE path.
 
-As of 0.33.0, the web UI distinguishes a **degraded backend**
-(the server responds but PostgreSQL is temporarily unavailable,
-surfacing as 5xx errors) from an unreachable one. Instead of
-forcing a page reload — which could loop while the database was
-down — the app stays interactive with its current data, shows a
-compact warning in the status bar, and clears it once a real
-data read succeeds. Click the status bar to retry immediately.
-True network failures still use the reload-based recovery path.
+As of 0.33.0, the web UI distinguishes a **degraded backend** (the server
+responds but PostgreSQL is temporarily unavailable, surfacing as 5xx errors)
+from an unreachable one. Instead of forcing a page reload — which could loop
+while the database was down — the app stays interactive with its current data,
+shows a compact warning in the status bar, and clears it once a real data read
+succeeds. Click the status bar to retry immediately. True network failures still
+use the reload-based recovery path.
 
-CockroachDB also works as the shared database. 0.33.0 reworked
-the analytics and usage queries to perform well on CockroachDB
-(filter pushdown into the source tables, SQL-side tool-call
-aggregation, batched pricing writes) without changing any
-report semantics on PostgreSQL or SQLite.
+CockroachDB also works as the shared database. 0.33.0 reworked the analytics and
+usage queries to perform well on CockroachDB (filter pushdown into the source
+tables, SQL-side tool-call aggregation, batched pricing writes) without changing
+any report semantics on PostgreSQL or SQLite.
 
-In a multi-tenant deployment behind PostgreSQL row-level
-security, slow analytics or usage panels usually point at the
-policy shape rather than at agentsview itself. The read-side
-queries are already session-id-shaped, so expose child rows
-through a set-based predicate such as `session_id IN (SELECT
-...)`, not a per-row `SECURITY DEFINER` call that runs once
-per scanned row. If shared-dataset aggregates still need more
-time, raise the API deadline with `--write-timeout`; the
-[Remote Access](/docs/remote-access/#slow-aggregates-behind-a-proxy)
-page covers the flag and the larger troubleshooting path.
+In a multi-tenant deployment behind PostgreSQL row-level security, slow
+analytics or usage panels usually point at the policy shape rather than at
+agentsview itself. The read-side queries are already session-id-shaped, so
+expose child rows through a set-based predicate such as
+`session_id IN (SELECT ...)`, not a per-row `SECURITY DEFINER` call that runs
+once per scanned row. If shared-dataset aggregates still need more time, raise
+the API deadline with `--write-timeout`; the
+[Remote Access](/docs/remote-access/#slow-aggregates-behind-a-proxy) page covers
+the flag and the larger troubleshooting path.
 
-When a reverse proxy reaches the backend by an internal
-hostname or service name, keep `--public-url` on the browser
-origin and add the proxy's upstream origin with
-`--public-origin`. The forwarded-access contract and
-troubleshooting details live in
+When a reverse proxy reaches the backend by an internal hostname or service
+name, keep `--public-url` on the browser origin and add the proxy's upstream
+origin with `--public-origin`. The forwarded-access contract and troubleshooting
+details live in
 [Remote Access](/docs/remote-access/#public-url-and-trusted-origins).
 
 !!! warning
-    Query-parameter tokens can leak through server logs, browser
-    history, and Referer headers. Prefer the `Authorization`
-    header for all non-SSE requests, and use TLS (via managed
-    Caddy or an external reverse proxy) to protect tokens in
+
+    Query-parameter tokens can leak through server logs, browser history, and
+    Referer headers. Prefer the `Authorization` header for all non-SSE requests, and
+    use TLS (via managed Caddy or an external reverse proxy) to protect tokens in
     transit.
 
-For managed Caddy mode, keep the backend `--host` on loopback
-and use `--proxy-bind-host` / `--public-port` to expose the
-public listener. The `pg serve` and normal `serve` modes keep
-separate managed-Caddy state, so both can coexist on one host.
+For managed Caddy mode, keep the backend `--host` on loopback and use
+`--proxy-bind-host` / `--public-port` to expose the public listener. The
+`pg serve` and normal `serve` modes keep separate managed-Caddy state, so both
+can coexist on one host.
 
 **Examples:**
 
 !!! warning "Enable auth before exposing `pg serve`"
-    Only the loopback example below is safe without auth. Every other
-    example binds off `127.0.0.1` or fronts a public proxy, so set
-    `require_auth = true` in `~/.agentsview/config.toml` before
-    starting the server. The same bearer-token mechanism described in
-    [Remote Access](/docs/remote-access/#authentication) applies.
+
+    Only the loopback example below is safe without auth. Every other example binds
+    off `127.0.0.1` or fronts a public proxy, so set `require_auth = true` in
+    `~/.agentsview/config.toml` before starting the server. The same bearer-token
+    mechanism described in [Remote Access](/docs/remote-access/#authentication)
+    applies.
 
 ```bash
 # Local development — loopback, no auth required
@@ -479,19 +452,18 @@ agentsview pg serve \
   --public-origin http://agentsview:8080
 ```
 
----
+______________________________________________________________________
 
 ## Machine Labels
 
-When multiple machines push to the same PostgreSQL database,
-each session is tagged with its source machine name. In the
-web UI, session items show a machine label when the session
-did not originate from the local machine. Use the multi-host
-filter in the sidebar to show sessions from specific machines.
+When multiple machines push to the same PostgreSQL database, each session is
+tagged with its source machine name. In the web UI, session items show a machine
+label when the session did not originate from the local machine. Use the
+multi-host filter in the sidebar to show sessions from specific machines.
 
 ![Machine labels on session items](/docs/assets/generated/screenshots/machine-labels.png)
 
----
+______________________________________________________________________
 
 ## Configuration
 
@@ -506,14 +478,14 @@ schema = "agentsview"
 allow_insecure = false
 ```
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| `url` | (required) | PostgreSQL connection string |
-| `machine_name` | OS hostname | Identifies the pushing machine; defaults to `os.Hostname()` if omitted |
-| `schema` | `agentsview` | PostgreSQL schema name |
-| `allow_insecure` | `false` | Allow non-TLS connections to non-loopback hosts |
-| `projects` | | Array of project names to include in push |
-| `exclude_projects` | | Array of project names to exclude from push |
+| Field              | Default      | Description                                                            |
+| ------------------ | ------------ | ---------------------------------------------------------------------- |
+| `url`              | (required)   | PostgreSQL connection string                                           |
+| `machine_name`     | OS hostname  | Identifies the pushing machine; defaults to `os.Hostname()` if omitted |
+| `schema`           | `agentsview` | PostgreSQL schema name                                                 |
+| `allow_insecure`   | `false`      | Allow non-TLS connections to non-loopback hosts                        |
+| `projects`         |              | Array of project names to include in push                              |
+| `exclude_projects` |              | Array of project names to exclude from push                            |
 
 To manage more than one PostgreSQL destination, define named `[pg.NAME]` blocks
 and select the effective default target with `default_pg`:
@@ -539,17 +511,15 @@ explicitly. `agentsview pg serve` and `agentsview pg service` stay on the
 effective default target in this release, and `--all --watch` is rejected.
 
 !!! warning
-    The `url` field is required for all `pg` commands. If it
-    contains credentials, ensure `config.toml` has restricted
-    file permissions (`0600`).
 
-The connection string supports standard PostgreSQL parameters.
-Use `sslmode=require` or `sslmode=verify-full` for remote
-databases. Only use `sslmode=disable` for trusted local
-connections.
+    The `url` field is required for all `pg` commands. If it contains credentials,
+    ensure `config.toml` has restricted file permissions (`0600`).
 
-Environment variables in the URL are expanded using `${VAR}`
-syntax:
+The connection string supports standard PostgreSQL parameters. Use
+`sslmode=require` or `sslmode=verify-full` for remote databases. Only use
+`sslmode=disable` for trusted local connections.
+
+Environment variables in the URL are expanded using `${VAR}` syntax:
 
 ```toml
 [pg]
@@ -558,31 +528,30 @@ url = "postgres://${PG_USER}:${PG_PASSWORD}@host:5432/dbname?sslmode=require"
 
 ### Environment Variables
 
-PostgreSQL settings can also be configured via environment
-variables. In legacy single-target mode they override the `[pg]`
-values. In named-target mode they apply only to the effective default
-target:
+PostgreSQL settings can also be configured via environment variables. In legacy
+single-target mode they override the `[pg]` values. In named-target mode they
+apply only to the effective default target:
 
-| Variable | Description |
-|----------|-------------|
-| `AGENTSVIEW_PG_URL` | PostgreSQL connection URL |
-| `AGENTSVIEW_PG_MACHINE` | Machine name for push sync |
-| `AGENTSVIEW_PG_SCHEMA` | Schema name (default `agentsview`) |
+| Variable                | Description                        |
+| ----------------------- | ---------------------------------- |
+| `AGENTSVIEW_PG_URL`     | PostgreSQL connection URL          |
+| `AGENTSVIEW_PG_MACHINE` | Machine name for push sync         |
+| `AGENTSVIEW_PG_SCHEMA`  | Schema name (default `agentsview`) |
 
----
+______________________________________________________________________
 
 ## Multi-Machine Workflow
 
 A typical team setup:
 
-1. **Each developer** configures `[pg]` in their local
-   `config.toml` with a unique `machine_name`
-2. **Each developer** installs `agentsview pg service` or runs
+1. **Each developer** configures `[pg]` in their local `config.toml` with a
+   unique `machine_name`
+1. **Each developer** installs `agentsview pg service` or runs
    `agentsview pg push --watch` to sync their sessions
-3. **One server** runs `agentsview pg serve` pointed at the
-   shared PostgreSQL database
-4. **The team** opens the shared dashboard to browse everyone's
-   sessions, filtered by machine if needed
+1. **One server** runs `agentsview pg serve` pointed at the shared PostgreSQL
+   database
+1. **The team** opens the shared dashboard to browse everyone's sessions,
+   filtered by machine if needed
 
 ```bash
 # Developer A's machine
@@ -596,26 +565,22 @@ agentsview pg serve \
   --public-origin http://agentsview:8080
 ```
 
----
+______________________________________________________________________
 
 ## Limitations
 
-- **One-way sync** — sessions flow from SQLite to PostgreSQL
-  only. Changes in PostgreSQL do not propagate back to local
-  machines.
-- **Permanent deletes not propagated** — sessions removed via
-  `agentsview prune` are not deleted from PostgreSQL because
-  the local rows no longer exist at push time. Use a direct
-  SQL DELETE to clean up PostgreSQL if needed. Soft-deleted
-  sessions (trash) sync correctly.
-- **Schema compatibility** — `pg serve` automatically applies
-  pending schema migrations on startup. If the PostgreSQL role
-  lacks DDL permissions, run `agentsview pg push` from a
-  machine with write access to update the schema.
-- **Trigram index bloat on pre-0.33.0 schemas** — the content
-  search index was created with GIN `fastupdate` on, which let
-  a pending-insert list grow unbounded under continuous ingest.
-  0.33.0 creates the index with `fastupdate = off` and alters
-  existing indexes automatically, which stops further growth —
-  but space already consumed is only reclaimed by a one-time
+- **One-way sync** — sessions flow from SQLite to PostgreSQL only. Changes in
+  PostgreSQL do not propagate back to local machines.
+- **Permanent deletes not propagated** — sessions removed via `agentsview prune`
+  are not deleted from PostgreSQL because the local rows no longer exist at
+  push time. Use a direct SQL DELETE to clean up PostgreSQL if needed.
+  Soft-deleted sessions (trash) sync correctly.
+- **Schema compatibility** — `pg serve` automatically applies pending schema
+  migrations on startup. If the PostgreSQL role lacks DDL permissions, run
+  `agentsview pg push` from a machine with write access to update the schema.
+- **Trigram index bloat on pre-0.33.0 schemas** — the content search index was
+  created with GIN `fastupdate` on, which let a pending-insert list grow
+  unbounded under continuous ingest. 0.33.0 creates the index with
+  `fastupdate = off` and alters existing indexes automatically, which stops
+  further growth — but space already consumed is only reclaimed by a one-time
   `REINDEX INDEX idx_messages_content_trgm;`.

--- a/docs/screenshots/run.sh
+++ b/docs/screenshots/run.sh
@@ -63,6 +63,14 @@ rsync -a \
   --exclude='node_modules' \
   --exclude='.cache' \
   --exclude='.git' \
+  --exclude='.worktrees' \
+  --exclude='.golangci-cache' \
+  --exclude='.pytest_cache' \
+  --exclude='dist' \
+  --exclude='tmp' \
+  --exclude='test-results' \
+  --exclude='coverage.out' \
+  --exclude='sync.test' \
   --exclude='/agentsview' \
   --exclude='desktop/src-tauri/target' \
   "$AGENTSVIEW_SRC/" "$CONTEXT/agentsview/"

--- a/docs/screenshots/tests/screenshots.spec.ts
+++ b/docs/screenshots/tests/screenshots.spec.ts
@@ -159,7 +159,7 @@ test.describe('Dashboard', () => {
     const timeline = page.locator('.timeline-container');
     if (await timeline.count() > 0) {
       await timeline.scrollIntoViewIfNeeded();
-      await page.waitForSelector('.timeline-svg', {
+      await timeline.locator('.timeline-chart').waitFor({
         timeout: 10_000,
       });
       await page.waitForTimeout(500);

--- a/docs/scripts/check_built_site.py
+++ b/docs/scripts/check_built_site.py
@@ -49,7 +49,7 @@ ROUTES = ["/", "/guide/", "/docs/"] + [f"/docs/{page}/" for page in DOCS_PAGES]
 
 REQUIRED_FRAGMENTS = [
     "/docs/configuration/#session-discovery",
-    "/docs/token-usage/#how-it-compares-to-ccusage",
+    "/docs/token-usage/#reporting-model",
     "/docs/session-api/#agentsview-session-usage",
 ]
 

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -3,17 +3,15 @@ title: Session API
 description: Programmatic access to session data via the agentsview session CLI and REST endpoints
 ---
 
-The `agentsview session` command group is a stable, programmatic
-surface for reading and writing session data. It is designed for
-shell scripts, automation agents, and CI jobs that need structured
-output rather than the web UI.
+The `agentsview session` command group is a stable, programmatic surface for
+reading and writing session data. It is designed for shell scripts, automation
+agents, and CI jobs that need structured output rather than the web UI.
 
-When an AgentsView daemon is running, the CLI proxies supported
-operations to it over HTTP. On a cold archive, read-only commands
-open local SQLite directly in read-only mode, while commands that
-need fresh data or need to write start or reuse the detached local
-daemon. This keeps one-off reads fast and keeps SQLite writes owned
-by one process.
+When an AgentsView daemon is running, the CLI proxies supported operations to it
+over HTTP. On a cold archive, read-only commands open local SQLite directly in
+read-only mode, while commands that need fresh data or need to write start or
+reuse the detached local daemon. This keeps one-off reads fast and keeps SQLite
+writes owned by one process.
 
 ## Quick examples
 
@@ -35,84 +33,77 @@ agentsview session search "regression" --pg --json
 
 ## Stability
 
-- **Additive-only.** New fields may appear at any time. Existing
-  fields are never renamed or removed.
+- **Additive-only.** New fields may appear at any time. Existing fields are
+  never renamed or removed.
 - **Types are stable.** A field that is a string stays a string.
-- **Unknown fields are safe to ignore.** Well-behaved consumers
-  tolerate forward-compatible additions.
+- **Unknown fields are safe to ignore.** Well-behaved consumers tolerate
+  forward-compatible additions.
 
-HTTP and CLI share DTOs for bounded responses (same JSON object).
-The CLI `watch` command emits NDJSON whose lines mirror the
-underlying SSE events.
+HTTP and CLI share DTOs for bounded responses (same JSON object). The CLI
+`watch` command emits NDJSON whose lines mirror the underlying SSE events.
 
 ## Transport
 
-Detection uses kit daemon runtime records in `AGENTSVIEW_DATA_DIR`
-and the daemon ping endpoint. Runtime records include service and
-API metadata so incompatible or read-only daemons are not mistaken
-for a writable local archive owner.
+Detection uses kit daemon runtime records in `AGENTSVIEW_DATA_DIR` and the
+daemon ping endpoint. Runtime records include service and API metadata so
+incompatible or read-only daemons are not mistaken for a writable local archive
+owner.
 
-- If `--server <url>` is set, supported commands proxy to that
-  daemon over HTTP. `--server` and `--pg` are mutually exclusive.
-  The local config `auth_token` is not sent to explicit URLs; set
-  `AGENTSVIEW_SERVER_TOKEN` or pass `--server-token-file <path>`
-  when that remote daemon requires auth.
-- If no explicit server is set and a local daemon is running, read
-  and write commands proxy to it over HTTP.
-- If a [`pg serve`](/docs/pg-sync/#agentsview-pg-serve) daemon is
-  running (read-only), read commands proxy to it but
-  `session sync` refuses with a clear error.
-- If both a writable local daemon and a `pg serve` daemon
-  advertise the same data directory, the writable one wins so
-  sync/write operations don't silently land on a read-only
-  target.
-- If no daemon is running, read-only commands open the local
-  archive directly in read-only mode.
-- If a command requires fresh data or needs to write and no daemon
-  is running, the CLI starts `agentsview serve --background`, waits
-  for readiness, and proxies the operation to that daemon.
-- If `AGENTSVIEW_NO_DAEMON=1` is set, the CLI never auto-starts a
-  daemon. Read commands use direct read-only SQLite. Write commands
-  run directly only after acquiring the per-data-dir write-owner
-  lock.
-- If a writable daemon is known to own the local archive but is not
-  reachable, write commands refuse instead of opening SQLite as a
-  second writer. Read commands may still fall back to direct
-  read-only SQLite.
-- `session export` always runs locally regardless of daemon
-  state, and rejects `--server`, `--pg`, and `--format`/`--json`
-  because it streams raw source bytes.
+- If `--server <url>` is set, supported commands proxy to that daemon over HTTP.
+  `--server` and `--pg` are mutually exclusive. The local config `auth_token`
+  is not sent to explicit URLs; set `AGENTSVIEW_SERVER_TOKEN` or pass
+  `--server-token-file <path>` when that remote daemon requires auth.
+- If no explicit server is set and a local daemon is running, read and write
+  commands proxy to it over HTTP.
+- If a [`pg serve`](/docs/pg-sync/#agentsview-pg-serve) daemon is running
+  (read-only), read commands proxy to it but `session sync` refuses with a
+  clear error.
+- If both a writable local daemon and a `pg serve` daemon advertise the same
+  data directory, the writable one wins so sync/write operations don't
+  silently land on a read-only target.
+- If no daemon is running, read-only commands open the local archive directly in
+  read-only mode.
+- If a command requires fresh data or needs to write and no daemon is running,
+  the CLI starts `agentsview serve --background`, waits for readiness, and
+  proxies the operation to that daemon.
+- If `AGENTSVIEW_NO_DAEMON=1` is set, the CLI never auto-starts a daemon. Read
+  commands use direct read-only SQLite. Write commands run directly only after
+  acquiring the per-data-dir write-owner lock.
+- If a writable daemon is known to own the local archive but is not reachable,
+  write commands refuse instead of opening SQLite as a second writer. Read
+  commands may still fall back to direct read-only SQLite.
+- `session export` always runs locally regardless of daemon state, and rejects
+  `--server`, `--pg`, and `--format`/`--json` because it streams raw source
+  bytes.
 
-When a discovered local daemon requires auth (`require_auth: true`),
-the CLI attaches `Authorization: Bearer <token>` using the
-`auth_token` from the shared config. Explicit `--server` URLs are
-different: they only receive a bearer token supplied with
-`AGENTSVIEW_SERVER_TOKEN` or `--server-token-file <path>`, so a
+When a discovered local daemon requires auth (`require_auth: true`), the CLI
+attaches `Authorization: Bearer <token>` using the `auth_token` from the shared
+config. Explicit `--server` URLs are different: they only receive a bearer token
+supplied with `AGENTSVIEW_SERVER_TOKEN` or `--server-token-file <path>`, so a
 local daemon token is not leaked to arbitrary remote URLs. Prefer
-`--server-token-file` for long-running commands and shared hosts so
-the token does not appear in process arguments.
+`--server-token-file` for long-running commands and shared hosts so the token
+does not appear in process arguments.
 
-`--pg` opens the configured PostgreSQL read store directly. It is
-useful for automation running away from the UI server, but it is
-read-only: `session sync` and `session export` reject it. If
-`AGENTSVIEW_PG_URL` or `[pg].url` is configured, read commands still
-use local SQLite unless `--pg` is supplied.
+`--pg` opens the configured PostgreSQL read store directly. It is useful for
+automation running away from the UI server, but it is read-only: `session sync`
+and `session export` reject it. If `AGENTSVIEW_PG_URL` or `[pg].url` is
+configured, read commands still use local SQLite unless `--pg` is supplied.
 
 ## Common flags
 
-| Flag                         | Description                                      |
-|------------------------------|--------------------------------------------------|
-| `--format human\|json`       | Output format. Default `human`.                  |
-| `--json`                     | Alias for `--format json`.                       |
-| `--server <url>`             | Explicit daemon URL for HTTP-backed operations.  |
-| `--server-token-file <path>` | Bearer token file for an explicit `--server` URL. |
+| Flag                         | Description                                                                                                                                                                                    |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--format human\|json`       | Output format. Default `human`.                                                                                                                                                                |
+| `--json`                     | Alias for `--format json`.                                                                                                                                                                     |
+| `--server <url>`             | Explicit daemon URL for HTTP-backed operations.                                                                                                                                                |
+| `--server-token-file <path>` | Bearer token file for an explicit `--server` URL.                                                                                                                                              |
 | `--machine <value>`          | Filter bare Codebuff/Freebuff timestamp resolution to a single machine identity (`local`, a name, or `*`). Default `local`. `session get` only; canonical IDs and other agents are unaffected. |
-| `--pg`                       | Read from configured PostgreSQL instead of SQLite. |
+| `--pg`                       | Read from configured PostgreSQL instead of SQLite.                                                                                                                                             |
 
 ## Shared metadata endpoints
 
-The web UI and generated API clients use shared metadata endpoints
-for filter options:
+The web UI and generated API clients use shared metadata endpoints for filter
+options:
 
 ```http
 GET /api/v1/projects
@@ -121,8 +112,8 @@ GET /api/v1/branches
 GET /api/v1/agents
 ```
 
-`GET /api/v1/branches` returns distinct `(project, branch)` pairs
-plus an opaque `token` field:
+`GET /api/v1/branches` returns distinct `(project, branch)` pairs plus an opaque
+`token` field:
 
 ```json
 {
@@ -136,11 +127,10 @@ plus an opaque `token` field:
 }
 ```
 
-Pass the returned token back as the `git_branch` query parameter on
-branch-aware endpoints. Treat it as opaque and URL-encode it in
-manual HTTP calls. The token is scoped by both project and branch,
-so `app-a/main` and `app-b/main` remain distinct, and an empty
-branch remains distinct from a literal `unknown` branch.
+Pass the returned token back as the `git_branch` query parameter on branch-aware
+endpoints. Treat it as opaque and URL-encode it in manual HTTP calls. The token
+is scoped by both project and branch, so `app-a/main` and `app-b/main` remain
+distinct, and an empty branch remains distinct from a literal `unknown` branch.
 
 ## Commands
 
@@ -154,20 +144,17 @@ agentsview session get <id> [--format json]
 ```
 
 **Bare timestamps on remote stores.** Codebuff/Freebuff sessions live as
-`<agent>:<project>:<timestamp>` canonical IDs; a bare timestamp
-(e.g. `2026-07-16T00-09-00.236Z`) is not a canonical ID. Against the
-local archive the CLI resolves a bare timestamp to its canonical ID
-by walking the configured codebuff/freebuff roots, gated by
-`--machine` (default `local`). Against a remote store (`--server`,
-`--pg`) a bare Codebuff/Freebuff timestamp is rejected with an
-explicit error pointing at `session list`, because a bare timestamp is
-intrinsically ambiguous across machines and projects.
-The rejection is scoped to the Codebuff/Freebuff timestamp shape;
-bare IDs that are not timestamps (Codex / Copilot / Gemini UUIDs,
-etc.) are unaffected and continue to resolve via the registered
-agent prefix retry on remote reads, the same way they do locally.
-Always pass the full canonical ID on remote reads when one is
-known:
+`<agent>:<project>:<timestamp>` canonical IDs; a bare timestamp (e.g.
+`2026-07-16T00-09-00.236Z`) is not a canonical ID. Against the local archive the
+CLI resolves a bare timestamp to its canonical ID by walking the configured
+codebuff/freebuff roots, gated by `--machine` (default `local`). Against a
+remote store (`--server`, `--pg`) a bare Codebuff/Freebuff timestamp is rejected
+with an explicit error pointing at `session list`, because a bare timestamp is
+intrinsically ambiguous across machines and projects. The rejection is scoped to
+the Codebuff/Freebuff timestamp shape; bare IDs that are not timestamps (Codex /
+Copilot / Gemini UUIDs, etc.) are unaffected and continue to resolve via the
+registered agent prefix retry on remote reads, the same way they do locally.
+Always pass the full canonical ID on remote reads when one is known:
 
 ```bash
 # Local reads: bare timestamp OK (--machine=local by default).
@@ -204,30 +191,28 @@ agentsview session get host~freebuff:myproject:1704067200 --server http://remote
 }
 ```
 
-`health_score_basis` and `health_penalties` are populated when
-`health_score` is non-null. Both HTTP and CLI surfaces return them.
+`health_score_basis` and `health_penalties` are populated when `health_score` is
+non-null. Both HTTP and CLI surfaces return them.
 
-`git_branch` is the branch captured at sync time when the parser or
-source metadata exposes it; sessions with no recorded branch omit
-the field. `parser_malformed_lines` counts the malformed source
-lines a parser skipped while still recovering the session and is
-omitted when zero. Antigravity detail responses may also include
-`decode_confidence`; the value `low` means the session came from an
-unrecognized Antigravity schema fingerprint and was decoded
+`git_branch` is the branch captured at sync time when the parser or source
+metadata exposes it; sessions with no recorded branch omit the field.
+`parser_malformed_lines` counts the malformed source lines a parser skipped
+while still recovering the session and is omitted when zero. Antigravity detail
+responses may also include `decode_confidence`; the value `low` means the
+session came from an unrecognized Antigravity schema fingerprint and was decoded
 heuristically.
 
-`secret_leak_count` (added in 0.30.0) counts definite-tier
-findings from [secret scanning](#secret-scanning) and is stamped
-inline during sync. Candidate-tier findings only show up after
-an explicit [`agentsview secrets scan --backfill`](/docs/commands/#agentsview-secrets)
-and do not contribute to this count.
+`secret_leak_count` (added in 0.30.0) counts definite-tier findings from
+[secret scanning](#secret-scanning) and is stamped inline during sync.
+Candidate-tier findings only show up after an explicit
+[`agentsview secrets scan --backfill`](/docs/commands/#agentsview-secrets) and
+do not contribute to this count.
 
----
+______________________________________________________________________
 
 ### `agentsview session list`
 
-Filtered session list. Response shape matches
-`GET /api/v1/sessions`.
+Filtered session list. Response shape matches `GET /api/v1/sessions`.
 
 ```bash
 agentsview session list [flags]
@@ -241,60 +226,59 @@ agentsview session list [flags]
 }
 ```
 
-One-shot and automated sessions are excluded by default. When the first CLI
-page hides any, `session list` writes an advisory to stderr with the hidden
-count for each category and the `--include-one-shot` or `--include-automated`
-flag that reveals it. Human and JSON stdout are unchanged, so redirecting or
-piping structured output remains safe. The JSON `total` continues to describe
-the filtered result, not the excluded sessions. Use the `--include-*` flags to
-opt back in.
+One-shot and automated sessions are excluded by default. When the first CLI page
+hides any, `session list` writes an advisory to stderr with the hidden count for
+each category and the `--include-one-shot` or `--include-automated` flag that
+reveals it. Human and JSON stdout are unchanged, so redirecting or piping
+structured output remains safe. The JSON `total` continues to describe the
+filtered result, not the excluded sessions. Use the `--include-*` flags to opt
+back in.
 
-Date filters match a session when its activity window overlaps the selected
-date or range. Sessions that start before midnight and remain active after it
+Date filters match a session when its activity window overlaps the selected date
+or range. Sessions that start before midnight and remain active after it
 therefore appear on both dates.
 
-| Flag                  | HTTP param          | Notes                             |
-|-----------------------|---------------------|-----------------------------------|
-| `--project`           | `project`           | string                            |
-| `--exclude-project`   | `exclude_project`   | string                            |
-| `--machine`           | `machine`           | string                            |
-| —                     | `git_branch`        | opaque token from `GET /api/v1/branches` |
-| `--agent`             | `agent`             | string                            |
-| `--date`              | `date`              | `YYYY-MM-DD`                      |
-| `--date-from`         | `date_from`         | `YYYY-MM-DD`                      |
-| `--date-to`           | `date_to`           | `YYYY-MM-DD`                      |
-| `--active-since`      | `active_since`      | RFC3339 timestamp                 |
+| Flag                  | HTTP param          | Notes                                                                                                                                                                             |
+| --------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--project`           | `project`           | string                                                                                                                                                                            |
+| `--exclude-project`   | `exclude_project`   | string                                                                                                                                                                            |
+| `--machine`           | `machine`           | string                                                                                                                                                                            |
+| —                     | `git_branch`        | opaque token from `GET /api/v1/branches`                                                                                                                                          |
+| `--agent`             | `agent`             | string                                                                                                                                                                            |
+| `--date`              | `date`              | `YYYY-MM-DD`                                                                                                                                                                      |
+| `--date-from`         | `date_from`         | `YYYY-MM-DD`                                                                                                                                                                      |
+| `--date-to`           | `date_to`           | `YYYY-MM-DD`                                                                                                                                                                      |
+| `--active-since`      | `active_since`      | RFC3339 timestamp                                                                                                                                                                 |
 | `--since`             | `active_since`      | Relative — `Nh` hours, `Nd` days, `Nw` weeks, `Nm` calendar months (not minutes), `Ny` years — or `YYYY-MM-DD`; resolved against now and mutually exclusive with `--active-since` |
-| `--resume`            | `active_since`      | CLI shortcut for sessions active in the last 15 minutes |
-| `--active`            | `active_since`      | Alias for `--resume`              |
-| `--min-messages`      | `min_messages`      | int                               |
-| `--max-messages`      | `max_messages`      | int                               |
-| `--min-user-messages` | `min_user_messages` | int                               |
-| `--include-one-shot`  | `include_one_shot`  | bool                              |
-| `--include-automated` | `include_automated` | bool                              |
-| `--include-children`  | `include_children`  | bool                              |
-| `--outcome`           | `outcome`           | comma-separated                   |
-| `--health-grade`      | `health_grade`      | comma-separated                   |
-| `--min-tool-failures` | `min_tool_failures` | int; `0` is a meaningful filter   |
-| `--has-secret`        | `has_secret`        | bool — only sessions with at least one definite [secret finding](#secret-scanning) |
-| `--sort`              | `order_by`          | comma-separated keys; optional `:asc` / `:desc` suffix per key |
-| `--reverse`, `-r`     | `descending`        | flips the default direction for unsuffixed sort keys |
-| `--cursor`            | `cursor`            | opaque string from prior response |
-| `--limit`             | `limit`             | int; default 200, max 500         |
+| `--resume`            | `active_since`      | CLI shortcut for sessions active in the last 15 minutes                                                                                                                           |
+| `--active`            | `active_since`      | Alias for `--resume`                                                                                                                                                              |
+| `--min-messages`      | `min_messages`      | int                                                                                                                                                                               |
+| `--max-messages`      | `max_messages`      | int                                                                                                                                                                               |
+| `--min-user-messages` | `min_user_messages` | int                                                                                                                                                                               |
+| `--include-one-shot`  | `include_one_shot`  | bool                                                                                                                                                                              |
+| `--include-automated` | `include_automated` | bool                                                                                                                                                                              |
+| `--include-children`  | `include_children`  | bool                                                                                                                                                                              |
+| —                     | `include_source`    | bool; include source file paths, which are hidden by default                                                                                                                      |
+| `--outcome`           | `outcome`           | comma-separated                                                                                                                                                                   |
+| `--health-grade`      | `health_grade`      | comma-separated                                                                                                                                                                   |
+| `--min-tool-failures` | `min_tool_failures` | int; `0` is a meaningful filter                                                                                                                                                   |
+| `--has-secret`        | `has_secret`        | bool — only sessions with at least one definite [secret finding](#secret-scanning)                                                                                                |
+| `--sort`              | `order_by`          | comma-separated keys; optional `:asc` / `:desc` suffix per key                                                                                                                    |
+| `--reverse`, `-r`     | `descending`        | flips the default direction for unsuffixed sort keys                                                                                                                              |
+| `--cursor`            | `cursor`            | opaque string from prior response                                                                                                                                                 |
+| `--limit`             | `limit`             | int; default 200, max 500                                                                                                                                                         |
 
-Sort keys are `recent`, `started`, `messages`, `user-messages`,
-`output-tokens`, `peak-context`, `failures`, `retries`,
-`edit-churn`, `compactions`, `context-pressure`, `health`,
-`secrets`, and `id`. `recent` defaults descending; the other keys
-default ascending unless `--reverse`, `descending=true`, or an
+Sort keys are `recent`, `started`, `messages`, `user-messages`, `output-tokens`,
+`peak-context`, `failures`, `retries`, `edit-churn`, `compactions`,
+`context-pressure`, `health`, `secrets`, and `id`. `recent` defaults descending;
+the other keys default ascending unless `--reverse`, `descending=true`, or an
 explicit suffix overrides them.
 
-Human CLI output is formatted for resuming work: it shows the full
-session ID, age, agent, project, branch, message count, title, and
-working directory, with a marker on sessions active in the last 15
-minutes. `--resume` and `--active` set `active_since` to that
-15-minute window unless `--active-since` is supplied explicitly.
-HTTP callers should pass `active_since` directly.
+Human CLI output is formatted for resuming work: it shows the full session ID,
+age, agent, project, branch, message count, title, and working directory, with a
+marker on sessions active in the last 15 minutes. `--resume` and `--active` set
+`active_since` to that 15-minute window unless `--active-since` is supplied
+explicitly. HTTP callers should pass `active_since` directly.
 
 Examples:
 
@@ -304,7 +288,7 @@ agentsview session list --sort messages:desc,started:asc
 agentsview session list --sort health --reverse
 ```
 
----
+______________________________________________________________________
 
 ### `agentsview session messages`
 
@@ -316,24 +300,24 @@ agentsview session messages <id> [--from N] [--limit N] [--direction asc|desc]
 agentsview session messages <id> --around N [--before N] [--after N] [--role user,assistant]
 ```
 
-`--from` is pointer-valued at the service layer: omitting it means
-"start at the beginning" for ascending and "start at the newest
-page" for descending; an explicit `--from 0` means "start at ordinal
-0" in both directions. `--direction` is validated to `asc` or `desc`.
+`--from` is pointer-valued at the service layer: omitting it means "start at the
+beginning" for ascending and "start at the newest page" for descending; an
+explicit `--from 0` means "start at ordinal 0" in both directions. `--direction`
+is validated to `asc` or `desc`.
 
 Window and role flags (see
 [Semantic Search](/docs/semantic-search/#cursor-follow-from-a-hit-to-its-surrounding-conversation)
 for the cursor-follow workflow they support):
 
-| Flag       | HTTP param | Notes                                                        |
-|------------|------------|--------------------------------------------------------------|
+| Flag       | HTTP param | Notes                                                                           |
+| ---------- | ---------- | ------------------------------------------------------------------------------- |
 | `--around` | `around`   | Center a window on this ordinal; mutually exclusive with `--from`/`--direction` |
-| `--before` | `before`   | Messages before the anchor (default 5); requires `--around`  |
-| `--after`  | `after`    | Messages after the anchor (default 5); requires `--around`   |
-| `--role`   | `roles`    | Comma-separated roles to include, e.g. `user,assistant`      |
+| `--before` | `before`   | Messages before the anchor (default 5); requires `--around`                     |
+| `--after`  | `after`    | Messages after the anchor (default 5); requires `--around`                      |
+| `--role`   | `roles`    | Comma-separated roles to include, e.g. `user,assistant`                         |
 
-With a `--role` filter, `--before`/`--after` count filtered messages;
-the anchor message is always included. Responses report the window's
+With a `--role` filter, `--before`/`--after` count filtered messages; the anchor
+message is always included. Responses report the window's
 `first_ordinal`/`last_ordinal` so callers can continue paging with
 `--from <last_ordinal + 1>`.
 
@@ -357,16 +341,14 @@ the anchor message is always included. Responses report the window's
 }
 ```
 
-`thinking_text` holds the concatenated text of any `thinking` blocks
-the agent emitted, separated from the flattened `content` which
-still contains inline `[Thinking]...[/Thinking]` markers for UI
-rendering.
+`thinking_text` holds the concatenated text of any `thinking` blocks the agent
+emitted, separated from the flattened `content` which still contains inline
+`[Thinking]...[/Thinking]` markers for UI rendering.
 
-Promoted `source_subtype` values on `is_system: true` messages:
-`continuation`, `resume`, `interrupted`, `task_notification`,
-`stop_hook`, `compact_boundary`.
+Promoted `source_subtype` values on `is_system: true` messages: `continuation`,
+`resume`, `interrupted`, `task_notification`, `stop_hook`, `compact_boundary`.
 
----
+______________________________________________________________________
 
 ### `agentsview session tool-calls`
 
@@ -395,16 +377,15 @@ agentsview session tool-calls <id>
 }
 ```
 
-`input_json` is a string — usually a serialized JSON object but may
-be a plain string (e.g. `"echo hello world"` from Codex).
+`input_json` is a string — usually a serialized JSON object but may be a plain
+string (e.g. `"echo hello world"` from Codex).
 
----
+______________________________________________________________________
 
 ### `POST /api/v1/sessions/{id}/resume`
 
-Resume a local session in its native agent, or return the command
-that would be launched. This is an HTTP-only surface used by the
-web UI's resume menu.
+Resume a local session in its native agent, or return the command that would be
+launched. This is an HTTP-only surface used by the web UI's resume menu.
 
 ```http
 POST /api/v1/sessions/{id}/resume
@@ -433,32 +414,29 @@ Response:
 }
 ```
 
-`command_only: true` returns the command without launching a
-terminal. When a launch is attempted but fails, the response still
-includes the command with `launched: false` and an `error` code of
-`no_terminal_found` or `launch_failed`. Read-only local mode can
-still return commands, but remote sessions and read-only remote
-serving cannot launch local programs.
+`command_only: true` returns the command without launching a terminal. When a
+launch is attempted but fails, the response still includes the command with
+`launched: false` and an `error` code of `no_terminal_found` or `launch_failed`.
+Read-only local mode can still return commands, but remote sessions and
+read-only remote serving cannot launch local programs.
 
-For Claude Code sessions, setting `fork_session: true` without
-`from_ordinal` appends Claude's native `--fork-session` flag to the
-normal resume command. Setting both `fork_session: true` and
-`from_ordinal` creates a message-point fork: AgentsView renders the
-transcript through that message ordinal into a temporary prompt and
-runs `claude < prompt` from the resolved session working directory.
-Message-point forks are Claude-only, require `fork_session`, reject
+For Claude Code sessions, setting `fork_session: true` without `from_ordinal`
+appends Claude's native `--fork-session` flag to the normal resume command.
+Setting both `fork_session: true` and `from_ordinal` creates a message-point
+fork: AgentsView renders the transcript through that message ordinal into a
+temporary prompt and runs `claude < prompt` from the resolved session working
+directory. Message-point forks are Claude-only, require `fork_session`, reject
 `opener_id`, and return `404` when the ordinal is not present.
 
----
+______________________________________________________________________
 
 ### `agentsview session export`
 
-Stream the raw session source file to stdout. This is a
-**local-only** filesystem helper: the source file path is resolved
-from the local SQLite archive, never from any daemon. Both
-`--server` and `--format`/`--json` are rejected with an error — the
-command also rejects `--pg`. It streams raw bytes, so
-structured-output and remote-store flags don't apply.
+Stream the raw session source file to stdout. This is a **local-only**
+filesystem helper: the source file path is resolved from the local SQLite
+archive, never from any daemon. Both `--server` and `--format`/`--json` are
+rejected with an error — the command also rejects `--pg`. It streams raw bytes,
+so structured-output and remote-store flags don't apply.
 
 ```bash
 agentsview session export <id>
@@ -466,12 +444,12 @@ agentsview session export <id>
 
 Exit states:
 
-| State                                  | Behavior                                                  |
-|----------------------------------------|-----------------------------------------------------------|
-| Session in local archive, file on disk | Streams bytes verbatim                                    |
-| Session in local archive, file missing | Exit 1: error prefixed `source file not found`            |
-| Session in local archive, path empty   | Exit 1: `source file not found for session <id>`          |
-| Session not in local archive           | Exit 1: `session not in local archive: <id>`              |
+| State                                  | Behavior                                         |
+| -------------------------------------- | ------------------------------------------------ |
+| Session in local archive, file on disk | Streams bytes verbatim                           |
+| Session in local archive, file missing | Exit 1: error prefixed `source file not found`   |
+| Session in local archive, path empty   | Exit 1: `source file not found for session <id>` |
+| Session not in local archive           | Exit 1: `session not in local archive: <id>`     |
 
 For a DB-derived export (HTML or markdown) use the HTTP endpoints
 `/api/v1/sessions/{id}/export` or `/api/v1/sessions/{id}/md`.
@@ -484,55 +462,53 @@ Markdown export accepts an optional `depth` query parameter:
 
 Any other `depth` value is rejected.
 
----
+______________________________________________________________________
 
 ### `agentsview session sync`
 
-Parse and insert a single session. Blocks until indexing and signal
-computation complete. JSON output is the `SessionDetail` of the
-synced session; human output is one line: `synced: <id>`.
+Parse and insert a single session. Blocks until indexing and signal computation
+complete. JSON output is the `SessionDetail` of the synced session; human output
+is one line: `synced: <id>`.
 
 ```bash
 agentsview session sync <path-or-id>
 ```
 
-Argument resolution: if the argument is an existing filesystem
-path, it is treated as a raw JSONL file to parse. Otherwise it is
-treated as a session ID for re-parse.
+Argument resolution: if the argument is an existing filesystem path, it is
+treated as a raw JSONL file to parse. Otherwise it is treated as a session ID
+for re-parse.
 
 With `--server <url>`, path-shaped arguments such as
-`/var/log/agent/session.jsonl` or `./session.jsonl` are sent to the
-remote daemon as paths and resolved on that daemon host. Bare values
-without path separators are treated as session IDs.
+`/var/log/agent/session.jsonl` or `./session.jsonl` are sent to the remote
+daemon as paths and resolved on that daemon host. Bare values without path
+separators are treated as session IDs.
 
-When a single JSONL maps to more than one session (for example a
-Claude transcript with forked/resumed branches), `session sync
-<path>` refuses with an error that lists every candidate id. The
-contract is "one session in, one `SessionDetail` back", so the CLI
-never picks arbitrarily.
+When a single JSONL maps to more than one session (for example a Claude
+transcript with forked/resumed branches), `session sync <path>` refuses with an
+error that lists every candidate id. The contract is "one session in, one
+`SessionDetail` back", so the CLI never picks arbitrarily.
 
-At that point the file has already been parsed and every candidate
-session written to the local archive — the ambiguity check runs
-after the sync engine finishes. Re-run `session sync <id>` with the
-specific session you want; the `<id>` form resolves the file path
-from the archive, so it only works for sessions already present
-there.
+At that point the file has already been parsed and every candidate session
+written to the local archive — the ambiguity check runs after the sync engine
+finishes. Re-run `session sync <id>` with the specific session you want; the
+`<id>` form resolves the file path from the archive, so it only works for
+sessions already present there.
 
-- `session sync` uses a writable local daemon when one is running,
-  or starts a detached daemon when no compatible daemon is running.
-  It then proxies to `POST /api/v1/sessions/sync` so parsing and
-  signal computation remain daemon-owned.
-- If a [`pg serve`](/docs/pg-sync/#agentsview-pg-serve) daemon is
-  running (read-only), sync refuses with a clear error.
-- If `AGENTSVIEW_NO_DAEMON=1` is set, the CLI runs the sync
-  in-process only after acquiring the local write-owner lock.
+- `session sync` uses a writable local daemon when one is running, or starts a
+  detached daemon when no compatible daemon is running. It then proxies to
+  `POST /api/v1/sessions/sync` so parsing and signal computation remain
+  daemon-owned.
+- If a [`pg serve`](/docs/pg-sync/#agentsview-pg-serve) daemon is running
+  (read-only), sync refuses with a clear error.
+- If `AGENTSVIEW_NO_DAEMON=1` is set, the CLI runs the sync in-process only
+  after acquiring the local write-owner lock.
 
----
+______________________________________________________________________
 
 ### `agentsview session watch`
 
-Stream NDJSON events as the session updates. Each line is a small
-object that wraps an SSE event.
+Stream NDJSON events as the session updates. Each line is a small object that
+wraps an SSE event.
 
 ```bash
 agentsview session watch <id>
@@ -543,26 +519,23 @@ agentsview session watch <id>
 {"event":"heartbeat","data":"2026-04-18T12:05:00Z"}
 ```
 
-Recognized `event` values today: `session_updated`, `heartbeat`.
-New events may be added; consumers should ignore unknown events.
-The command runs until interrupted (Ctrl+C) or the context is
-cancelled. Like `session export`, it streams a fixed format and
-rejects `--format`/`--json`.
+Recognized `event` values today: `session_updated`, `heartbeat`. New events may
+be added; consumers should ignore unknown events. The command runs until
+interrupted (Ctrl+C) or the context is cancelled. Like `session export`, it
+streams a fixed format and rejects `--format`/`--json`.
 
-Watch validates the session id before opening the stream. An
-unknown id fails fast with a `watch: session not found: <id>`
-error and non-zero exit instead of producing an indefinite
-heartbeat stream — typos in automation scripts surface immediately.
-When proxied to a daemon, the same condition surfaces as HTTP 404
+Watch validates the session id before opening the stream. An unknown id fails
+fast with a `watch: session not found: <id>` error and non-zero exit instead of
+producing an indefinite heartbeat stream — typos in automation scripts surface
+immediately. When proxied to a daemon, the same condition surfaces as HTTP 404
 at the transport layer before being translated to the CLI error.
 
----
+______________________________________________________________________
 
 ### `agentsview session search`
 
-Substring, RE2 regex, or FTS5 search across message bodies,
-tool inputs, and tool result content. Response shape matches
-`GET /api/v1/search/content`.
+Substring, RE2 regex, or FTS5 search across message bodies, tool inputs, and
+tool result content. Response shape matches `GET /api/v1/search/content`.
 
 ```bash
 agentsview session search <pattern> [flags]
@@ -584,100 +557,91 @@ agentsview session search <pattern> [flags]
 }
 ```
 
-One-shot, automated, and subagent sessions are excluded by
-default; opt back in with `--include-one-shot`,
-`--include-automated`, or `--include-children`.
+One-shot, automated, and subagent sessions are excluded by default; opt back in
+with `--include-one-shot`, `--include-automated`, or `--include-children`.
 
-| Flag                  | HTTP param          | Notes                                                  |
-|-----------------------|---------------------|--------------------------------------------------------|
-| `--regex`             | `mode=regex`        | Treat pattern as an RE2 regex                          |
-| `--fts`               | `mode=fts`          | Tokenized FTS5 search; messages-only                   |
-| `--semantic`          | `mode=semantic`     | Vector search over user/assistant messages; messages-only — see [Semantic Search](/docs/semantic-search/) |
-| `--hybrid`            | `mode=hybrid`       | Semantic + FTS reciprocal rank fusion; messages-only — see [Semantic Search](/docs/semantic-search/) |
-| `--scope`             | `scope`             | `top`, `all` (default), or `subordinate` — semantic/hybrid only; supersedes `include_children` in those modes |
-| `--context`           | `context`           | int — N messages of context before/after each match (max 10) |
-| `--in`                | `in`                | Comma-separated: `messages,tool_input,tool_result` (default all) |
-| `--exclude-system`    | `exclude_system`    | Drop system messages from the scan                     |
-| `--reveal`            | `reveal`            | Show full secret values (localhost-only; warning to stderr) |
-| `--project`           | `project`           | string                                                 |
-| `--exclude-project`   | `exclude_project`   | string                                                 |
-| `--machine`           | `machine`           | string                                                 |
-| —                     | `git_branch`        | opaque token from `GET /api/v1/branches`               |
-| `--agent`             | `agent`             | string                                                 |
-| `--date`              | `date`              | `YYYY-MM-DD`                                           |
-| `--date-from`         | `date_from`         | `YYYY-MM-DD`                                           |
-| `--date-to`           | `date_to`           | `YYYY-MM-DD`                                           |
-| `--active-since`      | `active_since`      | RFC3339 timestamp                                      |
+| Flag                  | HTTP param          | Notes                                                                                                                                                                             |
+| --------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--regex`             | `mode=regex`        | Treat pattern as an RE2 regex                                                                                                                                                     |
+| `--fts`               | `mode=fts`          | Tokenized FTS5 search; messages-only                                                                                                                                              |
+| `--semantic`          | `mode=semantic`     | Vector search over user/assistant messages; messages-only — see [Semantic Search](/docs/semantic-search/)                                                                         |
+| `--hybrid`            | `mode=hybrid`       | Semantic + FTS reciprocal rank fusion; messages-only — see [Semantic Search](/docs/semantic-search/)                                                                              |
+| `--scope`             | `scope`             | `top`, `all` (default), or `subordinate` — semantic/hybrid only; supersedes `include_children` in those modes                                                                     |
+| `--context`           | `context`           | int — N messages of context before/after each match (max 10)                                                                                                                      |
+| `--in`                | `in`                | Comma-separated: `messages,tool_input,tool_result` (default all)                                                                                                                  |
+| `--exclude-system`    | `exclude_system`    | Drop system messages from the scan                                                                                                                                                |
+| `--reveal`            | `reveal`            | Show full secret values (localhost-only; warning to stderr)                                                                                                                       |
+| `--project`           | `project`           | string                                                                                                                                                                            |
+| `--exclude-project`   | `exclude_project`   | string                                                                                                                                                                            |
+| `--machine`           | `machine`           | string                                                                                                                                                                            |
+| —                     | `git_branch`        | opaque token from `GET /api/v1/branches`                                                                                                                                          |
+| `--agent`             | `agent`             | string                                                                                                                                                                            |
+| `--date`              | `date`              | `YYYY-MM-DD`                                                                                                                                                                      |
+| `--date-from`         | `date_from`         | `YYYY-MM-DD`                                                                                                                                                                      |
+| `--date-to`           | `date_to`           | `YYYY-MM-DD`                                                                                                                                                                      |
+| `--active-since`      | `active_since`      | RFC3339 timestamp                                                                                                                                                                 |
 | `--since`             | `active_since`      | Relative — `Nh` hours, `Nd` days, `Nw` weeks, `Nm` calendar months (not minutes), `Ny` years — or `YYYY-MM-DD`; resolved against now and mutually exclusive with `--active-since` |
-| `--include-children`  | `include_children`  | bool                                                   |
-| `--include-automated` | `include_automated` | bool                                                   |
-| `--include-one-shot`  | `include_one_shot`  | bool                                                   |
-| `--limit`             | `limit`             | int; default 50, max 500                               |
-| `--cursor`            | `cursor`            | int — pagination cursor from a previous response       |
+| `--include-children`  | `include_children`  | bool                                                                                                                                                                              |
+| `--include-automated` | `include_automated` | bool                                                                                                                                                                              |
+| `--include-one-shot`  | `include_one_shot`  | bool                                                                                                                                                                              |
+| `--limit`             | `limit`             | int; default 50, max 500                                                                                                                                                          |
+| `--cursor`            | `cursor`            | int — pagination cursor from a previous response                                                                                                                                  |
 
-`--regex`, `--fts`, `--semantic`, and `--hybrid` are mutually
-exclusive. `--fts` is the fastest mode on large archives but only
-searches message bodies; substring (the default) and regex modes
-also walk `tool_calls.input_json`, `tool_calls.result_content`,
-and the `tool_result_events` rows. `--semantic` and `--hybrid`
-require an embedding index and return a single ranked page
-(`--cursor` is rejected) — see [Semantic Search](/docs/semantic-search/)
-for setup, scoring, and limitations.
+`--regex`, `--fts`, `--semantic`, and `--hybrid` are mutually exclusive. `--fts`
+is the fastest mode on large archives but only searches message bodies;
+substring (the default) and regex modes also walk `tool_calls.input_json`,
+`tool_calls.result_content`, and the `tool_result_events` rows. `--semantic` and
+`--hybrid` require an embedding index and return a single ranked page
+(`--cursor` is rejected) — see [Semantic Search](/docs/semantic-search/) for
+setup, scoring, and limitations.
 
-Every match, in every mode, carries the conversation-unit
-citation described in
+Every match, in every mode, carries the conversation-unit citation described in
 [Hit shape](/docs/semantic-search/#hit-shape-ranges-and-anchors):
-`ordinal_range` — `[start, end]` of the conversation unit
-containing the match, always present, `[ordinal, ordinal]` when
-the match is its own unit — plus the lineage fields
-`subordinate`, `relationship`, `parent_session_id`, and
-`is_sidechain`. `ordinal` stays the anchor (the exact matched
-message) in every mode. Only the lineage fields are `omitempty`:
-a missing key unambiguously means top-level with no lineage,
-while `ordinal_range` is never omitted, even at `[0, 0]`.
-`score` is the one field only `--semantic`/`--hybrid` emit.
-`--scope` is rejected outside `--semantic`/`--hybrid`; in those
-modes it supersedes `--include-children`, and
-subagent/fork-typed or parent-linked sessions are exempt from
-the default one-shot exclusion.
+`ordinal_range` — `[start, end]` of the conversation unit containing the match,
+always present, `[ordinal, ordinal]` when the match is its own unit — plus the
+lineage fields `subordinate`, `relationship`, `parent_session_id`, and
+`is_sidechain`. `ordinal` stays the anchor (the exact matched message) in every
+mode. Only the lineage fields are `omitempty`: a missing key unambiguously means
+top-level with no lineage, while `ordinal_range` is never omitted, even at
+`[0, 0]`. `score` is the one field only `--semantic`/`--hybrid` emit. `--scope`
+is rejected outside `--semantic`/`--hybrid`; in those modes it supersedes
+`--include-children`, and subagent/fork-typed or parent-linked sessions are
+exempt from the default one-shot exclusion.
 
-Snippets carry ~60 characters of context on each side of the
-match, snapped to rune boundaries. Any substring that matches
-the [secret scanner](#secret-scanning) rule set is masked unless
-`--reveal` is passed. The same masking applies to the HTTP
-endpoint when called from a remote origin — `reveal=true` is
-only honored on a localhost-bound daemon.
+Snippets carry ~60 characters of context on each side of the match, snapped to
+rune boundaries. Any substring that matches the
+[secret scanner](#secret-scanning) rule set is masked unless `--reveal` is
+passed. The same masking applies to the HTTP endpoint when called from a remote
+origin — `reveal=true` is only honored on a localhost-bound daemon.
 
----
+______________________________________________________________________
 
 ### `agentsview session usage`
 
-Per-session token usage and cost estimate. Output shape is
-stable for the fields shown below; new fields may be added.
+Per-session token usage and cost estimate. Output shape is stable for the fields
+shown below; new fields may be added.
 
-Totals cover the named session **and every subagent transcript spawned
-beneath it**. Claude Code writes each Task-tool subagent to its own file
-under `<session>/subagents/`, which agentsview ingests as a separate
-session; reporting only the parent's own rows understated its cost by up
-to 77% in real sessions. Attribution happens at read time — no rollup is
-persisted, no child row is duplicated under the parent, and daily/activity
-aggregates (which already count subagent sessions as first-class spend)
-are unaffected. Pass `--own-only` to report just the named transcript's
-rows, which is the pre-0.40.0 output.
+Totals cover the named session **and every subagent transcript spawned beneath
+it**. Claude Code writes each Task-tool subagent to its own file under
+`<session>/subagents/`, which agentsview ingests as a separate session;
+reporting only the parent's own rows understated its cost by up to 77% in real
+sessions. Attribution happens at read time — no rollup is persisted, no child
+row is duplicated under the parent, and daily/activity aggregates (which already
+count subagent sessions as first-class spend) are unaffected. Pass `--own-only`
+to report just the named transcript's rows, which is the pre-0.40.0 output.
 
-The REST endpoint is `GET /api/v1/sessions/{id}/usage`, and it is
-own-session by default. Two query params widen it, and they are not
-composable: if both are passed, `rollup=true` takes precedence and
-`subagents` is ignored for that request.
+The REST endpoint is `GET /api/v1/sessions/{id}/usage`, and it is own-session by
+default. Two query params widen it, and they are not composable: if both are
+passed, `rollup=true` takes precedence and `subagents` is ignored for that
+request.
 
-- `?subagents=true` folds descendant usage into `cost`,
-  `total_output_tokens`, `models`, `breakdown`, and `breakdown_count`,
-  and adds `subagent_count`. This is what the CLI requests.
-- `?rollup=true` keeps the totals own-session and reports the combined
-  cost in the separate `rollup_*` fields below. The session detail header
-  uses this form. When both `rollup=true` and `subagents=true` are passed,
-  the handler returns from the rollup branch first, so `subagents` has no
-  effect.
+- `?subagents=true` folds descendant usage into `cost`, `total_output_tokens`,
+  `models`, `breakdown`, and `breakdown_count`, and adds `subagent_count`.
+  This is what the CLI requests.
+- `?rollup=true` keeps the totals own-session and reports the combined cost in
+  the separate `rollup_*` fields below. The session detail header uses this
+  form. When both `rollup=true` and `subagents=true` are passed, the handler
+  returns from the rollup branch first, so `subagents` has no effect.
 
 ```bash
 agentsview session usage <id> [--format json] [--own-only]
@@ -735,48 +699,47 @@ agentsview session usage <id> [--format json] [--own-only]
 }
 ```
 
-| Field                 | Notes                                                                |
-|-----------------------|----------------------------------------------------------------------|
-| `total_output_tokens` | Generated output tokens across the session and its included subagents, deduplicated the same way `cost` is (see below) |
-| `peak_context_tokens` | Highest context-token count observed in any included session; peaks are high-water marks, so they are maxed rather than summed |
-| `has_token_data`      | `false` when no included session has token usage                     |
-| `cost`                | Model-pricing estimate as an integer microdollar object; zero when `has_cost` is `false` |
-| `has_cost`            | `false` if any contributing row is unpriced — never reports a partial total as complete |
-| `cost_usd`            | Deprecated compatibility alias for `cost.microdollars / 1e6`, present only when `has_cost` is `true`; will be removed in a future release, use `cost.microdollars` instead |
-| `cost_source`         | Omitted without a complete cost; `reported` for an authoritative session total, otherwise `computed`, `reported`, or `mixed` for the contributing rows |
-| `ai_credits`          | Omitted unless the priced agent uses AI Credits; derived from `cost_usd` at 100 credits per dollar |
-| `models`              | Models with contributing usage, sorted by model name                    |
-| `unpriced_models`     | Omitted from JSON when empty; lists models seen but missing from pricing |
-| `breakdown_count`     | Number of deduplicated per-step usage rows across all included sessions; always populated |
-| `subagent_count`      | Number of subagent descendant sessions folded in; omitted when zero, so own-session results are byte-identical to before |
-| `breakdown`           | Per-step usage rows ordered by timestamp across all included sessions (the queried session wins ties); when a reported session total exists, row costs are estimated allocations that sum to it; CLI JSON always includes them (added in 0.37.1) |
-| `server_running`      | `true` when the report came from an already-running daemon           |
-| `rollup_cost`          | REST only, with `rollup=true`; integer microdollar object present only when `has_rollup_cost` is true, carrying the complete cost across the root and explicit subagent descendants |
-| `has_rollup_cost`      | REST only, with `rollup=true`; true only when at least one contributing row exists and every contributing row is priced |
-| `rollup_subagent_count`| REST only, with `rollup=true`; count of reachable explicit subagent descendants, including those without usage rows |
+| Field                   | Notes                                                                                                                                                                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `total_output_tokens`   | Generated output tokens across the session and its included subagents, deduplicated the same way `cost` is (see below)                                                                                                                           |
+| `peak_context_tokens`   | Highest context-token count observed in any included session; peaks are high-water marks, so they are maxed rather than summed                                                                                                                   |
+| `has_token_data`        | `false` when no included session has token usage                                                                                                                                                                                                 |
+| `cost`                  | Model-pricing estimate as an integer microdollar object; zero when `has_cost` is `false`                                                                                                                                                         |
+| `has_cost`              | `false` if any contributing row is unpriced — never reports a partial total as complete                                                                                                                                                          |
+| `cost_usd`              | Deprecated compatibility alias for `cost.microdollars / 1e6`, present only when `has_cost` is `true`; will be removed in a future release, use `cost.microdollars` instead                                                                       |
+| `cost_source`           | Omitted without a complete cost; `reported` for an authoritative session total, otherwise `computed`, `reported`, or `mixed` for the contributing rows                                                                                           |
+| `ai_credits`            | Omitted unless the priced agent uses AI Credits; derived from `cost_usd` at 100 credits per dollar                                                                                                                                               |
+| `models`                | Models with contributing usage, sorted by model name                                                                                                                                                                                             |
+| `unpriced_models`       | Omitted from JSON when empty; lists models seen but missing from pricing                                                                                                                                                                         |
+| `breakdown_count`       | Number of deduplicated per-step usage rows across all included sessions; always populated                                                                                                                                                        |
+| `subagent_count`        | Number of subagent descendant sessions folded in; omitted when zero, so own-session results are byte-identical to before                                                                                                                         |
+| `breakdown`             | Per-step usage rows ordered by timestamp across all included sessions (the queried session wins ties); when a reported session total exists, row costs are estimated allocations that sum to it; CLI JSON always includes them (added in 0.37.1) |
+| `server_running`        | `true` when the report came from an already-running daemon                                                                                                                                                                                       |
+| `rollup_cost`           | REST only, with `rollup=true`; integer microdollar object present only when `has_rollup_cost` is true, carrying the complete cost across the root and explicit subagent descendants                                                              |
+| `has_rollup_cost`       | REST only, with `rollup=true`; true only when at least one contributing row exists and every contributing row is priced                                                                                                                          |
+| `rollup_subagent_count` | REST only, with `rollup=true`; count of reachable explicit subagent descendants, including those without usage rows                                                                                                                              |
 
-Claude Code echoes some parent turns into a subagent's sidechain
-transcript, so the same message can appear in two sessions. Every combined
-figure counts it once: `cost`, `total_output_tokens`, `breakdown`, and
-`breakdown_count` are all derived from one deduplicated row set, so they
-agree with each other and with the day aggregates. This is why the combined
-`total_output_tokens` can be lower than the sum of the included sessions'
-individual `total_output_tokens` — each of those is derived from its own
-transcript in isolation and still contains the echo. A session with no
-per-message usage rows contributes its session-level total instead, since
-it has nothing to deduplicate against.
+Claude Code echoes some parent turns into a subagent's sidechain transcript, so
+the same message can appear in two sessions. Every combined figure counts it
+once: `cost`, `total_output_tokens`, `breakdown`, and `breakdown_count` are all
+derived from one deduplicated row set, so they agree with each other and with
+the day aggregates. This is why the combined `total_output_tokens` can be lower
+than the sum of the included sessions' individual `total_output_tokens` — each
+of those is derived from its own transcript in isolation and still contains the
+echo. A session with no per-message usage rows contributes its session-level
+total instead, since it has nothing to deduplicate against.
 
 Each `breakdown` row carries the fields shown in the example:
 
-| Row field         | Notes                                                            |
-|-------------------|------------------------------------------------------------------|
-| `ordinal`         | 1-based position of the row in the deduplicated usage stream     |
-| `message_ordinal` | Ordinal of the originating message; omitted when the row is not tied to one |
-| `source`          | `message` for per-message token usage; otherwise the usage-event source. Subagent rows keep their real source — they are marked by `subagent_session_id`, not by a different source |
-| `subagent_session_id` | Id of the subagent session the row came from; omitted for the queried session's own rows |
-| `label`           | Display label — `Prompt N` for message rows, `Step N` for other rows tied to a message, else the source name |
-| `web_search_requests` | Anthropic server-side web searches this row was billed for, at $0.01 each on top of tokens; omitted when the row performed none |
-| `cost`            | Per-row integer microdollar object; includes the web search fee when `web_search_requests` is present and the row's cost is computed. A row with an authoritative reported cost is assumed to already settle its own server tool use, so the fee is not added on top even when `web_search_requests` is present. Zero with `has_cost: false` when the model is unpriced and the row performed no web search; an unpriced computed row that did still reports the fee, because the fee does not depend on token rates |
+| Row field             | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ordinal`             | 1-based position of the row in the deduplicated usage stream                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `message_ordinal`     | Ordinal of the originating message; omitted when the row is not tied to one                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `source`              | `message` for per-message token usage; otherwise the usage-event source. Subagent rows keep their real source — they are marked by `subagent_session_id`, not by a different source                                                                                                                                                                                                                                                                                                                                  |
+| `subagent_session_id` | Id of the subagent session the row came from; omitted for the queried session's own rows                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `label`               | Display label — `Prompt N` for message rows, `Step N` for other rows tied to a message, else the source name                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `web_search_requests` | Anthropic server-side web searches this row was billed for, at $0.01 each on top of tokens; omitted when the row performed none                                                                                                                                                                                                                                                                                                                                                                                      |
+| `cost`                | Per-row integer microdollar object; includes the web search fee when `web_search_requests` is present and the row's cost is computed. A row with an authoritative reported cost is assumed to already settle its own server tool use, so the fee is not added on top even when `web_search_requests` is present. Zero with `has_cost: false` when the model is unpriced and the row performed no web search; an unpriced computed row that did still reports the fee, because the fee does not depend on token rates |
 
 Human output is a compact summary:
 
@@ -789,41 +752,37 @@ Subagents:     2 (included)
 Cost:          ~$2.41 (claude-opus-4-7)
 ```
 
-The `Subagents` line appears only when the figures cover subagent
-transcripts, so a session without them (or a `--own-only` run) prints the
-same five lines it always has.
+The `Subagents` line appears only when the figures cover subagent transcripts,
+so a session without them (or a `--own-only` run) prints the same five lines it
+always has.
 
 The leading `~` on the cost line marks a computed or mixed figure. A reported
-cost omits it. The parenthesized model list is
-shown only when contributing models exist, so a cost-only reported session does
-not render empty parentheses. When some contributing models are unpriced, the
-cost line reads `n/a (unpriced: model-x)`; when the session has no token data at
-all, it reads `n/a`. Priced Copilot-family sessions add an `AI Credits` line
-after the cost.
+cost omits it. The parenthesized model list is shown only when contributing
+models exist, so a cost-only reported session does not render empty parentheses.
+When some contributing models are unpriced, the cost line reads
+`n/a (unpriced: model-x)`; when the session has no token data at all, it reads
+`n/a`. Priced Copilot-family sessions add an `AI Credits` line after the cost.
 
-**HTTP endpoint** — as of 0.32.0, the same data is available
-over REST:
+**HTTP endpoint** — as of 0.32.0, the same data is available over REST:
 
 ```http
 GET /api/v1/sessions/{id}/usage
 ```
 
-The response uses the same JSON fields shown above and is
-available from both local SQLite-backed `agentsview serve` and
-read-only [`agentsview pg serve`](/docs/pg-sync/#agentsview-pg-serve).
-HTTP responses set `server_running: true`. As of 0.37.1, pass
-`?breakdown=true` to include the per-step `breakdown` rows;
-without it `breakdown` is `[]` while `breakdown_count` still
-reports the row count. The CLI requests the breakdown on every
-path (local, `--server`, and `--pg`), so its `--format json`
-output always includes the rows; it also passes `subagents=true`
-unless `--own-only` was given, so the three backends return the
-same document. The session detail header uses
-this endpoint to render its
-[per-step usage breakdown](/docs/usage/#token-usage). Existing sessions
-return `200 OK` even when token or cost data is absent; inspect
-`has_token_data`, `has_cost`, and `unpriced_models` to decide
-how to present that state. Missing sessions return `404` with:
+The response uses the same JSON fields shown above and is available from both
+local SQLite-backed `agentsview serve` and read-only
+[`agentsview pg serve`](/docs/pg-sync/#agentsview-pg-serve). HTTP responses set
+`server_running: true`. As of 0.37.1, pass `?breakdown=true` to include the
+per-step `breakdown` rows; without it `breakdown` is `[]` while
+`breakdown_count` still reports the row count. The CLI requests the breakdown on
+every path (local, `--server`, and `--pg`), so its `--format json` output always
+includes the rows; it also passes `subagents=true` unless `--own-only` was
+given, so the three backends return the same document. The session detail header
+uses this endpoint to render its
+[per-step usage breakdown](/docs/usage/#token-usage). Existing sessions return
+`200 OK` even when token or cost data is absent; inspect `has_token_data`,
+`has_cost`, and `unpriced_models` to decide how to present that state. Missing
+sessions return `404` with:
 
 ```json
 {
@@ -839,45 +798,43 @@ Unexpected usage-query failures return `500` with
 
 **Exit codes** — `usage` keeps the older `token-use` contract:
 
-| Code | Meaning                                       |
-|------|-----------------------------------------------|
-| `0`  | Token data or cost present and reported       |
-| `2`  | Session not found in the local archive        |
+| Code | Meaning                                            |
+| ---- | -------------------------------------------------- |
+| `0`  | Token data or cost present and reported            |
+| `2`  | Session not found in the local archive             |
 | `3`  | Session exists but has neither token data nor cost |
 
-The codes classify the reported document, so a session whose only token
-data lives in its subagents exits `0`, not `3`. With `--own-only` it
-exits `3`, as it did before.
+The codes classify the reported document, so a session whose only token data
+lives in its subagents exits `0`, not `3`. With `--own-only` it exits `3`, as it
+did before.
 
-Before querying, the local backend refreshes the session's own transcript
-and the `agent-*.jsonl` files under its `subagents/` directory, so a
-session that just finished reports complete numbers. `--own-only` skips
-the subagent refresh.
+Before querying, the local backend refreshes the session's own transcript and
+the `agent-*.jsonl` files under its `subagents/` directory, so a session that
+just finished reports complete numbers. `--own-only` skips the subagent refresh.
 
-The command uses a writable local daemon when one is running, or
-starts a detached daemon when fresh local data is needed and no
-compatible daemon is running. With `AGENTSVIEW_NO_DAEMON=1`, it
-falls back to direct local SQLite after acquiring the write-owner
-lock for any required refresh. Configured PostgreSQL does not
-change this command's default local behavior; pass `--pg` to read
-usage from the shared PostgreSQL store. With `--server`, it calls
-`GET /api/v1/sessions/{id}/usage` on the explicit daemon. With
-`--pg`, it reads usage from the shared PostgreSQL store.
+The command uses a writable local daemon when one is running, or starts a
+detached daemon when fresh local data is needed and no compatible daemon is
+running. With `AGENTSVIEW_NO_DAEMON=1`, it falls back to direct local SQLite
+after acquiring the write-owner lock for any required refresh. Configured
+PostgreSQL does not change this command's default local behavior; pass `--pg` to
+read usage from the shared PostgreSQL store. With `--server`, it calls
+`GET /api/v1/sessions/{id}/usage` on the explicit daemon. With `--pg`, it reads
+usage from the shared PostgreSQL store.
 
 Pricing comes from the same `model_pricing` table and
-[custom pricing overrides](/docs/token-usage/#custom-model-pricing)
-that back `agentsview usage daily`. Replaces the older
-[`agentsview token-use`](/docs/commands/#agentsview-token-use), which
-remains as a deprecated alias.
+[custom pricing overrides](/docs/token-usage/#custom-model-pricing) that back
+`agentsview usage daily`. Replaces the older
+[`agentsview token-use`](/docs/commands/#agentsview-token-use), which remains as
+a deprecated alias.
 
----
+______________________________________________________________________
 
 ## Activity Report
 
-The Activity report endpoint powers the top-level
-[Activity](/docs/activity/) page and the `agentsview activity report`
-CLI command. It returns one resolved range with concurrency buckets,
-summary totals, breakdowns, and contributing sessions.
+The Activity report endpoint powers the top-level [Activity](/docs/activity/)
+page and the `agentsview activity report` CLI command. It returns one resolved
+range with concurrency buckets, summary totals, breakdowns, and contributing
+sessions.
 
 ```http
 GET /api/v1/activity/report
@@ -889,9 +846,8 @@ bucket filtering, and pagination stay page-bounded. Stateless clients can add
 `include_report=true`; a `refresh_required` response includes its complete
 replacement report regardless.
 
-Activity includes one-shot sessions by default. Automated sessions
-are also included by default and can be filtered with the
-`automation` query parameter.
+Activity includes one-shot sessions by default. Automated sessions are also
+included by default and can be filtered with the `automation` query parameter.
 
 The JSON response shares the same `schema_version`, `pricing`, and `projects`
 metadata contract as `agentsview activity report --json`.
@@ -901,19 +857,19 @@ plain JSON. Clients requesting `text/event-stream` receive throttled `progress`
 events followed by one terminal `report` event. Both forms use the long-running
 route and are not subject to the ordinary 30-second operation timeout.
 
-| Query param | Notes |
-|-------------|-------|
-| `preset` | `day`, `week`, `month`, or `custom` |
-| `date` | Anchor date for day/week/month presets (`YYYY-MM-DD`) |
-| `from` | Custom range start, RFC3339 |
-| `to` | Custom range end, RFC3339 |
-| `timezone` | IANA timezone name; default `UTC` |
-| `bucket` | Optional bucket override: `5m`, `15m`, `1h`, `1d`, or `1w` |
-| `project` | Filter by project |
-| `git_branch` | Filter by opaque branch token from `GET /api/v1/branches` |
-| `agent` | Filter by agent |
-| `machine` | Filter by machine |
-| `automation` | `all`, `interactive`, or `automated`; default `all` |
+| Query param  | Notes                                                      |
+| ------------ | ---------------------------------------------------------- |
+| `preset`     | `day`, `week`, `month`, or `custom`                        |
+| `date`       | Anchor date for day/week/month presets (`YYYY-MM-DD`)      |
+| `from`       | Custom range start, RFC3339                                |
+| `to`         | Custom range end, RFC3339                                  |
+| `timezone`   | IANA timezone name; default `UTC`                          |
+| `bucket`     | Optional bucket override: `5m`, `15m`, `1h`, `1d`, or `1w` |
+| `project`    | Filter by project                                          |
+| `git_branch` | Filter by opaque branch token from `GET /api/v1/branches`  |
+| `agent`      | Filter by agent                                            |
+| `machine`    | Filter by machine                                          |
+| `automation` | `all`, `interactive`, or `automated`; default `all`        |
 
 Project, branch, agent, and machine filters are limited to 1,024 UTF-8 bytes
 each and 3,072 bytes combined. The fully encoded signed report ID is also
@@ -1040,40 +996,39 @@ Response excerpt:
 }
 ```
 
-Breakdown rows include total, automated, and interactive minutes and
-costs. Session rows with no reliable timestamped activity use
-`"timing_quality": "untimed"` and `agent_minutes: null`; they can
-still contribute cost and output tokens when usage rows exist.
+Breakdown rows include total, automated, and interactive minutes and costs.
+Session rows with no reliable timestamped activity use
+`"timing_quality": "untimed"` and `agent_minutes: null`; they can still
+contribute cost and output tokens when usage rows exist.
 
 Schema v6 returns at most the first 200 session rows in `by_session` and no
 longer returns raw activity intervals. Fetch later pages, alternate sorts, or a
 bucket drill-down through the sessions endpoint. It accepts `limit` (default
 200, maximum 500), `cursor`, `sort`, `direction`, and the zero-based half-open
-range `bucket_start` and `bucket_end`. Both range bounds must be present.
-If the archive changed since the signed `report_id` was created, the response
-sets `refresh_required` and includes a complete replacement `report` so clients
-never combine different report generations.
+range `bucket_start` and `bucket_end`. Both range bounds must be present. If the
+archive changed since the signed `report_id` was created, the response sets
+`refresh_required` and includes a complete replacement `report` so clients never
+combine different report generations.
 
----
+______________________________________________________________________
 
 ## Secret Scanning
 
-As of 0.30.0, AgentsView scans session content for credentials
-during sync and exposes findings through CLI, HTTP, and per-
-session metadata. Two confidence tiers exist:
+As of 0.30.0, AgentsView scans session content for credentials during sync and
+exposes findings through CLI, HTTP, and per- session metadata. Two confidence
+tiers exist:
 
-| Tier | Rules | When scanned |
-|------|-------|--------------|
-| **Definite** | Well-anchored vendor formats: AWS access keys, Anthropic `sk-ant-…`, OpenAI `sk-proj-`/`sk-svcacct-`/`sk-admin-`, GitHub `ghp_…` and `github_pat_…`, GitLab `glpat-…`, Slack `xoxb`/`xoxa`/`xoxp`/`xoxr`/`xoxs`, Stripe `sk_live_…` and `rk_live_…`, Google `AIza…`, npm `npm_…`, PyPI `pypi-…`, Hugging Face `hf_…`, SendGrid `SG.…`, PEM private-key blocks | Inline during sync |
-| **Candidate** | FP-prone heuristics: basic-auth URLs, JWTs, high-entropy assignments | Only when `agentsview secrets scan` runs explicitly |
+| Tier          | Rules                                                                                                                                                                                                                                                                                                                                                         | When scanned                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| **Definite**  | Well-anchored vendor formats: AWS access keys, Anthropic `sk-ant-…`, OpenAI `sk-proj-`/`sk-svcacct-`/`sk-admin-`, GitHub `ghp_…` and `github_pat_…`, GitLab `glpat-…`, Slack `xoxb`/`xoxa`/`xoxp`/`xoxr`/`xoxs`, Stripe `sk_live_…` and `rk_live_…`, Google `AIza…`, npm `npm_…`, PyPI `pypi-…`, Hugging Face `hf_…`, SendGrid `SG.…`, PEM private-key blocks | Inline during sync                                  |
+| **Candidate** | FP-prone heuristics: basic-auth URLs, JWTs, high-entropy assignments                                                                                                                                                                                                                                                                                          | Only when `agentsview secrets scan` runs explicitly |
 
-Findings are written to a `secret_findings` table keyed by
-session ID, with the rule name, confidence, location
-(message / tool_input / tool_result / tool_result_event),
-match coordinates, and a `redacted_match` value (the raw
-secret is never stored). Each session also carries a
-`secret_leak_count` and a `secrets_rules_version` so a future
-ruleset bump can drive an incremental backfill.
+Findings are written to a `secret_findings` table keyed by session ID, with the
+rule name, confidence, location (message / tool_input / tool_result /
+tool_result_event), match coordinates, and a `redacted_match` value (the raw
+secret is never stored). Each session also carries a `secret_leak_count` and a
+`secrets_rules_version` so a future ruleset bump can drive an incremental
+backfill.
 
 ### HTTP API
 
@@ -1083,28 +1038,26 @@ POST /api/v1/secrets/scan
 GET /api/v1/search/content    (when called with text that matches a secret rule, snippets are masked)
 ```
 
-`GET /api/v1/secrets` accepts: `project`, `agent`, `date_from`,
-`date_to`, `rule`, `confidence` (`definite` / `candidate` /
-`all`, default `definite`), `reveal`, `limit`, `cursor`.
-`reveal=true` is only honored on a localhost-bound daemon —
-remote callers that request reveal receive HTTP 403.
+`GET /api/v1/secrets` accepts: `project`, `agent`, `date_from`, `date_to`,
+`rule`, `confidence` (`definite` / `candidate` / `all`, default `definite`),
+`reveal`, `limit`, `cursor`. `reveal=true` is only honored on a localhost-bound
+daemon — remote callers that request reveal receive HTTP 403.
 
-`POST /api/v1/secrets/scan` streams progress with
-Server-Sent Events and accepts `backfill`, `project`, `agent`,
-`date_from`, and `date_to`. It is only available from a
-writable local daemon.
+`POST /api/v1/secrets/scan` streams progress with Server-Sent Events and accepts
+`backfill`, `project`, `agent`, `date_from`, and `date_to`. It is only available
+from a writable local daemon.
 
 ### Listing sessions with findings
 
 `agentsview session list --has-secret` (or `has_secret=true` on
-`GET /api/v1/sessions`) returns only sessions with at least one
-definite finding. The candidate tier does not contribute to
-`secret_leak_count` and so does not surface through this filter.
+`GET /api/v1/sessions`) returns only sessions with at least one definite
+finding. The candidate tier does not contribute to `secret_leak_count` and so
+does not surface through this filter.
 
 ### CLI
 
-The [`agentsview secrets`](/docs/commands/#agentsview-secrets) command
-group wraps the scan and list operations. The fast path is:
+The [`agentsview secrets`](/docs/commands/#agentsview-secrets) command group
+wraps the scan and list operations. The fast path is:
 
 ```bash
 # Re-scan the archive with the full ruleset (definite + candidate)
@@ -1117,9 +1070,7 @@ agentsview secrets list --reveal
 
 ### PostgreSQL parity
 
-When [PostgreSQL sync](/docs/pg-sync/) is enabled, the
-`secret_findings` table, the session-level `secret_leak_count`,
-and the `--has-secret` filter all mirror to the shared
-database. Substring and regex content search work the same way
-against `pg serve`, with the same masking and `--reveal`
-constraints.
+When [PostgreSQL sync](/docs/pg-sync/) is enabled, the `secret_findings` table,
+the session-level `secret_leak_count`, and the `--has-secret` filter all mirror
+to the shared database. Substring and regex content search work the same way
+against `pg serve`, with the same masking and `--reveal` constraints.

--- a/docs/superpowers/plans/2026-09-01-release-documentation-refresh.md
+++ b/docs/superpowers/plans/2026-09-01-release-documentation-refresh.md
@@ -1,0 +1,321 @@
+# Release Documentation Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish an accurate, outcome-first 0.42.0 story across the changelog,
+Zensical documentation, marketing site, and generated screenshots.
+
+**Architecture:** Keep the existing three-tier site and asset-branch design.
+Edit the canonical Markdown and hand-written marketing sources, regenerate the
+privacy-filtered UI screenshots on the orphan asset branch, assemble the site,
+and inspect desktop and mobile renders.
+
+**Tech Stack:** Markdown, Zensical, static HTML/CSS/JavaScript, Go documentation
+validators, Docker, Playwright, Git orphan asset branches.
+
+## Global Constraints
+
+- Keep the current site routes, visual system, and nine-part product story.
+- Lead with user outcomes. Put implementation detail after the visible change.
+- Use “local-first system of record” in the marketing hero subline, not the
+  headline.
+- Describe AgentsView as local by default. Explain that data leaves the machine
+  only when the user configures a remote or hosted target.
+- Preserve changelog dates, facts, limits, issue references, and
+  acknowledgements from 0.36.0 through 0.42.0.
+- Keep image media off `main`; generated PNGs belong on `docs-generated-assets`.
+- Do not push branches, deploy the site, or publish assets.
+
+______________________________________________________________________
+
+### Task 1: Set the Changelog Standard and Rewrite Recent Releases
+
+**Files:**
+
+- Modify: `AGENTS.md`
+- Modify: `docs/changelog.md`
+
+**Interfaces:**
+
+- Consumes: the 0.42.0 feature list and release tags from `v0.36.0` through
+  `v0.42.0`.
+
+- Produces: the durable writing rule and canonical public release history used
+  by Zensical and the Markdown twin.
+
+- [ ] **Step 1: Add the durable changelog rule**
+
+    Add a `Changelog` subsection under `Content and Publishing` in `AGENTS.md`.
+    Require plain language, user-visible outcomes first, and technical details
+    only when they help readers act or understand a limit.
+
+- [ ] **Step 2: Promote 0.42.0 from Unreleased**
+
+    Replace `## Unreleased` with `## 0.42.0` dated `2026-09-01`. Rewrite the
+    supplied features, improvements, and fixes as outcome-first bullets.
+    Preserve exact command and config names where readers need them.
+
+- [ ] **Step 3: Rewrite the previous two months**
+
+    Review every release from 0.41.1 through 0.36.0. Rewrite bullets that begin
+    with internal mechanisms, compress implementation detail that does not
+    change user action, define specialized terms on first use, and retain each
+    release's acknowledgements unchanged except for line wrapping.
+
+- [ ] **Step 4: Format and inspect the release history**
+
+    Run:
+
+    ```bash
+    docs/.venv/bin/mdformat --wrap 80 AGENTS.md docs/changelog.md
+    git diff --check
+    sed -n '1,1100p' docs/changelog.md
+    ```
+
+    Expected: formatting and whitespace checks pass; versions 0.42.0 through
+    0.36.0 remain ordered newest-first with dates and acknowledgements.
+
+### Task 2: Bring the Public Documentation Up to 0.42.0
+
+**Files:**
+
+- Modify: `docs/index.md`
+- Modify: `docs/quickstart.md`
+- Modify: `docs/commands.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/hosted-raw-sync.md`
+- Modify: `docs/one-shot-capture.md`
+- Modify: `docs/token-usage.md`
+- Modify: `docs/session-api.md`
+- Modify: `docs/recall.md`
+- Modify: `docs/pg-sync.md`
+- Modify: `docs/zensical.toml`
+- Modify other public `docs/*.md` pages only when the 0.42.0 audit finds an
+  inaccurate statement or broken cross-link.
+
+**Interfaces:**
+
+- Consumes: the implemented CLI help, configuration schema, API routes, and
+  focused internal design documentation for each 0.42.0 feature.
+
+- Produces: task-oriented documentation and navigation that agree with the
+  shipped commands and privacy boundaries.
+
+- [ ] **Step 1: Verify each released contract in source**
+
+    Trace hosted raw sync, capture, S3 provider coverage, source-path opt-in,
+    historical pricing, and Recall candidate policy to their owning commands,
+    configuration, and API implementation. Record only behavior supported by
+    source or executable help.
+
+- [ ] **Step 2: Rewrite hosted raw sync as a released workflow**
+
+    Remove “in development” and “no supported command” language. Lead with the
+    outcome: a device can continuously upload recoverable raw session history to
+    a configured host. Document device authentication, consent for shortened
+    uploads, resumable transfers, checkpoints, status, watching, HTTPS, and the
+    separation from parsed PostgreSQL sync.
+
+- [ ] **Step 3: Update the remaining 0.42.0 task pages**
+
+    Make one-shot capture start with its exact per-run usage result. Document the
+    provider, S3, Japanese localization, historical pricing, source-path,
+    candidate-policy, and usage-cache changes where users configure or observe
+    them. Keep experimental or opt-in labels where they remain true.
+
+- [ ] **Step 4: Correct site-wide privacy and navigation language**
+
+    Replace absolute “no cloud services” claims with “local by default” wording.
+    Rename the Zensical navigation item to `Hosted Raw Sync`. Add or repair
+    links from overview and quick-start pages so readers can find the released
+    workflows.
+
+- [ ] **Step 5: Format and validate source Markdown**
+
+    Run:
+
+    ```bash
+    docs/.venv/bin/mdformat --wrap 80 docs/*.md
+    python3 docs/scripts/check_markdown_sources.py
+    git diff --check
+    ```
+
+    Expected: all three commands exit successfully.
+
+### Task 3: Make the Marketing Site Lead With the Outcome
+
+**Files:**
+
+- Modify: `docs/website/index.html`
+- Modify: `docs/website/index.md`
+- Modify: `docs/website/guide/index.html`
+- Modify: `docs/website/guide.md`
+- Modify: `docs/website/styles/site.css` only if the approved hero copy exposes
+  a verified layout problem.
+
+**Interfaces:**
+
+- Consumes: the corrected public documentation and generated screenshot paths.
+
+- Produces: matching human-readable HTML and machine-readable Markdown product
+  stories.
+
+- [ ] **Step 1: Rewrite the hero hierarchy**
+
+    Use the outcome-first headline
+    `Find every coding-agent session, answer, and cost in one place.` Put
+    `AgentsView is the local-first system of record for your coding-agent sessions.`
+    at the start of the supporting copy. Keep the install command and primary
+    calls to action.
+
+- [ ] **Step 2: Update the nine-part story**
+
+    Preserve the numbered sections and layout. Shorten internal language, add the
+    0.42.0 hosted-sync outcome to the sharing story, and make the ownership
+    section say local by default rather than claiming no hosted service exists.
+
+- [ ] **Step 3: Keep HTML and Markdown twins equivalent**
+
+    Compare each marketing heading, outcome, command, limitation, and destination
+    link between `index.html` and `index.md`, then between the guide HTML and
+    Markdown files.
+
+- [ ] **Step 4: Build and inspect the source diff**
+
+    Run:
+
+    ```bash
+    docs/.venv/bin/mdformat --wrap 80 docs/website/index.md docs/website/guide.md
+    AGENTSVIEW_DOCS_USE_LOCAL_ASSET_BRANCHES=1 make docs-build
+    git diff --check
+    ```
+
+    Expected: the assembled three-tier site builds without validator errors.
+
+### Task 4: Regenerate and Review Published Screenshots
+
+**Files:**
+
+- Regenerate ignored files under: `docs/assets/generated/screenshots/`
+- Update local orphan branch: `docs-generated-assets`
+- Modify: `docs/screenshots/tests/screenshots.spec.ts` only if a released UI
+  route or control makes an existing capture invalid.
+
+**Interfaces:**
+
+- Consumes: the current branch build and the screenshot pipeline's
+  privacy-filtered database extractor.
+
+- Produces: the complete expected PNG set used by the marketing site, guide,
+  README, and Zensical docs.
+
+- [ ] **Step 1: Run the isolated screenshot pipeline**
+
+    Run:
+
+    ```bash
+    make docs-generated-assets-branch
+    ```
+
+    Expected: Docker builds the branch binary, Playwright finishes with no failed
+    screenshot tests, every expected PNG exists, and the command updates only
+    the local `docs-generated-assets` ref.
+
+- [ ] **Step 2: Scan the outgoing media**
+
+    Use the configured private-terms file and structural path, hostname, email,
+    and identity checks against the generated file names and extracted image
+    text. Inspect PNG metadata and require no unexpected author, path, host, or
+    location fields.
+
+- [ ] **Step 3: Inspect every screenshot at original resolution**
+
+    Build contact sheets for coverage, then open any dense, clipped, blank, or
+    suspicious image individually at original resolution. Confirm that captions,
+    selected controls, tooltips, tables, and modal bounds are visible and that
+    no private data appears in pixels.
+
+- [ ] **Step 4: Rehydrate from the local asset branches**
+
+    Run:
+
+    ```bash
+    AGENTSVIEW_DOCS_USE_LOCAL_ASSET_BRANCHES=1 docs/assets/hydrate-assets.sh
+    ```
+
+    Expected: all generated assets hydrate from the new local orphan commit.
+
+### Task 5: Verify the Complete Site and Commit the Refresh
+
+**Files:**
+
+- Verify all files changed by Tasks 1–4.
+
+**Interfaces:**
+
+- Consumes: the edited sources and regenerated asset branch.
+
+- Produces: a committed, reviewable documentation refresh with local rendered
+  evidence.
+
+- [ ] **Step 1: Run the complete documentation checks**
+
+    Run:
+
+    ```bash
+    AGENTSVIEW_DOCS_USE_LOCAL_ASSET_BRANCHES=1 make docs-check
+    git diff --check
+    ```
+
+    Expected: all source, build, redirect, asset, and link validators pass.
+
+- [ ] **Step 2: Inspect assembled desktop and mobile pages**
+
+    Serve `docs/site/` on loopback. Capture the landing page, guide, docs home,
+    hosted raw sync, changelog, and one-shot capture at `1440x900` and
+    `390x844`. View every capture and confirm readable hierarchy, no overflow,
+    correct image loading, and matching privacy language.
+
+- [ ] **Step 3: Perform the final private-data scan**
+
+    Scan the full tracked diff, untracked files selected for commit, commit
+    message, and regenerated screenshot set. Require zero denylist or structural
+    privacy hits before committing.
+
+- [ ] **Step 4: Review and commit the tracked changes**
+
+    Review `git status --short`, `git diff --stat`, `git diff HEAD`, and recent
+    commit style. Stage only the documentation refresh, run staged whitespace
+    and privacy checks, then create one conventional `docs:` commit with a plain
+    language body explaining why the release story changed.
+
+### Task 6: Finish Release Monitoring
+
+**Files:** none.
+
+**Interfaces:**
+
+- Consumes: GitHub Actions run IDs `33550358918`, `33550359123`, and
+  `33550358969` plus the published `v0.42.0` release record.
+
+- Produces: an evidence-backed final status for release binaries, desktop
+  bundles, Docker images, and published assets.
+
+- [ ] **Step 1: Wait for all release workflows to finish**
+
+    Query each run until `status=completed`. If a conclusion is not `success`,
+    inspect the failed job and logs before reporting it.
+
+- [ ] **Step 2: Verify the published release record**
+
+    Run:
+
+    ```bash
+    gh release view v0.42.0 --json tagName,publishedAt,assets,url
+    ```
+
+    Expected: the release exists and lists the artifacts produced by the release
+    workflows.

--- a/docs/superpowers/specs/2026-09-01-release-documentation-design.md
+++ b/docs/superpowers/specs/2026-09-01-release-documentation-design.md
@@ -1,0 +1,96 @@
+# Release Documentation Refresh Design
+
+## Goal
+
+Make the 0.42.0 release easy to understand and keep future changelog entries
+focused on what changes for users. Update the product site and documentation so
+they describe the released product accurately, including its optional hosted
+sync path.
+
+## Approach
+
+Keep the new site's visual system, routes, and nine-part product story. Rewrite
+the content around user outcomes and correct facts that changed in 0.42.0. This
+is broader than a release-note patch but does not redesign the site.
+
+Two other approaches were considered:
+
+- A facts-only patch would be smaller, but it would leave internal terms and
+  implementation-led changelog entries in place.
+- A full site redesign could change the product story, but it would add visual
+  and navigation risk without helping people understand this release.
+
+## Marketing hierarchy
+
+The hero headline states the immediate outcome: people can find their coding
+agent sessions, answers, and costs in one place. The supporting line identifies
+AgentsView as the local-first system of record for coding-agent sessions.
+
+The rest of the page keeps the current progression from capture through search,
+cost, knowledge, sharing, and ownership. Copy leads with the result for the
+reader. Product architecture and implementation details follow only when they
+help explain that result.
+
+The site must describe privacy precisely. AgentsView keeps data local by
+default. Data leaves the machine only when the user configures a remote target,
+including hosted raw sync. The site must not say that the product has no cloud
+services now that an optional hosted path is released.
+
+## Changelog scope and style
+
+Replace the current Unreleased section with a dated 0.42.0 entry based on the
+released feature set. Review and rewrite every release from 0.36.0 on 2026-07-02
+through 0.42.0 on 2026-09-01.
+
+Keep version headings, dates, categories, facts, limitations, issue references,
+and acknowledgements. Each bullet starts with the outcome a user or operator
+will notice. Use a second sentence only when a boundary, migration, opt-in, or
+technical term changes what the reader should do. Keep command names, config
+keys, providers, and storage engines when those names help a reader act.
+
+Add a durable rule to `AGENTS.md`: changelog entries must use plain language,
+lead with human outcomes, and put implementation detail after the user-visible
+change.
+
+## Documentation scope
+
+Review the public Zensical pages against 0.42.0 and update the pages affected by
+the release. The review includes:
+
+- hosted raw sync authentication, resumable upload, checkpointing, consent,
+  continuous watching, and operational boundaries;
+- exact one-shot capture usage and durable raw artifacts;
+- Cursor IDE, ICodeMate, and Posit Assistant session and usage coverage;
+- S3 discovery across supported single-file providers;
+- Japanese localization;
+- historical pricing and OpenRouter coverage;
+- optional source paths in API responses;
+- candidate-finding policy for Recall;
+- usage-report performance and other user-visible 0.42 improvements and fixes.
+
+Navigation labels, overview pages, quick starts, privacy text, cross-links, and
+machine-readable Markdown twins must agree with the detailed pages. Do not claim
+support beyond the implementation or remove documented limits.
+
+## Screenshots
+
+Regenerate the full Playwright screenshot set from the privacy-filtered fixture.
+Review each outgoing PNG at original resolution and inspect its metadata before
+updating the local `docs-generated-assets` orphan branch. Do not push the asset
+branch without a separate request.
+
+Use the refreshed screenshots in the existing marketing and guide layouts. Check
+the landing page, guide, and Zensical documentation at desktop and mobile widths
+after the assets are hydrated.
+
+## Verification
+
+Run the repository's documentation build and checks, Markdown formatting, and
+focused tests for any validator or screenshot-pipeline code that changes.
+Inspect the assembled site and generated screenshots rather than relying only on
+source checks. Scan changed public content and outgoing images for private data
+before committing or publishing.
+
+Continue monitoring the 0.42.0 Release, Desktop Release, and Docker workflows
+until all three finish. If a workflow fails, inspect the failed job before
+making any claim about the cause or proposing a fix.

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -13,10 +13,7 @@ agent activity, see the [Activity](/docs/activity/) dashboard.
 
 If you've used [`ccusage`](https://github.com/ryoppippi/ccusage) this will feel
 familiar. AgentsView covers the same core job — "how much did I spend on AI
-coding yesterday?" — across multiple coding agents from one archive. Because it
-reads from pre-indexed SQLite instead of re-parsing JSONL on every invocation,
-it's also dramatically faster on large histories (see
-[benchmarks](#how-it-compares-to-ccusage) below).
+coding yesterday?" — across multiple coding agents from one archive.
 
 !!! warning "Experimental"
 
@@ -540,43 +537,15 @@ Note that recent Amp versions keep complete threads server-side and leave only
 stub files on disk. AgentsView reports usage for whatever complete threads are
 present locally; threads that exist only as stubs have nothing to read.
 
-## How It Compares to `ccusage`
+## Reporting Model
 
-`ccusage` re-walks every Claude Code JSONL file and re-parses from scratch on
-every invocation. `agentsview usage` queries pre-indexed SQLite with an
-in-memory pricing join, so the cost of reporting drops dramatically as history
-grows.
+`agentsview usage` reads token and cost facts from the same SQLite archive as
+the UI, then joins them with the applicable pricing data.
 
 Version 0.42.0 also keeps an exact daily rollup cache for repeated reports. The
 cache is disposable rather than authoritative: AgentsView rebuilds any missing
-or stale day from the archived usage rows before returning it. This keeps large
-reports fast without trading away exact results.
-
-Measured on a real 22,000-session database (~310,000 token-bearing messages) on
-an M5 Max, median of 5 steady-state runs:
-
-| Command                                                  |    Time | Speedup vs `ccusage` |
-| -------------------------------------------------------- | ------: | -------------------: |
-| `npx ccusage@latest daily --json --offline`              | 44.59 s |                   1× |
-| `agentsview usage daily --json --all --offline`          |  0.53 s |              **84×** |
-| `agentsview usage daily --json --offline` (default 30 d) |  0.41 s |             **109×** |
-| `agentsview usage daily --json --offline --no-sync`      |  0.20 s |             **223×** |
-
-!!! note
-
-    These numbers are from a large local database (22k sessions, 310k token-bearing
-    messages). The speedup scales with session count — smaller databases will see
-    smaller absolute differences because `ccusage` has less JSONL to re-parse, but
-    AgentsView stays in the sub-second range either way. The ratios above are an
-    upper bound, not a universal guarantee.
-
-Apples-to-apples: `ccusage` scans all history by default, so the `--all` row is
-the matched comparison. The default 30-day window is faster still because most
-invocations don't need four months of history, and `--no-sync` skips the
-refresh-recent-files pass entirely (useful when you just want to re-render an
-existing report).
-
-Beyond raw speed, `agentsview usage`:
+or stale day from the archived usage rows before returning it. The reporting
+workflow also:
 
 - **Works beyond Claude Code** — coverage includes Claude Code, Codex, Copilot
   CLI, OpenCode-format tools, Pi, Prime Agent, Gemini, Qwen Code,
@@ -590,7 +559,7 @@ Beyond raw speed, `agentsview usage`:
 - **Includes on-demand sync** — when no AgentsView server is running, `usage`
   does a quick incremental sync scoped to files modified since the last sync
   start time so reports always reflect current state. Skip with `--no-sync`
-  for the fastest path.
+  when you want to report only from the existing archive.
 
 ## `agentsview usage daily`
 

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -30,11 +30,11 @@ it's also dramatically faster on large histories (see
 
 !!! note
 
-    **As of 0.34.0**, usage totals are populated when the source session includes
+    **As of 0.42.0**, usage totals are populated when the source session includes
     token metadata for **Claude Code**, **Codex**, **Copilot CLI**, **OpenCode** and
-    OpenCode-format forks such as **Kilo** and **MiMoCode**, **Pi**, **Prime
-    Agent**, **Gemini**,
-    **Qwen Code**, **OpenClaw**, **QClaw**, **Hermes**, **WorkBuddy**, **Forge**,
+    OpenCode-format forks such as **IcodeMate**, **Kilo**, and **MiMoCode**,
+    **Cursor IDE**, **Posit Assistant**, **Pi**, **Prime Agent**, **Gemini**, **Qwen
+    Code**, **OpenClaw**, **QClaw**, **Hermes**, **WorkBuddy**, **Forge**,
     **Piebald**, **Antigravity IDE/CLI**, **Zed**, **VS Code Copilot**, **Visual
     Studio Copilot**, **Mistral Vibe**, **gptme**, and **Amp**.
 
@@ -298,8 +298,8 @@ Every message parsed from a session file stores its raw `token_usage` JSON
 (input, output, cache creation, cache read) and the model name reported by the
 agent. The usage command:
 
-1. Loads `model_pricing` and its `model_pricing_bands` children into memory
-   once per invocation. They hold base per-million-token rates and any
+1. Loads `model_pricing` and its `model_pricing_bands` children into memory once
+   per invocation. They hold base per-million-token rates and any
    whole-request input thresholds published by the pricing catalog.
 1. Scans `messages` filtered by the requested date range and agent, parsing each
    row's `token_usage` blob in Go with `gjson` — faster than SQLite's per-row
@@ -334,38 +334,37 @@ layered underneath for models LiteLLM does not list. Both are fetched together
 an OpenRouter row is dropped once LiteLLM picks the model up. If the LiteLLM
 fetch fails, AgentsView keeps the last stored rates; if only the OpenRouter
 fetch fails, the fresh LiteLLM rates are still stored and the stored OpenRouter
-rates are kept. Fresh databases are seeded from
-an embedded LiteLLM snapshot so offline use works before any refresh completes.
-Pass `--offline` to skip the fetch entirely and always use the embedded
-fallback.
+rates are kept. Fresh databases are seeded from an embedded LiteLLM snapshot so
+offline use works before any refresh completes. Pass `--offline` to skip the
+fetch entirely and always use the embedded fallback.
 
 The embedded fallback is updated with AgentsView releases, so the numbers are as
 current as your installed version. For up-to-the-minute rates, leave `--offline`
 off.
 
-LiteLLM's standard whole-request 200K and 272K token rates are preserved in
-both fetched and embedded catalogs. Processing variants such as Batch, Flex,
+LiteLLM's standard whole-request 200K and 272K token rates are preserved in both
+fetched and embedded catalogs. Processing variants such as Batch, Flex,
 Priority, regional, and one-hour cache pricing are not inferred when the stored
 usage does not identify that service tier.
 
 ### Anthropic Web Search Fee
 
 Anthropic charges a flat
-[$10 per 1,000 server-side web search requests](https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool)
+\[$10 per 1,000 server-side web search requests](https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool)
 on top of tokens. That fee is not a per-token rate, so it lives outside the
 `model_pricing` catalog as a fixed $0.01 per request. AgentsView adds it to any
 usage row whose stored `token_usage` reports
-`server_tool_use.web_search_requests`, and `session usage --format json`
-reports the per-row count as `web_search_requests` so the charge is auditable.
-A row that carries an authoritative reported cost is left alone, since that
-cost already settles the whole row.
+`server_tool_use.web_search_requests`, and `session usage --format json` reports
+the per-row count as `web_search_requests` so the charge is auditable. A row
+that carries an authoritative reported cost is left alone, since that cost
+already settles the whole row.
 
 Claude Code runs each `WebSearch` in an out-of-band side call and writes a zero
 counter on the assistant message, so AgentsView takes the count from the linked
 tool result instead. That side call's own tokens — tens of thousands of input
 tokens on a Haiku model per search — are not written to the transcript at all
-and are therefore a known undercount: AgentsView records the fee, not the
-hidden tokens.
+and are therefore a known undercount: AgentsView records the fee, not the hidden
+tokens.
 
 As of 0.32.0, the embedded fallback includes `claude-opus-4-7` at the same Opus
 tier used for 4.6 and 4.8, so offline reports and fresh installs price Opus 4.7
@@ -391,13 +390,13 @@ input_microdollars_per_mtok = 200_000
 output_microdollars_per_mtok = 800_000
 ```
 
-| Field                                  | Description                                                                 |
-| -------------------------------------- | --------------------------------------------------------------------------- |
-| `input_microdollars_per_mtok`          | Integer microdollars per million input tokens (defaults to `0` if omitted)  |
-| `output_microdollars_per_mtok`         | Integer microdollars per million output tokens (defaults to `0` if omitted) |
-| `cache_creation_microdollars_per_mtok` | Integer microdollars per million cache-creation tokens (optional)           |
+| Field                                     | Description                                                                                                                                                 |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `input_microdollars_per_mtok`             | Integer microdollars per million input tokens (defaults to `0` if omitted)                                                                                  |
+| `output_microdollars_per_mtok`            | Integer microdollars per million output tokens (defaults to `0` if omitted)                                                                                 |
+| `cache_creation_microdollars_per_mtok`    | Integer microdollars per million cache-creation tokens (optional)                                                                                           |
 | `cache_creation_1h_microdollars_per_mtok` | Integer microdollars per million 1-hour-TTL cache-creation tokens (optional; when omitted or `0`, 1h writes bill at `cache_creation_microdollars_per_mtok`) |
-| `cache_read_microdollars_per_mtok`     | Integer microdollars per million cache-read tokens (optional)               |
+| `cache_read_microdollars_per_mtok`        | Integer microdollars per million cache-read tokens (optional)                                                                                               |
 
 The table key is the model name as it appears in your session data (match the
 string the agent itself writes, dots and all — quote the key if it contains
@@ -412,8 +411,8 @@ stored catalog.
 ### Posit Assistant Billing
 
 For usage rows whose stored provider ID is exactly `positai`, AgentsView
-estimates computed token costs and cache savings at 110% of the selected
-catalog rates. Model, timestamp, and request-band selection happen before the
+estimates computed token costs and cache savings at 110% of the selected catalog
+rates. Model, timestamp, and request-band selection happen before the
 adjustment. Rows with empty or other provider IDs — including observed
 `anthropic` bring-your-own-provider rows in the same session — use base rates.
 
@@ -548,6 +547,11 @@ every invocation. `agentsview usage` queries pre-indexed SQLite with an
 in-memory pricing join, so the cost of reporting drops dramatically as history
 grows.
 
+Version 0.42.0 also keeps an exact daily rollup cache for repeated reports. The
+cache is disposable rather than authoritative: AgentsView rebuilds any missing
+or stale day from the archived usage rows before returning it. This keeps large
+reports fast without trading away exact results.
+
 Measured on a real 22,000-session database (~310,000 token-bearing messages) on
 an M5 Max, median of 5 steady-state runs:
 
@@ -576,18 +580,17 @@ Beyond raw speed, `agentsview usage`:
 
 - **Works beyond Claude Code** — coverage includes Claude Code, Codex, Copilot
   CLI, OpenCode-format tools, Pi, Prime Agent, Gemini, Qwen Code,
-  OpenClaw/QClaw, Hermes,
-  WorkBuddy, Forge, Piebald, Antigravity, Zed, VS Code Copilot, Visual Studio
-  Copilot, Mistral Vibe, and gptme from the same database and command whenever
-  those sessions log token metadata. Filter with `--agent <name>` when you want
-  a single-agent view.
+  OpenClaw/QClaw, Hermes, WorkBuddy, Forge, Piebald, Antigravity, Zed, VS Code
+  Copilot, Visual Studio Copilot, Mistral Vibe, and gptme from the same
+  database and command whenever those sessions log token metadata. Filter with
+  `--agent <name>` when you want a single-agent view.
 - **Shares one database with the UI** — the same data powers
-  [Analytics](/docs/usage/#dashboard) and session detail views, so there's no second
-  index to keep fresh.
+  [Analytics](/docs/usage/#dashboard) and session detail views, so there's no
+  second index to keep fresh.
 - **Includes on-demand sync** — when no AgentsView server is running, `usage`
   does a quick incremental sync scoped to files modified since the last sync
-  start time so reports always reflect current state. Skip with `--no-sync` for
-  the fastest path.
+  start time so reports always reflect current state. Skip with `--no-sync`
+  for the fastest path.
 
 ## `agentsview usage daily`
 
@@ -848,8 +851,7 @@ exactly `model_pattern`, `input_per_mtok`, `output_per_mtok`,
 exactly `above_input_tokens`, `input_per_mtok`, `output_per_mtok`,
 `cache_write_per_mtok`, `cache_read_per_mtok`, and `updated_at`. Application
 counts describe one report and are deliberately excluded from the catalog
-digest.
-`updated_at` is `null` or a UTC RFC3339 timestamp such as
+digest. `updated_at` is `null` or a UTC RFC3339 timestamp such as
 `2026-07-03T12:00:00Z`. Digest canonicalization errors fail the export instead
 of emitting an empty digest. The digest uses the resolver's internal canonical
 pricing-row keys; the public `pricing.models` block uses the `*_cost_per_mtok`
@@ -976,8 +978,8 @@ incremental sync before querying so reports always include recent activity:
 1. If the parser data version has changed (i.e. you just upgraded), a full
    resync runs first.
 1. Otherwise, the sync scans only files modified since the last recorded sync
-   start time, minus a 10-second safety margin to catch files written during the
-   prior sync.
+   start time, minus a 10-second safety margin to catch files written during
+   the prior sync.
 
 If an `agentsview serve` process is already running, the file watcher already
 has you covered and the on-demand sync is skipped to avoid duplicate work. A
@@ -1029,8 +1031,7 @@ systemd timer's journal, or a Windows Task Scheduler action.
 
 `--json` reports the cost as exact microdollars, so the threshold is an integer
 comparison instead of a parse of the formatted line. `jq -e` fails the script
-when the value is missing, so a broken read cannot pass for an under-budget
-day:
+when the value is missing, so a broken read cannot pass for an under-budget day:
 
 ```bash
 budget_usd=25
@@ -1046,11 +1047,12 @@ fi
 ## Where the Data Lives
 
 Usage reports read from the same local SQLite database that powers the
-[web UI](/docs/usage/) and [Analytics dashboard](/docs/usage/#dashboard). Token usage is
-stored on each message row in the `messages` table; pricing is cached in a small
-`model_pricing` table that's refreshed on each `usage` invocation.
+[web UI](/docs/usage/) and [Analytics dashboard](/docs/usage/#dashboard). Token
+usage is stored on each message row in the `messages` table; pricing is cached
+in a small `model_pricing` table that's refreshed on each `usage` invocation.
 
-Session data stays on your machine. The only outbound requests are the LiteLLM
-and OpenRouter pricing fetches, which you can disable with `--offline`. See
+Usage data stays on your machine unless you enable a sharing feature. The usage
+command's only outbound requests are the LiteLLM and OpenRouter pricing fetches,
+which you can disable with `--offline`. See
 [Privacy and Telemetry](/docs/configuration/#privacy-and-telemetry) for the full
 picture.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,71 +3,67 @@ title: Usage Guide
 description: Complete guide to the AgentsView web interface
 ---
 
-AgentsView serves a full-featured web application for browsing,
-searching, and analyzing your AI agent sessions. This page walks
-through every part of the interface.
+AgentsView serves a full-featured web application for browsing, searching, and
+analyzing your AI agent sessions. This page walks through every part of the
+interface.
 
 ## Dashboard
 
-When you open AgentsView with no session selected, you see the
-analytics dashboard. It provides a high-level overview of your
-agent activity across all projects.
+When you open AgentsView with no session selected, you see the analytics
+dashboard. It provides a high-level overview of your agent activity across all
+projects.
 
 ![Analytics dashboard](/docs/assets/generated/screenshots/dashboard.png)
 
 The dashboard header includes:
 
-- **Project filter** — typeahead to scope everything to a single
-  project. Type to filter by name; each entry shows its session
-  count. Navigate with arrow keys, select with Enter, and close
-  with Escape.
+- **Project filter** — typeahead to scope everything to a single project. Type
+  to filter by name; each entry shows its session count. Navigate with arrow
+  keys, select with Enter, and close with Escape.
 - **Search bar** — opens the command palette (`Cmd+K`)
 - **Sync button** — triggers a manual sync of session files
 - **Theme toggle** — switch between light and dark mode
-- **Import button** — opens the [Chat Import](/docs/chat-import/)
-  dialog for importing Claude.ai or ChatGPT conversations
+- **Import button** — opens the [Chat Import](/docs/chat-import/) dialog for
+  importing Claude.ai or ChatGPT conversations
 - **Shortcuts button** (`?`) — shows all keyboard shortcuts
 
-The status bar at the bottom shows session count, message count,
-project count, last sync time, and the build version.
+The status bar at the bottom shows session count, message count, project count,
+last sync time, and the build version.
 
-On the normal local `agentsview serve` runtime, the session lists in
-the sidebar update automatically from a global SSE event stream
-(debounced during busy syncs). The dashboard, Usage page, and
-Activity page do not refetch their charts on every sync event —
-each pairs a manual refresh button with a relative "Updated…"
-timestamp, and the Analytics dashboard also refreshes periodically
-on its own. Click refresh, or change the date range, to pull the
-latest numbers.
+On the normal local `agentsview serve` runtime, the session lists in the sidebar
+update automatically from a global SSE event stream (debounced during busy
+syncs). The dashboard, Usage page, and Activity page do not refetch their charts
+on every sync event — each pairs a manual refresh button with a relative
+"Updated…" timestamp, and the Analytics dashboard also refreshes periodically on
+its own. Click refresh, or change the date range, to pull the latest numbers.
 
-For range-based concurrency and agent-minutes reporting, use the
-top-level [Activity](/docs/activity/) page.
+For range-based concurrency and agent-minutes reporting, use the top-level
+[Activity](/docs/activity/) page.
 
 ### Summary Cards
 
-Six cards at the top of the dashboard show key metrics for the
-selected date range:
+Six cards at the top of the dashboard show key metrics for the selected date
+range:
 
 ![Summary cards](/docs/assets/generated/screenshots/summary-cards.png)
 
-| Card | Description |
-|------|-------------|
-| Sessions | Total session count |
-| Messages | Total message count |
-| Projects | Number of active projects |
-| Active Days | Days with at least one session |
-| Messages/Session | Average with median and p90 |
-| Concentration | Most active project and its share |
+| Card             | Description                       |
+| ---------------- | --------------------------------- |
+| Sessions         | Total session count               |
+| Messages         | Total message count               |
+| Projects         | Number of active projects         |
+| Active Days      | Days with at least one session    |
+| Messages/Session | Average with median and p90       |
+| Concentration    | Most active project and its share |
 
 ### Date Range Picker
 
-Quick presets for 7 days, 30 days, 90 days, 1 year, and All,
-plus custom start/end date inputs. The **All** preset shows
-every session regardless of age. All charts update when the
-range changes. The same range picker is used on the dashboard,
-the [Usage](/docs/token-usage/#usage-dashboard) page, and the
-[Activity](/docs/activity/) page so presets and behavior stay
-consistent across panels.
+Quick presets for 7 days, 30 days, 90 days, 1 year, and All, plus custom
+start/end date inputs. The **All** preset shows every session regardless of age.
+All charts update when the range changes. The same range picker is used on the
+dashboard, the [Usage](/docs/token-usage/#usage-dashboard) page, and the
+[Activity](/docs/activity/) page so presets and behavior stay consistent across
+panels.
 
 ![Date range picker](/docs/assets/generated/screenshots/date-range.png)
 
@@ -80,107 +76,100 @@ Activity URL returns to its current-day calendar default unless an enabled
 shared range supplies another selection. The `All` preset always pins to
 `(earliest_session, today)`.
 
-Bare pages use independent defaults: the Sessions dashboard opens
-to a rolling 1-year range, Usage opens to a rolling 30-day range,
-and Activity opens to the current day. Cross-page linking is
-disabled by default because applying a broad range automatically
-can make some pages run substantially more expensive queries.
+Bare pages use independent defaults: the Sessions dashboard opens to a rolling
+1-year range, Usage opens to a rolling 30-day range, and Activity opens to the
+current day. Cross-page linking is disabled by default because applying a broad
+range automatically can make some pages run substantially more expensive
+queries.
 
-To carry selections among Sessions, Usage, Activity, Trends, and
-Quality, enable **Settings > Date ranges > Link date ranges across
-pages**. An explicit dated URL always controls the target page. With
-linking enabled, that selection can then carry to date-aware pages
-opened later at their bare URLs.
+To carry selections among Sessions, Usage, Activity, Trends, and Quality, enable
+**Settings > Date ranges > Link date ranges across pages**. An explicit dated
+URL always controls the target page. With linking enabled, that selection can
+then carry to date-aware pages opened later at their bare URLs.
 
 ### Model Filter
 
-The dashboard toolbar includes a **Model** dropdown that scopes
-every panel to one or more AI models. By default the button reads
-**Model: All** and nothing is filtered.
+The dashboard toolbar includes a **Model** dropdown that scopes every panel to
+one or more AI models. By default the button reads **Model: All** and nothing is
+filtered.
 
 ![Dashboard model filter](/docs/assets/generated/screenshots/analytics-model-filter.png)
 
-Open the dropdown for a searchable list of the models found in
-your sessions, then click models to include them. The button then
-shows the chosen model — for example **Model: gpt-4o** — or
-**Model: 3 selected** once several are active. Click the
-**All models** row at the top of the list to clear the filter and
-return to every model. Selected models also appear as removable
-chips beneath the toolbar.
+Open the dropdown for a searchable list of the models found in your sessions,
+then click models to include them. The button then shows the chosen model — for
+example **Model: gpt-4o** — or **Model: 3 selected** once several are active.
+Click the **All models** row at the top of the list to clear the filter and
+return to every model. Selected models also appear as removable chips beneath
+the toolbar.
 
-While a model filter is active, every dashboard panel reflects
-only the selected model(s): the summary cards, activity chart,
-heatmap, hour-of-week grid, projects, session shape, velocity,
-tools, skills, top sessions, and the Session Health rollup.
+While a model filter is active, every dashboard panel reflects only the selected
+model(s): the summary cards, activity chart, heatmap, hour-of-week grid,
+projects, session shape, velocity, tools, skills, top sessions, and the Session
+Health rollup.
 
-Model filtering is **message-grain**, unlike the session-grain
-project and agent filters, because a single session can switch
-models across turns. A session is included when it has at least
-one message from a selected model, and most panels count only the
-matching messages. The user turn paired with a matching assistant
-turn is kept alongside it — even though a user message carries no
-model of its own — so prompts and their responses stay aligned in
-the counts and in the top-session evidence.
+Model filtering is **message-grain**, unlike the session-grain project and agent
+filters, because a single session can switch models across turns. A session is
+included when it has at least one message from a selected model, and most panels
+count only the matching messages. The user turn paired with a matching assistant
+turn is kept alongside it — even though a user message carries no model of its
+own — so prompts and their responses stay aligned in the counts and in the
+top-session evidence.
 
-**Session Health** is the exception. It is scoped to whole
-sessions that used the selected model, but its health scores,
-outcomes, tool-failure rates, and compaction counts stay
-whole-session aggregates — they are not recomputed from only that
-model's messages.
+**Session Health** is the exception. It is scoped to whole sessions that used
+the selected model, but its health scores, outcomes, tool-failure rates, and
+compaction counts stay whole-session aggregates — they are not recomputed from
+only that model's messages.
 
 !!! note "Dashboard-only scope"
+
     The model filter applies only to the analytics dashboard. The
-    [Generated insights](/docs/recall/?tab=generated) and the session list are
-    not scoped by it, so a model selected here does not silently
-    narrow those views. The [Usage](/docs/token-usage/) page keeps its
-    own separate model filter.
+    [Generated insights](/docs/recall/?tab=generated) and the session list are not
+    scoped by it, so a model selected here does not silently narrow those views. The
+    [Usage](/docs/token-usage/) page keeps its own separate model filter.
 
 ### Activity Heatmap
 
-A GitHub-style contribution graph showing daily activity. Toggle
-between message count and session count.
+A GitHub-style contribution graph showing daily activity. Toggle between message
+count and session count.
 
 ![Activity heatmap](/docs/assets/generated/screenshots/heatmap.png)
 
 #### Click-to-Filter
 
-Click any heatmap cell to filter all charts and the session list
-to that single day. The selected cell gets a highlighted border,
-and an active filter chip appears in the toolbar. Click the same
-cell again (or dismiss the filter chip) to deselect.
+Click any heatmap cell to filter all charts and the session list to that single
+day. The selected cell gets a highlighted border, and an active filter chip
+appears in the toolbar. Click the same cell again (or dismiss the filter chip)
+to deselect.
 
 ![Heatmap filtered to a single day](/docs/assets/generated/screenshots/heatmap-filtered.png)
 
 ### Hour of Week Heatmap
 
-A 7x24 grid showing when you use agents most. Rows are days of
-the week, columns are hours. Color intensity represents message
-volume.
+A 7x24 grid showing when you use agents most. Rows are days of the week, columns
+are hours. Color intensity represents message volume.
 
 ![Hour of week heatmap](/docs/assets/generated/screenshots/hour-of-week.png)
 
 ### Activity Timeline
 
-A stacked chart showing messages, sessions, tool calls, and
-thinking blocks over time. Toggle between daily, weekly, and
-monthly granularity. Includes breakdown by agent.
+A stacked chart showing messages, sessions, tool calls, and thinking blocks over
+time. Toggle between daily, weekly, and monthly granularity. Includes breakdown
+by agent.
 
 ![Activity timeline](/docs/assets/generated/screenshots/activity-timeline.png)
 
 ### Top Sessions
 
-A ranked list of your longest sessions by message count or
-duration. Click any session to jump directly to it in the
-session viewer.
+A ranked list of your longest sessions by message count or duration. Click any
+session to jump directly to it in the session viewer.
 
 ![Top sessions](/docs/assets/generated/screenshots/top-sessions.png)
 
 ### Project Breakdown
 
-Bar chart of all projects sorted by session or message count.
-Shows average and median messages per session for each project.
-Click any project bar to filter the dashboard and session list
-to that project.
+Bar chart of all projects sorted by session or message count. Shows average and
+median messages per session for each project. Click any project bar to filter
+the dashboard and session list to that project.
 
 ![Project breakdown](/docs/assets/generated/screenshots/project-breakdown.png)
 
@@ -189,33 +178,32 @@ to that project.
 Three histograms showing the distribution of:
 
 1. **Session length** — number of messages per session
-2. **Session duration** — time in minutes
-3. **Session autonomy** — ratio of tool calls to conversation turns
+1. **Session duration** — time in minutes
+1. **Session autonomy** — ratio of tool calls to conversation turns
 
 ![Session shape](/docs/assets/generated/screenshots/session-shape.png)
 
 ### Tool Usage
 
-Total tool call count with breakdowns by category (Read, Edit,
-Write, Bash, Search, Web, Task) and by agent. Includes a trend
-chart showing tool usage over time.
+Total tool call count with breakdowns by category (Read, Edit, Write, Bash,
+Search, Web, Task) and by agent. Includes a trend chart showing tool usage over
+time.
 
 ![Tool usage](/docs/assets/generated/screenshots/tool-usage.png)
 
 ### Top Skills
 
-The Top Skills panel ranks skill-backed tool calls by call count,
-session count, recency, agent mix, and project mix. The adjacent
-Skill Usage Over Time chart plots the leading skills, folds
-the long tail into Other, and lets you switch between day, week,
-and month buckets or hide individual series. Both views follow the
-active Analytics date and session filters.
+The Top Skills panel ranks skill-backed tool calls by call count, session count,
+recency, agent mix, and project mix. The adjacent Skill Usage Over Time chart
+plots the leading skills, folds the long tail into Other, and lets you switch
+between day, week, and month buckets or hide individual series. Both views
+follow the active Analytics date and session filters.
 
-Skill analytics is populated from normalized `skill_name` metadata
-on tool calls and from inferred skill names when Codex or Cursor
-reads a `SKILL.md` file through a read-like tool call. It appears
-when your local transcripts include either explicit skill metadata
-or enough `SKILL.md` reads for AgentsView to infer the skill name.
+Skill analytics is populated from normalized `skill_name` metadata on tool calls
+and from inferred skill names when Codex or Cursor reads a `SKILL.md` file
+through a read-like tool call. It appears when your local transcripts include
+either explicit skill metadata or enough `SKILL.md` reads for AgentsView to
+infer the skill name.
 
 ![Top Skills](/docs/assets/generated/screenshots/top-skills.png)
 
@@ -234,22 +222,20 @@ Performance metrics including:
 
 ### Agent Comparison
 
-Side-by-side metrics across agents: session count, total
-messages, average response time, tool usage patterns, and
-concentration metrics.
+Side-by-side metrics across agents: session count, total messages, average
+response time, tool usage patterns, and concentration metrics.
 
 ![Agent comparison](/docs/assets/generated/screenshots/agent-comparison.png)
 
 ### Session Health
 
-The 0.23.0 dashboard adds a **Session Health** section that rolls up
-the new session-intelligence signals. It shows:
+The 0.23.0 dashboard adds a **Session Health** section that rolls up the new
+session-intelligence signals. It shows:
 
 - average health score and derived grade
-- headline counts for the `completed` and `errored` outcomes
-  (`abandoned` and `unknown` sessions are not counted here, but are
-  visible in the dashboard's outcome-distribution chart alongside
-  them)
+- headline counts for the `completed` and `errored` outcomes (`abandoned` and
+  `unknown` sessions are not counted here, but are visible in the dashboard's
+  outcome-distribution chart alongside them)
 - tool-failure rate and sessions with failures
 - compaction counts, including mid-task compactions
 - score trend over time
@@ -258,16 +244,15 @@ the new session-intelligence signals. It shows:
 ![Session Health section on the dashboard](/docs/assets/generated/screenshots/session-health.png)
 
 See [Session Intelligence](/docs/session-intelligence/#outcome-classification)
-for the full four-outcome model that both this section and
-`agentsview stats` derive from.
+for the full four-outcome model that both this section and `agentsview stats`
+derive from.
 
 ### CSV Export
 
-Click **Export CSV** in the dashboard toolbar to download all
-analytics data as a CSV file. Includes summary, activity,
-projects, tools, and velocity sections.
+Click **Export CSV** in the dashboard toolbar to download all analytics data as
+a CSV file. Includes summary, activity, projects, tools, and velocity sections.
 
----
+______________________________________________________________________
 
 ## Generated Insights
 
@@ -279,42 +264,37 @@ scope, template, generator, and optional focus.
 See [Recall](/docs/recall/#current-surface) for generation, archive, and privacy
 details.
 
----
+______________________________________________________________________
 
 ## Trends
 
-Open **More → Trends** in the header navigation for ad-hoc
-term-frequency line charts over your session history. Type one
-term per line into the textarea, hit **Refresh**, and AgentsView
-counts how often each term appears in user and assistant message
-content over the selected window.
+Open **More → Trends** in the header navigation for ad-hoc term-frequency line
+charts over your session history. Type one term per line into the textarea, hit
+**Refresh**, and AgentsView counts how often each term appears in user and
+assistant message content over the selected window.
 
 ![Trends page](/docs/assets/generated/screenshots/trends.png)
 
-Use Trends to track topics or technologies as your work shifts
-over time — for example, plotting `rust`, `typescript`, and
-`python` to see which language you've been spending the most
-time in this quarter, or watching whether mentions of a problem
-keyword like `flaky` or `timeout` are trending up or down.
+Use Trends to track topics or technologies as your work shifts over time — for
+example, plotting `rust`, `typescript`, and `python` to see which language
+you've been spending the most time in this quarter, or watching whether mentions
+of a problem keyword like `flaky` or `timeout` are trending up or down.
 
 The toolbar controls the window and resolution:
 
-- **From / To** — date inputs at the top of the page; defaults
-  cover the last year.
-- **Granularity** — `day`, `week`, or `month`. Pick coarser
-  buckets for longer windows.
-- **Normalize by number of messages** — toggle to chart per-term
-  rate instead of raw counts, so a busy week doesn't drown out
-  a quiet one.
+- **From / To** — date inputs at the top of the page; defaults cover the last
+  year.
+- **Granularity** — `day`, `week`, or `month`. Pick coarser buckets for longer
+  windows.
+- **Normalize by number of messages** — toggle to chart per-term rate instead of
+  raw counts, so a busy week doesn't drown out a quiet one.
 
-Each line in the **Terms** textarea is a separate term, capped
-at 12 terms per chart. Within a line, pipe-separated variants
-fold into a single series. AgentsView also adds a simple
-plural form (just appending `s`) for each variant, and for
-single-word variants ending in `c` it expands the silent-`e`
-stem (`slic` matches `slice`, `slices`, `sliced`, `slicing`) —
-beyond those two cases, spell out other forms explicitly as
-pipe variants:
+Each line in the **Terms** textarea is a separate term, capped at 12 terms per
+chart. Within a line, pipe-separated variants fold into a single series.
+AgentsView also adds a simple plural form (just appending `s`) for each variant,
+and for single-word variants ending in `c` it expands the silent-`e` stem
+(`slic` matches `slice`, `slices`, `sliced`, `slicing`) — beyond those two
+cases, spell out other forms explicitly as pipe variants:
 
 ```text
 rust
@@ -322,216 +302,194 @@ type|types|typing
 docker|kubernetes|k8s
 ```
 
-Matching is case-insensitive. Single-word matchers honor word
-boundaries — `cat` won't match `catalog`. Multi-word matchers
-match as substrings. Each line accepts up to 8 variants.
+Matching is case-insensitive. Single-word matchers honor word boundaries — `cat`
+won't match `catalog`. Multi-word matchers match as substrings. Each line
+accepts up to 8 variants.
 
-The chart panel uses one color per term. Hover a line to
-highlight that term's series and draw point markers at each
-bucket; for exact per-bucket counts, switch granularities or
-read off the y-axis. The companion table below the chart lists
-each term's color swatch, expanded variants, and total — `Count`
-in raw mode or `Per 1k messages` in normalized mode.
+The chart panel uses one color per term. Hover a line to highlight that term's
+series and draw point markers at each bucket; for exact per-bucket counts,
+switch granularities or read off the y-axis. The companion table below the chart
+lists each term's color swatch, expanded variants, and total — `Count` in raw
+mode or `Per 1k messages` in normalized mode.
 
-Page state lives in the URL — `from`, `to`, `granularity`,
-`normalized`, and repeated `term=` parameters — so any view is
-shareable and bookmarkable.
+Page state lives in the URL — `from`, `to`, `granularity`, `normalized`, and
+repeated `term=` parameters — so any view is shareable and bookmarkable.
 
-The same data is available through the
-`GET /api/v1/trends/terms` endpoint for scripting, and works
-under both local `agentsview serve` and shared
+The same data is available through the `GET /api/v1/trends/terms` endpoint for
+scripting, and works under both local `agentsview serve` and shared
 [`pg serve`](/docs/pg-sync/) deployments.
 
----
+______________________________________________________________________
 
 ## Session Browser
 
-The left sidebar lists all sessions with virtual scrolling for
-smooth performance even with thousands of sessions. On desktop,
-drag the resize handle between the sidebar and the content pane
-to adjust the sidebar width. The width is constrained between
-220px and 520px, always leaving at least 480px for the content
-area. Your preferred width is saved in localStorage and restored
-on next visit.
+The left sidebar lists all sessions with virtual scrolling for smooth
+performance even with thousands of sessions. On desktop, drag the resize handle
+between the sidebar and the content pane to adjust the sidebar width. The width
+is constrained between 220px and 520px, always leaving at least 480px for the
+content area. Your preferred width is saved in localStorage and restored on next
+visit.
 
-As of 0.30.0, the sidebar loads from a skinny session-index
-endpoint and hydrates the visible rows on demand, so large
-refresh storms (e.g. after a bulk import or `resync`) no
-longer freeze the list while the full payloads arrive.
+As of 0.30.0, the sidebar loads from a skinny session-index endpoint and
+hydrates the visible rows on demand, so large refresh storms (e.g. after a bulk
+import or `resync`) no longer freeze the list while the full payloads arrive.
 
 ![Session list](/docs/assets/generated/screenshots/session-list.png)
 
 Each session item shows:
 
-- **Status indicator** — small dot on the left whose color and
-  animation reflect both how recently the session was active and
-  whether it ended cleanly. See
-  [Session status indicator](#session-status-indicator) for the
-  full state set.
-- **Session name** — display name if set, otherwise first message
-  text. OpenCode sessions use their native session titles. As of
-  0.27.0, Copilot CLI sessions use the `name` field from the
-  session's `workspace.yaml` when present, falling back to the
-  first user message otherwise. As of 0.33.0, labels are no
-  longer hard-truncated at 50 characters — the full label is
-  clipped responsively to the sidebar width instead.
-- **Agent-provided session names** — several agents record a
-  session title themselves (Claude Code's `/rename`, Codex
-  `session_index.jsonl` thread names, Claude.ai and ChatGPT
-  conversation names, Forge, Hermes, Kiro, Piebald, Cortex Code,
-  and Command Code's `.meta.json` titles). As of 0.33.0, the
-  sidebar shows these titles automatically when
-  present. Manual in-app renames always take precedence and are
-  never overwritten by an agent-provided name. As of 0.34.0, Codex
-  titles renamed by the agent are imported from `session_index.jsonl`
-  for both current and archived sessions.
-- **Model name** — the AI model used for the session, shown when
-  available (including Codex session models).
-- **Star button** — click the star icon or press `s` to star
-  a session. Starred sessions persist in the SQLite database
-  so they survive server restarts.
-- **Agent tag** — agent name on the right side, tinted with the
-  agent's accent color.
-- **Machine label** — when using [PostgreSQL sync](/docs/pg-sync/),
-  sessions from other machines show a machine name tag. Only
-  visible in shared multi-host deployments.
+- **Status indicator** — small dot on the left whose color and animation reflect
+  both how recently the session was active and whether it ended cleanly. See
+  [Session status indicator](#session-status-indicator) for the full state
+  set.
+- **Session name** — display name if set, otherwise first message text. OpenCode
+  sessions use their native session titles. As of 0.27.0, Copilot CLI sessions
+  use the `name` field from the session's `workspace.yaml` when present,
+  falling back to the first user message otherwise. As of 0.33.0, labels are
+  no longer hard-truncated at 50 characters — the full label is clipped
+  responsively to the sidebar width instead.
+- **Agent-provided session names** — several agents record a session title
+  themselves (Claude Code's `/rename`, Codex `session_index.jsonl` thread
+  names, Claude.ai and ChatGPT conversation names, Forge, Hermes, Kiro,
+  Piebald, Cortex Code, and Command Code's `.meta.json` titles). As of 0.33.0,
+  the sidebar shows these titles automatically when present. Manual in-app
+  renames always take precedence and are never overwritten by an
+  agent-provided name. As of 0.34.0, Codex titles renamed by the agent are
+  imported from `session_index.jsonl` for both current and archived sessions.
+- **Model name** — the AI model used for the session, shown when available
+  (including Codex session models).
+- **Star button** — click the star icon or press `s` to star a session. Starred
+  sessions persist in the SQLite database so they survive server restarts.
+- **Agent tag** — agent name on the right side, tinted with the agent's accent
+  color.
+- **Machine label** — when using [PostgreSQL sync](/docs/pg-sync/), sessions
+  from other machines show a machine name tag. Only visible in shared
+  multi-host deployments.
 - **Project name** — abbreviated, right-aligned
 - **Relative time** — "2h ago", "Mon", "Dec 1"
 - **User prompt count** — number of user messages in the session
 
-When a session has a native resume target, the sidebar also exposes
-a direct native session link so supported agents can reopen their own
-session instead of only navigating inside AgentsView.
+When a session has a native resume target, the sidebar also exposes a direct
+native session link so supported agents can reopen their own session instead of
+only navigating inside AgentsView.
 
 ### Session Status Indicator
 
-As of 0.27.0, the small dot at the left edge of each session
-row encodes how recently the session was written to and how it
-last ended. The same indicator appears in the dashboard's
-**Top Sessions** list. Hover the dot for a tooltip explaining
-the current state.
+As of 0.27.0, the small dot at the left edge of each session row encodes how
+recently the session was written to and how it last ended. The same indicator
+appears in the dashboard's **Top Sessions** list. Hover the dot for a tooltip
+explaining the current state.
 
-| State | Indicator | Meaning |
-|-------|-----------|---------|
-| Working | Pulsing green | Last write within the last minute |
-| Waiting | Tan speech bubble | Session ended on the agent's "your turn" stop reason and was active in the last 10 minutes |
-| Idle | Muted green | 1–10 minutes idle, not awaiting user input |
-| Stale | Amber | 10–60 minutes idle and last assistant message has an unresolved tool call (or the session file was truncated mid-write) |
-| Unclean | Red | Same flagged state as Stale, but idle for more than an hour |
-| Quiet | Hidden | Cleanly-ended sessions older than 10 minutes; no dot is rendered |
+| State   | Indicator         | Meaning                                                                                                                 |
+| ------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Working | Pulsing green     | Last write within the last minute                                                                                       |
+| Waiting | Tan speech bubble | Session ended on the agent's "your turn" stop reason and was active in the last 10 minutes                              |
+| Idle    | Muted green       | 1–10 minutes idle, not awaiting user input                                                                              |
+| Stale   | Amber             | 10–60 minutes idle and last assistant message has an unresolved tool call (or the session file was truncated mid-write) |
+| Unclean | Red               | Same flagged state as Stale, but idle for more than an hour                                                             |
+| Quiet   | Hidden            | Cleanly-ended sessions older than 10 minutes; no dot is rendered                                                        |
 
-The "flagged" tier (Stale and Unclean) is meant to surface
-sessions that look like an agent crashed mid tool call or had
-its session file truncated, so they're easy to pick out from
-sessions that simply haven't been touched in a while.
+The "flagged" tier (Stale and Unclean) is meant to surface sessions that look
+like an agent crashed mid tool call or had its session file truncated, so
+they're easy to pick out from sessions that simply haven't been touched in a
+while.
 
-Termination classification currently runs for **Claude Code**
-and **Codex** sessions — those parsers read the per-message
-`stop_reason` (Claude) or task lifecycle events (Codex). Other
-agents render as plain time-based states (Working / Idle /
-Quiet) without the flagged tier.
+Termination classification currently runs for **Claude Code** and **Codex**
+sessions — those parsers read the per-message `stop_reason` (Claude) or task
+lifecycle events (Codex). Other agents render as plain time-based states
+(Working / Idle / Quiet) without the flagged tier.
 
-When a parent session has subagents or a continuation chain,
-the dot reflects the freshest activity across the group: a
-parent in `tool_call_pending` whose subagent is currently
-writing rolls up to Working green. The parent's parser status
-still wins for the Waiting state — a fork running in parallel
-doesn't change that the parent has said *"your turn"*.
+When a parent session has subagents or a continuation chain, the dot reflects
+the freshest activity across the group: a parent in `tool_call_pending` whose
+subagent is currently writing rolls up to Working green. The parent's parser
+status still wins for the Waiting state — a fork running in parallel doesn't
+change that the parent has said *"your turn"*.
 
 ### Group by Agent
 
-Click the group-by-agent toggle in the sidebar header to
-organize sessions into collapsible sections by agent type.
-Each agent group shows a color-coded dot, agent name, and
-session count. Click an agent header to expand or collapse
-its section. Groups start collapsed when first enabled.
+Click the group-by-agent toggle in the sidebar header to organize sessions into
+collapsible sections by agent type. Each agent group shows a color-coded dot,
+agent name, and session count. Click an agent header to expand or collapse its
+section. Groups start collapsed when first enabled.
 
 ### Sub-Agent Tree
 
-When a session spawns sub-agents or teams, the sidebar
-organizes them in a collapsible tree view. Parent sessions
-show a disclosure triangle; click to expand and see child
-agents nested underneath. This makes complex multi-agent
+When a session spawns sub-agents or teams, the sidebar organizes them in a
+collapsible tree view. Parent sessions show a disclosure triangle; click to
+expand and see child agents nested underneath. This makes complex multi-agent
 workflows easier to navigate without leaving the session list.
 
 ![Sub-agent tree view](/docs/assets/generated/screenshots/subagent-tree.png)
 
 ### Forks and Subagent Sessions
 
-AgentsView automatically detects conversation forks in Claude
-Code sessions — for example, when you use "retry from here" to
-branch a conversation. Large forks (more than 3 user turns)
-appear as separate session entries grouped with their parent.
-Small retries fold into the main session.
+AgentsView automatically detects conversation forks in Claude Code sessions —
+for example, when you use "retry from here" to branch a conversation. Large
+forks (more than 3 user turns) appear as separate session entries grouped with
+their parent. Small retries fold into the main session.
 
-Subagent sessions spawned by the Task tool are organized
-under their parent in the sidebar's
-[sub-agent tree](#sub-agent-tree) and are also viewable
-inline through the parent session's tool blocks (see
-[Subagent Linking](#subagent-linking) below). Claude companion
-session layouts are also linked when the parent can be inferred
-from the companion directory structure, including externalized tool
-result content stored beside the transcript.
+Subagent sessions spawned by the Task tool are organized under their parent in
+the sidebar's [sub-agent tree](#sub-agent-tree) and are also viewable inline
+through the parent session's tool blocks (see
+[Subagent Linking](#subagent-linking) below). Claude companion session layouts
+are also linked when the parent can be inferred from the companion directory
+structure, including externalized tool result content stored beside the
+transcript.
 
 ### Session Filters
 
-Click the filter icon next to the session count to open a
-dropdown with several filter categories that can be combined:
+Click the filter icon next to the session count to open a dropdown with several
+filter categories that can be combined:
 
 ![Session filter dropdown](/docs/assets/generated/screenshots/session-filters.png)
 
 - **Starred** — toggle to show only starred sessions
-- **Recently Active** — toggle to show only sessions updated
-  within the last 24 hours
+- **Recently Active** — toggle to show only sessions updated within the last 24
+  hours
 - **Agent** — searchable multi-select of
-  [supported agents](/docs/configuration/#session-discovery). Click an
-  agent to toggle its selection; multiple agents can be active
-  at once.
-- **Machine** — searchable multi-select of machine names.
-  Surfaces in shared [PostgreSQL sync](/docs/pg-sync/) deployments
-  when more than five machines have pushed sessions.
+  [supported agents](/docs/configuration/#session-discovery). Click an agent
+  to toggle its selection; multiple agents can be active at once.
+- **Machine** — searchable multi-select of machine names. Surfaces in shared
+  [PostgreSQL sync](/docs/pg-sync/) deployments when more than five machines
+  have pushed sessions.
 - **Status** — three-pill multi-select of the
-  [status](#session-status-indicator) recency tiers (**Active**,
-  **Stale**, **Unclean**), tinted to match the indicator colors.
-  The underlying `?termination=` URL parameter and API also accept
-  the parser-side values `clean` and `awaiting_user`, but those
-  aren't exposed as sidebar pills.
-- **Min Prompts** — filter to sessions with at least 2, 3, 5,
-  or 10 user messages
-- **Include single-turn** — toggle to include sessions with one
-  or fewer user messages (excluded by default to reduce noise)
-- **Include automated** — toggle to include sessions classified
-  as automation (roborev runs, title generation, AgentsView's own
-  internal prompts, and any patterns you've added to
+  [status](#session-status-indicator) recency tiers (**Active**, **Stale**,
+  **Unclean**), tinted to match the indicator colors. The underlying
+  `?termination=` URL parameter and API also accept the parser-side values
+  `clean` and `awaiting_user`, but those aren't exposed as sidebar pills.
+- **Min Prompts** — filter to sessions with at least 2, 3, 5, or 10 user
+  messages
+- **Include single-turn** — toggle to include sessions with one or fewer user
+  messages (excluded by default to reduce noise)
+- **Include automated** — toggle to include sessions classified as automation
+  (roborev runs, title generation, AgentsView's own internal prompts, and any
+  patterns you've added to
   [`[automated] prefixes`](/docs/configuration/#automated-session-detection))
-- **Hide unknown** — toggle to hide sessions whose project
-  could not be determined
+- **Hide unknown** — toggle to hide sessions whose project could not be
+  determined
 
-When any filter is active, a green dot appears on the filter
-button. Click **Clear filters** at the bottom of the dropdown
-to reset all filters at once.
+When any filter is active, a green dot appears on the filter button. Click
+**Clear filters** at the bottom of the dropdown to reset all filters at once.
 
-As of 0.27.0, the sidebar filter store is shared with the
-analytics dashboard and the Usage page: agent, machine, project,
-min user-message threshold, hide-single-turn, and include-automated
-selections applied in the sidebar carry across to the dashboard
-panels and the Usage page header, which mounts the same filter
-widget. The **Status** filter is sidebar- and dashboard-only —
-the Usage page does not currently filter by termination status.
-Filter state is also persisted to localStorage and serialized
-into the URL.
+As of 0.27.0, the sidebar filter store is shared with the analytics dashboard
+and the Usage page: agent, machine, project, min user-message threshold,
+hide-single-turn, and include-automated selections applied in the sidebar carry
+across to the dashboard panels and the Usage page header, which mounts the same
+filter widget. The **Status** filter is sidebar- and dashboard-only — the Usage
+page does not currently filter by termination status. Filter state is also
+persisted to localStorage and serialized into the URL.
 
 ### Direct Session Links
 
-Each session has a shareable URL. Click the session ID in the
-detail header to copy the link, or use the URL bar directly:
+Each session has a shareable URL. Click the session ID in the detail header to
+copy the link, or use the URL bar directly:
 
 ```
 /sessions/550e8400-e29b-41d4-a716-446655440000
 ```
 
-Session URLs work as bookmarks and can be shared with teammates
-when using [PostgreSQL sync](/docs/pg-sync/) for shared deployments.
+Session URLs work as bookmarks and can be shared with teammates when using
+[PostgreSQL sync](/docs/pg-sync/) for shared deployments.
 
 ### URL Filters
 
@@ -543,47 +501,44 @@ URL parameters are supported for direct linking:
 
 Available URL filters:
 
-| Parameter | Value |
-|-----------|-------|
-| `project` | comma-separated project names |
-| `agent` | comma-separated agent ids |
-| `machine` | comma-separated machine names |
-| `termination` | comma-separated [status](#session-status-indicator) tiers — any of `active`, `stale`, `unclean`, `clean`, `awaiting_user` |
-| `date`, `date_from`, `date_to` | ISO date or activity-overlap range bounds |
-| `active_since` | `true` to limit to the last 24 hours |
-| `min_messages`, `max_messages` | numeric message count bounds |
-| `min_user_messages` | numeric user-message threshold |
-| `include_one_shot` | `false` to hide single-turn sessions (default) |
-| `include_automated` | `true` to include automated sessions |
-| `exclude_project` | comma-separated projects to hide (e.g. `unknown`) |
+| Parameter                      | Value                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `project`                      | comma-separated project names                                                                                             |
+| `agent`                        | comma-separated agent ids                                                                                                 |
+| `machine`                      | comma-separated machine names                                                                                             |
+| `termination`                  | comma-separated [status](#session-status-indicator) tiers — any of `active`, `stale`, `unclean`, `clean`, `awaiting_user` |
+| `date`, `date_from`, `date_to` | ISO date or activity-overlap range bounds                                                                                 |
+| `active_since`                 | `true` to limit to the last 24 hours                                                                                      |
+| `min_messages`, `max_messages` | numeric message count bounds                                                                                              |
+| `min_user_messages`            | numeric user-message threshold                                                                                            |
+| `include_one_shot`             | `false` to hide single-turn sessions (default)                                                                            |
+| `include_automated`            | `true` to include automated sessions                                                                                      |
+| `exclude_project`              | comma-separated projects to hide (e.g. `unknown`)                                                                         |
 
 ### Navigation
 
-Use `]` and `[` to move between sessions in the list. The
-selected session is highlighted with a left border accent.
+Use `]` and `[` to move between sessions in the list. The selected session is
+highlighted with a left border accent.
 
----
+______________________________________________________________________
 
 ## Message Viewer
 
-Selecting a session opens the message viewer in the main content
-area. Messages display in a scrollable list with virtual
-rendering for large sessions.
+Selecting a session opens the message viewer in the main content area. Messages
+display in a scrollable list with virtual rendering for large sessions.
 
 ![Message viewer](/docs/assets/generated/screenshots/message-viewer.png)
 
-The session detail header shows the session name, agent, project, a
-health grade badge, and a copyable **Session ID**. Click the ID to
-copy it to the clipboard for sharing or lookup. Click the grade
-badge to toggle the signal panel.
+The session detail header shows the session name, agent, project, a health grade
+badge, and a copyable **Session ID**. Click the ID to copy it to the clipboard
+for sharing or lookup. Click the grade badge to toggle the signal panel.
 
-If a parser skipped malformed source lines while still recovering
-the session, the header shows a malformed-lines badge with the
-persisted count (for example "3 malformed lines"). For Antigravity IDE and
-CLI sessions decoded from an unrecognized SQLite schema fingerprint,
-the header also shows **Unverified schema**. That badge means the
-session was decoded heuristically from a newer schema and may be
-incomplete.
+If a parser skipped malformed source lines while still recovering the session,
+the header shows a malformed-lines badge with the persisted count (for example
+"3 malformed lines"). For Antigravity IDE and CLI sessions decoded from an
+unrecognized SQLite schema fingerprint, the header also shows **Unverified
+schema**. That badge means the session was decoded heuristically from a newer
+schema and may be incomplete.
 
 AgentsView stores reading progress for the most recent 500 sessions in the
 current browser. When a transcript changes after you have read it, the sidebar
@@ -594,30 +549,28 @@ browser-local and is not synced through SQLite or PostgreSQL.
 
 ### Message Layouts
 
-Four layouts control how messages are rendered. Cycle between
-them with the `l` key or the layout button in the header, or pick
-one directly in Settings > Appearance:
+Four layouts control how messages are rendered. Cycle between them with the `l`
+key or the layout button in the header, or pick one directly in Settings >
+Appearance:
 
-| Layout | Description |
-|--------|-------------|
-| Default | Full card layout with colored borders and spacing |
-| Compact | Condensed view with minimal spacing |
-| Stream | Continuous flow optimized for reading |
-| Skim | Collapses tool calls to summary headers for fast skimming |
+| Layout  | Description                                               |
+| ------- | --------------------------------------------------------- |
+| Default | Full card layout with colored borders and spacing         |
+| Compact | Condensed view with minimal spacing                       |
+| Stream  | Continuous flow optimized for reading                     |
+| Skim    | Collapses tool calls to summary headers for fast skimming |
 
 ### Focused Transcript Mode
 
-Focused mode strips intermediate tool calls, thinking blocks,
-and partial assistant messages, showing only user prompts and
-final assistant responses. This makes long sessions easier to
-read as a clean conversation transcript.
+Focused mode strips intermediate tool calls, thinking blocks, and partial
+assistant messages, showing only user prompts and final assistant responses.
+This makes long sessions easier to read as a clean conversation transcript.
 
 ![Focused transcript mode](/docs/assets/generated/screenshots/focused-transcript.png)
 
-Toggle between Normal and Focused mode using the transcript
-mode button in the session header. The header adjusts
-responsively to fit the available space. The mode preference
-is saved in localStorage.
+Toggle between Normal and Focused mode using the transcript mode button in the
+session header. The header adjusts responsively to fit the available space. The
+mode preference is saved in localStorage.
 
 ### Message Display
 
@@ -626,55 +579,49 @@ Each message has a colored left border indicating role:
 - **Blue** — user messages
 - **Purple** — assistant messages
 
-The header shows the role label, timestamp, and a **copy
-button** that appears on hover. Click it to copy the full
-message content to the clipboard — a checkmark confirms the
-copy for 1.5 seconds.
+The header shows the role label, timestamp, and a **copy button** that appears
+on hover. Click it to copy the full message content to the clipboard — a
+checkmark confirms the copy for 1.5 seconds.
 
 Inline `<teammate-message>` content and messages from teammate session ancestry
 are labeled **Teammate**, keeping peer-agent replies distinct from user prompts
 and ordinary subagent output.
 
-Claude Code sessions also show a fork action on each message header
-when the local server can launch or return a command. Clicking it
-starts a new Claude run from the selected point by rendering the
-transcript through that message ordinal into a temporary prompt,
-starting `claude` in the session working directory, and removing the
-temporary prompt after launch. In read-only local mode the action
-copies the command instead of launching it; remote sessions cannot be
-forked from the browser.
+Claude Code sessions also show a fork action on each message header when the
+local server can launch or return a command. Clicking it starts a new Claude run
+from the selected point by rendering the transcript through that message ordinal
+into a temporary prompt, starting `claude` in the session working directory, and
+removing the temporary prompt after launch. In read-only local mode the action
+copies the command instead of launching it; remote sessions cannot be forked
+from the browser.
 
 ### Thinking Blocks
 
-Assistant thinking blocks appear as collapsible sections with a
-purple left border. Toggle visibility for thinking blocks using
-the [block-type filter](#block-type-filtering) in the header.
+Assistant thinking blocks appear as collapsible sections with a purple left
+border. Toggle visibility for thinking blocks using the
+[block-type filter](#block-type-filtering) in the header.
 
 ### Tool Blocks
 
-Tool invocations display as collapsible amber-bordered sections
-showing the tool name, arguments, and output. When collapsed,
-the header surfaces the most meaningful input field rather than
-the first line of the rendered content. `TodoWrite` shows the
-in-progress (or last) todo with a `→` prefix; `TaskCreate`
-shows the subject; `TaskUpdate` shows `#<id> · <status> ·
-<subject>`; `Skill` shows the skill name; `ToolSearch` shows
-the first line of the query; and `Task`/`Agent`/subagent calls
-show the description (falling back to the prompt). For tools
-without a structured preview, the header falls back to the
-first line of content, the `command`/`cmd` (Bash), or the
-`file_path`/`pattern` (Read, Edit, Write, Glob).
+Tool invocations display as collapsible amber-bordered sections showing the tool
+name, arguments, and output. When collapsed, the header surfaces the most
+meaningful input field rather than the first line of the rendered content.
+`TodoWrite` shows the in-progress (or last) todo with a `→` prefix; `TaskCreate`
+shows the subject; `TaskUpdate` shows `#<id> · <status> · <subject>`; `Skill`
+shows the skill name; `ToolSearch` shows the first line of the query; and
+`Task`/`Agent`/subagent calls show the description (falling back to the prompt).
+For tools without a structured preview, the header falls back to the first line
+of content, the `command`/`cmd` (Bash), or the `file_path`/`pattern` (Read,
+Edit, Write, Glob).
 
 ![Tool blocks](/docs/assets/generated/screenshots/tool-blocks.png)
 
-When expanded, tool blocks display structured metadata tags
-extracted from the tool call input. For task management tools
-(TaskCreate, TaskUpdate, TaskGet), these tags show the task
-subject, status, and ID at a glance. Bash tool blocks show
-the full command text, including multi-line commands like
-heredocs that would otherwise be truncated. Tool result content
-is stored alongside the tool call when available, giving a
-complete view of input and output.
+When expanded, tool blocks display structured metadata tags extracted from the
+tool call input. For task management tools (TaskCreate, TaskUpdate, TaskGet),
+these tags show the task subject, status, and ID at a glance. Bash tool blocks
+show the full command text, including multi-line commands like heredocs that
+would otherwise be truncated. Tool result content is stored alongside the tool
+call when available, giving a complete view of input and output.
 
 Expanded outputs start in **Raw** mode, which preserves the exact escaped text
 recorded by the agent. Switch to **Formatted** to render Markdown, including
@@ -684,90 +631,83 @@ continue to use the raw output.
 
 ![Formatted tool output](/docs/assets/generated/screenshots/tool-output-formatted.png)
 
-Hover or focus a tool block to reveal copy buttons for the
-structured input and, when present, the tool output.
+Hover or focus a tool block to reveal copy buttons for the structured input and,
+when present, the tool output.
 
 ![Copy buttons on a tool block](/docs/assets/generated/screenshots/tool-block-copy-btn.png)
 
-Codex tool calls receive special formatting: bash commands,
-write_stdin operations, and apply_patch calls display with
-structured argument previews and categorized detail labels.
-Cursor `ApplyPatch` tool calls render as patch/diff content instead
-of plain JSON when the Cursor transcript exposes the patch payload.
+Codex tool calls receive special formatting: bash commands, write_stdin
+operations, and apply_patch calls display with structured argument previews and
+categorized detail labels. Cursor `ApplyPatch` tool calls render as patch/diff
+content instead of plain JSON when the Cursor transcript exposes the patch
+payload.
 
-When a Codex tool call has subagent result events — status
-updates captured during execution — an expandable **history**
-section appears below the tool output. Click it to see the
-full chronological timeline of status changes (e.g. "wait",
-"completed", "failed") with source and content for each
-event. The latest event summary is shown by default.
+When a Codex tool call has subagent result events — status updates captured
+during execution — an expandable **history** section appears below the tool
+output. Click it to see the full chronological timeline of status changes (e.g.
+"wait", "completed", "failed") with source and content for each event. The
+latest event summary is shown by default.
 
 ### Subagent Linking
 
-When a Task or Agent tool block is linked to a subagent
-session, it shows an expandable toggle. Click it to view the
-subagent's full transcript inline without leaving the parent
-session. Messages load on demand when the section is expanded,
-showing the complete subagent conversation with role labels
-and timestamps.
+When a Task or Agent tool block is linked to a subagent session, it shows an
+expandable toggle. Click it to view the subagent's full transcript inline
+without leaving the parent session. Messages load on demand when the section is
+expanded, showing the complete subagent conversation with role labels and
+timestamps.
 
 ### Tool Call Groups
 
-Consecutive tool-only assistant messages are grouped into
-compact "N tool calls" sections with a gear icon and timestamp.
-Click to expand individual tool blocks within the group.
+Consecutive tool-only assistant messages are grouped into compact "N tool calls"
+sections with a gear icon and timestamp. Click to expand individual tool blocks
+within the group.
 
 ![Tool call groups](/docs/assets/generated/screenshots/tool-groups.png)
 
 ### Code Blocks
 
-Fenced code blocks render with language labels, monospace
-formatting, and horizontal scrolling for long lines. Hover or
-focus a code block to reveal a **copy button** in the corner;
-clicking it copies the raw code (no fences or language tag)
-to the clipboard.
+Fenced code blocks render with language labels, monospace formatting, and
+horizontal scrolling for long lines. Hover or focus a code block to reveal a
+**copy button** in the corner; clicking it copies the raw code (no fences or
+language tag) to the clipboard.
 
-As of 0.33.0, labeled code fences get **syntax highlighting**
-powered by Shiki. Twelve common languages are bundled —
-JavaScript, TypeScript, Python, Bash, JSON, YAML, Markdown,
-HTML, CSS, Rust, Go, and SQL (plus their usual aliases like
-`py`, `sh`, and `yml`). Unlabeled or unrecognized languages
-fall back to plain text. To keep large sessions fast,
-highlighting is skipped for blocks over 50 KB or 800 lines,
-and the highlighter loads lazily so it costs nothing until the
-first code fence renders.
+As of 0.33.0, labeled code fences get **syntax highlighting** powered by Shiki.
+Twelve common languages are bundled — JavaScript, TypeScript, Python, Bash,
+JSON, YAML, Markdown, HTML, CSS, Rust, Go, and SQL (plus their usual aliases
+like `py`, `sh`, and `yml`). Unlabeled or unrecognized languages fall back to
+plain text. To keep large sessions fast, highlighting is skipped for blocks over
+50 KB or 800 lines, and the highlighter loads lazily so it costs nothing until
+the first code fence renders.
 
-Fenced code blocks labeled `mermaid` render as Mermaid diagrams
-in an interactive viewer with source-copy and expanded-view
-controls. If the Mermaid runtime cannot load, AgentsView keeps
-the escaped diagram source readable in the message. When
-in-session search is active, Mermaid fences render as source code
+Fenced code blocks labeled `mermaid` render as Mermaid diagrams in an
+interactive viewer with source-copy and expanded-view controls. If the Mermaid
+runtime cannot load, AgentsView keeps the escaped diagram source readable in the
+message. When in-session search is active, Mermaid fences render as source code
 so matches can be highlighted.
 
 ![Copy button on a code block](/docs/assets/generated/screenshots/code-block-copy-btn.png)
 
 ### Block-Type Filtering
 
-Click the filter icon in the message viewer header to open a
-dropdown that toggles visibility of five content categories:
+Click the filter icon in the message viewer header to open a dropdown that
+toggles visibility of five content categories:
 
-| Category | What It Controls |
-|----------|-----------------|
-| User | User messages |
-| Assistant | Assistant responses |
-| Thinking | Thinking/reasoning blocks |
-| Tool | Tool call blocks |
-| Code | Code blocks |
+| Category  | What It Controls          |
+| --------- | ------------------------- |
+| User      | User messages             |
+| Assistant | Assistant responses       |
+| Thinking  | Thinking/reasoning blocks |
+| Tool      | Tool call blocks          |
+| Code      | Code blocks               |
 
-All categories are visible by default. When any are hidden,
-a badge on the filter button shows the count of hidden types.
-Click **Show all** to restore visibility.
+All categories are visible by default. When any are hidden, a badge on the
+filter button shows the count of hidden types. Click **Show all** to restore
+visibility.
 
 ### Sorting
 
-Toggle between newest-first and oldest-first with the `o` key
-or the sort button in the header. The arrow icon indicates the
-current direction.
+Toggle between newest-first and oldest-first with the `o` key or the sort button
+in the header. The arrow icon indicates the current direction.
 
 ### Message Navigation
 
@@ -782,55 +722,48 @@ and the active block-type filter.
 
 ### In-Session Search
 
-Press `Cmd+F` (or `Ctrl+F`) to open a search bar within the
-current session. Type to find matching text across all visible
-messages. The match count and current position are shown in the
-search bar.
+Press `Cmd+F` (or `Ctrl+F`) to open a search bar within the current session.
+Type to find matching text across all visible messages. The match count and
+current position are shown in the search bar.
 
 ![In-session search](/docs/assets/generated/screenshots/in-session-search.png)
 
-Use the arrow buttons or `Enter` / `Shift+Enter` to jump
-between matches. The matching message scrolls into view and the
-search term is highlighted. Press `Esc` to close the search bar.
+Use the arrow buttons or `Enter` / `Shift+Enter` to jump between matches. The
+matching message scrolls into view and the search term is highlighted. Press
+`Esc` to close the search bar.
 
 ### Token Usage
 
-The session detail header displays token usage when available,
-showing input and output token counts for the session. This
-gives a quick view of how much context the agent consumed
-and how much it generated.
+The session detail header displays token usage when available, showing input and
+output token counts for the session. This gives a quick view of how much context
+the agent consumed and how much it generated.
 
 ![Token usage display](/docs/assets/generated/screenshots/token-usage.png)
 
-As of 0.33.0, the header also shows the session's **estimated
-cost** next to the token summary, computed from the same data
-as [`agentsview session usage`](/docs/session-api/#agentsview-session-usage).
-Costs under a cent display as `<$0.01`, costs up to $100 with
-two decimals, and larger costs as whole dollars. The badge is
-hidden when the session has no token data or its models have
-no pricing.
+As of 0.33.0, the header also shows the session's **estimated cost** next to the
+token summary, computed from the same data as
+[`agentsview session usage`](/docs/session-api/#agentsview-session-usage). Costs
+under a cent display as `<$0.01`, costs up to $100 with two decimals, and larger
+costs as whole dollars. The badge is hidden when the session has no token data
+or its models have no pricing.
 
-When the selected session has explicit `subagent` descendants, the
-automatic header request adds `rollup=true`. A complete priced aggregate
-shows a localized total marker and the descendant count. If any contributing
-row is unpriced, the header keeps the root session's own cost when available
-and does not label it as a total. Sessions without explicit subagent
-descendants keep the existing badge.
+When the selected session has explicit `subagent` descendants, the automatic
+header request adds `rollup=true`. A complete priced aggregate shows a localized
+total marker and the descendant count. If any contributing row is unpriced, the
+header keeps the root session's own cost when available and does not label it as
+a total. Sessions without explicit subagent descendants keep the existing badge.
 
-As of 0.37.1, sessions with per-step usage rows also show a
-**step count** next to the token summary. Click it to expand a
-per-step breakdown: each row lists the prompt or usage event,
-the model that served it, its context size (input tokens plus
-cache reads and writes), its output tokens, and a per-step cost
-estimate when the model is priced. The rows come from the same
-session usage API with `?breakdown=true` — see
+As of 0.37.1, sessions with per-step usage rows also show a **step count** next
+to the token summary. Click it to expand a per-step breakdown: each row lists
+the prompt or usage event, the model that served it, its context size (input
+tokens plus cache reads and writes), its output tokens, and a per-step cost
+estimate when the model is priced. The rows come from the same session usage API
+with `?breakdown=true` — see
 [`agentsview session usage`](/docs/session-api/#agentsview-session-usage).
 
-For aggregate token usage and estimated cost reports across
-all sessions, see the
-[Token Usage & Costs](/docs/token-usage/) page and the
-[`agentsview usage daily`](/docs/commands/#agentsview-usage-daily)
-CLI command.
+For aggregate token usage and estimated cost reports across all sessions, see
+the [Token Usage & Costs](/docs/token-usage/) page and the
+[`agentsview usage daily`](/docs/commands/#agentsview-usage-daily) CLI command.
 
 For a scriptable report on the current session, use
 [`agentsview session usage <id>`](/docs/session-api/#agentsview-session-usage)
@@ -840,25 +773,25 @@ REST endpoint.
 
 ### Signal Panel
 
-Click the health grade badge in the session header to open the
-signal panel for the current session. The panel shows:
+Click the health grade badge in the session header to open the signal panel for
+the current session. The panel shows:
 
 - grade and numeric score
 - outcome icon and confidence
-- basis tags showing whether outcome, tool health, and context
-  pressure contributed to the score
+- basis tags showing whether outcome, tool health, and context pressure
+  contributed to the score
 - compaction summary, including mid-task compactions
 - penalty chips for the deductions that were applied
 
-When a session does not have enough usable data, the panel shows a
-small empty state instead of a score. See
+When a session does not have enough usable data, the panel shows a small empty
+state instead of a score. See
 [Session Intelligence](/docs/session-intelligence/) for the full model.
 
 ### Session Vital Signs
 
-The right column of an open session shows a **Session Vital
-Signs** panel with timing data derived from the message
-timestamps. Toggle it from the session header.
+The right column of an open session shows a **Session Vital Signs** panel with
+timing data derived from the message timestamps. Toggle it from the session
+header.
 
 ![Session Vital Signs in context](/docs/assets/generated/screenshots/session-vital-signs.png)
 
@@ -872,139 +805,128 @@ It has five stacked sections when experimental Recall is available:
   from the current session. Evidence-range links jump to the supporting
   transcript message. An empty state appears when the local archive has no
   matching entries.
-- **Time spent** — per-category aggregate bars across the
-  normalized taxonomy (`Read`, `Edit`, `Write`, `Bash`, `Grep`,
-  `Glob`, `Task`, `Tool`, `Other`, plus a `Mixed` bucket for
-  turns split across categories). Click a row to filter the rest
-  of the panel to that category.
-- **Timeline** — turns lane plus per-category lanes plus an
-  activity lane, with a legend. Hover a turn segment to see its
-  primary category and duration (e.g. `Task · 2m`); click to
-  scroll the conversation to that turn.
-- **Calls** — chronological list of tool calls with horizontal
-  duration bars. Parallel `tool_use` runs are bracketed as a
-  single group. Call details start collapsed for quicker transcript navigation.
-  Sub-agent rows expand inline to show the child session's calls.
+- **Time spent** — per-category aggregate bars across the normalized taxonomy
+  (`Read`, `Edit`, `Write`, `Bash`, `Grep`, `Glob`, `Task`, `Tool`, `Other`,
+  plus a `Mixed` bucket for turns split across categories). Click a row to
+  filter the rest of the panel to that category.
+- **Timeline** — turns lane plus per-category lanes plus an activity lane, with
+  a legend. Hover a turn segment to see its primary category and duration
+  (e.g. `Task · 2m`); click to scroll the conversation to that turn.
+- **Calls** — chronological list of tool calls with horizontal duration bars.
+  Parallel `tool_use` runs are bracketed as a single group. Call details start
+  collapsed for quicker transcript navigation. Sub-agent rows expand inline to
+  show the child session's calls.
 
 ![Vital Signs panel detail](/docs/assets/generated/screenshots/vital-signs-panel.png)
 
-Inline in the conversation column, each `ToolBlock` header gets
-a duration badge, and each assistant message gets a turn-summary
-line ("turn 2m 18s · 3 calls"). Parallel non-sub-agent calls
-render with a striped bar and a `≤duration` upper bound — the
-JSONL source has only one timestamp per assistant message, so
-per-call precision inside parallel groups isn't recoverable for
-non-sub-agent calls. Tool labels are normalized across agents,
-so Codex's `exec_command` and Claude's `Bash` show up under the
-same "Bash" category in headers and in the Calls list.
+Inline in the conversation column, each `ToolBlock` header gets a duration
+badge, and each assistant message gets a turn-summary line ("turn 2m 18s · 3
+calls"). Parallel non-sub-agent calls render with a striped bar and a
+`≤duration` upper bound — the JSONL source has only one timestamp per assistant
+message, so per-call precision inside parallel groups isn't recoverable for
+non-sub-agent calls. Tool labels are normalized across agents, so Codex's
+`exec_command` and Claude's `Bash` show up under the same "Bash" category in
+headers and in the Calls list.
 
-Call duration bars in the Calls list are scaled relative to the
-longest call in scope, not total session wall-clock — so even in
-long sessions where any single call is a small fraction of the
-total, call-vs-call comparison stays legible. Very short calls
-floor at 4% width to remain visible.
+Call duration bars in the Calls list are scaled relative to the longest call in
+scope, not total session wall-clock — so even in long sessions where any single
+call is a small fraction of the total, call-vs-call comparison stays legible.
+Very short calls floor at 4% width to remain visible.
 
 ### Progressive Loading
 
-Sessions with more than 3,000 messages load the most recent
-1,000 messages first. Older pages load automatically as you
-scroll up. Smaller sessions load all messages at once.
+Sessions with more than 3,000 messages load the most recent 1,000 messages
+first. Older pages load automatically as you scroll up. Smaller sessions load
+all messages at once.
 
 ### Live Updates
 
-When viewing an active session, AgentsView uses Server-Sent
-Events to stream new messages in real time. The message list
-updates incrementally — only new activity is fetched, rather
-than reloading the entire session — so updates arrive faster
-and with less overhead.
+When viewing an active session, AgentsView uses Server-Sent Events to stream new
+messages in real time. The message list updates incrementally — only new
+activity is fetched, rather than reloading the entire session — so updates
+arrive faster and with less overhead.
 
 ### Follow Latest Message
 
-As of 0.30.0, the session header has a **Follow latest
-messages** toggle. When active, the message list auto-scrolls
-to the newest message as updates stream in, so a long-running
-session stays pinned to the tail without manual scrolling.
-The toggle is also handy after a sync that rebuilt the
-session — it snaps back to the latest message once the
-re-rendered list settles.
+As of 0.30.0, the session header has a **Follow latest messages** toggle. When
+active, the message list auto-scrolls to the newest message as updates stream
+in, so a long-running session stays pinned to the tail without manual scrolling.
+The toggle is also handy after a sync that rebuilt the session — it snaps back
+to the latest message once the re-rendered list settles.
 
 ![Follow latest toggle in the session header](/docs/assets/generated/screenshots/follow-latest-toggle.png)
 
-Cancellation is automatic: scrolling up by hand or clicking a
-specific message turns follow mode off. Clicking the toggle
-again re-engages it and jumps to the latest message. The
-preference is persisted in localStorage, so a session you
+Cancellation is automatic: scrolling up by hand or clicking a specific message
+turns follow mode off. Clicking the toggle again re-engages it and jumps to the
+latest message. The preference is persisted in localStorage, so a session you
 opened in follow mode comes back in follow mode.
 
----
+______________________________________________________________________
 
 ## Command Palette
 
-Press `Cmd+K` (or `Ctrl+K`) to open the command palette — a
-full-screen search overlay.
+Press `Cmd+K` (or `Ctrl+K`) to open the command palette — a full-screen search
+overlay.
 
 ![Command palette](/docs/assets/generated/screenshots/command-palette.png)
 
 ### Recent Sessions
 
-With an empty or short query (under 3 characters), the palette
-shows your 10 most recent sessions. Type to filter by project
-name or first message.
+With an empty or short query (under 3 characters), the palette shows your 10
+most recent sessions. Type to filter by project name or first message.
 
 ### Search Modes
 
 Type 3 or more characters to search in one of three modes:
 
-- **Full text** searches indexed message content with FTS5. It
-  also matches session display names and first messages.
-- **Semantic** ranks message content by meaning using the active
-  embeddings index.
-- **Hybrid** combines semantic and full-text rankings so that
-  both conceptual and exact-term matches can surface.
+- **Full text** searches indexed message content with FTS5. It also matches
+  session display names and first messages.
+- **Semantic** ranks message content by meaning using the active embeddings
+  index.
+- **Hybrid** combines semantic and full-text rankings so that both conceptual
+  and exact-term matches can surface.
 
-The palette remembers the last mode you selected across openings
-and browser sessions. Results update after a 300ms typing pause.
+The palette remembers the last mode you selected across openings and browser
+sessions. Results update after a 300ms typing pause.
 
 !!! tip
-    For deeper searches across full transcripts — including tool
-    inputs, tool result content, and regex patterns — use the
-    [`agentsview session search`](/docs/session-api/#agentsview-session-search)
-    CLI or the `GET /api/v1/search/content` HTTP endpoint added
-    in 0.30.0. The command palette indexes message bodies via
-    FTS5 for fast scoring; the content-search endpoints add
-    substring and regex modes and cover tool I/O as well.
+
+    For deeper searches across full transcripts — including tool inputs, tool result
+    content, and regex patterns — use the
+    [`agentsview session search`](/docs/session-api/#agentsview-session-search) CLI
+    or the `GET /api/v1/search/content` HTTP endpoint added in 0.30.0. The command
+    palette indexes message bodies via FTS5 for fast scoring; the content-search
+    endpoints add substring and regex modes and cover tool I/O as well.
 
 ![Search results](/docs/assets/generated/screenshots/search-results.png)
 
-Results are grouped by session — each session shows its best
-matching result. This prevents a single long session from
-dominating the results list. Full text also matches against
-session display names and first messages, so you can find
+Results are grouped by session — each session shows its best matching result.
+This prevents a single long session from dominating the results list. Full text
+also matches against session display names and first messages, so you can find
 sessions by title.
 
-In Full text mode, use the sort toggle in the palette header to
-switch between **Relevance** (best matches first) and **Recency**
-(newest sessions first). Semantic and Hybrid use their backend
-rankings, so this toggle is hidden in those modes.
+In Full text mode, use the sort toggle in the palette header to switch between
+**Relevance** (best matches first) and **Recency** (newest sessions first).
+Semantic and Hybrid use their backend rankings, so this toggle is hidden in
+those modes.
 
-Semantic and Hybrid require an enabled [`[vector]`](semantic-search.md#enabling-vector)
-configuration and an active embeddings index. If setup, index
-state, or the embeddings service prevents a search, the palette
-keeps the selected mode and shows actionable remediation rather
-than silently falling back to Full text.
+Semantic and Hybrid require an enabled
+[`[vector]`](semantic-search.md#enabling-vector) configuration and an active
+embeddings index. If setup, index state, or the embeddings service prevents a
+search, the palette keeps the selected mode and shows actionable remediation
+rather than silently falling back to Full text.
 
 Results use a compact row:
 
-- **Full text** may show the session name and a sanitized snippet
-  with highlighted search terms.
-- **Semantic and Hybrid** lead with a plain-text matching snippet.
-  Content search does not return a session name or highlight
-  markup.
-- **All modes** show an agent-colored dot, project and result
-  time, and a copyable session ID.
+- **Full text** may show the session name and a sanitized snippet with
+  highlighted search terms.
+- **Semantic and Hybrid** lead with a plain-text matching snippet. Content
+  search does not return a session name or highlight markup.
+- **All modes** show an agent-colored dot, project and result time, and a
+  copyable session ID.
 
-Select a result to jump to that session and scroll directly to
-the matching message.
+Select a result to jump to that session and scroll directly to the matching
+message.
 
 ### Keyboard Navigation
 
@@ -1012,52 +934,46 @@ the matching message.
 - `Enter` — select current result
 - `Esc` — close palette
 
----
+______________________________________________________________________
 
 ## Session Management
 
 ### Renaming Sessions
 
-Double-click a session name in the sidebar to rename it inline.
-You can also right-click a session to open a context menu and
-select **Rename**. Press Enter to save or Escape to cancel. The
-custom name persists as a `display_name` in the database and
-overrides the default first-message title.
+Double-click a session name in the sidebar to rename it inline. You can also
+right-click a session to open a context menu and select **Rename**. Press Enter
+to save or Escape to cancel. The custom name persists as a `display_name` in the
+database and overrides the default first-message title.
 
 ### Trash
 
-Press `Del` (or `Backspace`) with a session selected, or
-right-click and select **Delete**, to move it to the trash.
-An undo toast appears briefly to let you recover the session
-immediately. Trashed sessions are hidden from all listings
+Press `Del` (or `Backspace`) with a session selected, or right-click and select
+**Delete**, to move it to the trash. An undo toast appears briefly to let you
+recover the session immediately. Trashed sessions are hidden from all listings
 and analytics.
 
-Click **More → Trash** in the header navigation to view
-trashed sessions. From the trash page you can restore
-individual sessions or permanently delete them. Use **Empty
-trash** to permanently delete all trashed sessions at once.
+Click **More → Trash** in the header navigation to view trashed sessions. From
+the trash page you can restore individual sessions or permanently delete them.
+Use **Empty trash** to permanently delete all trashed sessions at once.
 
 ### Batch Selection
 
-Click the **Multi-select** toggle in the sidebar header to enter
-selection mode. A checkbox appears on each session; click
-sessions to check them, or use **All** to select every visible
-session and **Clear** to deselect. The batch toolbar shows how
-many are selected and a **Delete** action that moves the whole
-selection to the trash at once. Toggle multi-select off to return
-to normal browsing.
+Click the **Multi-select** toggle in the sidebar header to enter selection mode.
+A checkbox appears on each session; click sessions to check them, or use **All**
+to select every visible session and **Clear** to deselect. The batch toolbar
+shows how many are selected and a **Delete** action that moves the whole
+selection to the trash at once. Toggle multi-select off to return to normal
+browsing.
 
 ### Pinned Messages
 
-Click the pin icon on any message header to pin it. Pinned
-messages are saved to the database and accessible from
-**More → Pinned** in the header navigation.
+Click the pin icon on any message header to pin it. Pinned messages are saved to
+the database and accessible from **More → Pinned** in the header navigation.
 
-The pinned page shows a gallery-style grid of pinned messages.
-Each card shows the message content (expandable for long
-messages), the session and project it belongs to, and actions
-to copy the content, unpin, or navigate back to the source
-message in its session.
+The pinned page shows a gallery-style grid of pinned messages. Each card shows
+the message content (expandable for long messages), the session and project it
+belongs to, and actions to copy the content, unpin, or navigate back to the
+source message in its session.
 
 ### Session Resume Menu
 
@@ -1065,8 +981,7 @@ Select a session and open **Resume** in the detail header. For supported local
 agents, the menu can launch the configured terminal, use the default terminal,
 or copy the exact resume command. Cursor resume resolves the original workspace
 path and passes it as `--workspace` to `cursor agent --resume`. The same menu
-can copy the session directory and open it in detected editors or file
-browsers.
+can copy the session directory and open it in detected editors or file browsers.
 
 Local Codex sessions add **Open in Codex Desktop**, which deep-links to the
 stored thread. Local Claude sessions add **Open in Claude Code**, which opens a
@@ -1077,33 +992,31 @@ desktop app cannot open another machine's transcript or directory.
 
 ![Session resume menu](/docs/assets/generated/screenshots/session-resume-menu.png)
 
-The `agentsview session list --resume` and `--active` CLI modes use
-the same recent-activity signal to produce a compact terminal table
-for picking up in-flight work.
+The `agentsview session list --resume` and `--active` CLI modes use the same
+recent-activity signal to produce a compact terminal table for picking up
+in-flight work.
 
-These actions let you quickly pick up where you left off
-without manually navigating to the project directory.
+These actions let you quickly pick up where you left off without manually
+navigating to the project directory.
 
----
+______________________________________________________________________
 
 ## Session Export
 
-Press `e` or open the export menu in the header to download the
-current session as a standalone HTML file. The exported file
-includes styled message rendering and works offline. As of
-0.30.0, the export ships with a **Normal / Focused** radio
-toggle in the document header so the recipient can flip into
-[focused mode](#focused-transcript-mode) — only user prompts
-and final assistant responses — without re-running the export.
+Press `e` or open the export menu in the header to download the current session
+as a standalone HTML file. The exported file includes styled message rendering
+and works offline. As of 0.30.0, the export ships with a **Normal / Focused**
+radio toggle in the document header so the recipient can flip into
+[focused mode](#focused-transcript-mode) — only user prompts and final assistant
+responses — without re-running the export.
 
-The same menu also includes **Copy markdown export link**, which
-copies a URL for the session's markdown export endpoint. That link
-can be used in scripts, notes, or shared internal tooling when you
-want a text-oriented representation instead of the standalone HTML
-export. When the active session has a source file path, the menu
-also offers **Copy source file path** for quick handoff to another
-tool or terminal. The markdown export is particularly well-suited
-for handing session context to another agent.
+The same menu also includes **Copy markdown export link**, which copies a URL
+for the session's markdown export endpoint. That link can be used in scripts,
+notes, or shared internal tooling when you want a text-oriented representation
+instead of the standalone HTML export. When the active session has a source file
+path, the menu also offers **Copy source file path** for quick handoff to
+another tool or terminal. The markdown export is particularly well-suited for
+handing session context to another agent.
 
 The markdown export route is:
 
@@ -1111,17 +1024,17 @@ The markdown export route is:
 GET /api/v1/sessions/{id}/md
 ```
 
-By default, it exports only the current session. Add the
-`depth` query parameter to inline descendants:
+By default, it exports only the current session. Add the `depth` query parameter
+to inline descendants:
 
 - `?depth=1` — include direct child sessions
 - `?depth=all` — include the full descendant tree
 
-Subagent children are embedded inline near the tool call that
-spawned them. Other child sessions are appended after the parent
-transcript in `<child_session>` blocks. The markdown payload also
-includes XML-style tags for metadata, thinking blocks, tool
-calls, code blocks, and child-session boundaries.
+Subagent children are embedded inline near the tool call that spawned them.
+Other child sessions are appended after the parent transcript in
+`<child_session>` blocks. The markdown payload also includes XML-style tags for
+metadata, thinking blocks, tool calls, code blocks, and child-session
+boundaries.
 
 Typical agent handoff flow:
 
@@ -1130,41 +1043,38 @@ curl "http://127.0.0.1:8080/api/v1/sessions/<session-id>/md?depth=all" \
   -o session-context.md
 ```
 
-Then attach `session-context.md` to another agent run or paste
-its contents into a prompt so the next agent can inspect the
-full session tree without opening the AgentsView UI.
+Then attach `session-context.md` to another agent run or paste its contents into
+a prompt so the next agent can inspect the full session tree without opening the
+AgentsView UI.
 
----
+______________________________________________________________________
 
 ## Publish to Gist
 
-Press `p` or click the publish button to share a session via
-GitHub Gist. As of 0.33.0, the publish button is a dropdown
-with two entries: **Publish public Gist** and **Publish secret
-Gist**. The `p` shortcut publishes publicly.
+Press `p` or click the publish button to share a session via GitHub Gist. As of
+0.33.0, the publish button is a dropdown with two entries: **Publish public
+Gist** and **Publish secret Gist**. The `p` shortcut publishes publicly.
 
 ![Publish modal](/docs/assets/generated/screenshots/publish-modal.png)
 
-AgentsView prefers your existing GitHub CLI login for local
-publishing. If no token is saved in AgentsView and
-`AGENTSVIEW_GITHUB_TOKEN` is not set, it runs `gh auth token` and
-uses that token to create the gist. Run `gh auth login` once if
-the GitHub CLI is not authenticated yet.
+AgentsView prefers your existing GitHub CLI login for local publishing. If no
+token is saved in AgentsView and `AGENTSVIEW_GITHUB_TOKEN` is not set, it runs
+`gh auth token` and uses that token to create the gist. Run `gh auth login` once
+if the GitHub CLI is not authenticated yet.
 
-For remote or proxied AgentsView access, save a GitHub token in
-AgentsView before publishing. Remote requests do not use the server
-process environment or GitHub CLI credential as a fallback.
+For remote or proxied AgentsView access, save a GitHub token in AgentsView
+before publishing. Remote requests do not use the server process environment or
+GitHub CLI credential as a fallback.
 
-If neither a saved token, `AGENTSVIEW_GITHUB_TOKEN`, nor
-`gh auth token` is available for local publishing, the publish
-modal prompts for a GitHub personal access token with the `gist`
-scope. That token is saved to your config file and reused for
-future publishes.
+If neither a saved token, `AGENTSVIEW_GITHUB_TOKEN`, nor `gh auth token` is
+available for local publishing, the publish modal prompts for a GitHub personal
+access token with the `gist` scope. That token is saved to your config file and
+reused for future publishes.
 
 !!! warning
-    Secret gists are unlisted, not access-controlled: they don't
-    appear in your public gist list or in search, but anyone who
-    has the URL can read them.
+
+    Secret gists are unlisted, not access-controlled: they don't appear in your
+    public gist list or in search, but anyone who has the URL can read them.
 
 After publishing, the modal shows two URLs:
 
@@ -1173,7 +1083,7 @@ After publishing, the modal shows two URLs:
 
 Both have copy buttons and an "Open in Browser" action.
 
----
+______________________________________________________________________
 
 ## Session Upload
 
@@ -1184,59 +1094,60 @@ curl -F "file=@session.jsonl" \
   "http://127.0.0.1:8080/api/v1/sessions/upload?project=myapp"
 ```
 
-Uploaded files are stored in `~/.agentsview/uploads/` and
-synced into the database.
+Uploaded files are stored in `~/.agentsview/uploads/` and synced into the
+database.
 
-Replacing an existing session with fewer messages returns `409 Conflict` without changing the stored transcript. To permit an intentional shorter rewrite, add `allow_shorter=true` to the upload query.
+Replacing an existing session with fewer messages returns `409 Conflict` without
+changing the stored transcript. To permit an intentional shorter rewrite, add
+`allow_shorter=true` to the upload query.
 
----
+______________________________________________________________________
 
 ## Keyboard Shortcuts
 
 Press `?` to see all shortcuts in a modal overlay.
 
-| Key | Action |
-|-----|--------|
-| `Cmd+K` | Open command palette |
-| `Cmd+F` | Search within current session |
-| `Esc` | Close modal / deselect session |
-| `j` / `↓` | Next message |
-| `k` / `↑` | Previous message |
-| `Shift+J` | Next user prompt |
-| `Shift+K` | Previous user prompt |
-| `]` | Next session |
-| `[` | Previous session |
-| `o` | Toggle sort order |
-| `l` | Cycle message layout |
-| `s` | Star / unstar current session |
-| `Del` | Delete / archive selected session |
-| `r` | Trigger sync |
-| `e` | Export session |
-| `p` | Publish to Gist |
-| `?` | Show shortcuts |
+| Key       | Action                            |
+| --------- | --------------------------------- |
+| `Cmd+K`   | Open command palette              |
+| `Cmd+F`   | Search within current session     |
+| `Esc`     | Close modal / deselect session    |
+| `j` / `↓` | Next message                      |
+| `k` / `↑` | Previous message                  |
+| `Shift+J` | Next user prompt                  |
+| `Shift+K` | Previous user prompt              |
+| `]`       | Next session                      |
+| `[`       | Previous session                  |
+| `o`       | Toggle sort order                 |
+| `l`       | Cycle message layout              |
+| `s`       | Star / unstar current session     |
+| `Del`     | Delete / archive selected session |
+| `r`       | Trigger sync                      |
+| `e`       | Export session                    |
+| `p`       | Publish to Gist                   |
+| `?`       | Show shortcuts                    |
 
-Shortcuts are disabled when typing in an input field. `Esc`
-always works.
+Shortcuts are disabled when typing in an input field. `Esc` always works.
 
----
+______________________________________________________________________
 
 ## Settings
 
-Click the gear icon in the header to open the Settings page.
-Settings are organized into sections:
+Click the gear icon in the header to open the Settings page. Settings are
+organized into sections:
 
 ![Settings page](/docs/assets/generated/screenshots/settings.png)
 
-| Section | What You Can Configure |
-|---------|----------------------|
-| Language | Interface language (English, French, Simplified Chinese, Traditional Chinese, or Korean) |
-| Appearance | Theme (light/dark), high-contrast mode, chart colors, message layout, text size, block visibility, desktop zoom level |
-| Date ranges | Browser-local checkbox for linking date selections across Sessions, Usage, Activity, Trends, and Quality |
+| Section           | What You Can Configure                                                                                                                                                                                    |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Language          | Interface language (English, French, Japanese, Korean, Simplified Chinese, or Traditional Chinese)                                                                                                        |
+| Appearance        | Theme (light/dark), high-contrast mode, chart colors, message layout, text size, block visibility, desktop zoom level                                                                                     |
+| Date ranges       | Browser-local checkbox for linking date selections across Sessions, Usage, Activity, Trends, and Quality                                                                                                  |
 | Agent Directories | Custom paths for each agent's session files. For Devin CLI, point at the local root that contains `cli/` (for example a redacted `.../Application Support/devin` path), not copied config or OAuth files. |
-| Terminal | Default terminal emulator for session resume |
-| Embeddings | Current semantic-index build phase, progress, throughput, ETA, last result, and local generations |
-| GitHub | Personal access token for Gist publishing |
-| Remote Access | Remote connections toggle, auth token, connect to remote server |
+| Terminal          | Default terminal emulator for session resume                                                                                                                                                              |
+| Embeddings        | Current semantic-index build phase, progress, throughput, ETA, last result, and local generations                                                                                                         |
+| GitHub            | Personal access token for Gist publishing                                                                                                                                                                 |
+| Remote Access     | Remote connections toggle, auth token, connect to remote server                                                                                                                                           |
 
 ![Embedding build progress](/docs/assets/generated/screenshots/settings-embeddings.png)
 
@@ -1249,47 +1160,45 @@ desktop zoom, and Date ranges preferences are stored in the browser. **Chart
 colors** are the exception within Appearance: the selected palette is saved
 server-wide as `chart_palette` in `~/.agentsview/config.toml`. Agent directory
 overrides, terminal settings, the saved GitHub token, and the local server's
-remote-access authentication settings also use that file. Worktree mapping
-rules moved to the [Data page](/docs/data/#rules) and live in the local archive
-database. See [Remote Access](/docs/remote-access/) for details on the remote access
-settings.
+remote-access authentication settings also use that file. Worktree mapping rules
+moved to the [Data page](/docs/data/#rules) and live in the local archive
+database. See [Remote Access](/docs/remote-access/) for details on the remote
+access settings.
 
----
+______________________________________________________________________
 
 ## About Dialog
 
-Click the version number in the status bar or select **About**
-from the header menu to open the About dialog. It shows the
-current version, build date, git commit, and links to the
-changelog and GitHub repository.
+Click the version number in the status bar or select **About** from the header
+menu to open the About dialog. It shows the current version, build date, git
+commit, and links to the changelog and GitHub repository.
 
 ![About dialog](/docs/assets/generated/screenshots/about-dialog.png)
 
----
+______________________________________________________________________
 
 ## Desktop Zoom
 
-In the desktop app, use `Cmd+Plus` and `Cmd+Minus` (or
-`Ctrl+Plus` / `Ctrl+Minus` on Windows) to zoom in and out.
-`Cmd+0` resets to the default zoom level. The zoom level can
-also be set in the Settings page under the **Appearance** tab.
+In the desktop app, use `Cmd+Plus` and `Cmd+Minus` (or `Ctrl+Plus` /
+`Ctrl+Minus` on Windows) to zoom in and out. `Cmd+0` resets to the default zoom
+level. The zoom level can also be set in the Settings page under the
+**Appearance** tab.
 
----
+______________________________________________________________________
 
 ## Theme
 
-Click the theme toggle in the header or go to Settings >
-Appearance to switch between light and dark mode. The
-preference is saved and persists across sessions.
+Click the theme toggle in the header or go to Settings > Appearance to switch
+between light and dark mode. The preference is saved and persists across
+sessions.
 
 ![Light theme](/docs/assets/generated/screenshots/theme-light.png)
 
 ![Dark theme](/docs/assets/generated/screenshots/theme-dark.png)
 
-Settings > Appearance also offers a **high-contrast** mode for
-greater legibility and a **text size** control (90–130%) that
-scales message and interface text. Both preferences are saved
-and persist across sessions.
+Settings > Appearance also offers a **high-contrast** mode for greater
+legibility and a **text size** control (90–130%) that scales message and
+interface text. Both preferences are saved and persist across sessions.
 
 The **Chart colors** control selects the categorical palette used by the
 dashboard skill trend, Trends, and Usage charts. Choose **Agentsview** for the
@@ -1299,8 +1208,8 @@ the same writable server use the same palette.
 
 ### Iframe Embedding
 
-When embedding AgentsView in an iframe, the parent page can
-control the theme via `postMessage`:
+When embedding AgentsView in an iframe, the parent page can control the theme
+via `postMessage`:
 
 ```javascript
 iframe.contentWindow.postMessage(
@@ -1311,43 +1220,38 @@ iframe.contentWindow.postMessage(
 
 Accepted values for `theme` are `"light"` and `"dark"`.
 
----
+______________________________________________________________________
 
 ## Sync
 
-AgentsView automatically syncs session files on startup and
-watches for changes in real time. The sync status is shown in
-the status bar:
+AgentsView automatically syncs session files on startup and watches for changes
+in real time. The sync status is shown in the status bar:
 
-- **Syncing indicator** — green text showing progress percentage
-  and phase (`Scanning [project]...` or parse progress)
-- **Last sync time** — relative timestamp ("synced 2h ago")
-  that updates automatically. Hover to see the exact sync
-  timestamp.
+- **Syncing indicator** — green text showing progress percentage and phase
+  (`Scanning [project]...` or parse progress)
+- **Last sync time** — relative timestamp ("synced 2h ago") that updates
+  automatically. Hover to see the exact sync timestamp.
 
-Press `r` to trigger a manual sync. The sync button in the
-header shows a spinning animation while syncing.
+Press `r` to trigger a manual sync. The sync button in the header shows a
+spinning animation while syncing.
 
-The status bar also shows a version mismatch warning (red) if
-the frontend and backend versions differ. Click it to reload.
+The status bar also shows a version mismatch warning (red) if the frontend and
+backend versions differ. Click it to reload.
 
 ### Full Resync
 
 ![Resync modal](/docs/assets/generated/screenshots/resync-modal.png)
 
-Click the **gear icon** in the header to open the Full Resync
-modal. This re-parses all session files from scratch using a
-non-destructive flow — existing session data is preserved and
-orphaned sessions (those no longer present on disk) are carried
-forward. This is useful after upgrading AgentsView or when
+Click the **gear icon** in the header to open the Full Resync modal. This
+re-parses all session files from scratch using a non-destructive flow — existing
+session data is preserved and orphaned sessions (those no longer present on
+disk) are carried forward. This is useful after upgrading AgentsView or when
 sessions appear to be parsed incorrectly.
 
 The modal shows live progress as sessions are processed:
 
-1. **Confirm** — describes what the resync does, with Start and
-   Cancel buttons
-2. **Progress** — live counter and progress bar ("Syncing X / Y
-   sessions..."). The modal stays open until the resync finishes.
-3. **Done** — shows synced, skipped, and total session counts
-4. **Error** — if the resync fails, shows the error with Retry
-   and Close buttons
+1. **Confirm** — describes what the resync does, with Start and Cancel buttons
+1. **Progress** — live counter and progress bar ("Syncing X / Y sessions...").
+   The modal stays open until the resync finishes.
+1. **Done** — shows synced, skipped, and total session counts
+1. **Error** — if the resync fails, shows the error with Retry and Close buttons

--- a/docs/website/guide.md
+++ b/docs/website/guide.md
@@ -6,9 +6,9 @@ stops, five minutes.
 
 ## 01 — Capture every session
 
-The daemon discovers the session directories that Claude Code, Codex, Cursor,
-Copilot, Gemini, and more than 50 other agents already write, and syncs them
-into one local SQLite archive with full-text indexes. It keeps watching, so the
+The daemon discovers the session directories behind more than 60 agent formats,
+including Claude Code, Codex, Cursor, Copilot, and Gemini, and syncs them into
+one local SQLite archive with full-text indexes. It keeps watching, so the
 archive stays current while you work. [Quick start](/docs/quickstart/).
 
 ## 02 — Browse the full conversation
@@ -64,11 +64,11 @@ tried before repeating it. [MCP server](/docs/mcp/) ·
 
 ## 09 — Extend beyond one machine
 
-Push each machine's archive to PostgreSQL for a merged team view with
-per-machine labels, mirror into DuckDB for analytical queries, or sync raw
-session directories through the filesystem or S3. SQLite on your disk remains
-the archive of record. [PostgreSQL sync](/docs/pg-sync/) ·
-[DuckDB mirror](/docs/duckdb/).
+Push each machine's archive to PostgreSQL for a merged team view, mirror into
+DuckDB for analytical queries, read source files through the filesystem or S3,
+or keep original files in hosted raw custody. SQLite on your disk remains the
+local archive of record. [PostgreSQL sync](/docs/pg-sync/) ·
+[DuckDB mirror](/docs/duckdb/) · [Hosted raw sync](/docs/hosted-raw-sync/).
 
 ## Next
 

--- a/docs/website/guide/index.html
+++ b/docs/website/guide/index.html
@@ -118,7 +118,7 @@
         <li class="guide-stop" id="capture">
           <div class="guide-copy">
             <h2>Capture every session</h2>
-            <p>The daemon discovers the session directories that Claude Code, Codex, Cursor, Copilot, Gemini, and more than 50 other agents already write, and syncs them into one local SQLite archive with full-text indexes. It keeps watching, so the archive stays current while you work.</p>
+            <p>The daemon discovers the session directories behind more than 60 agent formats, including Claude Code, Codex, Cursor, Copilot, and Gemini, and syncs them into one local SQLite archive with full-text indexes. It keeps watching, so the archive stays current while you work.</p>
             <a href="/docs/quickstart/">Quick start</a>
           </div>
           <div class="guide-media">
@@ -248,7 +248,7 @@
         <li class="guide-stop" id="sync">
           <div class="guide-copy">
             <h2>Extend beyond one machine</h2>
-            <p>Push each machine's archive to PostgreSQL for a merged team view with per-machine labels, mirror into DuckDB for analytical queries, or sync raw session directories through the filesystem or S3. SQLite on your disk remains the archive of record.</p>
+            <p>Push each machine's archive to PostgreSQL for a merged team view, mirror into DuckDB for analytical queries, read source files through the filesystem or S3, or keep original files in hosted raw custody. SQLite on your disk remains the local archive of record.</p>
             <a href="/docs/pg-sync/">PostgreSQL sync</a> · <a href="/docs/duckdb/">DuckDB mirror</a>
           </div>
           <div class="guide-media">
@@ -280,7 +280,7 @@
     </main>
 
     <footer class="site-footer">
-      <p>Session data stays on your machine.</p>
+      <p>Local by default. Shared only through features you choose.</p>
       <nav class="footer-links" aria-label="Footer navigation">
         <a href="/">Product</a>
         <a href="/guide.md">Markdown</a>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -3,23 +3,23 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>AgentsView — the system of record for your AI coding agents</title>
-    <meta name="description" content="AgentsView is a local-first daemon that captures every session from more than 50 coding agents into one searchable archive: transcripts, activity, cost, quality, and recall.">
+    <title>AgentsView — see what your AI coding agents did and what it cost</title>
+    <meta name="description" content="See every AI coding session, search what happened, track cost and quality, and keep the archive local by default.">
     <link rel="canonical" href="https://agentsview.io/">
     <link rel="alternate" type="text/markdown" href="https://agentsview.io/index.md">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/styles/site.css">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="The system of record for your AI coding agents.">
-    <meta property="og:description" content="A local-first daemon that captures every session from more than 50 coding agents into one searchable archive: transcripts, activity, cost, quality, and recall.">
+    <meta property="og:title" content="See what your AI coding agents did — and what it cost.">
+    <meta property="og:description" content="The local-first system of record for AI coding sessions, with search, activity, cost, quality, and recall.">
     <meta property="og:url" content="https://agentsview.io/">
     <meta property="og:site_name" content="AgentsView">
     <meta property="og:image" content="https://agentsview.io/docs/assets/static/og-image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="The system of record for your AI coding agents.">
-    <meta name="twitter:description" content="A local-first daemon that captures every session from more than 50 coding agents into one searchable archive: transcripts, activity, cost, quality, and recall.">
+    <meta name="twitter:title" content="See what your AI coding agents did — and what it cost.">
+    <meta name="twitter:description" content="The local-first system of record for AI coding sessions, with search, activity, cost, quality, and recall.">
     <meta name="twitter:image" content="https://agentsview.io/docs/assets/static/og-image.png">
   </head>
   <body>
@@ -100,8 +100,8 @@
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-layout">
           <div class="hero-copy">
-            <h1 id="hero-title">The system of record for your AI coding agents.</h1>
-            <p class="lede">AgentsView is a local-first daemon that captures every session from more than 50 coding agents into one searchable archive. Browse transcripts, monitor activity, track cost, measure quality, and feed what you learn back to your agents. Session data stays on your machine.</p>
+            <h1 id="hero-title">See what your AI coding agents did — and what it cost.</h1>
+            <p class="lede">AgentsView is the local-first system of record for AI coding sessions. It turns more than 60 agent formats into one searchable archive for transcripts, activity, cost, quality, and recall. Your archive stays on your machine by default and leaves only through features you choose.</p>
             <div class="install-command" data-install-command data-command="curl -fsSL https://agentsview.io/install.sh | bash">
               <code>curl -fsSL https://agentsview.io/install.sh | bash</code>
               <button class="button install-copy" type="button" data-install-copy>Copy</button>
@@ -153,6 +153,7 @@
           <a class="agent-chip" href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener"><span class="agent-chip-glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#i-gemini"/></svg></span><span class="agent-chip-name">Gemini</span></a>
           <a class="agent-chip" href="https://github.com/features/copilot" target="_blank" rel="noopener"><span class="agent-chip-glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#i-copilot"/></svg></span><span class="agent-chip-name">Copilot</span></a>
           <a class="agent-chip" href="https://cursor.com" target="_blank" rel="noopener"><span class="agent-chip-glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#i-cursor"/></svg></span><span class="agent-chip-name">Cursor</span></a>
+          <a class="agent-chip" href="https://cursor.com" target="_blank" rel="noopener"><span class="agent-chip-glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#i-cursor"/></svg></span><span class="agent-chip-name">Cursor IDE</span></a>
           <a class="agent-chip" href="https://github.com/features/copilot" target="_blank" rel="noopener"><span class="agent-chip-glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#i-vscode"/></svg></span><span class="agent-chip-name">VS Code Copilot</span></a>
           <a class="agent-chip" href="https://visualstudio.microsoft.com" target="_blank" rel="noopener"><span class="agent-chip-glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#i-visualstudio"/></svg></span><span class="agent-chip-name">Visual Studio Copilot</span></a>
           <a class="agent-chip" href="https://github.com/QwenLM/qwen-code" target="_blank" rel="noopener"><span class="agent-chip-glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use xlink:href="#i-qwen"/></svg></span><span class="agent-chip-name">Qwen Code</span></a>
@@ -187,6 +188,7 @@
           <a class="agent-chip" href="/docs/configuration/#session-discovery"><span class="agent-chip-glyph">Gr</span><span class="agent-chip-name">Grok</span></a>
           <a class="agent-chip" href="/docs/configuration/#session-discovery"><span class="agent-chip-glyph">He</span><span class="agent-chip-name">Hermes</span></a>
           <a class="agent-chip" href="/docs/configuration/#session-discovery"><span class="agent-chip-glyph">iF</span><span class="agent-chip-name">iFlow</span></a>
+          <a class="agent-chip" href="/docs/configuration/#session-discovery"><span class="agent-chip-glyph">Ic</span><span class="agent-chip-name">IcodeMate</span></a>
           <a class="agent-chip" href="/docs/configuration/#session-discovery"><span class="agent-chip-glyph">Mi</span><span class="agent-chip-name">MiMoCode</span></a>
           <a class="agent-chip" href="/docs/configuration/#session-discovery"><span class="agent-chip-glyph">Om</span><span class="agent-chip-name">OhMyPi</span></a>
           <a class="agent-chip" href="/docs/configuration/#session-discovery"><span class="agent-chip-glyph">Oc</span><span class="agent-chip-name">OpenClaw</span></a>
@@ -205,7 +207,7 @@
           <a class="agent-chip" href="/docs/configuration/#session-discovery"><span class="agent-chip-glyph">Wb</span><span class="agent-chip-name">WorkBuddy</span></a>
         </div>
         <div class="stat-row">
-          <div class="stat"><span class="stat-value">56</span><span class="stat-label">agent harnesses parsed</span></div>
+          <div class="stat"><span class="stat-value">60+</span><span class="stat-label">agent formats parsed</span></div>
           <div class="stat"><span class="stat-value">1</span><span class="stat-label">binary, zero accounts</span></div>
           <div class="stat"><span class="stat-value">80&ndash;220&times;</span><span class="stat-label">faster than ccusage on large archives</span></div>
         </div>
@@ -321,7 +323,7 @@
             <p class="section-index">07 / Share</p>
             <h2 id="share-title">One machine or the whole team.</h2>
           </div>
-          <p>SQLite is the archive of record. From there, push to PostgreSQL for a shared team backend with per-machine labels, mirror into DuckDB for analytical queries, or sync session files across machines without any database at all.</p>
+          <p>SQLite is the local archive of record. From there, push parsed sessions to PostgreSQL, mirror into DuckDB, read provider files from S3, or keep original source files in hosted raw custody.</p>
         </div>
         <div class="proof-grid">
           <article class="proof">
@@ -340,9 +342,19 @@
             <p>Point a primary viewer at out-of-band copies of native session directories, including S3-backed sources. <a href="/docs/filesystem-sync/">Filesystem sync</a>.</p>
           </article>
           <article class="proof">
+            <p class="proof-tag">Hosted raw sync</p>
+            <h3>Keep the original files off-device.</h3>
+            <p>Continuously capture supported local sources with device authentication, resumable uploads, and durable checkpoints. <a href="/docs/hosted-raw-sync/">Hosted raw sync</a>.</p>
+          </article>
+          <article class="proof">
             <p class="proof-tag">Remote access</p>
             <h3>Reach it from anywhere you trust.</h3>
             <p>Loopback by default, with explicit flags for SSH forwards, remote dev environments, and authenticated non-loopback exposure. <a href="/docs/remote-access/">Remote access</a>.</p>
+          </article>
+          <article class="proof">
+            <p class="proof-tag">Artifact folders</p>
+            <h3>Exchange normalized revisions.</h3>
+            <p>Move immutable session revisions between trusted folders for experimental portable workflows. <a href="/docs/artifact-sync/">Artifact folder sync</a>.</p>
           </article>
         </div>
       </section>
@@ -351,25 +363,25 @@
         <div class="section-heading">
           <div>
             <p class="section-index">08 / Own</p>
-            <h2 id="own-title">Not a hosted analytics product.</h2>
+            <h2 id="own-title">Local by default. Shared when you choose.</h2>
           </div>
-          <p>Your agent transcripts are some of the most sensitive data on your machine. AgentsView treats them that way: everything is stored and served locally, there are no accounts, and the server binds to loopback unless you say otherwise.</p>
+          <p>Your agent transcripts can contain source code, credentials, paths, and private conversations. AgentsView starts with one local SQLite archive and a loopback-only server. Nothing leaves the machine unless you enable a feature that sends it elsewhere.</p>
         </div>
         <div class="boundary-grid">
           <article class="boundary">
-            <p class="proof-tag">Hosted dashboard</p>
-            <h3>Your transcripts become their data.</h3>
-            <p>Session content, prompts, and file paths leave your machine to power someone else's analytics account.</p>
+            <p class="proof-tag">Default</p>
+            <h3>Keep the archive on your machine.</h3>
+            <p>Browse, search, report, and run local Recall workflows without sending session content to an AgentsView account.</p>
           </article>
           <article class="boundary">
-            <p class="proof-tag">Raw session files</p>
-            <h3>The history exists but can't answer.</h3>
-            <p>Dozens of formats in dot-directories, no index, no cross-agent view, and no way to ask what last month cost.</p>
+            <p class="proof-tag">Your choice</p>
+            <h3>Share only for a clear purpose.</h3>
+            <p>Configure PostgreSQL, remote DuckDB, Generated Insights, GitHub publishing, or hosted raw sync only when that outcome is worth sending data.</p>
           </article>
           <article class="boundary">
-            <p class="proof-tag">AgentsView</p>
-            <h3>A local archive that answers.</h3>
-            <p>One indexed SQLite database on your disk, queryable by you and your agents, shared further only when you configure it. <a href="/docs/#privacy">Privacy details</a>.</p>
+            <p class="proof-tag">Visible boundaries</p>
+            <h3>Know what crosses the boundary.</h3>
+            <p>Each sharing feature documents what it sends, where it goes, and which controls apply. <a href="/docs/#privacy">Privacy details</a>.</p>
           </article>
         </div>
       </section>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -209,7 +209,7 @@
         <div class="stat-row">
           <div class="stat"><span class="stat-value">60+</span><span class="stat-label">agent formats parsed</span></div>
           <div class="stat"><span class="stat-value">1</span><span class="stat-label">binary, zero accounts</span></div>
-          <div class="stat"><span class="stat-value">80&ndash;220&times;</span><span class="stat-label">faster than ccusage on large archives</span></div>
+          <div class="stat"><span class="stat-value">SQLite</span><span class="stat-label">archive of record</span></div>
         </div>
       </section>
 
@@ -235,7 +235,7 @@
             <p class="section-index">03 / Account</p>
             <h2 id="account-title">Know what every agent costs.</h2>
           </div>
-          <p>Token and cost reports read from the pre-indexed archive, so they return in well under a second even on histories with tens of thousands of sessions: 80&ndash;220&times; faster than <code>npx ccusage</code> on a 22,000-session database. Pricing tracks LiteLLM and OpenRouter rates with an offline fallback, and cache-aware accounting covers prompt-cache creation and reads.</p>
+          <p>Token and cost reports read from the pre-indexed archive instead of reparsing every raw session file for each report. Pricing tracks LiteLLM and OpenRouter rates with an offline fallback, and cache-aware accounting covers prompt-cache creation and reads.</p>
         </div>
         <div class="split-layout">
           <figure class="capture">

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -37,7 +37,7 @@ RooCode, Trae, Windsurf, and dozens more. Every supported source is listed in
 
 - **60+** agent formats parsed
 - **1** binary, zero accounts
-- **80–220×** faster than ccusage on large archives
+- **SQLite** archive of record
 
 ## See when your agents are actually working
 
@@ -49,11 +49,10 @@ machine. Live sync streams new messages into the UI as sessions run.
 
 ## Know what every agent costs
 
-[Token and cost reports](/docs/token-usage/) read from the pre-indexed archive,
-so they return in well under a second even on histories with tens of thousands
-of sessions: 80–220× faster than `npx ccusage` on a 22,000-session database.
-Pricing tracks LiteLLM and OpenRouter rates with an offline fallback, and
-cache-aware accounting covers prompt-cache creation and reads.
+[Token and cost reports](/docs/token-usage/) read from the pre-indexed archive
+instead of reparsing every raw session file for each report. Pricing tracks
+LiteLLM and OpenRouter rates with an offline fallback, and cache-aware
+accounting covers prompt-cache creation and reads.
 
 ```bash
 agentsview usage daily          # last 30 days, terminal table

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -1,9 +1,9 @@
-# The system of record for your AI coding agents
+# See what your AI coding agents did — and what it cost
 
-AgentsView is a local-first daemon that captures every session from more than 50
-coding agents into one searchable archive. Browse transcripts, monitor activity,
-track cost, measure quality, and feed what you learn back to your agents.
-Session data stays on your machine.
+AgentsView is the local-first system of record for AI coding sessions. It turns
+more than 60 agent formats into one searchable archive for transcripts,
+activity, cost, quality, and recall. Your archive stays on your machine by
+default and leaves only through features you choose.
 
 ## Install
 
@@ -29,13 +29,13 @@ A background daemon watches the session directories your agents already write,
 parses each format, and syncs everything into a local SQLite archive with
 full-text indexes. Auto-discovered, nothing to configure. Supported harnesses
 include Claude Code, OpenClaude, Codex, Gemini, Copilot (CLI, VS Code, and
-Visual Studio), Cursor, Qwen Code, DeepSeek TUI and Harness, Mistral Vibe, Zed,
-Warp, OpenCode, Positron, Posit Assistant, Claude Cowork, Aider, Antigravity,
-gptme, Kilo, Kimi, Kiro, OpenHands, Goose, Grok, RooCode, Trae, Windsurf, and
-dozens more. All 56 harnesses are listed in
+Visual Studio), Cursor, Cursor IDE, IcodeMate, Qwen Code, DeepSeek TUI and
+Harness, Mistral Vibe, Zed, Warp, OpenCode, Positron, Posit Assistant, Claude
+Cowork, Aider, Antigravity, gptme, Kilo, Kimi, Kiro, OpenHands, Goose, Grok,
+RooCode, Trae, Windsurf, and dozens more. Every supported source is listed in
 [session discovery](/docs/configuration/#session-discovery).
 
-- **56** agent harnesses parsed
+- **60+** agent formats parsed
 - **1** binary, zero accounts
 - **80–220×** faster than ccusage on large archives
 
@@ -103,15 +103,19 @@ SQLite is the archive of record. From there:
 - [Filesystem sync](/docs/filesystem-sync/) and
   [artifact folder sync](/docs/artifact-sync/) move sessions between machines
   without any database server.
+- [Hosted raw sync](/docs/hosted-raw-sync/) keeps original provider files in
+  hosted custody with device authentication, resumable uploads, and durable
+  checkpoints.
 - [Remote access](/docs/remote-access/) stays loopback-only by default, with
   explicit flags for SSH forwards and authenticated exposure.
 
-## Not a hosted analytics product
+## Local by default. Shared when you choose
 
 Your agent transcripts are some of the most sensitive data on your machine.
-AgentsView stores and serves everything locally, has no accounts, and binds to
-loopback unless you say otherwise. Session content never leaves your machine
-unless you configure a sync target you control.
+AgentsView starts with one local SQLite archive and a loopback-only server. Data
+leaves the machine only when you choose a feature such as PostgreSQL sync,
+remote DuckDB access, Generated Insights, GitHub publishing, or hosted raw sync.
+Each feature documents what it sends and where it goes.
 
 ## Start
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -38,7 +38,7 @@ nav = [
   {"Artifact Folder Sync" = "artifact-sync.md"},
   {"Filesystem Session Sync" = "filesystem-sync.md"},
   {"PostgreSQL Sync" = "pg-sync.md"},
-  {"Hosted Raw Sync (In Development)" = "hosted-raw-sync.md"},
+  {"Hosted Raw Sync" = "hosted-raw-sync.md"},
   {"DuckDB Mirror" = "duckdb.md"},
 ]
 

--- a/scripts/docs_assets_test.go
+++ b/scripts/docs_assets_test.go
@@ -488,7 +488,7 @@ func writeMinimalBuiltDocsSite(t *testing.T, siteDir string) {
 		case "/docs/configuration/":
 			ids = append(ids, "session-discovery")
 		case "/docs/token-usage/":
-			ids = append(ids, "how-it-compares-to-ccusage")
+			ids = append(ids, "reporting-model")
 		case "/docs/session-api/":
 			ids = append(ids, "agentsview-session-usage")
 		}


### PR DESCRIPTION
AgentsView 0.42.0 now has one accurate, outcome-first story across the product
site, reference docs, and release history. The site leads with what people can
learn from their agent history, keeps “local-first system of record” as the hero
subline, and explains that sharing is opt-in instead of claiming cloud features
do not exist.

- Rewrites releases 0.36.0 through 0.42.0 in plain language and records that
  standard in `AGENTS.md`.
- Documents hosted raw custody, one-shot capture, new providers, broader S3
  discovery, Japanese localization, historical pricing, source-path opt-in,
  Recall policy, and exact Usage caching with their current limits.
- Refreshes the complete generated screenshot set and keeps local worktrees and
  caches out of its Docker build context.
