### PR TITLE
perf(activity): speed up reports on large archives

### DIFF
--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -119,6 +119,20 @@ must read the full source fingerprint in the same transaction as the facts it
 installs. Do not compare fingerprints for ordering, and do not skip a refill
 because a cached fingerprint merely looks newer.
 
+### Activity report index
+
+Activity session selection checks terminal tool-execution events even when a
+session's `ended_at` predates the report. Keep the partial
+`idx_tool_result_events_terminal` index on `(session_id, timestamp)` aligned
+between SQLite and PostgreSQL. It includes completed and errored executions with
+non-null timestamps, so the lookup can skip unrelated result payloads and seek
+directly to the report's lower bound.
+
+The next writable SQLite open or PostgreSQL schema setup builds the index once
+for existing archives. PostgreSQL push must also detect its absence before
+taking the schema-current fast path. Creating the index scans existing tool
+results and can delay that first startup; it does not require a session resync.
+
 ### Usage archive indexes
 
 The usage cache discovers bounded-window candidates through
@@ -159,14 +173,14 @@ content clears them for a fresh scan.
 the summary equals that event's content, the summary is not stored: the column
 is empty while `result_content_length` still records the summary's size. That
 pair, an empty column with a non-zero length, tells a reader to take the text
-from the single event. Multi-event summaries, single-event summaries that
-differ from their event, calls with no events, and blocked categories store
-exactly what the parser produced. Load tool calls through the message loaders,
-which refill the summary once events are attached; a query that selects the
-column directly must apply the same fallback, and PostgreSQL and DuckDB apply
-the same write rule so their tool-call fingerprints match SQLite. Anyone
-reading the archive or a mirror by hand sees the empty column and must join
-the events table to recover the text.
+from the single event. Multi-event summaries, single-event summaries that differ
+from their event, calls with no events, and blocked categories store exactly
+what the parser produced. Load tool calls through the message loaders, which
+refill the summary once events are attached; a query that selects the column
+directly must apply the same fallback, and PostgreSQL and DuckDB apply the same
+write rule so their tool-call fingerprints match SQLite. Anyone reading the
+archive or a mirror by hand sees the empty column and must join the events table
+to recover the text.
 
 ## DuckDB Mirror
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,11 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
+- Activity reports load faster on large archives by skipping historical tool
+  results that cannot affect the selected period. SQLite and PostgreSQL build a
+  focused index during the next writable database setup, which can make that
+  first startup longer. No session resync is needed for this index.
+
 - Price Codex Luna Reserve turns that persist as `gpt-reserve` using the
   existing GPT-5.6 Luna catalog rates. Usage reports still list `gpt-reserve`
   as the reported model. Existing SQLite usage caches rebuild so previously

