### PR TITLE
Draw Activity concurrency as one stacked bar chart

### DIFF
--- a/docs/activity.md
+++ b/docs/activity.md
@@ -67,30 +67,33 @@ shows the report's current **as of** time.
 
 ## Concurrency
 
-The **Concurrency** chart shows three aligned tracks on a shared time axis:
-**Interactive** in blue, **Subagents** in violet, and **Automated** in orange.
-Interactive is first and has more vertical space. Each track has its own scale
-and peak count, so a large subagent burst does not flatten the interactive
-activity. Each bar shows that class's maximum within the bucket; the three
-maxima may occur at different instants. The strip below the tracks marks active
-versus idle buckets across all sessions. Interactive concurrency counts
-overlapping human-facing conversations; human attention is not measured.
+The **Concurrency** chart is a stacked bar chart on one time axis. Each bucket
+is a single bar whose segments are **Interactive** in blue, **Subagents** in
+violet, and **Automated** in orange, stacked from the baseline in that order on
+one shared scale. Bar height is the bucket's combined concurrency peak, and each
+segment is that class's count at the instant of that peak, so the segments
+always add up to the bar. The legend above the chart names the segments, and the
+label on the right gives the combined peak for the range. The strip below the
+bars marks active versus idle buckets across all sessions. Interactive
+concurrency counts overlapping human-facing conversations; human attention is
+not measured.
 
 ![Weekly Activity concurrency chart](/docs/assets/generated/screenshots/activity-concurrency.png)
 
-Hover a bucket to see its time range, each class's independent peak, the
-combined peak, agent-minutes, input and output tokens, and cost. The
-**All-session overlay** control draws a combined **Tokens** or **Cost** trend
-over the Interactive track, with its own scale on the right. These usage totals
-include all three classes.
+Hover a bucket to see its time range, the stacked split at the combined peak,
+the combined peak, each class's own peak within the bucket, agent-minutes, input
+and output tokens, and cost. A class's own peak can exceed its segment when that
+class peaked at a different instant from the combined peak. The **All-session
+overlay** control draws a combined **Tokens** or **Cost** trend over the bars,
+with its own scale on the right. These usage totals include all three classes.
 
 Clicking a bucket filters the Sessions table to the sessions active in that time
-slot. Drag across buckets to select a range on all three tracks. Keyboard users
-can select with Enter or Space, extend with Shift+Arrow, and clear with Escape.
-Click the same bucket again, or dismiss the **Active:** badge in the table
-header, to clear the slot filter. Membership is computed by the same shared
-aggregator that builds the chart, then fetched as a bounded page; the browser no
-longer downloads every raw activity interval to perform this drill-down.
+slot. Drag across buckets to select a range. Keyboard users can select with
+Enter or Space, extend with Shift+Arrow, and clear with Escape. Click the same
+bucket again, or dismiss the **Active:** badge in the table header, to clear the
+slot filter. Membership is computed by the same shared aggregator that builds
+the chart, then fetched as a bounded page; the browser no longer downloads every
+raw activity interval to perform this drill-down.
 
 ## Sessions
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1057,7 +1057,6 @@
   "activity_automated_peak": "Automated peak",
   "activity_combined_peak": "Combined peak",
   "activity_peak_at": "peak {count} at {time}",
-  "activity_independent_scales": "Each track has its own scale.",
   "activity_all_sessions_overlay": "All-session overlay",
   "activity_class_split": "int {int} / sub {sub} / auto {auto}",
   "activity_concurrency": "Concurrency",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1057,7 +1057,6 @@
   "activity_automated_peak": "Pic automatisé",
   "activity_combined_peak": "Pic global",
   "activity_peak_at": "pic {count} à {time}",
