### PR TITLE
feat(mcp): add session search date filters and contextual search guidance

### DIFF
--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -1118,25 +1119,34 @@ func (e *scopedEmitter) Emit(scope string) {
 }
 
 func TestStartRemoteHostSync_EmitsSessionsScopeAfterSuccess(t *testing.T) {
-	em := &scopedEmitter{scopes: make(chan string, 1)}
-	syncFn := func() (int, error) { return 3, nil }
+	synctest.Test(t, func(t *testing.T) {
+		em := &scopedEmitter{scopes: make(chan string, 1)}
+		syncFn := func() (int, error) { return 3, nil }
 
-	done := make(chan struct{})
-	exited := make(chan struct{})
-	interval := 10 * time.Millisecond
-	go func() {
-		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, em, nil, done)
-		close(exited)
-	}()
+		done := make(chan struct{})
+		exited := make(chan struct{})
+		interval := 10 * time.Millisecond
+		go func() {
+			runRemoteHostSyncLoop(t.Context(), "test-host", interval, syncFn, em, nil, done)
+			close(exited)
+		}()
+		defer func() {
+			close(done)
+			<-exited
+		}()
 
-	select {
-	case scope := <-em.scopes:
-		assert.Equal(t, "sessions", scope)
-	case <-time.After(3 * interval):
-		require.FailNow(t, "timed out waiting for remote sync event")
-	}
-	close(done)
-	<-exited
+		// Wait for the loop to start its ticker before advancing fake time.
+		synctest.Wait()
+		time.Sleep(interval)
+		synctest.Wait()
+
+		select {
+		case scope := <-em.scopes:
+			assert.Equal(t, "sessions", scope)
+		default:
+			require.FailNow(t, "remote sync did not emit after its first tick")
+		}
+	})
 }
 
 func TestStartRemoteHostSync_NoEmitOnZeroSynced(t *testing.T) {

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -51,7 +51,8 @@ client will see these tools:
 `search_sessions` accepts optional `date_from` and `date_to` bounds in
 `YYYY-MM-DD` format, just like `list_sessions` and `search_content`. Dates
 include sessions whose activity overlaps the requested days in UTC. Either bound
-can be omitted; omitting both preserves unrestricted date matching.
+can be omitted; omitting both preserves unrestricted date matching. Malformed
+dates and ranges where `date_from` is after `date_to` return an error.
 
 When a vector search index is configured, prefer `search_content` with
 `mode: "hybrid"` or `mode: "semantic"` for questions about prior work,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -48,6 +48,19 @@ client will see these tools:
 | `search_content`       | Substring, regex, semantic, or hybrid search over raw session text |
 | `get_usage_summary`    | Aggregate token and cost usage                                     |
 
+`search_sessions` accepts optional `date_from` and `date_to` bounds in
+`YYYY-MM-DD` format, just like `list_sessions` and `search_content`. Dates
+include sessions whose activity overlaps the requested days in UTC. Either bound
+can be omitted; omitting both preserves unrestricted date matching.
+
+When a vector search index is configured, prefer `search_content` with
+`mode: "hybrid"` or `mode: "semantic"` for questions about prior work,
+especially when the exact wording is unknown. Hybrid combines semantic
+similarity with keyword matching. Use `context` to include surrounding messages.
+If the index is unavailable, use `search_sessions` for keyword search, or
+`search_content` with substring/regex for exact errors, identifiers, and code
+fragments. The default search mode remains substring.
+
 `search_content` accepts a `mode` of `substring` (default), `regex`, `semantic`,
 or `hybrid`, plus a `scope` of `top`, `all` (default), or `subordinate` that is
 only valid with the semantic and hybrid modes. The `semantic` and `hybrid` modes

--- a/frontend/src/lib/api/generated/models/getApiV1SearchParams.ts
+++ b/frontend/src/lib/api/generated/models/getApiV1SearchParams.ts
@@ -5,6 +5,14 @@ import type { GetApiV1SearchSort } from "./getApiV1SearchSort.ts";
 
 export type GetApiV1SearchParams = {
   /**
+   * Filter sessions active on or after this date
+   */
+  date_from?: string;
+  /**
+   * Filter sessions active on or before this date
+   */
+  date_to?: string;
+  /**
    * Search query
    */
   q: string;

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -590,18 +590,7 @@ func sessionFilterPredicates(
 				f.Date, f.Timezone, true,
 			)))+")")
 	}
