### PR TITLE
test(sync): convert convertible internal/sync timing waits to testing/synctest

### DIFF
--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -4086,25 +4086,33 @@ func TestStartupReconciledCallbackOwnersRetainFailureForLaterSuccess(t *testing.
 }
 
 func TestStartupReconciledCallbackReportsAbortedResyncAttempt(t *testing.T) {
-	database := openTestDB(t)
-	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
-	dbtest.SeedSession(t, database, "existing", "proj", func(s *db.Session) {
-		s.FilePath = &missingPath
-	})
-	reconciled := make(chan error, 1)
-	engine := NewEngine(database, EngineConfig{
-		OnStartupReconciled: func(stats SyncStats, err error) {
-			assert.True(t, stats.Aborted)
-			reconciled <- err
-		},
-	})
-	t.Cleanup(engine.Close)
+	synctest.Test(t, func(t *testing.T) {
+		database := openTestDB(t)
+		missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
+		dbtest.SeedSession(t, database, "existing", "proj", func(s *db.Session) {
+			s.FilePath = &missingPath
+		})
+		reconciled := make(chan error, 1)
+		engine := NewEngine(database, EngineConfig{
+			OnStartupReconciled: func(stats SyncStats, err error) {
+				assert.True(t, stats.Aborted)
+				reconciled <- err
+			},
+		})
+		t.Cleanup(engine.Close)
 
-	resync := engine.ResyncAll(t.Context(), nil)
-	assert.True(t, resync.Aborted)
-	require.Error(t, requireReceiveWithin(t, reconciled, time.Second))
-	fallback := engine.SyncAll(t.Context(), nil)
-	assert.False(t, fallback.Aborted)
+		resync := engine.ResyncAll(t.Context(), nil)
+		assert.True(t, resync.Aborted)
+		synctest.Wait()
+		select {
+		case err := <-reconciled:
+			require.Error(t, err)
+		default:
+			require.FailNow(t, "aborted resync did not report startup reconciliation")
+		}
+		fallback := engine.SyncAll(t.Context(), nil)
+		assert.False(t, fallback.Aborted)
+	})
 }
 
 func TestStartupSyncFallbackSkipsAfterForegroundSyncCompletes(t *testing.T) {
@@ -9825,9 +9833,10 @@ func TestEngine_ReconcileWatchRootsReportsProgressBeforeDiscoveryReturns(t *test
 		go func() {
 			done <- engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
 		}()
+		synctest.Wait()
 		select {
 		case <-started:
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "reconciliation did not enter discovery")
 		}
 
@@ -9835,10 +9844,11 @@ func TestEngine_ReconcileWatchRootsReportsProgressBeforeDiscoveryReturns(t *test
 		assert.Equal(t, PhaseDiscovering, progress.Phase)
 
 		release <- struct{}{}
+		synctest.Wait()
 		select {
 		case err := <-done:
 			require.NoError(t, err)
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "reconciliation did not finish after discovery resumed")
 		}
 	})
@@ -9871,9 +9881,10 @@ func TestEngine_SyncPathsReportsProgressBeforeChangedPathStatReturns(t *testing.
 		go func() {
 			done <- fx.engine.SyncPathsContext(t.Context(), []string{path})
 		}()
+		synctest.Wait()
 		select {
 		case <-started:
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "changed-path sync did not enter source stat")
 		}
 
@@ -9881,10 +9892,11 @@ func TestEngine_SyncPathsReportsProgressBeforeChangedPathStatReturns(t *testing.
 		assert.Equal(t, PhaseDiscovering, progress.Phase)
 
 		release <- struct{}{}
+		synctest.Wait()
 		select {
 		case err := <-done:
 			require.NoError(t, err)
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "changed-path sync did not finish after stat resumed")
 		}
 		_, active := fx.engine.CurrentProgress()
@@ -9961,9 +9973,10 @@ func TestEngine_TryRunExclusiveRejectsBusySyncWithoutRunningWork(t *testing.T) {
 				return nil
 			})
 		}()
+		synctest.Wait()
 		select {
 		case <-entered:
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "first exclusive sync did not acquire the lock")
 		}
 

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -16,6 +16,7 @@ import (
 	gosync "sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -3837,41 +3838,40 @@ func TestDeferredStartupPassDoesNotAcknowledgeReconciliation(t *testing.T) {
 }
 
 func TestStartupSyncFallbackRunsWhenForegroundSyncNeverArrives(t *testing.T) {
-	database := openTestDB(t)
-	engine := NewEngine(database, EngineConfig{
-		Machine:                 "local",
-		DeferStartupMaintenance: true,
-	})
-	t.Cleanup(engine.Close)
+	synctest.Test(t, func(t *testing.T) {
+		database := openTestDB(t)
+		engine := NewEngine(database, EngineConfig{
+			Machine:                 "local",
+			DeferStartupMaintenance: true,
+		})
+		t.Cleanup(engine.Close)
 
-	maintenanceStarted := make(chan struct{})
-	maintenanceDone := make(chan error, 1)
-	go func() {
-		maintenanceDone <- engine.RunStartupMaintenance(
-			t.Context(),
-			func() error {
-				close(maintenanceStarted)
-				return nil
-			},
-		)
-	}()
+		maintenanceStarted := make(chan struct{})
+		maintenanceDone := make(chan error, 1)
+		go func() {
+			maintenanceDone <- engine.RunStartupMaintenance(
+				t.Context(),
+				func() error {
+					close(maintenanceStarted)
+					return nil
+				},
+			)
+		}()
 
-	stats, ran, err := engine.RunStartupSyncFallback(t.Context(), nil)
-	require.NoError(t, err)
-	assert.True(t, ran)
-	assert.False(t, stats.Aborted)
-	assert.False(t, engine.LastSyncStartedAt().IsZero(),
-		"fallback must perform the skipped startup sync")
-	require.Eventually(t, func() bool {
+		stats, ran, err := engine.RunStartupSyncFallback(t.Context(), nil)
+		require.NoError(t, err)
+		assert.True(t, ran)
+		assert.False(t, stats.Aborted)
+		assert.False(t, engine.LastSyncStartedAt().IsZero(),
+			"fallback must perform the skipped startup sync")
+		synctest.Wait()
 		select {
 		case <-maintenanceStarted:
-			return true
 		default:
-			return false
+			require.FailNow(t, "fallback completion must release startup maintenance")
 		}
-	}, time.Second, 10*time.Millisecond,
-		"fallback completion must release startup maintenance")
-	require.NoError(t, <-maintenanceDone)
+		require.NoError(t, <-maintenanceDone)
+	})
 }
 
 func TestStartupReconciledCallbackRunsOnceAfterSyncLockRelease(t *testing.T) {
@@ -3930,7 +3930,7 @@ func TestStartupReconciledCallbackReportsIncompleteDiscoveryOnce(t *testing.T) {
 
 	failed := engine.SyncAll(t.Context(), nil)
 	assert.Greater(t, failed.Failed, 0)
-	first := requireReceiveWithin(t, reconciled, time.Second)
+	first := <-reconciled
 	require.Error(t, first.err)
 	assert.False(t, first.stats.AuthoritativeDiscoveryComplete())
 
@@ -3939,7 +3939,7 @@ func TestStartupReconciledCallbackReportsIncompleteDiscoveryOnce(t *testing.T) {
 	select {
 	case duplicate := <-reconciled:
 		require.Fail(t, "startup attempt callback ran more than once", "%+v", duplicate)
-	case <-time.After(50 * time.Millisecond):
+	default:
 	}
 }
 
@@ -3981,7 +3981,7 @@ func TestStartupSyncFallbackUsesSuccessSignalNotMaintenanceRelease(t *testing.T)
 		"maintenance release from an incomplete foreground attempt must not skip fallback")
 	select {
 	case <-reconciled:
-	case <-time.After(time.Second):
+	default:
 		require.FailNow(t, "successful fallback did not reconcile startup")
 	}
 }
@@ -4077,10 +4077,10 @@ func TestStartupReconciledCallbackOwnersRetainFailureForLaterSuccess(t *testing.
 			select {
 			case <-reconciled:
 				require.Fail(t, "failed owner opened startup gate")
-			case <-time.After(50 * time.Millisecond):
+			default:
 			}
 			tt.succeed(t.Context(), engine)
-			requireReceiveWithin(t, reconciled, time.Second)
+			<-reconciled
 		})
 	}
 }
