### PR TITLE
feat(db): add db migrate --images to move tool-result images into the asset store

### DIFF
--- a/cmd/agentsview/db_compact.go
+++ b/cmd/agentsview/db_compact.go
@@ -23,6 +23,7 @@ func newDBCommand() *cobra.Command {
 	}
 	cmd.AddCommand(newDBCompactCommand())
 	cmd.AddCommand(newDBStripCommand())
+	cmd.AddCommand(newDBMigrateCommand())
 	return cmd
 }
 

--- a/cmd/agentsview/db_migrate.go
+++ b/cmd/agentsview/db_migrate.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/agentsview/internal/assets"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func newDBMigrateCommand() *cobra.Command {
+	var images bool
+	var project, before string
+	var dryRun, yes bool
+	cmd := &cobra.Command{
+		Use:          "migrate",
+		Short:        "Move retained inline tool-result images into the asset store",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !images {
+				return fmt.Errorf("db migrate requires --images")
+			}
+			jsonOutput := outputFormat(cmd) == "json"
+			if jsonOutput && !yes && !dryRun {
+				return fmt.Errorf("--format json requires --yes for db migrate --images")
+			}
+			cfg, err := config.LoadReadOnly()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			filter := db.StripImagesFilter{Project: project, Before: before}
+			if dryRun {
+				report, err := previewDBMigrate(cmd.Context(), cfg, filter)
+				if err != nil {
+					return err
+				}
+				return writeDBMigrateReport(cmd.OutOrStdout(), report, jsonOutput, true)
+			}
+			if !yes {
+				report, err := previewDBMigrate(cmd.Context(), cfg, filter)
+				if err != nil {
+					return err
+				}
+				if err := writeDBMigrateReport(cmd.ErrOrStderr(), report, false, true); err != nil {
+					return err
+				}
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"Migrated images require a backup of the assets directory beside the archive.")
+				if !confirm(cmd.InOrStdin(), cmd.ErrOrStderr(),
+					fmt.Sprintf("Migrate images from %d sessions?", report.Sessions)) {
+					fmt.Fprintln(cmd.ErrOrStderr(), "Aborted.")
+					return nil
+				}
+			}
+			report, err := runDBMigrate(cmd.Context(), cfg, filter)
+			if err != nil {
+				if report.Sessions > 0 {
+					writeDBMigratePartialReport(cmd.ErrOrStderr(), report)
+				}
+				return err
+			}
+			return writeDBMigrateReport(cmd.OutOrStdout(), report, jsonOutput, false)
+		},
+	}
+	cmd.Flags().BoolVar(&images, "images", false, "Migrate inline image payloads into the asset store")
+	cmd.Flags().StringVar(&project, "project", "", "Sessions whose project contains this substring")
+	cmd.Flags().StringVar(&before, "before", "", "Sessions that ended before this date (YYYY-MM-DD)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report matching rows without changing the archive")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip the confirmation prompt")
+	registerFormatFlags(cmd.Flags())
+	return cmd
+}
+
+func previewDBMigrate(
+	ctx context.Context, cfg config.Config, filter db.StripImagesFilter,
+) (db.StripImagesReport, error) {
+	database, err := openReadOnlyDB(cfg)
+	if err != nil {
+		return db.StripImagesReport{}, fmt.Errorf("opening archive for image migration preview: %w", err)
+	}
+	defer database.Close()
+	report, err := database.PreviewMigrateToolImages(ctx, filter)
+	if err != nil {
+		return db.StripImagesReport{}, fmt.Errorf("previewing image migration: %w", err)
+	}
+	return report, nil
+}
+
+func runDBMigrate(
+	ctx context.Context, cfg config.Config, filter db.StripImagesFilter,
+) (db.StripImagesReport, error) {
+	database, lock, err := openWriteDB(ctx, cfg)
+	if err != nil {
+		return db.StripImagesReport{}, fmt.Errorf("opening archive for image migration: %w", err)
+	}
+	defer closeWriteDB(database, lock)
+	assetsDir := filepath.Join(cfg.DataDir, "assets")
+	put := func(mediaType string, body []byte) (string, bool, error) {
+		return assets.Put(assetsDir, mediaType, body)
+	}
+	report, err := database.MigrateToolImages(ctx, filter, put)
+	if err != nil {
+		// Return the partial report so the caller can show committed work.
+		return report, fmt.Errorf("migrating images: %w", err)
+	}
+	return report, nil
+}
+
+func writeDBMigrateReport(
+	out io.Writer, report db.StripImagesReport, jsonOutput, preview bool,
+) error {
+	if jsonOutput {
+		return json.NewEncoder(out).Encode(report)
+	}
+	if preview {
+		fmt.Fprintln(out, "Image migration preview.")
+	} else {
+		fmt.Fprintln(out, "Image migration completed.")
+	}
+	writeDBMigrateCounts(out, report)
+	if !preview {
+		fmt.Fprintln(out, "Migrated images live in the assets directory beside the archive; back them up together.")
+		fmt.Fprintln(out, "Run db compact separately to measure SQLite file-space reclamation.")
+	}
+	return nil
+}
+
+// writeDBMigratePartialReport describes the work a failed run committed before
+// it stopped. The run neither completed nor left the archive as it found it, so
+// the counts arrive under their own header and without the tips that only make
+// sense once every selected session is done.
+func writeDBMigratePartialReport(out io.Writer, report db.StripImagesReport) {
+	fmt.Fprintln(out, "Image migration stopped early. Counts below cover the sessions that committed:")
+	writeDBMigrateCounts(out, report)
+}
+
+func writeDBMigrateCounts(out io.Writer, report db.StripImagesReport) {
+	fmt.Fprintf(out, "  Sessions: %d\n", report.Sessions)
+	fmt.Fprintf(out, "  Changed: %d\n", report.Changed)
+	fmt.Fprintf(out, "  Image payloads: %d\n", report.Payloads)
+	fmt.Fprintf(out, "  Stored content bytes: %s\n", formatBytes(report.StoredBytes))
+	fmt.Fprintf(out, "  Decoded image bytes: %s\n", formatBytes(report.DecodedBytes))
+	if len(report.Projects) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "By project:")
+	for _, project := range report.Projects {
+		fmt.Fprintf(out,
+			"  %s: %d sessions, %d changed, %d payloads, %s stored, %s decoded\n",
+			project.Project, project.Sessions, project.Changed, project.Payloads,
+			formatBytes(project.StoredBytes), formatBytes(project.DecodedBytes))
+	}
+}

--- a/cmd/agentsview/db_migrate.go
+++ b/cmd/agentsview/db_migrate.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -14,67 +12,10 @@ import (
 )
 
 func newDBMigrateCommand() *cobra.Command {
-	var images bool
-	var project, before string
-	var dryRun, yes bool
-	cmd := &cobra.Command{
-		Use:          "migrate",
-		Short:        "Move retained inline tool-result images into the asset store",
-		SilenceUsage: true,
-		Args:         cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if !images {
-				return fmt.Errorf("db migrate requires --images")
-			}
-			jsonOutput := outputFormat(cmd) == "json"
-			if jsonOutput && !yes && !dryRun {
-				return fmt.Errorf("--format json requires --yes for db migrate --images")
-			}
-			cfg, err := config.LoadReadOnly()
-			if err != nil {
-				return fmt.Errorf("loading config: %w", err)
-			}
-			filter := db.StripImagesFilter{Project: project, Before: before}
-			if dryRun {
-				report, err := previewDBMigrate(cmd.Context(), cfg, filter)
-				if err != nil {
-					return err
-				}
-				return writeDBMigrateReport(cmd.OutOrStdout(), report, jsonOutput, true)
-			}
-			if !yes {
-				report, err := previewDBMigrate(cmd.Context(), cfg, filter)
-				if err != nil {
-					return err
-				}
-				if err := writeDBMigrateReport(cmd.ErrOrStderr(), report, false, true); err != nil {
-					return err
-				}
-				fmt.Fprintln(cmd.ErrOrStderr(),
-					"Migrated images require a backup of the assets directory beside the archive.")
-				if !confirm(cmd.InOrStdin(), cmd.ErrOrStderr(),
-					fmt.Sprintf("Migrate images from %d sessions?", report.Sessions)) {
-					fmt.Fprintln(cmd.ErrOrStderr(), "Aborted.")
-					return nil
-				}
-			}
-			report, err := runDBMigrate(cmd.Context(), cfg, filter)
-			if err != nil {
-				if report.Sessions > 0 {
-					writeDBMigratePartialReport(cmd.ErrOrStderr(), report)
-				}
-				return err
-			}
-			return writeDBMigrateReport(cmd.OutOrStdout(), report, jsonOutput, false)
-		},
-	}
-	cmd.Flags().BoolVar(&images, "images", false, "Migrate inline image payloads into the asset store")
-	cmd.Flags().StringVar(&project, "project", "", "Sessions whose project contains this substring")
-	cmd.Flags().StringVar(&before, "before", "", "Sessions that ended before this date (YYYY-MM-DD)")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report matching rows without changing the archive")
-	cmd.Flags().BoolVar(&yes, "yes", false, "Skip the confirmation prompt")
-	registerFormatFlags(cmd.Flags())
-	return cmd
+	return newDBImageCommand(
+		"Migrate", "migration", "Move retained inline tool-result images into the asset store",
+		"Migrate inline image payloads into the asset store", previewDBMigrate, runDBMigrate,
+	)
 }
 
 func previewDBMigrate(
@@ -110,50 +51,4 @@ func runDBMigrate(
 		return report, fmt.Errorf("migrating images: %w", err)
 	}
 	return report, nil
-}
-
-func writeDBMigrateReport(
-	out io.Writer, report db.StripImagesReport, jsonOutput, preview bool,
-) error {
-	if jsonOutput {
-		return json.NewEncoder(out).Encode(report)
-	}
-	if preview {
-		fmt.Fprintln(out, "Image migration preview.")
-	} else {
-		fmt.Fprintln(out, "Image migration completed.")
-	}
-	writeDBMigrateCounts(out, report)
-	if !preview {
-		fmt.Fprintln(out, "Migrated images live in the assets directory beside the archive; back them up together.")
-		fmt.Fprintln(out, "Run db compact separately to measure SQLite file-space reclamation.")
-	}
-	return nil
-}
-
-// writeDBMigratePartialReport describes the work a failed run committed before
-// it stopped. The run neither completed nor left the archive as it found it, so
-// the counts arrive under their own header and without the tips that only make
-// sense once every selected session is done.
-func writeDBMigratePartialReport(out io.Writer, report db.StripImagesReport) {
-	fmt.Fprintln(out, "Image migration stopped early. Counts below cover the sessions that committed:")
-	writeDBMigrateCounts(out, report)
-}
-
-func writeDBMigrateCounts(out io.Writer, report db.StripImagesReport) {
-	fmt.Fprintf(out, "  Sessions: %d\n", report.Sessions)
-	fmt.Fprintf(out, "  Changed: %d\n", report.Changed)
-	fmt.Fprintf(out, "  Image payloads: %d\n", report.Payloads)
-	fmt.Fprintf(out, "  Stored content bytes: %s\n", formatBytes(report.StoredBytes))
-	fmt.Fprintf(out, "  Decoded image bytes: %s\n", formatBytes(report.DecodedBytes))
-	if len(report.Projects) == 0 {
-		return
-	}
-	fmt.Fprintln(out, "By project:")
-	for _, project := range report.Projects {
-		fmt.Fprintf(out,
-			"  %s: %d sessions, %d changed, %d payloads, %s stored, %s decoded\n",
-			project.Project, project.Sessions, project.Changed, project.Payloads,
-			formatBytes(project.StoredBytes), formatBytes(project.DecodedBytes))
-	}
 }

--- a/cmd/agentsview/db_migrate_test.go
+++ b/cmd/agentsview/db_migrate_test.go
@@ -12,12 +12,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/agentsview/internal/assets"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
-	"go.kenn.io/agentsview/internal/dbtest"
 )
 
 func TestDBMigrateJSONRequiresYes(t *testing.T) {
@@ -124,53 +123,69 @@ func TestDBMigrateInteractiveConfirmation(t *testing.T) {
 	assert.DirExists(t, assetsDir)
 }
 
-// TestDBMigratePartialFailureReportsCommittedWork verifies the failure path
-// header. A run that dies on a later session must name the committed counts
-// rather than claim completion, and must not print the follow-up tips.
-func TestDBMigratePartialFailureReportsCommittedWork(t *testing.T) {
-	dataDir := testDataDir(t)
-	cfg, err := config.LoadReadOnly()
-	require.NoError(t, err)
-	database, err := db.Open(cfg.DBPath)
-	require.NoError(t, err)
-	for _, id := range []string{"mig-pf-a", "mig-pf-b"} {
-		insertSessionForStripTest(t, database, id)
-		require.NoError(t, database.InsertMessages([]db.Message{commandImageMessage(id)}))
+func TestDBStripAndMigratePartialFailureReportsCommittedWork(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		command func() *cobra.Command
+		title   string
+	}{
+		{"strip", newDBStripCommand, "Image strip"},
+		{"migrate", newDBMigrateCommand, "Image migration"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testDataDir(t)
+			cfg, err := config.LoadReadOnly()
+			require.NoError(t, err)
+			database, err := db.Open(cfg.DBPath)
+			require.NoError(t, err)
+			for _, id := range []string{"mig-pf-a", "mig-pf-b"} {
+				insertSessionForStripTest(t, database, id)
+				require.NoError(t, database.InsertMessages([]db.Message{commandImageMessage(id)}))
+			}
+			// Sessions run in id order, one transaction each. Aborting the second
+			// session's revision bump commits the first and stops the run mid-selection.
+			require.NoError(t, database.Update(func(tx *sql.Tx) error {
+				_, err := tx.Exec(`
+					CREATE TRIGGER fail_mig_pf_b
+					AFTER UPDATE OF transcript_revision ON sessions
+					WHEN NEW.id = 'mig-pf-b'
+					BEGIN
+						SELECT RAISE(ABORT, 'forced failure for mig-pf-b');
+					END`)
+				return err
+			}))
+			require.NoError(t, database.Close())
+
+			cmd := tt.command()
+			cmd.SetArgs([]string{"--images", "--yes"})
+			var output, errOutput bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&errOutput)
+			require.Error(t, cmd.Execute())
+
+			assert.Contains(t, errOutput.String(), tt.title+" stopped early.")
+			assert.Contains(t, errOutput.String(), "Sessions: 1")
+			assert.Contains(t, errOutput.String(), "Changed: 1")
+			assert.NotContains(t, errOutput.String(), tt.title+" completed.")
+			assert.NotContains(t, errOutput.String(), "Run db compact separately")
+			assert.NotContains(t, output.String(), tt.title+" completed.")
+			t.Logf("partial report:\n%s", errOutput.String())
+			database, err = db.Open(cfg.DBPath)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, database.Close()) }()
+			committed, err := database.GetAllMessages(t.Context(), "mig-pf-a")
+			require.NoError(t, err)
+			require.Len(t, committed, 1)
+			assert.NotContains(t, committed[0].ToolCalls[0].ResultContent, "input_image")
+			failed, err := database.GetAllMessages(t.Context(), "mig-pf-b")
+			require.NoError(t, err)
+			require.Len(t, failed, 1)
+			assert.Contains(t, failed[0].ToolCalls[0].ResultContent, "input_image")
+		})
 	}
-	// Sessions run in id order, one transaction each. Aborting the second
-	// session's revision bump commits the first and stops the run mid-selection.
-	require.NoError(t, database.Update(func(tx *sql.Tx) error {
-		_, err := tx.Exec(`
-			CREATE TRIGGER fail_mig_pf_b
-			AFTER UPDATE OF transcript_revision ON sessions
-			WHEN NEW.id = 'mig-pf-b'
-			BEGIN
-				SELECT RAISE(ABORT, 'forced failure for mig-pf-b');
-			END`)
-		return err
-	}))
-	require.NoError(t, database.Close())
-
-	cmd := newDBMigrateCommand()
-	cmd.SetArgs([]string{"--images", "--yes"})
-	var output, errOutput bytes.Buffer
-	cmd.SetOut(&output)
-	cmd.SetErr(&errOutput)
-	require.Error(t, cmd.Execute())
-
-	assert.Contains(t, errOutput.String(), "Image migration stopped early.")
-	assert.Contains(t, errOutput.String(), "Sessions: 1")
-	assert.NotContains(t, errOutput.String(), "Image migration completed.")
-	assert.NotContains(t, errOutput.String(), "Run db compact separately")
-	assert.NotContains(t, output.String(), "Image migration completed.")
-	assert.DirExists(t, filepath.Join(dataDir, "assets"))
-	t.Logf("partial report:\n%s", errOutput.String())
 }
 
-// TestDBMigrateReferenceMatchesAssetsPut checks the stored sha256 field against
-// the file the real assets.Put wrote. The db-level equivalent injects a put that
-// names files by the same hash the block records, so only a command-level run
-// can catch the field and the asset store disagreeing.
+// The archive reference and digest must identify the bytes in the asset store.
 func TestDBMigrateReferenceMatchesAssetsPut(t *testing.T) {
 	dataDir := testDataDir(t)
 	seedMigrateCommandArchive(t)
@@ -197,48 +212,6 @@ func TestDBMigrateReferenceMatchesAssetsPut(t *testing.T) {
 		"sha256 must be the digest of the bytes assets.Put stored")
 	assert.Equal(t, "asset://"+entries[0].Name(), ref)
 	assert.Equal(t, sha256Hex+".png", entries[0].Name())
-}
-
-func TestDBMigratePreservesSources(t *testing.T) {
-	database := dbtest.OpenTestDB(t)
-	srcDir := t.TempDir()
-	path := filepath.Join(srcDir, "provider.jsonl")
-	sourcePath := path
-	insertSessionForStripTest(t, database, "mig-source", func(s *db.Session) {
-		s.FilePath = &sourcePath
-	})
-	require.NoError(t, database.InsertMessages([]db.Message{commandImageMessage("mig-source")}))
-	database.SetToolResultImages(config.ToolResultImagesKeep)
-
-	transcriptBefore := "provider transcript remains byte-for-byte unchanged"
-	require.NoError(t, os.WriteFile(path, []byte(transcriptBefore), 0o600))
-
-	// Standalone GIF beside the archive: migration must not open any write handle
-	// to standalone image files. PI-4 requirement.
-	gifBody := []byte("GIF89a") // minimal GIF header
-	gifPath := filepath.Join(srcDir, "photo.gif")
-	require.NoError(t, os.WriteFile(gifPath, gifBody, 0o600))
-
-	assetsDir := t.TempDir()
-	put := func(mediaType string, body []byte) (string, bool, error) {
-		return assets.Put(assetsDir, mediaType, body)
-	}
-	report, err := database.MigrateToolImages(context.Background(), db.StripImagesFilter{}, put)
-	require.NoError(t, err)
-	assert.Equal(t, 1, report.Changed)
-
-	// Provider transcript stays byte-identical.
-	transcriptAfter, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Equal(t, transcriptBefore, string(transcriptAfter))
-
-	// Standalone GIF stays byte-identical.
-	gifAfter, err := os.ReadFile(gifPath)
-	require.NoError(t, err)
-	assert.Equal(t, gifBody, gifAfter)
-
-	t.Logf("0 bytes changed in either file: transcript before=%d bytes, after=%d; gif before=%d bytes, after=%d",
-		len(transcriptBefore), len(transcriptAfter), len(gifBody), len(gifAfter))
 }
 
 // TestDBMigrateReachesTrashedAndOrphanRows verifies that the command migrates
@@ -318,11 +291,10 @@ func TestDBMigrateReachesTrashedAndOrphanRows(t *testing.T) {
 
 	// Count trashed-session event rows that were migrated.
 	var trashedMigrated int
-	_ = database2.Reader().QueryRow(`
+	require.NoError(t, database2.Reader().QueryRow(`
 		SELECT COUNT(*) FROM tool_result_events e
 		JOIN sessions s ON s.id = e.session_id
-		WHERE s.deleted_at IS NOT NULL AND e.content LIKE '%image_ref%'`).Scan(&trashedMigrated)
-	t.Logf("trashed-session event rows migrated: got %d", trashedMigrated)
+		WHERE s.deleted_at IS NOT NULL AND e.content LIKE '%image_ref%'`).Scan(&trashedMigrated))
 	assert.Equal(t, 1, trashedMigrated)
 }
 

