### PR TITLE
fix(parser): preserve Antigravity CLI effort for experimental serving variants

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1801,10 +1801,10 @@ add an archived or maintained mirror without replacing the original identity.
   specification, or authoritative protobuf schema was found. The independent
   CodeBurn evidence pinned in the `antigravity` entry also covers CLI
   discovery, live RPC metadata, and the shorter capture window, but not the
-  encrypted producer format. Reverified 2026-08-20 against Google's official
-  [Antigravity CLI 1.1.16 macOS ARM64 release](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.16),
+  encrypted producer format. Reverified 2026-09-02 against Google's official
+  [Antigravity CLI 1.1.24 macOS ARM64 release](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.24),
   asset SHA-256
-  `a902e8b24fdc53504e7daf658e18f7ba47ebb9cfcf058aa6c01e37c5e610d389`. Its Go
+  `189af288ed9527f567ab3a53b35a6da2fc0c3812c6245f266c75a2a3604bdec3`. Its Go
   binary embeds `FileDescriptorProto` records for
   `third_party/jetski/cortex_pb/cortex.proto` and
   `third_party/jetski/codeium_common_pb/codeium_common.proto`. These compiled
@@ -1814,9 +1814,10 @@ add an archived or maintained mirror without replacing the original identity.
   input, output, thinking-output, cache-read, and model fields; output already
   includes thinking. In CLI 1.1.5 SQLite,
   `CortexStepGeneratorMetadata.step_indices` (field 2) contains packed step
-  indices and `ChatModelMetadata.response_model` (field 19) can contain only
-  the base model slug. The matching `ExecutorMetadata.last_step_idx` range
-  carries the effort-qualified model at
+  indices and `ChatModelMetadata.response_model` (field 19) can contain the
+  base model slug, and in CLI 1.1.24 can contain an experimental serving
+  variant such as `gemini-3.7-flash-exp-b`. The matching
+  `ExecutorMetadata.last_step_idx` range carries the effort-qualified model at
   `cascade_config.planner_config.model_name` (fields 10, 1, and 28).
   `ChatModelMetadata.model_display_name` (field 21) remains the complete label
   when present. Agentsview avoids double counting and catalog-prices usage. No

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1819,6 +1819,9 @@ add an archived or maintained mirror without replacing the original identity.
   variant such as `gemini-3.7-flash-exp-b`. The matching
   `ExecutorMetadata.last_step_idx` range carries the effort-qualified model at
   `cascade_config.planner_config.model_name` (fields 10, 1, and 28).
+  Agentsview normalizes observed serving canary suffixes (such as `-exp-b`)
+  against the covering executor model, while preserving distinct product
+  models ending in generic `-exp` (such as `gemini-2.0-flash-exp`).
   `ChatModelMetadata.model_display_name` (field 21) remains the complete label
   when present. Agentsview avoids double counting and catalog-prices usage. No
   provider USD cost is consumed.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -458,7 +458,11 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // (98: The Pi parser now attributes skill loads (SKILL.md
 // reads and skill:// URIs) so Pi tool calls count toward Top Skills.
 // Existing Pi rows need re-parsing to backfill the skill attribution.)
-const dataVersion = 98
+// (99: the Antigravity CLI parser normalizes observed experimental serving
+// variant suffixes (-exp-b) against the matching effort-qualified executor
+// model. Existing Antigravity rows need re-parsing so stored messages and
+// usage events reflect the intended effort-qualified model.)
+const dataVersion = 99
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1090,6 +1090,11 @@ func TestCurrentDataVersionPiSkillAttribution(t *testing.T) {
 		"version 98 is the data-version boundary for Pi skill attribution")
 }
 
