### PR TITLE
fix(usage): unify model picker and chart visibility

### DIFF
--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -148,6 +148,16 @@ Each filter dropdown supports multi-select with a search box, Select all /
 Deselect all shortcuts, and a colored dot for agents so you can tell them apart
 at a glance.
 
+In the Model picker, checked models are visible and unchecked models are
+hidden. Clicking a model in the attribution chart unchecks it in the picker.
+Recheck it to show it again without changing the other models. Hidden models
+remain in the picker after a reload or when opening a shared URL.
+
+Usage saves model visibility with `exclude_model`. The previous Usage-only
+`model` URL parameter and saved inclusion selections no longer restrict the
+view; choose hidden models in the picker instead. The Analytics model filter
+and API model filters are unchanged.
+
 ![Model filter dropdown](/docs/assets/generated/screenshots/usage-filter-dropdown.png)
 
 ### Summary Cards

--- a/frontend/src/lib/components/usage/AttributionPanel.test.ts
+++ b/frontend/src/lib/components/usage/AttributionPanel.test.ts
@@ -247,7 +247,6 @@ describe("AttributionPanel model exclusion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     usage.summary = summaryWithModels();
-    usage.selectedModels = "";
     usage.excludedModels = "";
     usage.toggles.attribution.groupBy = "model";
   });
