### PR TITLE
perf: reduce recurring sync work and retain performance simulators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ test: pricing-snapshot ensure-embed-dir
 .PHONY: perf-sim
 PERF_SIM_FLAGS ?=
 perf-sim: pricing-snapshot ensure-embed-dir
-	CGO_ENABLED=1 go run -tags fts5 ./cmd/perfsim $(PERF_SIM_FLAGS)
+	CGO_ENABLED=1 go run -buildvcs=true -tags fts5 ./cmd/perfsim $(PERF_SIM_FLAGS)
 
 # Run fast tests only
 test-short: pricing-snapshot ensure-embed-dir

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,12 @@ GO_TEST_P_FLAG := $(if $(GO_TEST_P),-p $(GO_TEST_P),)
 test: pricing-snapshot ensure-embed-dir
 	go test $(GO_TEST_P_FLAG) -tags "fts5" ./... -v
 
+# Reproducible synthetic ingest, steady-state sync, and analytics measurements.
+.PHONY: perf-sim
+PERF_SIM_FLAGS ?=
+perf-sim: pricing-snapshot ensure-embed-dir
+	CGO_ENABLED=1 go run -tags fts5 ./cmd/perfsim $(PERF_SIM_FLAGS)
+
 # Run fast tests only
 test-short: pricing-snapshot ensure-embed-dir
 	go test $(GO_TEST_P_FLAG) -tags "fts5" ./... -short

