### PR TITLE
fix(cli): resolve Windows local timezone to IANA

### DIFF
--- a/cmd/agentsview/activity_test.go
+++ b/cmd/agentsview/activity_test.go
@@ -47,6 +47,33 @@ func TestActivityReportCommand_Flags(t *testing.T) {
 	}
 }
 
+func TestResolveCLIActivitySelection(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	oldLocal := time.Local
+	time.Local = time.FixedZone("Eastern Standard Time", -5*60*60)
+	t.Cleanup(func() { time.Local = oldLocal })
+	oldNow := activityReportNow
+	activityReportNow = func() time.Time {
+		return time.Date(2026, 3, 9, 2, 30, 0, 0, time.UTC)
+	}
+	t.Cleanup(func() { activityReportNow = oldNow })
+
+	query, filter, err := resolveCLIActivitySelection(ActivityReportConfig{
+		Preset: "day",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "America/New_York", query.Timezone)
+	assert.Equal(t, "America/New_York", filter.Timezone)
+	assert.Equal(t, "2026-03-08T05:00:00Z", query.RangeStart.Format(time.RFC3339))
+
+	query, filter, err = resolveCLIActivitySelection(ActivityReportConfig{
+		Preset: "day", Date: "2026-03-09", Timezone: "Europe/Berlin",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Europe/Berlin", query.Timezone)
+	assert.Equal(t, "Europe/Berlin", filter.Timezone)
+}
+
 func TestResolveActivityReportPagesSessionsWithDirectCursor(t *testing.T) {
 	dataDir := setupExportGoldenDataDir(t)
 	database := dbtest.OpenTestDBAt(t, sessionsDBPath(dataDir))

--- a/cmd/agentsview/archive_query_backend_test.go
+++ b/cmd/agentsview/archive_query_backend_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,6 +18,37 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
+
+func TestDaemonArchiveQueryBackendDefaultsMappedLocalTimezone(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	oldLocal := time.Local
+	time.Local = time.FixedZone("Eastern Standard Time", -5*60*60)
+	t.Cleanup(func() { time.Local = oldLocal })
+
+	var queries []url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.Query())
+		writeJSONResponse(w, `{"timezone":"America/New_York"}`)
+	}))
+	t.Cleanup(ts.Close)
+	backend := daemonArchiveQueryBackend{tr: transport{URL: ts.URL}}
+
+	_, err := backend.ActivityReport(context.Background(), ActivityReportConfig{
+		Preset: "day",
+	})
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	assert.Equal(t, "America/New_York", queries[0].Get("timezone"))
+	assert.Equal(t, todayIn("America/New_York"), queries[0].Get("date"))
+
+	_, err = backend.ActivityReport(context.Background(), ActivityReportConfig{
+		Preset: "day", Date: "2026-03-09", Timezone: "Europe/Berlin",
+	})
+	require.NoError(t, err)
+	require.Len(t, queries, 2)
+	assert.Equal(t, "Europe/Berlin", queries[1].Get("timezone"))
+	assert.Equal(t, "2026-03-09", queries[1].Get("date"))
+}
 
 func TestResolveArchiveQueryBackendNoSyncStartsNoSyncDaemon(t *testing.T) {
 	testDataDir(t)

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -237,13 +237,22 @@ type usageStatuslineReport struct {
 	Agent string      `json:"agent,omitempty"`
 }
 
+func usageDateForTimezone(now time.Time, timezone string) string {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	return now.In(loc).Format("2006-01-02")
+}
+
 func runUsageStatusline(cfg UsageStatuslineConfig) {
-	today := time.Now().Format("2006-01-02")
+	timezone := localTimezone()
+	today := usageDateForTimezone(time.Now(), timezone)
 	filter := db.UsageFilter{
 		From:     today,
 		To:       today,
 		Agent:    cfg.Agent,
-		Timezone: localTimezone(),
+		Timezone: timezone,
 	}
 
 	ctx := context.Background()

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -24,6 +24,7 @@ import (
 	"go.kenn.io/agentsview/internal/pricingrefresh"
 	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 // quickSyncMargin pads the mtime cutoff backward from the
@@ -653,7 +654,7 @@ func printDailyTable(
 
 // localTimezone returns the IANA name of the system's local timezone.
 func localTimezone() string {
-	return time.Now().Location().String()
+	return timeutil.LocalTimezoneOrUTC()
 }
 
 // fmtCost formats a dollar amount with two decimal places,

--- a/cmd/agentsview/usage_cursor.go
+++ b/cmd/agentsview/usage_cursor.go
@@ -12,6 +12,7 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/cursorusage"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 var newCursorUsageClient = cursorusage.NewClient
@@ -82,10 +83,7 @@ func runUsageCursor(cfg UsageCursorConfig) error {
 		}
 	}
 
-	loc, err := time.LoadLocation(localTimezone())
-	if err != nil {
-		loc = time.Local
-	}
+	loc := timeutil.LocalLocation()
 
 	start, end, err := resolveCursorUsageWindow(cfg, loc)
 	if err != nil {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -27,6 +27,7 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/parsertest"
 	"go.kenn.io/agentsview/internal/pricingrefresh"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 var goldenFixtureNow = time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
@@ -585,6 +586,106 @@ func TestFetchHTTPDailyUsage(t *testing.T) {
 	assert.Equal(t, 10, got.Totals.InputTokens)
 	assert.Equal(t, 20, got.Daily[0].OutputTokens)
 	assert.Equal(t, 1, got.SessionCounts.Total)
+}
+
+func TestLocalTimezoneWindowsNameProducesServerAcceptedUsageQuery(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	oldLocal := time.Local
+	time.Local = time.FixedZone("Eastern Standard Time", -5*60*60)
+	t.Cleanup(func() { time.Local = oldLocal })
+
+	var gotTimezones []string
+	ts := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, r *http.Request,
+	) {
+		tz := r.URL.Query().Get("timezone")
+		gotTimezones = append(gotTimezones, tz)
+		if tz == "Eastern Standard Time" {
+			w.WriteHeader(http.StatusBadRequest)
+			writeJSONResponse(w, `{"error":"invalid timezone: Eastern Standard Time"}`)
+			return
+		}
+		if tz != "America/New_York" {
+			w.WriteHeader(http.StatusBadRequest)
+			writeJSONResponse(w, `{"error":"invalid timezone: `+tz+`"}`)
+			return
+		}
+		writeJSONResponse(w, sampleDailyUsageJSON)
+	}))
+	t.Cleanup(ts.Close)
+
+	base, err := fetchHTTPDailyUsage(context.Background(), transport{URL: ts.URL}, "",
+		dailyUsageQuery{Filter: db.UsageFilter{
+			Timezone: time.Now().Location().String(),
+		}, NoDefaultRange: true})
+	assert.Equal(t, db.DailyUsageResult{}, base)
+	require.EqualError(t, err,
+		`usage summary: HTTP 400: {"error":"invalid timezone: Eastern Standard Time"}`)
+	t.Logf("base: timezone=%q error=%v", gotTimezones[0], err)
+
+	head, err := fetchHTTPDailyUsage(context.Background(), transport{URL: ts.URL}, "",
+		dailyUsageQuery{Filter: db.UsageFilter{
+			Timezone: localTimezone(),
+		}, NoDefaultRange: true})
+	require.NoError(t, err)
+	require.Len(t, head.Daily, 1)
+	assert.Equal(t, "America/New_York", gotTimezones[1])
+	t.Logf("head: timezone=%q status=200 daily=%d", gotTimezones[1], len(head.Daily))
+}
+
+func TestRunUsageDailyDefaultsToMappedLocalTimezone(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	oldLocal := time.Local
+	time.Local = time.FixedZone("Eastern Standard Time", -5*60*60)
+	t.Cleanup(func() { time.Local = oldLocal })
+	dataDir := newAgentDataDir(t)
+	var gotTimezone string
+	ts := sessionUsageRuntimeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotTimezone = r.URL.Query().Get("timezone")
+		writeJSONResponse(w, sampleDailyUsageJSON)
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	captureStdout(t, func() {
+		runUsageDaily(UsageDailyConfig{JSON: true, Offline: false})
+	})
+	assert.Equal(t, "America/New_York", gotTimezone)
+}
+
+func TestRunUsageStatuslineDefaultsToMappedLocalTimezone(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	oldLocal := time.Local
+	time.Local = time.FixedZone("Eastern Standard Time", -5*60*60)
+	t.Cleanup(func() { time.Local = oldLocal })
+	dataDir := newAgentDataDir(t)
+	var gotTimezone string
+	ts := sessionUsageRuntimeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotTimezone = r.URL.Query().Get("timezone")
+		writeJSONResponse(w, sampleDailyUsageJSON)
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	captureStdout(t, func() {
+		runUsageStatusline(UsageStatuslineConfig{JSON: true})
+	})
+	assert.Equal(t, "America/New_York", gotTimezone)
+}
+
+func TestCursorUsageWindowUsesMappedLocalTimezone(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	oldLocal := time.Local
+	time.Local = time.FixedZone("Eastern Standard Time", -5*60*60)
+	t.Cleanup(func() { time.Local = oldLocal })
+
+	loc := timeutil.LocalLocation()
+	assert.Equal(t, "America/New_York", loc.String())
+	start, end, err := resolveCursorUsageWindow(UsageCursorConfig{
+		Since: "2026-03-08", Until: "2026-03-08",
+	}, loc)
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 3, 8, 5, 0, 0, 0, time.UTC), start)
+	assert.Equal(t,
+		time.Date(2026, 3, 9, 3, 59, 59, 999000000, time.UTC), end)
 }
 
 func TestFetchHTTPDailyUsageMissingProjectsDefaultsEmptyMap(t *testing.T) {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thlib/go-timezone-local/tzlocal"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/cursorusage"
 	"go.kenn.io/agentsview/internal/db"
@@ -605,6 +606,9 @@ func TestLocalTimezoneWindowsNameProducesServerAcceptedUsageQuery(t *testing.T) 
 	oldLocal := time.Local
 	time.Local = time.FixedZone("Eastern Standard Time", -5*60*60)
 	t.Cleanup(func() { time.Local = oldLocal })
+	expected, err := tzlocal.LocalTZ()
+	require.NoError(t, err)
+	require.NotEmpty(t, expected)
 
 	var gotTimezones []string
 	ts := httptest.NewServer(http.HandlerFunc(func(
@@ -617,7 +621,7 @@ func TestLocalTimezoneWindowsNameProducesServerAcceptedUsageQuery(t *testing.T) 
 			writeJSONResponse(w, `{"error":"invalid timezone: Eastern Standard Time"}`)
 			return
 		}
-		if tz != "America/New_York" {
+		if tz != expected {
 			w.WriteHeader(http.StatusBadRequest)
 			writeJSONResponse(w, `{"error":"invalid timezone: `+tz+`"}`)
 			return
@@ -641,8 +645,15 @@ func TestLocalTimezoneWindowsNameProducesServerAcceptedUsageQuery(t *testing.T) 
 		}, NoDefaultRange: true})
 	require.NoError(t, err)
 	require.Len(t, head.Daily, 1)
-	assert.Equal(t, "America/New_York", gotTimezones[1])
+	assert.Equal(t, expected, gotTimezones[1])
 	t.Logf("head: timezone=%q status=200 daily=%d", gotTimezones[1], len(head.Daily))
+}
+
+func TestUsageDateForTimezoneFallsBackToUTC(t *testing.T) {
+	now := time.Date(2026, 7, 3, 22, 30, 0, 0, time.FixedZone("local", -5*60*60))
+	assert.Equal(t, "2026-07-03", usageDateForTimezone(now, "America/New_York"))
+	assert.Equal(t, "2026-07-04", usageDateForTimezone(now, "UTC"))
+	assert.Equal(t, "2026-07-04", usageDateForTimezone(now, "not/a-zone"))
 }
 
 func TestRunUsageDailyDefaultsToMappedLocalTimezone(t *testing.T) {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -589,7 +590,18 @@ func TestFetchHTTPDailyUsage(t *testing.T) {
 }
 
 func TestLocalTimezoneWindowsNameProducesServerAcceptedUsageQuery(t *testing.T) {
-	t.Setenv("TZ", "America/New_York")
+	if runtime.GOOS != "windows" {
+		t.Skip("requires the Windows local timezone resolver")
+	}
+	previousTZ, hadTZ := os.LookupEnv("TZ")
+	require.NoError(t, os.Unsetenv("TZ"))
+	t.Cleanup(func() {
+		if hadTZ {
+			_ = os.Setenv("TZ", previousTZ)
+		} else {
+			_ = os.Unsetenv("TZ")
+		}
+	})
 	oldLocal := time.Local
 	time.Local = time.FixedZone("Eastern Standard Time", -5*60*60)
 	t.Cleanup(func() { time.Local = oldLocal })

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/stretchr/testify v1.12.1
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.44.0
+	github.com/thlib/go-timezone-local v0.0.8
 	github.com/tidwall/gjson v1.19.0
 	go.kenn.io/docbank v0.13.0
 	go.kenn.io/kit v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/testcontainers/testcontainers-go v0.44.0 h1:/Fwh6HY1mIikhnm9e7HwoxGyc
 github.com/testcontainers/testcontainers-go v0.44.0/go.mod h1:IcnwQrYTO86xHXu5bvMaBH7ATlbS3Qn1M1QWW3c66rE=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.44.0 h1:8fdv/9y3JMxjQ+ULAcOG8RtgeNu5t9XF9LolSXDuTwM=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.44.0/go.mod h1:CFr2LncGYokw+OKjXcr8ARCKG1SaC2UEnGxFBovE86g=
+github.com/thlib/go-timezone-local v0.0.8 h1:wPh1JtBHBqAKmYjHD4j6GbQMGGbOOOnB6YRMQUTzYAY=
+github.com/thlib/go-timezone-local v0.0.8/go.mod h1:/Tnicc6m/lsJE0irFMA0LfIwTBo4QP7A8IfyIv4zZKI=
 github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
 github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -1194,9 +1194,10 @@ func addMessageToCacheTotals(
 // the JSON output emits "hourly_utc": [] rather than null.
 //
 // ReporterTimezone reflects f.Timezone when set (honouring the CLI
-// --timezone flag), otherwise the best-effort local IANA name. When
-// the env/local fallback cannot be resolved safely, the field stays
-// empty so downstream fallback logic can take over.
+// --timezone flag), otherwise the best-effort local IANA name resolved
+// from TZ, the local location, or the OS-aware platform adapter. When
+// no loadable name can be resolved safely, the field stays empty so
+// downstream fallback logic can take over.
 func (db *DB) computeTemporal(
 	ctx context.Context, stats *SessionStats, f StatsFilter,
 	from, to time.Time, sessionIDs []string,
@@ -1310,9 +1311,10 @@ func (db *DB) accumulateHourlyUTC(
 // SessionStats.Temporal.ReporterTimezone. Precedence:
 //
 //  1. f.Timezone when non-empty — echoes the --timezone flag.
-//  2. Valid IANA names from TZ or the current local location.
-//  3. Empty string when the fallback name is only a sentinel or
-//     otherwise cannot be resolved safely.
+//  2. Valid IANA names from TZ or the current local location, followed
+//     by the OS-aware platform adapter for identities such as Windows
+//     registry names.
+//  3. Empty string when no loadable name can be resolved safely.
 func reporterTimezone(f StatsFilter) string {
 	if f.Timezone != "" {
 		return f.Timezone

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -2128,10 +2129,69 @@ func TestReporterTimezone_Precedence(t *testing.T) {
 		reporterTimezone(StatsFilter{}),
 		"valid local name should pass through")
 
-	// No filter, no env, Local sentinel → emit empty fallback.
+	// No filter, no env, Local sentinel → use the platform resolver when it is
+	// available, otherwise retain the existing empty metadata fallback.
 	time.Local = time.FixedZone("Local", 0)
-	assert.Equal(t, "", reporterTimezone(StatsFilter{}),
-		"Local sentinel should not be published")
+	mapped := reporterTimezone(StatsFilter{})
+	if mapped != "" {
+		_, err := time.LoadLocation(mapped)
+		assert.NoError(t, err, "platform timezone must be loadable")
+	}
+}
+
+func TestReporterTimezoneUsesPlatformMapping(t *testing.T) {
+	previousTZ, hadTZ := os.LookupEnv("TZ")
+	require.NoError(t, os.Unsetenv("TZ"))
+	t.Cleanup(func() {
+		if hadTZ {
+			_ = os.Setenv("TZ", previousTZ)
+		} else {
+			_ = os.Unsetenv("TZ")
+		}
+	})
+	oldLocal := time.Local
+	time.Local = time.FixedZone("Local", 0)
+	t.Cleanup(func() { time.Local = oldLocal })
+
+	got := reporterTimezone(StatsFilter{})
+	if runtime.GOOS == "windows" {
+		require.NotEmpty(t, got)
+	}
+	if got != "" {
+		_, err := time.LoadLocation(got)
+		require.NoError(t, err)
+	}
+	t.Logf("platform reporter timezone: %q", got)
+}
+
+func TestGetSessionStatsReportsPlatformTimezone(t *testing.T) {
+	previousTZ, hadTZ := os.LookupEnv("TZ")
+	require.NoError(t, os.Unsetenv("TZ"))
+	t.Cleanup(func() {
+		if hadTZ {
+			_ = os.Setenv("TZ", previousTZ)
+		} else {
+			_ = os.Unsetenv("TZ")
+		}
+	})
+	oldLocal := time.Local
+	time.Local = time.FixedZone("Local", 0)
+	t.Cleanup(func() { time.Local = oldLocal })
+
+	stats, err := testDB(t).GetSessionStats(
+		context.Background(), StatsFilter{Since: "28d"})
+	require.NoError(t, err)
+	if runtime.GOOS == "windows" {
+		require.NotEmpty(t, stats.Temporal.ReporterTimezone)
+	}
+	if stats.Temporal.ReporterTimezone != "" {
+		_, err := time.LoadLocation(stats.Temporal.ReporterTimezone)
+		require.NoError(t, err)
+	}
+	raw, err := json.Marshal(stats.Temporal)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"reporter_timezone"`)
+	t.Logf("stats reporter timezone: %q", stats.Temporal.ReporterTimezone)
 }
 
 func TestGetSessionStats_Temporal_FilterByAgentFlowsThrough(t *testing.T) {

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/thlib/go-timezone-local/tzlocal"
 )
 
 // Ptr formats a time.Time to an RFC3339Nano string pointer
@@ -83,9 +85,10 @@ func sinceFormatError(s string) error {
 }
 
 func BestEffortLocalTimezone() string {
-	return bestEffortLocalTimezone(
+	return resolveLocalTimezone(
 		os.Getenv("TZ"),
 		time.Now().Location(),
+		tzlocal.LocalTZ,
 	)
 }
 
@@ -97,6 +100,48 @@ func bestEffortLocalTimezone(envTZ string, loc *time.Location) string {
 		return ""
 	}
 	return validatedTimezoneName(loc.String())
+}
+
+func resolveLocalTimezone(
+	envTZ string,
+	loc *time.Location,
+	systemLocal func() (string, error),
+) string {
+	if name := validatedTimezoneName(envTZ); name != "" {
+		return name
+	}
+	if loc != nil {
+		if name := validatedTimezoneName(loc.String()); name != "" {
+			return name
+		}
+	}
+	if systemLocal == nil {
+		return ""
+	}
+	name, err := systemLocal()
+	if err != nil {
+		return ""
+	}
+	return validatedTimezoneName(name)
+}
+
+func LocalTimezoneOrUTC() string {
+	if name := BestEffortLocalTimezone(); name != "" {
+		return name
+	}
+	return "UTC"
+}
+
+func LocalLocation() *time.Location {
+	name := BestEffortLocalTimezone()
+	if name == "" {
+		return time.Local
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return time.Local
+	}
+	return loc
 }
 
 func validatedTimezoneName(name string) string {

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -93,13 +93,7 @@ func BestEffortLocalTimezone() string {
 }
 
 func bestEffortLocalTimezone(envTZ string, loc *time.Location) string {
-	if name := validatedTimezoneName(envTZ); name != "" {
-		return name
-	}
-	if loc == nil {
-		return ""
-	}
-	return validatedTimezoneName(loc.String())
+	return resolveLocalTimezone(envTZ, loc, nil)
 }
 
 func resolveLocalTimezone(
@@ -125,21 +119,33 @@ func resolveLocalTimezone(
 	return validatedTimezoneName(name)
 }
 
+// LocalTimezoneOrUTC returns the best-effort local IANA timezone name, or UTC
+// when no loadable local timezone can be resolved.
 func LocalTimezoneOrUTC() string {
-	if name := BestEffortLocalTimezone(); name != "" {
+	return localTimezoneOrUTC(BestEffortLocalTimezone)
+}
+
+func localTimezoneOrUTC(resolve func() string) string {
+	if name := resolve(); name != "" {
 		return name
 	}
 	return "UTC"
 }
 
+// LocalLocation returns the resolved local timezone location, or time.Local
+// when no loadable local timezone can be resolved.
 func LocalLocation() *time.Location {
-	name := BestEffortLocalTimezone()
+	return localLocation(BestEffortLocalTimezone, time.Local)
+}
+
+func localLocation(resolve func() string, fallback *time.Location) *time.Location {
+	name := resolve()
 	if name == "" {
-		return time.Local
+		return fallback
 	}
 	loc, err := time.LoadLocation(name)
 	if err != nil {
-		return time.Local
+		return fallback
 	}
 	return loc
 }

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -323,11 +323,16 @@ func TestResolveLocalTimezone(t *testing.T) {
 }
 
 func TestLocalTimezoneOrUTC(t *testing.T) {
-	t.Setenv("TZ", "UTC")
-	assert.Equal(t, "UTC", LocalTimezoneOrUTC())
+	assert.Equal(t, "America/New_York", localTimezoneOrUTC(
+		func() string { return "America/New_York" }))
+	assert.Equal(t, "UTC", localTimezoneOrUTC(func() string { return "" }))
 }
 
 func TestLocalLocation(t *testing.T) {
-	t.Setenv("TZ", "America/New_York")
-	assert.Equal(t, "America/New_York", LocalLocation().String())
+	fallback := time.FixedZone("fallback", 0)
+	assert.Equal(t, "America/New_York", localLocation(
+		func() string { return "America/New_York" }, fallback).String())
+	assert.Same(t, fallback, localLocation(func() string { return "" }, fallback))
+	assert.Same(t, fallback, localLocation(
+		func() string { return "not/a-zone" }, fallback))
 }

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -1,6 +1,7 @@
 package timeutil
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -237,4 +238,96 @@ func TestBestEffortLocalTimezone(t *testing.T) {
 				bestEffortLocalTimezone(tt.envTZ, tt.loc))
 		})
 	}
+}
+
+func TestResolveLocalTimezone(t *testing.T) {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		envTZ      string
+		loc        *time.Location
+		systemName string
+		systemErr  error
+		want       string
+	}{
+		{
+			name:  "valid environment wins",
+			envTZ: "Europe/Berlin", loc: la,
+			systemName: "America/New_York", want: "Europe/Berlin",
+		},
+		{
+			name:  "accepted alias wins",
+			envTZ: "US/Eastern", loc: la,
+			systemName: "America/New_York", want: "US/Eastern",
+		},
+		{
+			name:  "invalid environment falls through",
+			envTZ: "not/a-zone", loc: berlin,
+			systemName: "America/New_York", want: "Europe/Berlin",
+		},
+		{
+			name:  "UTC is preserved",
+			envTZ: "UTC", loc: la,
+			systemName: "America/New_York", want: "UTC",
+		},
+		{
+			name: "valid local IANA name passes through",
+			loc:  berlin, systemName: "America/New_York", want: "Europe/Berlin",
+		},
+		{
+			name:       "Windows identity uses platform mapping",
+			loc:        time.FixedZone("Eastern Standard Time", -5*60*60),
+			systemName: "America/New_York", want: "America/New_York",
+		},
+		{
+			name:       "nil location uses platform mapping",
+			systemName: "America/New_York", want: "America/New_York",
+		},
+		{
+			name: "unknown platform identity is empty",
+			loc:  time.FixedZone("Local", 0), systemName: "Eastern Standard Time",
+		},
+		{
+			name: "platform error is empty",
+			loc:  time.FixedZone("Local", 0), systemErr: errors.New("unavailable"),
+		},
+		{
+			name: "invalid platform result is empty",
+			loc:  time.FixedZone("Local", 0), systemName: "not/a-zone",
+		},
+		{
+			name:       "offset identity is not guessed",
+			loc:        time.FixedZone("UTC-5", -5*60*60),
+			systemName: "Eastern Standard Time",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			got := resolveLocalTimezone(tt.envTZ, tt.loc, func() (string, error) {
+				calls++
+				return tt.systemName, tt.systemErr
+			})
+			assert.Equal(t, tt.want, got)
+			if tt.want != "" && (tt.envTZ != "" || tt.loc != nil &&
+				validatedTimezoneName(tt.loc.String()) != "") {
+				assert.Zero(t, calls, "platform resolver should not run")
+			}
+		})
+	}
+}
+
+func TestLocalTimezoneOrUTC(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	assert.Equal(t, "UTC", LocalTimezoneOrUTC())
+}
+
+func TestLocalLocation(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	assert.Equal(t, "America/New_York", LocalLocation().String())
 }

--- a/internal/timeutil/timeutil_windows_test.go
+++ b/internal/timeutil/timeutil_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package timeutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thlib/go-timezone-local/tzlocal"
+)
+
+func TestBestEffortLocalTimezoneRuntime(t *testing.T) {
+	mapped, err := tzlocal.LocalTZ()
+	require.NoError(t, err)
+	require.NotEmpty(t, mapped)
+	_, err = time.LoadLocation(mapped)
+	require.NoError(t, err)
+	t.Logf("Windows local identity %q maps to loadable IANA zone %q", time.Local.String(), mapped)
+}

--- a/internal/timeutil/timeutil_windows_test.go
+++ b/internal/timeutil/timeutil_windows_test.go
@@ -3,6 +3,7 @@
 package timeutil
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -11,9 +12,21 @@ import (
 )
 
 func TestBestEffortLocalTimezoneRuntime(t *testing.T) {
-	mapped, err := tzlocal.LocalTZ()
+	previousTZ, hadTZ := os.LookupEnv("TZ")
+	require.NoError(t, os.Unsetenv("TZ"))
+	t.Cleanup(func() {
+		if hadTZ {
+			_ = os.Setenv("TZ", previousTZ)
+		} else {
+			_ = os.Unsetenv("TZ")
+		}
+	})
+
+	nativeMapped, err := tzlocal.LocalTZ()
 	require.NoError(t, err)
-	require.NotEmpty(t, mapped)
+	require.NotEmpty(t, nativeMapped)
+	mapped := BestEffortLocalTimezone()
+	require.Equal(t, nativeMapped, mapped)
 	_, err = time.LoadLocation(mapped)
 	require.NoError(t, err)
 	t.Logf("Windows local identity %q maps to loadable IANA zone %q", time.Local.String(), mapped)


### PR DESCRIPTION
CLI usage and activity defaults now resolve the host timezone to a loadable IANA name, so Windows local-day reports reach the daemon with the correct calendar rules. Statusline date bounds use the same resolved timezone. Explicit timezone values and valid TZ overrides remain unchanged.

The shared time utility now uses an OS-aware resolver for Windows identities, including Eastern Standard Time, while retaining safe fallbacks for environments that cannot provide a named zone. This adds `github.com/thlib/go-timezone-local` for the Windows-to-IANA zone mapping. Daily usage, statusline usage, Cursor usage windows, direct activity reports, daemon activity requests, and stats metadata use one timezone decision.

This also allows `agentsview usage daily` to work on Windows; currently it returns `HTTP 500: {"error":"internal error"}`

Closes #1619