@@ -4153,41 +4153,40 @@ func TestStartupSyncFallbackRecoversCanceledForegroundSync(t *testing.T) {
 func TestStartupSyncFallbackReleasesMaintenanceAfterCanceledAttempt(
 	t *testing.T,
 ) {
-	database := openTestDB(t)
-	engine := NewEngine(database, EngineConfig{
-		Machine:                 "local",
-		DeferStartupMaintenance: true,
-	})
-	t.Cleanup(engine.Close)
+	synctest.Test(t, func(t *testing.T) {
+		database := openTestDB(t)
+		engine := NewEngine(database, EngineConfig{
+			Machine:                 "local",
+			DeferStartupMaintenance: true,
+		})
+		t.Cleanup(engine.Close)
 
-	maintenanceStarted := make(chan struct{})
-	maintenanceDone := make(chan error, 1)
-	go func() {
-		maintenanceDone <- engine.RunStartupMaintenance(
-			t.Context(),
-			func() error {
-				close(maintenanceStarted)
-				return nil
-			},
-		)
-	}()
+		maintenanceStarted := make(chan struct{})
+		maintenanceDone := make(chan error, 1)
+		go func() {
+			maintenanceDone <- engine.RunStartupMaintenance(
+				t.Context(),
+				func() error {
+					close(maintenanceStarted)
+					return nil
+				},
+			)
+		}()
 
-	fallbackCtx, cancelFallback := context.WithCancel(t.Context())
-	cancelFallback()
-	_, ran, err := engine.RunStartupSyncFallback(fallbackCtx, nil)
-	require.ErrorIs(t, err, context.Canceled)
-	assert.True(t, ran)
+		fallbackCtx, cancelFallback := context.WithCancel(t.Context())
+		cancelFallback()
+		_, ran, err := engine.RunStartupSyncFallback(fallbackCtx, nil)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.True(t, ran)
 
-	require.Eventually(t, func() bool {
+		synctest.Wait()
 		select {
 		case <-maintenanceStarted:
-			return true
 		default:
-			return false
+			require.FailNow(t, "an attempted fallback must release startup maintenance")
 		}
-	}, time.Second, 10*time.Millisecond,
-		"an attempted fallback must release startup maintenance")
-	require.NoError(t, <-maintenanceDone)
+		require.NoError(t, <-maintenanceDone)
+	})
 }
 
 func TestStartupSyncFallbackRechecksAfterInFlightForegroundSync(t *testing.T) {
@@ -9780,118 +9779,117 @@ func TestEngine_ReconcileWatchRootsClearsCurrentProgress(t *testing.T) {
 
 func requireStalledCurrentProgress(t *testing.T, engine *Engine) Progress {
 	t.Helper()
-	var progress Progress
-	require.Eventually(t, func() bool {
-		current, active := engine.CurrentProgress()
-		if !active || !current.Stalled {
-			return false
-		}
-		progress = current
-		return true
-	}, time.Second, time.Millisecond,
+	synctest.Sleep(time.Millisecond)
+	progress, active := engine.CurrentProgress()
+	require.True(t, active, "active progress did not age into the stalled state")
+	require.True(t, progress.Stalled,
 		"active progress did not age into the stalled state")
 	return progress
 }
 
 func TestEngine_ReconcileWatchRootsReportsProgressBeforeDiscoveryReturns(t *testing.T) {
-	const agent parser.AgentType = "blocked-discovery"
-	root := t.TempDir()
-	started := make(chan struct{}, 1)
-	release := make(chan struct{}, 1)
-	defer func() {
-		select {
-		case release <- struct{}{}:
-		default:
+	synctest.Test(t, func(t *testing.T) {
+		const agent parser.AgentType = "blocked-discovery"
+		root := t.TempDir()
+		started := make(chan struct{}, 1)
+		release := make(chan struct{}, 1)
+		defer func() {
+			select {
+			case release <- struct{}{}:
+			default:
+			}
+		}()
+		provider := &directStreamingProvider{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+			}},
+			discoverStarted: started,
+			discoverRelease: release,
 		}
-	}()
-	provider := &directStreamingProvider{
-		Def: parser.AgentDef{Type: agent, FileBased: true},
-		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
-			DiscoverSources:    parser.CapabilitySupported,
-			StreamingDiscovery: parser.CapabilitySupported,
-			WatchSources:       parser.CapabilitySupported,
-		}},
-		discoverStarted: started,
-		discoverRelease: release,
-	}
-	engine := NewEngine(openTestDB(t), EngineConfig{
-		AgentDirs:          map[parser.AgentType][]string{agent: {root}},
-		Machine:            "local",
-		ProgressStallAfter: time.Nanosecond,
-		ProviderFactories: []parser.ProviderFactory{
-			directStreamingFactory{provider: provider},
-		},
-		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-			agent: parser.ProviderMigrationProviderAuthoritative,
-		},
+		engine := NewEngine(openTestDB(t), EngineConfig{
+			AgentDirs:          map[parser.AgentType][]string{agent: {root}},
+			Machine:            "local",
+			ProgressStallAfter: time.Nanosecond,
+			ProviderFactories: []parser.ProviderFactory{
+				directStreamingFactory{provider: provider},
+			},
+			ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				agent: parser.ProviderMigrationProviderAuthoritative,
+			},
+		})
+		t.Cleanup(engine.Close)
+		done := make(chan error, 1)
+		go func() {
+			done <- engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
+		}()
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			require.FailNow(t, "reconciliation did not enter discovery")
+		}
+
+		progress := requireStalledCurrentProgress(t, engine)
+		assert.Equal(t, PhaseDiscovering, progress.Phase)
+
+		release <- struct{}{}
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "reconciliation did not finish after discovery resumed")
+		}
 	})
