### PR TITLE
docs(site): rewrite tiered-site copy in a plainer human voice

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@ archive on your machine, and serves them through a web UI, desktop app, CLI,
 REST API, and MCP server.
 
 New here? The [product overview](/) explains what AgentsView is for, and the
-[five-minute guide](/guide/) walks the whole loop with screenshots. This
-documentation is the comprehensive, task-oriented reference.
+[five-minute guide](/guide/) walks the whole loop with screenshots. The pages
+here go deeper: a task-oriented reference for every feature.
 
 <p class="hero-actions">
   <a class="md-button md-button--primary" href="/docs/quickstart/">Quick Start</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # AgentsView
 
-> AgentsView is a local-first system of record for AI coding agent sessions: a daemon syncs sessions from more than 50 agent harnesses into a searchable SQLite archive with transcripts, activity, token and cost reports, quality signals, and recall, served through a web UI, desktop app, CLI, REST API, and MCP server.
+> AgentsView is a local-first system of record for AI coding agent sessions: a daemon syncs sessions from more than 60 agent harnesses into a searchable SQLite archive with transcripts, activity, token and cost reports, quality signals, and recall, served through a web UI, desktop app, CLI, REST API, and MCP server.
 
 Every public page is also published as raw Markdown at the route listed below.
 The Markdown pages are canonical for machine readers; the HTML routes drop the

--- a/docs/website/404.html
+++ b/docs/website/404.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Page not found — AgentsView</title>
+    <title>Page not found - AgentsView</title>
     <meta name="description" content="This AgentsView page does not exist.">
     <meta name="robots" content="noindex">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">

--- a/docs/website/guide.md
+++ b/docs/website/guide.md
@@ -1,60 +1,60 @@
 # The session intelligence loop
 
-Your agents already produce the raw data. AgentsView turns it into an archive,
-the archive into answers, and the answers back into better agent runs. Nine
-stops, five minutes.
+Your agents already write the raw data. AgentsView turns it into a searchable
+archive, and the archive into answers your agents can use on their next run.
+Nine stops, five minutes.
 
-## 01 — Capture every session
+## 01. Capture every session
 
 The daemon discovers the session directories behind more than 60 agent formats,
 including Claude Code, Codex, Cursor, Copilot, and Gemini, and syncs them into
 one local SQLite archive with full-text indexes. It keeps watching, so the
 archive stays current while you work. [Quick start](/docs/quickstart/).
 
-## 02 — Browse the full conversation
+## 02. Browse the full conversation
 
 Every session renders as a complete transcript: user prompts, assistant
 responses, thinking blocks, and tool calls, with filters by project, agent,
 date, and message count. Subagent trees, resume chains, and edited files stay
 connected to their parent session. [Usage guide](/docs/usage/).
 
-## 03 — Monitor the fleet
+## 03. Monitor the fleet
 
 The Activity dashboard shows when agents ran, how much work overlapped, and what
 it cost: peak concurrency with the exact moment it happened, active versus idle
 time, and agent-minutes over any window. Click a timeline bucket to see exactly
 which sessions were running in that slot. [Activity reference](/docs/activity/).
 
-## 04 — Meter tokens and cost
+## 04. Meter tokens and cost
 
-Sub-second usage reports over the whole archive, priced from LiteLLM and
-OpenRouter rates with cache-aware accounting. The CLI answers in the terminal
-(`agentsview usage daily`), the statusline shows today's spend inside your
-editor, and one-shot capture meters a single CI run exactly.
+Usage reports over the whole archive come back in under a second, priced from
+LiteLLM and OpenRouter rates with cache-aware accounting. The CLI answers in the
+terminal (`agentsview usage daily`), the statusline shows today's spend inside
+your editor, and one-shot capture meters a single CI run exactly.
 [Token usage and costs](/docs/token-usage/).
 
-## 05 — Search by words or by meaning
+## 05. Search by words or by meaning
 
 Full-text search finds the conversation where you discussed a specific function
 or error, even months later. Opt-in semantic and hybrid search match by meaning
 over conversation units, cite the unit behind every result, and can pull the
 surrounding context on demand. [Semantic search](/docs/semantic-search/).
 
