### PR TITLE
fix(db): stop live archive writes from vetoing the usage rollup

### DIFF
--- a/docs/agents/background-work.md
+++ b/docs/agents/background-work.md
@@ -37,10 +37,11 @@ long-running background work. Also read it before investigating memory growth.
   process-local timezone plus up to eight retained recently requested explicit
   timezones. Installed source and aggregate fingerprints, not a progress
   cursor, are the authoritative coverage records.
-- If a source fingerprint changes during a pass, recapture and restart the
-  snapshot pass at most three times. Already installed current fingerprints
-  make stable batches reusable; never pair facts from the newer source with
-  rollup metadata from the older snapshot.
+- A pass runs once and is never restarted because the archive was written while
+  it ran. Each session's facts and source version come from one archive read
+  transaction, so they are always paired correctly, and a session written during
+  the pass is refilled by its own mutation notification. Do not reintroduce a
+  restart loop over a moving source fingerprint.
 - Sweep the archive deletion journal before and after the pass and between
   install batches. Queries also inner-join current archive sessions before
   ranking, so tombstone processing is hygiene rather than a correctness

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -69,8 +69,9 @@ batch, or deletion changes the set of dedup identities a session (or the Cursor
 store) contributes, it must, in the same cache transaction, delete the timezone
 rollup installs of every other session holding a changed identity; rollup
 installation re-verifies inside its transaction that no finalized identity
-gained an outside member and retries as a moved source otherwise. A finalized
-daily row must never survive gaining a sibling.
+gained an outside member and, when one did, reclassifies against the newly
+committed facts rather than failing the caller. A finalized daily row must never
+survive gaining a sibling.
 
 Treat a usage-cache file as identifiable only after both its SQLite
 `application_id` and `usage_cache_metadata.cache_kind` match. Filename matching
@@ -89,12 +90,23 @@ file and warn that the cache will rebuild after restart.
 Usage reads are exact. A cold aggregate request fills facts, builds the required
 timezone rollups, then reads them in one pinned cache transaction. Verify every
 candidate session's facts fingerprint, exact baked metadata, canonical pricing
-digest, resolved rate hashes, and Cursor high-water mark. Recheck each changed
-source session before installing it. A result is no older than the archive
-snapshot captured when the read began. A session confirmed deleted during fill
-is dropped from the request. Other fingerprint movement or archive-busy races
-are retried at most three times and then fail clearly rather than serving stale
-data. `cached_at` is diagnostic only.
+digest, resolved rate hashes, and Cursor high-water mark. A result is no older
+than the archive snapshot captured when the read began, and may be newer for a
+session whose facts were refilled meanwhile. A session confirmed deleted during
+fill is dropped from the request. `cached_at` is diagnostic only.
+
+The layers are kept apart so a live archive cannot veto a read. A fill reads one
+session's facts and that session's source version inside a single archive read
+transaction, installs both together, and reports the version it actually read,
+which may be newer than the one the caller asked for. Rollup aggregation then
+reads committed facts out of the usage cache only; it never touches the archive,
+so an append landing mid-build cannot abort it. An install is stale when the
+fact versions it was built from differ from the ones the cache now holds, and
+only those installs are rebuilt. Sessions written during a build are refilled by
+their own mutation notification and appear in the next aggregation, so staleness
+of a few seconds is expected and intended. Do not reintroduce a whole-snapshot
+recheck against the archive: validating a snapshot against a source that changes
+one session at a time livelocks the request.
 
 Timezone rollup identity includes both the resolved zone name and its rule
 fingerprint. Cache-generation retirement cancels detached work immediately but
@@ -103,8 +115,9 @@ query, backfill, fill, and rollup leases drain.
 
 `sync_marker` is a fingerprint component, not a monotonic version: its trigger
 recomputes the maximum of mutable timestamp fields, so it can decrease. A fill
-must recheck the full source fingerprint before installation. Do not replace
-that recheck with ordering comparisons.
+must read the full source fingerprint in the same transaction as the facts it
+installs. Do not compare fingerprints for ordering, and do not skip a refill
+because a cached fingerprint merely looks newer.
 
 ### Usage archive indexes
 

--- a/internal/db/recall_evidence_window.go
+++ b/internal/db/recall_evidence_window.go
@@ -504,12 +504,11 @@ func recallEvidenceAuthorizationDigest(
 }
 
 func digestRecallEvidenceCanonical(value any) (string, error) {
-	encoded, err := json.Marshal(value)
-	if err != nil {
+	digest := sha256.New()
+	if err := json.MarshalWrite(digest, value); err != nil {
 		return "", fmt.Errorf("encoding canonical recall evidence: %w", err)
 	}
-	digest := sha256.Sum256(encoded)
-	return hex.EncodeToString(digest[:]), nil
+	return hex.EncodeToString(digest.Sum(nil)), nil
 }
 
 func normalizeRecallEvidenceToolUseIDs(values []string) ([]string, error) {

--- a/internal/db/usage_cache_background.go
+++ b/internal/db/usage_cache_background.go
@@ -135,44 +135,18 @@ func (db *DB) StopUsageCacheBackfill() {
 	}
 }
 
+// runUsageCacheBackfill runs one coverage pass. Facts are filled per session
+// from their own archive read snapshot and rollups aggregate only committed
+// facts, so a pass no longer has to be restarted because the archive was
+// written while it ran. Sessions written during the pass are picked up by
+// their own mutation notification.
 func (db *DB) runUsageCacheBackfill(ctx context.Context) error {
-	started := time.Now()
-	var lastErr error
-	deferred := make(map[string]bool)
-	var previous usageQuerySnapshot
-	havePrevious := false
-	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
-		snapshot, err := db.captureUsageQuery(
-			ctx, UsageFilter{}, usageQueryKindActivity)
-		if err != nil {
-			return err
-		}
-		if havePrevious {
-			if snapshot.DatabaseID != previous.DatabaseID {
-				clear(deferred)
-			} else {
-				for sessionID := range usageBackfillChangedSessions(previous, snapshot) {
-					deferred[sessionID] = true
-				}
-			}
-		}
-		deferChangingUsageBackfillSessions(&snapshot, deferred)
-		lastErr = db.runUsageCacheBackfillPass(ctx, started, snapshot)
-		if !errors.Is(lastErr, errUsageCacheSourceChanged) {
-			if lastErr == nil && len(deferred) > 0 {
-				log.Printf(
-					"usage cache backfill: deferred %d changing sessions to incremental updates",
-					len(deferred),
-				)
-			}
-			return lastErr
-		}
-		previous = snapshot
-		havePrevious = true
+	snapshot, err := db.captureUsageQuery(
+		ctx, UsageFilter{}, usageQueryKindActivity)
+	if err != nil {
+		return err
 	}
-	return fmt.Errorf(
-		"usage cache backfill could not stabilize after %d attempts: %w",
-		usageFillMaxAttempts, lastErr)
+	return db.runUsageCacheBackfillPass(ctx, time.Now(), snapshot)
 }
 
 func (db *DB) runUsageCacheBackfillPass(
@@ -302,60 +276,6 @@ func (db *DB) runUsageCacheBackfillPass(
 		covered, deleted, dailyRows, exceptionRows, exceptionGroups,
 		time.Since(started).Round(time.Millisecond))
 	return nil
-}
-
-func usageBackfillChangedSessions(
-	previous, current usageQuerySnapshot,
-) map[string]bool {
-	currentVersions := make(map[string]usageSourceVersion, len(current.Versions))
-	for _, version := range current.Versions {
-		currentVersions[version.SessionID] = version
-	}
-	currentSessions := make(map[string]usageQuerySession, len(current.Sessions))
-	for _, session := range current.Sessions {
-		currentSessions[session.ID] = session
-	}
-	previousSessions := make(map[string]usageQuerySession, len(previous.Sessions))
-	for _, session := range previous.Sessions {
-		previousSessions[session.ID] = session
-	}
-	changed := make(map[string]bool)
-	for _, version := range previous.Versions {
-		currentVersion, exists := currentVersions[version.SessionID]
-		if !exists || !currentVersion.Equal(version) {
-			changed[version.SessionID] = true
-			continue
-		}
-		before := previousSessions[version.SessionID]
-		after, exists := currentSessions[version.SessionID]
-		if !exists || before.Agent != after.Agent ||
-			before.StartedAt != after.StartedAt {
-			changed[version.SessionID] = true
-		}
-	}
-	return changed
-}
-
-func deferChangingUsageBackfillSessions(
-	snapshot *usageQuerySnapshot, deferred map[string]bool,
-) {
-	if len(deferred) == 0 {
-		return
-	}
-	sessions := snapshot.Sessions[:0]
-	for _, session := range snapshot.Sessions {
-		if !deferred[session.ID] {
-			sessions = append(sessions, session)
-		}
-	}
-	versions := snapshot.Versions[:0]
-	for _, version := range snapshot.Versions {
-		if !deferred[version.SessionID] {
-			versions = append(versions, version)
-		}
-	}
-	snapshot.Sessions = sessions
-	snapshot.Versions = versions
 }
 
 func usageBackfillLocations(

--- a/internal/db/usage_cache_background_test.go
+++ b/internal/db/usage_cache_background_test.go
@@ -340,6 +340,45 @@ func TestUsageCacheBackfillSweepsHardDeletionTombstones(t *testing.T) {
 		"deletion hygiene must reclaim every timezone rollup for the session")
 }
 
+func TestUsageCacheBackfillContinuesWhenSessionIsDeletedDuringRollup(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "deleted-during-rollup", "project", func(session *Session) {
+		session.StartedAt = Ptr("2026-08-10T10:00:00Z")
+	})
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: "deleted-during-rollup", Ordinal: 0, Role: "assistant",
+		Timestamp: "2026-08-10T10:00:00Z", Model: "model",
+		TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+	}}))
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindActivity)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	deleted := make(chan error, 1)
+	var once atomic.Bool
+	cache.rollup.observer.beforeInstall = func(builds []usageRollupBuild) {
+		if len(builds) == 0 || !once.CompareAndSwap(false, true) {
+			return
+		}
+		deleteErr := database.DeleteSession("deleted-during-rollup")
+		if deleteErr == nil {
+			deleteErr = cache.fill.deleteNotificationSessions(
+				[]string{"deleted-during-rollup"})
+		}
+		deleted <- deleteErr
+	}
+
+	require.NoError(t, database.runUsageCacheBackfillPass(
+		context.Background(), time.Now(), snapshot))
+	require.NoError(t, <-deleted)
+	assert.Zero(t, usageCacheCount(t, cache, "usage_cached_sessions"))
+	assert.Zero(t, usageCacheCount(t, cache, "usage_rollup_installs"))
+	assert.NotEmpty(t,
+		readUsageCacheMetadata(t, cache.db)[usageCacheMetadataBackfillCompletedAt])
+}
+
 func TestUsageMatchingCountDiscoversWritesAfterCompletedBackfill(t *testing.T) {
 	database := testDB(t)
 	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))

