### PR TITLE
fix(usage): restore click-to-hide model attribution

### DIFF
--- a/frontend/src/lib/components/usage/AttributionPanel.svelte
+++ b/frontend/src/lib/components/usage/AttributionPanel.svelte
@@ -104,7 +104,7 @@
     } else if (groupBy === "agent") {
       usage.toggleAgent(id, { preserveTimeRange: true });
     } else {
-      usage.toggleModel(id, { preserveTimeRange: true });
+      usage.hideModel(id, { preserveTimeRange: true });
     }
   }
 

--- a/frontend/src/lib/components/usage/AttributionPanel.test.ts
+++ b/frontend/src/lib/components/usage/AttributionPanel.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { mount, tick, unmount } from "svelte";
 import type { UsageSummaryResponse } from "../../api/generated/index";
 import { testMoney } from "../../test/money.js";
@@ -240,6 +240,104 @@ describe("AttributionPanel project identity", () => {
       ),
     );
     unmount(component);
+  });
+});
+
+describe("AttributionPanel model exclusion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usage.summary = summaryWithModels();
+    usage.selectedModels = "";
+    usage.excludedModels = "";
+    usage.toggles.attribution.groupBy = "model";
+  });
+
+  afterEach(() => {
+    usage.cancelInFlightReads();
+    usage.summary = null;
+    usage.selectedModels = "";
+    usage.excludedModels = "";
+    usage.applyDateRange(usage.from, usage.to);
+    usage.toggles.attribution.groupBy = "project";
+    usage.toggles.attribution.view = "list";
+    document.body.innerHTML = "";
+  });
+
+  it.each([
+    ["treemap", ".tile"],
+    ["treemap", ".rail-row"],
+    ["list", ".list-row"],
+  ] as const)("hides a model through %s %s instead of selecting it", async (view, selector) => {
+    usage.toggles.attribution.view = view;
+    const remaining = summaryWithModels();
+    remaining.modelTotals = [remaining.modelTotals[1]!];
+    usageServiceMocks.getApiV1UsageSummary.mockResolvedValue(remaining);
+    const component = mountPanel();
+    await tick();
+
+    try {
+      document.querySelector(selector)!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      await vi.waitFor(() => {
+        const params = usageServiceMocks.getApiV1UsageSummary.mock.lastCall?.[0];
+        expect(params).toEqual(expect.objectContaining({ exclude_model: "gpt-5.6-sol" }));
+        expect(params.model).toBeUndefined();
+      });
+      await tick();
+      expect(Array.from(document.querySelectorAll(selector), (row) => row.textContent)).toEqual([
+        expect.stringContaining("claude-opus-5"),
+      ]);
+      expect(usage.hasActiveFilters).toBe(true);
+
+      const empty = summaryWithModels();
+      empty.modelTotals = [];
+      usageServiceMocks.getApiV1UsageSummary.mockResolvedValue(empty);
+      document.querySelector(selector)!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await vi.waitFor(() =>
+        expect(usageServiceMocks.getApiV1UsageSummary.mock.lastCall?.[0]).toEqual(
+          expect.objectContaining({ exclude_model: "gpt-5.6-sol,claude-opus-5" }),
+        ),
+      );
+      await tick();
+      expect(document.querySelectorAll(selector)).toHaveLength(0);
+
+      usageServiceMocks.getApiV1UsageSummary.mockResolvedValue(summaryWithModels());
+      usage.clearFilters();
+      await vi.waitFor(() => expect(document.querySelectorAll(selector)).toHaveLength(2));
+      expect(
+        usageServiceMocks.getApiV1UsageSummary.mock.lastCall?.[0].exclude_model,
+      ).toBeUndefined();
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  it("keeps the selected models and chart brush when hiding a model", async () => {
+    usage.selectedModels = "gpt-5.6-sol,claude-opus-5";
+    usage.selectedTimeRange = { from: "2024-01-08", to: "2024-01-14" };
+    usage.toggles.attribution.view = "treemap";
+    usageServiceMocks.getApiV1UsageSummary.mockResolvedValue(summaryWithModels());
+    const component = mountPanel();
+    await tick();
+
+    try {
+      document.querySelector(".tile")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await vi.waitFor(() =>
+        expect(
+          usageServiceMocks.getApiV1UsageSummary.mock.calls.map(([params]) => params),
+        ).toContainEqual(
+          expect.objectContaining({
+            from: "2024-01-08",
+            to: "2024-01-14",
+            model: "gpt-5.6-sol,claude-opus-5",
+            exclude_model: "gpt-5.6-sol",
+          }),
+        ),
+      );
+      expect(usage.selectedTimeRange).toEqual({ from: "2024-01-08", to: "2024-01-14" });
+    } finally {
+      await unmount(component);
+    }
   });
 });
 

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -379,14 +379,14 @@
         usage.excludedAgents = newExAgent;
         changed = true;
       }
