### PR TITLE
test(cli): convert convertible cmd/agentsview timing waits to testing/synctest

### DIFF
--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	stdsync "sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -29,24 +29,26 @@ import (
 // output: an immediate delegation announcement, elapsed-time heartbeats
 // while the blocking POST is in flight, and silence after stop.
 func TestDaemonPushHeartbeat(t *testing.T) {
-	orig := daemonPushHeartbeatInterval
-	daemonPushHeartbeatInterval = 5 * time.Millisecond
-	t.Cleanup(func() { daemonPushHeartbeatInterval = orig })
+	synctest.Test(t, func(t *testing.T) {
+		orig := daemonPushHeartbeatInterval
+		daemonPushHeartbeatInterval = 5 * time.Millisecond
+		t.Cleanup(func() { daemonPushHeartbeatInterval = orig })
 
-	var out syncBuffer
-	stop := startDaemonPushHeartbeatTo(&out, "PostgreSQL")
-	assert.Contains(t, out.String(),
-		"Pushing to PostgreSQL via the local daemon")
+		var out syncBuffer
+		stop := startDaemonPushHeartbeatTo(&out, "PostgreSQL")
+		assert.Contains(t, out.String(),
+			"Pushing to PostgreSQL via the local daemon")
 
-	require.Eventually(t, func() bool {
-		return strings.Contains(out.String(),
-			"still pushing to PostgreSQL via the daemon")
-	}, time.Second, time.Millisecond, "heartbeat line must appear")
+		synctest.Sleep(daemonPushHeartbeatInterval)
+		assert.Contains(t, out.String(),
+			"still pushing to PostgreSQL via the daemon",
+			"heartbeat line must appear")
 
-	stop()
-	settled := out.String()
-	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, settled, out.String(), "no output after stop")
+		stop()
+		settled := out.String()
+		synctest.Sleep(20 * time.Millisecond)
+		assert.Equal(t, settled, out.String(), "no output after stop")
+	})
 }
 
 // TestDaemonPushProgressSilencesHeartbeat pins that the first streamed
@@ -760,58 +762,58 @@ func TestPushWatchProductionOwnersRetainPartialStartupUntilPeriodicSuccess(
 ) {
 	for _, owner := range pushWatchOwnerCases(t) {
 		t.Run(owner.name, func(t *testing.T) {
-			h := newPushWatchOwnerHarness(1)
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
-			done := make(chan error, 1)
-			go func() { done <- owner.run(ctx, h.hooks()) }()
+			synctest.Test(t, func(t *testing.T) {
+				h := newPushWatchOwnerHarness(1)
+				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+				done := make(chan error, 1)
+				go func() { done <- owner.run(ctx, h.hooks()) }()
 
-			first := receiveArchiveTest(t, h.attempts)
-			require.Equal(t, 1, first.index)
-			if !isLocalEnginePushWatchOwner(owner.name) {
-				assert.Equal(t, reasonStartup, first.reason)
-			}
-			require.Eventually(t, func() bool {
+				first := receiveArchiveTest(t, h.attempts)
+				require.Equal(t, 1, first.index)
+				if !isLocalEnginePushWatchOwner(owner.name) {
+					assert.Equal(t, reasonStartup, first.reason)
+				}
+				synctest.Wait()
 				pending, waiters := h.pending()
-				return pending && waiters == 1
-			}, time.Second, time.Millisecond,
-				"partial startup must retain one dirty generation and waiter")
-			select {
-			case <-h.opened:
-				require.Fail(t, "partial startup opened watcher dispatch")
-			default:
-			}
+				require.True(t, pending && waiters == 1,
+					"partial startup must retain one dirty generation and waiter")
+				select {
+				case <-h.opened:
+					require.Fail(t, "partial startup opened watcher dispatch")
+				default:
+				}
 
-			h.floor <- time.Now()
-			second := receiveArchiveTest(t, h.attempts)
-			require.Equal(t, 2, second.index)
-			if !isLocalEnginePushWatchOwner(owner.name) {
-				assert.Equal(t, reasonInterval, second.reason)
-			}
-			receiveArchiveTest(t, h.opened)
-			require.Eventually(t, func() bool {
-				pending, waiters := h.pending()
-				return !pending && waiters == 0
-			}, time.Second, time.Millisecond,
-				"complete periodic push must drain startup work")
+				h.floor <- time.Now()
+				second := receiveArchiveTest(t, h.attempts)
+				require.Equal(t, 2, second.index)
+				if !isLocalEnginePushWatchOwner(owner.name) {
+					assert.Equal(t, reasonInterval, second.reason)
+				}
+				receiveArchiveTest(t, h.opened)
+				synctest.Wait()
+				pending, waiters = h.pending()
+				require.True(t, !pending && waiters == 0,
+					"complete periodic push must drain startup work")
 
-			events, opens, startupSyncs, localSyncs := h.snapshot()
-			require.NotEmpty(t, events)
-			assert.Equal(t, "collect", events[0],
-				"watcher collection must precede startup work")
-			assert.Equal(t, 1, opens)
-			if isLocalEnginePushWatchOwner(owner.name) {
-				assert.Equal(t, 1, startupSyncs)
-				assert.GreaterOrEqual(t, localSyncs, 2,
-					"initial and retry pushes each run local sync")
-				assert.Less(t, indexOfEvent(events, "startup-sync"),
-					indexOfEvent(events, "push"))
-				assert.Less(t, indexOfEvent(events, "local-sync"),
-					indexOfEvent(events, "push"))
-			}
+				events, opens, startupSyncs, localSyncs := h.snapshot()
+				require.NotEmpty(t, events)
+				assert.Equal(t, "collect", events[0],
+					"watcher collection must precede startup work")
+				assert.Equal(t, 1, opens)
+				if isLocalEnginePushWatchOwner(owner.name) {
+					assert.Equal(t, 1, startupSyncs)
+					assert.GreaterOrEqual(t, localSyncs, 2,
+						"initial and retry pushes each run local sync")
+					assert.Less(t, indexOfEvent(events, "startup-sync"),
+						indexOfEvent(events, "push"))
+					assert.Less(t, indexOfEvent(events, "local-sync"),
+						indexOfEvent(events, "push"))
+				}
 
-			cancel()
-			require.NoError(t, receiveArchiveTest(t, done))
+				cancel()
+				require.NoError(t, receiveArchiveTest(t, done))
+			})
 		})
 	}
 }