--- a/cmd/agentsview/db_migrate_test.go
+++ b/cmd/agentsview/db_migrate_test.go
@@ -1,0 +1,399 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/assets"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+)
+
+func TestDBMigrateJSONRequiresYes(t *testing.T) {
+	testDataDir(t)
+
+	cmd := newDBMigrateCommand()
+	cmd.SetArgs(nil)
+	err := cmd.Execute()
+	require.EqualError(t, err, "db migrate requires --images")
+
+	cmd = newDBMigrateCommand()
+	cmd.SetArgs([]string{"--images", "--format", "json"})
+	err = cmd.Execute()
+	require.EqualError(t, err, "--format json requires --yes for db migrate --images")
+}
+
+func TestDBMigratePreviewClassifies(t *testing.T) {
+	dataDir := testDataDir(t)
+	seedMigrateCommandArchive(t)
+
+	cmd := newDBMigrateCommand()
+	cmd.SetArgs([]string{"--images", "--dry-run", "--format", "json"})
+	var preview bytes.Buffer
+	cmd.SetOut(&preview)
+	require.NoError(t, cmd.Execute())
+
+	var report db.StripImagesReport
+	require.NoError(t, json.Unmarshal(preview.Bytes(), &report))
+	assert.Equal(t, 1, report.Sessions)
+	assert.Equal(t, 1, report.Changed)
+	assert.Equal(t, int64(1), report.Payloads)
+	assert.Positive(t, report.StoredBytes)
+	assert.Positive(t, report.DecodedBytes)
+
+	// Archive must be unchanged after a dry-run.
+	assertMigrateCommandArchiveStillContainsImage(t)
+	// Assets directory must not be created by a dry-run.
+	assert.NoDirExists(t, filepath.Join(dataDir, "assets"))
+	t.Logf("0 files created during preview: assets dir exists=%v", false)
+}
+
+// TestDBMigrateJSONApply covers the --yes --format json apply branch: the JSON
+// report decodes with the expected session and payload counts, and the archive
+// really carries an asset:// reference afterward.
+func TestDBMigrateJSONApply(t *testing.T) {
+	dataDir := testDataDir(t)
+	seedMigrateCommandArchive(t)
+
+	cmd := newDBMigrateCommand()
+	cmd.SetArgs([]string{"--images", "--yes", "--format", "json"})
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	require.NoError(t, cmd.Execute())
+
+	var report db.StripImagesReport
+	require.NoError(t, json.Unmarshal(output.Bytes(), &report))
+	assert.Equal(t, 1, report.Sessions)
+	assert.Equal(t, 1, report.Changed)
+	assert.Equal(t, int64(1), report.Payloads)
+	assert.Equal(t, int64(len(`data:image/png;base64,AAEC`)), report.StoredBytes)
+	assert.Equal(t, int64(3), report.DecodedBytes)
+	require.Len(t, report.Projects, 1)
+	assert.Equal(t, 1, report.Projects[0].Changed)
+
+	assertMigrateCommandArchiveHasAssetRef(t)
+	assert.DirExists(t, filepath.Join(dataDir, "assets"))
+}
+
+// TestDBMigrateInteractiveConfirmation covers the interactive branch both ways.
+// Declining leaves the archive and the assets directory untouched, which is what
+// docs/commands.md promises, and both runs state the backup obligation.
+func TestDBMigrateInteractiveConfirmation(t *testing.T) {
+	dataDir := testDataDir(t)
+	seedMigrateCommandArchive(t)
+	assetsDir := filepath.Join(dataDir, "assets")
+	const backupLine = "Migrated images require a backup of the assets directory beside the archive."
+
+	cmd := newDBMigrateCommand()
+	cmd.SetArgs([]string{"--images"})
+	cmd.SetIn(strings.NewReader("n\n"))
+	var declined bytes.Buffer
+	cmd.SetErr(&declined)
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, declined.String(), "Image migration preview.")
+	assert.Contains(t, declined.String(), backupLine)
+	assert.Contains(t, declined.String(), "Aborted.")
+	assert.NotContains(t, declined.String(), "Image migration completed.")
+	assertMigrateCommandArchiveStillContainsImage(t)
+	assert.NoDirExists(t, assetsDir)
+
+	cmd = newDBMigrateCommand()
+	cmd.SetArgs([]string{"--images"})
+	cmd.SetIn(strings.NewReader("y\n"))
+	var accepted, acceptedErr bytes.Buffer
+	cmd.SetOut(&accepted)
+	cmd.SetErr(&acceptedErr)
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, acceptedErr.String(), backupLine)
+	assert.Contains(t, accepted.String(), "Image migration completed.")
+	assert.Contains(t, accepted.String(), "Changed: 1")
+	assertMigrateCommandArchiveHasAssetRef(t)
+	assert.DirExists(t, assetsDir)
+}
+
+// TestDBMigratePartialFailureReportsCommittedWork verifies the failure path
+// header. A run that dies on a later session must name the committed counts
+// rather than claim completion, and must not print the follow-up tips.
+func TestDBMigratePartialFailureReportsCommittedWork(t *testing.T) {
+	dataDir := testDataDir(t)
+	cfg, err := config.LoadReadOnly()
+	require.NoError(t, err)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	for _, id := range []string{"mig-pf-a", "mig-pf-b"} {
+		insertSessionForStripTest(t, database, id)
+		require.NoError(t, database.InsertMessages([]db.Message{commandImageMessage(id)}))
+	}
+	// Sessions run in id order, one transaction each. Aborting the second
+	// session's revision bump commits the first and stops the run mid-selection.
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			CREATE TRIGGER fail_mig_pf_b
+			AFTER UPDATE OF transcript_revision ON sessions
+			WHEN NEW.id = 'mig-pf-b'
+			BEGIN
+				SELECT RAISE(ABORT, 'forced failure for mig-pf-b');
+			END`)
+		return err
+	}))
+	require.NoError(t, database.Close())
+
+	cmd := newDBMigrateCommand()
+	cmd.SetArgs([]string{"--images", "--yes"})
+	var output, errOutput bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&errOutput)
+	require.Error(t, cmd.Execute())
+
+	assert.Contains(t, errOutput.String(), "Image migration stopped early.")
+	assert.Contains(t, errOutput.String(), "Sessions: 1")
+	assert.NotContains(t, errOutput.String(), "Image migration completed.")
+	assert.NotContains(t, errOutput.String(), "Run db compact separately")
+	assert.NotContains(t, output.String(), "Image migration completed.")
+	assert.DirExists(t, filepath.Join(dataDir, "assets"))
+	t.Logf("partial report:\n%s", errOutput.String())
+}
+
+// TestDBMigrateReferenceMatchesAssetsPut checks the stored sha256 field against
+// the file the real assets.Put wrote. The db-level equivalent injects a put that
+// names files by the same hash the block records, so only a command-level run
+// can catch the field and the asset store disagreeing.
+func TestDBMigrateReferenceMatchesAssetsPut(t *testing.T) {
+	dataDir := testDataDir(t)
+	seedMigrateCommandArchive(t)
+
+	cmd := newDBMigrateCommand()
+	cmd.SetArgs([]string{"--images", "--yes"})
+	cmd.SetOut(&bytes.Buffer{})
+	require.NoError(t, cmd.Execute())
+
+	block := migrateCommandImageBlock(t)
+	var ref, sha256Hex string
+	require.NoError(t, json.Unmarshal(block["image_ref"], &ref))
+	require.NoError(t, json.Unmarshal(block["sha256"], &sha256Hex))
+
+	assetsDir := filepath.Join(dataDir, "assets")
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	stored, err := os.ReadFile(filepath.Join(assetsDir, entries[0].Name()))
+	require.NoError(t, err)
+	sum := sha256.Sum256(stored)
+	assert.Equal(t, fmt.Sprintf("%x", sum[:]), sha256Hex,
+		"sha256 must be the digest of the bytes assets.Put stored")
+	assert.Equal(t, "asset://"+entries[0].Name(), ref)
+	assert.Equal(t, sha256Hex+".png", entries[0].Name())
+}
+
+func TestDBMigratePreservesSources(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	srcDir := t.TempDir()
+	path := filepath.Join(srcDir, "provider.jsonl")
+	sourcePath := path
+	insertSessionForStripTest(t, database, "mig-source", func(s *db.Session) {
+		s.FilePath = &sourcePath
+	})
+	require.NoError(t, database.InsertMessages([]db.Message{commandImageMessage("mig-source")}))
+	database.SetToolResultImages(config.ToolResultImagesKeep)
+
+	transcriptBefore := "provider transcript remains byte-for-byte unchanged"
+	require.NoError(t, os.WriteFile(path, []byte(transcriptBefore), 0o600))
+
+	// Standalone GIF beside the archive: migration must not open any write handle
+	// to standalone image files. PI-4 requirement.
+	gifBody := []byte("GIF89a") // minimal GIF header
+	gifPath := filepath.Join(srcDir, "photo.gif")
+	require.NoError(t, os.WriteFile(gifPath, gifBody, 0o600))
+
+	assetsDir := t.TempDir()
+	put := func(mediaType string, body []byte) (string, bool, error) {
+		return assets.Put(assetsDir, mediaType, body)
+	}
+	report, err := database.MigrateToolImages(context.Background(), db.StripImagesFilter{}, put)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Changed)
+
+	// Provider transcript stays byte-identical.
+	transcriptAfter, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, transcriptBefore, string(transcriptAfter))
+
+	// Standalone GIF stays byte-identical.
+	gifAfter, err := os.ReadFile(gifPath)
+	require.NoError(t, err)
+	assert.Equal(t, gifBody, gifAfter)
+
+	t.Logf("0 bytes changed in either file: transcript before=%d bytes, after=%d; gif before=%d bytes, after=%d",
+		len(transcriptBefore), len(transcriptAfter), len(gifBody), len(gifAfter))
+}
+
+// TestDBMigrateReachesTrashedAndOrphanRows verifies that the command migrates
+// sessions regardless of deletion state, and that a true orphan tool_result_events
+// row (no matching tool_calls row) is also migrated and counted.
+func TestDBMigrateReachesTrashedAndOrphanRows(t *testing.T) {
+	dataDir := testDataDir(t)
+	cfg, err := config.LoadReadOnly()
+	require.NoError(t, err)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+
+	// Session A: active.
+	insertSessionForStripTest(t, database, "mig-active")
+	require.NoError(t, database.InsertMessages([]db.Message{commandImageMessage("mig-active")}))
+
+	// Session B: trashed (soft-deleted).
+	insertSessionForStripTest(t, database, "mig-trashed")
+	require.NoError(t, database.InsertMessages([]db.Message{commandImageMessage("mig-trashed")}))
+	require.NoError(t, database.SoftDeleteSession("mig-trashed"))
+
+	// Session C: a true orphan tool_result_events row with no matching tool_calls row.
+	// This exercises the UNION ALL branch that reads tool_result_events directly.
+	insertSessionForStripTest(t, database, "mig-orphan")
+	orphanContent := `[{"type":"input_image","image_url":"data:image/gif;base64,AAEC"}]`
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			INSERT INTO tool_result_events
+				(session_id, tool_call_message_ordinal, call_index,
+				 tool_use_id, agent_id, subagent_session_id,
+				 source, status, content, content_length, timestamp, event_index)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			"mig-orphan", 9, 0, "toolu-orphan-cli", "agent-cli", "",
+			"subagent_notification", "completed", orphanContent, len(orphanContent),
+			"2026-01-01T00:00:00Z", 0,
+		)
+		return err
+	}))
+
+	require.NoError(t, database.Close())
+
+	cmd := newDBMigrateCommand()
+	cmd.SetArgs([]string{"--images", "--yes"})
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, output.String(), "Image migration completed.")
+	// 3 sessions changed (active, trashed, orphan).
+	assert.Contains(t, output.String(), "Changed: 3")
+	assert.Contains(t, output.String(), "Image payloads: 3")
+	assert.DirExists(t, filepath.Join(dataDir, "assets"))
+	// active and trashed share bytes (PNG); orphan is a GIF — two files.
+	entries, err := os.ReadDir(filepath.Join(dataDir, "assets"))
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+
+	database2, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, database2.Close()) }()
+	for _, id := range []string{"mig-active", "mig-trashed"} {
+		messages, err := database2.GetAllMessages(context.Background(), id)
+		require.NoError(t, err)
+		require.Len(t, messages, 1)
+		assert.NotContains(t, messages[0].ToolCalls[0].ResultContent, "input_image")
+		assert.Contains(t, messages[0].ToolCalls[0].ResultContent, "image_ref")
+	}
+
+	// True orphan event row is migrated.
+	var orphanStored string
+	require.NoError(t, database2.Reader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "mig-orphan",
+	).Scan(&orphanStored))
+	assert.Contains(t, orphanStored, "image_ref")
+	assert.Contains(t, orphanStored, "asset://")
+	assert.NotContains(t, orphanStored, "input_image")
+
+	// Count trashed-session event rows that were migrated.
+	var trashedMigrated int
+	_ = database2.Reader().QueryRow(`
+		SELECT COUNT(*) FROM tool_result_events e
+		JOIN sessions s ON s.id = e.session_id
+		WHERE s.deleted_at IS NOT NULL AND e.content LIKE '%image_ref%'`).Scan(&trashedMigrated)
+	t.Logf("trashed-session event rows migrated: got %d", trashedMigrated)
+	assert.Equal(t, 1, trashedMigrated)
+}
+
+func seedMigrateCommandArchive(t *testing.T) {
+	t.Helper()
+	cfg, err := config.LoadReadOnly()
+	require.NoError(t, err)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, database.Close()) }()
+	insertSessionForStripTest(t, database, "mig-cmd")
+	require.NoError(t, database.InsertMessages([]db.Message{commandImageMessage("mig-cmd")}))
+}
+
+func assertMigrateCommandArchiveStillContainsImage(t *testing.T) {
+	t.Helper()
+	cfg, err := config.LoadReadOnly()
+	require.NoError(t, err)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, database.Close()) }()
+	messages, err := database.GetAllMessages(context.Background(), "mig-cmd")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0].ToolCalls[0].ResultContent, "input_image")
+}
+
+// assertMigrateCommandArchiveHasAssetRef verifies the archive content was
+// rewritten to use an asset:// reference.
+func assertMigrateCommandArchiveHasAssetRef(t *testing.T) {
+	t.Helper()
+	cfg, err := config.LoadReadOnly()
+	require.NoError(t, err)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, database.Close()) }()
+	messages, err := database.GetAllMessages(context.Background(), "mig-cmd")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	content := messages[0].ToolCalls[0].ResultContent
+	assert.NotContains(t, content, "input_image")
+	assert.Contains(t, content, "image_ref")
+	assert.Contains(t, content, "asset://")
+}
+
+// migrateCommandImageBlock returns the migrated image block of the seeded
+// mig-cmd session.
+func migrateCommandImageBlock(t *testing.T) map[string]json.RawMessage {
+	t.Helper()
+	cfg, err := config.LoadReadOnly()
+	require.NoError(t, err)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, database.Close()) }()
+	messages, err := database.GetAllMessages(context.Background(), "mig-cmd")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	var blocks []json.RawMessage
+	require.NoError(t, json.Unmarshal(
+		[]byte(messages[0].ToolCalls[0].ResultContent), &blocks,
+	))
+	for _, raw := range blocks {
+		var fields map[string]json.RawMessage
+		if json.Unmarshal(raw, &fields) != nil {
+			continue
+		}
+		if _, ok := fields["image_ref"]; ok {
+			return fields
+		}
+	}
+	t.Fatal("session mig-cmd carries no migrated image block")
+	return nil
+}

--- a/cmd/agentsview/db_strip.go
+++ b/cmd/agentsview/db_strip.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/config"
@@ -12,21 +13,32 @@ import (
 )
 
 func newDBStripCommand() *cobra.Command {
+	return newDBImageCommand(
+		"Strip", "strip", "Remove retained inline tool-result images",
+		"Strip inline image payloads", previewDBStrip, runDBStrip,
+	)
+}
+
+func newDBImageCommand(
+	verb, operation, short, imagesHelp string,
+	preview, apply func(context.Context, config.Config, db.StripImagesFilter) (db.StripImagesReport, error),
+) *cobra.Command {
+	name := strings.ToLower(verb)
 	var images bool
 	var project, before string
 	var dryRun, yes bool
 	cmd := &cobra.Command{
-		Use:          "strip",
-		Short:        "Remove retained inline tool-result images",
+		Use:          name,
+		Short:        short,
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !images {
-				return fmt.Errorf("db strip requires --images")
+				return fmt.Errorf("db %s requires --images", name)
 			}
 			jsonOutput := outputFormat(cmd) == "json"
 			if jsonOutput && !yes && !dryRun {
-				return fmt.Errorf("--format json requires --yes for db strip --images")
+				return fmt.Errorf("--format json requires --yes for db %s --images", name)
 			}
 			cfg, err := config.LoadReadOnly()
 			if err != nil {
@@ -34,34 +46,54 @@ func newDBStripCommand() *cobra.Command {
 			}
 			filter := db.StripImagesFilter{Project: project, Before: before}
 			if dryRun {
-				report, err := previewDBStrip(cmd.Context(), cfg, filter)
+				report, err := preview(cmd.Context(), cfg, filter)
 				if err != nil {
 					return err
 				}
-				return writeDBStripReport(cmd.OutOrStdout(), report, jsonOutput, true)
+				return writeDBImageReport(cmd.OutOrStdout(), report, jsonOutput, "Image "+operation+" preview.")
 			}
 			if !yes {
-				report, err := previewDBStrip(cmd.Context(), cfg, filter)
+				report, err := preview(cmd.Context(), cfg, filter)
 				if err != nil {
 					return err
 				}
-				if err := writeDBStripReport(cmd.ErrOrStderr(), report, false, true); err != nil {
+				if err := writeDBImageReport(cmd.ErrOrStderr(), report, false, "Image "+operation+" preview."); err != nil {
 					return err
 				}
+				if name == "migrate" {
+					fmt.Fprintln(cmd.ErrOrStderr(),
+						"Migrated images require a backup of the assets directory beside the archive.")
+				}
 				if !confirm(cmd.InOrStdin(), cmd.ErrOrStderr(),
-					fmt.Sprintf("Strip images from %d sessions?", report.Sessions)) {
+					fmt.Sprintf("%s images from %d sessions?", verb, report.Sessions)) {
 					fmt.Fprintln(cmd.ErrOrStderr(), "Aborted.")
 					return nil
 				}
 			}
-			report, err := runDBStrip(cmd.Context(), cfg, filter)
+			report, err := apply(cmd.Context(), cfg, filter)
 			if err != nil {
+				if report.Sessions > 0 {
+					_ = writeDBImageReport(cmd.ErrOrStderr(), report, false,
+						"Image "+operation+" stopped early. Counts below cover the sessions that committed:")
+				}
 				return err
 			}
-			return writeDBStripReport(cmd.OutOrStdout(), report, jsonOutput, false)
+			out := cmd.OutOrStdout()
+			if err := writeDBImageReport(out, report, jsonOutput, "Image "+operation+" completed."); err != nil {
+				return err
+			}
+			if !jsonOutput {
+				if name == "migrate" {
+					fmt.Fprintln(out, "Migrated images live in the assets directory beside the archive; back them up together.")
+					fmt.Fprintln(out, "Run db compact separately to measure SQLite file-space reclamation.")
+				} else {
+					fmt.Fprintln(out, "Run db compact separately to measure file-space reclamation.")
+				}
+			}
+			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&images, "images", false, "Strip inline image payloads")
+	cmd.Flags().BoolVar(&images, "images", false, imagesHelp)
 	cmd.Flags().StringVar(&project, "project", "", "Sessions whose project contains this substring")
 	cmd.Flags().StringVar(&before, "before", "", "Sessions that ended before this date (YYYY-MM-DD)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report matching rows without changing the archive")
@@ -95,22 +127,18 @@ func runDBStrip(
 	defer closeWriteDB(database, lock)
 	report, err := database.StripToolImages(ctx, filter)
 	if err != nil {
-		return db.StripImagesReport{}, fmt.Errorf("stripping images: %w", err)
+		return report, fmt.Errorf("stripping images: %w", err)
 	}
 	return report, nil
 }
 
-func writeDBStripReport(
-	out io.Writer, report db.StripImagesReport, jsonOutput, preview bool,
+func writeDBImageReport(
+	out io.Writer, report db.StripImagesReport, jsonOutput bool, heading string,
 ) error {
 	if jsonOutput {
 		return json.NewEncoder(out).Encode(report)
 	}
-	if preview {
-		fmt.Fprintln(out, "Image strip preview.")
-	} else {
-		fmt.Fprintln(out, "Image strip completed.")
-	}
+	fmt.Fprintln(out, heading)
 	fmt.Fprintf(out, "  Sessions: %d\n", report.Sessions)
 	fmt.Fprintf(out, "  Changed: %d\n", report.Changed)
 	fmt.Fprintf(out, "  Image payloads: %d\n", report.Payloads)
@@ -124,9 +152,6 @@ func writeDBStripReport(
 				project.Project, project.Sessions, project.Changed, project.Payloads,
 				formatBytes(project.StoredBytes), formatBytes(project.DecodedBytes))
 		}
-	}
-	if !preview {
-		fmt.Fprintln(out, "Run db compact separately to measure file-space reclamation.")
 	}
 	return nil
 }

--- a/cmd/agentsview/db_strip_test.go
+++ b/cmd/agentsview/db_strip_test.go
@@ -169,7 +169,7 @@ func TestStripThenCompactAccounting(t *testing.T) {
 	report, err := database.StripToolImages(context.Background(), db.StripImagesFilter{})
 	require.NoError(t, err)
 	var output strings.Builder
-	require.NoError(t, writeDBStripReport(&output, report, false, false))
+	require.NoError(t, writeDBImageReport(&output, report, false, "Image strip completed."))
 	assert.Contains(t, output.String(), "Stored content bytes:")
 	assert.Contains(t, output.String(), "Decoded image bytes:")
 	assert.NotContains(t, output.String(), "Reclaimed:")

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -106,12 +106,15 @@ written.
   so a later recompute from stored rows reproduces them.
 
 `db migrate --images` moves retained inline payloads out of SQLite and into the
-asset store. It writes each decoded payload to `{dataDir}/assets/<sha256hex><ext>`
-before any UPDATE commits in the session transaction. An existing object is
-reused only when its byte count and SHA-256 digest match. A missing or corrupt
-object is replaced while the source bytes remain available. The inline block is
-replaced with an `agentsview_image` placeholder whose `image_ref` field holds
-`asset://<sha256hex><ext>` and whose `text` field carries a markdown image
+asset store. It writes each decoded payload to
+`{dataDir}/assets/<sha256hex><ext>` before any UPDATE commits in the session
+transaction. If that transaction fails, complete objects remain unreferenced on
+disk and are reused by a matching retry; there is no automatic cleanup of
+unreferenced assets. An existing object is reused only when its byte count and
+SHA-256 digest match. A missing or corrupt object is replaced while the source
+bytes remain available. The inline block is replaced with an `agentsview_image`
+placeholder whose `image_ref` field holds `asset://<sha256hex><ext>` and whose
+`text` field carries a markdown image
 `![Image: <type>, <n> bytes](asset://<sha256hex><ext>)`. The discriminator for
 migrated blocks is `image_ref`. A later keep-mode reparse or full resync can
 restore inline bytes from provider source files. Only the four passive media

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -104,18 +104,22 @@ written.
   session lock before deleting them.
 - Compute derived values (signals, secret findings) from the projected messages
   so a later recompute from stored rows reproduces them.
+
 `db migrate --images` moves retained inline payloads out of SQLite and into the
 asset store. It writes each decoded payload to `{dataDir}/assets/<sha256hex><ext>`
-before any UPDATE commits in the session transaction. If the file already exists
-the write is skipped (content-addressed dedup). The inline block is replaced
-with an `agentsview_image` placeholder whose `image_ref` field holds
+before any UPDATE commits in the session transaction. An existing object is
+reused only when its byte count and SHA-256 digest match. A missing or corrupt
+object is replaced while the source bytes remain available. The inline block is
+replaced with an `agentsview_image` placeholder whose `image_ref` field holds
 `asset://<sha256hex><ext>` and whose `text` field carries a markdown image
 `![Image: <type>, <n> bytes](asset://<sha256hex><ext>)`. The discriminator for
-migrated blocks is `image_ref`, not `sha256`. Only the four passive media types are
-migrated: `image/png`, `image/jpeg`, `image/webp`, `image/gif`. SVG payloads
-stay inline. The command otherwise follows the same transaction, revision, and
-publication sequence as `db strip --images`. Back up `{dataDir}/assets` together
-with the archive.
+migrated blocks is `image_ref`. A later keep-mode reparse or full resync can
+restore inline bytes from provider source files. Only the four passive media
+types are migrated: `image/png`, `image/jpeg`, `image/webp`, and `image/gif`.
+SVG payloads stay inline. A separate serving host needs the matching
+`{dataDir}/assets` directory with the copied database content. The command
+otherwise follows the same transaction, revision, and publication sequence as
+`db strip --images`. Back up `{dataDir}/assets` together with the archive.
 
 ## Backend Parity
 

--- a/docs/agents/storage.md
+++ b/docs/agents/storage.md
@@ -104,6 +104,18 @@ written.
   session lock before deleting them.
 - Compute derived values (signals, secret findings) from the projected messages
   so a later recompute from stored rows reproduces them.
+`db migrate --images` moves retained inline payloads out of SQLite and into the
+asset store. It writes each decoded payload to `{dataDir}/assets/<sha256hex><ext>`
+before any UPDATE commits in the session transaction. If the file already exists
+the write is skipped (content-addressed dedup). The inline block is replaced
+with an `agentsview_image` placeholder whose `image_ref` field holds
+`asset://<sha256hex><ext>` and whose `text` field carries a markdown image
+`![Image: <type>, <n> bytes](asset://<sha256hex><ext>)`. The discriminator for
+migrated blocks is `image_ref`, not `sha256`. Only the four passive media types are
+migrated: `image/png`, `image/jpeg`, `image/webp`, `image/gif`. SVG payloads
+stay inline. The command otherwise follows the same transaction, revision, and
+publication sequence as `db strip --images`. Back up `{dataDir}/assets` together
+with the archive.
 
 ## Backend Parity
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -524,6 +524,54 @@ content measurements, not reclaimed disk space.
 
 ______________________________________________________________________
 
+### `agentsview db migrate --images`
+
+Move retained inline tool-result image payloads out of the archive and into the
+asset store at `{dataDir}/assets`. Each payload is written as a
+content-addressed file named `<sha256hex><ext>` and the inline `input_image`
+block is replaced with an `agentsview_image` placeholder whose `image_ref` field
+holds the `asset://` reference. The `GET /api/v1/assets/{filename}` route and
+`renderMarkdown` already resolve `asset://` references, so no HTTP route and no
+frontend changes are needed.
+
+The image appears when a tool result's output is switched to formatted mode and
+every other block in that result is a text block. Raw mode shows the stored
+text, including the markdown reference, as it always has, and so does a result
+that still holds an unmigrated image block, such as an SVG or an `image/bmp`
+payload beside a migrated PNG. Under `require_auth` the asset route rejects the
+browser's image request, because an `img` element sends no `Authorization`
+header. Chat-imported images already carry that limit.
+
+The command requires `--images`. It never changes provider source files. Run
+`db compact` separately to measure SQLite file-space reclamation after
+migration. Back up the `{dataDir}/assets` directory together with the archive.
+
+Only the four passive image media types are migrated: `image/png`, `image/jpeg`,
+`image/webp`, `image/gif`. Every other payload stays inline, including SVG,
+which the serving route refuses as active content, and near-misses such as the
+non-canonical `image/jpg` spelling. `db strip --images` is broader and replaces
+any `image/*` payload with a placeholder, so the two commands do not select the
+same rows.
+
+```bash
+agentsview db migrate --images [flags]
+```
+
+| Flag        | Default | Description                                         |
+| ----------- | ------- | --------------------------------------------------- |
+| `--images`  | `false` | Required image migration operation                  |
+| `--project` |         | Sessions whose project contains this substring      |
+| `--before`  |         | Sessions that ended before this date (`YYYY-MM-DD`) |
+| `--dry-run` | `false` | Preview selected sessions and byte counts           |
+| `--yes`     | `false` | Skip confirmation                                   |
+| `--format`  | `human` | Use `json` for machine-readable output              |
+
+JSON apply requires `--yes`. Preview and a declined confirmation leave the
+archive and assets directory unchanged. Reported stored-content bytes and
+decoded image bytes are content measurements, not reclaimed disk space.
+
+______________________________________________________________________
+
 ### `agentsview version`
 
 Print the version, git commit, and build date. Use `--json` for a stable,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -526,13 +526,15 @@ ______________________________________________________________________
 
 ### `agentsview db migrate --images`
 
-Move retained inline tool-result image payloads out of the archive and into the
-asset store at `{dataDir}/assets`. Each payload is written as a
-content-addressed file named `<sha256hex><ext>` and the inline `input_image`
-block is replaced with an `agentsview_image` placeholder whose `image_ref` field
-holds the `asset://` reference. The `GET /api/v1/assets/{filename}` route and
-`renderMarkdown` already resolve `asset://` references, so no HTTP route and no
-frontend changes are needed.
+Move retained inline tool-result image payloads from currently stored archive
+rows into the asset store at `{dataDir}/assets`. Each payload is written as a
+content-addressed file named `<sha256hex><ext>`. Before the row changes, an
+existing object must have the expected byte count and SHA-256 digest. A missing
+or corrupt object is replaced while the source bytes remain available. The
+inline `input_image` block is replaced with an `agentsview_image` placeholder
+whose `image_ref` field holds the `asset://` reference. The
+`GET /api/v1/assets/{filename}` route and `renderMarkdown` resolve these
+references from the local assets directory.
 
 The image appears when a tool result's output is switched to formatted mode and
 every other block in that result is a text block. Raw mode shows the stored
@@ -542,7 +544,12 @@ payload beside a migrated PNG. Under `require_auth` the asset route rejects the
 browser's image request, because an `img` element sends no `Authorization`
 header. Chat-imported images already carry that limit.
 
-The command requires `--images`. It never changes provider source files. Run
+Migration changes currently stored rows. A later keep-mode reparse or full
+resync can restore inline bytes from provider source files. The
+`tool_result_images = "drop"` policy keeps supported images projected during
+future ingestion and full resync. The command requires `--images` and never
+changes provider source files. A separate serving host needs the matching
+`{dataDir}/assets` directory as well as the copied database content. Run
 `db compact` separately to measure SQLite file-space reclamation after
 migration. Back up the `{dataDir}/assets` directory together with the archive.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -553,6 +553,16 @@ changes provider source files. A separate serving host needs the matching
 `db compact` separately to measure SQLite file-space reclamation after
 migration. Back up the `{dataDir}/assets` directory together with the archive.
 
+If a session transaction fails after writing assets, its rows remain unchanged
+but complete, unreferenced asset files remain on disk. Retrying the migration
+reuses matching files; there is no automatic cleanup of unreferenced assets.
+Both `db migrate --images` and `db strip --images` report the sessions that
+committed before a later failure.
+
+JPEG assets now use `.jpg` filenames, including `.jpeg` files copied from chat
+imports. Existing `asset://<hash>.jpeg` references still resolve, but re-importing
+an export with those files can create a second copy under `.jpg`.
+
 Only the four passive image media types are migrated: `image/png`, `image/jpeg`,
 `image/webp`, `image/gif`. Every other payload stays inline, including SVG,
 which the serving route refuses as active content, and near-misses such as the

--- a/docs/data.md
+++ b/docs/data.md
@@ -103,6 +103,15 @@ The local archive has four separate maintenance paths:
   Unlike category filtering, the rebuild also projects orphaned and trashed
   sessions onto the policy, so dropped tool payloads or transcript text leave
   the archive entirely.
+- `agentsview db migrate --images` moves retained inline tool-result image
+  payloads out of SQLite and into `{dataDir}/assets`. Each payload is written
+  as a content-addressed file named `<sha256hex><ext>` before any row commits;
+  the inline block is replaced with an `agentsview_image` placeholder whose
+  `image_ref` field holds the `asset://` reference. Only the four passive
+  media types are migrated (`image/png`, `image/jpeg`, `image/webp`, `image/gif`).
+  SVG payloads stay inline. After migration, back up `{dataDir}/assets` together
+  with the archive. Run `db compact` separately to measure SQLite file-space
+  reclamation.
 - Transparent compression or deduplication of live tool-result payloads is a
   separate storage-format change and is not part of `db compact`.
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -104,14 +104,19 @@ The local archive has four separate maintenance paths:
   sessions onto the policy, so dropped tool payloads or transcript text leave
   the archive entirely.
 - `agentsview db migrate --images` moves retained inline tool-result image
-  payloads out of SQLite and into `{dataDir}/assets`. Each payload is written
-  as a content-addressed file named `<sha256hex><ext>` before any row commits;
-  the inline block is replaced with an `agentsview_image` placeholder whose
-  `image_ref` field holds the `asset://` reference. Only the four passive
-  media types are migrated (`image/png`, `image/jpeg`, `image/webp`, `image/gif`).
-  SVG payloads stay inline. After migration, back up `{dataDir}/assets` together
-  with the archive. Run `db compact` separately to measure SQLite file-space
-  reclamation.
+  payloads from currently stored rows out of SQLite and into `{dataDir}/assets`.
+  Each payload is written as a content-addressed file named
+  `<sha256hex><ext>` before any row commits. An existing object must have the
+  expected byte count and SHA-256 digest. Missing or corrupt objects are
+  replaced while the source bytes remain available. A later keep-mode reparse
+  or full resync can restore inline bytes from provider source files. The inline
+  block is replaced with an `agentsview_image` placeholder whose `image_ref`
+  field holds the `asset://` reference. Only the four passive media types are
+  migrated (`image/png`, `image/jpeg`, `image/webp`, `image/gif`). SVG payloads
+  stay inline. A separate serving host needs the matching `{dataDir}/assets`
+  directory with the copied database content. After migration, back up
+  `{dataDir}/assets` together with the archive. Run `db compact` separately to
+  measure SQLite file-space reclamation.
 - Transparent compression or deduplication of live tool-result payloads is a
   separate storage-format change and is not part of `db compact`.
 

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -1,0 +1,163 @@
+package assets
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// allowedImageExts is the set of passive image formats safe to serve inline.
+// Active content (svg, html, js) is rejected to prevent stored XSS.
+var allowedImageExts = map[string]bool{
+	".png":  true,
+	".jpg":  true,
+	".jpeg": true,
+	".webp": true,
+	".gif":  true,
+}
+
+// mediaTypeToExt maps accepted image media types to their canonical extension.
+var mediaTypeToExt = map[string]string{
+	"image/png":  ".png",
+	"image/jpeg": ".jpg",
+	"image/webp": ".webp",
+	"image/gif":  ".gif",
+}
+
+// ExtForMediaType returns the canonical asset-store extension for an image
+// media type Put accepts. Callers that decide what to migrate must ask here so
+// their acceptance cannot drift from what Put will store.
+func ExtForMediaType(mediaType string) (string, bool) {
+	ext, ok := mediaTypeToExt[mediaType]
+	return ext, ok
+}
+
+// Put writes body to the assets directory under its SHA-256 hash and returns
+// the asset:// reference. created is false when a complete object already
+// existed; repairing a partial one reports true. mediaType must name a passive
+// image format.
+func Put(assetsDir, mediaType string, body []byte) (ref string, created bool, err error) {
+	ext, ok := mediaTypeToExt[mediaType]
+	if !ok {
+		return "", false, fmt.Errorf("unsupported asset type: %s", mediaType)
+	}
+
+	sum := sha256.Sum256(body)
+	hash := fmt.Sprintf("%x", sum[:])
+	filename := hash + ext
+	destPath := filepath.Join(assetsDir, filename)
+
+	if isCompleteObject(destPath, int64(len(body))) {
+		return "asset://" + filename, false, nil
+	}
+
+	if err := writeObject(assetsDir, destPath, func(out *os.File) error {
+		_, err := out.Write(body)
+		return err
+	}); err != nil {
+		return "", false, err
+	}
+
+	return "asset://" + filename, true, nil
+}
+
+// isCompleteObject reports whether the content-addressed path already holds the
+// whole object. Objects arrive through a rename, so a file whose size differs
+// from the payload is a partial write left by an interrupted older run and must
+// be replaced: the caller is about to drop the only other copy of those bytes.
+func isCompleteObject(destPath string, size int64) bool {
+	info, err := os.Stat(destPath)
+	return err == nil && info.Size() == size
+}
+
+// writeObject fills a temp file in assetsDir and renames it onto destPath, so
+// every byte is on disk before the content-addressed path exists. A crash or a
+// full disk mid-write leaves the temp file, never a short object.
+func writeObject(assetsDir, destPath string, fill func(*os.File) error) error {
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		return fmt.Errorf("creating assets dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(assetsDir, filepath.Base(destPath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("writing asset: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op once the rename has moved it
+
+	if err := fill(tmp); err != nil {
+		tmp.Close()
+		return fmt.Errorf("copying asset: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("flushing asset: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing asset: %w", err)
+	}
+	// os.CreateTemp opens at 0600; assets are served read-only to everyone.
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		return fmt.Errorf("setting asset mode: %w", err)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		return fmt.Errorf("publishing asset: %w", err)
+	}
+	return nil
+}
+
+// CopyAsset copies a file to the assets directory using its SHA-256 hash as
+// the filename. Returns the asset:// reference. Only passive image types are
+// accepted; active content is rejected.
+func CopyAsset(srcPath, assetsDir string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(srcPath))
+	if !allowedImageExts[ext] {
+		return "", fmt.Errorf(
+			"unsupported asset type: %s", ext,
+		)
+	}
+	// Normalize .jpeg to .jpg so Put and CopyAsset produce the same filename.
+	// Gated first, so allowedImageExts stays the list of accepted suffixes.
+	if ext == ".jpeg" {
+		ext = ".jpg"
+	}
+
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return "", fmt.Errorf("reading asset: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	size, err := io.Copy(h, f)
+	if err != nil {
+		return "", fmt.Errorf("hashing asset: %w", err)
+	}
+
+	hash := fmt.Sprintf("%x", h.Sum(nil))
+	filename := hash + ext // ext is already normalized to .jpg for .jpeg sources
+	destPath := filepath.Join(assetsDir, filename)
+
+	if isCompleteObject(destPath, size) {
+		return "asset://" + filename, nil
+	}
+
+	// Re-read source for copy (we consumed it for hashing).
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return "", fmt.Errorf("reopening asset: %w", err)
+	}
+	defer src.Close()
+
+	if err := writeObject(assetsDir, destPath, func(out *os.File) error {
+		_, err := io.Copy(out, src)
+		return err
+	}); err != nil {
+		return "", err
+	}
+
+	return "asset://" + filename, nil
+}

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -50,7 +50,7 @@ func Put(assetsDir, mediaType string, body []byte) (ref string, created bool, er
 	filename := hash + ext
 	destPath := filepath.Join(assetsDir, filename)
 
-	if isCompleteObject(destPath, int64(len(body))) {
+	if isCompleteObject(destPath, int64(len(body)), hash) {
 		return "asset://" + filename, false, nil
 	}
 
@@ -64,13 +64,25 @@ func Put(assetsDir, mediaType string, body []byte) (ref string, created bool, er
 	return "asset://" + filename, true, nil
 }
 
-// isCompleteObject reports whether the content-addressed path already holds the
-// whole object. Objects arrive through a rename, so a file whose size differs
-// from the payload is a partial write left by an interrupted older run and must
-// be replaced: the caller is about to drop the only other copy of those bytes.
-func isCompleteObject(destPath string, size int64) bool {
-	info, err := os.Stat(destPath)
-	return err == nil && info.Size() == size
+// isCompleteObject reports whether the content-addressed path already holds a
+// regular file with the expected size and SHA-256 digest.
+func isCompleteObject(destPath string, size int64, expectedHash string) bool {
+	info, err := os.Lstat(destPath)
+	if err != nil || !info.Mode().IsRegular() || info.Size() != size {
+		return false
+	}
+
+	f, err := os.Open(destPath)
+	if err != nil {
+		return false
+	}
+	h := sha256.New()
+	actualSize, copyErr := io.Copy(h, f)
+	closeErr := f.Close()
+	if copyErr != nil || closeErr != nil || actualSize != size {
+		return false
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)) == expectedHash
 }
 
 // writeObject fills a temp file in assetsDir and renames it onto destPath, so
@@ -141,7 +153,7 @@ func CopyAsset(srcPath, assetsDir string) (string, error) {
 	filename := hash + ext // ext is already normalized to .jpg for .jpeg sources
 	destPath := filepath.Join(assetsDir, filename)
 
-	if isCompleteObject(destPath, size) {
+	if isCompleteObject(destPath, size, hash) {
 		return "asset://" + filename, nil
 	}
 

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -1,0 +1,160 @@
+package assets_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/assets"
+)
+
+// TestCopyAssetNormalizesJPEGExtension verifies PI-7 extension parity:
+// a .jpeg source and Put with image/jpeg produce the same file and reference.
+func TestCopyAssetNormalizesJPEGExtension(t *testing.T) {
+	assetsDir := t.TempDir()
+	body := []byte{0xff, 0xd8, 0xff, 0xe0} // JPEG magic bytes
+
+	// Write source file with .jpeg extension.
+	srcPath := filepath.Join(t.TempDir(), "photo.jpeg")
+	require.NoError(t, os.WriteFile(srcPath, body, 0o644))
+
+	// CopyAsset normalizes .jpeg → .jpg before building the destination path.
+	refCopy, err := assets.CopyAsset(srcPath, assetsDir)
+	require.NoError(t, err)
+	assert.Contains(t, refCopy, ".jpg")
+	assert.NotContains(t, refCopy, ".jpeg")
+
+	// Put with image/jpeg maps to .jpg.
+	refPut, _, err := assets.Put(assetsDir, "image/jpeg", body)
+	require.NoError(t, err)
+	assert.Contains(t, refPut, ".jpg")
+
+	// Same bytes through both paths yield one reference and one file.
+	assert.Equal(t, refCopy, refPut)
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	t.Logf("1 file for 2 writes (CopyAsset .jpeg and Put image/jpeg): %d on disk", len(entries))
+}
+
+// TestPutContract verifies the bytes-in Put entry point:
+//   - identical bytes under image/png yield the same asset:// reference
+//   - the first call reports created=true, the second reports created=false
+//   - exactly one file is written after two calls with identical bytes
+//   - image/svg+xml is rejected with an error
+func TestPutContract(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	body := []byte{0x89, 0x50, 0x4e, 0x47} // PNG magic bytes
+
+	ref1, created1, err := assets.Put(assetsDir, "image/png", body)
+	require.NoError(t, err)
+	assert.True(t, created1)
+	assert.Contains(t, ref1, "asset://")
+	assert.Contains(t, ref1, ".png")
+
+	ref2, created2, err := assets.Put(assetsDir, "image/png", body)
+	require.NoError(t, err)
+	assert.False(t, created2)
+	assert.Equal(t, ref1, ref2)
+
+	// Boundary: exactly 1 file on disk after 2 writes.
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	t.Logf("1 file on disk after 2 writes: %d", len(entries))
+
+	// Verify the stored file matches the written bytes.
+	filename := entries[0].Name()
+	stored, err := os.ReadFile(filepath.Join(assetsDir, filename))
+	require.NoError(t, err)
+	assert.Equal(t, body, stored)
+
+	// Verify the sha256 in the filename matches the content.
+	sum := sha256.Sum256(body)
+	wantFilename := fmt.Sprintf("%x.png", sum[:])
+	assert.Equal(t, wantFilename, filename)
+
+	// svg+xml is not in the passive format set.
+	_, _, err = assets.Put(assetsDir, "image/svg+xml", []byte("<svg/>"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported asset type")
+}
+
+// TestPutReplacesTruncatedObject covers the migration's destructive path: the
+// caller drops the inline base64 once Put returns a reference, so a short file
+// left at the content-addressed path by an interrupted write must be replaced
+// rather than accepted as a hit.
+func TestPutReplacesTruncatedObject(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	body := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a} // PNG header
+	sum := sha256.Sum256(body)
+	destPath := filepath.Join(assetsDir, fmt.Sprintf("%x.png", sum[:]))
+	require.NoError(t, os.WriteFile(destPath, body[:3], 0o644))
+
+	ref, created, err := assets.Put(assetsDir, "image/png", body)
+	require.NoError(t, err)
+	assert.Equal(t, "asset://"+filepath.Base(destPath), ref)
+	// created reports that this call wrote the object, so repairing a partial
+	// file reads as created even though the path already existed.
+	assert.True(t, created)
+
+	stored, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, body, stored)
+
+	// The temp file the write used is renamed, not left beside the object.
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	t.Logf("truncated %d bytes replaced by %d: files=%d", 3, len(stored), len(entries))
+}
+
+// TestCopyAssetContract covers the path-in entry point: reference shape, the
+// bytes on disk, dedup on a repeat copy, replacement of a truncated object, and
+// rejection of a non-image extension.
+func TestCopyAssetContract(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "source.webp")
+	body := []byte("image data")
+	require.NoError(t, os.WriteFile(src, body, 0o644))
+
+	assetsDir := filepath.Join(t.TempDir(), "assets")
+
+	ref, err := assets.CopyAsset(src, assetsDir)
+	require.NoError(t, err)
+	assert.Contains(t, ref, "asset://")
+	assert.Contains(t, ref, ".webp")
+
+	destPath := filepath.Join(assetsDir, strings.TrimPrefix(ref, "asset://"))
+	stored, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, body, stored)
+
+	// A repeat copy returns the same reference without a second file.
+	ref2, err := assets.CopyAsset(src, assetsDir)
+	require.NoError(t, err)
+	assert.Equal(t, ref, ref2)
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+
+	// A short file at the destination is a partial write, not a dedup hit.
+	require.NoError(t, os.WriteFile(destPath, body[:2], 0o644))
+	ref3, err := assets.CopyAsset(src, assetsDir)
+	require.NoError(t, err)
+	assert.Equal(t, ref, ref3)
+	stored, err = os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, body, stored)
+
+	// Active content is rejected on extension.
+	_, err = assets.CopyAsset(filepath.Join(t.TempDir(), "payload.svg"), assetsDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported asset type")
+}

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -86,42 +86,55 @@ func TestPutContract(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported asset type")
 }
 
-// TestPutReplacesTruncatedObject covers the migration's destructive path: the
-// caller drops the inline base64 once Put returns a reference, so a short file
-// left at the content-addressed path by an interrupted write must be replaced
-// rather than accepted as a hit.
-func TestPutReplacesTruncatedObject(t *testing.T) {
-	assetsDir := t.TempDir()
-
+// TestPutReplacesIncompleteObject covers truncated and equal-length corrupt
+// objects at the content-addressed path.
+func TestPutReplacesIncompleteObject(t *testing.T) {
 	body := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a} // PNG header
 	sum := sha256.Sum256(body)
-	destPath := filepath.Join(assetsDir, fmt.Sprintf("%x.png", sum[:]))
-	require.NoError(t, os.WriteFile(destPath, body[:3], 0o644))
 
-	ref, created, err := assets.Put(assetsDir, "image/png", body)
-	require.NoError(t, err)
-	assert.Equal(t, "asset://"+filepath.Base(destPath), ref)
-	// created reports that this call wrote the object, so repairing a partial
-	// file reads as created even though the path already existed.
-	assert.True(t, created)
+	corrupt := append([]byte(nil), body...)
+	corrupt[0] ^= 0xff
+	for _, tt := range []struct {
+		name     string
+		existing []byte
+	}{
+		{name: "truncated", existing: body[:3]},
+		{name: "same-size-corrupt", existing: corrupt},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assetsDir := t.TempDir()
+			destPath := filepath.Join(assetsDir, fmt.Sprintf("%x.png", sum[:]))
+			require.NoError(t, os.WriteFile(destPath, tt.existing, 0o644))
 
-	stored, err := os.ReadFile(destPath)
-	require.NoError(t, err)
-	assert.Equal(t, body, stored)
+			ref, created, err := assets.Put(assetsDir, "image/png", body)
+			require.NoError(t, err)
+			assert.Equal(t, "asset://"+filepath.Base(destPath), ref)
+			assert.True(t, created)
 
-	// The temp file the write used is renamed, not left beside the object.
-	entries, err := os.ReadDir(assetsDir)
-	require.NoError(t, err)
-	assert.Len(t, entries, 1)
-	t.Logf("truncated %d bytes replaced by %d: files=%d", 3, len(stored), len(entries))
+			stored, err := os.ReadFile(destPath)
+			require.NoError(t, err)
+			assert.Equal(t, body, stored)
+			assert.Equal(t, sum, sha256.Sum256(stored))
+
+			entries, err := os.ReadDir(assetsDir)
+			require.NoError(t, err)
+			assert.Len(t, entries, 1)
+
+			ref2, created2, err := assets.Put(assetsDir, "image/png", body)
+			require.NoError(t, err)
+			assert.Equal(t, ref, ref2)
+			assert.False(t, created2)
+			t.Logf("%s object repaired: %d bytes, digest=%x, files=%d", tt.name, len(stored), sum, len(entries))
+		})
+	}
 }
 