-	t.Cleanup(engine.Close)
-	done := make(chan error, 1)
-	go func() {
-		done <- engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
-	}()
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		require.FailNow(t, "reconciliation did not enter discovery")
-	}
-
-	progress := requireStalledCurrentProgress(t, engine)
-	assert.Equal(t, PhaseDiscovering, progress.Phase)
-
-	release <- struct{}{}
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		require.FailNow(t, "reconciliation did not finish after discovery resumed")
-	}
 }
 
 func TestEngine_SyncPathsReportsProgressBeforeChangedPathStatReturns(t *testing.T) {
-	fx := newEngineFixture(t)
-	path := fx.writeClaudeSession(t, "proj", "blocked-stat.jsonl", "hello")
-	fx.engine.progressStallAfter = time.Nanosecond
-	started := make(chan struct{}, 1)
-	release := make(chan struct{}, 1)
-	defer func() {
+	synctest.Test(t, func(t *testing.T) {
+		fx := newEngineFixture(t)
+		path := fx.writeClaudeSession(t, "proj", "blocked-stat.jsonl", "hello")
+		fx.engine.progressStallAfter = time.Nanosecond
+		started := make(chan struct{}, 1)
+		release := make(chan struct{}, 1)
+		defer func() {
+			select {
+			case release <- struct{}{}:
+			default:
+			}
+		}()
+		realLstat := fx.engine.lstat
+		var calls atomic.Int32
+		fx.engine.lstat = func(got string) (os.FileInfo, error) {
+			if calls.Add(1) == 1 {
+				assert.Equal(t, path, got)
+				started <- struct{}{}
+				<-release
+			}
+			return realLstat(got)
+		}
+		done := make(chan error, 1)
+		go func() {
+			done <- fx.engine.SyncPathsContext(t.Context(), []string{path})
+		}()
 		select {
-		case release <- struct{}{}:
-		default:
+		case <-started:
+		case <-time.After(time.Second):
+			require.FailNow(t, "changed-path sync did not enter source stat")
 		}
-	}()
-	realLstat := fx.engine.lstat
-	var calls atomic.Int32
-	fx.engine.lstat = func(got string) (os.FileInfo, error) {
-		if calls.Add(1) == 1 {
-			assert.Equal(t, path, got)
-			started <- struct{}{}
-			<-release
+
+		progress := requireStalledCurrentProgress(t, fx.engine)
+		assert.Equal(t, PhaseDiscovering, progress.Phase)
+
+		release <- struct{}{}
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "changed-path sync did not finish after stat resumed")
 		}
-		return realLstat(got)
-	}
-	done := make(chan error, 1)
-	go func() {
-		done <- fx.engine.SyncPathsContext(t.Context(), []string{path})
-	}()
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		require.FailNow(t, "changed-path sync did not enter source stat")
-	}
-
-	progress := requireStalledCurrentProgress(t, fx.engine)
-	assert.Equal(t, PhaseDiscovering, progress.Phase)
-
-	release <- struct{}{}
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		require.FailNow(t, "changed-path sync did not finish after stat resumed")
-	}
-	_, active := fx.engine.CurrentProgress()
-	assert.False(t, active)
+		_, active := fx.engine.CurrentProgress()
+		assert.False(t, active)
+	})
 }
 
 func TestEngine_CoordinatedSyncClearsProgressBeforePostSyncWork(t *testing.T) {
@@ -9944,40 +9942,42 @@ func TestEngine_CoordinatedSyncClearsProgressBeforePostSyncWork(t *testing.T) {
 }
 
 func TestEngine_TryRunExclusiveRejectsBusySyncWithoutRunningWork(t *testing.T) {
-	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
-	t.Cleanup(engine.Close)
-	entered := make(chan struct{})
-	release := make(chan struct{}, 1)
-	defer func() {
+	synctest.Test(t, func(t *testing.T) {
+		engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+		t.Cleanup(engine.Close)
+		entered := make(chan struct{})
+		release := make(chan struct{}, 1)
+		defer func() {
+			select {
+			case release <- struct{}{}:
+			default:
+			}
+		}()
+		done := make(chan error, 1)
+		go func() {
+			done <- engine.RunExclusive(func() error {
+				close(entered)
+				<-release
+				return nil
+			})
+		}()
 		select {
-		case release <- struct{}{}:
-		default:
+		case <-entered:
+		case <-time.After(time.Second):
+			require.FailNow(t, "first exclusive sync did not acquire the lock")
 		}
-	}()
-	done := make(chan error, 1)
-	go func() {
-		done <- engine.RunExclusive(func() error {
-			close(entered)
-			<-release
+
+		workRan := false
+		err := engine.TryRunExclusive(func() error {
+			workRan = true
 			return nil
 		})
-	}()
-	select {
-	case <-entered:
-	case <-time.After(time.Second):
-		require.FailNow(t, "first exclusive sync did not acquire the lock")
-	}
 
-	workRan := false
-	err := engine.TryRunExclusive(func() error {
-		workRan = true
-		return nil
+		require.ErrorIs(t, err, ErrSyncInProgress)
+		assert.False(t, workRan)
+		release <- struct{}{}
+		require.NoError(t, <-done)
 	})
-
-	require.ErrorIs(t, err, ErrSyncInProgress)
-	assert.False(t, workRan)
-	release <- struct{}{}
-	require.NoError(t, <-done)
 }
 
 func TestEngine_ZeroSyncedSuccessfulResyncEmits(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -3930,7 +3930,12 @@ func TestStartupReconciledCallbackReportsIncompleteDiscoveryOnce(t *testing.T) {
 
 	failed := engine.SyncAll(t.Context(), nil)
 	assert.Greater(t, failed.Failed, 0)
-	first := <-reconciled
+	var first callbackResult
+	select {
+	case first = <-reconciled:
+	default:
+		require.FailNow(t, "failed startup attempt did not report reconciliation")
+	}
 	require.Error(t, first.err)
 	assert.False(t, first.stats.AuthoritativeDiscoveryComplete())
 
@@ -4080,7 +4085,11 @@ func TestStartupReconciledCallbackOwnersRetainFailureForLaterSuccess(t *testing.
 			default:
 			}
 			tt.succeed(t.Context(), engine)
-			<-reconciled
+			select {
+			case <-reconciled:
+			default:
+				require.FailNow(t, "successful owner did not report startup reconciliation")
+			}
 		})
 	}
 }

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -200,51 +201,57 @@ func TestScopedSyncKeepsBoundedRetentionBudget(t *testing.T) {
 }
 
 func TestBulkParseRetentionBudgetBoundsConcurrentSourceWeight(t *testing.T) {
-	budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
-	first, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
-	require.NoError(t, err)
-	t.Cleanup(first.Release)
+	synctest.Test(t, func(t *testing.T) {
+		budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
+		first, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+		require.NoError(t, err)
+		t.Cleanup(first.Release)
 
-	acquired := make(chan *parseRetentionLease, 1)
-	go func() {
-		second, acquireErr := budget.acquire(
-			t.Context(), defaultParseRetentionBytes,
-		)
-		if acquireErr == nil {
-			acquired <- second
+		acquired := make(chan *parseRetentionLease, 1)
+		go func() {
+			second, acquireErr := budget.acquire(
+				t.Context(), defaultParseRetentionBytes,
+			)
+			if acquireErr == nil {
+				acquired <- second
+			}
+		}()
+
+		synctest.Wait()
+		assert.True(t, budget.underPressure(),
+			"second bulk parse must wait for retained capacity")
+		select {
+		case second := <-acquired:
+			second.Release()
+			t.Fatal("second bulk parse admitted above the retention limit")
+		default:
 		}
-	}()
 
-	require.Eventually(t, budget.underPressure, time.Second, time.Millisecond,
-		"second bulk parse must wait for retained capacity")
-	select {
-	case second := <-acquired:
-		second.Release()
-		t.Fatal("second bulk parse admitted above the retention limit")
-	default:
-	}
-
-	first.Release()
-	select {
-	case second := <-acquired:
-		second.Release()
-	case <-time.After(time.Second):
-		t.Fatal("second bulk parse was not admitted after capacity was released")
-	}
-	assert.Equal(t, int64(2), budget.acquired.Load())
+		first.Release()
+		synctest.Wait()
+		select {
+		case second := <-acquired:
+			second.Release()
+		default:
+			t.Fatal("second bulk parse was not admitted after capacity was released")
+		}
+		assert.Equal(t, int64(2), budget.acquired.Load())
+	})
 }
 
 func TestBulkParseRetentionBudgetAdmitsWorkerPoolForMediumSources(t *testing.T) {
-	budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
 
-	for range maxWorkers {
-		lease, err := budget.acquire(ctx, 6<<20)
-		require.NoError(t, err,
-			"bulk admission must preserve the full worker pool for medium sources")
-		t.Cleanup(lease.Release)
-	}
+		for range maxWorkers {
+			lease, err := budget.acquire(ctx, 6<<20)
+			require.NoError(t, err,
+				"bulk admission must preserve the full worker pool for medium sources")
+			t.Cleanup(lease.Release)
+		}
+	})
 }
 
 func TestBulkParseRetentionBudgetScavengesOncePerParseBearingPass(t *testing.T) {
@@ -311,53 +318,70 @@ func TestCollectAndBatchFlushesOnByteCap(t *testing.T) {
 }
 
 func TestParseRetentionBudgetBoundsConcurrentSourceWeight(t *testing.T) {
-	budget := newParseRetentionBudget(defaultParseRetentionBytes)
-	first, err := budget.acquire(t.Context(), 7<<20)
-	require.NoError(t, err)
-	second, err := budget.acquire(t.Context(), 7<<20)
-	require.NoError(t, err)
-	t.Cleanup(first.Release)
-	t.Cleanup(second.Release)
+	synctest.Test(t, func(t *testing.T) {
+		budget := newParseRetentionBudget(defaultParseRetentionBytes)
+		first, err := budget.acquire(t.Context(), 7<<20)
+		require.NoError(t, err)
+		second, err := budget.acquire(t.Context(), 7<<20)
+		require.NoError(t, err)
+		t.Cleanup(first.Release)
+		t.Cleanup(second.Release)
 
-	acquired := make(chan *parseRetentionLease, 1)
-	go func() {
-		lease, acquireErr := budget.acquire(t.Context(), 7<<20)
-		if acquireErr == nil {
-			acquired <- lease
+		acquired := make(chan *parseRetentionLease, 1)
+		go func() {
+			lease, acquireErr := budget.acquire(t.Context(), 7<<20)
+			if acquireErr == nil {
+				acquired <- lease
+			}
+		}()
+
+		synctest.Wait()
+		select {
+		case lease := <-acquired:
+			lease.Release()
+			t.Fatal("third parse admitted above the weighted retention limit")
+		default:
 		}
-	}()
 
-	select {
-	case lease := <-acquired:
-		lease.Release()
-		t.Fatal("third parse admitted above the weighted retention limit")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	first.Release()
-	select {
-	case lease := <-acquired:
-		lease.Release()
-	case <-time.After(time.Second):
-		t.Fatal("third parse was not admitted after capacity was released")
-	}
+		first.Release()
+		synctest.Wait()
+		select {
+		case lease := <-acquired:
+			lease.Release()
+		default:
+			t.Fatal("third parse was not admitted after capacity was released")
+		}
+	})
 }
 
 func TestParseRetentionBudgetRunsOversizedSourceExclusively(t *testing.T) {
-	budget := newParseRetentionBudget(defaultParseRetentionBytes)
-	oversized, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
-	require.NoError(t, err)
-	t.Cleanup(oversized.Release)
+	synctest.Test(t, func(t *testing.T) {
+		budget := newParseRetentionBudget(defaultParseRetentionBytes)
+		oversized, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+		require.NoError(t, err)
+		t.Cleanup(oversized.Release)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
-	defer cancel()
-	_, err = budget.acquire(ctx, 1)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
+		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		defer cancel()
+		acquired := make(chan error, 1)
+		go func() {
+			_, acquireErr := budget.acquire(ctx, 1)
+			acquired <- acquireErr
+		}()
+		synctest.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+		select {
+		case err = <-acquired:
+		default:
+			require.FailNow(t, "oversized source admission did not reach its deadline")
+		}
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
 
-	oversized.Release()
-	lease, err := budget.acquire(t.Context(), 1)
-	require.NoError(t, err)
-	lease.Release()
+		oversized.Release()
+		lease, err := budget.acquire(t.Context(), 1)
+		require.NoError(t, err)
+		lease.Release()
+	})
 }
 
 func TestParseRetentionBudgetScavengesOnceAfterKnownLargeSource(t *testing.T) {
@@ -380,62 +404,71 @@ func TestParseRetentionBudgetScavengesOnceAfterKnownLargeSource(t *testing.T) {
 }
 
 func TestCollectAndBatchRetainsParseLeaseThroughWrite(t *testing.T) {
-	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
-	t.Cleanup(engine.Close)
-	budget := newParseRetentionBudget(defaultParseRetentionBytes)
-	lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
-	require.NoError(t, err)
+	synctest.Test(t, func(t *testing.T) {
+		engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+		t.Cleanup(engine.Close)
+		budget := newParseRetentionBudget(defaultParseRetentionBytes)
+		lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+		require.NoError(t, err)
 
-	writeEntered := make(chan struct{})
-	allowWrite := make(chan struct{})
-	engine.writeBatchOverride = func(
-		batch []pendingWrite, _ syncWriteMode, _ bool,
-	) (int, int, int, int) {
-		assert.Len(t, batch, 1)
-		close(writeEntered)
-		<-allowWrite
-		return len(batch), 0, 0, 0
-	}
-	results := make(chan syncJob, 1)
-	results <- syncJob{
-		path:           "/sessions/one.jsonl",
-		retentionLease: lease,
-		results: []parser.ParseResult{{
-			Session: parser.ParsedSession{ID: "one", Agent: parser.AgentClaude},
-		}},
-	}
-	close(results)
-	done := make(chan struct{})
-	go func() {
-		engine.collectAndBatch(
-			t.Context(), results, 1, 1, nil, syncWriteDefault,
-		)
-		close(done)
-	}()
-	<-writeEntered
-
-	secondAcquired := make(chan *parseRetentionLease, 1)
-	go func() {
-		second, acquireErr := budget.acquire(t.Context(), 1)
-		if acquireErr == nil {
-			secondAcquired <- second
+		writeEntered := make(chan struct{})
+		allowWrite := make(chan struct{})
+		engine.writeBatchOverride = func(
+			batch []pendingWrite, _ syncWriteMode, _ bool,
+		) (int, int, int, int) {
+			assert.Len(t, batch, 1)
+			close(writeEntered)
+			<-allowWrite
+			return len(batch), 0, 0, 0
 		}
-	}()
-	select {
-	case second := <-secondAcquired:
-		second.Release()
-		t.Fatal("next parse admitted while the prior parse payload was being written")
-	case <-time.After(50 * time.Millisecond):
-	}
+		results := make(chan syncJob, 1)
+		results <- syncJob{
+			path:           "/sessions/one.jsonl",
+			retentionLease: lease,
+			results: []parser.ParseResult{{
+				Session: parser.ParsedSession{ID: "one", Agent: parser.AgentClaude},
+			}},
+		}
+		close(results)
+		done := make(chan struct{})
+		go func() {
+			engine.collectAndBatch(
+				t.Context(), results, 1, 1, nil, syncWriteDefault,
+			)
+			close(done)
+		}()
+		synctest.Wait()
+		select {
+		case <-writeEntered:
+		default:
+			require.FailNow(t, "collector did not enter write")
+		}
 
-	close(allowWrite)
-	select {
-	case second := <-secondAcquired:
-		second.Release()
-	case <-time.After(time.Second):
-		t.Fatal("parse lease was not released after the database write completed")
-	}
-	<-done
+		secondAcquired := make(chan *parseRetentionLease, 1)
+		go func() {
+			second, acquireErr := budget.acquire(t.Context(), 1)
+			if acquireErr == nil {
+				secondAcquired <- second
+			}
+		}()
+		synctest.Wait()
+		select {
+		case second := <-secondAcquired:
+			second.Release()
+			t.Fatal("next parse admitted while the prior parse payload was being written")
+		default:
+		}
+
+		close(allowWrite)
+		synctest.Wait()
+		select {
+		case second := <-secondAcquired:
+			second.Release()
+		default:
+			t.Fatal("parse lease was not released after the database write completed")
+		}
+		<-done
+	})
 }
 
 func TestArchiveCollectorReleasesParseLeaseBeforeWrite(t *testing.T) {
@@ -448,58 +481,91 @@ func TestArchiveCollectorReleasesParseLeaseBeforeWrite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
-			t.Cleanup(engine.Close)
-			restore := engine.beginBulkRetentionPass()
-			t.Cleanup(restore)
-			budget := engine.retentionBudget()
-			lease, err := budget.acquire(
-				t.Context(), defaultBulkParseRetentionBytes,
-			)
-			require.NoError(t, err)
-
-			writeEntered := make(chan struct{})
-			allowWrite := make(chan struct{})
-			engine.writeBatchOverride = func(
-				batch []pendingWrite, _ syncWriteMode, _ bool,
-			) (int, int, int, int) {
-				assert.Len(t, batch, 1)
-				close(writeEntered)
-				<-allowWrite
-				return len(batch), 0, 0, 0
-			}
-			results := make(chan syncJob, 1)
-			results <- syncJob{
-				path:           "/sessions/one.jsonl",
-				retentionLease: lease,
-				results: []parser.ParseResult{{
-					Session: parser.ParsedSession{
-						ID: "one", Agent: parser.AgentClaude,
-					},
-				}},
-			}
-			close(results)
-			done := make(chan struct{})
-			go func() {
-				engine.collectAndBatch(
-					t.Context(), results, 1, 1, nil, tt.mode,
+			synctest.Test(t, func(t *testing.T) {
+				engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+				t.Cleanup(engine.Close)
+				restore := engine.beginBulkRetentionPass()
+				t.Cleanup(restore)
+				budget := engine.retentionBudget()
+				lease, err := budget.acquire(
+					t.Context(), defaultBulkParseRetentionBytes,
 				)
-				close(done)
-			}()
-			<-writeEntered
+				require.NoError(t, err)
 
-			acquireCtx, cancel := context.WithTimeout(
-				t.Context(), time.Second,
-			)
-			next, acquireErr := budget.acquire(acquireCtx, 1)
-			cancel()
-			if next != nil {
-				next.Release()
-			}
-			close(allowWrite)
-			<-done
-			assert.NoError(t, acquireErr,
-				"archive writes must not retain active parse admission")
+				writeEntered := make(chan struct{})
+				allowWrite := make(chan struct{})
+				engine.writeBatchOverride = func(
+					batch []pendingWrite, _ syncWriteMode, _ bool,
+				) (int, int, int, int) {
+					assert.Len(t, batch, 1)
+					close(writeEntered)
+					<-allowWrite
+					return len(batch), 0, 0, 0
+				}
+				results := make(chan syncJob, 1)
+				results <- syncJob{
+					path:           "/sessions/one.jsonl",
+					retentionLease: lease,
+					results: []parser.ParseResult{{
+						Session: parser.ParsedSession{
+							ID: "one", Agent: parser.AgentClaude,
+						},
+					}},
+				}
+				close(results)
+				done := make(chan struct{})
+				go func() {
+					engine.collectAndBatch(
+						t.Context(), results, 1, 1, nil, tt.mode,
+					)
+					close(done)
+				}()
+				synctest.Wait()
+				select {
+				case <-writeEntered:
+				default:
+					require.FailNow(t, "collector did not enter write")
+				}
+
+				acquireCtx, cancel := context.WithTimeout(
+					t.Context(), time.Second,
+				)
+				acquired := make(chan struct {
+					next *parseRetentionLease
+					err  error
+				}, 1)
+				go func() {
+					next, acquireErr := budget.acquire(acquireCtx, 1)
+					acquired <- struct {
+						next *parseRetentionLease
+						err  error
+					}{next: next, err: acquireErr}
+				}()
+				synctest.Wait()
+				var acquireResult struct {
+					next *parseRetentionLease
+					err  error
+				}
+				select {
+				case acquireResult = <-acquired:
+				default:
+					require.FailNow(t,
+						"archive writes must not retain active parse admission")
+				}
+				cancel()
+				if acquireResult.next != nil {
+					acquireResult.next.Release()
+				}
+				close(allowWrite)
+				synctest.Wait()
+				select {
+				case <-done:
+				default:
+					require.FailNow(t, "collector did not finish")
+				}
+				assert.NoError(t, acquireResult.err,
+					"archive writes must not retain active parse admission")
+			})
 		})
 	}
 }
@@ -569,137 +635,145 @@ func TestCollectAndBatchReportsFinalizingOnlyBeforeBulkTerminalFlush(t *testing.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
-			t.Cleanup(engine.Close)
-			writeEntered := make(chan struct{})
-			allowWrite := make(chan struct{})
-			engine.writeBatchOverride = func(
-				batch []pendingWrite, _ syncWriteMode, _ bool,
-			) (int, int, int, int) {
-				close(writeEntered)
-				<-allowWrite
-				return len(batch), 0, 0, 0
-			}
-			results := make(chan syncJob, tt.jobs)
-			for i := range tt.jobs {
-				results <- syncJob{
-					path: fmt.Sprintf("/sessions/%03d.jsonl", i),
-					results: []parser.ParseResult{{Session: parser.ParsedSession{
-						ID: fmt.Sprintf("session-%03d", i), Agent: parser.AgentClaude,
-					}}},
+			synctest.Test(t, func(t *testing.T) {
+				engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+				t.Cleanup(engine.Close)
+				writeEntered := make(chan struct{})
+				allowWrite := make(chan struct{})
+				engine.writeBatchOverride = func(
+					batch []pendingWrite, _ syncWriteMode, _ bool,
+				) (int, int, int, int) {
+					close(writeEntered)
+					<-allowWrite
+					return len(batch), 0, 0, 0
 				}
-			}
-			close(results)
-			progress := make(chan Progress, tt.jobs+8)
-			done := make(chan struct{})
-			go func() {
-				engine.collectAndBatch(
-					t.Context(), results, tt.jobs, tt.jobs,
-					func(p Progress) { progress <- p }, tt.mode,
-				)
-				close(done)
-			}()
-			select {
-			case <-writeEntered:
-			case <-time.After(time.Second):
-				require.FailNow(t, "collector did not enter write")
-			}
-			var last Progress
-		drain:
-			for {
+				results := make(chan syncJob, tt.jobs)
+				for i := range tt.jobs {
+					results <- syncJob{
+						path: fmt.Sprintf("/sessions/%03d.jsonl", i),
+						results: []parser.ParseResult{{Session: parser.ParsedSession{
+							ID: fmt.Sprintf("session-%03d", i), Agent: parser.AgentClaude,
+						}}},
+					}
+				}
+				close(results)
+				progress := make(chan Progress, tt.jobs+8)
+				done := make(chan struct{})
+				go func() {
+					engine.collectAndBatch(
+						t.Context(), results, tt.jobs, tt.jobs,
+						func(p Progress) { progress <- p }, tt.mode,
+					)
+					close(done)
+				}()
+				synctest.Wait()
 				select {
-				case last = <-progress:
+				case <-writeEntered:
 				default:
-					break drain
+					require.FailNow(t, "collector did not enter write")
 				}
-			}
-			assert.Equal(t, tt.wantPhase, last.Phase)
-			assert.Equal(t, tt.wantDetail, last.Detail)
-			close(allowWrite)
-			select {
-			case <-done:
-			case <-time.After(time.Second):
-				require.FailNow(t, "collector did not finish")
-			}
+				var last Progress
+			drain:
+				for {
+					select {
+					case last = <-progress:
+					default:
+						break drain
+					}
+				}
+				assert.Equal(t, tt.wantPhase, last.Phase)
+				assert.Equal(t, tt.wantDetail, last.Detail)
+				close(allowWrite)
+				synctest.Wait()
+				select {
+				case <-done:
+				default:
+					require.FailNow(t, "collector did not finish")
+				}
+			})
 		})
 	}
 }
 
 func TestCollectAndBatchReportsOrderedBulkFinalization(t *testing.T) {
-	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
-	t.Cleanup(engine.Close)
-	restore := engine.beginBulkRetentionPass()
-	defer restore()
-	budget := engine.retentionBudget()
-	// Parsing a source arms the end-of-pass bulk memory scavenge.
-	lease, err := budget.acquire(t.Context(), parseRetentionScavengeThreshold)
-	require.NoError(t, err)
+	synctest.Test(t, func(t *testing.T) {
+		engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+		t.Cleanup(engine.Close)
+		restore := engine.beginBulkRetentionPass()
+		defer restore()
+		budget := engine.retentionBudget()
+		// Parsing a source arms the end-of-pass bulk memory scavenge.
+		lease, err := budget.acquire(t.Context(), parseRetentionScavengeThreshold)
+		require.NoError(t, err)
 
-	scavengeEntered := make(chan struct{})
-	allowScavenge := make(chan struct{})
-	budget.scavenge = func() {
-		close(scavengeEntered)
-		<-allowScavenge
-	}
-	engine.writeBatchOverride = func(
-		batch []pendingWrite, _ syncWriteMode, _ bool,
-	) (int, int, int, int) {
-		return len(batch), 0, 0, 0
-	}
-	results := make(chan syncJob, 1)
-	results <- syncJob{
-		path: "/sessions/one.jsonl", retentionLease: lease,
-		results: []parser.ParseResult{{Session: parser.ParsedSession{
-			ID: "one", Agent: parser.AgentClaude,
-		}}},
-	}
-	close(results)
-	progress := make(chan Progress, 16)
-	done := make(chan struct{})
-	go func() {
-		engine.collectAndBatch(
-			t.Context(), results, 1, 1,
-			func(p Progress) { progress <- p }, syncWriteBulk,
-		)
-		close(done)
-	}()
-	select {
-	case <-scavengeEntered:
-	case <-time.After(time.Second):
-		require.FailNow(t, "collector did not enter memory scavenge")
-	}
-	var events []Progress
-drain:
-	for {
+		scavengeEntered := make(chan struct{})
+		allowScavenge := make(chan struct{})
+		budget.scavenge = func() {
+			close(scavengeEntered)
+			<-allowScavenge
+		}
+		engine.writeBatchOverride = func(
+			batch []pendingWrite, _ syncWriteMode, _ bool,
+		) (int, int, int, int) {
+			return len(batch), 0, 0, 0
+		}
+		results := make(chan syncJob, 1)
+		results <- syncJob{
+			path: "/sessions/one.jsonl", retentionLease: lease,
+			results: []parser.ParseResult{{Session: parser.ParsedSession{
+				ID: "one", Agent: parser.AgentClaude,
+			}}},
+		}
+		close(results)
+		progress := make(chan Progress, 16)
+		done := make(chan struct{})
+		go func() {
+			engine.collectAndBatch(
+				t.Context(), results, 1, 1,
+				func(p Progress) { progress <- p }, syncWriteBulk,
+			)
+			close(done)
+		}()
+		synctest.Wait()
 		select {
-		case event := <-progress:
-			events = append(events, event)
+		case <-scavengeEntered:
 		default:
-			break drain
+			require.FailNow(t, "collector did not enter memory scavenge")
 		}
-	}
-	require.NotEmpty(t, events)
-	assert.Equal(t, "Finalizing sync: releasing parsed-session memory",
-		events[len(events)-1].Detail)
-	close(allowScavenge)
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		require.FailNow(t, "collector did not finish after memory scavenge")
-	}
-	var details []string
-	for _, event := range events {
-		if event.Phase == PhaseFinalizing {
-			details = append(details, event.Detail)
+		var events []Progress
+	drain:
+		for {
+			select {
+			case event := <-progress:
+				events = append(events, event)
+			default:
+				break drain
+			}
 		}
-	}
-	assert.Equal(t, []string{
-		"Finalizing sync: committing session writes",
-		"Finalizing sync: saving session source state",
-		"Finalizing sync: linking file-backed subagent sessions",
-		"Finalizing sync: repairing subagent relationships",
-		"Finalizing sync: releasing parsed-session memory",
-	}, details)
+		require.NotEmpty(t, events)
+		assert.Equal(t, "Finalizing sync: releasing parsed-session memory",
+			events[len(events)-1].Detail)
+		close(allowScavenge)
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			require.FailNow(t, "collector did not finish after memory scavenge")
+		}
+		var details []string
+		for _, event := range events {
+			if event.Phase == PhaseFinalizing {
+				details = append(details, event.Detail)
+			}
+		}
+		assert.Equal(t, []string{
+			"Finalizing sync: committing session writes",
+			"Finalizing sync: saving session source state",
+			"Finalizing sync: linking file-backed subagent sessions",
+			"Finalizing sync: repairing subagent relationships",
+			"Finalizing sync: releasing parsed-session memory",
+		}, details)
+	})
 }
 
 func TestCollectAndBatchDiscardsPendingResultAfterCancellation(t *testing.T) {
@@ -755,20 +829,22 @@ func TestCollectAndBatchDiscardsPendingResultAfterCancellation(t *testing.T) {
 }
 
 func TestDrainResultsReleasesParseLeases(t *testing.T) {
-	budget := newParseRetentionBudget(defaultParseRetentionBytes)
-	lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
-	require.NoError(t, err)
-	results := make(chan syncJob, 1)
-	results <- syncJob{retentionLease: lease}
-	close(results)
+	synctest.Test(t, func(t *testing.T) {
+		budget := newParseRetentionBudget(defaultParseRetentionBytes)
+		lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+		require.NoError(t, err)
+		results := make(chan syncJob, 1)
+		results <- syncJob{retentionLease: lease}
+		close(results)
 
-	drainResults(results, 1)
+		drainResults(results, 1)
 
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	defer cancel()
-	next, err := budget.acquire(ctx, defaultParseRetentionBytes)
-	require.NoError(t, err)
-	next.Release()
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		next, err := budget.acquire(ctx, defaultParseRetentionBytes)
+		require.NoError(t, err)
+		next.Release()
+	})
 }
 
 func TestCollectAndBatchPromotesClaudeSourceAfterShutdownCancellation(t *testing.T) {
@@ -808,44 +884,46 @@ func TestCollectAndBatchPromotesClaudeSourceAfterShutdownCancellation(t *testing
 }
 
 func TestCollectAndBatchKeepsFanoutUnderOneLeaseUntilOneWrite(t *testing.T) {
-	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
-	t.Cleanup(engine.Close)
-	budget := newParseRetentionBudget(defaultParseRetentionBytes)
-	lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
-	require.NoError(t, err)
+	synctest.Test(t, func(t *testing.T) {
+		engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+		t.Cleanup(engine.Close)
+		budget := newParseRetentionBudget(defaultParseRetentionBytes)
+		lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+		require.NoError(t, err)
 
-	parsed := make([]parser.ParseResult, batchSize+1)
-	for i := range parsed {
-		parsed[i].Session = parser.ParsedSession{
-			ID: fmt.Sprintf("fanout-%03d", i), Agent: parser.AgentKiro,
+		parsed := make([]parser.ParseResult, batchSize+1)
+		for i := range parsed {
+			parsed[i].Session = parser.ParsedSession{
+				ID: fmt.Sprintf("fanout-%03d", i), Agent: parser.AgentKiro,
+			}
 		}
-	}
-	var batchLengths []int
-	engine.writeBatchOverride = func(
-		batch []pendingWrite, _ syncWriteMode, _ bool,
-	) (int, int, int, int) {
-		batchLengths = append(batchLengths, len(batch))
-		return len(batch), 0, 0, 0
-	}
-	results := make(chan syncJob, 1)
-	results <- syncJob{
-		path:           "/sessions/data.sqlite3",
-		retentionLease: lease,
-		results:        parsed,
-	}
-	close(results)
+		var batchLengths []int
+		engine.writeBatchOverride = func(
+			batch []pendingWrite, _ syncWriteMode, _ bool,
+		) (int, int, int, int) {
+			batchLengths = append(batchLengths, len(batch))
+			return len(batch), 0, 0, 0
+		}
+		results := make(chan syncJob, 1)
+		results <- syncJob{
+			path:           "/sessions/data.sqlite3",
+			retentionLease: lease,
+			results:        parsed,
+		}
+		close(results)
 
-	stats := engine.collectAndBatch(
-		t.Context(), results, 1, 1, nil, syncWriteDefault,
-	)
+		stats := engine.collectAndBatch(
+			t.Context(), results, 1, 1, nil, syncWriteDefault,
+		)
 
-	assert.Equal(t, []int{batchSize + 1}, batchLengths)
-	assert.Equal(t, batchSize+1, stats.Synced)
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	defer cancel()
-	next, err := budget.acquire(ctx, defaultParseRetentionBytes)
-	require.NoError(t, err)
-	next.Release()
+		assert.Equal(t, []int{batchSize + 1}, batchLengths)
+		assert.Equal(t, batchSize+1, stats.Synced)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		next, err := budget.acquire(ctx, defaultParseRetentionBytes)
+		require.NoError(t, err)
+		next.Release()
+	})
 }
 
 func TestStartWorkersKeepsBulkBatchingIndependentOfParseAdmission(t *testing.T) {
@@ -859,128 +937,134 @@ func TestStartWorkersKeepsBulkBatchingIndependentOfParseAdmission(t *testing.T) 
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			const agent parser.AgentType = "retention-test"
-			provider := &directStreamingProvider{
-				Def: parser.AgentDef{Type: agent},
-				parseOutcome: parser.ParseOutcome{
-					Results: []parser.ParseResultOutcome{{
-						Result: parser.ParseResult{Session: parser.ParsedSession{
-							ID: "retention-test:session", Agent: agent,
+			synctest.Test(t, func(t *testing.T) {
+				const agent parser.AgentType = "retention-test"
+				provider := &directStreamingProvider{
+					Def: parser.AgentDef{Type: agent},
+					parseOutcome: parser.ParseOutcome{
+						Results: []parser.ParseResultOutcome{{
+							Result: parser.ParseResult{Session: parser.ParsedSession{
+								ID: "retention-test:session", Agent: agent,
+							}},
 						}},
-					}},
-					ResultSetComplete: true,
-				},
-			}
-			engine := NewEngine(openTestDB(t), EngineConfig{
-				Machine: "local",
-				ProviderFactories: []parser.ProviderFactory{
-					directStreamingFactory{provider},
-				},
-				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-					agent: parser.ProviderMigrationProviderAuthoritative,
-				},
+						ResultSetComplete: true,
+					},
+				}
+				engine := NewEngine(openTestDB(t), EngineConfig{
+					Machine: "local",
+					ProviderFactories: []parser.ProviderFactory{
+						directStreamingFactory{provider},
+					},
+					ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+						agent: parser.ProviderMigrationProviderAuthoritative,
+					},
+				})
+				t.Cleanup(engine.Close)
+				if tt.mode == syncWriteBulk {
+					restore := engine.beginBulkRetentionPass()
+					t.Cleanup(restore)
+				}
+				engine.workerCountOverride = 2
+				var writes int
+				engine.writeBatchOverride = func(
+					batch []pendingWrite, _ syncWriteMode, _ bool,
+				) (int, int, int, int) {
+					writes++
+					return len(batch), 0, 0, 0
+				}
+
+				files := make([]parser.DiscoveredFile, 2)
+				for i := range files {
+					path := filepath.Join(t.TempDir(), fmt.Sprintf("large-%d.jsonl", i))
+					file, err := os.Create(path)
+					require.NoError(t, err)
+					require.NoError(t, file.Truncate(20<<20))
+					require.NoError(t, file.Close())
+					source := parser.SourceRef{
+						Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+					}
+					files[i] = parser.DiscoveredFile{
+						Path: path, Agent: agent, ProviderSource: &source,
+						ProviderProcess: true, ForceParse: true,
+					}
+				}
+
+				ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+				defer cancel()
+				stats := engine.collectAndBatch(
+					ctx, engine.startWorkers(ctx, files), len(files), len(files), nil,
+					tt.mode,
+				)
+
+				assert.False(t, stats.Aborted)
+				assert.Equal(t, 2, stats.Synced)
+				assert.Equal(t, tt.wantWrites, writes,
+					"bulk parse admission must not fragment the database batch")
 			})
-			t.Cleanup(engine.Close)
-			if tt.mode == syncWriteBulk {
-				restore := engine.beginBulkRetentionPass()
-				t.Cleanup(restore)
-			}
-			engine.workerCountOverride = 2
-			var writes int
-			engine.writeBatchOverride = func(
-				batch []pendingWrite, _ syncWriteMode, _ bool,
-			) (int, int, int, int) {
-				writes++
-				return len(batch), 0, 0, 0
-			}
-
-			files := make([]parser.DiscoveredFile, 2)
-			for i := range files {
-				path := filepath.Join(t.TempDir(), fmt.Sprintf("large-%d.jsonl", i))
-				file, err := os.Create(path)
-				require.NoError(t, err)
-				require.NoError(t, file.Truncate(20<<20))
-				require.NoError(t, file.Close())
-				source := parser.SourceRef{
-					Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
-				}
-				files[i] = parser.DiscoveredFile{
-					Path: path, Agent: agent, ProviderSource: &source,
-					ProviderProcess: true, ForceParse: true,
-				}
-			}
-
-			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
-			defer cancel()
-			stats := engine.collectAndBatch(
-				ctx, engine.startWorkers(ctx, files), len(files), len(files), nil,
-				tt.mode,
-			)
-
-			assert.False(t, stats.Aborted)
-			assert.Equal(t, 2, stats.Synced)
-			assert.Equal(t, tt.wantWrites, writes,
-				"bulk parse admission must not fragment the database batch")
 		})
 	}
 }
 
 func TestStartWorkersCancellationReleasesAdmissionWaiters(t *testing.T) {
-	const agent parser.AgentType = "retention-cancel-test"
-	provider := &directStreamingProvider{
-		Def: parser.AgentDef{Type: agent},
-		parseOutcome: parser.ParseOutcome{
-			Results: []parser.ParseResultOutcome{{
-				Result: parser.ParseResult{Session: parser.ParsedSession{
-					ID: "retention-cancel-test:session", Agent: agent,
+	synctest.Test(t, func(t *testing.T) {
+		const agent parser.AgentType = "retention-cancel-test"
+		provider := &directStreamingProvider{
+			Def: parser.AgentDef{Type: agent},
+			parseOutcome: parser.ParseOutcome{
+				Results: []parser.ParseResultOutcome{{
+					Result: parser.ParseResult{Session: parser.ParsedSession{
+						ID: "retention-cancel-test:session", Agent: agent,
+					}},
 				}},
-			}},
-			ResultSetComplete: true,
-		},
-	}
-	engine := NewEngine(openTestDB(t), EngineConfig{
-		Machine:           "local",
-		ProviderFactories: []parser.ProviderFactory{directStreamingFactory{provider}},
-		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-			agent: parser.ProviderMigrationProviderAuthoritative,
-		},
+				ResultSetComplete: true,
+			},
+		}
+		engine := NewEngine(openTestDB(t), EngineConfig{
+			Machine:           "local",
+			ProviderFactories: []parser.ProviderFactory{directStreamingFactory{provider}},
+			ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				agent: parser.ProviderMigrationProviderAuthoritative,
+			},
+		})
+		t.Cleanup(engine.Close)
+		engine.workerCountOverride = 2
+		budget := newParseRetentionBudget(defaultParseRetentionBytes)
+		engine.parseRetentionBudget = budget
+
+		holder, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+		require.NoError(t, err)
+		files := make([]parser.DiscoveredFile, 2)
+		for i := range files {
+			// A provider-authoritative, force-parsed source reaches the provider
+			// parse seam where the lease is acquired; a trivial file would return
+			// through a skip gate before the admission wait now that acquisition
+			// follows the gates.
+			path := filepath.Join(t.TempDir(), fmt.Sprintf("waiting-%d.jsonl", i))
+			require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+			source := parser.SourceRef{
+				Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+			}
+			files[i] = parser.DiscoveredFile{
+				Path: path, Agent: agent, ProviderSource: &source,
+				ProviderProcess: true, ForceParse: true,
+			}
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		results := engine.startWorkers(ctx, files)
+		synctest.Wait()
+		assert.True(t, budget.underPressure(),
+			"workers must reach the admission wait before cancellation")
+		cancel()
+		synctest.Wait()
+
+		for range files {
+			job := <-results
+			assert.ErrorIs(t, job.err, context.Canceled)
+			job.releaseRetention()
+		}
+		holder.Release()
+		next, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+		require.NoError(t, err, "canceled waiters must not leak weighted capacity")
+		next.Release()
 	})
-	t.Cleanup(engine.Close)
-	engine.workerCountOverride = 2
-	budget := newParseRetentionBudget(defaultParseRetentionBytes)
-	engine.parseRetentionBudget = budget
-
-	holder, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
-	require.NoError(t, err)
-	files := make([]parser.DiscoveredFile, 2)
-	for i := range files {
-		// A provider-authoritative, force-parsed source reaches the provider
-		// parse seam where the lease is acquired; a trivial file would return
-		// through a skip gate before the admission wait now that acquisition
-		// follows the gates.
-		path := filepath.Join(t.TempDir(), fmt.Sprintf("waiting-%d.jsonl", i))
-		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
-		source := parser.SourceRef{
-			Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
-		}
-		files[i] = parser.DiscoveredFile{
-			Path: path, Agent: agent, ProviderSource: &source,
-			ProviderProcess: true, ForceParse: true,
-		}
-	}
-	ctx, cancel := context.WithCancel(t.Context())
-	results := engine.startWorkers(ctx, files)
-	require.Eventually(t, budget.underPressure, time.Second, time.Millisecond,
-		"workers must reach the admission wait before cancellation")
-	cancel()
-
-	for range files {
-		job := <-results
-		assert.ErrorIs(t, job.err, context.Canceled)
-		job.releaseRetention()
-	}
-	holder.Release()
-	next, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
-	require.NoError(t, err, "canceled waiters must not leak weighted capacity")
-	next.Release()
 }

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -494,6 +495,11 @@ func TestArchiveCollectorReleasesParseLeaseBeforeWrite(t *testing.T) {
 
 				writeEntered := make(chan struct{})
 				allowWrite := make(chan struct{})
+				var releaseWriteOnce sync.Once
+				releaseWrite := func() {
+					releaseWriteOnce.Do(func() { close(allowWrite) })
+				}
+				t.Cleanup(releaseWrite)
 				engine.writeBatchOverride = func(
 					batch []pendingWrite, _ syncWriteMode, _ bool,
 				) (int, int, int, int) {
@@ -530,6 +536,7 @@ func TestArchiveCollectorReleasesParseLeaseBeforeWrite(t *testing.T) {
 				acquireCtx, cancel := context.WithTimeout(
 					t.Context(), time.Second,
 				)
+				t.Cleanup(cancel)
 				acquired := make(chan struct {
 					next *parseRetentionLease
 					err  error
@@ -556,7 +563,7 @@ func TestArchiveCollectorReleasesParseLeaseBeforeWrite(t *testing.T) {
 				if acquireResult.next != nil {
 					acquireResult.next.Release()
 				}
-				close(allowWrite)
+				releaseWrite()
 				synctest.Wait()
 				select {
 				case <-done:

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
@@ -553,111 +554,115 @@ func (f trackingRebuildFactory) NewProvider(parser.ProviderConfig) parser.Provid
 }
 
 func TestResyncContributorCancellationPreservesArchiveAndCleansTempDB(t *testing.T) {
-	root := t.TempDir()
-	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, database.Close()) })
-	engine := NewEngine(database, EngineConfig{
-		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
-		Machine:   "local",
-	})
-	t.Cleanup(engine.Close)
-	oldPath := filepath.Join(root, "old", "old.jsonl")
-	require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
-	require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
-		AddClaudeUser("2026-01-01T00:00:00Z", "archive before cancel").String()), 0o644))
-	require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
-	require.NoError(t, os.Remove(oldPath))
-
-	provider := &blockingRebuildProvider{
-		Def: parser.AgentDef{Type: parser.AgentCowork},
-		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
-			DiscoverSources: parser.CapabilitySupported,
-		}},
-		started: make(chan struct{}),
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	firstHookCalls := 0
-	secondHookCalls := 0
-	secondProvider := &trackingRebuildProvider{
-		Def: parser.AgentDef{Type: parser.AgentCowork},
-		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
-			DiscoverSources: parser.CapabilitySupported,
-		}}}
-	result := make(chan struct {
-		stats SyncStats
-		err   error
-	}, 1)
-	go func() {
-		stats, runErr := engine.ResyncAllWithOptions(ctx, nil, RebuildOptions{
-			Contributors: []RebuildContributor{
-				{
-					Name: "blocking",
-					Config: EngineConfig{
-						AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
-						Machine:   "blocking", Ephemeral: true,
-						ProviderFactories: []parser.ProviderFactory{
-							blockingRebuildFactory{provider: provider},
-						},
-						ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-							parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
-						},
-					},
-					AfterSync: func(*Engine, *db.DB) error {
-						firstHookCalls++
-						return nil
-					},
-				},
-				{
-					Name: "later",
-					Config: EngineConfig{
-						AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
-						Machine:   "later", Ephemeral: true,
-						ProviderFactories: []parser.ProviderFactory{
-							trackingRebuildFactory{provider: secondProvider},
-						},
-						ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-							parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
-						},
-					},
-					AfterSync: func(*Engine, *db.DB) error {
-						secondHookCalls++
-						return nil
-					},
-				},
-			},
+	synctest.Test(t, func(t *testing.T) {
+		root := t.TempDir()
+		database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, database.Close()) })
+		engine := NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+			Machine:   "local",
 		})
-		result <- struct {
+		t.Cleanup(engine.Close)
+		oldPath := filepath.Join(root, "old", "old.jsonl")
+		require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
+		require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", "archive before cancel").String()), 0o644))
+		require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
+		require.NoError(t, os.Remove(oldPath))
+
+		provider := &blockingRebuildProvider{
+			Def: parser.AgentDef{Type: parser.AgentCowork},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources: parser.CapabilitySupported,
+			}},
+			started: make(chan struct{}),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		firstHookCalls := 0
+		secondHookCalls := 0
+		secondProvider := &trackingRebuildProvider{
+			Def: parser.AgentDef{Type: parser.AgentCowork},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources: parser.CapabilitySupported,
+			}}}
+		result := make(chan struct {
 			stats SyncStats
 			err   error
-		}{stats: stats, err: runErr}
-	}()
+		}, 1)
+		go func() {
+			stats, runErr := engine.ResyncAllWithOptions(ctx, nil, RebuildOptions{
+				Contributors: []RebuildContributor{
+					{
+						Name: "blocking",
+						Config: EngineConfig{
+							AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+							Machine:   "blocking", Ephemeral: true,
+							ProviderFactories: []parser.ProviderFactory{
+								blockingRebuildFactory{provider: provider},
+							},
+							ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+								parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+							},
+						},
+						AfterSync: func(*Engine, *db.DB) error {
+							firstHookCalls++
+							return nil
+						},
+					},
+					{
+						Name: "later",
+						Config: EngineConfig{
+							AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+							Machine:   "later", Ephemeral: true,
+							ProviderFactories: []parser.ProviderFactory{
+								trackingRebuildFactory{provider: secondProvider},
+							},
+							ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+								parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+							},
+						},
+						AfterSync: func(*Engine, *db.DB) error {
+							secondHookCalls++
+							return nil
+						},
+					},
+				},
+			})
+			result <- struct {
+				stats SyncStats
+				err   error
+			}{stats: stats, err: runErr}
+		}()
 