@@ -821,61 +823,60 @@ func TestPushWatchProductionOwnersRetryPartialAuthoritativeBatch(
 ) {
 	for _, owner := range pushWatchOwnerCases(t) {
 		t.Run(owner.name, func(t *testing.T) {
-			h := newPushWatchOwnerHarness(2)
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
-			done := make(chan error, 1)
-			go func() { done <- owner.run(ctx, h.hooks()) }()
+			synctest.Test(t, func(t *testing.T) {
+				h := newPushWatchOwnerHarness(2)
+				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+				done := make(chan error, 1)
+				go func() { done <- owner.run(ctx, h.hooks()) }()
 
-			first := receiveArchiveTest(t, h.attempts)
-			require.Equal(t, 1, first.index)
-			if !isLocalEnginePushWatchOwner(owner.name) {
-				assert.Equal(t, reasonStartup, first.reason)
-			}
-			receiveArchiveTest(t, h.opened)
-			callback := h.watcherCallback()
-			require.NotNil(t, callback)
-			callbackDone := make(chan error, 1)
-			go func() {
-				callbackDone <- callback(ctx, syncpkg.WatchBatch{FullSync: true})
-			}()
-			require.Eventually(t, func() bool {
+				first := receiveArchiveTest(t, h.attempts)
+				require.Equal(t, 1, first.index)
+				if !isLocalEnginePushWatchOwner(owner.name) {
+					assert.Equal(t, reasonStartup, first.reason)
+				}
+				receiveArchiveTest(t, h.opened)
+				callback := h.watcherCallback()
+				require.NotNil(t, callback)
+				callbackDone := make(chan error, 1)
+				go func() {
+					callbackDone <- callback(ctx, syncpkg.WatchBatch{FullSync: true})
+				}()
+				synctest.Wait()
 				pending, waiters := h.pending()
-				return pending && waiters == 1
-			}, time.Second, time.Millisecond)
+				require.True(t, pending && waiters == 1)
 
-			h.floor <- time.Now()
-			second := receiveArchiveTest(t, h.attempts)
-			require.Equal(t, 2, second.index)
-			if !isLocalEnginePushWatchOwner(owner.name) {
-				assert.Equal(t, reasonInterval, second.reason)
-			}
-			select {
-			case err := <-callbackDone:
-				require.Fail(t, "partial runtime push acknowledged watcher batch", "%v", err)
-			case <-time.After(50 * time.Millisecond):
-			}
-			require.Eventually(t, func() bool {
-				pending, waiters := h.pending()
-				return pending && waiters == 1
-			}, time.Second, time.Millisecond)
+				h.floor <- time.Now()
+				second := receiveArchiveTest(t, h.attempts)
+				require.Equal(t, 2, second.index)
+				if !isLocalEnginePushWatchOwner(owner.name) {
+					assert.Equal(t, reasonInterval, second.reason)
+				}
+				synctest.Wait()
+				select {
+				case err := <-callbackDone:
+					require.Fail(t, "partial runtime push acknowledged watcher batch", "%v", err)
+				default:
+				}
+				pending, waiters = h.pending()
+				require.True(t, pending && waiters == 1)
 
-			h.floor <- time.Now()
-			third := receiveArchiveTest(t, h.attempts)
-			require.Equal(t, 3, third.index)
-			if !isLocalEnginePushWatchOwner(owner.name) {
-				assert.Equal(t, reasonInterval, third.reason)
-			}
-			require.NoError(t, receiveArchiveTest(t, callbackDone))
-			require.Eventually(t, func() bool {
-				pending, waiters := h.pending()
-				return !pending && waiters == 0
-			}, time.Second, time.Millisecond)
-			_, opens, _, _ := h.snapshot()
-			assert.Equal(t, 1, opens, "runtime retries must not reopen dispatch")
+				h.floor <- time.Now()
+				third := receiveArchiveTest(t, h.attempts)
+				require.Equal(t, 3, third.index)
+				if !isLocalEnginePushWatchOwner(owner.name) {
+					assert.Equal(t, reasonInterval, third.reason)
+				}
+				require.NoError(t, receiveArchiveTest(t, callbackDone))
+				synctest.Wait()
+				pending, waiters = h.pending()
+				require.True(t, !pending && waiters == 0)
+				_, opens, _, _ := h.snapshot()
+				assert.Equal(t, 1, opens, "runtime retries must not reopen dispatch")
 
-			cancel()
-			require.NoError(t, receiveArchiveTest(t, done))
+				cancel()
+				require.NoError(t, receiveArchiveTest(t, done))
+			})
 		})
 	}
 }
