### PR TITLE
feat(parser): read Cursor CLI store.db transcripts

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1040,6 +1040,43 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   Cursor IDE is retired through stored-source-hint tombstones on `state.vscdb`
   change events and through complete-container ownership reconciliation.
 
+### Cursor CLI store store.db
+
+Cursor CLI store format. A per-session SQLite store under
+  `~/.cursor/chats/<workspace-hash>/<agent-id>/store.db`, with `blobs` and
+  `meta` tables. Metadata key `0` is hex-encoded UTF-8 JSON that carries the
+  native `agentId` and `latestRootBlobId`. Conversation content is a protobuf
+  blob tree; Agentsview reads only the tree reachable from
+  `latestRootBlobId` and projects the field-8 typed turn index onto the
+  matching `agent-transcripts` session (same native UUID). Field-8 turns supply
+  assistant reasoning text and producer epoch-millisecond timestamps. Field-1
+  system/context blobs are not archived as transcript messages.
+Evidence for the CLI store. A live installed-tool capture from one Windows Cursor CLI install
+  was collected on 2026-09-07 with the structural probe described above. The
+  probe recorded no private prompts, paths, ids, or encryption-key values.
+  An independent directory measure on that install found 1 store among 18
+  transcript ids, 1 overlapping id, and 0 store-only sessions.
+Upstream evidence for the CLI store. No published `.proto` or store schema was found. Protobuf field
+  numbers are therefore provisional for the captured producer version.
+- **WAL requirement:** The live capture keeps schema and rows in
+  `store.db-wal` while the main file stays a 4096-byte header. A main-file-only
+  open reports an empty schema. Agentsview opens the live path read-only
+  (`mode=ro`) and reads one deferred transaction so the WAL remains attached.
+  The reader issues no mutating SQL and ignores `blobEncryptionKey`.
+CLI store usage and cost. The captured store has no priced usage fields consumed by
+  Agentsview.
+Unsupported in this slice. Native tool-call/result joining (the capture
+  contains no tool result), store-only discovery (no store-only sessions in the
+  measured install), encrypted blob payloads on other installs, and complete
+  cross-version field-number stability. Unknown or undecodable reachable blobs
+  are skipped without dropping decoded siblings; a present store with no
+  decodable selected turn is a source error that preserves the archive.
+Agentsview CLI store handling. `internal/parser/cursor_store.go` plus enrichment hooks in
+  `internal/parser/cursor_provider.go`. Discovery and archive identity remain
+  the existing transcript source (`cursor:<agentId>`). The chats directory is
+  carried only through `ResolveMetadataDir` / provider metadata and is not a
+  remote, SSH, or S3 transfer target.
+
 ## Amp (`amp`)
 
 - **Format:** One JSON thread document per session.

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1007,23 +1007,26 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   following only the selected root's turn tree in one deferred read-only
   transaction (`mode=ro`), without mutating SQL. Discovery and archive
   identity remain the transcript source (`cursor:<agentId>`). The chats
-  directory is local provider metadata, outside remote, SSH, and S3 transfer
-  targets. Store-only discovery, native tool-call/result joining, encrypted
-  blob payloads, and cross-version field-number stability remain unsupported;
-  the capture contained no tool result and the reader ignores
-  `blobEncryptionKey`. Unknown reachable blobs do not discard decoded
-  siblings. Missing required tables, unsupported metadata, missing roots or
-  turn indexes, and stores with no decodable turns leave the transcript
-  usable, with a warning. Store open/read errors remain retryable source
-  errors without replacing archived content. Store fingerprint failures
-  prevent freshness skips, and temporary path-access failures retain cached
-  stores for retry. A failed chats scan warns and preserves cached store
-  locations; otherwise sync uses transcripts alone. The next discovery pass
-  retries the scan, and store changes invalidate the composite fingerprint.
-  Reverified 2026-09-09 with synthetic parser and SQLite archive fixtures
-  covering initial import and subsequent transcript updates when store
-  enrichment is unavailable, missing store tables, and recovery after store
-  access failures.
+  directory is local provider metadata, automatically associated only with a
+  resolved `.cursor/projects` root, with case-insensitive matching on Windows.
+  Custom roots such as `.cursor/archive` remain transcript-only. The chats
+  directory stays outside remote, SSH, and S3 transfer targets. Store-only
+  discovery, native tool-call/result joining, encrypted blob payloads, and
+  cross-version field-number stability remain unsupported; the capture
+  contained no tool result and the reader ignores `blobEncryptionKey`. Unknown
+  reachable blobs do not discard decoded siblings. Missing required tables,
+  unsupported metadata, missing roots or turn indexes, and stores with no
+  decodable turns leave the transcript usable, with a warning. Store open/read
+  errors remain retryable source errors without replacing archived content.
+  Store fingerprint failures prevent freshness skips, and temporary
+  path-access failures retain cached stores for retry. A failed chats scan
+  warns and preserves cached store locations; otherwise sync uses transcripts
+  alone. The next discovery pass retries the scan, and store changes
+  invalidate the composite fingerprint. Reverified 2026-09-09 with synthetic
+  parser and SQLite archive fixtures covering initial import and subsequent
+  transcript updates when store enrichment is unavailable, missing store tables,
+  and recovery after store access failures, plus a custom-root fixture that
+  keeps sibling live-store reasoning out of archived transcripts.
 
 ## Cursor IDE (`cursor-ide`)
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1012,15 +1012,18 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   blob payloads, and cross-version field-number stability remain unsupported;
   the capture contained no tool result and the reader ignores
   `blobEncryptionKey`. Unknown reachable blobs do not discard decoded
-  siblings. Unsupported metadata, missing roots or turn indexes, and stores
-  with no decodable turns leave the transcript usable, with a warning. Store
-  open/read errors remain retryable source errors without replacing archived
-  content. A failed chats scan warns and preserves cached store locations;
-  otherwise sync uses transcripts alone. The next discovery pass retries the
-  scan, and store changes invalidate the composite fingerprint. Reverified
-  2026-09-08 with synthetic parser and SQLite archive fixtures covering
-  initial import and subsequent transcript updates when store enrichment is
-  unavailable.
+  siblings. Missing required tables, unsupported metadata, missing roots or
+  turn indexes, and stores with no decodable turns leave the transcript
+  usable, with a warning. Store open/read errors remain retryable source
+  errors without replacing archived content. Store fingerprint failures
+  prevent freshness skips, and temporary path-access failures retain cached
+  stores for retry. A failed chats scan warns and preserves cached store
+  locations; otherwise sync uses transcripts alone. The next discovery pass
+  retries the scan, and store changes invalidate the composite fingerprint.
+  Reverified 2026-09-09 with synthetic parser and SQLite archive fixtures
+  covering initial import and subsequent transcript updates when store
+  enrichment is unavailable, missing store tables, and recovery after store
+  access failures.
 
 ## Cursor IDE (`cursor-ide`)
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1014,19 +1014,21 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   discovery, native tool-call/result joining, encrypted blob payloads, and
   cross-version field-number stability remain unsupported; the capture
   contained no tool result and the reader ignores `blobEncryptionKey`. Unknown
-  reachable blobs do not discard decoded siblings. Missing required tables,
-  unsupported metadata, missing roots or turn indexes, and stores with no
-  decodable turns leave the transcript usable, with a warning. Store open/read
-  errors remain retryable source errors without replacing archived content.
-  Store fingerprint failures prevent freshness skips, and temporary
-  path-access failures retain cached stores for retry. A failed chats scan
-  warns and preserves cached store locations; otherwise sync uses transcripts
-  alone. The next discovery pass retries the scan, and store changes
-  invalidate the composite fingerprint. Reverified 2026-09-09 with synthetic
-  parser and SQLite archive fixtures covering initial import and subsequent
-  transcript updates when store enrichment is unavailable, missing store tables,
-  and recovery after store access failures, plus a custom-root fixture that
-  keeps sibling live-store reasoning out of archived transcripts.
+  reachable blobs do not discard decoded siblings. Missing required tables or
+  columns, unsupported metadata, missing roots or turn indexes, and stores
+  with no decodable turns leave the transcript usable, with a warning. Store
+  open/read errors remain retryable source errors without replacing archived
+  content. Store fingerprint failures prevent freshness skips, and temporary
+  path-access failures retain cached stores and newly observed store
+  candidates for retry. A failed chats scan warns and preserves cached store
+  locations; otherwise sync uses transcripts alone. The next discovery pass
+  retries the scan, and store changes invalidate the composite fingerprint.
+  Reverified 2026-09-09 with synthetic parser and SQLite archive fixtures
+  covering initial import and subsequent transcript updates when store
+  enrichment is unavailable, missing store tables or columns, and recovery
+  after access failures for cached or newly observed stores. A custom root
+  fixture keeps reasoning from sibling live stores out of archived
+  transcripts.
 
 ## Cursor IDE (`cursor-ide`)
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -942,7 +942,13 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
 ## Cursor (`cursor`)
 
 - **Format:** Legacy text and newer JSONL transcripts under per-project
-  `agent-transcripts` directories.
+  `agent-transcripts` directories. Cursor CLI also writes a per-session SQLite
+  store at `~/.cursor/chats/<workspace-hash>/<agent-id>/store.db`, with
+  `blobs` and `meta` tables. Metadata key `0` is hex-encoded UTF-8 JSON
+  carrying `agentId` and `latestRootBlobId`. The selected root's protobuf
+  field-8 turn index supplies assistant reasoning and producer
+  epoch-millisecond timestamps; field-1 system/context blobs are not
+  transcript messages.
 - **Turn timestamps:** Cursor user messages can carry a leading metadata tag in
   the form
   `<timestamp>Weekday, Mon D, YYYY, H:MM AM|PM (UTC±H[:MM])</timestamp>`
@@ -963,7 +969,15 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   characterization does not extend to Cursor IDE (the GUI editor, see below):
   for the GUI, `state.vscdb` is the only transcript store, not metadata beside
   one. Cursor's public GitHub organization was also searched 2026-07-19; no
