### PR TITLE
fix(sidebar): let agent names use available row width

### DIFF
--- a/frontend/e2e/sidebar-agent-names.spec.ts
+++ b/frontend/e2e/sidebar-agent-names.spec.ts
@@ -1,0 +1,332 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+const SIDEBAR_WIDTH_KEY = "agentsview-sidebar-width";
+const REVIEW_LABEL = "Open Code Review";
+const REGISTRY_LABEL = "Opencode";
+
+interface SidebarFixtureRow {
+  id: string;
+  parent_session_id: null;
+  relationship_type: null;
+  project: string;
+  machine: string;
+  agent: string;
+  agent_label?: string | null;
+  entrypoint?: string | null;
+  display_name: string;
+  first_message: string;
+  started_at: string;
+  ended_at: string;
+  created_at: string;
+  message_count: number;
+  user_message_count: number;
+  is_automated: boolean;
+  is_teammate: boolean;
+}
+
+interface SidebarFixtureResponse {
+  sessions: SidebarFixtureRow[];
+  next_cursor: null;
+  total: number;
+}
+
+const now = "2026-09-08T12:00:00Z";
+const fixtureRows: SidebarFixtureRow[] = [
+  {
+    id: "opencode-session",
+    parent_session_id: null,
+    relationship_type: null,
+    project: "fixture-project",
+    machine: "local",
+    agent: "opencode",
+    display_name: "OpenCode session",
+    first_message: "OpenCode session",
+    started_at: now,
+    ended_at: now,
+    created_at: now,
+    message_count: 3,
+    user_message_count: 2,
+    is_automated: false,
+    is_teammate: false,
+  },
+  {
+    id: "open-code-review-session",
+    parent_session_id: null,
+    relationship_type: null,
+    project: "fixture-project",
+    machine: "ci-runner-east",
+    agent: "opencode",
+    agent_label: REVIEW_LABEL,
+    entrypoint: "sdk-cli",
+    display_name: "Review session with a long title for ellipsis checks",
+    first_message: "Review session with a long title for ellipsis checks",
+    started_at: now,
+    ended_at: now,
+    created_at: now,
+    message_count: 4,
+    user_message_count: 3,
+    is_automated: false,
+    is_teammate: false,
+  },
+];
+
+function sidebarResponse(): SidebarFixtureResponse {
+  return {
+    sessions: fixtureRows,
+    next_cursor: null,
+    total: fixtureRows.length,
+  };
+}
+
+async function installSyntheticRoutes(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+
+    if (pathname.endsWith("/sessions/sidebar-index")) {
+      await route.fulfill({ json: sidebarResponse() });
+      return;
+    }
+    if (pathname.endsWith("/sessions")) {
+      await route.fulfill({ json: { sessions: fixtureRows, next_cursor: null, total: 2 } });
+      return;
+    }
+    if (pathname.endsWith("/agents")) {
+      await route.fulfill({ json: { agents: [{ name: "opencode", session_count: 2 }] } });
+      return;
+    }
+    if (pathname.endsWith("/machines")) {
+      await route.fulfill({ json: { machines: ["ci-runner-east"] } });
+      return;
+    }
+    if (pathname.endsWith("/projects")) {
+      await route.fulfill({
+        json: { projects: [{ name: "fixture-project", session_count: 2 }] },
+      });
+      return;
+    }
+    if (pathname.endsWith("/stats")) {
+      await route.fulfill({
+        json: {
+          session_count: 2,
+          message_count: 7,
+          user_message_count: 5,
+          assistant_message_count: 2,
+          tool_call_count: 0,
+          project_count: 1,
+          machine_count: 1,
+          agent_count: 1,
+          earliest_session: now,
+        },
+      });
+      return;
+    }
+    if (pathname.endsWith("/sync/status")) {
+      await route.fulfill({ json: { last_sync: null, stats: null } });
+      return;
+    }
+    if (pathname.endsWith("/version")) {
+      await route.fulfill({ json: { version: "test", commit: "test", read_only: false } });
+      return;
+    }
+    if (pathname.endsWith("/update/check")) {
+      await route.fulfill({ json: { update_available: false, current_version: "test" } });
+      return;
+    }
+    if (pathname.endsWith("/settings")) {
+      await route.fulfill({ json: {} });
+      return;
+    }
+
+    await route.fulfill({ json: {} });
+  });
+}
+
+async function openSessions(page: Page, viewportWidth: number, sidebarWidth: number) {
+  await page.setViewportSize({ width: viewportWidth, height: 900 });
+  await page.addInitScript(
+    ({ key, value }) => localStorage.setItem(key, String(value)),
+    { key: SIDEBAR_WIDTH_KEY, value: sidebarWidth },
+  );
+  await page.goto("/");
+  await expect(page.locator(".session-item").first()).toBeVisible();
+  await page.evaluate(() => document.fonts.ready);
+}
+
+async function measureRow(page: Page, sessionId: string) {
+  return page.locator(`[data-session-id="${sessionId}"]`).evaluate((row) => {
+    const rect = row.getBoundingClientRect();
+    const meta = row.querySelector<HTMLElement>(".side-meta")!;
+    const agent = row.querySelector<HTMLElement>(".agent-tag")!;
+    const name = row.querySelector<HTMLElement>(".session-name")!;
+    const controls = [...row.querySelectorAll<HTMLElement>("button, a")];
+    return {
+      row: { width: rect.width, height: rect.height, right: rect.right },
+      meta: { width: meta.getBoundingClientRect().width, right: meta.getBoundingClientRect().right },
+      agent: {
+        width: agent.getBoundingClientRect().width,
+        right: agent.getBoundingClientRect().right,
+        clientWidth: agent.clientWidth,
+        scrollWidth: agent.scrollWidth,
+      },
+      name: { width: name.getBoundingClientRect().width, scrollWidth: name.scrollWidth },
+      controls: controls.map((control) => {
+        const controlRect = control.getBoundingClientRect();
+        return { left: controlRect.left, right: controlRect.right, width: controlRect.width };
+      }),
+    };
+  });
+}
+
+async function prefixFitsBeforeEllipsis(page: Page, sessionId: string, prefixLength: number) {
+  return page.locator(`[data-session-id="${sessionId}"] .agent-tag`).evaluate(
+    (agent, length) => {
+      const textNode = agent.firstChild;
+      if (!textNode || textNode.nodeType !== Node.TEXT_NODE) return false;
+      const range = document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, length);
+      const prefix = range.getBoundingClientRect();
+      const tag = agent.getBoundingClientRect();
+      return prefix.width > 0 && prefix.right <= tag.right + 1;
+    },
+    prefixLength,
+  );
+}
+
+async function collectRenderFindings(page: Page) {
+  return page.evaluate(() => {
+    const sidebar = document.querySelector<HTMLElement>("#session-sidebar");
+    if (!sidebar) return ["missing #session-sidebar"];
+    const sidebarRect = sidebar.getBoundingClientRect();
+    const violations: string[] = [];
+    for (const row of sidebar.querySelectorAll<HTMLElement>(".session-item")) {
+      const rowRect = row.getBoundingClientRect();
+      const name = row.querySelector<HTMLElement>(".session-name");
+      const meta = row.querySelector<HTMLElement>(".side-meta");
+      if (rowRect.right > sidebarRect.right + 1) violations.push("row escaped sidebar");
+      if (name && name.getBoundingClientRect().right > rowRect.right + 1) {
+        violations.push("title escaped row");
+      }
+      if (meta && meta.getBoundingClientRect().right > rowRect.right + 1) {
+        violations.push("metadata escaped row");
+      }
+      for (const control of row.querySelectorAll<HTMLElement>("button, a")) {
+        const controlRect = control.getBoundingClientRect();
+        if (controlRect.right > rowRect.right + 1 || controlRect.left < rowRect.left - 1) {
+          violations.push("control escaped row");
+        }
+      }
+    }
+    return violations;
+  });
+}
+
+async function capture(page: Page, testInfo: TestInfo, name: string) {
+  const screenshotPath = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  return screenshotPath;
+}
+
+test.describe("sidebar agent names", () => {
+  test.beforeEach(async ({ page }) => {
+    await installSyntheticRoutes(page);
+  });
+
+  test("reporter distinction keeps the full label at 520px and a prefix at 220px", async ({ page }) => {
+    await openSessions(page, 1280, 520);
+    const wide = await measureRow(page, "open-code-review-session");
+    expect(wide.row.width).toBeGreaterThanOrEqual(518);
+    expect(wide.row.width).toBeLessThanOrEqual(520);
+    expect(wide.meta.width).toBeLessThanOrEqual(wide.row.width * 0.4 + 1);
+    expect(wide.agent.scrollWidth).toBeLessThanOrEqual(wide.agent.clientWidth + 1);
+    console.log(`width=520px ${JSON.stringify(wide)}`);
+    expect(page.locator('[data-session-id="open-code-review-session"] .agent-tag')).toHaveAttribute(
+      "title",
+      REVIEW_LABEL,
+    );
+    expect(page.locator('[data-session-id="opencode-session"] .agent-tag')).toHaveAttribute(
+      "title",
+      REGISTRY_LABEL,
+    );
+
+    await page.addInitScript(
+      ({ key, value }) => localStorage.setItem(key, String(value)),
+      { key: SIDEBAR_WIDTH_KEY, value: 220 },
+    );
+    await page.evaluate(
+      ({ key }) => localStorage.setItem(key, "220"),
+      { key: SIDEBAR_WIDTH_KEY },
+    );
+    await page.reload();
+    await expect(page.locator(".session-item").first()).toBeVisible();
+    await page.evaluate(() => document.fonts.ready);
+
+    const narrow = await measureRow(page, "open-code-review-session");
+    expect(narrow.row.width).toBeGreaterThanOrEqual(218);
+    expect(narrow.row.width).toBeLessThanOrEqual(220);
+    expect(narrow.meta.width).toBeLessThanOrEqual(narrow.row.width * 0.4 + 1);
+    expect(narrow.agent.scrollWidth).toBeGreaterThan(narrow.agent.clientWidth);
+    expect(await prefixFitsBeforeEllipsis(page, "open-code-review-session", "Open Code".length)).toBe(
+      true,
+    );
+    console.log(`width=220px ${JSON.stringify(narrow)}`);
+  });
+
+  test("metadata boundary preserves rows and controls across desktop and mobile widths", async ({ page }, testInfo) => {
+    await openSessions(page, 1280, 260);
+    const desktop = await measureRow(page, "open-code-review-session");
+    expect(desktop.row.height).toBeCloseTo(42, 0);
+    expect(desktop.name.width).toBeGreaterThan(0);
+    expect(desktop.meta.width).toBeLessThanOrEqual(desktop.row.width * 0.4 + 1);
+    expect(desktop.controls.every((control) => control.right <= desktop.row.right + 1)).toBe(true);
+    const desktopLint = await collectRenderFindings(page);
+    expect(desktopLint).toEqual([]);
+    console.log(`render-lint width=1280px violations=${JSON.stringify(desktopLint)}`);
+    console.log(`width=260px ${JSON.stringify(desktop)}`);
+    await capture(page, testInfo, "sidebar-agent-names-1280");
+
+    await page.setViewportSize({ width: 768, height: 900 });
+    await page.addInitScript(
+      ({ key, value }) => localStorage.setItem(key, String(value)),
+      { key: SIDEBAR_WIDTH_KEY, value: 520 },
+    );
+    await page.evaluate(
+      ({ key }) => localStorage.setItem(key, "520"),
+      { key: SIDEBAR_WIDTH_KEY },
+    );
+    await page.reload();
+    await expect(page.locator(".session-item").first()).toBeVisible();
+    await page.evaluate(() => document.fonts.ready);
+    const clamped = await page.locator("#session-sidebar").evaluate((sidebar) => {
+      const rect = sidebar.getBoundingClientRect();
+      return { viewport: "768px", width: rect.width };
+    });
+    expect(clamped.width).toBeGreaterThanOrEqual(220);
+    expect(clamped.width).toBeLessThan(520);
+    const clampedLint = await collectRenderFindings(page);
+    expect(clampedLint).toEqual([]);
+    console.log(`render-lint viewport=768px violations=${JSON.stringify(clampedLint)}`);
+    console.log(`viewport=768px actualSidebarWidth=${clamped.width}px`);
+    await capture(page, testInfo, "sidebar-agent-names-768");
+
+    await page.setViewportSize({ width: 400, height: 900 });
+    await page.reload();
+    const drawer = page.locator("#session-sidebar");
+    if (!(await drawer.evaluate((sidebar) => sidebar.classList.contains("open")))) {
+      await page.locator("button.hamburger").click();
+    }
+    await expect(drawer).toHaveClass(/open/);
+    await expect(page.locator(".session-item").first()).toBeVisible();
+    await page.evaluate(() => document.fonts.ready);
+    const drawerBox = await drawer.boundingBox();
+    expect(drawerBox?.width).toBeCloseTo(280, 0);
+    const mobile = await measureRow(page, "open-code-review-session");
+    expect(mobile.row.height).toBeCloseTo(42, 0);
+    expect(mobile.meta.width).toBeLessThanOrEqual(mobile.row.width * 0.4 + 1);
+    const mobileLint = await collectRenderFindings(page);
+    expect(mobileLint).toEqual([]);
+    console.log(`render-lint viewport=400px drawer=280px violations=${JSON.stringify(mobileLint)}`);
+    console.log(`viewport=400px drawer=280px ${JSON.stringify(mobile)}`);
+    await capture(page, testInfo, "sidebar-agent-names-400");
+  });
+});