-// TestCopyAssetContract covers the path-in entry point: reference shape, the
-// bytes on disk, dedup on a repeat copy, replacement of a truncated object, and
-// rejection of a non-image extension.
+// TestCopyAssetContract covers the path-in entry point, deduplication, repair
+// of incomplete objects, and rejection of a non-image extension.
 func TestCopyAssetContract(t *testing.T) {
 	src := filepath.Join(t.TempDir(), "source.webp")
 	body := []byte("image data")
+	sum := sha256.Sum256(body)
 	require.NoError(t, os.WriteFile(src, body, 0o644))
 
 	assetsDir := filepath.Join(t.TempDir(), "assets")
@@ -135,6 +148,7 @@ func TestCopyAssetContract(t *testing.T) {
 	stored, err := os.ReadFile(destPath)
 	require.NoError(t, err)
 	assert.Equal(t, body, stored)
+	assert.Equal(t, sum, sha256.Sum256(stored))
 
 	// A repeat copy returns the same reference without a second file.
 	ref2, err := assets.CopyAsset(src, assetsDir)
@@ -144,14 +158,29 @@ func TestCopyAssetContract(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, entries, 1)
 
-	// A short file at the destination is a partial write, not a dedup hit.
-	require.NoError(t, os.WriteFile(destPath, body[:2], 0o644))
-	ref3, err := assets.CopyAsset(src, assetsDir)
+	corrupt := append([]byte(nil), body...)
+	corrupt[0] ^= 0xff
+	for _, tt := range []struct {
+		name     string
+		existing []byte
+	}{
+		{name: "truncated", existing: body[:2]},
+		{name: "same-size-corrupt", existing: corrupt},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, os.WriteFile(destPath, tt.existing, 0o644))
+			ref3, err := assets.CopyAsset(src, assetsDir)
+			require.NoError(t, err)
+			assert.Equal(t, ref, ref3)
+			stored, err := os.ReadFile(destPath)
+			require.NoError(t, err)
+			assert.Equal(t, body, stored)
+			assert.Equal(t, sum, sha256.Sum256(stored))
+		})
+	}
+	entries, err = os.ReadDir(assetsDir)
 	require.NoError(t, err)
