### PR TITLE
fix(parser): use Cursor turn timestamps instead of file mtime for session times

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -938,6 +938,16 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
 
 - **Format:** Legacy text and newer JSONL transcripts under per-project
   `agent-transcripts` directories.
+- **Turn timestamps:** Cursor user messages can carry a leading metadata tag in
+  the form
+  `<timestamp>Weekday, Mon D, YYYY, H:MM AM|PM (UTC±H[:MM])</timestamp>`
+  immediately before `<user_query>`. Agentsview parses the explicit offset and
+  stores a UTC instant with zero seconds and nanoseconds. The source has
+  minute precision, so the encoded `:00` does not provide second precision.
+- **Session bounds:** Agentsview uses the earliest and latest usable tagged user
+  turns. A transcript with no usable tag retains the file modification time
+  for both bounds. The latest user turn gives a lower bound for assistant
+  completion because the Cursor format supplies no assistant completion time.
 - **Evidence:** `documentation`.
 - **Upstream:** Cursor's first-party
   [history documentation](https://docs.cursor.com/en/agent/chat/history)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -465,7 +465,10 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // (100: Codex subagent lineage now uses the structural source marker. Existing
 // guardian rows need re-parsing because a fingerprint change cannot repair
 // byte-identical files.)
-const dataVersion = 100
+// (101: Cursor user turn timestamps are parsed from recognized metadata.
+// Existing Cursor rows need re-parsing so stored message and session times
+// reflect the transcript timestamps.)
+const dataVersion = 101
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1096,8 +1096,13 @@ func TestCurrentDataVersionAntigravityCLIExperimentalServingVariant(t *testing.T
 }
 
 func TestCurrentDataVersionCodexGuardianLineage(t *testing.T) {
-	assert.Equal(t, 100, CurrentDataVersion(),
-		"Codex guardian lineage requires re-parsing unchanged rollout files")
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 100,
+		"version 100 is the data-version boundary for Codex guardian lineage")
+}
+
+func TestCurrentDataVersionCursorTurnTimestamps(t *testing.T) {
+	assert.Equal(t, 101, CurrentDataVersion(),
+		"Cursor turn timestamps require re-parsing existing sessions")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -89,6 +91,7 @@ func (p *cursorProvider) parseSession(
 	hash := fmt.Sprintf("%x", sha256.Sum256(data))
 
 	mtime := info.ModTime()
+	startedAt, endedAt := cursorSessionBounds(messages, mtime)
 	sess := &ParsedSession{
 		ID:           sessionID,
 		Project:      project,
@@ -96,8 +99,8 @@ func (p *cursorProvider) parseSession(
 		Agent:        AgentCursor,
 		Cwd:          cwd,
 		FirstMessage: firstMessage,
-		StartedAt:    mtime,
-		EndedAt:      mtime,
+		StartedAt:    startedAt,
+		EndedAt:      endedAt,
 		MessageCount: len(messages),
 		File: FileInfo{
 			Path:  path,
@@ -123,7 +126,7 @@ func parseCursorMessages(lines []string) []ParsedMessage {
 	messages := make([]ParsedMessage, 0, len(blocks))
 
 	for i, block := range blocks {
-		content, hasThinking, toolCalls := extractCursorContent(
+		content, timestamp, hasThinking, toolCalls := extractCursorContent(
 			block.role, block.lines,
 		)
 		content = strings.TrimSpace(content)
@@ -135,7 +138,7 @@ func parseCursorMessages(lines []string) []ParsedMessage {
 			Ordinal:       i,
 			Role:          block.role,
 			Content:       content,
-			Timestamp:     time.Time{},
+			Timestamp:     timestamp,
 			HasThinking:   hasThinking,
 			HasToolUse:    len(toolCalls) > 0,
 			ContentLength: len(content),
@@ -184,12 +187,114 @@ func splitCursorBlocks(lines []string) []cursorBlock {
 // was present, and any tool calls found.
 func extractCursorContent(
 	role RoleType, lines []string,
-) (string, bool, []ParsedToolCall) {
+) (string, time.Time, bool, []ParsedToolCall) {
 	if role == RoleUser {
-		content := extractUserQuery(lines)
-		return content, false, nil
+		content, timestamp := extractCursorUserContent(lines)
+		return content, timestamp, false, nil
 	}
-	return extractAssistantContent(lines)
+	content, hasThinking, toolCalls := extractAssistantContent(lines)
+	return content, time.Time{}, hasThinking, toolCalls
+}
+
+var cursorTimestampPattern = regexp.MustCompile(
+	`^<timestamp>(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{1,2}, [0-9]{4}, [0-9]{1,2}:[0-9]{2} (AM|PM) \(UTC([+-])[0-9]{1,2}(?::[0-9]{2})?\)</timestamp>`,
+)
+
+// extractCursorUserContent removes a recognized Cursor metadata tag and
+// returns its parsed time without changing the shared user-query helper.
+func extractCursorUserContent(lines []string) (string, time.Time) {
+	text := strings.Join(lines, "\n")
+	trimmed := strings.TrimLeft(text, " \t\r\n")
+	match := cursorTimestampPattern.FindStringSubmatch(trimmed)
+	if len(match) == 0 {
+		return extractUserQuery(lines), time.Time{}
+	}
+
+	remaining := strings.TrimLeft(
+		trimmed[len(match[0]):], " \t\r\n",
+	)
+	const (
+		userQueryStart = "<user_query>"
+		userQueryEnd   = "</user_query>"
+	)
+	if !strings.HasPrefix(remaining, userQueryStart) {
+		return extractUserQuery(lines), time.Time{}
+	}
+	if strings.Index(remaining, userQueryEnd) < len(userQueryStart) {
+		return extractUserQuery(lines), time.Time{}
+	}
+
+	timestamp, ok := parseCursorTimestamp(match[0])
+	if !ok {
+		return extractUserQuery(lines), time.Time{}
+	}
+	return extractUserQuery(strings.Split(trimmed[len(match[0]):], "\n")), timestamp
+}
+
+func parseCursorTimestamp(tag string) (time.Time, bool) {
+	match := cursorTimestampPattern.FindStringSubmatch(tag)
+	if len(match) == 0 {
+		return time.Time{}, false
+	}
+
+	dateText := strings.TrimSuffix(
+		strings.TrimPrefix(tag, "<timestamp>"),
+		"</timestamp>",
+	)
+	dateText = strings.TrimSuffix(dateText, ")")
+	zoneStart := strings.LastIndex(dateText, " (UTC")
+	if zoneStart < 0 {
+		return time.Time{}, false
+	}
+	localText := dateText[:zoneStart]
+	zoneText := dateText[zoneStart+len(" (UTC"):]
+	zoneText = strings.TrimSuffix(zoneText, ")")
+
+	parsed, err := time.Parse("Monday, Jan 2, 2006, 3:04 PM", localText)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	sign := 1
+	if zoneText[0] == '-' {
+		sign = -1
+	}
+	zoneText = zoneText[1:]
+	parts := strings.SplitN(zoneText, ":", 2)
+	hour, err := strconv.Atoi(parts[0])
+	if err != nil || hour > 23 {
+		return time.Time{}, false
+	}
+	minute := 0
+	if len(parts) == 2 {
+		minute, err = strconv.Atoi(parts[1])
+		if err != nil || minute > 59 {
+			return time.Time{}, false
+		}
+	}
+	offset := sign * (hour*60*60 + minute*60)
+	return time.Date(
+		parsed.Year(), parsed.Month(), parsed.Day(), parsed.Hour(),
+		parsed.Minute(), 0, 0, time.FixedZone("Cursor", offset),
+	).UTC(), true
+}
+
+func cursorSessionBounds(messages []ParsedMessage, fallback time.Time) (time.Time, time.Time) {
+	startedAt, endedAt := fallback, fallback
+	found := false
+	for _, message := range messages {
+		if message.Timestamp.IsZero() {
+			continue
+		}
+		if !found || message.Timestamp.Before(startedAt) {
+			startedAt = message.Timestamp
+		}
+		if !found || message.Timestamp.After(endedAt) {
+			endedAt = message.Timestamp
+		}
+		found = true
+	}
+	return startedAt, endedAt
 }
 
 // extractUserQuery extracts text from <user_query> tags.
@@ -457,7 +562,7 @@ func parseCursorJSONL(data string) []ParsedMessage {
 
 		if role == "user" {
 			msg.Role = RoleUser
-			msg.Content = extractJSONLUserContent(content)
+			msg.Content, msg.Timestamp = extractJSONLUserContent(content)
 		} else {
 			msg.Role = RoleAssistant
 			text, _, hasThinking, hasToolUse,
@@ -488,15 +593,15 @@ func parseCursorJSONL(data string) []ParsedMessage {
 // content field. If the content is a string, strips
 // <user_query> tags. If it's an array of blocks, collects
 // text blocks and strips tags from the combined result.
-func extractJSONLUserContent(content gjson.Result) string {
+func extractJSONLUserContent(content gjson.Result) (string, time.Time) {
 	if content.Type == gjson.String {
-		return extractUserQuery(
+		return extractCursorUserContent(
 			strings.Split(content.Str, "\n"),
 		)
 	}
 
 	if !content.IsArray() {
-		return ""
+		return "", time.Time{}
 	}
 
 	var parts []string
@@ -511,10 +616,10 @@ func extractJSONLUserContent(content gjson.Result) string {
 	})
 
 	if len(parts) == 0 {
-		return ""
+		return "", time.Time{}
 	}
 	combined := strings.Join(parts, "\n")
-	return extractUserQuery(strings.Split(combined, "\n"))
+	return extractCursorUserContent(strings.Split(combined, "\n"))
 }
 
 // cursorHighMarkers are directory names that are very

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -1,12 +1,259 @@
 package parser
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func cursorTestTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+	return parsed
+}
+
+func parseCursorTestFile(t *testing.T, path string) (*ParsedSession, []ParsedMessage) {
+	t.Helper()
+	provider := &cursorProvider{}
+	session, messages, err := provider.parseSession(
+		path, "project", "/workspace/project", "test-machine",
+	)
+	require.NoError(t, err)
+	return session, messages
+}
+
+func TestCursorLegacyTimestampReproduction(t *testing.T) {
+	data, err := os.ReadFile("testdata/cursor/legacy-timestamps.txt")
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "legacy-timestamps.txt")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+
+	session, messages := parseCursorTestFile(t, path)
+	require.Len(t, messages, 4)
+	assert.Equal(t, cursorTestTime(t, "2026-07-02T15:11:00Z"), messages[0].Timestamp)
+	assert.Equal(t, "Inspect the repository.", messages[0].Content)
+	assert.Zero(t, messages[1].Timestamp)
+	assert.Equal(t, cursorTestTime(t, "2026-07-02T15:12:00Z"), messages[2].Timestamp)
+	assert.Equal(t, "Continue with the next step.", messages[2].Content)
+	assert.Zero(t, messages[3].Timestamp)
+	assert.Equal(t, messages[0].Timestamp, session.StartedAt)
+	assert.Equal(t, messages[2].Timestamp, session.EndedAt)
+	t.Logf("turn 1 = %s; turn 2 = %s; assistant_timestamp_zero=%t", messages[0].Timestamp.Format(time.RFC3339), messages[2].Timestamp.Format(time.RFC3339), messages[1].Timestamp.IsZero())
+}
+
+func TestCursorJSONLTimestampFromTextBlock(t *testing.T) {
+	data := strings.Join([]string{
+		`{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Tuesday, Jun 16, 2026, 8:41 PM (UTC-4)</timestamp>\n<user_query>Inspect the logs.</user_query>"}]}}`,
+		`{"role":"assistant","message":{"content":[{"type":"text","text":"The logs are clean."}]}}`,
+	}, "\n")
+	messages := parseCursorJSONL(data)
+	require.Len(t, messages, 2)
+	assert.Equal(t, cursorTestTime(t, "2026-06-17T00:41:00Z"), messages[0].Timestamp)
+	assert.Equal(t, "Inspect the logs.", messages[0].Content)
+	assert.Zero(t, messages[1].Timestamp)
+}
+
+func TestCursorTimestampDayBoundary(t *testing.T) {
+	late, ok := parseCursorTimestamp(
+		"<timestamp>Thursday, Jul 2, 2026, 11:59 PM (UTC-4)</timestamp>",
+	)
+	require.True(t, ok)
+	early, ok := parseCursorTimestamp(
+		"<timestamp>Friday, Jul 3, 2026, 12:00 AM (UTC-4)</timestamp>",
+	)
+	require.True(t, ok)
+	assert.True(t, late.Before(early))
+	assert.Zero(t, late.Second())
+	assert.Zero(t, late.Nanosecond())
+	assert.Zero(t, early.Second())
+	assert.Zero(t, early.Nanosecond())
+}
+
+func TestCursorTimestampNoonMidnight(t *testing.T) {
+	midnight, ok := parseCursorTimestamp(
+		"<timestamp>Thursday, Jul 2, 2026, 12:00 AM (UTC-4)</timestamp>",
+	)
+	require.True(t, ok)
+	noon, ok := parseCursorTimestamp(
+		"<timestamp>Thursday, Jul 2, 2026, 12:00 PM (UTC-4)</timestamp>",
+	)
+	require.True(t, ok)
+	assert.Equal(t, cursorTestTime(t, "2026-07-02T04:00:00Z"), midnight)
+	assert.Equal(t, cursorTestTime(t, "2026-07-02T16:00:00Z"), noon)
+}
+
+func TestCursorTimestampExplicitOffsets(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{
+			name: "observed offset",
+			tag:  "<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>",
+			want: "2026-07-02T15:11:00Z",
+		},
+		{
+			name: "half hour offset",
+			tag:  "<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC+5:30)</timestamp>",
+			want: "2026-07-02T05:41:00Z",
+		},
+		{
+			name: "zero offset",
+			tag:  "<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC+0)</timestamp>",
+			want: "2026-07-02T11:11:00Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseCursorTimestamp(tt.tag)
+			require.True(t, ok)
+			assert.Equal(t, cursorTestTime(t, tt.want), got)
+		})
+	}
+	_, ok := parseCursorTimestamp(
+		"<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC)</timestamp>",
+	)
+	assert.False(t, ok)
+}
+
+func TestCursorMalformedTimestampTag(t *testing.T) {
+	fallback := cursorTestTime(t, "2026-01-01T00:00:00Z")
+	tests := []struct {
+		name        string
+		text        string
+		wantContent string
+	}{
+		{
+			name:        "invalid date",
+			text:        "user:\n<timestamp>Thursday, Feb 30, 2026, 11:11 AM (UTC-4)</timestamp>\n<user_query>Keep this.</user_query>",
+			wantContent: "Keep this.",
+		},
+		{
+			name:        "incomplete tag",
+			text:        "user:\n<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)\n<user_query>Keep this.</user_query>",
+			wantContent: "Keep this.",
+		},
+		{
+			name:        "unsupported bare UTC",
+			text:        "user:\n<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC)</timestamp>\n<user_query>Keep this.</user_query>",
+			wantContent: "Keep this.",
+		},
+		{
+			name:        "tag without query",
+			text:        "user:\n<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>\nKeep this.",
+			wantContent: "<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>\nKeep this.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "malformed.txt")
+			require.NoError(t, os.WriteFile(path, []byte(tt.text), 0o644))
+			require.NoError(t, os.Chtimes(path, fallback, fallback))
+			session, messages := parseCursorTestFile(t, path)
+			require.Len(t, messages, 1)
+			assert.Zero(t, messages[0].Timestamp)
+			assert.Equal(t, tt.wantContent, messages[0].Content)
+			assert.True(t, session.StartedAt.Equal(fallback))
+			assert.True(t, session.EndedAt.Equal(fallback))
+		})
+	}
+}
+
+func TestCursorTimestampRequiresLeadingCompleteUserQuery(t *testing.T) {
+	lines := []string{
+		"<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>",
+		"ordinary text before the query",
+		"<user_query>Keep the baseline extraction.</user_query>",
+	}
+
+	content, timestamp := extractCursorUserContent(lines)
+	assert.Zero(t, timestamp)
+	assert.Equal(t, "Keep the baseline extraction.", content)
+}
+
+func TestCursorLiteralTimestampXML(t *testing.T) {
+	text := strings.Join([]string{
+		"user:",
+		"<user_query>Show the literal <timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp> text.</user_query>",
+		"assistant:",
+		"The assistant repeats <timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>.",
+	}, "\n")
+	messages := parseCursorMessages(strings.Split(text, "\n"))
+	require.Len(t, messages, 2)
+	assert.Contains(t, messages[0].Content, "<timestamp>")
+	assert.Contains(t, messages[1].Content, "<timestamp>")
+	assert.Zero(t, messages[0].Timestamp)
+	assert.Zero(t, messages[1].Timestamp)
+}
+
+func TestCursorSessionBoundsFromTurns(t *testing.T) {
+	text := strings.Join([]string{
+		"user:", "<timestamp>Thursday, Jul 2, 2026, 11:59 PM (UTC-4)</timestamp>", "<user_query>late</user_query>",
+		"assistant:", "answer",
+		"user:", "<timestamp>Friday, Jul 3, 2026, 12:00 AM (UTC-4)</timestamp>", "<user_query>early</user_query>",
+	}, "\n")
+	path := filepath.Join(t.TempDir(), "bounds.txt")
+	require.NoError(t, os.WriteFile(path, []byte(text), 0o644))
+	session, messages := parseCursorTestFile(t, path)
+	require.Len(t, messages, 3)
+	assert.Equal(t, cursorTestTime(t, "2026-07-03T03:59:00Z"), session.StartedAt)
+	assert.Equal(t, cursorTestTime(t, "2026-07-03T04:00:00Z"), session.EndedAt)
+	assert.Equal(t, RoleUser, messages[0].Role)
+	assert.Equal(t, RoleAssistant, messages[1].Role)
+	assert.Equal(t, RoleUser, messages[2].Role)
+}
+
+func TestCursorMixedTaggedUntagged(t *testing.T) {
+	text := "user:\n<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>\n<user_query>tagged</user_query>\n" +
+		"assistant:\nanswer\nuser:\n<user_query>untagged</user_query>\n"
+	path := filepath.Join(t.TempDir(), "mixed.txt")
+	require.NoError(t, os.WriteFile(path, []byte(text), 0o644))
+	_, messages := parseCursorTestFile(t, path)
+	require.Len(t, messages, 3)
+	assert.False(t, messages[0].Timestamp.IsZero())
+	assert.Zero(t, messages[1].Timestamp)
+	assert.Zero(t, messages[2].Timestamp)
+}
+
+func TestCursorIdenticalContentDifferentMtimeSameTimes(t *testing.T) {
+	text := "user:\n<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>\n<user_query>same</user_query>\n"
+	firstPath := filepath.Join(t.TempDir(), "first.txt")
+	secondPath := filepath.Join(t.TempDir(), "second.txt")
+	require.NoError(t, os.WriteFile(firstPath, []byte(text), 0o644))
+	require.NoError(t, os.WriteFile(secondPath, []byte(text), 0o644))
+	firstMtime := cursorTestTime(t, "2026-01-01T00:00:00Z")
+	secondMtime := cursorTestTime(t, "2026-02-01T00:00:00Z")
+	require.NoError(t, os.Chtimes(firstPath, firstMtime, firstMtime))
+	require.NoError(t, os.Chtimes(secondPath, secondMtime, secondMtime))
+	firstSession, firstMessages := parseCursorTestFile(t, firstPath)
+	secondSession, secondMessages := parseCursorTestFile(t, secondPath)
+	assert.NotEqual(t, firstSession.File.Mtime, secondSession.File.Mtime)
+	assert.Equal(t, firstMessages[0].Timestamp, secondMessages[0].Timestamp)
+	assert.Equal(t, firstSession.StartedAt, secondSession.StartedAt)
+	assert.Equal(t, firstSession.EndedAt, secondSession.EndedAt)
+}
+
+func TestCursorParentAndChildTimestamps(t *testing.T) {
+	root := t.TempDir()
+	parentPath := filepath.Join(root, "parent.txt")
+	childPath := filepath.Join(root, "child.txt")
+	require.NoError(t, os.WriteFile(parentPath, []byte("user:\n<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>\n<user_query>parent</user_query>\n"), 0o644))
+	require.NoError(t, os.WriteFile(childPath, []byte("user:\n<timestamp>Thursday, Jul 2, 2026, 11:12 AM (UTC-4)</timestamp>\n<user_query>child</user_query>\n"), 0o644))
+	parent, parentMessages := parseCursorTestFile(t, parentPath)
+	child, childMessages := parseCursorTestFile(t, childPath)
+	require.Len(t, parentMessages, 1)
+	require.Len(t, childMessages, 1)
+	assert.Equal(t, parentMessages[0].Timestamp, parent.StartedAt)
+	assert.Equal(t, childMessages[0].Timestamp, child.StartedAt)
+	assert.NotEqual(t, parent.StartedAt, child.StartedAt)
+}
 
 func TestExtractAssistantContent(t *testing.T) {
 	tests := []struct {

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -103,6 +103,26 @@ func TestGrokProviderGoldenLegacyTranscript(t *testing.T) {
 	assert.Equal(t, "call_1", result.Messages[2].ToolResults[0].ToolUseID)
 }
 
+func TestGrokTimestampLookingPrompt(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "cwd-key", "grok-timestamp")
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "summary.json"), `{
+		"info":{"id":"grok-timestamp","cwd":"/workspace/agentsview"},
+		"created_at":"2026-07-02T15:11:00Z",
+		"updated_at":"2026-07-02T15:12:00Z"
+	}`)
+	literal := "<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp> review this prompt"
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "chat_history.jsonl"),
+		`{"type":"user","content":"`+literal+`"}`+"\n")
+
+	result, err := ParseGrokSummary(
+		filepath.Join(sessionDir, "summary.json"), "agentsview", "test-machine",
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, literal, result.Messages[0].Content)
+}
+
 func TestGrokProviderParsesMixedTranscriptFormats(t *testing.T) {
 	root := t.TempDir()
 	sessionID := "mixed-formats"

--- a/internal/parser/testdata/cursor/legacy-timestamps.txt
+++ b/internal/parser/testdata/cursor/legacy-timestamps.txt
@@ -1,0 +1,15 @@
+# Constructed and sanitized, not captured. The issue ships no transcript artifact. Tag values match the real observed grammar, and the surrounding prose is invented.
+user:
+<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>
+<user_query>
+Inspect the repository.
+</user_query>
+assistant:
+The repository is ready for inspection.
+user:
+<timestamp>Thursday, Jul 2, 2026, 11:12 AM (UTC-4)</timestamp>
+<user_query>
+Continue with the next step.
+</user_query>
+assistant:
+The next step is complete.

--- a/internal/sync/cwd_filter_integration_test.go
+++ b/internal/sync/cwd_filter_integration_test.go
@@ -419,7 +419,10 @@ func TestSyncEngineCursorCwdDataVersionRefresh(t *testing.T) {
 	path := filepath.Join(root, projectDir, "agent-transcripts", sessionID+".jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, os.WriteFile(path, []byte(
-		`{"role":"user","message":{"content":"refresh cursor cwd"}}`+"\n",
+		strings.Join([]string{
+			`{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Thursday, Jul 2, 2026, 11:11 AM (UTC-4)</timestamp>\n<user_query>refresh cursor cwd</user_query>"}]}}`,
+			`{"role":"assistant","message":{"content":[{"type":"text","text":"assistant reply"}]}}`,
+		}, "\n")+"\n",
 	), 0o644))
 	env := &testEnv{db: dbtest.OpenTestDB(t)}
 	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
@@ -447,7 +450,7 @@ func TestSyncEngineCursorCwdDataVersionRefresh(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.True(t, changed)
-	assert.Less(t, env.db.GetSessionDataVersion(fullID), db.CurrentDataVersion())
+	assert.Equal(t, 99, env.db.GetSessionDataVersion(fullID))
 	stats := env.engine.SyncAllSince(
 		t.Context(), time.Now().Add(time.Hour), nil,
 	)
@@ -458,6 +461,21 @@ func TestSyncEngineCursorCwdDataVersionRefresh(t *testing.T) {
 			"stale Cursor rows must be reparsed through the cutoff")
 	})
 	assert.Equal(t, db.CurrentDataVersion(), env.db.GetSessionDataVersion(fullID))
+
+	refreshed, err := env.db.GetSession(t.Context(), fullID)
+	require.NoError(t, err)
+	require.NotNil(t, refreshed)
+	require.NotNil(t, refreshed.StartedAt)
+	require.NotNil(t, refreshed.EndedAt)
+	assert.Equal(t, expectedCwd, refreshed.Cwd)
+	assert.Equal(t, "2026-07-02T15:11:00Z", *refreshed.StartedAt)
+	assert.Equal(t, "2026-07-02T15:11:00Z", *refreshed.EndedAt)
+
+	messages, err := env.db.GetMessages(t.Context(), fullID, 0, 10, true)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	assert.Equal(t, "2026-07-02T15:11:00Z", messages[0].Timestamp)
+	assert.Equal(t, "", messages[1].Timestamp)
 }
 
 // A session archived before the cwd allow-list was configured must not

--- a/internal/sync/cwd_filter_integration_test.go
+++ b/internal/sync/cwd_filter_integration_test.go
@@ -450,7 +450,8 @@ func TestSyncEngineCursorCwdDataVersionRefresh(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.True(t, changed)
-	assert.Equal(t, 99, env.db.GetSessionDataVersion(fullID))
+	assert.Equal(t, db.CurrentDataVersion()-1, env.db.GetSessionDataVersion(fullID),
+		"cwd repair must mark the row stale by exactly one version")
 	stats := env.engine.SyncAllSince(
 		t.Context(), time.Now().Add(time.Hour), nil,
 	)


### PR DESCRIPTION
Cursor transcripts now retain user turn times when the source includes the leading `<timestamp>` metadata tag. AgentsView parses the explicit UTC offset at minute precision, stores zero seconds, and derives session bounds from the earliest and latest usable user turns. Transcripts without a usable tag keep their file modification time, and the latest user turn remains a lower bound because Cursor provides no assistant completion time. Existing Cursor sessions reparse to receive the corrected values.

The parser recognizes the tag only in the Cursor user metadata position immediately before `<user_query>`. Ordinary timestamp XML outside that position remains in message content. Incomplete or unusable leading candidates keep the existing `<user_query>` extraction with an empty timestamp. The shared Grok user-query behavior remains unchanged.

This change follows prateek's report in issue #1627. The legacy transcript fixture is constructed and sanitized because the issue does not include a loadable transcript artifact. Its tag values follow the observed Cursor grammar.

Refs #1627