-	if f.DateFrom != "" {
-		preds = append(preds, b.dialect.dateEndExpr(q)+" >= "+
-			b.dialect.dateParam(b.Add(sessionDateBoundary(
-				f.DateFrom, f.Timezone, false,
-			))))
-	}
-	if f.DateTo != "" {
-		preds = append(preds, b.dialect.dateStartExpr(q)+" < "+
-			b.dialect.dateParam(b.Add(sessionDateBoundary(
-				f.DateTo, f.Timezone, true,
-			))))
-	}
+	preds = append(preds, b.SessionDateRangePredicates(f.DateFrom, f.DateTo, f.Timezone, q)...)
 	if f.ActiveSince != "" {
 		preds = append(preds, b.dialect.dateEndExpr(q)+" >= "+
 			b.dialect.dateParam(b.Add(f.ActiveSince)))
@@ -880,4 +869,23 @@ func (b *QueryBuilder) terminationParam(t time.Time) string {
 	default:
 		return b.dialect.activityParam(b.Add(t))
 	}
+}
+
+// SessionDateRangePredicates matches sessions whose activity overlaps the inclusive
+// calendar-date range. Empty bounds add no restriction, as in session listing.
+func (b *QueryBuilder) SessionDateRangePredicates(dateFrom, dateTo, timezone string, q func(string) string) []string {
+	var preds []string
+	if dateFrom != "" {
+		preds = append(preds, b.dialect.dateEndExpr(q)+" >= "+
+			b.dialect.dateParam(b.Add(sessionDateBoundary(
+				dateFrom, timezone, false,
+			))))
+	}
+	if dateTo != "" {
+		preds = append(preds, b.dialect.dateStartExpr(q)+" < "+
+			b.dialect.dateParam(b.Add(sessionDateBoundary(
+				dateTo, timezone, true,
+			))))
+	}
+	return preds
 }

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -313,11 +313,13 @@ type SearchResult struct {
 
 // SearchFilter specifies search parameters.
 type SearchFilter struct {
-	Query   string
-	Project string
-	Sort    string // "relevance" (default) or "recency"
-	Cursor  int    // offset for pagination
-	Limit   int
+	DateFrom string
+	DateTo   string
+	Query    string
+	Project  string
+	Sort     string // "relevance" (default) or "recency"
+	Cursor   int    // offset for pagination
+	Limit    int
 }
 
 // SearchPage holds paginated search results.
@@ -377,6 +379,16 @@ func (db *DB) Search(
 		nameProjectClause = "AND s.project = ?"
 		nameProjectArgs = []any{f.Project}
 	}
+
+	dateBuilder := NewQueryBuilder(SQLiteQueryDialect(), 0)
+	datePreds := dateBuilder.SessionDateRangePredicates(f.DateFrom, f.DateTo, "", func(col string) string { return "s2." + col })
+	innerWhere = append(innerWhere, datePreds...)
+	ftsArgs = append(ftsArgs, dateBuilder.Args()...)
+	nameDateBuilder := NewQueryBuilder(SQLiteQueryDialect(), 0)
+	for _, pred := range nameDateBuilder.SessionDateRangePredicates(f.DateFrom, f.DateTo, "", func(col string) string { return "s." + col }) {
+		nameProjectClause += " AND " + pred
+	}
+	nameProjectArgs = append(nameProjectArgs, nameDateBuilder.Args()...)
 
 	innerWhereSQL := strings.Join(innerWhere, " AND ")
 	// Strip FTS quoting before substring operations. PrepareFTSQuery wraps

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -986,3 +986,51 @@ func TestSearchPaginationStability(t *testing.T) {
 			i-1, allIDs[i-1], i, allIDs[i])
 	}
 }
