### PR TITLE
fix(copilot): report output without shutdown summaries

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -559,15 +559,21 @@ add an archived or maintained mirror without replacing the original identity.
   [Copilot format notes](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/docs/providers/copilot.md)
   and
   [parser](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/src/providers/copilot.ts).
-- **Usage and cost:** Shutdown metrics can persist input, output, cache-read,
-  cache-write, and reasoning tokens. Copilot accounting is credit-oriented;
-  Agentsview does not treat credits as USD and does not infer a monetary cost.
+- **Usage and cost:** Assistant messages can persist model identity and output
+  tokens. Shutdown metrics can persist input, output, cache-read, cache-write,
+  and reasoning totals. When the latter are absent, Agentsview records only
+  known per-message output tokens; it does not infer input, cache, reasoning,
+  or credit totals. Known-model tokens use catalog estimates; the existing
+  shutdown reported-cost treatment is unchanged.
 - **Agentsview:** `internal/parser/copilot.go` and
   `internal/parser/copilot_provider.go`. Reverified 2026-07-28 against local
   Copilot CLI 1.0.76-0 transcripts: `tool.execution_start` and
   `tool.execution_complete` carry the same `data.toolCallId` and independent
   RFC3339 `timestamp` values, providing an exact execution interval even when
   the next user message arrives after a long resumed-session idle gap.
+  Reverified 2026-09-04 against current local transcripts: an
+  `assistant.message` can carry `data.model` and `data.outputTokens` when no
+  usable `session.shutdown` metrics are present.
 
 ## Gemini CLI (`gemini`)
 

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -431,11 +431,14 @@ authoritative, and fixed web-search fees remain at their published face value.
 As of 0.32.0, Copilot CLI sessions contribute to usage and cost reports.
 AgentsView reads per-message assistant output tokens from
 `assistant.message.outputTokens`, then reads model-level session totals from
-`session.shutdown.modelMetrics`. Fresh input tokens are computed as total input
-minus cache reads and cache writes; cache writes map to cache-creation tokens,
-and cache reads map to cache-read tokens. Copilot's Claude model IDs use dotted
-version numbers, so the parser normalizes names such as `claude-sonnet-4.6` to
-`claude-sonnet-4-6` before pricing lookup.
+`session.shutdown.modelMetrics`. When Copilot has not written a usable shutdown
+summary, known per-message output tokens still appear in usage reports. That
+partial fallback cannot report input, cache, reasoning, or Copilot AI Credit
+totals. Fresh input tokens are computed as total input minus cache reads and
+cache writes; cache writes map to cache-creation tokens, and cache reads map to
+cache-read tokens. Copilot's Claude model IDs use dotted version numbers, so the
+parser normalizes names such as `claude-sonnet-4.6` to `claude-sonnet-4-6`
+before pricing lookup.
 
 Upgrading to 0.32.0 bumps the parser data version so existing Copilot CLI
 sessions are re-indexed with the new usage rows.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -471,7 +471,8 @@ CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
 // (102: Cursor legacy text transcripts now preserve nonempty tool-result
 // bodies as result events. Existing Cursor rows need re-parsing to recover
 // output from unchanged source files.)
