### PR TITLE
fix(parser): apply Claude queue links incrementally

### DIFF
--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -720,8 +720,7 @@ var ErrDAGDetected = fmt.Errorf(
 
 // ErrClaudeIncrementalNeedsFullParse signals that appended Claude
 // lines contain content the incremental path cannot stitch into
-// already-stored rows (renames, late identity fields, and subagent-map
-// repairs for tool calls outside the append).
+// already-stored rows (renames and late identity fields).
 var ErrClaudeIncrementalNeedsFullParse = fmt.Errorf(
 	"incremental parse: appended Claude lines require full parse",
 )
@@ -898,17 +897,17 @@ func claudeParseSessionFrom(
 	}
 
 	// Queue/progress events can repair subagent linkage on an already-stored
-	// tool call. If the mapped tool_use_id is not introduced in this append,
-	// incremental parsing would advance file_size without updating that row.
-	if needsClaudeFullParseForSubagentMap(entries, subagentMap) {
-		return nil, nil, time.Time{}, 0, ErrClaudeIncrementalNeedsFullParse
-	}
+	// tool call. Carry those mappings through the existing atomic incremental
+	// link writer instead of re-parsing the whole transcript. Map-derived
+	// links come first so the database's first-non-empty-wins rule preserves
+	// the same precedence as the full parser.
+	links := claudeSubagentMapLinks(subagentMap)
 	if needsClaudeFullParseForWebSearchCounts(entries) {
 		return nil, nil, time.Time{}, 0, ErrClaudeIncrementalNeedsFullParse
 	}
 
 	if len(entries) == 0 && len(queuedCommands) == 0 {
-		return nil, nil, latestTS, consumed, nil
+		return nil, links, latestTS, consumed, nil
 	}
 
 	// Fork detection only matters when the full parser would actually
@@ -943,7 +942,7 @@ func claudeParseSessionFrom(
 		return nil, nil, time.Time{}, 0, ErrDAGDetected
 	}
 
-	links := collectClaudeSubagentLinks(entries)
+	links = append(links, collectClaudeSubagentLinks(entries)...)
 	links = append(
 		links, collectClaudeUnmatchedToolResults(entries, links)...,
 	)
@@ -1089,20 +1088,23 @@ func collectClaudeSubagentLinks(entries []dagEntry) []ClaudeSubagentLink {
 	return links
 }
 
-func needsClaudeFullParseForSubagentMap(
-	entries []dagEntry, subagentMap map[string]string,
-) bool {
-	if len(subagentMap) == 0 {
-		return false
-	}
-
-	appendedToolUseIDs := claudeAppendedToolUseIDs(entries)
+func claudeSubagentMapLinks(
+	subagentMap map[string]string,
+) []ClaudeSubagentLink {
+	toolUseIDs := make([]string, 0, len(subagentMap))
 	for toolUseID := range subagentMap {
-		if _, ok := appendedToolUseIDs[toolUseID]; !ok {
-			return true
-		}
+		toolUseIDs = append(toolUseIDs, toolUseID)
 	}
-	return false
+	slices.Sort(toolUseIDs)
+
+	links := make([]ClaudeSubagentLink, 0, len(toolUseIDs))
+	for _, toolUseID := range toolUseIDs {
+		links = append(links, ClaudeSubagentLink{
+			ToolUseID:         toolUseID,
+			SubagentSessionID: subagentMap[toolUseID],
+		})
+	}
+	return links
 }
 
 func claudeAppendedToolUseIDs(entries []dagEntry) map[string]struct{} {

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1004,9 +1004,12 @@ func claudeSessionIdentityUpdate(line string, stored claudeStoredIdentity) bool 
 // collectClaudeUnmatchedToolResults returns result links for appended
 // tool_result blocks whose tool_use lives outside the appended window.
 // In-append results pair at write time and agentId-linked results are
-// already carried by collectClaudeSubagentLinks. isMeta carriers are
-// skipped: the full parser drops those lines entirely, so their result
-// content never reaches the stored tool call there either. Results
+// already carried by collectClaudeSubagentLinks. Only result-bearing
+// links suppress a late result: a queue/progress mapping for the same
+// tool_use carries no content, so its result still has to be copied
+// here. isMeta carriers are skipped: the full parser drops those lines
+// entirely, so their result content never reaches the stored tool call
+// there either. Results
 // whose tool_use id is unknown to the store no-op at apply time,
 // matching the full parser's unpaired-result behavior.
 func collectClaudeUnmatchedToolResults(
@@ -1014,7 +1017,9 @@ func collectClaudeUnmatchedToolResults(
 ) []ClaudeSubagentLink {
 	linked := make(map[string]struct{}, len(agentLinks))
 	for _, l := range agentLinks {
-		linked[l.ToolUseID] = struct{}{}
+		if l.HasResult {
+			linked[l.ToolUseID] = struct{}{}
+		}
 	}
 	appendedToolUse := make(map[string]struct{})
 	var out []ClaudeSubagentLink

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -2201,7 +2201,7 @@ func TestParseClaudeSession_RecordsLinearParseVerdict(t *testing.T) {
 		"single-root resolvable chain must record a DAG verdict")
 }
 
-func TestParseClaudeSessionFrom_QueueOperationOnlyFallsBack(t *testing.T) {
+func TestParseClaudeSessionFrom_QueueOperationOnlyAppliesLink(t *testing.T) {
 	t.Parallel()
 
 	initial := testjsonl.JoinJSONL(
@@ -2227,12 +2227,19 @@ func TestParseClaudeSessionFrom_QueueOperationOnlyFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = callParseClaudeSessionFrom(path, offset, 2, "a1")
-	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
-	assert.True(t, IsIncrementalFullParseFallback(err))
+	msgs, links, _, consumed, err := callParseClaudeSessionFromWithLinks(
+		path, offset, 2, "a1",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+	assert.Equal(t, int64(len(appended)), consumed)
+	assert.Equal(t, []ClaudeSubagentLink{{
+		ToolUseID:         "toolu_queue",
+		SubagentSessionID: "agent-childqueue",
+	}}, links)
 }
 
-func TestParseClaudeSessionFrom_ProgressOnlyFallsBack(t *testing.T) {
+func TestParseClaudeSessionFrom_ProgressOnlyAppliesLink(t *testing.T) {
 	t.Parallel()
 
 	initial := testjsonl.JoinJSONL(
@@ -2258,9 +2265,16 @@ func TestParseClaudeSessionFrom_ProgressOnlyFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = callParseClaudeSessionFrom(path, offset, 2, "a1")
-	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
-	assert.True(t, IsIncrementalFullParseFallback(err))
+	msgs, links, _, consumed, err := callParseClaudeSessionFromWithLinks(
+		path, offset, 2, "a1",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+	assert.Equal(t, int64(len(appended)), consumed)
+	assert.Equal(t, []ClaudeSubagentLink{{
+		ToolUseID:         "toolu_progress",
+		SubagentSessionID: "agent-childprogress",
+	}}, links)
 }
 
 // Sanity: a benign incremental append (one user, one assistant

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -12733,6 +12733,45 @@ func TestIncrementalSync_ClaudeProgressOnlyRepairsStoredSubagentMapping(
 	)
 }
 
+func TestIncrementalSync_ClaudeProgressWithLateResultPersistsBoth(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_progress_late","name":"Agent","input":{"description":"inspect","subagent_type":"Explore","prompt":"inspect"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "progress-late-result.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := testjsonl.JoinJSONL(
+		`{"type":"progress","timestamp":"2024-01-01T10:00:02Z","parentToolUseID":"toolu_progress_late","data":{"type":"agent_progress","agentId":"childlate"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_progress_late","content":"inspected"}]}}`,
+	) + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append progress mapping and result")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "progress-late-result")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(
+		t, "agent-childlate", msgs[1].ToolCalls[0].SubagentSessionID,
+		"subagent_session_id",
+	)
+	assert.Equal(
+		t, "inspected", msgs[1].ToolCalls[0].ResultContent,
+		"result_content",
+	)
+}
+
 // TestIncrementalSync_ClaudeFileReplaced verifies that when a
 // session file is replaced atomically (new inode/device), the
 // sync engine detects the identity change and falls back to a


### PR DESCRIPTION
## Summary

- Apply Claude queue and progress subagent links incrementally.
- Preserve deterministic ordering and existing first-link precedence.
- Keep link-only appends on the incremental sync path.

## Why

Active Claude sessions append queue and progress events. Replacing the stored session for each event repeatedly parses large JSONL files and drives sustained CPU use.

## Tests

- go test ./internal/parser -count=1
- focused incremental sync tests for Claude queue and progress links
- focused database incremental-link tests
- go vet ./internal/parser