+
+func TestSearch_DateRange(t *testing.T) {
+	store := testDB(t)
+	require.True(t, store.HasFTS(), "run with -tags fts5")
+	fixtures := []struct{ id, start, end string }{
+		{"early", "2024-06-01T10:00:00Z", "2024-06-01T11:00:00Z"},
+		{"boundary", "2024-06-02T23:59:59Z", "2024-06-02T23:59:59Z"},
+		{"late", "2024-06-03T00:00:00Z", "2024-06-03T01:00:00Z"},
+		{"spanning", "2024-06-01T23:00:00Z", "2024-06-03T01:00:00Z"},
+	}
+	for _, f := range fixtures {
+		insertSession(t, store, f.id, "project-a", func(s *Session) {
+			s.StartedAt = new(f.start)
+			s.EndedAt = new(f.end)
+			s.SessionName = new("datefilter name")
+		})
+		insertMessages(t, store, userMsg(f.id, 0, "datefilter message"))
+	}
+	for _, tc := range []struct {
+		name, from, to string
+		want           []string
+	}{
+		{"omitted", "", "", []string{"early", "boundary", "late", "spanning"}},
+		{"lower only", "2024-06-02", "", []string{"boundary", "late", "spanning"}},
+		{"upper only", "", "2024-06-02", []string{"early", "boundary", "spanning"}},
+		{"same day", "2024-06-02", "2024-06-02", []string{"boundary", "spanning"}},
+		{"no matches", "2024-06-04", "2024-06-04", []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, query := range []string{"message", "name"} {
+				filter := SearchFilter{Query: query, Project: "project-a", DateFrom: tc.from, DateTo: tc.to, Limit: 1}
+				var ids []string
+				for range len(fixtures) + 1 {
+					out, err := store.Search(context.Background(), filter)
+					require.NoError(t, err)
+					for _, hit := range out.Results {
+						ids = append(ids, hit.SessionID)
+					}
+					if out.NextCursor == 0 {
+						break
+					}
+					filter.Cursor = out.NextCursor
+				}
+				assert.ElementsMatch(t, tc.want, ids, "query %s", query)
+			}
+		})
+	}
+}

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -935,10 +935,17 @@ func (s *Store) Search(ctx context.Context, f db.SearchFilter) (db.SearchPage, e
 		args = append(args, f.Project)
 		nameProject = "AND s.project = ?"
 	}
+	dateBuilder := db.NewQueryBuilder(db.DuckDBQueryDialect(), 0)
+	for _, pred := range dateBuilder.SessionDateRangePredicates(f.DateFrom, f.DateTo, "", func(col string) string { return "s." + col }) {
+		project += " AND " + pred
+		nameProject += " AND " + pred
+	}
+	args = append(args, dateBuilder.Args()...)
 	args = append(args, namePattern, namePattern, namePattern, namePattern)
 	if f.Project != "" {
 		args = append(args, f.Project)
 	}
+	args = append(args, dateBuilder.Args()...)
 	orderBy := "match_priority ASC, match_pos ASC, session_ended_at DESC, session_id ASC"
 	if f.Sort == "recency" {
 		orderBy = "session_ended_at DESC, session_id ASC"

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -4425,3 +4425,53 @@ func TestDuckDBBranchDimension(t *testing.T) {
 	}
 	assert.Equal(t, 100, total, "branch filter restricts usage to alpha/main")
 }
