### PR TITLE
perf(sync): charge shared SQLite container members their share of the container

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -6309,12 +6309,22 @@ func (e *Engine) rehydrateReconciliationPage(
 					provider, &source, candidate.SourceState,
 					candidate.Provider, candidate.Path,
 				) {
-					files = append(files, parser.DiscoveredFile{
+					file := parser.DiscoveredFile{
 						Path: candidate.Path, Project: source.ProjectHint,
 						Agent: candidate.Provider, ForceParse: forceCandidate,
 						Machine:        candidate.Machine,
 						ProviderSource: &source, ProviderProcess: true,
+					}
+					membershipFile := file
+					membershipFile.Path = providerDiscoveredPath(source)
+					if membershipFile.Path == "" {
+						membershipFile.Path = candidate.Path
+					}
+					e.unNoteSQLiteContainerDiscovery(parser.DiscoveredFile{
+						Agent: candidate.Provider, Path: candidate.Path,
 					})
+					e.noteSQLiteContainerDiscovery(membershipFile)
+					files = append(files, file)
 					continue
 				}
 			}
@@ -6341,7 +6351,7 @@ func (e *Engine) rehydrateReconciliationPage(
 			provider, &source, candidate.SourceState,
 			candidate.Provider, candidate.Path,
 		)
-		files = append(files, parser.DiscoveredFile{
+		file := parser.DiscoveredFile{
 			Path: candidate.Path, Project: source.ProjectHint,
 			Agent: candidate.Provider, ForceParse: forceCandidate,
 			// Carry the candidate's stored attribution: recomputing it from the
@@ -6349,7 +6359,17 @@ func (e *Engine) rehydrateReconciliationPage(
 			// the labeled root it was configured under.
 			Machine:        candidate.Machine,
 			ProviderSource: &source, ProviderProcess: true,
+		}
+		membershipFile := file
+		membershipFile.Path = providerDiscoveredPath(source)
+		if membershipFile.Path == "" {
+			membershipFile.Path = candidate.Path
+		}
+		e.unNoteSQLiteContainerDiscovery(parser.DiscoveredFile{
+			Agent: candidate.Provider, Path: candidate.Path,
 		})
+		e.noteSQLiteContainerDiscovery(membershipFile)
+		files = append(files, file)
 	}
 	return files, nil
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11309,6 +11309,7 @@ func (e *Engine) processProviderFile(
 	if file.ProviderSource == nil && file.Project != "" {
 		source.ProjectHint = file.Project
 	}
+	file.ProviderSource = &source
 	cwdDecision = e.sourceCwdDecision(source)
 	cwdPath = e.sourceCwdLookupPath(source)
 	cwdAgent = source.Provider

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1612,8 +1612,16 @@ type syncJob struct {
 	processResult
 	agent          parser.AgentType
 	path           string
+	containerPath  string
 	machine        string
 	retentionLease *parseRetentionLease
+}
+
+func (j syncJob) containerResultPath() string {
+	if j.containerPath != "" {
+		return j.containerPath
+	}
+	return j.path
 }
 
 const (
@@ -9572,6 +9580,7 @@ func (e *Engine) startWorkers(
 					processResult:  result,
 					agent:          file.Agent,
 					path:           file.Path,
+					containerPath:  result.sqliteContainerResultPath,
 					machine:        e.machineForFile(file),
 					retentionLease: result.retentionLease,
 				})
@@ -10079,7 +10088,7 @@ func (e *Engine) collectAndBatchWithOptions(
 			if r.sourceCwdChanged && e.deferredSourceCwd == nil {
 				stats.RecordCwdUpdated(1)
 			}
-			e.noteSQLiteContainerResult(r.path, false)
+			e.noteSQLiteContainerResult(r.containerResultPath(), false)
 			if r.cacheSkip && r.mtime != 0 && !r.noCacheSkip {
 				e.cacheSkip(r.skipCacheKey(), r.mtime, r.sourceFingerprint)
 			}
@@ -10107,7 +10116,7 @@ func (e *Engine) collectAndBatchWithOptions(
 			if err != nil {
 				log.Printf("reconcile skipped source cwd: %v", err)
 				stats.RecordFailed()
-				e.noteSQLiteContainerResult(r.path, false)
+				e.noteSQLiteContainerResult(r.containerResultPath(), false)
 				r.releaseRetention()
 				continue
 			}
@@ -10125,7 +10134,7 @@ func (e *Engine) collectAndBatchWithOptions(
 				e.cacheSkip(r.skipCacheKey(), r.mtime)
 			}
 			stats.RecordSkip()
-			e.noteSQLiteContainerResult(r.path, !proofWithheld)
+			e.noteSQLiteContainerResult(r.containerResultPath(), !proofWithheld)
 			if !proofWithheld && !r.suppressPresenceSweep {
 				admitted, exactOwnerships, err :=
 					e.skippedSourceAllowsCwdFilter(ctx, r)
@@ -10167,7 +10176,7 @@ func (e *Engine) collectAndBatchWithOptions(
 		if err != nil {
 			log.Printf("list pre-write subagent children: %v", err)
 			stats.RecordFailed()
-			e.noteSQLiteContainerResult(r.path, false)
+			e.noteSQLiteContainerResult(r.containerResultPath(), false)
 			r.releaseAll()
 			continue
 		}
@@ -10177,7 +10186,7 @@ func (e *Engine) collectAndBatchWithOptions(
 		if err := e.db.QueueSubagentParentCleanupRepairs(children); err != nil {
 			log.Printf("queue subagent parent repairs: %v", err)
 			stats.RecordFailed()
-			e.noteSQLiteContainerResult(r.path, false)
+			e.noteSQLiteContainerResult(r.containerResultPath(), false)
 			r.releaseAll()
 			continue
 		}
@@ -10196,7 +10205,7 @@ func (e *Engine) collectAndBatchWithOptions(
 				e.clearProviderSourceFreshness(ctx, r.providerStatHash)
 				log.Printf("stage DAG source data versions: %v", err)
 				stats.RecordFailed()
-				e.noteSQLiteContainerResult(r.path, false)
+				e.noteSQLiteContainerResult(r.containerResultPath(), false)
 				r.releaseAll()
 				continue
 			}
@@ -10207,7 +10216,7 @@ func (e *Engine) collectAndBatchWithOptions(
 		if err != nil {
 			log.Printf("delete parser-excluded sessions: %v", err)
 			stats.RecordFailed()
-			e.noteSQLiteContainerResult(r.path, false)
+			e.noteSQLiteContainerResult(r.containerResultPath(), false)
 			r.releaseAll()
 			continue
 		}
@@ -10235,7 +10244,7 @@ func (e *Engine) collectAndBatchWithOptions(
 					"tombstone source-missing members: %v", tombstoneErr,
 				)
 				stats.RecordFailed()
-				e.noteSQLiteContainerResult(r.path, false)
+				e.noteSQLiteContainerResult(r.containerResultPath(), false)
 				r.releaseAll()
 				continue
 			}
@@ -10248,7 +10257,7 @@ func (e *Engine) collectAndBatchWithOptions(
 			if err != nil {
 				log.Printf("reconcile rowless source cwd: %v", err)
 				stats.RecordFailed()
-				e.noteSQLiteContainerResult(r.path, false)
+				e.noteSQLiteContainerResult(r.containerResultPath(), false)
 				r.releaseRetention()
 				continue
 			}
@@ -10281,7 +10290,7 @@ func (e *Engine) collectAndBatchWithOptions(
 					)
 				}
 			}
-			e.noteSQLiteContainerResult(r.path, !proofWithheld)
+			e.noteSQLiteContainerResult(r.containerResultPath(), !proofWithheld)
 			if !proofWithheld &&
 				sourceAllowsParserExclusions {
 				baselineProcessedSource(r, true)
@@ -10315,7 +10324,7 @@ func (e *Engine) collectAndBatchWithOptions(
 		if err != nil {
 			log.Printf("reconcile filtered source cwd: %v", err)
 			stats.RecordFailed()
-			e.noteSQLiteContainerResult(r.path, false)
+			e.noteSQLiteContainerResult(r.containerResultPath(), false)
 			r.releaseRetention()
 			continue
 		}
@@ -10331,7 +10340,7 @@ func (e *Engine) collectAndBatchWithOptions(
 		// behavior.
 		presenceProofWithheld := r.sourceProofWithheld(vetoed > 0)
 		sourceProofWithheld := r.sourceProofWithheld(false)
-		e.noteSQLiteContainerResult(r.path, !presenceProofWithheld)
+		e.noteSQLiteContainerResult(r.containerResultPath(), !presenceProofWithheld)
 		if vetoed > 0 && len(allowed) == 0 {
 			e.clearProviderSourceFreshness(ctx, r.providerStatHash)
 			// Claude can emit a synthetic base result for a replay-only
@@ -10847,9 +10856,10 @@ type processResult struct {
 	// sourceBytes is the physical source size used to acquire the retention
 	// lease and to account this result against the pending write batch byte
 	// cap. Zero on lease-free skips.
-	sourceBytes        int64
-	results            []parser.ParseResult
-	excludedSessionIDs []string
+	sourceBytes               int64
+	sqliteContainerResultPath string
+	results                   []parser.ParseResult
+	excludedSessionIDs        []string
 	// preservedSessionIDs are higher-ranked members omitted by a shared source;
 	// they remain present while lower-ranked source ownership is reconciled.
 	preservedSessionIDs []string
@@ -11196,7 +11206,9 @@ func (e *Engine) processProviderFile(
 	var cwdDecision sourceCwdDecision
 	var cwdPath string
 	var cwdAgent parser.AgentType
+	var sqliteContainerResultPath string
 	defer func() {
+		result.sqliteContainerResultPath = sqliteContainerResultPath
 		if cwdDecision.resolution.State == parser.SourceCwdUnspecified {
 			return
 		}
@@ -11310,6 +11322,7 @@ func (e *Engine) processProviderFile(
 		source.ProjectHint = file.Project
 	}
 	file.ProviderSource = &source
+	sqliteContainerResultPath = providerDiscoveredPath(source)
 	cwdDecision = e.sourceCwdDecision(source)
 	cwdPath = e.sourceCwdLookupPath(source)
 	cwdAgent = source.Provider

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11233,6 +11233,9 @@ func (e *Engine) processProviderFile(
 		return processResult{}, false
 	}
 	e.discardStaleSQLiteProviderSource(&file)
+	if file.ProviderSource != nil {
+		sqliteContainerResultPath = providerDiscoveredPath(*file.ProviderSource)
+	}
 
 	// OpenCode-family shared-SQLite gate: when the whole container
 	// provably has not changed since the last fully verified pass, none

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -11779,7 +11779,7 @@ func (e *Engine) processProviderFile(
 	// here the provider parses the source, so acquire the retention lease that
 	// bounds the parsed payload and attach it to every result carrying that
 	// data. A result still classified as a skip below releases it immediately.
-	sourceBytes := parseRetentionSourceBytes(file)
+	sourceBytes := e.parseRetentionSourceBytes(file)
 	lease, err := e.retentionBudget().acquire(
 		ctx, sourceBytes,
 	)
@@ -15050,7 +15050,7 @@ func (e *Engine) tryIncrementalJSONL(
 	// retention lease that bounds the parsed payload. It is attached to the
 	// incremental results below and released on every decline (fall-through to
 	// a full parse re-acquires at the provider parse seam) or skip return.
-	sourceBytes := parseRetentionSourceBytes(file)
+	sourceBytes := e.parseRetentionSourceBytes(file)
 	lease, leaseErr := e.retentionBudget().acquire(
 		ctx, sourceBytes,
 	)

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -618,6 +618,13 @@ func (e *Engine) sqliteContainerSourceFresh(file parser.DiscoveredFile) bool {
 	if e.forceParseRequested(file) {
 		return false
 	}
+	// Rehydration keeps the candidate path for archive identity, so gate the
+	// source that the provider resolved for this pass.
+	if file.ProviderSource != nil {
+		if path := providerDiscoveredPath(*file.ProviderSource); path != "" {
+			file.Path = path
+		}
+	}
 	dbPath, sessionID, ok := sqliteContainerSourceForFile(file)
 	if !ok {
 		return false

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -573,6 +573,25 @@ func (e *Engine) unNoteSQLiteContainerDiscovery(file parser.DiscoveredFile) {
 	pass.discovered[dbPath]--
 }
 
+// sqliteContainerDiscoveredMembers returns how many sessions this pass
+// discovered in the shared SQLite container backing the file, or 0 when the
+// file is not a container member or no pass is tracking membership. A zero
+// answer leaves the caller on the whole-container size, which is what the
+// engine charged before per-member sizing existed.
+func (e *Engine) sqliteContainerDiscoveredMembers(file parser.DiscoveredFile) int {
+	dbPath, _, ok := sqliteContainerSourceForFile(file)
+	if !ok {
+		return 0
+	}
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	pass := e.containerPass
+	if pass == nil {
+		return 0
+	}
+	return pass.discovered[dbPath]
+}
+
 func (e *Engine) finishStreamingSQLiteContainerDiscovery() {
 	e.containerMu.Lock()
 	defer e.containerMu.Unlock()

--- a/internal/sync/opencode_container_gate_internal_test.go
+++ b/internal/sync/opencode_container_gate_internal_test.go
@@ -1061,6 +1061,76 @@ func TestSQLiteContainerGateParsesNewlyUnshadowedSession(t *testing.T) {
 		"a newly exposed row must parse despite the unchanged container")
 }
 
+func TestSQLiteContainerGateUsesCarriedSourcePath(t *testing.T) {
+	archive := openTestDB(t)
+	e := &Engine{
+		db: archive,
+		providerMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentOpenCode: parser.ProviderMigrationProviderAuthoritative,
+		},
+	}
+	dbPath, _ := newContainerTestDB(t)
+	state, ok := parser.StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "container state must be readable")
+	virtualPath := parser.VirtualSourcePath(dbPath, "ses-1")
+	shadowPath := filepath.Join(t.TempDir(), "ses-1.json")
+	require.NoError(t, os.WriteFile(shadowPath, []byte("{}"), 0o600))
+
+	filePath := virtualPath
+	session := db.Session{
+		ID: "opencode:ses-1", Agent: string(parser.AgentOpenCode),
+		Project: "project", Machine: "local", FilePath: &filePath,
+	}
+	require.NoError(t, archive.UpsertSession(session))
+	require.NoError(t, archive.SetSessionDataVersion(
+		session.ID, db.CurrentDataVersion(),
+	))
+
+	virtualSource := parser.SourceRef{
+		Provider: parser.AgentOpenCode, DisplayPath: virtualPath,
+		FingerprintKey: virtualPath, Key: virtualPath,
+	}
+	e.trustedSQLiteContainers = map[string]trustedSQLiteContainer{
+		dbPath: {state: state},
+	}
+	e.beginSQLiteContainerPass(
+		[]parser.DiscoveredFile{{
+			Agent: parser.AgentOpenCode, Path: virtualPath,
+			ProviderSource: &virtualSource,
+		}},
+		map[string]parser.SQLiteContainerState{dbPath: state},
+	)
+	gateFile := parser.DiscoveredFile{
+		Agent:          parser.AgentOpenCode,
+		Path:           virtualPath,
+		ProviderSource: &virtualSource,
+	}
+	require.True(t, e.sqliteContainerSourceFresh(gateFile), "the carried virtual source must be fresh")
+
+	result, used := e.processProviderFile(t.Context(), parser.DiscoveredFile{
+		Agent:           parser.AgentOpenCode,
+		Path:            virtualPath,
+		ProviderSource:  &virtualSource,
+		ProviderProcess: true,
+	})
+	require.True(t, used)
+	require.NoError(t, result.err)
+	assert.True(t, result.skip)
+	assert.Equal(t, virtualPath, result.sqliteContainerResultPath,
+		"an early gate return must retain its carried source path")
+
+	shadowSource := virtualSource
+	shadowSource.DisplayPath = shadowPath
+	shadowSource.FingerprintKey = shadowPath
+	shadowSource.Key = shadowPath
+	shadow := parser.DiscoveredFile{
+		Agent: parser.AgentOpenCode, Path: virtualPath,
+		ProviderSource: &shadowSource,
+	}
+	assert.False(t, e.sqliteContainerSourceFresh(shadow),
+		"a resolved storage shadow must not use the SQLite container gate")
+}
+
 // TestSQLiteContainerScopedPassDoesNotPromoteUndiscoveredContainer pins the
 // promotion precondition: a pass may only trust a container it actually
 // verified, meaning it discovered (and completed) at least one of its

--- a/internal/sync/parse_retention.go
+++ b/internal/sync/parse_retention.go
@@ -174,12 +174,15 @@ func (e *Engine) parseRetentionSourceBytes(file parser.DiscoveredFile) int64 {
 			path = providerPath
 		}
 	}
-	path = validatedProviderSourceStatPath(path)
-	info, err := os.Stat(path)
+	info, err := os.Stat(validatedProviderSourceStatPath(path))
 	if err != nil || !info.Mode().IsRegular() {
 		return 0
 	}
-	if members := e.sqliteContainerDiscoveredMembers(file); members > 1 {
+	// Membership follows the same resolved path as the stat: a virtual member
+	// promoted to its storage JSON shadow stats the shadow, so dividing that
+	// size by the container's membership would undercharge the parse.
+	resolved := parser.DiscoveredFile{Agent: file.Agent, Path: path}
+	if members := e.sqliteContainerDiscoveredMembers(resolved); members > 1 {
 		// Sole-member containers keep the raw size so a zero-byte container
 		// still reports zero, which retainedBytes reads as an unknown source.
 		// Above one member the share floors at a byte instead, because a

--- a/internal/sync/parse_retention.go
+++ b/internal/sync/parse_retention.go
@@ -180,9 +180,11 @@ func (e *Engine) parseRetentionSourceBytes(file parser.DiscoveredFile) int64 {
 		return 0
 	}
 	if members := e.sqliteContainerDiscoveredMembers(file); members > 1 {
-		// retainedBytes reads a non-positive size as "unknown source" and
-		// charges the whole budget, which is the fault this fixes, so the
-		// share floors at one byte rather than dividing to zero.
+		// Sole-member containers keep the raw size so a zero-byte container
+		// still reports zero, which retainedBytes reads as an unknown source.
+		// Above one member the share floors at a byte instead, because a
+		// non-positive estimate would charge the whole budget: the fault this
+		// fixes.
 		return max(info.Size()/int64(members), 1)
 	}
 	return info.Size()

--- a/internal/sync/parse_retention.go
+++ b/internal/sync/parse_retention.go
@@ -156,7 +156,15 @@ func releaseParseRetentionLeases(leases []*parseRetentionLease) {
 	}
 }
 
-func parseRetentionSourceBytes(file parser.DiscoveredFile) int64 {
+// parseRetentionSourceBytes estimates the bytes one discovered source
+// contributes to a parse. A shared SQLite container fans into one virtual
+// source per session row and every member stats back to the same container
+// file, so the raw size would charge each member for rows only its siblings
+// hold. Members partition the container, so the container size divided by the
+// sessions this pass discovered in it sums back to the container across the
+// whole membership. An unknown or partial count returns a larger share and
+// therefore admits fewer parses, never more.
+func (e *Engine) parseRetentionSourceBytes(file parser.DiscoveredFile) int64 {
 	if file.SourceSize > 0 {
 		return file.SourceSize
 	}
@@ -170,6 +178,12 @@ func parseRetentionSourceBytes(file parser.DiscoveredFile) int64 {
 	info, err := os.Stat(path)
 	if err != nil || !info.Mode().IsRegular() {
 		return 0
+	}
+	if members := e.sqliteContainerDiscoveredMembers(file); members > 1 {
+		// retainedBytes reads a non-positive size as "unknown source" and
+		// charges the whole budget, which is the fault this fixes, so the
+		// share floors at one byte rather than dividing to zero.
+		return max(info.Size()/int64(members), 1)
 	}
 	return info.Size()
 }

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -1075,3 +1075,173 @@ func TestStartWorkersCancellationReleasesAdmissionWaiters(t *testing.T) {
 		next.Release()
 	})
 }
+
+// newSQLiteContainerMemberFixture builds a container-shaped fixture: one real
+// file named for an OpenCode-family container, truncated to containerBytes,
+// fanned into members virtual sources registered with a live container pass.
+func newSQLiteContainerMemberFixture(
+	t *testing.T, containerBytes int64, members int,
+) (*Engine, []parser.DiscoveredFile, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "mimocode.db")
+	handle, err := os.Create(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(containerBytes))
+	require.NoError(t, handle.Close())
+
+	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+
+	files := make([]parser.DiscoveredFile, members)
+	engine.beginStreamingSQLiteContainerPass(nil)
+	for i := range files {
+		files[i] = parser.DiscoveredFile{
+			Path:  parser.VirtualSourcePath(dbPath, fmt.Sprintf("ses-%03d", i)),
+			Agent: parser.AgentMiMoCode,
+		}
+		engine.noteSQLiteContainerDiscovery(files[i])
+	}
+	engine.finishStreamingSQLiteContainerDiscovery()
+	return engine, files, dbPath
+}
+
+func TestBulkAdmissionAdmitsWorkerPoolForSQLiteContainerMembers(t *testing.T) {
+	engine, files, _ := newSQLiteContainerMemberFixture(t, 64<<20, 64)
+	synctest.Test(t, func(t *testing.T) {
+		budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+
+		admitted := 0
+		for i := range maxWorkers {
+			lease, err := budget.acquire(
+				ctx, engine.parseRetentionSourceBytes(files[i]),
+			)
+			if err != nil {
+				break
+			}
+			admitted++
+			t.Cleanup(lease.Release)
+		}
+		assert.Equal(t, maxWorkers, admitted,
+			"members of one shared SQLite container must not serialize bulk admission")
+	})
+}
+
+func TestParseRetentionChargesContainerMemberItsShare(t *testing.T) {
+	engine, files, _ := newSQLiteContainerMemberFixture(t, 64<<20, 64)
+
+	assert.Equal(t, int64(1048576), engine.parseRetentionSourceBytes(files[0]),
+		"a member must be charged its share of the container, not the whole file")
+
+	var total int64
+	for _, file := range files {
+		total += engine.parseRetentionSourceBytes(file)
+	}
+	assert.Equal(t, int64(67108864), total)
+	assert.LessOrEqual(t, total, int64(67108864),
+		"member shares must sum back to the container they partition")
+}
+
+func TestParseRetentionKeepsWholeFileSourceExclusive(t *testing.T) {
+	engine, _, dbPath := newSQLiteContainerMemberFixture(t, 64<<20, 64)
+	plainPath := filepath.Join(filepath.Dir(dbPath), "whole.jsonl")
+	handle, err := os.Create(plainPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(67108864))
+	require.NoError(t, handle.Close())
+	plain := parser.DiscoveredFile{Path: plainPath, Agent: parser.AgentClaude}
+
+	sourceBytes := engine.parseRetentionSourceBytes(plain)
+	assert.Equal(t, int64(67108864), sourceBytes,
+		"a plain source must keep its whole-file size")
+
+	synctest.Test(t, func(t *testing.T) {
+		budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
+		assert.Equal(t, defaultBulkParseRetentionBytes, budget.weight(sourceBytes))
+
+		first, acquireErr := budget.acquire(t.Context(), sourceBytes)
+		require.NoError(t, acquireErr)
+		t.Cleanup(first.Release)
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		_, acquireErr = budget.acquire(ctx, sourceBytes)
+		assert.ErrorIs(t, acquireErr, context.DeadlineExceeded,
+			"a second whole-file source must still block on the bulk budget")
+	})
+}
+
+func TestParseRetentionIgnoresNonFamilyVirtualPath(t *testing.T) {
+	engine, _, dbPath := newSQLiteContainerMemberFixture(t, 64<<20, 64)
+	otherPath := filepath.Join(filepath.Dir(dbPath), "other.db")
+	handle, err := os.Create(otherPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(67108864))
+	require.NoError(t, handle.Close())
+
+	assert.Equal(t, int64(67108864), engine.parseRetentionSourceBytes(
+		parser.DiscoveredFile{
+			Path:  parser.VirtualSourcePath(otherPath, "ses-1"),
+			Agent: parser.AgentMiMoCode,
+		}),
+		"a virtual path over a non-family container base must keep the stat size")
+}
+
+func TestParseRetentionKeepsCodexSourceBytesForStagingThreshold(t *testing.T) {
+	engine, _, dbPath := newSQLiteContainerMemberFixture(t, 64<<20, 64)
+	codexPath := filepath.Join(filepath.Dir(dbPath), "rollout.jsonl")
+	handle, err := os.Create(codexPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(67108864))
+	require.NoError(t, handle.Close())
+
+	assert.Equal(t, int64(67108864), engine.parseRetentionSourceBytes(
+		parser.DiscoveredFile{Path: codexPath, Agent: parser.AgentCodex}),
+		"the Codex staging threshold input must keep the whole-file size")
+}
+
+func TestParseRetentionFallsBackToContainerSizeWithoutPass(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "mimocode.db")
+	handle, err := os.Create(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(67108864))
+	require.NoError(t, handle.Close())
+
+	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+	require.Nil(t, engine.containerPass)
+
+	assert.Equal(t, int64(67108864), engine.parseRetentionSourceBytes(
+		parser.DiscoveredFile{
+			Path:  parser.VirtualSourcePath(dbPath, "ses-001"),
+			Agent: parser.AgentMiMoCode,
+		}),
+		"a pass tracking no membership must keep the whole-container size")
+}
+
+func TestParseRetentionBudgetAdmissionWeights(t *testing.T) {
+	bulk := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
+	daemon := newParseRetentionBudget(defaultParseRetentionBytes)
+	for _, tc := range []struct {
+		name         string
+		budget       *parseRetentionBudget
+		sourceBytes  int64
+		wantWeight   int64
+		wantRetained int64
+	}{
+		{"bulk_one_byte", bulk, 1, 65540, 65540},
+		{"bulk_six_mib", bulk, 6291456, 25231360, 25231360},
+		{"bulk_below_clamp", bulk, 67092479, 268435452, 268435452},
+		{"bulk_at_clamp", bulk, 67092480, 268435456, 268435456},
+		{"bulk_saturated", bulk, 134217728, 268435456, 536870912},
+		{"bulk_unknown", bulk, 0, 268435456, 536870912},
+		{"bulk_negative", bulk, -1, 268435456, 536870912},
+		{"daemon_sixty_four_mib", daemon, 67108864, 67108864, 67108864},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantWeight, tc.budget.weight(tc.sourceBytes))
+			assert.Equal(t, tc.wantRetained, tc.budget.retainedBytes(tc.sourceBytes))
+		})
+	}
+}

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -1253,6 +1253,18 @@ func TestParseRetentionKeepsCodexSourceBytesForStagingThreshold(t *testing.T) {
 		"the Codex staging threshold input must keep the whole-file size")
 }
 
+func TestParseRetentionChargesPromotedStorageShadowWholeSize(t *testing.T) {
+	engine, files, _ := newSQLiteContainerMemberFixture(t, 64<<20, 64)
+	storagePath := filepath.Join(t.TempDir(), "ses-000.json")
+	require.NoError(t, os.WriteFile(storagePath, make([]byte, 4096), 0o644))
+
+	promoted := files[0]
+	promoted.ProviderSource = &parser.SourceRef{DisplayPath: storagePath}
+
+	assert.Equal(t, int64(4096), engine.parseRetentionSourceBytes(promoted),
+		"a member promoted to its storage shadow is charged the shadow, not a container share")
+}
+
 func TestParseRetentionFallsBackToContainerSizeWithoutPass(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "mimocode.db")
 	handle, err := os.Create(dbPath)

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -1265,6 +1265,134 @@ func TestParseRetentionChargesPromotedStorageShadowWholeSize(t *testing.T) {
 		"a member promoted to its storage shadow is charged the shadow, not a container share")
 }
 
+type retentionSourceTestProvider struct {
+	parser.ProviderBase
+	source parser.SourceRef
+}
+
+func (p *retentionSourceTestProvider) FindSource(
+	context.Context, parser.FindSourceRequest,
+) (parser.SourceRef, bool, error) {
+	return p.source, true, nil
+}
+
+func (p *retentionSourceTestProvider) Fingerprint(
+	context.Context, parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{}, nil
+}
+
+func (p *retentionSourceTestProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{ResultSetComplete: true}, nil
+}
+
+type retentionSourceTestFactory struct {
+	provider *retentionSourceTestProvider
+}
+
+func (f retentionSourceTestFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f retentionSourceTestFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f retentionSourceTestFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+func TestProcessProviderFileUsesResolvedSourceAfterStaleMetadataDiscard(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "mimocode.db")
+	handle, err := os.Create(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(64<<20))
+	require.NoError(t, handle.Close())
+
+	shadowPath := filepath.Join(t.TempDir(), "session.json")
+	handle, err = os.Create(shadowPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(64<<20))
+	require.NoError(t, handle.Close())
+
+	virtualPath := parser.VirtualSourcePath(dbPath, "session")
+	virtual := parser.SourceRef{
+		Provider:       parser.AgentMiMoCode,
+		DisplayPath:    virtualPath,
+		FingerprintKey: virtualPath,
+		Key:            virtualPath,
+	}
+	provider := &retentionSourceTestProvider{
+		source: parser.SourceRef{
+			Provider:       parser.AgentMiMoCode,
+			DisplayPath:    shadowPath,
+			FingerprintKey: shadowPath,
+			Key:            shadowPath,
+		},
+	}
+	provider.ProviderBase = parser.ProviderBase{
+		Def: parser.AgentDef{Type: parser.AgentMiMoCode},
+		Caps: parser.Capabilities{
+			Source: parser.SourceCapabilities{
+				FindSource: parser.CapabilitySupported,
+			},
+		},
+	}
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentMiMoCode: {filepath.Dir(dbPath)},
+		},
+		Machine:           "local",
+		ProviderFactories: []parser.ProviderFactory{retentionSourceTestFactory{provider: provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentMiMoCode: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	before := parser.SQLiteContainerState{
+		DBInode: 1, DBDevice: 2, DBChangeCounter: 3,
+	}
+	engine.beginStreamingSQLiteContainerPass(map[string]parser.SQLiteContainerState{
+		dbPath: before,
+	})
+	engine.noteSQLiteContainerDiscovery(parser.DiscoveredFile{
+		Agent: parser.AgentMiMoCode,
+		Path:  virtualPath,
+	})
+	for i := range 63 {
+		engine.noteSQLiteContainerDiscovery(parser.DiscoveredFile{
+			Agent: parser.AgentMiMoCode,
+			Path:  parser.VirtualSourcePath(dbPath, fmt.Sprintf("sibling-%02d", i)),
+		})
+	}
+
+	origStat := statSQLiteContainerState
+	t.Cleanup(func() { statSQLiteContainerState = origStat })
+	statSQLiteContainerState = func(path string) (parser.SQLiteContainerState, bool) {
+		if path == dbPath {
+			changed := before
+			changed.DBChangeCounter++
+			return changed, true
+		}
+		return origStat(path)
+	}
+
+	result, used := engine.processProviderFile(t.Context(), parser.DiscoveredFile{
+		Agent:           parser.AgentMiMoCode,
+		Path:            virtualPath,
+		ProviderSource:  &virtual,
+		ProviderProcess: true,
+	})
+	require.True(t, used)
+	require.NoError(t, result.err)
+	assert.Equal(t, int64(64<<20), result.sourceBytes,
+		"a source resolved after stale metadata discard must size from the resolved path")
+	(&syncJob{processResult: result}).releaseAll()
+}
+
 func TestRehydrateStorageShadowRemovesSQLiteMembership(t *testing.T) {
 	engine, files, dbPath := newSQLiteContainerMemberFixture(t, 64<<20, 64)
 	shadowPath := filepath.Join(filepath.Dir(dbPath), "storage", "session.json")

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -1380,17 +1380,26 @@ func TestProcessProviderFileUsesResolvedSourceAfterStaleMetadataDiscard(t *testi
 		return origStat(path)
 	}
 
-	result, used := engine.processProviderFile(t.Context(), parser.DiscoveredFile{
+	results := engine.startWorkers(t.Context(), []parser.DiscoveredFile{{
 		Agent:           parser.AgentMiMoCode,
 		Path:            virtualPath,
 		ProviderSource:  &virtual,
 		ProviderProcess: true,
-	})
-	require.True(t, used)
-	require.NoError(t, result.err)
-	assert.Equal(t, int64(64<<20), result.sourceBytes,
+	}})
+	job, ok := <-results
+	require.True(t, ok)
+	require.NoError(t, job.err)
+	assert.Equal(t, int64(64<<20), job.sourceBytes,
 		"a source resolved after stale metadata discard must size from the resolved path")
-	(&syncJob{processResult: result}).releaseAll()
+	assert.Equal(t, shadowPath, job.containerResultPath(),
+		"container completion must use the resolved source path")
+	engine.noteSQLiteContainerResult(job.containerResultPath(), true)
+	engine.containerMu.Lock()
+	completed := engine.containerPass.completed[dbPath]
+	engine.containerMu.Unlock()
+	assert.Zero(t, completed,
+		"a storage shadow must not count as a completed SQLite member")
+	job.releaseAll()
 }
 
 func TestRehydrateStorageShadowRemovesSQLiteMembership(t *testing.T) {

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -1265,6 +1265,40 @@ func TestParseRetentionChargesPromotedStorageShadowWholeSize(t *testing.T) {
 		"a member promoted to its storage shadow is charged the shadow, not a container share")
 }
 
+func TestRehydrateStorageShadowRemovesSQLiteMembership(t *testing.T) {
+	engine, files, dbPath := newSQLiteContainerMemberFixture(t, 64<<20, 64)
+	shadowPath := filepath.Join(filepath.Dir(dbPath), "storage", "session.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(shadowPath), 0o755))
+	handle, err := os.Create(shadowPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(64<<20))
+	require.NoError(t, handle.Close())
+
+	provider := &reconciliationSourceStateTestProvider{
+		source: parser.SourceRef{
+			Provider:    parser.AgentMiMoCode,
+			DisplayPath: shadowPath,
+		},
+	}
+	rehydrated, err := engine.rehydrateReconciliationPage(
+		t.Context(), []reconciliationCandidate{{
+			Provider: parser.AgentMiMoCode,
+			Identity: "session",
+			Path:     files[0].Path,
+		}},
+		map[parser.AgentType]parser.Provider{
+			parser.AgentMiMoCode: provider,
+		},
+		false,
+	)
+	require.NoError(t, err)
+	require.Len(t, rehydrated, 1)
+	assert.Equal(t, 63, engine.sqliteContainerDiscoveredMembers(files[0]),
+		"a storage-promoted candidate must leave the remaining SQLite member count")
+	assert.Equal(t, int64(64<<20), engine.parseRetentionSourceBytes(rehydrated[0]),
+		"a storage-promoted candidate must keep its resolved file size")
+}
+
 func TestParseRetentionFallsBackToContainerSizeWithoutPass(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "mimocode.db")
 	handle, err := os.Create(dbPath)

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -1143,6 +1143,59 @@ func TestParseRetentionChargesContainerMemberItsShare(t *testing.T) {
 		"member shares must sum back to the container they partition")
 }
 
+func TestParseRetentionFloorsContainerMemberShareAboveZero(t *testing.T) {
+	// A container smaller than its membership divides to zero, which
+	// retainedBytes reads as an unknown source and charges the whole budget:
+	// the exact fault per-member sizing removes. The floor is what prevents it,
+	// so pin it with a fixture the share test's 64 MiB container cannot reach.
+	engine, files, _ := newSQLiteContainerMemberFixture(t, 32, 64)
+
+	charged := engine.parseRetentionSourceBytes(files[0])
+	assert.Equal(t, int64(1), charged,
+		"a member share must floor at one byte, never divide to zero")
+
+	budget := newBulkParseRetentionBudget(defaultBulkParseRetentionBytes)
+	assert.Equal(t, parseRetentionFixedBytes+parseRetentionMultiplier, budget.weight(charged),
+		"the floored share must weigh as a known small source")
+	assert.Equal(t, defaultBulkParseRetentionBytes, budget.weight(0),
+		"a zero estimate would instead charge the whole admission capacity")
+
+	first, err := budget.acquire(t.Context(), charged)
+	require.NoError(t, err)
+	defer first.Release()
+	second, err := budget.acquire(t.Context(), charged)
+	require.NoError(t, err,
+		"a floored member share must not hold the budget exclusively")
+	second.Release()
+}
+
+func TestParseRetentionKeepsDaemonScavengeForLargeNonMembers(t *testing.T) {
+	// Preservation invariant: correcting the estimate narrows which sources
+	// clear the daemon scavenge threshold. A member's share may now fall below
+	// it, which is coherent with the smaller parse, but a genuinely large
+	// non-member source must still mark a scavenge.
+	engine, files, dbPath := newSQLiteContainerMemberFixture(t, 64<<20, 64)
+
+	memberBytes := engine.parseRetentionSourceBytes(files[0])
+	assert.Less(t, memberBytes, parseRetentionScavengeThreshold,
+		"a member share below the threshold is what narrows daemon scavenging")
+
+	plainPath := filepath.Join(filepath.Dir(dbPath), "large.jsonl")
+	handle, err := os.Create(plainPath)
+	require.NoError(t, err)
+	require.NoError(t, handle.Truncate(64<<20))
+	require.NoError(t, handle.Close())
+	plain := parser.DiscoveredFile{Path: plainPath, Agent: parser.AgentClaude}
+
+	daemon := newParseRetentionBudget(defaultParseRetentionBytes)
+	daemon.scavenge = func() {}
+	lease, err := daemon.acquire(t.Context(), engine.parseRetentionSourceBytes(plain))
+	require.NoError(t, err)
+	defer lease.Release()
+	assert.True(t, daemon.scavengePending.Load(),
+		"a large non-member source must still mark a daemon scavenge")
+}
+
 func TestParseRetentionKeepsWholeFileSourceExclusive(t *testing.T) {
 	engine, _, dbPath := newSQLiteContainerMemberFixture(t, 64<<20, 64)
 	plainPath := filepath.Join(filepath.Dir(dbPath), "whole.jsonl")

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -1138,8 +1138,7 @@ func TestParseRetentionChargesContainerMemberItsShare(t *testing.T) {
 	for _, file := range files {
 		total += engine.parseRetentionSourceBytes(file)
 	}
-	assert.Equal(t, int64(67108864), total)
-	assert.LessOrEqual(t, total, int64(67108864),
+	assert.Equal(t, int64(67108864), total,
 		"member shares must sum back to the container they partition")
 }
 

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -294,7 +294,7 @@ func (e *Engine) processS3Session(
 	// so acquire the retention lease that bounds the materialized-and-parsed
 	// payload just before the object is fetched and parsed. Every result from
 	// here carries the lease; releaseRetention frees it after consumption.
-	sourceBytes := parseRetentionSourceBytes(file)
+	sourceBytes := e.parseRetentionSourceBytes(file)
 	lease, err := e.retentionBudget().acquire(ctx, sourceBytes)
 	if err != nil {
 		return processResult{err: err}


### PR DESCRIPTION
Sessions in a shared OpenCode-family SQLite database are discovered as one virtual source per row, and each of them stats back to the same container file, so the parse retention budget charged every member the size of the whole database.

On a 2.5 GB opencode.db each of its 204 sessions weighed the full 256 MiB bulk budget and a sync admitted one parse at a time. This divides a container member's estimated source bytes by the sessions the current pass discovered in that container. Members partition the container's rows, so the shares still sum to the container file and the memory ceiling is unchanged.

The semaphore capacity, the four-times multiplier and the pending-results bound are untouched. A file that is not a container member keeps its stat size, and so does a member whose pass tracks no membership.

With a 64 MiB container holding 64 discovered sessions, bulk admission goes from one concurrent parse to the full worker pool. The estimate is read at the three parse seams in internal/sync/engine.go and internal/sync/s3.go.

Closes #1723
