### PR TITLE
fix(config): allow installation ID reads during Windows rename

### DIFF
--- a/internal/config/installation.go
+++ b/internal/config/installation.go
@@ -14,7 +14,7 @@ const installationIDFilename = "telemetry-install-id"
 
 func (c *Config) readInstallationID() error {
 	path := filepath.Join(c.DataDir, installationIDFilename)
-	data, err := os.ReadFile(path)
+	data, err := readInstallationIDFile(path)
 	if err != nil {
 		return err
 	}

--- a/internal/config/installation_read_other.go
+++ b/internal/config/installation_read_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package config
+
+import "os"
+
+func readInstallationIDFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/internal/config/installation_read_windows.go
+++ b/internal/config/installation_read_windows.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func readInstallationIDFile(path string) ([]byte, error) {
+	path16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	// Readers must share delete access while the publishing rename still holds its handle.
+	handle, err := windows.CreateFile(path16, windows.GENERIC_READ, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(handle), path)
+	defer file.Close()
+	return io.ReadAll(file)
+}

--- a/internal/config/installation_read_windows.go
+++ b/internal/config/installation_read_windows.go
@@ -3,12 +3,18 @@ package config
 import (
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"golang.org/x/sys/windows"
 )
 
 func readInstallationIDFile(path string) ([]byte, error) {
-	path16, err := windows.UTF16PtrFromString(path)
+	openPath, err := installationIDWindowsPath(path)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	path16, err := windows.UTF16PtrFromString(openPath)
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}
@@ -20,4 +26,22 @@ func readInstallationIDFile(path string) ([]byte, error) {
 	file := os.NewFile(uintptr(handle), path)
 	defer file.Close()
 	return io.ReadAll(file)
+}
+
+func installationIDWindowsPath(path string) (string, error) {
+	if strings.HasPrefix(path, `\\?\`) || strings.HasPrefix(path, `\\.\`) || strings.HasPrefix(path, `\??\`) {
+		return path, nil
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	// Older Windows versions require the extended prefix even in Go processes.
+	if len(absolute) < 248 {
+		return path, nil
+	}
+	if strings.HasPrefix(absolute, `\\`) {
+		return `\\?\UNC\` + absolute[2:], nil
+	}
+	return `\\?\` + absolute, nil
 }

--- a/internal/config/installation_windows_test.go
+++ b/internal/config/installation_windows_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestInstallationIdentityDuringRenameHandle(t *testing.T) {
+	for _, readOnly := range []bool{false, true} {
+		name := "ensure"
+		if readOnly {
+			name = "read"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			const id = "0123456789abcdef0123456789abcdef"
+			temporary := filepath.Join(dir, ".installation-proof")
+			require.NoError(t, os.WriteFile(temporary, []byte(id+"\n"), 0o600))
+			path16, err := windows.UTF16PtrFromString(temporary)
+			require.NoError(t, err)
+			// A rename publishes the name before closing its DELETE-access handle.
+			handle, err := windows.CreateFile(path16, windows.DELETE, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, windows.CloseHandle(handle)) })
+			path := filepath.Join(dir, installationIDFilename)
+			require.NoError(t, os.Rename(temporary, path))
+			_, err = os.ReadFile(path)
+			require.ErrorIs(t, err, windows.ERROR_SHARING_VIOLATION)
+			cfg := Config{DataDir: dir}
+			if readOnly {
+				err = cfg.readInstallationID()
+			} else {
+				err = cfg.ensureInstallationID()
+			}
+			require.NoError(t, err)
+			require.Equal(t, id, cfg.InstallationID)
+			_, err = os.Stat(filepath.Join(dir, configFileName+".lock"))
+			require.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestInstallationIdentityLongPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), strings.Repeat("a", 100), strings.Repeat("b", 100), strings.Repeat("c", 100))
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	const id = "0123456789abcdef0123456789abcdef"
+	path := filepath.Join(dir, installationIDFilename)
+	require.NoError(t, os.WriteFile(path, []byte(id+"\n"), 0o600))
+	cfg := Config{DataDir: dir}
+	require.NoError(t, cfg.ensureInstallationID())
+	require.Equal(t, id, cfg.InstallationID)
+}

--- a/internal/config/installation_windows_test.go
+++ b/internal/config/installation_windows_test.go
@@ -51,7 +51,44 @@ func TestInstallationIdentityLongPath(t *testing.T) {
 	const id = "0123456789abcdef0123456789abcdef"
 	path := filepath.Join(dir, installationIDFilename)
 	require.NoError(t, os.WriteFile(path, []byte(id+"\n"), 0o600))
-	cfg := Config{DataDir: dir}
-	require.NoError(t, cfg.ensureInstallationID())
-	require.Equal(t, id, cfg.InstallationID)
+	t.Chdir(dir)
+	for _, dataDir := range []string{dir, `\\?\` + dir, "."} {
+		cfg := Config{DataDir: dataDir}
+		require.NoError(t, cfg.ensureInstallationID())
+		require.Equal(t, id, cfg.InstallationID)
+	}
+}
+
+func TestInstallationIDWindowsPath(t *testing.T) {
+	tail := strings.Repeat(`directory\`, 30) + installationIDFilename
+	for _, tc := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{"short", `C:\data\telemetry-install-id`, `C:\data\telemetry-install-id`},
+		{"drive", `C:\data\` + tail, `\\?\C:\data\` + tail},
+		{"unc", `\\server\share\` + tail, `\\?\UNC\server\share\` + tail},
+		{"extended", `\\?\C:\data\` + tail, `\\?\C:\data\` + tail},
+		{"extended unc", `\\?\UNC\server\share\` + tail, `\\?\UNC\server\share\` + tail},
+		{"device", `\\.\C:\data\` + tail, `\\.\C:\data\` + tail},
+		{"native", `\??\C:\data\` + tail, `\??\C:\data\` + tail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := installationIDWindowsPath(tc.path)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestReadInstallationIDInvalidPath(t *testing.T) {
+	for _, path := range []string{"bad\x00path", "\\\\?\\C:\\bad\x00path"} {
+		_, err := readInstallationIDFile(path)
+		var pathErr *os.PathError
+		require.ErrorAs(t, err, &pathErr)
+		require.Equal(t, "open", pathErr.Op)
+		require.Equal(t, path, pathErr.Path)
+		require.NotErrorIs(t, err, os.ErrNotExist)
+	}
 }


### PR DESCRIPTION
Concurrent AgentsView startup on Windows now reads the installation ID while another process finishes creating it, avoiding intermittent file-sharing errors. Read-only diagnostics use the same reader.

Windows briefly keeps a delete-access handle open after publishing the filename. The reader now permits delete sharing while requesting read access, preserving the lock-free read path. A Windows regression test holds that handle open to exercise the race deterministically.
