### PR TITLE
fix(parser): preserve Cursor legacy tool results

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -57,6 +57,9 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
+- Preserve nonempty tool output from legacy Cursor text transcripts. Existing
+  archived sessions gain the output on their next sync when the source files
+  are still available. (#1627)
 - Activity reports load faster on large archives by skipping historical tool
   results that cannot affect the selected period. SQLite and PostgreSQL build a
   focused index during the next writable database setup, which can make that

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -970,10 +970,11 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   legacy `[Tool result]` blocks. It supplies no raw legacy excerpt or producer
   version. The parser retains its existing assumption that result bodies are
   indented: a nonempty line at column zero ends the body and becomes assistant
-  prose. The issue and linked first-party material do not establish that
-  indentation contract; the regression inputs are synthetic, not captured
-  producer fixtures. A redacted legacy excerpt is still needed to verify it.
-  The first-party
+  prose. Transcript role delimiters also start at column zero; indented
+  `user:` and `assistant:` lines remain in the result body. The issue and
+  linked first-party material do not establish that indentation contract; the
+  regression inputs are synthetic, not captured producer fixtures. A redacted
+  legacy excerpt is still needed to verify it. The first-party
   [JSONL discussion](https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311)
   reports missing tool outputs in JSONL, which does not establish legacy
   text boundaries. The history documentation link above now redirects to the

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -964,6 +964,20 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   for the GUI, `state.vscdb` is the only transcript store, not metadata beside
   one. Cursor's public GitHub organization was also searched 2026-07-19; no
   transcript schema or producer source was found.
+- **Legacy result evidence (rechecked 2026-09-08):**
+  [Issue #1627](https://github.com/kenn-io/agentsview/issues/1627), based on
+  read-only inspection of live transcripts on 2026-09-04, reports discarded
+  legacy `[Tool result]` blocks. It supplies no raw legacy excerpt or producer
+  version. The parser retains its existing assumption that result bodies are
+  indented: a nonempty line at column zero ends the body and becomes assistant
+  prose. The issue and linked first-party material do not establish that
+  indentation contract; the regression inputs are synthetic, not captured
+  producer fixtures. A redacted legacy excerpt is still needed to verify it.
+  The first-party
+  [JSONL discussion](https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311)
+  reports missing tool outputs in JSONL, which does not establish legacy
+  text boundaries. The history documentation link above now redirects to the
+  docs landing page and supplies no legacy format details.
 - **Usage and cost:** The consumed text/JSONL transcripts have no reliable
   per-message token, cache, reasoning, credit, or monetary-cost fields.
 - **Agentsview:** `internal/parser/cursor.go`,

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -964,7 +964,7 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   for the GUI, `state.vscdb` is the only transcript store, not metadata beside
   one. Cursor's public GitHub organization was also searched 2026-07-19; no
   transcript schema or producer source was found.
-- **Legacy result evidence (rechecked 2026-09-08):**
+- **Legacy result evidence (rechecked 2026-09-09):**
   [Issue #1627](https://github.com/kenn-io/agentsview/issues/1627), based on
   read-only inspection of live transcripts on 2026-09-04, reports discarded
   legacy `[Tool result]` blocks. It supplies no raw legacy excerpt or producer
@@ -978,7 +978,10 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   [JSONL discussion](https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311)
   reports missing tool outputs in JSONL, which does not establish legacy
   text boundaries. The history documentation link above now redirects to the
-  docs landing page and supplies no legacy format details.
+  docs landing page and supplies no legacy format details. The archive
+  regression also exercises incremental S3 sync from data version 101 with an
+  unchanged object, verifying recovered output and a skipped fetch on the next
+  pass. This uses synthetic input, not additional format evidence.
 - **Usage and cost:** The consumed text/JSONL transcripts have no reliable
   per-message token, cache, reasoning, credit, or monetary-cost fields.
 - **Agentsview:** `internal/parser/cursor.go`,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -468,7 +468,10 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // (101: Cursor user turn timestamps are parsed from recognized metadata.
 // Existing Cursor rows need re-parsing so stored message and session times
 // reflect the transcript timestamps.)
-const dataVersion = 101
+// (102: Cursor legacy text transcripts now preserve nonempty tool-result
+// bodies as result events. Existing Cursor rows need re-parsing to recover
+// output from unchanged source files.)
+const dataVersion = 102
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1101,7 +1101,7 @@ func TestCurrentDataVersionCodexGuardianLineage(t *testing.T) {
 }
 
 func TestCurrentDataVersionCursorTurnTimestamps(t *testing.T) {
-	assert.Equal(t, 101, CurrentDataVersion(),
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 101,
 		"Cursor turn timestamps require re-parsing existing sessions")
 }
 

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/tidwall/gjson"
 )
@@ -154,13 +155,13 @@ func parseCursorMessages(lines []string) []ParsedMessage {
 }
 
 // splitCursorBlocks splits lines into blocks delimited by
-// "user:" or "assistant:" on a line by itself.
+// "user:" or "assistant:" at the left margin, with optional trailing whitespace.
 func splitCursorBlocks(lines []string) []cursorBlock {
 	var blocks []cursorBlock
 	var current *cursorBlock
 
 	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		trimmed := strings.TrimRightFunc(line, unicode.IsSpace)
 		if trimmed == "user:" || trimmed == "assistant:" {
 			if current != nil {
 				blocks = append(blocks, *current)

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -368,14 +368,27 @@ func extractAssistantContent(
 			continue
 		}
 
-		// Tool result — skip the header and body
+		// Tool result — attach the body to the preceding call
 		if strings.HasPrefix(trimmed, "[Tool result]") {
 			i++
+			bodyStart := i
 			for i < len(lines) {
 				if isBlockBodyEnd(lines[i]) {
 					break
 				}
 				i++
+			}
+			if len(toolCalls) > 0 {
+				content := strings.TrimSpace(strings.Join(
+					dedentCursorBlock(lines[bodyStart:i]), "\n",
+				))
+				if content == "" {
+					continue
+				}
+				toolCalls[len(toolCalls)-1].ResultEvents = append(
+					toolCalls[len(toolCalls)-1].ResultEvents,
+					ParsedToolResultEvent{Content: content},
+				)
 			}
 			continue
 		}

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -885,10 +885,11 @@ func cursorProviderCapabilities() Capabilities {
 			S3Discovery:          CapabilitySupported,
 		},
 		Content: ContentCapabilities{
-			FirstMessage: CapabilitySupported,
-			Thinking:     CapabilitySupported,
-			ToolCalls:    CapabilitySupported,
-			ToolResults:  CapabilitySupported,
+			FirstMessage:     CapabilitySupported,
+			Thinking:         CapabilitySupported,
+			ToolCalls:        CapabilitySupported,
+			ToolResults:      CapabilitySupported,
+			ToolResultEvents: CapabilitySupported,
 		},
 	}
 }

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -432,12 +432,14 @@ func TestCursorLegacyToolResultMultiline(t *testing.T) {
 		cursorProviderCapabilities().Content.ToolResultEvents)
 
 	lines := []string{
-		"assistant:",
+		"assistant: \t\r",
 		"[Tool call] First",
 		"  command=first",
 		"[Tool result]",
 		"    first line",
 		"",
+		"    user:",
+		"    assistant:",
 		"    second line",
 		"[Tool result]",
 		"[Tool result]",
@@ -458,7 +460,7 @@ func TestCursorLegacyToolResultMultiline(t *testing.T) {
 		messages[0].Content)
 	firstCall := messages[0].ToolCalls[0]
 	require.Len(t, firstCall.ResultEvents, 2)
-	assert.Equal(t, "first line\n\nsecond line",
+	assert.Equal(t, "first line\n\nuser:\nassistant:\nsecond line",
 		firstCall.ResultEvents[0].Content)
 	assert.Equal(t, "third result", firstCall.ResultEvents[1].Content)
 	for _, event := range firstCall.ResultEvents {

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -257,11 +257,12 @@ func TestCursorParentAndChildTimestamps(t *testing.T) {
 
 func TestExtractAssistantContent(t *testing.T) {
 	tests := []struct {
-		name          string
-		lines         []string
-		wantText      string
-		wantThinking  bool
-		wantToolCount int
+		name             string
+		lines            []string
+		wantText         string
+		wantThinking     bool
+		wantToolCount    int
+		wantResultCounts []int
 	}{
 		{
 			name: "plain text",
@@ -311,9 +312,29 @@ func TestExtractAssistantContent(t *testing.T) {
 				"  file1.go",
 				"Here are the files I found.",
 			},
-			wantText:      "Here are the files I found.",
-			wantThinking:  true,
-			wantToolCount: 1,
+			wantText:         "Here are the files I found.",
+			wantThinking:     true,
+			wantToolCount:    1,
+			wantResultCounts: []int{1},
+		},
+		{
+			name: "thinking, two tools, prose after first result, no second result",
+			lines: []string{
+				"[Thinking]",
+				"  let me think...",
+				"[Tool call] First",
+				"  command=one",
+				"[Tool result]",
+				"  first result",
+				"The first call finished.",
+				"[Tool call] Second",
+				"  command=two",
+				"The second call is pending.",
+			},
+			wantText:         "The first call finished.\nThe second call is pending.",
+			wantThinking:     true,
+			wantToolCount:    2,
+			wantResultCounts: []int{1, 0},
 		},
 		{
 			name: "prose between markers",
@@ -331,7 +352,44 @@ func TestExtractAssistantContent(t *testing.T) {
 			wantText: "First I'll check the file.\n" +
 				"The file looks good.\n" +
 				"Build succeeded.",
-			wantToolCount: 2,
+			wantToolCount:    2,
+			wantResultCounts: []int{1, 0},
+		},
+		{
+			name: "result before a later call",
+			lines: []string{
+				"[Tool result]",
+				"  orphan output",
+				"The call follows.",
+				"[Tool call] Shell",
+				"  command=ls",
+			},
+			wantText:      "The call follows.",
+			wantToolCount: 1,
+		},
+		{
+			name: "result belongs to the latest call",
+			lines: []string{
+				"[Tool call] First",
+				"  command=one",
+				"[Tool call] Second",
+				"  command=two",
+				"[Tool result]",
+				"  second result",
+			},
+			wantToolCount:    2,
+			wantResultCounts: []int{0, 1},
+		},
+		{
+			name: "empty and whitespace-only results are omitted",
+			lines: []string{
+				"[Tool call] Shell",
+				"  command=ls",
+				"[Tool result]",
+				"[Tool result]",
+				"  ",
+			},
+			wantToolCount: 1,
 		},
 		{
 			name:  "empty lines",
@@ -357,9 +415,83 @@ func TestExtractAssistantContent(t *testing.T) {
 			)
 			assert.Equal(t, tt.wantText, text, "text")
 			assert.Equal(t, tt.wantThinking, hasThinking, "hasThinking")
-			assert.Len(t, toolCalls, tt.wantToolCount, "tool call count")
+			require.Len(t, toolCalls, tt.wantToolCount, "tool call count")
+			for i, call := range toolCalls {
+				wantResults := 0
+				if tt.wantResultCounts != nil {
+					wantResults = tt.wantResultCounts[i]
+				}
+				assert.Len(t, call.ResultEvents, wantResults, "results for call %d", i)
+			}
 		})
 	}
+}
+
+func TestCursorLegacyToolResultMultiline(t *testing.T) {
+	assert.Equal(t, CapabilitySupported,
+		cursorProviderCapabilities().Content.ToolResultEvents)
+
+	lines := []string{
+		"assistant:",
+		"[Tool call] First",
+		"  command=first",
+		"[Tool result]",
+		"    first line",
+		"",
+		"    second line",
+		"[Tool result]",
+		"[Tool result]",
+		"  third result",
+		"Visible prose line one.",
+		"Visible prose line two.",
+		"[Tool call] Second",
+		"  command=second",
+		"[Tool result]",
+		"    second call result",
+	}
+
+	messages := parseCursorMessages(lines)
+
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].ToolCalls, 2)
+	assert.Equal(t, "Visible prose line one.\nVisible prose line two.",
+		messages[0].Content)
+	firstCall := messages[0].ToolCalls[0]
+	require.Len(t, firstCall.ResultEvents, 2)
+	assert.Equal(t, "first line\n\nsecond line",
+		firstCall.ResultEvents[0].Content)
+	assert.Equal(t, "third result", firstCall.ResultEvents[1].Content)
+	for _, event := range firstCall.ResultEvents {
+		assert.Empty(t, event.ToolUseID)
+		assert.Empty(t, event.AgentID)
+		assert.Empty(t, event.SubagentSessionID)
+		assert.Empty(t, event.Source)
+		assert.Empty(t, event.Status)
+		assert.Zero(t, event.Timestamp)
+	}
+
+	secondCall := messages[0].ToolCalls[1]
+	require.Len(t, secondCall.ResultEvents, 1)
+	assert.Equal(t, "second call result",
+		secondCall.ResultEvents[0].Content)
+}
+
+func TestCursorLegacyToolResultStaysWithinAssistantBlock(t *testing.T) {
+	messages := parseCursorMessages([]string{
+		"assistant:",
+		"[Tool call] Shell",
+		"  command=ls",
+		"assistant:",
+		"[Tool result]",
+		"  orphan output",
+		"Later prose.",
+	})
+
+	require.Len(t, messages, 2)
+	require.Len(t, messages[0].ToolCalls, 1)
+	assert.Empty(t, messages[0].ToolCalls[0].ResultEvents)
+	assert.Equal(t, "Later prose.", messages[1].Content)
+	assert.Empty(t, messages[1].ToolCalls)
 }
 
 func TestExtractAssistantContentCursorApplyPatch(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8279,12 +8279,12 @@ func (e *Engine) filterFilesByMtime(
 				continue
 			}
 		}
-		if !isS3SourcePath(f.Path) &&
-			e.pathInStaleIdentitySet(staleIdentities, f.Agent, f.Path) &&
+		if e.pathInStaleIdentitySet(staleIdentities, f.Agent, f.Path) &&
 			e.staleSourceReparseAdmitted(
 				sourceCwdParticipating, sourceCwd,
 			) {
-			// Cwd-only reconciliation invalidates rows that must bypass mtime cutoff.
+			// Parser upgrades and cwd reconciliation must bypass the cutoff,
+			// including unchanged S3 objects with stale archived output.
 			out = append(out, f)
 			continue
 		}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -11328,6 +11328,59 @@ func TestEngine_SyncPathsReasonixPersistsToolResultContent(t *testing.T) {
 	assert.Equal(t, len("file contents here"), msgs[1].ToolCalls[0].ResultContentLength)
 }
 
+func TestSyncAllReparsesCursorLegacyToolResultsFromVersion101(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCursor: {root},
+		},
+		Machine:                           "local",
+		DisableFilesystemProjectDiscovery: true,
+	})
+	t.Cleanup(engine.Close)
+	const sessionID = "cursor:11111111-2222-4333-8444-555555555555"
+	path := filepath.Join(root, "project-a", "agent-transcripts",
+		"11111111-2222-4333-8444-555555555555.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(
+		"assistant:\n[Tool call] Shell\n  command=ls\n"+
+			"[Tool result]\n  file1.go\n",
+	), 0o644))
+	stats := engine.SyncAll(t.Context(), nil)
+	require.Zero(t, stats.Failed)
+	before, err := database.GetAllMessages(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+	require.Len(t, before[0].ToolCalls, 1)
+
+	// Reproduce the archived output of the parser at data version 101,
+	// preserving the source fingerprint and leaving the file unchanged.
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec("DELETE FROM tool_result_events WHERE session_id = ?", sessionID)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(`UPDATE tool_calls
+			SET result_content = '', result_content_length = 0
+			WHERE session_id = ?`, sessionID)
+		return err
+	}))
+	require.NoError(t, database.SetSessionDataVersion(sessionID, 101))
+
+	stats = engine.SyncAll(t.Context(), nil)
+	require.Zero(t, stats.Failed)
+	assert.False(t, stats.Aborted)
+	messages, err := database.GetAllMessages(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].ToolCalls, 1)
+	call := messages[0].ToolCalls[0]
+	require.Len(t, call.ResultEvents, 1)
+	assert.Equal(t, "file1.go", call.ResultEvents[0].Content)
+	assert.Equal(t, "file1.go", call.ResultContent)
+}
+
 func TestEngine_SyncSingleSessionEmitsOnSuccess(t *testing.T) {
 	fx := newEngineFixture(t)
 	em := &fakeEmitter{}

--- a/internal/sync/s3_source_test.go
+++ b/internal/sync/s3_source_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"io"
 	"os"
@@ -566,6 +567,79 @@ func TestProcessFileS3RestoredSessionBypassesSkipCache(t *testing.T) {
 		database.GetSessionDataVersion("laptop~restored"))
 }
 
