### PR TITLE
fix(parser): skip NULL cursorDiskKV values instead of failing the cursor-ide pass

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1208,6 +1208,18 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   update (3.16.29) has shrunk or wiped some users' `cursorDiskKV` rows, so the
   parser tolerates a `fullConversationHeadersOnly` entry whose `bubbleId` row
   is missing rather than failing the whole session.
+- **NULL values:**
+  [Issue #1676](https://github.com/kenn-io/agentsview/issues/1676) (reported
+  2026-09-08; rechecked 2026-09-10) records 64 SQL NULL values among 2,189
+  `cursorDiskKV` rows: 2 `composerData:` rows and 62 `bubbleId:` rows. What
+  created those NULLs remains unknown. The synthetic fixture
+  `internal/parser/testdata/cursor-ide-null-values.sql` reproduces both row
+  types. Tests also cover zero-length BLOBs as synthetic boundary cases; the
+  report establishes SQL NULLs only. Agentsview treats either zero-length
+  value as absent: a composer yields no session result, preserving any
+  archived transcript in the recoverable source-missing state; a bubble
+  becomes a gap and marks the transcript truncated. Nonempty malformed JSON
+  still errors.
 - **Usage and cost:** No per-message or per-session token, cache, reasoning,
   credit, or monetary-cost fields were observed in `composerData` or bubble
   documents. Agentsview emits no usage events for this agent; cost is

--- a/internal/parser/cursor_ide.go
+++ b/internal/parser/cursor_ide.go
@@ -213,6 +213,15 @@ func loadCursorIDEComposerMeta(
 		return cursorIDEComposerMeta{}, false, fmt.Errorf(
 			"loading cursor IDE composer meta %s: %w", composerID, err)
 	}
