### PR TITLE
fix(vector): reload Ollama Metal before CPU fallback

### DIFF
--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -196,7 +196,7 @@ func TestVectorGenerationParams(t *testing.T) {
 }
 
 func TestNewVectorEncoderWiresOllamaCPUFallback(t *testing.T) {
-	var cpuCalls atomic.Int32
+	var nativeCalls, cpuCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
@@ -207,11 +207,25 @@ func TestNewVectorEncoderWiresOllamaCPUFallback(t *testing.T) {
 				}},
 			}))
 		case "/api/embed":
+			nativeCalls.Add(1)
+			var request struct {
+				Options map[string]any `json:"options"`
+			}
+			require.NoError(t, json.UnmarshalRead(r.Body, &request))
+			if request.Options == nil {
+				require.NoError(t, json.MarshalWrite(w, map[string]any{
+					"model":      "test-model",
+					"embeddings": [][]float32{{0, 0, 0}},
+				}))
+				return
+			}
 			cpuCalls.Add(1)
 			require.NoError(t, json.MarshalWrite(w, map[string]any{
 				"model":      "test-model",
 				"embeddings": [][]float32{{1, 2, 3}},
 			}))
+		case "/api/ps":
+			require.NoError(t, json.MarshalWrite(w, map[string]any{"models": []any{}}))
 		default:
 			require.FailNow(t, "unexpected request path", r.URL.Path)
 		}
@@ -235,6 +249,7 @@ func TestNewVectorEncoderWiresOllamaCPUFallback(t *testing.T) {
 	out, err := enc(context.Background(), []string{"alpha"})
 	require.NoError(t, err)
 	assert.Equal(t, [][]float32{{1, 2, 3}}, out)
+	assert.Equal(t, int32(3), nativeCalls.Load())
 	assert.Equal(t, int32(1), cpuCalls.Load())
 }
 