-	select {
-	case <-provider.started:
-	case <-time.After(5 * time.Second):
-		t.Fatal("contributor parse did not reach controlled boundary")
-	}
-	cancel()
-	select {
-	case got := <-result:
-		require.ErrorIs(t, got.err, context.Canceled)
-		assert.True(t, got.stats.Aborted)
-		assert.Zero(t, firstHookCalls, "AfterSync ran on incomplete contributor data")
-		assert.Zero(t, secondProvider.discoverCalls, "later contributor started after cancellation")
-		assert.Zero(t, secondHookCalls, "later contributor hook ran after cancellation")
-	case <-time.After(5 * time.Second):
-		t.Fatal("cancelled contributor rebuild did not return")
-	}
+		synctest.Wait()
+		select {
+		case <-provider.started:
+		default:
+			require.FailNow(t, "contributor parse did not reach controlled boundary")
+		}
+		cancel()
+		synctest.Wait()
+		select {
+		case got := <-result:
+			require.ErrorIs(t, got.err, context.Canceled)
+			assert.True(t, got.stats.Aborted)
+			assert.Zero(t, firstHookCalls, "AfterSync ran on incomplete contributor data")
+			assert.Zero(t, secondProvider.discoverCalls, "later contributor started after cancellation")
+			assert.Zero(t, secondHookCalls, "later contributor hook ran after cancellation")
+		default:
+			require.FailNow(t, "cancelled contributor rebuild did not return")
+		}
 
