### PR TITLE
fix(sync): preserve bulk parse parallelism

### DIFF
--- a/internal/sync/parse_retention.go
+++ b/internal/sync/parse_retention.go
@@ -12,8 +12,12 @@ import (
 )
 
 const (
-	defaultParseRetentionBytes       = int64(64 << 20)
-	defaultBulkParseRetentionBytes   = int64(128 << 20)
+	defaultParseRetentionBytes = int64(64 << 20)
+	// Keep all eight workers available for the roughly 6 MiB sources that
+	// exposed bulk-sync throttling under the four-times-source-size estimate.
+	// Together with the pending-result limit, the two explicit pipeline bounds
+	// total 768 MiB.
+	defaultBulkParseRetentionBytes   = int64(256 << 20)
 	defaultBulkPendingRetentionBytes = int64(512 << 20)
 	parseRetentionFixedBytes         = int64(64 << 10)
 	parseRetentionMultiplier         = int64(4)

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -217,6 +217,19 @@ func TestBulkParseRetentionBudgetBoundsConcurrentSourceWeight(t *testing.T) {
 	assert.Equal(t, int64(2), budget.acquired.Load())
 }
 
+func TestBulkParseRetentionBudgetAdmitsWorkerPoolForMediumSources(t *testing.T) {
+	budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	for range maxWorkers {
+		lease, err := budget.acquire(ctx, 6<<20)
+		require.NoError(t, err,
+			"bulk admission must preserve the full worker pool for medium sources")
+		t.Cleanup(lease.Release)
+	}
+}
+
 func TestBulkParseRetentionBudgetScavengesOncePerParseBearingPass(t *testing.T) {
 	budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
 	var scavenges int


### PR DESCRIPTION
Full sync now keeps all eight parser workers available for medium-sized session
files while retaining explicit memory bounds. The 128 MiB active budget
introduced in #1595 charged each source at four times its on-disk size, so eight
roughly 6 MiB sources exceeded the budget and only five could parse
concurrently. In an isolated parse-heavy benchmark, that raised median elapsed
time from 165.1 ms to 255.2 ms.

This raises the active and queued parse capacity to 256 MiB while leaving the
completed pending-result limit at 512 MiB. The two explicit stage bounds
therefore total 768 MiB; conservative handling for unknown and oversized
sources and the existing collector batching remain unchanged. The same
benchmark completed in 153.6 ms, and a count-based invariant now protects
eight-worker admission for 6 MiB sources.