--- a/internal/db/usage_cache_background_test.go
+++ b/internal/db/usage_cache_background_test.go
@@ -66,7 +66,10 @@ func TestUsageCacheBackfillNewestFirstAndResumesInstalledCoverage(t *testing.T) 
 	assert.Empty(t, extracted, "installed versions are coverage truth on restart")
 }
 
-func TestUsageCacheBackfillRecapturesChangedSource(t *testing.T) {
+// The pass no longer recaptures when a source moves under it: it installs the
+// facts its read snapshot saw, and the next request refills the session that
+// changed. The observable outcome, an exact answer afterwards, is unchanged.
+func TestUsageCacheBackfillPicksUpSourceChangedDuringPass(t *testing.T) {
 	database := testDB(t)
 	started := "2026-08-10T08:00:00Z"
 	insertSession(t, database, "moving-backfill", "project", func(session *Session) {

--- a/internal/db/usage_cache_consumers.go
+++ b/internal/db/usage_cache_consumers.go
@@ -43,6 +43,13 @@ func (db *DB) queryUsageRollups(
 	ctx context.Context, filter UsageFilter, kind usageQueryKind,
 	includeCursor bool,
 ) (usageQuerySnapshot, usageFactsResult, *export.PricingResolver, error) {
+	// Live archive writes no longer force a recapture: facts are filled from
+	// their own read snapshot and rollups aggregate committed facts only.
+	// What remains is cache-generation retirement, which replaces the whole
+	// cache, and cache-side invalidation of an install between the build and
+	// the read. Both are resolved by recapturing, and neither is driven by
+	// the write rate.
+	var lastErr error
 	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
 		started := time.Now()
 		var timings usageRollupRequestTimings
@@ -58,8 +65,8 @@ func (db *DB) queryUsageRollups(
 		cache, release, generationErr := db.usageCache.acquireGeneration(
 			ctx, snapshot.DatabaseID)
 		if generationErr != nil {
-			if errors.Is(generationErr, errUsageCacheSourceChanged) &&
-				attempt < usageFillMaxAttempts {
+			if errors.Is(generationErr, errUsageCacheSourceChanged) {
+				lastErr = generationErr
 				continue
 			}
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, generationErr
@@ -76,8 +83,8 @@ func (db *DB) queryUsageRollups(
 		)
 		if fillErr != nil {
 			release()
-			if errors.Is(fillErr, errUsageCacheSourceChanged) &&
-				attempt < usageFillMaxAttempts {
+			if errors.Is(fillErr, errUsageCacheSourceChanged) {
+				lastErr = fillErr
 				continue
 			}
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, fillErr
@@ -89,8 +96,8 @@ func (db *DB) queryUsageRollups(
 			ctx, snapshot, fills, resolver)
 		if rollupErr != nil {
 			release()
-			if errors.Is(rollupErr, errUsageCacheSourceChanged) &&
-				attempt < usageFillMaxAttempts {
+			if errors.Is(rollupErr, errUsageCacheSourceChanged) {
+				lastErr = rollupErr
 				continue
 			}
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, rollupErr
@@ -115,14 +122,12 @@ func (db *DB) queryUsageRollups(
 			return snapshot, facts, resolver, nil
 		}
 		release()
-		if !usageCacheReadShouldRecapture(queryErr) || attempt == usageFillMaxAttempts {
+		if !usageCacheReadShouldRecapture(queryErr) {
 			return usageQuerySnapshot{}, usageFactsResult{}, nil, queryErr
 		}
+		lastErr = queryErr
 	}
-	return usageQuerySnapshot{}, usageFactsResult{}, nil, fmt.Errorf(
-		"usage cache read could not stabilize after %d attempts",
-		usageFillMaxAttempts,
-	)
+	return usageQuerySnapshot{}, usageFactsResult{}, nil, lastErr
 }
 
 // GetTopSessionsByCost returns filtered sessions ranked by cost or tokens.

--- a/internal/db/usage_cache_fill.go
+++ b/internal/db/usage_cache_fill.go
@@ -141,15 +141,10 @@ func (c *usageFillCoordinator) Ensure(
 			results[id] = call.result
 		}
 	}
-	for _, version := range versions {
-		result, ok := results[version.SessionID]
-		if ok && !result.Deleted && !result.source.Equal(version) {
-			return nil, fmt.Errorf(
-				"%w while filling session %s",
-				errUsageCacheSourceChanged, version.SessionID,
-			)
-		}
-	}
+	// A fill installs the facts its own archive read transaction saw and
+	// reports the exact source version they belong to. That version can be
+	// newer than the one the caller asked for, which is a valid answer, so
+	// there is no post-hoc comparison against the caller's snapshot here.
 	if cursorHighWater > 0 {
 		if err := c.ensureCursor(ctx, cursorHighWater); err != nil {
 			return nil, err
@@ -216,50 +211,53 @@ func (c *usageFillCoordinator) fillSessionsDetached(
 	ctx context.Context,
 	versions []usageSourceVersion,
 ) (map[string]usageFillResult, error) {
-	pending := append([]usageSourceVersion(nil), versions...)
 	results := make(map[string]usageFillResult, len(versions))
-	var spool *usageFactSpool
-	for attempt := 1; len(pending) > 0 && attempt <= usageFillMaxAttempts; attempt++ {
-		if spool == nil {
-			if c.observer.beforeExtract != nil {
-				c.observer.beforeExtract(append([]usageSourceVersion(nil), pending...))
-			}
-			var err error
-			spool, err = c.extractSessions(ctx, pending)
-			if err != nil {
-				return nil, err
-			}
-			if c.observer.afterExtract != nil {
-				c.observer.afterExtract(append([]usageSourceVersion(nil), pending...))
-			}
-		}
-		if c.observer.beforeInstall != nil {
-			c.observer.beforeInstall(append([]usageSourceVersion(nil), pending...))
-		}
-		installed, retry, err := c.installSpool(ctx, spool, pending)
-		if err != nil && isUsageCacheBusy(err) {
+	if len(versions) == 0 {
+		return results, nil
+	}
+	if c.observer.beforeExtract != nil {
+		c.observer.beforeExtract(slices.Clone(versions))
+	}
+	// One archive read transaction yields both the facts and the source
+	// version they belong to, so the install never has to consult the
+	// archive again and a concurrent append cannot invalidate this fill.
+	spool, extracted, err := c.extractSessions(ctx, versions)
+	if err != nil {
+		return nil, err
+	}
+	if c.observer.afterExtract != nil {
+		c.observer.afterExtract(slices.Clone(versions))
+	}
+	stable := make([]usageSourceVersion, 0, len(versions))
+	var deleted []string
+	for _, requested := range versions {
+		if version, ok := extracted[requested.SessionID]; ok {
+			stable = append(stable, version)
 			continue
 		}
-		closeErr := spool.Close()
-		spool = nil
-		if err != nil {
-			return nil, errors.Join(err, closeErr)
+		deleted = append(deleted, requested.SessionID)
+		results[requested.SessionID] = usageFillResult{Deleted: true}
+	}
+	if c.observer.beforeInstall != nil {
+		c.observer.beforeInstall(slices.Clone(stable))
+	}
+	// Cache-side lock contention is the only reason to try the install
+	// again; the facts themselves are already fixed by the read snapshot.
+	var installed map[string]usageFillResult
+	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
+		installed, err = c.installSpool(ctx, spool, stable, deleted)
+		if err == nil || !isUsageCacheBusy(err) {
+			break
 		}
-		if closeErr != nil {
-			return nil, closeErr
-		}
-		maps.Copy(results, installed)
-		pending = retry
 	}
-	if spool != nil {
-		_ = spool.Close()
+	closeErr := spool.Close()
+	if err != nil {
+		return nil, errors.Join(err, closeErr)
 	}
-	if len(pending) != 0 {
-		return nil, fmt.Errorf(
-			"usage cache fill could not verify archive state after %d attempts for %d sessions",
-			usageFillMaxAttempts, len(pending),
-		)
+	if closeErr != nil {
+		return nil, closeErr
 	}
+	maps.Copy(results, installed)
 	return results, nil
 }
 
@@ -371,12 +369,17 @@ func (s *usageFactSpool) Close() error {
 	return errors.Join(s.db.Close(), removeUsageCacheFiles(s.path))
 }
 
+// extractSessions reads the requested sessions' usage facts and their source
+// versions inside one archive read transaction. WAL gives that transaction a
+// consistent snapshot, so the returned versions describe exactly the facts in
+// the spool. Sessions missing from the returned map were deleted as of the
+// snapshot.
 func (c *usageFillCoordinator) extractSessions(
 	ctx context.Context, versions []usageSourceVersion,
-) (*usageFactSpool, error) {
+) (*usageFactSpool, map[string]usageSourceVersion, error) {
 	spool, err := newUsageFactSpool()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	fail := true
 	defer func() {
@@ -386,64 +389,85 @@ func (c *usageFillCoordinator) extractSessions(
 	}()
 	conn, err := c.archive.getReader().Conn(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("pinning archive usage fill connection: %w", err)
+		return nil, nil, fmt.Errorf("pinning archive usage fill connection: %w", err)
 	}
 	defer conn.Close()
 	tx, err := conn.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
-		return nil, fmt.Errorf("starting archive usage fill snapshot: %w", err)
+		return nil, nil, fmt.Errorf("starting archive usage fill snapshot: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	var databaseID string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT value FROM archive_metadata WHERE key = ?`,
+		archiveMetadataDatabaseIDKey,
+	).Scan(&databaseID); err != nil {
+		return nil, nil, err
+	}
+	if databaseID != c.cache.databaseID {
+		return nil, nil, fmt.Errorf("%w during session fill", errUsageCacheSourceChanged)
+	}
+	ids := make([]string, 0, len(versions))
+	for _, version := range versions {
+		ids = append(ids, version.SessionID)
+	}
+	extracted, err := loadUsageSourceVersions(ctx, tx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
 	if _, err := tx.ExecContext(ctx,
 		`CREATE TEMP TABLE IF NOT EXISTS usage_fill_sessions(
 			session_id TEXT PRIMARY KEY
 		) WITHOUT ROWID;
 		DELETE FROM usage_fill_sessions`,
 	); err != nil {
-		return nil, fmt.Errorf("creating usage fill session set: %w", err)
+		return nil, nil, fmt.Errorf("creating usage fill session set: %w", err)
 	}
 	insert, err := tx.PrepareContext(ctx,
 		`INSERT INTO usage_fill_sessions(session_id) VALUES (?)`)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	for _, version := range versions {
-		if _, err := insert.ExecContext(ctx, version.SessionID); err != nil {
+	for _, id := range ids {
+		if _, ok := extracted[id]; !ok {
+			continue
+		}
+		if _, err := insert.ExecContext(ctx, id); err != nil {
 			_ = insert.Close()
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	if err := insert.Close(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	spoolTx, err := spool.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() { _ = spoolTx.Rollback() }()
 	indexes := make(map[string]int, len(versions))
 	spoolWriter := usageFactSpoolWriter{ctx: ctx, tx: spoolTx}
 	if err := extractUsageMessageFacts(ctx, tx, &spoolWriter, indexes); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := extractUsageActivityFacts(ctx, tx, &spoolWriter, indexes); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := extractUsageEventFacts(ctx, tx, &spoolWriter, indexes); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := spoolWriter.Flush(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := spoolTx.Commit(); err != nil {
-		return nil, fmt.Errorf("committing usage fact spool: %w", err)
+		return nil, nil, fmt.Errorf("committing usage fact spool: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("closing archive usage fill snapshot: %w", err)
+		return nil, nil, fmt.Errorf("closing archive usage fill snapshot: %w", err)
 	}
 	fail = false
-	return spool, nil
+	return spool, extracted, nil
 }
 
 func extractUsageMessageFacts(
@@ -660,46 +684,56 @@ const usageFillEventFactsSQL = `
 	ORDER BY e.session_id, COALESCE(e.occurred_at, ''), e.id`
 
 func (c *usageFillCoordinator) installSpool(
-	ctx context.Context, spool *usageFactSpool, versions []usageSourceVersion,
-) (map[string]usageFillResult, []usageSourceVersion, error) {
-	installed := make(map[string]usageFillResult, len(versions))
-	var retry []usageSourceVersion
-	for start := 0; start < len(versions); start += usageFillInstallBatchSize {
-		end := min(start+usageFillInstallBatchSize, len(versions))
-		batchInstalled, batchRetry, err := c.installSpoolBatch(
-			ctx, spool, versions[start:end],
+	ctx context.Context, spool *usageFactSpool,
+	stable []usageSourceVersion, deleted []string,
+) (map[string]usageFillResult, error) {
+	installed := make(map[string]usageFillResult, len(stable))
+	if len(stable) == 0 && len(deleted) == 0 {
+		return installed, nil
+	}
+	// The loop body runs at least once so a batch that only removes deleted
+	// sessions still commits.
+	for start := 0; start == 0 || start < len(stable); start += usageFillInstallBatchSize {
+		end := min(start+usageFillInstallBatchSize, len(stable))
+		// Deletions belong to the first transaction only.
+		batchDeleted := deleted
+		if start > 0 {
+			batchDeleted = nil
+		}
+		batchInstalled, err := c.installSpoolBatch(
+			ctx, spool, stable[start:end], batchDeleted,
 		)
 		if err != nil {
-			return nil, versions, err
+			return nil, err
 		}
 		maps.Copy(installed, batchInstalled)
-		retry = append(retry, batchRetry...)
-		if end < len(versions) {
+		if end < len(stable) {
 			c.maintainBetweenInstallBatches(ctx)
 		}
 	}
-	return installed, retry, nil
+	return installed, nil
 }
 
 func (c *usageFillCoordinator) installSpoolBatch(
-	ctx context.Context, spool *usageFactSpool, versions []usageSourceVersion,
-) (map[string]usageFillResult, []usageSourceVersion, error) {
+	ctx context.Context, spool *usageFactSpool, stable []usageSourceVersion,
+	deleted []string,
+) (map[string]usageFillResult, error) {
 	conn, err := c.cache.db.Conn(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer conn.Close()
 	if _, err := conn.ExecContext(ctx,
 		`ATTACH DATABASE ? AS usage_fill_spool`, spool.path,
 	); err != nil {
-		return nil, nil, fmt.Errorf("attaching usage fact spool: %w", err)
+		return nil, fmt.Errorf("attaching usage fact spool: %w", err)
 	}
 	defer func() {
 		_, _ = conn.ExecContext(context.Background(),
 			`DETACH DATABASE usage_fill_spool`)
 	}()
 	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return nil, versions, fmt.Errorf("locking usage cache for fill: %w", err)
+		return nil, fmt.Errorf("locking usage cache for fill: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -708,26 +742,9 @@ func (c *usageFillCoordinator) installSpoolBatch(
 		}
 	}()
 
-	results := make(map[string]usageFillResult, len(versions))
-	var retry []usageSourceVersion
-	var deleted []string
-	stable := make([]usageSourceVersion, 0, len(versions))
-	currentVersions, err := c.recheckSourceVersions(ctx, versions)
-	if err != nil {
-		return nil, versions, err
-	}
-	for _, observed := range versions {
-		current, exists := currentVersions[observed.SessionID]
-		if !exists {
-			deleted = append(deleted, observed.SessionID)
-			results[observed.SessionID] = usageFillResult{Deleted: true}
-			continue
-		}
-		if !current.Equal(observed) {
-			retry = append(retry, current)
-			continue
-		}
-		stable = append(stable, current)
+	results := make(map[string]usageFillResult, len(stable)+len(deleted))
+	for _, sessionID := range deleted {
+		results[sessionID] = usageFillResult{Deleted: true}
 	}
 	affected := append([]string(nil), deleted...)
 	for _, version := range stable {
@@ -735,7 +752,7 @@ func (c *usageFillCoordinator) installSpoolBatch(
 	}
 	oldIdentities, err := usageFactIdentitiesForSessions(ctx, conn, affected)
 	if err != nil {
-		return nil, versions, err
+		return nil, err
 	}
 	for _, sessionID := range deleted {
 		for _, query := range []string{
@@ -743,25 +760,25 @@ func (c *usageFillCoordinator) installSpoolBatch(
 			`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
 		} {
 			if _, err := conn.ExecContext(ctx, query, sessionID); err != nil {
-				return nil, versions, err
+				return nil, err
 			}
 		}
 	}
 	stableResults, err := installSpoolSessions(ctx, conn, stable)
 	if err != nil {
-		return nil, versions, err
+		return nil, err
 	}
 	maps.Copy(results, stableResults)
 	if err := c.invalidateChangedIdentitySharers(
 		ctx, conn, oldIdentities, stable, affected,
 	); err != nil {
-		return nil, versions, err
+		return nil, err
 	}
 	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
-		return nil, versions, fmt.Errorf("committing usage cache fill: %w", err)
+		return nil, fmt.Errorf("committing usage cache fill: %w", err)
 	}
 	committed = true
-	return results, retry, nil
+	return results, nil
 }
 
 // invalidateChangedIdentitySharers compares the dedup identities a fill
@@ -792,6 +809,10 @@ func (c *usageFillCoordinator) invalidateChangedIdentitySharers(
 	return invalidateUsageDedupSharers(ctx, conn, changed, excluded)
 }
 
+// recheckSourceVersions resolves the archive's current source versions for the
+// given sessions. It backs the mutation-notification path, which has to decide
+// which sessions to refill or delete; fills and rollup builds read their own
+// consistent snapshot instead and never call it.
 func (c *usageFillCoordinator) recheckSourceVersions(
 	ctx context.Context, observed []usageSourceVersion,
 ) (map[string]usageSourceVersion, error) {
@@ -831,6 +852,22 @@ func (c *usageFillCoordinator) recheckSourceVersions(
 	for _, version := range observed {
 		ids = append(ids, version.SessionID)
 	}
+	current, err := loadUsageSourceVersions(ctx, tx, ids)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// loadUsageSourceVersions reads the current source version of each requested
+// session inside the caller's archive read transaction. Sessions absent from
+// the result are deleted as of that transaction's snapshot.
+func loadUsageSourceVersions(
+	ctx context.Context, tx *sql.Tx, ids []string,
+) (map[string]usageSourceVersion, error) {
 	current := make(map[string]usageSourceVersion, len(ids))
 	if err := queryChunked(ids, func(chunk []string) error {
 		placeholders, args := inPlaceholders(chunk)
@@ -861,18 +898,13 @@ func (c *usageFillCoordinator) recheckSourceVersions(
 			foundIDs = append(foundIDs, id)
 		}
 	}
-	fingerprints, err := usageEventFingerprintsWithQuerier(
-		ctx, tx, foundIDs,
-	)
+	fingerprints, err := usageEventFingerprintsWithQuerier(ctx, tx, foundIDs)
 	if err != nil {
 		return nil, err
 	}
 	for id, version := range current {
 		version.UsageEventFingerprint = fingerprints[id]
 		current[id] = version
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
 	}
 	return current, nil
 }

--- a/internal/db/usage_cache_fill.go
+++ b/internal/db/usage_cache_fill.go
@@ -30,6 +30,11 @@ type usageFillResult struct {
 	source          usageSourceVersion
 }
 
+type usageFillInstallExpectation struct {
+	InstallRevision int64
+	Exists          bool
+}
+
 type usageFillCall struct {
 	done   chan struct{}
 	result usageFillResult
@@ -215,50 +220,90 @@ func (c *usageFillCoordinator) fillSessionsDetached(
 	if len(versions) == 0 {
 		return results, nil
 	}
-	if c.observer.beforeExtract != nil {
-		c.observer.beforeExtract(slices.Clone(versions))
-	}
-	// One archive read transaction yields both the facts and the source
-	// version they belong to, so the install never has to consult the
-	// archive again and a concurrent append cannot invalidate this fill.
-	spool, extracted, err := c.extractSessions(ctx, versions)
-	if err != nil {
-		return nil, err
-	}
-	if c.observer.afterExtract != nil {
-		c.observer.afterExtract(slices.Clone(versions))
-	}
-	stable := make([]usageSourceVersion, 0, len(versions))
-	var deleted []string
-	for _, requested := range versions {
-		if version, ok := extracted[requested.SessionID]; ok {
-			stable = append(stable, version)
-			continue
+	pending := slices.Clone(versions)
+	for sourceAttempt := 1; sourceAttempt <= usageFillMaxAttempts; sourceAttempt++ {
+		expected, err := c.captureFillInstallExpectations(pending)
+		if err != nil {
+			return nil, err
 		}
-		deleted = append(deleted, requested.SessionID)
-		results[requested.SessionID] = usageFillResult{Deleted: true}
+		if c.observer.beforeExtract != nil {
+			c.observer.beforeExtract(slices.Clone(pending))
+		}
+		// One archive read transaction yields both the facts and the source
+		// version they belong to, so the install never has to consult the
+		// archive again. The cache expectation prevents an older concurrent
+		// extraction from replacing facts installed after this attempt began.
+		spool, extracted, err := c.extractSessions(ctx, pending)
+		if err != nil {
+			return nil, err
+		}
+		if c.observer.afterExtract != nil {
+			c.observer.afterExtract(slices.Clone(pending))
+		}
+		stable := make([]usageSourceVersion, 0, len(pending))
+		var deleted []string
+		for _, requested := range pending {
+			if version, ok := extracted[requested.SessionID]; ok {
+				stable = append(stable, version)
+				continue
+			}
+			deleted = append(deleted, requested.SessionID)
+		}
+		if c.observer.beforeInstall != nil {
+			c.observer.beforeInstall(slices.Clone(stable))
+		}
+		var installed map[string]usageFillResult
+		var lost []string
+		for installAttempt := 1; installAttempt <= usageFillMaxAttempts; installAttempt++ {
+			installed, lost, err = c.installSpool(
+				ctx, spool, stable, deleted, expected)
+			if err == nil || !isUsageCacheBusy(err) {
+				break
+			}
+		}
+		closeErr := spool.Close()
+		if err != nil {
+			return nil, errors.Join(err, closeErr)
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+		maps.Copy(results, installed)
+		if len(lost) == 0 {
+			return results, nil
+		}
+		lostSet := make(map[string]bool, len(lost))
+		for _, sessionID := range lost {
+			lostSet[sessionID] = true
+		}
+		next := make([]usageSourceVersion, 0, len(lost))
+		for _, version := range pending {
+			if lostSet[version.SessionID] {
+				next = append(next, version)
+			}
+		}
+		pending = next
 	}
-	if c.observer.beforeInstall != nil {
-		c.observer.beforeInstall(slices.Clone(stable))
-	}
-	// Cache-side lock contention is the only reason to try the install
-	// again; the facts themselves are already fixed by the read snapshot.
-	var installed map[string]usageFillResult
-	for attempt := 1; attempt <= usageFillMaxAttempts; attempt++ {
-		installed, err = c.installSpool(ctx, spool, stable, deleted)
-		if err == nil || !isUsageCacheBusy(err) {
-			break
+	return nil, fmt.Errorf(
+		"%w: usage cache facts kept changing during fill",
+		errUsageCacheSourceChanged)
+}
+
+func (c *usageFillCoordinator) captureFillInstallExpectations(
+	versions []usageSourceVersion,
+) (map[string]usageFillInstallExpectation, error) {
+	expected := make(map[string]usageFillInstallExpectation, len(versions))
+	for _, version := range versions {
+		cached, ok, err := c.cachedSession(version.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		expected[version.SessionID] = usageFillInstallExpectation{
+			InstallRevision: cached.InstallRevision,
+			Exists:          ok,
 		}
 	}
-	closeErr := spool.Close()
-	if err != nil {
-		return nil, errors.Join(err, closeErr)
-	}
-	if closeErr != nil {
-		return nil, closeErr
-	}
-	maps.Copy(results, installed)
-	return results, nil
+	return expected, nil
 }
 
 // FillBackground performs cancellable, non-single-flight work for the daemon
@@ -686,11 +731,13 @@ const usageFillEventFactsSQL = `
 func (c *usageFillCoordinator) installSpool(
 	ctx context.Context, spool *usageFactSpool,
 	stable []usageSourceVersion, deleted []string,
-) (map[string]usageFillResult, error) {
+	expected map[string]usageFillInstallExpectation,
+) (map[string]usageFillResult, []string, error) {
 	installed := make(map[string]usageFillResult, len(stable))
 	if len(stable) == 0 && len(deleted) == 0 {
-		return installed, nil
+		return installed, nil, nil
 	}
+	var lost []string
 	// The loop body runs at least once so a batch that only removes deleted
 	// sessions still commits.
 	for start := 0; start == 0 || start < len(stable); start += usageFillInstallBatchSize {
@@ -700,40 +747,41 @@ func (c *usageFillCoordinator) installSpool(
 		if start > 0 {
 			batchDeleted = nil
 		}
-		batchInstalled, err := c.installSpoolBatch(
-			ctx, spool, stable[start:end], batchDeleted,
+		batchInstalled, batchLost, err := c.installSpoolBatch(
+			ctx, spool, stable[start:end], batchDeleted, expected,
 		)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		maps.Copy(installed, batchInstalled)
+		lost = append(lost, batchLost...)
 		if end < len(stable) {
 			c.maintainBetweenInstallBatches(ctx)
 		}
 	}
-	return installed, nil
+	return installed, lost, nil
 }
 
 func (c *usageFillCoordinator) installSpoolBatch(
 	ctx context.Context, spool *usageFactSpool, stable []usageSourceVersion,
-	deleted []string,
-) (map[string]usageFillResult, error) {
+	deleted []string, expected map[string]usageFillInstallExpectation,
+) (map[string]usageFillResult, []string, error) {
 	conn, err := c.cache.db.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer conn.Close()
 	if _, err := conn.ExecContext(ctx,
 		`ATTACH DATABASE ? AS usage_fill_spool`, spool.path,
 	); err != nil {
-		return nil, fmt.Errorf("attaching usage fact spool: %w", err)
+		return nil, nil, fmt.Errorf("attaching usage fact spool: %w", err)
 	}
 	defer func() {
 		_, _ = conn.ExecContext(context.Background(),
 			`DETACH DATABASE usage_fill_spool`)
 	}()
 	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-		return nil, fmt.Errorf("locking usage cache for fill: %w", err)
+		return nil, nil, fmt.Errorf("locking usage cache for fill: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -742,43 +790,87 @@ func (c *usageFillCoordinator) installSpoolBatch(
 		}
 	}()
 
-	results := make(map[string]usageFillResult, len(stable)+len(deleted))
+	eligibleStable := make([]usageSourceVersion, 0, len(stable))
+	eligibleDeleted := make([]string, 0, len(deleted))
+	var lost []string
+	for _, version := range stable {
+		matches, matchErr := fillInstallExpectationMatches(
+			ctx, conn, version.SessionID, expected[version.SessionID])
+		if matchErr != nil {
+			return nil, nil, matchErr
+		}
+		if matches {
+			eligibleStable = append(eligibleStable, version)
+		} else {
+			lost = append(lost, version.SessionID)
+		}
+	}
 	for _, sessionID := range deleted {
+		matches, matchErr := fillInstallExpectationMatches(
+			ctx, conn, sessionID, expected[sessionID])
+		if matchErr != nil {
+			return nil, nil, matchErr
+		}
+		if matches {
+			eligibleDeleted = append(eligibleDeleted, sessionID)
+		} else {
+			lost = append(lost, sessionID)
+		}
+	}
+	results := make(map[string]usageFillResult,
+		len(eligibleStable)+len(eligibleDeleted))
+	for _, sessionID := range eligibleDeleted {
 		results[sessionID] = usageFillResult{Deleted: true}
 	}
-	affected := append([]string(nil), deleted...)
-	for _, version := range stable {
+	affected := append([]string(nil), eligibleDeleted...)
+	for _, version := range eligibleStable {
 		affected = append(affected, version.SessionID)
 	}
 	oldIdentities, err := usageFactIdentitiesForSessions(ctx, conn, affected)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	for _, sessionID := range deleted {
+	for _, sessionID := range eligibleDeleted {
 		for _, query := range []string{
 			`DELETE FROM usage_rollup_installs WHERE session_id = ?`,
 			`DELETE FROM usage_cached_sessions WHERE session_id = ?`,
 		} {
 			if _, err := conn.ExecContext(ctx, query, sessionID); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 	}
-	stableResults, err := installSpoolSessions(ctx, conn, stable)
+	stableResults, err := installSpoolSessions(ctx, conn, eligibleStable)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	maps.Copy(results, stableResults)
 	if err := c.invalidateChangedIdentitySharers(
-		ctx, conn, oldIdentities, stable, affected,
+		ctx, conn, oldIdentities, eligibleStable, affected,
 	); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
-		return nil, fmt.Errorf("committing usage cache fill: %w", err)
+		return nil, nil, fmt.Errorf("committing usage cache fill: %w", err)
 	}
 	committed = true
-	return results, nil
+	return results, lost, nil
+}
+
+func fillInstallExpectationMatches(
+	ctx context.Context, conn *sql.Conn, sessionID string,
+	expected usageFillInstallExpectation,
+) (bool, error) {
+	var revision int64
+	err := conn.QueryRowContext(ctx, `SELECT install_revision
+		FROM usage_cached_sessions WHERE session_id = ?`, sessionID).Scan(&revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return !expected.Exists, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return expected.Exists && revision == expected.InstallRevision, nil
 }
 
 // invalidateChangedIdentitySharers compares the dedup identities a fill

--- a/internal/db/usage_cache_fill_test.go
+++ b/internal/db/usage_cache_fill_test.go
@@ -221,6 +221,76 @@ func TestUsageFillCoordinatorDoesNotJoinOlderSourceVersion(t *testing.T) {
 	require.NoError(t, <-oldDone)
 }
 
+func TestUsageFillOlderExtractionCannotReplaceNewerCachedFacts(t *testing.T) {
+	database := usageCandidateFixture(t)
+	snapshot, err := database.captureUsageQuery(
+		t.Context(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	var oldVersion usageSourceVersion
+	for _, version := range snapshot.Versions {
+		if version.SessionID == "inside-message" {
+			oldVersion = version
+			break
+		}
+	}
+	require.Equal(t, "inside-message", oldVersion.SessionID)
+	oldExtracted := make(chan struct{})
+	releaseOld := make(chan struct{})
+	var oldExtractions atomic.Int32
+	cache.fill.observer.afterExtract = func(versions []usageSourceVersion) {
+		if versions[0].TranscriptRevision != oldVersion.TranscriptRevision {
+			return
+		}
+		if oldExtractions.Add(1) == 1 {
+			close(oldExtracted)
+			<-releaseOld
+		}
+	}
+	type fillOutcome struct {
+		results map[string]usageFillResult
+		err     error
+	}
+	oldDone := make(chan fillOutcome, 1)
+	go func() {
+		results, fillErr := cache.fill.Ensure(
+			t.Context(), []usageSourceVersion{oldVersion}, 0)
+		oldDone <- fillOutcome{results: results, err: fillErr}
+	}()
+	<-oldExtracted
+	tx, err := database.getWriter().BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	_, err = tx.Exec(`UPDATE messages SET token_usage = '{"input_tokens":9}'
+		WHERE session_id = ?`, oldVersion.SessionID)
+	require.NoError(t, err)
+	_, err = tx.Exec(`UPDATE sessions SET transcript_revision = 'newer'
+		WHERE id = ?`, oldVersion.SessionID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	current, err := cache.fill.recheckSourceVersions(
+		t.Context(), []usageSourceVersion{{SessionID: oldVersion.SessionID}})
+	require.NoError(t, err)
+	newVersion := current[oldVersion.SessionID]
+	newResults, err := cache.fill.Ensure(
+		t.Context(), []usageSourceVersion{newVersion}, 0)
+	require.NoError(t, err)
+	close(releaseOld)
+	oldOutcome := <-oldDone
+	require.NoError(t, oldOutcome.err)
+
+	assert.Equal(t, newVersion, newResults[oldVersion.SessionID].source)
+	assert.Equal(t, newVersion, oldOutcome.results[oldVersion.SessionID].source)
+	assert.Equal(t, int32(2), oldExtractions.Load(),
+		"the older fill should re-extract after losing the cache race")
+	var inputTokens int64
+	require.NoError(t, cache.db.QueryRow(`SELECT f.input_tokens
+		FROM usage_facts f JOIN usage_cached_sessions s
+		  ON s.id = f.cached_session_id
+		WHERE s.session_id = ?`, oldVersion.SessionID).Scan(&inputTokens))
+	assert.Equal(t, int64(9), inputTokens)
+}
+
 func TestUsageFillRecheckRestoresReaderBusyTimeout(t *testing.T) {
 	database := usageCandidateFixture(t)
 	database.reader.Load().SetMaxOpenConns(1)

--- a/internal/db/usage_cache_fill_test.go
+++ b/internal/db/usage_cache_fill_test.go
@@ -214,7 +214,11 @@ func TestUsageFillCoordinatorDoesNotJoinOlderSourceVersion(t *testing.T) {
 	}
 	close(releaseOld)
 	require.NoError(t, <-newDone)
-	require.ErrorIs(t, <-oldDone, errUsageCacheSourceChanged)
+	// The requested version still keys the single-flight call, so the newer
+	// version cannot join the older one's in-flight fill. The older caller
+	// itself no longer fails: its extraction reads whatever the archive holds
+	// when its own read transaction opens, and it reports that version back.
+	require.NoError(t, <-oldDone)
 }
 
 func TestUsageFillRecheckRestoresReaderBusyTimeout(t *testing.T) {
@@ -248,9 +252,11 @@ func TestUsageCacheFillReportsDeletedSession(t *testing.T) {
 	require.NoError(t, err)
 	version := snapshot.Versions[0]
 
+	// Deletion is now observed by the fill's own archive read transaction, so
+	// the delete has to land before extraction rather than after it.
 	var deleteErr error
 	cache.fill.observer = usageFillObserver{
-		afterExtract: func([]usageSourceVersion) {
+		beforeExtract: func([]usageSourceVersion) {
 			_, deleteErr = database.getWriter().Exec(
 				`DELETE FROM sessions WHERE id = ?`, version.SessionID,
 			)
@@ -262,7 +268,11 @@ func TestUsageCacheFillReportsDeletedSession(t *testing.T) {
 	assert.True(t, results[version.SessionID].Deleted)
 }
 
-func TestUsageCacheFillRetriesChangedFingerprint(t *testing.T) {
+// A source change that lands after extraction used to force a retry and, when
+// it kept happening, fail the fill. The facts now come from a single archive
+// read transaction, so the fill installs that snapshot and reports the version
+// it read; the later write is picked up by its own notification fill.
+func TestUsageCacheFillInstallsExtractedSnapshotDespiteLaterWrite(t *testing.T) {
 	database := usageCandidateFixture(t)
 	snapshot, err := database.captureUsageQuery(
 		context.Background(), UsageFilter{}, usageQueryKindToken,
@@ -289,15 +299,20 @@ func TestUsageCacheFillRetriesChangedFingerprint(t *testing.T) {
 	results, err := cache.fill.Ensure(
 		context.Background(), []usageSourceVersion{version}, 0,
 	)
-	require.ErrorIs(t, err, errUsageCacheSourceChanged)
+	require.NoError(t, err)
 	if stored := mutationErr.Load(); stored != nil {
 		require.NoError(t, stored.(error))
 	}
-	assert.Equal(t, int32(2), mutations.Load())
-	assert.Nil(t, results)
+	assert.Equal(t, int32(1), mutations.Load(), "fill extracted more than once")
+	assert.False(t, results[version.SessionID].Deleted)
+	assert.Equal(t, version, results[version.SessionID].source)
 }
 
-func TestDailyUsageRecapturesChangedFillSource(t *testing.T) {
+// A write that lands after the request's archive snapshot no longer forces a
+// recapture. The answer is exact as of the snapshot the request opened with,
+// which is the intended bounded staleness: the session's own notification fill
+// makes the new state visible to the next request.
+func TestDailyUsageAnswersFromRequestSnapshot(t *testing.T) {
 	database := testDB(t)
 	started := "2026-08-10T08:00:00Z"
 	insertSession(t, database, "moving", "keep", func(session *Session) {
@@ -336,10 +351,13 @@ func TestDailyUsageRecapturesChangedFillSource(t *testing.T) {
 	if stored := mutationErr.Load(); stored != nil {
 		require.NoError(t, stored.(error))
 	}
-	assert.Zero(t, daily.Totals.InputTokens)
+	assert.Equal(t, 1, daily.Totals.InputTokens)
 }
 
-func TestUsageCacheFillBoundsMovingFingerprintRetries(t *testing.T) {
+// A source fingerprint that keeps moving used to exhaust the fill's retry
+// budget and fail. One archive read transaction is now always enough, so the
+// fill extracts once and succeeds no matter how often the session is written.
+func TestUsageCacheFillCompletesUnderContinuousWrites(t *testing.T) {
 	database := usageCandidateFixture(t)
 	snapshot, err := database.captureUsageQuery(
 		context.Background(), UsageFilter{}, usageQueryKindToken,
@@ -357,11 +375,11 @@ func TestUsageCacheFillBoundsMovingFingerprintRetries(t *testing.T) {
 				fmt.Sprintf("moving-%d", n), version.SessionID)
 		},
 	}
-	_, err = cache.fill.Ensure(context.Background(), []usageSourceVersion{version}, 0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(),
-		"usage cache fill could not verify archive state after 3 attempts")
-	assert.Equal(t, int32(3), mutations.Load())
+	results, err := cache.fill.Ensure(
+		context.Background(), []usageSourceVersion{version}, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), mutations.Load())
+	assert.False(t, results[version.SessionID].Deleted)
 }
 
 func TestUsageCacheFillTwoHandlesRaceIdempotently(t *testing.T) {

--- a/internal/db/usage_cache_live_write_test.go
+++ b/internal/db/usage_cache_live_write_test.go
@@ -1,0 +1,152 @@
+//go:build fts5
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedLiveWriteSession inserts one session whose message carries a unique
+// Claude identity, so sessions in these tests never share a dedup group.
+func seedLiveWriteSession(
+	t *testing.T, database *DB, id, project, timestamp string,
+	ordinal, input int,
+) {
+	t.Helper()
+	started := timestamp
+	insertSession(t, database, id, project, func(session *Session) {
+		session.StartedAt = &started
+		session.Agent = "claude"
+	})
+	appendLiveWriteMessage(t, database, id, timestamp, ordinal, input)
+}
+
+func appendLiveWriteMessage(
+	t *testing.T, database *DB, id, timestamp string, ordinal, input int,
+) {
+	t.Helper()
+	suffix := id + "-" + strconv.Itoa(ordinal)
+	require.NoError(t, database.InsertMessages([]Message{{
+		SessionID: id, Ordinal: ordinal, Role: "assistant",
+		Timestamp: timestamp, Model: "model-a",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":` + strconv.Itoa(input) + `}`),
+		ClaudeMessageID: "message-" + suffix,
+		ClaudeRequestID: "request-" + suffix,
+	}}))
+}
+
+func liveWriteDailyInput(t *testing.T, database *DB, project string) int {
+	t.Helper()
+	daily, err := database.GetDailyUsage(context.Background(), UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+		Project: project, SkipSessionCounts: true,
+	})
+	require.NoError(t, err)
+	return daily.Totals.InputTokens
+}
+
+// A rollup build reads only committed per-session facts, so an archive write
+// landing while it runs can never abort it. The rollup coordinator's
+// beforeEnsure seam runs on the detached build goroutine, after this request's
+// facts are already filled, which is exactly the window that used to fail.
+func TestUsageSummarySurvivesArchiveWriteDuringRollupBuild(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		writtenID     string
+		wantDuring    []int
+		wantAfterFill int
+	}{
+		{
+			// A session the summary does not report cannot influence it at
+			// all, so the answer is unchanged in both directions.
+			name: "write outside the filter", writtenID: "other-project",
+			wantDuring: []int{10}, wantAfterFill: 10,
+		},
+		{
+			// An in-scope append is either invisible to this request or
+			// already part of it, but never an error.
+			name: "append inside the filter", writtenID: "reported",
+			wantDuring: []int{10, 17}, wantAfterFill: 17,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			database := testDB(t)
+			seedLiveWriteSession(t, database, "reported", "keep",
+				"2026-08-10T09:00:00Z", 0, 10)
+			seedLiveWriteSession(t, database, "other-project", "drop",
+				"2026-08-10T09:30:00Z", 0, 4)
+			require.Equal(t, 10, liveWriteDailyInput(t, database, "keep"))
+
+			snapshot, err := database.captureUsageQuery(
+				context.Background(), UsageFilter{}, usageQueryKindToken)
+			require.NoError(t, err)
+			cache, err := database.usageCache.Generation(
+				context.Background(), snapshot.DatabaseID)
+			require.NoError(t, err)
+			var written atomic.Bool
+			cache.rollup.observer.beforeEnsure = func() {
+				if written.Swap(true) {
+					return
+				}
+				appendLiveWriteMessage(t, database, testCase.writtenID,
+					"2026-08-10T09:45:00Z", 1, 7)
+			}
+			assert.Contains(t, testCase.wantDuring,
+				liveWriteDailyInput(t, database, "keep"))
+			assert.True(t, written.Load(), "the build seam never ran")
+
+			cache.rollup.observer.beforeEnsure = nil
+			assert.Equal(t, testCase.wantAfterFill,
+				liveWriteDailyInput(t, database, "keep"))
+		})
+	}
+}
+
+// The coverage pass used to restart itself, and then give up, whenever the
+// archive moved underneath it. Facts now come from each session's own read
+// snapshot, so a pass finishes against a continuously written archive.
+func TestUsageCacheBackfillCompletesUnderConcurrentArchiveWrites(t *testing.T) {
+	database := testDB(t)
+	for index := range 4 {
+		id := "churn-" + strconv.Itoa(index)
+		seedLiveWriteSession(t, database, id, "project",
+			"2026-08-10T09:00:00Z", 0, 1)
+	}
+	snapshot, err := database.captureUsageQuery(
+		context.Background(), UsageFilter{}, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(
+		context.Background(), snapshot.DatabaseID)
+	require.NoError(t, err)
+	// Write into the archive from both phases of the pass: while facts are
+	// being extracted, and while the rollups are being aggregated.
+	var appends atomic.Int32
+	churn := func() {
+		ordinal := int(appends.Add(1))
+		appendLiveWriteMessage(t, database, "churn-0",
+			"2026-08-10T09:00:00Z", ordinal, 1)
+	}
+	cache.fill.observer.afterExtract = func([]usageSourceVersion) { churn() }
+	cache.rollup.observer.beforeEnsure = churn
+
+	require.NoError(t, database.StartUsageCacheBackfill(context.Background()))
+	require.NoError(t, database.WaitUsageCacheBackfill(context.Background()))
+	written := int(appends.Load())
+	require.Positive(t, written)
+	assert.Equal(t, 4, usageCacheCount(t, cache, "usage_cached_sessions"))
+	assert.Equal(t, 4, usageCacheCount(t, cache, "usage_rollup_installs"))
+
+	cache.fill.observer.afterExtract = nil
+	cache.rollup.observer.beforeEnsure = nil
+	// Every write the pass raced is still accounted for once the next
+	// request refills the session it touched.
+	assert.Equal(t, 4+written, liveWriteDailyInput(t, database, "project"))
+}

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -333,7 +333,7 @@ func (m *usageCacheManager) Generation(
 	m.generations[databaseID] = cache
 	if m.archive != nil {
 		cache.fill = newUsageFillCoordinator(cacheContext, m.archive, cache)
-		cache.rollup = newUsageRollupCoordinator(cacheContext, m.archive, cache)
+		cache.rollup = newUsageRollupCoordinator(cacheContext, cache)
 	}
 	if !cache.temporary {
 		if err := retireStaleUsageCacheGenerations(

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -6,10 +6,10 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,6 +21,11 @@ import (
 )
 
 const usageRollupCursorSessionID = "\x00cursor"
+
+// usageRollupMaxBuildAttempts bounds the reclassification retry an install
+// transaction can request when a concurrent fill changes dedup membership.
+// Each attempt reads freshly committed facts, so it makes real progress.
+const usageRollupMaxBuildAttempts = 8
 
 type usageTimezoneIdentity struct {
 	Key, Name, IntervalFingerprint string
@@ -199,8 +204,10 @@ type usageRollupObserver struct {
 	beforeEnsure func()
 }
 
+// usageRollupCoordinator aggregates committed per-session facts out of the
+// usage cache. It deliberately holds no archive handle: the archive is read
+// only when a session's facts are filled.
 type usageRollupCoordinator struct {
-	archive  *DB
 	cache    *usageCache
 	ctx      context.Context
 	mu       sync.Mutex
@@ -209,10 +216,10 @@ type usageRollupCoordinator struct {
 }
 
 func newUsageRollupCoordinator(
-	ctx context.Context, archive *DB, cache *usageCache,
+	ctx context.Context, cache *usageCache,
 ) *usageRollupCoordinator {
 	return &usageRollupCoordinator{
-		archive: archive, cache: cache, ctx: ctx,
+		cache: cache, ctx: ctx,
 		calls: make(map[string]*usageRollupCall),
 	}
 }
@@ -261,6 +268,10 @@ func (c *usageRollupCoordinator) Ensure(
 	}
 }
 
+// ensureNow aggregates committed per-session facts out of the usage cache. It
+// never reads the archive, so an append landing mid-build cannot invalidate
+// it: that session's own notification fill installs new facts, which makes its
+// rollup install stale and rebuilds it on a later aggregation.
 func (c *usageRollupCoordinator) ensureNow(
 	ctx context.Context, snapshot usageQuerySnapshot,
 	fills map[string]usageFillResult, resolver *export.PricingResolver,
@@ -272,13 +283,45 @@ func (c *usageRollupCoordinator) ensureNow(
 		return nil, usageRollupMetrics{}, err
 	}
 	defer conn.Close()
+	var metrics usageRollupMetrics
+	// A concurrent fill can add a sibling to a dedup identity this build
+	// finalized, which the install transaction rejects. Reclassify against
+	// the newly committed facts instead of failing the caller.
+	for attempt := 1; ; attempt++ {
+		installs, done, attemptMetrics, attemptErr := c.ensureAttempt(
+			ctx, conn, identity, snapshot, fills, resolver, pricingHash)
+		metrics.DailyRows += attemptMetrics.DailyRows
+		metrics.ExceptionRows += attemptMetrics.ExceptionRows
+		metrics.ExceptionGroups += attemptMetrics.ExceptionGroups
+		metrics.BuildDuration += attemptMetrics.BuildDuration
+		metrics.InstallDuration += attemptMetrics.InstallDuration
+		if attemptErr != nil {
+			return nil, metrics, attemptErr
+		}
+		if done {
+			return installs, metrics, nil
+		}
+		if attempt >= usageRollupMaxBuildAttempts {
+			return nil, metrics, fmt.Errorf(
+				"usage rollup build kept losing dedup classification races")
+		}
+	}
+}
+
+// ensureAttempt performs one read-build-install cycle. It reports done when
+// every in-scope install matches the facts and metadata it must reflect.
+func (c *usageRollupCoordinator) ensureAttempt(
+	ctx context.Context, conn *sql.Conn, identity usageTimezoneIdentity,
+	snapshot usageQuerySnapshot, fills map[string]usageFillResult,
+	resolver *export.PricingResolver, pricingHash string,
+) (map[string]usageRollupInstall, bool, usageRollupMetrics, error) {
 	installs, stale, err := readUsageRollupInstalls(
 		ctx, conn, identity, snapshot, fills, pricingHash)
 	if err != nil || len(stale) == 0 {
 		cursorCurrent := installs[usageRollupCursorSessionID].FactRevision >=
 			snapshot.CursorHighWater
 		if err != nil || cursorCurrent {
-			return installs, usageRollupMetrics{}, err
+			return installs, err == nil, usageRollupMetrics{}, err
 		}
 	}
 	staleSessions := make(map[string]usageQuerySession, len(stale))
@@ -290,31 +333,35 @@ func (c *usageRollupCoordinator) ensureNow(
 		}
 	}
 	for _, version := range snapshot.Versions {
-		if stale[version.SessionID] {
-			staleVersions[version.SessionID] = version
-			staleFills[version.SessionID] = fills[version.SessionID]
+		if !stale[version.SessionID] {
+			continue
 		}
+		fill := fills[version.SessionID]
+		// Record the source version the cached facts came from, not the
+		// one the caller's archive snapshot observed.
+		staleVersions[version.SessionID] = fill.source
+		staleFills[version.SessionID] = fill
 	}
 	started := time.Now()
 	facts, err := loadUsageRollupFacts(ctx, conn, staleSessions)
 	if err != nil {
-		return nil, usageRollupMetrics{}, err
+		return nil, false, usageRollupMetrics{}, err
 	}
 	cross, err := loadUsageRollupCrossIdentities(ctx, conn)
 	if err != nil {
-		return nil, usageRollupMetrics{}, err
+		return nil, false, usageRollupMetrics{}, err
 	}
 	builds, err := buildUsageRollupSessions(
 		facts, staleSessions, staleVersions, staleFills, snapshot.location,
 		resolver, pricingHash, cross)
 	if err != nil {
-		return nil, usageRollupMetrics{}, err
+		return nil, false, usageRollupMetrics{}, err
 	}
 	if installs[usageRollupCursorSessionID].FactRevision < snapshot.CursorHighWater {
 		cursorBuild, cursorErr := loadCursorUsageRollupBuild(
 			ctx, conn, snapshot.CursorHighWater, snapshot.location, pricingHash)
 		if cursorErr != nil {
-			return nil, usageRollupMetrics{}, cursorErr
+			return nil, false, usageRollupMetrics{}, cursorErr
 		}
 		builds = append(builds, cursorBuild)
 	}
@@ -328,27 +375,29 @@ func (c *usageRollupCoordinator) ensureNow(
 		}
 		metrics.ExceptionGroups += int64(len(groups))
 	}
-	if err := c.recheck(ctx, staleVersions, staleSessions); err != nil {
-		return nil, metrics, err
-	}
 	installStarted := time.Now()
-	if err := installUsageRollupBuilds(
-		ctx, conn, identity, snapshot.location, builds, cross); err != nil {
-		return nil, metrics, err
-	}
+	err = installUsageRollupBuilds(
+		ctx, conn, identity, snapshot.location, builds, cross)
 	metrics.InstallDuration = time.Since(installStarted)
+	if err != nil {
+		if errors.Is(err, errUsageCacheSourceChanged) {
+			return nil, false, metrics, nil
+		}
+		return nil, false, metrics, err
+	}
 	installs, stale, err = readUsageRollupInstalls(
 		ctx, conn, identity, snapshot, fills, pricingHash)
 	if err != nil {
-		return nil, metrics, err
+		return nil, false, metrics, err
 	}
-	if len(stale) != 0 {
-		return nil, metrics, fmt.Errorf("usage rollup install did not verify")
+	if len(stale) != 0 ||
+		installs[usageRollupCursorSessionID].FactRevision < snapshot.CursorHighWater {
+		// Another builder installed a different generation of one of these
+		// sessions while this one was building. Its facts are committed, so
+		// the next attempt sees them.
+		return nil, false, metrics, nil
 	}
-	if installs[usageRollupCursorSessionID].FactRevision < snapshot.CursorHighWater {
-		return nil, metrics, fmt.Errorf("Cursor usage rollup install did not verify")
-	}
-	return installs, metrics, nil
+	return installs, true, metrics, nil
 }
 
 func readUsageRollupInstalls(
@@ -393,6 +442,9 @@ func readUsageRollupInstalls(
 	for _, session := range snapshot.Sessions {
 		sessions[session.ID] = session
 	}
+	// Staleness is decided entirely against the usage cache: an install is
+	// stale when the per-session facts it was built from are no longer the
+	// facts the cache holds. The archive is not consulted here.
 	stale := make(map[string]bool)
 	for _, version := range snapshot.Versions {
 		fill := fills[version.SessionID]
@@ -402,74 +454,13 @@ func readUsageRollupInstalls(
 			continue
 		}
 		if !ok || item.FactRevision != fill.InstallRevision ||
-			!sources[version.SessionID].Equal(version) ||
+			!sources[version.SessionID].Equal(fill.source) ||
 			baked[version.SessionID] != [2]string{session.Agent, session.StartedAt} ||
 			pricing[version.SessionID] != pricingHash {
 			stale[version.SessionID] = true
 		}
 	}
 	return installs, stale, nil
-}
-
-func (c *usageRollupCoordinator) recheck(
-	ctx context.Context, versions map[string]usageSourceVersion,
-	sessions map[string]usageQuerySession,
-) error {
-	observed := make([]usageSourceVersion, 0, len(versions))
-	for _, version := range versions {
-		observed = append(observed, version)
-	}
-	slices.SortFunc(observed, func(a, b usageSourceVersion) int {
-		return compareStrings(a.SessionID, b.SessionID)
-	})
-	current, err := c.cache.fill.recheckSourceVersions(ctx, observed)
-	if err != nil {
-		return err
-	}
-	for _, version := range observed {
-		if value, ok := current[version.SessionID]; !ok || !value.Equal(version) {
-			return fmt.Errorf("%w during rollup build", errUsageCacheSourceChanged)
-		}
-	}
-	metadata, err := c.currentMetadata(ctx, observed)
-	if err != nil {
-		return err
-	}
-	for id, session := range sessions {
-		if metadata[id] != [2]string{session.Agent, session.StartedAt} {
-			return fmt.Errorf("%w during rollup metadata check", errUsageCacheSourceChanged)
-		}
-	}
-	return nil
-}
-
-func (c *usageRollupCoordinator) currentMetadata(
-	ctx context.Context, versions []usageSourceVersion,
-) (map[string][2]string, error) {
-	ids := make([]string, 0, len(versions))
-	for _, version := range versions {
-		ids = append(ids, version.SessionID)
-	}
-	result := make(map[string][2]string, len(ids))
-	err := queryChunked(ids, func(chunk []string) error {
-		placeholders, args := inPlaceholders(chunk)
-		rows, err := c.archive.getReader().QueryContext(ctx, `SELECT id, agent,
-			COALESCE(started_at, '') FROM sessions
-			WHERE deleted_at IS NULL AND id IN `+placeholders, args...)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var id, agent, startedAt string
-			if err := rows.Scan(&id, &agent, &startedAt); err != nil {
-				return err
-			}
-			result[id] = [2]string{agent, startedAt}
-		}
-		return rows.Err()
-	})
-	return result, err
 }
 
 func installUsageRollupBuilds(
@@ -683,8 +674,14 @@ func usageRollupCallKey(
 		sessions[session.ID] = session
 	}
 	for _, version := range snapshot.Versions {
-		writeUsageHashString(digest, usageFillCallKey(version))
-		writeUsageHashInt64(digest, fills[version.SessionID].InstallRevision)
+		fill := fills[version.SessionID]
+		// Key on the source the cached facts came from so two requests
+		// whose archive snapshots differ still share one build when the
+		// facts they aggregate are identical.
+		writeUsageHashString(digest, version.SessionID)
+		writeUsageHashString(digest, usageFillCallKey(fill.source))
+		writeUsageHashInt64(digest, fill.InstallRevision)
+		writeUsageHashBool(digest, fill.Deleted)
 		session := sessions[version.SessionID]
 		writeUsageHashString(digest, session.Agent)
 		writeUsageHashString(digest, session.StartedAt)

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"maps"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -201,7 +203,8 @@ type usageRollupCall struct {
 }
 
 type usageRollupObserver struct {
-	beforeEnsure func()
+	beforeEnsure  func()
+	beforeInstall func([]usageRollupBuild)
 }
 
 // usageRollupCoordinator aggregates committed per-session facts out of the
@@ -284,12 +287,14 @@ func (c *usageRollupCoordinator) ensureNow(
 	}
 	defer conn.Close()
 	var metrics usageRollupMetrics
-	// A concurrent fill can add a sibling to a dedup identity this build
-	// finalized, which the install transaction rejects. Reclassify against
-	// the newly committed facts instead of failing the caller.
+	currentFills := maps.Clone(fills)
+	// A concurrent fill can replace a session's facts or add a sibling to a
+	// dedup identity this build finalized. The install transaction rejects
+	// both races. Refresh committed facts before the next attempt instead of
+	// failing the caller.
 	for attempt := 1; ; attempt++ {
 		installs, done, attemptMetrics, attemptErr := c.ensureAttempt(
-			ctx, conn, identity, snapshot, fills, resolver, pricingHash)
+			ctx, conn, identity, snapshot, currentFills, resolver, pricingHash)
 		metrics.DailyRows += attemptMetrics.DailyRows
 		metrics.ExceptionRows += attemptMetrics.ExceptionRows
 		metrics.ExceptionGroups += attemptMetrics.ExceptionGroups
@@ -300,6 +305,11 @@ func (c *usageRollupCoordinator) ensureNow(
 		}
 		if done {
 			return installs, metrics, nil
+		}
+		currentFills, err = readCurrentUsageFillResults(
+			ctx, conn, snapshot.Versions)
+		if err != nil {
+			return nil, metrics, err
 		}
 		if attempt >= usageRollupMaxBuildAttempts {
 			return nil, metrics, fmt.Errorf(
@@ -376,6 +386,9 @@ func (c *usageRollupCoordinator) ensureAttempt(
 		metrics.ExceptionGroups += int64(len(groups))
 	}
 	installStarted := time.Now()
+	if c.observer.beforeInstall != nil {
+		c.observer.beforeInstall(slices.Clone(builds))
+	}
 	err = installUsageRollupBuilds(
 		ctx, conn, identity, snapshot.location, builds, cross)
 	metrics.InstallDuration = time.Since(installStarted)
@@ -398,6 +411,31 @@ func (c *usageRollupCoordinator) ensureAttempt(
 		return nil, false, metrics, nil
 	}
 	return installs, true, metrics, nil
+}
+
+func readCurrentUsageFillResults(
+	ctx context.Context, conn *sql.Conn, versions []usageSourceVersion,
+) (map[string]usageFillResult, error) {
+	results := make(map[string]usageFillResult, len(versions))
+	for _, version := range versions {
+		var result usageFillResult
+		err := conn.QueryRowContext(ctx, `SELECT source_sync_marker,
+			source_transcript_rev, usage_event_fingerprint, install_revision
+			FROM usage_cached_sessions WHERE session_id = ?`, version.SessionID).Scan(
+			&result.source.SyncMarker, &result.source.TranscriptRevision,
+			&result.source.UsageEventFingerprint, &result.InstallRevision)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf(
+				"%w: usage facts disappeared during rollup build",
+				errUsageCacheSourceChanged)
+		}
+		if err != nil {
+			return nil, err
+		}
+		result.source.SessionID = version.SessionID
+		results[version.SessionID] = result
+	}
+	return results, nil
 }
 
 func readUsageRollupInstalls(
@@ -494,6 +532,28 @@ func installUsageRollupBuilds(
 		return fmt.Errorf(
 			"%w: dedup identities gained members during rollup build",
 			errUsageCacheSourceChanged)
+	}
+	for _, build := range builds {
+		if build.SessionID == usageRollupCursorSessionID {
+			continue
+		}
+		var current usageFillResult
+		err := conn.QueryRowContext(ctx, `SELECT source_sync_marker,
+			source_transcript_rev, usage_event_fingerprint, install_revision
+			FROM usage_cached_sessions WHERE session_id = ?`, build.SessionID).Scan(
+			&current.source.SyncMarker, &current.source.TranscriptRevision,
+			&current.source.UsageEventFingerprint, &current.InstallRevision)
+		current.source.SessionID = build.SessionID
+		if errors.Is(err, sql.ErrNoRows) || err == nil &&
+			(current.InstallRevision != build.FactRevision ||
+				!current.source.Equal(build.Source)) {
+			return fmt.Errorf(
+				"%w: usage facts changed during rollup build",
+				errUsageCacheSourceChanged)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	if _, err := conn.ExecContext(ctx, `INSERT INTO usage_rollup_timezones(

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -425,9 +425,8 @@ func readCurrentUsageFillResults(
 			&result.source.SyncMarker, &result.source.TranscriptRevision,
 			&result.source.UsageEventFingerprint, &result.InstallRevision)
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf(
-				"%w: usage facts disappeared during rollup build",
-				errUsageCacheSourceChanged)
+			results[version.SessionID] = usageFillResult{Deleted: true}
+			continue
 		}
 		if err != nil {
 			return nil, err
@@ -582,10 +581,19 @@ func installUsageRollupBuilds(
 	dates := make(map[string]bool)
 	for _, build := range builds {
 		var installID int64
-		err := conn.QueryRowContext(ctx, `SELECT id FROM usage_rollup_installs
-			WHERE timezone_id = ? AND session_id = ?`, timezoneID, build.SessionID).Scan(&installID)
+		var installedFactRevision int64
+		err := conn.QueryRowContext(ctx, `SELECT id, fact_install_revision
+			FROM usage_rollup_installs
+			WHERE timezone_id = ? AND session_id = ?`, timezoneID, build.SessionID).
+			Scan(&installID, &installedFactRevision)
 		if err != nil && err != sql.ErrNoRows {
 			return err
+		}
+		if err == nil && build.SessionID == usageRollupCursorSessionID &&
+			installedFactRevision > build.FactRevision {
+			return fmt.Errorf(
+				"%w: Cursor usage advanced during rollup build",
+				errUsageCacheSourceChanged)
 		}
 		if err == nil {
 			for _, table := range []string{

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -707,13 +707,3 @@ func writeUsageHashBool(digest hash.Hash, value bool) {
 		writeUsageHashInt64(digest, 0)
 	}
 }
-
-func compareStrings(left, right string) int {
-	if left < right {
-		return -1
-	}
-	if left > right {
-		return 1
-	}
-	return 0
-}

--- a/internal/db/usage_rollup_lifecycle_test.go
+++ b/internal/db/usage_rollup_lifecycle_test.go
@@ -538,6 +538,80 @@ func TestUsageRollupOlderBuildCannotReplaceNewerFacts(t *testing.T) {
 	assert.Equal(t, int64(20), result.Groups[0].OutputTokens)
 }
 
+func TestUsageRollupOlderCursorBuildCannotReplaceNewerEvents(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.InsertCursorUsageEvents([]CursorUsageEvent{{
+		OccurredAt: "2026-08-10T09:00:00Z", Model: "cursor-model",
+		InputTokens: 1, DedupKey: "cursor-one",
+	}}))
+	filter := UsageFilter{Timezone: "UTC", SkipSessionCounts: true}
+	oldSnapshot, err := database.captureUsageQuery(
+		t.Context(), filter, usageQueryKindToken)
+	require.NoError(t, err)
+	cache, err := database.usageCache.Generation(t.Context(), oldSnapshot.DatabaseID)
+	require.NoError(t, err)
+	oldFills, err := cache.fill.Ensure(
+		t.Context(), nil, oldSnapshot.CursorHighWater)
+	require.NoError(t, err)
+	oldBuilt := make(chan struct{})
+	releaseOld := make(chan struct{})
+	var blocked atomic.Bool
+	cache.rollup.observer.beforeInstall = func(builds []usageRollupBuild) {
+		for _, build := range builds {
+			if build.SessionID != usageRollupCursorSessionID ||
+				build.FactRevision != oldSnapshot.CursorHighWater ||
+				!blocked.CompareAndSwap(false, true) {
+				continue
+			}
+			close(oldBuilt)
+			<-releaseOld
+		}
+	}
+	type cursorRollupOutcome struct {
+		installs map[string]usageRollupInstall
+		err      error
+	}
+	oldDone := make(chan cursorRollupOutcome, 1)
+	go func() {
+		installs, _, ensureErr := cache.rollup.Ensure(
+			t.Context(), oldSnapshot, oldFills,
+			export.NewPricingResolver(oldSnapshot.PricingRows))
+		oldDone <- cursorRollupOutcome{installs: installs, err: ensureErr}
+	}()
+	<-oldBuilt
+	require.NoError(t, database.InsertCursorUsageEvents([]CursorUsageEvent{{
+		OccurredAt: "2026-08-10T10:00:00Z", Model: "cursor-model",
+		InputTokens: 2, DedupKey: "cursor-two",
+	}}))
+	newSnapshot, err := database.captureUsageQuery(
+		t.Context(), filter, usageQueryKindToken)
+	require.NoError(t, err)
+	newFills, err := cache.fill.Ensure(
+		t.Context(), nil, newSnapshot.CursorHighWater)
+	require.NoError(t, err)
+	newInstalls, _, err := cache.rollup.Ensure(
+		t.Context(), newSnapshot, newFills,
+		export.NewPricingResolver(newSnapshot.PricingRows))
+	require.NoError(t, err)
+	close(releaseOld)
+	oldOutcome := <-oldDone
+	require.NoError(t, oldOutcome.err)
+	assert.Equal(t, newSnapshot.CursorHighWater,
+		oldOutcome.installs[usageRollupCursorSessionID].FactRevision)
+	assert.Equal(t, newInstalls[usageRollupCursorSessionID].InstallRevision,
+		oldOutcome.installs[usageRollupCursorSessionID].InstallRevision)
+
+	result, err := cache.usageRollupQuery(
+		t.Context(), newSnapshot, filter, newInstalls,
+		export.NewPricingResolver(newSnapshot.PricingRows))
+	require.NoError(t, err)
+	var inputTokens int64
+	for _, group := range result.Groups {
+		inputTokens += group.InputTokens
+	}
+	assert.Equal(t, int64(3), inputTokens)
+}
+
 func prepareUsageRollupTest(
 	t *testing.T, database *DB,
 ) (usageQuerySnapshot, map[string]usageFillResult, *usageCache) {

--- a/internal/db/usage_rollup_lifecycle_test.go
+++ b/internal/db/usage_rollup_lifecycle_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -475,6 +476,66 @@ func TestUsageRollupConnectedSnapshotChangeRebuildsOnlyChangedSession(t *testing
 	assert.Equal(t, 2, daily.Totals.InputTokens)
 	assert.Equal(t, 30, daily.Totals.OutputTokens,
 		"the changed sibling must immediately replace the snapshot winner")
+}
+
+func TestUsageRollupOlderBuildCannotReplaceNewerFacts(t *testing.T) {
+	database := testDB(t)
+	seedUsageSnapshotSession(t, database, "rollup-race", "project-a",
+		"2026-08-10T09:00:00Z", 0, 10, "model-a")
+	oldSnapshot, oldFills, cache := prepareUsageRollupTest(t, database)
+	oldRevision := oldFills["rollup-race"].InstallRevision
+	oldBuilt := make(chan struct{})
+	releaseOld := make(chan struct{})
+	var blocked atomic.Bool
+	cache.rollup.observer.beforeInstall = func(builds []usageRollupBuild) {
+		if len(builds) != 1 || builds[0].FactRevision != oldRevision ||
+			!blocked.CompareAndSwap(false, true) {
+			return
+		}
+		close(oldBuilt)
+		<-releaseOld
+	}
+	type rollupOutcome struct {
+		installs map[string]usageRollupInstall
+		err      error
+	}
+	oldDone := make(chan rollupOutcome, 1)
+	go func() {
+		installs, _, ensureErr := cache.rollup.Ensure(
+			t.Context(), oldSnapshot, oldFills,
+			export.NewPricingResolver(oldSnapshot.PricingRows))
+		oldDone <- rollupOutcome{installs: installs, err: ensureErr}
+	}()
+	<-oldBuilt
+	tx, err := database.getWriter().BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	_, err = tx.Exec(`UPDATE messages SET token_usage = '{"output_tokens":20}'
+		WHERE session_id = 'rollup-race'`)
+	require.NoError(t, err)
+	_, err = tx.Exec(`UPDATE sessions SET transcript_revision = 'newer'
+		WHERE id = 'rollup-race'`)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	newSnapshot, newFills, _ := prepareUsageRollupTest(t, database)
+	newInstalls, _, err := cache.rollup.Ensure(
+		t.Context(), newSnapshot, newFills,
+		export.NewPricingResolver(newSnapshot.PricingRows))
+	require.NoError(t, err)
+	close(releaseOld)
+	oldOutcome := <-oldDone
+	require.NoError(t, oldOutcome.err)
+	assert.Equal(t, newInstalls["rollup-race"].InstallRevision,
+		oldOutcome.installs["rollup-race"].InstallRevision)
+
+	filter := UsageFilter{
+		From: "2026-08-10", To: "2026-08-10", Timezone: "UTC",
+	}
+	result, err := cache.usageRollupQuery(
+		t.Context(), newSnapshot, filter, oldOutcome.installs,
+		export.NewPricingResolver(newSnapshot.PricingRows))
+	require.NoError(t, err)
+	require.Len(t, result.Groups, 1)
+	assert.Equal(t, int64(20), result.Groups[0].OutputTokens)
 }
 
 func prepareUsageRollupTest(

--- a/internal/db/usage_rollup_query.go
+++ b/internal/db/usage_rollup_query.go
@@ -159,7 +159,12 @@ func verifyUsageRollupInstall(
 		}
 		return err
 	}
-	if revision != required.InstallRevision || pricingHash != required.PricingHash {
+	// A rebuild between the build and this read raises the install revision
+	// and leaves a newer, internally consistent set of rows for the same
+	// session. That is never older than the caller's archive snapshot, so
+	// read it rather than failing the request. Rollup installs already mix
+	// per-session generations across requests, so this adds no new mixing.
+	if revision < required.InstallRevision || pricingHash != required.PricingHash {
 		return fmt.Errorf("%w: usage rollup session %s changed before read",
 			errUsageCacheSourceChanged, sessionID)
 	}

--- a/internal/db/usage_rollup_query.go
+++ b/internal/db/usage_rollup_query.go
@@ -159,12 +159,10 @@ func verifyUsageRollupInstall(
 		}
 		return err
 	}
-	// A rebuild between the build and this read raises the install revision
-	// and leaves a newer, internally consistent set of rows for the same
-	// session. That is never older than the caller's archive snapshot, so
-	// read it rather than failing the request. Rollup installs already mix
-	// per-session generations across requests, so this adds no new mixing.
-	if revision < required.InstallRevision || pricingHash != required.PricingHash {
+	// The write sequence identifies the exact rows whose source and baked
+	// metadata Ensure checked. A different sequence can belong to a build from
+	// an older archive snapshot, even when its number is higher.
+	if revision != required.InstallRevision || pricingHash != required.PricingHash {
 		return fmt.Errorf("%w: usage rollup session %s changed before read",
 			errUsageCacheSourceChanged, sessionID)
 	}

--- a/internal/db/usage_rollup_query_test.go
+++ b/internal/db/usage_rollup_query_test.go
@@ -454,7 +454,10 @@ func TestUsageRollupSeededRandomParitySweep(t *testing.T) {
 	}
 }
 
-func TestUsageRollupQueryRecapturesAfterConcurrentInstall(t *testing.T) {
+// A newer install of the same session is a valid answer, so the read accepts a
+// raised install revision instead of recapturing. Only a changed pricing hash,
+// which means the rows were priced differently, still forces a recapture.
+func TestUsageRollupQueryAcceptsNewerInstallRejectsRepricedOne(t *testing.T) {
 	database := testDB(t)
 	seedUsageSnapshotSession(t, database, "session-a", "project-a",
 		"2026-08-10T09:00:00Z", 0, 10, "model-a")
@@ -473,6 +476,12 @@ func TestUsageRollupQueryRecapturesAfterConcurrentInstall(t *testing.T) {
 		SET install_revision = install_revision + 1 WHERE id = ?`, required.ID)
 	require.NoError(t, err)
 
+	_, err = cache.usageRollupQuery(t.Context(), snapshot, filter, installs, resolver)
+	assert.NoError(t, err)
+	_, err = cache.db.Exec(`UPDATE usage_rollup_installs
+		SET install_revision = ? WHERE id = ?`,
+		required.InstallRevision-1, required.ID)
+	require.NoError(t, err)
 	_, err = cache.usageRollupQuery(t.Context(), snapshot, filter, installs, resolver)
 	assert.ErrorIs(t, err, errUsageCacheSourceChanged)
 	_, err = cache.db.Exec(`UPDATE usage_rollup_installs

--- a/internal/db/usage_rollup_query_test.go
+++ b/internal/db/usage_rollup_query_test.go
@@ -454,10 +454,7 @@ func TestUsageRollupSeededRandomParitySweep(t *testing.T) {
 	}
 }
 
-// A newer install of the same session is a valid answer, so the read accepts a
-// raised install revision instead of recapturing. Only a changed pricing hash,
-// which means the rows were priced differently, still forces a recapture.
-func TestUsageRollupQueryAcceptsNewerInstallRejectsRepricedOne(t *testing.T) {
+func TestUsageRollupQueryRejectsDifferentInstallOrPricing(t *testing.T) {
 	database := testDB(t)
 	seedUsageSnapshotSession(t, database, "session-a", "project-a",
 		"2026-08-10T09:00:00Z", 0, 10, "model-a")
@@ -477,7 +474,7 @@ func TestUsageRollupQueryAcceptsNewerInstallRejectsRepricedOne(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cache.usageRollupQuery(t.Context(), snapshot, filter, installs, resolver)
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, errUsageCacheSourceChanged)
 	_, err = cache.db.Exec(`UPDATE usage_rollup_installs
 		SET install_revision = ? WHERE id = ?`,
 		required.InstallRevision-1, required.ID)


### PR DESCRIPTION
Usage summaries now complete while live sessions continue writing to the
archive. Previously, one session changing during a multi-session build could
invalidate the whole request and make the usage endpoint return an error after
its retry limit.

Fact extraction now reads each session's facts and source version from one
archive snapshot. The cache install compares its current revision with the
revision observed before extraction. If another fill installed different facts
first, only the sessions that lost that race are extracted again. Source
fingerprints remain equality checks because they are not ordered versions.

Rollup builds stay on the usage-cache side of the archive boundary. Under the
cache write lock, each install verifies that its facts and source still match
the committed cached session. Readers require the exact rollup write sequence
that they verified, so a late build cannot look current merely because it wrote
last. An older Cursor build cannot replace one that already includes newer
events, and a session deleted during a rollup retry is skipped without aborting
the background cache pass.

The branch also streams recall evidence JSON directly into SHA-256. This
preserves the digest while avoiding the full temporary evidence buffer that
caused the allocation benchmark to vary after the rebase.

The concurrency-sensitive paths are `fillSessionsDetached` and
`installSpoolBatch` in `internal/db/usage_cache_fill.go`, plus `ensureAttempt`
and `installUsageRollupBuilds` in `internal/db/usage_rollup.go`.

Closes #1590