--- a/internal/vector/encoder.go
+++ b/internal/vector/encoder.go
@@ -33,8 +33,8 @@ type EncoderConfig struct {
 	// APIKey is sent as a Bearer token when non-empty. Empty means
 	// anonymous, unauthenticated requests.
 	APIKey string
-	// OllamaCPUFallback enables one native Ollama CPU retry for invalid vectors.
-	// Callers must opt in only for an Ollama endpoint ending in /v1.
+	// OllamaCPUFallback reloads an invalid Ollama Metal runner before one native
+	// CPU retry. Callers must opt in only for an Ollama endpoint ending in /v1.
 	OllamaCPUFallback bool
 	// Model is the embeddings model name sent in the request body.
 	Model string
@@ -195,12 +195,12 @@ type embeddingsResponseBody struct {
 }
 
 type ollamaEmbedRequest struct {
-	Model      string             `json:"model"`
-	Input      []string           `json:"input"`
-	Truncate   bool               `json:"truncate"`
-	Dimensions int                `json:"dimensions,omitzero"`
-	Options    ollamaEmbedOptions `json:"options"`
-	KeepAlive  string             `json:"keep_alive"`
+	Model      string              `json:"model"`
+	Input      []string            `json:"input"`
+	Truncate   bool                `json:"truncate"`
+	Dimensions int                 `json:"dimensions,omitzero"`
+	Options    *ollamaEmbedOptions `json:"options,omitempty"`
+	KeepAlive  string              `json:"keep_alive,omitempty"`
 }
 
 type ollamaEmbedOptions struct {
@@ -209,6 +209,13 @@ type ollamaEmbedOptions struct {
 
 type ollamaEmbedResponse struct {
 	Embeddings []embeddingVector `json:"embeddings"`
+}
+
+type ollamaProcessResponse struct {
+	Models []struct {
+		Model string `json:"model"`
+		Name  string `json:"name"`
+	} `json:"models"`
 }
 
 // embeddingVector decodes an OpenAI-compatible embedding that arrives either
@@ -329,9 +336,9 @@ func (g *ollamaEndpointGate) releaseWrite() {
 
 // NewEncoder returns a kitvec.EncodeFunc that POSTs to an OpenAI-compatible
 // embeddings endpoint. Each invocation makes primary calls according to the
-// retry policy and, when explicitly enabled, at most one native Ollama CPU
-// fallback call. Batching and concurrency are the caller's responsibility via
-// kitvec.EncodeBatched.
+// retry policy and, when explicitly enabled, recovers invalid Ollama responses
+// by unloading and retrying the Metal runner before falling back to CPU.
+// Batching and concurrency are the caller's responsibility via kitvec.EncodeBatched.
 //
 // Requests ask for base64-encoded embeddings (encoding_format "base64",
 // ~4x smaller than JSON float arrays); responses in either format are
@@ -372,6 +379,14 @@ func openAIEmbeddingsURL(endpoint string) (string, error) {
 }
 
 func ollamaEmbedURL(endpoint string) (string, error) {
+	return ollamaAPIURL(endpoint, "/api/embed")
+}
+
+func ollamaPSURL(endpoint string) (string, error) {
+	return ollamaAPIURL(endpoint, "/api/ps")
+}
+
+func ollamaAPIURL(endpoint, apiPath string) (string, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return "", fmt.Errorf("parse Ollama endpoint: %w", err)
@@ -386,9 +401,9 @@ func ollamaEmbedURL(endpoint string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("parse Ollama endpoint path: %w", err)
 		}
-		u.RawPath = rawBase + "/api/embed"
+		u.RawPath = rawBase + apiPath
 	}
-	u.Path = basePath + "/api/embed"
+	u.Path = basePath + apiPath
 	return u.String(), nil
 }
 
@@ -501,7 +516,7 @@ func (ec *encoderClient) encode(ctx context.Context, texts []string) ([][]float3
 		nonRateLimitAttempts++
 		if nonRateLimitAttempts == maxAttempts && ec.cfg.OllamaCPUFallback {
 			if _, ok := errors.AsType[*InvalidEmbeddingError](err); ok {
-				merged, fallbackErr := ec.ollamaCPUFallback(ctx, texts, vectors)
+				merged, fallbackErr := ec.ollamaFallback(ctx, texts, vectors)
 				if fallbackErr == nil {
 					return merged, nil
 				}
@@ -529,7 +544,7 @@ func isRateLimitError(err error) bool {
 	return false
 }
 
-func (ec *encoderClient) ollamaCPUFallback(
+func (ec *encoderClient) ollamaFallback(
 	ctx context.Context, texts []string, primaryVectors [][]float32,
 ) ([][]float32, error) {
 	if ec.gate != nil {
@@ -550,29 +565,163 @@ func (ec *encoderClient) ollamaCPUFallback(
 		invalidInputs = append(invalidInputs, requestInputs[index])
 	}
 
+	fallbackURL, err := ollamaEmbedURL(ec.cfg.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	psURL, err := ollamaPSURL(ec.cfg.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	recovered, unloadErr := ec.ollamaNativeEmbed(
+		ctx, fallbackURL, invalidInputs, invalidIndices, nil, "0s",
+	)
+	unloadWaitErr := ec.waitForOllamaUnload(ctx, psURL)
+	if unloadErr == nil && unloadWaitErr == nil {
+		return mergeOllamaVectors(primaryVectors, invalidIndices, recovered), nil
+	}
+
+	var reloadErr error
+	if unloadWaitErr == nil {
+		recovered, reloadErr = ec.ollamaNativeEmbed(
+			ctx, fallbackURL, invalidInputs, invalidIndices, nil, "",
+		)
+		if reloadErr == nil {
+			return mergeOllamaVectors(primaryVectors, invalidIndices, recovered), nil
+		}
+	}
+
+	recovered, cpuErr := ec.ollamaNativeEmbed(
+		ctx, fallbackURL, invalidInputs, invalidIndices,
+		&ollamaEmbedOptions{NumGPU: 0}, "0s",
+	)
+	if cpuErr != nil {
+		var recoveryErr error
+		if unloadErr != nil {
+			recoveryErr = errors.Join(
+				recoveryErr, fmt.Errorf("ollama Metal unload request: %w", unloadErr))
+		}
+		if unloadWaitErr != nil {
+			recoveryErr = errors.Join(
+				recoveryErr, fmt.Errorf("ollama Metal unload wait: %w", unloadWaitErr))
+		}
+		if reloadErr != nil {
+			recoveryErr = errors.Join(
+				recoveryErr, fmt.Errorf("ollama Metal retry: %w", reloadErr))
+		}
+		return nil, errors.Join(recoveryErr, fmt.Errorf("ollama CPU fallback: %w", cpuErr))
+	}
+	return mergeOllamaVectors(primaryVectors, invalidIndices, recovered), nil
+}
+
+const ollamaUnloadTimeout = 10 * time.Second
+
+func (ec *encoderClient) waitForOllamaUnload(ctx context.Context, psURL string) error {
+	ctx, cancel := context.WithTimeout(ctx, ollamaUnloadTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		loaded, err := ec.ollamaModelLoaded(ctx, psURL)
+		if err != nil {
+			return err
+		}
+		if !loaded {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (ec *encoderClient) ollamaModelLoaded(ctx context.Context, psURL string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, psURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("build Ollama process request: %w", err)
+	}
+	if ec.cfg.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+ec.cfg.APIKey)
+	}
+	resp, err := ec.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("ollama process request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return false, &HTTPStatusError{
+			Status: resp.StatusCode,
+			Body:   strings.TrimSpace(string(body)),
+		}
+	}
+
+	var decoded ollamaProcessResponse
+	if err := json.UnmarshalRead(resp.Body, &decoded); err != nil {
+		return false, fmt.Errorf("decode Ollama process response: %w", err)
+	}
+	for _, model := range decoded.Models {
+		if ollamaModelNamesMatch(ec.cfg.Model, model.Model) ||
+			ollamaModelNamesMatch(ec.cfg.Model, model.Name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func ollamaModelNamesMatch(configured, loaded string) bool {
+	return ollamaDisplayModelName(configured) == ollamaDisplayModelName(loaded)
+}
+
+func ollamaDisplayModelName(name string) string {
+	if _, rest, ok := strings.Cut(name, "://"); ok {
+		name = rest
+	}
+	parts := strings.Split(name, "/")
+	if len(parts) >= 3 && strings.EqualFold(parts[0], "registry.ollama.ai") {
+		parts = parts[1:]
+		if len(parts) == 2 && strings.EqualFold(parts[0], "library") {
+			parts = parts[1:]
+		}
+	}
+	last := len(parts) - 1
+	if !strings.Contains(parts[last], ":") {
+		parts[last] += ":latest"
+	}
+	return strings.Join(parts, "/")
+}
+
+func (ec *encoderClient) ollamaNativeEmbed(
+	ctx context.Context,
+	fallbackURL string,
+	inputs []string,
+	originalIndices []int,
+	options *ollamaEmbedOptions,
+	keepAlive string,
+) ([][]float32, error) {
 	body := ollamaEmbedRequest{
 		Model:     ec.cfg.Model,
-		Input:     invalidInputs,
+		Input:     inputs,
 		Truncate:  false,
-		Options:   ollamaEmbedOptions{NumGPU: 0},
-		KeepAlive: "0s",
+		Options:   options,
+		KeepAlive: keepAlive,
 	}
 	if ec.cfg.RequestDimensions {
 		body.Dimensions = ec.cfg.Dimension
 	}
 	reqBody, err := json.Marshal(body)
 	if err != nil {
-		return nil, fmt.Errorf("marshal Ollama CPU request: %w", err)
-	}
-	fallbackURL, err := ollamaEmbedURL(ec.cfg.Endpoint)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("marshal Ollama embed request: %w", err)
 	}
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodPost, fallbackURL, bytes.NewReader(reqBody),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("build Ollama CPU request: %w", err)
+		return nil, fmt.Errorf("build Ollama embed request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if ec.cfg.APIKey != "" {
@@ -580,7 +729,7 @@ func (ec *encoderClient) ollamaCPUFallback(
 	}
 	resp, err := ec.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("ollama CPU request: %w", err)
+		return nil, fmt.Errorf("ollama embed request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -593,29 +742,39 @@ func (ec *encoderClient) ollamaCPUFallback(
 
 	var decoded ollamaEmbedResponse
 	if err := json.UnmarshalRead(resp.Body, &decoded); err != nil {
-		return nil, fmt.Errorf("decode Ollama CPU response: %w", err)
+		return nil, fmt.Errorf("decode Ollama embed response: %w", err)
 	}
-	if len(decoded.Embeddings) != len(invalidIndices) {
+	if len(decoded.Embeddings) != len(originalIndices) {
 		return nil, fmt.Errorf(
-			"ollama CPU response count mismatch: got %d embeddings, want %d",
-			len(decoded.Embeddings), len(invalidIndices))
+			"ollama embed response count mismatch: got %d embeddings, want %d",
+			len(decoded.Embeddings), len(originalIndices))
 	}
 
-	merged := make([][]float32, len(primaryVectors))
-	copy(merged, primaryVectors)
-	for fallbackIndex, originalIndex := range invalidIndices {
+	recovered := make([][]float32, len(decoded.Embeddings))
+	for fallbackIndex, originalIndex := range originalIndices {
 		vector := []float32(decoded.Embeddings[fallbackIndex])
 		if len(vector) != ec.cfg.Dimension {
 			return nil, fmt.Errorf(
-				"ollama CPU response dimension mismatch at index %d: got %d, want %d",
+				"ollama embed response dimension mismatch at index %d: got %d, want %d",
 				originalIndex, len(vector), ec.cfg.Dimension)
 		}
 		if err := validateEmbedding(vector, originalIndex); err != nil {
 			return nil, err
 		}
-		merged[originalIndex] = vector
+		recovered[fallbackIndex] = vector
 	}
-	return merged, nil
+	return recovered, nil
+}
+
+func mergeOllamaVectors(
+	primaryVectors [][]float32, invalidIndices []int, recovered [][]float32,
+) [][]float32 {
+	merged := make([][]float32, len(primaryVectors))
+	copy(merged, primaryVectors)
+	for recoveredIndex, originalIndex := range invalidIndices {
+		merged[originalIndex] = recovered[recoveredIndex]
+	}
+	return merged
 }
 
 // isEncodingFormatRejection reports whether err is a client-error response

--- a/internal/vector/encoder_test.go
+++ b/internal/vector/encoder_test.go
@@ -91,6 +91,44 @@ func TestEmbeddingURLsPreserveEndpointComponents(t *testing.T) {
 	}
 }
 
+func TestOllamaModelNamesMatchProcessDisplayNames(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		loaded     string
+		want       bool
+	}{
+		{name: "exact", configured: "model:tag", loaded: "model:tag", want: true},
+		{name: "implicit latest", configured: "model", loaded: "model:latest", want: true},
+		{
+			name: "default registry and namespace", configured: "registry.ollama.ai/library/model:tag",
+			loaded: "model:tag", want: true,
+		},
+		{
+			name:       "protocol-qualified default registry",
+			configured: "https://registry.ollama.ai/library/model:tag",
+			loaded:     "model:tag", want: true,
+		},
+		{
+			name: "default registry", configured: "registry.ollama.ai/team/model:tag",
+			loaded: "team/model:tag", want: true,
+		},
+		{
+			name: "different registries", configured: "host-a.example/team/model:tag",
+			loaded: "host-b.example/team/model:tag", want: false,
+		},
+		{
+			name: "different namespaces", configured: "team-a/model:tag",
+			loaded: "team-b/model:tag", want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ollamaModelNamesMatch(tt.configured, tt.loaded))
+		})
+	}
+}
+
 func TestEncoderHappyPath(t *testing.T) {
 	var gotPath string
 	var gotAuth string
@@ -271,9 +309,74 @@ func TestEncoderRetriesInvalidEmbeddingResponse(t *testing.T) {
 	assert.Equal(t, [][]float32{{1, 2, 3}}, out)
 }
 
+func TestEncoderOllamaFallbackReloadsMetalBeforeCPU(t *testing.T) {
+	var nativeRequests []testOllamaEmbedRequest
+	var unloadChecks int
+	runnerLoaded := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/embeddings":
+			writeJSON(t, w, http.StatusOK, map[string]any{"data": []map[string]any{
+				{"index": 0, "embedding": base64Embedding([]float32{0, 0, 0})},
+			}})
+		case "/api/embed":
+			var request testOllamaEmbedRequest
+			require.NoError(t, json.UnmarshalRead(r.Body, &request))
+			nativeRequests = append(nativeRequests, request)
+			switch len(nativeRequests) {
+			case 1:
+				runnerLoaded = true
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"embeddings": [][]float32{{0, 0, 0}},
+				})
+			case 2:
+				if runnerLoaded {
+					writeJSON(t, w, http.StatusOK, map[string]any{
+						"embeddings": [][]float32{{0, 0, 0}},
+					})
+					return
+				}
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"embeddings": [][]float32{{4, 5, 6}},
+				})
+			default:
+				http.Error(w, "unexpected CPU fallback", http.StatusInternalServerError)
+			}
+		case "/api/ps":
+			unloadChecks++
+			if unloadChecks == 1 {
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"models": []map[string]any{{"model": "test-model"}},
+				})
+				return
+			}
+			runnerLoaded = false
+			writeJSON(t, w, http.StatusOK, map[string]any{"models": []any{}})
+		default:
+			require.FailNow(t, "unexpected request path", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint: srv.URL + "/v1", Model: "test-model", Dimension: 3,
+		Timeout: time.Second, MaxRetries: 1, OllamaCPUFallback: true,
+	})
+	out, err := enc(context.Background(), []string{"alpha"})
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{4, 5, 6}}, out)
+	require.Len(t, nativeRequests, 2)
+	assert.Nil(t, nativeRequests[0].Options, "the unload request must stay on Metal")
+	assert.Equal(t, "0s", nativeRequests[0].KeepAlive)
+	assert.Nil(t, nativeRequests[1].Options, "the fresh retry must stay on Metal")
+	assert.Empty(t, nativeRequests[1].KeepAlive, "the fresh runner should remain loaded")
+	assert.Equal(t, 2, unloadChecks)
+}
+
 func TestEncoderOllamaCPUFallbackReplacesOnlyInvalidVectors(t *testing.T) {
-	var metalCalls, cpuCalls atomic.Int32
-	var gotCPU testOllamaEmbedRequest
+	var metalCalls, nativeCalls atomic.Int32
+	var gotNative []testOllamaEmbedRequest
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -286,13 +389,24 @@ func TestEncoderOllamaCPUFallbackReplacesOnlyInvalidVectors(t *testing.T) {
 					[]float32{1, float32(math.NaN()), 0})},
 			}})
 		case "/proxy/api/embed":
