### PR TITLE
fix(sync): reserve in-place progress for terminals

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -712,6 +712,7 @@ func runStartupSyncViaWorker(
 	t := time.Now()
 	resyncAnnounced := false
 	progressShown := false
+	terminal := isTerminalWriter(os.Stdout)
 	onLine := func(l workerLine) {
 		if l.Progress == nil {
 			return
@@ -726,8 +727,9 @@ func runStartupSyncViaWorker(
 				fmt.Println("Data version changed, running full resync...")
 			}
 		}
-		printSyncProgress(p)
-		progressShown = true
+		if writeSyncProgress(os.Stdout, terminal, p) {
+			progressShown = true
+		}
 		progress.SetDetail(startupProgressDetail(p))
 	}
 	result, err := launchSyncWorker(ctx, cfg, "startup", onLine)
@@ -1550,8 +1552,9 @@ func runInitialSync(
 ) sync.SyncStats {
 	fmt.Println("Running initial sync...")
 	t := time.Now()
+	progress := newSyncProgressPrinter(os.Stdout)
 	stats := engine.SyncAll(ctx, func(p sync.Progress) {
-		printSyncProgress(p)
+		progress(p)
 		startupProgress.SetDetail(startupProgressDetail(p))
 	})
 	printSyncSummary(stats, t)
@@ -1581,8 +1584,9 @@ func runInitialResync(
 	if stats.Aborted && ctx.Err() == nil {
 		fmt.Println("Resync incomplete, running incremental sync...")
 		t = time.Now()
+		progress := newSyncProgressPrinter(os.Stdout)
 		stats = engine.SyncAll(ctx, func(p sync.Progress) {
-			printSyncProgress(p)
+			progress(p)
 			startupProgress.SetDetail(startupProgressDetail(p))
 		})
 		printSyncSummary(stats, t)
@@ -1638,9 +1642,12 @@ func resyncCoversSignals(
 
 func printSyncSummary(stats sync.SyncStats, t time.Time) {
 	summary := fmt.Sprintf(
-		"\nSync complete: %d sessions synced",
+		"Sync complete: %d sessions synced",
 		stats.Synced,
 	)
+	if isTerminalWriter(os.Stdout) {
+		summary = "\n" + summary
+	}
 	if stats.OrphanedCopied > 0 {
 		summary += fmt.Sprintf(
 			", %d archived sessions preserved",
@@ -1663,6 +1670,7 @@ func printSyncSummary(stats sync.SyncStats, t time.Time) {
 type resyncProgressPrinter struct {
 	w        io.Writer
 	now      func() time.Time
+	terminal bool
 	label    string
 	started  time.Time
 	inPlace  bool
@@ -1672,7 +1680,9 @@ type resyncProgressPrinter struct {
 func newResyncProgressPrinter(
 	w io.Writer, now func() time.Time,
 ) *resyncProgressPrinter {
-	return &resyncProgressPrinter{w: w, now: now}
+	return &resyncProgressPrinter{
+		w: w, now: now, terminal: isTerminalWriter(w),
+	}
 }
 
 func (p *resyncProgressPrinter) Print(progress sync.Progress) {
@@ -1694,9 +1704,17 @@ func (p *resyncProgressPrinter) Print(progress sync.Progress) {
 			p.finishCurrent()
 			p.label = progress.Detail
 			p.started = p.now()
+			if !p.terminal {
+				fmt.Fprintf(
+					p.w, "  %s...\n",
+					strings.TrimSuffix(resyncProgressDisplayLabel(progress), "."),
+				)
+			}
 		}
-		p.inPlace = true
-		fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
+		p.inPlace = p.terminal
+		if p.terminal {
+			fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
+		}
 		return
 	}
 
@@ -1854,10 +1872,21 @@ func startupProgressDetail(p sync.Progress) string {
 	return resyncProgressDisplayLabel(p)
 }
 
-func printSyncProgress(p sync.Progress) {
+func writeSyncProgress(w io.Writer, terminal bool, p sync.Progress) bool {
+	if !terminal {
+		return false
+	}
 	if detail := formatSyncProgress(p); detail != "" {
-		fmt.Printf("\r  %s\x1b[K", detail)
-		return
+		fmt.Fprintf(w, "\r  %s\x1b[K", detail)
+		return true
+	}
+	return false
+}
+
+func newSyncProgressPrinter(w io.Writer) sync.ProgressFunc {
+	terminal := isTerminalWriter(w)
+	return func(p sync.Progress) {
+		writeSyncProgress(w, terminal, p)
 	}
 }
 

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -14,6 +14,7 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
+	"golang.org/x/term"
 )
 
 // parseDiffChangedCap caps the non-verbose changed-sessions
@@ -218,11 +219,7 @@ func isTerminalWriter(w io.Writer) bool {
 	if !ok {
 		return false
 	}
-	info, err := f.Stat()
-	if err != nil {
-		return false
-	}
-	return info.Mode()&os.ModeCharDevice != 0
+	return term.IsTerminal(int(f.Fd()))
 }
 
 // parseDiffAgentTypes validates --agent values against the parser

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -146,7 +146,7 @@ func doSync(cfg SyncConfig) (hadRemoteFailures bool) {
 					onProgress = progress.Print
 				} else {
 					fmt.Println("Running sync via daemon...")
-					onProgress = printSyncProgress
+					onProgress = newSyncProgressPrinter(os.Stdout)
 				}
 				stats, err := runDaemonSync(
 					context.Background(), tr, appCfg.AuthToken, cfg.Full,
@@ -271,6 +271,7 @@ func useDaemonForSync(tr transport) bool {
 type remoteProgressPrinter struct {
 	w        io.Writer
 	now      func() time.Time
+	terminal bool
 	label    string
 	started  time.Time
 	inPlace  bool
@@ -282,7 +283,9 @@ const remoteLocalSyncProgressLabel = "Syncing local sessions"
 func newRemoteProgressPrinter(
 	w io.Writer, now func() time.Time,
 ) *remoteProgressPrinter {
-	return &remoteProgressPrinter{w: w, now: now}
+	return &remoteProgressPrinter{
+		w: w, now: now, terminal: isTerminalWriter(w),
+	}
 }
 
 func (p *remoteProgressPrinter) Print(progress sync.Progress) {
@@ -314,9 +317,14 @@ func (p *remoteProgressPrinter) Print(progress sync.Progress) {
 			p.finishCurrent()
 			p.label = label
 			p.started = p.now()
+			if !p.terminal {
+				fmt.Fprintf(p.w, "  %s...\n", strings.TrimSuffix(label, "."))
+			}
 		}
-		p.inPlace = true
-		fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
+		p.inPlace = p.terminal
+		if p.terminal {
+			fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
+		}
 		return
 	}
 	if progress.Phase == sync.PhaseSyncing && progress.SessionsTotal > 0 {
@@ -324,9 +332,14 @@ func (p *remoteProgressPrinter) Print(progress sync.Progress) {
 			p.finishCurrent()
 			p.label = label
 			p.started = p.now()
+			if !p.terminal {
+				fmt.Fprintf(p.w, "  %s...\n", strings.TrimSuffix(label, "."))
+			}
 		}
-		p.inPlace = true
-		fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
+		p.inPlace = p.terminal
+		if p.terminal {
+			fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
+		}
 		return
 	}
 	if p.label == label {
@@ -888,7 +901,7 @@ func runLocalSyncResult(
 		progress = resyncProgress.Print
 	} else {
 		fmt.Println("Running initial sync...")
-		progress = printSyncProgress
+		progress = newSyncProgressPrinter(os.Stdout)
 	}
 	started := time.Now()
 	didResync, stats, err := coordinateLocalSyncRunner(

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -74,6 +74,32 @@ func TestPreparedHTTPRebuildLeaseCLIForwardsCommitOnce(t *testing.T) {
 	assert.Zero(t, prepared.closed, "commit must not infer cleanup")
 }
 
+func TestStartupWorkerDoesNotAddBlankLineForNonTerminalProgress(t *testing.T) {
+	cfg := config.Config{DataDir: t.TempDir()}
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, onLine func(workerLine),
+	) (workerResult, error) {
+		onLine(workerLine{Progress: &agentsync.Progress{
+			Phase:         agentsync.PhaseSyncing,
+			Detail:        "Syncing sessions",
+			SessionsDone:  1,
+			SessionsTotal: 1,
+		}})
+		return workerResult{}, errors.New("worker failed")
+	})
+	defer restore()
+
+	var err error
+	out := captureStdout(t, func() {
+		_, err = runStartupSyncViaWorker(
+			t.Context(), cfg, newStartupStateWriter(cfg.DataDir, time.Now),
+		)
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "Running initial sync...\n", out)
+}
+
 func newDirectSyncFixture(t *testing.T) (config.Config, *db.DB) {
 	t.Helper()
 	dataDir := t.TempDir()
@@ -1337,20 +1363,185 @@ func TestParseDaemonSyncSSEReportsProgressEvents(t *testing.T) {
 	assert.True(t, progress[0].Resync)
 }
 
-func TestPrintSyncProgressClearsShorterOverwrites(t *testing.T) {
-	out := captureStdout(t, func() {
-		printSyncProgress(agentsync.Progress{
-			Detail: "Rebuilding search index",
-			Hint:   "Rebuilding the search index may take a while on large archives.",
-		})
-		printSyncProgress(agentsync.Progress{
-			Detail: "Swapping rebuilt database into place",
-		})
+func TestWriteSyncProgressClearsShorterOverwritesInTerminalStyle(t *testing.T) {
+	var out bytes.Buffer
+	writeSyncProgress(&out, true, agentsync.Progress{
+		Detail: "Rebuilding search index",
+		Hint:   "Rebuilding the search index may take a while on large archives.",
+	})
+	writeSyncProgress(&out, true, agentsync.Progress{
+		Detail: "Swapping rebuilt database into place",
 	})
 
-	require.GreaterOrEqual(t, strings.Count(out, "\x1b[K"), 2,
+	outString := out.String()
+
+	require.GreaterOrEqual(t, strings.Count(outString, "\x1b[K"), 2,
 		"each carriage-return progress line must clear stale text")
-	assert.Contains(t, out, "\r  Swapping rebuilt database into place\x1b[K")
+	assert.Contains(t, outString, "\r  Swapping rebuilt database into place\x1b[K")
+}
+
+func TestPrintSyncProgressStaysCleanOnNonTerminalStdout(t *testing.T) {
+	out := captureStdout(t, func() {
+		printProgress := newSyncProgressPrinter(os.Stdout)
+		for _, progress := range []agentsync.Progress{
+			{Phase: agentsync.PhaseDiscovering, Detail: "Discovering sessions"},
+			{Phase: agentsync.PhaseSyncing, Detail: "Syncing sessions", SessionsTotal: 3},
+			{Phase: agentsync.PhaseSyncing, Detail: "Syncing sessions", SessionsTotal: 3, SessionsDone: 1},
+			{Phase: agentsync.PhaseSyncing, Detail: "Syncing sessions", SessionsTotal: 3, SessionsDone: 2},
+			{Phase: agentsync.PhaseSyncing, Detail: "Syncing sessions", SessionsTotal: 3, SessionsDone: 3},
+			{Phase: agentsync.PhaseSyncing, Detail: "Syncing sessions", SessionsTotal: 3, SessionsDone: 3, MessagesIndexed: 6},
+		} {
+			printProgress(progress)
+		}
+		printSyncSummary(agentsync.SyncStats{Synced: 3}, time.Now())
+	})
+
+	assert.NotContains(t, out, "\r")
+	assert.NotContains(t, out, "\x1b[K")
+	assert.True(t, strings.HasPrefix(out, "Sync complete: 3 sessions synced"),
+		"a redirected summary must not start with a blank line")
+}
+
+func TestResyncProgressPrinterStaysLineOrientedOnNonTerminalFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "resync-progress-*.txt")
+	require.NoError(t, err)
+	defer file.Close()
+
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	printer := newResyncProgressPrinter(file, func() time.Time { return now })
+	printer.Print(agentsync.Progress{
+		Phase: agentsync.PhasePreparingResync, Detail: "Preparing full resync", Resync: true,
+	})
+	printer.Print(agentsync.Progress{
+		Phase: agentsync.PhaseSyncing, Detail: "Syncing sessions", SessionsTotal: 3,
+		SessionsDone: 1, Resync: true,
+	})
+	printer.Print(agentsync.Progress{
+		Phase: agentsync.PhaseSyncing, Detail: "Syncing sessions", SessionsTotal: 3,
+		SessionsDone: 3, Resync: true,
+	})
+	printer.Print(agentsync.Progress{Phase: agentsync.PhaseDone, SessionsTotal: 3, Resync: true})
+	printer.Finish()
+	printer.Finish()
+	printer.Print(agentsync.Progress{Detail: "after finish"})
+	require.NoError(t, file.Close())
+
+	content, err := os.ReadFile(file.Name())
+	require.NoError(t, err)
+	out := string(content)
+	assert.NotContains(t, out, "\r")
+	assert.NotContains(t, out, "\x1b[K")
+	assert.Contains(t, out, "Preparing full resync...")
+	assert.Contains(t, out, "Syncing sessions...")
+	assert.Contains(t, out, "Syncing sessions completed in")
+	assert.NotContains(t, out, "after finish")
+}
+
+func TestRemoteProgressPrinterStaysLineOrientedOnNonTerminalFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "remote-progress-*.txt")
+	require.NoError(t, err)
+	defer file.Close()
+
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	printer := newRemoteProgressPrinter(file, func() time.Time { return now })
+	printer.Print(agentsync.Progress{
+		Detail: "Downloading session archive", BytesDone: 1, BytesTotal: 2,
+	})
+	printer.Print(agentsync.Progress{
+		Detail: "Downloading session archive", BytesDone: 2, BytesTotal: 2,
+	})
+	printer.Print(agentsync.Progress{
+		Phase: agentsync.PhaseSyncing, Detail: "Processing sessions", SessionsTotal: 2,
+		SessionsDone: 1,
+	})
+	printer.Print(agentsync.Progress{
+		Phase: agentsync.PhaseSyncing, Detail: "Processing sessions", SessionsTotal: 2,
+		SessionsDone: 2,
+	})
+	printer.Print(agentsync.Progress{Detail: "Synced 2 sessions"})
+	printer.Print(agentsync.Progress{Detail: "Skipped offline host"})
+	printer.Finish()
+	printer.Finish()
+	require.NoError(t, file.Close())
+
+	content, err := os.ReadFile(file.Name())
+	require.NoError(t, err)
+	out := string(content)
+	assert.NotContains(t, out, "\r")
+	assert.NotContains(t, out, "\x1b[K")
+	assert.Contains(t, out, "Downloading session archive...")
+	assert.Contains(t, out, "Processing sessions...")
+	assert.Contains(t, out, "Synced 2 sessions")
+	assert.Contains(t, out, "Skipped offline host")
+	assert.Contains(t, out, "Processing sessions completed in")
+}
+
+func TestIsTerminalWriterClassifiesDestinations(t *testing.T) {
+	assert.False(t, isTerminalWriter(&bytes.Buffer{}))
+
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	assert.False(t, isTerminalWriter(reader))
+	assert.False(t, isTerminalWriter(writer))
+	require.NoError(t, reader.Close())
+	require.NoError(t, writer.Close())
+
+	file, err := os.CreateTemp(t.TempDir(), "terminal-classification-*.txt")
+	require.NoError(t, err)
+	assert.False(t, isTerminalWriter(file))
+	require.NoError(t, file.Close())
+	assert.False(t, isTerminalWriter(file))
+
+	null, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	assert.False(t, isTerminalWriter(null))
+	require.NoError(t, null.Close())
+}
+
+func TestUsageResyncProgressStaysCleanOnNonTerminalStderr(t *testing.T) {
+	stdout := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			printer := newResyncProgressPrinter(os.Stderr, time.Now)
+			printer.Print(agentsync.Progress{
+				Phase: agentsync.PhasePreparingResync, Detail: "Preparing full resync",
+			})
+			printer.Print(agentsync.Progress{
+				Phase: agentsync.PhaseSyncing, Detail: "Syncing sessions", SessionsTotal: 1,
+				SessionsDone: 1,
+			})
+			printer.Print(agentsync.Progress{Phase: agentsync.PhaseDone, SessionsTotal: 1})
+			printer.Finish()
+			printSyncSummaryStderr(agentsync.SyncStats{Synced: 1}, time.Now())
+		})
+		assert.NotContains(t, stderr, "\r")
+		assert.NotContains(t, stderr, "\x1b[K")
+		assert.NotContains(t, stderr, "\n\n",
+			"a redirected summary must follow the completed phase without a blank line")
+		assert.Contains(t, stderr, "Sync complete: 1 sessions synced")
+	})
+
+	assert.Empty(t, stdout)
+}
+
+func TestNonTerminalProgressOutputIsBounded(t *testing.T) {
+	var out bytes.Buffer
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	printer := newRemoteProgressPrinter(&out, func() time.Time { return now })
+	for i := range 100 {
+		printer.Print(agentsync.Progress{
+			Phase: agentsync.PhaseSyncing, Detail: "Processing sessions", SessionsTotal: 10,
+			SessionsDone: i % 10,
+		})
+	}
+	printer.Finish()
+	printer.Finish()
+	printer.Print(agentsync.Progress{Detail: "after finish"})
+
+	assert.NotContains(t, out.String(), "\r")
+	assert.NotContains(t, out.String(), "\x1b[K")
+	assert.Equal(t, 1, strings.Count(out.String(), "Processing sessions..."))
+	assert.Equal(t, 1, strings.Count(out.String(), "Processing sessions completed in"))
+	assert.NotContains(t, out.String(), "after finish")
 }
 
 func TestResyncProgressPrinterWritesPhaseTimingsOnNewLines(t *testing.T) {
@@ -1358,6 +1549,7 @@ func TestResyncProgressPrinterWritesPhaseTimingsOnNewLines(t *testing.T) {
 	clock := func() time.Time { return now }
 	var out bytes.Buffer
 	printer := newResyncProgressPrinter(&out, clock)
+	printer.terminal = true
 
 	printer.Print(agentsync.Progress{
 		Phase:  agentsync.PhasePreparingResync,
@@ -1424,6 +1616,7 @@ func TestResyncProgressPrinterRendersDoneProgressBeforeCompletion(t *testing.T) 
 	clock := func() time.Time { return now }
 	var out bytes.Buffer
 	printer := newResyncProgressPrinter(&out, clock)
+	printer.terminal = true
 
 	printer.Print(agentsync.Progress{
 		Phase:           agentsync.PhaseSyncing,
@@ -1454,6 +1647,7 @@ func TestRemoteProgressPrinterWritesTimedStepLines(t *testing.T) {
 	clock := func() time.Time { return now }
 	var out bytes.Buffer
 	printer := newRemoteProgressPrinter(&out, clock)
+	printer.terminal = true
 
 	printer.Print(agentsync.Progress{
 		Detail: "Resolving agent directories on devbox",
@@ -1505,6 +1699,7 @@ func TestRemoteProgressPrinterRendersByteProgressInPlace(t *testing.T) {
 	clock := func() time.Time { return now }
 	var out bytes.Buffer
 	printer := newRemoteProgressPrinter(&out, clock)
+	printer.terminal = true
 
 	printer.Print(agentsync.Progress{
 		Detail:     "Downloading session archive from devbox",
@@ -1540,6 +1735,7 @@ func TestRemoteProgressPrinterRendersLocalSyncProgressWithoutDetail(t *testing.T
 	clock := func() time.Time { return now }
 	var out bytes.Buffer
 	printer := newRemoteProgressPrinter(&out, clock)
+	printer.terminal = true
 
 	printer.Print(agentsync.Progress{
 		Phase:           agentsync.PhaseSyncing,
@@ -1570,6 +1766,7 @@ func TestRemoteProgressPrinterKeepsResyncLabelOnDoneProgress(t *testing.T) {
 	clock := func() time.Time { return now }
 	var out bytes.Buffer
 	printer := newRemoteProgressPrinter(&out, clock)
+	printer.terminal = true
 
 	printer.Print(agentsync.Progress{
 		Phase:           agentsync.PhaseSyncing,

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -403,9 +403,12 @@ func ensureFreshData(
 // stderr so it does not pollute stdout-bound JSON or statusline output.
 func printSyncSummaryStderr(stats sync.SyncStats, t time.Time) {
 	summary := fmt.Sprintf(
-		"\nSync complete: %d sessions synced",
+		"Sync complete: %d sessions synced",
 		stats.Synced,
 	)
+	if isTerminalWriter(os.Stderr) {
+		summary = "\n" + summary
+	}
 	if stats.OrphanedCopied > 0 {
 		summary += fmt.Sprintf(
 			", %d archived sessions preserved",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -60,10 +60,11 @@ description: Release history for AgentsView
   focused index during the next writable database setup, which can make that
   first startup longer. No session resync is needed for this index.
 
-- Keep sync output readable when redirected to a pipe, file, or CI log. Show
-  summaries and coarse phase updates without terminal control sequences or
-  per-session refresh lines. Interactive terminals retain live progress.
-  (#1645)
+- Keep sync output readable when redirected to a pipe, file, or CI log.
+  Incremental sync prints its final summary; full resync and remote sync also
+  print coarse phase updates. Redirected output omits terminal control
+  sequences and per-session refresh lines. Interactive terminals retain live
+  progress. (#1645)
 - Price Codex Luna Reserve turns that persist as `gpt-reserve` using the
   existing GPT-5.6 Luna catalog rates. Usage reports still list `gpt-reserve`
   as the reported model. Existing SQLite usage caches rebuild so previously

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -60,6 +60,10 @@ description: Release history for AgentsView
   focused index during the next writable database setup, which can make that
   first startup longer. No session resync is needed for this index.
 
+- Keep sync output readable when redirected to a pipe, file, or CI log. Show
+  summaries and coarse phase updates without terminal control sequences or
+  per-session refresh lines. Interactive terminals retain live progress.
+  (#1645)
 - Price Codex Luna Reserve turns that persist as `gpt-reserve` using the
   existing GPT-5.6 Luna catalog rates. Usage reports still list `gpt-reserve`
   as the reported model. Existing SQLite usage caches rebuild so previously

--- a/internal/vector/manager_test.go
+++ b/internal/vector/manager_test.go
@@ -290,15 +290,27 @@ func TestManagerShutdownCancelsDetachedStartBuild(t *testing.T) {
 	// context is canceled. Shutdown must cancel the detached build so daemon
 	// shutdown does not hang on Wait.
 	ix := openTestIndex(t)
+	encoding := make(chan struct{})
 	stuckEncoder := func(ctx context.Context, _ []string) ([][]float32, error) {
+		close(encoding)
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
 	m := NewManager(
 		ix, twoDocSource(), soloEncoders(stuckEncoder), fakeGeneration("fake-model"),
 	)
+	t.Cleanup(func() {
+		m.cancelDetached()
+		m.Wait()
+	})
 	require.NoError(t, m.StartBuild(BuildRequest{}))
-	waitFor(t, func() bool { return m.Status().Running }, "build never reported running")
+	// Running is set before the build goroutine starts. Wait for the encoder
+	// so Shutdown exercises cancellation there, after SQLite setup finishes.
+	select {
+	case <-encoding:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "build never reached the encoder")
+	}
 
 	done := make(chan struct{})
 	go func() {


### PR DESCRIPTION
When you run `agentsview sync` with stdout or stderr redirected to a pipe, file, or CI log, AgentsView now emits readable output. Incremental sync keeps its final summary. Full resync and remote sync keep phase and completion lines. Interactive terminals retain live counters and line clearing.

The bug came from progress renderers writing carriage-return and `ESC[K` control sequences to every output writer. The fix checks the actual destination before using in-place rendering, then preserves existing summaries, timings, hints, `Synced` and `Skipped` results, failure reporting, and startup progress updates. The issue report measured about 700 KB of retained refresh frames for a 6,600-session sync.

Closes #1645
