### PR TITLE
perf(ci): keep the disposable PostgreSQL cluster in memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,7 +493,10 @@ jobs:
           POSTGRES_DB: agentsview_test
         ports:
           - 5433:5432
+        # PG18 keeps its data under /var/lib/postgresql/18/docker. The suite
+        # repeatedly rebuilds schemas; keep this disposable cluster in memory.
         options: >-
+          --tmpfs /var/lib/postgresql:rw,size=4g
           --health-cmd "pg_isready -U agentsview_test -d agentsview_test"
           --health-interval 2s
           --health-timeout 5s


### PR DESCRIPTION
Run the CI PostgreSQL 18 service on a 4 GiB memory-backed filesystem to remove disk I/O from its repeated schema creation and teardown. The mount covers PG18's data directory and keeps normal PostgreSQL durability settings. The full suite used about 1.8 GiB locally, so a 1 GiB mount is insufficient.

Local PostgreSQL suite times varied from 64 to 76 seconds on tmpfs versus 68 seconds on disk; this does not establish a reliable end-to-end speedup. CI timing remains to be measured. Stacked on #1631, which raises the timeout as a stopgap.
