### PR TITLE
test(timing): convert remaining in-process timing waits to testing/synctest

### DIFF
--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -497,7 +497,11 @@ func TestLoadPricingMapCancelsDBRowsWithCaller(t *testing.T) {
 		cancel()
 
 		synctest.Wait()
-		<-state.done
+		select {
+		case <-state.done:
+		default:
+			require.FailNow(t, "canceled pricing query did not finish")
+		}
 		require.ErrorIs(t, <-result, context.Canceled)
 	})
 }

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -324,46 +324,46 @@ func TestPGModelPricingSourceDetectsBandOnlyFallbackMismatch(t *testing.T) {
 }
 
 func TestLoadPricingMapSharesConcurrentDBRows(t *testing.T) {
-	block := make(chan struct{})
-	state := &pricingProbeState{
-		rows: [][]driver.Value{{
-			"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
-		}},
-		block: block,
-	}
-	pg := newPricingProbeDB(t, state)
-	store := &Store{pg: pg}
+	synctest.Test(t, func(t *testing.T) {
+		block := make(chan struct{})
+		state := &pricingProbeState{
+			rows: [][]driver.Value{{
+				"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
+			}},
+			block: block,
+		}
+		pg := newPricingProbeDB(t, state)
+		store := &Store{pg: pg}
 
-	type result struct {
-		prices []export.EffectivePricingRow
-		err    error
-	}
-	results := make(chan result, 2)
-	go func() {
-		prices, err := store.loadPricingMap(context.Background())
-		results <- result{prices: prices, err: err}
-	}()
-	require.Eventually(t, func() bool {
-		return state.queryCount() == 1
-	}, time.Second, 10*time.Millisecond)
+		type result struct {
+			prices []export.EffectivePricingRow
+			err    error
+		}
+		results := make(chan result, 2)
+		go func() {
+			prices, err := store.loadPricingMap(context.Background())
+			results <- result{prices: prices, err: err}
+		}()
+		synctest.Wait()
+		require.Equal(t, 1, state.queryCount(), "pricing queries")
 
-	go func() {
-		prices, err := store.loadPricingMap(context.Background())
-		results <- result{prices: prices, err: err}
-	}()
-	require.Never(t, func() bool {
-		return state.queryCount() > 1
-	}, 50*time.Millisecond, 10*time.Millisecond)
-	close(block)
+		go func() {
+			prices, err := store.loadPricingMap(context.Background())
+			results <- result{prices: prices, err: err}
+		}()
+		synctest.Wait()
+		require.Equal(t, 1, state.queryCount(), "pricing queries")
+		close(block)
 
-	first := <-results
-	second := <-results
-	require.NoError(t, first.err, "first loadPricingMap")
-	require.NoError(t, second.err, "second loadPricingMap")
-	require.Equal(t, 1, state.queryCount(), "pricing queries")
-	first.prices[0].Rates.InputPerMTok = money.MustParseDollars("99")
-	secondByPattern := pricingRowsByPattern(second.prices)
-	assert.Equal(t, money.MustParseDollars("1"), secondByPattern["db-model"].InputPerMTok)
+		first := <-results
+		second := <-results
+		require.NoError(t, first.err, "first loadPricingMap")
+		require.NoError(t, second.err, "second loadPricingMap")
+		require.Equal(t, 1, state.queryCount(), "pricing queries")
+		first.prices[0].Rates.InputPerMTok = money.MustParseDollars("99")
+		secondByPattern := pricingRowsByPattern(second.prices)
+		assert.Equal(t, money.MustParseDollars("1"), secondByPattern["db-model"].InputPerMTok)
+	})
 }
 
 func TestLoadPricingMapUsesFallbackForSentinelOnlyCatalog(t *testing.T) {
@@ -422,167 +422,162 @@ func TestLoadPricingMapUsesDBRowsAsEffectiveTable(t *testing.T) {
 }
 
 func TestLoadPricingMapKeepsSharedDBRowsForActiveCaller(t *testing.T) {
-	block := make(chan struct{})
-	var unblockOnce sync.Once
-	unblock := func() { unblockOnce.Do(func() { close(block) }) }
-	defer unblock()
-	state := &pricingProbeState{
-		rows: [][]driver.Value{{
-			"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
-		}},
-		block: block,
-	}
-	pg := newPricingProbeDB(t, state)
-	store := &Store{pg: pg}
+	synctest.Test(t, func(t *testing.T) {
+		block := make(chan struct{})
+		var unblockOnce sync.Once
+		unblock := func() { unblockOnce.Do(func() { close(block) }) }
+		defer unblock()
+		state := &pricingProbeState{
+			rows: [][]driver.Value{{
+				"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
+			}},
+			block: block,
+		}
+		pg := newPricingProbeDB(t, state)
+		store := &Store{pg: pg}
 
-	type result struct {
-		prices []export.EffectivePricingRow
-		err    error
-	}
-	firstCtx, cancelFirst := context.WithCancel(context.Background())
-	firstResult := make(chan result, 1)
-	go func() {
-		prices, err := store.loadPricingMap(firstCtx)
-		firstResult <- result{prices: prices, err: err}
-	}()
-	require.Eventually(t, func() bool {
-		return state.queryCount() == 1
-	}, time.Second, 10*time.Millisecond)
+		type result struct {
+			prices []export.EffectivePricingRow
+			err    error
+		}
+		firstCtx, cancelFirst := context.WithCancel(context.Background())
+		firstResult := make(chan result, 1)
+		go func() {
+			prices, err := store.loadPricingMap(firstCtx)
+			firstResult <- result{prices: prices, err: err}
+		}()
+		synctest.Wait()
+		require.Equal(t, 1, state.queryCount(), "pricing queries")
 
-	secondResult := make(chan result, 1)
-	go func() {
-		prices, err := store.loadPricingMap(context.Background())
-		secondResult <- result{prices: prices, err: err}
-	}()
-	require.Never(t, func() bool {
-		return state.queryCount() > 1
-	}, 50*time.Millisecond, 10*time.Millisecond)
+		secondResult := make(chan result, 1)
+		go func() {
+			prices, err := store.loadPricingMap(context.Background())
+			secondResult <- result{prices: prices, err: err}
+		}()
+		synctest.Wait()
+		require.Equal(t, 1, state.queryCount(), "pricing queries")
 
-	cancelFirst()
+		cancelFirst()
 
-	first := <-firstResult
-	require.ErrorIs(t, first.err, context.Canceled)
+		first := <-firstResult
+		require.ErrorIs(t, first.err, context.Canceled)
 
-	unblock()
-	second := <-secondResult
-	require.NoError(t, second.err, "second loadPricingMap")
-	secondByPattern := pricingRowsByPattern(second.prices)
-	assert.Equal(t, money.MustParseDollars("1"), secondByPattern["db-model"].InputPerMTok)
-	assert.Equal(t, 1, state.queryCount(), "pricing queries")
+		unblock()
+		second := <-secondResult
+		require.NoError(t, second.err, "second loadPricingMap")
+		secondByPattern := pricingRowsByPattern(second.prices)
+		assert.Equal(t, money.MustParseDollars("1"), secondByPattern["db-model"].InputPerMTok)
+		assert.Equal(t, 1, state.queryCount(), "pricing queries")
+	})
 }
 
 func TestLoadPricingMapCancelsDBRowsWithCaller(t *testing.T) {
-	block := make(chan struct{})
-	defer close(block)
-	state := &pricingProbeState{
-		rows: [][]driver.Value{{
-			"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
-		}},
-		block: block,
-		done:  make(chan struct{}),
-	}
-	pg := newPricingProbeDB(t, state)
-	store := &Store{pg: pg}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	result := make(chan error, 1)
-	go func() {
-		_, err := store.loadPricingMap(ctx)
-		result <- err
-	}()
-	require.Eventually(t, func() bool {
-		return state.queryCount() == 1
-	}, time.Second, 10*time.Millisecond)
-
-	cancel()
-
-	require.Eventually(t, func() bool {
-		select {
-		case <-state.done:
-			return true
-		default:
-			return false
+	synctest.Test(t, func(t *testing.T) {
+		block := make(chan struct{})
+		defer close(block)
+		state := &pricingProbeState{
+			rows: [][]driver.Value{{
+				"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
+			}},
+			block: block,
+			done:  make(chan struct{}),
 		}
-	}, time.Second, 10*time.Millisecond)
-	require.ErrorIs(t, <-result, context.Canceled)
+		pg := newPricingProbeDB(t, state)
+		store := &Store{pg: pg}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		result := make(chan error, 1)
+		go func() {
+			_, err := store.loadPricingMap(ctx)
+			result <- err
+		}()
+		synctest.Wait()
+		require.Equal(t, 1, state.queryCount(), "pricing queries")
+
+		cancel()
+
+		synctest.Wait()
+		<-state.done
+		require.ErrorIs(t, <-result, context.Canceled)
+	})
 }
 
 func TestLoadPricingMapStartsFreshLoadAfterAllWaitersCancel(t *testing.T) {
-	block := make(chan struct{})
-	releaseCanceledQuery := make(chan struct{})
-	defer close(releaseCanceledQuery)
-	state := &pricingProbeState{
-		rows: [][]driver.Value{{
-			"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
-		}},
-		block:            block,
-		afterCancelBlock: releaseCanceledQuery,
-	}
-	pg := newPricingProbeDB(t, state)
-	store := &Store{pg: pg}
+	synctest.Test(t, func(t *testing.T) {
+		block := make(chan struct{})
+		releaseCanceledQuery := make(chan struct{})
+		defer close(releaseCanceledQuery)
+		state := &pricingProbeState{
+			rows: [][]driver.Value{{
+				"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
+			}},
+			block:            block,
+			afterCancelBlock: releaseCanceledQuery,
+		}
+		pg := newPricingProbeDB(t, state)
+		store := &Store{pg: pg}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	firstResult := make(chan error, 1)
-	go func() {
-		_, err := store.loadPricingMap(ctx)
-		firstResult <- err
-	}()
-	require.Eventually(t, func() bool {
-		return state.queryCount() == 1
-	}, time.Second, 10*time.Millisecond)
+		ctx, cancel := context.WithCancel(context.Background())
+		firstResult := make(chan error, 1)
+		go func() {
+			_, err := store.loadPricingMap(ctx)
+			firstResult <- err
+		}()
+		synctest.Wait()
+		require.Equal(t, 1, state.queryCount(), "pricing queries")
 
-	cancel()
-	require.ErrorIs(t, <-firstResult, context.Canceled)
-	state.unblockNextQuery()
+		cancel()
+		require.ErrorIs(t, <-firstResult, context.Canceled)
+		state.unblockNextQuery()
 
-	secondResult := make(chan error, 1)
-	go func() {
-		_, err := store.loadPricingMap(context.Background())
-		secondResult <- err
-	}()
+		secondResult := make(chan error, 1)
+		go func() {
+			_, err := store.loadPricingMap(context.Background())
+			secondResult <- err
+		}()
 
-	require.Eventually(t, func() bool {
-		return state.queryCount() == 2
-	}, time.Second, 10*time.Millisecond)
-	require.NoError(t, <-secondResult, "second loadPricingMap")
+		synctest.Wait()
+		require.Equal(t, 2, state.queryCount(), "pricing queries")
+		require.NoError(t, <-secondResult, "second loadPricingMap")
+	})
 }
 
 func TestSetCustomPricingForgetsInFlightPricingLoad(t *testing.T) {
-	block := make(chan struct{})
-	defer close(block)
-	state := &pricingProbeState{
-		rows: [][]driver.Value{{
-			"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
-		}},
-		block: block,
-	}
-	pg := newPricingProbeDB(t, state)
-	store := &Store{pg: pg}
+	synctest.Test(t, func(t *testing.T) {
+		block := make(chan struct{})
+		defer close(block)
+		state := &pricingProbeState{
+			rows: [][]driver.Value{{
+				"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
+			}},
+			block: block,
+		}
+		pg := newPricingProbeDB(t, state)
+		store := &Store{pg: pg}
 
-	type result struct {
-		prices []export.EffectivePricingRow
-		err    error
-	}
-	results := make(chan result, 2)
-	go func() {
-		prices, err := store.loadPricingMap(context.Background())
-		results <- result{prices: prices, err: err}
-	}()
-	require.Eventually(t, func() bool {
-		return state.queryCount() == 1
-	}, time.Second, 10*time.Millisecond)
+		type result struct {
+			prices []export.EffectivePricingRow
+			err    error
+		}
+		results := make(chan result, 2)
+		go func() {
+			prices, err := store.loadPricingMap(context.Background())
+			results <- result{prices: prices, err: err}
+		}()
+		synctest.Wait()
+		require.Equal(t, 1, state.queryCount(), "pricing queries")
 
-	store.SetCustomPricing(map[string]config.CustomModelRate{
-		"custom-model": {InputMicrodollarsPerMTok: money.MustParseDollars("9.0").Microdollars},
+		store.SetCustomPricing(map[string]config.CustomModelRate{
+			"custom-model": {InputMicrodollarsPerMTok: money.MustParseDollars("9.0").Microdollars},
+		})
+		go func() {
+			prices, err := store.loadPricingMap(context.Background())
+			results <- result{prices: prices, err: err}
+		}()
+
+		synctest.Wait()
+		require.Equal(t, 2, state.queryCount(), "pricing queries")
 	})
-	go func() {
-		prices, err := store.loadPricingMap(context.Background())
-		results <- result{prices: prices, err: err}
-	}()
-
-	require.Eventually(t, func() bool {
-		return state.queryCount() == 2
-	}, time.Second, 10*time.Millisecond)
 }
 
 func TestLoadPricingMapReloadsAfterCompletedDBRows(t *testing.T) {

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -326,6 +326,9 @@ func TestPGModelPricingSourceDetectsBandOnlyFallbackMismatch(t *testing.T) {
 func TestLoadPricingMapSharesConcurrentDBRows(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		block := make(chan struct{})
+		var blockOnce sync.Once
+		releaseBlock := func() { blockOnce.Do(func() { close(block) }) }
+		t.Cleanup(releaseBlock)
 		state := &pricingProbeState{
 			rows: [][]driver.Value{{
 				"db-model", int64(1000000), int64(2000000), int64(3000000), int64(0), int64(4000000), "2026-06-08",
@@ -353,7 +356,7 @@ func TestLoadPricingMapSharesConcurrentDBRows(t *testing.T) {
 		}()
 		synctest.Wait()
 		require.Equal(t, 1, state.queryCount(), "pricing queries")
-		close(block)
+		releaseBlock()
 
 		first := <-results
 		second := <-results

--- a/internal/pricingrefresh/refresh_test.go
+++ b/internal/pricingrefresh/refresh_test.go
@@ -450,7 +450,11 @@ func TestRefreshCurrentSkipsWhileEnsureCurrentInFlight(t *testing.T) {
 		}()
 
 		synctest.Wait()
-		<-ensureFetchStarted
+		select {
+		case <-ensureFetchStarted:
+		default:
+			require.FailNow(t, "ensureCurrent did not start its fetch")
+		}
 
 		var refreshFetchCalls atomic.Int32
 		refreshDone := make(chan error, 1)
@@ -468,7 +472,12 @@ func TestRefreshCurrentSkipsWhileEnsureCurrentInFlight(t *testing.T) {
 		}()
 
 		synctest.Wait()
-		refreshErr := <-refreshDone
+		var refreshErr error
+		select {
+		case refreshErr = <-refreshDone:
+		default:
+			require.FailNow(t, "refreshCurrent did not finish while ensureCurrent was in flight")
+		}
 		require.NoError(t, refreshErr)
 		assert.Zero(t, refreshFetchCalls.Load())
 		scheduledPrice, err := database.GetModelPricing("scheduled-model")
@@ -477,7 +486,12 @@ func TestRefreshCurrentSkipsWhileEnsureCurrentInFlight(t *testing.T) {
 
 		releaseEnsureFetch <- struct{}{}
 		synctest.Wait()
-		ensureErr := <-ensureDone
+		var ensureErr error
+		select {
+		case ensureErr = <-ensureDone:
+		default:
+			require.FailNow(t, "ensureCurrent did not finish after its fetch was released")
+		}
 		require.NoError(t, ensureErr)
 		ensuredPrice, err := database.GetModelPricing("ensure-model")
 		require.NoError(t, err)

--- a/internal/pricingrefresh/refresh_test.go
+++ b/internal/pricingrefresh/refresh_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -426,80 +427,62 @@ func TestRefreshCurrentFetchesDespiteRecentAttempt(t *testing.T) {
 }
 
 func TestRefreshCurrentSkipsWhileEnsureCurrentInFlight(t *testing.T) {
-	database := testDB(t)
-	now := pricingTestNow()
-	ensureFetchStarted := make(chan struct{})
-	releaseEnsureFetch := make(chan struct{}, 1)
-	ensureDone := make(chan error, 1)
+	synctest.Test(t, func(t *testing.T) {
+		database := testDB(t)
+		now := pricingTestNow()
+		ensureFetchStarted := make(chan struct{})
+		releaseEnsureFetch := make(chan struct{}, 1)
+		ensureDone := make(chan error, 1)
 
-	go func() {
-		ensureDone <- ensureCurrent(context.Background(), database, func(
-			context.Context,
-		) (pricing.Catalog, error) {
-			close(ensureFetchStarted)
-			<-releaseEnsureFetch
-			return pricing.Catalog{LiteLLM: []pricing.ModelPricing{{
-				ModelPattern: "ensure-model",
-			}}}, nil
-		}, now)
-	}()
-	defer func() {
-		releaseEnsureFetch <- struct{}{}
-	}()
-
-	require.Eventually(t, func() bool {
-		select {
-		case <-ensureFetchStarted:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, time.Millisecond)
-
-	var refreshFetchCalls atomic.Int32
-	refreshDone := make(chan error, 1)
-	go func() {
-		refreshDone <- refreshCurrent(
-			context.Background(), database, func(
+		go func() {
+			ensureDone <- ensureCurrent(context.Background(), database, func(
 				context.Context,
 			) (pricing.Catalog, error) {
-				refreshFetchCalls.Add(1)
+				close(ensureFetchStarted)
+				<-releaseEnsureFetch
 				return pricing.Catalog{LiteLLM: []pricing.ModelPricing{{
-					ModelPattern: "scheduled-model",
+					ModelPattern: "ensure-model",
 				}}}, nil
-			}, now.Add(time.Minute),
-		)
-	}()
+			}, now)
+		}()
+		defer func() {
+			releaseEnsureFetch <- struct{}{}
+		}()
 
-	var refreshErr error
-	require.Eventually(t, func() bool {
-		select {
-		case refreshErr = <-refreshDone:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, time.Millisecond)
-	require.NoError(t, refreshErr)
-	assert.Zero(t, refreshFetchCalls.Load())
-	scheduledPrice, err := database.GetModelPricing("scheduled-model")
-	require.NoError(t, err)
-	assert.Nil(t, scheduledPrice)
+		synctest.Wait()
+		<-ensureFetchStarted
 
-	releaseEnsureFetch <- struct{}{}
-	var ensureErr error
-	require.Eventually(t, func() bool {
-		select {
-		case ensureErr = <-ensureDone:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, time.Millisecond)
-	require.NoError(t, ensureErr)
-	ensuredPrice, err := database.GetModelPricing("ensure-model")
-	require.NoError(t, err)
-	require.NotNil(t, ensuredPrice)
+		var refreshFetchCalls atomic.Int32
+		refreshDone := make(chan error, 1)
+		go func() {
+			refreshDone <- refreshCurrent(
+				context.Background(), database, func(
+					context.Context,
+				) (pricing.Catalog, error) {
+					refreshFetchCalls.Add(1)
+					return pricing.Catalog{LiteLLM: []pricing.ModelPricing{{
+						ModelPattern: "scheduled-model",
+					}}}, nil
+				}, now.Add(time.Minute),
+			)
+		}()
+
+		synctest.Wait()
+		refreshErr := <-refreshDone
+		require.NoError(t, refreshErr)
+		assert.Zero(t, refreshFetchCalls.Load())
+		scheduledPrice, err := database.GetModelPricing("scheduled-model")
+		require.NoError(t, err)
+		assert.Nil(t, scheduledPrice)
+
+		releaseEnsureFetch <- struct{}{}
+		synctest.Wait()
+		ensureErr := <-ensureDone
+		require.NoError(t, ensureErr)
+		ensuredPrice, err := database.GetModelPricing("ensure-model")
+		require.NoError(t, err)
+		require.NotNil(t, ensuredPrice)
+	})
 }
 
 func testDB(t *testing.T) *db.DB {

--- a/internal/server/activity_report_singleflight_test.go
+++ b/internal/server/activity_report_singleflight_test.go
@@ -108,7 +108,11 @@ func TestActivityReportBuildGroupCancelsAbandonedBuild(t *testing.T) {
 		cancel()
 		require.ErrorIs(t, <-done, context.Canceled)
 		synctest.Wait()
-		<-buildCanceled
+		select {
+		case <-buildCanceled:
+		default:
+			require.FailNow(t, "abandoned build was not canceled")
+		}
 	})
 }
 
@@ -153,7 +157,12 @@ func TestActivityReportBuildGroupStartsFreshAfterLastWaiterCancels(t *testing.T)
 			_, err := group.do(firstCtx, "same", build)
 			firstDone <- err
 		}()
-		<-firstStarted
+		synctest.Wait()
+		select {
+		case <-firstStarted:
+		default:
+			require.FailNow(t, "first build did not start")
+		}
 		group.mu.Lock()
 		firstFlight := group.flights["same"]
 		group.mu.Unlock()
@@ -162,7 +171,11 @@ func TestActivityReportBuildGroupStartsFreshAfterLastWaiterCancels(t *testing.T)
 		cancelFirst()
 		require.ErrorIs(t, <-firstDone, context.Canceled)
 		synctest.Wait()
-		<-firstCanceled
+		select {
+		case <-firstCanceled:
+		default:
+			require.FailNow(t, "abandoned build was not canceled")
+		}
 
 		type result struct {
 			artifacts activity.CandidateArtifacts
@@ -173,7 +186,12 @@ func TestActivityReportBuildGroupStartsFreshAfterLastWaiterCancels(t *testing.T)
 			artifacts, err := group.do(context.Background(), "same", build)
 			secondDone <- result{artifacts: artifacts, err: err}
 		}()
-		<-secondStarted
+		synctest.Wait()
+		select {
+		case <-secondStarted:
+		default:
+			require.FailNow(t, "replacement request joined the canceled flight")
+		}
 		group.mu.Lock()
 		secondFlight := group.flights["same"]
 		group.mu.Unlock()
@@ -181,7 +199,12 @@ func TestActivityReportBuildGroupStartsFreshAfterLastWaiterCancels(t *testing.T)
 		require.NotSame(t, firstFlight, secondFlight)
 
 		releaseFirstOnce.Do(func() { close(releaseFirst) })
-		<-firstFlight.done
+		synctest.Wait()
+		select {
+		case <-firstFlight.done:
+		default:
+			require.FailNow(t, "canceled flight did not exit")
+		}
 		group.mu.Lock()
 		currentFlight := group.flights["same"]
 		group.mu.Unlock()
@@ -237,9 +260,19 @@ func TestActivityReportProgressBuildsKeepCallbacksRequestLocal(t *testing.T) {
 		}
 
 		first := start("first")
-		<-store.started
+		synctest.Wait()
+		select {
+		case <-store.started:
+		default:
+			require.FailNow(t, "first report build did not start")
+		}
 		second := start("second")
-		<-store.started
+		synctest.Wait()
+		select {
+		case <-store.started:
+		default:
+			require.FailNow(t, "second progress request reused the first callback")
+		}
 		close(store.release)
 		require.NoError(t, <-first)
 		require.NoError(t, <-second)

--- a/internal/server/activity_report_singleflight_test.go
+++ b/internal/server/activity_report_singleflight_test.go
@@ -240,6 +240,9 @@ func TestActivityReportProgressBuildsKeepCallbacksRequestLocal(t *testing.T) {
 			started: make(chan struct{}, 2),
 			release: make(chan struct{}),
 		}
+		var releaseOnce sync.Once
+		release := func() { releaseOnce.Do(func() { close(store.release) }) }
+		t.Cleanup(release)
 		srv := &Server{activityReportFlights: newActivityReportBuildGroup()}
 		var mu sync.Mutex
 		seen := map[string][]int64{"first": {}, "second": {}}
@@ -273,7 +276,7 @@ func TestActivityReportProgressBuildsKeepCallbacksRequestLocal(t *testing.T) {
 		default:
 			require.FailNow(t, "second progress request reused the first callback")
 		}
-		close(store.release)
+		release()
 		require.NoError(t, <-first)
 		require.NoError(t, <-second)
 		require.Equal(t, int32(2), store.builds.Load())

--- a/internal/server/activity_report_singleflight_test.go
+++ b/internal/server/activity_report_singleflight_test.go
@@ -41,6 +41,9 @@ func TestActivityReportBuildGroupSharesBuildAfterOneWaiterCancels(t *testing.T) 
 		group := newActivityReportBuildGroup()
 		started := make(chan struct{})
 		release := make(chan struct{})
+		var releaseOnce sync.Once
+		releaseBuild := func() { releaseOnce.Do(func() { close(release) }) }
+		t.Cleanup(releaseBuild)
 		var builds atomic.Int32
 		build := func(ctx context.Context) (activity.CandidateArtifacts, error) {
 			if builds.Add(1) == 1 {
@@ -81,7 +84,7 @@ func TestActivityReportBuildGroupSharesBuildAfterOneWaiterCancels(t *testing.T) 
 		require.Equal(t, 2, sameWaiters)
 		cancelFirst()
 		require.ErrorIs(t, <-firstDone, context.Canceled)
-		close(release)
+		releaseBuild()
 		second := <-secondDone
 		require.NoError(t, second.err)
 		require.Equal(t, "ok", second.artifacts.Sessions[0].SessionID)

--- a/internal/server/activity_report_singleflight_test.go
+++ b/internal/server/activity_report_singleflight_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/require"
 
@@ -37,224 +37,217 @@ func (store *progressArtifactStore) BuildActivityReportArtifacts(
 }
 
 func TestActivityReportBuildGroupSharesBuildAfterOneWaiterCancels(t *testing.T) {
-	group := newActivityReportBuildGroup()
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var builds atomic.Int32
-	build := func(ctx context.Context) (activity.CandidateArtifacts, error) {
-		if builds.Add(1) == 1 {
-			close(started)
+	synctest.Test(t, func(t *testing.T) {
+		group := newActivityReportBuildGroup()
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var builds atomic.Int32
+		build := func(ctx context.Context) (activity.CandidateArtifacts, error) {
+			if builds.Add(1) == 1 {
+				close(started)
+			}
+			select {
+			case <-release:
+				return activity.CandidateArtifacts{Sessions: []activity.SessionRow{{SessionID: "ok"}}}, nil
+			case <-ctx.Done():
+				return activity.CandidateArtifacts{}, ctx.Err()
+			}
 		}
-		select {
-		case <-release:
-			return activity.CandidateArtifacts{Sessions: []activity.SessionRow{{SessionID: "ok"}}}, nil
-		case <-ctx.Done():
-			return activity.CandidateArtifacts{}, ctx.Err()
+		firstCtx, cancelFirst := context.WithCancel(context.Background())
+		firstDone := make(chan error, 1)
+		go func() {
+			_, err := group.do(firstCtx, "same", build)
+			firstDone <- err
+		}()
+		<-started
+		type result struct {
+			artifacts activity.CandidateArtifacts
+			err       error
 		}
-	}
-	firstCtx, cancelFirst := context.WithCancel(context.Background())
-	firstDone := make(chan error, 1)
-	go func() {
-		_, err := group.do(firstCtx, "same", build)
-		firstDone <- err
-	}()
-	<-started
-	type result struct {
-		artifacts activity.CandidateArtifacts
-		err       error
-	}
-	secondDone := make(chan result, 1)
-	go func() {
-		artifacts, err := group.do(context.Background(), "same", build)
-		secondDone <- result{artifacts: artifacts, err: err}
-	}()
-	require.Eventually(t, func() bool {
+		secondDone := make(chan result, 1)
+		go func() {
+			artifacts, err := group.do(context.Background(), "same", build)
+			secondDone <- result{artifacts: artifacts, err: err}
+		}()
+		synctest.Wait()
 		group.mu.Lock()
-		defer group.mu.Unlock()
-		return group.flights["same"] != nil && group.flights["same"].waiters == 2
-	}, time.Second, time.Millisecond)
-	cancelFirst()
-	require.ErrorIs(t, <-firstDone, context.Canceled)
-	close(release)
-	second := <-secondDone
-	require.NoError(t, second.err)
-	require.Equal(t, "ok", second.artifacts.Sessions[0].SessionID)
-	require.Equal(t, int32(1), builds.Load())
+		sameFlight := group.flights["same"]
+		sameWaiters := 0
+		if sameFlight != nil {
+			sameWaiters = sameFlight.waiters
+		}
+		group.mu.Unlock()
+		require.NotNil(t, sameFlight)
+		require.Equal(t, 2, sameWaiters)
+		cancelFirst()
+		require.ErrorIs(t, <-firstDone, context.Canceled)
+		close(release)
+		second := <-secondDone
+		require.NoError(t, second.err)
+		require.Equal(t, "ok", second.artifacts.Sessions[0].SessionID)
+		require.Equal(t, int32(1), builds.Load())
+	})
 }
 
 func TestActivityReportBuildGroupCancelsAbandonedBuild(t *testing.T) {
-	group := newActivityReportBuildGroup()
-	buildCanceled := make(chan struct{})
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() {
-		_, err := group.do(ctx, "abandoned", func(ctx context.Context) (
-			activity.CandidateArtifacts, error,
-		) {
-			<-ctx.Done()
-			close(buildCanceled)
-			return activity.CandidateArtifacts{}, ctx.Err()
-		})
-		done <- err
-	}()
-	cancel()
-	require.ErrorIs(t, <-done, context.Canceled)
-	select {
-	case <-buildCanceled:
-	case <-time.After(time.Second):
-		require.FailNow(t, "abandoned build was not canceled")
-	}
+	synctest.Test(t, func(t *testing.T) {
+		group := newActivityReportBuildGroup()
+		buildCanceled := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			_, err := group.do(ctx, "abandoned", func(ctx context.Context) (
+				activity.CandidateArtifacts, error,
+			) {
+				<-ctx.Done()
+				close(buildCanceled)
+				return activity.CandidateArtifacts{}, ctx.Err()
+			})
+			done <- err
+		}()
+		cancel()
+		require.ErrorIs(t, <-done, context.Canceled)
+		synctest.Wait()
+		<-buildCanceled
+	})
 }
 
 func TestActivityReportBuildGroupStartsFreshAfterLastWaiterCancels(t *testing.T) {
-	group := newActivityReportBuildGroup()
-	firstStarted := make(chan struct{})
-	firstCanceled := make(chan struct{})
-	releaseFirst := make(chan struct{})
-	secondStarted := make(chan struct{})
-	releaseSecond := make(chan struct{})
-	var releaseFirstOnce, releaseSecondOnce sync.Once
-	t.Cleanup(func() {
-		releaseFirstOnce.Do(func() { close(releaseFirst) })
-		releaseSecondOnce.Do(func() { close(releaseSecond) })
-	})
-	var builds atomic.Int32
-	build := func(ctx context.Context) (activity.CandidateArtifacts, error) {
-		switch builds.Add(1) {
-		case 1:
-			close(firstStarted)
-			<-ctx.Done()
-			close(firstCanceled)
-			<-releaseFirst
-			return activity.CandidateArtifacts{}, ctx.Err()
-		case 2:
-			close(secondStarted)
-			<-releaseSecond
-			return activity.CandidateArtifacts{
-				Sessions: []activity.SessionRow{{SessionID: "fresh"}},
-			}, nil
-		default:
-			return activity.CandidateArtifacts{
-				Sessions: []activity.SessionRow{{SessionID: "duplicate"}},
-			}, nil
+	synctest.Test(t, func(t *testing.T) {
+		group := newActivityReportBuildGroup()
+		firstStarted := make(chan struct{})
+		firstCanceled := make(chan struct{})
+		releaseFirst := make(chan struct{})
+		secondStarted := make(chan struct{})
+		releaseSecond := make(chan struct{})
+		var releaseFirstOnce, releaseSecondOnce sync.Once
+		t.Cleanup(func() {
+			releaseFirstOnce.Do(func() { close(releaseFirst) })
+			releaseSecondOnce.Do(func() { close(releaseSecond) })
+		})
+		var builds atomic.Int32
+		build := func(ctx context.Context) (activity.CandidateArtifacts, error) {
+			switch builds.Add(1) {
+			case 1:
+				close(firstStarted)
+				<-ctx.Done()
+				close(firstCanceled)
+				<-releaseFirst
+				return activity.CandidateArtifacts{}, ctx.Err()
+			case 2:
+				close(secondStarted)
+				<-releaseSecond
+				return activity.CandidateArtifacts{
+					Sessions: []activity.SessionRow{{SessionID: "fresh"}},
+				}, nil
+			default:
+				return activity.CandidateArtifacts{
+					Sessions: []activity.SessionRow{{SessionID: "duplicate"}},
+				}, nil
+			}
 		}
-	}
 
-	firstCtx, cancelFirst := context.WithCancel(context.Background())
-	firstDone := make(chan error, 1)
-	go func() {
-		_, err := group.do(firstCtx, "same", build)
-		firstDone <- err
-	}()
-	<-firstStarted
-	group.mu.Lock()
-	firstFlight := group.flights["same"]
-	group.mu.Unlock()
-	require.NotNil(t, firstFlight)
-
-	cancelFirst()
-	require.ErrorIs(t, <-firstDone, context.Canceled)
-	select {
-	case <-firstCanceled:
-	case <-time.After(time.Second):
-		require.FailNow(t, "abandoned build was not canceled")
-	}
-
-	type result struct {
-		artifacts activity.CandidateArtifacts
-		err       error
-	}
-	secondDone := make(chan result, 1)
-	go func() {
-		artifacts, err := group.do(context.Background(), "same", build)
-		secondDone <- result{artifacts: artifacts, err: err}
-	}()
-	select {
-	case <-secondStarted:
-	case <-time.After(time.Second):
-		require.FailNow(t, "replacement request joined the canceled flight")
-	}
-	group.mu.Lock()
-	secondFlight := group.flights["same"]
-	group.mu.Unlock()
-	require.NotNil(t, secondFlight)
-	require.NotSame(t, firstFlight, secondFlight)
-
-	releaseFirstOnce.Do(func() { close(releaseFirst) })
-	select {
-	case <-firstFlight.done:
-	case <-time.After(time.Second):
-		require.FailNow(t, "canceled flight did not exit")
-	}
-	group.mu.Lock()
-	currentFlight := group.flights["same"]
-	group.mu.Unlock()
-	require.Same(t, secondFlight, currentFlight,
-		"old build completion must not delete its replacement")
-
-	thirdDone := make(chan result, 1)
-	go func() {
-		artifacts, err := group.do(context.Background(), "same", build)
-		thirdDone <- result{artifacts: artifacts, err: err}
-	}()
-	require.Eventually(t, func() bool {
+		firstCtx, cancelFirst := context.WithCancel(context.Background())
+		firstDone := make(chan error, 1)
+		go func() {
+			_, err := group.do(firstCtx, "same", build)
+			firstDone <- err
+		}()
+		<-firstStarted
 		group.mu.Lock()
-		defer group.mu.Unlock()
-		return group.flights["same"] == secondFlight && secondFlight.waiters == 2
-	}, time.Second, time.Millisecond)
-	releaseSecondOnce.Do(func() { close(releaseSecond) })
+		firstFlight := group.flights["same"]
+		group.mu.Unlock()
+		require.NotNil(t, firstFlight)
 
-	for _, completed := range []result{<-secondDone, <-thirdDone} {
-		require.NoError(t, completed.err)
-		require.Len(t, completed.artifacts.Sessions, 1)
-		require.Equal(t, "fresh", completed.artifacts.Sessions[0].SessionID)
-	}
-	require.Equal(t, int32(2), builds.Load())
+		cancelFirst()
+		require.ErrorIs(t, <-firstDone, context.Canceled)
+		synctest.Wait()
+		<-firstCanceled
+
+		type result struct {
+			artifacts activity.CandidateArtifacts
+			err       error
+		}
+		secondDone := make(chan result, 1)
+		go func() {
+			artifacts, err := group.do(context.Background(), "same", build)
+			secondDone <- result{artifacts: artifacts, err: err}
+		}()
+		<-secondStarted
+		group.mu.Lock()
+		secondFlight := group.flights["same"]
+		group.mu.Unlock()
+		require.NotNil(t, secondFlight)
+		require.NotSame(t, firstFlight, secondFlight)
+
+		releaseFirstOnce.Do(func() { close(releaseFirst) })
+		<-firstFlight.done
+		group.mu.Lock()
+		currentFlight := group.flights["same"]
+		group.mu.Unlock()
+		require.Same(t, secondFlight, currentFlight,
+			"old build completion must not delete its replacement")
+
+		thirdDone := make(chan result, 1)
+		go func() {
+			artifacts, err := group.do(context.Background(), "same", build)
+			thirdDone <- result{artifacts: artifacts, err: err}
+		}()
+		synctest.Wait()
+		group.mu.Lock()
+		currentFlight = group.flights["same"]
+		currentWaiters := secondFlight.waiters
+		group.mu.Unlock()
+		require.Same(t, secondFlight, currentFlight)
+		require.Equal(t, 2, currentWaiters)
+		releaseSecondOnce.Do(func() { close(releaseSecond) })
+
+		for _, completed := range []result{<-secondDone, <-thirdDone} {
+			require.NoError(t, completed.err)
+			require.Len(t, completed.artifacts.Sessions, 1)
+			require.Equal(t, "fresh", completed.artifacts.Sessions[0].SessionID)
+		}
+		require.Equal(t, int32(2), builds.Load())
+	})
 }
 
 func TestActivityReportProgressBuildsKeepCallbacksRequestLocal(t *testing.T) {
-	store := &progressArtifactStore{
-		started: make(chan struct{}, 2),
-		release: make(chan struct{}),
-	}
-	srv := &Server{activityReportFlights: newActivityReportBuildGroup()}
-	var mu sync.Mutex
-	seen := map[string][]int64{"first": {}, "second": {}}
-	start := func(name string) <-chan error {
-		done := make(chan error, 1)
-		go func() {
-			_, err := srv.buildActivityArtifacts(
-				context.Background(), store, resolvedActivitySelection{},
-				activity.SourceProbe{}, func(progress activity.Progress) {
-					mu.Lock()
-					seen[name] = append(seen[name], progress.RowsProcessed)
-					mu.Unlock()
-				},
-			)
-			done <- err
-		}()
-		return done
-	}
+	synctest.Test(t, func(t *testing.T) {
+		store := &progressArtifactStore{
+			started: make(chan struct{}, 2),
+			release: make(chan struct{}),
+		}
+		srv := &Server{activityReportFlights: newActivityReportBuildGroup()}
+		var mu sync.Mutex
+		seen := map[string][]int64{"first": {}, "second": {}}
+		start := func(name string) <-chan error {
+			done := make(chan error, 1)
+			go func() {
+				_, err := srv.buildActivityArtifacts(
+					context.Background(), store, resolvedActivitySelection{},
+					activity.SourceProbe{}, func(progress activity.Progress) {
+						mu.Lock()
+						seen[name] = append(seen[name], progress.RowsProcessed)
+						mu.Unlock()
+					},
+				)
+				done <- err
+			}()
+			return done
+		}
 
-	first := start("first")
-	select {
-	case <-store.started:
-	case <-time.After(time.Second):
-		require.FailNow(t, "first report build did not start")
-	}
-	second := start("second")
-	select {
-	case <-store.started:
-	case <-time.After(time.Second):
-		require.FailNow(t, "second progress request reused the first callback")
-	}
-	close(store.release)
-	require.NoError(t, <-first)
-	require.NoError(t, <-second)
-	require.Equal(t, int32(2), store.builds.Load())
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, seen["first"], 1)
-	require.Len(t, seen["second"], 1)
-	require.NotEqual(t, seen["first"][0], seen["second"][0])
+		first := start("first")
+		<-store.started
+		second := start("second")
+		<-store.started
+		close(store.release)
+		require.NoError(t, <-first)
+		require.NoError(t, <-second)
+		require.Equal(t, int32(2), store.builds.Load())
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, seen["first"], 1)
+		require.Len(t, seen["second"], 1)
+		require.NotEqual(t, seen["first"][0], seen["second"][0])
+	})
 }

--- a/internal/server/broadcaster_test.go
+++ b/internal/server/broadcaster_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -10,275 +11,254 @@ import (
 )
 
 func TestBroadcaster_EmitFansOutToAllSubscribers(t *testing.T) {
-	b := NewBroadcaster(10 * time.Second)
-	sub1, unsub1 := b.Subscribe()
-	defer unsub1()
-	sub2, unsub2 := b.Subscribe()
-	defer unsub2()
+	synctest.Test(t, func(t *testing.T) {
+		b := NewBroadcaster(10 * time.Second)
+		sub1, unsub1 := b.Subscribe()
+		defer unsub1()
+		sub2, unsub2 := b.Subscribe()
+		defer unsub2()
 
-	b.Emit("messages")
+		b.Emit("messages")
 
-	for i, sub := range []<-chan Event{sub1, sub2} {
-		select {
-		case ev := <-sub:
+		for i, sub := range []<-chan Event{sub1, sub2} {
+			ev := <-sub
 			assert.Equal(t, "messages", ev.Scope, "sub %d", i)
-		case <-time.After(time.Second):
-			require.Fail(t, "timed out waiting for event", "sub %d", i)
 		}
-	}
+	})
 }
 
 func TestBroadcaster_EmitIsNonBlockingOnSlowSubscriber(t *testing.T) {
-	// Disable rate limiting so every Emit attempts a broadcast, which
-	// is what exercises the non-blocking select-default path against
-	// a slow subscriber.
-	b := NewBroadcaster(0)
-	slow, unsub := b.Subscribe()
-	defer unsub()
+	synctest.Test(t, func(t *testing.T) {
+		// Disable rate limiting so every Emit attempts a broadcast, which
+		// is what exercises the non-blocking select-default path against
+		// a slow subscriber.
+		b := NewBroadcaster(0)
+		slow, unsub := b.Subscribe()
+		defer unsub()
 
-	// Don't read from slow. Fill its buffer + one extra; Emit must not block.
-	const extra = 5
-	done := make(chan struct{})
-	go func() {
-		for range broadcasterBufferCap + extra {
-			b.Emit("messages")
-		}
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		require.Fail(t, "Emit blocked on slow subscriber")
-	}
+		// Don't read from slow. Fill its buffer + one extra; Emit must not block.
+		const extra = 5
+		done := make(chan struct{})
+		go func() {
+			for range broadcasterBufferCap + extra {
+				b.Emit("messages")
+			}
+			close(done)
+		}()
+		synctest.Wait()
+		<-done
 
-	// Drain what we can — drop count >= extra, exact count not guaranteed.
-	drained := 0
-	for {
-		select {
-		case <-slow:
-			drained++
-		case <-time.After(50 * time.Millisecond):
-			require.NotZero(t, drained, "slow subscriber received nothing")
-			return
+		// Drain what we can — drop count >= extra, exact count not guaranteed.
+		drained := 0
+	drain:
+		for {
+			select {
+			case <-slow:
+				drained++
+			default:
+				break drain
+			}
 		}
-	}
+		require.NotZero(t, drained, "slow subscriber received nothing")
+	})
 }
 
 func TestBroadcaster_UnsubscribeStopsDelivery(t *testing.T) {
-	b := NewBroadcaster(10 * time.Second)
-	sub, unsub := b.Subscribe()
-	unsub()
+	synctest.Test(t, func(t *testing.T) {
+		b := NewBroadcaster(10 * time.Second)
+		sub, unsub := b.Subscribe()
+		unsub()
 
-	b.Emit("messages")
+		b.Emit("messages")
 
-	select {
-	case ev, ok := <-sub:
+		ev, ok := <-sub
 		require.False(t, ok, "got event after unsubscribe: %v", ev)
-		// channel closed by unsubscribe — acceptable
-	case <-time.After(100 * time.Millisecond):
-		// no delivery — also acceptable
-	}
+	})
 }
 
 func TestBroadcaster_ConcurrentSubscribeAndEmit(t *testing.T) {
-	// Disable rate limiting so each subscriber's Emit reliably
-	// produces a broadcast during the race.
-	b := NewBroadcaster(0)
-	var wg sync.WaitGroup
-	for range 20 {
-		wg.Go(func() {
-			sub, unsub := b.Subscribe()
-			defer unsub()
-			b.Emit("sessions")
-			select {
-			case <-sub:
-			case <-time.After(time.Second):
-				assert.Fail(t, "concurrent subscriber did not receive event")
-			}
-		})
-	}
-	wg.Wait()
+	synctest.Test(t, func(t *testing.T) {
+		// Disable rate limiting so each subscriber's Emit reliably
+		// produces a broadcast during the race.
+		b := NewBroadcaster(0)
+		var wg sync.WaitGroup
+		for range 20 {
+			wg.Go(func() {
+				sub, unsub := b.Subscribe()
+				defer unsub()
+				b.Emit("sessions")
+				<-sub
+			})
+		}
+		wg.Wait()
+	})
 }
 
 func TestBroadcaster_LeadingEdgeEmitsImmediately(t *testing.T) {
-	b := NewBroadcaster(time.Second)
-	sub, unsub := b.Subscribe()
-	defer unsub()
+	synctest.Test(t, func(t *testing.T) {
+		b := NewBroadcaster(time.Second)
+		sub, unsub := b.Subscribe()
+		defer unsub()
 
-	b.Emit("messages")
+		b.Emit("messages")
 
-	select {
-	case ev := <-sub:
+		ev := <-sub
 		assert.Equal(t, "messages", ev.Scope)
-	case <-time.After(100 * time.Millisecond):
-		require.Fail(t, "first emit did not broadcast immediately")
-	}
+	})
 }
 
 func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
-	const interval = 100 * time.Millisecond
-	b := NewBroadcaster(interval)
-	sub, unsub := b.Subscribe()
-	defer unsub()
+	synctest.Test(t, func(t *testing.T) {
+		const interval = 100 * time.Millisecond
+		b := NewBroadcaster(interval)
+		sub, unsub := b.Subscribe()
+		defer unsub()
 
-	// Leading-edge broadcast drains the first emit.
-	b.Emit("sessions")
-	select {
-	case <-sub:
-	case <-time.After(50 * time.Millisecond):
-		require.Fail(t, "leading-edge emit did not broadcast immediately")
-	}
+		// Leading-edge broadcast drains the first emit.
+		b.Emit("sessions")
+		<-sub
 
-	// Bursts within the window are coalesced; no broadcast yet.
-	b.Emit("messages")
-	b.Emit("sync")
-	b.Emit("sessions")
+		// Bursts within the window are coalesced; no broadcast yet.
+		b.Emit("messages")
+		b.Emit("sync")
+		b.Emit("sessions")
 
-	select {
-	case ev := <-sub:
-		require.Fail(t, "got early broadcast during rate-limit window", "ev=%v", ev)
-	case <-time.After(interval / 2):
-	}
+		synctest.Sleep(interval / 2)
+		select {
+		case ev := <-sub:
+			require.Fail(t, "got early broadcast during rate-limit window", "ev=%v", ev)
+		default:
+		}
 
-	// After the window elapses a single trailing broadcast arrives
-	// carrying the most recent scope.
-	select {
-	case ev := <-sub:
+		// After the window elapses a single trailing broadcast arrives
+		// carrying the most recent scope.
+		ev := <-sub
 		assert.Equal(t, "sessions", ev.Scope, "trailing scope")
-	case <-time.After(interval * 3):
-		require.Fail(t, "trailing broadcast never arrived")
-	}
 
-	// The three coalesced emits produce exactly one trailing broadcast.
-	select {
-	case ev := <-sub:
-		require.Fail(t, "got duplicate broadcast after trailing fire", "ev=%v", ev)
-	case <-time.After(interval):
-	}
+		// The three coalesced emits produce exactly one trailing broadcast.
+		synctest.Sleep(interval)
+		select {
+		case ev := <-sub:
+			require.Fail(t, "got duplicate broadcast after trailing fire", "ev=%v", ev)
+		default:
+		}
+	})
 }
 
 func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
-	const interval = 50 * time.Millisecond
-	b := NewBroadcaster(interval)
-	sub, unsub := b.Subscribe()
-	defer unsub()
+	synctest.Test(t, func(t *testing.T) {
+		const interval = 50 * time.Millisecond
+		b := NewBroadcaster(interval)
+		sub, unsub := b.Subscribe()
+		defer unsub()
 
-	// Leading broadcast fills the window.
-	b.Emit("a")
-	select {
-	case <-sub:
-	case <-time.After(interval):
-		require.Fail(t, "leading emit did not broadcast")
-	}
+		// Leading broadcast fills the window.
+		b.Emit("a")
+		<-sub
 
-	// Rate-limited emit schedules a trailing broadcast of "b".
-	b.Emit("b")
+		// Rate-limited emit schedules a trailing broadcast of "b".
+		b.Emit("b")
 
-	// Simulate the race: another Emit arrives just after the window
-	// boundary but before the in-flight trailing timer can acquire
-	// the lock. Backdating lastEmit forces the next Emit to take the
-	// leading branch while pending is still set and the timer is
-	// still armed.
-	b.mu.Lock()
-	b.lastEmit = time.Now().Add(-2 * interval)
-	b.mu.Unlock()
+		// Simulate the race: another Emit arrives just after the window
+		// boundary but before the in-flight trailing timer can acquire
+		// the lock. Backdating lastEmit forces the next Emit to take the
+		// leading branch while pending is still set and the timer is
+		// still armed.
+		b.mu.Lock()
+		b.lastEmit = time.Now().Add(-2 * interval)
+		b.mu.Unlock()
 
-	b.Emit("c")
-	select {
-	case ev := <-sub:
+		b.Emit("c")
+		ev := <-sub
 		assert.Equal(t, "c", ev.Scope, "leading broadcast scope")
-	case <-time.After(interval):
-		require.Fail(t, "second leading emit did not broadcast")
-	}
 
-	// The pre-existing trailing timer for "b" may still fire. If the
-	// leading branch did not cancel pending/timer, flushTrailing
-	// would now deliver a stale "b" broadcast. Wait past the
-	// original deadline and assert no extra event arrives.
-	select {
-	case ev := <-sub:
-		require.Fail(t, "stale trailing broadcast after leading edge", "ev=%v", ev)
-	case <-time.After(2 * interval):
-	}
+		// The pre-existing trailing timer for "b" may still fire. If the
+		// leading branch did not cancel pending/timer, flushTrailing
+		// would now deliver a stale "b" broadcast. Wait past the
+		// original deadline and assert no extra event arrives.
+		synctest.Sleep(2 * interval)
+		select {
+		case ev := <-sub:
+			require.Fail(t, "stale trailing broadcast after leading edge", "ev=%v", ev)
+		default:
+		}
+	})
 }
 
 func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.T) {
-	// Narrow race: a trailing callback whose timer already fired is
-	// waiting for b.mu; a leading-edge Emit runs first and a follow-up
-	// rate-limited Emit installs a new pending+timer. Without a
-	// generation token, the stale callback clobbers b.timer and
-	// broadcasts the newer pending event immediately, violating the
-	// rate limit.
-	const interval = 50 * time.Millisecond
-	b := NewBroadcaster(interval)
-	sub, unsub := b.Subscribe()
-	defer unsub()
+	synctest.Test(t, func(t *testing.T) {
+		// Narrow race: a trailing callback whose timer already fired is
+		// waiting for b.mu; a leading-edge Emit runs first and a follow-up
+		// rate-limited Emit installs a new pending+timer. Without a
+		// generation token, the stale callback clobbers b.timer and
+		// broadcasts the newer pending event immediately, violating the
+		// rate limit.
+		const interval = 50 * time.Millisecond
+		b := NewBroadcaster(interval)
+		sub, unsub := b.Subscribe()
+		defer unsub()
 
-	b.Emit("a")
-	<-sub
+		b.Emit("a")
+		<-sub
 
-	// Rate-limited emit schedules a timer; capture the generation
-	// the scheduled callback will check against when it runs.
-	b.Emit("b")
-	b.mu.Lock()
-	staleGen := b.timerGen
-	b.mu.Unlock()
+		// Rate-limited emit schedules a timer; capture the generation
+		// the scheduled callback will check against when it runs.
+		b.Emit("b")
+		b.mu.Lock()
+		staleGen := b.timerGen
+		b.mu.Unlock()
 
-	// Force the next Emit into the leading branch, invalidating the
-	// prior timer's generation.
-	b.mu.Lock()
-	b.lastEmit = time.Now().Add(-2 * interval)
-	b.mu.Unlock()
-	b.Emit("c")
-	<-sub
+		// Force the next Emit into the leading branch, invalidating the
+		// prior timer's generation.
+		b.mu.Lock()
+		b.lastEmit = time.Now().Add(-2 * interval)
+		b.mu.Unlock()
+		b.Emit("c")
+		<-sub
 
-	// Rate-limited emit after the leading edge installs a fresh
-	// pending+timer under the new generation.
-	b.Emit("d")
+		// Rate-limited emit after the leading edge installs a fresh
+		// pending+timer under the new generation.
+		b.Emit("d")
 
-	// Simulate the stale callback from the "b" timer finally acquiring
-	// the lock after being blocked. With the generation check it must
-	// return without touching state; without it, the stale callback
-	// would clear b.timer and broadcast "d" prematurely.
-	b.flushTrailing(staleGen)
+		// Simulate the stale callback from the "b" timer finally acquiring
+		// the lock after being blocked. With the generation check it must
+		// return without touching state; without it, the stale callback
+		// would clear b.timer and broadcast "d" prematurely.
+		b.flushTrailing(staleGen)
 
-	// No premature broadcast in the window right after the stale
-	// callback supposedly ran.
-	select {
-	case ev := <-sub:
-		require.Fail(t, "stale callback consumed newer pending", "ev=%v", ev)
-	case <-time.After(interval / 2):
-	}
+		// No premature broadcast in the window right after the stale
+		// callback supposedly ran.
+		synctest.Sleep(interval / 2)
+		select {
+		case ev := <-sub:
+			require.Fail(t, "stale callback consumed newer pending", "ev=%v", ev)
+		default:
+		}
 
-	// The new timer scheduled for "d" must still be live and deliver
-	// "d" on its original schedule. A bug that lets the stale callback
-	// null out b.timer would orphan the new timer here — in which case
-	// the callback still fires, finds pending == nil, and no event
-	// arrives.
-	select {
-	case ev := <-sub:
+		// The new timer scheduled for "d" must still be live and deliver
+		// "d" on its original schedule. A bug that lets the stale callback
+		// null out b.timer would orphan the new timer here — in which case
+		// the callback still fires, finds pending == nil, and no event
+		// arrives.
+		ev := <-sub
 		assert.Equal(t, "d", ev.Scope)
-	case <-time.After(interval * 3):
-		require.Fail(t, "new trailing timer did not fire with pending scope")
-	}
+	})
 }
 
 func TestBroadcaster_EmitAfterIntervalBroadcastsImmediately(t *testing.T) {
-	const interval = 50 * time.Millisecond
-	b := NewBroadcaster(interval)
-	sub, unsub := b.Subscribe()
-	defer unsub()
+	synctest.Test(t, func(t *testing.T) {
+		const interval = 50 * time.Millisecond
+		b := NewBroadcaster(interval)
+		sub, unsub := b.Subscribe()
+		defer unsub()
 
-	b.Emit("first")
-	<-sub
+		b.Emit("first")
+		<-sub
 
-	time.Sleep(interval * 2)
+		synctest.Sleep(interval * 2)
 
-	b.Emit("second")
-	select {
-	case ev := <-sub:
+		b.Emit("second")
+		ev := <-sub
 		assert.Equal(t, "second", ev.Scope)
-	case <-time.After(interval):
-		require.Fail(t, "emit after quiet interval did not broadcast immediately")
-	}
+	})
 }

--- a/internal/server/broadcaster_test.go
+++ b/internal/server/broadcaster_test.go
@@ -184,7 +184,11 @@ func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
 
 		// Leading broadcast fills the window.
 		b.Emit("a")
-		<-sub
+		select {
+		case <-sub:
+		default:
+			require.Fail(t, "leading emit did not broadcast")
+		}
 
 		// Rate-limited emit schedules a trailing broadcast of "b".
 		b.Emit("b")

--- a/internal/server/broadcaster_test.go
+++ b/internal/server/broadcaster_test.go
@@ -21,8 +21,12 @@ func TestBroadcaster_EmitFansOutToAllSubscribers(t *testing.T) {
 		b.Emit("messages")
 
 		for i, sub := range []<-chan Event{sub1, sub2} {
-			ev := <-sub
-			assert.Equal(t, "messages", ev.Scope, "sub %d", i)
+			select {
+			case ev := <-sub:
+				assert.Equal(t, "messages", ev.Scope, "sub %d", i)
+			default:
+				require.Fail(t, "timed out waiting for event", "sub %d", i)
+			}
 		}
 	})
 }
@@ -46,7 +50,11 @@ func TestBroadcaster_EmitIsNonBlockingOnSlowSubscriber(t *testing.T) {
 			close(done)
 		}()
 		synctest.Wait()
-		<-done
+		select {
+		case <-done:
+		default:
+			require.Fail(t, "Emit blocked on slow subscriber")
+		}
 
 		// Drain what we can — drop count >= extra, exact count not guaranteed.
 		drained := 0
@@ -71,8 +79,13 @@ func TestBroadcaster_UnsubscribeStopsDelivery(t *testing.T) {
 
 		b.Emit("messages")
 
-		ev, ok := <-sub
-		require.False(t, ok, "got event after unsubscribe: %v", ev)
+		select {
+		case ev, ok := <-sub:
+			require.False(t, ok, "got event after unsubscribe: %v", ev)
+			// channel closed by unsubscribe — acceptable
+		default:
+			// no delivery — also acceptable
+		}
 	})
 }
 
@@ -87,7 +100,11 @@ func TestBroadcaster_ConcurrentSubscribeAndEmit(t *testing.T) {
 				sub, unsub := b.Subscribe()
 				defer unsub()
 				b.Emit("sessions")
-				<-sub
+				select {
+				case <-sub:
+				default:
+					assert.Fail(t, "concurrent subscriber did not receive event")
+				}
 			})
 		}
 		wg.Wait()
@@ -102,8 +119,12 @@ func TestBroadcaster_LeadingEdgeEmitsImmediately(t *testing.T) {
 
 		b.Emit("messages")
 
-		ev := <-sub
-		assert.Equal(t, "messages", ev.Scope)
+		select {
+		case ev := <-sub:
+			assert.Equal(t, "messages", ev.Scope)
+		default:
+			require.Fail(t, "first emit did not broadcast immediately")
+		}
 	})
 }
 
@@ -116,7 +137,11 @@ func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
 
 		// Leading-edge broadcast drains the first emit.
 		b.Emit("sessions")
-		<-sub
+		select {
+		case <-sub:
+		default:
+			require.Fail(t, "leading-edge emit did not broadcast immediately")
+		}
 
 		// Bursts within the window are coalesced; no broadcast yet.
 		b.Emit("messages")
@@ -132,8 +157,13 @@ func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
 
 		// After the window elapses a single trailing broadcast arrives
 		// carrying the most recent scope.
-		ev := <-sub
-		assert.Equal(t, "sessions", ev.Scope, "trailing scope")
+		synctest.Sleep(interval / 2)
+		select {
+		case ev := <-sub:
+			assert.Equal(t, "sessions", ev.Scope, "trailing scope")
+		default:
+			require.Fail(t, "trailing broadcast never arrived")
+		}
 
 		// The three coalesced emits produce exactly one trailing broadcast.
 		synctest.Sleep(interval)
@@ -169,8 +199,12 @@ func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
 		b.mu.Unlock()
 
 		b.Emit("c")
-		ev := <-sub
-		assert.Equal(t, "c", ev.Scope, "leading broadcast scope")
+		select {
+		case ev := <-sub:
+			assert.Equal(t, "c", ev.Scope, "leading broadcast scope")
+		default:
+			require.Fail(t, "second leading emit did not broadcast")
+		}
 
 		// The pre-existing trailing timer for "b" may still fire. If the
 		// leading branch did not cancel pending/timer, flushTrailing
@@ -199,7 +233,11 @@ func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.
 		defer unsub()
 
 		b.Emit("a")
-		<-sub
+		select {
+		case <-sub:
+		default:
+			require.Fail(t, "leading emit did not broadcast")
+		}
 
 		// Rate-limited emit schedules a timer; capture the generation
 		// the scheduled callback will check against when it runs.
@@ -214,7 +252,11 @@ func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.
 		b.lastEmit = time.Now().Add(-2 * interval)
 		b.mu.Unlock()
 		b.Emit("c")
-		<-sub
+		select {
+		case <-sub:
+		default:
+			require.Fail(t, "second leading emit did not broadcast")
+		}
 
 		// Rate-limited emit after the leading edge installs a fresh
 		// pending+timer under the new generation.
@@ -240,8 +282,13 @@ func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.
 		// null out b.timer would orphan the new timer here — in which case
 		// the callback still fires, finds pending == nil, and no event
 		// arrives.
-		ev := <-sub
-		assert.Equal(t, "d", ev.Scope)
+		synctest.Sleep(interval / 2)
+		select {
+		case ev := <-sub:
+			assert.Equal(t, "d", ev.Scope)
+		default:
+			require.Fail(t, "new trailing timer did not fire with pending scope")
+		}
 	})
 }
 
@@ -253,12 +300,20 @@ func TestBroadcaster_EmitAfterIntervalBroadcastsImmediately(t *testing.T) {
 		defer unsub()
 
 		b.Emit("first")
-		<-sub
+		select {
+		case <-sub:
+		default:
+			require.Fail(t, "leading emit did not broadcast")
+		}
 
 		synctest.Sleep(interval * 2)
 
 		b.Emit("second")
-		ev := <-sub
-		assert.Equal(t, "second", ev.Scope)
+		select {
+		case ev := <-sub:
+			assert.Equal(t, "second", ev.Scope)
+		default:
+			require.Fail(t, "emit after quiet interval did not broadcast immediately")
+		}
 	})
 }


### PR DESCRIPTION
The selected remaining timing tests now use `testing/synctest` for in-process PostgreSQL probes, pricing refresh coordination, activity-report singleflight, and the broadcaster's leading-edge timer window. They settle on channels, callbacks, and fake-clock timers instead of waiting for a wall-clock budget.

The change stays in four test files and leaves production code untouched. SQLite timestamp ordering, DuckDB filesystem replacement, capture and subprocess events, recall database chronology, and other network or OS waits retain their existing timing because their event sources sit outside the bubble. The conversion follows the `testing/synctest` pattern introduced in PR 1674.

Refs #1702
