### PR TITLE
feat(rawderive): add hosted parse worker foundation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,23 @@ description: Release history for AgentsView
   sync to apply the new category. A machine that only runs `agentsview usage`
   needs one `agentsview sync` to pick up subagent transcripts that already
   exist.
+
+- Hosted raw-sync operators now get a startup message identifying missing
+  database privileges when raw-sync routes are disabled. Existing least-privilege
+  runtime roles need `SELECT` and `UPDATE` on `raw_ingest_jobs`, in addition to
+  their existing grants. The internal hosted parse-worker foundation adds job
+  leases, source reconstruction, parsing, and retries; server startup and
+  PostgreSQL session projection are still pending. (#1607)
+
+- Hosted replay keeps skill-name inference within recorded transcript paths,
+  without reading worker-local `SKILL.md` files or cached names from local
+  parses. It also accepts Evener captures from either a home directory or a
+  directly configured sessions directory and preserves the parent history
+  needed to avoid duplicate fork messages. (#1607)
+
+- Hosted Codex forks retain parents from other configured directories, avoiding
+  duplicate parent messages during replay. (#1607)
+
 - Discover Pi sessions stored under `PI_CODING_AGENT_DIR` or
   `PI_CODING_AGENT_SESSION_DIR`, locally and over SSH. Existing `PI_DIR`
   overrides retain priority. (#1681)

--- a/docs/hosted-raw-sync.md
+++ b/docs/hosted-raw-sync.md
@@ -45,6 +45,12 @@ The tracked delivery sequence and production acceptance criteria live in
 | Server derivation      | Not available | Accepted generations are not yet parsed into PostgreSQL sessions or embeddings                                               |
 | Operations and cutover | Not available | Retention, garbage collection, disaster rebuilds, and migration from `pg push` remain future work                            |
 
+The server parse-worker foundation now includes fenced PostgreSQL job leases,
+verified source materialization, provider parsing, retry handling, and a
+projection interface. It is an internal library: `pg serve` does not start a
+worker, and a PostgreSQL session-projection implementation is still pending.
+Hosted browsing and embeddings therefore continue to require `pg push`.
+
 The broader delivery issue remains open because public enrollment, hosted
 session derivation, and production lifecycle controls are not finished.
 
@@ -79,7 +85,23 @@ doing so intentionally creates two watchers over the same provider roots.
 `agentsview pg serve` registers the raw-sync routes when its PostgreSQL role can
 write every raw-sync table and the ingest-job sequence. A read-only role keeps
 serving the normal PostgreSQL-backed UI and API without these runtime routes.
-There is no separate raw-sync configuration switch.
+There is no separate raw-sync configuration switch. When requirements are
+missing, startup logs `raw-sync routes disabled; missing requirements:` followed
+by the exact missing table privileges, sequence access, or read-only transaction
+setting.
+
+Upgrading a least-privilege raw-sync role now requires `SELECT` and `UPDATE` on
+`raw_ingest_jobs`, in addition to its existing `INSERT` and sequence `USAGE`.
+Manifest commits retire the previous source head's pending parse job. As the
+schema owner, grant the additional privileges and restart `pg serve`:
+
+```sql
+GRANT SELECT, UPDATE ON agentsview.raw_ingest_jobs TO raw_sync_runtime;
+```
+
+Replace `agentsview` and `raw_sync_runtime` with your schema and runtime role.
+Until these grants are applied, the normal session UI continues to work, but
+raw-sync HTTP routes are omitted.
 
 The implemented routes are:
 
@@ -132,7 +154,7 @@ The PostgreSQL acceptance transaction then:
 1. records the manifest, file entries, and ordered object references;
 1. assigns a monotonically increasing generation and durable receipt;
 1. creates the corresponding parse job; and
-1. advances the source head.
+1. advances the source head and retires its previous pending parse job.
 
 Repeating the same capture returns its existing receipt. Reusing a capture
 identity for different content or committing against a stale parent fails

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -263,19 +263,24 @@ add an archived or maintained mirror without replacing the original identity.
   transcript carries no `sessionKind` — the writer re-stamps the current
   process's kind on each persisted line, overwriting the copied value, so the
   bg marker reflects the forking process and cannot be inherited through
-  replayed entries. Evidence remains `no-public-source`. Reverified 2026-08-16
-  with Claude Code 2.1.233 using a controlled `claude -p --session-id <uuid>`
-  probe under an isolated `CLAUDE_CONFIG_DIR`. Before the deliberately bounded
-  probe was terminated during its API retry, Claude had created the exact UUID
-  transcript under `projects/<sanitized-cwd>/`. A working directory containing
-  spaces, `.`, `_`, `@`, and separators confirmed that the producer preserves
-  ASCII letters, digits, and `-` and replaces every other character with `-`.
-  The transcript existed before process exit, so an interrupted wrapper can
-  retain exact recovery evidence. One-shot capture copies the exact root and
-  bounded subagent tree after an unchanged-file interval, requires every
-  persisted child reference to have a captured transcript, and includes every
-  captured subagent file even when interruption prevented its link record from
-  being flushed. Parser termination remains separate assurance; an interrupted
+  replayed entries. Evidence remains `no-public-source`. Reverified 2026-09-10
+  against local parser fixtures: equal-length replay candidates with the same
+  background flag leave lineage unresolved when their complete UUID sets
+  differ. Identical sets elect the smallest stem, retaining one copy across
+  three background transcripts. An interactive original still wins a tie with
+  a background sibling. Reverified 2026-08-16 with Claude Code 2.1.233 using a
+  controlled `claude -p --session-id <uuid>` probe under an isolated
+  `CLAUDE_CONFIG_DIR`. Before the deliberately bounded probe was terminated
+  during its API retry, Claude had created the exact UUID transcript under
+  `projects/<sanitized-cwd>/`. A working directory containing spaces, `.`,
+  `_`, `@`, and separators confirmed that the producer preserves ASCII
+  letters, digits, and `-` and replaces every other character with `-`. The
+  transcript existed before process exit, so an interrupted wrapper can retain
+  exact recovery evidence. One-shot capture copies the exact root and bounded
+  subagent tree after an unchanged-file interval, requires every persisted
+  child reference to have a captured transcript, and includes every captured
+  subagent file even when interruption prevented its link record from being
+  flushed. Parser termination remains separate assurance; an interrupted
   transcript can still contain usable token records. Because an unparseable
   middle record may hide usage, one-shot capture marks assurance partial when
   any included session reports parser-malformed lines. One-shot correlation
@@ -286,22 +291,26 @@ add an archived or maintained mirror without replacing the original identity.
   child-start failure is persisted as a terminal capture state: later
   `capture report` retries do not discover or attribute a matching transcript
   for an execution that never started. Reverified 2026-08-21 that recovery
-  refuses to seal when the wrapper did not durably record execution completion,
-  even if the transcript is temporarily quiescent and receives more usage
-  later. Reverified 2026-08-21 that exact token projection compares canonical
-  output and context coverage separately for every included session, while
-  crediting a deduplicated snapshot to each source session that contained its
-  equivalent row. It also requires the materialized breakdown length to match
-  its recorded count. A larger context row from another session therefore
-  cannot hide missing delegated input or cache usage. Reverified 2026-08-22
-  that an incomplete category breakdown, malformed included transcript, or
-  unfinished included session withholds computed or mixed cost;
-  provider-reported cost remains authoritative. Reverified 2026-08-27 that
-  raw-capture membership mirrors persisted tool output resolution: it includes
-  regular files at any depth in the session's `tool-results/` directory and,
-  for subagents, the enclosing parent session's `tool-results/` directory.
-  These immutable companions are captured with the appendable transcript so a
-  reconstructed tree preserves the parser's physical inputs.
+  refuses to seal when the wrapper did not durably record execution
+  completion, even if the transcript is temporarily quiescent and receives
+  more usage later. Reverified 2026-08-21 that exact token projection compares
+  canonical output and context coverage separately for every included session,
+  while crediting a deduplicated snapshot to each source session that
+  contained its equivalent row. It also requires the materialized breakdown
+  length to match its recorded count. A larger context row from another
+  session therefore cannot hide missing delegated input or cache usage.
+  Reverified 2026-08-22 that an incomplete category breakdown, malformed
+  included transcript, or unfinished included session withholds computed or
+  mixed cost; provider-reported cost remains authoritative. Reverified
+  2026-08-27 that raw-capture membership mirrors persisted tool output
+  resolution: it includes regular files at any depth in the session's
+  `tool-results/` directory and, for subagents, the enclosing parent session's
+  `tool-results/` directory. These immutable companions are captured with the
+  appendable transcript so a reconstructed tree preserves the parser's
+  physical inputs. Reverified 2026-09-10 that hosted tool parsing derives
+  skill names from recorded paths without consulting worker-local `SKILL.md`
+  frontmatter or the local parse cache; local parsing retains frontmatter
+  lookup. `TestHostedSkillInferenceKeepsNamesLexical` covers this boundary.
 
 ## OpenClaude (`openclaude`)
 
@@ -463,34 +472,51 @@ add an archived or maintained mirror without replacing the original identity.
   archive export and import. Reverified on 2026-09-07 with
   `TestRemoteCodexAliasTitleSurvivesArchiveImport`, which checks the imported
   title while another provider retains its own metadata configuration.
-  Metadata paths are resolved at configuration load and belong to provider
-  instances; imports do not change process-wide configuration. S3 imports list
-  the child's configured Codex root for its explicitly named parent and
-  materialize only that one parent beside the child. When the parent is not
-  yet available, the child remains visible but is stored below the current
-  data version so a later unchanged-object sync retries and corrects the
-  overcount. Reverified 2026-08-13 against the materialized-S3 parser-to-SQLite
-  path: the first missing-parent pass kept replayed content as retryable,
-  and the next pass fetched only the named parent and replaced it with
-  child-owned messages and usage. A readable parent with no turns resolves as
-  current, whether or not the child carries copied parent metadata. Reverified
-  2026-09-06 against the provider parse path with both metadata shapes when
-  integrating the single-pass retry gate with the turnless-parent fix from
-  #1578. An appended `session_meta` after an incremental-sync offset forces an
-  authoritative replacement of that derived session, because the metadata can
-  be the copied parent record that activates replay filtering. The original
-  parent session remains valid and is not reparsed. Reverified 2026-08-12
-  against locally observed multi-agent rollouts that replayed differently
-  shaped opaque turn ids before the first child-owned turn, and against the
-  pinned format sources; the pinned TUI is the evidenced `history.jsonl`
-  producer. No `append_entry` producer call exists under the pinned
-  `app-server` or `exec` trees, so this evidence does not establish IDE,
-  desktop, or `codex exec` activity-hint coverage. Locally observed Codex app
-  builds can write the same schema, but that is observational evidence rather
-  than a public compatibility guarantee. A missing `session_index.jsonl` is
-  verified as normal absence; read or scan failures remain unverified and
-  cannot earn persisted freshness trust, so a transient failure cannot pin a
-  stale stored title. Agentsview derives the hint path as
+  Reverified hosted replay on 2026-09-10 with
+  `TestProviderParserHostedCodexAliasHomeMetadata`: captured primary and alias
+  indexes merge by their original modification times, with later configured
+  homes winning ties. Missing indexes preserve the remaining aliases' logical
+  paths and precedence, including generations without a primary index.
+  `TestProviderParserHostedCodexSkillNameStaysLexical` also verifies that hosted
+  skill inference ignores worker-local frontmatter and cached local names. A
+  bare `SKILL.md` reference without a lexical skill name remains unnamed in
+  hosted replay. Metadata paths are resolved at configuration load and belong
+  to provider instances; imports do not change process-wide configuration. S3
+  imports list the child's configured Codex root for its explicitly named
+  parent and materialize only that one parent beside the child. When the
+  parent is not yet available, the child remains visible but is stored below
+  the current data version so a later unchanged-object sync retries and
+  corrects the overcount. Reverified 2026-08-13 against the materialized-S3
+  parser-to-SQLite path: the first missing-parent pass kept replayed content
+  as retryable, and the next pass fetched only the named parent and replaced
+  it with child-owned messages and usage. A readable parent with no turns
+  resolves as current, whether or not the child carries copied parent metadata.
+  Reverified 2026-09-06 against the provider parse path with both metadata
+  shapes when integrating the single-pass retry gate with the turnless-parent
+  fix from #1578. Reverified 2026-09-10 that raw capture also preserves an
+  orphaned child's full transcript when its named parent is unavailable,
+  matching local parsing. When available, the explicitly named parent travels
+  with the captured fork so hosted parsing applies the local replay boundary.
+  Reverified on 2026-09-10 with
+  `TestProviderParserHostedParseMatchesLocalCodexForkLineage`: parents in
+  other configured homes, archives, and custom roots also travel with the
+  child. Capture keeps local root precedence when roots contain differing
+  parent copies; hosted replay discovers the selected external parent in its
+  own flat root. An appended `session_meta` after an incremental-sync offset
+  forces an authoritative replacement of that derived session, because the
+  metadata can be the copied parent record that activates replay filtering.
+  The original parent session remains valid and is not reparsed. Reverified
+  2026-08-12 against locally observed multi-agent rollouts that replayed
+  differently shaped opaque turn ids before the first child-owned turn, and
+  against the pinned format sources; the pinned TUI is the evidenced
+  `history.jsonl` producer. No `append_entry` producer call exists under the
+  pinned `app-server` or `exec` trees, so this evidence does not establish
+  IDE, desktop, or `codex exec` activity-hint coverage. Locally observed Codex
+  app builds can write the same schema, but that is observational evidence
+  rather than a public compatibility guarantee. A missing
+  `session_index.jsonl` is verified as normal absence; read or scan failures
+  remain unverified and cannot earn persisted freshness trust, so a transient
+  failure cannot pin a stale stored title. Agentsview derives the hint path as
   `<configured-sessions-root>/../history.jsonl`; a custom sessions root
   without that sibling, or `HistoryPersistence::None`, degrades to ordinary
   watcher behavior, degraded-coverage polling when applicable, and the daily
@@ -1989,7 +2015,10 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   cached tokens. Although Forge domain data can discuss cost, Agentsview does
   not consume a direct persisted currency total from this store and instead
   catalog-prices normalized tokens.
-- **Agentsview:** `internal/parser/forge.go`.
+- **Agentsview:** `internal/parser/forge.go`. Reverified 2026-09-10 with
+  isolated SQLite fixtures: hosted WAL snapshots use immutable reads in
+  read-only materializations; live reads retain uncheckpointed WAL rows.
+  Producer schema and usage semantics are unchanged.
 
 ## Devin CLI (`devin`)
 
@@ -2062,7 +2091,10 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   cache-write, model, and service-tier data. The official analyzer derives
   price from those fields; it does not read a persisted provider USD total.
   Agentsview likewise normalizes the counters and catalog-prices the result.
-- **Agentsview:** `internal/parser/piebald.go`.
+- **Agentsview:** `internal/parser/piebald.go`. Reverified 2026-09-10 with
+  isolated SQLite fixtures: hosted WAL snapshots use immutable reads in
+  read-only materializations; live reads retain uncheckpointed WAL rows.
+  Producer schema and usage semantics are unchanged.
 
 ## Warp (`warp`)
 
@@ -2086,6 +2118,9 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   it reports them as session metrics and does not derive USD from them.
 
 - **Agentsview:** `internal/parser/warp.go` and `internal/parser/warp_paths.go`.
+  Reverified 2026-09-10 with isolated SQLite fixtures: hosted WAL snapshots
+  use immutable reads in read-only materializations; live reads retain
+  uncheckpointed WAL rows. Producer schema and usage semantics are unchanged.
 
 ## Positron (`positron`)
 
@@ -2191,7 +2226,17 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   usage events and derives monetary price from its catalog rather than a
   provider-reported USD value.
 - **Agentsview:** `internal/parser/zcode.go`; table and column semantics remain
-  reverse-engineered implementation evidence.
+  reverse-engineered implementation evidence. Rechecked 2026-09-10 against
+  isolated SQLite fixtures: stable WAL snapshots parse read-only, live WAL
+  rows remain visible, and a damaged usage-table page preserves session
+  discovery while parsing reports the per-session error. Cancellation still
+  aborts usage-mtime lookup. Hosted tool skill inference uses recorded path
+  names without reading worker-local frontmatter, as checked by
+  `TestHostedSkillInferenceKeepsNamesLexical`. Captured WAL fixtures also pass
+  through capture, object storage, PostgreSQL job leases, and the hosted
+  worker to its projection boundary in
+  `TestRawCapturedSourcesReachHostedWorker`. No producer schema change is
+  inferred.
 
 ## Goose (`goose`)
 
@@ -2232,6 +2277,13 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   `internal/parser/goose_provider.go`; the provider uses per-session content
   fingerprints and bounded SQLite row cursors for watcher events, while a
   periodic full reconciliation covers metadata-only edits and row deletes.
+  Rechecked 2026-09-10: the pinned session manager enables WAL, and a SQLite
+  backup retains its WAL header. Stable snapshots use `immutable=1` so the
+  read-only materialized directory needs no WAL/SHM writes. Live reads retain
+  `immutable=0`; isolated provider fixtures verify both paths. Reverified
+  2026-09-10 with `TestHostedSkillInferenceKeepsNamesLexical` that hosted tool
+  parsing derives skill names from recorded paths without reading worker-local
+  frontmatter; local parsing retains frontmatter lookup.
 
 ## Zed (`zed`)
 
@@ -2722,7 +2774,19 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   unchanged. Tool-result bodies are stored through the existing category
   filter, without an unfiltered copy in message text; result lengths remain
   available. SSH roots remain file-scoped when invalid filename encodings are
-  skipped.
+  skipped. Reverified 2026-09-10 with
+  `TestProviderParserHostedEvenerMatchesLocal` that captures from both home
+  and directly configured sessions roots replay with the local session
+  identity and messages. Capture plans retain the sessions directory in their
+  logical entry paths so hosted discovery sees the provider's layout, and
+  include the immediate parent transcript and metadata needed to filter copied
+  fork history. Missing or invalid parent evidence preserves the child's
+  history, matching local parsing. The pinned transcript writer appends framed
+  entries and resumes at EOF after trimming a partial tail (see the pinned
+  [transcript writer][evener-source-1]).
+  `TestCapturerEvenerLineageParentGrowthReusesFork` verifies incremental
+  parent capture with unchanged fork-object reuse; metadata remains
+  replaceable.
 
 ## Tau (`tau`)
 
@@ -2779,6 +2843,7 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   distinguish machines with identical root paths. No legacy Tau v1 conversion,
   native transfer, or index metadata synchronization is included.
 
+[evener-source-1]: https://github.com/prime-radiant-inc/evener/blob/da7c06396c9848abfae362dcffce3861a6a0c95a/agent/transcript/transcript.go
 [evener-source-2]: https://github.com/prime-radiant-inc/evener/blob/da7c06396c9848abfae362dcffce3861a6a0c95a/agent/schema/turn.go
 [evener-source-3]: https://github.com/prime-radiant-inc/evener/blob/da7c06396c9848abfae362dcffce3861a6a0c95a/llm/types.go
 [evener-source-4]: https://github.com/prime-radiant-inc/evener/blob/da7c06396c9848abfae362dcffce3861a6a0c95a/agent/schema/snapshot.go

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -348,7 +348,18 @@ When the PostgreSQL role can write the raw-sync tables and ingest-job sequence,
 [hosted raw-sync control plane](/docs/hosted-raw-sync/#http-control-plane).
 Those routes can write raw custody metadata and local raw-sync storage, but they
 do not make the session APIs writable. A PostgreSQL role without the required
-raw-sync write privileges omits the runtime routes.
+raw-sync write privileges omits the runtime routes and logs the missing
+requirements. Existing least-privilege raw-sync roles now also need `SELECT` and
+`UPDATE` on `raw_ingest_jobs` so manifest commits can retire obsolete parse jobs:
+
+```sql
+GRANT SELECT, UPDATE ON agentsview.raw_ingest_jobs TO raw_sync_runtime;
+```
+
+Run this as the schema owner, substitute your schema and runtime role, and
+restart `pg serve`. Keep the existing `INSERT` and ingest-job sequence `USAGE`
+grants. This enables the raw-sync HTTP routes; `pg serve` does not yet start the
+internal parse worker or project hosted raw captures into browsable sessions.
 
 On startup, `pg serve` automatically applies any pending schema migrations to
 PostgreSQL, creating new tables and indexes added in newer AgentsView versions.

--- a/frontend/src/lib/api/generated/models/rawsyncEntry.ts
+++ b/frontend/src/lib/api/generated/models/rawsyncEntry.ts
@@ -5,6 +5,7 @@ import type { RawsyncObjectRef } from "./rawsyncObjectRef.ts";
 
 export interface RawsyncEntry {
   length: number;
+  mod_time_ns?: number;
   objects: RawsyncObjectRef[];
   path: string;
   type: string;

--- a/internal/parser/amp.go
+++ b/internal/parser/amp.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"encoding/json/v2"
 	"fmt"
 	"os"
@@ -97,7 +98,7 @@ func parseAmpSession(
 		}
 
 		content, thinkingText, hasThinking, hasToolUse, tcs, trs :=
-			ExtractTextContent(msg.Get("content"))
+			ExtractTextContent(context.Background(), msg.Get("content"))
 		trs = append(trs, extractAmpToolResults(msg.Get("content"))...)
 		usage := msg.Get("usage")
 		if strings.TrimSpace(content) == "" && len(trs) == 0 &&

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1239,7 +1239,7 @@ func extractMessagesFrom(
 
 		content := gjson.Get(e.line, "message.content")
 		text, thinkingText, hasThinking, hasToolUse, tcs, trs :=
-			ExtractTextContent(content)
+			ExtractTextContent(context.Background(), content)
 
 		// Convert command/skill invocation XML into readable
 		// text (e.g. "/roborev-fix 450"). If the content
@@ -2461,7 +2461,7 @@ func countUserTurnsContext(
 		visited++
 		current := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		if isCountedClaudeUserTurn(entries[current]) {
+		if isCountedClaudeUserTurn(ctx, entries[current]) {
 			count++
 		}
 		stack = append(stack, children[entries[current].uuid]...)
@@ -2469,14 +2469,14 @@ func countUserTurnsContext(
 	return count, ctx.Err()
 }
 
-func isCountedClaudeUserTurn(entry dagEntry) bool {
+func isCountedClaudeUserTurn(ctx context.Context, entry dagEntry) bool {
 	if entry.entryType != "user" ||
 		gjson.Get(entry.line, "isMeta").Bool() ||
 		gjson.Get(entry.line, "isCompactSummary").Bool() {
 		return false
 	}
 	content := gjson.Get(entry.line, "message.content")
-	text, _, _, _, _, _ := ExtractTextContent(content)
+	text, _, _, _, _, _ := ExtractTextContent(ctx, content)
 	text, skip := preprocessClaudeUserText(text)
 	if skip || strings.TrimSpace(text) == "" {
 		return false
@@ -2548,7 +2548,7 @@ func extractMessagesContext(
 
 		content := gjson.Get(e.line, "message.content")
 		text, thinkingText, hasThinking, hasToolUse, tcs, trs :=
-			ExtractTextContent(content)
+			ExtractTextContent(ctx, content)
 
 		// Convert command/skill invocation XML into readable
 		// text (e.g. "/roborev-fix 450"). If the content

--- a/internal/parser/claude_lineage.go
+++ b/internal/parser/claude_lineage.go
@@ -4,6 +4,9 @@ package parser
 
 import (
 	"context"
+	"crypto/sha256"
+	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -49,6 +52,12 @@ const (
 	// cache is rebuilt lazily after a reset, so overflow only costs
 	// re-reads of transcript heads.
 	claudeSniffCacheMaxEntries = 8192
+	// claudeSniffDigestBytes bounds the transcript prefix hashed to
+	// verify sniff-cache entries without reliable change times. Size and
+	// mtime alone cannot detect a same-length rewrite that restores mtime,
+	// so those hits require an unchanged leading digest too.
+	// Heads whose parse runs past the bound are not memoized.
+	claudeSniffDigestBytes = 64 << 10
 )
 
 // claudeHeadSniff summarizes the first uuid-bearing chain entry of a
@@ -62,6 +71,8 @@ type claudeHeadSniff struct {
 type claudeSniffCacheEntry struct {
 	size    int64
 	mtimeNS int64
+	ctimeNS int64
+	headSHA [sha256.Size]byte
 	sniff   claudeHeadSniff
 }
 
@@ -109,57 +120,117 @@ func claudeSniffHead(
 	if err != nil || info.IsDir() {
 		return claudeHeadSniff{}, nil
 	}
+	ctimeNS, changeTimeVerified := codexIndexChangeTime(path, info)
 	claudeSniffMu.Lock()
-	if e, ok := claudeSniffCache[path]; ok &&
-		e.size == info.Size() && e.mtimeNS == info.ModTime().UnixNano() {
-		claudeSniffMu.Unlock()
-		return e.sniff, nil
-	}
+	e, cached := claudeSniffCache[path]
 	claudeSniffMu.Unlock()
+	if cached && e.size == info.Size() && e.mtimeNS == info.ModTime().UnixNano() {
+		if changeTimeVerified && ctimeNS != 0 && e.ctimeNS == ctimeNS {
+			return e.sniff, nil
+		}
+		// Matching metadata does not prove matching content: a
+		// same-length rewrite that restores the mtime would replay a
+		// stale root uuid or bg stamp into lineage resolution. Verify
+		// a bounded digest of the leading bytes before trusting the
+		// memo.
+		headSHA, ok := claudeHeadDigest(path)
+		if ok && headSHA == e.headSHA {
+			return e.sniff, nil
+		}
+	}
 
-	sniff, err := claudeSniffHeadUncached(ctx, path)
+	sniff, headSHA, verified, err := claudeSniffHeadUncached(ctx, path)
 	if err != nil {
 		return claudeHeadSniff{}, err
 	}
 	if err := ctx.Err(); err != nil {
 		return claudeHeadSniff{}, err
 	}
-
-	claudeSniffMu.Lock()
-	if len(claudeSniffCache) >= claudeSniffCacheMaxEntries {
-		claudeSniffCache = map[string]claudeSniffCacheEntry{}
+	if verified {
+		claudeSniffMu.Lock()
+		if len(claudeSniffCache) >= claudeSniffCacheMaxEntries {
+			claudeSniffCache = map[string]claudeSniffCacheEntry{}
+		}
+		claudeSniffCache[path] = claudeSniffCacheEntry{
+			size:    info.Size(),
+			mtimeNS: info.ModTime().UnixNano(),
+			ctimeNS: ctimeNS,
+			headSHA: headSHA,
+			sniff:   sniff,
+		}
+		claudeSniffMu.Unlock()
 	}
-	claudeSniffCache[path] = claudeSniffCacheEntry{
-		size:    info.Size(),
-		mtimeNS: info.ModTime().UnixNano(),
-		sniff:   sniff,
-	}
-	claudeSniffMu.Unlock()
 	return sniff, nil
+}
+
+// claudeHeadDigest hashes the leading claudeSniffDigestBytes of
+// path. ok is false when the file cannot be opened or read.
+func claudeHeadDigest(path string) ([sha256.Size]byte, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return [sha256.Size]byte{}, false
+	}
+	defer f.Close()
+	headSHA, _, ok := claudeHashLeading(f, claudeSniffDigestBytes)
+	return headSHA, ok
+}
+
+// claudeHashLeading hashes the leading limit bytes of f without
+// moving the file offset, returning the digest and the number of
+// bytes hashed. ok is false when the read fails, including for
+// files that do not support positioned reads.
+func claudeHashLeading(
+	f *os.File, limit int64,
+) ([sha256.Size]byte, int64, bool) {
+	h := sha256.New()
+	n, err := io.Copy(h, io.NewSectionReader(f, 0, limit))
+	if err != nil {
+		return [sha256.Size]byte{}, 0, false
+	}
+	var headSHA [sha256.Size]byte
+	copy(headSHA[:], h.Sum(nil))
+	return headSHA, n, true
 }
 
 func claudeSniffHeadUncached(
 	ctx context.Context, path string,
-) (claudeHeadSniff, error) {
+) (claudeHeadSniff, [sha256.Size]byte, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return claudeHeadSniff{}, nil
+		return claudeHeadSniff{}, [sha256.Size]byte{}, false, nil
 	}
 	defer f.Close()
+	// Digest the head before parsing it, from the same open file, so
+	// the stored digest cannot describe content newer than the
+	// parsed lines. A rewrite racing between the digest read and the
+	// parse can still pair a digest with lines it did not cover; the
+	// settled file then hashes differently and the next lookup
+	// misses, so the mismatch cannot be served as a hit. The parse is
+	// memoized only when it consumed bytes inside the digested
+	// prefix: beyond it, a rewrite could hide from the digest.
+	headSHA, hashed, digestOK := claudeHashLeading(f, claudeSniffDigestBytes)
 	lr := newLineReaderContext(ctx, f, maxLineSize)
 	defer releaseLineReader(lr)
+	sniff, consumed, err := claudeSniffHeadLines(ctx, lr)
+	verified := digestOK && consumed <= hashed
+	return sniff, headSHA, verified, err
+}
+
+func claudeSniffHeadLines(
+	ctx context.Context, lr *lineReader,
+) (claudeHeadSniff, int64, error) {
 	for range claudeLineageSniffMaxLines {
 		if err := ctx.Err(); err != nil {
-			return claudeHeadSniff{}, err
+			return claudeHeadSniff{}, lr.bytesRead, err
 		}
 		lineBytes, ok := lr.nextBytes()
 		if !ok {
 			if lr.Err() != nil {
 				if err := ctx.Err(); err != nil {
-					return claudeHeadSniff{}, err
+					return claudeHeadSniff{}, lr.bytesRead, err
 				}
 			}
-			return claudeHeadSniff{}, nil
+			return claudeHeadSniff{}, lr.bytesRead, nil
 		}
 		if !gjson.ValidBytes(lineBytes) {
 			continue
@@ -172,18 +243,18 @@ func claudeSniffHeadUncached(
 		// replayed copy, which starts at the conversation root) has no
 		// parentUuid. Any other head shape is unexpected: fail open.
 		if gjson.GetBytes(lineBytes, "parentUuid").Str != "" {
-			return claudeHeadSniff{}, nil
+			return claudeHeadSniff{}, lr.bytesRead, nil
 		}
 		return claudeHeadSniff{
 			rootUUID: uuid,
 			rootIsBG: gjson.GetBytes(lineBytes, "sessionKind").Str == "bg",
 			ok:       true,
-		}, nil
+		}, lr.bytesRead, nil
 	}
 	if err := ctx.Err(); err != nil {
-		return claudeHeadSniff{}, err
+		return claudeHeadSniff{}, lr.bytesRead, err
 	}
-	return claudeHeadSniff{}, nil
+	return claudeHeadSniff{}, lr.bytesRead, nil
 }
 
 // claudeForkLine is one uuid-bearing line of a fork transcript.
@@ -234,11 +305,59 @@ func claudeScanUUIDs(
 	return lr.Err() == nil, nil
 }
 
+// claudeLineageCaptureSiblings returns the sibling transcripts the lineage
+// parser must be able to read for path: when path is a top-level project
+// transcript whose head is a bg-marked fork, every sibling .jsonl in the same
+// project directory whose first chain entry replays the fork's root uuid.
+// Only bg-marked forks ever trim or link, so interactive originals, subagent
+// transcripts, and unrelated conversations contribute no entries. The set is
+// exactly the candidate filter claudeResolveSiblingLineage applies, so a
+// capture generation carries every input the parser needs at replay time.
+func claudeLineageCaptureSiblings(ctx context.Context, path string) ([]string, error) {
+	self, err := claudeSniffHead(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if !self.ok || !self.rootIsBG {
+		return nil, nil
+	}
+	dir := filepath.Dir(path)
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, invalidRawCapturePlan(
+			"read Claude lineage siblings: %s", rawCaptureFilesystemError(err),
+		)
+	}
+	base := filepath.Base(path)
+	var siblings []string
+	for _, entry := range dirEntries {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		name := entry.Name()
+		if entry.IsDir() || name == base ||
+			!strings.HasSuffix(name, ".jsonl") ||
+			strings.HasPrefix(name, "agent-") {
+			continue
+		}
+		siblingPath := filepath.Join(dir, name)
+		sniff, err := claudeSniffHead(ctx, siblingPath)
+		if err != nil {
+			return nil, err
+		}
+		if sniff.ok && sniff.rootUUID == self.rootUUID {
+			siblings = append(siblings, siblingPath)
+		}
+	}
+	return siblings, nil
+}
+
 // claudeResolveSiblingLineage establishes the background-fork lineage
 // for path, or returns nil when no lineage can be positively oriented.
-// Sibling discovery is head-sniff only (memoized per size and mtime);
-// the qualifying candidates' full uuid sets are read once per full
-// parse of a bg-marked fork.
+// Sibling discovery is head-sniff only (memoized per size, mtime, and
+// change time, with a bounded digest when change time is unavailable).
+// Qualifying candidates' full uuid sets are read once per full parse of a
+// bg-marked fork.
 func claudeResolveSiblingLineage(
 	ctx context.Context, path string,
 ) (*claudeLineagePlan, error) {
@@ -323,6 +442,8 @@ func claudeResolveSiblingLineage(
 	bestRun := 0
 	bestStem := ""
 	var bestSet map[string]struct{}
+	bestTied := false
+	bestBG := false
 	for _, c := range candidates {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -352,9 +473,15 @@ func claudeResolveSiblingLineage(
 			bestRun = run
 			bestStem = c.stem
 			bestSet = set
+			bestTied = false
+			bestBG = c.bg
+		} else if run > 0 && run == bestRun && c.bg == bestBG && !maps.Equal(set, bestSet) {
+			bestTied = true
 		}
 	}
-	if bestRun == 0 {
+	// Different UUID sets sharing a maximum do not identify an ancestor:
+	// they may be independent forks. Identical sets keep the smallest stem.
+	if bestRun == 0 || bestTied {
 		return nil, nil
 	}
 	dropUUIDs := make(map[string]struct{}, bestRun)

--- a/internal/parser/claude_lineage_test.go
+++ b/internal/parser/claude_lineage_test.go
@@ -123,6 +123,25 @@ func TestClaudeBackgroundForkTrimsReplayAndLinksParent(t *testing.T) {
 	assert.Equal(t, 7, sess.TotalOutputTokens)
 }
 
+func TestClaudeBackgroundForkPrefersInteractiveOriginalOverTiedBackgroundSibling(t *testing.T) {
+	t.Parallel()
+	origPath, forkPath := writeLineageFixture(t,
+		"orig-1111.jsonl", lineageOriginalContent(),
+		"fork-2222.jsonl", lineageForkContent(),
+	)
+	sibling := strings.ReplaceAll(lineageForkContent(), "fork-2222", "sibling-3333")
+	sibling = strings.ReplaceAll(sibling, `"u2"`, `"u3"`)
+	sibling = strings.ReplaceAll(sibling, `"a2"`, `"a3"`)
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(origPath), "sibling-3333.jsonl"), []byte(sibling), 0o600))
+
+	results, _, err := claudeParseFile(forkPath, "demo", "local", claudeParseOptions{siblingLineage: true})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "orig-1111", results[0].Session.ParentSessionID)
+	require.Len(t, results[0].Messages, 2)
+	assert.Equal(t, "continued question", results[0].Messages[0].Content)
+}
+
 func TestClaudeOriginalUnaffectedBySiblingFork(t *testing.T) {
 	t.Parallel()
 	origPath, _ := writeLineageFixture(t,
@@ -312,6 +331,40 @@ func TestClaudeBackgroundForkEqualBgTwinsElectKeeperByStem(t *testing.T) {
 	assert.Contains(t, contents, "queued in c")
 	assert.NotContains(t, contents, "first question")
 	assert.Equal(t, "orig-1111", smallResults[0].Session.ParentSessionID)
+}
+
+func TestClaudeBackgroundForkEqualBgCopiesElectKeeperByStem(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	stems := []string{"aaaa-1111", "bbbb-2222", "cccc-3333"}
+	for _, stem := range stems {
+		content := strings.ReplaceAll(lineageForkContent(), "fork-2222", stem)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, stem+".jsonl"), []byte(content), 0o600))
+	}
+	for _, stem := range stems {
+		t.Run(stem, func(t *testing.T) {
+			results, excluded, err := claudeParseFile(
+				filepath.Join(dir, stem+".jsonl"), "demo", "local",
+				claudeParseOptions{siblingLineage: true},
+			)
+			require.NoError(t, err)
+			if stem != "aaaa-1111" {
+				assert.Empty(t, results)
+				assert.Equal(t, []string{stem}, excluded)
+				return
+			}
+			require.Len(t, results, 1)
+			assert.Empty(t, excluded)
+			assert.Empty(t, results[0].Session.ParentSessionID)
+			var contents []string
+			for _, message := range results[0].Messages {
+				contents = append(contents, message.Content)
+			}
+			assert.Equal(t, []string{
+				"first question", "first answer", "continued question", "continued answer",
+			}, contents)
+		})
+	}
 }
 
 func TestClaudeBackgroundForkBoundaryRetryFailsOpen(t *testing.T) {
@@ -552,6 +605,57 @@ func TestClaudeBackgroundForkPicksLongestReplayCandidate(t *testing.T) {
 	assert.Equal(t, "long-3333", results[0].Session.ParentSessionID)
 }
 
+func TestClaudeBackgroundForkEqualReplayCandidatesFailOpen(t *testing.T) {
+	t.Parallel()
+	// Two siblings cover the same leading replay run but diverge
+	// afterward. Neither can be positively identified as the fork's parent,
+	// so preserve the fork intact without emitting an arbitrary relationship.
+	leftContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "left-1111", "", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "left-1111", "", "msg_01", "first answer", 20),
+		lineageUserLine("left-u2", "a1", "2026-01-01T10:30:00Z", "left-1111", "", "left branch"),
+	}, "\n") + "\n"
+	rightContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "right-2222", "", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "right-2222", "", "msg_01", "first answer", 20),
+		lineageUserLine("right-u2", "a1", "2026-01-01T10:30:00Z", "right-2222", "", "right branch"),
+	}, "\n") + "\n"
+	forkContent := strings.Join([]string{
+		lineageUserLine("u1", "", "2026-01-01T10:00:00Z", "fork-3333", "bg", "first question"),
+		lineageAssistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-3333", "bg", "msg_01", "first answer", 20),
+		lineageUserLine("fork-u2", "a1", "2026-01-01T11:00:00Z", "fork-3333", "bg", "fork question"),
+	}, "\n") + "\n"
+
+	for _, kind := range []string{"interactive", "bg"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := t.TempDir()
+			left, right := leftContent, rightContent
+			if kind == "bg" {
+				left = strings.ReplaceAll(left, `"sessionId":`, `"sessionKind":"bg","sessionId":`)
+				right = strings.ReplaceAll(right, `"sessionId":`, `"sessionKind":"bg","sessionId":`)
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "left-1111.jsonl"), []byte(left), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "right-2222.jsonl"), []byte(right), 0o600))
+			// A later copy of the first candidate must not clear the ambiguity.
+			twin := strings.ReplaceAll(left, "left-1111", "twin-4444")
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "twin-4444.jsonl"), []byte(twin), 0o600))
+			forkPath := filepath.Join(dir, "fork-3333.jsonl")
+			require.NoError(t, os.WriteFile(forkPath, []byte(forkContent), 0o600))
+
+			results, excluded, err := claudeParseFile(
+				forkPath, "my_app", "local",
+				claudeParseOptions{siblingLineage: true},
+			)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Empty(t, excluded)
+			assert.Empty(t, results[0].Session.ParentSessionID)
+			assert.Equal(t, RelNone, results[0].Session.RelationshipType)
+			assert.Equal(t, 3, results[0].Session.MessageCount)
+		})
+	}
+}
+
 func TestClaudeBackgroundForkKeepsOwnUUIDLessRecords(t *testing.T) {
 	t.Parallel()
 	// Claude Code never replays uuid-less records into a fork
@@ -703,6 +807,116 @@ func TestClaudeBackgroundForkIncrementalAppendContinuesFromTrim(t *testing.T) {
 	// Ordinals continue from the trimmed message count, not the raw
 	// replayed line count.
 	assert.Equal(t, 2, msgs[0].Ordinal)
+}
+
+func TestClaudeLineageSniffCacheInvalidatedBySameSizeRewrite(t *testing.T) {
+	t.Parallel()
+	// The sniff memo keys entries by size and mtime. A same-length
+	// in-place rewrite with the original mtime restored must not be
+	// served from the stale entry: the re-parse has to observe the
+	// new head (bg stamp and root uuid) or fork siblings are omitted
+	// or misresolved. Each row proves one observable direction
+	// through a full parse.
+	origContent := lineageOriginalContent()
+	forkContent := lineageForkContent()
+	origAltRoot := strings.ReplaceAll(origContent, `"u1"`, `"z9"`)
+	forkNotBG := strings.ReplaceAll(
+		forkContent, `"sessionKind":"bg"`, `"sessionKind":"fg"`)
+
+	tests := []struct {
+		name       string
+		warmOrig   string
+		warmFork   string
+		warmParent string
+		rewrite    struct{ target, content string }
+		wantParent string
+		wantFirst  string
+		wantMsgs   int
+	}{
+		{
+			name:       "fork head rewritten without bg stamp",
+			warmOrig:   origContent,
+			warmFork:   forkContent,
+			warmParent: "orig-1111",
+			rewrite:    struct{ target, content string }{"fork", forkNotBG},
+			// The fork is no longer bg-marked: no trim, no link.
+			wantParent: "",
+			wantFirst:  "first question",
+			wantMsgs:   4,
+		},
+		{
+			name:       "sibling head rewritten to the fork root",
+			warmOrig:   origAltRoot,
+			warmFork:   forkContent,
+			warmParent: "",
+			rewrite:    struct{ target, content string }{"orig", origContent},
+			// The rewritten sibling now qualifies: the fork trims
+			// against it instead of keeping the duplicated replay.
+			wantParent: "orig-1111",
+			wantFirst:  "continued question",
+			wantMsgs:   2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			origPath, forkPath := writeLineageFixture(t,
+				"orig-1111.jsonl", tt.warmOrig,
+				"fork-2222.jsonl", tt.warmFork,
+			)
+
+			// Warm the memo and prove the warm-phase lineage state,
+			// so a stale hit has a wrong decision to serve.
+			warm, _, err := claudeParseFile(
+				forkPath, "my_app", "local",
+				claudeParseOptions{siblingLineage: true},
+			)
+			require.NoError(t, err)
+			require.Len(t, warm, 1)
+			assert.Equal(t, tt.warmParent, warm[0].Session.ParentSessionID)
+
+			target := origPath
+			if tt.rewrite.target == "fork" {
+				target = forkPath
+			}
+			info, err := os.Stat(target)
+			require.NoError(t, err)
+			require.Len(t, tt.rewrite.content, int(info.Size()))
+			require.NoError(t, os.WriteFile(target, []byte(tt.rewrite.content), 0o644))
+			require.NoError(t, os.Chtimes(target, info.ModTime(), info.ModTime()))
+			restored, err := os.Stat(target)
+			require.NoError(t, err)
+			require.Equal(t, info.ModTime().UnixNano(), restored.ModTime().UnixNano())
+
+			// The fork's lineage resolution is the observable: it is
+			// what consumes the rewritten head's sniff.
+			results, _, err := claudeParseFile(
+				forkPath, "my_app", "local",
+				claudeParseOptions{siblingLineage: true},
+			)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Equal(t, tt.wantParent, results[0].Session.ParentSessionID)
+			require.Len(t, results[0].Messages, tt.wantMsgs)
+			assert.Equal(t, tt.wantFirst, firstMessageContent(results[0].Messages))
+		})
+	}
+}
+
+func BenchmarkClaudeLineageSniffCacheHit(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "session.jsonl")
+	content := lineageOriginalContent() + strings.Repeat(" ", 64<<10)
+	require.NoError(b, os.WriteFile(path, []byte(content), 0o600))
+	warm, err := claudeSniffHead(b.Context(), path)
+	require.NoError(b, err)
+	require.True(b, warm.ok)
+	b.ResetTimer()
+	for b.Loop() {
+		sniff, err := claudeSniffHead(b.Context(), path)
+		if err != nil || !sniff.ok {
+			b.Fatal("sniff cache lost the transcript root", err)
+		}
+	}
 }
 
 func TestClaudeLineageSniffGivesUpAfterBoundedPreamble(t *testing.T) {

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -2881,7 +2881,7 @@ func TestExtractTextContent_ReturnsThinkingText(t *testing.T) {
 			{"type":"thinking","thinking":"second thought"},
 			{"type":"text","text":"reply B"}
 		]`)
-		text, thinking, hasThinking, _, _, _ := ExtractTextContent(content)
+		text, thinking, hasThinking, _, _, _ := ExtractTextContent(t.Context(), content)
 		assert.True(t, hasThinking)
 		assert.Equal(t, "first thought\n\nsecond thought", thinking)
 		assert.Contains(t, text, "[Thinking]\nfirst thought\n[/Thinking]")
@@ -2893,7 +2893,7 @@ func TestExtractTextContent_ReturnsThinkingText(t *testing.T) {
 			{"type":"thinking","thinking":""},
 			{"type":"thinking","thinking":"real thought"}
 		]`)
-		_, thinking, _, _, _, _ := ExtractTextContent(content)
+		_, thinking, _, _, _, _ := ExtractTextContent(t.Context(), content)
 		assert.Equal(t, "real thought", thinking)
 	})
 }

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -148,6 +148,27 @@ func (p *claudeProvider) PlanRawCapture(
 		LocalPath:  src.Path,
 		Appendable: true,
 	}}
+	// Background-fork lineage resolution reads sibling top-level project
+	// transcripts, so a project-level capture must carry them as appendable
+	// inputs. Provider ownership stays here: no hosted parser or classifier
+	// duplicates this set.
+	if claudeSourceIsProjectLevel(source, src.Path) {
+		siblings, err := claudeLineageCaptureSiblings(ctx, src.Path)
+		if err != nil {
+			return RawCapturePlan{}, err
+		}
+		for _, sibling := range siblings {
+			siblingRel, err := filepath.Rel(src.Root, sibling)
+			if err != nil {
+				return RawCapturePlan{}, invalidRawCapturePlan(
+					"resolve Claude lineage sibling: %s", rawCaptureFilesystemError(err),
+				)
+			}
+			entries = append(entries, RawCaptureEntry{
+				Path: filepath.ToSlash(siblingRel), LocalPath: sibling, Appendable: true,
+			})
+		}
+	}
 	sidecars, err := claudeLayoutSidecarFiles(ctx, src.Path)
 	if err != nil {
 		return RawCapturePlan{}, invalidRawCapturePlan(
@@ -198,9 +219,23 @@ func (p *claudeProvider) Parse(
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
 	project := claudeProviderProject(ctx, req.Source.ProjectHint, path)
+	var persistedOutputPathResolver func(string) (string, bool)
+	if req.StoredPathResolver != nil {
+		// Stored companions can carry a canonical machine-qualified
+		// spelling (remote mirrors) or the raw recorded path (hosted raw
+		// materializations); try both before falling back to the on-disk
+		// layout, mirroring the shared Claude-layout provider contract.
+		persistedOutputPathResolver = func(path string) (string, bool) {
+			if local, ok := req.StoredPathResolver(path); ok {
+				return local, true
+			}
+			return req.StoredPathResolver(machine + ":" + path)
+		}
+	}
 	opts := claudeParseOptions{
-		ctx:            ctx,
-		siblingLineage: claudeSourceIsProjectLevel(req.Source, path),
+		ctx:                         ctx,
+		siblingLineage:              claudeSourceIsProjectLevel(req.Source, path),
+		persistedOutputPathResolver: persistedOutputPathResolver,
 	}
 	results, excludedIDs, err := claudeParseFile(path, project, machine, opts)
 	if err != nil {
@@ -871,7 +906,7 @@ func claudeProviderCapabilities() Capabilities {
 		RawCapture: RawCaptureCapabilities{
 			Support:  CapabilitySupported,
 			Shape:    RawCaptureShapeFiles,
-			Append:   RawCaptureAppendOne,
+			Append:   RawCaptureAppendMany,
 			Snapshot: RawCaptureSnapshotNone,
 		},
 	}

--- a/internal/parser/claude_provider_test.go
+++ b/internal/parser/claude_provider_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -371,6 +373,139 @@ func TestClaudeProviderParse(t *testing.T) {
 	assert.Equal(t, "abc123", result.Result.Session.File.Hash)
 	assert.Equal(t, "parse question", result.Result.Session.FirstMessage)
 	assert.Len(t, result.Result.Messages, 2)
+}
+
+func TestClaudeProviderParseResolvesPersistedToolResultsThroughStoredPathResolver(t *testing.T) {
+	root := t.TempDir()
+	projectDir := "demo-project"
+	sessionID := "session-persisted"
+	sourcePath := filepath.Join(root, projectDir, sessionID+".jsonl")
+	resultPath := filepath.Join(
+		root, projectDir, sessionID, "tool-results", "r1.txt",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(resultPath), 0o755))
+	fullOutput := "resolved full output line 1\nresolved full output line 2\n"
+	require.NoError(t, os.WriteFile(resultPath, []byte(fullOutput), 0o644))
+	// The transcript references the companion through a canonical stored
+	// spelling that no longer matches the on-disk layout; only the caller's
+	// StoredPathResolver can map it back to the physical companion file.
+	storedPath := "devbox:" + resultPath
+	persistedNotice := "<persisted-output>\nOutput too large (35B). Full output saved to: " +
+		storedPath + "\n</persisted-output>"
+	content := strings.Join([]string{
+		`{"type":"user","timestamp":"2026-08-13T12:00:00Z","uuid":"u1","message":{"content":"run it"},"cwd":"/work/demo"}`,
+		`{"type":"assistant","timestamp":"2026-08-13T12:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make"}}]}}`,
+		`{"type":"user","timestamp":"2026-08-13T12:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + strconv.Quote(persistedNotice) + `,"is_error":false}]},"toolUseResult":{"persistedOutputPath":` + strconv.Quote(storedPath) + `,"persistedOutputSize":35}}`,
+	}, "\n") + "\n"
+	writeSourceFile(t, sourcePath, content)
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      sources[0],
+		Fingerprint: SourceFingerprint{Key: sourcePath, Hash: "abc123"},
+		Machine:     "devbox",
+		StoredPathResolver: func(path string) (string, bool) {
+			if unqualified, found := strings.CutPrefix(path, "devbox:"); found {
+				return unqualified, true
+			}
+			return "", false
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	messages := outcome.Results[0].Result.Messages
+	require.Len(t, messages, 3)
+	toolResults := messages[2].ToolResults
+	require.Len(t, toolResults, 1)
+	assert.Equal(t, len(fullOutput), toolResults[0].ContentLength)
+	assert.Equal(t, fullOutput, DecodeContent(toolResults[0].ContentRaw),
+		"a stored persisted-output path must resolve through ParseRequest.StoredPathResolver")
+}
+
+func TestClaudePlanRawCaptureCarriesLineageSiblingInputs(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	origPath := filepath.Join(projectDir, "orig-1111.jsonl")
+	forkPath := filepath.Join(projectDir, "fork-2222.jsonl")
+	unrelatedPath := filepath.Join(projectDir, "unrelated-3333.jsonl")
+	require.NoError(t, os.WriteFile(origPath, []byte(lineageOriginalContent()), 0o644))
+	require.NoError(t, os.WriteFile(forkPath, []byte(lineageForkContent()), 0o644))
+	unrelated := strings.Join([]string{
+		lineageUserLine("z1", "", "2026-02-01T10:00:00Z", "unrelated-3333", "", "other root"),
+		lineageAssistantLine("z2", "z1", "2026-02-01T10:00:05Z", "unrelated-3333", "", "msg_z", "other answer", 3),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(unrelatedPath, []byte(unrelated), 0o644))
+	subagentDir := filepath.Join(projectDir, "fork-2222", "subagents", "agent-4444")
+	require.NoError(t, os.MkdirAll(subagentDir, 0o755))
+	subagentPath := filepath.Join(subagentDir, "agent-4444.jsonl")
+	require.NoError(t, os.WriteFile(subagentPath, []byte(lineageForkContent()), 0o644))
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 4)
+	findSource := func(suffix string) SourceRef {
+		for _, source := range sources {
+			if strings.HasSuffix(source.Key, suffix) {
+				return source
+			}
+		}
+		t.Fatalf("source %s not discovered", suffix)
+		return SourceRef{}
+	}
+
+	// The bg fork replays the original's chain, so its capture plan must carry
+	// the original transcript as an appendable lineage input: the original
+	// can keep growing independently of the fork.
+	forkPlan, supported, err := ResolveRawCapturePlan(context.Background(), provider, findSource("fork-2222.jsonl"))
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Len(t, forkPlan.Entries, 2)
+	assert.Equal(t, "demo-project/fork-2222.jsonl", forkPlan.Entries[0].Path)
+	assert.True(t, forkPlan.Entries[0].Appendable)
+	assert.Equal(t, "demo-project/orig-1111.jsonl", forkPlan.Entries[1].Path)
+	assert.True(t, forkPlan.Entries[1].Appendable,
+		"sibling lineage inputs can grow independently of the fork")
+	// Windows temp roots can surface the same physical file under both 8.3
+	// and expanded path spellings, so compare file identity, not strings.
+	assertSameFile := func(want, got string) {
+		wantInfo, err := os.Stat(want)
+		require.NoError(t, err)
+		gotInfo, err := os.Stat(got)
+		require.NoError(t, err)
+		assert.True(t, os.SameFile(wantInfo, gotInfo),
+			"expected LocalPath %q to refer to %q", got, want)
+	}
+	assertSameFile(forkPath, forkPlan.Entries[0].LocalPath)
+	assertSameFile(origPath, forkPlan.Entries[1].LocalPath)
+
+	// The interactive original never trims, so its plan must not carry
+	// siblings; the unrelated-root transcript and subagent transcripts never
+	// participate in lineage either.
+	origPlan, supported, err := ResolveRawCapturePlan(context.Background(), provider, findSource("orig-1111.jsonl"))
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Len(t, origPlan.Entries, 1)
+	assert.Equal(t, "demo-project/orig-1111.jsonl", origPlan.Entries[0].Path)
+	assert.True(t, origPlan.Entries[0].Appendable)
+
+	subagentPlan, supported, err := ResolveRawCapturePlan(
+		context.Background(), provider, findSource("agent-4444.jsonl"))
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Len(t, subagentPlan.Entries, 1)
+	assert.True(t, subagentPlan.Entries[0].Appendable)
 }
 
 func TestClaudeProviderParseIncremental(t *testing.T) {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -640,7 +640,7 @@ func (b *codexSessionBuilder) handleFunctionCall(
 
 	content := formatCodexFunctionCall(name, payload)
 	inputJSON := extractCodexInputJSON(payload)
-	skillName := inferCodexSkillNameWithBase(name, inputJSON, b.cwd)
+	skillName := inferCodexSkillNameWithBase(b.projectContext, name, inputJSON, b.cwd)
 	waitAgentIDs := []string(nil)
 	if isCodexWaitAgentCall(name) && callID != "" {
 		args, _ := parseCodexFunctionArgs(payload)

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -356,6 +356,40 @@ func (p *codexProvider) PlanRawCapture(
 		Appendable: true,
 	}}
 	var sidecarRoots []string
+	if parentID, needed := codexReplayParentIDContext(ctx, src.Path); needed {
+		parentPath := ""
+		for _, root := range p.sources.roots {
+			if err := ctx.Err(); err != nil {
+				return RawCapturePlan{}, err
+			}
+			candidate := p.sources.findSourceFile(root, parentID)
+			if candidate == "" || samePath(candidate, src.Path) {
+				continue
+			}
+			parentPath = candidate
+			break
+		}
+		// Missing parents preserve the child's history, matching local parsing.
+		if parentPath != "" {
+			// One named parent may come from any configured root. Give an
+			// external parent its own flat root so it cannot collide with the
+			// child's layout, and hosted lookup can find it by session UUID.
+			parentRel := filepath.Join("replay-parent", filepath.Base(parentPath))
+			if rawCapturePathWithin(captureRoot, parentPath) {
+				parentRel, err = filepath.Rel(captureRoot, parentPath)
+				if err != nil {
+					return RawCapturePlan{}, invalidRawCapturePlan(
+						"resolve Codex replay parent: %s", rawCaptureFilesystemError(err),
+					)
+				}
+			} else {
+				sidecarRoots = append(sidecarRoots, filepath.Dir(parentPath))
+			}
+			entries = append(entries, RawCaptureEntry{
+				Path: filepath.ToSlash(parentRel), LocalPath: parentPath,
+			})
+		}
+	}
 	for i, candidate := range p.sources.metadata.IndexPaths(src.Path) {
 		info, err := os.Stat(candidate)
 		switch {
@@ -366,6 +400,17 @@ func (p *codexProvider) PlanRawCapture(
 			logical := CodexSessionIndexFilename
 			if i > 0 {
 				logical = fmt.Sprintf("alias-homes/%d/%s", i, CodexSessionIndexFilename)
+			}
+			if p.Config.StableSourceSnapshots && rawCapturePathWithin(captureRoot, candidate) {
+				// Materialized aliases already have custody paths. Keep their
+				// original ordinals even when missing indexes left gaps.
+				rel, err := filepath.Rel(captureRoot, candidate)
+				if err != nil {
+					return RawCapturePlan{}, invalidRawCapturePlan(
+						"resolve Codex session index: %s", rawCaptureFilesystemError(err),
+					)
+				}
+				logical = filepath.ToSlash(rel)
 			}
 			if filepath.Dir(candidate) != captureRoot {
 				sidecarRoots = append(sidecarRoots, filepath.Dir(candidate))

--- a/internal/parser/content.go
+++ b/internal/parser/content.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -16,7 +17,7 @@ import (
 // Thinking blocks are joined with "\n\n" to give an unambiguous
 // block boundary in the concatenated thinking text.
 func ExtractTextContent(
-	content gjson.Result,
+	ctx context.Context, content gjson.Result,
 ) (string, string, bool, bool, []ParsedToolCall, []ParsedToolResult) {
 	if content.Type == gjson.String {
 		return content.Str, "", false, false, nil, nil
@@ -57,7 +58,7 @@ func ExtractTextContent(
 			// it when "input" is missing or empty.
 			hasToolUse = true
 			rendering := formatToolUse(block)
-			if tc, ok := parseToolCall(block); ok {
+			if tc, ok := parseToolCall(ctx, block); ok {
 				tc.Rendering = rendering
 				toolCalls = append(toolCalls, tc)
 			}
@@ -75,7 +76,7 @@ func ExtractTextContent(
 		hasThinking, hasToolUse, toolCalls, toolResults
 }
 
-func parseToolCall(block gjson.Result) (ParsedToolCall, bool) {
+func parseToolCall(ctx context.Context, block gjson.Result) (ParsedToolCall, bool) {
 	name := block.Get("name").Str
 	if name == "" {
 		return ParsedToolCall{}, false
@@ -96,7 +97,7 @@ func parseToolCall(block gjson.Result) (ParsedToolCall, bool) {
 			tc.SkillName = input.Get("name").Str
 		}
 	default:
-		tc.SkillName = inferToolSkillName(name, tc.InputJSON)
+		tc.SkillName = inferToolSkillName(ctx, name, tc.InputJSON)
 	}
 	return tc, true
 }

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json/v2"
 	"fmt"
@@ -368,7 +369,7 @@ func extractAssistantContent(
 				ToolName:  toolName,
 				Category:  NormalizeToolCategory(toolName),
 				InputJSON: inputJSON,
-				SkillName: inferToolSkillName(
+				SkillName: inferToolSkillName(context.Background(),
 					toolName,
 					inputJSON,
 				),
@@ -590,7 +591,7 @@ func parseCursorJSONL(data string) []ParsedMessage {
 			msg.Role = RoleAssistant
 			text, _, hasThinking, hasToolUse,
 				toolCalls, toolResults :=
-				ExtractTextContent(content)
+				ExtractTextContent(context.Background(), content)
 			msg.Content = text
 			msg.HasThinking = hasThinking
 			msg.HasToolUse = hasToolUse

--- a/internal/parser/db_backed_parse_context_test.go
+++ b/internal/parser/db_backed_parse_context_test.go
@@ -1,0 +1,141 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Hosted raw derivation parses materialized SQLite snapshots under an attempt
+// context: an attempt timeout or a lost lease must abort the provider's
+// database work instead of being dropped before the first query. Each case
+// seeds a real provider database and parses through the same per-session
+// entrypoint the provider's dbBackedProviderSpec.parse closure calls, with an
+// already-canceled context. The provider-level Parse entrypoints cannot be
+// used for this: they reject a dead context before touching the database, so
+// they would mask a dropped-context regression inside the loading helpers.
+// With an already-dead context each case fails at the provider's first
+// context-aware query, so these cases pin that boundary only; deeper
+// helper-chain propagation past that first query is pinned separately for the
+// mtime path by TestZCodeMtimeQueryPropagatesCanceledContext below.
+func TestDBBackedParsePropagatesCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	t.Run("forge", func(t *testing.T) {
+		dbPath, seeder, db := newForgeTestDB(t)
+		defer db.Close()
+		seedForgeConversation(t, seeder)
+
+		sess, msgs, err := parseForgeSession(ctx, dbPath, "conv-001", "testmachine", false)
+		require.Error(t, err, "canceled context must abort forge parsing")
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, sess)
+		assert.Empty(t, msgs)
+	})
+
+	t.Run("piebald", func(t *testing.T) {
+		dbPath := newPiebaldTestDB(t)
+		execPiebaldTestSQL(t, dbPath,
+			`INSERT INTO chats
+			 (id, title, created_at, updated_at, is_deleted, message_count, current_directory)
+			 VALUES (42, 'Fix bug', '2026-05-01T10:00:00Z', '2026-05-01T10:05:00Z', 0, 1, '/repo/app')`)
+		execPiebaldTestSQL(t, dbPath,
+			`INSERT INTO messages
+			 (id, parent_chat_id, role, model, created_at, updated_at, status)
+			 VALUES (100, 42, 'user', '', '2026-05-01T10:00:01Z', '2026-05-01T10:00:01Z', 'completed')`)
+		seedPiebaldTextPart(t, dbPath, 200, 100, 0, "Please fix this", false)
+
+		results, err := parsePiebaldSessionResults(ctx, dbPath, "42", "testmachine", false)
+		require.Error(t, err, "canceled context must abort piebald parsing")
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Empty(t, results)
+	})
+
+	t.Run("warp", func(t *testing.T) {
+		dbPath, seeder, db := newWarpTestDB(t)
+		defer db.Close()
+		seedWarpConversation(t, seeder)
+
+		sess, msgs, err := parseWarpSession(ctx, dbPath, "conv-001", "testmachine", false)
+		require.Error(t, err, "canceled context must abort warp parsing")
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, sess)
+		assert.Empty(t, msgs)
+	})
+
+	t.Run("zcode", func(t *testing.T) {
+		fixture := newZCodeTestFixture(t)
+		fixture.insertSession(
+			t, "session-ctx", "/workspace/app", "Canceled",
+			"2026-07-06T13:00:00Z", "2026-07-06T13:01:00Z", "", "",
+		)
+		fixture.insertMessage(t, "m1", "session-ctx", "2026-07-06T13:00:01Z", `{"role":"user"}`)
+		fixture.insertPart(t, "p1", "m1", "session-ctx",
+			`{"type":"text","text":"Please fix this"}`)
+
+		result, err := parseZCodeSession(ctx, fixture.DBPath, "session-ctx", "testmachine", false)
+		require.Error(t, err, "canceled context must abort zcode parsing")
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, result)
+	})
+
+	t.Run("goose", func(t *testing.T) {
+		fixture := newGooseTestFixture(t)
+		fixture.insertSession(t, "child", "Auth review", "main_session", "")
+		fixture.insertMessage(t, "child", "user", `[
+			{"type":"text","text":"Inspect the authentication flow.","annotations":[]}
+		]`, 1_700_000_000)
+
+		result, err := parseGooseSession(ctx, fixture.dbPath, "child", "testmachine", false)
+		require.Error(t, err, "canceled context must abort goose parsing")
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, result)
+	})
+}
+
+// The zcode mtime lookup is the deepest database work in the metadata and
+// parse paths, and it tolerates a missing model_usage table, so a swallowed
+// query error there would silently degrade FileMtime instead of aborting the
+// parse. This reaches the usage-mtime query itself: the session row is loaded
+// under a live context and only the mtime lookup observes the dead one.
+func TestZCodeMtimeQueryPropagatesCanceledContext(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t, "session-mtime-ctx", "/workspace/app", "Canceled",
+		"2026-07-06T13:00:00Z", "2026-07-06T13:01:00Z", "", "",
+	)
+	row, err := loadZCodeSessionRow(
+		context.Background(), fixture.database, "session-mtime-ctx",
+	)
+	require.NoError(t, err)
+
+	t.Run("canceled context aborts the usage-mtime query", func(t *testing.T) {
+		canceled, cancel := context.WithCancel(context.Background())
+		cancel()
+		mtime, err := zcodeSessionFileMtime(canceled, fixture.DBPath, fixture.database, row)
+		require.Error(t, err, "canceled context must abort the zcode usage-mtime query")
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Zero(t, mtime)
+	})
+
+	t.Run("missing usage table stays tolerated", func(t *testing.T) {
+		_, err := fixture.database.Exec(`DROP TABLE model_usage`)
+		require.NoError(t, err)
+		oldDBMtime := time.Date(2026, 7, 6, 13, 0, 0, 0, time.UTC)
+		require.NoError(t, os.Chtimes(fixture.DBPath, oldDBMtime, oldDBMtime))
+
+		mtime, err := zcodeSessionFileMtime(
+			context.Background(), fixture.DBPath, fixture.database, row,
+		)
+		require.NoError(t, err)
+		assert.Equal(
+			t, int64(1783342860000000000), mtime,
+			"a missing model_usage table must not turn into an error",
+		)
+	})
+}

--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -22,14 +22,14 @@ type dbBackedProviderSpec struct {
 	findDB       func(string) string
 	streamMeta   func(context.Context, string, func(dbBackedSessionMeta) error) error
 	metaForID    func(context.Context, string, string) (dbBackedSessionMeta, bool, error)
-	parse        func(string, string, string) ([]ParseResult, error)
+	parse        func(context.Context, string, string, string) ([]ParseResult, error)
 	normalizeRaw func(string) string
 	caps         Capabilities
 }
 
 type dbBackedProviderFactory struct {
 	def  AgentDef
-	spec dbBackedProviderSpec
+	spec func(bool) dbBackedProviderSpec
 }
 
 func (f dbBackedProviderFactory) Definition() AgentDef {
@@ -37,17 +37,18 @@ func (f dbBackedProviderFactory) Definition() AgentDef {
 }
 
 func (f dbBackedProviderFactory) Capabilities() Capabilities {
-	return withDBBackedRawCapture(f.spec.caps)
+	return withDBBackedRawCapture(f.spec(false).caps)
 }
 
 func (f dbBackedProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	cfg = cfg.Clone()
+	spec := f.spec(cfg.StableSourceSnapshots)
 	return &dbBackedProvider{
 		Def:     cloneAgentDef(f.def),
-		Caps:    withDBBackedRawCapture(f.spec.caps),
+		Caps:    withDBBackedRawCapture(spec.caps),
 		Config:  cfg,
-		spec:    f.spec,
-		sources: newDBBackedSourceSet(f.spec, cfg.Roots),
+		spec:    spec,
+		sources: newDBBackedSourceSet(spec, cfg.Roots),
 	}
 }
 
@@ -184,6 +185,39 @@ func (p *dbBackedProvider) newRawCaptureSource(root, dbPath string) SourceRef {
 	}
 }
 
+// RawSnapshotSessions enumerates every logical session inside one physical
+// database snapshot, preserving the session-scoped virtual sources the
+// provider's ordinary Fingerprint and Parse contract consumes.
+func (p *dbBackedProvider) RawSnapshotSessions(
+	ctx context.Context,
+	source SourceRef,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	raw, ok := source.Opaque.(dbBackedRawSource)
+	if !ok || raw.Root == "" || raw.DBPath == "" {
+		return nil, invalidRawCapturePlan("database source path unavailable")
+	}
+	if source.Provider != p.spec.agent || source.Key != p.spec.dbName ||
+		!samePath(raw.DBPath, filepath.Join(raw.Root, p.spec.dbName)) ||
+		!IsRegularFile(raw.DBPath) {
+		return nil, invalidRawCapturePlan("database source does not match provider root")
+	}
+	var sessions []SourceRef
+	seen := make(map[string]struct{})
+	err := p.spec.streamMeta(ctx, raw.DBPath, func(meta dbBackedSessionMeta) error {
+		ref := p.sources.newSourceRef(raw.Root, raw.DBPath, meta.SessionID, meta.VirtualPath)
+		ref.DiscoveryMTimeNS = meta.FileMtime
+		addJSONLSource(ref, &sessions, seen)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
 func (p *dbBackedProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
@@ -276,7 +310,16 @@ func (p *dbBackedProvider) Parse(
 		return ParseOutcome{}, fmt.Errorf("stat %s: %w", src.DBPath, err)
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
-	results, err := p.spec.parse(src.DBPath, src.SessionID, machine)
+	if p.Config.StableSourceSnapshots {
+		// A stable-snapshot config parses a materialized copy of another
+		// host's tree (hosted raw derivation or bounded capture), so working
+		// directories recorded inside the store are foreign metadata. Keep
+		// project attribution lexical so cwd helpers that never consult the
+		// context still cannot walk the local filesystem from an untrusted
+		// path.
+		ctx = WithoutFilesystemProjectDiscovery(ctx)
+	}
+	results, err := p.spec.parse(ctx, src.DBPath, src.SessionID, machine)
 	if errors.Is(err, sql.ErrNoRows) {
 		return ParseOutcome{
 			ResultSetComplete: true,
@@ -462,7 +505,7 @@ func (s dbBackedSourceSet) FindSource(
 					continue
 				}
 				if req.RequireFreshSource {
-					fresh, err := s.sourceExists(src)
+					fresh, err := s.sourceExists(ctx, src)
 					if err != nil {
 						return SourceRef{}, false, err
 					}
@@ -493,11 +536,11 @@ func (s dbBackedSourceSet) FindSource(
 	return SourceRef{}, false, nil
 }
 
-func (s dbBackedSourceSet) sourceExists(src dbBackedSource) (bool, error) {
+func (s dbBackedSourceSet) sourceExists(ctx context.Context, src dbBackedSource) (bool, error) {
 	if !IsRegularFile(src.DBPath) {
 		return false, nil
 	}
-	_, found, err := s.spec.metaForID(context.Background(), src.DBPath, src.SessionID)
+	_, found, err := s.spec.metaForID(ctx, src.DBPath, src.SessionID)
 	if err != nil {
 		return false, err
 	}
@@ -626,11 +669,11 @@ func parseDBBackedVirtualPath(path string) (string, string, bool) {
 func newForgeProviderFactory(def AgentDef) ProviderFactory {
 	return dbBackedProviderFactory{
 		def:  cloneAgentDef(def),
-		spec: forgeProviderSpec(),
+		spec: forgeProviderSpec,
 	}
 }
 
-func forgeProviderSpec() dbBackedProviderSpec {
+func forgeProviderSpec(stableSnapshot bool) dbBackedProviderSpec {
 	return dbBackedProviderSpec{
 		agent:  AgentForge,
 		dbName: ForgeDBFilename,
@@ -638,18 +681,20 @@ func forgeProviderSpec() dbBackedProviderSpec {
 		streamMeta: func(
 			ctx context.Context, dbPath string, yield func(dbBackedSessionMeta) error,
 		) error {
-			return ForEachForgeSessionMeta(ctx, dbPath, func(meta ForgeSessionMeta) error {
+			return ForEachForgeSessionMeta(ctx, dbPath, stableSnapshot, func(meta ForgeSessionMeta) error {
 				return yield(dbBackedSessionMeta(meta))
 			})
 		},
 		metaForID: func(
 			ctx context.Context, dbPath, id string,
 		) (dbBackedSessionMeta, bool, error) {
-			meta, found, err := forgeSessionMeta(ctx, dbPath, id)
+			meta, found, err := forgeSessionMeta(ctx, dbPath, id, stableSnapshot)
 			return dbBackedSessionMeta(meta), found, err
 		},
-		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
-			sess, msgs, err := parseForgeSession(dbPath, sessionID, machine)
+		parse: func(
+			ctx context.Context, dbPath, sessionID, machine string,
+		) ([]ParseResult, error) {
+			sess, msgs, err := parseForgeSession(ctx, dbPath, sessionID, machine, stableSnapshot)
 			if err != nil || sess == nil {
 				return nil, err
 			}
@@ -662,11 +707,11 @@ func forgeProviderSpec() dbBackedProviderSpec {
 func newPiebaldProviderFactory(def AgentDef) ProviderFactory {
 	return dbBackedProviderFactory{
 		def:  cloneAgentDef(def),
-		spec: piebaldProviderSpec(),
+		spec: piebaldProviderSpec,
 	}
 }
 
-func piebaldProviderSpec() dbBackedProviderSpec {
+func piebaldProviderSpec(stableSnapshot bool) dbBackedProviderSpec {
 	return dbBackedProviderSpec{
 		agent:  AgentPiebald,
 		dbName: PiebaldDBFilename,
@@ -674,18 +719,20 @@ func piebaldProviderSpec() dbBackedProviderSpec {
 		streamMeta: func(
 			ctx context.Context, dbPath string, yield func(dbBackedSessionMeta) error,
 		) error {
-			return ForEachPiebaldSessionMeta(ctx, dbPath, func(meta PiebaldSessionMeta) error {
+			return ForEachPiebaldSessionMeta(ctx, dbPath, stableSnapshot, func(meta PiebaldSessionMeta) error {
 				return yield(dbBackedSessionMeta(meta))
 			})
 		},
 		metaForID: func(
 			ctx context.Context, dbPath, id string,
 		) (dbBackedSessionMeta, bool, error) {
-			meta, found, err := piebaldSessionMeta(ctx, dbPath, id)
+			meta, found, err := piebaldSessionMeta(ctx, dbPath, id, stableSnapshot)
 			return dbBackedSessionMeta(meta), found, err
 		},
-		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
-			return parsePiebaldSessionResults(dbPath, sessionID, machine)
+		parse: func(
+			ctx context.Context, dbPath, sessionID, machine string,
+		) ([]ParseResult, error) {
+			return parsePiebaldSessionResults(ctx, dbPath, sessionID, machine, stableSnapshot)
 		},
 		normalizeRaw: func(raw string) string {
 			chatID, _, _ := strings.Cut(raw, "-")
@@ -698,11 +745,11 @@ func piebaldProviderSpec() dbBackedProviderSpec {
 func newWarpProviderFactory(def AgentDef) ProviderFactory {
 	return dbBackedProviderFactory{
 		def:  cloneAgentDef(def),
-		spec: warpProviderSpec(),
+		spec: warpProviderSpec,
 	}
 }
 
-func warpProviderSpec() dbBackedProviderSpec {
+func warpProviderSpec(stableSnapshot bool) dbBackedProviderSpec {
 	return dbBackedProviderSpec{
 		agent:  AgentWarp,
 		dbName: WarpDBFilename,
@@ -710,18 +757,20 @@ func warpProviderSpec() dbBackedProviderSpec {
 		streamMeta: func(
 			ctx context.Context, dbPath string, yield func(dbBackedSessionMeta) error,
 		) error {
-			return ForEachWarpSessionMeta(ctx, dbPath, func(meta WarpSessionMeta) error {
+			return ForEachWarpSessionMeta(ctx, dbPath, stableSnapshot, func(meta WarpSessionMeta) error {
 				return yield(dbBackedSessionMeta(meta))
 			})
 		},
 		metaForID: func(
 			ctx context.Context, dbPath, id string,
 		) (dbBackedSessionMeta, bool, error) {
-			meta, found, err := warpSessionMeta(ctx, dbPath, id)
+			meta, found, err := warpSessionMeta(ctx, dbPath, id, stableSnapshot)
 			return dbBackedSessionMeta(meta), found, err
 		},
-		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
-			sess, msgs, err := parseWarpSession(dbPath, sessionID, machine)
+		parse: func(
+			ctx context.Context, dbPath, sessionID, machine string,
+		) ([]ParseResult, error) {
+			sess, msgs, err := parseWarpSession(ctx, dbPath, sessionID, machine, stableSnapshot)
 			if err != nil || sess == nil {
 				return nil, err
 			}

--- a/internal/parser/db_backed_provider_test.go
+++ b/internal/parser/db_backed_provider_test.go
@@ -2,10 +2,12 @@ package parser
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -244,6 +246,76 @@ func TestDBBackedProviderRawCaptureReportsDiscoveryCompleteness(t *testing.T) {
 			assert.Equal(t, dbPath, streamed[0].DisplayPath)
 		})
 	}
+}
+
+func TestDBBackedProviderRawSnapshotSessionsFanOutLogicalSessions(t *testing.T) {
+	dbPath, seeder, db := newForgeTestDB(t)
+	defer db.Close()
+	seedForgeConversation(t, seeder)
+	seeder.AddConversation(
+		"conv-002", "Second", 123,
+		`{"conversation_id":"conv-002","messages":[]}`,
+		"2026-05-03 09:58:15.000000000",
+		"2026-05-03 10:00:16.000000000", "",
+	)
+	root := filepath.Dir(dbPath)
+	provider, ok := NewProvider(AgentForge, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discovery, err := DiscoverRawCaptureSources(t.Context(), provider)
+	require.NoError(t, err)
+	require.True(t, discovery.Complete)
+	require.Len(t, discovery.Sources, 1)
+
+	sessions, supported, err := ResolveRawSnapshotSessions(
+		t.Context(), provider, discovery.Sources[0],
+	)
+	require.NoError(t, err)
+	require.True(t, supported, "db-backed providers must fan raw snapshots out to sessions")
+	require.Len(t, sessions, 2)
+	assert.Equal(t, dbPath+"#conv-001", sessions[0].Key)
+	assert.Equal(t, dbPath+"#conv-001", sessions[0].DisplayPath)
+	assert.Equal(t, dbPath+"#conv-002", sessions[1].Key)
+	assert.Equal(t,
+		time.Date(2026, 5, 2, 10, 0, 16, 848497543, time.UTC).UnixNano(),
+		sessions[0].DiscoveryMTimeNS)
+
+	// The ordinary per-session contract must accept each enumerated session.
+	fingerprint, err := provider.Fingerprint(t.Context(), sessions[0])
+	require.NoError(t, err)
+	assert.Equal(t, dbPath+"#conv-001", fingerprint.Key)
+	outcome, err := provider.Parse(t.Context(), ParseRequest{
+		Source:      sessions[0],
+		Fingerprint: fingerprint,
+		Machine:     "hosted-worker",
+		ForceParse:  true,
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, dbPath+"#conv-001", outcome.Results[0].Result.Session.File.Path)
+	assert.Equal(t, "forge:conv-001", outcome.Results[0].Result.Session.ID)
+
+	_, _, err = ResolveRawSnapshotSessions(t.Context(), provider, SourceRef{
+		Provider: AgentForge, Key: ForgeDBFilename,
+	})
+	assert.ErrorIs(t, err, ErrInvalidRawCapturePlan,
+		"a source without provider-owned raw state must not fan out")
+}
+
+func TestResolveRawSnapshotSessionsLeavesFileShapedProvidersAlone(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "session.jsonl"), []byte("{}\n"), 0o600,
+	))
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{dir}})
+	require.True(t, ok)
+
+	sessions, supported, err := ResolveRawSnapshotSessions(t.Context(), provider, SourceRef{
+		Provider: AgentClaude, Key: "session.jsonl",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, supported)
+	assert.Empty(t, sessions)
 }
 
 func TestPiebaldProviderSourceMethodsAndParse(t *testing.T) {
@@ -655,4 +727,101 @@ func seedPiebaldProviderBasicChat(t *testing.T, dbPath string) {
 		 (id, parent_chat_id, role, model, created_at, updated_at, status, finish_reason)
 		 VALUES (101, 42, 'assistant', 'claude-test', '2026-05-01T10:00:02Z', '2026-05-01T10:00:03Z', 'completed', 'end_turn')`)
 	seedPiebaldTextPart(t, dbPath, 201, 101, 0, "I fixed it", false)
+}
+
+func TestDBBackedSQLiteReadModes(t *testing.T) {
+	for _, agent := range []AgentType{AgentGoose, AgentZCode, AgentForge, AgentPiebald, AgentWarp} {
+		for _, stableSnapshot := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stable=%t", agent, stableSnapshot), func(t *testing.T) {
+				var database *sql.DB
+				var dbPath string
+				var insert func()
+				sessionID := "wal-session"
+				switch agent {
+				case AgentGoose:
+					fixture := newGooseTestFixture(t)
+					database, dbPath = fixture.database, fixture.dbPath
+					insert = func() {
+						fixture.insertSession(t, "wal-session", "WAL session", "user", "")
+						fixture.insertMessage(t, "wal-session", "user", `[{"type":"text","text":"WAL session"}]`, 1700000000)
+					}
+				case AgentZCode:
+					fixture := newZCodeTestFixture(t)
+					database, dbPath = fixture.database, fixture.DBPath
+					insert = func() {
+						fixture.insertSession(t, "wal-session", "/work/app", "WAL session",
+							1700000000, 1700000001, "", "")
+						fixture.insertMessage(t, "m1", "wal-session", 1700000000, `{"role":"user"}`)
+						fixture.insertPart(t, "p1", "m1", "wal-session", `{"type":"text","text":"WAL session"}`)
+					}
+				case AgentForge:
+					var seeder *ForgeSeeder
+					dbPath, seeder, database = newForgeTestDB(t)
+					insert = func() {
+						seeder.AddConversation("wal-session", "WAL session", 1,
+							`{"messages":[{"message":{"text":{"role":"User","content":"WAL session"}}}]}`,
+							"2026-05-01T10:00:00Z", "2026-05-01T10:01:00Z", "")
+					}
+				case AgentWarp:
+					var seeder *WarpSeeder
+					dbPath, seeder, database = newWarpTestDB(t)
+					insert = func() {
+						seeder.AddConversation("wal-session", `{}`, "2026-05-01 10:01:00")
+						seeder.AddExchange("ex-1", "wal-session", "2026-05-01 10:00:00",
+							`[{"Query":{"text":"WAL session","context":[]}}]`, "/work/app", `"Completed"`, "")
+					}
+				case AgentPiebald:
+					dbPath = newPiebaldTestDB(t)
+					var err error
+					database, err = sql.Open("sqlite3", dbPath)
+					require.NoError(t, err)
+					sessionID = "42"
+					insert = func() {
+						execPiebaldTestSQL(t, dbPath, `INSERT INTO chats
+                            (id, title, created_at, updated_at, is_deleted, message_count, current_directory)
+                            VALUES (42, 'WAL session', '2026-05-01T10:00:00Z', '2026-05-01T10:01:00Z', 0, 1, '/work/app')`)
+						execPiebaldTestSQL(t, dbPath, `INSERT INTO messages
+                            (id, parent_chat_id, role, model, created_at, updated_at, status)
+                            VALUES (100, 42, 'user', '', '2026-05-01T10:00:00Z', '2026-05-01T10:01:00Z', 'completed')`)
+						seedPiebaldTextPart(t, dbPath, 200, 100, 0, "WAL session", false)
+					}
+				}
+				t.Cleanup(func() { require.NoError(t, database.Close()) })
+				_, err := database.Exec("PRAGMA journal_mode=WAL")
+				require.NoError(t, err)
+				insert()
+				root := filepath.Dir(dbPath)
+				if stableSnapshot {
+					// Closing checkpoints the WAL, leaving a self-contained database
+					// with the WAL header retained, as an online backup does.
+					require.NoError(t, database.Close())
+					require.NoError(t, os.Chmod(dbPath, 0o400))
+					require.NoError(t, os.Chmod(root, 0o500))
+					t.Cleanup(func() { require.NoError(t, os.Chmod(root, 0o700)) })
+				}
+				provider, ok := NewProvider(agent, ProviderConfig{
+					Roots: []string{root}, StableSourceSnapshots: stableSnapshot,
+				})
+				require.True(t, ok)
+				discovery, err := DiscoverRawCaptureSources(t.Context(), provider)
+				require.NoError(t, err)
+				require.Len(t, discovery.Sources, 1)
+				sources, supported, err := ResolveRawSnapshotSessions(t.Context(), provider, discovery.Sources[0])
+				require.NoError(t, err)
+				require.True(t, supported)
+				require.Len(t, sources, 1)
+				fingerprint, err := provider.Fingerprint(t.Context(), sources[0])
+				require.NoError(t, err)
+				outcome, err := provider.Parse(t.Context(), ParseRequest{Source: sources[0], Fingerprint: fingerprint})
+				require.NoError(t, err)
+				require.Len(t, outcome.Results, 1)
+				assert.Equal(t, string(agent)+":"+sessionID, outcome.Results[0].Result.Session.ID)
+				assert.Equal(t, "WAL session", outcome.Results[0].Result.Session.FirstMessage)
+				// Goose's ordinary discovery also reads watcher watermarks.
+				sources, err = provider.Discover(t.Context())
+				require.NoError(t, err)
+				assert.Len(t, sources, 1)
+			})
+		}
+	}
 }

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -579,7 +579,7 @@ func parseDevinDBMessageNode(
 		return ParsedMessage{}, false, nil
 	}
 
-	content, thinking, hasThinking, hasToolUse, toolCalls, toolResults := ExtractTextContent(root.Get("content"))
+	content, thinking, hasThinking, hasToolUse, toolCalls, toolResults := ExtractTextContent(context.Background(), root.Get("content"))
 	topThinking := strings.TrimSpace(root.Get("thinking").Str)
 	if topThinking != "" && topThinking != thinking {
 		thinking = joinNonEmpty(thinking, topThinking)
@@ -733,7 +733,7 @@ func parseDevinDBToolCalls(toolCalls gjson.Result) ([]ParsedToolCall, string) {
 }
 
 func parseDevinDBToolCall(tc gjson.Result) (ParsedToolCall, bool) {
-	if parsed, ok := parseToolCall(tc); ok {
+	if parsed, ok := parseToolCall(context.Background(), tc); ok {
 		return parsed, true
 	}
 	name := firstNonEmpty(tc.Get("function.name").Str, tc.Get("name").Str)
@@ -965,7 +965,7 @@ func parseDevinStep(step gjson.Result, ordinal int, model string) (ParsedMessage
 	}
 
 	content, thinking, hasThinking, hasToolUse, toolCalls, toolResults :=
-		ExtractTextContent(step.Get("message"))
+		ExtractTextContent(context.Background(), step.Get("message"))
 	topLevelToolText, topLevelToolCalls := formatTopLevelToolUses(step.Get("tool_use"))
 	if topLevelToolText != "" {
 		content = joinNonEmpty(content, topLevelToolText)
@@ -1087,7 +1087,7 @@ func formatTopLevelToolUses(toolUses gjson.Result) (string, []ParsedToolCall) {
 		if text != "" {
 			parts = append(parts, text)
 		}
-		if tc, ok := parseToolCall(toolUse); ok {
+		if tc, ok := parseToolCall(context.Background(), toolUse); ok {
 			tc.Rendering = text
 			calls = append(calls, tc)
 		}

--- a/internal/parser/evener_provider.go
+++ b/internal/parser/evener_provider.go
@@ -351,7 +351,7 @@ func evenerProviderCapabilities() Capabilities {
 		RawCapture: RawCaptureCapabilities{
 			Support: CapabilitySupported,
 			Shape:   RawCaptureShapeFiles,
-			Append:  RawCaptureAppendReplaceOnly,
+			Append:  RawCaptureAppendMany,
 		},
 		Source: caps,
 		Content: ContentCapabilities{
@@ -397,8 +397,25 @@ func (p *evenerProvider) PlanRawCapture(ctx context.Context, source SourceRef) (
 	if _, ok := evenerClassifyPath(src.Root, src.Path, false); !ok {
 		return RawCapturePlan{}, invalidRawCapturePlan("evener source is outside its configured layout")
 	}
-	plan := RawCapturePlan{ConfiguredRoot: src.Root, CaptureRoot: src.Root, SourceKey: source.Key}
-	for _, path := range []string{src.Path, evenerMetadataPath(src.Path)} {
+	captureRoot := src.Root
+	if filepath.Base(captureRoot) == "sessions" {
+		// Retain the sessions directory in custody so discovery recognizes
+		// the layout after materialization under an arbitrary worker root.
+		captureRoot = filepath.Dir(captureRoot)
+	}
+	plan := RawCapturePlan{ConfiguredRoot: src.Root, CaptureRoot: captureRoot, SourceKey: source.Key}
+	paths := []string{src.Path, evenerMetadataPath(src.Path)}
+	// Parsing verifies copied fork history against one immediate parent and
+	// its metadata. Preserve those inputs without following the parent's forks.
+	// Invalid child metadata is still captured; parsing reports its error.
+	if parent, err := evenerParentTranscriptPath(src.Path); err == nil && evenerParentFileInfo(parent) != nil {
+		parentMeta := evenerMetadataPath(parent)
+		info, err := os.Lstat(parentMeta)
+		if os.IsNotExist(err) || err == nil && info.Mode().IsRegular() {
+			paths = append(paths, parent, parentMeta)
+		}
+	}
+	for _, path := range paths {
 		info, err := os.Lstat(path)
 		if os.IsNotExist(err) && path != src.Path {
 			continue
@@ -409,11 +426,14 @@ func (p *evenerProvider) PlanRawCapture(ctx context.Context, source SourceRef) (
 		if !info.Mode().IsRegular() {
 			return RawCapturePlan{}, invalidRawCapturePlan("evener capture source is not a regular file")
 		}
-		rel, err := filepath.Rel(src.Root, path)
+		rel, err := filepath.Rel(captureRoot, path)
 		if err != nil {
 			return RawCapturePlan{}, err
 		}
-		plan.Entries = append(plan.Entries, RawCaptureEntry{Path: filepath.ToSlash(rel), LocalPath: path})
+		plan.Entries = append(plan.Entries, RawCaptureEntry{
+			Path: filepath.ToSlash(rel), LocalPath: path,
+			Appendable: strings.HasSuffix(path, evenerTranscriptSuffix),
+		})
 	}
 	return plan, nil
 }

--- a/internal/parser/evener_provider_test.go
+++ b/internal/parser/evener_provider_test.go
@@ -182,9 +182,8 @@ func TestEvenerProviderRawCaptureNamesOnlyTranscriptAndMetadata(t *testing.T) {
 	assert.Equal(t, root, plan.CaptureRoot)
 	assert.Equal(t, "projects/demo/sessions/good.transcript.jsonl", plan.Entries[0].Path)
 	assert.Equal(t, "projects/demo/sessions/good.meta.json", plan.Entries[1].Path)
-	for _, entry := range plan.Entries {
-		assert.False(t, entry.Appendable)
-	}
+	assert.True(t, plan.Entries[0].Appendable)
+	assert.False(t, plan.Entries[1].Appendable)
 	require.NoError(t, os.Remove(meta))
 	plan, err = planner.PlanRawCapture(context.Background(), sources[0])
 	require.NoError(t, err)

--- a/internal/parser/forge.go
+++ b/internal/parser/forge.go
@@ -44,7 +44,7 @@ func forgeDBPath(dir string) string {
 func ListForgeSessionMeta(dbPath string) ([]ForgeSessionMeta, error) {
 	var metas []ForgeSessionMeta
 	err := ForEachForgeSessionMeta(
-		context.Background(), dbPath,
+		context.Background(), dbPath, false,
 		func(meta ForgeSessionMeta) error {
 			metas = append(metas, meta)
 			return nil
@@ -54,13 +54,13 @@ func ListForgeSessionMeta(dbPath string) ([]ForgeSessionMeta, error) {
 }
 
 func ForEachForgeSessionMeta(
-	ctx context.Context, dbPath string, yield func(ForgeSessionMeta) error,
+	ctx context.Context, dbPath string, stableSnapshot bool, yield func(ForgeSessionMeta) error,
 ) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil
 	}
 
-	db, err := openForgeDB(dbPath)
+	db, err := openForgeDB(dbPath, stableSnapshot)
 	if err != nil {
 		return err
 	}
@@ -96,9 +96,9 @@ func ForEachForgeSessionMeta(
 }
 
 func forgeSessionMeta(
-	ctx context.Context, dbPath, sessionID string,
+	ctx context.Context, dbPath, sessionID string, stableSnapshot bool,
 ) (ForgeSessionMeta, bool, error) {
-	db, err := openForgeDB(dbPath)
+	db, err := openForgeDB(dbPath, stableSnapshot)
 	if err != nil {
 		return ForgeSessionMeta{}, false, err
 	}
@@ -122,27 +122,32 @@ func forgeSessionMeta(
 }
 
 // parseForgeSession parses a single conversation by ID from the Forge database.
-func parseForgeSession(dbPath, conversationID, machine string) (*ParsedSession, []ParsedMessage, error) {
+func parseForgeSession(
+	ctx context.Context, dbPath, conversationID, machine string, stableSnapshot bool,
+) (*ParsedSession, []ParsedMessage, error) {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil, nil, fmt.Errorf("forge db not found: %s", dbPath)
 	}
 
-	db, err := openForgeDB(dbPath)
+	db, err := openForgeDB(dbPath, stableSnapshot)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer db.Close()
 
-	c, err := loadOneForgeConversation(db, conversationID)
+	c, err := loadOneForgeConversation(ctx, db, conversationID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading forge conversation %s: %w", conversationID, err)
 	}
-	return buildForgeSession(c, dbPath, machine)
+	return buildForgeSession(ctx, c, dbPath, machine)
 }
 
-func openForgeDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) +
-		"?mode=ro&_busy_timeout=3000"
+func openForgeDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
+	immutable := "0"
+	if stableSnapshot {
+		immutable = "1"
+	}
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening forge db %s: %w", dbPath, err)
@@ -159,8 +164,10 @@ type forgeConversationRow struct {
 	metrics   string
 }
 
-func loadOneForgeConversation(db *sql.DB, conversationID string) (forgeConversationRow, error) {
-	row := db.QueryRow(`
+func loadOneForgeConversation(
+	ctx context.Context, db *sql.DB, conversationID string,
+) (forgeConversationRow, error) {
+	row := db.QueryRowContext(ctx, `
 		SELECT conversation_id,
 		       COALESCE(title, ''),
 		       COALESCE(context, ''),
@@ -176,7 +183,9 @@ func loadOneForgeConversation(db *sql.DB, conversationID string) (forgeConversat
 	return c, err
 }
 
-func buildForgeSession(c forgeConversationRow, dbPath, machine string) (*ParsedSession, []ParsedMessage, error) {
+func buildForgeSession(
+	ctx context.Context, c forgeConversationRow, dbPath, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
 	root := gjson.Parse(c.context)
 	messagesRoot := root.Get("messages")
 	if !messagesRoot.IsArray() {
@@ -302,7 +311,7 @@ func buildForgeSession(c forgeConversationRow, dbPath, machine string) (*ParsedS
 		return nil, nil, nil
 	}
 
-	project := ExtractProjectFromCwd(cwd)
+	project := ExtractProjectFromCwdWithBranchContext(ctx, cwd, "")
 	startedAt := parseForgeTimestamp(c.createdAt)
 	endedAt := parseForgeTimestamp(c.updatedAt)
 	if endedAt.IsZero() {

--- a/internal/parser/forge_test.go
+++ b/internal/parser/forge_test.go
@@ -200,7 +200,7 @@ func TestParseForgeSession_SingleConversation(t *testing.T) {
 	defer db.Close()
 	seedForgeConversation(t, seeder)
 
-	sess, msgs, err := parseForgeSession(dbPath, "conv-001", "testmachine")
+	sess, msgs, err := parseForgeSession(t.Context(), dbPath, "conv-001", "testmachine", false)
 	require.NoError(t, err, "parseForgeSession")
 	require.NotNil(t, sess, "expected non-nil session")
 
@@ -266,7 +266,7 @@ func TestCollectForgeToolCalls_TaskSubagentIDPrefixed(t *testing.T) {
 		"2026-05-02 10:00:00", "2026-05-02 10:00:01", "",
 	)
 
-	sess, msgs, err := parseForgeSession(dbPath, "parent-conv", "m")
+	sess, msgs, err := parseForgeSession(t.Context(), dbPath, "parent-conv", "m", false)
 	require.NoError(t, err, "parseForgeSession")
 	require.NotNil(t, sess, "expected non-nil session")
 	require.NotEmpty(t, msgs, "expected messages")

--- a/internal/parser/goose.go
+++ b/internal/parser/goose.go
@@ -65,12 +65,13 @@ type gooseUsageRow struct {
 func forEachGooseSessionMeta(
 	ctx context.Context,
 	dbPath string,
+	stableSnapshot bool,
 	yield func(dbBackedSessionMeta) error,
 ) error {
 	if !IsRegularFile(dbPath) {
 		return nil
 	}
-	db, err := openGooseDB(dbPath)
+	db, err := openGooseDB(dbPath, stableSnapshot)
 	if err != nil {
 		return err
 	}
@@ -94,7 +95,7 @@ func forEachGooseSessionMeta(
 		if err != nil {
 			return err
 		}
-		mtime, err := gooseSessionFileMtime(dbPath, db, hasUsage, row)
+		mtime, err := gooseSessionFileMtime(ctx, dbPath, db, hasUsage, row)
 		if err != nil {
 			return err
 		}
@@ -111,12 +112,12 @@ func forEachGooseSessionMeta(
 }
 
 func gooseSessionMeta(
-	ctx context.Context, dbPath, sessionID string,
+	ctx context.Context, dbPath, sessionID string, stableSnapshot bool,
 ) (dbBackedSessionMeta, bool, error) {
 	if !IsRegularFile(dbPath) {
 		return dbBackedSessionMeta{}, false, nil
 	}
-	db, err := openGooseDB(dbPath)
+	db, err := openGooseDB(dbPath, stableSnapshot)
 	if err != nil {
 		return dbBackedSessionMeta{}, false, err
 	}
@@ -129,7 +130,7 @@ func gooseSessionMeta(
 	if err != nil {
 		return dbBackedSessionMeta{}, false, err
 	}
-	mtime, err := gooseSessionFileMtime(dbPath, db, hasUsage, row)
+	mtime, err := gooseSessionFileMtime(ctx, dbPath, db, hasUsage, row)
 	if err != nil {
 		return dbBackedSessionMeta{}, false, err
 	}
@@ -141,21 +142,21 @@ func gooseSessionMeta(
 }
 
 func parseGooseSession(
-	dbPath, sessionID, machine string,
+	ctx context.Context, dbPath, sessionID, machine string, stableSnapshot bool,
 ) (*ParseResult, error) {
-	db, err := openGooseDB(dbPath)
+	db, err := openGooseDB(dbPath, stableSnapshot)
 	if err != nil {
 		return nil, err
 	}
 	defer db.Close()
-	row, found, err := loadGooseSessionRow(context.Background(), db, sessionID)
+	row, found, err := loadGooseSessionRow(ctx, db, sessionID)
 	if err != nil {
 		return nil, err
 	}
 	if !found {
 		return nil, sql.ErrNoRows
 	}
-	result, err := buildGooseParseResult(dbPath, machine, row, db)
+	result, err := buildGooseParseResult(ctx, dbPath, machine, row, db)
 	if err != nil {
 		return nil, err
 	}
@@ -308,9 +309,9 @@ func gooseNullableColumn(columns map[string]bool, name string) string {
 }
 
 func buildGooseParseResult(
-	dbPath, machine string, row gooseSessionRow, db *sql.DB,
+	ctx context.Context, dbPath, machine string, row gooseSessionRow, db *sql.DB,
 ) (ParseResult, error) {
-	messages, err := loadGooseMessages(db, row.id, gooseSessionModel(row))
+	messages, err := loadGooseMessages(ctx, db, row.id, gooseSessionModel(row))
 	if err != nil {
 		return ParseResult{}, err
 	}
@@ -339,7 +340,7 @@ func buildGooseParseResult(
 	if firstMessage == "" {
 		firstMessage = truncate(strings.ReplaceAll(sessionName, "\n", " "), 300)
 	}
-	project := ExtractProjectFromCwd(row.workingDir)
+	project := ExtractProjectFromCwdWithBranchContext(ctx, row.workingDir, "")
 	if project == "" {
 		if projectID := strings.TrimSpace(row.projectID); projectID != "" {
 			project = "project-" + projectID
@@ -354,15 +355,15 @@ func buildGooseParseResult(
 			userMessages++
 		}
 	}
-	schemaVersion, err := gooseSchemaVersion(context.Background(), db)
+	schemaVersion, err := gooseSchemaVersion(ctx, db)
 	if err != nil {
 		return ParseResult{}, err
 	}
-	hasUsage, err := gooseTableExists(context.Background(), db, "usage_ledger")
+	hasUsage, err := gooseTableExists(ctx, db, "usage_ledger")
 	if err != nil {
 		return ParseResult{}, err
 	}
-	mtime, err := gooseSessionFileMtime(dbPath, db, hasUsage, row)
+	mtime, err := gooseSessionFileMtime(ctx, dbPath, db, hasUsage, row)
 	if err != nil {
 		return ParseResult{}, err
 	}
@@ -390,7 +391,7 @@ func buildGooseParseResult(
 		session.ParentSessionID = "goose:" + parentID
 		session.RelationshipType = RelSubagent
 	}
-	usageEvents, err := listGooseUsageEvents(db, row, hasUsage, startedAt, endedAt)
+	usageEvents, err := listGooseUsageEvents(ctx, db, row, hasUsage, startedAt, endedAt)
 	if err != nil {
 		return ParseResult{}, err
 	}
@@ -408,9 +409,9 @@ func buildGooseParseResult(
 }
 
 func loadGooseMessages(
-	db *sql.DB, sessionID, sessionModel string,
+	ctx context.Context, db *sql.DB, sessionID, sessionModel string,
 ) ([]ParsedMessage, error) {
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT id,
 		       COALESCE(role, ''),
 		       COALESCE(content_json, '[]'),
@@ -434,7 +435,7 @@ func loadGooseMessages(
 		); err != nil {
 			return nil, fmt.Errorf("scanning goose message row: %w", err)
 		}
-		message, ok, err := buildGooseMessage(len(parsed), row, sessionModel)
+		message, ok, err := buildGooseMessage(ctx, len(parsed), row, sessionModel)
 		if err != nil {
 			return nil, err
 		}
@@ -449,7 +450,7 @@ func loadGooseMessages(
 }
 
 func buildGooseMessage(
-	ordinal int, row gooseMessageRow, sessionModel string,
+	ctx context.Context, ordinal int, row gooseMessageRow, sessionModel string,
 ) (ParsedMessage, bool, error) {
 	if visible := gjson.Get(row.metadataJSON, "userVisible"); visible.Exists() && !visible.Bool() {
 		return ParsedMessage{}, false, nil
@@ -490,7 +491,7 @@ func buildGooseMessage(
 			message.HasThinking = true
 		case "toolRequest", "frontendToolRequest":
 			message.HasToolUse = true
-			if call, ok := gooseParseToolCall(block); ok {
+			if call, ok := gooseParseToolCall(ctx, block); ok {
 				message.ToolCalls = append(message.ToolCalls, call)
 			}
 		case "toolResponse":
@@ -523,7 +524,7 @@ func normalizeGooseRole(role string) (RoleType, bool) {
 	}
 }
 
-func gooseParseToolCall(block gjson.Result) (ParsedToolCall, bool) {
+func gooseParseToolCall(ctx context.Context, block gjson.Result) (ParsedToolCall, bool) {
 	toolUseID := strings.TrimSpace(block.Get("id").Str)
 	envelope := block.Get("toolCall")
 	if toolUseID == "" || envelope.Get("status").Str != "success" {
@@ -551,7 +552,7 @@ func gooseParseToolCall(block gjson.Result) (ParsedToolCall, bool) {
 			call.SkillName = arguments.Get("name").Str
 		}
 	} else {
-		call.SkillName = inferToolSkillName(name, inputJSON)
+		call.SkillName = inferToolSkillName(ctx, name, inputJSON)
 	}
 	return call, true
 }
@@ -632,6 +633,7 @@ func gooseSessionModel(row gooseSessionRow) string {
 }
 
 func listGooseUsageEvents(
+	ctx context.Context,
 	db *sql.DB,
 	row gooseSessionRow,
 	hasLedger bool,
@@ -640,7 +642,7 @@ func listGooseUsageEvents(
 	if !hasLedger {
 		return gooseAggregateUsageFallback(row, startedAt, endedAt), nil
 	}
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT id,
 		       session_id,
 		       COALESCE(created_timestamp, 0),
@@ -826,12 +828,13 @@ func gooseMessageTime(createdTimestamp int64, fallback string) time.Time {
 }
 
 func gooseSessionFileMtime(
+	ctx context.Context,
 	dbPath string, db *sql.DB, hasUsage bool, row gooseSessionRow,
 ) (int64, error) {
 	maxTime := maxGooseTime(gooseParseTime(row.updatedAt), gooseParseTime(row.createdAt))
 	var messageTimestamp sql.NullInt64
-	if err := db.QueryRow(
-		"SELECT MAX(created_timestamp) FROM messages WHERE session_id = ?", row.id,
+	if err := db.QueryRowContext(
+		ctx, "SELECT MAX(created_timestamp) FROM messages WHERE session_id = ?", row.id,
 	).Scan(&messageTimestamp); err != nil {
 		return 0, fmt.Errorf("reading goose session %s message mtime: %w", row.id, err)
 	}
@@ -840,8 +843,8 @@ func gooseSessionFileMtime(
 	}
 	if hasUsage {
 		var usageTimestamp sql.NullInt64
-		if err := db.QueryRow(
-			"SELECT MAX(created_timestamp) FROM usage_ledger WHERE session_id = ?", row.id,
+		if err := db.QueryRowContext(
+			ctx, "SELECT MAX(created_timestamp) FROM usage_ledger WHERE session_id = ?", row.id,
 		).Scan(&usageTimestamp); err != nil {
 			return 0, fmt.Errorf("reading goose session %s usage mtime: %w", row.id, err)
 		}
@@ -867,9 +870,9 @@ func maxGooseTime(values ...time.Time) time.Time {
 }
 
 func gooseSessionFingerprint(
-	ctx context.Context, dbPath, sessionID string,
+	ctx context.Context, dbPath, sessionID string, stableSnapshot bool,
 ) (string, bool, error) {
-	db, err := openGooseDB(dbPath)
+	db, err := openGooseDB(dbPath, stableSnapshot)
 	if err != nil {
 		return "", false, err
 	}

--- a/internal/parser/goose_provider.go
+++ b/internal/parser/goose_provider.go
@@ -38,7 +38,7 @@ func (f *gooseProviderFactory) Capabilities() Capabilities {
 func (f *gooseProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	cfg = cfg.Clone()
 	cfg.Roots = normalizeGooseRoots(cfg.Roots)
-	spec := gooseProviderSpec()
+	spec := gooseProviderSpec(cfg.StableSourceSnapshots)
 	base := &dbBackedProvider{
 		Def:     cloneAgentDef(f.def),
 		Caps:    withDBBackedRawCapture(spec.caps),
@@ -93,7 +93,7 @@ func (p *gooseProvider) captureDiscoveryWatermarks(
 		if dbPath == "" {
 			continue
 		}
-		state, err := readGooseTrackedDatabase(ctx, dbPath)
+		state, err := readGooseTrackedDatabase(ctx, dbPath, p.Config.StableSourceSnapshots)
 		if err != nil {
 			return nil, err
 		}
@@ -130,7 +130,7 @@ func (p *gooseProvider) SourcesForChangedPath(
 			// cannot prove that any archived Goose member was deleted.
 			return nil, nil
 		}
-		ids, cold, snapshot, err := p.tracker.changedSessionIDs(ctx, dbPath)
+		ids, cold, snapshot, err := p.tracker.changedSessionIDs(ctx, dbPath, p.Config.StableSourceSnapshots)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +149,7 @@ func (p *gooseProvider) SourcesForChangedPath(
 
 		sources := make([]SourceRef, 0, len(ids))
 		for _, id := range ids {
-			meta, found, err := gooseSessionMeta(ctx, dbPath, id)
+			meta, found, err := gooseSessionMeta(ctx, dbPath, id, p.Config.StableSourceSnapshots)
 			if err != nil {
 				return nil, err
 			}
@@ -179,7 +179,7 @@ func (p *gooseProvider) Fingerprint(
 	if !ok || !IsRegularFile(src.DBPath) {
 		return fingerprint, nil
 	}
-	hash, found, err := gooseSessionFingerprint(ctx, src.DBPath, src.SessionID)
+	hash, found, err := gooseSessionFingerprint(ctx, src.DBPath, src.SessionID, p.Config.StableSourceSnapshots)
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
@@ -214,7 +214,7 @@ func gooseProviderCapabilities() Capabilities {
 	}
 }
 
-func gooseProviderSpec() dbBackedProviderSpec {
+func gooseProviderSpec(stableSnapshot bool) dbBackedProviderSpec {
 	return dbBackedProviderSpec{
 		agent:  AgentGoose,
 		dbName: GooseDBName,
@@ -224,15 +224,17 @@ func gooseProviderSpec() dbBackedProviderSpec {
 			dbPath string,
 			yield func(dbBackedSessionMeta) error,
 		) error {
-			return forEachGooseSessionMeta(ctx, dbPath, yield)
+			return forEachGooseSessionMeta(ctx, dbPath, stableSnapshot, yield)
 		},
 		metaForID: func(
 			ctx context.Context, dbPath, sessionID string,
 		) (dbBackedSessionMeta, bool, error) {
-			return gooseSessionMeta(ctx, dbPath, sessionID)
+			return gooseSessionMeta(ctx, dbPath, sessionID, stableSnapshot)
 		},
-		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
-			result, err := parseGooseSession(dbPath, sessionID, machine)
+		parse: func(
+			ctx context.Context, dbPath, sessionID, machine string,
+		) ([]ParseResult, error) {
+			result, err := parseGooseSession(ctx, dbPath, sessionID, machine, stableSnapshot)
 			if err != nil || result == nil {
 				return nil, err
 			}
@@ -317,8 +319,12 @@ func GooseSQLiteVirtualPath(dbPath, sessionID string) string {
 	return VirtualSourcePath(dbPath, sessionID)
 }
 
-func openGooseDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=0&_busy_timeout=3000"
+func openGooseDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
+	immutable := "0"
+	if stableSnapshot {
+		immutable = "1"
+	}
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening goose sessions database %s: %w", dbPath, err)
@@ -428,7 +434,7 @@ func furthestGooseRowCursor(a, b gooseRowCursor) gooseRowCursor {
 // skipped — deletions are reconciliation's job — while inserts from the
 // tables whose cursors are intact are still listed.
 func (t *gooseChangeTracker) changedSessionIDs(
-	ctx context.Context, dbPath string,
+	ctx context.Context, dbPath string, stableSnapshot bool,
 ) (ids []string, cold bool, snapshot gooseTrackedDatabase, err error) {
 	entry := t.entry(dbPath)
 	entry.mu.Lock()
@@ -439,7 +445,7 @@ func (t *gooseChangeTracker) changedSessionIDs(
 		return nil, false, gooseTrackedDatabase{},
 			fmt.Errorf("stat goose sessions database: %w", err)
 	}
-	db, err := openGooseDB(dbPath)
+	db, err := openGooseDB(dbPath, stableSnapshot)
 	if err != nil {
 		return nil, false, gooseTrackedDatabase{}, err
 	}
@@ -487,13 +493,13 @@ func gooseTrackedDatabaseReplaced(
 }
 
 func readGooseTrackedDatabase(
-	ctx context.Context, dbPath string,
+	ctx context.Context, dbPath string, stableSnapshot bool,
 ) (gooseTrackedDatabase, error) {
 	info, err := os.Stat(dbPath)
 	if err != nil {
 		return gooseTrackedDatabase{}, fmt.Errorf("stat goose sessions database: %w", err)
 	}
-	db, err := openGooseDB(dbPath)
+	db, err := openGooseDB(dbPath, stableSnapshot)
 	if err != nil {
 		return gooseTrackedDatabase{}, err
 	}

--- a/internal/parser/goose_test.go
+++ b/internal/parser/goose_test.go
@@ -309,7 +309,7 @@ func TestGooseUsesAccumulatedUsageWhenLedgerIsUnavailable(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
-	result, err := parseGooseSession(fixture.dbPath, "legacy", "devbox")
+	result, err := parseGooseSession(t.Context(), fixture.dbPath, "legacy", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.UsageEvents, 1)
@@ -615,7 +615,7 @@ func TestGooseParsesSessionsSchemaWithoutOptionalColumns(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, fingerprint.Hash, 64)
 
-	result, err := parseGooseSession(dbPath, "bare", "devbox")
+	result, err := parseGooseSession(t.Context(), dbPath, "bare", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, "goose:bare", result.Session.ID)
@@ -635,7 +635,7 @@ func TestGooseUnknownToolResponseStatusIsNotAHumanMessage(t *testing.T) {
 		{"type":"toolResponse","id":"call-1","toolResult":{"status":"pending"}}
 	]`, 1_700_000_001)
 
-	result, err := parseGooseSession(fixture.dbPath, "session", "devbox")
+	result, err := parseGooseSession(t.Context(), fixture.dbPath, "session", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, 1, result.Session.UserMessageCount,
@@ -659,7 +659,7 @@ func TestGooseLedgerModelFallsBackToSessionModel(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
-	result, err := parseGooseSession(fixture.dbPath, "session", "devbox")
+	result, err := parseGooseSession(t.Context(), fixture.dbPath, "session", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.UsageEvents, 1)

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"encoding/json/v2"
 	"errors"
 	"fmt"
@@ -1037,7 +1038,7 @@ func grokToolCalls(arr gjson.Result) []ParsedToolCall {
 			ToolName:  name,
 			Category:  NormalizeToolCategory(name),
 			InputJSON: inputJSON,
-			SkillName: inferToolSkillName(name, inputJSON),
+			SkillName: inferToolSkillName(context.Background(), name, inputJSON),
 		})
 		return true
 	})

--- a/internal/parser/iflow.go
+++ b/internal/parser/iflow.go
@@ -3,6 +3,7 @@
 package parser
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -362,7 +363,7 @@ func extractMessagesIflow(entries []dagEntryIflow) (
 
 		content := gjson.Get(e.line, "message.content")
 		text, _, hasThinking, hasToolUse, tcs, trs :=
-			ExtractTextContent(content)
+			ExtractTextContent(context.Background(), content)
 
 		// Convert command/skill invocation XML into readable
 		// text (e.g. "/roborev-fix 450"). If the content

--- a/internal/parser/kilo_legacy.go
+++ b/internal/parser/kilo_legacy.go
@@ -20,6 +20,7 @@
 package parser
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
@@ -1701,7 +1702,7 @@ func parseKiloLegacyToolCall(text string, ordinal int) *ParsedToolCall {
 			tc.SkillName, _ = toolData["name"].(string)
 		}
 	} else {
-		tc.SkillName = inferToolSkillName(toolName, tc.InputJSON)
+		tc.SkillName = inferToolSkillName(context.Background(), toolName, tc.InputJSON)
 	}
 	// FilePath is exposed from the payload when present so the
 	// frontend can route Edits / Writes to the right file even
@@ -1737,7 +1738,7 @@ func parseKiloLegacyMCPToolCall(
 		Category:  "MCP",
 		InputJSON: inputJSON,
 	}
-	tc.SkillName = inferToolSkillName(qualified, inputJSON)
+	tc.SkillName = inferToolSkillName(context.Background(), qualified, inputJSON)
 	return tc
 }
 

--- a/internal/parser/kimi.go
+++ b/internal/parser/kimi.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
@@ -389,7 +390,7 @@ func parseKimiSessionWithFallbackModel(
 						ToolName:  fnName,
 						Category:  NormalizeToolCategory(fnName),
 						InputJSON: fnArgs,
-						SkillName: inferToolSkillName(
+						SkillName: inferToolSkillName(context.Background(),
 							fnName, fnArgs,
 						),
 					}
@@ -607,7 +608,7 @@ func parseKimiSessionWithFallbackModel(
 				ToolName:  fnName,
 				Category:  NormalizeToolCategory(fnName),
 				InputJSON: fnArgs,
-				SkillName: inferToolSkillName(
+				SkillName: inferToolSkillName(context.Background(),
 					fnName, fnArgs,
 				),
 			}

--- a/internal/parser/openclaude.go
+++ b/internal/parser/openclaude.go
@@ -481,7 +481,7 @@ func parseOpenClaudeSession(
 		}
 
 		if isOpenClaudeCompactBoundary(line) {
-			content, _, _, _, _, _ := ExtractTextContent(
+			content, _, _, _, _, _ := ExtractTextContent(context.Background(),
 				gjson.Get(line, "message.content"),
 			)
 			messages = append(messages, ParsedMessage{
@@ -517,7 +517,7 @@ func parseOpenClaudeSession(
 
 		content := gjson.Get(line, "message.content")
 		text, thinkingText, hasThinking, hasToolUse, toolCalls, toolResults :=
-			ExtractTextContent(content)
+			ExtractTextContent(context.Background(), content)
 		if strings.TrimSpace(text) == "" && len(toolResults) == 0 &&
 			len(toolCalls) == 0 && role != "system" {
 			continue
@@ -688,7 +688,7 @@ func extractOpenClaudeQueuedCommand(line string) (claudeQueuedCommand, bool) {
 		return claudeQueuedCommand{}, false
 	}
 
-	prompt, _, _, _, _, _ := ExtractTextContent(attachment.Get("prompt"))
+	prompt, _, _, _, _, _ := ExtractTextContent(context.Background(), attachment.Get("prompt"))
 	if strings.TrimSpace(prompt) == "" {
 		return claudeQueuedCommand{}, false
 	}

--- a/internal/parser/openclaw.go
+++ b/internal/parser/openclaw.go
@@ -3,6 +3,7 @@
 package parser
 
 import (
+	"context"
 	"encoding/json/v2"
 	"fmt"
 	"os"
@@ -101,7 +102,7 @@ func (p *openClawProvider) parseSession(
 		case "user":
 			content := msg.Get("content")
 			text, thinkingText, hasThinking, hasToolUse, tcs, trs :=
-				ExtractTextContent(content)
+				ExtractTextContent(context.Background(), content)
 			text = strings.TrimSpace(text)
 			if text == "" && len(tcs) == 0 && len(trs) == 0 {
 				continue
@@ -134,7 +135,7 @@ func (p *openClawProvider) parseSession(
 		case "assistant":
 			content := msg.Get("content")
 			text, thinkingText, hasThinking, hasToolUse, tcs, trs :=
-				ExtractTextContent(content)
+				ExtractTextContent(context.Background(), content)
 			text = strings.TrimSpace(text)
 			if text == "" && len(tcs) == 0 && len(trs) == 0 {
 				continue

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -1743,13 +1743,13 @@ func inferOpenCodeSkillName(toolName, inputJSON, cwd string) string {
 		// paths and falls back to the parent directory name. Try the
 		// file_path directly against the session worktree first.
 		if fp := gjson.Get(inputJSON, "file_path").Str; fp != "" && cwd != "" {
-			if name := skillNameFromPath(fp, cwd); name != "" {
+			if name := skillNameFromPath(context.Background(), fp, cwd); name != "" {
 				return name
 			}
 		}
-		return inferSkillNameFromJSONPaths(inputJSON)
+		return inferSkillNameFromJSONPaths(context.Background(), inputJSON)
 	}
-	return inferCodexSkillNameWithBase(toolName, inputJSON, cwd)
+	return inferCodexSkillNameWithBase(context.Background(), toolName, inputJSON, cwd)
 }
 
 type openCodeStorageTime struct {

--- a/internal/parser/openhands.go
+++ b/internal/parser/openhands.go
@@ -276,7 +276,7 @@ func parseOpenHandsMessageEvent(
 	}
 
 	content, _, _, _, toolCalls, toolResults :=
-		ExtractTextContent(llmMessage.Get("content"))
+		ExtractTextContent(context.Background(), llmMessage.Get("content"))
 	content, hasThinking := openHandsAppendThinking(
 		content, ev,
 	)
@@ -431,7 +431,7 @@ func openHandsBaseStateCwd(base gjson.Result) string {
 }
 
 func openHandsText(content gjson.Result) string {
-	text, _, _, _, _, _ := ExtractTextContent(content)
+	text, _, _, _, _, _ := ExtractTextContent(context.Background(), content)
 	return strings.TrimSpace(text)
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -214,7 +214,7 @@ func TestExtractTextContent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := gjson.Parse(tt.json)
 			text, _, hasThinking, hasToolUse, tcs, _ :=
-				ExtractTextContent(result)
+				ExtractTextContent(t.Context(), result)
 			assert.Equal(t, tt.wantText, text, "text")
 			assert.Equal(t, tt.wantThink, hasThinking, "hasThinking")
 			assert.Equal(t, tt.wantToolUse, hasToolUse, "hasToolUse")
@@ -229,7 +229,7 @@ func TestExtractTextContent_AmpSkillNameExtraction(t *testing.T) {
 	)
 
 	text, _, hasThinking, hasToolUse, toolCalls, toolResults :=
-		ExtractTextContent(result)
+		ExtractTextContent(t.Context(), result)
 
 	require.Equal(t, "[Skill: walkthrough]", text, "text")
 	require.False(t, hasThinking, "hasThinking")
@@ -278,7 +278,7 @@ func TestExtractToolResults(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := gjson.Parse(tt.json)
-			_, _, _, _, _, trs := ExtractTextContent(result)
+			_, _, _, _, _, trs := ExtractTextContent(t.Context(), result)
 			require.Len(t, trs, len(tt.wantResults), "tool_results count")
 			for i := range tt.wantResults {
 				assert.Equalf(t, tt.wantResults[i].ToolUseID, trs[i].ToolUseID,
@@ -329,7 +329,7 @@ func TestExtractTextContent_IflowToolResult(t *testing.T) {
 		"tool_use_id":"tu_123",
 		"content":{"responseParts":{"functionResponse":{"response":{"output":"result text"}}}}
 	}]`
-	_, _, _, _, _, trs := ExtractTextContent(gjson.Parse(content))
+	_, _, _, _, _, trs := ExtractTextContent(t.Context(), gjson.Parse(content))
 	require.Len(t, trs, 1, "expected 1 tool result")
 	tr := trs[0]
 	assert.Equal(t, "tu_123", tr.ToolUseID, "ToolUseID")
@@ -344,7 +344,7 @@ func TestExtractTextContent_IflowToolResult(t *testing.T) {
 		"tool_use_id":"tu_456",
 		"content":{"other":"data"}
 	}]`
-	_, _, _, _, _, trs2 := ExtractTextContent(gjson.Parse(noOutput))
+	_, _, _, _, _, trs2 := ExtractTextContent(t.Context(), gjson.Parse(noOutput))
 	require.Len(t, trs2, 1, "expected 1 tool result")
 	assert.Zero(t, trs2[0].ContentLength, "ContentLength")
 	assert.Empty(t, DecodeContent(trs2[0].ContentRaw), "DecodeContent")

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bufio"
+	"context"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
@@ -530,14 +531,14 @@ func inferPiSkillName(toolName, inputJSON, sessionCwd string) string {
 				return skill
 			}
 			if fp != "" && sessionCwd != "" {
-				if name := skillNameFromPath(fp, sessionCwd); name != "" {
+				if name := skillNameFromPath(context.Background(), fp, sessionCwd); name != "" {
 					return name
 				}
 			}
 		}
-		return inferSkillNameFromJSONPaths(inputJSON)
+		return inferSkillNameFromJSONPaths(context.Background(), inputJSON)
 	}
-	return inferCodexSkillNameWithBase(toolName, inputJSON, sessionCwd)
+	return inferCodexSkillNameWithBase(context.Background(), toolName, inputJSON, sessionCwd)
 }
 
 // piSkillURISkillName extracts the decoded skill name from the

--- a/internal/parser/piebald.go
+++ b/internal/parser/piebald.go
@@ -41,7 +41,7 @@ func piebaldDBPath(dir string) string {
 func ListPiebaldSessionMeta(dbPath string) ([]PiebaldSessionMeta, error) {
 	var metas []PiebaldSessionMeta
 	err := ForEachPiebaldSessionMeta(
-		context.Background(), dbPath,
+		context.Background(), dbPath, false,
 		func(meta PiebaldSessionMeta) error {
 			metas = append(metas, meta)
 			return nil
@@ -51,13 +51,13 @@ func ListPiebaldSessionMeta(dbPath string) ([]PiebaldSessionMeta, error) {
 }
 
 func ForEachPiebaldSessionMeta(
-	ctx context.Context, dbPath string, yield func(PiebaldSessionMeta) error,
+	ctx context.Context, dbPath string, stableSnapshot bool, yield func(PiebaldSessionMeta) error,
 ) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil
 	}
 
-	db, err := openPiebaldDB(dbPath)
+	db, err := openPiebaldDB(dbPath, stableSnapshot)
 	if err != nil {
 		return err
 	}
@@ -94,9 +94,9 @@ func ForEachPiebaldSessionMeta(
 }
 
 func piebaldSessionMeta(
-	ctx context.Context, dbPath, sessionID string,
+	ctx context.Context, dbPath, sessionID string, stableSnapshot bool,
 ) (PiebaldSessionMeta, bool, error) {
-	db, err := openPiebaldDB(dbPath)
+	db, err := openPiebaldDB(dbPath, stableSnapshot)
 	if err != nil {
 		return PiebaldSessionMeta{}, false, err
 	}
@@ -123,26 +123,32 @@ func piebaldSessionMeta(
 
 // parsePiebaldSessionResults parses a single Piebald chat and any large
 // message-DAG branches as fork child sessions.
-func parsePiebaldSessionResults(dbPath, chatID, machine string) ([]ParseResult, error) {
+func parsePiebaldSessionResults(
+	ctx context.Context, dbPath, chatID, machine string, stableSnapshot bool,
+) ([]ParseResult, error) {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("piebald db not found: %s", dbPath)
 	}
 
-	db, err := openPiebaldDB(dbPath)
+	db, err := openPiebaldDB(dbPath, stableSnapshot)
 	if err != nil {
 		return nil, err
 	}
 	defer db.Close()
 
-	c, err := loadOnePiebaldChat(db, chatID)
+	c, err := loadOnePiebaldChat(ctx, db, chatID)
 	if err != nil {
 		return nil, fmt.Errorf("loading piebald chat %s: %w", chatID, err)
 	}
-	return buildPiebaldSessionResults(db, c, dbPath, machine)
+	return buildPiebaldSessionResults(ctx, db, c, dbPath, machine)
 }
 
-func openPiebaldDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&_busy_timeout=3000"
+func openPiebaldDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
+	immutable := "0"
+	if stableSnapshot {
+		immutable = "1"
+	}
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening piebald db %s: %w", dbPath, err)
@@ -163,8 +169,10 @@ type piebaldChatRow struct {
 	projectName      string
 }
 
-func loadOnePiebaldChat(db *sql.DB, chatID string) (piebaldChatRow, error) {
-	row := db.QueryRow(piebaldChatSelect(`
+func loadOnePiebaldChat(
+	ctx context.Context, db *sql.DB, chatID string,
+) (piebaldChatRow, error) {
+	row := db.QueryRowContext(ctx, piebaldChatSelect(`
 		WHERE c.id = ?
 		  AND COALESCE(c.is_deleted, 0) = 0
 	`), chatID)
@@ -237,8 +245,10 @@ type piebaldToolCallRow struct {
 	subAgentChatID    sql.NullInt64
 }
 
-func buildPiebaldSessionResults(db *sql.DB, c piebaldChatRow, dbPath, machine string) ([]ParseResult, error) {
-	messageRows, err := loadPiebaldMessages(db, c.id)
+func buildPiebaldSessionResults(
+	ctx context.Context, db *sql.DB, c piebaldChatRow, dbPath, machine string,
+) ([]ParseResult, error) {
+	messageRows, err := loadPiebaldMessages(ctx, db, c.id)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +264,7 @@ func buildPiebaldSessionResults(db *sql.DB, c piebaldChatRow, dbPath, machine st
 	var results []ParseResult
 	baseID := fmt.Sprintf("piebald:%d", c.id)
 	for i, b := range branches {
-		messages, firstMsg, realUserCount, err := buildPiebaldMessages(db, b.rows)
+		messages, firstMsg, realUserCount, err := buildPiebaldMessages(ctx, db, b.rows)
 		if err != nil {
 			return nil, err
 		}
@@ -293,14 +303,16 @@ func buildPiebaldSessionResults(db *sql.DB, c piebaldChatRow, dbPath, machine st
 	return results, nil
 }
 
-func buildPiebaldMessages(db *sql.DB, rows []piebaldMessageRow) ([]ParsedMessage, string, int, error) {
+func buildPiebaldMessages(
+	ctx context.Context, db *sql.DB, rows []piebaldMessageRow,
+) ([]ParsedMessage, string, int, error) {
 	var (
 		messages      []ParsedMessage
 		firstMsg      string
 		realUserCount int
 	)
 	for _, mr := range rows {
-		msg, ok, err := buildPiebaldMessage(db, mr, len(messages))
+		msg, ok, err := buildPiebaldMessage(ctx, db, mr, len(messages))
 		if err != nil {
 			return nil, "", 0, err
 		}
@@ -347,8 +359,10 @@ func buildPiebaldSessionMeta(c piebaldChatRow, dbPath, machine string) ParsedSes
 	}
 }
 
-func loadPiebaldMessages(db *sql.DB, chatID int64) ([]piebaldMessageRow, error) {
-	rows, err := db.Query(`
+func loadPiebaldMessages(
+	ctx context.Context, db *sql.DB, chatID int64,
+) ([]piebaldMessageRow, error) {
+	rows, err := db.QueryContext(ctx, `
 		SELECT id,
 		       parent_chat_id,
 		       parent_message_id,
@@ -476,8 +490,10 @@ func (m piebaldMessageRow) enabled() bool {
 	return m.isEnabled != 0
 }
 
-func buildPiebaldMessage(db *sql.DB, mr piebaldMessageRow, ordinal int) (ParsedMessage, bool, error) {
-	parts, err := loadPiebaldMessageParts(db, mr.id)
+func buildPiebaldMessage(
+	ctx context.Context, db *sql.DB, mr piebaldMessageRow, ordinal int,
+) (ParsedMessage, bool, error) {
+	parts, err := loadPiebaldMessageParts(ctx, db, mr.id)
 	if err != nil {
 		return ParsedMessage{}, false, err
 	}
@@ -491,7 +507,7 @@ func buildPiebaldMessage(db *sql.DB, mr piebaldMessageRow, ordinal int) (ParsedM
 	for _, part := range parts {
 		switch part.partType {
 		case "text":
-			text, isThinking, err := loadPiebaldTextPart(db, part.id)
+			text, isThinking, err := loadPiebaldTextPart(ctx, db, part.id)
 			if err != nil {
 				return ParsedMessage{}, false, err
 			}
@@ -504,7 +520,7 @@ func buildPiebaldMessage(db *sql.DB, mr piebaldMessageRow, ordinal int) (ParsedM
 				contentParts = append(contentParts, text)
 			}
 		case "tool_call":
-			call, result, err := loadPiebaldToolCall(db, part.id)
+			call, result, err := loadPiebaldToolCall(ctx, db, part.id)
 			if err != nil {
 				return ParsedMessage{}, false, err
 			}
@@ -542,8 +558,10 @@ func buildPiebaldMessage(db *sql.DB, mr piebaldMessageRow, ordinal int) (ParsedM
 	return msg, true, nil
 }
 
-func loadPiebaldMessageParts(db *sql.DB, messageID int64) ([]piebaldPartRow, error) {
-	rows, err := db.Query(`
+func loadPiebaldMessageParts(
+	ctx context.Context, db *sql.DB, messageID int64,
+) ([]piebaldPartRow, error) {
+	rows, err := db.QueryContext(ctx, `
 		SELECT id, part_type, part_index
 		FROM message_parts
 		WHERE parent_chat_message_id = ?
@@ -564,16 +582,18 @@ func loadPiebaldMessageParts(db *sql.DB, messageID int64) ([]piebaldPartRow, err
 	return parts, rows.Err()
 }
 
-func loadPiebaldTextPart(db *sql.DB, partID int64) (string, bool, error) {
+func loadPiebaldTextPart(
+	ctx context.Context, db *sql.DB, partID int64,
+) (string, bool, error) {
 	var isThinking bool
-	if err := db.QueryRow(`
+	if err := db.QueryRowContext(ctx, `
 		SELECT COALESCE(is_thinking, 0)
 		FROM message_part_text
 		WHERE message_part_id = ?
 	`, partID).Scan(&isThinking); err != nil {
 		return "", false, err
 	}
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT COALESCE(mnt.content, '')
 		FROM message_content_nodes mcn
 		JOIN message_node_text mnt ON mnt.node_id = mcn.id
@@ -596,8 +616,10 @@ func loadPiebaldTextPart(db *sql.DB, partID int64) (string, bool, error) {
 	return strings.Join(chunks, ""), isThinking, rows.Err()
 }
 
-func loadPiebaldToolCall(db *sql.DB, partID int64) (ParsedToolCall, ParsedToolResult, error) {
-	row := db.QueryRow(`
+func loadPiebaldToolCall(
+	ctx context.Context, db *sql.DB, partID int64,
+) (ParsedToolCall, ParsedToolResult, error) {
+	row := db.QueryRowContext(ctx, `
 		SELECT provider_tool_use_id,
 		       tool_name,
 		       COALESCE(tool_input, ''),

--- a/internal/parser/piebald_test.go
+++ b/internal/parser/piebald_test.go
@@ -193,7 +193,7 @@ func parsePiebaldOneSession(
 	t *testing.T, dbPath, chatID, machine string,
 ) (*ParsedSession, []ParsedMessage) {
 	t.Helper()
-	results, err := parsePiebaldSessionResults(dbPath, chatID, machine)
+	results, err := parsePiebaldSessionResults(t.Context(), dbPath, chatID, machine, false)
 	require.NoError(t, err, "parsePiebaldSessionResults")
 	require.NotEmpty(t, results, "expected at least one parsed session")
 	return &results[0].Session, results[0].Messages
@@ -307,7 +307,7 @@ func TestParsePiebaldSessionResultsSplitsForks(t *testing.T) {
 		piebaldTextPartSeed{2001, 201, 0, "fork answer", false},
 	)
 
-	results, err := parsePiebaldSessionResults(dbPath, "42", "machine")
+	results, err := parsePiebaldSessionResults(t.Context(), dbPath, "42", "machine", false)
 	require.NoError(t, err, "parsePiebaldSessionResults")
 	require.Len(t, results, 2)
 	main := results[0]
@@ -366,7 +366,7 @@ func TestParsePiebaldSessionResultsHandlesNestedForks(t *testing.T) {
 		piebaldTextPartSeed{1301, 301, 0, "nested fork answer", false},
 	)
 
-	results, err := parsePiebaldSessionResults(dbPath, "42", "machine")
+	results, err := parsePiebaldSessionResults(t.Context(), dbPath, "42", "machine", false)
 	require.NoError(t, err, "parsePiebaldSessionResults")
 	require.Len(t, results, 3, "main + outer fork + nested fork")
 

--- a/internal/parser/poolside.go
+++ b/internal/parser/poolside.go
@@ -12,6 +12,7 @@
 package parser
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
@@ -323,7 +324,7 @@ func parsePoolsideSession(
 				// Extract skill name from skill tool calls.
 				// For other tools, infer from SKILL.md references in read/shell.
 				var skillName string
-				skillName = inferToolSkillName(name, inputJSON)
+				skillName = inferToolSkillName(context.Background(), name, inputJSON)
 				if name == "skill" && skillName == "" {
 					skillName = gjson.Get(inputJSON, "skill").Str
 					if skillName == "" {

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -61,9 +61,9 @@ var allowProtectedPathProbes atomic.Bool
 
 type filesystemProjectDiscoveryKey struct{}
 
-// WithoutFilesystemProjectDiscovery returns a context that limits project
-// attribution to transcript metadata and lexical path rules. Bounded importers
-// use it so recorded working directories are never touched on the local host.
+// WithoutFilesystemProjectDiscovery limits project and skill attribution to
+// transcript metadata and lexical path rules. Bounded importers use it so
+// captured paths never trigger local Git discovery or skill frontmatter reads.
 func WithoutFilesystemProjectDiscovery(ctx context.Context) context.Context {
 	return context.WithValue(ctx, filesystemProjectDiscoveryKey{}, true)
 }

--- a/internal/parser/qclaw.go
+++ b/internal/parser/qclaw.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"encoding/json/v2"
 	"fmt"
 	"os"
@@ -95,7 +96,7 @@ func (p *qClawProvider) parseSession(
 		case "user":
 			content := msg.Get("content")
 			text, thinkingText, hasThinking, hasToolUse, tcs, trs :=
-				ExtractTextContent(content)
+				ExtractTextContent(context.Background(), content)
 			text = strings.TrimSpace(text)
 			if text == "" && len(tcs) == 0 && len(trs) == 0 {
 				continue
@@ -128,7 +129,7 @@ func (p *qClawProvider) parseSession(
 		case "assistant":
 			content := msg.Get("content")
 			text, thinkingText, hasThinking, hasToolUse, tcs, trs :=
-				ExtractTextContent(content)
+				ExtractTextContent(context.Background(), content)
 			text = strings.TrimSpace(text)
 			if text == "" && len(tcs) == 0 && len(trs) == 0 {
 				continue

--- a/internal/parser/raw_capture.go
+++ b/internal/parser/raw_capture.go
@@ -14,6 +14,8 @@ import (
 
 const ProviderFeatureRawCapture = "raw capture"
 
+const ProviderFeatureRawSnapshotSessions = "raw snapshot sessions"
+
 var ErrInvalidRawCapturePlan = errors.New("invalid raw capture plan")
 
 // RawCaptureShape describes the physical shape a provider exposes for raw
@@ -26,13 +28,14 @@ const (
 	RawCaptureShapeSQLite
 )
 
-// RawCaptureAppendPolicy declares whether a provider can safely extend one
-// entry while retaining the prior generation's ordered object references.
+// RawCaptureAppendPolicy declares which entries can safely extend while
+// retaining the prior generation's ordered object references.
 type RawCaptureAppendPolicy uint8
 
 const (
 	RawCaptureAppendReplaceOnly RawCaptureAppendPolicy = iota
 	RawCaptureAppendOne
+	RawCaptureAppendMany
 )
 
 // RawCaptureSnapshotRequirement declares how capture obtains a consistent
@@ -92,6 +95,43 @@ type RawCaptureSourceProvider interface {
 	RawCaptureSourcesForChangedPath(
 		context.Context, ChangedPathRequest,
 	) ([]SourceRef, error)
+}
+
+// RawSnapshotSessionProvider fans one physical raw-capture source out to its
+// logical session sources. Providers whose ordinary Fingerprint and Parse
+// operate on session-scoped virtual sources -- a single shared SQLite store
+// captured as one physical file -- implement it so raw-snapshot parsing can
+// enumerate and parse every logical session inside a materialized copy of
+// that file through the provider's own per-session contract.
+type RawSnapshotSessionProvider interface {
+	RawSnapshotSessions(context.Context, SourceRef) ([]SourceRef, error)
+}
+
+// ResolveRawSnapshotSessions returns the logical session sources of one
+// physical raw-capture source when the provider fans SQLite raw snapshots out
+// to session-scoped virtual sources. File-shaped sources keep the caller's
+// single-source flow and report supported=false without an error.
+func ResolveRawSnapshotSessions(
+	ctx context.Context,
+	provider Provider,
+	source SourceRef,
+) ([]SourceRef, bool, error) {
+	if provider.Capabilities().RawCapture.Shape != RawCaptureShapeSQLite {
+		return nil, false, nil
+	}
+	fanout, ok := provider.(RawSnapshotSessionProvider)
+	if !ok {
+		return nil, false, UnsupportedProviderFeatureError{
+			Provider: provider.Definition().Type,
+			Feature:  ProviderFeatureRawSnapshotSessions,
+		}
+	}
+	sessions, err := fanout.RawSnapshotSessions(ctx, source)
+	if err != nil {
+		return nil, true, err
+	}
+	sortJSONLSources(sessions)
+	return sessions, true, nil
 }
 
 // StreamingRawCaptureSourceProvider emits physical raw sources without
@@ -339,6 +379,10 @@ func validateRawCapturePlan(
 	case RawCaptureAppendOne:
 		if appendable != 1 {
 			return RawCapturePlan{}, invalidRawCapturePlan("source must have exactly one appendable entry")
+		}
+	case RawCaptureAppendMany:
+		if appendable == 0 {
+			return RawCapturePlan{}, invalidRawCapturePlan("source must have an appendable entry")
 		}
 	default:
 		return RawCapturePlan{}, invalidRawCapturePlan("unknown append policy %d", capabilities.Append)

--- a/internal/parser/raw_capture_test.go
+++ b/internal/parser/raw_capture_test.go
@@ -442,6 +442,57 @@ func TestCodexProviderPlansTranscriptWithOptionalIndex(t *testing.T) {
 	assert.True(t, plan.Entries[0].Appendable)
 }
 
+func TestCodexProviderPlansForkWithReplayParent(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "sessions")
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	parentPath := writeCodexProviderSession(t, root, parentID, "parent task")
+	childPath := writeCodexProviderSessionContent(t, root, childID,
+		`{"type":"session_meta","payload":{"id":"`+childID+`","forked_from_id":"`+parentID+`"}}`+"\n",
+	)
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	child := requireCodexProviderSource(t, provider, childID)
+
+	plan, supported, err := ResolveRawCapturePlan(t.Context(), provider, child)
+
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Len(t, plan.Entries, 2)
+	entries := make(map[string]RawCaptureEntry, len(plan.Entries))
+	for _, entry := range plan.Entries {
+		entries[entry.LocalPath] = entry
+	}
+	require.Contains(t, entries, parentPath)
+	require.Contains(t, entries, childPath)
+	assert.False(t, entries[parentPath].Appendable,
+		"the parent is an immutable parse input for this child generation")
+	assert.True(t, entries[childPath].Appendable,
+		"only the primary child transcript may extend the generation")
+}
+
+func TestCodexProviderPlansForkCaptureWithoutReplayParent(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "sessions")
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	writeCodexProviderSessionContent(t, root, childID,
+		`{"type":"session_meta","payload":{"id":"`+childID+`","forked_from_id":"`+parentID+`"}}`+"\n",
+	)
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	child := requireCodexProviderSource(t, provider, childID)
+
+	plan, supported, err := ResolveRawCapturePlan(t.Context(), provider, child)
+
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, child.DisplayPath, plan.Entries[0].LocalPath)
+	assert.True(t, plan.Entries[0].Appendable)
+}
+
 func TestClaudeProviderPlansThroughSymlinkedRoot(t *testing.T) {
 	base := t.TempDir()
 	realRoot := filepath.Join(base, "real-projects")

--- a/internal/parser/roocode.go
+++ b/internal/parser/roocode.go
@@ -8,6 +8,7 @@
 package parser
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
@@ -1365,7 +1366,7 @@ func parseRooCodeToolCall(text string, ordinal int) *ParsedToolCall {
 		// Infer skill name from readFile calls to SKILL.md files,
 		// matching how Cursor, Codex, Grok, Kimi, and ZCode detect
 		// skill usage from file reads.
-		tc.SkillName = inferToolSkillName(toolName, tc.InputJSON)
+		tc.SkillName = inferToolSkillName(context.Background(), toolName, tc.InputJSON)
 	}
 	return tc
 }

--- a/internal/parser/skill_inference.go
+++ b/internal/parser/skill_inference.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"encoding/json/v2"
 	"io"
 	"os"
@@ -39,29 +40,29 @@ var searchValueFlags = map[string]bool{
 // call by trying the read-file heuristic first, then the shell
 // read-command heuristic. Used by both the Cursor JSONL and
 // plain-text transcript paths so they stay in sync.
-func inferToolSkillName(toolName, inputJSON string) string {
-	if name := inferCursorSkillName(toolName, inputJSON); name != "" {
+func inferToolSkillName(ctx context.Context, toolName, inputJSON string) string {
+	if name := inferCursorSkillName(ctx, toolName, inputJSON); name != "" {
 		return name
 	}
-	return inferCodexSkillName(toolName, inputJSON)
+	return inferCodexSkillName(ctx, toolName, inputJSON)
 }
 
-func inferCursorSkillName(toolName, inputJSON string) string {
+func inferCursorSkillName(ctx context.Context, toolName, inputJSON string) string {
 	if !isCursorSkillReadTool(toolName) {
 		return ""
 	}
-	return inferSkillNameFromJSONPaths(inputJSON)
+	return inferSkillNameFromJSONPaths(ctx, inputJSON)
 }
 
-func inferCodexSkillName(toolName, inputJSON string) string {
-	return inferCodexSkillNameWithBase(toolName, inputJSON, "")
+func inferCodexSkillName(ctx context.Context, toolName, inputJSON string) string {
+	return inferCodexSkillNameWithBase(ctx, toolName, inputJSON, "")
 }
 
 // inferCodexSkillNameWithBase infers a Codex skill name, resolving
 // relative SKILL.md paths against the tool call's own workdir/cwd
 // hint when present, otherwise against fallbackBaseDir (typically
 // the session working directory from session_meta).
-func inferCodexSkillNameWithBase(toolName, inputJSON, fallbackBaseDir string) string {
+func inferCodexSkillNameWithBase(ctx context.Context, toolName, inputJSON, fallbackBaseDir string) string {
 	if !isCodexShellTool(toolName) {
 		return ""
 	}
@@ -74,7 +75,7 @@ func inferCodexSkillNameWithBase(toolName, inputJSON, fallbackBaseDir string) st
 		baseDir = fallbackBaseDir
 	}
 	for _, path := range skillPathsFromCommand(cmd) {
-		if name := skillNameFromPath(path, baseDir); name != "" {
+		if name := skillNameFromPath(ctx, path, baseDir); name != "" {
 			return name
 		}
 	}
@@ -246,7 +247,7 @@ func skillPathsFromSearchArgs(args []string) []string {
 	return skillFilePaths(files)
 }
 
-func inferSkillNameFromJSONPaths(inputJSON string) string {
+func inferSkillNameFromJSONPaths(ctx context.Context, inputJSON string) string {
 	trimmed := strings.TrimSpace(inputJSON)
 	if trimmed == "" {
 		return ""
@@ -254,7 +255,7 @@ func inferSkillNameFromJSONPaths(inputJSON string) string {
 	baseDir := skillBaseDirFromInput(trimmed)
 	if !gjson.Valid(trimmed) {
 		for _, path := range skillPathsFromText(trimmed) {
-			if name := skillNameFromPath(path, baseDir); name != "" {
+			if name := skillNameFromPath(ctx, path, baseDir); name != "" {
 				return name
 			}
 		}
@@ -276,12 +277,12 @@ func inferSkillNameFromJSONPaths(inputJSON string) string {
 			// A JSON string value is already one unescaped path, so
 			// try it whole first — the free-text regex below splits
 			// on whitespace and would truncate paths with spaces.
-			if name := skillNameFromPath(t, baseDir); name != "" {
+			if name := skillNameFromPath(ctx, t, baseDir); name != "" {
 				found = name
 				return
 			}
 			for _, path := range skillPathsFromText(t) {
-				if name := skillNameFromPath(path, baseDir); name != "" {
+				if name := skillNameFromPath(ctx, path, baseDir); name != "" {
 					found = name
 					return
 				}
@@ -383,10 +384,18 @@ func skillPathMatchHasBoundary(text string, end int) bool {
 // Paths carrying shell glob metacharacters are rejected: they come
 // from discovery commands (e.g. "**/SKILL.md") rather than a
 // concrete file, and would otherwise yield a bogus name like "**".
-func skillNameFromPath(path, baseDir string) string {
+func skillNameFromPath(ctx context.Context, path, baseDir string) string {
 	path = strings.TrimSpace(path)
 	if path == "" || skillPathIsGlob(path) || !isSkillMarkdownPath(path) {
 		return ""
+	}
+	if filesystemProjectDiscoveryDisabled(ctx) {
+		// Captured paths name another host. Do not expand the worker's home,
+		// read frontmatter, or reuse a cached local frontmatter name.
+		if skillPathIsBare(path) {
+			return ""
+		}
+		return skillNameFromParentDir(strings.ReplaceAll(path, "\\", "/"))
 	}
 	resolved, readable := resolveSkillPath(path, baseDir)
 	clean := filepath.Clean(resolved)

--- a/internal/parser/skill_inference_nonwindows_test.go
+++ b/internal/parser/skill_inference_nonwindows_test.go
@@ -23,7 +23,7 @@ func TestSkillNameFromFrontmatterRejectsSymlink(t *testing.T) {
 	link := filepath.Join(linkDir, "SKILL.md")
 	require.NoError(t, os.Symlink(real, link))
 
-	assert.Equal(t, "evil", skillNameFromPath(link, ""))
+	assert.Equal(t, "evil", skillNameFromPath(t.Context(), link, ""))
 }
 
 func TestSkillNameFromFrontmatterRejectsNonRegularFile(t *testing.T) {
@@ -36,5 +36,5 @@ func TestSkillNameFromFrontmatterRejectsNonRegularFile(t *testing.T) {
 
 	// Must not block on the FIFO open and must not read frontmatter;
 	// resolution falls back to the parent directory name.
-	assert.Equal(t, "qa", skillNameFromPath(fifo, ""))
+	assert.Equal(t, "qa", skillNameFromPath(t.Context(), fifo, ""))
 }

--- a/internal/parser/skill_inference_test.go
+++ b/internal/parser/skill_inference_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -13,6 +14,43 @@ import (
 
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
+
+func TestHostedSkillInferenceKeepsNamesLexical(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		parse func(*testing.T, context.Context, string) string
+	}{
+		{"claude", func(t *testing.T, ctx context.Context, path string) string {
+			_, _, _, _, calls, _ := ExtractTextContent(ctx, gjson.Parse(
+				`[{"type":"tool_use","id":"call-1","name":"Read","input":{"file_path":`+strconv.Quote(path)+`}}]`,
+			))
+			require.Len(t, calls, 1)
+			return calls[0].SkillName
+		}},
+		{"goose", func(t *testing.T, ctx context.Context, path string) string {
+			call, ok := gooseParseToolCall(ctx, gjson.Parse(
+				`{"id":"call-1","toolCall":{"status":"success","value":{"name":"Read","arguments":{"file_path":`+strconv.Quote(path)+`}}}}`,
+			))
+			require.True(t, ok)
+			return call.SkillName
+		}},
+		{"zcode", func(t *testing.T, ctx context.Context, path string) string {
+			call, ok := zcodeParseToolCall(ctx, gjson.Parse(
+				`{"id":"call-1","name":"Read","input":{"file_path":`+strconv.Quote(path)+`}}`,
+			))
+			require.True(t, ok)
+			return call.SkillName
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTestSkill(t, "visible-folder", "server-only-frontmatter-name")
+			// Populate the local cache first: hosted parsing must not expose
+			// either freshly read frontmatter or a previous local lookup.
+			assert.Equal(t, "server-only-frontmatter-name", tc.parse(t, t.Context(), path))
+			assert.Equal(t, "visible-folder", tc.parse(t, WithoutFilesystemProjectDiscovery(t.Context()), path))
+		})
+	}
+}
 
 func TestInferCursorSkillNameFromReadFile(t *testing.T) {
 	path := writeTestSkill(t, "foo", "foo")
@@ -112,7 +150,7 @@ func TestInferCodexSkillNameFromReadCommands(t *testing.T) {
 		"cd /tmp && sed -n '1,220p' " + path,
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+`}`,
 			)
@@ -136,7 +174,7 @@ func TestInferCodexSkillNameIgnoresWriteCommands(t *testing.T) {
 		"cat > " + path,
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+`}`,
 			)
@@ -157,7 +195,7 @@ func TestInferCodexSkillNameMixedWriteThenRead(t *testing.T) {
 		"touch marker; grep name " + path,
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+`}`,
 			)
@@ -175,7 +213,7 @@ func TestInferCodexSkillNameIgnoresGlobDiscovery(t *testing.T) {
 		"head -40 skills/[ab]/SKILL.md",
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+`}`,
 			)
@@ -188,7 +226,7 @@ func TestInferCodexSkillNameBareSkillFileWithWorkdir(t *testing.T) {
 	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
 	workdir := filepath.Dir(path)
 
-	got := inferCodexSkillName(
+	got := inferCodexSkillName(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "cat SKILL.md")+
 			`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -200,7 +238,7 @@ func TestInferCodexSkillNameBareSkillFileUsesFallbackCwd(t *testing.T) {
 	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
 	cwd := filepath.Dir(path)
 
-	got := inferCodexSkillNameWithBase(
+	got := inferCodexSkillNameWithBase(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "sed -n '1,40p' SKILL.md")+`}`,
 		cwd,
@@ -214,7 +252,7 @@ func TestInferCodexSkillNameBareSkillPatternWithoutFileIgnored(t *testing.T) {
 	// not be resolved to the workdir name and miscounted as usage.
 	workdir := t.TempDir()
 
-	got := inferCodexSkillName(
+	got := inferCodexSkillName(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "grep SKILL.md notes.txt")+
 			`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -238,7 +276,7 @@ func TestInferCodexSkillNameBareSkillSearchPatternIgnoredEvenWithFile(t *testing
 		"grep -e SKILL.md notes.txt",   // SKILL.md is the -e pattern value
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+
 					`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -262,7 +300,7 @@ func TestInferCodexSkillNameSearchCommandReadsFileOperand(t *testing.T) {
 		"grep -i name SKILL.md",
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+
 					`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -284,7 +322,7 @@ func TestInferCodexSkillNameSearchQuotedPatternIgnored(t *testing.T) {
 		`grep -e "read the SKILL.md" notes.txt`,
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+
 					`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -306,7 +344,7 @@ func TestInferCodexSkillNameIgnoresNonReadSegments(t *testing.T) {
 		"grep foo notes.txt; ls SKILL.md",
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+
 					`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -387,7 +425,7 @@ func TestInferCodexSkillNameIgnoresRedirectTargets(t *testing.T) {
 		"cat foo >skills/data-analytics/SKILL.md",
 	} {
 		t.Run(cmd, func(t *testing.T) {
-			got := inferCodexSkillName(
+			got := inferCodexSkillName(t.Context(),
 				"exec_command",
 				`{"cmd":`+quoteJSON(t, cmd)+
 					`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -402,7 +440,7 @@ func TestInferCodexSkillNameReadsFileDespiteQuotedRedirectChar(t *testing.T) {
 	// so the SKILL.md file operand is still read.
 	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
 
-	got := inferCodexSkillName(
+	got := inferCodexSkillName(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, `grep ">" `+path)+`}`,
 	)
@@ -414,7 +452,7 @@ func TestInferCodexSkillNameReadsSourceDespiteRedirect(t *testing.T) {
 	// so the read is still inferred.
 	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
 
-	got := inferCodexSkillName(
+	got := inferCodexSkillName(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "cat "+path+" > out.txt")+`}`,
 	)
@@ -426,7 +464,7 @@ func TestInferCodexSkillNameSearchCommandStillReadsPathOperand(t *testing.T) {
 	// (the pattern is a separate token), so it is still inferred.
 	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
 
-	got := inferCodexSkillName(
+	got := inferCodexSkillName(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "grep name "+path)+`}`,
 	)
@@ -510,7 +548,7 @@ func TestExtractTextContentInfersCursorJSONLSkillName(t *testing.T) {
 			quoteJSON(t, path) + `}}]`,
 	)
 
-	_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+	_, _, _, _, toolCalls, _ := ExtractTextContent(t.Context(), content)
 
 	require.Len(t, toolCalls, 1)
 	assert.Equal(t, "Read", toolCalls[0].ToolName)
@@ -524,7 +562,7 @@ func TestExtractTextContentInfersCursorJSONLSkillNameFromFrontmatter(t *testing.
 			quoteJSON(t, path) + `}}]`,
 	)
 
-	_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+	_, _, _, _, toolCalls, _ := ExtractTextContent(t.Context(), content)
 
 	require.Len(t, toolCalls, 1)
 	assert.Equal(t, "ReadFile", toolCalls[0].ToolName)
@@ -540,7 +578,7 @@ func TestExtractTextContentInfersSkillNameFromPathWithSpaces(t *testing.T) {
 			quoteJSON(t, path) + `}}]`,
 	)
 
-	_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+	_, _, _, _, toolCalls, _ := ExtractTextContent(t.Context(), content)
 
 	require.Len(t, toolCalls, 1)
 	assert.Equal(t, "data-analytics:index", toolCalls[0].SkillName)
@@ -553,7 +591,7 @@ func TestExtractTextContentInfersCursorJSONLSkillNameFromShellRead(t *testing.T)
 			quoteJSON(t, "cd /tmp && sed -n '1,120p' "+path) + `}}]`,
 	)
 
-	_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+	_, _, _, _, toolCalls, _ := ExtractTextContent(t.Context(), content)
 
 	require.Len(t, toolCalls, 1)
 	assert.Equal(t, "Shell", toolCalls[0].ToolName)
@@ -609,7 +647,7 @@ func TestExtractTextContentDoesNotInferCursorJSONLNonUsage(t *testing.T) {
 					quoteJSON(t, tt.toolName) + `,"input":` + tt.input + `}]`,
 			)
 
-			_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+			_, _, _, _, toolCalls, _ := ExtractTextContent(t.Context(), content)
 
 			require.Len(t, toolCalls, 1)
 			assert.Empty(t, toolCalls[0].SkillName)
@@ -621,7 +659,7 @@ func TestInferCodexSkillNameResolvesRelativePathAgainstWorkdir(t *testing.T) {
 	path := writeTestSkill(t, "index", "data-analytics:index")
 	workdir := filepath.Dir(filepath.Dir(filepath.Dir(path)))
 
-	got := inferCodexSkillName(
+	got := inferCodexSkillName(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "sed -n '1,220p' skills/index/SKILL.md")+
 			`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -634,7 +672,7 @@ func TestInferCodexSkillNameWorkdirOverridesFallbackBase(t *testing.T) {
 	path := writeTestSkill(t, "index", "data-analytics:index")
 	workdir := filepath.Dir(filepath.Dir(filepath.Dir(path)))
 
-	got := inferCodexSkillNameWithBase(
+	got := inferCodexSkillNameWithBase(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "cat skills/index/SKILL.md")+
 			`,"workdir":`+quoteJSON(t, workdir)+`}`,
@@ -648,7 +686,7 @@ func TestInferCodexSkillNameUsesFallbackBaseWhenNoWorkdir(t *testing.T) {
 	path := writeTestSkill(t, "index", "data-analytics:index")
 	fallback := filepath.Dir(filepath.Dir(filepath.Dir(path)))
 
-	got := inferCodexSkillNameWithBase(
+	got := inferCodexSkillNameWithBase(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "cat skills/index/SKILL.md")+`}`,
 		fallback,
@@ -665,7 +703,7 @@ func TestInferCodexSkillNameRelativePathNoWorkdirUsesParentFallback(t *testing.T
 	// unrelated SKILL.md under the process cwd.
 	writeTestSkill(t, "index", "data-analytics:index")
 
-	got := inferCodexSkillName(
+	got := inferCodexSkillName(t.Context(),
 		"exec_command",
 		`{"cmd":`+quoteJSON(t, "cat skills/index/SKILL.md")+`}`,
 	)
@@ -743,7 +781,7 @@ func TestSkillNameFromFrontmatterBoundsReadSize(t *testing.T) {
 	sb.WriteString("\nname: too-far\n---\n")
 	require.NoError(t, os.WriteFile(path, []byte(sb.String()), 0o644))
 
-	assert.Equal(t, "huge", skillNameFromPath(path, ""))
+	assert.Equal(t, "huge", skillNameFromPath(t.Context(), path, ""))
 }
 
 func writeTestSkill(t *testing.T, folder, name string) string {

--- a/internal/parser/warp.go
+++ b/internal/parser/warp.go
@@ -32,7 +32,7 @@ func ListWarpSessionMeta(
 ) ([]WarpSessionMeta, error) {
 	var metas []WarpSessionMeta
 	err := ForEachWarpSessionMeta(
-		context.Background(), dbPath,
+		context.Background(), dbPath, false,
 		func(meta WarpSessionMeta) error {
 			metas = append(metas, meta)
 			return nil
@@ -42,13 +42,13 @@ func ListWarpSessionMeta(
 }
 
 func ForEachWarpSessionMeta(
-	ctx context.Context, dbPath string, yield func(WarpSessionMeta) error,
+	ctx context.Context, dbPath string, stableSnapshot bool, yield func(WarpSessionMeta) error,
 ) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil
 	}
 
-	db, err := openWarpDB(dbPath)
+	db, err := openWarpDB(dbPath, stableSnapshot)
 	if err != nil {
 		return err
 	}
@@ -89,9 +89,9 @@ func ForEachWarpSessionMeta(
 }
 
 func warpSessionMeta(
-	ctx context.Context, dbPath, sessionID string,
+	ctx context.Context, dbPath, sessionID string, stableSnapshot bool,
 ) (WarpSessionMeta, bool, error) {
-	db, err := openWarpDB(dbPath)
+	db, err := openWarpDB(dbPath, stableSnapshot)
 	if err != nil {
 		return WarpSessionMeta{}, false, err
 	}
@@ -116,7 +116,7 @@ func warpSessionMeta(
 // parseWarpSession parses a single conversation by ID from
 // the Warp database.
 func parseWarpSession(
-	dbPath, conversationID, machine string,
+	ctx context.Context, dbPath, conversationID, machine string, stableSnapshot bool,
 ) (*ParsedSession, []ParsedMessage, error) {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil, nil, fmt.Errorf(
@@ -124,13 +124,13 @@ func parseWarpSession(
 		)
 	}
 
-	db, err := openWarpDB(dbPath)
+	db, err := openWarpDB(dbPath, stableSnapshot)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer db.Close()
 
-	c, err := loadOneWarpConversation(db, conversationID)
+	c, err := loadOneWarpConversation(ctx, db, conversationID)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"loading warp conversation %s: %w",
@@ -138,12 +138,15 @@ func parseWarpSession(
 		)
 	}
 
-	return buildWarpSession(db, c, dbPath, machine)
+	return buildWarpSession(ctx, db, c, dbPath, machine)
 }
 
-func openWarpDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) +
-		"?mode=ro&_busy_timeout=3000"
+func openWarpDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
+	immutable := "0"
+	if stableSnapshot {
+		immutable = "1"
+	}
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -161,9 +164,9 @@ type warpConversationRow struct {
 }
 
 func loadOneWarpConversation(
-	db *sql.DB, conversationID string,
+	ctx context.Context, db *sql.DB, conversationID string,
 ) (warpConversationRow, error) {
-	row := db.QueryRow(`
+	row := db.QueryRowContext(ctx, `
 		SELECT conversation_id,
 		       COALESCE(conversation_data, '{}'),
 		       last_modified_at
@@ -189,9 +192,9 @@ type warpExchangeRow struct {
 }
 
 func loadWarpExchanges(
-	db *sql.DB, conversationID string,
+	ctx context.Context, db *sql.DB, conversationID string,
 ) ([]warpExchangeRow, error) {
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT exchange_id, start_ts,
 		       COALESCE(input, '[]'),
 		       COALESCE(model_id, ''),
@@ -221,11 +224,12 @@ func loadWarpExchanges(
 }
 
 func buildWarpSession(
+	ctx context.Context,
 	db *sql.DB,
 	c warpConversationRow,
 	dbPath, machine string,
 ) (*ParsedSession, []ParsedMessage, error) {
-	exchanges, err := loadWarpExchanges(db, c.id)
+	exchanges, err := loadWarpExchanges(ctx, db, c.id)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"loading exchanges for %s: %w", c.id, err,
@@ -295,7 +299,7 @@ func buildWarpSession(
 
 	// Extract project from working directory.
 	if cwd != "" {
-		project = ExtractProjectFromCwd(cwd)
+		project = ExtractProjectFromCwdWithBranchContext(ctx, cwd, "")
 	}
 	if project == "" {
 		project = "unknown"

--- a/internal/parser/warp_test.go
+++ b/internal/parser/warp_test.go
@@ -184,7 +184,7 @@ func TestParseWarpSession_SingleConversation(t *testing.T) {
 	seedWarpConversation(t, seeder)
 
 	sess, msgs, err := parseWarpSession(
-		dbPath, "conv-001", "testmachine",
+		t.Context(), dbPath, "conv-001", "testmachine", false,
 	)
 	require.NoError(t, err, "parseWarpSession")
 	require.NotNil(t, sess, "expected non-nil session")

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -35,8 +35,8 @@ func (f zcodeProviderFactory) Capabilities() Capabilities {
 
 func (f zcodeProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	cfg = cfg.Clone()
-	cfg.Roots = normalizeZCodeRoots(cfg.Roots)
-	spec := zcodeProviderSpec()
+	cfg.Roots = normalizeZCodeRoots(cfg.Roots, cfg.StableSourceSnapshots)
+	spec := zcodeProviderSpec(cfg.StableSourceSnapshots)
 	return &dbBackedProvider{
 		Def:     cloneAgentDef(f.def),
 		Caps:    withDBBackedRawCapture(spec.caps),
@@ -62,7 +62,7 @@ func zcodeProviderCapabilities() Capabilities {
 	}
 }
 
-func zcodeProviderSpec() dbBackedProviderSpec {
+func zcodeProviderSpec(stableSnapshot bool) dbBackedProviderSpec {
 	return dbBackedProviderSpec{
 		agent:  AgentZCode,
 		dbName: zcodeDBName,
@@ -72,15 +72,17 @@ func zcodeProviderSpec() dbBackedProviderSpec {
 			dbPath string,
 			yield func(dbBackedSessionMeta) error,
 		) error {
-			return forEachZCodeSessionMeta(ctx, dbPath, yield)
+			return forEachZCodeSessionMeta(ctx, dbPath, stableSnapshot, yield)
 		},
 		metaForID: func(
 			ctx context.Context, dbPath, sessionID string,
 		) (dbBackedSessionMeta, bool, error) {
-			return zcodeSessionMeta(ctx, dbPath, sessionID)
+			return zcodeSessionMeta(ctx, dbPath, sessionID, stableSnapshot)
 		},
-		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
-			result, err := parseZCodeSession(dbPath, sessionID, machine)
+		parse: func(
+			ctx context.Context, dbPath, sessionID, machine string,
+		) ([]ParseResult, error) {
+			result, err := parseZCodeSession(ctx, dbPath, sessionID, machine, stableSnapshot)
 			if err != nil || result == nil {
 				return nil, err
 			}
@@ -90,12 +92,12 @@ func zcodeProviderSpec() dbBackedProviderSpec {
 	}
 }
 
-func normalizeZCodeRoots(roots []string) []string {
+func normalizeZCodeRoots(roots []string, directRoot bool) []string {
 	cleaned := cleanJSONLRoots(roots)
 	out := make([]string, 0, len(cleaned))
 	seen := make(map[string]struct{}, len(cleaned))
 	for _, root := range cleaned {
-		normalized := normalizeZCodeRoot(root)
+		normalized := normalizeZCodeRoot(root, directRoot)
 		if normalized == "" {
 			continue
 		}
@@ -108,10 +110,18 @@ func normalizeZCodeRoots(roots []string) []string {
 	return out
 }
 
-func normalizeZCodeRoot(root string) string {
+func normalizeZCodeRoot(root string, directRoot bool) string {
 	root = filepath.Clean(root)
 	if root == "" || root == "." {
 		return ""
+	}
+	// A materialized raw snapshot (stable source snapshots) places db.sqlite
+	// directly inside the snapshot root, so only that mode accepts a root that
+	// already contains the database. A configured root keeps its existing
+	// mapping: a stray top-level db.sqlite must never win over the established
+	// db/db.sqlite layout.
+	if directRoot && IsRegularFile(filepath.Join(root, zcodeDBName)) {
+		return root
 	}
 	if filepath.Base(root) == "db" {
 		return root
@@ -136,12 +146,12 @@ func ZCodeSQLiteVirtualPath(dbPath, sessionID string) string {
 }
 
 func forEachZCodeSessionMeta(
-	ctx context.Context, dbPath string, yield func(dbBackedSessionMeta) error,
+	ctx context.Context, dbPath string, stableSnapshot bool, yield func(dbBackedSessionMeta) error,
 ) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil
 	}
-	db, err := openZCodeDB(dbPath)
+	db, err := openZCodeDB(dbPath, stableSnapshot)
 	if err != nil {
 		return err
 	}
@@ -172,10 +182,14 @@ func forEachZCodeSessionMeta(
 			continue
 		}
 		observeStreamingDiscoveryBuffer(ctx, 1)
+		mtime, err := zcodeSessionFileMtime(ctx, dbPath, db, row)
+		if err != nil {
+			return err
+		}
 		if err := yield(dbBackedSessionMeta{
 			SessionID:   row.id,
 			VirtualPath: ZCodeSQLiteVirtualPath(dbPath, row.id),
-			FileMtime:   zcodeSessionFileMtime(dbPath, db, row),
+			FileMtime:   mtime,
 		}); err != nil {
 			return err
 		}
@@ -187,14 +201,14 @@ func forEachZCodeSessionMeta(
 }
 
 func zcodeSessionMeta(
-	ctx context.Context, dbPath, sessionID string,
+	ctx context.Context, dbPath, sessionID string, stableSnapshot bool,
 ) (dbBackedSessionMeta, bool, error) {
-	db, err := openZCodeDB(dbPath)
+	db, err := openZCodeDB(dbPath, stableSnapshot)
 	if err != nil {
 		return dbBackedSessionMeta{}, false, err
 	}
 	defer db.Close()
-	row, err := loadZCodeSessionRow(db, sessionID)
+	row, err := loadZCodeSessionRow(ctx, db, sessionID)
 	if err == sql.ErrNoRows {
 		return dbBackedSessionMeta{}, false, nil
 	}
@@ -204,32 +218,42 @@ func zcodeSessionMeta(
 	if err := ctx.Err(); err != nil {
 		return dbBackedSessionMeta{}, false, err
 	}
+	mtime, err := zcodeSessionFileMtime(ctx, dbPath, db, row)
+	if err != nil {
+		return dbBackedSessionMeta{}, false, err
+	}
 	return dbBackedSessionMeta{
 		SessionID: row.id, VirtualPath: ZCodeSQLiteVirtualPath(dbPath, row.id),
-		FileMtime: zcodeSessionFileMtime(dbPath, db, row),
+		FileMtime: mtime,
 	}, true, nil
 }
 
-func parseZCodeSession(dbPath, sessionID, machine string) (*ParseResult, error) {
-	db, err := openZCodeDB(dbPath)
+func parseZCodeSession(
+	ctx context.Context, dbPath, sessionID, machine string, stableSnapshot bool,
+) (*ParseResult, error) {
+	db, err := openZCodeDB(dbPath, stableSnapshot)
 	if err != nil {
 		return nil, err
 	}
 	defer db.Close()
 
-	row, err := loadZCodeSessionRow(db, sessionID)
+	row, err := loadZCodeSessionRow(ctx, db, sessionID)
 	if err != nil {
 		return nil, err
 	}
-	result, err := buildZCodeParseResult(dbPath, machine, row, db)
+	result, err := buildZCodeParseResult(ctx, dbPath, machine, row, db)
 	if err != nil {
 		return nil, err
 	}
 	return &result, nil
 }
 
-func openZCodeDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=0&_busy_timeout=3000"
+func openZCodeDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
+	immutable := "0"
+	if stableSnapshot {
+		immutable = "1"
+	}
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening zcode db %s: %w", dbPath, err)
@@ -278,8 +302,10 @@ type zcodePartRow struct {
 	data        string
 }
 
-func loadZCodeSessionRow(db *sql.DB, sessionID string) (zcodeSessionRow, error) {
-	row := db.QueryRow(`
+func loadZCodeSessionRow(
+	ctx context.Context, db *sql.DB, sessionID string,
+) (zcodeSessionRow, error) {
+	row := db.QueryRowContext(ctx, `
 		SELECT id,
 		       project_id,
 		       workspace_id,
@@ -314,7 +340,7 @@ func scanZCodeSessionRow(rows *sql.Rows) (zcodeSessionRow, error) {
 }
 
 func buildZCodeParseResult(
-	dbPath, machine string,
+	ctx context.Context, dbPath, machine string,
 	row zcodeSessionRow,
 	db *sql.DB,
 ) (ParseResult, error) {
@@ -328,7 +354,7 @@ func buildZCodeParseResult(
 	}
 
 	directory := row.directory.String
-	project := ExtractProjectFromCwd(directory)
+	project := ExtractProjectFromCwdWithBranchContext(ctx, directory, "")
 	if project == "" {
 		switch {
 		case row.projectID.Valid:
@@ -346,15 +372,15 @@ func buildZCodeParseResult(
 		firstMessage = truncate(strings.ReplaceAll(firstMessage, "\n", " "), 300)
 	}
 
-	msgs, err := loadZCodeMessages(db, row.id)
+	msgs, err := loadZCodeMessages(ctx, db, row.id)
 	if err != nil {
 		return ParseResult{}, err
 	}
-	parts, err := loadZCodeParts(db, row.id)
+	parts, err := loadZCodeParts(ctx, db, row.id)
 	if err != nil {
 		return ParseResult{}, err
 	}
-	parsedMessages := buildZCodeMessages(msgs, parts)
+	parsedMessages := buildZCodeMessages(ctx, msgs, parts)
 	userMessageCount := 0
 	for _, msg := range parsedMessages {
 		if msg.Role == RoleUser {
@@ -381,9 +407,12 @@ func buildZCodeParseResult(
 	if info, err := os.Stat(dbPath); err == nil {
 		sess.File.Size = info.Size()
 	}
-	sess.File.Mtime = zcodeSessionFileMtime(dbPath, db, row)
+	sess.File.Mtime, err = zcodeSessionFileMtime(ctx, dbPath, db, row)
+	if err != nil {
+		return ParseResult{}, err
+	}
 
-	usageEvents, err := listZCodeUsageEvents(db, row.id, startedAt, endedAt)
+	usageEvents, err := listZCodeUsageEvents(ctx, db, row.id, startedAt, endedAt)
 	if err != nil {
 		return ParseResult{}, err
 	}
@@ -397,9 +426,9 @@ func buildZCodeParseResult(
 }
 
 func loadZCodeMessages(
-	db *sql.DB, sessionID string,
+	ctx context.Context, db *sql.DB, sessionID string,
 ) ([]zcodeMessageRow, error) {
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT id,
 		       COALESCE(data, '{}'),
 		       CAST(COALESCE(time_created, '') AS TEXT)
@@ -433,18 +462,18 @@ func loadZCodeMessages(
 }
 
 func loadZCodeParts(
-	db *sql.DB, sessionID string,
+	ctx context.Context, db *sql.DB, sessionID string,
 ) (map[string][]zcodePartRow, error) {
 	selectTime := `''`
 	orderBy := `id`
-	if has, err := zcodeTableHasColumn(db, "part", "time_created"); err != nil {
+	if has, err := zcodeTableHasColumn(ctx, db, "part", "time_created"); err != nil {
 		return nil, err
 	} else if has {
 		selectTime = `CAST(COALESCE(time_created, '') AS TEXT)`
 		orderBy = selectTime + `, id`
 	}
 
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT id,
 		       message_id,
 		       `+selectTime+`,
@@ -478,7 +507,7 @@ func loadZCodeParts(
 }
 
 func buildZCodeMessages(
-	msgs []zcodeMessageRow,
+	ctx context.Context, msgs []zcodeMessageRow,
 	parts map[string][]zcodePartRow,
 ) []ParsedMessage {
 	if msgs == nil || parts == nil {
@@ -487,7 +516,7 @@ func buildZCodeMessages(
 
 	parsed := make([]ParsedMessage, 0, len(msgs))
 	for _, row := range msgs {
-		msg, ok := buildZCodeMessage(len(parsed), row, parts[row.id])
+		msg, ok := buildZCodeMessage(ctx, len(parsed), row, parts[row.id])
 		if !ok {
 			continue
 		}
@@ -497,7 +526,7 @@ func buildZCodeMessages(
 }
 
 func buildZCodeMessage(
-	ordinal int,
+	ctx context.Context, ordinal int,
 	row zcodeMessageRow,
 	parts []zcodePartRow,
 ) (ParsedMessage, bool) {
@@ -533,7 +562,7 @@ func buildZCodeMessage(
 			texts = append(texts, "[Thinking]\n"+text+"\n[/Thinking]")
 		case "tool_use", "tool":
 			msg.HasToolUse = true
-			if tc, ok := zcodeParseToolCall(block); ok {
+			if tc, ok := zcodeParseToolCall(ctx, block); ok {
 				msg.ToolCalls = append(msg.ToolCalls, tc)
 			}
 			if tr, ok := zcodeParseToolResult(block); ok {
@@ -613,7 +642,7 @@ func zcodeThinkingText(block gjson.Result) string {
 	return ""
 }
 
-func zcodeParseToolCall(block gjson.Result) (ParsedToolCall, bool) {
+func zcodeParseToolCall(ctx context.Context, block gjson.Result) (ParsedToolCall, bool) {
 	name := block.Get("name").Str
 	if name == "" {
 		name = block.Get("tool_name").Str
@@ -665,7 +694,7 @@ func zcodeParseToolCall(block gjson.Result) (ParsedToolCall, bool) {
 			call.SkillName = input.Get("name").Str
 		}
 	default:
-		call.SkillName = inferToolSkillName(name, inputJSON)
+		call.SkillName = inferToolSkillName(ctx, name, inputJSON)
 	}
 	return call, true
 }
@@ -721,8 +750,10 @@ func zcodeParseToolResult(block gjson.Result) (ParsedToolResult, bool) {
 	return ParsedToolResult{}, false
 }
 
-func zcodeTableHasColumn(db *sql.DB, table, column string) (bool, error) {
-	rows, err := db.Query(`PRAGMA table_info(` + table + `)`)
+func zcodeTableHasColumn(
+	ctx context.Context, db *sql.DB, table, column string,
+) (bool, error) {
+	rows, err := db.QueryContext(ctx, `PRAGMA table_info(`+table+`)`)
 	if err != nil {
 		return false, fmt.Errorf("listing zcode table info for %s: %w", table, err)
 	}
@@ -753,11 +784,12 @@ func zcodeTableHasColumn(db *sql.DB, table, column string) (bool, error) {
 }
 
 func listZCodeUsageEvents(
+	ctx context.Context,
 	db *sql.DB,
 	sessionID string,
 	startedAt, endedAt time.Time,
 ) ([]ParsedUsageEvent, error) {
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT session_id,
 		       CAST(turn_id AS TEXT),
 		       provider_id,
@@ -907,11 +939,18 @@ func zcodeUsageTime(raw string) time.Time {
 	return zcodeParseTime(raw)
 }
 
-func zcodeSessionFileMtime(dbPath string, db *sql.DB, row zcodeSessionRow) int64 {
+func zcodeSessionFileMtime(
+	ctx context.Context, dbPath string, db *sql.DB, row zcodeSessionRow,
+) (int64, error) {
 	maxMtime := zcodeTimeUnixNano(zcodeRowUpdatedAt(row))
-	if usageMtime, err := zcodeMaxUsageMtime(db, row.id); err == nil {
+	usageMtime, err := zcodeMaxUsageMtime(ctx, db, row.id)
+	if err == nil {
 		maxMtime = max(maxMtime, usageMtime)
+	} else if ctx.Err() != nil {
+		return 0, ctx.Err()
 	}
+	// Usage read failures belong to per-session parsing, not discovery of the
+	// whole container. Preserve the session and physical database mtimes.
 	// The -shm index is excluded on purpose: readers rewrite it, this
 	// provider's own read connection included, so folding its mtime into the
 	// fingerprint made every scan report the whole container as changed.
@@ -921,11 +960,13 @@ func zcodeSessionFileMtime(dbPath string, db *sql.DB, row zcodeSessionRow) int64
 			maxMtime = max(maxMtime, info.ModTime().UnixNano())
 		}
 	}
-	return maxMtime
+	return maxMtime, nil
 }
 
-func zcodeMaxUsageMtime(db *sql.DB, sessionID string) (int64, error) {
-	rows, err := db.Query(`
+func zcodeMaxUsageMtime(
+	ctx context.Context, db *sql.DB, sessionID string,
+) (int64, error) {
+	rows, err := db.QueryContext(ctx, `
 		SELECT CAST(COALESCE(completed_at, '') AS TEXT),
 		       CAST(COALESCE(started_at, '') AS TEXT)
 		  FROM model_usage

--- a/internal/parser/zcode_test.go
+++ b/internal/parser/zcode_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -214,6 +214,112 @@ func TestZCodeParsesReportedIntegerTimestamps(t *testing.T) {
 	assert.Equal(t, int64(1783352401000000000), outcome.Results[0].Result.Session.StartedAt.UnixNano())
 	assert.Equal(t, int64(1783352700000000000), outcome.Results[0].Result.Session.EndedAt.UnixNano())
 	assert.Equal(t, int64(1783352700000000000), outcome.Results[0].Result.Session.File.Mtime)
+}
+
+func TestZCodeProviderFindsRawDatabaseInDirectRoot(t *testing.T) {
+	// A materialized raw snapshot places db.sqlite directly inside the given
+	// root, so stable-snapshot root normalization must accept that layout
+	// instead of always appending a "db" child.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ZCodeDBName), []byte("sqlite\n"), 0o600,
+	))
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:                 []string{dir},
+		StableSourceSnapshots: true,
+	})
+	require.True(t, ok)
+
+	discovery, err := DiscoverRawCaptureSources(t.Context(), provider)
+
+	require.NoError(t, err)
+	require.True(t, discovery.Complete)
+	require.Len(t, discovery.Sources, 1)
+	assert.Equal(t, ZCodeDBName, discovery.Sources[0].Key)
+	assert.Equal(t, filepath.Join(dir, ZCodeDBName), discovery.Sources[0].DisplayPath)
+}
+
+func TestZCodeDiscoveryPreservesSessionsWhenUsageTableCorrupt(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(t, "readable", "/work/app", "Readable session",
+		1700000000, 1700000001, "", "")
+	// Keep the producer schema and session data intact while damaging the
+	// usage table's page. Discovery must retain session identities; the usage
+	// failure belongs to parsing each source, as in ordinary local sync.
+	var page, pageSize int
+	require.NoError(t, fixture.database.QueryRow(
+		"SELECT rootpage FROM sqlite_schema WHERE name = 'model_usage'",
+	).Scan(&page))
+	require.NoError(t, fixture.database.QueryRow("PRAGMA page_size").Scan(&pageSize))
+	require.NoError(t, fixture.database.Close())
+	contents, err := os.ReadFile(fixture.DBPath)
+	require.NoError(t, err)
+	contents[(page-1)*pageSize] = 0
+	require.NoError(t, os.WriteFile(fixture.DBPath, contents, 0o600))
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{Roots: []string{fixture.CLIRoot}})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, fixture.DBPath+"#readable", sources[0].DisplayPath)
+	fingerprint, err := provider.Fingerprint(t.Context(), sources[0])
+	require.NoError(t, err)
+	assert.NotZero(t, fingerprint.MTimeNS)
+	_, err = provider.Parse(t.Context(), ParseRequest{Source: sources[0], Fingerprint: fingerprint})
+	var sqliteErr sqlite3.Error
+	require.ErrorAs(t, err, &sqliteErr)
+	assert.Equal(t, sqlite3.ErrCorrupt, sqliteErr.Code)
+}
+
+func TestZCodeConfiguredRootKeepsEstablishedDBLayoutPrecedence(t *testing.T) {
+	// A configured root that carries both a stray top-level db.sqlite and the
+	// established db/db.sqlite layout must keep resolving to db/db.sqlite:
+	// direct-root acceptance exists only for hosted stable snapshots.
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "db"), 0o755))
+	directPath := filepath.Join(root, ZCodeDBName)
+	establishedPath := filepath.Join(root, "db", ZCodeDBName)
+	require.NoError(t, os.WriteFile(directPath, []byte("direct"), 0o600))
+	db, err := sql.Open("sqlite3", establishedPath)
+	require.NoError(t, err)
+	_, err = db.Exec(zcodeTestSchema)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		INSERT INTO session (id, project_id, workspace_id, directory, title,
+			time_created, time_updated)
+		VALUES ('session-001', NULL, NULL, '/work/app', 'Established',
+			'2026-07-06T13:00:01Z', '2026-07-06T13:05:00Z')`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: sources[0], Machine: "devbox",
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, "zcode:session-001", outcome.Results[0].Result.Session.ID,
+		"discovery must use the established db/db.sqlite, not the stray top-level copy")
+}
+
+func TestZCodeConfiguredRootWithoutDBDirKeepsAppendingDB(t *testing.T) {
+	// Without the stable-snapshot flag a root that only carries a stray
+	// top-level database keeps the historical mapping onto root/db, so local
+	// discovery behavior is unchanged by the hosted direct-root support.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ZCodeDBName), []byte("not a sqlite database"), 0o600,
+	))
+
+	assert.Equal(t, filepath.Join(root, "db"), normalizeZCodeRoot(root, false))
+	assert.Equal(t, root, normalizeZCodeRoot(root, true))
 }
 
 func TestZCodeProviderSourceMethodsAndParse(t *testing.T) {
@@ -530,7 +636,7 @@ func TestZCodeIngestsTranscriptMessages(t *testing.T) {
 		`{"type":"text","text":"I'll inspect the auth flow."}`,
 	)
 
-	result, err := parseZCodeSession(fixture.DBPath, "session-transcript", "devbox")
+	result, err := parseZCodeSession(t.Context(), fixture.DBPath, "session-transcript", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, 2, result.Session.MessageCount)
@@ -590,7 +696,7 @@ func TestZCodeToolCallsAndResults(t *testing.T) {
 		`{"type":"tool_result","tool_use_id":"call-read","content":"package auth"}`,
 	)
 
-	result, err := parseZCodeSession(fixture.DBPath, "session-tools", "devbox")
+	result, err := parseZCodeSession(t.Context(), fixture.DBPath, "session-tools", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Messages, 2)
@@ -670,7 +776,7 @@ func TestZCodeOpenCodeStyleReasoningAndToolParts(t *testing.T) {
 		`{"type":"tool","tool":"Read","callID":"call-read","state":{"input":{"file_path":"auth.go"},"output":"package auth"}}`,
 	)
 
-	result, err := parseZCodeSession(fixture.DBPath, "session-opencode-parts", "devbox")
+	result, err := parseZCodeSession(t.Context(), fixture.DBPath, "session-opencode-parts", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Messages, 2)
@@ -723,7 +829,7 @@ func TestZCodeOpenCodeStyleFailedToolPart(t *testing.T) {
 		`{"type":"tool","tool":"Read","callID":"call-read","state":{"input":{"file_path":"auth.go"},"error":"permission denied"}}`,
 	)
 
-	result, err := parseZCodeSession(fixture.DBPath, "session-tool-error", "devbox")
+	result, err := parseZCodeSession(t.Context(), fixture.DBPath, "session-tool-error", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Messages, 1)
@@ -965,7 +1071,7 @@ func TestZCodeMissingTranscriptTables(t *testing.T) {
 		2,
 	)
 
-	result, err := parseZCodeSession(fixture.DBPath, "session-no-transcript", "devbox")
+	result, err := parseZCodeSession(t.Context(), fixture.DBPath, "session-no-transcript", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, 0, result.Session.MessageCount)
@@ -1025,7 +1131,7 @@ func TestZCodeSystemMessagesAreMarkedSystem(t *testing.T) {
 		`{"type":"text","text":"You are a code reviewer."}`,
 	)
 
-	result, err := parseZCodeSession(fixture.DBPath, "session-system", "devbox")
+	result, err := parseZCodeSession(t.Context(), fixture.DBPath, "session-system", "devbox", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Messages, 1)

--- a/internal/postgres/raw_derive_pipeline_pgtest_test.go
+++ b/internal/postgres/raw_derive_pipeline_pgtest_test.go
@@ -1,0 +1,158 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/artifact"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawcapture"
+	"go.kenn.io/agentsview/internal/rawcheckpoint"
+	"go.kenn.io/agentsview/internal/rawderive"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestRawCapturedSourcesReachHostedWorker(t *testing.T) {
+	for _, agent := range []parser.AgentType{parser.AgentClaude, parser.AgentZCode} {
+		t.Run(string(agent), func(t *testing.T) {
+			pg, metadata := newRawIngestTestStore(t)
+			identity := rawIngestIdentity(t, "tenant-a")
+			root := t.TempDir()
+			if agent == parser.AgentClaude {
+				contents, err := os.ReadFile("../parser/testdata/claude/valid_session.jsonl")
+				require.NoError(t, err)
+				project := filepath.Join(root, "project")
+				require.NoError(t, os.Mkdir(project, 0o700))
+				require.NoError(t, os.WriteFile(filepath.Join(project, "session.jsonl"), contents, 0o600))
+			} else {
+				dbDir := filepath.Join(root, "db")
+				require.NoError(t, os.Mkdir(dbDir, 0o700))
+				sourceDB, err := sql.Open("sqlite3", filepath.Join(dbDir, parser.ZCodeDBName))
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, sourceDB.Close()) })
+				_, err = sourceDB.Exec(`
+					PRAGMA journal_mode = WAL;
+					CREATE TABLE session (
+						id TEXT PRIMARY KEY, project_id TEXT, workspace_id TEXT,
+						directory TEXT, title TEXT, time_created INTEGER, time_updated INTEGER
+					);
+					CREATE TABLE message (
+						id TEXT PRIMARY KEY, session_id TEXT, time_created TEXT, data TEXT
+					);
+					CREATE TABLE part (
+						id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created TEXT, data TEXT
+					);
+					INSERT INTO session VALUES (
+						'session-a', NULL, NULL, '/workspace/project', 'Captured session',
+						1783339200000, 1783339260000
+					);
+					INSERT INTO message VALUES (
+						'message-a', 'session-a', '2026-07-06T12:00:01Z', '{"role":"user"}'
+					);
+					INSERT INTO part VALUES (
+						'part-a', 'message-a', 'session-a', '2026-07-06T12:00:01Z',
+						'{"type":"text","text":"Fix the login bug"}'
+					);
+				`)
+				require.NoError(t, err)
+			}
+			provider, ok := parser.NewProvider(agent, parser.ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			sources, err := parser.DiscoverRawCaptureSources(t.Context(), provider)
+			require.NoError(t, err)
+			require.True(t, sources.Complete)
+			require.Len(t, sources.Sources, 1)
+			checkpointDir := t.TempDir()
+			checkpoint, err := rawcheckpoint.OpenWithOptions(t.Context(), filepath.Join(checkpointDir, "checkpoint.db"), rawcheckpoint.Options{
+				SpoolDir: filepath.Join(checkpointDir, "spool"), MaxOutboxBytes: 1 << 20,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, checkpoint.Close()) })
+			require.NoError(t, checkpoint.SetDevice(t.Context(), identity.DeviceID))
+			capture, err := rawcapture.New(checkpoint).Capture(t.Context(), provider, sources.Sources[0])
+			require.NoError(t, err)
+			require.Equal(t, rawcapture.StatusCaptured, capture.Status)
+			manifest, found, err := checkpoint.FinalizeNextManifest(t.Context(), identity.DeviceID)
+			require.NoError(t, err)
+			require.True(t, found)
+
+			repository, err := artifact.OpenRepository(t.Context(), t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, repository.Close()) })
+			objects, err := rawsync.NewArtifactObjectStore(repository.Content())
+			require.NoError(t, err)
+			limits := rawsync.DefaultManifestLimits()
+			service, err := rawsync.NewService(objects, metadata, limits, "parser-data-17")
+			require.NoError(t, err)
+			for _, entry := range manifest.Entries {
+				for _, object := range entry.Objects {
+					file, err := os.Open(checkpoint.ObjectPath(object))
+					require.NoError(t, err)
+					_, uploadErr := service.FinalizeObject(t.Context(), identity, agent, object, file)
+					require.NoError(t, file.Close())
+					require.NoError(t, uploadErr)
+				}
+			}
+			commit, err := service.CommitManifest(t.Context(), identity, manifest)
+			require.NoError(t, err)
+			dispatch, err := rawderive.NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+			require.NoError(t, err)
+			materializationDir := t.TempDir()
+			sink := &rawParseRecordingSink{store: metadata}
+			worker, err := rawderive.NewWorker(rawderive.WorkerConfig{
+				Queue: metadata, Manifests: rawderive.ManifestLoader{Store: objects, Limits: limits},
+				Materializer: rawderive.Materializer{Store: objects, BaseDir: materializationDir, MaxTotalBytes: 1 << 20},
+				Parser:       dispatch, Projection: sink, Owner: "worker-a", BatchSize: 1,
+				LeaseDuration: time.Minute, HeartbeatInterval: 10 * time.Second, AttemptTimeout: time.Minute,
+				RetryBase: time.Second, RetryMax: time.Minute, MaxAttempts: 3,
+			})
+			require.NoError(t, err)
+
+			result, err := worker.RunBatch(t.Context())
+
+			require.NoError(t, err)
+			assert.Equal(t, rawderive.BatchResult{Claimed: 1, Succeeded: 1}, result)
+			require.Len(t, sink.parsed.Outcome.Results, 1)
+			assert.Empty(t, sink.parsed.Outcome.SourceErrors)
+			parsed := sink.parsed.Outcome.Results[0].Result
+			require.NotNil(t, parsed.Session)
+			assert.Equal(t, agent, parsed.Session.Agent)
+			require.NotEmpty(t, parsed.Messages)
+			assert.Equal(t, "Fix the login bug", parsed.Messages[0].Content)
+			var state string
+			require.NoError(t, pg.QueryRowContext(t.Context(),
+				`SELECT state FROM raw_ingest_jobs WHERE manifest_id = $1`, commit.ManifestID,
+			).Scan(&state))
+			assert.Equal(t, "complete", state)
+			remaining, err := os.ReadDir(materializationDir)
+			require.NoError(t, err)
+			assert.Empty(t, remaining, "the worker must remove the captured source tree")
+		})
+	}
+}
+
+// The production projection is a later layer. Record its input while using
+// the real lease-completion fence; this test stops at that boundary.
+type rawParseRecordingSink struct {
+	store  *RawIngestStore
+	parsed rawderive.ParsedManifest
+}
+
+func (s *rawParseRecordingSink) Project(
+	ctx context.Context, lease rawderive.JobLease, _ rawsync.CanonicalManifest, parsed rawderive.ParsedManifest,
+) error {
+	if err := s.store.CompleteRawParseJob(ctx, lease); err != nil {
+		return err
+	}
+	s.parsed = parsed
+	return nil
+}

--- a/internal/postgres/raw_ingest_custody_pgtest_test.go
+++ b/internal/postgres/raw_ingest_custody_pgtest_test.go
@@ -124,13 +124,18 @@ func TestRawCustodyEndToEnd(t *testing.T) {
 	assert.Equal(t, "snapshot", storedKind)
 	assert.Equal(t, int64(2), storedGeneration)
 
-	var exactJobs int
+	var readyJobs, supersededJobs int
 	require.NoError(t, pg.QueryRowContext(t.Context(), `
-		SELECT count(*) FROM raw_ingest_jobs
-		WHERE stage = 'parse' AND state = 'ready'
-			AND processing_version = 'parser-data-17'`,
-	).Scan(&exactJobs))
-	assert.Equal(t, 2, exactJobs)
+		SELECT
+			COUNT(*) FILTER (WHERE state = 'ready'),
+			COUNT(*) FILTER (WHERE state = 'superseded')
+		FROM raw_ingest_jobs
+		WHERE stage = 'parse' AND processing_version = 'parser-data-17'`,
+	).Scan(&readyJobs, &supersededJobs))
+	assert.Equal(t, 1, readyJobs,
+		"only the current head's parse job stays ready")
+	assert.Equal(t, 1, supersededJobs,
+		"advancing the head retires the prior parse job immediately")
 
 	var storedPath, storedEntryType string
 	var storedLength int64

--- a/internal/postgres/raw_ingest_schema.go
+++ b/internal/postgres/raw_ingest_schema.go
@@ -265,7 +265,9 @@ WITH required_table_privileges(table_name, privilege) AS (
         ('raw_source_heads', 'SELECT'),
         ('raw_source_heads', 'INSERT'),
         ('raw_source_heads', 'UPDATE'),
-        ('raw_ingest_jobs', 'INSERT')
+        ('raw_ingest_jobs', 'SELECT'),
+        ('raw_ingest_jobs', 'INSERT'),
+        ('raw_ingest_jobs', 'UPDATE')
 ), job_table(table_name, table_ref) AS (
     SELECT
         format('%I.%I', $1::text, 'raw_ingest_jobs'),
@@ -277,22 +279,24 @@ WITH required_table_privileges(table_name, privilege) AS (
     END
     FROM job_table
 )
-SELECT
-    COALESCE(current_setting('transaction_read_only', true), 'off') <> 'on'
-    AND COALESCE(bool_and(
-        to_regclass(format('%I.%I', $1::text, table_name)) IS NOT NULL
-        AND has_table_privilege(
-            current_user,
-            to_regclass(format('%I.%I', $1::text, table_name)),
-            privilege
-        )
+SELECT COALESCE(string_agg(reason, ', ' ORDER BY reason), '')
+FROM (
+    SELECT privilege || ' ON ' || table_name AS reason
+    FROM required_table_privileges
+    WHERE NOT COALESCE(has_table_privilege(
+        current_user,
+        to_regclass(format('%I.%I', $1::text, table_name)),
+        privilege
     ), false)
-    AND COALESCE((
-        SELECT sequence_name IS NULL
-            OR has_sequence_privilege(current_user, sequence_name, 'USAGE')
-        FROM job_sequence
-    ), false)
-FROM required_table_privileges`
+    UNION ALL
+    SELECT 'USAGE ON raw_ingest_jobs ID sequence'
+    FROM job_sequence
+    WHERE sequence_name IS NOT NULL
+        AND NOT has_sequence_privilege(current_user, sequence_name, 'USAGE')
+    UNION ALL
+    SELECT 'writable transaction (transaction_read_only is on)'
+    WHERE current_setting('transaction_read_only', true) = 'on'
+) AS missing_privileges`
 
 // CanWriteRawSyncSchema reports whether the current role can use every table
 // and any owned sequence required by the raw-sync control plane. It deliberately
@@ -307,11 +311,14 @@ func CanWriteRawSyncSchema(
 	if strings.TrimSpace(schema) == "" {
 		return false, errors.New("raw sync write probe requires a schema")
 	}
-	var writable bool
-	if err := db.QueryRowContext(ctx, rawSyncWritePrivilegeSQL, schema).Scan(&writable); err != nil {
+	var missing string
+	if err := db.QueryRowContext(ctx, rawSyncWritePrivilegeSQL, schema).Scan(&missing); err != nil {
 		return false, fmt.Errorf("probing raw sync write privileges: %w", err)
 	}
-	return writable, nil
+	if missing != "" {
+		log.Printf("pg serve: raw-sync routes disabled; missing requirements: %s", missing)
+	}
+	return missing == "", nil
 }
 
 func ensureRawIngestSchemaPG(ctx context.Context, db *sql.DB) error {

--- a/internal/postgres/raw_ingest_schema_pgtest_test.go
+++ b/internal/postgres/raw_ingest_schema_pgtest_test.go
@@ -3,7 +3,9 @@
 package postgres
 
 import (
+	"bytes"
 	"database/sql"
+	"log"
 	"net/url"
 	"strings"
 	"testing"
@@ -342,7 +344,18 @@ func TestCanWriteRawSyncSchemaRequiresExactRuntimePrivileges(t *testing.T) {
 	require.NoError(t, err, "Open runtime role")
 	t.Cleanup(func() { _ = restricted.Close() })
 
+	var output bytes.Buffer
+	previousOutput := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(previousOutput) })
 	writable, err := CanWriteRawSyncSchema(t.Context(), restricted, schema)
+	require.NoError(t, err)
+	assert.False(t, writable, "the prior insert-only job grants disable raw-sync routes")
+	assert.Contains(t, output.String(), "raw-sync routes disabled; missing requirements: SELECT ON raw_ingest_jobs, UPDATE ON raw_ingest_jobs")
+
+	_, err = admin.Exec(`GRANT SELECT, UPDATE ON ` + schema + `.raw_ingest_jobs TO ` + role)
+	require.NoError(t, err)
+	writable, err = CanWriteRawSyncSchema(t.Context(), restricted, schema)
 	require.NoError(t, err)
 	assert.True(t, writable)
 
@@ -367,7 +380,9 @@ func TestCanWriteRawSyncSchemaRequiresExactRuntimePrivileges(t *testing.T) {
 		{"raw_source_heads", "SELECT"},
 		{"raw_source_heads", "INSERT"},
 		{"raw_source_heads", "UPDATE"},
+		{"raw_ingest_jobs", "SELECT"},
 		{"raw_ingest_jobs", "INSERT"},
+		{"raw_ingest_jobs", "UPDATE"},
 	}
 	for _, required := range requiredTablePrivileges {
 		t.Run(required.table+"_"+strings.ToLower(required.privilege), func(t *testing.T) {

--- a/internal/postgres/raw_ingest_store.go
+++ b/internal/postgres/raw_ingest_store.go
@@ -114,7 +114,11 @@ func (s *RawIngestStore) MissingObjects(
 	return missing, nil
 }
 
-// CommitManifest atomically records a manifest, advances its head, and queues parsing.
+// CommitManifest atomically records a manifest, advances its head, queues
+// parsing, and supersedes one prior-head nonterminal parse job so stale
+// prefixes never accumulate behind the current head. Legacy duplicate
+// processing versions for the prior head stay nonterminal here and drain
+// through the bounded claim-time supersession fallback.
 func (s *RawIngestStore) CommitManifest(
 	ctx context.Context,
 	manifest rawsync.CanonicalManifest,
@@ -245,6 +249,38 @@ func (s *RawIngestStore) CommitManifest(
 	}
 	if affected != 1 {
 		return rawsync.CommitResult{}, fmt.Errorf("advancing raw source head affected %d rows", affected)
+	}
+	if head.ManifestID != "" {
+		// The unique key permits legacy rows with several processing versions
+		// per manifest, so supersede exactly one deterministic candidate per
+		// advance and leave the remaining duplicates to the bounded fallback.
+		// We intentionally rely on the outer UPDATE's nonterminal-state
+		// predicate rather than a FOR UPDATE lock: under READ COMMITTED, when
+		// this statement waits on the candidate's row lock, EvalPlanQual
+		// rechecks the WHERE clause against the newest committed version, so
+		// a candidate completed or failed by a concurrent lease transition is
+		// skipped instead of overwritten, and the remaining obsolete rows are
+		// handled by the bounded claim-time fallback.
+		if _, err := tx.ExecContext(ctx, `
+			WITH candidate AS (
+				SELECT job.id
+				FROM raw_ingest_jobs AS job
+				WHERE job.tenant_id = $1 AND job.manifest_id = $2
+					AND job.stage = 'parse'
+					AND job.state IN ('ready', 'retrying', 'leased')
+				ORDER BY job.id
+				LIMIT 1
+			)
+			UPDATE raw_ingest_jobs AS job
+			SET state = 'superseded', lease_owner = '', lease_expires_at = NULL,
+				updated_at = now()
+			FROM candidate
+			WHERE job.id = candidate.id
+				AND job.state IN ('ready', 'retrying', 'leased')`,
+			manifest.Identity.TenantID, head.ManifestID,
+		); err != nil {
+			return rawsync.CommitResult{}, fmt.Errorf("superseding prior raw parse job: %w", err)
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return rawsync.CommitResult{}, fmt.Errorf("committing raw manifest: %w", err)

--- a/internal/postgres/raw_ingest_store_pgtest_test.go
+++ b/internal/postgres/raw_ingest_store_pgtest_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawderive"
 	"go.kenn.io/agentsview/internal/rawsync"
 )
 
@@ -138,6 +139,274 @@ func TestRawIngestStoreCommitIsAtomicFencedAndIdempotent(t *testing.T) {
 	assert.Equal(t, second.ManifestID, headManifest)
 	assert.Equal(t, second.Receipt, headReceipt)
 	assert.Equal(t, int64(2), generation)
+}
+
+func TestRawIngestStoreCommitSupersedesPriorHeadParseJob(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	firstManifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	first, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+	require.NoError(t, err)
+	secondManifest := rawIngestManifest(
+		t, identity, "capture-b", first.Receipt,
+		rawIngestCapturedAt().Add(time.Minute), object,
+	)
+	second, err := store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+	require.NoError(t, err)
+
+	priorState, priorOwner, priorExpiry := readRawParseJob(
+		t, pg, identity.TenantID, firstManifest.ManifestID,
+	)
+	assert.Equal(t, "superseded", priorState,
+		"advancing a source head must retire its prior ready parse job in the commit itself")
+	assert.Empty(t, priorOwner)
+	assert.False(t, priorExpiry.Valid)
+	headState, _, _ := readRawParseJob(
+		t, pg, identity.TenantID, secondManifest.ManifestID,
+	)
+	assert.Equal(t, "ready", headState,
+		"the new current-head parse job must stay claimable")
+
+	// Terminal jobs must survive later head advances untouched.
+	lease := claimOneRawParseJob(t, store)
+	assert.Equal(t, secondManifest.ManifestID, lease.ManifestID)
+	require.NoError(t, store.CompleteRawParseJob(t.Context(), lease))
+	thirdManifest := rawIngestManifest(
+		t, identity, "capture-c", second.Receipt,
+		rawIngestCapturedAt().Add(2*time.Minute), object,
+	)
+	_, err = store.CommitManifest(t.Context(), thirdManifest, "parser-data-17")
+	require.NoError(t, err)
+	completedState, _, _ := readRawParseJob(
+		t, pg, identity.TenantID, secondManifest.ManifestID,
+	)
+	assert.Equal(t, "complete", completedState,
+		"a terminal prior job must never be rewritten by a later head advance")
+	thirdState, _, _ := readRawParseJob(
+		t, pg, identity.TenantID, thirdManifest.ManifestID,
+	)
+	assert.Equal(t, "ready", thirdState)
+}
+
+func TestRawIngestStoreCommitFencesLeasedPriorHeadParseJob(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	firstManifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	first, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+	require.NoError(t, err)
+	lease := claimOneRawParseJob(t, store)
+
+	secondManifest := rawIngestManifest(
+		t, identity, "capture-b", first.Receipt,
+		rawIngestCapturedAt().Add(time.Minute), object,
+	)
+	_, err = store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+	require.NoError(t, err)
+
+	state, owner, expiry := readRawParseJob(
+		t, pg, identity.TenantID, firstManifest.ManifestID,
+	)
+	assert.Equal(t, "superseded", state,
+		"an advancing head must fence a leased prior job immediately")
+	assert.Empty(t, owner)
+	assert.False(t, expiry.Valid)
+	err = store.CompleteRawParseJob(t.Context(), lease)
+	assert.ErrorIs(t, err, rawderive.ErrLeaseLost)
+	err = store.RetryRawParseJob(
+		t.Context(), lease, time.Now().Add(time.Minute), "object_store", "fenced",
+	)
+	assert.ErrorIs(t, err, rawderive.ErrLeaseLost)
+}
+
+func TestRawIngestStoreCommitDoesNotOverwriteTerminalPriorHeadJobAfterWait(
+	t *testing.T,
+) {
+	for _, terminal := range []string{"complete", "failed"} {
+		t.Run(terminal, func(t *testing.T) {
+			pg, store := newRawIngestTestStore(t)
+			identity := rawIngestIdentity(t, "tenant-a")
+			object := rawIngestObject(t, "a", 7)
+			require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+			firstManifest := rawIngestManifest(
+				t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+			)
+			first, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+			require.NoError(t, err)
+			lease := claimOneRawParseJob(t, store)
+
+			// A worker holds the leased prior-head job's row lock with the same
+			// guarded terminal transition CompleteRawParseJob and FailRawParseJob
+			// perform, but leaves it uncommitted so the commit below must wait.
+			worker, err := pg.BeginTx(t.Context(), nil)
+			require.NoError(t, err)
+			defer func() { _ = worker.Rollback() }()
+			_, err = worker.ExecContext(t.Context(), `
+				UPDATE raw_ingest_jobs AS job
+				SET state = $4, lease_owner = '', lease_expires_at = NULL,
+					updated_at = now()
+				WHERE job.id = $1 AND job.lease_owner = $2
+					AND job.attempt_count = $3
+					AND job.state = 'leased' AND job.lease_expires_at > now()
+					AND EXISTS (
+						SELECT 1
+						FROM raw_manifests AS manifest
+						JOIN raw_source_heads AS head
+							ON head.tenant_id = manifest.tenant_id
+							AND head.device_id = manifest.device_id
+							AND head.provider = manifest.provider
+							AND head.configured_root_id = manifest.configured_root_id
+							AND head.source_key_sha256 = manifest.source_key_sha256
+							AND head.manifest_id = manifest.manifest_id
+						WHERE manifest.tenant_id = job.tenant_id
+							AND manifest.manifest_id = job.manifest_id
+					)`,
+				lease.ID, lease.Owner, lease.Attempt, terminal,
+			)
+			require.NoError(t, err)
+
+			// The committing pool carries a distinct application name so the
+			// test can observe in pg_stat_activity exactly when its supersession
+			// statement starts waiting on the worker's row lock.
+			committerURL, err := appendConnParams(testPGURL(t), map[string]string{
+				"application_name": "raw-commit-supersession",
+			})
+			require.NoError(t, err)
+			committer, err := Open(committerURL, schemaTestSchema, true)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, committer.Close()) })
+			committerStore, err := NewRawIngestStore(committer)
+			require.NoError(t, err)
+
+			secondManifest := rawIngestManifest(
+				t, identity, "capture-b", first.Receipt,
+				rawIngestCapturedAt().Add(time.Minute), object,
+			)
+			commitDone := make(chan rawIngestOutcome, 1)
+			go func() {
+				result, err := committerStore.CommitManifest(
+					t.Context(), secondManifest, "parser-data-17",
+				)
+				commitDone <- rawIngestOutcome{result: result, err: err}
+			}()
+
+			// By the time the commit waits on a lock, its supersession statement
+			// has already qualified the leased prior-head row from its snapshot.
+			require.Eventually(t, func() bool {
+				var waiting int
+				err := pg.QueryRowContext(t.Context(), `
+					SELECT count(*)
+					FROM pg_stat_activity
+					WHERE application_name = 'raw-commit-supersession'
+					AND state = 'active' AND wait_event_type = 'Lock'`,
+				).Scan(&waiting)
+				return err == nil && waiting == 1
+			}, 10*time.Second, 10*time.Millisecond,
+				"commit supersession should wait behind the terminal prior-head update")
+
+			require.NoError(t, worker.Commit(), "releasing the terminal prior-head update")
+			var got rawIngestOutcome
+			select {
+			case got = <-commitDone:
+			case <-time.After(10 * time.Second):
+				t.Fatal("commit manifest never finished after the worker released the row")
+			}
+			require.NoError(t, got.err)
+			assert.True(t, got.result.Created)
+
+			state, owner, expiry := readRawParseJob(
+				t, pg, identity.TenantID, firstManifest.ManifestID,
+			)
+			assert.Equal(t, terminal, state,
+				"a job that reached a terminal state while the commit waited must never be rewritten as superseded")
+			assert.Empty(t, owner)
+			assert.False(t, expiry.Valid)
+			headState, _, _ := readRawParseJob(
+				t, pg, identity.TenantID, secondManifest.ManifestID,
+			)
+			assert.Equal(t, "ready", headState,
+				"the new current-head parse job must stay claimable")
+		})
+	}
+}
+
+func TestRawIngestStoreCommitSupersedesSingleLegacyPriorHeadJob(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	firstManifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	first, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+	require.NoError(t, err)
+
+	// The job unique key is (tenant, manifest, stage, processing_version), so
+	// a prior deployment can leave several nonterminal parse jobs behind for
+	// the same head manifest.
+	for _, version := range []string{"legacy-1", "legacy-2", "legacy-3"} {
+		_, err := pg.ExecContext(t.Context(), `
+			INSERT INTO raw_ingest_jobs (
+				tenant_id, manifest_id, stage, processing_version, state
+			) VALUES ($1, $2, 'parse', $3, 'ready')`,
+			identity.TenantID, firstManifest.ManifestID, version,
+		)
+		require.NoError(t, err)
+	}
+
+	secondManifest := rawIngestManifest(
+		t, identity, "capture-b", first.Receipt,
+		rawIngestCapturedAt().Add(time.Minute), object,
+	)
+	_, err = store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+	require.NoError(t, err)
+
+	var superseded, nonterminal int
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT
+			count(*) FILTER (WHERE state = 'superseded'),
+			count(*) FILTER (WHERE state IN ('ready', 'retrying', 'leased'))
+		FROM raw_ingest_jobs
+		WHERE tenant_id = $1 AND manifest_id = $2 AND stage = 'parse'`,
+		identity.TenantID, firstManifest.ManifestID,
+	).Scan(&superseded, &nonterminal))
+	assert.Equal(t, 1, superseded,
+		"a head advance must supersede exactly one prior-head job")
+	assert.Equal(t, 3, nonterminal,
+		"legacy duplicate prior-head jobs must stay nonterminal for the bounded fallback cleanup")
+
+	var supersededVersion string
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT processing_version FROM raw_ingest_jobs
+		WHERE tenant_id = $1 AND manifest_id = $2 AND stage = 'parse'
+			AND state = 'superseded'`,
+		identity.TenantID, firstManifest.ManifestID,
+	).Scan(&supersededVersion))
+	assert.Equal(t, "parser-data-17", supersededVersion,
+		"the deterministic candidate must be the lowest-id prior-head job")
+}
+
+func readRawParseJob(
+	t *testing.T,
+	pg *sql.DB,
+	tenantID string,
+	manifestID string,
+) (state string, leaseOwner string, leaseExpiresAt sql.NullTime) {
+	t.Helper()
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT state, lease_owner, lease_expires_at
+		FROM raw_ingest_jobs
+		WHERE tenant_id = $1 AND manifest_id = $2 AND stage = 'parse'`,
+		tenantID, manifestID,
+	).Scan(&state, &leaseOwner, &leaseExpiresAt))
+	return state, leaseOwner, leaseExpiresAt
 }
 
 func TestRawIngestStoreMissingObjectChangesNoAcceptanceState(t *testing.T) {

--- a/internal/postgres/raw_parse_jobs.go
+++ b/internal/postgres/raw_parse_jobs.go
@@ -1,0 +1,376 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/rawderive"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+const (
+	// maxRawParseSupersedeBatch bounds how many obsolete jobs one short claim
+	// may retire, so per-call mutation work stays bounded while a backlog
+	// drains across successive claims.
+	maxRawParseSupersedeBatch = 4 * rawderive.MaxClaimBatchSize
+)
+
+// ClaimRawParseJobs leases available current-head parse jobs without waiting on
+// jobs claimed concurrently by other workers. A claim that fills its whole
+// batch from current heads skips the obsolete-job cleanup scan entirely, so
+// draining a healthy backlog pays no head probes; only a claim that cannot
+// fill its batch runs the bounded cleanup.
+func (s *RawIngestStore) ClaimRawParseJobs(
+	ctx context.Context,
+	owner string,
+	limit int,
+	leaseDuration time.Duration,
+) ([]rawderive.JobLease, error) {
+	if err := validateRawParseLeaseRequest(owner, limit, leaseDuration); err != nil {
+		return nil, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("beginning raw parse job claim: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	rows, err := tx.QueryContext(ctx, `
+		WITH candidates AS (
+			SELECT job.id
+			FROM raw_ingest_jobs AS job
+			JOIN raw_manifests AS manifest
+				ON manifest.tenant_id = job.tenant_id
+				AND manifest.manifest_id = job.manifest_id
+			WHERE (
+				(job.state IN ('ready', 'retrying') AND job.available_at <= now())
+				OR (job.state = 'leased' AND job.lease_expires_at <= now())
+			)
+				AND job.stage = 'parse'
+				AND EXISTS (
+				SELECT 1
+				FROM raw_source_heads AS head
+				WHERE head.tenant_id = manifest.tenant_id
+					AND head.device_id = manifest.device_id
+					AND head.provider = manifest.provider
+					AND head.configured_root_id = manifest.configured_root_id
+					AND head.source_key_sha256 = manifest.source_key_sha256
+					AND head.manifest_id = manifest.manifest_id
+				)
+			ORDER BY job.available_at, job.id
+			LIMIT $1
+			FOR UPDATE OF job SKIP LOCKED
+		), claimed AS (
+			UPDATE raw_ingest_jobs AS job
+			SET state = 'leased', attempt_count = job.attempt_count + 1,
+				lease_owner = $2,
+				lease_expires_at = now() + ($3 * interval '1 microsecond'),
+				last_error_class = '', last_error = '', updated_at = now()
+			FROM candidates
+			WHERE job.id = candidates.id
+			RETURNING job.id, job.tenant_id, job.manifest_id,
+				job.processing_version, job.attempt_count, job.lease_owner,
+				job.lease_expires_at
+		)
+		SELECT claimed.id, claimed.tenant_id, manifest.device_id,
+			claimed.manifest_id, claimed.processing_version,
+			claimed.attempt_count, claimed.lease_owner, claimed.lease_expires_at
+		FROM claimed
+		JOIN raw_manifests AS manifest
+			ON manifest.tenant_id = claimed.tenant_id
+			AND manifest.manifest_id = claimed.manifest_id
+		ORDER BY claimed.id`,
+		limit, owner, leaseDuration.Microseconds(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("claiming raw parse jobs: %w", err)
+	}
+	leasing := make([]rawderive.JobLease, 0, limit)
+	for rows.Next() {
+		var lease rawderive.JobLease
+		if err := rows.Scan(
+			&lease.ID,
+			&lease.Identity.TenantID,
+			&lease.Identity.DeviceID,
+			&lease.ManifestID,
+			&lease.ProcessingVersion,
+			&lease.Attempt,
+			&lease.Owner,
+			&lease.ExpiresAt,
+		); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scanning raw parse job lease: %w", err)
+		}
+		leasing = append(leasing, lease)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("closing raw parse job leases: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading raw parse job leases: %w", err)
+	}
+	// The claim predicate above already refuses every obsolete row, so
+	// supersession only reclaims rows no claim could ever lease. Running it
+	// after a short claim keeps cleanup bounded without charging the common
+	// full-batch path for an O(backlog) head-probe scan.
+	if len(leasing) < limit {
+		if err := supersedeObsoleteRawParseJobs(
+			ctx, tx, maxRawParseSupersedeBatch,
+		); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing raw parse job claim: %w", err)
+	}
+	committed = true
+	return leasing, nil
+}
+
+// supersedeObsoleteRawParseJobs retires at most limit jobs whose manifest is
+// no longer the current source head. Each call performs bounded mutation
+// work: candidates are locked with FOR UPDATE OF obsolete SKIP LOCKED in a
+// deterministic id order — only the job rows being retired, never joined
+// manifest rows — so concurrent claims cooperate instead of piling up lock
+// traffic, and a large obsolete backlog drains across successive calls.
+func supersedeObsoleteRawParseJobs(
+	ctx context.Context,
+	tx *sql.Tx,
+	limit int,
+) error {
+	if _, err := tx.ExecContext(ctx, rawParseSupersedeSQL,
+		limit,
+	); err != nil {
+		return fmt.Errorf("superseding obsolete raw parse jobs: %w", err)
+	}
+	return nil
+}
+
+// Future retries stay outside the idle cleanup scan until they become due.
+const rawParseSupersedeSQL = `
+		UPDATE raw_ingest_jobs AS job
+		SET state = 'superseded', lease_owner = '', lease_expires_at = NULL,
+			updated_at = now()
+		WHERE job.id IN (
+			SELECT obsolete.id
+			FROM raw_ingest_jobs AS obsolete
+			JOIN raw_manifests AS manifest
+				ON manifest.tenant_id = obsolete.tenant_id
+				AND manifest.manifest_id = obsolete.manifest_id
+			WHERE (
+					(obsolete.state IN ('ready', 'retrying') AND obsolete.available_at <= now())
+					OR (obsolete.state = 'leased' AND obsolete.lease_expires_at <= now())
+			)
+				AND obsolete.stage = 'parse'
+				AND NOT EXISTS (
+					SELECT 1
+					FROM raw_source_heads AS head
+					WHERE head.tenant_id = manifest.tenant_id
+						AND head.device_id = manifest.device_id
+						AND head.provider = manifest.provider
+						AND head.configured_root_id = manifest.configured_root_id
+						AND head.source_key_sha256 = manifest.source_key_sha256
+						AND head.manifest_id = manifest.manifest_id
+				)
+			ORDER BY obsolete.id
+			LIMIT $1
+			FOR UPDATE OF obsolete SKIP LOCKED
+		)`
+
+// HeartbeatRawParseJob extends an active lease held by the current source head.
+func (s *RawIngestStore) HeartbeatRawParseJob(
+	ctx context.Context,
+	lease rawderive.JobLease,
+	leaseDuration time.Duration,
+) error {
+	if err := validateRawParseLease(lease); err != nil {
+		return err
+	}
+	if err := validateRawParseLeaseDuration(leaseDuration); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE raw_ingest_jobs AS job
+		SET lease_expires_at = now() + ($4 * interval '1 microsecond'),
+			updated_at = now()
+		WHERE job.id = $1 AND job.lease_owner = $2 AND job.attempt_count = $3
+			AND job.state = 'leased' AND job.lease_expires_at > now()
+			AND EXISTS (
+				SELECT 1
+				FROM raw_manifests AS manifest
+				JOIN raw_source_heads AS head
+					ON head.tenant_id = manifest.tenant_id
+					AND head.device_id = manifest.device_id
+					AND head.provider = manifest.provider
+					AND head.configured_root_id = manifest.configured_root_id
+					AND head.source_key_sha256 = manifest.source_key_sha256
+					AND head.manifest_id = manifest.manifest_id
+				WHERE manifest.tenant_id = job.tenant_id
+					AND manifest.manifest_id = job.manifest_id
+			)`,
+		lease.ID, lease.Owner, lease.Attempt, leaseDuration.Microseconds(),
+	)
+	if err != nil {
+		return fmt.Errorf("heartbeating raw parse job: %w", err)
+	}
+	return requireRawParseLeaseUpdate(result)
+}
+
+// CompleteRawParseJob marks an active current-head lease complete.
+func (s *RawIngestStore) CompleteRawParseJob(
+	ctx context.Context,
+	lease rawderive.JobLease,
+) error {
+	if err := validateRawParseLease(lease); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE raw_ingest_jobs AS job
+		SET state = 'complete', lease_owner = '', lease_expires_at = NULL,
+			last_error_class = '', last_error = '', updated_at = now()
+		WHERE job.id = $1 AND job.lease_owner = $2 AND job.attempt_count = $3
+			AND job.state = 'leased' AND job.lease_expires_at > now()
+			AND EXISTS (
+				SELECT 1
+				FROM raw_manifests AS manifest
+				JOIN raw_source_heads AS head
+					ON head.tenant_id = manifest.tenant_id
+					AND head.device_id = manifest.device_id
+					AND head.provider = manifest.provider
+					AND head.configured_root_id = manifest.configured_root_id
+					AND head.source_key_sha256 = manifest.source_key_sha256
+					AND head.manifest_id = manifest.manifest_id
+				WHERE manifest.tenant_id = job.tenant_id
+					AND manifest.manifest_id = job.manifest_id
+			)`,
+		lease.ID, lease.Owner, lease.Attempt,
+	)
+	if err != nil {
+		return fmt.Errorf("completing raw parse job: %w", err)
+	}
+	return requireRawParseLeaseUpdate(result)
+}
+
+// RetryRawParseJob releases an active lease for a later attempt.
+func (s *RawIngestStore) RetryRawParseJob(
+	ctx context.Context,
+	lease rawderive.JobLease,
+	availableAt time.Time,
+	errorClass string,
+	message string,
+) error {
+	if err := validateRawParseLease(lease); err != nil {
+		return err
+	}
+	if availableAt.IsZero() {
+		return fmt.Errorf("%w: retry time is required", rawsync.ErrInvalid)
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE raw_ingest_jobs AS job
+		SET state = 'retrying', available_at = $4, lease_owner = '',
+			lease_expires_at = NULL, last_error_class = $5, last_error = $6,
+			updated_at = now()
+		WHERE job.id = $1 AND job.lease_owner = $2 AND job.attempt_count = $3
+			AND job.state = 'leased' AND job.lease_expires_at > now()
+			AND EXISTS (
+				SELECT 1
+				FROM raw_manifests AS manifest
+				JOIN raw_source_heads AS head
+					ON head.tenant_id = manifest.tenant_id
+					AND head.device_id = manifest.device_id
+					AND head.provider = manifest.provider
+					AND head.configured_root_id = manifest.configured_root_id
+					AND head.source_key_sha256 = manifest.source_key_sha256
+					AND head.manifest_id = manifest.manifest_id
+				WHERE manifest.tenant_id = job.tenant_id
+					AND manifest.manifest_id = job.manifest_id
+			)`,
+		lease.ID, lease.Owner, lease.Attempt, availableAt.UTC(), errorClass, message,
+	)
+	if err != nil {
+		return fmt.Errorf("retrying raw parse job: %w", err)
+	}
+	return requireRawParseLeaseUpdate(result)
+}
+
+// FailRawParseJob moves an active current-head lease into durable terminal
+// failure for operator inspection.
+func (s *RawIngestStore) FailRawParseJob(
+	ctx context.Context,
+	lease rawderive.JobLease,
+	errorClass string,
+	message string,
+) error {
+	if err := validateRawParseLease(lease); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE raw_ingest_jobs AS job
+		SET state = 'failed', lease_owner = '', lease_expires_at = NULL,
+			last_error_class = $4, last_error = $5, updated_at = now()
+		WHERE job.id = $1 AND job.lease_owner = $2 AND job.attempt_count = $3
+			AND job.state = 'leased' AND job.lease_expires_at > now()
+			AND EXISTS (
+				SELECT 1
+				FROM raw_manifests AS manifest
+				JOIN raw_source_heads AS head
+					ON head.tenant_id = manifest.tenant_id
+					AND head.device_id = manifest.device_id
+					AND head.provider = manifest.provider
+					AND head.configured_root_id = manifest.configured_root_id
+					AND head.source_key_sha256 = manifest.source_key_sha256
+					AND head.manifest_id = manifest.manifest_id
+				WHERE manifest.tenant_id = job.tenant_id
+					AND manifest.manifest_id = job.manifest_id
+			)`,
+		lease.ID, lease.Owner, lease.Attempt, errorClass, message,
+	)
+	if err != nil {
+		return fmt.Errorf("failing raw parse job: %w", err)
+	}
+	return requireRawParseLeaseUpdate(result)
+}
+
+func validateRawParseLeaseRequest(owner string, limit int, duration time.Duration) error {
+	if !rawderive.ValidLeaseOwner(owner) {
+		return fmt.Errorf("%w: parse lease owner is invalid", rawsync.ErrInvalid)
+	}
+	if limit <= 0 || limit > rawderive.MaxClaimBatchSize {
+		return fmt.Errorf("%w: parse claim limit must be between 1 and %d",
+			rawsync.ErrInvalid, rawderive.MaxClaimBatchSize)
+	}
+	return validateRawParseLeaseDuration(duration)
+}
+
+func validateRawParseLeaseDuration(duration time.Duration) error {
+	if duration <= 0 || duration.Microseconds() <= 0 {
+		return fmt.Errorf("%w: lease duration must be positive", rawsync.ErrInvalid)
+	}
+	return nil
+}
+
+func validateRawParseLease(lease rawderive.JobLease) error {
+	if lease.ID <= 0 || lease.Attempt <= 0 || strings.TrimSpace(lease.Owner) == "" {
+		return fmt.Errorf("%w: parse job lease is invalid", rawsync.ErrInvalid)
+	}
+	return nil
+}
+
+func requireRawParseLeaseUpdate(result sql.Result) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking raw parse job lease update: %w", err)
+	}
+	if affected != 1 {
+		return rawderive.ErrLeaseLost
+	}
+	return nil
+}

--- a/internal/postgres/raw_parse_jobs_pgtest_test.go
+++ b/internal/postgres/raw_parse_jobs_pgtest_test.go
@@ -1,0 +1,627 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"database/sql"
+	"encoding/json/v2"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/rawderive"
+)
+
+func TestRawParseJobsLeaseExclusivelyAndFenceExpiredAttempts(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	manifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	_, err := store.CommitManifest(t.Context(), manifest, "parser-data-17")
+	require.NoError(t, err)
+
+	first, err := store.ClaimRawParseJobs(t.Context(), "worker-a", 1, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, manifest.ManifestID, first[0].ManifestID)
+	assert.Equal(t, 1, first[0].Attempt)
+	assert.Equal(t, identity, first[0].Identity)
+
+	other, err := store.ClaimRawParseJobs(t.Context(), "worker-b", 1, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, other, "an active lease must be exclusive")
+
+	_, err = pg.ExecContext(t.Context(), `
+		UPDATE raw_ingest_jobs
+		SET lease_expires_at = now() - interval '1 second'
+		WHERE id = $1`, first[0].ID)
+	require.NoError(t, err)
+
+	second, err := store.ClaimRawParseJobs(t.Context(), "worker-b", 1, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.Equal(t, first[0].ID, second[0].ID)
+	assert.Equal(t, 2, second[0].Attempt)
+
+	err = store.HeartbeatRawParseJob(t.Context(), first[0], time.Minute)
+	assert.ErrorIs(t, err, rawderive.ErrLeaseLost)
+	err = store.CompleteRawParseJob(t.Context(), first[0])
+	assert.ErrorIs(t, err, rawderive.ErrLeaseLost)
+	require.NoError(t, store.HeartbeatRawParseJob(t.Context(), second[0], time.Minute))
+	require.NoError(t, store.CompleteRawParseJob(t.Context(), second[0]))
+
+	var state string
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT state FROM raw_ingest_jobs WHERE id = $1`, second[0].ID,
+	).Scan(&state))
+	assert.Equal(t, "complete", state)
+}
+
+func TestRawParseJobsSupersedeNonHeadManifestsOnShortClaim(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	firstManifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	firstCommit, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+	require.NoError(t, err)
+	secondManifest := rawIngestManifest(
+		t, identity, "capture-b", firstCommit.Receipt,
+		rawIngestCapturedAt().Add(time.Minute), object,
+	)
+	_, err = store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+	require.NoError(t, err)
+	// Commit-time supersession already retired the prior-head job, so reopen
+	// it as a legacy row the commit path never reached.
+	reOpenSupersededRawParseJobs(t, pg)
+
+	leases, err := store.ClaimRawParseJobs(t.Context(), "worker-a", 2, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, leases, 1)
+	assert.Equal(t, secondManifest.ManifestID, leases[0].ManifestID)
+
+	var state string
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT state
+		FROM raw_ingest_jobs
+		WHERE tenant_id = $1 AND manifest_id = $2`,
+		identity.TenantID, firstManifest.ManifestID,
+	).Scan(&state))
+	assert.Equal(t, "superseded", state,
+		"a short claim must still retire legacy non-head rows the commit path missed")
+}
+
+func TestRawParseJobsRetryOnlyWhenAvailable(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	manifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	_, err := store.CommitManifest(t.Context(), manifest, "parser-data-17")
+	require.NoError(t, err)
+	lease := claimOneRawParseJob(t, store)
+
+	retryAt := time.Now().Add(time.Hour)
+	require.NoError(t, store.RetryRawParseJob(
+		t.Context(), lease, retryAt, "object_store", "temporary failure",
+	))
+	leasing, err := store.ClaimRawParseJobs(t.Context(), "worker-b", 1, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, leasing)
+
+	_, err = pg.ExecContext(t.Context(), `
+		UPDATE raw_ingest_jobs SET available_at = now() - interval '1 second'
+		WHERE id = $1`, lease.ID)
+	require.NoError(t, err)
+	leasing, err = store.ClaimRawParseJobs(t.Context(), "worker-b", 1, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, leasing, 1)
+	assert.Equal(t, lease.Attempt+1, leasing[0].Attempt)
+}
+
+func TestRawParseJobsFenceRetryAfterSourceHeadAdvances(t *testing.T) {
+	_, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	firstManifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	firstCommit, err := store.CommitManifest(
+		t.Context(), firstManifest, "parser-data-17",
+	)
+	require.NoError(t, err)
+	lease := claimOneRawParseJob(t, store)
+
+	secondManifest := rawIngestManifest(
+		t, identity, "capture-b", firstCommit.Receipt,
+		rawIngestCapturedAt().Add(time.Minute), object,
+	)
+	_, err = store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+	require.NoError(t, err)
+
+	err = store.RetryRawParseJob(
+		t.Context(), lease, time.Now().Add(time.Minute),
+		"object_store", "temporary failure",
+	)
+	assert.ErrorIs(t, err, rawderive.ErrLeaseLost)
+}
+
+func TestRawParseJobsRecordTerminalFailureWithLeaseFence(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	manifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	_, err := store.CommitManifest(t.Context(), manifest, "parser-data-17")
+	require.NoError(t, err)
+	lease := claimOneRawParseJob(t, store)
+
+	require.NoError(t, store.FailRawParseJob(
+		t.Context(), lease, "parse", "unsupported provider format",
+	))
+	err = store.FailRawParseJob(t.Context(), lease, "parse", "duplicate completion")
+	assert.ErrorIs(t, err, rawderive.ErrLeaseLost)
+
+	var state, errorClass, message string
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT state, last_error_class, last_error
+		FROM raw_ingest_jobs WHERE id = $1`, lease.ID,
+	).Scan(&state, &errorClass, &message))
+	assert.Equal(t, "failed", state)
+	assert.Equal(t, "parse", errorClass)
+	assert.Equal(t, "unsupported provider format", message)
+
+	leasing, err := store.ClaimRawParseJobs(t.Context(), "worker-b", 1, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, leasing)
+}
+
+func TestClaimRawParseJobsSupersedeBatchIsBounded(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	// Chain six generations for one source: every commit moves the head, so
+	// five obsolete jobs pile up behind the current one.
+	receipt := ""
+	capturedAt := rawIngestCapturedAt()
+	for i := range 6 {
+		manifest := rawIngestManifest(t, identity, fmt.Sprintf("capture-%d", i), receipt, capturedAt.Add(time.Duration(i)*time.Minute), object)
+		commit, err := store.CommitManifest(t.Context(), manifest, "parser-data-17")
+		require.NoError(t, err)
+		receipt = commit.Receipt
+	}
+	countState := func(state string) int {
+		var count int
+		require.NoError(t, pg.QueryRowContext(t.Context(), `
+			SELECT COUNT(*) FROM raw_ingest_jobs WHERE state = $1`, state,
+		).Scan(&count))
+		return count
+	}
+	assert.Equal(t, 1, countState("ready"),
+		"commit-time supersession keeps only the current head's job ready")
+	assert.Equal(t, 5, countState("superseded"))
+	// Reopen the retired jobs as a legacy backlog no commit path can reach,
+	// so the bounded claim-path fallback stays provably bounded.
+	reOpenSupersededRawParseJobs(t, pg)
+	require.Equal(t, 6, countState("ready"))
+
+	tx, err := pg.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	require.NoError(t, supersedeObsoleteRawParseJobs(t.Context(), tx, 2))
+	require.NoError(t, tx.Commit())
+	assert.Equal(t, 2, countState("superseded"),
+		"obsolete-job supersession must be bounded per call")
+	assert.Equal(t, 4, countState("ready"))
+
+	for range 2 {
+		tx, err = pg.BeginTx(t.Context(), nil)
+		require.NoError(t, err)
+		require.NoError(t, supersedeObsoleteRawParseJobs(t.Context(), tx, 2))
+		require.NoError(t, tx.Commit())
+	}
+	assert.Equal(t, 5, countState("superseded"),
+		"repeated bounded calls must drain the obsolete backlog")
+	assert.Equal(t, 1, countState("ready"))
+}
+
+// reOpenSupersededRawParseJobs simulates legacy non-head rows that the
+// commit-time supersession never reached, so claim-path cleanup stays
+// exercised against rows only its bounded fallback can retire.
+func reOpenSupersededRawParseJobs(t *testing.T, pg *sql.DB) {
+	t.Helper()
+	_, err := pg.ExecContext(t.Context(), `
+		UPDATE raw_ingest_jobs
+		SET state = 'ready', lease_owner = '', lease_expires_at = NULL,
+			available_at = now() - interval '1 second', updated_at = now()
+		WHERE state = 'superseded'`)
+	require.NoError(t, err)
+}
+
+func TestClaimRawParseJobsSkipsSupersedeWhenBatchFillsWithCurrentHeads(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	// Two sources, each with one obsolete ready job behind a current-head
+	// ready job: four claimable-looking rows, two of which may never lease.
+	headManifestIDs := make([]string, 0, 2)
+	for i, tenant := range []string{"tenant-a", "tenant-b"} {
+		identity := rawIngestIdentity(t, tenant)
+		object := rawIngestObject(t, string(rune('a'+i)), 7)
+		require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+		firstManifest := rawIngestManifest(
+			t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+		)
+		firstCommit, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+		require.NoError(t, err)
+		secondManifest := rawIngestManifest(
+			t, identity, "capture-b", firstCommit.Receipt,
+			rawIngestCapturedAt().Add(time.Minute), object,
+		)
+		commit, err := store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+		require.NoError(t, err)
+		headManifestIDs = append(headManifestIDs, commit.ManifestID)
+	}
+	countJobs := func(state string) int {
+		var count int
+		require.NoError(t, pg.QueryRowContext(t.Context(), `
+			SELECT COUNT(*) FROM raw_ingest_jobs WHERE state = $1`, state,
+		).Scan(&count))
+		return count
+	}
+	// The second commit of each source already superseded the prior job, so
+	// reopen those rows as legacy backlog the full claim must still skip.
+	reOpenSupersededRawParseJobs(t, pg)
+	require.Equal(t, 4, countJobs("ready"),
+		"setup must leave two legacy obsolete and two current-head ready jobs")
+
+	leases, err := store.ClaimRawParseJobs(t.Context(), "worker-a", 2, time.Minute)
+
+	require.NoError(t, err)
+	require.Len(t, leases, 2)
+	leasedManifestIDs := []string{leases[0].ManifestID, leases[1].ManifestID}
+	assert.ElementsMatch(t, headManifestIDs, leasedManifestIDs,
+		"the claim itself must only ever lease current source heads")
+	assert.Equal(t, 2, countJobs("leased"))
+	assert.Equal(t, 2, countJobs("ready"),
+		"a full current-head claim must not pay the obsolete-job supersede scan")
+	assert.Zero(t, countJobs("superseded"))
+
+	starved, err := store.ClaimRawParseJobs(t.Context(), "worker-b", 1, time.Minute)
+
+	require.NoError(t, err)
+	assert.Empty(t, starved,
+		"the leased heads and the head-probed obsolete rows leave nothing to claim")
+	assert.Equal(t, 2, countJobs("superseded"),
+		"a claim that cannot be filled must still drain obsolete jobs")
+}
+
+func TestClaimRawParseJobsRequiresCurrentHeadEvenWhenSupersedeMissed(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	firstManifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	firstCommit, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+	require.NoError(t, err)
+	secondManifest := rawIngestManifest(
+		t, identity, "capture-b", firstCommit.Receipt,
+		rawIngestCapturedAt().Add(time.Minute), object,
+	)
+	_, err = store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+	require.NoError(t, err)
+	// Leave more obsolete jobs than one bounded supersede pass can retire. The
+	// claim statement itself must refuse to lease the stale rows that remain.
+	_, err = pg.ExecContext(t.Context(), `
+		UPDATE raw_ingest_jobs
+		SET state = 'ready', lease_owner = '', lease_expires_at = NULL,
+			available_at = now() - interval '1 second', updated_at = now()
+		WHERE tenant_id = $1 AND manifest_id = $2`,
+		identity.TenantID, firstManifest.ManifestID)
+	require.NoError(t, err)
+	_, err = pg.ExecContext(t.Context(), `
+		INSERT INTO raw_ingest_jobs (
+			tenant_id, manifest_id, stage, processing_version, state, available_at
+		)
+		SELECT $1, $2, 'parse', 'stale-backlog-' || sequence, 'ready',
+			now() - interval '1 second'
+		FROM generate_series(1, $3) AS sequence`,
+		identity.TenantID, firstManifest.ManifestID, maxRawParseSupersedeBatch+1)
+	require.NoError(t, err)
+
+	leases, err := store.ClaimRawParseJobs(t.Context(), "worker-a", 10, time.Minute)
+
+	require.NoError(t, err)
+	require.Len(t, leases, 1)
+	assert.Equal(t, secondManifest.ManifestID, leases[0].ManifestID,
+		"the claim itself must only ever lease current source heads")
+	var state string
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT state FROM raw_ingest_jobs
+		WHERE tenant_id = $1 AND manifest_id = $2
+			AND processing_version = 'parser-data-17'`,
+		identity.TenantID, firstManifest.ManifestID).Scan(&state))
+	assert.Equal(t, "superseded", state)
+	var staleReady, staleLeased int
+	require.NoError(t, pg.QueryRowContext(t.Context(), `
+		SELECT
+			COUNT(*) FILTER (WHERE state = 'ready'),
+			COUNT(*) FILTER (WHERE state = 'leased')
+		FROM raw_ingest_jobs
+		WHERE tenant_id = $1 AND manifest_id = $2`,
+		identity.TenantID, firstManifest.ManifestID,
+	).Scan(&staleReady, &staleLeased))
+	assert.Greater(t, staleReady, 0,
+		"the bounded supersede pass must leave stale claimable rows behind")
+	assert.Zero(t, staleLeased,
+		"the current-head predicate must prevent every remaining stale row from leasing")
+}
+
+// loosenRawIngestJobStageCheck removes the raw_ingest_jobs stage CHECK
+// from this test's isolated per-test schema only, so tests can model job rows
+// from stages the production schema does not admit yet. The constraint is
+// discovered by definition rather than assumed name, and the schema itself
+// is dropped again when the test ends.
+func loosenRawIngestJobStageCheck(t *testing.T, pg *sql.DB) {
+	t.Helper()
+	rows, err := pg.QueryContext(t.Context(), `
+		SELECT format(
+			'ALTER TABLE %I.raw_ingest_jobs DROP CONSTRAINT %I',
+			$1::text, conname)
+		FROM pg_catalog.pg_constraint
+		WHERE conrelid = to_regclass(format('%I.raw_ingest_jobs', $1::text))
+			AND contype = 'c'
+			AND pg_get_constraintdef(oid) LIKE '%stage%'
+			AND pg_get_constraintdef(oid) LIKE '%parse%'`,
+		schemaTestSchema)
+	require.NoError(t, err)
+	defer rows.Close()
+	var drops []string
+	for rows.Next() {
+		var ddl string
+		require.NoError(t, rows.Scan(&ddl))
+		drops = append(drops, ddl)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, drops, 1,
+		"a fresh test schema must carry exactly one raw_ingest_jobs stage CHECK")
+	_, err = pg.ExecContext(t.Context(), drops[0])
+	require.NoError(t, err)
+}
+
+// TestClaimRawParseJobsLeasesAndSupersedesOnlyParseStageJobs proves the
+// claim and claim-path supersession queries stay scoped to parse jobs even
+// when the schema admits other stages: a future stage must never be leased
+// by parse workers nor retired by their cleanup, while obsolete parse jobs
+// keep draining.
+func TestClaimRawParseJobsLeasesAndSupersedesOnlyParseStageJobs(t *testing.T) {
+	pg, store := newRawIngestTestStore(t)
+	identity := rawIngestIdentity(t, "tenant-a")
+	object := rawIngestObject(t, "a", 7)
+	require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+	firstManifest := rawIngestManifest(
+		t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+	)
+	firstCommit, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+	require.NoError(t, err)
+	secondManifest := rawIngestManifest(
+		t, identity, "capture-b", firstCommit.Receipt,
+		rawIngestCapturedAt().Add(time.Minute), object,
+	)
+	_, err = store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+	require.NoError(t, err)
+	// The production schema only admits the parse stage today. Drop exactly
+	// that CHECK inside this test's isolated schema to model a future schema
+	// that also carries other stages, then seed eligible-looking derive jobs:
+	// one on the current head (claim bait) and one behind it (supersede
+	// bait).
+	loosenRawIngestJobStageCheck(t, pg)
+	_, err = pg.ExecContext(t.Context(), `
+		INSERT INTO raw_ingest_jobs (
+			tenant_id, manifest_id, stage, processing_version, state, available_at
+		) VALUES
+			($1, $2, 'derive', 'derive-1', 'ready', now() - interval '5 seconds'),
+			($1, $3, 'derive', 'derive-1', 'ready', now() - interval '5 seconds')`,
+		identity.TenantID, secondManifest.ManifestID, firstManifest.ManifestID)
+	require.NoError(t, err)
+	// Commit-time supersession retired the prior head's parse job. Reopen it
+	// as legacy backlog so the claim-path cleanup still has a parse row it
+	// must keep retiring.
+	reOpenSupersededRawParseJobs(t, pg)
+
+	leases, err := store.ClaimRawParseJobs(t.Context(), "worker-a", 3, time.Minute)
+
+	require.NoError(t, err)
+	require.Len(t, leases, 1,
+		"the parse claim must lease only the current-head parse job")
+	assert.Equal(t, secondManifest.ManifestID, leases[0].ManifestID)
+
+	readJob := func(manifestID, stage string) (state, owner string, attempts int) {
+		require.NoError(t, pg.QueryRowContext(t.Context(), `
+			SELECT state, lease_owner, attempt_count
+			FROM raw_ingest_jobs
+			WHERE tenant_id = $1 AND manifest_id = $2 AND stage = $3`,
+			identity.TenantID, manifestID, stage,
+		).Scan(&state, &owner, &attempts))
+		return state, owner, attempts
+	}
+
+	state, owner, attempts := readJob(secondManifest.ManifestID, "derive")
+	assert.Equal(t, "ready", state,
+		"a non-parse job on the current head must never be leased by parse workers")
+	assert.Empty(t, owner)
+	assert.Zero(t, attempts)
+
+	state, owner, _ = readJob(firstManifest.ManifestID, "derive")
+	assert.Equal(t, "ready", state,
+		"an obsolete non-parse job must never be superseded by the parse claim path")
+	assert.Empty(t, owner)
+
+	state, _, _ = readJob(firstManifest.ManifestID, "parse")
+	assert.Equal(t, "superseded", state,
+		"the bounded claim-path cleanup must still retire obsolete parse jobs")
+}
+
+// TestClaimRawParseJobsRunsUnderRestrictedParseWorkerPrivileges pins the
+// worker-role contract for both claim paths from the least-privileged seat:
+// a role that may read custody rows but only update raw_ingest_jobs must be
+// able to fill a full claim batch and to run the short-claim obsolete
+// cleanup. PostgreSQL demands UPDATE privilege on every table a locking
+// clause touches, so a regression that locks joined manifest rows fails
+// here with permission denied even though the privileged seeding role
+// would never notice, and the documented clause order (LIMIT before the
+// locking clause) is exercised by both statements end to end.
+func TestClaimRawParseJobsRunsUnderRestrictedParseWorkerPrivileges(t *testing.T) {
+	pgURL := testPGURL(t)
+	pg, store := newRawIngestTestStore(t)
+	const role = "agentsview_parse_worker"
+	const rolePassword = "agentsview_parse_worker_pw"
+
+	_, _ = pg.Exec(`DROP OWNED BY ` + role)
+	_, _ = pg.Exec(`DROP ROLE IF EXISTS ` + role)
+	_, err := pg.Exec(`CREATE ROLE ` + role + ` LOGIN PASSWORD '` + rolePassword + `'`)
+	require.NoError(t, err, "create parse worker role")
+	t.Cleanup(func() {
+		_, _ = pg.Exec(`DROP OWNED BY ` + role)
+		_, _ = pg.Exec(`DROP ROLE IF EXISTS ` + role)
+	})
+	for _, grant := range []string{
+		`GRANT USAGE ON SCHEMA ` + schemaTestSchema + ` TO ` + role,
+		`GRANT SELECT ON ` + schemaTestSchema + `.raw_manifests TO ` + role,
+		`GRANT SELECT ON ` + schemaTestSchema + `.raw_source_heads TO ` + role,
+		`GRANT SELECT, UPDATE ON ` + schemaTestSchema + `.raw_ingest_jobs TO ` + role,
+	} {
+		_, err = pg.Exec(grant)
+		require.NoError(t, err, grant)
+	}
+	workerURL, err := url.Parse(pgURL)
+	require.NoError(t, err)
+	workerURL.User = url.UserPassword(role, rolePassword)
+	workerDB, err := Open(workerURL.String(), schemaTestSchema, true)
+	require.NoError(t, err, "Open parse worker")
+	t.Cleanup(func() { require.NoError(t, workerDB.Close()) })
+	workerStore, err := NewRawIngestStore(workerDB)
+	require.NoError(t, err)
+
+	// Two sources, each with one legacy obsolete ready job behind a
+	// current-head ready job, so a full claim skips cleanup while a starved
+	// claim must run it.
+	headManifestIDs := make([]string, 0, 2)
+	for i, tenant := range []string{"tenant-a", "tenant-b"} {
+		identity := rawIngestIdentity(t, tenant)
+		object := rawIngestObject(t, string(rune('a'+i)), 7)
+		require.NoError(t, store.RecordVerifiedObject(t.Context(), identity, object))
+		firstManifest := rawIngestManifest(
+			t, identity, "capture-a", "", rawIngestCapturedAt(), object,
+		)
+		firstCommit, err := store.CommitManifest(t.Context(), firstManifest, "parser-data-17")
+		require.NoError(t, err)
+		secondManifest := rawIngestManifest(
+			t, identity, "capture-b", firstCommit.Receipt,
+			rawIngestCapturedAt().Add(time.Minute), object,
+		)
+		commit, err := store.CommitManifest(t.Context(), secondManifest, "parser-data-17")
+		require.NoError(t, err)
+		headManifestIDs = append(headManifestIDs, commit.ManifestID)
+	}
+	reOpenSupersededRawParseJobs(t, pg)
+	countJobs := func(state string) int {
+		var count int
+		require.NoError(t, pg.QueryRowContext(t.Context(), `
+			SELECT COUNT(*) FROM raw_ingest_jobs WHERE state = $1`, state,
+		).Scan(&count))
+		return count
+	}
+
+	leases, err := workerStore.ClaimRawParseJobs(t.Context(), "worker-a", 2, time.Minute)
+
+	require.NoError(t, err,
+		"a restricted parse worker must fill a full claim batch")
+	require.Len(t, leases, 2)
+	assert.ElementsMatch(t, headManifestIDs,
+		[]string{leases[0].ManifestID, leases[1].ManifestID},
+		"the restricted claim must lease only current source heads")
+	assert.Equal(t, 2, countJobs("leased"))
+	assert.Equal(t, 2, countJobs("ready"),
+		"a full restricted claim must not disturb the legacy obsolete rows")
+
+	starved, err := workerStore.ClaimRawParseJobs(t.Context(), "worker-b", 1, time.Minute)
+
+	require.NoError(t, err,
+		"a restricted parse worker must run the obsolete-job cleanup")
+	assert.Empty(t, starved)
+	assert.Equal(t, 2, countJobs("superseded"),
+		"the restricted short claim must retire legacy obsolete jobs")
+}
+
+func claimOneRawParseJob(t *testing.T, store *RawIngestStore) rawderive.JobLease {
+	t.Helper()
+	leases, err := store.ClaimRawParseJobs(t.Context(), "worker-a", 1, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, leases, 1)
+	return leases[0]
+}
+
+func TestRawParseCleanupSkipsFutureRetryBacklog(t *testing.T) {
+	pg, _ := newRawIngestTestStore(t)
+	var smallBuffers int
+	for _, count := range []int{100, 10000} {
+		_, err := pg.ExecContext(t.Context(), `
+			INSERT INTO raw_manifests (tenant_id, manifest_id, device_id, provider,
+				configured_root_id, source_key, source_key_sha256, capture_id,
+				parent_receipt, receipt, generation, kind, captured_at, canonical_json)
+			SELECT 'tenant-a', repeat(md5(i::text), 2), 'device-a', 'codex',
+				'root-a', i::text, repeat(md5(i::text), 2), 'capture-a', '',
+				repeat(md5(i::text), 2), 1, 'snapshot', now(), '{}'
+			FROM generate_series(1, $1::int) i ON CONFLICT DO NOTHING;
+		`, count)
+		require.NoError(t, err)
+		_, err = pg.ExecContext(t.Context(), `
+			INSERT INTO raw_source_heads (tenant_id, device_id, provider,
+				configured_root_id, source_key, source_key_sha256, manifest_id,
+				receipt, generation)
+			SELECT tenant_id, device_id, provider, configured_root_id, source_key,
+				source_key_sha256, manifest_id, receipt, generation
+			FROM raw_manifests ON CONFLICT DO NOTHING;
+			INSERT INTO raw_ingest_jobs (tenant_id, manifest_id, stage,
+				processing_version, state, available_at)
+			SELECT tenant_id, manifest_id, 'parse', 'parser-data-17', 'retrying',
+				now() + interval '1 day' FROM raw_manifests ON CONFLICT DO NOTHING;
+			ANALYZE raw_manifests; ANALYZE raw_source_heads; ANALYZE raw_ingest_jobs;
+		`)
+		require.NoError(t, err)
+		var raw []byte
+		require.NoError(t, pg.QueryRowContext(t.Context(),
+			"EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) "+rawParseSupersedeSQL,
+			maxRawParseSupersedeBatch).Scan(&raw))
+		var plans []struct {
+			Plan struct {
+				Hits  int `json:"Shared Hit Blocks"`
+				Reads int `json:"Shared Read Blocks"`
+			}
+		}
+		require.NoError(t, json.Unmarshal(raw, &plans))
+		require.Len(t, plans, 1)
+		buffers := plans[0].Plan.Hits + plans[0].Plan.Reads
+		t.Logf("future retry jobs=%d cleanup buffers=%d", count, buffers)
+		if count == 100 {
+			smallBuffers = buffers
+		} else {
+			assert.LessOrEqual(t, buffers, smallBuffers+20,
+				"idle cleanup must not read the growing future retry archive")
+		}
+	}
+}

--- a/internal/postgres/raw_parse_jobs_unit_test.go
+++ b/internal/postgres/raw_parse_jobs_unit_test.go
@@ -1,0 +1,43 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/rawderive"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestValidateRawParseLeaseRequestBoundsClaimBatch(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateRawParseLeaseRequest(
+		"worker-a", rawderive.MaxClaimBatchSize, time.Minute,
+	))
+
+	err := validateRawParseLeaseRequest("worker-a", 0, time.Minute)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+	err = validateRawParseLeaseRequest("worker-a", -1, time.Minute)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+	err = validateRawParseLeaseRequest("worker-a", rawderive.MaxClaimBatchSize+1, time.Minute)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid,
+		"the queue and worker must share one claim cap from the rawderive contract")
+}
+
+func TestRawParseLeaseDurationsRequireOneMicrosecond(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateRawParseLeaseRequest("worker-a", 1, time.Microsecond))
+	assert.ErrorIs(t,
+		validateRawParseLeaseRequest("worker-a", 1, time.Nanosecond),
+		rawsync.ErrInvalid,
+	)
+	assert.ErrorIs(t,
+		(&RawIngestStore{}).HeartbeatRawParseJob(t.Context(), rawderive.JobLease{
+			ID: 1, Attempt: 1, Owner: "worker-a",
+		}, time.Nanosecond),
+		rawsync.ErrInvalid,
+	)
+}

--- a/internal/rawcapture/capturer.go
+++ b/internal/rawcapture/capturer.go
@@ -151,6 +151,7 @@ func (c *Capturer) Capture(
 		finishPublication()
 	}()
 	snapshot := false
+	var snapshotSourceModTimeNS int64
 	observationRecorded := false
 	var removeSnapshot func() error
 	switch {
@@ -180,6 +181,7 @@ func (c *Capturer) Capture(
 		if len(sourceObserved) != 1 {
 			return Result{}, ErrSourceChanged
 		}
+		snapshotSourceModTimeNS = sourceObserved[0].info.ModTime().UnixNano()
 		sqliteSource, openErr := openSQLiteSnapshotSource(
 			ctx, sourcePath, sourceObserved[0].info,
 		)
@@ -347,7 +349,8 @@ func (c *Capturer) Capture(
 		planned := observed[i].planned
 		var entry rawcheckpoint.CapturedEntry
 		var newlyInstalled bool
-		if assessment.mode == captureAppend && planned.Appendable {
+		if assessment.mode == captureAppend && planned.Appendable &&
+			observed[i].info.Size() > assessment.appendBases[i].Length {
 			entry, newlyInstalled, err = c.captureAppendFile(
 				ctx, observed[i], assessment.appendBases[i],
 			)
@@ -364,11 +367,15 @@ func (c *Capturer) Capture(
 			return Result{}, err
 		}
 		capturedIdentity := entry.FileIdentity
+		capturedModTimeNS := entry.ModTimeNS
 		entry.FileIdentity = observed[i].checkpointIdentity
+		if snapshot {
+			entry.ModTimeNS = snapshotSourceModTimeNS
+		}
 		entries = append(entries, entry)
 		capturedFiles = append(capturedFiles, capturedFileState{
 			length:       entry.Length,
-			modTimeNS:    entry.ModTimeNS,
+			modTimeNS:    capturedModTimeNS,
 			fileIdentity: capturedIdentity,
 			prefixSHA256: entry.PrefixSHA256,
 		})
@@ -672,7 +679,8 @@ func (c *Capturer) validateForUpload(
 	for _, entry := range entries {
 		manifestEntries = append(manifestEntries, rawsync.Entry{
 			Path: entry.Path, Type: "file", Length: entry.Length,
-			Objects: append([]rawsync.ObjectRef(nil), entry.Objects...),
+			ModTimeNS: entry.ModTimeNS,
+			Objects:   append([]rawsync.ObjectRef(nil), entry.Objects...),
 		})
 	}
 	return rawsync.ValidateManifestForUpload(rawsync.Manifest{

--- a/internal/rawcapture/capturer_test.go
+++ b/internal/rawcapture/capturer_test.go
@@ -135,6 +135,86 @@ func TestCapturerPersistsStableGenerationWithoutParsing(t *testing.T) {
 	assert.Equal(t, []byte("one\n"), content)
 }
 
+func TestCapturerClaudeLineageParentGrowthReusesFork(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	require.NoError(t, os.MkdirAll(project, 0o700))
+	parentPath := filepath.Join(project, "parent.jsonl")
+	forkPath := filepath.Join(project, "fork.jsonl")
+	require.NoError(t, os.WriteFile(parentPath, []byte(`{"type":"user","uuid":"u1","parentUuid":null,"message":{"content":"question"}}`+"\n"), 0o600))
+	require.NoError(t, os.WriteFile(forkPath, []byte(`{"type":"user","uuid":"u1","parentUuid":null,"sessionKind":"bg","message":{"content":"question"}}`+"\n"), 0o600))
+	provider, supported := parser.NewProvider(parser.AgentClaude, parser.ProviderConfig{Roots: []string{root}})
+	require.True(t, supported)
+	sources, err := provider.SourcesForChangedPath(t.Context(), parser.ChangedPathRequest{Path: forkPath})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, sources[0])
+	require.NoError(t, err)
+	before, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, appendFile(parentPath, `{"type":"assistant","uuid":"a1","parentUuid":"u1","message":{"content":"answer"}}`+"\n"))
+	second, err := capturer.Capture(t.Context(), provider, sources[0])
+	require.NoError(t, err)
+	assert.Equal(t, StatusCaptured, second.Status)
+	after, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, after.Entries, 2)
+	assert.Equal(t, before.Entries[0].Objects, after.Entries[0].Objects)
+	require.Len(t, after.Entries[1].Objects, 2)
+	assert.Equal(t, before.Entries[1].Objects[0], after.Entries[1].Objects[0])
+}
+
+func TestCapturerEvenerLineageParentGrowthReusesFork(t *testing.T) {
+	store, _ := openCapturerTestStore(t, 1<<20)
+	root := t.TempDir()
+	sessions := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessions, 0o700))
+	parentPath := filepath.Join(sessions, "parent.transcript.jsonl")
+	forkPath := filepath.Join(sessions, "fork.transcript.jsonl")
+	metaPath := filepath.Join(sessions, "fork.meta.json")
+	require.NoError(t, os.WriteFile(parentPath, []byte("parent prefix\n"), 0o600))
+	require.NoError(t, os.WriteFile(forkPath, []byte("fork transcript\n"), 0o600))
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"id":"fork","parent_session_id":"parent","divergence_turn":2}`), 0o600))
+	provider, supported := parser.NewProvider(parser.AgentEvener, parser.ProviderConfig{Roots: []string{root}})
+	require.True(t, supported)
+	source, found, err := provider.FindSource(t.Context(), parser.FindSourceRequest{RawSessionID: "fork"})
+	require.NoError(t, err)
+	require.True(t, found)
+	capturer := New(store)
+	first, err := capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	before, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, before.Entries, 3)
+
+	require.NoError(t, appendFile(parentPath, "parent suffix\n"))
+	_, err = capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	after, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, after.Entries, 3)
+	assert.Equal(t, before.Entries[1].Objects, after.Entries[1].Objects)
+	require.Len(t, after.Entries[2].Objects, 2)
+	assert.Equal(t, before.Entries[2].Objects[0], after.Entries[2].Objects[0])
+
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"id":"fork","name":"Renamed","parent_session_id":"parent","divergence_turn":2}`), 0o600))
+	_, err = capturer.Capture(t.Context(), provider, source)
+	require.NoError(t, err)
+	renamed, ok, err := store.CaptureBase(t.Context(), first.Source)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, renamed.Entries, 3)
+	require.Len(t, renamed.Entries[0].Objects, 1)
+	assert.NotEqual(t, after.Entries[0].Objects, renamed.Entries[0].Objects)
+}
+
 func TestConcurrentCapturesDoNotDiscardAnotherCaptureSharedObject(t *testing.T) {
 	store, _ := openCapturerTestStore(t, 1<<20)
 	providerA, sourceA, _ := captureFileProvider(t, "shared\n")
@@ -672,6 +752,10 @@ func TestCapturerSnapshotsSQLiteWithOnlineBackup(t *testing.T) {
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO items (value) VALUES ('committed')`)
 	require.NoError(t, err)
+	requestedModTime := time.Date(2024, time.January, 2, 3, 4, 5, 678_000_000, time.UTC)
+	require.NoError(t, os.Chtimes(dbPath, requestedModTime, requestedModTime))
+	sourceInfo, err := os.Stat(dbPath)
+	require.NoError(t, err)
 	tx, err := db.Begin()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = tx.Rollback() })
@@ -708,6 +792,7 @@ func TestCapturerSnapshotsSQLiteWithOnlineBackup(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, generation.Entries, 1)
 	assert.Equal(t, "live.db", generation.Entries[0].Path)
+	assert.Equal(t, sourceInfo.ModTime().UnixNano(), generation.Entries[0].ModTimeNS)
 	require.Len(t, generation.Entries[0].Objects, 1)
 	snapshot, err := sql.Open(
 		sqliteSnapshotDriverName, store.ObjectPath(generation.Entries[0].Objects[0]),
@@ -1468,7 +1553,8 @@ func uploadCanonicalBytes(
 	for _, entry := range entries {
 		manifestEntries = append(manifestEntries, rawsync.Entry{
 			Path: entry.Path, Type: "file", Length: entry.Length,
-			Objects: append([]rawsync.ObjectRef(nil), entry.Objects...),
+			ModTimeNS: entry.ModTimeNS,
+			Objects:   append([]rawsync.ObjectRef(nil), entry.Objects...),
 		})
 	}
 	identity, err := rawsync.NewAuthIdentity(strings.Repeat(`"`, 128), strings.Repeat(`"`, 128))

--- a/internal/rawcheckpoint/ack.go
+++ b/internal/rawcheckpoint/ack.go
@@ -603,7 +603,8 @@ func loadManifestEntriesConn(
 	for _, entry := range captured {
 		entries = append(entries, rawsync.Entry{
 			Path: entry.Path, Type: "file", Length: entry.Length,
-			Objects: append([]rawsync.ObjectRef(nil), entry.Objects...),
+			ModTimeNS: entry.ModTimeNS,
+			Objects:   append([]rawsync.ObjectRef(nil), entry.Objects...),
 		})
 	}
 	return entries, nil

--- a/internal/rawcheckpoint/ack_test.go
+++ b/internal/rawcheckpoint/ack_test.go
@@ -89,6 +89,26 @@ func TestFinalizeAndAcknowledgeOfflineChainInOrder(t *testing.T) {
 	assert.True(t, replayed.Replayed)
 }
 
+func TestFinalizeNextManifestCarriesEntryModTime(t *testing.T) {
+	store, root := openOutboxTestStore(t, 1<<20)
+	require.NoError(t, store.SetDevice(t.Context(), "device-a"))
+	ref := rawsync.ObjectRef{SHA256: validCheckpointDigest(21), Length: 3}
+	installOutboxTestObject(t, store, ref, []byte("abc"))
+	generation := testCapturedGeneration(4, root, "", ref)
+	require.Equal(t, int64(4), generation.Entries[0].ModTimeNS)
+	reservation, err := store.ReserveCapture(t.Context(), root.ID, 1795)
+	require.NoError(t, err)
+	require.NoError(t, store.CommitCapture(t.Context(), reservation.ID, generation))
+
+	manifest, found, err := store.FinalizeNextManifest(t.Context(), "device-a")
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, manifest.Entries, 1)
+	assert.Equal(t, int64(4), manifest.Entries[0].ModTimeNS,
+		"finalized manifests must retain each captured file's mod time")
+}
+
 func TestFinalizeNextManifestOrdersExactSecondBeforeLaterFraction(t *testing.T) {
 	store, root := openOutboxTestStore(t, 1<<20)
 	require.NoError(t, store.SetDevice(t.Context(), "device-a"))

--- a/internal/rawderive/job.go
+++ b/internal/rawderive/job.go
@@ -1,0 +1,40 @@
+// Package rawderive turns accepted raw custody manifests into derived sessions.
+package rawderive
+
+import (
+	"errors"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// ErrLeaseLost means a worker no longer owns the fenced job attempt.
+var ErrLeaseLost = errors.New("raw derivation lease lost")
+
+// MaxClaimBatchSize is the shared upper bound on how many raw parse jobs one
+// worker may lease per claim. Queues and workers validate against this single
+// contract so a configured worker can never request a claim the queue rejects.
+const MaxClaimBatchSize = 256
+
+// MaxLeaseOwnerBytes is the shared upper bound for a durable worker identity.
+const MaxLeaseOwnerBytes = 128
+
+// ValidLeaseOwner reports whether owner is a nonblank UTF-8 worker identity
+// that every queue implementation can persist.
+func ValidLeaseOwner(owner string) bool {
+	return strings.TrimSpace(owner) != "" && utf8.ValidString(owner) &&
+		len(owner) <= MaxLeaseOwnerBytes
+}
+
+// JobLease is the fenced ownership token for one parse attempt.
+type JobLease struct {
+	ID                int64
+	Identity          rawsync.AuthIdentity
+	ManifestID        string
+	ProcessingVersion string
+	Attempt           int
+	Owner             string
+	ExpiresAt         time.Time
+}

--- a/internal/rawderive/manifest.go
+++ b/internal/rawderive/manifest.go
@@ -1,0 +1,81 @@
+package rawderive
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// ManifestStore provides authenticated access to canonical manifest objects.
+type ManifestStore interface {
+	OpenManifest(
+		context.Context,
+		rawsync.AuthIdentity,
+		string,
+	) (rawsync.ObjectInfo, rawsync.VerifiedObjectReader, error)
+}
+
+// ManifestLoader loads and verifies the authoritative custody envelope for a
+// leased parse job.
+type ManifestLoader struct {
+	Store  ManifestStore
+	Limits rawsync.ManifestLimits
+}
+
+// Load returns the exact canonical manifest named by lease.
+func (l ManifestLoader) Load(
+	ctx context.Context,
+	lease JobLease,
+) (_ rawsync.CanonicalManifest, resultErr error) {
+	if l.Store == nil {
+		return rawsync.CanonicalManifest{}, fmt.Errorf("%w: manifest store is required", rawsync.ErrInvalid)
+	}
+	if l.Limits.MaxCanonicalBytes <= 0 {
+		return rawsync.CanonicalManifest{}, fmt.Errorf("%w: manifest limits are invalid", rawsync.ErrInvalid)
+	}
+	if _, err := rawsync.NewObjectRef(lease.ManifestID, 0); err != nil {
+		return rawsync.CanonicalManifest{}, fmt.Errorf("loading raw manifest: %w", err)
+	}
+	info, reader, err := l.Store.OpenManifest(ctx, lease.Identity, lease.ManifestID)
+	if err != nil {
+		return rawsync.CanonicalManifest{}, fmt.Errorf("opening raw manifest: %w", err)
+	}
+	if reader == nil {
+		return rawsync.CanonicalManifest{}, fmt.Errorf("opening raw manifest: %w: reader is missing", rawsync.ErrInvalid)
+	}
+	defer func() {
+		if err := reader.Close(); err != nil && resultErr == nil {
+			resultErr = fmt.Errorf("closing raw manifest: %w", err)
+		}
+	}()
+	if info.Ref.SHA256 != lease.ManifestID || info.Ref.Length <= 0 ||
+		info.Ref.Length > int64(l.Limits.MaxCanonicalBytes) {
+		return rawsync.CanonicalManifest{}, fmt.Errorf(
+			"%w: stored manifest identity is inconsistent", rawsync.ErrInvalid,
+		)
+	}
+	canonicalJSON, err := io.ReadAll(io.LimitReader(
+		reader, int64(l.Limits.MaxCanonicalBytes)+1,
+	))
+	if err != nil {
+		return rawsync.CanonicalManifest{}, fmt.Errorf("reading raw manifest: %w", err)
+	}
+	if len(canonicalJSON) > l.Limits.MaxCanonicalBytes ||
+		int64(len(canonicalJSON)) != info.Ref.Length {
+		return rawsync.CanonicalManifest{}, fmt.Errorf(
+			"%w: stored manifest length is inconsistent", rawsync.ErrInvalid,
+		)
+	}
+	if err := reader.Verify(); err != nil {
+		return rawsync.CanonicalManifest{}, fmt.Errorf("verifying raw manifest: %w", err)
+	}
+	manifest, err := rawsync.ParseCanonicalManifest(
+		lease.Identity, lease.ManifestID, canonicalJSON, l.Limits,
+	)
+	if err != nil {
+		return rawsync.CanonicalManifest{}, fmt.Errorf("parsing raw manifest: %w", err)
+	}
+	return manifest, nil
+}

--- a/internal/rawderive/manifest_test.go
+++ b/internal/rawderive/manifest_test.go
@@ -1,0 +1,165 @@
+package rawderive
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestManifestLoaderReadsAndVerifiesCanonicalEnvelope(t *testing.T) {
+	t.Parallel()
+	identity, canonical := canonicalTestManifest(t)
+	reader := &testVerifiedReader{Reader: bytes.NewReader(canonical.CanonicalJSON)}
+	store := manifestStoreFunc(func(
+		_ context.Context,
+		gotIdentity rawsync.AuthIdentity,
+		gotManifestID string,
+	) (rawsync.ObjectInfo, rawsync.VerifiedObjectReader, error) {
+		assert.Equal(t, identity, gotIdentity)
+		assert.Equal(t, canonical.ManifestID, gotManifestID)
+		return rawsync.ObjectInfo{Ref: rawsync.ObjectRef{
+			SHA256: canonical.ManifestID,
+			Length: int64(len(canonical.CanonicalJSON)),
+		}}, reader, nil
+	})
+
+	got, err := (ManifestLoader{
+		Store:  store,
+		Limits: rawsync.DefaultManifestLimits(),
+	}).Load(t.Context(), JobLease{Identity: identity, ManifestID: canonical.ManifestID})
+	require.NoError(t, err)
+	assert.Equal(t, canonical, got)
+	assert.True(t, reader.verified)
+	assert.True(t, reader.closed)
+}
+
+func TestManifestLoaderRejectsUnverifiedOrMismatchedObjects(t *testing.T) {
+	t.Parallel()
+	identity, canonical := canonicalTestManifest(t)
+	verificationFailure := errors.New("digest mismatch")
+
+	for _, tc := range []struct {
+		name   string
+		info   rawsync.ObjectInfo
+		bytes  []byte
+		verify error
+	}{
+		{
+			name: "wrong advertised digest",
+			info: rawsync.ObjectInfo{Ref: rawsync.ObjectRef{
+				SHA256: "0000000000000000000000000000000000000000000000000000000000000000",
+				Length: int64(len(canonical.CanonicalJSON)),
+			}},
+			bytes: canonical.CanonicalJSON,
+		},
+		{
+			name: "wrong advertised length",
+			info: rawsync.ObjectInfo{Ref: rawsync.ObjectRef{
+				SHA256: canonical.ManifestID,
+				Length: int64(len(canonical.CanonicalJSON) + 1),
+			}},
+			bytes: canonical.CanonicalJSON,
+		},
+		{
+			name: "verification failure",
+			info: rawsync.ObjectInfo{Ref: rawsync.ObjectRef{
+				SHA256: canonical.ManifestID,
+				Length: int64(len(canonical.CanonicalJSON)),
+			}},
+			bytes:  canonical.CanonicalJSON,
+			verify: verificationFailure,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reader := &testVerifiedReader{
+				Reader:    bytes.NewReader(tc.bytes),
+				verifyErr: tc.verify,
+			}
+			store := manifestStoreFunc(func(
+				context.Context,
+				rawsync.AuthIdentity,
+				string,
+			) (rawsync.ObjectInfo, rawsync.VerifiedObjectReader, error) {
+				return tc.info, reader, nil
+			})
+
+			_, err := (ManifestLoader{
+				Store:  store,
+				Limits: rawsync.DefaultManifestLimits(),
+			}).Load(t.Context(), JobLease{
+				Identity: identity, ManifestID: canonical.ManifestID,
+			})
+			require.Error(t, err)
+			assert.True(t, reader.closed)
+		})
+	}
+}
+
+type manifestStoreFunc func(
+	context.Context,
+	rawsync.AuthIdentity,
+	string,
+) (rawsync.ObjectInfo, rawsync.VerifiedObjectReader, error)
+
+func (f manifestStoreFunc) OpenManifest(
+	ctx context.Context,
+	identity rawsync.AuthIdentity,
+	manifestID string,
+) (rawsync.ObjectInfo, rawsync.VerifiedObjectReader, error) {
+	return f(ctx, identity, manifestID)
+}
+
+type testVerifiedReader struct {
+	io.Reader
+	verifyErr error
+	verified  bool
+	closed    bool
+}
+
+func (r *testVerifiedReader) Verify() error {
+	r.verified = true
+	return r.verifyErr
+}
+
+func (r *testVerifiedReader) Close() error {
+	r.closed = true
+	// Cancellation closes this reader to interrupt in-flight reads, so a
+	// close must reach a closable underlying stream too.
+	if closer, ok := r.Reader.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+func canonicalTestManifest(t *testing.T) (rawsync.AuthIdentity, rawsync.CanonicalManifest) {
+	t.Helper()
+	identity, err := rawsync.NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+	object, err := rawsync.NewObjectRef(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 3,
+	)
+	require.NoError(t, err)
+	canonical, err := rawsync.ValidateAndCanonicalize(identity, rawsync.Manifest{
+		SchemaVersion:    rawsync.ManifestSchemaVersion,
+		Provider:         "codex",
+		ConfiguredRootID: "root-a",
+		SourceKey:        "sessions/demo.jsonl#main",
+		CaptureID:        "capture-a",
+		CapturedAt:       time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		Kind:             rawsync.ManifestSnapshot,
+		Entries: []rawsync.Entry{{
+			Path: "session.jsonl", Type: "file", Length: 3,
+			Objects: []rawsync.ObjectRef{object},
+		}},
+	}, rawsync.DefaultManifestLimits())
+	require.NoError(t, err)
+	return identity, canonical
+}

--- a/internal/rawderive/materializer.go
+++ b/internal/rawderive/materializer.go
@@ -1,0 +1,259 @@
+package rawderive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// ObjectStore provides authenticated access to immutable custody objects.
+type ObjectStore interface {
+	CopyObject(
+		context.Context,
+		string,
+		rawsync.ObjectRef,
+		io.Writer,
+	) (rawsync.ObjectInfo, error)
+}
+
+// Materializer reconstructs one canonical source generation in an isolated
+// filesystem tree.
+type Materializer struct {
+	Store         ObjectStore
+	BaseDir       string
+	MaxTotalBytes int64
+	// removeTree overrides tree removal for tests. Production removal
+	// chmods directories writable again and removes the private tree.
+	removeTree func(string) error
+}
+
+// Materialization owns one private, read-only reconstructed source tree.
+type Materialization struct {
+	root       string
+	entries    map[string]string
+	removeTree func(string) error
+	mu         sync.Mutex
+}
+
+// Root returns the private materialization root.
+func (m *Materialization) Root() string {
+	if m == nil {
+		return ""
+	}
+	return m.root
+}
+
+// EntryPath resolves a canonical manifest entry inside the private tree.
+func (m *Materialization) EntryPath(entry string) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("%w: materialization is missing", rawsync.ErrInvalid)
+	}
+	path, ok := m.entries[entry]
+	if !ok {
+		return "", fmt.Errorf("%w: materialized entry %q", rawsync.ErrNotFound, entry)
+	}
+	return path, nil
+}
+
+var errMaterializationCleanup = errors.New("materialization cleanup failed")
+
+// Cleanup removes the private tree. It is safe to call more than once and
+// stays retryable: a transient removal failure is reported without latching,
+// so a later call can succeed once the underlying condition clears. Errors
+// never expose the raw tree location, and every failure carries
+// errMaterializationCleanup so callers can report the cleanup stage
+// distinctly in sanitized diagnostics.
+func (m *Materialization) Cleanup() error {
+	if m == nil || m.root == "" {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	remove := m.removeTree
+	if remove == nil {
+		remove = removeMaterializationTree
+	}
+	if err := remove(m.root); err != nil {
+		return fmt.Errorf("%w: cleaning raw materialization: %w",
+			errMaterializationCleanup,
+			redactedProviderError{
+				message: strings.ReplaceAll(err.Error(), m.root, "<materialized>"),
+				cause:   err,
+			},
+		)
+	}
+	return nil
+}
+
+func removeMaterializationTree(root string) error {
+	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err == nil && entry.IsDir() {
+			_ = os.Chmod(path, 0o700)
+		}
+		return nil
+	})
+	return os.RemoveAll(root)
+}
+
+// Materialize verifies and reconstructs every object in manifest before making
+// the resulting source tree read-only.
+func (m Materializer) Materialize(
+	ctx context.Context,
+	manifest rawsync.CanonicalManifest,
+) (_ *Materialization, resultErr error) {
+	if m.Store == nil {
+		return nil, fmt.Errorf("%w: object store is required", rawsync.ErrInvalid)
+	}
+	if strings.TrimSpace(m.BaseDir) == "" {
+		return nil, fmt.Errorf("%w: materialization base directory is required", rawsync.ErrInvalid)
+	}
+	if m.MaxTotalBytes <= 0 {
+		return nil, fmt.Errorf("%w: materialization byte limit must be positive", rawsync.ErrInvalid)
+	}
+	if err := rawsync.ValidateCanonicalManifest(manifest); err != nil {
+		return nil, err
+	}
+	var total int64
+	for _, entry := range manifest.Manifest.Entries {
+		if entry.Length > m.MaxTotalBytes-total {
+			return nil, fmt.Errorf(
+				"%w: materialization exceeds %d bytes", rawsync.ErrInvalid, m.MaxTotalBytes,
+			)
+		}
+		total += entry.Length
+	}
+
+	root, err := os.MkdirTemp(m.BaseDir, "agentsview-raw-")
+	if err != nil {
+		return nil, fmt.Errorf("creating raw materialization: %w", err)
+	}
+	result := &Materialization{
+		root: root, entries: make(map[string]string), removeTree: m.removeTree,
+	}
+	defer func() {
+		if resultErr != nil {
+			if cleanupErr := result.Cleanup(); cleanupErr != nil {
+				resultErr = errors.Join(resultErr, cleanupErr)
+			}
+		}
+	}()
+
+	for _, entry := range manifest.Manifest.Entries {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		target := filepath.Join(root, filepath.FromSlash(entry.Path))
+		if err := ensureMaterializedPath(root, target); err != nil {
+			return nil, err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			return nil, fmt.Errorf("creating raw materialization directory: %w", err)
+		}
+		if err := m.materializeEntry(
+			ctx, manifest.Identity.TenantID, entry, manifest.Manifest.CapturedAt, target,
+		); err != nil {
+			return nil, err
+		}
+		result.entries[entry.Path] = target
+	}
+	if err := makeMaterializationReadOnly(root); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (m Materializer) materializeEntry(
+	ctx context.Context,
+	tenantID string,
+	entry rawsync.Entry,
+	capturedAt time.Time,
+	target string,
+) (resultErr error) {
+	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating materialized raw entry: %w", err)
+	}
+	defer func() {
+		if file == nil {
+			return
+		}
+		if err := file.Close(); err != nil && resultErr == nil {
+			resultErr = fmt.Errorf("closing materialized raw entry: %w", err)
+		}
+	}()
+
+	var written int64
+	for _, object := range entry.Objects {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		info, err := m.Store.CopyObject(ctx, tenantID, object, file)
+		if err != nil {
+			return fmt.Errorf("copying raw object %s: %w", object.SHA256, err)
+		}
+		if info.Ref != object {
+			return fmt.Errorf("%w: raw object identity is inconsistent", rawsync.ErrInvalid)
+		}
+		written += object.Length
+	}
+	if written != entry.Length {
+		return fmt.Errorf("%w: materialized entry length is inconsistent", rawsync.ErrInvalid)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("closing materialized raw entry: %w", err)
+	}
+	file = nil
+	// Restore the captured source modification time so downstream parsers
+	// cannot observe the worker-local creation time. Generations captured
+	// before mod-time carriage normalize to the capture instant instead.
+	modTime := capturedAt
+	if entry.ModTimeNS != 0 {
+		modTime = time.Unix(0, entry.ModTimeNS)
+	}
+	if err := os.Chtimes(target, modTime, modTime); err != nil {
+		return fmt.Errorf("restoring materialized raw entry mod time: %w", err)
+	}
+	if err := os.Chmod(target, 0o400); err != nil {
+		return fmt.Errorf("making materialized raw entry read-only: %w", err)
+	}
+	return nil
+}
+
+func ensureMaterializedPath(root, target string) error {
+	relative, err := filepath.Rel(root, target)
+	if err != nil || relative == "." || relative == ".." ||
+		strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return fmt.Errorf("%w: materialized entry escapes its root", rawsync.ErrInvalid)
+	}
+	return nil
+}
+
+func makeMaterializationReadOnly(root string) error {
+	var directories []string
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			directories = append(directories, path)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("walking raw materialization: %w", err)
+	}
+	for _, directory := range slices.Backward(directories) {
+		if err := os.Chmod(directory, 0o500); err != nil {
+			return fmt.Errorf("making raw materialization read-only: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/rawderive/materializer_test.go
+++ b/internal/rawderive/materializer_test.go
@@ -1,0 +1,551 @@
+package rawderive
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestMaterializerReconstructsVerifiedReadOnlyTreeAndCleansUp(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	first := []byte("first ")
+	second := []byte("second")
+	firstRef := objectRefForBytes(t, first)
+	secondRef := objectRefForBytes(t, second)
+	identity, manifest := materializerTestManifest(t, []rawsync.Entry{{
+		Path:   "nested/session.jsonl",
+		Type:   "file",
+		Length: int64(len(first) + len(second)),
+		Objects: []rawsync.ObjectRef{
+			firstRef,
+			secondRef,
+		},
+	}})
+	store := &materializerStore{objects: map[rawsync.ObjectRef][]byte{
+		firstRef:  first,
+		secondRef: second,
+	}}
+
+	materialized, err := (Materializer{
+		Store:         store,
+		BaseDir:       baseDir,
+		MaxTotalBytes: 1024,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	require.NotEmpty(t, materialized.Root())
+	assert.Equal(t, []rawsync.ObjectRef{firstRef, secondRef}, store.opened)
+	assert.Equal(t, identity.TenantID, store.tenantID)
+
+	path, err := materialized.EntryPath("nested/session.jsonl")
+	require.NoError(t, err)
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, append(append([]byte(nil), first...), second...), contents)
+	fileInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), fileInfo.Mode().Perm()&0o222,
+		"materialized files must not be writable")
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), dirInfo.Mode().Perm()&0o222,
+		"materialized directories must not be writable")
+	for _, reader := range store.readers {
+		assert.True(t, reader.verified)
+		assert.True(t, reader.closed)
+	}
+
+	require.NoError(t, materialized.Cleanup())
+	_, err = os.Stat(materialized.Root())
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	require.NoError(t, materialized.Cleanup(), "cleanup must be idempotent")
+}
+
+func TestMaterializerRestoresSourceModTimeBeforeParsing(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	// Use 100 ns precision so the assertion is portable to Windows filesystems.
+	sourceModTime := time.Date(2026, 8, 13, 11, 0, 0, 123456700, time.UTC)
+	sourced := []byte("sourced")
+	legacy := []byte("legacy")
+	sourcedRef := objectRefForBytes(t, sourced)
+	legacyRef := objectRefForBytes(t, legacy)
+	_, manifest := materializerTestManifest(t, []rawsync.Entry{
+		{
+			Path: "sourced.jsonl", Type: "file", Length: int64(len(sourced)),
+			ModTimeNS: sourceModTime.UnixNano(),
+			Objects:   []rawsync.ObjectRef{sourcedRef},
+		},
+		{
+			Path: "legacy.jsonl", Type: "file", Length: int64(len(legacy)),
+			Objects: []rawsync.ObjectRef{legacyRef},
+		},
+	})
+	store := &materializerStore{objects: map[rawsync.ObjectRef][]byte{
+		sourcedRef: sourced,
+		legacyRef:  legacy,
+	}}
+
+	materialized, err := (Materializer{
+		Store: store, BaseDir: baseDir, MaxTotalBytes: 1024,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+
+	sourcedInfo, err := os.Stat(materialized.entries["sourced.jsonl"])
+	require.NoError(t, err)
+	assert.True(t, sourcedInfo.ModTime().Equal(sourceModTime),
+		"entries with a captured mod time must be restored to it, not the worker clock")
+	legacyInfo, err := os.Stat(materialized.entries["legacy.jsonl"])
+	require.NoError(t, err)
+	assert.True(t, legacyInfo.ModTime().Equal(manifest.Manifest.CapturedAt),
+		"legacy entries without a captured mod time must be normalized to the capture time")
+}
+
+func TestMaterializerRejectsUnverifiedObjectsAndRemovesPartialTree(t *testing.T) {
+	t.Parallel()
+	data := []byte("session")
+	object := objectRefForBytes(t, data)
+	_, manifest := materializerTestManifest(t, []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: int64(len(data)),
+		Objects: []rawsync.ObjectRef{object},
+	}})
+	verificationFailure := errors.New("digest mismatch")
+
+	for _, tc := range []struct {
+		name      string
+		info      rawsync.ObjectRef
+		data      []byte
+		verifyErr error
+	}{
+		{name: "wrong identity", info: rawsync.ObjectRef{
+			SHA256: object.SHA256, Length: object.Length + 1,
+		}, data: data},
+		{name: "short body", info: object, data: data[:len(data)-1]},
+		{name: "long body", info: object, data: append(append([]byte(nil), data...), '!')},
+		{name: "verification failure", info: object, data: data, verifyErr: verificationFailure},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			baseDir := t.TempDir()
+			store := &materializerStore{
+				objects: map[rawsync.ObjectRef][]byte{object: tc.data},
+				infos:   map[rawsync.ObjectRef]rawsync.ObjectRef{object: tc.info},
+				verify:  map[rawsync.ObjectRef]error{object: tc.verifyErr},
+			}
+			_, err := (Materializer{
+				Store: store, BaseDir: baseDir, MaxTotalBytes: 1024,
+			}).Materialize(t.Context(), manifest)
+			require.Error(t, err)
+			entries, readErr := os.ReadDir(baseDir)
+			require.NoError(t, readErr)
+			assert.Empty(t, entries, "failed materialization must remove its private tree")
+		})
+	}
+}
+
+func TestMaterializerEnforcesAggregateLimitBeforeOpeningObjects(t *testing.T) {
+	t.Parallel()
+	data := []byte("session")
+	object := objectRefForBytes(t, data)
+	_, manifest := materializerTestManifest(t, []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: int64(len(data)),
+		Objects: []rawsync.ObjectRef{object},
+	}})
+	store := &materializerStore{objects: map[rawsync.ObjectRef][]byte{object: data}}
+
+	_, err := (Materializer{
+		Store: store, BaseDir: t.TempDir(), MaxTotalBytes: int64(len(data) - 1),
+	}).Materialize(t.Context(), manifest)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+	assert.Empty(t, store.opened)
+}
+
+func TestMaterializeObjectCopyObservesCancellationInBoundedChunks(t *testing.T) {
+	t.Parallel()
+	chunk := bytes.Repeat([]byte("agentsview"), 512) // 4 KiB chunks
+	total := int64(len(chunk)) * 48                  // ~192 KiB across many chunks
+	data := bytes.Repeat(chunk, 48)
+	object := objectRefForBytes(t, data)
+	_, manifest := materializerTestManifest(t, []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: total,
+		Objects: []rawsync.ObjectRef{object},
+	}})
+	// The reader ignores the context on purpose: only the copy loop's own
+	// bounded-chunk observation may stop it.
+	store := &materializerStore{
+		objects: map[rawsync.ObjectRef][]byte{object: data},
+		readerFactory: func(ctx context.Context, data []byte) io.Reader {
+			return &pacedReader{ctx: ctx, data: data, chunkSize: len(chunk), delay: 15 * time.Millisecond}
+		},
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+
+	_, err := (Materializer{
+		Store: store, BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(ctx, manifest)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"a stalled object stream must stop materialization at a chunk boundary")
+	assert.Less(t, time.Since(started), 2*time.Second,
+		"cancellation must be observed between bounded copy chunks")
+}
+
+func TestMaterializeTrailingProbeObservesCancellation(t *testing.T) {
+	t.Parallel()
+	data := []byte("session-body")
+	object := objectRefForBytes(t, data)
+	_, manifest := materializerTestManifest(t, []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: int64(len(data)),
+		Objects: []rawsync.ObjectRef{object},
+	}})
+	// The body arrives immediately; the first extra read (the one-byte
+	// trailing probe) stalls until the context is done. The probe must
+	// observe the context instead of blocking on the stalled stream.
+	store := &materializerStore{
+		objects: map[rawsync.ObjectRef][]byte{object: data},
+		readerFactory: func(ctx context.Context, data []byte) io.Reader {
+			return &probeStallReader{ctx: ctx, data: data}
+		},
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+
+	_, err := (Materializer{
+		Store: store, BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(ctx, manifest)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"the trailing length probe must observe cancellation")
+	assert.Less(t, time.Since(started), 2*time.Second)
+}
+
+// pacedReader yields fixed-size chunks after a delay and deliberately ignores
+// its context, so only explicit bounded-chunk context observation stops it.
+type pacedReader struct {
+	ctx       context.Context
+	data      []byte
+	chunkSize int
+	delay     time.Duration
+	offset    int
+}
+
+func (r *pacedReader) Read(p []byte) (int, error) {
+	if r.offset >= len(r.data) {
+		return 0, io.EOF
+	}
+	time.Sleep(r.delay)
+	if r.offset >= len(r.data) {
+		return 0, io.EOF
+	}
+	size := min(len(p), r.chunkSize, len(r.data)-r.offset)
+	n := copy(p, r.data[r.offset:r.offset+size])
+	r.offset += n
+	return n, nil
+}
+
+// probeStallReader serves its whole body immediately, then blocks the next
+// read until the context is done.
+type probeStallReader struct {
+	ctx    context.Context
+	data   []byte
+	offset int
+}
+
+func (r *probeStallReader) Read(p []byte) (int, error) {
+	if r.offset < len(r.data) {
+		n := copy(p, r.data[r.offset:])
+		r.offset += n
+		return n, nil
+	}
+	<-r.ctx.Done()
+	return 0, r.ctx.Err()
+}
+
+func TestMaterializerRejectsConflictingEntryPathsBeforeCreatingFiles(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	data := []byte("session")
+	object := objectRefForBytes(t, data)
+	identity, err := rawsync.NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+
+	// Forge the exact envelope a binary without the path-collision check
+	// would have persisted: "a" is a file while "a/b" needs "a" as a
+	// directory, so the manifest is internally consistent yet unmaterializable.
+	captiveManifest := rawsync.Manifest{
+		SchemaVersion:    rawsync.ManifestSchemaVersion,
+		Provider:         "codex",
+		ConfiguredRootID: "root-a",
+		SourceKey:        "sessions/demo.jsonl#main",
+		CaptureID:        "capture-a",
+		CapturedAt:       time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		Kind:             rawsync.ManifestSnapshot,
+		Entries: []rawsync.Entry{
+			{Path: "a", Type: "file", Length: int64(len(data)),
+				Objects: []rawsync.ObjectRef{object}},
+			{Path: "a/b", Type: "file", Length: int64(len(data)),
+				Objects: []rawsync.ObjectRef{object}},
+		},
+	}
+	canonicalJSON := []byte(fmt.Sprintf(
+		`{"schema_version":1,"tenant_id":"tenant-a","device_id":"device-a","provider":"codex","configured_root_id":"root-a","source_key":"sessions/demo.jsonl#main","capture_id":"capture-a","captured_at":"2026-08-13T12:00:00Z","kind":"snapshot","entries":[{"path":"a","type":"file","length":7,"objects":[{"sha256":%q,"length":7}]},{"path":"a/b","type":"file","length":7,"objects":[{"sha256":%q,"length":7}]}]}`+"\n",
+		object.SHA256, object.SHA256,
+	))
+	digest := sha256.Sum256(canonicalJSON)
+	conflicted := rawsync.CanonicalManifest{
+		Identity:      identity,
+		Manifest:      captiveManifest,
+		ManifestID:    hex.EncodeToString(digest[:]),
+		CanonicalJSON: canonicalJSON,
+		Objects:       []rawsync.ObjectRef{object},
+	}
+	store := &materializerStore{objects: map[rawsync.ObjectRef][]byte{object: data}}
+
+	materialized, err := (Materializer{
+		Store: store, BaseDir: baseDir, MaxTotalBytes: 1024,
+	}).Materialize(t.Context(), conflicted)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid,
+		"conflicting paths must fail validation, not filesystem materialization")
+	assert.Nil(t, materialized)
+	assert.Empty(t, store.opened,
+		"conflicting manifests must be rejected before any object is opened")
+	entries, readErr := os.ReadDir(baseDir)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries,
+		"no materialization tree may be created for conflicting paths")
+}
+
+func TestMaterializeDelegatesInFlightCancellationToObjectStore(t *testing.T) {
+	t.Parallel()
+	data := []byte("session-body")
+	object := objectRefForBytes(t, data)
+	_, manifest := materializerTestManifest(t, []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: int64(len(data)),
+		Objects: []rawsync.ObjectRef{object},
+	}})
+	copyStarted := make(chan struct{})
+	store := &materializerStore{
+		objects: map[rawsync.ObjectRef][]byte{object: data},
+		copyObject: func(ctx context.Context, _ []byte, _ io.Writer) error {
+			close(copyStarted)
+			select {
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+			}
+			return ctx.Err()
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := (Materializer{
+			Store: store, BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+		}).Materialize(ctx, manifest)
+		done <- err
+	}()
+	select {
+	case <-copyStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the materializer never started copying the object")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled,
+			"the materializer must pass attempt cancellation into the store-owned copy")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the materialized copy never observed cancellation")
+	}
+}
+
+func TestMaterializationCleanupIsRetryableAfterTransientFailure(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	transient := errors.New("transient removal failure")
+	attempts := 0
+	materialized := &Materialization{
+		root:    root,
+		entries: map[string]string{},
+		removeTree: func(path string) error {
+			attempts++
+			if attempts == 1 {
+				return transient
+			}
+			return os.RemoveAll(path)
+		},
+	}
+
+	firstErr := materialized.Cleanup()
+
+	require.ErrorIs(t, firstErr, transient,
+		"a failed cleanup must stay reportable")
+	assert.NotContains(t, firstErr.Error(), root,
+		"cleanup errors must not expose the raw tree path")
+	_, statErr := os.Stat(root)
+	require.NoError(t, statErr, "a failed removal must leave the tree in place")
+
+	require.NoError(t, materialized.Cleanup(),
+		"a transient cleanup failure must be retryable, not latched")
+	_, statErr = os.Stat(root)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+	require.NoError(t, materialized.Cleanup(), "successful cleanup stays idempotent")
+}
+
+func TestMaterializeJoinsPartialCleanupFailureIntoOperationError(t *testing.T) {
+	t.Parallel()
+	data := []byte("session")
+	object := objectRefForBytes(t, data)
+	_, manifest := materializerTestManifest(t, []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: int64(len(data)),
+		Objects: []rawsync.ObjectRef{object},
+	}})
+	cleanupFailure := errors.New("scratch removal failed")
+	store := &materializerStore{
+		objects: map[rawsync.ObjectRef][]byte{object: data},
+		verify:  map[rawsync.ObjectRef]error{object: errors.New("digest mismatch")},
+	}
+
+	_, err := (Materializer{
+		Store: store, BaseDir: t.TempDir(), MaxTotalBytes: 1024,
+		removeTree: func(string) error { return cleanupFailure },
+	}).Materialize(t.Context(), manifest)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cleanupFailure,
+		"partial-materialization cleanup failures must join the operation error")
+	assert.NotContains(t, err.Error(), "agentsview-raw",
+		"the joined error must not expose the raw tree path")
+}
+
+type materializerStore struct {
+	objects       map[rawsync.ObjectRef][]byte
+	infos         map[rawsync.ObjectRef]rawsync.ObjectRef
+	verify        map[rawsync.ObjectRef]error
+	readerFactory func(context.Context, []byte) io.Reader
+	copyObject    func(context.Context, []byte, io.Writer) error
+	tenantID      string
+	opened        []rawsync.ObjectRef
+	readers       []*testVerifiedReader
+}
+
+func (s *materializerStore) CopyObject(
+	ctx context.Context,
+	tenantID string,
+	object rawsync.ObjectRef,
+	destination io.Writer,
+) (rawsync.ObjectInfo, error) {
+	s.tenantID = tenantID
+	s.opened = append(s.opened, object)
+	data, ok := s.objects[object]
+	if !ok {
+		return rawsync.ObjectInfo{}, rawsync.ErrNotFound
+	}
+	info := object
+	if replacement, ok := s.infos[object]; ok {
+		info = replacement
+	}
+	reader := &testVerifiedReader{
+		Reader:    bytes.NewReader(data),
+		verifyErr: s.verify[object],
+	}
+	if s.readerFactory != nil {
+		reader = &testVerifiedReader{
+			Reader:    s.readerFactory(ctx, data),
+			verifyErr: s.verify[object],
+		}
+	}
+	s.readers = append(s.readers, reader)
+	defer func() { _ = reader.Close() }()
+	if s.copyObject != nil {
+		if err := s.copyObject(ctx, data, destination); err != nil {
+			return rawsync.ObjectInfo{}, err
+		}
+		return rawsync.ObjectInfo{Ref: info}, nil
+	}
+	stream := materializerContextReader{ctx: ctx, reader: reader}
+	if _, err := io.CopyN(destination, stream, object.Length); err != nil {
+		return rawsync.ObjectInfo{}, err
+	}
+	extra, err := io.Copy(io.Discard, io.LimitReader(stream, 1))
+	if err != nil {
+		return rawsync.ObjectInfo{}, err
+	}
+	if extra != 0 {
+		return rawsync.ObjectInfo{}, rawsync.ErrInvalid
+	}
+	if err := ctx.Err(); err != nil {
+		return rawsync.ObjectInfo{}, err
+	}
+	if err := reader.Verify(); err != nil {
+		return rawsync.ObjectInfo{}, err
+	}
+	return rawsync.ObjectInfo{Ref: info}, nil
+}
+
+type materializerContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r materializerContextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(p) > 64<<10 {
+		p = p[:64<<10]
+	}
+	n, err := r.reader.Read(p)
+	if err != nil && r.ctx.Err() != nil {
+		return n, r.ctx.Err()
+	}
+	return n, err
+}
+
+func objectRefForBytes(t *testing.T, data []byte) rawsync.ObjectRef {
+	t.Helper()
+	digest := sha256.Sum256(data)
+	object, err := rawsync.NewObjectRef(hex.EncodeToString(digest[:]), int64(len(data)))
+	require.NoError(t, err)
+	return object
+}
+
+func materializerTestManifest(
+	t *testing.T,
+	entries []rawsync.Entry,
+) (rawsync.AuthIdentity, rawsync.CanonicalManifest) {
+	t.Helper()
+	identity, err := rawsync.NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+	canonical, err := rawsync.ValidateAndCanonicalize(identity, rawsync.Manifest{
+		SchemaVersion:    rawsync.ManifestSchemaVersion,
+		Provider:         "codex",
+		ConfiguredRootID: "root-a",
+		SourceKey:        "sessions/demo.jsonl#main",
+		CaptureID:        "capture-a",
+		CapturedAt:       time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		Kind:             rawsync.ManifestSnapshot,
+		Entries:          entries,
+	}, rawsync.DefaultManifestLimits())
+	require.NoError(t, err)
+	return identity, canonical
+}

--- a/internal/rawderive/parser.go
+++ b/internal/rawderive/parser.go
@@ -1,0 +1,647 @@
+package rawderive
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// ParsedManifest is the provider-owned normalized outcome for one raw source
+// generation. Tombstones intentionally carry an empty outcome.
+type ParsedManifest struct {
+	Outcome   parser.ParseOutcome
+	Tombstone bool
+}
+
+// ProviderParser dispatches materialized sources through registered provider
+// implementations.
+type ProviderParser struct {
+	factories map[parser.AgentType]parser.ProviderFactory
+	machine   string
+}
+
+// NewProviderParser constructs a provider dispatcher from an explicit factory
+// registry.
+func NewProviderParser(
+	factories []parser.ProviderFactory,
+	machine string,
+) (*ProviderParser, error) {
+	if strings.TrimSpace(machine) == "" {
+		return nil, fmt.Errorf("%w: parser machine is required", rawsync.ErrInvalid)
+	}
+	registry := make(map[parser.AgentType]parser.ProviderFactory, len(factories))
+	for _, factory := range factories {
+		if factory == nil || factory.Definition().Type == "" {
+			return nil, fmt.Errorf("%w: provider factory is invalid", rawsync.ErrInvalid)
+		}
+		providerType := factory.Definition().Type
+		if _, exists := registry[providerType]; exists {
+			return nil, fmt.Errorf("%w: duplicate provider factory %q", rawsync.ErrInvalid, providerType)
+		}
+		registry[providerType] = factory
+	}
+	return &ProviderParser{factories: registry, machine: machine}, nil
+}
+
+// Parse discovers the single provider source described by manifest, verifies
+// its raw-capture membership, and invokes that provider's parser.
+func (p *ProviderParser) Parse(
+	ctx context.Context,
+	manifest rawsync.CanonicalManifest,
+	materialized *Materialization,
+) (ParsedManifest, error) {
+	if p == nil {
+		return ParsedManifest{}, fmt.Errorf("%w: provider parser is missing", rawsync.ErrInvalid)
+	}
+	if err := rawsync.ValidateCanonicalManifest(manifest); err != nil {
+		return ParsedManifest{}, err
+	}
+	if manifest.Manifest.Kind == rawsync.ManifestTombstone {
+		return ParsedManifest{Tombstone: true}, nil
+	}
+	if materialized == nil || materialized.Root() == "" {
+		return ParsedManifest{}, fmt.Errorf("%w: materialized source is required", rawsync.ErrInvalid)
+	}
+	// The materialized tree is untrusted client data: every cwd recorded in
+	// transcripts and provider databases names the capturing host, never this
+	// worker. Pin project attribution to transcript metadata and lexical path
+	// rules for the whole hosted pipeline -- discovery, plan matching,
+	// fingerprinting, and parsing -- so provider helpers cannot walk this
+	// server's filesystem or read its .git metadata from an attacker-chosen
+	// cwd.
+	ctx = parser.WithoutFilesystemProjectDiscovery(ctx)
+	factory, ok := p.factories[manifest.Manifest.Provider]
+	if !ok {
+		return ParsedManifest{}, fmt.Errorf(
+			"%w: provider %q is not registered", rawsync.ErrInvalid, manifest.Manifest.Provider,
+		)
+	}
+	// A manifest is provider-owned custody data, but the factory registry
+	// is this worker's: only a factory that explicitly advertises raw-capture
+	// support may construct a provider for hosted derivation. Rejecting
+	// earlier keeps unvetted discovery code off the materialized tree.
+	if factory.Capabilities().RawCapture.Support != parser.CapabilitySupported {
+		return ParsedManifest{}, fmt.Errorf(
+			"%w: provider %q does not support %s", rawsync.ErrInvalid,
+			manifest.Manifest.Provider, parser.ProviderFeatureRawCapture,
+		)
+	}
+	paths := newStablePathMap(manifest, materialized)
+	roots := materializedProviderRoots(manifest, materialized)
+	provider := factory.NewProvider(parser.ProviderConfig{
+		Roots:                 roots,
+		MetadataDirs:          materializedProviderMetadataDirs(manifest, materialized, roots),
+		Machine:               p.machine,
+		StableSourceSnapshots: true,
+		PathRewriter:          paths.rewrite,
+	})
+	if provider == nil {
+		return ParsedManifest{}, fmt.Errorf("%w: provider construction failed", rawsync.ErrInvalid)
+	}
+	discovery, err := parser.DiscoverRawCaptureSources(ctx, provider)
+	if err != nil {
+		return ParsedManifest{}, redactMaterializedError("discovering provider source", err, materialized.Root())
+	}
+	if !discovery.Complete {
+		return ParsedManifest{}, fmt.Errorf("provider raw-capture discovery is incomplete")
+	}
+	source, err := matchProviderSource(ctx, provider, discovery.Sources, manifest, materialized)
+	if err != nil {
+		return ParsedManifest{}, err
+	}
+	paths.bindSource(source, manifest.Manifest.SourceKey)
+	sessions, fanOut, err := parser.ResolveRawSnapshotSessions(ctx, provider, source)
+	if err != nil {
+		return ParsedManifest{}, redactMaterializedError(
+			"resolving raw snapshot sessions", err, materialized.Root(),
+		)
+	}
+	if fanOut {
+		return p.parseRawSnapshotSessions(ctx, provider, paths, materialized, sessions)
+	}
+	fingerprint, err := provider.Fingerprint(ctx, source)
+	if err != nil {
+		return ParsedManifest{}, redactMaterializedError("fingerprinting provider source", err, materialized.Root())
+	}
+	fingerprint.Key = paths.rewrite(fingerprint.Key)
+	source.Key = manifest.Manifest.SourceKey
+	source.DisplayPath = paths.rewrite(source.DisplayPath)
+	source.FingerprintKey = paths.rewrite(source.FingerprintKey)
+	if source.DisplayPath == "" {
+		source.DisplayPath = manifest.Manifest.SourceKey
+	}
+	if source.FingerprintKey == "" {
+		source.FingerprintKey = manifest.Manifest.SourceKey
+	}
+	if fingerprint.Key == "" {
+		fingerprint.Key = source.FingerprintKey
+	}
+	outcome, err := provider.Parse(ctx, parser.ParseRequest{
+		Source:             source,
+		Fingerprint:        fingerprint,
+		Machine:            p.machine,
+		ForceParse:         true,
+		StoredPathResolver: paths.resolve,
+	})
+	if err != nil {
+		return ParsedManifest{}, redactMaterializedError("parsing provider source", err, materialized.Root())
+	}
+	rewriteParseOutcome(&outcome, paths, materialized.Root())
+	return ParsedManifest{Outcome: outcome}, nil
+}
+
+// materializedProviderRoots reconstructs provider discovery roots inside the
+// private materialization. Codex capture plans widen from a configured
+// sessions or archived_sessions directory to its parent so they can carry
+// session_index.jsonl. Cross-root replay parents have their own flat root.
+// Recover both using the provider's recognized flat and dated layouts while
+// keeping the primary transcript's root first.
+func materializedProviderRoots(
+	manifest rawsync.CanonicalManifest,
+	materialized *Materialization,
+) []string {
+	root := materialized.Root()
+	if manifest.Manifest.Provider != parser.AgentCodex {
+		return []string{root}
+	}
+	sourcePrefix := string(parser.AgentCodex) + ":"
+	sourceID := strings.TrimPrefix(manifest.Manifest.SourceKey, sourcePrefix)
+	if sourceID == manifest.Manifest.SourceKey {
+		sourceID = ""
+	}
+	var primaryRoot string
+	seen := make(map[string]struct{}, 2)
+	var roots []string
+	for _, entry := range manifest.Manifest.Entries {
+		local := filepath.Join(root, filepath.FromSlash(entry.Path))
+		candidate := root
+		_, id, valid := parser.CodexSessionPathInfo(candidate, local)
+		if !valid {
+			top, _, nested := strings.Cut(entry.Path, "/")
+			if !nested {
+				continue
+			}
+			candidate = filepath.Join(root, top)
+			_, id, valid = parser.CodexSessionPathInfo(candidate, local)
+			if !valid {
+				continue
+			}
+		}
+		if _, exists := seen[candidate]; !exists {
+			seen[candidate] = struct{}{}
+			roots = append(roots, candidate)
+		}
+		if sourceID != "" && id == sourceID {
+			primaryRoot = candidate
+		}
+	}
+	if len(roots) == 0 {
+		return []string{root}
+	}
+	if primaryRoot == "" || roots[0] == primaryRoot {
+		return roots
+	}
+	for i := range roots {
+		if roots[i] == primaryRoot {
+			roots[0], roots[i] = roots[i], roots[0]
+			break
+		}
+	}
+	return roots
+}
+
+// materializedProviderMetadataDirs restores Codex's ordered home indexes.
+// The provider merges indexes by captured mtime, with later homes winning ties.
+func materializedProviderMetadataDirs(
+	manifest rawsync.CanonicalManifest,
+	materialized *Materialization,
+	roots []string,
+) map[string][]string {
+	if manifest.Manifest.Provider != parser.AgentCodex {
+		return nil
+	}
+	type aliasHome struct {
+		index int
+		dir   string
+	}
+	var aliases []aliasHome
+	for _, entry := range manifest.Manifest.Entries {
+		if path.Base(entry.Path) != parser.CodexSessionIndexFilename {
+			continue
+		}
+		ordinal, ok := strings.CutPrefix(path.Dir(entry.Path), "alias-homes/")
+		index, err := strconv.Atoi(ordinal)
+		if !ok || err != nil || index <= 0 || strconv.Itoa(index) != ordinal {
+			continue
+		}
+		aliases = append(aliases, aliasHome{
+			index: index, dir: filepath.Join(materialized.Root(), filepath.FromSlash(path.Dir(entry.Path))),
+		})
+	}
+	slices.SortFunc(aliases, func(a, b aliasHome) int { return cmp.Compare(a.index, b.index) })
+	dirs := []string{materialized.Root()}
+	for _, alias := range aliases {
+		dirs = append(dirs, alias.dir)
+	}
+	metadata := make(map[string][]string, len(roots))
+	for _, root := range roots {
+		metadata[root] = dirs
+	}
+	return metadata
+}
+
+func (p *ProviderParser) parseRawSnapshotSessions(
+	ctx context.Context,
+	provider parser.Provider,
+	paths *stablePathMap,
+	materialized *Materialization,
+	sessions []parser.SourceRef,
+) (ParsedManifest, error) {
+	// One physical SQLite snapshot replaces the provider's whole logical
+	// session set for this source generation.
+	aggregate := parser.ParseOutcome{ResultSetComplete: true, ForceReplace: true}
+	if len(sessions) == 0 {
+		aggregate.SkipReason = parser.SkipNoSession
+		return ParsedManifest{Outcome: aggregate}, nil
+	}
+	for _, session := range sessions {
+		if err := ctx.Err(); err != nil {
+			return ParsedManifest{}, err
+		}
+		fingerprint, err := provider.Fingerprint(ctx, session)
+		if err != nil {
+			return ParsedManifest{}, redactMaterializedError(
+				"fingerprinting raw snapshot session", err, materialized.Root(),
+			)
+		}
+		fingerprint.Key = paths.rewrite(fingerprint.Key)
+		source := session
+		source.Key = paths.rewrite(session.Key)
+		source.DisplayPath = paths.rewrite(session.DisplayPath)
+		source.FingerprintKey = paths.rewrite(session.FingerprintKey)
+		if source.DisplayPath == "" {
+			source.DisplayPath = source.Key
+		}
+		if source.FingerprintKey == "" {
+			source.FingerprintKey = source.Key
+		}
+		if fingerprint.Key == "" {
+			fingerprint.Key = source.FingerprintKey
+		}
+		outcome, err := provider.Parse(ctx, parser.ParseRequest{
+			Source:             source,
+			Fingerprint:        fingerprint,
+			Machine:            p.machine,
+			ForceParse:         true,
+			StoredPathResolver: paths.resolve,
+		})
+		if err != nil {
+			return ParsedManifest{}, redactMaterializedError(
+				"parsing raw snapshot session", err, materialized.Root(),
+			)
+		}
+		aggregate.Results = append(aggregate.Results, outcome.Results...)
+		aggregate.ExcludedSessionIDs = append(aggregate.ExcludedSessionIDs, outcome.ExcludedSessionIDs...)
+		aggregate.SourceErrors = append(aggregate.SourceErrors, outcome.SourceErrors...)
+		aggregate.ResultSetComplete = aggregate.ResultSetComplete && outcome.ResultSetComplete
+	}
+	rewriteParseOutcome(&aggregate, paths, materialized.Root())
+	return ParsedManifest{Outcome: aggregate}, nil
+}
+
+// sameMaterializedEntryFile reports whether a validated provider plan entry
+// and a materialized manifest entry resolve to the same existing regular
+// file. Plan validation canonicalizes spelling through symlink resolution,
+// so entries can carry equivalent spellings of one file (symlinked components,
+// Windows short names, and case-insensitive paths).
+func sameMaterializedEntryFile(planPath, materializedPath string) bool {
+	planned, err := os.Stat(planPath)
+	if err != nil || !planned.Mode().IsRegular() {
+		return false
+	}
+	materialized, err := os.Stat(materializedPath)
+	if err != nil || !materialized.Mode().IsRegular() {
+		return false
+	}
+	if os.SameFile(planned, materialized) {
+		return true
+	}
+	// Filesystems that cannot report stable file identities fall back to
+	// comparing resolved spellings.
+	resolvedPlan, planErr := filepath.EvalSymlinks(planPath)
+	resolvedMaterialized, materializedErr := filepath.EvalSymlinks(materializedPath)
+	return planErr == nil && materializedErr == nil &&
+		filepath.Clean(resolvedPlan) == filepath.Clean(resolvedMaterialized)
+}
+
+func matchProviderSource(
+	ctx context.Context,
+	provider parser.Provider,
+	sources []parser.SourceRef,
+	manifest rawsync.CanonicalManifest,
+	materialized *Materialization,
+) (parser.SourceRef, error) {
+	wantPaths := make([]string, 0, len(manifest.Manifest.Entries))
+	// The manifest's primary entry is the relative entry its source key ends
+	// with. Sibling lineage plans can share the same entries, so select the
+	// source whose physical path matches that primary entry.
+	sourceEntry := manifestPrimaryEntry(manifest)
+	for _, entry := range manifest.Manifest.Entries {
+		wantPaths = append(wantPaths, entry.Path)
+	}
+	slices.Sort(wantPaths)
+	var matches, primaryMatches []parser.SourceRef
+	for _, source := range sources {
+		plan, supported, err := parser.ResolveRawCapturePlan(ctx, provider, source)
+		if err != nil {
+			return parser.SourceRef{}, redactMaterializedError(
+				"resolving provider raw-capture plan", err, materialized.Root(),
+			)
+		}
+		if !supported || len(plan.Entries) != len(wantPaths) {
+			continue
+		}
+		if !rawCaptureSourceIdentityMatches(
+			source, plan.SourceKey,
+			manifest.Manifest.SourceKey, sourceEntry,
+		) {
+			continue
+		}
+		gotPaths := make([]string, 0, len(plan.Entries))
+		valid := true
+		primaryEntry := ""
+		for _, entry := range plan.Entries {
+			wantLocal, err := materialized.EntryPath(entry.Path)
+			if err != nil || !sameMaterializedEntryFile(entry.LocalPath, wantLocal) {
+				valid = false
+				break
+			}
+			if sameMaterializedEntryFile(entry.LocalPath, source.DisplayPath) {
+				primaryEntry = entry.Path
+			}
+			gotPaths = append(gotPaths, entry.Path)
+		}
+		slices.Sort(gotPaths)
+		if valid && slices.Equal(gotPaths, wantPaths) {
+			matches = append(matches, source)
+			if sourceEntry != "" && primaryEntry == sourceEntry {
+				primaryMatches = append(primaryMatches, source)
+			}
+		}
+	}
+	if len(primaryMatches) == 1 {
+		return primaryMatches[0], nil
+	}
+	if len(primaryMatches) > 1 || len(matches) != 1 {
+		return parser.SourceRef{}, fmt.Errorf(
+			"%w: manifest matched %d provider sources", rawsync.ErrInvalid, len(matches),
+		)
+	}
+	return matches[0], nil
+}
+
+// rawCaptureSourceIdentityMatches validates the provider-owned logical source
+// identity independently of its physical capture entries. Logical keys must
+// survive capture exactly. A source keyed by its display path instead uses the
+// primary manifest-relative entry as its portable identity.
+func rawCaptureSourceIdentityMatches(
+	source parser.SourceRef,
+	planKey string,
+	manifestKey string,
+	primaryEntry string,
+) bool {
+	if source.Key != source.DisplayPath {
+		return planKey == manifestKey
+	}
+	return primaryEntry != "" &&
+		sourceKeyEndsWithEntry(planKey, primaryEntry) &&
+		sourceKeyEndsWithEntry(manifestKey, primaryEntry)
+}
+
+type stablePathMap struct {
+	root    string
+	forward map[string]string
+	reverse map[string]string
+	prefix  string
+}
+
+func newStablePathMap(
+	manifest rawsync.CanonicalManifest,
+	materialized *Materialization,
+) *stablePathMap {
+	paths := &stablePathMap{
+		root:    filepath.Clean(materialized.Root()),
+		forward: make(map[string]string, len(manifest.Manifest.Entries)),
+		reverse: make(map[string]string, len(manifest.Manifest.Entries)),
+		prefix:  "raw-manifest:" + manifest.ManifestID + ":",
+	}
+	sourceEntry := manifestPrimaryEntry(manifest)
+	for _, entry := range manifest.Manifest.Entries {
+		local, err := materialized.EntryPath(entry.Path)
+		if err != nil {
+			continue
+		}
+		stable := paths.prefix + entry.Path
+		if entry.Path == sourceEntry {
+			stable = manifest.Manifest.SourceKey
+		}
+		paths.bind(local, stable)
+	}
+	paths.bindClientAliases(manifest, sourceEntry, materialized)
+	return paths
+}
+
+func manifestPrimaryEntry(manifest rawsync.CanonicalManifest) string {
+	primary := ""
+	for _, entry := range manifest.Manifest.Entries {
+		if sourceKeyEndsWithEntry(manifest.Manifest.SourceKey, entry.Path) &&
+			len(entry.Path) > len(primary) {
+			primary = entry.Path
+		}
+	}
+	return primary
+}
+
+func (m *stablePathMap) bindSource(source parser.SourceRef, stable string) {
+	m.bind(source.DisplayPath, stable)
+	m.bind(source.FingerprintKey, stable)
+}
+
+// bindClientAliases registers safe lexical aliases so an absolute client
+// path embedded in a transcript (the spelling the capturing host wrote, not
+// any server-side location) resolves back to the materialized copy of the
+// same validated manifest entry. The derivation is purely lexical: the
+// manifest source key minus the primary relative entry yields the captured
+// client root, and each entry rejoins that root with the client's separator
+// style, including Windows-style keys parsed on a different host OS. Aliases
+// are lookup keys only; they never rewrite worker-local paths and resolve
+// solely to entries the materialization already validated.
+func (m *stablePathMap) bindClientAliases(
+	manifest rawsync.CanonicalManifest,
+	sourceEntry string,
+	materialized *Materialization,
+) {
+	if sourceEntry == "" {
+		return
+	}
+	root, separator := clientSourceRoot(manifest.Manifest.SourceKey, sourceEntry)
+	if root == "" {
+		return
+	}
+	for _, entry := range manifest.Manifest.Entries {
+		local, err := materialized.EntryPath(entry.Path)
+		if err != nil {
+			continue
+		}
+		stable := m.prefix + entry.Path
+		if entry.Path == sourceEntry {
+			stable = manifest.Manifest.SourceKey
+		}
+		clientPath := strings.ReplaceAll(entry.Path, "/", separator)
+		for _, alias := range []string{
+			root + separator + clientPath,
+			root + "/" + entry.Path,
+		} {
+			if alias == stable {
+				continue
+			}
+			if _, exists := m.reverse[alias]; !exists {
+				m.reverse[alias] = local
+			}
+		}
+	}
+}
+
+// clientSourceRoot removes the primary relative entry from the manifest
+// source key and returns the remaining client root together with the
+// separator style the capturing host used. The root is empty when no safe
+// lexical derivation exists.
+func clientSourceRoot(sourceKey, sourceEntry string) (string, string) {
+	normalized := strings.ReplaceAll(sourceKey, "\\", "/")
+	if normalized == sourceEntry {
+		// A relative source key carries no client root to strip.
+		return "", ""
+	}
+	suffix := "/" + sourceEntry
+	if !strings.HasSuffix(normalized, suffix) {
+		return "", ""
+	}
+	root := strings.TrimRight(sourceKey[:len(sourceKey)-len(suffix)], "/\\")
+	if root == "" {
+		return "", ""
+	}
+	separator := "/"
+	if strings.Contains(sourceKey, "\\") {
+		separator = "\\"
+	}
+	return root, separator
+}
+
+func (m *stablePathMap) bind(local, stable string) {
+	if local == "" || stable == "" {
+		return
+	}
+	local = filepath.Clean(local)
+	if previous, ok := m.forward[local]; ok {
+		delete(m.reverse, previous)
+	}
+	m.forward[local] = stable
+	m.reverse[stable] = local
+}
+
+func (m *stablePathMap) rewrite(path string) string {
+	if path == "" {
+		return ""
+	}
+	if stable, ok := m.forward[filepath.Clean(path)]; ok {
+		return stable
+	}
+	if base, suffix, ok := parser.ParseVirtualSourcePath(path); ok {
+		if stable, exists := m.forward[filepath.Clean(base)]; exists {
+			return parser.VirtualSourcePath(stable, suffix)
+		}
+	}
+	clean := filepath.Clean(path)
+	relative, err := filepath.Rel(m.root, clean)
+	if err == nil && relative != "." && relative != ".." &&
+		!strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative) {
+		return m.prefix + filepath.ToSlash(relative)
+	}
+	return path
+}
+
+func (m *stablePathMap) resolve(stable string) (string, bool) {
+	local, ok := m.reverse[stable]
+	if ok {
+		return local, true
+	}
+	if base, _, hasSuffix := parser.ParseVirtualSourcePath(stable); hasSuffix {
+		local, ok = m.reverse[base]
+	}
+	return local, ok
+}
+
+func sourceKeyEndsWithEntry(sourceKey, entry string) bool {
+	key := strings.ReplaceAll(sourceKey, "\\", "/")
+	return key == entry || strings.HasSuffix(key, "/"+entry)
+}
+
+func rewriteParseOutcome(outcome *parser.ParseOutcome, paths *stablePathMap, root string) {
+	for index := range outcome.Results {
+		file := &outcome.Results[index].Result.Session.File
+		file.Path = paths.rewrite(file.Path)
+		// The materialization is worker-local: inode and device identities
+		// cannot be reconstructed from the manifest, so strip values that
+		// would otherwise differ on every reparse.
+		file.Inode = 0
+		file.Device = 0
+		if strings.Contains(file.Path, root) {
+			file.Path = paths.prefix + "source"
+		}
+	}
+	for index := range outcome.SourceErrors {
+		sourceErr := &outcome.SourceErrors[index]
+		sourceErr.SourceKey = paths.rewrite(sourceErr.SourceKey)
+		sourceErr.DisplayPath = paths.rewrite(sourceErr.DisplayPath)
+		if sourceErr.Err != nil && strings.Contains(sourceErr.Err.Error(), root) {
+			sourceErr.Err = redactedProviderError{
+				message: strings.ReplaceAll(sourceErr.Err.Error(), root, "<materialized>"),
+				cause:   sourceErr.Err,
+			}
+		}
+	}
+}
+
+func redactMaterializedError(operation string, err error, root string) error {
+	return redactedProviderError{
+		operation: operation,
+		message:   strings.ReplaceAll(err.Error(), root, "<materialized>"),
+		cause:     err,
+	}
+}
+
+type redactedProviderError struct {
+	operation string
+	message   string
+	cause     error
+}
+
+func (e redactedProviderError) Error() string {
+	if e.operation == "" {
+		return e.message
+	}
+	return e.operation + ": " + e.message
+}
+
+func (e redactedProviderError) Unwrap() error {
+	return e.cause
+}

--- a/internal/rawderive/parser_test.go
+++ b/internal/rawderive/parser_test.go
@@ -1,0 +1,1645 @@
+package rawderive
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+func TestProviderParserUsesProviderCaptureContractAndStablePaths(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	localPath := filepath.Join(root, "session.jsonl")
+	require.NoError(t, os.WriteFile(localPath, []byte("session"), 0o400))
+	stablePath := "/canonical/claude/session.jsonl"
+	manifest := parserTestManifest(t, parser.AgentClaude, stablePath, []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: 7,
+		Objects: []rawsync.ObjectRef{objectRefForBytes(t, []byte("session"))},
+	}})
+	provider := &providerParserFixture{root: root, localPath: localPath}
+	factory := &providerParserFixtureFactory{provider: provider}
+	dispatch, err := NewProviderParser([]parser.ProviderFactory{factory}, "hosted-worker")
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, &Materialization{
+		root: root, entries: map[string]string{"session.jsonl": localPath},
+	})
+	require.NoError(t, err)
+	assert.False(t, parsed.Tombstone)
+	require.Len(t, parsed.Outcome.Results, 1)
+	assert.Equal(t, stablePath, parsed.Outcome.Results[0].Result.Session.File.Path)
+	assert.Equal(t, "hosted-worker", factory.config.Machine)
+	assert.True(t, factory.config.StableSourceSnapshots)
+	assert.Equal(t, []string{root}, factory.config.Roots)
+	assert.Equal(t, stablePath, factory.config.PathRewriter(localPath))
+	assert.Equal(t, stablePath, provider.request.Source.Key)
+	assert.Equal(t, stablePath, provider.request.Fingerprint.Key)
+	resolved, ok := provider.request.StoredPathResolver(stablePath)
+	assert.True(t, ok)
+	assert.Equal(t, localPath, resolved)
+}
+
+func TestProviderParserAcceptsPortableClaudeSourceIdentity(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	localPath := filepath.Join(root, "session.jsonl")
+	require.NoError(t, os.WriteFile(localPath, []byte("session"), 0o400))
+	manifest := parserTestManifest(
+		t, parser.AgentClaude, `C:\Users\agent\projects\session.jsonl`,
+		[]rawsync.Entry{{
+			Path: "session.jsonl", Type: "file", Length: 7,
+			Objects: []rawsync.ObjectRef{objectRefForBytes(t, []byte("session"))},
+		}},
+	)
+	provider := &providerParserFixture{root: root, localPath: localPath}
+	dispatch, err := NewProviderParser(
+		[]parser.ProviderFactory{&providerParserFixtureFactory{provider: provider}},
+		"hosted-worker",
+	)
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, &Materialization{
+		root: root, entries: map[string]string{"session.jsonl": localPath},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, parsed.Outcome.Results, 1)
+	assert.Equal(t, manifest.Manifest.SourceKey, provider.request.Source.Key)
+}
+
+func TestProviderParserRunsRegisteredClaudeParserWithoutLeakingMaterializedPath(t *testing.T) {
+	t.Parallel()
+	contents := []byte(
+		`{"type":"user","timestamp":"2026-08-13T12:00:00Z","uuid":"u1",` +
+			`"sessionId":"session-a","message":{"content":"hello"},"cwd":"/work/project"}` + "\n" +
+			`{"type":"assistant","timestamp":"2026-08-13T12:00:01Z","uuid":"a1",` +
+			`"parentUuid":"u1","sessionId":"session-a","message":{"content":"hi"}}` + "\n",
+	)
+	stablePath := "/canonical/claude/project/session.jsonl"
+	// Use 100 ns precision so the assertion is portable to Windows filesystems.
+	sourceModTime := time.Date(2026, 8, 13, 11, 30, 0, 246813500, time.UTC)
+	object := objectRefForBytes(t, contents)
+	manifest := parserTestManifest(t, parser.AgentClaude, stablePath, []rawsync.Entry{{
+		Path: "project/session.jsonl", Type: "file", Length: int64(len(contents)),
+		ModTimeNS: sourceModTime.UnixNano(),
+		Objects:   []rawsync.ObjectRef{object},
+	}})
+	materialized, err := (Materializer{
+		Store:         &materializerStore{objects: map[rawsync.ObjectRef][]byte{object: contents}},
+		BaseDir:       t.TempDir(),
+		MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, materialized.Cleanup()) }()
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err)
+	require.Len(t, parsed.Outcome.Results, 1)
+	assert.Equal(t, stablePath, parsed.Outcome.Results[0].Result.Session.File.Path)
+	assert.NotContains(t, parsed.Outcome.Results[0].Result.Session.File.Path, materialized.Root())
+	assert.Equal(t, parser.AgentClaude, parsed.Outcome.Results[0].Result.Session.Agent)
+	assert.Equal(t, sourceModTime.UnixNano(), parsed.Outcome.Results[0].Result.Session.File.Mtime,
+		"parser output must inherit the captured source mod time, not the worker clock")
+}
+
+// hostileServerRepo creates a real git repository outside any materialized
+// tree and returns a working directory inside it whose lexical base name
+// ("workdir") differs from the repository name a filesystem git-root walk
+// would leak.
+func hostileServerRepo(t *testing.T, repoName string) string {
+	t.Helper()
+	base := t.TempDir()
+	repo := filepath.Join(base, repoName)
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o700))
+	cwd := filepath.Join(repo, "workdir")
+	require.NoError(t, os.MkdirAll(cwd, 0o700))
+	return cwd
+}
+
+// TestProviderParserHostedParseKeepsClaudeProjectLexicalForHostileCwd pins
+// that a hostile cwd recorded in a materialized transcript cannot make the
+// hosted parse walk this worker's filesystem: the attributed project stays
+// the lexical cwd base name and never leaks the server-side repository name
+// a git-root walk would find.
+func TestProviderParserHostedParseKeepsClaudeProjectLexicalForHostileCwd(t *testing.T) {
+	t.Parallel()
+	hostileCwd := hostileServerRepo(t, "server-secret-claude")
+	contents := []byte(
+		`{"type":"user","timestamp":"2026-08-13T12:00:00Z","uuid":"u1",` +
+			`"sessionId":"session-hostile","message":{"content":"hello"},"cwd":` +
+			strconv.Quote(hostileCwd) + `}` + "\n" +
+			`{"type":"assistant","timestamp":"2026-08-13T12:00:01Z","uuid":"a1",` +
+			`"parentUuid":"u1","sessionId":"session-hostile","message":{"content":"hi"}}` + "\n",
+	)
+	object := objectRefForBytes(t, contents)
+	stablePath := "/canonical/claude/project/session-hostile.jsonl"
+	manifest := parserTestManifest(t, parser.AgentClaude, stablePath, []rawsync.Entry{{
+		Path: "project/session-hostile.jsonl", Type: "file", Length: int64(len(contents)),
+		Objects: []rawsync.ObjectRef{object},
+	}})
+	materialized, err := (Materializer{
+		Store:   &materializerStore{objects: map[rawsync.ObjectRef][]byte{object: contents}},
+		BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err)
+	require.Len(t, parsed.Outcome.Results, 1)
+	project := parsed.Outcome.Results[0].Result.Session.Project
+	assert.Equal(t, "workdir", project,
+		"hosted project attribution must stay lexical for a hostile recorded cwd")
+	assert.NotContains(t, project, "secret",
+		"the server-side repository name must not leak through project attribution")
+}
+
+// TestProviderParserHostedParseKeepsDBBackedProjectLexicalForHostileCwd pins
+// the same contract for a provider whose project extraction runs through an
+// unconditional cwd helper: the working directory recorded inside a
+// materialized provider database must stay lexical metadata and must not
+// walk this worker's filesystem.
+func TestProviderParserHostedParseKeepsDBBackedProjectLexicalForHostileCwd(t *testing.T) {
+	t.Parallel()
+	hostileCwd := hostileServerRepo(t, "server-secret-forge")
+	dbBytes := forgeSnapshotFixtureWithCwd(t, map[string]string{
+		"conv-001": "2026-05-02 09:58:15",
+	}, hostileCwd)
+	dbRef := objectRefForBytes(t, dbBytes)
+	manifest := parserTestManifest(t, parser.AgentForge, parser.ForgeDBFilename, []rawsync.Entry{{
+		Path: parser.ForgeDBFilename, Type: "file", Length: int64(len(dbBytes)),
+		Objects: []rawsync.ObjectRef{dbRef},
+	}})
+	materialized, err := (Materializer{
+		Store:   &materializerStore{objects: map[rawsync.ObjectRef][]byte{dbRef: dbBytes}},
+		BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err)
+	require.Len(t, parsed.Outcome.Results, 1)
+	project := parsed.Outcome.Results[0].Result.Session.Project
+	assert.Equal(t, "workdir", project,
+		"db-backed hosted attribution must stay lexical for a hostile recorded cwd")
+	assert.NotContains(t, project, "secret",
+		"the server-side repository name must not leak through project attribution")
+}
+
+// TestProviderParserAppliesHostedProjectPolicyToDiscoveryAndParse pins that
+// every context rawderive hands to a provider -- raw-capture discovery and
+// the parse itself -- carries the hosted filesystem-project-discovery guard,
+// by probing through the same context-honoring helper providers use.
+func TestProviderParserAppliesHostedProjectPolicyToDiscoveryAndParse(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	localPath := filepath.Join(root, "session.jsonl")
+	require.NoError(t, os.WriteFile(localPath, []byte("session"), 0o400))
+	hostileCwd := hostileServerRepo(t, "server-secret-policy")
+	manifest := parserTestManifest(t, parser.AgentClaude, "/canonical/claude/session.jsonl", []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: 7,
+		Objects: []rawsync.ObjectRef{objectRefForBytes(t, []byte("session"))},
+	}})
+	fixture := &projectPolicyProbingFixture{
+		root: root, localPath: localPath, hostileCwd: hostileCwd,
+	}
+	dispatch, err := NewProviderParser(
+		[]parser.ProviderFactory{&projectPolicyProbingFactory{provider: fixture}}, "hosted-worker",
+	)
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, &Materialization{
+		root: root, entries: map[string]string{"session.jsonl": localPath},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, parsed.Outcome.Results, 1)
+	for _, probe := range []struct {
+		name    string
+		project string
+	}{{"discovery", fixture.discoveryProject}, {"parse", fixture.parseProject}} {
+		assert.Equal(t, "workdir", probe.project,
+			"the hosted %s context must disable filesystem project discovery", probe.name)
+		assert.NotContains(t, probe.project, "secret", probe.name)
+	}
+}
+
+func TestStablePathMapUsesLongestSourceKeySuffix(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "worker#root")
+	deepPath := filepath.Join(root, "x", "y", "file.jsonl")
+	shallowPath := filepath.Join(root, "y", "file.jsonl")
+	deepObject := objectRefForBytes(t, []byte("deep"))
+	shallowObject := objectRefForBytes(t, []byte("shallow"))
+	stablePath := "/canonical/x/y/file.jsonl"
+	manifest := parserTestManifest(t, parser.AgentClaude, stablePath, []rawsync.Entry{
+		{
+			Path: "x/y/file.jsonl", Type: "file", Length: deepObject.Length,
+			Objects: []rawsync.ObjectRef{deepObject},
+		},
+		{
+			Path: "y/file.jsonl", Type: "file", Length: shallowObject.Length,
+			Objects: []rawsync.ObjectRef{shallowObject},
+		},
+	})
+	paths := newStablePathMap(manifest, &Materialization{
+		root: root,
+		entries: map[string]string{
+			"x/y/file.jsonl": deepPath,
+			"y/file.jsonl":   shallowPath,
+		},
+	})
+
+	resolved, ok := paths.resolve(stablePath)
+	require.True(t, ok)
+	assert.Equal(t, deepPath, resolved)
+	assert.Equal(t, stablePath, paths.rewrite(deepPath))
+	assert.Equal(t, paths.prefix+"y/file.jsonl", paths.rewrite(shallowPath))
+	stableVirtual := parser.VirtualSourcePath(stablePath, "conversation-1")
+	assert.Equal(t, stableVirtual,
+		paths.rewrite(parser.VirtualSourcePath(deepPath, "conversation-1")))
+	resolved, ok = paths.resolve(stableVirtual)
+	require.True(t, ok)
+	assert.Equal(t, deepPath, resolved)
+}
+
+func TestStablePathMapResolvesOriginalClientPathAliases(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	transcript := filepath.Join(root, "project", "session-a.jsonl")
+	sidecar := filepath.Join(root, "project", "session-a", "tool-results", "r1.txt")
+	transcriptObject := objectRefForBytes(t, []byte("transcript"))
+	sidecarObject := objectRefForBytes(t, []byte("sidecar"))
+
+	for _, tc := range []struct {
+		name         string
+		sourceKey    string
+		embeddedPath string
+	}{
+		{
+			name:         "posix client path",
+			sourceKey:    "/srv/agent/projects/project/session-a.jsonl",
+			embeddedPath: "/srv/agent/projects/project/session-a/tool-results/r1.txt",
+		},
+		{
+			name:         "windows client path parsed on another host",
+			sourceKey:    `C:\ProgramData\agent\projects\project\session-a.jsonl`,
+			embeddedPath: `C:\ProgramData\agent\projects\project\session-a\tool-results\r1.txt`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			manifest := parserTestManifest(t, parser.AgentClaude, tc.sourceKey, []rawsync.Entry{
+				{
+					Path: "project/session-a.jsonl", Type: "file", Length: transcriptObject.Length,
+					Objects: []rawsync.ObjectRef{transcriptObject},
+				},
+				{
+					Path: "project/session-a/tool-results/r1.txt", Type: "file", Length: sidecarObject.Length,
+					Objects: []rawsync.ObjectRef{sidecarObject},
+				},
+			})
+			paths := newStablePathMap(manifest, &Materialization{
+				root: root,
+				entries: map[string]string{
+					"project/session-a.jsonl":               transcript,
+					"project/session-a/tool-results/r1.txt": sidecar,
+				},
+			})
+
+			resolved, ok := paths.resolve(tc.embeddedPath)
+			require.True(t, ok,
+				"an original client path embedded in a transcript must resolve to its materialized companion")
+			assert.Equal(t, sidecar, resolved)
+			resolved, ok = paths.resolve(tc.sourceKey)
+			require.True(t, ok)
+			assert.Equal(t, transcript, resolved)
+
+			// Aliases are lookup keys only: they must never become rewrite
+			// targets for worker-local paths.
+			assert.Equal(t, tc.sourceKey, paths.rewrite(transcript))
+			assert.Equal(t, tc.embeddedPath, paths.rewrite(tc.embeddedPath))
+		})
+	}
+}
+
+func TestStablePathMapSkipsClientAliasesWithoutEntrySuffix(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	session := filepath.Join(root, "session.jsonl")
+	object := objectRefForBytes(t, []byte("session"))
+	// A source key that does not end in any manifest entry carries no safe
+	// client-root derivation, so no aliases may be invented for it.
+	manifest := parserTestManifest(t, parser.AgentClaude, "claude:opaque-uuid", []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: object.Length,
+		Objects: []rawsync.ObjectRef{object},
+	}})
+	paths := newStablePathMap(manifest, &Materialization{
+		root: root, entries: map[string]string{"session.jsonl": session},
+	})
+
+	_, ok := paths.resolve("/srv/agent/projects/session.jsonl")
+	assert.False(t, ok)
+	assert.Equal(t, paths.prefix+"session.jsonl", paths.rewrite(session))
+}
+
+func TestProviderParserMatchesPlanEntriesAcrossEquivalentPathSpellings(t *testing.T) {
+	t.Parallel()
+	// Plan validation resolves symlinks while the materialization keeps its
+	// original spelling, so the same regular file can carry two spellings.
+	for _, tc := range []struct {
+		name string
+		// prepare builds one regular file reachable through an alternate
+		// spelling and returns the materialization root, the manifest entry's
+		// materialized path, and the plan-side path spelling.
+		prepare func(t *testing.T, base string) (root, materializedPath, planPath string, ok bool)
+	}{
+		{
+			name: "materialization root contains a symlinked directory",
+			prepare: func(t *testing.T, base string) (string, string, string, bool) {
+				realDir := filepath.Join(base, "real")
+				if err := os.MkdirAll(realDir, 0o700); err != nil {
+					return "", "", "", false
+				}
+				alias := filepath.Join(base, "alias")
+				if err := os.Symlink(realDir, alias); err != nil {
+					return "", "", "", false
+				}
+				materialized := filepath.Join(alias, "session.jsonl")
+				if err := os.WriteFile(materialized, []byte("session"), 0o600); err != nil {
+					return "", "", "", false
+				}
+				return alias, materialized, materialized, true
+			},
+		},
+		{
+			name: "plan entry reaches the materialized file through a symlink",
+			prepare: func(t *testing.T, base string) (string, string, string, bool) {
+				root := filepath.Join(base, "mat")
+				if err := os.MkdirAll(root, 0o700); err != nil {
+					return "", "", "", false
+				}
+				materialized := filepath.Join(root, "session.jsonl")
+				if err := os.WriteFile(materialized, []byte("session"), 0o600); err != nil {
+					return "", "", "", false
+				}
+				if err := os.Symlink(materialized, filepath.Join(root, "linked.jsonl")); err != nil {
+					return "", "", "", false
+				}
+				return root, materialized, filepath.Join(root, "linked.jsonl"), true
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root, materializedPath, planPath, ok := tc.prepare(t, t.TempDir())
+			if !ok {
+				t.Skipf("path aliasing unavailable on this platform")
+			}
+			stablePath := "/canonical/claude/session.jsonl"
+			manifest := parserTestManifest(t, parser.AgentClaude, stablePath, []rawsync.Entry{{
+				Path: "session.jsonl", Type: "file", Length: 7,
+				Objects: []rawsync.ObjectRef{objectRefForBytes(t, []byte("session"))},
+			}})
+			provider := &providerParserFixture{
+				root: root, localPath: materializedPath, planLocalPath: planPath,
+			}
+			dispatch, err := NewProviderParser(
+				[]parser.ProviderFactory{&providerParserFixtureFactory{provider: provider}}, "hosted-worker",
+			)
+			require.NoError(t, err)
+
+			parsed, err := dispatch.Parse(t.Context(), manifest, &Materialization{
+				root: root, entries: map[string]string{"session.jsonl": materializedPath},
+			})
+
+			require.NoError(t, err,
+				"the same regular file must match across equivalent path spellings")
+			require.Len(t, parsed.Outcome.Results, 1)
+			assert.Equal(t, stablePath, parsed.Outcome.Results[0].Result.Session.File.Path)
+		})
+	}
+}
+func TestProviderParserHostedParseMatchesLocalPersistedToolResults(t *testing.T) {
+	t.Parallel()
+	clientRoot := t.TempDir()
+	projectDir := "demo-project"
+	sessionID := "session-hosted"
+	transcriptPath := filepath.Join(clientRoot, projectDir, sessionID+".jsonl")
+	sidecarPath := filepath.Join(
+		clientRoot, projectDir, sessionID, "tool-results", "r1.txt",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sidecarPath), 0o755))
+	fullOutput := "hosted parity full output line 1\nhosted parity full output line 2\n"
+	require.NoError(t, os.WriteFile(sidecarPath, []byte(fullOutput), 0o644))
+	persistedNotice := "<persisted-output>\nOutput too large (48B). Full output saved to: " +
+		sidecarPath + "\n</persisted-output>"
+	transcript := strings.Join([]string{
+		`{"type":"user","timestamp":"2026-08-13T12:00:00Z","uuid":"u1","sessionId":"` + sessionID + `","cwd":"/work/project","message":{"content":"run it"}}`,
+		`{"type":"assistant","timestamp":"2026-08-13T12:00:01Z","uuid":"a1","parentUuid":"u1","sessionId":"` + sessionID + `","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make"}}]}}`,
+		`{"type":"user","timestamp":"2026-08-13T12:00:02Z","uuid":"u2","parentUuid":"a1","sessionId":"` + sessionID + `","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + strconv.Quote(persistedNotice) + `,"is_error":false}]},"toolUseResult":{"persistedOutputPath":` + strconv.Quote(sidecarPath) + `,"persistedOutputSize":48}}`,
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	localProvider, ok := parser.NewProvider(parser.AgentClaude, parser.ProviderConfig{
+		Roots: []string{clientRoot}, Machine: "hosted-worker",
+	})
+	require.True(t, ok)
+	sources, err := localProvider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	localOutcome, err := localProvider.Parse(t.Context(), parser.ParseRequest{
+		Source: sources[0], Fingerprint: parser.SourceFingerprint{Key: transcriptPath},
+		Machine: "hosted-worker",
+	})
+	require.NoError(t, err)
+	require.Len(t, localOutcome.Results, 1)
+	localMessages := localOutcome.Results[0].Result.Messages
+	require.Len(t, localMessages, 3)
+	localToolResults := localMessages[2].ToolResults
+	require.Len(t, localToolResults, 1)
+	assert.Equal(t, fullOutput, parser.DecodeContent(localToolResults[0].ContentRaw),
+		"local parse must resolve the persisted tool result from its sidecar")
+
+	manifest, objects := manifestFromCapturePlan(t, parser.AgentClaude, localProvider, sources[0])
+	materialized, err := (Materializer{
+		Store:   &materializerStore{objects: objects},
+		BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	hosted, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err)
+	require.Len(t, hosted.Outcome.Results, 1)
+	hostedMessages := hosted.Outcome.Results[0].Result.Messages
+	require.Len(t, hostedMessages, 3)
+	hostedToolResults := hostedMessages[2].ToolResults
+	require.Len(t, hostedToolResults, 1)
+	assert.Equal(t, localToolResults[0].ContentLength, hostedToolResults[0].ContentLength)
+	assert.Equal(t, fullOutput, parser.DecodeContent(hostedToolResults[0].ContentRaw),
+		"materialized parse must resolve persisted tool results exactly like local parse")
+	assert.Equal(t,
+		localOutcome.Results[0].Result.Session.File.Path,
+		hosted.Outcome.Results[0].Result.Session.File.Path,
+		"the hosted session must keep the captured client path")
+}
+
+// manifestFromCapturePlan builds a canonical manifest from the provider-owned
+// capture plan of one source, mirroring how the client producer materializes a
+// generation: every planned file becomes one entry carrying its digest, size,
+// and captured mod time.
+func manifestFromCapturePlan(
+	t *testing.T,
+	agent parser.AgentType,
+	provider parser.Provider,
+	source parser.SourceRef,
+) (rawsync.CanonicalManifest, map[rawsync.ObjectRef][]byte) {
+	t.Helper()
+	plan, supported, err := parser.ResolveRawCapturePlan(t.Context(), provider, source)
+	require.NoError(t, err)
+	require.True(t, supported)
+	entries := make([]rawsync.Entry, 0, len(plan.Entries))
+	objects := make(map[rawsync.ObjectRef][]byte, len(plan.Entries))
+	for _, entry := range plan.Entries {
+		contents, err := os.ReadFile(entry.LocalPath)
+		require.NoError(t, err)
+		info, err := os.Stat(entry.LocalPath)
+		require.NoError(t, err)
+		object := objectRefForBytes(t, contents)
+		objects[object] = contents
+		entries = append(entries, rawsync.Entry{
+			Path: entry.Path, Type: "file", Length: info.Size(),
+			ModTimeNS: info.ModTime().UnixNano(),
+			Objects:   []rawsync.ObjectRef{object},
+		})
+	}
+	return parserTestManifest(t, agent, plan.SourceKey, entries), objects
+}
+
+func TestProviderParserHostedParseMatchesLocalBackgroundForkLineage(t *testing.T) {
+	t.Parallel()
+	clientRoot := t.TempDir()
+	projectDir := filepath.Join(clientRoot, "demo-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	origLine := func(uuid, parent, ts, sessionID, kind, content string) string {
+		parentJSON := "null"
+		if parent != "" {
+			parentJSON = strconv.Quote(parent)
+		}
+		kindField := ""
+		if kind != "" {
+			kindField = `"sessionKind":` + strconv.Quote(kind) + `,`
+		}
+		return `{"type":"user","uuid":` + strconv.Quote(uuid) + `,"parentUuid":` + parentJSON +
+			`,"timestamp":"` + ts + `","sessionId":"` + sessionID + `",` + kindField +
+			`"cwd":"/work/project","message":{"content":` + strconv.Quote(content) + `}}`
+	}
+	assistantLine := func(uuid, parent, ts, sessionID, kind, text string) string {
+		kindField := ""
+		if kind != "" {
+			kindField = `"sessionKind":` + strconv.Quote(kind) + `,`
+		}
+		return `{"type":"assistant","uuid":` + strconv.Quote(uuid) + `,"parentUuid":` + strconv.Quote(parent) +
+			`,"timestamp":"` + ts + `","sessionId":"` + sessionID + `",` + kindField +
+			`"message":{"id":"msg_` + uuid + `","content":[{"type":"text","text":` + strconv.Quote(text) + `}]}}`
+	}
+	origContent := strings.Join([]string{
+		origLine("u1", "", "2026-01-01T10:00:00Z", "orig-1111", "", "first question"),
+		assistantLine("a1", "u1", "2026-01-01T10:00:05Z", "orig-1111", "", "first answer"),
+	}, "\n") + "\n"
+	forkContent := strings.Join([]string{
+		origLine("u1", "", "2026-01-01T10:00:00Z", "fork-2222", "bg", "first question"),
+		assistantLine("a1", "u1", "2026-01-01T10:00:05Z", "fork-2222", "bg", "first answer"),
+		origLine("u2", "a1", "2026-01-01T11:00:00Z", "fork-2222", "bg", "continued question"),
+		assistantLine("a2", "u2", "2026-01-01T11:00:05Z", "fork-2222", "bg", "continued answer"),
+	}, "\n") + "\n"
+	origPath := filepath.Join(projectDir, "orig-1111.jsonl")
+	forkPath := filepath.Join(projectDir, "fork-2222.jsonl")
+	require.NoError(t, os.WriteFile(origPath, []byte(origContent), 0o644))
+	require.NoError(t, os.WriteFile(forkPath, []byte(forkContent), 0o644))
+
+	localProvider, ok := parser.NewProvider(parser.AgentClaude, parser.ProviderConfig{
+		Roots: []string{clientRoot}, Machine: "hosted-worker",
+	})
+	require.True(t, ok)
+	sources, err := localProvider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 2)
+	var forkSource parser.SourceRef
+	for _, source := range sources {
+		if strings.HasSuffix(source.Key, "fork-2222.jsonl") {
+			forkSource = source
+		}
+	}
+	require.NotEmpty(t, forkSource.Key)
+	localOutcome, err := localProvider.Parse(t.Context(), parser.ParseRequest{
+		Source: forkSource, Fingerprint: parser.SourceFingerprint{Key: forkPath},
+		Machine: "hosted-worker",
+	})
+	require.NoError(t, err)
+	require.Len(t, localOutcome.Results, 1)
+	localSession := localOutcome.Results[0].Result.Session
+	require.Equal(t, "orig-1111", localSession.ParentSessionID,
+		"local parse must link the background fork to its parent")
+	require.Len(t, localOutcome.Results[0].Result.Messages, 2,
+		"local parse must trim the replayed prefix")
+
+	manifest, objects := manifestFromCapturePlan(t, parser.AgentClaude, localProvider, forkSource)
+	require.Len(t, manifest.Manifest.Entries, 2,
+		"the fork generation must carry its lineage sibling transcript")
+	materialized, err := (Materializer{
+		Store:   &materializerStore{objects: objects},
+		BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	hosted, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err)
+	require.Len(t, hosted.Outcome.Results, 1)
+	hostedResult := hosted.Outcome.Results[0].Result
+	hostedSession := hostedResult.Session
+	assert.Equal(t, localSession.ParentSessionID, hostedSession.ParentSessionID,
+		"materialized parse must reproduce background-fork parent linkage")
+	assert.Equal(t, localSession.RelationshipType, hostedSession.RelationshipType)
+	assert.Equal(t, localSession.MessageCount, hostedSession.MessageCount)
+	require.Len(t, hostedResult.Messages, 2,
+		"materialized parse must trim the replayed prefix like local parse")
+	for i := range hostedResult.Messages {
+		assert.Equal(t,
+			localOutcome.Results[0].Result.Messages[i].Content,
+			hostedResult.Messages[i].Content)
+		assert.Equal(t,
+			localOutcome.Results[0].Result.Messages[i].Role,
+			hostedResult.Messages[i].Role)
+		assert.Equal(t,
+			localOutcome.Results[0].Result.Messages[i].Timestamp,
+			hostedResult.Messages[i].Timestamp)
+	}
+	assert.Equal(t, forkPath, hostedSession.File.Path,
+		"the hosted session must keep the captured client path")
+}
+
+func TestProviderParserHostedParseMatchesLocalCodexForkLineage(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		layout       string
+		withIndex    bool
+		parentLayout string
+		shadowParent bool
+	}{
+		{name: "sessions without session index", layout: "sessions"},
+		{name: "sessions with session index", layout: "sessions", withIndex: true},
+		{name: "archive without session index", layout: "archived_sessions"},
+		{name: "archive with session index", layout: "archived_sessions", withIndex: true},
+		{name: "parent in another home", layout: "sessions", parentLayout: "sessions", withIndex: true},
+		{name: "parent in another archive", layout: "archived_sessions", parentLayout: "archived_sessions"},
+		{name: "parent with custom roots", layout: "custom", parentLayout: "custom"},
+		{name: "first root wins over another parent copy", layout: "sessions", parentLayout: "sessions", shadowParent: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			testProviderParserHostedCodexForkLineage(t, tc.layout, tc.withIndex, tc.parentLayout, tc.shadowParent)
+		})
+	}
+}
+
+func TestProviderParserHostedCodexAliasHomeMetadata(t *testing.T) {
+	const id = "11111111-1111-4111-8111-111111111111"
+	type index struct {
+		home   int
+		id     string
+		title  string
+		minute int
+	}
+	for _, tc := range []struct {
+		name    string
+		indexes []index
+		want    string
+	}{
+		{"newer alias", []index{{0, id, "Primary title", 1}, {1, id, "Alias title", 2}}, "Alias title"},
+		{"newer primary", []index{{0, id, "Primary title", 2}, {1, id, "Alias title", 1}}, "Primary title"},
+		{"merge indexes", []index{{0, id, "Primary title", 1}, {1, "other-session", "Unrelated title", 2}}, "Primary title"},
+		{"sparse aliases with equal mtimes", []index{{2, id, "Earlier alias", 1}, {10, id, "Later alias", 1}}, "Later alias"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			clientBase := t.TempDir()
+			dirs := []string{filepath.Join(clientBase, "primary")}
+			for i := 1; i <= tc.indexes[len(tc.indexes)-1].home; i++ {
+				dirs = append(dirs, filepath.Join(clientBase, "alias-"+strconv.Itoa(i)))
+			}
+			root := filepath.Join(dirs[0], "sessions")
+			rollout := filepath.Join(root, "2026", "09", "10", "rollout-2026-09-10T10-00-00-"+id+".jsonl")
+			require.NoError(t, os.MkdirAll(filepath.Dir(rollout), 0o700))
+			require.NoError(t, os.WriteFile(rollout, []byte(testjsonl.JoinJSONL(
+				testjsonl.CodexSessionMetaJSON(id, "/workspace/project", "codex_cli_rs", "2026-09-10T10:00:00Z"),
+				testjsonl.CodexMsgJSON("user", "Session prompt", "2026-09-10T10:00:01Z"),
+			)), 0o600))
+			mtime := time.Date(2026, 9, 10, 10, 0, 0, 0, time.UTC)
+			require.NoError(t, os.Chtimes(rollout, mtime, mtime))
+			for _, idx := range tc.indexes {
+				require.NoError(t, os.MkdirAll(dirs[idx.home], 0o700))
+				indexPath := filepath.Join(dirs[idx.home], parser.CodexSessionIndexFilename)
+				require.NoError(t, os.WriteFile(indexPath, []byte(fmt.Sprintf(
+					"{\"id\":%q,\"thread_name\":%q}\n", idx.id, idx.title,
+				)), 0o600))
+				indexMtime := mtime.Add(time.Duration(idx.minute) * time.Minute)
+				require.NoError(t, os.Chtimes(indexPath, indexMtime, indexMtime))
+			}
+			provider, ok := parser.NewProvider(parser.AgentCodex, parser.ProviderConfig{
+				Roots: []string{root}, MetadataDirs: map[string][]string{root: dirs},
+			})
+			require.True(t, ok)
+			sources, err := provider.Discover(t.Context())
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+			local, err := provider.Parse(t.Context(), parser.ParseRequest{Source: sources[0]})
+			require.NoError(t, err)
+			require.Len(t, local.Results, 1)
+			assert.Equal(t, tc.want, local.Results[0].Result.Session.SessionName)
+			manifest, objects := manifestFromCapturePlan(t, parser.AgentCodex, provider, sources[0])
+			materialized, err := (Materializer{
+				Store: &materializerStore{objects: objects}, BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+			}).Materialize(t.Context(), manifest)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+			dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+			require.NoError(t, err)
+
+			hosted, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+			require.NoError(t, err)
+			require.Len(t, hosted.Outcome.Results, 1)
+			assert.Equal(t, tc.want, hosted.Outcome.Results[0].Result.Session.SessionName)
+			assert.Equal(t, local.Results[0].Result.Session.File.Mtime, hosted.Outcome.Results[0].Result.Session.File.Mtime)
+		})
+	}
+}
+
+func TestProviderParserHostedCodexOrphanPreservesHistory(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "sessions")
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	path := filepath.Join(root, "2026", "01", "01", "rollout-2026-01-01T10-00-00-"+childID+".jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(childID, parentID, "/workspace/project", "codex_cli_rs", "2026-01-01T10:00:00Z"),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", "child-turn", "2026-01-01T10:00:01Z"),
+		testjsonl.CodexMsgJSON("user", "child task", "2026-01-01T10:00:01Z"),
+		testjsonl.CodexMsgJSON("assistant", "child answer", "2026-01-01T10:00:02Z"),
+	)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	provider, ok := parser.NewProvider(parser.AgentCodex, parser.ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	manifest, objects := manifestFromCapturePlan(t, parser.AgentCodex, provider, sources[0])
+	materialized, err := (Materializer{
+		Store: &materializerStore{objects: objects}, BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	hosted, err := dispatch.Parse(t.Context(), manifest, materialized)
+	require.NoError(t, err)
+	require.Len(t, hosted.Outcome.Results, 1)
+	result := hosted.Outcome.Results[0]
+	assert.Equal(t, parser.DataVersionNeedsRetry, result.DataVersion)
+	require.Len(t, result.Result.Messages, 2)
+	assert.Equal(t, "child task", result.Result.Messages[0].Content)
+	assert.Equal(t, "child answer", result.Result.Messages[1].Content)
+}
+
+func testProviderParserHostedCodexForkLineage(
+	t *testing.T,
+	layout string,
+	withIndex bool,
+	parentLayout string,
+	shadowParent bool,
+) {
+	t.Helper()
+	clientBase := t.TempDir()
+	clientRoot := filepath.Join(clientBase, layout)
+	parentRoot := clientRoot
+	roots := []string{clientRoot}
+	if parentLayout != "" {
+		parentRoot = filepath.Join(t.TempDir(), parentLayout)
+		roots = append([]string{parentRoot}, roots...)
+	} else {
+		parentLayout = layout
+	}
+	const parentID = "11111111-1111-4111-8111-111111111111"
+	const childID = "22222222-2222-4222-8222-222222222222"
+	const parentTurnID = "parent-turn"
+	const childTurnID = "child-turn"
+	parentPath := filepath.Join(parentRoot,
+		"rollout-2026-09-08T10-00-00-"+parentID+".jsonl")
+	childPath := filepath.Join(clientRoot,
+		"rollout-2026-09-09T10-00-00-"+childID+".jsonl")
+	if parentLayout == "sessions" {
+		parentPath = filepath.Join(parentRoot, "2026", "09", "08", filepath.Base(parentPath))
+	}
+	if layout == "sessions" {
+		childPath = filepath.Join(clientRoot, "2026", "09", "09", filepath.Base(childPath))
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(parentPath), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(childPath), 0o755))
+	require.NoError(t, os.WriteFile(parentPath, []byte(testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/work/project", "codex_cli_rs", "2026-09-08T10:00:00Z"),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, "2026-09-08T10:00:01Z"),
+	)), 0o600))
+	require.NoError(t, os.WriteFile(childPath, []byte(testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(
+			childID, parentID, "/work/project", "codex_cli_rs", "2026-09-09T10:00:00Z",
+		),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, "2026-09-09T10:00:01Z"),
+		testjsonl.CodexMsgJSON("user", "replayed parent task", "2026-09-09T10:00:02Z"),
+		testjsonl.CodexMsgJSON("assistant", "replayed parent answer", "2026-09-09T10:00:03Z"),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", childTurnID, "2026-09-09T10:01:00Z"),
+		testjsonl.CodexMsgJSON("user", "child task", "2026-09-09T10:01:01Z"),
+		testjsonl.CodexMsgJSON("assistant", "child answer", "2026-09-09T10:01:02Z"),
+	)), 0o600))
+	if shadowParent {
+		// The same parent filename in a later configured root carries different
+		// turns. Capture must select the same first-root copy as local parsing.
+		shadowPath := filepath.Join(filepath.Dir(childPath), filepath.Base(parentPath))
+		require.NoError(t, os.WriteFile(shadowPath, []byte(testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON(parentID, "/work/project", "codex_cli_rs", "2026-09-08T10:00:00Z"),
+			testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", "other-parent-turn", "2026-09-08T10:00:01Z"),
+		)), 0o600))
+	}
+	if withIndex {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(clientBase, parser.CodexSessionIndexFilename),
+			[]byte(`{"id":"`+childID+`","thread_name":"Hosted fork","updated_at":"2026-09-09T10:02:00Z"}`+"\n"),
+			0o600,
+		))
+	}
+
+	localProvider, ok := parser.NewProvider(parser.AgentCodex, parser.ProviderConfig{
+		Roots: roots, Machine: "hosted-worker",
+	})
+	require.True(t, ok)
+	childSource, found, err := localProvider.FindSource(t.Context(), parser.FindSourceRequest{
+		FullSessionID: "host~codex:" + childID,
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	localOutcome, err := localProvider.Parse(t.Context(), parser.ParseRequest{Source: childSource})
+	require.NoError(t, err)
+	require.Len(t, localOutcome.Results, 1)
+	require.Len(t, localOutcome.Results[0].Result.Messages, 2)
+	assert.Equal(t, parser.DataVersionCurrent, localOutcome.Results[0].DataVersion)
+
+	manifest, objects := manifestFromCapturePlan(
+		t, parser.AgentCodex, localProvider, childSource,
+	)
+	materialized, err := (Materializer{
+		Store:   &materializerStore{objects: objects},
+		BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	hosted, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err)
+	require.Len(t, hosted.Outcome.Results, 1)
+	hostedResult := hosted.Outcome.Results[0]
+	assert.Equal(t, parser.DataVersionCurrent, hostedResult.DataVersion)
+	assert.Empty(t, hostedResult.RetryReason)
+	assert.Equal(t,
+		localOutcome.Results[0].Result.Session.ParentSessionID,
+		hostedResult.Result.Session.ParentSessionID,
+	)
+	assert.Equal(t,
+		localOutcome.Results[0].Result.Session.SessionName,
+		hostedResult.Result.Session.SessionName,
+		"the parent-side session index must remain visible from the sessions root",
+	)
+	if withIndex {
+		assert.Equal(t, "Hosted fork", hostedResult.Result.Session.SessionName)
+	} else {
+		assert.Empty(t, hostedResult.Result.Session.SessionName)
+	}
+	require.Len(t, hostedResult.Result.Messages, 2)
+	assert.Equal(t, "child task", hostedResult.Result.Messages[0].Content)
+	assert.Equal(t, "child answer", hostedResult.Result.Messages[1].Content)
+}
+
+func TestProviderParserRejectsMiskeyedCodexManifest(t *testing.T) {
+	t.Parallel()
+	clientRoot := t.TempDir()
+	const sourceID = "11111111-1111-4111-8111-111111111111"
+	const wrongID = "22222222-2222-4222-8222-222222222222"
+	sourcePath := filepath.Join(clientRoot,
+		"rollout-2026-09-09T10-00-00-"+sourceID+".jsonl")
+	contents := []byte(testjsonl.JoinJSONL(testjsonl.CodexSessionMetaJSON(
+		sourceID, "/work/project", "codex_cli_rs", "2026-09-09T10:00:00Z",
+	)))
+	require.NoError(t, os.WriteFile(sourcePath, contents, 0o600))
+	provider, ok := parser.NewProvider(parser.AgentCodex, parser.ProviderConfig{
+		Roots: []string{clientRoot},
+	})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	manifest, objects := manifestFromCapturePlan(t, parser.AgentCodex, provider, sources[0])
+	manifest = parserTestManifest(
+		t, parser.AgentCodex, parser.CodexSourceKey(parser.AgentCodex, wrongID),
+		manifest.Manifest.Entries,
+	)
+	materialized, err := (Materializer{
+		Store:   &materializerStore{objects: objects},
+		BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	_, err = dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+	assert.Contains(t, err.Error(), "manifest matched 0 provider sources")
+	assert.NotContains(t, err.Error(), materialized.Root())
+}
+
+func TestProviderParserRejectsMiskeyedDatabaseManifest(t *testing.T) {
+	t.Parallel()
+	clientRoot := t.TempDir()
+	contents := forgeSnapshotFixture(t, map[string]string{
+		"conv-001": "2026-05-02 09:58:15",
+	})
+	require.NoError(t, os.WriteFile(
+		filepath.Join(clientRoot, parser.ForgeDBFilename), contents, 0o600,
+	))
+	provider, ok := parser.NewProvider(parser.AgentForge, parser.ProviderConfig{
+		Roots: []string{clientRoot},
+	})
+	require.True(t, ok)
+	discovery, err := parser.DiscoverRawCaptureSources(t.Context(), provider)
+	require.NoError(t, err)
+	require.Len(t, discovery.Sources, 1)
+	manifest, objects := manifestFromCapturePlan(
+		t, parser.AgentForge, provider, discovery.Sources[0],
+	)
+	manifest = parserTestManifest(
+		t, parser.AgentForge, parser.PiebaldDBFilename, manifest.Manifest.Entries,
+	)
+	materialized, err := (Materializer{
+		Store:   &materializerStore{objects: objects},
+		BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	_, err = dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+	assert.Contains(t, err.Error(), "manifest matched 0 provider sources")
+	assert.NotContains(t, err.Error(), materialized.Root())
+}
+
+func TestProviderParserMatchSelectsPrimarySourceWhenSiblingPlansShareEntries(t *testing.T) {
+	t.Parallel()
+	clientRoot := t.TempDir()
+	projectDir := filepath.Join(clientRoot, "demo-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	line := func(kind, uuid, parent, ts, sessionID, mark, content string) string {
+		parentJSON := "null"
+		if parent != "" {
+			parentJSON = strconv.Quote(parent)
+		}
+		markField := ""
+		if mark != "" {
+			markField = `"sessionKind":` + strconv.Quote(mark) + `,`
+		}
+		role := "user"
+		body := `"message":{"content":` + strconv.Quote(content) + `}`
+		if kind == "assistant" {
+			role = "assistant"
+			body = `"message":{"id":"msg_` + uuid + `","content":[{"type":"text","text":` +
+				strconv.Quote(content) + `}]}`
+		}
+		return `{"type":"` + role + `","uuid":` + strconv.Quote(uuid) + `,"parentUuid":` + parentJSON +
+			`,"timestamp":"` + ts + `","sessionId":"` + sessionID + `",` + markField + body + `}`
+	}
+	chain := func(sessionID string, ownQuestion, ownAnswer string) string {
+		return strings.Join([]string{
+			line("user", "u1", "", "2026-01-01T10:00:00Z", sessionID, "bg", "first question"),
+			line("assistant", "a1", "u1", "2026-01-01T10:00:05Z", sessionID, "bg", "first answer"),
+			line("user", "u2", "a1", "2026-01-01T11:00:00Z", sessionID, "bg", ownQuestion),
+			line("assistant", "a2", "u2", "2026-01-01T11:00:05Z", sessionID, "bg", ownAnswer),
+		}, "\n") + "\n"
+	}
+	// A chained background fork: fork-2222 and fork-3333 are both bg-marked
+	// and share one root uuid, so each one's capture plan carries the other as
+	// an appendable lineage input and both plans cover the same entry set.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "fork-2222.jsonl"),
+		[]byte(chain("fork-2222", "continued question", "continued answer")), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "fork-3333.jsonl"),
+		[]byte(chain("fork-3333", "later question", "later answer")), 0o644,
+	))
+
+	localProvider, ok := parser.NewProvider(parser.AgentClaude, parser.ProviderConfig{
+		Roots: []string{clientRoot}, Machine: "hosted-worker",
+	})
+	require.True(t, ok)
+	sources, err := localProvider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 2)
+	var primary parser.SourceRef
+	for _, source := range sources {
+		if strings.HasSuffix(source.Key, "fork-2222.jsonl") {
+			primary = source
+		}
+	}
+	require.NotEmpty(t, primary.Key)
+
+	manifest, objects := manifestFromCapturePlan(t, parser.AgentClaude, localProvider, primary)
+	require.Len(t, manifest.Manifest.Entries, 2)
+	materialized, err := (Materializer{
+		Store:   &materializerStore{objects: objects},
+		BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	hosted, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err,
+		"shared sibling entries must not make source matching ambiguous")
+	require.Len(t, hosted.Outcome.Results, 1)
+	assert.True(t, strings.HasSuffix(
+		hosted.Outcome.Results[0].Result.Session.File.Path, "fork-2222.jsonl"),
+		"the manifest's primary transcript must be the parsed source")
+	assert.Equal(t, "fork-2222", hosted.Outcome.Results[0].Result.Session.ID)
+}
+
+// TestProviderParserRejectsProviderWithoutRawCaptureSupportBeforeDiscovery
+// pins that a registered factory which does not advertise
+// RawCapture.Support is rejected before the provider is constructed or its
+// discovery runs: unsupported providers would otherwise fall back to their
+// ordinary normalized discovery over untrusted materialized data.
+func TestProviderParserRejectsProviderWithoutRawCaptureSupportBeforeDiscovery(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	localPath := filepath.Join(root, "session.jsonl")
+	require.NoError(t, os.WriteFile(localPath, []byte("session"), 0o400))
+	manifest := parserTestManifest(t, parser.AgentClaude, "/canonical/claude/session.jsonl", []rawsync.Entry{{
+		Path: "session.jsonl", Type: "file", Length: 7,
+		Objects: []rawsync.ObjectRef{objectRefForBytes(t, []byte("session"))},
+	}})
+	factory := &unsupportedRawCaptureFactory{provider: &unsupportedRawCaptureProvider{}}
+	dispatch, err := NewProviderParser([]parser.ProviderFactory{factory}, "hosted-worker")
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, &Materialization{
+		root: root, entries: map[string]string{"session.jsonl": localPath},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+	assert.Contains(t, err.Error(), parser.ProviderFeatureRawCapture)
+	assert.False(t, parsed.Tombstone)
+	assert.Empty(t, parsed.Outcome.Results)
+	assert.False(t, factory.constructed,
+		"an unsupported provider must be rejected before construction")
+	assert.False(t, factory.provider.discoverInvoked,
+		"an unsupported provider must be rejected before discovery runs")
+}
+
+func TestProviderParserHandlesTombstoneWithoutInvokingProvider(t *testing.T) {
+	t.Parallel()
+	identity, err := rawsync.NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+	manifest, err := rawsync.ValidateAndCanonicalize(identity, rawsync.Manifest{
+		SchemaVersion:    rawsync.ManifestSchemaVersion,
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: "root-a",
+		SourceKey:        "/canonical/claude/session.jsonl",
+		CaptureID:        "capture-a",
+		CapturedAt:       time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		Kind:             rawsync.ManifestTombstone,
+	}, rawsync.DefaultManifestLimits())
+	require.NoError(t, err)
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, nil)
+	require.NoError(t, err)
+	assert.True(t, parsed.Tombstone)
+	assert.Empty(t, parsed.Outcome.Results)
+}
+
+type providerParserFixtureFactory struct {
+	provider *providerParserFixture
+	config   parser.ProviderConfig
+}
+
+func (f *providerParserFixtureFactory) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: parser.AgentClaude}
+}
+
+func (f *providerParserFixtureFactory) Capabilities() parser.Capabilities {
+	return providerParserCapabilities()
+}
+
+func (f *providerParserFixtureFactory) NewProvider(config parser.ProviderConfig) parser.Provider {
+	f.config = config
+	return f.provider
+}
+
+type providerParserFixture struct {
+	parser.Provider
+	root          string
+	localPath     string
+	planLocalPath string
+	request       parser.ParseRequest
+}
+
+func (p *providerParserFixture) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: parser.AgentClaude}
+}
+
+func (p *providerParserFixture) Capabilities() parser.Capabilities {
+	return providerParserCapabilities()
+}
+
+func (p *providerParserFixture) Discover(context.Context) ([]parser.SourceRef, error) {
+	return []parser.SourceRef{{
+		Provider:       parser.AgentClaude,
+		ConfiguredRoot: p.root,
+		Key:            p.localPath,
+		DisplayPath:    p.localPath,
+		FingerprintKey: p.localPath,
+	}}, nil
+}
+
+func (p *providerParserFixture) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	yield func(parser.SourceRef) error,
+) (bool, error) {
+	sources, err := p.Discover(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, source := range sources {
+		if err := yield(source); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (p *providerParserFixture) PlanRawCapture(
+	_ context.Context,
+	_ parser.SourceRef,
+) (parser.RawCapturePlan, error) {
+	planPath := p.planLocalPath
+	if planPath == "" {
+		planPath = p.localPath
+	}
+	return parser.RawCapturePlan{
+		ConfiguredRoot: p.root,
+		CaptureRoot:    p.root,
+		SourceKey:      p.localPath,
+		Entries: []parser.RawCaptureEntry{{
+			Path: "session.jsonl", LocalPath: planPath, Appendable: true,
+		}},
+	}, nil
+}
+
+func (p *providerParserFixture) Fingerprint(
+	_ context.Context,
+	source parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{Key: source.FingerprintKey, Size: 7}, nil
+}
+
+func (p *providerParserFixture) Parse(
+	_ context.Context,
+	request parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	p.request = request
+	return parser.ParseOutcome{
+		Results: []parser.ParseResultOutcome{{Result: parser.ParseResult{
+			Session: parser.ParsedSession{File: parser.FileInfo{Path: p.localPath}},
+		}}},
+		ResultSetComplete: true,
+	}, nil
+}
+
+func providerParserCapabilities() parser.Capabilities {
+	return parser.Capabilities{RawCapture: parser.RawCaptureCapabilities{
+		Support:  parser.CapabilitySupported,
+		Shape:    parser.RawCaptureShapeFiles,
+		Append:   parser.RawCaptureAppendOne,
+		Snapshot: parser.RawCaptureSnapshotNone,
+	}}
+}
+
+// unsupportedRawCaptureFactory is registered for Claude but advertises no
+// raw-capture support, recording whether construction ever happened.
+type unsupportedRawCaptureFactory struct {
+	provider    *unsupportedRawCaptureProvider
+	constructed bool
+}
+
+func (f *unsupportedRawCaptureFactory) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: parser.AgentClaude}
+}
+
+func (f *unsupportedRawCaptureFactory) Capabilities() parser.Capabilities {
+	capabilities := providerParserCapabilities()
+	capabilities.RawCapture.Support = parser.CapabilityUnsupported
+	return capabilities
+}
+
+func (f *unsupportedRawCaptureFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	f.constructed = true
+	return f.provider
+}
+
+// unsupportedRawCaptureProvider records any discovery invocation and fails
+// if its unsupported discovery surface is ever reached.
+type unsupportedRawCaptureProvider struct {
+	parser.Provider
+	discoverInvoked bool
+}
+
+func (p *unsupportedRawCaptureProvider) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: parser.AgentClaude}
+}
+
+func (p *unsupportedRawCaptureProvider) Capabilities() parser.Capabilities {
+	return parser.Capabilities{}
+}
+
+func (p *unsupportedRawCaptureProvider) DiscoverRawCaptureSourcesEach(
+	context.Context, func(parser.SourceRef) error,
+) (bool, error) {
+	p.discoverInvoked = true
+	return false, errors.New("unsupported raw-capture discovery must never run")
+}
+
+type projectPolicyProbingFactory struct {
+	provider *projectPolicyProbingFixture
+}
+
+func (f *projectPolicyProbingFactory) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: parser.AgentClaude}
+}
+
+func (f *projectPolicyProbingFactory) Capabilities() parser.Capabilities {
+	return providerParserCapabilities()
+}
+
+func (f *projectPolicyProbingFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+// projectPolicyProbingFixture answers project attribution through the same
+// context-honoring helper providers use, at both hosted seams: raw-capture
+// discovery and the parse itself.
+type projectPolicyProbingFixture struct {
+	parser.Provider
+	root             string
+	localPath        string
+	hostileCwd       string
+	discoveryProject string
+	parseProject     string
+}
+
+func (p *projectPolicyProbingFixture) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: parser.AgentClaude}
+}
+
+func (p *projectPolicyProbingFixture) Capabilities() parser.Capabilities {
+	return providerParserCapabilities()
+}
+
+func (p *projectPolicyProbingFixture) DiscoverRawCaptureSourcesEach(
+	ctx context.Context,
+	yield func(parser.SourceRef) error,
+) (bool, error) {
+	p.discoveryProject = parser.ExtractProjectFromCwdWithBranchContext(
+		ctx, p.hostileCwd, "",
+	)
+	return true, yield(parser.SourceRef{
+		Provider:       parser.AgentClaude,
+		ConfiguredRoot: p.root,
+		Key:            p.localPath,
+		DisplayPath:    p.localPath,
+		FingerprintKey: p.localPath,
+	})
+}
+
+func (p *projectPolicyProbingFixture) PlanRawCapture(
+	_ context.Context,
+	_ parser.SourceRef,
+) (parser.RawCapturePlan, error) {
+	return parser.RawCapturePlan{
+		ConfiguredRoot: p.root,
+		CaptureRoot:    p.root,
+		SourceKey:      p.localPath,
+		Entries: []parser.RawCaptureEntry{{
+			Path: "session.jsonl", LocalPath: p.localPath, Appendable: true,
+		}},
+	}, nil
+}
+
+func (p *projectPolicyProbingFixture) Fingerprint(
+	_ context.Context,
+	source parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{Key: source.FingerprintKey, Size: 7}, nil
+}
+
+func (p *projectPolicyProbingFixture) Parse(
+	ctx context.Context,
+	_ parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	p.parseProject = parser.ExtractProjectFromCwdWithBranchContext(
+		ctx, p.hostileCwd, "",
+	)
+	return parser.ParseOutcome{
+		Results: []parser.ParseResultOutcome{{Result: parser.ParseResult{
+			Session: parser.ParsedSession{
+				File:    parser.FileInfo{Path: p.localPath},
+				Project: p.parseProject,
+			},
+		}}},
+		ResultSetComplete: true,
+	}, nil
+}
+
+func parserTestManifest(
+	t *testing.T,
+	provider parser.AgentType,
+	sourceKey string,
+	entries []rawsync.Entry,
+) rawsync.CanonicalManifest {
+	t.Helper()
+	identity, err := rawsync.NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+	manifest, err := rawsync.ValidateAndCanonicalize(identity, rawsync.Manifest{
+		SchemaVersion:    rawsync.ManifestSchemaVersion,
+		Provider:         provider,
+		ConfiguredRootID: "root-a",
+		SourceKey:        sourceKey,
+		CaptureID:        "capture-a",
+		CapturedAt:       time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		Kind:             rawsync.ManifestSnapshot,
+		Entries:          entries,
+	}, rawsync.DefaultManifestLimits())
+	require.NoError(t, err)
+	return manifest
+}
+
+func TestProviderParserParsesEveryForgeSessionFromMaterializedSnapshot(t *testing.T) {
+	t.Parallel()
+	dbBytes := forgeSnapshotFixture(t, map[string]string{
+		"conv-001": "2026-05-02 09:58:15",
+		"conv-002": "2026-05-03 09:58:15",
+	})
+	dbRef := objectRefForBytes(t, dbBytes)
+	sourceModTime := time.Date(2026, 8, 13, 11, 0, 0, 987654321, time.UTC)
+	manifest := parserTestManifest(t, parser.AgentForge, parser.ForgeDBFilename, []rawsync.Entry{{
+		Path:      parser.ForgeDBFilename,
+		Type:      "file",
+		Length:    int64(len(dbBytes)),
+		ModTimeNS: sourceModTime.UnixNano(),
+		Objects:   []rawsync.ObjectRef{dbRef},
+	}})
+	store := &materializerStore{objects: map[rawsync.ObjectRef][]byte{dbRef: dbBytes}}
+	materializationBase := filepath.Join(t.TempDir(), "hosted#worker")
+	require.NoError(t, os.Mkdir(materializationBase, 0o700))
+	materialized, err := (Materializer{
+		Store: store, BaseDir: materializationBase, MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, materialized.Cleanup()) }()
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err)
+	assert.False(t, parsed.Tombstone)
+	require.Len(t, parsed.Outcome.Results, 2)
+	assert.True(t, parsed.Outcome.ResultSetComplete)
+	assert.True(t, parsed.Outcome.ForceReplace)
+	assert.Empty(t, parsed.Outcome.SourceErrors)
+	first := parsed.Outcome.Results[0].Result
+	second := parsed.Outcome.Results[1].Result
+	assert.Equal(t, "forge:conv-001", first.Session.ID)
+	assert.Equal(t, "forge:conv-002", second.Session.ID)
+	assert.Equal(t, parser.AgentForge, first.Session.Agent)
+	assert.Equal(t, parser.ForgeDBFilename+"#conv-001", first.Session.File.Path,
+		"each logical session must keep a stable per-session virtual identity")
+	assert.Equal(t, parser.ForgeDBFilename+"#conv-002", second.Session.File.Path)
+	assert.NotContains(t, first.Session.File.Path, materialized.Root())
+	assert.Equal(t, int(2), first.Session.MessageCount)
+	assert.Equal(t, int(2), second.Session.MessageCount)
+	assert.Equal(t,
+		time.Date(2026, 5, 2, 10, 0, 16, 848497543, time.UTC).UnixNano(),
+		first.Session.File.Mtime,
+		"database-derived session timestamps must stay source-derived")
+	assert.Equal(t,
+		time.Date(2026, 5, 3, 10, 00, 16, 848497543, time.UTC).UnixNano(),
+		second.Session.File.Mtime)
+	assert.NotEqual(t, sourceModTime.UnixNano(), first.Session.File.Mtime)
+}
+
+func TestProviderParserHandlesEmptyForgeSnapshot(t *testing.T) {
+	t.Parallel()
+	dbBytes := forgeSnapshotFixture(t, nil)
+	dbRef := objectRefForBytes(t, dbBytes)
+	manifest := parserTestManifest(t, parser.AgentForge, parser.ForgeDBFilename, []rawsync.Entry{{
+		Path:    parser.ForgeDBFilename,
+		Type:    "file",
+		Length:  int64(len(dbBytes)),
+		Objects: []rawsync.ObjectRef{dbRef},
+	}})
+	store := &materializerStore{objects: map[rawsync.ObjectRef][]byte{dbRef: dbBytes}}
+	materialized, err := (Materializer{
+		Store: store, BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20,
+	}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, materialized.Cleanup()) }()
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+
+	parsed, err := dispatch.Parse(t.Context(), manifest, materialized)
+
+	require.NoError(t, err)
+	assert.False(t, parsed.Tombstone)
+	assert.Empty(t, parsed.Outcome.Results)
+	assert.True(t, parsed.Outcome.ResultSetComplete)
+	assert.True(t, parsed.Outcome.ForceReplace)
+	assert.Equal(t, parser.SkipNoSession, parsed.Outcome.SkipReason)
+}
+
+// forgeSnapshotFixture writes a real Forge SQLite store carrying one
+// conversation per supplied session ID mapped to its created_at timestamp.
+func forgeSnapshotFixture(t *testing.T, conversations map[string]string) []byte {
+	t.Helper()
+	return forgeSnapshotFixtureWithCwd(t, conversations, "/srv/agent/project")
+}
+
+// forgeSnapshotFixtureWithCwd writes a real Forge SQLite store whose recorded
+// system working directory is cwd.
+func forgeSnapshotFixtureWithCwd(
+	t *testing.T, conversations map[string]string, cwd string,
+) []byte {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), parser.ForgeDBFilename)
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE conversations (
+		conversation_id TEXT PRIMARY KEY NOT NULL,
+		title TEXT,
+		workspace_id BIGINT NOT NULL,
+		context TEXT,
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP,
+		metrics TEXT
+	)`)
+	require.NoError(t, err)
+	ids := make([]string, 0, len(conversations))
+	for id := range conversations {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	for _, id := range ids {
+		updatedAt := strings.Replace(conversations[id], "09:58:15", "10:00:16.848497543", 1)
+		systemInformation := "<system_information>\n<current_working_directory>" +
+			cwd + "</current_working_directory>\n</system_information>"
+		context := fmt.Sprintf(`{
+			"conversation_id": %q,
+			"messages": [
+				{
+					"message": {"text": {
+						"role": "System",
+						"content": %s,
+						"model": "gpt-5.4",
+						"timestamp": "2026-05-02T09:58:15.741021507Z"
+					}}
+				},
+				{
+					"message": {"text": {
+						"role": "User",
+						"content": "Summarize the repository.",
+						"model": "gpt-5.4",
+						"timestamp": "2026-05-02T09:58:16.000000000Z"
+					}}
+				},
+				{
+					"message": {"text": {
+						"role": "Assistant",
+						"content": "It syncs agent sessions.",
+						"model": "gpt-5.4",
+						"timestamp": "2026-05-02T09:58:18.000000000Z"
+					}}
+				}
+			]
+		}`, id, strconv.Quote(systemInformation))
+		_, err = db.Exec(
+			`INSERT INTO conversations
+			 (conversation_id, title, workspace_id, context, created_at, updated_at, metrics)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			id, "Forge Session", int64(1), context,
+			conversations[id], updatedAt, "",
+		)
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.Close())
+	contents, err := os.ReadFile(dbPath)
+	require.NoError(t, err)
+	return contents
+}
+
+func TestProviderParserHostedEvenerMatchesLocal(t *testing.T) {
+	for _, directSessionsRoot := range []bool{false, true} {
+		for _, parentState := range []string{"missing", "present", "invalid_metadata"} {
+			t.Run(fmt.Sprintf("direct_sessions_root_%t/parent_%s", directSessionsRoot, parentState), func(t *testing.T) {
+				root := t.TempDir()
+				sessions := filepath.Join(root, "sessions")
+				require.NoError(t, os.MkdirAll(sessions, 0o700))
+				header := `{"kind":"header","format_version":2,"session_id":"session","created_at":"2026-01-01T00:00:00Z","working_dir":"/work/project"}` + "\n"
+				replayed := `{"kind":"entry","seq":0,"turn":{"kind":"USER_INPUT","timestamp":"2026-01-01T00:01:00Z","message":{"role":"user","content":[{"kind":"text","text":"Shared history"}]}}}` + "\n"
+				child := `{"kind":"entry","seq":1,"turn":{"kind":"USER_INPUT","timestamp":"2026-01-01T00:02:00Z","message":{"role":"user","content":[{"kind":"text","text":"Hello"}]}}}` + "\n"
+				require.NoError(t, os.WriteFile(filepath.Join(sessions, "session.transcript.jsonl"), []byte(header+replayed+child), 0o600))
+				require.NoError(t, os.WriteFile(filepath.Join(sessions, "session.meta.json"), []byte(`{"id":"session","name":"Child session","parent_session_id":"parent","divergence_turn":2}`), 0o600))
+				if parentState != "missing" {
+					parentHeader := strings.Replace(header, `"session_id":"session"`, `"session_id":"parent"`, 1)
+					require.NoError(t, os.WriteFile(filepath.Join(sessions, "parent.transcript.jsonl"), []byte(parentHeader+replayed), 0o600))
+					parentMeta := `{"id":"parent","name":"Parent session"}`
+					if parentState == "invalid_metadata" {
+						parentMeta = `{"id":"different-parent"}`
+					}
+					require.NoError(t, os.WriteFile(filepath.Join(sessions, "parent.meta.json"), []byte(parentMeta), 0o600))
+				}
+				if directSessionsRoot {
+					root = sessions
+				}
+				provider, ok := parser.NewProvider(parser.AgentEvener, parser.ProviderConfig{Roots: []string{root}})
+				require.True(t, ok)
+				source, found, err := provider.FindSource(t.Context(), parser.FindSourceRequest{RawSessionID: "session"})
+				require.NoError(t, err)
+				require.True(t, found)
+				local, err := provider.Parse(t.Context(), parser.ParseRequest{Source: source})
+				require.NoError(t, err)
+				require.Len(t, local.Results, 1)
+				if parentState == "present" {
+					require.Len(t, local.Results[0].Result.Messages, 1)
+					assert.Equal(t, "Hello", local.Results[0].Result.Messages[0].Content)
+				} else {
+					require.Len(t, local.Results[0].Result.Messages, 2)
+					assert.Equal(t, "Shared history", local.Results[0].Result.Messages[0].Content)
+				}
+				manifest, objects := manifestFromCapturePlan(t, parser.AgentEvener, provider, source)
+				materialized, err := (Materializer{Store: &materializerStore{objects: objects}, BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20}).Materialize(t.Context(), manifest)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+				dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+				require.NoError(t, err)
+				hosted, err := dispatch.Parse(t.Context(), manifest, materialized)
+				require.NoError(t, err)
+				require.Len(t, hosted.Outcome.Results, 1)
+				assert.Equal(t, local.Results[0].Result.Messages, hosted.Outcome.Results[0].Result.Messages)
+				assert.Equal(t, source.DisplayPath, hosted.Outcome.Results[0].Result.Session.File.Path)
+				assert.Equal(t, "Child session", hosted.Outcome.Results[0].Result.Session.SessionName)
+				assert.Equal(t, "evener:parent", hosted.Outcome.Results[0].Result.Session.ParentSessionID)
+			})
+		}
+	}
+}
+
+func TestProviderParserHostedCodexSkillNameStaysLexical(t *testing.T) {
+	serverDir := filepath.Join(t.TempDir(), "visible-folder")
+	require.NoError(t, os.MkdirAll(serverDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(serverDir, "SKILL.md"), []byte("---\nname: server-only-frontmatter-name\n---\n"), 0o600))
+	root := filepath.Join(t.TempDir(), "sessions")
+	require.NoError(t, os.MkdirAll(root, 0o700))
+	const id = "11111111-1111-4111-8111-111111111111"
+	args := `{"cmd":"cat SKILL.md"}`
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(id, serverDir, "codex_cli_rs", "2026-09-08T10:00:00Z"),
+		`{"type":"response_item","timestamp":"2026-09-08T10:00:01Z","payload":{"type":"function_call","name":"exec_command","call_id":"call-1","arguments":`+strconv.Quote(args)+`}}`,
+	)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "rollout-2026-09-08T10-00-00-"+id+".jsonl"), []byte(content), 0o600))
+	provider, ok := parser.NewProvider(parser.AgentCodex, parser.ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discovery, err := parser.DiscoverRawCaptureSources(t.Context(), provider)
+	require.NoError(t, err)
+	require.Len(t, discovery.Sources, 1)
+	local, err := provider.Parse(t.Context(), parser.ParseRequest{Source: discovery.Sources[0]})
+	require.NoError(t, err)
+	require.Len(t, local.Results, 1)
+	require.Len(t, local.Results[0].Result.Messages, 1)
+	assert.Equal(t, "server-only-frontmatter-name", local.Results[0].Result.Messages[0].ToolCalls[0].SkillName)
+	manifest, objects := manifestFromCapturePlan(t, parser.AgentCodex, provider, discovery.Sources[0])
+	materialized, err := (Materializer{Store: &materializerStore{objects: objects}, BaseDir: t.TempDir(), MaxTotalBytes: 1 << 20}).Materialize(t.Context(), manifest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, materialized.Cleanup()) })
+	dispatch, err := NewProviderParser(parser.ProviderFactories(), "hosted-worker")
+	require.NoError(t, err)
+	out, err := dispatch.Parse(t.Context(), manifest, materialized)
+	require.NoError(t, err)
+	require.Len(t, out.Outcome.Results, 1)
+	require.Len(t, out.Outcome.Results[0].Result.Messages, 1)
+	require.Len(t, out.Outcome.Results[0].Result.Messages[0].ToolCalls, 1)
+	assert.Empty(t, out.Outcome.Results[0].Result.Messages[0].ToolCalls[0].SkillName)
+}

--- a/internal/rawderive/worker.go
+++ b/internal/rawderive/worker.go
@@ -1,0 +1,503 @@
+package rawderive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+// jobErrorCode maps an arbitrary pipeline error onto a fixed allowlisted
+// code. Provider and materializer errors can embed client source paths or raw
+// content, so only these codes may be persisted or returned to callers;
+// errors.Is classification on the original error stays internal.
+func jobErrorCode(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, ErrLeaseLost):
+		return "lease_lost"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case errors.Is(err, rawsync.ErrNotFound):
+		return "object_not_found"
+	case errors.Is(err, rawsync.ErrMissingObject):
+		return "missing_object"
+	case errors.Is(err, rawsync.ErrConflict):
+		return "conflict"
+	case errors.Is(err, rawsync.ErrInvalid):
+		return "invalid"
+	default:
+		return "internal"
+	}
+}
+
+// jobErrorDiagnostic renders the allowlisted durable diagnostic for one
+// failed pipeline attempt: its stage plus the error code, with a cleanup
+// suffix when a materialization cleanup failure joined the outcome.
+func jobErrorDiagnostic(stage string, err error) string {
+	code := jobErrorCode(err)
+	if stage != "" {
+		code = stage + ":" + code
+	}
+	if errors.Is(err, errMaterializationCleanup) {
+		code += "+cleanup_failed"
+	}
+	return code
+}
+
+// reportableJobError builds the caller-facing error for one lease outcome.
+// Only allowlisted diagnostics and safe sentinels appear; the underlying
+// pipeline error never reaches callers who might log it.
+func reportableJobError(id int64, stage string, err error) error {
+	detail := ""
+	if errors.Is(err, errMaterializationCleanup) {
+		detail = " (materialization cleanup failed)"
+	}
+	switch {
+	case errors.Is(err, ErrLeaseLost):
+		return fmt.Errorf("raw parse job %d: %s: %w%s", id, stage, ErrLeaseLost, detail)
+	case errors.Is(err, context.Canceled):
+		return fmt.Errorf("raw parse job %d: %s: %w%s", id, stage, context.Canceled, detail)
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("raw parse job %d: %s: %w%s", id, stage, context.DeadlineExceeded, detail)
+	default:
+		return fmt.Errorf("raw parse job %d: %s%s", id, jobErrorDiagnostic(stage, err), detail)
+	}
+}
+
+// JobQueue owns fenced parse-job leasing and retry state.
+type JobQueue interface {
+	ClaimRawParseJobs(context.Context, string, int, time.Duration) ([]JobLease, error)
+	HeartbeatRawParseJob(context.Context, JobLease, time.Duration) error
+	RetryRawParseJob(context.Context, JobLease, time.Time, string, string) error
+	FailRawParseJob(context.Context, JobLease, string, string) error
+}
+
+// ManifestSource loads the authoritative manifest named by a job lease.
+type ManifestSource interface {
+	Load(context.Context, JobLease) (rawsync.CanonicalManifest, error)
+}
+
+// SourceMaterializer reconstructs one verified, isolated provider tree.
+type SourceMaterializer interface {
+	Materialize(context.Context, rawsync.CanonicalManifest) (*Materialization, error)
+}
+
+// SourceParser invokes the provider-owned parser over a materialized tree.
+type SourceParser interface {
+	Parse(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error)
+}
+
+// ProjectionSink atomically applies a normalized outcome and completes the
+// supplied fenced lease. Implementations must change neither projection nor
+// job state when the manifest is no longer the current source head.
+type ProjectionSink interface {
+	Project(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error
+}
+
+// WorkerConfig supplies bounded parse-worker dependencies and timing.
+type WorkerConfig struct {
+	Queue             JobQueue
+	Manifests         ManifestSource
+	Materializer      SourceMaterializer
+	Parser            SourceParser
+	Projection        ProjectionSink
+	Owner             string
+	BatchSize         int
+	LeaseDuration     time.Duration
+	HeartbeatInterval time.Duration
+	// AttemptTimeout bounds how long one attempt may keep renewing its
+	// durable lease. When the deadline fires, the attempt's contexts cancel
+	// and heartbeat renewal stops, so the lease expires and another worker
+	// can reclaim the job. The deadline cannot stop arbitrary provider code:
+	// a non-cooperative stage that ignores its context can still block this
+	// worker's goroutine, but it can no longer keep its lease alive.
+	AttemptTimeout time.Duration
+	RetryBase      time.Duration
+	RetryMax       time.Duration
+	MaxAttempts    int
+}
+
+// Worker processes bounded batches of leased raw parse jobs.
+type Worker struct {
+	Queue             JobQueue
+	Manifests         ManifestSource
+	Materializer      SourceMaterializer
+	Parser            SourceParser
+	Projection        ProjectionSink
+	Owner             string
+	BatchSize         int
+	LeaseDuration     time.Duration
+	HeartbeatInterval time.Duration
+	AttemptTimeout    time.Duration
+	RetryBase         time.Duration
+	RetryMax          time.Duration
+	MaxAttempts       int
+	now               func() time.Time
+}
+
+// BatchResult summarizes durable outcomes for one claimed batch.
+type BatchResult struct {
+	Claimed   int
+	Succeeded int
+	Retried   int
+	Failed    int
+	LeaseLost int
+}
+
+// NewWorker validates and constructs a raw parse worker.
+func NewWorker(config WorkerConfig) (*Worker, error) {
+	if config.Queue == nil || config.Manifests == nil || config.Materializer == nil ||
+		config.Parser == nil || config.Projection == nil {
+		return nil, fmt.Errorf("%w: all raw parse worker dependencies are required", rawsync.ErrInvalid)
+	}
+	if !ValidLeaseOwner(config.Owner) || config.BatchSize <= 0 ||
+		config.BatchSize > MaxClaimBatchSize {
+		return nil, fmt.Errorf(
+			"%w: raw parse worker identity and a batch size between 1 and %d are required",
+			rawsync.ErrInvalid, MaxClaimBatchSize,
+		)
+	}
+	if config.LeaseDuration <= 0 || config.HeartbeatInterval <= 0 ||
+		config.HeartbeatInterval >= config.LeaseDuration {
+		return nil, fmt.Errorf("%w: raw parse worker lease timing is invalid", rawsync.ErrInvalid)
+	}
+	if config.RetryBase <= 0 || config.RetryMax < config.RetryBase {
+		return nil, fmt.Errorf("%w: raw parse worker retry timing is invalid", rawsync.ErrInvalid)
+	}
+	if config.MaxAttempts <= 0 {
+		return nil, fmt.Errorf("%w: raw parse worker max attempts must be positive", rawsync.ErrInvalid)
+	}
+	if config.AttemptTimeout <= 0 {
+		return nil, fmt.Errorf("%w: raw parse worker attempt timeout must be positive", rawsync.ErrInvalid)
+	}
+	return &Worker{
+		Queue:             config.Queue,
+		Manifests:         config.Manifests,
+		Materializer:      config.Materializer,
+		Parser:            config.Parser,
+		Projection:        config.Projection,
+		Owner:             config.Owner,
+		BatchSize:         config.BatchSize,
+		LeaseDuration:     config.LeaseDuration,
+		HeartbeatInterval: config.HeartbeatInterval,
+		AttemptTimeout:    config.AttemptTimeout,
+		RetryBase:         config.RetryBase,
+		RetryMax:          config.RetryMax,
+		MaxAttempts:       config.MaxAttempts,
+		now:               time.Now,
+	}, nil
+}
+
+// RunBatch claims and processes at most BatchSize jobs concurrently.
+func (w *Worker) RunBatch(ctx context.Context) (BatchResult, error) {
+	if w == nil {
+		return BatchResult{}, fmt.Errorf("%w: raw parse worker is missing", rawsync.ErrInvalid)
+	}
+	leasing, err := w.Queue.ClaimRawParseJobs(
+		ctx, w.Owner, w.BatchSize, w.LeaseDuration,
+	)
+	if err != nil {
+		return BatchResult{}, fmt.Errorf("claiming raw parse jobs: %w", err)
+	}
+	result := BatchResult{Claimed: len(leasing)}
+	if len(leasing) == 0 {
+		return result, nil
+	}
+	completed := make(chan leaseResult, len(leasing))
+	for _, lease := range leasing {
+		go func() {
+			completed <- w.processLease(ctx, lease)
+		}()
+	}
+	var batchErr error
+	for range leasing {
+		job := <-completed
+		result.Succeeded += job.succeeded
+		result.Retried += job.retried
+		result.Failed += job.failed
+		result.LeaseLost += job.leaseLost
+		if job.err != nil {
+			batchErr = errors.Join(batchErr, job.err)
+		}
+	}
+	return result, batchErr
+}
+
+type leaseResult struct {
+	id        int64
+	succeeded int
+	retried   int
+	failed    int
+	leaseLost int
+	err       error
+}
+
+func (w *Worker) processLease(parent context.Context, lease JobLease) leaseResult {
+	result := leaseResult{id: lease.ID}
+	timeoutCtx, cancelTimeout := context.WithTimeout(parent, w.AttemptTimeout)
+	workCtx, cancelWork := context.WithCancelCause(timeoutCtx)
+	stopHeartbeat := w.startHeartbeat(workCtx, cancelWork, lease)
+	stage, operationErr := w.runPipeline(workCtx, lease)
+	heartbeatErr := stopHeartbeat()
+	workCause := context.Cause(workCtx)
+	cancelWork(nil)
+	cancelTimeout()
+	if operationErr == nil {
+		// The pipeline committed its outcome; a heartbeat failure after
+		// that point cannot un-commit it.
+		result.succeeded = 1
+		return result
+	}
+	if heartbeatErr != nil && errors.Is(operationErr, context.Canceled) &&
+		errors.Is(workCause, heartbeatErr) {
+		// The heartbeat failure canceled cooperative work mid-attempt. Prune
+		// only the generic cancellation it induced so substantive failures
+		// that joined the outcome -- independent parser errors, materialization
+		// cleanup -- are not discarded when the heartbeat event is restored.
+		stripped, _ := stripCanceledLeaves(operationErr)
+		if stripped == nil {
+			// Cancellation was the pipeline's only substantive cause. A
+			// cooperative stage reports the work context's generic cancellation,
+			// so restore the heartbeat cause and let the durable outcome record
+			// the event that actually stopped the attempt, without exposing
+			// transport detail.
+			stage = "heartbeat"
+			operationErr = heartbeatErr
+			heartbeatErr = nil
+		} else {
+			// Substantive causes remain: the pipeline stage survives, the
+			// stripped error keeps every non-cancellation cause and sentinel
+			// (including errMaterializationCleanup), and the heartbeat failure
+			// joins below as ErrLeaseLost or a sanitized diagnostic.
+			operationErr = stripped
+		}
+	}
+	if heartbeatErr != nil && !errors.Is(heartbeatErr, context.Canceled) {
+		if errors.Is(heartbeatErr, ErrLeaseLost) {
+			// Lease loss dominates the outcome classification, but the
+			// pipeline failure remains the durable stage and cause.
+			operationErr = errors.Join(operationErr, ErrLeaseLost)
+		} else {
+			// Secondary heartbeat diagnostics join only in sanitized
+			// form; they never replace the pipeline failure.
+			operationErr = errors.Join(
+				operationErr,
+				fmt.Errorf("heartbeat:%s", jobErrorCode(heartbeatErr)),
+			)
+		}
+	}
+	result.err = reportableJobError(lease.ID, stage, operationErr)
+	if errors.Is(operationErr, ErrLeaseLost) {
+		result.leaseLost = 1
+		return result
+	}
+	if parent.Err() != nil {
+		return result
+	}
+	if lease.Attempt >= w.MaxAttempts {
+		failureErr := w.Queue.FailRawParseJob(
+			parent, lease, stage, jobErrorDiagnostic(stage, operationErr),
+		)
+		if errors.Is(failureErr, ErrLeaseLost) {
+			result.leaseLost = 1
+			result.err = errors.Join(result.err, reportableJobError(lease.ID, stage, ErrLeaseLost))
+			return result
+		}
+		if failureErr != nil {
+			result.err = errors.Join(result.err, fmt.Errorf(
+				"recording terminal failure: %s", jobErrorDiagnostic("fail", failureErr),
+			))
+			return result
+		}
+		result.failed = 1
+		return result
+	}
+	retryAt := w.now().Add(retryDelay(lease.Attempt, w.RetryBase, w.RetryMax))
+	retryErr := w.Queue.RetryRawParseJob(
+		parent, lease, retryAt, stage, jobErrorDiagnostic(stage, operationErr),
+	)
+	if errors.Is(retryErr, ErrLeaseLost) {
+		result.leaseLost = 1
+		result.err = errors.Join(result.err, reportableJobError(lease.ID, stage, ErrLeaseLost))
+		return result
+	}
+	if retryErr != nil {
+		result.err = errors.Join(result.err, fmt.Errorf(
+			"recording retry: %s", jobErrorDiagnostic("retry", retryErr),
+		))
+		return result
+	}
+	result.retried = 1
+	return result
+}
+
+func (w *Worker) runPipeline(
+	ctx context.Context,
+	lease JobLease,
+) (stage string, resultErr error) {
+	manifest, err := w.Manifests.Load(ctx, lease)
+	if err != nil {
+		return "manifest", err
+	}
+	if manifest.ManifestID != lease.ManifestID || manifest.Identity != lease.Identity {
+		return "manifest", fmt.Errorf("%w: loaded manifest does not match its lease", rawsync.ErrInvalid)
+	}
+	var materialized *Materialization
+	if manifest.Manifest.Kind != rawsync.ManifestTombstone {
+		materialized, err = w.Materializer.Materialize(ctx, manifest)
+		if err != nil {
+			return "materialize", err
+		}
+	}
+	var cleanupReported bool
+	if materialized != nil {
+		defer func() {
+			if cleanupErr := materialized.Cleanup(); cleanupErr != nil && !cleanupReported {
+				// The deferred cleanup is one retry of the pre-projection
+				// removal. Cleanup failures always join the operation error,
+				// and the durable stage only becomes the cleanup stage when
+				// nothing else failed first. When the pre-projection removal
+				// already reported its failure, the retry outcome must not
+				// duplicate it in the joined error.
+				if resultErr == nil {
+					stage = "materialize"
+				}
+				resultErr = errors.Join(resultErr, cleanupErr)
+			}
+		}()
+	}
+	parsed, err := w.Parser.Parse(ctx, manifest, materialized)
+	if err != nil {
+		return "parse", err
+	}
+	if materialized != nil {
+		if err := materialized.Cleanup(); err != nil {
+			cleanupReported = true
+			return "materialize", fmt.Errorf("cleaning raw materialization: %w", err)
+		}
+	}
+	if err := w.Projection.Project(ctx, lease, manifest, parsed); err != nil {
+		return "projection", err
+	}
+	return "", nil
+}
+
+// startHeartbeat renews the leased job on a fixed cadence until the
+// attempt's work context is done. The heartbeat context must derive from
+// the work context, never from the longer-lived parent: once the
+// AttemptTimeout deadline fires, renewal stops even when a non-cooperative
+// pipeline stage never returns, so the durable lease is left to expire.
+func (w *Worker) startHeartbeat(
+	workCtx context.Context,
+	cancelWork context.CancelCauseFunc,
+	lease JobLease,
+) func() error {
+	heartbeatCtx, cancelHeartbeat := context.WithCancel(workCtx)
+	done := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(w.HeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				done <- nil
+				return
+			case <-ticker.C:
+				if heartbeatCtx.Err() != nil {
+					// The attempt deadline (or cancellation) already fired;
+					// a tick that lost the select race must not renew past
+					// the attempt's lifetime.
+					done <- nil
+					return
+				}
+				if err := w.Queue.HeartbeatRawParseJob(
+					heartbeatCtx, lease, w.LeaseDuration,
+				); err != nil {
+					if heartbeatCtx.Err() != nil {
+						done <- nil
+						return
+					}
+					cancelWork(err)
+					done <- err
+					return
+				}
+			}
+		}
+	}()
+	return func() error {
+		cancelHeartbeat()
+		return <-done
+	}
+}
+
+// stripCanceledLeaves prunes context.Canceled leaves from an operation
+// error while preserving every substantive non-cancellation cause and
+// sentinel. Ordinary unwrap chains collapse only when cancellation is their
+// entire content; errors.Join multi-error trees drop just their canceled
+// branches and keep the rest. The second result reports whether any
+// cancellation leaf was removed.
+func stripCanceledLeaves(err error) (error, bool) {
+	if err == nil {
+		return nil, false
+	}
+	if err == context.Canceled {
+		return nil, true
+	}
+	if tree, ok := err.(interface{ Unwrap() []error }); ok {
+		branches := tree.Unwrap()
+		kept := make([]error, 0, len(branches))
+		removed := false
+		for _, branch := range branches {
+			stripped, branchRemoved := stripCanceledLeaves(branch)
+			removed = removed || branchRemoved
+			if stripped != nil {
+				kept = append(kept, stripped)
+			}
+		}
+		switch {
+		case !removed:
+			// Rebuilding an untouched tree would needlessly replace the
+			// original error and its formatting.
+			return err, false
+		case len(kept) == 0:
+			return nil, true
+		case len(kept) == 1:
+			return kept[0], true
+		default:
+			return errors.Join(kept...), true
+		}
+	}
+	if chain, ok := err.(interface{ Unwrap() error }); ok {
+		stripped, removed := stripCanceledLeaves(chain.Unwrap())
+		if removed {
+			// Wrapper text is diagnostic context, not an independent cause. Once
+			// its child changes, return the stripped child rather than retaining
+			// the original wrapper and its canceled branch.
+			return stripped, true
+		}
+	}
+	return err, false
+}
+
+func retryDelay(attempt int, base, maximum time.Duration) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	delay := base
+	for range attempt - 1 {
+		if delay >= maximum/2 {
+			return maximum
+		}
+		delay *= 2
+	}
+	if delay > maximum {
+		return maximum
+	}
+	return delay
+}

--- a/internal/rawderive/worker_test.go
+++ b/internal/rawderive/worker_test.go
@@ -1,0 +1,1162 @@
+package rawderive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/rawsync"
+)
+
+func TestWorkerRunsSnapshotPipelineAndCleansBeforeAtomicProjection(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	var materializedRoot string
+	var projected bool
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			root, err := os.MkdirTemp(t.TempDir(), "worker-materialized-")
+			if err != nil {
+				return nil, err
+			}
+			materializedRoot = root
+			return &Materialization{root: root, entries: map[string]string{}}, nil
+		}),
+		sourceParserFunc(func(
+			_ context.Context,
+			gotManifest rawsync.CanonicalManifest,
+			materialized *Materialization,
+		) (ParsedManifest, error) {
+			assert.Equal(t, manifest, gotManifest)
+			_, err := os.Stat(materialized.Root())
+			if err != nil {
+				return ParsedManifest{}, err
+			}
+			return ParsedManifest{Outcome: parser.ParseOutcome{ResultSetComplete: true}}, nil
+		}),
+		projectionSinkFunc(func(
+			_ context.Context,
+			gotLease JobLease,
+			gotManifest rawsync.CanonicalManifest,
+			gotParsed ParsedManifest,
+		) error {
+			assert.Equal(t, lease, gotLease)
+			assert.Equal(t, manifest, gotManifest)
+			assert.True(t, gotParsed.Outcome.ResultSetComplete)
+			_, err := os.Stat(materializedRoot)
+			assert.ErrorIs(t, err, os.ErrNotExist, "raw bytes must be gone before projection")
+			projected = true
+			return nil
+		}),
+	)
+
+	result, err := worker.RunBatch(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, BatchResult{Claimed: 1, Succeeded: 1}, result)
+	assert.True(t, projected)
+	assert.Empty(t, queue.retries)
+}
+
+func TestWorkerClassifiesParseFailureAndRetriesAfterCleanup(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	parseFailure := errors.New("malformed provider source")
+	var materializedRoot string
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			root, err := os.MkdirTemp(t.TempDir(), "worker-materialized-")
+			if err != nil {
+				return nil, err
+			}
+			materializedRoot = root
+			return &Materialization{root: root, entries: map[string]string{}}, nil
+		}),
+		sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+			return ParsedManifest{}, parseFailure
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after parse failure")
+		}),
+	)
+	started := time.Now()
+
+	result, err := worker.RunBatch(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse:internal",
+		"the returned error carries the allowlisted diagnostic instead of raw provider text")
+	assert.NotContains(t, err.Error(), parseFailure.Error())
+	assert.Equal(t, BatchResult{Claimed: 1, Retried: 1}, result)
+	require.Len(t, queue.retries, 1)
+	assert.Equal(t, "parse", queue.retries[0].class)
+	assert.Equal(t, "parse:internal", queue.retries[0].message)
+	assert.WithinDuration(t, started.Add(time.Minute), queue.retries[0].availableAt, time.Second)
+	_, statErr := os.Stat(materializedRoot)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestWorkerMovesTerminalAttemptToDurableFailure(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	lease.Attempt = 3
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	parseFailure := errors.New("unsupported provider format")
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return &Materialization{root: t.TempDir(), entries: map[string]string{}}, nil
+		}),
+		sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+			return ParsedManifest{}, parseFailure
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after parse failure")
+		}),
+	)
+
+	result, err := worker.RunBatch(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse:internal")
+	assert.NotContains(t, err.Error(), parseFailure.Error())
+	assert.Equal(t, BatchResult{Claimed: 1, Failed: 1}, result)
+	assert.Empty(t, queue.retries)
+	require.Len(t, queue.failures, 1)
+	assert.Equal(t, lease, queue.failures[0].lease)
+	assert.Equal(t, "parse", queue.failures[0].class)
+	assert.Equal(t, "parse:internal", queue.failures[0].message)
+}
+
+func TestWorkerCancelsWorkAndDoesNotRetryAfterLeaseLoss(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{
+		leases:       []JobLease{lease},
+		heartbeatErr: ErrLeaseLost,
+	}
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return &Materialization{root: t.TempDir(), entries: map[string]string{}}, nil
+		}),
+		sourceParserFunc(func(ctx context.Context, _ rawsync.CanonicalManifest, _ *Materialization) (ParsedManifest, error) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+			}
+			return ParsedManifest{}, ctx.Err()
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after lease loss")
+		}),
+	)
+	worker.HeartbeatInterval = time.Millisecond
+
+	result, err := worker.RunBatch(t.Context())
+	require.ErrorIs(t, err, ErrLeaseLost)
+	assert.Equal(t, BatchResult{Claimed: 1, LeaseLost: 1}, result)
+	assert.Empty(t, queue.retries)
+	assert.NotZero(t, queue.heartbeats.Load())
+}
+
+func TestWorkerClassifiesHeartbeatTransportCancellation(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	heartbeatFailure := errors.New("heartbeat transport unavailable")
+	heartbeatObserved := make(chan struct{})
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	queue.heartbeat = func(context.Context, JobLease, time.Duration) error {
+		close(heartbeatObserved)
+		return heartbeatFailure
+	}
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return &Materialization{root: t.TempDir(), entries: map[string]string{}}, nil
+		}),
+		sourceParserFunc(func(ctx context.Context, _ rawsync.CanonicalManifest, _ *Materialization) (ParsedManifest, error) {
+			select {
+			case <-heartbeatObserved:
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+			}
+			select {
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+			}
+			return ParsedManifest{}, ctx.Err()
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after heartbeat failure")
+		}),
+	)
+	worker.HeartbeatInterval = time.Millisecond
+
+	result, err := worker.RunBatch(t.Context())
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, context.Canceled)
+	assert.NotContains(t, err.Error(), heartbeatFailure.Error())
+	assert.Contains(t, err.Error(), "heartbeat:internal")
+	assert.Equal(t, BatchResult{Claimed: 1, Retried: 1}, result)
+	require.Len(t, queue.retries, 1)
+	assert.Equal(t, "heartbeat", queue.retries[0].class)
+	assert.Equal(t, "heartbeat:internal", queue.retries[0].message)
+}
+
+func TestWorkerTreatsPostProjectionLeaseReleaseAsSuccess(t *testing.T) {
+	t.Parallel()
+	testWorkerTreatsPostProjectionHeartbeatFailureAsSuccess(t, ErrLeaseLost)
+}
+
+func TestWorkerTreatsPostProjectionHeartbeatTransportFailureAsSuccess(t *testing.T) {
+	t.Parallel()
+	testWorkerTreatsPostProjectionHeartbeatFailureAsSuccess(
+		t, errors.New("heartbeat transport unavailable"),
+	)
+}
+
+func testWorkerTreatsPostProjectionHeartbeatFailureAsSuccess(
+	t *testing.T,
+	heartbeatErr error,
+) {
+	t.Helper()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestTombstone)
+	lease.ManifestID = manifest.ManifestID
+	projectionCommitted := make(chan struct{})
+	heartbeatFinished := make(chan struct{})
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	queue.heartbeat = func(context.Context, JobLease, time.Duration) error {
+		select {
+		case <-projectionCommitted:
+		case <-time.After(5 * time.Second):
+		}
+		close(heartbeatFinished)
+		return heartbeatErr
+	}
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return nil, errors.New("unexpected tombstone materialization")
+		}),
+		sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+			return ParsedManifest{Tombstone: true}, nil
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			close(projectionCommitted)
+			select {
+			case <-heartbeatFinished:
+			case <-time.After(5 * time.Second):
+			}
+			return nil
+		}),
+	)
+	worker.HeartbeatInterval = time.Millisecond
+
+	result, err := worker.RunBatch(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, BatchResult{Claimed: 1, Succeeded: 1}, result)
+	assert.NotZero(t, queue.heartbeats.Load(),
+		"the heartbeat must have run and failed before the outcome was classified")
+	assert.Empty(t, queue.retries)
+	assert.Empty(t, queue.failures)
+}
+
+func TestWorkerProjectsTombstoneWithoutMaterialization(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestTombstone)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return nil, errors.New("unexpected tombstone materialization")
+		}),
+		sourceParserFunc(func(
+			_ context.Context,
+			_ rawsync.CanonicalManifest,
+			materialized *Materialization,
+		) (ParsedManifest, error) {
+			assert.Nil(t, materialized)
+			return ParsedManifest{Tombstone: true}, nil
+		}),
+		projectionSinkFunc(func(
+			_ context.Context,
+			_ JobLease,
+			_ rawsync.CanonicalManifest,
+			parsed ParsedManifest,
+		) error {
+			assert.True(t, parsed.Tombstone)
+			return nil
+		}),
+	)
+
+	result, err := worker.RunBatch(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, BatchResult{Claimed: 1, Succeeded: 1}, result)
+}
+
+func TestNewWorkerBoundsClaimBatchSize(t *testing.T) {
+	t.Parallel()
+	newConfig := func(batchSize int) WorkerConfig {
+		return WorkerConfig{
+			Queue: &workerQueueFixture{},
+			Manifests: manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+				panic("must not run")
+			}),
+			Materializer: sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+				panic("must not run")
+			}),
+			Parser: sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+				panic("must not run")
+			}),
+			Projection: projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+				panic("must not run")
+			}),
+			Owner:             "worker-a",
+			BatchSize:         batchSize,
+			LeaseDuration:     time.Minute,
+			HeartbeatInterval: 10 * time.Second,
+			RetryBase:         time.Minute,
+			RetryMax:          time.Hour,
+			MaxAttempts:       3,
+			AttemptTimeout:    5 * time.Minute,
+		}
+	}
+
+	worker, err := NewWorker(newConfig(MaxClaimBatchSize))
+	require.NoError(t, err)
+	assert.Equal(t, MaxClaimBatchSize, worker.BatchSize)
+
+	_, err = NewWorker(newConfig(MaxClaimBatchSize + 1))
+	assert.ErrorIs(t, err, rawsync.ErrInvalid,
+		"the worker must reject a claim batch the shared queue contract refuses")
+}
+
+func TestNewWorkerSharesQueueOwnerContract(t *testing.T) {
+	t.Parallel()
+	newConfig := func(owner string) WorkerConfig {
+		return WorkerConfig{
+			Queue: &workerQueueFixture{},
+			Manifests: manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+				panic("must not run")
+			}),
+			Materializer: sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+				panic("must not run")
+			}),
+			Parser: sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+				panic("must not run")
+			}),
+			Projection: projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+				panic("must not run")
+			}),
+			Owner:             owner,
+			BatchSize:         1,
+			LeaseDuration:     time.Minute,
+			HeartbeatInterval: 10 * time.Second,
+			RetryBase:         time.Minute,
+			RetryMax:          time.Hour,
+			MaxAttempts:       3,
+			AttemptTimeout:    5 * time.Minute,
+		}
+	}
+
+	_, err := NewWorker(newConfig(strings.Repeat("a", MaxLeaseOwnerBytes)))
+	require.NoError(t, err)
+
+	_, err = NewWorker(newConfig(strings.Repeat("a", MaxLeaseOwnerBytes+1)))
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+
+	_, err = NewWorker(newConfig(string([]byte{0xff})))
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+}
+
+func TestNewWorkerRequiresValidatedAttemptTimeout(t *testing.T) {
+	t.Parallel()
+	config := WorkerConfig{
+		Queue: &workerQueueFixture{},
+		Manifests: manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			panic("must not run")
+		}),
+		Materializer: sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			panic("must not run")
+		}),
+		Parser: sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+			panic("must not run")
+		}),
+		Projection: projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			panic("must not run")
+		}),
+		Owner:             "worker-a",
+		BatchSize:         2,
+		LeaseDuration:     time.Minute,
+		HeartbeatInterval: 10 * time.Second,
+		RetryBase:         time.Minute,
+		RetryMax:          time.Hour,
+		MaxAttempts:       3,
+	}
+
+	_, err := NewWorker(config)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid,
+		"a worker without a per-attempt timeout must be rejected")
+
+	config.AttemptTimeout = -time.Second
+	_, err = NewWorker(config)
+	assert.ErrorIs(t, err, rawsync.ErrInvalid)
+
+	config.AttemptTimeout = 90 * time.Second
+	worker, err := NewWorker(config)
+	require.NoError(t, err)
+	assert.Equal(t, 90*time.Second, worker.AttemptTimeout)
+}
+
+func TestWorkerAttemptTimeoutStopsRunawayPipelineAndRecordsDeadline(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	parseStopped := make(chan struct{})
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return &Materialization{root: t.TempDir(), entries: map[string]string{}}, nil
+		}),
+		sourceParserFunc(func(ctx context.Context, _ rawsync.CanonicalManifest, _ *Materialization) (ParsedManifest, error) {
+			defer close(parseStopped)
+			select {
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+			}
+			return ParsedManifest{}, ctx.Err()
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after attempt deadline")
+		}),
+	)
+	worker.AttemptTimeout = 50 * time.Millisecond
+	worker.HeartbeatInterval = 10 * time.Millisecond
+	started := time.Now()
+
+	result, err := worker.RunBatch(t.Context())
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(started), 5*time.Second,
+		"a cooperative pipeline must observe the per-attempt deadline, not outlive the lease")
+	select {
+	case <-parseStopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the parse pipeline never observed the attempt deadline")
+	}
+	assert.Equal(t, BatchResult{Claimed: 1, Retried: 1}, result)
+	require.Len(t, queue.retries, 1)
+	assert.Equal(t, "parse", queue.retries[0].class)
+	assert.Contains(t, queue.retries[0].message, "deadline")
+	assert.WithinDuration(t, started.Add(time.Minute), queue.retries[0].availableAt, 2*time.Second)
+}
+
+func TestWorkerStopsRenewingLeaseWhenStageBlocksPastAttemptDeadline(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseBlocked := func() { releaseOnce.Do(func() { close(release) }) }
+	// A failing assertion must not strand the batch goroutine on the
+	// non-cooperative stage's release channel.
+	t.Cleanup(releaseBlocked)
+	heartbeatStarted := make(chan struct{})
+	deadlineObserved := make(chan struct{})
+	var heartbeatOnce sync.Once
+	queue.heartbeat = func(context.Context, JobLease, time.Duration) error {
+		heartbeatOnce.Do(func() { close(heartbeatStarted) })
+		return nil
+	}
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return &Materialization{root: t.TempDir(), entries: map[string]string{}}, nil
+		}),
+		sourceParserFunc(func(ctx context.Context, _ rawsync.CanonicalManifest, _ *Materialization) (ParsedManifest, error) {
+			// A non-cooperative stage: it never observes its context, so
+			// neither the attempt deadline nor cancellation can end it and
+			// only the test's release channel unblocks it.
+			go func() {
+				select {
+				case <-ctx.Done():
+					close(deadlineObserved)
+				case <-time.After(5 * time.Second):
+				}
+			}()
+			select {
+			case <-release:
+			case <-time.After(5 * time.Second):
+			}
+			return ParsedManifest{}, nil
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return nil
+		}),
+	)
+	worker.AttemptTimeout = 250 * time.Millisecond
+	worker.HeartbeatInterval = 10 * time.Millisecond
+	batchDone := make(chan BatchResult, 1)
+	batchErr := make(chan error, 1)
+	go func() {
+		result, err := worker.RunBatch(t.Context())
+		batchDone <- result
+		batchErr <- err
+	}()
+
+	select {
+	case <-heartbeatStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the lease never began renewing before the attempt deadline")
+	}
+	select {
+	case <-deadlineObserved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the blocked stage never observed its attempt deadline")
+	}
+	frozen := queue.heartbeats.Load()
+	time.Sleep(8 * worker.HeartbeatInterval)
+	still := queue.heartbeats.Load()
+	require.Equal(t, frozen, still,
+		"the attempt deadline must stop lease renewal; a stage that blocks past it cannot keep the lease alive")
+
+	releaseBlocked()
+	select {
+	case result := <-batchDone:
+		require.NoError(t, <-batchErr,
+			"a stage that finishes after the deadline keeps its fenced outcome")
+		assert.Equal(t, BatchResult{Claimed: 1, Succeeded: 1}, result)
+	case <-time.After(5 * time.Second):
+		t.Fatal("releasing the blocked stage must let the batch finish")
+	}
+	assert.Equal(t, still, queue.heartbeats.Load(),
+		"no renewal may happen after the deadline fires or after the stage finally returns")
+}
+
+func TestWorkerJoinsCleanupFailureWithParseFailure(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	parseFailure := errors.New("malformed provider source")
+	cleanupFailure := errors.New("scratch cleanup failed")
+	materialized := &Materialization{
+		root:    t.TempDir(),
+		entries: map[string]string{},
+		removeTree: func(string) error {
+			return cleanupFailure
+		},
+	}
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return materialized, nil
+		}),
+		sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+			return ParsedManifest{}, parseFailure
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after parse failure")
+		}),
+	)
+
+	result, err := worker.RunBatch(t.Context())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cleanup_failed",
+		"a cleanup failure must not be swallowed when parsing already failed")
+	assert.NotContains(t, err.Error(), materialized.Root(),
+		"the returned error must not expose the raw tree path")
+	assert.Equal(t, BatchResult{Claimed: 1, Retried: 1}, result)
+	require.Len(t, queue.retries, 1)
+	assert.Equal(t, "parse", queue.retries[0].class,
+		"the parse failure stays the durable stage")
+}
+
+func TestWorkerReportsPreProjectionCleanupFailureOnceWhenRetryFailsToo(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	cleanupFailure := errors.New("scratch cleanup failed")
+	var attempts atomic.Int64
+	materialized := &Materialization{
+		root:    t.TempDir(),
+		entries: map[string]string{},
+		removeTree: func(string) error {
+			attempts.Add(1)
+			return cleanupFailure
+		},
+	}
+	worker := newWorkerForTest(t, &workerQueueFixture{},
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return materialized, nil
+		}),
+		sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+			return ParsedManifest{Outcome: parser.ParseOutcome{ResultSetComplete: true}}, nil
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection before materialization cleanup")
+		}),
+	)
+
+	stage, pipelineErr := worker.runPipeline(t.Context(), lease)
+
+	require.Error(t, pipelineErr)
+	assert.Equal(t, "materialize", stage,
+		"the pre-projection cleanup failure owns the durable stage")
+	assert.ErrorIs(t, pipelineErr, errMaterializationCleanup)
+	assert.Equal(t, 1, strings.Count(pipelineErr.Error(), cleanupFailure.Error()),
+		"a failed cleanup retry must not re-report the already reported cleanup failure")
+	assert.Equal(t, int64(2), attempts.Load(),
+		"the deferred cleanup must retry the failed removal exactly once")
+}
+
+func TestWorkerRetriesJobWhenPreProjectionCleanupRetrySucceeds(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	cleanupFailure := errors.New("scratch cleanup failed")
+	var attempts atomic.Int64
+	materialized := &Materialization{
+		root:    t.TempDir(),
+		entries: map[string]string{},
+		removeTree: func(path string) error {
+			if attempts.Add(1) == 1 {
+				return cleanupFailure
+			}
+			return os.RemoveAll(path)
+		},
+	}
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return materialized, nil
+		}),
+		sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+			return ParsedManifest{Outcome: parser.ParseOutcome{ResultSetComplete: true}}, nil
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after materialization cleanup failure")
+		}),
+	)
+
+	result, err := worker.RunBatch(t.Context())
+
+	require.Error(t, err,
+		"a first cleanup failure must still fail the attempt even when the retry succeeds")
+	assert.Contains(t, err.Error(), "materialize:internal+cleanup_failed")
+	assert.Equal(t, 1, strings.Count(err.Error(), "(materialization cleanup failed)"))
+	assert.Equal(t, BatchResult{Claimed: 1, Retried: 1}, result)
+	require.Len(t, queue.retries, 1)
+	assert.Equal(t, "materialize", queue.retries[0].class)
+	assert.Equal(t, "materialize:internal+cleanup_failed", queue.retries[0].message,
+		"the durable diagnostic carries the cleanup failure exactly once")
+	_, statErr := os.Stat(materialized.Root())
+	assert.ErrorIs(t, statErr, os.ErrNotExist,
+		"the successful retry must still remove the private tree")
+}
+
+func TestWorkerSanitizesPathAndContentBearingErrors(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	clientPath := "/srv/agent/projects/demo-project/session.jsonl"
+	rawContent := "<raw transcript payload>"
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return &Materialization{root: t.TempDir(), entries: map[string]string{}}, nil
+		}),
+		sourceParserFunc(func(context.Context, rawsync.CanonicalManifest, *Materialization) (ParsedManifest, error) {
+			return ParsedManifest{}, fmt.Errorf("reading %s: %s", clientPath, rawContent)
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after parse failure")
+		}),
+	)
+
+	result, err := worker.RunBatch(t.Context())
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), clientPath,
+		"returned errors must not leak client source paths")
+	assert.NotContains(t, err.Error(), rawContent,
+		"returned errors must not leak raw provider content")
+	assert.Equal(t, BatchResult{Claimed: 1, Retried: 1}, result)
+	require.Len(t, queue.retries, 1)
+	assert.Equal(t, "parse", queue.retries[0].class)
+	assert.NotContains(t, queue.retries[0].message, clientPath,
+		"durable queue arguments must not carry client source paths")
+	assert.NotContains(t, queue.retries[0].message, rawContent,
+		"durable queue arguments must not carry raw provider content")
+	assert.Equal(t, "parse:internal", queue.retries[0].message,
+		"only allowlisted stage and error codes may be persisted")
+}
+
+func TestWorkerKeepsPipelineCauseWhenHeartbeatLosesLeaseToo(t *testing.T) {
+	t.Parallel()
+	run := func(t *testing.T, heartbeatErr error) {
+		t.Helper()
+		lease := workerTestLease()
+		manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+		lease.ManifestID = manifest.ManifestID
+		queue := &workerQueueFixture{leases: []JobLease{lease}, heartbeatErr: heartbeatErr}
+		parseFailure := errors.New("malformed provider source")
+		heartbeatObserved := make(chan struct{})
+		var heartbeatOnce sync.Once
+		queue.heartbeat = func(context.Context, JobLease, time.Duration) error {
+			heartbeatOnce.Do(func() { close(heartbeatObserved) })
+			return heartbeatErr
+		}
+		worker := newWorkerForTest(t, queue,
+			manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+				return manifest, nil
+			}),
+			sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+				return &Materialization{root: t.TempDir(), entries: map[string]string{}}, nil
+			}),
+			sourceParserFunc(func(ctx context.Context, _ rawsync.CanonicalManifest, _ *Materialization) (ParsedManifest, error) {
+				// Return the real pipeline failure only after a heartbeat beat
+				// has failed, so both failures deterministically coexist.
+				select {
+				case <-heartbeatObserved:
+				case <-ctx.Done():
+				case <-time.After(5 * time.Second):
+				}
+				return ParsedManifest{}, parseFailure
+			}),
+			projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+				return errors.New("unexpected projection after parse failure")
+			}),
+		)
+		worker.HeartbeatInterval = time.Millisecond
+
+		result, err := worker.RunBatch(t.Context())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse",
+			"the real pipeline failure must remain the durable stage and cause")
+		assert.Empty(t, queue.failures)
+		if errors.Is(heartbeatErr, ErrLeaseLost) {
+			assert.ErrorIs(t, err, ErrLeaseLost,
+				"lease loss must still dominate the outcome classification")
+			assert.Equal(t, BatchResult{Claimed: 1, LeaseLost: 1}, result)
+			assert.Empty(t, queue.retries)
+			return
+		}
+		assert.Equal(t, BatchResult{Claimed: 1, Retried: 1}, result,
+			"a heartbeat transport failure must not mask the parse failure")
+		require.Len(t, queue.retries, 1)
+		assert.Equal(t, "parse", queue.retries[0].class)
+		assert.Equal(t, "parse:internal", queue.retries[0].message)
+	}
+
+	t.Run("lease lost", func(t *testing.T) {
+		t.Parallel()
+		run(t, ErrLeaseLost)
+	})
+	t.Run("transport failure", func(t *testing.T) {
+		t.Parallel()
+		run(t, errors.New("heartbeat transport unavailable"))
+	})
+}
+
+func TestWorkerPreservesCleanupFailureWhenHeartbeatCancelsCooperativeParse(t *testing.T) {
+	t.Parallel()
+	lease := workerTestLease()
+	manifest := workerTestManifest(t, rawsync.ManifestSnapshot)
+	lease.ManifestID = manifest.ManifestID
+	heartbeatFailure := errors.New("heartbeat transport unavailable")
+	heartbeatObserved := make(chan struct{})
+	var heartbeatOnce sync.Once
+	queue := &workerQueueFixture{leases: []JobLease{lease}}
+	queue.heartbeat = func(context.Context, JobLease, time.Duration) error {
+		heartbeatOnce.Do(func() { close(heartbeatObserved) })
+		return heartbeatFailure
+	}
+	cleanupFailure := errors.New("scratch cleanup failed")
+	materialized := &Materialization{
+		root:    t.TempDir(),
+		entries: map[string]string{},
+		removeTree: func(string) error {
+			return cleanupFailure
+		},
+	}
+	worker := newWorkerForTest(t, queue,
+		manifestSourceFunc(func(context.Context, JobLease) (rawsync.CanonicalManifest, error) {
+			return manifest, nil
+		}),
+		sourceMaterializerFunc(func(context.Context, rawsync.CanonicalManifest) (*Materialization, error) {
+			return materialized, nil
+		}),
+		sourceParserFunc(func(ctx context.Context, _ rawsync.CanonicalManifest, _ *Materialization) (ParsedManifest, error) {
+			// A cooperative parser: it observes the heartbeat-induced
+			// cancellation and reports the generic context error, while the
+			// deferred materialization cleanup fails alongside it.
+			select {
+			case <-heartbeatObserved:
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+			}
+			select {
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+			}
+			return ParsedManifest{}, ctx.Err()
+		}),
+		projectionSinkFunc(func(context.Context, JobLease, rawsync.CanonicalManifest, ParsedManifest) error {
+			return errors.New("unexpected projection after heartbeat failure")
+		}),
+	)
+	worker.HeartbeatInterval = time.Millisecond
+
+	result, err := worker.RunBatch(t.Context())
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, context.Canceled,
+		"the heartbeat-induced cancellation must not become the classified outcome")
+	assert.Contains(t, err.Error(), "parse:internal+cleanup_failed",
+		"the durable diagnostic keeps the pipeline stage and the cleanup failure")
+	assert.Contains(t, err.Error(), "(materialization cleanup failed)")
+	assert.NotContains(t, err.Error(), heartbeatFailure.Error(),
+		"heartbeat transport detail must not leak")
+	assert.NotContains(t, err.Error(), cleanupFailure.Error(),
+		"raw cleanup detail must not leak")
+	assert.NotContains(t, err.Error(), materialized.Root(),
+		"the raw tree path must not leak")
+	assert.Equal(t, BatchResult{Claimed: 1, Retried: 1}, result)
+	require.Len(t, queue.retries, 1)
+	assert.Equal(t, "parse", queue.retries[0].class,
+		"the parse stage stays the durable stage instead of degrading to heartbeat")
+	assert.Equal(t, "parse:internal+cleanup_failed", queue.retries[0].message)
+	assert.NotContains(t, queue.retries[0].message, heartbeatFailure.Error())
+	assert.NotContains(t, queue.retries[0].message, cleanupFailure.Error())
+	assert.Empty(t, queue.failures)
+}
+
+func TestStripCanceledLeavesPreservesSubstantiveCauses(t *testing.T) {
+	t.Parallel()
+	substantive := errors.New("malformed provider source")
+	wrappedCleanup := fmt.Errorf("%w: cleaning raw materialization: %w",
+		errMaterializationCleanup, errors.New("scratch removal failed"),
+	)
+
+	tests := []struct {
+		name       string
+		err        error
+		wantMsg    string
+		wantInside error
+	}{
+		{name: "nil stays nil", err: nil},
+		{name: "bare cancellation is removed", err: context.Canceled},
+		{
+			name: "cancellation-only unwrap chain collapses",
+			err:  fmt.Errorf("loading manifest: %w", context.Canceled),
+		},
+		{
+			name:       "join keeps substantive branches",
+			err:        errors.Join(context.Canceled, substantive),
+			wantMsg:    substantive.Error(),
+			wantInside: substantive,
+		},
+		{
+			name:       "join keeps wrapped cleanup sentinels",
+			err:        errors.Join(context.Canceled, wrappedCleanup),
+			wantMsg:    wrappedCleanup.Error(),
+			wantInside: errMaterializationCleanup,
+		},
+		{
+			name: "ordinary wrapper around join keeps substantive branch",
+			err: fmt.Errorf("parsing source: %w",
+				errors.Join(context.Canceled, substantive)),
+			wantMsg:    substantive.Error(),
+			wantInside: substantive,
+		},
+		{
+			name: "join of only cancellation collapses",
+			err:  errors.Join(context.Canceled, fmt.Errorf("parse: %w", context.Canceled)),
+		},
+		{
+			name:       "untouched join keeps its branches and formatting",
+			err:        errors.Join(substantive, wrappedCleanup),
+			wantMsg:    errors.Join(substantive, wrappedCleanup).Error(),
+			wantInside: substantive,
+		},
+		{
+			name:       "substantive error is unchanged",
+			err:        substantive,
+			wantMsg:    substantive.Error(),
+			wantInside: substantive,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stripped, removed := stripCanceledLeaves(tc.err)
+			if tc.wantInside == nil {
+				assert.Nil(t, stripped)
+				if tc.err != nil {
+					assert.True(t, removed)
+				} else {
+					assert.False(t, removed)
+				}
+				return
+			}
+			require.NotNil(t, stripped)
+			assert.Equal(t, tc.wantMsg, stripped.Error())
+			assert.ErrorIs(t, stripped, tc.wantInside)
+		})
+	}
+}
+
+func newWorkerForTest(
+	t *testing.T,
+	queue JobQueue,
+	manifests ManifestSource,
+	materializer SourceMaterializer,
+	parser SourceParser,
+	projection ProjectionSink,
+) *Worker {
+	t.Helper()
+	worker, err := NewWorker(WorkerConfig{
+		Queue:             queue,
+		Manifests:         manifests,
+		Materializer:      materializer,
+		Parser:            parser,
+		Projection:        projection,
+		Owner:             "worker-a",
+		BatchSize:         2,
+		LeaseDuration:     time.Minute,
+		HeartbeatInterval: 10 * time.Second,
+		RetryBase:         time.Minute,
+		RetryMax:          time.Hour,
+		MaxAttempts:       3,
+		AttemptTimeout:    5 * time.Minute,
+	})
+	require.NoError(t, err)
+	return worker
+}
+
+type workerQueueFixture struct {
+	leases       []JobLease
+	heartbeatErr error
+	heartbeat    func(context.Context, JobLease, time.Duration) error
+	heartbeats   atomic.Int64
+	retries      []workerRetry
+	failures     []workerFailure
+}
+
+type workerRetry struct {
+	lease       JobLease
+	availableAt time.Time
+	class       string
+	message     string
+}
+
+type workerFailure struct {
+	lease   JobLease
+	class   string
+	message string
+}
+
+func (q *workerQueueFixture) ClaimRawParseJobs(
+	context.Context,
+	string,
+	int,
+	time.Duration,
+) ([]JobLease, error) {
+	return append([]JobLease(nil), q.leases...), nil
+}
+
+func (q *workerQueueFixture) HeartbeatRawParseJob(
+	ctx context.Context,
+	lease JobLease,
+	duration time.Duration,
+) error {
+	q.heartbeats.Add(1)
+	if q.heartbeat != nil {
+		return q.heartbeat(ctx, lease, duration)
+	}
+	return q.heartbeatErr
+}
+
+func (q *workerQueueFixture) RetryRawParseJob(
+	_ context.Context,
+	lease JobLease,
+	availableAt time.Time,
+	class string,
+	message string,
+) error {
+	q.retries = append(q.retries, workerRetry{
+		lease: lease, availableAt: availableAt, class: class, message: message,
+	})
+	return nil
+}
+
+func (q *workerQueueFixture) FailRawParseJob(
+	_ context.Context,
+	lease JobLease,
+	class string,
+	message string,
+) error {
+	q.failures = append(q.failures, workerFailure{
+		lease: lease, class: class, message: message,
+	})
+	return nil
+}
+
+type manifestSourceFunc func(context.Context, JobLease) (rawsync.CanonicalManifest, error)
+
+func (f manifestSourceFunc) Load(
+	ctx context.Context,
+	lease JobLease,
+) (rawsync.CanonicalManifest, error) {
+	return f(ctx, lease)
+}
+
+type sourceMaterializerFunc func(
+	context.Context,
+	rawsync.CanonicalManifest,
+) (*Materialization, error)
+
+func (f sourceMaterializerFunc) Materialize(
+	ctx context.Context,
+	manifest rawsync.CanonicalManifest,
+) (*Materialization, error) {
+	return f(ctx, manifest)
+}
+
+type sourceParserFunc func(
+	context.Context,
+	rawsync.CanonicalManifest,
+	*Materialization,
+) (ParsedManifest, error)
+
+func (f sourceParserFunc) Parse(
+	ctx context.Context,
+	manifest rawsync.CanonicalManifest,
+	materialized *Materialization,
+) (ParsedManifest, error) {
+	return f(ctx, manifest, materialized)
+}
+
+type projectionSinkFunc func(
+	context.Context,
+	JobLease,
+	rawsync.CanonicalManifest,
+	ParsedManifest,
+) error
+
+func (f projectionSinkFunc) Project(
+	ctx context.Context,
+	lease JobLease,
+	manifest rawsync.CanonicalManifest,
+	parsed ParsedManifest,
+) error {
+	return f(ctx, lease, manifest, parsed)
+}
+
+func workerTestLease() JobLease {
+	identity, err := rawsync.NewAuthIdentity("tenant-a", "device-a")
+	if err != nil {
+		panic(err)
+	}
+	return JobLease{
+		ID: 1, Identity: identity,
+		ManifestID:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ProcessingVersion: "parser-data-17",
+		Attempt:           1,
+		Owner:             "worker-a",
+		ExpiresAt:         time.Now().Add(time.Minute),
+	}
+}
+
+func workerTestManifest(t *testing.T, kind rawsync.ManifestKind) rawsync.CanonicalManifest {
+	t.Helper()
+	identity, err := rawsync.NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+	manifest := rawsync.Manifest{
+		SchemaVersion:    rawsync.ManifestSchemaVersion,
+		Provider:         parser.AgentClaude,
+		ConfiguredRootID: "root-a",
+		SourceKey:        "/canonical/claude/session.jsonl",
+		CaptureID:        "capture-a",
+		CapturedAt:       time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		Kind:             kind,
+	}
+	if kind == rawsync.ManifestSnapshot {
+		data := []byte("session")
+		object := objectRefForBytes(t, data)
+		manifest.Entries = []rawsync.Entry{{
+			Path: "session.jsonl", Type: "file", Length: int64(len(data)),
+			Objects: []rawsync.ObjectRef{object},
+		}}
+	}
+	canonical, err := rawsync.ValidateAndCanonicalize(
+		identity, manifest, rawsync.DefaultManifestLimits(),
+	)
+	require.NoError(t, err)
+	return canonical
+}

--- a/internal/rawpath/path.go
+++ b/internal/rawpath/path.go
@@ -14,6 +14,20 @@ const DefaultMaxBytes = 4096
 
 var ErrInvalid = errors.New("invalid raw logical path")
 
+// PlatformKey maps a validated logical path to its cross-platform
+// filesystem-equivalence key: two paths with the same key denote the same
+// location wherever a manifest may materialize. Windows (NTFS, ReFS) and
+// macOS (default case-insensitive APFS volumes) compare file names
+// case-insensitively using simple Unicode case mapping, so the key lowercases
+// every rune. The mapping deliberately stops at case: those filesystems do
+// not normalize Unicode, so NFC and NFD spellings stay distinct keys, and
+// NTFS short-name aliases depend on per-volume state that cannot be
+// predicted here. The result depends only on the input, never on locale,
+// time, or the host running the check.
+func PlatformKey(value string) string {
+	return strings.ToLower(value)
+}
+
 // Validate enforces the cross-platform relative-path contract used by capture
 // plans and raw manifests.
 func Validate(value string, maxBytes int) error {

--- a/internal/rawsync/manifest.go
+++ b/internal/rawsync/manifest.go
@@ -75,11 +75,14 @@ const (
 )
 
 // Entry describes one logical source file and its ordered object slices.
+// ModTimeNS is the captured source modification time in Unix nanoseconds;
+// zero means the generation predates mod-time capture.
 type Entry struct {
-	Path    string      `json:"path"`
-	Type    string      `json:"type"`
-	Length  int64       `json:"length"`
-	Objects []ObjectRef `json:"objects"`
+	Path      string      `json:"path"`
+	Type      string      `json:"type"`
+	Length    int64       `json:"length"`
+	ModTimeNS int64       `json:"mod_time_ns,omitzero"`
+	Objects   []ObjectRef `json:"objects"`
 }
 
 // Manifest declares one complete logical provider-source generation.
@@ -136,6 +139,50 @@ type canonicalEnvelope struct {
 	CapturedAt            time.Time        `json:"captured_at"`
 	Kind                  ManifestKind     `json:"kind"`
 	Entries               []Entry          `json:"entries,omitempty"`
+}
+
+// ParseCanonicalManifest reconstructs a canonical manifest only when the
+// stored envelope exactly matches its authenticated identity and digest.
+func ParseCanonicalManifest(
+	identity AuthIdentity,
+	manifestID string,
+	canonicalJSON []byte,
+	limits ManifestLimits,
+) (CanonicalManifest, error) {
+	if err := validateManifestLimits(limits); err != nil {
+		return CanonicalManifest{}, err
+	}
+	if !isCanonicalSHA256(manifestID) {
+		return CanonicalManifest{}, fmt.Errorf("%w: manifest digest must be lowercase SHA-256", ErrInvalid)
+	}
+	if len(canonicalJSON) == 0 || len(canonicalJSON) > limits.MaxCanonicalBytes {
+		return CanonicalManifest{}, fmt.Errorf("%w: canonical manifest size is invalid", ErrInvalid)
+	}
+	var envelope canonicalEnvelope
+	if err := json.Unmarshal(canonicalJSON, &envelope); err != nil {
+		return CanonicalManifest{}, fmt.Errorf("%w: decoding canonical raw manifest: %v", ErrInvalid, err)
+	}
+	if envelope.TenantID != identity.TenantID || envelope.DeviceID != identity.DeviceID {
+		return CanonicalManifest{}, fmt.Errorf("%w: canonical manifest identity does not match authentication", ErrInvalid)
+	}
+	validated, err := ValidateAndCanonicalize(identity, Manifest{
+		SchemaVersion:         envelope.SchemaVersion,
+		Provider:              envelope.Provider,
+		ConfiguredRootID:      envelope.ConfiguredRootID,
+		SourceKey:             envelope.SourceKey,
+		ExpectedParentReceipt: envelope.ExpectedParentReceipt,
+		CaptureID:             envelope.CaptureID,
+		CapturedAt:            envelope.CapturedAt,
+		Kind:                  envelope.Kind,
+		Entries:               envelope.Entries,
+	}, limits)
+	if err != nil {
+		return CanonicalManifest{}, err
+	}
+	if validated.ManifestID != manifestID || !bytes.Equal(validated.CanonicalJSON, canonicalJSON) {
+		return CanonicalManifest{}, fmt.Errorf("%w: canonical manifest envelope is inconsistent", ErrInvalid)
+	}
+	return validated, nil
 }
 
 // ValidateAndCanonicalize binds authentication to validated canonical bytes.
@@ -253,7 +300,7 @@ func manifestsEqual(a, b Manifest) bool {
 
 func entriesEqual(a, b Entry) bool {
 	return a.Path == b.Path && a.Type == b.Type && a.Length == b.Length &&
-		slices.Equal(a.Objects, b.Objects)
+		a.ModTimeNS == b.ModTimeNS && slices.Equal(a.Objects, b.Objects)
 }
 
 func validateManifestLimits(limits ManifestLimits) error {
@@ -348,16 +395,16 @@ func validateEntries(manifest Manifest, limits ManifestLimits) ([]ObjectRef, err
 		return nil, fmt.Errorf("%w: manifest entry limit exceeded", ErrInvalid)
 	}
 	byDigest := make(map[string]ObjectRef)
+	filePaths := make(map[string]string, len(manifest.Entries))
+	directoryPaths := make(map[string]string)
 	objectCount := 0
-	previousPath := ""
 	for _, entry := range manifest.Entries {
 		if err := validateEntryPath(entry.Path, limits.MaxPathBytes); err != nil {
 			return nil, err
 		}
-		if entry.Path == previousPath {
-			return nil, fmt.Errorf("%w: duplicate manifest path %q", ErrInvalid, entry.Path)
+		if err := claimEntryPath(entry.Path, filePaths, directoryPaths); err != nil {
+			return nil, err
 		}
-		previousPath = entry.Path
 		if entry.Type != "file" {
 			return nil, fmt.Errorf("%w: unsupported entry type %q", ErrInvalid, entry.Type)
 		}
@@ -408,6 +455,46 @@ func validateEntryPath(value string, maxBytes int) error {
 		return fmt.Errorf("%w: entry path: %v", ErrInvalid, err)
 	}
 	return nil
+}
+
+// claimEntryPath records one file entry path and rejects the collisions that
+// make a manifest unmaterializable: two entries claiming one logical
+// location, exactly or under case-insensitive platform comparison, and one
+// file path doubling as a parent directory of another. Detection works from
+// maps of already-claimed locations, so the outcome never depends on entry
+// order.
+func claimEntryPath(entryPath string, filePaths, directoryPaths map[string]string) error {
+	key := rawpath.PlatformKey(entryPath)
+	if other, ok := filePaths[key]; ok {
+		if other == entryPath {
+			return fmt.Errorf("%w: duplicate manifest path %q", ErrInvalid, entryPath)
+		}
+		return fmt.Errorf(
+			"%w: manifest path %q differs from %q only by letter case", ErrInvalid, entryPath, other,
+		)
+	}
+	if descendant, ok := directoryPaths[key]; ok {
+		return fmt.Errorf(
+			"%w: manifest file path %q is also a parent directory of %q",
+			ErrInvalid, entryPath, descendant,
+		)
+	}
+	filePaths[key] = entryPath
+	for ancestor := key; ; {
+		slash := strings.LastIndex(ancestor, "/")
+		if slash <= 0 {
+			return nil
+		}
+		ancestor = ancestor[:slash]
+		if file, ok := filePaths[ancestor]; ok {
+			return fmt.Errorf(
+				"%w: manifest file path %q is also a parent directory of %q", ErrInvalid, file, entryPath,
+			)
+		}
+		if _, ok := directoryPaths[ancestor]; !ok {
+			directoryPaths[ancestor] = entryPath
+		}
+	}
 }
 
 // validateProvider fails closed for providers the server cannot classify and

--- a/internal/rawsync/manifest_test.go
+++ b/internal/rawsync/manifest_test.go
@@ -3,6 +3,7 @@ package rawsync
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -119,6 +120,39 @@ func TestValidateAndCanonicalizeBindsAuthenticatedIdentity(t *testing.T) {
 	assert.Equal(t, first.ManifestID, again.ManifestID)
 	assert.Equal(t, first.CanonicalJSON, again.CanonicalJSON)
 	assert.NotEqual(t, first.ManifestID, otherTenant.ManifestID)
+}
+
+func TestParseCanonicalManifestAcceptsOnlyExactAuthenticatedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	identity, err := NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+	canonical, err := ValidateAndCanonicalize(identity, validManifest(), DefaultManifestLimits())
+	require.NoError(t, err)
+
+	parsed, err := ParseCanonicalManifest(
+		identity, canonical.ManifestID, canonical.CanonicalJSON, DefaultManifestLimits(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, canonical, parsed)
+
+	otherIdentity, err := NewAuthIdentity("tenant-b", "device-a")
+	require.NoError(t, err)
+	_, err = ParseCanonicalManifest(
+		otherIdentity, canonical.ManifestID, canonical.CanonicalJSON, DefaultManifestLimits(),
+	)
+	assert.ErrorIs(t, err, ErrInvalid)
+
+	noncanonical := append([]byte(" "), canonical.CanonicalJSON...)
+	_, err = ParseCanonicalManifest(
+		identity, canonical.ManifestID, noncanonical, DefaultManifestLimits(),
+	)
+	assert.ErrorIs(t, err, ErrInvalid)
+
+	_, err = ParseCanonicalManifest(
+		identity, strings.Repeat("0", 64), canonical.CanonicalJSON, DefaultManifestLimits(),
+	)
+	assert.ErrorIs(t, err, ErrInvalid)
 }
 
 func TestValidateAndCanonicalizeNormalizesCapturedInstantToUTC(t *testing.T) {
@@ -261,6 +295,46 @@ func TestValidateManifestForUploadReservesWorstCaseEscapedAuthenticationIDs(t *t
 	require.ErrorIs(t, err, ErrInvalid)
 }
 
+func TestValidateAndCanonicalizeCarriesEntryModTimeBackwardCompatibly(t *testing.T) {
+	t.Parallel()
+
+	identity, err := NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+
+	// A canonical manifest written before entry modification times existed
+	// must parse and revalidate byte-for-byte.
+	legacyJSON := []byte(`{"schema_version":1,"tenant_id":"tenant-a","device_id":"device-a","provider":"codex","configured_root_id":"root-a","source_key":"sessions/demo.jsonl#main","capture_id":"capture-a","captured_at":"2026-08-13T12:34:56Z","kind":"snapshot","entries":[{"path":"a.jsonl","type":"file","length":3,"objects":[{"sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","length":3}]}]}` + "\n")
+	legacyDigest := sha256.Sum256(legacyJSON)
+	legacy, err := ParseCanonicalManifest(
+		identity, hex.EncodeToString(legacyDigest[:]), legacyJSON, DefaultManifestLimits(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, ValidateCanonicalManifest(legacy))
+	require.Len(t, legacy.Manifest.Entries, 1)
+	assert.Equal(t, int64(0), legacy.Manifest.Entries[0].ModTimeNS)
+	assert.NotContains(t, string(legacy.CanonicalJSON), "mod_time_ns")
+
+	zeroValued, err := ValidateAndCanonicalize(identity, validManifest(), DefaultManifestLimits())
+	require.NoError(t, err)
+	assert.NotContains(t, string(zeroValued.CanonicalJSON), "mod_time_ns",
+		"zero-valued entry mod times must re-canonicalize to the legacy encoding")
+
+	manifest := validManifest()
+	manifest.Entries[0].ModTimeNS = 1691929296741012507
+	canonical, err := ValidateAndCanonicalize(identity, manifest, DefaultManifestLimits())
+	require.NoError(t, err)
+	assert.Contains(t, string(canonical.CanonicalJSON), `"mod_time_ns":1691929296741012507`)
+	parsed, err := ParseCanonicalManifest(
+		identity, canonical.ManifestID, canonical.CanonicalJSON, DefaultManifestLimits(),
+	)
+	require.NoError(t, err)
+	require.Len(t, parsed.Manifest.Entries, 2)
+	assert.Equal(t, "a.jsonl", parsed.Manifest.Entries[0].Path)
+	assert.Equal(t, int64(0), parsed.Manifest.Entries[0].ModTimeNS)
+	assert.Equal(t, "z.jsonl", parsed.Manifest.Entries[1].Path)
+	assert.Equal(t, int64(1691929296741012507), parsed.Manifest.Entries[1].ModTimeNS)
+}
+
 func validManifest() Manifest {
 	return Manifest{
 		SchemaVersion:    ManifestSchemaVersion,
@@ -302,6 +376,86 @@ func cloneManifest(source Manifest) Manifest {
 	return cloned
 }
 
+// manifestWithEntryPaths returns a snapshot manifest whose entries all carry
+// the single-object file entry from validManifest under the given paths.
+func manifestWithEntryPaths(paths ...string) Manifest {
+	manifest := validManifest()
+	file := manifest.Entries[1]
+	entries := make([]Entry, len(paths))
+	for i, path := range paths {
+		entries[i] = Entry{
+			Path: path, Type: file.Type, Length: file.Length, Objects: file.Objects,
+		}
+	}
+	manifest.Entries = entries
+	return manifest
+}
+
+func entryPaths(manifest CanonicalManifest) []string {
+	paths := make([]string, len(manifest.Manifest.Entries))
+	for i, entry := range manifest.Manifest.Entries {
+		paths[i] = entry.Path
+	}
+	return paths
+}
+
+func TestValidateAndCanonicalizeRejectsConflictingEntryPathsInAnyOrder(t *testing.T) {
+	t.Parallel()
+	identity, err := NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name  string
+		paths []string
+	}{
+		{name: "exact duplicate", paths: []string{"a.jsonl", "a.jsonl"}},
+		{name: "file path prefixes nested file", paths: []string{"a", "a/b.jsonl"}},
+		{name: "deep file path prefix", paths: []string{"a/b", "a/b/c.jsonl"}},
+		{name: "case-insensitive duplicate", paths: []string{"Session.jsonl", "session.jsonl"}},
+		{name: "case-insensitive prefix", paths: []string{"Logs", "logs/session.jsonl"}},
+		{name: "unicode case duplicate", paths: []string{"Séance.jsonl", "sÉANCE.jsonl"}},
+	} {
+		// The same collision must be rejected no matter which entry the
+		// caller lists first: canonicalization sorts, validation must not
+		// depend on the surviving order.
+		for order, permutation := range [][]int{{0, 1}, {1, 0}} {
+			t.Run(fmt.Sprintf("%s/%d", tc.name, order), func(t *testing.T) {
+				t.Parallel()
+
+				manifest := manifestWithEntryPaths(
+					tc.paths[permutation[0]], tc.paths[permutation[1]],
+				)
+				_, err := ValidateAndCanonicalize(identity, manifest, DefaultManifestLimits())
+				assert.ErrorIs(t, err, ErrInvalid)
+			})
+		}
+	}
+}
+
+func TestValidateAndCanonicalizeAcceptsDistinctSiblingAndNestedEntryPaths(t *testing.T) {
+	t.Parallel()
+	identity, err := NewAuthIdentity("tenant-a", "device-a")
+	require.NoError(t, err)
+
+	// "a.jsonl" shares no path component boundary with "a/b.jsonl": the
+	// near-miss between a file and a directory name must stay valid.
+	forward, err := ValidateAndCanonicalize(
+		identity, manifestWithEntryPaths("a.jsonl", "a/b.jsonl", "a/c/d.jsonl", "z.jsonl"),
+		DefaultManifestLimits(),
+	)
+	require.NoError(t, err)
+	reversed, err := ValidateAndCanonicalize(
+		identity, manifestWithEntryPaths("z.jsonl", "a/c/d.jsonl", "a/b.jsonl", "a.jsonl"),
+		DefaultManifestLimits(),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, forward.ManifestID, reversed.ManifestID,
+		"entry ordering must not influence the canonical manifest")
+	assert.Equal(t, forward.CanonicalJSON, reversed.CanonicalJSON)
+	assert.Equal(t, []string{"a.jsonl", "a/b.jsonl", "a/c/d.jsonl", "z.jsonl"}, entryPaths(forward))
+}
+
 func TestValidateCanonicalManifestRejectsNoncanonicalValues(t *testing.T) {
 	t.Parallel()
 
@@ -333,6 +487,9 @@ func TestValidateCanonicalManifestRejectsNoncanonicalValues(t *testing.T) {
 		}},
 		{name: "wrong identity", mutate: func(m *CanonicalManifest) {
 			m.Identity.DeviceID = "device-b"
+		}},
+		{name: "tampered entry mod time", mutate: func(m *CanonicalManifest) {
+			m.Manifest.Entries[0].ModTimeNS = 7
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rawsync/object_store.go
+++ b/internal/rawsync/object_store.go
@@ -29,6 +29,9 @@ type ObjectStore interface {
 	PutObject(context.Context, string, ObjectRef, io.Reader) (PutResult, error)
 	StatObject(context.Context, string, ObjectRef) (ObjectInfo, error)
 	OpenObject(context.Context, string, ObjectRef) (ObjectInfo, VerifiedObjectReader, error)
+	// CopyObject writes exactly one verified object to destination. The store
+	// owns the reader lifecycle and observes ctx without concurrent Read/Close.
+	CopyObject(context.Context, string, ObjectRef, io.Writer) (ObjectInfo, error)
 	MissingObjects(context.Context, string, []ObjectRef) ([]ObjectRef, error)
 	// VerifyObjects requires every supplied semantic identity to exist exactly.
 	VerifyObjects(context.Context, string, []ObjectRef) error

--- a/internal/rawsync/object_store_artifact.go
+++ b/internal/rawsync/object_store_artifact.go
@@ -90,6 +90,73 @@ func (s *artifactObjectStore) OpenObject(
 	return objectInfoFromArtifact(entry), reader, nil
 }
 
+// CopyObject copies one exact, terminally verified custody object while the
+// store owns the reader lifecycle. The artifact reader is opened with ctx and
+// is read and closed sequentially; callers never need to assume that Close is
+// safe to race with an in-flight Read.
+func (s *artifactObjectStore) CopyObject(
+	ctx context.Context,
+	tenantID string,
+	object ObjectRef,
+	destination io.Writer,
+) (_ ObjectInfo, resultErr error) {
+	if destination == nil {
+		return ObjectInfo{}, fmt.Errorf("%w: raw object destination is required", ErrInvalid)
+	}
+	info, reader, err := s.OpenObject(ctx, tenantID, object)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	defer func() {
+		if closeErr := reader.Close(); closeErr != nil && resultErr == nil {
+			resultErr = fmt.Errorf("closing raw object: %w", closeErr)
+		}
+	}()
+	if info.Ref != object {
+		return ObjectInfo{}, fmt.Errorf("%w: raw object identity is inconsistent", ErrInvalid)
+	}
+	stream := rawObjectCopyReader{ctx: ctx, reader: reader}
+	written, err := io.CopyN(destination, stream, object.Length)
+	if err != nil {
+		return ObjectInfo{}, fmt.Errorf("copying raw object: %w", err)
+	}
+	extra, err := io.Copy(io.Discard, io.LimitReader(stream, 1))
+	if err != nil {
+		return ObjectInfo{}, fmt.Errorf("finishing raw object read: %w", err)
+	}
+	if written != object.Length || extra != 0 {
+		return ObjectInfo{}, fmt.Errorf("%w: raw object length is inconsistent", ErrInvalid)
+	}
+	if err := ctx.Err(); err != nil {
+		return ObjectInfo{}, err
+	}
+	if err := reader.Verify(); err != nil {
+		return ObjectInfo{}, fmt.Errorf("verifying raw object: %w", err)
+	}
+	return info, nil
+}
+
+const maxRawObjectCopyChunkBytes = 64 << 10
+
+type rawObjectCopyReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r rawObjectCopyReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(p) > maxRawObjectCopyChunkBytes {
+		p = p[:maxRawObjectCopyChunkBytes]
+	}
+	n, err := r.reader.Read(p)
+	if err != nil && r.ctx.Err() != nil {
+		return n, r.ctx.Err()
+	}
+	return n, err
+}
+
 func (s *artifactObjectStore) MissingObjects(
 	ctx context.Context,
 	tenantID string,

--- a/internal/rawsync/object_store_artifact_test.go
+++ b/internal/rawsync/object_store_artifact_test.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,6 +49,11 @@ func TestArtifactObjectStoreContract(t *testing.T) {
 	require.NoError(t, reader.Close())
 	assert.Equal(t, body, got)
 	assert.Equal(t, ref, info.Ref)
+	var copied bytes.Buffer
+	copyInfo, err := store.CopyObject(t.Context(), identity.TenantID, ref, &copied)
+	require.NoError(t, err)
+	assert.Equal(t, ref, copyInfo.Ref)
+	assert.Equal(t, body, copied.Bytes())
 	wrongLength := ObjectRef{SHA256: ref.SHA256, Length: ref.Length + 1}
 	_, err = store.StatObject(t.Context(), identity.TenantID, wrongLength)
 	assert.ErrorIs(t, err, ErrConflict)
@@ -73,6 +81,87 @@ func TestArtifactObjectStoreContract(t *testing.T) {
 	assert.Equal(t, []ObjectRef{ref}, otherTenantMissing)
 	_, _, err = store.OpenObject(t.Context(), "tenant-b", ref)
 	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestArtifactObjectStoreCopyCancellationNeverClosesDuringRead(t *testing.T) {
+	t.Parallel()
+	body := []byte("raw bytes")
+	ref := objectRefForBytes(t, body)
+	artifactRef, artifactIdentity, err := rawArtifactCoordinates("tenant-a", ref)
+	require.NoError(t, err)
+	reader := &cancelAwareArtifactReader{started: make(chan struct{})}
+	content := &copyArtifactStore{
+		entry:  artifact.Entry{Ref: artifactRef, Identity: artifactIdentity},
+		reader: reader,
+	}
+	store, err := NewArtifactObjectStore(content)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, copyErr := store.CopyObject(ctx, "tenant-a", ref, io.Discard)
+		done <- copyErr
+	}()
+	select {
+	case <-reader.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the object store never began reading the artifact")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, reader.concurrentClose.Load(),
+			"the adapter must close only after the context-aware read returns")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the artifact copy never observed cancellation")
+	}
+}
+
+type copyArtifactStore struct {
+	artifact.ArtifactStore
+	entry  artifact.Entry
+	reader artifact.VerifiedReader
+}
+
+func (s *copyArtifactStore) Open(
+	ctx context.Context,
+	ref artifact.Ref,
+) (artifact.Entry, artifact.VerifiedReader, error) {
+	if reader, ok := s.reader.(*cancelAwareArtifactReader); ok {
+		reader.ctx = ctx
+	}
+	return s.entry, s.reader, nil
+}
+
+type cancelAwareArtifactReader struct {
+	ctx             context.Context
+	started         chan struct{}
+	reading         atomic.Bool
+	concurrentClose atomic.Bool
+}
+
+func (r *cancelAwareArtifactReader) Read([]byte) (int, error) {
+	r.reading.Store(true)
+	defer r.reading.Store(false)
+	close(r.started)
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	case <-time.After(5 * time.Second):
+		return 0, errors.New("canceled artifact read never observed its context")
+	}
+}
+
+func (*cancelAwareArtifactReader) Verify() error { return nil }
+
+func (r *cancelAwareArtifactReader) Close() error {
+	if r.reading.Load() {
+		r.concurrentClose.Store(true)
+	}
+	return nil
 }
 
 func TestArtifactObjectStoreRejectsInvalidWritesAndRequests(t *testing.T) {

--- a/internal/rawsync/service_test.go
+++ b/internal/rawsync/service_test.go
@@ -475,6 +475,15 @@ func (s *recordingObjectStore) OpenObject(
 	return ObjectInfo{}, nil, errors.New("unexpected OpenObject call")
 }
 
+func (s *recordingObjectStore) CopyObject(
+	context.Context,
+	string,
+	ObjectRef,
+	io.Writer,
+) (ObjectInfo, error) {
+	return ObjectInfo{}, errors.New("unexpected CopyObject call")
+}
+
 func (s *recordingObjectStore) MissingObjects(
 	_ context.Context,
 	tenantID string,

--- a/internal/rawwatch/auditor.go
+++ b/internal/rawwatch/auditor.go
@@ -168,12 +168,18 @@ func (a *Auditor) auditProviderBounded(
 		}
 		seenPhysical[physicalKey] = struct{}{}
 		capture, err := a.capturer.Capture(ctx, provider, event.source)
+		remaining--
+		result.Visited++
+		if errors.Is(err, rawcapture.ErrSourceChanged) {
+			if remaining == 0 {
+				return result, nil
+			}
+			continue
+		}
 		if err != nil {
 			a.stopDiscoveryScan(providerType)
 			return result, err
 		}
-		remaining--
-		result.Visited++
 		switch capture.Status {
 		case rawcapture.StatusCaptured:
 			result.Captured++
@@ -488,10 +494,15 @@ func (a *Auditor) auditProviderFull(
 	}
 	for _, item := range discovered {
 		capture, err := a.capturer.Capture(ctx, provider, item.source)
+		result.Visited++
+		if errors.Is(err, rawcapture.ErrSourceChanged) {
+			result.Degraded++
+			degradedRootIDs[item.rootID] = struct{}{}
+			continue
+		}
 		if err != nil {
 			return result, err
 		}
-		result.Visited++
 		switch capture.Status {
 		case rawcapture.StatusCaptured:
 			result.Captured++

--- a/internal/rawwatch/auditor_test.go
+++ b/internal/rawwatch/auditor_test.go
@@ -28,6 +28,7 @@ type auditProvider struct {
 	examinedEntries     int
 	planCalls           int
 	planErrorAt         int
+	planError           error
 }
 
 type partialAuditProvider struct {
@@ -176,6 +177,9 @@ func (p *auditProvider) PlanRawCapture(
 ) (parser.RawCapturePlan, error) {
 	p.planCalls++
 	if p.planErrorAt == p.planCalls {
+		if p.planError != nil {
+			return parser.RawCapturePlan{}, p.planError
+		}
 		return parser.RawCapturePlan{}, errors.New("injected plan failure")
 	}
 	return parser.RawCapturePlan{
@@ -184,6 +188,46 @@ func (p *auditProvider) PlanRawCapture(
 			Path: source.Key, LocalPath: filepath.Join(p.root, source.Key),
 		}},
 	}, nil
+}
+
+func TestAuditorContinuesAfterSourceChangesDuringCapture(t *testing.T) {
+	for _, full := range []bool{false, true} {
+		t.Run(fmt.Sprintf("full=%t", full), func(t *testing.T) {
+			root := t.TempDir()
+			for _, name := range []string{"a.jsonl", "b.jsonl"} {
+				require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(name), 0o600))
+			}
+			base := t.TempDir()
+			store, err := rawcheckpoint.OpenWithOptions(t.Context(), filepath.Join(base, "checkpoint.db"), rawcheckpoint.Options{
+				SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			provider := newAuditProvider(root)
+			// Fail at Capture's plan call, after source identity was established.
+			provider.planErrorAt = 2
+			if full {
+				provider.planErrorAt = 3
+			}
+			provider.planError = rawcapture.ErrSourceChanged
+			auditor := NewAuditor(store, rawcapture.New(store), 32)
+			run := auditor.AuditProvider
+			if full {
+				run = auditor.AuditProviderFull
+			}
+
+			result, err := run(t.Context(), provider)
+			require.NoError(t, err)
+			assert.Equal(t, 2, result.Visited)
+			assert.Equal(t, 1, result.Captured)
+			assert.True(t, result.Complete)
+			// The skipped source remains discoverable on the next pass.
+			retry, err := run(t.Context(), provider)
+			require.NoError(t, err)
+			assert.Equal(t, 1, retry.Captured)
+			assert.Equal(t, 1, retry.Unchanged)
+		})
+	}
 }
 
 func newPartialAuditProvider(roots ...string) *partialAuditProvider {

--- a/internal/rawwatch/worker_test.go
+++ b/internal/rawwatch/worker_test.go
@@ -332,6 +332,46 @@ func TestWorkerFullSyncReportsOutboxBackpressure(t *testing.T) {
 	}
 }
 
+func TestWorkerFullSyncRetriesChangedSource(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "session.jsonl"), []byte("session\n"), 0o600))
+	base := t.TempDir()
+	store, err := rawcheckpoint.OpenWithOptions(
+		t.Context(), filepath.Join(base, "checkpoint.db"),
+		rawcheckpoint.Options{
+			SpoolDir: filepath.Join(base, "spool"), MaxOutboxBytes: 1 << 20,
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := newAuditProvider(root)
+	provider.planErrorAt = 2 // Fail capture after discovery resolves the source identity.
+	provider.planError = rawcapture.ErrSourceChanged
+	capturer := rawcapture.New(store)
+	worker := NewWorker(
+		[]parser.Provider{provider}, capturer,
+		NewAuditor(store, capturer, 1), nil,
+	)
+
+	err = worker.HandleBatch(t.Context(), syncpkg.WatchBatch{FullSync: true})
+
+	require.ErrorIs(t, err, ErrFullSyncIncomplete)
+	configured, err := store.ResolveConfiguredRoot(t.Context(), parser.AgentClaude, root)
+	require.NoError(t, err)
+	identity := rawcheckpoint.SourceIdentity{
+		Provider: parser.AgentClaude, ConfiguredRootID: configured.ID, SourceKey: "session.jsonl",
+	}
+	_, ok, err := store.CaptureBase(t.Context(), identity)
+	require.NoError(t, err)
+	assert.False(t, ok, "the changed source must remain uncaptured")
+
+	require.NoError(t, worker.HandleBatch(t.Context(), syncpkg.WatchBatch{FullSync: true}))
+	capture, ok, err := store.CaptureBase(t.Context(), identity)
+	require.NoError(t, err)
+	require.True(t, ok, "the retry must capture the source")
+	assert.Equal(t, rawsync.ManifestSnapshot, capture.Kind)
+}
+
 func TestWorkerFullSyncReportsIncompleteDiscovery(t *testing.T) {
 	healthyRoot := t.TempDir()
 	healthyPath := filepath.Join(healthyRoot, "session.jsonl")

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -199,7 +199,11 @@ func resolveFileScopedTarget(agent parser.AgentType, root string) (string, []str
 			for _, entry := range plan.Entries {
 				// Capture validation canonicalizes paths; retain the configured
 				// root spelling used by the remote target's authorization scope.
-				localPath := filepath.Join(root, filepath.FromSlash(entry.Path))
+				rel, err := filepath.Rel(plan.ConfiguredRoot, entry.LocalPath)
+				if err != nil {
+					return "", nil, err
+				}
+				localPath := filepath.Join(root, rel)
 				regular, err := regularCuratedFile(root, localPath)
 				if err != nil {
 					return "", nil, err


### PR DESCRIPTION
Adds a worker library for deriving sessions from retained raw captures. Workers verify manifest and object digests, reconstruct a read-only source tree, reuse provider parsing, and hand results to an atomic projection sink. PostgreSQL leases fence job completion to the current source generation.

Replay preserves provider inputs: SQLite snapshots use immutable reads, Codex retains alias-home title precedence and replay parents across configured directories, and Claude and Evener retain their lineage companions. Growing transcripts reuse captured prefixes. Hosted skill names come from recorded paths without reading worker-local frontmatter or cached local names.

Changing sources no longer stop an audit; full audits report skipped captures as incomplete so the watcher retries. Unchanged Claude sniff checks reuse filesystem evidence, and idle job cleanup excludes future retries.

Runtime activation and PostgreSQL session projection remain pending, so hosted browsing still requires `pg push`. The implemented capture-to-parser boundary has been exercised with Claude and WAL-mode ZCode inputs using PostgreSQL job leases and a recording projection sink.

Existing least-privilege raw-sync roles need `SELECT` and `UPDATE` on `raw_ingest_jobs`. Startup names missing requirements; grants are documented in the hosted raw-sync and PostgreSQL sync guides.

Rollout to existing raw-sync deployments still needs a compatibility decision: stricter validation rejects stored case-colliding paths, and an upload committed remotely but not bound locally before upgrading can retry indefinitely with a different manifest ID after modification times are added.

Refs #1352