@@ -883,28 +884,29 @@ func TestPushWatchProductionOwnersRetryPartialAuthoritativeBatch(
 func TestPushWatchProductionOwnersFallbackUsesActiveIntervalFloor(t *testing.T) {
 	for _, owner := range pushWatchOwnerCases(t) {
 		t.Run(owner.name, func(t *testing.T) {
-			h := newPushWatchOwnerHarness()
-			ctx, cancel := context.WithCancel(context.Background())
-			done := make(chan error, 1)
-			go func() { done <- owner.run(ctx, h.hooks()) }()
+			synctest.Test(t, func(t *testing.T) {
+				h := newPushWatchOwnerHarness()
+				ctx, cancel := context.WithCancel(context.Background())
+				done := make(chan error, 1)
+				go func() { done <- owner.run(ctx, h.hooks()) }()
 
-			receiveArchiveTest(t, h.attempts)
-			receiveArchiveTest(t, h.opened)
-			degraded := h.degradationCallback()
-			require.NotNil(t, degraded, "watcher collection receives a degradation owner")
-			require.NoError(t, degraded([]string{"/root-a", "/root-a", "/root-b"}))
-			require.Eventually(t, func() bool {
+				receiveArchiveTest(t, h.attempts)
+				receiveArchiveTest(t, h.opened)
+				degraded := h.degradationCallback()
+				require.NotNil(t, degraded, "watcher collection receives a degradation owner")
+				require.NoError(t, degraded([]string{"/root-a", "/root-a", "/root-b"}))
+				synctest.Wait()
 				pending, waiters := h.pending()
-				return pending && waiters == 0
-			}, time.Second, time.Millisecond)
+				require.True(t, pending && waiters == 0)
 
-			h.floor <- time.Now()
-			attempt := receiveArchiveTest(t, h.attempts)
-			if !isLocalEnginePushWatchOwner(owner.name) {
-				assert.Equal(t, reasonInterval, attempt.reason)
-			}
-			cancel()
-			require.NoError(t, receiveArchiveTest(t, done))
+				h.floor <- time.Now()
+				attempt := receiveArchiveTest(t, h.attempts)
+				if !isLocalEnginePushWatchOwner(owner.name) {
+					assert.Equal(t, reasonInterval, attempt.reason)
+				}
+				cancel()
+				require.NoError(t, receiveArchiveTest(t, done))
+			})
 		})
 	}
 }

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -40,7 +40,7 @@ func TestDaemonPushHeartbeat(t *testing.T) {
 			"Pushing to PostgreSQL via the local daemon")
 
 		synctest.Sleep(daemonPushHeartbeatInterval)
-		assert.Contains(t, out.String(),
+		require.Contains(t, out.String(),
 			"still pushing to PostgreSQL via the daemon",
 			"heartbeat line must appear")
 
@@ -887,6 +887,7 @@ func TestPushWatchProductionOwnersFallbackUsesActiveIntervalFloor(t *testing.T) 
 			synctest.Test(t, func(t *testing.T) {
 				h := newPushWatchOwnerHarness()
 				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
 				done := make(chan error, 1)
 				go func() { done <- owner.run(ctx, h.hooks()) }()
 

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -36,6 +36,9 @@ func TestDaemonPushHeartbeat(t *testing.T) {
 
 		var out syncBuffer
 		stop := startDaemonPushHeartbeatTo(&out, "PostgreSQL")
+		var stopOnce stdsync.Once
+		stopHeartbeat := func() { stopOnce.Do(stop) }
+		t.Cleanup(stopHeartbeat)
 		assert.Contains(t, out.String(),
 			"Pushing to PostgreSQL via the local daemon")
 
@@ -44,7 +47,7 @@ func TestDaemonPushHeartbeat(t *testing.T) {
 			"still pushing to PostgreSQL via the daemon",
 			"heartbeat line must appear")
 
-		stop()
+		stopHeartbeat()
 		settled := out.String()
 		synctest.Sleep(20 * time.Millisecond)
 		assert.Equal(t, settled, out.String(), "no output after stop")

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -117,27 +117,26 @@ func waitForSchedulerConditionWithin(
 }
 
 func TestEmbedSchedulerBurstOfNotifyProducesExactlyOneBuild(t *testing.T) {
-	fake := &fakeEmbedManager{}
-	s := newEmbedScheduler(fake, 20*time.Millisecond, 0, false, nil)
+	synctest.Test(t, func(t *testing.T) {
+		fake := &fakeEmbedManager{}
+		s := newEmbedScheduler(fake, 20*time.Millisecond, 0, false, nil)
 
-	// Queue the whole burst before Run starts so the test exercises the
-	// scheduler's documented pre-reader coalescing without racing the debounce
-	// interval on slow or coarsely scheduled runners.
-	for range 10 {
-		s.Notify()
-	}
+		// Queue the whole burst before Run starts so the test exercises the
+		// scheduler's documented pre-reader coalescing without racing the debounce
+		// interval on slow or coarsely scheduled runners.
+		for range 10 {
+			s.Notify()
+		}
 
-	ctx := t.Context()
-	go s.Run(ctx)
-	defer s.Stop()
+		go s.Run(t.Context())
+		defer s.Stop()
 
-	waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 1 },
-		"expected a build after the burst quieted")
-	// Give any spurious extra build a chance to show up before asserting
-	// there is exactly one.
-	time.Sleep(60 * time.Millisecond)
-	assert.Equal(t, 1, fake.callCount(), "a burst of Notify must collapse to one build")
-	assert.Equal(t, []vector.BuildRequest{{}}, fake.callsSnapshot())
+		synctest.Sleep(60 * time.Millisecond)
+		require.GreaterOrEqual(t, fake.callCount(), 1,
+			"expected a build after the burst quieted")
+		assert.Equal(t, 1, fake.callCount(), "a burst of Notify must collapse to one build")
+		assert.Equal(t, []vector.BuildRequest{{}}, fake.callsSnapshot())
+	})
 }
 
 // TestEmbedSchedulerIncludeAutomatedThreadsIntoBuildRequests asserts the
@@ -667,24 +666,25 @@ func (e *recordingEmitter) count() int {
 }
 
 func TestTeeEmitterAlwaysCallsPrimaryAndGatesSchedulerOnRunAfterSync(t *testing.T) {
-	primary := &recordingEmitter{}
-	fake := &fakeEmbedManager{}
-	s := newEmbedScheduler(fake, 10*time.Millisecond, 0, false, nil)
-	ctx := t.Context()
-	go s.Run(ctx)
-	defer s.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		primary := &recordingEmitter{}
+		fake := &fakeEmbedManager{}
+		s := newEmbedScheduler(fake, 10*time.Millisecond, 0, false, nil)
+		go s.Run(t.Context())
+		defer s.Stop()
 
-	disabled := teeEmitter{primary: primary, scheduler: s, runAfterSync: false}
-	disabled.Emit("sessions")
-	assert.Equal(t, 1, primary.count())
-	time.Sleep(30 * time.Millisecond)
-	assert.Equal(t, 0, fake.callCount(), "runAfterSync=false must not notify the scheduler")
+		disabled := teeEmitter{primary: primary, scheduler: s, runAfterSync: false}
+		disabled.Emit("sessions")
+		assert.Equal(t, 1, primary.count())
+		synctest.Sleep(30 * time.Millisecond)
+		assert.Equal(t, 0, fake.callCount(), "runAfterSync=false must not notify the scheduler")
 
-	enabled := teeEmitter{primary: primary, scheduler: s, runAfterSync: true}
-	enabled.Emit("sessions")
-	assert.Equal(t, 2, primary.count())
-	waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 1 },
-		"runAfterSync=true must notify the scheduler")
+		enabled := teeEmitter{primary: primary, scheduler: s, runAfterSync: true}
+		enabled.Emit("sessions")
+		assert.Equal(t, 2, primary.count())
+		synctest.Sleep(30 * time.Millisecond)
+		require.Equal(t, 1, fake.callCount(), "runAfterSync=true must notify the scheduler")
+	})
 }
 
 // TestRunRemoteHostSyncLoop_EmitsThroughTeeNotifiesScheduler is a

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -132,8 +132,6 @@ func TestEmbedSchedulerBurstOfNotifyProducesExactlyOneBuild(t *testing.T) {
 		defer s.Stop()
 
 		synctest.Sleep(60 * time.Millisecond)
-		require.GreaterOrEqual(t, fake.callCount(), 1,
-			"expected a build after the burst quieted")
 		assert.Equal(t, 1, fake.callCount(), "a burst of Notify must collapse to one build")
 		assert.Equal(t, []vector.BuildRequest{{}}, fake.callsSnapshot())
 	})

--- a/cmd/agentsview/extract_scheduler_test.go
+++ b/cmd/agentsview/extract_scheduler_test.go
@@ -72,7 +72,6 @@ func TestExtractSchedulerBurstOfNotifyProducesExactlyOnePass(t *testing.T) {
 		}
 		synctest.Sleep(50 * time.Millisecond)
 		require.Equal(t, 1, mgr.callCount(), "debounced pass never ran")
-		assert.Equal(t, 1, mgr.callCount(), "burst must coalesce into one pass")
 		calls := mgr.callsSnapshot()
 		assert.True(t, calls[0].Full,
 			"the lifetime's first pass carries the startup full top-up")