-const dataVersion = 102
+// (103: Copilot assistant output is reported without a shutdown summary.)
+const dataVersion = 103
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"encoding/json/jsontext"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,15 +35,16 @@ var copilotUsageBasedPricingStartedAt = time.Date(
 // copilotSessionBuilder accumulates state while scanning a
 // Copilot JSONL session file line by line.
 type copilotSessionBuilder struct {
-	messages     []ParsedMessage
-	usageEvents  []ParsedUsageEvent
-	firstMessage string
-	startedAt    time.Time
-	endedAt      time.Time
-	sessionID    string
-	project      string
-	ordinal      int
-	currentModel string
+	messages                []ParsedMessage
+	usageEvents             []ParsedUsageEvent
+	firstMessage            string
+	startedAt               time.Time
+	endedAt                 time.Time
+	sessionID               string
+	project                 string
+	ordinal                 int
+	currentModel            string
+	shutdownCoveredMessages int
 }
 
 func newCopilotSessionBuilder() *copilotSessionBuilder {
@@ -193,6 +195,10 @@ func (b *copilotSessionBuilder) handleAssistantMessage(
 
 	outputTokens := int(data.Get("outputTokens").Int())
 	hasOutputTokens := data.Get("outputTokens").Exists()
+	model := normalizeCopilotModel(data.Get("model").Str)
+	if model == "" {
+		model = b.currentModel
+	}
 
 	b.messages = append(b.messages, ParsedMessage{
 		Ordinal:         b.ordinal,
@@ -203,7 +209,7 @@ func (b *copilotSessionBuilder) handleAssistantMessage(
 		HasToolUse:      hasToolUse,
 		ContentLength:   len(displayContent),
 		ToolCalls:       toolCalls,
-		Model:           b.currentModel,
+		Model:           model,
 		OutputTokens:    outputTokens,
 		HasOutputTokens: hasOutputTokens,
 	})
@@ -343,6 +349,9 @@ func (b *copilotSessionBuilder) handleShutdown(
 			return true
 		},
 	)
+	if len(events) > 0 {
+		b.shutdownCoveredMessages = len(b.messages)
+	}
 	sort.Slice(events, func(i, j int) bool {
 		return events[i].Model < events[j].Model
 	})
@@ -368,6 +377,19 @@ func (b *copilotSessionBuilder) handleShutdown(
 		events[0].CostSource = copilotReportedCostSource
 	}
 	b.usageEvents = append(b.usageEvents, events...)
+}
+
+func (b *copilotSessionBuilder) applyMessageUsageFallback() {
+	for i := range b.messages {
+		message := &b.messages[i]
+		if i < b.shutdownCoveredMessages || message.Role != RoleAssistant || message.Model == "" ||
+			!message.HasOutputTokens {
+			continue
+		}
+		message.TokenUsage = jsontext.Value(
+			fmt.Sprintf(`{"output_tokens":%d}`, message.OutputTokens),
+		)
+	}
 }
 
 func formatCopilotToolCalls(
@@ -478,6 +500,7 @@ func (p *copilotProvider) parseSession(
 	if !hasContent {
 		return nil, nil, nil, nil
 	}
+	b.applyMessageUsageFallback()
 
 	sessionID := b.sessionID
 	if sessionID == "" {

--- a/internal/parser/copilot_test.go
+++ b/internal/parser/copilot_test.go
@@ -524,6 +524,18 @@ func TestParseCopilotSession_ModelChange(t *testing.T) {
 	assertEqual(t, "", msgs[0].Model, "msgs[0].Model")
 }
 
+func TestParseCopilotSession_AssistantModel(t *testing.T) {
+	path := writeCopilotJSONL(t,
+		`{"type":"session.start","data":{"sessionId":"assistant-model"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Hello"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Hi there","model":"claude-sonnet-4.6"},"timestamp":"2025-01-15T10:00:02Z"}`,
+	)
+
+	_, msgs := parseAndValidateHelper(t, path, "m", 2)
+
+	assert.Equal(t, "claude-sonnet-4-6", msgs[1].Model)
+}
+
 func TestParseCopilotSession_NoModel(t *testing.T) {
 	path := writeCopilotJSONL(t,
 		`{"type":"session.start","data":{"sessionId":"no-model"},"timestamp":"2025-01-15T10:00:00Z"}`,
@@ -894,9 +906,40 @@ func TestParseCopilotSession_NoShutdown_NoUsageEvents(t *testing.T) {
 	path := writeCopilotJSONL(t,
 		`{"type":"session.start","data":{"sessionId":"no-shut","context":{"cwd":"/proj","branch":"main"}},"timestamp":"2025-01-15T10:00:00Z"}`,
 		`{"type":"user.message","data":{"content":"Hello"},"timestamp":"2025-01-15T10:00:01Z"}`,
-		`{"type":"assistant.message","data":{"content":"Hi."},"timestamp":"2025-01-15T10:00:02Z"}`,
+		`{"type":"assistant.message","data":{"content":"Hi.","model":"gpt-5.6-terra","outputTokens":42},"timestamp":"2025-01-15T10:00:02Z"}`,
 	)
 
-	_, _, usage := parseCopilotFull(t, path, "m")
+	_, msgs, usage := parseCopilotFull(t, path, "m")
 	assert.Empty(t, usage, "no shutdown event should produce no usage events")
+	assert.Equal(t, "gpt-5.6-terra", msgs[1].Model)
+	assert.JSONEq(t, `{"output_tokens":42}`, string(msgs[1].TokenUsage))
+}
+
+func TestParseCopilotSession_ShutdownUsageSuppressesMessageFallback(t *testing.T) {
+	path := writeCopilotJSONL(t,
+		`{"type":"session.start","data":{"sessionId":"shutdown-wins"},"timestamp":"2026-06-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Hello"},"timestamp":"2026-06-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Hi.","model":"gpt-5.6-terra","outputTokens":42},"timestamp":"2026-06-15T10:00:02Z"}`,
+		`{"type":"session.shutdown","data":{"modelMetrics":{"gpt-5.6-terra":{"usage":{"inputTokens":100,"outputTokens":50}}}},"timestamp":"2026-06-15T10:01:00Z"}`,
+	)
+
+	_, msgs, usage := parseCopilotFull(t, path, "m")
+
+	require.Len(t, usage, 1)
+	assert.Equal(t, 50, usage[0].OutputTokens)
+	assert.Empty(t, msgs[1].TokenUsage)
+}
+
+func TestCopilotResumedOutputAfterShutdown(t *testing.T) {
+	path := writeCopilotJSONL(t,
+		`{"type":"session.start","timestamp":"2026-09-01T10:00:00Z","data":{"sessionId":"resumed"}}`,
+		`{"type":"assistant.message","timestamp":"2026-09-01T10:00:01Z","data":{"content":"First","model":"gpt-5.4","outputTokens":3}}`,
+		`{"type":"session.shutdown","timestamp":"2026-09-01T10:00:02Z","data":{"modelMetrics":{"gpt-5.4":{"usage":{"outputTokens":3}}}}}`,
+		`{"type":"assistant.message","timestamp":"2026-09-01T11:00:00Z","data":{"content":"Later","model":"gpt-5.4","outputTokens":7}}`,
+	)
+	_, msgs, usage := parseCopilotFull(t, path, "local")
+	require.Len(t, usage, 1)
+	assert.Equal(t, 3, usage[0].OutputTokens)
+	assert.Empty(t, msgs[0].TokenUsage)
+	assert.JSONEq(t, `{"output_tokens":7}`, string(msgs[1].TokenUsage))
 }

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -11853,6 +11853,79 @@ func TestSyncPathsVSCodeCopilotPersistsUsageEvents(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-8", events[0].Model)
 }
 
+func TestSyncPathsCopilotUsesAssistantOutputFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := t.TempDir()
+	sessionID := "cccccccc-dddd-eeee-ffff-000000000000"
+	path := filepath.Join(root, "session-state", sessionID, "events.jsonl")
+	dbtest.WriteTestFile(t, path, []byte(strings.Join([]string{
+		`{"type":"session.start","data":{"sessionId":"` + sessionID + `"},"timestamp":"2026-06-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"hello"},"timestamp":"2026-06-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"hi","model":"claude-sonnet-4.6","outputTokens":42},"timestamp":"2026-06-15T10:00:02Z"}`,
+	}, "\n")+"\n"))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCopilot: {root},
+		},
+		Machine: "local",
+	})
+
+	engine.SyncPaths([]string{path})
+
+	events, err := database.GetUsageEvents(t.Context(), "copilot:"+sessionID)
+	require.NoError(t, err)
+	assert.Empty(t, events, "fallback is stored on the assistant message")
+
+	daily, err := database.GetDailyUsage(t.Context(), db.UsageFilter{
+		From:     "2026-06-15",
+		To:       "2026-06-15",
+		Timezone: "UTC",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 42, daily.Totals.OutputTokens)
+	assert.Equal(t, []string{"claude-sonnet-4-6"}, daily.Daily[0].ModelsUsed)
+}
+
+func TestSyncPathsCopilotShutdownUsageSuppressesAssistantFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := t.TempDir()
+	sessionID := "dddddddd-eeee-ffff-0000-000000000000"
+	path := filepath.Join(root, "session-state", sessionID, "events.jsonl")
+	dbtest.WriteTestFile(t, path, []byte(strings.Join([]string{
+		`{"type":"session.start","data":{"sessionId":"` + sessionID + `"},"timestamp":"2026-06-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"hello"},"timestamp":"2026-06-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"hi","model":"claude-sonnet-4.6","outputTokens":42},"timestamp":"2026-06-15T10:00:02Z"}`,
+		`{"type":"session.shutdown","data":{"modelMetrics":{"claude-sonnet-4.6":{"usage":{"inputTokens":100,"outputTokens":50}}}},"timestamp":"2026-06-15T10:01:00Z"}`,
+	}, "\n")+"\n"))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCopilot: {root},
+		},
+		Machine: "local",
+	})
+
+	engine.SyncPaths([]string{path})
+
+	daily, err := database.GetDailyUsage(t.Context(), db.UsageFilter{
+		From:     "2026-06-15",
+		To:       "2026-06-15",
+		Timezone: "UTC",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 50, daily.Totals.OutputTokens,
+		"authoritative shutdown totals must replace assistant fallback data")
+}
+
 func TestSyncPathsPositronJSONLPriority(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")


### PR DESCRIPTION
Completed Copilot responses now contribute their known output tokens even when no shutdown summary exists. Output already covered by a shutdown stays suppressed, while responses after a resumed session's last shutdown remain counted. Input, cache, and reasoning usage are not invented.

This is the first replacement for #1626. It contains only transcript parsing and the data-version refresh; observed store usage and shared-store performance follow in dependent PRs.

Merge order: #1683, then #1684, then #1685.
