### PR TITLE
fix(pricing): correct Codex costs on Amazon Bedrock

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,9 +58,10 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
-- Price Codex Astra turns reported as `openai.gpt-6-astra` using the
-  `gpt-6-astra` catalog rates while keeping the reported model name in usage
-  breakdowns, including before a live pricing refresh succeeds.
+- Price namespaced Codex GPT-5.4, GPT-5.6 Luna, GPT-5.6 Terra, and GPT-6 Astra
+  turns while keeping their reported model names in usage breakdowns. The
+  first three use the standard Bedrock catalog rows; Astra remains priced
+  before a live pricing refresh succeeds.
 - Preserve nonempty tool output from legacy Cursor text transcripts. Existing
   archived sessions gain the output on their next sync when the source files
   are still available. (#1627)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,10 +58,12 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
-- Price namespaced Codex GPT-5.4, GPT-5.6 Luna, GPT-5.6 Terra, and GPT-6 Astra
-  turns while keeping their reported model names in usage breakdowns. The
-  first three use the standard Bedrock catalog rows; Astra remains priced
-  before a live pricing refresh succeeds.
+- Show Bedrock costs for Codex turns reported as `openai.gpt-5.4`,
+  `openai.gpt-5.6-luna`, `openai.gpt-5.6-terra`, and `openai.gpt-6-astra`,
+  while keeping those names in usage breakdowns. Dated usage uses AWS rates
+  from GenAI Prices when available, including Luna and Terra prices before
+  the July 30 cut. Astra gains offline pricing at Bedrock rates. Full
+  region-qualified catalog names retain their own pricing.
 - Preserve nonempty tool output from legacy Cursor text transcripts. Existing
   archived sessions gain the output on their next sync when the source files
   are still available. (#1627)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,6 +58,9 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
+- Price Codex Astra turns reported as `openai.gpt-6-astra` using the
+  `gpt-6-astra` catalog rates while keeping the reported model name in usage
+  breakdowns, including before a live pricing refresh succeeds.
 - Preserve nonempty tool output from legacy Cursor text transcripts. Existing
   archived sessions gain the output on their next sync when the source files
   are still available. (#1627)

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -423,7 +423,15 @@ add an archived or maintained mirror without replacing the original identity.
   An exact `[custom_model_pricing."gpt-reserve"]` row still wins. Reverified
   2026-09-06 against OpenAI's Luna Reserve help article
     <https://help.openai.com/en/articles/20001499-luna-reserve-in-codex-and-chatgpt-work>
-    and Codex `turn_context` model seeding in `internal/parser/codex.go`.
+    and Codex `turn_context` model seeding in `internal/parser/codex.go`. Codex
+  Astra turns can persist the namespaced model `openai.gpt-6-astra`;
+  Agentsview maps that reported name to the `gpt-6-astra` catalog row while
+  retaining it in usage breakdowns. Reverified 2026-09-10 against an observed
+  Codex rollout and the LiteLLM catalog at commit
+  [`328a5f5d`](https://github.com/BerriAI/litellm/blob/328a5f5d6024c673c4d5e37bad8dab17ab8e79ee/model_prices_and_context_window.json).
+  The pinned fallback snapshot predates Astra, so the supplemental catalog
+  mirrors those base rates and the higher-rate band above 272k input tokens
+  until the snapshot is refreshed.
 
 - **Agentsview:** `internal/parser/codex.go` and
   `internal/parser/codex_provider.go`; usage is taken from the last-turn

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -423,11 +423,14 @@ add an archived or maintained mirror without replacing the original identity.
   An exact `[custom_model_pricing."gpt-reserve"]` row still wins. Reverified
   2026-09-06 against OpenAI's Luna Reserve help article
     <https://help.openai.com/en/articles/20001499-luna-reserve-in-codex-and-chatgpt-work>
-    and Codex `turn_context` model seeding in `internal/parser/codex.go`. Codex
-  Astra turns can persist the namespaced model `openai.gpt-6-astra`;
-  Agentsview maps that reported name to the `gpt-6-astra` catalog row while
-  retaining it in usage breakdowns. Reverified 2026-09-10 against an observed
-  Codex rollout and the LiteLLM catalog at commit
+    and Codex `turn_context` model seeding in `internal/parser/codex.go`.
+  Codex also persists namespaced GPT-5.4, GPT-5.6 Luna, GPT-5.6 Terra, and
+  GPT-6 Astra model names. Agentsview retains those names in usage breakdowns
+  while pricing the first three through their standard `bedrock_mantle`
+  catalog rows and `openai.gpt-6-astra` through `gpt-6-astra`. GPT-5.5 and
+  GPT-5.6 Sol already resolve unambiguously to their standard Bedrock rows.
+  Reverified 2026-09-10 against observed Codex rollouts and the LiteLLM
+  catalog at commit
   [`328a5f5d`](https://github.com/BerriAI/litellm/blob/328a5f5d6024c673c4d5e37bad8dab17ab8e79ee/model_prices_and_context_window.json).
   The pinned fallback snapshot predates Astra, so the supplemental catalog
   mirrors those base rates and the higher-rate band above 272k input tokens

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -423,18 +423,28 @@ add an archived or maintained mirror without replacing the original identity.
   An exact `[custom_model_pricing."gpt-reserve"]` row still wins. Reverified
   2026-09-06 against OpenAI's Luna Reserve help article
     <https://help.openai.com/en/articles/20001499-luna-reserve-in-codex-and-chatgpt-work>
-    and Codex `turn_context` model seeding in `internal/parser/codex.go`.
-  Codex also persists namespaced GPT-5.4, GPT-5.6 Luna, GPT-5.6 Terra, and
-  GPT-6 Astra model names. Agentsview retains those names in usage breakdowns
-  while pricing the first three through their standard `bedrock_mantle`
-  catalog rows and `openai.gpt-6-astra` through `gpt-6-astra`. GPT-5.5 and
-  GPT-5.6 Sol already resolve unambiguously to their standard Bedrock rows.
-  Reverified 2026-09-10 against observed Codex rollouts and the LiteLLM
-  catalog at commit
-  [`328a5f5d`](https://github.com/BerriAI/litellm/blob/328a5f5d6024c673c4d5e37bad8dab17ab8e79ee/model_prices_and_context_window.json).
-  The pinned fallback snapshot predates Astra, so the supplemental catalog
-  mirrors those base rates and the higher-rate band above 272k input tokens
-  until the snapshot is refreshed.
+    and Codex `turn_context` model seeding in `internal/parser/codex.go`. With
+    the `amazon-bedrock` provider, Codex reports `openai.gpt-5.4`,
+    `openai.gpt-5.6-luna`, `openai.gpt-5.6-terra`, and `openai.gpt-6-astra`.
+    Reverified 2026-09-10 against Codex's
+    [provider model IDs](https://github.com/openai/codex/blob/713caa89f389acd9cbcd77016edbb607273826af/codex-rs/model-provider-info/src/lib.rs#L45-L53)
+    and
+    [Bedrock catalog](https://github.com/openai/codex/blob/713caa89f389acd9cbcd77016edbb607273826af/codex-rs/model-provider/src/amazon_bedrock/catalog.rs).
+    Agentsview retains these reported names and maps them to the corresponding
+    `bedrock_mantle/openai.gpt-*` pricing names. Only the full reported IDs
+    match these aliases; provider- and region-qualified catalog keys pass
+    through unchanged. Exact custom pricing still wins. For timestamped usage,
+    GenAI Prices' `aws/openai.*` entries take precedence over flat LiteLLM rows
+    when available, including Luna and Terra prices before the 2026-07-30
+    reduction. Usage without a valid timestamp uses the flat catalog. The
+    embedded GenAI document uses the pinned
+    [AWS price history](https://github.com/pydantic/genai-prices/blob/83a49e8b386176a1e28e9d9aedeea5e2b4abc586/prices/providers/aws.yml).
+    The pinned LiteLLM snapshot predates Astra. A temporary supplemental
+    `bedrock_mantle/openai.gpt-6-astra` row uses $11 input, $55 output,
+    $13.75 cache write, and $1.10 cache read per million tokens; above 272k
+    input tokens these become $22, $82.50, $27.50, and $2.20. Reverified against
+    [LiteLLM's Bedrock row](https://github.com/BerriAI/litellm/blob/fbed17d567a62b14b8fc7d9ef13c5cd61a8d1ae0/model_prices_and_context_window.json).
+    Remove that supplemental row when the shared snapshot includes it.
 
 - **Agentsview:** `internal/parser/codex.go` and
   `internal/parser/codex_provider.go`; usage is taken from the last-turn

--- a/internal/db/usage_cache_schema.go
+++ b/internal/db/usage_cache_schema.go
@@ -34,7 +34,9 @@ const (
 	// turns stored as gpt-reserve now resolve to gpt-5.6-luna catalog
 	// rates. EffectivePricingDigest hashes only catalog rows, so the
 	// same facts and catalog would otherwise keep the unpriced costs.
-	usageCacheFormatVersion             = 9
+	// Version 10 rebuilds rollups with Bedrock pricing for namespaced Codex
+	// models, including historical AWS rates for timestamped usage.
+	usageCacheFormatVersion             = 10
 	usageCacheApplicationID             = 0x41565543
 	usageCacheKind                      = "agentsview-usage-facts"
 	usageCacheRetirementProtocolVersion = 1

--- a/internal/db/usage_cache_schema_test.go
+++ b/internal/db/usage_cache_schema_test.go
@@ -27,7 +27,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cache.temporary)
 	assert.Equal(t, filepath.Join(filepath.Dir(archivePath),
-		"usage-cache-v9-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
+		"usage-cache-v10-980e32c89da32cb0d3588c0c06864b4e.db"), cache.path)
 
 	info, err := os.Stat(cache.path)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestUsageCacheGenerationCreatesIdentifiedSchema(t *testing.T) {
 
 	metadata := readUsageCacheMetadata(t, cache.db)
 	assert.Equal(t, "agentsview-usage-facts", metadata[usageCacheMetadataKind])
-	assert.Equal(t, "9", metadata[usageCacheMetadataFormatVersion])
+	assert.Equal(t, "10", metadata[usageCacheMetadataFormatVersion])
 	assert.Equal(t, "database-id-one", metadata[usageCacheMetadataSourceDatabaseID])
 	assert.Equal(t, "1", metadata[usageCacheMetadataRetirementProtocol])
 	assert.Equal(t, "1", metadata[usageCacheMetadataNextInstallRevision])

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -5822,90 +5822,51 @@ func TestGetDailyUsage_GPTReserveLunaPricing(t *testing.T) {
 
 func TestGetDailyUsage_CodexNamespacedPricing(t *testing.T) {
 	d := testDB(t)
-	ctx := context.Background()
-
+	d.SetEmptyCatalogPricing(fallbackRateMap())
+	// This region-qualified row is newer than the embedded snapshot.
+	d.SetEffectivePricing(map[string]export.ModelRates{
+		"bedrock_mantle/us-gov-west-1/openai.gpt-5.4": {
+			InputPerMTok:  money.MustParseDollars("3.3"),
+			OutputPerMTok: money.MustParseDollars("19.8"),
+			Source:        export.PricingRowSourceFetched,
+		},
+	})
 	tests := []struct {
-		name      string
-		reported  string
-		canonical string
-		rate      string
+		model, date, canonical, pattern, input, output, cost string
 	}{
-		{
-			name:      "GPT-5.4",
-			reported:  pricingpkg.CodexGPT54ModelName,
-			canonical: pricingpkg.BedrockGPT54Canonical,
-			rate:      "4",
-		},
-		{
-			name:      "GPT-5.6 Luna",
-			reported:  pricingpkg.CodexGPT56LunaModelName,
-			canonical: pricingpkg.BedrockGPT56LunaCanonical,
-			rate:      "6",
-		},
-		{
-			name:      "GPT-5.6 Terra",
-			reported:  pricingpkg.CodexGPT56TerraModelName,
-			canonical: pricingpkg.BedrockGPT56TerraCanonical,
-			rate:      "8",
-		},
-		{
-			name:      "GPT-6 Astra",
-			reported:  pricingpkg.CodexAstraModelName,
-			canonical: pricingpkg.GPT6AstraCanonical,
-			rate:      "10",
-		},
+		{"openai.gpt-5.4", "2026-09-09", "bedrock_mantle/openai.gpt-5.4", "aws/openai.gpt-5.4", "2.75", "16.5", "1.925"},
+		{"openai.gpt-5.6-luna", "2026-07-29", "bedrock_mantle/openai.gpt-5.6-luna", "aws/openai.gpt-5.6-luna", "1.1", "6.6", "0.77"},
+		{"openai.gpt-5.6-luna", "2026-07-30", "bedrock_mantle/openai.gpt-5.6-luna", "aws/openai.gpt-5.6-luna", "0.22", "1.32", "0.154"},
+		{"openai.gpt-5.6-terra", "2026-07-29", "bedrock_mantle/openai.gpt-5.6-terra", "aws/openai.gpt-5.6-terra", "2.75", "16.5", "1.925"},
+		{"openai.gpt-5.6-terra", "2026-07-30", "bedrock_mantle/openai.gpt-5.6-terra", "aws/openai.gpt-5.6-terra", "2.2", "13.2", "1.54"},
+		{"openai.gpt-6-astra", "2026-09-09", "bedrock_mantle/openai.gpt-6-astra", "bedrock_mantle/openai.gpt-6-astra", "11", "55", "6.6"},
+		{"bedrock_mantle/us-gov-west-1/openai.gpt-5.4", "2026-09-09", "bedrock_mantle/us-gov-west-1/openai.gpt-5.4", "bedrock_mantle/us-gov-west-1/openai.gpt-5.4", "3.3", "19.8", "2.31"},
 	}
-
-	ts := "2026-09-09T12:00:00Z"
-	tokenUsage := jsontext.Value(`{"input_tokens":1000000,"output_tokens":0}`)
 	for i, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
-				ModelPattern: tt.canonical,
-				InputPerMTok: money.MustParseDollars(tt.rate),
-			}}), "seed canonical pricing")
-
-			for suffix, model := range map[string]string{
-				"reported":  tt.reported,
-				"canonical": tt.canonical,
-			} {
-				id := fmt.Sprintf("codex-namespaced-%d-%s", i, suffix)
-				insertSession(t, d, id, "proj", func(s *Session) {
-					s.Agent = "codex"
-					s.StartedAt = new(ts)
-				})
-				insertMessages(t, d, Message{
-					SessionID:  id,
-					Ordinal:    0,
-					Role:       "assistant",
-					Timestamp:  ts,
-					Model:      model,
-					TokenUsage: tokenUsage,
-				})
-			}
-
-			canonical, err := d.GetDailyUsage(ctx, UsageFilter{
-				From:     "2026-09-09",
-				To:       "2026-09-09",
-				Timezone: "UTC",
-				Model:    tt.canonical,
+		t.Run(tt.model+"/"+tt.date, func(t *testing.T) {
+			ts := tt.date + "T12:00:00Z"
+			id := fmt.Sprintf("codex-namespaced-%d", i)
+			insertSession(t, d, id, "proj", func(s *Session) {
+				s.Agent = "codex"
+				s.StartedAt = new(ts)
 			})
-			requireNoError(t, err, "GetDailyUsage canonical model")
-			assert.NotZero(t, canonical.Totals.TotalCost.Microdollars)
-
-			namespaced, err := d.GetDailyUsage(ctx, UsageFilter{
-				From:     "2026-09-09",
-				To:       "2026-09-09",
-				Timezone: "UTC",
-				Model:    tt.reported,
+			insertMessages(t, d, Message{
+				SessionID: id, Ordinal: 0, Role: "assistant",
+				Timestamp: ts, Model: tt.model,
+				TokenUsage: jsontext.Value(`{"input_tokens":100000,"output_tokens":100000}`),
 			})
-			requireNoError(t, err, "GetDailyUsage namespaced model")
-			assert.Equal(t, canonical.Totals.TotalCost, namespaced.Totals.TotalCost)
-			require.NotNil(t, namespaced.Pricing)
-			resolutions := namespaced.Pricing.Models[tt.reported].Resolutions
+			got, err := d.GetDailyUsage(t.Context(), UsageFilter{
+				From: tt.date, To: tt.date, Timezone: "UTC", Model: tt.model,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, money.MustParseDollars(tt.cost), got.Totals.TotalCost)
+			require.NotNil(t, got.Pricing)
+			resolutions := got.Pricing.Models[tt.model].Resolutions
 			require.Len(t, resolutions, 1)
 			assert.Equal(t, tt.canonical, resolutions[0].PricedModel)
-			assert.NotContains(t, namespaced.Pricing.Models, tt.canonical)
+			assert.Equal(t, new(tt.pattern), resolutions[0].MatchedPattern)
+			assert.Equal(t, money.MustParseDollars(tt.input), resolutions[0].InputCostPerMTok)
+			assert.Equal(t, money.MustParseDollars(tt.output), resolutions[0].OutputCostPerMTok)
 		})
 	}
 }

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -5820,6 +5820,64 @@ func TestGetDailyUsage_GPTReserveLunaPricing(t *testing.T) {
 	assert.NotContains(t, reserve.Pricing.Models, pricingpkg.GPT56LunaCanonical)
 }
 
+func TestGetDailyUsage_AstraPricing(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern: pricingpkg.GPT6AstraCanonical,
+		InputPerMTok: money.MustParseDollars("10"),
+	}}), "seed Astra pricing")
+
+	ts := "2026-09-09T12:00:00Z"
+	tokenUsage := jsontext.Value(`{"input_tokens":1000000,"output_tokens":0}`)
+	for _, fixture := range []struct {
+		id    string
+		model string
+	}{
+		{id: "codex-astra-namespaced", model: pricingpkg.CodexAstraModelName},
+		{id: "codex-astra-canonical", model: pricingpkg.GPT6AstraCanonical},
+	} {
+		insertSession(t, d, fixture.id, "proj", func(s *Session) {
+			s.Agent = "codex"
+			s.StartedAt = new(ts)
+		})
+		insertMessages(t, d, Message{
+			SessionID:  fixture.id,
+			Ordinal:    0,
+			Role:       "assistant",
+			Timestamp:  ts,
+			Model:      fixture.model,
+			TokenUsage: tokenUsage,
+		})
+	}
+
+	canonical, err := d.GetDailyUsage(ctx, UsageFilter{
+		From:     "2026-09-09",
+		To:       "2026-09-09",
+		Timezone: "UTC",
+		Model:    pricingpkg.GPT6AstraCanonical,
+	})
+	requireNoError(t, err, "GetDailyUsage canonical Astra")
+	assert.NotZero(t, canonical.Totals.TotalCost.Microdollars)
+
+	namespaced, err := d.GetDailyUsage(ctx, UsageFilter{
+		From:     "2026-09-09",
+		To:       "2026-09-09",
+		Timezone: "UTC",
+		Model:    pricingpkg.CodexAstraModelName,
+	})
+	requireNoError(t, err, "GetDailyUsage namespaced Astra")
+	assert.Equal(t, canonical.Totals.TotalCost, namespaced.Totals.TotalCost)
+	require.NotNil(t, namespaced.Pricing)
+	resolutions := namespaced.Pricing.Models[pricingpkg.CodexAstraModelName].Resolutions
+	require.Len(t, resolutions, 1)
+	assert.Equal(t, pricingpkg.GPT6AstraCanonical,
+		resolutions[0].PricedModel)
+	assert.NotContains(t, namespaced.Pricing.Models,
+		pricingpkg.GPT6AstraCanonical)
+}
+
 // TestGetDailyUsage_KimiDateAliasMixedDaySameModel proves one reported
 // model straddling the cutoff sums both eras: a pre-cutoff row prices
 // at K2.6 and a post-cutoff row at K3 within the same model breakdown.

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -5820,62 +5820,94 @@ func TestGetDailyUsage_GPTReserveLunaPricing(t *testing.T) {
 	assert.NotContains(t, reserve.Pricing.Models, pricingpkg.GPT56LunaCanonical)
 }
 
-func TestGetDailyUsage_AstraPricing(t *testing.T) {
+func TestGetDailyUsage_CodexNamespacedPricing(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
 
-	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
-		ModelPattern: pricingpkg.GPT6AstraCanonical,
-		InputPerMTok: money.MustParseDollars("10"),
-	}}), "seed Astra pricing")
+	tests := []struct {
+		name      string
+		reported  string
+		canonical string
+		rate      string
+	}{
+		{
+			name:      "GPT-5.4",
+			reported:  pricingpkg.CodexGPT54ModelName,
+			canonical: pricingpkg.BedrockGPT54Canonical,
+			rate:      "4",
+		},
+		{
+			name:      "GPT-5.6 Luna",
+			reported:  pricingpkg.CodexGPT56LunaModelName,
+			canonical: pricingpkg.BedrockGPT56LunaCanonical,
+			rate:      "6",
+		},
+		{
+			name:      "GPT-5.6 Terra",
+			reported:  pricingpkg.CodexGPT56TerraModelName,
+			canonical: pricingpkg.BedrockGPT56TerraCanonical,
+			rate:      "8",
+		},
+		{
+			name:      "GPT-6 Astra",
+			reported:  pricingpkg.CodexAstraModelName,
+			canonical: pricingpkg.GPT6AstraCanonical,
+			rate:      "10",
+		},
+	}
 
 	ts := "2026-09-09T12:00:00Z"
 	tokenUsage := jsontext.Value(`{"input_tokens":1000000,"output_tokens":0}`)
-	for _, fixture := range []struct {
-		id    string
-		model string
-	}{
-		{id: "codex-astra-namespaced", model: pricingpkg.CodexAstraModelName},
-		{id: "codex-astra-canonical", model: pricingpkg.GPT6AstraCanonical},
-	} {
-		insertSession(t, d, fixture.id, "proj", func(s *Session) {
-			s.Agent = "codex"
-			s.StartedAt = new(ts)
-		})
-		insertMessages(t, d, Message{
-			SessionID:  fixture.id,
-			Ordinal:    0,
-			Role:       "assistant",
-			Timestamp:  ts,
-			Model:      fixture.model,
-			TokenUsage: tokenUsage,
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+				ModelPattern: tt.canonical,
+				InputPerMTok: money.MustParseDollars(tt.rate),
+			}}), "seed canonical pricing")
+
+			for suffix, model := range map[string]string{
+				"reported":  tt.reported,
+				"canonical": tt.canonical,
+			} {
+				id := fmt.Sprintf("codex-namespaced-%d-%s", i, suffix)
+				insertSession(t, d, id, "proj", func(s *Session) {
+					s.Agent = "codex"
+					s.StartedAt = new(ts)
+				})
+				insertMessages(t, d, Message{
+					SessionID:  id,
+					Ordinal:    0,
+					Role:       "assistant",
+					Timestamp:  ts,
+					Model:      model,
+					TokenUsage: tokenUsage,
+				})
+			}
+
+			canonical, err := d.GetDailyUsage(ctx, UsageFilter{
+				From:     "2026-09-09",
+				To:       "2026-09-09",
+				Timezone: "UTC",
+				Model:    tt.canonical,
+			})
+			requireNoError(t, err, "GetDailyUsage canonical model")
+			assert.NotZero(t, canonical.Totals.TotalCost.Microdollars)
+
+			namespaced, err := d.GetDailyUsage(ctx, UsageFilter{
+				From:     "2026-09-09",
+				To:       "2026-09-09",
+				Timezone: "UTC",
+				Model:    tt.reported,
+			})
+			requireNoError(t, err, "GetDailyUsage namespaced model")
+			assert.Equal(t, canonical.Totals.TotalCost, namespaced.Totals.TotalCost)
+			require.NotNil(t, namespaced.Pricing)
+			resolutions := namespaced.Pricing.Models[tt.reported].Resolutions
+			require.Len(t, resolutions, 1)
+			assert.Equal(t, tt.canonical, resolutions[0].PricedModel)
+			assert.NotContains(t, namespaced.Pricing.Models, tt.canonical)
 		})
 	}
-
-	canonical, err := d.GetDailyUsage(ctx, UsageFilter{
-		From:     "2026-09-09",
-		To:       "2026-09-09",
-		Timezone: "UTC",
-		Model:    pricingpkg.GPT6AstraCanonical,
-	})
-	requireNoError(t, err, "GetDailyUsage canonical Astra")
-	assert.NotZero(t, canonical.Totals.TotalCost.Microdollars)
-
-	namespaced, err := d.GetDailyUsage(ctx, UsageFilter{
-		From:     "2026-09-09",
-		To:       "2026-09-09",
-		Timezone: "UTC",
-		Model:    pricingpkg.CodexAstraModelName,
-	})
-	requireNoError(t, err, "GetDailyUsage namespaced Astra")
-	assert.Equal(t, canonical.Totals.TotalCost, namespaced.Totals.TotalCost)
-	require.NotNil(t, namespaced.Pricing)
-	resolutions := namespaced.Pricing.Models[pricingpkg.CodexAstraModelName].Resolutions
-	require.Len(t, resolutions, 1)
-	assert.Equal(t, pricingpkg.GPT6AstraCanonical,
-		resolutions[0].PricedModel)
-	assert.NotContains(t, namespaced.Pricing.Models,
-		pricingpkg.GPT6AstraCanonical)
 }
 
 // TestGetDailyUsage_KimiDateAliasMixedDaySameModel proves one reported

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3582,9 +3582,13 @@ func duckPriceModelCaseSQL() string {
 	var b strings.Builder
 	b.WriteString("CASE\n")
 	for _, alias := range pricingpkg.FixedPricingAliases() {
+		modelExpr := "regexp_replace(model, '^.*/', '')"
+		if alias.Exact {
+			modelExpr = "model"
+		}
 		fmt.Fprintf(&b,
-			"\t\tWHEN regexp_replace(model, '^.*/', '') = %s THEN %s\n",
-			duckSQLString(alias.Name), duckSQLString(alias.Canonical),
+			"\t\tWHEN %s = %s THEN %s\n",
+			modelExpr, duckSQLString(alias.Name), duckSQLString(alias.Canonical),
 		)
 	}
 	aliases := pricingpkg.DateAliasedModels()

--- a/internal/duckdb/usage_pricing_test.go
+++ b/internal/duckdb/usage_pricing_test.go
@@ -500,3 +500,24 @@ func TestDuckPositBillingPublicAPIReproduction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, money.MustParseDollars("1.1"), report.Totals.Cost)
 }