-  "activity_independent_scales": "Chaque piste a sa propre échelle.",
   "activity_all_sessions_overlay": "Superposition globale",
   "activity_class_split": "int {int} / sous-agents {sub} / auto {auto}",
   "activity_concurrency": "Simultanéité",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1057,7 +1057,6 @@
   "activity_automated_peak": "自動実行のピーク",
   "activity_combined_peak": "全体のピーク",
   "activity_peak_at": "{time} にピーク {count}",
-  "activity_independent_scales": "各トラックは独立したスケールを使用します。",
   "activity_all_sessions_overlay": "全セッションのオーバーレイ",
   "activity_class_split": "対話 {int} / サブ {sub} / 自動 {auto}",
   "activity_concurrency": "同時実行性",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -1004,7 +1004,6 @@
   "activity_automated_peak": "자동화 최대 동시 실행",
   "activity_combined_peak": "전체 최대 동시 실행",
   "activity_peak_at": "{time}에 최대 {count}",
-  "activity_independent_scales": "각 트랙은 별도의 척도를 사용합니다.",
   "activity_all_sessions_overlay": "전체 세션 오버레이",
   "activity_class_split": "대화형 {int} / 하위 {sub} / 자동 {auto}",
   "activity_concurrency": "동시성",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1002,7 +1002,6 @@
   "activity_automated_peak": "自动化峰值",
   "activity_combined_peak": "总并发峰值",
   "activity_peak_at": "{time} 达到峰值 {count}",
-  "activity_independent_scales": "每条轨道使用独立刻度。",
   "activity_all_sessions_overlay": "所有会话叠加",
   "activity_class_split": "交互 {int} / 子代理 {sub} / 自动 {auto}",
   "activity_concurrency": "并发",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -1002,7 +1002,6 @@
   "activity_automated_peak": "自動化尖峰",
   "activity_combined_peak": "總並發尖峰",
   "activity_peak_at": "{time} 達到尖峰 {count}",
-  "activity_independent_scales": "每條軌道使用獨立刻度。",
   "activity_all_sessions_overlay": "所有工作階段疊加",
   "activity_class_split": "交互 {int} / 子代理 {sub} / 自動 {auto}",
   "activity_concurrency": "並發",

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -19,16 +19,16 @@
     ) => void;
   } = $props();
 
-  const TRACK_HEADER_H = 24;
-  const TRACK_GAP = 10;
+  const TOP_PAD = 8;
+  const PLOT_H = 160;
   const X_LABEL_H = 18;
   const STRIP_H = 14;
   const STRIP_GAP = 6;
   const Y_LABEL_W = 32;
   const RIGHT_PAD = 16;
   const OVERLAY_AXIS_W = 48;
-  const TOP_PAD = TRACK_HEADER_H;
   const TICK_TARGET = 4;
+  const PLOT_BOTTOM = TOP_PAD + PLOT_H;
 
   const buckets = $derived(report.buckets ?? []);
 
@@ -248,7 +248,7 @@
     dragEnd = null;
   }
 
-  // Combined usage overlays the interactive track with its own right axis.
+  // Combined usage overlays the stacked plot with its own right axis.
   let overlayMetric = $state<"none" | "tokens" | "cost">("none");
   const overlayOptions: TypeaheadOption[] = $derived([
     { name: "none", label: m.activity_overlay_none(), displayLabel: m.activity_overlay_none() },
@@ -280,12 +280,29 @@
     }).format(v);
   }
 
-  function trackPeakLabel(peak: Report["peak"]): string {
-    const count = peak.agents.toLocaleString(getLocale());
-    return peak.at
-      ? m.activity_peak_at({ count, time: timeLabel(Date.parse(peak.at)) })
-      : m.activity_peak_label({ count });
+  // Sub-day ranges read the clock alone; longer ranges need the date too.
+  function peakTimeLabel(ms: number): string {
+    if (report.bucket_unit === "minute" || report.bucket_unit === "hour") {
+      return timeLabel(ms);
+    }
+    return formatDateTime(ms, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+      timeZone: report.timezone,
+    });
   }