--- a/internal/db/activityreport_index_test.go
+++ b/internal/db/activityreport_index_test.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActivityReportTerminalLookupIndex(t *testing.T) {
+	for _, upgrade := range []bool{false, true} {
+		name := "fresh"
+		if upgrade {
+			name = "existing archive"
+		}
+		t.Run(name, func(t *testing.T) {
+			d := testDB(t)
+			for _, status := range []string{"completed", "errored", "started"} {
+				insertSession(t, d, status, "project", func(s *Session) {
+					s.StartedAt = Ptr("2026-06-15T23:59:00Z")
+					s.EndedAt = Ptr("2026-06-15T23:59:30Z")
+				})
+				timingInsertToolResultEvent(t, d, status, 0, 0,
+					"call", status, "2026-06-16T00:01:00Z", 0)
+			}
+			if upgrade {
+				_, err := d.getWriter().Exec("DROP INDEX IF EXISTS idx_tool_result_events_terminal")
+				require.NoError(t, err)
+				path := d.Path()
+				require.NoError(t, d.Close())
+				d, err = OpenIsolated(path)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, d.Close()) })
+			}
+
+			// The report's terminal-event lookup must seek by date as well as
+			// session, without loading unrelated transcript result payloads.
+			rows, err := d.getReader().QueryContext(t.Context(), `EXPLAIN QUERY PLAN
+				SELECT 1 FROM tool_result_events tre
+				WHERE tre.session_id = ? AND tre.source = 'tool_execution'
+					AND tre.status IN ('completed', 'errored')
+					AND tre.timestamp IS NOT NULL AND tre.timestamp != ''
+					AND agentsview_timestamp_unix_micro(tre.timestamp) IS NOT NULL
+					AND tre.timestamp >= ?`, "completed", "2026-06-16T00:00:00Z")
+			require.NoError(t, err)
+			var details []string
+			for rows.Next() {
+				var id, parent, unused int
+				var detail string
+				require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+				details = append(details, detail)
+			}
+			require.NoError(t, rows.Err())
+			require.NoError(t, rows.Close())
+			assert.Contains(t, strings.Join(details, "\n"), "(session_id=? AND timestamp>?)")
+
+			_, ids, err := d.activityReportSessions(t.Context(), AnalyticsFilter{},
+				"2026-06-16T00:00:00Z", "2026-06-17T00:00:00Z")
+			require.NoError(t, err)
+			assert.Equal(t, []string{"completed", "errored"}, ids)
+		})
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3299,7 +3299,25 @@ func (db *DB) scrubProjectIdentityGitRemoteCredentialsLocked(
 // createPartialIndexesLocked creates partial indexes that are not
 // covered by the initial schema DDL. Idempotent via IF NOT EXISTS.
 func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
+	var terminalIndexExists bool
+	if err := w.QueryRow(`SELECT EXISTS (
+		SELECT 1 FROM sqlite_master WHERE type = 'index'
+		AND name = 'idx_tool_result_events_terminal'
+	)`).Scan(&terminalIndexExists); err != nil {
+		return fmt.Errorf("checking activity terminal index: %w", err)
+	}
+	if !terminalIndexExists {
+		log.Print("building SQLite activity index; startup waits for the tool-result scan to finish")
+	}
 	indexes := []string{
+		// Activity checks terminal events even for sessions whose ended_at
+		// predates the report. Avoid reading historical result payloads for
+		// every session just to find a recent tool completion.
+		`CREATE INDEX IF NOT EXISTS idx_tool_result_events_terminal
+		 ON tool_result_events(session_id, timestamp)
+		 WHERE source = 'tool_execution'
+		   AND status IN ('completed', 'errored')
+		   AND timestamp IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_cwd
 		 ON sessions(cwd) WHERE cwd != ''`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_project_git_branch

--- a/internal/postgres/activityreport_index_pgtest_test.go
+++ b/internal/postgres/activityreport_index_pgtest_test.go
@@ -1,0 +1,74 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"encoding/json/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestPGActivityReportTerminalLookupIndex(t *testing.T) {
+	const schema = "agentsview_activity_index_test"
+	_, store := prepareUsageSchema(t, schema)
+	for _, status := range []string{"completed", "errored", "started"} {
+		_, err := store.DB().ExecContext(t.Context(), `
+			INSERT INTO sessions (id, machine, project, agent, started_at, ended_at,
+				message_count, user_message_count)
+			VALUES ($1, 'machine', 'project', 'grok',
+				'2026-06-15T23:59:00Z', '2026-06-15T23:59:30Z', 1, 1)`, status)
+		require.NoError(t, err)
+		_, err = store.DB().ExecContext(t.Context(), `
+			INSERT INTO tool_result_events (session_id, tool_call_message_ordinal,
+				source, status, content, timestamp)
+			VALUES ($1, 0, 'tool_execution', $1, '', '2026-06-16T00:01:00Z')`, status)
+		require.NoError(t, err)
+	}
+	for _, upgrade := range []bool{false, true} {
+		name := "fresh"
+		if upgrade {
+			name = "existing archive"
+		}
+		t.Run(name, func(t *testing.T) {
+			if upgrade {
+				_, err := store.DB().ExecContext(t.Context(),
+					"DROP INDEX IF EXISTS idx_tool_result_events_terminal")
+				require.NoError(t, err)
+				syncer := &Sync{pg: store.DB(), schema: schema}
+				require.NoError(t, syncer.EnsureSchema(t.Context()))
+			}
+			tx, err := store.DB().BeginTx(t.Context(), nil)
+			require.NoError(t, err)
+			defer tx.Rollback()
+			// On this tiny fixture a sequential scan is cheaper. Inspect the
+			// available index path that a large archive needs instead.
+			_, err = tx.ExecContext(t.Context(), "SET LOCAL enable_seqscan = off; SET LOCAL enable_bitmapscan = off")
+			require.NoError(t, err)
+			var raw []byte
+			require.NoError(t, tx.QueryRowContext(t.Context(), `EXPLAIN (FORMAT JSON)
+				SELECT 1 FROM tool_result_events tre
+				WHERE tre.session_id = $1 AND tre.source = 'tool_execution'
+					AND tre.status IN ('completed', 'errored')
+					AND tre.timestamp >= $2::timestamptz`,
+				"completed", "2026-06-16T00:00:00Z").Scan(&raw))
+			var plan []struct {
+				Plan struct {
+					IndexCond string `json:"Index Cond"`
+				}
+			}
+			require.NoError(t, json.Unmarshal(raw, &plan))
+			require.Len(t, plan, 1)
+			assert.Contains(t, plan[0].Plan.IndexCond, "session_id =")
+			assert.Contains(t, plan[0].Plan.IndexCond, `"timestamp" >=`)
+			require.NoError(t, tx.Rollback())
+
+			_, ids, err := store.activityReportSessions(t.Context(), db.AnalyticsFilter{},
+				"2026-06-16T00:00:00Z", "2026-06-17T00:00:00Z")
+			require.NoError(t, err)
+			assert.Equal(t, []string{"completed", "errored"}, ids)
+		})
+	}
+}

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -1523,6 +1523,13 @@ func EnsureSchema(
 // Idempotent via IF NOT EXISTS.
 func createPartialIndexesPG(ctx context.Context, db *sql.DB) error {
 	indexes := []string{
+		// Match SQLite's bounded Activity terminal-event lookup, including
+		// completions that outlive a session's ended_at metadata.
+		`CREATE INDEX IF NOT EXISTS idx_tool_result_events_terminal
+		 ON tool_result_events(session_id, timestamp)
+		 WHERE source = 'tool_execution'
+		   AND status IN ('completed', 'errored')
+		   AND timestamp IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_cwd
 		 ON sessions(cwd) WHERE cwd != ''`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_project_git_branch
@@ -2776,7 +2783,10 @@ func pushSchemaCurrent(ctx context.Context, db *sql.DB) bool {
 	// DO NOTHING, which only suppresses duplicates when this partial
 	// unique index exists. Fall back to EnsureSchema when it is missing
 	// so repeated pushes cannot duplicate cursor usage rows.
-	return pgHasIndex(ctx, db, "idx_cursor_usage_events_dedup")
+	// A push may provision the schema for a read-only serve role. Include
+	// the Activity index so that upgrading through push installs it too.
+	return pgHasIndex(ctx, db, "idx_cursor_usage_events_dedup") &&
+		pgHasIndex(ctx, db, "idx_tool_result_events_terminal")
 }
 
 // CheckDataVersionCompat rejects PG datasets containing rows written by a

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -596,7 +596,8 @@ func TestSyncEnsureSchemaSkipsLegacyDDLWhenSchemaCompatible(t *testing.T) {
 		"cursor_usage_events":                             true,
 	}
 	state.existingIndexes = map[string]bool{
-		"idx_cursor_usage_events_dedup": true,
+		"idx_cursor_usage_events_dedup":   true,
+		"idx_tool_result_events_terminal": true,
 	}
 	syncer := &Sync{pg: pg, schema: "agentsview"}
 
@@ -635,7 +636,8 @@ func TestEnsureSchemaScrubsProjectIdentityGitRemoteCredentials(t *testing.T) {
 		"cursor_usage_events":                             true,
 	}
 	state.existingIndexes = map[string]bool{
-		"idx_cursor_usage_events_dedup": true,
+		"idx_cursor_usage_events_dedup":   true,
+		"idx_tool_result_events_terminal": true,
 	}
 	state.syncMetadataKeys = map[string]bool{
 		sourceCurationBackfillMetadataKey: true,
@@ -930,7 +932,8 @@ func TestSyncEnsureSchemaRunsDDLWhenPushMetadataMissing(t *testing.T) {
 		"cursor_usage_events": true,
 	}
 	state.existingIndexes = map[string]bool{
-		"idx_cursor_usage_events_dedup": true,
+		"idx_cursor_usage_events_dedup":   true,
+		"idx_tool_result_events_terminal": true,
 	}
 	// Read-compatible with tables and index present, but the push-only
 	// owner_marker column is absent, so the push fast path must fall back
@@ -1001,7 +1004,8 @@ func TestSyncEnsureSchemaRunsDDLWhenMappingTableMissing(t *testing.T) {
 		"cursor_usage_events":                       true,
 	}
 	state.existingIndexes = map[string]bool{
-		"idx_cursor_usage_events_dedup": true,
+		"idx_cursor_usage_events_dedup":   true,
+		"idx_tool_result_events_terminal": true,
 	}
 	syncer := &Sync{pg: pg, schema: "agentsview"}
 


### PR DESCRIPTION
Activity reports no longer read historical tool-result payloads for every session while finding sessions in the selected period. SQLite and PostgreSQL now use a partial index on session and timestamp for completed or errored tool-execution events. The existing report query still includes completions that outlive session end metadata.

On an isolated large-archive snapshot, the same HTTP report took 60.1 seconds before indexing, 4.06 seconds on the first request afterward, and 0.44 seconds on a repeated request after reopening. The report data was unchanged.

Existing SQLite archives receive the index on their next writable open. PostgreSQL schema setup and the push readiness check install it for existing mirrors. Building the index requires a one-time scan and can delay that startup; SQLite logs the wait. The index does not require a session resync. Reviewers should focus on the partial-index predicates and the PostgreSQL push upgrade path.