-  transcript schema or producer source was found.
+  transcript schema or producer source was found. CLI store evidence comes
+  from a structural capture of one Windows install on 2026-09-07, which
+  recorded the store shape without private prompts, paths, IDs, or
+  encryption-key values. A directory measure found one store among 18
+  transcript IDs, one overlapping ID, and no store-only sessions. No published
+  `.proto` or store schema was found; field numbers remain provisional for
+  that captured producer version. Its main database was a 4096-byte header
+  while schema and rows lived in `store.db-wal`, so the reader must keep the
+  WAL attached.
 - **Legacy result evidence (rechecked 2026-09-09):**
   [Issue #1627](https://github.com/kenn-io/agentsview/issues/1627), based on
   read-only inspection of live transcripts on 2026-09-04, reports discarded
@@ -983,11 +997,30 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   unchanged object, verifying recovered output and a skipped fetch on the next
   pass. This uses synthetic input, not additional format evidence.
 - **Usage and cost:** The consumed text/JSONL transcripts have no reliable
-  per-message token, cache, reasoning, credit, or monetary-cost fields.
+  per-message token, cache, reasoning, credit, or monetary-cost fields. The
+  captured store adds no priced usage fields consumed by agentsview.
 - **Agentsview:** `internal/parser/cursor.go`,
   `internal/parser/cursor_paths.go`, and `internal/parser/cursor_provider.go`;
   workspace identity uses a filesystem-backed unique-match resolver, while
   role and attribution boundaries are reconstructed from Markdown.
+  `internal/parser/cursor_store.go` enriches the matching transcript UUID by
+  following only the selected root's turn tree in one deferred read-only
+  transaction (`mode=ro`), without mutating SQL. Discovery and archive
+  identity remain the transcript source (`cursor:<agentId>`). The chats
+  directory is local provider metadata, outside remote, SSH, and S3 transfer
+  targets. Store-only discovery, native tool-call/result joining, encrypted
+  blob payloads, and cross-version field-number stability remain unsupported;
+  the capture contained no tool result and the reader ignores
+  `blobEncryptionKey`. Unknown reachable blobs do not discard decoded
+  siblings. Unsupported metadata, missing roots or turn indexes, and stores
+  with no decodable turns leave the transcript usable, with a warning. Store
+  open/read errors remain retryable source errors without replacing archived
+  content. A failed chats scan warns and preserves cached store locations;
+  otherwise sync uses transcripts alone. The next discovery pass retries the
+  scan, and store changes invalidate the composite fingerprint. Reverified
+  2026-09-08 with synthetic parser and SQLite archive fixtures covering
+  initial import and subsequent transcript updates when store enrichment is
+  unavailable.
 
 ## Cursor IDE (`cursor-ide`)
 
@@ -1039,43 +1072,6 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   `lastUpdatedAt` untouched still reads as changed. A chat deleted inside
   Cursor IDE is retired through stored-source-hint tombstones on `state.vscdb`
   change events and through complete-container ownership reconciliation.
-
-### Cursor CLI store store.db
-
-Cursor CLI store format. A per-session SQLite store under
-  `~/.cursor/chats/<workspace-hash>/<agent-id>/store.db`, with `blobs` and
-  `meta` tables. Metadata key `0` is hex-encoded UTF-8 JSON that carries the
-  native `agentId` and `latestRootBlobId`. Conversation content is a protobuf
-  blob tree; Agentsview reads only the tree reachable from
-  `latestRootBlobId` and projects the field-8 typed turn index onto the
-  matching `agent-transcripts` session (same native UUID). Field-8 turns supply
-  assistant reasoning text and producer epoch-millisecond timestamps. Field-1
-  system/context blobs are not archived as transcript messages.
-Evidence for the CLI store. A live installed-tool capture from one Windows Cursor CLI install
-  was collected on 2026-09-07 with the structural probe described above. The
-  probe recorded no private prompts, paths, ids, or encryption-key values.
-  An independent directory measure on that install found 1 store among 18
-  transcript ids, 1 overlapping id, and 0 store-only sessions.
-Upstream evidence for the CLI store. No published `.proto` or store schema was found. Protobuf field
-  numbers are therefore provisional for the captured producer version.
-- **WAL requirement:** The live capture keeps schema and rows in
-  `store.db-wal` while the main file stays a 4096-byte header. A main-file-only
-  open reports an empty schema. Agentsview opens the live path read-only
-  (`mode=ro`) and reads one deferred transaction so the WAL remains attached.
-  The reader issues no mutating SQL and ignores `blobEncryptionKey`.
-CLI store usage and cost. The captured store has no priced usage fields consumed by
-  Agentsview.
-Unsupported in this slice. Native tool-call/result joining (the capture
-  contains no tool result), store-only discovery (no store-only sessions in the
-  measured install), encrypted blob payloads on other installs, and complete
-  cross-version field-number stability. Unknown or undecodable reachable blobs
-  are skipped without dropping decoded siblings; a present store with no
-  decodable selected turn is a source error that preserves the archive.
-Agentsview CLI store handling. `internal/parser/cursor_store.go` plus enrichment hooks in
-  `internal/parser/cursor_provider.go`. Discovery and archive identity remain
-  the existing transcript source (`cursor:<agentId>`). The chats directory is
-  carried only through `ResolveMetadataDir` / provider metadata and is not a
-  remote, SSH, or S3 transfer target.
 
 ## Amp (`amp`)
 

--- a/internal/parser/capabilities_sync_test.go
+++ b/internal/parser/capabilities_sync_test.go
@@ -53,6 +53,10 @@ func TestProviderSyncSemanticsDeclarations(t *testing.T) {
 		AgentZed: {
 			UnchangedResults: UnchangedResultMTime,
 		},
+		AgentCursor: {
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+		},
 		AgentCursorIDE: {
 			FingerprintHashInCacheKey:           true,
 			FingerprintHashRequiredForFreshness: true,

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -130,9 +130,8 @@ func (p *cursorProvider) Parse(
 			SkipReason:        SkipNoSession,
 		}, nil
 	}
-	var enrichErr error
-	storePath, agentID := p.sources.storePathForSource(req.Source, path)
-	if storePath != "" {
+	storePath, agentID, enrichErr := p.sources.storePathForSource(req.Source, path)
+	if enrichErr == nil && storePath != "" {
 		enrichErr = enrichCursorSessionFromStore(
 			ctx, storePath, agentID, sess, msgs,
 		)
@@ -784,19 +783,24 @@ func (s cursorSourceSet) Fingerprint(
 		}
 	}
 	mtime := info.ModTime().UnixNano()
-	storePath, _ := s.storePathForSource(source, path)
+	storePath, _, err := s.storePathForSource(source, path)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
 	if storePath != "" {
 		if composite, err := sqliteDBCompositeMtime(
 			storePath, sqliteDBJournalSuffixes,
 		); err == nil && composite > mtime {
 			mtime = composite
 		}
-		if stateHash, hashErr := cursorIDESQLiteStateHash(storePath); hashErr == nil {
-			if hash == "" {
-				hash = "store:" + stateHash
-			} else {
-				hash = hash + "|store:" + stateHash
-			}
+		stateHash, err := cursorIDESQLiteStateHash(storePath)
+		if err != nil {
+			return SourceFingerprint{}, fmt.Errorf("fingerprint Cursor store %s: %w", storePath, err)
+		}
+		if hash == "" {
+			hash = "store:" + stateHash
+		} else {
+			hash = hash + "|store:" + stateHash
 		}
 	}
 	return SourceFingerprint{
@@ -943,7 +947,7 @@ func (s cursorSourceSet) projectsRootForChats(chatsRoot string) (string, bool) {
 
 func (s cursorSourceSet) storePathForSource(
 	source SourceRef, path string,
-) (string, string) {
+) (string, string, error) {
 	root := ""
 	switch src := source.Opaque.(type) {
 	case cursorSource:
@@ -965,29 +969,26 @@ func (s cursorSourceSet) storePathForSource(
 		}
 	}
 	if root == "" {
-		return "", ""
+		return "", "", nil
 	}
 	agentID := cursorRawIDFromTranscriptPath(path)
 	if !IsValidSessionID(agentID) {
-		return "", ""
+		return "", "", nil
 	}
-	storePath := s.storePathForRawID(root, agentID)
-	if storePath == "" {
-		return "", ""
-	}
-	return storePath, agentID
+	storePath, err := s.storePathForRawID(root, agentID)
+	return storePath, agentID, err
 }
 
-func (s cursorSourceSet) storePathForRawID(root, agentID string) string {
+func (s cursorSourceSet) storePathForRawID(root, agentID string) (string, error) {
 	for _, chats := range s.chatsDirs(root) {
 		if !s.storeIndex.initialized(chats) {
 			s.storeIndex.refresh(chats)
 		}
-		if path := s.storeIndex.path(chats, agentID); path != "" {
-			return path
+		if path, err := s.storeIndex.path(chats, agentID); path != "" || err != nil {
+			return path, err
 		}
 	}
-	return ""
+	return "", nil
 }
 
 func (s cursorSourceSet) sourcesForStorePath(root, path string) ([]SourceRef, error) {

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,11 +131,9 @@ func (p *cursorProvider) Parse(
 		}, nil
 	}
 	var enrichErr error
-	storePath, agentID, storeIndexErr := p.sources.storePathForSource(req.Source, path)
-	if storeIndexErr != nil {
-		enrichErr = fmt.Errorf("cursor store index: %w", storeIndexErr)
-	} else if storePath != "" {
-		_, enrichErr = enrichCursorSessionFromStore(
+	storePath, agentID := p.sources.storePathForSource(req.Source, path)
+	if storePath != "" {
+		enrichErr = enrichCursorSessionFromStore(
 			ctx, storePath, agentID, sess, msgs,
 		)
 		if errors.Is(enrichErr, context.Canceled) ||
@@ -145,7 +144,9 @@ func (p *cursorProvider) Parse(
 			enrichErr = fmt.Errorf("cursor store %s: %w", storePath, enrichErr)
 		}
 	}
-	if enrichErr != nil {
+	if errors.Is(enrichErr, errCursorStoreFormat) {
+		log.Printf("warning: %v; using Cursor transcript only", enrichErr)
+	} else if enrichErr != nil {
 		return ParseOutcome{
 			SourceErrors: []SourceError{{
 				SourceKey:   req.Source.Key,
@@ -166,7 +167,7 @@ func (p *cursorProvider) Parse(
 	if req.Fingerprint.Hash != "" {
 		sess.File.Hash = req.Fingerprint.Hash
 	}
-	outcome := ParseOutcome{
+	return ParseOutcome{
 		Results: []ParseResultOutcome{{
 			Result: ParseResult{
 				Session:  *sess,
@@ -175,8 +176,7 @@ func (p *cursorProvider) Parse(
 			DataVersion: DataVersionCurrent,
 		}},
 		ResultSetComplete: true,
-	}
-	return outcome, nil
+	}, nil
 }
 
 type cursorSource struct {
@@ -289,9 +289,7 @@ func (s cursorSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 			continue
 		}
 		for _, chats := range s.chatsDirs(root) {
-			if err := s.storeIndex.refresh(chats); err != nil {
-				return nil, err
-			}
+			s.storeIndex.refresh(chats)
 		}
 		for _, path := range s.discoverTranscriptPaths(root) {
 			source, ok := s.sourceRefWithCache(root, path, resolutionCache)
@@ -324,9 +322,7 @@ func (s cursorSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef)
 			continue
 		}
 		for _, chats := range s.chatsDirs(root) {
-			if err := s.storeIndex.refresh(chats); err != nil {
-				return err
-			}
+			s.storeIndex.refresh(chats)
 		}
 		resolvedRoot, err := filepath.EvalSymlinks(root)
 		if err != nil {
@@ -629,10 +625,9 @@ func (s cursorSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 			}
 			seenChats[chats] = struct{}{}
 			roots = append(roots, WatchRoot{
-				Path:         chats,
-				Recursive:    true,
-				IncludeGlobs: []string{"store.db", "store.db-wal"},
-				DebounceKey:  string(AgentCursor) + ":store:" + chats,
+				Path:        chats,
+				Recursive:   true,
+				DebounceKey: string(AgentCursor) + ":store:" + chats,
 			})
 		}
 	}
@@ -789,10 +784,7 @@ func (s cursorSourceSet) Fingerprint(
 		}
 	}
 	mtime := info.ModTime().UnixNano()
-	storePath, _, storeIndexErr := s.storePathForSource(source, path)
-	if storeIndexErr != nil {
-		return SourceFingerprint{}, fmt.Errorf("cursor store index: %w", storeIndexErr)
-	}
+	storePath, _ := s.storePathForSource(source, path)
 	if storePath != "" {
 		if composite, err := sqliteDBCompositeMtime(
 			storePath, sqliteDBJournalSuffixes,
@@ -951,7 +943,7 @@ func (s cursorSourceSet) projectsRootForChats(chatsRoot string) (string, bool) {
 
 func (s cursorSourceSet) storePathForSource(
 	source SourceRef, path string,
-) (string, string, error) {
+) (string, string) {
 	root := ""
 	switch src := source.Opaque.(type) {
 	case cursorSource:
@@ -973,34 +965,29 @@ func (s cursorSourceSet) storePathForSource(
 		}
 	}
 	if root == "" {
-		return "", "", nil
+		return "", ""
 	}
 	agentID := cursorRawIDFromTranscriptPath(path)
 	if !IsValidSessionID(agentID) {
-		return "", "", nil
+		return "", ""
 	}
-	storePath, err := s.storePathForRawID(root, agentID)
-	if err != nil {
-		return "", "", err
-	}
+	storePath := s.storePathForRawID(root, agentID)
 	if storePath == "" {
-		return "", "", nil
+		return "", ""
 	}
-	return storePath, agentID, nil
+	return storePath, agentID
 }
 
-func (s cursorSourceSet) storePathForRawID(root, agentID string) (string, error) {
+func (s cursorSourceSet) storePathForRawID(root, agentID string) string {
 	for _, chats := range s.chatsDirs(root) {
 		if !s.storeIndex.initialized(chats) {
-			if err := s.storeIndex.refresh(chats); err != nil {
-				return "", err
-			}
+			s.storeIndex.refresh(chats)
 		}
 		if path := s.storeIndex.path(chats, agentID); path != "" {
-			return path, nil
+			return path
 		}
 	}
-	return "", nil
+	return ""
 }
 
 func (s cursorSourceSet) sourcesForStorePath(root, path string) ([]SourceRef, error) {

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -7,36 +7,58 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"go.kenn.io/agentsview/internal/pathutil"
 )
 
 var _ Provider = (*cursorProvider)(nil)
 var _ S3Provider = (*cursorProvider)(nil)
 
 type cursorProviderFactory struct {
-	def AgentDef
+	def        AgentDef
+	storeIndex *cursorStoreIndex
 }
 
 func newCursorProviderFactory(def AgentDef) ProviderFactory {
-	return cursorProviderFactory{def: cloneAgentDef(def)}
+	return &cursorProviderFactory{
+		def:        cloneAgentDef(def),
+		storeIndex: newCursorStoreIndex(),
+	}
 }
 
-func (f cursorProviderFactory) Definition() AgentDef {
+func (f *cursorProviderFactory) Definition() AgentDef {
 	return cloneAgentDef(f.def)
 }
 
-func (f cursorProviderFactory) Capabilities() Capabilities {
+func (f *cursorProviderFactory) Capabilities() Capabilities {
 	return cursorProviderCapabilities()
 }
 
-func (f cursorProviderFactory) NewProvider(cfg ProviderConfig) Provider {
+func (f *cursorProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	cfg = cfg.Clone()
+	sources := newCursorSourceSetWithConfig(cfg)
+	sources.storeIndex = f.storeIndex
 	return &cursorProvider{
 		Def:               cloneAgentDef(f.def),
 		Caps:              cursorProviderCapabilities(),
 		Config:            cfg,
 		DefaultS3Provider: cursorS3Provider,
-		sources:           newCursorSourceSetWithConfig(cfg),
+		sources:           sources,
 	}
+}
+
+// ResolveMetadataDir returns the sibling .cursor/chats directory for a local
+// .cursor/projects root. Remote, rewritten and unrelated roots yield "".
+func (f cursorProviderFactory) ResolveMetadataDir(path string) (string, error) {
+	root, err := pathutil.ResolveAbsolute(path)
+	if err != nil {
+		return "", err
+	}
+	parent := filepath.Dir(root)
+	if filepath.Base(parent) != ".cursor" {
+		return "", nil
+	}
+	return pathutil.ResolveAbsolute(filepath.Join(parent, "chats"))
 }
 
 type cursorProvider struct {
@@ -107,10 +129,41 @@ func (p *cursorProvider) Parse(
 			SkipReason:        SkipNoSession,
 		}, nil
 	}
+	var enrichErr error
+	if storePath, agentID := p.sources.storePathForSource(req.Source, path); storePath != "" {
+		_, enrichErr = enrichCursorSessionFromStore(
+			ctx, storePath, agentID, sess, msgs,
+		)
+		if errors.Is(enrichErr, context.Canceled) ||
+			errors.Is(enrichErr, context.DeadlineExceeded) {
+			return ParseOutcome{}, enrichErr
+		}
+		if enrichErr != nil {
+			enrichErr = fmt.Errorf("cursor store %s: %w", storePath, enrichErr)
+		}
+	}
+	if enrichErr != nil {
+		return ParseOutcome{
+			SourceErrors: []SourceError{{
+				SourceKey:   req.Source.Key,
+				DisplayPath: path,
+				SessionID:   sess.ID,
+				Err:         enrichErr,
+				Retryable:   true,
+			}},
+			ResultSetComplete: true,
+		}, nil
+	}
+	if req.Fingerprint.Size > 0 {
+		sess.File.Size = req.Fingerprint.Size
+	}
+	if req.Fingerprint.MTimeNS > 0 {
+		sess.File.Mtime = req.Fingerprint.MTimeNS
+	}
 	if req.Fingerprint.Hash != "" {
 		sess.File.Hash = req.Fingerprint.Hash
 	}
-	return ParseOutcome{
+	outcome := ParseOutcome{
 		Results: []ParseResultOutcome{{
 			Result: ParseResult{
 				Session:  *sess,
@@ -119,7 +172,8 @@ func (p *cursorProvider) Parse(
 			DataVersion: DataVersionCurrent,
 		}},
 		ResultSetComplete: true,
-	}, nil
+	}
+	return outcome, nil
 }
 
 type cursorSource struct {
@@ -129,6 +183,8 @@ type cursorSource struct {
 
 type cursorSourceSet struct {
 	roots              []string
+	metadataDirs       map[string][]string
+	storeIndex         *cursorStoreIndex
 	resolver           func(string) string
 	resolutionResolver func(string, CursorResolveMode, string) SourceCwdResolution
 	remote             bool
@@ -138,12 +194,14 @@ type cursorSourceSet struct {
 func newCursorSourceSet(roots []string) cursorSourceSet {
 	return cursorSourceSet{
 		roots:       cleanJSONLRoots(roots),
+		storeIndex:  newCursorStoreIndex(),
 		remoteRoots: make(map[string]bool),
 	}
 }
 
 func newCursorSourceSetWithConfig(cfg ProviderConfig) cursorSourceSet {
 	s := newCursorSourceSet(cfg.Roots)
+	s.metadataDirs = cloneMetadataDirs(cfg.MetadataDirs)
 	s.remote = cfg.PathRewriter != nil
 	for root, machine := range cfg.SourceMachines {
 		if machine != "" && machine != cfg.Machine {
@@ -227,6 +285,9 @@ func (s cursorSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 			}
 			continue
 		}
+		for _, chats := range s.chatsDirs(root) {
+			s.storeIndex.refresh(chats)
+		}
 		for _, path := range s.discoverTranscriptPaths(root) {
 			source, ok := s.sourceRefWithCache(root, path, resolutionCache)
 			if !ok {
@@ -256,6 +317,9 @@ func (s cursorSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef)
 				}
 			}
 			continue
+		}
+		for _, chats := range s.chatsDirs(root) {
+			s.storeIndex.refresh(chats)
 		}
 		resolvedRoot, err := filepath.EvalSymlinks(root)
 		if err != nil {
@@ -360,6 +424,7 @@ func (s cursorSourceSet) streamingSourceRefWithCache(
 	if project == "" {
 		project = "unknown"
 	}
+	s.storeIndex.rememberTranscript(root, path)
 	return SourceRef{
 		Provider: AgentCursor, Key: path, DisplayPath: path,
 		FingerprintKey: path, ProjectHint: project,
@@ -538,7 +603,8 @@ func cursorAddSeen(seen map[string]string, name, fullPath string) {
 }
 
 func (s cursorSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
-	roots := make([]WatchRoot, 0, len(s.roots))
+	roots := make([]WatchRoot, 0, len(s.roots)*2)
+	seenChats := make(map[string]struct{})
 	for _, root := range s.roots {
 		if isS3URI(root) {
 			continue
@@ -549,6 +615,19 @@ func (s cursorSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 			IncludeGlobs: []string{"*.jsonl", "*.txt"},
 			DebounceKey:  string(AgentCursor) + ":transcripts:" + root,
 		})
+		for _, chats := range s.chatsDirs(root) {
+			chats = filepath.Clean(chats)
+			if _, ok := seenChats[chats]; ok {
+				continue
+			}
+			seenChats[chats] = struct{}{}
+			roots = append(roots, WatchRoot{
+				Path:         chats,
+				Recursive:    true,
+				IncludeGlobs: []string{"store.db", "store.db-wal"},
+				DebounceKey:  string(AgentCursor) + ":store:" + chats,
+			})
+		}
 	}
 	return WatchPlan{Roots: roots}, nil
 }
@@ -561,20 +640,30 @@ func (s cursorSourceSet) SourcesForChangedPath(
 		return nil, err
 	}
 	if req.WatchRoot != "" {
-		root := filepath.Clean(req.WatchRoot)
-		if !s.hasRoot(root) {
-			return nil, nil
+		watchRoot := filepath.Clean(req.WatchRoot)
+		if s.hasRoot(watchRoot) {
+			source, ok := s.sourceForPathInRoot(watchRoot, req.Path)
+			if !ok {
+				return nil, nil
+			}
+			return []SourceRef{source}, nil
 		}
-		source, ok := s.sourceForPathInRoot(root, req.Path)
-		if !ok {
-			return nil, nil
+		if projectsRoot, ok := s.projectsRootForChats(watchRoot); ok {
+			return s.sourcesForStorePath(projectsRoot, req.Path)
 		}
-		return []SourceRef{source}, nil
+		return nil, nil
 	}
 	for _, root := range s.roots {
 		source, ok := s.sourceForPathInRoot(root, req.Path)
 		if ok {
 			return []SourceRef{source}, nil
+		}
+	}
+	for _, root := range s.roots {
+		if sources, err := s.sourcesForStorePath(root, req.Path); err != nil {
+			return nil, err
+		} else if len(sources) > 0 {
+			return sources, nil
 		}
 	}
 	return nil, nil
@@ -692,10 +781,25 @@ func (s cursorSourceSet) Fingerprint(
 			return SourceFingerprint{}, err
 		}
 	}
+	mtime := info.ModTime().UnixNano()
+	if storePath, _ := s.storePathForSource(source, path); storePath != "" {
+		if composite, err := sqliteDBCompositeMtime(
+			storePath, sqliteDBJournalSuffixes,
+		); err == nil && composite > mtime {
+			mtime = composite
+		}
+		if stateHash, hashErr := cursorIDESQLiteStateHash(storePath); hashErr == nil {
+			if hash == "" {
+				hash = "store:" + stateHash
+			} else {
+				hash = hash + "|store:" + stateHash
+			}
+		}
+	}
 	return SourceFingerprint{
 		Key:     firstNonEmptyJSONLString(source.FingerprintKey, source.Key, path),
 		Size:    info.Size(),
-		MTimeNS: info.ModTime().UnixNano(),
+		MTimeNS: mtime,
 		Hash:    hash,
 	}, nil
 }
@@ -780,6 +884,7 @@ func (s cursorSourceSet) sourceRefWithCache(
 	if project == "" {
 		project = "unknown"
 	}
+	s.storeIndex.rememberTranscript(root, path)
 	return SourceRef{
 		Provider:       AgentCursor,
 		Key:            path,
@@ -803,6 +908,113 @@ func (s cursorSourceSet) hasRoot(root string) bool {
 		}
 	}
 	return false
+}
+
+func (s cursorSourceSet) chatsDirs(root string) []string {
+	if isS3URI(root) || s.remote || s.remoteRoot(root) {
+		return nil
+	}
+	clean := filepath.Clean(root)
+	if dirs := s.metadataDirs[clean]; len(dirs) > 0 {
+		return dirs
+	}
+	for configured, dirs := range s.metadataDirs {
+		if samePath(configured, clean) {
+			return dirs
+		}
+	}
+	return nil
+}
+
+func (s cursorSourceSet) projectsRootForChats(chatsRoot string) (string, bool) {
+	chatsRoot = filepath.Clean(chatsRoot)
+	for _, root := range s.roots {
+		for _, chats := range s.chatsDirs(root) {
+			if samePath(chats, chatsRoot) {
+				return root, true
+			}
+		}
+	}
+	return "", false
+}
+
+func (s cursorSourceSet) storePathForSource(source SourceRef, path string) (string, string) {
+	root := ""
+	switch src := source.Opaque.(type) {
+	case cursorSource:
+		root = src.Root
+	case *cursorSource:
+		if src != nil {
+			root = src.Root
+		}
+	}
+	if root == "" {
+		for _, candidate := range s.roots {
+			if _, ok := cursorRawSessionIDFromPath(candidate, path); !ok {
+				continue
+			}
+			if _, ok := cursorProjectDirFromPath(candidate, path); ok {
+				root = candidate
+				break
+			}
+		}
+	}
+	if root == "" {
+		return "", ""
+	}
+	agentID := cursorRawIDFromTranscriptPath(path)
+	if !IsValidSessionID(agentID) {
+		return "", ""
+	}
+	storePath := s.storePathForRawID(root, agentID)
+	if storePath == "" {
+		return "", ""
+	}
+	return storePath, agentID
+}
+
+func (s cursorSourceSet) storePathForRawID(root, agentID string) string {
+	for _, chats := range s.chatsDirs(root) {
+		if !s.storeIndex.initialized(chats) {
+			s.storeIndex.refresh(chats)
+		}
+		if path := s.storeIndex.path(chats, agentID); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func (s cursorSourceSet) sourcesForStorePath(root, path string) ([]SourceRef, error) {
+	agentID, ok := cursorStoreAgentIDFromPath(path)
+	if !ok {
+		return nil, nil
+	}
+	underMetadata := false
+	matchingChats := ""
+	for _, chats := range s.chatsDirs(root) {
+		if !isContainedIn(filepath.Clean(path), filepath.Clean(chats)) {
+			continue
+		}
+		underMetadata = true
+		matchingChats = chats
+		break
+	}
+	if !underMetadata {
+		return nil, nil
+	}
+	s.storeIndex.remember(
+		matchingChats, agentID, filepath.Join(filepath.Dir(path), "store.db"),
+	)
+	transcript := s.storeIndex.transcriptPath(root, agentID)
+	if transcript == "" {
+		transcript = cursorFindSourceFile(root, agentID)
+	}
+	source, ok := s.sourceRef(root, transcript)
+	if !ok {
+		return nil, nil
+	}
+	return []SourceRef{source}, nil
 }
 
 func cursorFindSourceFileInProject(root, projectDir, rawID string) string {
@@ -890,6 +1102,10 @@ func cursorProviderCapabilities() Capabilities {
 			ToolCalls:        CapabilitySupported,
 			ToolResults:      CapabilitySupported,
 			ToolResultEvents: CapabilitySupported,
+		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
 		},
 	}
 }

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -130,7 +130,10 @@ func (p *cursorProvider) Parse(
 		}, nil
 	}
 	var enrichErr error
-	if storePath, agentID := p.sources.storePathForSource(req.Source, path); storePath != "" {
+	storePath, agentID, storeIndexErr := p.sources.storePathForSource(req.Source, path)
+	if storeIndexErr != nil {
+		enrichErr = fmt.Errorf("cursor store index: %w", storeIndexErr)
+	} else if storePath != "" {
 		_, enrichErr = enrichCursorSessionFromStore(
 			ctx, storePath, agentID, sess, msgs,
 		)
@@ -286,7 +289,9 @@ func (s cursorSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 			continue
 		}
 		for _, chats := range s.chatsDirs(root) {
-			s.storeIndex.refresh(chats)
+			if err := s.storeIndex.refresh(chats); err != nil {
+				return nil, err
+			}
 		}
 		for _, path := range s.discoverTranscriptPaths(root) {
 			source, ok := s.sourceRefWithCache(root, path, resolutionCache)
@@ -319,7 +324,9 @@ func (s cursorSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef)
 			continue
 		}
 		for _, chats := range s.chatsDirs(root) {
-			s.storeIndex.refresh(chats)
+			if err := s.storeIndex.refresh(chats); err != nil {
+				return err
+			}
 		}
 		resolvedRoot, err := filepath.EvalSymlinks(root)
 		if err != nil {
@@ -782,7 +789,11 @@ func (s cursorSourceSet) Fingerprint(
 		}
 	}
 	mtime := info.ModTime().UnixNano()
-	if storePath, _ := s.storePathForSource(source, path); storePath != "" {
+	storePath, _, storeIndexErr := s.storePathForSource(source, path)
+	if storeIndexErr != nil {
+		return SourceFingerprint{}, fmt.Errorf("cursor store index: %w", storeIndexErr)
+	}
+	if storePath != "" {
 		if composite, err := sqliteDBCompositeMtime(
 			storePath, sqliteDBJournalSuffixes,
 		); err == nil && composite > mtime {
@@ -938,7 +949,9 @@ func (s cursorSourceSet) projectsRootForChats(chatsRoot string) (string, bool) {
 	return "", false
 }
 
-func (s cursorSourceSet) storePathForSource(source SourceRef, path string) (string, string) {
+func (s cursorSourceSet) storePathForSource(
+	source SourceRef, path string,
+) (string, string, error) {
 	root := ""
 	switch src := source.Opaque.(type) {
 	case cursorSource:
@@ -960,29 +973,34 @@ func (s cursorSourceSet) storePathForSource(source SourceRef, path string) (stri
 		}
 	}
 	if root == "" {
-		return "", ""
+		return "", "", nil
 	}
 	agentID := cursorRawIDFromTranscriptPath(path)
 	if !IsValidSessionID(agentID) {
-		return "", ""
+		return "", "", nil
 	}
-	storePath := s.storePathForRawID(root, agentID)
+	storePath, err := s.storePathForRawID(root, agentID)
+	if err != nil {
+		return "", "", err
+	}
 	if storePath == "" {
-		return "", ""
+		return "", "", nil
 	}
-	return storePath, agentID
+	return storePath, agentID, nil
 }
 
-func (s cursorSourceSet) storePathForRawID(root, agentID string) string {
+func (s cursorSourceSet) storePathForRawID(root, agentID string) (string, error) {
 	for _, chats := range s.chatsDirs(root) {
 		if !s.storeIndex.initialized(chats) {
-			s.storeIndex.refresh(chats)
+			if err := s.storeIndex.refresh(chats); err != nil {
+				return "", err
+			}
 		}
 		if path := s.storeIndex.path(chats, agentID); path != "" {
-			return path
+			return path, nil
 		}
 	}
-	return ""
+	return "", nil
 }
 
 func (s cursorSourceSet) sourcesForStorePath(root, path string) ([]SourceRef, error) {

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -55,11 +55,14 @@ func (f cursorProviderFactory) ResolveMetadataDir(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	parent := filepath.Dir(root)
-	if filepath.Base(parent) != ".cursor" {
+	key, err := pathutil.LocalComparisonKey(root)
+	if err != nil {
+		return "", err
+	}
+	if filepath.Base(key) != "projects" || filepath.Base(filepath.Dir(key)) != ".cursor" {
 		return "", nil
 	}
-	return pathutil.ResolveAbsolute(filepath.Join(parent, "chats"))
+	return pathutil.ResolveAbsolute(filepath.Join(filepath.Dir(root), "chats"))
 }
 
 type cursorProvider struct {

--- a/internal/parser/cursor_provider_test.go
+++ b/internal/parser/cursor_provider_test.go
@@ -585,7 +585,6 @@ func TestCursorProviderPathRewriterMakesResolutionRemote(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, changed)
-	t.Log("latestRootBlobId=n/a remote_chats_ignored=true")
 }
 
 func TestCursorProviderSourceMachineMakesResolutionRemote(t *testing.T) {

--- a/internal/parser/cursor_provider_test.go
+++ b/internal/parser/cursor_provider_test.go
@@ -561,7 +561,9 @@ func TestCursorProviderPathRewriterMakesResolutionRemote(t *testing.T) {
 	}
 
 	provider, ok := NewProvider(AgentCursor, ProviderConfig{
-		Roots: []string{root}, PathRewriter: func(string) string { return "remote:" + path },
+		Roots:        []string{root},
+		PathRewriter: func(string) string { return "remote:" + path },
+		MetadataDirs: map[string][]string{root: {filepath.Join(root, "chats")}},
 	})
 	require.True(t, ok)
 	sources, err := provider.Discover(t.Context())
@@ -571,6 +573,19 @@ func TestCursorProviderPathRewriterMakesResolutionRemote(t *testing.T) {
 	assert.Zero(t, probeCalls)
 	assert.Zero(t, readDirCalls)
 	assert.Zero(t, statCalls)
+	watchPlan, err := provider.WatchPlan(t.Context())
+	require.NoError(t, err)
+	for _, watchRoot := range watchPlan.Roots {
+		assert.False(t, samePath(watchRoot.Path, filepath.Join(root, "chats")))
+	}
+	changed, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+		Path:      filepath.Join(root, "chats", "store.db"),
+		WatchRoot: filepath.Join(root, "chats"),
+		EventKind: "write",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	t.Log("latestRootBlobId=n/a remote_chats_ignored=true")
 }
 
 func TestCursorProviderSourceMachineMakesResolutionRemote(t *testing.T) {

--- a/internal/parser/cursor_store.go
+++ b/internal/parser/cursor_store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json/v2"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,16 +15,9 @@ import (
 	"time"
 )
 
-// cursorStoreReadStats records bounded store-read accounting for tests and
-// proof output. BlobLoads counts SELECT attempts for reachable ids only.
-type cursorStoreReadStats struct {
-	LatestRootBlobID string
-	BlobLoads        int
-	Reachable        int
-	DecodedTurns     int
-}
-
-var cursorStoreReadDir = os.ReadDir
+// errCursorStoreFormat identifies readable stores whose structure cannot be
+// used for enrichment. Database I/O errors remain retryable source errors.
+var errCursorStoreFormat = errors.New("unsupported Cursor store format")
 
 type cursorStoreTurn struct {
 	UserDecoded      bool
@@ -115,19 +109,25 @@ func (i *cursorStoreIndex) initialized(chatsRoot string) bool {
 	return ok
 }
 
-func (i *cursorStoreIndex) refresh(chatsRoot string) error {
+// refresh keeps the last complete index on scan failure. An unsuccessful first
+// scan records an empty index so each transcript does not repeat the same scan;
+// the next discovery pass retries, and store events can populate it meanwhile.
+func (i *cursorStoreIndex) refresh(chatsRoot string) {
 	if i == nil || chatsRoot == "" {
-		return nil
+		return
 	}
 	key := filepath.Clean(chatsRoot)
 	paths, err := cursorStorePathsUnderChats(key)
-	if err != nil {
-		return err
-	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	if err != nil {
+		if _, ok := i.roots[key]; !ok {
+			i.roots[key] = nil
+		}
+		log.Printf("warning: Cursor store index: %v; continuing with transcripts and cached stores", err)
+		return
+	}
 	i.roots[key] = paths
-	return nil
 }
 
 func (i *cursorStoreIndex) validPath(
@@ -168,97 +168,90 @@ func enrichCursorSessionFromStore(
 	storePath, agentID string,
 	sess *ParsedSession,
 	msgs []ParsedMessage,
-) (cursorStoreReadStats, error) {
-	turns, stats, err := readCursorStoreTurns(ctx, storePath, agentID)
+) error {
+	turns, err := readCursorStoreTurns(ctx, storePath, agentID)
 	if err != nil {
-		return stats, err
-	}
-	if stats.DecodedTurns == 0 {
-		return stats, fmt.Errorf(
-			"cursor store %s: no decodable turn (latestRootBlobId=%s)",
-			storePath, stats.LatestRootBlobID,
-		)
+		return err
 	}
 	applyCursorStoreTurns(sess, msgs, turns)
-	return stats, nil
+	return nil
 }
 
 func readCursorStoreTurns(
 	ctx context.Context, storePath, agentID string,
-) ([]cursorStoreTurn, cursorStoreReadStats, error) {
-	var stats cursorStoreReadStats
+) ([]cursorStoreTurn, error) {
 	if storePath == "" || !IsValidSessionID(agentID) {
-		return nil, stats, fmt.Errorf("cursor store: missing agent id")
+		return nil, fmt.Errorf("%w: missing agent id", errCursorStoreFormat)
 	}
 	conn, err := openCursorIDEDB(storePath)
 	if err != nil {
-		return nil, stats, err
+		return nil, err
 	}
 	defer conn.Close()
 
 	tx, err := beginCursorIDESnapshot(ctx, conn, agentID)
 	if err != nil {
-		return nil, stats, err
+		return nil, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
 	meta, err := loadCursorStoreMeta(ctx, tx, agentID)
 	if err != nil {
-		return nil, stats, err
+		return nil, err
 	}
-	stats.LatestRootBlobID = meta.LatestRootBlobID
 
-	loader := newCursorStoreBlobLoader(ctx, tx, &stats)
+	loader := newCursorStoreBlobLoader(ctx, tx)
 	rootData, ok := loader.load(meta.LatestRootBlobID)
 	if loader.err != nil {
-		return nil, stats, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"cursor store %s: reading selected root (latestRootBlobId=%s): %w",
 			storePath, meta.LatestRootBlobID, loader.err,
 		)
 	}
 	if !ok {
-		return nil, stats, fmt.Errorf(
-			"cursor store %s: missing selected root (latestRootBlobId=%s)",
-			storePath, meta.LatestRootBlobID,
+		return nil, fmt.Errorf(
+			"%w: missing selected root (latestRootBlobId=%s)",
+			errCursorStoreFormat, meta.LatestRootBlobID,
 		)
 	}
 
 	rootFields, err := agProtoParse(rootData)
 	if err != nil {
-		return nil, stats, fmt.Errorf(
-			"cursor store %s: decoding root (latestRootBlobId=%s): %w",
-			storePath, meta.LatestRootBlobID, err,
+		return nil, fmt.Errorf(
+			"%w: decoding root (latestRootBlobId=%s): %w",
+			errCursorStoreFormat, meta.LatestRootBlobID, err,
 		)
 	}
 	turnIndexField, ok := agProtoFind(rootFields, 8)
 	if !ok {
-		return nil, stats, fmt.Errorf(
-			"cursor store %s: root missing turn index (latestRootBlobId=%s)",
-			storePath, meta.LatestRootBlobID,
+		return nil, fmt.Errorf(
+			"%w: root missing turn index (latestRootBlobId=%s)",
+			errCursorStoreFormat, meta.LatestRootBlobID,
 		)
 	}
 	turnIndexFields, ok := cursorStoreResolveMessage(turnIndexField, loader)
 	if loader.err != nil {
-		return nil, stats, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"cursor store %s: reading turn index (latestRootBlobId=%s): %w",
 			storePath, meta.LatestRootBlobID, loader.err,
 		)
 	}
 	if !ok {
-		return nil, stats, fmt.Errorf(
-			"cursor store %s: undecodable turn index (latestRootBlobId=%s)",
-			storePath, meta.LatestRootBlobID,
+		return nil, fmt.Errorf(
+			"%w: undecodable turn index (latestRootBlobId=%s)",
+			errCursorStoreFormat, meta.LatestRootBlobID,
 		)
 	}
 
 	var turns []cursorStoreTurn
+	decodedAny := false
 	for _, f := range turnIndexFields {
 		if f.Number != 1 {
 			continue
 		}
 		turnFields, ok := cursorStoreResolveMessage(f, loader)
 		if loader.err != nil {
-			return nil, stats, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"cursor store %s: reading turn (latestRootBlobId=%s): %w",
 				storePath, meta.LatestRootBlobID, loader.err,
 			)
@@ -269,18 +262,21 @@ func readCursorStoreTurns(
 		}
 		turn, decoded := decodeCursorStoreTurn(turnFields, loader)
 		if loader.err != nil {
-			return nil, stats, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"cursor store %s: reading turn payload (latestRootBlobId=%s): %w",
 				storePath, meta.LatestRootBlobID, loader.err,
 			)
 		}
-		if decoded {
-			stats.DecodedTurns++
-		}
+		decodedAny = decodedAny || decoded
 		turns = append(turns, turn)
 	}
-	stats.Reachable = len(loader.seen)
-	return turns, stats, nil
+	if !decodedAny {
+		return nil, fmt.Errorf(
+			"%w: no decodable turn (latestRootBlobId=%s)",
+			errCursorStoreFormat, meta.LatestRootBlobID,
+		)
+	}
+	return turns, nil
 }
 
 func loadCursorStoreMeta(
@@ -290,7 +286,7 @@ func loadCursorStoreMeta(
 	err := q.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = ?`, "0").Scan(&raw)
 	if err == sql.ErrNoRows {
 		return cursorStoreMetaJSON{}, fmt.Errorf(
-			"cursor store: missing metadata key 0 for %s", agentID,
+			"%w: missing metadata key 0 for %s", errCursorStoreFormat, agentID,
 		)
 	}
 	if err != nil {
@@ -301,25 +297,25 @@ func loadCursorStoreMeta(
 	decoded, err := hex.DecodeString(strings.TrimSpace(raw))
 	if err != nil {
 		return cursorStoreMetaJSON{}, fmt.Errorf(
-			"cursor store: metadata key 0 is not hex for %s: %w", agentID, err,
+			"%w: metadata key 0 is not hex for %s: %w", errCursorStoreFormat, agentID, err,
 		)
 	}
 	var meta cursorStoreMetaJSON
 	if err := json.Unmarshal(decoded, &meta); err != nil {
 		return cursorStoreMetaJSON{}, fmt.Errorf(
-			"cursor store: metadata key 0 is not JSON for %s: %w", agentID, err,
+			"%w: metadata key 0 is not JSON for %s: %w", errCursorStoreFormat, agentID, err,
 		)
 	}
 	if meta.AgentID == "" || meta.LatestRootBlobID == "" {
 		return cursorStoreMetaJSON{}, fmt.Errorf(
-			"cursor store: metadata key 0 missing agentId or latestRootBlobId for %s",
-			agentID,
+			"%w: metadata key 0 missing agentId or latestRootBlobId for %s",
+			errCursorStoreFormat, agentID,
 		)
 	}
 	if meta.AgentID != agentID {
 		return cursorStoreMetaJSON{}, fmt.Errorf(
-			"cursor store: metadata agentId %q does not match %s",
-			meta.AgentID, agentID,
+			"%w: metadata agentId %q does not match %s",
+			errCursorStoreFormat, meta.AgentID, agentID,
 		)
 	}
 	return meta, nil
@@ -328,20 +324,16 @@ func loadCursorStoreMeta(
 type cursorStoreBlobLoader struct {
 	ctx   context.Context
 	q     cursorIDEQuerier
-	stats *cursorStoreReadStats
-	seen  map[string]struct{}
 	cache map[string][]byte
 	err   error
 }
 
 func newCursorStoreBlobLoader(
-	ctx context.Context, q cursorIDEQuerier, stats *cursorStoreReadStats,
+	ctx context.Context, q cursorIDEQuerier,
 ) *cursorStoreBlobLoader {
 	return &cursorStoreBlobLoader{
 		ctx:   ctx,
 		q:     q,
-		stats: stats,
-		seen:  make(map[string]struct{}),
 		cache: make(map[string][]byte),
 	}
 }
@@ -353,7 +345,6 @@ func (l *cursorStoreBlobLoader) load(id string) ([]byte, bool) {
 	if data, ok := l.cache[id]; ok {
 		return data, true
 	}
-	l.stats.BlobLoads++
 	var data []byte
 	err := l.q.QueryRowContext(
 		l.ctx, `SELECT data FROM blobs WHERE id = ?`, id,
@@ -364,7 +355,6 @@ func (l *cursorStoreBlobLoader) load(id string) ([]byte, bool) {
 		}
 		return nil, false
 	}
-	l.seen[id] = struct{}{}
 	l.cache[id] = data
 	return data, true
 }
@@ -692,7 +682,7 @@ func cursorStorePathsUnderChats(chatsRoot string) (map[string]string, error) {
 	if chatsRoot == "" {
 		return paths, nil
 	}
-	entries, err := cursorStoreReadDir(chatsRoot)
+	entries, err := os.ReadDir(chatsRoot)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return paths, nil
@@ -703,7 +693,7 @@ func cursorStorePathsUnderChats(chatsRoot string) (map[string]string, error) {
 		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
 			continue
 		}
-		agentDirs, readErr := cursorStoreReadDir(
+		agentDirs, readErr := os.ReadDir(
 			filepath.Join(chatsRoot, entry.Name()),
 		)
 		if readErr != nil {

--- a/internal/parser/cursor_store.go
+++ b/internal/parser/cursor_store.go
@@ -1,0 +1,743 @@
+package parser
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json/v2"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// cursorStoreReadStats records bounded store-read accounting for tests and
+// proof output. BlobLoads counts SELECT attempts for reachable ids only.
+type cursorStoreReadStats struct {
+	LatestRootBlobID string
+	BlobLoads        int
+	Reachable        int
+	DecodedTurns     int
+}
+
+type cursorStoreTurn struct {
+	UserDecoded      bool
+	AssistantDecoded bool
+	UserText         string
+	AssistantText    string
+	UserTime         time.Time
+	AssistantTime    time.Time
+	ReasoningText    string
+	ReasoningTime    time.Time
+}
+
+type cursorStoreMetaJSON struct {
+	AgentID          string `json:"agentId"`
+	LatestRootBlobID string `json:"latestRootBlobId"`
+}
+
+type cursorStoreIndex struct {
+	mu          sync.Mutex
+	roots       map[string]map[string]string
+	transcripts map[string]map[string]string
+}
+
+func newCursorStoreIndex() *cursorStoreIndex {
+	return &cursorStoreIndex{
+		roots:       make(map[string]map[string]string),
+		transcripts: make(map[string]map[string]string),
+	}
+}
+
+func (i *cursorStoreIndex) rememberTranscript(root, path string) {
+	if i == nil || root == "" || path == "" {
+		return
+	}
+	agentID := cursorRawIDFromTranscriptPath(path)
+	if !IsValidSessionID(agentID) {
+		return
+	}
+	key := filepath.Clean(root)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	paths := i.transcripts[key]
+	if paths == nil {
+		paths = make(map[string]string)
+		i.transcripts[key] = paths
+	}
+	paths[agentID] = filepath.Clean(path)
+}
+
+func (i *cursorStoreIndex) transcriptPath(root, agentID string) string {
+	if i == nil || root == "" || !IsValidSessionID(agentID) {
+		return ""
+	}
+	key := filepath.Clean(root)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	path := i.transcripts[key][agentID]
+	if path == "" {
+		return ""
+	}
+	if _, ok := cursorRawSessionIDFromPath(key, path); !ok || !IsRegularFile(path) {
+		delete(i.transcripts[key], agentID)
+		return ""
+	}
+	return path
+}
+
+func (i *cursorStoreIndex) path(chatsRoot, agentID string) string {
+	if i == nil {
+		return ""
+	}
+	key := filepath.Clean(chatsRoot)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	paths, ok := i.roots[key]
+	if !ok {
+		return ""
+	}
+	return i.validPath(key, paths, agentID)
+}
+
+func (i *cursorStoreIndex) initialized(chatsRoot string) bool {
+	if i == nil || chatsRoot == "" {
+		return false
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	_, ok := i.roots[filepath.Clean(chatsRoot)]
+	return ok
+}
+
+func (i *cursorStoreIndex) refresh(chatsRoot string) {
+	if i == nil || chatsRoot == "" {
+		return
+	}
+	key := filepath.Clean(chatsRoot)
+	paths := cursorStorePathsUnderChats(key)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.roots[key] = paths
+}
+
+func (i *cursorStoreIndex) validPath(
+	chatsRoot string, paths map[string]string, agentID string,
+) string {
+	path := paths[agentID]
+	if path != "" && !cursorStorePathIsValid(chatsRoot, path) {
+		delete(paths, agentID)
+		return ""
+	}
+	return path
+}
+
+func (i *cursorStoreIndex) remember(chatsRoot, agentID, storePath string) {
+	if i == nil || chatsRoot == "" || !IsValidSessionID(agentID) {
+		return
+	}
+	key := filepath.Clean(chatsRoot)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	paths := i.roots[key]
+	if paths == nil {
+		paths = make(map[string]string)
+		i.roots[key] = paths
+	}
+	if storePath == "" || !cursorStorePathIsValid(key, storePath) {
+		delete(paths, agentID)
+		return
+	}
+	paths[agentID] = storePath
+}
+
+// enrichCursorSessionFromStore overlays field-8 turn data onto an existing
+// transcript parse. The store must exist; callers skip this when absent.
+// Message count, roles and order stay with the transcript.
+func enrichCursorSessionFromStore(
+	ctx context.Context,
+	storePath, agentID string,
+	sess *ParsedSession,
+	msgs []ParsedMessage,
+) (cursorStoreReadStats, error) {
+	turns, stats, err := readCursorStoreTurns(ctx, storePath, agentID)
+	if err != nil {
+		return stats, err
+	}
+	if stats.DecodedTurns == 0 {
+		return stats, fmt.Errorf(
+			"cursor store %s: no decodable turn (latestRootBlobId=%s)",
+			storePath, stats.LatestRootBlobID,
+		)
+	}
+	applyCursorStoreTurns(sess, msgs, turns)
+	return stats, nil
+}
+
+func readCursorStoreTurns(
+	ctx context.Context, storePath, agentID string,
+) ([]cursorStoreTurn, cursorStoreReadStats, error) {
+	var stats cursorStoreReadStats
+	if storePath == "" || !IsValidSessionID(agentID) {
+		return nil, stats, fmt.Errorf("cursor store: missing agent id")
+	}
+	conn, err := openCursorIDEDB(storePath)
+	if err != nil {
+		return nil, stats, err
+	}
+	defer conn.Close()
+
+	tx, err := beginCursorIDESnapshot(ctx, conn, agentID)
+	if err != nil {
+		return nil, stats, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	meta, err := loadCursorStoreMeta(ctx, tx, agentID)
+	if err != nil {
+		return nil, stats, err
+	}
+	stats.LatestRootBlobID = meta.LatestRootBlobID
+
+	loader := newCursorStoreBlobLoader(ctx, tx, &stats)
+	rootData, ok := loader.load(meta.LatestRootBlobID)
+	if loader.err != nil {
+		return nil, stats, fmt.Errorf(
+			"cursor store %s: reading selected root (latestRootBlobId=%s): %w",
+			storePath, meta.LatestRootBlobID, loader.err,
+		)
+	}
+	if !ok {
+		return nil, stats, fmt.Errorf(
+			"cursor store %s: missing selected root (latestRootBlobId=%s)",
+			storePath, meta.LatestRootBlobID,
+		)
+	}
+
+	rootFields, err := agProtoParse(rootData)
+	if err != nil {
+		return nil, stats, fmt.Errorf(
+			"cursor store %s: decoding root (latestRootBlobId=%s): %w",
+			storePath, meta.LatestRootBlobID, err,
+		)
+	}
+	turnIndexField, ok := agProtoFind(rootFields, 8)
+	if !ok {
+		return nil, stats, fmt.Errorf(
+			"cursor store %s: root missing turn index (latestRootBlobId=%s)",
+			storePath, meta.LatestRootBlobID,
+		)
+	}
+	turnIndexFields, ok := cursorStoreResolveMessage(turnIndexField, loader)
+	if loader.err != nil {
+		return nil, stats, fmt.Errorf(
+			"cursor store %s: reading turn index (latestRootBlobId=%s): %w",
+			storePath, meta.LatestRootBlobID, loader.err,
+		)
+	}
+	if !ok {
+		return nil, stats, fmt.Errorf(
+			"cursor store %s: undecodable turn index (latestRootBlobId=%s)",
+			storePath, meta.LatestRootBlobID,
+		)
+	}
+
+	var turns []cursorStoreTurn
+	for _, f := range turnIndexFields {
+		if f.Number != 1 {
+			continue
+		}
+		turnFields, ok := cursorStoreResolveMessage(f, loader)
+		if loader.err != nil {
+			return nil, stats, fmt.Errorf(
+				"cursor store %s: reading turn (latestRootBlobId=%s): %w",
+				storePath, meta.LatestRootBlobID, loader.err,
+			)
+		}
+		if !ok {
+			turns = append(turns, cursorStoreTurn{})
+			continue
+		}
+		turn, decoded := decodeCursorStoreTurn(turnFields, loader)
+		if loader.err != nil {
+			return nil, stats, fmt.Errorf(
+				"cursor store %s: reading turn payload (latestRootBlobId=%s): %w",
+				storePath, meta.LatestRootBlobID, loader.err,
+			)
+		}
+		if decoded {
+			stats.DecodedTurns++
+		}
+		turns = append(turns, turn)
+	}
+	stats.Reachable = len(loader.seen)
+	return turns, stats, nil
+}
+
+func loadCursorStoreMeta(
+	ctx context.Context, q cursorIDEQuerier, agentID string,
+) (cursorStoreMetaJSON, error) {
+	var raw string
+	err := q.QueryRowContext(ctx, `SELECT value FROM meta WHERE key = ?`, "0").Scan(&raw)
+	if err == sql.ErrNoRows {
+		return cursorStoreMetaJSON{}, fmt.Errorf(
+			"cursor store: missing metadata key 0 for %s", agentID,
+		)
+	}
+	if err != nil {
+		return cursorStoreMetaJSON{}, fmt.Errorf(
+			"cursor store: reading metadata for %s: %w", agentID, err,
+		)
+	}
+	decoded, err := hex.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		return cursorStoreMetaJSON{}, fmt.Errorf(
+			"cursor store: metadata key 0 is not hex for %s: %w", agentID, err,
+		)
+	}
+	var meta cursorStoreMetaJSON
+	if err := json.Unmarshal(decoded, &meta); err != nil {
+		return cursorStoreMetaJSON{}, fmt.Errorf(
+			"cursor store: metadata key 0 is not JSON for %s: %w", agentID, err,
+		)
+	}
+	if meta.AgentID == "" || meta.LatestRootBlobID == "" {
+		return cursorStoreMetaJSON{}, fmt.Errorf(
+			"cursor store: metadata key 0 missing agentId or latestRootBlobId for %s",
+			agentID,
+		)
+	}
+	if meta.AgentID != agentID {
+		return cursorStoreMetaJSON{}, fmt.Errorf(
+			"cursor store: metadata agentId %q does not match %s",
+			meta.AgentID, agentID,
+		)
+	}
+	return meta, nil
+}
+
+type cursorStoreBlobLoader struct {
+	ctx   context.Context
+	q     cursorIDEQuerier
+	stats *cursorStoreReadStats
+	seen  map[string]struct{}
+	cache map[string][]byte
+	err   error
+}
+
+func newCursorStoreBlobLoader(
+	ctx context.Context, q cursorIDEQuerier, stats *cursorStoreReadStats,
+) *cursorStoreBlobLoader {
+	return &cursorStoreBlobLoader{
+		ctx:   ctx,
+		q:     q,
+		stats: stats,
+		seen:  make(map[string]struct{}),
+		cache: make(map[string][]byte),
+	}
+}
+
+func (l *cursorStoreBlobLoader) load(id string) ([]byte, bool) {
+	if id == "" {
+		return nil, false
+	}
+	if data, ok := l.cache[id]; ok {
+		return data, true
+	}
+	l.stats.BlobLoads++
+	var data []byte
+	err := l.q.QueryRowContext(
+		l.ctx, `SELECT data FROM blobs WHERE id = ?`, id,
+	).Scan(&data)
+	if err != nil {
+		if err != sql.ErrNoRows && l.err == nil {
+			l.err = err
+		}
+		return nil, false
+	}
+	l.seen[id] = struct{}{}
+	l.cache[id] = data
+	return data, true
+}
+
+func cursorStoreResolveMessage(
+	f agProtoField, loader *cursorStoreBlobLoader,
+) ([]agProtoField, bool) {
+	if f.Wire != pbWireBytes {
+		return nil, false
+	}
+	if len(f.Bytes) == 32 {
+		id := hex.EncodeToString(f.Bytes)
+		if data, ok := loader.load(id); ok {
+			if fields, err := agProtoParse(data); err == nil {
+				return fields, true
+			}
+		}
+	}
+	if f.Nested != nil {
+		return f.Nested, true
+	}
+	fields, err := agProtoParse(f.Bytes)
+	if err != nil {
+		return nil, false
+	}
+	return fields, true
+}
+
+func decodeCursorStoreTurn(
+	fields []agProtoField, loader *cursorStoreBlobLoader,
+) (cursorStoreTurn, bool) {
+	var turn cursorStoreTurn
+	decoded := false
+	for _, f := range fields {
+		switch f.Number {
+		case 1:
+			msgFields, ok := cursorStoreResolveMessage(f, loader)
+			if !ok {
+				continue
+			}
+			if text, ts, ok := decodeCursorStoreUserMessage(msgFields); ok {
+				turn.UserDecoded = true
+				turn.UserText = text
+				turn.UserTime = ts
+				decoded = true
+			}
+		case 2:
+			msgFields, ok := cursorStoreResolveMessage(f, loader)
+			if !ok {
+				continue
+			}
+			if text, ts, ok := decodeCursorStoreReasoning(msgFields); ok {
+				if turn.ReasoningText != "" {
+					turn.ReasoningText += "\n\n"
+				}
+				turn.ReasoningText += text
+				if turn.ReasoningTime.IsZero() || ts.After(turn.ReasoningTime) {
+					turn.ReasoningTime = ts
+				}
+				decoded = true
+				continue
+			}
+			if text, ts, ok := decodeCursorStoreAssistantMessage(msgFields); ok {
+				turn.AssistantDecoded = true
+				turn.AssistantText = text
+				turn.AssistantTime = ts
+				decoded = true
+			}
+		}
+	}
+	return turn, decoded
+}
+
+func decodeCursorStoreUserMessage(fields []agProtoField) (string, time.Time, bool) {
+	textField, ok := agProtoFind(fields, 1)
+	if !ok {
+		return "", time.Time{}, false
+	}
+	text, ok := agProtoString(textField)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", time.Time{}, false
+	}
+	var ts time.Time
+	if f, ok := agProtoFind(fields, 25); ok {
+		if t, ok := cursorStoreTimeMS(f.Varint); ok {
+			ts = t
+		}
+	}
+	if ts.IsZero() {
+		if f, ok := agProtoFind(fields, 26); ok {
+			if t, ok := cursorStoreTimeMS(f.Varint); ok {
+				ts = t
+			}
+		}
+	}
+	return text, ts, true
+}
+
+func decodeCursorStoreReasoning(fields []agProtoField) (string, time.Time, bool) {
+	block, ok := agProtoFind(fields, 3)
+	if !ok {
+		return "", time.Time{}, false
+	}
+	inner := block.Nested
+	if inner == nil && len(block.Bytes) > 0 {
+		var err error
+		inner, err = agProtoParse(block.Bytes)
+		if err != nil {
+			return "", time.Time{}, false
+		}
+	}
+	if inner == nil {
+		return "", time.Time{}, false
+	}
+	textField, ok := agProtoFind(inner, 1)
+	if !ok {
+		return "", time.Time{}, false
+	}
+	text, ok := agProtoString(textField)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", time.Time{}, false
+	}
+	var ts time.Time
+	if f, ok := agProtoFind(inner, 4); ok {
+		if t, ok := cursorStoreTimeMS(f.Varint); ok {
+			ts = t
+		}
+	}
+	if ts.IsZero() {
+		if f, ok := agProtoFind(inner, 3); ok {
+			if t, ok := cursorStoreTimeMS(f.Varint); ok {
+				ts = t
+			}
+		}
+	}
+	if ts.IsZero() {
+		return "", time.Time{}, false
+	}
+	return text, ts, true
+}
+
+func decodeCursorStoreAssistantMessage(fields []agProtoField) (string, time.Time, bool) {
+	block, ok := agProtoFind(fields, 1)
+	if !ok {
+		return "", time.Time{}, false
+	}
+	inner := block.Nested
+	if inner == nil && len(block.Bytes) > 0 {
+		var err error
+		inner, err = agProtoParse(block.Bytes)
+		if err != nil {
+			return "", time.Time{}, false
+		}
+	}
+	if inner == nil {
+		return "", time.Time{}, false
+	}
+	textField, ok := agProtoFind(inner, 1)
+	if !ok {
+		return "", time.Time{}, false
+	}
+	text, ok := agProtoString(textField)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", time.Time{}, false
+	}
+	var ts time.Time
+	if f, ok := agProtoFind(inner, 2); ok {
+		if t, ok := cursorStoreTimeMS(f.Varint); ok {
+			ts = t
+		}
+	}
+	return text, ts, true
+}
+
+func cursorStoreTimeMS(v uint64) (time.Time, bool) {
+	// Producer millisecond stamps in the captured Cursor CLI store sit near
+	// 1.7e12 (2026). Reject second-scale and absurd values so inferred times
+	// are not presented as exact producer stamps.
+	if v < 1_000_000_000_000 || v > 99_999_999_999_999 {
+		return time.Time{}, false
+	}
+	if v > uint64(^uint64(0)>>1) {
+		return time.Time{}, false
+	}
+	return time.UnixMilli(int64(v)).UTC(), true
+}
+
+func applyCursorStoreTurns(
+	sess *ParsedSession, msgs []ParsedMessage, turns []cursorStoreTurn,
+) {
+	if sess == nil || len(msgs) == 0 {
+		return
+	}
+	mi := 0
+	mappedPairs := 0
+	expectedUsers := 0
+	expectedAssistants := 0
+	for _, msg := range msgs {
+		switch msg.Role {
+		case RoleUser:
+			expectedUsers++
+		case RoleAssistant:
+			expectedAssistants++
+		}
+	}
+	expectedPairs := max(expectedUsers, expectedAssistants)
+	var started, ended time.Time
+	note := func(ts time.Time) {
+		if ts.IsZero() {
+			return
+		}
+		if started.IsZero() || ts.Before(started) {
+			started = ts
+		}
+		if ended.IsZero() || ts.After(ended) {
+			ended = ts
+		}
+	}
+	for _, turn := range turns {
+		if !turn.UserDecoded || !turn.AssistantDecoded {
+			knownIndex, known := cursorStoreKnownMessage(msgs, mi, turn)
+			if !known {
+				break
+			}
+			mi = knownIndex + 1
+			continue
+		}
+		userIndex, assistantIndex, ok := cursorStoreTranscriptPair(
+			msgs, mi, turn,
+		)
+		if !ok {
+			break
+		}
+		mi = assistantIndex + 1
+		if !turn.UserTime.IsZero() {
+			msgs[userIndex].Timestamp = turn.UserTime
+			note(turn.UserTime)
+		}
+		if turn.ReasoningText != "" {
+			msgs[assistantIndex].ThinkingText = turn.ReasoningText
+			msgs[assistantIndex].HasThinking = true
+		}
+		switch {
+		case !turn.AssistantTime.IsZero():
+			msgs[assistantIndex].Timestamp = turn.AssistantTime
+			note(turn.AssistantTime)
+		case !turn.ReasoningTime.IsZero():
+			msgs[assistantIndex].Timestamp = turn.ReasoningTime
+			note(turn.ReasoningTime)
+		}
+		note(turn.ReasoningTime)
+		if !turn.UserTime.IsZero() && !turn.AssistantTime.IsZero() {
+			mappedPairs++
+		}
+	}
+	if !started.IsZero() {
+		if mappedPairs == expectedPairs {
+			sess.StartedAt = started
+			sess.EndedAt = ended
+		} else {
+			if sess.StartedAt.IsZero() || started.Before(sess.StartedAt) {
+				sess.StartedAt = started
+			}
+			if sess.EndedAt.IsZero() || ended.After(sess.EndedAt) {
+				sess.EndedAt = ended
+			}
+		}
+	}
+}
+
+func cursorStoreKnownMessage(
+	msgs []ParsedMessage, start int, turn cursorStoreTurn,
+) (int, bool) {
+	if turn.UserText != "" {
+		want := strings.TrimSpace(turn.UserText)
+		for i := start; i < len(msgs); i++ {
+			if msgs[i].Role == RoleUser &&
+				strings.TrimSpace(msgs[i].Content) == want {
+				return i, true
+			}
+		}
+	}
+	if turn.AssistantText != "" {
+		want := strings.TrimSpace(turn.AssistantText)
+		for i := start; i < len(msgs); i++ {
+			if msgs[i].Role == RoleAssistant &&
+				strings.TrimSpace(msgs[i].Content) == want {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func cursorStoreTranscriptPair(
+	msgs []ParsedMessage, start int, turn cursorStoreTurn,
+) (int, int, bool) {
+	for userIndex := start; userIndex < len(msgs); userIndex++ {
+		if msgs[userIndex].Role != RoleUser {
+			continue
+		}
+		if turn.UserText != "" &&
+			strings.TrimSpace(msgs[userIndex].Content) != strings.TrimSpace(turn.UserText) {
+			continue
+		}
+		for assistantIndex := userIndex + 1; assistantIndex < len(msgs); assistantIndex++ {
+			if msgs[assistantIndex].Role == RoleUser {
+				break
+			}
+			if msgs[assistantIndex].Role != RoleAssistant {
+				continue
+			}
+			if turn.AssistantText != "" &&
+				strings.TrimSpace(msgs[assistantIndex].Content) != strings.TrimSpace(turn.AssistantText) {
+				continue
+			}
+			return userIndex, assistantIndex, true
+		}
+	}
+	return 0, 0, false
+}
+
+func cursorStorePathsUnderChats(chatsRoot string) map[string]string {
+	paths := make(map[string]string)
+	if chatsRoot == "" {
+		return paths
+	}
+	entries, err := os.ReadDir(chatsRoot)
+	if err != nil {
+		return paths
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		agentDirs, readErr := os.ReadDir(filepath.Join(chatsRoot, entry.Name()))
+		if readErr != nil {
+			continue
+		}
+		for _, agentEntry := range agentDirs {
+			if !agentEntry.IsDir() || !IsValidSessionID(agentEntry.Name()) {
+				continue
+			}
+			candidate := filepath.Join(
+				chatsRoot, entry.Name(), agentEntry.Name(), "store.db",
+			)
+			if cursorStorePathIsValid(chatsRoot, candidate) {
+				paths[agentEntry.Name()] = candidate
+			}
+		}
+	}
+	return paths
+}
+
+func cursorStorePathIsValid(chatsRoot, storePath string) bool {
+	info, err := os.Stat(storePath)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(chatsRoot)
+	if err != nil {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(storePath)
+	return err == nil && isContainedIn(resolved, resolvedRoot)
+}
+
+func cursorStoreAgentIDFromPath(path string) (string, bool) {
+	base := filepath.Base(path)
+	switch base {
+	case "store.db", "store.db-wal":
+		agentID := filepath.Base(filepath.Dir(path))
+		if IsValidSessionID(agentID) {
+			return agentID, true
+		}
+	}
+	return "", false
+}
+
+func cursorRawIDFromTranscriptPath(path string) string {
+	id := CursorSessionID(path)
+	return strings.TrimPrefix(id, "cursor:")
+}

--- a/internal/parser/cursor_store.go
+++ b/internal/parser/cursor_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,6 +22,8 @@ type cursorStoreReadStats struct {
 	Reachable        int
 	DecodedTurns     int
 }
+
+var cursorStoreReadDir = os.ReadDir
 
 type cursorStoreTurn struct {
 	UserDecoded      bool
@@ -112,15 +115,19 @@ func (i *cursorStoreIndex) initialized(chatsRoot string) bool {
 	return ok
 }
 
-func (i *cursorStoreIndex) refresh(chatsRoot string) {
+func (i *cursorStoreIndex) refresh(chatsRoot string) error {
 	if i == nil || chatsRoot == "" {
-		return
+		return nil
 	}
 	key := filepath.Clean(chatsRoot)
-	paths := cursorStorePathsUnderChats(key)
+	paths, err := cursorStorePathsUnderChats(key)
+	if err != nil {
+		return err
+	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.roots[key] = paths
+	return nil
 }
 
 func (i *cursorStoreIndex) validPath(
@@ -680,22 +687,33 @@ func cursorStoreTranscriptPair(
 	return 0, 0, false
 }
 
-func cursorStorePathsUnderChats(chatsRoot string) map[string]string {
+func cursorStorePathsUnderChats(chatsRoot string) (map[string]string, error) {
 	paths := make(map[string]string)
 	if chatsRoot == "" {
-		return paths
+		return paths, nil
 	}
-	entries, err := os.ReadDir(chatsRoot)
+	entries, err := cursorStoreReadDir(chatsRoot)
 	if err != nil {
-		return paths
+		if errors.Is(err, os.ErrNotExist) {
+			return paths, nil
+		}
+		return nil, fmt.Errorf("read Cursor chats root %s: %w", chatsRoot, err)
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
 			continue
 		}
-		agentDirs, readErr := os.ReadDir(filepath.Join(chatsRoot, entry.Name()))
+		agentDirs, readErr := cursorStoreReadDir(
+			filepath.Join(chatsRoot, entry.Name()),
+		)
 		if readErr != nil {
-			continue
+			if errors.Is(readErr, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf(
+				"read Cursor workspace %s: %w",
+				filepath.Join(chatsRoot, entry.Name()), readErr,
+			)
 		}
 		for _, agentEntry := range agentDirs {
 			if !agentEntry.IsDir() || !IsValidSessionID(agentEntry.Name()) {
@@ -709,7 +727,7 @@ func cursorStorePathsUnderChats(chatsRoot string) map[string]string {
 			}
 		}
 	}
-	return paths
+	return paths, nil
 }
 
 func cursorStorePathIsValid(chatsRoot, storePath string) bool {

--- a/internal/parser/cursor_store.go
+++ b/internal/parser/cursor_store.go
@@ -162,6 +162,10 @@ func (i *cursorStoreIndex) remember(chatsRoot, agentID, storePath string) {
 	}
 	valid, err := cursorStorePathIsValid(key, storePath)
 	if err != nil {
+		// Let subsequent lookups retry validation of newly observed stores.
+		if paths[agentID] == "" {
+			paths[agentID] = storePath
+		}
 		return
 	}
 	if !valid {
@@ -206,13 +210,23 @@ func readCursorStoreTurns(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var tables int
-	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_schema
-		WHERE type = 'table' AND name IN ('meta', 'blobs')`).Scan(&tables); err != nil {
+	var tables, metaColumns, blobColumns int
+	if err := tx.QueryRowContext(ctx, `SELECT
+		(SELECT count(*) FROM sqlite_schema
+			WHERE type = 'table' AND name IN ('meta', 'blobs')),
+		(SELECT count(*) FROM pragma_table_info('meta')
+			WHERE name COLLATE NOCASE IN ('key', 'value')),
+		(SELECT count(*) FROM pragma_table_info('blobs')
+			WHERE name COLLATE NOCASE IN ('id', 'data'))`).Scan(
+		&tables, &metaColumns, &blobColumns,
+	); err != nil {
 		return nil, fmt.Errorf("cursor store: reading schema: %w", err)
 	}
 	if tables != 2 {
 		return nil, fmt.Errorf("%w: missing meta or blobs table", errCursorStoreFormat)
+	}
+	if metaColumns != 2 || blobColumns != 2 {
+		return nil, fmt.Errorf("%w: missing required meta or blobs columns", errCursorStoreFormat)
 	}
 
 	meta, err := loadCursorStoreMeta(ctx, tx, agentID)

--- a/internal/parser/cursor_store.go
+++ b/internal/parser/cursor_store.go
@@ -85,16 +85,16 @@ func (i *cursorStoreIndex) transcriptPath(root, agentID string) string {
 	return path
 }
 
-func (i *cursorStoreIndex) path(chatsRoot, agentID string) string {
+func (i *cursorStoreIndex) path(chatsRoot, agentID string) (string, error) {
 	if i == nil {
-		return ""
+		return "", nil
 	}
 	key := filepath.Clean(chatsRoot)
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	paths, ok := i.roots[key]
 	if !ok {
-		return ""
+		return "", nil
 	}
 	return i.validPath(key, paths, agentID)
 }
@@ -132,13 +132,20 @@ func (i *cursorStoreIndex) refresh(chatsRoot string) {
 
 func (i *cursorStoreIndex) validPath(
 	chatsRoot string, paths map[string]string, agentID string,
-) string {
+) (string, error) {
 	path := paths[agentID]
-	if path != "" && !cursorStorePathIsValid(chatsRoot, path) {
-		delete(paths, agentID)
-		return ""
+	if path == "" {
+		return "", nil
 	}
-	return path
+	valid, err := cursorStorePathIsValid(chatsRoot, path)
+	if err != nil {
+		return path, fmt.Errorf("validate Cursor store %s: %w", path, err)
+	}
+	if !valid {
+		delete(paths, agentID)
+		return "", nil
+	}
+	return path, nil
 }
 
 func (i *cursorStoreIndex) remember(chatsRoot, agentID, storePath string) {
@@ -153,7 +160,11 @@ func (i *cursorStoreIndex) remember(chatsRoot, agentID, storePath string) {
 		paths = make(map[string]string)
 		i.roots[key] = paths
 	}
-	if storePath == "" || !cursorStorePathIsValid(key, storePath) {
+	valid, err := cursorStorePathIsValid(key, storePath)
+	if err != nil {
+		return
+	}
+	if !valid {
 		delete(paths, agentID)
 		return
 	}
@@ -194,6 +205,15 @@ func readCursorStoreTurns(
 		return nil, err
 	}
 	defer func() { _ = tx.Rollback() }()
+
+	var tables int
+	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM sqlite_schema
+		WHERE type = 'table' AND name IN ('meta', 'blobs')`).Scan(&tables); err != nil {
+		return nil, fmt.Errorf("cursor store: reading schema: %w", err)
+	}
+	if tables != 2 {
+		return nil, fmt.Errorf("%w: missing meta or blobs table", errCursorStoreFormat)
+	}
 
 	meta, err := loadCursorStoreMeta(ctx, tx, agentID)
 	if err != nil {
@@ -712,7 +732,11 @@ func cursorStorePathsUnderChats(chatsRoot string) (map[string]string, error) {
 			candidate := filepath.Join(
 				chatsRoot, entry.Name(), agentEntry.Name(), "store.db",
 			)
-			if cursorStorePathIsValid(chatsRoot, candidate) {
+			valid, err := cursorStorePathIsValid(chatsRoot, candidate)
+			if err != nil {
+				return nil, fmt.Errorf("validate Cursor store %s: %w", candidate, err)
+			}
+			if valid {
 				paths[agentEntry.Name()] = candidate
 			}
 		}
@@ -720,17 +744,34 @@ func cursorStorePathsUnderChats(chatsRoot string) (map[string]string, error) {
 	return paths, nil
 }
 
-func cursorStorePathIsValid(chatsRoot, storePath string) bool {
+// cursorStorePathIsValid distinguishes absent or invalid paths from access
+// failures, which must not discard a known store or mark it fresh.
+func cursorStorePathIsValid(chatsRoot, storePath string) (bool, error) {
 	info, err := os.Stat(storePath)
-	if err != nil || !info.Mode().IsRegular() {
-		return false
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() {
+		return false, nil
 	}
 	resolvedRoot, err := filepath.EvalSymlinks(chatsRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
 	if err != nil {
-		return false
+		return false, err
 	}
 	resolved, err := filepath.EvalSymlinks(storePath)
-	return err == nil && isContainedIn(resolved, resolvedRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return isContainedIn(resolved, resolvedRoot), nil
 }
 
 func cursorStoreAgentIDFromPath(path string) (string, bool) {

--- a/internal/parser/cursor_store_test.go
+++ b/internal/parser/cursor_store_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1063,30 +1064,58 @@ func TestCursorStoreDoesNotDiscoverStoreOnlySession(t *testing.T) {
 }
 
 func TestCursorStoreResolveMetadataDir(t *testing.T) {
-	home := t.TempDir()
-	projects := filepath.Join(home, ".cursor", "projects")
-	chats := filepath.Join(home, ".cursor", "chats")
-	require.NoError(t, os.MkdirAll(projects, 0o755))
-	require.NoError(t, os.MkdirAll(chats, 0o755))
-	factory, ok := ProviderFactoryByType(AgentCursor)
-	require.True(t, ok)
-	resolver, ok := factory.(interface {
-		ResolveMetadataDir(string) (string, error)
+	for _, tt := range []struct {
+		root      string
+		wantChats bool
+	}{
+		{root: ".cursor/projects", wantChats: true},
+		{root: ".cursor/archive"},
+		{root: "other/projects"},
+		{root: ".cursor/Projects", wantChats: runtime.GOOS == "windows"},
+		{root: ".Cursor/projects", wantChats: runtime.GOOS == "windows"},
+	} {
+		t.Run(tt.root, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), filepath.FromSlash(tt.root))
+			chats := filepath.Join(filepath.Dir(root), "chats")
+			require.NoError(t, os.MkdirAll(root, 0o755))
+			require.NoError(t, os.MkdirAll(chats, 0o755))
+			_, got, err := ResolveProviderRoot(AgentCursor, root)
+			require.NoError(t, err)
+			if !tt.wantChats {
+				assert.Empty(t, got)
+				return
+			}
+			want, err := filepath.EvalSymlinks(chats)
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestCursorStoreCustomRootKeepsTranscriptOnly(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	archive := filepath.Join(filepath.Dir(fx.ProjectsRoot), "archive")
+	require.NoError(t, os.Rename(fx.ProjectsRoot, archive))
+	root, metadata, err := ResolveProviderRoot(AgentCursor, archive)
+	require.NoError(t, err)
+	provider, ok := NewProvider(AgentCursor, ProviderConfig{
+		Roots: []string{root},
+		MetadataDirs: map[string][]string{
+			root: {metadata},
+		},
 	})
 	require.True(t, ok)
-	got, err := resolver.ResolveMetadataDir(projects)
+	sources, err := provider.Discover(t.Context())
 	require.NoError(t, err)
-	want, err := filepath.EvalSymlinks(chats)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(t.Context(), ParseRequest{Source: sources[0]})
 	require.NoError(t, err)
-	got, err = filepath.EvalSymlinks(got)
-	require.NoError(t, err)
-	assert.Equal(t, want, got)
-
-	unrelated := filepath.Join(home, "other")
-	require.NoError(t, os.MkdirAll(unrelated, 0o755))
-	empty, err := resolver.ResolveMetadataDir(unrelated)
-	require.NoError(t, err)
-	assert.Empty(t, empty)
+	require.Empty(t, outcome.SourceErrors)
+	require.Len(t, outcome.Results, 1)
+	require.Len(t, outcome.Results[0].Result.Messages, 2)
+	assistant := outcome.Results[0].Result.Messages[1]
+	assert.Equal(t, "I'm Auto, an agent router designed by Cursor.", assistant.Content)
+	assert.Empty(t, assistant.ThinkingText)
 }
 
 func TestCursorStoreFingerprintTracksWAL(t *testing.T) {

--- a/internal/parser/cursor_store_test.go
+++ b/internal/parser/cursor_store_test.go
@@ -410,6 +410,32 @@ func TestCursorStoreMalformedMetaKeepsTranscript(t *testing.T) {
 	assertCursorStoreTranscriptOnly(t, outcome)
 }
 
+func TestCursorStoreMissingTableKeepsTranscript(t *testing.T) {
+	for _, missing := range []string{"meta", "blobs"} {
+		t.Run(missing, func(t *testing.T) {
+			fx := setupCursorStoreFixture(t, false)
+			// Replace the fixture with a readable but unsupported store schema.
+			require.NoError(t, os.Remove(fx.StorePath))
+			store, err := sql.Open("sqlite3", fx.StorePath)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = store.Close() })
+			if missing == "meta" {
+				_, err = store.Exec(`CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)`)
+				require.NoError(t, err)
+			} else {
+				_, err = store.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)`)
+				require.NoError(t, err)
+				writeCursorStoreMeta(t, store, cursorStoreTestAgentID, fx.RootID)
+			}
+			require.NoError(t, store.Close())
+
+			outcome, err := fx.Provider.Parse(t.Context(), ParseRequest{Source: fx.Source})
+			require.NoError(t, err)
+			assertCursorStoreTranscriptOnly(t, outcome)
+		})
+	}
+}
+
 func TestCursorStoreMissingMetadataKeepsTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, true)
 	_, err := fx.Writer.Exec(`DELETE FROM meta WHERE key = '0'`)
@@ -567,6 +593,58 @@ func TestCursorStoreUnreadableMatchingStoreReturnsError(t *testing.T) {
 	assert.True(t, outcome.ResultSetComplete)
 	assert.True(t, outcome.SourceErrors[0].Retryable)
 	assert.Contains(t, outcome.SourceErrors[0].Err.Error(), "cursor store")
+}
+
+func TestCursorStoreAccessFailureKeepsEnrichmentRetryable(t *testing.T) {
+	for _, target := range []string{"store", "session directory"} {
+		t.Run(target, func(t *testing.T) {
+			fx := setupCursorStoreFixture(t, false)
+			path := fx.StorePath
+			if target == "session directory" {
+				path = filepath.Dir(path)
+			}
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			require.NoError(t, os.Chmod(path, 0))
+			t.Cleanup(func() { require.NoError(t, os.Chmod(path, info.Mode().Perm())) })
+			if file, err := os.Open(fx.StorePath); err == nil {
+				require.NoError(t, file.Close())
+				t.Skip("filesystem permissions are not enforced")
+			}
+
+			for _, operation := range []string{"cached lookup", "discovery refresh", "store event"} {
+				switch operation {
+				case "discovery refresh":
+					sources, err := fx.Provider.Discover(t.Context())
+					require.NoError(t, err)
+					require.Len(t, sources, 1)
+				case "store event":
+					sources, err := fx.Provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+						Path: fx.StorePath, EventKind: "write", WatchRoot: fx.ChatsRoot,
+					})
+					require.NoError(t, err)
+					require.Len(t, sources, 1)
+				}
+				_, err := fx.Provider.Fingerprint(t.Context(), fx.Source)
+				assert.ErrorIs(t, err, os.ErrPermission, operation)
+				outcome, err := fx.Provider.Parse(t.Context(), ParseRequest{Source: fx.Source})
+				require.NoError(t, err)
+				assert.Empty(t, outcome.Results, operation)
+				require.Len(t, outcome.SourceErrors, 1, operation)
+				assert.True(t, outcome.SourceErrors[0].Retryable, operation)
+			}
+
+			require.NoError(t, os.Chmod(path, info.Mode().Perm()))
+			outcome, err := fx.Provider.Parse(t.Context(), ParseRequest{Source: fx.Source})
+			require.NoError(t, err)
+			require.Empty(t, outcome.SourceErrors)
+			require.Len(t, outcome.Results, 1)
+			require.Len(t, outcome.Results[0].Result.Messages, 2)
+			assert.Contains(t, outcome.Results[0].Result.Messages[1].ThinkingText, "asking who I am")
+			_, err = fx.Provider.Fingerprint(t.Context(), fx.Source)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestCursorStoreEnrichesSourceWithoutOpaque(t *testing.T) {
@@ -904,7 +982,8 @@ func TestCursorStoreIndexKeepsSiblingStoresVisible(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
 	otherAgentID := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 	provider := fx.Provider.(*cursorProvider)
-	path := provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
+	path, err := provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
+	require.NoError(t, err)
 	assert.Empty(t, path)
 	otherStore := filepath.Join(
 		fx.ChatsRoot, "deadbeefdeadbeefdeadbeefdeadbeef", otherAgentID, "store.db",
@@ -913,7 +992,8 @@ func TestCursorStoreIndexKeepsSiblingStoresVisible(t *testing.T) {
 	require.NoError(t, os.WriteFile(otherStore, []byte("store"), 0o644))
 	provider.sources.storeIndex.refresh(fx.ChatsRoot)
 
-	path = provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
+	path, err = provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
+	require.NoError(t, err)
 	assert.Equal(t, otherStore, path)
 }
 

--- a/internal/parser/cursor_store_test.go
+++ b/internal/parser/cursor_store_test.go
@@ -1,0 +1,1003 @@
+package parser
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json/v2"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	cursorStoreTestAgentID = "ac2369fb-93cd-4e41-9df4-65dac43045c5"
+	cursorStoreTestUserMS  = uint64(1788818588927)
+	cursorStoreTestAsstMS  = uint64(1788818591931)
+	cursorStoreTestThinkMS = uint64(1788818591930)
+)
+
+type cursorStoreFixture struct {
+	ProjectsRoot string
+	ChatsRoot    string
+	Transcript   string
+	StorePath    string
+	RootID       string
+	Writer       *sql.DB
+	Provider     Provider
+	Source       SourceRef
+}
+
+func cursorStoreBlobRef(id string) []byte {
+	b, err := hex.DecodeString(id)
+	if err != nil || len(b) != 32 {
+		panic("cursor store test blob id must be 64 hex chars")
+	}
+	return b
+}
+
+func cursorStoreHashID(parts ...string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(h[:])
+}
+
+func cursorStoreEncodeUser(text string, ms uint64) []byte {
+	return encodePB([]pbField{
+		{num: 1, wire: pbWireBytes, bytes: []byte(text)},
+		{num: 2, wire: pbWireBytes, bytes: []byte("3a4f6ea0-cec3-4164-9224-53337c595581")},
+		{num: 4, wire: pbWireVarint, varint: 1},
+		{num: 25, wire: pbWireVarint, varint: ms},
+		{num: 26, wire: pbWireVarint, varint: ms},
+	})
+}
+
+func cursorStoreEncodeReasoning(text string, ms uint64) []byte {
+	inner := encodePB([]pbField{
+		{num: 1, wire: pbWireBytes, bytes: []byte(text)},
+		{num: 2, wire: pbWireVarint, varint: 1439},
+		{num: 3, wire: pbWireVarint, varint: ms - 1000},
+		{num: 4, wire: pbWireVarint, varint: ms},
+	})
+	return encodePB([]pbField{
+		{num: 3, wire: pbWireBytes, bytes: inner},
+	})
+}
+
+func cursorStoreEncodeAssistant(text string, ms uint64) []byte {
+	inner := encodePB([]pbField{
+		{num: 1, wire: pbWireBytes, bytes: []byte(text)},
+		{num: 2, wire: pbWireVarint, varint: ms},
+	})
+	return encodePB([]pbField{
+		{num: 1, wire: pbWireBytes, bytes: inner},
+	})
+}
+
+func cursorStoreEncodeTurn(userID, reasoningID, assistantID string) []byte {
+	fields := []pbField{
+		{num: 1, wire: pbWireBytes, bytes: cursorStoreBlobRef(userID)},
+	}
+	if reasoningID != "" {
+		fields = append(fields, pbField{
+			num: 2, wire: pbWireBytes, bytes: cursorStoreBlobRef(reasoningID),
+		})
+	}
+	if assistantID != "" {
+		fields = append(fields, pbField{
+			num: 2, wire: pbWireBytes, bytes: cursorStoreBlobRef(assistantID),
+		})
+	}
+	fields = append(fields,
+		pbField{num: 3, wire: pbWireBytes, bytes: []byte("6a670ffe-168a-4a4e-b2e3-bcf1ad472814")},
+		pbField{num: 5, wire: pbWireVarint, varint: 3},
+	)
+	return encodePB(fields)
+}
+
+func cursorStoreEncodeTurnIndex(turnBlobIDs ...string) []byte {
+	var fields []pbField
+	for _, id := range turnBlobIDs {
+		fields = append(fields, pbField{
+			num: 1, wire: pbWireBytes, bytes: cursorStoreBlobRef(id),
+		})
+	}
+	return encodePB(fields)
+}
+
+func cursorStoreEncodeRoot(turnIndexID string, extra ...pbField) []byte {
+	fields := []pbField{
+		{num: 8, wire: pbWireBytes, bytes: cursorStoreBlobRef(turnIndexID)},
+		{num: 9, wire: pbWireBytes, bytes: []byte("file:///workspace")},
+		{num: 22, wire: pbWireBytes, bytes: []byte("cli")},
+		{num: 26, wire: pbWireVarint, varint: cursorStoreTestUserMS},
+	}
+	fields = append(fields, extra...)
+	return encodePB(fields)
+}
+
+func writeCursorStoreMeta(t *testing.T, db *sql.DB, agentID, rootID string) {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"agentId":          agentID,
+		"latestRootBlobId": rootID,
+		"name":             "Composer Model",
+		"mode":             "default",
+	})
+	require.NoError(t, err)
+	_, err = db.Exec(
+		`INSERT INTO meta(key, value) VALUES(?, ?)`,
+		"0", hex.EncodeToString(payload),
+	)
+	require.NoError(t, err)
+}
+
+func writeCursorStoreBlob(t *testing.T, db *sql.DB, id string, data []byte) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO blobs(id, data) VALUES(?, ?)`, id, data)
+	require.NoError(t, err)
+}
+
+func openCursorStoreWriter(t *testing.T, storePath string) *sql.DB {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(storePath), 0o755))
+	db, err := sql.Open("sqlite3", storePath+"?_journal_mode=WAL&_busy_timeout=3000")
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA journal_mode=WAL`)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)`)
+	require.NoError(t, err)
+	return db
+}
+
+func cursorStoreTranscriptJSONL(user, assistant string) string {
+	return strings.Join([]string{
+		fmt.Sprintf(
+			`{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\n%s\n</user_query>"}]}}`,
+			user,
+		),
+		fmt.Sprintf(
+			`{"role":"assistant","message":{"content":[{"type":"text","text":%q}]}}`,
+			assistant,
+		),
+		`{"type":"turn_ended","status":"success"}`,
+	}, "\n") + "\n"
+}
+
+func setupCursorStoreFixture(t *testing.T, keepWriterOpen bool) cursorStoreFixture {
+	t.Helper()
+	home := t.TempDir()
+	projects := filepath.Join(home, ".cursor", "projects")
+	chats := filepath.Join(home, ".cursor", "chats")
+	projectDir := "Users-demo-Code-app"
+	agentID := cursorStoreTestAgentID
+	transcriptDir := filepath.Join(projects, projectDir, "agent-transcripts", agentID)
+	require.NoError(t, os.MkdirAll(transcriptDir, 0o755))
+	transcript := filepath.Join(transcriptDir, agentID+".jsonl")
+	userText := "is this composer? what model is this?"
+	assistantText := "I'm Auto, an agent router designed by Cursor."
+	require.NoError(t, os.WriteFile(
+		transcript,
+		[]byte(cursorStoreTranscriptJSONL(userText, assistantText)),
+		0o644,
+	))
+
+	wsHash := "ac6bc72e07173e02c3524eb823d07ad5"
+	storePath := filepath.Join(chats, wsHash, agentID, "store.db")
+	writer := openCursorStoreWriter(t, storePath)
+
+	userID := cursorStoreHashID("user", userText)
+	reasoningID := cursorStoreHashID("reasoning", "think")
+	assistantID := cursorStoreHashID("assistant", assistantText)
+	turnID := cursorStoreHashID("turn", userID, reasoningID, assistantID)
+	turnIndexID := cursorStoreHashID("turn-index", turnID)
+	rootID := cursorStoreHashID("root", turnIndexID)
+	orphanRootID := cursorStoreHashID("orphan-root")
+
+	writeCursorStoreBlob(t, writer, userID, cursorStoreEncodeUser(userText, cursorStoreTestUserMS))
+	writeCursorStoreBlob(t, writer, reasoningID, cursorStoreEncodeReasoning(
+		"The user is asking who I am and what model I am.", cursorStoreTestThinkMS,
+	))
+	writeCursorStoreBlob(t, writer, assistantID, cursorStoreEncodeAssistant(
+		assistantText, cursorStoreTestAsstMS,
+	))
+	writeCursorStoreBlob(t, writer, turnID, cursorStoreEncodeTurn(userID, reasoningID, assistantID))
+	writeCursorStoreBlob(t, writer, turnIndexID, cursorStoreEncodeTurnIndex(turnID))
+	writeCursorStoreBlob(t, writer, rootID, cursorStoreEncodeRoot(turnIndexID))
+	// Superseded root carries a different assistant message that must not surface.
+	orphanUser := cursorStoreHashID("orphan-user")
+	orphanAsst := cursorStoreHashID("orphan-asst")
+	orphanTurn := cursorStoreHashID("orphan-turn")
+	orphanIndex := cursorStoreHashID("orphan-index")
+	writeCursorStoreBlob(t, writer, orphanUser, cursorStoreEncodeUser("stale prompt", cursorStoreTestUserMS))
+	writeCursorStoreBlob(t, writer, orphanAsst, cursorStoreEncodeAssistant(
+		"STALE ROOT CONTENT MUST NOT APPEAR", cursorStoreTestAsstMS,
+	))
+	writeCursorStoreBlob(t, writer, orphanTurn, cursorStoreEncodeTurn(orphanUser, "", orphanAsst))
+	writeCursorStoreBlob(t, writer, orphanIndex, cursorStoreEncodeTurnIndex(orphanTurn))
+	writeCursorStoreBlob(t, writer, orphanRootID, cursorStoreEncodeRoot(orphanIndex))
+	writeCursorStoreMeta(t, writer, agentID, rootID)
+
+	if !keepWriterOpen {
+		require.NoError(t, writer.Close())
+		writer = nil
+	} else {
+		t.Cleanup(func() { _ = writer.Close() })
+	}
+
+	provider, ok := NewProvider(AgentCursor, ProviderConfig{
+		Roots:   []string{projects},
+		Machine: "devbox",
+		MetadataDirs: map[string][]string{
+			filepath.Clean(projects): {filepath.Clean(chats)},
+		},
+	})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	return cursorStoreFixture{
+		ProjectsRoot: projects,
+		ChatsRoot:    chats,
+		Transcript:   transcript,
+		StorePath:    storePath,
+		RootID:       rootID,
+		Writer:       writer,
+		Provider:     provider,
+		Source:       sources[0],
+	}
+}
+
+func TestCursorStoreParsesRowsHeldOnlyInWAL(t *testing.T) {
+	fx := setupCursorStoreFixture(t, true)
+	info, err := os.Stat(fx.StorePath)
+	require.NoError(t, err)
+	walInfo, err := os.Stat(fx.StorePath + "-wal")
+	require.NoError(t, err)
+	t.Logf("latestRootBlobId=%s main_size=%d wal_size=%d", fx.RootID, info.Size(), walInfo.Size())
+	assert.Positive(t, walInfo.Size())
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	msgs := outcome.Results[0].Result.Messages
+	require.Len(t, msgs, 2)
+	assert.True(t, msgs[1].HasThinking)
+	assert.Contains(t, msgs[1].ThinkingText, "asking who I am")
+	assert.Equal(t, "cursor:"+cursorStoreTestAgentID, outcome.Results[0].Result.Session.ID)
+}
+
+func TestCursorStoreTraversesOnlyLatestRootBlobId(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	raw, err := json.Marshal(outcome.Results[0].Result.Messages)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "STALE ROOT CONTENT MUST NOT APPEAR")
+	assert.Contains(t, outcome.Results[0].Result.Messages[1].Content, "Auto")
+}
+
+func TestCursorStoreEnrichesExistingTranscript(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+	discovered, err := fx.Provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, fx.Transcript, discovered[0].DisplayPath)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0].Result
+	assert.Equal(t, "cursor:"+cursorStoreTestAgentID, result.Session.ID)
+	require.Len(t, result.Messages, 2)
+	assert.Equal(t, RoleUser, result.Messages[0].Role)
+	assert.Equal(t, RoleAssistant, result.Messages[1].Role)
+	assert.True(t, result.Messages[1].HasThinking)
+	assert.Equal(
+		t,
+		time.UnixMilli(int64(cursorStoreTestUserMS)).UTC(),
+		result.Messages[0].Timestamp.UTC(),
+	)
+	assert.Equal(
+		t,
+		time.UnixMilli(int64(cursorStoreTestAsstMS)).UTC(),
+		result.Messages[1].Timestamp.UTC(),
+	)
+	assert.Empty(t, result.Session.SourceVersion)
+}
+
+func TestCursorStoreUsesTurnIndexProjection(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	msgs := outcome.Results[0].Result.Messages
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "is this composer? what model is this?", msgs[0].Content)
+	assert.Contains(t, msgs[1].Content, "Auto")
+	assert.Contains(t, msgs[1].ThinkingText, "asking who I am")
+	assert.Equal(t, 2, outcome.Results[0].Result.Session.MessageCount)
+	joined := msgs[0].Content + msgs[1].Content + msgs[1].ThinkingText
+	assert.NotContains(t, joined, `"role":"system"`)
+	assert.NotContains(t, strings.ToLower(joined), "model-context")
+}
+
+func TestCursorStoreSkipsUndecodableBlobWithoutDroppingSiblings(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	db, err := sql.Open("sqlite3", fx.StorePath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	userText := "is this composer? what model is this?"
+	assistantText := "I'm Auto, an agent router designed by Cursor."
+	userID := cursorStoreHashID("user", userText)
+	reasoningID := cursorStoreHashID("reasoning", "think")
+	assistantID := cursorStoreHashID("assistant", assistantText)
+	junkID := cursorStoreHashID("junk-undecodable")
+	writeCursorStoreBlob(t, db, junkID, []byte{0xff, 0x00, 0x01, 0x02, 0x03})
+
+	turnID := cursorStoreHashID("turn", userID, reasoningID, assistantID)
+	turnData := encodePB([]pbField{
+		{num: 1, wire: pbWireBytes, bytes: cursorStoreBlobRef(userID)},
+		{num: 2, wire: pbWireBytes, bytes: cursorStoreBlobRef(reasoningID)},
+		{num: 2, wire: pbWireBytes, bytes: cursorStoreBlobRef(junkID)},
+		{num: 2, wire: pbWireBytes, bytes: cursorStoreBlobRef(assistantID)},
+		{num: 3, wire: pbWireBytes, bytes: []byte("6a670ffe-168a-4a4e-b2e3-bcf1ad472814")},
+		{num: 5, wire: pbWireVarint, varint: 3},
+	})
+	_, err = db.Exec(`UPDATE blobs SET data = ? WHERE id = ?`, turnData, turnID)
+	require.NoError(t, err)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results[0].Result.Messages, 2)
+	assert.True(t, outcome.Results[0].Result.Messages[1].HasThinking)
+	assert.Contains(t, outcome.Results[0].Result.Messages[1].Content, "Auto")
+}
+
+func TestCursorStoreResolvesInline32ByteMessage(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	db, err := openCursorIDEDB(fx.StorePath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	text := strings.Repeat("i", 28)
+	message := encodePB([]pbField{{num: 1, wire: pbWireBytes, bytes: []byte(text)}})
+	payload := encodePB([]pbField{{num: 1, wire: pbWireBytes, bytes: message}})
+	require.Len(t, payload, 32)
+	loader := newCursorStoreBlobLoader(
+		context.Background(), db, &cursorStoreReadStats{},
+	)
+	resolved, ok := cursorStoreResolveMessage(agProtoField{
+		Wire: pbWireBytes, Bytes: payload,
+	}, loader)
+	require.True(t, ok)
+	_, _, ok = decodeCursorStoreAssistantMessage(resolved)
+	t.Logf("latestRootBlobId=%s inline_payload_bytes=%d", fx.RootID, len(payload))
+	assert.True(t, ok)
+}
+
+func TestCursorStoreMalformedMetaReturnsError(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	db, err := sql.Open("sqlite3", fx.StorePath)
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec(`UPDATE meta SET value = ? WHERE key = '0'`, "not-hex")
+	require.NoError(t, err)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	require.Len(t, outcome.SourceErrors, 1)
+	assert.Contains(t, outcome.SourceErrors[0].Err.Error(), "metadata")
+}
+
+func TestCursorStoreMissingMetadataReturnsError(t *testing.T) {
+	fx := setupCursorStoreFixture(t, true)
+	_, err := fx.Writer.Exec(`DELETE FROM meta WHERE key = '0'`)
+	require.NoError(t, err)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	require.Len(t, outcome.SourceErrors, 1)
+	t.Logf("latestRootBlobId=%s metadata_case=missing error=%q", fx.RootID, outcome.SourceErrors[0].Err.Error())
+}
+
+func TestCursorStoreIncompleteMetadataReturnsError(t *testing.T) {
+	fx := setupCursorStoreFixture(t, true)
+	payload, err := json.Marshal(map[string]any{
+		"agentId": cursorStoreTestAgentID,
+	})
+	require.NoError(t, err)
+	_, err = fx.Writer.Exec(
+		`UPDATE meta SET value = ? WHERE key = '0'`,
+		hex.EncodeToString(payload),
+	)
+	require.NoError(t, err)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	require.Len(t, outcome.SourceErrors, 1)
+	t.Logf("latestRootBlobId=%s metadata_case=incomplete error=%q", fx.RootID, outcome.SourceErrors[0].Err.Error())
+}
+
+func TestCursorStoreMetadataAgentMismatchReturnsError(t *testing.T) {
+	fx := setupCursorStoreFixture(t, true)
+	payload, err := json.Marshal(map[string]any{
+		"agentId":          "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+		"latestRootBlobId": fx.RootID,
+	})
+	require.NoError(t, err)
+	_, err = fx.Writer.Exec(
+		`UPDATE meta SET value = ? WHERE key = '0'`,
+		hex.EncodeToString(payload),
+	)
+	require.NoError(t, err)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	require.Len(t, outcome.SourceErrors, 1)
+	t.Logf("latestRootBlobId=%s metadata_case=agent_mismatch error=%q", fx.RootID, outcome.SourceErrors[0].Err.Error())
+}
+
+func TestCursorStoreMissingSelectedRootReturnsError(t *testing.T) {
+	fx := setupCursorStoreFixture(t, true)
+	missingRoot := strings.Repeat("f", 64)
+	payload, err := json.Marshal(map[string]any{
+		"agentId":          cursorStoreTestAgentID,
+		"latestRootBlobId": missingRoot,
+	})
+	require.NoError(t, err)
+	_, err = fx.Writer.Exec(
+		`UPDATE meta SET value = ? WHERE key = '0'`,
+		hex.EncodeToString(payload),
+	)
+	require.NoError(t, err)
+	t.Logf("latestRootBlobId=%s", missingRoot)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	require.Len(t, outcome.SourceErrors, 1)
+	assert.Contains(t, outcome.SourceErrors[0].Err.Error(), "missing selected root")
+}
+
+func TestCursorStoreUnreadableMatchingStoreReturnsError(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	require.NoError(t, os.WriteFile(fx.StorePath, []byte("not a sqlite database"), 0o644))
+	for _, suffix := range []string{"-wal", "-shm"} {
+		_ = os.Remove(fx.StorePath + suffix)
+	}
+	t.Logf("latestRootBlobId=%s unreadable_store=true", fx.RootID)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	require.Len(t, outcome.SourceErrors, 1)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.True(t, outcome.SourceErrors[0].Retryable)
+	assert.Contains(t, outcome.SourceErrors[0].Err.Error(), "cursor store")
+	t.Log("store_error=cursor_store_unreadable")
+}
+
+func TestCursorStoreEnrichesSourceWithoutOpaque(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	source := fx.Source
+	source.Opaque = nil
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Empty(t, outcome.SourceErrors)
+	assert.True(t, outcome.Results[0].Result.Messages[1].HasThinking)
+}
+
+func TestCursorStoreEnrichesTargetedLookupWithoutDiscovery(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	provider, ok := NewProvider(AgentCursor, ProviderConfig{
+		Roots: []string{fx.ProjectsRoot},
+		MetadataDirs: map[string][]string{
+			filepath.Clean(fx.ProjectsRoot): {filepath.Clean(fx.ChatsRoot)},
+		},
+	})
+	require.True(t, ok)
+
+	source, found, err := provider.FindSource(context.Background(), FindSourceRequest{
+		StoredFilePath: fx.Transcript,
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	fingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      source,
+		Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.True(t, outcome.Results[0].Result.Messages[1].HasThinking)
+}
+
+func TestCursorStoreSkipsTurnWithoutUserToPreserveAlignment(t *testing.T) {
+	firstAssistant := time.UnixMilli(1_788_818_602_000).UTC()
+	secondUser := time.UnixMilli(1_788_818_603_000).UTC()
+	secondAssistant := time.UnixMilli(1_788_818_604_000).UTC()
+	msgs := []ParsedMessage{
+		{Role: RoleUser, Content: "first question"},
+		{Role: RoleAssistant, Content: "first answer"},
+		{Role: RoleUser, Content: "second question"},
+		{Role: RoleAssistant, Content: "second answer"},
+	}
+	sess := ParsedSession{}
+	applyCursorStoreTurns(&sess, msgs, []cursorStoreTurn{
+		{
+			AssistantTime: firstAssistant,
+			AssistantText: "first answer",
+			ReasoningText: "orphaned reasoning",
+			ReasoningTime: firstAssistant,
+		},
+		{
+			UserDecoded:      true,
+			AssistantDecoded: true,
+			UserText:         "second question",
+			AssistantText:    "second answer",
+			UserTime:         secondUser,
+			AssistantTime:    secondAssistant,
+			ReasoningText:    "aligned reasoning",
+			ReasoningTime:    secondAssistant,
+		},
+	})
+
+	assert.Empty(t, msgs[0].Timestamp)
+	assert.Empty(t, msgs[1].Timestamp)
+	assert.Empty(t, msgs[1].ThinkingText)
+	assert.Equal(t, secondUser, msgs[2].Timestamp)
+	assert.Equal(t, secondAssistant, msgs[3].Timestamp)
+	assert.Equal(t, "aligned reasoning", msgs[3].ThinkingText)
+	t.Log("latestRootBlobId=n/a missing_user_turn_skipped=true")
+}
+
+func TestCursorStoreSkipsTurnWithoutAssistantToPreserveAlignment(t *testing.T) {
+	firstUser := time.UnixMilli(1_788_818_601_000).UTC()
+	secondUser := time.UnixMilli(1_788_818_603_000).UTC()
+	secondAssistant := time.UnixMilli(1_788_818_604_000).UTC()
+	msgs := []ParsedMessage{
+		{Role: RoleUser, Content: "first question"},
+		{Role: RoleAssistant, Content: "first answer"},
+		{Role: RoleUser, Content: "second question"},
+		{Role: RoleAssistant, Content: "second answer"},
+	}
+	sess := ParsedSession{}
+	applyCursorStoreTurns(&sess, msgs, []cursorStoreTurn{
+		{
+			UserDecoded: true,
+			UserText:    "first question",
+			UserTime:    firstUser,
+		},
+		{
+			UserDecoded:      true,
+			AssistantDecoded: true,
+			UserText:         "second question",
+			AssistantText:    "second answer",
+			UserTime:         secondUser,
+			AssistantTime:    secondAssistant,
+			ReasoningText:    "aligned reasoning",
+			ReasoningTime:    secondAssistant,
+		},
+	})
+
+	assert.Empty(t, msgs[0].Timestamp)
+	assert.Empty(t, msgs[1].Timestamp)
+	assert.Empty(t, msgs[1].ThinkingText)
+	assert.Equal(t, secondUser, msgs[2].Timestamp)
+	assert.Equal(t, secondAssistant, msgs[3].Timestamp)
+	assert.Equal(t, "aligned reasoning", msgs[3].ThinkingText)
+	t.Log("latestRootBlobId=n/a missing_assistant_turn_skipped=true")
+}
+
+func TestCursorStoreLeavesLaterTurnUnmappedAfterUndecodableTurn(t *testing.T) {
+	msgs := []ParsedMessage{
+		{Role: RoleUser, Content: "first question"},
+		{Role: RoleAssistant, Content: "first answer"},
+		{Role: RoleUser, Content: "second question"},
+		{Role: RoleAssistant, Content: "second answer"},
+	}
+	sess := ParsedSession{}
+	applyCursorStoreTurns(&sess, msgs, []cursorStoreTurn{
+		{},
+		{
+			UserDecoded:      true,
+			AssistantDecoded: true,
+			UserText:         "second question",
+			AssistantText:    "second answer",
+			UserTime:         time.UnixMilli(1_788_818_603_000).UTC(),
+			AssistantTime:    time.UnixMilli(1_788_818_604_000).UTC(),
+			ReasoningText:    "ambiguous reasoning",
+		},
+	})
+
+	for _, msg := range msgs {
+		assert.Empty(t, msg.Timestamp)
+		assert.Empty(t, msg.ThinkingText)
+	}
+	t.Log("latestRootBlobId=n/a undecodable_turn_stops_alignment=true")
+}
+
+func TestCursorStoreMatchesFinalAssistantAfterIntermediateMessage(t *testing.T) {
+	msgs := []ParsedMessage{
+		{Role: RoleUser, Content: "first question"},
+		{Role: RoleAssistant, Content: "intermediate note"},
+		{Role: RoleAssistant, Content: "first answer"},
+		{Role: RoleUser, Content: "second question"},
+		{Role: RoleAssistant, Content: "second answer"},
+	}
+	sess := ParsedSession{}
+	applyCursorStoreTurns(&sess, msgs, []cursorStoreTurn{
+		{
+			UserDecoded:      true,
+			AssistantDecoded: true,
+			UserText:         "first question",
+			AssistantText:    "first answer",
+			ReasoningText:    "first reasoning",
+		},
+		{
+			UserDecoded:      true,
+			AssistantDecoded: true,
+			UserText:         "second question",
+			AssistantText:    "second answer",
+			ReasoningText:    "second reasoning",
+		},
+	})
+
+	assert.Empty(t, msgs[1].ThinkingText)
+	assert.Equal(t, "first reasoning", msgs[2].ThinkingText)
+	assert.Equal(t, "second reasoning", msgs[4].ThinkingText)
+	t.Log("latestRootBlobId=n/a intermediate_assistant_skipped=true")
+}
+
+func TestCursorStoreUsesProducerMillisecondTimes(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(fx.Transcript, old, old))
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	sess := outcome.Results[0].Result.Session
+	wantStart := time.UnixMilli(int64(cursorStoreTestUserMS)).UTC()
+	wantEnd := time.UnixMilli(int64(cursorStoreTestAsstMS)).UTC()
+	assert.Equal(t, wantStart, sess.StartedAt.UTC())
+	assert.Equal(t, wantEnd, sess.EndedAt.UTC())
+	assert.NotEqual(t, old.UTC().Truncate(time.Second), sess.StartedAt.UTC().Truncate(time.Second))
+}
+
+func TestCursorStorePartialTurnIndexRetainsTranscriptEndBound(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	secondTranscript := cursorStoreTranscriptJSONL(
+		"a later question", "a later answer",
+	)
+	require.NoError(t, os.WriteFile(
+		fx.Transcript,
+		[]byte(cursorStoreTranscriptJSONL(
+			"is this composer? what model is this?",
+			"I'm Auto, an agent router designed by Cursor.",
+		)+secondTranscript),
+		0o644,
+	))
+	transcriptTime := time.UnixMilli(int64(cursorStoreTestAsstMS) + 10_000).UTC()
+	require.NoError(t, os.Chtimes(fx.Transcript, transcriptTime, transcriptTime))
+	t.Logf("latestRootBlobId=%s transcript_end=%d", fx.RootID, transcriptTime.UnixMilli())
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	sess := outcome.Results[0].Result.Session
+	assert.Equal(t, transcriptTime, sess.EndedAt.UTC())
+	assert.GreaterOrEqual(t, sess.EndedAt.UnixMilli(), int64(cursorStoreTestAsstMS))
+}
+
+func TestCursorStoreExtraAssistantRetainsTranscriptEndBound(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	transcript := cursorStoreTranscriptJSONL(
+		"is this composer? what model is this?",
+		"I'm Auto, an agent router designed by Cursor.",
+	)
+	transcript += fmt.Sprintf(
+		`{"role":"assistant","message":{"content":[{"type":"text","text":%q}]}}`+"\n",
+		"a later assistant message",
+	)
+	require.NoError(t, os.WriteFile(fx.Transcript, []byte(transcript), 0o644))
+	transcriptTime := time.UnixMilli(int64(cursorStoreTestAsstMS) + 30_000).UTC()
+	require.NoError(t, os.Chtimes(fx.Transcript, transcriptTime, transcriptTime))
+	t.Logf("latestRootBlobId=%s transcript_end=%d", fx.RootID, transcriptTime.UnixMilli())
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, transcriptTime, outcome.Results[0].Result.Session.EndedAt.UTC())
+}
+
+func TestCursorStoreIncompleteTurnTimesRetainTranscriptEndBound(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	assistantID := cursorStoreHashID(
+		"assistant", "I'm Auto, an agent router designed by Cursor.",
+	)
+	db, err := sql.Open("sqlite3", fx.StorePath)
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec(
+		`UPDATE blobs SET data = ? WHERE id = ?`,
+		cursorStoreEncodeAssistant(
+			"I'm Auto, an agent router designed by Cursor.", 0,
+		), assistantID,
+	)
+	require.NoError(t, err)
+	transcriptTime := time.UnixMilli(int64(cursorStoreTestAsstMS) + 20_000).UTC()
+	require.NoError(t, os.Chtimes(fx.Transcript, transcriptTime, transcriptTime))
+	t.Logf("latestRootBlobId=%s transcript_end=%d", fx.RootID, transcriptTime.UnixMilli())
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, transcriptTime, outcome.Results[0].Result.Session.EndedAt.UTC())
+}
+
+func TestCursorStoreDoesNotTreatUntimedFieldThreeAsReasoning(t *testing.T) {
+	inner := encodePB([]pbField{{num: 1, wire: pbWireBytes, bytes: []byte("ambiguous")}})
+	fields, err := agProtoParse(encodePB([]pbField{{
+		num: 3, wire: pbWireBytes, bytes: inner,
+	}}))
+	require.NoError(t, err)
+	text, _, ok := decodeCursorStoreReasoning(fields)
+	t.Log("latestRootBlobId=n/a field=3 untimed=true")
+	assert.False(t, ok)
+	assert.Empty(t, text)
+}
+
+func TestCursorStoreWatchPlanIncludesWAL(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	plan, err := fx.Provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 2)
+	var chatsRoot WatchRoot
+	found := false
+	for _, root := range plan.Roots {
+		if samePath(root.Path, fx.ChatsRoot) {
+			chatsRoot = root
+			found = true
+		}
+	}
+	require.True(t, found)
+	assert.ElementsMatch(t, []string{"store.db", "store.db-wal"}, chatsRoot.IncludeGlobs)
+	assert.NotContains(t, chatsRoot.IncludeGlobs, "store.db-shm")
+	changed, err := fx.Provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: fx.StorePath + "-shm", EventKind: "write", WatchRoot: fx.ChatsRoot,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	t.Logf("latestRootBlobId=%s watch_chats=%s shm_ignored=true", fx.RootID, chatsRoot.Path)
+}
+
+func TestCursorStoreChangedPathUsesTranscriptSource(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+
+	changed, err := fx.Provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: fx.StorePath, EventKind: "write", WatchRoot: fx.ChatsRoot,
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, fx.Transcript, changed[0].DisplayPath)
+
+	walChanged, err := fx.Provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: fx.StorePath + "-wal", EventKind: "write", WatchRoot: fx.ChatsRoot,
+	})
+	require.NoError(t, err)
+	require.Len(t, walChanged, 1)
+	assert.Equal(t, fx.Transcript, walChanged[0].DisplayPath)
+
+	storeOnly := filepath.Join(fx.ChatsRoot, "deadbeefdeadbeefdeadbeefdeadbeef", "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", "store.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(storeOnly), 0o755))
+	require.NoError(t, os.WriteFile(storeOnly, []byte("x"), 0o644))
+	none, err := fx.Provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: storeOnly, EventKind: "write", WatchRoot: fx.ChatsRoot,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
+func TestCursorStoreChangedPathFindsTranscriptBeforeDiscovery(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	provider, ok := NewProvider(AgentCursor, ProviderConfig{
+		Roots: []string{fx.ProjectsRoot},
+		MetadataDirs: map[string][]string{
+			filepath.Clean(fx.ProjectsRoot): {filepath.Clean(fx.ChatsRoot)},
+		},
+	})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: fx.StorePath, EventKind: "write", WatchRoot: fx.ChatsRoot,
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, fx.Transcript, changed[0].DisplayPath)
+}
+
+func TestCursorStoreIndexKeepsSiblingStoresVisible(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	otherAgentID := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+	provider := fx.Provider.(*cursorProvider)
+	assert.Empty(t, provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID))
+	otherStore := filepath.Join(
+		fx.ChatsRoot, "deadbeefdeadbeefdeadbeefdeadbeef", otherAgentID, "store.db",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(otherStore), 0o755))
+	require.NoError(t, os.WriteFile(otherStore, []byte("store"), 0o644))
+	provider.sources.storeIndex.refresh(fx.ChatsRoot)
+
+	assert.Equal(
+		t,
+		otherStore,
+		provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID),
+	)
+	t.Logf("latestRootBlobId=%s sibling_store_indexed=true", fx.RootID)
+}
+
+func TestCursorStoreRemovalKeepsTranscript(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+	require.NoError(t, os.Remove(fx.StorePath))
+	_ = os.Remove(fx.StorePath + "-wal")
+	_ = os.Remove(fx.StorePath + "-shm")
+
+	discovered, err := fx.Provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, fx.Transcript, discovered[0].DisplayPath)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: discovered[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results[0].Result.Messages, 2)
+	assert.False(t, outcome.Results[0].Result.Messages[1].HasThinking)
+	assert.Equal(t, "", outcome.Results[0].Result.Session.SourceVersion)
+}
+
+func TestCursorStoreOpensReadOnly(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	t.Logf("latestRootBlobId=%s", fx.RootID)
+	conn, err := openCursorIDEDB(fx.StorePath)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Exec(`CREATE TABLE should_fail (id INTEGER)`)
+	require.Error(t, err)
+}
+
+func TestCursorStoreReadsOnlyReachableBlobs(t *testing.T) {
+	fx := setupCursorStoreFixture(t, true)
+	turns, stats, err := readCursorStoreTurns(
+		context.Background(), fx.StorePath, cursorStoreTestAgentID,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, turns)
+	var tableBlobCount int
+	require.NoError(t, fx.Writer.QueryRow(`SELECT COUNT(*) FROM blobs`).Scan(&tableBlobCount))
+	t.Logf(
+		"latestRootBlobId=%s blob_loads=%d reachable=%d table_blobs=%d",
+		stats.LatestRootBlobID, stats.BlobLoads, stats.Reachable, tableBlobCount,
+	)
+	assert.Equal(t, fx.RootID, stats.LatestRootBlobID)
+	assert.Equal(t, stats.Reachable, stats.BlobLoads)
+	assert.Less(t, stats.Reachable, tableBlobCount)
+	assert.Equal(t, 32, len(cursorStoreBlobRef(fx.RootID)))
+}
+
+func TestCursorStoreDoesNotDiscoverStoreOnlySession(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	storeOnlyID := "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+	storeOnly := filepath.Join(fx.ChatsRoot, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", storeOnlyID, "store.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(storeOnly), 0o755))
+	require.NoError(t, os.WriteFile(storeOnly, []byte("not a real store"), 0o644))
+	t.Logf("latestRootBlobId=%s store_only=%s", fx.RootID, storeOnlyID)
+
+	discovered, err := fx.Provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, fx.Transcript, discovered[0].DisplayPath)
+	for _, src := range discovered {
+		assert.NotContains(t, src.DisplayPath, storeOnlyID)
+		assert.NotContains(t, src.Key, "store.db")
+	}
+}
+
+func TestCursorStoreResolveMetadataDir(t *testing.T) {
+	home := t.TempDir()
+	projects := filepath.Join(home, ".cursor", "projects")
+	chats := filepath.Join(home, ".cursor", "chats")
+	require.NoError(t, os.MkdirAll(projects, 0o755))
+	require.NoError(t, os.MkdirAll(chats, 0o755))
+	factory, ok := ProviderFactoryByType(AgentCursor)
+	require.True(t, ok)
+	resolver, ok := factory.(interface {
+		ResolveMetadataDir(string) (string, error)
+	})
+	require.True(t, ok)
+	got, err := resolver.ResolveMetadataDir(projects)
+	require.NoError(t, err)
+	want, err := filepath.EvalSymlinks(chats)
+	require.NoError(t, err)
+	got, err = filepath.EvalSymlinks(got)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	unrelated := filepath.Join(home, "other")
+	require.NoError(t, os.MkdirAll(unrelated, 0o755))
+	empty, err := resolver.ResolveMetadataDir(unrelated)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}
+
+func TestCursorStoreFingerprintTracksWAL(t *testing.T) {
+	fx := setupCursorStoreFixture(t, true)
+	fp1, err := fx.Provider.Fingerprint(context.Background(), fx.Source)
+	require.NoError(t, err)
+	require.Contains(t, fp1.Hash, "|store:")
+
+	_, err = fx.Writer.Exec(
+		`INSERT INTO blobs(id, data) VALUES(?, ?)`,
+		cursorStoreHashID("extra-wal-row"), []byte("x"),
+	)
+	require.NoError(t, err)
+	fp2, err := fx.Provider.Fingerprint(context.Background(), fx.Source)
+	require.NoError(t, err)
+	assert.NotEqual(t, fp1.Hash, fp2.Hash)
+	t.Logf("latestRootBlobId=%s hash1=%s hash2=%s", fx.RootID, fp1.Hash, fp2.Hash)
+}
+
+func TestCursorStoreFingerprintSurvivesStoreRemoval(t *testing.T) {
+	fx := setupCursorStoreFixture(t, false)
+	_, err := fx.Provider.Fingerprint(context.Background(), fx.Source)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(fx.StorePath))
+	_ = os.Remove(fx.StorePath + "-wal")
+	_ = os.Remove(fx.StorePath + "-shm")
+
+	fingerprint, err := fx.Provider.Fingerprint(context.Background(), fx.Source)
+	require.NoError(t, err)
+	assert.NotContains(t, fingerprint.Hash, "|store:")
+	t.Logf("latestRootBlobId=%s store_removed=true", fx.RootID)
+}
+
+func TestCursorStoreParseCarriesFingerprintMtime(t *testing.T) {
+	fx := setupCursorStoreFixture(t, true)
+	fingerprint, err := fx.Provider.Fingerprint(context.Background(), fx.Source)
+	require.NoError(t, err)
+
+	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{
+		Source:      fx.Source,
+		Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, fingerprint.MTimeNS, outcome.Results[0].Result.Session.File.Mtime)
+	assert.Equal(t, fingerprint.Size, outcome.Results[0].Result.Session.File.Size)
+	t.Logf("latestRootBlobId=%s fingerprint_mtime=%d", fx.RootID, fingerprint.MTimeNS)
+}

--- a/internal/parser/cursor_store_test.go
+++ b/internal/parser/cursor_store_test.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json/v2"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -261,11 +260,8 @@ func setupCursorStoreFixture(t *testing.T, keepWriterOpen bool) cursorStoreFixtu
 
 func TestCursorStoreParsesRowsHeldOnlyInWAL(t *testing.T) {
 	fx := setupCursorStoreFixture(t, true)
-	info, err := os.Stat(fx.StorePath)
-	require.NoError(t, err)
 	walInfo, err := os.Stat(fx.StorePath + "-wal")
 	require.NoError(t, err)
-	t.Logf("latestRootBlobId=%s main_size=%d wal_size=%d", fx.RootID, info.Size(), walInfo.Size())
 	assert.Positive(t, walInfo.Size())
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
@@ -280,7 +276,6 @@ func TestCursorStoreParsesRowsHeldOnlyInWAL(t *testing.T) {
 
 func TestCursorStoreTraversesOnlyLatestRootBlobId(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
 	require.Len(t, outcome.Results, 1)
@@ -292,7 +287,6 @@ func TestCursorStoreTraversesOnlyLatestRootBlobId(t *testing.T) {
 
 func TestCursorStoreEnrichesExistingTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 	discovered, err := fx.Provider.Discover(context.Background())
 	require.NoError(t, err)
 	require.Len(t, discovered, 1)
@@ -322,7 +316,6 @@ func TestCursorStoreEnrichesExistingTranscript(t *testing.T) {
 
 func TestCursorStoreUsesTurnIndexProjection(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
 	msgs := outcome.Results[0].Result.Messages
@@ -361,7 +354,6 @@ func TestCursorStoreSkipsUndecodableBlobWithoutDroppingSiblings(t *testing.T) {
 	})
 	_, err = db.Exec(`UPDATE blobs SET data = ? WHERE id = ?`, turnData, turnID)
 	require.NoError(t, err)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
@@ -381,46 +373,54 @@ func TestCursorStoreResolvesInline32ByteMessage(t *testing.T) {
 	payload := encodePB([]pbField{{num: 1, wire: pbWireBytes, bytes: message}})
 	require.Len(t, payload, 32)
 	loader := newCursorStoreBlobLoader(
-		context.Background(), db, &cursorStoreReadStats{},
+		context.Background(), db,
 	)
 	resolved, ok := cursorStoreResolveMessage(agProtoField{
 		Wire: pbWireBytes, Bytes: payload,
 	}, loader)
 	require.True(t, ok)
 	_, _, ok = decodeCursorStoreAssistantMessage(resolved)
-	t.Logf("latestRootBlobId=%s inline_payload_bytes=%d", fx.RootID, len(payload))
 	assert.True(t, ok)
 }
 
-func TestCursorStoreMalformedMetaReturnsError(t *testing.T) {
+func assertCursorStoreTranscriptOnly(t *testing.T, outcome ParseOutcome) {
+	t.Helper()
+	assert.Empty(t, outcome.SourceErrors)
+	assert.True(t, outcome.ResultSetComplete)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0].Result
+	assert.Equal(t, "cursor:"+cursorStoreTestAgentID, result.Session.ID)
+	require.Len(t, result.Messages, 2)
+	assert.Equal(t, "is this composer? what model is this?", result.Messages[0].Content)
+	assert.Equal(t, "I'm Auto, an agent router designed by Cursor.", result.Messages[1].Content)
+	assert.False(t, result.Messages[1].HasThinking)
+	assert.Empty(t, result.Messages[1].ThinkingText)
+}
+
+func TestCursorStoreMalformedMetaKeepsTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
 	db, err := sql.Open("sqlite3", fx.StorePath)
 	require.NoError(t, err)
 	defer db.Close()
 	_, err = db.Exec(`UPDATE meta SET value = ? WHERE key = '0'`, "not-hex")
 	require.NoError(t, err)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
-	assert.Empty(t, outcome.Results)
-	require.Len(t, outcome.SourceErrors, 1)
-	assert.Contains(t, outcome.SourceErrors[0].Err.Error(), "metadata")
+	assertCursorStoreTranscriptOnly(t, outcome)
 }
 
-func TestCursorStoreMissingMetadataReturnsError(t *testing.T) {
+func TestCursorStoreMissingMetadataKeepsTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, true)
 	_, err := fx.Writer.Exec(`DELETE FROM meta WHERE key = '0'`)
 	require.NoError(t, err)
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
-	assert.Empty(t, outcome.Results)
-	require.Len(t, outcome.SourceErrors, 1)
-	t.Logf("latestRootBlobId=%s metadata_case=missing error=%q", fx.RootID, outcome.SourceErrors[0].Err.Error())
+	assertCursorStoreTranscriptOnly(t, outcome)
 }
 
-func TestCursorStoreIncompleteMetadataReturnsError(t *testing.T) {
+func TestCursorStoreIncompleteMetadataKeepsTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, true)
 	payload, err := json.Marshal(map[string]any{
 		"agentId": cursorStoreTestAgentID,
@@ -434,12 +434,10 @@ func TestCursorStoreIncompleteMetadataReturnsError(t *testing.T) {
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
-	assert.Empty(t, outcome.Results)
-	require.Len(t, outcome.SourceErrors, 1)
-	t.Logf("latestRootBlobId=%s metadata_case=incomplete error=%q", fx.RootID, outcome.SourceErrors[0].Err.Error())
+	assertCursorStoreTranscriptOnly(t, outcome)
 }
 
-func TestCursorStoreMetadataAgentMismatchReturnsError(t *testing.T) {
+func TestCursorStoreMetadataAgentMismatchKeepsTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, true)
 	payload, err := json.Marshal(map[string]any{
 		"agentId":          "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
@@ -454,12 +452,10 @@ func TestCursorStoreMetadataAgentMismatchReturnsError(t *testing.T) {
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
-	assert.Empty(t, outcome.Results)
-	require.Len(t, outcome.SourceErrors, 1)
-	t.Logf("latestRootBlobId=%s metadata_case=agent_mismatch error=%q", fx.RootID, outcome.SourceErrors[0].Err.Error())
+	assertCursorStoreTranscriptOnly(t, outcome)
 }
 
-func TestCursorStoreMissingSelectedRootReturnsError(t *testing.T) {
+func TestCursorStoreMissingSelectedRootKeepsTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, true)
 	missingRoot := strings.Repeat("f", 64)
 	payload, err := json.Marshal(map[string]any{
@@ -472,13 +468,91 @@ func TestCursorStoreMissingSelectedRootReturnsError(t *testing.T) {
 		hex.EncodeToString(payload),
 	)
 	require.NoError(t, err)
-	t.Logf("latestRootBlobId=%s", missingRoot)
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
-	assert.Empty(t, outcome.Results)
-	require.Len(t, outcome.SourceErrors, 1)
-	assert.Contains(t, outcome.SourceErrors[0].Err.Error(), "missing selected root")
+	assertCursorStoreTranscriptOnly(t, outcome)
+}
+
+func TestCursorStoreUnsupportedRootKeepsTranscript(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		root []byte
+	}{
+		{name: "undecodable root", root: []byte{0xff}},
+		{name: "missing turn index", root: encodePB([]pbField{
+			{num: 22, wire: pbWireBytes, bytes: []byte("cli")},
+		})},
+		{name: "undecodable turn index", root: encodePB([]pbField{
+			{num: 8, wire: pbWireBytes, bytes: []byte{0xff}},
+		})},
+		{name: "no decoded turns", root: encodePB([]pbField{
+			{num: 8, wire: pbWireBytes, bytes: encodePB([]pbField{
+				{num: 1, wire: pbWireBytes, bytes: []byte{0xff}},
+			})},
+		})},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fx := setupCursorStoreFixture(t, true)
+			_, err := fx.Writer.Exec(`UPDATE blobs SET data = ? WHERE id = ?`, tt.root, fx.RootID)
+			require.NoError(t, err)
+			outcome, err := fx.Provider.Parse(t.Context(), ParseRequest{Source: fx.Source})
+			require.NoError(t, err)
+			assertCursorStoreTranscriptOnly(t, outcome)
+		})
+	}
+}
+
+func TestCursorStoreIndexFailureKeepsTranscripts(t *testing.T) {
+	for _, failure := range []string{"chats is a file", "unreadable workspace"} {
+		t.Run(failure, func(t *testing.T) {
+			fx := setupCursorStoreFixture(t, false)
+			switch failure {
+			case "chats is a file":
+				require.NoError(t, os.Rename(fx.ChatsRoot, fx.ChatsRoot+"-saved"))
+				require.NoError(t, os.WriteFile(fx.ChatsRoot, []byte("file"), 0o644))
+			case "unreadable workspace":
+				workspace := filepath.Dir(filepath.Dir(fx.StorePath))
+				require.NoError(t, os.Chmod(workspace, 0))
+				t.Cleanup(func() { require.NoError(t, os.Chmod(workspace, 0o755)) })
+				if _, err := os.ReadDir(workspace); err == nil {
+					t.Skip("directory permissions are not enforced")
+				}
+			}
+			provider := fx.Provider.(*cursorProvider)
+			logs := captureLog(t)
+			for _, operation := range []string{"Discover", "DiscoverEach", "Fingerprint", "Parse"} {
+				t.Run(operation, func(t *testing.T) {
+					provider.sources.storeIndex = newCursorStoreIndex()
+					switch operation {
+					case "Discover":
+						sources, err := provider.Discover(t.Context())
+						require.NoError(t, err)
+						require.Len(t, sources, 1)
+						assert.Equal(t, fx.Transcript, sources[0].DisplayPath)
+					case "DiscoverEach":
+						var paths []string
+						err := provider.DiscoverEach(t.Context(), func(source SourceRef) error {
+							paths = append(paths, source.DisplayPath)
+							return nil
+						})
+						require.NoError(t, err)
+						assert.Equal(t, []string{fx.Transcript}, paths)
+					case "Fingerprint":
+						fp, err := provider.Fingerprint(t.Context(), fx.Source)
+						require.NoError(t, err)
+						assert.NotEmpty(t, fp.Hash)
+						assert.NotContains(t, fp.Hash, "|store:")
+					case "Parse":
+						outcome, err := provider.Parse(t.Context(), ParseRequest{Source: fx.Source})
+						require.NoError(t, err)
+						assertCursorStoreTranscriptOnly(t, outcome)
+					}
+				})
+			}
+			assertLogContains(t, logs, "warning", "Cursor store index")
+		})
+	}
 }
 
 func TestCursorStoreUnreadableMatchingStoreReturnsError(t *testing.T) {
@@ -487,7 +561,6 @@ func TestCursorStoreUnreadableMatchingStoreReturnsError(t *testing.T) {
 	for _, suffix := range []string{"-wal", "-shm"} {
 		_ = os.Remove(fx.StorePath + suffix)
 	}
-	t.Logf("latestRootBlobId=%s unreadable_store=true", fx.RootID)
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
@@ -496,7 +569,6 @@ func TestCursorStoreUnreadableMatchingStoreReturnsError(t *testing.T) {
 	assert.True(t, outcome.ResultSetComplete)
 	assert.True(t, outcome.SourceErrors[0].Retryable)
 	assert.Contains(t, outcome.SourceErrors[0].Err.Error(), "cursor store")
-	t.Log("store_error=cursor_store_unreadable")
 }
 
 func TestCursorStoreEnrichesSourceWithoutOpaque(t *testing.T) {
@@ -573,7 +645,6 @@ func TestCursorStoreSkipsTurnWithoutUserToPreserveAlignment(t *testing.T) {
 	assert.Equal(t, secondUser, msgs[2].Timestamp)
 	assert.Equal(t, secondAssistant, msgs[3].Timestamp)
 	assert.Equal(t, "aligned reasoning", msgs[3].ThinkingText)
-	t.Log("latestRootBlobId=n/a missing_user_turn_skipped=true")
 }
 
 func TestCursorStoreSkipsTurnWithoutAssistantToPreserveAlignment(t *testing.T) {
@@ -611,7 +682,6 @@ func TestCursorStoreSkipsTurnWithoutAssistantToPreserveAlignment(t *testing.T) {
 	assert.Equal(t, secondUser, msgs[2].Timestamp)
 	assert.Equal(t, secondAssistant, msgs[3].Timestamp)
 	assert.Equal(t, "aligned reasoning", msgs[3].ThinkingText)
-	t.Log("latestRootBlobId=n/a missing_assistant_turn_skipped=true")
 }
 
 func TestCursorStoreLeavesLaterTurnUnmappedAfterUndecodableTurn(t *testing.T) {
@@ -639,7 +709,6 @@ func TestCursorStoreLeavesLaterTurnUnmappedAfterUndecodableTurn(t *testing.T) {
 		assert.Empty(t, msg.Timestamp)
 		assert.Empty(t, msg.ThinkingText)
 	}
-	t.Log("latestRootBlobId=n/a undecodable_turn_stops_alignment=true")
 }
 
 func TestCursorStoreMatchesFinalAssistantAfterIntermediateMessage(t *testing.T) {
@@ -671,12 +740,10 @@ func TestCursorStoreMatchesFinalAssistantAfterIntermediateMessage(t *testing.T) 
 	assert.Empty(t, msgs[1].ThinkingText)
 	assert.Equal(t, "first reasoning", msgs[2].ThinkingText)
 	assert.Equal(t, "second reasoning", msgs[4].ThinkingText)
-	t.Log("latestRootBlobId=n/a intermediate_assistant_skipped=true")
 }
 
 func TestCursorStoreUsesProducerMillisecondTimes(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 	old := time.Now().Add(-48 * time.Hour)
 	require.NoError(t, os.Chtimes(fx.Transcript, old, old))
 
@@ -705,7 +772,6 @@ func TestCursorStorePartialTurnIndexRetainsTranscriptEndBound(t *testing.T) {
 	))
 	transcriptTime := time.UnixMilli(int64(cursorStoreTestAsstMS) + 10_000).UTC()
 	require.NoError(t, os.Chtimes(fx.Transcript, transcriptTime, transcriptTime))
-	t.Logf("latestRootBlobId=%s transcript_end=%d", fx.RootID, transcriptTime.UnixMilli())
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
@@ -728,7 +794,6 @@ func TestCursorStoreExtraAssistantRetainsTranscriptEndBound(t *testing.T) {
 	require.NoError(t, os.WriteFile(fx.Transcript, []byte(transcript), 0o644))
 	transcriptTime := time.UnixMilli(int64(cursorStoreTestAsstMS) + 30_000).UTC()
 	require.NoError(t, os.Chtimes(fx.Transcript, transcriptTime, transcriptTime))
-	t.Logf("latestRootBlobId=%s transcript_end=%d", fx.RootID, transcriptTime.UnixMilli())
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
@@ -753,7 +818,6 @@ func TestCursorStoreIncompleteTurnTimesRetainTranscriptEndBound(t *testing.T) {
 	require.NoError(t, err)
 	transcriptTime := time.UnixMilli(int64(cursorStoreTestAsstMS) + 20_000).UTC()
 	require.NoError(t, os.Chtimes(fx.Transcript, transcriptTime, transcriptTime))
-	t.Logf("latestRootBlobId=%s transcript_end=%d", fx.RootID, transcriptTime.UnixMilli())
 
 	outcome, err := fx.Provider.Parse(context.Background(), ParseRequest{Source: fx.Source})
 	require.NoError(t, err)
@@ -768,12 +832,11 @@ func TestCursorStoreDoesNotTreatUntimedFieldThreeAsReasoning(t *testing.T) {
 	}}))
 	require.NoError(t, err)
 	text, _, ok := decodeCursorStoreReasoning(fields)
-	t.Log("latestRootBlobId=n/a field=3 untimed=true")
 	assert.False(t, ok)
 	assert.Empty(t, text)
 }
 
-func TestCursorStoreWatchPlanIncludesWAL(t *testing.T) {
+func TestCursorStoreWatchPlanIgnoresSHM(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
 	plan, err := fx.Provider.WatchPlan(context.Background())
 	require.NoError(t, err)
@@ -787,19 +850,15 @@ func TestCursorStoreWatchPlanIncludesWAL(t *testing.T) {
 		}
 	}
 	require.True(t, found)
-	assert.ElementsMatch(t, []string{"store.db", "store.db-wal"}, chatsRoot.IncludeGlobs)
-	assert.NotContains(t, chatsRoot.IncludeGlobs, "store.db-shm")
 	changed, err := fx.Provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
-		Path: fx.StorePath + "-shm", EventKind: "write", WatchRoot: fx.ChatsRoot,
+		Path: fx.StorePath + "-shm", EventKind: "write", WatchRoot: chatsRoot.Path,
 	})
 	require.NoError(t, err)
 	assert.Empty(t, changed)
-	t.Logf("latestRootBlobId=%s watch_chats=%s shm_ignored=true", fx.RootID, chatsRoot.Path)
 }
 
 func TestCursorStoreChangedPathUsesTranscriptSource(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 
 	changed, err := fx.Provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
 		Path: fx.StorePath, EventKind: "write", WatchRoot: fx.ChatsRoot,
@@ -847,8 +906,7 @@ func TestCursorStoreIndexKeepsSiblingStoresVisible(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
 	otherAgentID := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 	provider := fx.Provider.(*cursorProvider)
-	path, err := provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
-	require.NoError(t, err)
+	path := provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
 	assert.Empty(t, path)
 	otherStore := filepath.Join(
 		fx.ChatsRoot, "deadbeefdeadbeefdeadbeefdeadbeef", otherAgentID, "store.db",
@@ -857,41 +915,31 @@ func TestCursorStoreIndexKeepsSiblingStoresVisible(t *testing.T) {
 	require.NoError(t, os.WriteFile(otherStore, []byte("store"), 0o644))
 	provider.sources.storeIndex.refresh(fx.ChatsRoot)
 
-	path, err = provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
-	require.NoError(t, err)
+	path = provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
 	assert.Equal(t, otherStore, path)
-	t.Logf("latestRootBlobId=%s sibling_store_indexed=true", fx.RootID)
 }
 
 func TestCursorStoreIndexRetainsLastCompleteScanOnRefreshError(t *testing.T) {
-	root := t.TempDir()
-	agentID := cursorStoreTestAgentID
-	storePath := filepath.Join(root, "workspace", agentID, "store.db")
-	require.NoError(t, os.MkdirAll(filepath.Dir(storePath), 0o755))
-	require.NoError(t, os.WriteFile(storePath, []byte("store"), 0o644))
-
-	index := newCursorStoreIndex()
-	require.NoError(t, index.refresh(root))
-	key := filepath.Clean(root)
-	before := index.roots[key][agentID]
-	require.Equal(t, storePath, before)
-
-	readDir := cursorStoreReadDir
-	cursorStoreReadDir = func(path string) ([]os.DirEntry, error) {
-		if path == root {
-			return nil, errors.New("transient directory read failure")
-		}
-		return readDir(path)
+	fx := setupCursorStoreFixture(t, false)
+	workspace := filepath.Join(fx.ChatsRoot, "unreadable-workspace")
+	require.NoError(t, os.Mkdir(workspace, 0))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(workspace, 0o755)) })
+	if _, err := os.ReadDir(workspace); err == nil {
+		t.Skip("directory permissions are not enforced")
 	}
-	t.Cleanup(func() { cursorStoreReadDir = readDir })
-	err := index.refresh(root)
-	require.Error(t, err)
-	assert.Equal(t, before, index.roots[key][agentID])
+
+	sources, err := fx.Provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := fx.Provider.Parse(t.Context(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	require.Len(t, outcome.Results[0].Result.Messages, 2)
+	assert.Contains(t, outcome.Results[0].Result.Messages[1].ThinkingText, "asking who I am")
 }
 
 func TestCursorStoreRemovalKeepsTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 	require.NoError(t, os.Remove(fx.StorePath))
 	_ = os.Remove(fx.StorePath + "-wal")
 	_ = os.Remove(fx.StorePath + "-shm")
@@ -910,31 +958,11 @@ func TestCursorStoreRemovalKeepsTranscript(t *testing.T) {
 
 func TestCursorStoreOpensReadOnly(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
-	t.Logf("latestRootBlobId=%s", fx.RootID)
 	conn, err := openCursorIDEDB(fx.StorePath)
 	require.NoError(t, err)
 	defer conn.Close()
 	_, err = conn.Exec(`CREATE TABLE should_fail (id INTEGER)`)
 	require.Error(t, err)
-}
-
-func TestCursorStoreReadsOnlyReachableBlobs(t *testing.T) {
-	fx := setupCursorStoreFixture(t, true)
-	turns, stats, err := readCursorStoreTurns(
-		context.Background(), fx.StorePath, cursorStoreTestAgentID,
-	)
-	require.NoError(t, err)
-	require.NotEmpty(t, turns)
-	var tableBlobCount int
-	require.NoError(t, fx.Writer.QueryRow(`SELECT COUNT(*) FROM blobs`).Scan(&tableBlobCount))
-	t.Logf(
-		"latestRootBlobId=%s blob_loads=%d reachable=%d table_blobs=%d",
-		stats.LatestRootBlobID, stats.BlobLoads, stats.Reachable, tableBlobCount,
-	)
-	assert.Equal(t, fx.RootID, stats.LatestRootBlobID)
-	assert.Equal(t, stats.Reachable, stats.BlobLoads)
-	assert.Less(t, stats.Reachable, tableBlobCount)
-	assert.Equal(t, 32, len(cursorStoreBlobRef(fx.RootID)))
 }
 
 func TestCursorStoreDoesNotDiscoverStoreOnlySession(t *testing.T) {
@@ -943,7 +971,6 @@ func TestCursorStoreDoesNotDiscoverStoreOnlySession(t *testing.T) {
 	storeOnly := filepath.Join(fx.ChatsRoot, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", storeOnlyID, "store.db")
 	require.NoError(t, os.MkdirAll(filepath.Dir(storeOnly), 0o755))
 	require.NoError(t, os.WriteFile(storeOnly, []byte("not a real store"), 0o644))
-	t.Logf("latestRootBlobId=%s store_only=%s", fx.RootID, storeOnlyID)
 
 	discovered, err := fx.Provider.Discover(context.Background())
 	require.NoError(t, err)
@@ -996,7 +1023,6 @@ func TestCursorStoreFingerprintTracksWAL(t *testing.T) {
 	fp2, err := fx.Provider.Fingerprint(context.Background(), fx.Source)
 	require.NoError(t, err)
 	assert.NotEqual(t, fp1.Hash, fp2.Hash)
-	t.Logf("latestRootBlobId=%s hash1=%s hash2=%s", fx.RootID, fp1.Hash, fp2.Hash)
 }
 
 func TestCursorStoreFingerprintSurvivesStoreRemoval(t *testing.T) {
@@ -1010,7 +1036,6 @@ func TestCursorStoreFingerprintSurvivesStoreRemoval(t *testing.T) {
 	fingerprint, err := fx.Provider.Fingerprint(context.Background(), fx.Source)
 	require.NoError(t, err)
 	assert.NotContains(t, fingerprint.Hash, "|store:")
-	t.Logf("latestRootBlobId=%s store_removed=true", fx.RootID)
 }
 
 func TestCursorStoreParseCarriesFingerprintMtime(t *testing.T) {
@@ -1026,5 +1051,4 @@ func TestCursorStoreParseCarriesFingerprintMtime(t *testing.T) {
 	require.Len(t, outcome.Results, 1)
 	assert.Equal(t, fingerprint.MTimeNS, outcome.Results[0].Result.Session.File.Mtime)
 	assert.Equal(t, fingerprint.Size, outcome.Results[0].Result.Session.File.Size)
-	t.Logf("latestRootBlobId=%s fingerprint_mtime=%d", fx.RootID, fingerprint.MTimeNS)
 }

--- a/internal/parser/cursor_store_test.go
+++ b/internal/parser/cursor_store_test.go
@@ -447,6 +447,40 @@ func TestCursorStoreMissingMetadataKeepsTranscript(t *testing.T) {
 	assertCursorStoreTranscriptOnly(t, outcome)
 }
 
+func TestCursorStoreMissingColumnKeepsTranscript(t *testing.T) {
+	for _, tt := range []struct {
+		missing string
+		schema  string
+	}{
+		{"meta.key", `CREATE TABLE meta (other_key TEXT, value TEXT);
+			CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)`},
+		{"meta.value", `CREATE TABLE meta (key TEXT PRIMARY KEY, payload TEXT);
+			CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)`},
+		{"blobs.id", `CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+			CREATE TABLE blobs (other_id TEXT, data BLOB)`},
+		{"blobs.data", `CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+			CREATE TABLE blobs (id TEXT PRIMARY KEY, payload BLOB)`},
+	} {
+		t.Run(tt.missing, func(t *testing.T) {
+			fx := setupCursorStoreFixture(t, false)
+			require.NoError(t, os.Remove(fx.StorePath))
+			store, err := sql.Open("sqlite3", fx.StorePath)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = store.Close() })
+			_, err = store.Exec(tt.schema)
+			require.NoError(t, err)
+			if strings.HasPrefix(tt.missing, "blobs.") {
+				writeCursorStoreMeta(t, store, cursorStoreTestAgentID, fx.RootID)
+			}
+			require.NoError(t, store.Close())
+
+			outcome, err := fx.Provider.Parse(t.Context(), ParseRequest{Source: fx.Source})
+			require.NoError(t, err)
+			assertCursorStoreTranscriptOnly(t, outcome)
+		})
+	}
+}
+
 func TestCursorStoreIncompleteMetadataKeepsTranscript(t *testing.T) {
 	fx := setupCursorStoreFixture(t, true)
 	payload, err := json.Marshal(map[string]any{
@@ -644,6 +678,61 @@ func TestCursorStoreAccessFailureKeepsEnrichmentRetryable(t *testing.T) {
 			assert.Contains(t, outcome.Results[0].Result.Messages[1].ThinkingText, "asking who I am")
 			_, err = fx.Provider.Fingerprint(t.Context(), fx.Source)
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCursorStoreUncachedEventAccessFailureRemainsRetryable(t *testing.T) {
+	for _, discovery := range []string{"before discovery", "after transcript-only discovery"} {
+		t.Run(discovery, func(t *testing.T) {
+			fx := setupCursorStoreFixture(t, false)
+			provider, ok := NewProvider(AgentCursor, ProviderConfig{
+				Roots: []string{fx.ProjectsRoot},
+				MetadataDirs: map[string][]string{
+					fx.ProjectsRoot: {fx.ChatsRoot},
+				},
+			})
+			require.True(t, ok)
+			if discovery == "after transcript-only discovery" {
+				require.NoError(t, os.Rename(fx.StorePath, fx.StorePath+".pending"))
+				sources, err := provider.Discover(t.Context())
+				require.NoError(t, err)
+				require.Len(t, sources, 1)
+				require.NoError(t, os.Rename(fx.StorePath+".pending", fx.StorePath))
+			}
+			sessionDir := filepath.Dir(fx.StorePath)
+			require.NoError(t, os.Chmod(sessionDir, 0))
+			t.Cleanup(func() { require.NoError(t, os.Chmod(sessionDir, 0o755)) })
+			_, err := os.Stat(fx.StorePath)
+			if err == nil {
+				t.Skip("directory permissions are not enforced")
+			}
+			require.ErrorIs(t, err, os.ErrPermission)
+
+			sources, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
+				Path: fx.StorePath, EventKind: "write", WatchRoot: fx.ChatsRoot,
+			})
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+			_, err = provider.Fingerprint(t.Context(), sources[0])
+			assert.ErrorIs(t, err, os.ErrPermission)
+			outcome, err := provider.Parse(t.Context(), ParseRequest{Source: sources[0]})
+			require.NoError(t, err)
+			assert.Empty(t, outcome.Results)
+			require.Len(t, outcome.SourceErrors, 1)
+			assert.True(t, outcome.SourceErrors[0].Retryable)
+			assert.ErrorIs(t, outcome.SourceErrors[0].Err, os.ErrPermission)
+
+			require.NoError(t, os.Chmod(sessionDir, 0o755))
+			fingerprint, err := provider.Fingerprint(t.Context(), sources[0])
+			require.NoError(t, err)
+			assert.Contains(t, fingerprint.Hash, "|store:")
+			outcome, err = provider.Parse(t.Context(), ParseRequest{Source: sources[0]})
+			require.NoError(t, err)
+			require.Empty(t, outcome.SourceErrors)
+			require.Len(t, outcome.Results, 1)
+			require.Len(t, outcome.Results[0].Result.Messages, 2)
+			assert.Contains(t, outcome.Results[0].Result.Messages[1].ThinkingText, "asking who I am")
 		})
 	}
 }

--- a/internal/parser/cursor_store_test.go
+++ b/internal/parser/cursor_store_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -846,7 +847,9 @@ func TestCursorStoreIndexKeepsSiblingStoresVisible(t *testing.T) {
 	fx := setupCursorStoreFixture(t, false)
 	otherAgentID := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 	provider := fx.Provider.(*cursorProvider)
-	assert.Empty(t, provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID))
+	path, err := provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
+	require.NoError(t, err)
+	assert.Empty(t, path)
 	otherStore := filepath.Join(
 		fx.ChatsRoot, "deadbeefdeadbeefdeadbeefdeadbeef", otherAgentID, "store.db",
 	)
@@ -854,12 +857,36 @@ func TestCursorStoreIndexKeepsSiblingStoresVisible(t *testing.T) {
 	require.NoError(t, os.WriteFile(otherStore, []byte("store"), 0o644))
 	provider.sources.storeIndex.refresh(fx.ChatsRoot)
 
-	assert.Equal(
-		t,
-		otherStore,
-		provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID),
-	)
+	path, err = provider.sources.storePathForRawID(fx.ProjectsRoot, otherAgentID)
+	require.NoError(t, err)
+	assert.Equal(t, otherStore, path)
 	t.Logf("latestRootBlobId=%s sibling_store_indexed=true", fx.RootID)
+}
+
+func TestCursorStoreIndexRetainsLastCompleteScanOnRefreshError(t *testing.T) {
+	root := t.TempDir()
+	agentID := cursorStoreTestAgentID
+	storePath := filepath.Join(root, "workspace", agentID, "store.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(storePath), 0o755))
+	require.NoError(t, os.WriteFile(storePath, []byte("store"), 0o644))
+
+	index := newCursorStoreIndex()
+	require.NoError(t, index.refresh(root))
+	key := filepath.Clean(root)
+	before := index.roots[key][agentID]
+	require.Equal(t, storePath, before)
+
+	readDir := cursorStoreReadDir
+	cursorStoreReadDir = func(path string) ([]os.DirEntry, error) {
+		if path == root {
+			return nil, errors.New("transient directory read failure")
+		}
+		return readDir(path)
+	}
+	t.Cleanup(func() { cursorStoreReadDir = readDir })
+	err := index.refresh(root)
+	require.Error(t, err)
+	assert.Equal(t, before, index.roots[key][agentID])
 }
 
 func TestCursorStoreRemovalKeepsTranscript(t *testing.T) {

--- a/internal/parser/cursor_store_test.go
+++ b/internal/parser/cursor_store_test.go
@@ -520,7 +520,6 @@ func TestCursorStoreIndexFailureKeepsTranscripts(t *testing.T) {
 				}
 			}
 			provider := fx.Provider.(*cursorProvider)
-			logs := captureLog(t)
 			for _, operation := range []string{"Discover", "DiscoverEach", "Fingerprint", "Parse"} {
 				t.Run(operation, func(t *testing.T) {
 					provider.sources.storeIndex = newCursorStoreIndex()
@@ -550,7 +549,6 @@ func TestCursorStoreIndexFailureKeepsTranscripts(t *testing.T) {
 					}
 				})
 			}
-			assertLogContains(t, logs, "warning", "Cursor store index")
 		})
 	}
 }
@@ -928,6 +926,7 @@ func TestCursorStoreIndexRetainsLastCompleteScanOnRefreshError(t *testing.T) {
 		t.Skip("directory permissions are not enforced")
 	}
 
+	logs := captureLog(t)
 	sources, err := fx.Provider.Discover(t.Context())
 	require.NoError(t, err)
 	require.Len(t, sources, 1)
@@ -936,6 +935,7 @@ func TestCursorStoreIndexRetainsLastCompleteScanOnRefreshError(t *testing.T) {
 	require.Len(t, outcome.Results, 1)
 	require.Len(t, outcome.Results[0].Result.Messages, 2)
 	assert.Contains(t, outcome.Results[0].Result.Messages[1].ThinkingText, "asking who I am")
+	assertLogContains(t, logs, "warning", "Cursor store index")
 }
 
 func TestCursorStoreRemovalKeepsTranscript(t *testing.T) {

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -969,3 +969,55 @@ func TestRooCodeRemoteSyncSkipsRootWithoutSessions(t *testing.T) {
 	assert.NotContains(t, targets.Dirs, parser.AgentRooCode)
 	assert.NotContains(t, targets.Files, parser.AgentRooCode)
 }
+
+func TestCursorRemoteTargetsExcludeChatsRoot(t *testing.T) {
+	home, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	projects := filepath.Join(home, ".cursor", "projects")
+	chats := filepath.Join(home, ".cursor", "chats")
+	require.NoError(t, os.MkdirAll(projects, 0o755))
+	require.NoError(t, os.MkdirAll(chats, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(chats, "workspace", "session"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(chats, "workspace", "session", "store.db"),
+		[]byte("store"),
+		0o644,
+	))
+
+	root, meta, err := parser.ResolveProviderRoot(parser.AgentCursor, projects)
+	require.NoError(t, err)
+	require.NotEmpty(t, meta)
+	assert.True(t, samePathForTest(t, meta, chats))
+
+	targets := resolveTargetsForTest(t, config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCursor: {root},
+		},
+		ProviderMetadata: map[parser.AgentType]map[string][]string{
+			parser.AgentCursor: {root: {meta}},
+		},
+	})
+	require.Contains(t, targets.Dirs, parser.AgentCursor)
+	assert.Contains(t, targets.Dirs[parser.AgentCursor], root)
+	for _, dir := range targets.Dirs[parser.AgentCursor] {
+		assert.False(t, samePathForTest(t, dir, meta), "chats metadata must not be a transfer dir: %s", dir)
+		assert.NotEqual(t, "chats", filepath.Base(dir))
+	}
+	for _, files := range targets.Files {
+		for _, file := range files {
+			assert.NotContains(t, file, string(filepath.Separator)+"chats"+string(filepath.Separator))
+			assert.NotContains(t, filepath.Base(file), "store.db")
+		}
+	}
+	t.Logf("latestRootBlobId=n/a projects=%s chats_excluded=%s", root, meta)
+}
+
+func samePathForTest(t *testing.T, a, b string) bool {
+	t.Helper()
+	aAbs, err := filepath.Abs(a)
+	require.NoError(t, err)
+	bAbs, err := filepath.Abs(b)
+	require.NoError(t, err)
+	return filepath.Clean(aAbs) == filepath.Clean(bAbs) ||
+		strings.EqualFold(filepath.Clean(aAbs), filepath.Clean(bAbs))
+}

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -1009,7 +1009,6 @@ func TestCursorRemoteTargetsExcludeChatsRoot(t *testing.T) {
 			assert.NotContains(t, filepath.Base(file), "store.db")
 		}
 	}
-	t.Logf("latestRootBlobId=n/a projects=%s chats_excluded=%s", root, meta)
 }
 
 func samePathForTest(t *testing.T, a, b string) bool {

--- a/internal/sync/provider_freshness_integration_test.go
+++ b/internal/sync/provider_freshness_integration_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -106,4 +107,56 @@ func TestCursorSameMtimeHashChangeReparses(t *testing.T) {
 	require.NotNil(t, after.FirstMessage)
 	assert.Equal(t, "two!", *after.FirstMessage,
 		"a same-mtime content change must bypass Cursor freshness")
+}
+
+func TestCursorStoreEnrichmentFailureStillArchivesTranscriptUpdates(t *testing.T) {
+	for _, failure := range []string{"chats is a file", "unsupported metadata"} {
+		t.Run(failure, func(t *testing.T) {
+			cursorDir := filepath.Join(t.TempDir(), ".cursor")
+			root := filepath.Join(cursorDir, "projects")
+			const sessionID = "11111111-2222-4333-8444-555555555555"
+			path := filepath.Join(root, "Users-demo-Code-app", "agent-transcripts", sessionID+".jsonl")
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+			transcript := `{"role":"user","message":{"content":"<user_query>First prompt</user_query>"}}` + "\n" +
+				`{"role":"assistant","message":{"content":"First answer"}}` + "\n"
+			require.NoError(t, os.WriteFile(path, []byte(transcript), 0o644))
+			chats := filepath.Join(cursorDir, "chats")
+			if failure == "chats is a file" {
+				require.NoError(t, os.WriteFile(chats, []byte("file"), 0o644))
+			} else {
+				storePath := filepath.Join(chats, "workspace", sessionID, "store.db")
+				require.NoError(t, os.MkdirAll(filepath.Dir(storePath), 0o755))
+				store, err := sql.Open("sqlite3", storePath)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = store.Close() })
+				_, err = store.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+					CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB);
+					INSERT INTO meta VALUES ('0', 'not-hex');`)
+				require.NoError(t, err)
+				require.NoError(t, store.Close())
+			}
+
+			archive := dbtest.OpenTestDB(t)
+			engine := sync.NewEngine(archive, sync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentCursor: {root}},
+				Machine:   "local",
+			})
+			t.Cleanup(engine.Close)
+			first := engine.SyncAll(t.Context(), nil)
+			require.Equal(t, 1, first.Synced)
+			messages, err := archive.GetMessages(t.Context(), "cursor:"+sessionID, 0, 10, true)
+			require.NoError(t, err)
+			require.Len(t, messages, 2)
+			assert.Equal(t, "First answer", messages[1].Content)
+
+			transcript += `{"role":"user","message":{"content":"<user_query>Next prompt</user_query>"}}` + "\n" +
+				`{"role":"assistant","message":{"content":"Next answer"}}` + "\n"
+			require.NoError(t, os.WriteFile(path, []byte(transcript), 0o644))
+			engine.SyncPaths([]string{path})
+			messages, err = archive.GetMessages(t.Context(), "cursor:"+sessionID, 0, 10, true)
+			require.NoError(t, err)
+			require.Len(t, messages, 4)
+			assert.Equal(t, "Next answer", messages[3].Content)
+		})
+	}
 }

--- a/internal/sync/provider_freshness_integration_test.go
+++ b/internal/sync/provider_freshness_integration_test.go
@@ -2,7 +2,11 @@ package sync_test
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,4 +54,56 @@ func TestProviderAuthoritativeUnchangedSessionSkipsOnResync(t *testing.T) {
 		"an unchanged provider-authoritative session must not be re-synced")
 	assert.GreaterOrEqual(t, second.Skipped, 1,
 		"the unchanged session must be counted as skipped")
+}
+
+func TestCursorSameMtimeHashChangeReparses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := t.TempDir()
+	const sessionID = "11111111-2222-4333-8444-555555555555"
+	path := filepath.Join(
+		root, "Users-demo-Code-app", "agent-transcripts", sessionID+".jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	writeTranscript := func(first string) {
+		require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(
+			`{"role":"user","message":{"content":"<user_query>%s</user_query>"}}`+"\n"+
+				`{"role":"assistant","message":{"content":"Done."}}`+"\n",
+			first,
+		)), 0o644))
+	}
+	writeTranscript("one!")
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(path, mtime, mtime))
+
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCursor: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	ctx := context.Background()
+	first := engine.SyncAll(ctx, nil)
+	require.Equal(t, 1, first.Synced)
+	before, err := testDB.GetSession(ctx, "cursor:"+sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, before)
+	require.NotNil(t, before.FirstMessage)
+	assert.Equal(t, "one!", *before.FirstMessage)
+
+	writeTranscript("two!")
+	require.NoError(t, os.Chtimes(path, mtime, mtime))
+	engine.SyncPaths([]string{path})
+
+	after, err := testDB.GetSession(ctx, "cursor:"+sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	require.NotNil(t, after.FirstMessage)
+	assert.Equal(t, "two!", *after.FirstMessage,
+		"a same-mtime content change must bypass Cursor freshness")
 }

--- a/internal/sync/provider_freshness_integration_test.go
+++ b/internal/sync/provider_freshness_integration_test.go
@@ -109,6 +109,61 @@ func TestCursorSameMtimeHashChangeReparses(t *testing.T) {
 		"a same-mtime content change must bypass Cursor freshness")
 }
 
+func TestCursorUnreadableStoreDoesNotCountAsFresh(t *testing.T) {
+	cursorRoot := filepath.Join(t.TempDir(), ".cursor")
+	projects := filepath.Join(cursorRoot, "projects")
+	const sessionID = "11111111-2222-4333-8444-555555555555"
+	transcript := filepath.Join(projects, "synthetic-project", "agent-transcripts", sessionID+".jsonl")
+	storePath := filepath.Join(cursorRoot, "chats", "workspace", sessionID, "store.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(storePath), 0o755))
+	store, err := sql.Open("sqlite3", storePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, err = store.Exec(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+		CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB);`)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+	old := time.Now().Add(-time.Minute)
+	require.NoError(t, os.Chtimes(storePath, old, old))
+	require.NoError(t, os.Rename(storePath, storePath+".backup"))
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcript), 0o755))
+	require.NoError(t, os.WriteFile(transcript, []byte(
+		`{"role":"user","message":{"content":"<user_query>Example</user_query>"}}`+"\n"+
+			`{"role":"assistant","message":{"content":"Example answer"}}`+"\n",
+	), 0o644))
+
+	archive := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(archive, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCursor: {projects}},
+		ProviderMetadata: map[parser.AgentType]map[string][]string{
+			parser.AgentCursor: {projects: {filepath.Join(cursorRoot, "chats")}},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	first := engine.SyncAll(t.Context(), nil)
+	require.Equal(t, 1, first.Synced)
+
+	// A previously unavailable store is older than the unchanged transcript,
+	// so only its required hash can distinguish it from the archived source.
+	require.NoError(t, os.Rename(storePath+".backup", storePath))
+	require.NoError(t, os.Chmod(storePath, 0))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(storePath, 0o600)) })
+	if file, err := os.Open(storePath); err == nil {
+		require.NoError(t, file.Close())
+		t.Skip("file permissions are not enforced")
+	}
+	second := engine.SyncAll(t.Context(), nil)
+	assert.Equal(t, 1, second.Failed)
+	assert.Zero(t, second.Skipped)
+	assert.Zero(t, second.Synced)
+
+	require.NoError(t, os.Chmod(storePath, 0o600))
+	recovered := engine.SyncAll(t.Context(), nil)
+	assert.Zero(t, recovered.Failed)
+	assert.Equal(t, 1, recovered.Synced)
+}
+
 func TestCursorStoreEnrichmentFailureStillArchivesTranscriptUpdates(t *testing.T) {
 	for _, failure := range []string{"chats is a file", "unsupported metadata"} {
 		t.Run(failure, func(t *testing.T) {
@@ -139,7 +194,10 @@ func TestCursorStoreEnrichmentFailureStillArchivesTranscriptUpdates(t *testing.T
 			archive := dbtest.OpenTestDB(t)
 			engine := sync.NewEngine(archive, sync.EngineConfig{
 				AgentDirs: map[parser.AgentType][]string{parser.AgentCursor: {root}},
-				Machine:   "local",
+				ProviderMetadata: map[parser.AgentType]map[string][]string{
+					parser.AgentCursor: {root: {chats}},
+				},
+				Machine: "local",
 			})
 			t.Cleanup(engine.Close)
 			first := engine.SyncAll(t.Context(), nil)


### PR DESCRIPTION
Cursor CLI sessions now gain assistant reasoning and producer timestamps from matching `~/.cursor/chats/<workspace>/<agent-id>/store.db` files while keeping the transcript's session identity. Previously, AgentsView read only the text or JSONL transcript under `~/.cursor/projects`.

The provider reads the database and its WAL in one read-only transaction, follows only the tree selected by `latestRootBlobId`, and aligns decoded turns with transcript messages. The composite fingerprint detects store changes even when the transcript is unchanged.

Chats directory scan failures and readable stores with missing required tables or columns, or unsupported metadata or blob structure leave transcripts available for initial import and later updates, with a warning. A failed scan retains usable cached store locations and retries on the next discovery pass. Database open/read errors remain retryable source errors that preserve existing archive content. Temporary path-access failures retain cached stores and newly observed store candidates for retry, and store fingerprint failures prevent freshness skips.

Format evidence is limited to one installed Cursor CLI capture. Native tool-call/result joining, store-only discovery, encrypted payloads, and cross-version field stability remain outside this change. Store enrichment is local and automatically associates chats only with a resolved `.cursor/projects` root. Custom roots such as `.cursor/archive` remain transcript-only. The chats directory stays outside remote, SSH, and S3 transfer targets. Store and WAL events map back to the transcript, and shared-memory events are ignored by the provider.

Refs #1627