+
+  // The combined peak is the tallest stacked bar: its segments sum to
+  // report.peak.agents at that instant.
+  const peakLabel = $derived.by(() => {
+    const count = report.peak.agents.toLocaleString(getLocale());
+    return report.peak.at
+      ? m.activity_peak_at({ count, time: peakTimeLabel(Date.parse(report.peak.at)) })
+      : m.activity_peak_label({ count });
+  });
 
   function fmtOverlayTick(v: number): string {
     if (overlayMetric === "cost") return formatMoney(moneyFromMicrodollars(v));
@@ -343,63 +360,74 @@
     return { step, max };
   }
 
-  // Class maxima occur independently; a busy subagent track must not flatten
-  // the interactive track or hide a class peak outside the combined peak.
-  const tracks = $derived.by(() => {
-    const definitions = [
-      {
-        kind: "interactive",
-        label: m.activity_interactive(),
-        peakLabel: m.activity_interactive_peak(),
-        field: "max_interactive_agents" as const,
-        peak: report.interactive_peak,
-        height: 120,
-      },
-      {
-        kind: "subagent",
-        label: m.activity_subagents(),
-        peakLabel: m.activity_subagent_peak(),
-        field: "max_subagent_agents" as const,
-        peak: report.subagent_peak,
-        height: 72,
-      },
-      {
-        kind: "automated",
-        label: m.activity_automated(),
-        peakLabel: m.activity_automated_peak(),
-        field: "max_automated_agents" as const,
-        peak: report.automated_peak,
-        height: 72,
-      },
-    ];
-    let offset = 0;
-    return definitions.map((track) => {
-      const top = offset + TRACK_HEADER_H;
-      const bottom = top + track.height;
-      offset = bottom + TRACK_GAP;
-      const scale = niceScale(
-        Math.max(0, ...buckets.map((bucket) => bucket[track.field])),
-      );
-      const ticks = Array.from(
-        { length: Math.round(scale.max / scale.step) + 1 },
-        (_, i) => ({
-          y: bottom - ((i * scale.step) / scale.max) * track.height,
-          label: (i * scale.step).toLocaleString(getLocale()),
-        }),
-      );
-      return { ...track, top, bottom, scale, ticks };
-    });
-  });
-  const chartH = $derived(tracks[2]!.bottom);
+  // Segment order from the baseline up. Each segment is that class's count at
+  // the instant of the bucket's combined peak, so the stack sums to max_agents.
+  // The independent class maxima can occur at different instants and are only
+  // reported in the tooltip; stacking them would overstate overlap.
+  const classes = $derived([
+    {
+      kind: "interactive",
+      label: m.activity_interactive(),
+      peakLabel: m.activity_interactive_peak(),
+      atPeak: "interactive_at_peak" as const,
+      max: "max_interactive_agents" as const,
+    },
+    {
+      kind: "subagent",
+      label: m.activity_subagents(),
+      peakLabel: m.activity_subagent_peak(),
+      atPeak: "subagent_at_peak" as const,
+      max: "max_subagent_agents" as const,
+    },
+    {
+      kind: "automated",
+      label: m.activity_automated(),
+      peakLabel: m.activity_automated_peak(),
+      atPeak: "automated_at_peak" as const,
+      max: "max_automated_agents" as const,
+    },
+  ]);
 
