### PR TITLE
test(ci): stabilize capture and Windows process timing

### DIFF
--- a/internal/capture/capture_integration_test.go
+++ b/internal/capture/capture_integration_test.go
@@ -2093,8 +2093,6 @@ func TestCaptureDistinguishesAnObservedSourceThatDisappears(t *testing.T) {
 	resultPath := filepath.Join(t.TempDir(), "result.json")
 	producer := copyCaptureHelper(t, "claude")
 	limits := testLimits()
-	limits.FinalizationWait = 5 * time.Second
-	limits.Quiescence = 2 * time.Second
 	type runResponse struct {
 		outcome RunOutcome
 		err     error
@@ -2125,36 +2123,6 @@ func TestCaptureDistinguishesAnObservedSourceThatDisappears(t *testing.T) {
 		default:
 		}
 	})
-
-	// Wait for the manifest to record an observed source, but fail
-	// immediately with the run's actual error if the capture finishes
-	// first: an opaque Eventually timeout here has flaked on Windows CI
-	// and hides whether the run aborted early or is still in flight.
-	observeDeadline := time.NewTimer(20 * time.Second)
-	defer observeDeadline.Stop()
-	poll := time.NewTicker(10 * time.Millisecond)
-	defer poll.Stop()
-	for observed := false; !observed; {
-		select {
-		case response := <-done:
-			t.Fatalf(
-				"capture run finished before the source was observed: exit=%d err=%v",
-				response.outcome.ExitCode, response.err,
-			)
-		case <-observeDeadline.C:
-			t.Fatal(
-				"timed out waiting for an observed source; capture run still in flight",
-			)
-		case <-poll.C:
-			data, err := os.ReadFile(filepath.Join(captureDir, manifestFileName))
-			if err != nil {
-				continue
-			}
-			var captured manifest
-			observed = json.Unmarshal(data, &captured) == nil &&
-				captured.SourceObserved
-		}
-	}
 
 	select {
 	case <-persisted:

--- a/internal/capture/capture_signal_unix_test.go
+++ b/internal/capture/capture_signal_unix_test.go
@@ -37,7 +37,6 @@ func TestInterruptedChildStillSealsRecoverableUsage(t *testing.T) {
 	}
 	done := make(chan response, 1)
 	limits := testLimits()
-	limits.FinalizationWait = 3 * time.Second
 	go func() {
 		outcome, err := Run(context.Background(), RunOptions{
 			Provider: ProviderClaude, OccurrenceID: "interrupted",
@@ -56,7 +55,7 @@ func TestInterruptedChildStillSealsRecoverableUsage(t *testing.T) {
 	var got response
 	select {
 	case got = <-done:
-	case <-time.After(3 * time.Second):
+	case <-time.After(limits.FinalizationWait + 5*time.Second):
 		t.Fatal("capture did not finish after forwarding SIGTERM")
 	}
 	require.NoError(t, got.err)
@@ -189,7 +188,7 @@ func TestForwardSignalsDeliversSignalBufferedBeforeChildAvailable(t *testing.T) 
 
 func waitForCaptureSignalMarker(t *testing.T, marker string) int {
 	t.Helper()
-	deadline := time.After(2 * time.Second)
+	deadline := time.After(20 * time.Second)
 	for {
 		if data, err := os.ReadFile(marker); err == nil {
 			group, parseErr := strconv.Atoi(string(data))

--- a/scripts/docs_assets_test.go
+++ b/scripts/docs_assets_test.go
@@ -1,16 +1,20 @@
 package scripts
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const windowsStatusDLLInitFailed = uint32(0xc0000142)
 
 func TestHydrateAssetsForceFetchesRemoteAssetBranches(t *testing.T) {
 	tempDir := t.TempDir()
@@ -57,9 +61,7 @@ func TestHydrateAssetsForceFetchesRemoteAssetBranches(t *testing.T) {
 	scriptPath := filepath.Join(docsAssetsDir, "hydrate-assets.sh")
 	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
 
-	cmd := exec.Command("bash", scriptPath)
-	cmd.Dir = localRepo
-	output, err := cmd.CombinedOutput()
+	output, err := runBash(t, localRepo, nil, scriptPath)
 	require.NoError(t, err, string(output))
 
 	logo, err := os.ReadFile(filepath.Join(localRepo, "docs", "assets", "static", "og-image.png"))
@@ -110,9 +112,7 @@ func TestAssetPublishersRejectUnexpectedFiles(t *testing.T) {
 			require.NoError(t, os.WriteFile(filepath.Join(sourceDir, ".env.local"), []byte("TOKEN=secret\n"), 0o600))
 
 			scriptPath := installScript(t, repo, tc.scriptRel)
-			cmd := exec.Command("bash", scriptPath, "--source", sourceDir)
-			cmd.Dir = repo
-			output, err := cmd.CombinedOutput()
+			output, err := runBash(t, repo, nil, scriptPath, "--source", sourceDir)
 
 			require.Error(t, err, string(output))
 			assert.Contains(t, string(output), "unexpected")
@@ -133,9 +133,7 @@ func TestGeneratedAssetPublisherAcceptsSemanticSetupScreenshot(t *testing.T) {
 		t, repo,
 		filepath.Join("docs", "screenshots", "update-generated-assets-branch.sh"),
 	)
-	cmd := exec.Command("bash", scriptPath, "--source", sourceDir)
-	cmd.Dir = repo
-	output, err := cmd.CombinedOutput()
+	output, err := runBash(t, repo, nil, scriptPath, "--source", sourceDir)
 	require.NoError(t, err, string(output))
 
 	show := exec.Command(
@@ -174,11 +172,9 @@ func TestCheckDocsRejectsCorruptedMarkdownSyntax(t *testing.T) {
 		0o644,
 	))
 
-	cmd := exec.Command("bash", checkScript)
-	cmd.Dir = repo
 	pythonPath := requireRunnablePython3(t)
-	cmd.Env = append(envWithout("PATH", "PYTHON"), "PYTHON="+pythonPath, "PATH=/usr/bin:/bin")
-	output, err := cmd.CombinedOutput()
+	env := append(envWithout("PATH", "PYTHON"), "PYTHON="+pythonPath, "PATH=/usr/bin:/bin")
+	output, err := runBash(t, repo, env, checkScript)
 
 	require.Error(t, err, string(output))
 	assert.Contains(t, string(output), "docs markdown")
@@ -212,15 +208,11 @@ func TestCheckDocsRequiresRipgrepForMediaReferenceChecks(t *testing.T) {
 		0o644,
 	))
 
-	bashPath, err := exec.LookPath("bash")
-	require.NoError(t, err)
-	cmd := exec.Command(bashPath, checkScript)
-	cmd.Dir = repo
 	pythonPath := requireRunnablePython3(t)
 	emptyBin := filepath.Join(tempDir, "empty-bin")
 	require.NoError(t, os.MkdirAll(emptyBin, 0o755))
-	cmd.Env = append(envWithout("PATH", "PYTHON"), "PYTHON="+pythonPath, "PATH="+emptyBin)
-	output, err := cmd.CombinedOutput()
+	env := append(envWithout("PATH", "PYTHON"), "PYTHON="+pythonPath, "PATH="+emptyBin)
+	output, err := runBash(t, repo, env, checkScript)
 
 	require.Error(t, err, string(output))
 	assert.Contains(t, string(output), "rg not found")
@@ -351,9 +343,7 @@ cp -R "$public_docs"/. site/docs/
 printf '<urlset></urlset>\n' > site/docs/sitemap.xml
 `), 0o755))
 
-	cmd := exec.Command("bash", scriptPath, "build")
-	cmd.Dir = docsDir
-	output, err := cmd.CombinedOutput()
+	output, err := runBash(t, docsDir, nil, scriptPath, "build")
 	require.NoError(t, err, string(output))
 	assert.FileExists(t, filepath.Join(docsDir, "site", "docs", "index.md"))
 	assert.FileExists(t, filepath.Join(
@@ -409,6 +399,40 @@ func installScript(t *testing.T, repo, scriptRel string) string {
 	require.NoError(t, os.MkdirAll(filepath.Dir(scriptPath), 0o755))
 	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
 	return scriptPath
+}
+
+func runBash(
+	t *testing.T, dir string, env []string, args ...string,
+) ([]byte, error) {
+	t.Helper()
+	bashPath, err := exec.LookPath("bash")
+	require.NoError(t, err)
+	var output []byte
+	for attempt := range 3 {
+		cmd := exec.Command(bashPath, args...)
+		cmd.Dir = dir
+		if env != nil {
+			cmd.Env = env
+		}
+		output, err = cmd.CombinedOutput()
+		if !windowsDLLInitializationFailure(err) {
+			return output, err
+		}
+		if attempt < 2 {
+			time.Sleep(time.Second)
+		}
+	}
+	return output, err
+}
+
+// Git for Windows can occasionally terminate MSYS Bash before the script runs.
+// Retry only the Windows loader failure; script failures remain single-attempt.
+func windowsDLLInitializationFailure(err error) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	exitErr, ok := errors.AsType[*exec.ExitError](err)
+	return ok && uint32(exitErr.ExitCode()) == windowsStatusDLLInitFailed
 }
 
 func requireRunnablePython3(t *testing.T) string {


### PR DESCRIPTION
Capture integration tests now keep the normal 15-second finalization budget,
with outer watchdogs beyond that boundary. The disappearing-source test
synchronizes at the persisted-source hook instead of polling the manifest, so
slow SQLite setup no longer exhausts an artificially short test deadline before
the `source_unavailable` assertion. The signal test likewise allows
race-instrumented shutdown to complete within the real operation budget.

Docs script tests retry only Windows `STATUS_DLL_INIT_FAILED` (`0xC0000142`)
when launching Bash. Every other nonzero exit remains single-attempt, so script
and assertion failures are not masked.

The capture failures reproduced locally under heavy contention with the old
short deadlines and passed repeated normal and race-instrumented runs after the
change. [Default-branch CI run 5035](https://github.com/kenn-io/agentsview/actions/runs/33702150659),
the next run after 5034, also completed successfully.