--- a/cmd/agentsview/extract_scheduler_test.go
+++ b/cmd/agentsview/extract_scheduler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -60,29 +61,29 @@ func (f *fakePassManager) callsSnapshot() []extract.PassOptions {
 }
 
 func TestExtractSchedulerBurstOfNotifyProducesExactlyOnePass(t *testing.T) {
-	mgr := &fakePassManager{}
-	s := newExtractScheduler(mgr, 20*time.Millisecond, 0, 0, nil)
-	ctx := t.Context()
-	go s.Run(ctx)
-	defer s.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		mgr := &fakePassManager{}
+		s := newExtractScheduler(mgr, 20*time.Millisecond, 0, 0, nil)
+		go s.Run(t.Context())
+		defer s.Stop()
 
-	for range 5 {
+		for range 5 {
+			s.Notify()
+		}
+		synctest.Sleep(50 * time.Millisecond)
+		require.Equal(t, 1, mgr.callCount(), "debounced pass never ran")
+		assert.Equal(t, 1, mgr.callCount(), "burst must coalesce into one pass")
+		calls := mgr.callsSnapshot()
+		assert.True(t, calls[0].Full,
+			"the lifetime's first pass carries the startup full top-up")
+
 		s.Notify()
-	}
-	waitForSchedulerCondition(t, func() bool { return mgr.callCount() == 1 },
-		"debounced pass never ran")
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 1, mgr.callCount(), "burst must coalesce into one pass")
-	calls := mgr.callsSnapshot()
-	assert.True(t, calls[0].Full,
-		"the lifetime's first pass carries the startup full top-up")
-
-	s.Notify()
-	waitForSchedulerCondition(t, func() bool { return mgr.callCount() == 2 },
-		"second debounced pass never ran")
-	calls = mgr.callsSnapshot()
-	assert.False(t, calls[1].Full,
-		"event-driven passes after the startup pass are incremental")
+		synctest.Sleep(50 * time.Millisecond)
+		calls = mgr.callsSnapshot()
+		require.Equal(t, 2, mgr.callCount(), "second debounced pass never ran")
+		assert.False(t, calls[1].Full,
+			"event-driven passes after the startup pass are incremental")
+	})
 }
 
 func TestExtractSchedulerNotifiesDownstreamAfterEveryStartedPass(t *testing.T) {
@@ -156,52 +157,59 @@ func TestExtractSchedulerDroppedBackstopRetriesOnDebouncedPass(t *testing.T) {
 }
 
 func TestExtractSchedulerStopTerminatesRun(t *testing.T) {
-	mgr := &fakePassManager{}
-	s := newExtractScheduler(mgr, time.Hour, 0, 0, nil)
-	go s.Run(context.Background())
-	done := make(chan struct{})
-	go func() {
-		s.Stop()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Stop did not terminate Run")
-	}
+	synctest.Test(t, func(t *testing.T) {
+		mgr := &fakePassManager{}
+		s := newExtractScheduler(mgr, time.Hour, 0, 0, nil)
+		go s.Run(t.Context())
+		done := make(chan struct{})
+		go func() {
+			s.Stop()
+			close(done)
+		}()
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Fatal("Stop did not terminate Run")
+		}
+	})
 }
 
 func TestExtractSchedulerNotifyNeverBlocksWithoutAReader(t *testing.T) {
-	s := newExtractScheduler(&fakePassManager{}, time.Hour, 0, 0, nil)
-	done := make(chan struct{})
-	go func() {
-		for range 100 {
-			s.Notify()
+	synctest.Test(t, func(t *testing.T) {
+		s := newExtractScheduler(&fakePassManager{}, time.Hour, 0, 0, nil)
+		done := make(chan struct{})
+		go func() {
+			for range 100 {
+				s.Notify()
+			}
+			close(done)
+		}()
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Fatal("Notify blocked without a running scheduler")
 		}
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Notify blocked without a running scheduler")
-	}
+	})
 }
 
 func TestExtractTeeEmitterNotifiesScheduler(t *testing.T) {
-	mgr := &fakePassManager{}
-	s := newExtractScheduler(mgr, 10*time.Millisecond, 0, 0, nil)
-	primary := &recordingEmitter{}
-	tee := extractTeeEmitter{primary: primary, scheduler: s}
+	synctest.Test(t, func(t *testing.T) {
+		mgr := &fakePassManager{}
+		s := newExtractScheduler(mgr, 10*time.Millisecond, 0, 0, nil)
+		primary := &recordingEmitter{}
+		tee := extractTeeEmitter{primary: primary, scheduler: s}
 
-	ctx := t.Context()
-	go s.Run(ctx)
-	defer s.Stop()
+		go s.Run(t.Context())
+		defer s.Stop()
 
-	tee.Emit("sessions")
-	assert.Equal(t, 1, primary.count(),
-		"primary emitter must still receive the event")
-	waitForSchedulerCondition(t, func() bool { return mgr.callCount() == 1 },
-		"emit must schedule a pass")
+		tee.Emit("sessions")
+		assert.Equal(t, 1, primary.count(),
+			"primary emitter must still receive the event")
+		synctest.Sleep(10 * time.Millisecond)
+		require.Equal(t, 1, mgr.callCount(), "emit must schedule a pass")
+	})
 }
 
 func TestExtractSchedulerCatchupTicksWhenBackstopDisabled(t *testing.T) {
@@ -302,24 +310,26 @@ func TestExtractSchedulerPassHoldsIdleWorkLease(t *testing.T) {
 // lease contract: once the idle reaper has begun draining, a queued Notify
 // must not start a fresh pass under a daemon that is shutting down.
 func TestExtractSchedulerStartsNoPassAfterDraining(t *testing.T) {
-	mgr := &fakePassManager{}
-	idled := make(chan struct{})
-	tracker := server.NewIdleTracker(time.Millisecond, func() { close(idled) })
-	s := newExtractScheduler(mgr, 10*time.Millisecond, 0, 0, tracker)
-	ctx := t.Context()
-	go tracker.Run(ctx)
-	select {
-	case <-idled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("tracker never went idle")
-	}
-	go s.Run(ctx)
-	defer s.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		mgr := &fakePassManager{}
+		idled := make(chan struct{})
+		tracker := server.NewIdleTracker(time.Millisecond, func() { close(idled) })
+		s := newExtractScheduler(mgr, 10*time.Millisecond, 0, 0, tracker)
+		go tracker.Run(t.Context())
+		synctest.Sleep(time.Millisecond)
+		select {
+		case <-idled:
+		default:
+			t.Fatal("tracker never went idle")
+		}
+		go s.Run(t.Context())
+		defer s.Stop()
 
-	s.Notify()
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 0, mgr.callCount(),
-		"a draining daemon must not start new extraction passes")
+		s.Notify()
+		synctest.Sleep(100 * time.Millisecond)
+		assert.Equal(t, 0, mgr.callCount(),
+			"a draining daemon must not start new extraction passes")
+	})
 }
 
 // TestExtractSchedulerStartupPassSurvivesShortIdleTimeout pins that the

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -755,22 +755,26 @@ type fakeEmitter struct {
 func (f *fakeEmitter) Emit(_ string) { f.count.Add(1) }
 
 func TestStartRemoteHostSync_EmitsAfterSuccess(t *testing.T) {
-	em := &fakeEmitter{}
-	syncFn := func() (int, error) { return 3, nil }
+	synctest.Test(t, func(t *testing.T) {
+		em := &fakeEmitter{}
+		syncFn := func() (int, error) { return 3, nil }
 
-	done := make(chan struct{})
-	exited := make(chan struct{})
-	interval := 10 * time.Millisecond
-	go func() {
-		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, em, nil, done)
-		close(exited)
-	}()
+		done := make(chan struct{})
+		exited := make(chan struct{})
+		interval := 10 * time.Millisecond
+		go func() {
+			runRemoteHostSyncLoop(t.Context(), "test-host", interval, syncFn, em, nil, done)
+			close(exited)
+		}()
+		defer func() {
+			close(done)
+			synctest.Wait()
+			<-exited
+		}()
 
-	time.Sleep(3 * interval)
-	close(done)
-	<-exited
-
-	assert.Positive(t, em.count.Load(), "emitter should have been called at least once")
+		synctest.Sleep(3 * interval)
+		assert.Positive(t, em.count.Load(), "emitter should have been called at least once")
+	})
 }
 
 func TestRemoteHostSyncFuncSerializesWithEngineExclusiveLock(t *testing.T) {
@@ -1150,57 +1154,70 @@ func TestStartRemoteHostSync_EmitsSessionsScopeAfterSuccess(t *testing.T) {
 }
 
 func TestStartRemoteHostSync_NoEmitOnZeroSynced(t *testing.T) {
-	em := &fakeEmitter{}
-	syncFn := func() (int, error) { return 0, nil }
+	synctest.Test(t, func(t *testing.T) {
+		em := &fakeEmitter{}
+		syncFn := func() (int, error) { return 0, nil }
 
-	done := make(chan struct{})
-	exited := make(chan struct{})
-	interval := 10 * time.Millisecond
-	go func() {
-		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, em, nil, done)
-		close(exited)
-	}()
+		done := make(chan struct{})
+		exited := make(chan struct{})
+		interval := 10 * time.Millisecond
+		go func() {
+			runRemoteHostSyncLoop(t.Context(), "test-host", interval, syncFn, em, nil, done)
+			close(exited)
+		}()
+		defer func() {
+			close(done)
+			synctest.Wait()
+			<-exited
+		}()
 
-	time.Sleep(3 * interval)
-	close(done)
-	<-exited
-
-	assert.Zero(t, em.count.Load(), "emitter should not fire when no sessions synced")
+		synctest.Sleep(3 * interval)
+		assert.Zero(t, em.count.Load(), "emitter should not fire when no sessions synced")
+	})
 }
 
 func TestStartRemoteHostSync_NoEmitOnError(t *testing.T) {
-	em := &fakeEmitter{}
-	syncFn := func() (int, error) { return 0, errors.New("ssh failure") }
+	synctest.Test(t, func(t *testing.T) {
+		em := &fakeEmitter{}
+		syncFn := func() (int, error) { return 0, errors.New("ssh failure") }
 
-	done := make(chan struct{})
-	exited := make(chan struct{})
-	interval := 10 * time.Millisecond
-	go func() {
-		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, em, nil, done)
-		close(exited)
-	}()
+		done := make(chan struct{})
+		exited := make(chan struct{})
+		interval := 10 * time.Millisecond
+		go func() {
+			runRemoteHostSyncLoop(t.Context(), "test-host", interval, syncFn, em, nil, done)
+			close(exited)
+		}()
+		defer func() {
+			close(done)
+			synctest.Wait()
+			<-exited
+		}()
 
-	time.Sleep(3 * interval)
-	close(done)
-	<-exited
-
-	assert.Zero(t, em.count.Load(), "emitter should not fire when sync fails")
+		synctest.Sleep(3 * interval)
+		assert.Zero(t, em.count.Load(), "emitter should not fire when sync fails")
+	})
 }
 
 func TestStartRemoteHostSync_NilEmitterSafe(t *testing.T) {
-	syncFn := func() (int, error) { return 1, nil }
+	synctest.Test(t, func(t *testing.T) {
+		syncFn := func() (int, error) { return 1, nil }
 
-	done := make(chan struct{})
-	exited := make(chan struct{})
-	interval := 10 * time.Millisecond
-	go func() {
-		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, nil, nil, done)
-		close(exited)
-	}()
+		done := make(chan struct{})
+		exited := make(chan struct{})
+		interval := 10 * time.Millisecond
+		go func() {
+			runRemoteHostSyncLoop(t.Context(), "test-host", interval, syncFn, nil, nil, done)
+			close(exited)
+		}()
+		defer func() {
+			close(done)
+			synctest.Wait()
+			<-exited
+		}()
 
-	time.Sleep(2 * interval)
-	close(done)
-	<-exited
+		synctest.Sleep(2 * interval)
+	})
 }
 
 func TestCollectWatchRootsHermesSessionsWatchesStateDBParent(t *testing.T) {

--- a/cmd/agentsview/poll_coordinator_scope_test.go
+++ b/cmd/agentsview/poll_coordinator_scope_test.go
@@ -457,12 +457,7 @@ func TestUnwatchedPollDefersOnlyTheProviderWhoseProbeIsMissing(t *testing.T) {
 		}))
 
 		coordinator.requestPoll()
