### PR TITLE
fix(sync): stop SQLite-backed containers from re-syncing on their own -shm writes

### DIFF
--- a/internal/parser/cursor_ide_provider.go
+++ b/internal/parser/cursor_ide_provider.go
@@ -113,7 +113,7 @@ func cursorIDEFingerprintSource(
 	if src.MemberID == "" {
 		mtime := info.ModTime().UnixNano()
 		if composite, err := sqliteDBCompositeMtime(
-			src.Container, cursorIDEDBMtimeSuffixes,
+			src.Container, sqliteDBJournalSuffixes,
 		); err == nil {
 			mtime = composite
 		}
@@ -149,12 +149,6 @@ func cursorIDEFingerprintSource(
 		Hash:    meta.digest,
 	}, nil
 }
-
-// cursorIDEDBMtimeSuffixes omits "-shm": Cursor IDE keeps its own read/write
-// connection open against state.vscdb, which continually touches the
-// shared-memory file, so including it would make every scan trigger the next
-// one (the same reasoning as omnigentDBMtimeSuffixes).
-var cursorIDEDBMtimeSuffixes = []string{"", "-wal"}
 
 // cursorIDESQLiteStateHash digests the parts of a SQLite database's on-disk
 // state that change with every committed transaction, without reading any

--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -587,9 +587,12 @@ func (s dbBackedSourceSet) dbPathForEvent(root, path string) (string, bool) {
 	if strings.Contains(rel, string(filepath.Separator)) {
 		return "", false
 	}
-	if rel == s.spec.dbName ||
-		rel == s.spec.dbName+"-wal" ||
-		rel == s.spec.dbName+"-shm" {
+	// A bare "-shm" event never resolves to the container. Every write to a
+	// WAL-mode database lands in the main file or its -wal sibling; the -shm
+	// index is also rewritten by readers, including this process's own scan,
+	// so honoring it would make each scan schedule the next one. Omnigent and
+	// Cursor IDE apply the same rule through classifySQLiteContainerPath.
+	if rel == s.spec.dbName || rel == s.spec.dbName+"-wal" {
 		dbPath := filepath.Join(root, s.spec.dbName)
 		return dbPath, true
 	}

--- a/internal/parser/db_backed_provider_test.go
+++ b/internal/parser/db_backed_provider_test.go
@@ -360,6 +360,33 @@ func TestDBBackedProviderFingerprintIgnoresUnrelatedRows(t *testing.T) {
 	assert.Equal(t, before, after)
 }
 
+func TestDBBackedProviderIgnoresBareShmSiblingEvents(t *testing.T) {
+	// Opening a WAL-mode database as a reader rewrites its -shm index. If that
+	// event resolved to the container, every scan would schedule the next
+	// one and rewrite every member session in between.
+	dbPath, seeder, db := newForgeTestDB(t)
+	defer db.Close()
+	seedForgeConversation(t, seeder)
+	root := filepath.Dir(dbPath)
+
+	provider, ok := NewProvider(AgentForge, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: dbPath + "-shm", EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+
+	changed, err = provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: dbPath + "-wal", EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, changed, "-wal writes still resolve to the container")
+}
+
 func TestDBBackedProviderDeletedRowFingerprintsTombstoneAndSkips(t *testing.T) {
 	dbPath, seeder, db := newForgeTestDB(t)
 	defer db.Close()

--- a/internal/parser/devin_provider.go
+++ b/internal/parser/devin_provider.go
@@ -553,7 +553,10 @@ func (s devinSourceSet) dbPathForEvent(root, path string) (string, bool) {
 	if !ok || strings.Contains(rel, string(filepath.Separator)) {
 		return "", false
 	}
-	if rel == devinDBFilename || rel == devinDBFilename+"-wal" || rel == devinDBFilename+"-shm" {
+	// A bare "-shm" event is ignored: the provider's own read connections
+	// rewrite that index, and every committed write lands in the main file
+	// or the WAL.
+	if rel == devinDBFilename || rel == devinDBFilename+"-wal" {
 		return filepath.Join(cliRoot, devinDBFilename), true
 	}
 	return "", false

--- a/internal/parser/devin_provider_test.go
+++ b/internal/parser/devin_provider_test.go
@@ -124,7 +124,7 @@ func TestDevinProviderDBEventsFanOutAndPreserveTombstones(t *testing.T) {
 	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
 	require.True(t, ok)
 
-	for _, changedPath := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+	for _, changedPath := range []string{dbPath, dbPath + "-wal"} {
 		changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
 			Path:              changedPath,
 			EventKind:         "write",
@@ -187,6 +187,12 @@ func TestDevinProviderRejectsUnrelatedChangedPaths(t *testing.T) {
 	for _, req := range []ChangedPathRequest{
 		{
 			Path:      filepath.Join(root, "cli", "sessions.db-backup"),
+			EventKind: "write",
+			WatchRoot: filepath.Join(root, "cli"),
+		},
+		{
+			// The provider's own read connection rewrites the -shm index.
+			Path:      filepath.Join(root, "cli", devinDBFilename+"-shm"),
 			EventKind: "write",
 			WatchRoot: filepath.Join(root, "cli"),
 		},

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -1351,6 +1351,12 @@ func kiroDBPathForEvent(root, path string) (string, bool) {
 	if !ok {
 		return "", false
 	}
+	// A bare "-shm" event is ignored: the provider's own read connections
+	// rewrite that index, and every committed write lands in the main file
+	// or a journal sibling.
+	if strings.HasSuffix(rel, "-shm") {
+		return "", false
+	}
 	if filepath.ToSlash(rel) == kiroSQLiteDBName ||
 		(filepath.Dir(rel) == "." &&
 			strings.HasPrefix(filepath.Base(rel), kiroSQLiteDBName+"-")) {

--- a/internal/parser/kiro_provider_test.go
+++ b/internal/parser/kiro_provider_test.go
@@ -1151,3 +1151,41 @@ func kiroIDEProviderOldFixture(question string) string {
 func kiroIDEProviderNewFixture(question string) string {
 	return `{"sessionId":"new-session","title":"New title","workspaceDirectory":"/home/user/dev/new-app","history":[{"message":{"role":"user","content":"` + question + `","id":"m1"}},{"message":{"role":"assistant","content":"New IDE answer","id":"m2"}}]}` + "\n"
 }
+
+func TestKiroProviderIgnoresBareShmSibling(t *testing.T) {
+	// The provider's own read connection rewrites the -shm index, so neither
+	// a bare -shm event nor the -shm mtime may move the physical database
+	// source, or every scan would schedule the next one.
+	root := t.TempDir()
+	dbPath, db := newKiroProviderSQLiteDBAt(t, root)
+	seedKiroSQLiteSession(
+		t, db, "/home/user/code/kiro-app", "sqlite-session",
+		readKiroFixture(t, "standard_payload.json"),
+		1779012000000, 1779012030000,
+	)
+
+	provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: dbPath + "-shm", EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, sources)
+	require.Equal(t, dbPath, sources[0].DisplayPath)
+	before, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+
+	shmPath := dbPath + "-shm"
+	writeSourceFile(t, shmPath, "shm")
+	shmTime := time.Unix(0, before.MTimeNS+int64(time.Hour))
+	require.NoError(t, os.Chtimes(shmPath, shmTime, shmTime))
+	after, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+	assert.Equal(t, before.MTimeNS, after.MTimeNS)
+}

--- a/internal/parser/omnigent_provider.go
+++ b/internal/parser/omnigent_provider.go
@@ -343,7 +343,7 @@ func omnigentFingerprintSource(src multiSessionSource) (SourceFingerprint, error
 	}
 	if src.MemberID == "" {
 		if compositeMtime, err := sqliteDBCompositeMtime(
-			src.Container, omnigentDBMtimeSuffixes,
+			src.Container, sqliteDBJournalSuffixes,
 		); err == nil {
 			fingerprint.MTimeNS = compositeMtime
 		}
@@ -904,12 +904,6 @@ func (t *omnigentChangeTracker) parseContainer(
 	}
 	return results, nil
 }
-
-// omnigentDBMtimeSuffixes tracks content-bearing SQLite files only, omitting
-// "-shm": opening a read connection can update the shared-memory file, so
-// including it would turn the provider's own reads into apparent source
-// changes and keep the scheduled fingerprint pass reparsing forever.
-var omnigentDBMtimeSuffixes = []string{"", "-wal"}
 
 func omnigentMemberPresent(src multiSessionSource) bool {
 	if src.MemberID == "" {

--- a/internal/parser/shelley_provider.go
+++ b/internal/parser/shelley_provider.go
@@ -77,14 +77,16 @@ func shelleyWatchRoots(roots []string) []WatchRoot {
 
 // shelleyClassifyPath maps a stored or changed path to its database container
 // and conversation. allowMissing relaxes the regular-file requirement so a
-// database delete (or its WAL/SHM sibling) still classifies for changed-path
+// database delete (or its WAL sibling) still classifies for changed-path
 // tombstones, reproducing the legacy strict sourceRef / lenient
-// sourceRefForChangedPath split.
+// sourceRefForChangedPath split. A bare "-shm" sibling event is rejected: the
+// provider's own read connections rewrite that file, so honoring it would make
+// every scan schedule the next.
 func shelleyClassifyPath(
 	root, path string, allowMissing bool,
 ) (multiSessionMatch, bool) {
 	return classifySQLiteContainerPath(
-		root, path, shelleyDBName, allowMissing, false, parseShelleyVirtualPath,
+		root, path, shelleyDBName, allowMissing, true, parseShelleyVirtualPath,
 	)
 }
 

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -912,7 +912,11 @@ func zcodeSessionFileMtime(dbPath string, db *sql.DB, row zcodeSessionRow) int64
 	if usageMtime, err := zcodeMaxUsageMtime(db, row.id); err == nil {
 		maxMtime = max(maxMtime, usageMtime)
 	}
-	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+	// The -shm index is excluded on purpose: readers rewrite it, this
+	// provider's own read connection included, so folding its mtime into the
+	// fingerprint made every scan report the whole container as changed.
+	// Content changes always touch the main file or the -wal sibling.
+	for _, path := range []string{dbPath, dbPath + "-wal"} {
 		if info, err := os.Stat(path); err == nil {
 			maxMtime = max(maxMtime, info.ModTime().UnixNano())
 		}

--- a/internal/parser/zcode_test.go
+++ b/internal/parser/zcode_test.go
@@ -825,6 +825,42 @@ func TestZCodeFingerprintTracksDBMtimeForUsageOnlyChanges(t *testing.T) {
 	assert.Equal(t, dbMtime.UnixNano(), fingerprint.MTimeNS)
 }
 
+func TestZCodeFingerprintIgnoresShmIndexMtime(t *testing.T) {
+	// Readers rewrite the -shm index, this provider's own connection
+	// included, so its mtime must not move the fingerprint or every scan
+	// would report the whole container as changed.
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-shm",
+		"/Users/alice/code/acme-app",
+		"SHM",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:10:00Z",
+		"",
+		"",
+	)
+	dbMtime := time.Date(2026, 7, 6, 13, 20, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(fixture.DBPath, dbMtime, dbMtime))
+	shmPath := fixture.DBPath + "-shm"
+	require.NoError(t, os.WriteFile(shmPath, make([]byte, 32), 0o644))
+	shmMtime := dbMtime.Add(time.Hour)
+	require.NoError(t, os.Chtimes(shmPath, shmMtime, shmMtime))
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:   []string{fixture.CLIRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+	assert.Equal(t, dbMtime.UnixNano(), fingerprint.MTimeNS)
+}
+
 func TestZCodeFallsBackToDBMtimeWhenTimestampsAreMissing(t *testing.T) {
 	fixture := newZCodeTestFixture(t)
 	fixture.insertSession(

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -88,10 +88,12 @@ func zedWatchRoots(roots []string) []WatchRoot {
 // zedClassifyPath maps a stored or changed path to its database container and
 // thread, reproducing the legacy strict sourceRef / lenient
 // sourceRefForChangedPath split: allowMissing relaxes the regular-file check so
-// a database delete (or its WAL/SHM sibling) still classifies for tombstones.
+// a database delete (or its WAL sibling) still classifies for tombstones. A
+// bare "-shm" sibling event is rejected: the provider's own read connections
+// rewrite that file, so honoring it would make every scan schedule the next.
 func zedClassifyPath(root, path string, allowMissing bool) (multiSessionMatch, bool) {
 	return classifySQLiteContainerPath(
-		root, path, zedThreadsDBRelPath, allowMissing, false, parseZedVirtualPath,
+		root, path, zedThreadsDBRelPath, allowMissing, true, parseZedVirtualPath,
 	)
 }
 
@@ -242,12 +244,13 @@ func zedParseContainer(
 	return results, nil
 }
 
-// sqliteDBJournalSuffixes is the default sibling-file suffix list for
-// sqliteDBCompositeMtime: the database file itself plus its WAL and
-// shared-memory files. Omnigent uses a narrower list (see
-// omnigentDBMtimeSuffixes) because it opens its own read connections against
-// the database, which touch the shared-memory file.
-var sqliteDBJournalSuffixes = []string{"", "-wal", "-shm"}
+// sqliteDBJournalSuffixes is the sibling-file suffix list for
+// sqliteDBCompositeMtime: the database file itself plus its WAL. The "-shm"
+// index is left out on purpose. Every committed write lands in the main file
+// or the WAL, while readers, including this process's own scan connections,
+// rewrite the shared-memory file, so folding its mtime in would make every
+// scan report the container as changed and schedule the next scan.
+var sqliteDBJournalSuffixes = []string{"", "-wal"}
 
 // sqliteDBCompositeMtime returns the freshest mtime across a SQLite database
 // file and the listed sibling suffixes (e.g. "-wal", "-shm").

--- a/internal/parser/zed_shelley_provider_test.go
+++ b/internal/parser/zed_shelley_provider_test.go
@@ -557,7 +557,7 @@ func TestShelleyProviderSourceMethods(t *testing.T) {
 
 	changed, err := provider.SourcesForChangedPath(
 		context.Background(),
-		ChangedPathRequest{Path: dbPath + "-shm", EventKind: "write", WatchRoot: root},
+		ChangedPathRequest{Path: dbPath + "-wal", EventKind: "write", WatchRoot: root},
 	)
 	require.NoError(t, err)
 	require.Len(t, changed, 1)
@@ -882,4 +882,111 @@ func TestShelleyProviderIgnoresUnrelatedSidecarBasename(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Empty(t, changed)
+}
+
+func TestZedProviderIgnoresBareShmSiblingEvents(t *testing.T) {
+	// The provider's own read connection rewrites the -shm index, so a bare
+	// -shm event must not resolve to the container or every scan would
+	// schedule the next one.
+	root := t.TempDir()
+	dbPath := filepath.Join(root, zedThreadsDBRelPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	createZedThreadsDBAt(t, dbPath, []zedTestThread{{
+		id:        "10431c84-c47b-4e6c-b2df-f9f3b9ad025b",
+		summary:   "Provider thread",
+		updatedAt: "2026-06-08T09:14:10Z",
+		dataType:  "json",
+		data:      []byte(`{"messages":[{"User":{"content":[{"Text":"Hello Zed"}]}}]}`),
+	}})
+
+	provider, ok := NewProvider(AgentZed, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: dbPath + "-shm", EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+
+	changed, err = provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: dbPath + "-wal", EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, changed, "-wal writes still resolve to the container")
+}
+
+func TestZedProviderFingerprintIgnoresShmSibling(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, zedThreadsDBRelPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	createZedThreadsDBAt(t, dbPath, []zedTestThread{{
+		id:        "10431c84-c47b-4e6c-b2df-f9f3b9ad025b",
+		summary:   "Provider thread",
+		updatedAt: "2026-06-08T09:14:10Z",
+		dataType:  "json",
+		data:      []byte(`{"messages":[{"User":{"content":[{"Text":"Hello Zed"}]}}]}`),
+	}})
+
+	provider, ok := NewProvider(AgentZed, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	before, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+
+	shmPath := dbPath + "-shm"
+	writeSourceFile(t, shmPath, "shm")
+	shmTime := time.Unix(0, before.MTimeNS+int64(time.Hour))
+	require.NoError(t, os.Chtimes(shmPath, shmTime, shmTime))
+	after, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+
+	assert.Equal(t, before.MTimeNS, after.MTimeNS)
+}
+
+func TestShelleyProviderIgnoresBareShmSiblingEvents(t *testing.T) {
+	root, dbPath, db := newShelleyTestDB(t)
+	seedShelleyMainConversation(t, db)
+
+	provider, ok := NewProvider(AgentShelley, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: dbPath + "-shm", EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+
+	changed, err = provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: dbPath + "-wal", EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, changed, "-wal writes still resolve to the container")
+}
+
+func TestShelleyProviderFingerprintIgnoresShmSibling(t *testing.T) {
+	root, dbPath, db := newShelleyTestDB(t)
+	seedShelleyMainConversation(t, db)
+
+	provider, ok := NewProvider(AgentShelley, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	before, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+
+	shmPath := dbPath + "-shm"
+	writeSourceFile(t, shmPath, "shm")
+	shmTime := time.Unix(0, before.MTimeNS+int64(time.Hour))
+	require.NoError(t, os.Chtimes(shmPath, shmTime, shmTime))
+	after, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+
+	assert.Equal(t, before.MTimeNS, after.MTimeNS)
 }

--- a/internal/sync/stored_source_hints_test.go
+++ b/internal/sync/stored_source_hints_test.go
@@ -196,7 +196,7 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 					folder_paths TEXT, folder_paths_order TEXT, created_at TEXT)`)
 				require.NoError(t, err)
 				require.NoError(t, store.Close())
-				return root, path + "-shm", parser.ZedSQLiteVirtualPath(path, "deleted")
+				return root, path + "-wal", parser.ZedSQLiteVirtualPath(path, "deleted")
 			},
 		},
 		{
@@ -238,7 +238,7 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 				_, err = store.Exec(`DELETE FROM conversations_v2 WHERE conversation_id = 'deleted'`)
 				require.NoError(t, err)
 				require.NoError(t, store.Close())
-				return root, path + "-shm", parser.KiroSQLiteVirtualPath(path, "deleted")
+				return root, path + "-wal", parser.KiroSQLiteVirtualPath(path, "deleted")
 			},
 		},
 		{


### PR DESCRIPTION
Opening a WAL-mode SQLite database as a reader rewrites its `-shm` index. Several providers treated that rewrite as a source change: they resolved a bare `-shm` event to the whole container, folded the `-shm` mtime into the container fingerprint, or both, while each of them opens its own read connection during a scan. Together those made each scan schedule the next. On one archive the ZCode container had not changed for half an hour while its 22 sessions were rewritten every five seconds, and the usage-cache backfill and `/api/v1/usage/summary` failed continuously with "source archive changed during rollup build" because the archive never held still long enough.

Every SQLite-backed provider that opens its own read connection now ignores bare `-shm` events and leaves the `-shm` mtime out of its fingerprint:

- The db-backed containers (Forge, Piebald, Warp, Goose, ZCode) through the shared `dbPathForEvent`, plus the ZCode fingerprint.
- Zed and Shelley through the shared container classifier, the same flag Omnigent already passed.
- Kiro and Devin through their own event mapping.
- The shared journal suffix list is now main file plus `-wal`, so Omnigent and Cursor IDE use it instead of private copies.

Real changes always land in the main file or its `-wal` sibling, and every path still honors those. Existing tests that used a `-shm` event as an example database sibling now use `-wal`.

Two limits remain. The first read-only open after an agent closes its database cleanly re-creates an empty `-wal`, so a provider whose fingerprint reads the `-wal` mtime re-parses its container once per app close. That is one bounded pass, not a loop; the OpenCode provider already guards it by checking whether the WAL has frames, and the same check could be extended later. Stored ZCode mtimes from older builds included the `-shm` mtime, so the first scan after upgrading rewrites the ZCode archive once.

Reviewers should look at `dbPathForEvent` in `internal/parser/db_backed_provider.go`, `zcodeSessionFileMtime` in `internal/parser/zcode.go`, and `sqliteDBJournalSuffixes` in `internal/parser/zed_provider.go`.

Closes #1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBqd7h5vuXFZehmrZATaNu

<sup>generated by a clanker</sup>
