### PR TITLE
feat(frontend): let readers hide system boundary cards

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -690,7 +690,7 @@ so matches can be highlighted.
 ### Block-Type Filtering
 
 Click the filter icon in the message viewer header to open a dropdown that
-toggles visibility of five content categories:
+toggles visibility of six content categories:
 
 | Category  | What It Controls          |
 | --------- | ------------------------- |
@@ -699,6 +699,12 @@ toggles visibility of five content categories:
 | Thinking  | Thinking/reasoning blocks |
 | Tool      | Tool call blocks          |
 | Code      | Code blocks               |
+| System    | System boundary cards     |
+
+System boundary cards are the compact rows that mark a session continuation or
+resume, an interrupted request, a task notification, or stop hook feedback.
+Hiding the category removes all of them; the rest of the transcript is
+unaffected.
 
 All categories are visible by default. When any are hidden, a badge on the
 filter button shows the count of hidden types. Click **Show all** to restore

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -40,6 +40,7 @@
   "header_transcript_blocks_thinking": "Thinking blocks",
   "header_transcript_blocks_tool": "Tool calls",
   "header_transcript_blocks_code": "Code blocks",
+  "header_transcript_blocks_system": "System boundaries",
   "header_actions_follow_latest": "Follow latest messages",
   "header_actions_toggle_sort": "Toggle sort order (o)",
   "header_actions_cycle_layout": "Cycle layout: {layout} (l)",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -40,6 +40,7 @@
   "header_transcript_blocks_thinking": "Blocs de réflexion",
   "header_transcript_blocks_tool": "Appels d'outil",
   "header_transcript_blocks_code": "Blocs de code",
+  "header_transcript_blocks_system": "Limites système",
   "header_actions_follow_latest": "Suivre les derniers messages",
   "header_actions_toggle_sort": "Inverser l'ordre de tri (o)",
   "header_actions_cycle_layout": "Changer de disposition : {layout} (l)",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -40,6 +40,7 @@
   "header_transcript_blocks_thinking": "思考ブロック",
   "header_transcript_blocks_tool": "ツール呼び出し",
   "header_transcript_blocks_code": "コードブロック",
+  "header_transcript_blocks_system": "システム境界",
   "header_actions_follow_latest": "最新のメッセージをフォローする",
   "header_actions_toggle_sort": "並べ替え順序を切り換える (o)",
   "header_actions_cycle_layout": "サイクルレイアウト: {layout} (l)",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -40,6 +40,7 @@
   "header_transcript_blocks_thinking": "사고 블록",
   "header_transcript_blocks_tool": "도구 호출",
   "header_transcript_blocks_code": "코드 블록",
+  "header_transcript_blocks_system": "시스템 경계",
   "header_actions_follow_latest": "최신 메시지 따라가기",
   "header_actions_toggle_sort": "정렬 순서 전환 (o)",
   "header_actions_cycle_layout": "레이아웃 전환: {layout} (l)",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -40,6 +40,7 @@
   "header_transcript_blocks_thinking": "思考块",
   "header_transcript_blocks_tool": "工具调用",
   "header_transcript_blocks_code": "代码块",
+  "header_transcript_blocks_system": "系统边界",
   "header_actions_follow_latest": "跟随最新消息",
   "header_actions_toggle_sort": "切换排序 (o)",
   "header_actions_cycle_layout": "切换布局：{layout} (l)",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -40,6 +40,7 @@
   "header_transcript_blocks_thinking": "思考區塊",
   "header_transcript_blocks_tool": "工具使用",
   "header_transcript_blocks_code": "程式碼區塊",
+  "header_transcript_blocks_system": "系統邊界",
   "header_actions_follow_latest": "跟隨最新訊息",
   "header_actions_toggle_sort": "切換排序 (o)",
   "header_actions_cycle_layout": "切換佈局：{layout} (l)",

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -22,7 +22,10 @@
   import {
     hasVisibleSegments,
   } from "../../utils/content-parser.js";
-  import { isSystemMessage } from "../../utils/messages.js";
+  import {
+    isSystemBoundaryMessage,
+    isSystemMessage,
+  } from "../../utils/messages.js";
   import { resolveMessageLayout } from "../../utils/message-layout.js";
   import { inSessionSearch } from "../../stores/inSessionSearch.svelte.js";
   import { sessionActivity } from "../../stores/sessionActivity.svelte.js";