-		synctest.Wait()
-		select {
-		case <-syncer.wake:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, syncer.wake, time.Second)
 
 		calls := syncer.snapshot()
 		require.Len(t, calls, 1,
@@ -471,12 +466,6 @@ func TestUnwatchedPollDefersOnlyTheProviderWhoseProbeIsMissing(t *testing.T) {
 			"the call must be for the healthy provider")
 		assert.Equal(t, []string{sharedRoot}, calls[0].Roots)
 
-		// Assert A was never called.
-		synctest.Wait()
-		for _, c := range syncer.snapshot() {
-			assert.NotEqual(t, parser.AgentClaude, c.Agent,
-				"provider A must never be called while its probe is missing")
-		}
 	})
 }
 

--- a/cmd/agentsview/poll_coordinator_scope_test.go
+++ b/cmd/agentsview/poll_coordinator_scope_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -426,54 +427,57 @@ func TestUnwatchedPollAttemptsEveryProviderAfterOneFails(t *testing.T) {
 // TestUnwatchedPollDefersOnlyTheProviderWhoseProbeIsMissing asserts that a
 // missing probe defers only its own provider; the healthy provider still polls.
 func TestUnwatchedPollDefersOnlyTheProviderWhoseProbeIsMissing(t *testing.T) {
-	parent := t.TempDir()
-	sharedRoot := requireExistingPollRoot(t, parent, "shared")
-	probeA := filepath.Join(sharedRoot, "probe-a")
-	require.NoError(t, os.Mkdir(probeA, 0o755))
-	// probeB is intentionally absent — A's probe is missing.
+	synctest.Test(t, func(t *testing.T) {
+		parent := t.TempDir()
+		sharedRoot := requireExistingPollRoot(t, parent, "shared")
+		probeA := filepath.Join(sharedRoot, "probe-a")
+		require.NoError(t, os.Mkdir(probeA, 0o755))
+		// probeB is intentionally absent — A's probe is missing.
 
-	syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
-	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
-		time.Now, time.After,
-	)
-	t.Cleanup(coordinator.Stop)
+		syncer := &recordingProviderPollSyncer{wake: make(chan struct{}, 4)}
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			t.Context(), syncer, make(chan time.Time), func() {},
+			func(run func()) { run() }, nil,
+			time.Now, time.After,
+		)
+		t.Cleanup(coordinator.Stop)
 
-	// Provider A: probe is missing → must be deferred.
-	missingProbeA := filepath.Join(sharedRoot, "missing-probe-a")
-	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key:    "agent-a-root",
-		Scopes: []pollingScope{{Agent: parser.AgentClaude, Root: sharedRoot}},
-		Probe:  missingProbeA,
-	}))
-	// Provider B: probe is present → must be polled.
-	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key:    "agent-b-root",
-		Scopes: []pollingScope{{Agent: parser.AgentOpenHands, Root: sharedRoot}},
-		Probe:  probeA, // present
-	}))
+		// Provider A: probe is missing → must be deferred.
+		missingProbeA := filepath.Join(sharedRoot, "missing-probe-a")
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key:    "agent-a-root",
+			Scopes: []pollingScope{{Agent: parser.AgentClaude, Root: sharedRoot}},
+			Probe:  missingProbeA,
+		}))
+		// Provider B: probe is present → must be polled.
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key:    "agent-b-root",
+			Scopes: []pollingScope{{Agent: parser.AgentOpenHands, Root: sharedRoot}},
+			Probe:  probeA, // present
+		}))
 
-	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-
-	calls := syncer.snapshot()
-	require.Len(t, calls, 1,
-		"only the healthy provider must be called; the one with missing probe must be deferred")
-	assert.Equal(t, parser.AgentOpenHands, calls[0].Agent,
-		"the call must be for the healthy provider")
-	assert.Equal(t, []string{sharedRoot}, calls[0].Roots)
-
-	// Assert A was never called.
-	assert.Never(t, func() bool {
-		for _, c := range syncer.snapshot() {
-			if c.Agent == parser.AgentClaude {
-				return true
-			}
+		coordinator.requestPoll()
+		synctest.Wait()
+		select {
+		case <-syncer.wake:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
 		}
-		return false
-	}, 100*time.Millisecond, 10*time.Millisecond,
-		"provider A must never be called while its probe is missing")
+
+		calls := syncer.snapshot()
+		require.Len(t, calls, 1,
+			"only the healthy provider must be called; the one with missing probe must be deferred")
+		assert.Equal(t, parser.AgentOpenHands, calls[0].Agent,
+			"the call must be for the healthy provider")
+		assert.Equal(t, []string{sharedRoot}, calls[0].Roots)
+
+		// Assert A was never called.
+		synctest.Wait()
+		for _, c := range syncer.snapshot() {
+			assert.NotEqual(t, parser.AgentClaude, c.Agent,
+				"provider A must never be called while its probe is missing")
+		}
+	})
 }
 
 // TestUnwatchedPollStopDuringCooldown asserts that Stop() returns immediately

