### PR TITLE
fix(recall): bound vector overfetch

### DIFF
--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -454,6 +454,10 @@ func (a recallSearcherAdapter) ValidateRecallSnapshot(
 	return nil
 }
 
+func (a recallSearcherAdapter) MaxRecallSearchCandidates() int {
+	return a.ix.MaxSearchCandidates()
+}
+
 // newSearcherAdapter builds a searcherAdapter for gen's configured
 // embedding identity.
 func newSearcherAdapter(ix *vector.Index, enc kitvec.EncodeFunc, gen kitvec.Generation) searcherAdapter {

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -151,7 +151,7 @@ embedding configuration and endpoint privacy considerations.
 Vector candidates are ranked before Recall filters are applied. The embedding
 backend bounds the candidate window, so a narrow project, cwd, or other filter
 can produce a short vector page when that boundary is reached. Hybrid search
-still ranks the full filtered corpus through its lexical leg, then fuses those
+still ranks the lexical candidates selected for the query, then fuses those
 results with the available vector candidates.
 
 ## Automatic extraction

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -148,6 +148,12 @@ using lexical mode while an automatic refresh catches up. See
 [Semantic Search](/docs/semantic-search/#enabling-vector) for the shared
 embedding configuration and endpoint privacy considerations.
 
+Vector candidates are ranked before Recall filters are applied. The embedding
+backend bounds the candidate window, so a narrow project, cwd, or other filter
+can produce a short vector page when that boundary is reached. Hybrid search
+still ranks the full filtered corpus through its lexical leg, then fuses those
+results with the available vector candidates.
+
 ## Automatic extraction
 
 Extraction is opt-in and off by default. When `[recall.extract]` is enabled, a

--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -1225,7 +1225,10 @@ func (db *DB) queryRecallEntriesVector(
 		)
 	}
 	limit := recallLimit(q.Limit)
-	k := max(recallLimit(q.Limit)*4, SemanticOverfetchMin)
+	ceiling := searcher.MaxRecallSearchCandidates()
+	k := clampRecallVectorCandidates(
+		max(recallLimit(q.Limit)*4, SemanticOverfetchMin), ceiling,
+	)
 	for {
 		hits, exhausted, snapshot, err := searcher.SearchRecall(ctx, q.Text, k)
 		if err != nil {
@@ -1241,12 +1244,19 @@ func (db *DB) queryRecallEntriesVector(
 		if len(page.RecallEntries) >= limit || exhausted {
 			return page, nil
 		}
-		next := k * 2
+		next := clampRecallVectorCandidates(k*2, ceiling)
 		if next <= k {
 			return page, nil
 		}
 		k = next
 	}
+}
+
+func clampRecallVectorCandidates(k, ceiling int) int {
+	if ceiling <= 0 || k <= ceiling {
+		return k
+	}
+	return ceiling
 }
 
 func (db *DB) recallPageFromVectorHits(

--- a/internal/db/recall_test.go
+++ b/internal/db/recall_test.go
@@ -25,22 +25,37 @@ type fakeRecallVectorSearcher struct {
 }
 
 type boundedRecallVectorSearcher struct {
-	hits   []RecallVectorHit
-	limits []int
+	hits              []RecallVectorHit
+	limits            []int
+	maxCandidates     int
+	forceNotExhausted bool
+	err               error
+	errAt             int
 }
 
 func (f *boundedRecallVectorSearcher) SearchRecall(
 	_ context.Context, _ string, limit int,
 ) ([]RecallVectorHit, bool, RecallVectorSnapshot, error) {
 	f.limits = append(f.limits, limit)
+	if f.err != nil && (f.errAt == 0 || limit >= f.errAt) {
+		return nil, false, RecallVectorSnapshot{}, f.err
+	}
+	exhausted := len(f.hits) <= limit
+	if f.forceNotExhausted {
+		exhausted = false
+	}
 	return append([]RecallVectorHit(nil), f.hits[:min(limit, len(f.hits))]...),
-		len(f.hits) <= limit, RecallVectorSnapshot{}, nil
+		exhausted, RecallVectorSnapshot{}, nil
 }
 
 func (f *boundedRecallVectorSearcher) ValidateRecallSnapshot(
 	context.Context, RecallVectorSnapshot,
 ) error {
 	return nil
+}
+
+func (f *boundedRecallVectorSearcher) MaxRecallSearchCandidates() int {
+	return f.maxCandidates
 }
 
 func (f *fakeRecallVectorSearcher) SearchRecall(
@@ -76,6 +91,29 @@ func (f *fakeRecallVectorSearcher) ValidateRecallSnapshot(
 		return NewSemanticUnavailableError("recall corpus changed during search")
 	}
 	return nil
+}
+
+func (f *fakeRecallVectorSearcher) MaxRecallSearchCandidates() int {
+	return 0
+}
+
+func TestClampRecallVectorCandidates(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		k       int
+		ceiling int
+		want    int
+	}{
+		{name: "unbounded", k: 8192, ceiling: 0, want: 8192},
+		{name: "below ceiling", k: 2048, ceiling: 4096, want: 2048},
+		{name: "at ceiling", k: 4096, ceiling: 4096, want: 4096},
+		{name: "above ceiling", k: 8192, ceiling: 4096, want: 4096},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want,
+				clampRecallVectorCandidates(tt.k, tt.ceiling))
+		})
+	}
 }
 
 func TestRecallEntriesSchemaIndexesSourceEpisode(t *testing.T) {
@@ -1873,6 +1911,121 @@ func TestQueryRecallEntriesVectorExpandsPastFilteredCandidates(t *testing.T) {
 	require.Len(t, page.RecallEntries, 1)
 	assert.Equal(t, "matching-project", page.RecallEntries[0].ID)
 	assert.Equal(t, []int{SemanticOverfetchMin, SemanticOverfetchMin * 2}, searcher.limits)
+}
+
+func TestQueryRecallEntriesVectorStopsAtSearcherCandidateCeiling(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	for _, entry := range []RecallEntry{
+		{
+			ID: "excluded", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Other project status", Body: "Filtered status result.",
+			Project: "other", SourceSessionID: "s1",
+		},
+		{
+			ID: "matching", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Matching project status", Body: "Eligible status result.",
+			Project: "agentsview", SourceSessionID: "s1",
+		},
+	} {
+		_, err := d.InsertRecallEntry(entry)
+		require.NoError(t, err)
+	}
+	searcher := &boundedRecallVectorSearcher{
+		hits: []RecallVectorHit{
+			{EntryID: "excluded", Score: 0.9},
+			{EntryID: "matching", Score: 0.8},
+		},
+		maxCandidates:     4096,
+		forceNotExhausted: true,
+	}
+	d.SetRecallVectorSearcher(searcher)
+
+	page, err := d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "status", Mode: RecallQueryModeVector,
+		Project: "agentsview", Limit: 3,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, page.RecallEntries, 1)
+	assert.Equal(t, "matching", page.RecallEntries[0].ID)
+	assert.Equal(t, []int{200, 400, 800, 1600, 3200, 4096}, searcher.limits)
+	for _, limit := range searcher.limits {
+		assert.LessOrEqual(t, limit, 4096)
+	}
+}
+
+func TestQueryRecallEntriesHybridReturnsPartialPageAtCandidateCeiling(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	for _, entry := range []RecallEntry{
+		{
+			ID: "excluded", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Other project status", Body: "Filtered status result.",
+			Project: "other", SourceSessionID: "s1",
+		},
+		{
+			ID: "matching", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Matching project status", Body: "Eligible status result.",
+			Project: "agentsview", SourceSessionID: "s1",
+		},
+	} {
+		_, err := d.InsertRecallEntry(entry)
+		require.NoError(t, err)
+	}
+	searcher := &boundedRecallVectorSearcher{
+		hits: []RecallVectorHit{
+			{EntryID: "excluded", Score: 0.9},
+			{EntryID: "matching", Score: 0.8},
+		},
+		maxCandidates:     4096,
+		forceNotExhausted: true,
+	}
+	d.SetRecallVectorSearcher(searcher)
+
+	page, err := d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "status", Mode: RecallQueryModeHybrid,
+		Project: "agentsview", Limit: 3,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, page.RecallEntries, 1)
+	assert.Equal(t, "matching", page.RecallEntries[0].ID)
+	assert.Equal(t, []int{2000, 4000, 4096}, searcher.limits)
+	for _, limit := range searcher.limits {
+		assert.LessOrEqual(t, limit, 4096)
+	}
+}
+
+func TestQueryRecallEntriesVectorPreservesSearcherErrorAtCandidateCeiling(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "excluded", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Other project status", Body: "Filtered status result.",
+		Project: "other", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	wantErr := errors.New("searcher failed at candidate ceiling")
+	searcher := &boundedRecallVectorSearcher{
+		hits:              []RecallVectorHit{{EntryID: "excluded", Score: 0.9}},
+		maxCandidates:     4096,
+		forceNotExhausted: true,
+		err:               wantErr,
+		errAt:             4096,
+	}
+	d.SetRecallVectorSearcher(searcher)
+
+	_, err = d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "status", Mode: RecallQueryModeVector,
+		Project: "agentsview", Limit: 3,
+	})
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.Equal(t, []int{200, 400, 800, 1600, 3200, 4096}, searcher.limits)
 }
 
 func TestQueryRecallEntriesHybridUsesReciprocalRankFusion(t *testing.T) {

--- a/internal/db/recall_test.go
+++ b/internal/db/recall_test.go
@@ -1919,6 +1919,34 @@ func TestQueryRecallEntriesVectorExpandsPastFilteredCandidates(t *testing.T) {
 	assert.Equal(t, []int{SemanticOverfetchMin, SemanticOverfetchMin * 2}, searcher.limits)
 }
 
+func TestQueryRecallEntriesVectorStopsAtExhaustionBelowCandidateCeiling(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	hits := make([]RecallVectorHit, 0, SemanticOverfetchMin+1)
+	for i := range SemanticOverfetchMin + 1 {
+		id := fmt.Sprintf("excluded-%03d", i)
+		_, err := d.InsertRecallEntry(RecallEntry{
+			ID: id, Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Other project", Body: "Excluded before the candidate ceiling.",
+			Project: "other", SourceSessionID: "s1",
+		})
+		require.NoError(t, err)
+		hits = append(hits, RecallVectorHit{EntryID: id, Score: float32(1 - float64(i)/1000)})
+	}
+	searcher := &boundedRecallVectorSearcher{hits: hits, maxCandidates: 4096}
+	d.SetRecallVectorSearcher(searcher)
+
+	page, err := d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "semantic policy", Mode: RecallQueryModeVector,
+		Project: "agentsview", Limit: 1,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, page.RecallEntries)
+	assert.Equal(t, []int{SemanticOverfetchMin, SemanticOverfetchMin * 2}, searcher.limits)
+}
+
 func TestQueryRecallEntriesVectorStopsAtSearcherCandidateCeiling(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/db/recall_test.go
+++ b/internal/db/recall_test.go
@@ -31,6 +31,8 @@ type boundedRecallVectorSearcher struct {
 	forceNotExhausted bool
 	err               error
 	errAt             int
+	snapshotErr       error
+	snapshotErrAt     int
 }
 
 func (f *boundedRecallVectorSearcher) SearchRecall(
@@ -51,6 +53,10 @@ func (f *boundedRecallVectorSearcher) SearchRecall(
 func (f *boundedRecallVectorSearcher) ValidateRecallSnapshot(
 	context.Context, RecallVectorSnapshot,
 ) error {
+	if f.snapshotErr != nil && len(f.limits) > 0 &&
+		(f.snapshotErrAt == 0 || f.limits[len(f.limits)-1] >= f.snapshotErrAt) {
+		return f.snapshotErr
+	}
 	return nil
 }
 
@@ -1899,7 +1905,7 @@ func TestQueryRecallEntriesVectorExpandsPastFilteredCandidates(t *testing.T) {
 	})
 	require.NoError(t, err)
 	hits = append(hits, RecallVectorHit{EntryID: "matching-project", Score: 0.5})
-	searcher := &boundedRecallVectorSearcher{hits: hits}
+	searcher := &boundedRecallVectorSearcher{hits: hits, maxCandidates: 4096}
 	d.SetRecallVectorSearcher(searcher)
 
 	page, err := d.QueryRecallEntries(ctx, RecallQuery{
@@ -2016,6 +2022,35 @@ func TestQueryRecallEntriesVectorPreservesSearcherErrorAtCandidateCeiling(t *tes
 		forceNotExhausted: true,
 		err:               wantErr,
 		errAt:             4096,
+	}
+	d.SetRecallVectorSearcher(searcher)
+
+	_, err = d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "status", Mode: RecallQueryModeVector,
+		Project: "agentsview", Limit: 3,
+	})
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.Equal(t, []int{200, 400, 800, 1600, 3200, 4096}, searcher.limits)
+}
+
+func TestQueryRecallEntriesVectorPreservesSnapshotErrorAtCandidateCeiling(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "excluded", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Other project status", Body: "Filtered status result.",
+		Project: "other", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	wantErr := errors.New("snapshot changed at candidate ceiling")
+	searcher := &boundedRecallVectorSearcher{
+		hits:              []RecallVectorHit{{EntryID: "excluded", Score: 0.9}},
+		maxCandidates:     4096,
+		forceNotExhausted: true,
+		snapshotErr:       wantErr,
+		snapshotErrAt:     4096,
 	}
 	d.SetRecallVectorSearcher(searcher)
 

--- a/internal/db/vector.go
+++ b/internal/db/vector.go
@@ -118,6 +118,9 @@ type RecallVectorSearcher interface {
 		ctx context.Context, query string, limit int,
 	) (hits []RecallVectorHit, exhausted bool, snapshot RecallVectorSnapshot, err error)
 	ValidateRecallSnapshot(ctx context.Context, snapshot RecallVectorSnapshot) error
+	// MaxRecallSearchCandidates returns the largest accepted SearchRecall
+	// limit, or zero when the backend has no candidate ceiling.
+	MaxRecallSearchCandidates() int
 }
 
 // SetVectorSearcher wires (or, with nil, clears) the semantic search

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -35,6 +35,10 @@ func (f *fakeMCPRecallVectorSearcher) ValidateRecallSnapshot(
 	return nil
 }
 
+func (f *fakeMCPRecallVectorSearcher) MaxRecallSearchCandidates() int {
+	return 0
+}
+
 func newTestToolset(t *testing.T) (*toolset, *db.DB) {
 	t.Helper()
 	d := dbtest.OpenTestDB(t)

--- a/internal/server/recall_test.go
+++ b/internal/server/recall_test.go
@@ -78,6 +78,35 @@ func (*readOnlyRecallQueryStore) ReadOnly() bool { return true }
 
 type recallErrorSearcher struct{ err error }
 
+type issueRecallVectorSearcher struct {
+	hits   []db.RecallVectorHit
+	limits []int
+}
+
+func (s *issueRecallVectorSearcher) SearchRecall(
+	_ context.Context, _ string, limit int,
+) ([]db.RecallVectorHit, bool, db.RecallVectorSnapshot, error) {
+	s.limits = append(s.limits, limit)
+	if limit > 4096 {
+		return nil, false, db.RecallVectorSnapshot{}, fmt.Errorf(
+			"search: k value in knn query too large, provided %d and the limit is 4096",
+			limit,
+		)
+	}
+	return append([]db.RecallVectorHit(nil), s.hits...), false,
+		db.RecallVectorSnapshot{}, nil
+}
+
+func (s *issueRecallVectorSearcher) ValidateRecallSnapshot(
+	context.Context, db.RecallVectorSnapshot,
+) error {
+	return nil
+}
+
+func (s *issueRecallVectorSearcher) MaxRecallSearchCandidates() int {
+	return 4096
+}
+
 type recallExtractionStatusProvider struct {
 	status recallextract.Status
 	err    error
@@ -119,6 +148,56 @@ func (s recallErrorSearcher) ValidateRecallSnapshot(
 	context.Context, db.RecallVectorSnapshot,
 ) error {
 	return s.err
+}
+
+func (s recallErrorSearcher) MaxRecallSearchCandidates() int {
+	return 0
+}
+
+func TestQueryRecallHybridWithFilterReturnsPartialAtVectorCandidateCeiling(t *testing.T) {
+	te := setup(t)
+	seedRecallEntrySession(t, te)
+	seedRecallEntry(t, te, db.RecallEntry{
+		ID:              "eligible",
+		Title:           "Status recovery",
+		Body:            "Check status before retrying the operation.",
+		Project:         "agentsview",
+		SourceSessionID: "recall-session",
+	})
+	seedRecallEntry(t, te, db.RecallEntry{
+		ID:              "filtered",
+		Title:           "Status from another project",
+		Body:            "This result should be removed by the project filter.",
+		Project:         "other",
+		SourceSessionID: "other-session",
+	})
+	searcher := &issueRecallVectorSearcher{hits: []db.RecallVectorHit{
+		{EntryID: "filtered", Score: 0.9},
+		{EntryID: "eligible", Score: 0.8},
+	}}
+	te.db.SetRecallVectorSearcher(searcher)
+
+	w := te.post(t, "/api/v1/recall/query", `{
+		"query":"status",
+		"project":"agentsview",
+		"mode":"hybrid",
+		"limit":3
+	}`)
+
+	if !assert.Equal(t, http.StatusOK, w.Code) {
+		t.Logf("observed response: HTTP %d body=%s", w.Code, w.Body.String())
+		assertBodyContains(t, w,
+			"search: k value in knn query too large, provided 8000 and the limit is 4096")
+		assert.Equal(t, []int{2000, 4000, 8000}, searcher.limits)
+		return
+	}
+	r := decode[queryRecallEntriesResponse](t, w)
+	require.NotEmpty(t, r.RecallEntries)
+	assert.Equal(t, []string{"eligible"}, []string{r.RecallEntries[0].ID})
+	assert.Equal(t, []int{2000, 4000, 4096}, searcher.limits)
+	for _, limit := range searcher.limits {
+		assert.LessOrEqual(t, limit, 4096)
+	}
 }
 
 func TestQueryRecallMapsSemanticAvailabilityErrors(t *testing.T) {

--- a/internal/server/recall_test.go
+++ b/internal/server/recall_test.go
@@ -192,8 +192,8 @@ func TestQueryRecallHybridWithFilterReturnsPartialAtVectorCandidateCeiling(t *te
 		return
 	}
 	r := decode[queryRecallEntriesResponse](t, w)
-	require.NotEmpty(t, r.RecallEntries)
-	assert.Equal(t, []string{"eligible"}, []string{r.RecallEntries[0].ID})
+	require.Len(t, r.RecallEntries, 1)
+	assert.Equal(t, "eligible", r.RecallEntries[0].ID)
 	assert.Equal(t, []int{2000, 4000, 4096}, searcher.limits)
 	for _, limit := range searcher.limits {
 		assert.LessOrEqual(t, limit, 4096)

--- a/internal/vector/search.go
+++ b/internal/vector/search.go
@@ -13,7 +13,10 @@ import (
 
 // snippetMaxRunes bounds the length of a Hit's Snippet; longer chunks are
 // truncated with a trailing ellipsis.
-const snippetMaxRunes = 200
+const (
+	snippetMaxRunes  = 200
+	MaxKNNCandidates = 4096 // sqlite-vec's vec0 KNN candidate ceiling.
+)
 
 // Hit is one unit-level semantic search result, anchored to a specific
 // message. For a run document Ordinal is the anchor: the member message
@@ -133,6 +136,12 @@ func (ix *Index) SearchPage(
 
 	hydrated, err := ix.hydrateHits(ctx, hits)
 	return hydrated, exhausted, err
+}
+
+// MaxSearchCandidates reports the largest KNN candidate count accepted by
+// the sqlite-vec engine backing this index.
+func (ix *Index) MaxSearchCandidates() int {
+	return MaxKNNCandidates
 }
 
 // noActiveGenerationError distinguishes an empty index (ErrNoActiveGeneration)

--- a/internal/vector/search_test.go
+++ b/internal/vector/search_test.go
@@ -121,6 +121,26 @@ func TestSearchPageExhaustionUsesChunkCandidatesBeforeDocumentRollup(t *testing.
 	assert.True(t, exhausted)
 }
 
+func TestSearchRejectsCandidateCountAboveEngineKMax(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+
+	_, err := ix.Build(ctx, threeDocSearchSource(), fakeSearchEncoder(),
+		fakeGeneration("fake-model"), BuildOptions{})
+	require.NoError(t, err)
+
+	_, _, err = ix.SearchPage(
+		ctx, fakeSearchEncoder(), "alpha", MaxKNNCandidates,
+	)
+	require.NoError(t, err)
+
+	_, _, err = ix.SearchPage(
+		ctx, fakeSearchEncoder(), "alpha", MaxKNNCandidates+1,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "k value in knn query too large")
+}
+
 func TestSearchNoGenerationsReturnsErrNoActiveGeneration(t *testing.T) {
 	ix := openTestIndex(t)
 	ctx := context.Background()


### PR DESCRIPTION
Selective hybrid recall queries can exceed sqlite-vec's 4,096-result KNN limit when a project, cwd, or current-cwd filter matches a small share of the archive, turning a normal short result into HTTP 500.

This bounds vector candidate expansion at the backend's supported window and returns the snapshot-validated filtered page available at that boundary. Expansion below the ceiling, lexical ranking, reciprocal-rank fusion, and existing recall filter semantics remain unchanged.

Closes #1565
