### PR TITLE
perf(copilot): refresh shared-store usage without rereading transcripts

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -679,6 +679,15 @@ add an archived or maintained mirror without replacing the original identity.
   calls can mask missing output, and missing input or request bands cannot be
   recovered. A recovered row replaces that excess without adding it twice.
 
+- **Store refresh:** The native usage insert leaves `sessions.updated_at`
+  unchanged. Its `(session_id, id)` usage index supports per-session
+  maximum-ID lookups. Agentsview hashes changed sessions' usage rows once per
+  store update and reuses unchanged transcript hashes across provider and
+  engine restarts. Session timestamps still come from the transcript. Startup
+  rebuilds store hashes; runtime refresh follows appends and latest-row
+  removal. Historical edits below an unchanged maximum ID wait for a new
+  engine or CLI sync.
+
 ## Gemini CLI (`gemini`)
 
 - **Format:** Project chat recordings written as JSONL, with older JSON

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -652,7 +652,12 @@ add an archived or maintained mirror without replacing the original identity.
   initializes session-store schema version 4 without `assistant_usage_events`.
   Running that initialization SQL in isolated SQLite reproduced the missing
   table. A store without the required usage schema leaves transcript and
-  shutdown usage available.
+  shutdown usage available. Missing or incomplete usage schemas are cached as
+  empty usage for the current SQLite state. Reverified 2026-09-10 with
+  isolated syncs of 8 and 800 sessions: metadata-only writes do not reparse
+  transcripts, unchanged states reuse the cached result while the store is
+  locked, and a completed schema imports new usage for only the affected
+  session.
 
 - **Store refresh:** Store database and WAL writes participate in incremental
   sync cutoff filtering without changing session activity timestamps. Parent

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -440,6 +440,14 @@ cache-read tokens. Copilot's Claude model IDs use dotted version numbers, so the
 parser normalizes names such as `claude-sonnet-4.6` to `claude-sonnet-4-6`
 before pricing lookup.
 
+For sessions starting June 1, 2026 or later, available per-call usage from
+`session-store.db` supplies input, output, cache, and reasoning counts before
+shutdown. Store updates refresh the affected sessions without rereading
+unchanged transcripts. Overlapping transcript output contributes only its
+positive per-model difference from store totals; missing input cannot be
+reconstructed. Store tokens use catalog estimates, while the latest shutdown
+reported cost retains the treatment described below.
+
 Upgrading to 0.32.0 bumps the parser data version so existing Copilot CLI
 sessions are re-indexed with the new usage rows.
 

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json/jsontext"
 	"errors"