-      if (usage.excludedModels) {
-        usage.excludedModels = "";
+      const newExModel = params["exclude_model"] ?? "";
+      if (newExModel !== usage.excludedModels) {
+        usage.excludedModels = newExModel;
         changed = true;
       }
       const newModel = params["model"] ?? "";
       if (newModel !== usage.selectedModels) {
         usage.selectedModels = newModel;
-        if (newModel) usage.excludedModels = "";
         changed = true;
       }
       if ((changed || sessionChanged) && urlInitRan) {

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -137,6 +137,8 @@ afterEach(() => {
   usage.toggles.attribution.view = "treemap";
   usage.excludedProjects = "";
   usage.excludedProjectKeys = "";
+  usage.excludedModels = "";
+  usage.selectedModels = "";
   usage.knownProjects = [];
   settings.chartPalette = "agentsview";
   sessions.projects = [];
@@ -145,6 +147,22 @@ afterEach(() => {
 });
 
 describe("UsagePage refresh behavior", () => {
+  it("restores hidden models from a shared URL alongside selected models", async () => {
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    router.route = "usage";
+    router.params = { model: "model-alpha,model-bravo", exclude_model: "model-alpha" };
+    usage.summary = usageSummaryWithUnsupported();
+
+    component = mount(UsagePage, { target: document.body });
+    await flushEffects();
+
+    expect(usage.excludedModels).toBe("model-alpha");
+    expect(usage.selectedModels).toBe("model-alpha,model-bravo");
+    expect(router.params.exclude_model).toBe("model-alpha");
+    expect(usage.hasActiveFilters).toBe(true);
+  });
+
   it("uses stable project keys in the Project filter", async () => {
     vi.stubGlobal(
       "ResizeObserver",

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -132,7 +132,7 @@ function loadUsageFilters(): UsageFilterState {
         excludedProjects: saved.excludedProjects ?? "",
         excludedProjectKeys: "",
         excludedAgents: saved.excludedAgents ?? "",
-        excludedModels: "",
+        excludedModels: saved.excludedModels ?? "",
         selectedModels: saved.selectedModels ?? "",
       };
     }
@@ -324,8 +324,8 @@ class UsageStore {
   selectedTokenTypes: UsageTokenType[] = $state([...ALL_TOKEN_TYPES]);
   selectedTimeRange: { from: string; to: string } | null = $state(null);
 
-  // Excluded project items and included model items
-  // (comma-separated strings). Empty models = all models.
+  // Exclusions and the model picker's inclusion set are comma-separated.
+  // Empty selectedModels includes all models except explicit exclusions.
   // Initialized from localStorage to survive tab switches.
   excludedProjects: string = $state("");
   excludedProjectKeys: string = $state("");
@@ -423,6 +423,9 @@ class UsageStore {
     }
     if (this.selectedModels) {
       p.model = this.selectedModels;
+    }
+    if (this.excludedModels) {
+      p.exclude_model = this.excludedModels;
     }
     return p;
   }
@@ -637,6 +640,18 @@ class UsageStore {
     });
   }
 
+  hideModel(name: string, options: { preserveTimeRange?: boolean } = {}): void {
+    const previous = this.excludedModels;
+    const hadSelectedTimeRange = options.preserveTimeRange && this.selectedTimeRange !== null;
+    this.excludedModels = joinCsvParts(this.excludedModels, name);
+    const changed = this.excludedModels;
+    void this.fetchAllWithResult(options).then((result) => {
+      if (result !== "error" || !hadSelectedTimeRange || this.excludedModels !== changed) return;
+      this.excludedModels = previous;
+      void this.fetchAll({ preserveTimeRange: true });
+    });
+  }
+
   toggleModel(name: string, options: { preserveTimeRange?: boolean } = {}): void {
     const previousSelected = this.selectedModels;
     const previousExcluded = this.excludedModels;
@@ -741,6 +756,7 @@ class UsageStore {
       this.excludedProjects !== "" ||
       this.excludedProjectKeys !== "" ||
       this.excludedAgents !== "" ||
+      this.excludedModels !== "" ||
       this.selectedModels !== ""
     );
   }
@@ -1282,6 +1298,9 @@ export function buildUsageUrlParams(state: UsageUrlState): Record<string, string
   }
   if (state.selectedModels) {
     params["model"] = state.selectedModels;
+  }
+  if (state.excludedModels) {
+    params["exclude_model"] = state.excludedModels;
   }
   if (state.excludedProjects) {
     params["exclude_project"] = state.excludedProjects;

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -424,7 +424,7 @@ describe("UsageStore filter persistence", () => {
     const { usage } = await loadStore();
     expect(usage.excludedProjects).toBe("saved-proj");
     expect(usage.excludedProjectKeys).toBe("");
-    expect(usage.excludedModels).toBe("");
+    expect(usage.excludedModels).toBe("opus");
     expect(usage.selectedModels).toBe("sonnet");
     expect(usage.excludedAgents).toBe("");
   });
@@ -1770,6 +1770,7 @@ describe("buildUsageUrlParams", () => {
     expect(params).toEqual({
       exclude_project: "p1",
       exclude_agent: "a1",
+      exclude_model: "m1",
       model: "m2",
     });
   });


### PR DESCRIPTION
Clicking a model in the Usage attribution treemap, side rail, or list now hides it and leaves the other models visible. These clicks had reused the header model picker's inclusion toggle, which isolated the clicked model instead.

Attribution now uses a separate model-exclusion action. The header picker keeps its selection behavior, the active chart range stays in place, and hidden models survive refreshes and shared URLs. Clear Filters restores all models. The main behavior change is in the usage store, with URL restoration handled by UsagePage.