@@ -889,7 +892,7 @@
               />
             {:else if item.message.is_compact_boundary}
               <CompactBoundaryDivider message={item.message} />
-            {:else if item.message.is_system && item.message.source_subtype && item.message.source_subtype !== 'compact_boundary'}
+            {:else if isSystemBoundaryMessage(item.message)}
               <SystemBoundaryCard
                 subtype={item.message.source_subtype}
                 content={item.message.content}

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -321,6 +321,32 @@ describe("MessageList follow cancellation", () => {
     expect(readProgress.get("s1")?.token).toBe("current");
   });
 
+  it("hides system boundary cards when the system block is filtered out", async () => {
+    messages.messages = [
+      {
+        ...makeMessage(0),
+        role: "user",
+        content:
+          "<task-notification>\n<status>completed</status>\n</task-notification>",
+        is_system: true,
+        source_subtype: "task_notification",
+      },
+    ];
+    messages.messageCount = 1;
+    setVirtualRows(1);
+
+    component = mount(MessageList, { target: document.body });
+    await tick();
+    expect(
+      document.querySelector(".system-boundary"),
+    ).not.toBeNull();
+
+    ui.setBlockVisible("system", false);
+    await tick();
+
+    expect(document.querySelector(".system-boundary")).toBeNull();
+  });
+
   it("acknowledges traversal when a block filter hides the raw boundary", async () => {
     messages.messages = [
       { ...makeMessage(0), role: "assistant" },

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -119,6 +119,7 @@
     thinking: m.header_transcript_blocks_thinking,
     tool: m.header_transcript_blocks_tool,
     code: m.header_transcript_blocks_code,
+    system: m.header_transcript_blocks_system,
   };
 
   const BLOCK_COLORS: Record<BlockType, string> = {
@@ -127,6 +128,7 @@
     thinking: "var(--accent-purple)",
     tool: "var(--accent-amber)",
     code: "var(--text-muted)",
+    system: "var(--text-muted)",
   };
 
   async function handleExport() {

--- a/frontend/src/lib/components/settings/AppearanceSettings.svelte
+++ b/frontend/src/lib/components/settings/AppearanceSettings.svelte
@@ -39,6 +39,7 @@
     thinking: m.header_transcript_blocks_thinking(),
     tool: m.header_transcript_blocks_tool(),
     code: m.header_transcript_blocks_code(),
+    system: m.header_transcript_blocks_system(),
   });
 
   const FONT_SCALE_OPTIONS = $derived(

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -38,7 +38,8 @@ export type BlockType =
   | "assistant"
   | "thinking"
   | "tool"
-  | "code";
+  | "code"
+  | "system";
 
 export const ALL_BLOCK_TYPES: BlockType[] = [
   "user",
@@ -46,6 +47,7 @@ export const ALL_BLOCK_TYPES: BlockType[] = [
   "thinking",
   "tool",
   "code",
+  "system",
 ];
 
 const BLOCK_FILTER_KEY = "agentsview-block-filters";
@@ -56,23 +58,71 @@ const VITALS_CALLS_EXPANDED_KEY =
 const SIGNAL_PANEL_KEY = "agentsview-signal-panel";
 const FOLLOW_LATEST_KEY = "agentsview-follow-latest";
 
-function readBlockFilters(): Set<BlockType> {
+// The block types the original stored payload could name. That payload listed
+// the visible types, so any type added later is missing from every stored
+// payload and must not be read back as one the reader chose to hide. The
+// current payload lists hidden types instead, which keeps a future block type
+// visible by default without another migration.
+const LEGACY_VISIBLE_BLOCK_TYPES: BlockType[] = [
+  "user",
+  "assistant",
+  "thinking",
+  "tool",
+  "code",
+];
+
+/**
+ * Resolves the visible block types from a stored filter payload. Exported so
+ * the stored-format migration can be exercised with literal payloads.
+ */
+export function parseBlockFilters(raw: string | null): Set<BlockType> {
+  const hidden = parseHiddenBlocks(raw);
+  return new Set(ALL_BLOCK_TYPES.filter((type) => !hidden.has(type)));
+}
+
+/** Serializes the visible block types for storage. */
+export function serializeBlockFilters(
+  visible: Set<BlockType>,
+): string {
+  return JSON.stringify({
+    hidden: ALL_BLOCK_TYPES.filter((type) => !visible.has(type)),
+  });
+}
+
+function parseHiddenBlocks(raw: string | null): Set<BlockType> {
+  if (!raw) return new Set();
   try {
-    const raw = localStorage?.getItem(BLOCK_FILTER_KEY);
-    if (raw) {
-      const arr = JSON.parse(raw);
-      if (Array.isArray(arr)) {
-        return new Set(
-          arr.filter((t: string) =>
-            ALL_BLOCK_TYPES.includes(t as BlockType),
-          ) as BlockType[],
-        );
-      }
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(
+        LEGACY_VISIBLE_BLOCK_TYPES.filter(
+          (type) => !parsed.includes(type),
+        ),
+      );
+    }
+    if (parsed && Array.isArray(parsed.hidden)) {
+      return new Set(knownBlockTypes(parsed.hidden));
     }
   } catch {
     // ignore
   }
-  return new Set(ALL_BLOCK_TYPES);
+  return new Set();
+}
+
+function knownBlockTypes(values: unknown[]): BlockType[] {
+  return values.filter((value): value is BlockType =>
+    ALL_BLOCK_TYPES.includes(value as BlockType),
+  );
+}
+
+function readBlockFilters(): Set<BlockType> {
+  try {
+    return parseBlockFilters(
+      localStorage?.getItem(BLOCK_FILTER_KEY) ?? null,
+    );
+  } catch {
+    return new Set(ALL_BLOCK_TYPES);
+  }
 }
 
 const LAYOUT_KEY = "agentsview-message-layout";
@@ -528,7 +578,7 @@ class UIStore {
     try {
       localStorage?.setItem(
         BLOCK_FILTER_KEY,
-        JSON.stringify([...this.visibleBlocks]),
+        serializeBlockFilters(this.visibleBlocks),
       );
     } catch {
       // ignore

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -58,23 +58,7 @@ const VITALS_CALLS_EXPANDED_KEY =
 const SIGNAL_PANEL_KEY = "agentsview-signal-panel";
 const FOLLOW_LATEST_KEY = "agentsview-follow-latest";
 
-// The block types the original stored payload could name. That payload listed
-// the visible types, so any type added later is missing from every stored
-// payload and must not be read back as one the reader chose to hide. The
-// current payload lists hidden types instead, which keeps a future block type
-// visible by default without another migration.
-const LEGACY_VISIBLE_BLOCK_TYPES: BlockType[] = [
-  "user",
-  "assistant",
-  "thinking",
-  "tool",
-  "code",
-];
-
-/**
- * Resolves the visible block types from a stored filter payload. Exported so
- * the stored-format migration can be exercised with literal payloads.
- */
+/** Resolves the visible block types from a stored filter payload. */
 export function parseBlockFilters(raw: string | null): Set<BlockType> {
   const hidden = parseHiddenBlocks(raw);
   return new Set(ALL_BLOCK_TYPES.filter((type) => !hidden.has(type)));
@@ -93,13 +77,6 @@ function parseHiddenBlocks(raw: string | null): Set<BlockType> {
   if (!raw) return new Set();
   try {
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      return new Set(
-        LEGACY_VISIBLE_BLOCK_TYPES.filter(
-          (type) => !parsed.includes(type),
-        ),
-      );
-    }
     if (parsed && Array.isArray(parsed.hidden)) {
       return new Set(knownBlockTypes(parsed.hidden));
     }

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -785,23 +785,6 @@ describe("UIStore", () => {
       expect(ui.isBlockVisible("system")).toBe(true);
     });
 
-    it("keeps system boundaries visible for a payload stored before that block existed", () => {
-      // Written by a build whose vocabulary ended at "code", with the code
-      // block hidden. "system" is missing because it did not exist yet, not
-      // because the reader turned it off.
-      const legacy = JSON.stringify([
-        "user",
-        "assistant",
-        "thinking",
-        "tool",
-      ]);
-
-      const visible = parseBlockFilters(legacy);
-
-      expect(visible.has("code")).toBe(false);
-      expect(visible.has("system")).toBe(true);
-    });
-
     it("keeps a hidden system boundary hidden across a reload", () => {
       const visible = parseBlockFilters(
         JSON.stringify({ hidden: ["system"] }),

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -12,7 +12,13 @@ import {
   SIDEBAR_WIDTH_MIN,
   SIDEBAR_WIDTH_STORAGE_MAX,
 } from "../components/layout/sidebar-width.js";
-import { ui } from "./ui.svelte.js";
+import {
+  ALL_BLOCK_TYPES,
+  parseBlockFilters,
+  serializeBlockFilters,
+  ui,
+  type BlockType,
+} from "./ui.svelte.js";
 
 describe("UIStore", () => {
   beforeEach(() => {
@@ -776,6 +782,59 @@ describe("UIStore", () => {
       expect(ui.isBlockVisible("thinking")).toBe(true);
       expect(ui.isBlockVisible("code")).toBe(true);
       expect(ui.isBlockVisible("assistant")).toBe(true);
+      expect(ui.isBlockVisible("system")).toBe(true);
+    });
+
+    it("keeps system boundaries visible for a payload stored before that block existed", () => {
+      // Written by a build whose vocabulary ended at "code", with the code
+      // block hidden. "system" is missing because it did not exist yet, not
+      // because the reader turned it off.
+      const legacy = JSON.stringify([
+        "user",
+        "assistant",
+        "thinking",
+        "tool",
+      ]);
+
+      const visible = parseBlockFilters(legacy);
+
+      expect(visible.has("code")).toBe(false);
+      expect(visible.has("system")).toBe(true);
+    });
+
+    it("keeps a hidden system boundary hidden across a reload", () => {
+      const visible = parseBlockFilters(
+        JSON.stringify({ hidden: ["system"] }),
+      );
+
+      expect(visible.has("system")).toBe(false);
+      expect(visible.has("user")).toBe(true);
+    });
+
+    it("restores the same hidden set it stored", () => {
+      const chosen = new Set<BlockType>(ALL_BLOCK_TYPES);
+      chosen.delete("system");
+      chosen.delete("tool");
+
+      const restored = parseBlockFilters(
+        serializeBlockFilters(chosen),
+      );
+
+      expect([...restored].sort()).toEqual([
+        "assistant",
+        "code",
+        "thinking",
+        "user",
+      ]);
+    });
+
+    it("shows every block when the stored payload is missing or unreadable", () => {
+      expect(parseBlockFilters(null).size).toBe(
+        ALL_BLOCK_TYPES.length,
+      );
+      expect(parseBlockFilters("{not json").size).toBe(
+        ALL_BLOCK_TYPES.length,
+      );
     });
 
     it("should toggle a block type off and on", () => {

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -1020,8 +1020,69 @@ describe("hasVisibleSegments", () => {
   }
 
   const allBlocksVisible = visibilityFrom(
-    new Set(["user", "assistant", "thinking", "tool", "code"]),
+    new Set([
+      "user",
+      "assistant",
+      "thinking",
+      "tool",
+      "code",
+      "system",
+    ]),
   );
+
+  it("boundary card answers to the system filter, not its user role", () => {
+    const m = makeMsg({
+      role: "user",
+      content:
+        "<task-notification>\n<status>completed</status>\n</task-notification>",
+      is_system: true,
+      source_subtype: "task_notification",
+    });
+    const noSystem = visibilityFrom(
+      new Set(["user", "assistant", "thinking", "tool", "code"]),
+    );
+    const noUser = visibilityFrom(
+      new Set(["assistant", "thinking", "tool", "code", "system"]),
+    );
+
+    expect(hasVisibleSegments(m, noSystem)).toBe(false);
+    expect(hasVisibleSegments(m, noUser)).toBe(true);
+  });
+
+  it("boundary card ignores the filters its body would parse into", () => {
+    const body = "```sh\nexit 2\n```";
+    const noCode = visibilityFrom(
+      new Set(["user", "assistant", "thinking", "tool", "system"]),
+    );
+    // Control: the same body outside a boundary card is code-only, so the
+    // code filter does hide it. The card itself renders a label and a
+    // one-line preview, so that filter must not reach it.
+    const plain = makeMsg({ role: "user", content: body });
+    const card = makeMsg({
+      role: "user",
+      content: body,
+      is_system: true,
+      source_subtype: "stop_hook",
+    });
+
+    expect(hasVisibleSegments(plain, noCode)).toBe(false);
+    expect(hasVisibleSegments(card, noCode)).toBe(true);
+  });
+
+  it("compact boundary is not governed by the system filter", () => {
+    const m = makeMsg({
+      role: "user",
+      content: "Session summary",
+      is_system: true,
+      is_compact_boundary: true,
+      source_subtype: "compact_boundary",
+    });
+    const noSystem = visibilityFrom(
+      new Set(["user", "assistant", "thinking", "tool", "code"]),
+    );
+
+    expect(hasVisibleSegments(m, noSystem)).toBe(true);
+  });
 
   it("tool-only message hidden when tool filter is off", () => {
     const m = makeMsg({

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -1,5 +1,6 @@
 import type { Message, ToolCall } from "../api/types.js";
 import { LRUCache } from "./cache.js";
+import { isSystemBoundaryMessage } from "./messages.js";
 
 export type SegmentType = "text" | "thinking" | "tool" | "code" | "skill";
 
@@ -578,9 +579,20 @@ export function enrichSegments(
 export function hasVisibleSegments(
   msg: Message,
   isVisible: (
-    type: "user" | "assistant" | "thinking" | "tool" | "code",
+    type:
+      | "user"
+      | "assistant"
+      | "thinking"
+      | "tool"
+      | "code"
+      | "system",
   ) => boolean,
 ): boolean {
+  // A boundary card shows a label and a one-line preview, never the parsed
+  // segments of its body, so its own block type owns its visibility. Parsing
+  // the body here would let an unrelated toggle hide the card, and would tie
+  // every boundary card to the "user" role it carries for analytics.
+  if (isSystemBoundaryMessage(msg)) return isVisible("system");
   const role: "user" | "assistant" =
     msg.role === "user" ? "user" : "assistant";
   const segs = enrichSegments(

--- a/frontend/src/lib/utils/messages.ts
+++ b/frontend/src/lib/utils/messages.ts
@@ -29,6 +29,22 @@ const VISIBLE_SYSTEM_SUBTYPES = new Set([
 ]);
 
 /**
+ * Reports whether the transcript renders this message as a system boundary
+ * card instead of ordinary message content. The Claude parser keeps these
+ * rows on role "user" so analytics do not count them as assistant replies,
+ * so the role alone cannot tell them apart.
+ */
+export function isSystemBoundaryMessage(
+  m: Message,
+): m is Message & { source_subtype: string } {
+  if (m.is_compact_boundary) return false;
+  if (!m.is_system) return false;
+  return (
+    !!m.source_subtype && m.source_subtype !== "compact_boundary"
+  );
+}
+
+/**
  * Returns true if the message is system-injected and should be
  * hidden from the UI. Checks the backend is_system flag first,
  * then falls back to prefix detection for parsers that don't set it.


### PR DESCRIPTION
Closes #1605.

Session continuation, resume, interrupted-request, task notification, and stop
hook feedback render as their own boundary cards, but the block-visibility menu
had no switch for them. They were filtered as ordinary user messages, because
the Claude parser keeps these rows on role `user` so analytics do not count
them as assistant replies. Turning off "User messages" hid every boundary card
as a side effect, and nothing could hide only the cards.

A `system` block type now covers the whole family. Both surfaces that expose
block visibility iterate `ALL_BLOCK_TYPES`, so the header dropdown and the
Appearance settings pick it up together, and the `Record<BlockType, ...>` label
and colour maps make a missing entry a type error rather than a silent gap.

`hasVisibleSegments` now short-circuits on boundary messages and asks about
`system` alone. That also fixes a smaller bug: the old path parsed the card's
body even though the card renders only a label and a one-line preview, so a
card whose body held no text segment vanished when "Code blocks" was hidden.
`MessageList` renders through the same `isSystemBoundaryMessage` predicate the
filter uses, so the two cannot drift apart.

The stored filter payload needed a format change. It listed the visible types,
so a newly added type is absent from every payload already on disk and would
have been read back as one the reader had hidden: anyone who had ever touched a
block filter would have lost their boundary cards on upgrade, with a stray
count on the funnel badge. The payload now lists hidden types, and a legacy
array is migrated against the vocabulary the writing build could name. Any
block type added later stays visible by default without another migration.

Reviewers should look at `parseHiddenBlocks` in `ui.svelte.ts` for the
migration, and at the short-circuit in `hasVisibleSegments` for the filtering
change.