-	assert.Equal(t, ref, ref3)
-	stored, err = os.ReadFile(destPath)
-	require.NoError(t, err)
-	assert.Equal(t, body, stored)
+	assert.Len(t, entries, 1)
 
 	// Active content is rejected on extension.
 	_, err = assets.CopyAsset(filepath.Join(t.TempDir(), "payload.svg"), assetsDir)

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -13,8 +13,8 @@ import (
 	"go.kenn.io/agentsview/internal/assets"
 )
 
-// TestCopyAssetNormalizesJPEGExtension verifies PI-7 extension parity:
-// a .jpeg source and Put with image/jpeg produce the same file and reference.
+// TestCopyAssetNormalizesJPEGExtension verifies that a .jpeg source and Put
+// with image/jpeg produce the same file and reference.
 func TestCopyAssetNormalizesJPEGExtension(t *testing.T) {
 	assetsDir := t.TempDir()
 	body := []byte{0xff, 0xd8, 0xff, 0xe0} // JPEG magic bytes

--- a/internal/db/migrate_images.go
+++ b/internal/db/migrate_images.go
@@ -1,0 +1,188 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// PreviewMigrateToolImages reports the inline image payloads that would be
+// moved without writing any file or changing any row.
+func (db *DB) PreviewMigrateToolImages(
+	ctx context.Context, filter StripImagesFilter,
+) (StripImagesReport, error) {
+	return db.scanMigrateToolImages(ctx, filter, nil)
+}
+
+// MigrateToolImages moves retained inline tool-result image payloads into the
+// asset store. put is called once per payload with the decoded bytes; it must
+// write the file and return the asset:// reference. The caller owns the archive
+// write lock before invoking this method.
+func (db *DB) MigrateToolImages(
+	ctx context.Context, filter StripImagesFilter, put imagePutFunc,
+) (StripImagesReport, error) {
+	if err := db.requireWritable(); err != nil {
+		return StripImagesReport{}, err
+	}
+	return db.scanMigrateToolImages(ctx, filter, func(
+		ctx context.Context, session stripImageSession,
+	) (bool, error) {
+		var stats ToolImageStats
+		changed, err := db.migrateStoredToolResultRows(ctx, session.id, put, &stats)
+		if err != nil {
+			return false, fmt.Errorf(
+				"migrating tool results for %s: %w", session.id, err,
+			)
+		}
+		return changed, nil
+	})
+}
+
+// migrateStoredToolResultRows rewrites one session's content columns through
+// migrateToolResultImages, writing asset files before any UPDATE commits.
+func (db *DB) migrateStoredToolResultRows(
+	ctx context.Context, sessionID string, put imagePutFunc, stats *ToolImageStats,
+) (bool, error) {
+	return db.rewriteStoredToolResultRows(ctx, sessionID, func(content string) (string, error) {
+		return migrateToolResultImages(content, put, stats)
+	})
+}
+
+func (db *DB) scanMigrateToolImages(
+	ctx context.Context,
+	filter StripImagesFilter,
+	apply func(context.Context, stripImageSession) (bool, error),
+) (StripImagesReport, error) {
+	sessions, err := db.stripImageSessions(ctx, filter)
+	if err != nil {
+		return StripImagesReport{}, err
+	}
+	report := StripImagesReport{
+		Projects: make([]StripImagesProjectReport, 0),
+	}
+	byProject := make(map[string]*StripImagesProjectReport)
+	for _, session := range sessions {
+		if err := ctx.Err(); err != nil {
+			return StripImagesReport{}, err
+		}
+		stats, err := db.migrateImageStats(ctx, session.id)
+		if err != nil {
+			return StripImagesReport{}, err
+		}
+		if stats.Payloads == 0 {
+			continue
+		}
+		project := byProject[session.project]
+		if project == nil {
+			report.Projects = append(report.Projects, StripImagesProjectReport{
+				Project: session.project,
+			})
+			project = &report.Projects[len(report.Projects)-1]
+			byProject[session.project] = project
+		}
+		project.Sessions++
+		report.Sessions++
+		if apply != nil {
+			changed, err := apply(ctx, session)
+			if err != nil {
+				// Undo the pre-increment for the failed session so the caller
+				// receives only the work that committed successfully.
+				project.Sessions--
+				report.Sessions--
+				if project.Sessions == 0 {
+					// Sessions arrive grouped by project, so an emptied entry
+					// is always the one just appended.
+					report.Projects = report.Projects[:len(report.Projects)-1]
+					delete(byProject, session.project)
+				}
+				return report, err
+			}
+			if changed {
+				project.Changed++
+				report.Changed++
+			}
+		} else if stats.Payloads > 0 {
+			project.Changed++
+			report.Changed++
+		}
+		project.Payloads += stats.Payloads
+		project.StoredBytes += stats.StoredBytes
+		project.DecodedBytes += stats.DecodedBytes
+		report.Payloads += stats.Payloads
+		report.StoredBytes += stats.StoredBytes
+		report.DecodedBytes += stats.DecodedBytes
+	}
+	sort.Slice(report.Projects, func(i, j int) bool {
+		return report.Projects[i].Project < report.Projects[j].Project
+	})
+	return report, nil
+}
+
+func (db *DB) migrateImageStats(
+	ctx context.Context, sessionID string,
+) (ToolImageStats, error) {
+	var stats ToolImageStats
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT COALESCE(result_content, '')
+		FROM tool_calls
+		WHERE session_id = ?
+		UNION ALL
+		SELECT COALESCE(content, '')
+		FROM tool_result_events
+		WHERE session_id = ?`, sessionID, sessionID)
+	if err != nil {
+		return ToolImageStats{}, fmt.Errorf("reading tool result bytes for migrate stats: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			return ToolImageStats{}, fmt.Errorf("scanning tool result bytes for migrate stats: %w", err)
+		}
+		countMigratable(content, &stats)
+	}
+	if err := rows.Err(); err != nil {
+		return ToolImageStats{}, fmt.Errorf("iterating tool result bytes for migrate stats: %w", err)
+	}
+	return stats, nil
+}
+
+// countMigratable scans content for migratable inline image blocks and
+// accumulates their byte counts into stats. It handles both array and
+// labeled/anonymous summary forms.
+func countMigratable(content string, stats *ToolImageStats) {
+	// Try direct JSON array.
+	var blocks []json.RawMessage
+	if err := json.Unmarshal([]byte(content), &blocks); err == nil && blocks != nil {
+		countMigratableBlocks(blocks, stats)
+		return
+	}
+	// Labeled/anonymous summary: count through the same scanner the rewrite
+	// uses, so the preview cannot see a different set of sections.
+	scanSummarySections(content, func(_, _ int, raw json.RawMessage) {
+		var sectionBlocks []json.RawMessage
+		if err := json.Unmarshal(raw, &sectionBlocks); err == nil {
+			countMigratableBlocks(sectionBlocks, stats)
+		}
+	})
+}
+
+func countMigratableBlocks(blocks []json.RawMessage, stats *ToolImageStats) {
+	for _, raw := range blocks {
+		if !isMigratableToolImageBlock(raw) {
+			continue
+		}
+		var block toolImageBlock
+		if err := json.Unmarshal(raw, &block); err != nil {
+			continue
+		}
+		_, decoded, stored, ok := decodeInlineImage(block.ImageURL)
+		if !ok {
+			continue
+		}
+		stats.Payloads++
+		stats.StoredBytes += stored
+		stats.DecodedBytes += int64(len(decoded))
+	}
+}

--- a/internal/db/migrate_images.go
+++ b/internal/db/migrate_images.go
@@ -64,11 +64,11 @@ func (db *DB) scanMigrateToolImages(
 	byProject := make(map[string]*StripImagesProjectReport)
 	for _, session := range sessions {
 		if err := ctx.Err(); err != nil {
-			return StripImagesReport{}, err
+			return report, err
 		}
 		stats, err := db.migrateImageStats(ctx, session.id)
 		if err != nil {
-			return StripImagesReport{}, err
+			return report, err
 		}
 		if stats.Payloads == 0 {
 			continue

--- a/internal/db/migrate_images.go
+++ b/internal/db/migrate_images.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 )
 
 // PreviewMigrateToolImages reports the inline image payloads that would be
@@ -12,7 +11,7 @@ import (
 func (db *DB) PreviewMigrateToolImages(
 	ctx context.Context, filter StripImagesFilter,
 ) (StripImagesReport, error) {
-	return db.scanMigrateToolImages(ctx, filter, nil)
+	return db.scanToolImages(ctx, filter, countMigratable, nil)
 }
 
 // MigrateToolImages moves retained inline tool-result image payloads into the
@@ -25,11 +24,10 @@ func (db *DB) MigrateToolImages(
 	if err := db.requireWritable(); err != nil {
 		return StripImagesReport{}, err
 	}
-	return db.scanMigrateToolImages(ctx, filter, func(
+	return db.scanToolImages(ctx, filter, countMigratable, func(
 		ctx context.Context, session stripImageSession,
 	) (bool, error) {
-		var stats ToolImageStats
-		changed, err := db.migrateStoredToolResultRows(ctx, session.id, put, &stats)
+		changed, err := db.migrateStoredToolResultRows(ctx, session.id, put)
 		if err != nil {
 			return false, fmt.Errorf(
 				"migrating tool results for %s: %w", session.id, err,
@@ -42,130 +40,33 @@ func (db *DB) MigrateToolImages(
 // migrateStoredToolResultRows rewrites one session's content columns through
 // migrateToolResultImages, writing asset files before any UPDATE commits.
 func (db *DB) migrateStoredToolResultRows(
-	ctx context.Context, sessionID string, put imagePutFunc, stats *ToolImageStats,
+	ctx context.Context, sessionID string, put imagePutFunc,
 ) (bool, error) {
 	return db.rewriteStoredToolResultRows(ctx, sessionID, func(content string) (string, error) {
-		return migrateToolResultImages(content, put, stats)
+		return migrateToolResultImages(content, put)
 	})
-}
-
-func (db *DB) scanMigrateToolImages(
-	ctx context.Context,
-	filter StripImagesFilter,
-	apply func(context.Context, stripImageSession) (bool, error),
-) (StripImagesReport, error) {
-	sessions, err := db.stripImageSessions(ctx, filter)
-	if err != nil {
-		return StripImagesReport{}, err
-	}
-	report := StripImagesReport{
-		Projects: make([]StripImagesProjectReport, 0),
-	}
-	byProject := make(map[string]*StripImagesProjectReport)
-	for _, session := range sessions {
-		if err := ctx.Err(); err != nil {
-			return report, err
-		}
-		stats, err := db.migrateImageStats(ctx, session.id)
-		if err != nil {
-			return report, err
-		}
-		if stats.Payloads == 0 {
-			continue
-		}
-		project := byProject[session.project]
-		if project == nil {
-			report.Projects = append(report.Projects, StripImagesProjectReport{
-				Project: session.project,
-			})
-			project = &report.Projects[len(report.Projects)-1]
-			byProject[session.project] = project
-		}
-		project.Sessions++
-		report.Sessions++
-		if apply != nil {
-			changed, err := apply(ctx, session)
-			if err != nil {
-				// Undo the pre-increment for the failed session so the caller
-				// receives only the work that committed successfully.
-				project.Sessions--
-				report.Sessions--
-				if project.Sessions == 0 {
-					// Sessions arrive grouped by project, so an emptied entry
-					// is always the one just appended.
-					report.Projects = report.Projects[:len(report.Projects)-1]
-					delete(byProject, session.project)
-				}
-				return report, err
-			}
-			if changed {
-				project.Changed++
-				report.Changed++
-			}
-		} else if stats.Payloads > 0 {
-			project.Changed++
-			report.Changed++
-		}
-		project.Payloads += stats.Payloads
-		project.StoredBytes += stats.StoredBytes
-		project.DecodedBytes += stats.DecodedBytes
-		report.Payloads += stats.Payloads
-		report.StoredBytes += stats.StoredBytes
-		report.DecodedBytes += stats.DecodedBytes
-	}
-	sort.Slice(report.Projects, func(i, j int) bool {
-		return report.Projects[i].Project < report.Projects[j].Project
-	})
-	return report, nil
-}
-
-func (db *DB) migrateImageStats(
-	ctx context.Context, sessionID string,
-) (ToolImageStats, error) {
-	var stats ToolImageStats
-	rows, err := db.getReader().QueryContext(ctx, `
-		SELECT COALESCE(result_content, '')
-		FROM tool_calls
-		WHERE session_id = ?
-		UNION ALL
-		SELECT COALESCE(content, '')
-		FROM tool_result_events
-		WHERE session_id = ?`, sessionID, sessionID)
-	if err != nil {
-		return ToolImageStats{}, fmt.Errorf("reading tool result bytes for migrate stats: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var content string
-		if err := rows.Scan(&content); err != nil {
-			return ToolImageStats{}, fmt.Errorf("scanning tool result bytes for migrate stats: %w", err)
-		}
-		countMigratable(content, &stats)
-	}
-	if err := rows.Err(); err != nil {
-		return ToolImageStats{}, fmt.Errorf("iterating tool result bytes for migrate stats: %w", err)
-	}
-	return stats, nil
 }
 
 // countMigratable scans content for migratable inline image blocks and
 // accumulates their byte counts into stats. It handles both array and
 // labeled/anonymous summary forms.
-func countMigratable(content string, stats *ToolImageStats) {
+func countMigratable(content string) ToolImageStats {
+	var stats ToolImageStats
 	// Try direct JSON array.
 	var blocks []json.RawMessage
 	if err := json.Unmarshal([]byte(content), &blocks); err == nil && blocks != nil {
-		countMigratableBlocks(blocks, stats)
-		return
+		countMigratableBlocks(blocks, &stats)
+		return stats
 	}
 	// Labeled/anonymous summary: count through the same scanner the rewrite
 	// uses, so the preview cannot see a different set of sections.
 	scanSummarySections(content, func(_, _ int, raw json.RawMessage) {
 		var sectionBlocks []json.RawMessage
 		if err := json.Unmarshal(raw, &sectionBlocks); err == nil {
-			countMigratableBlocks(sectionBlocks, stats)
+			countMigratableBlocks(sectionBlocks, &stats)
 		}
 	})
+	return stats
 }
 
 func countMigratableBlocks(blocks []json.RawMessage, stats *ToolImageStats) {
@@ -177,12 +78,12 @@ func countMigratableBlocks(blocks []json.RawMessage, stats *ToolImageStats) {
 		if err := json.Unmarshal(raw, &block); err != nil {
 			continue
 		}
-		_, decoded, stored, ok := decodeInlineImage(block.ImageURL)
+		_, decoded, stored, ok := decodeInlineImageURL(block.ImageURL)
 		if !ok {
 			continue
 		}
 		stats.Payloads++
 		stats.StoredBytes += stored
-		stats.DecodedBytes += int64(len(decoded))
+		stats.DecodedBytes += decoded
 	}
 }

--- a/internal/db/migrate_images_test.go
+++ b/internal/db/migrate_images_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
@@ -178,6 +179,48 @@ func TestMigratePartialFailurePreservesReport(t *testing.T) {
 	).Scan(&secondAfter))
 	assert.Equal(t, secondBefore, secondAfter)
 	assert.NotContains(t, secondAfter, "image_ref")
+}
+
+// TestMigrateCancellationPreservesReport verifies that cancellation after a
+// committed session still reports the work that preceded it.
+func TestMigrateCancellationPreservesReport(t *testing.T) {
+	d := testDB(t)
+	assetsDir := t.TempDir()
+	insertSession(t, d, "cancel-first", "project")
+	insertSession(t, d, "cancel-second", "project")
+	insertMessages(t, d, testImageMessage("cancel-first"))
+	insertMessages(t, d, testImageMessage("cancel-second"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	calls := 0
+	put := func(mediaType string, body []byte) (string, bool, error) {
+		result, created, err := realPut(assetsDir)(mediaType, body)
+		calls++
+		if calls == 2 {
+			cancel()
+		}
+		return result, created, err
+	}
+
+	report, err := d.MigrateToolImages(ctx, StripImagesFilter{}, put)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, report.Sessions)
+	assert.Equal(t, 1, report.Changed)
+	assert.Equal(t, int64(1), report.Payloads)
+	t.Logf("cancellation report: sessions=%d changed=%d payloads=%d", report.Sessions, report.Changed, report.Payloads)
+
+	var firstContent string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "cancel-first",
+	).Scan(&firstContent))
+	assert.Contains(t, firstContent, "image_ref")
+
+	var secondContent string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "cancel-second",
+	).Scan(&secondContent))
+	assert.Contains(t, secondContent, "input_image")
 }
 
 // TestMigratedReferenceMatchesStoredFile verifies that migration repairs a

--- a/internal/db/migrate_images_test.go
+++ b/internal/db/migrate_images_test.go
@@ -60,8 +60,7 @@ func TestToolImageMigrationContract(t *testing.T) {
 
 	content := "[" + audioBlock + "," + inlineBlock + "," + placeholderV7 + "]"
 
-	var stats ToolImageStats
-	projected, err := migrateToolResultImages(content, fakePut, &stats)
+	projected, err := migrateToolResultImages(content, fakePut)
 	require.NoError(t, err)
 
 	var blocks []json.RawMessage
@@ -83,14 +82,10 @@ func TestToolImageMigrationContract(t *testing.T) {
 	assert.Equal(t, `"agentsview_image"`, string(migrated["type"]))
 	assert.Equal(t, `1`, string(migrated["version"]))
 
-	assert.Equal(t, int64(1), stats.Payloads)
-
 	// A failing put returns original content and the error.
-	var stats2 ToolImageStats
-	result, err2 := migrateToolResultImages(content, errorPut, &stats2)
+	result, err2 := migrateToolResultImages(content, errorPut)
 	require.Error(t, err2)
 	assert.Equal(t, content, result)
-	assert.Zero(t, stats2.Payloads)
 }
 
 // TestMigrateLeavesBlockInlineWhenPutFails verifies the fault guard:
@@ -118,9 +113,7 @@ func TestMigrateLeavesBlockInlineWhenPutFails(t *testing.T) {
 	// Boundary: 0 rows carrying image_ref after failure.
 	assert.Equal(t, beforeContent, afterContent)
 	assert.NotContains(t, afterContent, "image_ref")
-	var rowsWithRef int
-	_ = d.getReader().QueryRow(`SELECT COUNT(*) FROM tool_result_events WHERE session_id = 'fail-put' AND content LIKE '%image_ref%'`).Scan(&rowsWithRef)
-	t.Logf("0 rows carrying image_ref after the failure: got %d", rowsWithRef)
+
 }
 
 // TestMigratePartialFailurePreservesReport verifies the partial-failure contract:
@@ -195,9 +188,8 @@ func TestMigrateCancellationPreservesReport(t *testing.T) {
 	defer cancel()
 	applies := 0
 	apply := func(ctx context.Context, session stripImageSession) (bool, error) {
-		var stats ToolImageStats
 		changed, err := d.migrateStoredToolResultRows(
-			ctx, session.id, realPut(assetsDir), &stats,
+			ctx, session.id, realPut(assetsDir),
 		)
 		applies++
 		if applies == 1 {
@@ -206,7 +198,7 @@ func TestMigrateCancellationPreservesReport(t *testing.T) {
 		return changed, err
 	}
 
-	report, err := d.scanMigrateToolImages(ctx, StripImagesFilter{}, apply)
+	report, err := d.scanToolImages(ctx, StripImagesFilter{}, countMigratable, apply)
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, 1, report.Sessions)
 	assert.Equal(t, 1, report.Changed)
@@ -238,9 +230,8 @@ func TestMigrateStatsFailurePreservesReport(t *testing.T) {
 
 	applies := 0
 	apply := func(ctx context.Context, session stripImageSession) (bool, error) {
-		var stats ToolImageStats
 		changed, err := d.migrateStoredToolResultRows(
-			ctx, session.id, realPut(assetsDir), &stats,
+			ctx, session.id, realPut(assetsDir),
 		)
 		if err != nil {
 			return false, err
@@ -253,9 +244,9 @@ func TestMigrateStatsFailurePreservesReport(t *testing.T) {
 		return changed, nil
 	}
 
-	report, err := d.scanMigrateToolImages(t.Context(), StripImagesFilter{}, apply)
+	report, err := d.scanToolImages(t.Context(), StripImagesFilter{}, countMigratable, apply)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "migrate stats")
+	assert.ErrorContains(t, err, "tool result bytes")
 	assert.Equal(t, 1, report.Sessions)
 	assert.Equal(t, 1, report.Changed)
 	assert.Equal(t, int64(1), report.Payloads)
@@ -586,16 +577,12 @@ func TestMigratePreviewAndApplyAgreeOnUnsupportedType(t *testing.T) {
 		preview.Payloads, applied.Payloads, len(putTypes))
 }
 
-// TestMigrateSummaryPutFailureLeavesStatsUntouched verifies that the
-// labeled-summary path unwinds like the array path: when a later section's put
-// fails, the caller's stats keep the value they had and the content is returned
-// unchanged. Boundary: 0 counts added for 1 successful section.
-func TestMigrateSummaryPutFailureLeavesStatsUntouched(t *testing.T) {
+// TestMigrateSummaryPutFailurePreservesContent verifies that a failure in a
+// later summary section returns the original content.
+func TestMigrateSummaryPutFailurePreservesContent(t *testing.T) {
 	content := "agent-a:\n" + testInlineImageContent() +
 		"\n\nagent-b:\n" + testInlineImageContent()
 
-	before := ToolImageStats{Payloads: 5, StoredBytes: 50, DecodedBytes: 500}
-	stats := before
 	calls := 0
 	put := func(mediaType string, body []byte) (string, bool, error) {
 		calls++
@@ -605,16 +592,13 @@ func TestMigrateSummaryPutFailureLeavesStatsUntouched(t *testing.T) {
 		return "", false, errors.New("forced put failure in the second section")
 	}
 
-	got, err := migrateToolResultImages(content, put, &stats)
+	got, err := migrateToolResultImages(content, put)
 	require.Error(t, err)
 	assert.Equal(t, content, got)
 	assert.Equal(t, 2, calls, "the first section must migrate before the failure")
-	assert.Equal(t, before, stats)
-	t.Logf("0 counts added for 1 successful section: payloads before=%d after=%d",
-		before.Payloads, stats.Payloads)
 }
 
-// TestMigrateNoOpPreservesRevisionAndQueue verifies PI-3: a session with no
+// TestMigrateNoOpPreservesRevisionAndQueue verifies that a session with no
 // migratable payloads produces no publications, no revision bump, no queue row.
 // Boundary: 0 publications.
 func TestMigrateNoOpPreservesRevisionAndQueue(t *testing.T) {
@@ -668,9 +652,9 @@ func TestMigrateNoOpPreservesRevisionAndQueue(t *testing.T) {
 	// No new publication queued: pending stays 0 (clearArtifactExportQueue zeros
 	// rows but does not delete them).
 	var pending int
-	_ = d.getReader().QueryRow(
+	require.NoError(t, d.getReader().QueryRow(
 		"SELECT pending FROM artifact_export_queue WHERE session_id = ?", "noop-session",
-	).Scan(&pending)
+	).Scan(&pending))
 	assert.Zero(t, pending)
 
 	// Signal invalidation and incremental-marker reset must not fire.
@@ -689,106 +673,7 @@ func TestMigrateNoOpPreservesRevisionAndQueue(t *testing.T) {
 	t.Logf("0 publications: sessions=%d, changed=%d, assets=%d", report.Sessions, report.Changed, len(entries))
 }
 
-// TestStripToolResultImagesUnchangedAfterRefactor verifies PI-6: extracting
-// rewriteStoredToolResultRows does not change StripToolResultImages output.
-// Six stored strings including a webp with charset parameter and a labeled
-// summary whose second section is anonymous.
-// Golden values were captured at base commit fccd49abbd53.
-// Boundary: 6 strings compared with 0 differences.
-func TestStripToolResultImagesUnchangedAfterRefactor(t *testing.T) {
-	inputs := []string{
-		// 1. Simple PNG inline.
-		`[{"type":"input_image","image_url":"data:image/png;base64,AAEC"}]`,
-		// 2. WebP with charset parameter — parseInlineImageHeader requires exactly
-		// two semicolon-delimited parts before the comma, so this passes through.
-		`[{"type":"input_image","image_url":"data:image/webp;charset=utf-8;base64,AAEC"}]`,
-		// 3. Already-stripped placeholder (no-op for strip).
-		`[{"type":"agentsview_image","version":1,"text":"[Image: image/png, 3 bytes]","media_type":"image/png","byte_size":3,"sha256":""}]`,
-		// 4. Mixed array with non-image blocks.
-		`[{"type":"text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AAEC"},{"type":"text","text":"after"}]`,
-		// 5. Labeled summary with anonymous trailing section.
-		"agent-a:\n[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAEC\"}]\n\n[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAEC\"}]",
-		// 6. Plain text with no images.
-		`plain text, no images`,
-	}
-	// Golden outputs captured at base commit fccd49abbd53. Head must match.
-	baseGolden := []string{
-		// 1. PNG stripped to placeholder.
-		`[{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1}]`,
-		// 2. WebP with charset passes through unchanged (3-part header rejected).
-		`[{"type":"input_image","image_url":"data:image/webp;charset=utf-8;base64,AAEC"}]`,
-		// 3. Already-stripped placeholder passes through unchanged.
-		`[{"type":"agentsview_image","version":1,"text":"[Image: image/png, 3 bytes]","media_type":"image/png","byte_size":3,"sha256":""}]`,
-		// 4. Mixed array: image stripped, text blocks pass through.
-		`[{"type":"text","text":"before"},{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1},{"type":"text","text":"after"}]`,
-		// 5. Both labeled sections stripped.
-		"agent-a:\n[{\"byte_size\":3,\"media_type\":\"image/png\",\"sha256\":\"\",\"text\":\"[Image: image/png, 3 bytes]\",\"type\":\"agentsview_image\",\"version\":1}]\n\n[{\"byte_size\":3,\"media_type\":\"image/png\",\"sha256\":\"\",\"text\":\"[Image: image/png, 3 bytes]\",\"type\":\"agentsview_image\",\"version\":1}]",
-		// 6. Plain text passes through unchanged.
-		`plain text, no images`,
-	}
-
-	diffs := 0
-	for i, input := range inputs {
-		got, _ := StripToolResultImages(input)
-		if got != baseGolden[i] {
-			t.Errorf("input %d: head output differs from base golden\n  got:  %q\n  want: %q", i+1, got, baseGolden[i])
-			diffs++
-		}
-	}
-	// Boundary: 0 differences.
-	assert.Equal(t, 0, diffs)
-	t.Logf("6 strings compared with 0 differences: inputs=%d, diffs=%d", len(inputs), diffs)
-}
-
-// TestStripPublicationSequenceUnchanged verifies PI-6 at the database level:
-// strip over a seeded archive produces the expected revision bump. A second
-// strip is a no-op. Post-strip row content matches the base golden at commit
-// fccd49abbd53.
-func TestStripPublicationSequenceUnchanged(t *testing.T) {
-	d := testDB(t)
-	seedArtifactOrigin(t, d)
-	insertSession(t, d, "pub-unchanged", "project")
-	insertMessages(t, d, testImageMessage("pub-unchanged"))
-	clearArtifactExportQueue(t, d)
-
-	var before string
-	require.NoError(t, d.getReader().QueryRow(
-		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
-	).Scan(&before))
-
-	report, err := d.StripToolImages(t.Context(), StripImagesFilter{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, report.Changed)
-	assert.Equal(t, int64(1), report.Payloads)
-
-	var after string
-	require.NoError(t, d.getReader().QueryRow(
-		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
-	).Scan(&after))
-	assert.NotEqual(t, before, after)
-
-	// PI-6: post-strip event content must equal the base golden (fccd49abbd53).
-	// testImageMessage seeds the mixed-array format: text+image+text.
-	const baseGoldenStripped = `[{"type":"text","text":"before"},{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1},{"type":"text","text":"after"}]`
-	var eventContent string
-	require.NoError(t, d.getReader().QueryRow(
-		"SELECT content FROM tool_result_events WHERE session_id = ?", "pub-unchanged",
-	).Scan(&eventContent))
-	assert.Equal(t, baseGoldenStripped, eventContent, "post-strip content must match base golden (fccd49abbd53)")
-
-	// Second strip: no change, revision stays.
-	report2, err := d.StripToolImages(t.Context(), StripImagesFilter{})
-	require.NoError(t, err)
-	assert.Zero(t, report2.Changed)
-
-	var after2 string
-	require.NoError(t, d.getReader().QueryRow(
-		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
-	).Scan(&after2))
-	assert.Equal(t, after, after2)
-}
-
-// TestMigrateDeduplicatesAcrossSessions verifies PI-7: the same inline image
+// TestMigrateDeduplicatesAcrossSessions verifies that the same inline image
 // in two sessions produces one file and two identical asset:// references.
 // Boundary: 1 file for 2 references.
 func TestMigrateDeduplicatesAcrossSessions(t *testing.T) {

--- a/internal/db/migrate_images_test.go
+++ b/internal/db/migrate_images_test.go
@@ -193,17 +193,20 @@ func TestMigrateCancellationPreservesReport(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	calls := 0
-	put := func(mediaType string, body []byte) (string, bool, error) {
-		result, created, err := realPut(assetsDir)(mediaType, body)
-		calls++
-		if calls == 2 {
+	applies := 0
+	apply := func(ctx context.Context, session stripImageSession) (bool, error) {
+		var stats ToolImageStats
+		changed, err := d.migrateStoredToolResultRows(
+			ctx, session.id, realPut(assetsDir), &stats,
+		)
+		applies++
+		if applies == 1 {
 			cancel()
 		}
-		return result, created, err
+		return changed, err
 	}
 
-	report, err := d.MigrateToolImages(ctx, StripImagesFilter{}, put)
+	report, err := d.scanMigrateToolImages(ctx, StripImagesFilter{}, apply)
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, 1, report.Sessions)
 	assert.Equal(t, 1, report.Changed)
@@ -221,6 +224,45 @@ func TestMigrateCancellationPreservesReport(t *testing.T) {
 		"SELECT content FROM tool_result_events WHERE session_id = ?", "cancel-second",
 	).Scan(&secondContent))
 	assert.Contains(t, secondContent, "input_image")
+}
+
+// TestMigrateStatsFailurePreservesReport verifies that a statistics error
+// after a committed session still reports the work that preceded it.
+func TestMigrateStatsFailurePreservesReport(t *testing.T) {
+	d := testDB(t)
+	assetsDir := t.TempDir()
+	insertSession(t, d, "stats-first", "project")
+	insertSession(t, d, "stats-second", "project")
+	insertMessages(t, d, testImageMessage("stats-first"))
+	insertMessages(t, d, testImageMessage("stats-second"))
+
+	applies := 0
+	apply := func(ctx context.Context, session stripImageSession) (bool, error) {
+		var stats ToolImageStats
+		changed, err := d.migrateStoredToolResultRows(
+			ctx, session.id, realPut(assetsDir), &stats,
+		)
+		if err != nil {
+			return false, err
+		}
+		applies++
+		if applies == 1 {
+			_, err = d.getWriter().Exec("DROP TABLE tool_result_events")
+			require.NoError(t, err)
+		}
+		return changed, nil
+	}
+
+	report, err := d.scanMigrateToolImages(t.Context(), StripImagesFilter{}, apply)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "migrate stats")
+	assert.Equal(t, 1, report.Sessions)
+	assert.Equal(t, 1, report.Changed)
+	assert.Equal(t, int64(1), report.Payloads)
+	entries, readErr := os.ReadDir(assetsDir)
+	require.NoError(t, readErr)
+	assert.Len(t, entries, 1)
+	t.Logf("stats failure report: sessions=%d changed=%d payloads=%d", report.Sessions, report.Changed, report.Payloads)
 }
 
 // TestMigratedReferenceMatchesStoredFile verifies that migration repairs a

--- a/internal/db/migrate_images_test.go
+++ b/internal/db/migrate_images_test.go
@@ -38,26 +38,10 @@ func hexSHA256(b []byte) string {
 	return fmt.Sprintf("%x", sum[:])
 }
 
-// realPut returns a put closure that writes to assetsDir.
+// realPut returns a put closure backed by the production asset writer.
 func realPut(assetsDir string) imagePutFunc {
 	return func(mediaType string, body []byte) (string, bool, error) {
-		ext, ok := assets.ExtForMediaType(mediaType)
-		if !ok {
-			return "", false, fmt.Errorf("unsupported: %s", mediaType)
-		}
-		digest := hexSHA256(body)
-		filename := digest + ext
-		path := filepath.Join(assetsDir, filename)
-		if _, err := os.Stat(path); err == nil {
-			return "asset://" + filename, false, nil
-		}
-		if err := os.MkdirAll(assetsDir, 0o755); err != nil {
-			return "", false, err
-		}
-		if err := os.WriteFile(path, body, 0o644); err != nil {
-			return "", false, err
-		}
-		return "asset://" + filename, true, nil
+		return assets.Put(assetsDir, mediaType, body)
 	}
 }
 
@@ -196,52 +180,93 @@ func TestMigratePartialFailurePreservesReport(t *testing.T) {
 	assert.NotContains(t, secondAfter, "image_ref")
 }
 
-// TestMigratedReferenceMatchesStoredFile verifies that the reference written to
-// the row matches the SHA-256 digest of the file written to disk.
+// TestMigratedReferenceMatchesStoredFile verifies that migration repairs a
+// same-size corrupt object before removing the inline source.
 func TestMigratedReferenceMatchesStoredFile(t *testing.T) {
-	d := testDB(t)
-	assetsDir := t.TempDir()
-	insertSession(t, d, "ref-match", "project")
-	insertMessages(t, d, testImageMessage("ref-match"))
-
-	put := realPut(assetsDir)
-	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
-	require.NoError(t, err)
-	assert.Equal(t, 1, report.Changed)
-
-	var storedContent string
-	require.NoError(t, d.getReader().QueryRow(
-		"SELECT content FROM tool_result_events WHERE session_id = ?", "ref-match",
-	).Scan(&storedContent))
-
-	var blocks []json.RawMessage
-	require.NoError(t, json.Unmarshal([]byte(storedContent), &blocks))
-
-	var imageRef, sha256Hex string
-	for _, raw := range blocks {
-		var m map[string]json.RawMessage
-		if json.Unmarshal(raw, &m) != nil {
-			continue
-		}
-		if refRaw, ok := m["image_ref"]; ok {
-			require.NoError(t, json.Unmarshal(refRaw, &imageRef))
-			require.NoError(t, json.Unmarshal(m["sha256"], &sha256Hex))
-			break
-		}
-	}
-	require.NotEmpty(t, imageRef)
-
-	filename := strings.TrimPrefix(imageRef, "asset://")
-	stored, err := os.ReadFile(filepath.Join(assetsDir, filename))
-	require.NoError(t, err)
-
-	// The file holds the decoded payload of the inline image.
 	decoded, err := base64.StdEncoding.DecodeString("AAEC")
 	require.NoError(t, err)
-	assert.Equal(t, decoded, stored)
+	sum := sha256.Sum256(decoded)
+	filename := fmt.Sprintf("%x.png", sum[:])
+	for _, tt := range []struct {
+		name        string
+		seedCorrupt bool
+	}{
+		{name: "missing-object"},
+		{name: "same-size-corrupt-object", seedCorrupt: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			d := testDB(t)
+			assetsDir := t.TempDir()
+			insertSession(t, d, "ref-match", "project")
+			insertMessages(t, d, testImageMessage("ref-match"))
 
-	// sha256 field in the block matches the file's digest.
-	assert.Equal(t, hexSHA256(decoded), sha256Hex)
+			if tt.seedCorrupt {
+				corrupt := append([]byte(nil), decoded...)
+				corrupt[0] ^= 0xff
+				require.NoError(t, os.WriteFile(filepath.Join(assetsDir, filename), corrupt, 0o644))
+				assert.Len(t, corrupt, len(decoded))
+			}
+
+			report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+			require.NoError(t, err)
+			assert.Equal(t, 1, report.Changed)
+
+			var storedContent string
+			require.NoError(t, d.getReader().QueryRow(
+				"SELECT content FROM tool_result_events WHERE session_id = ?", "ref-match",
+			).Scan(&storedContent))
+			assert.NotContains(t, storedContent, "input_image")
+			assert.Contains(t, storedContent, `"text":"before"`)
+			assert.Contains(t, storedContent, `"text":"after"`)
+
+			var blocks []json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(storedContent), &blocks))
+
+			var imageRef, sha256Hex string
+			for _, raw := range blocks {
+				var m map[string]json.RawMessage
+				if json.Unmarshal(raw, &m) != nil {
+					continue
+				}
+				if refRaw, ok := m["image_ref"]; ok {
+					require.NoError(t, json.Unmarshal(refRaw, &imageRef))
+					require.NoError(t, json.Unmarshal(m["sha256"], &sha256Hex))
+					break
+				}
+			}
+			require.Equal(t, "asset://"+filename, imageRef)
+
+			stored, err := os.ReadFile(filepath.Join(assetsDir, filename))
+			require.NoError(t, err)
+			assert.Equal(t, decoded, stored)
+			assert.Equal(t, sum, sha256.Sum256(stored))
+			assert.Equal(t, hexSHA256(decoded), sha256Hex)
+
+			messages, err := d.GetAllMessages(t.Context(), "ref-match")
+			require.NoError(t, err)
+			require.Len(t, messages, 1)
+			require.Len(t, messages[0].ToolCalls, 1)
+			call := messages[0].ToolCalls[0]
+			assert.Equal(t, storedContent, call.ResultContent)
+			assert.NotContains(t, call.ResultContent, "input_image")
+
+			var summaryLength, eventLength int
+			require.NoError(t, d.getReader().QueryRow(`
+				SELECT tc.result_content_length, ev.content_length
+				FROM tool_calls tc
+				JOIN messages m ON m.id = tc.message_id
+				JOIN tool_result_events ev
+				  ON ev.session_id = tc.session_id
+				 AND ev.tool_call_message_ordinal = m.ordinal
+				 AND ev.call_index = tc.call_index
+				WHERE tc.session_id = ? AND tc.tool_use_id = ?`,
+				"ref-match", "call-1",
+			).Scan(&summaryLength, &eventLength))
+			assert.Equal(t, len(storedContent), eventLength)
+			assert.Equal(t, eventLength, summaryLength)
+			assert.Equal(t, eventLength, call.ResultContentLength)
+		})
+	}
 }
 
 // TestMigrateWritesBeforeCommit verifies the write-before-commit ordering:

--- a/internal/db/migrate_images_test.go
+++ b/internal/db/migrate_images_test.go
@@ -1,0 +1,1055 @@
+package db
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/assets"
+	"go.kenn.io/agentsview/internal/config"
+)
+
+// fakePut returns a deterministic asset:// reference without writing any file.
+func fakePut(mediaType string, _ []byte) (string, bool, error) {
+	ext, ok := assets.ExtForMediaType(mediaType)
+	if !ok {
+		return "", false, fmt.Errorf("unsupported: %s", mediaType)
+	}
+	return "asset://fake" + ext, true, nil
+}
+
+// errorPut always returns an error.
+func errorPut(_ string, _ []byte) (string, bool, error) {
+	return "", false, errors.New("forced put failure")
+}
+
+// hexSHA256 computes the lowercase hex SHA-256 of b.
+func hexSHA256(b []byte) string {
+	sum := sha256.Sum256(b)
+	return fmt.Sprintf("%x", sum[:])
+}
+
+// realPut returns a put closure that writes to assetsDir.
+func realPut(assetsDir string) imagePutFunc {
+	return func(mediaType string, body []byte) (string, bool, error) {
+		ext, ok := assets.ExtForMediaType(mediaType)
+		if !ok {
+			return "", false, fmt.Errorf("unsupported: %s", mediaType)
+		}
+		digest := hexSHA256(body)
+		filename := digest + ext
+		path := filepath.Join(assetsDir, filename)
+		if _, err := os.Stat(path); err == nil {
+			return "asset://" + filename, false, nil
+		}
+		if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+			return "", false, err
+		}
+		if err := os.WriteFile(path, body, 0o644); err != nil {
+			return "", false, err
+		}
+		return "asset://" + filename, true, nil
+	}
+}
+
+// TestToolImageMigrationContract verifies the core migration contract:
+//   - A migratable block gains image_ref and a markdown text.
+//   - A neighboring input_audio block stays byte-identical.
+//   - A version:7 placeholder stays byte-identical.
+//   - A failing put returns the original input plus the error.
+//
+// Boundary: 2 blocks preserved byte-identical.
+func TestToolImageMigrationContract(t *testing.T) {
+	audioBlock := `{"type":"input_audio","data":"dGVzdA==","format":"wav"}`
+	placeholderV7 := `{"type":"agentsview_image","version":7,"text":"[Image]","media_type":"image/png","byte_size":3}`
+	inlineBlock := `{"type":"input_image","image_url":"data:image/png;base64,AAEC"}`
+
+	content := "[" + audioBlock + "," + inlineBlock + "," + placeholderV7 + "]"
+
+	var stats ToolImageStats
+	projected, err := migrateToolResultImages(content, fakePut, &stats)
+	require.NoError(t, err)
+
+	var blocks []json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(projected), &blocks))
+	require.Len(t, blocks, 3)
+
+	// migrateToolResultImageArray re-emits skipped blocks through a bytes.Buffer
+	// unchanged, so exact byte identity (not just JSON equality) is required.
+	assert.Equal(t, audioBlock, string(blocks[0]))
+	assert.Equal(t, placeholderV7, string(blocks[2]))
+	t.Logf("2 blocks preserved byte-identical: preserved=2, migrated=1")
+
+	// Migrated block has image_ref and markdown text.
+	var migrated map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(blocks[1], &migrated))
+	assert.Contains(t, string(migrated["image_ref"]), "asset://")
+	assert.Contains(t, string(migrated["text"]), "![Image:")
+	assert.Contains(t, string(migrated["text"]), "asset://")
+	assert.Equal(t, `"agentsview_image"`, string(migrated["type"]))
+	assert.Equal(t, `1`, string(migrated["version"]))
+
+	assert.Equal(t, int64(1), stats.Payloads)
+
+	// A failing put returns original content and the error.
+	var stats2 ToolImageStats
+	result, err2 := migrateToolResultImages(content, errorPut, &stats2)
+	require.Error(t, err2)
+	assert.Equal(t, content, result)
+	assert.Zero(t, stats2.Payloads)
+}
+
+// TestMigrateLeavesBlockInlineWhenPutFails verifies the fault guard:
+// a put failure leaves the row byte-identical and rolls back.
+// Boundary: 0 rows carrying image_ref after failure.
+func TestMigrateLeavesBlockInlineWhenPutFails(t *testing.T) {
+	d := testDB(t)
+	seedArtifactOrigin(t, d)
+	insertSession(t, d, "fail-put", "project")
+	insertMessages(t, d, testImageMessage("fail-put"))
+
+	var beforeContent string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "fail-put",
+	).Scan(&beforeContent))
+	assert.Contains(t, beforeContent, "input_image")
+
+	_, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, errorPut)
+	require.Error(t, err)
+
+	var afterContent string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "fail-put",
+	).Scan(&afterContent))
+	// Boundary: 0 rows carrying image_ref after failure.
+	assert.Equal(t, beforeContent, afterContent)
+	assert.NotContains(t, afterContent, "image_ref")
+	var rowsWithRef int
+	_ = d.getReader().QueryRow(`SELECT COUNT(*) FROM tool_result_events WHERE session_id = 'fail-put' AND content LIKE '%image_ref%'`).Scan(&rowsWithRef)
+	t.Logf("0 rows carrying image_ref after the failure: got %d", rowsWithRef)
+}
+
+// TestMigratePartialFailurePreservesReport verifies the partial-failure contract:
+// when the second session's put fails, the returned report counts the first
+// session's committed payloads, the error names the failed session, and the
+// first session's rows are committed while the second's are unchanged.
+func TestMigratePartialFailurePreservesReport(t *testing.T) {
+	d := testDB(t)
+	assetsDir := t.TempDir()
+
+	insertSession(t, d, "pf-first", "project")
+	insertSession(t, d, "pf-second", "project")
+	insertMessages(t, d, testImageMessage("pf-first"))
+	insertMessages(t, d, testImageMessage("pf-second"))
+
+	// Snapshot second session content before migration.
+	var secondBefore string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "pf-second",
+	).Scan(&secondBefore))
+
+	calls := 0
+	countingPut := func(mediaType string, body []byte) (string, bool, error) {
+		calls++
+		if calls == 1 {
+			// First call succeeds (first session).
+			return realPut(assetsDir)(mediaType, body)
+		}
+		// Second call fails (second session).
+		return "", false, errors.New("forced put failure for pf-second")
+	}
+
+	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, countingPut)
+	require.Error(t, err)
+
+	// Error names the failed session.
+	assert.Contains(t, err.Error(), "pf-second")
+
+	// Report reflects only the committed first session.
+	assert.Equal(t, 1, report.Sessions)
+	assert.Equal(t, 1, report.Changed)
+	assert.Equal(t, int64(1), report.Payloads)
+
+	// First session's row is migrated.
+	var firstAfter string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "pf-first",
+	).Scan(&firstAfter))
+	assert.Contains(t, firstAfter, "image_ref")
+	assert.Contains(t, firstAfter, "asset://")
+
+	// Second session's row is unchanged.
+	var secondAfter string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "pf-second",
+	).Scan(&secondAfter))
+	assert.Equal(t, secondBefore, secondAfter)
+	assert.NotContains(t, secondAfter, "image_ref")
+}
+
+// TestMigratedReferenceMatchesStoredFile verifies that the reference written to
+// the row matches the SHA-256 digest of the file written to disk.
+func TestMigratedReferenceMatchesStoredFile(t *testing.T) {
+	d := testDB(t)
+	assetsDir := t.TempDir()
+	insertSession(t, d, "ref-match", "project")
+	insertMessages(t, d, testImageMessage("ref-match"))
+
+	put := realPut(assetsDir)
+	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Changed)
+
+	var storedContent string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "ref-match",
+	).Scan(&storedContent))
+
+	var blocks []json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(storedContent), &blocks))
+
+	var imageRef, sha256Hex string
+	for _, raw := range blocks {
+		var m map[string]json.RawMessage
+		if json.Unmarshal(raw, &m) != nil {
+			continue
+		}
+		if refRaw, ok := m["image_ref"]; ok {
+			require.NoError(t, json.Unmarshal(refRaw, &imageRef))
+			require.NoError(t, json.Unmarshal(m["sha256"], &sha256Hex))
+			break
+		}
+	}
+	require.NotEmpty(t, imageRef)
+
+	filename := strings.TrimPrefix(imageRef, "asset://")
+	stored, err := os.ReadFile(filepath.Join(assetsDir, filename))
+	require.NoError(t, err)
+
+	// The file holds the decoded payload of the inline image.
+	decoded, err := base64.StdEncoding.DecodeString("AAEC")
+	require.NoError(t, err)
+	assert.Equal(t, decoded, stored)
+
+	// sha256 field in the block matches the file's digest.
+	assert.Equal(t, hexSHA256(decoded), sha256Hex)
+}
+
+// TestMigrateWritesBeforeCommit verifies the write-before-commit ordering:
+// after a forced transaction failure the asset file exists on disk but the
+// archive row is unchanged, and a retry converges.
+// Boundary: 1 file after 2 attempts.
+func TestMigrateWritesBeforeCommit(t *testing.T) {
+	d := testDB(t)
+	seedArtifactOrigin(t, d)
+	assetsDir := t.TempDir()
+
+	insertSession(t, d, "write-before-commit", "project")
+	content := `[{"type":"input_image","image_url":"data:image/png;base64,AAEC"}]`
+	_, err := d.getWriter().Exec(`
+		INSERT INTO tool_result_events
+			(session_id, tool_call_message_ordinal, call_index,
+			 tool_use_id, agent_id, subagent_session_id,
+			 source, status, content, content_length, timestamp, event_index)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"write-before-commit", 0, 0, "toolu-wbc", "", "",
+		"tool", "completed", content, len(content),
+		"2026-01-01T00:00:00Z", 0,
+	)
+	require.NoError(t, err)
+	clearArtifactExportQueue(t, d)
+
+	// Trigger that fires after bumpTranscriptRevisionTx updates transcript_revision,
+	// aborting the transaction. At that point content UPDATEs have run but the
+	// file has already been written to disk (projection runs before UPDATEs).
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			CREATE TRIGGER fail_after_revision_bump
+			AFTER UPDATE OF transcript_revision ON sessions
+			BEGIN
+				SELECT RAISE(ABORT, 'forced failure after content update');
+			END`)
+		return err
+	}))
+
+	put := realPut(assetsDir)
+
+	// First attempt: file written but transaction rolls back.
+	_, err = d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.Error(t, err)
+
+	// Boundary: 1 file on disk despite the rollback.
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+
+	// Archive row still carries inline content.
+	var storedAfterFail string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?",
+		"write-before-commit",
+	).Scan(&storedAfterFail))
+	assert.Contains(t, storedAfterFail, "input_image")
+	assert.NotContains(t, storedAfterFail, "image_ref")
+
+	// Drop the trigger so the retry can succeed.
+	_, err = d.getWriter().Exec(`DROP TRIGGER fail_after_revision_bump`)
+	require.NoError(t, err)
+
+	// Retry converges: same file (created=false), row now has image_ref.
+	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Changed)
+
+	// Boundary: still 1 file after 2 attempts.
+	entries2, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries2, 1)
+	t.Logf("1 file after 2 attempts: %d on disk", len(entries2))
+}
+
+// TestMigrateSkipsStrippedAndUnservable verifies the negative space:
+// a v1 placeholder with a provider sha256 and no image_ref is skipped,
+// and an inline image/svg+xml payload stays inline.
+// Boundary: 0 files written.
+func TestMigrateSkipsStrippedAndUnservable(t *testing.T) {
+	d := testDB(t)
+	assetsDir := t.TempDir()
+	insertSession(t, d, "skip-ineligible", "project")
+
+	// Slice-1 placeholder with provider sha256 but no image_ref.
+	placeholderContent := `[{"type":"agentsview_image","version":1,"text":"[Image: image/png, 3 bytes]","media_type":"image/png","byte_size":3,"sha256":"abc123"}]`
+	// Inline SVG: accepted by decodeInlineImage but not in the four passive media types.
+	svgContent := `[{"type":"input_image","image_url":"data:image/svg+xml;base64,PHN2Zy8+"}]`
+
+	_, err := d.getWriter().Exec(`
+		INSERT INTO tool_result_events
+			(session_id, tool_call_message_ordinal, call_index,
+			 tool_use_id, agent_id, subagent_session_id,
+			 source, status, content, content_length, timestamp, event_index)
+		VALUES
+			(?, 0, 0, 'p1', '', '', 'tool', 'completed', ?, ?, '2026-01-01T00:00:00Z', 0),
+			(?, 0, 1, 'p2', '', '', 'tool', 'completed', ?, ?, '2026-01-01T00:00:01Z', 1)`,
+		"skip-ineligible", placeholderContent, len(placeholderContent),
+		"skip-ineligible", svgContent, len(svgContent),
+	)
+	require.NoError(t, err)
+
+	var beforeRevision string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "skip-ineligible",
+	).Scan(&beforeRevision))
+
+	put := realPut(assetsDir)
+	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.NoError(t, err)
+
+	// Boundary: 0 files written.
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	t.Logf("0 files written: %d in assets dir", len(entries))
+	assert.Zero(t, report.Sessions)
+	assert.Zero(t, report.Changed)
+
+	// SVG payload stays inline.
+	var svgAfter string
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT content FROM tool_result_events
+		WHERE session_id = ? AND event_index = 1`, "skip-ineligible",
+	).Scan(&svgAfter))
+	assert.Equal(t, svgContent, svgAfter)
+
+	// Revision unchanged.
+	var afterRevision string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "skip-ineligible",
+	).Scan(&afterRevision))
+	assert.Equal(t, beforeRevision, afterRevision)
+}
+
+// TestMigrateRejectsUnsupportedImageMediaTypes verifies that acceptance is the
+// asset store's media-type map rather than the image/ prefix parseInlineImageHeader
+// checks: image/bmp and the non-canonical image/jpg spelling providers emit both
+// stay inline. Boundary: 0 files written per media type.
+func TestMigrateRejectsUnsupportedImageMediaTypes(t *testing.T) {
+	for _, mediaType := range []string{"image/bmp", "image/jpg"} {
+		t.Run(mediaType, func(t *testing.T) {
+			d := testDB(t)
+			assetsDir := t.TempDir()
+			insertSession(t, d, "reject-media", "project")
+
+			content := `[{"type":"input_image","image_url":"data:` +
+				mediaType + `;base64,AAEC"}]`
+			_, err := d.getWriter().Exec(`
+				INSERT INTO tool_result_events
+					(session_id, tool_call_message_ordinal, call_index,
+					 tool_use_id, agent_id, subagent_session_id,
+					 source, status, content, content_length, timestamp, event_index)
+				VALUES (?, 0, 0, 'reject', '', '', 'tool', 'completed', ?, ?,
+					'2026-01-01T00:00:00Z', 0)`,
+				"reject-media", content, len(content),
+			)
+			require.NoError(t, err)
+
+			report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+			require.NoError(t, err)
+			assert.Zero(t, report.Sessions)
+			assert.Zero(t, report.Payloads)
+
+			var after string
+			require.NoError(t, d.getReader().QueryRow(
+				"SELECT content FROM tool_result_events WHERE session_id = ?", "reject-media",
+			).Scan(&after))
+			assert.Equal(t, content, after)
+
+			entries, err := os.ReadDir(assetsDir)
+			require.NoError(t, err)
+			assert.Empty(t, entries)
+			t.Logf("%s: 0 files written, block unchanged: %d in assets dir", mediaType, len(entries))
+
+			// db strip --images still removes these payloads: strip accepts any
+			// image/* data URI, so the two commands disagree by design.
+			stripped, stats := StripToolResultImages(content)
+			assert.Equal(t, int64(1), stats.Payloads)
+			assert.Contains(t, stripped, `"type":"agentsview_image"`)
+		})
+	}
+}
+
+// TestMigratePreviewAndApplyAgreeOnUnsupportedType verifies that preview and
+// apply share one migratability predicate. A session mixing a migratable PNG
+// with an unsupported media type must report the same payload count either way,
+// and put must never see the unsupported block: assets.Put would reject it and
+// the projection error would abort the whole session transaction.
+func TestMigratePreviewAndApplyAgreeOnUnsupportedType(t *testing.T) {
+	d := testDB(t)
+	assetsDir := t.TempDir()
+	insertSession(t, d, "mixed-media", "project")
+
+	content := `[{"type":"input_image","image_url":"data:image/png;base64,AAEC"},` +
+		`{"type":"input_image","image_url":"data:image/bmp;base64,AAEC"}]`
+	_, err := d.getWriter().Exec(`
+		INSERT INTO tool_result_events
+			(session_id, tool_call_message_ordinal, call_index,
+			 tool_use_id, agent_id, subagent_session_id,
+			 source, status, content, content_length, timestamp, event_index)
+		VALUES (?, 0, 0, 'mixed', '', '', 'tool', 'completed', ?, ?,
+			'2026-01-01T00:00:00Z', 0)`,
+		"mixed-media", content, len(content),
+	)
+	require.NoError(t, err)
+
+	preview, err := d.PreviewMigrateToolImages(t.Context(), StripImagesFilter{})
+	require.NoError(t, err)
+
+	write := realPut(assetsDir)
+	var putTypes []string
+	put := func(mediaType string, body []byte) (string, bool, error) {
+		putTypes = append(putTypes, mediaType)
+		return write(mediaType, body)
+	}
+	applied, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.NoError(t, err)
+
+	assert.Equal(t, preview.Payloads, applied.Payloads)
+	assert.Equal(t, int64(1), applied.Payloads)
+	assert.Equal(t, preview.Sessions, applied.Sessions)
+	assert.Equal(t, []string{"image/png"}, putTypes)
+
+	var after string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "mixed-media",
+	).Scan(&after))
+	assert.Contains(t, after, "image_ref")
+	assert.Contains(t, after, "data:image/bmp;base64,AAEC")
+	t.Logf("preview payloads=%d, applied payloads=%d, put calls=%d",
+		preview.Payloads, applied.Payloads, len(putTypes))
+}
+
+// TestMigrateSummaryPutFailureLeavesStatsUntouched verifies that the
+// labeled-summary path unwinds like the array path: when a later section's put
+// fails, the caller's stats keep the value they had and the content is returned
+// unchanged. Boundary: 0 counts added for 1 successful section.
+func TestMigrateSummaryPutFailureLeavesStatsUntouched(t *testing.T) {
+	content := "agent-a:\n" + testInlineImageContent() +
+		"\n\nagent-b:\n" + testInlineImageContent()
+
+	before := ToolImageStats{Payloads: 5, StoredBytes: 50, DecodedBytes: 500}
+	stats := before
+	calls := 0
+	put := func(mediaType string, body []byte) (string, bool, error) {
+		calls++
+		if calls == 1 {
+			return fakePut(mediaType, body)
+		}
+		return "", false, errors.New("forced put failure in the second section")
+	}
+
+	got, err := migrateToolResultImages(content, put, &stats)
+	require.Error(t, err)
+	assert.Equal(t, content, got)
+	assert.Equal(t, 2, calls, "the first section must migrate before the failure")
+	assert.Equal(t, before, stats)
+	t.Logf("0 counts added for 1 successful section: payloads before=%d after=%d",
+		before.Payloads, stats.Payloads)
+}
+
+// TestMigrateNoOpPreservesRevisionAndQueue verifies PI-3: a session with no
+// migratable payloads produces no publications, no revision bump, no queue row.
+// Boundary: 0 publications.
+func TestMigrateNoOpPreservesRevisionAndQueue(t *testing.T) {
+	d := testDB(t)
+	seedArtifactOrigin(t, d)
+	assetsDir := t.TempDir()
+	insertSession(t, d, "noop-session", "project")
+	insertMessages(t, d, Message{
+		SessionID: "noop-session",
+		Ordinal:   0,
+		Role:      "assistant",
+		Content:   "plain text only",
+		ToolCalls: []ToolCall{{
+			ToolUseID:     "call-plain",
+			ResultContent: "plain result",
+			ResultEvents:  []ToolResultEvent{{Content: "plain result"}},
+		}},
+	})
+
+	var beforeRevision string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "noop-session",
+	).Scan(&beforeRevision))
+
+	// Seed observable tail-step state so a spurious execution of any step is
+	// detectable. rewriteStoredToolResultRows touches quality_signal_version
+	// (invalidateSessionSignalsTx) and last_write_incremental
+	// (resetIncrementalMarkerTx) on every change; we verify both are unchanged.
+	_, err := d.getWriter().Exec(
+		"UPDATE sessions SET quality_signal_version = 7, last_write_incremental = 1 WHERE id = ?",
+		"noop-session",
+	)
+	require.NoError(t, err)
+	// Clear after seeding: the sessions UPDATE may trigger an artifact-export enqueue.
+	clearArtifactExportQueue(t, d)
+
+	put := realPut(assetsDir)
+	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.NoError(t, err)
+
+	// Boundary: 0 publications.
+	assert.Zero(t, report.Sessions)
+	assert.Zero(t, report.Changed)
+
+	var afterRevision string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "noop-session",
+	).Scan(&afterRevision))
+	assert.Equal(t, beforeRevision, afterRevision)
+
+	// No new publication queued: pending stays 0 (clearArtifactExportQueue zeros
+	// rows but does not delete them).
+	var pending int
+	_ = d.getReader().QueryRow(
+		"SELECT pending FROM artifact_export_queue WHERE session_id = ?", "noop-session",
+	).Scan(&pending)
+	assert.Zero(t, pending)
+
+	// Signal invalidation and incremental-marker reset must not fire.
+	var qualitySignalVersion, lastWriteIncremental int
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT quality_signal_version, last_write_incremental FROM sessions WHERE id = ?",
+		"noop-session",
+	).Scan(&qualitySignalVersion, &lastWriteIncremental))
+	assert.Equal(t, 7, qualitySignalVersion, "quality_signal_version must not be zeroed by invalidateSessionSignalsTx")
+	assert.Equal(t, 1, lastWriteIncremental, "last_write_incremental must not be zeroed by resetIncrementalMarkerTx")
+
+	// Nothing written to the assets directory.
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	t.Logf("0 publications: sessions=%d, changed=%d, assets=%d", report.Sessions, report.Changed, len(entries))
+}
+
+// TestStripToolResultImagesUnchangedAfterRefactor verifies PI-6: extracting
+// rewriteStoredToolResultRows does not change StripToolResultImages output.
+// Six stored strings including a webp with charset parameter and a labeled
+// summary whose second section is anonymous.
+// Golden values were captured at base commit fccd49abbd53.
+// Boundary: 6 strings compared with 0 differences.
+func TestStripToolResultImagesUnchangedAfterRefactor(t *testing.T) {
+	inputs := []string{
+		// 1. Simple PNG inline.
+		`[{"type":"input_image","image_url":"data:image/png;base64,AAEC"}]`,
+		// 2. WebP with charset parameter — parseInlineImageHeader requires exactly
+		// two semicolon-delimited parts before the comma, so this passes through.
+		`[{"type":"input_image","image_url":"data:image/webp;charset=utf-8;base64,AAEC"}]`,
+		// 3. Already-stripped placeholder (no-op for strip).
+		`[{"type":"agentsview_image","version":1,"text":"[Image: image/png, 3 bytes]","media_type":"image/png","byte_size":3,"sha256":""}]`,
+		// 4. Mixed array with non-image blocks.
+		`[{"type":"text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AAEC"},{"type":"text","text":"after"}]`,
+		// 5. Labeled summary with anonymous trailing section.
+		"agent-a:\n[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAEC\"}]\n\n[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAEC\"}]",
+		// 6. Plain text with no images.
+		`plain text, no images`,
+	}
+	// Golden outputs captured at base commit fccd49abbd53. Head must match.
+	baseGolden := []string{
+		// 1. PNG stripped to placeholder.
+		`[{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1}]`,
+		// 2. WebP with charset passes through unchanged (3-part header rejected).
+		`[{"type":"input_image","image_url":"data:image/webp;charset=utf-8;base64,AAEC"}]`,
+		// 3. Already-stripped placeholder passes through unchanged.
+		`[{"type":"agentsview_image","version":1,"text":"[Image: image/png, 3 bytes]","media_type":"image/png","byte_size":3,"sha256":""}]`,
+		// 4. Mixed array: image stripped, text blocks pass through.
+		`[{"type":"text","text":"before"},{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1},{"type":"text","text":"after"}]`,
+		// 5. Both labeled sections stripped.
+		"agent-a:\n[{\"byte_size\":3,\"media_type\":\"image/png\",\"sha256\":\"\",\"text\":\"[Image: image/png, 3 bytes]\",\"type\":\"agentsview_image\",\"version\":1}]\n\n[{\"byte_size\":3,\"media_type\":\"image/png\",\"sha256\":\"\",\"text\":\"[Image: image/png, 3 bytes]\",\"type\":\"agentsview_image\",\"version\":1}]",
+		// 6. Plain text passes through unchanged.
+		`plain text, no images`,
+	}
+
+	diffs := 0
+	for i, input := range inputs {
+		got, _ := StripToolResultImages(input)
+		if got != baseGolden[i] {
+			t.Errorf("input %d: head output differs from base golden\n  got:  %q\n  want: %q", i+1, got, baseGolden[i])
+			diffs++
+		}
+	}
+	// Boundary: 0 differences.
+	assert.Equal(t, 0, diffs)
+	t.Logf("6 strings compared with 0 differences: inputs=%d, diffs=%d", len(inputs), diffs)
+}
+
+// TestStripPublicationSequenceUnchanged verifies PI-6 at the database level:
+// strip over a seeded archive produces the expected revision bump. A second
+// strip is a no-op. Post-strip row content matches the base golden at commit
+// fccd49abbd53.
+func TestStripPublicationSequenceUnchanged(t *testing.T) {
+	d := testDB(t)
+	seedArtifactOrigin(t, d)
+	insertSession(t, d, "pub-unchanged", "project")
+	insertMessages(t, d, testImageMessage("pub-unchanged"))
+	clearArtifactExportQueue(t, d)
+
+	var before string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
+	).Scan(&before))
+
+	report, err := d.StripToolImages(t.Context(), StripImagesFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Changed)
+	assert.Equal(t, int64(1), report.Payloads)
+
+	var after string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
+	).Scan(&after))
+	assert.NotEqual(t, before, after)
+
+	// PI-6: post-strip event content must equal the base golden (fccd49abbd53).
+	// testImageMessage seeds the mixed-array format: text+image+text.
+	const baseGoldenStripped = `[{"type":"text","text":"before"},{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1},{"type":"text","text":"after"}]`
+	var eventContent string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "pub-unchanged",
+	).Scan(&eventContent))
+	assert.Equal(t, baseGoldenStripped, eventContent, "post-strip content must match base golden (fccd49abbd53)")
+
+	// Second strip: no change, revision stays.
+	report2, err := d.StripToolImages(t.Context(), StripImagesFilter{})
+	require.NoError(t, err)
+	assert.Zero(t, report2.Changed)
+
+	var after2 string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
+	).Scan(&after2))
+	assert.Equal(t, after, after2)
+}
+
+// TestMigrateDeduplicatesAcrossSessions verifies PI-7: the same inline image
+// in two sessions produces one file and two identical asset:// references.
+// Boundary: 1 file for 2 references.
+func TestMigrateDeduplicatesAcrossSessions(t *testing.T) {
+	d := testDB(t)
+	assetsDir := t.TempDir()
+	for _, id := range []string{"dedup-a", "dedup-b"} {
+		insertSession(t, d, id, "project")
+		insertMessages(t, d, testImageMessage(id))
+	}
+
+	put := realPut(assetsDir)
+	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.NoError(t, err)
+	assert.Equal(t, 2, report.Changed)
+
+	// Boundary: 1 file for 2 references.
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	t.Logf("1 file for 2 references: files=%d", len(entries))
+
+	refs := make([]string, 0, 2)
+	for _, id := range []string{"dedup-a", "dedup-b"} {
+		var content string
+		require.NoError(t, d.getReader().QueryRow(
+			"SELECT content FROM tool_result_events WHERE session_id = ?", id,
+		).Scan(&content))
+		var blocks []json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(content), &blocks))
+		for _, raw := range blocks {
+			var m map[string]json.RawMessage
+			if json.Unmarshal(raw, &m) != nil {
+				continue
+			}
+			if refRaw, ok := m["image_ref"]; ok {
+				var ref string
+				require.NoError(t, json.Unmarshal(refRaw, &ref))
+				refs = append(refs, ref)
+			}
+		}
+	}
+	require.Len(t, refs, 2)
+	assert.Equal(t, refs[0], refs[1])
+}
+
+// TestMigrateStateMatrix covers keep, drop, tombstoned-session, and orphan
+// rows over stored content.
+func TestMigrateStateMatrix(t *testing.T) {
+	// keep: inline payload migrated.
+	t.Run("keep", func(t *testing.T) {
+		d := testDB(t)
+		assetsDir := t.TempDir()
+		insertSession(t, d, "keep-session", "project")
+		insertMessages(t, d, testImageMessage("keep-session"))
+		report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+		require.NoError(t, err)
+		assert.Equal(t, 1, report.Changed)
+	})
+
+	// drop: slice-1 placeholder carries no inline bytes; nothing to migrate.
+	t.Run("drop", func(t *testing.T) {
+		d := testDB(t)
+		d.SetToolResultImages(config.ToolResultImagesDrop)
+		insertSession(t, d, "drop-session", "project")
+		insertMessages(t, d, testImageMessage("drop-session"))
+		report, err := d.PreviewMigrateToolImages(t.Context(), StripImagesFilter{})
+		require.NoError(t, err)
+		assert.Zero(t, report.Sessions)
+	})
+
+	// tombstoned: session deleted from table; not selected.
+	t.Run("tombstoned", func(t *testing.T) {
+		d := testDB(t)
+		assetsDir := t.TempDir()
+		insertSession(t, d, "tombstoned", "project")
+		insertMessages(t, d, testImageMessage("tombstoned"))
+		_, err := d.getWriter().Exec("DELETE FROM sessions WHERE id = ?", "tombstoned")
+		require.NoError(t, err)
+		report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+		require.NoError(t, err)
+		assert.Zero(t, report.Sessions)
+		entries, err := os.ReadDir(assetsDir)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+
+	// trashed and source-missing sessions are reachable.
+	t.Run("trashed-and-source-missing", func(t *testing.T) {
+		d := testDB(t)
+		assetsDir := t.TempDir()
+		insertSession(t, d, "trashed-mig", "project")
+		insertSession(t, d, "srcmissing-mig", "project")
+		insertMessages(t, d, testImageMessage("trashed-mig"))
+		insertMessages(t, d, testImageMessage("srcmissing-mig"))
+		require.NoError(t, d.SoftDeleteSession("trashed-mig"))
+		sourcePath := filepath.Join(t.TempDir(), "missing.jsonl")
+		insertSession(t, d, "srcmissing-mig", "project", func(s *Session) {
+			s.FilePath = &sourcePath
+		})
+		_, err := d.getWriter().Exec(
+			"UPDATE sessions SET source_missing_at = ? WHERE id = ?",
+			"2026-01-01T00:00:00Z", "srcmissing-mig",
+		)
+		require.NoError(t, err)
+		report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+		require.NoError(t, err)
+		assert.Equal(t, 2, report.Changed)
+	})
+
+	// labeled-summary: content in multiline labeled-summary format (multi-agent)
+	// exercises migrateToolResultSummaryImages. Only the inline image block
+	// within the labeled section is migrated; the plain-text section is unchanged.
+	t.Run("labeled-summary", func(t *testing.T) {
+		d := testDB(t)
+		assetsDir := t.TempDir()
+		insertSession(t, d, "labeled-sum", "project")
+
+		// Multiline labeled-summary: agent-a has an inline image, agent-b is plain.
+		labeledContent := "agent-a:\n" + testInlineImageContent() + "\n\nagent-b:\n[{\"type\":\"text\",\"text\":\"plain\"}]"
+		_, err := d.getWriter().Exec(`
+			INSERT INTO tool_result_events
+				(session_id, tool_call_message_ordinal, call_index,
+				 tool_use_id, agent_id, subagent_session_id,
+				 source, status, content, content_length, timestamp, event_index)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			"labeled-sum", 0, 0, "toolu-ls", "", "",
+			"tool", "completed", labeledContent, len(labeledContent),
+			"2026-01-01T00:00:00Z", 0,
+		)
+		require.NoError(t, err)
+
+		report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+		require.NoError(t, err)
+		assert.Equal(t, 1, report.Changed)
+
+		var stored string
+		require.NoError(t, d.getReader().QueryRow(
+			"SELECT content FROM tool_result_events WHERE session_id = ?", "labeled-sum",
+		).Scan(&stored))
+		assert.Contains(t, stored, "image_ref")
+		assert.Contains(t, stored, "asset://")
+		assert.Contains(t, stored, "agent-b:")
+		assert.Contains(t, stored, `"text":"plain"`)
+		assert.NotContains(t, stored, "input_image")
+	})
+
+	// keep-to-drop-historical: session with a mix of historical inline content
+	// (stored under keep policy) and an already-stripped placeholder (stored
+	// under drop policy). Migration migrates only the inline block.
+	t.Run("keep-to-drop-historical", func(t *testing.T) {
+		d := testDB(t)
+		assetsDir := t.TempDir()
+		insertSession(t, d, "ktd-session", "project")
+
+		inlineContent := testInlineImageContent()
+		// Slice-1 placeholder already stored (simulates a later result stripped at ingest).
+		strippedContent := `[{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1}]`
+
+		_, err := d.getWriter().Exec(`
+			INSERT INTO tool_result_events
+				(session_id, tool_call_message_ordinal, call_index,
+				 tool_use_id, agent_id, subagent_session_id,
+				 source, status, content, content_length, timestamp, event_index)
+			VALUES
+				(?, 0, 0, 'ktd-inline', '', '', 'tool', 'completed', ?, ?, '2026-01-01T00:00:00Z', 0),
+				(?, 0, 1, 'ktd-stripped', '', '', 'tool', 'completed', ?, ?, '2026-01-01T00:00:01Z', 1)`,
+			"ktd-session", inlineContent, len(inlineContent),
+			"ktd-session", strippedContent, len(strippedContent),
+		)
+		require.NoError(t, err)
+
+		report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+		require.NoError(t, err)
+		assert.Equal(t, 1, report.Changed)
+		assert.Equal(t, int64(1), report.Payloads, "only the historical inline event should be migrated")
+
+		// Inline event is migrated.
+		var inlineAfter string
+		require.NoError(t, d.getReader().QueryRow(`
+			SELECT content FROM tool_result_events
+			WHERE session_id = ? AND event_index = 0`, "ktd-session",
+		).Scan(&inlineAfter))
+		assert.Contains(t, inlineAfter, "image_ref")
+
+		// Already-stripped event is unchanged.
+		var strippedAfter string
+		require.NoError(t, d.getReader().QueryRow(`
+			SELECT content FROM tool_result_events
+			WHERE session_id = ? AND event_index = 1`, "ktd-session",
+		).Scan(&strippedAfter))
+		assert.Equal(t, strippedContent, strippedAfter)
+	})
+
+	// late-result: a tool result event that arrived via an incremental write
+	// (event_index > 0) carries an inline image. Migration reaches it.
+	t.Run("late-result", func(t *testing.T) {
+		d := testDB(t)
+		assetsDir := t.TempDir()
+		insertSession(t, d, "late-mig", "project")
+
+		// Insert a late-arriving event directly (simulates WriteSessionIncremental).
+		lateContent := `[{"type":"input_image","image_url":"data:image/gif;base64,AAEC"}]`
+		_, err := d.getWriter().Exec(`
+			INSERT INTO tool_result_events
+				(session_id, tool_call_message_ordinal, call_index,
+				 tool_use_id, agent_id, subagent_session_id,
+				 source, status, content, content_length, timestamp, event_index)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			"late-mig", 1, 0, "toolu-late", "agent-x", "",
+			"function_call_output", "completed", lateContent, len(lateContent),
+			"2026-01-01T00:00:01Z", 1,
+		)
+		require.NoError(t, err)
+
+		report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+		require.NoError(t, err)
+		assert.Equal(t, 1, report.Changed)
+
+		var stored string
+		require.NoError(t, d.getReader().QueryRow(
+			"SELECT content FROM tool_result_events WHERE session_id = ?", "late-mig",
+		).Scan(&stored))
+		assert.Contains(t, stored, "image_ref")
+		assert.Contains(t, stored, "asset://")
+		assert.NotContains(t, stored, "input_image")
+	})
+
+	// blocked-result-neighbor: a withheld (blocked) tool result beside a migratable
+	// inline image. Migration must not alter the blocked result's accounting length.
+	// Boundary: 913, the neighboring withheld empty result's retained accounting length.
+	t.Run("blocked-result-neighbor", func(t *testing.T) {
+		d := testDB(t)
+		assetsDir := t.TempDir()
+		insertSession(t, d, "blocked-nbr", "project")
+
+		const blockedLen = 913
+		blockedRaw := strings.Repeat("x", blockedLen)
+
+		insertMessages(t, d, Message{
+			SessionID: "blocked-nbr",
+			Ordinal:   0,
+			Role:      "assistant",
+			ToolCalls: []ToolCall{
+				{
+					ToolName:      "Read",
+					Category:      "Read",
+					ToolUseID:     "call-img",
+					ResultContent: testInlineImageContent(),
+					ResultEvents: []ToolResultEvent{{
+						ToolUseID: "call-img",
+						Source:    "tool",
+						Status:    "completed",
+						Content:   testInlineImageContent(),
+					}},
+				},
+				{
+					ToolName:            "exec_command",
+					Category:            "Bash",
+					ToolUseID:           "call-blocked",
+					ResultContentLength: blockedLen,
+					ResultEvents: []ToolResultEvent{{
+						ToolUseID:     "call-blocked",
+						Source:        "function_call_output",
+						Status:        "completed",
+						Content:       blockedRaw,
+						ContentLength: blockedLen,
+					}},
+				},
+			},
+		})
+
+		report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, realPut(assetsDir))
+		require.NoError(t, err)
+		assert.Equal(t, 1, report.Changed)
+
+		var storedLen int
+		require.NoError(t, d.getReader().QueryRow(`
+			SELECT COALESCE(result_content_length, 0)
+			FROM tool_calls WHERE session_id = ? AND tool_use_id = ?`,
+			"blocked-nbr", "call-blocked",
+		).Scan(&storedLen))
+		assert.Equal(t, blockedLen, storedLen)
+		t.Logf("neighboring withheld empty result retained accounting length: %d — boundary 913", storedLen)
+	})
+}
+
+// TestMigrateDeduplicatedSummaryKeepsCollapse verifies that the
+// deduplicated-summary collapse in rewriteStoredToolResultRows is preserved:
+// a collapsed call (empty result_content, non-zero result_content_length from
+// the event) migrates the event's content and keeps the length in sync.
+// testImageMessage already produces a dedup scenario: result_content is NULL in
+// tool_calls (the db deduplicates it against the event content on insert).
+func TestMigrateDeduplicatedSummaryKeepsCollapse(t *testing.T) {
+	d := testDB(t)
+	assetsDir := t.TempDir()
+	put := realPut(assetsDir)
+	seedArtifactOrigin(t, d)
+	insertSession(t, d, "dedup-collapse", "project")
+	insertMessages(t, d, testImageMessage("dedup-collapse"))
+	clearArtifactExportQueue(t, d)
+
+	// Verify the dedup invariant: result_content is empty, result_content_length
+	// is positive (set to the event length at insert time).
+	var beforeCallContent string
+	var beforeLength int
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT COALESCE(result_content, ''), result_content_length
+		FROM tool_calls WHERE session_id = ?`, "dedup-collapse",
+	).Scan(&beforeCallContent, &beforeLength))
+	assert.Empty(t, beforeCallContent)
+	assert.Positive(t, beforeLength)
+
+	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Changed)
+
+	var callContent string
+	var callLength int
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT COALESCE(result_content, ''), result_content_length
+		FROM tool_calls WHERE session_id = ?`, "dedup-collapse",
+	).Scan(&callContent, &callLength))
+
+	var eventContent string
+	var eventLength int
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT content, content_length
+		FROM tool_result_events WHERE session_id = ?`, "dedup-collapse",
+	).Scan(&eventContent, &eventLength))
+
+	// Call stays collapsed (result_content still empty) but length follows the
+	// migrated event content.
+	assert.Empty(t, callContent)
+	assert.Equal(t, eventLength, callLength)
+	assert.Equal(t, len(eventContent), eventLength)
+	// Event carries image_ref and asset:// reference.
+	assert.Contains(t, eventContent, "image_ref")
+	assert.Contains(t, eventContent, "asset://")
+}
+
+// TestMigrateReachesOrphanEventRows verifies that orphaned tool_result_events
+// rows (with no matching tool_call) are migrated.
+func TestMigrateReachesOrphanEventRows(t *testing.T) {
+	d := testDB(t)
+	seedArtifactOrigin(t, d)
+	assetsDir := t.TempDir()
+	insertSession(t, d, "orphan-event", "project")
+
+	content := `[{"type":"input_image","image_url":"data:image/png;base64,AAEC"}]`
+	_, err := d.getWriter().Exec(`
+		INSERT INTO tool_result_events
+			(session_id, tool_call_message_ordinal, call_index,
+			 tool_use_id, agent_id, subagent_session_id,
+			 source, status, content, content_length, timestamp, event_index)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"orphan-event", 7, 2, "toolu-orphan", "agent-1", "child-1",
+		"subagent_notification", "completed", content, len(content),
+		"2026-01-01T00:00:00Z", 0,
+	)
+	require.NoError(t, err)
+	clearArtifactExportQueue(t, d)
+
+	put := realPut(assetsDir)
+	report, err := d.MigrateToolImages(t.Context(), StripImagesFilter{}, put)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Changed)
+
+	var stored string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "orphan-event",
+	).Scan(&stored))
+	assert.Contains(t, stored, "image_ref")
+	assert.Contains(t, stored, "asset://")
+}