+
+func TestPriceModelCasePreservesQualifiedBedrockModels(t *testing.T) {
+	syncer := newInMemoryTestSync(t, newLocalDB(t), SyncOptions{})
+	for _, tt := range []struct{ model, want string }{
+		{"openai.gpt-6-astra", "bedrock_mantle/openai.gpt-6-astra"},
+		{"openai.gpt-5.4", "bedrock_mantle/openai.gpt-5.4"},
+		{"bedrock_mantle/us-gov-west-1/openai.gpt-5.4", "bedrock_mantle/us-gov-west-1/openai.gpt-5.4"},
+		{"openai/gpt-reserve", "gpt-5.6-luna"},
+		{"daimon/k2d6-agent", "moonshot/kimi-k2.6"},
+	} {
+		t.Run(tt.model, func(t *testing.T) {
+			var got string
+			err := syncer.DB().QueryRowContext(t.Context(),
+				"SELECT "+duckPriceModelCaseSQL()+
+					" FROM (SELECT ? AS model, TIMESTAMP '2026-09-09' AS pricing_ts)",
+				tt.model).Scan(&got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -75,6 +75,41 @@ func TestStoreGetDailyUsageUsesFallbackPricing(t *testing.T) {
 	assert.Len(t, result.Daily, 1)
 }
 
+func TestStoreGetDailyUsageCodexBedrockPricing(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_codex_bedrock_test")
+	for _, tt := range []struct{ model, date, cost string }{
+		{"openai.gpt-5.4", "2026-09-09", "1.925"},
+		{"openai.gpt-5.6-luna", "2026-07-29", "0.77"},
+		{"openai.gpt-5.6-luna", "2026-07-30", "0.154"},
+		{"openai.gpt-5.6-terra", "2026-07-29", "1.925"},
+		{"openai.gpt-5.6-terra", "2026-07-30", "1.54"},
+		{"openai.gpt-6-astra", "2026-09-09", "6.6"},
+	} {
+		t.Run(tt.model+"/"+tt.date, func(t *testing.T) {
+			id := tt.model + ":" + tt.date
+			ts := tt.date + "T12:00:00Z"
+			_, err := store.DB().ExecContext(t.Context(), `
+				INSERT INTO sessions (id, machine, project, agent, started_at, message_count)
+				VALUES ($1, 'test-machine', 'proj', 'codex', $2::timestamptz, 1)`, id, ts)
+			require.NoError(t, err)
+			_, err = store.DB().ExecContext(t.Context(), `
+				INSERT INTO messages (session_id, ordinal, role, content, timestamp, model, token_usage)
+				VALUES ($1, 0, 'assistant', 'hi', $2::timestamptz, $3,
+					'{"input_tokens":100000,"output_tokens":100000}')`, id, ts, tt.model)
+			require.NoError(t, err)
+			got, err := store.GetDailyUsage(t.Context(), db.UsageFilter{
+				From: tt.date, To: tt.date, Timezone: "UTC", Model: tt.model,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, money.MustParseDollars(tt.cost), got.Totals.TotalCost)
+			require.NotNil(t, got.Pricing)
+			resolutions := got.Pricing.Models[tt.model].Resolutions
+			require.Len(t, resolutions, 1)
+			assert.Equal(t, "bedrock_mantle/"+tt.model, resolutions[0].PricedModel)
+		})
+	}
+}
+
 func TestStoreGetDailyUsageReturnsAggregateCostOverflow(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_usage_overflow_test")
 	ctx := t.Context()

--- a/internal/pricing/supplemental.go
+++ b/internal/pricing/supplemental.go
@@ -16,8 +16,8 @@ import (
 // date-based pricing: those names left the static set (the seed
 // deletes their stale rows) and k3/k3-agent moved from K2.6 to K3
 // rates. Version 3 removed moonshot/kimi-k3 after LiteLLM added it.
-// Version 4 adds a temporary gpt-6-astra fallback until the pinned
-// LiteLLM snapshot includes it.
+// Version 4 adds namespaced Codex mappings and a temporary gpt-6-astra
+// fallback until the pinned LiteLLM snapshot includes it.
 const supplementalVersion = "4"
 
 // Canonical pricing models runtime aliases resolve to.
@@ -25,14 +25,22 @@ const supplementalVersion = "4"
 // KimiK3Canonical is seeded by the supplemental set below because the
 // LiteLLM catalog lists only the provider-qualified Kimi K3 name.
 // GPT56LunaCanonical is the catalog id for Codex Luna Reserve (gpt-reserve).
+// The Bedrock constants are the standard catalog rows for namespaced Codex
+// models that otherwise collide with provider-qualified variants.
 // GPT6AstraCanonical is the catalog id for Codex's namespaced Astra model.
 const (
-	KimiK26Canonical    = "moonshot/kimi-k2.6"
-	KimiK3Canonical     = "kimi-k3"
-	GPT56LunaCanonical  = "gpt-5.6-luna"
-	GPT6AstraCanonical  = "gpt-6-astra"
-	GPTReserveModelName = "gpt-reserve"
-	CodexAstraModelName = "openai.gpt-6-astra"
+	KimiK26Canonical           = "moonshot/kimi-k2.6"
+	KimiK3Canonical            = "kimi-k3"
+	GPT56LunaCanonical         = "gpt-5.6-luna"
+	BedrockGPT54Canonical      = "bedrock_mantle/openai.gpt-5.4"
+	BedrockGPT56LunaCanonical  = "bedrock_mantle/openai.gpt-5.6-luna"
+	BedrockGPT56TerraCanonical = "bedrock_mantle/openai.gpt-5.6-terra"
+	GPT6AstraCanonical         = "gpt-6-astra"
+	GPTReserveModelName        = "gpt-reserve"
+	CodexGPT54ModelName        = "openai.gpt-5.4"
+	CodexGPT56LunaModelName    = "openai.gpt-5.6-luna"
+	CodexGPT56TerraModelName   = "openai.gpt-5.6-terra"
+	CodexAstraModelName        = "openai.gpt-6-astra"
 )
 
 // KimiModelEraCutoff is the UTC instant at which the date-ambiguous
@@ -65,15 +73,18 @@ type FixedPricingAlias struct {
 	Canonical string
 }
 
-// fixedPricingAliases are timestamp-independent reported names that
-// never appear as catalog keys. Codex writes gpt-reserve for Luna
-// Reserve turns; Kimi Work writes k2d6-agent for the K2.6 era. A
-// static supplemental rate row for these names would hide later
-// catalog updates for the canonical model, including Pydantic
-// time-window rates for GPT-5.6 Luna.
+// fixedPricingAliases are timestamp-independent reported names that need a
+// curated catalog target. Codex writes gpt-reserve for Luna Reserve turns and
+// namespaced model ids that can collide with provider-qualified rows; Kimi Work
+// writes k2d6-agent for the K2.6 era. A static supplemental rate row for these
+// names would hide later catalog updates for the canonical model, including
+// Pydantic time-window rates for GPT-5.6 Luna.
 var fixedPricingAliases = []FixedPricingAlias{
 	{Name: "k2d6-agent", Canonical: KimiK26Canonical},
 	{Name: GPTReserveModelName, Canonical: GPT56LunaCanonical},
+	{Name: CodexGPT54ModelName, Canonical: BedrockGPT54Canonical},
+	{Name: CodexGPT56LunaModelName, Canonical: BedrockGPT56LunaCanonical},
+	{Name: CodexGPT56TerraModelName, Canonical: BedrockGPT56TerraCanonical},
 	{Name: CodexAstraModelName, Canonical: GPT6AstraCanonical},
 }
 

--- a/internal/pricing/supplemental.go
+++ b/internal/pricing/supplemental.go
@@ -16,7 +16,7 @@ import (
 // date-based pricing: those names left the static set (the seed
 // deletes their stale rows) and k3/k3-agent moved from K2.6 to K3
 // rates. Version 3 removed moonshot/kimi-k3 after LiteLLM added it.
-// Version 4 adds namespaced Codex mappings and a temporary gpt-6-astra
+// Version 4 adds namespaced Codex mappings and a temporary Bedrock Astra
 // fallback until the pinned LiteLLM snapshot includes it.
 const supplementalVersion = "4"
 
@@ -35,7 +35,7 @@ const (
 	BedrockGPT54Canonical      = "bedrock_mantle/openai.gpt-5.4"
 	BedrockGPT56LunaCanonical  = "bedrock_mantle/openai.gpt-5.6-luna"
 	BedrockGPT56TerraCanonical = "bedrock_mantle/openai.gpt-5.6-terra"
-	GPT6AstraCanonical         = "gpt-6-astra"
+	GPT6AstraCanonical         = "bedrock_mantle/openai.gpt-6-astra"
 	GPTReserveModelName        = "gpt-reserve"
 	CodexGPT54ModelName        = "openai.gpt-5.4"
 	CodexGPT56LunaModelName    = "openai.gpt-5.6-luna"
@@ -71,6 +71,8 @@ var kimiAmbiguousDateAliases = []string{
 type FixedPricingAlias struct {
 	Name      string
 	Canonical string
+	// Exact preserves provider and region qualifiers on catalog model names.
+	Exact bool
 }
 
 // fixedPricingAliases are timestamp-independent reported names that need a
@@ -82,10 +84,10 @@ type FixedPricingAlias struct {
 var fixedPricingAliases = []FixedPricingAlias{
 	{Name: "k2d6-agent", Canonical: KimiK26Canonical},
 	{Name: GPTReserveModelName, Canonical: GPT56LunaCanonical},
-	{Name: CodexGPT54ModelName, Canonical: BedrockGPT54Canonical},
-	{Name: CodexGPT56LunaModelName, Canonical: BedrockGPT56LunaCanonical},
-	{Name: CodexGPT56TerraModelName, Canonical: BedrockGPT56TerraCanonical},
-	{Name: CodexAstraModelName, Canonical: GPT6AstraCanonical},
+	{Name: CodexGPT54ModelName, Canonical: BedrockGPT54Canonical, Exact: true},
+	{Name: CodexGPT56LunaModelName, Canonical: BedrockGPT56LunaCanonical, Exact: true},
+	{Name: CodexGPT56TerraModelName, Canonical: BedrockGPT56TerraCanonical, Exact: true},
+	{Name: CodexAstraModelName, Canonical: GPT6AstraCanonical, Exact: true},
 }
 
 // DateAliasedModels returns the sorted unqualified date-ambiguous
@@ -126,7 +128,7 @@ func isDateAliasedModel(model string) bool {
 func fixedCanonicalModel(model string) string {
 	name := pricingAliasName(model)
 	for _, alias := range fixedPricingAliases {
-		if alias.Name == name {
+		if alias.Name == model || (!alias.Exact && alias.Name == name) {
 			return alias.Canonical
 		}
 	}
@@ -193,16 +195,16 @@ func CanonicalModelForTimestamp(model, ts string) string {
 var supplementalPricing = []ModelPricing{
 	{
 		ModelPattern:         GPT6AstraCanonical,
-		InputPerMTok:         money.MustParseDollars("10.00"),
-		OutputPerMTok:        money.MustParseDollars("50.00"),
-		CacheCreationPerMTok: money.MustParseDollars("12.50"),
-		CacheReadPerMTok:     money.MustParseDollars("1.00"),
+		InputPerMTok:         money.MustParseDollars("11.00"),
+		OutputPerMTok:        money.MustParseDollars("55.00"),
+		CacheCreationPerMTok: money.MustParseDollars("13.75"),
+		CacheReadPerMTok:     money.MustParseDollars("1.10"),
 		Bands: []PricingBand{{
 			AboveInputTokens:     272_000,
-			InputPerMTok:         money.MustParseDollars("20.00"),
-			OutputPerMTok:        money.MustParseDollars("75.00"),
-			CacheCreationPerMTok: money.MustParseDollars("25.00"),
-			CacheReadPerMTok:     money.MustParseDollars("2.00"),
+			InputPerMTok:         money.MustParseDollars("22.00"),
+			OutputPerMTok:        money.MustParseDollars("82.50"),
+			CacheCreationPerMTok: money.MustParseDollars("27.50"),
+			CacheReadPerMTok:     money.MustParseDollars("2.20"),
 		}},
 	},
 	{

--- a/internal/pricing/supplemental.go
+++ b/internal/pricing/supplemental.go
@@ -16,18 +16,23 @@ import (
 // date-based pricing: those names left the static set (the seed
 // deletes their stale rows) and k3/k3-agent moved from K2.6 to K3
 // rates. Version 3 removed moonshot/kimi-k3 after LiteLLM added it.
-const supplementalVersion = "3"
+// Version 4 adds a temporary gpt-6-astra fallback until the pinned
+// LiteLLM snapshot includes it.
+const supplementalVersion = "4"
 
 // Canonical pricing models runtime aliases resolve to.
 // KimiK26Canonical exists in the embedded LiteLLM snapshot;
 // KimiK3Canonical is seeded by the supplemental set below because the
 // LiteLLM catalog lists only the provider-qualified Kimi K3 name.
 // GPT56LunaCanonical is the catalog id for Codex Luna Reserve (gpt-reserve).
+// GPT6AstraCanonical is the catalog id for Codex's namespaced Astra model.
 const (
 	KimiK26Canonical    = "moonshot/kimi-k2.6"
 	KimiK3Canonical     = "kimi-k3"
 	GPT56LunaCanonical  = "gpt-5.6-luna"
+	GPT6AstraCanonical  = "gpt-6-astra"
 	GPTReserveModelName = "gpt-reserve"
+	CodexAstraModelName = "openai.gpt-6-astra"
 )
 
 // KimiModelEraCutoff is the UTC instant at which the date-ambiguous
@@ -69,6 +74,7 @@ type FixedPricingAlias struct {
 var fixedPricingAliases = []FixedPricingAlias{
 	{Name: "k2d6-agent", Canonical: KimiK26Canonical},
 	{Name: GPTReserveModelName, Canonical: GPT56LunaCanonical},
+	{Name: CodexAstraModelName, Canonical: GPT6AstraCanonical},
 }
 
 // DateAliasedModels returns the sorted unqualified date-ambiguous
@@ -160,12 +166,11 @@ func CanonicalModelForTimestamp(model, ts string) string {
 	return CanonicalModelForDate(model, t)
 }
 
-// supplementalPricing lists curated pricing aliases for internal model
-// names that never appear in the upstream LiteLLM catalog (neither in
-// the embedded snapshot nor in the fetched table), so sessions priced
-// through them would otherwise report $0.
+// supplementalPricing lists curated pricing fallbacks for model names
+// that are absent from the pinned LiteLLM snapshot, so sessions priced
+// through them would otherwise report $0 before a live refresh.
 //
-// The rates below are ESTIMATES at the Kimi K3 list pricing (input
+// The Kimi rates below are ESTIMATES at the Kimi K3 list pricing (input
 // 3.00, output 15.00, cache creation 0, cache read 0.30 per MTok):
 // the Kimi CLI reports k3 and kimi-k3, and Kimi Work (the kimi-desktop
 // daimon runtime) reports k3-agent, none of which carry public rate
@@ -175,6 +180,20 @@ func CanonicalModelForTimestamp(model, ts string) string {
 // these rows like any other fallback row, so a later LiteLLM refresh
 // still overwrites them if upstream lists the real models.
 var supplementalPricing = []ModelPricing{
+	{
+		ModelPattern:         GPT6AstraCanonical,
+		InputPerMTok:         money.MustParseDollars("10.00"),
+		OutputPerMTok:        money.MustParseDollars("50.00"),
+		CacheCreationPerMTok: money.MustParseDollars("12.50"),
+		CacheReadPerMTok:     money.MustParseDollars("1.00"),
+		Bands: []PricingBand{{
+			AboveInputTokens:     272_000,
+			InputPerMTok:         money.MustParseDollars("20.00"),
+			OutputPerMTok:        money.MustParseDollars("75.00"),
+			CacheCreationPerMTok: money.MustParseDollars("25.00"),
+			CacheReadPerMTok:     money.MustParseDollars("2.00"),
+		}},
+	},
 	{
 		ModelPattern:         "k3",
 		InputPerMTok:         money.MustParseDollars("3.00"),
@@ -198,9 +217,9 @@ var supplementalPricing = []ModelPricing{
 	},
 }
 
-// SupplementalPricing returns the curated alias set, copied for caller
+// SupplementalPricing returns the curated fallback set, copied for caller
 // safety. It is already folded into FallbackPricing; this accessor
 // exists for tests and diagnostics that need the supplementals alone.
 func SupplementalPricing() []ModelPricing {
-	return slices.Clone(supplementalPricing)
+	return cloneModelPricing(supplementalPricing)
 }

--- a/internal/pricing/supplemental_test.go
+++ b/internal/pricing/supplemental_test.go
@@ -96,6 +96,7 @@ func TestCanonicalModelForDate(t *testing.T) {
 		{"gpt-reserve maps to Luna after cutoff", GPTReserveModelName, post, GPT56LunaCanonical},
 		{"gpt-reserve ignores zero time", GPTReserveModelName, time.Time{}, GPT56LunaCanonical},
 		{"provider-prefixed gpt-reserve", "openai/" + GPTReserveModelName, post, GPT56LunaCanonical},
+		{"Codex Astra maps to catalog model", CodexAstraModelName, post, GPT6AstraCanonical},
 		{"flat k3 alias is not date-ambiguous", "k3", pre, ""},
 		{"flat k3-agent alias is not date-ambiguous", "k3-agent", pre, ""},
 		{"canonical k2.6 model passes through", KimiK26Canonical, pre, ""},
@@ -154,20 +155,38 @@ func TestFallbackPricing_IncludesSupplementals(t *testing.T) {
 	}
 }
 
-// TestFallbackPricing_DateAliasTargetsResolvable proves both canonical
-// models the date-ambiguous aliases map onto exist in the fallback
-// set, so a mapped lookup always resolves: KimiK26Canonical from the
-// embedded snapshot, KimiK3Canonical from the supplemental rows.
-func TestFallbackPricing_DateAliasTargetsResolvable(t *testing.T) {
+// TestFallbackPricing_AliasTargetsResolvable proves every canonical model
+// runtime aliases map onto exists in the fallback set.
+func TestFallbackPricing_AliasTargetsResolvable(t *testing.T) {
 	byPattern := make(map[string]ModelPricing)
 	for _, p := range requireEmbeddedFallbackPricing(t) {
 		byPattern[p.ModelPattern] = p
 	}
-	for _, model := range []string{KimiK26Canonical, KimiK3Canonical, GPT56LunaCanonical} {
+	for _, model := range []string{
+		KimiK26Canonical,
+		KimiK3Canonical,
+		GPT56LunaCanonical,
+		GPT6AstraCanonical,
+	} {
 		_, ok := byPattern[model]
-		assert.True(t, ok,
-			"date-alias target %q missing from FallbackPricing", model)
+		require.True(t, ok,
+			"alias target %q missing from FallbackPricing", model)
 	}
+
+	astra := byPattern[GPT6AstraCanonical]
+	assert.Equal(t, money.MustParseDollars("10"), astra.InputPerMTok)
+	assert.Equal(t, money.MustParseDollars("50"), astra.OutputPerMTok)
+	assert.Equal(t, money.MustParseDollars("12.50"),
+		astra.CacheCreationPerMTok)
+	assert.Equal(t, money.MustParseDollars("1"), astra.CacheReadPerMTok)
+	require.Len(t, astra.Bands, 1)
+	assert.Equal(t, PricingBand{
+		AboveInputTokens:     272_000,
+		InputPerMTok:         money.MustParseDollars("20"),
+		OutputPerMTok:        money.MustParseDollars("75"),
+		CacheCreationPerMTok: money.MustParseDollars("25"),
+		CacheReadPerMTok:     money.MustParseDollars("2"),
+	}, astra.Bands[0])
 }
 
 // TestFallbackPricing_SupplementalsDoNotCollideWithSnapshot guards
@@ -214,8 +233,31 @@ func TestFixedPricingAliasesReturnsCopy(t *testing.T) {
 func TestSupplementalPricing_ReturnsCopy(t *testing.T) {
 	first := SupplementalPricing()
 	require.NotEmpty(t, first)
-	first[0].InputPerMTok = money.Money{Microdollars: -1}
+	var astra *ModelPricing
+	for i := range first {
+		if first[i].ModelPattern == GPT6AstraCanonical {
+			astra = &first[i]
+			break
+		}
+	}
+	require.NotNil(t, astra)
+	require.NotEmpty(t, astra.Bands)
+	astra.InputPerMTok = money.Money{Microdollars: -1}
+	astra.Bands[0].AboveInputTokens = 1
+
+	second := SupplementalPricing()
+	var secondAstra *ModelPricing
+	for i := range second {
+		if second[i].ModelPattern == GPT6AstraCanonical {
+			secondAstra = &second[i]
+			break
+		}
+	}
+	require.NotNil(t, secondAstra)
 	assert.NotEqual(t, money.Money{Microdollars: -1},
-		SupplementalPricing()[0].InputPerMTok,
+		secondAstra.InputPerMTok,
 		"SupplementalPricing must return an independent copy")
+	assert.NotEqual(t, 1,
+		secondAstra.Bands[0].AboveInputTokens,
+		"SupplementalPricing bands must be independently copied")
 }

--- a/internal/pricing/supplemental_test.go
+++ b/internal/pricing/supplemental_test.go
@@ -96,6 +96,9 @@ func TestCanonicalModelForDate(t *testing.T) {
 		{"gpt-reserve maps to Luna after cutoff", GPTReserveModelName, post, GPT56LunaCanonical},
 		{"gpt-reserve ignores zero time", GPTReserveModelName, time.Time{}, GPT56LunaCanonical},
 		{"provider-prefixed gpt-reserve", "openai/" + GPTReserveModelName, post, GPT56LunaCanonical},
+		{"Codex GPT-5.4 maps to standard Bedrock model", CodexGPT54ModelName, post, BedrockGPT54Canonical},
+		{"Codex GPT-5.6 Luna maps to standard Bedrock model", CodexGPT56LunaModelName, post, BedrockGPT56LunaCanonical},
+		{"Codex GPT-5.6 Terra maps to standard Bedrock model", CodexGPT56TerraModelName, post, BedrockGPT56TerraCanonical},
 		{"Codex Astra maps to catalog model", CodexAstraModelName, post, GPT6AstraCanonical},
 		{"flat k3 alias is not date-ambiguous", "k3", pre, ""},
 		{"flat k3-agent alias is not date-ambiguous", "k3-agent", pre, ""},
@@ -127,6 +130,7 @@ func TestCanonicalModelForTimestamp(t *testing.T) {
 		{"garbage timestamp falls back to K3", "kimi-for-coding", "not-a-time", KimiK3Canonical},
 		{"explicit K2.6 alias ignores timestamp", "k2d6-agent", "not-a-time", KimiK26Canonical},
 		{"gpt-reserve ignores garbage timestamp", GPTReserveModelName, "not-a-time", GPT56LunaCanonical},
+		{"Codex GPT-5.6 Luna ignores garbage timestamp", CodexGPT56LunaModelName, "not-a-time", BedrockGPT56LunaCanonical},
 		{"non-alias passes through", "k3", "2026-07-18T12:00:00Z", ""},
 	}
 	for _, tt := range tests {
@@ -166,6 +170,9 @@ func TestFallbackPricing_AliasTargetsResolvable(t *testing.T) {
 		KimiK26Canonical,
 		KimiK3Canonical,
 		GPT56LunaCanonical,
+		BedrockGPT54Canonical,
+		BedrockGPT56LunaCanonical,
+		BedrockGPT56TerraCanonical,
 		GPT6AstraCanonical,
 	} {
 		_, ok := byPattern[model]

--- a/internal/pricing/supplemental_test.go
+++ b/internal/pricing/supplemental_test.go
@@ -99,7 +99,9 @@ func TestCanonicalModelForDate(t *testing.T) {
 		{"Codex GPT-5.4 maps to standard Bedrock model", CodexGPT54ModelName, post, BedrockGPT54Canonical},
 		{"Codex GPT-5.6 Luna maps to standard Bedrock model", CodexGPT56LunaModelName, post, BedrockGPT56LunaCanonical},
 		{"Codex GPT-5.6 Terra maps to standard Bedrock model", CodexGPT56TerraModelName, post, BedrockGPT56TerraCanonical},
-		{"Codex Astra maps to catalog model", CodexAstraModelName, post, GPT6AstraCanonical},
+		{"Codex Astra maps to Bedrock model", "openai.gpt-6-astra", post, "bedrock_mantle/openai.gpt-6-astra"},
+		{"qualified Bedrock model passes through", "bedrock_mantle/openai.gpt-5.4", post, ""},
+		{"GovCloud model passes through", "bedrock_mantle/us-gov-west-1/openai.gpt-5.4", post, ""},
 		{"flat k3 alias is not date-ambiguous", "k3", pre, ""},
 		{"flat k3-agent alias is not date-ambiguous", "k3-agent", pre, ""},
 		{"canonical k2.6 model passes through", KimiK26Canonical, pre, ""},
@@ -181,18 +183,18 @@ func TestFallbackPricing_AliasTargetsResolvable(t *testing.T) {
 	}
 
 	astra := byPattern[GPT6AstraCanonical]
-	assert.Equal(t, money.MustParseDollars("10"), astra.InputPerMTok)
-	assert.Equal(t, money.MustParseDollars("50"), astra.OutputPerMTok)
-	assert.Equal(t, money.MustParseDollars("12.50"),
+	assert.Equal(t, money.MustParseDollars("11"), astra.InputPerMTok)
+	assert.Equal(t, money.MustParseDollars("55"), astra.OutputPerMTok)
+	assert.Equal(t, money.MustParseDollars("13.75"),
 		astra.CacheCreationPerMTok)
-	assert.Equal(t, money.MustParseDollars("1"), astra.CacheReadPerMTok)
+	assert.Equal(t, money.MustParseDollars("1.1"), astra.CacheReadPerMTok)
 	require.Len(t, astra.Bands, 1)
 	assert.Equal(t, PricingBand{
 		AboveInputTokens:     272_000,
-		InputPerMTok:         money.MustParseDollars("20"),
-		OutputPerMTok:        money.MustParseDollars("75"),
-		CacheCreationPerMTok: money.MustParseDollars("25"),
-		CacheReadPerMTok:     money.MustParseDollars("2"),
+		InputPerMTok:         money.MustParseDollars("22"),
+		OutputPerMTok:        money.MustParseDollars("82.5"),
+		CacheCreationPerMTok: money.MustParseDollars("27.5"),
+		CacheReadPerMTok:     money.MustParseDollars("2.2"),
 	}, astra.Bands[0])
 }
 


### PR DESCRIPTION
Fix missing or incorrect cost estimates for Codex sessions using GPT-5.4, GPT-5.6 Luna, GPT-5.6 Terra, or GPT-6 Astra through Amazon Bedrock.

These sessions report names such as `openai.gpt-6-astra`. Agentsview now uses Bedrock prices for those exact names, wherever they are reported. Direct OpenAI names such as `gpt-6-astra` continue to use their own pricing lookup.

Use historical Bedrock prices when available, so older Luna and Terra sessions use the prices from before the July 30 cut. Include Astra's Bedrock prices in the app so costs are available before an online price refresh. Recalculate cached usage totals with the corrected pricing.

Keep custom price overrides, regional prices such as GovCloud, and the model names shown in usage breakdowns.