-## 06 — Assess session health
+## 06. Assess session health
 
 Session intelligence classifies outcomes and scores health from the transcript
 itself: tool failures, context pressure, and loop signals. Deterministic quality
 rules turn recurring patterns into recommendations, each backed by the source
 sessions that triggered it. [Session intelligence](/docs/session-intelligence/).
 
-## 07 — Keep what the sessions learned
+## 07. Keep what the sessions learned
 
 Recall (experimental) extracts durable, provenance-linked knowledge from the
 archive and keeps it browsable: every entry carries evidence links back to its
 source transcripts. Generated Insights add model-written reports over an
 explicit session scope. [Recall reference](/docs/recall/).
 
-## 08 — Give your agents the archive
+## 08. Give your agents the archive
 
 The loop closes when agents read their own history. The MCP server exposes
 session history as assistant tools, the REST API and CLI serve scripts and
@@ -62,7 +62,7 @@ hooks, and SSE streams live messages. An agent can check what a previous run
 tried before repeating it. [MCP server](/docs/mcp/) ·
 [Session API](/docs/session-api/).
 
-## 09 — Extend beyond one machine
+## 09. Extend beyond one machine
 
 Push each machine's archive to PostgreSQL for a merged team view, mirror into
 DuckDB for analytical queries, read source files through the filesystem or S3,

--- a/docs/website/guide/index.html
+++ b/docs/website/guide/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>The session intelligence loop — AgentsView</title>
+    <title>The session intelligence loop - AgentsView</title>
     <meta name="description" content="Follow your agent sessions through AgentsView: capture, browse, monitor, meter, search, assess, recall, automate, and sync.">
     <link rel="canonical" href="https://agentsview.io/guide/">
     <link rel="alternate" type="text/markdown" href="https://agentsview.io/guide.md">
@@ -100,7 +100,7 @@
       <header class="hero compact">
         <p class="eyebrow">Five-minute guide</p>
         <h1>The session intelligence loop</h1>
-        <p class="lede">Your agents already produce the raw data. AgentsView turns it into an archive, the archive into answers, and the answers back into better agent runs.</p>
+        <p class="lede">Your agents already write the raw data. AgentsView turns it into a searchable archive, and the archive into answers your agents can use on their next run.</p>
         <ol class="guide-nav" aria-label="Guide stops">
           <li><a href="#capture">01 Capture</a></li>
           <li><a href="#browse">02 Browse</a></li>
@@ -166,7 +166,7 @@
         <li class="guide-stop" id="meter">
           <div class="guide-copy">
             <h2>Meter tokens and cost</h2>
-            <p>Sub-second usage reports over the whole archive, priced from LiteLLM and OpenRouter rates with cache-aware accounting. The CLI answers in the terminal, the statusline shows today's spend inside your editor, and one-shot capture meters a single CI run exactly.</p>
+            <p>Usage reports over the whole archive come back in under a second, priced from LiteLLM and OpenRouter rates with cache-aware accounting. The CLI answers in the terminal, the statusline shows today's spend inside your editor, and one-shot capture meters a single CI run exactly.</p>
             <a href="/docs/token-usage/">Token usage and costs</a>
             <figure class="terminal">
               <code><span class="prompt">$</span> agentsview usage daily --breakdown
@@ -269,7 +269,7 @@
             <h2 id="operate-title">Run it on your own history.</h2>
           </div>
           <div>
-            <p>Installation takes under a minute and the first sync uses the sessions already on your machine. The docs carry configuration, exact command behavior, and the full feature reference.</p>
+            <p>Installation takes under a minute and the first sync uses the sessions already on your machine. The docs cover configuration, exact command behavior, and the full feature reference.</p>
             <div class="actions">
               <a class="button primary" href="/docs/quickstart/">Run the quickstart</a>
               <a class="button" href="/docs/">Open the docs</a>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>AgentsView — see what your AI coding agents did and what it cost</title>
+    <title>AgentsView: see what your AI coding agents did and what it cost</title>
     <meta name="description" content="See every AI coding session, search what happened, track cost and quality, and keep the archive local by default.">
     <link rel="canonical" href="https://agentsview.io/">
     <link rel="alternate" type="text/markdown" href="https://agentsview.io/index.md">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/styles/site.css">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="See what your AI coding agents did — and what it cost.">