--- a/cmd/agentsview/pricing_schedule_test.go
+++ b/cmd/agentsview/pricing_schedule_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -52,63 +53,59 @@ func (t pricingCatalogTransport) RoundTrip(
 }
 
 func TestRunPeriodicPricingRefreshFetchesAfterRecentAttempt(t *testing.T) {
-	database := dbtest.OpenTestDB(t)
-	previousAttempt := time.Now().Add(-10 * time.Minute).UTC().Format(
-		time.RFC3339,
-	)
-	require.NoError(t, database.SetPricingMeta(
-		"_litellm_last_attempt", previousAttempt,
-	))
+	synctest.Test(t, func(t *testing.T) {
+		database := dbtest.OpenTestDB(t)
+		previousAttempt := time.Now().Add(-10 * time.Minute).UTC().Format(
+			time.RFC3339,
+		)
+		require.NoError(t, database.SetPricingMeta(
+			"_litellm_last_attempt", previousAttempt,
+		))
 
-	requests := make(chan *http.Request, 3)
-	originalTransport := http.DefaultTransport
-	http.DefaultTransport = pricingCatalogTransport{requests: requests}
-	t.Cleanup(func() {
-		http.DefaultTransport = originalTransport
-	})
+		requests := make(chan *http.Request, 3)
+		originalTransport := http.DefaultTransport
+		http.DefaultTransport = pricingCatalogTransport{requests: requests}
+		t.Cleanup(func() {
+			http.DefaultTransport = originalTransport
+		})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	ticks := make(chan time.Time, 1)
-	done := make(chan struct{})
-	go func() {
-		runPeriodicPricingRefresh(ctx, ticks, database, nil)
-		close(done)
-	}()
-	t.Cleanup(func() {
-		cancel()
-		require.Eventually(t, func() bool {
-			select {
-			case <-done:
-				return true
-			default:
-				return false
-			}
-		}, pricingResyncTestTimeout, time.Millisecond)
-	})
+		ctx, cancel := context.WithCancel(context.Background())
+		ticks := make(chan time.Time, 1)
+		done := make(chan struct{})
+		go func() {
+			runPeriodicPricingRefresh(ctx, ticks, database, nil)
+			close(done)
+		}()
+		t.Cleanup(func() {
+			cancel()
+			synctest.Wait()
+			<-done
+		})
 
-	ticks <- time.Now()
-	require.Eventually(t, func() bool {
+		ticks <- time.Now()
+		synctest.Wait()
 		price, err := database.GetModelPricing("scheduled-model")
-		return err == nil && price != nil
-	}, pricingResyncTestTimeout, time.Millisecond)
+		require.NoError(t, err)
+		require.NotNil(t, price)
 
-	require.Equal(t,
-		"https://raw.githubusercontent.com/pydantic/genai-prices/main/"+
-			"prices/new_data/v2/data.json",
-		(<-requests).URL.String(),
-	)
-	require.Equal(t,
-		"https://raw.githubusercontent.com/BerriAI/litellm/main/"+
-			"model_prices_and_context_window.json",
-		(<-requests).URL.String(),
-	)
-	require.Equal(t,
-		"https://openrouter.ai/api/v1/models",
-		(<-requests).URL.String(),
-	)
-	currentAttempt, err := database.GetPricingMeta("_litellm_last_attempt")
-	require.NoError(t, err)
-	require.NotEqual(t, previousAttempt, currentAttempt)
+		require.Equal(t,
+			"https://raw.githubusercontent.com/pydantic/genai-prices/main/"+
+				"prices/new_data/v2/data.json",
+			(<-requests).URL.String(),
+		)
+		require.Equal(t,
+			"https://raw.githubusercontent.com/BerriAI/litellm/main/"+
+				"model_prices_and_context_window.json",
+			(<-requests).URL.String(),
+		)
+		require.Equal(t,
+			"https://openrouter.ai/api/v1/models",
+			(<-requests).URL.String(),
+		)
+		currentAttempt, err := database.GetPricingMeta("_litellm_last_attempt")
+		require.NoError(t, err)
+		require.NotEqual(t, previousAttempt, currentAttempt)
+	})
 }
 
 func TestStartPeriodicPricingRefreshWaitsForResyncSwap(t *testing.T) {
@@ -272,39 +269,33 @@ func TestSeedPricingWaitsForResyncSwap(t *testing.T) {
 }
 
 func TestRunPricingRefreshLoopContinuesAfterFailure(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	ticks := make(chan time.Time, 2)
-	done := make(chan struct{})
-	var attempts atomic.Int32
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		ticks := make(chan time.Time, 2)
+		done := make(chan struct{})
+		var attempts atomic.Int32
 
-	go func() {
-		runPricingRefreshLoop(ctx, ticks, func(context.Context) error {
-			if attempts.Add(1) == 1 {
-				return errors.New("temporary pricing failure")
-			}
-			return nil
+		go func() {
+			runPricingRefreshLoop(ctx, ticks, func(context.Context) error {
+				if attempts.Add(1) == 1 {
+					return errors.New("temporary pricing failure")
+				}
+				return nil
+			})
+			close(done)
+		}()
+		t.Cleanup(func() {
+			cancel()
+			synctest.Wait()
+			<-done
 		})
-		close(done)
-	}()
-	t.Cleanup(func() {
-		cancel()
-		require.Eventually(t, func() bool {
-			select {
-			case <-done:
-				return true
-			default:
-				return false
-			}
-		}, pricingResyncTestTimeout, time.Millisecond)
+
+		ticks <- time.Time{}
+		synctest.Wait()
+		require.Equal(t, int32(1), attempts.Load())
+
+		ticks <- time.Time{}
+		synctest.Wait()
+		require.Equal(t, int32(2), attempts.Load())
 	})
-
-	ticks <- time.Time{}
-	require.Eventually(t, func() bool {
-		return attempts.Load() == 1
-	}, pricingResyncTestTimeout, time.Millisecond)
-
-	ticks <- time.Time{}
-	require.Eventually(t, func() bool {
-		return attempts.Load() == 2
-	}, pricingResyncTestTimeout, time.Millisecond)
 }

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -233,12 +233,7 @@ func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
 		}))
 
 		coordinator.requestPoll()
-		synctest.Wait()
-		select {
-		case <-syncer.wake:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, syncer.wake, time.Second)
 		assert.Equal(t, [][]string{{root}}, syncer.snapshot())
 
 		require.NoError(t, os.RemoveAll(root))
@@ -249,12 +244,7 @@ func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
 
 		require.NoError(t, os.Mkdir(root, 0o755))
 		coordinator.requestPoll()
-		synctest.Wait()
-		select {
-		case <-syncer.wake:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, syncer.wake, time.Second)
 		assert.Equal(t, [][]string{{root}, {root}}, syncer.snapshot(),
 			"the polling obligation must remain active for a returning root")
 	})
@@ -288,12 +278,7 @@ func TestUnwatchedPollDefersScopesWhileProbePathMissing(t *testing.T) {
 		}))
 
 		coordinator.requestPoll()
-		synctest.Wait()
-		select {
-		case <-syncer.wake:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, syncer.wake, time.Second)
 		assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
 			"an available probe reconciles the configured scope")
 