+	if len(raw) == 0 {
+		// A composerData key whose value is NULL or empty holds no session
+		// document, so there is nothing to fingerprint. This is the same fact
+		// as the vanished row above, not the malformed case below: an absent
+		// value yields no shorter transcript that could replace the archived
+		// one. The engine proceeds to Parse, which routes the stored session
+		// to the recoverable source-missing seam while state.vscdb is present.
+		return cursorIDEComposerMeta{}, false, nil
+	}
 	var doc cursorIDEComposerDoc
 	if err := json.Unmarshal(raw, &doc); err != nil {
 		// Malformed is not missing: a row that exists but no longer decodes
@@ -291,6 +300,14 @@ func loadCursorIDEBubble(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"loading cursor IDE bubble %s:%s: %w", composerID, bubbleID, err)
+	}
+	if len(raw) == 0 {
+		// A bubbleId row whose value is NULL or empty carries no turn text,
+		// which is the same gap as the missing row above. The caller flags the
+		// transcript truncated, and the engine's truncation guard
+		// (dropShrinkingTruncatedCursorIDEResults) still refuses any result
+		// that would drop an archived message.
+		return nil, nil
 	}
 	var bubble cursorIDEBubble
 	if err := json.Unmarshal(raw, &bubble); err != nil {
@@ -414,6 +431,13 @@ func parseCursorIDEComposer(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"loading cursor IDE composer %s: %w", composerID, err)
+	}
+	if len(raw) == 0 {
+		// Same husk row as in loadCursorIDEComposerMeta: no document, so no
+		// result. A nil result keeps the container fan-out running for every
+		// sibling composer instead of failing the whole pass, and the stored
+		// session is preserved through the source-missing seam.
+		return nil, nil
 	}
 	var doc cursorIDEComposerDoc
 	if err := json.Unmarshal(raw, &doc); err != nil {

--- a/internal/parser/cursor_ide_provider.go
+++ b/internal/parser/cursor_ide_provider.go
@@ -140,7 +140,11 @@ func cursorIDEFingerprintSource(
 	if !ok {
 		// Composer row is gone but the DB file remains: a keyed-empty
 		// fingerprint without error so the engine proceeds to Parse, which
-		// force-replaces the deleted composer out of the archive.
+		// force-replaces the deleted composer out of the archive. This branch
+		// is also reached by a husk row whose key is still present (value is
+		// NULL or empty): CursorIDEComposerExists selects on key alone, so
+		// cursorIDEBatchMemberPresent still reports it present and the
+		// session lands on source_missing_at instead of being force-replaced.
 		return SourceFingerprint{}, nil
 	}
 	return SourceFingerprint{

--- a/internal/parser/cursor_ide_provider.go
+++ b/internal/parser/cursor_ide_provider.go
@@ -138,13 +138,12 @@ func cursorIDEFingerprintSource(
 		return SourceFingerprint{}, err
 	}
 	if !ok {
-		// Composer row is gone but the DB file remains: a keyed-empty
-		// fingerprint without error so the engine proceeds to Parse, which
-		// force-replaces the deleted composer out of the archive. This branch
-		// is also reached by a husk row whose key is still present (value is
-		// NULL or empty): CursorIDEComposerExists selects on key alone, so
-		// cursorIDEBatchMemberPresent still reports it present and the
-		// session lands on source_missing_at instead of being force-replaced.
+		// Composer row is absent or a husk (NULL/empty value): return a
+		// keyed-empty fingerprint without error. With the container file
+		// present, both cases land on source_missing_at. They differ only
+		// upstream: a husk key is still returned by listCursorIDEComposerIDs,
+		// so changedPathTombstones emits no member tombstone for it, while a
+		// fully deleted key does produce one.
 		return SourceFingerprint{}, nil
 	}
 	return SourceFingerprint{

--- a/internal/parser/cursor_ide_test.go
+++ b/internal/parser/cursor_ide_test.go
@@ -438,120 +438,175 @@ func TestParseCursorIDEComposer_EndedAtNotBeforeLastMessage(t *testing.T) {
 }
 
 func TestCursorIDEParseContainerKeepsSiblingsPastNullComposer(t *testing.T) {
-	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{
-		{
-			id:        "husk-0000-0000-0000-000000000000",
-			name:      "Husk chat",
-			createdAt: 1782026756842,
-			updatedAt: 1782026791522,
-			bubbles: []cursorIDETestBubble{{
-				id: "b1", bubbleType: cursorIDEBubbleTypeUser,
-				text: "will be nulled", createdAt: "2026-06-21T07:27:29.606Z",
-			}},
-		},
-		{
-			id:        "sibling-one-0000-0000-000000000000",
-			name:      "Sibling one",
-			createdAt: 1782026756842,
-			updatedAt: 1782026791522,
-			bubbles: []cursorIDETestBubble{{
-				id: "b1", bubbleType: cursorIDEBubbleTypeUser,
-				text: "kept one", createdAt: "2026-06-21T07:27:29.606Z",
-			}},
-		},
-		{
-			id:        "sibling-two-0000-0000-000000000000",
-			name:      "Sibling two",
-			createdAt: 1782026756842,
-			updatedAt: 1782026791522,
-			bubbles: []cursorIDETestBubble{{
-				id: "b1", bubbleType: cursorIDEBubbleTypeUser,
-				text: "kept two", createdAt: "2026-06-21T07:27:29.606Z",
-			}},
-		},
-	})
-	writer, err := sql.Open("sqlite3", dbPath)
-	require.NoError(t, err)
-	_, err = writer.Exec(
-		`UPDATE cursorDiskKV SET value = NULL WHERE key = ?`,
-		"composerData:husk-0000-0000-0000-000000000000",
-	)
-	require.NoError(t, err)
-	require.NoError(t, writer.Close())
-
-	root := filepath.Dir(dbPath)
-	provider, ok := NewProvider(AgentCursorIDE, ProviderConfig{
-		Roots: []string{root}, Machine: "devbox",
-	})
-	require.True(t, ok)
-
-	discovered, err := provider.Discover(context.Background())
-	require.NoError(t, err)
-	require.Len(t, discovered, 1)
-
-	fingerprint, err := provider.Fingerprint(context.Background(), discovered[0])
-	require.NoError(t, err)
-
-	outcome, err := provider.Parse(context.Background(), ParseRequest{
-		Source: discovered[0], Machine: "devbox", Fingerprint: fingerprint,
-	})
-	require.NoError(t, err,
-		"a husk composer must not fail the whole container fan-out")
-	require.Len(t, outcome.Results, 2,
-		"both healthy siblings must survive past the husk composer")
-
-	var ids []string
-	for _, r := range outcome.Results {
-		ids = append(ids, r.Result.Session.ID)
+	// NULL and a stored zero-length BLOB both scan into a zero-length []byte,
+	// but they are distinct SQLite storage shapes (sql.ErrNoRows never fires
+	// for either). The guard is len(raw) == 0, not raw == nil, precisely so a
+	// database holding either shape stops failing; both cases must be proven
+	// separately so a regression narrowing the predicate to raw == nil would
+	// be caught.
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{name: "null", value: nil},
+		{name: "empty-blob", value: []byte{}},
 	}
-	assert.ElementsMatch(t, []string{
-		"cursor-ide:sibling-one-0000-0000-000000000000",
-		"cursor-ide:sibling-two-0000-0000-000000000000",
-	}, ids)
-	assert.NotContains(t, ids, "cursor-ide:husk-0000-0000-0000-000000000000")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := createCursorIDEDB(t, []cursorIDETestComposer{
+				{
+					id:        "husk-0000-0000-0000-000000000000",
+					name:      "Husk chat",
+					createdAt: 1782026756842,
+					updatedAt: 1782026791522,
+					bubbles: []cursorIDETestBubble{{
+						id: "b1", bubbleType: cursorIDEBubbleTypeUser,
+						text: "will be husked", createdAt: "2026-06-21T07:27:29.606Z",
+					}},
+				},
+				{
+					id:        "sibling-one-0000-0000-000000000000",
+					name:      "Sibling one",
+					createdAt: 1782026756842,
+					updatedAt: 1782026791522,
+					bubbles: []cursorIDETestBubble{{
+						id: "b1", bubbleType: cursorIDEBubbleTypeUser,
+						text: "kept one", createdAt: "2026-06-21T07:27:29.606Z",
+					}},
+				},
+				{
+					id:        "sibling-two-0000-0000-000000000000",
+					name:      "Sibling two",
+					createdAt: 1782026756842,
+					updatedAt: 1782026791522,
+					bubbles: []cursorIDETestBubble{{
+						id: "b1", bubbleType: cursorIDEBubbleTypeUser,
+						text: "kept two", createdAt: "2026-06-21T07:27:29.606Z",
+					}},
+				},
+			})
+			writer, err := sql.Open("sqlite3", dbPath)
+			require.NoError(t, err)
+			_, err = writer.Exec(
+				`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+				tc.value, "composerData:husk-0000-0000-0000-000000000000",
+			)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
+
+			root := filepath.Dir(dbPath)
+			provider, ok := NewProvider(AgentCursorIDE, ProviderConfig{
+				Roots: []string{root}, Machine: "devbox",
+			})
+			require.True(t, ok)
+
+			discovered, err := provider.Discover(context.Background())
+			require.NoError(t, err)
+			require.Len(t, discovered, 1)
+
+			fingerprint, err := provider.Fingerprint(context.Background(), discovered[0])
+			require.NoError(t, err)
+
+			outcome, err := provider.Parse(context.Background(), ParseRequest{
+				Source: discovered[0], Machine: "devbox", Fingerprint: fingerprint,
+			})
+			require.NoError(t, err,
+				"a husk composer must not fail the whole container fan-out")
+			require.Len(t, outcome.Results, 2,
+				"both healthy siblings must survive past the husk composer")
+
+			var ids []string
+			var siblingOne ParseResult
+			for _, r := range outcome.Results {
+				ids = append(ids, r.Result.Session.ID)
+				if r.Result.Session.ID == "cursor-ide:sibling-one-0000-0000-000000000000" {
+					siblingOne = r.Result
+				}
+			}
+			assert.ElementsMatch(t, []string{
+				"cursor-ide:sibling-one-0000-0000-000000000000",
+				"cursor-ide:sibling-two-0000-0000-000000000000",
+			}, ids)
+			assert.NotContains(t, ids, "cursor-ide:husk-0000-0000-0000-000000000000")
+
+			// P3: a surviving sibling's full parsed-session metadata contract
+			// (not just its ID) is unaffected by a sibling husk elsewhere in the
+			// same container.
+			require.Len(t, siblingOne.Messages, 1)
+			assert.Equal(t, "kept one", siblingOne.Messages[0].Content)
+			assert.Equal(t, "b1", siblingOne.Messages[0].SourceUUID)
+			assert.False(t, siblingOne.Session.IsTruncated)
+			assert.Equal(t, "Sibling one", siblingOne.Session.SessionName)
+			assert.NotEmpty(t, siblingOne.Session.File.Hash)
+			assert.False(t, siblingOne.Session.StartedAt.IsZero())
+			assert.False(t, siblingOne.Session.EndedAt.IsZero())
+			// P7: cursor-ide assigns none of these lineage fields; a sibling
+			// surviving a husk composer must not pick any of them up either.
+			assert.Empty(t, siblingOne.Session.RelationshipType)
+			assert.Empty(t, siblingOne.Session.SourceVersion)
+			assert.Empty(t, siblingOne.Session.ParentSessionID)
+			assert.Empty(t, siblingOne.Session.TerminationStatus)
+		})
+	}
 }
 
 func TestParseCursorIDEComposer_NullBubbleValueBecomesGap(t *testing.T) {
-	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
-		id:        "null-bubble-0000-0000-000000000000",
-		name:      "Null bubble thread",
-		createdAt: 1782026756842,
-		updatedAt: 1782026791522,
-		bubbles: []cursorIDETestBubble{
-			{id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "kept", createdAt: "2026-06-21T07:27:29.606Z"},
-			{id: "b2", bubbleType: cursorIDEBubbleTypeAssistant, text: "will be nulled", createdAt: "2026-06-21T07:27:31.522Z"},
-		},
-	}})
-	writer, err := sql.Open("sqlite3", dbPath)
-	require.NoError(t, err)
-	_, err = writer.Exec(
-		`UPDATE cursorDiskKV SET value = NULL WHERE key = ?`,
-		"bubbleId:null-bubble-0000-0000-000000000000:b2",
-	)
-	require.NoError(t, err)
-	require.NoError(t, writer.Close())
+	// NULL and a stored zero-length BLOB are distinct storage shapes but must
+	// take the same absent path; see the guard-boundary note in
+	// TestCursorIDEParseContainerKeepsSiblingsPastNullComposer.
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{name: "null", value: nil},
+		{name: "empty-blob", value: []byte{}},
+	}
 
-	conn, err := openCursorIDEDB(dbPath)
-	require.NoError(t, err)
-	defer conn.Close()
-	info, err := os.Stat(dbPath)
-	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+				id:        "null-bubble-0000-0000-000000000000",
+				name:      "Null bubble thread",
+				createdAt: 1782026756842,
+				updatedAt: 1782026791522,
+				bubbles: []cursorIDETestBubble{
+					{id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "kept", createdAt: "2026-06-21T07:27:29.606Z"},
+					{id: "b2", bubbleType: cursorIDEBubbleTypeAssistant, text: "will be husked", createdAt: "2026-06-21T07:27:31.522Z"},
+				},
+			}})
+			writer, err := sql.Open("sqlite3", dbPath)
+			require.NoError(t, err)
+			_, err = writer.Exec(
+				`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+				tc.value, "bubbleId:null-bubble-0000-0000-000000000000:b2",
+			)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
 
-	result, err := parseCursorIDEComposer(
-		context.Background(), conn, dbPath,
-		"null-bubble-0000-0000-000000000000", "devbox", info,
-	)
-	require.NoError(t, err,
-		"a bubble whose value is NULL must become a truncation gap, not a fatal error")
-	require.NotNil(t, result)
-	require.Len(t, result.Messages, 1)
-	assert.Equal(t, "kept", result.Messages[0].Content)
-	assert.True(t, result.Session.IsTruncated,
-		"a transcript with a null-valued bubble row must be flagged truncated")
-	assert.Zero(t, result.Session.MalformedLines,
-		"this diff writes no malformed-line counter for a husk bubble")
-	assert.Equal(t, "b1", result.Messages[0].SourceUUID,
-		"the surviving message's SourceUUID must be unchanged")
+			conn, err := openCursorIDEDB(dbPath)
+			require.NoError(t, err)
+			defer conn.Close()
+			info, err := os.Stat(dbPath)
+			require.NoError(t, err)
+
+			result, err := parseCursorIDEComposer(
+				context.Background(), conn, dbPath,
+				"null-bubble-0000-0000-000000000000", "devbox", info,
+			)
+			require.NoError(t, err,
+				"a bubble whose value is NULL or empty must become a truncation gap, not a fatal error")
+			require.NotNil(t, result)
+			require.Len(t, result.Messages, 1)
+			assert.Equal(t, "kept", result.Messages[0].Content)
+			assert.True(t, result.Session.IsTruncated,
+				"a transcript with a husked bubble row must be flagged truncated")
+			assert.Zero(t, result.Session.MalformedLines,
+				"this diff writes no malformed-line counter for a husk bubble")
+			assert.Equal(t, "b1", result.Messages[0].SourceUUID,
+				"the surviving message's SourceUUID must be unchanged")
+		})
+	}
 }
 
 func TestCursorIDEEmptyJSONObjectValuesTakeExistingPaths(t *testing.T) {
@@ -582,6 +637,23 @@ func TestCursorIDEEmptyJSONObjectValuesTakeExistingPaths(t *testing.T) {
 			"a two-byte {} value decodes cleanly and must not take the absent path")
 		assert.Nil(t, result,
 			"a composer with zero headers must not surface as a session")
+
+		// parseCursorIDEComposer's (nil, nil) return is identical whether the
+		// guard fired or the value decoded to zero headers, so it cannot by
+		// itself prove {} took the decode path rather than the absent path. The
+		// discriminator lives one level down: loadCursorIDEComposerMeta reports
+		// ok=true with a real digest for a value that decoded (this {} case),
+		// and ok=false with a zero meta for a husk (TestLoadCursorIDEComposerMetaNullValueReportsNotFound).
+		// A guard broadened to catch len(raw) <= 2 would flip this ok to false,
+		// which is exactly the false-positive this row exists to catch.
+		meta, ok, err := loadCursorIDEComposerMeta(
+			context.Background(), conn, "empty-object-composer-0000-00000000",
+		)
+		require.NoError(t, err)
+		assert.True(t, ok,
+			"a decoded {} composer must report found, unlike a husk composer")
+		assert.NotEmpty(t, meta.digest,
+			"a decoded {} composer must fingerprint with a real digest")
 	})
 
 	t.Run("bubble", func(t *testing.T) {
@@ -621,44 +693,79 @@ func TestCursorIDEEmptyJSONObjectValuesTakeExistingPaths(t *testing.T) {
 		assert.Equal(t, "kept", result.Messages[0].Content)
 		assert.True(t, result.Session.IsTruncated,
 			"a bubble that decodes but renders nothing still takes the truncation path")
+
+		// parseCursorIDEComposer's outer result (one surviving message,
+		// truncated=true) is identical whether the {} bubble decoded and then
+		// rendered nothing, or the row was an absent husk, so it cannot by
+		// itself prove {} reached the renderless-bubble branch rather than the
+		// absent-bubble branch. The discriminator is one level down, at
+		// loadCursorIDEBubble itself: a decoded {} returns a non-nil bubble
+		// (this case), while a husk returns nil
+		// (TestParseCursorIDEComposer_NullBubbleValueBecomesGap). A guard
+		// broadened to catch len(raw) <= 2 would flip this to nil, which is
+		// exactly the false-positive this row exists to catch.
+		bubble, err := loadCursorIDEBubble(
+			context.Background(), conn,
+			"empty-object-bubble-0000-0000000000", "b2",
+		)
+		require.NoError(t, err)
+		require.NotNil(t, bubble,
+			"a decoded {} bubble must return non-nil, unlike a husk bubble")
+		assert.Equal(t, cursorIDEBubble{}, *bubble,
+			"a {} bubble decodes to a zero-valued struct, not an absence")
 	})
 }
 
 func TestLoadCursorIDEComposerMetaNullValueReportsNotFound(t *testing.T) {
-	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
-		id:        "null-meta-0000-0000-000000000000",
-		name:      "Null meta chat",
-		createdAt: 1782026756842,
-		updatedAt: 1782026791522,
-		bubbles: []cursorIDETestBubble{{
-			id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "hi",
-			createdAt: "2026-06-21T07:27:29.606Z",
-		}},
-	}})
-	writer, err := sql.Open("sqlite3", dbPath)
-	require.NoError(t, err)
-	_, err = writer.Exec(
-		`UPDATE cursorDiskKV SET value = NULL WHERE key = ?`,
-		"composerData:null-meta-0000-0000-000000000000",
-	)
-	require.NoError(t, err)
-	require.NoError(t, writer.Close())
+	// NULL and a stored zero-length BLOB are distinct storage shapes but must
+	// take the same absent path; see the guard-boundary note in
+	// TestCursorIDEParseContainerKeepsSiblingsPastNullComposer.
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{name: "null", value: nil},
+		{name: "empty-blob", value: []byte{}},
+	}
 