-  // All three tracks, the activity strip, and selection share bucket bounds.
+  // One shared y-axis from zero to the tallest stacked bar.
+  const yScale = $derived(
+    niceScale(Math.max(0, ...buckets.map((bucket) => bucket.max_agents))),
+  );
+  const yTicks = $derived(
+    Array.from({ length: Math.round(yScale.max / yScale.step) + 1 }, (_, i) => ({
+      y: PLOT_BOTTOM - ((i * yScale.step) / yScale.max) * PLOT_H,
+      label: (i * yScale.step).toLocaleString(getLocale()),
+    })),
+  );
+
+  function segmentHeight(count: number): number {
+    return (count / yScale.max) * PLOT_H;
+  }
+
+  // The stacked bar, the activity strip, and selection share bucket bounds.
+  // Segments are stacked from the baseline in class order; zero-count classes
+  // draw nothing.
   const bars = $derived(buckets.map((bucket, idx) => {
     const start = Date.parse(bucket.start);
     const end = Date.parse(bucket.end);
     const cellX = xForMs(start);
     const cellW = Math.max(((end - start) / rangeSpanMs) * plotWidth, 1);
     const gap = Math.min(cellW * 0.2, 2);
-    return { x: cellX + gap / 2, w: Math.max(cellW - gap, 1), cellX, cellW, idx };
+    let top = PLOT_BOTTOM;
+    const segments = classes.flatMap((cls) => {
+      const count = bucket[cls.atPeak];
+      if (count <= 0) return [];
+      const height = segmentHeight(count);
+      top -= height;
+      return [{ kind: cls.kind, y: top, height }];
+    });
+    return {
+      x: cellX + gap / 2,
+      w: Math.max(cellW - gap, 1),
+      cellX,
+      cellW,
+      idx,
+      segments,
+    };
   }));
 
   const selectionBounds = $derived.by(() => {
@@ -437,7 +465,7 @@
     const values =
       overlayDataMax <= 0 ? [0] : [0, overlayDataMax / 2, overlayDataMax];
     return values.map((val) => ({
-      y: tracks[0]!.bottom - (val / overlayMax) * tracks[0]!.height,
+      y: PLOT_BOTTOM - (val / overlayMax) * PLOT_H,
       label: fmtOverlayTick(val),
     }));
   });
@@ -525,8 +553,8 @@
     bars.filter((bar) => Date.parse(buckets[bar.idx]!.start) < futureStartMs),
   );
 