+    <meta property="og:title" content="See what your AI coding agents did, and what it cost.">
     <meta property="og:description" content="The local-first system of record for AI coding sessions, with search, activity, cost, quality, and recall.">
     <meta property="og:url" content="https://agentsview.io/">
     <meta property="og:site_name" content="AgentsView">
@@ -18,7 +18,7 @@
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="See what your AI coding agents did — and what it cost.">
+    <meta name="twitter:title" content="See what your AI coding agents did, and what it cost.">
     <meta name="twitter:description" content="The local-first system of record for AI coding sessions, with search, activity, cost, quality, and recall.">
     <meta name="twitter:image" content="https://agentsview.io/docs/assets/static/og-image.png">
   </head>
@@ -100,8 +100,8 @@
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-layout">
           <div class="hero-copy">
-            <h1 id="hero-title">See what your AI coding agents did — and what it cost.</h1>
-            <p class="lede">AgentsView is the local-first system of record for AI coding sessions. It turns more than 60 agent formats into one searchable archive for transcripts, activity, cost, quality, and recall. Your archive stays on your machine by default and leaves only through features you choose.</p>
+            <h1 id="hero-title">See what your AI coding agents did, and what it cost.</h1>
+            <p class="lede">AgentsView is the local-first system of record for AI coding sessions. It merges sessions from more than 60 agent formats into one searchable archive covering transcripts, activity, cost, quality, and recall. The archive stays on your machine unless you turn on a feature that shares it.</p>
             <div class="install-command" data-install-command data-command="curl -fsSL https://agentsview.io/install.sh | bash">
               <code>curl -fsSL https://agentsview.io/install.sh | bash</code>
               <button class="button install-copy" type="button" data-install-copy>Copy</button>
@@ -125,7 +125,7 @@
         <div class="section-heading">
           <div>
             <p class="section-index">01 / Record</p>
-            <h2 id="record-title">Every agent. Every session. One archive.</h2>
+            <h2 id="record-title">Every session from every agent, in one archive.</h2>
           </div>
           <p class="agent-section-lead">A background daemon watches the session directories your agents already write, parses each format, and syncs everything into a local SQLite archive with full-text indexes. Auto-discovered, nothing to configure. Start a session in one window and watch it stream into AgentsView in another.</p>
         </div>
@@ -255,7 +255,7 @@
             <p class="section-index">02 / Observe</p>
             <h2 id="observe-title">See when your agents are actually working.</h2>
           </div>
-          <p>The Activity dashboard turns timestamped session data into an operational picture: peak concurrency and the exact moment it happened, active versus idle time, agent-minutes across parallel sessions, and cost, scoped to any day, week, month, or custom range and filterable by project, agent, and machine. Live sync streams new messages into the UI as sessions run.</p>
+          <p>The Activity dashboard shows peak concurrency and the exact moment it happened, active versus idle time, agent-minutes across parallel sessions, and cost. Scope it to any day, week, month, or custom range, and filter by project, agent, and machine. Live sync streams new messages into the UI as sessions run.</p>
         </div>
         <figure class="capture">
           <a href="/docs/assets/generated/screenshots/activity-page.png" data-lightbox>
@@ -271,7 +271,7 @@
             <p class="section-index">03 / Account</p>
             <h2 id="account-title">Know what every agent costs.</h2>
           </div>
-          <p>Token and cost reports read from the pre-indexed archive instead of reparsing every raw session file for each report. Pricing tracks LiteLLM and OpenRouter rates with an offline fallback, and cache-aware accounting covers prompt-cache creation and reads.</p>
+          <p>Token and cost reports read from the pre-indexed archive instead of reparsing raw session files every time. Pricing tracks LiteLLM and OpenRouter rates with an offline fallback, and cache-aware accounting covers prompt-cache creation and reads.</p>
         </div>
         <div class="split-layout">
           <figure class="capture">
@@ -429,7 +429,7 @@
             <h2 id="start-title">Your agents are already writing the data.</h2>
           </div>
           <div>
