### PR TITLE
perf(vector): make the after-sync embedding refresh read only what changed

### DIFF
--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -465,7 +465,7 @@ type UnitOffset struct {
 // since != "" restricts the scan to sessions with ended_at >= since (RFC3339
 // or RFC3339Nano) for incremental refresh, comparing parsed timestamps
 // rather than raw strings via SQLite's datetime() so mixed fractional-second
-// precision doesn't produce a wrong ordering (see optionalSinceClause); ""
+// precision doesn't produce a wrong ordering (see sinceSessionScopeClause); ""
 // scans every session. includeAutomated=false additionally excludes
 // automated sessions (sessions.is_automated = 1) using the exact predicate
 // sessionFilterPredicates' ExcludeAutomated scope applies
@@ -490,32 +490,13 @@ func (db *DB) ScanEmbeddableUnits(
 	ctx context.Context, since string, includeAutomated bool,
 	fn func(EmbeddableUnit) error,
 ) (maxEnded string, err error) {
-	preds := []string{
-		"m.role IN ('user', 'assistant')",
-		"m.is_system = 0",
-		"s.deleted_at IS NULL",
-		SystemPrefixSQL("m.content", "m.role"),
-	}
-	if !includeAutomated {
-		preds = append(preds, automatedScopePredicate("human", "s.is_automated"))
-	}
-
-	query := `
-		SELECT m.session_id, m.role, m.source_uuid, m.ordinal, m.content,
-		       m.is_sidechain, s.relationship_type, s.parent_session_id,
-		       s.ended_at
-		FROM messages m
-		JOIN sessions s ON s.id = m.session_id
-		WHERE ` + strings.Join(preds, "\n\t\t  AND ") + `
-		` + optionalSinceClause(since) + `
-		ORDER BY m.session_id, m.ordinal`
-
 	args := []any{}
 	if since != "" {
 		args = append(args, since)
 	}
 
-	rows, err := db.getReader().QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(
+		ctx, embeddableUnitsQuery(since, includeAutomated), args...)
 	if err != nil {
 		return "", fmt.Errorf("scanning embeddable units: %w", err)
 	}
@@ -698,9 +679,49 @@ func runUnit(members []unitRow) EmbeddableUnit {
 	}
 }
 
-// optionalSinceClause returns the AND clause restricting the embeddable scan
-// to sessions with ended_at >= since (or ended_at IS NULL), or "" when since
-// is unset. It compares via SQLite's datetime() rather than raw string
+// embeddableUnitsQuery builds ScanEmbeddableUnits' statement. It takes one
+// bound argument (since) when since is set and none otherwise, and always
+// emits rows in (session_id, ordinal) order, which unitReducer depends on.
+func embeddableUnitsQuery(since string, includeAutomated bool) string {
+	preds := []string{
+		"m.role IN ('user', 'assistant')",
+		"m.is_system = 0",
+		"s.deleted_at IS NULL",
+		SystemPrefixSQL("m.content", "m.role"),
+	}
+	if !includeAutomated {
+		preds = append(preds, automatedScopePredicate("human", "s.is_automated"))
+	}
+	return `
+		SELECT m.session_id, m.role, m.source_uuid, m.ordinal, m.content,
+		       m.is_sidechain, s.relationship_type, s.parent_session_id,
+		       s.ended_at
+		FROM messages m
+		JOIN sessions s ON s.id = m.session_id
+		WHERE ` + strings.Join(preds, "\n\t\t  AND ") + `
+		` + sinceSessionScopeClause(since, includeAutomated) + `
+		ORDER BY m.session_id, m.ordinal`
+}
+
+// sinceSessionScopeClause returns the AND clause restricting the embeddable
+// scan to sessions with ended_at >= since (or ended_at IS NULL), or "" when
+// since is unset.
+//
+// The restriction is written as a session-id IN subquery rather than a
+// predicate on the joined sessions row so SQLite can drive the scan from
+// sessions, which is orders of magnitude smaller than messages. With the
+// predicate on the join, the planner had no indexed way to apply it and
+// scanned every message row (content included) through
+// idx_messages_session_ordinal before discarding almost all of them; an
+// incremental refresh touching eight sessions still read the whole corpus.
+// The IN form makes the candidate session list the outer loop and looks its
+// messages up with SEARCH ... (session_id=?) on that same index, which also
+// keeps the ORDER BY m.session_id, m.ordinal contract satisfied by the index
+// instead of a sort. The subquery repeats the caller's deleted_at and
+// automated-scope predicates so the candidate list stays as small as the
+// outer query's own filters allow.
+//
+// The since comparison uses SQLite's datetime() rather than raw string
 // ordering: RFC3339Nano's variable fractional-second precision (e.g.
 // ended_at values are sometimes stored with milliseconds, sometimes
 // without) makes lexicographic comparison wrong, since "...00.123Z" sorts
@@ -719,12 +740,19 @@ func runUnit(members []unitRow) EmbeddableUnit {
 // the same way via NULLIF(s.ended_at, ""): without it, "" is neither NULL
 // nor >= since, so a changed legacy session would never be rescanned again
 // once any watermark exists.
-func optionalSinceClause(since string) string {
+func sinceSessionScopeClause(since string, includeAutomated bool) string {
 	if since == "" {
 		return ""
 	}
-	return "AND (NULLIF(s.ended_at, '') IS NULL OR " +
-		"datetime(NULLIF(s.ended_at, '')) >= datetime(?))"
+	preds := []string{"es.deleted_at IS NULL"}
+	if !includeAutomated {
+		preds = append(preds, automatedScopePredicate("human", "es.is_automated"))
+	}
+	preds = append(preds, "(NULLIF(es.ended_at, '') IS NULL OR "+
+		"datetime(NULLIF(es.ended_at, '')) >= datetime(?))")
+	return `AND m.session_id IN (
+			SELECT es.id FROM sessions es
+			 WHERE ` + strings.Join(preds, "\n\t\t\t   AND ") + `)`
 }
 
 // endedAfter reports whether candidate is chronologically after current,

--- a/internal/db/messages_units_scope_test.go
+++ b/internal/db/messages_units_scope_test.go
@@ -1,0 +1,238 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedEmbeddableScopeCorpus inserts one session per scope case an
+// incremental refresh has to decide about, each carrying two messages so a
+// caller can also assert per-session ordering. Every session ends after the
+// watermark the tests pass, ends before it, or has no usable ended_at at
+// all.
+func seedEmbeddableScopeCorpus(t *testing.T, d *DB) {
+	t.Helper()
+	sessions := []struct {
+		id       string
+		endedAt  *string
+		mutate   func(*Session)
+		softKill bool
+	}{
+		{id: "a-new", endedAt: Ptr(tsMidYear)},
+		{id: "b-old", endedAt: Ptr(tsZero)},
+		{id: "c-open", endedAt: nil},
+		{id: "d-legacy", endedAt: Ptr("")},
+		{id: "e-auto", endedAt: Ptr(tsMidYear), mutate: func(s *Session) {
+			s.IsAutomated = true
+		}},
+		{id: "f-trashed", endedAt: Ptr(tsMidYear), softKill: true},
+	}
+	for _, sess := range sessions {
+		insertSession(t, d, sess.id, "proj", func(s *Session) {
+			s.EndedAt = sess.endedAt
+			if sess.mutate != nil {
+				sess.mutate(s)
+			}
+		})
+		insertMessages(t, d,
+			Message{
+				SessionID: sess.id, Ordinal: 0, Role: "user",
+				Content: sess.id + "-u0", ContentLength: len(sess.id) + 3,
+				Timestamp: tsZero,
+			},
+			Message{
+				SessionID: sess.id, Ordinal: 1, Role: "user",
+				Content: sess.id + "-u1", ContentLength: len(sess.id) + 3,
+				Timestamp: tsZeroS1,
+			},
+		)
+		if sess.softKill {
+			require.NoError(t, d.SoftDeleteSession(sess.id))
+		}
+	}
+}
+
+// TestScanEmbeddableUnitsSinceScope pins the exact session set an
+// incremental scan emits now that the since watermark is applied through a
+// session-id subquery rather than a predicate on the joined sessions row.
+// The two forms must agree on every scope case: newer than the watermark,
+// older than it, no ended_at at all (NULL or the legacy empty-string
+// sentinel), automated, and trashed.
+func TestScanEmbeddableUnitsSinceScope(t *testing.T) {
+	d := testDB(t)
+	seedEmbeddableScopeCorpus(t, d)
+
+	tests := []struct {
+		name             string
+		since            string
+		includeAutomated bool
+		want             []string
+	}{
+		{
+			name:             "SinceKeepsNewerOpenAndLegacySessions",
+			since:            tsHour1,
+			includeAutomated: true,
+			want:             []string{"a-new", "c-open", "d-legacy", "e-auto"},
+		},
+		{
+			name:             "SinceStillExcludesAutomatedByDefault",
+			since:            tsHour1,
+			includeAutomated: false,
+			want:             []string{"a-new", "c-open", "d-legacy"},
+		},
+		{
+			name:             "EmptySinceScansEverySession",
+			since:            "",
+			includeAutomated: true,
+			want:             []string{"a-new", "b-old", "c-open", "d-legacy", "e-auto"},
+		},
+		{
+			name:             "SinceAfterEveryEndedAtKeepsOnlyUnendedSessions",
+			since:            "2030-01-01T00:00:00Z",
+			includeAutomated: true,
+			want:             []string{"c-open", "d-legacy"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := scanUnits(t, d, tt.since, tt.includeAutomated)
+
+			var ids []string
+			for _, u := range got {
+				ids = append(ids, u.SessionID)
+			}
+			// Two user messages per session, so every kept session
+			// contributes exactly two units in session order.
+			var want []string
+			for _, id := range tt.want {
+				want = append(want, id, id)
+			}
+			assert.Equal(t, want, ids)
+			assert.NotContains(t, ids, "f-trashed",
+				"a trashed session must never reach the embedding scan")
+		})
+	}
+}
+
+// TestScanEmbeddableUnitsSinceOrdering asserts the (session_id, ordinal)
+// stream contract unitReducer depends on still holds for a since-filtered
+// scan, where the query now drives from sessions instead of messages.
+func TestScanEmbeddableUnitsSinceOrdering(t *testing.T) {
+	d := testDB(t)
+	for _, id := range []string{"sess-c", "sess-a", "sess-b"} {
+		insertSession(t, d, id, "proj", func(s *Session) {
+			s.EndedAt = Ptr(tsMidYear)
+		})
+		insertMessages(t, d,
+			Message{
+				SessionID: id, Ordinal: 2, Role: "user",
+				Content: id + "-2", ContentLength: 8, Timestamp: tsZeroS2,
+			},
+			Message{
+				SessionID: id, Ordinal: 0, Role: "user",
+				Content: id + "-0", ContentLength: 8, Timestamp: tsZero,
+			},
+			Message{
+				SessionID: id, Ordinal: 1, Role: "user",
+				Content: id + "-1", ContentLength: 8, Timestamp: tsZeroS1,
+			},
+		)
+	}
+
+	got, maxEnded := scanUnits(t, d, tsHour1, true)
+
+	require.Len(t, got, 9)
+	var seen []string
+	for _, u := range got {
+		seen = append(seen, u.Content)
+	}
+	assert.Equal(t, []string{
+		"sess-a-0", "sess-a-1", "sess-a-2",
+		"sess-b-0", "sess-b-1", "sess-b-2",
+		"sess-c-0", "sess-c-1", "sess-c-2",
+	}, seen)
+	assert.Equal(t, tsMidYear, maxEnded)
+}
+
+// explainQueryPlan returns the flattened EXPLAIN QUERY PLAN detail lines for
+// query.
+func explainQueryPlan(t *testing.T, d *DB, query string, args ...any) []string {
+	t.Helper()
+	rows, err := d.getReader().QueryContext(
+		context.Background(), "EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, details)
+	return details
+}
+
+// TestEmbeddableUnitsQueryPlanDrivesFromSessionsWhenSinceIsSet is the
+// regression guard for the after-sync refresh reading the entire message
+// corpus (including content) on every run. With a watermark the planner must
+// look messages up per candidate session through
+// idx_messages_session_ordinal; a plan that scans messages means the
+// watermark stopped narrowing the scan. Without a watermark the full scan is
+// the intended shape and must stay.
+func TestEmbeddableUnitsQueryPlanDrivesFromSessionsWhenSinceIsSet(t *testing.T) {
+	d := testDB(t)
+	seedEmbeddableScopeCorpus(t, d)
+
+	tests := []struct {
+		name             string
+		since            string
+		includeAutomated bool
+		wantScanMessages bool
+	}{
+		{name: "SinceSetHumanScope", since: tsHour1, wantScanMessages: false},
+		{
+			name: "SinceSetIncludingAutomated", since: tsHour1,
+			includeAutomated: true, wantScanMessages: false,
+		},
+		{name: "EmptySinceKeepsFullScan", since: "", wantScanMessages: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []any
+			if tt.since != "" {
+				args = append(args, tt.since)
+			}
+			plan := explainQueryPlan(t, d,
+				embeddableUnitsQuery(tt.since, tt.includeAutomated), args...)
+			joined := strings.Join(plan, "\n")
+
+			scansMessages := false
+			searchesMessages := false
+			for _, line := range plan {
+				if strings.HasPrefix(line, "SCAN m") {
+					scansMessages = true
+				}
+				if strings.HasPrefix(line,
+					"SEARCH m USING INDEX idx_messages_session_ordinal (session_id=") {
+					searchesMessages = true
+				}
+			}
+			assert.Equal(t, tt.wantScanMessages, scansMessages,
+				"unexpected messages scan in plan:\n%s", joined)
+			assert.Equal(t, !tt.wantScanMessages, searchesMessages,
+				"expected a per-session index search in plan:\n%s", joined)
+			if tt.since != "" {
+				assert.NotContains(t, joined, "USE TEMP B-TREE FOR ORDER BY",
+					"the (session_id, ordinal) order must come from the index, not a sort:\n%s",
+					joined)
+			}
+		})
+	}
+}

--- a/internal/vector/build.go
+++ b/internal/vector/build.go
@@ -537,12 +537,7 @@ func (ix *Index) countPending(ctx context.Context, fp string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	rows, err := ix.db.QueryContext(ctx, `
-SELECT content FROM `+ix.spec.DocsTable+` d WHERE NOT EXISTS (
-    SELECT 1 FROM `+ix.spec.stampsTable()+` s WHERE s.ordinal = ? AND s.doc_key = d.doc_key
-      AND s.revision = d.content_hash)`,
-		ordinal,
-	)
+	rows, err := ix.db.QueryContext(ctx, ix.pendingContentQuery(), ordinal)
 	if err != nil {
 		return 0, fmt.Errorf("count pending documents: %w", err)
 	}
@@ -560,6 +555,27 @@ SELECT content FROM `+ix.spec.DocsTable+` d WHERE NOT EXISTS (
 		return 0, fmt.Errorf("iterating pending documents: %w", err)
 	}
 	return total, nil
+}
+
+// pendingContentQuery returns the content of every document not stamped at
+// its current revision for the bound generation ordinal.
+//
+// The pending CTE is materialized on purpose: it resolves doc_keys through
+// the mirror's (doc_key, content_hash) covering index alone, and the outer
+// join then reads content only for the documents that survive. Flattened
+// into one statement, SQLite reads every mirror row's content just to
+// discard the already-stamped ones, so an after-sync refresh with nothing
+// pending still paid for the whole corpus.
+func (ix *Index) pendingContentQuery() string {
+	return `
+WITH pending AS MATERIALIZED (
+    SELECT d.doc_key FROM ` + ix.spec.DocsTable + ` d WHERE NOT EXISTS (
+        SELECT 1 FROM ` + ix.spec.stampsTable() + ` s
+         WHERE s.ordinal = ? AND s.doc_key = d.doc_key
+           AND s.revision = d.content_hash)
+)
+SELECT d.content FROM pending p
+  JOIN ` + ix.spec.DocsTable + ` d ON d.doc_key = p.doc_key`
 }
 
 // ordinalForFingerprint looks up a generation's generations-table ordinal

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -26,6 +26,15 @@ var registerVecOnce sync.Once
 // ordinal for single-message (user) documents. subordinate and offsets
 // default to the "no run grouping yet" shape so a row inserted without
 // them (see mirror.go) is still valid.
+//
+// The (doc_key, content_hash) index covers the stamp anti-join that
+// countPending and generationCoverageQuery run, so SQLite can answer "which
+// documents are not stamped at their current revision" from the index alone
+// instead of reading every mirror row's content. It is additive, and
+// prepareMirrorSchema replays MirrorDDL on every write-path open, so
+// existing vectors.db files gain it on their next build without bumping
+// MirrorSchemaVersion; a bump would drop and re-embed the whole corpus for
+// what is only an index addition.
 const messageMirrorDDL = `
 CREATE TABLE IF NOT EXISTS vector_messages (
     doc_key      TEXT PRIMARY KEY,
@@ -41,6 +50,8 @@ CREATE TABLE IF NOT EXISTS vector_messages (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_vector_messages_session_ordinal
     ON vector_messages(session_id, ordinal);
+CREATE INDEX IF NOT EXISTS idx_vector_messages_revision
+    ON vector_messages(doc_key, content_hash);
 CREATE TABLE IF NOT EXISTS vector_meta (
     key TEXT PRIMARY KEY, value TEXT NOT NULL
 );
@@ -61,6 +72,8 @@ CREATE TABLE IF NOT EXISTS vector_recall_entries (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_vector_recall_entries_identity
     ON vector_recall_entries(session_id, ordinal);
+CREATE INDEX IF NOT EXISTS idx_vector_recall_entries_revision
+    ON vector_recall_entries(doc_key, content_hash);
 CREATE TABLE IF NOT EXISTS vector_recall_meta (
     key TEXT PRIMARY KEY, value TEXT NOT NULL
 );

--- a/internal/vector/pending_scan_test.go
+++ b/internal/vector/pending_scan_test.go
@@ -1,0 +1,193 @@
+package vector
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	kitvec "go.kenn.io/kit/vector"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// explainVectorPlan returns the flattened EXPLAIN QUERY PLAN detail lines
+// for query.
+func explainVectorPlan(t *testing.T, ix *Index, query string, args ...any) []string {
+	t.Helper()
+	rows, err := ix.db.QueryContext(
+		context.Background(), "EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, details)
+	return details
+}
+
+// TestMirrorRevisionIndexExists asserts every store's mirror carries the
+// (doc_key, content_hash) index the stamp anti-joins depend on. The index is
+// additive, so an existing vectors.db picks it up from MirrorDDL on its next
+// write-path open rather than through a MirrorSchemaVersion bump.
+func TestMirrorRevisionIndexExists(t *testing.T) {
+	tests := []struct {
+		name  string
+		spec  IndexSpec
+		index string
+	}{
+		{"messages", MessageIndexSpec(), "idx_vector_messages_revision"},
+		{"recall", RecallIndexSpec(), "idx_vector_recall_entries_revision"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ix, err := OpenSpec(context.Background(),
+				filepath.Join(t.TempDir(), "vectors.db"), tt.spec, false, 4000)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, ix.Close()) })
+
+			var sql string
+			require.NoError(t, ix.db.QueryRow(
+				`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?`,
+				tt.index).Scan(&sql))
+			assert.Contains(t, sql, tt.spec.DocsTable)
+			assert.Contains(t, strings.ReplaceAll(sql, " ", ""), "(doc_key,content_hash)")
+		})
+	}
+}
+
+// TestPendingContentQueryPlanSkipsStampedDocumentContent is the regression
+// guard for countPending reading every mirror document's content on every
+// after-sync refresh. The pending set must resolve through the mirror's
+// covering index, and content must only be read per pending doc_key.
+func TestPendingContentQueryPlanSkipsStampedDocumentContent(t *testing.T) {
+	ix, gen := builtPendingIndex(t)
+	ordinal, err := ix.ordinalForFingerprint(context.Background(), gen.Fingerprint())
+	require.NoError(t, err)
+
+	plan := explainVectorPlan(t, ix, ix.pendingContentQuery(), ordinal)
+	joined := strings.Join(plan, "\n")
+
+	assert.Contains(t, joined,
+		"SCAN d USING COVERING INDEX idx_vector_messages_revision",
+		"the pending set must come from the covering index:\n%s", joined)
+	assert.Contains(t, joined,
+		"SEARCH d USING INDEX sqlite_autoindex_vector_messages_1 (doc_key=?)",
+		"content must be fetched per pending doc_key:\n%s", joined)
+	for _, line := range plan {
+		assert.NotEqual(t, "SCAN d", line,
+			"no step may read every mirror row's content:\n%s", joined)
+	}
+}
+
+// TestGenerationCoverageQueryPlanUsesRevisionIndex asserts the coverage
+// query's Embedded and Missing anti-joins are answered from the same
+// covering index, so `embeddings status` does not walk the whole mirror
+// either.
+func TestGenerationCoverageQueryPlanUsesRevisionIndex(t *testing.T) {
+	ix, _ := builtPendingIndex(t)
+
+	plan := explainVectorPlan(t, ix, ix.generationCoverageQuery())
+	joined := strings.Join(plan, "\n")
+
+	assert.Contains(t, joined,
+		"SEARCH d EXISTS USING COVERING INDEX idx_vector_messages_revision",
+		"the Embedded column must probe the covering index:\n%s", joined)
+	assert.Contains(t, joined,
+		"SCAN d USING COVERING INDEX idx_vector_messages_revision",
+		"the Missing column must scan the covering index, not the table:\n%s", joined)
+	for _, line := range plan {
+		assert.NotEqual(t, "SCAN d", line,
+			"no coverage step may read every mirror row's content:\n%s", joined)
+	}
+}
+
+// TestCountPendingMatchesCoverageMissing pins countPending's chunk
+// denominator against the same stamp anti-join `embeddings status` reports
+// as Missing, across the states a refresh can leave a mirror in.
+func TestCountPendingMatchesCoverageMissing(t *testing.T) {
+	ctx := context.Background()
+	longContent := strings.Repeat("word ", 2000)
+
+	tests := []struct {
+		name string
+		// mutate leaves the built mirror in the state under test.
+		mutate func(t *testing.T, ix *Index)
+		// wantChunks is the chunk denominator countPending must report.
+		wantChunks func(t *testing.T, ix *Index) int64
+		// wantMissing is the document count `embeddings status` must
+		// report for the same anti-join.
+		wantMissing int64
+	}{
+		{
+			name:        "NothingPendingAfterBuild",
+			mutate:      func(*testing.T, *Index) {},
+			wantChunks:  func(*testing.T, *Index) int64 { return 0 },
+			wantMissing: 0,
+		},
+		{
+			name: "StaleRevisionCountsAsPending",
+			mutate: func(t *testing.T, ix *Index) {
+				_, err := ix.db.ExecContext(ctx,
+					`UPDATE vector_messages SET content_hash = 'changed'
+					 WHERE doc_key = 'u:s1:u1'`)
+				require.NoError(t, err)
+			},
+			wantChunks:  func(*testing.T, *Index) int64 { return 1 },
+			wantMissing: 1,
+		},
+		{
+			name: "UnstampedMultiChunkDocumentCountsEveryChunk",
+			mutate: func(t *testing.T, ix *Index) {
+				_, err := ix.db.ExecContext(ctx, `
+INSERT INTO vector_messages
+    (doc_key, session_id, source_uuid, ordinal, ordinal_end, content, content_hash)
+VALUES ('u:s1:u3', 's1', 'u3', 9, 9, ?, 'hash-u3')`, longContent)
+				require.NoError(t, err)
+			},
+			wantChunks: func(t *testing.T, ix *Index) int64 {
+				chunks := int64(len(kitvec.Split(longContent, ix.split)))
+				require.Greater(t, chunks, int64(1),
+					"content must split into several chunks for this case to be meaningful")
+				return chunks
+			},
+			wantMissing: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ix, gen := builtPendingIndex(t)
+			tt.mutate(t, ix)
+			want := tt.wantChunks(t, ix)
+
+			total, err := ix.countPending(ctx, gen.Fingerprint())
+			require.NoError(t, err)
+			assert.Equal(t, want, total)
+
+			gens, err := ix.Generations(ctx)
+			require.NoError(t, err)
+			require.Len(t, gens, 1)
+			assert.Equal(t, tt.wantMissing, gens[0].Missing,
+				"countPending and the coverage query must agree on what is pending")
+		})
+	}
+}
+
+// builtPendingIndex returns an index with the two-document corpus fully
+// built and embedded.
+func builtPendingIndex(t *testing.T) (*Index, kitvec.Generation) {
+	t.Helper()
+	ix := openTestIndex(t)
+	gen := fakeGeneration("fake-model")
+	_, err := ix.Build(
+		context.Background(), twoDocSource(), fakeBuildEncoder(), gen, BuildOptions{})
+	require.NoError(t, err)
+	return ix, gen
+}


### PR DESCRIPTION
With `[vector] enabled` and `run_after_sync = true`, every sync completion schedules an embedding refresh that read the whole message corpus twice, however little had changed. On a 693k-message archive one seven-message append was followed by about 640 MB of `sessions.db` and 275 MB of `vectors.db` being pulled into the page cache, all of it cold afterwards, against a measured UI working set of about 85 MB. Two queries were responsible.

`ScanEmbeddableUnits` has a `since` watermark, but the predicate lived on the joined `sessions` row behind a `datetime()` call, so SQLite drove the scan from `messages` (`SCAN m USING INDEX idx_messages_session_ordinal`) and read every row's content before discarding it; only 550 messages in 8 sessions were newer than the watermark. The restriction is now a session-id `IN` subquery that repeats the caller's `deleted_at` and automated-scope filters, so the small `sessions` table becomes the outer loop and messages are fetched with `SEARCH m ... (session_id=?)` on the same index, which also keeps the `(session_id, ordinal)` order the reducer relies on without a temp sort. The `since` comparison semantics, the `NULL ended_at` handling, and the empty-`since` full scan are unchanged. On the real archive the plan is now `SEARCH m USING INDEX idx_messages_session_ordinal (session_id=?)` with a bloom-filtered list subquery over `sessions`, and the equivalent count query drops from 0.50 s to 0.10 s while returning the identical 1,090 rows.

`countPending` selected `content` for every mirror document to evaluate the stamp anti-join and then split each one in Go to size the progress bar. The mirror DDL gains a `(doc_key, content_hash)` covering index on the docs tables, and the pending set is resolved in a materialized CTE through that index before content is read only for the survivors; the generation coverage query in `index.go` shares the anti-join and benefits from the same index. The index is additive and `prepareMirrorSchema` replays the DDL on every write-path open, so existing `vectors.db` files gain it on their next build; bumping `MirrorSchemaVersion` would instead drop the mirror state and re-embed the corpus for what is only an index. One consequence: a read-only open never runs DDL, so `embeddings status` against a store that has not been rebuilt yet keeps the old plan until the next build.

Reviewers should look at `sinceSessionScopeClause` and `embeddableUnitsQuery` in `internal/db/messages.go`, and `pendingContentQuery` plus the DDL change in `internal/vector`. The new tests pin the emitted unit sequence, the stream order and watermark across since/automated combinations, and assert the query plans directly (no `SCAN` of messages when `since` is set, covering-index anti-join for pending documents).

Measured after deploying this build against the same 693k-message archive: with the database files evicted from the page cache, a 90 s window containing a dozen incremental syncs (two live sessions appending) left 5 to 9 MB of sessions.db and 0 bytes of vectors.db resident. The identical experiment on the previous build pulled 640 MB of sessions.db and 275 MB of vectors.db into the cache about 30 s after a single seven-message append.

End-to-end effect: the dashboard queries the app runs on a cold open are page-cache bound, taking 0.3 to 1.6 s warm but 2 to 18 s once the archive has been evicted. Before this change the embedding refresh evicted it every 30 s of activity by streaming 900 MB of unrelated pages through the cache, so an interactive session kept landing in the cold regime; after it the archive's working set stays resident (5 to 9 MB touched per sync) and the warm numbers are the steady state.

Closes #1584