-			cpuCalls.Add(1)
+			call := nativeCalls.Add(1)
 			require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
-			require.NoError(t, json.UnmarshalRead(r.Body, &gotCPU))
+			var request testOllamaEmbedRequest
+			require.NoError(t, json.UnmarshalRead(r.Body, &request))
+			gotNative = append(gotNative, request)
+			if call < 3 {
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"embeddings": [][]float32{{0, 0, 0}, {0, 0, 0}},
+				})
+				return
+			}
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"model":      "test-model",
 				"embeddings": [][]float32{{4, 5, 6}, {7, 8, 9}},
 			})
+		case "/proxy/api/ps":
+			require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+			writeJSON(t, w, http.StatusOK, map[string]any{"models": []any{}})
 		default:
 			require.FailNow(t, "unexpected request path", r.URL.Path)
 		}
@@ -310,19 +424,25 @@ func TestEncoderOllamaCPUFallbackReplacesOnlyInvalidVectors(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, [][]float32{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, out)
 	assert.Equal(t, int32(2), metalCalls.Load(), "normal retries run first")
-	assert.Equal(t, int32(1), cpuCalls.Load(), "CPU is attempted exactly once")
-	assert.Equal(t, "test-model", gotCPU.Model)
-	assert.Equal(t, []string{"pre:beta:suf", "pre:gamma:suf"}, gotCPU.Input)
-	require.NotNil(t, gotCPU.Truncate, "truncate must be present explicitly")
-	assert.False(t, *gotCPU.Truncate)
-	require.NotNil(t, gotCPU.Dimensions)
-	assert.Equal(t, 3, *gotCPU.Dimensions)
-	assert.EqualValues(t, 0, gotCPU.Options["num_gpu"])
-	assert.Equal(t, "0s", gotCPU.KeepAlive)
+	require.Len(t, gotNative, 3)
+	for _, request := range gotNative {
+		assert.Equal(t, "test-model", request.Model)
+		assert.Equal(t, []string{"pre:beta:suf", "pre:gamma:suf"}, request.Input)
+		require.NotNil(t, request.Truncate, "truncate must be present explicitly")
+		assert.False(t, *request.Truncate)
+		require.NotNil(t, request.Dimensions)
+		assert.Equal(t, 3, *request.Dimensions)
+	}
+	assert.Nil(t, gotNative[0].Options, "the unload request must stay on Metal")
+	assert.Equal(t, "0s", gotNative[0].KeepAlive)
+	assert.Nil(t, gotNative[1].Options, "the fresh retry must stay on Metal")
+	assert.Empty(t, gotNative[1].KeepAlive)
+	assert.EqualValues(t, 0, gotNative[2].Options["num_gpu"])
+	assert.Equal(t, "0s", gotNative[2].KeepAlive)
 }
 
 func TestEncoderOllamaCPUFallbackOmitsDimensionsWhenNotRequested(t *testing.T) {
-	var gotCPU testOllamaEmbedRequest
+	var gotNative []testOllamaEmbedRequest
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -331,11 +451,21 @@ func TestEncoderOllamaCPUFallbackOmitsDimensionsWhenNotRequested(t *testing.T) {
 				{"index": 0, "embedding": base64Embedding([]float32{0, 0, 0})},
 			}})
 		case "/api/embed":
