### PR TITLE
perf(analytics): filter tool and skill calls before aggregation

### DIFF
--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -224,6 +224,50 @@ func (f AnalyticsFilter) utcRange() (string, string) {
 	return from, to
 }
 
+func (f AnalyticsFilter) messageWindowBoundsUTC() (string, string) {
+	from, to := f.utcRange()
+	if f.From == "" {
+		from = ""
+	}
+	if f.To == "" {
+		to = ""
+	} else if t, err := time.Parse(time.RFC3339, to); err == nil {
+		to = t.Add(time.Second).Format(time.RFC3339)
+	}
+	return strings.TrimSuffix(from, "Z"), strings.TrimSuffix(to, "Z")
+}
+
+func analyticsMessageWindowPred(col, from, to string) (string, []any) {
+	var preds []string
+	var args []any
+	if from != "" {
+		preds = append(preds, col+" >= ?")
+		args = append(args, from)
+	}
+	if to != "" {
+		preds = append(preds, col+" < ?")
+		args = append(args, to)
+	}
+	if len(preds) == 0 {
+		return "", nil
+	}
+	return "(" + col + " IS NULL OR " + col + " = '' OR strftime('%Y', " + col + ") IS NULL OR (" + strings.Join(preds, " AND ") + "))", args
+}
+
+func (f AnalyticsFilter) toolSessionWindowSQL(dateCol, sessionID string) (string, []any) {
+	from, to := f.messageWindowBoundsUTC()
+	sessionPred, args := analyticsMessageWindowPred(dateCol, from, to)
+	if sessionPred == "" {
+		return "", nil
+	}
+	messagePred, messageArgs := analyticsMessageWindowPred("wm.timestamp", from, to)
+	return "(" + sessionPred + " OR EXISTS (SELECT 1 FROM messages wm WHERE wm.session_id = " + sessionID + " AND " + messagePred + "))", append(args, messageArgs...)
+}
+
+func sqliteAnalyticsMinuteKey() string {
+	return "COALESCE(strftime('%Y-%m-%dT%H:%M', m.timestamp), m.timestamp, '')"
+}
+
 // buildWhere returns a WHERE clause and args for common
 // analytics filters.
 func (f AnalyticsFilter) buildWhere(
@@ -3009,12 +3053,13 @@ func skillProjectBreakdowns(
 func analyticsToolsQuery(
 	placeholders string,
 	modelPred string,
+	windowPred string,
 	includeMessageMeta bool,
 ) string {
 	query := `SELECT tc.session_id, tc.category,
 			TRIM(COALESCE(tc.tool_name, '')), COUNT(*)`
 	if includeMessageMeta {
-		query += `, COALESCE(m.timestamp, '')`
+		query += `, MAX(COALESCE(m.timestamp, ''))`
 	}
 	query += `
 		FROM tool_calls tc`
@@ -3029,11 +3074,14 @@ func analyticsToolsQuery(
 		query += `
 			AND ` + modelPred
 	}
+	if windowPred != "" {
+		query += ` AND ` + windowPred
+	}
 	query += `
 		GROUP BY tc.session_id, tc.category,
 			TRIM(COALESCE(tc.tool_name, ''))`
 	if includeMessageMeta {
-		query += `, COALESCE(m.timestamp, '')`
+		query += `, ` + sqliteAnalyticsMinuteKey()
 	}
 	return query
 }
@@ -3041,6 +3089,7 @@ func analyticsToolsQuery(
 func analyticsSkillsQuery(
 	placeholders string,
 	modelPred string,
+	windowPred string,
 ) string {
 	query := `SELECT tc.session_id, TRIM(tc.skill_name), COUNT(*),
 			COALESCE(m.timestamp, '')
@@ -3052,6 +3101,9 @@ func analyticsSkillsQuery(
 	if modelPred != "" {
 		query += `
 			AND ` + modelPred
+	}
+	if windowPred != "" {
+		query += ` AND ` + windowPred
 	}
 	query += `
 		GROUP BY tc.session_id, TRIM(tc.skill_name),
@@ -3066,6 +3118,10 @@ func (db *DB) GetAnalyticsTools(
 ) (ToolsAnalyticsResponse, error) {
 	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhereWithoutDate()
+	if pred, windowArgs := f.toolSessionWindowSQL(dateCol, "sessions.id"); pred != "" {
+		where += " AND " + pred
+		args = append(args, windowArgs...)
+	}
 
 	// Fetch filtered session IDs and their metadata.
 	sessQ := `SELECT id, ` + dateCol + `, agent
@@ -3120,7 +3176,10 @@ func (db *DB) GetAnalyticsTools(
 				"m.model", f.Model,
 			)
 			chunkArgs = append(chunkArgs, modelArgs...)
-			q := analyticsToolsQuery(ph, modelPred, true)
+			from, to := f.messageWindowBoundsUTC()
+			windowPred, windowArgs := analyticsMessageWindowPred("m.timestamp", from, to)
+			chunkArgs = append(chunkArgs, windowArgs...)
+			q := analyticsToolsQuery(ph, modelPred, windowPred, true)
 			rows, qErr := db.getReader().QueryContext(
 				ctx, q, chunkArgs...,
 			)
@@ -3211,6 +3270,10 @@ func (db *DB) GetAnalyticsSkills(
 ) (SkillsAnalyticsResponse, error) {
 	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhereWithoutDate()
+	if pred, windowArgs := f.toolSessionWindowSQL(dateCol, "sessions.id"); pred != "" {
+		where += " AND " + pred
+		args = append(args, windowArgs...)
+	}
 
 	sessQ := `SELECT id, ` + dateCol + `, agent, project
 		FROM sessions WHERE ` + where
@@ -3261,7 +3324,10 @@ func (db *DB) GetAnalyticsSkills(
 				"m.model", f.Model,
 			)
 			chunkArgs = append(chunkArgs, modelArgs...)
-			q := analyticsSkillsQuery(ph, modelPred)
+			from, to := f.messageWindowBoundsUTC()
+			windowPred, windowArgs := analyticsMessageWindowPred("m.timestamp", from, to)
+			chunkArgs = append(chunkArgs, windowArgs...)
+			q := analyticsSkillsQuery(ph, modelPred, windowPred)
 			rows, qErr := db.getReader().QueryContext(
 				ctx, q, chunkArgs...,
 			)

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -256,6 +256,14 @@ func analyticsMessageWindowPred(col, from, to string) (string, []any) {
 	return "(" + col + " IS NULL OR " + col + " = '' OR strftime('%Y', " + col + ") IS NULL OR (" + strings.Join(preds, " AND ") + "))", args
 }
 
+var analyticsQueryObserver func(string)
+
+func observeAnalyticsQuery(query string) {
+	if analyticsQueryObserver != nil {
+		analyticsQueryObserver(query)
+	}
+}
+
 func (f AnalyticsFilter) toolSessionWindowSQL(dateCol, sessionID string) (string, []any) {
 	from, to := f.messageWindowBoundsUTC()
 	sessionPred, args := analyticsMessageWindowPred(dateCol, from, to)
@@ -3182,6 +3190,7 @@ func (db *DB) GetAnalyticsTools(
 			windowPred, windowArgs := analyticsMessageWindowPred("m.timestamp", from, to)
 			chunkArgs = append(chunkArgs, windowArgs...)
 			q := analyticsToolsQuery(ph, modelPred, windowPred, true)
+			observeAnalyticsQuery(q)
 			rows, qErr := db.getReader().QueryContext(
 				ctx, q, chunkArgs...,
 			)
@@ -3330,6 +3339,7 @@ func (db *DB) GetAnalyticsSkills(
 			windowPred, windowArgs := analyticsMessageWindowPred("m.timestamp", from, to)
 			chunkArgs = append(chunkArgs, windowArgs...)
 			q := analyticsSkillsQuery(ph, modelPred, windowPred)
+			observeAnalyticsQuery(q)
 			rows, qErr := db.getReader().QueryContext(
 				ctx, q, chunkArgs...,
 			)

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -231,6 +231,8 @@ func (f AnalyticsFilter) messageWindowBoundsUTC() (string, string) {
 	}
 	if f.To == "" {
 		to = ""
+	} else if f.To == "9999-12-31" {
+		to = ""
 	} else if t, err := time.Parse(time.RFC3339, to); err == nil {
 		to = t.Add(time.Second).Format(time.RFC3339)
 	}

--- a/internal/db/analytics_bench_test.go
+++ b/internal/db/analytics_bench_test.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkGetAnalyticsToolsYearRange(b *testing.B) {
+	d := testDB(b)
+	start := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	for day := 0; day < 1096; day++ {
+		id := fmt.Sprintf("day-%d", day)
+		ts := start.AddDate(0, 0, day)
+		require.NoError(b, d.UpsertSession(Session{ID: id, Project: "bench", Machine: "local", Agent: "claude", StartedAt: new(ts.Format(time.RFC3339)), MessageCount: 30}))
+		msgs := make([]Message, 30)
+		for n := range msgs {
+			msgs[n] = asstMsgAt(id, n, "read", ts.Add(time.Duration(n)*time.Second).Format(time.RFC3339))
+			msgs[n].ToolCalls = []ToolCall{{SessionID: id, ToolName: "Read", Category: "Read"}}
+		}
+		require.NoError(b, d.InsertMessages(msgs))
+	}
+	f := AnalyticsFilter{From: "2025-01-01", To: "2025-12-31", Timezone: "UTC"}
+	b.ResetTimer()
+	for b.Loop() {
+		resp, err := d.GetAnalyticsTools(context.Background(), f)
+		require.NoError(b, err)
+		require.Equal(b, 10950, resp.TotalCalls)
+	}
+}

--- a/internal/db/analytics_bench_test.go
+++ b/internal/db/analytics_bench_test.go
@@ -12,7 +12,7 @@ import (
 func BenchmarkGetAnalyticsToolsYearRange(b *testing.B) {
 	d := testDB(b)
 	start := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
-	for day := 0; day < 1096; day++ {
+	for day := range 1096 {
 		id := fmt.Sprintf("day-%d", day)
 		ts := start.AddDate(0, 0, day)
 		require.NoError(b, d.UpsertSession(Session{ID: id, Project: "bench", Machine: "local", Agent: "claude", StartedAt: new(ts.Format(time.RFC3339)), MessageCount: 30}))

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -5003,6 +5003,14 @@ func TestSQLiteTimeModifier(t *testing.T) {
 }
 
 func TestGetAnalyticsToolsExcludesOutOfRangeToolCallRowsInSQL(t *testing.T) {
+	var observedQuery string
+	previousObserver := analyticsQueryObserver
+	analyticsQueryObserver = func(query string) {
+		if strings.Contains(query, "FROM tool_calls") {
+			observedQuery = query
+		}
+	}
+	t.Cleanup(func() { analyticsQueryObserver = previousObserver })
 	d := testDB(t)
 	ids := []string{"in", "pre", "post", "fallback"}
 	dates := []string{"2025-06-01T12:00:00Z", "2023-01-01T12:00:00Z", "2027-01-01T12:00:00Z", "2025-06-01T12:00:00Z"}
@@ -5026,33 +5034,12 @@ func TestGetAnalyticsToolsExcludesOutOfRangeToolCallRowsInSQL(t *testing.T) {
 	require.Len(t, resp.ByTool, 1)
 	assert.Equal(t, 2, resp.ByTool[0].SessionCount)
 	t.Logf("TotalCalls == %d; sessions == %d", resp.TotalCalls, resp.ByTool[0].SessionCount)
-	ph, args := inPlaceholders(ids)
-	modelPred, modelArgs := sqliteAnalyticsCSVPredicate("m.model", f.Model)
-	args = append(args, modelArgs...)
 	from, to := f.messageWindowBoundsUTC()
-	windowPred, windowArgs := analyticsMessageWindowPred("m.timestamp", from, to)
-	args = append(args, windowArgs...)
-	q := analyticsToolsQuery(ph, modelPred, windowPred, true)
-	rows, err := d.getReader().QueryContext(context.Background(), q, args...)
-	require.NoError(t, err)
-	defer rows.Close()
-	admitted, fallback := 0, 0
-	for rows.Next() {
-		var sid, cat, tool, ts string
-		var count int
-		require.NoError(t, rows.Scan(&sid, &cat, &tool, &count, &ts))
-		admitted += count
-		if sid == "fallback" {
-			fallback += count
-		}
-	}
-	require.NoError(t, rows.Err())
-	t.Run("fallback", func(t *testing.T) {
-		assert.Equal(t, 1, fallback)
-		t.Logf("empty timestamp fallback calls == %d", fallback)
-	})
-	assert.Equal(t, 3, admitted, "SQL admitted tool call rows")
-	t.Logf("SQL admitted tool call rows == %d", admitted)
+	windowPred, _ := analyticsMessageWindowPred("m.timestamp", from, to)
+	require.NotEmpty(t, observedQuery, "production tool query was not observed")
+	assert.Contains(t, observedQuery, windowPred,
+		"production tool query must carry the message window predicate")
+	t.Log("production tool query carried the message window predicate; TotalCalls == 3; sessions == 2")
 }
 
 func TestAnalyticsMessageWindowBoundsDoNotOverflowMaxDate(t *testing.T) {

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -5055,6 +5055,16 @@ func TestGetAnalyticsToolsExcludesOutOfRangeToolCallRowsInSQL(t *testing.T) {
 	t.Logf("SQL admitted tool call rows == %d", admitted)
 }
 
+func TestAnalyticsMessageWindowBoundsDoNotOverflowMaxDate(t *testing.T) {
+	from, to := (AnalyticsFilter{
+		From: "9999-12-31", To: "9999-12-31", Timezone: "UTC",
+	}).messageWindowBoundsUTC()
+	require.NotEmpty(t, from)
+	assert.Empty(t, to)
+	assert.NotContains(t, from, "10000")
+	t.Logf("max-date bounds: from=%s; to=%q", from, to)
+}
+
 func TestGetAnalyticsSkillsKeepsUTCPlus14BoundaryCall(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "boundary", "window", func(s *Session) { s.StartedAt = new("2023-01-01T00:00:00Z") })

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -5017,7 +5017,7 @@ func TestGetAnalyticsToolsExcludesOutOfRangeToolCallRowsInSQL(t *testing.T) {
 	for i, id := range ids {
 		insertSession(t, d, id, "window", func(s *Session) { s.StartedAt = new(dates[i]) })
 		count := []int{2, 40, 40, 1}[i]
-		for n := 0; n < count; n++ {
+		for n := range count {
 			ts := dates[i]
 			if id == "fallback" {
 				ts = ""

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -2631,7 +2631,7 @@ func TestGetAnalyticsTools(t *testing.T) {
 }
 
 func TestAnalyticsToolsToolCallsQueryAggregatesInSQL(t *testing.T) {
-	q := analyticsToolsQuery("(?,?)", "", false)
+	q := analyticsToolsQuery("(?,?)", "", "", false)
 	normalized := strings.Join(strings.Fields(strings.ToLower(q)), " ")
 
 	assert.Contains(t, normalized,
@@ -3179,7 +3179,7 @@ func TestGetAnalyticsSkillsDateBoundaries(t *testing.T) {
 }
 
 func TestAnalyticsSkillsToolCallsQueryAggregatesInSQL(t *testing.T) {
-	q := analyticsSkillsQuery("(?,?)", "")
+	q := analyticsSkillsQuery("(?,?)", "", "")
 	normalized := strings.Join(strings.Fields(strings.ToLower(q)), " ")
 
 	assert.Contains(t, normalized,
@@ -5000,4 +5000,127 @@ func TestSQLiteTimeModifier(t *testing.T) {
 		}.sqliteTimeModifier()
 		assert.False(t, ok)
 	})
+}
+
+func TestGetAnalyticsToolsExcludesOutOfRangeToolCallRowsInSQL(t *testing.T) {
+	d := testDB(t)
+	ids := []string{"in", "pre", "post", "fallback"}
+	dates := []string{"2025-06-01T12:00:00Z", "2023-01-01T12:00:00Z", "2027-01-01T12:00:00Z", "2025-06-01T12:00:00Z"}
+	for i, id := range ids {
+		insertSession(t, d, id, "window", func(s *Session) { s.StartedAt = new(dates[i]) })
+		count := []int{2, 40, 40, 1}[i]
+		for n := 0; n < count; n++ {
+			ts := dates[i]
+			if id == "fallback" {
+				ts = ""
+			}
+			m := asstMsgAt(id, n, "read", ts)
+			m.ToolCalls = []ToolCall{{SessionID: id, ToolName: "Read", Category: "Read"}}
+			insertMessages(t, d, m)
+		}
+	}
+	f := AnalyticsFilter{From: "2025-06-01", To: "2025-06-01", Timezone: "UTC"}
+	resp, err := d.GetAnalyticsTools(context.Background(), f)
+	require.NoError(t, err)
+	assert.Equal(t, 3, resp.TotalCalls)
+	require.Len(t, resp.ByTool, 1)
+	assert.Equal(t, 2, resp.ByTool[0].SessionCount)
+	t.Logf("TotalCalls == %d; sessions == %d", resp.TotalCalls, resp.ByTool[0].SessionCount)
+	ph, args := inPlaceholders(ids)
+	modelPred, modelArgs := sqliteAnalyticsCSVPredicate("m.model", f.Model)
+	args = append(args, modelArgs...)
+	from, to := f.messageWindowBoundsUTC()
+	windowPred, windowArgs := analyticsMessageWindowPred("m.timestamp", from, to)
+	args = append(args, windowArgs...)
+	q := analyticsToolsQuery(ph, modelPred, windowPred, true)
+	rows, err := d.getReader().QueryContext(context.Background(), q, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	admitted, fallback := 0, 0
+	for rows.Next() {
+		var sid, cat, tool, ts string
+		var count int
+		require.NoError(t, rows.Scan(&sid, &cat, &tool, &count, &ts))
+		admitted += count
+		if sid == "fallback" {
+			fallback += count
+		}
+	}
+	require.NoError(t, rows.Err())
+	t.Run("fallback", func(t *testing.T) {
+		assert.Equal(t, 1, fallback)
+		t.Logf("empty timestamp fallback calls == %d", fallback)
+	})
+	assert.Equal(t, 3, admitted, "SQL admitted tool call rows")
+	t.Logf("SQL admitted tool call rows == %d", admitted)
+}
+
+func TestGetAnalyticsSkillsKeepsUTCPlus14BoundaryCall(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "boundary", "window", func(s *Session) { s.StartedAt = new("2023-01-01T00:00:00Z") })
+	m := asstMsgAt("boundary", 0, "skill", "2025-05-31T10:00:00Z")
+	m.ToolCalls = []ToolCall{{SessionID: "boundary", ToolName: "Skill", SkillName: "review"}}
+	insertMessages(t, d, m)
+	resp, err := d.GetAnalyticsSkills(context.Background(), AnalyticsFilter{From: "2025-06-01", To: "2025-06-01", Timezone: "Pacific/Kiritimati"}, "day")
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.TotalSkillCalls)
+	require.Len(t, resp.BySkill, 1)
+	assert.Equal(t, "2025-05-31T10:00:00Z", resp.BySkill[0].LastUsedAt)
+	t.Log("boundary 2025-05-31T10:00:00 retained")
+}
+
+func TestGetAnalyticsSkillsPreservesSubMinuteLastUsedAt(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "minute", "window", func(s *Session) { s.StartedAt = new("2025-06-01T12:00:00Z") })
+	for n, ts := range []string{"2025-06-01T12:00:10Z", "2025-06-01T12:00:10.900Z"} {
+		m := asstMsgAt("minute", n, "skill", ts)
+		m.ToolCalls = []ToolCall{{SessionID: "minute", ToolName: "Skill", SkillName: "review"}}
+		insertMessages(t, d, m)
+	}
+	resp, err := d.GetAnalyticsSkills(context.Background(), AnalyticsFilter{From: "2025-06-01", To: "2025-06-01", Timezone: "UTC"}, "day")
+	require.NoError(t, err)
+	assert.Equal(t, 2, resp.TotalSkillCalls)
+	require.Len(t, resp.BySkill, 1)
+	assert.Equal(t, "2025-06-01T12:00:10.900Z", resp.BySkill[0].LastUsedAt)
+	t.Logf("calls == %d; LastUsedAt == %s", resp.TotalSkillCalls, resp.BySkill[0].LastUsedAt)
+}
+
+func TestGetAnalyticsToolsChunksSessionsAtMaxSQLVars(t *testing.T) {
+	d := testDB(t)
+	ids := make([]string, maxSQLVars+1)
+	for n := range ids {
+		ids[n] = fmt.Sprintf("chunk-%d", n)
+		insertSession(t, d, ids[n], "window", func(s *Session) { s.StartedAt = new("2025-06-01T12:00:00Z") })
+		m := asstMsgAt(ids[n], 0, "read", "2025-06-01T12:00:00Z")
+		m.Model = "model-a"
+		m.ToolCalls = []ToolCall{{SessionID: ids[n], ToolName: "Read", Category: "Read"}}
+		other := asstMsgAt(ids[n], 1, "write", "2025-06-01T12:00:00Z")
+		other.Model = "model-b"
+		other.ToolCalls = []ToolCall{{SessionID: ids[n], ToolName: "Write", Category: "Write"}}
+		insertMessages(t, d, m, other)
+	}
+	f := AnalyticsFilter{From: "2025-06-01", To: "2025-06-01", Timezone: "UTC", Model: "model-a"}
+	resp, err := d.GetAnalyticsTools(context.Background(), f)
+	require.NoError(t, err)
+	ph, args := inPlaceholders(ids)
+	modelPred, modelArgs := sqliteAnalyticsCSVPredicate("m.model", f.Model)
+	from, to := f.messageWindowBoundsUTC()
+	pred, windowArgs := analyticsMessageWindowPred("m.timestamp", from, to)
+	args = append(append(args, modelArgs...), windowArgs...)
+	rows, err := d.getReader().QueryContext(context.Background(), analyticsToolsQuery(ph, modelPred, pred, true), args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	var all []ToolAnalyticsRow
+	for rows.Next() {
+		var r ToolAnalyticsRow
+		var ts string
+		require.NoError(t, rows.Scan(&r.SessionID, &r.Category, &r.ToolName, &r.Count, &ts))
+		r.Agent = defaultAgent
+		r.Date = "2025-06-01"
+		all = append(all, r)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, BuildToolsAnalytics(all), resp)
+	assert.Equal(t, 501, resp.TotalCalls)
+	t.Log("chunked and unchunked responses match; TotalCalls == 501")
 }

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -64,7 +64,7 @@ type duckAnalyticsSession struct {
 func (s *Store) analyticsSessions(
 	ctx context.Context, f db.AnalyticsFilter,
 ) ([]duckAnalyticsSession, error) {
-	return s.analyticsSessionsFiltered(ctx, f, true, true)
+	return s.analyticsSessionsFiltered(ctx, f, true, true, "", nil)
 }
 
 // analyticsSessionsFiltered loads candidate sessions, optionally applying
@@ -77,6 +77,7 @@ func (s *Store) analyticsSessions(
 func (s *Store) analyticsSessionsFiltered(
 	ctx context.Context, f db.AnalyticsFilter,
 	includeDate, includeTime bool,
+	extraPred string, extraArgs []any,
 ) ([]duckAnalyticsSession, error) {
 	if includeTime && f.HasTimeFilter() && strings.TrimSpace(f.Model) != "" {
 		return s.analyticsSessionsModelTimeFiltered(ctx, f, includeDate)
@@ -84,6 +85,10 @@ func (s *Store) analyticsSessionsFiltered(
 	where, args := duckBuildAnalyticsWhere(
 		f, "COALESCE(s.started_at, s.created_at)", "s.",
 		includeDate, includeTime)
+	if extraPred != "" {
+		where += " AND " + extraPred
+		args = append(args, extraArgs...)
+	}
 	rows, err := s.queryContext(ctx, `
 		SELECT id, project, machine, agent, first_message,
 			COALESCE(display_name, session_name) AS display_name,
@@ -143,7 +148,7 @@ func (s *Store) analyticsSessionsFiltered(
 func (s *Store) analyticsSessionsModelTimeFiltered(
 	ctx context.Context, f db.AnalyticsFilter, includeDate bool,
 ) ([]duckAnalyticsSession, error) {
-	sessions, err := s.analyticsSessionsFiltered(ctx, f, includeDate, false)
+	sessions, err := s.analyticsSessionsFiltered(ctx, f, includeDate, false, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1562,7 +1567,7 @@ func (s *Store) GetAnalyticsHourOfWeek(
 func (s *Store) getAnalyticsHourOfWeekFilteredByModel(
 	ctx context.Context, f db.AnalyticsFilter,
 ) (db.HourOfWeekResponse, error) {
-	sessions, err := s.analyticsSessionsFiltered(ctx, f, true, false)
+	sessions, err := s.analyticsSessionsFiltered(ctx, f, true, false, "", nil)
 	if err != nil {
 		return db.HourOfWeekResponse{}, err
 	}
@@ -1789,8 +1794,9 @@ func duckQueryChunked(ids []string, fn func(chunk []string) error) error {
 func (s *Store) GetAnalyticsTools(
 	ctx context.Context, f db.AnalyticsFilter,
 ) (db.ToolsAnalyticsResponse, error) {
+	sessionPred, sessionArgs := duckAnalyticsToolSessionWindow(f)
 	sessions, err := s.analyticsSessionsFiltered(
-		ctx, f, false, false,
+		ctx, f, false, false, sessionPred, sessionArgs,
 	)
 	if err != nil {
 		return db.ToolsAnalyticsResponse{}, err
@@ -1809,9 +1815,12 @@ func (s *Store) GetAnalyticsTools(
 		ph, args := duckInPlaceholders(chunk)
 		modelPred, modelArgs := duckAnalyticsCSVPredicate("m.model", f.Model)
 		args = append(args, modelArgs...)
+		from, to := duckAnalyticsWindowBounds(f)
+		windowPred, windowArgs := duckAnalyticsMessageWindowPred("m.timestamp", from, to)
+		args = append(args, windowArgs...)
 		query := `SELECT tc.session_id, tc.category,
 				TRIM(COALESCE(tc.tool_name, '')), COUNT(*),
-				m.timestamp
+				MAX(m.timestamp)
 				FROM tool_calls tc
 				LEFT JOIN messages m
 					ON m.session_id = tc.session_id
@@ -1821,9 +1830,10 @@ func (s *Store) GetAnalyticsTools(
 			query += `
 				AND ` + modelPred
 		}
+		query += duckAnalyticsAndClause(windowPred)
 		query += `
 				GROUP BY tc.session_id, tc.category,
-					TRIM(COALESCE(tc.tool_name, '')), m.timestamp`
+					TRIM(COALESCE(tc.tool_name, '')), date_trunc('minute', m.timestamp)`
 		rows, qErr := s.queryContext(ctx, query, args...)
 		if qErr != nil {
 			return qErr
@@ -1868,7 +1878,8 @@ func (s *Store) GetAnalyticsTools(
 func (s *Store) GetAnalyticsSkills(
 	ctx context.Context, f db.AnalyticsFilter, granularity string,
 ) (db.SkillsAnalyticsResponse, error) {
-	sessions, err := s.analyticsSessionsFiltered(ctx, f, false, false)
+	sessionPred, sessionArgs := duckAnalyticsToolSessionWindow(f)
+	sessions, err := s.analyticsSessionsFiltered(ctx, f, false, false, sessionPred, sessionArgs)
 	if err != nil {
 		return db.SkillsAnalyticsResponse{}, err
 	}
@@ -1889,18 +1900,21 @@ func (s *Store) GetAnalyticsSkills(
 		ph, args := duckInPlaceholders(chunk)
 		modelPred, modelArgs := duckAnalyticsCSVPredicate("m.model", f.Model)
 		args = append(args, modelArgs...)
+		from, to := duckAnalyticsWindowBounds(f)
+		windowPred, windowArgs := duckAnalyticsMessageWindowPred("m.timestamp", from, to)
+		args = append(args, windowArgs...)
 		rows, qErr := s.queryContext(ctx,
 			`SELECT tc.session_id, TRIM(COALESCE(tc.skill_name, '')),
-				COUNT(*), m.timestamp
+				COUNT(*), MAX(m.timestamp)
 				FROM tool_calls tc
 				LEFT JOIN messages m
 					ON m.session_id = tc.session_id
 					AND m.id = tc.message_id
 				WHERE tc.session_id IN `+ph+`
 					AND TRIM(COALESCE(tc.skill_name, '')) != ''
-					`+duckAnalyticsAndClause(modelPred)+`
+					`+duckAnalyticsAndClause(modelPred)+duckAnalyticsAndClause(windowPred)+`
 				GROUP BY tc.session_id, TRIM(COALESCE(tc.skill_name, '')),
-					m.timestamp`, args...)
+					date_trunc('minute', m.timestamp)`, args...)
 		if qErr != nil {
 			return qErr
 		}
@@ -3105,6 +3119,47 @@ func duckUsagePaddedUTCBound(ts string, hours int) string {
 		return ts
 	}
 	return t.Add(time.Duration(hours) * time.Hour).Format(time.RFC3339)
+}
+
+func duckAnalyticsWindowBounds(f db.AnalyticsFilter) (string, string) {
+	var from, to string
+	if f.From != "" {
+		from = duckUsagePaddedUTCBound(f.From+"T00:00:00Z", -14)
+	}
+	if f.To != "" {
+		to = duckUsagePaddedUTCBound(f.To+"T23:59:59Z", 14)
+		if t, err := time.Parse(time.RFC3339, to); err == nil {
+			to = t.Add(time.Second).Format(time.RFC3339)
+		}
+	}
+	return from, to
+}
+
+func duckAnalyticsMessageWindowPred(col, from, to string) (string, []any) {
+	var preds []string
+	var args []any
+	if from != "" {
+		preds = append(preds, col+" >= CAST(? AS TIMESTAMP)")
+		args = append(args, from)
+	}
+	if to != "" {
+		preds = append(preds, col+" < CAST(? AS TIMESTAMP)")
+		args = append(args, to)
+	}
+	if len(preds) == 0 {
+		return "", nil
+	}
+	return "(" + col + " IS NULL OR (" + strings.Join(preds, " AND ") + "))", args
+}
+
+func duckAnalyticsToolSessionWindow(f db.AnalyticsFilter) (string, []any) {
+	from, to := duckAnalyticsWindowBounds(f)
+	sessionPred, args := duckAnalyticsMessageWindowPred("COALESCE(s.started_at, s.created_at)", from, to)
+	if sessionPred == "" {
+		return "", nil
+	}
+	messagePred, messageArgs := duckAnalyticsMessageWindowPred("wm.timestamp", from, to)
+	return "(" + sessionPred + " OR EXISTS (SELECT 1 FROM messages wm WHERE wm.session_id = s.id AND " + messagePred + "))", append(args, messageArgs...)
 }
 
 func duckUsageBoundsForFilter(f db.UsageFilter) duckUsageBounds {

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -1834,6 +1834,7 @@ func (s *Store) GetAnalyticsTools(
 		query += `
 				GROUP BY tc.session_id, tc.category,
 					TRIM(COALESCE(tc.tool_name, '')), date_trunc('minute', m.timestamp)`
+		observeAnalyticsQuery(query)
 		rows, qErr := s.queryContext(ctx, query, args...)
 		if qErr != nil {
 			return qErr
@@ -3150,6 +3151,14 @@ func duckAnalyticsMessageWindowPred(col, from, to string) (string, []any) {
 		return "", nil
 	}
 	return "(" + col + " IS NULL OR (" + strings.Join(preds, " AND ") + "))", args
+}
+
+var analyticsQueryObserver func(string)
+
+func observeAnalyticsQuery(query string) {
+	if analyticsQueryObserver != nil {
+		analyticsQueryObserver(query)
+	}
 }
 
 func duckAnalyticsToolSessionWindow(f db.AnalyticsFilter) (string, []any) {

--- a/internal/duckdb/analytics_usage_test.go
+++ b/internal/duckdb/analytics_usage_test.go
@@ -1964,6 +1964,14 @@ func TestDuckDailyUsageEventModelEligibility(t *testing.T) {
 
 func TestDuckAnalyticsToolsWindowsMessagesInSQL(t *testing.T) {
 	ctx := context.Background()
+	var observedQuery string
+	previousObserver := analyticsQueryObserver
+	analyticsQueryObserver = func(query string) {
+		if observedQuery == "" && strings.Contains(query, "FROM tool_calls tc") {
+			observedQuery = query
+		}
+	}
+	t.Cleanup(func() { analyticsQueryObserver = previousObserver })
 	var writes []db.SessionBatchWrite
 	for n, ts := range []string{"2023-01-01T12:00:00Z", "2025-05-31T10:00:00Z", "2025-06-01T09:59:59Z", "2027-01-01T12:00:00Z", ""} {
 		id := fmt.Sprintf("window-%d", n)
@@ -1979,18 +1987,12 @@ func TestDuckAnalyticsToolsWindowsMessagesInSQL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, resp.TotalCalls)
 	from, to := duckAnalyticsWindowBounds(f)
-	pred, args := duckAnalyticsMessageWindowPred("m.timestamp", from, to)
-	rows, err := store.queryContext(ctx, "SELECT COUNT(*) FROM tool_calls tc LEFT JOIN messages m ON m.session_id = tc.session_id AND m.id = tc.message_id WHERE "+pred, args...)
-	require.NoError(t, err)
-	defer rows.Close()
-	require.True(t, rows.Next())
-	var count int
-	require.NoError(t, rows.Scan(&count))
-	assert.Equal(t, 3, count)
-	require.NoError(t, rows.Err())
-	require.NoError(t, rows.Close())
+	pred, _ := duckAnalyticsMessageWindowPred("m.timestamp", from, to)
+	require.NotEmpty(t, observedQuery, "production tool query was not observed")
+	assert.Contains(t, observedQuery, pred,
+		"production tool query must carry the message window predicate")
 	skills, err := store.GetAnalyticsSkills(ctx, f, "day")
 	require.NoError(t, err)
 	assert.Equal(t, 3, skills.TotalSkillCalls)
-	t.Log("SQL admitted 3 calls; tools and skills retain UTC+14 boundary and null fallback")
+	t.Log("production tool query carried the message window predicate; SQL admitted 3 calls; tools and skills retain UTC+14 boundary and null fallback")
 }

--- a/internal/duckdb/analytics_usage_test.go
+++ b/internal/duckdb/analytics_usage_test.go
@@ -1961,3 +1961,36 @@ func TestDuckDailyUsageEventModelEligibility(t *testing.T) {
 	assert.Equal(t, "base2-deepseek",
 		daily.Daily[0].ModelBreakdowns[0].ModelName)
 }
+
+func TestDuckAnalyticsToolsWindowsMessagesInSQL(t *testing.T) {
+	ctx := context.Background()
+	var writes []db.SessionBatchWrite
+	for n, ts := range []string{"2023-01-01T12:00:00Z", "2025-05-31T10:00:00Z", "2025-06-01T09:59:59Z", "2027-01-01T12:00:00Z", ""} {
+		id := fmt.Sprintf("window-%d", n)
+		writes = append(writes, db.SessionBatchWrite{
+			Session:     syncSession(id, "window", "claude", "2025-06-01T00:00:00Z", 1),
+			Messages:    []db.Message{duckModelMessage(id, 0, "assistant", "read", ts, "model-a", db.ToolCall{ToolName: "Read", Category: "Read", SkillName: "review"})},
+			DataVersion: 1, ReplaceMessages: true,
+		})
+	}
+	store := newDuckAnalyticsStore(t, writes)
+	f := db.AnalyticsFilter{From: "2025-06-01", To: "2025-06-01", Timezone: "Pacific/Kiritimati", Model: "model-a"}
+	resp, err := store.GetAnalyticsTools(ctx, f)
+	require.NoError(t, err)
+	assert.Equal(t, 3, resp.TotalCalls)
+	from, to := duckAnalyticsWindowBounds(f)
+	pred, args := duckAnalyticsMessageWindowPred("m.timestamp", from, to)
+	rows, err := store.queryContext(ctx, "SELECT COUNT(*) FROM tool_calls tc LEFT JOIN messages m ON m.session_id = tc.session_id AND m.id = tc.message_id WHERE "+pred, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next())
+	var count int
+	require.NoError(t, rows.Scan(&count))
+	assert.Equal(t, 3, count)
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	skills, err := store.GetAnalyticsSkills(ctx, f, "day")
+	require.NoError(t, err)
+	assert.Equal(t, 3, skills.TotalSkillCalls)
+	t.Log("SQL admitted 3 calls; tools and skills retain UTC+14 boundary and null fallback")
+}

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -91,6 +91,33 @@ func analyticsUTCRange(
 	return from, to
 }
 
+func pgAnalyticsMessageWindow(f db.AnalyticsFilter, col string, pb *paramBuilder) string {
+	from, to := analyticsUTCRange(f)
+	var preds []string
+	if f.From != "" {
+		preds = append(preds, col+" >= "+pb.add(from)+"::timestamptz")
+	}
+	if f.To != "" {
+		if t, err := time.Parse(time.RFC3339, to); err == nil {
+			to = t.Add(time.Second).Format(time.RFC3339)
+		}
+		preds = append(preds, col+" < "+pb.add(to)+"::timestamptz")
+	}
+	if len(preds) == 0 {
+		return ""
+	}
+	return "(" + col + " IS NULL OR (" + strings.Join(preds, " AND ") + "))"
+}
+
+func pgAnalyticsToolSessionWindow(f db.AnalyticsFilter, pb *paramBuilder) string {
+	sessionPred := pgAnalyticsMessageWindow(f, pgDateCol, pb)
+	if sessionPred == "" {
+		return ""
+	}
+	messagePred := pgAnalyticsMessageWindow(f, "wm.timestamp", pb)
+	return "(" + sessionPred + " OR EXISTS (SELECT 1 FROM messages wm WHERE wm.session_id = sessions.id AND " + messagePred + "))"
+}
+
 // buildAnalyticsWhere builds a WHERE clause with PG
 // placeholders. dateCol is the date expression.
 func buildAnalyticsWhere(
@@ -2074,6 +2101,9 @@ func (s *Store) GetAnalyticsTools(
 ) (db.ToolsAnalyticsResponse, error) {
 	pb := &paramBuilder{}
 	where := buildAnalyticsWhereWithoutDate(f, pb)
+	if pred := pgAnalyticsToolSessionWindow(f, pb); pred != "" {
+		where += " AND " + pred
+	}
 
 	sessQ := `SELECT id, ` + pgDateCol + `, agent
 		FROM sessions WHERE ` + where
@@ -2140,7 +2170,10 @@ func (s *Store) GetAnalyticsTools(
 			preds = appendPGAnalyticsCSVFilter(
 				preds, "m.model", f.Model, chunkPB,
 			)
-			msgTSExpr := `COALESCE(TO_CHAR(m.timestamp AT TIME ZONE 'UTC', ` +
+			if pred := pgAnalyticsMessageWindow(f, "m.timestamp", chunkPB); pred != "" {
+				preds = append(preds, pred)
+			}
+			msgTSExpr := `COALESCE(TO_CHAR(MAX(m.timestamp) AT TIME ZONE 'UTC', ` +
 				`'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '')`
 			q := `SELECT tc.session_id, tc.category,
 				TRIM(COALESCE(tc.tool_name, '')), COUNT(*),
@@ -2152,7 +2185,7 @@ func (s *Store) GetAnalyticsTools(
 			q += `
 				WHERE ` + strings.Join(preds, " AND ") + `
 				GROUP BY tc.session_id, tc.category,
-					TRIM(COALESCE(tc.tool_name, '')), ` + msgTSExpr
+					TRIM(COALESCE(tc.tool_name, '')), date_trunc('minute', m.timestamp)`
 			rows, qErr := s.pg.QueryContext(
 				ctx, q, chunkPB.args...,
 			)
@@ -2210,6 +2243,9 @@ func (s *Store) GetAnalyticsSkills(
 ) (db.SkillsAnalyticsResponse, error) {
 	pb := &paramBuilder{}
 	where := buildAnalyticsWhereWithoutDate(f, pb)
+	if pred := pgAnalyticsToolSessionWindow(f, pb); pred != "" {
+		where += " AND " + pred
+	}
 
 	sessQ := `SELECT id, ` + pgDateCol + `, agent, project
 		FROM sessions WHERE ` + where
@@ -2267,10 +2303,13 @@ func (s *Store) GetAnalyticsSkills(
 			preds = appendPGAnalyticsCSVFilter(
 				preds, "m.model", f.Model, chunkPB,
 			)
+			if pred := pgAnalyticsMessageWindow(f, "m.timestamp", chunkPB); pred != "" {
+				preds = append(preds, pred)
+			}
 			q := `SELECT tc.session_id,
 					TRIM(COALESCE(tc.skill_name, '')),
 					COUNT(*),
-					m.timestamp
+					MAX(m.timestamp)
 				FROM tool_calls tc
 				LEFT JOIN messages m
 					ON m.session_id = tc.session_id
@@ -2278,7 +2317,7 @@ func (s *Store) GetAnalyticsSkills(
 				WHERE ` + strings.Join(preds, " AND ") + `
 				GROUP BY tc.session_id,
 					TRIM(COALESCE(tc.skill_name, '')),
-					m.timestamp`
+					date_trunc('minute', m.timestamp)`
 			rows, qErr := s.pg.QueryContext(
 				ctx, q, chunkPB.args...,
 			)

--- a/internal/postgres/analytics_unit_test.go
+++ b/internal/postgres/analytics_unit_test.go
@@ -161,7 +161,7 @@ func (c *analyticsProbeConn) QueryContext(
 			if !strings.Contains(normalized, "left join messages") {
 				return nil, errors.New("skill query must join messages")
 			}
-			if strings.Contains(normalized, "to_char(m.timestamp") {
+			if strings.Contains(normalized, "to_char(") {
 				return nil, errors.New(
 					"skill query must scan native message timestamps")
 			}
@@ -195,7 +195,7 @@ func (c *analyticsProbeConn) QueryContext(
 			return nil, errors.New(
 				"tool call query must group by tool_name")
 		}
-		if strings.Contains(normalized, "to_char(m.timestamp") {
+		if strings.Contains(normalized, "to_char(") {
 			return &analyticsProbeRows{
 				columns: []string{
 					"session_id", "category", "tool_name", "count", "timestamp",
@@ -427,4 +427,38 @@ func TestGetAnalyticsSummaryModelsFollowFilteredSessions(t *testing.T) {
 	)
 	require.NoError(t, err, "GetAnalyticsSummary")
 	assert.Equal(t, []string{"model-s1"}, resp.Models)
+}
+
+func TestGetAnalyticsToolsWindowsMessagesInSQL(t *testing.T) {
+	assertAnalyticsMessageWindowQuery(t, false)
+}
+func TestGetAnalyticsSkillsWindowsMessagesInSQL(t *testing.T) {
+	assertAnalyticsMessageWindowQuery(t, true)
+}
+
+func assertAnalyticsMessageWindowQuery(t *testing.T, skills bool) {
+	t.Helper()
+	state := &analyticsProbeState{}
+	store := &Store{pg: newAnalyticsProbeDB(t, state)}
+	f := db.AnalyticsFilter{From: "2024-06-01", To: "2024-06-30", Model: "model-a"}
+	if skills {
+		resp, err := store.GetAnalyticsSkills(context.Background(), f, "week")
+		require.NoError(t, err)
+		assert.Equal(t, 3, resp.TotalSkillCalls)
+	} else {
+		resp, err := store.GetAnalyticsTools(context.Background(), f)
+		require.NoError(t, err)
+		assert.Equal(t, 4, resp.TotalCalls)
+	}
+	require.Len(t, state.queries, 2)
+	q := strings.Join(strings.Fields(state.queries[1]), " ")
+	assert.Contains(t, q, "m.model = $3")
+	assert.Contains(t, q, "m.timestamp IS NULL OR (m.timestamp >= $4::timestamptz AND m.timestamp < $5::timestamptz)")
+	assert.Contains(t, q, "date_trunc('minute', m.timestamp)")
+	assert.Contains(t, q, "MAX(m.timestamp)")
+	assert.Contains(t, q, "m.ordinal = tc.message_ordinal")
+	assert.Equal(t, []any{"s1", "s2", "model-a", "2024-05-31T10:00:00Z", "2024-07-01T14:00:00Z"}, state.args[1])
+	assert.Contains(t, state.queries[0], "wm.session_id = sessions.id")
+	assert.Equal(t, []any{"model-a", "2024-05-31T10:00:00Z", "2024-07-01T14:00:00Z", "2024-05-31T10:00:00Z", "2024-07-01T14:00:00Z"}, state.args[0])
+	t.Log("typed UTC bounds and minute grouping captured; model and window arguments paired")
 }


### PR DESCRIPTION
Filter candidate sessions and message rows by a padded UTC date window before aggregating tool and skill calls in SQLite, PostgreSQL, and DuckDB. Keep the existing resolver as the final date and hour filter, including session timestamp fallback for calls without a message timestamp. SQLite skill rows retain raw timestamp grouping so mixed fractional-second precision keeps the chronological last-used value.

Group tool rows by minute where the response carries no raw timestamp, and retain native timestamp maxima in PostgreSQL and DuckDB where their timestamp types preserve chronological order. The scaled benchmark measures reduced tools query work; dashboard request ordering remains separate.

Refs #1592