--- a/internal/db/strip_images.go
+++ b/internal/db/strip_images.go
@@ -89,10 +89,27 @@ func (db *DB) StripToolImagesForSessions(ctx context.Context, sessionIDs []strin
 	return nil
 }
 
-// stripStoredToolResultRows projects both stored tool-result tables in one
-// transaction. Direct row updates preserve event coordinates and metadata.
+// storedToolResultProjection transforms one stored result-content string.
+// A returned error aborts the session transaction.
+type storedToolResultProjection func(string) (string, error)
+
+// stripStoredToolResultRows is a wrapper over rewriteStoredToolResultRows
+// that applies the strip projection: StripToolResultImages, discarding stats.
 func (db *DB) stripStoredToolResultRows(
 	ctx context.Context, sessionID string,
+) (bool, error) {
+	return db.rewriteStoredToolResultRows(ctx, sessionID, func(content string) (string, error) {
+		projected, _ := StripToolResultImages(content)
+		return projected, nil
+	})
+}
+
+// rewriteStoredToolResultRows rewrites both stored tool-result tables in one
+// transaction using the given projection. Direct row updates preserve event
+// coordinates and metadata. The projection is called once per stored content
+// string; a projection error closes the open Rows and aborts the transaction.
+func (db *DB) rewriteStoredToolResultRows(
+	ctx context.Context, sessionID string, project storedToolResultProjection,
 ) (bool, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -143,7 +160,11 @@ func (db *DB) stripStoredToolResultRows(
 			return false, fmt.Errorf("scanning tool call: %w", err)
 		}
 		allCalls = append(allCalls, update)
-		projected, _ := StripToolResultImages(update.content)
+		projected, err := project(update.content)
+		if err != nil {
+			callRows.Close()
+			return false, err
+		}
 		if projected != update.content {
 			update.content = projected
 			update.length = ResolveResultContentLength(projected, update.length)
@@ -174,7 +195,11 @@ func (db *DB) stripStoredToolResultRows(
 			eventRows.Close()
 			return false, fmt.Errorf("scanning tool result event: %w", err)
 		}
-		projected, _ := StripToolResultImages(update.content)
+		projected, err := project(update.content)
+		if err != nil {
+			eventRows.Close()
+			return false, err
+		}
 		eventContents[update.key] = append(
 			eventContents[update.key], projected,
 		)

--- a/internal/db/strip_images.go
+++ b/internal/db/strip_images.go
@@ -44,7 +44,7 @@ type stripImageSession struct {
 func (db *DB) PreviewStripToolImages(
 	ctx context.Context, filter StripImagesFilter,
 ) (StripImagesReport, error) {
-	return db.scanStripToolImages(ctx, filter, nil)
+	return db.scanToolImages(ctx, filter, countStrippable, nil)
 }
 
 // StripToolImages transforms selected sessions one at a time. The caller owns
@@ -55,7 +55,7 @@ func (db *DB) StripToolImages(
 	if err := db.requireWritable(); err != nil {
 		return StripImagesReport{}, err
 	}
-	return db.scanStripToolImages(ctx, filter, func(
+	return db.scanToolImages(ctx, filter, countStrippable, func(
 		ctx context.Context, session stripImageSession,
 	) (bool, error) {
 		changed, err := db.stripStoredToolResultRows(ctx, session.id)
@@ -75,7 +75,7 @@ func (db *DB) StripToolImagesForSessions(ctx context.Context, sessionIDs []strin
 		return err
 	}
 	for _, id := range sessionIDs {
-		stats, err := db.stripImageStats(ctx, id)
+		stats, err := db.toolImageStats(ctx, id, countStrippable)
 		if err != nil {
 			return err
 		}
@@ -308,9 +308,10 @@ func (db *DB) rewriteStoredToolResultRows(
 	return true, nil
 }
 
-func (db *DB) scanStripToolImages(
+func (db *DB) scanToolImages(
 	ctx context.Context,
 	filter StripImagesFilter,
+	count func(string) ToolImageStats,
 	apply func(context.Context, stripImageSession) (bool, error),
 ) (StripImagesReport, error) {
 	sessions, err := db.stripImageSessions(ctx, filter)
@@ -323,15 +324,23 @@ func (db *DB) scanStripToolImages(
 	byProject := make(map[string]*StripImagesProjectReport)
 	for _, session := range sessions {
 		if err := ctx.Err(); err != nil {
-			return StripImagesReport{}, err
+			return report, err
 		}
-		stats, err := db.stripImageStats(ctx, session.id)
+		stats, err := db.toolImageStats(ctx, session.id, count)
 		if err != nil {
-			return StripImagesReport{}, err
+			return report, err
 		}
 		if stats.Payloads == 0 {
 			continue
 		}
+		changed := true
+		if apply != nil {
+			changed, err = apply(ctx, session)
+			if err != nil {
+				return report, err
+			}
+		}
+		// Only include sessions whose transaction succeeded in partial reports.
 		project := byProject[session.project]
 		if project == nil {
 			report.Projects = append(report.Projects, StripImagesProjectReport{
@@ -342,16 +351,7 @@ func (db *DB) scanStripToolImages(
 		}
 		project.Sessions++
 		report.Sessions++
-		if apply != nil {
-			changed, err := apply(ctx, session)
-			if err != nil {
-				return StripImagesReport{}, err
-			}
-			if changed {
-				project.Changed++
-				report.Changed++
-			}
-		} else if stats.Payloads > 0 {
+		if changed {
 			project.Changed++
 			report.Changed++
 		}
@@ -416,8 +416,8 @@ func (db *DB) stripImageSessions(
 	return sessions, rows.Err()
 }
 
-func (db *DB) stripImageStats(
-	ctx context.Context, sessionID string,
+func (db *DB) toolImageStats(
+	ctx context.Context, sessionID string, count func(string) ToolImageStats,
 ) (ToolImageStats, error) {
 	var stats ToolImageStats
 	rows, err := db.getReader().QueryContext(ctx, `
@@ -437,7 +437,7 @@ func (db *DB) stripImageStats(
 		if err := rows.Scan(&content); err != nil {
 			return ToolImageStats{}, fmt.Errorf("scanning tool result bytes: %w", err)
 		}
-		_, found := StripToolResultImages(content)
+		found := count(content)
 		stats.Payloads += found.Payloads
 		stats.StoredBytes += found.StoredBytes
 		stats.DecodedBytes += found.DecodedBytes
@@ -446,4 +446,9 @@ func (db *DB) stripImageStats(
 		return ToolImageStats{}, fmt.Errorf("iterating tool result bytes: %w", err)
 	}
 	return stats, nil
+}
+
+func countStrippable(content string) ToolImageStats {
+	_, stats := StripToolResultImages(content)
+	return stats
 }

--- a/internal/db/strip_images_test.go
+++ b/internal/db/strip_images_test.go
@@ -320,6 +320,8 @@ func TestStripToolImagesProjectsOrphanedStoredEvents(t *testing.T) {
 
 func TestStripToolImagesRollsBackWhenEventUpdateFails(t *testing.T) {
 	d := testDB(t)
+	insertSession(t, d, "committed", "earlier-project")
+	insertMessages(t, d, testImageMessage("committed"))
 	insertSession(t, d, "rollback", "project")
 	message := testImageMessage("rollback")
 	message.ToolCalls[0].ResultContent =
@@ -329,15 +331,29 @@ func TestStripToolImagesRollsBackWhenEventUpdateFails(t *testing.T) {
 		_, err := tx.Exec(`
 			CREATE TRIGGER fail_strip_event_update
 			AFTER UPDATE OF content ON tool_result_events
+			WHEN OLD.session_id = 'rollback'
 			BEGIN
 				SELECT RAISE(FAIL, 'forced strip event update failure');
 			END`)
 		return err
 	}))
 
-	_, err := d.StripToolImages(context.Background(), StripImagesFilter{})
+	report, err := d.StripToolImages(context.Background(), StripImagesFilter{})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "updating orphaned tool result event")
+	assert.Equal(t, StripImagesReport{
+		Sessions: 1, Changed: 1, Payloads: 1, StoredBytes: 26, DecodedBytes: 3,
+		Projects: []StripImagesProjectReport{{
+			Project: "earlier-project", Sessions: 1, Changed: 1,
+			Payloads: 1, StoredBytes: 26, DecodedBytes: 3,
+		}},
+	}, report)
+	var committedContent string
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT content FROM tool_result_events WHERE session_id = 'committed'`,
+	).Scan(&committedContent))
+	assert.Contains(t, committedContent, "agentsview_image")
+	assert.NotContains(t, committedContent, "input_image")
 
 	var storedCall, storedEvent string
 	require.NoError(t, d.getReader().QueryRow(`
@@ -482,4 +498,88 @@ func TestStripToolImagesRescansStoredEventCoordinates(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStripToolResultImagesGolden covers placeholders, unsupported headers,
+// mixed blocks, and summaries with anonymous sections.
+func TestStripToolResultImagesGolden(t *testing.T) {
+	inputs := []string{
+		// 1. Simple PNG inline.
+		`[{"type":"input_image","image_url":"data:image/png;base64,AAEC"}]`,
+		// 2. WebP with charset parameter — parseInlineImageHeader requires exactly
+		// two semicolon-delimited parts before the comma, so this passes through.
+		`[{"type":"input_image","image_url":"data:image/webp;charset=utf-8;base64,AAEC"}]`,
+		// 3. Already-stripped placeholder (no-op for strip).
+		`[{"type":"agentsview_image","version":1,"text":"[Image: image/png, 3 bytes]","media_type":"image/png","byte_size":3,"sha256":""}]`,
+		// 4. Mixed array with non-image blocks.
+		`[{"type":"text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AAEC"},{"type":"text","text":"after"}]`,
+		// 5. Labeled summary with anonymous trailing section.
+		"agent-a:\n[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAEC\"}]\n\n[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,AAEC\"}]",
+		// 6. Plain text with no images.
+		`plain text, no images`,
+	}
+	want := []string{
+		// 1. PNG stripped to placeholder.
+		`[{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1}]`,
+		// 2. WebP with charset passes through unchanged (3-part header rejected).
+		`[{"type":"input_image","image_url":"data:image/webp;charset=utf-8;base64,AAEC"}]`,
+		// 3. Already-stripped placeholder passes through unchanged.
+		`[{"type":"agentsview_image","version":1,"text":"[Image: image/png, 3 bytes]","media_type":"image/png","byte_size":3,"sha256":""}]`,
+		// 4. Mixed array: image stripped, text blocks pass through.
+		`[{"type":"text","text":"before"},{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1},{"type":"text","text":"after"}]`,
+		// 5. Both labeled sections stripped.
+		"agent-a:\n[{\"byte_size\":3,\"media_type\":\"image/png\",\"sha256\":\"\",\"text\":\"[Image: image/png, 3 bytes]\",\"type\":\"agentsview_image\",\"version\":1}]\n\n[{\"byte_size\":3,\"media_type\":\"image/png\",\"sha256\":\"\",\"text\":\"[Image: image/png, 3 bytes]\",\"type\":\"agentsview_image\",\"version\":1}]",
+		// 6. Plain text passes through unchanged.
+		`plain text, no images`,
+	}
+
+	for i, input := range inputs {
+		got, _ := StripToolResultImages(input)
+		assert.Equal(t, want[i], got, "input %d", i+1)
+	}
+}
+
+// TestStripPublicationSequence verifies that stripping changes stored content
+// and its revision once, while a second strip is a no-op.
+func TestStripPublicationSequence(t *testing.T) {
+	d := testDB(t)
+	seedArtifactOrigin(t, d)
+	insertSession(t, d, "pub-unchanged", "project")
+	insertMessages(t, d, testImageMessage("pub-unchanged"))
+	clearArtifactExportQueue(t, d)
+
+	var before string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
+	).Scan(&before))
+
+	report, err := d.StripToolImages(t.Context(), StripImagesFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.Changed)
+	assert.Equal(t, int64(1), report.Payloads)
+
+	var after string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
+	).Scan(&after))
+	assert.NotEqual(t, before, after)
+
+	// testImageMessage seeds the mixed-array format: text+image+text.
+	const wantStripped = `[{"type":"text","text":"before"},{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1},{"type":"text","text":"after"}]`
+	var eventContent string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT content FROM tool_result_events WHERE session_id = ?", "pub-unchanged",
+	).Scan(&eventContent))
+	assert.Equal(t, wantStripped, eventContent, "post-strip content preserves text around the placeholder")
+
+	// Second strip: no change, revision stays.
+	report2, err := d.StripToolImages(t.Context(), StripImagesFilter{})
+	require.NoError(t, err)
+	assert.Zero(t, report2.Changed)
+
+	var after2 string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT transcript_revision FROM sessions WHERE id = ?", "pub-unchanged",
+	).Scan(&after2))
+	assert.Equal(t, after, after2)
 }

--- a/internal/db/tool_result_images.go
+++ b/internal/db/tool_result_images.go
@@ -213,21 +213,21 @@ func decodeInlineImageURL(raw json.RawMessage) (string, int64, int64, bool) {
 
 // decodeInlineImage returns the parsed media type and decoded bytes of a
 // supported inline data URI. Acceptance matches decodeInlineImageURL.
-func decodeInlineImage(raw json.RawMessage) (mediaType string, decoded []byte, stored int64, ok bool) {
+func decodeInlineImage(raw json.RawMessage) (mediaType string, decoded []byte, ok bool) {
 	var uri string
 	if err := json.Unmarshal(raw, &uri); err != nil {
-		return "", nil, 0, false
+		return "", nil, false
 	}
 	mediaType, payload, ok := parseInlineImageHeader(uri)
 	if !ok {
-		return "", nil, 0, false
+		return "", nil, false
 	}
 	var buf bytes.Buffer
 	decoder := base64.NewDecoder(base64.StdEncoding.Strict(), strings.NewReader(payload))
 	if _, err := io.Copy(&buf, decoder); err != nil {
-		return "", nil, 0, false
+		return "", nil, false
 	}
-	return mediaType, buf.Bytes(), int64(len(uri)), true
+	return mediaType, buf.Bytes(), true
 }
 
 // imagePutFunc writes decoded image bytes and returns their asset reference.
@@ -256,30 +256,26 @@ func isMigratableToolImageBlock(raw json.RawMessage) bool {
 // migrateToolResultImages rewrites every migratable inline image block in one
 // stored result string with a durable asset:// reference. Unsupported shapes
 // keep their original JSON bytes. A put error returns the original content and
-// the error. stats is updated in place.
-func migrateToolResultImages(content string, put imagePutFunc, stats *ToolImageStats) (string, error) {
-	projected, arrayStats, err := migrateToolResultImageArray(content, put)
+// the error.
+func migrateToolResultImages(content string, put imagePutFunc) (string, error) {
+	projected, err := migrateToolResultImageArray(content, put)
 	if err != nil {
 		return content, err
 	}
-	if arrayStats.Payloads > 0 {
-		stats.Payloads += arrayStats.Payloads
-		stats.StoredBytes += arrayStats.StoredBytes
-		stats.DecodedBytes += arrayStats.DecodedBytes
+	if projected != content {
 		return projected, nil
 	}
-	return migrateToolResultSummaryImages(content, put, stats)
+	return migrateToolResultSummaryImages(content, put)
 }
 
-func migrateToolResultImageArray(content string, put imagePutFunc) (string, ToolImageStats, error) {
+func migrateToolResultImageArray(content string, put imagePutFunc) (string, error) {
 	var blocks []json.RawMessage
 	if err := json.Unmarshal([]byte(content), &blocks); err != nil || blocks == nil {
-		return content, ToolImageStats{}, nil
+		return content, nil
 	}
 
 	projected := make([]json.RawMessage, len(blocks))
 	copy(projected, blocks)
-	var stats ToolImageStats
 	changed := false
 
 	for i, raw := range blocks {
@@ -296,13 +292,13 @@ func migrateToolResultImageArray(content string, put imagePutFunc) (string, Tool
 		if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
 			continue
 		}
-		mediaType, decoded, storedBytes, ok := decodeInlineImage(block.ImageURL)
+		mediaType, decoded, ok := decodeInlineImage(block.ImageURL)
 		if !ok {
 			continue
 		}
 		ref, _, err := put(mediaType, decoded)
 		if err != nil {
-			return content, ToolImageStats{}, err
+			return content, err
 		}
 		// Hash the payload we handed to put rather than reading the digest back
 		// out of the reference: put is caller-supplied and may name files freely.
@@ -338,12 +334,9 @@ func migrateToolResultImageArray(content string, put imagePutFunc) (string, Tool
 		}
 		projected[i] = placeholder
 		changed = true
-		stats.Payloads++
-		stats.StoredBytes += storedBytes
-		stats.DecodedBytes += decodedBytes
 	}
 	if !changed {
-		return content, ToolImageStats{}, nil
+		return content, nil
 	}
 	var result bytes.Buffer
 	result.WriteByte('[')
@@ -354,14 +347,11 @@ func migrateToolResultImageArray(content string, put imagePutFunc) (string, Tool
 		result.Write(block)
 	}
 	result.WriteByte(']')
-	return result.String(), stats, nil
+	return result.String(), nil
 }
 
-func migrateToolResultSummaryImages(content string, put imagePutFunc, stats *ToolImageStats) (string, error) {
+func migrateToolResultSummaryImages(content string, put imagePutFunc) (string, error) {
 	var result strings.Builder
-	// Section counts land in *stats only once every section has been written,
-	// so a later put failure leaves the caller's totals untouched.
-	var found ToolImageStats
 	var putErr error
 	copied := 0
 	scanSummarySections(content, func(arrayStart, end int, raw json.RawMessage) {
@@ -370,31 +360,25 @@ func migrateToolResultSummaryImages(content string, put imagePutFunc, stats *Too
 		if putErr != nil {
 			return
 		}
-		projected, sectionStats, err := migrateToolResultImageArray(string(raw), put)
+		projected, err := migrateToolResultImageArray(string(raw), put)
 		if err != nil {
 			putErr = err
 			return
 		}
-		if sectionStats.Payloads == 0 {
+		if projected == string(raw) {
 			return
 		}
 		result.WriteString(content[copied:arrayStart])
 		result.WriteString(projected)
 		copied = end
-		found.Payloads += sectionStats.Payloads
-		found.StoredBytes += sectionStats.StoredBytes
-		found.DecodedBytes += sectionStats.DecodedBytes
 	})
 	if putErr != nil {
 		return content, putErr
 	}
-	if found.Payloads == 0 {
+	if copied == 0 {
 		return content, nil
 	}
 	result.WriteString(content[copied:])
-	stats.Payloads += found.Payloads
-	stats.StoredBytes += found.StoredBytes
-	stats.DecodedBytes += found.DecodedBytes
 	return result.String(), nil
 }
 

--- a/internal/db/tool_result_images.go
+++ b/internal/db/tool_result_images.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"mime"
 	"strings"
 
+	"go.kenn.io/agentsview/internal/assets"
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -108,10 +110,13 @@ func stripToolResultImageArray(content string) (string, ToolImageStats) {
 	return result.String(), stats
 }
 
-func stripToolResultSummaryImages(content string) (string, ToolImageStats) {
-	var result strings.Builder
-	var stats ToolImageStats
-	copied := 0
+// scanSummarySections walks a labeled or anonymous tool-result summary and
+// calls fn once per section that holds a JSON array, passing the offsets the
+// array occupies in content and its raw bytes. Preview, strip and migrate all
+// scan through here so they cannot disagree about which sections exist.
+func scanSummarySections(
+	content string, fn func(arrayStart, end int, raw json.RawMessage),
+) {
 	for start := 0; start < len(content); {
 		section := strings.TrimLeft(content[start:], " \t\r\n")
 		arrayStart := len(content) - len(section)
@@ -133,15 +138,7 @@ func stripToolResultSummaryImages(content string) (string, ToolImageStats) {
 			scanEnd = end
 			tail, _, _ := strings.Cut(content[end:], "\n\n")
 			if len(raw) > 0 && raw[0] == '[' && strings.TrimSpace(tail) == "" {
-				projected, found := stripToolResultImageArray(string(raw))
-				if found.Payloads > 0 {
-					result.WriteString(content[copied:arrayStart])
-					result.WriteString(projected)
-					copied = end
-					stats.Payloads += found.Payloads
-					stats.StoredBytes += found.StoredBytes
-					stats.DecodedBytes += found.DecodedBytes
-				}
+				fn(arrayStart, end, raw)
 			}
 		}
 		separator := strings.Index(content[scanEnd:], "\n\n")
@@ -150,6 +147,24 @@ func stripToolResultSummaryImages(content string) (string, ToolImageStats) {
 		}
 		start = scanEnd + separator + 2
 	}
+}
+
+func stripToolResultSummaryImages(content string) (string, ToolImageStats) {
+	var result strings.Builder
+	var stats ToolImageStats
+	copied := 0
+	scanSummarySections(content, func(arrayStart, end int, raw json.RawMessage) {
+		projected, found := stripToolResultImageArray(string(raw))
+		if found.Payloads == 0 {
+			return
+		}
+		result.WriteString(content[copied:arrayStart])
+		result.WriteString(projected)
+		copied = end
+		stats.Payloads += found.Payloads
+		stats.StoredBytes += found.StoredBytes
+		stats.DecodedBytes += found.DecodedBytes
+	})
 	if stats.Payloads == 0 {
 		return content, stats
 	}
@@ -157,30 +172,35 @@ func stripToolResultSummaryImages(content string) (string, ToolImageStats) {
 	return result.String(), stats
 }
 
+// parseInlineImageHeader parses a data URI header and returns the parsed
+// media type and base64 payload. It accepts only base64-encoded image/* URIs.
+func parseInlineImageHeader(uri string) (mediaType, payload string, ok bool) {
+	if !strings.HasPrefix(strings.ToLower(uri), "data:") {
+		return "", "", false
+	}
+	header, payload, found := strings.Cut(uri, ",")
+	if !found || payload == "" {
+		return "", "", false
+	}
+	parts := strings.Split(header, ";")
+	if len(parts) != 2 || !strings.EqualFold(parts[1], "base64") {
+		return "", "", false
+	}
+	rawType := parts[0][len("data:"):]
+	parsedType, _, err := mime.ParseMediaType(rawType)
+	if err != nil || !strings.HasPrefix(strings.ToLower(parsedType), "image/") {
+		return "", "", false
+	}
+	return parsedType, payload, true
+}
+
 func decodeInlineImageURL(raw json.RawMessage) (string, int64, int64, bool) {
 	var uri string
 	if err := json.Unmarshal(raw, &uri); err != nil {
 		return "", 0, 0, false
 	}
-	if !strings.HasPrefix(strings.ToLower(uri), "data:") {
-		return "", 0, 0, false
-	}
-	comma := strings.IndexByte(uri, ',')
-	if comma < 0 {
-		return "", 0, 0, false
-	}
-	header := uri[:comma]
-	payload := uri[comma+1:]
-	if payload == "" {
-		return "", 0, 0, false
-	}
-	parts := strings.Split(header, ";")
-	if len(parts) != 2 || !strings.EqualFold(parts[1], "base64") {
-		return "", 0, 0, false
-	}
-	mediaType := parts[0][len("data:"):]
-	parsedType, _, err := mime.ParseMediaType(mediaType)
-	if err != nil || !strings.HasPrefix(strings.ToLower(parsedType), "image/") {
+	mediaType, payload, ok := parseInlineImageHeader(uri)
+	if !ok {
 		return "", 0, 0, false
 	}
 	var count countingWriter
@@ -188,7 +208,194 @@ func decodeInlineImageURL(raw json.RawMessage) (string, int64, int64, bool) {
 	if _, err := io.Copy(&count, decoder); err != nil {
 		return "", 0, 0, false
 	}
-	return parsedType, count.n, int64(len(uri)), true
+	return mediaType, count.n, int64(len(uri)), true
+}
+
+// decodeInlineImage returns the parsed media type and decoded bytes of a
+// supported inline data URI. Acceptance matches decodeInlineImageURL.
+func decodeInlineImage(raw json.RawMessage) (mediaType string, decoded []byte, stored int64, ok bool) {
+	var uri string
+	if err := json.Unmarshal(raw, &uri); err != nil {
+		return "", nil, 0, false
+	}
+	mediaType, payload, ok := parseInlineImageHeader(uri)
+	if !ok {
+		return "", nil, 0, false
+	}
+	var buf bytes.Buffer
+	decoder := base64.NewDecoder(base64.StdEncoding.Strict(), strings.NewReader(payload))
+	if _, err := io.Copy(&buf, decoder); err != nil {
+		return "", nil, 0, false
+	}
+	return mediaType, buf.Bytes(), int64(len(uri)), true
+}
+
+// imagePutFunc writes decoded image bytes and returns their asset reference.
+type imagePutFunc func(mediaType string, body []byte) (ref string, created bool, err error)
+
+// isMigratableToolImageBlock reports whether one stored block holds an inline
+// image payload this migration can move. The block must be an input_image
+// with a base64 data URI whose media type is one the asset store accepts.
+func isMigratableToolImageBlock(raw json.RawMessage) bool {
+	var block toolImageBlock
+	if err := json.Unmarshal(raw, &block); err != nil || block.Type != "input_image" {
+		return false
+	}
+	var uri string
+	if err := json.Unmarshal(block.ImageURL, &uri); err != nil {
+		return false
+	}
+	mediaType, _, ok := parseInlineImageHeader(uri)
+	if !ok {
+		return false
+	}
+	_, allowed := assets.ExtForMediaType(mediaType)
+	return allowed
+}
+
+// migrateToolResultImages rewrites every migratable inline image block in one
+// stored result string with a durable asset:// reference. Unsupported shapes
+// keep their original JSON bytes. A put error returns the original content and
+// the error. stats is updated in place.
+func migrateToolResultImages(content string, put imagePutFunc, stats *ToolImageStats) (string, error) {
+	projected, arrayStats, err := migrateToolResultImageArray(content, put)
+	if err != nil {
+		return content, err
+	}
+	if arrayStats.Payloads > 0 {
+		stats.Payloads += arrayStats.Payloads
+		stats.StoredBytes += arrayStats.StoredBytes
+		stats.DecodedBytes += arrayStats.DecodedBytes
+		return projected, nil
+	}
+	return migrateToolResultSummaryImages(content, put, stats)
+}
+
+func migrateToolResultImageArray(content string, put imagePutFunc) (string, ToolImageStats, error) {
+	var blocks []json.RawMessage
+	if err := json.Unmarshal([]byte(content), &blocks); err != nil || blocks == nil {
+		return content, ToolImageStats{}, nil
+	}
+
+	projected := make([]json.RawMessage, len(blocks))
+	copy(projected, blocks)
+	var stats ToolImageStats
+	changed := false
+
+	for i, raw := range blocks {
+		// The preview path counts through this same predicate, so apply cannot
+		// call put for a payload the preview never counted.
+		if !isMigratableToolImageBlock(raw) {
+			continue
+		}
+		var block toolImageBlock
+		if err := json.Unmarshal(raw, &block); err != nil {
+			continue
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+			continue
+		}
+		mediaType, decoded, storedBytes, ok := decodeInlineImage(block.ImageURL)
+		if !ok {
+			continue
+		}
+		ref, _, err := put(mediaType, decoded)
+		if err != nil {
+			return content, ToolImageStats{}, err
+		}
+		// Hash the payload we handed to put rather than reading the digest back
+		// out of the reference: put is caller-supplied and may name files freely.
+		sum := sha256.Sum256(decoded)
+		sha256hex := fmt.Sprintf("%x", sum[:])
+		decodedBytes := int64(len(decoded))
+
+		placeholderFields := make(map[string]json.RawMessage, len(fields)+7)
+		for key, value := range fields {
+			if !strings.EqualFold(key, "type") &&
+				!strings.EqualFold(key, "image_url") {
+				placeholderFields[key] = value
+			}
+		}
+		placeholderFields["type"] = json.RawMessage(`"agentsview_image"`)
+		placeholderFields["version"] = json.RawMessage(`1`)
+		textValue, _ := json.Marshal(
+			fmt.Sprintf("![Image: %s, %d bytes](%s)", mediaType, decodedBytes, ref),
+		)
+		placeholderFields["text"] = textValue
+		mediaValue, _ := json.Marshal(mediaType)
+		placeholderFields["media_type"] = mediaValue
+		byteSizeValue, _ := json.Marshal(decodedBytes)
+		placeholderFields["byte_size"] = byteSizeValue
+		sha256Value, _ := json.Marshal(sha256hex)
+		placeholderFields["sha256"] = sha256Value
+		imageRefValue, _ := json.Marshal(ref)
+		placeholderFields["image_ref"] = imageRefValue
+
+		placeholder, err := json.Marshal(placeholderFields)
+		if err != nil {
+			continue
+		}
+		projected[i] = placeholder
+		changed = true
+		stats.Payloads++
+		stats.StoredBytes += storedBytes
+		stats.DecodedBytes += decodedBytes
+	}
+	if !changed {
+		return content, ToolImageStats{}, nil
+	}
+	var result bytes.Buffer
+	result.WriteByte('[')
+	for i, block := range projected {
+		if i > 0 {
+			result.WriteByte(',')
+		}
+		result.Write(block)
+	}
+	result.WriteByte(']')
+	return result.String(), stats, nil
+}
+
+func migrateToolResultSummaryImages(content string, put imagePutFunc, stats *ToolImageStats) (string, error) {
+	var result strings.Builder
+	// Section counts land in *stats only once every section has been written,
+	// so a later put failure leaves the caller's totals untouched.
+	var found ToolImageStats
+	var putErr error
+	copied := 0
+	scanSummarySections(content, func(arrayStart, end int, raw json.RawMessage) {
+		// The first put failure abandons the rewrite; later sections are still
+		// walked but do no work, so no further payload leaves the row.
+		if putErr != nil {
+			return
+		}
+		projected, sectionStats, err := migrateToolResultImageArray(string(raw), put)
+		if err != nil {
+			putErr = err
+			return
+		}
+		if sectionStats.Payloads == 0 {
+			return
+		}
+		result.WriteString(content[copied:arrayStart])
+		result.WriteString(projected)
+		copied = end
+		found.Payloads += sectionStats.Payloads
+		found.StoredBytes += sectionStats.StoredBytes
+		found.DecodedBytes += sectionStats.DecodedBytes
+	})
+	if putErr != nil {
+		return content, putErr
+	}
+	if found.Payloads == 0 {
+		return content, nil
+	}
+	result.WriteString(content[copied:])
+	stats.Payloads += found.Payloads
+	stats.StoredBytes += found.StoredBytes
+	stats.DecodedBytes += found.DecodedBytes
+	return result.String(), nil
 }
 
 type countingWriter struct{ n int64 }

--- a/internal/importer/assets.go
+++ b/internal/importer/assets.go
@@ -1,9 +1,6 @@
 package importer
 
 import (
-	"crypto/sha256"
-	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,73 +102,4 @@ func (idx AssetIndex) Resolve(pointer string) (string, bool) {
 	}
 	path, ok := idx.entries[prefix]
 	return path, ok
-}
-
-// allowedImageExts is the set of passive image formats that
-// are safe to serve inline. Active content (svg, html, js) is
-// rejected to prevent stored XSS.
-var allowedImageExts = map[string]bool{
-	".png":  true,
-	".jpg":  true,
-	".jpeg": true,
-	".webp": true,
-	".gif":  true,
-}
-
-// CopyAsset copies a file to the assets directory using its
-// SHA-256 hash as the filename. Returns the asset:// reference.
-// Only passive image types are accepted; active content is
-// rejected.
-func CopyAsset(srcPath, assetsDir string) (string, error) {
-	ext := strings.ToLower(filepath.Ext(srcPath))
-	if !allowedImageExts[ext] {
-		return "", fmt.Errorf(
-			"unsupported asset type: %s", ext,
-		)
-	}
-
-	f, err := os.Open(srcPath)
-	if err != nil {
-		return "", fmt.Errorf("reading asset: %w", err)
-	}
-	defer f.Close()
-
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", fmt.Errorf("hashing asset: %w", err)
-	}
-
-	hash := fmt.Sprintf("%x", h.Sum(nil))
-	filename := hash + ext
-	destPath := filepath.Join(assetsDir, filename)
-
-	if _, err := os.Stat(destPath); err == nil {
-		return "asset://" + filename, nil
-	}
-
-	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
-		return "", fmt.Errorf("creating assets dir: %w", err)
-	}
-
-	// Re-read source for copy (we consumed it for hashing).
-	src, err := os.Open(srcPath)
-	if err != nil {
-		return "", fmt.Errorf("reopening asset: %w", err)
-	}
-	defer src.Close()
-
-	out, err := os.Create(destPath)
-	if err != nil {
-		return "", fmt.Errorf("writing asset: %w", err)
-	}
-
-	if _, err := io.Copy(out, src); err != nil {
-		out.Close()
-		return "", fmt.Errorf("copying asset: %w", err)
-	}
-	if err := out.Close(); err != nil {
-		return "", fmt.Errorf("closing asset: %w", err)
-	}
-
-	return "asset://" + filename, nil
 }

--- a/internal/importer/assets_test.go
+++ b/internal/importer/assets_test.go
@@ -3,10 +3,12 @@ package importer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestBuildAssetIndex(t *testing.T) {
@@ -40,23 +42,50 @@ func TestBuildAssetIndex(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestCopyAsset(t *testing.T) {
-	src := filepath.Join(t.TempDir(), "source.webp")
-	require.NoError(t, os.WriteFile(src, []byte("image data"), 0o644))
+// TestAssetResolverAdapterCopiesThroughParserBoundary drives the production
+// call site the package move touched: parser.AssetResolver.Copy, implemented by
+// assetResolverAdapter, is what chatgpt.resolveImageAsset calls to turn an
+// export pointer into an asset:// reference. Boundary: 1 file on disk, the
+// source bytes unchanged, and a repeat copy that adds no second file.
+func TestAssetResolverAdapterCopiesThroughParserBoundary(t *testing.T) {
+	exportDir := t.TempDir()
+	userDir := filepath.Join(exportDir, "user-xyz")
+	require.NoError(t, os.MkdirAll(userDir, 0o755))
+	body := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a} // PNG header
+	require.NoError(t, os.WriteFile(
+		filepath.Join(userDir, "file_deadbeef-aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee.png"),
+		body, 0o644,
+	))
 
 	assetsDir := filepath.Join(t.TempDir(), "assets")
+	var resolver parser.AssetResolver = &assetResolverAdapter{
+		index:     BuildAssetIndex(exportDir),
+		assetsDir: assetsDir,
+	}
 
-	ref, err := CopyAsset(src, assetsDir)
+	srcPath, ok := resolver.Resolve("sediment://file_deadbeef")
+	require.True(t, ok)
+
+	ref, err := resolver.Copy(srcPath)
 	require.NoError(t, err)
 	assert.Contains(t, ref, "asset://")
-	assert.Contains(t, ref, ".webp")
+	assert.Contains(t, ref, ".png")
 
-	// Second call should return same ref (dedup).
-	ref2, err := CopyAsset(src, assetsDir)
+	// The reference names a file holding exactly the export's bytes.
+	stored, err := os.ReadFile(filepath.Join(assetsDir, strings.TrimPrefix(ref, "asset://")))
 	require.NoError(t, err)
-	assert.Equal(t, ref, ref2)
+	assert.Equal(t, body, stored)
 
 	entries, err := os.ReadDir(assetsDir)
 	require.NoError(t, err)
 	assert.Len(t, entries, 1)
+
+	// A second reference to the same image reuses the stored object.
+	ref2, err := resolver.Copy(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, ref, ref2)
+	entries, err = os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	t.Logf("1 file for 2 copies through parser.AssetResolver: files=%d, ref=%s", len(entries), ref)
 }

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/agentsview/internal/assets"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 )
@@ -277,7 +278,7 @@ func (a *assetResolverAdapter) Resolve(
 func (a *assetResolverAdapter) Copy(
 	srcPath string,
 ) (string, error) {
-	return CopyAsset(srcPath, a.assetsDir)
+	return assets.CopyAsset(srcPath, a.assetsDir)
 }
 
 // ImportChatGPT reads a ChatGPT export directory (containing


### PR DESCRIPTION
`agentsview db migrate --images` moves retained inline tool-result images out of `sessions.db` and into the assets directory beside it, leaving a reference in their place. The database rows lose the inline payload at once; `db compact` can reclaim the resulting free pages.

Before/after:

| ![Tool output before migration, showing a base64 data URI inline in the stored result](https://raw.githubusercontent.com/rodboev/agentsview/screenshots/agentsview-1622-2-before.png) | ![The same tool output after migration, rendering the image from the asset store](https://raw.githubusercontent.com/rodboev/agentsview/screenshots/agentsview-1622-2-after.png) |
| --- | --- |

Each eligible payload is written to the content-addressed store chat import already uses. An existing object is reused only when its byte count and SHA-256 digest match. A missing or corrupt object is replaced before the row changes. The `input_image` block becomes an `agentsview_image` placeholder carrying an `image_ref` and a markdown image. The file lands through a rename before its referencing row commits.

If that session transaction fails, complete assets remain unreferenced on disk. A matching retry reuses them; there is no automatic orphan cleanup. Both migrate and strip report sessions that committed before a later failure.

JPEG assets now use `.jpg` filenames, including `.jpeg` files copied from chat exports. Existing `asset://<hash>.jpeg` references still resolve, but re-importing an export with those files can store a second copy under `.jpg`.

Migration changes rows already stored locally. A later keep-mode reparse or full resync can restore inline payloads from provider source files. The existing `tool_result_images = "drop"` policy continues to remove supported inline images during future ingestion and resync. A separate mirror or serving host needs the matching assets directory.

Only four passive media types are migrated. The image renders in formatted mode when every sibling block is text. Under `require_auth`, the asset request remains protected. `db strip --images` remains the broader removal command.

Refs #1622
