### PR TITLE
fix(codex): resolve forks of turnless parents instead of retrying forever

### DIFF
--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -212,11 +212,6 @@ func (b *codexSessionBuilder) armForkGate(payload gjson.Result) {
 		b.parentTurnIDs, resolved = b.resolveParentTurns(parentID)
 	}
 	b.forkGate.armFromMeta(payload, resolved)
-	if resolved && len(b.parentTurnIDs) == 0 {
-		// The parent exists but holds no turns, so the fork replayed no
-		// history: every record in this rollout is the child's own.
-		b.forkGate.active = false
-	}
 }
 
 func (b *codexSessionBuilder) suppresses(
@@ -1670,16 +1665,21 @@ func (p *codexProvider) parentTurnResolver(
 func (p *codexProvider) codexParentResolution(
 	ctx context.Context, childPath string,
 ) (string, bool) {
-	parentID, resolutionNeeded := codexReplayParentIDContext(ctx, childPath)
-	if parentID == "" || !resolutionNeeded {
+	scan := codexReplayParentScan(ctx, childPath)
+	if scan.parentID == "" || !scan.resolutionNeeded {
 		return "", false
 	}
-	// A parent that was read but never opened a turn (Codex Desktop writes
-	// a rollout on thread open, and a fork taken before the first prompt
-	// copies nothing) is resolved: there is no replayed history to drop,
-	// and nothing a retry could learn later.
-	_, resolved := p.parentTurnResolver(ctx, childPath)(parentID)
-	return parentID, resolved
+	turnIDs, resolved := p.parentTurnResolver(ctx, childPath)(scan.parentID)
+	if !resolved {
+		return scan.parentID, false
+	}
+	// A readable parent with no turn ids is settled unless the child holds
+	// the copied parent session_meta. Codex Desktop writes a rollout when a
+	// thread opens, so a fork taken before the first prompt names such a
+	// parent and replayed nothing; the child is current. The copied meta is
+	// the one case where the parent wrote turns the fork copied but has not
+	// flushed to its own file yet, and only then does the child wait.
+	return scan.parentID, len(turnIDs) > 0 || !scan.copiedParentMeta
 }
 
 // CodexReplayParentID returns the explicit parent only when the rollout has a
@@ -1693,49 +1693,79 @@ func CodexReplayParentID(childPath string) (string, bool) {
 func codexReplayParentIDContext(
 	ctx context.Context, childPath string,
 ) (string, bool) {
-	if ctx.Err() != nil {
+	scan := codexReplayParentScan(ctx, childPath)
+	if scan.parentID == "" || !scan.resolutionNeeded {
 		return "", false
+	}
+	return scan.parentID, true
+}
+
+// codexReplayParentResult is what the head of a child rollout says about
+// its lineage: the parent it names, whether that parent must be resolved
+// before the replay gate can act, and whether the copied parent
+// session_meta, the positive proof that replayed history follows, is
+// present.
+type codexReplayParentResult struct {
+	parentID         string
+	resolutionNeeded bool
+	copiedParentMeta bool
+}
+
+func codexReplayParentScan(
+	ctx context.Context, childPath string,
+) codexReplayParentResult {
+	if ctx.Err() != nil {
+		return codexReplayParentResult{}
 	}
 	f, err := os.Open(childPath)
 	if err != nil {
-		return "", false
+		return codexReplayParentResult{}
 	}
 	defer f.Close()
 
-	parentID := ""
-	resolutionNeeded := false
+	var result codexReplayParentResult
 	scanner := bufio.NewScanner(checkedContextReader{ctx: ctx, reader: f})
 	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
 	for scanner.Scan() {
 		if ctx.Err() != nil {
-			return "", false
+			return codexReplayParentResult{}
 		}
 		line := strings.TrimSpace(scanner.Text())
 		if !gjson.Valid(line) {
 			continue
 		}
-		if resolutionNeeded || gjson.Get(line, "type").Str != codexTypeSessionMeta {
+		if gjson.Get(line, "type").Str != codexTypeSessionMeta {
 			continue
 		}
 		payload := gjson.Get(line, "payload")
+		if result.resolutionNeeded {
+			if result.parentID != "" &&
+				payload.Get("id").Str == result.parentID {
+				result.copiedParentMeta = true
+				break
+			}
+			continue
+		}
 		forkedFromID := strings.TrimSpace(payload.Get("forked_from_id").Str)
 		if forkedFromID != "" {
-			parentID = forkedFromID
-			resolutionNeeded = true
+			result.parentID = forkedFromID
+			result.resolutionNeeded = true
 			continue
 		}
-		if parentID == "" {
-			parentID = codexSubagentParentThreadID(payload)
+		if result.parentID == "" {
+			result.parentID = codexSubagentParentThreadID(payload)
 			continue
 		}
-		if payload.Get("id").Str == parentID {
-			resolutionNeeded = true
+		if payload.Get("id").Str == result.parentID {
+			result.resolutionNeeded = true
+			result.copiedParentMeta = true
+			break
 		}
 	}
-	if scanner.Err() != nil || parentID == "" || !resolutionNeeded {
-		return "", false
+	if scanner.Err() != nil {
+		return codexReplayParentResult{}
 	}
-	return parentID, true
+	return result
 }
 
 // parseSessionSnapshot parses exactly the raw-size snapshot captured from f.

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1665,21 +1665,17 @@ func (p *codexProvider) parentTurnResolver(
 func (p *codexProvider) codexParentResolution(
 	ctx context.Context, childPath string,
 ) (string, bool) {
-	scan := codexReplayParentScan(ctx, childPath)
-	if scan.parentID == "" || !scan.resolutionNeeded {
+	parentID, resolutionNeeded := codexReplayParentIDContext(ctx, childPath)
+	if parentID == "" || !resolutionNeeded {
 		return "", false
 	}
-	turnIDs, resolved := p.parentTurnResolver(ctx, childPath)(scan.parentID)
-	if !resolved {
-		return scan.parentID, false
-	}
-	// A readable parent with no turn ids is settled unless the child holds
-	// the copied parent session_meta. Codex Desktop writes a rollout when a
-	// thread opens, so a fork taken before the first prompt names such a
-	// parent and replayed nothing; the child is current. The copied meta is
-	// the one case where the parent wrote turns the fork copied but has not
-	// flushed to its own file yet, and only then does the child wait.
-	return scan.parentID, len(turnIDs) > 0 || !scan.copiedParentMeta
+	// A parent that was read is settled even when it holds no turn ids.
+	// Codex writes a rollout the moment a thread opens, so a fork taken
+	// before the first prompt names a parent with only session_meta and
+	// settings events; the fork replayed nothing and a retry could never
+	// learn more. Only a parent that cannot be read defers the child.
+	_, resolved := p.parentTurnResolver(ctx, childPath)(parentID)
+	return parentID, resolved
 }
 
 // CodexReplayParentID returns the explicit parent only when the rollout has a
@@ -1693,79 +1689,49 @@ func CodexReplayParentID(childPath string) (string, bool) {
 func codexReplayParentIDContext(
 	ctx context.Context, childPath string,
 ) (string, bool) {
-	scan := codexReplayParentScan(ctx, childPath)
-	if scan.parentID == "" || !scan.resolutionNeeded {
-		return "", false
-	}
-	return scan.parentID, true
-}
-
-// codexReplayParentResult is what the head of a child rollout says about
-// its lineage: the parent it names, whether that parent must be resolved
-// before the replay gate can act, and whether the copied parent
-// session_meta, the positive proof that replayed history follows, is
-// present.
-type codexReplayParentResult struct {
-	parentID         string
-	resolutionNeeded bool
-	copiedParentMeta bool
-}
-
-func codexReplayParentScan(
-	ctx context.Context, childPath string,
-) codexReplayParentResult {
 	if ctx.Err() != nil {
-		return codexReplayParentResult{}
+		return "", false
 	}
 	f, err := os.Open(childPath)
 	if err != nil {
-		return codexReplayParentResult{}
+		return "", false
 	}
 	defer f.Close()
 
-	var result codexReplayParentResult
+	parentID := ""
+	resolutionNeeded := false
 	scanner := bufio.NewScanner(checkedContextReader{ctx: ctx, reader: f})
 	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
 	for scanner.Scan() {
 		if ctx.Err() != nil {
-			return codexReplayParentResult{}
+			return "", false
 		}
 		line := strings.TrimSpace(scanner.Text())
 		if !gjson.Valid(line) {
 			continue
 		}
-		if gjson.Get(line, "type").Str != codexTypeSessionMeta {
+		if resolutionNeeded || gjson.Get(line, "type").Str != codexTypeSessionMeta {
 			continue
 		}
 		payload := gjson.Get(line, "payload")
-		if result.resolutionNeeded {
-			if result.parentID != "" &&
-				payload.Get("id").Str == result.parentID {
-				result.copiedParentMeta = true
-				break
-			}
-			continue
-		}
 		forkedFromID := strings.TrimSpace(payload.Get("forked_from_id").Str)
 		if forkedFromID != "" {
-			result.parentID = forkedFromID
-			result.resolutionNeeded = true
+			parentID = forkedFromID
+			resolutionNeeded = true
 			continue
 		}
-		if result.parentID == "" {
-			result.parentID = codexSubagentParentThreadID(payload)
+		if parentID == "" {
+			parentID = codexSubagentParentThreadID(payload)
 			continue
 		}
-		if payload.Get("id").Str == result.parentID {
-			result.resolutionNeeded = true
-			result.copiedParentMeta = true
-			break
+		if payload.Get("id").Str == parentID {
+			resolutionNeeded = true
 		}
 	}
-	if scanner.Err() != nil {
-		return codexReplayParentResult{}
+	if scanner.Err() != nil || parentID == "" || !resolutionNeeded {
+		return "", false
 	}
-	return result
+	return parentID, true
 }
 
 // parseSessionSnapshot parses exactly the raw-size snapshot captured from f.

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -212,6 +212,11 @@ func (b *codexSessionBuilder) armForkGate(payload gjson.Result) {
 		b.parentTurnIDs, resolved = b.resolveParentTurns(parentID)
 	}
 	b.forkGate.armFromMeta(payload, resolved)
+	if resolved && len(b.parentTurnIDs) == 0 {
+		// The parent exists but holds no turns, so the fork replayed no
+		// history: every record in this rollout is the child's own.
+		b.forkGate.active = false
+	}
 }
 
 func (b *codexSessionBuilder) suppresses(
@@ -1669,8 +1674,12 @@ func (p *codexProvider) codexParentResolution(
 	if parentID == "" || !resolutionNeeded {
 		return "", false
 	}
-	turnIDs, resolved := p.parentTurnResolver(ctx, childPath)(parentID)
-	return parentID, resolved && len(turnIDs) > 0
+	// A parent that was read but never opened a turn (Codex Desktop writes
+	// a rollout on thread open, and a fork taken before the first prompt
+	// copies nothing) is resolved: there is no replayed history to drop,
+	// and nothing a retry could learn later.
+	_, resolved := p.parentTurnResolver(ctx, childPath)(parentID)
+	return parentID, resolved
 }
 
 // CodexReplayParentID returns the explicit parent only when the rollout has a

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -127,6 +127,42 @@ func TestCodexProviderUnresolvedParentNeedsRetry(t *testing.T) {
 	assert.Equal(t, "child answer", result.Result.Messages[1].Content)
 }
 
+func TestCodexProviderTurnlessParentResolvesWithoutRetry(t *testing.T) {
+	// Codex Desktop writes a rollout when a thread opens; forking before the
+	// first prompt produces a parent holding only session_meta and settings
+	// events. Such a parent is present and fully readable, so the fork must
+	// parse as current instead of being marked for a retry that can never
+	// succeed and blocking every later reconciliation page behind it.
+	root := t.TempDir()
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	writeCodexProviderSessionContent(t, root, parentID, testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/workspace/project", "codex_cli_rs", tsEarly),
+	))
+	writeCodexProviderSessionContent(t, root, childID, testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(
+			childID, parentID, "/workspace/project", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", "child-turn", tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "child task", tsEarlyS1),
+		testjsonl.CodexMsgJSON("assistant", "child answer", tsEarlyS5),
+	))
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source := requireCodexProviderSource(t, provider, childID)
+
+	outcome, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0]
+	assert.Equal(t, DataVersionCurrent, result.DataVersion)
+	assert.Empty(t, result.RetryReason)
+	require.Len(t, result.Result.Messages, 2)
+	assert.Equal(t, "child task", result.Result.Messages[0].Content)
+	assert.Equal(t, "child answer", result.Result.Messages[1].Content)
+}
+
 func TestCodexProviderUnresolvedParentWithoutFinalNewlineNeedsRetry(t *testing.T) {
 	root := t.TempDir()
 	const childID = "22222222-2222-4222-8222-222222222222"

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -127,79 +127,13 @@ func TestCodexProviderUnresolvedParentNeedsRetry(t *testing.T) {
 	assert.Equal(t, "child answer", result.Result.Messages[1].Content)
 }
 
-func TestCodexProviderReadableParentWithoutTurnsRetriesUntilParentAdvances(
-	t *testing.T,
-) {
-	root := t.TempDir()
-	const childID = "22222222-2222-4222-8222-222222222223"
-	const parentID = "11111111-1111-4111-8111-111111111112"
-	const parentTurnID = "parent-turn-later"
-	const childTurnID = "child-turn"
-
-	parentPath := writeCodexProviderSessionContent(t, root, parentID,
-		testjsonl.JoinJSONL(testjsonl.CodexSessionMetaJSON(
-			parentID, "/workspace/project", "codex_cli_rs", tsEarly,
-		)),
-	)
-	childContent := testjsonl.JoinJSONL(
-		testjsonl.CodexForkedSessionMetaJSON(
-			childID, parentID, "/workspace/project", "codex_cli_rs", tsEarly,
-		),
-		testjsonl.CodexSessionMetaJSON(
-			parentID, "/workspace/project", "codex_cli_rs", tsEarly,
-		),
-		testjsonl.CodexTurnContextWithIDJSON(
-			"gpt-5.4", parentTurnID, tsEarlyS1,
-		),
-		testjsonl.CodexMsgJSON("user", "replayed task", tsEarlyS1),
-		testjsonl.CodexMsgJSON("assistant", "replayed answer", "2024-01-01T10:00:02Z"),
-		testjsonl.CodexTurnContextWithIDJSON(
-			"gpt-5.4", childTurnID, "2024-01-01T10:00:03Z",
-		),
-		testjsonl.CodexMsgJSON("user", "child task", "2024-01-01T10:00:03Z"),
-		testjsonl.CodexMsgJSON("assistant", "child answer", tsEarlyS5),
-	)
-	writeCodexProviderSessionContent(t, root, childID, childContent)
-
-	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
-	require.True(t, ok)
-	source := requireCodexProviderSource(t, provider, childID)
-
-	first, err := provider.Parse(t.Context(), ParseRequest{Source: source})
-	require.NoError(t, err)
-	require.Len(t, first.Results, 1)
-	require.Equal(t, DataVersionNeedsRetry, first.Results[0].DataVersion,
-		"a readable parent with no turn IDs is still unresolved")
-	require.Contains(t, first.Results[0].RetryReason, "parent turns")
-	require.Len(t, first.Results[0].Result.Messages, 4,
-		"unresolved parsing fails open until the parent becomes usable")
-
-	f, err := os.OpenFile(parentPath, os.O_APPEND|os.O_WRONLY, 0o644)
-	require.NoError(t, err)
-	_, err = f.WriteString(testjsonl.JoinJSONL(
-		testjsonl.CodexTurnContextWithIDJSON(
-			"gpt-5.4", parentTurnID, tsEarlyS1,
-		),
-	))
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-
-	second, err := provider.Parse(t.Context(), ParseRequest{Source: source})
-	require.NoError(t, err)
-	require.Len(t, second.Results, 1)
-	require.Equal(t, DataVersionCurrent, second.Results[0].DataVersion)
-	require.Empty(t, second.Results[0].RetryReason)
-	require.Len(t, second.Results[0].Result.Messages, 2)
-	require.Equal(t, "child task", second.Results[0].Result.Messages[0].Content)
-	require.Equal(t, "child answer", second.Results[0].Result.Messages[1].Content)
-}
-
 func TestCodexProviderTurnlessParentResolvesWithoutRetry(t *testing.T) {
 	// Codex Desktop writes a rollout when a thread opens; forking before the
 	// first prompt produces a parent holding only session_meta and settings
 	// events. Such a parent is present and fully readable, so the fork must
 	// parse as current instead of being marked for a retry that can never
-	// succeed and blocking every later reconciliation page behind it.
+	// succeed. Whether the child carries a copied parent session_meta is
+	// not a signal: real forks replay parent history with and without it.
 	root := t.TempDir()
 	const childID = "22222222-2222-4222-8222-222222222222"
 	const parentID = "11111111-1111-4111-8111-111111111111"

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -127,6 +127,73 @@ func TestCodexProviderUnresolvedParentNeedsRetry(t *testing.T) {
 	assert.Equal(t, "child answer", result.Result.Messages[1].Content)
 }
 
+func TestCodexProviderReadableParentWithoutTurnsRetriesUntilParentAdvances(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	const childID = "22222222-2222-4222-8222-222222222223"
+	const parentID = "11111111-1111-4111-8111-111111111112"
+	const parentTurnID = "parent-turn-later"
+	const childTurnID = "child-turn"
+
+	parentPath := writeCodexProviderSessionContent(t, root, parentID,
+		testjsonl.JoinJSONL(testjsonl.CodexSessionMetaJSON(
+			parentID, "/workspace/project", "codex_cli_rs", tsEarly,
+		)),
+	)
+	childContent := testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(
+			childID, parentID, "/workspace/project", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexSessionMetaJSON(
+			parentID, "/workspace/project", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextWithIDJSON(
+			"gpt-5.4", parentTurnID, tsEarlyS1,
+		),
+		testjsonl.CodexMsgJSON("user", "replayed task", tsEarlyS1),
+		testjsonl.CodexMsgJSON("assistant", "replayed answer", "2024-01-01T10:00:02Z"),
+		testjsonl.CodexTurnContextWithIDJSON(
+			"gpt-5.4", childTurnID, "2024-01-01T10:00:03Z",
+		),
+		testjsonl.CodexMsgJSON("user", "child task", "2024-01-01T10:00:03Z"),
+		testjsonl.CodexMsgJSON("assistant", "child answer", tsEarlyS5),
+	)
+	writeCodexProviderSessionContent(t, root, childID, childContent)
+
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source := requireCodexProviderSource(t, provider, childID)
+
+	first, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, first.Results, 1)
+	require.Equal(t, DataVersionNeedsRetry, first.Results[0].DataVersion,
+		"a readable parent with no turn IDs is still unresolved")
+	require.Contains(t, first.Results[0].RetryReason, "parent turns")
+	require.Len(t, first.Results[0].Result.Messages, 4,
+		"unresolved parsing fails open until the parent becomes usable")
+
+	f, err := os.OpenFile(parentPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.JoinJSONL(
+		testjsonl.CodexTurnContextWithIDJSON(
+			"gpt-5.4", parentTurnID, tsEarlyS1,
+		),
+	))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	second, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, second.Results, 1)
+	require.Equal(t, DataVersionCurrent, second.Results[0].DataVersion)
+	require.Empty(t, second.Results[0].RetryReason)
+	require.Len(t, second.Results[0].Result.Messages, 2)
+	require.Equal(t, "child task", second.Results[0].Result.Messages[0].Content)
+	require.Equal(t, "child answer", second.Results[0].Result.Messages[1].Content)
+}
+
 func TestCodexProviderTurnlessParentResolvesWithoutRetry(t *testing.T) {
 	// Codex Desktop writes a rollout when a thread opens; forking before the
 	// first prompt produces a parent holding only session_meta and settings


### PR DESCRIPTION
Codex Desktop writes a rollout the moment a thread opens, so a fork taken before the first prompt names a parent that holds only `session_meta` and settings events. The fork gate treated a parent with no turn ids the same way as a parent it could not find: the child was stamped `DataVersionNeedsRetry`, re-parsed on every pass, and never reached the current data version. Because a retry counts as a failure in `collectAndBatch`, one such fork on a reconciliation page aborted that page and every page behind it. A local archive carried six of these forks in one chain, every parent present and readable, and logged the identical abort every fifteen seconds for a day; the deferred-source work in #1490 stops the abort from spreading but leaves those forks permanently deferred.

`codexParentResolution` now treats any parent that can be read as resolved, whether or not it holds turn ids. A turnless parent never opened a turn, so the fork replayed nothing and the gate has nothing to drop; with an empty parent turn set the gate suppresses nothing either way, so parsing the child as current is the only change. A parent that cannot be read still defers the child, exactly as before.

An earlier revision of this PR kept a turnless parent blocking when the child carried a copied parent `session_meta`, on the theory that a replay prefix always begins with that copied meta. A survey of a large local Codex archive disproved it: about half of the forks there, including many written by Codex 0.147.0, replay parent turns with no copied parent meta at all. That gate and its test are gone, which is why the net diff is small.

Reviewers should look at `codexParentResolution` in `internal/parser/codex.go` and `TestCodexProviderTurnlessParentResolvesWithoutRetry`, which parses a fork of a meta-only parent and expects a current result with only the child's messages.

Closes #1582

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158DH4fPMj7ogzQdPmyRqUZ