-	page, searchErr := database.Search(context.Background(), db.SearchFilter{
-		Query: "archive before cancel", Limit: 5,
+		page, searchErr := database.Search(context.Background(), db.SearchFilter{
+			Query: "archive before cancel", Limit: 5,
+		})
+		require.NoError(t, searchErr)
+		require.Len(t, page.Results, 1)
+		assert.NoFileExists(t, database.Path()+resyncTempSuffix)
+		assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
+		assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
 	})
-	require.NoError(t, searchErr)
-	require.Len(t, page.Results, 1)
-	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
-	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
-	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
 }
 
 type incompleteContributorProvider struct {
@@ -813,93 +818,97 @@ func TestResyncAllRejectsDeferredLocalReplacement(t *testing.T) {
 }
 
 func TestResyncLocalCancellationPreventsContributors(t *testing.T) {
-	root := t.TempDir()
-	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, database.Close()) })
-	oldPath := filepath.Join(root, "old", "old.jsonl")
-	require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
-	require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
-		AddClaudeUser("2026-01-01T00:00:00Z", "archive before local cancel").String()), 0o644))
-	seedEngine := NewEngine(database, EngineConfig{
-		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
-		Machine:   "local",
-	})
-	require.Equal(t, 1, seedEngine.SyncAll(context.Background(), nil).Synced)
-	seedEngine.Close()
-	require.NoError(t, os.Remove(oldPath))
-
-	blocking := &blockingRebuildProvider{
-		Def: parser.AgentDef{Type: parser.AgentCowork},
-		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
-			DiscoverSources: parser.CapabilitySupported,
-		}},
-		started: make(chan struct{}),
-	}
-	later := &trackingRebuildProvider{
-		Def: parser.AgentDef{Type: parser.AgentCowork},
-		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
-			DiscoverSources: parser.CapabilitySupported,
-		}}}
-	engine := NewEngine(database, EngineConfig{
-		AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
-		Machine:   "local",
-		ProviderFactories: []parser.ProviderFactory{
-			blockingRebuildFactory{provider: blocking},
-		},
-		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
-		},
-	})
-	t.Cleanup(engine.Close)
-	ctx, cancel := context.WithCancel(context.Background())
-	result := make(chan struct {
-		stats SyncStats
-		err   error
-	}, 1)
-	go func() {
-		stats, runErr := engine.ResyncAllWithOptions(ctx, nil, RebuildOptions{
-			Contributors: []RebuildContributor{{
-				Name: "later",
-				Config: EngineConfig{
-					AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
-					Machine:   "later", Ephemeral: true,
-					ProviderFactories: []parser.ProviderFactory{
-						trackingRebuildFactory{provider: later},
-					},
-					ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-						parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
-					},
-				},
-			}},
+	synctest.Test(t, func(t *testing.T) {
+		root := t.TempDir()
+		database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, database.Close()) })
+		oldPath := filepath.Join(root, "old", "old.jsonl")
+		require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
+		require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", "archive before local cancel").String()), 0o644))
+		seedEngine := NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+			Machine:   "local",
 		})