--- a/frontend/e2e/sidebar-agent-names.spec.ts
+++ b/frontend/e2e/sidebar-agent-names.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page, type TestInfo } from "@playwright/test";
 
 const SIDEBAR_WIDTH_KEY = "agentsview-sidebar-width";
 const REVIEW_LABEL = "Open Code Review";
+const LONG_LABEL = "Open Code Review With a Very Long Custom Label";
 const REGISTRY_LABEL = "Opencode";
 
 interface SidebarFixtureRow {
@@ -68,6 +69,25 @@ const fixtureRows: SidebarFixtureRow[] = [
     is_automated: false,
     is_teammate: false,
   },
+  {
+    id: "long-label-session",
+    parent_session_id: null,
+    relationship_type: null,
+    project: "fixture-project",
+    machine: "ci-runner-west",
+    agent: "opencode",
+    agent_label: LONG_LABEL,
+    entrypoint: "sdk-python-experimental-runner",
+    display_name: "Long label session with metadata",
+    first_message: "Long label session with metadata",
+    started_at: now,
+    ended_at: now,
+    created_at: now,
+    message_count: 5,
+    user_message_count: 4,
+    is_automated: false,
+    is_teammate: false,
+  },
 ];
 
 function sidebarResponse(): SidebarFixtureResponse {
@@ -87,33 +107,37 @@ async function installSyntheticRoutes(page: Page) {
       return;
     }
     if (pathname.endsWith("/sessions")) {
-      await route.fulfill({ json: { sessions: fixtureRows, next_cursor: null, total: 2 } });
+      await route.fulfill({
+        json: { sessions: fixtureRows, next_cursor: null, total: fixtureRows.length },
+      });
       return;
     }
     if (pathname.endsWith("/agents")) {
-      await route.fulfill({ json: { agents: [{ name: "opencode", session_count: 2 }] } });
+      await route.fulfill({
+        json: { agents: [{ name: "opencode", session_count: fixtureRows.length }] },
+      });
       return;
     }
     if (pathname.endsWith("/machines")) {
-      await route.fulfill({ json: { machines: ["ci-runner-east"] } });
+      await route.fulfill({ json: { machines: ["ci-runner-east", "ci-runner-west"] } });
       return;
     }
     if (pathname.endsWith("/projects")) {
       await route.fulfill({
-        json: { projects: [{ name: "fixture-project", session_count: 2 }] },
+        json: { projects: [{ name: "fixture-project", session_count: fixtureRows.length }] },
       });
       return;
     }
     if (pathname.endsWith("/stats")) {
       await route.fulfill({
         json: {
-          session_count: 2,
-          message_count: 7,
-          user_message_count: 5,
-          assistant_message_count: 2,
+          session_count: fixtureRows.length,
+          message_count: 12,
+          user_message_count: 9,
+          assistant_message_count: 3,
           tool_call_count: 0,
           project_count: 1,
-          machine_count: 1,
+          machine_count: 2,
           agent_count: 1,
           earliest_session: now,
         },
@@ -160,7 +184,13 @@ async function measureRow(page: Page, sessionId: string) {
     const name = row.querySelector<HTMLElement>(".session-name")!;
     const controls = [...row.querySelectorAll<HTMLElement>("button, a")];
     return {
-      row: { width: rect.width, height: rect.height, right: rect.right },
+      row: {
+        width: rect.width,
+        height: rect.height,
+        top: rect.top,
+        bottom: rect.bottom,
+        right: rect.right,
+      },
       meta: { width: meta.getBoundingClientRect().width, right: meta.getBoundingClientRect().right },
       agent: {
         width: agent.getBoundingClientRect().width,
@@ -168,6 +198,12 @@ async function measureRow(page: Page, sessionId: string) {
         clientWidth: agent.clientWidth,
         scrollWidth: agent.scrollWidth,
       },
+      entrypoint: (() => {
+        const element = row.querySelector<HTMLElement>(".entrypoint-tag");
+        if (!element) return null;
+        const rect = element.getBoundingClientRect();
+        return { top: rect.top, bottom: rect.bottom, height: rect.height };
+      })(),
       name: { width: name.getBoundingClientRect().width, scrollWidth: name.scrollWidth },
       controls: controls.map((control) => {
         const controlRect = control.getBoundingClientRect();
@@ -210,10 +246,21 @@ async function collectRenderFindings(page: Page) {
       if (meta && meta.getBoundingClientRect().right > rowRect.right + 1) {
         violations.push("metadata escaped row");
       }
-      for (const control of row.querySelectorAll<HTMLElement>("button, a")) {
-        const controlRect = control.getBoundingClientRect();
-        if (controlRect.right > rowRect.right + 1 || controlRect.left < rowRect.left - 1) {
-          violations.push("control escaped row");
+      for (const element of row.querySelectorAll<HTMLElement>(
+        ".session-name, .side-meta, .side-meta > *, button, a",
+      )) {
+        const elementRect = element.getBoundingClientRect();
+        if (
+          elementRect.right > rowRect.right + 1 ||
+          elementRect.left < rowRect.left - 1
+        ) {
+          violations.push("element escaped row horizontally");
+        }
+        if (
+          elementRect.bottom > rowRect.bottom + 1 ||
+          elementRect.top < rowRect.top - 1
+        ) {
+          violations.push("element escaped row vertically");
         }
       }
     }
@@ -223,7 +270,7 @@ async function collectRenderFindings(page: Page) {
 
 async function capture(page: Page, testInfo: TestInfo, name: string) {
   const screenshotPath = testInfo.outputPath(`${name}.png`);
-  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await page.locator("#session-sidebar").screenshot({ path: screenshotPath });
   return screenshotPath;
 }
 
@@ -265,11 +312,22 @@ test.describe("sidebar agent names", () => {
     expect(narrow.row.width).toBeGreaterThanOrEqual(218);
     expect(narrow.row.width).toBeLessThanOrEqual(220);
     expect(narrow.meta.width).toBeLessThanOrEqual(narrow.row.width * 0.4 + 1);
-    expect(narrow.agent.scrollWidth).toBeGreaterThan(narrow.agent.clientWidth);
     expect(await prefixFitsBeforeEllipsis(page, "open-code-review-session", "Open Code".length)).toBe(
       true,
     );
+    const longLabel = await measureRow(page, "long-label-session");
+    expect(longLabel.row.height).toBeCloseTo(42, 0);
+    expect(longLabel.meta.width).toBeLessThanOrEqual(longLabel.row.width * 0.4 + 1);
+    expect(longLabel.name.width).toBeGreaterThan(0);
+    expect(longLabel.agent.scrollWidth).toBeGreaterThan(longLabel.agent.clientWidth);
+    expect(longLabel.entrypoint?.bottom).toBeLessThanOrEqual(longLabel.row.bottom + 1);
+    expect(longLabel.entrypoint?.top).toBeGreaterThanOrEqual(longLabel.row.top - 1);
+    expect(page.locator('[data-session-id="long-label-session"] .agent-tag')).toHaveAttribute(
+      "title",
+      LONG_LABEL,
+    );
     console.log(`width=220px ${JSON.stringify(narrow)}`);
+    console.log(`width=220px long-label ${JSON.stringify(longLabel)}`);
   });
 
   test("metadata boundary preserves rows and controls across desktop and mobile widths", async ({ page }, testInfo) => {
@@ -279,6 +337,8 @@ test.describe("sidebar agent names", () => {
     expect(desktop.name.width).toBeGreaterThan(0);
     expect(desktop.meta.width).toBeLessThanOrEqual(desktop.row.width * 0.4 + 1);
     expect(desktop.controls.every((control) => control.right <= desktop.row.right + 1)).toBe(true);
+    const longDesktop = await measureRow(page, "long-label-session");
+    expect(longDesktop.entrypoint?.bottom).toBeLessThanOrEqual(longDesktop.row.bottom + 1);
     const desktopLint = await collectRenderFindings(page);
     expect(desktopLint).toEqual([]);
     console.log(`render-lint width=1280px violations=${JSON.stringify(desktopLint)}`);

--- a/frontend/e2e/sidebar-agent-names.spec.ts
+++ b/frontend/e2e/sidebar-agent-names.spec.ts
@@ -326,8 +326,6 @@ test.describe("sidebar agent names", () => {
       "title",
       LONG_LABEL,
     );
-    await page.locator('[data-session-id="long-label-session"] .agent-tag').hover();
-    await expect(page.locator(".kit-tooltip")).toHaveText(LONG_LABEL);
     console.log(`width=220px ${JSON.stringify(narrow)}`);
     console.log(`width=220px long-label ${JSON.stringify(longLabel)}`);
   });

--- a/frontend/e2e/sidebar-agent-names.spec.ts
+++ b/frontend/e2e/sidebar-agent-names.spec.ts
@@ -327,7 +327,7 @@ test.describe("sidebar agent names", () => {
       LONG_LABEL,
     );
     await page.locator('[data-session-id="long-label-session"] .agent-tag').hover();
-    await expect(page.locator(".agent-tooltip")).toHaveText(LONG_LABEL);
+    await expect(page.locator(".kit-tooltip")).toHaveText(LONG_LABEL);
     console.log(`width=220px ${JSON.stringify(narrow)}`);
     console.log(`width=220px long-label ${JSON.stringify(longLabel)}`);
   });

--- a/frontend/e2e/sidebar-agent-names.spec.ts
+++ b/frontend/e2e/sidebar-agent-names.spec.ts
@@ -326,6 +326,8 @@ test.describe("sidebar agent names", () => {
       "title",
       LONG_LABEL,
     );
+    await page.locator('[data-session-id="long-label-session"] .agent-tag').hover();
+    await expect(page.locator(".agent-tooltip")).toHaveText(LONG_LABEL);
     console.log(`width=220px ${JSON.stringify(narrow)}`);
     console.log(`width=220px long-label ${JSON.stringify(longLabel)}`);
   });

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -189,6 +189,38 @@
   // Context menu state
   let contextMenu: { x: number; y: number } | null = $state(null);
 
+  type AgentTooltip = {
+    label: string;
+    left: number;
+    top: number;
+    maxWidth: number;
+  };
+
+  let agentTooltip: AgentTooltip | null = $state(null);
+
+  function showAgentTooltip(target: EventTarget | null) {
+    if (!(target instanceof HTMLElement)) return;
+    const label = target.getAttribute("title")?.trim();
+    if (!label || target.scrollWidth <= target.clientWidth + 1) return;
+    const rect = target.getBoundingClientRect();
+    const maxWidth = Math.min(360, Math.max(180, window.innerWidth - 16));
+    const rightAlignedLeft = rect.right - maxWidth;
+    const left = Math.min(
+      Math.max(8, rightAlignedLeft),
+      Math.max(8, window.innerWidth - maxWidth - 8),
+    );
+    const estimatedHeight = 32;
+    const belowTop = rect.bottom + 6;
+    const top = belowTop + estimatedHeight <= window.innerHeight
+      ? belowTop
+      : Math.max(8, rect.top - estimatedHeight - 6);
+    agentTooltip = { label, left, top, maxWidth };
+  }
+
+  function hideAgentTooltip() {
+    agentTooltip = null;
+  }
+
   // Rename state
   let renaming = $state(false);
   let renameValue = $state("");
@@ -485,6 +517,8 @@
           class="agent-tag"
           style:color={agentColor}
           title={agentLabel(session.agent, session.agent_label)}
+          onmouseenter={(event) => showAgentTooltip(event.currentTarget)}
+          onmouseleave={hideAgentTooltip}
         >{agentLabel(session.agent, session.agent_label)}</span>
         {#if entrypointBadge(session.entrypoint)}
           <span class="entrypoint-tag">{entrypointBadge(session.entrypoint)}</span>
@@ -498,6 +532,17 @@
     </div>
   {/if}
 </div>
+
+{#if agentTooltip}
+  <div
+    class="agent-tooltip"
+    use:portal
+    role="tooltip"
+    style:left={`${agentTooltip.left}px`}
+    style:top={`${agentTooltip.top}px`}
+    style:max-width={`${agentTooltip.maxWidth}px`}
+  >{agentTooltip.label}</div>
+{/if}
 
 {#if contextMenu}
   <div
@@ -641,6 +686,22 @@
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  :global(.agent-tooltip) {
+    position: fixed;
+    z-index: 1000;
+    box-sizing: border-box;
+    padding: 5px 8px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    box-shadow: var(--shadow-md);
+    font-size: 11px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+    pointer-events: none;
   }
 
   .entrypoint-tag {

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -23,7 +23,7 @@
     UserRoundIcon,
     UsersRoundIcon,
   } from "../../icons.js";
-  import { StatusDot } from "@kenn-io/kit-ui";
+  import { StatusDot, Tooltip } from "@kenn-io/kit-ui";
   import { sessionStatusLabel } from "../../utils/sessionStatus.js";
   import { router } from "../../stores/router.svelte.js";
 
@@ -188,38 +188,6 @@
 
   // Context menu state
   let contextMenu: { x: number; y: number } | null = $state(null);
-
-  type AgentTooltip = {
-    label: string;
-    left: number;
-    top: number;
-    maxWidth: number;
-  };
-
-  let agentTooltip: AgentTooltip | null = $state(null);
-
-  function showAgentTooltip(target: EventTarget | null) {
-    if (!(target instanceof HTMLElement)) return;
-    const label = target.getAttribute("title")?.trim();
-    if (!label || target.scrollWidth <= target.clientWidth + 1) return;
-    const rect = target.getBoundingClientRect();
-    const maxWidth = Math.min(360, Math.max(180, window.innerWidth - 16));
-    const rightAlignedLeft = rect.right - maxWidth;
-    const left = Math.min(
-      Math.max(8, rightAlignedLeft),
-      Math.max(8, window.innerWidth - maxWidth - 8),
-    );
-    const estimatedHeight = 32;
-    const belowTop = rect.bottom + 6;
-    const top = belowTop + estimatedHeight <= window.innerHeight
-      ? belowTop
-      : Math.max(8, rect.top - estimatedHeight - 6);
-    agentTooltip = { label, left, top, maxWidth };
-  }
-
-  function hideAgentTooltip() {
-    agentTooltip = null;
-  }
 
   // Rename state
   let renaming = $state(false);
@@ -513,13 +481,19 @@
   {#if !compact && (!hideAgent || showMachine)}
     <div class="side-meta">
       {#if !hideAgent}
-        <span
-          class="agent-tag"
-          style:color={agentColor}
-          title={agentLabel(session.agent, session.agent_label)}
-          onmouseenter={(event) => showAgentTooltip(event.currentTarget)}
-          onmouseleave={hideAgentTooltip}
-        >{agentLabel(session.agent, session.agent_label)}</span>
+        <div class="agent-tag-wrapper">
+          <Tooltip
+            text={agentLabel(session.agent, session.agent_label)}
+            openDelayMs={0}
+            align="end"
+          >
+            <span
+              class="agent-tag"
+              style:color={agentColor}
+              title={agentLabel(session.agent, session.agent_label)}
+            >{agentLabel(session.agent, session.agent_label)}</span>
+          </Tooltip>
+        </div>
         {#if entrypointBadge(session.entrypoint)}
           <span class="entrypoint-tag">{entrypointBadge(session.entrypoint)}</span>
         {/if}
@@ -532,17 +506,6 @@
     </div>
   {/if}
 </div>
-
-{#if agentTooltip}
-  <div
-    class="agent-tooltip"
-    use:portal
-    role="tooltip"
-    style:left={`${agentTooltip.left}px`}
-    style:top={`${agentTooltip.top}px`}
-    style:max-width={`${agentTooltip.maxWidth}px`}
-  >{agentTooltip.label}</div>
-{/if}
 
 {#if contextMenu}
   <div
@@ -688,20 +651,19 @@
     text-overflow: ellipsis;
   }
 
-  :global(.agent-tooltip) {
-    position: fixed;
-    z-index: 1000;
-    box-sizing: border-box;
-    padding: 5px 8px;
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-sm);
-    background: var(--bg-surface);
-    color: var(--text-primary);
-    box-shadow: var(--shadow-md);
-    font-size: 11px;
-    line-height: 1.35;
-    overflow-wrap: anywhere;
-    pointer-events: none;
+  .agent-tag-wrapper {
+    display: flex;
+    align-items: flex-end;
+    height: 8px;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .agent-tag-wrapper :global(.kit-tooltip-trigger) {
+    display: flex;
+    align-items: flex-end;
+    height: 8px;
+    max-width: 100%;
   }
 
   .entrypoint-tag {

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -23,7 +23,7 @@
     UserRoundIcon,
     UsersRoundIcon,
   } from "../../icons.js";
-  import { StatusDot, Tooltip } from "@kenn-io/kit-ui";
+  import { StatusDot } from "@kenn-io/kit-ui";
   import { sessionStatusLabel } from "../../utils/sessionStatus.js";
   import { router } from "../../stores/router.svelte.js";
 
@@ -427,6 +427,7 @@
         <div
           class="session-name"
           class:shell={displayLabel.isShell}
+          title={displayLabel.text}
           ondblclick={handleDblClick}
         >
           {#if displayLabel.isShell}
@@ -437,7 +438,7 @@
         </div>
         <div class="session-meta">
           {#if !hideProject}
-            <span class="session-project">{session.project}</span>
+            <span class="session-project" title={session.project}>{session.project}</span>
           {/if}
           <span class="session-time">{timeStr}</span>
           {#if hasUnread}
@@ -481,21 +482,16 @@
   {#if !compact && (!hideAgent || showMachine)}
     <div class="side-meta">
       {#if !hideAgent}
-        <div class="agent-tag-wrapper">
-          <Tooltip
-            text={agentLabel(session.agent, session.agent_label)}
-            openDelayMs={0}
-            align="end"
-          >
-            <span
-              class="agent-tag"
-              style:color={agentColor}
-              title={agentLabel(session.agent, session.agent_label)}
-            >{agentLabel(session.agent, session.agent_label)}</span>
-          </Tooltip>
-        </div>
+        <span
+          class="agent-tag"
+          style:color={agentColor}
+          title={agentLabel(session.agent, session.agent_label)}
+        >{agentLabel(session.agent, session.agent_label)}</span>
         {#if entrypointBadge(session.entrypoint)}
-          <span class="entrypoint-tag">{entrypointBadge(session.entrypoint)}</span>
+          <span
+            class="entrypoint-tag"
+            title={entrypointBadge(session.entrypoint)}
+          >{entrypointBadge(session.entrypoint)}</span>
         {/if}
       {/if}
       {#if showMachine}
@@ -649,21 +645,6 @@
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .agent-tag-wrapper {
-    display: flex;
-    align-items: flex-end;
-    height: 8px;
-    min-width: 0;
-    max-width: 100%;
-  }
-
-  .agent-tag-wrapper :global(.kit-tooltip-trigger) {
-    display: flex;
-    align-items: flex-end;
-    height: 8px;
-    max-width: 100%;
   }
 
   .entrypoint-tag {

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -495,7 +495,7 @@
         {/if}
       {/if}
       {#if showMachine}
-        <span class="machine-tag" title={session.machine}>
+        <span class="machine-tag">
           {truncate(session.machine, 18)}
         </span>
       {/if}

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -646,6 +646,10 @@
   .entrypoint-tag {
     opacity: 0.75;
     font-size: 0.9em;
+    white-space: nowrap;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .machine-tag {

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -481,7 +481,11 @@
   {#if !compact && (!hideAgent || showMachine)}
     <div class="side-meta">
       {#if !hideAgent}
-        <span class="agent-tag" style:color={agentColor}>{agentLabel(session.agent, session.agent_label)}</span>
+        <span
+          class="agent-tag"
+          style:color={agentColor}
+          title={agentLabel(session.agent, session.agent_label)}
+        >{agentLabel(session.agent, session.agent_label)}</span>
         {#if entrypointBadge(session.entrypoint)}
           <span class="entrypoint-tag">{entrypointBadge(session.entrypoint)}</span>
         {/if}
@@ -621,6 +625,7 @@
     gap: var(--space-1);
     min-width: 0;
     flex-shrink: 0;
+    max-width: 40%;
     margin-left: 4px;
   }
 
@@ -633,7 +638,7 @@
     line-height: 1;
     opacity: 0.7;
     white-space: nowrap;
-    max-width: 52px;
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/frontend/src/lib/components/sidebar/SessionItem.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionItem.test.ts
@@ -38,12 +38,24 @@ describe("SessionItem identity", () => {
   }
 
   it("renders the session label and entrypoint badge", () => {
-    mountSession({ id: "custom-label", agent_label: "Claude Triage", entrypoint: "sdk-cli" });
+    mountSession({
+      id: "custom-label",
+      display_name: "A session with a long title",
+      agent_label: "Claude Triage",
+      entrypoint: "sdk-cli",
+      machine: "remote-machine",
+    });
 
     const agentTag = document.querySelector<HTMLElement>(".agent-tag");
     expect(agentTag?.textContent).toBe("Claude Triage");
     expect(agentTag?.title).toBe("Claude Triage");
     expect(document.querySelector(".entrypoint-tag")?.textContent).toBe("sdk-cli");
+    expect(document.querySelector<HTMLElement>(".session-name")?.title).toBe(
+      "A session with a long title",
+    );
+    expect(document.querySelector<HTMLElement>(".session-project")?.title).toBe("project");
+    expect(document.querySelector<HTMLElement>(".entrypoint-tag")?.title).toBe("sdk-cli");
+    expect(document.querySelector<HTMLElement>(".machine-tag")?.title).toBe("remote-machine");
   });
 
   it("uses the registry label when no override exists", () => {

--- a/frontend/src/lib/components/sidebar/SessionItem.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionItem.test.ts
@@ -55,7 +55,6 @@ describe("SessionItem identity", () => {
     );
     expect(document.querySelector<HTMLElement>(".session-project")?.title).toBe("project");
     expect(document.querySelector<HTMLElement>(".entrypoint-tag")?.title).toBe("sdk-cli");
-    expect(document.querySelector<HTMLElement>(".machine-tag")?.title).toBe("remote-machine");
   });
 
   it("uses the registry label when no override exists", () => {

--- a/frontend/src/lib/components/sidebar/SessionItem.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionItem.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import { flushSync, mount, unmount } from "svelte";
+import { createClassComponent } from "svelte/legacy";
 import SessionItem from "./SessionItem.svelte";
 
 let component: ReturnType<typeof mount> | undefined;
@@ -12,54 +13,94 @@ afterEach(() => {
 });
 
 describe("SessionItem identity", () => {
-  it("renders the session label and entrypoint badge", () => {
+  const baseSession = {
+    id: "session",
+    project: "project",
+    machine: "local",
+    agent: "claude",
+    first_message: "Inspect the issue",
+    started_at: "2024-01-01T00:00:00Z",
+    ended_at: "2024-01-01T00:01:00Z",
+    created_at: "2024-01-01T00:00:00Z",
+    message_count: 1,
+    user_message_count: 1,
+  };
+
+  function mountSession(overrides: Record<string, unknown> = {}, props = {}) {
     component = mount(SessionItem, {
       target: document.body,
       props: {
-        session: {
-          id: "custom-label",
-          project: "project",
-          machine: "local",
-          agent: "claude",
-          agent_label: "Claude Triage",
-          entrypoint: "sdk-cli",
-          first_message: "Inspect the issue",
-          started_at: "2024-01-01T00:00:00Z",
-          ended_at: "2024-01-01T00:01:00Z",
-          created_at: "2024-01-01T00:00:00Z",
-          message_count: 1,
-          user_message_count: 1,
-        },
+        session: { ...baseSession, ...overrides },
+        ...props,
       },
     });
     flushSync();
+  }
 
-    expect(document.querySelector(".agent-tag")?.textContent).toBe("Claude Triage");
+  it("renders the session label and entrypoint badge", () => {
+    mountSession({ id: "custom-label", agent_label: "Claude Triage", entrypoint: "sdk-cli" });
+
+    const agentTag = document.querySelector<HTMLElement>(".agent-tag");
+    expect(agentTag?.textContent).toBe("Claude Triage");
+    expect(agentTag?.title).toBe("Claude Triage");
     expect(document.querySelector(".entrypoint-tag")?.textContent).toBe("sdk-cli");
   });
 
-  it("suppresses the default cli entrypoint badge", () => {
-    component = mount(SessionItem, {
+  it("uses the registry label when no override exists", () => {
+    mountSession({ agent: "qwen" });
+
+    const agentTag = document.querySelector<HTMLElement>(".agent-tag");
+    expect(agentTag?.textContent).toBe("Qwen Code");
+    expect(agentTag?.title).toBe("Qwen Code");
+  });
+
+  it("uses the registry label for a whitespace-only override", () => {
+    mountSession({ agent: "qwen", agent_label: "   " });
+
+    const agentTag = document.querySelector<HTMLElement>(".agent-tag");
+    expect(agentTag?.textContent).toBe("Qwen Code");
+    expect(agentTag?.title).toBe("Qwen Code");
+  });
+
+  it("updates the visible label and title when the session prop changes", () => {
+    const session = { ...baseSession, agent: "qwen", agent_label: "Initial Label" };
+    const legacyComponent = createClassComponent({
+      component: SessionItem,
       target: document.body,
-      props: {
-        session: {
-          id: "default-entrypoint",
-          project: "project",
-          machine: "local",
-          agent: "claude",
-          entrypoint: "cli",
-          first_message: "Inspect the issue",
-          started_at: "2024-01-01T00:00:00Z",
-          ended_at: "2024-01-01T00:01:00Z",
-          created_at: "2024-01-01T00:00:00Z",
-          message_count: 1,
-          user_message_count: 1,
-        },
-      },
+      props: { session },
+    });
+    component = legacyComponent as unknown as ReturnType<typeof mount>;
+    flushSync();
+
+    legacyComponent.$set({
+      session: { ...session, agent_label: "Updated Label" },
     });
     flushSync();
 
+    const agentTag = document.querySelector<HTMLElement>(".agent-tag");
+    expect(agentTag?.textContent).toBe("Updated Label");
+    expect(agentTag?.title).toBe("Updated Label");
+  });
+
+  it("suppresses the default cli entrypoint badge", () => {
+    mountSession({ id: "default-entrypoint", entrypoint: "cli" });
+
     expect(document.querySelector(".agent-tag")?.textContent).toBe("Claude");
     expect(document.querySelector(".entrypoint-tag")).toBeNull();
+  });
+
+  it("preserves compact and grouped metadata visibility", () => {
+    mountSession({ machine: "remote" }, { compact: true });
+    expect(document.querySelector(".agent-tag")).toBeNull();
+    expect(document.querySelector(".machine-tag")).toBeNull();
+    expect(document.querySelector(".session-item")?.classList.contains("compact")).toBe(true);
+
+    unmount(component!);
+    component = undefined;
+    document.body.innerHTML = "";
+
+    mountSession({ machine: "remote", agent_label: "Grouped Label" }, { hideAgent: true });
+    expect(document.querySelector(".agent-tag")).toBeNull();
+    expect(document.querySelector(".machine-tag")?.textContent).toBe("remote");
   });
 });


### PR DESCRIPTION
Long agent names use more of the session sidebar, so OpenCode and Open Code Review remain distinguishable while you scan rows. Names that still need truncation show their full label in a tooltip on hover.

`SessionItem.svelte` capped every agent label at 52px even when the sidebar had more room. This change lets the label use a bounded share of the row while preserving the flexible session title, machine metadata, entrypoint resolution and suppression, row actions, and responsive sidebar limits. Long entrypoint badges stay on one line and ellipsize within that bound.

The reproduction came from @thibaudcolas while testing https://github.com/kenn-io/agentsview/pull/1660#issuecomment-5583286507.

Closes #1673

