### PR TITLE
test(pricing): use the shared wait budget for pricing schedule tests

### DIFF
--- a/cmd/agentsview/pricing_schedule_test.go
+++ b/cmd/agentsview/pricing_schedule_test.go
@@ -16,8 +16,11 @@ import (
 	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
-// Resync may spend up to five seconds draining SQLite connections before a
-// swap, and the surrounding work can take longer on loaded Windows runners.
+// Budget for the polling waits in this file. Resync may spend up to five
+// seconds draining SQLite connections before a swap, and under contention on
+// the Windows runner these waits run tens of times slower than on an idle
+// machine, so one second leaves no margin for a refresh that takes about a
+// tenth of a second unloaded.
 const pricingResyncTestTimeout = 30 * time.Second
 
 // pricingCatalogTransport answers the GenAI Prices, LiteLLM, and OpenRouter
@@ -80,14 +83,14 @@ func TestRunPeriodicPricingRefreshFetchesAfterRecentAttempt(t *testing.T) {
 			default:
 				return false
 			}
-		}, time.Second, time.Millisecond)
+		}, pricingResyncTestTimeout, time.Millisecond)
 	})
 
 	ticks <- time.Now()
 	require.Eventually(t, func() bool {
 		price, err := database.GetModelPricing("scheduled-model")
 		return err == nil && price != nil
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 
 	require.Equal(t,
 		"https://raw.githubusercontent.com/pydantic/genai-prices/main/"+
@@ -292,16 +295,16 @@ func TestRunPricingRefreshLoopContinuesAfterFailure(t *testing.T) {
 			default:
 				return false
 			}
-		}, time.Second, time.Millisecond)
+		}, pricingResyncTestTimeout, time.Millisecond)
 	})
 
 	ticks <- time.Time{}
 	require.Eventually(t, func() bool {
 		return attempts.Load() == 1
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 
 	ticks <- time.Time{}
 	require.Eventually(t, func() bool {
 		return attempts.Load() == 2
-	}, time.Second, time.Millisecond)
+	}, pricingResyncTestTimeout, time.Millisecond)
 }


### PR DESCRIPTION
This raises the wait for a flaky pricing refresh test, and the four like it in the same file, to the 30 second budget the file's other seven waits already use.

`TestRunPeriodicPricingRefreshFetchesAfterRecentAttempt` gave a goroutine one second to be scheduled and finish, which a loaded 4-vCPU Windows runner misses, timing out in 13 of 60 runs pinned to one core and none of 60 at thirty seconds.

Closes #1700