-			require.NoError(t, json.UnmarshalRead(r.Body, &gotCPU))
+			var request testOllamaEmbedRequest
+			require.NoError(t, json.UnmarshalRead(r.Body, &request))
+			gotNative = append(gotNative, request)
+			if len(gotNative) < 3 {
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"embeddings": [][]float32{{0, 0, 0}},
+				})
+				return
+			}
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"model":      "test-model",
 				"embeddings": [][]float32{{1, 2, 3}},
 			})
+		case "/api/ps":
+			writeJSON(t, w, http.StatusOK, map[string]any{"models": []any{}})
 		default:
 			require.FailNow(t, "unexpected request path", r.URL.Path)
 		}
@@ -349,13 +479,16 @@ func TestEncoderOllamaCPUFallbackOmitsDimensionsWhenNotRequested(t *testing.T) {
 	out, err := enc(context.Background(), []string{"alpha"})
 	require.NoError(t, err)
 	assert.Equal(t, [][]float32{{1, 2, 3}}, out)
-	require.NotNil(t, gotCPU.Truncate, "truncate must be present explicitly")
-	assert.False(t, *gotCPU.Truncate)
-	assert.Nil(t, gotCPU.Dimensions, "dimensions must be omitted unless requested")
+	require.Len(t, gotNative, 3)
+	for _, request := range gotNative {
+		require.NotNil(t, request.Truncate, "truncate must be present explicitly")
+		assert.False(t, *request.Truncate)
+		assert.Nil(t, request.Dimensions, "dimensions must be omitted unless requested")
+	}
 }
 
 func TestEncoderOllamaCPUFallbackPreservesQueryOnBothRoutes(t *testing.T) {
-	var primaryCalls, cpuCalls atomic.Int32
+	var primaryCalls, nativeCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "local", r.URL.Query().Get("tenant"))
 		switch r.URL.Path {
@@ -365,10 +498,18 @@ func TestEncoderOllamaCPUFallbackPreservesQueryOnBothRoutes(t *testing.T) {
 				{"index": 0, "embedding": base64Embedding([]float32{0, 0, 0})},
 			}})
 		case "/proxy/api/embed":