+
+func TestSearch_DateRange(t *testing.T) {
+	fixtures := []struct{ id, start, end string }{
+		{"early", "2024-06-01T10:00:00Z", "2024-06-01T11:00:00Z"},
+		{"boundary", "2024-06-02T23:59:59Z", "2024-06-02T23:59:59Z"},
+		{"late", "2024-06-03T00:00:00Z", "2024-06-03T01:00:00Z"},
+		{"spanning", "2024-06-01T23:00:00Z", "2024-06-03T01:00:00Z"},
+	}
+	var writes []db.SessionBatchWrite
+	for _, f := range fixtures {
+		sess := syncSession(f.id, "project-a", "seed", f.start, 1)
+		sess.EndedAt = new(f.end)
+		sess.SessionName = new("datefilter name")
+		writes = append(writes, db.SessionBatchWrite{
+			Session:     sess,
+			Messages:    []db.Message{syncMessage(f.id, 0, "user", "datefilter message", f.start)},
+			DataVersion: 1, ReplaceMessages: true,
+		})
+	}
+	store := newUnitsStore(t, writes)
+	for _, tc := range []struct {
+		name, from, to string
+		want           []string
+	}{
+		{"omitted", "", "", []string{"early", "boundary", "late", "spanning"}},
+		{"lower only", "2024-06-02", "", []string{"boundary", "late", "spanning"}},
+		{"upper only", "", "2024-06-02", []string{"early", "boundary", "spanning"}},
+		{"same day", "2024-06-02", "2024-06-02", []string{"boundary", "spanning"}},
+		{"no matches", "2024-06-04", "2024-06-04", []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, query := range []string{"message", "name"} {
+				filter := db.SearchFilter{Query: query, Project: "project-a", DateFrom: tc.from, DateTo: tc.to, Limit: 1}
+				var ids []string
+				for range len(fixtures) + 1 {
+					out, err := store.Search(context.Background(), filter)
+					require.NoError(t, err)
+					for _, hit := range out.Results {
+						ids = append(ids, hit.SessionID)
+					}
+					if out.NextCursor == 0 {
+						break
+					}
+					filter.Cursor = out.NextCursor
+				}
+				assert.ElementsMatch(t, tc.want, ids, "query %s", query)
+			}
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -65,8 +65,9 @@ func newServer(opts ServeOptions) *mcp.Server {
 		Name: ToolSearchSessions,
 		Description: "Full-text search across all recorded AI agent sessions (Claude Code, Codex, Gemini, " +
 			"Antigravity, and others) from every project and machine. Returns ranked snippets with a " +
-			"match_ordinal usable with get_messages to read the surrounding conversation. Use this to " +
-			"answer questions like 'have I solved this before?' or to find prior work on a topic. " +
+			"match_ordinal usable with get_messages to read the surrounding conversation. For prior-work " +
+			"questions, prefer search_content with mode hybrid or semantic when a vector search index " +
+			"is configured. Use this tool for keyword search, with optional date_from/date_to bounds. " +
 			"Every term must appear (AND); wrap the query in double quotes for an exact phrase. " +
 			"Sessions active in the last 10 minutes (including the current conversation) are excluded " +
 			"unless include_active is set.",
@@ -87,8 +88,9 @@ func newServer(opts ServeOptions) *mcp.Server {
 	mcp.AddTool(s, &mcp.Tool{
 		Name: ToolListSessions,
 		Description: "List recorded agent sessions with filters (project, agent, machine, date range). " +
-			"Returns compact metadata rows, newest first. Use search_sessions instead when looking for " +
-			"specific content.",
+			"Returns compact metadata rows, newest first. For prior-work questions, prefer search_content " +
+			"with mode hybrid or semantic when a vector search index is configured; use search_sessions " +
+			"for keyword search.",
 		Annotations: readOnly,
 	}, t.listSessions)
 
@@ -114,10 +116,12 @@ func newServer(opts ServeOptions) *mcp.Server {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name: ToolSearchContent,
-		Description: "Substring, regex, or semantic/hybrid embedding search over raw session text, including " +
-			"tool inputs and results. Slower but more precise than search_sessions; use it for error " +
-			"messages, identifiers, and code fragments (substring/regex), or a natural-language query when " +
-			"the exact wording is unknown (semantic/hybrid). Set context to include N messages of " +
+		Description: "Search raw session text, including tool inputs and results. When a vector search index is " +
+			"configured, prefer mode hybrid (semantic similarity plus keywords) or semantic for finding " +
+			"prior work and answering contextual questions, especially when the exact wording is unknown. " +
+			"If these modes report not available, use search_sessions for keywords or this tool with " +
+			"substring/regex for exact error messages, identifiers, and code fragments. " +
+			"The default mode remains substring. Set context to include N messages of " +
 			"surrounding conversation with each match. Matches from the last 10 minutes (including the " +
 			"current conversation) are excluded unless include_active is set.",
 		Annotations: readOnly,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -80,6 +80,8 @@ func (t *toolset) lookupActivity(
 // --- search_sessions ---
 
 type searchSessionsIn struct {
+	DateFrom      string `json:"date_from,omitempty" jsonschema:"Only sessions on or after this date (YYYY-MM-DD)."`
+	DateTo        string `json:"date_to,omitempty" jsonschema:"Only sessions on or before this date (YYYY-MM-DD)."`
 	Query         string `json:"query" jsonschema:"Search terms across all agent sessions. Every term must appear (AND), not an exact phrase; wrap the whole query in double quotes for an exact phrase, e.g. \"build failed\". Punctuation in a term (hyphens, colons) is handled safely."`
 	Project       string `json:"project,omitempty" jsonschema:"Restrict to one project (repo/directory name)."`
 	Sort          string `json:"sort,omitempty" jsonschema:"relevance (default) or recency."`
@@ -108,11 +110,13 @@ func (t *toolset) searchSessions(
 	ctx context.Context, _ *mcp.CallToolRequest, in searchSessionsIn,
 ) (*mcp.CallToolResult, searchSessionsOut, error) {
 	res, err := t.svc.Search(ctx, service.SearchRequest{
-		Query:   buildSearchQuery(in.Query),
-		Project: in.Project,
-		Sort:    in.Sort,
-		Cursor:  in.Cursor,
-		Limit:   clampLimit(in.Limit, defaultSearchLimit, maxSearchLimit),
+		DateFrom: in.DateFrom,
+		DateTo:   in.DateTo,
+		Query:    buildSearchQuery(in.Query),
+		Project:  in.Project,
+		Sort:     in.Sort,
+		Cursor:   in.Cursor,
+		Limit:    clampLimit(in.Limit, defaultSearchLimit, maxSearchLimit),
 	})
 	if err != nil {
 		return nil, searchSessionsOut{}, err
@@ -516,8 +520,8 @@ func (t *toolset) getMessagesAround(
 // --- search_content ---
 
 type searchContentIn struct {
-	Pattern       string `json:"pattern" jsonschema:"Exact substring or regex to find across message text and tool inputs/results."`
-	Mode          string `json:"mode,omitempty" jsonschema:"substring (default), regex, semantic, or hybrid."`
+	Pattern       string `json:"pattern" jsonschema:"Natural-language query for semantic/hybrid, or exact substring/regex for lexical search across message text and tool inputs/results."`
+	Mode          string `json:"mode,omitempty" jsonschema:"substring (default), regex, semantic, or hybrid. Prefer hybrid or semantic for contextual questions when a vector search index is configured."`
 	Scope         string `json:"scope,omitempty" jsonschema:"Semantic/hybrid result scope: top, all, or subordinate (default all). Only valid with mode semantic or hybrid."`
 	Project       string `json:"project,omitempty" jsonschema:"Restrict to one project."`
 	Agent         string `json:"agent,omitempty" jsonschema:"Restrict to one agent."`

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1356,3 +1356,23 @@ func TestSearchSessions_DateRange(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchSessions_RejectsInvalidDateRange(t *testing.T) {
+	ts, _ := newTestToolset(t)
+	for _, tc := range []struct {
+		name, from, to, message string
+	}{
+		{"reversed", "2024-06-03", "2024-06-01", "date_from must not be after date_to"},
+		{"malformed from", "not-a-date", "", "invalid date format: use YYYY-MM-DD"},
+		{"malformed to", "", "2024-02-30", "invalid date format: use YYYY-MM-DD"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := ts.searchSessions(context.Background(), nil, searchSessionsIn{
+				Query: "hello", DateFrom: tc.from, DateTo: tc.to,
+			})
+			var inputErr *db.SearchInputError
+			require.ErrorAs(t, err, &inputErr)
+			assert.Contains(t, inputErr.Error(), tc.message)
+		})
+	}
+}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1294,3 +1294,65 @@ func TestGetMessages_AroundClampsOversizedWindow(t *testing.T) {
 		"the oversized request must actually be capped below what an "+
 			"unclamped window would have returned")
 }
+
+func TestSearchSessions_DateRange(t *testing.T) {
+	ts, d := newTestToolset(t)
+	require.True(t, d.HasFTS(), "run with -tags fts5")
+	fixtures := []struct{ id, start, end string }{
+		{"early", "2024-06-01T10:00:00Z", "2024-06-01T11:00:00Z"},
+		{"boundary", "2024-06-02T23:59:59Z", "2024-06-02T23:59:59Z"},
+		{"late", "2024-06-03T00:00:00Z", "2024-06-03T01:00:00Z"},
+		{"spanning", "2024-06-01T23:00:00Z", "2024-06-03T01:00:00Z"},
+	}
+	for _, f := range fixtures {
+		dbtest.SeedSession(t, d, f.id, "project-a", func(s *db.Session) {
+			s.StartedAt = new(f.start)
+			s.EndedAt = new(f.end)
+			s.SessionName = new("datefilter name")
+		})
+		require.NoError(t, d.InsertMessages([]db.Message{dbtest.UserMsg(f.id, 0, "datefilter message")}))
+	}
+	srv := newServer(ServeOptions{Service: ts.svc, Now: ts.now})
+	st, ct := newInMemoryPair(t, srv)
+	defer func() { require.NoError(t, ct.Close()); require.NoError(t, st.Wait()) }()
+	for _, tc := range []struct {
+		name, from, to string
+		want           []string
+	}{
+		{"omitted", "", "", []string{"early", "boundary", "late", "spanning"}},
+		{"lower only", "2024-06-02", "", []string{"boundary", "late", "spanning"}},
+		{"upper only", "", "2024-06-02", []string{"early", "boundary", "spanning"}},
+		{"same day", "2024-06-02", "2024-06-02", []string{"boundary", "spanning"}},
+		{"no matches", "2024-06-04", "2024-06-04", []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, query := range []string{"message", "name"} {
+				args := map[string]any{"query": query, "project": "project-a", "limit": 1}
+				if tc.from != "" {
+					args["date_from"] = tc.from
+				}
+				if tc.to != "" {
+					args["date_to"] = tc.to
+				}
+				var ids []string
+				for range len(fixtures) + 1 {
+					res, err := ct.CallTool(context.Background(), callParams(ToolSearchSessions, args))
+					require.NoError(t, err)
+					require.False(t, res.IsError, "%+v", res.Content)
+					raw, err := json.Marshal(res.StructuredContent)
+					require.NoError(t, err)
+					var out searchSessionsOut
+					require.NoError(t, json.Unmarshal(raw, &out))
+					for _, hit := range out.Results {
+						ids = append(ids, hit.SessionID)
+					}
+					if out.NextCursor == nil {
+						break
+					}
+					args["cursor"] = *out.NextCursor
+				}
+				assert.ElementsMatch(t, tc.want, ids, "query %s", query)
+			}
+		})
+	}
+}

--- a/internal/postgres/messages.go
+++ b/internal/postgres/messages.go
@@ -397,6 +397,14 @@ func (s *Store) Search(
 		argIdx++
 	}
 
+	dateBuilder := db.NewQueryBuilder(db.PostgresQueryDialect(), argIdx-1)
+	for _, pred := range dateBuilder.SessionDateRangePredicates(f.DateFrom, f.DateTo, "", func(col string) string { return "s." + col }) {
+		msgProjectClause += " AND " + pred
+		nameProjectClause += " AND " + pred
+	}
+	args = append(args, dateBuilder.Args()...)
+	argIdx += len(dateBuilder.Args())
+
 	query := fmt.Sprintf(`
 		WITH msg_matches AS (
 			SELECT DISTINCT ON (m.session_id)

--- a/internal/postgres/search_content_pgtest_test.go
+++ b/internal/postgres/search_content_pgtest_test.go
@@ -878,3 +878,48 @@ func TestPGSearchContentExcludeSession(t *testing.T) {
 	require.Len(t, got.Matches, 1, "excluded id must not consume the page")
 	assert.Equal(t, "keep", got.Matches[0].SessionID)
 }
+
+func TestSearch_DateRange(t *testing.T) {
+	store := setupContentSearch(t)
+	fixtures := []struct{ id, start, end string }{
+		{"early", "2024-06-01T10:00:00Z", "2024-06-01T11:00:00Z"},
+		{"boundary", "2024-06-02T23:59:59Z", "2024-06-02T23:59:59Z"},
+		{"late", "2024-06-03T00:00:00Z", "2024-06-03T01:00:00Z"},
+		{"spanning", "2024-06-01T23:00:00Z", "2024-06-03T01:00:00Z"},
+	}
+	for _, f := range fixtures {
+		insertCSSession(t, store, f.id, "project-a", "codex", f.start, f.end)
+		insertCSMessage(t, store, f.id, 0, "user", "datefilter message", f.start, false)
+		_, err := store.DB().Exec("UPDATE sessions SET display_name = 'datefilter name' WHERE id = $1", f.id)
+		require.NoError(t, err)
+	}
+	for _, tc := range []struct {
+		name, from, to string
+		want           []string
+	}{
+		{"omitted", "", "", []string{"early", "boundary", "late", "spanning"}},
+		{"lower only", "2024-06-02", "", []string{"boundary", "late", "spanning"}},
+		{"upper only", "", "2024-06-02", []string{"early", "boundary", "spanning"}},
+		{"same day", "2024-06-02", "2024-06-02", []string{"boundary", "spanning"}},
+		{"no matches", "2024-06-04", "2024-06-04", []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, query := range []string{"message", "name"} {
+				filter := db.SearchFilter{Query: query, Project: "project-a", DateFrom: tc.from, DateTo: tc.to, Limit: 1}
+				var ids []string
+				for range len(fixtures) + 1 {
+					out, err := store.Search(context.Background(), filter)
+					require.NoError(t, err)
+					for _, hit := range out.Results {
+						ids = append(ids, hit.SessionID)
+					}
+					if out.NextCursor == 0 {
+						break
+					}
+					filter.Cursor = out.NextCursor
+				}
+				assert.ElementsMatch(t, tc.want, ids, "query %s", query)
+			}
+		})
+	}
+}

--- a/internal/server/huma_routes_search.go
+++ b/internal/server/huma_routes_search.go
@@ -24,11 +24,13 @@ type contentSearchMode string
 type contentSearchScope string
 
 type searchInput struct {
-	Query   string     `query:"q" required:"true" doc:"Search query"`
-	Project string     `query:"project" doc:"Filter by project"`
-	Sort    searchSort `query:"sort" enum:"relevance,recency" default:"relevance" doc:"Sort order"`
-	Limit   int        `query:"limit" minimum:"0" doc:"Maximum number of results"`
-	Cursor  int        `query:"cursor" minimum:"0" doc:"Pagination cursor"`
+	DateFrom string     `query:"date_from" format:"date" doc:"Filter sessions active on or after this date"`
+	DateTo   string     `query:"date_to" format:"date" doc:"Filter sessions active on or before this date"`
+	Query    string     `query:"q" required:"true" doc:"Search query"`
+	Project  string     `query:"project" doc:"Filter by project"`
+	Sort     searchSort `query:"sort" enum:"relevance,recency" default:"relevance" doc:"Sort order"`
+	Limit    int        `query:"limit" minimum:"0" doc:"Maximum number of results"`
+	Cursor   int        `query:"cursor" minimum:"0" doc:"Pagination cursor"`
 }
 
 type contentSearchInput struct {
@@ -67,11 +69,13 @@ func (s *Server) humaSearch(
 		return nil, apiError(http.StatusBadRequest, "query required")
 	}
 	res, err := s.sessions.Search(ctx, service.SearchRequest{
-		Query:   query,
-		Project: in.Project,
-		Sort:    string(in.Sort),
-		Cursor:  in.Cursor,
-		Limit:   in.Limit,
+		DateFrom: in.DateFrom,
+		DateTo:   in.DateTo,
+		Query:    query,
+		Project:  in.Project,
+		Sort:     string(in.Sort),
+		Cursor:   in.Cursor,
+		Limit:    in.Limit,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrSearchUnavailable) {

--- a/internal/server/search_test.go
+++ b/internal/server/search_test.go
@@ -107,3 +107,27 @@ func TestSearchDateRangeHTTPTransport(t *testing.T) {
 	assert.Equal(t, "2024-06-01", spy.filter.DateFrom)
 	assert.Equal(t, "2024-06-02", spy.filter.DateTo)
 }
+
+func TestSearchRejectsInvalidDateRange(t *testing.T) {
+	spy := &searchSpy{}
+	srv := &Server{
+		cfg: config.Config{Host: "127.0.0.1"}, db: spy,
+		sessions: service.NewReadOnlyBackend(spy), mux: http.NewServeMux(),
+	}
+	srv.routes()
+	for _, tc := range []struct {
+		name, params, message string
+	}{
+		{"reversed", "date_from=2024-06-03&date_to=2024-06-01", "date_from must not be after date_to"},
+		{"malformed from", "date_from=not-a-date", "date"},
+		{"malformed to", "date_to=2024-02-30", "date"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=hello&"+tc.params, nil)
+			srv.mux.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code, "%s", w.Body.String())
+			assert.Contains(t, w.Body.String(), tc.message)
+		})
+	}
+}

--- a/internal/server/search_test.go
+++ b/internal/server/search_test.go
@@ -89,3 +89,21 @@ func TestHandleSearchSortParam(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchDateRangeHTTPTransport(t *testing.T) {
+	spy := &searchSpy{}
+	srv := &Server{
+		cfg: config.Config{Host: "127.0.0.1"}, db: spy,
+		sessions: service.NewReadOnlyBackend(spy), mux: http.NewServeMux(),
+	}
+	srv.routes()
+	httpServer := httptest.NewServer(srv.mux)
+	t.Cleanup(httpServer.Close)
+	client := service.NewHTTPBackend(httpServer.URL, "", true)
+	_, err := client.Search(context.Background(), service.SearchRequest{
+		Query: "hello", DateFrom: "2024-06-01", DateTo: "2024-06-02",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "2024-06-01", spy.filter.DateFrom)
+	assert.Equal(t, "2024-06-02", spy.filter.DateTo)
+}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -656,6 +656,14 @@ func (b *directBackend) Search(
 	if query == "" {
 		return nil, &db.SearchInputError{Msg: "search: query required"}
 	}
+	for _, d := range []string{req.DateFrom, req.DateTo} {
+		if d != "" && !timeutil.IsValidDate(d) {
+			return nil, &db.SearchInputError{Msg: "search: invalid date format: use YYYY-MM-DD"}
+		}
+	}
+	if req.DateFrom != "" && req.DateTo != "" && req.DateFrom > req.DateTo {
+		return nil, &db.SearchInputError{Msg: "search: date_from must not be after date_to"}
+	}
 	if !b.db.HasFTS() {
 		return nil, ErrSearchUnavailable
 	}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -670,11 +670,13 @@ func (b *directBackend) Search(
 		limit = db.MaxSearchLimit
 	}
 	page, err := b.db.Search(ctx, db.SearchFilter{
-		Query:   db.PrepareFTSQuery(query),
-		Project: req.Project,
-		Sort:    req.Sort,
-		Cursor:  req.Cursor,
-		Limit:   limit,
+		DateFrom: req.DateFrom,
+		DateTo:   req.DateTo,
+		Query:    db.PrepareFTSQuery(query),
+		Project:  req.Project,
+		Sort:     req.Sort,
+		Cursor:   req.Cursor,
+		Limit:    limit,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -454,6 +454,12 @@ func (b *httpBackend) Search(
 	if req.Project != "" {
 		q.Set("project", req.Project)
 	}
+	if req.DateFrom != "" {
+		q.Set("date_from", req.DateFrom)
+	}
+	if req.DateTo != "" {
+		q.Set("date_to", req.DateTo)
+	}
 	if req.Sort != "" {
 		q.Set("sort", req.Sort)
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -140,11 +140,13 @@ type SecretFindingList struct {
 // It mirrors the GET /api/v1/search query parameters so both transports
 // produce identical results.
 type SearchRequest struct {
-	Query   string `json:"query"`
-	Project string `json:"project,omitempty"`
-	Sort    string `json:"sort,omitempty"` // "relevance" (default) or "recency"
-	Cursor  int    `json:"cursor,omitempty"`
-	Limit   int    `json:"limit,omitempty"`
+	DateFrom string `json:"date_from,omitempty"`
+	DateTo   string `json:"date_to,omitempty"`
+	Query    string `json:"query"`
+	Project  string `json:"project,omitempty"`
+	Sort     string `json:"sort,omitempty"` // "relevance" (default) or "recency"
+	Cursor   int    `json:"cursor,omitempty"`
+	Limit    int    `json:"limit,omitempty"`
 }
 
 // SessionSearchResult mirrors db.SearchPage for transport: ranked


### PR DESCRIPTION
`search_sessions` now accepts optional `date_from` and `date_to` values in `YYYY-MM-DD` format. They match the inclusive session-activity date rules used by `list_sessions` and `search_content`; omitting either bound leaves that side unrestricted. The filters apply before pagination through the daemon API and SQLite, PostgreSQL, and DuckDB.

MCP descriptions now recommend hybrid or semantic content search for questions about prior work when a vector index is configured, with keyword and exact-text guidance when those modes are unavailable. Search defaults remain unchanged.
