### PR TITLE
fix(search): derive snippet spans from the matched bytes

### DIFF
--- a/internal/db/search_content.go
+++ b/internal/db/search_content.go
@@ -610,46 +610,57 @@ func (f ContentSearchFilter) buildSnippet(body string, start, end int) string {
 
 // substringSnippet builds the snippet for a substring match: it locates the
 // case-insensitive pattern in body (the LIKE already matched, so it is present;
-// fall back to the start if case-folding shifts the offset) and windows it.
+// fall back to the start of the body if case-folding cannot locate it) and
+// windows it.
 func (f ContentSearchFilter) substringSnippet(body string) string {
-	off := max(CaseInsensitiveIndex(body, f.Pattern), 0)
-	return f.buildSnippet(body, off, min(off+len(f.Pattern), len(body)))
+	start, end, _ := CaseInsensitiveSpan(body, f.Pattern)
+	return f.buildSnippet(body, start, end)
 }
 
-// CaseInsensitiveIndex returns the byte offset in s of the first
-// case-insensitive occurrence of sub, or -1. The offset always indexes s
-// directly: it walks s rune by rune instead of searching strings.ToLower(s),
-// whose byte length can differ from s — the Kelvin sign U+212A lowercases from
-// three bytes to one, U+023A lowercases from two bytes to three — which would
-// shift the offset and, when ToLower grows the prefix, push it past len(s) so
-// the caller's slice panics. Both backends use it to center snippets.
-func CaseInsensitiveIndex(s, sub string) int {
+// CaseInsensitiveSpan returns the byte range [start, end) that the first
+// case-insensitive occurrence of sub covers in s, and whether one exists;
+// a miss reports the start of s so callers can window from there.
+//
+// Both offsets index s directly: the search walks s rune by rune instead of
+// searching strings.ToLower(s), whose byte length can differ from s — the
+// Kelvin sign U+212A lowercases from three bytes to one, U+023A lowercases
+// from two bytes to three — which would shift the offset and, when ToLower
+// grows the prefix, push it past len(s) so the caller's slice panics.
+//
+// end comes from s for the same reason it cannot come from sub: those same
+// mappings make the matched bytes shorter or longer than sub, so start +
+// len(sub) can land inside a rune of s or past the end of the match. Snippet
+// windowing relies on the span being rune-aligned (see snippetBounds, which
+// snaps only the padding edges), so every backend derives the end here.
+func CaseInsensitiveSpan(s, sub string) (int, int, bool) {
 	if sub == "" {
-		return 0
+		return 0, 0, true
 	}
 	for i := range s {
-		if hasFoldPrefixAt(s, i, sub) {
-			return i
+		if end, ok := foldPrefixEnd(s, i, sub); ok {
+			return i, end, true
 		}
 	}
-	return -1
+	return 0, 0, false
 }
 
-// hasFoldPrefixAt reports whether s[i:] begins with sub under simple Unicode
-// lower-case folding, compared rune by rune so a case mapping that changes
-// UTF-8 byte length cannot desynchronize the two cursors.
-func hasFoldPrefixAt(s string, i int, sub string) bool {
+// foldPrefixEnd reports whether s[i:] begins with sub under simple Unicode
+// lower-case folding and, when it does, the offset in s just past the match.
+// The two strings are compared rune by rune so a case mapping that changes
+// UTF-8 byte length cannot desynchronize the cursors, which is also what
+// leaves the returned end on a rune boundary of s.
+func foldPrefixEnd(s string, i int, sub string) (int, bool) {
 	for _, want := range sub {
 		if i >= len(s) {
-			return false
+			return 0, false
 		}
 		got, size := utf8.DecodeRuneInString(s[i:])
 		if got != want && unicode.ToLower(got) != unicode.ToLower(want) {
-			return false
+			return 0, false
 		}
 		i += size
 	}
-	return true
+	return i, true
 }
 
 // literalPrefix extracts a required literal prefix from a regex for use
@@ -724,21 +735,20 @@ func (f ContentSearchFilter) ftsSnippet(body string) string {
 // first parsed prepared-FTS term, and finally to the start of the body.
 func FTSSnippetRange(pattern, body string) (int, int) {
 	if phrase := strings.Trim(pattern, "\""); phrase != "" {
-		if off := CaseInsensitiveIndex(body, phrase); off >= 0 {
-			return off, min(off+len(phrase), len(body))
+		if start, end, ok := CaseInsensitiveSpan(body, phrase); ok {
+			return start, end
 		}
 	}
 	for _, term := range FTSTerms(PrepareFTSQuery(pattern)) {
 		if term == "" {
 			continue
 		}
-		if off := CaseInsensitiveIndex(body, term); off >= 0 {
-			return off, min(off+len(term), len(body))
+		if start, end, ok := CaseInsensitiveSpan(body, term); ok {
+			return start, end
 		}
 		if fields := strings.Fields(term); len(fields) > 0 && fields[0] != term {
-			first := fields[0]
-			if off := CaseInsensitiveIndex(body, first); off >= 0 {
-				return off, min(off+len(first), len(body))
+			if start, end, ok := CaseInsensitiveSpan(body, fields[0]); ok {
+				return start, end
 			}
 		}
 		break

--- a/internal/db/search_content_test.go
+++ b/internal/db/search_content_test.go
@@ -85,16 +85,61 @@ func TestSearchContentRedactsStraddlingSecret(t *testing.T) {
 		"reveal snippet should show raw bytes")
 }
 
-// TestCaseInsensitiveIndexUnicodeOffset pins that the returned offset indexes
+// TestCaseInsensitiveSpanUnicodeOffset pins that the returned offsets index
 // the original string, not strings.ToLower(s). The Kelvin sign U+212A is three
 // bytes but lowercases to one ('k'), so a ToLower-based index would report a
 // byte offset shifted left of the real match position.
-func TestCaseInsensitiveIndexUnicodeOffset(t *testing.T) {
+func TestCaseInsensitiveSpanUnicodeOffset(t *testing.T) {
 	body := strings.Repeat("K", 5) + "match here"
-	got := CaseInsensitiveIndex(body, "MATCH")
+	start, end, ok := CaseInsensitiveSpan(body, "MATCH")
+	require.True(t, ok, "CaseInsensitiveSpan did not find the match")
 	want := strings.Index(body, "match") // real offset into the original string
-	assert.Equal(t, want, got,
-		"CaseInsensitiveIndex offset into original body")
+	assert.Equal(t, want, start,
+		"CaseInsensitiveSpan start into original body")
+	assert.Equal(t, want+len("match"), end,
+		"CaseInsensitiveSpan end into original body")
+}
+
+// TestCaseInsensitiveSpanEndTracksMatchedBytes pins that the end offset is
+// taken from the matched bytes rather than from the pattern. U+212A KELVIN
+// SIGN is three bytes and folds to the one-byte "k", so start+len(pattern)
+// lands inside a rune of the body when the body carries the long form and
+// overshoots the match when the pattern does. snippetBounds snaps only its
+// padding edges and leaves the span alone, so a span that is not rune-aligned
+// reaches the slice unrepaired.
+func TestCaseInsensitiveSpanEndTracksMatchedBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		body    string
+		pattern string
+		match   string
+	}{
+		{"body rune longer than pattern", "a\u212Ab", "k", "\u212A"},
+		{"body rune shorter than pattern", "akb", "\u212A", "k"},
+		{"multi rune phrase", "the Key word", "key", "Key"},
+		{"ascii unaffected", "the key word", "KEY", "key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, ok := CaseInsensitiveSpan(tc.body, tc.pattern)
+			require.True(t, ok, "no match for %q in %q", tc.pattern, tc.body)
+			assert.Equal(t, tc.match, tc.body[start:end],
+				"span does not cover exactly the matched bytes")
+			assert.True(t, utf8.ValidString(tc.body[start:end]),
+				"span splits a rune: %d..%d of %q", start, end, tc.body)
+		})
+	}
+}
+
+// TestFTSSnippetRangeRuneAligned pins the same guarantee for the shared
+// snippet-centering helper every backend calls (SQLite, the PostgreSQL keyword
+// and hybrid legs, DuckDB).
+func TestFTSSnippetRangeRuneAligned(t *testing.T) {
+	body := "prefix a\u212Ab suffix"
+	start, end := FTSSnippetRange("k", body)
+	assert.Equal(t, "\u212A", body[start:end],
+		"FTS snippet range does not cover the matched bytes")
+	assert.True(t, utf8.RuneStart(body[end]),
+		"FTS snippet range end %d splits a rune in %q", end, body)
 }
 
 // TestSubstringSnippetUnicodeOffset guards against the snippet panic and

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -1288,8 +1288,8 @@ func (s *Store) collectContentSubstringMatches(
 			start, end := db.FTSSnippetRange(f.Pattern, body)
 			return duckContentSnippet(f, body, start, end)
 		}
-		off := max(db.CaseInsensitiveIndex(body, f.Pattern), 0)
-		return duckContentSnippet(f, body, off, min(off+len(f.Pattern), len(body)))
+		start, end, _ := db.CaseInsensitiveSpan(body, f.Pattern)
+		return duckContentSnippet(f, body, start, end)
 	})
 }
 

--- a/internal/postgres/search_content.go
+++ b/internal/postgres/search_content.go
@@ -585,15 +585,15 @@ func pgBuildSnippet(f db.ContentSearchFilter, body string, start, end int) strin
 
 // pgSubstringSnippet builds a substring-match snippet: it locates the
 // case-insensitive pattern (the ILIKE already matched, so it is present; fall
-// back to the start) and windows it. It uses db.CaseInsensitiveIndex so the
-// offset indexes body directly even when lowercasing would change byte length.
+// back to the start) and windows it. It uses db.CaseInsensitiveSpan so both
+// offsets index body directly even when lowercasing would change byte length.
 func pgSubstringSnippet(f db.ContentSearchFilter, body string) string {
 	if f.Mode == "fts" {
 		start, end := db.FTSSnippetRange(f.Pattern, body)
 		return pgBuildSnippet(f, body, start, end)
 	}
-	off := max(db.CaseInsensitiveIndex(body, f.Pattern), 0)
-	return pgBuildSnippet(f, body, off, min(off+len(f.Pattern), len(body)))
+	start, end, _ := db.CaseInsensitiveSpan(body, f.Pattern)
+	return pgBuildSnippet(f, body, start, end)
 }
 
 // literalPrefixPG returns the required literal prefix from a regex pattern,


### PR DESCRIPTION
The three content-search snippet paths end a match at `start+len(pattern)`. The start offset is already computed the careful way, rune by rune over the body, so a case mapping that changes UTF-8 length cannot shift it, but the end is taken from the pattern. Simple folding maps U+212A KELVIN SIGN, three bytes, to `k`, one byte, so a body holding the long form ends the span two bytes inside that rune, and a pattern holding it ends the span two bytes past the match.

`snippetBounds` and its PostgreSQL and DuckDB twins pad the span by 60 bytes and snap only the padding edges back to a rune boundary. Their loops stop when they reach the span, so none of them can repair a span that is not aligned. The 60-byte radius means no snippet is visibly wrong today, but rune alignment is the precondition those helpers and `secrets.RedactWindow` are written against, and the three copies of the same end expression are the kind of thing that drifts.

`CaseInsensitiveIndex` becomes `CaseInsensitiveSpan`: it returns the byte range the match actually covers in the body plus whether one was found, and each backend windows that range instead of recomputing an end from the pattern. Everything ASCII, which is nearly every query, gets the identical span it got before.

One behavior change comes with it. A miss now yields an empty span at the start of the body rather than a pattern-length one, so the fallback window is up to `len(pattern)` bytes shorter on its right edge. The substring paths reach that branch only if SQL `LIKE`/`ILIKE` matched where the Go search did not, and the Go fold is the wider of the two, so it is unreachable there; `FTSSnippetRange` already returned `0, 0` for its own start fallback.

Reviewer attention is best spent on `CaseInsensitiveSpan` and `foldPrefixEnd` in `internal/db/search_content.go`. The PostgreSQL and DuckDB call sites are the same two-line substitution, and I could not exercise their suites locally since both need services I do not have set up.
