### PR TITLE
fix(frontend): keep task notifications inside their turn in focused mode

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -565,6 +565,9 @@ Appearance:
 Focused mode strips intermediate tool calls, thinking blocks, and partial
 assistant messages, showing only user prompts and final assistant responses.
 This makes long sessions easier to read as a clean conversation transcript.
+Task notifications and stop hook feedback count as part of the turn they
+interrupt rather than as new prompts, so a session that waits on background
+agents still collapses to its prompts and final answers.
 
 ![Focused transcript mode](/docs/assets/generated/screenshots/focused-transcript.png)
 

--- a/frontend/src/lib/utils/transcript-mode.test.ts
+++ b/frontend/src/lib/utils/transcript-mode.test.ts
@@ -44,6 +44,16 @@ function toolMsg(ordinal: number, tool = "Bash", args = "$ ls") {
   });
 }
 
+function systemMsg(ordinal: number, subtype: string, content: string) {
+  return msg({
+    ordinal,
+    role: "user",
+    is_system: true,
+    source_subtype: subtype,
+    content,
+  });
+}
+
 function ordinalsOf(messages: Message[], keepAnswerBeforeTrailingTools = false) {
   const items = buildDisplayItems(messages);
   return filterDisplayItemsByTranscriptMode(items, "focused", {
@@ -55,6 +65,58 @@ describe("filterDisplayItemsByTranscriptMode", () => {
   it("returns items unchanged in normal mode", () => {
     const items = buildDisplayItems([userMsg(0), assistantMsg(1), toolMsg(2)]);
     expect(filterDisplayItemsByTranscriptMode(items, "normal")).toEqual(items);
+  });
+
+  it("keeps one turn across task notifications", () => {
+    expect(
+      ordinalsOf([
+        userMsg(0, "review the repo"),
+        assistantMsg(1, "spawning four review agents"),
+        toolMsg(2, "Task", "review ui"),
+        systemMsg(3, "task_notification", "<task-notification>done</task-notification>"),
+        assistantMsg(4, "one agent finished, waiting for the rest"),
+        toolMsg(5, "Task", "review errors"),
+        systemMsg(6, "task_notification", "<task-notification>done</task-notification>"),
+        assistantMsg(7, "review complete, report published"),
+        userMsg(8, "thanks"),
+      ]),
+    ).toEqual([0, 7, 8]);
+  });
+
+  it("does not let a task notification resurrect dropped narration", () => {
+    expect(
+      ordinalsOf([
+        userMsg(0),
+        assistantMsg(1, "working"),
+        toolMsg(2),
+        systemMsg(3, "task_notification", "<task-notification>done</task-notification>"),
+        userMsg(4),
+      ]),
+    ).toEqual([0, 4]);
+  });
+
+  it("keeps one turn across stop hook feedback", () => {
+    expect(
+      ordinalsOf([
+        userMsg(0),
+        assistantMsg(1, "first attempt"),
+        systemMsg(2, "stop_hook", "Stop hook feedback: tests failed"),
+        assistantMsg(3, "fixed and rerun"),
+        userMsg(4),
+      ]),
+    ).toEqual([0, 3, 4]);
+  });
+
+  it("still ends the turn at an interruption", () => {
+    expect(
+      ordinalsOf([
+        userMsg(0),
+        assistantMsg(1, "partial answer"),
+        systemMsg(2, "interrupted", "[Request interrupted by user]"),
+        userMsg(3),
+        assistantMsg(4, "answer"),
+      ]),
+    ).toEqual([0, 1, 2, 3, 4]);
   });
 
   it("keeps the final assistant before the next user", () => {

--- a/frontend/src/lib/utils/transcript-mode.ts
+++ b/frontend/src/lib/utils/transcript-mode.ts
@@ -1,6 +1,23 @@
 import type { DisplayItem, MessageItem } from "./display-items.js";
 import type { Message } from "../api/types.js";
 
+// System rows that arrive while the assistant is still working on the
+// current prompt. The Claude parser keeps them on role "user" so analytics
+// do not count them as replies, but they are not prompts: a task
+// notification reports a background agent finishing, and stop hook feedback
+// is injected by tooling. Treating them as turn boundaries split one
+// exchange into many and promoted every "still waiting" status line before
+// them to a final answer.
+const MID_TURN_SYSTEM_SUBTYPES = new Set(["task_notification", "stop_hook"]);
+
+function isMidTurnSystemMessage(m: Message): boolean {
+  return (
+    m.is_system === true &&
+    !!m.source_subtype &&
+    MID_TURN_SYSTEM_SUBTYPES.has(m.source_subtype)
+  );
+}
+
 export function filterDisplayItemsByTranscriptMode(
   items: DisplayItem[],
   mode: "normal" | "focused",
@@ -21,6 +38,13 @@ export function filterDisplayItemsByTranscriptMode(
       if (pendingAssistant && !keepAnswerBeforeTrailingTools) {
         toolAfterPendingAssistant = true;
       }
+      continue;
+    }
+
+    // Mid-turn system rows are neither prompts nor answers. Focused mode
+    // drops them with the rest of the intermediate work; normal mode still
+    // renders them as boundary cards.
+    if (isMidTurnSystemMessage(item.message)) {
       continue;
     }
 


### PR DESCRIPTION
Closes #1650.

Focused mode ended a turn at every row with role `user`. The Claude parser
keeps task notifications and stop hook feedback on that role so analytics do
not count them as assistant replies, but they arrive mid-turn while the
assistant is still working. Each one split the exchange, promoted the "still
waiting" status line before it to a final answer, and dropped any narration
that a tool call had followed. A session driven by background agents came out
as a wall of notification cards and one-line progress updates: one real
transcript rendered 145 focused items for 29 prompts.

`filterDisplayItemsByTranscriptMode` now drops those two subtypes as
intermediate work, the way it already drops tool groups. Interruptions,
continuations, resumes, and queued commands still end the turn, since each of
them really does. Normal mode is unchanged and still renders the cards, where
the System boundaries block toggle from #1606 governs them. The exported HTML
needs no change: `focusedExportOrdinals` already skips every system row
before its boundary logic runs.

The same transcript now renders 53 focused items: its 29 prompts, 23 final
answers, and one interruption. Reviewers should look at the new
`isMidTurnSystemMessage` check at the top of the loop and at the four cases
added to `transcript-mode.test.ts`, including the one that pins an
interruption as a boundary so the rule is not widened by accident.