-		result <- struct {
+		require.Equal(t, 1, seedEngine.SyncAll(context.Background(), nil).Synced)
+		seedEngine.Close()
+		require.NoError(t, os.Remove(oldPath))
+
+		blocking := &blockingRebuildProvider{
+			Def: parser.AgentDef{Type: parser.AgentCowork},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources: parser.CapabilitySupported,
+			}},
+			started: make(chan struct{}),
+		}
+		later := &trackingRebuildProvider{
+			Def: parser.AgentDef{Type: parser.AgentCowork},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources: parser.CapabilitySupported,
+			}}}
+		engine := NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+			Machine:   "local",
+			ProviderFactories: []parser.ProviderFactory{
+				blockingRebuildFactory{provider: blocking},
+			},
+			ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+			},
+		})
+		t.Cleanup(engine.Close)
+		ctx, cancel := context.WithCancel(context.Background())
+		result := make(chan struct {
 			stats SyncStats
 			err   error
-		}{stats: stats, err: runErr}
-	}()
-	select {
-	case <-blocking.started:
-	case <-time.After(5 * time.Second):
-		t.Fatal("local parse did not reach controlled boundary")
-	}
-	cancel()
-	select {
-	case got := <-result:
-		require.ErrorIs(t, got.err, context.Canceled)
-		assert.True(t, got.stats.Aborted)
-		assert.Zero(t, later.discoverCalls)
-	case <-time.After(5 * time.Second):
-		t.Fatal("cancelled local rebuild did not return")
-	}
-	page, searchErr := database.Search(context.Background(), db.SearchFilter{
-		Query: "archive before local cancel", Limit: 5,
+		}, 1)
+		go func() {
+			stats, runErr := engine.ResyncAllWithOptions(ctx, nil, RebuildOptions{
+				Contributors: []RebuildContributor{{
+					Name: "later",
+					Config: EngineConfig{
+						AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+						Machine:   "later", Ephemeral: true,
+						ProviderFactories: []parser.ProviderFactory{
+							trackingRebuildFactory{provider: later},
+						},
+						ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+							parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+						},
+					},
+				}},
+			})
+			result <- struct {
+				stats SyncStats
+				err   error
+			}{stats: stats, err: runErr}
+		}()
+		synctest.Wait()
+		select {
+		case <-blocking.started:
+		default:
+			require.FailNow(t, "local parse did not reach controlled boundary")
+		}
+		cancel()
+		synctest.Wait()
+		select {
+		case got := <-result:
+			require.ErrorIs(t, got.err, context.Canceled)
+			assert.True(t, got.stats.Aborted)
+			assert.Zero(t, later.discoverCalls)
+		default:
+			require.FailNow(t, "cancelled local rebuild did not return")
+		}
+		page, searchErr := database.Search(context.Background(), db.SearchFilter{
+			Query: "archive before local cancel", Limit: 5,
+		})
+		require.NoError(t, searchErr)
+		require.Len(t, page.Results, 1)
+		assert.NoFileExists(t, database.Path()+resyncTempSuffix)
+		assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
+		assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
 	})
