### PR TITLE
Use stepped area chart for Cost Over Time

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/virtual-core": "3.17.8",
         "d3-hierarchy": "3.1.2",
         "d3-scale": "4.0.2",
+        "d3-shape": "3.2.0",
         "d3-time": "3.1.0",
         "dompurify": "3.4.14",
         "layerchart": "2.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@tanstack/virtual-core": "3.17.8",
     "d3-hierarchy": "3.1.2",
     "d3-scale": "4.0.2",
+    "d3-shape": "3.2.0",
     "d3-time": "3.1.0",
     "dompurify": "3.4.14",
     "layerchart": "2.3.0",

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -63,7 +63,7 @@
     return usage.selectedModels.split(",").includes(key);
   }
 
-  function dailyEntriesWithZeros(
+  function fillMissingDailyEntries(
     summary: UsageSummaryResponse,
   ): DailyUsageEntry[] {
     const entriesByDate = new Map(
@@ -97,7 +97,7 @@
     if (!summary) {
       return { points: [], keys: [], maxY: 0, labels: {} };
     }
-    const daily = dailyEntriesWithZeros(summary);
+    const daily = fillMissingDailyEntries(summary);
 
     // Sum the selected value per key across the whole range to find top N.
     const totals = new Map<string, number>();

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -2,6 +2,7 @@
   import { Area, Bar, Chart, Layer, Tooltip } from "layerchart";
   import { Button } from "@kenn-io/kit-ui";
   import { scaleBand, scalePoint } from "d3-scale";
+  import { curveStepAfter } from "d3-shape";
   import LargeChartFrame from "../shared/LargeChartFrame.svelte";
   import { usage, type GroupBy } from "../../stores/usage.svelte.js";
   import { formatDateTime, m } from "../../i18n/index.js";
@@ -487,6 +488,7 @@
                 <Area
                   seriesKey={item.key}
                   fill={item.color}
+                  curve={curveStepAfter}
                 />
               {/if}
             {/each}

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -94,7 +94,7 @@
     labels: Record<string, string>;
   } => {
     const summary = usage.timeSeriesSummary;
-    if (!summary) {
+    if (!summary || summary.daily.length === 0) {
       return { points: [], keys: [], maxY: 0, labels: {} };
     }
     const daily = fillMissingDailyEntries(summary);

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -10,9 +10,9 @@
   import { sumSelectedTokens } from "../../stores/usageTokenTypes.js";
   import { addDays } from "../../utils/dates.js";
   import type {
-    DailyUsageEntry,
+    DbDailyUsageEntry,
     UsageSummaryResponse,
-  } from "../../api/types/usage.js";
+  } from "../../api/generated/index";
 
   interface Props {
     colorMap: ReadonlyMap<string, string>;
@@ -65,11 +65,11 @@
 
   function fillMissingDailyEntries(
     summary: UsageSummaryResponse,
-  ): DailyUsageEntry[] {
+  ): DbDailyUsageEntry[] {
     const entriesByDate = new Map(
       summary.daily.map((entry) => [entry.date, entry]),
     );
-    const daily: DailyUsageEntry[] = [];
+    const daily: DbDailyUsageEntry[] = [];
     for (let date = summary.from; date <= summary.to;) {
       daily.push(entriesByDate.get(date) ?? {
         date,
@@ -79,6 +79,10 @@
         cacheReadTokens: 0,
         totalCost: { microdollars: 0 },
         modelsUsed: [],
+        projectBreakdowns: [],
+        modelBreakdowns: [],
+        agentBreakdowns: [],
+        machineBreakdowns: [],
       });
       const nextDate = addDays(date, 1);
       if (!nextDate) break;

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -2,12 +2,17 @@
   import { Area, Bar, Chart, Layer, Tooltip } from "layerchart";
   import { Button } from "@kenn-io/kit-ui";
   import { scaleBand, scalePoint } from "d3-scale";
-  import { curveStepAfter } from "d3-shape";
+  import { curveStep } from "d3-shape";
   import LargeChartFrame from "../shared/LargeChartFrame.svelte";
   import { usage, type GroupBy } from "../../stores/usage.svelte.js";
   import { formatDateTime, m } from "../../i18n/index.js";
   import { formatMoney, moneyFromMicrodollars } from "../../money.js";
   import { sumSelectedTokens } from "../../stores/usageTokenTypes.js";
+  import { addDays } from "../../utils/dates.js";
+  import type {
+    DailyUsageEntry,
+    UsageSummaryResponse,
+  } from "../../api/types/usage.js";
 
   interface Props {
     colorMap: ReadonlyMap<string, string>;
@@ -58,16 +63,41 @@
     return usage.selectedModels.split(",").includes(key);
   }
 
+  function dailyEntriesWithZeros(
+    summary: UsageSummaryResponse,
+  ): DailyUsageEntry[] {
+    const entriesByDate = new Map(
+      summary.daily.map((entry) => [entry.date, entry]),
+    );
+    const daily: DailyUsageEntry[] = [];
+    for (let date = summary.from; date <= summary.to;) {
+      daily.push(entriesByDate.get(date) ?? {
+        date,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalCost: { microdollars: 0 },
+        modelsUsed: [],
+      });
+      const nextDate = addDays(date, 1);
+      if (!nextDate) break;
+      date = nextDate;
+    }
+    return daily;
+  }
+
   const seriesData = $derived.by((): {
     points: Point[];
     keys: string[];
     maxY: number;
     labels: Record<string, string>;
   } => {
-    const daily = usage.timeSeriesSummary?.daily;
-    if (!daily || daily.length === 0) {
+    const summary = usage.timeSeriesSummary;
+    if (!summary) {
       return { points: [], keys: [], maxY: 0, labels: {} };
     }
+    const daily = dailyEntriesWithZeros(summary);
 
     // Sum the selected value per key across the whole range to find top N.
     const totals = new Map<string, number>();
@@ -488,7 +518,7 @@
                 <Area
                   seriesKey={item.key}
                   fill={item.color}
-                  curve={curveStepAfter}
+                  curve={curveStep}
                 />
               {/if}
             {/each}

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -77,10 +77,12 @@ function dailyEntry(index: number): DbDailyUsageEntry {
   };
 }
 
-function usageSummary(): UsageSummaryResponse {
+function usageSummary(
+  daily = Array.from({ length: 15 }, (_, index) => dailyEntry(index)),
+): UsageSummaryResponse {
   return {
-    from: "2026-06-04",
-    to: "2026-06-18",
+    from: daily[0]!.date,
+    to: daily.at(-1)!.date,
     projects: {},
     totals: {
       inputTokens: 1500,
@@ -90,7 +92,7 @@ function usageSummary(): UsageSummaryResponse {
       totalCost: testMoney(150),
       cacheSavings: testMoney(0),
     },
-    daily: Array.from({ length: 15 }, (_, i) => dailyEntry(i)),
+    daily,
     projectTotals: [
       {
         project_key: "pl1:sha256:agentsview",
@@ -147,12 +149,6 @@ function mountChart() {
   });
 }
 
-function setSummaryRangeToDailyEntries() {
-  const daily = usage.summary!.daily;
-  usage.summary!.from = daily[0]!.date;
-  usage.summary!.to = daily.at(-1)!.date;
-}
-
 describe("CostTimeSeriesChart", () => {
   beforeEach(() => {
     globalThis.ResizeObserver = ImmediateResizeObserver as typeof ResizeObserver;
@@ -205,9 +201,7 @@ describe("CostTimeSeriesChart", () => {
   });
 
   it("renders a visible stacked bar for a one-day range", async () => {
-    usage.summary = usageSummary();
-    usage.summary.daily = [dailyEntry(0)];
-    setSummaryRangeToDailyEntries();
+    usage.summary = usageSummary([dailyEntry(0)]);
 
     const component = mountChart();
     await tick();
@@ -352,9 +346,7 @@ describe("CostTimeSeriesChart", () => {
   });
 
   it("keeps projects with the same display label as distinct series", async () => {
-    usage.summary = usageSummary();
-    usage.summary.daily = [dailyEntry(0)];
-    setSummaryRangeToDailyEntries();
+    usage.summary = usageSummary([dailyEntry(0)]);
     usage.summary.daily[0]!.projectBreakdowns = [
       { ...usage.summary.daily[0]!.projectBreakdowns![0]!, cost: testMoney(6) },
       {
@@ -373,9 +365,8 @@ describe("CostTimeSeriesChart", () => {
   });
 
   it("uses distinct active model colors for paths and legend dots", async () => {
-    usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
-    usage.summary.daily = [
+    usage.summary = usageSummary([
       modelDailyEntry(0, [
         { modelName: "claude-sonnet-5", cost: testMoney(6) },
         { modelName: "claude-opus-4-8", cost: testMoney(4) },
@@ -384,8 +375,7 @@ describe("CostTimeSeriesChart", () => {
         { modelName: "claude-sonnet-5", cost: testMoney(3) },
         { modelName: "claude-opus-4-8", cost: testMoney(2) },
       ]),
-    ];
-    setSummaryRangeToDailyEntries();
+    ]);
 
     const component = mountChart();
     await tick();
@@ -402,13 +392,11 @@ describe("CostTimeSeriesChart", () => {
   });
 
   it("assigns the first usage color to a single rendered model series", async () => {
-    usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
-    usage.summary.daily = [
+    usage.summary = usageSummary([
       modelDailyEntry(0, [{ modelName: "single-model", cost: testMoney(6) }]),
       modelDailyEntry(1, [{ modelName: "single-model", cost: testMoney(3) }]),
-    ];
-    setSummaryRangeToDailyEntries();
+    ]);
 
     const component = mountChart();
     await tick();
@@ -421,14 +409,12 @@ describe("CostTimeSeriesChart", () => {
   });
 
   it("renders ten named series before rolling the rest into Other", async () => {
-    usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
     const models = Array.from({ length: 11 }, (_, index) => ({
       modelName: `model-${index}`,
       cost: testMoney(11 - index),
     }));
-    usage.summary.daily = [modelDailyEntry(0, models)];
-    setSummaryRangeToDailyEntries();
+    usage.summary = usageSummary([modelDailyEntry(0, models)]);
 
     const component = mountChart();
     await tick();
@@ -443,9 +429,8 @@ describe("CostTimeSeriesChart", () => {
   });
 
   it("shows hovered series in descending value order", async () => {
-    usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
-    usage.summary.daily = [
+    usage.summary = usageSummary([
       modelDailyEntry(0, [
         { modelName: "small", cost: testMoney(1) },
         { modelName: "large", cost: testMoney(9) },
@@ -456,8 +441,7 @@ describe("CostTimeSeriesChart", () => {
         { modelName: "large", cost: testMoney(3) },
         { modelName: "medium", cost: testMoney(8) },
       ]),
-    ];
-    setSummaryRangeToDailyEntries();
+    ]);
 
     const component = mountChart();
     await tick();
@@ -504,14 +488,12 @@ describe("CostTimeSeriesChart", () => {
       configurable: true,
       get: () => OBSERVED_WIDTH,
     });
-    usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
-    usage.summary.daily = [
+    usage.summary = usageSummary([
       modelDailyEntry(0, [{ modelName: "model", cost: testMoney(1) }]),
       modelDailyEntry(1, [{ modelName: "model", cost: testMoney(2) }]),
       modelDailyEntry(2, [{ modelName: "model", cost: testMoney(3) }]),
-    ];
-    setSummaryRangeToDailyEntries();
+    ]);
 
     const component = mountChart();
     await tick();
@@ -572,9 +554,8 @@ describe("CostTimeSeriesChart", () => {
 
   it("uses aggregate-cost-ranked Matplotlib colors for model paths and legend dots", async () => {
     settings.chartPalette = "matplotlib";
-    usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
-    usage.summary.daily = [
+    usage.summary = usageSummary([
       modelDailyEntry(0, [
         { modelName: "gpt-5.6-sol", cost: testMoney(8) },
         { modelName: "claude-opus-5", cost: testMoney(4) },
@@ -583,8 +564,7 @@ describe("CostTimeSeriesChart", () => {
         { modelName: "gpt-5.6-sol", cost: testMoney(3) },
         { modelName: "claude-opus-5", cost: testMoney(2) },
       ]),
-    ];
-    setSummaryRangeToDailyEntries();
+    ]);
 
     const component = mountChart();
     await tick();

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -147,6 +147,12 @@ function mountChart() {
   });
 }
 
+function setSummaryRangeToDailyEntries() {
+  const daily = usage.summary!.daily;
+  usage.summary!.from = daily[0]!.date;
+  usage.summary!.to = daily.at(-1)!.date;
+}
+
 describe("CostTimeSeriesChart", () => {
   beforeEach(() => {
     globalThis.ResizeObserver = ImmediateResizeObserver as typeof ResizeObserver;
@@ -201,6 +207,7 @@ describe("CostTimeSeriesChart", () => {
   it("renders a visible stacked bar for a one-day range", async () => {
     usage.summary = usageSummary();
     usage.summary.daily = [dailyEntry(0)];
+    setSummaryRangeToDailyEntries();
 
     const component = mountChart();
     await tick();
@@ -214,9 +221,10 @@ describe("CostTimeSeriesChart", () => {
     unmount(component);
   });
 
-  it("renders stepped stacked areas without dimming their colors", async () => {
+  it("renders centered stepped areas without dimming their colors", async () => {
     usage.summary = usageSummary();
     usage.summary.daily = usage.summary.daily.slice(0, 2);
+    setSummaryRangeToDailyEntries();
     usage.summary.daily[0]!.projectBreakdowns![0]!.cost = testMoney(10);
     usage.summary.daily[1]!.projectBreakdowns![0]!.cost = testMoney(20);
 
@@ -231,12 +239,31 @@ describe("CostTimeSeriesChart", () => {
       /[ML]([-+]?\d*\.?\d+(?:e[-+]?\d+)?),([-+]?\d*\.?\d+(?:e[-+]?\d+)?)/gi,
     )].map((match) => [Number(match[1]), Number(match[2])] as const);
 
-    expect(coordinates).toHaveLength(6);
+    expect(coordinates).toHaveLength(8);
+    expect(coordinates[1]![0]).toBe(
+      (coordinates[0]![0] + coordinates[3]![0]) / 2,
+    );
     for (let index = 1; index < coordinates.length; index++) {
       const [previousX, previousY] = coordinates[index - 1]!;
       const [x, y] = coordinates[index]!;
       expect(x === previousX || y === previousY).toBe(true);
     }
+
+    unmount(component);
+  });
+
+  it("renders a zero-usage day between populated dates", async () => {
+    usage.summary = usageSummary();
+    usage.summary.from = "2026-06-04";
+    usage.summary.to = "2026-06-06";
+    usage.summary.daily = [dailyEntry(0), dailyEntry(2)];
+
+    const component = mountChart();
+    await tick();
+
+    const labels = Array.from(document.querySelectorAll<SVGTextElement>("text.x-label"))
+      .map((label) => label.textContent?.trim());
+    expect(labels).toContain("Jun 5");
 
     unmount(component);
   });
@@ -347,6 +374,7 @@ describe("CostTimeSeriesChart", () => {
   it("keeps projects with the same display label as distinct series", async () => {
     usage.summary = usageSummary();
     usage.summary.daily = [dailyEntry(0)];
+    setSummaryRangeToDailyEntries();
     usage.summary.daily[0]!.projectBreakdowns = [
       { ...usage.summary.daily[0]!.projectBreakdowns![0]!, cost: testMoney(6) },
       {
@@ -377,6 +405,7 @@ describe("CostTimeSeriesChart", () => {
         { modelName: "claude-opus-4-8", cost: testMoney(2) },
       ]),
     ];
+    setSummaryRangeToDailyEntries();
 
     const component = mountChart();
     await tick();
@@ -399,6 +428,7 @@ describe("CostTimeSeriesChart", () => {
       modelDailyEntry(0, [{ modelName: "single-model", cost: testMoney(6) }]),
       modelDailyEntry(1, [{ modelName: "single-model", cost: testMoney(3) }]),
     ];
+    setSummaryRangeToDailyEntries();
 
     const component = mountChart();
     await tick();
@@ -418,6 +448,7 @@ describe("CostTimeSeriesChart", () => {
       cost: testMoney(11 - index),
     }));
     usage.summary.daily = [modelDailyEntry(0, models)];
+    setSummaryRangeToDailyEntries();
 
     const component = mountChart();
     await tick();
@@ -446,6 +477,7 @@ describe("CostTimeSeriesChart", () => {
         { modelName: "medium", cost: testMoney(8) },
       ]),
     ];
+    setSummaryRangeToDailyEntries();
 
     const component = mountChart();
     await tick();
@@ -499,6 +531,7 @@ describe("CostTimeSeriesChart", () => {
       modelDailyEntry(1, [{ modelName: "model", cost: testMoney(2) }]),
       modelDailyEntry(2, [{ modelName: "model", cost: testMoney(3) }]),
     ];
+    setSummaryRangeToDailyEntries();
 
     const component = mountChart();
     await tick();
@@ -571,6 +604,7 @@ describe("CostTimeSeriesChart", () => {
         { modelName: "claude-opus-5", cost: testMoney(2) },
       ]),
     ];
+    setSummaryRangeToDailyEntries();
 
     const component = mountChart();
     await tick();

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -221,33 +221,13 @@ describe("CostTimeSeriesChart", () => {
     unmount(component);
   });
 
-  it("renders centered stepped areas without dimming their colors", async () => {
-    usage.summary = usageSummary();
-    usage.summary.daily = usage.summary.daily.slice(0, 2);
-    setSummaryRangeToDailyEntries();
-    usage.summary.daily[0]!.projectBreakdowns![0]!.cost = testMoney(10);
-    usage.summary.daily[1]!.projectBreakdowns![0]!.cost = testMoney(20);
-
+  it("renders stacked areas without dimming their colors", async () => {
     const component = mountChart();
     await tick();
 
     const area = document.querySelector<SVGPathElement>("path.lc-area-path");
     expect(area).not.toBeNull();
     expect(Number(area!.getAttribute("opacity") ?? 1)).toBe(1);
-    const path = area!.getAttribute("d")!;
-    const coordinates = [...path.matchAll(
-      /[ML]([-+]?\d*\.?\d+(?:e[-+]?\d+)?),([-+]?\d*\.?\d+(?:e[-+]?\d+)?)/gi,
-    )].map((match) => [Number(match[1]), Number(match[2])] as const);
-
-    expect(coordinates).toHaveLength(8);
-    expect(coordinates[1]![0]).toBe(
-      (coordinates[0]![0] + coordinates[3]![0]) / 2,
-    );
-    for (let index = 1; index < coordinates.length; index++) {
-      const [previousX, previousY] = coordinates[index - 1]!;
-      const [x, y] = coordinates[index]!;
-      expect(x === previousX || y === previousY).toBe(true);
-    }
 
     unmount(component);
   });

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -227,17 +227,16 @@ describe("CostTimeSeriesChart", () => {
     expect(area).not.toBeNull();
     expect(Number(area!.getAttribute("opacity") ?? 1)).toBe(1);
     const path = area!.getAttribute("d")!;
-    const points = [...path.matchAll(/[-+]?\d*\.?\d+(?:e[-+]?\d+)?/gi)]
-      .map((match) => Number(match[0]));
-    const coordinates = Array.from(
-      { length: Math.floor(points.length / 2) },
-      (_, index) => [points[index * 2]!, points[index * 2 + 1]!] as const,
-    );
+    const coordinates = [...path.matchAll(
+      /[ML]([-+]?\d*\.?\d+(?:e[-+]?\d+)?),([-+]?\d*\.?\d+(?:e[-+]?\d+)?)/gi,
+    )].map((match) => [Number(match[1]), Number(match[2])] as const);
 
-    expect(coordinates[0]![0]).not.toBe(coordinates[1]![0]);
-    expect(coordinates[0]![1]).toBe(coordinates[1]![1]);
-    expect(coordinates[1]![0]).toBe(coordinates[2]![0]);
-    expect(coordinates[1]![1]).not.toBe(coordinates[2]![1]);
+    expect(coordinates).toHaveLength(6);
+    for (let index = 1; index < coordinates.length; index++) {
+      const [previousX, previousY] = coordinates[index - 1]!;
+      const [x, y] = coordinates[index]!;
+      expect(x === previousX || y === previousY).toBe(true);
+    }
 
     unmount(component);
   });

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -215,7 +215,7 @@ describe("CostTimeSeriesChart", () => {
     unmount(component);
   });
 
-  it("renders stacked areas without dimming their colors", async () => {
+  it("renders stacked area colors without dimming them", async () => {
     const component = mountChart();
     await tick();
 

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -215,7 +215,7 @@ describe("CostTimeSeriesChart", () => {
     unmount(component);
   });
 
-  it("renders stacked area colors without dimming them", async () => {
+  it("renders stacked areas without dimming their colors", async () => {
     const component = mountChart();
     await tick();
 

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -242,6 +242,21 @@ describe("CostTimeSeriesChart", () => {
     unmount(component);
   });
 
+  it("keeps the no-data state when the usage response has no daily entries", async () => {
+    usage.summary = usageSummary();
+    usage.summary.daily = [];
+
+    const component = mountChart();
+    await tick();
+
+    expect(document.querySelector(".empty")?.textContent).toContain(
+      "No data for this period",
+    );
+    expect(document.querySelector(".chart-svg")).toBeNull();
+
+    unmount(component);
+  });
+
   it("brushes a date range and exposes a clear-selection action", async () => {
     const component = mountChart();
     await tick();

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -214,13 +214,30 @@ describe("CostTimeSeriesChart", () => {
     unmount(component);
   });
 
-  it("renders stacked area colors without dimming them", async () => {
+  it("renders stepped stacked areas without dimming their colors", async () => {
+    usage.summary = usageSummary();
+    usage.summary.daily = usage.summary.daily.slice(0, 2);
+    usage.summary.daily[0]!.projectBreakdowns![0]!.cost = testMoney(10);
+    usage.summary.daily[1]!.projectBreakdowns![0]!.cost = testMoney(20);
+
     const component = mountChart();
     await tick();
 
     const area = document.querySelector<SVGPathElement>("path.lc-area-path");
     expect(area).not.toBeNull();
     expect(Number(area!.getAttribute("opacity") ?? 1)).toBe(1);
+    const path = area!.getAttribute("d")!;
+    const points = [...path.matchAll(/[-+]?\d*\.?\d+(?:e[-+]?\d+)?/gi)]
+      .map((match) => Number(match[0]));
+    const coordinates = Array.from(
+      { length: Math.floor(points.length / 2) },
+      (_, index) => [points[index * 2]!, points[index * 2 + 1]!] as const,
+    );
+
+    expect(coordinates[0]![0]).not.toBe(coordinates[1]![0]);
+    expect(coordinates[0]![1]).toBe(coordinates[1]![1]);
+    expect(coordinates[1]![0]).toBe(coordinates[2]![0]);
+    expect(coordinates[1]![1]).not.toBe(coordinates[2]![1]);
 
     unmount(component);
   });

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -97,6 +97,8 @@ function tenModelUsageSummary(): UsageSummaryResponse {
         machineBreakdowns: [],
       },
     ],
+    from: "2026-07-01",
+    to: "2026-07-01",
     modelTotals: models.map((model, index) => ({
       model,
       inputTokens: 10,


### PR DESCRIPTION
Resolves #1567.

The Usage Cost Over Time visualization now renders stacked daily amounts as centered steps, rather than diagonally interpolating between dates.

It also fills dates omitted by the daily usage response with zero-valued entries across the selected range, so zero-usage days appear at the baseline and the timeline remains continuous.

`d3-shape` is now a direct frontend dependency for LayerChart's step curve.

## Screenshot
<img width="589" height="294" alt="Screenshot 2026-09-02 at 10 27 41" src="https://github.com/user-attachments/assets/8038509b-cf61-406d-8389-8b613530ffcd" />
