### PR TITLE
refactor(parser): share SQLite source handling

### DIFF
--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -87,8 +87,7 @@ func (p *antigravityProvider) parseSession(
 
 	// Open read-only; SQLite session files have WAL/SHM
 	// sidecars that the driver expects in the same dir.
-	dsn := "file:" + sqliteURIPath(path) + "?mode=ro&immutable=0"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(path, sqliteReadOptions{})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf(
 			"open antigravity db %s: %w", path, err,

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
@@ -383,8 +382,7 @@ func normalizeAntigravityCLIWorkspace(workspace string) string {
 func loadAntigravityCLIDBSteps(
 	path string,
 ) (antigravityStepLoadResult, error) {
-	dsn := "file:" + sqliteURIPath(path) + "?mode=ro&immutable=0"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(path, sqliteReadOptions{})
 	if err != nil {
 		return antigravityStepLoadResult{}, fmt.Errorf(
 			"open antigravity cli db %s: %w", path, err,

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -487,10 +487,7 @@ func loadCopilotStoreUsage(
 		}
 		return nil, fmt.Errorf("stat copilot session store %s: %w", storePath, err)
 	}
-	store, err := sql.Open(
-		"sqlite3",
-		"file:"+sqliteURIPath(storePath)+"?mode=ro&_busy_timeout=3000",
-	)
+	store, err := openSQLiteReadOnly(storePath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf("opening copilot session store %s: %w", storePath, err)
 	}

--- a/internal/parser/copilot_store_freshness.go
+++ b/internal/parser/copilot_store_freshness.go
@@ -172,7 +172,7 @@ func (c *copilotSourceCache) usageHash(ctx context.Context, path, sessionID stri
 	if valid && exists && state == prior.state && !full {
 		return prior.members[sessionID].hash, nil
 	}
-	store, err := sql.Open("sqlite3", "file:"+sqliteURIPath(path)+"?mode=ro&_busy_timeout=3000")
+	store, err := openSQLiteReadOnly(path, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return "", err
 	}

--- a/internal/parser/cursor_attribution.go
+++ b/internal/parser/cursor_attribution.go
@@ -160,13 +160,7 @@ func cursorAttributionDBPath() string {
 }
 
 func openCursorAttributionDB(path string) (*sql.DB, error) {
-	// The file: prefix is required for go-sqlite3 to honor mode=ro;
-	// without it the query string is dropped and the live Cursor db
-	// would be opened read-write.
-	conn, err := sql.Open(
-		"sqlite3",
-		"file:"+sqliteURIPath(path)+"?mode=ro&_busy_timeout=3000",
-	)
+	conn, err := openSQLiteReadOnly(path, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf("opening cursor attribution db: %w", err)
 	}

--- a/internal/parser/cursor_ide.go
+++ b/internal/parser/cursor_ide.go
@@ -52,8 +52,7 @@ func cursorIDEDefaultDirs() []string {
 }
 
 func openCursorIDEDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf("opening cursor IDE db %s: %w", dbPath, err)
 	}

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -127,8 +127,7 @@ func ForEachDevinSessionMeta(
 }
 
 func openDevinDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf("opening devin db %s: %w", dbPath, err)
 	}

--- a/internal/parser/forge.go
+++ b/internal/parser/forge.go
@@ -143,12 +143,10 @@ func parseForgeSession(
 }
 
 func openForgeDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
-	immutable := "0"
-	if stableSnapshot {
-		immutable = "1"
-	}
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{
+		stableSnapshot: stableSnapshot,
+		busyTimeoutMS:  3000,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("opening forge db %s: %w", dbPath, err)
 	}

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -587,7 +587,7 @@ func hermesStatePaths(root string) (stateDB, sessionsDir string, ok bool) {
 func (p *hermesProvider) parseStateDB(
 	stateDB, sessionsDir, project, machine string,
 ) ([]ParseResult, error) {
-	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	conn, err := openSQLiteReadOnly(stateDB, sqliteReadOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("open hermes state db: %w", err)
 	}
@@ -819,7 +819,7 @@ func writeHermesStateSessionJSONL(
 func readHermesStateSessionSource(
 	stateDB, rawSessionID string,
 ) (hermesStateSession, []hermesStateMessage, string, error) {
-	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	conn, err := openSQLiteReadOnly(stateDB, sqliteReadOptions{})
 	if err != nil {
 		return hermesStateSession{}, nil, "", hermesStateLookupError{
 			err: fmt.Errorf("open hermes state db: %w", err),

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -264,7 +264,7 @@ func (p *hermesProvider) parseStateMember(
 	ctx context.Context,
 	src hermesSource, project, machine string, fingerprint SourceFingerprint,
 ) (ParseOutcome, error) {
-	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(src.StateDB)+"?mode=ro")
+	conn, err := openSQLiteReadOnly(src.StateDB, sqliteReadOptions{})
 	if err != nil {
 		return ParseOutcome{}, fmt.Errorf("open hermes state db: %w", err)
 	}
@@ -528,7 +528,7 @@ func (s hermesSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef)
 func (s hermesSourceSet) discoverStateEach(
 	ctx context.Context, root, stateDB string, yield func(SourceRef) error,
 ) (bool, error) {
-	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	conn, err := openSQLiteReadOnly(stateDB, sqliteReadOptions{})
 	if err != nil {
 		return false, fmt.Errorf("open hermes state db: %w", err)
 	}
@@ -623,7 +623,7 @@ type hermesStateMembership struct {
 func openHermesStateMembership(
 	ctx context.Context, stateDB string,
 ) (*hermesStateMembership, error) {
-	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	conn, err := openSQLiteReadOnly(stateDB, sqliteReadOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("open hermes state db: %w", err)
 	}
@@ -1114,7 +1114,7 @@ func (e hermesStateLookupError) Unwrap() error {
 }
 
 func hermesStateDBHasSession(stateDB string, rawID string) (bool, error) {
-	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	conn, err := openSQLiteReadOnly(stateDB, sqliteReadOptions{})
 	if err != nil {
 		return false, fmt.Errorf("open hermes state db: %w", err)
 	}
@@ -1586,12 +1586,12 @@ func seedHermesMemberCores(ctx context.Context, stateDB string) error {
 }
 
 func seedHermesMemberCoresLocked(ctx context.Context, stateDB string) error {
-	idsConn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	idsConn, err := openSQLiteReadOnly(stateDB, sqliteReadOptions{})
 	if err != nil {
 		return fmt.Errorf("open hermes state db: %w", err)
 	}
 	defer idsConn.Close()
-	memberConn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	memberConn, err := openSQLiteReadOnly(stateDB, sqliteReadOptions{})
 	if err != nil {
 		return fmt.Errorf("open hermes member state db: %w", err)
 	}

--- a/internal/parser/icodemate_provider.go
+++ b/internal/parser/icodemate_provider.go
@@ -49,7 +49,7 @@ func (f icodemateProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	opencodeCfg := cfg
 	opencodeCfg.Roots = opencodeRoots
 	provider := &icodemateProvider{
-		opencode: &openCodeFormatProvider{
+		opencode: &SourceSetProvider{
 			sources: newOpenCodeFormatSourceSet(
 				opencodeRoots,
 				openCodeProviderSpecForAgent(AgentIcodemate),
@@ -120,7 +120,7 @@ func splitIcodemateRoots(roots []string) (opencodeRoots, cliRoots []string) {
 
 type icodemateProvider struct {
 	ProviderBase
-	opencode *openCodeFormatProvider
+	opencode *SourceSetProvider
 	cli      *icodemateCLISourceSet
 	// allRoots carries every configured root so reconciliation validates and
 	// walks the full configured scope, not just the OpenCode subset the inner
@@ -276,13 +276,13 @@ func (p *icodemateProvider) SourceForReconciliationWithState(
 func (p *icodemateProvider) ReconciliationSourceState(
 	source SourceRef,
 ) (ReconciliationSourceState, bool) {
-	return p.allSources.reconciliationSourceState(source)
+	return p.allSources.ReconciliationSourceState(source)
 }
 
 func (p *icodemateProvider) ApplyReconciliationSourceState(
 	source *SourceRef, state ReconciliationSourceState,
 ) error {
-	return p.allSources.applyReconciliationSourceState(source, state)
+	return p.allSources.ApplyReconciliationSourceState(source, state)
 }
 
 // ResolveReconciliationScopes preserves the OpenCode container topology for
@@ -300,6 +300,6 @@ func (p *icodemateProvider) ResolveReconciliationScopes(
 		return ReconciliationScopePlan{}, err
 	}
 	return containerAwareReconciliationScopePlan(
-		p.allRoots, req.Roots, p.allSources.reconciliationContainer,
+		p.allRoots, req.Roots, p.allSources.ReconciliationContainer,
 	), nil
 }

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -1180,7 +1180,7 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 		}
 		return s.newSourceRef(root, path, dbPath, sessionID, kiroSourceSQLiteSession), true
 	}
-	if dbPath, ok := kiroDBPathForEvent(root, path); ok {
+	if dbPath, ok := sqliteContainerPathForEvent(root, path, kiroSQLiteDBName, true); ok {
 		if !kiroDBUnderRoot(root, dbPath, false) {
 			return SourceRef{}, false
 		}
@@ -1342,27 +1342,6 @@ func kiroDBUnderRoot(root, dbPath string, requireRegular bool) bool {
 		return false
 	}
 	return !requireRegular || IsRegularFile(dbPath)
-}
-
-func kiroDBPathForEvent(root, path string) (string, bool) {
-	root = filepath.Clean(root)
-	path = filepath.Clean(path)
-	rel, ok := relUnder(root, path)
-	if !ok {
-		return "", false
-	}
-	// A bare "-shm" event is ignored: the provider's own read connections
-	// rewrite that index, and every committed write lands in the main file
-	// or a journal sibling.
-	if strings.HasSuffix(rel, "-shm") {
-		return "", false
-	}
-	if filepath.ToSlash(rel) == kiroSQLiteDBName ||
-		(filepath.Dir(rel) == "." &&
-			strings.HasPrefix(filepath.Base(rel), kiroSQLiteDBName+"-")) {
-		return filepath.Join(root, kiroSQLiteDBName), true
-	}
-	return "", false
 }
 
 func kiroLegacyPathUnderRoot(root, path string) bool {

--- a/internal/parser/kiro_sqlite.go
+++ b/internal/parser/kiro_sqlite.go
@@ -433,9 +433,7 @@ func (s *KiroSQLiteStore) ParseSession(
 }
 
 func openKiroSQLiteDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) +
-		"?mode=ro&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf(
 			"opening kiro sqlite db %s: %w", dbPath, err,

--- a/internal/parser/omnigent.go
+++ b/internal/parser/omnigent.go
@@ -173,8 +173,7 @@ func (m omnigentMemberID) sessionID() string {
 
 // openOmnigentDB opens chat.db read-only. Callers own Close.
 func openOmnigentDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf("opening omnigent db %s: %w", dbPath, err)
 	}

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -707,9 +707,7 @@ func openCodeStorageFingerprintFromSnapshot(
 }
 
 func openOpenCodeDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) +
-		"?mode=ro&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf(
 			"opening opencode db %s: %w", dbPath, err,

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -17,158 +17,55 @@ import (
 	"sync"
 )
 
-var _ Provider = (*openCodeFormatProvider)(nil)
-
-// A SQLite WAL begins with a 32-byte header. Bytes beyond the header are
-// transaction frames, so a larger WAL can contain source changes worth
-// syncing. Read-only SQLite connections may create an empty WAL and its SHM
-// index simply by opening a quiet WAL-mode database; those sidecars must not
-// make the watcher trigger itself.
-const sqliteWALHeaderSize = int64(32)
-
-type openCodeFormatProviderFactory struct {
-	def   AgentDef
-	spec  openCodeProviderSpec
-	index *openCodeFormatSourceIndex
-}
+var _ SourceSet = openCodeFormatSourceSet{}
 
 func newOpenCodeProviderFactory(def AgentDef) ProviderFactory {
-	return openCodeFormatProviderFactory{
-		def:   cloneAgentDef(def),
-		spec:  openCodeProviderSpecForAgent(AgentOpenCode),
-		index: newOpenCodeFormatSourceIndex(),
-	}
+	return newOpenCodeFormatProviderFactory(def, AgentOpenCode)
 }
 
 func newKiloProviderFactory(def AgentDef) ProviderFactory {
-	return openCodeFormatProviderFactory{
-		def:   cloneAgentDef(def),
-		spec:  openCodeProviderSpecForAgent(AgentKilo),
-		index: newOpenCodeFormatSourceIndex(),
-	}
+	return newOpenCodeFormatProviderFactory(def, AgentKilo)
 }
 
 func newMiMoCodeProviderFactory(def AgentDef) ProviderFactory {
-	return openCodeFormatProviderFactory{
-		def:   cloneAgentDef(def),
-		spec:  openCodeProviderSpecForAgent(AgentMiMoCode),
-		index: newOpenCodeFormatSourceIndex(),
-	}
+	return newOpenCodeFormatProviderFactory(def, AgentMiMoCode)
 }
 
-func (f openCodeFormatProviderFactory) Definition() AgentDef {
-	return cloneAgentDef(f.def)
+func newOpenCodeFormatProviderFactory(def AgentDef, agent AgentType) ProviderFactory {
+	spec := openCodeProviderSpecForAgent(agent)
+	index := newOpenCodeFormatSourceIndex()
+	return NewSourceSetFactory(def, openCodeFormatProviderCapabilities(),
+		func(cfg ProviderConfig) SourceSet {
+			return newOpenCodeFormatSourceSet(
+				cfg.Roots, spec, cfg.SQLiteContainerListsWatermarkOnly, index,
+			)
+		},
+	)
 }
 
-func (f openCodeFormatProviderFactory) Capabilities() Capabilities {
-	return openCodeFormatProviderCapabilities()
-}
-
-func (f openCodeFormatProviderFactory) NewProvider(cfg ProviderConfig) Provider {
-	cfg = cfg.Clone()
-	return &openCodeFormatProvider{
-		Def:    cloneAgentDef(f.def),
-		Caps:   openCodeFormatProviderCapabilities(),
-		Config: cfg,
-		sources: newOpenCodeFormatSourceSet(
-			cfg.Roots, f.spec, cfg.SQLiteContainerListsWatermarkOnly, f.index,
-		),
-	}
-}
-
-type openCodeFormatProvider struct {
-	ProviderBase
-	sources openCodeFormatSourceSet
-}
-
-func (p *openCodeFormatProvider) Discover(ctx context.Context) ([]SourceRef, error) {
-	return p.sources.Discover(ctx)
-}
-
-func (p *openCodeFormatProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
-	return p.sources.DiscoverEach(ctx, yield)
-}
-
-func (p *openCodeFormatProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
-	return p.sources.WatchPlan(ctx)
-}
-
-func (p *openCodeFormatProvider) SourcesForChangedPath(
-	ctx context.Context,
-	req ChangedPathRequest,
-) ([]SourceRef, error) {
-	return p.sources.SourcesForChangedPath(ctx, req)
-}
-
-func (p *openCodeFormatProvider) ChangedPathRelevance(
-	ctx context.Context,
-	req ChangedPathRequest,
-) (ChangedPathRelevance, error) {
-	return p.sources.ChangedPathRelevance(ctx, req)
-}
-
-func (p *openCodeFormatProvider) SourceForReconciliation(
-	ctx context.Context, path, project string,
-) (SourceRef, bool, error) {
-	return p.sources.SourceForReconciliation(ctx, path, project)
-}
-
-// ResolveReconciliationScopes widens a request naming the family database, a
-// WAL or SHM sidecar, or one virtual member to the container itself. The
-// container's membership is atomic: a proof of the bare database path admits
-// no member row, and a proof of one member would let a completed pass promote
-// container-state trust over siblings it never verified.
-func (p *openCodeFormatProvider) ResolveReconciliationScopes(
-	_ context.Context, req ReconciliationScopeRequest,
-) (ReconciliationScopePlan, error) {
-	if err := ValidateReconciliationScopeRoots(
-		p.Def.Type, p.Config.Roots, req.Roots,
-	); err != nil {
-		return ReconciliationScopePlan{}, err
-	}
-	return containerAwareReconciliationScopePlan(
-		p.Config.Roots, req.Roots, p.sources.reconciliationContainer,
-	), nil
-}
-
-func (p *openCodeFormatProvider) FindSource(
-	ctx context.Context,
-	req FindSourceRequest,
-) (SourceRef, bool, error) {
-	req = ProviderFindRequestWithRawSessionID(p.Def, req)
-	return p.sources.FindSource(ctx, req)
-}
-
-func (p *openCodeFormatProvider) Fingerprint(
-	ctx context.Context,
-	source SourceRef,
-) (SourceFingerprint, error) {
-	return p.sources.Fingerprint(ctx, source)
-}
-
-func (p *openCodeFormatProvider) Parse(
+func (s openCodeFormatSourceSet) Parse(
 	ctx context.Context,
 	req ParseRequest,
 ) (ParseOutcome, error) {
 	if err := ctx.Err(); err != nil {
 		return ParseOutcome{}, err
 	}
-	path, ok := p.sources.pathFromSource(req.Source)
+	path, ok := s.pathFromSource(req.Source)
 	if !ok {
-		return ParseOutcome{}, fmt.Errorf("%s source path unavailable", p.Def.Type)
+		return ParseOutcome{}, fmt.Errorf("%s source path unavailable", s.spec.agent)
 	}
 
-	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
+	machine := req.Machine
 	var (
 		sess *ParsedSession
 		msgs []ParsedMessage
 		err  error
 	)
-	dbPath, sessionID, sqliteSource := p.sources.spec.parseVirtual(path)
+	dbPath, sessionID, sqliteSource := s.spec.parseVirtual(path)
 	if sqliteSource {
-		sess, msgs, err = p.sources.spec.parseSQLite(dbPath, sessionID, machine)
+		sess, msgs, err = s.spec.parseSQLite(dbPath, sessionID, machine)
 	} else {
-		sess, msgs, err = p.sources.spec.parseFile(path, machine)
+		sess, msgs, err = s.spec.parseFile(path, machine)
 	}
 	if err != nil {
 		return ParseOutcome{}, err
@@ -806,14 +703,14 @@ func openCodeStorageWatchDir(root string) string {
 	return filepath.Join(root, "storage")
 }
 
-// reconciliationContainer maps a requested path to the SQLite container that
+// ReconciliationContainer maps a requested path to the SQLite container that
 // atomically owns it, without statting: a deleted database must still resolve
 // so its members remain reclaimable through the container proof. A virtual
 // spelling splits at the raw separator instead of parseVirtual, whose exact
 // basename check would let a Windows case variant of the database name skip
 // widening and admit a single member; the alias comparison below already
 // carries the platform's case rule.
-func (s openCodeFormatSourceSet) reconciliationContainer(
+func (s openCodeFormatSourceSet) ReconciliationContainer(
 	requested string,
 ) (string, bool) {
 	physical := requested
@@ -1538,25 +1435,7 @@ func (s openCodeFormatSourceSet) sqliteSourceRefFromMeta(
 	return ref, true
 }
 
-func (p *openCodeFormatProvider) ReconciliationSourceState(
-	source SourceRef,
-) (ReconciliationSourceState, bool) {
-	return p.sources.reconciliationSourceState(source)
-}
-
-func (p *openCodeFormatProvider) SourceForReconciliationWithState(
-	ctx context.Context, path, project string, state ReconciliationSourceState,
-) (SourceRef, bool, error) {
-	return p.sources.SourceForReconciliationWithState(ctx, path, project, state)
-}
-
-func (p *openCodeFormatProvider) ApplyReconciliationSourceState(
-	source *SourceRef, state ReconciliationSourceState,
-) error {
-	return p.sources.applyReconciliationSourceState(source, state)
-}
-
-func (s openCodeFormatSourceSet) reconciliationSourceState(
+func (s openCodeFormatSourceSet) ReconciliationSourceState(
 	source SourceRef,
 ) (ReconciliationSourceState, bool) {
 	path, ok := s.pathFromSource(source)
@@ -1588,7 +1467,7 @@ func (s openCodeFormatSourceSet) reconciliationSourceState(
 	}, true
 }
 
-func (s openCodeFormatSourceSet) applyReconciliationSourceState(
+func (s openCodeFormatSourceSet) ApplyReconciliationSourceState(
 	source *SourceRef, state ReconciliationSourceState,
 ) error {
 	if source == nil || state.Version == 0 {

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -900,9 +900,10 @@ func TestOpenCodeProviderProjectMetadataChangeReportsSessionDirectoryError(
 
 	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
 	require.True(t, ok)
-	formatProvider, ok := provider.(*openCodeFormatProvider)
-	require.True(t, ok)
-	_, err := formatProvider.sources.sourcesForProject(root, projectID)
+	sources := newOpenCodeFormatSourceSet(
+		[]string{root}, openCodeProviderSpecForAgent(AgentOpenCode), nil,
+	)
+	_, err := sources.sourcesForProject(root, projectID)
 	assert.Error(t, err)
 	_, publicErr := provider.SourcesForChangedPath(t.Context(), ChangedPathRequest{
 		Path: projectPath, EventKind: "write",
@@ -1725,7 +1726,7 @@ func TestOpenCodeReconciliationSourceStateRoundTrips(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	state, ok := discoverySources.reconciliationSourceState(discovered)
+	state, ok := discoverySources.ReconciliationSourceState(discovered)
 	require.True(t, ok)
 	rehydrationSources := newOpenCodeFormatSourceSet(
 		[]string{root}, spec, nil,
@@ -1736,7 +1737,7 @@ func TestOpenCodeReconciliationSourceStateRoundTrips(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.NoError(t,
-		rehydrationSources.applyReconciliationSourceState(&source, state),
+		rehydrationSources.ApplyReconciliationSourceState(&source, state),
 	)
 	assert.Equal(t, childDigest, sourceCarriedChildDigest(source))
 
@@ -1777,7 +1778,7 @@ func TestOpenCodeReconciliationRejectsInvalidSourceState(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Error(t, sources.applyReconciliationSourceState(&source, test.state))
+			assert.Error(t, sources.ApplyReconciliationSourceState(&source, test.state))
 		})
 	}
 }

--- a/internal/parser/piebald.go
+++ b/internal/parser/piebald.go
@@ -144,12 +144,10 @@ func parsePiebaldSessionResults(
 }
 
 func openPiebaldDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
-	immutable := "0"
-	if stableSnapshot {
-		immutable = "1"
-	}
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{
+		stableSnapshot: stableSnapshot,
+		busyTimeoutMS:  3000,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("opening piebald db %s: %w", dbPath, err)
 	}

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -390,9 +390,7 @@ func OpenShelleyDB(dbPath string) (*sql.DB, error) {
 }
 
 func openShelleyDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) +
-		"?mode=ro&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf("opening shelley db %s: %w", dbPath, err)
 	}

--- a/internal/parser/source_set.go
+++ b/internal/parser/source_set.go
@@ -98,6 +98,16 @@ func (p *SourceSetProvider) SourcesForChangedPath(
 	return p.sources.SourcesForChangedPath(ctx, req)
 }
 
+func (p *SourceSetProvider) ChangedPathRelevance(
+	ctx context.Context, req ChangedPathRequest,
+) (ChangedPathRelevance, error) {
+	resolver, ok := p.sources.(ChangedPathRelevanceProvider)
+	if !ok {
+		return ChangedPathUnclassified, nil
+	}
+	return resolver.ChangedPathRelevance(ctx, req)
+}
+
 // reconciliationContainerTopologyProvider is implemented by source sets whose
 // members are virtual children of a physical container. The provider-level
 // scope resolver widens a request naming the container, a sidecar, or one
@@ -170,6 +180,41 @@ func (p *SourceSetProvider) SourceForReconciliation(
 		return SourceRef{}, false, nil
 	}
 	return resolver.SourceForReconciliation(ctx, path, project)
+}
+
+func (p *SourceSetProvider) SourceForReconciliationWithState(
+	ctx context.Context, path, project string, state ReconciliationSourceState,
+) (SourceRef, bool, error) {
+	resolver, ok := p.sources.(ReconciliationSourceStateResolver)
+	if !ok {
+		return p.SourceForReconciliation(ctx, path, project)
+	}
+	return resolver.SourceForReconciliationWithState(ctx, path, project, state)
+}
+
+func (p *SourceSetProvider) ReconciliationSourceState(
+	source SourceRef,
+) (ReconciliationSourceState, bool) {
+	provider, ok := p.sources.(ReconciliationSourceStateProvider)
+	if !ok {
+		return ReconciliationSourceState{}, false
+	}
+	return provider.ReconciliationSourceState(source)
+}
+
+func (p *SourceSetProvider) ApplyReconciliationSourceState(
+	source *SourceRef, state ReconciliationSourceState,
+) error {
+	provider, ok := p.sources.(ReconciliationSourceStateProvider)
+	if !ok {
+		if state.Version == 0 {
+			return nil
+		}
+		return UnsupportedProviderFeatureError{
+			Provider: p.Def.Type, Feature: "reconciliation source state",
+		}
+	}
+	return provider.ApplyReconciliationSourceState(source, state)
 }
 
 func (p *SourceSetProvider) ReconciliationMemberIdentity(

--- a/internal/parser/source_set_provider_test.go
+++ b/internal/parser/source_set_provider_test.go
@@ -1,0 +1,106 @@
+package parser
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceSetProviderPreservesSQLiteEventRelevance(t *testing.T) {
+	root := t.TempDir()
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	for _, tc := range []struct {
+		path string
+		want ChangedPathRelevance
+	}{
+		{"opencode.db-shm", ChangedPathNonData},
+		{"opencode.db-wal", ChangedPathNonData},
+		{"opencode.db", ChangedPathDataBearing},
+		{"opencode.db-backup", ChangedPathUnclassified},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			relevance, err := ResolveChangedPathRelevance(t.Context(), provider, ChangedPathRequest{
+				Path: filepath.Join(root, tc.path), WatchRoot: root,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, relevance)
+		})
+	}
+}
+
+func TestSourceSetProviderPreservesSQLiteDiscoveryState(t *testing.T) {
+	root := t.TempDir()
+	dbPath, seeder, database := newTestDBAt(t, filepath.Join(root, "opencode.db"))
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	seeder.AddProject("project", "/workspace/project")
+	seeder.AddSession("session", "project", "", "SQLite session", 1700000000000, 1700000010000)
+	seeder.AddMessage("message", "session", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("part", "message", "session", 1700000000000, 1700000000000,
+		`{"type":"text","text":"SQLite message"}`)
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sources, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	listed, err := provider.Fingerprint(t.Context(), sources[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, listed.Hash)
+	stateProvider, ok := provider.(ReconciliationSourceStateProvider)
+	require.True(t, ok, "the shared provider must preserve discovery state across the spool")
+	state, ok := stateProvider.ReconciliationSourceState(sources[0])
+	require.True(t, ok)
+	resolver, ok := provider.(ReconciliationSourceStateResolver)
+	require.True(t, ok)
+	before := OpenCodeSessionChildLookups()
+	source, found, err := resolver.SourceForReconciliationWithState(t.Context(), dbPath+"#session", "", state)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, stateProvider.ApplyReconciliationSourceState(&source, state))
+	fingerprint, err := provider.Fingerprint(t.Context(), source)
+	require.NoError(t, err)
+	assert.Equal(t, listed, fingerprint)
+	assert.Equal(t, before, OpenCodeSessionChildLookups(), "rehydration must not reread the child tables")
+
+	// A JSON session appearing after discovery becomes canonical. SQLite
+	// metadata from the spool must not be attached to that replacement.
+	storagePath := writeOpenCodeProviderStorageSession(t, root, "session", "session", "project", "JSON session")
+	source, found, err = resolver.SourceForReconciliationWithState(t.Context(), dbPath+"#session", "", state)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NoError(t, stateProvider.ApplyReconciliationSourceState(&source, state))
+	assert.Equal(t, storagePath, source.DisplayPath)
+	_, carried := stateProvider.ReconciliationSourceState(source)
+	assert.False(t, carried, "SQLite discovery state must not survive selection of a JSON source")
+	parsed, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, parsed.Results, 1)
+	assert.Equal(t, storagePath, parsed.Results[0].Result.Session.File.Path)
+	require.Len(t, parsed.Results[0].Result.Messages, 1)
+	assert.Equal(t, "Hello from storage", parsed.Results[0].Result.Messages[0].Content)
+	assert.False(t, parsed.ForceReplace)
+}
+
+func TestSourceSetProviderReconcilesWithoutDiscoveryState(t *testing.T) {
+	fixture := shelleyProviderReadFixture(t)
+	provider, ok := NewProvider(AgentShelley, ProviderConfig{Roots: []string{fixture.Root}})
+	require.True(t, ok)
+	path := ShelleyVirtualPath(fixture.DBPath, "cMAIN1")
+	source, found, err := provider.(ReconciliationSourceStateResolver).
+		SourceForReconciliationWithState(t.Context(), path, "", ReconciliationSourceState{})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, path, source.DisplayPath)
+	stateProvider := provider.(ReconciliationSourceStateProvider)
+	_, carried := stateProvider.ReconciliationSourceState(source)
+	assert.False(t, carried)
+	require.NoError(t, stateProvider.ApplyReconciliationSourceState(&source, ReconciliationSourceState{}))
+	var unsupported UnsupportedProviderFeatureError
+	assert.ErrorAs(t, stateProvider.ApplyReconciliationSourceState(&source, ReconciliationSourceState{Version: 1}), &unsupported)
+	parsed, err := provider.Parse(t.Context(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, parsed.Results, 1)
+	assert.Equal(t, "shelley:cMAIN1", parsed.Results[0].Result.Session.ID)
+}

--- a/internal/parser/sqlite_container_state.go
+++ b/internal/parser/sqlite_container_state.go
@@ -85,6 +85,37 @@ const (
 
 var sqliteHeaderMagic = []byte("SQLite format 3\x00")
 
+// A SQLite WAL begins with a 32-byte header. Only bytes beyond the header
+// can contain transaction frames; read-only clients can create an empty WAL.
+const sqliteWALHeaderSize = int64(32)
+
+// sqliteDBJournalSuffixes is the sibling-file suffix list for
+// sqliteDBCompositeMtime: the database file itself plus its WAL. The "-shm"
+// index is left out on purpose. Every committed write lands in the main file
+// or the WAL, while readers, including this process's own scan connections,
+// rewrite the shared-memory file, so folding its mtime in would make every
+// scan report the container as changed and schedule the next scan.
+var sqliteDBJournalSuffixes = []string{"", "-wal"}
+
+// sqliteDBCompositeMtime returns the freshest mtime across a SQLite database
+// file and the listed sibling suffixes (e.g. "-wal", "-shm").
+func sqliteDBCompositeMtime(dbPath string, suffixes []string) (int64, error) {
+	var maxMtime int64
+	for _, suffix := range suffixes {
+		info, err := os.Stat(dbPath + suffix)
+		if err != nil {
+			continue
+		}
+		if mtime := info.ModTime().UnixNano(); mtime > maxMtime {
+			maxMtime = mtime
+		}
+	}
+	if maxMtime == 0 {
+		return 0, &os.PathError{Op: "stat", Path: dbPath, Err: os.ErrNotExist}
+	}
+	return maxMtime, nil
+}
+
 // StatSQLiteContainerState captures the current change-detection state of a
 // shared SQLite container. ok is false when the container is missing or its
 // headers cannot be read, in which case the container must never be treated

--- a/internal/parser/sqlite_dsn.go
+++ b/internal/parser/sqlite_dsn.go
@@ -1,6 +1,30 @@
 package parser
 
-import "strings"
+import (
+	"database/sql"
+	"strconv"
+	"strings"
+)
+
+type sqliteReadOptions struct {
+	// Only archive copies that cannot change may skip SQLite locking and WAL reads.
+	stableSnapshot bool
+	// Zero preserves the driver's busy timeout rather than overriding it.
+	busyTimeoutMS int
+}
+
+// openSQLiteReadOnly shares source-database URI and read policies. Opening is
+// lazy, as with sql.Open; callers retain ownership of queries and Close.
+func openSQLiteReadOnly(path string, options sqliteReadOptions) (*sql.DB, error) {
+	dsn := "file:" + sqliteURIPath(path) + "?mode=ro"
+	if options.stableSnapshot {
+		dsn += "&immutable=1"
+	}
+	if options.busyTimeoutMS != 0 {
+		dsn += "&_busy_timeout=" + strconv.Itoa(options.busyTimeoutMS)
+	}
+	return sql.Open("sqlite3", dsn)
+}
 
 // sqliteURIPath escapes a filesystem path for use in a SQLite file: URI.
 // SQLite percent-decodes URI paths and stops parsing them at '?' or '#',

--- a/internal/parser/sqlite_dsn_test.go
+++ b/internal/parser/sqlite_dsn_test.go
@@ -58,3 +58,55 @@ func TestOpenSQLiteWithSpecialCharPath(t *testing.T) {
 	_, err = db.Exec("INSERT INTO t VALUES (2)")
 	require.Error(t, err, "mode=ro must survive special characters in the path")
 }
+
+func TestOpenSQLiteReadOnlyLiveWAL(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
+	_, err = writer.Exec(`PRAGMA journal_mode=WAL;
+		PRAGMA wal_autocheckpoint=0;
+		CREATE TABLE messages (content TEXT);
+		INSERT INTO messages VALUES ('committed in WAL')`)
+	require.NoError(t, err)
+
+	reader, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	var content string
+	require.NoError(t, reader.QueryRow("SELECT content FROM messages").Scan(&content))
+	assert.Equal(t, "committed in WAL", content)
+
+	_, err = writer.Exec("UPDATE messages SET content = 'later commit'")
+	require.NoError(t, err)
+	require.NoError(t, reader.QueryRow("SELECT content FROM messages").Scan(&content))
+	assert.Equal(t, "later commit", content)
+	_, err = reader.Exec("DELETE FROM messages")
+	require.Error(t, err)
+}
+
+func TestOpenSQLiteReadOnlyStableSnapshot(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "snapshot.db")
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(`PRAGMA journal_mode=WAL;
+		CREATE TABLE messages (content TEXT);
+		INSERT INTO messages VALUES ('snapshot content')`)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	reader, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{
+		stableSnapshot: true,
+		busyTimeoutMS:  3000,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	var content string
+	require.NoError(t, reader.QueryRow("SELECT content FROM messages").Scan(&content))
+	assert.Equal(t, "snapshot content", content)
+	// Immutable archive copies must not create live WAL coordination files.
+	assert.NoFileExists(t, dbPath+"-wal")
+	assert.NoFileExists(t, dbPath+"-shm")
+	_, err = reader.Exec("DELETE FROM messages")
+	require.Error(t, err)
+}

--- a/internal/parser/warp.go
+++ b/internal/parser/warp.go
@@ -142,12 +142,10 @@ func parseWarpSession(
 }
 
 func openWarpDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
-	immutable := "0"
-	if stableSnapshot {
-		immutable = "1"
-	}
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{
+		stableSnapshot: stableSnapshot,
+		busyTimeoutMS:  3000,
+	})
 	if err != nil {
 		return nil, fmt.Errorf(
 			"opening warp db %s: %w", dbPath, err,

--- a/internal/parser/windsurf_provider.go
+++ b/internal/parser/windsurf_provider.go
@@ -1041,8 +1041,7 @@ func loadWindsurfSessionRecord(
 }
 
 func openWindsurfDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=0&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf("open windsurf db %s: %w", dbPath, err)
 	}

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -249,12 +249,10 @@ func parseZCodeSession(
 }
 
 func openZCodeDB(dbPath string, stableSnapshot bool) (*sql.DB, error) {
-	immutable := "0"
-	if stableSnapshot {
-		immutable = "1"
-	}
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=" + immutable + "&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{
+		stableSnapshot: stableSnapshot,
+		busyTimeoutMS:  3000,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("opening zcode db %s: %w", dbPath, err)
 	}
@@ -955,10 +953,8 @@ func zcodeSessionFileMtime(
 	// provider's own read connection included, so folding its mtime into the
 	// fingerprint made every scan report the whole container as changed.
 	// Content changes always touch the main file or the -wal sibling.
-	for _, path := range []string{dbPath, dbPath + "-wal"} {
-		if info, err := os.Stat(path); err == nil {
-			maxMtime = max(maxMtime, info.ModTime().UnixNano())
-		}
+	if physicalMtime, err := sqliteDBCompositeMtime(dbPath, sqliteDBJournalSuffixes); err == nil {
+		maxMtime = max(maxMtime, physicalMtime)
 	}
 	return maxMtime, nil
 }

--- a/internal/parser/zed.go
+++ b/internal/parser/zed.go
@@ -262,8 +262,7 @@ func OpenZedDB(dbPath string) (*sql.DB, error) {
 }
 
 func openZedDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=0&_busy_timeout=3000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := openSQLiteReadOnly(dbPath, sqliteReadOptions{busyTimeoutMS: 3000})
 	if err != nil {
 		return nil, fmt.Errorf("opening zed db %s: %w", dbPath, err)
 	}

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -244,33 +244,6 @@ func zedParseContainer(
 	return results, nil
 }
 
-// sqliteDBJournalSuffixes is the sibling-file suffix list for
-// sqliteDBCompositeMtime: the database file itself plus its WAL. The "-shm"
-// index is left out on purpose. Every committed write lands in the main file
-// or the WAL, while readers, including this process's own scan connections,
-// rewrite the shared-memory file, so folding its mtime in would make every
-// scan report the container as changed and schedule the next scan.
-var sqliteDBJournalSuffixes = []string{"", "-wal"}
-
-// sqliteDBCompositeMtime returns the freshest mtime across a SQLite database
-// file and the listed sibling suffixes (e.g. "-wal", "-shm").
-func sqliteDBCompositeMtime(dbPath string, suffixes []string) (int64, error) {
-	var maxMtime int64
-	for _, suffix := range suffixes {
-		info, err := os.Stat(dbPath + suffix)
-		if err != nil {
-			continue
-		}
-		if mtime := info.ModTime().UnixNano(); mtime > maxMtime {
-			maxMtime = mtime
-		}
-	}
-	if maxMtime == 0 {
-		return 0, &os.PathError{Op: "stat", Path: dbPath, Err: os.ErrNotExist}
-	}
-	return maxMtime, nil
-}
-
 // parseZedVirtualPath splits a Zed virtual source path into its physical
 // threads.db path and raw thread ID. The container basename must be threads.db
 // and the thread ID must pass IsValidSessionID so path-like input is rejected.


### PR DESCRIPTION
SQLite source readers now share read-only connection setup, so changes to that setup no longer need to be repeated across providers. Each reader keeps its existing busy timeout and live-WAL or immutable-snapshot behavior. Goose is excluded from this refactor.

The OpenCode family uses the shared provider factory and adapter. The adapter now forwards event relevance and reconciliation source state, preserving discovery digests across the sync spool. JSON precedence, per-session freshness, archive preservation, and the existing container trust gates remain unchanged; hybrid sources are not forced into whole-container replacement semantics.

Generic database/WAL mtime helpers and the WAL header constant move out of provider-specific files. Kiro reuses the shared event classifier while retaining its symlink containment checks, and ZCode reuses the shared mtime calculation. Most edits are connection substitutions; the main review points are `source_set.go`, `opencode_provider.go`, and `sqlite_dsn.go`.

<sup>generated by a clanker</sup>
