### PR TITLE
perf(serve): cap glibc malloc arenas in the serve daemon

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -135,6 +135,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 	start := time.Now()
 	setupLogFile(cfg.DataDir)
 	applyServeMemoryLimit()
+	applyServeMallocTuning()
 
 	if err := validateServeConfig(cfg); err != nil {
 		fatal("invalid serve config: %v", err)

--- a/cmd/agentsview/malloc_tuning.go
+++ b/cmd/agentsview/malloc_tuning.go
@@ -1,0 +1,19 @@
+package main
+
+// mallocTuningPlan records which glibc knobs the daemon should set.
+type mallocTuningPlan struct {
+	SetArenaMax      bool
+	SetTrimThreshold bool
+}
+
+// planMallocTuning decides which knobs to install given an environment
+// lookup. glibc reads MALLOC_ARENA_MAX and MALLOC_TRIM_THRESHOLD_ at
+// startup and has already applied them by the time this runs, so an
+// operator who set either one keeps that value; the knobs are
+// independent, so setting one does not suppress the other.
+func planMallocTuning(getenv func(string) string) mallocTuningPlan {
+	return mallocTuningPlan{
+		SetArenaMax:      getenv("MALLOC_ARENA_MAX") == "",
+		SetTrimThreshold: getenv("MALLOC_TRIM_THRESHOLD_") == "",
+	}
+}

--- a/cmd/agentsview/malloc_tuning_linux.go
+++ b/cmd/agentsview/malloc_tuning_linux.go
@@ -1,0 +1,68 @@
+//go:build linux && cgo
+
+package main
+
+/*
+#include <stdlib.h>
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
+
+static void set_malloc_arena_max(int value) {
+#ifdef __GLIBC__
+	mallopt(M_ARENA_MAX, value);
+#endif
+}
+
+static void set_malloc_trim_threshold(int value) {
+#ifdef __GLIBC__
+	mallopt(M_TRIM_THRESHOLD, value);
+#endif
+}
+*/
+import "C"
+
+import "os"
+
+// The Go soft memory limit only bounds the Go heap. The serve daemon's
+// other large allocator is glibc malloc, which the cgo SQLite driver
+// calls on every query. glibc gives each thread its own arena, so with
+// the daemon's ~20 threads a transient allocation can land in any of
+// them; freed chunks stay resident, and fragmentation across arenas
+// keeps the high-water mark of every burst. That is what makes the
+// daemon's RSS ratchet from a couple of hundred megabytes at startup
+// past a gigabyte after a day of use.
+//
+// The trim threshold is pinned rather than lowered. glibc's static
+// default is 128 KiB, but by default the threshold is dynamic: freeing
+// a block larger than the current mmap threshold raises the mmap
+// threshold to that size (up to 32 MiB) and the trim threshold to twice
+// it, so a daemon that has freed one large query result or parse stops
+// trimming until 64 MiB of free memory sits at the top of the heap.
+// Setting M_TRIM_THRESHOLD explicitly disables that adjustment: the
+// mmap threshold stays at 128 KiB so large transients are mmapped and
+// returned to the OS on free, and the top of the heap is trimmed once
+// 1 MiB is free. 1 MiB is the measured value that held RSS flat under
+// the usage and session load in #1585 with no measurable query latency
+// cost; the static 128 KiB default would trim more often for no
+// observed RSS gain.
+const (
+	mallocArenaMax      = 2
+	mallocTrimThreshold = 1 << 20
+)
+
+// applyServeMallocTuning caps the glibc arena count and trim threshold
+// for the long-running serve daemon. Other Linux C libraries get a no-op.
+// Only the daemon is tuned:
+// one-shot CLI commands exit before fragmentation can accumulate, and
+// the resync worker child returns everything to the OS when it exits,
+// so restricting its arenas would only slow the rebuild down.
+func applyServeMallocTuning() {
+	plan := planMallocTuning(os.Getenv)
+	if plan.SetArenaMax {
+		C.set_malloc_arena_max(C.int(mallocArenaMax))
+	}
+	if plan.SetTrimThreshold {
+		C.set_malloc_trim_threshold(C.int(mallocTrimThreshold))
+	}
+}

--- a/cmd/agentsview/malloc_tuning_other.go
+++ b/cmd/agentsview/malloc_tuning_other.go
@@ -1,0 +1,7 @@
+//go:build !linux || !cgo
+
+package main
+
+// applyServeMallocTuning is a no-op away from glibc: mallopt is a
+// glibc extension, and a non-cgo build has no C allocator to tune.
+func applyServeMallocTuning() {}

--- a/cmd/agentsview/malloc_tuning_test.go
+++ b/cmd/agentsview/malloc_tuning_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The daemon installs each glibc malloc knob only when the operator has
+// not already set the matching environment variable.
+func TestPlanMallocTuning(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want mallocTuningPlan
+	}{
+		{
+			name: "sets both knobs when the environment is clean",
+			env:  map[string]string{},
+			want: mallocTuningPlan{SetArenaMax: true, SetTrimThreshold: true},
+		},
+		{
+			name: "leaves the arena count to the operator",
+			env:  map[string]string{"MALLOC_ARENA_MAX": "8"},
+			want: mallocTuningPlan{SetArenaMax: false, SetTrimThreshold: true},
+		},
+		{
+			name: "leaves the trim threshold to the operator",
+			env:  map[string]string{"MALLOC_TRIM_THRESHOLD_": "131072"},
+			want: mallocTuningPlan{SetArenaMax: true, SetTrimThreshold: false},
+		},
+		{
+			name: "defers on both when both are set",
+			env: map[string]string{
+				"MALLOC_ARENA_MAX":       "1",
+				"MALLOC_TRIM_THRESHOLD_": "0",
+			},
+			want: mallocTuningPlan{SetArenaMax: false, SetTrimThreshold: false},
+		},
+		{
+			name: "treats an empty value as unset, matching glibc",
+			env: map[string]string{
+				"MALLOC_ARENA_MAX":       "",
+				"MALLOC_TRIM_THRESHOLD_": "",
+			},
+			want: mallocTuningPlan{SetArenaMax: true, SetTrimThreshold: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planMallocTuning(func(key string) string {
+				return tt.env[key]
+			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1435,6 +1435,17 @@ keep more roots watched in real time:
 sudo sysctl fs.inotify.max_user_watches=524288
 ```
 
+## Memory Behavior
+
+The serve daemon bounds its own memory, so no tuning is required. It installs a
+256 MiB Go soft memory limit, and on Linux it also limits glibc to two malloc
+arenas and pins the heap trim threshold at 1 MiB. Pinning the threshold turns
+off glibc's dynamic adjustment, which otherwise lets a long-running process stop
+trimming until as much as 64 MiB is free, so memory freed by the SQLite driver
+goes back to the operating system instead of accumulating as fragmentation.
+Setting `GOMEMLIMIT`, `MALLOC_ARENA_MAX`, or `MALLOC_TRIM_THRESHOLD_` in the
+daemon's environment overrides the corresponding default.
+
 ## Manual Sync
 
 Trigger a sync from the API:


### PR DESCRIPTION
The serve daemon's RSS ratchets from about 230 MB after startup to over 1 GB after a day even though its working set does not grow. The Go heap is already bounded by the 256 MiB soft limit `applyServeMemoryLimit` installs and holds about 33 MB; the growth is entirely glibc malloc arenas used by the cgo SQLite driver. With roughly 20 threads each cgo call lands in a per-thread arena, freed chunks stay resident, and fragmentation across arenas retains the high-water mark of every transient (usage rollups, large queries, full parses).

On Linux with cgo, `runServe` now calls `mallopt(M_ARENA_MAX, 2)` and `mallopt(M_TRIM_THRESHOLD, 1 MiB)` right after the Go memory limit. The change is three new files under cmd/agentsview, one line in runServe, and a short docs section; it is independent of every other open PR. An operator who already set `MALLOC_ARENA_MAX` or `MALLOC_TRIM_THRESHOLD_` keeps that value for that knob, since glibc has applied it before `main` runs; the decision lives in a pure-Go function with a table-driven test. Other platforms and non-cgo builds get a no-op. Only the daemon is tuned: one-shot commands exit before fragmentation accumulates, and the resync worker child returns everything on exit, so capping its arenas would only serialize its parse workers.

Measured on the same binary and archive under an identical load of usage and session endpoints: RSS after three load rounds went from 356 MB and still climbing to 157 MB and flat, with no measurable change in `usage/summary` latency (0.5 to 0.8 s before, 0.47 to 0.77 s after). All release and Docker builds are glibc (Debian bookworm), so the `linux && cgo` constraint covers them; musl would compile the stub.

Measured after deploying this build (no MALLOC_* variables in the environment, so the in-code policy is what ran): RSS went from 191 MB to 208 MB across three rounds of the same usage and session load and then stayed there, against 293 MB to 356 MB and still climbing on the same binary without the change.

Closes #1585

