### PR TITLE
fix(parser): attribute skill names for Pi skill loads

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -710,32 +710,33 @@ add an archived or maintained mirror without replacing the original identity.
   session or project row that advances past its own stored metadata watermark
   is always a candidate, wherever other sessions' watermarks or its own child
   timestamps sit. Periodic full passes and streamed reconciliation passes over
-  a container whose last complete digest verification is less than five minutes
-  old may list the watermark form (`SQLiteContainerListsWatermarkOnly`): every
-  member gate-skips before fingerprinting, so the child identity scan would be
-  archive-sized work nothing reads. A changed container may continue using
-  this form during that bounded interval; after the interval, the next pass
-  carries the complete digest again. Watermark-only skips additionally
-  require the pass's container capture to still be valid
-  (`sqliteContainerPassCaptureValid`) — a container that changes between
-  listing and the recapture check resolves full per-session digests instead,
-  so a concurrent child-only write cannot hide beneath an unchanged metadata
-  watermark. The trade is explicit: any child-only write that leaves the
-  session and project rows untouched — wherever its timestamps land relative
-  to the stored composite — is invisible to watermark-only discovery and is
-  reconciled by the next full digest pass, at most five minutes after the last
-  successful digest verification. That due pass bypasses the container-level
-  trusted-state skip so every session reaches the authoritative digest comparison;
-  when the platform cannot provide stable file identity, the policy fails closed
-  to this full digest form rather than authorizing a stale verification timestamp;
-  on the production container above, 96% of sessions
-  carry a session/project timestamp at or above every child, and actively
-  watched sessions bypass this entirely via the per-session composite poll.
-  Per-event work is bounded by the changed batch plus one O(session-count)
-  scan of small fixed-width rows (the session table and the paged
-  stored-member reads); that floor is irreducible without a watermark index,
-  which OpenCode's schema does not have and which is not agentsview's to add —
-  but only the changed batch and one stored page are ever held in memory.
+  a container whose last complete digest verification is less than five
+  minutes old may list the watermark form
+  (`SQLiteContainerListsWatermarkOnly`): every member gate-skips before
+  fingerprinting, so the child identity scan would be archive-sized work
+  nothing reads. A changed container may continue using this form during that
+  bounded interval; after the interval, the next pass carries the complete
+  digest again. Watermark-only skips additionally require the pass's container
+  capture to still be valid (`sqliteContainerPassCaptureValid`) — a container
+  that changes between listing and the recapture check resolves full per-session
+  digests instead, so a concurrent child-only write cannot hide beneath an
+  unchanged metadata watermark. The trade is explicit: any child-only write that
+  leaves the session and project rows untouched — wherever its timestamps land
+  relative to the stored composite — is invisible to watermark-only discovery
+  and is reconciled by the next full digest pass, at most five minutes after
+  the last successful digest verification. That due pass bypasses the
+  container-level trusted-state skip so every session reaches the
+  authoritative digest comparison; when the platform cannot provide stable
+  file identity, the policy fails closed to this full digest form rather than
+  authorizing a stale verification timestamp; on the production container
+  above, 96% of sessions carry a session/project timestamp at or above every
+  child, and actively watched sessions bypass this entirely via the
+  per-session composite poll. Per-event work is bounded by the changed batch
+  plus one O(session-count) scan of small fixed-width rows (the session table
+  and the paged stored-member reads); that floor is irreducible without a
+  watermark index, which OpenCode's schema does not have and which is not
+  agentsview's to add — but only the changed batch and one stored page are
+  ever held in memory.
 - **Agentsview:** `internal/parser/opencode.go`,
   `internal/parser/opencode_provider.go`, and
   `internal/parser/opencode_storage_state.go`; legacy and database layouts are
