### PR TITLE
fix(parser): validate DeepSeek Harness v0 provenance ranges

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1670,7 +1670,7 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
 
 ## DeepSeek Harness (`deepseek-harness`)
 
-- **Format:** Version `0` session JSONL under
+- **Format:** Agentsview reads version `0` session JSONL under
   `<sessions-root>/<project>/<encoded-session-id>/session.jsonl`, or the
   default checksummed multi-frame zstd encoding at `session.jsonl.zstd`. The
   immutable header records session identity, cwd, creation time, seed lineage,
@@ -1680,13 +1680,31 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   strings and are injectively encoded before use as a directory name. A
   sessions root belongs to one physical encoding; the upstream backend rejects
   an opposite-suffix artifact rather than providing mixed-root fallback or
-  migration.
+  migration. `sourceEventSeqs` uses non-negative safe integers and inclusive
+  `[start, end]` ranges, mixed entry by entry: `[[138, 144]]` represents seven
+  sequences. This is intentional storage compression, introduced in upstream
+  commit
+  [df76bc6](https://github.com/deepseek-ai/deepseek-harness/commit/df76bc695b4bdff093369ab22a506cd37ca087c1).
 
 - **Evidence:** `source`.
 
 - **Upstream:** Clone `https://github.com/deepseek-ai/deepseek-harness.git` at
-  `47f943859bef60e4160492346772ded9b24f765a`. See the pinned
-  [JSONL layout, header, and scanner](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/session/session-persistence-jsonl/src/format.ts),
+  `56c4c3e47c195ff5edbfe3d307bdef81f3de348b` (reverified 2026-09-11). The
+  [frozen version-0 codec](https://github.com/deepseek-ai/deepseek-harness/blob/56c4c3e47c195ff5edbfe3d307bdef81f3de348b/packages/session/session-format-v0-to-v1/src/codec.ts),
+
+    [released event inventory](https://github.com/deepseek-ai/deepseek-harness/blob/56c4c3e47c195ff5edbfe3d307bdef81f3de348b/packages/session/session-format-v0-to-v1/src/dispositions.ts),
+    and
+    [version-0 envelope validation](https://github.com/deepseek-ai/deepseek-harness/blob/56c4c3e47c195ff5edbfe3d307bdef81f3de348b/packages/session/session-format-v0-to-v1/src/validation.ts)
+    define the generation this parser reads. The codec accepts mixed
+    provenance ranges, bounds their expanded count by the owning event sequence,
+    and requires strictly increasing sequences when ranges occur. Agentsview
+    validates those rules without allocating an unused expanded list. Version 0
+    retains `assistant/chunk` and `tool/code-dispatch*`, allows assistant
+    provenance, and uses `start`/`end` for surface replacements.
+
+    The original format evidence remains pinned at
+    `47f943859bef60e4160492346772ded9b24f765a` for the
+    [JSONL layout, header, and scanner](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/session/session-persistence-jsonl/src/format.ts),
 
     [multi-frame zstd backend](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/session/session-persistence-jsonl/src/index.ts),
 
@@ -1729,7 +1747,21 @@ preservation of archived messages for OpenCode, Kilo, MiMoCode, and Icodemate.
   Plain and zstd artifacts in one session directory are treated as one logical
   source and rejected while both exist; a change maps directly to the
   surviving sibling once that conflict is removed. The optional Harness SQLite
-  persistence backend is not supported.
+  persistence backend is not supported. The updated inventory accepts all
+  released version-0 event names, including `model/selection`, delivery
+  tracking, subagent model policy, and team events. These metadata events do
+  not add transcript rows; model-selection reasoning effort is not imported.
+
+- **Later formats:** The reverified upstream
+  [session schema](https://github.com/deepseek-ai/deepseek-harness/blob/56c4c3e47c195ff5edbfe3d307bdef81f3de348b/packages/core/session/src/types.ts)
+  is version `3`. Agentsview still rejects versions `1` through `3` and does
+  not run upstream's migrations. The current
+  [generated event inventory](https://github.com/deepseek-ai/deepseek-harness/blob/56c4c3e47c195ff5edbfe3d307bdef81f3de348b/packages/core/session/src/known-event-types.ts)
+  includes later events such as `assistant/attempt`, `system/message`, and
+  `tool/ptc-dispatch*`; these do not belong to the frozen version-0 inventory.
+  Version-3 system messages and `startSeq`/`endSeq` surface replacements need
+  a separate format update. Accepting compressed provenance and version-0
+  metadata does not add support for later session formats.
 
 ## OpenClaw (`openclaw`)
 

--- a/internal/parser/deepseek_harness_format.go
+++ b/internal/parser/deepseek_harness_format.go
@@ -80,7 +80,7 @@ var deepSeekHarnessKnownEvents = map[string]struct{}{
 	"compaction/end": {}, "compaction/prune": {}, "compaction/start": {},
 	"compaction/summary": {}, "feedback/record": {}, "goal/change": {},
 	"hook/invoked": {}, "hook/result": {}, "llm/retry": {},
-	"llm/retry-started": {}, "permission/preset": {}, "plan/mode": {},
+	"llm/retry-started": {}, "model/selection": {}, "permission/preset": {}, "plan/mode": {},
 	"request/context": {}, "request/header": {}, "sandbox/mode": {},
 	"schedule/change": {}, "session/end-seed": {}, "session/title": {},
 	"session/title-llm-request": {}, "step/end": {}, "step/start": {},

--- a/internal/parser/deepseek_harness_format.go
+++ b/internal/parser/deepseek_harness_format.go
@@ -674,9 +674,7 @@ func parseDeepSeekHarnessEvent(
 		)
 	}
 	if hasSourceEventSeqs {
-		if _, err := deepSeekHarnessSafeIntArray(sourceEventSeqs, true); err != nil {
-			return deepSeekHarnessEvent{}, errors.New("event sourceEventSeqs is invalid")
-		}
+		_ = deepSeekHarnessSafeSourceEventSeqs(sourceEventSeqs)
 	}
 	if hasSurfaceOp {
 		if err := validateDeepSeekHarnessSurfaceOp(surfaceOp); err != nil {
@@ -906,6 +904,22 @@ func deepSeekHarnessSafeIntArray(raw jsontext.Value, nonNegative bool) ([]int64,
 		out = append(out, value)
 	}
 	return out, nil
+}
+
+func deepSeekHarnessSafeSourceEventSeqs(raw jsontext.Value) []int64 {
+	flat, err := deepSeekHarnessSafeIntArray(raw, true)
+	if err == nil {
+		return flat
+	}
+	var nested [][]int64
+	if err := json.Unmarshal(raw, &nested); err != nil {
+		return nil
+	}
+	var out []int64
+	for _, inner := range nested {
+		out = append(out, inner...)
+	}
+	return out
 }
 
 func deepSeekHarnessStringArray(raw jsontext.Value) ([]string, error) {

--- a/internal/parser/deepseek_harness_format.go
+++ b/internal/parser/deepseek_harness_format.go
@@ -72,6 +72,7 @@ func (err deepSeekHarnessUnsupportedError) Error() string {
 	return err.message
 }
 
+// Released version-0 inventory; see the pinned provenance in session-format-sources.md.
 var deepSeekHarnessKnownEvents = map[string]struct{}{
 	"agent-preset/selected": {}, "agent/inbox/spliced": {},
 	"approval/asked": {}, "approval/decided": {}, "approval/policy": {},
@@ -83,8 +84,11 @@ var deepSeekHarnessKnownEvents = map[string]struct{}{
 	"llm/retry-started": {}, "model/selection": {}, "permission/preset": {}, "plan/mode": {},
 	"request/context": {}, "request/header": {}, "sandbox/mode": {},
 	"schedule/change": {}, "session/end-seed": {}, "session/title": {},
-	"session/title-llm-request": {}, "step/end": {}, "step/start": {},
-	"subagent/descriptor": {}, "todo/write": {},
+	"session-log-deepseek/delivery-accepted": {},
+	"session/title-llm-request":              {}, "step/end": {}, "step/start": {},
+	"subagent/descriptor": {}, "subagent/model-selection-policy": {},
+	"team/member": {}, "team/message/delivered": {},
+	"team/message/queued": {}, "team/task": {}, "todo/write": {},
 	"tool-workflow/agent-end": {}, "tool-workflow/agent-start": {},
 	"tool-workflow/run-end": {}, "tool-workflow/run-start": {},
 	"tool/call": {}, "tool/code-dispatch": {},
@@ -674,7 +678,9 @@ func parseDeepSeekHarnessEvent(
 		)
 	}
 	if hasSourceEventSeqs {
-		_ = deepSeekHarnessSafeSourceEventSeqs(sourceEventSeqs)
+		if err := validateDeepSeekHarnessSourceEventSeqs(sourceEventSeqs, seq); err != nil {
+			return deepSeekHarnessEvent{}, fmt.Errorf("event sourceEventSeqs is invalid: %w", err)
+		}
 	}
 	if hasSurfaceOp {
 		if err := validateDeepSeekHarnessSurfaceOp(surfaceOp); err != nil {
@@ -906,20 +912,46 @@ func deepSeekHarnessSafeIntArray(raw jsontext.Value, nonNegative bool) ([]int64,
 	return out, nil
 }
 
-func deepSeekHarnessSafeSourceEventSeqs(raw jsontext.Value) []int64 {
-	flat, err := deepSeekHarnessSafeIntArray(raw, true)
-	if err == nil {
-		return flat
+func validateDeepSeekHarnessSourceEventSeqs(raw jsontext.Value, maxEntries int64) error {
+	if raw.Kind() != '[' {
+		return errors.New("expected array")
 	}
-	var nested [][]int64
-	if err := json.Unmarshal(raw, &nested); err != nil {
-		return nil
+	var entries []jsontext.Value
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return err
 	}
-	var out []int64
-	for _, inner := range nested {
-		out = append(out, inner...)
+	// Lineage is not used for transcript reconstruction. Validate inclusive
+	// ranges and their expanded count without allocating the expanded list.
+	previous := int64(-1)
+	hasRange, increasing := false, true
+	for _, entry := range entries {
+		var start, end int64
+		if entry.Kind() == '[' {
+			pair, err := deepSeekHarnessSafeIntArray(entry, true)
+			if err != nil || len(pair) != 2 || pair[0] > pair[1] {
+				return errors.New("expected safe integer range [start, end] with start <= end")
+			}
+			start, end = pair[0], pair[1]
+			hasRange = true
+		} else {
+			value, err := deepSeekHarnessRequiredSafeInt(map[string]jsontext.Value{"value": entry}, "value", true)
+			if err != nil {
+				return err
+			}
+			start, end = value, value
+		}
+		count := end - start + 1
+		if count > maxEntries {
+			return errors.New("expanded sources exceed event sequence")
+		}
+		maxEntries -= count
+		increasing = increasing && start > previous
+		previous = end
 	}
-	return out
+	if hasRange && !increasing {
+		return errors.New("ranges must be strictly increasing")
+	}
+	return nil
 }
 
 func deepSeekHarnessStringArray(raw jsontext.Value) ([]string, error) {

--- a/internal/parser/deepseek_harness_test.go
+++ b/internal/parser/deepseek_harness_test.go
@@ -776,6 +776,22 @@ func TestDeepSeekHarnessFormatErrorsAndCrashTails(t *testing.T) {
 		assert.Empty(t, result.Messages)
 	})
 
+	t.Run("model/selection accepted", func(t *testing.T) {
+		records := []any{
+			deepSeekHarnessFixtureHeader("model-select", deepSeekHarnessFixtureCwd, nil),
+			map[string]any{
+				"type": "model/selection", "seq": 0, "time": 1700000000001,
+				"data": map[string]any{"provider": "deepseek-official", "model": "deepseek-v4-flash", "reasoningEffort": "high"},
+			},
+			deepSeekHarnessFixtureEvent(1, "turn/start", map[string]any{"turn": 1}, nil),
+			deepSeekHarnessFixtureEvent(2, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
+		}
+		path := writeDeepSeekHarnessFixture(t, t.TempDir(), "model-select", deepSeekHarnessFixtureCwd, "plain", records)
+		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
+		require.NoError(t, err)
+		assert.Len(t, result.Messages, 0)
+	})
+
 	t.Run("unsafe event integer", func(t *testing.T) {
 		records := []any{
 			deepSeekHarnessFixtureHeader("unsafe-int", deepSeekHarnessFixtureCwd, nil),

--- a/internal/parser/deepseek_harness_test.go
+++ b/internal/parser/deepseek_harness_test.go
@@ -693,6 +693,83 @@ func TestDeepSeekHarnessTornZstdFrameRetainsRecoveredEvents(t *testing.T) {
 	assert.Equal(t, "recovered interrupted reply", result.Messages[2].Content)
 }
 
+func TestDeepSeekHarnessKnownV0Events(t *testing.T) {
+	for _, eventType := range []string{
+		"model/selection", "session-log-deepseek/delivery-accepted",
+		"subagent/model-selection-policy", "team/member",
+		"team/message/delivered", "team/message/queued", "team/task",
+	} {
+		t.Run(eventType, func(t *testing.T) {
+			records := []any{
+				deepSeekHarnessFixtureHeader("known-event", deepSeekHarnessFixtureCwd, nil),
+				deepSeekHarnessFixtureEvent(0, eventType, map[string]any{}, nil),
+				deepSeekHarnessFixtureEvent(1, "turn/start", map[string]any{"turn": 1}, nil),
+				deepSeekHarnessFixtureEvent(2, "user/message", deepSeekHarnessUser("visible prompt", "human"), "append"),
+				deepSeekHarnessFixtureEvent(3, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
+			}
+			path := writeDeepSeekHarnessFixture(t, t.TempDir(), "known-event", deepSeekHarnessFixtureCwd, "plain", records)
+			result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
+			require.NoError(t, err)
+			require.Len(t, result.Messages, 1)
+			assert.Equal(t, "visible prompt", result.Messages[0].Content)
+		})
+	}
+}
+
+func TestDeepSeekHarnessSourceEventSeqs(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		raw     string
+		seq     int
+		wantErr bool
+	}{
+		{name: "flat", raw: `[1, 2, 3]`, seq: 145},
+		{name: "inclusive range", raw: `[[138, 144]]`, seq: 145},
+		{name: "mixed", raw: `[1, [3, 9], 12]`, seq: 145},
+		{name: "single entry range", raw: `[[1, 1]]`, seq: 145},
+		{name: "unordered flat", raw: `[3, 1, 2]`, seq: 145},
+		{name: "range fills count", raw: `[[0, 6]]`, seq: 7},
+		{name: "range exceeds count", raw: `[[0, 7]]`, seq: 7, wantErr: true},
+		{name: "mixed exceeds count", raw: `[0, [1, 6], 7]`, seq: 7, wantErr: true},
+		{name: "not array", raw: `1`, seq: 145, wantErr: true},
+		{name: "null", raw: `null`, seq: 145, wantErr: true},
+		{name: "invalid member", raw: `["not-a-number"]`, seq: 145, wantErr: true},
+		{name: "fraction", raw: `[1.5]`, seq: 145, wantErr: true},
+		{name: "negative", raw: `[-1]`, seq: 145, wantErr: true},
+		{name: "unsafe integer", raw: `[9007199254740992]`, seq: 145, wantErr: true},
+		{name: "short pair", raw: `[[1]]`, seq: 145, wantErr: true},
+		{name: "long pair", raw: `[[1, 2, 3]]`, seq: 145, wantErr: true},
+		{name: "fractional endpoint", raw: `[[1, 2.5]]`, seq: 145, wantErr: true},
+		{name: "reversed pair", raw: `[[3, 1]]`, seq: 145, wantErr: true},
+		{name: "nested pair", raw: `[[[1, 2]]]`, seq: 145, wantErr: true},
+		{name: "overlapping ranges", raw: `[[1, 3], [3, 5]]`, seq: 145, wantErr: true},
+		{name: "unordered mixed", raw: `[2, 1, [3, 5]]`, seq: 145, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			records := []any{deepSeekHarnessFixtureHeader("source-seqs", deepSeekHarnessFixtureCwd, nil)}
+			// Keep the reported range's references earlier than the owning event.
+			for seq := range test.seq - 1 {
+				records = append(records, deepSeekHarnessFixtureEvent(seq, "feedback/record", map[string]any{"text": "source"}, nil))
+			}
+			records = append(records, deepSeekHarnessFixtureEvent(test.seq-1, "turn/start", map[string]any{"turn": 1}, nil))
+			event := deepSeekHarnessFixtureEvent(test.seq, "user/message", deepSeekHarnessUser("derived prompt", "plugin"), "append")
+			event["sourceEventSeqs"] = jsontext.Value(test.raw)
+			records = append(records, event,
+				deepSeekHarnessFixtureEvent(test.seq+1, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil))
+			path := writeDeepSeekHarnessFixture(t, t.TempDir(), "source-seqs", deepSeekHarnessFixtureCwd, "plain", records)
+			result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
+			if test.wantErr {
+				require.ErrorContains(t, err, "corrupt committed DeepSeek Harness log")
+				assert.ErrorContains(t, err, "sourceEventSeqs")
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, result.Messages, 1)
+			assert.Equal(t, "derived prompt", result.Messages[0].Content)
+		})
+	}
+}
+
 func TestDeepSeekHarnessFormatErrorsAndCrashTails(t *testing.T) {
 	t.Run("foreign version", func(t *testing.T) {
 		records := deepSeekHarnessCompleteFixture("foreign", nil)
@@ -774,82 +851,6 @@ func TestDeepSeekHarnessFormatErrorsAndCrashTails(t *testing.T) {
 		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
 		require.NoError(t, err)
 		assert.Empty(t, result.Messages)
-	})
-
-	t.Run("model/selection accepted", func(t *testing.T) {
-		records := []any{
-			deepSeekHarnessFixtureHeader("model-select", deepSeekHarnessFixtureCwd, nil),
-			map[string]any{
-				"type": "model/selection", "seq": 0, "time": 1700000000001,
-				"data": map[string]any{"provider": "deepseek-official", "model": "deepseek-v4-flash", "reasoningEffort": "high"},
-			},
-			deepSeekHarnessFixtureEvent(1, "turn/start", map[string]any{"turn": 1}, nil),
-			deepSeekHarnessFixtureEvent(2, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
-		}
-		path := writeDeepSeekHarnessFixture(t, t.TempDir(), "model-select", deepSeekHarnessFixtureCwd, "plain", records)
-		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
-		require.NoError(t, err)
-		assert.Len(t, result.Messages, 0)
-	})
-
-	t.Run("sourceEventSeqs flat accepted", func(t *testing.T) {
-		records := []any{
-			deepSeekHarnessFixtureHeader("src-seqs-flat", deepSeekHarnessFixtureCwd, nil),
-			deepSeekHarnessFixtureEvent(0, "turn/start", map[string]any{"turn": 1}, nil),
-			deepSeekHarnessFixtureEvent(1, "step/start", map[string]any{"turn": 1, "step": 1}, nil),
-			map[string]any{
-				"type": "assistant/message", "seq": 2, "time": 1700000000003,
-				"data": deepSeekHarnessAssistantDataMap(1, 1, "hello", nil),
-				"sourceEventSeqs": []any{float64(1), float64(2), float64(3)},
-				"surfaceOp":       "append",
-			},
-			deepSeekHarnessFixtureEvent(3, "step/end", map[string]any{"turn": 1, "step": 1}, nil),
-			deepSeekHarnessFixtureEvent(4, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
-		}
-		path := writeDeepSeekHarnessFixture(t, t.TempDir(), "src-seqs-flat", deepSeekHarnessFixtureCwd, "plain", records)
-		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
-		require.NoError(t, err)
-		assert.NotEmpty(t, result.Messages)
-	})
-
-	t.Run("sourceEventSeqs nested accepted", func(t *testing.T) {
-		records := []any{
-			deepSeekHarnessFixtureHeader("src-seqs-nested", deepSeekHarnessFixtureCwd, nil),
-			deepSeekHarnessFixtureEvent(0, "turn/start", map[string]any{"turn": 1}, nil),
-			deepSeekHarnessFixtureEvent(1, "step/start", map[string]any{"turn": 1, "step": 1}, nil),
-			map[string]any{
-				"type": "assistant/message", "seq": 2, "time": 1700000000003,
-				"data": deepSeekHarnessAssistantDataMap(1, 1, "hello", nil),
-				"sourceEventSeqs": []any{[]any{float64(1), float64(2)}},
-				"surfaceOp":       "append",
-			},
-			deepSeekHarnessFixtureEvent(3, "step/end", map[string]any{"turn": 1, "step": 1}, nil),
-			deepSeekHarnessFixtureEvent(4, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
-		}
-		path := writeDeepSeekHarnessFixture(t, t.TempDir(), "src-seqs-nested", deepSeekHarnessFixtureCwd, "plain", records)
-		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
-		require.NoError(t, err)
-		assert.NotEmpty(t, result.Messages)
-	})
-
-	t.Run("sourceEventSeqs invalid accepted", func(t *testing.T) {
-		records := []any{
-			deepSeekHarnessFixtureHeader("src-seqs-bad", deepSeekHarnessFixtureCwd, nil),
-			deepSeekHarnessFixtureEvent(0, "turn/start", map[string]any{"turn": 1}, nil),
-			deepSeekHarnessFixtureEvent(1, "step/start", map[string]any{"turn": 1, "step": 1}, nil),
-			map[string]any{
-				"type": "assistant/message", "seq": 2, "time": 1700000000003,
-				"data": deepSeekHarnessAssistantDataMap(1, 1, "hello", nil),
-				"sourceEventSeqs": []any{"not-a-number"},
-				"surfaceOp":       "append",
-			},
-			deepSeekHarnessFixtureEvent(3, "step/end", map[string]any{"turn": 1, "step": 1}, nil),
-			deepSeekHarnessFixtureEvent(4, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
-		}
-		path := writeDeepSeekHarnessFixture(t, t.TempDir(), "src-seqs-bad", deepSeekHarnessFixtureCwd, "plain", records)
-		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
-		require.NoError(t, err)
-		assert.NotEmpty(t, result.Messages)
 	})
 
 	t.Run("unsafe event integer", func(t *testing.T) {

--- a/internal/parser/deepseek_harness_test.go
+++ b/internal/parser/deepseek_harness_test.go
@@ -792,6 +792,66 @@ func TestDeepSeekHarnessFormatErrorsAndCrashTails(t *testing.T) {
 		assert.Len(t, result.Messages, 0)
 	})
 
+	t.Run("sourceEventSeqs flat accepted", func(t *testing.T) {
+		records := []any{
+			deepSeekHarnessFixtureHeader("src-seqs-flat", deepSeekHarnessFixtureCwd, nil),
+			deepSeekHarnessFixtureEvent(0, "turn/start", map[string]any{"turn": 1}, nil),
+			deepSeekHarnessFixtureEvent(1, "step/start", map[string]any{"turn": 1, "step": 1}, nil),
+			map[string]any{
+				"type": "assistant/message", "seq": 2, "time": 1700000000003,
+				"data": deepSeekHarnessAssistantDataMap(1, 1, "hello", nil),
+				"sourceEventSeqs": []any{float64(1), float64(2), float64(3)},
+				"surfaceOp":       "append",
+			},
+			deepSeekHarnessFixtureEvent(3, "step/end", map[string]any{"turn": 1, "step": 1}, nil),
+			deepSeekHarnessFixtureEvent(4, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
+		}
+		path := writeDeepSeekHarnessFixture(t, t.TempDir(), "src-seqs-flat", deepSeekHarnessFixtureCwd, "plain", records)
+		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.Messages)
+	})
+
+	t.Run("sourceEventSeqs nested accepted", func(t *testing.T) {
+		records := []any{
+			deepSeekHarnessFixtureHeader("src-seqs-nested", deepSeekHarnessFixtureCwd, nil),
+			deepSeekHarnessFixtureEvent(0, "turn/start", map[string]any{"turn": 1}, nil),
+			deepSeekHarnessFixtureEvent(1, "step/start", map[string]any{"turn": 1, "step": 1}, nil),
+			map[string]any{
+				"type": "assistant/message", "seq": 2, "time": 1700000000003,
+				"data": deepSeekHarnessAssistantDataMap(1, 1, "hello", nil),
+				"sourceEventSeqs": []any{[]any{float64(1), float64(2)}},
+				"surfaceOp":       "append",
+			},
+			deepSeekHarnessFixtureEvent(3, "step/end", map[string]any{"turn": 1, "step": 1}, nil),
+			deepSeekHarnessFixtureEvent(4, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
+		}
+		path := writeDeepSeekHarnessFixture(t, t.TempDir(), "src-seqs-nested", deepSeekHarnessFixtureCwd, "plain", records)
+		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.Messages)
+	})
+
+	t.Run("sourceEventSeqs invalid accepted", func(t *testing.T) {
+		records := []any{
+			deepSeekHarnessFixtureHeader("src-seqs-bad", deepSeekHarnessFixtureCwd, nil),
+			deepSeekHarnessFixtureEvent(0, "turn/start", map[string]any{"turn": 1}, nil),
+			deepSeekHarnessFixtureEvent(1, "step/start", map[string]any{"turn": 1, "step": 1}, nil),
+			map[string]any{
+				"type": "assistant/message", "seq": 2, "time": 1700000000003,
+				"data": deepSeekHarnessAssistantDataMap(1, 1, "hello", nil),
+				"sourceEventSeqs": []any{"not-a-number"},
+				"surfaceOp":       "append",
+			},
+			deepSeekHarnessFixtureEvent(3, "step/end", map[string]any{"turn": 1, "step": 1}, nil),
+			deepSeekHarnessFixtureEvent(4, "turn/end", deepSeekHarnessTurnEnd(1, "completed"), nil),
+		}
+		path := writeDeepSeekHarnessFixture(t, t.TempDir(), "src-seqs-bad", deepSeekHarnessFixtureCwd, "plain", records)
+		result, err := parseDeepSeekHarnessSession(t.Context(), path, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.Messages)
+	})
+
 	t.Run("unsafe event integer", func(t *testing.T) {
 		records := []any{
 			deepSeekHarnessFixtureHeader("unsafe-int", deepSeekHarnessFixtureCwd, nil),


### PR DESCRIPTION
DeepSeek Harness version-0 sessions accept compressed `sourceEventSeqs` while retaining strict validation. Each entry may be a non-negative safe integer or an inclusive `[start, end]` range, including mixed arrays such as `[1, [3, 9], 12]`. `[[138, 144]]` represents seven sequences. Invalid members, malformed ranges, overlapping or unordered ranges, and expansions exceeding the owning event sequence produce a parse error when the log is committed. The parser validates lineage without allocating an unused expanded list.

The known-event map now matches upstream's complete frozen version-0 inventory, including `model/selection`, delivery tracking, subagent model policy, and team events. The provenance entry is reverified against `56c4c3e47c195ff5edbfe3d307bdef81f3de348b` and links to the frozen codec, event inventory, and envelope rules.

This remains a version-0 parser. It retains `assistant/chunk`, `tool/code-dispatch*`, and `start`/`end` surface replacements. Versions 1–3, their migrations, newer event semantics such as `system/message` and `assistant/attempt`, and model-selection reasoning-effort import require separate work.