@@ -306,12 +291,7 @@ func TestUnwatchedPollDefersScopesWhileProbePathMissing(t *testing.T) {
 
 		require.NoError(t, os.Mkdir(physical, 0o755))
 		coordinator.requestPoll()
-		synctest.Wait()
-		select {
-		case <-syncer.wake:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, syncer.wake, time.Second)
 		assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
 			"the deferred scope must resume once the physical path returns")
 	})
@@ -347,12 +327,7 @@ func TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing(t *testing.T) {
 		}))
 
 		coordinator.requestPoll()
-		synctest.Wait()
-		select {
-		case <-syncer.wake:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, syncer.wake, time.Second)
 		assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
 			"with every probe available the shared scope reconciles")
 
@@ -365,12 +340,7 @@ func TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing(t *testing.T) {
 
 		require.NoError(t, os.Mkdir(sessions, 0o755))
 		coordinator.requestPoll()
-		synctest.Wait()
-		select {
-		case <-syncer.wake:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, syncer.wake, time.Second)
 		assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
 			"the shared scope must resume once every probe returns")
 	})
@@ -615,12 +585,7 @@ func TestUnwatchedPollStopCancelsAndJoinsActiveReconciliation(t *testing.T) {
 			Key: "owned", Scopes: []pollingScope{{Root: owned}},
 		}))
 		coordinator.requestPoll()
-		synctest.Wait()
-		select {
-		case <-syncer.started:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, syncer.started, time.Second)
 		coordinator.requestPoll()
 
 		stopDone := make(chan struct{})
@@ -628,12 +593,7 @@ func TestUnwatchedPollStopCancelsAndJoinsActiveReconciliation(t *testing.T) {
 			coordinator.Stop()
 			close(stopDone)
 		}()
-		synctest.Wait()
-		select {
-		case <-stopDone:
-		default:
-			require.FailNow(t, "poll did not run before timeout")
-		}
+		requirePollWithin(t, stopDone, time.Second)
 		select {
 		case <-syncer.canceled:
 		default:

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -208,43 +209,55 @@ func TestUnwatchedPollTickUsesRootsAddedAfterStart(t *testing.T) {
 }
 
 func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
-	parent := t.TempDir()
-	root := filepath.Join(parent, "provider")
-	require.NoError(t, os.Mkdir(root, 0o755))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(root, "session.jsonl"), []byte("session\n"), 0o600,
-	))
+	synctest.Test(t, func(t *testing.T) {
+		parent := t.TempDir()
+		root := filepath.Join(parent, "provider")
+		require.NoError(t, os.Mkdir(root, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(root, "session.jsonl"), []byte("session\n"), 0o600,
+		))
 
-	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
-	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil, time.Now,
-		func(d time.Duration) <-chan time.Time {
-			ch := make(chan time.Time, 1)
-			ch <- time.Time{}
-			return ch
-		},
-	)
-	t.Cleanup(coordinator.Stop)
-	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "provider-root", Scopes: []pollingScope{{Root: root}},
-	}))
+		syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			t.Context(), syncer, make(chan time.Time), func() {},
+			func(run func()) { run() }, nil, time.Now,
+			func(d time.Duration) <-chan time.Time {
+				ch := make(chan time.Time, 1)
+				ch <- time.Time{}
+				return ch
+			},
+		)
+		t.Cleanup(coordinator.Stop)
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key: "provider-root", Scopes: []pollingScope{{Root: root}},
+		}))
 
-	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{{root}}, syncer.snapshot())
+		coordinator.requestPoll()
+		synctest.Wait()
+		select {
+		case <-syncer.wake:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		assert.Equal(t, [][]string{{root}}, syncer.snapshot())
 
-	require.NoError(t, os.RemoveAll(root))
-	coordinator.requestPoll()
-	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
-		100*time.Millisecond, 10*time.Millisecond,
-		"an absent root must not become an authoritative empty scope")
+		require.NoError(t, os.RemoveAll(root))
+		coordinator.requestPoll()
+		synctest.Wait()
+		assert.Len(t, syncer.snapshot(), 1,
+			"an absent root must not become an authoritative empty scope")
 
-	require.NoError(t, os.Mkdir(root, 0o755))
-	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{{root}, {root}}, syncer.snapshot(),
-		"the polling obligation must remain active for a returning root")
+		require.NoError(t, os.Mkdir(root, 0o755))
+		coordinator.requestPoll()
+		synctest.Wait()
+		select {
+		case <-syncer.wake:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		assert.Equal(t, [][]string{{root}, {root}}, syncer.snapshot(),
+			"the polling obligation must remain active for a returning root")
+	})
 }
 
 // TestUnwatchedPollDefersScopesWhileProbePathMissing is the nested-root
@@ -254,42 +267,54 @@ func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
 // of authoritatively reconciling the still-present <root>, which would
 // tombstone every session under the vanished subtree.
 func TestUnwatchedPollDefersScopesWhileProbePathMissing(t *testing.T) {
-	configured := t.TempDir()
-	physical := filepath.Join(configured, "tmp")
-	require.NoError(t, os.Mkdir(physical, 0o755))
+	synctest.Test(t, func(t *testing.T) {
+		configured := t.TempDir()
+		physical := filepath.Join(configured, "tmp")
+		require.NoError(t, os.Mkdir(physical, 0o755))
 
-	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
-	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil, time.Now,
-		func(d time.Duration) <-chan time.Time {
-			ch := make(chan time.Time, 1)
-			ch <- time.Time{}
-			return ch
-		},
-	)
-	t.Cleanup(coordinator.Stop)
-	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: physical, Scopes: []pollingScope{{Root: configured}}, Probe: physical,
-	}))
+		syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			t.Context(), syncer, make(chan time.Time), func() {},
+			func(run func()) { run() }, nil, time.Now,
+			func(d time.Duration) <-chan time.Time {
+				ch := make(chan time.Time, 1)
+				ch <- time.Time{}
+				return ch
+			},
+		)
+		t.Cleanup(coordinator.Stop)
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key: physical, Scopes: []pollingScope{{Root: configured}}, Probe: physical,
+		}))
 
-	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
-		"an available probe reconciles the configured scope")
+		coordinator.requestPoll()
+		synctest.Wait()
+		select {
+		case <-syncer.wake:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
+			"an available probe reconciles the configured scope")
 
-	require.NoError(t, os.RemoveAll(physical))
-	coordinator.requestPoll()
-	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
-		100*time.Millisecond, 10*time.Millisecond,
-		"a missing physical watcher path must defer its reconciliation "+
-			"scopes even though the configured root still exists")
+		require.NoError(t, os.RemoveAll(physical))
+		coordinator.requestPoll()
+		synctest.Wait()
+		assert.Len(t, syncer.snapshot(), 1,
+			"a missing physical watcher path must defer its reconciliation "+
+				"scopes even though the configured root still exists")
 
-	require.NoError(t, os.Mkdir(physical, 0o755))
-	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
-		"the deferred scope must resume once the physical path returns")
+		require.NoError(t, os.Mkdir(physical, 0o755))
+		coordinator.requestPoll()
+		synctest.Wait()
+		select {
+		case <-syncer.wake:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
+			"the deferred scope must resume once the physical path returns")
+	})
 }
 
 // TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing pins the shared-scope