-			cpuCalls.Add(1)
+			call := nativeCalls.Add(1)
+			if call < 3 {
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"embeddings": [][]float32{{0, 0, 0}},
+				})
+				return
+			}
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"embeddings": [][]float32{{1, 2, 3}},
 			})
+		case "/proxy/api/ps":
+			writeJSON(t, w, http.StatusOK, map[string]any{"models": []any{}})
 		default:
 			http.Error(w, "unexpected request path", http.StatusNotFound)
 		}
@@ -385,11 +526,11 @@ func TestEncoderOllamaCPUFallbackPreservesQueryOnBothRoutes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, [][]float32{{1, 2, 3}}, out)
 	assert.Equal(t, int32(1), primaryCalls.Load())
-	assert.Equal(t, int32(1), cpuCalls.Load())
+	assert.Equal(t, int32(3), nativeCalls.Load())
 }
 
 func TestEncoderOllamaCPUFallbackQuiescesSharedEndpointTraffic(t *testing.T) {
-	var primaryCalls atomic.Int32
+	var primaryCalls, nativeCalls atomic.Int32
 	cpuStarted := make(chan struct{})
 	releaseCPU := make(chan struct{})
 	secondPrimaryStarted := make(chan struct{}, 1)
@@ -409,11 +550,19 @@ func TestEncoderOllamaCPUFallbackQuiescesSharedEndpointTraffic(t *testing.T) {
 				{"index": 0, "embedding": base64Embedding([]float32{4, 5, 6})},
 			}})
 		case "/api/embed":