+func TestCurrentDataVersionAntigravityCLIExperimentalServingVariant(t *testing.T) {
+	assert.Equal(t, 99, CurrentDataVersion(),
+		"Antigravity CLI experimental serving variant normalization requires re-parsing usage events")
+}
+
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "s-events", "proj")

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -931,13 +931,13 @@ func resolveAntigravityGenerationModel(
 ) string {
 	generationModel, hasDisplayLabel :=
 		extractAntigravityGenerationModel(data)
-	if hasDisplayLabel {
+	if hasDisplayLabel || executorModel == "" {
 		return generationModel
 	}
-	if executorModel != "" && antigravityBaseModel(executorModel) == antigravityBaseModel(generationModel) {
+	if antigravityBaseModel(executorModel) == antigravityBaseModel(generationModel) {
 		return executorModel
 	}
-	return antigravityBaseModel(generationModel)
+	return generationModel
 }
 
 func antigravityBaseModel(model string) string {

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -945,6 +945,19 @@ func resolveAntigravityGenerationModel(
 	)
 }
 
+// resolveAntigravityModelName reconciles the model reported by downstream LLM
+// RPC generation metadata with the user's intended effort-qualified model from
+// the covering executor range.
+//
+// Antigravity CLI does not record reasoning effort in generation metadata
+// (field 19 response_model), recording only the base model slug or an internal
+// serving canary identifier (e.g. "gemini-3.7-flash-exp-b"). The effort
+// qualification (-low, -medium, -high) is recorded only in the covering
+// ExecutorMetadata. If the generation model matches the executor's base model
+// after stripping known experimental serving variants, the effort-qualified
+// executor model is returned so dashboard usage accounting is not fragmented.
+// If hasDisplayLabel is true or the models do not match, generationModel is
+// preserved unchanged.
 func resolveAntigravityModelName(
 	generationModel, executorModel string, hasDisplayLabel bool,
 ) string {
@@ -967,6 +980,21 @@ func antigravityBaseModel(model string) string {
 	return model
 }
 
+// stripAntigravityExperimentalVariant strips internal backend serving
+// experiment / canary suffixes (such as "-exp-b") observed in Antigravity CLI
+// RPC responses so the model can be matched against covering executor ranges.
+//
+// Guidance for adding future suffixes:
+//   - Only add exact, observed serving canary suffixes here (e.g. "-exp-a",
+//     "-exp-c") once verified against upstream captures.
+//   - DO NOT strip generic "-exp": standalone models exist whose canonical
+//     name ends in "-exp" (e.g. "gemini-2.0-flash-exp"). Stripping generic
+//     "-exp" causes false-positive matches against -high/-medium/-low executors
+//     and incorrectly overrides the user's chosen model.
+//   - Adding or modifying suffixes alters historical session parsing: always
+//     bump dataVersion in internal/db/db.go, update the provenance notes in
+//     docs/internal/session-format-sources.md, and add regression tests in
+//     internal/parser/antigravity_test.go.
 func stripAntigravityExperimentalVariant(model string) string {
 	if base, ok := strings.CutSuffix(model, "-exp-b"); ok {
 		return base

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -611,6 +611,9 @@ func executorModelForStep(
 			return executor.modelName
 		}
 	}
+	if len(executors) > 0 {
+		return executors[len(executors)-1].modelName
+	}
 	return ""
 }
 
@@ -928,13 +931,13 @@ func resolveAntigravityGenerationModel(
 ) string {
 	generationModel, hasDisplayLabel :=
 		extractAntigravityGenerationModel(data)
-	if hasDisplayLabel || executorModel == "" {
+	if hasDisplayLabel {
 		return generationModel
 	}
-	if antigravityBaseModel(executorModel) == antigravityBaseModel(generationModel) {
+	if executorModel != "" && antigravityBaseModel(executorModel) == antigravityBaseModel(generationModel) {
 		return executorModel
 	}
-	return generationModel
+	return antigravityBaseModel(generationModel)
 }
 
 func antigravityBaseModel(model string) string {

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -611,9 +611,6 @@ func executorModelForStep(
 			return executor.modelName
 		}
 	}
-	if len(executors) > 0 {
-		return executors[len(executors)-1].modelName
-	}
 	return ""
 }
 
@@ -934,24 +931,25 @@ func resolveAntigravityGenerationModel(
 	if hasDisplayLabel || executorModel == "" {
 		return generationModel
 	}
-	if antigravityBaseModel(executorModel) == antigravityBaseModel(generationModel) {
+	normalizedGeneration := stripAntigravityExperimentalVariant(generationModel)
+	if antigravityBaseModel(executorModel) == normalizedGeneration {
 		return executorModel
 	}
 	return generationModel
 }
 
 func antigravityBaseModel(model string) string {
-	suffixes := []string{"-low", "-medium", "-high", "-exp-b", "-exp"}
-	changed := true
-	for changed {
-		changed = false
-		for _, suffix := range suffixes {
-			if base, ok := strings.CutSuffix(model, suffix); ok {
-				model = base
-				changed = true
-				break
-			}
+	for _, suffix := range []string{"-low", "-medium", "-high"} {
+		if base, ok := strings.CutSuffix(model, suffix); ok {
+			return base
 		}
+	}
+	return model
+}
+
+func stripAntigravityExperimentalVariant(model string) string {
+	if base, ok := strings.CutSuffix(model, "-exp-b"); ok {
+		return base
 	}
 	return model
 }

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -931,16 +931,23 @@ func resolveAntigravityGenerationModel(
 	if hasDisplayLabel || executorModel == "" {
 		return generationModel
 	}
-	if antigravityBaseModel(executorModel) == generationModel {
+	if antigravityBaseModel(executorModel) == antigravityBaseModel(generationModel) {
 		return executorModel
 	}
 	return generationModel
 }
 
 func antigravityBaseModel(model string) string {
-	for _, suffix := range []string{"-low", "-medium", "-high"} {
-		if base, ok := strings.CutSuffix(model, suffix); ok {
-			return base
+	suffixes := []string{"-low", "-medium", "-high", "-exp-b", "-exp"}
+	changed := true
+	for changed {
+		changed = false
+		for _, suffix := range suffixes {
+			if base, ok := strings.CutSuffix(model, suffix); ok {
+				model = base
+				changed = true
+				break
+			}
 		}
 	}
 	return model

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -140,7 +140,9 @@ func (p *antigravityProvider) parseSession(
 	// sidecar is absent, malformed, or fails the coverage gate the parser
 	// falls back to the heuristic decode exactly as before.
 	sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
-	tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
+	tRes, tErr := parseAntigravityCLITrajectory(
+		sidecarPath, dbResult.executors,
+	)
 	sidecarOK := tErr == nil &&
 		hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages)
 	sidecarCovers := dbResult.rawStepCount == 0 ||
@@ -251,8 +253,12 @@ func (p *antigravityProvider) parseSession(
 }
 
 type antigravityStepLoadResult struct {
-	messages     []ParsedMessage
-	usageEvents  []ParsedUsageEvent
+	messages    []ParsedMessage
+	usageEvents []ParsedUsageEvent
+	// executors is retained for preferred trajectory sidecars so their
+	// generatorMetadata uses the same range-qualified model attribution as
+	// SQLite gen_metadata.
+	executors    []antigravityExecutorMetadata
 	rawStepCount int
 	// hasGenMetadata reports whether the steps DB carried a non-empty
 	// gen_metadata table. Paired with an empty usageEvents slice it flags a
@@ -353,18 +359,20 @@ func loadAntigravityStepsWithRawCount(
 ) (antigravityStepLoadResult, error) {
 	generations := loadAntigravityGenerationMetadata(db)
 	executors := loadAntigravityExecutorMetadata(db)
+	result := antigravityStepLoadResult{
+		executors:      executors,
+		hasGenMetadata: len(generations) > 0,
+	}
 	rows, err := db.Query(
 		`SELECT idx, step_type, step_payload FROM steps ` +
 			`ORDER BY idx`,
 	)
 	if err != nil {
-		return antigravityStepLoadResult{}, fmt.Errorf("query steps: %w", err)
+		return result, fmt.Errorf("query steps: %w", err)
 	}
 	defer rows.Close()
 	steps := make([]antigravityLoadedStep, 0)
 	stepPositions := make(map[int]int)
-	var result antigravityStepLoadResult
-	result.hasGenMetadata = len(generations) > 0
 	for rows.Next() {
 		var (
 			idx      int
@@ -372,7 +380,7 @@ func loadAntigravityStepsWithRawCount(
 			payload  []byte
 		)
 		if err := rows.Scan(&idx, &stepType, &payload); err != nil {
-			return antigravityStepLoadResult{}, fmt.Errorf("scan step: %w", err)
+			return result, fmt.Errorf("scan step: %w", err)
 		}
 		parsedStep, parsed := newAntigravityStep(idx, stepType, payload)
 		var msg ParsedMessage
@@ -389,7 +397,7 @@ func loadAntigravityStepsWithRawCount(
 		result.rawStepCount++
 	}
 	if err := rows.Err(); err != nil {
-		return antigravityStepLoadResult{}, fmt.Errorf("iterate steps: %w", err)
+		return result, fmt.Errorf("iterate steps: %w", err)
 	}
 
 	for _, generation := range generations {
@@ -437,16 +445,20 @@ func (g antigravityGenerationMetadata) maxStepIndex() (int, bool) {
 	if !g.hasStepIndices {
 		return g.idx, true
 	}
-	if !g.stepIndicesValid || len(g.stepIndices) == 0 {
+	if !g.stepIndicesValid {
 		return 0, false
 	}
-	maxIdx := g.stepIndices[0]
-	for _, idx := range g.stepIndices[1:] {
+	return maxAntigravityStepIndex(g.stepIndices)
+}
+
+func maxAntigravityStepIndex(indices []int) (int, bool) {
+	maxIdx := -1
+	for _, idx := range indices {
 		if idx > maxIdx {
 			maxIdx = idx
 		}
 	}
-	return maxIdx, true
+	return maxIdx, maxIdx >= 0
 }
 
 type antigravityExecutorMetadata struct {
@@ -928,6 +940,14 @@ func resolveAntigravityGenerationModel(
 ) string {
 	generationModel, hasDisplayLabel :=
 		extractAntigravityGenerationModel(data)
+	return resolveAntigravityModelName(
+		generationModel, executorModel, hasDisplayLabel,
+	)
+}
+
+func resolveAntigravityModelName(
+	generationModel, executorModel string, hasDisplayLabel bool,
+) string {
 	if hasDisplayLabel || executorModel == "" {
 		return generationModel
 	}

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -145,7 +145,9 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 		// heuristic cannot decode -- so a partial sidecar is never persisted
 		// as a current transcript.
 		sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
-		tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
+		tRes, tErr := parseAntigravityCLITrajectory(
+			sidecarPath, dbResult.executors,
+		)
 		if tErr == nil {
 			parentCascadeID = tRes.parentCascadeID
 		}
@@ -193,7 +195,9 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 		// .pb files are no longer produced, so their sidecars are final,
 		// and even a sidecar older than the .pb beats the fallbacks.
 		sidecarPath := strings.TrimSuffix(path, ".pb") + ".trajectory.json"
-		if tRes, err := parseAntigravityCLITrajectory(sidecarPath); err == nil {
+		if tRes, err := parseAntigravityCLITrajectory(
+			sidecarPath, nil,
+		); err == nil {
 			parentCascadeID = tRes.parentCascadeID
 			// Usage events flow whenever the sidecar parses, even when
 			// no message is displayable, matching the message-less
@@ -1452,7 +1456,9 @@ func canonicalAgyCascadeID(value string) string {
 
 // parseAntigravityCLITrajectory reads a <uuid>.trajectory.json sidecar
 // produced out-of-process by agy-reader and returns the decoded
-// transcript as ParsedMessages.
+// transcript as ParsedMessages. When the source database supplied executor
+// ranges, they qualify sidecar generation models using the same rules as the
+// SQLite gen_metadata path.
 //
 // Trust posture (see SECURITY.md, "Imports and new readers" row of the
 // Trust boundaries table): the sidecar is treated as untrusted
@@ -1462,6 +1468,7 @@ func canonicalAgyCascadeID(value string) string {
 // is executed or echoed back over any outbound channel.
 func parseAntigravityCLITrajectory(
 	trajectoryPath string,
+	executors []antigravityExecutorMetadata,
 ) (agyTrajectoryParseResult, error) {
 	f, err := os.Open(trajectoryPath)
 	if err != nil {
@@ -1682,9 +1689,11 @@ func parseAntigravityCLITrajectory(
 
 	flushPendingResults()
 	return agyTrajectoryParseResult{
-		messages:        msgs,
-		rawSteps:        len(traj.Steps),
-		usageEvents:     extractAgyGeneratorUsage(traj, plannerMsgIdx, msgs),
+		messages: msgs,
+		rawSteps: len(traj.Steps),
+		usageEvents: extractAgyGeneratorUsage(
+			traj, plannerMsgIdx, msgs, executors,
+		),
 		parentCascadeID: parseAgyReaderParentCascadeID(traj.AgyReader),
 	}, nil
 }
@@ -1705,12 +1714,14 @@ func parseAntigravityCLITrajectory(
 // MessageOrdinal is left nil: ordinals are reassigned after the
 // timestamp re-sort and brain-doc merge in
 // ParseAntigravityCLISessionWithStatus, so any ordinal computed here
-// would be wrong. Cost fields stay zero/empty - MODEL_PLACEHOLDER_*
-// models are unpriced.
+// would be wrong. A generation's maximum step index selects the covering
+// executor range, matching SQLite gen_metadata attribution. Cost fields stay
+// zero/empty - MODEL_PLACEHOLDER_* models are unpriced.
 func extractAgyGeneratorUsage(
 	traj agyTrajectory,
 	plannerMsgIdx map[int]int,
 	msgs []ParsedMessage,
+	executors []antigravityExecutorMetadata,
 ) []ParsedUsageEvent {
 	var events []ParsedUsageEvent
 	for _, gen := range traj.GeneratorMetadata {
@@ -1735,6 +1746,11 @@ func extractAgyGeneratorUsage(
 		if model == "" {
 			model = usage.Model
 		}
+		executorModel := ""
+		if stepIndex, ok := maxAntigravityStepIndex(gen.StepIndices); ok {
+			executorModel = executorModelForStep(executors, stepIndex)
+		}
+		model = resolveAntigravityModelName(model, executorModel, false)
 
 		// Find the planner message this generation produced.
 		var targetMsg *ParsedMessage

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2889,6 +2889,13 @@ func TestAntigravityCLIGenerationMetadataMapsToPlannerStepAndExecutorModel(t *te
 			wantModel:       "gemini-3.7-flash-high",
 		},
 		{
+			name:            "experimental serving variant gains executor effort",
+			generationModel: "gemini-3.7-flash-exp-b",
+			modelField:      agChatModelMetadataResponseModelField,
+			executorModel:   "gemini-3.7-flash-high",
+			wantModel:       "gemini-3.7-flash-high",
+		},
+		{
 			name:            "different executor base is ignored",
 			generationModel: "claude-sonnet-4-6",
 			modelField:      agChatModelMetadataResponseModelField,

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2567,6 +2567,78 @@ func TestAntigravityCLIDBWithoutGenMetadataGetsSidecarUsage(t *testing.T) {
 	assert.True(t, sess.HasPeakContextTokens)
 }
 
+func TestAntigravityCLISidecarModelUsesCoveringExecutorEffort(t *testing.T) {
+	tests := []struct {
+		name                  string
+		executorLastStepIndex int
+		wantModel             string
+	}{
+		{
+			name:                  "covered serving variant gains executor effort",
+			executorLastStepIndex: 1,
+			wantModel:             "gemini-3.7-flash-high",
+		},
+		{
+			name:                  "step outside executor range preserves serving variant",
+			executorLastStepIndex: 0,
+			wantModel:             "gemini-3.7-flash-exp-b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			id := "adadadad-bebe-cfcf-d0d0-e1e1e1e1e1e1"
+			mustMkdir(t, filepath.Join(root, "conversations"))
+
+			dbPath := filepath.Join(root, "conversations", id+".db")
+			createAntigravityTestDB(t, dbPath)
+			db, err := sql.Open("sqlite3", dbPath)
+			require.NoError(t, err)
+			mustExec(t, db, `CREATE TABLE executor_metadata (
+				idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+			executorData := createAntigravityMockExecutorMetadata(
+				tt.executorLastStepIndex, "gemini-3.7-flash-high",
+			)
+			mustExec(t, db,
+				`INSERT INTO executor_metadata (idx, data, size) VALUES (0, ?, ?)`,
+				executorData, len(executorData))
+			require.NoError(t, db.Close())
+
+			genJSON := `[{
+				"stepIndices": [1],
+				"chatModel": {
+					"model": "gemini-3.7-flash-exp-b",
+					"usage": {
+						"inputTokens": "1500",
+						"outputTokens": "77"
+					}
+				}
+			}]`
+			writeAntigravityTestSidecarWithGenMetadata(
+				t, root, id, 2, genJSON,
+			)
+
+			_, msgs, usageEvents, status, err :=
+				parseAntigravityCLITestSessionWithStatus(
+					t, dbPath, "", "test-machine",
+				)
+			require.NoError(t, err)
+			assert.False(t, status.NeedsRetry)
+			require.Len(t, msgs, 2)
+			assert.Equal(t, tt.wantModel, msgs[1].Model)
+			assert.Equal(t, 1500, msgs[1].ContextTokens)
+			assert.Equal(t, 77, msgs[1].OutputTokens)
+
+			require.Len(t, usageEvents, 1)
+			assert.Equal(t, "sidecar", usageEvents[0].Source)
+			assert.Equal(t, tt.wantModel, usageEvents[0].Model)
+			assert.Equal(t, 1500, usageEvents[0].InputTokens)
+			assert.Equal(t, 77, usageEvents[0].OutputTokens)
+		})
+	}
+}
+
 func TestAntigravityCLINonCoveringSidecarUsageRejected(t *testing.T) {
 	root := t.TempDir()
 	id := "acacacac-bdbd-cece-dfdf-565656565656"

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2923,6 +2923,20 @@ func TestAntigravityCLIGenerationMetadataMapsToPlannerStepAndExecutorModel(t *te
 			executorModel:   "claude-sonnet-4-6",
 			wantModel:       "gemini-3.7-flash-exp-b",
 		},
+		{
+			name:            "conflicting generation effort is preserved",
+			generationModel: "gemini-3.7-flash-low",
+			modelField:      agChatModelMetadataResponseModelField,
+			executorModel:   "gemini-3.7-flash-high",
+			wantModel:       "gemini-3.7-flash-low",
+		},
+		{
+			name:            "generic exp model is preserved rather than treated as serving alias",
+			generationModel: "gemini-2.0-flash-exp",
+			modelField:      agChatModelMetadataResponseModelField,
+			executorModel:   "gemini-2.0-flash-high",
+			wantModel:       "gemini-2.0-flash-exp",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2909,6 +2909,20 @@ func TestAntigravityCLIGenerationMetadataMapsToPlannerStepAndExecutorModel(t *te
 			executorModel:   "gemini-3.7-flash-medium",
 			wantModel:       "Gemini 3.7 Flash (High)",
 		},
+		{
+			name:            "empty executor preserves generation model",
+			generationModel: "gemini-3.7-flash-high",
+			modelField:      agChatModelMetadataResponseModelField,
+			executorModel:   "",
+			wantModel:       "gemini-3.7-flash-high",
+		},
+		{
+			name:            "mismatched executor preserves experimental generation model",
+			generationModel: "gemini-3.7-flash-exp-b",
+			modelField:      agChatModelMetadataResponseModelField,
+			executorModel:   "claude-sonnet-4-6",
+			wantModel:       "gemini-3.7-flash-exp-b",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Antigravity CLI 1.1.24 can store an experimental serving identifier such as `gemini-3.7-flash-exp-b` in generation metadata while the covering executor metadata records the effort-qualified product model, such as `gemini-3.7-flash-high`. The parser previously required the generation value to equal the executor's base slug, so the serving identifier leaked into usage events and split one model's dashboard accounting.

This change applies the executor range to both SQLite `gen_metadata` and preferred `.trajectory.json` sidecar generations. It recognizes only the observed `-exp-b` serving suffix when matching generation metadata to a covering executor range. Complete display labels and explicitly effort-qualified generation models remain authoritative, unmatched or missing executors preserve the raw generation model, and steps outside every declared executor range are not guessed. Existing archived rows are reparsed through data version 98 so historical message and usage records receive the correction.

The Antigravity format inventory now pins the official CLI 1.1.24 release and records the observed field 19 variant. Generic `-exp` and hypothetical serving suffixes remain distinct until evidence supports normalizing them.

The shared model-resolution and executor-range behavior is in `internal/parser/antigravity.go`; sidecar attribution is in `internal/parser/antigravity_cli.go`; regression coverage is in `internal/parser/antigravity_test.go`. The archive reparse boundary is in `internal/db/db.go`, and provenance is documented in `docs/internal/session-format-sources.md`.

Closes #1593.