### PR TITLE
fix(sync): honor existing image policy overrides

### DIFF
--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1400,10 +1400,24 @@ const slowOpThreshold = 100 * time.Millisecond
 
 // InsertMessages batch-inserts messages for a session.
 func (db *DB) InsertMessages(msgs []Message) error {
+	return db.insertMessages(msgs, db.ToolResultImages())
+}
+
+// InsertMessagesWithToolResultImages inserts messages with the policy selected
+// by the sync engine.
+func (db *DB) InsertMessagesWithToolResultImages(
+	msgs []Message, policy config.ToolResultImages,
+) error {
+	return db.insertMessages(msgs, policy)
+}
+
+func (db *DB) insertMessages(
+	msgs []Message, policy config.ToolResultImages,
+) error {
 	if err := db.requireWritable(); err != nil {
 		return err
 	}
-	msgs, _ = db.ProjectToolResultImages(msgs)
+	msgs, _ = ProjectToolResultImages(msgs, policy)
 	rawMessages := msgs
 	msgs = db.messagesForStorage(msgs)
 	if len(rawMessages) == 0 {
@@ -1611,11 +1625,29 @@ func applyMessageTokenUsageUpdateTx(
 func (db *DB) WriteSessionIncremental(
 	sessionID string, msgs []Message, update IncrementalSessionUpdate,
 ) (bool, error) {
+	return db.writeSessionIncremental(
+		sessionID, msgs, update, db.ToolResultImages(),
+	)
+}
+
+// WriteSessionIncrementalWithToolResultImages writes an incremental update
+// with the policy selected by the sync engine.
+func (db *DB) WriteSessionIncrementalWithToolResultImages(
+	sessionID string, msgs []Message, update IncrementalSessionUpdate,
+	policy config.ToolResultImages,
+) (bool, error) {
+	return db.writeSessionIncremental(sessionID, msgs, update, policy)
+}
+
+func (db *DB) writeSessionIncremental(
+	sessionID string, msgs []Message, update IncrementalSessionUpdate,
+	policy config.ToolResultImages,
+) (bool, error) {
 	if err := db.requireWritable(); err != nil {
 		return false, err
 	}
-	msgs, _ = db.ProjectToolResultImages(msgs)
-	if db.ToolResultImages() == config.ToolResultImagesDrop {
+	msgs, _ = ProjectToolResultImages(msgs, policy)
+	if policy == config.ToolResultImagesDrop {
 		update.SubagentLinks = append([]ToolCallSubagentLink(nil), update.SubagentLinks...)
 		for i := range update.SubagentLinks {
 			content, _ := StripToolResultImages(update.SubagentLinks[i].ResultContent)
@@ -1674,7 +1706,7 @@ func (db *DB) WriteSessionIncremental(
 	}
 	for _, link := range update.SubagentLinks {
 		changed, err := applyToolCallSubagentLinkTx(
-			tx, sessionID, link, update.BlockedResultCategories,
+			tx, sessionID, link, update.BlockedResultCategories, policy,
 		)
 		if err != nil {
 			return false, err
@@ -1685,7 +1717,7 @@ func (db *DB) WriteSessionIncremental(
 	for _, resultUpdate := range update.ToolCallResultUpdates {
 		changed, inserted, err := applyToolCallResultUpdateTx(
 			tx, sessionID, resultUpdate,
-			update.BlockedResultCategories, db.ToolResultImages(),
+			update.BlockedResultCategories, policy,
 		)
 		if err != nil {
 			return false, err
@@ -1845,7 +1877,21 @@ type savedPin struct {
 func (db *DB) ReplaceSessionMessages(
 	sessionID string, msgs []Message,
 ) error {
-	msgs, _ = db.ProjectToolResultImages(msgs)
+	return db.replaceSessionMessages(sessionID, msgs, db.ToolResultImages())
+}
+
+// ReplaceSessionMessagesWithToolResultImages replaces messages with the
+// policy selected by the sync engine.
+func (db *DB) ReplaceSessionMessagesWithToolResultImages(
+	sessionID string, msgs []Message, policy config.ToolResultImages,
+) error {
+	return db.replaceSessionMessages(sessionID, msgs, policy)
+}
+
+func (db *DB) replaceSessionMessages(
+	sessionID string, msgs []Message, policy config.ToolResultImages,
+) error {
+	msgs, _ = ProjectToolResultImages(msgs, policy)
 	msgs = append([]Message(nil), msgs...)
 	_ = ValidateAndSanitize(nil, msgs, nil)
 	rawMessages := msgs
@@ -2144,7 +2190,9 @@ func (db *DB) ReplaceSessionContent(
 	sessionID string, msgs []Message,
 	signals SessionSignalUpdate, findings []SecretFinding,
 ) error {
-	return db.replaceSessionContent(sessionID, msgs, signals, findings, nil, nil)
+	return db.replaceSessionContent(
+		sessionID, msgs, signals, findings, nil, nil, db.ToolResultImages(),
+	)
 }
 
 // ReplaceSessionContentWithCheckpoint replaces a session's content and
@@ -2156,15 +2204,43 @@ func (db *DB) ReplaceSessionContentWithCheckpoint(
 	signals SessionSignalUpdate, findings []SecretFinding,
 	cp *ParserCheckpoint, blobs *ParserCheckpointBlobs,
 ) error {
-	return db.replaceSessionContent(sessionID, msgs, signals, findings, cp, blobs)
+	return db.replaceSessionContent(
+		sessionID, msgs, signals, findings, cp, blobs, db.ToolResultImages(),
+	)
+}
+
+// ReplaceSessionContentWithCheckpointAndToolResultImages replaces session
+// content with the policy selected by the sync engine.
+func (db *DB) ReplaceSessionContentWithCheckpointAndToolResultImages(
+	sessionID string, msgs []Message,
+	signals SessionSignalUpdate, findings []SecretFinding,
+	cp *ParserCheckpoint, blobs *ParserCheckpointBlobs,
+	policy config.ToolResultImages,
+) error {
+	return db.replaceSessionContent(
+		sessionID, msgs, signals, findings, cp, blobs, policy,
+	)
+}
+
+// ReplaceSessionContentWithToolResultImages replaces session content with the
+// policy selected by the sync engine.
+func (db *DB) ReplaceSessionContentWithToolResultImages(
+	sessionID string, msgs []Message,
+	signals SessionSignalUpdate, findings []SecretFinding,
+	policy config.ToolResultImages,
+) error {
+	return db.replaceSessionContent(
+		sessionID, msgs, signals, findings, nil, nil, policy,
+	)
 }
 
 func (db *DB) replaceSessionContent(
 	sessionID string, msgs []Message,
 	signals SessionSignalUpdate, findings []SecretFinding,
 	cp *ParserCheckpoint, blobs *ParserCheckpointBlobs,
+	policy config.ToolResultImages,
 ) error {
-	msgs, _ = db.ProjectToolResultImages(msgs)
+	msgs, _ = ProjectToolResultImages(msgs, policy)
 	if len(msgs) > 0 {
 		msgs = append([]Message(nil), msgs...)
 		_ = ValidateAndSanitize(nil, msgs, nil)
@@ -3208,7 +3284,7 @@ func (db *DB) SetToolCallSubagentSession(
 		tx, sessionID, ToolCallSubagentLink{
 			ToolUseID:         toolUseID,
 			SubagentSessionID: subagentSessionID,
-		}, nil,
+		}, nil, db.ToolResultImages(),
 	)
 	if err != nil {
 		return err
@@ -3273,6 +3349,7 @@ func soleToolResultEventTx(
 func applyToolCallSubagentLinkTx(
 	tx *sql.Tx, sessionID string, link ToolCallSubagentLink,
 	blockedResultCategories map[string]bool,
+	imagePolicy config.ToolResultImages,
 ) (bool, error) {
 	var toolName, category, currentSubagent, currentResultContent string
 	var currentResultContentLen, messageOrdinal, callIndex int
@@ -3323,6 +3400,10 @@ func applyToolCallSubagentLinkTx(
 	if blockedResultCategories[category] {
 		resultContent = ""
 	} else {
+		resultContent = projectToolResultImageContent(resultContent, imagePolicy)
+		resultContentLen = ResolveResultContentLength(
+			resultContent, resultContentLen,
+		)
 		// A linked result carries no events of its own, but the call it
 		// targets may already have one stored. Re-storing a summary the
 		// event repeats would undo the dedup on every incremental pass.

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -3312,6 +3312,7 @@ func (db *DB) SetToolCallSubagentSession(
 // loading content so repeated appends do not rescan the event history.
 func soleToolResultEventTx(
 	tx *sql.Tx, sessionID string, messageOrdinal, callIndex int,
+	imagePolicy config.ToolResultImages, summary string,
 ) ([]ToolResultEvent, error) {
 	var count int
 	var content sql.NullString
@@ -3343,7 +3344,9 @@ func soleToolResultEventTx(
 			sessionID, messageOrdinal, callIndex, err,
 		)
 	}
-	return []ToolResultEvent{{Content: content.String}}, nil
+	return []ToolResultEvent{{Content: projectToolResultEventForDedup(
+		content.String, summary, imagePolicy,
+	)}}, nil
 }
 
 func applyToolCallSubagentLinkTx(
@@ -3408,7 +3411,7 @@ func applyToolCallSubagentLinkTx(
 		// targets may already have one stored. Re-storing a summary the
 		// event repeats would undo the dedup on every incremental pass.
 		sole, err := soleToolResultEventTx(
-			tx, sessionID, messageOrdinal, callIndex,
+			tx, sessionID, messageOrdinal, callIndex, imagePolicy, resultContent,
 		)
 		if err != nil {
 			return false, err
@@ -3605,6 +3608,7 @@ func applyToolCallResultUpdateTx(
 
 		sole, err := soleToolResultEventTx(
 			tx, sessionID, position.MessageOrdinal, position.CallIndex,
+			imagePolicy, summary,
 		)
 		if err != nil {
 			return false, nil, err

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/export"
 )
 
@@ -32,6 +33,17 @@ type SessionBatchWrite struct {
 	RejectMessageCountDecrease bool
 	Checkpoint                 *ParserCheckpoint
 	CheckpointBlobs            *ParserCheckpointBlobs
+	// ToolResultImages overrides the DB policy for this sync-engine write.
+	ToolResultImages *config.ToolResultImages
+}
+
+func (db *DB) projectSessionBatchMessages(write SessionBatchWrite) []Message {
+	policy := db.ToolResultImages()
+	if write.ToolResultImages != nil {
+		policy = *write.ToolResultImages
+	}
+	projected, _ := ProjectToolResultImages(write.Messages, policy)
+	return projected
 }
 
 // SessionWouldShortenError reports a rejected message-count decrease.
@@ -134,7 +146,7 @@ func (db *DB) WriteSessionBatchContext(
 		if err != nil {
 			return result, err
 		}
-		write.Messages, _ = db.ProjectToolResultImages(write.Messages)
+		write.Messages = db.projectSessionBatchMessages(write)
 		if db.ArchiveContent().OmitsToolContent() {
 			write.Checkpoint, write.CheckpointBlobs = nil, nil
 		}
@@ -235,7 +247,7 @@ func (db *DB) WriteSessionBatchAtomic(
 
 	for i, write := range writes {
 		write = sanitizeSessionBatchWrite(write)
-		write.Messages, _ = db.ProjectToolResultImages(write.Messages)
+		write.Messages = db.projectSessionBatchMessages(write)
 		if db.ArchiveContent().OmitsToolContent() {
 			write.Checkpoint, write.CheckpointBlobs = nil, nil
 		}

--- a/internal/db/tool_result_images.go
+++ b/internal/db/tool_result_images.go
@@ -12,7 +12,6 @@ import (
 
 	"go.kenn.io/agentsview/internal/assets"
 	"go.kenn.io/agentsview/internal/config"
-	"go.kenn.io/agentsview/internal/parser"
 )
 
 // ToolImageStats describes inline image payloads found by the projection.
@@ -462,10 +461,6 @@ func projectToolResultEventForDedup(
 	projected, stats := StripToolResultImages(content)
 	if stats.Payloads == 0 {
 		return content
-	}
-	// Linked summaries use decoded text, while late summaries keep projected JSON.
-	if decoded := parser.DecodeContent(content); decoded == summary {
-		return decoded
 	}
 	return projected
 }

--- a/internal/db/tool_result_images.go
+++ b/internal/db/tool_result_images.go
@@ -442,6 +442,16 @@ func projectToolResultText(
 	return projected, stats
 }
 
+func projectToolResultImageContent(
+	content string, policy config.ToolResultImages,
+) string {
+	if policy != config.ToolResultImagesDrop {
+		return content
+	}
+	projected, _ := StripToolResultImages(content)
+	return projected
+}
+
 // SetToolResultImages stores the policy on a writable database handle.
 func (db *DB) SetToolResultImages(policy config.ToolResultImages) {
 	if db.readOnly {

--- a/internal/db/tool_result_images.go
+++ b/internal/db/tool_result_images.go
@@ -12,6 +12,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/assets"
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // ToolImageStats describes inline image payloads found by the projection.
@@ -449,6 +450,23 @@ func projectToolResultImageContent(
 		return content
 	}
 	projected, _ := StripToolResultImages(content)
+	return projected
+}
+
+func projectToolResultEventForDedup(
+	content, summary string, policy config.ToolResultImages,
+) string {
+	if policy != config.ToolResultImagesDrop {
+		return content
+	}
+	projected, stats := StripToolResultImages(content)
+	if stats.Payloads == 0 {
+		return content
+	}
+	// Linked summaries use decoded text, while late summaries keep projected JSON.
+	if decoded := parser.DecodeContent(content); decoded == summary {
+		return decoded
+	}
 	return projected
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -16838,19 +16838,22 @@ func (e *Engine) writeBatchWithOutcomeContext(
 					)
 					cp, blobs = nil, nil
 				}
-				werr = e.db.ReplaceSessionContentWithCheckpoint(
+				werr = e.db.ReplaceSessionContentWithCheckpointAndToolResultImages(
 					s.ID, msgs, update, findings, cp, blobs,
+					e.toolResultImages,
 				)
 			} else {
-				werr = e.db.ReplaceSessionContent(
-					s.ID, msgs, update, findings,
+				werr = e.db.ReplaceSessionContentWithToolResultImages(
+					s.ID, msgs, update, findings, e.toolResultImages,
 				)
 			}
 		} else if replaceMessages {
 			if msgs == nil {
 				msgs = []db.Message{}
 			}
-			werr = e.db.ReplaceSessionMessages(s.ID, msgs)
+			werr = e.db.ReplaceSessionMessagesWithToolResultImages(
+				s.ID, msgs, e.toolResultImages,
+			)
 		} else {
 			if !e.disableSignalRecompute {
 				update, findings = e.computeSignalsAndSecretsForStorage(s, msgs)
@@ -16988,7 +16991,7 @@ func (e *Engine) prepareSessionWriteContext(
 	if err != nil {
 		return db.Session{}, nil, sessionWritePreserved, err
 	}
-	msgs, _ = e.db.ProjectToolResultImages(msgs)
+	msgs, _ = db.ProjectToolResultImages(msgs, e.toolResultImages)
 	s, err := toDBSessionContext(ctx, pw)
 	if err != nil {
 		return db.Session{}, nil, sessionWritePreserved, err
@@ -17039,7 +17042,7 @@ func (e *Engine) prepareSessionWriteContext(
 	} else if mergedMsgs != nil {
 		parsedMsgs := msgs
 		msgs = mergedMsgs
-		msgs, _ = e.db.ProjectToolResultImages(msgs)
+		msgs, _ = db.ProjectToolResultImages(msgs, e.toolResultImages)
 		applyVisualStudioCopilotArchiveSessionFields(
 			&s, archived, parsedMsgs, msgs,
 		)
@@ -18103,9 +18106,10 @@ func (e *Engine) writeBatchBulkWithOutcomeContext(
 		identityObservation, hasIdentityObservation :=
 			e.projectIdentityObservationForWrite(pw, s)
 		writes = append(writes, db.SessionBatchWrite{
-			Session:     s,
-			Messages:    msgs,
-			UsageEvents: usageEvents,
+			Session:          s,
+			Messages:         msgs,
+			UsageEvents:      usageEvents,
+			ToolResultImages: &e.toolResultImages,
 			IdentityObservation: identityObservationOrZero(
 				identityObservation, hasIdentityObservation,
 			),
@@ -18721,7 +18725,7 @@ func (e *Engine) writeIncremental(
 		},
 		e.blockedResultCategories,
 	)
-	dbMsgs, _ = e.db.ProjectToolResultImages(dbMsgs)
+	dbMsgs, _ = db.ProjectToolResultImages(dbMsgs, e.toolResultImages)
 	// The incremental append path bypasses prepareSessionWrite, so run
 	// the central validation/sanitization pass on the new message rows
 	// here to keep coverage uniform across write paths. The fix counts
@@ -18854,7 +18858,7 @@ func (e *Engine) writeIncremental(
 			}
 		}
 	}
-	signalsMaintained, err := e.db.WriteSessionIncremental(
+	signalsMaintained, err := e.db.WriteSessionIncrementalWithToolResultImages(
 		inc.sessionID,
 		dbMsgs,
 		db.IncrementalSessionUpdate{
@@ -18879,6 +18883,7 @@ func (e *Engine) writeIncremental(
 			BlockedResultCategories:  e.blockedResultCategories,
 			SignalMaintainer:         maintainer,
 		},
+		e.toolResultImages,
 	)
 	if err != nil {
 		return fmt.Errorf(
@@ -18942,7 +18947,9 @@ func (e *Engine) writeMessages(
 
 	// No existing messages — insert all.
 	if maxOrd < 0 {
-		if err := e.db.InsertMessages(msgs); err != nil {
+		if err := e.db.InsertMessagesWithToolResultImages(
+			msgs, e.toolResultImages,
+		); err != nil {
 			return fmt.Errorf(
 				"insert messages for %s: %w",
 				sessionID, err,
@@ -18965,7 +18972,9 @@ func (e *Engine) writeMessages(
 		return nil
 	}
 
-	if err := e.db.InsertMessages(msgs); err != nil {
+	if err := e.db.InsertMessagesWithToolResultImages(
+		msgs, e.toolResultImages,
+	); err != nil {
 		return fmt.Errorf(
 			"append messages for %s: %w",
 			sessionID, err,
@@ -19038,7 +19047,9 @@ func (e *Engine) writeSessionFullWithResolver(
 		if msgs == nil {
 			msgs = []db.Message{}
 		}
-		if err := e.db.ReplaceSessionMessages(s.ID, msgs); err != nil {
+		if err := e.db.ReplaceSessionMessagesWithToolResultImages(
+			s.ID, msgs, e.toolResultImages,
+		); err != nil {
 			log.Printf(
 				"replace messages for %s: %v",
 				s.ID, err,
@@ -19064,8 +19075,9 @@ func (e *Engine) writeSessionFullWithResolver(
 				checkpoint, checkpointBlobs = nil, nil
 			}
 		}
-		if err := e.db.ReplaceSessionContentWithCheckpoint(
+		if err := e.db.ReplaceSessionContentWithCheckpointAndToolResultImages(
 			s.ID, msgs, update, findings, checkpoint, checkpointBlobs,
+			e.toolResultImages,
 		); err != nil {
 			log.Printf(
 				"replace messages for %s: %v",

--- a/internal/sync/tool_result_images_test.go
+++ b/internal/sync/tool_result_images_test.go
@@ -234,6 +234,84 @@ func TestEngineImagePolicyOverridesDatabaseForBulkAppendAndLink(t *testing.T) {
 	assert.Equal(t, len(linkWant), messages[0].ToolCalls[0].ResultContentLength)
 }
 
+func TestEngineImagePolicyDeduplicatesHistoricalRawLinkedResult(t *testing.T) {
+	const raw = `[{"type":"text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AAEC"},{"type":"text","text":"after"}]`
+	database := dbtest.OpenTestDB(t)
+	database.SetToolResultImages(config.ToolResultImagesKeep)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "historical-link", Agent: string(parser.AgentClaude), Project: "project",
+		Machine: "local", MessageCount: 1,
+	}))
+	require.NoError(t, database.InsertMessages([]db.Message{{
+		SessionID: "historical-link", Ordinal: 0, Role: "assistant",
+		ToolCalls: []db.ToolCall{{
+			ToolUseID: "link-call", ToolName: "Task", Category: "Task",
+			ResultContent: raw,
+			ResultEvents: []db.ToolResultEvent{{
+				ToolUseID: "link-call", Source: "tool", Status: "completed",
+				Content: raw,
+			}},
+		}},
+	}}))
+
+	engine := NewEngine(database, EngineConfig{
+		Machine: "local", ToolResultImages: config.ToolResultImagesDrop,
+	})
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.writeIncremental(&incrementalUpdate{
+		sessionID: "historical-link", machine: "local", project: "project", msgCount: 1,
+		links: []parser.ClaudeSubagentLink{{
+			ToolUseID: "link-call", ResultContentRaw: raw,
+			ResultContentLen: len(raw), HasResult: true,
+		}},
+	}))
+
+	var storedSummary string
+	require.NoError(t, database.Reader().QueryRowContext(
+		t.Context(), "SELECT COALESCE(result_content, '') FROM tool_calls WHERE session_id = ?", "historical-link",
+	).Scan(&storedSummary))
+	assert.Empty(t, storedSummary)
+}
+
+func TestEngineImagePolicyDeduplicatesLateProjectedResult(t *testing.T) {
+	const raw = `[{"type":"text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AAEC"},{"type":"text","text":"after"}]`
+	const want = `[{"type":"text","text":"before"},{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1},{"type":"text","text":"after"}]`
+	database := dbtest.OpenTestDB(t)
+	database.SetToolResultImages(config.ToolResultImagesKeep)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "late-result", Agent: string(parser.AgentCodex), Project: "project",
+		Machine: "local", MessageCount: 1,
+	}))
+	require.NoError(t, database.InsertMessages([]db.Message{{
+		SessionID: "late-result", Ordinal: 0, Role: "assistant",
+		ToolCalls: []db.ToolCall{{ToolUseID: "late-call", ToolName: "Bash", Category: "Bash"}},
+	}}))
+
+	engine := NewEngine(database, EngineConfig{
+		Machine: "local", ToolResultImages: config.ToolResultImagesDrop,
+	})
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.writeIncremental(&incrementalUpdate{
+		sessionID: "late-result", machine: "local", project: "project", msgCount: 1,
+		toolCallUpdates: []parser.ParsedToolCallUpdate{{
+			ToolUseID: "late-call", MessageOrdinal: 0, CallIndex: 0,
+			ResultEvents: []parser.ParsedToolResultEvent{{
+				ToolUseID: "late-call", Source: "function_call_output", Content: raw,
+			}},
+		}},
+	}))
+
+	var storedSummary, storedEvent string
+	require.NoError(t, database.Reader().QueryRowContext(
+		t.Context(), "SELECT COALESCE(result_content, '') FROM tool_calls WHERE session_id = ?", "late-result",
+	).Scan(&storedSummary))
+	require.NoError(t, database.Reader().QueryRowContext(
+		t.Context(), "SELECT content FROM tool_result_events WHERE session_id = ?", "late-result",
+	).Scan(&storedEvent))
+	assert.Empty(t, storedSummary)
+	assert.Equal(t, want, storedEvent)
+}
+
 func TestReadOnlyResyncReplacementCarriesDropPolicy(t *testing.T) {
 	root := t.TempDir()
 	archivePath := filepath.Join(t.TempDir(), "archive.db")

--- a/internal/sync/tool_result_images_test.go
+++ b/internal/sync/tool_result_images_test.go
@@ -236,6 +236,7 @@ func TestEngineImagePolicyOverridesDatabaseForBulkAppendAndLink(t *testing.T) {
 
 func TestEngineImagePolicyDeduplicatesHistoricalRawLinkedResult(t *testing.T) {
 	const raw = `[{"type":"text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AAEC"},{"type":"text","text":"after"}]`
+	const linkWant = "beforeafter"
 	database := dbtest.OpenTestDB(t)
 	database.SetToolResultImages(config.ToolResultImagesKeep)
 	require.NoError(t, database.UpsertSession(db.Session{
@@ -270,7 +271,14 @@ func TestEngineImagePolicyDeduplicatesHistoricalRawLinkedResult(t *testing.T) {
 	require.NoError(t, database.Reader().QueryRowContext(
 		t.Context(), "SELECT COALESCE(result_content, '') FROM tool_calls WHERE session_id = ?", "historical-link",
 	).Scan(&storedSummary))
-	assert.Empty(t, storedSummary)
+	assert.Equal(t, linkWant, storedSummary)
+
+	messages, err := database.GetAllMessages(t.Context(), "historical-link")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].ToolCalls, 1)
+	assert.Equal(t, linkWant, messages[0].ToolCalls[0].ResultContent)
+	assert.Equal(t, len(linkWant), messages[0].ToolCalls[0].ResultContentLength)
 }
 
 func TestEngineImagePolicyDeduplicatesLateProjectedResult(t *testing.T) {

--- a/internal/sync/tool_result_images_test.go
+++ b/internal/sync/tool_result_images_test.go
@@ -333,7 +333,7 @@ func TestCodexImageRetentionAcrossFullAndLateResults(t *testing.T) {
 			)
 			require.NoError(t, os.WriteFile(path, []byte(transcript), 0o600))
 			database := openTestDB(t)
-			database.SetToolResultImages(config.ToolResultImagesDrop)
+			database.SetToolResultImages(config.ToolResultImagesKeep)
 			engine := NewEngine(database, EngineConfig{Machine: "local", Ephemeral: true,
 				AgentDirs:        map[parser.AgentType][]string{parser.AgentCodex: {root}},
 				ToolResultImages: config.ToolResultImagesDrop, StagedCodexParseMinBytes: threshold,

--- a/internal/sync/tool_result_images_test.go
+++ b/internal/sync/tool_result_images_test.go
@@ -149,6 +149,91 @@ func TestIncrementalSubagentLinksPreserveDecodedToolResults(t *testing.T) {
 	}
 }
 
+func TestEngineImagePolicyOverridesDatabaseForBulkAppendAndLink(t *testing.T) {
+	const raw = `[ {"type":"text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AAEC"},{"type":"text","text":"after"} ]`
+	const want = `[{"type":"text","text":"before"},{"byte_size":3,"media_type":"image/png","sha256":"","text":"[Image: image/png, 3 bytes]","type":"agentsview_image","version":1},{"type":"text","text":"after"}]`
+	const linkWant = "beforeafter"
+
+	database := dbtest.OpenTestDB(t)
+	database.SetToolResultImages(config.ToolResultImagesKeep)
+	engine := NewEngine(database, EngineConfig{
+		Machine:          "local",
+		ToolResultImages: config.ToolResultImagesDrop,
+	})
+	t.Cleanup(engine.Close)
+
+	bulkID := "engine-policy-bulk"
+	bulk := engine.writeBatchBulkWithOutcome([]pendingWrite{{
+		sess: parser.ParsedSession{
+			ID: bulkID, Project: "project", Machine: "local",
+			Agent: parser.AgentClaude, StartedAt: time.Unix(1, 0),
+		},
+		msgs: []parser.ParsedMessage{{
+			Ordinal: 0, Role: parser.RoleAssistant, Content: "answer",
+			ToolCalls: []parser.ParsedToolCall{{
+				ToolUseID: "bulk-call", ToolName: "Bash", Category: "Bash",
+				ResultEvents: []parser.ParsedToolResultEvent{{
+					ToolUseID: "bulk-call", Source: "tool", Status: "completed",
+					Content: raw,
+				}},
+			}},
+		}},
+	}}, true)
+	require.Equal(t, 1, bulk.writtenSessions)
+	require.Equal(t, 0, bulk.failedSessions)
+
+	messages, err := database.GetAllMessages(t.Context(), bulkID)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].ToolCalls, 1)
+	assert.Equal(t, want, messages[0].ToolCalls[0].ResultContent)
+	assert.Equal(t, len(want), messages[0].ToolCalls[0].ResultContentLength)
+
+	appendMessages := append([]db.Message(nil), messages...)
+	appendMessages = append(appendMessages, db.Message{
+		SessionID: bulkID, Ordinal: 1, Role: "assistant",
+		ToolCalls: []db.ToolCall{{
+			ToolUseID: "append-call", ResultContent: raw,
+			ResultEvents: []db.ToolResultEvent{{
+				ToolUseID: "append-call", Source: "tool", Status: "completed",
+				Content: raw,
+			}},
+		}},
+	})
+	require.NoError(t, engine.writeMessages(bulkID, appendMessages))
+
+	messages, err = database.GetAllMessages(t.Context(), bulkID)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	assert.Equal(t, want, messages[1].ToolCalls[0].ResultContent)
+	assert.Equal(t, len(want), messages[1].ToolCalls[0].ResultContentLength)
+
+	linkID := "engine-policy-link"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: linkID, Agent: string(parser.AgentClaude), Project: "project",
+		Machine: "local", MessageCount: 1,
+	}))
+	require.NoError(t, database.InsertMessages([]db.Message{{
+		SessionID: linkID, Ordinal: 0, Role: "assistant",
+		ToolCalls: []db.ToolCall{{
+			ToolUseID: "link-call", ToolName: "Task", Category: "Task",
+		}},
+	}}))
+	require.NoError(t, engine.writeIncremental(&incrementalUpdate{
+		sessionID: linkID, machine: "local", project: "project", msgCount: 1,
+		links: []parser.ClaudeSubagentLink{{
+			ToolUseID: "link-call", ResultContentRaw: raw,
+			ResultContentLen: len(raw), HasResult: true,
+		}},
+	}))
+
+	messages, err = database.GetAllMessages(t.Context(), linkID)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, linkWant, messages[0].ToolCalls[0].ResultContent)
+	assert.Equal(t, len(linkWant), messages[0].ToolCalls[0].ResultContentLength)
+}
+
 func TestReadOnlyResyncReplacementCarriesDropPolicy(t *testing.T) {
 	root := t.TempDir()
 	archivePath := filepath.Join(t.TempDir(), "archive.db")


### PR DESCRIPTION
The sync engine now applies its configured existing `keep` or `drop` tool-result image policy across full, bulk, replacement, staged, incremental, late-result, and linked-subagent writes, even when the database handle has a different default.

The change keeps the current placeholder projection, text and metadata retention, event ordering, result lengths, deduplication, and resync behavior. It adds no retention value, schema field, asset write, or image-loading path.

Refs #1718, slice 3