+func TestSyncAllSinceReparsesCursorS3ToolResultsFromVersion101(t *testing.T) {
+	database := openTestDB(t)
+	const root = "s3://bucket/laptop/raw/cursor"
+	const uri = root + "/demo-proj/11111111-2222-4333-8444-555555555555.txt"
+	const sessionID = "laptop~cursor:11111111-2222-4333-8444-555555555555"
+	const content = "assistant:\n[Tool call] Shell\n  command=ls\n[Tool result]\n  file1.go\n"
+	mtime := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	oldFetch, oldStat := fetchS3Object, statS3Object
+	t.Cleanup(func() { fetchS3Object, statS3Object = oldFetch, oldStat })
+	var fetches atomic.Int32
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		if got != uri {
+			return nil, missingS3ObjectError()
+		}
+		fetches.Add(1)
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+	statS3Object = func(string) (parser.S3Object, error) {
+		return parser.S3Object{}, missingS3ObjectError()
+	}
+	def, ok := parser.AgentByType(parser.AgentCursor)
+	require.True(t, ok)
+	// Stub remote discovery and transport; parsing and archive writes are real.
+	factory := processFixtureFactory{provider: &processFixtureProvider{
+		Def: def, Caps: parser.Capabilities{
+			Source: parser.SourceCapabilities{DiscoverSources: parser.CapabilitySupported},
+		},
+		discovered: []parser.SourceRef{{
+			Provider: parser.AgentCursor, Key: uri, DisplayPath: uri,
+			FingerprintKey: uri, ProjectHint: "demo-proj",
+			Opaque: parser.S3DiscoveredSource{URI: uri, Project: "demo-proj",
+				Machine: "laptop", Size: int64(len(content)), MtimeNS: mtime.UnixNano()},
+		}},
+	}}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCursor: {root}},
+		Machine:   "local", DisableFilesystemProjectDiscovery: true,
+		ProviderFactories: []parser.ProviderFactory{factory},
+	})
+	t.Cleanup(engine.Close)
+	stats := engine.SyncAll(t.Context(), nil)
+	require.Zero(t, stats.Failed)
+	require.Equal(t, 1, stats.Synced)
+	// Recreate the old parser's missing output, keeping the S3 fingerprint intact.
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		if _, err := tx.Exec("DELETE FROM tool_result_events WHERE session_id = ?", sessionID); err != nil {
+			return err
+		}
+		_, err := tx.Exec("UPDATE tool_calls SET result_content = '', result_content_length = 0 WHERE session_id = ?", sessionID)
+		return err
+	}))
+	require.NoError(t, database.SetSessionDataVersion(sessionID, 101))
+	fetches.Store(0)
+	cutoff := mtime.Add(time.Hour)
+	stats = engine.SyncAllSince(t.Context(), cutoff, nil)
+	require.Zero(t, stats.Failed)
+	require.Equal(t, 1, stats.Synced, "old parser output must refresh despite the object cutoff")
+	messages, err := database.GetAllMessages(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].ToolCalls, 1)
+	call := messages[0].ToolCalls[0]
+	require.Len(t, call.ResultEvents, 1)
+	assert.Equal(t, "file1.go", call.ResultEvents[0].Content)
+	assert.Equal(t, "file1.go", call.ResultContent)
+	assert.Equal(t, db.CurrentDataVersion(), database.GetSessionDataVersion(sessionID))
+	require.EqualValues(t, 1, fetches.Load())
+	stats = engine.SyncAllSince(t.Context(), cutoff, nil)
+	assert.Zero(t, stats.Failed)
+	assert.Zero(t, stats.Synced)
+	assert.EqualValues(t, 1, fetches.Load(), "current unchanged sources must not be fetched again")
+}
+
 func TestFilterFilesByMtimeKeepsS3ChangedFingerprint(t *testing.T) {
 	database := openTestDB(t)
 	path := "s3://bucket/laptop/raw/claude/test-proj/fingerprint.jsonl"
@@ -580,6 +654,9 @@ func TestFilterFilesByMtimeKeepsS3ChangedFingerprint(t *testing.T) {
 		FileMtime: int64Ptr(mtime),
 		FileHash:  strPtr("s3:fingerprint:old"),
 	}))
