### PR TITLE
refactor(goose): reuse shared SQLite provider infrastructure

### DIFF
--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -17,19 +17,22 @@ type dbBackedSessionMeta struct {
 }
 
 type dbBackedProviderSpec struct {
-	agent        AgentType
-	dbName       string
-	findDB       func(string) string
-	streamMeta   func(context.Context, string, func(dbBackedSessionMeta) error) error
-	metaForID    func(context.Context, string, string) (dbBackedSessionMeta, bool, error)
-	parse        func(context.Context, string, string, string) ([]ParseResult, error)
-	normalizeRaw func(string) string
-	caps         Capabilities
+	agent           AgentType
+	dbName          string
+	findDB          func(string) string
+	streamMeta      func(context.Context, string, func(dbBackedSessionMeta) error) error
+	metaForID       func(context.Context, string, string) (dbBackedSessionMeta, bool, error)
+	fingerprintHash func(context.Context, string, string) (string, bool, error)
+	parse           func(context.Context, string, string, string) ([]ParseResult, error)
+	normalizeRaw    func(string) string
+	caps            Capabilities
 }
 
 type dbBackedProviderFactory struct {
-	def  AgentDef
-	spec func(bool) dbBackedProviderSpec
+	def            AgentDef
+	spec           func(bool) dbBackedProviderSpec
+	normalizeRoots func([]string) []string
+	tracker        *sqliteChangeTracker
 }
 
 func (f dbBackedProviderFactory) Definition() AgentDef {
@@ -42,13 +45,19 @@ func (f dbBackedProviderFactory) Capabilities() Capabilities {
 
 func (f dbBackedProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	cfg = cfg.Clone()
+	if f.normalizeRoots != nil {
+		cfg.Roots = f.normalizeRoots(cfg.Roots)
+	}
 	spec := f.spec(cfg.StableSourceSnapshots)
+	sources := newDBBackedSourceSet(spec, cfg.Roots)
+	sources.tracker = f.tracker
+	sources.stableSnapshot = cfg.StableSourceSnapshots
 	return &dbBackedProvider{
 		Def:     cloneAgentDef(f.def),
 		Caps:    withDBBackedRawCapture(spec.caps),
 		Config:  cfg,
 		spec:    spec,
-		sources: newDBBackedSourceSet(spec, cfg.Roots),
+		sources: sources,
 	}
 }
 
@@ -363,6 +372,10 @@ type dbBackedSource struct {
 type dbBackedSourceSet struct {
 	spec  dbBackedProviderSpec
 	roots []string
+	// A tracker opts into insert-only watcher work. Edits and deletions still
+	// rely on reconciliation; providers without one keep full event listings.
+	tracker        *sqliteChangeTracker
+	stableSnapshot bool
 }
 
 func newDBBackedSourceSet(
@@ -382,6 +395,20 @@ func (s dbBackedSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 func (s dbBackedSourceSet) DiscoverEach(
 	ctx context.Context, yield func(SourceRef) error,
 ) error {
+	// Capture every root before enumeration, and publish only after the whole
+	// pass succeeds. Rows written during discovery remain visible to watchers.
+	var watermarks []sqliteDiscoveryWatermark
+	if s.tracker != nil {
+		for _, root := range s.roots {
+			if dbPath := s.spec.findDB(root); dbPath != "" {
+				state, err := s.tracker.read(ctx, dbPath, s.stableSnapshot)
+				if err != nil {
+					return err
+				}
+				watermarks = append(watermarks, sqliteDiscoveryWatermark{dbPath: dbPath, state: state})
+			}
+		}
+	}
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -403,6 +430,9 @@ func (s dbBackedSourceSet) DiscoverEach(
 		if err != nil {
 			return err
 		}
+	}
+	if s.tracker != nil {
+		s.tracker.storeDiscoveryWatermarks(watermarks)
 	}
 	return nil
 }
@@ -438,6 +468,35 @@ func (s dbBackedSourceSet) SourcesForChangedPath(
 		if !ok {
 			continue
 		}
+		var snapshot sqliteTrackedDatabase
+		storedPaths := req.StoredSourcePaths
+		if s.tracker != nil {
+			if !IsRegularFile(dbPath) {
+				// A vanished database cannot prove that its archived members
+				// were deleted. Keep them without enumerating stored hints.
+				return nil, nil
+			}
+			ids, cold, state, err := s.tracker.changedSessionIDs(ctx, dbPath, s.stableSnapshot)
+			if err != nil {
+				return nil, err
+			}
+			if !cold {
+				sources := make([]SourceRef, 0, len(ids))
+				for _, id := range ids {
+					meta, found, err := s.spec.metaForID(ctx, dbPath, id)
+					if err != nil {
+						return nil, err
+					}
+					if found {
+						sources = append(sources, s.newSourceRef(root, dbPath, meta.SessionID, meta.VirtualPath))
+					}
+				}
+				sortJSONLSources(sources)
+				return sources, nil
+			}
+			snapshot = state
+			storedPaths = nil
+		}
 		var sources []SourceRef
 		seen := make(map[string]struct{})
 		err := s.spec.streamMeta(ctx, dbPath, func(meta dbBackedSessionMeta) error {
@@ -451,7 +510,7 @@ func (s dbBackedSourceSet) SourcesForChangedPath(
 		if err != nil {
 			return nil, err
 		}
-		for _, path := range req.StoredSourcePaths {
+		for _, path := range storedPaths {
 			ref, ok := s.sourceRef(root, path, true)
 			if !ok {
 				continue
@@ -463,6 +522,9 @@ func (s dbBackedSourceSet) SourcesForChangedPath(
 			addJSONLSource(ref, &sources, seen)
 		}
 		sortJSONLSources(sources)
+		if s.tracker != nil {
+			s.tracker.commit(dbPath, snapshot)
+		}
 		return sources, nil
 	}
 	return nil, nil
@@ -569,13 +631,20 @@ func (s dbBackedSourceSet) Fingerprint(
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
+	fingerprint := SourceFingerprint{Key: key}
 	if found {
-		return SourceFingerprint{
-			Key:     key,
-			MTimeNS: meta.FileMtime,
-		}, nil
+		fingerprint.MTimeNS = meta.FileMtime
 	}
-	return SourceFingerprint{Key: key}, nil
+	if s.spec.fingerprintHash != nil && IsRegularFile(src.DBPath) {
+		hash, found, err := s.spec.fingerprintHash(ctx, src.DBPath, src.SessionID)
+		if err != nil {
+			return SourceFingerprint{}, err
+		}
+		if found {
+			fingerprint.Hash = hash
+		}
+	}
+	return fingerprint, nil
 }
 
 func (s dbBackedSourceSet) sourceFromRef(source SourceRef) (dbBackedSource, bool) {

--- a/internal/parser/goose.go
+++ b/internal/parser/goose.go
@@ -85,6 +85,7 @@ func forEachGooseSessionMeta(
 	if err != nil {
 		return err
 	}
+	observeSharedContainerScan(ctx)
 	rows, err := db.QueryContext(ctx, gooseSessionSelect(columns, "", true))
 	if err != nil {
 		return fmt.Errorf("listing goose sessions: %w", err)

--- a/internal/parser/goose_provider.go
+++ b/internal/parser/goose_provider.go
@@ -3,13 +3,10 @@ package parser
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 )
 
 // GooseDBName is the SQLite filename inside Goose's sessions directory.
@@ -17,7 +14,7 @@ const GooseDBName = "sessions.db"
 
 type gooseProviderFactory struct {
 	def     AgentDef
-	tracker *gooseChangeTracker
+	tracker *sqliteChangeTracker
 }
 
 func newGooseProviderFactory(def AgentDef) ProviderFactory {
@@ -51,7 +48,7 @@ func (f *gooseProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 
 type gooseProvider struct {
 	*dbBackedProvider
-	tracker *gooseChangeTracker
+	tracker *sqliteChangeTracker
 }
 
 func (p *gooseProvider) Discover(ctx context.Context) ([]SourceRef, error) {
@@ -86,18 +83,18 @@ func (p *gooseProvider) DiscoverEach(
 // discovery available to the next watcher event.
 func (p *gooseProvider) captureDiscoveryWatermarks(
 	ctx context.Context,
-) ([]gooseDiscoveryWatermark, error) {
-	watermarks := make([]gooseDiscoveryWatermark, 0, len(p.sources.roots))
+) ([]sqliteDiscoveryWatermark, error) {
+	watermarks := make([]sqliteDiscoveryWatermark, 0, len(p.sources.roots))
 	for _, root := range p.sources.roots {
 		dbPath := p.spec.findDB(root)
 		if dbPath == "" {
 			continue
 		}
-		state, err := readGooseTrackedDatabase(ctx, dbPath, p.Config.StableSourceSnapshots)
+		state, err := p.tracker.read(ctx, dbPath, p.Config.StableSourceSnapshots)
 		if err != nil {
 			return nil, err
 		}
-		watermarks = append(watermarks, gooseDiscoveryWatermark{
+		watermarks = append(watermarks, sqliteDiscoveryWatermark{
 			dbPath: dbPath,
 			state:  state,
 		})
@@ -332,353 +329,40 @@ func openGooseDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
 	return db, nil
 }
 
-type gooseRowCursor struct {
-	id       int64
-	identity string
-}
-
-type gooseTrackedDatabase struct {
-	schemaVersion int
-	inode         uint64
-	device        uint64
-	sessions      gooseRowCursor
-	messages      gooseRowCursor
-	usage         gooseRowCursor
-	hasUsage      bool
-}
-
-type gooseDiscoveryWatermark struct {
-	dbPath string
-	state  gooseTrackedDatabase
-}
-
-type gooseChangeTracker struct {
-	mu      sync.Mutex
-	entries map[string]*gooseTrackedDatabaseEntry
-}
-
-type gooseTrackedDatabaseEntry struct {
-	mu    sync.Mutex
-	known bool
-	state gooseTrackedDatabase
-}
-
-func newGooseChangeTracker() *gooseChangeTracker {
-	return &gooseChangeTracker{
-		entries: make(map[string]*gooseTrackedDatabaseEntry),
+func newGooseChangeTracker() *sqliteChangeTracker {
+	return &sqliteChangeTracker{
+		agent:  AgentGoose,
+		open:   openGooseDB,
+		schema: gooseCursorSchema,
 	}
 }
 
-// entry returns the per-database tracker entry, creating it on first use.
-// Each database has its own lock so a slow or busy sessions.db cannot stall
-// watcher classification for other Goose roots.
-func (t *gooseChangeTracker) entry(dbPath string) *gooseTrackedDatabaseEntry {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	key := filepath.Clean(dbPath)
-	entry, ok := t.entries[key]
-	if !ok {
-		entry = &gooseTrackedDatabaseEntry{}
-		t.entries[key] = entry
-	}
-	return entry
-}
-
-func (t *gooseChangeTracker) storeDiscoveryWatermarks(
-	watermarks []gooseDiscoveryWatermark,
-) {
-	for _, watermark := range watermarks {
-		entry := t.entry(watermark.dbPath)
-		entry.mu.Lock()
-		entry.mergeLocked(watermark.state)
-		entry.mu.Unlock()
-	}
-}
-
-// commit publishes a snapshot that was captured before a full enumeration.
-// Callers invoke it only after that enumeration succeeds, so a failed pass
-// cannot advance the cursors past rows it never delivered.
-func (t *gooseChangeTracker) commit(dbPath string, state gooseTrackedDatabase) {
-	entry := t.entry(dbPath)
-	entry.mu.Lock()
-	entry.mergeLocked(state)
-	entry.mu.Unlock()
-}
-
-// mergeLocked adopts state without retreating row cursors that a concurrent
-// watcher event already advanced past this snapshot. Callers hold entry.mu.
-func (e *gooseTrackedDatabaseEntry) mergeLocked(state gooseTrackedDatabase) {
-	if !e.known || gooseTrackedDatabaseReplaced(e.state, state) {
-		e.state = state
-		e.known = true
-		return
-	}
-	merged := state
-	merged.sessions = furthestGooseRowCursor(e.state.sessions, state.sessions)
-	merged.messages = furthestGooseRowCursor(e.state.messages, state.messages)
-	merged.usage = furthestGooseRowCursor(e.state.usage, state.usage)
-	e.state = merged
-}
-
-func furthestGooseRowCursor(a, b gooseRowCursor) gooseRowCursor {
-	if a.id > b.id {
-		return a
-	}
-	return b
-}
-
-// changedSessionIDs lists sessions with rows inserted past the stored
-// cursors. cold reports that the caller must fall back to full enumeration;
-// the returned snapshot must then be published via commit only after that
-// enumeration succeeds. A table whose cursor retreated or was rewritten is
-// skipped — deletions are reconciliation's job — while inserts from the
-// tables whose cursors are intact are still listed.
-func (t *gooseChangeTracker) changedSessionIDs(
-	ctx context.Context, dbPath string, stableSnapshot bool,
-) (ids []string, cold bool, snapshot gooseTrackedDatabase, err error) {
-	entry := t.entry(dbPath)
-	entry.mu.Lock()
-	defer entry.mu.Unlock()
-
-	info, err := os.Stat(dbPath)
+func gooseCursorSchema(
+	ctx context.Context, db *sql.DB,
+) (int, []sqliteCursorTable, error) {
+	version, err := gooseSchemaVersion(ctx, db)
 	if err != nil {
-		return nil, false, gooseTrackedDatabase{},
-			fmt.Errorf("stat goose sessions database: %w", err)
-	}
-	db, err := openGooseDB(dbPath, stableSnapshot)
-	if err != nil {
-		return nil, false, gooseTrackedDatabase{}, err
-	}
-	defer db.Close()
-	current, err := readGooseTrackedDatabaseFrom(ctx, db, info)
-	if err != nil {
-		return nil, false, gooseTrackedDatabase{}, err
-	}
-	if !entry.known || gooseTrackedDatabaseReplaced(entry.state, current) {
-		return nil, true, current, nil
-	}
-
-	seen := make(map[string]struct{})
-	for _, check := range gooseCursorChecks(entry.state, current) {
-		valid, err := gooseCursorStillValid(ctx, db, check)
-		if err != nil {
-			return nil, false, gooseTrackedDatabase{}, err
-		}
-		if !valid {
-			continue
-		}
-		if err := listChangedGooseSessionIDsForTable(
-			ctx, db, check.table, check.previous.id, seen,
-		); err != nil {
-			return nil, false, gooseTrackedDatabase{}, err
-		}
-	}
-	entry.state = current
-	entry.known = true
-	ids = make([]string, 0, len(seen))
-	for id := range seen {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	return ids, false, current, nil
-}
-
-func gooseTrackedDatabaseReplaced(
-	previous, current gooseTrackedDatabase,
-) bool {
-	identityChanged := (previous.inode != 0 || previous.device != 0) &&
-		(previous.inode != current.inode || previous.device != current.device)
-	return identityChanged || previous.schemaVersion != current.schemaVersion ||
-		previous.hasUsage != current.hasUsage
-}
-
-func readGooseTrackedDatabase(
-	ctx context.Context, dbPath string, stableSnapshot bool,
-) (gooseTrackedDatabase, error) {
-	info, err := os.Stat(dbPath)
-	if err != nil {
-		return gooseTrackedDatabase{}, fmt.Errorf("stat goose sessions database: %w", err)
-	}
-	db, err := openGooseDB(dbPath, stableSnapshot)
-	if err != nil {
-		return gooseTrackedDatabase{}, err
-	}
-	defer db.Close()
-	return readGooseTrackedDatabaseFrom(ctx, db, info)
-}
-
-func readGooseTrackedDatabaseFrom(
-	ctx context.Context, db *sql.DB, info os.FileInfo,
-) (gooseTrackedDatabase, error) {
-	inode, device := sourceFileIdentity(info)
-	schemaVersion, err := gooseSchemaVersion(ctx, db)
-	if err != nil {
-		return gooseTrackedDatabase{}, err
+		return 0, nil, err
 	}
 	hasUsage, err := gooseTableExists(ctx, db, "usage_ledger")
 	if err != nil {
-		return gooseTrackedDatabase{}, err
+		return 0, nil, err
 	}
-	sessions, err := latestGooseRowCursor(ctx, db, "sessions")
-	if err != nil {
-		return gooseTrackedDatabase{}, err
+	tables := []sqliteCursorTable{
+		{
+			name: "sessions", rowID: "rowid", sessionID: "id",
+			identity: "CAST(id AS TEXT)",
+		},
+		{
+			name: "messages", rowID: "id", sessionID: "session_id",
+			identity: "session_id || char(31) || COALESCE(message_id, '') || char(31) || CAST(created_timestamp AS TEXT)",
+		},
 	}
-	messages, err := latestGooseRowCursor(ctx, db, "messages")
-	if err != nil {
-		return gooseTrackedDatabase{}, err
-	}
-	var usage gooseRowCursor
 	if hasUsage {
-		usage, err = latestGooseRowCursor(ctx, db, "usage_ledger")
-		if err != nil {
-			return gooseTrackedDatabase{}, err
-		}
-	}
-	return gooseTrackedDatabase{
-		schemaVersion: schemaVersion,
-		inode:         inode,
-		device:        device,
-		sessions:      sessions,
-		messages:      messages,
-		usage:         usage,
-		hasUsage:      hasUsage,
-	}, nil
-}
-
-func latestGooseRowCursor(
-	ctx context.Context, db *sql.DB, table string,
-) (gooseRowCursor, error) {
-	identityExpr, ok := gooseRowIdentityExpression(table)
-	if !ok {
-		return gooseRowCursor{}, fmt.Errorf("unsupported goose cursor table %q", table)
-	}
-	rowID := "rowid"
-	if table != "sessions" {
-		rowID = "id"
-	}
-	query := "SELECT " + rowID + ", " + identityExpr + " FROM " + table +
-		" ORDER BY " + rowID + " DESC LIMIT 1"
-	var cursor gooseRowCursor
-	err := db.QueryRowContext(ctx, query).Scan(&cursor.id, &cursor.identity)
-	if errors.Is(err, sql.ErrNoRows) {
-		return gooseRowCursor{}, nil
-	}
-	if err != nil {
-		return gooseRowCursor{}, fmt.Errorf("reading latest goose %s row: %w", table, err)
-	}
-	return cursor, nil
-}
-
-func gooseRowIdentityExpression(table string) (string, bool) {
-	switch table {
-	case "sessions":
-		return "CAST(id AS TEXT)", true
-	case "messages":
-		return "session_id || char(31) || COALESCE(message_id, '') || char(31) || CAST(created_timestamp AS TEXT)", true
-	case "usage_ledger":
-		return "session_id || char(31) || COALESCE(model, '') || char(31) || CAST(created_timestamp AS TEXT)", true
-	default:
-		return "", false
-	}
-}
-
-type gooseCursorCheck struct {
-	table    string
-	previous gooseRowCursor
-	current  gooseRowCursor
-}
-
-func gooseCursorChecks(
-	previous, current gooseTrackedDatabase,
-) []gooseCursorCheck {
-	checks := []gooseCursorCheck{
-		{table: "sessions", previous: previous.sessions, current: current.sessions},
-		{table: "messages", previous: previous.messages, current: current.messages},
-	}
-	if current.hasUsage {
-		checks = append(checks, gooseCursorCheck{
-			table: "usage_ledger", previous: previous.usage, current: current.usage,
+		tables = append(tables, sqliteCursorTable{
+			name: "usage_ledger", rowID: "id", sessionID: "session_id",
+			identity: "session_id || char(31) || COALESCE(model, '') || char(31) || CAST(created_timestamp AS TEXT)",
 		})
 	}
-	return checks
-}
-
-func gooseCursorStillValid(
-	ctx context.Context, db *sql.DB, check gooseCursorCheck,
-) (bool, error) {
-	if check.current.id < check.previous.id {
-		return false, nil
-	}
-	if check.previous.id == 0 {
-		return true, nil
-	}
-	identity, found, err := gooseRowIdentityAt(
-		ctx, db, check.table, check.previous.id,
-	)
-	if err != nil {
-		return false, err
-	}
-	return found && identity == check.previous.identity, nil
-}
-
-func gooseRowIdentityAt(
-	ctx context.Context, db *sql.DB, table string, rowID int64,
-) (string, bool, error) {
-	identityExpr, ok := gooseRowIdentityExpression(table)
-	if !ok {
-		return "", false, fmt.Errorf("unsupported goose cursor table %q", table)
-	}
-	idColumn := "rowid"
-	if table != "sessions" {
-		idColumn = "id"
-	}
-	query := "SELECT " + identityExpr + " FROM " + table + " WHERE " + idColumn + " = ?"
-	var identity string
-	err := db.QueryRowContext(ctx, query, rowID).Scan(&identity)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", false, nil
-	}
-	if err != nil {
-		return "", false, fmt.Errorf("reading goose %s cursor identity: %w", table, err)
-	}
-	return identity, true, nil
-}
-
-func listChangedGooseSessionIDsForTable(
-	ctx context.Context,
-	db *sql.DB,
-	table string,
-	after int64,
-	seen map[string]struct{},
-) error {
-	var query string
-	switch table {
-	case "sessions":
-		query = "SELECT id FROM sessions WHERE rowid > ? ORDER BY rowid"
-	case "messages":
-		query = "SELECT session_id FROM messages WHERE id > ? ORDER BY id"
-	case "usage_ledger":
-		query = "SELECT session_id FROM usage_ledger WHERE id > ? ORDER BY id"
-	default:
-		return fmt.Errorf("unsupported goose cursor table %q", table)
-	}
-	rows, err := db.QueryContext(ctx, query, after)
-	if err != nil {
-		return fmt.Errorf("listing changed goose sessions: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return fmt.Errorf("scanning changed goose session ID: %w", err)
-		}
-		id = strings.TrimSpace(id)
-		if id != "" {
-			seen[id] = struct{}{}
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	return rows.Close()
+	return version, tables, nil
 }

--- a/internal/parser/goose_provider.go
+++ b/internal/parser/goose_provider.go
@@ -5,185 +5,23 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
 // GooseDBName is the SQLite filename inside Goose's sessions directory.
 const GooseDBName = "sessions.db"
 
-type gooseProviderFactory struct {
-	def     AgentDef
-	tracker *sqliteChangeTracker
-}
-
 func newGooseProviderFactory(def AgentDef) ProviderFactory {
-	return &gooseProviderFactory{
-		def:     cloneAgentDef(def),
-		tracker: newGooseChangeTracker(),
+	return dbBackedProviderFactory{
+		def:            cloneAgentDef(def),
+		spec:           gooseProviderSpec,
+		normalizeRoots: normalizeGooseRoots,
+		tracker: &sqliteChangeTracker{
+			agent:  AgentGoose,
+			open:   openGooseDB,
+			schema: gooseCursorSchema,
+		},
 	}
-}
-
-func (f *gooseProviderFactory) Definition() AgentDef {
-	return cloneAgentDef(f.def)
-}
-
-func (f *gooseProviderFactory) Capabilities() Capabilities {
-	return withDBBackedRawCapture(gooseProviderCapabilities())
-}
-
-func (f *gooseProviderFactory) NewProvider(cfg ProviderConfig) Provider {
-	cfg = cfg.Clone()
-	cfg.Roots = normalizeGooseRoots(cfg.Roots)
-	spec := gooseProviderSpec(cfg.StableSourceSnapshots)
-	base := &dbBackedProvider{
-		Def:     cloneAgentDef(f.def),
-		Caps:    withDBBackedRawCapture(spec.caps),
-		Config:  cfg,
-		spec:    spec,
-		sources: newDBBackedSourceSet(spec, cfg.Roots),
-	}
-	return &gooseProvider{dbBackedProvider: base, tracker: f.tracker}
-}
-
-type gooseProvider struct {
-	*dbBackedProvider
-	tracker *sqliteChangeTracker
-}
-
-func (p *gooseProvider) Discover(ctx context.Context) ([]SourceRef, error) {
-	watermarks, err := p.captureDiscoveryWatermarks(ctx)
-	if err != nil {
-		return nil, err
-	}
-	sources, err := p.dbBackedProvider.Discover(ctx)
-	if err != nil {
-		return nil, err
-	}
-	p.tracker.storeDiscoveryWatermarks(watermarks)
-	return sources, nil
-}
-
-func (p *gooseProvider) DiscoverEach(
-	ctx context.Context, yield func(SourceRef) error,
-) error {
-	watermarks, err := p.captureDiscoveryWatermarks(ctx)
-	if err != nil {
-		return err
-	}
-	if err := p.dbBackedProvider.DiscoverEach(ctx, yield); err != nil {
-		return err
-	}
-	p.tracker.storeDiscoveryWatermarks(watermarks)
-	return nil
-}
-
-// captureDiscoveryWatermarks reads the change cursors before enumeration.
-// Publishing them only after a successful pass leaves rows committed during
-// discovery available to the next watcher event.
-func (p *gooseProvider) captureDiscoveryWatermarks(
-	ctx context.Context,
-) ([]sqliteDiscoveryWatermark, error) {
-	watermarks := make([]sqliteDiscoveryWatermark, 0, len(p.sources.roots))
-	for _, root := range p.sources.roots {
-		dbPath := p.spec.findDB(root)
-		if dbPath == "" {
-			continue
-		}
-		state, err := p.tracker.read(ctx, dbPath, p.Config.StableSourceSnapshots)
-		if err != nil {
-			return nil, err
-		}
-		watermarks = append(watermarks, sqliteDiscoveryWatermark{
-			dbPath: dbPath,
-			state:  state,
-		})
-	}
-	return watermarks, nil
-}
-
-// SourcesForChangedPath returns only Goose sessions with newly inserted
-// session, message, or usage rows. Metadata-only updates and row deletes are
-// intentionally handled by the provider's scheduled reconciliation pass.
-func (p *gooseProvider) SourcesForChangedPath(
-	ctx context.Context, req ChangedPathRequest,
-) ([]SourceRef, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	for _, root := range p.sources.roots {
-		if req.WatchRoot != "" && !samePath(req.WatchRoot, root) {
-			continue
-		}
-		if ref, ok := p.sources.sourceRef(root, req.Path, true); ok {
-			return []SourceRef{ref}, nil
-		}
-		dbPath, ok := p.sources.dbPathForEvent(root, req.Path)
-		if !ok {
-			continue
-		}
-		if !IsRegularFile(dbPath) {
-			// The SQLite archive is persistent. A vanished physical database
-			// cannot prove that any archived Goose member was deleted.
-			return nil, nil
-		}
-		ids, cold, snapshot, err := p.tracker.changedSessionIDs(ctx, dbPath, p.Config.StableSourceSnapshots)
-		if err != nil {
-			return nil, err
-		}
-		if cold {
-			sources, err := p.dbBackedProvider.SourcesForChangedPath(ctx, ChangedPathRequest{
-				Path:      req.Path,
-				EventKind: req.EventKind,
-				WatchRoot: req.WatchRoot,
-			})
-			if err != nil {
-				return nil, err
-			}
-			p.tracker.commit(dbPath, snapshot)
-			return sources, nil
-		}
-
-		sources := make([]SourceRef, 0, len(ids))
-		for _, id := range ids {
-			meta, found, err := gooseSessionMeta(ctx, dbPath, id, p.Config.StableSourceSnapshots)
-			if err != nil {
-				return nil, err
-			}
-			if !found {
-				continue
-			}
-			sources = append(sources, p.sources.newSourceRef(
-				root, dbPath, meta.SessionID, meta.VirtualPath,
-			))
-		}
-		sort.Slice(sources, func(i, j int) bool {
-			return sources[i].DisplayPath < sources[j].DisplayPath
-		})
-		return sources, nil
-	}
-	return nil, nil
-}
-
-func (p *gooseProvider) Fingerprint(
-	ctx context.Context, source SourceRef,
-) (SourceFingerprint, error) {
-	fingerprint, err := p.dbBackedProvider.Fingerprint(ctx, source)
-	if err != nil {
-		return SourceFingerprint{}, err
-	}
-	src, ok := p.sources.sourceFromRef(source)
-	if !ok || !IsRegularFile(src.DBPath) {
-		return fingerprint, nil
-	}
-	hash, found, err := gooseSessionFingerprint(ctx, src.DBPath, src.SessionID, p.Config.StableSourceSnapshots)
-	if err != nil {
-		return SourceFingerprint{}, err
-	}
-	if found {
-		fingerprint.Hash = hash
-	}
-	return fingerprint, nil
 }
 
 func gooseProviderCapabilities() Capabilities {
@@ -236,6 +74,9 @@ func gooseProviderSpec(stableSnapshot bool) dbBackedProviderSpec {
 				return nil, err
 			}
 			return []ParseResult{*result}, nil
+		},
+		fingerprintHash: func(ctx context.Context, dbPath, sessionID string) (string, bool, error) {
+			return gooseSessionFingerprint(ctx, dbPath, sessionID, stableSnapshot)
 		},
 		caps: gooseProviderCapabilities(),
 	}
@@ -327,14 +168,6 @@ func openGooseDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
 		return nil, fmt.Errorf("opening goose sessions database %s: %w", dbPath, err)
 	}
 	return db, nil
-}
-
-func newGooseChangeTracker() *sqliteChangeTracker {
-	return &sqliteChangeTracker{
-		agent:  AgentGoose,
-		open:   openGooseDB,
-		schema: gooseCursorSchema,
-	}
 }
 
 func gooseCursorSchema(

--- a/internal/parser/goose_test.go
+++ b/internal/parser/goose_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -337,18 +338,23 @@ func TestGooseChangedPathWorkStaysProportionalToNewRows(t *testing.T) {
 				Roots: []string{fixture.pathRoot}, Machine: "devbox",
 			})
 			require.True(t, ok)
-			_, err := provider.Discover(context.Background())
+			scans := 0
+			ctx := WithSharedContainerScanObserver(context.Background(), func() { scans++ })
+			_, err := provider.Discover(ctx)
 			require.NoError(t, err)
+			require.Equal(t, 1, scans, "discovery must report its full container scan")
+			scans = 0
 
 			fixture.insertMessage(t, "session-000", "assistant", `[{"type":"text","text":"changed"}]`, 1_700_000_001)
 			sources, err := provider.SourcesForChangedPath(
-				context.Background(), ChangedPathRequest{
+				ctx, ChangedPathRequest{
 					Path: fixture.dbPath + "-wal", WatchRoot: fixture.sessionDir,
 				},
 			)
 			require.NoError(t, err)
 			require.Len(t, sources, 1)
 			assert.Equal(t, fixture.dbPath+"#session-000", sources[0].DisplayPath)
+			assert.Zero(t, scans, "a warm watcher event must not enumerate the container")
 		})
 	}
 }
@@ -402,18 +408,23 @@ func TestGooseTailDeletionWatcherWorkStaysBounded(t *testing.T) {
 					Roots: []string{fixture.pathRoot}, Machine: "devbox",
 				})
 				require.True(t, ok)
-				_, err := provider.Discover(context.Background())
+				scans := 0
+				ctx := WithSharedContainerScanObserver(context.Background(), func() { scans++ })
+				_, err := provider.Discover(ctx)
 				require.NoError(t, err)
+				require.Equal(t, 1, scans)
+				scans = 0
 
 				test.delete(t, fixture)
 				sources, err := provider.SourcesForChangedPath(
-					context.Background(), ChangedPathRequest{
+					ctx, ChangedPathRequest{
 						Path: fixture.dbPath + "-wal", WatchRoot: fixture.sessionDir,
 					},
 				)
 				require.NoError(t, err)
 				assert.Empty(t, sources,
 					"tail deletion must wait for reconciliation instead of enumerating the archive")
+				assert.Zero(t, scans)
 			})
 		}
 	}
@@ -554,6 +565,61 @@ func TestGooseDiscoveryLeavesConcurrentRowsForWatcherProcessing(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sources, 1)
 	assert.Equal(t, fixture.dbPath+"#session", sources[0].DisplayPath)
+}
+
+func TestGooseFailedDiscoveryDoesNotPublishWatermark(t *testing.T) {
+	fixture := newGooseTestFixture(t)
+	fixture.insertSession(t, "session-a", "a", "user", "")
+	fixture.insertSession(t, "session-b", "b", "user", "")
+	provider, ok := NewProvider(AgentGoose, ProviderConfig{Roots: []string{fixture.pathRoot}})
+	require.True(t, ok)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	stop := errors.New("consumer stopped discovery")
+	err := discoverer.DiscoverEach(context.Background(), func(SourceRef) error { return stop })
+	require.ErrorIs(t, err, stop)
+
+	// A failed enumeration must leave the next event cold, even without new rows.
+	sources, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: fixture.dbPath + "-wal", WatchRoot: fixture.sessionDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, sources, 2)
+	assert.Equal(t, fixture.dbPath+"#session-a", sources[0].DisplayPath)
+	assert.Equal(t, fixture.dbPath+"#session-b", sources[1].DisplayPath)
+}
+
+func TestGooseChangedSchemaReenumeratesOnce(t *testing.T) {
+	for _, change := range []struct{ name, sql string }{
+		{"version", "UPDATE schema_version SET version = 16"},
+		{"optional usage table", "DROP TABLE usage_ledger"},
+	} {
+		t.Run(change.name, func(t *testing.T) {
+			fixture := newGooseTestFixture(t)
+			fixture.insertSession(t, "session-a", "a", "user", "")
+			fixture.insertSession(t, "session-b", "b", "user", "")
+			provider, ok := NewProvider(AgentGoose, ProviderConfig{Roots: []string{fixture.pathRoot}})
+			require.True(t, ok)
+			_, err := provider.Discover(context.Background())
+			require.NoError(t, err)
+			_, err = fixture.database.Exec(change.sql)
+			require.NoError(t, err)
+			scans := 0
+			ctx := WithSharedContainerScanObserver(context.Background(), func() { scans++ })
+			req := ChangedPathRequest{Path: fixture.dbPath, WatchRoot: fixture.sessionDir}
+			sources, err := provider.SourcesForChangedPath(ctx, req)
+			require.NoError(t, err)
+			require.Len(t, sources, 2)
+			assert.Equal(t, 1, scans)
+
+			fixture.insertMessage(t, "session-b", "user", `[{"type":"text","text":"new"}]`, 1_700_000_001)
+			sources, err = provider.SourcesForChangedPath(ctx, req)
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+			assert.Equal(t, fixture.dbPath+"#session-b", sources[0].DisplayPath)
+			assert.Equal(t, 1, scans, "the new schema's cursor must keep later events bounded")
+		})
+	}
 }
 
 func TestGooseDiscoveryRejectsUnsupportedMessagesSchema(t *testing.T) {

--- a/internal/parser/goose_test.go
+++ b/internal/parser/goose_test.go
@@ -334,10 +334,11 @@ func TestGooseChangedPathWorkStaysProportionalToNewRows(t *testing.T) {
 				fixture.insertSession(t, id, id, "user", "")
 				fixture.insertMessage(t, id, "user", `[{"type":"text","text":"seed"}]`, 1_700_000_000)
 			}
-			provider, ok := NewProvider(AgentGoose, ProviderConfig{
+			factory, ok := ProviderFactoryByType(AgentGoose)
+			require.True(t, ok)
+			provider := factory.NewProvider(ProviderConfig{
 				Roots: []string{fixture.pathRoot}, Machine: "devbox",
 			})
-			require.True(t, ok)
 			scans := 0
 			ctx := WithSharedContainerScanObserver(context.Background(), func() { scans++ })
 			_, err := provider.Discover(ctx)
@@ -346,6 +347,9 @@ func TestGooseChangedPathWorkStaysProportionalToNewRows(t *testing.T) {
 			scans = 0
 
 			fixture.insertMessage(t, "session-000", "assistant", `[{"type":"text","text":"changed"}]`, 1_700_000_001)
+			// The engine creates short-lived providers; the factory must retain
+			// the discovery cursor rather than making each event a cold scan.
+			provider = factory.NewProvider(ProviderConfig{Roots: []string{fixture.pathRoot}})
 			sources, err := provider.SourcesForChangedPath(
 				ctx, ChangedPathRequest{
 					Path: fixture.dbPath + "-wal", WatchRoot: fixture.sessionDir,

--- a/internal/parser/sqlite_change_tracker.go
+++ b/internal/parser/sqlite_change_tracker.go
@@ -1,0 +1,233 @@
+package parser
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// sqliteCursorTable describes producer-owned SQL, never user input. Each table
+// has an indexed integer cursor and an identity that detects tail-row reuse.
+type sqliteCursorTable struct {
+	name, rowID, identity, sessionID string
+}
+
+type sqliteRowCursor struct {
+	id       int64
+	identity string
+}
+
+type sqliteTrackedDatabase struct {
+	schemaVersion int
+	inode, device uint64
+	tables        []sqliteCursorTable
+	cursors       []sqliteRowCursor
+}
+
+type sqliteDiscoveryWatermark struct {
+	dbPath string
+	state  sqliteTrackedDatabase
+}
+
+// sqliteChangeTracker retains only table tails per database. Inserts are
+// delivered on watcher events; edits and deletions remain reconciliation's job.
+// The factory owns it so short-lived provider instances share the same cursors.
+type sqliteChangeTracker struct {
+	agent  AgentType
+	open   func(string, bool) (*sql.DB, error)
+	schema func(context.Context, *sql.DB) (int, []sqliteCursorTable, error)
+
+	mu      sync.Mutex
+	entries map[string]*sqliteTrackedDatabaseEntry
+}
+
+type sqliteTrackedDatabaseEntry struct {
+	mu    sync.Mutex
+	known bool
+	state sqliteTrackedDatabase
+}
+
+// Each database has its own lock so a busy container cannot block other roots.
+func (t *sqliteChangeTracker) entry(dbPath string) *sqliteTrackedDatabaseEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.entries == nil {
+		t.entries = make(map[string]*sqliteTrackedDatabaseEntry)
+	}
+	key := filepath.Clean(dbPath)
+	entry := t.entries[key]
+	if entry == nil {
+		entry = &sqliteTrackedDatabaseEntry{}
+		t.entries[key] = entry
+	}
+	return entry
+}
+
+func (t *sqliteChangeTracker) storeDiscoveryWatermarks(watermarks []sqliteDiscoveryWatermark) {
+	for _, watermark := range watermarks {
+		t.commit(watermark.dbPath, watermark.state)
+	}
+}
+
+// commit publishes a pre-enumeration snapshot only after enumeration succeeds.
+// An older discovery must not retreat cursors advanced by a concurrent watcher.
+func (t *sqliteChangeTracker) commit(dbPath string, state sqliteTrackedDatabase) {
+	entry := t.entry(dbPath)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.known && !sqliteTrackedDatabaseReplaced(entry.state, state) {
+		state.cursors = slices.Clone(state.cursors)
+		for i, cursor := range entry.state.cursors {
+			if cursor.id > state.cursors[i].id {
+				state.cursors[i] = cursor
+			}
+		}
+	}
+	entry.state, entry.known = state, true
+}
+
+// changedSessionIDs returns cold for a new or replaced database. Its caller
+// must enumerate that container and commit the returned snapshot on success.
+// A retreated or rewritten table tail skips that table, not the other tables.
+func (t *sqliteChangeTracker) changedSessionIDs(
+	ctx context.Context, dbPath string, stableSnapshot bool,
+) (ids []string, cold bool, snapshot sqliteTrackedDatabase, err error) {
+	entry := t.entry(dbPath)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return nil, false, sqliteTrackedDatabase{}, fmt.Errorf("stat %s sessions database: %w", t.agent, err)
+	}
+	db, err := t.open(dbPath, stableSnapshot)
+	if err != nil {
+		return nil, false, sqliteTrackedDatabase{}, err
+	}
+	defer db.Close()
+	current, err := t.readFrom(ctx, db, info)
+	if err != nil {
+		return nil, false, sqliteTrackedDatabase{}, err
+	}
+	if !entry.known || sqliteTrackedDatabaseReplaced(entry.state, current) {
+		return nil, true, current, nil
+	}
+	seen := make(map[string]struct{})
+	for i, table := range current.tables {
+		previous := entry.state.cursors[i]
+		valid, err := t.cursorStillValid(ctx, db, table, previous, current.cursors[i])
+		if err != nil {
+			return nil, false, sqliteTrackedDatabase{}, err
+		}
+		if !valid {
+			continue
+		}
+		if err := t.listChangedSessionIDs(ctx, db, table, previous.id, seen); err != nil {
+			return nil, false, sqliteTrackedDatabase{}, err
+		}
+	}
+	entry.state, entry.known = current, true
+	ids = make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, false, current, nil
+}
+
+func sqliteTrackedDatabaseReplaced(previous, current sqliteTrackedDatabase) bool {
+	identityChanged := (previous.inode != 0 || previous.device != 0) &&
+		(previous.inode != current.inode || previous.device != current.device)
+	return identityChanged || previous.schemaVersion != current.schemaVersion ||
+		!slices.Equal(previous.tables, current.tables)
+}
+
+func (t *sqliteChangeTracker) read(
+	ctx context.Context, dbPath string, stableSnapshot bool,
+) (sqliteTrackedDatabase, error) {
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return sqliteTrackedDatabase{}, fmt.Errorf("stat %s sessions database: %w", t.agent, err)
+	}
+	db, err := t.open(dbPath, stableSnapshot)
+	if err != nil {
+		return sqliteTrackedDatabase{}, err
+	}
+	defer db.Close()
+	return t.readFrom(ctx, db, info)
+}
+
+func (t *sqliteChangeTracker) readFrom(
+	ctx context.Context, db *sql.DB, info os.FileInfo,
+) (sqliteTrackedDatabase, error) {
+	version, tables, err := t.schema(ctx, db)
+	if err != nil {
+		return sqliteTrackedDatabase{}, err
+	}
+	inode, device := sourceFileIdentity(info)
+	state := sqliteTrackedDatabase{
+		schemaVersion: version, inode: inode, device: device,
+		tables: tables, cursors: make([]sqliteRowCursor, len(tables)),
+	}
+	for i, table := range tables {
+		query := "SELECT " + table.rowID + ", " + table.identity + " FROM " + table.name +
+			" ORDER BY " + table.rowID + " DESC LIMIT 1"
+		err := db.QueryRowContext(ctx, query).Scan(&state.cursors[i].id, &state.cursors[i].identity)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return sqliteTrackedDatabase{}, fmt.Errorf("reading latest %s %s row: %w", t.agent, table.name, err)
+		}
+	}
+	return state, nil
+}
+
+func (t *sqliteChangeTracker) cursorStillValid(
+	ctx context.Context, db *sql.DB, table sqliteCursorTable, previous, current sqliteRowCursor,
+) (bool, error) {
+	if current.id < previous.id {
+		return false, nil
+	}
+	if previous.id == 0 {
+		return true, nil
+	}
+	query := "SELECT " + table.identity + " FROM " + table.name + " WHERE " + table.rowID + " = ?"
+	var identity string
+	err := db.QueryRowContext(ctx, query, previous.id).Scan(&identity)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("reading %s %s cursor identity: %w", t.agent, table.name, err)
+	}
+	return identity == previous.identity, nil
+}
+
+func (t *sqliteChangeTracker) listChangedSessionIDs(
+	ctx context.Context, db *sql.DB, table sqliteCursorTable, after int64, seen map[string]struct{},
+) error {
+	query := "SELECT " + table.sessionID + " FROM " + table.name +
+		" WHERE " + table.rowID + " > ? ORDER BY " + table.rowID
+	rows, err := db.QueryContext(ctx, query, after)
+	if err != nil {
+		return fmt.Errorf("listing changed %s sessions: %w", t.agent, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("scanning changed %s session ID: %w", t.agent, err)
+		}
+		if id = strings.TrimSpace(id); id != "" {
+			seen[id] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return rows.Close()
+}


### PR DESCRIPTION
Goose now uses the shared database provider directly, removing its duplicate factory, discovery, watcher routing, and fingerprint wrappers. SQLite cursor bookkeeping is reusable; Goose retains its producer schema, row identities, and content hash. The refactor removes 180 production lines overall while preserving archive handling and raw capture.

The factory retains cursors across short-lived providers. Watcher events return only sessions with newly inserted rows; edits and deletions remain reconciliation's job. Discovery reports through the shared scan observer and publishes cursors only after every root succeeds, without retreating progress from a concurrent watcher. Other database providers retain their existing event behavior.

<sup>generated by a clanker</sup>
