### PR TITLE
fix: blank invalid token_usage instead of panicking the messages API on every backend

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1833,6 +1833,7 @@ func sanitizeBreakdownLines(s sync.SanitizeStats) []string {
 		{"tokens clamped", s.TokensClamped},
 		{"role coerced", s.RoleCoerced},
 		{"timestamps blanked", s.TimestampsBlanked},
+		{"token usage blanked", s.TokenUsageBlanked},
 	}
 	var out []string
 	for _, c := range cats {

--- a/frontend/src/lib/api/generated/models/SyncSanitizeStats.ts
+++ b/frontend/src/lib/api/generated/models/SyncSanitizeStats.ts
@@ -7,6 +7,7 @@ export type SyncSanitizeStats = {
   model_clamped?: number;
   role_coerced?: number;
   timestamps_blanked?: number;
+  token_usage_blanked?: number;
   tokens_clamped?: number;
 };
 

--- a/internal/artifact/export_test.go
+++ b/internal/artifact/export_test.go
@@ -441,7 +441,16 @@ func TestExportContinuesPastDeterministicRejection(t *testing.T) {
 	assert.Contains(t, rejection.Error, "message count exceeds 2")
 }
 
-func TestExportContinuesPastInvalidTokenUsage(t *testing.T) {
+// Invalid token usage no longer costs a session its artifact export. The
+// db layer now blanks a malformed usage blob at the write seam
+// (ValidateAndSanitize) and again on read (scanMessages, which this export
+// path loads through), so the value can never reach the segment encoder.
+// Previously one truncated usage object -- the same corruption that
+// panicked GET /api/v1/sessions/{id}/messages -- rejected the whole
+// session here. Export continuing past a genuinely un-encodable session
+// stays covered by TestExportContinuesPastInvalidManifestValue and
+// TestExportContinuesPastDeterministicRejection.
+func TestExportSanitizesInvalidTokenUsage(t *testing.T) {
 	t.Parallel()
 
 	database := testExportDB(t)
@@ -457,18 +466,24 @@ func TestExportContinuesPastInvalidTokenUsage(t *testing.T) {
 		t.Context(), database, store, ExportOptions{Origin: contractOrigin},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, 1, result.ExportedSessions)
-	assert.Equal(t, 1, result.RejectedSessions)
+	assert.Equal(t, 2, result.ExportedSessions)
+	assert.Equal(t, 0, result.RejectedSessions)
 	checkpoint := latestStoreCheckpointForTest(t, store, contractOrigin)
-	assert.NotContains(t, checkpoint.Sessions, contractOrigin+"~invalid")
+	assert.Contains(t, checkpoint.Sessions, contractOrigin+"~invalid")
 	assert.Contains(t, checkpoint.Sessions, contractOrigin+"~valid")
 	pending, err := database.PendingArtifactExports(t.Context(), 10)
 	require.NoError(t, err)
 	assert.Empty(t, pending)
-	rejection, ok, err := database.GetArtifactExportRejection(t.Context(), "invalid")
+	_, ok, err := database.GetArtifactExportRejection(t.Context(), "invalid")
 	require.NoError(t, err)
-	require.True(t, ok)
-	assert.Contains(t, rejection.Error, "encoding message segment at ordinal 0")
+	assert.False(t, ok, "a sanitized usage blob must not reject the session")
+
+	// The message itself survives; only the unusable metadata is dropped.
+	msgs, err := database.GetAllMessages(t.Context(), "invalid")
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "bad usage", msgs[0].Content)
+	assert.Empty(t, string(msgs[0].TokenUsage))
 }
 
 func TestExportContinuesPastInvalidManifestValue(t *testing.T) {

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2139,7 +2139,7 @@ func scanMessages(rows *sql.Rows) ([]Message, error) {
 		if err != nil {
 			return nil, fmt.Errorf("scanning message: %w", err)
 		}
-		m.TokenUsage = decodeStoredTokenUsage(tokenUsage)
+		m.TokenUsage = DecodeStoredTokenUsage(tokenUsage)
 		msgs = append(msgs, m)
 	}
 	return msgs, rows.Err()
@@ -2742,7 +2742,7 @@ func (db *DB) GetMessageByOrdinal(
 	if err != nil {
 		return nil, err
 	}
-	m.TokenUsage = decodeStoredTokenUsage(tokenUsage)
+	m.TokenUsage = DecodeStoredTokenUsage(tokenUsage)
 	return &m, nil
 }
 
@@ -2834,7 +2834,7 @@ func resolveToolResultEvents(msgs []Message) []toolResultEventRow {
 	return rows
 }
 
-// decodeStoredTokenUsage converts a stored token_usage column into a
+// DecodeStoredTokenUsage converts a stored token_usage column into a
 // jsontext.Value, dropping the value when it is not valid JSON.
 //
 // jsontext.Value defers parsing to marshal time, so a malformed blob is
@@ -2850,7 +2850,13 @@ func resolveToolResultEvents(msgs []Message) []toolResultEventRow {
 // must not trust the column. Dropping only the unusable metadata keeps the
 // rest of the message intact, matching the sanitize-don't-drop policy in
 // validate.go.
-func decodeStoredTokenUsage(raw string) jsontext.Value {
+//
+// Exported because every backend that serves messages needs the identical
+// guard: a PostgreSQL or DuckDB mirror populated before the write-side fix
+// still holds the malformed blob, and pg serve / duckdb serve reach the
+// same response encoder. See internal/postgres/messages.go and
+// internal/duckdb/messages.go.
+func DecodeStoredTokenUsage(raw string) jsontext.Value {
 	if raw == "" {
 		return nil
 	}

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2139,9 +2139,7 @@ func scanMessages(rows *sql.Rows) ([]Message, error) {
 		if err != nil {
 			return nil, fmt.Errorf("scanning message: %w", err)
 		}
-		if tokenUsage != "" {
-			m.TokenUsage = jsontext.Value(tokenUsage)
-		}
+		m.TokenUsage = decodeStoredTokenUsage(tokenUsage)
 		msgs = append(msgs, m)
 	}
 	return msgs, rows.Err()
@@ -2744,9 +2742,7 @@ func (db *DB) GetMessageByOrdinal(
 	if err != nil {
 		return nil, err
 	}
-	if tokenUsage != "" {
-		m.TokenUsage = jsontext.Value(tokenUsage)
-	}
+	m.TokenUsage = decodeStoredTokenUsage(tokenUsage)
 	return &m, nil
 }
 
@@ -2836,4 +2832,31 @@ func resolveToolResultEvents(msgs []Message) []toolResultEventRow {
 		}
 	}
 	return rows
+}
+
+// decodeStoredTokenUsage converts a stored token_usage column into a
+// jsontext.Value, dropping the value when it is not valid JSON.
+//
+// jsontext.Value defers parsing to marshal time, so a malformed blob is
+// stored without complaint and only fails when the API encodes the
+// response. internal/server installs no recover(), so that surfaced as an
+// unrecovered handler panic that dropped the connection
+// (ERR_EMPTY_RESPONSE) on GET /api/v1/sessions/{id}/messages, while the
+// HTML export of the same session still rendered because it never
+// marshals this field.
+//
+// ValidateAndSanitize now blanks invalid usage at the write seam, but rows
+// written before that guard existed are still on disk, so the read path
+// must not trust the column. Dropping only the unusable metadata keeps the
+// rest of the message intact, matching the sanitize-don't-drop policy in
+// validate.go.
+func decodeStoredTokenUsage(raw string) jsontext.Value {
+	if raw == "" {
+		return nil
+	}
+	v := jsontext.Value(raw)
+	if !v.IsValid() {
+		return nil
+	}
+	return v
 }

--- a/internal/db/messages_invalid_token_usage_test.go
+++ b/internal/db/messages_invalid_token_usage_test.go
@@ -1,0 +1,112 @@
+package db
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// corruptTokenUsage writes a malformed token_usage blob straight to the
+// row, bypassing the sanitize pass. This reproduces a database that was
+// already populated before that pass validated the field -- the state a
+// user upgrading into the fix actually has on disk.
+func corruptTokenUsage(t *testing.T, d *DB, sessionID string, ordinal int, raw string) {
+	t.Helper()
+	_, err := d.getWriter().Exec(
+		`UPDATE messages SET token_usage = ? WHERE session_id = ? AND ordinal = ?`,
+		raw, sessionID, ordinal,
+	)
+	require.NoError(t, err)
+}
+
+func seedMessageWithUsage(t *testing.T, d *DB) {
+	t.Helper()
+	insertSession(t, d, "s1", "proj")
+	insertMessages(t, d, Message{
+		SessionID:     "s1",
+		Ordinal:       0,
+		Role:          "assistant",
+		Content:       "hi",
+		ContentLength: 2,
+		Model:         "claude-opus-4",
+		TokenUsage:    jsontext.Value(`{"input_tokens":50}`),
+	})
+}
+
+// The read path must not hand an unmarshalable row to the API. Without a
+// guard the invalid blob reaches the response encoder, which panics with
+// "cannot marshal from Go jsontext.Value: unexpected EOF" and, since
+// internal/server installs no recover(), drops the connection outright
+// (ERR_EMPTY_RESPONSE in the browser) while the HTML export of the same
+// session still renders.
+func TestReadPathDropsInvalidTokenUsage(t *testing.T) {
+	truncated := `{"input_tokens":4,"cache_read_input_tokens":123`
+
+	for _, tc := range []struct {
+		name string
+		read func(t *testing.T, d *DB) []Message
+	}{
+		{
+			name: "GetMessages",
+			read: func(t *testing.T, d *DB) []Message {
+				got, err := d.GetMessages(context.Background(), "s1", 0, 100, true)
+				require.NoError(t, err)
+				return got
+			},
+		},
+		{
+			name: "GetAllMessages",
+			read: func(t *testing.T, d *DB) []Message {
+				got, err := d.GetAllMessages(context.Background(), "s1")
+				require.NoError(t, err)
+				return got
+			},
+		},
+		{
+			name: "GetMessagesWindow",
+			read: func(t *testing.T, d *DB) []Message {
+				from := 0
+				got, err := d.GetMessagesWindow(context.Background(), "s1",
+					MessageWindow{Limit: 100, Asc: true, From: &from})
+				require.NoError(t, err)
+				return got
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := testDB(t)
+			seedMessageWithUsage(t, d)
+			corruptTokenUsage(t, d, "s1", 0, truncated)
+
+			got := tc.read(t, d)
+			require.Len(t, got, 1)
+			assert.Empty(t, string(got[0].TokenUsage),
+				"invalid token_usage must not reach the caller")
+
+			// The real regression: the row must be marshalable.
+			_, err := json.Marshal(struct {
+				Messages []Message `json:"messages"`
+			}{Messages: got})
+			require.NoError(t, err)
+
+			// Everything else on the row survives.
+			assert.Equal(t, "hi", got[0].Content)
+			assert.Equal(t, "claude-opus-4", got[0].Model)
+		})
+	}
+}
+
+// Valid usage must still round-trip untouched.
+func TestReadPathPreservesValidTokenUsage(t *testing.T) {
+	d := testDB(t)
+	seedMessageWithUsage(t, d)
+
+	got, err := d.GetAllMessages(context.Background(), "s1")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.JSONEq(t, `{"input_tokens":50}`, string(got[0].TokenUsage))
+}

--- a/internal/db/validate.go
+++ b/internal/db/validate.go
@@ -37,9 +37,19 @@ import (
 //     blanked. Empty-string handling is preserved as-is so downstream
 //     localTime treats a blanked timestamp as invalid.
 //
-// Message.TokenUsage (jsontext.Value) and transient
-// ToolResults.ContentRaw are intentionally not run through this pass. They are
-// raw provider payloads, not persisted display text. Persisted result content
+// Message.TokenUsage (jsontext.Value) is a raw provider payload, so it is
+// not run through the text contract below -- but it IS checked for JSON
+// validity and blanked when malformed. jsontext.Value defers parsing to
+// marshal time, so an invalid blob (e.g. a truncated gjson raw slice from a
+// torn read of a JSONL line still being written) is stored without
+// complaint and only fails much later, when the API marshals it. With no
+// recover() in internal/server that became an unrecovered handler panic and
+// a dropped connection on GET /api/v1/sessions/{id}/messages, while the
+// HTML export of the same session still rendered because it never marshals
+// the field. Blanking here follows the sanitize-don't-drop policy: the
+// message keeps its content and only the unusable metadata is cleared.
+// Transient ToolResults.ContentRaw remains outside this pass. It is a
+// raw provider payload, not persisted display text. Persisted result content
 // (tool_calls.result_content and tool_result_events.content) follows the same
 // text contract as Message.Content, with length fields reduced by the
 // stripped-byte delta so re-ingest rewrites historical poison rows into the
@@ -101,6 +111,7 @@ type ValidationStats struct {
 	TokensClamped        int
 	RoleCoerced          int
 	TimestampsBlanked    int
+	TokenUsageBlanked    int
 }
 
 // add accumulates another stats value into the receiver.
@@ -110,6 +121,7 @@ func (s *ValidationStats) add(o ValidationStats) {
 	s.TokensClamped += o.TokensClamped
 	s.RoleCoerced += o.RoleCoerced
 	s.TimestampsBlanked += o.TimestampsBlanked
+	s.TokenUsageBlanked += o.TokenUsageBlanked
 }
 
 // ValidateAndSanitize applies the central validation contract in place
@@ -161,6 +173,16 @@ func SanitizeMessage(m *Message) ValidationStats {
 	if !validMessageRole(m.Role) {
 		m.Role = ""
 		stats.RoleCoerced++
+	}
+
+	// Parsers store the provider's raw usage object (e.g. gjson's .Raw in
+	// extractClaudeTokenFields) without validating it. jsontext.Value only
+	// re-parses at marshal time, so a malformed blob survives the write and
+	// detonates in the API response instead. Blank it here, at the shared
+	// write seam, so every agent and every write path is covered.
+	if len(m.TokenUsage) > 0 && !m.TokenUsage.IsValid() {
+		m.TokenUsage = nil
+		stats.TokenUsageBlanked++
 	}
 
 	// Adjust ContentLength by the DELTA of bytes the sanitizer removed

--- a/internal/db/validate_token_usage_test.go
+++ b/internal/db/validate_token_usage_test.go
@@ -1,0 +1,113 @@
+package db
+
+import (
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A truncated token_usage blob (produced by a torn read of a JSONL line
+// still being written) is stored verbatim by the parsers, which use
+// gjson's raw slice without checking validity. It only fails later, when
+// the API marshals the response, because jsontext.Value re-parses its
+// bytes at marshal time. That surfaced as an unrecovered handler panic
+// and a dropped connection (ERR_EMPTY_RESPONSE) on
+// GET /api/v1/sessions/{id}/messages.
+func TestSanitizeMessageBlanksInvalidTokenUsage(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		usage     string
+		want      string
+		wantCount int
+	}{
+		{
+			name:  "valid usage preserved",
+			usage: `{"input_tokens":4,"output_tokens":9}`,
+			want:  `{"input_tokens":4,"output_tokens":9}`,
+		},
+		{
+			name:  "empty usage preserved",
+			usage: "",
+			want:  "",
+		},
+		{
+			name:      "truncated object blanked",
+			usage:     `{"input_tokens":4,"cache_read_input_tokens":123`,
+			want:      "",
+			wantCount: 1,
+		},
+		{
+			name:      "trailing garbage blanked",
+			usage:     `{"input_tokens":4} trailing`,
+			want:      "",
+			wantCount: 1,
+		},
+		{
+			name:      "non-json blanked",
+			usage:     `not json at all`,
+			want:      "",
+			wantCount: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Message{Role: "assistant"}
+			if tc.usage != "" {
+				m.TokenUsage = jsontext.Value(tc.usage)
+			}
+			stats := SanitizeMessage(&m)
+			assert.Equal(t, tc.want, string(m.TokenUsage))
+			assert.Equal(t, tc.wantCount, stats.TokenUsageBlanked)
+		})
+	}
+}
+
+// Sanitizing must leave every row marshalable, since that is the failure
+// the pass exists to prevent.
+func TestSanitizeMessageLeavesRowMarshalable(t *testing.T) {
+	m := Message{
+		Role:       "assistant",
+		TokenUsage: jsontext.Value(`{"input_tokens":4,"cache_read_input_tokens":123`),
+	}
+	_, err := json.Marshal(struct {
+		Messages []Message `json:"messages"`
+	}{Messages: []Message{m}})
+	require.Error(t, err, "precondition: invalid usage must fail to marshal")
+
+	SanitizeMessage(&m)
+
+	_, err = json.Marshal(struct {
+		Messages []Message `json:"messages"`
+	}{Messages: []Message{m}})
+	require.NoError(t, err)
+}
+
+// ValidateAndSanitize is the seam every write path shares, so the guard
+// must hold there and not only in SanitizeMessage.
+func TestValidateAndSanitizeBlanksInvalidTokenUsage(t *testing.T) {
+	msgs := []Message{
+		{Role: "assistant", TokenUsage: jsontext.Value(`{"input_tokens":1`)},
+		{Role: "assistant", TokenUsage: jsontext.Value(`{"input_tokens":2}`)},
+	}
+	stats := ValidateAndSanitize(nil, msgs, nil)
+	assert.Equal(t, 1, stats.TokenUsageBlanked)
+	assert.Empty(t, string(msgs[0].TokenUsage))
+	assert.Equal(t, `{"input_tokens":2}`, string(msgs[1].TokenUsage))
+}
+
+// The pass must stay idempotent: running it over its own output produces
+// no further fixes (see the idempotency invariant in validate.go).
+func TestSanitizeMessageTokenUsageIdempotent(t *testing.T) {
+	m := Message{
+		Role:       "assistant",
+		TokenUsage: jsontext.Value(`{"input_tokens":4,"cache_read`),
+	}
+	first := SanitizeMessage(&m)
+	require.Equal(t, 1, first.TokenUsageBlanked)
+
+	second := SanitizeMessage(&m)
+	assert.Equal(t, 0, second.TokenUsageBlanked)
+	assert.Empty(t, string(m.TokenUsage))
+}

--- a/internal/db/validate_token_usage_test.go
+++ b/internal/db/validate_token_usage_test.go
@@ -111,3 +111,30 @@ func TestSanitizeMessageTokenUsageIdempotent(t *testing.T) {
 	assert.Equal(t, 0, second.TokenUsageBlanked)
 	assert.Empty(t, string(m.TokenUsage))
 }
+
+// DecodeStoredTokenUsage is exported because every backend that serves
+// messages needs the identical guard (internal/postgres/messages.go,
+// internal/duckdb/messages.go), so its contract is pinned here.
+func TestDecodeStoredTokenUsage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty yields nil", raw: "", want: ""},
+		{name: "valid object preserved", raw: `{"input_tokens":4}`, want: `{"input_tokens":4}`},
+		{name: "valid array preserved", raw: `[1,2]`, want: `[1,2]`},
+		{name: "truncated object dropped", raw: `{"input_tokens":4`, want: ""},
+		{name: "trailing garbage dropped", raw: `{"a":1} x`, want: ""},
+		{name: "non-json dropped", raw: `nope`, want: ""},
+		{name: "bare whitespace dropped", raw: `   `, want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DecodeStoredTokenUsage(tc.raw)
+			assert.Equal(t, tc.want, string(got))
+			if tc.want == "" {
+				assert.Nil(t, got, "dropped values must be nil, not empty non-nil")
+			}
+		})
+	}
+}

--- a/internal/duckdb/messages.go
+++ b/internal/duckdb/messages.go
@@ -293,7 +293,11 @@ func scanMessages(rows *sql.Rows) ([]db.Message, error) {
 			return nil, fmt.Errorf("scanning duckdb message: %w", err)
 		}
 		m.Timestamp = formatDBTime(ts)
-		m.TokenUsage = []byte(tokenUsage)
+		// A mirror built before the write-side guard existed can still
+		// hold a malformed usage blob, and duckdb serve reaches the same
+		// response encoder that panicked on it (see
+		// db.DecodeStoredTokenUsage).
+		m.TokenUsage = db.DecodeStoredTokenUsage(tokenUsage)
 		msgs = append(msgs, m)
 	}
 	return msgs, rows.Err()

--- a/internal/duckdb/messages_invalid_token_usage_test.go
+++ b/internal/duckdb/messages_invalid_token_usage_test.go
@@ -1,0 +1,73 @@
+//go:build !(windows && arm64)
+
+package duckdb
+
+import (
+	"context"
+	json "encoding/json/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// A DuckDB mirror built before the write-side guard existed still holds
+// whatever malformed token_usage blob was pushed into it, and duckdb serve
+// reaches the same response encoder that panicked on SQLite:
+//
+//	json: cannot marshal from Go jsontext.Value: unexpected EOF within
+//	"/messages/0/token_usage"
+//
+// The mirror is corrupted directly here because the SQLite write path now
+// sanitizes the value before it could ever be pushed.
+func TestDuckGetMessagesDropsInvalidStoredTokenUsage(t *testing.T) {
+	ctx := context.Background()
+	store := newDuckWindowStore(t, func(local *db.DB) {
+		seedDuckWindowMessages(t, local, "sInvalidUsage")
+	})
+
+	_, err := store.DB().ExecContext(ctx,
+		`UPDATE messages SET token_usage = ?
+		 WHERE session_id = ? AND ordinal = ?`,
+		`{"input_tokens":4,"cache_read_input_tokens":123`, "sInvalidUsage", 0,
+	)
+	require.NoError(t, err)
+
+	msgs, err := store.GetMessages(ctx, "sInvalidUsage", 0, 10, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, msgs)
+	assert.Empty(t, string(msgs[0].TokenUsage),
+		"invalid token_usage must not reach the caller")
+
+	// The real regression: the row must be marshalable.
+	_, err = json.Marshal(struct {
+		Messages []db.Message `json:"messages"`
+	}{Messages: msgs})
+	require.NoError(t, err)
+
+	// Everything else on the row survives.
+	assert.Equal(t, 0, msgs[0].Ordinal)
+	assert.NotEmpty(t, msgs[0].Content)
+}
+
+// Valid usage must still round-trip through the mirror untouched.
+func TestDuckGetMessagesPreservesValidStoredTokenUsage(t *testing.T) {
+	ctx := context.Background()
+	store := newDuckWindowStore(t, func(local *db.DB) {
+		seedDuckWindowMessages(t, local, "sValidUsage")
+	})
+
+	_, err := store.DB().ExecContext(ctx,
+		`UPDATE messages SET token_usage = ?
+		 WHERE session_id = ? AND ordinal = ?`,
+		`{"input_tokens":7}`, "sValidUsage", 0,
+	)
+	require.NoError(t, err)
+
+	msgs, err := store.GetMessages(ctx, "sValidUsage", 0, 10, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, msgs)
+	assert.JSONEq(t, `{"input_tokens":7}`, string(msgs[0].TokenUsage))
+}

--- a/internal/postgres/messages.go
+++ b/internal/postgres/messages.go
@@ -754,9 +754,11 @@ func scanPGMessages(rows interface {
 		if ts != nil {
 			m.Timestamp = FormatISO8601(*ts)
 		}
-		if tokenUsage != "" {
-			m.TokenUsage = []byte(tokenUsage)
-		}
+		// A mirror pushed before the write-side guard existed can still
+		// hold a malformed usage blob, and pg serve reaches the same
+		// response encoder that panicked on it (see
+		// db.DecodeStoredTokenUsage).
+		m.TokenUsage = db.DecodeStoredTokenUsage(tokenUsage)
 		msgs = append(msgs, m)
 	}
 	return msgs, rows.Err()

--- a/internal/postgres/messages_invalid_token_usage_pgtest_test.go
+++ b/internal/postgres/messages_invalid_token_usage_pgtest_test.go
@@ -1,0 +1,102 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	json "encoding/json/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// A PostgreSQL mirror pushed before the write-side guard existed still
+// holds whatever malformed token_usage blob reached it, and pg serve
+// reaches the same response encoder that panicked on SQLite:
+//
+//	json: cannot marshal from Go jsontext.Value: unexpected EOF within
+//	"/messages/0/token_usage"
+//
+// The row is written directly here because the SQLite write path now
+// sanitizes the value before it could ever be pushed.
+func TestPGGetMessagesDropsInvalidStoredTokenUsage(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	pg, err := Open(pgURL, testSchema, false)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	seedInvalidUsageRow(t, pg, "pg-invalid-usage",
+		`{"input_tokens":4,"cache_read_input_tokens":123`)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	ctx := context.Background()
+	msgs, err := store.GetMessages(ctx, "pg-invalid-usage", 0, 10, true)
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, msgs, 1)
+	assert.Empty(t, string(msgs[0].TokenUsage),
+		"invalid token_usage must not reach the caller")
+
+	// The real regression: the row must be marshalable.
+	_, err = json.Marshal(struct {
+		Messages []db.Message `json:"messages"`
+	}{Messages: msgs})
+	require.NoError(t, err)
+
+	// Everything else on the row survives.
+	assert.Equal(t, "hello", msgs[0].Content)
+	assert.Equal(t, "claude-sonnet-4-20250514", msgs[0].Model)
+}
+
+// Valid usage must still round-trip through the mirror untouched.
+func TestPGGetMessagesPreservesValidStoredTokenUsage(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	pg, err := Open(pgURL, testSchema, false)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	seedInvalidUsageRow(t, pg, "pg-valid-usage", `{"input_tokens":7}`)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	msgs, err := store.GetMessages(context.Background(), "pg-valid-usage", 0, 10, true)
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, msgs, 1)
+	assert.JSONEq(t, `{"input_tokens":7}`, string(msgs[0].TokenUsage))
+}
+
+// seedInvalidUsageRow writes one session and one message carrying the given
+// raw token_usage text, bypassing every sanitize seam.
+func seedInvalidUsageRow(t *testing.T, pg *sql.DB, sessionID, rawUsage string) {
+	t.Helper()
+	_, err := pg.Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, message_count, user_message_count
+		) VALUES ($1, 'test-machine', 'test-project', 'claude', 1, 1)
+		ON CONFLICT (id) DO UPDATE SET message_count = EXCLUDED.message_count
+	`, sessionID)
+	require.NoError(t, err, "insert session")
+
+	_, err = pg.Exec(`
+		INSERT INTO messages (
+			session_id, ordinal, role, content,
+			content_length, model, token_usage
+		) VALUES ($1, 0, 'assistant', 'hello', 5,
+			'claude-sonnet-4-20250514', $2)
+		ON CONFLICT (session_id, ordinal) DO UPDATE SET
+			token_usage = EXCLUDED.token_usage
+	`, sessionID, rawUsage)
+	require.NoError(t, err, "insert message")
+}

--- a/internal/server/messages_invalid_token_usage_test.go
+++ b/internal/server/messages_invalid_token_usage_test.go
@@ -1,0 +1,54 @@
+package server_test
+
+import (
+	"database/sql"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A malformed token_usage blob used to take the whole endpoint down.
+// jsontext.Value defers parsing to marshal time, so the bad value survived
+// the query and detonated in the response encoder. internal/server
+// installs no recover(), so net/http closed the connection without a
+// response -- ERR_EMPTY_RESPONSE in the browser, a blank transcript in the
+// UI, while exporting the same session to HTML still rendered its content
+// because the export path never marshals this field.
+func TestGetMessages_InvalidStoredTokenUsageDoesNotBreakResponse(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "my-app", 3)
+	te.seedMessages(t, "s1", 3)
+
+	// Corrupt the row behind the DB layer's back, reproducing a database
+	// populated before the write-side guard existed.
+	corruptStoredTokenUsage(t, filepath.Join(te.dataDir, "test.db"), "s1", 0,
+		`{"input_tokens":4,"cache_read_input_tokens":123`)
+
+	w := te.get(t, "/api/v1/sessions/s1/messages")
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := decode[messageListResponse](t, w)
+	assert.Len(t, resp.Messages, 3,
+		"every message must still be served; only the bad metadata is dropped")
+}
+
+func corruptStoredTokenUsage(
+	t *testing.T, dbPath, sessionID string, ordinal int, raw string,
+) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	res, err := conn.Exec(
+		`UPDATE messages SET token_usage = ? WHERE session_id = ? AND ordinal = ?`,
+		raw, sessionID, ordinal,
+	)
+	require.NoError(t, err)
+	affected, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected, "expected to corrupt exactly one row")
+}

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -188,12 +188,13 @@ type SanitizeStats struct {
 	TokensClamped        int `json:"tokens_clamped,omitempty"`
 	RoleCoerced          int `json:"role_coerced,omitempty"`
 	TimestampsBlanked    int `json:"timestamps_blanked,omitempty"`
+	TokenUsageBlanked    int `json:"token_usage_blanked,omitempty"`
 }
 
 // Total returns the sum of all sanitize fix counts.
 func (s SanitizeStats) Total() int {
 	return s.ControlCharsStripped + s.ModelClamped + s.TokensClamped +
-		s.RoleCoerced + s.TimestampsBlanked
+		s.RoleCoerced + s.TimestampsBlanked + s.TokenUsageBlanked
 }
 
 // IsZero reports whether no sanitize fixes were recorded.
@@ -272,6 +273,7 @@ func (a *AnomalyStats) addSanitize(v validationStats) {
 	a.Sanitize.TokensClamped += v.TokensClamped
 	a.Sanitize.RoleCoerced += v.RoleCoerced
 	a.Sanitize.TimestampsBlanked += v.TimestampsBlanked
+	a.Sanitize.TokenUsageBlanked += v.TokenUsageBlanked
 }
 
 // merge folds another AnomalyStats into the receiver.
@@ -293,6 +295,7 @@ func (a *AnomalyStats) merge(o AnomalyStats) {
 	a.Sanitize.TokensClamped += o.Sanitize.TokensClamped
 	a.Sanitize.RoleCoerced += o.Sanitize.RoleCoerced
 	a.Sanitize.TimestampsBlanked += o.Sanitize.TimestampsBlanked
+	a.Sanitize.TokenUsageBlanked += o.Sanitize.TokenUsageBlanked
 }
 
 // anomalyAccumulator is the engine's per-run, concurrency-safe sink for

--- a/internal/sync/progress_token_usage_test.go
+++ b/internal/sync/progress_token_usage_test.go
@@ -1,0 +1,29 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TokenUsageBlanked must reach the CLI summary like every other sanitize
+// counter. The pass silently drops a malformed provider usage blob, and a
+// silent drop with no reporting is what made the underlying bug
+// (a panicking GET /api/v1/sessions/{id}/messages) hard to trace.
+func TestSanitizeStatsIncludesTokenUsageBlanked(t *testing.T) {
+	s := SanitizeStats{TokenUsageBlanked: 3}
+	assert.Equal(t, 3, s.Total())
+	assert.False(t, s.IsZero())
+}
+
+func TestAnomalyStatsAccumulatesTokenUsageBlanked(t *testing.T) {
+	var a AnomalyStats
+	a.addSanitize(validationStats{TokenUsageBlanked: 2})
+	a.addSanitize(validationStats{TokenUsageBlanked: 1})
+	assert.Equal(t, 3, a.Sanitize.TokenUsageBlanked)
+
+	var b AnomalyStats
+	b.merge(a)
+	assert.Equal(t, 3, b.Sanitize.TokenUsageBlanked)
+	assert.Equal(t, 3, b.Sanitize.Total())
+}


### PR DESCRIPTION
Fixes #1614.

A malformed `token_usage` blob takes down `GET /api/v1/sessions/{id}/messages`
entirely. `jsontext.Value` defers parsing to marshal time, so an invalid value
is stored without complaint and only fails when the API encodes the response:

```
json: cannot marshal from Go jsontext.Value: unexpected EOF within
"/messages/0/token_usage" after offset 396
```

`internal/server` installs no `recover()`, so `net/http` closes the connection
without a response. The session list still renders, the transcript comes back
blank, and exporting the same session to HTML still shows its content because
`humaExportSession` -> `GetAllMessages` -> `generateExportHTML` never marshals
the field. That asymmetry makes it look like a frontend rendering bug.

### Scope correction vs. the issue

Issue #1614 describes this as a SQLite-path bug. It is not — **all three
backends are affected**. The reporter was running `duckdb serve`, and
`internal/duckdb/messages.go` had no guard at all (it assigned
`[]byte(tokenUsage)` unconditionally, not even checking for empty).
`internal/postgres/messages.go` checked only for non-empty. Any mirror pushed or
built before this change still reproduces the panic through `pg serve` and
`duckdb serve`.

### Changes

**Write seam** — `ValidateAndSanitize` now blanks invalid `TokenUsage`. This is
the single path every session write passes through, so it covers every agent and
every write path (sync, upload, import) rather than only the Claude extraction
site at `internal/parser/claude.go:2671`, which stores gjson's `.Raw` verbatim.
A torn read of a JSONL line still being written yields a truncated `.Raw`;
`IsValid()` is already used for exactly this purpose in `hermes.go:899` and
`piebald.go:713`. Follows the file's stated sanitize-don't-drop policy: the
message keeps its content, only the unusable metadata is cleared.

**Read path** — `db.DecodeStoredTokenUsage` is exported and used by all three
scanners (`internal/db`, `internal/postgres`, `internal/duckdb`), so databases
and mirrors populated before the write guard render without a resync, and the
backends cannot drift again. This is the backend-parity rule in AGENTS.md.

**Observability** — `TokenUsageBlanked` is reported alongside the other
sanitize counters, so the drop shows up in the sync summary instead of being
silent. Silence is what made this hard to trace.

**Generated client** — regenerated after `token_usage_blanked` was added to
`SanitizeStats`; `npm run check:api` was failing the consistency gate.

### Behavior change worth a reviewer's attention

Invalid usage no longer rejects a session from artifact export, because the
value can no longer reach the segment encoder (`artifact_export_load.go:118`
loads through `scanMessages`). Previously one truncated blob cost the whole
session its export.

`TestExportContinuesPastInvalidTokenUsage` asserted that old behavior, so it now
describes an unreachable scenario. **I rewrote it rather than deleting it** —
it is now `TestExportSanitizesInvalidTokenUsage` and asserts the new outcome.
Export continuing past a genuinely un-encodable session remains covered by
`TestExportContinuesPastInvalidManifestValue` and
`TestExportContinuesPastDeterministicRejection`, both untouched and passing.
This is the one change here that flips an existing assertion, so it deserves
the closest look.

### Tests

Regression coverage at all three backends, each seeding the store directly
because the write seam now sanitizes the value before it could reach a mirror:

- `internal/db` — sanitize, idempotency, read-path, and `DecodeStoredTokenUsage`
  contract tests
- `internal/server` — endpoint returns 200 instead of panicking
- `internal/duckdb` — corrupts the mirror after push
- `internal/postgres` — writes the row directly (`pgtest` tag)

Every one of them was confirmed to **fail with its guard reverted**, reproducing
`cannot marshal from Go jsontext.Value: unexpected EOF`, so none are tautological.

### Verification

| Check | Result |
| --- | --- |
| `go vet` | clean |
| `make test-short` | 48 packages passing |
| `make test-postgres` | passing against a real PostgreSQL instance |
| frontend `vitest` | 159 files / 2457 tests passing |
| `npm run check:api` | exit 0 |

One pre-existing failure is unrelated and untouched by this change:
`cmd/agentsview TestRunDaemonArtifactExchangeConnectsToIPv6LocalhostListener`.
It is environmental — the test listens on `[::1]` but rewrites the endpoint host
to `localhost`, and on hosts whose `/etc/hosts` maps `localhost` to `127.0.0.1`
only (the Debian/Ubuntu default, where `::1` is named `ip6-localhost`) the dial
lands where nothing is listening. Its skip guard covers IPv6 *listening* being
unavailable, not resolution. It fails identically at tag `v0.41.1`.

### Workaround for affected users on an existing install

The read-side guard means no data surgery is needed — but for anyone pinned to a
released build, blank the unparseable rows in whichever store is being served
(`sessions.db` for `serve`, `sessions.duckdb` for `duckdb serve`):

```sql
UPDATE messages SET token_usage = ''
WHERE token_usage != '' AND json_valid(token_usage) = 0;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BtS7hmmCDXSXvLRDxmkFx