+	require.NoError(t, database.SetSessionDataVersion(
+		"laptop~fingerprint", db.CurrentDataVersion(),
+	))
 
 	e := &Engine{db: database}
 	got := e.filterFilesByMtime(context.Background(), []parser.DiscoveredFile{{
@@ -609,6 +686,9 @@ func TestFilterFilesByMtimeKeepsS3ChangedSize(t *testing.T) {
 		FileSize:  int64Ptr(512),
 		FileMtime: int64Ptr(mtime),
 	}))
+	require.NoError(t, database.SetSessionDataVersion(
+		"laptop~size", db.CurrentDataVersion(),
+	))
 
 	e := &Engine{db: database}
 	got := e.filterFilesByMtime(context.Background(), []parser.DiscoveredFile{{
@@ -1807,6 +1887,9 @@ func TestFilterFilesByMtimeAppliesCutoffToProviderDiscoveredClaudeS3(t *testing.
 		FileMtime: int64Ptr(mtime),
 		FileHash:  strPtr("s3:fingerprint:stable"),
 	}))
+	require.NoError(t, database.SetSessionDataVersion(
+		"laptop~old", db.CurrentDataVersion(),
+	))
 
 	claudeFactory, ok := parser.ProviderFactoryByType(parser.AgentClaude)
 	require.True(t, ok, "claude provider factory must be registered")


### PR DESCRIPTION
Legacy Cursor text transcripts now retain nonempty `[Tool result]` bodies as ordered anonymous events on the latest preceding tool call in the same assistant block. Results without a preceding call and empty bodies are omitted. Indented `user:` and `assistant:` lines stay in tool output instead of starting extra messages. The existing call summary selects the last nonempty anonymous result.

Data version 102 makes unchanged, available source files eligible for reparsing, so previously archived sessions gain the output on their next sync. Incremental S3 sync also checks stale parser versions, so an old object modification time does not prevent recovery. Current S3 sources still follow the modification-time cutoff. Cursor also declares its result-event capability.

The parser keeps its existing indentation convention: a nonempty unindented line ends a result body and becomes assistant prose. `docs/internal/session-format-sources.md` records the live-inspection report in #1627 and its limits; the available references contain no raw legacy excerpt that verifies indentation. JSONL parsing is unchanged.

Refs #1627