@@ -1052,7 +1053,11 @@ add an archived or maintained mirror without replacing the original identity.
   `f1c587dde39025c75d7397bc14532d8fa5c001d9`; see the pinned
   [session format](https://github.com/earendil-works/pi/blob/f1c587dde39025c75d7397bc14532d8fa5c001d9/packages/coding-agent/docs/session-format.md)
   and
-  [session manager](https://github.com/earendil-works/pi/blob/f1c587dde39025c75d7397bc14532d8fa5c001d9/packages/coding-agent/src/core/session-manager.ts).
+  [session manager](https://github.com/earendil-works/pi/blob/f1c587dde39025c75d7397bc14532d8fa5c001d9/packages/coding-agent/src/core/session-manager.ts),
+  plus the
+  [skill documentation](https://github.com/earendil-works/pi/blob/f1c587dde39025c75d7397bc14532d8fa5c001d9/packages/coding-agent/docs/skills.md)
+  and
+  [skill loader](https://github.com/earendil-works/pi/blob/f1c587dde39025c75d7397bc14532d8fa5c001d9/packages/coding-agent/src/core/skills.ts).
 - **Usage and cost:** Assistant messages persist input and output tokens plus
   cache-read and cache-write/creation values in nested or historical flat
   shapes. Model IDs are present. Agentsview catalog-prices the tokens. Data
@@ -1060,7 +1065,10 @@ add an archived or maintained mirror without replacing the original identity.
   `cacheWrite` spelling.
 - **Agentsview:** `internal/parser/pi.go` and `internal/parser/pi_provider.go`;
   alternate branches remain in the file but only the active ancestry is a
-  conversation.
+  conversation. Reverified 2026-09-03 against 156 local Pi transcripts: the
+  parser attributed 1,316 `read` calls whose `path` or `file_path` named a
+  concrete `SKILL.md`, while shell commands that only mentioned the filename
+  without reading it stayed unattributed.
 
 ## Prime Agent (`prime-agent`)
 
@@ -1072,11 +1080,11 @@ add an archived or maintained mirror without replacing the original identity.
 - **Upstream:** Clone `https://github.com/PrimeIntellect-ai/prime-agent.git` at
   `0e0d23391bcd879f1aea70dbda4d07dda7970b34`; see the pinned
 
-  [session format](https://github.com/PrimeIntellect-ai/prime-agent/blob/0e0d23391bcd879f1aea70dbda4d07dda7970b34/packages/coding-agent/docs/session-format.md),
+    [session format](https://github.com/PrimeIntellect-ai/prime-agent/blob/0e0d23391bcd879f1aea70dbda4d07dda7970b34/packages/coding-agent/docs/session-format.md),
 
-  [session types and persistence](https://github.com/PrimeIntellect-ai/prime-agent/blob/0e0d23391bcd879f1aea70dbda4d07dda7970b34/packages/coding-agent/src/core/session-manager.ts),
-  and
-  [configuration paths](https://github.com/PrimeIntellect-ai/prime-agent/blob/0e0d23391bcd879f1aea70dbda4d07dda7970b34/packages/coding-agent/src/config.ts).
+    [session types and persistence](https://github.com/PrimeIntellect-ai/prime-agent/blob/0e0d23391bcd879f1aea70dbda4d07dda7970b34/packages/coding-agent/src/core/session-manager.ts),
+    and
+    [configuration paths](https://github.com/PrimeIntellect-ai/prime-agent/blob/0e0d23391bcd879f1aea70dbda4d07dda7970b34/packages/coding-agent/src/config.ts).
 
 - **Usage and cost:** Assistant messages persist input, output, cache-read, and
   cache-write tokens with model IDs. `child_usage_attributed` entries replace
@@ -1118,16 +1126,24 @@ add an archived or maintained mirror without replacing the original identity.
   `39c95e5e29b1c8b082059f57421ce445c3dffdd4`; see
   [session-entries.ts](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/session/session-entries.ts),
 
-  [session-persistence.ts](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/session/session-persistence.ts),
-  and
-  [usage.ts](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/ai/src/usage.ts).
+    [session-persistence.ts](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/session/session-persistence.ts),
+    and
+    [usage.ts](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/ai/src/usage.ts).
+    Skill attribution follows the pinned
+    [skill protocol](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/internal-urls/skill-protocol.ts)
+    and
+    [shell URL resolver](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/tools/bash-skill-urls.ts).
 
 - **Usage and cost:** Pi-family usage persists input, output, cache-read, and
   cache-write tokens with a model. Agentsview derives monetary cost from the
   catalog; provider reporting notes are not treated as exact persisted USD.
 
 - **Agentsview:** Oh My Pi is registered through the Pi-family provider in
-  `internal/parser/pi.go` and `internal/parser/pi_provider.go`.
+  `internal/parser/pi.go` and `internal/parser/pi_provider.go`. Reverified
+  2026-09-03 that OMP exposes on-demand skill content through `read` calls
+  with a `skill://<name>` path, percent-decodes namespaced skill names, and
+  accepts a relative resource path after the name. Agentsview attributes only
+  the URI in the Pi-family read path and decodes the name before storing it.
 
 ## Qwen Code (`qwen`)
 
@@ -1200,23 +1216,23 @@ add an archived or maintained mirror without replacing the original identity.
   `47f943859bef60e4160492346772ded9b24f765a`. See the pinned
   [JSONL layout, header, and scanner](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/session/session-persistence-jsonl/src/format.ts),
 
-  [multi-frame zstd backend](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/session/session-persistence-jsonl/src/index.ts),
+    [multi-frame zstd backend](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/session/session-persistence-jsonl/src/index.ts),
 
-  [packed chunk codec](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/core/session/src/chunk-rows.ts),
+    [packed chunk codec](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/core/session/src/chunk-rows.ts),
 
-  [session event and seed schema](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/core/session/src/types.ts),
+    [session event and seed schema](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/core/session/src/types.ts),
 
-  [turn and step production order](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/core/agent-loop/src/agent.ts#L245-L292),
+    [turn and step production order](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/core/agent-loop/src/agent.ts#L245-L292),
 
-  [turn and step invariants](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/core/session/src/invariant.ts),
+    [turn and step invariants](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/core/session/src/invariant.ts),
 
-  [agent preset reconstruction](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/preset/agent-presets/src/session.ts),
+    [agent preset reconstruction](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/preset/agent-presets/src/session.ts),
 
-  [compaction model-call facts](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/compaction/compaction/src/types.ts),
-  and the
-  [message/content schema](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/llm/llm/src/message.ts)
-  plus the
-  [usage schema](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/llm/llm/src/types.ts).
+    [compaction model-call facts](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/compaction/compaction/src/types.ts),
+    and the
+    [message/content schema](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/llm/llm/src/message.ts)
+    plus the
+    [usage schema](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/llm/llm/src/types.ts).
 
 - **Usage and cost:** Each model response and summarizing compaction can persist
   disjoint input, output, cache-read, cache-write, and reasoning token counts.
@@ -1292,9 +1308,9 @@ add an archived or maintained mirror without replacing the original identity.
   `4a550effdfcb29a25a5d325bf935296cc50cd417`; see
   [session.py](https://github.com/MoonshotAI/kimi-cli/blob/4a550effdfcb29a25a5d325bf935296cc50cd417/src/kimi_cli/session.py),
 
-  [wire-mode.md](https://github.com/MoonshotAI/kimi-cli/blob/4a550effdfcb29a25a5d325bf935296cc50cd417/docs/en/customization/wire-mode.md),
-  and the
-  [Kimi provider usage mapping](https://github.com/MoonshotAI/kimi-cli/blob/4a550effdfcb29a25a5d325bf935296cc50cd417/packages/kosong/src/kosong/chat_provider/kimi.py).
+    [wire-mode.md](https://github.com/MoonshotAI/kimi-cli/blob/4a550effdfcb29a25a5d325bf935296cc50cd417/docs/en/customization/wire-mode.md),
+    and the
+    [Kimi provider usage mapping](https://github.com/MoonshotAI/kimi-cli/blob/4a550effdfcb29a25a5d325bf935296cc50cd417/packages/kosong/src/kosong/chat_provider/kimi.py).
 
 - **Usage and cost:** Native usage distinguishes uncached/other input, output,
   cache read, and cache creation. The aggregate fallback exposes only output
@@ -1374,17 +1390,17 @@ add an archived or maintained mirror without replacing the original identity.
 - **Format:** Legacy JSONL plus companion metadata JSON, and newer SQLite
   session databases.
 
-  The issue-reported current layout uses
-  `~/.kiro/sessions/<workspace>/sess_<id>/messages.jsonl` or the direct
-  `sess_<id>/messages.jsonl` form, with optional `session.json`. Agentsview
-  admits only these exact producer-relative shapes: one workspace segment, no
-  `.history` or `snapshots` workspace, a valid `sess_<id>` directory, and no
-  nested session directory. It preserves the literal `sess_<id>` identity and
-  maps user, assistant, tool-call, and tool-result envelope fields; unknown
-  and malformed records are ignored. This observed layout has no pinned
-  producer schema source. For duplicate IDs, SQLite outranks current JSONL,
-  current outranks legacy JSONL, configured root order breaks ties within a
-  class, and recency then canonical path provide deterministic ties.
+    The issue-reported current layout uses
+    `~/.kiro/sessions/<workspace>/sess_<id>/messages.jsonl` or the direct
+    `sess_<id>/messages.jsonl` form, with optional `session.json`. Agentsview
+    admits only these exact producer-relative shapes: one workspace segment, no
+    `.history` or `snapshots` workspace, a valid `sess_<id>` directory, and no
+    nested session directory. It preserves the literal `sess_<id>` identity and
+    maps user, assistant, tool-call, and tool-result envelope fields; unknown
+    and malformed records are ignored. This observed layout has no pinned
+    producer schema source. For duplicate IDs, SQLite outranks current JSONL,
+    current outranks legacy JSONL, configured root order breaks ties within a
+    class, and recency then canonical path provide deterministic ties.
 
 - **Evidence:** `documentation`.
 
@@ -1402,11 +1418,11 @@ add an archived or maintained mirror without replacing the original identity.
   at `12375a273a289c131a45b4fd3eb1ad6483b4e9d4`; see its pinned
   [Kiro JSONL parser](https://github.com/ingo-eichhorst/Irrlicht/blob/12375a273a289c131a45b4fd3eb1ad6483b4e9d4/core/adapters/inbound/agents/kirocli/parser.go),
 
-  [sidecar metrics reader](https://github.com/ingo-eichhorst/Irrlicht/blob/12375a273a289c131a45b4fd3eb1ad6483b4e9d4/core/adapters/inbound/agents/kirocli/sidecar_metrics.go),
-  and recorded
-  [token-accounting assessment](https://github.com/ingo-eichhorst/Irrlicht/blob/12375a273a289c131a45b4fd3eb1ad6483b4e9d4/replaydata/agents/kiro-cli/scenarios/5-1_token-accounting/metadata.json).
-  These are consumer observations, not Kiro producer authority, and they do
-  not cover the newer `conversations_v2` writer.
+    [sidecar metrics reader](https://github.com/ingo-eichhorst/Irrlicht/blob/12375a273a289c131a45b4fd3eb1ad6483b4e9d4/core/adapters/inbound/agents/kirocli/sidecar_metrics.go),
+    and recorded
+    [token-accounting assessment](https://github.com/ingo-eichhorst/Irrlicht/blob/12375a273a289c131a45b4fd3eb1ad6483b4e9d4/replaydata/agents/kiro-cli/scenarios/5-1_token-accounting/metadata.json).
+    These are consumer observations, not Kiro producer authority, and they do
+    not cover the newer `conversations_v2` writer.
 
 - **Usage and cost:** JSONL events contain no model, token, cache, credit, or
   USD fields. The companion state can contain model/window metadata, context
@@ -1572,9 +1588,9 @@ add an archived or maintained mirror without replacing the original identity.
   `69ce3728acae0b01c2f457b65a90c144664686aa`; see the pinned
   [agent conversation migration](https://github.com/warpdotdev/warp/blob/69ce3728acae0b01c2f457b65a90c144664686aa/crates/persistence/migrations/2025-06-09-013710_create_agent_conversations_table/up.sql),
 
-  [persistence writer](https://github.com/warpdotdev/warp/blob/69ce3728acae0b01c2f457b65a90c144664686aa/app/src/persistence/agent.rs),
-  and
-  [conversation usage types](https://github.com/warpdotdev/warp/blob/69ce3728acae0b01c2f457b65a90c144664686aa/crates/persistence/src/model.rs).
+    [persistence writer](https://github.com/warpdotdev/warp/blob/69ce3728acae0b01c2f457b65a90c144664686aa/app/src/persistence/agent.rs),
+    and
+    [conversation usage types](https://github.com/warpdotdev/warp/blob/69ce3728acae0b01c2f457b65a90c144664686aa/crates/persistence/src/model.rs).
 
 - **Usage and cost:** The consumed metadata has aggregate `warp_tokens` and
   `byok_tokens` by model and category, plus custom-endpoint tokens and credit
@@ -1701,21 +1717,21 @@ add an archived or maintained mirror without replacing the original identity.
 - **Upstream:** Clone `https://github.com/aaif-goose/goose.git` at
   `5ab0e6df34e69444f6f2016de40717a9f54bf816`; see the pinned
 
-  [session manager](https://github.com/aaif-goose/goose/blob/5ab0e6df34e69444f6f2016de40717a9f54bf816/crates/goose/src/session/session_manager.rs),
+    [session manager](https://github.com/aaif-goose/goose/blob/5ab0e6df34e69444f6f2016de40717a9f54bf816/crates/goose/src/session/session_manager.rs),
 
-  [message model](https://github.com/aaif-goose/goose/blob/5ab0e6df34e69444f6f2016de40717a9f54bf816/crates/goose-provider-types/src/conversation/message.rs),
+    [message model](https://github.com/aaif-goose/goose/blob/5ab0e6df34e69444f6f2016de40717a9f54bf816/crates/goose-provider-types/src/conversation/message.rs),
 
-  [tool-result serialization](https://github.com/aaif-goose/goose/blob/5ab0e6df34e69444f6f2016de40717a9f54bf816/crates/goose-provider-types/src/conversation/tool_result_serde.rs),
-  and
-  [path resolution](https://github.com/aaif-goose/goose/blob/5ab0e6df34e69444f6f2016de40717a9f54bf816/crates/goose/src/config/paths.rs).
+    [tool-result serialization](https://github.com/aaif-goose/goose/blob/5ab0e6df34e69444f6f2016de40717a9f54bf816/crates/goose-provider-types/src/conversation/tool_result_serde.rs),
+    and
+    [path resolution](https://github.com/aaif-goose/goose/blob/5ab0e6df34e69444f6f2016de40717a9f54bf816/crates/goose/src/config/paths.rs).
 
-  `Paths::data_dir()` uses etcetera 0.11 `choose_app_strategy` (XDG on macOS and
-  Linux; the Windows strategy appends a `data` subfolder under
-  `%APPDATA%\Block\goose\`), and `GOOSE_PATH_ROOT` overrides it with
-  `<root>/data`. The first-party
-  [session-management guide](https://goose-docs.ai/docs/guides/sessions/session-management/)
-  and an isolated observed schema-version-15 database were also checked
-  2026-08-03.
+    `Paths::data_dir()` uses etcetera 0.11 `choose_app_strategy` (XDG on macOS and
+    Linux; the Windows strategy appends a `data` subfolder under
+    `%APPDATA%\Block\goose\`), and `GOOSE_PATH_ROOT` overrides it with
+    `<root>/data`. The first-party
+    [session-management guide](https://goose-docs.ai/docs/guides/sessions/session-management/)
+    and an isolated observed schema-version-15 database were also checked
+    2026-08-03.
 
 - **Usage and cost:** `usage_ledger` rows provide model, input, output,
   cache-read, cache-write, compaction, cost, and cost-source data without a

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -455,7 +455,10 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // records the summary size and readers re-derive the text from the event.
 // Existing rows need re-parsing to drop the duplicate copy, which was about
 // 40% of a large archive.)
-const dataVersion = 97
+// (98: The Pi parser now attributes skill loads (SKILL.md
+// reads and skill:// URIs) so Pi tool calls count toward Top Skills.
+// Existing Pi rows need re-parsing to backfill the skill attribution.)
+const dataVersion = 98
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1053,12 +1053,17 @@ func TestCurrentDataVersionPositAssistantProviderIdentity(t *testing.T) {
 
 func TestCurrentDataVersionAntigravityCLICwdAndWorktreeProject(t *testing.T) {
 	assert.GreaterOrEqual(t, CurrentDataVersion(), 96,
-		"Antigravity CLI cwd and worktree project recovery require a sequential backfill")
+		"version 96 is the data-version boundary for Antigravity CLI cwd and worktree project recovery")
 }
 
 func TestCurrentDataVersionToolResultSummaryDedup(t *testing.T) {
-	assert.Equal(t, 97, CurrentDataVersion(),
-		"dropping summaries a single result event repeats requires a re-parse")
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 97,
+		"version 97 is the data-version boundary for tool-result summary deduplication")
+}
+
+func TestCurrentDataVersionPiSkillAttribution(t *testing.T) {
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 98,
+		"version 98 is the data-version boundary for Pi skill attribution")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/db/tool_result_dedup_bench_test.go
+++ b/internal/db/tool_result_dedup_bench_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -125,13 +126,21 @@ func BenchmarkRecallEvidenceWindowFiveAgentEventCalls(b *testing.B) {
 	}
 }
 
-func BenchmarkRecallEvidenceWindowSingleEventCalls(b *testing.B) {
+func BenchmarkRecallEvidenceWindowSingleEventCallsColdPools(b *testing.B) {
 	d := testDB(b)
 	const msgs, callsPerMsg = 200, 3
 	seedBenchToolResultSession(b, d, "bench-recall-1", msgs, callsPerMsg, 1)
 	ctx := context.Background()
 	b.ResetTimer()
 	for b.Loop() {
+		// Two collections evict both the primary and victim sync.Pool
+		// caches. Keep them outside the measurement so every operation
+		// measures the same cold-pool read instead of whichever pool state
+		// the process happened to inherit from earlier benchmarks.
+		b.StopTimer()
+		runtime.GC()
+		runtime.GC()
+		b.StartTimer()
 		w, err := d.BuildRecallEvidenceWindow(ctx, "bench-recall-1", 0, msgs-1)
 		if err != nil {
 			b.Fatal(err)

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -513,20 +514,22 @@ func parsePiAssistantMessage(
 // at the skill's SKILL.md (Pi resolves skills from many roots:
 // ~/.pi/agent/skills, project .pi/skills, .agents/skills, package
 // skills/, --skill <path>), or, in newer OMP builds, at a
-// skill://<name> URI. Without attribution these calls inflate the Read
-// tool count and leave the Skills dimension empty. Relative SKILL.md
-// paths resolve against the session working directory (sessionCwd).
+// skill://<name> URI in that read path. Without attribution these calls
+// inflate the Read tool count and leave the Skills dimension empty.
+// Relative SKILL.md paths resolve against the session working directory
+// (sessionCwd).
 func inferPiSkillName(toolName, inputJSON, sessionCwd string) string {
-	if skill, ok := piSkillURISkillName(inputJSON); ok {
-		return skill
-	}
 	if isCursorSkillReadTool(toolName) {
 		// Pi's read input carries no cwd/workdir key, so
 		// inferSkillNameFromJSONPaths can't resolve relative SKILL.md
 		// paths; try the path keys directly against the session working
 		// directory first, mirroring the OpenCode parser.
 		for _, key := range []string{"path", "file_path"} {
-			if fp := gjson.Get(inputJSON, key).Str; fp != "" && sessionCwd != "" {
+			fp := gjson.Get(inputJSON, key).Str
+			if skill, ok := piSkillURISkillName(fp); ok {
+				return skill
+			}
+			if fp != "" && sessionCwd != "" {
 				if name := skillNameFromPath(fp, sessionCwd); name != "" {
 					return name
 				}
@@ -537,31 +540,24 @@ func inferPiSkillName(toolName, inputJSON, sessionCwd string) string {
 	return inferCodexSkillNameWithBase(toolName, inputJSON, sessionCwd)
 }
 
-// piSkillURISkillName extracts a skill name from a skill://<name>
-// URI appearing anywhere in a Pi tool call's input JSON. Pi-family
-// producers pass the URI as the read path, but any string field may
-// carry it, so the whole input is scanned. ok is false when no URI
-// is present, leaving attribution to the other heuristics.
-func piSkillURISkillName(inputJSON string) (string, bool) {
-	idx := strings.Index(inputJSON, "skill://")
-	if idx < 0 {
+// piSkillURISkillName extracts the decoded skill name from the
+// skill://<name> URI used as a Pi-family read path. ok is false when
+// path is not a valid skill URI, leaving attribution to the SKILL.md
+// path heuristic.
+func piSkillURISkillName(path string) (string, bool) {
+	path = strings.TrimSpace(path)
+	if !strings.HasPrefix(path, "skill://") {
 		return "", false
 	}
-	rest := inputJSON[idx+len("skill://"):]
-	end := 0
-	for end < len(rest) {
-		c := rest[end]
-		if c == '"' || c == '\\' || c == ' ' || c == '\t' ||
-			c == '\n' || c == '\r' || c == '?' || c == '#' {
-			break
-		}
-		end++
+	rest := path[len("skill://"):]
+	if end := strings.IndexAny(rest, "/?# \t\n\r"); end >= 0 {
+		rest = rest[:end]
 	}
-	name := strings.TrimLeft(rest[:end], "/")
-	if idx := strings.IndexByte(name, '/'); idx >= 0 {
-		name = name[:idx]
+	if rest == "" {
+		return "", false
 	}
-	if name == "" {
+	name, err := url.PathUnescape(rest)
+	if err != nil || name == "" {
 		return "", false
 	}
 	return name, true

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -195,7 +195,7 @@ func parsePiLikeSession(
 				sourceParentUUID := resolveVisibleAncestor(parentID)
 				msg := parsePiAssistantMessage(
 					line, ordinal, currentModel, entryID,
-					sourceParentUUID,
+					sourceParentUUID, cwd,
 				)
 				if msg == nil {
 					continue
@@ -431,7 +431,7 @@ func parsePiUserMessage(
 // model_change entry), used when this message has no inline model.
 func parsePiAssistantMessage(
 	line string, ordinal int, fallbackModel, sourceUUID,
-	sourceParentUUID string,
+	sourceParentUUID, sessionCwd string,
 ) *ParsedMessage {
 	var (
 		parts       []string
@@ -475,6 +475,9 @@ func parsePiAssistantMessage(
 					ToolName:  name,
 					Category:  NormalizeToolCategory(name),
 					InputJSON: argsRaw,
+					SkillName: inferPiSkillName(
+						name, argsRaw, sessionCwd,
+					),
 				})
 				parts = append(parts, formatPiToolUse(
 					name, argsRaw,
@@ -502,6 +505,66 @@ func parsePiAssistantMessage(
 	}
 	applyPiTokenUsage(pm, line, fallbackModel)
 	return pm
+}
+
+// inferPiSkillName attributes a Pi tool call to a skill when the call
+// is a skill load. Pi has no dedicated skill tool: a native skill load
+// is emitted as an ordinary `read` tool call whose path argument points
+// at the skill's SKILL.md (Pi resolves skills from many roots:
+// ~/.pi/agent/skills, project .pi/skills, .agents/skills, package
+// skills/, --skill <path>), or, in newer OMP builds, at a
+// skill://<name> URI. Without attribution these calls inflate the Read
+// tool count and leave the Skills dimension empty. Relative SKILL.md
+// paths resolve against the session working directory (sessionCwd).
+func inferPiSkillName(toolName, inputJSON, sessionCwd string) string {
+	if skill, ok := piSkillURISkillName(inputJSON); ok {
+		return skill
+	}
+	if isCursorSkillReadTool(toolName) {
+		// Pi's read input carries no cwd/workdir key, so
+		// inferSkillNameFromJSONPaths can't resolve relative SKILL.md
+		// paths; try the path keys directly against the session working
+		// directory first, mirroring the OpenCode parser.
+		for _, key := range []string{"path", "file_path"} {
+			if fp := gjson.Get(inputJSON, key).Str; fp != "" && sessionCwd != "" {
+				if name := skillNameFromPath(fp, sessionCwd); name != "" {
+					return name
+				}
+			}
+		}
+		return inferSkillNameFromJSONPaths(inputJSON)
+	}
+	return inferCodexSkillNameWithBase(toolName, inputJSON, sessionCwd)
+}
+
+// piSkillURISkillName extracts a skill name from a skill://<name>
+// URI appearing anywhere in a Pi tool call's input JSON. Pi-family
+// producers pass the URI as the read path, but any string field may
+// carry it, so the whole input is scanned. ok is false when no URI
+// is present, leaving attribution to the other heuristics.
+func piSkillURISkillName(inputJSON string) (string, bool) {
+	idx := strings.Index(inputJSON, "skill://")
+	if idx < 0 {
+		return "", false
+	}
+	rest := inputJSON[idx+len("skill://"):]
+	end := 0
+	for end < len(rest) {
+		c := rest[end]
+		if c == '"' || c == '\\' || c == ' ' || c == '\t' ||
+			c == '\n' || c == '\r' || c == '?' || c == '#' {
+			break
+		}
+		end++
+	}
+	name := strings.TrimLeft(rest[:end], "/")
+	if idx := strings.IndexByte(name, '/'); idx >= 0 {
+		name = name[:idx]
+	}
+	if name == "" {
+		return "", false
+	}
+	return name, true
 }
 
 // applyPiTokenUsage extracts the assistant message's model and

--- a/internal/parser/pi_skill_inference_test.go
+++ b/internal/parser/pi_skill_inference_test.go
@@ -1,0 +1,203 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInferPiSkillNameReadSKILLMD(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolName   string
+		inputJSON  string
+		sessionCwd string
+		want       string
+	}{
+		{
+			name:      "absolute SKILL.md read yields parent dir",
+			toolName:  "read",
+			inputJSON: `{"path":"/skills/engineering/implement-plan/SKILL.md"}`,
+			want:      "implement-plan",
+		},
+		{
+			name:      "file_path key also matches",
+			toolName:  "read",
+			inputJSON: `{"file_path":"/skills/review/SKILL.md"}`,
+			want:      "review",
+		},
+		{
+			name:      "tilde path resolves to parent dir",
+			toolName:  "read",
+			inputJSON: `{"path":"~/.pi/agent/skills/create-plan/SKILL.md"}`,
+			want:      "create-plan",
+		},
+		{
+			name:       "relative path resolves against session cwd",
+			toolName:   "read",
+			inputJSON:  `{"path":"skills/engineering/create-plan/SKILL.md"}`,
+			sessionCwd: "/worktrees/demo",
+			want:       "create-plan",
+		},
+		{
+			name:      "plain source file read is not a skill",
+			toolName:  "read",
+			inputJSON: `{"path":"/repo/auth.go"}`,
+			want:      "",
+		},
+		{
+			name:      "glob path is not a skill",
+			toolName:  "read",
+			inputJSON: `{"path":"/skills/*/SKILL.md"}`,
+			want:      "",
+		},
+		{
+			name:      "non-read tools stay unattributed",
+			toolName:  "edit",
+			inputJSON: `{"path":"/skills/foo/SKILL.md"}`,
+			want:      "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferPiSkillName(tt.toolName, tt.inputJSON, tt.sessionCwd)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInferPiSkillNameReadFrontmatter(t *testing.T) {
+	skillDir := filepath.Join(t.TempDir(), "deploy-docs")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte(
+		"---\nname: deploy-docs\ndescription: Deployment guides\n---\n\nbody\n",
+	), 0o644))
+
+	got := inferPiSkillName(
+		"read", `{"path":"/opt/skills/deploy-docs/SKILL.md"}`, "",
+	)
+	assert.Equal(t, "deploy-docs", got)
+}
+
+func TestInferPiSkillNameSkillURI(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		inputJSON string
+		want      string
+	}{
+		{
+			name:      "read with skill path URI",
+			toolName:  "read",
+			inputJSON: `{"path":"skill://create-plan/SKILL.md"}`,
+			want:      "create-plan",
+		},
+		{
+			name:      "leading slashes are trimmed",
+			toolName:  "read",
+			inputJSON: `{"path":"skill:///review-pr"}`,
+			want:      "review-pr",
+		},
+		{
+			name:      "bare name is attributed",
+			toolName:  "read",
+			inputJSON: `{"path":"skill://coding-standards"}`,
+			want:      "coding-standards",
+		},
+		{
+			name:      "URI in any string field is attributed",
+			toolName:  "view",
+			inputJSON: `{"url":"skill://deploy-docs"}`,
+			want:      "deploy-docs",
+		},
+		{
+			name:      "query suffix is stripped",
+			toolName:  "read",
+			inputJSON: `{"path":"skill://create-plan?section=1"}`,
+			want:      "create-plan",
+		},
+		{
+			name:      "empty name falls through",
+			toolName:  "read",
+			inputJSON: `{"path":"skill:///"}`,
+			want:      "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferPiSkillName(tt.toolName, tt.inputJSON, "")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInferPiSkillNameShellCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolName   string
+		inputJSON  string
+		sessionCwd string
+		want       string
+	}{
+		{
+			name:       "cat of a SKILL.md",
+			toolName:   "bash",
+			inputJSON:  `{"command":"cat skills/review/SKILL.md"}`,
+			sessionCwd: "/worktrees/demo",
+			want:       "review",
+		},
+		{
+			name:       "grep of a SKILL.md",
+			toolName:   "bash",
+			inputJSON:  `{"command":"grep -n frontmatter /skills/review/SKILL.md"}`,
+			sessionCwd: "",
+			want:       "review",
+		},
+		{
+			name:       "sed without -i is a read",
+			toolName:   "bash",
+			inputJSON:  `{"command":"sed -n 1,10p /skills/review/SKILL.md"}`,
+			sessionCwd: "",
+			want:       "review",
+		},
+		{
+			name:       "relative path resolves against session cwd",
+			toolName:   "bash",
+			inputJSON:  `{"command":"cat ./skills/create-plan/SKILL.md"}`,
+			sessionCwd: "/worktrees/demo",
+			want:       "create-plan",
+		},
+		{
+			name:       "unrelated command is untouched",
+			toolName:   "bash",
+			inputJSON:  `{"command":"go test ./..."}`,
+			sessionCwd: "/worktrees/demo",
+			want:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferPiSkillName(tt.toolName, tt.inputJSON, tt.sessionCwd)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPiProviderAttributesSkillNames(t *testing.T) {
+	fixturePath := createTestFile(
+		t, "pi-session.jsonl",
+		loadFixture(t, "pi/session.jsonl"),
+	)
+	sess, msgs, err := parsePiTestSession(t, fixturePath, "", "local")
+	require.NoError(t, err)
+
+	// The fixture header carries cwd /Users/alice/code/my-project and
+	// entry-2 holds one read tool call with file_path auth.go. No
+	// SKILL.md is involved, so no skill name may be attributed.
+	assert.Equal(t, "", msgs[1].ToolCalls[0].SkillName)
+	assert.NotEmpty(t, sess.Cwd)
+}

--- a/internal/parser/pi_skill_inference_test.go
+++ b/internal/parser/pi_skill_inference_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,13 +76,13 @@ func TestInferPiSkillNameReadFrontmatter(t *testing.T) {
 	require.NoError(t, os.MkdirAll(skillDir, 0o755))
 	skillFile := filepath.Join(skillDir, "SKILL.md")
 	require.NoError(t, os.WriteFile(skillFile, []byte(
-		"---\nname: deploy-docs\ndescription: Deployment guides\n---\n\nbody\n",
+		"---\nname: canonical-deploy-docs\ndescription: Deployment guides\n---\n\nbody\n",
 	), 0o644))
 
 	got := inferPiSkillName(
-		"read", `{"path":"/opt/skills/deploy-docs/SKILL.md"}`, "",
+		"read", `{"path":`+strconv.Quote(skillFile)+`}`, "",
 	)
-	assert.Equal(t, "deploy-docs", got)
+	assert.Equal(t, "canonical-deploy-docs", got)
 }
 
 func TestInferPiSkillNameSkillURI(t *testing.T) {
@@ -97,22 +99,22 @@ func TestInferPiSkillNameSkillURI(t *testing.T) {
 			want:      "create-plan",
 		},
 		{
-			name:      "leading slashes are trimmed",
-			toolName:  "read",
-			inputJSON: `{"path":"skill:///review-pr"}`,
-			want:      "review-pr",
-		},
-		{
 			name:      "bare name is attributed",
 			toolName:  "read",
 			inputJSON: `{"path":"skill://coding-standards"}`,
 			want:      "coding-standards",
 		},
 		{
-			name:      "URI in any string field is attributed",
-			toolName:  "view",
-			inputJSON: `{"url":"skill://deploy-docs"}`,
-			want:      "deploy-docs",
+			name:      "percent-encoded namespace is decoded",
+			toolName:  "read",
+			inputJSON: `{"path":"skill://superpowers%3Abrainstorming"}`,
+			want:      "superpowers:brainstorming",
+		},
+		{
+			name:      "URI mention in a non-read tool is not a skill load",
+			toolName:  "write",
+			inputJSON: `{"path":"notes.md","content":"See skill://deploy-docs"}`,
+			want:      "",
 		},
 		{
 			name:      "query suffix is stripped",
@@ -188,16 +190,13 @@ func TestInferPiSkillNameShellCommand(t *testing.T) {
 }
 
 func TestPiProviderAttributesSkillNames(t *testing.T) {
-	fixturePath := createTestFile(
-		t, "pi-session.jsonl",
-		loadFixture(t, "pi/session.jsonl"),
-	)
-	sess, msgs, err := parsePiTestSession(t, fixturePath, "", "local")
-	require.NoError(t, err)
-
-	// The fixture header carries cwd /Users/alice/code/my-project and
-	// entry-2 holds one read tool call with file_path auth.go. No
-	// SKILL.md is involved, so no skill name may be attributed.
-	assert.Equal(t, "", msgs[1].ToolCalls[0].SkillName)
-	assert.NotEmpty(t, sess.Cwd)
+	_, msgs := parsePiLikeTestSession(t, AgentPi, strings.Join([]string{
+		`{"type":"session","version":3,"id":"skill-test","timestamp":"2026-09-03T10:00:00Z","cwd":"/worktrees/demo"}`,
+		`{"type":"message","id":"entry-1","parentId":null,"timestamp":"2026-09-03T10:00:01Z","message":{"role":"user","content":[{"type":"text","text":"Review this change"}]}}`,
+		`{"type":"message","id":"entry-2","parentId":"entry-1","timestamp":"2026-09-03T10:00:02Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"tool-1","name":"read","arguments":{"path":"skills/code-review/SKILL.md"}},{"type":"toolCall","id":"tool-2","name":"read","arguments":{"path":"auth.go"}}]}}`,
+	}, "\n"))
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 2)
+	assert.Equal(t, "code-review", msgs[1].ToolCalls[0].SkillName)
+	assert.Empty(t, msgs[1].ToolCalls[1].SkillName)
 }


### PR DESCRIPTION
Top Skills analytics is empty for Pi sessions because the Pi parser never
populates `ParsedToolCall.SkillName`. Pi has no dedicated skill tool: a
native skill load is emitted as an ordinary `read` tool call whose path
points at the skill's `SKILL.md` (resolved from many roots:
`~/.pi/agent/skills`, project `.pi/skills`, `.agents/skills`, package
`skills/`, `--skill <path>`), or, in newer OMP builds, at a
`skill://<name>` URI. Without attribution these calls inflate the Read
tool count and leave the Skills dimension empty.

This mirrors the OpenCode gap fixed in #1040/#1041/#1042, applied to the
Pi parser.

## What the code does now

`parsePiAssistantMessage` receives the session working directory (already
parsed from the session header) and runs a new `inferPiSkillName` helper
on every tool call. Attribution is additive: every call that does not
look like a skill load keeps an empty `SkillName`, exactly as before.

The helper attributes three shapes:

- `skill://<name>` URIs are scanned from the input JSON and reduced to
  the URI's first path segment, so `skill://create-plan/SKILL.md`
  attributes `create-plan`.
- Read calls whose `path`/`file_path` value ends in `SKILL.md` resolve
  through the shared inference helpers. Pi's read input carries no
  cwd/workdir key, so the session working directory is tried first and
  relative `SKILL.md` paths resolve against it; this mirrors
  `inferOpenCodeSkillName`.
- Shell commands route through the existing Codex shell-command
  heuristic (`inferCodexSkillNameWithBase`) with the session working
  directory as the fallback base, the same way the Codex and OpenCode
  parsers thread their session cwd.

`dataVersion` is bumped to 97 so existing Pi sessions re-parse on the
next sync and backfill skill attribution. The resync is the standard
non-destructive rebuild: no session data is lost.

## Limits

- The URI scan is a substring scan of the raw input JSON, so a skill
  name containing JSON-escaped or control characters would truncate.
  Real skill names are plain identifiers, so this is not expected in
  practice.
- A URI extraction win means a `read` of a path that is *also* a
  SKILL.md path but arrives with a `skill://` URI inside another field
  attributes from the URI. Both routes describe the same skill load, so
  the attribution is the same in practice.

## Where to look

- `inferPiSkillName` / `piSkillURISkillName` in `internal/parser/pi.go`
- Data-version bump in `internal/db/db.go`
- Table-driven tests in `internal/parser/pi_skill_inference_test.go`
  covering SKILL.md reads (absolute, tilde, relative-to-cwd,
  frontmatter-named), `skill://` URIs (path form, bare form, other
  fields, query suffix, empty-name fallthrough), shell commands
  (cat/grep/sed, relative paths, non-skill commands), and a
  session-level fixture test asserting non-skill reads stay
  unattributed.

Fixes #1608