--- a/cmd/perfsim/corpus.go
+++ b/cmd/perfsim/corpus.go
@@ -17,17 +17,18 @@ type source struct {
 	Agent    parser.AgentType
 	Turns    int
 	Start    time.Time
-	Store    *sql.DB
+	Store    *sql.DB `json:"-"`
 }
 
 func corpus(dir string, o options) ([]source, map[parser.AgentType][]string, error) {
 	if o.SourceFormat == "opencode" {
 		return openCodeCorpus(dir, o)
 	}
+	claudeRoot, codexRoot := filepath.Join(dir, "claude"), filepath.Join(dir, "codex")
 	roots := map[parser.AgentType][]string{
-		parser.AgentClaude: {filepath.Join(dir, "claude")}, parser.AgentCodex: {filepath.Join(dir, "codex")},
+		parser.AgentClaude: {claudeRoot}, parser.AgentCodex: {codexRoot},
 	}
-	var sources []source
+	sources := make([]source, 0, o.Sessions+o.Empty)
 	for i := 0; i < o.Sessions+o.Empty; i++ {
 		agent := parser.AgentCodex
 		if i >= o.Sessions || i%2 == 0 {
@@ -35,9 +36,9 @@ func corpus(dir string, o options) ([]source, map[parser.AgentType][]string, err
 		}
 		id := fmt.Sprintf("00000000-0000-4000-8000-%012d", i+1)
 		start := time.Date(2026, 6, 1+i%28, 10, 0, 0, 0, time.UTC)
-		path := filepath.Join(roots[agent][0], fmt.Sprintf("project-%02d", i%20), id+".jsonl")
+		path := filepath.Join(claudeRoot, fmt.Sprintf("project-%02d", i%20), id+".jsonl")
 		if agent == parser.AgentCodex {
-			path = filepath.Join(roots[agent][0], "2026", "06", start.Format("02"), "rollout-"+start.Format("2006-01-02T15-04-05")+"-"+id+".jsonl")
+			path = filepath.Join(codexRoot, "2026", "06", start.Format("02"), "rollout-"+start.Format("2006-01-02T15-04-05")+"-"+id+".jsonl")
 		}
 		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 			return nil, nil, err

--- a/cmd/perfsim/corpus.go
+++ b/cmd/perfsim/corpus.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,9 +17,13 @@ type source struct {
 	Agent    parser.AgentType
 	Turns    int
 	Start    time.Time
+	Store    *sql.DB
 }
 
 func corpus(dir string, o options) ([]source, map[parser.AgentType][]string, error) {
+	if o.SourceFormat == "opencode" {
+		return openCodeCorpus(dir, o)
+	}
 	roots := map[parser.AgentType][]string{
 		parser.AgentClaude: {filepath.Join(dir, "claude")}, parser.AgentCodex: {filepath.Join(dir, "codex")},
 	}
@@ -60,6 +65,21 @@ func corpus(dir string, o options) ([]source, map[parser.AgentType][]string, err
 }
 
 func (s *source) appendTurns(n, contentBytes int) error {
+	if s.Store != nil {
+		tx, err := s.Store.Begin()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback() }()
+		if err := s.writeSQLiteTurns(tx, n, contentBytes); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		s.Turns += n
+		return nil
+	}
 	b := testjsonl.NewSessionBuilder()
 	for j := range n {
 		turn := s.Turns + j

--- a/cmd/perfsim/corpus.go
+++ b/cmd/perfsim/corpus.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+type source struct {
+	Path, ID string
+	Agent    parser.AgentType
+	Turns    int
+	Start    time.Time
+}
+
+func corpus(dir string, o options) ([]source, map[parser.AgentType][]string, error) {
+	roots := map[parser.AgentType][]string{
+		parser.AgentClaude: {filepath.Join(dir, "claude")}, parser.AgentCodex: {filepath.Join(dir, "codex")},
+	}
+	var sources []source
+	for i := 0; i < o.Sessions+o.Empty; i++ {
+		agent := parser.AgentCodex
+		if i >= o.Sessions || i%2 == 0 {
+			agent = parser.AgentClaude
+		}
+		id := fmt.Sprintf("00000000-0000-4000-8000-%012d", i+1)
+		start := time.Date(2026, 6, 1+i%28, 10, 0, 0, 0, time.UTC)
+		path := filepath.Join(roots[agent][0], fmt.Sprintf("project-%02d", i%20), id+".jsonl")
+		if agent == parser.AgentCodex {
+			path = filepath.Join(roots[agent][0], "2026", "06", start.Format("02"), "rollout-"+start.Format("2006-01-02T15-04-05")+"-"+id+".jsonl")
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return nil, nil, err
+		}
+		s := source{Path: path, ID: id, Agent: agent, Start: start}
+		initial := ""
+		if agent == parser.AgentCodex {
+			initial = testjsonl.CodexSessionMetaJSON(id, "/workspace/project-a", "codex_cli_rs", start.Format(time.RFC3339)) + "\n" + testjsonl.CodexTurnContextJSON("gpt-5.4", start.Format(time.RFC3339)) + "\n"
+		}
+		if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+			return nil, nil, err
+		}
+		if i < o.Sessions {
+			turns := o.Turns
+			if i < o.Active && o.ActiveTurns > 0 {
+				turns = o.ActiveTurns
+			}
+			if err := s.appendTurns(turns, o.ContentBytes); err != nil {
+				return nil, nil, err
+			}
+			sources = append(sources, s)
+		}
+	}
+	return sources, roots, nil
+}
+
+func (s *source) appendTurns(n, contentBytes int) error {
+	b := testjsonl.NewSessionBuilder()
+	for j := range n {
+		turn := s.Turns + j
+		ts := s.Start.Add(time.Duration(turn) * time.Minute).Format(time.RFC3339)
+		text := fmt.Sprintf("Investigate query latency in module %d. ", turn) + strings.Repeat("sample code and context ", contentBytes/24)
+		if s.Agent == parser.AgentClaude {
+			b.AddClaudeUserWithSessionID(ts, text, s.ID)
+			b.AddClaudeAssistantUsage(ts, "Implemented and checked the query. "+text, testjsonl.ClaudeAssistantUsage{
+				MessageID: fmt.Sprintf("msg-%s-%d", s.ID, turn), RequestID: fmt.Sprintf("req-%s-%d", s.ID, turn), Model: "claude-sonnet-4-20250514", InputTokens: 1000 + turn, OutputTokens: 200,
+			})
+		} else {
+			b.AddCodexMessage(ts, "user", text).AddCodexMessage(ts, "assistant", "Implemented and checked the query. "+text).
+				AddRaw(testjsonl.CodexTokenCountJSON(ts, 1000+turn, 200, 100))
+		}
+	}
+	f, err := os.OpenFile(s.Path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(b.String())
+	closeErr := f.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	s.Turns += n
+	return nil
+}

--- a/cmd/perfsim/main.go
+++ b/cmd/perfsim/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 type options struct {
+	SourceFormat   string `json:"source_format"`
 	Sessions       int    `json:"sessions"`
 	Turns          int    `json:"turns_per_session"`
 	ActiveTurns    int    `json:"active_session_turns"`
@@ -32,7 +33,8 @@ type options struct {
 
 func main() {
 	o := options{}
-	flag.IntVar(&o.Sessions, "sessions", 1000, "Sessions split between Claude and Codex")
+	flag.StringVar(&o.SourceFormat, "source-format", "jsonl", "Source layout: jsonl (Claude/Codex) or opencode (SQLite)")
+	flag.IntVar(&o.Sessions, "sessions", 1000, "Total sessions in the selected source format")
 	flag.IntVar(&o.Turns, "turns", 20, "User/assistant pairs per session")
 	flag.IntVar(&o.ActiveTurns, "active-turns", 0, "Initial turns in active sessions; 0 uses --turns")
 	flag.IntVar(&o.Active, "active", 2, "Sessions receiving one pair per iteration")
@@ -53,6 +55,12 @@ func main() {
 }
 
 func execute(ctx context.Context, o options) error {
+	if o.SourceFormat != "jsonl" && o.SourceFormat != "opencode" {
+		return fmt.Errorf("source-format must be jsonl or opencode")
+	}
+	if o.SourceFormat == "opencode" && o.Empty != 0 {
+		return fmt.Errorf("empty sources apply only to the jsonl workload")
+	}
 	if o.Sessions < 2 || o.Turns < 1 || o.ActiveTurns < 0 || o.Active < 1 || o.Active > o.Sessions || o.Iterations < 1 || o.Empty < 0 || o.ReconcileEvery < 0 || o.QueryEvery < 0 || o.ContentBytes < 1 {
 		return fmt.Errorf("sessions >= 2, turns/iterations/message-bytes >= 1, 1 <= active <= sessions, and active-turns/empty/reconcile-every/query-every >= 0 are required")
 	}

--- a/cmd/perfsim/main.go
+++ b/cmd/perfsim/main.go
@@ -1,0 +1,111 @@
+// Command perfsim measures parsed synthetic sessions through the real sync and query paths.
+package main
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"syscall"
+)
+
+type options struct {
+	Sessions       int    `json:"sessions"`
+	Turns          int    `json:"turns_per_session"`
+	ActiveTurns    int    `json:"active_session_turns"`
+	Active         int    `json:"active_sessions"`
+	Iterations     int    `json:"iterations"`
+	Empty          int    `json:"empty_sources"`
+	ReconcileEvery int    `json:"reconcile_every"`
+	QueryEvery     int    `json:"query_every"`
+	ContentBytes   int    `json:"message_bytes"`
+	Output         string `json:"-"`
+	Keep           bool   `json:"-"`
+}
+
+func main() {
+	o := options{}
+	flag.IntVar(&o.Sessions, "sessions", 1000, "Sessions split between Claude and Codex")
+	flag.IntVar(&o.Turns, "turns", 20, "User/assistant pairs per session")
+	flag.IntVar(&o.ActiveTurns, "active-turns", 0, "Initial turns in active sessions; 0 uses --turns")
+	flag.IntVar(&o.Active, "active", 2, "Sessions receiving one pair per iteration")
+	flag.IntVar(&o.Iterations, "iterations", 10, "Warm reconciliation, append, and query repetitions")
+	flag.IntVar(&o.Empty, "empty", 0, "Additional empty Claude source files")
+	flag.IntVar(&o.ReconcileEvery, "reconcile-every", 1, "Reconcile every N iterations; 0 isolates appends")
+	flag.IntVar(&o.QueryEvery, "query-every", 1, "Run analytics every N iterations; 0 isolates sync")
+	flag.IntVar(&o.ContentBytes, "message-bytes", 512, "Approximate content bytes per message")
+	flag.StringVar(&o.Output, "output-dir", "", "New output directory; defaults to a temporary directory")
+	flag.BoolVar(&o.Keep, "keep-data", false, "Keep the synthetic archive and sources for inspection")
+	flag.Parse()
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	if err := execute(ctx, o); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func execute(ctx context.Context, o options) error {
+	if o.Sessions < 2 || o.Turns < 1 || o.ActiveTurns < 0 || o.Active < 1 || o.Active > o.Sessions || o.Iterations < 1 || o.Empty < 0 || o.ReconcileEvery < 0 || o.QueryEvery < 0 || o.ContentBytes < 1 {
+		return fmt.Errorf("sessions >= 2, turns/iterations/message-bytes >= 1, 1 <= active <= sessions, and active-turns/empty/reconcile-every/query-every >= 0 are required")
+	}
+	if o.Output == "" {
+		var err error
+		o.Output, err = os.MkdirTemp("", "agentsview-perfsim-")
+		if err != nil {
+			return err
+		}
+	} else if err := os.Mkdir(o.Output, 0o700); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "Performance artifacts:", o.Output)
+	data := filepath.Join(o.Output, "data")
+	if err := os.Mkdir(data, 0o700); err != nil {
+		return err
+	}
+	if !o.Keep {
+		defer os.RemoveAll(data)
+	}
+	report, err := run(ctx, o, data)
+	if err != nil {
+		return err
+	}
+	report.GoVersion = runtime.Version()
+	report.GOOS = runtime.GOOS
+	report.GOARCH = runtime.GOARCH
+	encoded, err := json.Marshal(report, jsontext.WithIndent("  "))
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(o.Output, "results.json"), append(encoded, '\n'), 0o600); err != nil {
+		return err
+	}
+	var bench strings.Builder
+	bench.WriteString("pkg: go.kenn.io/agentsview/cmd/perfsim\n")
+	for _, v := range report.Observations {
+		if v.Phase == "cold" {
+			continue
+		}
+		fmt.Fprintf(&bench, "BenchmarkPerfsim_%s_%s 1 %.0f ns/op %d B/op %d allocs/op\n", v.Phase, v.Operation, v.Milliseconds*1e6, v.AllocatedBytes, v.Allocations)
+	}
+	return os.WriteFile(filepath.Join(o.Output, "bench.txt"), []byte(bench.String()), 0o600)
+}
+
+func cpuProfile(path string) (func(), error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return func() { pprof.StopCPUProfile(); f.Close() }, nil
+}

--- a/cmd/perfsim/main.go
+++ b/cmd/perfsim/main.go
@@ -17,6 +17,8 @@ import (
 )
 
 type options struct {
+	GenerateOnly   bool   `json:"generate_only"`
+	ProvenanceNote string `json:"provenance_note,omitempty"`
 	SourceFormat   string `json:"source_format"`
 	Sessions       int    `json:"sessions"`
 	Turns          int    `json:"turns_per_session"`
@@ -33,6 +35,8 @@ type options struct {
 
 func main() {
 	o := options{}
+	flag.BoolVar(&o.GenerateOnly, "generate-only", false, "Retain producer sources and a manifest without running the sync engine")
+	flag.StringVar(&o.ProvenanceNote, "provenance-note", "", "Describe any build overlay or other source changes not captured by VCS metadata")
 	flag.StringVar(&o.SourceFormat, "source-format", "jsonl", "Source layout: jsonl (Claude/Codex) or opencode (SQLite)")
 	flag.IntVar(&o.Sessions, "sessions", 1000, "Total sessions in the selected source format")
 	flag.IntVar(&o.Turns, "turns", 20, "User/assistant pairs per session")
@@ -78,8 +82,28 @@ func execute(ctx context.Context, o options) error {
 	if err := os.Mkdir(data, 0o700); err != nil {
 		return err
 	}
-	if !o.Keep {
+	if !o.Keep && !o.GenerateOnly {
 		defer os.RemoveAll(data)
+	}
+	if o.GenerateOnly {
+		sources, roots, err := corpus(data, o)
+		if err != nil {
+			return err
+		}
+		if sources[0].Store != nil {
+			defer sources[0].Store.Close()
+		}
+		manifest := struct {
+			Options    options         `json:"options"`
+			Sources    []source        `json:"sources"`
+			Roots      any             `json:"roots"`
+			Provenance buildProvenance `json:"provenance"`
+		}{o, sources, roots, provenance()}
+		encoded, err := json.Marshal(manifest, jsontext.WithIndent("  "))
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(o.Output, "sources.json"), append(encoded, '\n'), 0o600)
 	}
 	report, err := run(ctx, o, data)
 	if err != nil {
@@ -88,6 +112,7 @@ func execute(ctx context.Context, o options) error {
 	report.GoVersion = runtime.Version()
 	report.GOOS = runtime.GOOS
 	report.GOARCH = runtime.GOARCH
+	report.Provenance = provenance()
 	encoded, err := json.Marshal(report, jsontext.WithIndent("  "))
 	if err != nil {
 		return err

--- a/cmd/perfsim/opencode.go
+++ b/cmd/perfsim/opencode.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json/v2"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	syncengine "go.kenn.io/agentsview/internal/sync"
+)
+
+// The four provider-consumed tables and their indexes follow OpenCode's pinned
+// core/session/sql.ts and core/project/sql.ts; see session-format-sources.md.
+// Do not add watermark indexes absent from the producer: that hides scan costs.
+const openCodeSchema = `
+CREATE TABLE project (
+ id TEXT PRIMARY KEY, worktree TEXT NOT NULL, vcs TEXT, name TEXT,
+ icon_url TEXT, icon_url_override TEXT, icon_color TEXT,
+ time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+ time_initialized INTEGER, sandboxes TEXT NOT NULL, commands TEXT
+);
+CREATE TABLE session (
+ id TEXT PRIMARY KEY, project_id TEXT NOT NULL REFERENCES project(id) ON DELETE CASCADE,
+ workspace_id TEXT, parent_id TEXT, slug TEXT NOT NULL, directory TEXT NOT NULL,
+ path TEXT, title TEXT NOT NULL, version TEXT NOT NULL, share_url TEXT,
+ summary_additions INTEGER, summary_deletions INTEGER, summary_files INTEGER,
+ summary_diffs TEXT, metadata TEXT, cost REAL NOT NULL DEFAULT 0,
+ tokens_input INTEGER NOT NULL DEFAULT 0, tokens_output INTEGER NOT NULL DEFAULT 0,
+ tokens_reasoning INTEGER NOT NULL DEFAULT 0, tokens_cache_read INTEGER NOT NULL DEFAULT 0,
+ tokens_cache_write INTEGER NOT NULL DEFAULT 0, revert TEXT, permission TEXT,
+ agent TEXT, model TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+ time_compacting INTEGER, time_archived INTEGER
+);
+CREATE INDEX session_project_idx ON session(project_id);
+CREATE INDEX session_workspace_idx ON session(workspace_id);
+CREATE INDEX session_parent_idx ON session(parent_id);
+CREATE TABLE message (
+ id TEXT PRIMARY KEY, session_id TEXT NOT NULL REFERENCES session(id) ON DELETE CASCADE,
+ time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL
+);
+CREATE INDEX message_session_time_created_id_idx ON message(session_id, time_created, id);
+CREATE TABLE part (
+ id TEXT PRIMARY KEY, message_id TEXT NOT NULL REFERENCES message(id) ON DELETE CASCADE,
+ session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+ data TEXT NOT NULL
+);
+CREATE INDEX part_message_id_id_idx ON part(message_id, id);
+CREATE INDEX part_session_idx ON part(session_id);
+`
+
+func openCodeCorpus(dir string, o options) ([]source, map[parser.AgentType][]string, error) {
+	root := filepath.Join(dir, "opencode")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, nil, err
+	}
+	path := filepath.Join(root, "opencode.db")
+	store, err := sql.Open("sqlite3", path)
+	if err != nil {
+		return nil, nil, err
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			store.Close()
+		}
+	}()
+	store.SetMaxOpenConns(1)
+	if _, err := store.Exec("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;" + openCodeSchema); err != nil {
+		return nil, nil, err
+	}
+	tx, err := store.Begin()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	start := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	for i := range 20 {
+		if _, err := tx.Exec(`INSERT INTO project
+ (id, worktree, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, '[]')`,
+			fmt.Sprintf("project-%02d", i), fmt.Sprintf("/workspace/project-%02d", i), start.UnixMilli(), start.UnixMilli()); err != nil {
+			return nil, nil, err
+		}
+	}
+	sources := make([]source, 0, o.Sessions)
+	for i := range o.Sessions {
+		s := source{Path: path, ID: fmt.Sprintf("ses_%012d", i+1), Agent: parser.AgentOpenCode, Store: store, Start: start.AddDate(0, 0, i%28)}
+		if _, err := tx.Exec(`INSERT INTO session
+ (id, project_id, slug, directory, title, version, time_created, time_updated)
+ VALUES (?, ?, ?, ?, ?, 'simulation', ?, ?)`, s.ID, fmt.Sprintf("project-%02d", i%20), s.ID,
+			fmt.Sprintf("/workspace/project-%02d", i%20), "Investigate query latency", s.Start.UnixMilli(), s.Start.UnixMilli()); err != nil {
+			return nil, nil, err
+		}
+		turns := o.Turns
+		if i < o.Active && o.ActiveTurns > 0 {
+			turns = o.ActiveTurns
+		}
+		if err := s.writeSQLiteTurns(tx, turns, o.ContentBytes); err != nil {
+			return nil, nil, err
+		}
+		s.Turns = turns
+		sources = append(sources, s)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, nil, err
+	}
+	complete = true
+	return sources, map[parser.AgentType][]string{parser.AgentOpenCode: {root}}, nil
+}
+
+func (s *source) writeSQLiteTurns(tx *sql.Tx, n, contentBytes int) error {
+	for j := range n {
+		turn := s.Turns + j
+		for roleIndex, role := range []string{"user", "assistant"} {
+			stamp := s.Start.Add(time.Duration(turn)*time.Minute).UnixMilli() + int64(roleIndex)
+			id := fmt.Sprintf("msg_%s_%08d_%d", s.ID, turn, roleIndex)
+			data := map[string]any{"role": role, "time": map[string]int64{"created": stamp}}
+			if role == "assistant" {
+				data["parentID"] = fmt.Sprintf("msg_%s_%08d_0", s.ID, turn)
+				data["modelID"], data["providerID"] = "gpt-5.4", "openai"
+				data["mode"], data["agent"], data["finish"], data["cost"] = "build", "build", "stop", 0
+				data["path"] = map[string]string{"cwd": "/workspace/project-a", "root": "/workspace"}
+				data["time"] = map[string]int64{"created": stamp, "completed": stamp + 1}
+				data["tokens"] = map[string]any{"input": 1000 + turn, "output": 200, "reasoning": 0, "cache": map[string]int{"read": 100, "write": 0}}
+			}
+			encoded, err := json.Marshal(data)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)`, id, s.ID, stamp, stamp, string(encoded)); err != nil {
+				return err
+			}
+			text := fmt.Sprintf("Investigate query latency in module %d. ", turn) + strings.Repeat("sample code and context ", contentBytes/24)
+			encoded, err = json.Marshal(map[string]string{"type": "text", "text": text})
+			if err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)`, "prt_"+id, id, s.ID, stamp, stamp, string(encoded)); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := tx.Exec("UPDATE session SET time_updated = ? WHERE id = ?", s.Start.Add(time.Duration(s.Turns+n-1)*time.Minute).UnixMilli()+2, s.ID)
+	return err
+}
+
+const sqliteEditedText = "Streaming part finalized after session metadata update."
+
+func (s *source) editSQLitePart() error {
+	encoded, err := json.Marshal(map[string]string{"type": "text", "text": sqliteEditedText})
+	if err != nil {
+		return err
+	}
+	// Only the part watermark advances, exercising the active-session poll.
+	_, err = s.Store.Exec("UPDATE part SET data = ?, time_updated = ? WHERE id = ?", string(encoded),
+		s.Start.Add(time.Duration(s.Turns-1)*time.Minute).UnixMilli()+10, fmt.Sprintf("prt_msg_%s_%08d_1", s.ID, s.Turns-1))
+	return err
+}
+
+func pollSQLiteSessions(sources []source) ([]int64, error) {
+	watermarks := make([]int64, len(sources))
+	for i, s := range sources {
+		mtime, err := parser.OpenCodeSourceMtime(parser.OpenCodeSQLiteVirtualPath(s.Path, s.ID))
+		if err != nil {
+			return nil, err
+		}
+		if mtime == 0 {
+			return nil, fmt.Errorf("active SQLite session missing a watermark")
+		}
+		watermarks[i] = mtime
+	}
+	return watermarks, nil
+}
+
+func measureSQLiteScans(ctx context.Context, r *report, sources []source, active int) error {
+	for _, scan := range []struct {
+		name string
+		run  func(context.Context, string, func(parser.OpenCodeSessionMeta) error) error
+	}{
+		{"metadata_scan", parser.ForEachOpenCodeSessionWatermarkMeta},
+		{"full_digest_scan", parser.ForEachOpenCodeSessionMeta},
+	} {
+		if err := r.measure("warm", scan.name, func() error {
+			count := 0
+			err := scan.run(ctx, sources[0].Path, func(parser.OpenCodeSessionMeta) error { count++; return nil })
+			if err != nil {
+				return err
+			}
+			if count != len(sources) {
+				return fmt.Errorf("SQLite scan returned %d sessions, want %d", count, len(sources))
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return r.measure("warm", "session_poll", func() error {
+		_, err := pollSQLiteSessions(sources[:active])
+		return err
+	})
+}
+
+func syncSQLiteChildEdits(ctx context.Context, r *report, engine *syncengine.Engine, database *db.DB, sources []source) error {
+	before, err := pollSQLiteSessions(sources)
+	if err != nil {
+		return err
+	}
+	var virtualPaths []string
+	for j := range sources {
+		s := &sources[j]
+		if err := s.editSQLitePart(); err != nil {
+			return err
+		}
+		virtualPaths = append(virtualPaths, parser.OpenCodeSQLiteVirtualPath(s.Path, s.ID))
+	}
+	if err := r.measure("active", "session_poll", func() error {
+		after, err := pollSQLiteSessions(sources)
+		if err != nil {
+			return err
+		}
+		for j := range after {
+			if after[j] == before[j] {
+				return fmt.Errorf("active-session poll missed a child-only edit for session %d", j)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := r.measure("active", "child_edit", func() error { return engine.SyncPathsContext(ctx, virtualPaths) }); err != nil {
+		return err
+	}
+	for j := range sources {
+		messages, err := database.GetAllMessages(ctx, "opencode:"+sources[j].ID)
+		if err != nil {
+			return err
+		}
+		if len(messages) == 0 || messages[len(messages)-1].Content != sqliteEditedText {
+			return fmt.Errorf("child-only edit was not archived for active session %d", j)
+		}
+	}
+	return nil
+}

--- a/cmd/perfsim/provenance.go
+++ b/cmd/perfsim/provenance.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+)
+
+type buildProvenance struct {
+	Revision         string `json:"revision,omitempty"`
+	Modified         *bool  `json:"modified,omitempty"`
+	ExecutableSHA256 string `json:"executable_sha256,omitempty"`
+}
+
+func provenance() buildProvenance {
+	var p buildProvenance
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				p.Revision = setting.Value
+			case "vcs.modified":
+				p.Modified = new(setting.Value == "true")
+			}
+		}
+	}
+	if path, err := os.Executable(); err == nil {
+		if f, err := os.Open(path); err == nil {
+			defer f.Close()
+			h := sha256.New()
+			if _, err := io.Copy(h, f); err == nil {
+				p.ExecutableSHA256 = fmt.Sprintf("%x", h.Sum(nil))
+			}
+		}
+	}
+	return p
+}

--- a/cmd/perfsim/run.go
+++ b/cmd/perfsim/run.go
@@ -12,21 +12,24 @@ import (
 )
 
 type observation struct {
-	Phase          string  `json:"phase"`
-	Operation      string  `json:"operation"`
-	Milliseconds   float64 `json:"ms"`
-	AllocatedBytes uint64  `json:"allocated_bytes"`
-	Allocations    uint64  `json:"allocations"`
-	HeapBytes      uint64  `json:"heap_bytes"`
+	CompletedUpdates int     `json:"completed_updates"`
+	Phase            string  `json:"phase"`
+	Operation        string  `json:"operation"`
+	Milliseconds     float64 `json:"ms"`
+	AllocatedBytes   uint64  `json:"allocated_bytes"`
+	Allocations      uint64  `json:"allocations"`
+	HeapBytes        uint64  `json:"heap_bytes"`
 }
 type report struct {
-	Options      options       `json:"options"`
-	GoVersion    string        `json:"go_version"`
-	GOOS         string        `json:"goos"`
-	GOARCH       string        `json:"goarch"`
-	Observations []observation `json:"observations"`
-	Initial      db.Stats      `json:"initial_stats"`
-	Final        db.Stats      `json:"final_stats"`
+	Provenance       buildProvenance `json:"provenance"`
+	completedUpdates int
+	Options          options       `json:"options"`
+	GoVersion        string        `json:"go_version"`
+	GOOS             string        `json:"goos"`
+	GOARCH           string        `json:"goarch"`
+	Observations     []observation `json:"observations"`
+	Initial          db.Stats      `json:"initial_stats"`
+	Final            db.Stats      `json:"final_stats"`
 }
 
 func (r *report) measure(phase, name string, fn func() error) error {
@@ -36,7 +39,7 @@ func (r *report) measure(phase, name string, fn func() error) error {
 	err := fn()
 	elapsed := time.Since(start)
 	runtime.ReadMemStats(&after)
-	r.Observations = append(r.Observations, observation{phase, name, float64(elapsed) / float64(time.Millisecond), after.TotalAlloc - before.TotalAlloc, after.Mallocs - before.Mallocs, after.HeapAlloc})
+	r.Observations = append(r.Observations, observation{CompletedUpdates: r.completedUpdates, Phase: phase, Operation: name, Milliseconds: float64(elapsed) / float64(time.Millisecond), AllocatedBytes: after.TotalAlloc - before.TotalAlloc, Allocations: after.Mallocs - before.Mallocs, HeapBytes: after.HeapAlloc})
 	if err != nil {
 		return fmt.Errorf("%s %s: %w", phase, name, err)
 	}
@@ -113,7 +116,27 @@ func run(ctx context.Context, o options, dir string) (report, error) {
 		if err := ctx.Err(); err != nil {
 			return r, err
 		}
-		if o.ReconcileEvery > 0 && i%o.ReconcileEvery == 0 {
+
+		var changed []string
+		for j := 0; j < o.Active; j++ {
+			s := &sources[j]
+			if err := s.appendTurns(1, o.ContentBytes); err != nil {
+				return r, err
+			}
+			if s.Store == nil || len(changed) == 0 {
+				changed = append(changed, s.Path)
+			}
+		}
+		if err := r.measure("active", "append", func() error { return engine.SyncPathsContext(ctx, changed) }); err != nil {
+			return r, err
+		}
+		r.completedUpdates = i + 1
+		if o.SourceFormat == "opencode" {
+			if err := syncSQLiteChildEdits(ctx, &r, engine, database, sources[:o.Active]); err != nil {
+				return r, err
+			}
+		}
+		if o.ReconcileEvery > 0 && (i+1)%o.ReconcileEvery == 0 {
 			if o.SourceFormat == "opencode" {
 				if err := measureSQLiteScans(ctx, &r, sources, o.Active); err != nil {
 					return r, err
@@ -137,29 +160,23 @@ func run(ctx context.Context, o options, dir string) (report, error) {
 				return r, err
 			}
 		}
-		var changed []string
-		for j := 0; j < o.Active; j++ {
-			s := &sources[j]
-			if err := s.appendTurns(1, o.ContentBytes); err != nil {
-				return r, err
-			}
-			if s.Store == nil || len(changed) == 0 {
-				changed = append(changed, s.Path)
-			}
-		}
-		if err := r.measure("active", "append", func() error { return engine.SyncPathsContext(ctx, changed) }); err != nil {
-			return r, err
-		}
-		if o.SourceFormat == "opencode" {
-			if err := syncSQLiteChildEdits(ctx, &r, engine, database, sources[:o.Active]); err != nil {
-				return r, err
-			}
-		}
-		if o.QueryEvery > 0 && i%o.QueryEvery == 0 {
+		if o.QueryEvery > 0 && (i+1)%o.QueryEvery == 0 {
 			for _, q := range queries {
 				if err := r.measure("active", q.name, q.run); err != nil {
 					return r, err
 				}
+			}
+		}
+	}
+	if o.SourceFormat == "opencode" {
+		if err := sources[0].Store.Close(); err != nil {
+			return r, err
+		}
+		for range 3 {
+			if err := r.measure("recovery", "closed_writer_event", func() error {
+				return engine.SyncPathsContext(ctx, []string{sources[0].Path + "-wal"})
+			}); err != nil {
+				return r, err
 			}
 		}
 	}

--- a/cmd/perfsim/run.go
+++ b/cmd/perfsim/run.go
@@ -49,6 +49,9 @@ func run(ctx context.Context, o options, dir string) (report, error) {
 	if err != nil {
 		return r, err
 	}
+	if sources[0].Store != nil {
+		defer sources[0].Store.Close()
+	}
 	database, err := db.OpenIsolated(filepath.Join(dir, "sessions.db"))
 	if err != nil {
 		return r, err
@@ -111,6 +114,16 @@ func run(ctx context.Context, o options, dir string) (report, error) {
 			return r, err
 		}
 		if o.ReconcileEvery > 0 && i%o.ReconcileEvery == 0 {
+			if o.SourceFormat == "opencode" {
+				if err := measureSQLiteScans(ctx, &r, sources, o.Active); err != nil {
+					return r, err
+				}
+				if err := r.measure("warm", "container_event", func() error {
+					return engine.SyncPathsContext(ctx, []string{sources[0].Path})
+				}); err != nil {
+					return r, err
+				}
+			}
 			if err := r.measure("warm", "reconcile", func() error {
 				stats, _, err := engine.ReconcileWatchRootsWithStats(ctx, nil, true, nil)
 				if err != nil {
@@ -130,10 +143,17 @@ func run(ctx context.Context, o options, dir string) (report, error) {
 			if err := s.appendTurns(1, o.ContentBytes); err != nil {
 				return r, err
 			}
-			changed = append(changed, s.Path)
+			if s.Store == nil || len(changed) == 0 {
+				changed = append(changed, s.Path)
+			}
 		}
 		if err := r.measure("active", "append", func() error { return engine.SyncPathsContext(ctx, changed) }); err != nil {
 			return r, err
+		}
+		if o.SourceFormat == "opencode" {
+			if err := syncSQLiteChildEdits(ctx, &r, engine, database, sources[:o.Active]); err != nil {
+				return r, err
+			}
 		}
 		if o.QueryEvery > 0 && i%o.QueryEvery == 0 {
 			for _, q := range queries {

--- a/cmd/perfsim/run.go
+++ b/cmd/perfsim/run.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+	syncengine "go.kenn.io/agentsview/internal/sync"
+)
+
+type observation struct {
+	Phase          string  `json:"phase"`
+	Operation      string  `json:"operation"`
+	Milliseconds   float64 `json:"ms"`
+	AllocatedBytes uint64  `json:"allocated_bytes"`
+	Allocations    uint64  `json:"allocations"`
+	HeapBytes      uint64  `json:"heap_bytes"`
+}
+type report struct {
+	Options      options       `json:"options"`
+	GoVersion    string        `json:"go_version"`
+	GOOS         string        `json:"goos"`
+	GOARCH       string        `json:"goarch"`
+	Observations []observation `json:"observations"`
+	Initial      db.Stats      `json:"initial_stats"`
+	Final        db.Stats      `json:"final_stats"`
+}
+
+func (r *report) measure(phase, name string, fn func() error) error {
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	start := time.Now()
+	err := fn()
+	elapsed := time.Since(start)
+	runtime.ReadMemStats(&after)
+	r.Observations = append(r.Observations, observation{phase, name, float64(elapsed) / float64(time.Millisecond), after.TotalAlloc - before.TotalAlloc, after.Mallocs - before.Mallocs, after.HeapAlloc})
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", phase, name, err)
+	}
+	return nil
+}
+
+func run(ctx context.Context, o options, dir string) (report, error) {
+	r := report{Options: o}
+	sources, roots, err := corpus(dir, o)
+	if err != nil {
+		return r, err
+	}
+	database, err := db.OpenIsolated(filepath.Join(dir, "sessions.db"))
+	if err != nil {
+		return r, err
+	}
+	defer database.Close()
+	engine := syncengine.NewEngine(database, syncengine.EngineConfig{AgentDirs: roots, Machine: "simulation", DisableFilesystemProjectDiscovery: true})
+	defer engine.Close()
+	if err := r.measure("cold", "ingest", func() error {
+		stats := engine.SyncAll(ctx, nil)
+		if stats.Failed != 0 || stats.Aborted {
+			return fmt.Errorf("ingest failed: %+v", stats)
+		}
+		return ctx.Err()
+	}); err != nil {
+		return r, err
+	}
+	r.Initial, err = database.GetStats(ctx, false, false)
+	if err != nil {
+		return r, err
+	}
+	initialMessages := o.Sessions * o.Turns * 2
+	if o.ActiveTurns > 0 {
+		initialMessages += o.Active * (o.ActiveTurns - o.Turns) * 2
+	}
+	if r.Initial.SessionCount != o.Sessions || r.Initial.MessageCount != initialMessages {
+		return r, fmt.Errorf("parsed corpus mismatch: got %d sessions/%d messages, want %d/%d", r.Initial.SessionCount, r.Initial.MessageCount, o.Sessions, initialMessages)
+	}
+	filter := db.AnalyticsFilter{From: "2026-06-01", To: "2026-06-30", Timezone: "UTC"}
+	queries := []struct {
+		name string
+		run  func() error
+	}{
+		{"stats", func() error { _, err := database.GetStats(ctx, false, false); return err }},
+		{"sidebar", func() error {
+			_, err := database.GetSidebarSessionIndex(ctx, db.SessionFilter{IncludeChildren: true})
+			return err
+		}},
+		{"analytics_summary", func() error { _, err := database.GetAnalyticsSummary(ctx, filter); return err }},
+		{"analytics_activity", func() error { _, err := database.GetAnalyticsActivity(ctx, filter, "day"); return err }},
+		{"daily_usage", func() error {
+			_, err := database.GetDailyUsage(ctx, db.UsageFilter{From: filter.From, To: filter.To, Timezone: "UTC"})
+			return err
+		}},
+		{"search", func() error { _, err := database.Search(ctx, db.SearchFilter{Query: "latency", Limit: 50}); return err }},
+	}
+	for _, q := range queries {
+		if err := r.measure("cold", q.name, q.run); err != nil {
+			return r, err
+		}
+	}
+	stopProfile, err := cpuProfile(filepath.Join(o.Output, "steady.cpu.pprof"))
+	if err != nil {
+		return r, err
+	}
+	defer stopProfile()
+	// No sleep or filesystem watcher debounce is included: each measurement
+	// exercises a completed engine batch, making equal workloads comparable.
+	for i := 0; i < o.Iterations; i++ {
+		if err := ctx.Err(); err != nil {
+			return r, err
+		}
+		if o.ReconcileEvery > 0 && i%o.ReconcileEvery == 0 {
+			if err := r.measure("warm", "reconcile", func() error {
+				stats, _, err := engine.ReconcileWatchRootsWithStats(ctx, nil, true, nil)
+				if err != nil {
+					return err
+				}
+				if stats.Synced != 0 {
+					return fmt.Errorf("unchanged sources resynced: %d", stats.Synced)
+				}
+				return nil
+			}); err != nil {
+				return r, err
+			}
+		}
+		var changed []string
+		for j := 0; j < o.Active; j++ {
+			s := &sources[j]
+			if err := s.appendTurns(1, o.ContentBytes); err != nil {
+				return r, err
+			}
+			changed = append(changed, s.Path)
+		}
+		if err := r.measure("active", "append", func() error { return engine.SyncPathsContext(ctx, changed) }); err != nil {
+			return r, err
+		}
+		if o.QueryEvery > 0 && i%o.QueryEvery == 0 {
+			for _, q := range queries {
+				if err := r.measure("active", q.name, q.run); err != nil {
+					return r, err
+				}
+			}
+		}
+	}
+	r.Final, err = database.GetStats(ctx, false, false)
+	if err != nil {
+		return r, err
+	}
+	wantMessages := initialMessages + o.Active*o.Iterations*2
+	if r.Final.SessionCount != o.Sessions || r.Final.MessageCount != wantMessages {
+		return r, fmt.Errorf("append lost data: got %d sessions/%d messages, want %d/%d", r.Final.SessionCount, r.Final.MessageCount, o.Sessions, wantMessages)
+	}
+	return r, nil
+}

--- a/cmd/perfsim/run_test.go
+++ b/cmd/perfsim/run_test.go
@@ -16,7 +16,7 @@ import (
 func TestSimulatorParsesAndAppendsBothProviders(t *testing.T) {
 	out := t.TempDir()
 	data := filepath.Join(out, "data")
-	result, err := run(t.Context(), options{Sessions: 4, Turns: 2, Active: 2, Iterations: 2, ReconcileEvery: 1, QueryEvery: 1, Empty: 3, ContentBytes: 64, Output: out}, data)
+	result, err := run(t.Context(), options{Sessions: 4, Turns: 2, Active: 2, Iterations: 2, ReconcileEvery: 1, QueryEvery: 1, Empty: 1, ContentBytes: 64, Output: out}, data)
 	require.NoError(t, err)
 	assert.Equal(t, 4, result.Initial.SessionCount)
 	assert.Equal(t, 16, result.Initial.MessageCount)
@@ -25,15 +25,10 @@ func TestSimulatorParsesAndAppendsBothProviders(t *testing.T) {
 	archive, err := db.OpenReadOnly(filepath.Join(data, "sessions.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, archive.Close()) })
-	for _, id := range []string{"00000000-0000-4000-8000-000000000005", "00000000-0000-4000-8000-000000000006", "00000000-0000-4000-8000-000000000007"} {
-		session, err := archive.GetSessionFull(t.Context(), id)
-		require.NoError(t, err)
-		require.NotNil(t, session, "empty sources are archived even though sidebar stats exclude them")
-		assert.Zero(t, session.MessageCount)
-	}
-	skipped, err := archive.LoadSkippedFiles()
+	empty, err := archive.GetSessionFull(t.Context(), "00000000-0000-4000-8000-000000000005")
 	require.NoError(t, err)
-	assert.Empty(t, skipped)
+	require.NotNil(t, empty, "empty sources are archived even though sidebar stats exclude them")
+	assert.Zero(t, empty.MessageCount)
 	for _, id := range []string{"00000000-0000-4000-8000-000000000001", "codex:00000000-0000-4000-8000-000000000002"} {
 		messages, err := archive.GetAllMessages(t.Context(), id)
 		require.NoError(t, err)
@@ -103,8 +98,7 @@ func TestGenerateOnlyRetainsSQLiteWorkload(t *testing.T) {
 	encoded, err := os.ReadFile(filepath.Join(out, "sources.json"))
 	require.NoError(t, err)
 	var manifest struct {
-		Sources    []source        `json:"sources"`
-		Provenance buildProvenance `json:"provenance"`
+		Sources []source `json:"sources"`
 	}
 	require.NoError(t, json.Unmarshal(encoded, &manifest))
 	require.Len(t, manifest.Sources, 2)
@@ -114,5 +108,4 @@ func TestGenerateOnlyRetainsSQLiteWorkload(t *testing.T) {
 	var messages int
 	require.NoError(t, store.QueryRow("SELECT COUNT(*) FROM message").Scan(&messages))
 	assert.Equal(t, 8, messages)
-	assert.Len(t, manifest.Provenance.ExecutableSHA256, 64)
 }

--- a/cmd/perfsim/run_test.go
+++ b/cmd/perfsim/run_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestSimulatorParsesAndAppendsBothProviders(t *testing.T) {
+	out := t.TempDir()
+	data := filepath.Join(out, "data")
+	result, err := run(t.Context(), options{Sessions: 4, Turns: 2, Active: 2, Iterations: 2, ReconcileEvery: 1, QueryEvery: 1, Empty: 3, ContentBytes: 64, Output: out}, data)
+	require.NoError(t, err)
+	assert.Equal(t, 4, result.Initial.SessionCount)
+	assert.Equal(t, 16, result.Initial.MessageCount)
+	assert.Equal(t, 4, result.Final.SessionCount)
+	assert.Equal(t, 24, result.Final.MessageCount)
+	archive, err := db.OpenReadOnly(filepath.Join(data, "sessions.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, archive.Close()) })
+	for _, id := range []string{"00000000-0000-4000-8000-000000000001", "codex:00000000-0000-4000-8000-000000000002"} {
+		messages, err := archive.GetAllMessages(t.Context(), id)
+		require.NoError(t, err)
+		require.Len(t, messages, 8)
+		assert.Contains(t, messages[6].Content, "module 3.")
+	}
+	usage, err := archive.GetDailyUsage(t.Context(), db.UsageFilter{From: "2026-06-01", To: "2026-06-30", Timezone: "UTC"})
+	require.NoError(t, err)
+	assert.Equal(t, 2400, usage.Totals.OutputTokens)
+}

--- a/cmd/perfsim/run_test.go
+++ b/cmd/perfsim/run_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"database/sql"
+	"encoding/json/v2"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -23,6 +25,15 @@ func TestSimulatorParsesAndAppendsBothProviders(t *testing.T) {
 	archive, err := db.OpenReadOnly(filepath.Join(data, "sessions.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, archive.Close()) })
+	for _, id := range []string{"00000000-0000-4000-8000-000000000005", "00000000-0000-4000-8000-000000000006", "00000000-0000-4000-8000-000000000007"} {
+		session, err := archive.GetSessionFull(t.Context(), id)
+		require.NoError(t, err)
+		require.NotNil(t, session, "empty sources are archived even though sidebar stats exclude them")
+		assert.Zero(t, session.MessageCount)
+	}
+	skipped, err := archive.LoadSkippedFiles()
+	require.NoError(t, err)
+	assert.Empty(t, skipped)
 	for _, id := range []string{"00000000-0000-4000-8000-000000000001", "codex:00000000-0000-4000-8000-000000000002"} {
 		messages, err := archive.GetAllMessages(t.Context(), id)
 		require.NoError(t, err)
@@ -32,6 +43,23 @@ func TestSimulatorParsesAndAppendsBothProviders(t *testing.T) {
 	usage, err := archive.GetDailyUsage(t.Context(), db.UsageFilter{From: "2026-06-01", To: "2026-06-30", Timezone: "UTC"})
 	require.NoError(t, err)
 	assert.Equal(t, 2400, usage.Totals.OutputTokens)
+}
+
+func TestSimulatorCadenceMeasuresCompletedUpdateBatches(t *testing.T) {
+	out := t.TempDir()
+	result, err := run(t.Context(), options{Sessions: 2, Turns: 2, Active: 1, Iterations: 5, ReconcileEvery: 2, QueryEvery: 3, ContentBytes: 64, Output: out}, filepath.Join(out, "data"))
+	require.NoError(t, err)
+	var reconciled, queried []int
+	for _, observation := range result.Observations {
+		if observation.Phase == "warm" && observation.Operation == "reconcile" {
+			reconciled = append(reconciled, observation.CompletedUpdates)
+		}
+		if observation.Phase == "active" && observation.Operation == "stats" {
+			queried = append(queried, observation.CompletedUpdates)
+		}
+	}
+	assert.Equal(t, []int{2, 4}, reconciled)
+	assert.Equal(t, []int{3}, queried)
 }
 
 func TestSimulatorScansSQLiteAndArchivesChildOnlyEdits(t *testing.T) {
@@ -46,6 +74,10 @@ func TestSimulatorScansSQLiteAndArchivesChildOnlyEdits(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, archive.Close()) })
 	for _, id := range []string{"opencode:ses_000000000001", "opencode:ses_000000000002"} {
+		stored, err := archive.GetSessionFull(t.Context(), id)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.Nil(t, stored.SourceMissingAt, "writer closure must retain the source")
 		messages, err := archive.GetAllMessages(t.Context(), id)
 		require.NoError(t, err)
 		require.Len(t, messages, 10)
@@ -63,4 +95,24 @@ func TestSimulatorScansSQLiteAndArchivesChildOnlyEdits(t *testing.T) {
  FROM part p JOIN session s ON s.id = p.session_id
  WHERE p.id = 'prt_msg_ses_000000000001_00000004_1'`).Scan(&childAhead))
 	assert.Positive(t, childAhead, "part edits must exercise a change invisible to session-row-only scans")
+}
+
+func TestGenerateOnlyRetainsSQLiteWorkload(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "corpus")
+	require.NoError(t, execute(t.Context(), options{GenerateOnly: true, SourceFormat: "opencode", Sessions: 2, Turns: 2, Active: 1, Iterations: 1, ContentBytes: 64, Output: out}))
+	encoded, err := os.ReadFile(filepath.Join(out, "sources.json"))
+	require.NoError(t, err)
+	var manifest struct {
+		Sources    []source        `json:"sources"`
+		Provenance buildProvenance `json:"provenance"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &manifest))
+	require.Len(t, manifest.Sources, 2)
+	store, err := sql.Open("sqlite3", "file:"+manifest.Sources[0].Path+"?mode=ro")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	var messages int
+	require.NoError(t, store.QueryRow("SELECT COUNT(*) FROM message").Scan(&messages))
+	assert.Equal(t, 8, messages)
+	assert.Len(t, manifest.Provenance.ExecutableSHA256, 64)
 }

--- a/cmd/perfsim/run_test.go
+++ b/cmd/perfsim/run_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"path/filepath"
 	"testing"
 
@@ -31,4 +32,35 @@ func TestSimulatorParsesAndAppendsBothProviders(t *testing.T) {
 	usage, err := archive.GetDailyUsage(t.Context(), db.UsageFilter{From: "2026-06-01", To: "2026-06-30", Timezone: "UTC"})
 	require.NoError(t, err)
 	assert.Equal(t, 2400, usage.Totals.OutputTokens)
+}
+
+func TestSimulatorScansSQLiteAndArchivesChildOnlyEdits(t *testing.T) {
+	out := t.TempDir()
+	data := filepath.Join(out, "data")
+	result, err := run(t.Context(), options{SourceFormat: "opencode", Sessions: 4, Turns: 2, ActiveTurns: 3, Active: 2, Iterations: 2, ReconcileEvery: 1, QueryEvery: 1, ContentBytes: 64, Output: out}, data)
+	require.NoError(t, err)
+	assert.Equal(t, 4, result.Initial.SessionCount)
+	assert.Equal(t, 20, result.Initial.MessageCount)
+	assert.Equal(t, 28, result.Final.MessageCount)
+	archive, err := db.OpenReadOnly(filepath.Join(data, "sessions.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, archive.Close()) })
+	for _, id := range []string{"opencode:ses_000000000001", "opencode:ses_000000000002"} {
+		messages, err := archive.GetAllMessages(t.Context(), id)
+		require.NoError(t, err)
+		require.Len(t, messages, 10)
+		assert.Contains(t, messages[8].Content, "module 4.")
+		assert.Equal(t, "Streaming part finalized after session metadata update.", messages[9].Content)
+	}
+	usage, err := archive.GetDailyUsage(t.Context(), db.UsageFilter{From: "2026-06-01", To: "2026-06-30", Timezone: "UTC"})
+	require.NoError(t, err)
+	assert.Equal(t, 2800, usage.Totals.OutputTokens)
+	producer, err := sql.Open("sqlite3", filepath.Join(data, "opencode", "opencode.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, producer.Close()) })
+	var childAhead int
+	require.NoError(t, producer.QueryRow(`SELECT p.time_updated - s.time_updated
+ FROM part p JOIN session s ON s.id = p.session_id
+ WHERE p.id = 'prt_msg_ses_000000000001_00000004_1'`).Scan(&childAhead))
+	assert.Positive(t, childAhead, "part edits must exercise a change invisible to session-row-only scans")
 }

--- a/docs/internal/performance-data/daemon-opencode-2026-09-04.json
+++ b/docs/internal/performance-data/daemon-opencode-2026-09-04.json
@@ -1,0 +1,1315 @@
+{
+  "revision": "a87db9ce06b6514db44689434acd22f27f3af765",
+  "binary_sha256": "8c6f6637aad26a38bf0c191c64e85e4d68622739a2948b189ace1e0c859a63fc",
+  "date": "2026-09-04",
+  "sessions": 10000,
+  "initial_messages": 403920,
+  "notes": [
+    "Server code matches revision; uncommitted changes affected only the simulator.",
+    "One preparatory append preceded capture. First measured append timed out during watch setup.",
+    "Updates used one 1000-turn session, with an open SSE watch and HTTP tail polling every 250ms.",
+    "Updates were handled by session fallback. Native watcher batches resumed after the writer closed; recovery CPU was therefore not idle CPU.",
+    "CPU profiles cover parent only and the first 30 seconds of each active phase.",
+    "This is a short single-run characterization, not a before/after daemon comparison.",
+    "Recovery retained an SSE watch. Repeated native watcher batches stopped after that watch disconnected."
+  ],
+  "process_phases": {
+    "idle-before": {
+      "seconds": 30.743706941604614,
+      "parent_cpu_seconds": 0.19999999999999996,
+      "one_core_percent": 0.6505396385019058,
+      "parent_rss_kib_first": 99888,
+      "parent_rss_kib_last": 108464,
+      "parent_rss_kib_max": 108464,
+      "child_pids_seen": [],
+      "physical_footprint": "51.9M",
+      "writable_regions": "Writable regions: Total=579.1M written=48.2M(8%) resident=66.5M(11%) swapped_out=0K(0%) unallocated=512.6M(89%)"
+    },
+    "active": {
+      "seconds": 118.45315599441528,
+      "parent_cpu_seconds": 1.35,
+      "one_core_percent": 1.1396910353858773,
+      "parent_rss_kib_first": 109664,
+      "parent_rss_kib_last": 117936,
+      "parent_rss_kib_max": 117936,
+      "child_pids_seen": []
+    },
+    "active-queries": {
+      "seconds": 80.08048605918884,
+      "parent_cpu_seconds": 23.64,
+      "one_core_percent": 29.520300341992524,
+      "parent_rss_kib_first": 118144,
+      "parent_rss_kib_last": 564656,
+      "parent_rss_kib_max": 632816,
+      "child_pids_seen": []
+    },
+    "idle-after": {
+      "seconds": 62.20649313926697,
+      "parent_cpu_seconds": 5.219999999999999,
+      "one_core_percent": 8.391406968262205,
+      "parent_rss_kib_first": 564656,
+      "parent_rss_kib_last": 480288,
+      "parent_rss_kib_max": 564656,
+      "child_pids_seen": [],
+      "physical_footprint": "76.2M",
+      "writable_regions": "Writable regions: Total=964.2M written=406.4M(42%) resident=428.6M(44%) swapped_out=0K(0%) unallocated=535.6M(56%)"
+    }
+  },
+  "query_medians_ms": {
+    "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day": 238.210812502075,
+    "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC": 161.04185406584293,
+    "/search?q=latency&limit=50": 747.1386045217514,
+    "/sessions/sidebar-index": 37.6889375038445,
+    "/stats?include_one_shot=true&include_automated=true": 4.60737495450303,
+    "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC": 397.3374380148016
+  },
+  "observations": [
+    {
+      "phase": "active",
+      "kind": "append",
+      "ms": 45093.321040971205,
+      "visible": false
+    },
+    {
+      "phase": "active",
+      "kind": "child-edit",
+      "ms": 7868.185125058517,
+      "visible": true
+    },
+    {
+      "phase": "active",
+      "kind": "append",
+      "ms": 6773.922500084154,
+      "visible": true
+    },
+    {
+      "phase": "active",
+      "kind": "child-edit",
+      "ms": 7346.544542000629,
+      "visible": true
+    },
+    {
+      "phase": "active",
+      "kind": "append",
+      "ms": 7026.697083958425,
+      "visible": true
+    },
+    {
+      "phase": "active",
+      "kind": "child-edit",
+      "ms": 7602.381790988147,
+      "visible": true
+    },
+    {
+      "phase": "active",
+      "kind": "append",
+      "ms": 7028.144708019681,
+      "visible": true
+    },
+    {
+      "phase": "active",
+      "kind": "child-edit",
+      "ms": 7316.636000061408,
+      "visible": true
+    },
+    {
+      "phase": "active",
+      "kind": "append",
+      "ms": 7031.707874964923,
+      "visible": true
+    },
+    {
+      "phase": "active",
+      "kind": "child-edit",
+      "ms": 7640.1155409403145,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.421374993398786,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 166.95700003765523,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 238.18095796741545,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 3636.6177500458434,
+      "status": "ok",
+      "bytes": 66693
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 757.7392909443006,
+      "status": "ok",
+      "bytes": 21400
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 37.613125052303076,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "append",
+      "ms": 7103.897417080589,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.328375100158155,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 160.63270810991526,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 245.697750011459,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 398.69391708634794,
+      "status": "ok",
+      "bytes": 66693
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 742.9603340569884,
+      "status": "ok",
+      "bytes": 21400
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 37.73495799396187,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "child-edit",
+      "ms": 7311.54483393766,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.617040976881981,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 158.82704209070653,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 245.88579207193106,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 389.4383340375498,
+      "status": "ok",
+      "bytes": 66693
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 761.1051250714809,
+      "status": "ok",
+      "bytes": 21400
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 37.43470797780901,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "append",
+      "ms": 7027.69699995406,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.341459018178284,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 164.49291701428592,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 238.24066703673452,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 395.98095894325525,
+      "status": "ok",
+      "bytes": 66693
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 751.3168749865144,
+      "status": "ok",
+      "bytes": 21399
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 38.05045795161277,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "child-edit",
+      "ms": 7681.872374960221,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.695665906183422,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 164.05849996954203,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 242.346707964316,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 422.8195420000702,
+      "status": "ok",
+      "bytes": 66693
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 915.0952079799026,
+      "status": "ok",
+      "bytes": 21400
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 42.142792022787035,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "append",
+      "ms": 6822.382541955449,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.957583034411073,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 180.91170908883214,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 267.99212500918657,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 414.8932499811053,
+      "status": "ok",
+      "bytes": 66693
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 769.7548749856651,
+      "status": "ok",
+      "bytes": 21400
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 37.33724995981902,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "child-edit",
+      "ms": 7670.26604199782,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 9.140957961790264,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 153.61866692546755,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 230.6549579370767,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 391.7722919723019,
+      "status": "ok",
+      "bytes": 66693
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 732.9240839462727,
+      "status": "ok",
+      "bytes": 21400
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 41.22479201760143,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "append",
+      "ms": 6741.300916997716,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.685749998316169,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 161.4510000217706,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 230.2945420378819,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 389.09162511117756,
+      "status": "ok",
+      "bytes": 66703
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 735.7376669533551,
+      "status": "ok",
+      "bytes": 21400
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 37.54600009415299,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "child-edit",
+      "ms": 7674.497041967697,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.597708932124078,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 159.60545802954584,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 232.3811660753563,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 416.5504580596462,
+      "status": "ok",
+      "bytes": 66703
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 725.1293330918998,
+      "status": "ok",
+      "bytes": 21400
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 38.48345798905939,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "append",
+      "ms": 7026.890791021287,
+      "visible": true
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/stats?include_one_shot=true&include_automated=true",
+      "ms": 4.149000043980777,
+      "status": "ok",
+      "bytes": 125
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 156.26970794983208,
+      "status": "ok",
+      "bytes": 346
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/analytics/activity?from=2026-06-01&to=2026-09-30&timezone=UTC&granularity=day",
+      "ms": 235.48158397898078,
+      "status": "ok",
+      "bytes": 4736
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/usage/summary?from=2026-06-01&to=2026-09-30&timezone=UTC",
+      "ms": 389.4442080054432,
+      "status": "ok",
+      "bytes": 66703
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/search?q=latency&limit=50",
+      "ms": 736.2522919429466,
+      "status": "ok",
+      "bytes": 21351
+    },
+    {
+      "phase": "active-queries",
+      "kind": "query",
+      "route": "/sessions/sidebar-index",
+      "ms": 37.64291701372713,
+      "status": "ok",
+      "bytes": 3290037
+    },
+    {
+      "phase": "active-queries",
+      "kind": "child-edit",
+      "ms": 7316.642416990362,
+      "visible": true
+    }
+  ],
+  "generator_options": {
+    "generate_only": true,
+    "source_format": "opencode",
+    "sessions": 10000,
+    "turns_per_session": 20,
+    "active_session_turns": 1000,
+    "active_sessions": 2,
+    "iterations": 10,
+    "empty_sources": 0,
+    "reconcile_every": 1,
+    "query_every": 1,
+    "message_bytes": 512
+  },
+  "generator_provenance": {
+    "revision": "a87db9ce06b6514db44689434acd22f27f3af765",
+    "modified": true,
+    "executable_sha256": "c1e103518e8cd2ac3e64038b19f238ae360ccc65fb96fae0f957c5680e1a5c8e"
+  },
+  "active_sessions_in_daemon_capture": 1,
+  "sidecar_followup": {
+    "candidate": {
+      "binary_sha256": "ce66c93f0b33d4432f5cfba3d9a500d9337aa5158eb7f9ee2ad8ef50bb0e907e",
+      "base_revision": "a87db9ce06b6514db44689434acd22f27f3af765",
+      "change": "existing-container WAL/SHM absence filter"
+    },
+    "notes": [
+      "Six no-op SQLite writer transactions, each followed by connection close, during an SSE watch.",
+      "Before and after used the same synthetic archive after separate server warmups.",
+      "Neither no-op cycle run reproduced the initial recovery existence-scan spike; no steady CPU reduction is established."
+    ],
+    "samples": {
+      "closed-writer-before": [
+        {
+          "time": 1788566597.790528,
+          "cpu": "0:32.53",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566598.804957,
+          "cpu": "0:32.53",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566599.812068,
+          "cpu": "0:32.53",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566600.825099,
+          "cpu": "0:32.54",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566601.83903,
+          "cpu": "0:32.54",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566602.8492851,
+          "cpu": "0:32.55",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566603.863082,
+          "cpu": "0:32.55",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566604.872071,
+          "cpu": "0:32.55",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566605.890269,
+          "cpu": "0:32.56",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566606.909656,
+          "cpu": "0:32.57",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566607.9157,
+          "cpu": "0:32.58",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566608.9378781,
+          "cpu": "0:32.58",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566609.954017,
+          "cpu": "0:32.58",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566610.962551,
+          "cpu": "0:32.58",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566611.972877,
+          "cpu": "0:32.59",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566612.9827468,
+          "cpu": "0:32.59",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566613.9976141,
+          "cpu": "0:32.59",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566615.0153332,
+          "cpu": "0:32.60",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566616.026619,
+          "cpu": "0:32.61",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566617.033348,
+          "cpu": "0:32.61",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566618.0464058,
+          "cpu": "0:32.61",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566619.0580978,
+          "cpu": "0:32.61",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566620.0727758,
+          "cpu": "0:32.61",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566621.0849931,
+          "cpu": "0:32.62",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566622.094694,
+          "cpu": "0:32.62",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566623.109285,
+          "cpu": "0:32.62",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566624.119884,
+          "cpu": "0:32.63",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566625.132211,
+          "cpu": "0:32.63",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566626.143054,
+          "cpu": "0:32.63",
+          "rss_kib": 480352
+        },
+        {
+          "time": 1788566627.1554508,
+          "cpu": "0:32.64",
+          "rss_kib": 480352
+        }
+      ],
+      "closed-writer-after": [
+        {
+          "time": 1788566710.641419,
+          "cpu": "0:08.79",
+          "rss_kib": 164384
+        },
+        {
+          "time": 1788566711.649199,
+          "cpu": "0:08.79",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566712.665766,
+          "cpu": "0:08.79",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566713.686412,
+          "cpu": "0:08.80",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566714.6965382,
+          "cpu": "0:08.80",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566715.7149508,
+          "cpu": "0:08.80",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566716.724239,
+          "cpu": "0:08.81",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566717.732167,
+          "cpu": "0:08.81",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566718.747416,
+          "cpu": "0:08.81",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566719.756821,
+          "cpu": "0:08.82",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566720.772161,
+          "cpu": "0:08.82",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566721.7818081,
+          "cpu": "0:08.83",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566722.7884889,
+          "cpu": "0:08.83",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566723.797099,
+          "cpu": "0:08.83",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566724.808512,
+          "cpu": "0:08.84",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566725.823405,
+          "cpu": "0:08.85",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566726.838957,
+          "cpu": "0:08.85",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566727.852542,
+          "cpu": "0:08.85",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566728.864089,
+          "cpu": "0:08.86",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566729.878017,
+          "cpu": "0:08.86",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566730.885607,
+          "cpu": "0:08.87",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566731.8957,
+          "cpu": "0:08.87",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566732.901675,
+          "cpu": "0:08.87",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566733.922451,
+          "cpu": "0:08.88",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566734.936557,
+          "cpu": "0:08.88",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566735.944026,
+          "cpu": "0:08.88",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566736.9500642,
+          "cpu": "0:08.88",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566737.955807,
+          "cpu": "0:08.89",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566738.9673011,
+          "cpu": "0:08.89",
+          "rss_kib": 164368
+        },
+        {
+          "time": 1788566739.985823,
+          "cpu": "0:08.89",
+          "rss_kib": 164368
+        }
+      ],
+      "writer-cycles-before": [
+        {
+          "time": 1788566897.907605,
+          "cpu": "0:05.78",
+          "rss_kib": 155616
+        },
+        {
+          "time": 1788566898.920047,
+          "cpu": "0:05.79",
+          "rss_kib": 155616
+        },
+        {
+          "time": 1788566899.933365,
+          "cpu": "0:05.80",
+          "rss_kib": 155616
+        },
+        {
+          "time": 1788566900.9437592,
+          "cpu": "0:05.80",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566901.964603,
+          "cpu": "0:05.80",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566902.975569,
+          "cpu": "0:05.81",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566903.99441,
+          "cpu": "0:05.81",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566905.010209,
+          "cpu": "0:05.81",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566906.03575,
+          "cpu": "0:05.82",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566907.045179,
+          "cpu": "0:05.82",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566908.054157,
+          "cpu": "0:05.83",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566909.0647418,
+          "cpu": "0:05.83",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566910.079307,
+          "cpu": "0:05.83",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566911.098343,
+          "cpu": "0:05.83",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566912.110147,
+          "cpu": "0:05.84",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566913.121099,
+          "cpu": "0:05.84",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566914.1360462,
+          "cpu": "0:05.84",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566915.144188,
+          "cpu": "0:05.85",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566916.162771,
+          "cpu": "0:05.85",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566917.182584,
+          "cpu": "0:05.86",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566918.201699,
+          "cpu": "0:05.86",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566919.215243,
+          "cpu": "0:05.87",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566920.228009,
+          "cpu": "0:05.87",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566921.24146,
+          "cpu": "0:05.87",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566922.2503538,
+          "cpu": "0:05.88",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566923.2660742,
+          "cpu": "0:05.88",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566924.2722838,
+          "cpu": "0:05.88",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566925.28425,
+          "cpu": "0:05.89",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566926.298316,
+          "cpu": "0:05.89",
+          "rss_kib": 147424
+        },
+        {
+          "time": 1788566927.3080919,
+          "cpu": "0:05.90",
+          "rss_kib": 147424
+        }
+      ],
+      "writer-cycles-after": [
+        {
+          "time": 1788566793.8696609,
+          "cpu": "0:08.92",
+          "rss_kib": 164432
+        },
+        {
+          "time": 1788566794.885822,
+          "cpu": "0:08.92",
+          "rss_kib": 164416
+        },
+        {
+          "time": 1788566795.9036312,
+          "cpu": "0:08.93",
+          "rss_kib": 164416
+        },
+        {
+          "time": 1788566796.9118872,
+          "cpu": "0:08.93",
+          "rss_kib": 164464
+        },
+        {
+          "time": 1788566797.918745,
+          "cpu": "0:08.93",
+          "rss_kib": 164464
+        },
+        {
+          "time": 1788566798.937679,
+          "cpu": "0:08.94",
+          "rss_kib": 164464
+        },
+        {
+          "time": 1788566799.947689,
+          "cpu": "0:08.94",
+          "rss_kib": 164464
+        },
+        {
+          "time": 1788566800.9596019,
+          "cpu": "0:08.94",
+          "rss_kib": 164464
+        },
+        {
+          "time": 1788566801.97618,
+          "cpu": "0:08.95",
+          "rss_kib": 164464
+        },
+        {
+          "time": 1788566802.990274,
+          "cpu": "0:08.95",
+          "rss_kib": 164464
+        },
+        {
+          "time": 1788566804.010265,
+          "cpu": "0:08.95",
+          "rss_kib": 164464
+        },
+        {
+          "time": 1788566805.026977,
+          "cpu": "0:08.95",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566806.040131,
+          "cpu": "0:08.96",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566807.052733,
+          "cpu": "0:08.96",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566808.0679219,
+          "cpu": "0:08.97",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566809.088539,
+          "cpu": "0:08.97",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566810.094475,
+          "cpu": "0:08.97",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566811.1121411,
+          "cpu": "0:08.97",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566812.1299741,
+          "cpu": "0:08.98",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566813.140327,
+          "cpu": "0:08.98",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566814.149586,
+          "cpu": "0:08.98",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566815.159219,
+          "cpu": "0:08.99",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566816.165012,
+          "cpu": "0:08.99",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566817.178164,
+          "cpu": "0:09.00",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566818.19249,
+          "cpu": "0:09.00",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566819.2074409,
+          "cpu": "0:09.00",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566820.216138,
+          "cpu": "0:09.00",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566821.229016,
+          "cpu": "0:09.00",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566822.2433631,
+          "cpu": "0:09.01",
+          "rss_kib": 164480
+        },
+        {
+          "time": 1788566823.258484,
+          "cpu": "0:09.01",
+          "rss_kib": 164480
+        }
+      ]
+    },
+    "allocation_regression": {
+      "sessions": 800,
+      "old_missing_wal_allocations": 188690,
+      "new_missing_wal_allocations": 89,
+      "unchanged_container_allocations": 22796
+    }
+  }
+}

--- a/docs/internal/performance-data/daemon-opencode-2026-09-04.json
+++ b/docs/internal/performance-data/daemon-opencode-2026-09-04.json
@@ -681,7 +681,9 @@
   "generator_provenance": {
     "revision": "a87db9ce06b6514db44689434acd22f27f3af765",
     "modified": true,
-    "executable_sha256": "c1e103518e8cd2ac3e64038b19f238ae360ccc65fb96fae0f957c5680e1a5c8e"
+    "executable_sha256": "c1e103518e8cd2ac3e64038b19f238ae360ccc65fb96fae0f957c5680e1a5c8e",
+    "provenance_note": "Generated from an uncommitted simulator implementation. The exact generator patch, build command, and toolchain were not retained. The binary hash does not reconstruct that source. This capture is not a reproducible benchmark or release gate.",
+    "source_reconstructable": false
   },
   "active_sessions_in_daemon_capture": 1,
   "sidecar_followup": {
@@ -1311,5 +1313,6 @@
       "new_missing_wal_allocations": 89,
       "unchanged_container_allocations": 22796
     }
-  }
+  },
+  "evidence_status": "exploratory_capture_incomplete_generator_provenance"
 }

--- a/docs/internal/performance-gates.md
+++ b/docs/internal/performance-gates.md
@@ -95,6 +95,8 @@ with `cmd/benchgate`:
   rebuild through a contributor engine.
 - `BenchmarkSearchContentSubstringPage` / `BenchmarkSearchContentFTSPage` — one
   page of content search through the substring and FTS paths.
+- `BenchmarkPersistUnchangedSkipCache` — repeated persistence of an unchanged
+  10k-entry skip cache must avoid copying the map and rewriting its rows.
 - `BenchmarkGetStats` — the repeatedly polled sidebar totals over 10k sessions.
   Computes all totals together so a refresh scans filtered sessions once.
 - `BenchmarkGetDailyUsage` — usage aggregation over 100k message rows. The usage
@@ -253,3 +255,16 @@ reported without gating; it gates automatically once merged.
 1. If the benchmark's fixture grows across iterations, say so in its comment;
    the fixed `-benchtime=Nx` keeps both sides comparable, but readers need to
    know per-op cost depends on the iteration count.
+
+## Synthetic workload simulator
+
+`make perf-sim` runs the retained simulator in `cmd/perfsim`. See
+[the simulator guide](performance-simulator.md) for archive-size comparisons,
+append-only profiles, and analytic-query measurements. Its small correctness
+fixture runs in the normal Go suite. Large runs are opt-in; their process-wide
+allocation samples include background work and are not CI timing assertions.
+
+`BenchmarkCodexStreamingDiscovery` in `internal/parser` is a diagnostic
+benchmark, like `BenchmarkCodexIncrementalCursor`, outside the default gate
+package list. The sync candidate-lookup and unchanged-cache work regressions
+also run as deterministic tests in the regular suite.

--- a/docs/internal/performance-gates.md
+++ b/docs/internal/performance-gates.md
@@ -268,3 +268,8 @@ allocation samples include background work and are not CI timing assertions.
 benchmark, like `BenchmarkCodexIncrementalCursor`, outside the default gate
 package list. The sync candidate-lookup and unchanged-cache work regressions
 also run as deterministic tests in the regular suite.
+
+The simulator's `--source-format opencode` mode covers SQLite metadata and
+full-digest scans, active-session polling, container events, and child-only part
+edits. `TestOpenCodeVirtualEventDoesNotRecheckUnrelatedMembers` bounds unchanged
+virtual-event work as the archive grows and checks deletion behavior.

--- a/docs/internal/performance-gates.md
+++ b/docs/internal/performance-gates.md
@@ -95,6 +95,8 @@ with `cmd/benchgate`:
   rebuild through a contributor engine.
 - `BenchmarkSearchContentSubstringPage` / `BenchmarkSearchContentFTSPage` — one
   page of content search through the substring and FTS paths.
+- `BenchmarkGetStats` — the repeatedly polled sidebar totals over 10k sessions.
+  Computes all totals together so a refresh scans filtered sessions once.
 - `BenchmarkGetDailyUsage` — usage aggregation over 100k message rows. The usage
   aggregate implementation keeps this benchmark name so the gate compares it
   with the merge-base request path. Its warm cases must scan no normalized

--- a/docs/internal/performance-investigation.md
+++ b/docs/internal/performance-investigation.md
@@ -74,8 +74,10 @@ behaviors.
 
 The retained OpenCode workload uses the producer's indexed session/message/part
 schema in WAL mode. Both runs below used 20 turns per session, two active
-sessions with 1,000 initial turns, and five iterations. Only archive size
-changed. These measurements preceded the virtual-event deletion-check fix.
+sessions with 1,000 initial turns, and five iterations. The producer database
+and archive both grew with session count; active session length and update count
+stayed constant. These measurements preceded the virtual-event deletion-check
+fix.
 
 | Operation                            | 1,000 sessions | 10,000 sessions |
 | ------------------------------------ | -------------: | --------------: |
@@ -115,3 +117,72 @@ Full reconciliation still performs these member-existence checks. Its measured
 optimization target. The 10,000-session analytical query medians were 166 ms for
 summary, 242 ms for activity, 360 ms for usage, and 753 ms for common-term
 search.
+
+## Historical evidence limits
+
+The component timings above were recorded during the investigation, but their
+original temporary raw captures are no longer available. They are historical
+observations, not independently replayable benchmark evidence. Earlier simulator
+reports also omitted build revision and dirty-state metadata. The matched
+OpenCode comparison used a source overlay; its quoted numbers should be rerun
+with the retained simulator before treating them as a release gate. New reports
+record build metadata, executable hashes, and optional overlay notes.
+
+## Real daemon with a synthetic SQLite producer
+
+A separate loopback server built from `a87db9ce0`, which includes the checked
+`origin/main`, imported 10,000 sessions and 403,920 messages. Its binary hash,
+HTTP samples, and process measurements are retained in
+[the daemon capture](performance-data/daemon-opencode-2026-09-04.json). The
+installed application and its archive were not changed. Raw profiles and the
+local experiment scripts remain in the worktree's ignored `tmp/daemon-perf`
+directory; they are not needed to run the retained simulator.
+
+One long session received ten user/assistant pairs and ten child-only edits,
+with an SSE watch open. The client checked the newest ten HTTP messages every
+250 ms. One preparatory append preceded capture, and the first measured append
+timed out during watch setup. The remaining updates appeared in roughly 7–8
+seconds through the session fallback. These timings include polling and the
+five-second fallback delay, unlike the component measurements above.
+
+Ten requests to each analytical endpoint all succeeded while updates ran. The
+median HTTP times were 4.6 ms for stats, 37.7 ms for sidebar index, 161.0 ms for
+summary, 238.2 ms for daily activity, 397.3 ms for usage summary, and 747.1 ms
+for common-term search. The window covered June through September in UTC. The
+first request to each endpoint is included, so these are mixed cold/warm
+observations. The parent used about 29.5% of one CPU core during this phase. Its
+first 30-second profile contained 10.23 CPU seconds, with 51.7% of samples in C
+calls. No sync-worker subprocess was observed during these samples; initial
+ingest had used a worker before capture.
+
+RSS peaked near 618 MiB during queries. After 60 seconds of recovery and a
+forced collection, sampled live Go heap was about 17.2 MiB and macOS physical
+footprint was 76.2 MiB, compared with 51.9 MiB before updates. RSS remained near
+469 MiB before collection, and `vmmap` reported 406.4 MiB of written writable
+regions. These measures describe different accounting categories. This short run
+does not establish a long-duration memory-retention result.
+
+The recovery minute was not idle: after the producer writer closed, native
+watcher batches ran every five seconds while the SSE watch remained open. The
+profile attributed 3.6 CPU seconds to source-missing reconciliation, primarily
+per-session SQLite existence probes. A focused reproduction found 188,690
+allocations for a missing WAL event versus 22,797 for the same unchanged
+container event with 800 sessions. Removing a WAL or SHM sidecar does not itself
+mean that the database or its sessions disappeared.
+
+Changed-path preparation now excludes vanished sidecars of known containers
+whose pre-discovery state was captured successfully. Content classification
+still runs, and actual container removal keeps source-missing reconciliation.
+The regression checks both retained messages and missing-source state after
+removing the database. The fixed missing-WAL event made 89 allocations, down
+from 188,690 in the old path. The simulator retains a writer-close recovery
+phase. Repeated watcher notifications alone do not establish repeated expensive
+reconciliation: a later no-writer baseline used only 0.11 CPU seconds across
+29.4 seconds. Writer-close cost must be measured separately from quiet polling.
+
+A follow-up with six no-op SQLite writer transactions and closes over thirty
+seconds used 0.12 CPU seconds before and 0.09 after. Neither run reproduced the
+initial existence-scan spike; that difference is too small to establish an idle
+or average writer-cycle improvement. The allocation regression and original
+profile support the specific removed-sidecar fix. They do not prove that every
+writer close will incur or avoid the original spike.

--- a/docs/internal/performance-investigation.md
+++ b/docs/internal/performance-investigation.md
@@ -69,3 +69,49 @@ simulator currently excludes malformed records and watcher scheduling, so these
 results do not establish an idle-daemon CPU reduction or a long-duration
 memory-retention result. Add those workloads before using it to gate those
 behaviors.
+
+## OpenCode SQLite scans
+
+The retained OpenCode workload uses the producer's indexed session/message/part
+schema in WAL mode. Both runs below used 20 turns per session, two active
+sessions with 1,000 initial turns, and five iterations. Only archive size
+changed. These measurements preceded the virtual-event deletion-check fix.
+
+| Operation                            | 1,000 sessions | 10,000 sessions |
+| ------------------------------------ | -------------: | --------------: |
+| Session metadata scan                |        1.37 ms |        10.79 ms |
+| Full child-digest scan               |       52.13 ms |       523.47 ms |
+| Poll two active sessions after edits |        1.46 ms |         1.57 ms |
+| Unchanged container event            |        4.42 ms |        37.04 ms |
+| Append two long sessions             |      121.23 ms |       163.55 ms |
+| Archive two child-only edits         |      333.50 ms |     2,428.55 ms |
+| Unchanged reconciliation             |      388.49 ms |     4,260.64 ms |
+
+The profile attributed about 30% of total CPU samples to source-missing
+reconciliation. Its per-member provider lookups repeatedly opened the producer
+database to check session existence. Changed-path preparation treated virtual
+paths as missing filesystem entries even after the provider resolved them to
+existing sessions. Those apparent deletions triggered container-wide ownership
+and existence checks on active-session events.
+
+Preparation now removes successfully resolved OpenCode virtual members from the
+missing-path list. Actually missing members keep the deletion path. A regression
+compares 8 with 800 archived sessions, checks unchanged virtual-event work, then
+removes the target producer session and verifies source-missing state, retained
+archived messages, and an unaffected neighboring session. The previous
+implementation allocated 189,332 times for the larger unchanged event, failing
+the test's threefold scaling bound of 8,397.
+
+A matched 10,000-session comparison using identical final simulator code and an
+overlay of the previous engine measured **2,491.26 ms to 120.17 ms** for the
+two-session child-edit batch, about **20.7 times faster**. Median allocation
+fell from **596.72 MiB to 77.04 MiB**, and allocation count from 2,824,784 to
+327,523. The unchanged reconciliation path remained expensive at 4.10 seconds
+and 1.07 GiB after this fix; the improvement is specific to active virtual
+events, not full reconciliation or an idle-daemon measurement.
+
+Full reconciliation still performs these member-existence checks. Its measured
+10,000-session allocation was about 1.07 GiB per pass; that remains a separate
+optimization target. The 10,000-session analytical query medians were 166 ms for
+summary, 242 ms for activity, 360 ms for usage, and 753 ms for common-term
+search.

--- a/docs/internal/performance-investigation.md
+++ b/docs/internal/performance-investigation.md
@@ -1,0 +1,71 @@
+# Steady-state performance measurements
+
+Measurements collected on macOS arm64 with Go 1.27.0 and SQLite FTS5. These are
+local observations, not portable latency targets. Live logs and a native process
+sample guided the investigation; branch code ran on isolated database and source
+clones or synthetic data. No collector was needed for these runs.
+
+## Measured changes
+
+| Operation                        |       Before |                  After | Workload                                            |
+| -------------------------------- | -----------: | ---------------------: | --------------------------------------------------- |
+| SQLite sidebar stats             |     27.99 ms |               10.16 ms | Local archive snapshot                              |
+| PostgreSQL sidebar stats         |      11.1 ms |                 4.7 ms | Anonymized session metadata                         |
+| Codex source discovery           |  about 90 ms |            about 56 ms | 12,656 cloned source files, warm filesystem         |
+| Changed-path append batch        |     12.60 ms |                5.72 ms | 1,000 sessions, 10,000 empty sources, 25 iterations |
+| Unchanged skip-cache persistence | about 8.7 ms | about 0.3 microseconds | Focused benchmark, 10,000 cached entries            |
+
+Stats now calculate five totals in one filtered aggregate. Codex discovery
+reuses directory-entry file types, avoiding a repeated stat per source. Its
+allocation dropped from about 16.4 MB to 11.4 MB per discovery pass.
+
+Claude duplicate resolution probes the requested transcript filenames in each
+project instead of enumerating unrelated transcripts. Append allocation fell
+from 11.14 MB to 0.266 MB per batch (33,912 to 2,091 allocations). Nested
+subagent candidates still require traversal. The regression test compares 8 with
+8,000 unrelated files, checks duplicate selection and deletion, and fails
+against the previous implementation.
+
+An unchanged skip cache no longer copies its map and replaces all persistent
+rows. The focused benchmark went from about 60,059 allocations to one
+assertion-related allocation. The simulator's empty files become empty sessions,
+so they do not populate this cache; the append improvement above must not be
+attributed to skip-cache persistence. A separate durable-cache regression checks
+unchanged work, updates, deletion, and engine restart.
+
+## Larger workload and remaining costs
+
+Run this workload with the retained [simulator](performance-simulator.md):
+
+```bash
+make perf-sim PERF_SIM_FLAGS='--sessions 10000 --turns 20 --active-turns 1000 --iterations 5'
+```
+
+It starts with 403,920 messages. Two active sessions receive a new pair per
+iteration. The following are medians after initial ingest and query warmup;
+queries run after each append, so usage reads include refreshing changed data.
+
+| Operation                     | Median duration | Median allocated memory |
+| ----------------------------- | --------------: | ----------------------: |
+| Stats                         |         3.63 ms |                1.68 KiB |
+| Sidebar index                 |        43.69 ms |               15.71 MiB |
+| Analytics summary             |       202.82 ms |                6.64 MiB |
+| Daily activity                |       264.92 ms |               11.55 MiB |
+| Daily usage                   |       435.70 ms |              152.34 MiB |
+| Common-term full-text search  |       852.94 ms |                0.19 MiB |
+| Unchanged full reconciliation |     1,232.65 ms |              159.46 MiB |
+| Long-session append batch     |        90.64 ms |               33.97 MiB |
+
+Allocation is process-wide work during each operation, not retained heap or
+resident memory. The CPU profile spent about 60% of samples in C calls, so SQL
+query plans or native profiling are needed to explain that work further. Search
+uses a deliberately common term and is not representative of rare-term queries.
+These observations identify further work; no optimization of these analytical
+queries is claimed here.
+
+The live daemon also repeatedly logged a malformed Harness source failure at
+roughly seven-second intervals. That retry behavior remains unresolved. The
+simulator currently excludes malformed records and watcher scheduling, so these
+results do not establish an idle-daemon CPU reduction or a long-duration
+memory-retention result. Add those workloads before using it to gate those
+behaviors.

--- a/docs/internal/performance-investigation.md
+++ b/docs/internal/performance-investigation.md
@@ -186,3 +186,13 @@ initial existence-scan spike; that difference is too small to establish an idle
 or average writer-cycle improvement. The allocation regression and original
 profile support the specific removed-sidecar fix. They do not prove that every
 writer close will incur or avoid the original spike.
+
+The retained daemon JSON is explicitly an exploratory capture with incomplete
+generator provenance. Its generator was built from uncommitted simulator code;
+the exact generator patch, command, and toolchain are unavailable. The generator
+hash and workload options do not reconstruct that source. Do not use this
+capture as a reproducible benchmark or release gate, or infer that its corpus is
+byte-identical to output from a committed simulator. A controlled comparison
+requires fresh runs from identified committed builds or fully retained patches.
+The provenance requirements in the simulator guide apply to those new runs; they
+are not a claim that this earlier capture met them.

--- a/docs/internal/performance-simulator.md
+++ b/docs/internal/performance-simulator.md
@@ -1,0 +1,99 @@
+# Performance simulator
+
+`cmd/perfsim` creates synthetic Claude and Codex JSONL sources and feeds them
+through the real parsers, SQLite archive, sync engine, usage cache, and query
+implementations. It checks session/message totals after ingest and appends so a
+parser failure cannot look like a performance improvement.
+
+Run the default workload:
+
+```bash
+make perf-sim
+```
+
+The command creates a private temporary output directory and prints its path. It
+removes synthetic source/database files on completion but keeps measurements and
+profiles. `--keep-data` retains those files for query inspection. `--output-dir`
+must name a new directory; the command refuses an existing one. It does not load
+the user's app configuration or run against a live archive.
+
+## Workloads
+
+```bash
+# Small archive with steady updates and analytics after each update.
+make perf-sim PERF_SIM_FLAGS='--sessions 100 --turns 20 --iterations 10'
+
+# Larger archive; the active sessions have much longer histories.
+make perf-sim PERF_SIM_FLAGS='--sessions 10000 --turns 20 --active-turns 1000 --iterations 10'
+
+# Isolate append work from periodic full reconciliation and analytics.
+make perf-sim PERF_SIM_FLAGS='--sessions 1000 --empty 10000 --iterations 25 --reconcile-every 0 --query-every 0'
+```
+
+Sessions alternate between Claude and Codex. `--active` selects how many of the
+first sessions receive a new user/assistant pair per iteration, default two.
+`--active-turns` changes their initial length without making every archived
+session long. `--message-bytes` controls approximate content size. `--empty`
+adds empty Claude source files; current parsers archive these as empty sessions,
+so they stress discovery and bookkeeping without adding analytical messages.
+
+The corpus uses fixed dates across June 2026, unique session/message/request
+IDs, and usage-bearing assistant turns. It does not contact model providers. The
+default query window covers that month. Extremely long sessions may extend
+outside it, just as real sessions can extend beyond a query window.
+
+Each run records:
+
+- Cold ingest and first execution of each query.
+- Warm full reconciliation, requiring zero rewritten sessions.
+- Changed-path sync after appending to the active sessions.
+- Stats, sidebar index, analytics summary, daily activity, daily token usage,
+  and full-text search after each update.
+
+Use `--reconcile-every N` and `--query-every N` to schedule those operations
+once per N update iterations. Zero disables that repeated phase. First-query
+warmup still runs before the steady-state CPU profile starts.
+
+## Comparing results
+
+The output directory contains:
+
+- `results.json`: configuration, Go version/platform, actual archive totals, and
+  every operation's duration, allocated bytes, allocation count, and heap.
+- `bench.txt`: non-cold observations in Go benchmark format.
+- `steady.cpu.pprof`: CPU samples collected after ingest and first-query warmup.
+
+Use identical flags, source revision except for the measured change, toolchain,
+and machine for before/after runs. Avoid simultaneous benchmark runs. Collect at
+least five iterations. Appends grow the active sessions, so iteration counts
+must match. Compare cold and steady measurements separately.
+
+```bash
+go tool pprof -top /tmp/run-after/steady.cpu.pprof
+go run ./cmd/benchgate -alloc-floor 1e18 \
+  -old /tmp/run-before/bench.txt -new /tmp/run-after/bench.txt
+```
+
+The comparison command disables the allocation-count gate because it compares
+the worst candidate sample with the baseline median. Process-wide simulator
+counts include asynchronous signal work and can fail that rule even when a file
+is compared with itself. Time and allocated-byte gates still compare medians
+with a significance check. Keep the default allocation-count gate for focused
+benchmarks with stable work.
+
+The simulator reports process-wide allocations, including asynchronous signal
+work. These samples can vary; use them to find expensive paths, then add a
+focused benchmark or work-count regression for a confirmed fix. The regular
+suite checks the simulator's parsed output and usage totals. It does not enforce
+machine-dependent latency thresholds.
+
+## Limits
+
+This measures completed engine batches and direct store queries. It excludes
+filesystem watcher debounce, HTTP serialization, frontend rendering, network
+latency, and PostgreSQL. An unchanged reconciliation is a scheduled pass, not a
+measurement of a daemon sleeping with no events. CPU profiles include corpus
+append generation as well as sync; per-operation timings exclude generation. The
+corpus currently has no tool calls, forks, subagents, or malformed records. Use
+real-data clones or additional producer fixtures for those cases. Query content
+deliberately contains repeated search terms, stressing common-term FTS.

--- a/docs/internal/performance-simulator.md
+++ b/docs/internal/performance-simulator.md
@@ -184,3 +184,22 @@ means unknown, not a clean build. Build overlays are not described by VCS
 metadata; use `--provenance-note` to record the overlay and retain its patch
 with the results. Executable hashes identify binaries but cannot reconstruct
 them.
+
+## Sidecar events and deleted members
+
+For OpenCode, Kilo, MiMoCode, and Icodemate SQLite containers, disappearance of
+WAL/SHM files beside an existing database is housekeeping, not evidence that
+sessions disappeared. A database/sidecar changed-path batch processes surviving
+sources. It does not promise immediate `source_missing_at` updates for sessions
+deleted inside that database. The next successful authoritative reconciliation
+of the provider root or container detects those deletions and retains the
+archived messages. An explicitly missing virtual-member event still takes the
+member absence path. Removal of the database itself still takes source-missing
+reconciliation when the database removal event is processed.
+
+The sidecar regression compares 8 and 800 sessions for each of the four provider
+layouts and both suffixes. It also deletes a member, closes its writer,
+processes the database/WAL/SHM event batch, and verifies the eventual
+missing-source state after authoritative reconciliation. This defines
+consistency, not a fixed time bound: reconciliation must successfully run before
+that state changes.

--- a/docs/internal/performance-simulator.md
+++ b/docs/internal/performance-simulator.md
@@ -1,9 +1,10 @@
 # Performance simulator
 
-`cmd/perfsim` creates synthetic Claude and Codex JSONL sources and feeds them
-through the real parsers, SQLite archive, sync engine, usage cache, and query
-implementations. It checks session/message totals after ingest and appends so a
-parser failure cannot look like a performance improvement.
+`cmd/perfsim` creates synthetic Claude/Codex JSONL sources or an OpenCode SQLite
+store and feeds them through the real parsers, SQLite archive, sync engine,
+usage cache, and query implementations. It checks session/message totals after
+ingest and appends so a parser failure cannot look like a performance
+improvement.
 
 Run the default workload:
 
@@ -28,14 +29,21 @@ make perf-sim PERF_SIM_FLAGS='--sessions 10000 --turns 20 --active-turns 1000 --
 
 # Isolate append work from periodic full reconciliation and analytics.
 make perf-sim PERF_SIM_FLAGS='--sessions 1000 --empty 10000 --iterations 25 --reconcile-every 0 --query-every 0'
+
+# SQLite container scans, long active sessions, and analytical queries.
+make perf-sim PERF_SIM_FLAGS='--source-format opencode --sessions 10000 --turns 20 --active-turns 1000 --iterations 5'
+
+# Larger part payloads to exercise SQLite overflow pages.
+make perf-sim PERF_SIM_FLAGS='--source-format opencode --sessions 1000 --message-bytes 16384 --iterations 5'
 ```
 
-Sessions alternate between Claude and Codex. `--active` selects how many of the
-first sessions receive a new user/assistant pair per iteration, default two.
-`--active-turns` changes their initial length without making every archived
-session long. `--message-bytes` controls approximate content size. `--empty`
-adds empty Claude source files; current parsers archive these as empty sessions,
-so they stress discovery and bookkeeping without adding analytical messages.
+The default `--source-format jsonl` alternates between Claude and Codex.
+`--active` selects how many of the first sessions receive a new user/assistant
+pair per iteration, default two. `--active-turns` changes their initial length
+without making every archived session long. `--message-bytes` controls
+approximate content size. `--empty` adds empty Claude source files; current
+parsers archive these as empty sessions, so they stress discovery and
+bookkeeping without adding analytical messages.
 
 The corpus uses fixed dates across June 2026, unique session/message/request
 IDs, and usage-bearing assistant turns. It does not contact model providers. The
@@ -97,3 +105,47 @@ append generation as well as sync; per-operation timings exclude generation. The
 corpus currently has no tool calls, forks, subagents, or malformed records. Use
 real-data clones or additional producer fixtures for those cases. Query content
 deliberately contains repeated search terms, stressing common-term FTS.
+
+## OpenCode SQLite workload
+
+`--source-format opencode` creates a separate producer database in WAL mode and
+keeps its writer open while Agentsview reads it. Only this synthetic database
+receives producer writes; the archive is populated through the normal provider.
+The fixture includes the session, project, message, and part table columns and
+indexes from the pinned upstream schema. It deliberately adds no timestamp
+indexes that would make production scans look cheaper. `--empty` applies only to
+JSONL and is rejected for this workload.
+
+Each append inserts a user/assistant pair and text parts in a transaction,
+advancing the session timestamp. The container path is then passed to the
+engine, exercising its session-metadata scan and stored-freshness comparison.
+Each active session also receives an in-place edit to the last assistant text
+part. That edit advances only the part timestamp. The simulator polls the
+session's virtual source, syncs it, and verifies that the archive contains the
+edited text. Thus a session-row-only detector cannot silently pass the workload.
+
+Additional observations distinguish the SQLite read paths:
+
+- `warm_metadata_scan`: streamed session/project watermarks.
+- `warm_full_digest_scan`: streamed metadata with child identity checks.
+- `warm_session_poll`: per-session composite timestamp reads for active
+  sessions.
+- `warm_container_event`: an unchanged container notification through the
+  engine.
+- `active_session_poll`: the same active-session reads after child-only edits.
+- `active_child_edit`: engine processing of those edited virtual sources.
+
+Warm scans and unchanged container events follow `--reconcile-every`; active
+polls and child edits run every iteration. Full digest scans are diagnostic
+provider calls, separate from the engine's five-minute verification schedule.
+They warm SQLite/filesystem caches, so compare equivalent workloads. Source
+writes and parsed-content validation are outside operation timings but inside
+the steady CPU profile. The normal analytical query suite runs for this format
+too. Session/message count and literal usage/content assertions cover both
+layouts in the normal Go suite.
+
+This is the OpenCode `message`/`part` layout consumed by Agentsview, not an
+OpenCode process or an exhaustive producer emulator. It omits the newer
+`session_message` projection, tools, concurrent writers, and deletions. Schema
+and write provenance are recorded in
+[session format sources](session-format-sources.md).

--- a/docs/internal/performance-simulator.md
+++ b/docs/internal/performance-simulator.md
@@ -59,15 +59,18 @@ Each run records:
   and full-text search after each update.
 
 Use `--reconcile-every N` and `--query-every N` to schedule those operations
-once per N update iterations. Zero disables that repeated phase. First-query
-warmup still runs before the steady-state CPU profile starts.
+after N completed update iterations, then after each additional N. For example,
+N=3 runs after updates 3, 6, and 9. Each observation records the number of
+completed updates when measurement began. Zero disables that repeated phase.
+First-query warmup still runs before the steady-state CPU profile starts.
 
 ## Comparing results
 
 The output directory contains:
 
-- `results.json`: configuration, Go version/platform, actual archive totals, and
-  every operation's duration, allocated bytes, allocation count, and heap.
+- `results.json`: configuration, build revision and dirty state when available,
+  executable SHA-256, Go version/platform, actual archive totals, and every
+  operation's duration, allocated bytes, allocation count, and heap.
 - `bench.txt`: non-cold observations in Go benchmark format.
 - `steady.cpu.pprof`: CPU samples collected after ingest and first-query warmup.
 
@@ -134,6 +137,8 @@ Additional observations distinguish the SQLite read paths:
   engine.
 - `active_session_poll`: the same active-session reads after child-only edits.
 - `active_child_edit`: engine processing of those edited virtual sources.
+- `recovery_closed_writer_event`: three container notifications after closing
+  the producer writer, including a disappeared WAL sidecar.
 
 Warm scans and unchanged container events follow `--reconcile-every`; active
 polls and child edits run every iteration. Full digest scans are diagnostic
@@ -149,3 +154,33 @@ OpenCode process or an exhaustive producer emulator. It omits the newer
 `session_message` projection, tools, concurrent writers, and deletions. Schema
 and write provenance are recorded in
 [session format sources](session-format-sources.md).
+
+## Generating sources for a real server
+
+Use `--generate-only --keep-data --output-dir /tmp/new-corpus` with the normal
+workload flags to retain producer files without running the in-process engine.
+The new directory contains `sources.json` with source paths, provider roots,
+workload options, and generator build provenance. Point a separately configured
+branch server at those roots and a new archive directory. Disable all other
+providers and update checks, build with telemetry disabled, and bind to
+loopback. Do not use the installed server's config or archive.
+
+For OpenCode, keep a SQLite writer open in WAL mode, append message/part rows,
+and separately edit a part without advancing the session timestamp. Use current
+timestamps for daemon activity tests. The generated June corpus is historical.
+Open the active session's `/api/v1/sessions/{id}/watch` SSE stream, and verify
+new content through `/api/v1/sessions/{id}/messages?direction=desc&limit=10`.
+Record commit-to-visible latency separately from engine batch duration.
+
+A real server launches sync-worker subprocesses. Capture parent and worker CPU
+and memory separately; parent `/debug/pprof` profiles omit worker execution.
+Record forced-GC heaps and macOS `vmmap -summary` alongside RSS. Keep raw
+captures in a durable output directory, not only an operating-system temporary
+directory.
+
+`make perf-sim` enables VCS build metadata. Direct builds should use
+`go build -buildvcs=true` or `go run -buildvcs=true`. Missing revision metadata
+means unknown, not a clean build. Build overlays are not described by VCS
+metadata; use `--provenance-note` to record the overlay and retain its patch
+with the results. Executable hashes identify binaries but cannot reconstruct
+them.

--- a/docs/internal/performance-simulator.md
+++ b/docs/internal/performance-simulator.md
@@ -197,9 +197,9 @@ archived messages. An explicitly missing virtual-member event still takes the
 member absence path. Removal of the database itself still takes source-missing
 reconciliation when the database removal event is processed.
 
-The sidecar regression compares 8 and 800 sessions for each of the four provider
-layouts and both suffixes. It also deletes a member, closes its writer,
-processes the database/WAL/SHM event batch, and verifies the eventual
-missing-source state after authoritative reconciliation. This defines
-consistency, not a fixed time bound: reconciliation must successfully run before
-that state changes.
+The sidecar scaling regression compares 8 and 800 OpenCode sessions for both
+suffixes. Separate two-session cases cover all four provider layouts: they
+delete a member, close its writer, process the database/WAL/SHM event batch, and
+verify the eventual missing-source state after authoritative reconciliation.
+This defines consistency, not a fixed time bound: reconciliation must
+successfully run before that state changes.

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -101,9 +101,17 @@ add an archived or maintained mirror without replacing the original identity.
 
 ## Claude Code (`claude`)
 
+- **Performance fixture check (2026-09-04):** Rechecked the pinned Codeburn
+  format notes below for project-scoped JSONL. `cmd/perfsim` uses the shared
+  Claude fixture builder to emit user/assistant pairs with message/request
+  identities and usage, then checks actual parsed counts. These synthetic
+  records are a measured subset, not an authoritative or exhaustive schema.
+
 - **Format:** Project-scoped JSONL transcripts, including subagent JSONL, with
   `user`, `assistant`, `system`, and progress records.
+
 - **Evidence:** `no-public-source`.
+
 - **Upstream:** The public
   [Claude Code repository](https://github.com/anthropics/claude-code) at
   `015170d3fd84fb57ef4685a64b673fadd0690dc1` and the
@@ -116,6 +124,7 @@ add an archived or maintained mirror without replacing the original identity.
   and
   [parser](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/src/providers/claude.ts);
   these are consumer observations, not Anthropic authority.
+
 - **Usage and cost:** Assistant messages persist input, output, cache-creation,
   and cache-read tokens. Model IDs are present. No authoritative persisted USD
   cost field is consumed; Agentsview prices the tokens from its catalog.
@@ -131,6 +140,7 @@ add an archived or maintained mirror without replacing the original identity.
   rate. The flat counter stays authoritative: the nested subset is clamped to
   it, and an absent or malformed breakdown falls back to the 5m rate for the
   whole write total (issue #1452).
+
 - **Server tool use (web search):** Anthropic bills server-side web search at
   $10 per 1,000 requests on top of tokens and reports the count in
   `message.usage.server_tool_use.web_search_requests`, which Claude Code
@@ -152,6 +162,7 @@ add an archived or maintained mirror without replacing the original identity.
   neither recorded nor estimated. `web_fetch_requests` is recorded when
   present but is not priced. Data version 82 reparses existing Claude archives
   so persisted side-call counts receive the flat fee.
+
 - **Subagent attribution:** Task-tool subagents are written to their own
   transcripts under `<project>/<parent-session-id>/subagents/`, named
   `agent-<id>.jsonl` (nested one more level under `workflows/<workflow-id>/`
@@ -203,6 +214,7 @@ add an archived or maintained mirror without replacing the original identity.
   SQLite archive. Reverified 2026-08-22 that activity buckets carry the
   selected Claude input-token snapshots identically across SQLite, PostgreSQL,
   and DuckDB.
+
 - **Agentsview:** `internal/parser/claude.go` and
   `internal/parser/claude_provider.go`; local observations and fixtures are
   the implementation evidence for fields not documented upstream. Reverified
@@ -341,6 +353,12 @@ add an archived or maintained mirror without replacing the original identity.
 
 ## Codex (`codex`)
 
+- **Performance fixture check (2026-09-04):** Rechecked the pinned rollout
+  recorder below for session metadata and rollout-item persistence.
+  `cmd/perfsim` generates dated rollouts with session metadata, turn context,
+  response items and token-count events through the shared fixture builder.
+  Its integration test checks parsed messages and aggregate output tokens.
+
 - **Format:** Rollout JSONL files, with a separate JSONL session index used by
   older releases for discovery and metadata. Current releases no longer write
   `session_index.jsonl`; thread titles live in `thread_history_*.sqlite`
@@ -351,7 +369,9 @@ add an archived or maintained mirror without replacing the original identity.
   contain `session_id`, Unix-seconds `ts`, and submitted prompt `text`;
   configured size enforcement can rewrite a retained tail in place. Agentsview
   consumes only the first two fields as a live-activity hint.
+
 - **Evidence:** `source`.
+
 - **Upstream:** Clone `https://github.com/openai/codex.git` at
   `406dc9239492aff6d295cca5eebe2a548548d42f`; see the pinned
   [rollout recorder](https://github.com/openai/codex/blob/406dc9239492aff6d295cca5eebe2a548548d42f/codex-rs/rollout/src/recorder.rs)
@@ -367,6 +387,7 @@ add an archived or maintained mirror without replacing the original identity.
   The
   [configuration schema](https://github.com/openai/codex/blob/406dc9239492aff6d295cca5eebe2a548548d42f/codex-rs/core/config.schema.json)
   defines `save-all` (the default) and `none`.
+
 - **Usage and cost:** `token_count` records include total and last usage with
   input, cached input, cache-write input, output, reasoning output, and total
   tokens. Agentsview currently consumes input, cached input, and output only:
@@ -380,6 +401,7 @@ add an archived or maintained mirror without replacing the original identity.
   2026-09-06 against OpenAI's Luna Reserve help article
   <https://help.openai.com/en/articles/20001499-luna-reserve-in-codex-and-chatgpt-work>
   and Codex `turn_context` model seeding in `internal/parser/codex.go`.
+
 - **Agentsview:** `internal/parser/codex.go` and
   `internal/parser/codex_provider.go`; usage is taken from the last-turn
   counters rather than repeatedly counting cumulative totals. Fork and

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -643,6 +643,22 @@ add an archived or maintained mirror without replacing the original identity.
 
 ## OpenCode (`opencode`)
 
+**Performance fixture check (2026-09-04):** Rechecked the pinned commit's
+[session tables](https://github.com/anomalyco/opencode/blob/67caf894e0843ee370e72839e8265e483233479b/packages/core/src/session/sql.ts),
+[project tables](https://github.com/anomalyco/opencode/blob/67caf894e0843ee370e72839e8265e483233479b/packages/core/src/project/sql.ts),
+[timestamp defaults](https://github.com/anomalyco/opencode/blob/67caf894e0843ee370e72839e8265e483233479b/packages/core/src/database/schema.sql.ts),
+and
+[event projector](https://github.com/anomalyco/opencode/blob/67caf894e0843ee370e72839e8265e483233479b/packages/core/src/session/projector.ts).
+The projector inserts/upserts JSON message and part data; updates stamp
+`time_updated` through the shared column definition. `cmd/perfsim` preserves the
+four provider-consumed tables and their indexes in a synthetic WAL database,
+writes usage-bearing messages, and edits text parts without advancing session
+metadata. Parsed message, usage, and edited-content assertions verify the
+fixture. This subset omits the newer `session_message` projection and does not
+establish support for that layout. A successfully resolved virtual member is no
+longer treated as a missing filesystem path during changed-path preparation;
+missing members still follow normal source-missing reconciliation.
+
 - **Format:** Current SQLite-backed session/message/part records and the legacy
   JSON storage tree.
 - **Evidence:** `source`.

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -657,7 +657,10 @@ metadata. Parsed message, usage, and edited-content assertions verify the
 fixture. This subset omits the newer `session_message` projection and does not
 establish support for that layout. A successfully resolved virtual member is no
 longer treated as a missing filesystem path during changed-path preparation;
-missing members still follow normal source-missing reconciliation.
+missing members still follow normal source-missing reconciliation. The retained
+recovery workload also closes the producer writer and sends WAL-sidecar events.
+A vanished sidecar beside a captured existing database does not imply missing
+sessions; an absent database still follows source-missing reconciliation.
 
 - **Format:** Current SQLite-backed session/message/part records and the legacy
   JSON storage tree.

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -660,7 +660,11 @@ longer treated as a missing filesystem path during changed-path preparation;
 missing members still follow normal source-missing reconciliation. The retained
 recovery workload also closes the producer writer and sends WAL-sidecar events.
 A vanished sidecar beside a captured existing database does not imply missing
-sessions; an absent database still follows source-missing reconciliation.
+sessions; an absent database still follows source-missing reconciliation. Member
+deletions inside a surviving OpenCode-family container are detected by the next
+successful authoritative root/container reconciliation, not promised by a
+sidecar event. The retained integration scenario checks that eventual state and
+preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
 
 - **Format:** Current SQLite-backed session/message/part records and the legacy
   JSON storage tree.

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -206,21 +206,12 @@ func (db *DB) GetStats(
 	if excludeAutomated {
 		filter += " AND is_automated = 0"
 	}
-	query := fmt.Sprintf(`
-		SELECT
-			(SELECT COUNT(*) FROM sessions
-			 WHERE %s),
-			(SELECT COALESCE(SUM(message_count), 0)
-			 FROM sessions WHERE %s),
-			(SELECT COUNT(DISTINCT project) FROM sessions
-			 WHERE %s),
-			(SELECT COUNT(DISTINCT machine) FROM sessions
-			 WHERE %s),
-			(SELECT MIN(COALESCE(
-				NULLIF(started_at, ''), created_at
-			 )) FROM sessions
-			 WHERE %s)`,
-		filter, filter, filter, filter, filter)
+	// Sidebar polling needs all totals for the same rows. Aggregate them
+	// together so each refresh visits the filtered sessions only once.
+	query := `SELECT COUNT(*), COALESCE(SUM(message_count), 0),
+		COUNT(DISTINCT project), COUNT(DISTINCT machine),
+		MIN(COALESCE(NULLIF(started_at, ''), created_at))
+		FROM sessions WHERE ` + filter
 
 	var s Stats
 	err := db.getReader().QueryRowContext(ctx, query).Scan(

--- a/internal/db/stats_aggregate_test.go
+++ b/internal/db/stats_aggregate_test.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatsAllTotalsUseSameFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	stats, err := d.GetStats(ctx, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, Stats{}, stats)
+
+	for _, row := range []struct {
+		id, project, machine, started, relationship string
+		messages, users                             int
+		automated                                   bool
+		deleted                                     *string
+	}{
+		{"human", "project-a", "machine-a", "2026-01-04T00:00:00Z", "", 10, 5, false, nil},
+		{"one-shot", "project-a", "machine-b", "2026-01-03T00:00:00Z", "", 3, 1, false, nil},
+		{"automated", "project-b", "machine-b", "2026-01-02T00:00:00Z", "", 4, 1, true, nil},
+		{"automated-multi", "project-b", "machine-c", "2026-01-01T00:00:00Z", "", 6, 3, true, nil},
+		{"empty", "excluded", "excluded", "2025-01-01T00:00:00Z", "", 0, 0, false, nil},
+		{"child", "excluded", "excluded", "2025-01-01T00:00:00Z", "subagent", 100, 50, false, nil},
+		{"fork", "excluded", "excluded", "2025-01-01T00:00:00Z", "fork", 100, 50, false, nil},
+		{"deleted", "excluded", "excluded", "2025-01-01T00:00:00Z", "", 100, 50, false, new("2026-02-01T00:00:00Z")},
+	} {
+		_, err := d.getWriter().ExecContext(ctx, `INSERT INTO sessions
+			(id, project, machine, agent, started_at, relationship_type,
+			 message_count, user_message_count, is_automated, deleted_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, row.id, row.project, row.machine, "claude",
+			row.started, row.relationship, row.messages, row.users, row.automated, row.deleted)
+		require.NoError(t, err)
+	}
+	for _, tc := range []struct {
+		name               string
+		oneShot, automated bool
+		want               Stats
+	}{
+		{"all", false, false, Stats{SessionCount: 4, MessageCount: 23,
+			ProjectCount: 2, MachineCount: 3,
+			EarliestSession: new("2026-01-01T00:00:00Z")}},
+		{"exclude one-shot", true, false, Stats{SessionCount: 3, MessageCount: 20,
+			ProjectCount: 2, MachineCount: 3,
+			EarliestSession: new("2026-01-01T00:00:00Z")}},
+		{"exclude automated", false, true, Stats{SessionCount: 2, MessageCount: 13,
+			ProjectCount: 1, MachineCount: 2,
+			EarliestSession: new("2026-01-03T00:00:00Z")}},
+		{"exclude both", true, true, Stats{SessionCount: 1, MessageCount: 10,
+			ProjectCount: 1, MachineCount: 1,
+			EarliestSession: new("2026-01-04T00:00:00Z")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := d.GetStats(ctx, tc.oneShot, tc.automated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/db/stats_bench_test.go
+++ b/internal/db/stats_bench_test.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The sidebar polls these totals even when no transcript is open.
+func BenchmarkGetStats(b *testing.B) {
+	d := testDB(b)
+	_, err := d.getWriter().Exec(`WITH RECURSIVE n(i) AS (
+		SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i < 10000
+		) INSERT INTO sessions (id, project, machine, agent, message_count,
+		user_message_count, started_at)
+		SELECT 'session-' || i, 'project-' || (i % 100), 'machine-' || (i % 3),
+		'claude', 10, 5, '2026-01-01T00:00:00Z' FROM n`)
+	require.NoError(b, err)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		stats, err := d.GetStats(ctx, false, false)
+		require.NoError(b, err)
+		require.Equal(b, 10000, stats.SessionCount)
+		require.Equal(b, 100000, stats.MessageCount)
+	}
+}

--- a/internal/parser/codex_discovery_bench_test.go
+++ b/internal/parser/codex_discovery_bench_test.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCodexStreamingDiscovery(b *testing.B) {
+	root := b.TempDir()
+	for i := range 1000 {
+		path := filepath.Join(root, fmt.Sprintf("rollout-2026-06-01T10-00-00-00000000-0000-4000-8000-%012d.jsonl", i))
+		require.NoError(b, os.WriteFile(path, nil, 0o600))
+	}
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(b, ok)
+	discoverer := provider.(StreamingDiscoverer)
+	b.ReportAllocs()
+	for b.Loop() {
+		count := 0
+		require.NoError(b, discoverer.DiscoverEach(b.Context(), func(SourceRef) error { count++; return nil }))
+		require.Equal(b, 1000, count)
+	}
+}
+
+func TestCodexStreamingDiscoveryExcludesSymlinksAndDirectories(t *testing.T) {
+	root := t.TempDir()
+	name := "rollout-2026-06-01T10-00-00-00000000-0000-4000-8000-000000000001.jsonl"
+	target := filepath.Join(root, name)
+	require.NoError(t, os.WriteFile(target, nil, 0o600))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "rollout-directory.jsonl"), 0o700))
+	if err := os.Symlink(target, filepath.Join(root, "rollout-link.jsonl")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	var paths []string
+	require.NoError(t, provider.(StreamingDiscoverer).DiscoverEach(t.Context(), func(s SourceRef) error { paths = append(paths, s.DisplayPath); return nil }))
+	require.Equal(t, []string{target}, paths)
+}

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -614,13 +614,15 @@ func (s codexSourceSet) discoverEachRoot(
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if !isCodexSessionFilename(entry.Name()) {
+		if !isCodexSessionFilename(entry.Name()) || !entry.Type().IsRegular() {
 			return nil
 		}
-		source, ok := s.sourceRef(root, path, true)
+		// ReadDir already classified the entry without following symlinks.
+		// Reuse that result instead of issuing another lstat per rollout.
+		source, ok := s.sourceRef(root, path, false)
 		if !ok {
 			if _, _, supported := CodexSessionPathInfo(root, path); supported {
-				source, ok = s.directPathSource(root, path, true)
+				source, ok = s.directPathSource(root, path, false)
 			}
 		}
 		if !ok {

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -492,7 +492,7 @@ func ResolveCodexShallowWatchRoots(root string) []string {
 // expansion. The name carries no legacy entrypoint verb so the
 // provider can call it without shimming a Discover* free function.
 func ClaudeProjectSessionFiles(projectsDir string) []DiscoveredFile {
-	return projectJSONLSessionFiles(projectsDir, AgentClaude, claudeS3Scanner)
+	return projectJSONLSessionFiles(projectsDir, AgentClaude, claudeS3Scanner, nil)
 }
 
 // IcodemateCLIProjectSessionFiles enumerates a terminal CLI projects root in
@@ -501,7 +501,20 @@ func ClaudeProjectSessionFiles(projectsDir string) []DiscoveredFile {
 // the icodemate provider segment (.../raw/icodemate) so machine metadata and
 // source labeling match the owning agent instead of Claude's.
 func IcodemateCLIProjectSessionFiles(projectsDir string) []DiscoveredFile {
-	return projectJSONLSessionFiles(projectsDir, AgentIcodemate, icodemateCLIS3Scanner)
+	return projectJSONLSessionFiles(projectsDir, AgentIcodemate, icodemateCLIS3Scanner, nil)
+}
+
+// ProjectJSONLSessionCandidates finds only the requested Claude-layout filename
+// stems. Root transcripts need one exact probe per project and ID; subagents
+// still require traversal because workflow directories do not encode their ID.
+func ProjectJSONLSessionCandidates(
+	root string, agent AgentType, ids map[string]struct{},
+) []DiscoveredFile {
+	scanner := claudeS3Scanner
+	if agent == AgentIcodemate {
+		scanner = icodemateCLIS3Scanner
+	}
+	return projectJSONLSessionFiles(root, agent, scanner, ids)
 }
 
 // projectJSONLSessionFiles walks one Claude-layout projects root
@@ -514,6 +527,7 @@ func projectJSONLSessionFiles(
 	projectsDir string,
 	agent AgentType,
 	scanner func() S3SessionScanner,
+	wanted map[string]struct{},
 ) []DiscoveredFile {
 	if strings.HasPrefix(projectsDir, "s3://") {
 		return s3PrefixScan(projectsDir, scanner())
@@ -523,6 +537,13 @@ func projectJSONLSessionFiles(
 		return nil
 	}
 
+	nested := wanted == nil
+	for id := range wanted {
+		if strings.HasPrefix(id, "agent-") {
+			nested = true
+			break
+		}
+	}
 	var files []DiscoveredFile
 	for _, entry := range entries {
 		if !isDirOrSymlink(entry, projectsDir) {
@@ -530,6 +551,16 @@ func projectJSONLSessionFiles(
 		}
 
 		projDir := filepath.Join(projectsDir, entry.Name())
+		if wanted != nil && !nested {
+			for id := range wanted {
+				path := filepath.Join(projDir, id+".jsonl")
+				info, err := os.Lstat(path)
+				if err == nil && !info.IsDir() {
+					files = append(files, DiscoveredFile{Path: path, Project: entry.Name(), Agent: agent})
+				}
+			}
+			continue
+		}
 		sessionFiles, err := os.ReadDir(projDir)
 		if err != nil {
 			continue
@@ -544,6 +575,11 @@ func projectJSONLSessionFiles(
 				continue
 			}
 			stem := strings.TrimSuffix(name, ".jsonl")
+			if wanted != nil {
+				if _, ok := wanted[stem]; !ok {
+					continue
+				}
+			}
 			if strings.HasPrefix(stem, "agent-") {
 				continue
 			}
@@ -576,6 +612,11 @@ func projectJSONLSessionFiles(
 					if !strings.HasPrefix(name, "agent-") ||
 						!strings.HasSuffix(name, ".jsonl") {
 						return nil
+					}
+					if wanted != nil {
+						if _, ok := wanted[strings.TrimSuffix(name, ".jsonl")]; !ok {
+							return nil
+						}
 					}
 					files = append(files, DiscoveredFile{
 						Path:    path,

--- a/internal/parser/project_candidates_test.go
+++ b/internal/parser/project_candidates_test.go
@@ -1,0 +1,40 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectSessionCandidatesKeepNestedSubagentsAndProviderLabels(t *testing.T) {
+	for _, agent := range []AgentType{AgentClaude, AgentIcodemate} {
+		t.Run(string(agent), func(t *testing.T) {
+			root := t.TempDir()
+			paths := []string{"project-a/shared.jsonl", "project-b/shared.jsonl", "project-a/unrelated.jsonl", "project-a/shared/subagents/workflows/task/agent-child.jsonl"}
+			for _, name := range paths {
+				path := filepath.Join(root, filepath.FromSlash(name))
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+				require.NoError(t, os.WriteFile(path, nil, 0o600))
+			}
+			for _, tc := range []struct {
+				ids  map[string]struct{}
+				want []string
+			}{
+				{map[string]struct{}{"shared": {}}, []string{paths[0], paths[1]}},
+				{map[string]struct{}{"agent-child": {}}, []string{paths[3]}},
+			} {
+				var got []string
+				for _, file := range ProjectJSONLSessionCandidates(root, agent, tc.ids) {
+					assert.Equal(t, agent, file.Agent)
+					rel, err := filepath.Rel(root, file.Path)
+					require.NoError(t, err)
+					got = append(got, filepath.ToSlash(rel))
+				}
+				assert.ElementsMatch(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -1018,20 +1018,12 @@ func (s *Store) GetStats(
 	if excludeAutomated {
 		filter += " AND is_automated = FALSE"
 	}
-	query := fmt.Sprintf(`
-		SELECT
-			(SELECT COUNT(*) FROM sessions
-			 WHERE %s),
-			(SELECT COALESCE(SUM(message_count), 0)
-			 FROM sessions WHERE %s),
-			(SELECT COUNT(DISTINCT project) FROM sessions
-			 WHERE %s),
-			(SELECT COUNT(DISTINCT machine) FROM sessions
-			 WHERE %s),
-			(SELECT MIN(COALESCE(started_at, created_at))
-			 FROM sessions
-			 WHERE %s)`,
-		filter, filter, filter, filter, filter)
+	// Sidebar polling needs all totals for the same rows. Aggregate them
+	// together so each refresh visits the filtered sessions only once.
+	query := `SELECT COUNT(*), COALESCE(SUM(message_count), 0),
+		COUNT(DISTINCT project), COUNT(DISTINCT machine),
+		MIN(COALESCE(started_at, created_at))
+		FROM sessions WHERE ` + filter
 
 	var st db.Stats
 	var earliest *time.Time

--- a/internal/postgres/stats_pgtest_test.go
+++ b/internal/postgres/stats_pgtest_test.go
@@ -1,0 +1,68 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestStatsAllTotalsUseSameFilter(t *testing.T) {
+	_, d := prepareUsageSchema(t, "agentsview_stats_filters_test")
+	ctx := context.Background()
+	stats, err := d.GetStats(ctx, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, db.Stats{}, stats)
+
+	for _, row := range []struct {
+		id, project, machine, started, relationship string
+		messages, users                             int
+		automated                                   bool
+		deleted                                     *string
+	}{
+		{"human", "project-a", "machine-a", "2026-01-04T00:00:00Z", "", 10, 5, false, nil},
+		{"one-shot", "project-a", "machine-b", "2026-01-03T00:00:00Z", "", 3, 1, false, nil},
+		{"automated", "project-b", "machine-b", "2026-01-02T00:00:00Z", "", 4, 1, true, nil},
+		{"automated-multi", "project-b", "machine-c", "2026-01-01T00:00:00Z", "", 6, 3, true, nil},
+		{"empty", "excluded", "excluded", "2025-01-01T00:00:00Z", "", 0, 0, false, nil},
+		{"child", "excluded", "excluded", "2025-01-01T00:00:00Z", "subagent", 100, 50, false, nil},
+		{"fork", "excluded", "excluded", "2025-01-01T00:00:00Z", "fork", 100, 50, false, nil},
+		{"deleted", "excluded", "excluded", "2025-01-01T00:00:00Z", "", 100, 50, false, new("2026-02-01T00:00:00Z")},
+	} {
+		_, err := d.DB().ExecContext(ctx, `INSERT INTO sessions
+			(id, project, machine, agent, started_at, relationship_type,
+			 message_count, user_message_count, is_automated, deleted_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`, row.id, row.project, row.machine, "claude",
+			row.started, row.relationship, row.messages, row.users, row.automated, row.deleted)
+		require.NoError(t, err)
+	}
+	for _, tc := range []struct {
+		name               string
+		oneShot, automated bool
+		want               db.Stats
+	}{
+		{"all", false, false, db.Stats{SessionCount: 4, MessageCount: 23,
+			ProjectCount: 2, MachineCount: 3,
+			EarliestSession: new("2026-01-01T00:00:00Z")}},
+		{"exclude one-shot", true, false, db.Stats{SessionCount: 3, MessageCount: 20,
+			ProjectCount: 2, MachineCount: 3,
+			EarliestSession: new("2026-01-01T00:00:00Z")}},
+		{"exclude automated", false, true, db.Stats{SessionCount: 2, MessageCount: 13,
+			ProjectCount: 1, MachineCount: 2,
+			EarliestSession: new("2026-01-03T00:00:00Z")}},
+		{"exclude both", true, true, db.Stats{SessionCount: 1, MessageCount: 10,
+			ProjectCount: 1, MachineCount: 1,
+			EarliestSession: new("2026-01-04T00:00:00Z")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := d.GetStats(ctx, tc.oneShot, tc.automated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/sync/claude_candidates_perf_test.go
+++ b/internal/sync/claude_candidates_perf_test.go
@@ -1,0 +1,50 @@
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestClaudeChangedPathCandidateWorkIgnoresUnrelatedSessions(t *testing.T) {
+	var allocations []float64
+	for _, size := range []int{8, 8000} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			root := t.TempDir()
+			for _, project := range []string{"project-a", "project-b"} {
+				require.NoError(t, os.Mkdir(filepath.Join(root, project), 0o700))
+			}
+			changed := filepath.Join(root, "project-a", "shared.jsonl")
+			duplicate := filepath.Join(root, "project-b", "shared.jsonl")
+			require.NoError(t, os.WriteFile(changed, []byte("{}\n"), 0o600))
+			require.NoError(t, os.WriteFile(duplicate, []byte("{}\n"), 0o600))
+			require.NoError(t, os.Chtimes(changed, time.Unix(100, 0), time.Unix(100, 0)))
+			require.NoError(t, os.Chtimes(duplicate, time.Unix(200, 0), time.Unix(200, 0)))
+			for i := range size {
+				require.NoError(t, os.WriteFile(filepath.Join(root, "project-a", fmt.Sprintf("unrelated-%d.jsonl", i)), nil, 0o600))
+			}
+			database := openTestDB(t)
+			engine := NewEngine(database, EngineConfig{AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}}})
+			t.Cleanup(engine.Close)
+			var files []parser.DiscoveredFile
+			var err error
+			allocations = append(allocations, testing.AllocsPerRun(3, func() { files, err = engine.classifyPaths(t.Context(), []string{changed}) }))
+			require.NoError(t, err)
+			require.Len(t, files, 1)
+			assert.Equal(t, duplicate, files[0].Path, "the newer duplicate must still win")
+			require.NoError(t, os.Remove(duplicate))
+			files, err = engine.classifyPaths(t.Context(), []string{changed})
+			require.NoError(t, err)
+			require.Len(t, files, 1)
+			assert.Equal(t, changed, files[0].Path, "a deleted duplicate must not stay selected")
+		})
+	}
+	assert.Less(t, allocations[1], allocations[0]*2, "one changed transcript must not enumerate thousands of unrelated files")
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -552,8 +552,10 @@ type Engine struct {
 	// non-interactive sessions (nil result). The file is
 	// retried when its mtime changes. S3 entries also keep an
 	// in-memory source fingerprint when one is available.
-	skipMu           gosync.RWMutex
-	skipCache        map[string]int64
+	skipMu    gosync.RWMutex
+	skipCache map[string]int64
+	// skipCacheDirty is protected by skipMu and cleared only for a persistence attempt.
+	skipCacheDirty   bool
 	skipFingerprints map[string]string
 	// retryUnsafeSkipPaths records sources whose successful processing changed
 	// exclusion or source-missing state in the current database. A rebuild that
@@ -906,6 +908,7 @@ func NewEngine(
 		homeDir:                 userHomeDirOrEmpty(),
 		goos:                    runtime.GOOS,
 		skipCache:               skipCache,
+		skipCacheDirty:          true,
 		skipFingerprints:        make(map[string]string),
 		skipHashKeys:            skipHashKeys,
 		s3CodexIndexCache:       make(map[string]s3CodexIndexSnapshot),
@@ -934,7 +937,6 @@ func NewEngine(
 		reconciliationSpoolFactory: func(path string) (reconciliationSpoolStore, error) {
 			return newReconciliationSpool(path)
 		},
-		claudeProjectSessionFiles: parser.ClaudeProjectSessionFiles,
 	}
 	if len(cfg.InitialSkipCache) > 0 {
 		e.InjectSkipCache(cfg.InitialSkipCache)
@@ -2487,18 +2489,17 @@ func (e *Engine) expandClaudeDuplicateCandidates(
 
 	out := files
 	for agent, ids := range sessionIDs {
-		listSessionFiles := parser.IcodemateCLIProjectSessionFiles
-		if agent == parser.AgentClaude {
-			listSessionFiles = e.claudeProjectSessionFiles
-			if listSessionFiles == nil {
-				listSessionFiles = parser.ClaudeProjectSessionFiles
-			}
-		}
 		for _, root := range e.agentDirs[agent] {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
-			for _, candidate := range listSessionFiles(root) {
+			var candidates []parser.DiscoveredFile
+			if agent == parser.AgentClaude && e.claudeProjectSessionFiles != nil {
+				candidates = e.claudeProjectSessionFiles(root)
+			} else {
+				candidates = parser.ProjectJSONLSessionCandidates(root, agent, ids)
+			}
+			for _, candidate := range candidates {
 				if err := ctx.Err(); err != nil {
 					return nil, err
 				}
@@ -2794,6 +2795,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 			// archive there.
 			e.skipMu.Lock()
 			e.skipCache = preBuildSkipCache
+			e.skipCacheDirty = true
 			e.skipHashKeys = preBuildSkipHashKeys
 			e.skipMu.Unlock()
 			stats.Tombstoned = 0
@@ -2942,12 +2944,14 @@ func (e *Engine) resyncBuildLocked(
 	savedSkipCache := e.skipCache
 	savedSkipHashKeys := e.skipHashKeys
 	e.skipCache = make(map[string]int64)
+	e.skipCacheDirty = true
 	e.skipHashKeys = make(map[string]string)
 	e.skipMu.Unlock()
 
 	restoreSkipCache := func() {
 		e.skipMu.Lock()
 		e.skipCache = savedSkipCache
+		e.skipCacheDirty = true
 		e.skipHashKeys = savedSkipHashKeys
 		e.skipMu.Unlock()
 	}
@@ -3844,6 +3848,7 @@ func (e *Engine) ReloadSkipCache() error {
 
 	e.skipMu.Lock()
 	e.skipCache = skipCache
+	e.skipCacheDirty = true
 	e.skipHashKeys = skipHashKeys
 	e.skipFingerprints = make(map[string]string)
 	e.skipMu.Unlock()
@@ -13257,8 +13262,16 @@ func (e *Engine) cacheSkip(
 	path string, mtime int64, sourceFingerprint ...string,
 ) int {
 	e.skipMu.Lock()
+	old, exists := e.skipCache[path]
+	previousSize, previouslyDirty := len(e.skipCache), e.skipCacheDirty
 	work := e.removeSkipHashSiblingsLocked(path)
+	if !exists || old != mtime {
+		e.skipCacheDirty = true
+	}
 	e.skipCache[path] = mtime
+	if exists && old == mtime && len(e.skipCache) == previousSize {
+		e.skipCacheDirty = previouslyDirty
+	}
 	if base, _, hashed := strings.Cut(path, sourceHashSkipMarker); hashed {
 		e.skipHashKeys[base] = path
 	}
@@ -13291,6 +13304,7 @@ func (e *Engine) clearSkip(path string) int {
 func (e *Engine) clearSkipInMemory(path string) int {
 	e.skipMu.Lock()
 	defer e.skipMu.Unlock()
+	before := len(e.skipCache)
 	work := e.removeSkipHashSiblingsLocked(path)
 	delete(e.skipCache, path)
 	delete(e.skipFingerprints, path)
@@ -13300,6 +13314,7 @@ func (e *Engine) clearSkipInMemory(path string) int {
 		delete(e.skipCache, legacyPath)
 		delete(e.skipFingerprints, legacyPath)
 	}
+	e.skipCacheDirty = e.skipCacheDirty || len(e.skipCache) != before
 	return work
 }
 
@@ -13323,6 +13338,8 @@ func (e *Engine) clearSkipPersistent(path string) (int, error) {
 }
 
 func (e *Engine) removeSkipHashSiblingsLocked(path string) int {
+	before := len(e.skipCache)
+	defer func() { e.skipCacheDirty = e.skipCacheDirty || len(e.skipCache) != before }()
 	if e.skipHashKeys == nil {
 		e.skipHashKeys, _ = normalizeSourceHashSkipCache(
 			e.skipCache, e.skipFingerprints,
@@ -13353,6 +13370,7 @@ func (e *Engine) removeSkipHashSiblingsLocked(path string) int {
 func (e *Engine) clearWatcherOverflowCaches() {
 	e.skipMu.Lock()
 	e.skipCache = make(map[string]int64)
+	e.skipCacheDirty = true
 	e.skipFingerprints = make(map[string]string)
 	e.skipHashKeys = make(map[string]string)
 	e.skipMu.Unlock()
@@ -13386,6 +13404,9 @@ func (e *Engine) InjectSkipCache(entries map[string]int64) {
 	}
 	for path, mtime := range incoming {
 		e.removeSkipHashSiblingsLocked(path)
+		if old, exists := e.skipCache[path]; !exists || old != mtime {
+			e.skipCacheDirty = true
+		}
 		e.skipCache[path] = mtime
 		if base, _, hashed := strings.Cut(path, sourceHashSkipMarker); hashed {
 			e.skipHashKeys[base] = path
@@ -13447,12 +13468,23 @@ func (e *Engine) persistSkipCacheInto(target *db.DB) int {
 	if e.ephemeral {
 		return 0
 	}
-	e.skipMu.RLock()
+	e.skipMu.Lock()
+	if target == e.db && !e.skipCacheDirty {
+		count := len(e.skipCache)
+		e.skipMu.Unlock()
+		return count
+	}
 	snapshot := make(map[string]int64, len(e.skipCache))
 	maps.Copy(snapshot, e.skipCache)
-	e.skipMu.RUnlock()
+	if target == e.db {
+		e.skipCacheDirty = false
+	}
+	e.skipMu.Unlock()
 
 	if err := target.ReplaceSkippedFiles(snapshot); err != nil {
+		e.skipMu.Lock()
+		e.skipCacheDirty = true
+		e.skipMu.Unlock()
 		log.Printf("persisting skip cache: %v", err)
 	}
 	return len(snapshot)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1632,7 +1632,19 @@ func (e *Engine) prepareChangedPathSync(
 		}
 	}
 	prepared.missingPaths = slices.DeleteFunc(prepared.missingPaths, func(path string) bool {
-		_, resolved := resolvedVirtual[filepath.Clean(path)]
+		path = filepath.Clean(path)
+		// Closing a SQLite writer can remove its WAL/SHM files while the
+		// container and every session remain. The pre-discovery capture
+		// proves this is a known, existing container. Classify its contents
+		// normally, but do not infer source loss from a vanished sidecar.
+		for _, suffix := range []string{"-wal", "-shm"} {
+			if container, ok := strings.CutSuffix(path, suffix); ok {
+				if _, exists := prepared.preContainerStates[container]; exists {
+					return true
+				}
+			}
+		}
+		_, resolved := resolvedVirtual[path]
 		return resolved
 	})
 	return prepared

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1621,6 +1621,20 @@ func (e *Engine) prepareChangedPathSync(
 	prepared.missingPaths = omitMissingPersistentContainerPaths(
 		prepared.missingPaths, prepared.files,
 	)
+	// OpenCode virtual paths never exist as filesystem entries. Its changed-
+	// path provider already checked that each returned SQLite member exists;
+	// do not turn a successful single-member classification into a container-
+	// wide absence scan. Missing members return no source and keep that scan.
+	resolvedVirtual := make(map[string]struct{})
+	for _, file := range prepared.files {
+		if file.ProviderSource != nil && isOpenCodeFormatSQLiteVirtualPath(file.Agent, file.Path) {
+			resolvedVirtual[filepath.Clean(file.Path)] = struct{}{}
+		}
+	}
+	prepared.missingPaths = slices.DeleteFunc(prepared.missingPaths, func(path string) bool {
+		_, resolved := resolvedVirtual[filepath.Clean(path)]
+		return resolved
+	})
 	return prepared
 }
 

--- a/internal/sync/opencode_virtual_event_perf_test.go
+++ b/internal/sync/opencode_virtual_event_perf_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,4 +50,42 @@ func TestOpenCodeVirtualEventDoesNotRecheckUnrelatedMembers(t *testing.T) {
 	}
 	assert.Less(t, allocations[1], allocations[0]*3,
 		"an existing virtual member must not trigger archive-wide absence checks")
+}
+
+func TestOpenCodeMissingWALDoesNotRecheckUnrelatedMembers(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "project-a", "/workspace/project-a")
+	oc.inTransaction(t, func(oc *openCodeTestDB) {
+		for i := range 800 {
+			seedOpenCodeSQLiteTextSession(t, oc, "project-a", fmt.Sprintf("ses%05d", i),
+				1779012000000, 1779012030000, "prompt", "answer")
+		}
+	})
+	require.Equal(t, 800, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.NoFileExists(t, oc.path+"-wal")
+	var syncErr error
+	baseline := testing.AllocsPerRun(3, func() {
+		syncErr = env.engine.SyncPathsContext(t.Context(), []string{oc.path})
+	})
+	require.NoError(t, syncErr)
+	removedWAL := testing.AllocsPerRun(3, func() {
+		syncErr = env.engine.SyncPathsContext(t.Context(), []string{oc.path + "-wal"})
+	})
+	require.NoError(t, syncErr)
+	t.Logf("container %.0f allocations; missing WAL %.0f allocations", baseline, removedWAL)
+	assert.Less(t, removedWAL, baseline*3, "a vanished SQLite sidecar does not prove any session disappeared")
+	stored, err := env.db.GetSessionFull(t.Context(), "opencode:ses00000")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Nil(t, stored.SourceMissingAt)
+	assertMessageContent(t, env.db, "opencode:ses00000", "prompt", "answer")
+	require.NoError(t, oc.db.Close())
+	require.NoError(t, os.Rename(oc.path, oc.path+".removed"))
+	require.NoError(t, env.engine.SyncPathsContext(t.Context(), []string{oc.path + "-wal"}))
+	stored, err = env.db.GetSessionFull(t.Context(), "opencode:ses00000")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.NotNil(t, stored.SourceMissingAt)
+	assertMessageContent(t, env.db, "opencode:ses00000", "prompt", "answer")
 }

--- a/internal/sync/opencode_virtual_event_perf_test.go
+++ b/internal/sync/opencode_virtual_event_perf_test.go
@@ -56,7 +56,48 @@ func TestOpenCodeVirtualEventDoesNotRecheckUnrelatedMembers(t *testing.T) {
 		"an existing virtual member must not trigger archive-wide absence checks")
 }
 
-func TestOpenCodeFamilyMissingSidecarWorkStaysBounded(t *testing.T) {
+func TestOpenCodeMissingSidecarWorkStaysBounded(t *testing.T) {
+	allocations := map[string][]float64{"-wal": {}, "-shm": {}}
+	for _, count := range []int{8, 800} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+			oc := createOpenCodeDB(t, env.opencodeDir)
+			_, err := oc.db.Exec("PRAGMA journal_mode=WAL")
+			require.NoError(t, err)
+			oc.addProject(t, "project-a", "/workspace/project-a")
+			oc.inTransaction(t, func(oc *openCodeTestDB) {
+				for i := range count {
+					seedOpenCodeSQLiteTextSession(t, oc, "project-a", fmt.Sprintf("ses%05d", i),
+						1779012000000, 1779012030000, "prompt", "answer")
+				}
+			})
+			require.Equal(t, count, env.engine.SyncAll(t.Context(), nil).Synced)
+			require.NoError(t, oc.db.Close())
+			for _, suffix := range []string{"-wal", "-shm"} {
+				work := testing.AllocsPerRun(3, func() {
+					// Reader probes may recreate sidecars. Close a producer
+					// connection before every sample, including warmup, so
+					// every measured event still names a missing sidecar.
+					writer, err := sql.Open("sqlite3", oc.path)
+					require.NoError(t, err)
+					_, err = writer.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+					require.NoError(t, err)
+					require.NoError(t, writer.Close())
+					require.NoFileExists(t, oc.path+suffix)
+					require.NoError(t, env.engine.SyncPathsContext(t.Context(), []string{oc.path + suffix}))
+				})
+				allocations[suffix] = append(allocations[suffix], work)
+			}
+		})
+	}
+	for suffix, work := range allocations {
+		require.Len(t, work, 2)
+		t.Logf("%s: 8 sessions %.0f allocations; 800 sessions %.0f allocations", suffix, work[0], work[1])
+		assert.Less(t, work[1], work[0]*3, "missing sidecar work must not scale with archive size")
+	}
+}
+
+func TestOpenCodeFamilySidecarDeletionReconciliation(t *testing.T) {
 	for _, provider := range []struct {
 		agent    parser.AgentType
 		filename string
@@ -65,83 +106,49 @@ func TestOpenCodeFamilyMissingSidecarWorkStaysBounded(t *testing.T) {
 		{parser.AgentMiMoCode, "mimocode.db"}, {parser.AgentIcodemate, "icodemate.db"},
 	} {
 		t.Run(string(provider.agent), func(t *testing.T) {
-			allocations := map[string][]float64{"-wal": {}, "-shm": {}}
-			for _, count := range []int{8, 800} {
-				t.Run(fmt.Sprint(count), func(t *testing.T) {
-					root := t.TempDir()
-					archive := dbtest.OpenTestDB(t)
-					engine := syncengine.NewEngine(archive, syncengine.EngineConfig{
-						AgentDirs: map[parser.AgentType][]string{provider.agent: {root}}, Machine: "local",
-					})
-					t.Cleanup(engine.Close)
-					oc := createOpenCodeLikeDB(t, filepath.Join(root, provider.filename), string(provider.agent))
-					_, err := oc.db.Exec("PRAGMA journal_mode=WAL")
-					require.NoError(t, err)
-					oc.addProject(t, "project-a", "/workspace/project-a")
-					oc.inTransaction(t, func(oc *openCodeTestDB) {
-						for i := range count {
-							seedOpenCodeSQLiteTextSession(t, oc, "project-a", fmt.Sprintf("ses%05d", i),
-								1779012000000, 1779012030000, "prompt", "answer")
-						}
-					})
-					require.Equal(t, count, engine.SyncAll(t.Context(), nil).Synced)
-					require.NoError(t, oc.db.Close())
-					for _, suffix := range []string{"-wal", "-shm"} {
-						work := testing.AllocsPerRun(3, func() {
-							// Reader probes may recreate sidecars. Close a producer
-							// connection before every sample, including warmup, so
-							// every measured event still names a missing sidecar.
-							writer, err := sql.Open("sqlite3", oc.path)
-							require.NoError(t, err)
-							_, err = writer.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
-							require.NoError(t, err)
-							require.NoError(t, writer.Close())
-							require.NoFileExists(t, oc.path+suffix)
-							require.NoError(t, engine.SyncPathsContext(t.Context(), []string{oc.path + suffix}))
-						})
-						allocations[suffix] = append(allocations[suffix], work)
-					}
-					if count != 8 {
-						return
-					}
-					// Deleting a member then checkpointing the writer does not make the
-					// surviving container disappear. The authoritative pass detects it.
-					writer, err := sql.Open("sqlite3", oc.path)
-					require.NoError(t, err)
-					t.Cleanup(func() { _ = writer.Close() })
-					_, err = writer.Exec("DELETE FROM session WHERE id = 'ses00000'")
-					require.NoError(t, err)
-					require.NoError(t, writer.Close())
-					require.NoError(t, engine.SyncPathsContext(t.Context(), []string{oc.path, oc.path + "-wal", oc.path + "-shm"}))
-					id := string(provider.agent) + ":ses00000"
-					stored, err := archive.GetSessionFull(t.Context(), id)
-					require.NoError(t, err)
-					require.NotNil(t, stored)
-					assert.Nil(t, stored.SourceMissingAt)
-					_, _, err = engine.ReconcileWatchRootsWithStats(t.Context(), []string{root}, true, nil)
-					require.NoError(t, err)
-					stored, err = archive.GetSessionFull(t.Context(), id)
-					require.NoError(t, err)
-					require.NotNil(t, stored)
-					assert.NotNil(t, stored.SourceMissingAt)
-					assertMessageContent(t, archive, id, "prompt", "answer")
-					// Container removal still marks the surviving member missing, without
-					// removing its archived messages.
-					require.NoError(t, os.Rename(oc.path, oc.path+".removed"))
-					require.NoError(t, engine.SyncPathsContext(t.Context(), []string{oc.path, oc.path + "-wal", oc.path + "-shm"}))
-					other := string(provider.agent) + ":ses00001"
-					stored, err = archive.GetSessionFull(t.Context(), other)
-					require.NoError(t, err)
-					require.NotNil(t, stored)
-					assert.NotNil(t, stored.SourceMissingAt)
-					assertMessageContent(t, archive, other, "prompt", "answer")
-				})
+			root := t.TempDir()
+			archive := dbtest.OpenTestDB(t)
+			engine := syncengine.NewEngine(archive, syncengine.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{provider.agent: {root}}, Machine: "local",
+			})
+			t.Cleanup(engine.Close)
+			oc := createOpenCodeLikeDB(t, filepath.Join(root, provider.filename), string(provider.agent))
+			_, err := oc.db.Exec("PRAGMA journal_mode=WAL")
+			require.NoError(t, err)
+			oc.addProject(t, "project-a", "/workspace/project-a")
+			for i := range 2 {
+				seedOpenCodeSQLiteTextSession(t, oc, "project-a", fmt.Sprintf("ses%05d", i),
+					1779012000000, 1779012030000, "prompt", "answer")
 			}
-			for suffix, work := range allocations {
-				require.Len(t, work, 2)
-				t.Logf("%s: 8 sessions %.0f allocations; 800 sessions %.0f allocations", suffix, work[0], work[1])
-				assert.Less(t, work[1], work[0]*3, "missing sidecar work must not scale with archive size")
-			}
+			require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+			// Deleting a member then checkpointing the writer does not make the
+			// surviving container disappear. The authoritative pass detects it.
+			_, err = oc.db.Exec("DELETE FROM session WHERE id = 'ses00000'")
+			require.NoError(t, err)
+			require.NoError(t, oc.db.Close())
+			require.NoError(t, engine.SyncPathsContext(t.Context(), []string{oc.path, oc.path + "-wal", oc.path + "-shm"}))
+			id := string(provider.agent) + ":ses00000"
+			stored, err := archive.GetSessionFull(t.Context(), id)
+			require.NoError(t, err)
+			require.NotNil(t, stored)
+			assert.Nil(t, stored.SourceMissingAt)
+			_, _, err = engine.ReconcileWatchRootsWithStats(t.Context(), []string{root}, true, nil)
+			require.NoError(t, err)
+			stored, err = archive.GetSessionFull(t.Context(), id)
+			require.NoError(t, err)
+			require.NotNil(t, stored)
+			assert.NotNil(t, stored.SourceMissingAt)
+			assertMessageContent(t, archive, id, "prompt", "answer")
+			// Container removal still marks the surviving member missing, without
+			// removing its archived messages.
+			require.NoError(t, os.Rename(oc.path, oc.path+".removed"))
+			require.NoError(t, engine.SyncPathsContext(t.Context(), []string{oc.path, oc.path + "-wal", oc.path + "-shm"}))
+			other := string(provider.agent) + ":ses00001"
+			stored, err = archive.GetSessionFull(t.Context(), other)
+			require.NoError(t, err)
+			require.NotNil(t, stored)
+			assert.NotNil(t, stored.SourceMissingAt)
+			assertMessageContent(t, archive, other, "prompt", "answer")
 		})
 	}
 }

--- a/internal/sync/opencode_virtual_event_perf_test.go
+++ b/internal/sync/opencode_virtual_event_perf_test.go
@@ -1,0 +1,52 @@
+package sync_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestOpenCodeVirtualEventDoesNotRecheckUnrelatedMembers(t *testing.T) {
+	var allocations []float64
+	for _, count := range []int{8, 800} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+			oc := createOpenCodeDB(t, env.opencodeDir)
+			oc.addProject(t, "project-a", "/workspace/project-a")
+			oc.inTransaction(t, func(oc *openCodeTestDB) {
+				for i := range count {
+					seedOpenCodeSQLiteTextSession(t, oc, "project-a", fmt.Sprintf("ses%05d", i),
+						1779012000000, 1779012030000, "prompt", "answer")
+				}
+			})
+			require.Equal(t, count, env.engine.SyncAll(t.Context(), nil).Synced)
+			path := parser.OpenCodeSQLiteVirtualPath(oc.path, "ses00000")
+			var syncErr error
+			allocations = append(allocations, testing.AllocsPerRun(3, func() {
+				syncErr = env.engine.SyncPathsContext(t.Context(), []string{path})
+			}))
+			require.NoError(t, syncErr)
+			assertMessageContent(t, env.db, "opencode:ses00000", "prompt", "answer")
+			// A genuinely removed virtual member still needs source-missing
+			// reconciliation, and the persistent archive must retain its content.
+			_, err := oc.db.Exec("DELETE FROM session WHERE id = 'ses00000'")
+			require.NoError(t, err)
+			require.NoError(t, env.engine.SyncPathsContext(t.Context(), []string{path}))
+			stored, err := env.db.GetSessionFull(t.Context(), "opencode:ses00000")
+			require.NoError(t, err)
+			require.NotNil(t, stored)
+			assert.NotNil(t, stored.SourceMissingAt)
+			assertMessageContent(t, env.db, "opencode:ses00000", "prompt", "answer")
+			other, err := env.db.GetSessionFull(t.Context(), "opencode:ses00001")
+			require.NoError(t, err)
+			require.NotNil(t, other)
+			assert.Nil(t, other.SourceMissingAt)
+		})
+	}
+	assert.Less(t, allocations[1], allocations[0]*3,
+		"an existing virtual member must not trigger archive-wide absence checks")
+}

--- a/internal/sync/opencode_virtual_event_perf_test.go
+++ b/internal/sync/opencode_virtual_event_perf_test.go
@@ -1,14 +1,18 @@
 package sync_test
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
+	syncengine "go.kenn.io/agentsview/internal/sync"
 )
 
 func TestOpenCodeVirtualEventDoesNotRecheckUnrelatedMembers(t *testing.T) {
@@ -52,40 +56,92 @@ func TestOpenCodeVirtualEventDoesNotRecheckUnrelatedMembers(t *testing.T) {
 		"an existing virtual member must not trigger archive-wide absence checks")
 }
 
-func TestOpenCodeMissingWALDoesNotRecheckUnrelatedMembers(t *testing.T) {
-	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
-	oc := createOpenCodeDB(t, env.opencodeDir)
-	oc.addProject(t, "project-a", "/workspace/project-a")
-	oc.inTransaction(t, func(oc *openCodeTestDB) {
-		for i := range 800 {
-			seedOpenCodeSQLiteTextSession(t, oc, "project-a", fmt.Sprintf("ses%05d", i),
-				1779012000000, 1779012030000, "prompt", "answer")
-		}
-	})
-	require.Equal(t, 800, env.engine.SyncAll(t.Context(), nil).Synced)
-	require.NoFileExists(t, oc.path+"-wal")
-	var syncErr error
-	baseline := testing.AllocsPerRun(3, func() {
-		syncErr = env.engine.SyncPathsContext(t.Context(), []string{oc.path})
-	})
-	require.NoError(t, syncErr)
-	removedWAL := testing.AllocsPerRun(3, func() {
-		syncErr = env.engine.SyncPathsContext(t.Context(), []string{oc.path + "-wal"})
-	})
-	require.NoError(t, syncErr)
-	t.Logf("container %.0f allocations; missing WAL %.0f allocations", baseline, removedWAL)
-	assert.Less(t, removedWAL, baseline*3, "a vanished SQLite sidecar does not prove any session disappeared")
-	stored, err := env.db.GetSessionFull(t.Context(), "opencode:ses00000")
-	require.NoError(t, err)
-	require.NotNil(t, stored)
-	assert.Nil(t, stored.SourceMissingAt)
-	assertMessageContent(t, env.db, "opencode:ses00000", "prompt", "answer")
-	require.NoError(t, oc.db.Close())
-	require.NoError(t, os.Rename(oc.path, oc.path+".removed"))
-	require.NoError(t, env.engine.SyncPathsContext(t.Context(), []string{oc.path + "-wal"}))
-	stored, err = env.db.GetSessionFull(t.Context(), "opencode:ses00000")
-	require.NoError(t, err)
-	require.NotNil(t, stored)
-	assert.NotNil(t, stored.SourceMissingAt)
-	assertMessageContent(t, env.db, "opencode:ses00000", "prompt", "answer")
+func TestOpenCodeFamilyMissingSidecarWorkStaysBounded(t *testing.T) {
+	for _, provider := range []struct {
+		agent    parser.AgentType
+		filename string
+	}{
+		{parser.AgentOpenCode, "opencode.db"}, {parser.AgentKilo, "kilo.db"},
+		{parser.AgentMiMoCode, "mimocode.db"}, {parser.AgentIcodemate, "icodemate.db"},
+	} {
+		t.Run(string(provider.agent), func(t *testing.T) {
+			allocations := map[string][]float64{"-wal": {}, "-shm": {}}
+			for _, count := range []int{8, 800} {
+				t.Run(fmt.Sprint(count), func(t *testing.T) {
+					root := t.TempDir()
+					archive := dbtest.OpenTestDB(t)
+					engine := syncengine.NewEngine(archive, syncengine.EngineConfig{
+						AgentDirs: map[parser.AgentType][]string{provider.agent: {root}}, Machine: "local",
+					})
+					t.Cleanup(engine.Close)
+					oc := createOpenCodeLikeDB(t, filepath.Join(root, provider.filename), string(provider.agent))
+					_, err := oc.db.Exec("PRAGMA journal_mode=WAL")
+					require.NoError(t, err)
+					oc.addProject(t, "project-a", "/workspace/project-a")
+					oc.inTransaction(t, func(oc *openCodeTestDB) {
+						for i := range count {
+							seedOpenCodeSQLiteTextSession(t, oc, "project-a", fmt.Sprintf("ses%05d", i),
+								1779012000000, 1779012030000, "prompt", "answer")
+						}
+					})
+					require.Equal(t, count, engine.SyncAll(t.Context(), nil).Synced)
+					require.NoError(t, oc.db.Close())
+					for _, suffix := range []string{"-wal", "-shm"} {
+						work := testing.AllocsPerRun(3, func() {
+							// Reader probes may recreate sidecars. Close a producer
+							// connection before every sample, including warmup, so
+							// every measured event still names a missing sidecar.
+							writer, err := sql.Open("sqlite3", oc.path)
+							require.NoError(t, err)
+							_, err = writer.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+							require.NoError(t, err)
+							require.NoError(t, writer.Close())
+							require.NoFileExists(t, oc.path+suffix)
+							require.NoError(t, engine.SyncPathsContext(t.Context(), []string{oc.path + suffix}))
+						})
+						allocations[suffix] = append(allocations[suffix], work)
+					}
+					if count != 8 {
+						return
+					}
+					// Deleting a member then checkpointing the writer does not make the
+					// surviving container disappear. The authoritative pass detects it.
+					writer, err := sql.Open("sqlite3", oc.path)
+					require.NoError(t, err)
+					t.Cleanup(func() { _ = writer.Close() })
+					_, err = writer.Exec("DELETE FROM session WHERE id = 'ses00000'")
+					require.NoError(t, err)
+					require.NoError(t, writer.Close())
+					require.NoError(t, engine.SyncPathsContext(t.Context(), []string{oc.path, oc.path + "-wal", oc.path + "-shm"}))
+					id := string(provider.agent) + ":ses00000"
+					stored, err := archive.GetSessionFull(t.Context(), id)
+					require.NoError(t, err)
+					require.NotNil(t, stored)
+					assert.Nil(t, stored.SourceMissingAt)
+					_, _, err = engine.ReconcileWatchRootsWithStats(t.Context(), []string{root}, true, nil)
+					require.NoError(t, err)
+					stored, err = archive.GetSessionFull(t.Context(), id)
+					require.NoError(t, err)
+					require.NotNil(t, stored)
+					assert.NotNil(t, stored.SourceMissingAt)
+					assertMessageContent(t, archive, id, "prompt", "answer")
+					// Container removal still marks the surviving member missing, without
+					// removing its archived messages.
+					require.NoError(t, os.Rename(oc.path, oc.path+".removed"))
+					require.NoError(t, engine.SyncPathsContext(t.Context(), []string{oc.path, oc.path + "-wal", oc.path + "-shm"}))
+					other := string(provider.agent) + ":ses00001"
+					stored, err = archive.GetSessionFull(t.Context(), other)
+					require.NoError(t, err)
+					require.NotNil(t, stored)
+					assert.NotNil(t, stored.SourceMissingAt)
+					assertMessageContent(t, archive, other, "prompt", "answer")
+				})
+			}
+			for suffix, work := range allocations {
+				require.Len(t, work, 2)
+				t.Logf("%s: 8 sessions %.0f allocations; 800 sessions %.0f allocations", suffix, work[0], work[1])
+				assert.Less(t, work[1], work[0]*3, "missing sidecar work must not scale with archive size")
+			}
+		})
+	}
 }

--- a/internal/sync/skip_persistence_perf_test.go
+++ b/internal/sync/skip_persistence_perf_test.go
@@ -1,0 +1,57 @@
+package sync
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnchangedSkipPersistenceIsCardinalityIndependent(t *testing.T) {
+	for _, size := range []int{8, 8000} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			database := openTestDB(t)
+			engine := NewEngine(database, EngineConfig{})
+			t.Cleanup(engine.Close)
+			entries := make(map[string]int64, size)
+			for i := range size {
+				entries[fmt.Sprintf("/archive/session-%d.jsonl", i)] = 42
+			}
+			engine.InjectSkipCache(entries)
+			require.Equal(t, size, engine.persistSkipCache())
+			allocations := testing.AllocsPerRun(5, func() { engine.persistSkipCache() })
+			assert.Less(t, allocations, float64(10), "unchanged background persistence must not copy or rewrite the archive-sized cache")
+			got, err := database.LoadSkippedFiles()
+			require.NoError(t, err)
+			assert.Equal(t, entries, got)
+			// A removed source must not return on the next flush or engine restart.
+			engine.clearSkip("/archive/session-0.jsonl")
+			delete(entries, "/archive/session-0.jsonl")
+			engine.cacheSkip("/archive/new.jsonl", 84)
+			entries["/archive/new.jsonl"] = 84
+			engine.persistSkipCache()
+			restarted := NewEngine(database, EngineConfig{})
+			t.Cleanup(restarted.Close)
+			assert.Equal(t, entries, restarted.SnapshotSkipCache())
+		})
+	}
+}
+
+func BenchmarkPersistUnchangedSkipCache(b *testing.B) {
+	routeBenchLogs(b)
+	engine, database := openBenchEngine(b, b.TempDir())
+	entries := make(map[string]int64, 10000)
+	for i := range 10000 {
+		entries[fmt.Sprintf("/archive/session-%d.jsonl", i)] = 42
+	}
+	engine.InjectSkipCache(entries)
+	require.Equal(b, 10000, engine.persistSkipCache())
+	got, err := database.LoadSkippedFiles()
+	require.NoError(b, err)
+	require.Len(b, got, 10000)
+	b.ReportAllocs()
+	for b.Loop() {
+		require.Equal(b, 10000, engine.persistSkipCache())
+	}
+}


### PR DESCRIPTION
Reduce recurring sidebar and session-sync work as archives grow. SQLite and PostgreSQL now compute sidebar totals in one filtered session scan. Claude duplicate lookup probes the requested session IDs, Codex discovery reuses directory-entry metadata, and unchanged skip caches avoid another database rewrite.

OpenCode active-session events no longer trigger container-wide source-existence checks for successfully resolved virtual members. Removed WAL/SHM sidecars also avoid those checks when the database still exists. Actual source removal continues to preserve archived messages and mark their sources missing. The retained missing-WAL regression drops from 188,690 allocations to 89. Coverage compares 8 and 800 OpenCode sessions for both WAL and SHM events; small deletion cases cover OpenCode, Kilo, MiMoCode, and Icodemate. Deleted members inside a surviving database become source-missing after the next successful authoritative reconciliation; an ordinary sidecar event does not promise immediate detection.

Includes the reusable `cmd/perfsim` simulator, available through `make perf-sim`: synthetic Claude/Codex JSONL and OpenCode SQLite/WAL sources pass through the real parsers, sync engine, archive, usage cache, and analytical queries. It covers cold ingest, steady appends, long sessions, reconciliation, child-only edits, and writer-close recovery; records profiles and build provenance; and supports source-only generation for isolated server experiments.

The investigation and sanitized daemon measurements are in `docs/internal/performance-investigation.md`; workload instructions are in `docs/internal/performance-simulator.md`. Earlier component timings are marked historical because their original temporary captures were lost. This PR does not claim a demonstrated idle-CPU reduction or optimize the remaining usage/search query hotspots.


The retained daemon capture is exploratory and has incomplete generator provenance: its exact uncommitted generator cannot be reconstructed. It must not be used as a reproducible benchmark or release gate.