@@ -506,14 +507,8 @@ func loadCopilotStoreUsage(
 		// Older stores need not contain usage data. Confirm a missing schema
 		// before falling back; operational read failures must remain retryable.
 		if sqliteErr, ok := errors.AsType[sqlite3.Error](err); ok && sqliteErr.Code == sqlite3.ErrError {
-			var columns int
-			schemaErr := store.QueryRow(`
-				SELECT count(*) FROM pragma_table_info('assistant_usage_events')
-				WHERE name IN ('id', 'session_id', 'model', 'input_tokens',
-				    'output_tokens', 'cache_read_tokens', 'cache_write_tokens',
-				    'reasoning_tokens', 'created_at')
-			`).Scan(&columns)
-			if schemaErr == nil && columns < 9 {
+			hasUsage, schemaErr := copilotStoreHasUsageSchema(context.Background(), store.QueryRowContext)
+			if schemaErr == nil && !hasUsage {
 				return nil, nil
 			}
 		}
@@ -548,6 +543,17 @@ func loadCopilotStoreUsage(
 		return nil, fmt.Errorf("iterating copilot session-store usage: %w", err)
 	}
 	return events, nil
+}
+
+func copilotStoreHasUsageSchema(ctx context.Context, queryRow func(context.Context, string, ...any) *sql.Row) (bool, error) {
+	var columns int
+	err := queryRow(ctx, `
+		SELECT count(*) FROM pragma_table_info('assistant_usage_events')
+		WHERE name IN ('id', 'session_id', 'model', 'input_tokens',
+		    'output_tokens', 'cache_read_tokens', 'cache_write_tokens',
+		    'reasoning_tokens', 'created_at')
+	`).Scan(&columns)
+	return columns == 9, err
 }
 
 func formatCopilotToolCalls(

--- a/internal/parser/copilot_provider.go
+++ b/internal/parser/copilot_provider.go
@@ -2,10 +2,7 @@ package parser
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
-	"hash"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,11 +11,12 @@ import (
 var _ Provider = (*copilotProvider)(nil)
 
 type copilotProviderFactory struct {
-	def AgentDef
+	def   AgentDef
+	cache *copilotSourceCache
 }
 
 func newCopilotProviderFactory(def AgentDef) ProviderFactory {
-	return copilotProviderFactory{def: cloneAgentDef(def)}
+	return copilotProviderFactory{def: cloneAgentDef(def), cache: newCopilotSourceCache()}
 }
 
 func (f copilotProviderFactory) Definition() AgentDef {
@@ -35,7 +33,7 @@ func (f copilotProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 		Def:     cloneAgentDef(f.def),
 		Caps:    copilotProviderCapabilities(),
 		Config:  cfg,
-		sources: newCopilotSourceSet(cfg.Roots),
+		sources: newCopilotSourceSet(cfg.Roots, f.cache),
 	}
 }
 
@@ -76,6 +74,10 @@ func (p *copilotProvider) Fingerprint(
 	source SourceRef,
 ) (SourceFingerprint, error) {
 	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *copilotProvider) FingerprintWithStored(ctx context.Context, source SourceRef, load StoredFingerprintLookup) (SourceFingerprint, error) {
+	return p.sources.fingerprint(ctx, source, load)
 }
 
 func (p *copilotProvider) Parse(
@@ -130,26 +132,22 @@ type copilotSource struct {
 
 type copilotSourceSet struct {
 	roots []string
+	cache *copilotSourceCache
 }
 
-func newCopilotSourceSet(roots []string) copilotSourceSet {
-	return copilotSourceSet{roots: cleanJSONLRoots(roots)}
+func newCopilotSourceSet(roots []string, cache *copilotSourceCache) copilotSourceSet {
+	return copilotSourceSet{roots: cleanJSONLRoots(roots), cache: cache}
 }
 
 func (s copilotSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	var sources []SourceRef
 	seen := make(map[string]struct{})
-	for _, root := range s.roots {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		for _, path := range s.discoverSessionPaths(root) {
-			source, ok := s.sourceRef(root, path)
-			if !ok {
-				continue
-			}
-			addJSONLSource(source, &sources, seen)
-		}
+	err := s.DiscoverEach(ctx, func(source SourceRef) error {
+		addJSONLSource(source, &sources, seen)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	sortJSONLSources(sources)
 	return sources, nil
@@ -160,6 +158,7 @@ func (s copilotSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		seen := make(map[string]bool)
 		stateDir := filepath.Join(root, copilotStateDir)
 		err := streamDirectoryEntries(ctx, stateDir, func(entry os.DirEntry) error {
 			name := entry.Name()
@@ -176,6 +175,7 @@ func (s copilotSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef
 			}
 			if path != "" {
 				if source, ok := s.sourceRef(root, path); ok {
+					seen[path] = true
 					return yield(source)
 				}
 			}
@@ -184,6 +184,7 @@ func (s copilotSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef
 		if err != nil {
 			return err
 		}
+		s.cache.pruneTranscripts(root, seen)
 	}
 	return nil
 }
@@ -343,6 +344,10 @@ func (s copilotSourceSet) Fingerprint(
 	ctx context.Context,
 	source SourceRef,
 ) (SourceFingerprint, error) {
+	return s.fingerprint(ctx, source, nil)
+}
+
+func (s copilotSourceSet) fingerprint(ctx context.Context, source SourceRef, load StoredFingerprintLookup) (SourceFingerprint, error) {
 	if err := ctx.Err(); err != nil {
 		return SourceFingerprint{}, err
 	}
@@ -357,42 +362,39 @@ func (s copilotSourceSet) Fingerprint(
 	if info.IsDir() {
 		return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", path)
 	}
-	size := info.Size()
-	mtime := info.ModTime().UnixNano()
-	if workspace := copilotWorkspacePath(path); workspace != "" {
-		if wsInfo, err := os.Stat(workspace); err == nil {
-			size += wsInfo.Size()
-			if wsMtime := wsInfo.ModTime().UnixNano(); wsMtime > mtime {
-				mtime = wsMtime
-			}
-		}
-	}
-	fingerprint := SourceFingerprint{
-		Key:     firstNonEmptyJSONLString(source.FingerprintKey, source.Key, path),
-		Size:    size,
-		MTimeNS: mtime,
-	}
-	h := sha256.New()
-	if err := addCopilotFingerprintPart(h, "events", path, info); err != nil {
+	transcript, err := s.cache.transcript(ctx, path, info, load)
+	if err != nil {
 		return SourceFingerprint{}, err
 	}
-	if workspace := copilotWorkspacePath(path); workspace != "" {
-		if wsInfo, err := os.Stat(workspace); err == nil && !wsInfo.IsDir() {
-			if err := addCopilotFingerprintPart(h, "workspace", workspace, wsInfo); err != nil {
-				return SourceFingerprint{}, err
+	storeHash := ""
+	if transcript.UsesStore {
+		storePath := filepath.Join(copilotRootForEventsPath(path), "session-store.db")
+		if _, captured := StatSQLiteContainerState(storePath); !captured {
+			if _, err := os.Stat(storePath); !os.IsNotExist(err) {
+				return SourceFingerprint{}, fmt.Errorf("cannot capture copilot session store state %s", storePath)
 			}
 		}
-	}
-	// SQLite write markers affect freshness, never session timestamps.
-	storePath := filepath.Join(copilotRootForEventsPath(path), "session-store.db")
-	state, captured := StatSQLiteContainerState(storePath)
-	if !captured {
-		if _, err := os.Stat(storePath); !os.IsNotExist(err) {
-			return SourceFingerprint{}, fmt.Errorf("cannot capture copilot session store state %s", storePath)
+		storeHash, err = s.cache.usageHash(ctx, storePath, transcript.SessionID)
+		if err != nil {
+			if ctx.Err() != nil {
+				return SourceFingerprint{}, ctx.Err()
+			}
+			// Preserve the parser's transcript-only fallback when the optional
+			// store cannot be read. Failed reads are not cached, so recovery is
+			// retried on the next fingerprint even without a file change.
+			state, _ := StatSQLiteContainerState(storePath)
+			storeHash = fmt.Sprintf("unavailable:%v", state)
 		}
 	}
-	fmt.Fprintf(h, "%v", state)
-	fingerprint.Hash = fmt.Sprintf("%x", h.Sum(nil))
+	encoded, err := transcript.encode()
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	fingerprint := SourceFingerprint{
+		Key:  firstNonEmptyJSONLString(source.FingerprintKey, source.Key, path),
+		Size: transcript.Size, MTimeNS: transcript.Mtime,
+		Hash: fmt.Sprintf("copilot-session:v4:%s:%s", encoded, storeHash),
+	}
 	return fingerprint, nil
 }
 
@@ -496,31 +498,40 @@ func copilotWorkspacePath(eventsPath string) string {
 	return filepath.Join(filepath.Dir(eventsPath), "workspace.yaml")
 }
 
-func addCopilotFingerprintPart(
-	h hash.Hash,
-	label string,
-	path string,
-	info os.FileInfo,
-) error {
-	if _, err := fmt.Fprintf(
-		h,
-		"%s\x00%s\x00%d\x00%d\x00",
-		label,
-		path,
-		info.Size(),
-		info.ModTime().UnixNano(),
-	); err != nil {
-		return err
+func copilotRootForEventsPath(eventsPath string) string {
+	stateDir := filepath.Dir(eventsPath)
+	if filepath.Base(eventsPath) == "events.jsonl" {
+		stateDir = filepath.Dir(stateDir)
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("open %s: %w", path, err)
+	if filepath.Base(stateDir) != copilotStateDir {
+		return ""
 	}
-	defer f.Close()
-	if _, err := io.Copy(h, f); err != nil {
-		return fmt.Errorf("hash %s: %w", path, err)
+	return filepath.Dir(stateDir)
+}
+
+// CopilotCompositeFileStat describes only this transcript and its workspace.
+// Shared store writes are compared through per-session usage fingerprints.
+func CopilotCompositeFileStat(eventsPath string, info os.FileInfo) (size, mtime int64) {
+	size, mtime = info.Size(), info.ModTime().UnixNano()
+	if workspace := copilotWorkspacePath(eventsPath); workspace != "" {
+		if ws, err := os.Stat(workspace); err == nil && !ws.IsDir() {
+			size += ws.Size()
+			mtime = max(mtime, ws.ModTime().UnixNano())
+		}
 	}
-	return nil
+	return size, mtime
+}
+
+func copilotStoreChangedPath(root, path string) bool {
+	if !samePath(filepath.Dir(path), root) {
+		return false
+	}
+	switch filepath.Base(path) {
+	case "session-store.db", "session-store.db-wal":
+		return true
+	default:
+		return false
+	}
 }
 
 func copilotProviderCapabilities() Capabilities {
@@ -538,7 +549,6 @@ func copilotProviderCapabilities() Capabilities {
 			ExcludedSessions:     CapabilityNotApplicable,
 			ForceReplaceOnParse:  CapabilityNotApplicable,
 		},
-		Sync: ProviderSyncSemantics{FingerprintHashRequiredForFreshness: true},
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			Cwd:                  CapabilitySupported,
@@ -550,28 +560,8 @@ func copilotProviderCapabilities() Capabilities {
 			AggregateUsageEvents: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
-	}
-}
-
-func copilotRootForEventsPath(eventsPath string) string {
-	stateDir := filepath.Dir(eventsPath)
-	if filepath.Base(eventsPath) == "events.jsonl" {
-		stateDir = filepath.Dir(stateDir)
-	}
-	if filepath.Base(stateDir) != copilotStateDir {
-		return ""
-	}
-	return filepath.Dir(stateDir)
-}
-
-func copilotStoreChangedPath(root, path string) bool {
-	if !samePath(filepath.Dir(path), root) {
-		return false
-	}
-	switch filepath.Base(path) {
-	case "session-store.db", "session-store.db-wal":
-		return true
-	default:
-		return false
+		Sync: ProviderSyncSemantics{
+			FingerprintHashRequiredForFreshness: true,
+		},
 	}
 }

--- a/internal/parser/copilot_store_freshness.go
+++ b/internal/parser/copilot_store_freshness.go
@@ -182,10 +182,16 @@ func (c *copilotSourceCache) usageHash(ctx context.Context, path, sessionID stri
 		return "", err
 	}
 	defer func() { _ = tx.Rollback() }()
+	hasUsage, err := copilotStoreHasUsageSchema(ctx, tx.QueryRowContext)
+	if err != nil {
+		return "", fmt.Errorf("checking copilot usage schema: %w", err)
+	}
+	// Missing or incomplete usage schemas are valid empty results. Cache them
+	// with this SQLite state and check again only after the store changes.
 	members := make(map[string]copilotStoreMember)
-	if full || !valid {
+	if hasUsage && (full || !valid) {
 		members, err = c.readUsageHashes(ctx, tx, "", nil)
-	} else {
+	} else if hasUsage {
 		// sessions is small metadata. The producer's (session_id, id) index makes
 		// each MAX lookup bounded; do not aggregate every usage row on a WAL event.
 		var rows *sql.Rows

--- a/internal/parser/copilot_store_freshness.go
+++ b/internal/parser/copilot_store_freshness.go
@@ -1,0 +1,290 @@
+package parser
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json/v2"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+var copilotTranscriptBytesRead atomic.Int64
+
+// CopilotTranscriptBytesRead reports transcript payload work for sync scaling checks.
+func CopilotTranscriptBytesRead() int64 { return copilotTranscriptBytesRead.Load() }
+
+// Like the OpenCode factory index, this cache is shared by the short-lived
+// providers of one engine. It caches producer inputs, never successful archive
+// writes: only the engine's persisted fingerprint comparison permits a skip.
+type copilotSourceCache struct {
+	mu          sync.Mutex
+	transcripts map[string]copilotTranscriptFingerprint
+	stores      map[string]copilotStoreFingerprint
+	// Work counters pin the amount of payload read by scaling regressions.
+	transcriptBytes int64
+	usageRows       int64
+}
+
+type copilotTranscriptFingerprint struct {
+	Stat            uint64
+	Size, Mtime     int64
+	Hash, SessionID string
+	UsesStore       bool
+}
+
+func (f copilotTranscriptFingerprint) encode() (string, error) {
+	data, err := json.Marshal(f)
+	return base64.RawURLEncoding.EncodeToString(data), err
+}
+
+func restoreCopilotTranscriptFingerprint(value string, stat uint64) (copilotTranscriptFingerprint, bool) {
+	parts := strings.SplitN(value, ":", 4)
+	if len(parts) != 4 || parts[0] != "copilot-session" || parts[1] != "v4" || stat == 0 {
+		return copilotTranscriptFingerprint{}, false
+	}
+	data, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return copilotTranscriptFingerprint{}, false
+	}
+	var f copilotTranscriptFingerprint
+	if json.Unmarshal(data, &f) != nil || f.Stat != stat {
+		return copilotTranscriptFingerprint{}, false
+	}
+	return f, true
+}
+
+type copilotStoreMember struct {
+	lastID int64
+	hash   string
+}
+
+type copilotStoreFingerprint struct {
+	state   SQLiteContainerState
+	members map[string]copilotStoreMember
+}
+
+func newCopilotSourceCache() *copilotSourceCache {
+	return &copilotSourceCache{
+		transcripts: make(map[string]copilotTranscriptFingerprint),
+		stores:      make(map[string]copilotStoreFingerprint),
+	}
+}
+
+func (c *copilotSourceCache) transcript(ctx context.Context, path string, info os.FileInfo, load StoredFingerprintLookup) (copilotTranscriptFingerprint, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	workspace := copilotWorkspacePath(path)
+	paths := []string{path}
+	if workspace != "" {
+		paths = append(paths, workspace)
+	}
+	stat := fileStatTupleDigest(0xC3, paths...)
+	if prior, ok := c.transcripts[path]; ok && stat != 0 && prior.Stat == stat {
+		return prior, nil
+	}
+	if load != nil && stat != 0 {
+		if value, ok := load(path); ok {
+			if prior, valid := restoreCopilotTranscriptFingerprint(value, stat); valid {
+				c.transcripts[path] = prior
+				return prior, nil
+			}
+		}
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		delete(c.transcripts, path)
+		return copilotTranscriptFingerprint{}, err
+	}
+	defer file.Close()
+	c.transcriptBytes += info.Size()
+	copilotTranscriptBytesRead.Add(info.Size())
+	h := sha256.New()
+	var started time.Time
+	sessionID := ""
+	lr := newLineReader(io.TeeReader(file, h), maxLineSize)
+	defer releaseLineReader(lr)
+	for {
+		if err := ctx.Err(); err != nil {
+			return copilotTranscriptFingerprint{}, err
+		}
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if !gjson.Valid(line) {
+			continue
+		}
+		if started.IsZero() {
+			started = parseTimestamp(gjson.Get(line, "timestamp").Str)
+		}
+		if gjson.Get(line, "type").Str == copilotEventSessionStart {
+			if id := gjson.Get(line, "data.sessionId").Str; id != "" {
+				sessionID = id
+			}
+		}
+	}
+	if err := lr.Err(); err != nil {
+		return copilotTranscriptFingerprint{}, err
+	}
+	if sessionID == "" {
+		sessionID = sessionIDFromPath(path)
+	}
+	if workspace != "" {
+		data, err := os.ReadFile(workspace)
+		if err != nil && !os.IsNotExist(err) {
+			return copilotTranscriptFingerprint{}, err
+		}
+		fmt.Fprintf(h, "\x00workspace:%d\x00", len(data))
+		h.Write(data)
+	}
+	size, mtime := CopilotCompositeFileStat(path, info)
+	result := copilotTranscriptFingerprint{Stat: stat, Size: size, Mtime: mtime,
+		Hash: fmt.Sprintf("%x", h.Sum(nil)), SessionID: sessionID,
+		UsesStore: !started.Before(copilotUsageBasedPricingStartedAt)}
+	c.transcripts[path] = result
+	return result, nil
+}
+
+func (c *copilotSourceCache) usageHash(ctx context.Context, path, sessionID string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	state, valid := StatSQLiteContainerState(path)
+	if !valid {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			delete(c.stores, path)
+			return "", nil
+		}
+	}
+	prior, exists := c.stores[path]
+	full := !exists ||
+		state.DBInode != prior.state.DBInode || state.DBDevice != prior.state.DBDevice
+	if valid && exists && state == prior.state && !full {
+		return prior.members[sessionID].hash, nil
+	}
+	store, err := sql.Open("sqlite3", "file:"+sqliteURIPath(path)+"?mode=ro&_busy_timeout=3000")
+	if err != nil {
+		return "", err
+	}
+	defer store.Close()
+	tx, err := store.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = tx.Rollback() }()
+	members := make(map[string]copilotStoreMember)
+	if full || !valid {
+		members, err = c.readUsageHashes(ctx, tx, "", nil)
+	} else {
+		// sessions is small metadata. The producer's (session_id, id) index makes
+		// each MAX lookup bounded; do not aggregate every usage row on a WAL event.
+		var rows *sql.Rows
+		rows, err = tx.QueryContext(ctx, `SELECT id,
+   COALESCE((SELECT MAX(id) FROM assistant_usage_events WHERE session_id = sessions.id), 0)
+   FROM sessions`)
+		if err == nil {
+			for rows.Next() {
+				var id string
+				var lastID int64
+				if err = rows.Scan(&id, &lastID); err != nil {
+					break
+				}
+				if lastID != 0 {
+					members[id] = copilotStoreMember{lastID: lastID}
+				}
+			}
+			if err == nil {
+				err = rows.Err()
+			}
+			rows.Close()
+		}
+		if err == nil {
+			for id, member := range members {
+				if old, ok := prior.members[id]; ok && old.lastID == member.lastID {
+					members[id] = old
+					continue
+				}
+				var changed map[string]copilotStoreMember
+				changed, err = c.readUsageHashes(ctx, tx, "WHERE session_id = ?", []any{id})
+				if err != nil {
+					break
+				}
+				members[id] = changed[id]
+			}
+		}
+	}
+	if err != nil {
+		return "", fmt.Errorf("fingerprinting copilot usage: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return "", err
+	}
+	// A failed or unreadable state is never trusted for an idle skip.
+	if valid {
+		c.stores[path] = copilotStoreFingerprint{state, members}
+	}
+	return members[sessionID].hash, nil
+}
+
+func (c *copilotSourceCache) readUsageHashes(ctx context.Context, tx *sql.Tx, where string, args []any) (map[string]copilotStoreMember, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT session_id, id, model,
+  COALESCE(input_tokens,0), COALESCE(output_tokens,0), COALESCE(cache_read_tokens,0),
+  COALESCE(cache_write_tokens,0), COALESCE(reasoning_tokens,0), created_at
+  FROM assistant_usage_events `+where+` ORDER BY session_id, id`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[string]copilotStoreMember)
+	var current string
+	var h hash.Hash
+	var lastID int64
+	finish := func() {
+		if h != nil {
+			result[current] = copilotStoreMember{lastID, fmt.Sprintf("%x", h.Sum(nil))}
+		}
+	}
+	for rows.Next() {
+		var id int64
+		var sessionID, model, timestamp string
+		var input, output, read, write, reasoning int64
+		if err := rows.Scan(&sessionID, &id, &model, &input, &output, &read, &write, &reasoning, &timestamp); err != nil {
+			return nil, err
+		}
+		c.usageRows++
+		if h == nil || sessionID != current {
+			finish()
+			current = sessionID
+			h = sha256.New()
+		}
+		lastID = id
+		fmt.Fprintf(h, "%d:%q:%d:%d:%d:%d:%d:%q\n", id, model, input, output, read, write, reasoning, timestamp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	finish()
+	return result, nil
+}
+
+// Prune transcript hash entries during authoritative discovery, not on each
+// store event. Deleted transcripts must not accumulate in the factory cache.
+func (c *copilotSourceCache) pruneTranscripts(root string, seen map[string]bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for path := range c.transcripts {
+		if copilotRootForEventsPath(path) == filepath.Clean(root) && !seen[path] {
+			delete(c.transcripts, path)
+		}
+	}
+}

--- a/internal/parser/copilot_store_freshness_test.go
+++ b/internal/parser/copilot_store_freshness_test.go
@@ -1,0 +1,77 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopilotStoreFingerprintWorkScalesWithChangedUsage(t *testing.T) {
+	for _, count := range []int{8, 800} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			root := t.TempDir()
+			store := createCopilotUsageStore(t, root)
+			tx, err := store.Begin()
+			require.NoError(t, err)
+			for i := range count {
+				id := fmt.Sprintf("session-%04d", i)
+				_, err := tx.Exec(`INSERT INTO sessions VALUES (?);
+     INSERT INTO assistant_usage_events(session_id,model,input_tokens,output_tokens,created_at)
+     VALUES (?, 'gpt-5.4', 100, 3, '2026-09-04T17:00:02Z')`, id, id)
+				require.NoError(t, err)
+				path := filepath.Join(root, copilotStateDir, id, "events.jsonl")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				text := fmt.Sprintf("{\"type\":\"session.start\",\"timestamp\":\"2026-09-04T17:00:00Z\",\"data\":{\"sessionId\":%q}}\n", id) +
+					fmt.Sprintf("{\"type\":\"assistant.message\",\"timestamp\":\"2026-09-04T17:00:01Z\",\"data\":{\"content\":%q,\"outputTokens\":3}}\n", strings.Repeat("x", 8192))
+				require.NoError(t, os.WriteFile(path, []byte(text), 0o644))
+			}
+			require.NoError(t, tx.Commit())
+			provider := newCopilotTestProvider(t, root)
+			sources, err := provider.Discover(t.Context())
+			require.NoError(t, err)
+			before := make(map[string]SourceFingerprint)
+			for _, source := range sources {
+				fp, err := provider.Fingerprint(t.Context(), source)
+				require.NoError(t, err)
+				before[source.Key] = fp
+			}
+			// A fresh provider restores transcript metadata from the archive's
+			// fingerprint but independently rebuilds usage hashes from the store.
+			cold := newCopilotTestProvider(t, root)
+			for _, source := range sources {
+				fp, err := cold.FingerprintWithStored(t.Context(), source, func(path string) (string, bool) {
+					stored, ok := before[path]
+					return stored.Hash, ok
+				})
+				require.NoError(t, err)
+				assert.Equal(t, before[source.Key], fp)
+			}
+			assert.Zero(t, cold.sources.cache.transcriptBytes)
+			provider = cold
+			cache := provider.sources.cache
+			bytesBefore, rowsBefore := cache.transcriptBytes, cache.usageRows
+			_, err = store.Exec(`INSERT INTO assistant_usage_events(session_id,model,input_tokens,output_tokens,created_at)
+    VALUES ('session-0000','gpt-5.4',100,7,'2026-09-04T17:00:03Z')`)
+			require.NoError(t, err)
+			changed, err := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{Path: filepath.Join(root, "session-store.db-wal"), EventKind: "write"})
+			require.NoError(t, err)
+			var changedKeys []string
+			for _, source := range changed {
+				fp, err := provider.Fingerprint(t.Context(), source)
+				require.NoError(t, err)
+				if fp.Hash != before[source.Key].Hash {
+					changedKeys = append(changedKeys, source.Key)
+				}
+				assert.Equal(t, before[source.Key].MTimeNS, fp.MTimeNS)
+			}
+			assert.Equal(t, []string{filepath.Join(root, copilotStateDir, "session-0000", "events.jsonl")}, changedKeys)
+			assert.Zero(t, cache.transcriptBytes-bytesBefore, "a store-only event must not reread transcript payloads")
+			assert.Equal(t, int64(2), cache.usageRows-rowsBefore, "only the changed session's two usage rows are read")
+		})
+	}
+}

--- a/internal/parser/copilot_store_test.go
+++ b/internal/parser/copilot_store_test.go
@@ -207,7 +207,7 @@ func TestCopilotFingerprintRejectsUnreadableStoreState(t *testing.T) {
 		t.Run("session-store.db"+suffix, func(t *testing.T) {
 			root := t.TempDir()
 			path := filepath.Join(root, "session-state", "fingerprint.jsonl")
-			writeSourceFile(t, path, `{"type":"session.start","data":{"sessionId":"fingerprint"}}`)
+			writeSourceFile(t, path, `{"type":"session.start","timestamp":"2026-09-08T12:00:00Z","data":{"sessionId":"fingerprint"}}`)
 			provider := newCopilotTestProvider(t, root)
 			sources, err := provider.Discover(t.Context())
 			require.NoError(t, err)
@@ -216,6 +216,9 @@ func TestCopilotFingerprintRejectsUnreadableStoreState(t *testing.T) {
 			require.NoError(t, err, "a missing optional store is valid")
 
 			store := createCopilotUsageStore(t, root)
+			_, err = store.Exec(`INSERT INTO assistant_usage_events(session_id,model,output_tokens,created_at)
+				VALUES ('fingerprint','gpt-5.4',3,'2026-09-08T12:00:01Z')`)
+			require.NoError(t, err)
 			require.NoError(t, store.Close())
 			storePath := filepath.Join(root, "session-store.db")
 			original, err := os.ReadFile(storePath)

--- a/internal/parser/gemini_copilot_provider_test.go
+++ b/internal/parser/gemini_copilot_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -657,6 +658,9 @@ func TestCopilotProviderSourceMethods(t *testing.T) {
 	assert.NotEmpty(t, fingerprint.Hash)
 
 	writeSourceFile(t, workspacePath, "name: Workspace other\n")
+	// Equal-size writes can share a filesystem timestamp tick on Windows.
+	workspaceTime := time.Unix(0, fingerprint.MTimeNS).Add(time.Second)
+	require.NoError(t, os.Chtimes(workspacePath, workspaceTime, workspaceTime))
 	renamedFingerprint, err := provider.Fingerprint(context.Background(), found)
 	require.NoError(t, err)
 	assert.NotEqual(t, fingerprint.Hash, renamedFingerprint.Hash)

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -94,6 +94,17 @@ func (cfg ProviderConfig) RootsCopy() []string {
 
 // Provider is the target parser/source facade. Providers own source shape,
 // source identity, freshness, and lookup; the engine consumes SourceRefs,
+// StoredFingerprintLookup reads the archive's last successful source fingerprint.
+// It is lazy: providers invoke it only when their in-memory cache needs a seed.
+type StoredFingerprintLookup func(path string) (string, bool)
+
+// StoredFingerprintProvider can reuse independently verified parts of a persisted
+// fingerprint. It must still check every other input before returning freshness.
+// Providers without this optional capability receive no archive lookup.
+type StoredFingerprintProvider interface {
+	FingerprintWithStored(context.Context, SourceRef, StoredFingerprintLookup) (SourceFingerprint, error)
+}
+
 // SourceFingerprints, and normalized ParseResults without knowing whether the
 // backing data is a file, virtual DB row, sidecar set, remote canonical path, or
 // multi-session container.

--- a/internal/sync/copilot_store_test.go
+++ b/internal/sync/copilot_store_test.go
@@ -308,3 +308,80 @@ VALUES ('session-0000','gpt-5.4',100,7,'2026-09-04T17:00:03Z')`)
 		})
 	}
 }
+
+func TestCopilotStoreWithoutUsageSchemaSkipsUnchangedSessions(t *testing.T) {
+	for _, incomplete := range []bool{false, true} {
+		for _, count := range []int{8, 800} {
+			t.Run(fmt.Sprintf("incomplete=%t/sessions=%d", incomplete, count), func(t *testing.T) {
+				root := t.TempDir()
+				storePath := filepath.Join(root, "session-store.db")
+				store, err := sql.Open("sqlite3", storePath)
+				require.NoError(t, err)
+				store.SetMaxOpenConns(1)
+				t.Cleanup(func() { require.NoError(t, store.Close()) })
+				_, err = store.Exec(`CREATE TABLE sessions(id TEXT PRIMARY KEY, summary TEXT)`)
+				require.NoError(t, err)
+				if incomplete {
+					_, err = store.Exec(`CREATE TABLE assistant_usage_events(id INTEGER PRIMARY KEY, session_id TEXT, model TEXT)`)
+					require.NoError(t, err)
+				}
+				for i := range count {
+					id := fmt.Sprintf("session-%04d", i)
+					_, err = store.Exec(`INSERT INTO sessions VALUES (?, 'before')`, id)
+					require.NoError(t, err)
+					path := filepath.Join(root, "session-state", id, "events.jsonl")
+					require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+					transcript := fmt.Sprintf(`{"type":"session.start","timestamp":"2026-09-08T12:00:00Z","data":{"sessionId":%q}}
+{"type":"assistant.message","timestamp":"2026-09-08T12:00:01Z","data":{"content":"Hello","model":"gpt-5.4","outputTokens":3}}
+`, id)
+					require.NoError(t, os.WriteFile(path, []byte(transcript), 0o644))
+				}
+				archive := dbtest.OpenTestDB(t)
+				engine := agentsync.NewEngine(archive, agentsync.EngineConfig{
+					AgentDirs: map[parser.AgentType][]string{parser.AgentCopilot: {root}}, Machine: "local",
+				})
+				t.Cleanup(engine.Close)
+				require.Equal(t, count, engine.SyncAll(t.Context(), nil).Synced)
+
+				_, err = store.Exec(`UPDATE sessions SET summary='after' WHERE id='session-0000'`)
+				require.NoError(t, err)
+				require.NoError(t, engine.SyncPathsContext(t.Context(), []string{storePath}))
+				stats := engine.LastSyncStats()
+				require.Zero(t, stats.Synced, "metadata-only writes must not reparse transcripts")
+				assert.Equal(t, count, stats.Skipped)
+
+				// Taking a lock without writing leaves the SQLite state unchanged.
+				// Reusing the cached no-usage result must not query the locked store.
+				_, err = store.Exec(`BEGIN EXCLUSIVE`)
+				require.NoError(t, err)
+				t.Cleanup(func() { _, _ = store.Exec("ROLLBACK") })
+				require.NoError(t, engine.SyncPathsContext(t.Context(), []string{storePath}))
+				assert.Equal(t, count, engine.LastSyncStats().Skipped)
+				_, err = store.Exec(`ROLLBACK`)
+				require.NoError(t, err)
+
+				if !incomplete {
+					_, err = store.Exec(`CREATE TABLE assistant_usage_events(id INTEGER PRIMARY KEY, session_id TEXT, model TEXT)`)
+					require.NoError(t, err)
+				}
+				_, err = store.Exec(`ALTER TABLE assistant_usage_events ADD COLUMN input_tokens INTEGER;
+ALTER TABLE assistant_usage_events ADD COLUMN output_tokens INTEGER;
+ALTER TABLE assistant_usage_events ADD COLUMN cache_read_tokens INTEGER;
+ALTER TABLE assistant_usage_events ADD COLUMN cache_write_tokens INTEGER;
+ALTER TABLE assistant_usage_events ADD COLUMN reasoning_tokens INTEGER;
+ALTER TABLE assistant_usage_events ADD COLUMN created_at TEXT;
+CREATE INDEX idx_assistant_usage_events_session ON assistant_usage_events(session_id,id);
+INSERT INTO assistant_usage_events VALUES(1,'session-0000','gpt-5.4',100,7,0,0,0,'2026-09-08T12:00:01Z')`)
+				require.NoError(t, err)
+				require.NoError(t, engine.SyncPathsContext(t.Context(), []string{storePath}))
+				stats = engine.LastSyncStats()
+				assert.Equal(t, 1, stats.Synced)
+				assert.Equal(t, count-1, stats.Skipped)
+				usage, err := archive.GetSessionUsage(t.Context(), "copilot:session-0000", true)
+				require.NoError(t, err)
+				require.NotNil(t, usage)
+				assert.Equal(t, 7, usage.TotalOutputTokens)
+			})
+		}
+	}
+}

--- a/internal/sync/copilot_store_test.go
+++ b/internal/sync/copilot_store_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -216,5 +217,94 @@ INSERT INTO assistant_usage_events VALUES(1,'gap','gpt-5.4',100,7,0,0,0,'2026-09
 	require.Len(t, usage.Breakdown, 2)
 	for _, entry := range usage.Breakdown {
 		assert.Equal(t, "session-store", entry.Source)
+	}
+}
+
+func TestCopilotStoreUpdateOnlySyncsChangedSession(t *testing.T) {
+	for _, count := range []int{8, 800} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			root := t.TempDir()
+			storePath := filepath.Join(root, "session-store.db")
+			store, err := sql.Open("sqlite3", storePath)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			_, err = store.Exec(`PRAGMA journal_mode=WAL;
+CREATE TABLE sessions (id TEXT PRIMARY KEY);
+CREATE TABLE assistant_usage_events (
+id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, model TEXT,
+input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER,
+cache_write_tokens INTEGER, reasoning_tokens INTEGER, created_at TEXT);
+CREATE INDEX idx_assistant_usage_events_session ON assistant_usage_events(session_id,id);`)
+			require.NoError(t, err)
+			tx, err := store.Begin()
+			require.NoError(t, err)
+			for i := range count {
+				id := fmt.Sprintf("session-%04d", i)
+				_, err = tx.Exec(`INSERT INTO sessions VALUES (?);
+INSERT INTO assistant_usage_events(session_id,model,input_tokens,output_tokens,created_at)
+VALUES (?,'gpt-5.4',100,3,'2026-09-04T17:00:02Z')`, id, id)
+				require.NoError(t, err)
+				path := filepath.Join(root, "session-state", id, "events.jsonl")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				transcript := fmt.Sprintf(`{"type":"session.start","timestamp":"2026-09-04T17:00:00Z","data":{"sessionId":%q}}
+{"type":"user.message","timestamp":"2026-09-04T17:00:01Z","data":{"content":"Question"}}
+{"type":"assistant.message","timestamp":"2026-09-04T17:00:02Z","data":{"content":"Answer","outputTokens":3}}
+`, id)
+				require.NoError(t, os.WriteFile(path, []byte(transcript), 0o644))
+			}
+			require.NoError(t, tx.Commit())
+			archive := dbtest.OpenTestDB(t)
+			cfg := agentsync.EngineConfig{AgentDirs: map[parser.AgentType][]string{parser.AgentCopilot: {root}}, Machine: "local"}
+			engine := agentsync.NewEngine(archive, cfg)
+			t.Cleanup(engine.Close)
+			require.Equal(t, count, engine.SyncAll(t.Context(), nil).Synced)
+			_, err = store.Exec(`INSERT INTO assistant_usage_events(session_id,model,input_tokens,output_tokens,created_at)
+VALUES ('session-0000','gpt-5.4',100,7,'2026-09-04T17:00:03Z')`)
+			require.NoError(t, err)
+			require.NoError(t, engine.SyncPathsContext(t.Context(), []string{storePath + "-wal"}))
+			stats := engine.LastSyncStats()
+			assert.Equal(t, 1, stats.Synced)
+			assert.Equal(t, count-1, stats.Skipped)
+			usage, err := archive.GetUsageEvents(t.Context(), "copilot:session-0000")
+			require.NoError(t, err)
+			require.Len(t, usage, 2)
+			assert.Equal(t, 3, usage[0].OutputTokens)
+			assert.Equal(t, 7, usage[1].OutputTokens)
+			other, err := archive.GetUsageEvents(t.Context(), "copilot:session-0001")
+			require.NoError(t, err)
+			require.Len(t, other, 1)
+			assert.Equal(t, 3, other[0].OutputTokens)
+
+			// Rebuilding the transient producer cache must still honor archive fingerprints.
+			engine.Close()
+			restarted := agentsync.NewEngine(archive, cfg)
+			t.Cleanup(restarted.Close)
+			bytesBefore := parser.CopilotTranscriptBytesRead()
+			stats = restarted.SyncAll(t.Context(), nil)
+			assert.Zero(t, parser.CopilotTranscriptBytesRead()-bytesBefore, "cold engines reuse verified transcript fingerprints")
+			assert.Zero(t, stats.Synced)
+			assert.Equal(t, count, stats.Skipped)
+
+			_, err = store.Exec(`DELETE FROM assistant_usage_events WHERE id=(SELECT MAX(id) FROM assistant_usage_events)`)
+			require.NoError(t, err)
+			require.NoError(t, restarted.SyncPathsContext(t.Context(), []string{storePath + "-wal"}))
+			assert.Equal(t, 1, restarted.LastSyncStats().Synced)
+			usage, err = archive.GetUsageEvents(t.Context(), "copilot:session-0000")
+			require.NoError(t, err)
+			require.Len(t, usage, 1)
+			assert.Equal(t, 3, usage[0].OutputTokens)
+
+			missing := filepath.Join(root, "session-state", "session-0001", "events.jsonl")
+			require.NoError(t, os.Remove(missing))
+			require.NoError(t, restarted.ReconcileWatchRoots(t.Context(), []string{root}, false))
+			saved, err := archive.GetSessionFull(t.Context(), "copilot:session-0001")
+			require.NoError(t, err)
+			require.NotNil(t, saved, "missing transcripts remain archived")
+			assert.NotNil(t, saved.SourceMissingAt)
+			assert.Nil(t, saved.DeletedAt)
+			other, err = archive.GetUsageEvents(t.Context(), "copilot:session-0001")
+			require.NoError(t, err)
+			require.Len(t, other, 1, "source removal preserves archived usage")
+		})
 	}
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2353,6 +2353,10 @@ func providerChangedPathForceParse(
 		return eventKind == "remove" &&
 			providerDeletedPhysicalSQLiteSource(agent, sourcePath)
 	}
+	// Copilot companion events compare per-session hashes before parsing.
+	if agent == parser.AgentCopilot && filepath.Clean(sourcePath) != filepath.Clean(eventPath) {
+		return false
+	}
 	if mode != parser.ProviderMigrationProviderAuthoritative {
 		return true
 	}
@@ -8626,6 +8630,18 @@ func (e *Engine) discoveredFileEffectiveMtime(
 // the owning provider's Fingerprint. The boolean reports whether the provider
 // runtime produced a usable timestamp; a false result tells the caller to fall
 // back to the legacy mtime path.
+func (e *Engine) providerFingerprint(ctx context.Context, provider parser.Provider, source parser.SourceRef) (parser.SourceFingerprint, error) {
+	if reusable, ok := provider.(parser.StoredFingerprintProvider); ok {
+		return reusable.FingerprintWithStored(ctx, source, func(path string) (string, bool) {
+			if e.pathRewriter != nil {
+				path = e.pathRewriter(path)
+			}
+			return e.db.GetFileHashByAgentPath(path, string(provider.Definition().Type))
+		})
+	}
+	return provider.Fingerprint(ctx, source)
+}
+
 func (e *Engine) providerSourceMtime(
 	ctx context.Context, file parser.DiscoveredFile,
 ) (int64, bool, error) {
@@ -8649,7 +8665,7 @@ func (e *Engine) providerSourceMtime(
 		Machine:      e.machine,
 		PathRewriter: e.pathRewriter,
 	})
-	fingerprint, err := provider.Fingerprint(ctx, source)
+	fingerprint, err := e.providerFingerprint(ctx, provider, source)
 	if err != nil {
 		return 0, false, err
 	}
@@ -9272,7 +9288,7 @@ func (e *Engine) syncProviderDBBacked(
 	discovered, sourceFailures := 0, 0
 	err := discoverer.DiscoverEach(ctx, func(source parser.SourceRef) error {
 		discovered++
-		fingerprint, err := provider.Fingerprint(ctx, source)
+		fingerprint, err := e.providerFingerprint(ctx, provider, source)
 		if err != nil {
 			log.Printf("sync %s fingerprint: %v", agent, err)
 			sourceFailures++
@@ -11530,7 +11546,7 @@ func (e *Engine) processProviderFile(
 			}
 		}
 		if !codexFingerprintFromParse {
-			fingerprint, err = provider.Fingerprint(ctx, source)
+			fingerprint, err = e.providerFingerprint(ctx, provider, source)
 		}
 		if err != nil {
 			if (file.ForceParse || file.ForceFullParse) &&
@@ -11605,8 +11621,8 @@ func (e *Engine) processProviderFile(
 						}, true
 					}
 					if restored {
-						currentFingerprint, err := provider.Fingerprint(
-							ctx, source,
+						currentFingerprint, err := e.providerFingerprint(
+							ctx, provider, source,
 						)
 						if err != nil {
 							return processResult{err: err}, true
@@ -20032,7 +20048,7 @@ func (e *Engine) providerSessionSourceMtime(
 	if !found {
 		return 0
 	}
-	fingerprint, err := provider.Fingerprint(ctx, source)
+	fingerprint, err := e.providerFingerprint(ctx, provider, source)
 	if err != nil {
 		log.Printf("%s provider source mtime fingerprint: %v", def.Type, err)
 		return 0


### PR DESCRIPTION
A Copilot store update now rereads usage payloads only for sessions whose latest row ID changed. Unchanged transcript hashes are reused across provider instances and engine restarts. Shared database timestamps affect freshness, not session timestamps.

The producer leaves sessions.updated_at unchanged when inserting usage, so the refresh uses the producer's session-and-row-ID index. Startup builds the store hashes once. Runtime updates follow appends and latest-row removal; historical edits below an unchanged maximum ID wait for a new engine or CLI sync. Missing or incomplete usage schemas are cached as empty usage for the current SQLite state, so metadata-only writes leave unchanged sessions skipped. Unreadable store markers and operational read failures remain retryable.