-            <p>Install AgentsView and it finds the sessions that are already on your machine. The guide walks the whole loop in five minutes; the docs carry installation, workflows, and exact command behavior.</p>
+            <p>Install AgentsView and it finds the sessions that are already on your machine. The guide walks the whole loop in five minutes; the docs cover installation, workflows, and exact command behavior.</p>
             <div class="actions">
               <a class="button primary" href="/guide/">Follow the guide</a>
               <a class="button" href="/docs/quickstart/">Run the quickstart</a>

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -1,9 +1,9 @@
-# See what your AI coding agents did — and what it cost
+# See what your AI coding agents did, and what it cost
 
-AgentsView is the local-first system of record for AI coding sessions. It turns
-more than 60 agent formats into one searchable archive for transcripts,
-activity, cost, quality, and recall. Your archive stays on your machine by
-default and leaves only through features you choose.
+AgentsView is the local-first system of record for AI coding sessions. It merges
+sessions from more than 60 agent formats into one searchable archive covering
+transcripts, activity, cost, quality, and recall. The archive stays on your
+machine unless you turn on a feature that shares it.
 
 ## Install
 
@@ -23,7 +23,7 @@ Desktop app, pip/uvx, and Docker installs are covered in the
 [quick start](/docs/quickstart/). Then [follow the guide](/guide/) or read the
 [documentation](/docs/).
 
-## Every agent. Every session. One archive.
+## Every session from every agent, in one archive
 
 A background daemon watches the session directories your agents already write,
 parses each format, and syncs everything into a local SQLite archive with
@@ -41,18 +41,18 @@ RooCode, Trae, Windsurf, and dozens more. Every supported source is listed in
 
 ## See when your agents are actually working
 
-The [Activity dashboard](/docs/activity/) turns timestamped session data into an
-operational picture: peak concurrency and the exact moment it happened, active
-versus idle time, agent-minutes across parallel sessions, and cost, scoped to
-any day, week, month, or custom range and filterable by project, agent, and
-machine. Live sync streams new messages into the UI as sessions run.
+The [Activity dashboard](/docs/activity/) shows peak concurrency and the exact
+moment it happened, active versus idle time, agent-minutes across parallel
+sessions, and cost. Scope it to any day, week, month, or custom range, and
+filter by project, agent, and machine. Live sync streams new messages into the
+UI as sessions run.
 
 ## Know what every agent costs
 
 [Token and cost reports](/docs/token-usage/) read from the pre-indexed archive
-instead of reparsing every raw session file for each report. Pricing tracks
-LiteLLM and OpenRouter rates with an offline fallback, and cache-aware
-accounting covers prompt-cache creation and reads.
+instead of reparsing raw session files every time. Pricing tracks LiteLLM and
+OpenRouter rates with an offline fallback, and cache-aware accounting covers
+prompt-cache creation and reads.
 
 ```bash
 agentsview usage daily          # last 30 days, terminal table


### PR DESCRIPTION
Rewrites the copy on the new tiered site in a plainer, more human voice while keeping the same structure, facts, and links. Each HTML page stays in sync with its Markdown twin.

What changed:

- Removed every em-dash from the site copy: the headline is now "See what your AI coding agents did, and what it cost." across the h1, page title, and Open Graph/Twitter tags; the nine `guide.md` headings use "01." instead of "01 —"; the guide and 404 page titles use a plain hyphen.
- Replaced the fragment triad "Every agent. Every session. One archive." with "Every session from every agent, in one archive."
- Simplified the guide lede: "AgentsView turns it into a searchable archive, and the archive into answers your agents can use on their next run."
- Cut jargon and fragments: "operational picture" is gone from the Activity sections (the long sentence is now split in two), "Sub-second usage reports over the whole archive, priced..." became a full sentence, "the docs carry" became "the docs cover", and the docs landing no longer calls itself "the comprehensive, task-oriented reference".
- Reworded the hero's "leaves only through features you choose" to "unless you turn on a feature that shares it".
- Fact fix: `llms.txt` said "more than 50 agent harnesses" while the rest of the site says 60+; aligned to 60.

Where to look: `docs/website/index.html` and `docs/website/index.md` carry most of the rewording; `docs/website/guide.md` has the heading punctuation change. `make docs-build` and `check_built_site.py` pass, so the twin/llms.txt contracts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
