### PR TITLE
fix(copilot): import observed request usage without double counting

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -597,7 +597,9 @@ add an archived or maintained mirror without replacing the original identity.
 
 - **Format:** Flat session JSONL or a session directory containing
   `events.jsonl`.
+
 - **Evidence:** `documentation`.
+
 - **Upstream:** The public
   [Copilot CLI repository](https://github.com/github/copilot-cli) at
   `fd24cea5cb11da4e630485ff2d9269318b8c2a4e` and
@@ -614,12 +616,14 @@ add an archived or maintained mirror without replacing the original identity.
   [Copilot format notes](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/docs/providers/copilot.md)
   and
   [parser](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/src/providers/copilot.ts).
+
 - **Usage and cost:** Assistant messages can persist model identity and output
   tokens. Shutdown metrics can persist input, output, cache-read, cache-write,
-  and reasoning totals. When the latter are absent, Agentsview records only
-  known per-message output tokens; it does not infer input, cache, reasoning,
-  or credit totals. Known-model tokens use catalog estimates; the existing
-  shutdown reported-cost treatment is unchanged.
+  and reasoning totals. When both shutdown and store usage are absent,
+  Agentsview records only known per-message output tokens; it does not infer
+  input, cache, reasoning, or credit totals. Known-model tokens use catalog
+  estimates; the existing shutdown reported-cost treatment is unchanged.
+
 - **Agentsview:** `internal/parser/copilot.go` and
   `internal/parser/copilot_provider.go`. Reverified 2026-07-28 against local
   Copilot CLI 1.0.76-0 transcripts: `tool.execution_start` and
@@ -629,6 +633,51 @@ add an archived or maintained mirror without replacing the original identity.
   Reverified 2026-09-04 against current local transcripts: an
   `assistant.message` can carry `data.model` and `data.outputTokens` when no
   usable `session.shutdown` metrics are present.
+
+- **Store evidence:** Reverified 2026-09-10 against the published Copilot CLI
+  1.0.83
+  [native package](https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.83.tgz)
+  (SHA1 `8b8f67a38e893b61e6cef9c011a6fe22d8fdcd4d`). Native tracking writes
+  one usage row per model call, including multiple calls in one turn. Store
+  rows therefore use request pricing without a message ordinal. The native
+  emitter supplies ISO timestamps. A controlled SQLite writer lock rejected an
+  earlier usage insert; a later insert succeeded, and flush did not replay the
+  failed insert. A maximum row timestamp is not proof of complete transcript
+  coverage. The package's embedded schema and tracking handoff confirm the
+  queried token fields and explicit event timestamp.
+
+- **Optional store schema:** Reverified 2026-09-10 against the published
+  [Copilot CLI 1.0.60 package](https://registry.npmjs.org/@github/copilot/-/copilot-1.0.60.tgz)
+  (SHA1 `8c3a6ae7f9b98986092a9adcb6a2e4d42d915ae3`). Its `app.js`
+  initializes session-store schema version 4 without `assistant_usage_events`.
+  Running that initialization SQL in isolated SQLite reproduced the missing
+  table. A store without the required usage schema leaves transcript and
+  shutdown usage available.
+
+- **Store refresh:** Store database and WAL writes participate in incremental
+  sync cutoff filtering without changing session activity timestamps. Parent
+  directory timestamps and available file change times also retain deleted or
+  replaced stores whose mtimes are old. Non-missing stat errors retain the
+  source for worker verification; operational read failures preserve the
+  archived result and remain retryable. Reverified 2026-09-10 with isolated
+  sync tests for store-only writes in both journal modes, deletion,
+  replacement with an older mtime, database/WAL stat errors, and a lock
+  followed by a retry without another store write.
+
+- **Store marker capture:** Reverified 2026-09-10 with isolated SQLite writes
+  and connection closes. WAL cleanup racing a marker read can leave usage
+  readable while the marker capture fails. Failed captures remain retryable;
+  only a confirmed missing database uses the absent-store fingerprint. Parser
+  regressions cover failed database/WAL captures, recovery, and an absent
+  store.
+
+- **Store accounting:** For sessions starting June 1, 2026 or later, observed
+  store tokens replace shutdown token estimates. The latest shutdown reported
+  cost remains authoritative; store tokens use catalog estimates, not inferred
+  invoice prices. Overlapping transcript output contributes only its positive
+  per-model excess over store output. This is a lower bound: extra store-only
+  calls can mask missing output, and missing input or request bands cannot be
+  recovered. A recovered row replaces that excess without adding it twice.
 
 ## Gemini CLI (`gemini`)
 

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -36,7 +36,8 @@ const (
 	// same facts and catalog would otherwise keep the unpriced costs.
 	// Version 10 rebuilds rollups with Bedrock pricing for namespaced Codex
 	// models, including historical AWS rates for timestamped usage.
-	usageCacheFormatVersion             = 10
+	// Version 11 rebuilds Copilot store usage with request-scoped pricing.
+	usageCacheFormatVersion             = 11
 	usageCacheApplicationID             = 0x41565543
 	usageCacheKind                      = "agentsview-usage-facts"
 	usageCacheRetirementProtocolVersion = 1

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -27,7 +27,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cache.temporary)
 	assert.Equal(t, filepath.Join(filepath.Dir(archivePath),
-		"usage-cache-v10-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
+		"usage-cache-v11-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
 
 	info, err := os.Stat(cache.path)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 
 	metadata := readUsageCacheMetadata(t, cache.db)
 	assert.Equal(t, "agentsview-usage-facts", metadata[usageCacheMetadataKind])
-	assert.Equal(t, "10", metadata[usageCacheMetadataFormatVersion])
+	assert.Equal(t, "11", metadata[usageCacheMetadataFormatVersion])
 	assert.Equal(t, "database-id-one", metadata[usageCacheMetadataSourceDatabaseID])
 	assert.Equal(t, "1", metadata[usageCacheMetadataRetirementProtocol])
 	assert.Equal(t, "1", metadata[usageCacheMetadataNextInstallRevision])

--- a/internal/db/usage_rollup_build_test.go
+++ b/internal/db/usage_rollup_build_test.go
@@ -394,3 +394,38 @@ func rollupGeneralFact(
 		},
 	}
 }
+
+func TestPriceCopilotStoreRequestsWithoutMessageOrdinal(t *testing.T) {
+	resolver := export.NewPricingResolver([]export.EffectivePricingRow{{
+		ModelPattern: "gpt-5.4",
+		Rates: export.ModelRates{
+			InputPerMTok: money.MustParseDollars("2.50"),
+			Bands: []export.PricingBand{{
+				AboveInputTokens: 272_000,
+				InputPerMTok:     money.MustParseDollars("5"),
+			}},
+		},
+	}})
+	for _, tc := range []struct {
+		name             string
+		inputs           []int64
+		wantMicrodollars int64
+	}{
+		{"one large call", []int64{300_000}, 1_500_000},
+		{"two smaller calls", []int64{150_000, 150_000}, 750_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var total int64
+			for _, input := range tc.inputs {
+				fact, ok := usagefacts.FromEvent(usagefacts.EventInput{
+					Source: "session-store", Model: "gpt-5.4", InputTokens: input,
+				})
+				require.True(t, ok)
+				got, err := priceUsageFact(usagePriceInput{ReportedModel: fact.Model, Fact: fact}, resolver)
+				require.NoError(t, err)
+				total += got.Cost.Microdollars
+			}
+			assert.Equal(t, tc.wantMicrodollars, total)
+		})
+	}
+}

--- a/internal/parser/capabilities_sync_test.go
+++ b/internal/parser/capabilities_sync_test.go
@@ -112,6 +112,9 @@ func TestProviderSyncSemanticsDeclarations(t *testing.T) {
 		AgentCodebuff: {
 			FingerprintHashRequiredForFreshness: true,
 		},
+		AgentCopilot: {
+			FingerprintHashRequiredForFreshness: true,
+		},
 	}
 
 	for _, factory := range ProviderFactories() {

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -1,7 +1,9 @@
 package parser
 
 import (
+	"database/sql"
 	"encoding/json/jsontext"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mattn/go-sqlite3"
 	"github.com/tidwall/gjson"
 
 	"go.kenn.io/agentsview/internal/money"
@@ -45,6 +48,9 @@ type copilotSessionBuilder struct {
 	ordinal                 int
 	currentModel            string
 	shutdownCoveredMessages int
+	usageCoveredAt          time.Time
+	fallbackOutput          int
+	hasFallbackOutput       bool
 }
 
 func newCopilotSessionBuilder() *copilotSessionBuilder {
@@ -350,6 +356,7 @@ func (b *copilotSessionBuilder) handleShutdown(
 		},
 	)
 	if len(events) > 0 {
+		// Transcript order identifies covered messages even without timestamps.
 		b.shutdownCoveredMessages = len(b.messages)
 	}
 	sort.Slice(events, func(i, j int) bool {
@@ -379,17 +386,168 @@ func (b *copilotSessionBuilder) handleShutdown(
 	b.usageEvents = append(b.usageEvents, events...)
 }
 
+// retainStoreOutputRemainder treats pre-cutoff store and transcript output as
+// overlapping observations, not proof that every response reached the store.
+// Without a shared response ID, only the positive aggregate difference is
+// known to be absent. Keep it separate from per-request store facts rather than
+// attributing a missing call to an arbitrary transcript message.
+func (b *copilotSessionBuilder) retainStoreOutputRemainder() {
+	storeOutput := make(map[string]int)
+	for _, event := range b.usageEvents {
+		if event.Source == "session-store" {
+			storeOutput[event.Model] += event.OutputTokens
+		}
+	}
+	type observedOutput struct {
+		tokens int
+		at     time.Time
+	}
+	observed := make(map[string]observedOutput)
+	unknown := 0
+	for _, message := range b.messages {
+		if message.Role != RoleAssistant || !message.HasOutputTokens ||
+			(!message.Timestamp.IsZero() && message.Timestamp.After(b.usageCoveredAt)) {
+			continue
+		}
+		if message.Model == "" {
+			unknown += message.OutputTokens
+			continue
+		}
+		value := observed[message.Model]
+		value.tokens += message.OutputTokens
+		if message.Timestamp.After(value.at) {
+			value.at = message.Timestamp
+		}
+		observed[message.Model] = value
+	}
+	models := make([]string, 0, len(observed))
+	for model := range observed {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+	for _, model := range models {
+		value := observed[model]
+		if extra := value.tokens - storeOutput[model]; extra > 0 {
+			b.usageEvents = append(b.usageEvents, ParsedUsageEvent{
+				Source: "transcript-output-remainder", Model: model, OutputTokens: extra,
+				OccurredAt: timeString(value.at, b.startedAt),
+			})
+		}
+		storeOutput[model] = max(storeOutput[model]-value.tokens, 0)
+	}
+	// Unknown-model responses can overlap any remaining store output. Retain
+	// only the excess, unpriced, as for other model-less transcript fallback.
+	for _, tokens := range storeOutput {
+		unknown -= tokens
+	}
+	if unknown > 0 {
+		b.fallbackOutput += unknown
+		b.hasFallbackOutput = true
+	}
+}
+
 func (b *copilotSessionBuilder) applyMessageUsageFallback() {
 	for i := range b.messages {
 		message := &b.messages[i]
-		if i < b.shutdownCoveredMessages || message.Role != RoleAssistant || message.Model == "" ||
-			!message.HasOutputTokens {
+		if i < b.shutdownCoveredMessages || message.Role != RoleAssistant ||
+			!message.HasOutputTokens ||
+			(!b.usageCoveredAt.IsZero() &&
+				(message.Timestamp.IsZero() || !message.Timestamp.After(b.usageCoveredAt))) {
+			continue
+		}
+		b.fallbackOutput += message.OutputTokens
+		b.hasFallbackOutput = true
+		if message.Model == "" {
 			continue
 		}
 		message.TokenUsage = jsontext.Value(
 			fmt.Sprintf(`{"output_tokens":%d}`, message.OutputTokens),
 		)
 	}
+}
+
+func (b *copilotSessionBuilder) markUsageCoveredAt(occurredAt time.Time) {
+	if occurredAt.After(b.usageCoveredAt) {
+		b.usageCoveredAt = occurredAt
+	}
+}
+
+// loadCopilotStoreUsage reads the CLI's observed per-request token data when
+// available. Billing semantics for this undocumented store are not assumed.
+func loadCopilotStoreUsage(
+	storePath, rawSessionID string,
+) ([]ParsedUsageEvent, error) {
+	if storePath == "" || rawSessionID == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(storePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat copilot session store %s: %w", storePath, err)
+	}
+	store, err := sql.Open(
+		"sqlite3",
+		"file:"+sqliteURIPath(storePath)+"?mode=ro&_busy_timeout=3000",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("opening copilot session store %s: %w", storePath, err)
+	}
+	defer store.Close()
+
+	rows, err := store.Query(`
+		SELECT id, model, input_tokens, output_tokens, cache_read_tokens,
+		       cache_write_tokens, reasoning_tokens, created_at
+		FROM assistant_usage_events
+		WHERE session_id = ?
+		ORDER BY id
+	`, rawSessionID)
+	if err != nil {
+		// Older stores need not contain usage data. Confirm a missing schema
+		// before falling back; operational read failures must remain retryable.
+		if sqliteErr, ok := errors.AsType[sqlite3.Error](err); ok && sqliteErr.Code == sqlite3.ErrError {
+			var columns int
+			schemaErr := store.QueryRow(`
+				SELECT count(*) FROM pragma_table_info('assistant_usage_events')
+				WHERE name IN ('id', 'session_id', 'model', 'input_tokens',
+				    'output_tokens', 'cache_read_tokens', 'cache_write_tokens',
+				    'reasoning_tokens', 'created_at')
+			`).Scan(&columns)
+			if schemaErr == nil && columns < 9 {
+				return nil, nil
+			}
+		}
+		return nil, fmt.Errorf("reading copilot session store %s: %w", storePath, err)
+	}
+	defer rows.Close()
+
+	var events []ParsedUsageEvent
+	for rows.Next() {
+		var id int64
+		var model, createdAt string
+		var input, output, cacheRead, cacheWrite, reasoning sql.NullInt64
+		if err := rows.Scan(
+			&id, &model, &input, &output, &cacheRead, &cacheWrite, &reasoning,
+			&createdAt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning copilot session-store usage: %w", err)
+		}
+		events = append(events, ParsedUsageEvent{
+			Source:                   "session-store",
+			Model:                    normalizeCopilotModel(model),
+			InputTokens:              max(int(input.Int64-cacheRead.Int64-cacheWrite.Int64), 0),
+			OutputTokens:             int(output.Int64),
+			CacheCreationInputTokens: int(cacheWrite.Int64),
+			CacheReadInputTokens:     int(cacheRead.Int64),
+			ReasoningTokens:          int(reasoning.Int64),
+			OccurredAt:               createdAt,
+			DedupKey:                 fmt.Sprintf("session-store:%d", id),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating copilot session-store usage: %w", err)
+	}
+	return events, nil
 }
 
 func formatCopilotToolCalls(
@@ -455,6 +613,12 @@ func readCopilotWorkspaceName(eventsPath string) string {
 func (p *copilotProvider) parseSession(
 	path, machine string,
 ) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
+	return p.parseSessionWithStore(path, machine, "")
+}
+
+func (p *copilotProvider) parseSessionWithStore(
+	path, machine, storePath string,
+) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -500,13 +664,45 @@ func (p *copilotProvider) parseSession(
 	if !hasContent {
 		return nil, nil, nil, nil
 	}
+	rawSessionID := b.sessionID
+	if rawSessionID == "" {
+		rawSessionID = sessionIDFromPath(path)
+	}
+	usesStoreUsage := false
+	if !b.startedAt.Before(copilotUsageBasedPricingStartedAt) {
+		storeUsage, err := loadCopilotStoreUsage(storePath, rawSessionID)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if len(storeUsage) > 0 {
+			for _, event := range storeUsage {
+				b.markUsageCoveredAt(parseTimestamp(event.OccurredAt))
+			}
+			for _, event := range b.usageEvents {
+				if event.Cost == nil ||
+					event.CostSource != copilotReportedCostSource {
+					continue
+				}
+				// Store usage supplies richer observed tokens, but transcript
+				// shutdown remains the authoritative reported-cost source.
+				storeUsage = append(storeUsage, ParsedUsageEvent{
+					Source: event.Source, Model: event.Model, OccurredAt: event.OccurredAt,
+					Cost: event.Cost, CostStatus: event.CostStatus, CostSource: event.CostSource,
+				})
+				break
+			}
+			b.usageEvents = storeUsage
+			// Only the selected token source determines message coverage.
+			b.shutdownCoveredMessages = 0
+			usesStoreUsage = true
+		}
+	}
+	if usesStoreUsage {
+		b.retainStoreOutputRemainder()
+	}
 	b.applyMessageUsageFallback()
 
-	sessionID := b.sessionID
-	if sessionID == "" {
-		sessionID = sessionIDFromPath(path)
-	}
-	sessionID = "copilot:" + sessionID
+	sessionID := "copilot:" + rawSessionID
 
 	// Prefer the workspace.yaml name (LLM-generated or user-set
 	// title) over the raw first user message. Falls back to the
@@ -541,6 +737,17 @@ func (p *copilotProvider) parseSession(
 	}
 
 	accumulateMessageTokenUsage(sess, b.messages)
+	if usesStoreUsage {
+		// Store output and uncovered message output replace the transcript total,
+		// including when the store contains no positive output tokens.
+		sess.TotalOutputTokens = 0
+		sess.HasTotalOutputTokens = false
+		applyUsageEventTokenTotals(sess, b.usageEvents)
+		if b.hasFallbackOutput {
+			sess.HasTotalOutputTokens = true
+			sess.TotalOutputTokens += b.fallbackOutput
+		}
+	}
 
 	// Stamp the session ID on usage events (not known until here).
 	// DedupKey encodes the event's position in the slice so that
@@ -548,12 +755,14 @@ func (p *copilotProvider) parseSession(
 	// several shutdown events) each get a distinct key.
 	for i := range b.usageEvents {
 		b.usageEvents[i].SessionID = sessionID
-		b.usageEvents[i].DedupKey = fmt.Sprintf(
-			"shutdown:%s:%s:%d",
-			sessionID,
-			b.usageEvents[i].Model,
-			i,
-		)
+		if b.usageEvents[i].DedupKey == "" {
+			b.usageEvents[i].DedupKey = fmt.Sprintf(
+				"shutdown:%s:%s:%d",
+				sessionID,
+				b.usageEvents[i].Model,
+				i,
+			)
+		}
 	}
 
 	return sess, b.messages, b.usageEvents, nil

--- a/internal/parser/copilot_provider.go
+++ b/internal/parser/copilot_provider.go
@@ -90,7 +90,7 @@ func (p *copilotProvider) Parse(
 		return ParseOutcome{}, fmt.Errorf("copilot source path unavailable")
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
-	sess, msgs, usage, err := p.parseSession(path, machine)
+	sess, msgs, usage, err := p.parseSessionWithStore(path, machine, filepath.Join(copilotRootForEventsPath(path), "session-store.db"))
 	if err != nil {
 		return ParseOutcome{}, err
 	}
@@ -236,7 +236,7 @@ func (s copilotSourceSet) discoverSessionPaths(root string) []string {
 }
 
 func (s copilotSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
-	roots := make([]WatchRoot, 0, len(s.roots))
+	roots := make([]WatchRoot, 0, len(s.roots)*2)
 	for _, root := range s.roots {
 		stateDir := filepath.Join(root, copilotStateDir)
 		roots = append(roots, WatchRoot{
@@ -244,6 +244,11 @@ func (s copilotSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 			Recursive:    true,
 			IncludeGlobs: []string{"*.jsonl", "workspace.yaml"},
 			DebounceKey:  string(AgentCopilot) + ":state:" + stateDir,
+		})
+		roots = append(roots, WatchRoot{
+			Path:         root,
+			IncludeGlobs: []string{"session-store.db", "session-store.db-wal"},
+			DebounceKey:  string(AgentCopilot) + ":store:" + root,
 		})
 	}
 	return WatchPlan{Roots: roots}, nil
@@ -257,6 +262,19 @@ func (s copilotSourceSet) SourcesForChangedPath(
 		return nil, err
 	}
 	for _, root := range s.roots {
+		if copilotStoreChangedPath(root, req.Path) {
+			var sources []SourceRef
+			for _, path := range s.discoverSessionPaths(root) {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+				if source, ok := s.sourceRef(root, path); ok {
+					sources = append(sources, source)
+				}
+			}
+			sortJSONLSources(sources)
+			return sources, nil
+		}
 		source, ok := s.sourceForChangedPath(root, req)
 		if ok {
 			return []SourceRef{source}, nil
@@ -365,6 +383,15 @@ func (s copilotSourceSet) Fingerprint(
 			}
 		}
 	}
+	// SQLite write markers affect freshness, never session timestamps.
+	storePath := filepath.Join(copilotRootForEventsPath(path), "session-store.db")
+	state, captured := StatSQLiteContainerState(storePath)
+	if !captured {
+		if _, err := os.Stat(storePath); !os.IsNotExist(err) {
+			return SourceFingerprint{}, fmt.Errorf("cannot capture copilot session store state %s", storePath)
+		}
+	}
+	fmt.Fprintf(h, "%v", state)
 	fingerprint.Hash = fmt.Sprintf("%x", h.Sum(nil))
 	return fingerprint, nil
 }
@@ -511,6 +538,7 @@ func copilotProviderCapabilities() Capabilities {
 			ExcludedSessions:     CapabilityNotApplicable,
 			ForceReplaceOnParse:  CapabilityNotApplicable,
 		},
+		Sync: ProviderSyncSemantics{FingerprintHashRequiredForFreshness: true},
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			Cwd:                  CapabilitySupported,
@@ -522,5 +550,28 @@ func copilotProviderCapabilities() Capabilities {
 			AggregateUsageEvents: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+	}
+}
+
+func copilotRootForEventsPath(eventsPath string) string {
+	stateDir := filepath.Dir(eventsPath)
+	if filepath.Base(eventsPath) == "events.jsonl" {
+		stateDir = filepath.Dir(stateDir)
+	}
+	if filepath.Base(stateDir) != copilotStateDir {
+		return ""
+	}
+	return filepath.Dir(stateDir)
+}
+
+func copilotStoreChangedPath(root, path string) bool {
+	if !samePath(filepath.Dir(path), root) {
+		return false
+	}
+	switch filepath.Base(path) {
+	case "session-store.db", "session-store.db-wal":
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/parser/copilot_store_test.go
+++ b/internal/parser/copilot_store_test.go
@@ -1,0 +1,239 @@
+package parser
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+func createCopilotUsageStore(t *testing.T, root string) *sql.DB {
+	t.Helper()
+	store, err := sql.Open("sqlite3", filepath.Join(root, "session-store.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	_, err = store.Exec(`PRAGMA journal_mode=WAL;
+ CREATE TABLE sessions (id TEXT PRIMARY KEY);
+ CREATE TABLE assistant_usage_events (
+ id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, model TEXT,
+ input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER,
+ cache_write_tokens INTEGER, reasoning_tokens INTEGER, created_at TEXT);
+ CREATE INDEX idx_assistant_usage_events_session ON assistant_usage_events(session_id, id);`)
+	require.NoError(t, err)
+	return store
+}
+
+func TestCopilotStoreGapRetainsOnlyAggregateOutputRemainder(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		firstModel    string
+		storeOutput   int
+		wantTotal     int
+		wantRemainder int
+	}{
+		{"missing first call", "gpt-5.4", 7, 10, 3},
+		{"all calls stored", "gpt-5.4", 10, 10, 0},
+		{"store has extra calls", "gpt-5.4", 20, 20, 0},
+		{"missing other model", "gpt-5.5", 20, 23, 3},
+		{"unknown model overlaps store", "", 10, 10, 0},
+		{"unknown model excess", "", 7, 10, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			store := createCopilotUsageStore(t, root)
+			_, err := store.Exec(`INSERT INTO sessions VALUES ('gap');
+INSERT INTO assistant_usage_events(session_id,model,input_tokens,output_tokens,created_at)
+VALUES ('gap','gpt-5.4',100,?,'2026-09-08T12:00:03Z')`, tc.storeOutput)
+			require.NoError(t, err)
+			path := writeCopilotJSONL(t,
+				`{"type":"session.start","timestamp":"2026-09-08T12:00:00Z","data":{"sessionId":"gap"}}`,
+				fmt.Sprintf(`{"type":"assistant.message","timestamp":"2026-09-08T12:00:01Z","data":{"content":"First","model":%q,"outputTokens":3}}`, tc.firstModel),
+				`{"type":"assistant.message","timestamp":"2026-09-08T12:00:02Z","data":{"content":"Later","model":"gpt-5.4","outputTokens":7}}`,
+			)
+			sess, msgs, events, err := newCopilotTestProvider(t).parseSessionWithStore(path, "local", filepath.Join(root, "session-store.db"))
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+			assert.Equal(t, tc.wantTotal, sess.TotalOutputTokens)
+			for _, msg := range msgs {
+				assert.Empty(t, msg.TokenUsage, "no invented request-to-response correlation")
+			}
+			require.NotEmpty(t, events)
+			assert.Equal(t, tc.storeOutput, events[0].OutputTokens)
+			if tc.wantRemainder == 0 {
+				require.Len(t, events, 1)
+			} else {
+				require.Len(t, events, 2)
+				assert.Equal(t, "transcript-output-remainder", events[1].Source)
+				assert.Equal(t, tc.firstModel, events[1].Model)
+				assert.Equal(t, tc.wantRemainder, events[1].OutputTokens)
+				assert.Nil(t, events[1].MessageOrdinal)
+			}
+		})
+	}
+}
+
+func TestParseCopilotSession_StoreUsageSupersedesShutdown(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "session-store.db")
+	store, err := sql.Open("sqlite3", storePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	_, err = store.Exec(`
+		CREATE TABLE assistant_usage_events (
+			id INTEGER PRIMARY KEY, session_id TEXT, model TEXT,
+			input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER,
+			cache_write_tokens INTEGER, reasoning_tokens INTEGER,
+			total_nano_aiu INTEGER, created_at TEXT
+		);
+		INSERT INTO assistant_usage_events VALUES
+			(42, 'store-wins', 'gpt-5.6-sol', 200, 50, 100, 20, 10,
+			 250000000, '2026-09-04T17:40:54.970Z');
+	`)
+	require.NoError(t, err)
+	path := writeCopilotJSONL(t,
+		`{"type":"session.start","data":{"sessionId":"store-wins"},"timestamp":"2026-09-04T17:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Hello"},"timestamp":"2026-09-04T17:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Hi.","model":"gpt-5.6-sol","outputTokens":3},"timestamp":"2026-09-04T17:00:02Z"}`,
+		`{"type":"session.shutdown","data":{"totalNanoAiu":100000000,"modelMetrics":{"gpt-5.6-sol":{"usage":{"inputTokens":10,"outputTokens":3}}}},"timestamp":"2026-09-04T17:00:03Z"}`,
+	)
+
+	sess, _, usage, err := newCopilotTestProvider(t).parseSessionWithStore(
+		path, "local", storePath,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, usage, 2)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 50, sess.TotalOutputTokens)
+	assert.Equal(t, "session-store", usage[0].Source)
+	assert.Equal(t, 80, usage[0].InputTokens)
+	assert.Equal(t, 50, usage[0].OutputTokens)
+	assert.Nil(t, usage[0].Cost)
+	assert.Empty(t, usage[0].CostSource)
+	assert.Equal(t, "2026-09-04T17:40:54.970Z", usage[0].OccurredAt)
+	assert.Equal(t, "session-store:42", usage[0].DedupKey)
+	assert.Equal(t, "shutdown", usage[1].Source)
+	assert.Zero(t, usage[1].InputTokens)
+	assert.Zero(t, usage[1].OutputTokens)
+	assert.Zero(t, usage[1].CacheCreationInputTokens)
+	assert.Zero(t, usage[1].CacheReadInputTokens)
+	assert.Zero(t, usage[1].ReasoningTokens)
+	require.NotNil(t, usage[1].Cost)
+	assert.Equal(t, money.MustParseDollars("0.001"), *usage[1].Cost)
+	assert.Equal(t, copilotReportedCostSource, usage[1].CostSource)
+	assert.Equal(t, "2026-09-04T17:00:03Z", usage[1].OccurredAt)
+}
+
+func TestLoadCopilotStoreUsage(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "session-store.db")
+	store, err := sql.Open("sqlite3", storePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	_, err = store.Exec(`
+		CREATE TABLE assistant_usage_events (
+			id INTEGER PRIMARY KEY, session_id TEXT, model TEXT,
+			input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER,
+			cache_write_tokens INTEGER, reasoning_tokens INTEGER,
+			total_nano_aiu INTEGER, created_at TEXT
+		);
+		INSERT INTO assistant_usage_events VALUES
+			(7, 'session-1', 'claude-sonnet-4.6', 100, 30, 60, 10, 4,
+			 125050000, '2026-09-04T17:40:54.970Z'),
+			(8, 'other-session', 'gpt-5.6-sol', 9, 8, 0, 0, 0,
+			 5000000, '2026-09-04T17:41:00Z');
+	`)
+	require.NoError(t, err)
+
+	events, err := loadCopilotStoreUsage(storePath, "session-1")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "session-store", events[0].Source)
+	assert.Equal(t, "claude-sonnet-4-6", events[0].Model)
+	assert.Equal(t, 30, events[0].InputTokens)
+	assert.Equal(t, 30, events[0].OutputTokens)
+	assert.Equal(t, 60, events[0].CacheReadInputTokens)
+	assert.Equal(t, 10, events[0].CacheCreationInputTokens)
+	assert.Equal(t, 4, events[0].ReasoningTokens)
+	assert.Nil(t, events[0].Cost)
+	assert.Empty(t, events[0].CostSource)
+	assert.Equal(t, "2026-09-04T17:40:54.970Z", events[0].OccurredAt)
+	assert.Equal(t, "session-store:7", events[0].DedupKey)
+}
+
+func TestParseCopilotSession_StoreWithoutUsageSchema(t *testing.T) {
+	for _, shutdown := range []bool{false, true} {
+		t.Run(fmt.Sprintf("shutdown=%t", shutdown), func(t *testing.T) {
+			storePath := filepath.Join(t.TempDir(), "session-store.db")
+			store, err := sql.Open("sqlite3", storePath)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			// Copilot 1.0.60 stores sessions but has no assistant_usage_events.
+			_, err = store.Exec(`CREATE TABLE sessions (id TEXT PRIMARY KEY)`)
+			require.NoError(t, err)
+			lines := []string{
+				`{"type":"session.start","timestamp":"2026-06-05T12:00:00Z","data":{"sessionId":"no-store-usage"}}`,
+				`{"type":"assistant.message","timestamp":"2026-06-05T12:00:01Z","data":{"content":"Hello","model":"gpt-5.4","outputTokens":3}}`,
+			}
+			if shutdown {
+				lines = append(lines, `{"type":"session.shutdown","timestamp":"2026-06-05T12:00:02Z","data":{"modelMetrics":{"gpt-5.4":{"usage":{"inputTokens":10,"outputTokens":3}}}}}`)
+			}
+			path := writeCopilotJSONL(t, lines...)
+			sess, messages, usage, err := newCopilotTestProvider(t).parseSessionWithStore(path, "local", storePath)
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+			require.Len(t, messages, 1)
+			assert.Equal(t, "Hello", messages[0].Content)
+			assert.Equal(t, 3, sess.TotalOutputTokens)
+			if shutdown {
+				require.Len(t, usage, 1)
+				assert.Equal(t, "shutdown", usage[0].Source)
+				assert.Equal(t, 10, usage[0].InputTokens)
+				assert.Equal(t, 3, usage[0].OutputTokens)
+				assert.Empty(t, messages[0].TokenUsage)
+			} else {
+				assert.Empty(t, usage)
+				assert.JSONEq(t, `{"output_tokens":3}`, string(messages[0].TokenUsage))
+			}
+		})
+	}
+}
+
+func TestCopilotFingerprintRejectsUnreadableStoreState(t *testing.T) {
+	for _, suffix := range []string{"", "-wal"} {
+		t.Run("session-store.db"+suffix, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "session-state", "fingerprint.jsonl")
+			writeSourceFile(t, path, `{"type":"session.start","data":{"sessionId":"fingerprint"}}`)
+			provider := newCopilotTestProvider(t, root)
+			sources, err := provider.Discover(t.Context())
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+			absent, err := provider.Fingerprint(t.Context(), sources[0])
+			require.NoError(t, err, "a missing optional store is valid")
+
+			store := createCopilotUsageStore(t, root)
+			require.NoError(t, store.Close())
+			storePath := filepath.Join(root, "session-store.db")
+			original, err := os.ReadFile(storePath)
+			require.NoError(t, err)
+			// A deterministic failed capture exercises the same retry contract
+			// as a header read racing a real WAL checkpoint.
+			require.NoError(t, os.WriteFile(storePath+suffix, make([]byte, 100), 0o644))
+			_, err = provider.Fingerprint(t.Context(), sources[0])
+			assert.Error(t, err, "an unreadable marker must not become a valid fingerprint")
+
+			if suffix == "" {
+				require.NoError(t, os.WriteFile(storePath, original, 0o644))
+			} else {
+				require.NoError(t, os.Remove(storePath+suffix))
+			}
+			recovered, err := provider.Fingerprint(t.Context(), sources[0])
+			require.NoError(t, err)
+			assert.NotEqual(t, absent.Hash, recovered.Hash, "recovery must expose the available store")
+		})
+	}
+}

--- a/internal/parser/gemini_copilot_provider_test.go
+++ b/internal/parser/gemini_copilot_provider_test.go
@@ -598,10 +598,14 @@ func TestCopilotProviderSourceMethods(t *testing.T) {
 
 	plan, err := provider.WatchPlan(context.Background())
 	require.NoError(t, err)
-	require.Len(t, plan.Roots, 1)
+	require.Len(t, plan.Roots, 2)
 	assert.Equal(t, filepath.Join(root, copilotStateDir), plan.Roots[0].Path)
 	assert.True(t, plan.Roots[0].Recursive)
 	assert.Equal(t, []string{"*.jsonl", "workspace.yaml"}, plan.Roots[0].IncludeGlobs)
+	assert.Equal(t, root, plan.Roots[1].Path)
+	assert.False(t, plan.Roots[1].Recursive)
+	assert.Equal(t, []string{"session-store.db", "session-store.db-wal"},
+		plan.Roots[1].IncludeGlobs)
 
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)

--- a/internal/sync/copilot_store_test.go
+++ b/internal/sync/copilot_store_test.go
@@ -1,0 +1,220 @@
+package sync_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	agentsync "go.kenn.io/agentsview/internal/sync"
+)
+
+func TestCopilotStoreChangesPassIncrementalCutoff(t *testing.T) {
+	for _, tc := range []struct {
+		name, sessionPath, journal, change string
+		wantOutput                         int
+	}{
+		{"flat database", "session-state/usage.jsonl", "DELETE", "write", 11},
+		{"directory WAL", "session-state/usage/events.jsonl", "WAL", "write", 11},
+		{"deleted store", "session-state/usage.jsonl", "DELETE", "delete", 3},
+		{"older replacement", "session-state/usage/events.jsonl", "DELETE", "replace", 11},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, tc.sessionPath)
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+			require.NoError(t, os.WriteFile(path, []byte(`{"type":"session.start","timestamp":"2026-09-08T12:00:00Z","data":{"sessionId":"usage"}}
+{"type":"assistant.message","timestamp":"2026-09-08T12:00:01Z","data":{"content":"Hello","model":"gpt-5.4","outputTokens":3}}
+`), 0o644))
+			old := time.Now().Add(-2 * time.Hour)
+			require.NoError(t, os.Chtimes(path, old, old))
+			storePath := filepath.Join(root, "session-store.db")
+			store, err := sql.Open("sqlite3", storePath)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			_, err = store.Exec(`PRAGMA journal_mode=` + tc.journal + `;
+CREATE TABLE assistant_usage_events(id INTEGER PRIMARY KEY, session_id TEXT,
+model TEXT,input_tokens INTEGER,output_tokens INTEGER,cache_read_tokens INTEGER,
+cache_write_tokens INTEGER,reasoning_tokens INTEGER,created_at TEXT);
+INSERT INTO assistant_usage_events VALUES(1,'usage','gpt-5.4',100,7,0,0,0,'2026-09-08T12:00:02Z');`)
+			require.NoError(t, err)
+			archive := dbtest.OpenTestDB(t)
+			engine := agentsync.NewEngine(archive, agentsync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentCopilot: {root}}, Machine: "local",
+			})
+			t.Cleanup(engine.Close)
+			require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+			before, err := archive.GetSession(t.Context(), "copilot:usage")
+			require.NoError(t, err)
+			require.NotNil(t, before)
+			require.NoError(t, os.Chtimes(storePath, old, old))
+			if tc.journal == "WAL" {
+				require.NoError(t, os.Chtimes(storePath+"-wal", old, old))
+			}
+
+			if tc.change == "delete" {
+				require.NoError(t, store.Close())
+				require.NoError(t, os.Remove(storePath))
+			} else {
+				_, err = store.Exec(`UPDATE assistant_usage_events SET output_tokens=11 WHERE id=1`)
+				require.NoError(t, err)
+				if tc.change == "replace" {
+					require.NoError(t, store.Close())
+					data, err := os.ReadFile(storePath)
+					require.NoError(t, err)
+					replacement := filepath.Join(t.TempDir(), "session-store.db")
+					require.NoError(t, os.WriteFile(replacement, data, 0o644))
+					require.NoError(t, os.Chtimes(replacement, old, old))
+					require.NoError(t, os.Rename(replacement, storePath))
+				}
+			}
+			stats := engine.SyncAllSince(t.Context(), old.Add(time.Hour), nil)
+			assert.Equal(t, 1, stats.Synced, "a store-only change must survive the transcript cutoff")
+			usage, err := archive.GetSessionUsage(t.Context(), "copilot:usage", true)
+			require.NoError(t, err)
+			require.NotNil(t, usage)
+			assert.Equal(t, tc.wantOutput, usage.TotalOutputTokens)
+			after, err := archive.GetSession(t.Context(), "copilot:usage")
+			require.NoError(t, err)
+			require.NotNil(t, after)
+			assert.Equal(t, before.FileMtime, after.FileMtime)
+			assert.Equal(t, before.EndedAt, after.EndedAt)
+		})
+	}
+}
+
+func TestCopilotStoreStatErrorsSurviveIncrementalCutoff(t *testing.T) {
+	for _, suffix := range []string{"", "-wal"} {
+		t.Run("session-store.db"+suffix, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "session-state", "stat-error.jsonl")
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+			require.NoError(t, os.WriteFile(path, []byte(`{"type":"session.start","timestamp":"2026-09-08T12:00:00Z","data":{"sessionId":"stat-error"}}
+{"type":"assistant.message","timestamp":"2026-09-08T12:00:01Z","data":{"content":"Hello","model":"gpt-5.4","outputTokens":3}}
+`), 0o644))
+			storePath := filepath.Join(root, "session-store.db")
+			store, err := sql.Open("sqlite3", storePath)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			_, err = store.Exec(`CREATE TABLE sessions(id TEXT PRIMARY KEY)`)
+			require.NoError(t, err)
+			require.NoError(t, store.Close())
+			archive := dbtest.OpenTestDB(t)
+			engine := agentsync.NewEngine(archive, agentsync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentCopilot: {root}}, Machine: "local",
+			})
+			t.Cleanup(engine.Close)
+			require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+			if suffix == "" {
+				require.NoError(t, os.Remove(storePath))
+			}
+			badPath := storePath + suffix
+			if err := os.Symlink(filepath.Base(badPath), badPath); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+			// All timestamps, including parent mtime and ctime, predate this
+			// cutoff. Only the stat error may retain the source for verification.
+			stats := engine.SyncAllSince(t.Context(), time.Now().Add(time.Hour), nil)
+			assert.Equal(t, 1, stats.Failed, "an unreadable store must report an error instead of being filtered out")
+		})
+	}
+}
+
+func TestCopilotStoreReadFailurePreservesUsageAndRetries(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "session-state", "locked.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"type":"session.start","timestamp":"2026-09-08T12:00:00Z","data":{"sessionId":"locked"}}
+{"type":"assistant.message","timestamp":"2026-09-08T12:00:01Z","data":{"content":"Hello","model":"gpt-5.4","outputTokens":3}}
+`), 0o644))
+	storePath := filepath.Join(root, "session-store.db")
+	store, err := sql.Open("sqlite3", storePath)
+	require.NoError(t, err)
+	store.SetMaxOpenConns(1)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	_, err = store.Exec(`PRAGMA journal_mode=DELETE;
+CREATE TABLE assistant_usage_events(id INTEGER PRIMARY KEY, session_id TEXT,
+model TEXT,input_tokens INTEGER,output_tokens INTEGER,cache_read_tokens INTEGER,
+cache_write_tokens INTEGER,reasoning_tokens INTEGER,created_at TEXT);
+INSERT INTO assistant_usage_events VALUES(1,'locked','gpt-5.4',100,7,0,0,0,'2026-09-08T12:00:02Z');`)
+	require.NoError(t, err)
+	archive := dbtest.OpenTestDB(t)
+	engine := agentsync.NewEngine(archive, agentsync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCopilot: {root}}, Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	_, err = store.Exec(`UPDATE assistant_usage_events SET output_tokens=11 WHERE id=1;
+BEGIN EXCLUSIVE`)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = store.Exec("ROLLBACK") })
+
+	assert.Error(t, engine.SyncPathsContext(t.Context(), []string{storePath}))
+	usage, err := archive.GetSessionUsage(t.Context(), "copilot:locked", true)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, 7, usage.TotalOutputTokens, "a failed read must preserve the stored usage")
+	_, err = store.Exec("ROLLBACK")
+	require.NoError(t, err)
+
+	// Releasing the lock changes no store bytes or fingerprint. A retry must
+	// still import the row instead of treating the failed read as current.
+	assert.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	usage, err = archive.GetSessionUsage(t.Context(), "copilot:locked", true)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, 11, usage.TotalOutputTokens)
+}
+
+func TestCopilotStoreGapAndRecoveryDoNotDoubleCount(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "session-state", "gap", "events.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"type":"session.start","timestamp":"2026-09-08T12:00:00Z","data":{"sessionId":"gap"}}
+{"type":"assistant.message","timestamp":"2026-09-08T12:00:01Z","data":{"content":"First","model":"gpt-5.4","outputTokens":3}}
+{"type":"assistant.message","timestamp":"2026-09-08T12:00:02Z","data":{"content":"Later","model":"gpt-5.4","outputTokens":7}}
+`), 0o644))
+	storePath := filepath.Join(root, "session-store.db")
+	store, err := sql.Open("sqlite3", storePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	_, err = store.Exec(`PRAGMA journal_mode=WAL;
+CREATE TABLE sessions(id TEXT PRIMARY KEY);
+INSERT INTO sessions VALUES('gap');
+CREATE TABLE assistant_usage_events(id INTEGER PRIMARY KEY AUTOINCREMENT,
+session_id TEXT,model TEXT,input_tokens INTEGER,output_tokens INTEGER,
+cache_read_tokens INTEGER,cache_write_tokens INTEGER,reasoning_tokens INTEGER,created_at TEXT);
+CREATE INDEX idx_assistant_usage_events_session ON assistant_usage_events(session_id,id);
+INSERT INTO assistant_usage_events VALUES(1,'gap','gpt-5.4',100,7,0,0,0,'2026-09-08T12:00:03Z');`)
+	require.NoError(t, err)
+	archive := dbtest.OpenTestDB(t)
+	engine := agentsync.NewEngine(archive, agentsync.EngineConfig{AgentDirs: map[parser.AgentType][]string{parser.AgentCopilot: {root}}, Machine: "local"})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	usage, err := archive.GetSessionUsage(t.Context(), "copilot:gap", true)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, 10, usage.TotalOutputTokens)
+	require.Len(t, usage.Breakdown, 2)
+	total := 0
+	for _, entry := range usage.Breakdown {
+		total += entry.OutputTokens
+	}
+	assert.Equal(t, 10, total, "usage reports include the remainder exactly once")
+	_, err = store.Exec(`INSERT INTO assistant_usage_events VALUES(2,'gap','gpt-5.4',100,3,0,0,0,'2026-09-08T12:00:01Z')`)
+	require.NoError(t, err)
+	require.NoError(t, engine.SyncPathsContext(t.Context(), []string{storePath + "-wal"}))
+	usage, err = archive.GetSessionUsage(t.Context(), "copilot:gap", true)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, 10, usage.TotalOutputTokens)
+	require.Len(t, usage.Breakdown, 2)
+	for _, entry := range usage.Breakdown {
+		assert.Equal(t, "session-store", entry.Source)
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8498,6 +8498,32 @@ func (e *Engine) discoveredFileEffectiveMtime(
 	if isS3SourcePath(file.Path) {
 		return discoveredFileMtime(file)
 	}
+	// Copilot store changes must pass the cutoff even when the transcript is
+	// old. Parent timestamps expose deletions; ctime catches restored mtimes.
+	// Keep these stat-only signals separate from persisted session mtimes.
+	if file.Agent == parser.AgentCopilot {
+		mtime, err := discoveredFileMtime(file)
+		if err != nil {
+			return 0, err
+		}
+		root := filepath.Dir(filepath.Dir(file.Path))
+		if filepath.Base(file.Path) == "events.jsonl" {
+			root = filepath.Dir(root)
+		}
+		storePath := filepath.Join(root, "session-store.db")
+		for _, path := range []string{storePath, storePath + "-wal", root} {
+			info, err := os.Stat(path)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				return 0, err
+			}
+			changeTime, _ := fileChangeTime(path, info)
+			mtime = max(mtime, info.ModTime().UnixNano(), changeTime)
+		}
+		return mtime, nil
+	}
 	// RooCode is excluded from the provider-Fingerprint path for cost, not
 	// correctness: its Fingerprint content-hashes history_item.json plus
 	// ui_messages.json, so consulting it here would read every task's full
@@ -14593,15 +14619,6 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 	// on scheduled syncs. Gemini relies on the post-fingerprint DB hash check
 	// instead (providerFingerprintHashRequiredForFreshness), which catches a
 	// resolved-project change even when size and mtime are unchanged.
-	case parser.AgentCopilot:
-		mtime := copilotEffectiveMtime(path, info)
-		effectiveInfo := fakeSnapshotInfo{
-			fSize:  info.Size(),
-			fMtime: mtime,
-		}
-		if e.shouldSkipByPath(path, effectiveInfo) {
-			return mtime, true
-		}
 	case parser.AgentRooCode:
 		// RooCode's fingerprint is composite (history_item.json plus
 		// ui_messages.json) and content-hashes both files. The
@@ -15738,9 +15755,6 @@ func pickPreferredCodexDiscoveredFile(
 	return chosen
 }
 
-// copilotEffectiveMtime returns max(events.jsonl mtime,
-// workspace.yaml mtime). For flat .jsonl sessions (no
-// workspace.yaml sibling) it returns the events.jsonl mtime.
 // roocodeEffectiveStat returns the composite size and latest mtime of
 // a RooCode task's history_item.json and its ui_messages.json sibling
 // using stat calls only. The values mirror what
@@ -15787,6 +15801,9 @@ func kiloLegacyEffectiveStat(metadataPath string, info os.FileInfo) (int64, int6
 	return size, mtime
 }
 
+// copilotEffectiveMtime returns max(events.jsonl mtime,
+// workspace.yaml mtime). For flat .jsonl sessions (no
+// workspace.yaml sibling) it returns the events.jsonl mtime.
 func copilotEffectiveMtime(eventsPath string, info os.FileInfo) int64 {
 	m := info.ModTime().UnixNano()
 	if filepath.Base(eventsPath) != "events.jsonl" {

--- a/internal/usagefacts/fact.go
+++ b/internal/usagefacts/fact.go
@@ -291,7 +291,7 @@ func floorTokens(value int64) int64 {
 // posit-assistant-keepalive, posit-assistant-classifier) each record one
 // provider request, so the whole prefix is request-scoped.
 func SourceIsRequestScoped(source string) bool {
-	return source == "message" || source == "goose-request" ||
+	return source == "message" || source == "goose-request" || source == "session-store" ||
 		source == "deepseek-harness" ||
 		strings.HasPrefix(source, "posit-assistant-")
 }


### PR DESCRIPTION
Copilot sessions now import observed per-call tokens from session-store.db, so usage can appear before shutdown. Each row receives request-level catalog pricing without requiring a transcript message ordinal. The latest shutdown reported cost remains authoritative.

A failed earlier store insert can coexist with a later successful row. Overlapping transcript output contributes only its positive per-model excess over store output; a recovered row replaces that excess without double counting. This remains a lower bound when extra store-only calls mask missing output, and it cannot recover missing input or request bands.

This is the second replacement for #1626. The dependent performance PR bounds refresh work for the shared store.

Merge order: #1683, then #1684, then #1685.