-	require.NoError(t, searchErr)
-	require.Len(t, page.Results, 1)
-	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
-	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
-	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
 }
 
 type staticUsageRebuildProvider struct {

--- a/internal/sync/signal_schedule_test.go
+++ b/internal/sync/signal_schedule_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -271,60 +272,62 @@ func TestSignalSchedulerStopFlushesAndRunsInlineAfter(t *testing.T) {
 // running on the timer goroutine must finish before stop returns,
 // or the owner could close the DB underneath it.
 func TestSignalSchedulerStopWaitsForInflightTimerRun(t *testing.T) {
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var startedOnce sync.Once
-	var mu sync.Mutex
-	clock := time.Unix(1_700_000_000, 0)
-	sched := newSignalScheduler(10*time.Second, 2*time.Second,
-		func(string) {},
-		func(flush func()) {
-			startedOnce.Do(func() { close(started) })
-			<-release
-			flush()
-		},
-	)
-	sched.now = func() time.Time {
+	synctest.Test(t, func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var startedOnce sync.Once
+		var mu sync.Mutex
+		clock := time.Unix(1_700_000_000, 0)
+		sched := newSignalScheduler(10*time.Second, 2*time.Second,
+			func(string) {},
+			func(flush func()) {
+				startedOnce.Do(func() { close(started) })
+				<-release
+				flush()
+			},
+		)
+		sched.now = func() time.Time {
+			mu.Lock()
+			defer mu.Unlock()
+			return clock
+		}
+		var timerCB func()
+		sched.afterFunc = func(_ time.Duration, f func()) func() bool {
+			timerCB = f
+			return func() bool { return false }
+		}
+
+		sched.markDirty("s1") // leading edge, inline
+		sched.markDirty("s1") // defers and arms the timer
+		require.NotNil(t, timerCB, "deferral should arm the flush timer")
+
+		// The timer fires after the quiet delay and the deferred run
+		// blocks, simulating a recompute in the middle of DB work.
 		mu.Lock()
-		defer mu.Unlock()
-		return clock
-	}
-	var timerCB func()
-	sched.afterFunc = func(_ time.Duration, f func()) func() bool {
-		timerCB = f
-		return func() bool { return false }
-	}
+		clock = clock.Add(3 * time.Second)
+		mu.Unlock()
+		go timerCB()
+		<-started
 
-	sched.markDirty("s1") // leading edge, inline
-	sched.markDirty("s1") // defers and arms the timer
-	require.NotNil(t, timerCB, "deferral should arm the flush timer")
-
-	// The timer fires after the quiet delay and the deferred run
-	// blocks, simulating a recompute in the middle of DB work.
-	mu.Lock()
-	clock = clock.Add(3 * time.Second)
-	mu.Unlock()
-	go timerCB()
-	<-started
-
-	stopDone := make(chan struct{})
-	go func() {
-		sched.stop()
-		close(stopDone)
-	}()
-	stopped := func() bool {
+		stopDone := make(chan struct{})
+		go func() {
+			sched.stop()
+			close(stopDone)
+		}()
+		synctest.Wait()
 		select {
 		case <-stopDone:
-			return true
+			require.FailNow(t, "stop must wait for the in-flight timer recompute")
 		default:
-			return false
 		}
-	}
-	assert.Never(t, stopped, 100*time.Millisecond, 10*time.Millisecond,
-		"stop must wait for the in-flight timer recompute")
-	close(release)
-	require.Eventually(t, stopped, 2*time.Second, 5*time.Millisecond,
-		"stop must return once the in-flight recompute finishes")
+		close(release)
+		synctest.Wait()
+		select {
+		case <-stopDone:
+		default:
+			require.FailNow(t, "stop must return once the in-flight recompute finishes")
+		}
+	})
 }
 
 // TestSignalSchedulerFlushAllInlineUsesInlinePath covers the flush
@@ -611,24 +614,26 @@ func TestRunExclusiveFlushedFlushesSignalsBeforeWork(t *testing.T) {
 }
 
 func TestSignalSchedulerRealTimerFlushes(t *testing.T) {
-	var mu sync.Mutex
-	var runs int
-	run := func(string) {
-		mu.Lock()
-		runs++
-		mu.Unlock()
-	}
-	sched := newSignalScheduler(
-		50*time.Millisecond, 10*time.Millisecond, run,
-		func(flush func()) { flush() },
-	)
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		var runs int
+		run := func(string) {
+			mu.Lock()
+			runs++
+			mu.Unlock()
+		}
+		sched := newSignalScheduler(
+			50*time.Millisecond, 10*time.Millisecond, run,
+			func(flush func()) { flush() },
+		)
 
-	sched.markDirty("s1")
-	sched.markDirty("s1")
-	require.Eventually(t, func() bool {
+		sched.markDirty("s1")
+		sched.markDirty("s1")
+		synctest.Sleep(10 * time.Millisecond)
+		synctest.Wait()
 		mu.Lock()
 		defer mu.Unlock()
-		return runs == 2
-	}, 2*time.Second, 5*time.Millisecond,
-		"deferred recompute should flush via the real timer")
+		assert.Equal(t, 2, runs,
+			"deferred recompute should flush via the real timer")
+	})
 }

--- a/internal/sync/watch_batch_sync_test.go
+++ b/internal/sync/watch_batch_sync_test.go
@@ -465,9 +465,10 @@ func TestSyncWatchBatchThenRunReportsProgressBeforeReconciliationDiscoveryReturn
 			)
 			done <- err
 		}()
+		synctest.Wait()
 		select {
 		case <-started:
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "watch batch did not enter reconciliation discovery")
 		}
 
@@ -475,10 +476,11 @@ func TestSyncWatchBatchThenRunReportsProgressBeforeReconciliationDiscoveryReturn
 		assert.Equal(t, PhaseDiscovering, progress.Phase)
 
 		release <- struct{}{}
+		synctest.Wait()
 		select {
 		case err := <-done:
 			require.NoError(t, err)
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "watch batch did not finish after discovery resumed")
 		}
 	})
@@ -535,9 +537,10 @@ func TestSyncWatchBatchThenRunReportsProgressBeforeChangedPathParseReturns(
 			)
 			done <- err
 		}()
+		synctest.Wait()
 		select {
 		case <-started:
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "watch batch did not enter changed-path parsing")
 		}
 
@@ -545,10 +548,11 @@ func TestSyncWatchBatchThenRunReportsProgressBeforeChangedPathParseReturns(
 		assert.Equal(t, PhaseSyncing, progress.Phase)
 
 		release <- struct{}{}
+		synctest.Wait()
 		select {
 		case err := <-done:
 			require.NoError(t, err)
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "watch batch did not finish after parsing resumed")
 		}
 	})
@@ -613,11 +617,12 @@ func TestApplyWatchBatchReportsProgressBeforeUnknownRenameStatReturns(
 			)
 			done <- err
 		}()
+		synctest.Wait()
 		select {
 		case <-started:
 		case err := <-done:
 			require.FailNow(t, "watch batch bypassed the owned planning stat", "%v", err)
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "watch batch did not enter rename planning stat")
 		}
 