+			if nativeCalls.Add(1) < 3 {
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"embeddings": [][]float32{{0, 0, 0}},
+				})
+				return
+			}
 			close(cpuStarted)
 			<-releaseCPU
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"embeddings": [][]float32{{1, 2, 3}},
 			})
+		case "/api/ps":
+			writeJSON(t, w, http.StatusOK, map[string]any{"models": []any{}})
 		default:
 			require.FailNow(t, "unexpected request path", r.URL.Path)
 		}
@@ -461,7 +610,7 @@ func TestEncoderOllamaCPUFallbackQuiescesSharedEndpointTraffic(t *testing.T) {
 }
 
 func TestEncoderOllamaGatePrimaryWaitHonorsCancellation(t *testing.T) {
-	var primaryCalls atomic.Int32
+	var primaryCalls, nativeCalls atomic.Int32
 	cpuStarted := make(chan struct{})
 	releaseCPU := make(chan struct{})
 
@@ -473,11 +622,19 @@ func TestEncoderOllamaGatePrimaryWaitHonorsCancellation(t *testing.T) {
 				{"index": 0, "embedding": base64Embedding([]float32{0, 0, 0})},
 			}})
 		case "/api/embed":
+			if nativeCalls.Add(1) < 3 {
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"embeddings": [][]float32{{0, 0, 0}},
+				})
+				return
+			}
 			close(cpuStarted)
 			<-releaseCPU
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"embeddings": [][]float32{{1, 2, 3}},
 			})