-  const svgH = $derived(chartH + STRIP_GAP + STRIP_H + X_LABEL_H);
-  const stripY = $derived(chartH + STRIP_GAP);
+  const svgH = PLOT_BOTTOM + STRIP_GAP + STRIP_H + X_LABEL_H;
+  const stripY = PLOT_BOTTOM + STRIP_GAP;
 
   function setOverlayMetric(value: string) {
     overlayMetric = value as "none" | "tokens" | "cost";
@@ -565,7 +593,16 @@
     </div>
   </div>
 
-  <p class="scale-note">{m.activity_independent_scales()}</p>
+  <div class="chart-meta">
+    <div class="legend" aria-hidden="true">
+      {#each classes as cls (cls.kind)}
+        <span class="legend-item">
+          <span class={`swatch ${cls.kind}`}></span>{cls.label}
+        </span>
+      {/each}
+    </div>
+    <span class="chart-peak">{peakLabel}</span>
+  </div>
 
   <div
     class="timeline-body"
@@ -582,7 +619,7 @@
       xDomain={[rangeStartMs, rangeEndMs]}
       yDomain={[0, 1]}
       xRange={[Y_LABEL_W, Y_LABEL_W + plotWidth]}
-      yRange={[tracks[0]!.bottom, tracks[0]!.top]}
+      yRange={[PLOT_BOTTOM, TOP_PAD]}
       padding={0}
       height={svgH}
     >
@@ -594,49 +631,36 @@
             x={futureX}
             y={TOP_PAD}
             width={futureW}
-            height={chartH - TOP_PAD}
+            height={PLOT_H}
           />
         {/if}
 
-        {#each tracks as track (track.kind)}
-          <g class="concurrency-track" data-track={track.kind}>
-            <Text
-              class={`track-label ${track.kind}`}
-              value={track.label}
-              x={Y_LABEL_W}
-              y={track.top - 8}
-            />
-            <Text
-              class="track-peak"
-              value={trackPeakLabel(track.peak)}
-              x={Y_LABEL_W + plotWidth}
-              y={track.top - 8}
-              textAnchor="end"
-            />
-            {#each track.ticks as tick}
-              <Line
-                x1={Y_LABEL_W}
-                y1={tick.y}
-                x2={Y_LABEL_W + plotWidth}
-                y2={tick.y}
-                class="grid-line"
-              />
-              <Text
-                value={tick.label}
-                x={Y_LABEL_W - 4}
-                y={tick.y + 3}
-                class="y-label"
-                textAnchor="end"
-              />
-            {/each}
-            {#each bars as bar (bar.idx)}
-              {@const height = buckets[bar.idx]![track.field] / track.scale.max * track.height}
+        {#each yTicks as tick}
+          <Line
+            x1={Y_LABEL_W}
+            y1={tick.y}
+            x2={Y_LABEL_W + plotWidth}
+            y2={tick.y}
+            class="grid-line"
+          />
+          <Text
+            value={tick.label}
+            x={Y_LABEL_W - 4}
+            y={tick.y + 3}
+            class="y-label"
+            textAnchor="end"
+          />
+        {/each}
+        {#each bars as bar (bar.idx)}
+          {@const selected = activeRange !== null && bar.idx >= activeRange.start && bar.idx < activeRange.end}
+          <g class="concurrency-bar" data-concurrency-bar={bar.idx}>
+            {#each bar.segments as seg (seg.kind)}
               <Rect
-                class={`concurrency-seg ${track.kind}${activeRange && bar.idx >= activeRange.start && bar.idx < activeRange.end ? " selected" : ""}`}
+                class={`concurrency-seg ${seg.kind}${selected ? " selected" : ""}`}
                 x={bar.x}
-                y={track.bottom - height}
+                y={seg.y}
                 width={bar.w}
-                {height}
+                height={seg.height}
               />
             {/each}
           </g>
@@ -655,7 +679,7 @@
             x1={Y_LABEL_W + plotWidth}
             y1={TOP_PAD}
             x2={Y_LABEL_W + plotWidth}
-            y2={tracks[0]!.bottom}
+            y2={PLOT_BOTTOM}
           />
           {#each overlayTicks as tick}
             <Line
@@ -753,16 +777,22 @@
       >
         <div class="tooltip-date">{fmtBucketRange(tooltip.bucket)}</div>
         <dl class="tooltip-metrics">
-          {#each tracks as track (track.kind)}
+          {#each classes as cls (cls.kind)}
             <div>
-              <dt>{track.peakLabel}</dt>
-              <dd>{tooltip.bucket[track.field].toLocaleString(getLocale())}</dd>
+              <dt>{cls.label}</dt>
+              <dd>{tooltip.bucket[cls.atPeak].toLocaleString(getLocale())}</dd>
             </div>
           {/each}
           <div>
             <dt>{m.activity_combined_peak()}</dt>
             <dd>{tooltip.bucket.max_agents.toLocaleString(getLocale())}</dd>
           </div>
+          {#each classes as cls (cls.kind)}
+            <div>
+              <dt>{cls.peakLabel}</dt>
+              <dd>{tooltip.bucket[cls.max].toLocaleString(getLocale())}</dd>
+            </div>
+          {/each}
           <div>
             <dt>{m.activity_agent_min()}</dt>
             <dd>{fmtCompactValue(tooltip.bucket.agent_minutes)}</dd>
@@ -819,33 +849,52 @@
     font-size: 10px;
   }
 
-  .scale-note {
-    margin: 0 0 8px;
+  .chart-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    margin-bottom: 4px;
+  }
+
+  .legend {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-5);
+  }
+
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     font-size: 10px;
     color: var(--text-muted);
   }
 
-  .timeline :global(.track-label) {
-    font-size: 11px;
-    font-weight: 600;
-    fill: var(--text-secondary);
+  .swatch {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
   }
 
-  .timeline :global(.track-label.interactive) {
-    fill: var(--accent-blue);
+  .swatch.interactive {
+    background: var(--accent-blue);
   }
 
-  .timeline :global(.track-label.subagent) {
-    fill: var(--accent-violet);
+  .swatch.subagent {
+    background: var(--accent-violet);
   }
 
-  .timeline :global(.track-label.automated) {
-    fill: var(--accent-orange);
+  .swatch.automated {
+    background: var(--accent-orange);
   }
 
-  .timeline :global(.track-peak) {
+  .chart-peak {
     font-size: 10px;
-    fill: var(--text-muted);
+    color: var(--text-muted);
+    font-family: var(--font-mono);
   }
 
   .overlay-toggle {
@@ -897,6 +946,9 @@
 
   .timeline :global(.concurrency-seg) {
     opacity: 0.75;
+    /* Surface-colored seam so stacked segments read as separate parts. */
+    stroke: var(--bg-surface);
+    stroke-width: 1;
   }
 
   .timeline :global(.concurrency-seg.interactive) {

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { fireEvent, render } from "@testing-library/svelte";
 import { mount, tick, unmount } from "svelte";
 import ConcurrencyTimeline from "./ConcurrencyTimeline.svelte";
@@ -268,46 +268,68 @@ describe("ConcurrencyTimeline", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders aligned tracks with independent scales and independent class peaks", async () => {
+  it("stacks the at-peak split of every bucket on one shared scale", async () => {
     const report = makeReport();
-    // The class maxima occur at different instants from the combined peak.
+    // The combined peak of 100 splits 20/60/20, while the independent class
+    // maxima (40/60/30) occur at other instants and would sum past the scale.
     report.buckets![2] = {
       ...report.buckets![2]!,
-      max_agents: 101,
-      interactive_at_peak: 1,
-      subagent_at_peak: 100,
-      automated_at_peak: 0,
-      max_interactive_agents: 2,
-      max_subagent_agents: 100,
-      max_automated_agents: 4,
+      max_agents: 100,
+      interactive_at_peak: 20,
+      subagent_at_peak: 60,
+      automated_at_peak: 20,
+      max_interactive_agents: 40,
+      max_subagent_agents: 60,
+      max_automated_agents: 30,
     };
-    report.peak = { agents: 101, at: "2026-06-16T07:00:00Z" };
-    report.subagent_peak = { agents: 100, at: "2026-06-16T07:00:00Z" };
-    report.automated_peak = { agents: 4, at: "2026-06-16T08:00:00Z" };
+    report.peak = { agents: 100, at: "2026-06-16T07:00:00Z" };
     const c = mount(ConcurrencyTimeline, { target: document.body, props: { report } });
     await tick();
 
-    const tracks = [...document.querySelectorAll(".concurrency-track")];
-    expect(tracks.map((track) => track.querySelector(".track-label")?.textContent)).toEqual([
-      "Interactive",
-      "Subagents",
-      "Automated",
+    // One y-axis, from zero to a nice ceiling of the tallest stacked bar.
+    expect([...document.querySelectorAll(".y-label")].map((el) => el.textContent)).toEqual([
+      "0",
+      "50",
+      "100",
     ]);
-    expect(tracks.map((track) => track.querySelector(".track-peak")?.textContent)).toEqual([
-      "peak 2 at 06:00",
-      "peak 100 at 07:00",
-      "peak 4 at 08:00",
-    ]);
-    const bars = tracks.map((track) => track.querySelectorAll(".concurrency-seg")[2]!);
-    expect(bars.map((bar) => bar.getAttribute("x"))).toEqual([
-      bars[0]!.getAttribute("x"),
-      bars[0]!.getAttribute("x"),
-      bars[0]!.getAttribute("x"),
-    ]);
-    expect(bars.map((bar) => Number(bar.getAttribute("height")))).toEqual([120, 72, 72]);
+    const baseline = Number([...document.querySelectorAll(".grid-line")][0]!.getAttribute("y1"));
+    const top = Number([...document.querySelectorAll(".grid-line")].at(-1)!.getAttribute("y1"));
+    const plotH = baseline - top;
+
+    const bar = document.querySelector('[data-concurrency-bar="2"]')!;
+    const seg = (kind: string) => {
+      const el = bar.querySelector(`.concurrency-seg.${kind}`)!;
+      return { y: Number(el.getAttribute("y")), h: Number(el.getAttribute("height")) };
+    };
+    const interactive = seg("interactive");
+    const subagent = seg("subagent");
+    const automated = seg("automated");
+    // Segment heights are 20%, 60%, and 20% of the plot, in that order from
+    // the baseline, so the bar top is the full plot height for a 100 peak.
+    expect(interactive.h).toBeCloseTo(plotH * 0.2);
+    expect(subagent.h).toBeCloseTo(plotH * 0.6);
+    expect(automated.h).toBeCloseTo(plotH * 0.2);
+    expect(interactive.y + interactive.h).toBeCloseTo(baseline);
+    expect(subagent.y + subagent.h).toBeCloseTo(interactive.y);
+    expect(automated.y + automated.h).toBeCloseTo(subagent.y);
+    expect(automated.y).toBeCloseTo(top);
+    expect([...bar.querySelectorAll(".concurrency-seg")].map((el) => el.getAttribute("x"))).toEqual(
+      Array(3).fill(bar.querySelector(".concurrency-seg")!.getAttribute("x")),
+    );
+
+    // A bucket with no automated work draws no automated segment; the next
+    // class still starts at the baseline.
+    const idle = document.querySelector('[data-concurrency-bar="3"]')!;
+    expect(idle.querySelector(".concurrency-seg.automated")).toBeNull();
+    const only = idle.querySelector(".concurrency-seg.interactive")!;
+    expect(Number(only.getAttribute("y")) + Number(only.getAttribute("height"))).toBeCloseTo(
+      baseline,
+    );
+
     expect(
-      tracks.map((track) => [...track.querySelectorAll(".y-label")].at(-1)?.textContent),
-    ).toEqual(["2", "100", "4"]);
+      [...document.querySelectorAll(".legend-item")].map((el) => el.textContent?.trim()),
+    ).toEqual(["Interactive", "Subagents", "Automated"]);
+    expect(document.querySelector(".chart-peak")?.textContent).toBe("peak 100 at 07:00");
     unmount(c);
   });
 
@@ -387,8 +409,8 @@ describe("ConcurrencyTimeline", () => {
     const hits = target.querySelectorAll(".slot-hit");
     expect(hits.length).toBe(2);
     expect(target.querySelector('[data-concurrency-bucket-index="2"]')).toBeNull();
-    // The future bucket keeps its (zero-height) bar segments.
-    expect(target.querySelectorAll(".concurrency-seg.interactive").length).toBe(3);
+    // The future bucket keeps its bar slot.
+    expect(target.querySelectorAll("[data-concurrency-bar]").length).toBe(3);
 
     // Shift+ArrowRight from the last live slot clamps to the live range
     // instead of extending the selection into the future bucket.
@@ -470,7 +492,7 @@ describe("ConcurrencyTimeline", () => {
     await tick();
     const tip = target.querySelector(".tooltip");
     expect(tip).toBeTruthy();
-    expect(tip!.querySelector(".tooltip-metrics > div")?.textContent).toContain("Interactive peak");
+    expect(tip!.querySelector(".tooltip-metrics > div")?.textContent).toContain("Interactive");
     hit.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
     await tick();
     expect(target.querySelector(".tooltip")).toBeNull();
@@ -492,10 +514,13 @@ describe("ConcurrencyTimeline", () => {
     expect(tip).toBeTruthy();
     const rows = Array.from(tip!.querySelectorAll(".tooltip-metrics > div"));
     expect(rows.map((row) => row.textContent?.replace(/\s+/g, " ").trim())).toEqual([
+      "Interactive 2",
+      "Subagents 0",
+      "Automated 1",
+      "Combined peak 3",
       "Interactive peak 2",
       "Subagent peak 0",
       "Automated peak 1",
-      "Combined peak 3",
       "Agent-min 7.5K",
       "Input Tokens 120K",
       "Output Tokens 9K",
@@ -748,6 +773,21 @@ describe("ConcurrencyTimeline", () => {
     expect(document.body.textContent).toMatch(/Jun/);
   });
 
+  it("dates the combined peak label on day-bucketed ranges", () => {
+    const r = makeReport({
+      bucket_unit: "day",
+      range_start: "2026-06-15T00:00:00Z",
+      range_end: "2026-06-17T00:00:00Z",
+      bucket_seconds: 86400,
+      bucket_count: 2,
+      elapsed_bucket_count: 2,
+      effective_end: "2026-06-17T00:00:00Z",
+      peak: { agents: 3, at: "2026-06-16T06:30:00Z" },
+    });
+    render(ConcurrencyTimeline, { report: r });
+    expect(document.querySelector(".chart-peak")?.textContent).toBe("peak 3 at Jun 16, 06:30");
+  });
+
   it("formats a DST-safe week tooltip with the inclusive last day", async () => {
     const r = makeReport({
       bucket_unit: "week",
@@ -809,7 +849,7 @@ describe("ConcurrencyTimeline", () => {
     target.remove();
   });
 
-  it("labels the overlay scale on the right y-axis", async () => {
+  it("labels the overlay scale on the right y-axis of the stacked plot", async () => {
     const target = document.createElement("div");
     document.body.appendChild(target);
     const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
@@ -817,11 +857,17 @@ describe("ConcurrencyTimeline", () => {
 
     await chooseOverlayMetric(target, "Cost");
 
-    const labels = Array.from(target.querySelectorAll("text.overlay-y-label")).map(
-      (el) => el.textContent?.trim() ?? "",
-    );
+    const overlayLabels = Array.from(target.querySelectorAll("text.overlay-y-label"));
+    const labels = overlayLabels.map((el) => el.textContent?.trim() ?? "");
     expect(labels).toContain("$0.90");
     expect(labels).toContain("$0.00");
+    // The overlay axis spans the same plot as the concurrency axis: its zero
+    // sits on the bar baseline and its maximum on the top concurrency tick.
+    const yLabels = Array.from(target.querySelectorAll("text.y-label"));
+    const yOf = (els: Element[], text: string) =>
+      els.find((el) => el.textContent?.trim() === text)!.getAttribute("y");
+    expect(yOf(overlayLabels, "$0.00")).toBe(yOf(yLabels, "0"));
+    expect(yOf(overlayLabels, "$0.90")).toBe(yLabels.at(-1)!.getAttribute("y"));
 
     await chooseOverlayMetric(target, "Tokens");
 


### PR DESCRIPTION
## TL;DR

The Concurrency chart on the Activity page was designed as a stacked bar chart but shipped as three separate tracks, each with its own y-axis and peak label, so a reader could not see how much work ran at the same time. Each time bucket is now one bar with Interactive, Subagents, and Automated segments stacked on a shared axis.

## How

Segment heights come from the counts recorded at the bucket's combined peak, so the segments always sum to the bar. The independent class maxima are not stacked; they can occur at different instants inside the bucket and stacking them would overstate overlap. The tooltip shows both the stacked split and each class's own peak.

A legend and the combined peak label replace the three track titles and the "each track has its own scale" note, which is removed from every locale. The usage overlay draws over the single plot. Hover, drag and keyboard selection, future shading, and the activity strip are unchanged.

## Reviewer notes

- **Peak label gains a date on day and week ranges.** A bare clock time did not identify the peak there.
- **Focus area:** the stacking order and seam styling in the segment loop of `ConcurrencyTimeline.svelte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