@@ -298,45 +323,57 @@ func TestUnwatchedPollDefersScopesWhileProbePathMissing(t *testing.T) {
 // present shallow plan must not make <root> pollable, or authoritative
 // reconciliation would tombstone every session under the vanished subtree.
 func TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing(t *testing.T) {
-	configured := t.TempDir()
-	sessions := filepath.Join(configured, "tmp")
-	require.NoError(t, os.Mkdir(sessions, 0o755))
+	synctest.Test(t, func(t *testing.T) {
+		configured := t.TempDir()
+		sessions := filepath.Join(configured, "tmp")
+		require.NoError(t, os.Mkdir(sessions, 0o755))
 
-	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
-	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil, time.Now,
-		func(d time.Duration) <-chan time.Time {
-			ch := make(chan time.Time, 1)
-			ch <- time.Time{}
-			return ch
-		},
-	)
-	t.Cleanup(coordinator.Stop)
-	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: configured, Scopes: []pollingScope{{Root: configured}}, Probe: configured,
-	}))
-	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: sessions, Scopes: []pollingScope{{Root: configured}}, Probe: sessions,
-	}))
+		syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			t.Context(), syncer, make(chan time.Time), func() {},
+			func(run func()) { run() }, nil, time.Now,
+			func(d time.Duration) <-chan time.Time {
+				ch := make(chan time.Time, 1)
+				ch <- time.Time{}
+				return ch
+			},
+		)
+		t.Cleanup(coordinator.Stop)
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key: configured, Scopes: []pollingScope{{Root: configured}}, Probe: configured,
+		}))
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key: sessions, Scopes: []pollingScope{{Root: configured}}, Probe: sessions,
+		}))
 
-	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
-		"with every probe available the shared scope reconciles")
+		coordinator.requestPoll()
+		synctest.Wait()
+		select {
+		case <-syncer.wake:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
+			"with every probe available the shared scope reconciles")
 
-	require.NoError(t, os.RemoveAll(sessions))
-	coordinator.requestPoll()
-	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
-		100*time.Millisecond, 10*time.Millisecond,
-		"a missing session subtree must defer the shared scope even though "+
-			"the metadata plan's probe still exists")
+		require.NoError(t, os.RemoveAll(sessions))
+		coordinator.requestPoll()
+		synctest.Wait()
+		assert.Len(t, syncer.snapshot(), 1,
+			"a missing session subtree must defer the shared scope even though "+
+				"the metadata plan's probe still exists")
 
-	require.NoError(t, os.Mkdir(sessions, 0o755))
-	coordinator.requestPoll()
-	requirePollWithin(t, syncer.wake, time.Second)
-	assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
-		"the shared scope must resume once every probe returns")
+		require.NoError(t, os.Mkdir(sessions, 0o755))
+		coordinator.requestPoll()
+		synctest.Wait()
+		select {
+		case <-syncer.wake:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
+			"the shared scope must resume once every probe returns")
+	})
 }
 
 // TestAvailableUnwatchedPollRootsDefersRootsOverlappingBlockedScopes pins the
@@ -559,41 +596,57 @@ func TestUnwatchedPollObligationUpdatesRemainResponsiveDuringReconciliation(
 }
 
 func TestUnwatchedPollStopCancelsAndJoinsActiveReconciliation(t *testing.T) {
-	parentCtx, cancelParent := context.WithCancel(context.Background())
-	syncer := &cancelBlockingUnwatchedPollSyncer{
-		started:  make(chan struct{}, 2),
-		canceled: make(chan struct{}, 2),
-	}
-	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		parentCtx, syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil, time.Now, time.After,
-	)
-	t.Cleanup(func() {
-		cancelParent()
-		coordinator.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		parentCtx, cancelParent := context.WithCancel(context.Background())
+		syncer := &cancelBlockingUnwatchedPollSyncer{
+			started:  make(chan struct{}, 2),
+			canceled: make(chan struct{}, 2),
+		}
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			parentCtx, syncer, make(chan time.Time), func() {},
+			func(run func()) { run() }, nil, time.Now, time.After,
+		)
+		t.Cleanup(func() {
+			cancelParent()
+			coordinator.Stop()
+		})
+		owned := requireExistingPollRoot(t, t.TempDir(), "owned")
+		require.NoError(t, coordinator.AddObligation(pollingObligation{
+			Key: "owned", Scopes: []pollingScope{{Root: owned}},
+		}))
+		coordinator.requestPoll()
+		synctest.Wait()
+		select {
+		case <-syncer.started:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		coordinator.requestPoll()
+
+		stopDone := make(chan struct{})
+		go func() {
+			coordinator.Stop()
+			close(stopDone)
+		}()
+		synctest.Wait()
+		select {
+		case <-stopDone:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		select {
+		case <-syncer.canceled:
+		default:
+			require.FailNow(t, "poll did not run before timeout")
+		}
+		assert.Equal(t, 1, syncer.callCount(),
+			"shutdown must discard the wake queued during reconciliation")
+
+		coordinator.requestPoll()
+		synctest.Wait()
+		assert.Equal(t, 1, syncer.callCount(),
+			"shutdown must not start another queued reconciliation")
 	})
-	owned := requireExistingPollRoot(t, t.TempDir(), "owned")
-	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key: "owned", Scopes: []pollingScope{{Root: owned}},
-	}))
-	coordinator.requestPoll()
-	requirePollWithin(t, syncer.started, time.Second)
-	coordinator.requestPoll()
-
-	stopDone := make(chan struct{})
-	go func() {
-		coordinator.Stop()
-		close(stopDone)
-	}()
-	requirePollWithin(t, stopDone, time.Second)
-	requirePollWithin(t, syncer.canceled, time.Second)
-	assert.Equal(t, 1, syncer.callCount(),
-		"shutdown must discard the wake queued during reconciliation")
-
-	coordinator.requestPoll()
-	assert.Never(t, func() bool { return syncer.callCount() > 1 },
-		100*time.Millisecond, 10*time.Millisecond,
-		"shutdown must not start another queued reconciliation")
 }
 
 func TestUnwatchedPollParentCancellationCancelsJoinsAndRejectsUpdates(
@@ -688,18 +741,20 @@ func TestUnwatchedPollRemovingOneOverlappingObligationKeepsSharedRoot(t *testing
 }
 
 func TestUnwatchedPollEmptyObligationNeverExpandsToFullReconciliation(t *testing.T) {
-	ticks := make(chan time.Time)
-	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
-	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now, time.After,
-	)
-	t.Cleanup(coordinator.Stop)
-	require.NoError(t, coordinator.AddObligation(pollingObligation{Key: "empty"}))
+	synctest.Test(t, func(t *testing.T) {
+		ticks := make(chan time.Time)
+		syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, time.Now, time.After,
+		)
+		t.Cleanup(coordinator.Stop)
+		require.NoError(t, coordinator.AddObligation(pollingObligation{Key: "empty"}))
 
-	coordinator.requestPoll()
+		coordinator.requestPoll()
+		synctest.Wait()
 
-	assert.Never(t, func() bool { return len(syncer.snapshot()) > 0 },
-		100*time.Millisecond, 10*time.Millisecond)
+		assert.Empty(t, syncer.snapshot())
+	})
 }
 
 func TestUnwatchedPollStopIsConcurrentAndRejectsLaterRoots(t *testing.T) {


### PR DESCRIPTION
The in-process `cmd/agentsview` timing tests now use `testing/synctest` to wait for goroutines and advance test timers. Assertions that currently poll or sleep can settle at the exact channel, callback, or timer event they exercise, which removes scheduler dependent failures from those tests.

The seven test files change test code only. OS signals, subprocesses, file locks, real pipes, loopback servers, filesystem watchers, and SQLite connection draining retain their timing budgets because their event sources sit outside a bubble. The conversion follows PR 1674 and continues PR 1701.

Closes #1702