+		case "/api/ps":
+			writeJSON(t, w, http.StatusOK, map[string]any{"models": []any{}})
 		default:
 			require.FailNow(t, "unexpected request path", r.URL.Path)
 		}
@@ -807,8 +964,18 @@ func TestEncoderOllamaCPUFallbackFailureLeavesBatchFailed(t *testing.T) {
 				case "/v1/embeddings":
 					writeJSON(t, w, http.StatusOK, map[string]any{"data": tt.primary})
 				case "/api/embed":
+					var request testOllamaEmbedRequest
+					require.NoError(t, json.UnmarshalRead(r.Body, &request))
+					if request.Options == nil {
+						writeJSON(t, w, http.StatusOK, map[string]any{
+							"embeddings": [][]float32{{0, 0, 0}},
+						})
+						return
+					}
 					cpuCalls.Add(1)
 					tt.respondCPU(t, w)
+				case "/api/ps":
+					writeJSON(t, w, http.StatusOK, map[string]any{"models": []any{}})
 				default:
 					require.FailNow(t, "unexpected request path", r.URL.Path)
 				}


### PR DESCRIPTION
Ollama can enter a state where embedding requests return zero vectors until its model runner unloads. AgentsView previously sent invalid inputs directly to CPU, which could leave a long-running CPU fallback doing work that a fresh Metal runner could handle.

Recovery now stays under the existing endpoint-wide gate. AgentsView unloads the affected Metal runner, confirms its removal through Ollama's process API, retries only the invalid inputs on fresh Metal, and uses `num_gpu: 0` only if Metal recovery fails. Valid vectors from the original batch remain unchanged.

<sup>generated by a clanker</sup>
