### PR TITLE
fix(docker): reuse base-image build tools and certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,7 @@ RUN npm run build
 
 FROM golang:1.27.0-bookworm AS build
 
-COPY docker/debian-*.list /etc/apt/mirrors/
-RUN sed -i \
-      -e 's#URIs: http://deb.debian.org/debian$#URIs: mirror+file:/etc/apt/mirrors/debian-mirrors.list#' \
-      -e 's#URIs: http://deb.debian.org/debian-security$#URIs: mirror+file:/etc/apt/mirrors/debian-security-mirrors.list#' \
-      /etc/apt/sources.list.d/debian.sources \
-    && timeout 90s apt-get -o Acquire::http::Timeout=10 update \
-    && timeout 90s apt-get -o Acquire::http::Timeout=10 install -y --no-install-recommends build-essential ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+# The Go Bookworm image already includes the C/C++ toolchain and CA bundle.
 
 WORKDIR /src
 
@@ -60,15 +53,8 @@ RUN /out/agentsview --version
 
 FROM debian:bookworm-slim
 
-COPY docker/debian-*.list /etc/apt/mirrors/
-RUN sed -i \
-      -e 's#URIs: http://deb.debian.org/debian$#URIs: mirror+file:/etc/apt/mirrors/debian-mirrors.list#' \
-      -e 's#URIs: http://deb.debian.org/debian-security$#URIs: mirror+file:/etc/apt/mirrors/debian-security-mirrors.list#' \
-      /etc/apt/sources.list.d/debian.sources \
-    && timeout 90s apt-get -o Acquire::http::Timeout=10 update \
-    && timeout 90s apt-get -o Acquire::http::Timeout=10 install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /data /agents
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN mkdir -p /data /agents
 
 ENV AGENTSVIEW_DATA_DIR=/data
 

--- a/docker/debian-mirrors.list
+++ b/docker/debian-mirrors.list
@@ -1,8 +1,0 @@
-http://debian-archive.trafficmanager.net/debian/
-http://deb.debian.org/debian/
-http://ftp.us.debian.org/debian/
-http://debian.csail.mit.edu/debian/
-http://mirror.us.oneandone.net/debian/
-http://mirrors.ocf.berkeley.edu/debian/
-http://mirrors.accretive-networks.net/debian/
-http://repo.ialab.dsu.edu/debian/

--- a/docker/debian-security-mirrors.list
+++ b/docker/debian-security-mirrors.list
@@ -1,7 +1,0 @@
-http://debian-archive.trafficmanager.net/debian-security/
-http://security.debian.org/debian-security/
-http://debian.csail.mit.edu/debian-security/
-http://mirror.us.oneandone.net/debian-security/
-http://mirrors.ocf.berkeley.edu/debian-security/
-http://mirrors.accretive-networks.net/debian-security/
-http://repo.ialab.dsu.edu/debian-security/


### PR DESCRIPTION
Removes Debian package downloads from the Docker build, where mirror requests were exhausting the 90-second timeout. The Go Bookworm base already supplies the compilers and CA certificates; the runtime image now copies that CA bundle from the build stage.

Removes the unused mirror lists. Base images, application compilation, entrypoint, and runner configuration are unchanged.
