### PR TITLE
test(e2e): match the full image cleanup preview count

### DIFF
--- a/frontend/e2e/settings-image-cleanup.spec.ts
+++ b/frontend/e2e/settings-image-cleanup.spec.ts
@@ -76,7 +76,7 @@ test.describe("Settings: Tool-result images", () => {
     const previewBtn = page.getByRole("button", { name: "Preview" });
     await previewBtn.click();
 
-    await expect(page.getByText("5", { exact: false })).toBeVisible();
+    await expect(page.getByText("5 image payloads", { exact: true })).toBeVisible();
     await expect(page.getByText("my-project")).toBeVisible();
   });
 


### PR DESCRIPTION
The image-cleanup preview test now matches `5 image payloads` exactly. This prevents temporary paths containing `5` in hidden provider settings from causing Playwright strict-mode failures.