@@ -255,7 +254,6 @@ describe("AttributionPanel model exclusion", () => {
   afterEach(() => {
     usage.cancelInFlightReads();
     usage.summary = null;
-    usage.selectedModels = "";
     usage.excludedModels = "";
     usage.applyDateRange(usage.from, usage.to);
     usage.toggles.attribution.groupBy = "project";
@@ -312,8 +310,8 @@ describe("AttributionPanel model exclusion", () => {
     }
   });
 
-  it("keeps the selected models and chart brush when hiding a model", async () => {
-    usage.selectedModels = "gpt-5.6-sol,claude-opus-5";
+  it("keeps other hidden models and the chart brush when hiding a model", async () => {
+    usage.excludedModels = "model-other";
     usage.selectedTimeRange = { from: "2024-01-08", to: "2024-01-14" };
     usage.toggles.attribution.view = "treemap";
     usageServiceMocks.getApiV1UsageSummary.mockResolvedValue(summaryWithModels());
@@ -329,8 +327,7 @@ describe("AttributionPanel model exclusion", () => {
           expect.objectContaining({
             from: "2024-01-08",
             to: "2024-01-14",
-            model: "gpt-5.6-sol,claude-opus-5",
-            exclude_model: "gpt-5.6-sol",
+            exclude_model: "model-other,gpt-5.6-sol",
           }),
         ),
       );

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -53,8 +53,7 @@
   function isSeriesVisible(key: string): boolean {
     if (groupBy === "project") return !usage.isProjectKeyExcluded(key);
     if (groupBy === "agent") return !usage.isAgentExcluded(key);
-    if (!usage.selectedModels) return true;
-    return usage.selectedModels.split(",").includes(key);
+    return !usage.isModelExcluded(key);
   }
 
   const seriesData = $derived.by((): {

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -163,7 +163,7 @@ describe("CostTimeSeriesChart", () => {
     usage.selectedTimeRange = null;
     usage.excludedProjectKeys = "";
     usage.excludedAgents = "";
-    usage.selectedModels = "";
+    usage.excludedModels = "";
     usage.mode = "cost";
     usage.setSelectedTokenTypes(["input", "cache_write", "cache_read", "output"]);
     settings.chartPalette = "agentsview";
@@ -539,6 +539,34 @@ describe("CostTimeSeriesChart", () => {
     expect(document.querySelector(".empty")).toBeTruthy();
     expect(document.querySelectorAll(".chart-svg path.lc-area-path")).toHaveLength(0);
     unmount(component);
+  });
+
+  it("hides and restores model series in the cached chart range", async () => {
+    usage.toggles.timeSeries.groupBy = "model";
+    usage.summary!.daily = [
+      modelDailyEntry(0, [
+        { modelName: "model-alpha", cost: testMoney(3) },
+        { modelName: "model-bravo", cost: testMoney(2) },
+      ]),
+      modelDailyEntry(1, [
+        { modelName: "model-alpha", cost: testMoney(3) },
+        { modelName: "model-bravo", cost: testMoney(2) },
+      ]),
+    ];
+    usage.excludedModels = "model-alpha";
+    const component = mountChart();
+    await tick();
+    try {
+      expect(document.querySelectorAll("path.lc-area-path")).toHaveLength(1);
+      usage.excludedModels = "model-alpha,model-bravo";
+      await tick();
+      expect(document.querySelectorAll("path.lc-area-path")).toHaveLength(0);
+      usage.excludedModels = "";
+      await tick();
+      expect(document.querySelectorAll("path.lc-area-path")).toHaveLength(2);
+    } finally {
+      await unmount(component);
+    }
   });
 
   it("uses aggregate-cost-ranked Matplotlib colors for model paths and legend dots", async () => {

--- a/frontend/src/lib/components/usage/ModelVisibility.test.ts
+++ b/frontend/src/lib/components/usage/ModelVisibility.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { mount, tick, unmount } from "svelte";
+import type { UsageSummaryResponse } from "../../api/generated/index";
+import { testMoney } from "../../test/money.js";
+
+const api = vi.hoisted(() => {
+  const zero = { microdollars: 0 };
+  const metrics = {
+    totalCost: zero,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    totalTokens: 0,
+    sessionCount: 0,
+    costPerSession: null,
+    tokensPerSession: null,
+  };
+  return {
+    getApiV1UsageSummary: vi.fn(),
+    getApiV1UsageComparison: vi.fn().mockResolvedValue({
+      priorFrom: "2023-12-01",
+      priorTo: "2023-12-31",
+      priorTotalCost: zero,
+      deltaPct: null,
+    }),
+    getApiV1UsagePairwiseComparison: vi.fn().mockResolvedValue({
+      left: metrics,
+      right: metrics,
+      deltas: {
+        totalCostDelta: zero,
+        totalCostDeltaRatio: null,
+        inputTokensDelta: 0,
+        inputTokensDeltaRatio: null,
+        outputTokensDelta: 0,
+        outputTokensDeltaRatio: null,
+        cacheCreationDelta: 0,
+        cacheCreationDeltaRatio: null,
+        cacheReadDelta: 0,
+        cacheReadDeltaRatio: null,
+        totalTokensDelta: 0,
+        totalTokensDeltaRatio: null,
+        sessionCountDelta: 0,
+        sessionCountDeltaRatio: null,
+        costPerSessionDelta: null,
+        costPerSessionRatio: null,
+        tokensPerSessionDelta: null,
+        tokensPerSessionRatio: null,
+      },
+    }),
+    getApiV1UsageTopSessions: vi.fn().mockResolvedValue([]),
+  };
+});
+vi.mock("../../api/generated/index", () => ({ UsageService: api }));
+vi.mock("../../api/runtime.js", () => ({
+  callGenerated: (request: () => Promise<unknown>) => request(),
+  isAbortError: () => false,
+}));
+
+import UsagePage from "./UsagePage.svelte";
+import { usage } from "../../stores/usage.svelte.js";
+import { sessions } from "../../stores/sessions.svelte.js";
+import { router } from "../../stores/router.svelte.js";
+
+function summary(excluded = ""): UsageSummaryResponse {
+  const hidden = excluded.split(",");
+  return {
+    from: "2024-01-01",
+    to: "2024-01-31",
+    projects: {},
+    totals: {
+      inputTokens: 30,
+      outputTokens: 15,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      totalCost: testMoney(6),
+      cacheSavings: testMoney(0),
+    },
+    daily: [],
+    projectTotals: [],
+    agentTotals: [],
+    modelTotals: ["model-alpha", "model-bravo", "model-charlie"]
+      .filter((model) => !hidden.includes(model))
+      .map((model, index) => ({
+        model,
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        cost: testMoney(3 - index),
+      })),
+    sessionCounts: { total: 3, byProject: {}, byAgent: {} },
+    cacheStats: {
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      uncachedInputTokens: 30,
+      outputTokens: 15,
+      hitRate: 0,
+      savingsVsUncached: testMoney(0),
+    },
+  };
+}
+
+function modelPicker() {
+  return document.querySelector<HTMLButtonElement>(
+    '.kit-filter-dropdown__btn[aria-label^="Model:"]',
+  )!;
+}
+
+function modelOption(name: string) {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>(".kit-filter-dropdown__item"),
+  ).find((button) => button.textContent?.trim() === name)!;
+}
+
+let component: ReturnType<typeof mount>;
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+  api.getApiV1UsageSummary.mockImplementation(async (params) => summary(params.exclude_model));
+  usage.excludedModels = "";
+  usage.toggles.attribution.groupBy = "model";
+  usage.toggles.attribution.view = "treemap";
+  usage.summary = summary();
+  router.route = "usage";
+  router.params = {};
+});
+afterEach(async () => {
+  await unmount(component);
+  usage.cancelInFlightReads();
+  usage.summary = null;
+  usage.excludedModels = "";
+  usage.toggles.attribution.groupBy = "project";
+  router.route = "sessions";
+  router.params = {};
+  document.body.innerHTML = "";
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("Usage model visibility", () => {
+  it.each(["URL", "saved filters"])(
+    "restores one hidden model from %s without isolating it",
+    async (source) => {
+      const excluded = "model-alpha,model-bravo";
+      if (source === "URL") router.params = { exclude_model: excluded };
+      else usage.excludedModels = excluded;
+      usage.summary = summary(excluded);
+      component = mount(UsagePage, { target: document.body });
+      await tick();
+
+      expect(modelPicker().textContent).not.toContain("All");
+      modelPicker().click();
+      await tick();
+      expect(modelOption("model-alpha")).toBeDefined();
+      expect(modelOption("model-alpha").classList.contains("active")).toBe(false);
+      expect(modelOption("model-charlie").classList.contains("active")).toBe(true);
+      modelOption("model-alpha").click();
+
+      await vi.waitFor(() => {
+        const params = api.getApiV1UsageSummary.mock.lastCall?.[0];
+        expect(params.exclude_model).toBe("model-bravo");
+        expect(params.model).toBeUndefined();
+        expect(
+          Array.from(document.querySelectorAll(".tile title"), (tile) => tile.textContent),
+        ).toEqual(["Click to hide model-alpha", "Click to hide model-charlie"]);
+      });
+      expect(router.params.exclude_model).toBe("model-bravo");
+    },
+  );
+
+  it("keeps chart hiding, picker restoring, and bulk visibility in sync", async () => {
+    component = mount(UsagePage, { target: document.body });
+    await tick();
+    document.querySelector(".tile")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await vi.waitFor(() => expect(document.querySelectorAll(".tile")).toHaveLength(2));
+    expect(modelPicker().textContent).not.toContain("All");
+
+    modelPicker().click();
+    await tick();
+    expect(modelOption("model-alpha").classList.contains("active")).toBe(false);
+    modelOption("model-alpha").click();
+    await vi.waitFor(() => expect(document.querySelectorAll(".tile")).toHaveLength(3));
+
+    modelOption("model-bravo").click();
+    await vi.waitFor(() => {
+      expect(api.getApiV1UsageSummary.mock.lastCall?.[0].exclude_model).toBe("model-bravo");
+      expect(document.querySelectorAll(".tile")).toHaveLength(2);
+    });
+
+    const bulk = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".kit-filter-dropdown__bulk-btn"),
+    );
+    const deselectAll = bulk.find((button) => button.textContent === "Deselect all")!;
+    const selectAll = bulk.find((button) => button.textContent === "Select all")!;
+    deselectAll.click();
+    await vi.waitFor(() => expect(document.querySelectorAll(".tile")).toHaveLength(0));
+    expect(modelPicker().textContent).toContain("None");
+    selectAll.click();
+    await vi.waitFor(() => expect(document.querySelectorAll(".tile")).toHaveLength(3));
+    expect(modelPicker().textContent).toContain("All");
+    expect(api.getApiV1UsageSummary.mock.lastCall?.[0].exclude_model).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -146,9 +146,7 @@
 
   // Seed from URL/local model filters before a response arrives.
   $effect(() => {
-    const filtered = [
-      usage.selectedModels,
-    ].filter(Boolean).join(",");
+    const filtered = usage.excludedModels;
     untrack(() => {
       if (!filtered) return;
       mergeIntoKnownModels(filtered.split(","));
@@ -157,11 +155,6 @@
 
   const modelItems = $derived(
     knownModels.map((m) => ({ name: m })),
-  );
-  const selectedModels = $derived(
-    usage.selectedModels
-      ? usage.selectedModels.split(",").filter(Boolean)
-      : [],
   );
   const unsupportedUsageMessage = $derived.by(() => {
     const kind = usage.isTimeRangeSummaryProvisional
@@ -212,7 +205,7 @@
   // apply params that are actually present in the URL.
   const USAGE_FILTER_KEYS = new Set([
     "from", "to", "window_days",
-    "model", "exclude_model", "exclude_agent",
+    "exclude_model", "exclude_agent",
   ]);
   const SESSION_FILTER_KEYS = new Set([
     "project", "machine", "agent",
@@ -384,11 +377,6 @@
         usage.excludedModels = newExModel;
         changed = true;
       }
-      const newModel = params["model"] ?? "";
-      if (newModel !== usage.selectedModels) {
-        usage.selectedModels = newModel;
-        changed = true;
-      }
       if ((changed || sessionChanged) && urlInitRan) {
         usage.fetchAll();
       }
@@ -408,7 +396,6 @@
       excludedProjectKeys: usage.excludedProjectKeys,
       excludedAgents: usage.excludedAgents,
       excludedModels: usage.excludedModels,
-      selectedModels: usage.selectedModels,
     };
     const nextParams = withSelectedTokenTypes(
       withUsageMode(
@@ -521,8 +508,7 @@
       <FilterDropdown
         label={m.usage_model()}
         items={modelItems}
-        excludedCsv={usage.selectedModels}
-        mode="include"
+        excludedCsv={usage.excludedModels}
         onToggle={(name) => usage.toggleModel(name)}
         onSelectAll={() => usage.selectAllModels()}
         onDeselectAll={() =>
@@ -541,10 +527,8 @@
   </div>
 
   <SessionActiveFilters
-    modelFilters={selectedModels}
     onClearProjects={() => usage.selectAllProjects()}
     onClearAgents={() => usage.selectAllAgents()}
-    onRemoveModel={(model) => usage.toggleModel(model)}
     onClearModels={() => usage.selectAllModels()}
   />
 

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -138,7 +138,6 @@ afterEach(() => {
   usage.excludedProjects = "";
   usage.excludedProjectKeys = "";
   usage.excludedModels = "";
-  usage.selectedModels = "";
   usage.knownProjects = [];
   settings.chartPalette = "agentsview";
   sessions.projects = [];
@@ -147,18 +146,17 @@ afterEach(() => {
 });
 
 describe("UsagePage refresh behavior", () => {
-  it("restores hidden models from a shared URL alongside selected models", async () => {
+  it("restores hidden models from a shared URL", async () => {
     vi.spyOn(usage, "fetchAll").mockResolvedValue();
     vi.spyOn(sessions, "loadAgents").mockResolvedValue();
     router.route = "usage";
-    router.params = { model: "model-alpha,model-bravo", exclude_model: "model-alpha" };
+    router.params = { exclude_model: "model-alpha" };
     usage.summary = usageSummaryWithUnsupported();
 
     component = mount(UsagePage, { target: document.body });
     await flushEffects();
 
     expect(usage.excludedModels).toBe("model-alpha");
-    expect(usage.selectedModels).toBe("model-alpha,model-bravo");
     expect(router.params.exclude_model).toBe("model-alpha");
     expect(usage.hasActiveFilters).toBe(true);
   });
@@ -617,17 +615,17 @@ describe("UsagePage refresh behavior", () => {
 
     router.route = "usage";
     router.params = {
-      model: "fixture-model",
+      exclude_model: "fixture-model",
       exclude_project_key: "pl1:sha256:stale",
     };
     usage.excludedProjectKeys = "";
-    usage.selectedModels = "";
+    usage.excludedModels = "";
 
     component = mount(UsagePage, { target: document.body });
     await flushEffects();
 
     expect(usage.excludedProjectKeys).toBe("");
-    expect(usage.selectedModels).toBe("fixture-model");
+    expect(usage.excludedModels).toBe("fixture-model");
   });
 
   it("seeds bare Usage from an enabled fixed range", async () => {

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -120,7 +120,6 @@ export interface UsageFilterState {
   excludedProjectKeys?: string;
   excludedAgents: string;
   excludedModels: string;
-  selectedModels: string;
 }
 
 function loadUsageFilters(): UsageFilterState {
@@ -133,7 +132,6 @@ function loadUsageFilters(): UsageFilterState {
         excludedProjectKeys: "",
         excludedAgents: saved.excludedAgents ?? "",
         excludedModels: saved.excludedModels ?? "",
-        selectedModels: saved.selectedModels ?? "",
       };
     }
   } catch {
@@ -144,7 +142,6 @@ function loadUsageFilters(): UsageFilterState {
     excludedProjectKeys: "",
     excludedAgents: "",
     excludedModels: "",
-    selectedModels: "",
   };
 }
 
@@ -154,7 +151,6 @@ function saveUsageFilters(f: UsageFilterState): void {
       excludedProjects: f.excludedProjects,
       excludedAgents: f.excludedAgents,
       excludedModels: f.excludedModels,
-      selectedModels: f.selectedModels,
     };
     localStorage.setItem(USAGE_FILTERS_KEY, JSON.stringify(data));
   } catch {
@@ -324,14 +320,13 @@ class UsageStore {
   selectedTokenTypes: UsageTokenType[] = $state([...ALL_TOKEN_TYPES]);
   selectedTimeRange: { from: string; to: string } | null = $state(null);
 
-  // Exclusions and the model picker's inclusion set are comma-separated.
-  // Empty selectedModels includes all models except explicit exclusions.
+  // Empty exclusion sets show all items. Chart clicks and picker checkboxes
+  // share these comma-separated sets.
   // Initialized from localStorage to survive tab switches.
   excludedProjects: string = $state("");
   excludedProjectKeys: string = $state("");
   excludedAgents: string = $state("");
   excludedModels: string = $state("");
-  selectedModels: string = $state("");
   knownProjects: UsageProjectFilterItem[] = $state([]);
 
   constructor() {
@@ -340,7 +335,6 @@ class UsageStore {
     this.excludedProjectKeys = saved.excludedProjectKeys ?? "";
     this.excludedAgents = saved.excludedAgents;
     this.excludedModels = saved.excludedModels;
-    this.selectedModels = saved.selectedModels;
   }
 
   summary = $state<UsageSummaryResponse | null>(null);
@@ -420,9 +414,6 @@ class UsageStore {
     }
     if (this.excludedAgents) {
       p.exclude_agent = this.excludedAgents;
-    }
-    if (this.selectedModels) {
-      p.model = this.selectedModels;
     }
     if (this.excludedModels) {
       p.exclude_model = this.excludedModels;
@@ -653,16 +644,13 @@ class UsageStore {
   }
 
   toggleModel(name: string, options: { preserveTimeRange?: boolean } = {}): void {
-    const previousSelected = this.selectedModels;
-    const previousExcluded = this.excludedModels;
+    const previous = this.excludedModels;
     const hadSelectedTimeRange = options.preserveTimeRange && this.selectedTimeRange !== null;
-    this.selectedModels = this.toggleCsv(this.selectedModels, name);
-    this.excludedModels = "";
-    const changed = this.selectedModels;
+    this.excludedModels = this.toggleCsv(this.excludedModels, name);
+    const changed = this.excludedModels;
     void this.fetchAllWithResult(options).then((result) => {
-      if (result !== "error" || !hadSelectedTimeRange || this.selectedModels !== changed) return;
-      this.selectedModels = previousSelected;
-      this.excludedModels = previousExcluded;
+      if (result !== "error" || !hadSelectedTimeRange || this.excludedModels !== changed) return;
+      this.excludedModels = previous;
       void this.fetchAll({ preserveTimeRange: true });
     });
   }
@@ -700,11 +688,6 @@ class UsageStore {
     return this.excludedModels.split(",").includes(name);
   }
 
-  isModelSelected(name: string): boolean {
-    if (!this.selectedModels) return false;
-    return this.selectedModels.split(",").includes(name);
-  }
-
   selectAllProjects(): void {
     this.excludedProjects = "";
     this.excludedProjectKeys = "";
@@ -731,14 +714,12 @@ class UsageStore {
   }
 
   selectAllModels(): void {
-    this.selectedModels = "";
     this.excludedModels = "";
     this.fetchAll();
   }
 
-  deselectAllModels(_all: string[]): void {
-    this.selectedModels = "";
-    this.excludedModels = "";
+  deselectAllModels(all: string[]): void {
+    this.excludedModels = joinCsvParts(this.excludedModels, all.join(","));
     this.fetchAll();
   }
 
@@ -747,7 +728,6 @@ class UsageStore {
     this.excludedProjectKeys = "";
     this.excludedAgents = "";
     this.excludedModels = "";
-    this.selectedModels = "";
     this.fetchAll();
   }
 
@@ -756,8 +736,7 @@ class UsageStore {
       this.excludedProjects !== "" ||
       this.excludedProjectKeys !== "" ||
       this.excludedAgents !== "" ||
-      this.excludedModels !== "" ||
-      this.selectedModels !== ""
+      this.excludedModels !== ""
     );
   }
 
@@ -1274,7 +1253,6 @@ export interface UsageUrlState {
   excludedProjectKeys: string;
   excludedAgents: string;
   excludedModels: string;
-  selectedModels: string;
 }
 
 export const USAGE_DEFAULT_WINDOW_DAYS = DEFAULT_WINDOW_DAYS;
@@ -1295,9 +1273,6 @@ export function buildUsageUrlParams(state: UsageUrlState): Record<string, string
     if (state.to) params["to"] = state.to;
   } else if (state.windowDays > 0 && state.windowDays !== DEFAULT_WINDOW_DAYS) {
     params["window_days"] = String(state.windowDays);
-  }
-  if (state.selectedModels) {
-    params["model"] = state.selectedModels;
   }
   if (state.excludedModels) {
     params["exclude_model"] = state.excludedModels;

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -403,12 +403,14 @@ describe("UsageStore filter persistence", () => {
     usage.excludedProjects = "proj-a";
     usage.excludedProjectKeys = "pl1:sha256:proj-a";
     usage.excludedAgents = "claude";
+    usage.excludedModels = "opus";
     await usage.fetchAll();
 
     const saved = JSON.parse(localStorage.getItem("usage-filters") ?? "{}");
     expect(saved.excludedProjects).toBe("proj-a");
     expect(saved.excludedProjectKeys).toBeUndefined();
     expect(saved.excludedAgents).toBe("claude");
+    expect(saved.excludedModels).toBe("opus");
   });
 
   it("restores usage filters from localStorage on load", async () => {
@@ -418,14 +420,12 @@ describe("UsageStore filter persistence", () => {
         excludedProjects: "saved-proj",
         excludedProjectKeys: "pl1:sha256:saved-proj",
         excludedModels: "opus",
-        selectedModels: "sonnet",
       }),
     );
     const { usage } = await loadStore();
     expect(usage.excludedProjects).toBe("saved-proj");
     expect(usage.excludedProjectKeys).toBe("");
     expect(usage.excludedModels).toBe("opus");
-    expect(usage.selectedModels).toBe("sonnet");
     expect(usage.excludedAgents).toBe("");
   });
 
@@ -1675,7 +1675,7 @@ describe("UsageStore time-series range selection", () => {
 
     expect(usage.selectedTimeRange).toBeNull();
     expect(usageServiceMocks.getApiV1UsageSummary.mock.lastCall?.[0]).toEqual(
-      expect.objectContaining({ from: "2026-06-04", to: "2026-06-18", model: "model-a" }),
+      expect.objectContaining({ from: "2026-06-04", to: "2026-06-18", exclude_model: "model-a" }),
     );
   });
 
@@ -1765,13 +1765,11 @@ describe("buildUsageUrlParams", () => {
       excludedProjectKeys: "pk1",
       excludedAgents: "a1",
       excludedModels: "m1",
-      selectedModels: "m2",
     });
     expect(params).toEqual({
       exclude_project: "p1",
       exclude_agent: "a1",
       exclude_model: "m1",
-      model: "m2",
     });
   });
 
@@ -1786,7 +1784,6 @@ describe("buildUsageUrlParams", () => {
       excludedProjectKeys: "",
       excludedAgents: "",
       excludedModels: "",
-      selectedModels: "",
     });
     expect(params).toEqual({
       from: "2026-01-01",
@@ -1805,7 +1802,6 @@ describe("buildUsageUrlParams", () => {
       excludedProjectKeys: "",
       excludedAgents: "",
       excludedModels: "",
-      selectedModels: "",
     });
     expect(params).toEqual({});
   });
@@ -1821,7 +1817,6 @@ describe("buildUsageUrlParams", () => {
       excludedProjectKeys: "",
       excludedAgents: "",
       excludedModels: "",
-      selectedModels: "",
     });
     expect(params).toEqual({});
   });
@@ -1837,7 +1832,6 @@ describe("buildUsageUrlParams", () => {
       excludedProjectKeys: "",
       excludedAgents: "",
       excludedModels: "",
-      selectedModels: "",
     });
     expect(params).toEqual({ window_days: "7" });
   });
@@ -1853,7 +1847,6 @@ describe("buildUsageUrlParams", () => {
       excludedProjectKeys: "",
       excludedAgents: "",
       excludedModels: "",
-      selectedModels: "",
     });
     expect(params).toEqual({
       from: "2026-01-01",


### PR DESCRIPTION
The Usage model picker now controls visibility: checked models are shown, unchecked models are hidden. Clicking an attribution tile unchecks that model, and checking it in the picker restores it without changing the other models. Select all and Deselect all use the same visibility state.

This completes the restore path missed in #1649. Hidden models now seed the picker even when they are absent from a filtered response, including on fresh URLs and reloads. The time-series chart also uses the same exclusions while displaying cached range data.

Usage now stores and shares only `exclude_model` filters. Its former inclusion-only `model` links and saved selections no longer restrict the view. Analytics and API model filters are unchanged. The behavior is concentrated in the usage store and UsagePage; page-level coverage exercises chart clicks, picker restoration, and bulk actions through the real store and mocked API responses.