-	conn, err := openCursorIDEDB(dbPath)
-	require.NoError(t, err)
-	defer conn.Close()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+				id:        "null-meta-0000-0000-000000000000",
+				name:      "Null meta chat",
+				createdAt: 1782026756842,
+				updatedAt: 1782026791522,
+				bubbles: []cursorIDETestBubble{{
+					id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "hi",
+					createdAt: "2026-06-21T07:27:29.606Z",
+				}},
+			}})
+			writer, err := sql.Open("sqlite3", dbPath)
+			require.NoError(t, err)
+			_, err = writer.Exec(
+				`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+				tc.value, "composerData:null-meta-0000-0000-000000000000",
+			)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
 
-	meta, ok, err := loadCursorIDEComposerMeta(
-		context.Background(), conn, "null-meta-0000-0000-000000000000",
-	)
-	require.NoError(t, err,
-		"a NULL composer value must fingerprint as absent, not error")
-	assert.False(t, ok)
-	assert.Equal(t, cursorIDEComposerMeta{}, meta)
+			conn, err := openCursorIDEDB(dbPath)
+			require.NoError(t, err)
+			defer conn.Close()
 
-	assert.True(t,
-		CursorIDEComposerExists(dbPath, "null-meta-0000-0000-000000000000"),
-		"the key remains present in cursorDiskKV even though its value is NULL")
+			meta, ok, err := loadCursorIDEComposerMeta(
+				context.Background(), conn, "null-meta-0000-0000-000000000000",
+			)
+			require.NoError(t, err,
+				"a NULL or empty composer value must fingerprint as absent, not error")
+			assert.False(t, ok)
+			assert.Equal(t, cursorIDEComposerMeta{}, meta)
+
+			assert.True(t,
+				CursorIDEComposerExists(dbPath, "null-meta-0000-0000-000000000000"),
+				"the key remains present in cursorDiskKV even though its value is NULL or empty")
+		})
+	}
 }
 
 func TestParseCursorIDEComposer_TypelessBubbleFallsBackToHeaderType(t *testing.T) {

--- a/internal/parser/cursor_ide_test.go
+++ b/internal/parser/cursor_ide_test.go
@@ -437,6 +437,230 @@ func TestParseCursorIDEComposer_EndedAtNotBeforeLastMessage(t *testing.T) {
 	assert.False(t, result.Session.EndedAt.Before(result.Session.StartedAt))
 }
 
+func TestCursorIDEParseContainerKeepsSiblingsPastNullComposer(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{
+		{
+			id:        "husk-0000-0000-0000-000000000000",
+			name:      "Husk chat",
+			createdAt: 1782026756842,
+			updatedAt: 1782026791522,
+			bubbles: []cursorIDETestBubble{{
+				id: "b1", bubbleType: cursorIDEBubbleTypeUser,
+				text: "will be nulled", createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+		{
+			id:        "sibling-one-0000-0000-000000000000",
+			name:      "Sibling one",
+			createdAt: 1782026756842,
+			updatedAt: 1782026791522,
+			bubbles: []cursorIDETestBubble{{
+				id: "b1", bubbleType: cursorIDEBubbleTypeUser,
+				text: "kept one", createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+		{
+			id:        "sibling-two-0000-0000-000000000000",
+			name:      "Sibling two",
+			createdAt: 1782026756842,
+			updatedAt: 1782026791522,
+			bubbles: []cursorIDETestBubble{{
+				id: "b1", bubbleType: cursorIDEBubbleTypeUser,
+				text: "kept two", createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+	})
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = NULL WHERE key = ?`,
+		"composerData:husk-0000-0000-0000-000000000000",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	root := filepath.Dir(dbPath)
+	provider, ok := NewProvider(AgentCursorIDE, ProviderConfig{
+		Roots: []string{root}, Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: discovered[0], Machine: "devbox", Fingerprint: fingerprint,
+	})
+	require.NoError(t, err,
+		"a husk composer must not fail the whole container fan-out")
+	require.Len(t, outcome.Results, 2,
+		"both healthy siblings must survive past the husk composer")
+
+	var ids []string
+	for _, r := range outcome.Results {
+		ids = append(ids, r.Result.Session.ID)
+	}
+	assert.ElementsMatch(t, []string{
+		"cursor-ide:sibling-one-0000-0000-000000000000",
+		"cursor-ide:sibling-two-0000-0000-000000000000",
+	}, ids)
+	assert.NotContains(t, ids, "cursor-ide:husk-0000-0000-0000-000000000000")
+}
+
+func TestParseCursorIDEComposer_NullBubbleValueBecomesGap(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id:        "null-bubble-0000-0000-000000000000",
+		name:      "Null bubble thread",
+		createdAt: 1782026756842,
+		updatedAt: 1782026791522,
+		bubbles: []cursorIDETestBubble{
+			{id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "kept", createdAt: "2026-06-21T07:27:29.606Z"},
+			{id: "b2", bubbleType: cursorIDEBubbleTypeAssistant, text: "will be nulled", createdAt: "2026-06-21T07:27:31.522Z"},
+		},
+	}})
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = NULL WHERE key = ?`,
+		"bubbleId:null-bubble-0000-0000-000000000000:b2",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	conn, err := openCursorIDEDB(dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err)
+
+	result, err := parseCursorIDEComposer(
+		context.Background(), conn, dbPath,
+		"null-bubble-0000-0000-000000000000", "devbox", info,
+	)
+	require.NoError(t, err,
+		"a bubble whose value is NULL must become a truncation gap, not a fatal error")
+	require.NotNil(t, result)
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, "kept", result.Messages[0].Content)
+	assert.True(t, result.Session.IsTruncated,
+		"a transcript with a null-valued bubble row must be flagged truncated")
+	assert.Zero(t, result.Session.MalformedLines,
+		"this diff writes no malformed-line counter for a husk bubble")
+	assert.Equal(t, "b1", result.Messages[0].SourceUUID,
+		"the surviving message's SourceUUID must be unchanged")
+}
+
+func TestCursorIDEEmptyJSONObjectValuesTakeExistingPaths(t *testing.T) {
+	t.Run("composer", func(t *testing.T) {
+		dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+			id: "empty-object-composer-0000-00000000",
+		}})
+		writer, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		_, err = writer.Exec(
+			`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+			[]byte(`{}`), "composerData:empty-object-composer-0000-00000000",
+		)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		conn, err := openCursorIDEDB(dbPath)
+		require.NoError(t, err)
+		defer conn.Close()
+		info, err := os.Stat(dbPath)
+		require.NoError(t, err)
+
+		result, err := parseCursorIDEComposer(
+			context.Background(), conn, dbPath,
+			"empty-object-composer-0000-00000000", "devbox", info,
+		)
+		require.NoError(t, err,
+			"a two-byte {} value decodes cleanly and must not take the absent path")
+		assert.Nil(t, result,
+			"a composer with zero headers must not surface as a session")
+	})
+
+	t.Run("bubble", func(t *testing.T) {
+		dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+			id:        "empty-object-bubble-0000-0000000000",
+			name:      "Empty object bubble",
+			createdAt: 1782026756842,
+			updatedAt: 1782026791522,
+			bubbles: []cursorIDETestBubble{
+				{id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "kept", createdAt: "2026-06-21T07:27:29.606Z"},
+				{id: "b2", bubbleType: cursorIDEBubbleTypeAssistant, text: "will be emptied", createdAt: "2026-06-21T07:27:31.522Z"},
+			},
+		}})
+		writer, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		_, err = writer.Exec(
+			`UPDATE cursorDiskKV SET value = ? WHERE key = ?`,
+			[]byte(`{}`), "bubbleId:empty-object-bubble-0000-0000000000:b2",
+		)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		conn, err := openCursorIDEDB(dbPath)
+		require.NoError(t, err)
+		defer conn.Close()
+		info, err := os.Stat(dbPath)
+		require.NoError(t, err)
+
+		result, err := parseCursorIDEComposer(
+			context.Background(), conn, dbPath,
+			"empty-object-bubble-0000-0000000000", "devbox", info,
+		)
+		require.NoError(t, err,
+			"a two-byte {} bubble value decodes cleanly and must not take the absent path")
+		require.NotNil(t, result)
+		require.Len(t, result.Messages, 1)
+		assert.Equal(t, "kept", result.Messages[0].Content)
+		assert.True(t, result.Session.IsTruncated,
+			"a bubble that decodes but renders nothing still takes the truncation path")
+	})
+}
+
+func TestLoadCursorIDEComposerMetaNullValueReportsNotFound(t *testing.T) {
+	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+		id:        "null-meta-0000-0000-000000000000",
+		name:      "Null meta chat",
+		createdAt: 1782026756842,
+		updatedAt: 1782026791522,
+		bubbles: []cursorIDETestBubble{{
+			id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "hi",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = NULL WHERE key = ?`,
+		"composerData:null-meta-0000-0000-000000000000",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	conn, err := openCursorIDEDB(dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	meta, ok, err := loadCursorIDEComposerMeta(
+		context.Background(), conn, "null-meta-0000-0000-000000000000",
+	)
+	require.NoError(t, err,
+		"a NULL composer value must fingerprint as absent, not error")
+	assert.False(t, ok)
+	assert.Equal(t, cursorIDEComposerMeta{}, meta)
+
+	assert.True(t,
+		CursorIDEComposerExists(dbPath, "null-meta-0000-0000-000000000000"),
+		"the key remains present in cursorDiskKV even though its value is NULL")
+}
+
 func TestParseCursorIDEComposer_TypelessBubbleFallsBackToHeaderType(t *testing.T) {
 	dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
 		id:        "typeless-0000-0000-0000-000000000000",

--- a/internal/parser/cursor_ide_test.go
+++ b/internal/parser/cursor_ide_test.go
@@ -105,6 +105,33 @@ func createCursorIDEDB(t *testing.T, composers []cursorIDETestComposer) string {
 	return dbPath
 }
 
+// assertCursorDiskKVStoredShape pins the on-disk premise the null/empty-blob
+// subtests rest on: a SQL NULL value reports typeof "null", while a stored
+// zero-length BLOB reports typeof "blob" with length 0. Without this check,
+// a driver whose bind path folded []byte{} into NULL (the repo carries a
+// second SQLite driver, modernc.org/sqlite, so this is not hypothetical)
+// would silently collapse the empty-blob subtests into copies of their null
+// siblings and still pass.
+func assertCursorDiskKVStoredShape(t *testing.T, dbPath, key string, wantNull bool) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+	var typ string
+	var length sql.NullInt64
+	require.NoError(t, conn.QueryRow(
+		`SELECT typeof(value), length(value) FROM cursorDiskKV WHERE key = ?`,
+		key,
+	).Scan(&typ, &length))
+	if wantNull {
+		assert.Equal(t, "null", typ)
+		return
+	}
+	assert.Equal(t, "blob", typ)
+	require.True(t, length.Valid)
+	assert.Zero(t, length.Int64)
+}
+
 func TestCursorIDEProviderCapabilities(t *testing.T) {
 	factory, ok := ProviderFactoryByType(AgentCursorIDE)
 	require.True(t, ok)
@@ -494,6 +521,8 @@ func TestCursorIDEParseContainerKeepsSiblingsPastNullComposer(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.NoError(t, writer.Close())
+			assertCursorDiskKVStoredShape(t, dbPath,
+				"composerData:husk-0000-0000-0000-000000000000", tc.value == nil)
 
 			root := filepath.Dir(dbPath)
 			provider, ok := NewProvider(AgentCursorIDE, ProviderConfig{
@@ -565,7 +594,7 @@ func TestParseCursorIDEComposer_NullBubbleValueBecomesGap(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dbPath := createCursorIDEDB(t, []cursorIDETestComposer{{
+			composer := []cursorIDETestComposer{{
 				id:        "null-bubble-0000-0000-000000000000",
 				name:      "Null bubble thread",
 				createdAt: 1782026756842,
@@ -574,7 +603,29 @@ func TestParseCursorIDEComposer_NullBubbleValueBecomesGap(t *testing.T) {
 					{id: "b1", bubbleType: cursorIDEBubbleTypeUser, text: "kept", createdAt: "2026-06-21T07:27:29.606Z"},
 					{id: "b2", bubbleType: cursorIDEBubbleTypeAssistant, text: "will be husked", createdAt: "2026-06-21T07:27:31.522Z"},
 				},
-			}})
+			}}
+
+			// Reference digest: the same composer with bubble b2 intact. This
+			// is the one input for which cursorIDEComposerDigest becomes newly
+			// reachable by this diff: on base, loadCursorIDEBubble errored at
+			// header b2 and parseCursorIDEComposer returned before the digest
+			// call. P6 requires the digest to hash every stored bubble's key
+			// and value bytes unconditionally, so husking b2 must change it.
+			intactPath := createCursorIDEDB(t, composer)
+			intactConn, err := openCursorIDEDB(intactPath)
+			require.NoError(t, err)
+			intactInfo, err := os.Stat(intactPath)
+			require.NoError(t, err)
+			intactResult, err := parseCursorIDEComposer(
+				context.Background(), intactConn, intactPath,
+				"null-bubble-0000-0000-000000000000", "devbox", intactInfo,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, intactResult)
+			require.NotEmpty(t, intactResult.Session.File.Hash)
+			require.NoError(t, intactConn.Close())
+
+			dbPath := createCursorIDEDB(t, composer)
 			writer, err := sql.Open("sqlite3", dbPath)
 			require.NoError(t, err)
 			_, err = writer.Exec(
@@ -583,6 +634,8 @@ func TestParseCursorIDEComposer_NullBubbleValueBecomesGap(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.NoError(t, writer.Close())
+			assertCursorDiskKVStoredShape(t, dbPath,
+				"bubbleId:null-bubble-0000-0000-000000000000:b2", tc.value == nil)
 
 			conn, err := openCursorIDEDB(dbPath)
 			require.NoError(t, err)
@@ -605,6 +658,10 @@ func TestParseCursorIDEComposer_NullBubbleValueBecomesGap(t *testing.T) {
 				"this diff writes no malformed-line counter for a husk bubble")
 			assert.Equal(t, "b1", result.Messages[0].SourceUUID,
 				"the surviving message's SourceUUID must be unchanged")
+
+			assert.NotEmpty(t, result.Session.File.Hash)
+			assert.NotEqual(t, intactResult.Session.File.Hash, result.Session.File.Hash,
+				"husking bubble b2 must change the composer digest")
 		})
 	}
 }
@@ -748,6 +805,8 @@ func TestLoadCursorIDEComposerMetaNullValueReportsNotFound(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.NoError(t, writer.Close())
+			assertCursorDiskKVStoredShape(t, dbPath,
+				"composerData:null-meta-0000-0000-000000000000", tc.value == nil)
 
 			conn, err := openCursorIDEDB(dbPath)
 			require.NoError(t, err)

--- a/internal/parser/testdata/cursor-ide-null-values.sql
+++ b/internal/parser/testdata/cursor-ide-null-values.sql
@@ -1,48 +1,10 @@
--- Reporter artifact, kenn-io/agentsview#1676
--- Captured verbatim from https://github.com/kenn-io/agentsview/issues/1676
--- by hankel-ai, 2026-09-08T21:45:14Z.
---
--- Version: agentsview v0.42.0 (commit ff8fb4e8, built 2026-09-01T19:35:44Z),
--- Windows, daemon started as `serve --background --no-browser`.
---
--- Reported symptom, verbatim:
---
---   2026/09/07 19:52:35 sync error: decoding cursor IDE composer 1bf6b690-…: jsontext: unexpected EOF
---   … repeated every ~5s …
---   ERROR: startup sync worker ran but did not complete: startup worker pass reported failed
---   (surfacing incomplete pass; not re-syncing in process)
---
---   332/332 sessions (100%) · 43 messages   fatal: sync worker startup: failed
---
--- 13,734 occurrences of that line accumulated in debug.log over about 20 hours.
---
--- Reported root cause, verbatim: the offending record is not corrupt or
--- truncated, the value is NULL. Reading
--- %APPDATA%\Cursor\User\globalStorage\state.vscdb directly:
---
---   table = cursorDiskKV
---   key   = composerData:1bf6b690-2756-4be9-8cfd-033354f0e040
---   value = NULL
---
--- Distribution: 64 rows with a NULL value out of 2,189 in cursorDiskKV.
--- 2 composerData: keys and 62 bubbleId: keys. Only the first is ever logged,
--- because the pass gives up there.
---
--- Reported workaround, verbatim:
---
---   DELETE FROM cursorDiskKV WHERE value IS NULL;
---
--- Reported reproduce step, verbatim: insert a NULL-valued composerData: row
--- into cursorDiskKV in a state.vscdb under a cursor-ide root and start the
--- daemon.
---
--- Applied on top of a cursorDiskKV table the existing test helpers build.
--- Keyed by prefix so internal/parser and internal/sync tests load the same
--- file without hardcoding each other's composer IDs, following
--- internal/parser/testdata/zed-legacy-threads.sql.
+-- Synthetic reproduction of https://github.com/kenn-io/agentsview/issues/1676.
+-- Applies NULL composer and bubble values to a cursorDiskKV table built by
+-- the test helper. All identifiers are synthetic; nullvalue-* bubbles are
+-- selected by prefix so the fixture does not depend on sibling composer IDs.
 
 INSERT INTO cursorDiskKV (key, value)
-VALUES ('composerData:1bf6b690-2756-4be9-8cfd-033354f0e040', NULL);
+VALUES ('composerData:null-value-composer', NULL);
 
 UPDATE cursorDiskKV SET value = NULL
 WHERE key LIKE 'bubbleId:%:nullvalue-%';

--- a/internal/parser/testdata/cursor-ide-null-values.sql
+++ b/internal/parser/testdata/cursor-ide-null-values.sql
@@ -1,0 +1,48 @@
+-- Reporter artifact, kenn-io/agentsview#1676
+-- Captured verbatim from https://github.com/kenn-io/agentsview/issues/1676
+-- by hankel-ai, 2026-09-08T21:45:14Z.
+--
+-- Version: agentsview v0.42.0 (commit ff8fb4e8, built 2026-09-01T19:35:44Z),
+-- Windows, daemon started as `serve --background --no-browser`.
+--
+-- Reported symptom, verbatim:
+--
+--   2026/09/07 19:52:35 sync error: decoding cursor IDE composer 1bf6b690-…: jsontext: unexpected EOF
+--   … repeated every ~5s …
+--   ERROR: startup sync worker ran but did not complete: startup worker pass reported failed
+--   (surfacing incomplete pass; not re-syncing in process)
+--
+--   332/332 sessions (100%) · 43 messages   fatal: sync worker startup: failed
+--
+-- 13,734 occurrences of that line accumulated in debug.log over about 20 hours.
+--
+-- Reported root cause, verbatim: the offending record is not corrupt or
+-- truncated, the value is NULL. Reading
+-- %APPDATA%\Cursor\User\globalStorage\state.vscdb directly:
+--
+--   table = cursorDiskKV
+--   key   = composerData:1bf6b690-2756-4be9-8cfd-033354f0e040
+--   value = NULL
+--
+-- Distribution: 64 rows with a NULL value out of 2,189 in cursorDiskKV.
+-- 2 composerData: keys and 62 bubbleId: keys. Only the first is ever logged,
+-- because the pass gives up there.
+--
+-- Reported workaround, verbatim:
+--
+--   DELETE FROM cursorDiskKV WHERE value IS NULL;
+--
+-- Reported reproduce step, verbatim: insert a NULL-valued composerData: row
+-- into cursorDiskKV in a state.vscdb under a cursor-ide root and start the
+-- daemon.
+--
+-- Applied on top of a cursorDiskKV table the existing test helpers build.
+-- Keyed by prefix so internal/parser and internal/sync tests load the same
+-- file without hardcoding each other's composer IDs, following
+-- internal/parser/testdata/zed-legacy-threads.sql.
+
+INSERT INTO cursorDiskKV (key, value)
+VALUES ('composerData:1bf6b690-2756-4be9-8cfd-033354f0e040', NULL);
+
+UPDATE cursorDiskKV SET value = NULL
+WHERE key LIKE 'bubbleId:%:nullvalue-%';

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -831,3 +831,107 @@ func TestSyncAllCursorIDEReplacedDatabaseFileReparses(t *testing.T) {
 	assert.Equal(t, "howdy", *sess.FirstMessage,
 		"a replaced database file must miss the skip cache and reparse")
 }
+
+// TestSyncAllCursorIDENullValueRowsDoNotFailThePass reproduces
+// kenn-io/agentsview#1676: a cursorDiskKV row with a NULL value must not fail
+// the whole cursor-ide pass. It loads the reporter's captured artifact
+// verbatim, applied on top of two healthy sibling composers built by the
+// existing test helper.
+func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{
+		{
+			id: "sibling-a-composer", name: "Sibling A",
+			createdAt: 1782026756842, updatedAt: 1782026791522,
+			bubbles: []cursorIDESyncBubble{{
+				id: "b1", bubbleType: 1, text: "sibling a content",
+				createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+		{
+			id: "sibling-b-composer", name: "Sibling B",
+			createdAt: 1782026756842, updatedAt: 1782026791522,
+			bubbles: []cursorIDESyncBubble{{
+				id: "b1", bubbleType: 1, text: "sibling b content",
+				createdAt: "2026-06-21T07:27:29.606Z",
+			}},
+		},
+	})
+
+	artifact, err := os.ReadFile(
+		filepath.Join("..", "parser", "testdata", "cursor-ide-null-values.sql"),
+	)
+	require.NoError(t, err)
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(string(artifact))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	engine, database := newCursorIDESyncEngine(t, root)
+	stats := engine.SyncAll(t.Context(), nil)
+	require.True(t, stats.ProcessingComplete(),
+		"the reporter's NULL cursorDiskKV rows must not fail the sync pass: %+v", stats)
+	assert.Zero(t, stats.Failed)
+	assert.Equal(t, 2, stats.Synced,
+		"both healthy sibling composers must be synced past the husk rows")
+
+	a, err := database.GetSessionFull(t.Context(), "cursor-ide:sibling-a-composer")
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	assert.Equal(t, 1, a.MessageCount)
+	assert.Zero(t, a.ParserMalformedLines)
+	b, err := database.GetSessionFull(t.Context(), "cursor-ide:sibling-b-composer")
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	assert.Equal(t, 1, b.MessageCount)
+	assert.Zero(t, b.ParserMalformedLines)
+
+	_, hasCursorIDE := stats.Anomalies.MalformedLinesByAgent["cursor-ide"]
+	assert.False(t, hasCursorIDE,
+		"the husk rows must be published through source-missing and truncation, not a counter")
+}
+
+// TestSyncAllCursorIDENullComposerKeepsArchivedTranscript covers P5: a live
+// composer whose value later goes NULL must preserve the archived transcript
+// through the recoverable source-missing seam, not fail the pass or drop the
+// session.
+func TestSyncAllCursorIDENullComposerKeepsArchivedTranscript(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state.vscdb")
+	createCursorIDEStateDB(t, dbPath, []cursorIDESyncComposer{{
+		id: "goes-null-composer", name: "Goes null chat",
+		createdAt: 1782026756842, updatedAt: 1782026791522,
+		bubbles: []cursorIDESyncBubble{{
+			id: "b1", bubbleType: 1, text: "hello",
+			createdAt: "2026-06-21T07:27:29.606Z",
+		}},
+	}})
+	engine, database := newCursorIDESyncEngine(t, root)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	before, err := database.GetSessionFull(t.Context(), "cursor-ide:goes-null-composer")
+	require.NoError(t, err)
+	require.NotNil(t, before)
+
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(
+		`UPDATE cursorDiskKV SET value = NULL WHERE key = ?`,
+		"composerData:goes-null-composer",
+	)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	stats := engine.SyncAll(t.Context(), nil)
+	require.True(t, stats.ProcessingComplete(),
+		"a composer value going NULL must not fail the pass: %+v", stats)
+
+	archived, err := database.GetSessionFull(t.Context(), "cursor-ide:goes-null-composer")
+	require.NoError(t, err)
+	assertSourceMissingState(t, archived)
+	assert.Equal(t, before.MessageCount, archived.MessageCount,
+		"a NULL composer value must not truncate the archived transcript")
+	assert.False(t, database.IsSessionExcluded("cursor-ide:goes-null-composer"),
+		"the archived session must not be permanently deleted")
+}

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -832,15 +832,9 @@ func TestSyncAllCursorIDEReplacedDatabaseFileReparses(t *testing.T) {
 		"a replaced database file must miss the skip cache and reparse")
 }
 
-// TestSyncAllCursorIDENullValueRowsDoNotFailThePass reproduces
-// kenn-io/agentsview#1676: a cursorDiskKV row with a NULL value must not fail
-// the whole cursor-ide pass. It loads the reporter's captured artifact
-// verbatim, applied on top of two healthy sibling composers built by the
-// existing test helper. Sibling A additionally carries a bubble id matching
-// the fixture's own "bubbleId:%:nullvalue-%" UPDATE, so the artifact's second
-// statement (not just its first, the NULL composerData INSERT) actually
-// nulls a stored row: without this, the fixture's bubble-level UPDATE matches
-// zero rows and the test proves only the NULL-composer half of the fix.
+// TestSyncAllCursorIDENullValueRowsDoNotFailThePass uses a synthetic fixture
+// based on issue #1676. A NULL composer and a NULL bubble in sibling A must
+// leave both siblings available and the sync pass complete.
 func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
 	root := t.TempDir()
 	dbPath := filepath.Join(root, "state.vscdb")
@@ -855,7 +849,7 @@ func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
 				},
 				{
 					// Matches the fixture's "bubbleId:%:nullvalue-%" UPDATE, so
-					// applying the artifact nulls this row's value.
+					// applying the fixture nulls this row's value.
 					id: "nullvalue-1", bubbleType: 2, text: "will be nulled by the fixture",
 					createdAt: "2026-06-21T07:27:31.522Z",
 				},
@@ -871,13 +865,13 @@ func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
 		},
 	})
 
-	artifact, err := os.ReadFile(
+	fixture, err := os.ReadFile(
 		filepath.Join("..", "parser", "testdata", "cursor-ide-null-values.sql"),
 	)
 	require.NoError(t, err)
 	writer, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
-	_, err = writer.Exec(string(artifact))
+	_, err = writer.Exec(string(fixture))
 	require.NoError(t, err)
 	// Confirm the fixture's own UPDATE actually matched sibling A's
 	// nullvalue-1 bubble, so this test cannot silently regress to proving
@@ -894,7 +888,7 @@ func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
 	engine, database := newCursorIDESyncEngine(t, root)
 	stats := engine.SyncAll(t.Context(), nil)
 	require.True(t, stats.ProcessingComplete(),
-		"the reporter's NULL cursorDiskKV rows must not fail the sync pass: %+v", stats)
+		"NULL cursorDiskKV rows must not fail the sync pass: %+v", stats)
 	assert.Zero(t, stats.Failed)
 	assert.Equal(t, 2, stats.Synced,
 		"both healthy sibling composers must be synced past the husk rows")

--- a/internal/sync/cursor_ide_integration_test.go
+++ b/internal/sync/cursor_ide_integration_test.go
@@ -836,7 +836,11 @@ func TestSyncAllCursorIDEReplacedDatabaseFileReparses(t *testing.T) {
 // kenn-io/agentsview#1676: a cursorDiskKV row with a NULL value must not fail
 // the whole cursor-ide pass. It loads the reporter's captured artifact
 // verbatim, applied on top of two healthy sibling composers built by the
-// existing test helper.
+// existing test helper. Sibling A additionally carries a bubble id matching
+// the fixture's own "bubbleId:%:nullvalue-%" UPDATE, so the artifact's second
+// statement (not just its first, the NULL composerData INSERT) actually
+// nulls a stored row: without this, the fixture's bubble-level UPDATE matches
+// zero rows and the test proves only the NULL-composer half of the fix.
 func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
 	root := t.TempDir()
 	dbPath := filepath.Join(root, "state.vscdb")
@@ -844,10 +848,18 @@ func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
 		{
 			id: "sibling-a-composer", name: "Sibling A",
 			createdAt: 1782026756842, updatedAt: 1782026791522,
-			bubbles: []cursorIDESyncBubble{{
-				id: "b1", bubbleType: 1, text: "sibling a content",
-				createdAt: "2026-06-21T07:27:29.606Z",
-			}},
+			bubbles: []cursorIDESyncBubble{
+				{
+					id: "b1", bubbleType: 1, text: "sibling a content",
+					createdAt: "2026-06-21T07:27:29.606Z",
+				},
+				{
+					// Matches the fixture's "bubbleId:%:nullvalue-%" UPDATE, so
+					// applying the artifact nulls this row's value.
+					id: "nullvalue-1", bubbleType: 2, text: "will be nulled by the fixture",
+					createdAt: "2026-06-21T07:27:31.522Z",
+				},
+			},
 		},
 		{
 			id: "sibling-b-composer", name: "Sibling B",
@@ -867,6 +879,16 @@ func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
 	require.NoError(t, err)
 	_, err = writer.Exec(string(artifact))
 	require.NoError(t, err)
+	// Confirm the fixture's own UPDATE actually matched sibling A's
+	// nullvalue-1 bubble, so this test cannot silently regress to proving
+	// only the NULL-composer half again.
+	var nulledValue sql.NullString
+	require.NoError(t, writer.QueryRow(
+		`SELECT value FROM cursorDiskKV WHERE key = ?`,
+		"bubbleId:sibling-a-composer:nullvalue-1",
+	).Scan(&nulledValue))
+	require.False(t, nulledValue.Valid,
+		"the fixture's bubbleId:%%:nullvalue-%% UPDATE must have nulled this row")
 	require.NoError(t, writer.Close())
 
 	engine, database := newCursorIDESyncEngine(t, root)
@@ -880,12 +902,20 @@ func TestSyncAllCursorIDENullValueRowsDoNotFailThePass(t *testing.T) {
 	a, err := database.GetSessionFull(t.Context(), "cursor-ide:sibling-a-composer")
 	require.NoError(t, err)
 	require.NotNil(t, a)
-	assert.Equal(t, 1, a.MessageCount)
+	assert.Equal(t, 1, a.MessageCount,
+		"sibling A's nulled nullvalue-1 bubble must not surface as a message")
+	assert.True(t, a.IsTruncated,
+		"sibling A must be flagged truncated: the fixture nulled one of its two bubbles")
+	require.NotNil(t, a.FirstMessage)
+	assert.Equal(t, "sibling a content", *a.FirstMessage,
+		"sibling A's surviving turn must still carry its original content")
 	assert.Zero(t, a.ParserMalformedLines)
 	b, err := database.GetSessionFull(t.Context(), "cursor-ide:sibling-b-composer")
 	require.NoError(t, err)
 	require.NotNil(t, b)
 	assert.Equal(t, 1, b.MessageCount)
+	assert.False(t, b.IsTruncated,
+		"sibling B is untouched by the fixture and must not be flagged truncated")
 	assert.Zero(t, b.ParserMalformedLines)
 
 	_, hasCursorIDE := stats.Anomalies.MalformedLinesByAgent["cursor-ide"]


### PR DESCRIPTION
A Cursor IDE database with an empty `cursorDiskKV` row no longer fails the sync worker pass. One such row used to abort the whole parse with `jsontext: unexpected EOF`, dropping every other conversation and reporting `sync worker startup: failed` at each start, with no in-app fix.

A SQL `NULL` scans into a nil byte slice and a zero-length blob into an empty one, and neither is `sql.ErrNoRows`, so both reached the JSON decoder. The composer and bubble readers now treat a row holding no bytes as absent rather than malformed; a row with even one byte still fails loudly.

A composer with no bytes yields no result, and its session moves to the recoverable source-missing state with its transcript intact. A bubble with no bytes becomes one transcript gap, flagged truncated so the engine still refuses to drop an archived message.

The guard covers both `NULL` and empty blobs, since an empty value hits the identical error with the identical reach. It adds no anomaly counter, because that branch also covers a bubble row that never existed, so counting there would move a published number for databases with no empty rows.

Closes #1676