@@ -625,10 +630,11 @@ func TestApplyWatchBatchReportsProgressBeforeUnknownRenameStatReturns(
 		assert.Equal(t, PhaseDiscovering, progress.Phase)
 
 		release <- struct{}{}
+		synctest.Wait()
 		select {
 		case err := <-done:
 			require.NoError(t, err)
-		case <-time.After(time.Second):
+		default:
 			require.FailNow(t, "watch batch did not finish after planning resumed")
 		}
 		_, active := engine.CurrentProgress()

--- a/internal/sync/watch_batch_sync_test.go
+++ b/internal/sync/watch_batch_sync_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -424,129 +425,133 @@ func TestSyncWatchBatchThenRunMissingPathTombstoneIsCardinalityBounded(t *testin
 func TestSyncWatchBatchThenRunReportsProgressBeforeReconciliationDiscoveryReturns(
 	t *testing.T,
 ) {
-	const agent parser.AgentType = "watch-batch-blocked-discovery"
-	root := t.TempDir()
-	started := make(chan struct{}, 1)
-	release := make(chan struct{}, 1)
-	defer func() {
-		select {
-		case release <- struct{}{}:
-		default:
+	synctest.Test(t, func(t *testing.T) {
+		const agent parser.AgentType = "watch-batch-blocked-discovery"
+		root := t.TempDir()
+		started := make(chan struct{}, 1)
+		release := make(chan struct{}, 1)
+		defer func() {
+			select {
+			case release <- struct{}{}:
+			default:
+			}
+		}()
+		provider := &directStreamingProvider{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+			}},
+			discoverStarted: started,
+			discoverRelease: release,
 		}
-	}()
-	provider := &directStreamingProvider{
-		Def: parser.AgentDef{Type: agent, FileBased: true},
-		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
-			DiscoverSources:    parser.CapabilitySupported,
-			StreamingDiscovery: parser.CapabilitySupported,
-			WatchSources:       parser.CapabilitySupported,
-		}},
-		discoverStarted: started,
-		discoverRelease: release,
-	}
-	engine := NewEngine(openTestDB(t), EngineConfig{
-		AgentDirs:          map[parser.AgentType][]string{agent: {root}},
-		Machine:            "local",
-		ProgressStallAfter: time.Nanosecond,
-		ProviderFactories: []parser.ProviderFactory{
-			directStreamingFactory{provider: provider},
-		},
-		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-			agent: parser.ProviderMigrationProviderAuthoritative,
-		},
+		engine := NewEngine(openTestDB(t), EngineConfig{
+			AgentDirs:          map[parser.AgentType][]string{agent: {root}},
+			Machine:            "local",
+			ProgressStallAfter: time.Nanosecond,
+			ProviderFactories: []parser.ProviderFactory{
+				directStreamingFactory{provider: provider},
+			},
+			ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				agent: parser.ProviderMigrationProviderAuthoritative,
+			},
+		})
+		t.Cleanup(engine.Close)
+		done := make(chan error, 1)
+		go func() {
+			_, err := engine.SyncWatchBatchThenRun(
+				t.Context(), WatchBatch{ReconcileRoots: []string{root}}, nil, nil,
+			)
+			done <- err
+		}()
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			require.FailNow(t, "watch batch did not enter reconciliation discovery")
+		}
+
+		progress := requireStalledCurrentProgress(t, engine)
+		assert.Equal(t, PhaseDiscovering, progress.Phase)
+
+		release <- struct{}{}
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "watch batch did not finish after discovery resumed")
+		}
 	})
-	t.Cleanup(engine.Close)
-	done := make(chan error, 1)
-	go func() {
-		_, err := engine.SyncWatchBatchThenRun(
-			t.Context(), WatchBatch{ReconcileRoots: []string{root}}, nil, nil,
-		)
-		done <- err
-	}()
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		require.FailNow(t, "watch batch did not enter reconciliation discovery")
-	}
-
-	progress := requireStalledCurrentProgress(t, engine)
-	assert.Equal(t, PhaseDiscovering, progress.Phase)
-
-	release <- struct{}{}
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		require.FailNow(t, "watch batch did not finish after discovery resumed")
-	}
 }
 
 func TestSyncWatchBatchThenRunReportsProgressBeforeChangedPathParseReturns(
 	t *testing.T,
 ) {
-	const agent parser.AgentType = "watch-batch-blocked-changed-path"
-	root := t.TempDir()
-	path := filepath.Join(root, "source.jsonl")
-	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
-	started := make(chan struct{}, 1)
-	release := make(chan struct{}, 1)
-	defer func() {
-		select {
-		case release <- struct{}{}:
-		default:
+	synctest.Test(t, func(t *testing.T) {
+		const agent parser.AgentType = "watch-batch-blocked-changed-path"
+		root := t.TempDir()
+		path := filepath.Join(root, "source.jsonl")
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+		started := make(chan struct{}, 1)
+		release := make(chan struct{}, 1)
+		defer func() {
+			select {
+			case release <- struct{}{}:
+			default:
+			}
+		}()
+		source := parser.SourceRef{
+			Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
 		}
-	}()
-	source := parser.SourceRef{
-		Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
-	}
-	provider := &directStreamingProvider{
-		Def: parser.AgentDef{Type: agent, FileBased: true},
-		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
-			DiscoverSources:    parser.CapabilitySupported,
-			StreamingDiscovery: parser.CapabilitySupported,
-			WatchSources:       parser.CapabilitySupported,
-			FindSource:         parser.CapabilitySupported,
-		}},
-		source:       &source,
-		parseStarted: started,
-		parseRelease: release,
-		parseOutcome: parser.ParseOutcome{ResultSetComplete: true},
-	}
-	engine := NewEngine(openTestDB(t), EngineConfig{
-		AgentDirs:          map[parser.AgentType][]string{agent: {root}},
-		Machine:            "local",
-		ProgressStallAfter: time.Nanosecond,
-		ProviderFactories: []parser.ProviderFactory{
-			directStreamingFactory{provider: provider},
-		},
-		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-			agent: parser.ProviderMigrationProviderAuthoritative,
-		},
+		provider := &directStreamingProvider{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+				FindSource:         parser.CapabilitySupported,
+			}},
+			source:       &source,
+			parseStarted: started,
+			parseRelease: release,
+			parseOutcome: parser.ParseOutcome{ResultSetComplete: true},
+		}
+		engine := NewEngine(openTestDB(t), EngineConfig{
+			AgentDirs:          map[parser.AgentType][]string{agent: {root}},
+			Machine:            "local",
+			ProgressStallAfter: time.Nanosecond,
+			ProviderFactories: []parser.ProviderFactory{
+				directStreamingFactory{provider: provider},
+			},
+			ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				agent: parser.ProviderMigrationProviderAuthoritative,
+			},
+		})
+		t.Cleanup(engine.Close)
+		done := make(chan error, 1)
+		go func() {
+			_, err := engine.SyncWatchBatchThenRun(
+				t.Context(), WatchBatch{Paths: []string{path}}, nil, nil,
+			)
+			done <- err
+		}()
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			require.FailNow(t, "watch batch did not enter changed-path parsing")
+		}
+
+		progress := requireStalledCurrentProgress(t, engine)
+		assert.Equal(t, PhaseSyncing, progress.Phase)
+
+		release <- struct{}{}
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "watch batch did not finish after parsing resumed")
+		}
 	})
-	t.Cleanup(engine.Close)
-	done := make(chan error, 1)
-	go func() {
-		_, err := engine.SyncWatchBatchThenRun(
-			t.Context(), WatchBatch{Paths: []string{path}}, nil, nil,
-		)
-		done <- err
-	}()
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		require.FailNow(t, "watch batch did not enter changed-path parsing")
-	}
-
-	progress := requireStalledCurrentProgress(t, engine)
-	assert.Equal(t, PhaseSyncing, progress.Phase)
-
-	release <- struct{}{}
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		require.FailNow(t, "watch batch did not finish after parsing resumed")
-	}
 }
 
 func TestSyncWatchBatchThenRunClearsProgressBeforePostSyncWork(t *testing.T) {
@@ -576,57 +581,59 @@ func TestSyncWatchBatchThenRunClearsProgressBeforePostSyncWork(t *testing.T) {
 func TestApplyWatchBatchReportsProgressBeforeUnknownRenameStatReturns(
 	t *testing.T,
 ) {
-	const agent parser.AgentType = "watch-batch-blocked-rename-plan"
-	_, engine, _, _, path := newChangedPathOutcomeEngine(
-		t, agent, func(string) parser.ParseOutcome {
-			return parser.ParseOutcome{ResultSetComplete: true}
-		},
-	)
-	engine.progressStallAfter = time.Nanosecond
-	started := make(chan struct{}, 1)
-	release := make(chan struct{}, 1)
-	defer func() {
-		select {
-		case release <- struct{}{}:
-		default:
-		}
-	}()
-	realStat := engine.stat
-	engine.stat = func(got string) (os.FileInfo, error) {
-		assert.Equal(t, path, got)
-		started <- struct{}{}
-		<-release
-		return realStat(got)
-	}
-	done := make(chan error, 1)
-	go func() {
-		err := ApplyWatchBatch(
-			t.Context(), engine, WatchBatch{Renames: []WatchRename{{
-				Path: path, Agent: string(agent), ItemType: ItemIsUnknown,
-			}}}, &WatchRecoveryScope{},
+	synctest.Test(t, func(t *testing.T) {
+		const agent parser.AgentType = "watch-batch-blocked-rename-plan"
+		_, engine, _, _, path := newChangedPathOutcomeEngine(
+			t, agent, func(string) parser.ParseOutcome {
+				return parser.ParseOutcome{ResultSetComplete: true}
+			},
 		)
-		done <- err
-	}()
-	select {
-	case <-started:
-	case err := <-done:
-		require.FailNow(t, "watch batch bypassed the owned planning stat", "%v", err)
-	case <-time.After(time.Second):
-		require.FailNow(t, "watch batch did not enter rename planning stat")
-	}
+		engine.progressStallAfter = time.Nanosecond
+		started := make(chan struct{}, 1)
+		release := make(chan struct{}, 1)
+		defer func() {
+			select {
+			case release <- struct{}{}:
+			default:
+			}
+		}()
+		realStat := engine.stat
+		engine.stat = func(got string) (os.FileInfo, error) {
+			assert.Equal(t, path, got)
+			started <- struct{}{}
+			<-release
+			return realStat(got)
+		}
+		done := make(chan error, 1)
+		go func() {
+			err := ApplyWatchBatch(
+				t.Context(), engine, WatchBatch{Renames: []WatchRename{{
+					Path: path, Agent: string(agent), ItemType: ItemIsUnknown,
+				}}}, &WatchRecoveryScope{},
+			)
+			done <- err
+		}()
+		select {
+		case <-started:
+		case err := <-done:
+			require.FailNow(t, "watch batch bypassed the owned planning stat", "%v", err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "watch batch did not enter rename planning stat")
+		}
 
-	progress := requireStalledCurrentProgress(t, engine)
-	assert.Equal(t, PhaseDiscovering, progress.Phase)
+		progress := requireStalledCurrentProgress(t, engine)
+		assert.Equal(t, PhaseDiscovering, progress.Phase)
 
-	release <- struct{}{}
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		require.FailNow(t, "watch batch did not finish after planning resumed")
-	}
-	_, active := engine.CurrentProgress()
-	assert.False(t, active)
+		release <- struct{}{}
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "watch batch did not finish after planning resumed")
+		}
+		_, active := engine.CurrentProgress()
+		assert.False(t, active)
+	})
 }
 
 func TestValidateWatchBatchAcceptsBoundedAndAuthoritativeScopes(t *testing.T) {


### PR DESCRIPTION
The non-watcher `internal/sync` timing tests now use `testing/synctest` to settle in-process goroutines and fake-clock timers. Fixed polling budgets no longer decide when channel, callback, wait-group, and injected stat work has completed.

The selected internal/sync test files keep every assertion, cleanup join, and success-path receive. Watcher suites, mutex serialization, SQLite timestamp checks, and native or external waits retain their timing because bubbles cannot observe those conditions. The scope follows issue 1702 and PR 1674.

Refs #1702
