### PR TITLE
fix(insights): allow generation on HTTP origins

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -94,6 +94,9 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
+- Generate insights and session analyses when opening AgentsView over HTTP
+  outside localhost. Starting a report no longer requires a browser UUID API
+  that is unavailable on those origins. (#1742)
 - Show costs for OpenCode turns served through Ollama Cloud, such as
   `kimi-k2.7-code:cloud` or `gpt-oss:120b-cloud`, which previously showed as
   $0.00. Ollama bills these models per token at the upstream model's

--- a/frontend/src/lib/stores/insights.svelte.ts
+++ b/frontend/src/lib/stores/insights.svelte.ts
@@ -67,6 +67,7 @@ class InsightsStore {
   tasks: InsightTask[] = $state([]);
 
   #handles = new Map<string, GenerateInsightHandle>();
+  #nextTaskId = 0;
   #version = 0;
   #listRead = new LatestRead();
 
@@ -220,7 +221,7 @@ class InsightsStore {
 
   #startGeneration(
     snap: GenerationSnapshot,
-    clientId: string = crypto.randomUUID(),
+    clientId: string = String(++this.#nextTaskId),
     selectTask = false,
   ) {
     const task: InsightTask = {

--- a/frontend/src/lib/stores/insights.test.ts
+++ b/frontend/src/lib/stores/insights.test.ts
@@ -299,6 +299,44 @@ describe("selectedItem", () => {
 });
 
 describe("generate (multi-task)", () => {
+  it("starts independent report and session tasks without crypto.randomUUID", () => {
+    // Non-localhost HTTP origins do not expose crypto.randomUUID.
+    vi.stubGlobal("crypto", {});
+    const abortReport = vi.fn();
+    const abortSession = vi.fn();
+    vi.mocked(api.generateInsight)
+      .mockReturnValueOnce({ abort: abortReport, done: new Promise(() => {}) })
+      .mockReturnValueOnce({ abort: abortSession, done: new Promise(() => {}) });
+
+    try {
+      insights.setType("llm_canned");
+      insights.generate();
+      insights.generateForSession(makeSession());
+
+      expect(api.generateInsight).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ type: "llm_canned", llm_opt_in: true }),
+        expect.any(Function),
+        expect.any(Function),
+      );
+      expect(api.generateInsight).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ type: "agent_analysis", session_id: "run:session-1" }),
+        expect.any(Function),
+        expect.any(Function),
+      );
+      expect(insights.tasks).toHaveLength(2);
+      insights.cancelTask(insights.tasks[0]!.clientId);
+      expect(abortReport).toHaveBeenCalledOnce();
+      expect(abortSession).not.toHaveBeenCalled();
+      insights.cancelTask(insights.tasks[1]!.clientId);
+      expect(abortSession).toHaveBeenCalledOnce();
+    } finally {
+      api.generateInsight.mockReset();
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("includes the browser timezone so summaries align with the dashboard", () => {
     const mockHandle = {
       abort: vi.fn(),


### PR DESCRIPTION
Generate now starts reports and session analyses when AgentsView is opened over HTTP outside localhost. The shared task starter used `crypto.randomUUID()`, which those browser origins do not expose, and threw before adding a task or sending the request. Task IDs stay within the store, so a counter provides the uniqueness they need.

This reproduces the no-request symptom in #1742 on HTTP; the same build already sends the request on HTTPS. The reporter's page scheme remains unconfirmed, and the local reproduction emits a browser error, so this does not yet establish the cause of every detail in that report. Endpoint selection remains on the server.

Related to #1742.
