### PR TITLE
fix: honor remote project discovery policy in OpenHands

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -922,6 +922,11 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
 - **Agentsview:** `internal/parser/openhands.go` and
   `internal/parser/openhands_provider.go`; `TASKS.json` is legacy supplemental
   state rather than a requirement of the pinned current producer.
+- **Project discovery reverified 2026-09-08:** The pinned SDK's
+  [terminal observation](https://github.com/OpenHands/software-agent-sdk/blob/4fe565663af2b4f1130a6e0dac7566b002bfe9b4/openhands-tools/openhands/tools/terminal/definition.py)
+  carries `metadata.working_dir`. Remote imports derive project names from
+  recorded paths without inspecting those directories on the receiving
+  machine; local sessions retain filesystem-based Git project discovery.
 
 ## Cursor (`cursor`)
 

--- a/internal/parser/openhands.go
+++ b/internal/parser/openhands.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json/v2"
@@ -110,6 +111,7 @@ func OpenHandsSnapshot(path string) (FileInfo, error) {
 // parseSession parses a single OpenHands CLI conversation
 // directory into a session and messages.
 func (p *openHandsProvider) parseSession(
+	ctx context.Context,
 	path, machine string,
 ) (*ParsedSession, []ParsedMessage, error) {
 	sessionDir, err := normalizeOpenHandsSessionPath(path)
@@ -239,7 +241,7 @@ func (p *openHandsProvider) parseSession(
 
 	project := ""
 	if cwd != "" {
-		project = ExtractProjectFromCwd(cwd)
+		project = ExtractProjectFromCwdWithBranchContext(ctx, cwd, "")
 	}
 	if project == "" {
 		project = "openhands"

--- a/internal/parser/openhands_provider.go
+++ b/internal/parser/openhands_provider.go
@@ -87,7 +87,7 @@ func (p *openHandsProvider) Parse(
 		return ParseOutcome{}, fmt.Errorf("openhands source path unavailable")
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
-	sess, msgs, err := p.parseSession(path, machine)
+	sess, msgs, err := p.parseSession(ctx, path, machine)
 	if err != nil {
 		return ParseOutcome{}, err
 	}

--- a/internal/parser/openhands_provider_test.go
+++ b/internal/parser/openhands_provider_test.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"context"
+	"encoding/json/v2"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -144,6 +146,59 @@ func TestOpenHandsProviderParse(t *testing.T) {
 	assert.Equal(t, fingerprint.Hash, result.Result.Session.File.Hash)
 	assert.Equal(t, "parse question", result.Result.Session.FirstMessage)
 	assert.Len(t, result.Result.Messages, 1)
+}
+
+func TestOpenHandsProviderProjectDiscoveryPolicy(t *testing.T) {
+	for _, disableDiscovery := range []bool{false, true} {
+		t.Run(fmt.Sprintf("disabled=%t", disableDiscovery), func(t *testing.T) {
+			root := t.TempDir()
+			repo := filepath.Join(t.TempDir(), "repository")
+			cwd := filepath.Join(repo, "nested")
+			require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+			require.NoError(t, os.MkdirAll(cwd, 0o755))
+			sessionDir := openHandsProviderWriteSession(t, root,
+				"086c7ecf6cb746b69fbcb900358d1247",
+				"086c7ecf-6cb7-46b6-9fbc-b900358d1247", "project question")
+			cwdJSON, err := json.Marshal(cwd)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "events", "event-00001.json"),
+				[]byte(fmt.Sprintf(`{"id":"e1","timestamp":"2026-04-02T15:25:42","source":"environment",
+"observation":{"content":[{"type":"text","text":"terminal output"}],
+"metadata":{"working_dir":%s},"kind":"TerminalObservation"},"kind":"ObservationEvent"}`, cwdJSON)), 0o600))
+			provider, ok := NewProvider(AgentOpenHands, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			sources, err := provider.Discover(t.Context())
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+
+			originalStat := osStat
+			t.Cleanup(func() { osStat = originalStat })
+			probes := 0
+			osStat = func(path string) (os.FileInfo, error) {
+				if path == cwd {
+					probes++
+				}
+				return originalStat(path)
+			}
+			ctx := t.Context()
+			if disableDiscovery {
+				ctx = WithoutFilesystemProjectDiscovery(ctx)
+			}
+			outcome, err := provider.Parse(ctx, ParseRequest{Source: sources[0]})
+			require.NoError(t, err)
+			require.Len(t, outcome.Results, 1)
+			result := outcome.Results[0].Result
+			assert.Equal(t, cwd, result.Session.Cwd)
+			assert.Equal(t, "project question", result.Session.FirstMessage)
+			if disableDiscovery {
+				assert.Zero(t, probes, "recorded cwd must not be inspected")
+				assert.Equal(t, "nested", result.Session.Project)
+			} else {
+				assert.Positive(t, probes, "local Git discovery must still run")
+				assert.Equal(t, "repository", result.Session.Project)
+			}
+		})
+	}
 }
 
 func openHandsProviderWriteSession(

--- a/internal/remotesync/project_discovery_test.go
+++ b/internal/remotesync/project_discovery_test.go
@@ -33,6 +33,14 @@ func TestImporterUsesRecordedProjectWithoutLocalGitDiscovery(t *testing.T) {
 {"type":"response_item","timestamp":"2026-09-01T10:01:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Remote session content"}]}}
 `,
 		},
+		{
+			agent:    parser.AgentOpenHands,
+			filename: "086c7ecf6cb746b69fbcb900358d1247/events/event-00000.json",
+			id:       "openhands:086c7ecf-6cb7-46b6-9fbc-b900358d1247",
+			body: `{"id":"e0","timestamp":"2026-09-01T10:00:00Z","source":"environment",
+"observation":{"content":[{"type":"text","text":"Remote session content"}],
+"metadata":{"working_dir":%s},"kind":"TerminalObservation"},"kind":"ObservationEvent"}`,
+		},
 	} {
 		t.Run(string(tc.agent), func(t *testing.T) {
 			database := dbtest.OpenTestDB(t)
@@ -46,7 +54,7 @@ func TestImporterUsesRecordedProjectWithoutLocalGitDiscovery(t *testing.T) {
 			extracted := t.TempDir()
 			const remoteDir = "/remote/sessions"
 			sessions := remappedRemotePath(extracted, remoteDir)
-			require.NoError(t, os.MkdirAll(sessions, 0o755))
+			require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(sessions, tc.filename)), 0o755))
 			require.NoError(t, os.WriteFile(filepath.Join(sessions, tc.filename),
 				[]byte(fmt.Sprintf(tc.body, cwdJSON)), 0o600))
 


### PR DESCRIPTION
OpenHands sessions imported from another machine now derive project names from their recorded paths without inspecting those directories on the receiving machine. Previously, OpenHands dropped the existing import policy and could pick up an unrelated local repository or probe a network-backed path. Local sessions keep their normal Git project discovery.

This is the focused OpenHands follow-up to #1638. Imported sessions may use the recorded directory name instead of a repository name discovered on the receiving machine.
