### PR TITLE
fix(db): scope usage rollup install reads to the snapshot

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -71,6 +71,13 @@ description: Release history for AgentsView
   print coarse phase updates. Redirected output omits terminal control
   sequences and per-session refresh lines. Interactive terminals retain live
   progress. (#1645)
+- Stop the server from consuming most of a machine's CPU while it sits idle on
+  a large archive. The usage-cache backfill verified each 256-session batch by
+  reading every installed rollup row, so the work grew with the square of the
+  archive size and the discarded rows kept the garbage collector saturated. The
+  backfill now reads only the rows for the sessions it is verifying. On a
+  128,000-session archive a pass that previously burned eight to nine cores for
+  several minutes and then gave up now finishes in about four minutes.
 - Price Codex Luna Reserve turns that persist as `gpt-reserve` using the
   existing GPT-5.6 Luna catalog rates. Usage reports still list `gpt-reserve`
   as the reported model. Existing SQLite usage caches rebuild so previously

--- a/internal/db/usage_rollup.go
+++ b/internal/db/usage_rollup.go
@@ -442,12 +442,30 @@ func readUsageRollupInstalls(
 	snapshot usageQuerySnapshot, fills map[string]usageFillResult,
 	pricingHash string,
 ) (map[string]usageRollupInstall, map[string]bool, error) {
-	rows, err := conn.QueryContext(ctx, `SELECT i.id, i.session_id,
+	query := `SELECT i.id, i.session_id,
 		i.fact_install_revision, i.install_revision, i.cached_at,
 		i.source_sync_marker, i.source_transcript_rev, i.usage_event_fingerprint,
 		i.baked_agent, i.baked_started_at, i.pricing_hash
 		FROM usage_rollup_timezones tz JOIN usage_rollup_installs i
-		  ON i.timezone_id = tz.id WHERE tz.timezone_key = ?`, identity.Key)
+		  ON i.timezone_id = tz.id WHERE tz.timezone_key = ?`
+	args := []any{identity.Key}
+	// Scope the read to the sessions this snapshot can consult, so a batched
+	// backfill pass stays linear in archive size instead of re-reading every
+	// installed row per batch. Sessions and Versions carry the same IDs in the
+	// same order from capture through ordering and batch slicing. Archive-scale
+	// snapshots exceed the bind limit and read unscoped, which returns a
+	// superset of the same rows.
+	scope := make([]string, 1, len(snapshot.Versions)+1)
+	scope[0] = usageRollupCursorSessionID
+	for _, version := range snapshot.Versions {
+		scope = append(scope, version.SessionID)
+	}
+	if len(scope) < maxSQLVars {
+		placeholders, scopeArgs := inPlaceholders(scope)
+		query += ` AND i.session_id IN ` + placeholders
+		args = append(args, scopeArgs...)
+	}
+	rows, err := conn.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/db/usage_rollup_lifecycle_test.go
+++ b/internal/db/usage_rollup_lifecycle_test.go
@@ -612,6 +612,47 @@ func TestUsageRollupOlderCursorBuildCannotReplaceNewerEvents(t *testing.T) {
 	assert.Equal(t, int64(3), inputTokens)
 }
 
+func TestUsageRollupInstallReadScopesToSnapshotBatch(t *testing.T) {
+	database := testDB(t)
+	for index, id := range []string{"session-a", "session-b"} {
+		started := []string{"2026-08-10T08:00:00Z", "2026-08-10T08:01:00Z"}[index]
+		insertSession(t, database, id, "project-a", func(session *Session) {
+			session.StartedAt = &started
+		})
+		require.NoError(t, database.InsertMessages([]Message{{
+			SessionID: id, Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-08-10T09:00:00Z", Model: "model-a",
+			TokenUsage: json.RawMessage(`{"input_tokens":2}`),
+		}}))
+	}
+	snapshot, fills, cache := prepareUsageRollupTest(t, database)
+	require.Len(t, snapshot.Sessions, 2)
+	_, _, err := cache.rollup.Ensure(t.Context(), snapshot, fills,
+		export.NewPricingResolver(snapshot.PricingRows))
+	require.NoError(t, err)
+
+	// A backfill pass verifies one batch at a time by slicing the snapshot.
+	batch := snapshot
+	batch.Sessions = snapshot.Sessions[:1]
+	batch.Versions = snapshot.Versions[:1]
+	require.Equal(t, batch.Sessions[0].ID, batch.Versions[0].SessionID)
+	conn, err := cache.db.Conn(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	pricingHash, err := usagePricingIdentity(batch.PricingRows)
+	require.NoError(t, err)
+
+	installs, stale, err := readUsageRollupInstalls(
+		t.Context(), conn,
+		usageTimezoneIdentityFor(batch.location, batch.Intervals),
+		batch, fills, pricingHash)
+	require.NoError(t, err)
+	assert.Empty(t, stale, "the batch was installed by the preceding Ensure")
+	assert.Contains(t, installs, batch.Sessions[0].ID)
+	assert.NotContains(t, installs, snapshot.Sessions[1].ID,
+		"verifying a batch must not read installs outside it")
+}
+
 func prepareUsageRollupTest(
 	t *testing.T, database *DB,
 ) (usageQuerySnapshot, map[string]usageFillResult, *usageCache) {


### PR DESCRIPTION
On a large archive the serve daemon burned most of a machine's CPU with no clients connected and startup sync long finished. Measured on a 24-core machine against a 128,343-session archive with 141,454 installed rollup rows, one daemon lifetime spent 3,161 CPU-seconds and 27,798 GC cycles, nearly all of it inside a five-and-a-half-minute window that ended when the backfill gave up with `could not stabilize after 3 attempts` — eight to nine cores sustained, of which the allocation profile attributed 57% to `readUsageRollupInstalls` alone. That read filtered only on `timezone_key`, so although a backfill pass correctly narrows each batch to 256 sessions and calls `Ensure` per batch, each of the 502 batches materialized all 141,454 installed rows into four maps and discarded them, twice per batch whenever anything was stale. The pass is quadratic in archive size, and against the 256 MiB soft memory limit the serve daemon sets for itself, that allocation rate is what turns a slow pass into sustained garbage collection.

This scopes the read to the sessions a snapshot can actually consult, binding them and the cursor row through the package's existing `maxSQLVars` and `inPlaceholders` seam. The unique `(timezone_id, session_id)` index turns the table scan into one seek per batched session, so a batched verification materializes 257 rows instead of 141,454 and the plan changes from `SCAN i` to `SEARCH i USING COVERING INDEX (timezone_id=? AND session_id=?)`.

Iterating `Versions` alone is sufficient because `Sessions` and `Versions` are appended one-for-one at capture, filtered by the same predicate in `dropDeleted`, reordered together, and sliced together per batch. Snapshots above the bind limit — the whole-archive verification at the end of a pass, and the foreground usage read — keep the unscoped query, which returns a superset of the same rows; that is safe because `installs` is only ever indexed by key and is never ranged over. Rollup contents, install revisions, staleness semantics, batch size, and the retry policy are unchanged, and no schema or column changes are involved, so the PostgreSQL and DuckDB paths need no matching update.

Reviewers should look at the bind gate in `readUsageRollupInstalls`, which reserves one parameter for the timezone predicate, and at `internal/db/usage_rollup_lifecycle_test.go`, where a real-database regression proves a batched verification does not materialize an installed session outside its batch.

Rebuilt and run against that same archive, the pass now completes in 4 minutes 6 seconds for 1,349 CPU-seconds and 14,397 GC cycles, and `readUsageRollupInstalls` falls to 0.6% of allocation; the remaining 63.5% is `loadUsageRollupFacts` building the rollups, which is linear and one-time. That archive's cache had not finished a backfill in three days, so it was being rebuilt from scratch and abandoned on every daemon start. This change does not alter how often a pass restarts — on an archive whose transcripts are appended continuously, a pass can still exhaust its three attempts against `errUsageCacheSourceChanged` — it just loses far less work each time, which on this archive was the difference between never finishing and finishing.


Closes #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6sY6VBHwhnwjuZq8kczcK
